### PR TITLE
feat(mobile): You/Progress community cluster — top setter + benchmarks pyramid

### DIFF
--- a/packages/mobile/src/components/you/BenchmarksCard.tsx
+++ b/packages/mobile/src/components/you/BenchmarksCard.tsx
@@ -1,0 +1,61 @@
+import { View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import type { RawBenchmarkSummary } from '@boardsesh/profile-stats';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { Card } from '../Card';
+import { StackedBarChart } from './YouCharts';
+import type { ColoredBar } from './profile-chart-colors';
+import { spacing } from '../../theme/tokens';
+import { useTheme } from '../../providers/theme-provider';
+
+type BenchmarksCardProps = {
+  summary: RawBenchmarkSummary;
+  /** Benchmark-only grade distribution (single grade segment per bar), or null. */
+  gradeBars: ColoredBar[] | null;
+};
+
+/**
+ * Benchmarks (test-pieces) sent — count + hardest, with a benchmark-only grade
+ * distribution reusing the grade-coloured StackedBarChart. Hidden by the parent
+ * when the count is 0. Neutral copy (renders on any climber's profile).
+ */
+export function BenchmarksCard({ summary, gradeBars }: BenchmarksCardProps) {
+  const { t } = useTranslation('profile');
+  const { systemColors, brandColors } = useTheme();
+
+  return (
+    <Card style={styles.card}>
+      <View style={styles.header}>
+        <Icon name="benchmark" size={16} color={brandColors.accent} />
+        <Text variant="footnote" color={systemColors.secondaryLabel}>
+          {summary.hardestLabel
+            ? t('charts.benchmarksSummary', { count: summary.count, grade: summary.hardestLabel })
+            : t('charts.benchmarksCount', { count: summary.count })}
+        </Text>
+      </View>
+      {gradeBars && gradeBars.length > 0 ? (
+        <StackedBarChart
+          bars={gradeBars}
+          colorBy="grade"
+          height={140}
+          interactive={false}
+          zoomable={false}
+          accessibilityLabel={t('charts.benchmarksCardA11y', { count: summary.count })}
+        />
+      ) : null}
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginHorizontal: spacing[4],
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    marginBottom: spacing[2],
+  },
+});

--- a/packages/mobile/src/components/you/ProgressTab.tsx
+++ b/packages/mobile/src/components/you/ProgressTab.tsx
@@ -25,6 +25,8 @@ import { ProjectingCard } from './ProjectingCard';
 import { AngleBreakdownChart } from './AngleBreakdownChart';
 import { WallRhythmGrid } from './WallRhythmGrid';
 import { GradeMilestonesTimeline } from './GradeMilestonesTimeline';
+import { TopSetterCard } from './TopSetterCard';
+import { BenchmarksCard } from './BenchmarksCard';
 import { LayoutShareDonut } from './LayoutShareDonut';
 import { layoutChartColor, flashRedpointColor } from './profile-chart-colors';
 import { useBottomChromeMetrics } from '../../hooks/use-bottom-chrome-metrics';
@@ -292,6 +294,21 @@ export const ProgressTab = memo(function ProgressTab({
               <Card style={styles.chartCard}>
                 <GradeMilestonesTimeline milestones={data.gradeMilestones} />
               </Card>
+            </>
+          )}
+
+          {/* Community cluster — who you've sent and the test-pieces you've ticked. */}
+          {data.setterSummary.topSetter && (
+            <>
+              <SectionHeader title={t('sections.topSetter')} />
+              <TopSetterCard summary={data.setterSummary} />
+            </>
+          )}
+
+          {data.benchmarkSummary.count > 0 && (
+            <>
+              <SectionHeader title={t('sections.benchmarks')} />
+              <BenchmarksCard summary={data.benchmarkSummary} gradeBars={data.benchmarkGradeBars} />
             </>
           )}
 

--- a/packages/mobile/src/components/you/TopSetterCard.tsx
+++ b/packages/mobile/src/components/you/TopSetterCard.tsx
@@ -1,0 +1,85 @@
+import { View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import type { RawSetterSummary } from '@boardsesh/profile-stats';
+import { Text } from '../Text';
+import { Card } from '../Card';
+import { spacing, borderRadius } from '../../theme/tokens';
+import { useTheme } from '../../providers/theme-provider';
+import { useVariantValue } from '../../theme/variants';
+
+const MATERIAL = { material: true, liquidGlass: false } as const;
+
+type TopSetterCardProps = {
+  summary: RawSetterSummary;
+};
+
+/**
+ * "Top setter" — the setter whose problems the climber has sent most + how many
+ * setters they've explored. Neutral copy (renders on any climber's profile).
+ * Hidden by the parent when there's no resolved setter.
+ */
+export function TopSetterCard({ summary }: TopSetterCardProps) {
+  const { t } = useTranslation('profile');
+  const { systemColors, m3, brandColors } = useTheme();
+  const isMaterial = useVariantValue(MATERIAL);
+
+  if (!summary.topSetter) return null;
+  const { username, count } = summary.topSetter;
+  const initial = username.charAt(0).toUpperCase();
+
+  const avatarBg = isMaterial ? m3.primaryContainer : systemColors.fill;
+  const counterColor = isMaterial ? m3.onSurfaceVariant : systemColors.secondaryLabel;
+
+  return (
+    <Card
+      style={styles.card}
+      accessibilityLabel={t('charts.setterA11y', { setter: username, count, total: summary.distinctSetters })}
+    >
+      <View style={styles.row}>
+        <View style={[styles.avatar, { backgroundColor: avatarBg, borderColor: brandColors.primary }]}>
+          <Text variant="headline" color={brandColors.primary}>
+            {initial}
+          </Text>
+        </View>
+        <View style={styles.body}>
+          <Text variant="headline" numberOfLines={1}>
+            {username}
+          </Text>
+          <Text variant="footnote" color={counterColor}>
+            {t('charts.setterProblems', { count })}
+          </Text>
+        </View>
+        <Text variant="footnote" color={counterColor} style={styles.counter} numberOfLines={2}>
+          {t('charts.settersExplored', { count: summary.distinctSetters })}
+        </Text>
+      </View>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginHorizontal: spacing[4],
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+  },
+  avatar: {
+    width: spacing[10],
+    height: spacing[10],
+    borderRadius: borderRadius.full,
+    borderWidth: StyleSheet.hairlineWidth,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  body: {
+    flex: 1,
+    gap: 2,
+  },
+  counter: {
+    maxWidth: spacing[16] + spacing[4],
+    textAlign: 'right',
+  },
+});

--- a/packages/shared/i18n/locales/en-US/profile.json
+++ b/packages/shared/i18n/locales/en-US/profile.json
@@ -113,7 +113,9 @@
     "yourAngle": "By wall angle",
     "wallRhythm": "Wall rhythm",
     "ceilingOverTime": "Ceiling over time",
-    "gradeMilestones": "Grade milestones"
+    "gradeMilestones": "Grade milestones",
+    "topSetter": "Top setter",
+    "benchmarks": "Benchmarks"
   },
   "charts": {
     "nextProject": "One more {{grade}} fills the gap",
@@ -131,6 +133,15 @@
     "ceilingA11y": "Hardest grade each week, now {{grade}}",
     "milestonesA11y": "First send at each grade",
     "milestoneA11y": "First {{grade}} in {{date}}",
+    "setterProblems_one": "{{count}} problem",
+    "setterProblems_other": "{{count}} problems",
+    "settersExplored_one": "{{count}} setter explored",
+    "settersExplored_other": "{{count}} setters explored",
+    "setterA11y": "Top setter {{setter}}, {{count}} problems sent, {{total}} setters explored",
+    "benchmarksSummary": "{{count}} sent · hardest {{grade}}",
+    "benchmarksCount_one": "{{count}} benchmark sent",
+    "benchmarksCount_other": "{{count}} benchmarks sent",
+    "benchmarksCardA11y": "Benchmark grades, {{count}} sent",
     "weekday": {
       "mon": "Mon",
       "tue": "Tue",

--- a/packages/shared/i18n/locales/es/profile.json
+++ b/packages/shared/i18n/locales/es/profile.json
@@ -113,7 +113,9 @@
     "yourAngle": "Por ángulo de pared",
     "wallRhythm": "Ritmo en el muro",
     "ceilingOverTime": "Techo a lo largo del tiempo",
-    "gradeMilestones": "Hitos por grado"
+    "gradeMilestones": "Hitos por grado",
+    "topSetter": "Mejor aperturista",
+    "benchmarks": "Benchmarks"
   },
   "charts": {
     "nextProject": "Un {{grade}} más cierra el hueco",
@@ -131,6 +133,15 @@
     "ceilingA11y": "Grado más difícil cada semana, ahora {{grade}}",
     "milestonesA11y": "Primer encadene en cada grado",
     "milestoneA11y": "Primer {{grade}} en {{date}}",
+    "setterProblems_one": "{{count}} bloque",
+    "setterProblems_other": "{{count}} bloques",
+    "settersExplored_one": "{{count}} aperturista explorado",
+    "settersExplored_other": "{{count}} aperturistas explorados",
+    "setterA11y": "Mejor aperturista {{setter}}, {{count}} bloques encadenados, {{total}} aperturistas explorados",
+    "benchmarksSummary": "{{count}} encadenados · más difícil {{grade}}",
+    "benchmarksCount_one": "{{count}} benchmark encadenado",
+    "benchmarksCount_other": "{{count}} benchmarks encadenados",
+    "benchmarksCardA11y": "Grados de benchmark, {{count}} encadenados",
     "weekday": {
       "mon": "lun",
       "tue": "mar",

--- a/packages/shared/i18n/locales/fr/profile.json
+++ b/packages/shared/i18n/locales/fr/profile.json
@@ -113,7 +113,9 @@
     "yourAngle": "Par inclinaison de mur",
     "wallRhythm": "Rythme au mur",
     "ceilingOverTime": "Plafond dans le temps",
-    "gradeMilestones": "Jalons par cotation"
+    "gradeMilestones": "Jalons par cotation",
+    "topSetter": "Meilleur ouvreur",
+    "benchmarks": "Références"
   },
   "charts": {
     "nextProject": "Un {{grade}} de plus comble le trou",
@@ -131,6 +133,15 @@
     "ceilingA11y": "Cotation la plus dure chaque semaine, maintenant {{grade}}",
     "milestonesA11y": "Premier enchaînement à chaque cotation",
     "milestoneA11y": "Premier {{grade}} en {{date}}",
+    "setterProblems_one": "{{count}} bloc",
+    "setterProblems_other": "{{count}} blocs",
+    "settersExplored_one": "{{count}} ouvreur exploré",
+    "settersExplored_other": "{{count}} ouvreurs explorés",
+    "setterA11y": "Meilleur ouvreur {{setter}}, {{count}} blocs enchaînés, {{total}} ouvreurs explorés",
+    "benchmarksSummary": "{{count}} enchaînés · plus dur {{grade}}",
+    "benchmarksCount_one": "{{count}} référence enchaînée",
+    "benchmarksCount_other": "{{count}} références enchaînées",
+    "benchmarksCardA11y": "Cotations de référence, {{count}} enchaînées",
     "weekday": {
       "mon": "lun",
       "tue": "mar",

--- a/packages/shared/profile-stats/src/__tests__/community-builders.test.ts
+++ b/packages/shared/profile-stats/src/__tests__/community-builders.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import dayjs from 'dayjs';
+import { buildSetterSummary, buildBenchmarkGradeBars } from '../chart-builders';
+import type { LogbookEntry } from '../types';
+
+const NOW = dayjs('2026-06-15T12:00:00').toISOString();
+function entry(overrides: Partial<LogbookEntry> = {}): LogbookEntry {
+  return { climbed_at: NOW, difficulty: 22, tries: 1, angle: 40, status: 'send', ...overrides };
+}
+
+describe('buildSetterSummary', () => {
+  it('counts distinct sent climbs per setter and finds the top setter', () => {
+    const logbook = [
+      entry({ setterUsername: 'kilterjackie', climbUuid: 'a' }),
+      entry({ setterUsername: 'kilterjackie', climbUuid: 'b' }),
+      entry({ setterUsername: 'kilterjackie', climbUuid: 'a' }), // dup climb → not recounted
+      entry({ setterUsername: 'kilterjackie', climbUuid: 'c' }),
+      entry({ setterUsername: 'tensionbot', climbUuid: 'd' }),
+      entry({ setterUsername: 'attemptsetter', climbUuid: 'e', status: 'attempt' }), // not sent
+    ];
+    const summary = buildSetterSummary(logbook);
+    expect(summary.topSetter).toEqual({ username: 'kilterjackie', count: 3 });
+    expect(summary.distinctSetters).toBe(2);
+  });
+
+  it('is empty when no sent climb has a setter', () => {
+    expect(buildSetterSummary([entry({ setterUsername: null })])).toEqual({ topSetter: null, distinctSetters: 0 });
+  });
+});
+
+describe('buildBenchmarkGradeBars', () => {
+  it('counts distinct benchmark sends per grade, grade-ascending', () => {
+    const logbook = [
+      entry({ isBenchmark: true, climbUuid: 'b1', difficulty: 22 }), // V6
+      entry({ isBenchmark: true, climbUuid: 'b2', difficulty: 22 }), // V6
+      entry({ isBenchmark: true, climbUuid: 'b1', difficulty: 22 }), // dup → not recounted
+      entry({ isBenchmark: true, climbUuid: 'b3', difficulty: 28 }), // V11
+      entry({ isBenchmark: false, climbUuid: 'n1', difficulty: 22 }), // not a benchmark
+      entry({ isBenchmark: true, climbUuid: 'b4', difficulty: 28, status: 'attempt' }), // not sent
+    ];
+    const bars = buildBenchmarkGradeBars(logbook, 'v-grade');
+    expect(bars).not.toBeNull();
+    expect(bars!.map((b) => [b.label, b.segments[0].value])).toEqual([
+      ['V6', 2],
+      ['V11', 1],
+    ]);
+  });
+
+  it('returns null when nothing is benchmarked', () => {
+    expect(buildBenchmarkGradeBars([entry({ isBenchmark: false })], 'v-grade')).toBeNull();
+  });
+});

--- a/packages/shared/profile-stats/src/chart-builders.ts
+++ b/packages/shared/profile-stats/src/chart-builders.ts
@@ -32,6 +32,7 @@ import type {
   RawNextProject,
   RawRunningMaxCeiling,
   RawGradeMilestone,
+  RawSetterSummary,
 } from './types';
 
 dayjs.extend(isoWeek);
@@ -968,4 +969,81 @@ export function buildGradeMilestones(
   return Array.from(byLabel.entries())
     .map(([label, info]) => ({ difficulty: info.difficulty, label, date: info.date }))
     .sort((a, b) => a.difficulty - b.difficulty);
+}
+
+// ── Community cluster (PR3) ─────────────────────────────────────────
+
+/**
+ * Top setter + setter diversity from sent climbs (needs `setterUsername` on the
+ * tick — the GraphQL `userTicks` field). Counts distinct climbs per setter
+ * (dedup by climbUuid). Lifetime/board-scoped — an identity stat.
+ */
+export function buildSetterSummary(boardScopedTicks: LogbookEntry[]): RawSetterSummary {
+  const climbsBySetter = new Map<string, Set<string>>();
+  const looseCountBySetter = new Map<string, number>();
+
+  for (const entry of boardScopedTicks) {
+    if (!isSend(entry)) continue;
+    const setter = entry.setterUsername?.trim();
+    if (!setter) continue;
+    if (entry.climbUuid) {
+      let set = climbsBySetter.get(setter);
+      if (!set) {
+        set = new Set<string>();
+        climbsBySetter.set(setter, set);
+      }
+      set.add(entry.climbUuid);
+    } else {
+      looseCountBySetter.set(setter, (looseCountBySetter.get(setter) ?? 0) + 1);
+    }
+  }
+
+  const setters = new Set<string>([...climbsBySetter.keys(), ...looseCountBySetter.keys()]);
+  let topSetter: { username: string; count: number } | null = null;
+  for (const setter of setters) {
+    const count = (climbsBySetter.get(setter)?.size ?? 0) + (looseCountBySetter.get(setter) ?? 0);
+    if (topSetter == null || count > topSetter.count) topSetter = { username: setter, count };
+  }
+
+  return { topSetter, distinctSetters: setters.size };
+}
+
+/**
+ * Benchmark-only grade distribution as single-series grade bars (for the
+ * benchmarks pyramid). Distinct benchmark climbs sent, counted per grade. Uses
+ * the climb-level `isBenchmark` flag. Returns null when there are none.
+ */
+export function buildBenchmarkGradeBars(
+  filteredLogbook: LogbookEntry[],
+  gradeFormat: GradeDisplayFormat = 'v-grade',
+): RawBar[] | null {
+  const mapping = getDifficultyMapping(gradeFormat);
+  const climbsByGrade = new Map<string, Set<string>>();
+  const looseByGrade = new Map<string, number>();
+
+  for (const entry of filteredLogbook) {
+    if (!entry.isBenchmark || !isSend(entry)) continue;
+    const gradeId = gradeIdForEntry(entry);
+    if (gradeId == null) continue;
+    const grade = mapping[gradeId];
+    if (!grade) continue;
+    if (entry.climbUuid) {
+      let set = climbsByGrade.get(grade);
+      if (!set) {
+        set = new Set<string>();
+        climbsByGrade.set(grade, set);
+      }
+      set.add(entry.climbUuid);
+    } else {
+      looseByGrade.set(grade, (looseByGrade.get(grade) ?? 0) + 1);
+    }
+  }
+
+  const grades = new Set<string>([...climbsByGrade.keys(), ...looseByGrade.keys()]);
+  if (grades.size === 0) return null;
+
+  return sortGrades(Array.from(grades), gradeFormat).map((grade) => {
+    const value = (climbsByGrade.get(grade)?.size ?? 0) + (looseByGrade.get(grade) ?? 0);
+    return { key: grade, label: grade, segments: [{ value, key: grade, label: grade }] };
+  });
 }

--- a/packages/shared/profile-stats/src/derive-view-model.ts
+++ b/packages/shared/profile-stats/src/derive-view-model.ts
@@ -17,6 +17,8 @@ import {
   findNextProjectGrade,
   buildRunningMaxCeiling,
   buildGradeMilestones,
+  buildSetterSummary,
+  buildBenchmarkGradeBars,
 } from './chart-builders';
 import { getDifficultyMapping } from './grade-mapping';
 import type {
@@ -40,6 +42,7 @@ import type {
   RawNextProject,
   RawRunningMaxCeiling,
   RawGradeMilestone,
+  RawSetterSummary,
 } from './types';
 
 export type DeriveProfileViewModelInput = {
@@ -82,6 +85,9 @@ export type ProfileViewModel = {
   nextProjectGrade: RawNextProject;
   runningMaxCeiling: RawRunningMaxCeiling | null;
   gradeMilestones: RawGradeMilestone[];
+  // ── Community cluster (PR3). Lifetime identity stats (board-scoped).
+  setterSummary: RawSetterSummary;
+  benchmarkGradeBars: RawBar[] | null;
 };
 
 /**
@@ -149,6 +155,10 @@ export function deriveProfileViewModel(input: DeriveProfileViewModelInput): Prof
   const runningMaxCeiling = buildRunningMaxCeiling(boardScopedTicks, gradeFormat);
   const gradeMilestones = buildGradeMilestones(boardScopedTicks, gradeFormat);
 
+  // Community cluster — lifetime identity stats.
+  const setterSummary = buildSetterSummary(boardScopedTicks);
+  const benchmarkGradeBars = buildBenchmarkGradeBars(boardScopedTicks, gradeFormat);
+
   return {
     filteredLogbook,
     weeklyBars,
@@ -169,6 +179,8 @@ export function deriveProfileViewModel(input: DeriveProfileViewModelInput): Prof
     nextProjectGrade,
     runningMaxCeiling,
     gradeMilestones,
+    setterSummary,
+    benchmarkGradeBars,
   };
 }
 

--- a/packages/shared/profile-stats/src/index.ts
+++ b/packages/shared/profile-stats/src/index.ts
@@ -23,6 +23,8 @@ export {
   findNextProjectGrade,
   buildRunningMaxCeiling,
   buildGradeMilestones,
+  buildSetterSummary,
+  buildBenchmarkGradeBars,
 } from './chart-builders';
 export { difficultyMapping, getDifficultyMapping, sortGrades } from './grade-mapping';
 export {

--- a/packages/shared/profile-stats/src/types.ts
+++ b/packages/shared/profile-stats/src/types.ts
@@ -270,3 +270,13 @@ export type RawGradeMilestone = {
   /** Local calendar date of the first send at this grade, `YYYY-MM-DD`. */
   date: string;
 };
+
+// ── Community cluster (PR3) ─────────────────────────────────────────
+
+/** Top setter + how many setters the climber has sent — "your setter". */
+export type RawSetterSummary = {
+  /** The setter whose problems the climber has sent most, or null. */
+  topSetter: { username: string; count: number } | null;
+  /** Distinct setters the climber has sent at least one problem from. */
+  distinctSetters: number;
+};


### PR DESCRIPTION
## Summary

**Stacked on #3315 (PR 3 of 3).** The final slice of the You/Progress redesign — the community/identity sections under the deep charts. Base branch is `mobile/you-progress-deep-charts`; merge #3308 → #3315 → this in order.

- **Top setter** — the setter whose problems you've sent most (avatar initial + count) and a "setters explored" diversity counter.
- **Benchmarks** — count + hardest, plus a benchmark-only grade distribution reusing the grade-coloured `StackedBarChart`.

Shared (`@boardsesh/profile-stats`, additive + 4 tests): `buildSetterSummary` (top setter + distinct count from the `setterUsername` field added in #3308) and `buildBenchmarkGradeBars` (benchmark-only grade bars from the climb-level `resolvedIsBenchmark`). Both lifetime board-scoped identity stats. All copy neutral so the sections read correctly on other climbers' public profiles. No new deps.

Verified on the Android M3 emulator against a local backend (`63 benchmarks` from the real `resolvedIsBenchmark` field).

## Release Notes

- Your profile now shows your go-to setter and how many setters you've explored, plus your benchmarks sent with a breakdown by grade

## Test plan

- `vp run typecheck:mobile` · `vp run typecheck:shared` — green
- `vp run test:mobile` — 2841 passed (incl. 4 new builder tests + i18n catalog-completeness en/es/fr)
- `vp run check:mobile-bundle` — Android bundle OK (12.8 MB)
- `vp check` on all changed paths — clean (0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)