### PR TITLE
feat: case-insensitive email + duplicate-account merge tooling

### DIFF
--- a/packages/backend/src/handlers/native-auth.ts
+++ b/packages/backend/src/handlers/native-auth.ts
@@ -4,6 +4,7 @@ import { SignJWT, createRemoteJWKSet, jwtVerify } from 'jose';
 import { compare, hash } from 'bcryptjs';
 import { eq, and, isNull, lt, or, isNotNull } from 'drizzle-orm';
 import { mobileRefreshTokens, users, userCredentials, accounts, userProfiles } from '@boardsesh/db/schema/auth';
+import { normalizeEmail } from '@boardsesh/db/utils';
 import { db } from '../db/client';
 import { redisClientManager } from '../redis/client';
 import { applyCorsHeaders } from './cors';
@@ -523,7 +524,7 @@ export async function handleNativeAuthCredentials(req: IncomingMessage, res: Ser
   }
 
   // Normalize the email to match how NextAuth's adapter stores it.
-  const normalizedEmail = email.trim().toLowerCase();
+  const normalizedEmail = normalizeEmail(email);
 
   try {
     const userRows = await db.select().from(users).where(eq(users.email, normalizedEmail)).limit(1);
@@ -625,7 +626,7 @@ export async function handleNativeAuthRegister(req: IncomingMessage, res: Server
     sendJson(res, 400, { error: 'email and password are required' });
     return;
   }
-  const normalizedEmail = email.trim().toLowerCase();
+  const normalizedEmail = normalizeEmail(email);
   if (!REGISTER_EMAIL_REGEX.test(normalizedEmail)) {
     sendJson(res, 400, { error: 'Invalid email address' });
     return;
@@ -893,7 +894,7 @@ async function findOrCreateOAuthUser(
       return { status: 'ok', tokenPair, userId: linked.userId };
     }
 
-    const normalizedEmail = identity.email ? identity.email.trim().toLowerCase() : null;
+    const normalizedEmail = identity.email ? normalizeEmail(identity.email) : null;
 
     // 2. Link by email — ONLY when the provider asserts the email is verified.
     // This is the security boundary NextAuth's allowDangerousEmailAccountLinking

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -60,6 +60,11 @@
       "types": "./src/test-utils/sql-text.ts",
       "import": "./src/test-utils/sql-text.ts",
       "default": "./src/test-utils/sql-text.ts"
+    },
+    "./utils": {
+      "types": "./src/utils/index.ts",
+      "import": "./src/utils/index.ts",
+      "default": "./src/utils/index.ts"
     }
   },
   "scripts": {
@@ -84,6 +89,7 @@
     "db:dedupe-gyms": "tsx scripts/dedupe-gym-locations.ts",
     "db:dedupe-beta-links": "tsx scripts/dedupe-beta-links.ts",
     "db:refresh-climb-grades": "tsx scripts/refresh-climb-grades.ts",
+    "db:merge-accounts": "tsx scripts/merge-accounts.ts",
     "db:seed-social": "tsx scripts/seed-social.ts",
     "db:create-test-user": "tsx scripts/create-test-user.ts",
     "db:seed-beta-links": "tsx scripts/seed-dev-beta-links.ts"

--- a/packages/db/scripts/merge-accounts-args.test.ts
+++ b/packages/db/scripts/merge-accounts-args.test.ts
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseArgs } from './merge-accounts.js';
+
+test('no args is a dry-run (apply stays false)', () => {
+  const parsed = parseArgs([]);
+  assert.equal(parsed.apply, false);
+  assert.equal(parsed.limit, null);
+  assert.equal(parsed.onlyEmail, null);
+  assert.equal(parsed.help, false);
+});
+
+test('--apply, --limit and --only-email parse; only-email is normalized', () => {
+  const parsed = parseArgs(['--apply', '--limit', '5', '--only-email', '  Foo@X.com ']);
+  assert.equal(parsed.apply, true);
+  assert.equal(parsed.limit, 5);
+  assert.equal(parsed.onlyEmail, 'foo@x.com');
+});
+
+test('a leading `--` separator is skipped, not treated as an unknown argument', () => {
+  assert.deepEqual(parseArgs(['--', '--apply']), parseArgs(['--apply']));
+});
+
+test('--help sets help', () => {
+  assert.equal(parseArgs(['--help']).help, true);
+});
+
+// The failure paths call process.exit(2). Stub it (and silence console.error)
+// so the test can assert they bail instead of returning a bad ScriptArgs.
+function assertExits(args: string[]): void {
+  const originalExit = process.exit;
+  const originalError = console.error;
+  process.exit = ((): never => {
+    throw new Error('process.exit');
+  }) as typeof process.exit;
+  console.error = () => {};
+  try {
+    assert.throws(() => parseArgs(args));
+  } finally {
+    process.exit = originalExit;
+    console.error = originalError;
+  }
+}
+
+test('an unknown flag exits', () => assertExits(['--nope']));
+test('--limit 0 exits (requires a positive integer)', () => assertExits(['--limit', '0']));
+test('--limit without a value exits', () => assertExits(['--limit']));
+test('--only-email without a value exits', () => assertExits(['--only-email']));

--- a/packages/db/scripts/merge-accounts.integration.test.ts
+++ b/packages/db/scripts/merge-accounts.integration.test.ts
@@ -182,6 +182,26 @@ void describe('merge-accounts apply path', () => {
             VALUES (${loserId}, 'tension', 999001, 'loserboard')
           `);
 
+          // Gym ownership claims (partial unique WHERE status='pending'): winner
+          // and loser both have a PENDING claim on gym A (collides — loser's
+          // dropped); loser also has an APPROVED claim on gym B (historical —
+          // always moves). Gyms owned by the third user to stay out of the merge.
+          const claimGymA = `${tag}-claimgym-a`;
+          const claimGymB = `${tag}-claimgym-b`;
+          await tx.execute(sql`
+            INSERT INTO gyms (uuid, name, owner_id, is_public, created_at, updated_at)
+            VALUES
+              (${claimGymA}, 'Claim Gym A', ${thirdId}, true, NOW(), NOW()),
+              (${claimGymB}, 'Claim Gym B', ${thirdId}, true, NOW(), NOW())
+          `);
+          await tx.execute(sql`
+            INSERT INTO gym_claims (gym_id, claimant_user_id, method, status)
+            VALUES
+              ((SELECT id FROM gyms WHERE uuid = ${claimGymA}), ${winnerId}, 'admin'::gym_claim_method, 'pending'::gym_claim_status),
+              ((SELECT id FROM gyms WHERE uuid = ${claimGymA}), ${loserId}, 'admin'::gym_claim_method, 'pending'::gym_claim_status),
+              ((SELECT id FROM gyms WHERE uuid = ${claimGymB}), ${loserId}, 'admin'::gym_claim_method, 'approved'::gym_claim_status)
+          `);
+
           // Ratings: climbA collides (winner rating 3 kept), climbB moves.
           await tx.execute(sql`
             INSERT INTO board_climb_ratings (board_type, climb_uuid, angle, user_id, rating)
@@ -342,6 +362,25 @@ void describe('merge-accounts apply path', () => {
             ),
             1,
             'beta-link attribution repointed to winner, not nulled',
+          );
+
+          assert.equal(
+            await countRows(
+              tx,
+              sql`SELECT count(*)::int AS count FROM gym_claims WHERE claimant_user_id = ${winnerId}`,
+            ),
+            2,
+            'colliding pending claim dropped, historical approved claim moved',
+          );
+          assert.equal(
+            await countRows(
+              tx,
+              sql`SELECT count(*)::int AS count
+                    FROM gym_claims gc JOIN gyms g ON g.id = gc.gym_id
+                   WHERE g.uuid = ${claimGymA} AND gc.status = 'pending'`,
+            ),
+            1,
+            'exactly one pending claim remains on the shared gym (no partial-unique violation)',
           );
 
           throw rollbackMarker;

--- a/packages/db/scripts/merge-accounts.integration.test.ts
+++ b/packages/db/scripts/merge-accounts.integration.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { sql, type SQLWrapper } from 'drizzle-orm';
 import { createScriptDb } from './db-connection.js';
-import { applyMerge, buildDuplicateSets, fetchMembersForEmail } from './merge-accounts.js';
+import { applyMerge, assertAllUserFksHandled, buildDuplicateSets, fetchMembersForEmail } from './merge-accounts.js';
 import { executeRows } from '../src/client/index.js';
 
 type ExecuteDb = {
@@ -47,6 +47,30 @@ async function countRows(commandDb: ExecuteDb, query: SQLWrapper): Promise<numbe
   const [row] = await executeRows<CountRow>(commandDb, query);
   return Number(row?.count ?? 0);
 }
+
+void describe('merge-accounts FK coverage', () => {
+  void it('handles every foreign key to users(id) in the live schema', async (testContext) => {
+    const databaseUrl = mergeTestDatabaseUrl();
+    if (!databaseUrl) {
+      testContext.skip('set MERGE_ACCOUNTS_DB_URL to a migrated writable DB, or run a local DATABASE_URL, to execute');
+      return;
+    }
+
+    const { db, close } = createScriptDb(databaseUrl);
+    try {
+      const unavailable = await skipReason(db);
+      if (unavailable) {
+        testContext.skip(unavailable);
+        return;
+      }
+      // Throws (listing the offending columns) if a migration added a user FK
+      // the repoint lists don't cover — keeps the script honest as the schema grows.
+      await assertAllUserFksHandled(db);
+    } finally {
+      await close();
+    }
+  });
+});
 
 void describe('merge-accounts apply path', () => {
   void it('repoints all owned rows onto the winner, dedupes uniques, and deletes losers', async (testContext) => {

--- a/packages/db/scripts/merge-accounts.integration.test.ts
+++ b/packages/db/scripts/merge-accounts.integration.test.ts
@@ -1,0 +1,332 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { sql, type SQLWrapper } from 'drizzle-orm';
+import { createScriptDb } from './db-connection.js';
+import { applyMerge, buildDuplicateSets, fetchMembersForEmail } from './merge-accounts.js';
+import { executeRows } from '../src/client/index.js';
+
+type ExecuteDb = {
+  execute(query: SQLWrapper | string): PromiseLike<unknown>;
+};
+type CountRow = { count: number | string };
+type StringRow = { value: string | null };
+type VoteCountRow = { entityId: string; upvotes: number | string; downvotes: number | string; score: number | string };
+
+function localDatabaseUrl(): string | null {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) return null;
+  const host = new URL(databaseUrl).hostname.toLowerCase();
+  return ['localhost', '127.0.0.1', 'postgres'].includes(host) ? databaseUrl : null;
+}
+
+function mergeTestDatabaseUrl(): string | null {
+  return process.env.MERGE_ACCOUNTS_DB_URL ?? localDatabaseUrl();
+}
+
+async function skipReason(commandDb: ExecuteDb): Promise<string | null> {
+  try {
+    const [state] = await executeRows<{ ticksTable: string | null; voteTrigger: boolean }>(
+      commandDb,
+      sql`
+        SELECT
+          to_regclass('public.boardsesh_ticks')::text AS "ticksTable",
+          EXISTS (
+            SELECT 1 FROM pg_trigger WHERE tgname = 'votes_count_trigger' AND tgrelid = 'votes'::regclass
+          ) AS "voteTrigger"
+      `,
+    );
+    if (!state?.ticksTable) return 'boardsesh_ticks is missing; run migrations before this integration test';
+    if (!state.voteTrigger) return 'votes_count_trigger is missing; run migrations before this integration test';
+  } catch (error: unknown) {
+    return `database unavailable: ${error instanceof Error ? error.message : String(error)}`;
+  }
+  return null;
+}
+
+async function countRows(commandDb: ExecuteDb, query: SQLWrapper): Promise<number> {
+  const [row] = await executeRows<CountRow>(commandDb, query);
+  return Number(row?.count ?? 0);
+}
+
+void describe('merge-accounts apply path', () => {
+  void it('repoints all owned rows onto the winner, dedupes uniques, and deletes losers', async (testContext) => {
+    const databaseUrl = mergeTestDatabaseUrl();
+    if (!databaseUrl) {
+      testContext.skip('set MERGE_ACCOUNTS_DB_URL to a migrated writable DB, or run a local DATABASE_URL, to execute');
+      return;
+    }
+
+    const { db, close } = createScriptDb(databaseUrl);
+    try {
+      const unavailable = await skipReason(db);
+      if (unavailable) {
+        testContext.skip(unavailable);
+        return;
+      }
+
+      const rollbackMarker = new Error('rollback merge fixture');
+      try {
+        await db.transaction(async (tx) => {
+          const tag = `merge-${Date.now()}`;
+          const lowerEmail = `${tag}@example.test`;
+          const winnerId = `${tag}-winner`;
+          const loserId = `${tag}-loser`;
+          const thirdId = `${tag}-third`;
+          const gymUuid = `${tag}-gym`;
+          const climbA = `${tag}-climb-a`;
+          const climbB = `${tag}-climb-b`;
+
+          // Winner email is upper-cased, loser is lower-case — same lower(email).
+          await tx.execute(sql`
+            INSERT INTO users (id, email, name, "emailVerified", created_at, updated_at)
+            VALUES
+              (${winnerId}, ${`${tag.toUpperCase()}@Example.test`}, 'Winner', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+              (${loserId}, ${lowerEmail}, 'Loser', NULL, '2026-02-01T00:00:00Z', '2026-03-01T00:00:00Z'),
+              (${thirdId}, ${`third-${tag}@example.test`}, 'Third', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+          `);
+
+          // Winner has more ticks → wins selection. Loser ticks (one with an
+          // aurora surrogate, one without) all move to the winner.
+          await tx.execute(sql`
+            INSERT INTO boardsesh_ticks (uuid, user_id, board_type, climb_uuid, angle, status, attempt_count, climbed_at)
+            VALUES
+              (${`${tag}-w1`}, ${winnerId}, 'kilter', ${climbA}, 40, 'send'::tick_status, 1, '2026-01-02T00:00:00Z'),
+              (${`${tag}-w2`}, ${winnerId}, 'kilter', ${climbB}, 40, 'send'::tick_status, 1, '2026-01-02T00:00:00Z'),
+              (${`${tag}-w3`}, ${winnerId}, 'kilter', ${`${tag}-c3`}, 40, 'send'::tick_status, 1, '2026-01-02T00:00:00Z'),
+              (${`${tag}-w4`}, ${winnerId}, 'kilter', ${`${tag}-c4`}, 40, 'send'::tick_status, 1, '2026-01-02T00:00:00Z'),
+              (${`${tag}-w5`}, ${winnerId}, 'kilter', ${`${tag}-c5`}, 40, 'send'::tick_status, 1, '2026-01-02T00:00:00Z'),
+              (${`${tag}-l1`}, ${loserId}, 'kilter', ${`${tag}-c6`}, 40, 'send'::tick_status, 1, '2026-02-02T00:00:00Z'),
+              (${`${tag}-l2`}, ${loserId}, 'tension', ${`${tag}-c7`}, 40, 'send'::tick_status, 1, '2026-02-02T00:00:00Z')
+          `);
+          await tx.execute(sql`
+            UPDATE boardsesh_ticks SET aurora_id = ${`${tag}-aurora`} WHERE uuid = ${`${tag}-l1`}
+          `);
+
+          // Favorites: climbA collides (winner keeps), climbB unique (moves).
+          await tx.execute(sql`
+            INSERT INTO user_favorites (user_id, board_name, climb_uuid, angle)
+            VALUES
+              (${winnerId}, 'kilter', ${climbA}, 40),
+              (${loserId}, 'kilter', ${climbA}, 40),
+              (${loserId}, 'kilter', ${climbB}, 40)
+          `);
+
+          // Follows: mutual loser↔winner (self-follow trap), loser→third and
+          // winner→third (dedup), third→loser (moves to third→winner).
+          await tx.execute(sql`
+            INSERT INTO user_follows (follower_id, following_id)
+            VALUES
+              (${loserId}, ${winnerId}),
+              (${winnerId}, ${loserId}),
+              (${winnerId}, ${thirdId}),
+              (${loserId}, ${thirdId}),
+              (${thirdId}, ${loserId})
+          `);
+
+          // Both have a password — winner keeps its own.
+          await tx.execute(sql`
+            INSERT INTO user_credentials (user_id, password_hash)
+            VALUES (${winnerId}, 'winner-hash'), (${loserId}, 'loser-hash')
+          `);
+
+          // Winner profile lacks a display name; loser supplies one.
+          await tx.execute(sql`
+            INSERT INTO user_profiles (user_id, display_name)
+            VALUES (${winnerId}, NULL), (${loserId}, 'Loser Display')
+          `);
+
+          // Votes on 'climb' entities: climbA collides (winner +1 kept, loser -1
+          // dropped), climbB moves. The votes_count_trigger maintains vote_counts.
+          await tx.execute(sql`
+            INSERT INTO votes (user_id, entity_type, entity_id, value)
+            VALUES
+              (${winnerId}, 'climb'::social_entity_type, ${climbA}, 1),
+              (${loserId}, 'climb'::social_entity_type, ${climbA}, -1),
+              (${loserId}, 'climb'::social_entity_type, ${climbB}, 1)
+          `);
+
+          // Loser owns a gym (gyms.owner_id is ON DELETE CASCADE — must repoint,
+          // not let the gym be deleted with the loser).
+          await tx.execute(sql`
+            INSERT INTO gyms (uuid, name, owner_id, is_public, created_at, updated_at)
+            VALUES (${gymUuid}, 'Loser Gym', ${loserId}, true, NOW(), NOW())
+          `);
+
+          // Loser linked a Tension board account; winner has none.
+          await tx.execute(sql`
+            INSERT INTO user_board_mappings (user_id, board_type, board_user_id, board_username)
+            VALUES (${loserId}, 'tension', 999001, 'loserboard')
+          `);
+
+          // Ratings: climbA collides (winner rating 3 kept), climbB moves.
+          await tx.execute(sql`
+            INSERT INTO board_climb_ratings (board_type, climb_uuid, angle, user_id, rating)
+            VALUES
+              ('kilter', ${climbA}, 40, ${winnerId}, 3),
+              ('kilter', ${climbA}, 40, ${loserId}, 5),
+              ('kilter', ${climbB}, 40, ${loserId}, 4)
+          `);
+
+          // Beta link attributed to the loser (created_by_user_id is a manual
+          // users(id) FK ON DELETE SET NULL — must repoint, not null on delete).
+          await tx.execute(sql`
+            INSERT INTO board_beta_links (board_type, climb_uuid, link, created_by_user_id)
+            VALUES ('kilter', ${climbA}, ${`https://instagram.com/p/${tag}/`}, ${loserId})
+          `);
+
+          // --- Run the merge through the real apply path ---
+          const members = await fetchMembersForEmail(tx, lowerEmail);
+          const duplicateSet = buildDuplicateSets(members)[0];
+          assert.equal(duplicateSet.winner.id, winnerId, 'winner is the account with more ticks');
+
+          const result = await applyMerge(tx, duplicateSet);
+          assert.equal(result.merged, true);
+
+          // --- Assertions ---
+          assert.equal(
+            await countRows(tx, sql`SELECT count(*)::int AS count FROM users WHERE id = ${loserId}`),
+            0,
+            'loser user deleted',
+          );
+          assert.equal(
+            await countRows(tx, sql`SELECT count(*)::int AS count FROM users WHERE id = ${winnerId}`),
+            1,
+            'winner user kept',
+          );
+          assert.equal(
+            await countRows(tx, sql`SELECT count(*)::int AS count FROM users WHERE lower(email) = ${lowerEmail}`),
+            1,
+            'no duplicate remains for the email',
+          );
+
+          assert.equal(
+            await countRows(tx, sql`SELECT count(*)::int AS count FROM boardsesh_ticks WHERE user_id = ${winnerId}`),
+            7,
+            'all 5 winner + 2 loser ticks now belong to the winner',
+          );
+
+          assert.equal(
+            await countRows(tx, sql`SELECT count(*)::int AS count FROM user_favorites WHERE user_id = ${winnerId}`),
+            2,
+            'colliding favorite deduped, unique favorite moved',
+          );
+
+          assert.equal(
+            await countRows(
+              tx,
+              sql`SELECT count(*)::int AS count FROM user_follows WHERE follower_id = ${winnerId} AND following_id = ${winnerId}`,
+            ),
+            0,
+            'no self-follow created',
+          );
+          assert.equal(
+            await countRows(tx, sql`SELECT count(*)::int AS count FROM user_follows WHERE follower_id = ${winnerId}`),
+            1,
+            'winner follows third once (loser→third deduped against winner→third)',
+          );
+          assert.equal(
+            await countRows(
+              tx,
+              sql`SELECT count(*)::int AS count FROM user_follows WHERE follower_id = ${thirdId} AND following_id = ${winnerId}`,
+            ),
+            1,
+            'third→loser repointed to third→winner',
+          );
+
+          const [credential] = await executeRows<StringRow>(
+            tx,
+            sql`SELECT password_hash AS value FROM user_credentials WHERE user_id = ${winnerId}`,
+          );
+          assert.equal(credential?.value, 'winner-hash', 'winner keeps its own password');
+
+          const [profile] = await executeRows<StringRow>(
+            tx,
+            sql`SELECT display_name AS value FROM user_profiles WHERE user_id = ${winnerId}`,
+          );
+          assert.equal(profile?.value, 'Loser Display', 'winner profile back-filled from loser');
+
+          const [emailVerified] = await executeRows<StringRow>(
+            tx,
+            sql`SELECT "emailVerified"::text AS value FROM users WHERE id = ${winnerId}`,
+          );
+          assert.notEqual(emailVerified?.value, null, 'verified timestamp preserved on the winner');
+
+          const winnerVotes = await executeRows<{ entityId: string; value: number | string }>(
+            tx,
+            sql`SELECT entity_id AS "entityId", value FROM votes WHERE user_id = ${winnerId} AND entity_type = 'climb'::social_entity_type ORDER BY entity_id`,
+          );
+          assert.deepEqual(
+            winnerVotes.map((vote) => ({ entityId: vote.entityId, value: Number(vote.value) })),
+            [
+              { entityId: climbA, value: 1 },
+              { entityId: climbB, value: 1 },
+            ],
+            'winner keeps its climbA vote and inherits the climbB vote',
+          );
+
+          const voteCounts = await executeRows<VoteCountRow>(
+            tx,
+            sql`
+              SELECT entity_id AS "entityId", upvotes, downvotes, score
+              FROM vote_counts
+              WHERE entity_type = 'climb'::social_entity_type AND entity_id IN (${climbA}, ${climbB})
+              ORDER BY entity_id
+            `,
+          );
+          assert.deepEqual(
+            voteCounts.map((row) => ({
+              entityId: row.entityId,
+              upvotes: Number(row.upvotes),
+              downvotes: Number(row.downvotes),
+              score: Number(row.score),
+            })),
+            [
+              { entityId: climbA, upvotes: 1, downvotes: 0, score: 1 },
+              { entityId: climbB, upvotes: 1, downvotes: 0, score: 1 },
+            ],
+            'trigger-maintained vote_counts reflect the deduped winner votes',
+          );
+
+          const [gymOwner] = await executeRows<StringRow>(
+            tx,
+            sql`SELECT owner_id AS value FROM gyms WHERE uuid = ${gymUuid}`,
+          );
+          assert.equal(gymOwner?.value, winnerId, 'gym repointed to winner, not cascade-deleted');
+
+          assert.equal(
+            await countRows(
+              tx,
+              sql`SELECT count(*)::int AS count FROM user_board_mappings WHERE user_id = ${winnerId} AND board_type = 'tension'`,
+            ),
+            1,
+            'loser Tension board link moved to winner',
+          );
+
+          assert.equal(
+            await countRows(
+              tx,
+              sql`SELECT count(*)::int AS count FROM board_climb_ratings WHERE user_id = ${winnerId}`,
+            ),
+            2,
+            'colliding rating deduped, unique rating moved',
+          );
+
+          assert.equal(
+            await countRows(
+              tx,
+              sql`SELECT count(*)::int AS count FROM board_beta_links WHERE created_by_user_id = ${winnerId}`,
+            ),
+            1,
+            'beta-link attribution repointed to winner, not nulled',
+          );
+
+          throw rollbackMarker;
+        });
+      } catch (error: unknown) {
+        if (error !== rollbackMarker) throw error;
+      }
+    } finally {
+      await close();
+    }
+  });
+});

--- a/packages/db/scripts/merge-accounts.integration.test.ts
+++ b/packages/db/scripts/merge-accounts.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
 import { sql, type SQLWrapper } from 'drizzle-orm';
 import { createScriptDb } from './db-connection.js';
 import { applyMerge, assertAllUserFksHandled, buildDuplicateSets, fetchMembersForEmail } from './merge-accounts.js';
@@ -91,7 +92,9 @@ void describe('merge-accounts apply path', () => {
       const rollbackMarker = new Error('rollback merge fixture');
       try {
         await db.transaction(async (tx) => {
-          const tag = `merge-${Date.now()}`;
+          // randomUUID, not Date.now(): two runs in the same millisecond (watch
+          // mode, or a parallel worker) would otherwise collide on users.id.
+          const tag = `merge-${randomUUID()}`;
           const lowerEmail = `${tag}@example.test`;
           const winnerId = `${tag}-winner`;
           const loserId = `${tag}-loser`;

--- a/packages/db/scripts/merge-accounts.ts
+++ b/packages/db/scripts/merge-accounts.ts
@@ -118,6 +118,9 @@ const PLAIN_REPOINTS: Array<{ table: string; column: string }> = [
   // the loser's beta-link attribution moves to the winner instead of nulling.
   { table: 'board_beta_links', column: 'created_by_user_id' },
   { table: 'gyms', column: 'owner_id' },
+  // Admin who reviewed a gym ownership claim (SET NULL, no unique) — repoint so
+  // the reviewer attribution follows the merged account.
+  { table: 'gym_claims', column: 'reviewed_by' },
 ];
 
 /**
@@ -130,7 +133,15 @@ const PLAIN_REPOINTS: Array<{ table: string; column: string }> = [
  * `IS NOT DISTINCT FROM` covers the nullable, NULLS-NOT-DISTINCT cases
  * (community_roles.board_type) and is equivalent to `=` for NOT NULL columns.
  */
-const DEDUPE_REPOINTS: Array<{ table: string; column: string; otherCols: string[] }> = [
+const DEDUPE_REPOINTS: Array<{
+  table: string;
+  column: string;
+  otherCols: string[];
+  // Extra SQL ANDed into the collision check for a PARTIAL unique index — only
+  // rows matching it can collide (references `winner_row` and `target`). Loser
+  // rows outside the predicate always move.
+  collisionPredicate?: string;
+}> = [
   { table: 'user_board_mappings', column: 'user_id', otherCols: ['board_type'] },
   { table: 'aurora_credentials', column: 'user_id', otherCols: ['board_type'] },
   { table: 'integration_credentials', column: 'user_id', otherCols: ['provider'] },
@@ -157,6 +168,15 @@ const DEDUPE_REPOINTS: Array<{ table: string; column: string; otherCols: string[
   // user-scoped unique only — the aurora_id/kilter_id partial uniques are global,
   // so a given surrogate exists on at most one rating and can never collide here.
   { table: 'board_climb_ratings', column: 'user_id', otherCols: ['board_type', 'climb_uuid', 'angle'] },
+  // Partial unique (gym_id, claimant_user_id) WHERE status = 'pending' — only two
+  // pending claims on the same gym collide; historical (approved/denied) claims
+  // always move so the merged account keeps the full claim history.
+  {
+    table: 'gym_claims',
+    column: 'claimant_user_id',
+    otherCols: ['gym_id'],
+    collisionPredicate: `winner_row.status = 'pending' AND target.status = 'pending'`,
+  },
 ];
 
 // Columns repointed by the hand-coded specials in mergeLoserIntoWinner / mergeSet
@@ -428,11 +448,14 @@ async function mergeLoserIntoWinner(commandDb: ExecuteDb, winnerId: string, lose
     );
   }
 
-  for (const { table, column, otherCols } of DEDUPE_REPOINTS) {
-    const matchClause = sql.join(
-      otherCols.map((otherCol) => sql.raw(`winner_row.${otherCol} IS NOT DISTINCT FROM target.${otherCol}`)),
-      sql` AND `,
+  for (const { table, column, otherCols, collisionPredicate } of DEDUPE_REPOINTS) {
+    const matchParts = otherCols.map((otherCol) =>
+      sql.raw(`winner_row.${otherCol} IS NOT DISTINCT FROM target.${otherCol}`),
     );
+    if (collisionPredicate) {
+      matchParts.push(sql.raw(`(${collisionPredicate})`));
+    }
+    const matchClause = sql.join(matchParts, sql` AND `);
     await execute(
       commandDb,
       sql`

--- a/packages/db/scripts/merge-accounts.ts
+++ b/packages/db/scripts/merge-accounts.ts
@@ -1,0 +1,714 @@
+/**
+ * Merge duplicate user accounts that share the same email (case-insensitively).
+ *
+ * `users.email` historically had no unique constraint and used the default
+ * (case-sensitive) collation, so `Foo@x.com` and `foo@x.com` could create
+ * separate accounts. This script collapses each `lower(email)` group down to a
+ * single winner: every row owned by a loser account is repointed onto the
+ * winner, then the loser `users` rows are deleted (FK cascades clean up anything
+ * left behind — including rows intentionally dropped because the winner already
+ * had an equivalent one).
+ *
+ * Winner selection: most boardsesh_ticks, then most other owned rows, then a
+ * verified email, then the oldest account. The winner keeps its `users.id` so
+ * existing web sessions (JWT `sub`) keep working; the losers' login methods
+ * (OAuth `accounts`, password `user_credentials`, mobile refresh tokens) are
+ * repointed onto the winner so every previous way of signing in still lands on
+ * the merged account.
+ *
+ * Default mode is dry-run. Use --apply only after reading the candidate report,
+ * and take a fresh pg_dump first — deleting users is irreversible.
+ *
+ * Usage:
+ *   vp run db:merge-accounts
+ *   vp run db:merge-accounts --only-email foo@x.com
+ *   vp run db:merge-accounts --apply --limit 5
+ */
+
+import { sql, type SQLWrapper, type SQL } from 'drizzle-orm';
+import { pathToFileURL } from 'node:url';
+import { createScriptDb } from './db-connection.js';
+import { executeRows } from '../src/client/index.js';
+
+const APPLY_FLAG = '--apply';
+const LIMIT_FLAG = '--limit';
+const ONLY_EMAIL_FLAG = '--only-email';
+const HELP_FLAG = '--help';
+const ARG_SEPARATOR = '--';
+
+type ExecuteDb = {
+  execute(query: SQLWrapper | string): PromiseLike<unknown>;
+};
+
+type ScriptArgs = {
+  apply: boolean;
+  limit: number | null;
+  onlyEmail: string | null;
+  help: boolean;
+};
+
+type MemberRow = {
+  id: string;
+  email: string;
+  name: string | null;
+  image: string | null;
+  emailVerified: string | null;
+  createdAt: string;
+  updatedAt: string;
+  tickCount: number | string;
+  favoriteCount: number | string;
+  followCount: number | string;
+  playlistCount: number | string;
+  hasCredential: boolean;
+};
+
+type Member = {
+  id: string;
+  email: string;
+  name: string | null;
+  image: string | null;
+  emailVerified: string | null;
+  createdAt: string;
+  updatedAt: string;
+  tickCount: number;
+  favoriteCount: number;
+  followCount: number;
+  playlistCount: number;
+  hasCredential: boolean;
+};
+
+type DuplicateSet = {
+  lowerEmail: string;
+  members: Member[];
+  winner: Member;
+  losers: Member[];
+};
+
+type CountRow = { count: number | string | null };
+
+/**
+ * Plain repoints: a user-referencing column NOT part of any user-scoped unique
+ * constraint. We move every loser row onto the winner. `accounts`/`sessions`
+ * use NextAuth's quoted camelCase `"userId"` column; everything else is
+ * snake_case. SET NULL columns are included here so attribution (who created a
+ * climb, who acted on a feed item) moves to the winner instead of being nulled
+ * when the loser is deleted.
+ */
+const PLAIN_REPOINTS: Array<{ table: string; column: string }> = [
+  { table: 'accounts', column: '"userId"' },
+  { table: 'sessions', column: '"userId"' },
+  { table: 'mobile_refresh_tokens', column: 'user_id' },
+  { table: 'esp32_controllers', column: 'user_id' },
+  { table: 'comments', column: 'user_id' },
+  { table: 'app_feedback', column: 'user_id' },
+  { table: 'board_climb_events', column: 'user_id' },
+  { table: 'feed_items', column: 'recipient_id' },
+  { table: 'feed_items', column: 'actor_id' },
+  { table: 'notifications', column: 'recipient_id' },
+  { table: 'notifications', column: 'actor_id' },
+  { table: 'activity_push_tokens', column: 'user_id' },
+  { table: 'board_sessions', column: 'created_by_user_id' },
+  { table: 'community_settings', column: 'set_by' },
+  { table: 'community_roles', column: 'granted_by' },
+  { table: 'climb_proposals', column: 'proposer_id' },
+  { table: 'climb_proposals', column: 'resolved_by' },
+  { table: 'board_climbs', column: 'user_id' },
+  // board_beta_links.created_by_user_id is a real users(id) FK (ON DELETE SET
+  // NULL) declared only in migration 0093, not via .references() — repoint it so
+  // the loser's beta-link attribution moves to the winner instead of nulling.
+  { table: 'board_beta_links', column: 'created_by_user_id' },
+  { table: 'gyms', column: 'owner_id' },
+];
+
+/**
+ * Dedupe repoints: the user-referencing column participates in a user-scoped
+ * unique constraint, so a loser row collides if the winner already holds the
+ * same tuple. We move only the non-colliding loser rows; the colliding ones are
+ * left behind and removed by the final `DELETE FROM users` cascade. Processing
+ * one loser at a time means a 3-row set also dedupes against losers already
+ * merged into the winner. `otherCols` are the rest of the unique constraint;
+ * `IS NOT DISTINCT FROM` covers the nullable, NULLS-NOT-DISTINCT cases
+ * (community_roles.board_type) and is equivalent to `=` for NOT NULL columns.
+ */
+const DEDUPE_REPOINTS: Array<{ table: string; column: string; otherCols: string[] }> = [
+  { table: 'user_board_mappings', column: 'user_id', otherCols: ['board_type'] },
+  { table: 'aurora_credentials', column: 'user_id', otherCols: ['board_type'] },
+  { table: 'integration_credentials', column: 'user_id', otherCols: ['provider'] },
+  { table: 'integration_exports', column: 'user_id', otherCols: ['provider', 'session_type', 'session_id'] },
+  { table: 'user_favorites', column: 'user_id', otherCols: ['board_name', 'climb_uuid', 'angle'] },
+  { table: 'setter_follows', column: 'follower_id', otherCols: ['setter_username'] },
+  { table: 'playlist_follows', column: 'follower_id', otherCols: ['playlist_uuid'] },
+  { table: 'board_follows', column: 'user_id', otherCols: ['board_uuid'] },
+  { table: 'gym_members', column: 'user_id', otherCols: ['gym_id'] },
+  { table: 'gym_follows', column: 'user_id', otherCols: ['gym_id'] },
+  { table: 'playlist_ownership', column: 'user_id', otherCols: ['playlist_id'] },
+  { table: 'user_playlist_pins', column: 'user_id', otherCols: ['playlist_id'] },
+  { table: 'proposal_votes', column: 'user_id', otherCols: ['proposal_id'] },
+  { table: 'community_roles', column: 'user_id', otherCols: ['role', 'board_type'] },
+  { table: 'board_session_participants', column: 'user_id', otherCols: ['session_id'] },
+  { table: 'session_health_kit_workouts', column: 'user_id', otherCols: ['session_id'] },
+  {
+    table: 'user_hold_classifications',
+    column: 'user_id',
+    otherCols: ['board_type', 'layout_id', 'size_id', 'hold_id'],
+  },
+  { table: 'new_climb_subscriptions', column: 'user_id', otherCols: ['board_type', 'layout_id'] },
+  { table: 'user_board_serials', column: 'user_id', otherCols: ['serial_number'] },
+  // user-scoped unique only — the aurora_id/kilter_id partial uniques are global,
+  // so a given surrogate exists on at most one rating and can never collide here.
+  { table: 'board_climb_ratings', column: 'user_id', otherCols: ['board_type', 'climb_uuid', 'angle'] },
+];
+
+function parsePositiveInteger(rawValue: string | undefined, flagName: string): number {
+  const parsedValue = Number(rawValue);
+  if (!Number.isInteger(parsedValue) || parsedValue <= 0) {
+    console.error(`[merge-accounts] ${flagName} requires a positive integer.`);
+    process.exit(2);
+  }
+  return parsedValue;
+}
+
+function readRequiredOptionValue(args: string[], optionIndex: number, flagName: string): string {
+  const optionValue = args[optionIndex + 1];
+  if (!optionValue || optionValue.startsWith('--')) {
+    console.error(`[merge-accounts] ${flagName} requires a value.`);
+    process.exit(2);
+  }
+  return optionValue;
+}
+
+export function parseArgs(args: string[]): ScriptArgs {
+  const parsedArgs: ScriptArgs = { apply: false, limit: null, onlyEmail: null, help: false };
+
+  for (let index = 0; index < args.length; index++) {
+    const currentArg = args[index];
+    if (currentArg === ARG_SEPARATOR) {
+      continue;
+    }
+    if (currentArg === APPLY_FLAG) {
+      parsedArgs.apply = true;
+      continue;
+    }
+    if (currentArg === HELP_FLAG) {
+      parsedArgs.help = true;
+      continue;
+    }
+    if (currentArg === LIMIT_FLAG) {
+      parsedArgs.limit = parsePositiveInteger(readRequiredOptionValue(args, index, LIMIT_FLAG), LIMIT_FLAG);
+      index += 1;
+      continue;
+    }
+    if (currentArg === ONLY_EMAIL_FLAG) {
+      parsedArgs.onlyEmail = readRequiredOptionValue(args, index, ONLY_EMAIL_FLAG).trim().toLowerCase();
+      index += 1;
+      continue;
+    }
+
+    console.error(`[merge-accounts] Unknown argument: ${currentArg}`);
+    process.exit(2);
+  }
+
+  return parsedArgs;
+}
+
+function printHelp(): void {
+  console.info(`Usage:
+  vp run db:merge-accounts                       Dry-run report of every duplicate-by-case set.
+  vp run db:merge-accounts --only-email a@b.com  Restrict to one lower-cased email.
+  vp run db:merge-accounts --apply --limit 5     Merge (up to 5 sets). Take a pg_dump first.
+
+Options:
+  --apply               Perform the merge. Omit for a dry-run report.
+  --limit <n>           Limit the number of duplicate sets processed.
+  --only-email <email>  Restrict to a single lower-cased email.
+  --help                Show this help text.`);
+}
+
+function coerceMember(row: MemberRow): Member {
+  return {
+    id: row.id,
+    email: row.email,
+    name: row.name,
+    image: row.image,
+    emailVerified: row.emailVerified,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    tickCount: Number(row.tickCount),
+    favoriteCount: Number(row.favoriteCount),
+    followCount: Number(row.followCount),
+    playlistCount: Number(row.playlistCount),
+    hasCredential: row.hasCredential,
+  };
+}
+
+function relatedCount(member: Member): number {
+  return member.favoriteCount + member.followCount + member.playlistCount;
+}
+
+/**
+ * Winner = most ticks, then most other owned rows, then a verified email, then
+ * the oldest account (stable). Deterministic so dry-run and apply agree.
+ */
+function compareForWinner(first: Member, second: Member): number {
+  if (first.tickCount !== second.tickCount) return second.tickCount - first.tickCount;
+  if (relatedCount(first) !== relatedCount(second)) return relatedCount(second) - relatedCount(first);
+  const firstVerified = first.emailVerified ? 1 : 0;
+  const secondVerified = second.emailVerified ? 1 : 0;
+  if (firstVerified !== secondVerified) return secondVerified - firstVerified;
+  return first.createdAt.localeCompare(second.createdAt);
+}
+
+export function buildDuplicateSets(members: Member[]): DuplicateSet[] {
+  const byEmail = new Map<string, Member[]>();
+  for (const member of members) {
+    const key = member.email.trim().toLowerCase();
+    const bucket = byEmail.get(key);
+    if (bucket) {
+      bucket.push(member);
+    } else {
+      byEmail.set(key, [member]);
+    }
+  }
+
+  const sets: DuplicateSet[] = [];
+  for (const [lowerEmail, bucket] of byEmail) {
+    if (bucket.length < 2) continue;
+    const ordered = [...bucket].sort(compareForWinner);
+    const [winner, ...losers] = ordered;
+    sets.push({ lowerEmail, members: ordered, winner, losers });
+  }
+  // Stable output order — by email so the report and apply iterate identically.
+  sets.sort((first, second) => first.lowerEmail.localeCompare(second.lowerEmail));
+  return sets;
+}
+
+const MEMBER_COLUMNS = sql`
+  u.id AS "id",
+  u.email AS "email",
+  u.name AS "name",
+  u.image AS "image",
+  u."emailVerified"::text AS "emailVerified",
+  u.created_at::text AS "createdAt",
+  u.updated_at::text AS "updatedAt",
+  COALESCE(tick_counts.count, 0)::int AS "tickCount",
+  COALESCE(favorite_counts.count, 0)::int AS "favoriteCount",
+  COALESCE(follow_counts.count, 0)::int AS "followCount",
+  COALESCE(playlist_counts.count, 0)::int AS "playlistCount",
+  (credentials.user_id IS NOT NULL) AS "hasCredential"
+`;
+
+const MEMBER_JOINS = sql`
+  LEFT JOIN (SELECT user_id, count(*) AS count FROM boardsesh_ticks GROUP BY user_id) tick_counts
+    ON tick_counts.user_id = u.id
+  LEFT JOIN (SELECT user_id, count(*) AS count FROM user_favorites GROUP BY user_id) favorite_counts
+    ON favorite_counts.user_id = u.id
+  LEFT JOIN (SELECT follower_id AS user_id, count(*) AS count FROM user_follows GROUP BY follower_id) follow_counts
+    ON follow_counts.user_id = u.id
+  LEFT JOIN (SELECT user_id, count(*) AS count FROM playlist_ownership GROUP BY user_id) playlist_counts
+    ON playlist_counts.user_id = u.id
+  LEFT JOIN user_credentials credentials ON credentials.user_id = u.id
+`;
+
+async function fetchAllDuplicateMembers(commandDb: ExecuteDb, onlyEmail: string | null): Promise<Member[]> {
+  const emailClause = onlyEmail
+    ? sql`lower(u.email) = ${onlyEmail}`
+    : sql`lower(u.email) IN (SELECT lower(email) FROM users GROUP BY lower(email) HAVING count(*) > 1)`;
+
+  const rows = await executeRows<MemberRow>(
+    commandDb,
+    sql`SELECT ${MEMBER_COLUMNS} FROM users u ${MEMBER_JOINS} WHERE ${emailClause} ORDER BY lower(u.email), u.created_at`,
+  );
+  return rows.map(coerceMember);
+}
+
+export async function fetchMembersForEmail(commandDb: ExecuteDb, lowerEmail: string): Promise<Member[]> {
+  const rows = await executeRows<MemberRow>(
+    commandDb,
+    sql`SELECT ${MEMBER_COLUMNS} FROM users u ${MEMBER_JOINS} WHERE lower(u.email) = ${lowerEmail} ORDER BY u.created_at`,
+  );
+  return rows.map(coerceMember);
+}
+
+function memberIdKey(members: Member[]): string {
+  return members
+    .map((member) => member.id)
+    .sort()
+    .join(',');
+}
+
+function sqlIdList(ids: string[]): SQL {
+  return sql.join(
+    ids.map((id) => sql`${id}`),
+    sql`, `,
+  );
+}
+
+function anomalyFlags(duplicateSet: DuplicateSet): string[] {
+  const flags: string[] = [];
+  if (duplicateSet.members.length > 2) flags.push(`${duplicateSet.members.length}-row set`);
+  if (duplicateSet.losers.some((loser) => loser.tickCount > 0) && duplicateSet.winner.tickCount > 0) {
+    flags.push('multiple accounts have ticks');
+  }
+  if (duplicateSet.members.filter((member) => member.hasCredential).length > 1) {
+    flags.push('multiple accounts have passwords');
+  }
+  return flags;
+}
+
+function formatMemberLabel(member: Member, isWinner: boolean): string {
+  const role = isWinner ? 'winner   ' : 'loser    ';
+  const verified = member.emailVerified ? 'verified' : 'unverified';
+  return (
+    `  ${role} ${member.email} (#${member.id}, ${member.createdAt.slice(0, 10)}, ${verified}` +
+    `${member.hasCredential ? ', password' : ''})\n` +
+    `    ticks=${member.tickCount}, favorites=${member.favoriteCount}, follows=${member.followCount}, playlists=${member.playlistCount}`
+  );
+}
+
+function printReport(sets: DuplicateSet[], apply: boolean): void {
+  const loserCount = sets.reduce((total, duplicateSet) => total + duplicateSet.losers.length, 0);
+  console.info(
+    `[merge-accounts] Found ${sets.length} duplicate-by-case set(s), ${loserCount} account(s) to merge away.`,
+  );
+
+  for (const [index, duplicateSet] of sets.entries()) {
+    const flags = anomalyFlags(duplicateSet);
+    console.info('');
+    console.info(
+      `[merge-accounts] ${index + 1}. ${duplicateSet.lowerEmail}${flags.length ? `  ⚠ ${flags.join('; ')}` : ''}`,
+    );
+    console.info(formatMemberLabel(duplicateSet.winner, true));
+    for (const loser of duplicateSet.losers) {
+      console.info(formatMemberLabel(loser, false));
+    }
+  }
+
+  if (!apply) {
+    console.info('');
+    console.info('[merge-accounts] Dry-run only. Re-run with --apply to merge (take a pg_dump first).');
+  }
+}
+
+async function execute(commandDb: ExecuteDb, query: SQL): Promise<void> {
+  await commandDb.execute(query);
+}
+
+async function executeCount(commandDb: ExecuteDb, query: SQL): Promise<number> {
+  const [row] = await executeRows<CountRow>(commandDb, query);
+  return Number(row?.count ?? 0);
+}
+
+/** Move every row a single loser owns onto the winner, deduping where needed. */
+async function mergeLoserIntoWinner(commandDb: ExecuteDb, winnerId: string, loserId: string): Promise<void> {
+  for (const { table, column } of PLAIN_REPOINTS) {
+    await execute(
+      commandDb,
+      sql`UPDATE ${sql.raw(table)} SET ${sql.raw(column)} = ${winnerId} WHERE ${sql.raw(column)} = ${loserId}`,
+    );
+  }
+
+  for (const { table, column, otherCols } of DEDUPE_REPOINTS) {
+    const matchClause = sql.join(
+      otherCols.map((otherCol) => sql.raw(`winner_row.${otherCol} IS NOT DISTINCT FROM target.${otherCol}`)),
+      sql` AND `,
+    );
+    await execute(
+      commandDb,
+      sql`
+        UPDATE ${sql.raw(table)} AS target
+           SET ${sql.raw(column)} = ${winnerId}
+         WHERE target.${sql.raw(column)} = ${loserId}
+           AND NOT EXISTS (
+             SELECT 1 FROM ${sql.raw(table)} AS winner_row
+              WHERE winner_row.${sql.raw(column)} = ${winnerId}
+                AND ${matchClause}
+           )
+      `,
+    );
+  }
+
+  // boardsesh_ticks: aurora_id/kilter_id are globally unique, so a loser tick
+  // can never share one with a winner tick under the current schema — this
+  // moves all of them. The surrogate guards are defensive: if the unique is
+  // ever scoped per-user, true duplicates stay behind and cascade away.
+  await execute(
+    commandDb,
+    sql`
+      UPDATE boardsesh_ticks AS target
+         SET user_id = ${winnerId}
+       WHERE target.user_id = ${loserId}
+         AND NOT EXISTS (
+           SELECT 1 FROM boardsesh_ticks AS winner_row
+            WHERE winner_row.user_id = ${winnerId}
+              AND winner_row.aurora_id IS NOT NULL
+              AND winner_row.aurora_id = target.aurora_id
+         )
+         AND NOT EXISTS (
+           SELECT 1 FROM boardsesh_ticks AS winner_row
+            WHERE winner_row.user_id = ${winnerId}
+              AND winner_row.kilter_id IS NOT NULL
+              AND winner_row.kilter_id = target.kilter_id
+         )
+    `,
+  );
+
+  // user_boards: partial uniques on (owner, board config) and (owner, serial),
+  // both only over active (deleted_at IS NULL) non-system rows. Move a loser
+  // board unless an active winner board already occupies the same config or
+  // serial; colliding loser boards cascade away with the loser.
+  await execute(
+    commandDb,
+    sql`
+      UPDATE user_boards AS target
+         SET owner_id = ${winnerId}, updated_at = NOW()
+       WHERE target.owner_id = ${loserId}
+         AND NOT EXISTS (
+           SELECT 1 FROM user_boards AS winner_row
+            WHERE winner_row.owner_id = ${winnerId}
+              AND winner_row.deleted_at IS NULL
+              AND target.deleted_at IS NULL
+              AND winner_row.board_type = target.board_type
+              AND winner_row.layout_id = target.layout_id
+              AND winner_row.size_id = target.size_id
+              AND winner_row.set_ids = target.set_ids
+         )
+         AND NOT EXISTS (
+           SELECT 1 FROM user_boards AS winner_row
+            WHERE winner_row.owner_id = ${winnerId}
+              AND winner_row.deleted_at IS NULL
+              AND target.deleted_at IS NULL
+              AND target.serial_number IS NOT NULL
+              AND target.serial_number <> ''
+              AND winner_row.serial_number = target.serial_number
+         )
+    `,
+  );
+
+  // votes: user-scoped unique on (user_id, entity_type, entity_id). Move the
+  // loser's votes onto the winner where the winner hasn't already voted; the
+  // dropped duplicates are reconciled in vote_counts after the merge.
+  await execute(
+    commandDb,
+    sql`
+      UPDATE votes AS target
+         SET user_id = ${winnerId}
+       WHERE target.user_id = ${loserId}
+         AND NOT EXISTS (
+           SELECT 1 FROM votes AS winner_row
+            WHERE winner_row.user_id = ${winnerId}
+              AND winner_row.entity_type = target.entity_type
+              AND winner_row.entity_id = target.entity_id
+         )
+    `,
+  );
+
+  // user_credentials / user_profiles are PK(user_id): adopt the loser's row
+  // only when the winner has none. user_profiles also back-fills the winner's
+  // null fields from the loser before the (no-op-if-present) adopt.
+  await execute(
+    commandDb,
+    sql`
+      UPDATE user_profiles AS winner_profile
+         SET display_name = COALESCE(winner_profile.display_name, loser_profile.display_name),
+             avatar_url = COALESCE(winner_profile.avatar_url, loser_profile.avatar_url),
+             instagram_url = COALESCE(winner_profile.instagram_url, loser_profile.instagram_url),
+             updated_at = NOW()
+        FROM user_profiles AS loser_profile
+       WHERE winner_profile.user_id = ${winnerId}
+         AND loser_profile.user_id = ${loserId}
+    `,
+  );
+  await execute(
+    commandDb,
+    sql`
+      UPDATE user_profiles
+         SET user_id = ${winnerId}
+       WHERE user_id = ${loserId}
+         AND NOT EXISTS (SELECT 1 FROM user_profiles AS winner_row WHERE winner_row.user_id = ${winnerId})
+    `,
+  );
+  await execute(
+    commandDb,
+    sql`
+      UPDATE user_credentials
+         SET user_id = ${winnerId}
+       WHERE user_id = ${loserId}
+         AND NOT EXISTS (SELECT 1 FROM user_credentials AS winner_row WHERE winner_row.user_id = ${winnerId})
+    `,
+  );
+}
+
+/** Apply the winner's reconciled name / image / emailVerified to the users row. */
+async function reconcileWinnerFields(commandDb: ExecuteDb, duplicateSet: DuplicateSet): Promise<void> {
+  const { winner, members } = duplicateSet;
+
+  const byRecentUpdate = [...members].sort((first, second) => second.updatedAt.localeCompare(first.updatedAt));
+  const name = winner.name ?? byRecentUpdate.find((member) => member.name)?.name ?? null;
+  const image = winner.image ?? byRecentUpdate.find((member) => member.image)?.image ?? null;
+  const verifiedTimestamps = members
+    .map((member) => member.emailVerified)
+    .filter((value): value is string => value !== null)
+    .sort();
+  const emailVerified = verifiedTimestamps[0] ?? null;
+
+  await execute(
+    commandDb,
+    sql`
+      UPDATE users
+         SET name = ${name},
+             image = ${image},
+             "emailVerified" = ${emailVerified},
+             updated_at = NOW()
+       WHERE id = ${winner.id}
+    `,
+  );
+}
+
+async function mergeSet(commandDb: ExecuteDb, duplicateSet: DuplicateSet): Promise<void> {
+  const winnerId = duplicateSet.winner.id;
+  const loserIds = duplicateSet.losers.map((loser) => loser.id);
+  const allIds = duplicateSet.members.map((member) => member.id);
+
+  // Remove every follow edge whose endpoints are both inside the set, so no
+  // repoint can produce a (winner, winner) self-follow.
+  await execute(
+    commandDb,
+    sql`
+      DELETE FROM user_follows
+       WHERE follower_id IN (${sqlIdList(allIds)})
+         AND following_id IN (${sqlIdList(allIds)})
+    `,
+  );
+
+  for (const loserId of loserIds) {
+    await mergeLoserIntoWinner(commandDb, winnerId, loserId);
+
+    // user_follows is symmetric: repoint both sides, deduping against edges the
+    // winner already has. Intra-set edges were deleted above, so neither side
+    // can create a self-follow.
+    await execute(
+      commandDb,
+      sql`
+        UPDATE user_follows AS target
+           SET follower_id = ${winnerId}
+         WHERE target.follower_id = ${loserId}
+           AND NOT EXISTS (
+             SELECT 1 FROM user_follows AS winner_row
+              WHERE winner_row.follower_id = ${winnerId}
+                AND winner_row.following_id = target.following_id
+           )
+      `,
+    );
+    await execute(
+      commandDb,
+      sql`
+        UPDATE user_follows AS target
+           SET following_id = ${winnerId}
+         WHERE target.following_id = ${loserId}
+           AND NOT EXISTS (
+             SELECT 1 FROM user_follows AS winner_row
+              WHERE winner_row.following_id = ${winnerId}
+                AND winner_row.follower_id = target.follower_id
+           )
+      `,
+    );
+  }
+
+  await reconcileWinnerFields(commandDb, duplicateSet);
+
+  // Delete losers last: FK cascades clear anything left behind (rows we
+  // intentionally dropped because the winner already had an equivalent one,
+  // plus derived tables like user_climb_percentiles). The votes_count_trigger
+  // (AFTER INSERT/UPDATE/DELETE on votes) keeps vote_counts correct as the
+  // repointed and cascade-deleted vote rows change — it recounts each affected
+  // entity idempotently, so no manual vote_counts maintenance is needed here.
+  await execute(commandDb, sql`DELETE FROM users WHERE id IN (${sqlIdList(loserIds)})`);
+}
+
+export async function applyMerge(
+  commandDb: ExecuteDb,
+  duplicateSet: DuplicateSet,
+): Promise<{ merged: boolean; reason?: string }> {
+  // Lock the set's user rows and re-derive membership inside the transaction so
+  // a concurrent signup/merge can't change the set out from under us.
+  await commandDb.execute(sql`SELECT id FROM users WHERE lower(email) = ${duplicateSet.lowerEmail} FOR UPDATE`);
+  const lockedMembers = await fetchMembersForEmail(commandDb, duplicateSet.lowerEmail);
+
+  if (lockedMembers.length < 2) {
+    return { merged: false, reason: 'no longer a duplicate set' };
+  }
+  if (memberIdKey(lockedMembers) !== memberIdKey(duplicateSet.members)) {
+    return { merged: false, reason: 'set membership changed since the dry-run' };
+  }
+
+  const lockedSet = buildDuplicateSets(lockedMembers)[0];
+  await mergeSet(commandDb, lockedSet);
+  return { merged: true };
+}
+
+async function main(): Promise<void> {
+  const scriptArgs = parseArgs(process.argv.slice(2));
+  if (scriptArgs.help) {
+    printHelp();
+    return;
+  }
+
+  const { db, close } = createScriptDb();
+
+  try {
+    const members = await fetchAllDuplicateMembers(db, scriptArgs.onlyEmail);
+    const allSets = buildDuplicateSets(members);
+    const selectedSets = scriptArgs.limit ? allSets.slice(0, scriptArgs.limit) : allSets;
+
+    printReport(selectedSets, scriptArgs.apply);
+
+    if (!scriptArgs.apply || selectedSets.length === 0) {
+      return;
+    }
+
+    let mergedCount = 0;
+    let skippedCount = 0;
+    for (const duplicateSet of selectedSets) {
+      const result = await db.transaction(async (transaction) => {
+        await transaction.execute(sql`SELECT pg_advisory_xact_lock(hashtext('boardsesh:merge-accounts'))`);
+        return applyMerge(transaction, duplicateSet);
+      });
+
+      if (result.merged) {
+        mergedCount += 1;
+        console.info(
+          `[merge-accounts] merged ${duplicateSet.losers.length} account(s) into ${duplicateSet.winner.email} (#${duplicateSet.winner.id}).`,
+        );
+      } else {
+        skippedCount += 1;
+        console.warn(`[merge-accounts] skipped ${duplicateSet.lowerEmail}: ${result.reason}.`);
+      }
+    }
+
+    const remaining = await executeCount(
+      db,
+      sql`
+        WITH dupes AS (
+          SELECT lower(email) FROM users GROUP BY lower(email) HAVING count(*) > 1
+        )
+        SELECT count(*)::int AS count FROM dupes
+      `,
+    );
+
+    console.info('');
+    console.info(
+      `[merge-accounts] Done. Merged ${mergedCount} set(s), skipped ${skippedCount}. ${remaining} duplicate set(s) remain.`,
+    );
+  } finally {
+    await close();
+  }
+}
+
+const isDirectRun = process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false;
+
+if (isDirectRun) {
+  main().catch((error: unknown) => {
+    console.error('[merge-accounts] failed:', error);
+    process.exit(1);
+  });
+}

--- a/packages/db/scripts/merge-accounts.ts
+++ b/packages/db/scripts/merge-accounts.ts
@@ -159,6 +159,27 @@ const DEDUPE_REPOINTS: Array<{ table: string; column: string; otherCols: string[
   { table: 'board_climb_ratings', column: 'user_id', otherCols: ['board_type', 'climb_uuid', 'angle'] },
 ];
 
+// Columns repointed by the hand-coded specials in mergeLoserIntoWinner / mergeSet
+// (not in the two arrays above). Listed here so the FK-completeness guard knows
+// they're handled.
+const SPECIAL_REPOINT_COLUMNS: Array<{ table: string; column: string }> = [
+  { table: 'boardsesh_ticks', column: 'user_id' },
+  { table: 'user_boards', column: 'owner_id' },
+  { table: 'votes', column: 'user_id' },
+  { table: 'user_follows', column: 'follower_id' },
+  { table: 'user_follows', column: 'following_id' },
+  { table: 'user_credentials', column: 'user_id' },
+  { table: 'user_profiles', column: 'user_id' },
+];
+
+// FKs to users(id) we deliberately do NOT repoint: derived/ephemeral rows the
+// loser owns that should just be cleaned up by the cascade on user delete.
+const CASCADE_ONLY_COLUMNS: Array<{ table: string; column: string }> = [
+  // Nightly-recomputed percentile snapshot keyed PK(user_id) — the loser's stale
+  // row cascades away and the winner's is recomputed from the repointed ticks.
+  { table: 'user_climb_percentiles', column: 'user_id' },
+];
+
 function parsePositiveInteger(rawValue: string | undefined, flagName: string): number {
   const parsedValue = Number(rawValue);
   if (!Number.isInteger(parsedValue) || parsedValue <= 0) {
@@ -646,6 +667,60 @@ export async function applyMerge(
   return { merged: true };
 }
 
+type ForeignKeyRow = { childTable: string; childColumn: string };
+
+/**
+ * Fail loudly before touching any data if a foreign key to users(id) exists that
+ * the script doesn't know how to handle. The repoint lists are hand-maintained;
+ * if a later migration adds a new user_id FK, a silent skip would either block
+ * the loser DELETE (RESTRICT) or cascade-delete / null data the operator
+ * expected to be moved. This diffs the actual FK set in pg_catalog against the
+ * union of the repoint lists, the specials, and the deliberate cascade-only
+ * allow-list — and aborts with the offending columns if anything is unaccounted.
+ */
+export async function assertAllUserFksHandled(commandDb: ExecuteDb): Promise<void> {
+  const handled = new Set<string>(
+    [...PLAIN_REPOINTS, ...DEDUPE_REPOINTS, ...SPECIAL_REPOINT_COLUMNS, ...CASCADE_ONLY_COLUMNS].map(
+      // strip NextAuth's quoted "userId" so it matches pg_catalog's attname
+      ({ table, column }) => `${table}.${column.replace(/"/g, '')}`,
+    ),
+  );
+
+  const actualForeignKeys = await executeRows<ForeignKeyRow>(
+    commandDb,
+    sql`
+      SELECT child.relname AS "childTable", child_attr.attname AS "childColumn"
+        FROM pg_constraint constraint_row
+        JOIN pg_class child ON child.oid = constraint_row.conrelid
+        JOIN pg_class parent ON parent.oid = constraint_row.confrelid
+        JOIN pg_attribute child_attr
+          ON child_attr.attrelid = constraint_row.conrelid
+         AND child_attr.attnum = constraint_row.conkey[1]
+        JOIN pg_attribute parent_attr
+          ON parent_attr.attrelid = constraint_row.confrelid
+         AND parent_attr.attnum = constraint_row.confkey[1]
+       WHERE constraint_row.contype = 'f'
+         AND parent.relname = 'users'
+         AND parent.relnamespace = 'public'::regnamespace
+         AND parent_attr.attname = 'id'
+         AND array_length(constraint_row.conkey, 1) = 1
+    `,
+  );
+
+  const unhandled = actualForeignKeys
+    .map((foreignKey) => `${foreignKey.childTable}.${foreignKey.childColumn}`)
+    .filter((key) => !handled.has(key))
+    .sort();
+
+  if (unhandled.length > 0) {
+    throw new Error(
+      `merge-accounts is out of date: ${unhandled.length} foreign key(s) to users(id) are not handled by the ` +
+        `repoint lists — ${unhandled.join(', ')}. Add each to PLAIN_REPOINTS, DEDUPE_REPOINTS, the specials, or ` +
+        `CASCADE_ONLY_COLUMNS before running a merge.`,
+    );
+  }
+}
+
 async function main(): Promise<void> {
   const scriptArgs = parseArgs(process.argv.slice(2));
   if (scriptArgs.help) {
@@ -656,6 +731,9 @@ async function main(): Promise<void> {
   const { db, close } = createScriptDb();
 
   try {
+    // Abort before any writes if the schema has grown a user FK we don't handle.
+    await assertAllUserFksHandled(db);
+
     const members = await fetchAllDuplicateMembers(db, scriptArgs.onlyEmail);
     const allSets = buildDuplicateSets(members);
     const selectedSets = scriptArgs.limit ? allSets.slice(0, scriptArgs.limit) : allSets;

--- a/packages/db/scripts/merge-accounts.ts
+++ b/packages/db/scripts/merge-accounts.ts
@@ -122,6 +122,12 @@ const PLAIN_REPOINTS: Array<{ table: string; column: string }> = [
   // Admin who reviewed a gym ownership claim (SET NULL, no unique) — repoint so
   // the reviewer attribution follows the merged account.
   { table: 'gym_claims', column: 'reviewed_by' },
+  // Staff who resolved a feedback item / performed a gym merge (both SET NULL,
+  // no unique). Same rationale as the reviewers above: the two rows are the same
+  // human, so the audit trail should name the surviving account rather than go
+  // blank when the loser is deleted.
+  { table: 'app_feedback', column: 'resolved_by' },
+  { table: 'gym_merge_audit', column: 'performed_by' },
 ];
 
 /**
@@ -701,6 +707,12 @@ type ForeignKeyRow = { childTable: string; childColumn: string };
  * expected to be moved. This diffs the actual FK set in pg_catalog against the
  * union of the repoint lists, the specials, and the deliberate cascade-only
  * allow-list — and aborts with the offending columns if anything is unaccounted.
+ *
+ * Known scope: single-column FKs only (`array_length(conkey, 1) = 1`). Nothing
+ * references users(id) as part of a composite key today, and every repoint in
+ * the lists is single-column by construction, so a composite FK would need its
+ * own repoint strategy regardless — widen this query and the repoint lists
+ * together if one ever lands.
  */
 export async function assertAllUserFksHandled(commandDb: ExecuteDb): Promise<void> {
   const handled = new Set<string>(

--- a/packages/db/scripts/merge-accounts.ts
+++ b/packages/db/scripts/merge-accounts.ts
@@ -676,6 +676,18 @@ async function mergeSet(commandDb: ExecuteDb, duplicateSet: DuplicateSet): Promi
   await execute(commandDb, sql`DELETE FROM users WHERE id IN (${sqlIdList(loserIds)})`);
 }
 
+/**
+ * Collapses one duplicate set onto its winner.
+ *
+ * MUST be called inside a transaction. The `FOR UPDATE` below is what stops a
+ * concurrent signup or a second merge run from changing the set mid-flight, and
+ * a row lock is released the moment its transaction ends — so outside one, the
+ * lock is dropped immediately and the membership re-check becomes advisory
+ * only. `ExecuteDb` is structural and matches both a transaction handle and a
+ * plain connection, so the type can't enforce this; `main` supplies a real
+ * `db.transaction(...)` handle, and the integration test drives it inside a
+ * rolled-back transaction.
+ */
 export async function applyMerge(
   commandDb: ExecuteDb,
   duplicateSet: DuplicateSet,

--- a/packages/db/scripts/merge-accounts.ts
+++ b/packages/db/scripts/merge-accounts.ts
@@ -29,6 +29,7 @@ import { sql, type SQLWrapper, type SQL } from 'drizzle-orm';
 import { pathToFileURL } from 'node:url';
 import { createScriptDb } from './db-connection.js';
 import { executeRows } from '../src/client/index.js';
+import { normalizeEmail } from '../src/utils/index.js';
 
 const APPLY_FLAG = '--apply';
 const LIMIT_FLAG = '--limit';
@@ -240,7 +241,7 @@ export function parseArgs(args: string[]): ScriptArgs {
       continue;
     }
     if (currentArg === ONLY_EMAIL_FLAG) {
-      parsedArgs.onlyEmail = readRequiredOptionValue(args, index, ONLY_EMAIL_FLAG).trim().toLowerCase();
+      parsedArgs.onlyEmail = normalizeEmail(readRequiredOptionValue(args, index, ONLY_EMAIL_FLAG));
       index += 1;
       continue;
     }
@@ -302,7 +303,7 @@ function compareForWinner(first: Member, second: Member): number {
 export function buildDuplicateSets(members: Member[]): DuplicateSet[] {
   const byEmail = new Map<string, Member[]>();
   for (const member of members) {
-    const key = member.email.trim().toLowerCase();
+    const key = normalizeEmail(member.email);
     const bucket = byEmail.get(key);
     if (bucket) {
       bucket.push(member);

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -4,3 +4,6 @@ export * from './relations/index';
 
 // Re-export client
 export * from './client/index';
+
+// Re-export leaf utilities (pure, dependency-free helpers)
+export * from './utils/index';

--- a/packages/db/src/utils/__tests__/normalize-email.test.ts
+++ b/packages/db/src/utils/__tests__/normalize-email.test.ts
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeEmail } from '../normalize-email.js';
+
+test('lower-cases the address', () => {
+  assert.equal(normalizeEmail('Foo@X.com'), 'foo@x.com');
+  assert.equal(normalizeEmail('PMBMOSK@GMAIL.COM'), 'pmbmosk@gmail.com');
+});
+
+test('trims surrounding whitespace', () => {
+  assert.equal(normalizeEmail('  foo@x.com  '), 'foo@x.com');
+  assert.equal(normalizeEmail('\tFoo@X.com\n'), 'foo@x.com');
+});
+
+test('is idempotent', () => {
+  const once = normalizeEmail('  Foo@X.com ');
+  assert.equal(normalizeEmail(once), once);
+});
+
+test('two case variants normalise to the same value', () => {
+  assert.equal(normalizeEmail('Pmbmosk@gmail.com'), normalizeEmail('pmbmosk@gmail.com'));
+});
+
+test('throws on a non-string input', () => {
+  // @ts-expect-error exercising the runtime guard
+  assert.throws(() => normalizeEmail(undefined), TypeError);
+  // @ts-expect-error exercising the runtime guard
+  assert.throws(() => normalizeEmail(null), TypeError);
+});

--- a/packages/db/src/utils/index.ts
+++ b/packages/db/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './normalize-email';

--- a/packages/db/src/utils/normalize-email.ts
+++ b/packages/db/src/utils/normalize-email.ts
@@ -1,0 +1,21 @@
+/**
+ * Canonicalises an email for storage, lookup, and identifier derivation.
+ *
+ * Trims surrounding whitespace and lower-cases the address so that
+ * `Foo@x.com` and `foo@x.com` resolve to the same account. This is the single
+ * source of truth for email canonicalisation — every auth write path (web +
+ * backend native-auth) and the account-merge/backfill route through it so the
+ * stored value, the case-insensitive `lower(email)` unique index, and any
+ * email-derived token identifier (verification tokens, `password-reset:<email>`)
+ * always agree.
+ *
+ * Throws on a non-string input rather than silently coercing: callers validate
+ * the email before reaching a write path, and a wrong-typed value matching the
+ * empty string could collide accounts.
+ */
+export function normalizeEmail(email: string): string {
+  if (typeof email !== 'string') {
+    throw new TypeError(`normalizeEmail expected a string, received ${typeof email}`);
+  }
+  return email.trim().toLowerCase();
+}

--- a/packages/web/app/api/auth/forgot-password/route.ts
+++ b/packages/web/app/api/auth/forgot-password/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
+import { normalizeEmail } from '@boardsesh/db/utils';
 import { z } from 'zod';
 import { getDb } from '@/app/lib/db/db';
 import * as schema from '@/app/lib/db/schema';
@@ -46,13 +47,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: validationResult.error.issues[0].message }, { status: 400 });
     }
 
-    const { email } = validationResult.data;
+    const email = normalizeEmail(validationResult.data.email);
     const db = getDb();
 
     const user = await db
       .select({ id: schema.users.id })
       .from(schema.users)
-      .where(eq(schema.users.email, email))
+      .where(sql`lower(${schema.users.email}) = ${email}`)
       .limit(1);
 
     if (user.length === 0) {

--- a/packages/web/app/api/auth/register/route.ts
+++ b/packages/web/app/api/auth/register/route.ts
@@ -2,7 +2,8 @@ import { type NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/app/lib/db/db';
 import * as schema from '@/app/lib/db/schema';
 import { hash } from 'bcryptjs';
-import { eq } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
+import { normalizeEmail } from '@boardsesh/db/utils';
 import { z } from 'zod';
 import { sendVerificationEmail } from '@boardsesh/email';
 import { checkRateLimit, getClientIp } from '@/app/lib/auth/rate-limiter';
@@ -44,11 +45,20 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: validationResult.error.issues[0].message }, { status: 400 });
     }
 
-    const { email, password, name } = validationResult.data;
+    const { password, name } = validationResult.data;
+    // Canonicalise the email so `Foo@x.com` and `foo@x.com` resolve to one
+    // account. Stored as the normalized form; the existence check below is
+    // case-insensitive so a different-cased re-signup is caught even before the
+    // backfill lower-cases legacy rows.
+    const email = normalizeEmail(validationResult.data.email);
     const db = getDb();
 
-    // Check if user already exists
-    const existingUser = await db.select().from(schema.users).where(eq(schema.users.email, email)).limit(1);
+    // Check if user already exists (case-insensitive — legacy rows may still be mixed-case)
+    const existingUser = await db
+      .select()
+      .from(schema.users)
+      .where(sql`lower(${schema.users.email}) = ${email}`)
+      .limit(1);
 
     if (existingUser.length > 0) {
       // An account with this email already exists

--- a/packages/web/app/api/auth/resend-verification/route.ts
+++ b/packages/web/app/api/auth/resend-verification/route.ts
@@ -1,7 +1,8 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/app/lib/db/db';
 import * as schema from '@/app/lib/db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
+import { normalizeEmail } from '@boardsesh/db/utils';
 import { z } from 'zod';
 import { sendVerificationEmail } from '@boardsesh/email';
 import { checkRateLimit, getClientIp } from '@/app/lib/auth/rate-limiter';
@@ -55,11 +56,15 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: validationResult.error.issues[0].message }, { status: 400 });
     }
 
-    const { email } = validationResult.data;
+    const email = normalizeEmail(validationResult.data.email);
     const db = getDb();
 
-    // Check if user exists and is unverified
-    const user = await db.select().from(schema.users).where(eq(schema.users.email, email)).limit(1);
+    // Check if user exists and is unverified (case-insensitive — legacy rows may be mixed-case)
+    const user = await db
+      .select()
+      .from(schema.users)
+      .where(sql`lower(${schema.users.email}) = ${email}`)
+      .limit(1);
 
     // Don't reveal user status - return same message for all cases
     // Use consistent delay for all paths to prevent timing attacks

--- a/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
@@ -11,6 +11,7 @@ vi.mock('@/app/lib/auth/rate-limiter', () => ({
 }));
 
 vi.mock('@/app/lib/auth/password-reset', () => ({
+  PASSWORD_RESET_IDENTIFIER_PREFIX: 'password-reset:',
   getPasswordResetIdentifier: (email: string) => `password-reset:${email}`,
   hashResetToken: (token: string) => `sha256:${token}`,
   consistentDelay: async () => {},

--- a/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/reset-password/__tests__/route.test.ts
@@ -10,6 +10,14 @@ vi.mock('@/app/lib/auth/rate-limiter', () => ({
   getClientIp: (...args: unknown[]) => mockGetClientIp(...args),
 }));
 
+// NOTE: `getPasswordResetIdentifier` is stubbed as the bare prefix plus the
+// email it is handed, WITHOUT normalizing. That is deliberate — it makes the
+// identifier a pure function of its argument, so these tests can observe which
+// email string the route passes in (normalized vs. raw-cased, for the
+// pre-deploy token fallback) instead of folding both into one value and
+// proving nothing. The trade-off: a regression in the real helper that dropped
+// its own normalizeEmail call wouldn't fail here. That behaviour is covered
+// directly by the normalizeEmail unit tests in @boardsesh/db.
 vi.mock('@/app/lib/auth/password-reset', () => ({
   PASSWORD_RESET_IDENTIFIER_PREFIX: 'password-reset:',
   getPasswordResetIdentifier: (email: string) => `password-reset:${email}`,

--- a/packages/web/app/api/auth/reset-password/route.ts
+++ b/packages/web/app/api/auth/reset-password/route.ts
@@ -1,12 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { and, eq, gt, isNull, sql } from 'drizzle-orm';
+import { and, eq, gt, isNull, sql, inArray } from 'drizzle-orm';
 import { normalizeEmail } from '@boardsesh/db/utils';
 import { z } from 'zod';
 import bcrypt from 'bcryptjs';
 import { getDb } from '@/app/lib/db/db';
 import * as schema from '@/app/lib/db/schema';
 import { checkRateLimit, getClientIp } from '@/app/lib/auth/rate-limiter';
-import { getPasswordResetIdentifier, hashResetToken, consistentDelay } from '@/app/lib/auth/password-reset';
+import {
+  getPasswordResetIdentifier,
+  hashResetToken,
+  consistentDelay,
+  PASSWORD_RESET_IDENTIFIER_PREFIX,
+} from '@/app/lib/auth/password-reset';
 
 const resetPasswordSchema = z
   .object({
@@ -59,6 +64,10 @@ export async function POST(request: NextRequest) {
     const email = normalizeEmail(validationResult.data.email);
     const db = getDb();
     const identifier = getPasswordResetIdentifier(email);
+    // Also match the raw-cased identifier so reset links minted before the
+    // normalization deploy (identifier `password-reset:<original-case>`) still work.
+    const legacyIdentifier = `${PASSWORD_RESET_IDENTIFIER_PREFIX}${validationResult.data.email}`;
+    const candidateIdentifiers = legacyIdentifier === identifier ? [identifier] : [identifier, legacyIdentifier];
     const tokenHash = hashResetToken(token);
 
     const now = new Date();
@@ -67,7 +76,7 @@ export async function POST(request: NextRequest) {
       .from(schema.verificationTokens)
       .where(
         and(
-          eq(schema.verificationTokens.identifier, identifier),
+          inArray(schema.verificationTokens.identifier, candidateIdentifiers),
           eq(schema.verificationTokens.token, tokenHash),
           gt(schema.verificationTokens.expires, now),
         ),
@@ -127,7 +136,9 @@ export async function POST(request: NextRequest) {
         .set({ emailVerified: new Date(), updatedAt: new Date() })
         .where(and(eq(schema.users.id, user[0].id), isNull(schema.users.emailVerified)));
 
-      await tx.delete(schema.verificationTokens).where(eq(schema.verificationTokens.identifier, identifier));
+      await tx
+        .delete(schema.verificationTokens)
+        .where(inArray(schema.verificationTokens.identifier, candidateIdentifiers));
     });
 
     await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);

--- a/packages/web/app/api/auth/reset-password/route.ts
+++ b/packages/web/app/api/auth/reset-password/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { and, eq, gt, isNull } from 'drizzle-orm';
+import { and, eq, gt, isNull, sql } from 'drizzle-orm';
+import { normalizeEmail } from '@boardsesh/db/utils';
 import { z } from 'zod';
 import bcrypt from 'bcryptjs';
 import { getDb } from '@/app/lib/db/db';
@@ -54,7 +55,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: validationResult.error.issues[0].message }, { status: 400 });
     }
 
-    const { email, token, password } = validationResult.data;
+    const { token, password } = validationResult.data;
+    const email = normalizeEmail(validationResult.data.email);
     const db = getDb();
     const identifier = getPasswordResetIdentifier(email);
     const tokenHash = hashResetToken(token);
@@ -86,7 +88,7 @@ export async function POST(request: NextRequest) {
     const user = await db
       .select({ id: schema.users.id })
       .from(schema.users)
-      .where(eq(schema.users.email, email))
+      .where(sql`lower(${schema.users.email}) = ${email}`)
       .limit(1);
     if (user.length === 0) {
       await consistentDelay(startTime, MIN_RESPONSE_TIME_MS);

--- a/packages/web/app/api/auth/verify-email/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/verify-email/__tests__/route.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('server-only', () => ({}));
+
+const mockCheckRateLimit = vi.fn();
+const mockGetClientIp = vi.fn();
+vi.mock('@/app/lib/auth/rate-limiter', () => ({
+  checkRateLimit: (...args: unknown[]) => mockCheckRateLimit(...args),
+  getClientIp: (...args: unknown[]) => mockGetClientIp(...args),
+}));
+
+// Record the predicates the route builds so assertions read what the code
+// actually emitted rather than a predicate rebuilt in the test.
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => ({ _type: 'and', args })),
+  eq: vi.fn((col: unknown, val: unknown) => ({ _type: 'eq', col, val })),
+  inArray: vi.fn((col: unknown, values: unknown[]) => ({ _type: 'inArray', col, values })),
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ _type: 'sql', strings, values })),
+}));
+
+type RecordedPredicate = { _type: string; values?: unknown[] };
+type RecordedAnd = { _type: 'and'; args: RecordedPredicate[] };
+
+const mockSelectLimit = vi.fn();
+const mockSelectWhere = vi.fn((_predicate: RecordedAnd) => ({ limit: mockSelectLimit }));
+const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
+const mockTxUpdateWhere = vi.fn().mockResolvedValue(undefined);
+const mockTxUpdateSet = vi.fn(() => ({ where: mockTxUpdateWhere }));
+const mockTransaction = vi.fn(async (fn: (tx: unknown) => Promise<void>) => {
+  await fn({
+    update: () => ({ set: mockTxUpdateSet }),
+    delete: () => ({ where: mockDeleteWhere }),
+  });
+});
+
+vi.mock('@/app/lib/db/db', () => ({
+  getDb: () => ({
+    select: () => ({ from: () => ({ where: mockSelectWhere }) }),
+    delete: () => ({ where: mockDeleteWhere }),
+    transaction: (fn: (tx: unknown) => Promise<void>) => mockTransaction(fn),
+  }),
+}));
+
+vi.mock('@/app/lib/db/schema', () => ({
+  users: { id: 'users.id', email: 'users.email' },
+  verificationTokens: { identifier: 'verification_tokens.identifier', token: 'verification_tokens.token' },
+}));
+
+import { GET } from '../route';
+
+function createRequest(params: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost/api/auth/verify-email');
+  for (const [key, value] of Object.entries(params)) url.searchParams.set(key, value);
+  return new NextRequest(url, { method: 'GET' });
+}
+
+/** The identifier list the route passed to its first `inArray(...)` predicate. */
+function recordedIdentifierCandidates(): unknown[] {
+  const andPredicate = mockSelectWhere.mock.calls[0][0];
+  const inArrayPredicate = andPredicate.args.find((arg) => arg._type === 'inArray');
+  return inArrayPredicate?.values ?? [];
+}
+
+const FUTURE = new Date(Date.now() + 60 * 60 * 1000);
+
+describe('GET /api/auth/verify-email', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetClientIp.mockReturnValue('127.0.0.1');
+    mockCheckRateLimit.mockReturnValue({ limited: false, retryAfterSeconds: 0 });
+    mockSelectWhere.mockReturnValue({ limit: mockSelectLimit });
+    // 1st select → the verification token; 2nd → the user row.
+    mockSelectLimit
+      .mockResolvedValueOnce([{ identifier: 'foo@example.com', token: 'tok-1', expires: FUTURE }])
+      .mockResolvedValueOnce([{ id: 'user-1', email: 'Foo@Example.com' }]);
+  });
+
+  it('verifies a link whose email is cased differently from the stored row', async () => {
+    const response = await GET(createRequest({ token: 'tok-1', email: 'FOO@Example.com' }));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toContain('/auth/login?verified=true');
+    expect(mockTxUpdateSet).toHaveBeenCalledWith({ emailVerified: expect.any(Date) });
+  });
+
+  it('also tries the raw-cased identifier so pre-normalization links still resolve', async () => {
+    await GET(createRequest({ token: 'tok-1', email: 'Foo@Example.com' }));
+
+    // Both the canonical identifier and the original casing the old code stored.
+    expect(recordedIdentifierCandidates()).toEqual(['foo@example.com', 'Foo@Example.com']);
+  });
+
+  it('does not duplicate the identifier when the link email is already canonical', async () => {
+    await GET(createRequest({ token: 'tok-1', email: 'foo@example.com' }));
+
+    expect(recordedIdentifierCandidates()).toEqual(['foo@example.com']);
+  });
+
+  it('marks only the account that owns the token, by id', async () => {
+    const { eq } = await import('drizzle-orm');
+    await GET(createRequest({ token: 'tok-1', email: 'FOO@Example.com' }));
+
+    // Scoped to users.id — NOT to every row sharing the lower-cased email.
+    expect(eq).toHaveBeenCalledWith('users.id', 'user-1');
+    expect(mockTxUpdateWhere).toHaveBeenCalledWith({ _type: 'eq', col: 'users.id', val: 'user-1' });
+  });
+
+  it('redirects to InvalidToken when no candidate identifier matches', async () => {
+    mockSelectLimit.mockReset();
+    mockSelectLimit.mockResolvedValue([]);
+
+    const response = await GET(createRequest({ token: 'nope', email: 'foo@example.com' }));
+
+    expect(response.headers.get('location')).toContain('error=InvalidToken');
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+
+  it('redirects to TokenExpired and clears the token when it has lapsed', async () => {
+    mockSelectLimit.mockReset();
+    mockSelectLimit.mockResolvedValueOnce([
+      { identifier: 'foo@example.com', token: 'tok-1', expires: new Date(Date.now() - 1000) },
+    ]);
+
+    const response = await GET(createRequest({ token: 'tok-1', email: 'foo@example.com' }));
+
+    expect(response.headers.get('location')).toContain('error=TokenExpired');
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+    expect(mockTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/api/auth/verify-email/route.ts
+++ b/packages/web/app/api/auth/verify-email/route.ts
@@ -1,7 +1,8 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/app/lib/db/db';
 import * as schema from '@/app/lib/db/schema';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, sql } from 'drizzle-orm';
+import { normalizeEmail } from '@boardsesh/db/utils';
 import { checkRateLimit, getClientIp } from '@/app/lib/auth/rate-limiter';
 
 export async function GET(request: NextRequest) {
@@ -22,13 +23,17 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(new URL('/auth/verify-request?error=InvalidToken', request.url));
   }
 
+  // Canonicalise so the identifier match and user lookup align with the
+  // normalized values written at register/resend time.
+  const normalizedEmail = normalizeEmail(email);
+
   const db = getDb();
 
   // Find the verification token
   const verificationToken = await db
     .select()
     .from(schema.verificationTokens)
-    .where(and(eq(schema.verificationTokens.identifier, email), eq(schema.verificationTokens.token, token)))
+    .where(and(eq(schema.verificationTokens.identifier, normalizedEmail), eq(schema.verificationTokens.token, token)))
     .limit(1);
 
   if (verificationToken.length === 0) {
@@ -42,30 +47,43 @@ export async function GET(request: NextRequest) {
     // Delete expired token
     await db
       .delete(schema.verificationTokens)
-      .where(and(eq(schema.verificationTokens.identifier, email), eq(schema.verificationTokens.token, token)));
+      .where(
+        and(eq(schema.verificationTokens.identifier, normalizedEmail), eq(schema.verificationTokens.token, token)),
+      );
 
     return NextResponse.redirect(new URL('/auth/verify-request?error=TokenExpired', request.url));
   }
 
-  // Verify user exists before updating
-  const user = await db.select().from(schema.users).where(eq(schema.users.email, email)).limit(1);
+  // Verify user exists before updating (case-insensitive — legacy rows may be mixed-case)
+  const user = await db
+    .select()
+    .from(schema.users)
+    .where(sql`lower(${schema.users.email}) = ${normalizedEmail}`)
+    .limit(1);
 
   if (user.length === 0) {
     // Token exists but user doesn't - cleanup the orphan token
     await db
       .delete(schema.verificationTokens)
-      .where(and(eq(schema.verificationTokens.identifier, email), eq(schema.verificationTokens.token, token)));
+      .where(
+        and(eq(schema.verificationTokens.identifier, normalizedEmail), eq(schema.verificationTokens.token, token)),
+      );
 
     return NextResponse.redirect(new URL('/auth/verify-request?error=InvalidToken', request.url));
   }
 
   // Update user and delete token atomically
   await db.transaction(async (tx) => {
-    await tx.update(schema.users).set({ emailVerified: new Date() }).where(eq(schema.users.email, email));
+    await tx
+      .update(schema.users)
+      .set({ emailVerified: new Date() })
+      .where(sql`lower(${schema.users.email}) = ${normalizedEmail}`);
 
     await tx
       .delete(schema.verificationTokens)
-      .where(and(eq(schema.verificationTokens.identifier, email), eq(schema.verificationTokens.token, token)));
+      .where(
+        and(eq(schema.verificationTokens.identifier, normalizedEmail), eq(schema.verificationTokens.token, token)),
+      );
   });
 
   // Redirect to login with success message

--- a/packages/web/app/api/auth/verify-email/route.ts
+++ b/packages/web/app/api/auth/verify-email/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/app/lib/db/db';
 import * as schema from '@/app/lib/db/schema';
-import { eq, and, sql } from 'drizzle-orm';
+import { eq, and, sql, inArray } from 'drizzle-orm';
 import { normalizeEmail } from '@boardsesh/db/utils';
 import { checkRateLimit, getClientIp } from '@/app/lib/auth/rate-limiter';
 
@@ -24,8 +24,11 @@ export async function GET(request: NextRequest) {
   }
 
   // Canonicalise so the identifier match and user lookup align with the
-  // normalized values written at register/resend time.
+  // normalized values written at register/resend time. Also match the raw
+  // link email so verification links minted before the normalization deploy
+  // (identifier stored as the original-cased email) still resolve.
   const normalizedEmail = normalizeEmail(email);
+  const candidateIdentifiers = normalizedEmail === email ? [normalizedEmail] : [normalizedEmail, email];
 
   const db = getDb();
 
@@ -33,7 +36,12 @@ export async function GET(request: NextRequest) {
   const verificationToken = await db
     .select()
     .from(schema.verificationTokens)
-    .where(and(eq(schema.verificationTokens.identifier, normalizedEmail), eq(schema.verificationTokens.token, token)))
+    .where(
+      and(
+        inArray(schema.verificationTokens.identifier, candidateIdentifiers),
+        eq(schema.verificationTokens.token, token),
+      ),
+    )
     .limit(1);
 
   if (verificationToken.length === 0) {
@@ -48,7 +56,10 @@ export async function GET(request: NextRequest) {
     await db
       .delete(schema.verificationTokens)
       .where(
-        and(eq(schema.verificationTokens.identifier, normalizedEmail), eq(schema.verificationTokens.token, token)),
+        and(
+          inArray(schema.verificationTokens.identifier, candidateIdentifiers),
+          eq(schema.verificationTokens.token, token),
+        ),
       );
 
     return NextResponse.redirect(new URL('/auth/verify-request?error=TokenExpired', request.url));
@@ -66,7 +77,10 @@ export async function GET(request: NextRequest) {
     await db
       .delete(schema.verificationTokens)
       .where(
-        and(eq(schema.verificationTokens.identifier, normalizedEmail), eq(schema.verificationTokens.token, token)),
+        and(
+          inArray(schema.verificationTokens.identifier, candidateIdentifiers),
+          eq(schema.verificationTokens.token, token),
+        ),
       );
 
     return NextResponse.redirect(new URL('/auth/verify-request?error=InvalidToken', request.url));
@@ -74,15 +88,15 @@ export async function GET(request: NextRequest) {
 
   // Update user and delete token atomically
   await db.transaction(async (tx) => {
-    await tx
-      .update(schema.users)
-      .set({ emailVerified: new Date() })
-      .where(sql`lower(${schema.users.email}) = ${normalizedEmail}`);
+    await tx.update(schema.users).set({ emailVerified: new Date() }).where(eq(schema.users.id, user[0].id));
 
     await tx
       .delete(schema.verificationTokens)
       .where(
-        and(eq(schema.verificationTokens.identifier, normalizedEmail), eq(schema.verificationTokens.token, token)),
+        and(
+          inArray(schema.verificationTokens.identifier, candidateIdentifiers),
+          eq(schema.verificationTokens.token, token),
+        ),
       );
   });
 

--- a/packages/web/app/lib/auth/__tests__/auth-options.test.ts
+++ b/packages/web/app/lib/auth/__tests__/auth-options.test.ts
@@ -10,6 +10,7 @@ vi.mock('drizzle-orm', () => ({
   and: vi.fn((...args: unknown[]) => ({ _type: 'and', args })),
   eq: vi.fn((col: unknown, val: unknown) => ({ _type: 'eq', col, val })),
   isNull: vi.fn((col: unknown) => ({ _type: 'isNull', col })),
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ _type: 'sql', strings, values })),
 }));
 
 // Mock DrizzleAdapter — we only care about the signIn callback, not adapter internals
@@ -551,13 +552,28 @@ function getNativeOAuthProvider(): CredentialProviderLike {
 }
 
 describe('CredentialsProvider.authorize — email/password', () => {
+  // The email lookup is now case-insensitive and returns ALL matching rows (a
+  // legacy duplicate-by-case set can briefly have more than one) — so the users
+  // query is `select().from().where(sql)` awaited directly (no .limit), and the
+  // per-candidate credential lookup is `select().from().where(eq).limit(1)`.
+  // A single `where` return that is both thenable (→ candidates) and has
+  // `.limit` (→ credentials) serves both query shapes.
+  function setAuthorizeRows(candidates: unknown[], credentialsByUserId: Record<string, unknown[]>): void {
+    mockDbWhere.mockImplementation((condition: { _type?: string; col?: unknown; val?: unknown }) => ({
+      then: (resolve: (rows: unknown[]) => unknown) => resolve(candidates),
+      limit: () => {
+        // credential lookup: eq(userCredentials.userId, user.id)
+        const userId = condition?._type === 'eq' ? String(condition.val) : '';
+        return Promise.resolve(credentialsByUserId[userId] ?? []);
+      },
+    }));
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
-
     mockDbSelect.mockReturnValue({ from: mockDbFrom });
     mockDbFrom.mockReturnValue({ where: mockDbWhere });
-    mockDbWhere.mockReturnValue({ limit: mockDbLimit });
-    mockDbLimit.mockResolvedValue([]);
+    setAuthorizeRows([], {});
   });
 
   it('returns null when credentials are missing', async () => {
@@ -579,8 +595,7 @@ describe('CredentialsProvider.authorize — email/password', () => {
   });
 
   it('returns null when user is not found', async () => {
-    // First select (users lookup) → empty
-    mockDbLimit.mockResolvedValue([]);
+    setAuthorizeRows([], {});
 
     const provider = getEmailCredentialsProvider();
     const result = await provider.authorize?.({ email: 'notfound@example.com', password: 'pass' });
@@ -588,10 +603,7 @@ describe('CredentialsProvider.authorize — email/password', () => {
   });
 
   it('returns null when user has no password (OAuth-only account)', async () => {
-    // First select (users) → user found; second select (userCredentials) → empty
-    mockDbLimit
-      .mockResolvedValueOnce([{ id: 'user-1', email: 'user@example.com', name: 'Test', image: null }])
-      .mockResolvedValueOnce([]);
+    setAuthorizeRows([{ id: 'user-1', email: 'user@example.com', name: 'Test', image: null }], {});
 
     const provider = getEmailCredentialsProvider();
     const result = await provider.authorize?.({
@@ -602,9 +614,9 @@ describe('CredentialsProvider.authorize — email/password', () => {
   });
 
   it('returns null when password is incorrect', async () => {
-    mockDbLimit
-      .mockResolvedValueOnce([{ id: 'user-1', email: 'user@example.com', name: 'Test', image: null }])
-      .mockResolvedValueOnce([{ userId: 'user-1', passwordHash: '$2a$12$hashed' }]);
+    setAuthorizeRows([{ id: 'user-1', email: 'user@example.com', name: 'Test', image: null }], {
+      'user-1': [{ userId: 'user-1', passwordHash: '$2a$12$hashed' }],
+    });
     mockBcryptCompare.mockResolvedValue(false);
 
     const provider = getEmailCredentialsProvider();
@@ -614,9 +626,7 @@ describe('CredentialsProvider.authorize — email/password', () => {
 
   it('returns user object when credentials are valid', async () => {
     const user = { id: 'user-1', email: 'user@example.com', name: 'Test User', image: null };
-    mockDbLimit
-      .mockResolvedValueOnce([user])
-      .mockResolvedValueOnce([{ userId: 'user-1', passwordHash: '$2a$12$hashed' }]);
+    setAuthorizeRows([user], { 'user-1': [{ userId: 'user-1', passwordHash: '$2a$12$hashed' }] });
     mockBcryptCompare.mockResolvedValue(true);
 
     const provider = getEmailCredentialsProvider();
@@ -632,6 +642,21 @@ describe('CredentialsProvider.authorize — email/password', () => {
       image: null,
     });
     expect(mockBcryptCompare).toHaveBeenCalledWith('correctpass', '$2a$12$hashed');
+  });
+
+  it('verifies the password against each candidate when a duplicate-by-case set still exists', async () => {
+    // Two rows share the email; only the second has the matching password.
+    const oauthOnly = { id: 'user-oauth', email: 'User@example.com', name: 'OAuth', image: null };
+    const passwordUser = { id: 'user-pw', email: 'user@example.com', name: 'Password', image: null };
+    setAuthorizeRows([oauthOnly, passwordUser], {
+      'user-pw': [{ userId: 'user-pw', passwordHash: '$2a$12$hashed' }],
+    });
+    mockBcryptCompare.mockResolvedValue(true);
+
+    const provider = getEmailCredentialsProvider();
+    const result = await provider.authorize?.({ email: 'user@example.com', password: 'correctpass' });
+
+    expect(result).toEqual({ id: 'user-pw', email: 'user@example.com', name: 'Password', image: null });
   });
 });
 

--- a/packages/web/app/lib/auth/__tests__/auth-options.test.ts
+++ b/packages/web/app/lib/auth/__tests__/auth-options.test.ts
@@ -662,6 +662,25 @@ describe('CredentialsProvider.authorize — email/password', () => {
 
     expect(result).toEqual({ id: 'user-pw', email: 'user@example.com', name: 'Password', image: null });
   });
+
+  it('returns null once every candidate in a duplicate set rejects the password', async () => {
+    // Both rows have a password, neither matches — the loop must exhaust and
+    // fall through to null rather than returning the last candidate anyway.
+    const firstTwin = { id: 'user-a', email: 'User@example.com', name: 'A', image: null };
+    const secondTwin = { id: 'user-b', email: 'user@example.com', name: 'B', image: null };
+    setAuthorizeRows([firstTwin, secondTwin], {
+      'user-a': [{ userId: 'user-a', passwordHash: '$2a$12$hash-a' }],
+      'user-b': [{ userId: 'user-b', passwordHash: '$2a$12$hash-b' }],
+    });
+    mockBcryptCompare.mockResolvedValue(false);
+
+    const provider = getEmailCredentialsProvider();
+    const result = await provider.authorize?.({ email: 'user@example.com', password: 'wrongpass' });
+
+    expect(result).toBeNull();
+    // Every candidate was actually checked, not short-circuited after the first.
+    expect(mockBcryptCompare).toHaveBeenCalledTimes(2);
+  });
 });
 
 // =============================================================================

--- a/packages/web/app/lib/auth/__tests__/auth-options.test.ts
+++ b/packages/web/app/lib/auth/__tests__/auth-options.test.ts
@@ -13,9 +13,12 @@ vi.mock('drizzle-orm', () => ({
   sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ _type: 'sql', strings, values })),
 }));
 
-// Mock DrizzleAdapter — we only care about the signIn callback, not adapter internals
+// Mock DrizzleAdapter. Most tests only care about the signIn callback, but the
+// case-insensitive wrapper delegates user creation to the base adapter, so
+// expose a spy for `createUser` (hoisted, because vi.mock factories are).
+const { mockBaseCreateUser } = vi.hoisted(() => ({ mockBaseCreateUser: vi.fn() }));
 vi.mock('@auth/drizzle-adapter', () => ({
-  DrizzleAdapter: vi.fn(() => ({})),
+  DrizzleAdapter: vi.fn(() => ({ createUser: mockBaseCreateUser })),
 }));
 
 // Mock OAuth providers — only present in the array; we test callbacks, not provider config
@@ -67,6 +70,7 @@ vi.mock('@/app/lib/db/schema', () => ({
     id: 'users.id',
     email: 'users.email',
     emailVerified: 'users.emailVerified',
+    createdAt: 'users.createdAt',
   },
   accounts: {},
   sessions: {},
@@ -874,5 +878,76 @@ describe('authOptions.cookies — shared .boardsesh.com domain', () => {
     expect(cookies?.sessionToken?.options.domain).toBeUndefined();
     expect(cookies?.sessionToken?.options.secure).toBe(false);
     expect(cookies?.callbackUrl?.options.domain).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adapter wrapper: case-insensitive OAuth account lookup / creation
+// ---------------------------------------------------------------------------
+
+describe('authOptions.adapter (case-insensitive wrapper)', () => {
+  const mockDbOrderBy = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // select().from().where().orderBy().limit()
+    mockDbSelect.mockReturnValue({ from: mockDbFrom });
+    mockDbFrom.mockReturnValue({ where: mockDbWhere });
+    mockDbWhere.mockReturnValue({ orderBy: mockDbOrderBy });
+    mockDbOrderBy.mockReturnValue({ limit: mockDbLimit });
+    mockDbLimit.mockResolvedValue([]);
+  });
+
+  it('matches an existing account whose stored email differs only in case', async () => {
+    mockDbLimit.mockResolvedValue([
+      {
+        id: 'user-mixed-case',
+        email: 'Foo@Example.com',
+        emailVerified: new Date('2026-01-01'),
+        name: 'Foo',
+        image: null,
+      },
+    ]);
+
+    const user = await authOptions.adapter?.getUserByEmail?.('FOO@example.com ');
+
+    expect(user).toMatchObject({ id: 'user-mixed-case', email: 'Foo@Example.com' });
+
+    // Assert on the predicate the code actually recorded, not one rebuilt here:
+    // it must compare lower(email) against the *normalized* input.
+    const recordedPredicate = mockDbWhere.mock.calls[0][0] as { strings: string[]; values: unknown[] };
+    expect(recordedPredicate.strings.join('?')).toContain('lower(');
+    expect(recordedPredicate.values).toContain('foo@example.com');
+  });
+
+  it('returns null when no row shares the lower-cased email', async () => {
+    mockDbLimit.mockResolvedValue([]);
+
+    await expect(authOptions.adapter?.getUserByEmail?.('nobody@example.com')).resolves.toBeNull();
+  });
+
+  it('takes a single row in verified-first, then oldest, order', async () => {
+    mockDbLimit.mockResolvedValue([]);
+
+    await authOptions.adapter?.getUserByEmail?.('dupe@example.com');
+
+    // NULLS LAST puts a verified row ahead of an unverified one; createdAt
+    // breaks the remaining tie so a duplicate set always resolves the same way.
+    const [orderExpression, tieBreaker] = mockDbOrderBy.mock.calls[0] as [{ strings: string[] }, unknown];
+    expect(orderExpression.strings.join('?')).toContain('ASC NULLS LAST');
+    expect(tieBreaker).toBe('users.createdAt');
+    expect(mockDbLimit).toHaveBeenCalledWith(1);
+  });
+
+  it('lower-cases the email before handing a new user to the base adapter', async () => {
+    mockBaseCreateUser.mockResolvedValue({ id: 'new-user' });
+
+    await authOptions.adapter?.createUser?.({
+      id: 'new-user',
+      email: '  New@Example.COM ',
+      emailVerified: null,
+    });
+
+    expect(mockBaseCreateUser).toHaveBeenCalledWith(expect.objectContaining({ email: 'new@example.com' }));
   });
 });

--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -1,5 +1,6 @@
 import type { NextAuthOptions } from 'next-auth';
 import { randomUUID } from 'node:crypto';
+import type { Adapter, AdapterUser } from 'next-auth/adapters';
 import { DrizzleAdapter } from '@auth/drizzle-adapter';
 import GoogleProvider from 'next-auth/providers/google';
 import AppleProvider from 'next-auth/providers/apple';
@@ -7,7 +8,8 @@ import FacebookProvider from 'next-auth/providers/facebook';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import { getDb } from '@/app/lib/db/db';
 import * as schema from '@/app/lib/db/schema';
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import { normalizeEmail } from '@boardsesh/db/utils';
 import { compare } from 'bcryptjs';
 import { verifyNativeOAuthTransferToken } from '@/app/lib/auth/native-oauth-transfer';
 import { isSecureCookieContext, sessionCookieDomain } from '@/app/lib/auth/secure-cookies';
@@ -108,41 +110,40 @@ providers.push(
       }
 
       const db = getDb();
+      const normalizedEmail = normalizeEmail(credentials.email);
 
-      // Look up user by email
-      const users = await db.select().from(schema.users).where(eq(schema.users.email, credentials.email)).limit(1);
-
-      if (users.length === 0) {
-        return null;
-      }
-
-      const user = users[0];
-
-      // Get user credentials (password hash)
-      const userCredentials = await db
+      // Look up user by email, case-insensitively. Legacy rows may still be
+      // mixed-case, and a duplicate-by-case set can briefly return more than one
+      // row until the account merge collapses it — so verify the password
+      // against each candidate and return whichever one matches.
+      const candidates = await db
         .select()
-        .from(schema.userCredentials)
-        .where(eq(schema.userCredentials.userId, user.id))
-        .limit(1);
+        .from(schema.users)
+        .where(sql`lower(${schema.users.email}) = ${normalizedEmail}`);
 
-      if (userCredentials.length === 0) {
-        // User exists but has no password (e.g., OAuth only)
-        return null;
+      for (const user of candidates) {
+        const userCredentials = await db
+          .select()
+          .from(schema.userCredentials)
+          .where(eq(schema.userCredentials.userId, user.id))
+          .limit(1);
+
+        if (userCredentials.length === 0) {
+          // This candidate has no password (e.g., OAuth only) — try the next.
+          continue;
+        }
+
+        if (await compare(credentials.password, userCredentials[0].passwordHash)) {
+          return {
+            id: user.id,
+            email: user.email,
+            name: user.name,
+            image: user.image,
+          };
+        }
       }
 
-      // Verify password
-      const isValidPassword = await compare(credentials.password, userCredentials[0].passwordHash);
-
-      if (!isValidPassword) {
-        return null;
-      }
-
-      return {
-        id: user.id,
-        email: user.email,
-        name: user.name,
-        image: user.image,
-      };
+      return null;
     },
   }),
 );
@@ -175,13 +176,48 @@ const useSecureCookies = isSecureCookieContext();
 // *.boardsesh.com hosts.
 const cookieDomain = sessionCookieDomain();
 
-export const authOptions: NextAuthOptions = {
-  adapter: DrizzleAdapter(getDb(), {
+// Wrap the Drizzle adapter so OAuth account-linking and user creation treat
+// email case-insensitively. Without this, an OAuth sign-in whose provider email
+// differs only in case from an existing row would miss it (the stock adapter
+// matches `email` exactly) and create a duplicate account. `createUser`
+// lower-cases on write so every new row is canonical; `getUserByEmail` matches
+// existing rows — including legacy mixed-case ones — via `lower(email)`, with a
+// deterministic order so a transient duplicate set resolves to the same row
+// until the account merge collapses it.
+function createAuthAdapter(): Adapter {
+  const base = DrizzleAdapter(getDb(), {
     usersTable: schema.users,
     accountsTable: schema.accounts,
     sessionsTable: schema.sessions,
     verificationTokensTable: schema.verificationTokens,
-  }),
+  });
+
+  return {
+    ...base,
+    createUser: (data: AdapterUser) => base.createUser!({ ...data, email: normalizeEmail(data.email) }),
+    getUserByEmail: async (email): Promise<AdapterUser | null> => {
+      const db = getDb();
+      const rows = await db
+        .select()
+        .from(schema.users)
+        .where(sql`lower(${schema.users.email}) = ${normalizeEmail(email)}`)
+        .orderBy(sql`${schema.users.emailVerified} ASC NULLS LAST`, schema.users.createdAt)
+        .limit(1);
+      const user = rows[0];
+      if (!user) return null;
+      return {
+        id: user.id,
+        email: user.email,
+        emailVerified: user.emailVerified,
+        name: user.name,
+        image: user.image,
+      };
+    },
+  };
+}
+
+export const authOptions: NextAuthOptions = {
+  adapter: createAuthAdapter(),
   providers,
   cookies: {
     // The session token is the login itself. SameSite=Lax (NOT None) is correct
@@ -311,7 +347,11 @@ export const authOptions: NextAuthOptions = {
       }
 
       const db = getDb();
-      const existingUser = await db.select().from(schema.users).where(eq(schema.users.email, user.email)).limit(1);
+      const existingUser = await db
+        .select()
+        .from(schema.users)
+        .where(sql`lower(${schema.users.email}) = ${normalizeEmail(user.email)}`)
+        .limit(1);
 
       // Check if email verification is enabled (disabled by default until Fastmail auth is set up)
       const emailVerificationEnabled = process.env.EMAIL_VERIFICATION_ENABLED === 'true';

--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -222,6 +222,13 @@ function createAuthAdapter(): Adapter {
       if (!user) return null;
       return {
         id: user.id,
+        // Deliberately the stored value, not the normalized one: NextAuth puts
+        // this in the JWT claims and on `session.user.email`, and it should
+        // reflect what's actually in the row. For a legacy mixed-case row that
+        // stays mixed-case until the PR-2 backfill lower-cases it, so any
+        // downstream `session.user.email === someEmail` check can mismatch —
+        // compare with `lower()` (or `normalizeEmail`) on both sides, as every
+        // lookup in this file does.
         email: user.email,
         emailVerified: user.emailVerified,
         name: user.name,

--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -190,6 +190,13 @@ const cookieDomain = sessionCookieDomain();
 // existing rows — including legacy mixed-case ones — via `lower(email)`, with a
 // deterministic order so a transient duplicate set resolves to the same row
 // until the account merge collapses it.
+//
+// That row is not necessarily the one merge-accounts picks as the winner (it
+// ranks by ticks → other rows → verified → oldest; this ranks verified → oldest,
+// because a sign-in wants the verified identity). The two can only disagree in
+// the window between this deploy and the merge run, and nothing is lost when
+// they do: `accounts` rows are repointed by the merge, so an OAuth link made
+// against the non-winner follows the user onto the winner.
 function createAuthAdapter(): Adapter {
   const base = DrizzleAdapter(getDb(), {
     usersTable: schema.users,

--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -200,6 +200,8 @@ function createAuthAdapter(): Adapter {
 
   return {
     ...base,
+    // DrizzleAdapter always defines createUser (it's a required Adapter method);
+    // the assertion documents that invariant so we can delegate to it.
     createUser: (data: AdapterUser) => base.createUser!({ ...data, email: normalizeEmail(data.email) }),
     getUserByEmail: async (email): Promise<AdapterUser | null> => {
       const db = getDb();

--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -116,6 +116,12 @@ providers.push(
       // mixed-case, and a duplicate-by-case set can briefly return more than one
       // row until the account merge collapses it — so verify the password
       // against each candidate and return whichever one matches.
+      //
+      // Candidate count is bounded by real duplicate-by-case signups for one
+      // address: the prod audit found at most 3, and after the merge runs it is
+      // always 1, so the per-candidate bcrypt compares below stay cheap. It is
+      // not attacker-inflatable (a row requires a completed signup), so no
+      // explicit cap is needed.
       const candidates = await db
         .select()
         .from(schema.users)

--- a/packages/web/app/lib/auth/password-reset.ts
+++ b/packages/web/app/lib/auth/password-reset.ts
@@ -1,9 +1,13 @@
 import { createHash } from 'node:crypto';
+import { normalizeEmail } from '@boardsesh/db/utils';
 
 export const PASSWORD_RESET_IDENTIFIER_PREFIX = 'password-reset:';
 
+// Build the identifier from the canonicalised email so the value written in
+// forgot-password and the value read in reset-password always agree, regardless
+// of how the address was cased in the request or the reset link.
 export function getPasswordResetIdentifier(email: string): string {
-  return `${PASSWORD_RESET_IDENTIFIER_PREFIX}${email}`;
+  return `${PASSWORD_RESET_IDENTIFIER_PREFIX}${normalizeEmail(email)}`;
 }
 
 /** sha256(token) stored in DB; raw token travels only in the email link. */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -206,6 +206,14 @@ export default defineConfig({
         // read-only validation/dry-runs before writing published grade rows.
         cache: false,
       },
+      'db:merge-accounts': {
+        command: 'bun run --filter=@boardsesh/db db:merge-accounts',
+        // No db:up dependency, same rationale as db:dedupe-gyms: a maintainer
+        // runs this by hand against DB_URL (often a remote database), not local
+        // Docker. Dry-run by default; --apply is the only write path. Forward
+        // flags with `vp run db:merge-accounts -- --apply`.
+        cache: false,
+      },
       'test:db': {
         command: 'bun run --filter=@boardsesh/db test',
       },


### PR DESCRIPTION
## Summary

`users.email` had no unique constraint and used the default (case-sensitive) collation, so `Foo@x.com` and `foo@x.com` created **separate accounts**. A read-only prod audit found **23 duplicate-by-case account sets** (47 user rows). When someone later links the same board on both twins, the second account shows an empty logbook — the support report that kicked this off.

This is **PR 1 of 2** — the foundation, safe to deploy on its own:

- **Shared `normalizeEmail` helper** at `@boardsesh/db/utils` (trim + lowercase). The backend native-auth handler now routes through it (replacing 3 inline copies).
- **Web auth normalized end-to-end**: email is lower-cased on every write (register insert, email-verification and `password-reset:` token identifiers) and every lookup is case-insensitive — register existence check, credentials login (verifies the password against each candidate so a transient duplicate set can't lock anyone out), forgot/reset/verify/resend, and the `signIn` callback. The NextAuth `DrizzleAdapter` is wrapped so OAuth account-linking and user creation lower-case email too. **This freezes creation of new duplicate accounts.**
- **`merge-accounts.ts`** (`vp run db:merge-accounts`, dry-run by default, `--apply` to write): collapses each `lower(email)` group onto a winner (most ticks → most other rows → verified → oldest), repointing every owned row across all user-referencing tables, deduping the user-scoped unique constraints, and handling the self-follow / shared-board / ticks-surrogate / credential / profile edge cases. Per-set transaction + advisory lock; the dry-run report flags anomalous sets (3-row, both-have-password, both-have-ticks). Relies on the existing `votes_count_trigger` to keep `vote_counts` correct.

The lowercase backfill + `CREATE UNIQUE INDEX … (lower(email))` and the operational merge run land in a follow-up PR, after the merge has been dry-run-reviewed and applied to prod (deleting users is irreversible — pg_dump first). **No migration in this PR mutates data.**

Also unblocks the #3526 cross-linked-account repair, which needs this merge tooling.

## What changed in the rebase

Rebased onto current `main`. The one real conflict was `auth-options.ts`, which `main` reworked twice since the branch was cut (JWT profile-claims caching in 9c34fc163, the shared parent-domain session cookie in 05f74cc40). Both are preserved verbatim; the adapter wrap and the multi-candidate credentials login are re-applied on top.

The FK-completeness guard earned its keep during the rebase: `main` has since added `app_feedback.resolved_by` and `gym_merge_audit.performed_by`, and the script aborted rather than silently skipping them. Both are `ON DELETE SET NULL` staff-attribution columns, so they join the plain repoints — the audit trail names the surviving account instead of going blank when the loser row is deleted.

Review nits from the last pass are addressed: a note on why the adapter's verified-first ordering can legitimately differ from the merge script's winner ranking (and why nothing is lost when it does), a comment scoping the FK guard to single-column FKs, and unit tests for the adapter wrapper.

## Release Notes

- Sign in with your email however you capitalise it. `You@Email.com` and `you@email.com` are the same account now, so you won't land in a second, empty profile with none of your sends in it.

## Test plan

- `vp run typecheck` — green (all 53 tasks).
- `vp check` — 0 errors.
- Unit: `normalizeEmail` (case/trim/idempotence/guard); web auth suites 188/188 across 15 files, including 4 new adapter-wrapper tests (case-insensitive match on a mixed-case stored row, the recorded `lower(email)` predicate, verified-then-oldest ordering, and `createUser` lower-casing before it delegates); backend native-auth.
- **Integration** (`merge-accounts.integration.test.ts`, real Postgres): seeds a winner+loser+third with rows across ticks, favorites, mutual follows (self-follow trap), credentials, profiles, votes (dedup + trigger-maintained counts), a loser-owned gym (cascade-delete trap), a Tension board link, ratings, and a beta link — asserts every row lands on the winner, uniques dedupe, no self-follow, and the loser is deleted. Plus the FK-coverage test that runs the guard against the live migrated schema, so the repoint lists can't drift undetected again. Passes, rolls back cleanly.
- The merge script was **not** run against any database in this rescue. It stays dry-run by default (`apply: false`); `--apply` is the only write path and returns early without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xu9FhyVPEPTuBSGBigiDgd
