### PR TITLE
feat(web): health endpoint + Railway config for the web service

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -34,9 +34,16 @@ COPY source/scripts ./scripts
 # Accept build arguments for environment variables baked into the Next.js build
 ARG NEXT_PUBLIC_WS_URL
 ARG BASE_URL
+# Public client key (phc_…), not a secret — inlined so getPosthog() doesn't
+# short-circuit. The Vercel build previously supplied this from the project
+# env; when the CI prebuilt Vercel build stopped getting it passed explicitly,
+# ALL client-side PostHog analytics went dark in prod. Don't drop this again
+# when wiring the Railway build-arg pipeline.
+ARG NEXT_PUBLIC_POSTHOG_KEY
 
 ENV NEXT_PUBLIC_WS_URL=$NEXT_PUBLIC_WS_URL
 ENV BASE_URL=$BASE_URL
+ENV NEXT_PUBLIC_POSTHOG_KEY=$NEXT_PUBLIC_POSTHOG_KEY
 
 # No Expo web export step here (W-24, #4438). The browser app ships only at
 # app.boardsesh.com, exported and published by production-deploy.yml's

--- a/packages/web/app/__tests__/rest-surface-inventory.test.ts
+++ b/packages/web/app/__tests__/rest-surface-inventory.test.ts
@@ -1,6 +1,7 @@
 /**
- * The standing inventory oracle for issue #1889 (REST surface audit: 38
- * routes classified after the board renderer moved to Railway in #4715).
+ * The standing inventory oracle for issue #1889 (REST surface audit: 39
+ * routes classified after the board renderer moved to Railway in #4715 and
+ * the Railway healthcheck route landed in #3798).
  *
  * A classification table living only in an issue body or a doc goes stale the
  * moment a route is added or removed without anyone re-reading it — exactly
@@ -26,7 +27,7 @@
  *
  * `keep-external` = published surface with no in-repo runtime caller by
  * design (an ESP32 firmware target, a documented `/api/v1/*` route, a Vercel
- * cron target, or a crawler-only redirect shim) — "no caller" is the intended
+ * cron target, a platform healthcheck target, or a crawler-only redirect shim) — "no caller" is the intended
  * steady state here, not evidence of deadness. `keep-caller` = has a live
  * in-repo (web, mobile, or backend) caller. Neither verdict means "safe to
  * delete" — see issue #1889 for the full reasoning per route.
@@ -53,6 +54,12 @@ const VERDICTS: Record<string, Verdict> = {
   'app/api/auth/resend-verification/route.ts': 'keep-caller',
   'app/api/auth/verify-email/route.ts': 'keep-caller',
   'app/api/auth/native/callback/route.ts': 'keep-caller',
+
+  // --- /api/health (1) — Railway's healthcheck target (railway.web.toml).
+  // Polled by the platform on every deploy and periodically after; nothing
+  // in-repo calls it, and it must stay dependency-free (no DB, no backend)
+  // so a transient blip can't fail a deploy or start a restart loop. ---
+  'app/api/health/route.ts': 'keep-external',
 
   // --- /api/internal/* (15) ---
   // Party-session / kiosk auth bridge — never delete.
@@ -198,6 +205,6 @@ describe('REST surface inventory (issue #1889)', () => {
   it('counts exactly the audited surface', () => {
     // Guards the headline number in issue #1889 itself — a change here means
     // the issue body needs a fresh audit pass, not a quiet reclassification.
-    expect(derived.size).toBe(38);
+    expect(derived.size).toBe(39);
   });
 });

--- a/packages/web/app/api/health/__tests__/route.test.ts
+++ b/packages/web/app/api/health/__tests__/route.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { GET, type HealthResponse } from '../route';
+
+describe('GET /api/health', () => {
+  it('returns 200 with an ok status', async () => {
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as HealthResponse;
+    expect(body).toEqual({ status: 'ok' });
+  });
+});

--- a/packages/web/app/api/health/route.ts
+++ b/packages/web/app/api/health/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+
+// Railway's healthcheck (see railway.web.toml) hits this on every deploy and
+// periodically thereafter. It MUST stay dependency-free: no database, no
+// backend/GraphQL calls, no Aurora proxying. A transient DB blip must not
+// fail the deploy healthcheck or trigger a restart loop on an otherwise
+// healthy web process.
+export const dynamic = 'force-dynamic';
+
+export type HealthResponse = {
+  status: 'ok';
+};
+
+export async function GET() {
+  const response: HealthResponse = { status: 'ok' };
+
+  return NextResponse.json(response, {
+    headers: {
+      'Cache-Control': 'no-store',
+    },
+  });
+}

--- a/railway.web.toml
+++ b/railway.web.toml
@@ -1,0 +1,15 @@
+# Config-as-code for the Railway `web` service (image
+# ghcr.io/boardsesh/boardsesh-web:production, built from Dockerfile.web by
+# .github/workflows/production-deploy.yml). The web service's Settings ->
+# Config file path must point at this file. Don't add a [build] section here;
+# it would put Railway back in charge of building instead of pulling the
+# prebuilt GHCR image.
+#
+# The root railway.toml remains the backend service's config — it is picked
+# up by default, so the web service must be pointed at this file explicitly.
+
+[deploy]
+healthcheckPath = "/api/health"
+healthcheckTimeout = 100
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 5


### PR DESCRIPTION
## Summary

- Add `/api/health` — a dependency-free health endpoint for Railway's healthcheck. It never touches the database or backend, so a DB blip can't fail a deploy healthcheck or trigger a restart loop.
- Add `railway.web.toml` — config-as-code for the Railway `web` service (image `ghcr.io/boardsesh/boardsesh-web:production`), pointing its healthcheck at `/api/health` and mirroring the backend's `railway.toml` restart policy. The web service's Settings → Config file path must point at this file.
- Add `NEXT_PUBLIC_POSTHOG_KEY` as a build arg in `Dockerfile.web` so `next build` inlines it, matching how the Vercel build supplies it. Without it, client-side PostHog analytics goes dark in prod (this happened once before on the Vercel CI build path).

Plumbing only — no deploy workflow changes. #3795 wires the Railway production deploy on top of this.

Part of #4648 (Phase 2, first merge in the sequence).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.
2. After merge, `/api/health` on www returns `{"status":"ok"}`.

## Risk

Risk: 1/5 — adds an unauthenticated no-op route, a Railway config file nothing reads yet, and one build arg.
