### PR TITLE
feat(mobile): You/Progress deep-chart sections — angle, rhythm, projecting, ceiling, milestones

### DIFF
--- a/packages/mobile/src/components/you/ActivityHeatmap.tsx
+++ b/packages/mobile/src/components/you/ActivityHeatmap.tsx
@@ -2,23 +2,22 @@ import { Fragment, useCallback, useMemo, useState } from 'react';
 import { View, StyleSheet, type LayoutChangeEvent } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import Svg, { Rect } from 'react-native-svg';
-import type { RawActivityDay, RawActivityHeatmap } from '@boardsesh/profile-stats';
+import type { RawActivityDay, RawActivityHeatmap, RawStreaks } from '@boardsesh/profile-stats';
 import { Text } from '../Text';
+import { Icon } from '../Icon';
 import { useTheme } from '../../providers/theme-provider';
-import { blendOpaque } from '../../theme/colors';
 import { borderRadius, spacing } from '../../theme/tokens';
+import { buildIntensityFills, colorForCount, INTENSITY_STEPS } from './heatmap-intensity';
 
 const ROWS = 7;
 const CELL_GAP = 3;
 // Column budget (cell + gap) used to decide how many weeks fit the screen.
 const TARGET_COLUMN = 16;
-const INTENSITY_STEPS = [0.4, 0.6, 0.8, 1] as const;
-// Opaque-composite alphas for the empty floor (kept faint, scheme-tuned).
-const EMPTY_FLOOR_ALPHA_DARK = 0.14;
-const EMPTY_FLOOR_ALPHA_LIGHT = 0.08;
 
 type ActivityHeatmapProps = {
   heatmap: RawActivityHeatmap;
+  /** Weekly streak — when set, the card gains a flame "{n}-week streak" header. */
+  streak?: RawStreaks;
 };
 
 /**
@@ -28,7 +27,7 @@ type ActivityHeatmapProps = {
  * edge-to-edge — the recent calendar is the part people read. Single instance on
  * a scroll screen, so the SVG grid isn't subject to the list-virtualization rule.
  */
-export function ActivityHeatmap({ heatmap }: ActivityHeatmapProps) {
+export function ActivityHeatmap({ heatmap, streak }: ActivityHeatmapProps) {
   const { colorScheme, chartColors, brandColors } = useTheme();
   const { t } = useTranslation('profile');
   const [width, setWidth] = useState(0);
@@ -53,16 +52,12 @@ export function ActivityHeatmap({ heatmap }: ActivityHeatmapProps) {
 
   // Per-variant brand accent (opaque hex on every variant/scheme) composited onto
   // the opaque card surface so the ramp + empty floor stay legible regardless of
-  // what sits behind the SVG. Computed once per scheme/variant change.
+  // what sits behind the SVG. Computed once per scheme/variant change via the
+  // shared ramp helper (also drives the wall-rhythm grid, so they stay siblings).
   const primary = chartColors.accent;
   const surface = chartColors.secondaryBackground;
-  const { emptyFill, stepFills } = useMemo(() => {
-    const floorAlpha = colorScheme === 'dark' ? EMPTY_FLOOR_ALPHA_DARK : EMPTY_FLOOR_ALPHA_LIGHT;
-    return {
-      emptyFill: blendOpaque(primary, surface, floorAlpha),
-      stepFills: INTENSITY_STEPS.map((step) => blendOpaque(primary, surface, step)),
-    };
-  }, [primary, surface, colorScheme]);
+  const fills = useMemo(() => buildIntensityFills(primary, surface, colorScheme), [primary, surface, colorScheme]);
+  const { emptyFill, stepFills } = fills;
 
   // "Today" via a LOCAL date string (NOT toISOString, which is UTC) so the
   // current-day ring lands on the right cell across time zones.
@@ -73,14 +68,9 @@ export function ActivityHeatmap({ heatmap }: ActivityHeatmapProps) {
     return `${now.getFullYear()}-${month}-${dayOfMonth}`;
   }, []);
 
-  const colorForCount = useCallback(
-    (count: number): string => {
-      if (count <= 0) return emptyFill;
-      const ratio = count / heatmap.maxCount;
-      const stepIndex = Math.min(stepFills.length - 1, Math.max(0, Math.ceil(ratio * stepFills.length) - 1));
-      return stepFills[stepIndex];
-    },
-    [emptyFill, stepFills, heatmap.maxCount],
+  const fillForCount = useCallback(
+    (count: number): string => colorForCount(count, heatmap.maxCount, fills),
+    [fills, heatmap.maxCount],
   );
 
   const fitWeeks =
@@ -96,12 +86,32 @@ export function ActivityHeatmap({ heatmap }: ActivityHeatmapProps) {
 
   const onLayout = (event: LayoutChangeEvent) => setWidth(event.nativeEvent.layout.width);
 
+  // Live streak header: flame + "{n}-week streak" left, "best {n} wks" right.
+  // Only when a streak is actually running — a "0-week streak" header is noise.
+  const showStreakHeader = streak != null && streak.currentWeeks > 0;
+
   return (
     <View
       onLayout={onLayout}
       accessibilityRole="image"
       accessibilityLabel={t('stats.calendarAria', { days: totals.activeDays, count: totals.totalClimbs })}
     >
+      {showStreakHeader ? (
+        <View style={styles.streakHeader} accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
+          <View style={styles.streakLeft}>
+            <Icon name="flame" size={16} color={brandColors.accent} />
+            <Text variant="headline" color={chartColors.label}>
+              {t('dashboard.streakChip', { count: streak.currentWeeks })}
+            </Text>
+          </View>
+          {streak.longestWeeks > 0 ? (
+            <Text variant="footnote" color={chartColors.secondaryLabel}>
+              {t('dashboard.streakBestWeeks', { count: streak.longestWeeks })}
+            </Text>
+          ) : null}
+        </View>
+      ) : null}
+
       {width > 0 && cell > 0 ? (
         <Svg width={width} height={gridHeight}>
           {shown.map((column, columnIndex) =>
@@ -119,7 +129,7 @@ export function ActivityHeatmap({ heatmap }: ActivityHeatmapProps) {
                     height={cell}
                     rx={cornerRadius}
                     ry={cornerRadius}
-                    fill={colorForCount(day.count)}
+                    fill={fillForCount(day.count)}
                     stroke={chartColors.separator}
                     strokeWidth={StyleSheet.hairlineWidth}
                   />
@@ -168,6 +178,17 @@ export function ActivityHeatmap({ heatmap }: ActivityHeatmapProps) {
 }
 
 const styles = StyleSheet.create({
+  streakHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing[3],
+  },
+  streakLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
   legend: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/packages/mobile/src/components/you/AngleBreakdownChart.tsx
+++ b/packages/mobile/src/components/you/AngleBreakdownChart.tsx
@@ -1,0 +1,164 @@
+import { useState } from 'react';
+import { View, StyleSheet, type LayoutChangeEvent } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import Svg, { Defs, LinearGradient, Rect, Stop } from 'react-native-svg';
+import type { RawAngleBreakdown } from '@boardsesh/profile-stats';
+import { Text } from '../Text';
+import { useTheme } from '../../providers/theme-provider';
+import { borderRadius, spacing } from '../../theme/tokens';
+import { angleChartColor } from './profile-chart-colors';
+import { shiftLightness } from '../playlist/playlist-gradient';
+
+type AngleBreakdownChartProps = {
+  breakdown: RawAngleBreakdown;
+};
+
+// Fixed leading rule + angle-label gutter, so every row's bar starts at the same
+// x regardless of which row is the home angle (the rule only paints on home).
+const LEAD_WIDTH = 3;
+const ANGLE_COL_WIDTH = 36;
+// Room reserved at the right so the grade tip label ("V13" / "8C+") clears the
+// longest bar without being clipped.
+const TIP_RESERVE = 44;
+const ROW_HEIGHT = 26;
+const BAR_HEIGHT = 14;
+// The faint volume track sits behind the grade bar, a touch taller so it reads
+// as a band the bar floats on.
+const TRACK_HEIGHT = ROW_HEIGHT - 6;
+const BAR_RADIUS = borderRadius.sm;
+const MIN_BAR = 4;
+
+/**
+ * "Your angle" — one horizontal row per wall angle (steep→slab). Each bar's
+ * length is the angle's hardest grade relative to the overall hardest; the bar
+ * is tinted by that grade's hue (`angleChartColor`) via a horizontal SVG
+ * gradient, with the grade label at the tip and a faint volume track behind it
+ * scaled by send count. The home angle (highest volume) gets a brand left rule +
+ * caption. Every SVG/track/label colour is a plain `chartColors.*` hex — never a
+ * PlatformColor — so react-native-svg fills stay valid. Parent gates the empty
+ * case, so an empty `rows` simply renders nothing.
+ */
+export function AngleBreakdownChart({ breakdown }: AngleBreakdownChartProps) {
+  const { chartColors, brandColors } = useTheme();
+  const { t } = useTranslation('profile');
+  const [width, setWidth] = useState(0);
+
+  if (breakdown.rows.length === 0) return null;
+
+  const onLayout = (event: LayoutChangeEvent) => setWidth(event.nativeEvent.layout.width);
+  // Deterministic bar area from a single container measurement (no per-row
+  // onLayout churn): the SVG track region after the lead + angle gutters, less
+  // the tip-label reserve so the grade label always fits.
+  const barAreaWidth = Math.max(0, width - LEAD_WIDTH - spacing[2] - ANGLE_COL_WIDTH - spacing[2]);
+  const trackWidth = Math.max(0, barAreaWidth - TIP_RESERVE);
+
+  return (
+    <View
+      onLayout={onLayout}
+      accessible
+      accessibilityRole="image"
+      accessibilityLabel={t('charts.angleA11y')}
+      importantForAccessibility="no-hide-descendants"
+    >
+      {width > 0
+        ? breakdown.rows.map((row) => {
+            const isHome = breakdown.homeAngle === row.angle;
+            const hue = angleChartColor(row.maxLabel);
+            const gradeWidth =
+              breakdown.maxDifficulty > 0
+                ? Math.max(MIN_BAR, (row.maxDifficulty / breakdown.maxDifficulty) * trackWidth)
+                : MIN_BAR;
+            const volumeWidth = breakdown.maxSendCount > 0 ? (row.sendCount / breakdown.maxSendCount) * trackWidth : 0;
+            const gradientId = `angle-${row.angle}`;
+            return (
+              <View key={row.angle} style={styles.rowGroup}>
+                <View style={styles.barRow}>
+                  <View style={[styles.lead, isHome ? { backgroundColor: brandColors.primary } : undefined]} />
+                  <Text variant="caption1" color={chartColors.secondaryLabel} style={styles.angleLabel}>
+                    {t('charts.angleUnit', { angle: row.angle })}
+                  </Text>
+                  <View style={[styles.barArea, { width: barAreaWidth }]}>
+                    <Svg width={barAreaWidth} height={ROW_HEIGHT}>
+                      <Defs>
+                        <LinearGradient id={gradientId} x1="0" y1="0" x2="1" y2="0">
+                          <Stop offset="0" stopColor={shiftLightness(hue, 16)} />
+                          <Stop offset="1" stopColor={hue} />
+                        </LinearGradient>
+                      </Defs>
+                      {volumeWidth > 0 ? (
+                        <Rect
+                          x={0}
+                          y={(ROW_HEIGHT - TRACK_HEIGHT) / 2}
+                          width={volumeWidth}
+                          height={TRACK_HEIGHT}
+                          rx={BAR_RADIUS}
+                          ry={BAR_RADIUS}
+                          fill={chartColors.secondaryBackground}
+                        />
+                      ) : null}
+                      <Rect
+                        x={0}
+                        y={(ROW_HEIGHT - BAR_HEIGHT) / 2}
+                        width={gradeWidth}
+                        height={BAR_HEIGHT}
+                        rx={BAR_RADIUS}
+                        ry={BAR_RADIUS}
+                        fill={`url(#${gradientId})`}
+                      />
+                    </Svg>
+                    <Text
+                      variant="caption1"
+                      color={chartColors.label}
+                      style={[styles.tipLabel, { left: gradeWidth + spacing[1] }]}
+                      numberOfLines={1}
+                    >
+                      {row.maxLabel}
+                    </Text>
+                  </View>
+                </View>
+                {isHome ? (
+                  <Text variant="caption2" color={brandColors.primary} style={styles.homeCaption}>
+                    {t('charts.homeAngle')}
+                  </Text>
+                ) : null}
+              </View>
+            );
+          })
+        : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  rowGroup: {
+    marginBottom: spacing[2],
+  },
+  barRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    height: ROW_HEIGHT,
+  },
+  lead: {
+    width: LEAD_WIDTH,
+    height: BAR_HEIGHT,
+    borderRadius: borderRadius.full,
+  },
+  angleLabel: {
+    width: ANGLE_COL_WIDTH,
+    textAlign: 'right',
+    fontVariant: ['tabular-nums'],
+  },
+  barArea: {
+    height: ROW_HEIGHT,
+    justifyContent: 'center',
+  },
+  tipLabel: {
+    position: 'absolute',
+    fontWeight: '600',
+  },
+  homeCaption: {
+    marginLeft: LEAD_WIDTH + spacing[2] + ANGLE_COL_WIDTH + spacing[2],
+    marginTop: 2,
+  },
+});

--- a/packages/mobile/src/components/you/GradeMilestonesTimeline.tsx
+++ b/packages/mobile/src/components/you/GradeMilestonesTimeline.tsx
@@ -1,0 +1,152 @@
+import { View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { getGradeTextColor } from '@boardsesh/play-view';
+import type { RawGradeMilestone } from '@boardsesh/profile-stats';
+import { Text } from '../Text';
+import { useTheme } from '../../providers/theme-provider';
+import { useVariantValue } from '../../theme/variants';
+import { spacing, borderRadius } from '../../theme/tokens';
+import { gradeBadgeColor } from './profile-chart-colors';
+
+const MATERIAL = { material: true, liquidGlass: false } as const;
+const RAIL_WIDTH = 18;
+const DOT_SIZE = 10;
+
+type TFunc = (key: string, options?: Record<string, unknown>) => string;
+
+type GradeMilestonesTimelineProps = {
+  milestones: RawGradeMilestone[];
+};
+
+// Literal t() keys (no dynamic lookups) so the catalog stays statically
+// analysable — same pattern as the wall-rhythm weekday switch.
+function monthAbbr(month: number, t: TFunc): string {
+  switch (month) {
+    case 1:
+      return t('charts.month.jan');
+    case 2:
+      return t('charts.month.feb');
+    case 3:
+      return t('charts.month.mar');
+    case 4:
+      return t('charts.month.apr');
+    case 5:
+      return t('charts.month.may');
+    case 6:
+      return t('charts.month.jun');
+    case 7:
+      return t('charts.month.jul');
+    case 8:
+      return t('charts.month.aug');
+    case 9:
+      return t('charts.month.sep');
+    case 10:
+      return t('charts.month.oct');
+    case 11:
+      return t('charts.month.nov');
+    default:
+      return t('charts.month.dec');
+  }
+}
+
+/**
+ * Format a milestone's `YYYY-MM-DD` (already a LOCAL calendar date from the
+ * builder) into "Mar '24". Parses the string parts directly rather than through
+ * a Date/dayjs — there is no dayjs in mobile, and re-parsing a local date string
+ * as UTC would shift it across a month boundary. Month names come from i18n
+ * (dayjs locale isn't wired app-wide).
+ */
+function formatMilestoneDate(date: string, t: TFunc): string {
+  const [year, month] = date.split('-');
+  return t('charts.milestoneDate', { month: monthAbbr(Number(month), t), year: year.slice(2) });
+}
+
+/**
+ * "Grade milestones" — a compact left-rail vertical timeline of the first send
+ * at each grade (grade-ascending, so it reads bottom-of-the-pyramid → ceiling
+ * top to bottom). Each row: a dot on the rail, the grade badge (`gradeBadgeColor`),
+ * and the first-send month. Parent gates the empty case.
+ */
+export function GradeMilestonesTimeline({ milestones }: GradeMilestonesTimelineProps) {
+  const { systemColors, m3 } = useTheme();
+  const { t } = useTranslation('profile');
+  const isMaterial = useVariantValue(MATERIAL);
+
+  if (milestones.length === 0) return null;
+
+  const railColor = isMaterial ? m3.outlineVariant : systemColors.separator;
+  const dateColor = isMaterial ? m3.onSurfaceVariant : systemColors.secondaryLabel;
+
+  return (
+    <View accessibilityRole="image" accessibilityLabel={t('charts.milestonesA11y')}>
+      {milestones.map((milestone, index) => {
+        const isLast = index === milestones.length - 1;
+        const badgeHex = gradeBadgeColor(milestone.label);
+        const dateText = formatMilestoneDate(milestone.date, t);
+        return (
+          <View
+            key={`${milestone.label}-${milestone.date}`}
+            style={styles.row}
+            accessibilityRole="text"
+            accessibilityLabel={t('charts.milestoneA11y', { grade: milestone.label, date: dateText })}
+          >
+            <View style={styles.rail}>
+              <View style={[styles.dot, { backgroundColor: badgeHex }]} />
+              {!isLast ? <View style={[styles.connector, { backgroundColor: railColor }]} /> : null}
+            </View>
+            <View style={[styles.content, isLast ? undefined : styles.contentSpacing]}>
+              <View style={[styles.badge, { backgroundColor: badgeHex }]}>
+                <Text variant="caption1" color={getGradeTextColor(badgeHex)} style={styles.badgeText}>
+                  {milestone.label}
+                </Text>
+              </View>
+              <Text variant="footnote" color={dateColor}>
+                {dateText}
+              </Text>
+            </View>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+  },
+  rail: {
+    width: RAIL_WIDTH,
+    alignItems: 'center',
+  },
+  dot: {
+    width: DOT_SIZE,
+    height: DOT_SIZE,
+    borderRadius: borderRadius.full,
+    marginTop: 4,
+  },
+  connector: {
+    flex: 1,
+    width: 2,
+    marginTop: 2,
+  },
+  content: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  contentSpacing: {
+    paddingBottom: spacing[3],
+  },
+  badge: {
+    borderRadius: borderRadius.sm,
+    paddingHorizontal: spacing[2],
+    paddingVertical: 2,
+    minWidth: 36,
+    alignItems: 'center',
+  },
+  badgeText: {
+    fontWeight: '700',
+  },
+});

--- a/packages/mobile/src/components/you/LayoutShareDonut.tsx
+++ b/packages/mobile/src/components/you/LayoutShareDonut.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { PieChart } from 'react-native-gifted-charts';
 import type { RawLayoutPercentage } from '@boardsesh/profile-stats';
 import { Text } from '../Text';
+import { CountUpNumber } from './CountUpNumber';
 import { layoutChartColor } from './profile-chart-colors';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
@@ -50,15 +51,8 @@ export function LayoutShareDonut({ layoutPercentages, totalAscents }: LayoutShar
   const centerLabel = useCallback(
     (): ReactNode => (
       <View style={styles.center} importantForAccessibility="no-hide-descendants" accessibilityElementsHidden>
-        <Text
-          variant="headline"
-          color={systemColors.label}
-          numberOfLines={1}
-          adjustsFontSizeToFit
-          maxFontSizeMultiplier={1.3}
-        >
-          {totalAscents}
-        </Text>
+        <CountUpNumber value={totalAscents} variant="headline" color={systemColors.label} />
+
         <Text
           variant="caption2"
           color={systemColors.secondaryLabel}

--- a/packages/mobile/src/components/you/ProgressTab.tsx
+++ b/packages/mobile/src/components/you/ProgressTab.tsx
@@ -7,13 +7,24 @@ import { ScreenTitle } from '../ScreenTitle';
 import { Icon } from '../Icon';
 import { Card } from '../Card';
 import { SectionHeader } from '../SectionHeader';
+import { CollapsibleSection } from '../CollapsibleSection';
 import { ActivityIndicator } from '../ActivityIndicator';
 import { ProfileBetaShelf } from './ProfileBetaShelf';
 import { HeroCeilingCard } from './HeroCeilingCard';
 import { ProgressControlBar } from './ProgressControlBar';
 import { ProgressGlanceGrid } from './ProgressGlanceGrid';
-import { StackedBarChart, GroupedBarChart, TotalAreaChart, type ChartLegendItem } from './YouCharts';
+import {
+  StackedBarChart,
+  GroupedBarChart,
+  TotalAreaChart,
+  RunningMaxLineChart,
+  type ChartLegendItem,
+} from './YouCharts';
 import { ActivityHeatmap } from './ActivityHeatmap';
+import { ProjectingCard } from './ProjectingCard';
+import { AngleBreakdownChart } from './AngleBreakdownChart';
+import { WallRhythmGrid } from './WallRhythmGrid';
+import { GradeMilestonesTimeline } from './GradeMilestonesTimeline';
 import { LayoutShareDonut } from './LayoutShareDonut';
 import { layoutChartColor, flashRedpointColor } from './profile-chart-colors';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
@@ -188,23 +199,59 @@ export const ProgressTab = memo(function ProgressTab({
               so it sits right under the glance grid. Hidden when none shared. */}
           {userId ? <ProfileBetaShelf userId={userId} /> : null}
 
-          {data.activityHeatmap && (
+          {/* Your biggest fights — the tries-to-send histogram + biggest project.
+              Hidden until a hard-won send (≥4 tries) is worth featuring. */}
+          {data.projectingStats.unlocked && (
             <>
-              <SectionHeader title={t('stats.calendar')} />
+              <SectionHeader title={t('sections.biggestFights')} />
               <Card style={styles.chartCard}>
-                <ActivityHeatmap heatmap={data.activityHeatmap} />
+                <ProjectingCard projectingStats={data.projectingStats} />
               </Card>
             </>
           )}
 
-          {data.statisticsSummary.layoutPercentages.length > 1 && (
+          {/* Grade pyramid — the existing grade × layout distribution, with a
+              "next project" nudge toward the thin grade above the modal grade. */}
+          <SectionHeader title={t('sections.gradePyramid')} />
+          <Card style={styles.chartCard}>
+            {data.nextProjectGrade ? (
+              <Text variant="footnote" color={brandColors.primary} style={styles.nextProject}>
+                {t('charts.nextProject', { grade: data.nextProjectGrade.label })}
+              </Text>
+            ) : null}
+            <StackedBarChart
+              bars={data.aggregatedStackedBars?.bars ?? null}
+              colorBy="layout"
+              emptyLabel={noAscentData}
+              legend={gradeDistLegend}
+              showYAxisScale
+              accessibilityLabel={t('stats.gradeDistributionAria')}
+            />
+          </Card>
+
+          {data.angleBreakdown && (
             <>
-              <SectionHeader title={t('stats.boards')} />
+              <SectionHeader title={t('sections.yourAngle')} />
               <Card style={styles.chartCard}>
-                <LayoutShareDonut
-                  layoutPercentages={data.statisticsSummary.layoutPercentages}
-                  totalAscents={data.statisticsSummary.totalAscents}
-                />
+                <AngleBreakdownChart breakdown={data.angleBreakdown} />
+              </Card>
+            </>
+          )}
+
+          {data.wallRhythm && (
+            <>
+              <SectionHeader title={t('sections.wallRhythm')} />
+              <Card style={styles.chartCard}>
+                <WallRhythmGrid rhythm={data.wallRhythm} />
+              </Card>
+            </>
+          )}
+
+          {data.activityHeatmap && (
+            <>
+              <SectionHeader title={t('stats.calendar')} />
+              <Card style={styles.chartCard}>
+                <ActivityHeatmap heatmap={data.activityHeatmap} streak={data.streaks} />
               </Card>
             </>
           )}
@@ -223,41 +270,66 @@ export const ProgressTab = memo(function ProgressTab({
             />
           </Card>
 
-          <SectionHeader title={t('stats.gradeDistribution')} />
-          <Card style={styles.chartCard}>
-            <StackedBarChart
-              bars={data.aggregatedStackedBars?.bars ?? null}
-              colorBy="layout"
-              emptyLabel={noAscentData}
-              legend={gradeDistLegend}
-              showYAxisScale
-              accessibilityLabel={t('stats.gradeDistributionAria')}
-            />
-          </Card>
-
-          {data.aggregatedFlashRedpointBars && (
+          {data.runningMaxCeiling && (
             <>
-              <SectionHeader title={t('stats.flashVsRedpoint')} />
-              <Card style={styles.chartCard} accessibilityLabel={t('stats.flashRedpointAria')}>
-                <GroupedBarChart
-                  bars={data.aggregatedFlashRedpointBars}
+              <SectionHeader title={t('sections.ceilingOverTime')} />
+              <Card
+                style={styles.chartCard}
+                accessibilityLabel={t('charts.ceilingA11y', { grade: data.runningMaxCeiling.currentLabel })}
+              >
+                <RunningMaxLineChart
+                  ceiling={data.runningMaxCeiling}
+                  color={brandColors.primary}
                   emptyLabel={noAscentData}
-                  legend={flashRedpointLegend}
                 />
               </Card>
             </>
           )}
 
-          {data.vPointsTimeline && (
+          {data.gradeMilestones.length > 0 && (
             <>
-              <SectionHeader title={t('stats.vPoints')} />
+              <SectionHeader title={t('sections.gradeMilestones')} />
               <Card style={styles.chartCard}>
+                <GradeMilestonesTimeline milestones={data.gradeMilestones} />
+              </Card>
+            </>
+          )}
+
+          {data.statisticsSummary.layoutPercentages.length > 1 && (
+            <>
+              <SectionHeader title={t('stats.boards')} />
+              <Card style={styles.chartCard}>
+                <LayoutShareDonut
+                  layoutPercentages={data.statisticsSummary.layoutPercentages}
+                  totalAscents={data.statisticsSummary.totalAscents}
+                />
+              </Card>
+            </>
+          )}
+
+          {/* Supporting curves — demoted into collapsed sections near the bottom;
+              the progression story is carried by the ceiling chart above. */}
+          {data.vPointsTimeline && (
+            <View style={styles.collapsible}>
+              <CollapsibleSection title={t('stats.vPoints')} defaultExpanded={false}>
                 <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.vpTotal}>
                   {t('stats.vPointsTotal', { value: data.vPointsTimeline.totalPoints.toLocaleString() })}
                 </Text>
                 <TotalAreaChart timeline={data.vPointsTimeline} color={brandColors.primary} emptyLabel={noAscentData} />
-              </Card>
-            </>
+              </CollapsibleSection>
+            </View>
+          )}
+
+          {data.aggregatedFlashRedpointBars && (
+            <View style={styles.collapsible}>
+              <CollapsibleSection title={t('stats.flashVsRedpoint')} defaultExpanded={false}>
+                <GroupedBarChart
+                  bars={data.aggregatedFlashRedpointBars}
+                  emptyLabel={noAscentData}
+                  legend={flashRedpointLegend}
+                />
+              </CollapsibleSection>
+            </View>
           )}
         </>
       )}
@@ -276,6 +348,8 @@ const styles = StyleSheet.create({
   chartCard: { marginHorizontal: spacing[4] },
   controlBar: { marginTop: spacing[4] },
   glanceGrid: { marginTop: spacing[4] },
+  collapsible: { marginHorizontal: spacing[4], marginTop: spacing[6] },
+  nextProject: { marginBottom: spacing[3], fontWeight: '600' },
   tipInset: { marginHorizontal: spacing[4], marginBottom: spacing[3] },
   vpTotal: { marginBottom: spacing[2] },
   empty: {

--- a/packages/mobile/src/components/you/ProjectingCard.tsx
+++ b/packages/mobile/src/components/you/ProjectingCard.tsx
@@ -1,0 +1,145 @@
+import { useState } from 'react';
+import { View, StyleSheet, type LayoutChangeEvent } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { BarChart } from 'react-native-gifted-charts';
+import { getGradeTextColor } from '@boardsesh/play-view';
+import type { RawProjectingStats } from '@boardsesh/profile-stats';
+import { Text } from '../Text';
+import { useTheme } from '../../providers/theme-provider';
+import { useVariantValue } from '../../theme/variants';
+import { spacing, borderRadius } from '../../theme/tokens';
+import { gradeBadgeColor } from './profile-chart-colors';
+import { shiftLightness } from '../playlist/playlist-gradient';
+
+const MATERIAL = { material: true, liquidGlass: false } as const;
+const CHART_HEIGHT = 132;
+const AXIS_LABEL_SIZE = 11;
+const BAR_RADIUS = 4;
+
+type ProjectingCardProps = {
+  projectingStats: RawProjectingStats;
+};
+
+/**
+ * "Your biggest fights" — a 4-bucket tries-to-send histogram (1 / 2–5 / 6–20 /
+ * 20+) over a hairline, then the biggest-won project as a grade badge + tries
+ * pill. Bars use the brand primary with the vertical in-chart gradient
+ * (`showGradient` + `gradientColor`, never `gradientDirection` — not a BarChart
+ * prop). Parent gates rendering on `projectingStats.unlocked`.
+ */
+export function ProjectingCard({ projectingStats }: ProjectingCardProps) {
+  const { chartColors, brandColors, systemColors, m3 } = useTheme();
+  const { t } = useTranslation('profile');
+  const isMaterial = useVariantValue(MATERIAL);
+  const [width, setWidth] = useState(0);
+
+  const onLayout = (event: LayoutChangeEvent) => setWidth(event.nativeEvent.layout.width);
+
+  const count = projectingStats.buckets.length;
+  const initialSpacing = 8;
+  const barSpacing = 12;
+  const barWidth =
+    width > 0 && count > 0
+      ? Math.max(8, Math.floor((width - initialSpacing * 2 - barSpacing * (count - 1)) / count))
+      : 0;
+  const labelBudget = barWidth + barSpacing;
+
+  const gradientColor = shiftLightness(brandColors.primary, 16);
+  const data = projectingStats.buckets.map((bucket) => ({
+    value: bucket.value,
+    label: bucket.label,
+    labelWidth: labelBudget,
+    frontColor: brandColors.primary,
+    showGradient: true,
+    gradientColor,
+  }));
+  const maxValue = Math.max(1, ...projectingStats.buckets.map((bucket) => bucket.value));
+
+  const biggest = projectingStats.biggestProject;
+  const pillBg = isMaterial ? m3.surfaceVariant : systemColors.fill;
+  const badgeHex = biggest ? gradeBadgeColor(biggest.label) : brandColors.primary;
+
+  return (
+    <View>
+      <View
+        onLayout={onLayout}
+        accessibilityRole="image"
+        accessibilityLabel={t('charts.projectingA11y')}
+        importantForAccessibility="no-hide-descendants"
+      >
+        {width > 0 && barWidth > 0 ? (
+          <BarChart
+            data={data}
+            width={width}
+            height={CHART_HEIGHT}
+            barWidth={barWidth}
+            spacing={barSpacing}
+            initialSpacing={initialSpacing}
+            barBorderRadius={BAR_RADIUS}
+            maxValue={maxValue}
+            hideRules
+            hideYAxisText
+            yAxisThickness={0}
+            xAxisThickness={StyleSheet.hairlineWidth}
+            xAxisColor={chartColors.separator}
+            xAxisLabelTextStyle={{ color: chartColors.tertiaryLabel, fontSize: AXIS_LABEL_SIZE }}
+            isAnimated={false}
+            disableScroll
+            disablePress
+          />
+        ) : null}
+      </View>
+
+      {biggest ? (
+        <>
+          <View style={[styles.hairline, { backgroundColor: chartColors.separator }]} />
+          <View
+            style={styles.biggestRow}
+            accessibilityRole="text"
+            accessibilityLabel={t('charts.biggestProjectA11y', { grade: biggest.label, count: biggest.tries })}
+          >
+            <View style={[styles.gradeBadge, { backgroundColor: badgeHex }]}>
+              <Text variant="caption1" color={getGradeTextColor(badgeHex)} style={styles.gradeBadgeText}>
+                {biggest.label}
+              </Text>
+            </View>
+            <View style={[styles.triesPill, { backgroundColor: pillBg }]}>
+              <Text variant="caption1" color={brandColors.accent} style={styles.triesText}>
+                {t('charts.triesPill', { count: biggest.tries })}
+              </Text>
+            </View>
+          </View>
+        </>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  hairline: {
+    height: StyleSheet.hairlineWidth,
+    alignSelf: 'stretch',
+    marginVertical: spacing[3],
+  },
+  biggestRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+  },
+  gradeBadge: {
+    borderRadius: borderRadius.sm,
+    paddingHorizontal: spacing[2],
+    paddingVertical: 2,
+  },
+  gradeBadgeText: {
+    fontWeight: '700',
+  },
+  triesPill: {
+    borderRadius: borderRadius.full,
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[1],
+  },
+  triesText: {
+    fontWeight: '600',
+  },
+});

--- a/packages/mobile/src/components/you/WallRhythmGrid.tsx
+++ b/packages/mobile/src/components/you/WallRhythmGrid.tsx
@@ -1,0 +1,223 @@
+import { Fragment, useMemo, useState } from 'react';
+import { View, StyleSheet, type LayoutChangeEvent } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import Svg, { Rect } from 'react-native-svg';
+import type { RawWallRhythm } from '@boardsesh/profile-stats';
+import { Text } from '../Text';
+import { useTheme } from '../../providers/theme-provider';
+import { borderRadius, spacing } from '../../theme/tokens';
+import { buildIntensityFills, colorForCount } from './heatmap-intensity';
+
+type WallRhythmGridProps = {
+  rhythm: RawWallRhythm;
+};
+
+type TFunc = (key: string, options?: Record<string, unknown>) => string;
+
+const COLS = 4;
+const GRID_ROWS = 7;
+const CELL_GAP = 4;
+const CELL_HEIGHT = 22;
+const ROW_LABEL_WIDTH = 34;
+
+// Literal t() keys (no dynamic key lookups) so the catalog stays statically
+// analysable — mirrors `format-session-when.ts`'s weekday/part-of-day switches.
+function weekdayShort(weekday: number, t: TFunc): string {
+  switch (weekday) {
+    case 0:
+      return t('charts.weekday.mon');
+    case 1:
+      return t('charts.weekday.tue');
+    case 2:
+      return t('charts.weekday.wed');
+    case 3:
+      return t('charts.weekday.thu');
+    case 4:
+      return t('charts.weekday.fri');
+    case 5:
+      return t('charts.weekday.sat');
+    default:
+      return t('charts.weekday.sun');
+  }
+}
+
+function weekdayFull(weekday: number, t: TFunc): string {
+  switch (weekday) {
+    case 0:
+      return t('charts.weekdayFull.mon');
+    case 1:
+      return t('charts.weekdayFull.tue');
+    case 2:
+      return t('charts.weekdayFull.wed');
+    case 3:
+      return t('charts.weekdayFull.thu');
+    case 4:
+      return t('charts.weekdayFull.fri');
+    case 5:
+      return t('charts.weekdayFull.sat');
+    default:
+      return t('charts.weekdayFull.sun');
+  }
+}
+
+function blockLabel(block: number, t: TFunc): string {
+  switch (block) {
+    case 0:
+      return t('charts.block.morning');
+    case 1:
+      return t('charts.block.midday');
+    case 2:
+      return t('charts.block.evening');
+    default:
+      return t('charts.block.night');
+  }
+}
+
+function timeOfDay(block: number, t: TFunc): string {
+  switch (block) {
+    case 0:
+      return t('charts.timeOfDay.morning');
+    case 1:
+      return t('charts.timeOfDay.midday');
+    case 2:
+      return t('charts.timeOfDay.evening');
+    default:
+      return t('charts.timeOfDay.night');
+  }
+}
+
+/**
+ * "Wall rhythm" — a 7×4 grid (weekday × morning/midday/evening/night) with cell
+ * intensity ∝ that slot's session count, reusing the activity calendar's
+ * `colorForCount` ramp so the two heatmaps read as siblings. Cells are flat (a
+ * gradient muddies the intensity steps). The busiest slot gets the same brand
+ * accent ring the calendar uses for "today". Every fill is a plain `chartColors.*`
+ * hex; parent gates the empty case.
+ */
+export function WallRhythmGrid({ rhythm }: WallRhythmGridProps) {
+  const { colorScheme, chartColors, brandColors } = useTheme();
+  const { t } = useTranslation('profile');
+  const [width, setWidth] = useState(0);
+
+  const fills = useMemo(
+    () => buildIntensityFills(chartColors.accent, chartColors.secondaryBackground, colorScheme),
+    [chartColors.accent, chartColors.secondaryBackground, colorScheme],
+  );
+
+  const onLayout = (event: LayoutChangeEvent) => setWidth(event.nativeEvent.layout.width);
+
+  const gridWidth = Math.max(0, width - ROW_LABEL_WIDTH - spacing[2]);
+  const cellWidth = gridWidth > 0 ? (gridWidth - (COLS - 1) * CELL_GAP) / COLS : 0;
+  const gridHeight = GRID_ROWS * CELL_HEIGHT + (GRID_ROWS - 1) * CELL_GAP;
+  const cornerRadius = Math.min(borderRadius.sm, Math.round(Math.min(cellWidth, CELL_HEIGHT) * 0.22));
+  const ringWidth = Math.max(1.5, Math.min(cellWidth, CELL_HEIGHT) * 0.12);
+
+  const hottestCaption =
+    rhythm.hottest != null
+      ? t('charts.wallRhythmCaption', {
+          weekday: weekdayFull(rhythm.hottest.weekday, t),
+          timeOfDay: timeOfDay(rhythm.hottest.block, t),
+        })
+      : null;
+
+  return (
+    <View onLayout={onLayout} accessibilityRole="image" accessibilityLabel={t('charts.wallRhythmA11y')}>
+      {width > 0 && cellWidth > 0 ? (
+        <View importantForAccessibility="no-hide-descendants" accessibilityElementsHidden>
+          {/* Column headers (time of day) aligned over the grid columns. */}
+          <View style={styles.headerRow}>
+            <View style={{ width: ROW_LABEL_WIDTH + spacing[2] }} />
+            {Array.from({ length: COLS }, (_, block) => (
+              <View key={block} style={{ width: cellWidth, marginRight: block < COLS - 1 ? CELL_GAP : 0 }}>
+                <Text variant="caption2" color={chartColors.tertiaryLabel} numberOfLines={1} style={styles.colLabel}>
+                  {blockLabel(block, t)}
+                </Text>
+              </View>
+            ))}
+          </View>
+
+          <View style={styles.body}>
+            {/* Weekday row labels, each aligned to its grid row. */}
+            <View style={{ width: ROW_LABEL_WIDTH, marginRight: spacing[2] }}>
+              {Array.from({ length: GRID_ROWS }, (_, weekday) => (
+                <View
+                  key={weekday}
+                  style={{ height: CELL_HEIGHT, marginBottom: weekday < GRID_ROWS - 1 ? CELL_GAP : 0 }}
+                >
+                  <Text variant="caption2" color={chartColors.tertiaryLabel} style={styles.rowLabel}>
+                    {weekdayShort(weekday, t)}
+                  </Text>
+                </View>
+              ))}
+            </View>
+
+            <Svg width={gridWidth} height={gridHeight}>
+              {Array.from({ length: GRID_ROWS }, (_, weekday) =>
+                Array.from({ length: COLS }, (_, block) => {
+                  const cellX = block * (cellWidth + CELL_GAP);
+                  const cellY = weekday * (CELL_HEIGHT + CELL_GAP);
+                  const count = rhythm.matrix[weekday]?.[block] ?? 0;
+                  const isHottest = rhythm.hottest?.weekday === weekday && rhythm.hottest?.block === block;
+                  return (
+                    <Fragment key={`${weekday}-${block}`}>
+                      <Rect
+                        x={cellX}
+                        y={cellY}
+                        width={cellWidth}
+                        height={CELL_HEIGHT}
+                        rx={cornerRadius}
+                        ry={cornerRadius}
+                        fill={colorForCount(count, rhythm.max, fills)}
+                        stroke={chartColors.separator}
+                        strokeWidth={StyleSheet.hairlineWidth}
+                      />
+                      {isHottest ? (
+                        <Rect
+                          x={cellX + ringWidth / 2}
+                          y={cellY + ringWidth / 2}
+                          width={cellWidth - ringWidth}
+                          height={CELL_HEIGHT - ringWidth}
+                          rx={cornerRadius}
+                          ry={cornerRadius}
+                          fill="none"
+                          stroke={brandColors.accent}
+                          strokeWidth={ringWidth}
+                        />
+                      ) : null}
+                    </Fragment>
+                  );
+                }),
+              )}
+            </Svg>
+          </View>
+        </View>
+      ) : null}
+
+      {hottestCaption ? (
+        <Text variant="footnote" color={chartColors.secondaryLabel} style={styles.caption}>
+          {hottestCaption}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  headerRow: {
+    flexDirection: 'row',
+    marginBottom: spacing[1],
+  },
+  colLabel: {
+    textAlign: 'center',
+  },
+  body: {
+    flexDirection: 'row',
+  },
+  rowLabel: {
+    flex: 1,
+    textAlignVertical: 'center',
+  },
+  caption: {
+    marginTop: spacing[3],
+  },
+});

--- a/packages/mobile/src/components/you/YouCharts.tsx
+++ b/packages/mobile/src/components/you/YouCharts.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode
 import { Pressable, View, StyleSheet, type GestureResponderEvent, type LayoutChangeEvent } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { BarChart, LineChart } from 'react-native-gifted-charts';
-import type { RawGroupedBar, RawVPointsTimeline } from '@boardsesh/profile-stats';
+import type { RawGroupedBar, RawRunningMaxCeiling, RawVPointsTimeline } from '@boardsesh/profile-stats';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { ActivityIndicator } from '../ActivityIndicator';
@@ -21,7 +21,7 @@ import {
 
 const MAX_X_LABELS = 12;
 const AXIS_LABEL_SIZE = 11;
-const STACK_BAR_RADIUS = 3;
+const STACK_BAR_RADIUS = 4;
 const MIN_ZOOM_SCALE = 1;
 const MAX_ZOOM_SCALE = 2.75;
 // Floor for grouped flash|redpoint bars so a dense V0-V17 axis keeps each bar
@@ -719,6 +719,154 @@ export const TotalAreaChart = memo(function TotalAreaChart({
                   </Text>
                 </View>
               ),
+            }}
+            isAnimated={false}
+            disableScroll={!scrollEnabled}
+          />
+        );
+      }}
+    </ChartFrame>
+  );
+});
+
+type RunningMaxProps = {
+  ceiling: RawRunningMaxCeiling | null;
+  color: string;
+  height?: number;
+  loading?: boolean;
+  emptyLabel?: string;
+  interactive?: boolean;
+  zoomable?: boolean;
+  /** Max x-axis labels before downsampling blanks the rest (wide week labels). */
+  maxXLabels?: number;
+};
+
+/**
+ * "Your ceiling over time" — the trailing running-max grade per week as a single
+ * filled line, with a dashed "best ever" reference line and an end-dot pill
+ * marking the current ceiling (its grade label). The y-values are raw difficulty
+ * ids (non-decreasing), so the axis text is hidden — the curve's rise + the
+ * reference line carry the story. Reuses `TotalAreaChart`'s frame/end-pill grammar.
+ */
+export const RunningMaxLineChart = memo(function RunningMaxLineChart({
+  ceiling,
+  color,
+  height = 170,
+  loading,
+  emptyLabel,
+  interactive = true,
+  zoomable = true,
+  maxXLabels = 6,
+}: RunningMaxProps) {
+  const { chartColors, colorScheme } = useTheme();
+  const { t } = useTranslation('profile');
+  const isEmpty = !ceiling || ceiling.runningMax.length === 0;
+
+  const model = useMemo(() => {
+    if (!ceiling) return null;
+    const { weekLabels, runningMax, bestEverDifficulty, currentLabel } = ceiling;
+    // Headroom above "best ever" so the dashed reference line + the end pill clear
+    // the top edge instead of clipping.
+    const headroom = Math.max(1, Math.round(bestEverDifficulty * 0.08));
+    const maxValue = bestEverDifficulty + headroom;
+    const data = runningMax.map((value, index) => {
+      const isLast = index === runningMax.length - 1;
+      return {
+        value,
+        label: downsampleLabel(index, weekLabels.length, weekLabels[index], maxXLabels),
+        hideDataPoint: !isLast,
+        ...(isLast
+          ? {
+              dataPointColor: color,
+              dataPointRadius: 4,
+              dataPointLabelShiftY: -14,
+              dataPointLabelShiftX: -12,
+              dataPointLabelComponent: () => (
+                <View
+                  style={[
+                    styles.endValuePill,
+                    { backgroundColor: chartColors.elevatedSurface, borderColor: chartColors.separator },
+                  ]}
+                >
+                  <Text variant="caption2" color={chartColors.label} style={styles.endValueText}>
+                    {currentLabel}
+                  </Text>
+                </View>
+              ),
+            }
+          : {}),
+      };
+    });
+    return { data, maxValue, bestEverDifficulty, pointCount: weekLabels.length };
+  }, [ceiling, color, maxXLabels, chartColors.elevatedSurface, chartColors.separator, chartColors.label]);
+
+  return (
+    <ChartFrame
+      height={height}
+      loading={loading}
+      isEmpty={isEmpty}
+      emptyLabel={emptyLabel}
+      zoomable={interactive && zoomable}
+    >
+      {(width, zoomScale, scrollEnabled) => {
+        if (!model) return null;
+        const baseSpacing = Math.max(1, Math.floor((width - 16) / Math.max(1, model.pointCount - 1)));
+        const lineSpacing = Math.max(1, Math.round(baseSpacing * zoomScale));
+        const labelStep = model.pointCount > maxXLabels ? Math.ceil(model.pointCount / maxXLabels) : 1;
+        const labelBudget = labelStep * lineSpacing;
+        const sizedData = model.data.map((point) =>
+          point.label
+            ? {
+                ...point,
+                labelComponent: () => (
+                  <Text
+                    variant="caption2"
+                    color={chartColors.tertiaryLabel}
+                    style={[styles.lineAxisLabel, { width: labelBudget }]}
+                    numberOfLines={1}
+                  >
+                    {point.label}
+                  </Text>
+                ),
+              }
+            : point,
+        );
+        return (
+          <LineChart
+            areaChart
+            data={sizedData}
+            width={width - 16}
+            height={height - 28}
+            spacing={lineSpacing}
+            initialSpacing={4}
+            endSpacing={spacing[4]}
+            color={color}
+            startFillColor={color}
+            endFillColor={color}
+            startOpacity={colorScheme === 'dark' ? 0.4 : 0.28}
+            endOpacity={colorScheme === 'dark' ? 0.08 : 0.03}
+            gradientDirection="vertical"
+            thickness={2}
+            curved
+            curvature={0.2}
+            maxValue={model.maxValue}
+            noOfSections={4}
+            hideYAxisText
+            yAxisThickness={0}
+            xAxisThickness={StyleSheet.hairlineWidth}
+            xAxisColor={chartColors.separator}
+            hideRules
+            yAxisTextStyle={{ color: chartColors.tertiaryLabel, fontSize: AXIS_LABEL_SIZE }}
+            xAxisLabelTextStyle={{ color: chartColors.tertiaryLabel, fontSize: AXIS_LABEL_SIZE }}
+            showReferenceLine1
+            referenceLine1Position={model.bestEverDifficulty}
+            referenceLine1Config={{
+              color: chartColors.separator,
+              dashWidth: 4,
+              dashGap: 4,
+              thickness: 1,
+              labelText: t('charts.bestEver'),
+              labelTextStyle: { color: chartColors.tertiaryLabel, fontSize: AXIS_LABEL_SIZE },
             }}
             isAnimated={false}
             disableScroll={!scrollEnabled}

--- a/packages/mobile/src/components/you/heatmap-intensity.ts
+++ b/packages/mobile/src/components/you/heatmap-intensity.ts
@@ -1,0 +1,43 @@
+import { blendOpaque } from '../../theme/colors';
+
+type ColorSchemeName = 'light' | 'dark';
+
+// Four-step intensity ramp: a busy day climbs from 40% → 100% of the accent
+// composited over the card surface. Shared by the activity calendar and the
+// wall-rhythm grid so the two heatmaps read as siblings.
+export const INTENSITY_STEPS = [0.4, 0.6, 0.8, 1] as const;
+// Opaque-composite alphas for the empty floor (kept faint, scheme-tuned).
+const EMPTY_FLOOR_ALPHA_DARK = 0.14;
+const EMPTY_FLOOR_ALPHA_LIGHT = 0.08;
+
+/** The empty-cell floor + the four lit steps, as opaque `#RRGGBB` fills. */
+export type IntensityFills = {
+  emptyFill: string;
+  stepFills: string[];
+};
+
+/**
+ * Build the heatmap intensity ramp by alpha-compositing `primaryHex` over
+ * `surfaceHex` at the empty-floor + four step alphas. Both inputs MUST be plain
+ * hex (chart accent + secondary background) so the result stays an opaque hex a
+ * react-native-svg `fill` / RN `backgroundColor` can take — never a PlatformColor.
+ */
+export function buildIntensityFills(primaryHex: string, surfaceHex: string, scheme: ColorSchemeName): IntensityFills {
+  const floorAlpha = scheme === 'dark' ? EMPTY_FLOOR_ALPHA_DARK : EMPTY_FLOOR_ALPHA_LIGHT;
+  return {
+    emptyFill: blendOpaque(primaryHex, surfaceHex, floorAlpha),
+    stepFills: INTENSITY_STEPS.map((step) => blendOpaque(primaryHex, surfaceHex, step)),
+  };
+}
+
+/**
+ * Map a cell `count` to its fill: the empty floor at 0, otherwise the step whose
+ * band the count/`maxCount` ratio falls into (ceil so a single ascent always
+ * lights the lowest step rather than rounding to empty).
+ */
+export function colorForCount(count: number, maxCount: number, fills: IntensityFills): string {
+  if (count <= 0 || maxCount <= 0) return fills.emptyFill;
+  const ratio = count / maxCount;
+  const stepIndex = Math.min(fills.stepFills.length - 1, Math.max(0, Math.ceil(ratio * fills.stepFills.length) - 1));
+  return fills.stepFills[stepIndex];
+}

--- a/packages/mobile/src/components/you/profile-chart-colors.ts
+++ b/packages/mobile/src/components/you/profile-chart-colors.ts
@@ -134,6 +134,18 @@ export function gradeBadgeColor(gradeLabel: string | null | undefined): string {
   return getGradeColor(gradeLabel) ?? DEFAULT_GRADE_COLOR;
 }
 
+/**
+ * The "Your angle" bar colour: an angle is tinted by the grade hue of its
+ * hardest send (a V8-at-40° bar gets the V8 colour). Plain vivid hex via
+ * `gradeBadgeColor` so the SVG `Defs/LinearGradient` stops never receive a
+ * PlatformColor (which would crash react-native-svg). `scheme` is accepted for
+ * symmetry with the other chart-colour helpers; the badge palette is scheme-
+ * independent so it goes unused.
+ */
+export function angleChartColor(maxGradeLabel: string | null | undefined, _scheme: ColorSchemeName = 'light'): string {
+  return gradeBadgeColor(maxGradeLabel);
+}
+
 export type SessionGradeBarsOptions =
   | {
       /**

--- a/packages/shared/i18n/locales/en-US/profile.json
+++ b/packages/shared/i18n/locales/en-US/profile.json
@@ -103,7 +103,78 @@
     "streakA11y": "{{count}}-week streak, best {{best}} weeks",
     "biggestFightA11y": "Biggest fight: {{count}}-try send at {{grade}}",
     "benchmarksA11y": "{{count}} benchmarks sent, hardest {{grade}}",
-    "activeDaysA11y": "{{count}} active days this month, {{delta}}"
+    "activeDaysA11y": "{{count}} active days this month, {{delta}}",
+    "streakBestWeeks_one": "best {{count}} wk",
+    "streakBestWeeks_other": "best {{count}} wks"
+  },
+  "sections": {
+    "biggestFights": "Biggest fights",
+    "gradePyramid": "Grade pyramid",
+    "yourAngle": "By wall angle",
+    "wallRhythm": "Wall rhythm",
+    "ceilingOverTime": "Ceiling over time",
+    "gradeMilestones": "Grade milestones"
+  },
+  "charts": {
+    "nextProject": "One more {{grade}} fills the gap",
+    "homeAngle": "home angle",
+    "bestEver": "best ever",
+    "angleUnit": "{{angle}}°",
+    "triesPill_one": "{{count}} try",
+    "triesPill_other": "{{count}} tries",
+    "wallRhythmCaption": "Most active {{weekday}} {{timeOfDay}}s",
+    "milestoneDate": "{{month}} '{{year}}",
+    "projectingA11y": "Tries per send",
+    "biggestProjectA11y": "Biggest project: {{grade}}, {{count}} tries",
+    "angleA11y": "Hardest grade by wall angle",
+    "wallRhythmA11y": "Climbing by weekday and time of day",
+    "ceilingA11y": "Hardest grade each week, now {{grade}}",
+    "milestonesA11y": "First send at each grade",
+    "milestoneA11y": "First {{grade}} in {{date}}",
+    "weekday": {
+      "mon": "Mon",
+      "tue": "Tue",
+      "wed": "Wed",
+      "thu": "Thu",
+      "fri": "Fri",
+      "sat": "Sat",
+      "sun": "Sun"
+    },
+    "weekdayFull": {
+      "mon": "Monday",
+      "tue": "Tuesday",
+      "wed": "Wednesday",
+      "thu": "Thursday",
+      "fri": "Friday",
+      "sat": "Saturday",
+      "sun": "Sunday"
+    },
+    "block": {
+      "morning": "Morning",
+      "midday": "Midday",
+      "evening": "Eve",
+      "night": "Night"
+    },
+    "timeOfDay": {
+      "morning": "morning",
+      "midday": "midday",
+      "evening": "evening",
+      "night": "night"
+    },
+    "month": {
+      "jan": "Jan",
+      "feb": "Feb",
+      "mar": "Mar",
+      "apr": "Apr",
+      "may": "May",
+      "jun": "Jun",
+      "jul": "Jul",
+      "aug": "Aug",
+      "sep": "Sep",
+      "oct": "Oct",
+      "nov": "Nov",
+      "dec": "Dec"
+    }
   },
   "empty": {
     "userNotFound": "User not found",

--- a/packages/shared/i18n/locales/es/profile.json
+++ b/packages/shared/i18n/locales/es/profile.json
@@ -103,7 +103,78 @@
     "streakA11y": "racha de {{count}} semanas, mejor {{best}} semanas",
     "biggestFightA11y": "Mayor pelea: encadene de {{count}} intentos en {{grade}}",
     "benchmarksA11y": "{{count}} benchmarks encadenados, el más difícil {{grade}}",
-    "activeDaysA11y": "{{count}} días activos este mes, {{delta}}"
+    "activeDaysA11y": "{{count}} días activos este mes, {{delta}}",
+    "streakBestWeeks_one": "mejor {{count}} sem",
+    "streakBestWeeks_other": "mejor {{count}} sem"
+  },
+  "sections": {
+    "biggestFights": "Mayores peleas",
+    "gradePyramid": "Pirámide de grados",
+    "yourAngle": "Por ángulo de pared",
+    "wallRhythm": "Ritmo en el muro",
+    "ceilingOverTime": "Techo a lo largo del tiempo",
+    "gradeMilestones": "Hitos por grado"
+  },
+  "charts": {
+    "nextProject": "Un {{grade}} más cierra el hueco",
+    "homeAngle": "ángulo habitual",
+    "bestEver": "mejor histórico",
+    "angleUnit": "{{angle}}°",
+    "triesPill_one": "{{count}} intento",
+    "triesPill_other": "{{count}} intentos",
+    "wallRhythmCaption": "Más activo los {{weekday}} por la {{timeOfDay}}",
+    "milestoneDate": "{{month}} '{{year}}",
+    "projectingA11y": "Intentos por encadene",
+    "biggestProjectA11y": "Mayor proyecto: {{grade}}, {{count}} intentos",
+    "angleA11y": "Grado más difícil por ángulo de pared",
+    "wallRhythmA11y": "Escalada por día de la semana y momento del día",
+    "ceilingA11y": "Grado más difícil cada semana, ahora {{grade}}",
+    "milestonesA11y": "Primer encadene en cada grado",
+    "milestoneA11y": "Primer {{grade}} en {{date}}",
+    "weekday": {
+      "mon": "lun",
+      "tue": "mar",
+      "wed": "mié",
+      "thu": "jue",
+      "fri": "vie",
+      "sat": "sáb",
+      "sun": "dom"
+    },
+    "weekdayFull": {
+      "mon": "lunes",
+      "tue": "martes",
+      "wed": "miércoles",
+      "thu": "jueves",
+      "fri": "viernes",
+      "sat": "sábado",
+      "sun": "domingo"
+    },
+    "block": {
+      "morning": "Mañana",
+      "midday": "Mediodía",
+      "evening": "Tarde",
+      "night": "Noche"
+    },
+    "timeOfDay": {
+      "morning": "mañana",
+      "midday": "mediodía",
+      "evening": "tarde",
+      "night": "noche"
+    },
+    "month": {
+      "jan": "ene",
+      "feb": "feb",
+      "mar": "mar",
+      "apr": "abr",
+      "may": "may",
+      "jun": "jun",
+      "jul": "jul",
+      "aug": "ago",
+      "sep": "sep",
+      "oct": "oct",
+      "nov": "nov",
+      "dec": "dic"
+    }
   },
   "empty": {
     "userNotFound": "Usuario no encontrado",

--- a/packages/shared/i18n/locales/fr/profile.json
+++ b/packages/shared/i18n/locales/fr/profile.json
@@ -103,7 +103,78 @@
     "streakA11y": "série de {{count}} semaines, record {{best}} semaines",
     "biggestFightA11y": "Plus gros combat : enchaînement en {{count}} essais à {{grade}}",
     "benchmarksA11y": "{{count}} références enchaînées, la plus dure {{grade}}",
-    "activeDaysA11y": "{{count}} jours actifs ce mois-ci, {{delta}}"
+    "activeDaysA11y": "{{count}} jours actifs ce mois-ci, {{delta}}",
+    "streakBestWeeks_one": "record {{count}} sem",
+    "streakBestWeeks_other": "record {{count}} sem"
+  },
+  "sections": {
+    "biggestFights": "Plus gros combats",
+    "gradePyramid": "Pyramide de cotations",
+    "yourAngle": "Par inclinaison de mur",
+    "wallRhythm": "Rythme au mur",
+    "ceilingOverTime": "Plafond dans le temps",
+    "gradeMilestones": "Jalons par cotation"
+  },
+  "charts": {
+    "nextProject": "Un {{grade}} de plus comble le trou",
+    "homeAngle": "inclinaison habituelle",
+    "bestEver": "record absolu",
+    "angleUnit": "{{angle}}°",
+    "triesPill_one": "{{count}} essai",
+    "triesPill_other": "{{count}} essais",
+    "wallRhythmCaption": "Plus actif le {{weekday}} en {{timeOfDay}}",
+    "milestoneDate": "{{month}} '{{year}}",
+    "projectingA11y": "Essais par enchaînement",
+    "biggestProjectA11y": "Plus gros projet : {{grade}}, {{count}} essais",
+    "angleA11y": "Cotation la plus dure par inclinaison de mur",
+    "wallRhythmA11y": "Grimpe par jour de la semaine et moment de la journée",
+    "ceilingA11y": "Cotation la plus dure chaque semaine, maintenant {{grade}}",
+    "milestonesA11y": "Premier enchaînement à chaque cotation",
+    "milestoneA11y": "Premier {{grade}} en {{date}}",
+    "weekday": {
+      "mon": "lun",
+      "tue": "mar",
+      "wed": "mer",
+      "thu": "jeu",
+      "fri": "ven",
+      "sat": "sam",
+      "sun": "dim"
+    },
+    "weekdayFull": {
+      "mon": "lundi",
+      "tue": "mardi",
+      "wed": "mercredi",
+      "thu": "jeudi",
+      "fri": "vendredi",
+      "sat": "samedi",
+      "sun": "dimanche"
+    },
+    "block": {
+      "morning": "Matin",
+      "midday": "Midi",
+      "evening": "Soir",
+      "night": "Nuit"
+    },
+    "timeOfDay": {
+      "morning": "matin",
+      "midday": "midi",
+      "evening": "soir",
+      "night": "nuit"
+    },
+    "month": {
+      "jan": "janv",
+      "feb": "févr",
+      "mar": "mars",
+      "apr": "avr",
+      "may": "mai",
+      "jun": "juin",
+      "jul": "juil",
+      "aug": "août",
+      "sep": "sept",
+      "oct": "oct",
+      "nov": "nov",
+      "dec": "déc"
+    }
   },
   "empty": {
     "userNotFound": "Utilisateur introuvable",

--- a/packages/shared/profile-stats/src/__tests__/deep-chart-builders.test.ts
+++ b/packages/shared/profile-stats/src/__tests__/deep-chart-builders.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import dayjs from 'dayjs';
+import {
+  buildAngleBreakdown,
+  buildWallRhythm,
+  findNextProjectGrade,
+  buildRunningMaxCeiling,
+  buildGradeMilestones,
+} from '../chart-builders';
+import type { LogbookEntry } from '../types';
+
+// TODAY is an ISO-week Monday (see dashboard-builders.test). toISOString round-trips
+// the local instant through parseTickTime (utc→local) in any TZ.
+const TODAY = dayjs('2026-06-15T12:00:00');
+const iso = (d: dayjs.Dayjs): string => d.toISOString();
+
+function entry(overrides: Partial<LogbookEntry> = {}): LogbookEntry {
+  return { climbed_at: iso(TODAY), difficulty: 16, tries: 1, angle: 40, status: 'send', ...overrides };
+}
+
+describe('buildAngleBreakdown', () => {
+  it('hides angles under 5 sends, tracks max grade, sorts steep→slab, finds home angle', () => {
+    const logbook = [
+      ...Array.from({ length: 5 }, () => entry({ angle: 40, difficulty: 16 })),
+      entry({ angle: 40, difficulty: 22 }), // 6th @40°, max V6
+      ...Array.from({ length: 5 }, () => entry({ angle: 50, difficulty: 16 })), // 5 @50°, max V3
+      ...Array.from({ length: 3 }, () => entry({ angle: 30, difficulty: 16 })), // hidden (<5)
+    ];
+    const result = buildAngleBreakdown(logbook, 'v-grade');
+    expect(result).not.toBeNull();
+    expect(result!.rows.map((r) => r.angle)).toEqual([50, 40]); // steep → slab
+    expect(result!.rows.find((r) => r.angle === 40)!.maxLabel).toBe('V6');
+    expect(result!.homeAngle).toBe(40); // 6 sends > 5
+    expect(result!.maxSendCount).toBe(6);
+  });
+
+  it('excludes attempts and returns null with no qualifying angle', () => {
+    const logbook = [entry({ angle: 40, status: 'attempt' }), entry({ angle: 45, difficulty: 16 })];
+    expect(buildAngleBreakdown(logbook, 'v-grade')).toBeNull();
+  });
+});
+
+describe('buildWallRhythm', () => {
+  it('buckets by weekday × time block and finds the hottest cell', () => {
+    const tuesdayEve = TODAY.add(1, 'day').hour(19); // Tue (weekday idx 1), evening (block 2)
+    const logbook = [
+      entry({ climbed_at: iso(tuesdayEve) }),
+      entry({ climbed_at: iso(tuesdayEve.minute(30)) }),
+      entry({ climbed_at: iso(tuesdayEve.hour(20)) }),
+      entry({ climbed_at: iso(TODAY.hour(8)) }), // Mon morning (0,0)
+    ];
+    const result = buildWallRhythm(logbook);
+    expect(result).not.toBeNull();
+    expect(result!.total).toBe(4);
+    expect(result!.matrix[1][2]).toBe(3); // Tue evening
+    expect(result!.matrix[0][0]).toBe(1); // Mon morning
+    expect(result!.hottest).toEqual({ weekday: 1, block: 2 });
+    expect(result!.max).toBe(3);
+  });
+
+  it('returns null with no entries', () => {
+    expect(buildWallRhythm([])).toBeNull();
+  });
+});
+
+describe('findNextProjectGrade', () => {
+  it('picks the thinnest sent grade above the modal grade', () => {
+    const logbook = [
+      ...Array.from({ length: 5 }, () => entry({ difficulty: 16 })), // V3 modal
+      entry({ difficulty: 22 }), // V6 ×1 (thinnest above modal)
+      ...Array.from({ length: 3 }, () => entry({ difficulty: 28 })), // V11 ×3
+    ];
+    expect(findNextProjectGrade(logbook, 'v-grade')).toEqual({ difficulty: 22, label: 'V6' });
+  });
+
+  it('returns null when nothing is harder than the modal grade', () => {
+    expect(findNextProjectGrade([entry({ difficulty: 16 }), entry({ difficulty: 16 })], 'v-grade')).toBeNull();
+  });
+});
+
+describe('buildRunningMaxCeiling', () => {
+  it('produces a non-decreasing running max with best-ever + current labels', () => {
+    const logbook = [
+      entry({ climbed_at: iso(TODAY.subtract(2, 'week')), difficulty: 16 }), // V3
+      entry({ climbed_at: iso(TODAY.subtract(1, 'week')), difficulty: 22 }), // V6
+      entry({ climbed_at: iso(TODAY), difficulty: 16 }), // V3 again — max holds at V6
+    ];
+    const result = buildRunningMaxCeiling(logbook, 'v-grade');
+    expect(result).not.toBeNull();
+    expect(result!.runningMax).toEqual([16, 22, 22]);
+    expect(result!.bestEverLabel).toBe('V6');
+    expect(result!.currentLabel).toBe('V6');
+  });
+
+  it('returns null with no sends', () => {
+    expect(buildRunningMaxCeiling([entry({ status: 'attempt' })], 'v-grade')).toBeNull();
+  });
+});
+
+describe('buildGradeMilestones', () => {
+  it('keeps the earliest send per grade band, sorted by grade', () => {
+    const logbook = [
+      entry({ climbed_at: iso(TODAY.subtract(10, 'day')), difficulty: 22 }), // V6 later
+      entry({ climbed_at: iso(TODAY.subtract(40, 'day')), difficulty: 22 }), // V6 first
+      entry({ climbed_at: iso(TODAY.subtract(20, 'day')), difficulty: 16 }), // V3
+    ];
+    const milestones = buildGradeMilestones(logbook, 'v-grade');
+    expect(milestones.map((m) => m.label)).toEqual(['V3', 'V6']); // grade-ascending
+    expect(milestones.find((m) => m.label === 'V6')!.date).toBe(TODAY.subtract(40, 'day').format('YYYY-MM-DD'));
+  });
+
+  it('is empty with no sends', () => {
+    expect(buildGradeMilestones([entry({ status: 'attempt' })], 'v-grade')).toEqual([]);
+  });
+});

--- a/packages/shared/profile-stats/src/chart-builders.ts
+++ b/packages/shared/profile-stats/src/chart-builders.ts
@@ -26,6 +26,12 @@ import type {
   RawActiveDaysDelta,
   RawLastSendGap,
   RawBenchmarkSummary,
+  RawAngleBreakdown,
+  RawAngleRow,
+  RawWallRhythm,
+  RawNextProject,
+  RawRunningMaxCeiling,
+  RawGradeMilestone,
 } from './types';
 
 dayjs.extend(isoWeek);
@@ -735,4 +741,231 @@ export function buildBenchmarkSummary(
     hardestDifficulty,
     hardestLabel: hardestDifficulty != null ? (mapping[hardestDifficulty] ?? `${hardestDifficulty}`) : null,
   };
+}
+
+// ── Deep-chart sections (PR2) ───────────────────────────────────────
+
+function isSend(entry: LogbookEntry): boolean {
+  return entry.status === 'send' || entry.status === 'flash';
+}
+
+const MIN_ANGLE_SENDS = 5;
+
+/**
+ * Max grade sent at each angle + the send volume there, steep→slab. Angles with
+ * fewer than 5 sends are hidden (too thin to read). `homeAngle` is the
+ * highest-volume angle ("you live at 40°"). Sent climbs only.
+ */
+export function buildAngleBreakdown(
+  filteredLogbook: LogbookEntry[],
+  gradeFormat: GradeDisplayFormat = 'v-grade',
+): RawAngleBreakdown | null {
+  const mapping = getDifficultyMapping(gradeFormat);
+  const byAngle = new Map<number, { maxDifficulty: number; sendCount: number }>();
+
+  for (const entry of filteredLogbook) {
+    if (!isSend(entry) || entry.angle == null) continue;
+    const gradeId = gradeIdForEntry(entry);
+    if (gradeId == null) continue;
+    const current = byAngle.get(entry.angle) ?? { maxDifficulty: -1, sendCount: 0 };
+    current.sendCount += 1;
+    if (gradeId > current.maxDifficulty) current.maxDifficulty = gradeId;
+    byAngle.set(entry.angle, current);
+  }
+
+  const rows: RawAngleRow[] = [];
+  for (const [angle, stats] of byAngle) {
+    if (stats.sendCount < MIN_ANGLE_SENDS || stats.maxDifficulty < 0) continue;
+    rows.push({
+      angle,
+      maxDifficulty: stats.maxDifficulty,
+      maxLabel: mapping[stats.maxDifficulty] ?? `${stats.maxDifficulty}`,
+      sendCount: stats.sendCount,
+    });
+  }
+  if (rows.length === 0) return null;
+
+  rows.sort((a, b) => b.angle - a.angle); // steep → slab
+  const maxSendCount = rows.reduce((max, row) => Math.max(max, row.sendCount), 0);
+  const maxDifficulty = rows.reduce((max, row) => Math.max(max, row.maxDifficulty), 0);
+  // Home angle = highest volume (ties → steeper, since rows are steep-first).
+  const homeAngle =
+    rows.reduce<RawAngleRow | null>((best, row) => (best == null || row.sendCount > best.sendCount ? row : best), null)
+      ?.angle ?? null;
+
+  return { rows, maxSendCount, maxDifficulty, homeAngle };
+}
+
+const RHYTHM_WEEKDAYS = 7;
+const RHYTHM_BLOCKS = 4;
+
+/** Local-time block for an hour: 0 morning, 1 midday, 2 evening, 3 night. */
+function timeBlock(hour: number): number {
+  if (hour >= 5 && hour < 11) return 0;
+  if (hour >= 11 && hour < 17) return 1;
+  if (hour >= 17 && hour < 22) return 2;
+  return 3;
+}
+
+/**
+ * Weekday × time-of-day rhythm. Every logged entry counts (showing up), bucketed
+ * by local weekday (Mon=0..Sun=6) and time block. `hottest` is the busiest cell
+ * ("you climb most Tuesday evenings").
+ */
+export function buildWallRhythm(filteredLogbook: LogbookEntry[]): RawWallRhythm | null {
+  const matrix: number[][] = Array.from({ length: RHYTHM_WEEKDAYS }, () =>
+    Array.from({ length: RHYTHM_BLOCKS }, () => 0),
+  );
+  let total = 0;
+  let max = 0;
+  let hottest: { weekday: number; block: number } | null = null;
+
+  for (const entry of filteredLogbook) {
+    const time = parseTickTime(entry.climbed_at);
+    const weekday = time.isoWeekday() - 1; // 1..7 (Mon..Sun) → 0..6
+    const block = timeBlock(time.hour());
+    matrix[weekday][block] += 1;
+    total += 1;
+    if (matrix[weekday][block] > max) {
+      max = matrix[weekday][block];
+      hottest = { weekday, block };
+    }
+  }
+
+  if (total === 0) return null;
+  return { matrix, max, total, hottest };
+}
+
+/**
+ * The thin grade just above the climber's modal sent grade — "one more {grade}
+ * fills the gap". Among sent grades harder than the most-common grade, picks the
+ * one with the fewest sends. Null when there's nothing above the wheelhouse.
+ */
+export function findNextProjectGrade(
+  filteredLogbook: LogbookEntry[],
+  gradeFormat: GradeDisplayFormat = 'v-grade',
+): RawNextProject {
+  const mapping = getDifficultyMapping(gradeFormat);
+  const countByDifficulty = new Map<number, number>();
+  for (const entry of filteredLogbook) {
+    if (!isSend(entry)) continue;
+    const gradeId = gradeIdForEntry(entry);
+    if (gradeId == null || !mapping[gradeId]) continue;
+    countByDifficulty.set(gradeId, (countByDifficulty.get(gradeId) ?? 0) + 1);
+  }
+  if (countByDifficulty.size === 0) return null;
+
+  let modalDifficulty = -1;
+  let modalCount = -1;
+  for (const [difficulty, count] of countByDifficulty) {
+    if (count > modalCount || (count === modalCount && difficulty > modalDifficulty)) {
+      modalCount = count;
+      modalDifficulty = difficulty;
+    }
+  }
+
+  let pick: { difficulty: number; count: number } | null = null;
+  for (const [difficulty, count] of countByDifficulty) {
+    if (difficulty <= modalDifficulty) continue;
+    if (pick == null || count < pick.count || (count === pick.count && difficulty < pick.difficulty)) {
+      pick = { difficulty, count };
+    }
+  }
+  if (pick == null) return null;
+  return { difficulty: pick.difficulty, label: mapping[pick.difficulty] ?? `${pick.difficulty}` };
+}
+
+const CEILING_MAX_WEEKS = 104;
+
+/**
+ * Running-max grade per ISO week — "are you getting stronger?". The line never
+ * decreases (it's a cumulative max of effective difficulty over sent climbs).
+ * Lifetime/board-scoped (pass the board-scoped ticks, not the timeframe-filtered
+ * set). Null when the climber has no sends.
+ */
+export function buildRunningMaxCeiling(
+  boardScopedTicks: LogbookEntry[],
+  gradeFormat: GradeDisplayFormat = 'v-grade',
+): RawRunningMaxCeiling | null {
+  const mapping = getDifficultyMapping(gradeFormat);
+  const sends = boardScopedTicks
+    .filter((entry) => isSend(entry) && gradeIdForEntry(entry) != null)
+    .sort((a, b) => tickTimeMs(a.climbed_at) - tickTimeMs(b.climbed_at));
+  if (sends.length === 0) return null;
+
+  // Max difficulty per ISO week.
+  const weekMax = new Map<string, number>();
+  for (const entry of sends) {
+    const gradeId = gradeIdForEntry(entry)!;
+    const time = parseTickTime(entry.climbed_at);
+    const key = `${time.isoWeekYear()}-W${time.isoWeek()}`;
+    weekMax.set(key, Math.max(weekMax.get(key) ?? -1, gradeId));
+  }
+
+  const first = parseTickTime(sends[0].climbed_at).startOf('isoWeek');
+  const last = parseTickTime(sends[sends.length - 1].climbed_at).endOf('isoWeek');
+  const allWeekKeys: string[] = [];
+  let cursor = first;
+  while (cursor.isBefore(last) || cursor.isSame(last, 'day')) {
+    allWeekKeys.push(`${cursor.isoWeekYear()}-W${cursor.isoWeek()}`);
+    cursor = cursor.add(1, 'week');
+  }
+
+  // Carry the running max forward across (possibly skipped) weeks.
+  let cumulativeMax = -1;
+  const fullRunning = allWeekKeys.map((key) => {
+    const value = weekMax.get(key);
+    if (value != null && value > cumulativeMax) cumulativeMax = value;
+    return cumulativeMax;
+  });
+
+  // Cap to the most recent weeks; the carried max means the window opens at the
+  // running-max as of its first week (no artificial drop).
+  const keptKeys = allWeekKeys.length > CEILING_MAX_WEEKS ? allWeekKeys.slice(-CEILING_MAX_WEEKS) : allWeekKeys;
+  const runningMax = fullRunning.slice(-keptKeys.length);
+
+  const spansYears = keptKeys.length > 1 && keptKeys[0].split('-')[0] !== keptKeys[keptKeys.length - 1].split('-')[0];
+  const weekLabels = keptKeys.map((key) => {
+    const [year, weekPart] = key.split('-');
+    return spansYears ? `${weekPart} '${year.slice(2)}` : weekPart;
+  });
+
+  const bestEverDifficulty = cumulativeMax;
+  return {
+    weekLabels,
+    runningMax,
+    bestEverDifficulty,
+    bestEverLabel: mapping[bestEverDifficulty] ?? `${bestEverDifficulty}`,
+    currentLabel: mapping[runningMax[runningMax.length - 1]] ?? `${runningMax[runningMax.length - 1]}`,
+  };
+}
+
+/**
+ * First-send date per grade band — the progression timeline ("first V5 · Mar
+ * '24"). Lifetime/board-scoped. Dedups to one entry per grade LABEL (multiple
+ * difficulty ids collapse to the same V-grade), keeping the earliest send.
+ */
+export function buildGradeMilestones(
+  boardScopedTicks: LogbookEntry[],
+  gradeFormat: GradeDisplayFormat = 'v-grade',
+): RawGradeMilestone[] {
+  const mapping = getDifficultyMapping(gradeFormat);
+  const byLabel = new Map<string, { difficulty: number; ms: number; date: string }>();
+
+  for (const entry of boardScopedTicks) {
+    if (!isSend(entry)) continue;
+    const gradeId = gradeIdForEntry(entry);
+    if (gradeId == null) continue;
+    const label = mapping[gradeId];
+    if (!label) continue;
+    const ms = tickTimeMs(entry.climbed_at);
+    const existing = byLabel.get(label);
+    if (!existing || ms < existing.ms) {
+      byLabel.set(label, { difficulty: gradeId, ms, date: parseTickTime(entry.climbed_at).format('YYYY-MM-DD') });
+    }
+  }
+
+  return Array.from(byLabel.entries())
+    .map(([label, info]) => ({ difficulty: info.difficulty, label, date: info.date }))
+    .sort((a, b) => a.difficulty - b.difficulty);
 }

--- a/packages/shared/profile-stats/src/derive-view-model.ts
+++ b/packages/shared/profile-stats/src/derive-view-model.ts
@@ -12,6 +12,11 @@ import {
   buildActiveDaysMoM,
   buildLastSendGap,
   buildBenchmarkSummary,
+  buildAngleBreakdown,
+  buildWallRhythm,
+  findNextProjectGrade,
+  buildRunningMaxCeiling,
+  buildGradeMilestones,
 } from './chart-builders';
 import { getDifficultyMapping } from './grade-mapping';
 import type {
@@ -30,6 +35,11 @@ import type {
   RawActiveDaysDelta,
   RawLastSendGap,
   RawBenchmarkSummary,
+  RawAngleBreakdown,
+  RawWallRhythm,
+  RawNextProject,
+  RawRunningMaxCeiling,
+  RawGradeMilestone,
 } from './types';
 
 export type DeriveProfileViewModelInput = {
@@ -64,6 +74,14 @@ export type ProfileViewModel = {
   activeDaysDelta: RawActiveDaysDelta;
   lastSendGap: RawLastSendGap;
   benchmarkSummary: RawBenchmarkSummary;
+  // ── Deep-chart sections (PR2). Angle/rhythm/next-project follow the timeframe
+  // filter (detailed charts); ceiling + milestones are lifetime progression
+  // (board-scoped, all-time) like the hero's hardestSend.
+  angleBreakdown: RawAngleBreakdown | null;
+  wallRhythm: RawWallRhythm | null;
+  nextProjectGrade: RawNextProject;
+  runningMaxCeiling: RawRunningMaxCeiling | null;
+  gradeMilestones: RawGradeMilestone[];
 };
 
 /**
@@ -124,6 +142,13 @@ export function deriveProfileViewModel(input: DeriveProfileViewModelInput): Prof
   const lastSendGap = buildLastSendGap(boardScopedTicks);
   const benchmarkSummary = buildBenchmarkSummary(boardScopedTicks, gradeFormat);
 
+  // Deep-chart sections.
+  const angleBreakdown = buildAngleBreakdown(filteredLogbook, gradeFormat);
+  const wallRhythm = buildWallRhythm(filteredLogbook);
+  const nextProjectGrade = findNextProjectGrade(filteredLogbook, gradeFormat);
+  const runningMaxCeiling = buildRunningMaxCeiling(boardScopedTicks, gradeFormat);
+  const gradeMilestones = buildGradeMilestones(boardScopedTicks, gradeFormat);
+
   return {
     filteredLogbook,
     weeklyBars,
@@ -139,6 +164,11 @@ export function deriveProfileViewModel(input: DeriveProfileViewModelInput): Prof
     activeDaysDelta,
     lastSendGap,
     benchmarkSummary,
+    angleBreakdown,
+    wallRhythm,
+    nextProjectGrade,
+    runningMaxCeiling,
+    gradeMilestones,
   };
 }
 

--- a/packages/shared/profile-stats/src/index.ts
+++ b/packages/shared/profile-stats/src/index.ts
@@ -18,6 +18,11 @@ export {
   buildActiveDaysMoM,
   buildLastSendGap,
   buildBenchmarkSummary,
+  buildAngleBreakdown,
+  buildWallRhythm,
+  findNextProjectGrade,
+  buildRunningMaxCeiling,
+  buildGradeMilestones,
 } from './chart-builders';
 export { difficultyMapping, getDifficultyMapping, sortGrades } from './grade-mapping';
 export {

--- a/packages/shared/profile-stats/src/types.ts
+++ b/packages/shared/profile-stats/src/types.ts
@@ -214,3 +214,59 @@ export type RawBenchmarkSummary = {
   hardestDifficulty: number | null;
   hardestLabel: string | null;
 };
+
+// ── Deep-chart sections (PR2) ───────────────────────────────────────
+
+/** One angle's max grade + send volume, for the "Your angle" chart. */
+export type RawAngleRow = {
+  angle: number;
+  maxDifficulty: number;
+  maxLabel: string;
+  sendCount: number;
+};
+
+/** Max-grade-by-angle, steep→slab. `homeAngle` is the highest-volume angle. */
+export type RawAngleBreakdown = {
+  rows: RawAngleRow[];
+  /** Highest sendCount across rows — for scaling the volume track. */
+  maxSendCount: number;
+  /** Highest maxDifficulty across rows — for scaling the grade bars. */
+  maxDifficulty: number;
+  homeAngle: number | null;
+};
+
+/**
+ * Weekday × time-of-day climbing rhythm. `matrix[weekday][block]` where weekday
+ * is 0=Mon..6=Sun and block is 0=morning,1=midday,2=evening,3=night.
+ */
+export type RawWallRhythm = {
+  matrix: number[][];
+  max: number;
+  total: number;
+  /** Busiest cell, or null when there's no activity. */
+  hottest: { weekday: number; block: number } | null;
+};
+
+/** The thin grade just above the climber's modal grade — the "next project". */
+export type RawNextProject = {
+  difficulty: number;
+  label: string;
+} | null;
+
+/** Trailing running-max grade per week — "your ceiling over time". */
+export type RawRunningMaxCeiling = {
+  weekLabels: string[];
+  /** Running-max effective difficulty per week (non-decreasing). */
+  runningMax: number[];
+  bestEverDifficulty: number;
+  bestEverLabel: string;
+  currentLabel: string;
+};
+
+/** First-send date for one grade band — a progression milestone. */
+export type RawGradeMilestone = {
+  difficulty: number;
+  label: string;
+  /** Local calendar date of the first send at this grade, `YYYY-MM-DD`. */
+  date: string;
+};


### PR DESCRIPTION
## Summary

**Stacked on #3308 (PR 2 of 3).** Adds the data-rich chart sections below the hero/glance grid and restyles the existing charts. Base branch is `mobile/you-progress-redesign` — review/merge #3308 first.

New sections (each gated on its data; neutral copy so they read right on other climbers' profiles too):
- **Your biggest fights** — tries-to-send histogram (1 / 2–5 / 6–20 / 20+) + the hardest-won project row.
- **Grade pyramid** — existing distribution + a "one more {grade} fills the gap" next-project callout.
- **By wall angle** — max grade sent per angle (steep→slab), grade-tinted `react-native-svg` bars + faint volume track, home angle highlighted.
- **Wall rhythm** — weekday × time-of-day heat grid (reuses the calendar intensity ramp), hottest cell ringed.
- **Your ceiling over time** — running-max grade line + dashed "best ever" reference line.
- **Grade milestones** — first-send date per grade, compact timeline.
- Streak overlay on the calendar; donut centre count-up; rounded bars + in-chart gradients; **V-Points + Flash vs Redpoint collapsed** at the bottom.

Shared (`@boardsesh/profile-stats`, additive + 10 tests): `buildAngleBreakdown`, `buildWallRhythm`, `findNextProjectGrade`, `buildRunningMaxCeiling`, `buildGradeMilestones`. Angle/rhythm/next-project follow the timeframe filter; ceiling + milestones are lifetime (board-scoped) like the hero. Charts use plain-hex `chartColors` only (no `PlatformColor`); no new deps.

Verified on the iOS sim + Android M3 emulator against a local backend; adversarially reviewed (no must-fix; the flagged public-profile copy was neutralized).

## Release Notes

- Your profile's stats go deeper: see your hardest grade at every wall angle, when you climb during the week, your tries-to-send and biggest projects, your grade over time, and the dates you first sent each grade

## Test plan

- `vp run typecheck:mobile` · `vp run typecheck:shared` — green
- `vp run test:mobile` — 2841 passed (incl. 10 new builder tests + i18n catalog-completeness en/es/fr)
- `vp run check:mobile-bundle` — Android bundle OK (12.8 MB)
- `vp check` (lint+format+types) on all changed paths — clean
- Manual: rendered all new sections on iOS sim + Android emulator vs local backend; collapsed sections, gating on empty data, and neutral copy verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)