### PR TITLE
feat(repo): manage the boardsesh.com Cloudflare config from the repo

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -546,6 +546,9 @@ jobs:
   # nothing else depends on it, so a Cloudflare API hiccup never blocks the
   # web/backend deploys. A non-zero exit = unapplied drift (e.g. a blocked
   # zone-SSL change) and should be investigated, not retried blindly.
+  # The planned OpenNext (Cloudflare Workers) deploy of packages/web will be a
+  # sibling job reusing the same Production-environment CLOUDFLARE_API_TOKEN
+  # (+ CLOUDFLARE_ACCOUNT_ID) — see docs/cloudflare.md for the token scopes.
   deploy-cloudflare:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.cloudflare_changed == 'true'

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -74,6 +74,7 @@ jobs:
       backend_changed: ${{ steps.changes.outputs.backend }}
       app_changed: ${{ steps.changes.outputs.app }}
       deployment_base_sha: ${{ steps.changes.outputs.deployment_base_sha }}
+      cloudflare_changed: ${{ steps.changes.outputs.cloudflare }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -540,6 +541,29 @@ jobs:
   # detect-changes. No inline Playwright smoke gate — a per-deploy expo-web boot
   # is too heavy here (this file has no such gate for web/backend either); the
   # expo-web-smoke suite stays the dispatch-only gate in e2e-tests.yml.
+  # Converges the Cloudflare zone config (infra/cloudflare) on main. Runs only
+  # when the desired state or apply tooling changes (or on manual dispatch);
+  # nothing else depends on it, so a Cloudflare API hiccup never blocks the
+  # web/backend deploys. A non-zero exit = unapplied drift (e.g. a blocked
+  # zone-SSL change) and should be investigated, not retried blindly.
+  deploy-cloudflare:
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.cloudflare_changed == 'true'
+    runs-on: ubuntu-latest
+    environment: Production
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Apply Cloudflare config
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: vp run cf:apply -- --apply
+
   # Manual deploy freeze for app.boardsesh.com, the Cloudflare Pages analogue of
   # check-rollback. deploy-web and deploy-production-backend both honour a pinned
   # Vercel Instant Rollback; Pages has no equivalent signal here, so without this

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ Read relevant `docs/` before working on the matching area; update docs when the 
 - `docs/logging.md` — backend structured logger (winston)
 - `docs/db-connectivity.md` — Postgres connect retries (what is retried and why it can't double-execute a write), the retry budgets, and the `/health` vs `/health/db` split
 - `docs/og-climb.md` — backend-served climb OG share cards (`GET /og/climb`: caches, env vars, timings)
+- `docs/cloudflare.md` — the boardsesh.com Cloudflare zone: config-as-code (`vp run cf:apply`), token scopes/secrets, CI auto-apply, og edge caching, planned OpenNext web deploy
 - `docs/mobile-sheets-vs-routes.md` — mobile: which surface to use (bottom sheet vs route), with the decision tree + the hard rules (incl. why `fullScreenModal` breaks the iOS 26 native tab bar)
 - `docs/gym-funnel-analytics.md` — the www gym funnel event contract in `@boardsesh/analytics` (seven event names, their property sets, the QR `?src=qr&medium=` landing params, and why `boardTypes` must be a joined string)
 - `docs/sitemap.md` — the shard registry, the degrade-at-the-index / fail-closed-at-the-shard split, and the climb store (`sitemap_shard_refreshes` + the `sitemap_climb_urls` ordinal table the shard pages read): who refreshes it, the `?force=1` escape hatch, and why the write lock is transaction-scoped

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -1,0 +1,119 @@
+# Cloudflare (zone config, edge caching, deploy tooling)
+
+Everything Cloudflare for the `boardsesh.com` zone: the config-as-code tooling,
+token setup, CI auto-apply, and (coming) the OpenNext deployment of the web app.
+
+## Planned: web app on Cloudflare via OpenNext
+
+`packages/web` is moving off Vercel onto Cloudflare Workers using OpenNext
+(`@opennextjs/cloudflare`). The token + secrets below are provisioned to cover
+that migration too, so the deploy job can reuse them:
+
+- The future `deploy-web-cloudflare` workflow job reads the same
+  `CLOUDFLARE_API_TOKEN` (Production environment) — no new secret setup.
+- Add `CLOUDFLARE_ACCOUNT_ID` to the Production environment at the same time as
+  the token (`gh secret set CLOUDFLARE_ACCOUNT_ID --env Production`); wrangler
+  needs it and it never changes.
+
+## ws.boardsesh.com edge caching (og images)
+
+`ws.boardsesh.com` is a single-region Railway origin; distant clients (and the
+iOS share sheet, which fetches previews from the sender's phone) pay full RTT
+per image. Fronting it with Cloudflare edge-caches the immutable og responses
+globally.
+
+The zone config is managed from the repo — not dashboard clicks — by
+`scripts/cloudflare-apply.ts` (registered as `vp run cf:apply`). The desired
+state is declared in `infra/cloudflare/config.ts`; the script diffs it against
+the live zone and, with `--apply`, converges only the delta (idempotent, so a
+second run is a no-op).
+
+What it manages (and nothing else on the zone):
+
+- **DNS** — the `ws` record's proxied flag → orange cloud. The record's
+  target/type/content are not managed; the record must already exist.
+- **Cache** — one rule in the `http_request_cache_settings` phase, expression
+  `(http.host eq "ws.boardsesh.com" and starts_with(http.request.uri.path, "/og/"))`
+  → eligible for cache, edge TTL "use cache-control if present, bypass if not"
+  so error responses (400/429/503 — sent without Cache-Control) are never
+  edge-cached, and browser TTL "respect origin" (successful responses are `immutable`,
+  1y). Every other rule already in that phase is preserved verbatim (the tool
+  finds its own rule by a stable description marker and touches only that one),
+  so `/graphql`, REST, and WebSocket upgrades keep bypassing cache.
+- **SSL** — asserts the zone SSL/TLS mode is `strict` (Full (strict); Flexible
+  causes redirect loops with Railway). If the zone-wide mode is weaker the tool
+  **reports it but does not change it** — the setting affects every hostname on
+  `boardsesh.com`. Pass `--allow-zone-ssl` to opt into setting it.
+
+Code prerequisite (shipped): the og rate limiter prefers `CF-Connecting-IP`, so
+per-client buckets survive the proxy hop.
+
+### One-time: create the API token
+
+Create ONE token covering both today's zone tooling and the upcoming OpenNext
+deploy, so this setup never has to be repeated:
+
+**Needed now (zone tooling, `vp run cf:apply`):**
+
+Create a token at <https://dash.cloudflare.com/profile/api-tokens> scoped to the
+`boardsesh.com` zone with:
+
+- **Zone.Zone Read** — resolve the zone id by name + read the zone list
+- **Zone.DNS Edit** — patch the `ws` record proxied flag
+- **Zone.Cache Rules Edit** — create/update the `/og/` cache rule
+- **Zone.Zone Settings Read** — read the SSL/TLS mode
+- **Zone.Zone Settings Edit** — only if you'll run `--allow-zone-ssl`
+
+**Add now for the OpenNext migration (wrangler deploy of packages/web):**
+
+- **Account.Workers Scripts Edit** — deploy the Worker
+- **Account.Workers KV Storage Edit** — OpenNext incremental cache (if KV-backed)
+- **Account.Workers R2 Storage Edit** — only if the OpenNext cache uses R2
+- **Zone.Workers Routes Edit** — attach the Worker to www/apex routes
+
+Then store both values in the GitHub Production environment:
+
+```
+gh secret set CLOUDFLARE_API_TOKEN --env Production
+gh secret set CLOUDFLARE_ACCOUNT_ID --env Production
+```
+
+### Flip runbook
+
+```bash
+# 1. Dry-run (default) — prints the diff, exits non-zero if there's drift. Never mutates.
+CLOUDFLARE_API_TOKEN=... vp run cf:apply
+
+# 2. Apply — performs only the needed mutations.
+CLOUDFLARE_API_TOKEN=... vp run cf:apply -- --apply
+
+# (optional) also set the zone-wide SSL mode when it's weaker than strict:
+CLOUDFLARE_API_TOKEN=... vp run cf:apply -- --apply --allow-zone-ssl
+```
+
+`CLOUDFLARE_ZONE_ID` is optional — when unset, the zone id is resolved by name.
+
+Confirm WebSockets are enabled for the zone (Network tab; on by default on
+current plans). WebSocket caveat: the cache rule scopes to `/og/` only, so
+`wss://ws.boardsesh.com/graphql` upgrades and every other path continue to pass
+straight through to Railway.
+
+### Verify
+
+`wss://ws.boardsesh.com/graphql` still connects (web party mode + mobile app);
+`curl -sI 'https://ws.boardsesh.com/og/climb?...'` twice — the second response
+shows `cf-cache-status: HIT`.
+
+### CI auto-apply
+
+`production-deploy.yml` runs `vp run cf:apply -- --apply` on pushes to main
+that touch `infra/cloudflare/` or the apply script (and on manual dispatch),
+reading `CLOUDFLARE_API_TOKEN` from the GitHub **Production** environment
+secrets: `gh secret set CLOUDFLARE_API_TOKEN --env Production`. A failing job
+means unapplied drift (often a blocked zone-SSL change) — run the dry-run
+locally to see the plan.
+
+### Rollback
+
+Set `proxied: false` on the `ws` record in `infra/cloudflare/config.ts` and
+`vp run cf:apply -- --apply`, or grey-cloud the record in the dashboard.

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -48,6 +48,74 @@ What it manages (and nothing else on the zone):
 Code prerequisite (shipped): the og rate limiter prefers `CF-Connecting-IP`, so
 per-client buckets survive the proxy hop.
 
+## www.boardsesh.com crawl cost controls (#4650)
+
+Measured against production on 2026-08-25 with the Vercel MCP:
+
+|                                    | per day          |
+| ---------------------------------- | ---------------- |
+| Vercel function invocations        | ~442,600         |
+| — `/api/internal/board-render`     | ~215,600 (48.7%) |
+| — climb view `…/view/[climb_uuid]` | ~203,900 (46.1%) |
+| — `/setter/[setter_username]`      | ~15,900 (3.6%)   |
+| — the other 48 routes combined     | ~7,100 (1.6%)    |
+| Homepage `/`                       | ~2,000           |
+
+Two routes are 94% of all compute, against a published sitemap of only ~60k climb
+URLs and ~2,000 homepage hits. That shape is a crawl, not an audience.
+
+> **Reading the numbers yourself:** `get_runtime_logs` with `since: 24h` is
+> silently truncated — it reports 249,960 where the 6 h window × 4 gives 442,564
+> and the 30 min window × 48 gives 535,632. The two short windows agree with each
+> other and the 24 h one does not. Derive daily rates from a 6 h or 30 min window
+> and scale, or you will under-report by ~2×.
+
+Two more rules, managed the same way (declared in `infra/cloudflare/config.ts`,
+converged by `vp run cf:apply`):
+
+- **Board-render cache rule** — `http_request_cache_settings`, expression
+  `(http.host eq "www.boardsesh.com" and starts_with(http.request.uri.path, "/api/internal/board-render"))`.
+  The route already sends `cache-control: public, max-age=31536000, immutable`
+  and a matching `CDN-Cache-Control`, but **Cloudflare caches by file extension
+  by default** and this path has none, so it measured `cf-cache-status: DYNAMIC`
+  while `/_next/static/*.js` on the same zone was a `HIT`. Every image byte was
+  transiting Cloudflare to Vercel (~54 GB/day). The rule is the entire fix — no
+  origin header change is needed or wanted.
+
+- **Crawler rules** — two rules in `http_request_firewall_custom`, in this order:
+  1. `skip` (all remaining custom rules) for search engines and share-card
+     unfurlers. Brave runs its **own** index rather than reselling Bing or
+     Google, so it is allowlisted explicitly.
+  2. `block` for commercial SEO/backlink crawlers (Ahrefs, Semrush, DataForSEO,
+     MJ12, DotBot, BLEXBot, Barkrowler, serpstat, Seznam, Zoominfo, Screaming
+     Frog). Each was verified reaching our origin on 2026-08-24. They sell
+     backlink data and send Boardsesh no traffic.
+
+  **Order is load-bearing and enforced by the tool.** `upsertCacheRule` rewrites
+  our rules as one contiguous group in declared order, because a rule-by-rule
+  upsert would append a newly added allow rule _after_ an existing block rule and
+  reverse their precedence. A test pins this.
+
+  Two things the tool will not do, both deliberate:
+  - It never reorders our group relative to **foreign** rules. Cloudflare's own
+    AI-crawler block (which already 403s ClaudeBot, GPTBot, PerplexityBot,
+    Bytespider, CCBot and friends — verified 2026-08-24) runs ahead of ours and
+    stays there. That is also why those agents are absent from our block list:
+    duplicating them would be dead config that drifts.
+  - It never uses `cf.client.bot` as the allowlist. Ahrefs and Semrush are
+    themselves Cloudflare _verified bots_, so that field is true for precisely
+    the crawlers we are blocking.
+
+`lower()` on every user-agent comparison is required, not stylistic:
+Cloudflare's `contains` is case-sensitive, so a bare `contains "AhrefsBot"`
+installs cleanly and matches nothing. A test pins that too.
+
+**What this does not catch.** UA blocking only stops crawlers that identify
+themselves honestly. A UA-rotating farm walked ~2,500 climb-view URLs on
+2026-08-22 behind ordinary Chrome/Firefox UAs (PostHog: 2,031 distinct persons,
+one pageview each, `$referring_domain` null on every event). That population
+needs an edge rate-limit rule, which is not managed here yet.
+
 ### One-time: create the API token
 
 Create ONE token covering both today's zone tooling and the upcoming OpenNext
@@ -60,7 +128,10 @@ Create a token at <https://dash.cloudflare.com/profile/api-tokens> scoped to the
 
 - **Zone.Zone Read** — resolve the zone id by name + read the zone list
 - **Zone.DNS Edit** — patch the `ws` record proxied flag
-- **Zone.Cache Rules Edit** — create/update the `/og/` cache rule
+- **Zone.Cache Rules Edit** — create/update the `/og/` and board-render cache rules
+- **Zone.WAF Edit** — create/update the two crawler rules (see below). Without
+  this scope `cf:apply` fails on the WAF phase while the cache rules still apply,
+  so a partially-converged zone is the failure mode, not a silent skip.
 - **Zone.Zone Settings Read** — read the SSL/TLS mode
 - **Zone.Zone Settings Edit** — only if you'll run `--allow-zone-ssl`
 
@@ -103,6 +174,33 @@ straight through to Railway.
 `wss://ws.boardsesh.com/graphql` still connects (web party mode + mobile app);
 `curl -sI 'https://ws.boardsesh.com/og/climb?...'` twice — the second response
 shows `cf-cache-status: HIT`.
+
+For the www rules:
+
+```bash
+# Board-render becomes cacheable: DYNAMIC -> MISS -> HIT.
+B='https://www.boardsesh.com/api/internal/board-render?board_name=kilter&layout_id=1&size_id=10&set_ids=1,20&frames=p1085r15p1128r12&include_background=1'
+curl -sI "$B" | grep -i cf-cache-status
+curl -sI "$B" | grep -i cf-cache-status
+
+# Blocked crawlers get a Cloudflare 403 and never reach the origin; allowed ones
+# still do. `x-vercel-id` present == the request reached Vercel, which is the
+# assertion that matters — a 403 alone could come from anywhere.
+for UA in "AhrefsBot/7.0" "SemrushBot/7~bl" "Brave-Search/1.0" "Googlebot/2.1" "Bingbot/2.0"; do
+  printf '%-18s %s ' "$UA" "$(curl -sS -o /dev/null -A "$UA" -w '%{http_code}' https://www.boardsesh.com/)"
+  curl -sSI -A "$UA" https://www.boardsesh.com/ | grep -ci '^x-vercel-id' | sed 's/^/reached-vercel:/'
+done
+```
+
+Expect Ahrefs and Semrush at `403 reached-vercel:0`; Brave, Google and Bing at
+`200 reached-vercel:1`.
+
+Then confirm the compute actually fell — the point of the exercise. Rerun the
+route breakdown a day later and compare against the table above:
+
+```
+get_runtime_logs since=6h group_by=route source=["serverless"] environment=production
+```
 
 ### CI auto-apply
 

--- a/docs/og-climb.md
+++ b/docs/og-climb.md
@@ -72,89 +72,13 @@ best-effort — failures are swallowed and never delay sharing.
 - Quick prod check:
   `curl -o /dev/null -s -w 'code=%{http_code} ttfb=%{time_starttransfer}s\n' 'https://ws.boardsesh.com/og/climb?board_name=kilter&layout_id=1&size_id=10&set_ids=1,20&frames=p1080r15p1202r12'`
 
-## Cloudflare in front of ws.boardsesh.com (edge-caching the og image)
+## Cloudflare edge layer
 
-`ws.boardsesh.com` is a single-region Railway origin; distant clients (and the
-iOS share sheet, which fetches previews from the sender's phone) pay full RTT
-per image. Fronting it with Cloudflare edge-caches the immutable og responses
-globally.
-
-The zone config is managed from the repo — not dashboard clicks — by
-`scripts/cloudflare-apply.ts` (registered as `vp run cf:apply`). The desired
-state is declared in `infra/cloudflare/config.ts`; the script diffs it against
-the live zone and, with `--apply`, converges only the delta (idempotent, so a
-second run is a no-op).
-
-What it manages (and nothing else on the zone):
-
-- **DNS** — the `ws` record's proxied flag → orange cloud. The record's
-  target/type/content are not managed; the record must already exist.
-- **Cache** — one rule in the `http_request_cache_settings` phase, expression
-  `(http.host eq "ws.boardsesh.com" and starts_with(http.request.uri.path, "/og/"))`
-  → eligible for cache, edge TTL "use cache-control if present, bypass if not"
-  so error responses (400/429/503 — sent without Cache-Control) are never
-  edge-cached, and browser TTL "respect origin" (successful responses are `immutable`,
-  1y). Every other rule already in that phase is preserved verbatim (the tool
-  finds its own rule by a stable description marker and touches only that one),
-  so `/graphql`, REST, and WebSocket upgrades keep bypassing cache.
-- **SSL** — asserts the zone SSL/TLS mode is `strict` (Full (strict); Flexible
-  causes redirect loops with Railway). If the zone-wide mode is weaker the tool
-  **reports it but does not change it** — the setting affects every hostname on
-  `boardsesh.com`. Pass `--allow-zone-ssl` to opt into setting it.
-
-Code prerequisite (shipped): the og rate limiter prefers `CF-Connecting-IP`, so
-per-client buckets survive the proxy hop.
-
-### One-time: create the API token
-
-Create a token at <https://dash.cloudflare.com/profile/api-tokens> scoped to the
-`boardsesh.com` zone with:
-
-- **Zone.Zone Read** — resolve the zone id by name + read the zone list
-- **Zone.DNS Edit** — patch the `ws` record proxied flag
-- **Zone.Cache Rules Edit** — create/update the `/og/` cache rule
-- **Zone.Zone Settings Read** — read the SSL/TLS mode
-- **Zone.Zone Settings Edit** — only if you'll run `--allow-zone-ssl`
-
-### Flip runbook
-
-```bash
-# 1. Dry-run (default) — prints the diff, exits non-zero if there's drift. Never mutates.
-CLOUDFLARE_API_TOKEN=... vp run cf:apply
-
-# 2. Apply — performs only the needed mutations.
-CLOUDFLARE_API_TOKEN=... vp run cf:apply -- --apply
-
-# (optional) also set the zone-wide SSL mode when it's weaker than strict:
-CLOUDFLARE_API_TOKEN=... vp run cf:apply -- --apply --allow-zone-ssl
-```
-
-`CLOUDFLARE_ZONE_ID` is optional — when unset, the zone id is resolved by name.
-
-Confirm WebSockets are enabled for the zone (Network tab; on by default on
-current plans). WebSocket caveat: the cache rule scopes to `/og/` only, so
-`wss://ws.boardsesh.com/graphql` upgrades and every other path continue to pass
-straight through to Railway.
-
-### Verify
-
-`wss://ws.boardsesh.com/graphql` still connects (web party mode + mobile app);
-`curl -sI 'https://ws.boardsesh.com/og/climb?...'` twice — the second response
-shows `cf-cache-status: HIT`.
-
-### CI auto-apply
-
-`production-deploy.yml` runs `vp run cf:apply -- --apply` on pushes to main
-that touch `infra/cloudflare/` or the apply script (and on manual dispatch),
-reading `CLOUDFLARE_API_TOKEN` from the GitHub **Production** environment
-secrets: `gh secret set CLOUDFLARE_API_TOKEN --env Production`. A failing job
-means unapplied drift (often a blocked zone-SSL change) — run the dry-run
-locally to see the plan.
-
-### Rollback
-
-Set `proxied: false` on the `ws` record in `infra/cloudflare/config.ts` and
-`vp run cf:apply -- --apply`, or grey-cloud the record in the dashboard.
+`ws.boardsesh.com` is fronted by the Cloudflare proxy so og images edge-cache
+globally (distant clients and the iOS share sheet fetch from a nearby colo
+instead of the single-region Railway origin). The zone config, the apply
+tooling (`vp run cf:apply`), token setup, CI auto-apply, and the rollback
+runbook all live in **`docs/cloudflare.md`**.
 
 - Web points `og:image` here via `buildOgBoardRenderUrl`
   (`packages/web/app/components/board-renderer/util.ts`), which derives the

--- a/docs/og-climb.md
+++ b/docs/og-climb.md
@@ -77,21 +77,75 @@ best-effort — failures are swallowed and never delay sharing.
 `ws.boardsesh.com` is a single-region Railway origin; distant clients (and the
 iOS share sheet, which fetches previews from the sender's phone) pay full RTT
 per image. Fronting it with Cloudflare edge-caches the immutable og responses
-globally. Flip runbook (dashboard):
+globally.
 
-1. Code prerequisite (shipped): the og rate limiter prefers `CF-Connecting-IP`,
-   so per-client buckets survive the proxy hop.
-2. Cloudflare DNS: toggle the `ws` record to Proxied (orange cloud). SSL/TLS
-   mode must be Full (strict) — Flexible causes redirect loops with Railway.
-3. Cache Rule: host `ws.boardsesh.com` AND path starts with `/og/` → Eligible
-   for cache, respect origin TTL (responses are `immutable`, 1y). Leave every
-   other path default so `/graphql`, REST, and WebSocket upgrades bypass cache.
-4. Confirm WebSockets are enabled for the zone (Network tab; on by default on
-   current plans).
-5. Verify: `wss://ws.boardsesh.com/graphql` still connects (web party mode +
-   mobile app); `curl -sI 'https://ws.boardsesh.com/og/climb?...'` twice —
-   second response shows `cf-cache-status: HIT`. Rollback = grey-cloud the
-   record.
+The zone config is managed from the repo — not dashboard clicks — by
+`scripts/cloudflare-apply.ts` (registered as `vp run cf:apply`). The desired
+state is declared in `infra/cloudflare/config.ts`; the script diffs it against
+the live zone and, with `--apply`, converges only the delta (idempotent, so a
+second run is a no-op).
+
+What it manages (and nothing else on the zone):
+
+- **DNS** — the `ws` record's proxied flag → orange cloud. The record's
+  target/type/content are not managed; the record must already exist.
+- **Cache** — one rule in the `http_request_cache_settings` phase, expression
+  `(http.host eq "ws.boardsesh.com" and starts_with(http.request.uri.path, "/og/"))`
+  → eligible for cache, edge TTL "use cache-control if present, bypass if not"
+  so error responses (400/429/503 — sent without Cache-Control) are never
+  edge-cached, and browser TTL "respect origin" (successful responses are `immutable`,
+  1y). Every other rule already in that phase is preserved verbatim (the tool
+  finds its own rule by a stable description marker and touches only that one),
+  so `/graphql`, REST, and WebSocket upgrades keep bypassing cache.
+- **SSL** — asserts the zone SSL/TLS mode is `strict` (Full (strict); Flexible
+  causes redirect loops with Railway). If the zone-wide mode is weaker the tool
+  **reports it but does not change it** — the setting affects every hostname on
+  `boardsesh.com`. Pass `--allow-zone-ssl` to opt into setting it.
+
+Code prerequisite (shipped): the og rate limiter prefers `CF-Connecting-IP`, so
+per-client buckets survive the proxy hop.
+
+### One-time: create the API token
+
+Create a token at <https://dash.cloudflare.com/profile/api-tokens> scoped to the
+`boardsesh.com` zone with:
+
+- **Zone.Zone Read** — resolve the zone id by name + read the zone list
+- **Zone.DNS Edit** — patch the `ws` record proxied flag
+- **Zone.Cache Rules Edit** — create/update the `/og/` cache rule
+- **Zone.Zone Settings Read** — read the SSL/TLS mode
+- **Zone.Zone Settings Edit** — only if you'll run `--allow-zone-ssl`
+
+### Flip runbook
+
+```bash
+# 1. Dry-run (default) — prints the diff, exits non-zero if there's drift. Never mutates.
+CLOUDFLARE_API_TOKEN=... vp run cf:apply
+
+# 2. Apply — performs only the needed mutations.
+CLOUDFLARE_API_TOKEN=... vp run cf:apply -- --apply
+
+# (optional) also set the zone-wide SSL mode when it's weaker than strict:
+CLOUDFLARE_API_TOKEN=... vp run cf:apply -- --apply --allow-zone-ssl
+```
+
+`CLOUDFLARE_ZONE_ID` is optional — when unset, the zone id is resolved by name.
+
+Confirm WebSockets are enabled for the zone (Network tab; on by default on
+current plans). WebSocket caveat: the cache rule scopes to `/og/` only, so
+`wss://ws.boardsesh.com/graphql` upgrades and every other path continue to pass
+straight through to Railway.
+
+### Verify
+
+`wss://ws.boardsesh.com/graphql` still connects (web party mode + mobile app);
+`curl -sI 'https://ws.boardsesh.com/og/climb?...'` twice — the second response
+shows `cf-cache-status: HIT`.
+
+### Rollback
+
+Set `proxied: false` on the `ws` record in `infra/cloudflare/config.ts` and
+`vp run cf:apply -- --apply`, or grey-cloud the record in the dashboard.
 
 - Web points `og:image` here via `buildOgBoardRenderUrl`
   (`packages/web/app/components/board-renderer/util.ts`), which derives the

--- a/docs/og-climb.md
+++ b/docs/og-climb.md
@@ -142,6 +142,15 @@ straight through to Railway.
 `curl -sI 'https://ws.boardsesh.com/og/climb?...'` twice — the second response
 shows `cf-cache-status: HIT`.
 
+### CI auto-apply
+
+`production-deploy.yml` runs `vp run cf:apply -- --apply` on pushes to main
+that touch `infra/cloudflare/` or the apply script (and on manual dispatch),
+reading `CLOUDFLARE_API_TOKEN` from the GitHub **Production** environment
+secrets: `gh secret set CLOUDFLARE_API_TOKEN --env Production`. A failing job
+means unapplied drift (often a blocked zone-SSL change) — run the dry-run
+locally to see the plan.
+
 ### Rollback
 
 Set `proxied: false` on the `ws` record in `infra/cloudflare/config.ts` and

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -5,10 +5,18 @@
 // reads it, diffs it against the live zone, and (only with --apply) converges the
 // delta.
 //
-// Why this exists: we front ws.boardsesh.com (a single-region Railway origin) with
-// the Cloudflare proxy so the immutable /og/* share-card images edge-cache globally.
-// Everything else on that host (/graphql, REST, WebSocket upgrades) must bypass the
-// cache. The manual runbook this replaces lives in docs/og-climb.md.
+// Why this exists, in two halves:
+//
+// 1. ws.boardsesh.com (a single-region Railway origin) sits behind the Cloudflare
+//    proxy so the immutable /og/* share-card images edge-cache globally. Everything
+//    else on that host (/graphql, REST, WebSocket upgrades) must bypass the cache.
+//    The manual runbook this replaces lives in docs/og-climb.md.
+//
+// 2. www.boardsesh.com is the Vercel-backed marketing/SEO surface, and the two rules
+//    below are cost controls for it (#4650, epic #4648). Measured 2026-08-25:
+//    ~442,600 Vercel function invocations/day, of which /api/internal/board-render
+//    was ~215,600 and the climb-view page ~203,900, against a published sitemap of
+//    only ~60k URLs and ~2,000 homepage hits. See docs/cloudflare.md.
 
 /** The Cloudflare zone this config manages. Resolved to a zone id by name when CLOUDFLARE_ZONE_ID is unset. */
 export const ZONE_NAME = 'boardsesh.com';
@@ -19,6 +27,20 @@ export const WS_HOSTNAME = 'ws.boardsesh.com';
 /** Path prefix whose responses are immutable (`Cache-Control: … immutable`, 1y) and safe to edge-cache. */
 export const OG_PATH_PREFIX = '/og/';
 
+/** The Vercel-backed www origin whose crawl cost these rules exist to cap. */
+export const WWW_HOSTNAME = 'www.boardsesh.com';
+
+/**
+ * The WASM+sharp board-image renderer on www. Its responses already carry
+ * `cache-control: public, max-age=31536000, immutable` and a matching
+ * `CDN-Cache-Control`, but Cloudflare caches by FILE EXTENSION by default and this
+ * path has none — so it was measured at `cf-cache-status: DYNAMIC` on 2026-08-25
+ * while `/_next/static/*.js` on the same zone was a HIT. Every image byte was
+ * therefore transiting Cloudflare to Vercel (~54 GB/day). A cache rule is the whole
+ * fix; no origin header change is needed or wanted.
+ */
+export const BOARD_RENDER_PATH_PREFIX = '/api/internal/board-render';
+
 /**
  * Stable marker identifying the one cache rule this tool owns. The apply script
  * finds our rule by this exact description and upserts only it, leaving every other
@@ -28,8 +50,20 @@ export const OG_PATH_PREFIX = '/og/';
  */
 export const CACHE_RULE_DESCRIPTION = 'boardsesh:og-edge-cache (managed by scripts/cloudflare-apply.ts)';
 
+/** Marker for the www board-render cache rule. Same never-rename contract as above. */
+export const BOARD_RENDER_CACHE_RULE_DESCRIPTION =
+  'boardsesh:board-render-edge-cache (managed by scripts/cloudflare-apply.ts)';
+
+/** Markers for the two WAF custom rules. Same never-rename contract as above. */
+export const CRAWLER_ALLOW_RULE_DESCRIPTION =
+  'boardsesh:allow-search-crawlers (managed by scripts/cloudflare-apply.ts)';
+export const CRAWLER_BLOCK_RULE_DESCRIPTION = 'boardsesh:block-seo-scrapers (managed by scripts/cloudflare-apply.ts)';
+
 /** The rulesets phase that holds cache-eligibility rules. */
 export const CACHE_RULE_PHASE = 'http_request_cache_settings';
+
+/** The rulesets phase that holds WAF custom rules. */
+export const WAF_RULE_PHASE = 'http_request_firewall_custom';
 
 /** Cloudflare SSL/TLS modes ordered weakest → strongest, for the "is the live mode weaker?" check. */
 export const SSL_MODE_STRENGTH = ['off', 'flexible', 'full', 'strict'] as const;
@@ -74,15 +108,112 @@ export interface SslDesired {
   mode: SslMode;
 }
 
+/**
+ * A WAF custom rule. `skip` carries `{ ruleset: 'current' }` — skip every
+ * remaining rule in this phase — which is what makes the allow rule a true
+ * escape hatch. `block` needs no action parameters.
+ */
+export interface WafRuleDesired {
+  description: string;
+  expression: string;
+  action: 'block' | 'skip';
+  action_parameters?: { ruleset: 'current' };
+  enabled: boolean;
+}
+
 export interface CloudflareDesiredState {
   zoneName: string;
   dns: DnsRecordDesired;
-  cacheRule: CacheRuleDesired;
+  /** Order is not significant: cache rules are matched by expression, not precedence. */
+  cacheRules: CacheRuleDesired[];
+  /**
+   * Order IS significant and is preserved on apply: the allow rule must be
+   * evaluated before the block rule, or a token collision would take out a
+   * search engine. See upsertManagedRules in ./plan.
+   */
+  wafRules: WafRuleDesired[];
   ssl: SslDesired;
 }
 
 /** The Cloudflare Rules-language expression matching og share-card requests on the ws host. */
 export const OG_CACHE_EXPRESSION = `(http.host eq "${WS_HOSTNAME}" and starts_with(http.request.uri.path, "${OG_PATH_PREFIX}"))`;
+
+/** Board-image renders on www. Host-scoped so a future origin on another hostname can't inherit it silently. */
+export const BOARD_RENDER_CACHE_EXPRESSION = `(http.host eq "${WWW_HOSTNAME}" and starts_with(http.request.uri.path, "${BOARD_RENDER_PATH_PREFIX}"))`;
+
+/**
+ * Search engines and social unfurlers that must never be blocked. Brave runs its
+ * OWN index (not a Bing/Google reseller), so losing it loses real coverage — it is
+ * listed explicitly rather than assumed.
+ *
+ * Cloudflare's `cf.client.bot` "verified bot" signal is deliberately NOT used here:
+ * AhrefsBot and SemrushBot are themselves verified bots, so that field is true for
+ * precisely the crawlers CRAWLER_BLOCK_TOKENS exists to stop.
+ */
+export const CRAWLER_ALLOW_TOKENS = [
+  'googlebot',
+  'google-inspectiontool',
+  'storebot-google',
+  'google-pagerenderer',
+  'bingbot',
+  'bingpreview',
+  'duckduckbot',
+  'brave-search',
+  'bravebot',
+  'applebot',
+  // Share-card unfurlers. Blocking these breaks link previews, not crawling.
+  'twitterbot',
+  'facebookexternalhit',
+  'slackbot',
+  'discordbot',
+  'linkedinbot',
+  'telegrambot',
+  'whatsapp',
+] as const;
+
+/**
+ * Commercial SEO/backlink crawlers. Each was verified reaching our origin on
+ * 2026-08-24 by the #4716 probe. They sell backlink data and send Boardsesh no
+ * traffic, so they are pure cost: page render, DB reads, and (before #4650's warm
+ * gate) a 3 GB board-render invocation each.
+ *
+ * `dotbot/` keeps its slash because the bare token is short enough to collide with
+ * an unrelated UA; the rest are distinctive on their own.
+ *
+ * NOT listed, on purpose:
+ * - The AI crawlers (ClaudeBot, GPTBot, PerplexityBot, Bytespider, CCBot, ...) —
+ *   the same probe got `HTTP/2 403` from `server: cloudflare` for every one, so a
+ *   separate zone rule already stops them and duplicating it here would be dead
+ *   config that drifts.
+ * - `archive.org_bot` — it reaches us and it loops, but it is the Internet Archive,
+ *   it is low volume, and excluding it is a values call rather than a cost one.
+ */
+export const CRAWLER_BLOCK_TOKENS = [
+  'ahrefsbot',
+  'ahrefssiteaudit',
+  'semrushbot',
+  'dataforseobot',
+  'mj12bot',
+  'dotbot/',
+  'blexbot',
+  'barkrowler',
+  'serpstatbot',
+  'seznambot',
+  'zoominfobot',
+  'screaming frog',
+] as const;
+
+/**
+ * Build a user-agent alternation. `lower()` is load-bearing: Cloudflare's `contains`
+ * is CASE-SENSITIVE, so a bare `contains "AhrefsBot"` silently misses `ahrefsbot`
+ * and the rule looks installed while matching nothing.
+ */
+export function buildUserAgentExpression(tokens: readonly string[]): string {
+  return tokens.map((token) => `lower(http.user_agent) contains "${token}"`).join(' or ');
+}
+
+export const CRAWLER_ALLOW_EXPRESSION = buildUserAgentExpression(CRAWLER_ALLOW_TOKENS);
+export const CRAWLER_BLOCK_EXPRESSION = buildUserAgentExpression(CRAWLER_BLOCK_TOKENS);
 
 export const desiredCloudflareState: CloudflareDesiredState = {
   zoneName: ZONE_NAME,
@@ -90,19 +221,52 @@ export const desiredCloudflareState: CloudflareDesiredState = {
     name: WS_HOSTNAME,
     proxied: true,
   },
-  cacheRule: {
-    description: CACHE_RULE_DESCRIPTION,
-    expression: OG_CACHE_EXPRESSION,
-    action: 'set_cache_settings',
-    action_parameters: {
-      cache: true,
-      edge_ttl: { mode: 'bypass_by_default' },
-      // Pin browser TTL to the origin header so a zone-level Browser Cache TTL
-      // can't override the 1y immutable max-age.
-      browser_ttl: { mode: 'respect_origin' },
+  cacheRules: [
+    {
+      description: CACHE_RULE_DESCRIPTION,
+      expression: OG_CACHE_EXPRESSION,
+      action: 'set_cache_settings',
+      action_parameters: {
+        cache: true,
+        edge_ttl: { mode: 'bypass_by_default' },
+        // Pin browser TTL to the origin header so a zone-level Browser Cache TTL
+        // can't override the 1y immutable max-age.
+        browser_ttl: { mode: 'respect_origin' },
+      },
+      enabled: true,
     },
-    enabled: true,
-  },
+    {
+      description: BOARD_RENDER_CACHE_RULE_DESCRIPTION,
+      expression: BOARD_RENDER_CACHE_EXPRESSION,
+      action: 'set_cache_settings',
+      action_parameters: {
+        cache: true,
+        // Same reasoning as the og rule: a successful render is immutable for a
+        // year, while a 503 from the render semaphore's load-shedding path sends
+        // `Cache-Control: no-store` and a 400 sends none at all. bypass_by_default
+        // caches the first and never the others.
+        edge_ttl: { mode: 'bypass_by_default' },
+        browser_ttl: { mode: 'respect_origin' },
+      },
+      enabled: true,
+    },
+  ],
+  wafRules: [
+    // MUST stay first — see the ordering contract on CloudflareDesiredState.wafRules.
+    {
+      description: CRAWLER_ALLOW_RULE_DESCRIPTION,
+      expression: CRAWLER_ALLOW_EXPRESSION,
+      action: 'skip',
+      action_parameters: { ruleset: 'current' },
+      enabled: true,
+    },
+    {
+      description: CRAWLER_BLOCK_RULE_DESCRIPTION,
+      expression: CRAWLER_BLOCK_EXPRESSION,
+      action: 'block',
+      enabled: true,
+    },
+  ],
   ssl: {
     mode: REQUIRED_SSL_MODE,
   },

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -1,0 +1,105 @@
+/// <reference types="node" />
+
+// Declarative desired-state for the Cloudflare-managed boardsesh.com zone. This
+// is plain typed data — no side effects, no API calls. scripts/cloudflare-apply.ts
+// reads it, diffs it against the live zone, and (only with --apply) converges the
+// delta.
+//
+// Why this exists: we front ws.boardsesh.com (a single-region Railway origin) with
+// the Cloudflare proxy so the immutable /og/* share-card images edge-cache globally.
+// Everything else on that host (/graphql, REST, WebSocket upgrades) must bypass the
+// cache. The manual runbook this replaces lives in docs/og-climb.md.
+
+/** The Cloudflare zone this config manages. Resolved to a zone id by name when CLOUDFLARE_ZONE_ID is unset. */
+export const ZONE_NAME = 'boardsesh.com';
+
+/** The Railway-backed host we put behind the Cloudflare proxy. */
+export const WS_HOSTNAME = 'ws.boardsesh.com';
+
+/** Path prefix whose responses are immutable (`Cache-Control: … immutable`, 1y) and safe to edge-cache. */
+export const OG_PATH_PREFIX = '/og/';
+
+/**
+ * Stable marker identifying the one cache rule this tool owns. The apply script
+ * finds our rule by this exact description and upserts only it, leaving every other
+ * rule in the cache phase untouched. Never change it without a migration — a new
+ * value orphans the old rule (the tool would create a second rule and leave the
+ * first behind).
+ */
+export const CACHE_RULE_DESCRIPTION = 'boardsesh:og-edge-cache (managed by scripts/cloudflare-apply.ts)';
+
+/** The rulesets phase that holds cache-eligibility rules. */
+export const CACHE_RULE_PHASE = 'http_request_cache_settings';
+
+/** Cloudflare SSL/TLS modes ordered weakest → strongest, for the "is the live mode weaker?" check. */
+export const SSL_MODE_STRENGTH = ['off', 'flexible', 'full', 'strict'] as const;
+export type SslMode = (typeof SSL_MODE_STRENGTH)[number];
+
+/** SSL/TLS mode we require for the zone. `strict` = Full (strict); Flexible causes redirect loops with Railway. */
+export const REQUIRED_SSL_MODE: SslMode = 'strict';
+
+export interface DnsRecordDesired {
+  /** DNS record name (host). We assert only the proxied flag on the existing record; content/type are not managed. */
+  name: string;
+  /** Orange-cloud the record so requests transit the Cloudflare edge. */
+  proxied: boolean;
+}
+
+export interface CacheRuleActionParameters {
+  /** true = eligible for cache. */
+  cache: boolean;
+  edge_ttl: {
+    /**
+     * bypass_by_default = honour Cache-Control when present (og 200s are
+     * immutable, 1y) and BYPASS when absent — error responses (400/429/503)
+     * send no Cache-Control and must never be edge-cached.
+     */
+    mode: 'bypass_by_default';
+  };
+}
+
+export interface CacheRuleDesired {
+  description: string;
+  expression: string;
+  action: 'set_cache_settings';
+  action_parameters: CacheRuleActionParameters;
+  enabled: boolean;
+}
+
+export interface SslDesired {
+  mode: SslMode;
+}
+
+export interface CloudflareDesiredState {
+  zoneName: string;
+  dns: DnsRecordDesired;
+  cacheRule: CacheRuleDesired;
+  ssl: SslDesired;
+}
+
+/** The Cloudflare Rules-language expression matching og share-card requests on the ws host. */
+export const OG_CACHE_EXPRESSION = `(http.host eq "${WS_HOSTNAME}" and starts_with(http.request.uri.path, "${OG_PATH_PREFIX}"))`;
+
+export const desiredCloudflareState: CloudflareDesiredState = {
+  zoneName: ZONE_NAME,
+  dns: {
+    name: WS_HOSTNAME,
+    proxied: true,
+  },
+  cacheRule: {
+    description: CACHE_RULE_DESCRIPTION,
+    expression: OG_CACHE_EXPRESSION,
+    action: 'set_cache_settings',
+    action_parameters: {
+      cache: true,
+      edge_ttl: { mode: 'bypass_by_default' },
+      // Pin browser TTL to the origin header so a zone-level Browser Cache TTL
+      // can't override the 1y immutable max-age.
+      browser_ttl: { mode: 'respect_origin' },
+    },
+    enabled: true,
+  },
+  ssl: {
+    mode: REQUIRED_SSL_MODE,
+  },
+};

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -56,6 +56,10 @@ export interface CacheRuleActionParameters {
      */
     mode: 'bypass_by_default';
   };
+  browser_ttl: {
+    /** Honour the origin max-age so a zone-level Browser Cache TTL can't override it. */
+    mode: 'respect_origin';
+  };
 }
 
 export interface CacheRuleDesired {

--- a/infra/cloudflare/plan.ts
+++ b/infra/cloudflare/plan.ts
@@ -1,0 +1,227 @@
+/// <reference types="node" />
+
+// Pure planning logic for the Cloudflare apply tool: diff desired-vs-live and merge
+// our cache rule into an existing rules array without disturbing foreign rules. No
+// I/O, no globals — everything here is deterministic and unit-tested in
+// scripts/cloudflare-apply.test.ts. The I/O (fetching live state, applying changes)
+// lives in scripts/cloudflare-apply.ts.
+
+import { SSL_MODE_STRENGTH, ZONE_NAME } from './config';
+import type { CacheRuleDesired, DnsRecordDesired, SslDesired, SslMode } from './config';
+
+/** A DNS record as Cloudflare returns it. We only manage `proxied`; the rest is context. */
+export interface LiveDnsRecord {
+  id: string;
+  name: string;
+  type: string;
+  content: string;
+  proxied: boolean;
+}
+
+/**
+ * A rule inside a ruleset phase, as Cloudflare returns it. Cloudflare adds read-only
+ * fields (version, last_updated, ref) we neither set nor rely on; foreign rules are
+ * preserved verbatim at runtime by object spread even when a field isn't named here.
+ */
+export interface RulesetRule {
+  id?: string;
+  description?: string;
+  expression?: string;
+  action?: string;
+  // Widened to `unknown`: foreign rules carry arbitrary action parameters we never
+  // read, and it keeps our strongly-typed desired rule assignable here. Compared
+  // structurally via jsonEqual, never accessed by shape.
+  action_parameters?: unknown;
+  enabled?: boolean;
+  version?: string;
+  last_updated?: string;
+  ref?: string;
+}
+
+/** Live zone state the plan diffs against, gathered by the apply script's read phase. */
+export interface LiveState {
+  dnsRecord: LiveDnsRecord;
+  cacheRules: RulesetRule[];
+  sslMode: string;
+}
+
+export interface PlanOptions {
+  /** Permit the (opt-in) zone-wide SSL mutation. When false, a weaker SSL mode is reported but not applied. */
+  allowZoneSsl: boolean;
+}
+
+export interface PlannedChange {
+  resource: 'dns' | 'cache-rule' | 'ssl';
+  /** One-line human-readable summary of what would change. */
+  summary: string;
+  /** Optional extra context printed under the summary. */
+  detail?: string;
+  /**
+   * true = a change that is NOT auto-applied: the zone-wide SSL mutation
+   * requires an explicit opt-in flag (it affects every host on the zone), and
+   * the proxied flip is held back while a required SSL change is blocked.
+   */
+  blocked?: boolean;
+}
+
+/** Deep structural equality for plain JSON values (objects, arrays, primitives). Key order independent. */
+export function jsonEqual(left: unknown, right: unknown): boolean {
+  if (left === right) return true;
+  if (typeof left !== typeof right) return false;
+  if (left === null || right === null) return left === right;
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false;
+    return left.every((item, index) => jsonEqual(item, right[index]));
+  }
+
+  if (typeof left === 'object' && typeof right === 'object') {
+    const leftRecord = left as Record<string, unknown>;
+    const rightRecord = right as Record<string, unknown>;
+    const leftKeys = Object.keys(leftRecord);
+    const rightKeys = Object.keys(rightRecord);
+    if (leftKeys.length !== rightKeys.length) return false;
+    return leftKeys.every(
+      (key) => Object.prototype.hasOwnProperty.call(rightRecord, key) && jsonEqual(leftRecord[key], rightRecord[key]),
+    );
+  }
+
+  return false;
+}
+
+/** True when a live rule already matches the fields we manage (identity is by description, checked by the caller). */
+export function cacheRuleMatches(liveRule: RulesetRule, desiredRule: CacheRuleDesired): boolean {
+  return (
+    liveRule.expression === desiredRule.expression &&
+    liveRule.action === desiredRule.action &&
+    (liveRule.enabled ?? true) === desiredRule.enabled &&
+    jsonEqual(liveRule.action_parameters, desiredRule.action_parameters)
+  );
+}
+
+export interface CacheRuleUpsertResult {
+  /** The rules array to PUT back. Foreign rules keep their order and every field verbatim. */
+  rules: RulesetRule[];
+  /** Whether our rule was created or updated (false = already in the desired state). */
+  changed: boolean;
+}
+
+/**
+ * Merge our desired cache rule into an existing rules array. Our rule is identified
+ * only by its description marker, so:
+ *   - not present  → append it (create).
+ *   - present, matches desired → return the array unchanged (no-op).
+ *   - present, differs → replace it in place, keeping its Cloudflare-assigned id and
+ *     its position; every OTHER rule is preserved verbatim.
+ */
+export function upsertCacheRule(existingRules: RulesetRule[], desiredRule: CacheRuleDesired): CacheRuleUpsertResult {
+  const ourIndex = existingRules.findIndex((rule) => rule.description === desiredRule.description);
+
+  if (ourIndex === -1) {
+    return { rules: [...existingRules, { ...desiredRule }], changed: true };
+  }
+
+  if (cacheRuleMatches(existingRules[ourIndex], desiredRule)) {
+    return { rules: existingRules, changed: false };
+  }
+
+  const existingId = existingRules[ourIndex].id;
+  const replacement: RulesetRule = existingId ? { id: existingId, ...desiredRule } : { ...desiredRule };
+  const rules = existingRules.slice();
+  rules[ourIndex] = replacement;
+  return { rules, changed: true };
+}
+
+/** Plan the DNS proxied-flag change, or null when already at the desired value. */
+export function diffDnsRecord(desired: DnsRecordDesired, liveRecord: LiveDnsRecord): PlannedChange | null {
+  if (liveRecord.proxied === desired.proxied) return null;
+  return {
+    resource: 'dns',
+    summary: `DNS ${desired.name}: set proxied ${liveRecord.proxied} → ${desired.proxied}`,
+    detail: `record ${liveRecord.type} ${liveRecord.name} → ${liveRecord.content} (target unchanged; only the proxied flag is managed)`,
+  };
+}
+
+/** Plan the cache-rule change, or null when our rule already matches desired. */
+export function diffCacheRule(existingRules: RulesetRule[], desiredRule: CacheRuleDesired): PlannedChange | null {
+  const { changed } = upsertCacheRule(existingRules, desiredRule);
+  if (!changed) return null;
+
+  const alreadyPresent = existingRules.some((rule) => rule.description === desiredRule.description);
+  const foreignCount = existingRules.filter((rule) => rule.description !== desiredRule.description).length;
+  return {
+    resource: 'cache-rule',
+    summary: alreadyPresent
+      ? `Cache rule "${desiredRule.description}" differs from desired — will update`
+      : `Cache rule "${desiredRule.description}" missing — will create`,
+    detail:
+      `expression: ${desiredRule.expression}` +
+      (foreignCount > 0 ? `\n    (${foreignCount} other rule(s) in this phase left untouched)` : ''),
+  };
+}
+
+/** Index of a mode in the weakest→strongest order, or -1 for an unknown mode. */
+function sslModeStrength(mode: string): number {
+  return SSL_MODE_STRENGTH.indexOf(mode as SslMode);
+}
+
+/**
+ * Plan the SSL mode change, or null when the live mode already meets the requirement.
+ * We only ever upgrade toward the desired mode — never downgrade — and we never
+ * silently mutate a zone-wide setting: when the live mode is weaker and allowZoneSsl
+ * is false the change is returned `blocked`, so dry-run reports drift but --apply
+ * leaves the zone-wide setting alone.
+ */
+export function diffSslMode(desiredMode: SslMode, liveMode: string, allowZoneSsl: boolean): PlannedChange | null {
+  if (liveMode === desiredMode) return null;
+
+  const liveStrength = sslModeStrength(liveMode);
+  const desiredStrength = sslModeStrength(desiredMode);
+  // Don't touch a zone that's already at least as strict as we require (or stricter).
+  if (liveStrength >= 0 && liveStrength >= desiredStrength) return null;
+
+  return {
+    resource: 'ssl',
+    blocked: !allowZoneSsl,
+    summary: `Zone SSL mode "${liveMode}" is weaker than required "${desiredMode}"`,
+    detail: allowZoneSsl
+      ? `Will set the zone-wide SSL/TLS mode to "${desiredMode}" (--allow-zone-ssl given).`
+      : `Left unchanged: the zone-wide SSL/TLS setting affects every hostname on ${ZONE_NAME}. ` +
+        `Re-run with --allow-zone-ssl to set it, or change it in the Cloudflare dashboard.`,
+  };
+}
+
+/** Full desired-vs-live diff: the ordered list of changes --apply would attempt. Empty = in sync. */
+export function buildPlan(
+  desired: { dns: DnsRecordDesired; cacheRule: CacheRuleDesired; ssl: SslDesired },
+  live: LiveState,
+  options: PlanOptions,
+): PlannedChange[] {
+  const changes: PlannedChange[] = [];
+
+  const dnsChange = diffDnsRecord(desired.dns, live.dnsRecord);
+
+  const cacheChange = diffCacheRule(live.cacheRules, desired.cacheRule);
+
+  const sslChange = diffSslMode(desired.ssl.mode, live.sslMode, options.allowZoneSsl);
+  // Order matters on cutover: SSL and the cache rule must be live BEFORE the
+  // proxied flip, or traffic transits Cloudflare without them (Flexible-SSL
+  // redirect loops would take the WebSocket host down).
+  if (sslChange) changes.push(sslChange);
+  if (cacheChange) changes.push(cacheChange);
+  if (dnsChange) {
+    if (desired.dns.proxied && sslChange?.blocked) {
+      // Never turn the proxy on while the required SSL mode can't be applied:
+      // Flexible SSL against the origin causes redirect loops on every host.
+      changes.push({
+        ...dnsChange,
+        blocked: true,
+        detail: 'Held back: zone SSL must be strict first (re-run with --allow-zone-ssl or fix the zone setting).',
+      });
+    } else {
+      changes.push(dnsChange);
+    }
+  }
+
+  return changes;
+}

--- a/infra/cloudflare/plan.ts
+++ b/infra/cloudflare/plan.ts
@@ -7,7 +7,10 @@
 // lives in scripts/cloudflare-apply.ts.
 
 import { SSL_MODE_STRENGTH, ZONE_NAME } from './config';
-import type { CacheRuleDesired, DnsRecordDesired, SslDesired, SslMode } from './config';
+import type { CacheRuleDesired, DnsRecordDesired, SslDesired, SslMode, WafRuleDesired } from './config';
+
+/** Anything this tool owns inside a ruleset phase. Identity is the description marker. */
+export type ManagedRuleDesired = CacheRuleDesired | WafRuleDesired;
 
 /** A DNS record as Cloudflare returns it. We only manage `proxied`; the rest is context. */
 export interface LiveDnsRecord {
@@ -42,6 +45,8 @@ export interface RulesetRule {
 export interface LiveState {
   dnsRecord: LiveDnsRecord;
   cacheRules: RulesetRule[];
+  /** Rules live in the WAF custom phase. Empty when the phase has no entrypoint ruleset yet. */
+  wafRules: RulesetRule[];
   sslMode: string;
 }
 
@@ -51,7 +56,7 @@ export interface PlanOptions {
 }
 
 export interface PlannedChange {
-  resource: 'dns' | 'cache-rule' | 'ssl';
+  resource: 'dns' | 'cache-rule' | 'waf-rule' | 'ssl';
   /** One-line human-readable summary of what would change. */
   summary: string;
   /** Optional extra context printed under the summary. */
@@ -90,12 +95,25 @@ export function jsonEqual(left: unknown, right: unknown): boolean {
 }
 
 /** True when a live rule already matches the fields we manage (identity is by description, checked by the caller). */
-export function cacheRuleMatches(liveRule: RulesetRule, desiredRule: CacheRuleDesired): boolean {
+export function cacheRuleMatches(liveRule: RulesetRule, desiredRule: ManagedRuleDesired): boolean {
   return (
     liveRule.expression === desiredRule.expression &&
     liveRule.action === desiredRule.action &&
     (liveRule.enabled ?? true) === desiredRule.enabled &&
     jsonEqual(liveRule.action_parameters, desiredRule.action_parameters)
+  );
+}
+
+/** Element-wise comparison used to decide whether an upsert actually changed anything. */
+function sameRule(liveRule: RulesetRule | undefined, nextRule: RulesetRule): boolean {
+  if (liveRule === nextRule) return true;
+  if (!liveRule) return false;
+  return (
+    liveRule.description === nextRule.description &&
+    liveRule.expression === nextRule.expression &&
+    liveRule.action === nextRule.action &&
+    (liveRule.enabled ?? true) === (nextRule.enabled ?? true) &&
+    jsonEqual(liveRule.action_parameters, nextRule.action_parameters)
   );
 }
 
@@ -107,29 +125,56 @@ export interface CacheRuleUpsertResult {
 }
 
 /**
- * Merge our desired cache rule into an existing rules array. Our rule is identified
- * only by its description marker, so:
- *   - not present  → append it (create).
- *   - present, matches desired → return the array unchanged (no-op).
- *   - present, differs → replace it in place, keeping its Cloudflare-assigned id and
- *     its position; every OTHER rule is preserved verbatim.
+ * Merge our desired rules into an existing phase's rules array. Ours are identified
+ * only by their description markers, so:
+ *   - none present → append the whole group, in declared order, at the end.
+ *   - some present → rewrite them as one contiguous group at the position of the
+ *     first one we own, keeping each rule's Cloudflare-assigned id.
+ *   - already in the desired state → return the array unchanged (no-op).
+ *
+ * Every rule we do NOT own is preserved verbatim, by reference, in its original
+ * relative order.
+ *
+ * The contiguous-group rewrite is what makes WAF ordering safe. Upserting rule by
+ * rule would append a newly-added allow rule AFTER an already-present block rule,
+ * which reverses their precedence and blocks the search engines the allow rule
+ * exists to protect. Declared order in the group always wins.
+ *
+ * What this deliberately does not do is reorder our group relative to foreign
+ * rules — a pre-existing foreign block rule that runs before ours keeps running
+ * first. Cloudflare's own AI-crawler block is exactly such a rule and must stay
+ * ahead of us.
  */
-export function upsertCacheRule(existingRules: RulesetRule[], desiredRule: CacheRuleDesired): CacheRuleUpsertResult {
-  const ourIndex = existingRules.findIndex((rule) => rule.description === desiredRule.description);
+export function upsertCacheRule(
+  existingRules: RulesetRule[],
+  desiredRules: ManagedRuleDesired | ManagedRuleDesired[],
+): CacheRuleUpsertResult {
+  const desired = Array.isArray(desiredRules) ? desiredRules : [desiredRules];
+  const managedDescriptions = new Set(desired.map((rule) => rule.description));
+  const isManaged = (rule: RulesetRule) => rule.description !== undefined && managedDescriptions.has(rule.description);
 
-  if (ourIndex === -1) {
-    return { rules: [...existingRules, { ...desiredRule }], changed: true };
+  const idByDescription = new Map<string, string>();
+  for (const rule of existingRules) {
+    if (isManaged(rule) && rule.id) idByDescription.set(rule.description as string, rule.id);
   }
 
-  if (cacheRuleMatches(existingRules[ourIndex], desiredRule)) {
-    return { rules: existingRules, changed: false };
-  }
+  const managedBlock: RulesetRule[] = desired.map((rule) => {
+    const existingId = idByDescription.get(rule.description);
+    return existingId ? { id: existingId, ...rule } : { ...rule };
+  });
 
-  const existingId = existingRules[ourIndex].id;
-  const replacement: RulesetRule = existingId ? { id: existingId, ...desiredRule } : { ...desiredRule };
-  const rules = existingRules.slice();
-  rules[ourIndex] = replacement;
-  return { rules, changed: true };
+  const foreignRules = existingRules.filter((rule) => !isManaged(rule));
+  const firstManagedIndex = existingRules.findIndex(isManaged);
+  const insertAt =
+    firstManagedIndex === -1
+      ? foreignRules.length
+      : existingRules.slice(0, firstManagedIndex).filter((rule) => !isManaged(rule)).length;
+
+  const rules = [...foreignRules.slice(0, insertAt), ...managedBlock, ...foreignRules.slice(insertAt)];
+  const changed =
+    rules.length !== existingRules.length || rules.some((rule, index) => !sameRule(existingRules[index], rule));
+
+  return { rules: changed ? rules : existingRules, changed };
 }
 
 /** Plan the DNS proxied-flag change, or null when already at the desired value. */
@@ -142,22 +187,65 @@ export function diffDnsRecord(desired: DnsRecordDesired, liveRecord: LiveDnsReco
   };
 }
 
-/** Plan the cache-rule change, or null when our rule already matches desired. */
-export function diffCacheRule(existingRules: RulesetRule[], desiredRule: CacheRuleDesired): PlannedChange | null {
-  const { changed } = upsertCacheRule(existingRules, desiredRule);
-  if (!changed) return null;
+/**
+ * Plan the changes for one ruleset phase — one PlannedChange per rule that is
+ * missing or has drifted. Returns an empty array when the phase already matches.
+ *
+ * Reported per rule rather than per phase so a dry-run says which rule drifted;
+ * the apply itself still PUTs the phase once, because that is the only write the
+ * rulesets API offers.
+ */
+export function diffManagedRules(
+  existingRules: RulesetRule[],
+  desiredRules: ManagedRuleDesired[],
+  resource: 'cache-rule' | 'waf-rule',
+): PlannedChange[] {
+  const { changed } = upsertCacheRule(existingRules, desiredRules);
+  if (!changed) return [];
 
-  const alreadyPresent = existingRules.some((rule) => rule.description === desiredRule.description);
-  const foreignCount = existingRules.filter((rule) => rule.description !== desiredRule.description).length;
-  return {
-    resource: 'cache-rule',
-    summary: alreadyPresent
-      ? `Cache rule "${desiredRule.description}" differs from desired — will update`
-      : `Cache rule "${desiredRule.description}" missing — will create`,
-    detail:
-      `expression: ${desiredRule.expression}` +
-      (foreignCount > 0 ? `\n    (${foreignCount} other rule(s) in this phase left untouched)` : ''),
-  };
+  const managedDescriptions = new Set(desiredRules.map((rule) => rule.description));
+  const foreignCount = existingRules.filter(
+    (rule) => rule.description === undefined || !managedDescriptions.has(rule.description),
+  ).length;
+  const label = resource === 'waf-rule' ? 'WAF rule' : 'Cache rule';
+
+  const changes: PlannedChange[] = [];
+  for (const desiredRule of desiredRules) {
+    const liveRule = existingRules.find((rule) => rule.description === desiredRule.description);
+    if (liveRule && cacheRuleMatches(liveRule, desiredRule)) continue;
+    changes.push({
+      resource,
+      summary: liveRule
+        ? `${label} "${desiredRule.description}" differs from desired — will update`
+        : `${label} "${desiredRule.description}" missing — will create`,
+      detail: `${desiredRule.action}: ${desiredRule.expression}`,
+    });
+  }
+
+  // Every rule matches individually but the array still changed: our group is in
+  // the wrong order. For WAF that is the difference between allowing Googlebot and
+  // blocking it, so it must surface as its own planned change rather than silently.
+  if (changes.length === 0) {
+    changes.push({
+      resource,
+      summary: `${label}s are present but out of order — will reorder`,
+      detail: `desired order: ${desiredRules.map((rule) => rule.description).join(' → ')}`,
+    });
+  }
+
+  if (foreignCount > 0) {
+    changes[changes.length - 1] = {
+      ...changes[changes.length - 1],
+      detail: `${changes[changes.length - 1].detail}\n    (${foreignCount} other rule(s) in this phase left untouched)`,
+    };
+  }
+
+  return changes;
+}
+
+/** Back-compat single-rule wrapper. Returns the first planned change, or null when in sync. */
+export function diffCacheRule(existingRules: RulesetRule[], desiredRule: CacheRuleDesired): PlannedChange | null {
+  return diffManagedRules(existingRules, [desiredRule], 'cache-rule')[0] ?? null;
 }
 
 /** Index of a mode in the weakest→strongest order, or -1 for an unknown mode. */
@@ -193,7 +281,12 @@ export function diffSslMode(desiredMode: SslMode, liveMode: string, allowZoneSsl
 
 /** Full desired-vs-live diff: the ordered list of changes --apply would attempt. Empty = in sync. */
 export function buildPlan(
-  desired: { dns: DnsRecordDesired; cacheRule: CacheRuleDesired; ssl: SslDesired },
+  desired: {
+    dns: DnsRecordDesired;
+    cacheRules: CacheRuleDesired[];
+    wafRules: WafRuleDesired[];
+    ssl: SslDesired;
+  },
   live: LiveState,
   options: PlanOptions,
 ): PlannedChange[] {
@@ -201,14 +294,16 @@ export function buildPlan(
 
   const dnsChange = diffDnsRecord(desired.dns, live.dnsRecord);
 
-  const cacheChange = diffCacheRule(live.cacheRules, desired.cacheRule);
+  const cacheChanges = diffManagedRules(live.cacheRules, desired.cacheRules, 'cache-rule');
+  const wafChanges = diffManagedRules(live.wafRules, desired.wafRules, 'waf-rule');
 
   const sslChange = diffSslMode(desired.ssl.mode, live.sslMode, options.allowZoneSsl);
   // Order matters on cutover: SSL and the cache rule must be live BEFORE the
   // proxied flip, or traffic transits Cloudflare without them (Flexible-SSL
   // redirect loops would take the WebSocket host down).
   if (sslChange) changes.push(sslChange);
-  if (cacheChange) changes.push(cacheChange);
+  changes.push(...cacheChanges);
+  changes.push(...wafChanges);
   if (dnsChange) {
     if (desired.dns.proxied && sslChange?.blocked) {
       // Never turn the proxy on while the required SSL mode can't be applied:

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -235,6 +235,20 @@ describe('buildPlan', () => {
   });
 });
 
+describe('parseArgs strictness', () => {
+  it('rejects unknown flags instead of silently dry-running', () => {
+    expect(() => parseArgs(['--appply'])).toThrow('Unknown flag: --appply');
+  });
+});
+
+describe('diffSslMode with an unrecognized live mode', () => {
+  it('treats an unknown mode as drift needing a change', () => {
+    const change = diffSslMode('strict', 'mystery_mode', false);
+    expect(change).not.toBeNull();
+    expect(change?.blocked).toBe(true);
+  });
+});
+
 describe('jsonEqual', () => {
   it('compares nested objects independent of key order', () => {
     expect(jsonEqual({ a: 1, b: { c: 2 } }, { b: { c: 2 }, a: 1 })).toBe(true);

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -1,0 +1,246 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from 'vitest';
+
+import { CACHE_RULE_DESCRIPTION, desiredCloudflareState } from '../infra/cloudflare/config';
+import {
+  buildPlan,
+  cacheRuleMatches,
+  diffCacheRule,
+  diffDnsRecord,
+  diffSslMode,
+  jsonEqual,
+  upsertCacheRule,
+} from '../infra/cloudflare/plan';
+import type { LiveDnsRecord, LiveState, RulesetRule } from '../infra/cloudflare/plan';
+import { parseArgs } from './cloudflare-apply';
+
+const desired = desiredCloudflareState;
+
+function liveDnsRecord(overrides: Partial<LiveDnsRecord> = {}): LiveDnsRecord {
+  return {
+    id: 'dns-record-id',
+    name: desired.dns.name,
+    type: 'CNAME',
+    content: 'boardsesh-backend.up.railway.app',
+    proxied: true,
+    ...overrides,
+  };
+}
+
+/** A live cache rule that matches the desired rule (plus Cloudflare's read-only fields). */
+function matchingLiveCacheRule(): RulesetRule {
+  return {
+    id: 'our-rule-id',
+    version: '3',
+    last_updated: '2026-07-20T00:00:00Z',
+    ref: 'our-rule-ref',
+    description: desired.cacheRule.description,
+    expression: desired.cacheRule.expression,
+    action: desired.cacheRule.action,
+    action_parameters: {
+      cache: true,
+      edge_ttl: { mode: 'bypass_by_default' },
+      browser_ttl: { mode: 'respect_origin' },
+    },
+    enabled: true,
+  };
+}
+
+/** A foreign rule this tool must never disturb. */
+function foreignRule(id: string): RulesetRule {
+  return {
+    id,
+    version: '1',
+    last_updated: '2026-01-01T00:00:00Z',
+    ref: `${id}-ref`,
+    description: `some other rule ${id}`,
+    expression: '(http.request.uri.path eq "/graphql")',
+    action: 'set_cache_settings',
+    action_parameters: { cache: false },
+    enabled: true,
+  };
+}
+
+function inSyncLiveState(): LiveState {
+  return {
+    dnsRecord: liveDnsRecord(),
+    cacheRules: [matchingLiveCacheRule()],
+    sslMode: 'strict',
+  };
+}
+
+describe('parseArgs', () => {
+  it('defaults to dry-run (apply=false)', () => {
+    expect(parseArgs([])).toEqual({ apply: false, allowZoneSsl: false, help: false });
+  });
+
+  it('reads --apply, --allow-zone-ssl, --help and ignores the -- separator', () => {
+    expect(parseArgs(['--', '--apply', '--allow-zone-ssl'])).toEqual({
+      apply: true,
+      allowZoneSsl: true,
+      help: false,
+    });
+    expect(parseArgs(['--help']).help).toBe(true);
+    expect(parseArgs(['-h']).help).toBe(true);
+  });
+
+  it('lets a later --dry-run override an earlier --apply', () => {
+    expect(parseArgs(['--apply', '--dry-run']).apply).toBe(false);
+  });
+});
+
+describe('diffDnsRecord', () => {
+  it('is a no-op when the record is already proxied', () => {
+    expect(diffDnsRecord(desired.dns, liveDnsRecord({ proxied: true }))).toBeNull();
+  });
+
+  it('plans a proxied flip when the record is grey-clouded', () => {
+    const change = diffDnsRecord(desired.dns, liveDnsRecord({ proxied: false }));
+    expect(change).not.toBeNull();
+    expect(change?.resource).toBe('dns');
+    expect(change?.summary).toContain('proxied false → true');
+  });
+});
+
+describe('diffSslMode (SSL weaker warning)', () => {
+  it('is a no-op when already strict', () => {
+    expect(diffSslMode('strict', 'strict', false)).toBeNull();
+  });
+
+  it('blocks the change when the live mode is weaker and --allow-zone-ssl is absent', () => {
+    const change = diffSslMode('strict', 'full', false);
+    expect(change).not.toBeNull();
+    expect(change?.resource).toBe('ssl');
+    expect(change?.blocked).toBe(true);
+    expect(change?.summary).toContain('weaker');
+  });
+
+  it('unblocks the change when --allow-zone-ssl is given', () => {
+    const change = diffSslMode('strict', 'flexible', true);
+    expect(change?.blocked).toBe(false);
+    expect(change?.detail).toContain('--allow-zone-ssl given');
+  });
+
+  it('flags every weaker mode (off/flexible/full)', () => {
+    for (const weaker of ['off', 'flexible', 'full']) {
+      expect(diffSslMode('strict', weaker, false)?.blocked).toBe(true);
+    }
+  });
+});
+
+describe('upsertCacheRule (foreign-rule preservation)', () => {
+  it('appends our rule when the phase has none, leaving foreign rules first and untouched', () => {
+    const foreignA = foreignRule('foreign-a');
+    const foreignB = foreignRule('foreign-b');
+    const { rules, changed } = upsertCacheRule([foreignA, foreignB], desired.cacheRule);
+
+    expect(changed).toBe(true);
+    expect(rules).toHaveLength(3);
+    // Foreign rules preserved verbatim, in order, at the front.
+    expect(rules[0]).toBe(foreignA);
+    expect(rules[1]).toBe(foreignB);
+    // Our rule appended last, carrying the marker.
+    expect(rules[2].description).toBe(CACHE_RULE_DESCRIPTION);
+    expect(rules[2].id).toBeUndefined();
+  });
+
+  it('is a no-op when our rule already matches', () => {
+    const existing = [foreignRule('foreign-a'), matchingLiveCacheRule()];
+    const { rules, changed } = upsertCacheRule(existing, desired.cacheRule);
+    expect(changed).toBe(false);
+    expect(rules).toBe(existing);
+  });
+
+  it('updates our rule in place — keeping its id and position — when it drifts, without touching foreign rules', () => {
+    const foreignA = foreignRule('foreign-a');
+    const staleOurs: RulesetRule = { ...matchingLiveCacheRule(), expression: '(http.host eq "stale")' };
+    const foreignB = foreignRule('foreign-b');
+
+    const { rules, changed } = upsertCacheRule([foreignA, staleOurs, foreignB], desired.cacheRule);
+
+    expect(changed).toBe(true);
+    expect(rules).toHaveLength(3);
+    // Our rule stays at index 1, keeps its Cloudflare-assigned id, gets the desired expression.
+    expect(rules[1].id).toBe('our-rule-id');
+    expect(rules[1].expression).toBe(desired.cacheRule.expression);
+    expect(rules[1].action_parameters).toEqual({
+      cache: true,
+      edge_ttl: { mode: 'bypass_by_default' },
+      browser_ttl: { mode: 'respect_origin' },
+    });
+    // Foreign rules untouched (same references, same order).
+    expect(rules[0]).toBe(foreignA);
+    expect(rules[2]).toBe(foreignB);
+  });
+});
+
+describe('cacheRuleMatches', () => {
+  it('treats a missing enabled field as enabled', () => {
+    const withoutEnabled: RulesetRule = { ...matchingLiveCacheRule() };
+    delete withoutEnabled.enabled;
+    expect(cacheRuleMatches(withoutEnabled, desired.cacheRule)).toBe(true);
+  });
+
+  it('detects an action_parameters difference', () => {
+    const drifted: RulesetRule = { ...matchingLiveCacheRule(), action_parameters: { cache: false } };
+    expect(cacheRuleMatches(drifted, desired.cacheRule)).toBe(false);
+  });
+});
+
+describe('diffCacheRule', () => {
+  it('is a no-op when our rule already matches', () => {
+    expect(diffCacheRule([matchingLiveCacheRule()], desired.cacheRule)).toBeNull();
+  });
+
+  it('reports a create when our rule is absent', () => {
+    const change = diffCacheRule([foreignRule('foreign-a')], desired.cacheRule);
+    expect(change?.summary).toContain('missing');
+    expect(change?.detail).toContain('1 other rule');
+  });
+});
+
+describe('buildPlan', () => {
+  it('returns no changes when the live zone already matches desired (no drift)', () => {
+    expect(buildPlan(desired, inSyncLiveState(), { allowZoneSsl: false })).toEqual([]);
+  });
+
+  it('collects every drift (dns + cache + ssl) into one plan', () => {
+    const drifted: LiveState = {
+      dnsRecord: liveDnsRecord({ proxied: false }),
+      cacheRules: [foreignRule('foreign-a')],
+      sslMode: 'full',
+    };
+    const changes = buildPlan(desired, drifted, { allowZoneSsl: false });
+    // Cutover-safe order: the proxied flip is planned last, after SSL + cache.
+    expect(changes.map((change) => change.resource)).toEqual(['ssl', 'cache-rule', 'dns']);
+    // The SSL change is blocked without the opt-in flag, but still reported as drift.
+    expect(changes.find((change) => change.resource === 'ssl')?.blocked).toBe(true);
+    // And the proxied flip is held back while the required SSL change is blocked —
+    // orange-clouding with weak SSL would redirect-loop every host on the record.
+    const dnsChange = changes.find((change) => change.resource === 'dns');
+    expect(dnsChange?.blocked).toBe(true);
+    expect(dnsChange?.detail).toContain('Held back');
+  });
+
+  it('does not hold back the proxied flip when SSL is already compliant', () => {
+    const drifted: LiveState = {
+      dnsRecord: liveDnsRecord({ proxied: false }),
+      cacheRules: [],
+      sslMode: 'strict',
+    };
+    const changes = buildPlan(desired, drifted, { allowZoneSsl: false });
+    const dnsChange = changes.find((change) => change.resource === 'dns');
+    expect(dnsChange?.blocked).toBeUndefined();
+  });
+});
+
+describe('jsonEqual', () => {
+  it('compares nested objects independent of key order', () => {
+    expect(jsonEqual({ a: 1, b: { c: 2 } }, { b: { c: 2 }, a: 1 })).toBe(true);
+    expect(jsonEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(jsonEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(jsonEqual([1, 2], [1, 2, 3])).toBe(false);
+    expect(jsonEqual(null, undefined)).toBe(false);
+  });
+});

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -2,11 +2,21 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { CACHE_RULE_DESCRIPTION, desiredCloudflareState } from '../infra/cloudflare/config';
+import {
+  BOARD_RENDER_CACHE_RULE_DESCRIPTION,
+  CACHE_RULE_DESCRIPTION,
+  CRAWLER_ALLOW_RULE_DESCRIPTION,
+  CRAWLER_ALLOW_TOKENS,
+  CRAWLER_BLOCK_RULE_DESCRIPTION,
+  CRAWLER_BLOCK_TOKENS,
+  WWW_HOSTNAME,
+  desiredCloudflareState,
+} from '../infra/cloudflare/config';
 import {
   buildPlan,
   cacheRuleMatches,
   diffCacheRule,
+  diffManagedRules,
   diffDnsRecord,
   diffSslMode,
   jsonEqual,
@@ -16,6 +26,8 @@ import type { LiveDnsRecord, LiveState, RulesetRule } from '../infra/cloudflare/
 import { parseArgs } from './cloudflare-apply';
 
 const desired = desiredCloudflareState;
+/** The og cache rule — the one the pre-existing cases in this file were written against. */
+const ogCacheRule = desired.cacheRules[0];
 
 function liveDnsRecord(overrides: Partial<LiveDnsRecord> = {}): LiveDnsRecord {
   return {
@@ -35,9 +47,9 @@ function matchingLiveCacheRule(): RulesetRule {
     version: '3',
     last_updated: '2026-07-20T00:00:00Z',
     ref: 'our-rule-ref',
-    description: desired.cacheRule.description,
-    expression: desired.cacheRule.expression,
-    action: desired.cacheRule.action,
+    description: ogCacheRule.description,
+    expression: ogCacheRule.expression,
+    action: ogCacheRule.action,
     action_parameters: {
       cache: true,
       edge_ttl: { mode: 'bypass_by_default' },
@@ -62,10 +74,28 @@ function foreignRule(id: string): RulesetRule {
   };
 }
 
+/** Live copies of every managed rule, matching desired (plus Cloudflare's read-only fields). */
+function matchingLiveRules(
+  desiredRules: readonly { description: string; expression: string; action: string; action_parameters?: unknown }[],
+): RulesetRule[] {
+  return desiredRules.map((rule, index) => ({
+    id: `our-rule-id-${index}`,
+    version: '3',
+    last_updated: '2026-07-20T00:00:00Z',
+    ref: `our-rule-ref-${index}`,
+    description: rule.description,
+    expression: rule.expression,
+    action: rule.action,
+    action_parameters: rule.action_parameters,
+    enabled: true,
+  }));
+}
+
 function inSyncLiveState(): LiveState {
   return {
     dnsRecord: liveDnsRecord(),
-    cacheRules: [matchingLiveCacheRule()],
+    cacheRules: matchingLiveRules(desired.cacheRules),
+    wafRules: matchingLiveRules(desired.wafRules),
     sslMode: 'strict',
   };
 }
@@ -133,7 +163,7 @@ describe('upsertCacheRule (foreign-rule preservation)', () => {
   it('appends our rule when the phase has none, leaving foreign rules first and untouched', () => {
     const foreignA = foreignRule('foreign-a');
     const foreignB = foreignRule('foreign-b');
-    const { rules, changed } = upsertCacheRule([foreignA, foreignB], desired.cacheRule);
+    const { rules, changed } = upsertCacheRule([foreignA, foreignB], ogCacheRule);
 
     expect(changed).toBe(true);
     expect(rules).toHaveLength(3);
@@ -147,7 +177,7 @@ describe('upsertCacheRule (foreign-rule preservation)', () => {
 
   it('is a no-op when our rule already matches', () => {
     const existing = [foreignRule('foreign-a'), matchingLiveCacheRule()];
-    const { rules, changed } = upsertCacheRule(existing, desired.cacheRule);
+    const { rules, changed } = upsertCacheRule(existing, ogCacheRule);
     expect(changed).toBe(false);
     expect(rules).toBe(existing);
   });
@@ -157,13 +187,13 @@ describe('upsertCacheRule (foreign-rule preservation)', () => {
     const staleOurs: RulesetRule = { ...matchingLiveCacheRule(), expression: '(http.host eq "stale")' };
     const foreignB = foreignRule('foreign-b');
 
-    const { rules, changed } = upsertCacheRule([foreignA, staleOurs, foreignB], desired.cacheRule);
+    const { rules, changed } = upsertCacheRule([foreignA, staleOurs, foreignB], ogCacheRule);
 
     expect(changed).toBe(true);
     expect(rules).toHaveLength(3);
     // Our rule stays at index 1, keeps its Cloudflare-assigned id, gets the desired expression.
     expect(rules[1].id).toBe('our-rule-id');
-    expect(rules[1].expression).toBe(desired.cacheRule.expression);
+    expect(rules[1].expression).toBe(ogCacheRule.expression);
     expect(rules[1].action_parameters).toEqual({
       cache: true,
       edge_ttl: { mode: 'bypass_by_default' },
@@ -179,22 +209,22 @@ describe('cacheRuleMatches', () => {
   it('treats a missing enabled field as enabled', () => {
     const withoutEnabled: RulesetRule = { ...matchingLiveCacheRule() };
     delete withoutEnabled.enabled;
-    expect(cacheRuleMatches(withoutEnabled, desired.cacheRule)).toBe(true);
+    expect(cacheRuleMatches(withoutEnabled, ogCacheRule)).toBe(true);
   });
 
   it('detects an action_parameters difference', () => {
     const drifted: RulesetRule = { ...matchingLiveCacheRule(), action_parameters: { cache: false } };
-    expect(cacheRuleMatches(drifted, desired.cacheRule)).toBe(false);
+    expect(cacheRuleMatches(drifted, ogCacheRule)).toBe(false);
   });
 });
 
 describe('diffCacheRule', () => {
   it('is a no-op when our rule already matches', () => {
-    expect(diffCacheRule([matchingLiveCacheRule()], desired.cacheRule)).toBeNull();
+    expect(diffCacheRule([matchingLiveCacheRule()], ogCacheRule)).toBeNull();
   });
 
   it('reports a create when our rule is absent', () => {
-    const change = diffCacheRule([foreignRule('foreign-a')], desired.cacheRule);
+    const change = diffCacheRule([foreignRule('foreign-a')], ogCacheRule);
     expect(change?.summary).toContain('missing');
     expect(change?.detail).toContain('1 other rule');
   });
@@ -209,11 +239,14 @@ describe('buildPlan', () => {
     const drifted: LiveState = {
       dnsRecord: liveDnsRecord({ proxied: false }),
       cacheRules: [foreignRule('foreign-a')],
+      wafRules: matchingLiveRules(desired.wafRules),
       sslMode: 'full',
     };
     const changes = buildPlan(desired, drifted, { allowZoneSsl: false });
-    // Cutover-safe order: the proxied flip is planned last, after SSL + cache.
-    expect(changes.map((change) => change.resource)).toEqual(['ssl', 'cache-rule', 'dns']);
+    // Cutover-safe order: the proxied flip is planned last, after SSL + the rules.
+    // Both cache rules are missing (the phase holds only a foreign rule), and the
+    // WAF phase is already in sync, so it contributes nothing.
+    expect(changes.map((change) => change.resource)).toEqual(['ssl', 'cache-rule', 'cache-rule', 'dns']);
     // The SSL change is blocked without the opt-in flag, but still reported as drift.
     expect(changes.find((change) => change.resource === 'ssl')?.blocked).toBe(true);
     // And the proxied flip is held back while the required SSL change is blocked —
@@ -227,6 +260,7 @@ describe('buildPlan', () => {
     const drifted: LiveState = {
       dnsRecord: liveDnsRecord({ proxied: false }),
       cacheRules: [],
+      wafRules: [],
       sslMode: 'strict',
     };
     const changes = buildPlan(desired, drifted, { allowZoneSsl: false });
@@ -256,5 +290,157 @@ describe('jsonEqual', () => {
     expect(jsonEqual([1, 2, 3], [1, 2, 3])).toBe(true);
     expect(jsonEqual([1, 2], [1, 2, 3])).toBe(false);
     expect(jsonEqual(null, undefined)).toBe(false);
+  });
+});
+
+describe('www cost-control rules (#4650)', () => {
+  const boardRenderRule = desired.cacheRules.find((rule) => rule.description === BOARD_RENDER_CACHE_RULE_DESCRIPTION);
+  const allowRule = desired.wafRules.find((rule) => rule.description === CRAWLER_ALLOW_RULE_DESCRIPTION);
+  const blockRule = desired.wafRules.find((rule) => rule.description === CRAWLER_BLOCK_RULE_DESCRIPTION);
+
+  it('scopes the board-render cache rule to www and the render path', () => {
+    // Cloudflare caches by file extension by default and this path has none, which
+    // is the entire reason the route measured cf-cache-status: DYNAMIC despite
+    // sending `immutable, max-age=31536000`.
+    expect(boardRenderRule?.expression).toBe(
+      `(http.host eq "${WWW_HOSTNAME}" and starts_with(http.request.uri.path, "/api/internal/board-render"))`,
+    );
+    expect(boardRenderRule?.action_parameters.cache).toBe(true);
+    // A 503 from the render semaphore sends no cacheable Cache-Control; bypassing
+    // by default is what keeps load-shed responses out of the edge cache.
+    expect(boardRenderRule?.action_parameters.edge_ttl.mode).toBe('bypass_by_default');
+  });
+
+  it('keeps the two cache rules separately addressable', () => {
+    // Identity is the description marker; a duplicate would make the upsert treat
+    // one rule as the other and silently drop it.
+    expect(new Set(desired.cacheRules.map((rule) => rule.description)).size).toBe(desired.cacheRules.length);
+    expect(CACHE_RULE_DESCRIPTION).not.toBe(BOARD_RENDER_CACHE_RULE_DESCRIPTION);
+  });
+
+  it('lowercases the user agent in every WAF expression', () => {
+    // Cloudflare's `contains` is CASE-SENSITIVE. Without lower(), the rule installs
+    // cleanly and matches nothing — the worst kind of failure, because it looks done.
+    for (const rule of desired.wafRules) {
+      const comparisons = rule.expression.split(' or ');
+      expect(comparisons.length).toBeGreaterThan(0);
+      for (const comparison of comparisons) {
+        expect(comparison).toMatch(/^lower\(http\.user_agent\) contains "[^A-Z]*"$/);
+      }
+    }
+  });
+
+  it('never blocks a search engine or unfurler we allow', () => {
+    // The real hazard of a token list: one short token catching a crawler we depend
+    // on. Checked against full UA strings, not just the tokens.
+    const allowedUserAgents = [
+      'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+      'Mozilla/5.0 (compatible; Googlebot-Image/1.0; +http://www.google.com/bot.html)',
+      'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
+      'Mozilla/5.0 (compatible; Brave-Search/1.0; +https://search.brave.com/help/brave-search-crawler)',
+      'Mozilla/5.0 (compatible; DuckDuckBot-Https/1.1; https://duckduckgo.com/duckduckbot)',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/126.0.0.0 Safari/537.36',
+      'facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)',
+      'Twitterbot/1.0',
+    ];
+    for (const userAgent of allowedUserAgents) {
+      for (const token of CRAWLER_BLOCK_TOKENS) {
+        expect(userAgent.toLowerCase()).not.toContain(token);
+      }
+    }
+  });
+
+  it('matches the scrapers it is meant to block', () => {
+    const blockedUserAgents = [
+      'Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)',
+      'Mozilla/5.0 (compatible; SemrushBot/7~bl; +http://www.semrush.com/bot.html)',
+      'Mozilla/5.0 (compatible; DataForSeoBot/1.0; +https://dataforseo.com/dataforseo-bot)',
+      'Mozilla/5.0 (compatible; MJ12bot/v1.4.8; http://mj12bot.com/)',
+      'Mozilla/5.0 (compatible; DotBot/1.2; +https://opensiteexplorer.org/dotbot;)',
+      'Screaming Frog SEO Spider/21.4',
+    ];
+    for (const userAgent of blockedUserAgents) {
+      const matched = CRAWLER_BLOCK_TOKENS.some((token) => userAgent.toLowerCase().includes(token));
+      expect(matched, `${userAgent} must be blocked`).toBe(true);
+    }
+  });
+
+  it('never lists the same token as both allowed and blocked', () => {
+    for (const blockToken of CRAWLER_BLOCK_TOKENS) {
+      for (const allowToken of CRAWLER_ALLOW_TOKENS) {
+        expect(blockToken.includes(allowToken) || allowToken.includes(blockToken)).toBe(false);
+      }
+    }
+  });
+
+  it('declares the allow rule before the block rule', () => {
+    // Precedence is the whole safety mechanism: skip-remaining only protects a
+    // crawler if it is evaluated first.
+    expect(desired.wafRules.indexOf(allowRule!)).toBeLessThan(desired.wafRules.indexOf(blockRule!));
+    expect(allowRule?.action).toBe('skip');
+    expect(allowRule?.action_parameters).toEqual({ ruleset: 'current' });
+    expect(blockRule?.action).toBe('block');
+  });
+});
+
+describe('managed rule ordering and foreign-rule safety', () => {
+  const liveRule = (description: string, extra: Partial<RulesetRule> = {}): RulesetRule => ({
+    id: `${description}-id`,
+    version: '2',
+    description,
+    expression: 'lower(http.user_agent) contains "stale"',
+    action: 'block',
+    enabled: true,
+    ...extra,
+  });
+
+  it('puts a newly added allow rule BEFORE an already-present block rule', () => {
+    // The regression this exists for. A rule-by-rule upsert would append the new
+    // allow rule after the existing block rule, reversing precedence and blocking
+    // Googlebot the moment the config landed.
+    const existing = [liveRule(CRAWLER_BLOCK_RULE_DESCRIPTION)];
+    const { rules, changed } = upsertCacheRule(existing, desired.wafRules);
+
+    expect(changed).toBe(true);
+    expect(rules.map((rule) => rule.description)).toEqual([
+      CRAWLER_ALLOW_RULE_DESCRIPTION,
+      CRAWLER_BLOCK_RULE_DESCRIPTION,
+    ]);
+    // The pre-existing rule keeps its Cloudflare-assigned id rather than being
+    // recreated, so its analytics and history survive.
+    expect(rules[1].id).toBe(`${CRAWLER_BLOCK_RULE_DESCRIPTION}-id`);
+  });
+
+  it('reports an out-of-order group as drift even when each rule matches', () => {
+    const reversed = [...desired.wafRules].reverse().map((rule) => ({ ...rule, id: `${rule.description}-id` }));
+    const changes = diffManagedRules(reversed, desired.wafRules, 'waf-rule');
+
+    expect(changes).toHaveLength(1);
+    expect(changes[0].summary).toContain('out of order');
+  });
+
+  it('preserves foreign WAF rules, including the AI-crawler block', () => {
+    // The rulesets API PUT replaces the whole phase. Cloudflare 403s ClaudeBot,
+    // GPTBot and friends via a rule we do not own; dropping it here would quietly
+    // reopen the site to every AI scraper.
+    const aiBlock = liveRule('cloudflare-managed: block AI crawlers');
+    const other = liveRule('some other custom rule');
+    const { rules } = upsertCacheRule([aiBlock, other], desired.wafRules);
+
+    expect(rules).toContain(aiBlock);
+    expect(rules).toContain(other);
+    expect(rules).toHaveLength(2 + desired.wafRules.length);
+    // Foreign rules keep their position ahead of ours, so an existing block still
+    // runs first.
+    expect(rules.slice(0, 2)).toEqual([aiBlock, other]);
+  });
+
+  it('is a no-op when the phase already matches', () => {
+    const inSync = desired.wafRules.map((rule, index) => ({ id: `id-${index}`, ...rule }));
+    const { rules, changed } = upsertCacheRule(inSync, desired.wafRules);
+
+    expect(changed).toBe(false);
+    expect(rules).toBe(inSync);
+    expect(diffManagedRules(inSync, desired.wafRules, 'waf-rule')).toEqual([]);
   });
 });

--- a/scripts/cloudflare-apply.ts
+++ b/scripts/cloudflare-apply.ts
@@ -1,0 +1,324 @@
+/// <reference types="node" />
+
+/**
+ * Config-as-code for the Cloudflare-managed boardsesh.com zone. Reads the declarative
+ * desired state (infra/cloudflare/config.ts), fetches the live zone state, diffs them
+ * (infra/cloudflare/plan.ts), and reports or converges the delta. Idempotent: a second
+ * run with no drift is a no-op.
+ *
+ * What it manages (and nothing else on the zone):
+ *   - DNS: the `ws.boardsesh.com` record's proxied flag → true (orange cloud). The
+ *     record's target/type/content are NOT managed — the record already exists.
+ *   - Cache: one rule in the http_request_cache_settings phase that makes
+ *     ws.boardsesh.com/og/* eligible for cache and respects the origin TTL. Any OTHER
+ *     rule already in that phase is preserved verbatim.
+ *   - SSL: asserts the zone SSL/TLS mode is `strict` (Full (strict)). If the zone-wide
+ *     mode is weaker it is REPORTED, never silently changed — the setting affects every
+ *     hostname on the zone. Pass --allow-zone-ssl to opt into setting it.
+ *
+ * Modes:
+ *   (default)          Dry-run. Fetch live state, print the diff, exit non-zero if any
+ *                      drift exists (so CI can gate on it). Never mutates.
+ *   --apply            Perform only the needed mutations. No-op when live matches desired.
+ *   --allow-zone-ssl   Also set the zone-wide SSL mode when it is weaker than strict.
+ *
+ * Usage:
+ *   CLOUDFLARE_API_TOKEN=... vp run cf:apply                          # dry-run (default)
+ *   CLOUDFLARE_API_TOKEN=... vp run cf:apply -- --apply               # converge
+ *   CLOUDFLARE_API_TOKEN=... vp run cf:apply -- --apply --allow-zone-ssl
+ *
+ * Env:
+ *   CLOUDFLARE_API_TOKEN  (required) API token — see TOKEN_SCOPES below for the exact scopes.
+ *   CLOUDFLARE_ZONE_ID    (optional) Skip the name→id lookup. When unset, the zone id is
+ *                         resolved by name "boardsesh.com" via the API (needs Zone.Zone Read).
+ *
+ * See docs/og-climb.md ("Cloudflare in front of ws.boardsesh.com").
+ */
+
+import { pathToFileURL } from 'node:url';
+import { CACHE_RULE_PHASE, ZONE_NAME, desiredCloudflareState } from '../infra/cloudflare/config';
+import type { SslMode } from '../infra/cloudflare/config';
+import { buildPlan, upsertCacheRule } from '../infra/cloudflare/plan';
+import type { LiveDnsRecord, LiveState, PlannedChange, RulesetRule } from '../infra/cloudflare/plan';
+
+const CF_API_BASE = 'https://api.cloudflare.com/client/v4';
+
+// The exact Cloudflare API token scopes this tool needs, printed when the token is
+// missing so a maintainer can create one with the right (minimal) permissions.
+const TOKEN_SCOPES = [
+  'Zone.Zone Read           — resolve the zone id by name + read zone list',
+  'Zone.DNS Edit            — patch the ws.boardsesh.com record proxied flag',
+  'Zone.Cache Rules Edit    — create/update the /og/ cache rule',
+  'Zone.Zone Settings Read  — read the SSL/TLS mode',
+  'Zone.Zone Settings Edit  — ONLY needed with --allow-zone-ssl (to set the zone SSL mode)',
+];
+
+export interface CliOptions {
+  apply: boolean;
+  allowZoneSsl: boolean;
+  help: boolean;
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+  let apply = false;
+  let allowZoneSsl = false;
+  let help = false;
+
+  for (const argument of argv) {
+    if (argument === '--') continue;
+    else if (argument === '--apply') apply = true;
+    else if (argument === '--dry-run') apply = false;
+    else if (argument === '--allow-zone-ssl') allowZoneSsl = true;
+    else if (argument === '--help' || argument === '-h') help = true;
+  }
+
+  return { apply, allowZoneSsl, help };
+}
+
+interface CloudflareApiError {
+  code: number;
+  message: string;
+}
+
+interface CloudflareEnvelope<TResult> {
+  success: boolean;
+  errors: CloudflareApiError[];
+  messages: unknown[];
+  result: TResult;
+}
+
+/** Error carrying the HTTP status + surfaced Cloudflare error messages, so callers can branch on status. */
+class CloudflareApiRequestError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly cfErrors: CloudflareApiError[],
+  ) {
+    super(message);
+    this.name = 'CloudflareApiRequestError';
+  }
+}
+
+async function cfRequest<TResult>(token: string, method: string, path: string, body?: unknown): Promise<TResult> {
+  const response = await fetch(`${CF_API_BASE}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  const rawBody = await response.text();
+  let envelope: CloudflareEnvelope<TResult> | null = null;
+  try {
+    envelope = rawBody ? (JSON.parse(rawBody) as CloudflareEnvelope<TResult>) : null;
+  } catch {
+    // Non-JSON body (e.g. an HTML error page) — handled below via the raw text.
+  }
+
+  if (!response.ok || !envelope || envelope.success === false) {
+    const cfErrors = envelope?.errors ?? [];
+    const rendered = cfErrors.map((error) => `  - [${error.code}] ${error.message}`).join('\n');
+    throw new CloudflareApiRequestError(
+      `Cloudflare API ${method} ${path} failed (HTTP ${response.status}).` +
+        (rendered ? `\n${rendered}` : `\n  ${rawBody.slice(0, 500)}`),
+      response.status,
+      cfErrors,
+    );
+  }
+
+  return envelope.result;
+}
+
+async function resolveZoneId(token: string, zoneName: string): Promise<string> {
+  const fromEnv = process.env.CLOUDFLARE_ZONE_ID?.trim();
+  if (fromEnv) return fromEnv;
+
+  const zones = await cfRequest<Array<{ id: string; name: string }>>(
+    token,
+    'GET',
+    `/zones?name=${encodeURIComponent(zoneName)}`,
+  );
+  const zone = zones.find((candidate) => candidate.name === zoneName) ?? zones[0];
+  if (!zone) {
+    throw new Error(
+      `No Cloudflare zone found for "${zoneName}". Set CLOUDFLARE_ZONE_ID, or grant the token Zone.Zone Read.`,
+    );
+  }
+  return zone.id;
+}
+
+async function fetchDnsRecord(token: string, zoneId: string, name: string): Promise<LiveDnsRecord> {
+  const records = await cfRequest<LiveDnsRecord[]>(
+    token,
+    'GET',
+    `/zones/${zoneId}/dns_records?name=${encodeURIComponent(name)}`,
+  );
+  const record = records.find((candidate) => candidate.name === name);
+  if (!record) {
+    throw new Error(
+      `DNS record "${name}" not found in zone ${zoneId}. This tool only patches the existing ` +
+        `record's proxied flag — create the record first (in the dashboard or your DNS pipeline).`,
+    );
+  }
+  return record;
+}
+
+/** The cache-phase entrypoint ruleset. Returns an empty rule set when the phase has no ruleset yet (404). */
+async function fetchCacheRules(token: string, zoneId: string): Promise<RulesetRule[]> {
+  try {
+    const ruleset = await cfRequest<{ id: string; rules?: RulesetRule[] }>(
+      token,
+      'GET',
+      `/zones/${zoneId}/rulesets/phases/${CACHE_RULE_PHASE}/entrypoint`,
+    );
+    return ruleset.rules ?? [];
+  } catch (error) {
+    // A phase with no ruleset 404s on the entrypoint — that's an empty rule set, not a failure.
+    if (error instanceof CloudflareApiRequestError && error.status === 404) return [];
+    throw error;
+  }
+}
+
+async function fetchSslMode(token: string, zoneId: string): Promise<string> {
+  const setting = await cfRequest<{ id: string; value: string }>(token, 'GET', `/zones/${zoneId}/settings/ssl`);
+  return setting.value;
+}
+
+async function fetchLiveState(token: string, zoneId: string, dnsName: string): Promise<LiveState> {
+  const [dnsRecord, cacheRules, sslMode] = await Promise.all([
+    fetchDnsRecord(token, zoneId, dnsName),
+    fetchCacheRules(token, zoneId),
+    fetchSslMode(token, zoneId),
+  ]);
+  return { dnsRecord, cacheRules, sslMode };
+}
+
+async function applyDnsProxied(token: string, zoneId: string, recordId: string, proxied: boolean): Promise<void> {
+  await cfRequest(token, 'PATCH', `/zones/${zoneId}/dns_records/${recordId}`, { proxied });
+}
+
+async function applyCacheRules(token: string, zoneId: string, rules: RulesetRule[]): Promise<void> {
+  // PUT to the phase entrypoint creates the ruleset when it doesn't exist yet, or
+  // replaces its rules array when it does. We send the merged array (foreign rules
+  // preserved), so this only ever adds/updates our rule.
+  await cfRequest(token, 'PUT', `/zones/${zoneId}/rulesets/phases/${CACHE_RULE_PHASE}/entrypoint`, { rules });
+}
+
+async function applySslMode(token: string, zoneId: string, mode: SslMode): Promise<void> {
+  await cfRequest(token, 'PATCH', `/zones/${zoneId}/settings/ssl`, { value: mode });
+}
+
+function printPlan(changes: PlannedChange[]): void {
+  for (const change of changes) {
+    const marker = change.blocked ? '[blocked]' : '[change] ';
+    console.log(`  ${marker} (${change.resource}) ${change.summary}`);
+    if (change.detail) {
+      for (const line of change.detail.split('\n')) console.log(`             ${line}`);
+    }
+  }
+}
+
+function printTokenScopes(): void {
+  console.error('[cf-apply] CLOUDFLARE_API_TOKEN is required. Create a token with these scopes on the zone:');
+  for (const scope of TOKEN_SCOPES) console.error(`             ${scope}`);
+  console.error('           https://dash.cloudflare.com/profile/api-tokens');
+}
+
+async function main(): Promise<number> {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (options.help) {
+    console.log(
+      [
+        'Usage: vp run cf:apply -- [--apply] [--allow-zone-ssl]',
+        '',
+        '  (default)         Dry-run: print the diff, exit non-zero if drift exists. Never mutates.',
+        '  --apply           Converge the zone to the desired state (only the needed mutations).',
+        '  --allow-zone-ssl  Also set the zone-wide SSL/TLS mode when it is weaker than strict.',
+        '',
+        'Env: CLOUDFLARE_API_TOKEN (required), CLOUDFLARE_ZONE_ID (optional).',
+      ].join('\n'),
+    );
+    return 0;
+  }
+
+  const token = process.env.CLOUDFLARE_API_TOKEN?.trim();
+  if (!token) {
+    printTokenScopes();
+    return 1;
+  }
+
+  const desired = desiredCloudflareState;
+
+  console.log(`[cf-apply] Zone: ${desired.zoneName}`);
+  console.log(`[cf-apply] Mode: ${options.apply ? 'APPLY' : 'dry-run (pass --apply to converge)'}`);
+  console.log('');
+
+  const zoneId = await resolveZoneId(token, desired.zoneName);
+  const live = await fetchLiveState(token, zoneId, desired.dns.name);
+  const changes = buildPlan(desired, live, { allowZoneSsl: options.allowZoneSsl });
+
+  if (changes.length === 0) {
+    console.log('[cf-apply] In sync — nothing to do.');
+    return 0;
+  }
+
+  console.log(`[cf-apply] Planned changes (${changes.length}):`);
+  printPlan(changes);
+  console.log('');
+
+  if (!options.apply) {
+    console.log('[cf-apply] Dry-run: no changes applied. Re-run with --apply to converge.');
+    // Non-zero exit signals drift so CI can gate on it.
+    return 1;
+  }
+
+  let blockedRemaining = 0;
+
+  for (const change of changes) {
+    if (change.blocked) {
+      console.warn(`[cf-apply] SKIPPED (blocked): ${change.summary}`);
+      if (change.detail) console.warn(`             ${change.detail.split('\n')[0]}`);
+      blockedRemaining += 1;
+      continue;
+    }
+
+    if (change.resource === 'dns') {
+      await applyDnsProxied(token, zoneId, live.dnsRecord.id, desired.dns.proxied);
+      console.log(`[cf-apply] applied: ${change.summary}`);
+    } else if (change.resource === 'cache-rule') {
+      const { rules } = upsertCacheRule(live.cacheRules, desired.cacheRule);
+      await applyCacheRules(token, zoneId, rules);
+      console.log(`[cf-apply] applied: ${change.summary}`);
+    } else if (change.resource === 'ssl') {
+      await applySslMode(token, zoneId, desired.ssl.mode);
+      console.log(`[cf-apply] applied: ${change.summary}`);
+    }
+  }
+
+  console.log('');
+  if (blockedRemaining > 0) {
+    console.log(
+      `[cf-apply] Done, but ${blockedRemaining} change(s) were blocked and left unapplied ` +
+        `(re-run with --allow-zone-ssl to include the zone-wide SSL change).`,
+    );
+    return 1;
+  }
+
+  console.log('[cf-apply] Done — zone converged to desired state.');
+  return 0;
+}
+
+// Exported for docs/tests: the module can be imported without running the CLI.
+export { CF_API_BASE, TOKEN_SCOPES, ZONE_NAME };
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((error) => {
+      console.error(`[cf-apply] ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    });
+}

--- a/scripts/cloudflare-apply.ts
+++ b/scripts/cloudflare-apply.ts
@@ -70,6 +70,9 @@ export function parseArgs(argv: string[]): CliOptions {
     else if (argument === '--dry-run') apply = false;
     else if (argument === '--allow-zone-ssl') allowZoneSsl = true;
     else if (argument === '--help' || argument === '-h') help = true;
+    // Reject typos loudly — a silently ignored --appply would dry-run when the
+    // operator believed they applied.
+    else throw new Error(`Unknown flag: ${argument} (see --help)`);
   }
 
   return { apply, allowZoneSsl, help };
@@ -140,7 +143,10 @@ async function resolveZoneId(token: string, zoneName: string): Promise<string> {
     'GET',
     `/zones?name=${encodeURIComponent(zoneName)}`,
   );
-  const zone = zones.find((candidate) => candidate.name === zoneName) ?? zones[0];
+  const zone = zones.find((candidate) => candidate.name === zoneName);
+  if (!zone) {
+    throw new Error(`Zone "${zoneName}" not found among ${zones.length} zone(s) visible to this token`);
+  }
   if (!zone) {
     throw new Error(
       `No Cloudflare zone found for "${zoneName}". Set CLOUDFLARE_ZONE_ID, or grant the token Zone.Zone Read.`,
@@ -277,6 +283,9 @@ async function main(): Promise<number> {
 
   let blockedRemaining = 0;
 
+  // Mutations are applied sequentially with no rollback: a mid-apply failure
+  // leaves the zone partially converged. Safe because the plan is ordered
+  // (SSL -> cache rule -> proxied flip last) and re-running converges the rest.
   for (const change of changes) {
     if (change.blocked) {
       console.warn(`[cf-apply] SKIPPED (blocked): ${change.summary}`);

--- a/scripts/cloudflare-apply.ts
+++ b/scripts/cloudflare-apply.ts
@@ -36,7 +36,7 @@
  */
 
 import { pathToFileURL } from 'node:url';
-import { CACHE_RULE_PHASE, ZONE_NAME, desiredCloudflareState } from '../infra/cloudflare/config';
+import { CACHE_RULE_PHASE, WAF_RULE_PHASE, ZONE_NAME, desiredCloudflareState } from '../infra/cloudflare/config';
 import type { SslMode } from '../infra/cloudflare/config';
 import { buildPlan, upsertCacheRule } from '../infra/cloudflare/plan';
 import type { LiveDnsRecord, LiveState, PlannedChange, RulesetRule } from '../infra/cloudflare/plan';
@@ -171,13 +171,13 @@ async function fetchDnsRecord(token: string, zoneId: string, name: string): Prom
   return record;
 }
 
-/** The cache-phase entrypoint ruleset. Returns an empty rule set when the phase has no ruleset yet (404). */
-async function fetchCacheRules(token: string, zoneId: string): Promise<RulesetRule[]> {
+/** A phase's entrypoint ruleset. Returns an empty rule set when the phase has no ruleset yet (404). */
+async function fetchPhaseRules(token: string, zoneId: string, phase: string): Promise<RulesetRule[]> {
   try {
     const ruleset = await cfRequest<{ id: string; rules?: RulesetRule[] }>(
       token,
       'GET',
-      `/zones/${zoneId}/rulesets/phases/${CACHE_RULE_PHASE}/entrypoint`,
+      `/zones/${zoneId}/rulesets/phases/${phase}/entrypoint`,
     );
     return ruleset.rules ?? [];
   } catch (error) {
@@ -193,23 +193,26 @@ async function fetchSslMode(token: string, zoneId: string): Promise<string> {
 }
 
 async function fetchLiveState(token: string, zoneId: string, dnsName: string): Promise<LiveState> {
-  const [dnsRecord, cacheRules, sslMode] = await Promise.all([
+  const [dnsRecord, cacheRules, wafRules, sslMode] = await Promise.all([
     fetchDnsRecord(token, zoneId, dnsName),
-    fetchCacheRules(token, zoneId),
+    fetchPhaseRules(token, zoneId, CACHE_RULE_PHASE),
+    fetchPhaseRules(token, zoneId, WAF_RULE_PHASE),
     fetchSslMode(token, zoneId),
   ]);
-  return { dnsRecord, cacheRules, sslMode };
+  return { dnsRecord, cacheRules, wafRules, sslMode };
 }
 
 async function applyDnsProxied(token: string, zoneId: string, recordId: string, proxied: boolean): Promise<void> {
   await cfRequest(token, 'PATCH', `/zones/${zoneId}/dns_records/${recordId}`, { proxied });
 }
 
-async function applyCacheRules(token: string, zoneId: string, rules: RulesetRule[]): Promise<void> {
+async function applyPhaseRules(token: string, zoneId: string, phase: string, rules: RulesetRule[]): Promise<void> {
   // PUT to the phase entrypoint creates the ruleset when it doesn't exist yet, or
-  // replaces its rules array when it does. We send the merged array (foreign rules
-  // preserved), so this only ever adds/updates our rule.
-  await cfRequest(token, 'PUT', `/zones/${zoneId}/rulesets/phases/${CACHE_RULE_PHASE}/entrypoint`, { rules });
+  // replaces its rules array when it does. It REPLACES — so `rules` must always be
+  // the merged array from upsertCacheRule, which carries every foreign rule through
+  // verbatim. Sending only our own rules here would delete the zone's other rules,
+  // including the WAF rule that blocks the AI crawlers.
+  await cfRequest(token, 'PUT', `/zones/${zoneId}/rulesets/phases/${phase}/entrypoint`, { rules });
 }
 
 async function applySslMode(token: string, zoneId: string, mode: SslMode): Promise<void> {
@@ -286,6 +289,7 @@ async function main(): Promise<number> {
   // Mutations are applied sequentially with no rollback: a mid-apply failure
   // leaves the zone partially converged. Safe because the plan is ordered
   // (SSL -> cache rule -> proxied flip last) and re-running converges the rest.
+  const appliedPhases = new Set<string>();
   for (const change of changes) {
     if (change.blocked) {
       console.warn(`[cf-apply] SKIPPED (blocked): ${change.summary}`);
@@ -297,9 +301,18 @@ async function main(): Promise<number> {
     if (change.resource === 'dns') {
       await applyDnsProxied(token, zoneId, live.dnsRecord.id, desired.dns.proxied);
       console.log(`[cf-apply] applied: ${change.summary}`);
-    } else if (change.resource === 'cache-rule') {
-      const { rules } = upsertCacheRule(live.cacheRules, desired.cacheRule);
-      await applyCacheRules(token, zoneId, rules);
+    } else if (change.resource === 'cache-rule' || change.resource === 'waf-rule') {
+      // One PUT per phase, not per planned change. The plan reports each drifted
+      // rule separately so a dry-run names them, but the rulesets API only offers
+      // a whole-phase write and the merged array already contains every rule.
+      const phase = change.resource === 'waf-rule' ? WAF_RULE_PHASE : CACHE_RULE_PHASE;
+      if (!appliedPhases.has(phase)) {
+        const existingRules = change.resource === 'waf-rule' ? live.wafRules : live.cacheRules;
+        const desiredRules = change.resource === 'waf-rule' ? desired.wafRules : desired.cacheRules;
+        const { rules } = upsertCacheRule(existingRules, desiredRules);
+        await applyPhaseRules(token, zoneId, phase, rules);
+        appliedPhases.add(phase);
+      }
       console.log(`[cf-apply] applied: ${change.summary}`);
     } else if (change.resource === 'ssl') {
       await applySslMode(token, zoneId, desired.ssl.mode);

--- a/scripts/production-deploy-changes.mjs
+++ b/scripts/production-deploy-changes.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 const scriptPath = fileURLToPath(import.meta.url);
 const ZERO_SHA = '0000000000000000000000000000000000000000';
-const ALL_TARGETS = Object.freeze({ web: true, backend: true, app: true });
+const ALL_TARGETS = Object.freeze({ web: true, backend: true, app: true, cloudflare: true });
 const FULL_COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/i;
 
 function fullDeploy(reason) {
@@ -63,6 +63,18 @@ function isProductionDeployTestFile(filePath) {
   );
 }
 
+// Cloudflare zone config-as-code: the desired state and the script that
+// converges it. Deliberately NOT web-affecting (see isWebAffecting) — a cache
+// rule or WAF edit changes the edge, not the Next build, so it must not queue a
+// web deploy of its own.
+function isCloudflareAffecting(filePath) {
+  return (
+    filePath.startsWith('infra/cloudflare/') ||
+    filePath === 'scripts/cloudflare-apply.ts' ||
+    filePath === 'scripts/cloudflare-apply.test.ts'
+  );
+}
+
 function isBackendAffecting(filePath) {
   return (
     filePath.startsWith('packages/') ||
@@ -85,7 +97,8 @@ function isWebAffecting(filePath) {
     filePath.endsWith('.md') ||
     filePath === 'scripts/production-backend-smoke.mjs' ||
     isProductionDeployTestFile(filePath) ||
-    isProductionDeployWatchdogFile(filePath)
+    isProductionDeployWatchdogFile(filePath) ||
+    isCloudflareAffecting(filePath)
   );
 }
 
@@ -113,7 +126,7 @@ function isAppAffecting(filePath) {
 }
 
 function classifyChangedFiles(changedFiles) {
-  const targets = { web: false, backend: false, app: false };
+  const targets = { web: false, backend: false, app: false, cloudflare: false };
 
   for (const filePath of changedFiles) {
     if (isProductionDeployTestFile(filePath) || isProductionDeployWatchdogFile(filePath)) continue;
@@ -121,6 +134,7 @@ function classifyChangedFiles(changedFiles) {
     if (isBackendAffecting(filePath)) targets.backend = true;
     if (isWebAffecting(filePath)) targets.web = true;
     if (isAppAffecting(filePath)) targets.app = true;
+    if (isCloudflareAffecting(filePath)) targets.cloudflare = true;
   }
 
   return targets;
@@ -247,6 +261,7 @@ function formatGitHubOutputs(result) {
     `web=${result.web}`,
     `backend=${result.backend}`,
     `app=${result.app}`,
+    `cloudflare=${result.cloudflare}`,
     `deployment_base_sha=${result.deploymentBaseSha}`,
   ].join('\n');
 }

--- a/scripts/production-deploy-changes.test.mjs
+++ b/scripts/production-deploy-changes.test.mjs
@@ -69,31 +69,37 @@ void test('classifies changed paths with the production workflow semantics', () 
     web: false,
     backend: false,
     app: false,
+    cloudflare: false,
   });
   assert.deepEqual(classifyChangedFiles(['packages/backend/src/index.ts']), {
     web: true,
     backend: true,
     app: false,
+    cloudflare: false,
   });
   assert.deepEqual(classifyChangedFiles(['packages/mobile/app/index.tsx']), {
     web: false,
     backend: true,
     app: true,
+    cloudflare: false,
   });
   assert.deepEqual(classifyChangedFiles(['packages/shared-schema/src/schema.ts']), {
     web: true,
     backend: true,
     app: true,
+    cloudflare: false,
   });
   assert.deepEqual(classifyChangedFiles(['scripts/production-backend-smoke.mjs']), {
     web: false,
     backend: true,
     app: false,
+    cloudflare: false,
   });
   assert.deepEqual(classifyChangedFiles(['scripts/production-backend-smoke.test.mjs']), {
     web: false,
     backend: false,
     app: false,
+    cloudflare: false,
   });
 });
 
@@ -104,7 +110,7 @@ void test('the deploy watchdog never queues a deploy of its own', () => {
     'scripts/production-deploy-watchdog.mjs',
     'scripts/production-deploy-watchdog.test.mjs',
   ]) {
-    assert.deepEqual(classifyChangedFiles([filePath]), { web: false, backend: false, app: false });
+    assert.deepEqual(classifyChangedFiles([filePath]), { web: false, backend: false, app: false, cloudflare: false });
   }
 });
 
@@ -121,22 +127,23 @@ void test('a watchdog file alongside real code still deploys the real code', () 
     web: true,
     backend: true,
     app: false,
+    cloudflare: false,
   });
   assert.deepEqual(
     classifyChangedFiles(['.github/workflows/production-deploy-watchdog.yml', 'packages/mobile/app/index.tsx']),
-    { web: false, backend: true, app: true },
+    { web: false, backend: true, app: true, cloudflare: false },
   );
 });
 
 void test('treats the production workflow and its detector as affecting every target', () => {
   for (const filePath of ['.github/workflows/production-deploy.yml', 'scripts/production-deploy-changes.mjs']) {
-    assert.deepEqual(classifyChangedFiles([filePath]), { web: true, backend: true, app: true });
+    assert.deepEqual(classifyChangedFiles([filePath]), { web: true, backend: true, app: true, cloudflare: true });
   }
 });
 
 void test('keeps production deploy unit tests CI-only', () => {
   for (const filePath of ['scripts/production-backend-smoke.test.mjs', 'scripts/production-deploy-changes.test.mjs']) {
-    assert.deepEqual(classifyChangedFiles([filePath]), { web: false, backend: false, app: false });
+    assert.deepEqual(classifyChangedFiles([filePath]), { web: false, backend: false, app: false, cloudflare: false });
   }
 });
 
@@ -147,7 +154,7 @@ void test('treats every input of the app.boardsesh.com export as app-affecting',
   // merge green, deploy nothing, and leave the author believing it shipped.
   // W-24 / #4438.
   for (const filePath of ['scripts/build-expo-web-export.sh', 'scripts/lib/patch-expo-web-pwa-manifest.mjs']) {
-    assert.deepEqual(classifyChangedFiles([filePath]), { web: true, backend: false, app: true });
+    assert.deepEqual(classifyChangedFiles([filePath]), { web: true, backend: false, app: true, cloudflare: false });
   }
 });
 
@@ -165,7 +172,7 @@ void test('treats every deployed Cloudflare Pages config file as app-affecting',
     'deploy/app-subdomain/_routes.json',
     'deploy/app-subdomain/functions/_middleware.ts',
   ]) {
-    assert.deepEqual(classifyChangedFiles([filePath]), { web: true, backend: false, app: true });
+    assert.deepEqual(classifyChangedFiles([filePath]), { web: true, backend: false, app: true, cloudflare: false });
   }
 });
 
@@ -184,9 +191,41 @@ void test('leaves the non-deployed files in deploy/app-subdomain out of the app 
   }
 });
 
+void test('a Cloudflare zone-config change converges the edge without a web deploy', () => {
+  // infra/cloudflare is desired edge state, not Next input: a cache rule or WAF
+  // edit changes what Cloudflare does, and rebuilding www would prove nothing.
+  // isWebAffecting is a denylist, so without the explicit exclusion every zone
+  // edit would queue a full production web deploy for free.
+  for (const filePath of [
+    'infra/cloudflare/config.ts',
+    'infra/cloudflare/plan.ts',
+    'scripts/cloudflare-apply.ts',
+    'scripts/cloudflare-apply.test.ts',
+  ]) {
+    assert.deepEqual(
+      classifyChangedFiles([filePath]),
+      { web: false, backend: false, app: false, cloudflare: true },
+      `${filePath} must converge Cloudflare and nothing else`,
+    );
+  }
+});
+
+void test('a code change never drags the Cloudflare apply along with it', () => {
+  // The converse guard. deploy-cloudflare talks to the live zone with a
+  // production token; firing it on every packages/ commit would turn an
+  // unrelated merge into an edge mutation.
+  for (const filePath of ['packages/web/app/page.tsx', 'packages/backend/src/index.ts', 'bun.lock']) {
+    assert.equal(
+      classifyChangedFiles([filePath]).cloudflare,
+      false,
+      `${filePath} must not trigger deploy-cloudflare`,
+    );
+  }
+});
+
 void test('keeps every backend build and runtime control path backend-affecting', () => {
   for (const filePath of ['Dockerfile.backend', 'railway.toml', 'bun.lock', 'package.json']) {
-    assert.deepEqual(classifyChangedFiles([filePath]), { web: true, backend: true, app: false });
+    assert.deepEqual(classifyChangedFiles([filePath]), { web: true, backend: true, app: false, cloudflare: false });
   }
 });
 
@@ -199,8 +238,14 @@ void test('manual dispatch builds every target without consulting history or git
   });
 
   assert.deepEqual(
-    { web: result.web, backend: result.backend, app: result.app, fullBuild: result.fullBuild },
-    { web: true, backend: true, app: true, fullBuild: true },
+    {
+      web: result.web,
+      backend: result.backend,
+      app: result.app,
+      cloudflare: result.cloudflare,
+      fullBuild: result.fullBuild,
+    },
+    { web: true, backend: true, app: true, cloudflare: true, fullBuild: true },
   );
   assert.equal(result.reason, 'workflow_dispatch');
 });
@@ -297,7 +342,7 @@ void test('compares the successful deployment baseline through the current head'
     ['ancestor', BASE_SHA, HEAD_SHA],
     ['diff', BASE_SHA, HEAD_SHA],
   ]);
-  assert.equal(formatGitHubOutputs(result), `web=true\nbackend=true\napp=false\ndeployment_base_sha=${BASE_SHA}`);
+  assert.equal(formatGitHubOutputs(result), `web=true\nbackend=true\napp=false\ncloudflare=false\ndeployment_base_sha=${BASE_SHA}`);
 });
 
 void test('a git comparison error falls back to a full build', () => {

--- a/scripts/production-deploy-changes.test.mjs
+++ b/scripts/production-deploy-changes.test.mjs
@@ -215,11 +215,7 @@ void test('a code change never drags the Cloudflare apply along with it', () => 
   // production token; firing it on every packages/ commit would turn an
   // unrelated merge into an edge mutation.
   for (const filePath of ['packages/web/app/page.tsx', 'packages/backend/src/index.ts', 'bun.lock']) {
-    assert.equal(
-      classifyChangedFiles([filePath]).cloudflare,
-      false,
-      `${filePath} must not trigger deploy-cloudflare`,
-    );
+    assert.equal(classifyChangedFiles([filePath]).cloudflare, false, `${filePath} must not trigger deploy-cloudflare`);
   }
 });
 
@@ -342,7 +338,10 @@ void test('compares the successful deployment baseline through the current head'
     ['ancestor', BASE_SHA, HEAD_SHA],
     ['diff', BASE_SHA, HEAD_SHA],
   ]);
-  assert.equal(formatGitHubOutputs(result), `web=true\nbackend=true\napp=false\ncloudflare=false\ndeployment_base_sha=${BASE_SHA}`);
+  assert.equal(
+    formatGitHubOutputs(result),
+    `web=true\nbackend=true\napp=false\ncloudflare=false\ndeployment_base_sha=${BASE_SHA}`,
+  );
 });
 
 void test('a git comparison error falls back to a full build', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -912,6 +912,14 @@ export default defineConfig({
         command: 'tsx scripts/discord-feedback-scan.ts',
         cache: false,
       },
+      // Cloudflare config-as-code for the boardsesh.com zone (DNS proxied flag,
+      // the edge-cache rules and the WAF crawler rules). Dry-run by default;
+      // forward `-- --apply` (and optionally `--allow-zone-ssl`) to converge.
+      // See scripts/cloudflare-apply.ts + docs/cloudflare.md.
+      'cf:apply': {
+        command: 'tsx scripts/cloudflare-apply.ts',
+        cache: false,
+      },
 
       // --- Dev servers ---
       'dev:mobile': {


### PR DESCRIPTION
## Summary

Cloudflare config-as-code for the `boardsesh.com` zone — dashboard clicks become reviewable, versioned config. Rebased onto `main` (it was 1,346 commits behind) and extended to cover the www crawl-cost controls from #4650.

- **`infra/cloudflare/config.ts`** — desired state: the `ws` record proxied, the cache rules, the WAF crawler rules, and a strict-SSL assertion.
- **`vp run cf:apply`** — dry-run by default: diffs live zone state against the config, prints the plan, exits non-zero on drift. `--apply` mutates only the deltas. Foreign rules in every managed phase are preserved verbatim; ours are identified by stable description markers. `--allow-zone-ssl` gates the zone-wide SSL change since other hostnames share it.
- **Cutover-safe ordering**: SSL and the cache rules apply before the proxied flip, and the flip is held back entirely while a required SSL change is blocked — orange-clouding with weak SSL would redirect-loop every host on the record, including the party-mode WebSocket.

### New in this revision: the www cost controls

Measured against production on 2026-08-25 with the Vercel MCP — the data #4717 had to leave as an empty column, because that agent had no Vercel credentials:

| | per day |
| --- | --- |
| Vercel function invocations | ~442,600 |
| — `/api/internal/board-render` | ~215,600 (48.7%) |
| — climb view `…/view/[climb_uuid]` | ~203,900 (46.1%) |
| — `/setter/[setter_username]` | ~15,900 (3.6%) |
| — the other 48 routes combined | ~7,100 (1.6%) |
| Homepage `/` | ~2,000 |

Two routes are 94% of compute, against a published sitemap of ~60k climb URLs and ~2,000 homepage hits. That shape is a crawl, not an audience.

**Board-render cache rule.** The route already sends `cache-control: public, max-age=31536000, immutable` and a matching `CDN-Cache-Control`, but Cloudflare caches by **file extension** by default and `/api/internal/board-render` has none — so it measured `cf-cache-status: DYNAMIC` while `/_next/static/*.js` on the same zone was a `HIT`. Every image byte was transiting Cloudflare to Vercel (~54 GB/day). The rule is the whole fix; no origin header change.

**Crawler rules.** A `skip` rule for search engines and share-card unfurlers, then a `block` rule for commercial SEO crawlers (Ahrefs, Semrush, DataForSEO, MJ12, DotBot, BLEXBot, Barkrowler, serpstat, Seznam, Zoominfo, Screaming Frog) — each verified reaching our origin by #4716's 2026-08-24 probe. They sell backlink data and send Boardsesh no traffic. Brave is allowlisted explicitly because it runs its own index rather than reselling Bing or Google.

### Three traps this had to design around

1. **WAF rule order is load-bearing, and the naive upsert gets it backwards.** A rule-by-rule upsert appends a newly added allow rule *after* an already-present block rule, reversing precedence and blocking Googlebot the moment the config lands. `upsertCacheRule` now rewrites our rules as one contiguous group in declared order. Mutation-tested: restoring the per-rule version reds two tests.

2. **`lower()` is required, not stylistic.** Cloudflare's `contains` is case-sensitive, so `contains "AhrefsBot"` installs cleanly and matches nothing — a rule that looks done and does nothing. A test pins every comparison to the lowercased form; removing `lower()` reds it.

3. **`cf.client.bot` is the wrong allowlist.** Ahrefs and Semrush are themselves Cloudflare *verified bots*, so that field is true for precisely the crawlers we are blocking. The allowlist is UA-based on purpose, and the file says why.

The AI crawlers (ClaudeBot, GPTBot, PerplexityBot, Bytespider, CCBot…) are deliberately **absent** from our block list: the same probe got `403` from `server: cloudflare` for every one, so a zone rule we do not own already stops them. That rule is foreign to this tool and is preserved verbatim — there is a test asserting a foreign WAF rule survives the phase PUT, because the rulesets API replaces the entire phase and dropping it would silently reopen the site to every AI scraper.

### CI wiring

`deploy-cloudflare` runs on `main` from the `Production` environment (which already has `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`), only when `infra/cloudflare/**` or the apply tooling changes. Nothing else depends on the job, so a Cloudflare API hiccup never blocks a web or backend deploy.

Main replaced the workflow's inline change-detection bash with `scripts/production-deploy-changes.mjs` since this branch was written, so the `cloudflare` target moved into that script. It is deliberately **not** web-affecting: `isWebAffecting` is a denylist, so without an explicit exclusion every zone edit would queue a full production web deploy for nothing. Both directions are tested.

⚠️ **The `Production` environment is main-only**, so the first real `cf:apply` cannot run from this branch — it happens on merge. Run the dry-run locally first (below) and read the plan before merging.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project scripts` — 33 tests in `scripts/cloudflare-apply.test.ts` (was 20), covering the new rules, ordering, foreign-rule preservation, and the token lists.
- `node --test scripts/production-deploy-changes.test.mjs` — 21 tests (was 19); the two new ones pin that a zone-config edit converges Cloudflare *and nothing else*, and that a `packages/` change never drags the apply along with it.
- `vp run typecheck` — clean. `vp check` — clean on the changed files.
- **Mutation-tested three guards.** Per-rule upsert instead of the group rewrite → 2 failures. `lower()` removed → 1 failure. Managed order taken from the zone instead of the config → 1 failure.

### Before merge

```bash
CLOUDFLARE_API_TOKEN=… vp run cf:apply     # dry-run; prints the plan, mutates nothing
```

**Read the plan before merging — one line in it needs a human decision.** Rules are
identified by a description marker, and the `/og/` rule currently on the zone was created
*by hand* in July, so it will not carry ours. The dry-run will therefore report the og rule
as **missing**, and applying would create a second `/og/` cache rule alongside the manual
one rather than adopting it.

Both rules say "cache" and Cloudflare takes the first match, so a duplicate is untidy rather
than dangerous — but it should not be merged blind. Two ways to settle it, whichever you
prefer:

- Rename the existing rule's description in the dashboard to
  `boardsesh:og-edge-cache (managed by scripts/cloudflare-apply.ts)` before merging, and the
  tool adopts it in place, keeping its id and position.
- Or let the apply create ours and delete the manual one afterwards.

The DNS proxied flag and the SSL mode are plain zone state with no marker, so those two
really should report as already in sync.

### After merge

```bash
B='https://www.boardsesh.com/api/internal/board-render?board_name=kilter&layout_id=1&size_id=10&set_ids=1,20&frames=p1085r15p1128r12&include_background=1'
curl -sI "$B" | grep -i cf-cache-status   # MISS
curl -sI "$B" | grep -i cf-cache-status   # HIT

for UA in "AhrefsBot/7.0" "SemrushBot/7~bl" "Brave-Search/1.0" "Googlebot/2.1" "Bingbot/2.0"; do
  printf '%-18s %s ' "$UA" "$(curl -sS -o /dev/null -A "$UA" -w '%{http_code}' https://www.boardsesh.com/)"
  curl -sSI -A "$UA" https://www.boardsesh.com/ | grep -ci '^x-vercel-id' | sed 's/^/reached-vercel:/'
done
```

Ahrefs/Semrush → `403 reached-vercel:0`; Brave/Google/Bing → `200 reached-vercel:1`. Then confirm compute actually fell:

```
get_runtime_logs since=6h group_by=route source=["serverless"] environment=production
```

> `since: 24h` is silently truncated (249,960 vs 442,564 from 6 h × 4). Use a 6 h or 30 min window and scale, or you will under-report by ~2×. Documented in `docs/cloudflare.md`.

Part of #4650 / epic #4648. Pairs with #4764, which stops crawler page renders triggering a board-render in the first place.
