### PR TITLE
fix(sync): surface circuit ownership conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       # `listing-guards` job (see below).
       storeMetadata: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.storeMetadata }}
       mobileLocales: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.mobileLocales }}
+      auroraCircuitArbitration: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.auroraCircuitArbitration }}
       # PR-only guard signal: did this PR edit the OTA-owned changelog data file?
       # Defaults false off PRs (the OTA bot legitimately rewrites it on push).
       changelogData: ${{ github.event_name == 'pull_request' && steps.filter.outputs.changelogData || 'false' }}
@@ -63,7 +64,7 @@ jobs:
       # non-JS files (SQL migrations under packages/db, .graphql under
       # shared-schema) that wouldn't trigger anyJs but still need setup so
       # test-backend / mobile-bundle / codegen-drift can run.
-      runAny: ${{ github.event_name != 'pull_request' || steps.filter.outputs.anyJs == 'true' || steps.filter.outputs.web == 'true' || steps.filter.outputs.i18nCatalogs == 'true' || steps.filter.outputs.sharedSchema == 'true' || steps.filter.outputs.sharedDeps == 'true' || steps.filter.outputs.backend == 'true' || steps.filter.outputs.mobile == 'true' || steps.filter.outputs.ocr == 'true' || steps.filter.outputs.locationSync == 'true' || steps.filter.outputs.rootCi == 'true' }}
+      runAny: ${{ github.event_name != 'pull_request' || steps.filter.outputs.anyJs == 'true' || steps.filter.outputs.web == 'true' || steps.filter.outputs.i18nCatalogs == 'true' || steps.filter.outputs.sharedSchema == 'true' || steps.filter.outputs.sharedDeps == 'true' || steps.filter.outputs.backend == 'true' || steps.filter.outputs.mobile == 'true' || steps.filter.outputs.ocr == 'true' || steps.filter.outputs.locationSync == 'true' || steps.filter.outputs.auroraCircuitArbitration == 'true' || steps.filter.outputs.rootCi == 'true' }}
       # NOTE: deployConfig, storeMetadata, and mobileLocales are deliberately
       # NOT part of runAny — the deploy-config and listing-guards jobs below
       # need [changes] only (no bun-install/build:db setup pass), so a PR
@@ -150,6 +151,19 @@ jobs:
             mobileLocales:
               - 'packages/mobile/locales/**'
               - 'scripts/mobile-locales-parity.test.ts'
+            # The real-database circuit ownership assertions only need the
+            # Aurora sync paths and their direct shared database contracts.
+            # Root manifests/workflow config are already covered by rootCi.
+            auroraCircuitArbitration:
+              - 'packages/aurora-sync/**'
+              - 'packages/web/app/lib/data-sync/aurora/**'
+              - 'packages/db/src/client/**'
+              - 'packages/db/src/queries/**'
+              - 'packages/db/src/schema/**'
+              - 'packages/sync-runtime/**'
+              - 'packages/shared-schema/src/sync-error-codes.ts'
+              - 'packages/shared-schema/src/__tests__/sync-error-codes.test.ts'
+              - 'packages/{aurora-sync,db,sync-runtime,shared-schema,web}/package.json'
             rootCi:
               - '.github/workflows/ci.yml'
               - 'vite.config.ts'
@@ -643,6 +657,55 @@ jobs:
           path: packages/backend/test-results/junit-backend-${{ matrix.shard }}.xml
           retention-days: 7
 
+  aurora-circuit-arbitration:
+    needs: [changes, setup]
+    if: needs.changes.outputs.auroraCircuitArbitration == 'true' || needs.changes.outputs.rootCi == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: ghcr.io/boardsesh/boardsesh-dev-db:latest
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: main
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d main"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: 'lts'
+          cache: true
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Download built packages
+        uses: actions/download-artifact@v4
+        with:
+          name: built-packages
+      - name: Run Aurora circuit arbitration database gate
+        env:
+          DATABASE_URL: postgresql://postgres:password@localhost:5432/main
+          REQUIRE_AURORA_CIRCUIT_INTEGRATION: '1'
+        run: >-
+          vp test run --project aurora-sync
+          packages/aurora-sync/src/sync/user-sync.concurrency.integration.test.ts
+          --reporter=verbose --reporter=github-actions
+      - name: Run Aurora daemon/web arbitration database gate
+        env:
+          DATABASE_URL: postgresql://postgres:password@localhost:5432/main
+          REQUIRE_AURORA_CIRCUIT_INTEGRATION: '1'
+        run: >-
+          vp test run --project web
+          packages/web/app/lib/data-sync/aurora/__tests__/user-sync.cross-writer.integration.test.ts
+          --reporter=verbose --reporter=github-actions
+
   test-ocr:
     needs: [changes, setup]
     # Include sharedDeps so OCR tests rerun when a shared package they
@@ -981,6 +1044,7 @@ jobs:
       - i18n
       - test-default
       - test-backend
+      - aurora-circuit-arbitration
       - test-ocr
       - test-location-sync-integration
       - mobile-bundle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,8 @@ jobs:
               - 'packages/sync-runtime/**'
               - 'packages/shared-schema/src/sync-error-codes.ts'
               - 'packages/shared-schema/src/__tests__/sync-error-codes.test.ts'
+              - 'scripts/prepare-aurora-circuit-integration-db.ts'
+              - 'scripts/prepare-aurora-circuit-integration-db.test.ts'
               - 'packages/{aurora-sync,db,sync-runtime,shared-schema,web}/package.json'
             rootCi:
               - '.github/workflows/ci.yml'
@@ -670,7 +672,7 @@ jobs:
           POSTGRES_PASSWORD: password
           POSTGRES_DB: main
         ports:
-          - 5432:5432
+          - 5433:5432
         options: >-
           --health-cmd "pg_isready -U postgres -d main"
           --health-interval 10s
@@ -689,9 +691,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: built-packages
+      - name: Prepare Aurora circuit arbitration database gate
+        env:
+          ALLOW_AURORA_CIRCUIT_SCHEMA_COMPAT: '1'
+          DATABASE_URL: postgresql://postgres:password@localhost:5433/main
+        run: vp node --import tsx scripts/prepare-aurora-circuit-integration-db.ts
       - name: Run Aurora circuit arbitration database gate
         env:
-          DATABASE_URL: postgresql://postgres:password@localhost:5432/main
+          DATABASE_URL: postgresql://postgres:password@localhost:5433/main
           REQUIRE_AURORA_CIRCUIT_INTEGRATION: '1'
         run: >-
           vp test run --project aurora-sync
@@ -699,7 +706,7 @@ jobs:
           --reporter=verbose --reporter=github-actions
       - name: Run Aurora daemon/web arbitration database gate
         env:
-          DATABASE_URL: postgresql://postgres:password@localhost:5432/main
+          DATABASE_URL: postgresql://postgres:password@localhost:5433/main
           REQUIRE_AURORA_CIRCUIT_INTEGRATION: '1'
         run: >-
           vp test run --project web

--- a/docs/aurora-sync.md
+++ b/docs/aurora-sync.md
@@ -52,6 +52,23 @@ The `@boardsesh/aurora-sync` package provides the shared sync implementation. It
   - `bids` → `kilter_bids` + `boardsesh_ticks`
   - `circuits` → `kilter_circuits` + `playlists` + `playlist_climbs`
 
+Circuit playlist writes are arbitrated per `(board_type, circuit_uuid)` with a
+transaction-scoped PostgreSQL advisory lock. After taking the lock, the daemon
+reads the current owner edges and either refuses a foreign/ambiguous claim or
+writes the playlist, sole-owner edge, and climb replacement in one transaction.
+Circuit deltas are deduplicated with the last payload row winning, then sorted.
+The transaction acquires that complete sorted lock set before any
+`board_circuits` source upsert or playlist write. Claiming an orphan also
+promotes an existing editor/viewer edge for the syncing user to `owner`.
+The playlist upsert also retains its correlated ownership predicate as defence
+in depth. If that predicate suppresses an upsert, the daemon re-reads owners,
+counts the circuit as refused, and logs the exact owner state; an empty owner
+state is treated as an invariant/concurrency warning and is never claimed
+silently. After each successful cycle, a persistent ownership read records one
+of `none`, `foreign`, or `ambiguous`; mobile and web show distinct localised
+guidance for the two conflict states while continuing to understand the older
+generic stored code.
+
 ### Logbook writes (`ascents`/`bids`): timezone, claim, soft-delete
 
 Both pull implementations (the daemon `packages/aurora-sync/src/sync/user-sync.ts`

--- a/packages/aurora-sync/package.json
+++ b/packages/aurora-sync/package.json
@@ -34,6 +34,11 @@
       "import": "./src/sync/apply-user-logbook.ts",
       "default": "./src/sync/apply-user-logbook.ts"
     },
+    "./circuit-arbitration": {
+      "types": "./src/sync/circuit-arbitration.ts",
+      "import": "./src/sync/circuit-arbitration.ts",
+      "default": "./src/sync/circuit-arbitration.ts"
+    },
     "./json-import": {
       "types": "./src/sync/json-import.ts",
       "import": "./src/sync/json-import.ts",

--- a/packages/aurora-sync/src/cli/index.ts
+++ b/packages/aurora-sync/src/cli/index.ts
@@ -4,6 +4,7 @@ import { credentialBackoffMs } from '@boardsesh/db/queries';
 import { SyncRunner } from '../runner/sync-runner';
 import { AURORA_BOARDS } from '../api/types';
 import { AURORA_LOCATION_BOARDS, type AuroraLocationBoardName } from '../sync/locations-sync';
+import { shouldLogAuroraSyncMessage } from './log-filter';
 
 // Load environment variables from .env files if available
 import { config } from 'dotenv';
@@ -17,21 +18,7 @@ function createRunner(verbose: boolean): SyncRunner {
     onLog: verbose
       ? console.info
       : (msg: string) => {
-          if (
-            msg.includes('✓') ||
-            msg.includes('✗') ||
-            msg.includes('Found') ||
-            msg.includes('Daemon') ||
-            msg.includes('Quiet hours') ||
-            msg.includes('Waiting') ||
-            msg.includes('No users') ||
-            msg.includes('Transient') ||
-            // Stuck-credential observability events (see SyncRunner):
-            // CREDENTIAL QUARANTINED / CREDENTIAL FLAPPING and the hourly
-            // "Sync health" fleet summary must surface in non-verbose prod logs.
-            msg.includes('CREDENTIAL') ||
-            msg.includes('Sync health')
-          ) {
+          if (shouldLogAuroraSyncMessage(msg)) {
             console.info(msg);
           }
         },

--- a/packages/aurora-sync/src/cli/log-filter.test.ts
+++ b/packages/aurora-sync/src/cli/log-filter.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { shouldLogAuroraSyncMessage } from './log-filter';
+
+describe('Aurora CLI non-verbose log filter', () => {
+  it.each([
+    '[aurora-sync] skipped foreign owner {"event":"aurora_circuit_playlist_refused"}',
+    '[SyncRunner] User user-1: circuits not syncing — tension playlist ownership state is foreign',
+    '[SyncRunner] CREDENTIAL FLAPPING user-1',
+    '[SyncRunner] Sync health: active=1',
+  ])('keeps operational warning %s', (message) => {
+    expect(shouldLogAuroraSyncMessage(message)).toBe(true);
+  });
+
+  it('still suppresses ordinary progress chatter', () => {
+    expect(shouldLogAuroraSyncMessage('Sync attempt 2 for user 144574')).toBe(false);
+  });
+});

--- a/packages/aurora-sync/src/cli/log-filter.ts
+++ b/packages/aurora-sync/src/cli/log-filter.ts
@@ -1,0 +1,22 @@
+/** Messages that must remain visible when the Aurora CLI is not verbose. */
+export function shouldLogAuroraSyncMessage(message: string): boolean {
+  return (
+    message.includes('✓') ||
+    message.includes('✗') ||
+    message.includes('Found') ||
+    message.includes('Daemon') ||
+    message.includes('Quiet hours') ||
+    message.includes('Waiting') ||
+    message.includes('No users') ||
+    message.includes('Transient') ||
+    // Circuit arbitration refusals are successful-cycle warnings, not thrown
+    // errors. Keep both the per-circuit structured event and the credential
+    // state summary visible in the default production logs.
+    message.includes('aurora_circuit_playlist_') ||
+    message.includes('circuits not syncing') ||
+    // Stuck-credential observability events (see SyncRunner): CREDENTIAL
+    // QUARANTINED / CREDENTIAL FLAPPING and the hourly fleet summary.
+    message.includes('CREDENTIAL') ||
+    message.includes('Sync health')
+  );
+}

--- a/packages/aurora-sync/src/runner/sync-runner.test.ts
+++ b/packages/aurora-sync/src/runner/sync-runner.test.ts
@@ -236,6 +236,47 @@ describe('SyncRunner login failure handling', () => {
     });
   });
 
+  it('routes non-fatal circuit write diagnostics through the configured onError callback', async () => {
+    const observedErrors: Array<{ error: Error; context: SyncErrorContext }> = [];
+    const runner = new SyncRunner({
+      onError: (error, context) => observedErrors.push({ error, context }),
+    });
+    const runnerPrivates = runner as unknown as SyncRunnerPrivates;
+
+    vi.spyOn(runnerPrivates, 'updateStoredToken').mockResolvedValue(undefined);
+    vi.spyOn(runnerPrivates, 'updateCredentialStatus').mockResolvedValue(undefined);
+    vi.spyOn(runnerPrivates, 'maybeRunSharedSync').mockResolvedValue(undefined);
+    mockSignIn.mockResolvedValue({ token: 'fresh-token', user_id: 42 });
+    mockSyncUserData.mockImplementation(
+      async (
+        _client: unknown,
+        _boardType: unknown,
+        _token: unknown,
+        _auroraUserId: unknown,
+        _userId: unknown,
+        _tables: unknown,
+        _log: unknown,
+        logError: (message: string) => void,
+      ) => {
+        logError('{"event":"aurora_circuit_playlist_malformed_payload","rejectedCount":1}');
+        return {};
+      },
+    );
+
+    await runnerPrivates.syncSingleCredential(createCredential({ syncStatus: 'active', consecutiveFailures: 3 }));
+
+    expect(observedErrors).toHaveLength(1);
+    expect(observedErrors[0]?.error.message).toContain('aurora_circuit_playlist_malformed_payload');
+    expect(observedErrors[0]?.context).toEqual({
+      userId: 'user-123',
+      board: 'decoy',
+      boardType: 'decoy',
+      syncStatus: 'active',
+      consecutiveFailures: 3,
+      quarantined: false,
+    });
+  });
+
   it('surfaces the foreign-owner sync_error code without failing the cycle (#3526)', async () => {
     // Only the circuits were refused — the Aurora account is linked to another
     // Boardsesh user who owns the playlists. Everything else synced, so the

--- a/packages/aurora-sync/src/runner/sync-runner.test.ts
+++ b/packages/aurora-sync/src/runner/sync-runner.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR } from '@boardsesh/shared-schema/sync-error-codes';
+import {
+  AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+  FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+} from '@boardsesh/shared-schema/sync-error-codes';
 import { SHARED_SYNC_COOLDOWN_CURSOR } from '@boardsesh/db/queries';
 import { AuroraRequestError } from '../api/errors';
 import {
@@ -42,7 +45,7 @@ const {
   mockEncrypt,
   mockSignIn,
   mockSyncUserData,
-  mockHasForeignOwnedCircuitPlaylists,
+  mockGetCircuitPlaylistOwnershipConflictState,
   mockSyncSharedData,
   mockSyncAuroraBoardLocations,
   mockClaimSharedSyncSlot,
@@ -53,7 +56,7 @@ const {
   mockEncrypt: vi.fn(),
   mockSignIn: vi.fn(),
   mockSyncUserData: vi.fn(),
-  mockHasForeignOwnedCircuitPlaylists: vi.fn(),
+  mockGetCircuitPlaylistOwnershipConflictState: vi.fn(),
   mockSyncSharedData: vi.fn(),
   mockSyncAuroraBoardLocations: vi.fn(),
   mockClaimSharedSyncSlot: vi.fn(),
@@ -84,7 +87,7 @@ vi.mock('@boardsesh/crypto', () => ({
 
 vi.mock('../sync/user-sync', () => ({
   syncUserData: mockSyncUserData,
-  hasForeignOwnedCircuitPlaylists: mockHasForeignOwnedCircuitPlaylists,
+  getCircuitPlaylistOwnershipConflictState: mockGetCircuitPlaylistOwnershipConflictState,
 }));
 
 vi.mock('../sync/shared-sync', () => ({
@@ -109,12 +112,12 @@ describe('SyncRunner login failure handling', () => {
     mockEncrypt.mockReset();
     mockSignIn.mockReset();
     mockSyncUserData.mockReset();
-    mockHasForeignOwnedCircuitPlaylists.mockReset();
+    mockGetCircuitPlaylistOwnershipConflictState.mockReset();
 
     mockDecrypt.mockImplementation((value: string) => `decrypted-${value}`);
     mockEncrypt.mockReturnValue('encrypted-token');
     mockSyncUserData.mockResolvedValue({});
-    mockHasForeignOwnedCircuitPlaylists.mockResolvedValue(false);
+    mockGetCircuitPlaylistOwnershipConflictState.mockResolvedValue('none');
     process.env.DATABASE_URL = 'postgres://test:test@localhost:5432/test';
   });
 
@@ -233,7 +236,7 @@ describe('SyncRunner login failure handling', () => {
     });
   });
 
-  it('surfaces the duplicate-account sync_error CODE when circuits were skipped, without failing the cycle (#3526)', async () => {
+  it('surfaces the foreign-owner sync_error code without failing the cycle (#3526)', async () => {
     // Only the circuits were refused — the Aurora account is linked to another
     // Boardsesh user who owns the playlists. Everything else synced, so the
     // credential stays 'active' (a failed status would stop the daemon
@@ -248,7 +251,7 @@ describe('SyncRunner login failure handling', () => {
     vi.spyOn(runnerPrivates, 'maybeRunSharedSync').mockResolvedValue(undefined);
 
     mockSignIn.mockResolvedValue({ token: 'fresh-token', user_id: 42 });
-    mockHasForeignOwnedCircuitPlaylists.mockResolvedValue(true);
+    mockGetCircuitPlaylistOwnershipConflictState.mockResolvedValue('foreign');
 
     await runnerPrivates.syncSingleCredential(createCredential());
 
@@ -256,10 +259,10 @@ describe('SyncRunner login failure handling', () => {
     expect(status).toBe('active');
     // A code, not a sentence: `es` / `fr` users get their own wording, and a
     // raw English string here is exactly what the board card can't localise.
-    expect(syncErrorCode).toBe(DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR);
+    expect(syncErrorCode).toBe(FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR);
   });
 
-  it('keeps the sync_error on a later cycle where Aurora returned no circuits at all (#3526)', async () => {
+  it('persists the ambiguous-owner state when Aurora returns no circuit delta (#3526)', async () => {
     // Aurora's user sync is incremental: once the watermark has advanced, a
     // cycle where nothing changed upstream carries no circuit rows. Deriving
     // the flag from "what did this cycle refuse" would clear the message right
@@ -275,12 +278,12 @@ describe('SyncRunner login failure handling', () => {
     // No circuits in this delta at all...
     mockSyncUserData.mockResolvedValue({ circuits: { synced: 0 } });
     // ...but the duplicate link is still there in the data.
-    mockHasForeignOwnedCircuitPlaylists.mockResolvedValue(true);
+    mockGetCircuitPlaylistOwnershipConflictState.mockResolvedValue('ambiguous');
 
     await runnerPrivates.syncSingleCredential(createCredential());
 
     const [, , , syncErrorCode] = updateCredentialStatus.mock.calls[0];
-    expect(syncErrorCode).toBe(DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR);
+    expect(syncErrorCode).toBe(AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR);
   });
 
   it('still marks the cycle successful when the duplicate-owner check itself fails (#3526)', async () => {
@@ -297,7 +300,9 @@ describe('SyncRunner login failure handling', () => {
     vi.spyOn(runnerPrivates, 'maybeRunSharedSync').mockResolvedValue(undefined);
 
     mockSignIn.mockResolvedValue({ token: 'fresh-token', user_id: 42 });
-    mockHasForeignOwnedCircuitPlaylists.mockRejectedValue(new Error('relation "board_circuits" does not exist'));
+    mockGetCircuitPlaylistOwnershipConflictState.mockRejectedValue(
+      new Error('relation "board_circuits" does not exist'),
+    );
 
     // Must not throw — the cycle succeeded.
     await expect(runnerPrivates.syncSingleCredential(createCredential())).resolves.toBeUndefined();
@@ -320,7 +325,7 @@ describe('SyncRunner login failure handling', () => {
 
     mockSignIn.mockResolvedValue({ token: 'fresh-token', user_id: 42 });
     mockSyncUserData.mockResolvedValue({ circuits: { synced: 3 } });
-    mockHasForeignOwnedCircuitPlaylists.mockResolvedValue(false);
+    mockGetCircuitPlaylistOwnershipConflictState.mockResolvedValue('none');
 
     await runnerPrivates.syncSingleCredential(createCredential());
 

--- a/packages/aurora-sync/src/runner/sync-runner.ts
+++ b/packages/aurora-sync/src/runner/sync-runner.ts
@@ -550,7 +550,24 @@ export class SyncRunner {
 
     const { client, db } = this.getClient();
     this.log(`[SyncRunner] Syncing user ${cred.userId} for ${boardType}...`);
-    await syncUserData(client, boardType, token, cred.auroraUserId, cred.userId, undefined, this.log.bind(this));
+    await syncUserData(
+      client,
+      boardType,
+      token,
+      cred.auroraUserId,
+      cred.userId,
+      undefined,
+      this.log.bind(this),
+      (message) =>
+        this.handleError(new Error(message), {
+          userId: cred.userId,
+          board: boardType,
+          boardType,
+          syncStatus: cred.syncStatus ?? undefined,
+          consecutiveFailures: cred.consecutiveFailures ?? undefined,
+          quarantined: false,
+        }),
+    );
     const succeededAt = new Date();
 
     // Circuits whose playlist belongs to another Boardsesh user get refused by

--- a/packages/aurora-sync/src/runner/sync-runner.ts
+++ b/packages/aurora-sync/src/runner/sync-runner.ts
@@ -19,8 +19,8 @@ import {
   stampSharedSyncFinished,
   type SharedSyncClaimToken,
 } from '@boardsesh/db/queries';
-import { DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR } from '@boardsesh/shared-schema/sync-error-codes';
-import { syncUserData, hasForeignOwnedCircuitPlaylists } from '../sync/user-sync';
+import { circuitPlaylistConflictSyncError } from '@boardsesh/shared-schema/sync-error-codes';
+import { syncUserData, getCircuitPlaylistOwnershipConflictState } from '../sync/user-sync';
 import { syncSharedData } from '../sync/shared-sync';
 import {
   AURORA_LOCATION_BOARDS,
@@ -575,7 +575,7 @@ export class SyncRunner {
     // sync would be recorded as a failure over a message. Swallow it, log it,
     // and report no duplicate; the check is a pure state read, so the next
     // cycle re-evaluates it from scratch and self-heals.
-    const hasDuplicateCircuitOwner = await hasForeignOwnedCircuitPlaylists(
+    const circuitPlaylistConflictState = await getCircuitPlaylistOwnershipConflictState(
       db,
       boardType,
       cred.auroraUserId,
@@ -586,15 +586,15 @@ export class SyncRunner {
           error instanceof Error ? error.message : String(error)
         }`,
       );
-      return false;
+      return 'none' as const;
     });
     // A CODE, not a sentence. The board card is the surface that shows this,
     // and it renders in the viewer's language — so the daemon states the
     // condition and the client owns the wording.
-    const duplicateCircuitOwnerError = hasDuplicateCircuitOwner ? DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR : null;
+    const duplicateCircuitOwnerError = circuitPlaylistConflictSyncError(circuitPlaylistConflictState);
     if (duplicateCircuitOwnerError) {
       this.log(
-        `[SyncRunner] User ${cred.userId}: circuits not syncing — the ${boardType} account is linked to another Boardsesh user who owns the playlists (see #3526)`,
+        `[SyncRunner] User ${cred.userId}: circuits not syncing — ${boardType} playlist ownership state is ${circuitPlaylistConflictState} (see #3526)`,
       );
     }
 

--- a/packages/aurora-sync/src/sync/circuit-arbitration.test.ts
+++ b/packages/aurora-sync/src/sync/circuit-arbitration.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import {
+  auroraCircuitAdvisoryLockStatement,
+  getAuroraCircuitAdvisoryLockKey,
+  normalizeAuroraCircuitItems,
+} from './circuit-arbitration';
+
+describe('Aurora circuit arbitration helpers', () => {
+  it('rejects missing, non-string and blank UUIDs, de-duplicates last-row-wins, and sorts', () => {
+    const normalized = normalizeAuroraCircuitItems([
+      { uuid: 'z-circuit', name: 'old' },
+      { name: 'missing' },
+      { uuid: 42, name: 'numeric' },
+      { uuid: '   ', name: 'blank' },
+      { uuid: ' padded ', name: 'padded' },
+      { uuid: 'a-circuit', name: 'first' },
+      { uuid: 'z-circuit', name: 'new' },
+    ]);
+
+    expect(normalized.rejectedCount).toBe(4);
+    expect(normalized.items).toEqual([
+      { uuid: 'a-circuit', name: 'first' },
+      { uuid: 'z-circuit', name: 'new' },
+    ]);
+  });
+
+  it('renders the namespaced, server-side 64-bit advisory lock statement', () => {
+    const rendered = new PgDialect().sqlToQuery(auroraCircuitAdvisoryLockStatement('tension', 'circuit-1'));
+
+    expect(getAuroraCircuitAdvisoryLockKey('tension', 'circuit-1')).toBe('boardsesh:aurora-circuit|tension|circuit-1');
+    expect(rendered.sql).toContain('pg_advisory_xact_lock');
+    expect(rendered.sql).toContain('hashtextextended');
+    expect(rendered.sql).toContain('0::bigint');
+    expect(rendered.params).toEqual(['boardsesh:aurora-circuit|tension|circuit-1']);
+  });
+});

--- a/packages/aurora-sync/src/sync/circuit-arbitration.ts
+++ b/packages/aurora-sync/src/sync/circuit-arbitration.ts
@@ -1,0 +1,63 @@
+import { sql, type SQL } from 'drizzle-orm';
+import type { AuroraBoardName } from '../api/types';
+
+/**
+ * Text namespace embedded in PostgreSQL's server-side 64-bit advisory-lock
+ * hash. There is no playlist row to lock when two users concurrently claim a
+ * new circuit, so every circuit writer must serialize on this key before its
+ * first source or playlist write.
+ */
+const AURORA_CIRCUIT_LOCK_KEY_PREFIX = 'boardsesh:aurora-circuit';
+
+export type NormalizedAuroraCircuitItems<CircuitItem> = {
+  items: Array<CircuitItem & { uuid: string }>;
+  rejectedCount: number;
+};
+
+/**
+ * De-duplicate Aurora circuit rows with their conventional last-row-wins
+ * semantics and return them in a stable lock/write order. Runtime payloads are
+ * not guaranteed to honour their TypeScript shape, so missing, non-string and
+ * blank UUIDs are rejected before they can become a lock key or database key.
+ */
+export function normalizeAuroraCircuitItems<CircuitItem extends { uuid?: unknown }>(
+  circuitItems: readonly CircuitItem[],
+): NormalizedAuroraCircuitItems<CircuitItem> {
+  const lastItemByUuid = new Map<string, CircuitItem & { uuid: string }>();
+  let rejectedCount = 0;
+
+  for (const circuitItem of circuitItems) {
+    if (
+      typeof circuitItem.uuid !== 'string' ||
+      circuitItem.uuid.trim().length === 0 ||
+      circuitItem.uuid !== circuitItem.uuid.trim()
+    ) {
+      rejectedCount += 1;
+      continue;
+    }
+    lastItemByUuid.set(circuitItem.uuid, circuitItem as CircuitItem & { uuid: string });
+  }
+
+  const items = [...lastItemByUuid.values()].sort((left, right) =>
+    left.uuid < right.uuid ? -1 : left.uuid > right.uuid ? 1 : 0,
+  );
+  return { items, rejectedCount };
+}
+
+/** @internal Pure/testable input to PostgreSQL's `hashtextextended(text, bigint)`. */
+export function getAuroraCircuitAdvisoryLockKey(boardName: AuroraBoardName, circuitUuid: string): string {
+  return `${AURORA_CIRCUIT_LOCK_KEY_PREFIX}|${boardName}|${circuitUuid}`;
+}
+
+/**
+ * The exact transaction-scoped advisory-lock statement shared by the daemon
+ * and legacy web proxy writers.
+ *
+ * @internal
+ */
+export function auroraCircuitAdvisoryLockStatement(boardName: AuroraBoardName, circuitUuid: string): SQL {
+  // Keep the 64-bit hash inside PostgreSQL. Converting it to a JavaScript
+  // Number would lose precision above 2^53 and could split contenders across
+  // different advisory keys.
+  return sql`SELECT pg_advisory_xact_lock(hashtextextended(${getAuroraCircuitAdvisoryLockKey(boardName, circuitUuid)}, 0::bigint))`;
+}

--- a/packages/aurora-sync/src/sync/index.ts
+++ b/packages/aurora-sync/src/sync/index.ts
@@ -1,4 +1,4 @@
-export { syncUserData, getLastSyncTimes, getLastSharedSyncTimes } from './user-sync';
+export { syncUserData, getLastSyncTimes, getLastSharedSyncTimes, upsertTableData } from './user-sync';
 export type { SyncUserDataResult } from './user-sync';
 export { syncSharedData, createSetterSyncNotifications } from './shared-sync';
 export type { SharedSyncResult, NewClimbInfo } from './shared-sync';

--- a/packages/aurora-sync/src/sync/sync-user-data-logging.test.ts
+++ b/packages/aurora-sync/src/sync/sync-user-data-logging.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockUserSync, fakeDb } = vi.hoisted(() => {
+  const db = {
+    select: () => ({
+      from: () => ({
+        where: () => Promise.resolve([]),
+      }),
+    }),
+    transaction: <Result>(processor: (transaction: unknown) => Promise<Result>) => processor(db),
+    execute: () => Promise.resolve([]),
+  };
+  return { mockUserSync: vi.fn(), fakeDb: db };
+});
+
+vi.mock('../api/user-sync-api', () => ({ userSync: mockUserSync }));
+vi.mock('drizzle-orm/postgres-js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm/postgres-js')>();
+  return { ...actual, drizzle: () => fakeDb };
+});
+
+import { syncUserData } from './user-sync';
+
+describe('syncUserData diagnostic logging', () => {
+  beforeEach(() => {
+    mockUserSync.mockReset();
+  });
+
+  it('forwards logError to the table writer without failing the otherwise successful cycle', async () => {
+    mockUserSync.mockResolvedValue({
+      circuits: [{ name: 'missing UUID' }],
+      user_syncs: [],
+      _complete: true,
+    });
+    const errorMessages: string[] = [];
+
+    await expect(
+      syncUserData(
+        {} as never,
+        'tension',
+        'token',
+        144574,
+        'user-1',
+        ['circuits'],
+        () => {},
+        (message) => errorMessages.push(message),
+      ),
+    ).resolves.toMatchObject({ circuits: { synced: 0, skipped: 1 } });
+
+    expect(errorMessages).toHaveLength(1);
+    expect(JSON.parse(errorMessages[0] ?? '{}')).toMatchObject({
+      event: 'aurora_circuit_playlist_malformed_payload',
+      rejectedCount: 1,
+    });
+  });
+});

--- a/packages/aurora-sync/src/sync/user-sync.concurrency.integration.test.ts
+++ b/packages/aurora-sync/src/sync/user-sync.concurrency.integration.test.ts
@@ -10,7 +10,7 @@ import { and, eq, inArray, sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import { boardCircuits, boardUsers, playlistClimbs, playlistOwnership, playlists, users } from '@boardsesh/db/schema';
-import { upsertTableData } from './user-sync';
+import { getAuroraCircuitAdvisoryLockKey, upsertTableData } from './user-sync';
 
 function localDatabaseUrl(): string | null {
   const databaseUrl = process.env.DATABASE_URL;
@@ -373,8 +373,7 @@ describeIntegration('Aurora circuit ownership arbitration concurrency (#3950)', 
         await waitForBlockedCircuitSourceUpsert(client, claimantApplicationNamePrefix);
         const [advisoryProbe] = await client<{ acquired: boolean }[]>`
           SELECT pg_try_advisory_xact_lock(
-            ${0x41555243},
-            hashtext(${`tension|${circuitUuid}`})
+            hashtextextended(${getAuroraCircuitAdvisoryLockKey('tension', circuitUuid)}, 0::bigint)
           ) AS acquired
         `;
         expect(advisoryProbe?.acquired).toBe(false);

--- a/packages/aurora-sync/src/sync/user-sync.concurrency.integration.test.ts
+++ b/packages/aurora-sync/src/sync/user-sync.concurrency.integration.test.ts
@@ -13,13 +13,15 @@ import { boardCircuits, boardUsers, playlistClimbs, playlistOwnership, playlists
 import { getAuroraCircuitAdvisoryLockKey } from './circuit-arbitration';
 import { upsertTableData } from './user-sync';
 
+const LOCAL_DATABASE_HOSTS = new Set(['localhost', '127.0.0.1', 'postgres', '[::1]', '::1']);
+
 function localDatabaseUrl(): string | null {
   const databaseUrl = process.env.DATABASE_URL;
   if (!databaseUrl) return null;
 
   try {
     const hostname = new URL(databaseUrl).hostname.toLowerCase();
-    return ['localhost', '127.0.0.1', 'postgres'].includes(hostname) ? databaseUrl : null;
+    return LOCAL_DATABASE_HOSTS.has(hostname) ? databaseUrl : null;
   } catch {
     return null;
   }
@@ -199,7 +201,10 @@ function createTransactionBarrier(participantCount: number, timeoutMs = 5_000): 
   let arrived = 0;
   let release: (() => void) | undefined;
   const allArrived = new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error('Timed out waiting for both circuit transactions')), timeoutMs);
+    const timeout = setTimeout(
+      () => reject(new Error(`Timed out waiting for ${participantCount} circuit transactions`)),
+      timeoutMs,
+    );
     release = () => {
       clearTimeout(timeout);
       resolve();

--- a/packages/aurora-sync/src/sync/user-sync.concurrency.integration.test.ts
+++ b/packages/aurora-sync/src/sync/user-sync.concurrency.integration.test.ts
@@ -10,7 +10,8 @@ import { and, eq, inArray, sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import { boardCircuits, boardUsers, playlistClimbs, playlistOwnership, playlists, users } from '@boardsesh/db/schema';
-import { getAuroraCircuitAdvisoryLockKey, upsertTableData } from './user-sync';
+import { getAuroraCircuitAdvisoryLockKey } from './circuit-arbitration';
+import { upsertTableData } from './user-sync';
 
 function localDatabaseUrl(): string | null {
   const databaseUrl = process.env.DATABASE_URL;
@@ -24,7 +25,8 @@ function localDatabaseUrl(): string | null {
   }
 }
 
-const describeIntegration = localDatabaseUrl() ? describe : describe.skip;
+const integrationRequired = process.env.REQUIRE_AURORA_CIRCUIT_INTEGRATION === '1';
+const describeIntegration = localDatabaseUrl() || integrationRequired ? describe : describe.skip;
 type UpsertDb = Parameters<typeof upsertTableData>[0];
 type CircuitRow = Parameters<typeof upsertTableData>[5][number];
 type IntegrationSqlClient = ReturnType<typeof postgres>;
@@ -237,6 +239,9 @@ describeIntegration('Aurora circuit ownership arbitration concurrency (#3950)', 
   it('holds the advisory lock before a blocked source upsert and gives one claimant sole ownership', async (testContext) => {
     const databaseUrl = localDatabaseUrl();
     if (!databaseUrl) {
+      if (integrationRequired) {
+        throw new Error('REQUIRE_AURORA_CIRCUIT_INTEGRATION=1 requires DATABASE_URL to point at local PostgreSQL');
+      }
       testContext.skip('set DATABASE_URL to a local, migrated PostgreSQL database to run issue #3950 coverage');
       return;
     }
@@ -246,6 +251,7 @@ describeIntegration('Aurora circuit ownership arbitration concurrency (#3950)', 
     const schemaSkipReason = await integrationSchemaSkipReason(client);
     if (schemaSkipReason) {
       await client.end();
+      if (integrationRequired) throw new Error(schemaSkipReason);
       testContext.skip(schemaSkipReason);
       return;
     }
@@ -427,6 +433,9 @@ describeIntegration('Aurora circuit ownership arbitration concurrency (#3950)', 
   it('promotes an existing viewer edge when the syncing user claims an orphaned playlist', async (testContext) => {
     const databaseUrl = localDatabaseUrl();
     if (!databaseUrl) {
+      if (integrationRequired) {
+        throw new Error('REQUIRE_AURORA_CIRCUIT_INTEGRATION=1 requires DATABASE_URL to point at local PostgreSQL');
+      }
       testContext.skip('set DATABASE_URL to a local, migrated PostgreSQL database to run issue #3950 coverage');
       return;
     }
@@ -436,6 +445,7 @@ describeIntegration('Aurora circuit ownership arbitration concurrency (#3950)', 
     const schemaSkipReason = await integrationSchemaSkipReason(client);
     if (schemaSkipReason) {
       await client.end();
+      if (integrationRequired) throw new Error(schemaSkipReason);
       testContext.skip(schemaSkipReason);
       return;
     }

--- a/packages/aurora-sync/src/sync/user-sync.concurrency.integration.test.ts
+++ b/packages/aurora-sync/src/sync/user-sync.concurrency.integration.test.ts
@@ -1,0 +1,537 @@
+// Real-PostgreSQL coverage for issue #3950. The test self-skips unless
+// DATABASE_URL points at a local, migrated database. Run it with:
+//
+//   DATABASE_URL=postgres://...@localhost:5432/... \
+//     vp test run --reporter=agent packages/aurora-sync/src/sync/user-sync.concurrency.integration.test.ts
+
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { boardCircuits, boardUsers, playlistClimbs, playlistOwnership, playlists, users } from '@boardsesh/db/schema';
+import { upsertTableData } from './user-sync';
+
+function localDatabaseUrl(): string | null {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) return null;
+
+  try {
+    const hostname = new URL(databaseUrl).hostname.toLowerCase();
+    return ['localhost', '127.0.0.1', 'postgres'].includes(hostname) ? databaseUrl : null;
+  } catch {
+    return null;
+  }
+}
+
+const describeIntegration = localDatabaseUrl() ? describe : describe.skip;
+type UpsertDb = Parameters<typeof upsertTableData>[0];
+type CircuitRow = Parameters<typeof upsertTableData>[5][number];
+type IntegrationSqlClient = ReturnType<typeof postgres>;
+
+type SchemaReadiness = {
+  missing_relations: string[];
+  missing_columns: string[];
+  missing_indexes: string[];
+  missing_constraints: string[];
+};
+
+async function integrationSchemaSkipReason(client: IntegrationSqlClient): Promise<string | null> {
+  const [readiness] = await client<SchemaReadiness[]>`
+    WITH required_relations(name) AS (
+      VALUES
+        ('users'),
+        ('board_users'),
+        ('board_circuits'),
+        ('playlists'),
+        ('playlist_ownership'),
+        ('playlist_climbs')
+    ),
+    required_columns(table_name, column_name) AS (
+      VALUES
+        ('users', 'id'),
+        ('users', 'email'),
+        ('board_users', 'board_type'),
+        ('board_users', 'id'),
+        ('board_users', 'username'),
+        ('board_circuits', 'board_type'),
+        ('board_circuits', 'uuid'),
+        ('board_circuits', 'name'),
+        ('board_circuits', 'description'),
+        ('board_circuits', 'color'),
+        ('board_circuits', 'user_id'),
+        ('board_circuits', 'is_public'),
+        ('board_circuits', 'created_at'),
+        ('board_circuits', 'updated_at'),
+        ('playlists', 'id'),
+        ('playlists', 'uuid'),
+        ('playlists', 'board_type'),
+        ('playlists', 'layout_id'),
+        ('playlists', 'name'),
+        ('playlists', 'description'),
+        ('playlists', 'is_public'),
+        ('playlists', 'color'),
+        ('playlists', 'icon'),
+        ('playlists', 'aurora_type'),
+        ('playlists', 'aurora_id'),
+        ('playlists', 'aurora_synced_at'),
+        ('playlists', 'kilter_type'),
+        ('playlists', 'kilter_id'),
+        ('playlists', 'kilter_synced_at'),
+        ('playlists', 'generated_recommendation'),
+        ('playlists', 'created_at'),
+        ('playlists', 'updated_at'),
+        ('playlists', 'last_accessed_at'),
+        ('playlist_ownership', 'playlist_id'),
+        ('playlist_ownership', 'user_id'),
+        ('playlist_ownership', 'role'),
+        ('playlist_climbs', 'playlist_id'),
+        ('playlist_climbs', 'climb_uuid'),
+        ('playlist_climbs', 'angle'),
+        ('playlist_climbs', 'position')
+    ),
+    required_indexes(name, table_name) AS (
+      VALUES
+        ('playlists_aurora_id_idx', 'playlists'),
+        ('unique_playlist_ownership', 'playlist_ownership')
+    ),
+    required_constraints(name, table_name, constraint_type, delete_action) AS (
+      VALUES
+        ('users_pkey', 'users', 'p', NULL),
+        ('board_users_board_type_id_pk', 'board_users', 'p', NULL),
+        ('board_circuits_board_type_uuid_pk', 'board_circuits', 'p', NULL),
+        ('playlists_pkey', 'playlists', 'p', NULL),
+        ('board_circuits_user_fk', 'board_circuits', 'f', 'c'),
+        ('playlist_climbs_playlist_id_playlists_id_fk', 'playlist_climbs', 'f', 'c'),
+        ('playlist_ownership_playlist_id_playlists_id_fk', 'playlist_ownership', 'f', 'c'),
+        ('playlist_ownership_user_id_users_id_fk', 'playlist_ownership', 'f', 'c')
+    )
+    SELECT
+      ARRAY(
+        SELECT required_relations.name
+        FROM required_relations
+        WHERE to_regclass('public.' || required_relations.name) IS NULL
+        ORDER BY required_relations.name
+      ) AS missing_relations,
+      ARRAY(
+        SELECT required_columns.table_name || '.' || required_columns.column_name
+        FROM required_columns
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM information_schema.columns AS schema_columns
+          WHERE schema_columns.table_schema = 'public'
+            AND schema_columns.table_name = required_columns.table_name
+            AND schema_columns.column_name = required_columns.column_name
+        )
+        ORDER BY required_columns.table_name, required_columns.column_name
+      ) AS missing_columns,
+      ARRAY(
+        SELECT required_indexes.name
+        FROM required_indexes
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM pg_class index_class
+          INNER JOIN pg_namespace index_namespace ON index_namespace.oid = index_class.relnamespace
+          INNER JOIN pg_index index_metadata ON index_metadata.indexrelid = index_class.oid
+          INNER JOIN pg_class table_class ON table_class.oid = index_metadata.indrelid
+          WHERE index_namespace.nspname = 'public'
+            AND index_class.relname = required_indexes.name
+            AND table_class.relname = required_indexes.table_name
+            AND index_metadata.indisunique
+            AND index_metadata.indisvalid
+            AND index_metadata.indisready
+        )
+        ORDER BY required_indexes.name
+      ) AS missing_indexes,
+      ARRAY(
+        SELECT required_constraints.name
+        FROM required_constraints
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM pg_constraint constraint_metadata
+          INNER JOIN pg_class table_class ON table_class.oid = constraint_metadata.conrelid
+          INNER JOIN pg_namespace table_namespace ON table_namespace.oid = table_class.relnamespace
+          WHERE table_namespace.nspname = 'public'
+            AND table_class.relname = required_constraints.table_name
+            AND constraint_metadata.conname = required_constraints.name
+            AND constraint_metadata.contype::text = required_constraints.constraint_type
+            AND constraint_metadata.convalidated
+            AND (
+              required_constraints.delete_action IS NULL
+              OR constraint_metadata.confdeltype::text = required_constraints.delete_action
+            )
+        )
+        ORDER BY required_constraints.name
+      ) AS missing_constraints
+  `;
+
+  if (!readiness) return 'could not inspect the local PostgreSQL schema for issue #3950';
+
+  const problems = [
+    readiness.missing_relations.length > 0 ? `relations: ${readiness.missing_relations.join(', ')}` : null,
+    readiness.missing_columns.length > 0 ? `columns: ${readiness.missing_columns.join(', ')}` : null,
+    readiness.missing_indexes.length > 0 ? `unique indexes: ${readiness.missing_indexes.join(', ')}` : null,
+    readiness.missing_constraints.length > 0 ? `constraints: ${readiness.missing_constraints.join(', ')}` : null,
+  ].filter((problem): problem is string => problem !== null);
+
+  return problems.length > 0
+    ? `local PostgreSQL schema is not current for issue #3950 (${problems.join('; ')}); run the repo migrations before treating this integration test as passing`
+    : null;
+}
+
+function circuitRow(uuid: string, name: string, climbUuid: string): CircuitRow {
+  return {
+    uuid,
+    name,
+    description: '',
+    color: '',
+    is_public: '',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    climbs: [{ climb_uuid: climbUuid }],
+  } as unknown as CircuitRow;
+}
+
+/** Release all participants only after every database transaction is open. */
+function createTransactionBarrier(participantCount: number, timeoutMs = 5_000): () => Promise<void> {
+  let arrived = 0;
+  let release: (() => void) | undefined;
+  const allArrived = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('Timed out waiting for both circuit transactions')), timeoutMs);
+    release = () => {
+      clearTimeout(timeout);
+      resolve();
+    };
+  });
+
+  return async () => {
+    arrived += 1;
+    if (arrived === participantCount) release?.();
+    await allArrived;
+  };
+}
+
+async function waitForBlockedCircuitSourceUpsert(
+  client: IntegrationSqlClient,
+  claimantApplicationNamePrefix: string,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const [activity] = await client<{ blocked_count: number }[]>`
+      SELECT count(*)::int AS blocked_count
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND application_name LIKE ${`${claimantApplicationNamePrefix}%`}
+        AND wait_event_type = 'Lock'
+        AND query ILIKE '%board_circuits%'
+    `;
+    if ((activity?.blocked_count ?? 0) > 0) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+  }
+
+  throw new Error('Timed out waiting for a claimant to block on the board_circuits source upsert');
+}
+
+describeIntegration('Aurora circuit ownership arbitration concurrency (#3950)', () => {
+  it('holds the advisory lock before a blocked source upsert and gives one claimant sole ownership', async (testContext) => {
+    const databaseUrl = localDatabaseUrl();
+    if (!databaseUrl) {
+      testContext.skip('set DATABASE_URL to a local, migrated PostgreSQL database to run issue #3950 coverage');
+      return;
+    }
+
+    const client = postgres(databaseUrl, { max: 4, prepare: false, idle_timeout: 5, onnotice: () => {} });
+    const db = drizzle(client);
+    const schemaSkipReason = await integrationSchemaSkipReason(client);
+    if (schemaSkipReason) {
+      await client.end();
+      testContext.skip(schemaSkipReason);
+      return;
+    }
+
+    const testTag = randomUUID();
+    const circuitUuid = `issue-3950-${testTag}`;
+    const userIds = [`issue-3950-a-${testTag}`, `issue-3950-b-${testTag}`] as const;
+    let insertedUserIds: string[] = [];
+    let auroraUserId: number | undefined;
+    let ownsCircuitFixture = false;
+    const climbUuids = [`issue-3950-climb-a-${testTag}`, `issue-3950-climb-b-${testTag}`] as const;
+    const logs: string[][] = [[], []];
+
+    try {
+      const insertedUsers = await db
+        .insert(users)
+        .values([
+          { id: userIds[0], email: `${userIds[0]}@example.invalid` },
+          { id: userIds[1], email: `${userIds[1]}@example.invalid` },
+        ])
+        .onConflictDoNothing()
+        .returning({ id: users.id });
+      insertedUserIds = insertedUsers.map((row) => row.id);
+      if (insertedUsers.length !== userIds.length) {
+        throw new Error('Could not allocate isolated user fixtures for issue #3950');
+      }
+
+      // board_users has a composite integer PK and shared developer databases
+      // may already contain high IDs. Claim one with INSERT ... DO NOTHING and
+      // only ever clean up the row this test actually inserted.
+      const candidateBase = 1_900_000_000 + (Number.parseInt(testTag.slice(0, 7), 16) % 100_000_000);
+      for (let attempt = 0; attempt < 20 && auroraUserId === undefined; attempt += 1) {
+        const candidateId = candidateBase + attempt;
+        const insertedBoardUsers = await db
+          .insert(boardUsers)
+          .values({
+            boardType: 'tension',
+            id: candidateId,
+            username: `issue-3950-${testTag}`,
+          })
+          .onConflictDoNothing()
+          .returning({ id: boardUsers.id });
+        auroraUserId = insertedBoardUsers[0]?.id;
+      }
+      if (auroraUserId === undefined) {
+        throw new Error('Could not allocate an isolated board_users fixture for issue #3950');
+      }
+      const claimedAuroraUserId = auroraUserId;
+
+      const [existingPlaylists, existingCircuits] = await Promise.all([
+        db.select({ id: playlists.id }).from(playlists).where(eq(playlists.auroraId, circuitUuid)),
+        db
+          .select({ uuid: boardCircuits.uuid })
+          .from(boardCircuits)
+          .where(and(eq(boardCircuits.boardType, 'tension'), eq(boardCircuits.uuid, circuitUuid))),
+      ]);
+      if (existingPlaylists.length > 0 || existingCircuits.length > 0) {
+        throw new Error('Could not allocate an isolated circuit namespace for issue #3950');
+      }
+      await db.insert(boardCircuits).values({
+        boardType: 'tension',
+        uuid: circuitUuid,
+        name: 'Source-lock fixture',
+        userId: claimedAuroraUserId,
+      });
+      ownsCircuitFixture = true;
+
+      let releaseSourceBlocker: (() => void) | undefined;
+      let markSourceBlockerReady: (() => void) | undefined;
+      const sourceBlockerRelease = new Promise<void>((resolve) => {
+        releaseSourceBlocker = resolve;
+      });
+      const sourceBlockerReady = new Promise<void>((resolve) => {
+        markSourceBlockerReady = resolve;
+      });
+      const sourceBlockerApplicationName = `issue-3950-source-blocker-${testTag}`;
+      const sourceBlockerPromise = db.transaction(async (transaction) => {
+        await transaction.execute(sql`SELECT set_config('application_name', ${sourceBlockerApplicationName}, true)`);
+        await transaction.execute(sql`
+          SELECT uuid
+          FROM board_circuits
+          WHERE board_type = 'tension' AND uuid = ${circuitUuid}
+          FOR UPDATE
+        `);
+        markSourceBlockerReady?.();
+        await sourceBlockerRelease;
+      });
+      await Promise.race([
+        sourceBlockerReady,
+        sourceBlockerPromise.then(() => {
+          throw new Error('Source blocker transaction exited before acquiring its row lock');
+        }),
+      ]);
+
+      const awaitBothTransactions = createTransactionBarrier(2);
+      const claimantApplicationNamePrefix = `issue-3950-claimant-${testTag}`;
+      const claimCircuit = (claimantIndex: 0 | 1) =>
+        db.transaction(async (transaction) => {
+          // Exercise the production shape: syncUserData owns this outer
+          // transaction, upsertTableData opens the arbitration savepoint, and
+          // each circuit opens its own nested playlist-write savepoint.
+          await transaction.execute(
+            sql`SELECT set_config('application_name', ${`${claimantApplicationNamePrefix}-${claimantIndex}`}, true)`,
+          );
+          await awaitBothTransactions();
+          return upsertTableData(
+            transaction as unknown as UpsertDb,
+            'tension',
+            'circuits',
+            claimedAuroraUserId,
+            userIds[claimantIndex],
+            [circuitRow(circuitUuid, `Claim ${claimantIndex === 0 ? 'A' : 'B'}`, climbUuids[claimantIndex])],
+            (message) => logs[claimantIndex].push(message),
+          );
+        });
+
+      const claimantOutcomesPromise = Promise.all([claimCircuit(0), claimCircuit(1)]);
+      let outcomes: Awaited<ReturnType<typeof upsertTableData>>[];
+      try {
+        // The fixture source row is deliberately locked by a third transaction.
+        // A claimant must therefore hold the advisory lock while blocked on its
+        // board_circuits upsert. Without advisory acquisition, the probe would
+        // succeed and this regression test would fail even though the source-row
+        // lock later happens to serialize the two playlist claims.
+        await waitForBlockedCircuitSourceUpsert(client, claimantApplicationNamePrefix);
+        const [advisoryProbe] = await client<{ acquired: boolean }[]>`
+          SELECT pg_try_advisory_xact_lock(
+            ${0x41555243},
+            hashtext(${`tension|${circuitUuid}`})
+          ) AS acquired
+        `;
+        expect(advisoryProbe?.acquired).toBe(false);
+
+        releaseSourceBlocker?.();
+        await sourceBlockerPromise;
+        outcomes = await claimantOutcomesPromise;
+      } finally {
+        releaseSourceBlocker?.();
+        await Promise.allSettled([sourceBlockerPromise, claimantOutcomesPromise]);
+      }
+
+      expect(outcomes.map((outcome) => outcome.skipped).sort((left, right) => left - right)).toEqual([0, 1]);
+      const winnerIndex = outcomes[0].skipped === 0 ? 0 : 1;
+      const loserIndex = winnerIndex === 0 ? 1 : 0;
+
+      const ownerRows = await db
+        .select({ userId: playlistOwnership.userId })
+        .from(playlists)
+        .innerJoin(playlistOwnership, eq(playlistOwnership.playlistId, playlists.id))
+        .where(and(eq(playlists.auroraId, circuitUuid), eq(playlistOwnership.role, 'owner')));
+      expect(ownerRows).toEqual([{ userId: userIds[winnerIndex] }]);
+
+      const climbRows = await db
+        .select({ climbUuid: playlistClimbs.climbUuid })
+        .from(playlists)
+        .innerJoin(playlistClimbs, eq(playlistClimbs.playlistId, playlists.id))
+        .where(eq(playlists.auroraId, circuitUuid));
+      expect(climbRows).toEqual([{ climbUuid: climbUuids[winnerIndex] }]);
+      expect(logs[loserIndex].some((line) => line.includes('"reason":"foreign"'))).toBe(true);
+      // The loser reaches the fresh ownership check only after the winning
+      // production-shaped outer transaction commits.
+      expect(logs[loserIndex].some((line) => line.includes('"stage":"ownership-check"'))).toBe(true);
+    } finally {
+      if (ownsCircuitFixture) {
+        await db.delete(playlists).where(eq(playlists.auroraId, circuitUuid));
+        await db
+          .delete(boardCircuits)
+          .where(and(eq(boardCircuits.boardType, 'tension'), eq(boardCircuits.uuid, circuitUuid)));
+      }
+      if (auroraUserId !== undefined) {
+        await db.delete(boardUsers).where(and(eq(boardUsers.boardType, 'tension'), eq(boardUsers.id, auroraUserId)));
+      }
+      if (insertedUserIds.length > 0) {
+        await db.delete(users).where(inArray(users.id, insertedUserIds));
+      }
+      await client.end();
+    }
+  }, 20_000);
+
+  it('promotes an existing viewer edge when the syncing user claims an orphaned playlist', async (testContext) => {
+    const databaseUrl = localDatabaseUrl();
+    if (!databaseUrl) {
+      testContext.skip('set DATABASE_URL to a local, migrated PostgreSQL database to run issue #3950 coverage');
+      return;
+    }
+
+    const client = postgres(databaseUrl, { max: 2, prepare: false, idle_timeout: 5, onnotice: () => {} });
+    const db = drizzle(client);
+    const schemaSkipReason = await integrationSchemaSkipReason(client);
+    if (schemaSkipReason) {
+      await client.end();
+      testContext.skip(schemaSkipReason);
+      return;
+    }
+
+    const testTag = randomUUID();
+    const circuitUuid = `issue-3950-promotion-${testTag}`;
+    const userId = `issue-3950-viewer-${testTag}`;
+    let insertedUserId: string | undefined;
+    let auroraUserId: number | undefined;
+    let insertedPlaylistId: bigint | undefined;
+    let ownsCircuitFixture = false;
+
+    try {
+      const insertedUsers = await db
+        .insert(users)
+        .values({ id: userId, email: `${userId}@example.invalid` })
+        .onConflictDoNothing()
+        .returning({ id: users.id });
+      insertedUserId = insertedUsers[0]?.id;
+      if (!insertedUserId) throw new Error('Could not allocate isolated promotion user fixture');
+
+      const candidateBase = 1_800_000_000 + (Number.parseInt(testTag.slice(0, 7), 16) % 100_000_000);
+      for (let attempt = 0; attempt < 20 && auroraUserId === undefined; attempt += 1) {
+        const insertedBoardUsers = await db
+          .insert(boardUsers)
+          .values({
+            boardType: 'tension',
+            id: candidateBase + attempt,
+            username: `issue-3950-promotion-${testTag}`,
+          })
+          .onConflictDoNothing()
+          .returning({ id: boardUsers.id });
+        auroraUserId = insertedBoardUsers[0]?.id;
+      }
+      if (auroraUserId === undefined) {
+        throw new Error('Could not allocate isolated promotion board_users fixture');
+      }
+      const claimedAuroraUserId = auroraUserId;
+
+      const existingCircuits = await db
+        .select({ uuid: boardCircuits.uuid })
+        .from(boardCircuits)
+        .where(and(eq(boardCircuits.boardType, 'tension'), eq(boardCircuits.uuid, circuitUuid)));
+      if (existingCircuits.length > 0) {
+        throw new Error('Could not allocate an isolated promotion circuit namespace');
+      }
+
+      const [playlist] = await db
+        .insert(playlists)
+        .values({
+          uuid: circuitUuid,
+          boardType: 'tension',
+          layoutId: null,
+          name: 'Orphaned circuit',
+          auroraType: 'circuits',
+          auroraId: circuitUuid,
+        })
+        .returning({ id: playlists.id });
+      if (!playlist) throw new Error('Could not create promotion playlist fixture');
+      insertedPlaylistId = playlist.id;
+      ownsCircuitFixture = true;
+      await db.insert(playlistOwnership).values({ playlistId: playlist.id, userId, role: 'viewer' });
+
+      const result = await db.transaction((transaction) =>
+        upsertTableData(
+          transaction as unknown as UpsertDb,
+          'tension',
+          'circuits',
+          claimedAuroraUserId,
+          userId,
+          [circuitRow(circuitUuid, 'Claimed circuit', 'issue-3950-promotion-climb')],
+          () => {},
+        ),
+      );
+
+      expect(result.skipped).toBe(0);
+      const [ownerEdge] = await db
+        .select({ role: playlistOwnership.role })
+        .from(playlistOwnership)
+        .where(and(eq(playlistOwnership.playlistId, playlist.id), eq(playlistOwnership.userId, userId)));
+      expect(ownerEdge?.role).toBe('owner');
+    } finally {
+      if (insertedPlaylistId !== undefined) {
+        await db.delete(playlists).where(eq(playlists.id, insertedPlaylistId));
+      }
+      if (ownsCircuitFixture) {
+        await db
+          .delete(boardCircuits)
+          .where(and(eq(boardCircuits.boardType, 'tension'), eq(boardCircuits.uuid, circuitUuid)));
+      }
+      if (auroraUserId !== undefined) {
+        await db.delete(boardUsers).where(and(eq(boardUsers.boardType, 'tension'), eq(boardUsers.id, auroraUserId)));
+      }
+      if (insertedUserId) await db.delete(users).where(eq(users.id, insertedUserId));
+      await client.end();
+    }
+  }, 20_000);
+});

--- a/packages/aurora-sync/src/sync/user-sync.test.ts
+++ b/packages/aurora-sync/src/sync/user-sync.test.ts
@@ -535,7 +535,8 @@ describe('upsertTableData circuits — race-guard suppression + owner lookup SQL
     expect(result.skippedReason).toBe(CIRCUIT_PLAYLIST_INVARIANT_SKIP_REASON);
     expect(result.skippedReason).not.toBe(DUPLICATE_CIRCUIT_OWNER_SKIP_REASON);
     expect(result.circuitPlaylistRefusals).toEqual({ foreign: 0, ambiguous: 0, invariant: 1 });
-    expect(logged.some((line) => line.includes('"reason":"own"'))).toBe(true);
+    expect(logged.some((line) => line.includes('"reason":"own"'))).toBe(false);
+    expect(logged.some((line) => line.includes('invariant/concurrency warning'))).toBe(false);
     expect(errorLogged).toHaveLength(1);
     expect(JSON.parse(errorLogged[0] ?? '{}')).toEqual({
       level: 'error',
@@ -570,6 +571,33 @@ describe('upsertTableData circuits — race-guard suppression + owner lookup SQL
     expect(insertsInto(playlistClimbs)).toHaveLength(0);
     expect(calls.filter((call) => call.kind === 'select' || call.kind === 'delete')).toHaveLength(0);
     expect(calls.filter((call) => call.kind === 'transaction')).toHaveLength(1);
+  });
+
+  it('keeps the valid input-row metric while de-duplicating source-only circuit writes', async () => {
+    const { db, calls, insertsInto } = createDbShim();
+    const malformed = { name: 'Missing UUID' } as unknown as CircuitFixture;
+
+    const result = await upsertTableData(
+      db as unknown as ShimDb,
+      'tension',
+      'circuits',
+      144574,
+      '',
+      [circuit('source-only', 'Old name'), malformed, circuit('source-only', 'New name')],
+      () => {},
+      () => {},
+    );
+
+    expect(result).toEqual({
+      synced: 2,
+      skipped: 1,
+      skippedReason: CIRCUIT_PLAYLIST_INVARIANT_SKIP_REASON,
+      circuitPlaylistRefusals: { foreign: 0, ambiguous: 0, invariant: 1 },
+    });
+    expect(calls.filter((call) => call.kind === 'execute')).toHaveLength(1);
+    const [sourceInsert] = insertsInto(boardCircuits);
+    const sourceValues = sourceInsert?.args[0] as Array<{ uuid: string; name: string }>;
+    expect(sourceValues).toEqual([expect.objectContaining({ uuid: 'source-only', name: 'New name' })]);
   });
 
   it('takes every namespaced advisory lock before the source upsert and fresh owner read', async () => {

--- a/packages/aurora-sync/src/sync/user-sync.test.ts
+++ b/packages/aurora-sync/src/sync/user-sync.test.ts
@@ -278,12 +278,12 @@ describe('upsertTableData circuits — foreign-owner guard (#3526)', () => {
     const logged: string[] = [];
     const { db, insertsInto } = createDbShim({
       selectResults: [
-        [{ upstreamId: 'mine', ownerUserId: 'user-1' }],
         [
+          { upstreamId: 'mine', ownerUserId: 'user-1' },
           { upstreamId: 'shared', ownerUserId: 'user-1' },
           { upstreamId: 'shared', ownerUserId: 'user-2' },
+          { upstreamId: 'theirs', ownerUserId: 'user-2' },
         ],
-        [{ upstreamId: 'theirs', ownerUserId: 'user-2' }],
       ],
       returningRows: [[{ id: BigInt(7) }]],
     });
@@ -329,7 +329,7 @@ describe('upsertTableData circuits — foreign-owner guard (#3526)', () => {
   });
 
   it('deduplicates and sorts before the board_circuits batch upsert, with the last duplicate winning', async () => {
-    const { db, insertsInto } = createDbShim({
+    const { db, calls, insertsInto } = createDbShim({
       selectResults: [[], []],
       returningRows: [[{ id: BigInt(7) }], [{ id: BigInt(8) }]],
     });
@@ -349,6 +349,42 @@ describe('upsertTableData circuits — foreign-owner guard (#3526)', () => {
       { uuid: 'a-circuit', name: 'First' },
       { uuid: 'z-circuit', name: 'Last value wins' },
     ]);
+    expect(calls.filter((call) => call.kind === 'select')).toHaveLength(1);
+  });
+
+  it('rejects malformed UUIDs before locks or writes and reports a safe invariant count', async () => {
+    const errorLogged: string[] = [];
+    const { db, calls } = createDbShim();
+
+    const result = await upsertTableData(
+      db as unknown as ShimDb,
+      'tension',
+      'circuits',
+      144574,
+      'user-1',
+      [
+        { name: 'missing', secret: 'do-not-log' },
+        { uuid: 42, name: 'numeric' },
+      ] as never,
+      () => {},
+      (message) => errorLogged.push(message),
+    );
+
+    expect(result).toEqual({
+      synced: 0,
+      skipped: 2,
+      skippedReason: CIRCUIT_PLAYLIST_INVARIANT_SKIP_REASON,
+      circuitPlaylistRefusals: { foreign: 0, ambiguous: 0, invariant: 2 },
+    });
+    expect(calls.filter((call) => call.kind === 'execute' || call.kind === 'insert')).toHaveLength(0);
+    expect(errorLogged).toHaveLength(1);
+    expect(JSON.parse(errorLogged[0] ?? '{}')).toEqual({
+      level: 'error',
+      event: 'aurora_circuit_playlist_malformed_payload',
+      boardType: 'tension',
+      rejectedCount: 2,
+    });
+    expect(errorLogged[0]).not.toContain('do-not-log');
   });
 
   it('attaches the NOT EXISTS ownership guard to the playlist upsert', async () => {

--- a/packages/aurora-sync/src/sync/user-sync.test.ts
+++ b/packages/aurora-sync/src/sync/user-sync.test.ts
@@ -5,8 +5,14 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 /** Driverless drizzle handle — `.toSQL()` renders without a connection. */
 const renderOnlyDb = drizzle({} as never);
 import { playlists, playlistClimbs, playlistOwnership } from '@boardsesh/db/schema/app';
+import { boardCircuits } from '@boardsesh/db/schema';
 import { foreignPlaylistOwnerGuard, upstreamPlaylistOwnersQuery } from '@boardsesh/db/queries';
-import { upsertTableData, hasForeignOwnedCircuitPlaylists, DUPLICATE_CIRCUIT_OWNER_SKIP_REASON } from './user-sync';
+import {
+  CIRCUIT_PLAYLIST_INVARIANT_SKIP_REASON,
+  DUPLICATE_CIRCUIT_OWNER_SKIP_REASON,
+  getCircuitPlaylistOwnershipConflictState,
+  upsertTableData,
+} from './user-sync';
 
 /**
  * Hand-rolled Drizzle shim, not a real DB — same philosophy as kilter-sync's
@@ -14,7 +20,11 @@ import { upsertTableData, hasForeignOwnedCircuitPlaylists, DUPLICATE_CIRCUIT_OWN
  * test can assert that a refused circuit produces NO writes of any kind, and
  * hands back canned rows for the owner lookup.
  */
-type DbCall = { kind: 'select' | 'insert' | 'delete' | 'conflict'; table?: unknown; args: unknown[] };
+type DbCall = {
+  kind: 'select' | 'insert' | 'delete' | 'conflict' | 'execute' | 'transaction';
+  table?: unknown;
+  args: unknown[];
+};
 type SelectRows = Array<Record<string, unknown>>;
 
 function createDbShim(
@@ -27,6 +37,14 @@ function createDbShim(
   let returningIdx = 0;
 
   const db = {
+    transaction<T>(processor: (transaction: unknown) => Promise<T>) {
+      calls.push({ kind: 'transaction', args: [] });
+      return processor(db);
+    },
+    execute(statement: unknown) {
+      calls.push({ kind: 'execute', args: [statement] });
+      return Promise.resolve([]);
+    },
     select(cols: unknown) {
       calls.push({ kind: 'select', args: [cols] });
       const rows = selectResults[selectIdx++] ?? [];
@@ -128,10 +146,11 @@ describe('upsertTableData circuits — foreign-owner guard (#3526)', () => {
     expect(calls.filter((c) => c.kind === 'conflict' && c.table === playlists)).toHaveLength(0);
 
     expect(result.skipped).toBe(1);
-    // The board_circuits upsert ran for every row and is user-scoped by
-    // aurora_user_id — those DID sync. Only the playlists mirror was refused.
+    // The board_circuits upsert ran for every payload row. Only the
+    // ownership-sensitive playlists mirror was refused.
     expect(result.synced).toBe(1);
     expect(result.skippedReason).toBe(DUPLICATE_CIRCUIT_OWNER_SKIP_REASON);
+    expect(result.circuitPlaylistRefusals).toEqual({ foreign: 1, ambiguous: 0, invariant: 0 });
     expect(logged.some((line) => line.includes('already owned by a different Boardsesh user'))).toBe(true);
   });
 
@@ -159,6 +178,7 @@ describe('upsertTableData circuits — foreign-owner guard (#3526)', () => {
     expect(insertsInto(playlists)).toHaveLength(0);
     expect(insertsInto(playlistOwnership)).toHaveLength(0);
     expect(result.skipped).toBe(1);
+    expect(result.circuitPlaylistRefusals).toEqual({ foreign: 0, ambiguous: 1, invariant: 0 });
     expect(logged.some((line) => line.includes('two owners'))).toBe(true);
   });
 
@@ -211,7 +231,7 @@ describe('upsertTableData circuits — foreign-owner guard (#3526)', () => {
     const { db, insertsInto } = createDbShim({
       // circuit-new has no playlist at all; circuit-orphan has one whose
       // ownership rows are gone (LEFT join → null owner). Both are claimable.
-      selectResults: [[{ upstreamId: 'circuit-orphan', ownerUserId: null }]],
+      selectResults: [[], [{ upstreamId: 'circuit-orphan', ownerUserId: null }]],
       returningRows: [[{ id: BigInt(7) }], [{ id: BigInt(8) }]],
     });
 
@@ -230,16 +250,40 @@ describe('upsertTableData circuits — foreign-owner guard (#3526)', () => {
     expect(result.skipped).toBe(0);
   });
 
+  it('promotes this user from editor or viewer to owner when claiming an orphan', async () => {
+    const { db, calls } = createDbShim({
+      // Owner queries intentionally omit editor/viewer edges, so this playlist
+      // is claimable even though the unique (playlist,user) edge already exists.
+      selectResults: [[]],
+      returningRows: [[{ id: BigInt(7) }]],
+    });
+
+    await upsertTableData(
+      db as unknown as ShimDb,
+      'tension',
+      'circuits',
+      144574,
+      'user-1',
+      [circuit('circuit-orphan', 'Orphan')],
+      () => {},
+    );
+
+    const ownershipConflict = calls.find((call) => call.kind === 'conflict' && call.table === playlistOwnership)
+      ?.args[0] as { target?: unknown[]; set?: { role?: string } } | undefined;
+    expect(ownershipConflict?.target).toEqual([playlistOwnership.playlistId, playlistOwnership.userId]);
+    expect(ownershipConflict?.set).toEqual({ role: 'owner' });
+  });
+
   it('counts every refused circuit in a mixed batch and writes only the owned ones', async () => {
     const logged: string[] = [];
     const { db, insertsInto } = createDbShim({
       selectResults: [
+        [{ upstreamId: 'mine', ownerUserId: 'user-1' }],
         [
-          { upstreamId: 'mine', ownerUserId: 'user-1' },
-          { upstreamId: 'theirs', ownerUserId: 'user-2' },
           { upstreamId: 'shared', ownerUserId: 'user-1' },
           { upstreamId: 'shared', ownerUserId: 'user-2' },
         ],
+        [{ upstreamId: 'theirs', ownerUserId: 'user-2' }],
       ],
       returningRows: [[{ id: BigInt(7) }]],
     });
@@ -257,7 +301,54 @@ describe('upsertTableData circuits — foreign-owner guard (#3526)', () => {
     expect(insertsInto(playlists)).toHaveLength(1);
     expect(result.synced).toBe(3);
     expect(result.skipped).toBe(2);
+    expect(result.circuitPlaylistRefusals).toEqual({ foreign: 1, ambiguous: 1, invariant: 0 });
     expect(logged.filter((line) => line.includes('duplicate board account link'))).toHaveLength(2);
+  });
+
+  it('counts a duplicated refused UUID once and reports zero distinct playlist writes', async () => {
+    const logged: string[] = [];
+    const { db, insertsInto } = createDbShim({
+      selectResults: [[{ upstreamId: 'theirs', ownerUserId: 'user-2' }]],
+    });
+
+    const result = await upsertTableData(
+      db as unknown as ShimDb,
+      'tension',
+      'circuits',
+      144574,
+      'user-1',
+      [circuit('theirs', 'First copy'), circuit('theirs', 'Duplicate copy')],
+      (message) => logged.push(message),
+    );
+
+    expect(insertsInto(playlists)).toHaveLength(0);
+    expect(result.synced).toBe(2);
+    expect(result.skipped).toBe(1);
+    expect(result.circuitPlaylistRefusals).toEqual({ foreign: 1, ambiguous: 0, invariant: 0 });
+    expect(logged).toContain('  Synced 0 circuits to playlists table');
+  });
+
+  it('deduplicates and sorts before the board_circuits batch upsert, with the last duplicate winning', async () => {
+    const { db, insertsInto } = createDbShim({
+      selectResults: [[], []],
+      returningRows: [[{ id: BigInt(7) }], [{ id: BigInt(8) }]],
+    });
+
+    await upsertTableData(
+      db as unknown as ShimDb,
+      'tension',
+      'circuits',
+      144574,
+      'user-1',
+      [circuit('z-circuit', 'Old value'), circuit('a-circuit', 'First'), circuit('z-circuit', 'Last value wins')],
+      () => {},
+    );
+
+    const [sourceInsert] = insertsInto(boardCircuits);
+    expect(sourceInsert?.args[0]).toMatchObject([
+      { uuid: 'a-circuit', name: 'First' },
+      { uuid: 'z-circuit', name: 'Last value wins' },
+    ]);
   });
 
   it('attaches the NOT EXISTS ownership guard to the playlist upsert', async () => {
@@ -298,12 +389,121 @@ describe('upsertTableData circuits — foreign-owner guard (#3526)', () => {
 });
 
 describe('upsertTableData circuits — race-guard suppression + owner lookup SQL', () => {
-  it('does not touch ownership or climbs when the SQL race guard suppresses the upsert', async () => {
+  it('counts and precisely logs a foreign owner found after the SQL race guard suppresses the upsert', async () => {
     // setWhere matched nothing → DO UPDATE was a no-op → .returning() is empty.
-    // The rest of the item must be abandoned, not run against an undefined id.
+    // The fresh re-read sees the transaction that won ownership arbitration.
+    const logged: string[] = [];
     const { db, calls, insertsInto } = createDbShim({
-      selectResults: [[]],
+      selectResults: [[], [{ upstreamId: 'circuit-1', ownerUserId: 'user-2' }]],
       returningRows: [[]],
+    });
+
+    const result = await upsertTableData(
+      db as unknown as ShimDb,
+      'tension',
+      'circuits',
+      144574,
+      'user-1',
+      [circuit('circuit-1', 'Lost the race', [{ climb_uuid: 'climb-A' }])],
+      (message) => logged.push(message),
+    );
+
+    expect(result.skipped).toBe(1);
+    expect(result.skippedReason).toBe(DUPLICATE_CIRCUIT_OWNER_SKIP_REASON);
+    expect(result.circuitPlaylistRefusals).toEqual({ foreign: 1, ambiguous: 0, invariant: 0 });
+    expect(insertsInto(playlistOwnership)).toHaveLength(0);
+    expect(insertsInto(playlistClimbs)).toHaveLength(0);
+    expect(calls.filter((c) => c.kind === 'delete')).toHaveLength(0);
+    expect(logged.some((line) => line.includes('"stage":"suppressed-upsert"'))).toBe(true);
+    expect(logged.some((line) => line.includes('"reason":"foreign"'))).toBe(true);
+  });
+
+  it('counts and precisely logs ambiguous owners found after a suppressed upsert', async () => {
+    const logged: string[] = [];
+    const { db, calls, insertsInto } = createDbShim({
+      selectResults: [
+        [],
+        [
+          { upstreamId: 'circuit-1', ownerUserId: 'user-1' },
+          { upstreamId: 'circuit-1', ownerUserId: 'user-2' },
+        ],
+      ],
+      returningRows: [[]],
+    });
+
+    const result = await upsertTableData(
+      db as unknown as ShimDb,
+      'tension',
+      'circuits',
+      144574,
+      'user-1',
+      [circuit('circuit-1', 'Already cross-linked', [{ climb_uuid: 'climb-A' }])],
+      (message) => logged.push(message),
+    );
+
+    expect(result.skipped).toBe(1);
+    expect(result.skippedReason).toBe(DUPLICATE_CIRCUIT_OWNER_SKIP_REASON);
+    expect(result.circuitPlaylistRefusals).toEqual({ foreign: 0, ambiguous: 1, invariant: 0 });
+    expect(insertsInto(playlistOwnership)).toHaveLength(0);
+    expect(insertsInto(playlistClimbs)).toHaveLength(0);
+    expect(calls.filter((call) => call.kind === 'delete')).toHaveLength(0);
+    expect(logged.some((line) => line.includes('"reason":"ambiguous"'))).toBe(true);
+  });
+
+  it('refuses with an invariant warning when a suppressed upsert has no owner on re-read', async () => {
+    const logged: string[] = [];
+    const { db, calls, insertsInto } = createDbShim({
+      selectResults: [[], []],
+      returningRows: [[]],
+    });
+
+    const result = await upsertTableData(
+      db as unknown as ShimDb,
+      'tension',
+      'circuits',
+      144574,
+      'user-1',
+      [circuit('circuit-1', 'Invariant failure', [{ climb_uuid: 'climb-A' }])],
+      (message) => logged.push(message),
+    );
+
+    expect(result.skipped).toBe(1);
+    expect(result.skippedReason).toBe(CIRCUIT_PLAYLIST_INVARIANT_SKIP_REASON);
+    expect(result.circuitPlaylistRefusals).toEqual({ foreign: 0, ambiguous: 0, invariant: 1 });
+    expect(insertsInto(playlistOwnership)).toHaveLength(0);
+    expect(insertsInto(playlistClimbs)).toHaveLength(0);
+    expect(calls.filter((call) => call.kind === 'delete')).toHaveLength(0);
+    expect(logged.some((line) => line.includes('invariant/concurrency warning'))).toBe(true);
+    expect(logged.some((line) => line.includes('"reason":"no-owner"'))).toBe(true);
+  });
+
+  it('does not label a suppressed upsert with only this owner as a duplicate account', async () => {
+    const logged: string[] = [];
+    const { db } = createDbShim({
+      selectResults: [[], [{ upstreamId: 'circuit-1', ownerUserId: 'user-1' }]],
+      returningRows: [[]],
+    });
+
+    const result = await upsertTableData(
+      db as unknown as ShimDb,
+      'tension',
+      'circuits',
+      144574,
+      'user-1',
+      [circuit('circuit-1', 'Invariant failure')],
+      (message) => logged.push(message),
+    );
+
+    expect(result.skippedReason).toBe(CIRCUIT_PLAYLIST_INVARIANT_SKIP_REASON);
+    expect(result.skippedReason).not.toBe(DUPLICATE_CIRCUIT_OWNER_SKIP_REASON);
+    expect(result.circuitPlaylistRefusals).toEqual({ foreign: 0, ambiguous: 0, invariant: 1 });
+    expect(logged.some((line) => line.includes('"reason":"own"'))).toBe(true);
+  });
+
+  it('takes every namespaced advisory lock before the source upsert and fresh owner read', async () => {
+    const { db, calls } = createDbShim({
+      selectResults: [[], []],
+      returningRows: [[{ id: BigInt(7) }], [{ id: BigInt(8) }]],
     });
 
     await upsertTableData(
@@ -312,13 +512,94 @@ describe('upsertTableData circuits — race-guard suppression + owner lookup SQL
       'circuits',
       144574,
       'user-1',
-      [circuit('circuit-1', 'Lost the race', [{ climb_uuid: 'climb-A' }])],
+      [circuit('z-circuit', 'Last'), circuit('a-circuit', 'First')],
       () => {},
     );
 
-    expect(insertsInto(playlistOwnership)).toHaveLength(0);
-    expect(insertsInto(playlistClimbs)).toHaveLength(0);
-    expect(calls.filter((c) => c.kind === 'delete')).toHaveLength(0);
+    const executeCallIndexes = calls
+      .map((call, index) => ({ call, index }))
+      .filter(({ call }) => call.kind === 'execute')
+      .map(({ index }) => index);
+    const sourceInsertCallIndex = calls.findIndex((call) => call.kind === 'insert' && call.table === boardCircuits);
+    const ownerSelectCallIndex = calls.findIndex((call) => call.kind === 'select');
+    expect(executeCallIndexes).toHaveLength(2);
+    expect(sourceInsertCallIndex).toBeGreaterThan(Math.max(...executeCallIndexes));
+    expect(ownerSelectCallIndex).toBeGreaterThan(sourceInsertCallIndex);
+
+    const lockStatement = calls[executeCallIndexes[0]]?.args[0];
+    const rendered = new PgDialect().sqlToQuery(lockStatement as never);
+    expect(rendered.sql).toContain('pg_advisory_xact_lock');
+    expect(rendered.sql).toContain('hashtext');
+    expect(rendered.params).toContain(0x41555243);
+    expect(rendered.params).toContain('tension|a-circuit');
+  });
+
+  it('takes multi-circuit locks in stable UUID order to avoid cross-transaction deadlocks', async () => {
+    const { db, calls } = createDbShim({
+      selectResults: [[], []],
+      returningRows: [[{ id: BigInt(7) }], [{ id: BigInt(8) }]],
+    });
+
+    await upsertTableData(
+      db as unknown as ShimDb,
+      'tension',
+      'circuits',
+      144574,
+      'user-1',
+      [circuit('z-circuit', 'Last'), circuit('a-circuit', 'First')],
+      () => {},
+    );
+
+    const lockKeys = calls
+      .filter((call) => call.kind === 'execute')
+      .map((call) => new PgDialect().sqlToQuery(call.args[0] as never).params)
+      .map((params) => params.find((parameter) => typeof parameter === 'string'));
+    expect(lockKeys).toEqual(['tension|a-circuit', 'tension|z-circuit']);
+  });
+
+  it('locks each normalized set before its source upsert when calls share an outer transaction', async () => {
+    const { db, calls } = createDbShim({
+      selectResults: [[], [], [], []],
+      returningRows: [[{ id: BigInt(7) }], [{ id: BigInt(8) }], [{ id: BigInt(9) }], [{ id: BigInt(10) }]],
+    });
+
+    await db.transaction(async (outerTransaction) => {
+      await upsertTableData(
+        outerTransaction as unknown as ShimDb,
+        'tension',
+        'circuits',
+        144574,
+        'user-1',
+        [circuit('z-circuit', 'Last'), circuit('a-circuit', 'First')],
+        () => {},
+      );
+      await upsertTableData(
+        outerTransaction as unknown as ShimDb,
+        'tension',
+        'circuits',
+        144574,
+        'user-1',
+        [circuit('d-circuit', 'Fourth'), circuit('c-circuit', 'Third')],
+        () => {},
+      );
+    });
+
+    const arbitrationEvents = calls
+      .filter((call) => call.kind === 'execute' || (call.kind === 'insert' && call.table === boardCircuits))
+      .map((call) => {
+        if (call.kind === 'insert') return 'source-upsert';
+        const parameters = new PgDialect().sqlToQuery(call.args[0] as never).params;
+        return parameters.find((parameter) => typeof parameter === 'string');
+      });
+
+    expect(arbitrationEvents).toEqual([
+      'tension|a-circuit',
+      'tension|z-circuit',
+      'source-upsert',
+      'tension|c-circuit',
+      'tension|d-circuit',
+      'source-upsert',
+    ]);
   });
 
   it('renders the owner lookup with the role filter, LEFT JOIN and aurora_id column', () => {
@@ -342,9 +623,9 @@ describe('upsertTableData circuits — race-guard suppression + owner lookup SQL
  * too: it flags both halves of the known duplicate Tension pair and none of the
  * other 110 Tension users.
  */
-describe('hasForeignOwnedCircuitPlaylists (#3526)', () => {
+describe('getCircuitPlaylistOwnershipConflictState (#3950)', () => {
   /**
-   * Stub for `.select().from().innerJoin().innerJoin().where().limit()`.
+   * Stub for `.select().from().innerJoin().leftJoin().where()`.
    *
    * `captured.where` holds the REAL predicate the production code passed.
    * Always render that — never rebuild the condition in the test. A rebuilt
@@ -353,44 +634,75 @@ describe('hasForeignOwnedCircuitPlaylists (#3526)', () => {
    * lesson learned the hard way).
    */
   function stubDb(rows: Array<Record<string, unknown>>) {
-    const captured: { where?: unknown } = {};
+    const captured: { where?: unknown; ownerJoin?: unknown } = {};
     const source = {
       innerJoin: (_table: unknown, _on: unknown) => source,
+      leftJoin: (_table: unknown, condition: unknown) => {
+        captured.ownerJoin = condition;
+        return source;
+      },
       where: (condition: unknown) => {
         captured.where = condition;
-        return { limit: (_n: number) => Promise.resolve(rows) };
+        return Promise.resolve(rows);
       },
     };
     return { db: { select: () => ({ from: () => source }) }, captured };
   }
 
-  it("reports a duplicate when a foreign owner holds one of the account's circuits", async () => {
-    const { db } = stubDb([{ playlistId: BigInt(1) }]);
-    await expect(hasForeignOwnedCircuitPlaylists(db as never, 'tension', 144574, 'user-1')).resolves.toBe(true);
+  it("reports foreign when another user solely owns one of the account's circuits", async () => {
+    const { db } = stubDb([{ circuitUuid: 'circuit-1', ownerUserId: 'user-2' }]);
+    await expect(getCircuitPlaylistOwnershipConflictState(db as never, 'tension', 144574, 'user-1')).resolves.toBe(
+      'foreign',
+    );
   });
 
-  it('reports no duplicate when nothing conflicts', async () => {
-    const { db } = stubDb([]);
-    await expect(hasForeignOwnedCircuitPlaylists(db as never, 'tension', 49399, 'user-1')).resolves.toBe(false);
+  it('reports ambiguous when this user and another user both own a playlist', async () => {
+    const { db } = stubDb([
+      { circuitUuid: 'circuit-1', ownerUserId: 'user-1' },
+      { circuitUuid: 'circuit-1', ownerUserId: 'user-2' },
+    ]);
+    await expect(getCircuitPlaylistOwnershipConflictState(db as never, 'tension', 144574, 'user-1')).resolves.toBe(
+      'ambiguous',
+    );
   });
 
-  it('scopes to this board, this Aurora account, and OTHER owners only', async () => {
-    // Renders the predicate PRODUCTION passed, pulled out of the stub. Flipping
-    // `ne(playlistOwnership.userId, ...)` to `eq` in user-sync.ts is the
-    // loudest failure mode in this change — every healthy Aurora user would get
-    // a permanent, false "circuits aren't syncing" banner — and a predicate
-    // rebuilt here would not notice.
+  it('gives ambiguous precedence when the account also has a foreign-only circuit', async () => {
+    const { db } = stubDb([
+      { circuitUuid: 'foreign', ownerUserId: 'user-2' },
+      { circuitUuid: 'shared', ownerUserId: 'user-1' },
+      { circuitUuid: 'shared', ownerUserId: 'user-3' },
+    ]);
+    await expect(getCircuitPlaylistOwnershipConflictState(db as never, 'tension', 144574, 'user-1')).resolves.toBe(
+      'ambiguous',
+    );
+  });
+
+  it.each([
+    ['no matching playlist', []],
+    ['an orphan', [{ circuitUuid: 'orphan', ownerUserId: null }]],
+    ['only this owner', [{ circuitUuid: 'mine', ownerUserId: 'user-1' }]],
+  ])('reports none for %s', async (_caseName, rows) => {
+    const { db } = stubDb(rows);
+    await expect(getCircuitPlaylistOwnershipConflictState(db as never, 'tension', 49399, 'user-1')).resolves.toBe(
+      'none',
+    );
+  });
+
+  it('scopes to this board/account and filters owner roles in the LEFT JOIN', async () => {
     const { db, captured } = stubDb([]);
 
-    await hasForeignOwnedCircuitPlaylists(db as never, 'tension', 144574, 'user-1');
+    await getCircuitPlaylistOwnershipConflictState(db as never, 'tension', 144574, 'user-1');
 
     expect(captured.where).toBeDefined();
     const rendered = new PgDialect().sqlToQuery(captured.where as never);
     expect(rendered.sql).toContain('"board_circuits"."board_type" =');
     expect(rendered.sql).toContain('"board_circuits"."user_id" =');
-    // The load-bearing character in the whole predicate.
-    expect(rendered.sql).toContain('"playlist_ownership"."user_id" <>');
-    expect(rendered.sql).not.toContain('"playlist_ownership"."user_id" =');
-    expect(rendered.params).toEqual(['tension', 144574, 'user-1']);
+    expect(rendered.params).toEqual(['tension', 144574]);
+
+    expect(captured.ownerJoin).toBeDefined();
+    const renderedOwnerJoin = new PgDialect().sqlToQuery(captured.ownerJoin as never);
+    expect(renderedOwnerJoin.sql).toContain('"playlist_ownership"."playlist_id" = "playlists"."id"');
+    expect(renderedOwnerJoin.sql).toContain('"playlist_ownership"."role" =');
+    expect(renderedOwnerJoin.params).toEqual(['owner']);
   });
 });

--- a/packages/aurora-sync/src/sync/user-sync.test.ts
+++ b/packages/aurora-sync/src/sync/user-sync.test.ts
@@ -479,6 +479,7 @@ describe('upsertTableData circuits — race-guard suppression + owner lookup SQL
 
   it('does not label a suppressed upsert with only this owner as a duplicate account', async () => {
     const logged: string[] = [];
+    const errorLogged: string[] = [];
     const { db } = createDbShim({
       selectResults: [[], [{ upstreamId: 'circuit-1', ownerUserId: 'user-1' }]],
       returningRows: [[]],
@@ -492,12 +493,47 @@ describe('upsertTableData circuits — race-guard suppression + owner lookup SQL
       'user-1',
       [circuit('circuit-1', 'Invariant failure')],
       (message) => logged.push(message),
+      (message) => errorLogged.push(message),
     );
 
     expect(result.skippedReason).toBe(CIRCUIT_PLAYLIST_INVARIANT_SKIP_REASON);
     expect(result.skippedReason).not.toBe(DUPLICATE_CIRCUIT_OWNER_SKIP_REASON);
     expect(result.circuitPlaylistRefusals).toEqual({ foreign: 0, ambiguous: 0, invariant: 1 });
     expect(logged.some((line) => line.includes('"reason":"own"'))).toBe(true);
+    expect(errorLogged).toHaveLength(1);
+    expect(JSON.parse(errorLogged[0] ?? '{}')).toEqual({
+      level: 'error',
+      event: 'aurora_circuit_playlist_suppressed_own_contradiction',
+      boardType: 'tension',
+      circuitUuid: 'circuit-1',
+      syncingUserId: 'user-1',
+      stage: 'suppressed-upsert',
+      reason: 'own',
+    });
+    expect(errorLogged[0]).not.toContain('Invariant failure');
+  });
+
+  it('locks and upserts only the source circuit when no NextAuth user ID is available', async () => {
+    const { db, calls, insertsInto } = createDbShim();
+
+    const result = await upsertTableData(
+      db as unknown as ShimDb,
+      'tension',
+      'circuits',
+      144574,
+      '',
+      [circuit('source-only', 'Source only')],
+      () => {},
+    );
+
+    expect(result).toEqual({ synced: 1, skipped: 0 });
+    expect(calls.filter((call) => call.kind === 'execute')).toHaveLength(1);
+    expect(insertsInto(boardCircuits)).toHaveLength(1);
+    expect(insertsInto(playlists)).toHaveLength(0);
+    expect(insertsInto(playlistOwnership)).toHaveLength(0);
+    expect(insertsInto(playlistClimbs)).toHaveLength(0);
+    expect(calls.filter((call) => call.kind === 'select' || call.kind === 'delete')).toHaveLength(0);
+    expect(calls.filter((call) => call.kind === 'transaction')).toHaveLength(1);
   });
 
   it('takes every namespaced advisory lock before the source upsert and fresh owner read', async () => {
@@ -529,9 +565,9 @@ describe('upsertTableData circuits — race-guard suppression + owner lookup SQL
     const lockStatement = calls[executeCallIndexes[0]]?.args[0];
     const rendered = new PgDialect().sqlToQuery(lockStatement as never);
     expect(rendered.sql).toContain('pg_advisory_xact_lock');
-    expect(rendered.sql).toContain('hashtext');
-    expect(rendered.params).toContain(0x41555243);
-    expect(rendered.params).toContain('tension|a-circuit');
+    expect(rendered.sql).toContain('hashtextextended');
+    expect(rendered.sql).toContain('0::bigint');
+    expect(rendered.params).toEqual(['boardsesh:aurora-circuit|tension|a-circuit']);
   });
 
   it('takes multi-circuit locks in stable UUID order to avoid cross-transaction deadlocks', async () => {
@@ -554,7 +590,10 @@ describe('upsertTableData circuits — race-guard suppression + owner lookup SQL
       .filter((call) => call.kind === 'execute')
       .map((call) => new PgDialect().sqlToQuery(call.args[0] as never).params)
       .map((params) => params.find((parameter) => typeof parameter === 'string'));
-    expect(lockKeys).toEqual(['tension|a-circuit', 'tension|z-circuit']);
+    expect(lockKeys).toEqual([
+      'boardsesh:aurora-circuit|tension|a-circuit',
+      'boardsesh:aurora-circuit|tension|z-circuit',
+    ]);
   });
 
   it('locks each normalized set before its source upsert when calls share an outer transaction', async () => {
@@ -593,11 +632,11 @@ describe('upsertTableData circuits — race-guard suppression + owner lookup SQL
       });
 
     expect(arbitrationEvents).toEqual([
-      'tension|a-circuit',
-      'tension|z-circuit',
+      'boardsesh:aurora-circuit|tension|a-circuit',
+      'boardsesh:aurora-circuit|tension|z-circuit',
       'source-upsert',
-      'tension|c-circuit',
-      'tension|d-circuit',
+      'boardsesh:aurora-circuit|tension|c-circuit',
+      'boardsesh:aurora-circuit|tension|d-circuit',
       'source-upsert',
     ]);
   });

--- a/packages/aurora-sync/src/sync/user-sync.ts
+++ b/packages/aurora-sync/src/sync/user-sync.ts
@@ -19,6 +19,7 @@ import { UNIFIED_TABLES } from '../db/table-select';
 import { playlists, playlistClimbs, playlistOwnership } from '@boardsesh/db/schema/app';
 import { formatDbError } from './db-error';
 import { applyAuroraAscents, applyAuroraBids } from './apply-user-logbook';
+import { auroraCircuitAdvisoryLockStatement, normalizeAuroraCircuitItems } from './circuit-arbitration';
 
 const BATCH_SIZE = 100;
 
@@ -129,41 +130,11 @@ type AuroraApiRow = Record<string, string>;
 
 type DrizzleDb = PostgresJsDatabase<Record<string, never>>;
 
-/**
- * Text namespace embedded in the server-side 64-bit advisory-lock hash. There
- * is no playlist row to lock when two users concurrently claim a new circuit,
- * so serializing on (board, circuit uuid) before the fresh ownership read closes
- * that gap across daemon instances. PostgreSQL releases the lock when the
- * surrounding transaction commits or rolls back.
- */
-const AURORA_CIRCUIT_LOCK_KEY_PREFIX = 'boardsesh:aurora-circuit';
-
-/** Pure/testable input to PostgreSQL's `hashtextextended(text, bigint)`. */
-export function getAuroraCircuitAdvisoryLockKey(boardName: AuroraBoardName, circuitUuid: string): string {
-  return `${AURORA_CIRCUIT_LOCK_KEY_PREFIX}|${boardName}|${circuitUuid}`;
-}
-
 type CircuitRefusalStage = 'ownership-check' | 'suppressed-upsert';
 type CircuitRefusalReason = 'foreign' | 'ambiguous' | 'no-owner' | 'own';
 type CircuitPlaylistWriteOutcome = { status: 'written' } | { status: 'refused'; reason: CircuitRefusalReason };
 
 export const CIRCUIT_PLAYLIST_INVARIANT_SKIP_REASON = 'circuit-playlist-invariant:circuits';
-
-/**
- * PostgreSQL rejects one INSERT ... ON CONFLICT batch containing the same
- * conflict key twice (SQLSTATE 21000). Aurora deltas are ordered, so preserve
- * their conventional last-row-wins meaning, then sort the unique rows before
- * either the source upsert or advisory-lock acquisition. The stable order also
- * prevents two multi-circuit transactions from locking source rows or advisory
- * keys in opposite order.
- */
-function normalizeCircuitItems(data: AuroraApiRow[]): AuroraApiRow[] {
-  const lastItemByUuid = new Map<string, AuroraApiRow>();
-  for (const item of data) lastItemByUuid.set(item.uuid, item);
-  return [...lastItemByUuid.values()].sort((left, right) =>
-    left.uuid < right.uuid ? -1 : left.uuid > right.uuid ? 1 : 0,
-  );
-}
 
 function logCircuitRefusal(
   log: (message: string) => void,
@@ -423,7 +394,18 @@ export async function upsertTableData(
 
     case 'circuits': {
       const circuitsSchema = UNIFIED_TABLES.circuits;
-      const circuitItems = normalizeCircuitItems(data);
+      const { items: circuitItems, rejectedCount } = normalizeAuroraCircuitItems(data);
+
+      if (rejectedCount > 0) {
+        logError(
+          JSON.stringify({
+            level: 'error',
+            event: 'aurora_circuit_playlist_malformed_payload',
+            boardType: boardName,
+            rejectedCount,
+          }),
+        );
+      }
 
       return db.transaction(async (transaction): Promise<UpsertResult> => {
         const circuitsTransaction = transaction as unknown as DrizzleDb;
@@ -437,12 +419,7 @@ export async function upsertTableData(
         // this callback is a savepoint and the locks remain owned by that outer
         // transaction until it commits or rolls back.
         for (const item of circuitItems) {
-          await circuitsTransaction.execute(
-            // Keep the 64-bit hash inside PostgreSQL. Converting the result to a
-            // JavaScript Number would lose precision above 2^53 and could make
-            // contenders derive different advisory keys.
-            sql`SELECT pg_advisory_xact_lock(hashtextextended(${getAuroraCircuitAdvisoryLockKey(boardName, item.uuid)}, 0::bigint))`,
-          );
+          await circuitsTransaction.execute(auroraCircuitAdvisoryLockStatement(boardName, item.uuid));
         }
 
         await processBatches(circuitItems, BATCH_SIZE, async (batch) => {
@@ -472,9 +449,27 @@ export async function upsertTableData(
             });
         });
 
-        if (!nextAuthUserId) return { synced: data.length, skipped: 0 };
+        if (!nextAuthUserId) {
+          return rejectedCount > 0
+            ? {
+                synced: data.length - rejectedCount,
+                skipped: rejectedCount,
+                skippedReason: CIRCUIT_PLAYLIST_INVARIANT_SKIP_REASON,
+                circuitPlaylistRefusals: { foreign: 0, ambiguous: 0, invariant: rejectedCount },
+              }
+            : { synced: data.length, skipped: 0 };
+        }
 
         const refusalReasonsByCircuitUuid = new Map<string, CircuitRefusalReason>();
+        // One owner query per payload, after every advisory lock and source
+        // write. Compliant writers cannot change these owner sets until this
+        // transaction releases its complete lock set; only the rare SQL-guard
+        // suppression path below needs a second, per-circuit diagnostic read.
+        const ownersByCircuitUuid = await selectUpstreamPlaylistOwners(
+          circuitsTransaction as unknown as OwnerQueryDb,
+          playlists.auroraId,
+          circuitItems.map((item) => item.uuid),
+        );
 
         for (const item of circuitItems) {
           const outcome = await circuitsTransaction.transaction(
@@ -484,9 +479,8 @@ export async function upsertTableData(
               // All server-wide per-(board,circuit) locks were acquired above,
               // before the source upsert. The fresh owner read therefore sees
               // any prior claimant's committed edge under READ COMMITTED.
-              const initialOwnerDecision = await selectCircuitOwnerDecision(
-                tx as unknown as OwnerQueryDb,
-                item.uuid,
+              const initialOwnerDecision = resolveUpstreamPlaylistWrite(
+                ownersByCircuitUuid.get(item.uuid) ?? [],
                 nextAuthUserId,
               );
               if (initialOwnerDecision === 'foreign' || initialOwnerDecision === 'ambiguous') {
@@ -605,11 +599,11 @@ export async function upsertTableData(
         }
 
         log(`  Synced ${circuitItems.length - refusalReasonsByCircuitUuid.size} circuits to playlists table`);
-        if (refusalReasonsByCircuitUuid.size > 0) {
+        if (refusalReasonsByCircuitUuid.size > 0 || rejectedCount > 0) {
           const circuitPlaylistRefusals: CircuitPlaylistRefusalSummary = {
             foreign: 0,
             ambiguous: 0,
-            invariant: 0,
+            invariant: rejectedCount,
           };
           for (const reason of refusalReasonsByCircuitUuid.values()) {
             if (reason === 'foreign') circuitPlaylistRefusals.foreign += 1;
@@ -622,8 +616,8 @@ export async function upsertTableData(
           // duplicate UUIDs are applied once, with their last payload row
           // winning. `skipped` and the detailed summary count unique circuits.
           return {
-            synced: data.length,
-            skipped: refusalReasonsByCircuitUuid.size,
+            synced: data.length - rejectedCount,
+            skipped: refusalReasonsByCircuitUuid.size + rejectedCount,
             skippedReason: hasOwnershipConflict
               ? DUPLICATE_CIRCUIT_OWNER_SKIP_REASON
               : CIRCUIT_PLAYLIST_INVARIANT_SKIP_REASON,
@@ -718,6 +712,7 @@ export async function syncUserData(
   nextAuthUserId: string,
   tables: string[] = USER_TABLES,
   log: (message: string) => void = console.info,
+  logError: (message: string) => void = console.error,
 ): Promise<SyncUserDataResult> {
   try {
     const syncParams: SyncOptions = {
@@ -767,6 +762,7 @@ export async function syncUserData(
                 nextAuthUserId,
                 data,
                 log,
+                logError,
               );
 
               if (!totalResults[tableName]) {

--- a/packages/aurora-sync/src/sync/user-sync.ts
+++ b/packages/aurora-sync/src/sync/user-sync.ts
@@ -130,16 +130,18 @@ type AuroraApiRow = Record<string, string>;
 type DrizzleDb = PostgresJsDatabase<Record<string, never>>;
 
 /**
- * Advisory-lock namespace for Aurora circuit playlist arbitration. `0x41555243`
- * is ASCII "AURC". The two-int lock form keeps this lock space separate from
- * the other transaction-scoped advisory locks used by Boardsesh.
- *
- * There is no playlist row to lock when two users concurrently claim a new
- * circuit. Serializing on (board, circuit uuid) before the fresh ownership read
- * closes that gap across daemon instances. PostgreSQL releases the lock when
- * the surrounding transaction commits or rolls back.
+ * Text namespace embedded in the server-side 64-bit advisory-lock hash. There
+ * is no playlist row to lock when two users concurrently claim a new circuit,
+ * so serializing on (board, circuit uuid) before the fresh ownership read closes
+ * that gap across daemon instances. PostgreSQL releases the lock when the
+ * surrounding transaction commits or rolls back.
  */
-const AURORA_CIRCUIT_LOCK_NAMESPACE = 0x41555243;
+const AURORA_CIRCUIT_LOCK_KEY_PREFIX = 'boardsesh:aurora-circuit';
+
+/** Pure/testable input to PostgreSQL's `hashtextextended(text, bigint)`. */
+export function getAuroraCircuitAdvisoryLockKey(boardName: AuroraBoardName, circuitUuid: string): string {
+  return `${AURORA_CIRCUIT_LOCK_KEY_PREFIX}|${boardName}|${circuitUuid}`;
+}
 
 type CircuitRefusalStage = 'ownership-check' | 'suppressed-upsert';
 type CircuitRefusalReason = 'foreign' | 'ambiguous' | 'no-owner' | 'own';
@@ -165,6 +167,7 @@ function normalizeCircuitItems(data: AuroraApiRow[]): AuroraApiRow[] {
 
 function logCircuitRefusal(
   log: (message: string) => void,
+  logError: (message: string) => void,
   input: {
     boardName: AuroraBoardName;
     circuitUuid: string;
@@ -181,6 +184,25 @@ function logCircuitRefusal(
     stage: input.stage,
     reason: input.reason,
   });
+
+  if (input.stage === 'suppressed-upsert' && input.reason === 'own') {
+    // `foreignPlaylistOwnerGuard` cannot suppress an update when the syncing
+    // user is the sole owner. Keep the item in the invariant refusal bucket,
+    // but emit a separate error-level event so an operator can distinguish this
+    // protocol contradiction from the recoverable no-owner race. Do not include
+    // the circuit payload, credentials, or other upstream response data.
+    logError(
+      JSON.stringify({
+        level: 'error',
+        event: 'aurora_circuit_playlist_suppressed_own_contradiction',
+        boardType: input.boardName,
+        circuitUuid: input.circuitUuid,
+        syncingUserId: input.syncingUserId,
+        stage: input.stage,
+        reason: input.reason,
+      }),
+    );
+  }
 
   if (input.reason === 'foreign' || input.reason === 'ambiguous') {
     log(
@@ -224,6 +246,7 @@ export async function upsertTableData(
   nextAuthUserId: string,
   data: AuroraApiRow[],
   log: (message: string) => void = console.info,
+  logError: (message: string) => void = console.error,
 ): Promise<UpsertResult> {
   if (data.length === 0) return { synced: 0, skipped: 0 };
 
@@ -415,7 +438,10 @@ export async function upsertTableData(
         // transaction until it commits or rolls back.
         for (const item of circuitItems) {
           await circuitsTransaction.execute(
-            sql`SELECT pg_advisory_xact_lock(${AURORA_CIRCUIT_LOCK_NAMESPACE}, hashtext(${`${boardName}|${item.uuid}`}))`,
+            // Keep the 64-bit hash inside PostgreSQL. Converting the result to a
+            // JavaScript Number would lose precision above 2^53 and could make
+            // contenders derive different advisory keys.
+            sql`SELECT pg_advisory_xact_lock(hashtextextended(${getAuroraCircuitAdvisoryLockKey(boardName, item.uuid)}, 0::bigint))`,
           );
         }
 
@@ -467,7 +493,7 @@ export async function upsertTableData(
                 // Refuse the whole item — upsert, ownership grant AND the
                 // playlist_climbs replace below. Skipping only the upsert would
                 // still wipe the other user's climbs further down.
-                logCircuitRefusal(log, {
+                logCircuitRefusal(log, logError, {
                   boardName,
                   circuitUuid: item.uuid,
                   syncingUserId: nextAuthUserId,
@@ -524,7 +550,7 @@ export async function upsertTableData(
                 );
                 const reason: CircuitRefusalReason =
                   suppressedOwnerDecision === 'adopt' ? 'no-owner' : suppressedOwnerDecision;
-                logCircuitRefusal(log, {
+                logCircuitRefusal(log, logError, {
                   boardName,
                   circuitUuid: item.uuid,
                   syncingUserId: nextAuthUserId,

--- a/packages/aurora-sync/src/sync/user-sync.ts
+++ b/packages/aurora-sync/src/sync/user-sync.ts
@@ -173,6 +173,7 @@ function logCircuitRefusal(
         reason: input.reason,
       }),
     );
+    return;
   }
 
   if (input.reason === 'foreign' || input.reason === 'ambiguous') {

--- a/packages/aurora-sync/src/sync/user-sync.ts
+++ b/packages/aurora-sync/src/sync/user-sync.ts
@@ -1,15 +1,18 @@
 import { userSync } from '../api/user-sync-api';
 import { type SyncOptions, type UserSyncData, type AuroraBoardName, USER_TABLES } from '../api/types';
-import { eq, and, inArray, ne, sql } from 'drizzle-orm';
+import { eq, and, inArray, sql } from 'drizzle-orm';
 import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type postgres from 'postgres';
 import {
   resolveUpstreamPlaylistWrite,
-  canWriteUpstreamPlaylist,
   upstreamPlaylistSkipLogLine,
+  type UpstreamPlaylistWriteDecision,
 } from '@boardsesh/sync-runtime';
 import { normalizePlaylistColor } from '@boardsesh/shared-schema';
-import { DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR } from '@boardsesh/shared-schema/sync-error-codes';
+import {
+  DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+  type CircuitPlaylistOwnershipConflictState,
+} from '@boardsesh/shared-schema/sync-error-codes';
 import { foreignPlaylistOwnerGuard, selectUpstreamPlaylistOwners } from '@boardsesh/db/queries';
 import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
 import { UNIFIED_TABLES } from '../db/table-select';
@@ -20,7 +23,7 @@ import { applyAuroraAscents, applyAuroraBids } from './apply-user-logbook';
 const BATCH_SIZE = 100;
 
 /**
- * The generic Drizzle shape `hasForeignOwnedCircuitPlaylists` accepts. Wider
+ * The generic Drizzle shape the ownership queries accept. Wider
  * than this module's `DrizzleDb` (which pins the postgres-js driver) so the
  * runner can hand over its own client without a cast.
  */
@@ -30,16 +33,17 @@ type OwnerQueryDb = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
  * Machine-stable marker on `SyncTableResult.skippedReason` for circuits refused
  * because another Boardsesh user owns the playlist.
  *
- * Same string the runners write to `aurora_credentials.sync_error`, so the
- * per-table result, the daemon log and the board card all name one condition —
- * but the runner does NOT derive the credential's value from this counter: see
- * hasForeignOwnedCircuitPlaylists for why that has to be a state question.
+ * Retains the pre-#3950 generic code for callers that inspect per-table sync
+ * results. The runner now persists a more precise foreign/ambiguous code and
+ * does NOT derive it from this counter: see
+ * getCircuitPlaylistOwnershipConflictState for why that must be a state
+ * question.
  */
 export const DUPLICATE_CIRCUIT_OWNER_SKIP_REASON = DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR;
 
 /**
- * Does any playlist mirroring one of THIS Aurora account's circuits belong to a
- * different Boardsesh user?
+ * Classify ownership across every playlist mirroring THIS Aurora account's
+ * circuits as `none`, `foreign`, or `ambiguous`.
  *
  * Drives the user-facing `sync_error`, and it is deliberately a STATE query
  * rather than a count of what this cycle refused. Aurora's user sync is
@@ -57,34 +61,44 @@ export const DUPLICATE_CIRCUIT_OWNER_SKIP_REASON = DUPLICATE_BOARD_ACCOUNT_CIRCU
  * does wipe it board-wide, but that also clears `board_user_syncs` in the same
  * transaction, so the next sync refills both and the check self-heals.
  */
-export async function hasForeignOwnedCircuitPlaylists(
+export async function getCircuitPlaylistOwnershipConflictState(
   db: OwnerQueryDb,
   boardName: AuroraBoardName,
   auroraUserId: number,
   nextAuthUserId: string,
-): Promise<boolean> {
+): Promise<CircuitPlaylistOwnershipConflictState> {
   const circuitsSchema = UNIFIED_TABLES.circuits;
-  const conflicting = await db
-    .select({ playlistId: playlistOwnership.playlistId })
+  const ownerRows = await db
+    .select({ circuitUuid: circuitsSchema.uuid, ownerUserId: playlistOwnership.userId })
     .from(circuitsSchema)
     .innerJoin(
       playlists,
       and(eq(playlists.auroraId, circuitsSchema.uuid), eq(playlists.boardType, circuitsSchema.boardType)),
     )
-    .innerJoin(
+    .leftJoin(
       playlistOwnership,
       and(eq(playlistOwnership.playlistId, playlists.id), eq(playlistOwnership.role, 'owner')),
     )
-    .where(
-      and(
-        eq(circuitsSchema.boardType, boardName),
-        eq(circuitsSchema.userId, auroraUserId),
-        ne(playlistOwnership.userId, nextAuthUserId),
-      ),
-    )
-    .limit(1);
+    .where(and(eq(circuitsSchema.boardType, boardName), eq(circuitsSchema.userId, auroraUserId)));
 
-  return conflicting.length > 0;
+  const ownerIdsByCircuit = new Map<string, string[]>();
+  for (const row of ownerRows) {
+    let ownerIds = ownerIdsByCircuit.get(row.circuitUuid);
+    if (!ownerIds) {
+      ownerIds = [];
+      ownerIdsByCircuit.set(row.circuitUuid, ownerIds);
+    }
+    if (typeof row.ownerUserId === 'string') ownerIds.push(row.ownerUserId);
+  }
+
+  let hasForeignOwner = false;
+  for (const ownerIds of ownerIdsByCircuit.values()) {
+    const decision = resolveUpstreamPlaylistWrite(ownerIds, nextAuthUserId);
+    if (decision === 'ambiguous') return 'ambiguous';
+    if (decision === 'foreign') hasForeignOwner = true;
+  }
+
+  return hasForeignOwner ? 'foreign' : 'none';
 }
 
 async function processBatches<T>(
@@ -98,15 +112,104 @@ async function processBatches<T>(
   }
 }
 
-type UpsertResult = {
+export type CircuitPlaylistRefusalSummary = {
+  foreign: number;
+  ambiguous: number;
+  invariant: number;
+};
+
+export type UpsertResult = {
   synced: number;
   skipped: number;
   skippedReason?: string;
+  circuitPlaylistRefusals?: CircuitPlaylistRefusalSummary;
 };
 
 type AuroraApiRow = Record<string, string>;
 
 type DrizzleDb = PostgresJsDatabase<Record<string, never>>;
+
+/**
+ * Advisory-lock namespace for Aurora circuit playlist arbitration. `0x41555243`
+ * is ASCII "AURC". The two-int lock form keeps this lock space separate from
+ * the other transaction-scoped advisory locks used by Boardsesh.
+ *
+ * There is no playlist row to lock when two users concurrently claim a new
+ * circuit. Serializing on (board, circuit uuid) before the fresh ownership read
+ * closes that gap across daemon instances. PostgreSQL releases the lock when
+ * the surrounding transaction commits or rolls back.
+ */
+const AURORA_CIRCUIT_LOCK_NAMESPACE = 0x41555243;
+
+type CircuitRefusalStage = 'ownership-check' | 'suppressed-upsert';
+type CircuitRefusalReason = 'foreign' | 'ambiguous' | 'no-owner' | 'own';
+type CircuitPlaylistWriteOutcome = { status: 'written' } | { status: 'refused'; reason: CircuitRefusalReason };
+
+export const CIRCUIT_PLAYLIST_INVARIANT_SKIP_REASON = 'circuit-playlist-invariant:circuits';
+
+/**
+ * PostgreSQL rejects one INSERT ... ON CONFLICT batch containing the same
+ * conflict key twice (SQLSTATE 21000). Aurora deltas are ordered, so preserve
+ * their conventional last-row-wins meaning, then sort the unique rows before
+ * either the source upsert or advisory-lock acquisition. The stable order also
+ * prevents two multi-circuit transactions from locking source rows or advisory
+ * keys in opposite order.
+ */
+function normalizeCircuitItems(data: AuroraApiRow[]): AuroraApiRow[] {
+  const lastItemByUuid = new Map<string, AuroraApiRow>();
+  for (const item of data) lastItemByUuid.set(item.uuid, item);
+  return [...lastItemByUuid.values()].sort((left, right) =>
+    left.uuid < right.uuid ? -1 : left.uuid > right.uuid ? 1 : 0,
+  );
+}
+
+function logCircuitRefusal(
+  log: (message: string) => void,
+  input: {
+    boardName: AuroraBoardName;
+    circuitUuid: string;
+    syncingUserId: string;
+    stage: CircuitRefusalStage;
+    reason: CircuitRefusalReason;
+  },
+): void {
+  const structuredContext = JSON.stringify({
+    event: 'aurora_circuit_playlist_refused',
+    boardType: input.boardName,
+    circuitUuid: input.circuitUuid,
+    syncingUserId: input.syncingUserId,
+    stage: input.stage,
+    reason: input.reason,
+  });
+
+  if (input.reason === 'foreign' || input.reason === 'ambiguous') {
+    log(
+      `${upstreamPlaylistSkipLogLine({
+        syncTag: 'aurora-sync',
+        upstreamIdColumn: 'aurora_id',
+        upstreamId: input.circuitUuid,
+        syncingUserId: input.syncingUserId,
+        decision: input.reason,
+      })} ${structuredContext}`,
+    );
+    return;
+  }
+
+  const ownerState = input.reason === 'no-owner' ? 'no owner edge' : 'only the syncing user as owner';
+  log(
+    `[aurora-sync] aurora_id ${input.circuitUuid}: invariant/concurrency warning — playlist upsert returned no row, but the fresh owner read found ${ownerState}; refusing to mutate ownership or climbs for user ${input.syncingUserId} ${structuredContext}`,
+  );
+}
+
+async function selectCircuitOwnerDecision(
+  db: OwnerQueryDb,
+  circuitUuid: string,
+  syncingUserId: string,
+): Promise<UpstreamPlaylistWriteDecision> {
+  const ownersByAuroraId = await selectUpstreamPlaylistOwners(db, playlists.auroraId, [circuitUuid]);
+  const owners = ownersByAuroraId.get(circuitUuid) ?? [];
+  return resolveUpstreamPlaylistWrite(owners, syncingUserId);
+}
 
 /**
  * Exported for unit tests: the circuits branch carries the duplicate-account
@@ -297,155 +400,213 @@ export async function upsertTableData(
 
     case 'circuits': {
       const circuitsSchema = UNIFIED_TABLES.circuits;
+      const circuitItems = normalizeCircuitItems(data);
 
-      await processBatches(data, BATCH_SIZE, async (batch) => {
-        const values = batch.map((item) => ({
-          boardType: boardName,
-          uuid: item.uuid,
-          name: item.name,
-          description: item.description,
-          color: item.color,
-          userId: Number(auroraUserId),
-          isPublic: Boolean(item.is_public),
-          createdAt: item.created_at,
-          updatedAt: item.updated_at,
-        }));
-        await db
-          .insert(circuitsSchema)
-          .values(values)
-          .onConflictDoUpdate({
-            target: [circuitsSchema.boardType, circuitsSchema.uuid],
-            set: {
-              name: sql`excluded.name`,
-              description: sql`excluded.description`,
-              color: sql`excluded.color`,
-              isPublic: sql`excluded.is_public`,
-              updatedAt: sql`excluded.updated_at`,
-            },
-          });
-      });
+      return db.transaction(async (transaction): Promise<UpsertResult> => {
+        const circuitsTransaction = transaction as unknown as DrizzleDb;
 
-      if (nextAuthUserId) {
-        // Who already owns the playlists behind these circuit uuids?
-        // `playlists_aurora_id_idx` is a GLOBAL unique index, so the
-        // `ON CONFLICT (aurora_id) DO UPDATE` below lands on whichever
-        // Boardsesh user's row got there first — and the ownership insert then
-        // hands this user an `owner` edge on it. That is how the 8 cross-linked
-        // tension playlists in prod were created (#3526 / #3541). Same
-        // partition-and-skip shape as the foreignAuroraIds guard in
-        // apply-user-logbook.ts.
-        const ownersByAuroraId = await selectUpstreamPlaylistOwners(
-          db,
-          playlists.auroraId,
-          data.map((item) => item.uuid).filter((uuid): uuid is string => typeof uuid === 'string'),
-        );
-        // Distinct circuit uuids, not items: a duplicated uuid in one payload
-        // must not inflate the count the log line and the result report.
-        const refusedCircuitUuids = new Set<string>();
+        // Take the complete normalized lock set before ANY row write. Source
+        // rows and playlist rows share the same surrounding transaction, so
+        // writing board_circuits first would mix row locks with advisory locks
+        // and let two reused outer transactions form a cross-lock deadlock.
+        // UUID sorting in normalizeCircuitItems gives every claimant the same
+        // acquisition order. When the caller already supplied a transaction,
+        // this callback is a savepoint and the locks remain owned by that outer
+        // transaction until it commits or rolls back.
+        for (const item of circuitItems) {
+          await circuitsTransaction.execute(
+            sql`SELECT pg_advisory_xact_lock(${AURORA_CIRCUIT_LOCK_NAMESPACE}, hashtext(${`${boardName}|${item.uuid}`}))`,
+          );
+        }
 
-        for (const item of data) {
-          const decision = resolveUpstreamPlaylistWrite(ownersByAuroraId.get(item.uuid) ?? [], nextAuthUserId);
-          if (!canWriteUpstreamPlaylist(decision)) {
-            // Refuse the whole item — upsert, ownership grant AND the
-            // playlist_climbs replace below. Skipping only the upsert would
-            // still wipe the other user's climbs further down.
-            refusedCircuitUuids.add(item.uuid);
-            log(
-              upstreamPlaylistSkipLogLine({
-                syncTag: 'aurora-sync',
-                upstreamIdColumn: 'aurora_id',
-                upstreamId: item.uuid,
-                syncingUserId: nextAuthUserId,
-                decision,
-              }),
-            );
-            continue;
-          }
-
-          const formattedColor = normalizePlaylistColor(item.color);
-
-          const [playlist] = await db
-            .insert(playlists)
-            .values({
-              uuid: item.uuid,
-              boardType: boardName,
-              layoutId: null,
-              name: item.name || 'Untitled Circuit',
-              description: item.description || null,
-              isPublic: Boolean(item.is_public),
-              color: formattedColor,
-              auroraType: 'circuits',
-              auroraId: item.uuid,
-              auroraSyncedAt: new Date(),
-              createdAt: item.created_at ? new Date(item.created_at) : new Date(),
-              updatedAt: item.updated_at ? new Date(item.updated_at) : new Date(),
-            })
+        await processBatches(circuitItems, BATCH_SIZE, async (batch) => {
+          const values = batch.map((item) => ({
+            boardType: boardName,
+            uuid: item.uuid,
+            name: item.name,
+            description: item.description,
+            color: item.color,
+            userId: Number(auroraUserId),
+            isPublic: Boolean(item.is_public),
+            createdAt: item.created_at,
+            updatedAt: item.updated_at,
+          }));
+          await circuitsTransaction
+            .insert(circuitsSchema)
+            .values(values)
             .onConflictDoUpdate({
-              target: playlists.auroraId,
+              target: [circuitsSchema.boardType, circuitsSchema.uuid],
               set: {
-                name: item.name || 'Untitled Circuit',
-                description: item.description || null,
-                isPublic: Boolean(item.is_public),
-                color: formattedColor,
-                updatedAt: item.updated_at ? new Date(item.updated_at) : new Date(),
-                auroraSyncedAt: new Date(),
+                name: sql`excluded.name`,
+                description: sql`excluded.description`,
+                color: sql`excluded.color`,
+                isPublic: sql`excluded.is_public`,
+                updatedAt: sql`excluded.updated_at`,
               },
-              // SQL-level twin of the decision gate above, evaluated at
-              // statement time against the conflicting row — closes the window
-              // where two daemons syncing two Boardsesh users on the SAME
-              // Aurora account both read "no playlist yet" and both INSERT.
-              // Widened by #3539 (no cross-instance mutual exclusion). When it
-              // bites, DO UPDATE matches nothing and `.returning()` comes back
-              // empty, so the guard below skips the item.
-              setWhere: foreignPlaylistOwnerGuard(nextAuthUserId),
-            })
-            .returning({ id: playlists.id });
+            });
+        });
 
-          if (!playlist) continue;
+        if (!nextAuthUserId) return { synced: data.length, skipped: 0 };
 
-          await db
-            .insert(playlistOwnership)
-            .values({
-              playlistId: playlist.id,
-              userId: nextAuthUserId,
-              role: 'owner',
-            })
-            .onConflictDoNothing();
+        const refusalReasonsByCircuitUuid = new Map<string, CircuitRefusalReason>();
 
-          if (item.climbs && Array.isArray(item.climbs)) {
-            await db.delete(playlistClimbs).where(eq(playlistClimbs.playlistId, playlist.id));
+        for (const item of circuitItems) {
+          const outcome = await circuitsTransaction.transaction(
+            async (playlistTransaction): Promise<CircuitPlaylistWriteOutcome> => {
+              const tx = playlistTransaction as unknown as DrizzleDb;
 
-            for (let i = 0; i < item.climbs.length; i++) {
-              const climb = item.climbs[i];
-              const climbUuid = climb.climb_uuid || climb.uuid || climb;
-              const climbAngle = climb.angle ?? null;
-              const climbPosition = climb.position ?? i;
-
-              if (typeof climbUuid === 'string') {
-                await db.insert(playlistClimbs).values({
-                  playlistId: playlist.id,
-                  climbUuid: climbUuid,
-                  angle: climbAngle,
-                  position: climbPosition,
+              // All server-wide per-(board,circuit) locks were acquired above,
+              // before the source upsert. The fresh owner read therefore sees
+              // any prior claimant's committed edge under READ COMMITTED.
+              const initialOwnerDecision = await selectCircuitOwnerDecision(
+                tx as unknown as OwnerQueryDb,
+                item.uuid,
+                nextAuthUserId,
+              );
+              if (initialOwnerDecision === 'foreign' || initialOwnerDecision === 'ambiguous') {
+                // Refuse the whole item — upsert, ownership grant AND the
+                // playlist_climbs replace below. Skipping only the upsert would
+                // still wipe the other user's climbs further down.
+                logCircuitRefusal(log, {
+                  boardName,
+                  circuitUuid: item.uuid,
+                  syncingUserId: nextAuthUserId,
+                  stage: 'ownership-check',
+                  reason: initialOwnerDecision,
                 });
+                return { status: 'refused', reason: initialOwnerDecision };
               }
-            }
+
+              const formattedColor = normalizePlaylistColor(item.color);
+
+              const [playlist] = await tx
+                .insert(playlists)
+                .values({
+                  uuid: item.uuid,
+                  boardType: boardName,
+                  layoutId: null,
+                  name: item.name || 'Untitled Circuit',
+                  description: item.description || null,
+                  isPublic: Boolean(item.is_public),
+                  color: formattedColor,
+                  auroraType: 'circuits',
+                  auroraId: item.uuid,
+                  auroraSyncedAt: new Date(),
+                  createdAt: item.created_at ? new Date(item.created_at) : new Date(),
+                  updatedAt: item.updated_at ? new Date(item.updated_at) : new Date(),
+                })
+                .onConflictDoUpdate({
+                  target: playlists.auroraId,
+                  set: {
+                    name: item.name || 'Untitled Circuit',
+                    description: item.description || null,
+                    isPublic: Boolean(item.is_public),
+                    color: formattedColor,
+                    updatedAt: item.updated_at ? new Date(item.updated_at) : new Date(),
+                    auroraSyncedAt: new Date(),
+                  },
+                  // Defence in depth: the advisory lock is the primary
+                  // arbitration mechanism, while this statement-time predicate
+                  // still prevents a foreign owner from being adopted if a
+                  // caller ever bypasses or changes the lock protocol.
+                  setWhere: foreignPlaylistOwnerGuard(nextAuthUserId),
+                })
+                .returning({ id: playlists.id });
+
+              if (!playlist) {
+                // The SQL guard suppressed the update. Re-read after the failed
+                // write so observability reports the actual owner state that
+                // caused it, rather than the stale pre-upsert decision.
+                const suppressedOwnerDecision = await selectCircuitOwnerDecision(
+                  tx as unknown as OwnerQueryDb,
+                  item.uuid,
+                  nextAuthUserId,
+                );
+                const reason: CircuitRefusalReason =
+                  suppressedOwnerDecision === 'adopt' ? 'no-owner' : suppressedOwnerDecision;
+                logCircuitRefusal(log, {
+                  boardName,
+                  circuitUuid: item.uuid,
+                  syncingUserId: nextAuthUserId,
+                  stage: 'suppressed-upsert',
+                  reason,
+                });
+                return { status: 'refused', reason };
+              }
+
+              await tx
+                .insert(playlistOwnership)
+                .values({
+                  playlistId: playlist.id,
+                  userId: nextAuthUserId,
+                  role: 'owner',
+                })
+                .onConflictDoUpdate({
+                  target: [playlistOwnership.playlistId, playlistOwnership.userId],
+                  // An orphan can still have this user attached as editor/viewer.
+                  // Claiming it must promote that existing edge, not let
+                  // ON CONFLICT DO NOTHING leave the playlist ownerless.
+                  set: { role: 'owner' },
+                });
+
+              if (item.climbs && Array.isArray(item.climbs)) {
+                await tx.delete(playlistClimbs).where(eq(playlistClimbs.playlistId, playlist.id));
+
+                for (let i = 0; i < item.climbs.length; i++) {
+                  const climb = item.climbs[i];
+                  const climbUuid = climb.climb_uuid || climb.uuid || climb;
+                  const climbAngle = climb.angle ?? null;
+                  const climbPosition = climb.position ?? i;
+
+                  if (typeof climbUuid === 'string') {
+                    await tx.insert(playlistClimbs).values({
+                      playlistId: playlist.id,
+                      climbUuid,
+                      angle: climbAngle,
+                      position: climbPosition,
+                    });
+                  }
+                }
+              }
+
+              return { status: 'written' };
+            },
+          );
+
+          if (outcome.status === 'refused') {
+            refusalReasonsByCircuitUuid.set(item.uuid, outcome.reason);
           }
         }
-        log(`  Synced ${data.length - refusedCircuitUuids.size} circuits to playlists table`);
-        if (refusedCircuitUuids.size > 0) {
-          // `synced` stays data.length: every row DID land in the `circuits`
-          // table above (that upsert is user-scoped by aurora_user_id and was
-          // never at risk). Only the playlists mirror was refused, and that's
-          // what `skipped` reports.
+
+        log(`  Synced ${circuitItems.length - refusalReasonsByCircuitUuid.size} circuits to playlists table`);
+        if (refusalReasonsByCircuitUuid.size > 0) {
+          const circuitPlaylistRefusals: CircuitPlaylistRefusalSummary = {
+            foreign: 0,
+            ambiguous: 0,
+            invariant: 0,
+          };
+          for (const reason of refusalReasonsByCircuitUuid.values()) {
+            if (reason === 'foreign') circuitPlaylistRefusals.foreign += 1;
+            else if (reason === 'ambiguous') circuitPlaylistRefusals.ambiguous += 1;
+            else circuitPlaylistRefusals.invariant += 1;
+          }
+          const hasOwnershipConflict = circuitPlaylistRefusals.foreign > 0 || circuitPlaylistRefusals.ambiguous > 0;
+
+          // `synced` retains the existing input-row metric for compatibility;
+          // duplicate UUIDs are applied once, with their last payload row
+          // winning. `skipped` and the detailed summary count unique circuits.
           return {
             synced: data.length,
-            skipped: refusedCircuitUuids.size,
-            skippedReason: DUPLICATE_CIRCUIT_OWNER_SKIP_REASON,
+            skipped: refusalReasonsByCircuitUuid.size,
+            skippedReason: hasOwnershipConflict
+              ? DUPLICATE_CIRCUIT_OWNER_SKIP_REASON
+              : CIRCUIT_PLAYLIST_INVARIANT_SKIP_REASON,
+            circuitPlaylistRefusals,
           };
         }
-      }
-      break;
+
+        return { synced: data.length, skipped: 0 };
+      });
     }
 
     default:
@@ -518,6 +679,7 @@ export type SyncTableResult = {
   synced: number;
   skipped?: number;
   skippedReason?: string;
+  circuitPlaylistRefusals?: CircuitPlaylistRefusalSummary;
 };
 
 export type SyncUserDataResult = Record<string, SyncTableResult>;
@@ -587,7 +749,26 @@ export async function syncUserData(
               totalResults[tableName].synced += upsertResult.synced;
               if (upsertResult.skipped > 0) {
                 totalResults[tableName].skipped = (totalResults[tableName].skipped || 0) + upsertResult.skipped;
-                totalResults[tableName].skippedReason = upsertResult.skippedReason;
+                // Keep the legacy duplicate-account marker if any page saw a
+                // genuine owner conflict; a later invariant refusal must not
+                // overwrite it. Detailed counts preserve every category.
+                if (
+                  !totalResults[tableName].skippedReason ||
+                  upsertResult.skippedReason === DUPLICATE_CIRCUIT_OWNER_SKIP_REASON
+                ) {
+                  totalResults[tableName].skippedReason = upsertResult.skippedReason;
+                }
+                if (upsertResult.circuitPlaylistRefusals) {
+                  const accumulated = totalResults[tableName].circuitPlaylistRefusals ?? {
+                    foreign: 0,
+                    ambiguous: 0,
+                    invariant: 0,
+                  };
+                  accumulated.foreign += upsertResult.circuitPlaylistRefusals.foreign;
+                  accumulated.ambiguous += upsertResult.circuitPlaylistRefusals.ambiguous;
+                  accumulated.invariant += upsertResult.circuitPlaylistRefusals.invariant;
+                  totalResults[tableName].circuitPlaylistRefusals = accumulated;
+                }
               }
             } else if (!totalResults[tableName]) {
               totalResults[tableName] = { synced: 0 };

--- a/packages/backend/src/__tests__/aurora-credentials-handler.test.ts
+++ b/packages/backend/src/__tests__/aurora-credentials-handler.test.ts
@@ -1,6 +1,9 @@
 import { Readable } from 'node:stream';
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
-import { FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR } from '@boardsesh/shared-schema/sync-error-codes';
+import {
+  DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+  FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+} from '@boardsesh/shared-schema/sync-error-codes';
 
 const saveAuroraCredentialMock = vi.fn();
 const getAuroraCredentialStatusesMock = vi.fn();
@@ -80,7 +83,7 @@ describe('Aurora credentials REST handler', () => {
     handlers = await import('../handlers/aurora-credentials');
   });
 
-  it('GET preserves the ownership-state sync_error code for clients to localise', async () => {
+  it('GET sends the legacy warning code plus a precise reason for stale-client compatibility', async () => {
     validateTokenMock.mockResolvedValue({ userId: 'foreign-owner-user' });
     getAuroraCredentialStatusesMock.mockResolvedValue([
       {
@@ -100,7 +103,12 @@ describe('Aurora credentials REST handler', () => {
 
     expect(response.statusCode).toBe(200);
     expect(JSON.parse(response.body)).toMatchObject({
-      credentials: [{ syncError: FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR }],
+      credentials: [
+        {
+          syncError: DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+          syncErrorReason: 'foreign',
+        },
+      ],
     });
   });
 

--- a/packages/backend/src/__tests__/aurora-credentials-handler.test.ts
+++ b/packages/backend/src/__tests__/aurora-credentials-handler.test.ts
@@ -1,7 +1,9 @@
 import { Readable } from 'node:stream';
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR } from '@boardsesh/shared-schema/sync-error-codes';
 
 const saveAuroraCredentialMock = vi.fn();
+const getAuroraCredentialStatusesMock = vi.fn();
 const validateTokenMock = vi.fn();
 
 // Mirror the real DuplicateBoardLinkError so the handler's `instanceof` → 409
@@ -17,13 +19,19 @@ const DuplicateBoardLinkErrorMock = class DuplicateBoardLinkError extends Error 
 vi.mock('../services/aurora-credentials', () => ({
   DuplicateBoardLinkError: DuplicateBoardLinkErrorMock,
   saveAuroraCredential: saveAuroraCredentialMock,
-  getAuroraCredentialStatuses: vi.fn(),
+  getAuroraCredentialStatuses: getAuroraCredentialStatusesMock,
   getAuroraUnsyncedCounts: vi.fn(),
   deleteAuroraCredential: vi.fn(),
 }));
 
 vi.mock('../middleware/auth', () => ({
   validateToken: validateTokenMock,
+}));
+
+vi.mock('../utils/logger', () => ({
+  logger: {
+    warn: vi.fn(),
+  },
 }));
 
 type TestResponse = {
@@ -67,8 +75,33 @@ describe('Aurora credentials REST handler', () => {
   beforeEach(async () => {
     vi.resetModules();
     saveAuroraCredentialMock.mockReset();
+    getAuroraCredentialStatusesMock.mockReset();
     validateTokenMock.mockReset();
     handlers = await import('../handlers/aurora-credentials');
+  });
+
+  it('GET preserves the ownership-state sync_error code for clients to localise', async () => {
+    validateTokenMock.mockResolvedValue({ userId: 'foreign-owner-user' });
+    getAuroraCredentialStatusesMock.mockResolvedValue([
+      {
+        boardType: 'tension',
+        auroraUsername: 'climber',
+        auroraUserId: 42,
+        lastSyncAt: '2026-07-31T00:00:00.000Z',
+        syncStatus: 'active',
+        syncError: FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+    const request = makeRequest({ method: 'GET', headers: { authorization: 'Bearer token' } });
+    const response = makeResponse();
+
+    await handlers.handleAuroraCredentials(request as never, response as never);
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toMatchObject({
+      credentials: [{ syncError: FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR }],
+    });
   });
 
   it('POST returns 409 + code when the account is already linked to another user', async () => {

--- a/packages/backend/src/handlers/aurora-credentials.ts
+++ b/packages/backend/src/handlers/aurora-credentials.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'http';
 import { z } from 'zod';
 import { isAuroraRequestError } from '@boardsesh/aurora-sync/api';
 import { AURORA_BOARDS } from '@boardsesh/shared-schema';
+import { circuitPlaylistSyncWireFields } from '@boardsesh/shared-schema/sync-error-codes';
 import { KILTER_BOARD_TYPE } from '@boardsesh/kilter-sync/api';
 import { applyCorsHeaders } from './cors';
 import { validateToken } from '../middleware/auth';
@@ -116,7 +117,12 @@ export async function handleAuroraCredentials(req: IncomingMessage, res: ServerR
 
   if (req.method === 'GET') {
     const credentials = await getAuroraCredentialStatuses(userId);
-    sendJson(res, 200, { credentials });
+    sendJson(res, 200, {
+      credentials: credentials.map((credential) => ({
+        ...credential,
+        ...circuitPlaylistSyncWireFields(credential.syncError),
+      })),
+    });
     return;
   }
 

--- a/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
+++ b/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
@@ -15,7 +15,7 @@ import * as Clipboard from 'expo-clipboard';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
-import { DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR } from '@boardsesh/shared-schema/sync-error-codes';
+import { circuitPlaylistSyncWarningKind } from '@boardsesh/shared-schema/sync-error-codes';
 import {
   AURORA_BOARDS,
   parseAuroraExportJson,
@@ -1074,11 +1074,19 @@ function BoardAccountCard({
   // client is expected to explain in the viewer's language (#3526). Everything
   // else in `sync_error` is still free text from an older path — those keep the
   // generic error pill rather than being swallowed.
-  const hasDuplicateAccountCircuits = credential?.syncError === DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR;
+  const circuitPlaylistWarning = circuitPlaylistSyncWarningKind(credential?.syncError ?? null);
+  const circuitPlaylistWarningCopy =
+    circuitPlaylistWarning === 'foreign'
+      ? t('aurora.status.foreignAccountCircuits')
+      : circuitPlaylistWarning === 'ambiguous'
+        ? t('aurora.status.ambiguousAccountCircuits')
+        : circuitPlaylistWarning === 'legacy'
+          ? t('aurora.status.duplicateAccountCircuits')
+          : null;
   // A warning, not a failure: the credential is active and syncing, only the
   // playlist mirror is paused. Red text here would tell a healthy account it is
   // broken, with nothing to act on.
-  const hasSyncFailure = Boolean(credential?.syncError) && !hasDuplicateAccountCircuits;
+  const hasSyncFailure = Boolean(credential?.syncError) && !circuitPlaylistWarning;
   const connectedLabel = credential?.auroraUsername
     ? t('aurora.mobile.connectedAs', { name: credential.auroraUsername })
     : t('aurora.mobile.connected');
@@ -1126,11 +1134,11 @@ function BoardAccountCard({
               {t('aurora.status.error')}
             </Text>
           ) : null}
-          {!isExpired && hasDuplicateAccountCircuits ? (
+          {!isExpired && circuitPlaylistWarningCopy ? (
             <View style={[styles.warningBlock, { backgroundColor: systemColors.tertiaryBackground }]}>
               <Icon name="warning" size={18} color={brandColors.warning} />
               <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.warningText}>
-                {t('aurora.status.duplicateAccountCircuits')}
+                {circuitPlaylistWarningCopy}
               </Text>
             </View>
           ) : null}

--- a/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
+++ b/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
@@ -1074,7 +1074,10 @@ function BoardAccountCard({
   // client is expected to explain in the viewer's language (#3526). Everything
   // else in `sync_error` is still free text from an older path — those keep the
   // generic error pill rather than being swallowed.
-  const circuitPlaylistWarning = circuitPlaylistSyncWarningKind(credential?.syncError ?? null);
+  const circuitPlaylistWarning = circuitPlaylistSyncWarningKind(
+    credential?.syncError ?? null,
+    credential?.syncErrorReason,
+  );
   const circuitPlaylistWarningCopy =
     circuitPlaylistWarning === 'foreign'
       ? t('aurora.status.foreignAccountCircuits')

--- a/packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
+++ b/packages/mobile/src/components/integrations/__tests__/BoardAccountsSection.test.tsx
@@ -2,7 +2,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
-import { DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR } from '@boardsesh/shared-schema/sync-error-codes';
+import {
+  AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+  DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+  FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+} from '@boardsesh/shared-schema/sync-error-codes';
 import type { AuroraCredentialStatus, AuroraCredentialsResponse } from '../../../lib/aurora-credentials';
 
 // --- Hoisted mock state, mutated per-test before render ---
@@ -406,15 +410,32 @@ describe('BoardAccountsSection — sync_error on a connected board card (#3526)'
     mocks.credentials = [];
   });
 
-  it('explains the duplicate board-account link instead of a bare red Error pill', () => {
-    mocks.credentials = [connectedCredential(DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR)];
+  it('explains a foreign-owned playlist without a bare red Error pill', () => {
+    mocks.credentials = [connectedCredential(FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR)];
     const { container } = render(<BoardAccountsSection />);
 
-    expect(container.textContent).toContain('aurora.status.duplicateAccountCircuits');
+    expect(container.textContent).toContain('aurora.status.foreignAccountCircuits');
     // The account is healthy and syncing — the generic failure copy would tell
     // this climber their board login is broken, with nothing to act on.
     expect(container.textContent).not.toContain('aurora.status.error');
     // And it never leaks the raw code to the card.
+    expect(container.textContent).not.toContain(FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR);
+  });
+
+  it('uses distinct copy for an already cross-linked playlist', () => {
+    mocks.credentials = [connectedCredential(AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR)];
+    const { container } = render(<BoardAccountsSection />);
+
+    expect(container.textContent).toContain('aurora.status.ambiguousAccountCircuits');
+    expect(container.textContent).not.toContain('aurora.status.foreignAccountCircuits');
+    expect(container.textContent).not.toContain(AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR);
+  });
+
+  it('keeps localising the legacy generic code already stored on credentials', () => {
+    mocks.credentials = [connectedCredential(DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR)];
+    const { container } = render(<BoardAccountsSection />);
+
+    expect(container.textContent).toContain('aurora.status.duplicateAccountCircuits');
     expect(container.textContent).not.toContain(DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR);
   });
 

--- a/packages/mobile/src/lib/aurora-credentials.ts
+++ b/packages/mobile/src/lib/aurora-credentials.ts
@@ -1,5 +1,6 @@
 import * as WebBrowser from 'expo-web-browser';
 import { type AuroraBoardName } from '@boardsesh/shared-schema';
+import type { CircuitPlaylistSyncErrorReason } from '@boardsesh/shared-schema/sync-error-codes';
 import type { ImportProgressEvent, ImportResult, StrippedAuroraExportData } from '@boardsesh/shared-schema';
 import { authenticatedFetch } from './auth-interceptor';
 import { parseDeepLinkQueryParams } from './deep-link-query';
@@ -15,6 +16,7 @@ export type AuroraCredentialStatus = {
   lastSyncAt: string | null;
   syncStatus: string;
   syncError: string | null;
+  syncErrorReason?: CircuitPlaylistSyncErrorReason;
   createdAt: string;
 };
 

--- a/packages/shared-schema/src/__tests__/sync-error-codes.test.ts
+++ b/packages/shared-schema/src/__tests__/sync-error-codes.test.ts
@@ -5,6 +5,7 @@ import {
   FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
   circuitPlaylistConflictSyncError,
   circuitPlaylistSyncWarningKind,
+  circuitPlaylistSyncWireFields,
 } from '../sync-error-codes';
 
 describe('circuit playlist sync error codes', () => {
@@ -20,5 +21,20 @@ describe('circuit playlist sync error codes', () => {
     expect(circuitPlaylistSyncWarningKind(DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR)).toBe('legacy');
     expect(circuitPlaylistSyncWarningKind('Refresh token rejected')).toBeNull();
     expect(circuitPlaylistSyncWarningKind(null)).toBeNull();
+  });
+
+  it('keeps the legacy code on the wire while preserving a precise reason for current clients', () => {
+    expect(circuitPlaylistSyncWireFields(FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR)).toEqual({
+      syncError: DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+      syncErrorReason: 'foreign',
+    });
+    expect(circuitPlaylistSyncWireFields(AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR)).toEqual({
+      syncError: DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+      syncErrorReason: 'ambiguous',
+    });
+    expect(circuitPlaylistSyncWireFields('Refresh token rejected')).toEqual({
+      syncError: 'Refresh token rejected',
+    });
+    expect(circuitPlaylistSyncWarningKind(DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR, 'foreign')).toBe('foreign');
   });
 });

--- a/packages/shared-schema/src/__tests__/sync-error-codes.test.ts
+++ b/packages/shared-schema/src/__tests__/sync-error-codes.test.ts
@@ -36,5 +36,8 @@ describe('circuit playlist sync error codes', () => {
       syncError: 'Refresh token rejected',
     });
     expect(circuitPlaylistSyncWarningKind(DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR, 'foreign')).toBe('foreign');
+    expect(circuitPlaylistSyncWarningKind(FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR, 'ambiguous')).toBe('foreign');
+    expect(circuitPlaylistSyncWarningKind('Refresh token rejected', 'foreign')).toBeNull();
+    expect(circuitPlaylistSyncWarningKind(null, 'ambiguous')).toBeNull();
   });
 });

--- a/packages/shared-schema/src/__tests__/sync-error-codes.test.ts
+++ b/packages/shared-schema/src/__tests__/sync-error-codes.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+  DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+  FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+  circuitPlaylistConflictSyncError,
+  circuitPlaylistSyncWarningKind,
+} from '../sync-error-codes';
+
+describe('circuit playlist sync error codes', () => {
+  it('encodes each persistent ownership state', () => {
+    expect(circuitPlaylistConflictSyncError('none')).toBeNull();
+    expect(circuitPlaylistConflictSyncError('foreign')).toBe(FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR);
+    expect(circuitPlaylistConflictSyncError('ambiguous')).toBe(AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR);
+  });
+
+  it('decodes current and legacy warning codes without swallowing unknown errors', () => {
+    expect(circuitPlaylistSyncWarningKind(FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR)).toBe('foreign');
+    expect(circuitPlaylistSyncWarningKind(AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR)).toBe('ambiguous');
+    expect(circuitPlaylistSyncWarningKind(DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR)).toBe('legacy');
+    expect(circuitPlaylistSyncWarningKind('Refresh token rejected')).toBeNull();
+    expect(circuitPlaylistSyncWarningKind(null)).toBeNull();
+  });
+});

--- a/packages/shared-schema/src/sync-error-codes.ts
+++ b/packages/shared-schema/src/sync-error-codes.ts
@@ -59,7 +59,10 @@ export function circuitPlaylistSyncWarningKind(
   syncError: string | null,
   syncErrorReason?: CircuitPlaylistSyncErrorReason,
 ): CircuitPlaylistSyncWarningKind | null {
-  if (syncErrorReason) return syncErrorReason;
+  // `syncErrorReason` crosses a REST boundary. Only trust it alongside the
+  // generic compatibility code that `circuitPlaylistSyncWireFields` emits;
+  // precise stored codes remain authoritative even if a response is malformed.
+  if (syncError === DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR && syncErrorReason) return syncErrorReason;
   if (syncError === FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR) return 'foreign';
   if (syncError === AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR) return 'ambiguous';
   if (syncError === DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR) return 'legacy';

--- a/packages/shared-schema/src/sync-error-codes.ts
+++ b/packages/shared-schema/src/sync-error-codes.ts
@@ -22,5 +22,47 @@
  */
 export const DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR = 'duplicate-board-account-link:circuits';
 
+/**
+ * This account cannot claim the circuit playlists because another Boardsesh
+ * user is their sole owner.
+ */
+export const FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR = 'duplicate-board-account-link:circuits:foreign';
+
+/**
+ * The syncing user and at least one other Boardsesh user both hold owner edges
+ * on a circuit playlist. Neither side may write until the legacy cross-link is
+ * resolved.
+ */
+export const AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR = 'duplicate-board-account-link:circuits:ambiguous';
+
+/** Persistent ownership state for one credential's Aurora circuit playlists. */
+export type CircuitPlaylistOwnershipConflictState = 'none' | 'foreign' | 'ambiguous';
+
+/** The warning variants mobile and web know how to localise. */
+export type CircuitPlaylistSyncWarningKind = Exclude<CircuitPlaylistOwnershipConflictState, 'none'> | 'legacy';
+
+/** Convert a fresh ownership-state read to the code persisted by the runner. */
+export function circuitPlaylistConflictSyncError(
+  state: CircuitPlaylistOwnershipConflictState,
+): typeof FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR | typeof AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR | null {
+  if (state === 'foreign') return FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR;
+  if (state === 'ambiguous') return AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR;
+  return null;
+}
+
+/**
+ * Decode both current codes and the pre-#3950 generic value. Unknown/free-text
+ * errors deliberately return null so clients continue rendering them verbatim.
+ */
+export function circuitPlaylistSyncWarningKind(syncError: string | null): CircuitPlaylistSyncWarningKind | null {
+  if (syncError === FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR) return 'foreign';
+  if (syncError === AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR) return 'ambiguous';
+  if (syncError === DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR) return 'legacy';
+  return null;
+}
+
 /** Every `sync_error` value clients are expected to recognise and localise. */
-export type SyncErrorCode = typeof DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR;
+export type SyncErrorCode =
+  | typeof DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR
+  | typeof FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR
+  | typeof AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR;

--- a/packages/shared-schema/src/sync-error-codes.ts
+++ b/packages/shared-schema/src/sync-error-codes.ts
@@ -37,6 +37,7 @@ export const AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR = 'duplicate-board-acco
 
 /** Persistent ownership state for one credential's Aurora circuit playlists. */
 export type CircuitPlaylistOwnershipConflictState = 'none' | 'foreign' | 'ambiguous';
+export type CircuitPlaylistSyncErrorReason = Exclude<CircuitPlaylistOwnershipConflictState, 'none'>;
 
 /** The warning variants mobile and web know how to localise. */
 export type CircuitPlaylistSyncWarningKind = Exclude<CircuitPlaylistOwnershipConflictState, 'none'> | 'legacy';
@@ -54,11 +55,36 @@ export function circuitPlaylistConflictSyncError(
  * Decode both current codes and the pre-#3950 generic value. Unknown/free-text
  * errors deliberately return null so clients continue rendering them verbatim.
  */
-export function circuitPlaylistSyncWarningKind(syncError: string | null): CircuitPlaylistSyncWarningKind | null {
+export function circuitPlaylistSyncWarningKind(
+  syncError: string | null,
+  syncErrorReason?: CircuitPlaylistSyncErrorReason,
+): CircuitPlaylistSyncWarningKind | null {
+  if (syncErrorReason) return syncErrorReason;
   if (syncError === FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR) return 'foreign';
   if (syncError === AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR) return 'ambiguous';
   if (syncError === DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR) return 'legacy';
   return null;
+}
+
+export type CircuitPlaylistSyncWireFields = {
+  syncError: string | null;
+  syncErrorReason?: CircuitPlaylistSyncErrorReason;
+};
+
+/**
+ * Keep the long-standing generic code on the REST wire so older clients still
+ * render their localised duplicate-account warning. Current clients receive a
+ * separate reason field for the more precise foreign/ambiguous copy.
+ */
+export function circuitPlaylistSyncWireFields(syncError: string | null): CircuitPlaylistSyncWireFields {
+  const warningKind = circuitPlaylistSyncWarningKind(syncError);
+  if (warningKind === 'foreign' || warningKind === 'ambiguous') {
+    return {
+      syncError: DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+      syncErrorReason: warningKind,
+    };
+  }
+  return { syncError };
 }
 
 /** Every `sync_error` value clients are expected to recognise and localise. */

--- a/packages/shared/i18n/locales/de/settings.json
+++ b/packages/shared/i18n/locales/de/settings.json
@@ -192,7 +192,9 @@
       "error": "Fehler",
       "expired": "Abgelaufen",
       "syncing": "Wird synchronisiert",
-      "duplicateAccountCircuits": "Circuits synchronisieren gerade nicht: Ein anderes Boardsesh-Konto hängt an diesem Board-Login, deshalb pausiert die Playlist-Sync für euch beide. Deine Begehungen und Bewertungen kommen weiter an."
+      "duplicateAccountCircuits": "Circuits synchronisieren gerade nicht: Ein anderes Boardsesh-Konto hängt an diesem Board-Login, deshalb pausiert die Playlist-Sync für euch beide. Deine Begehungen und Bewertungen kommen weiter an.",
+      "foreignAccountCircuits": "Circuits synchronisieren auf diesem Konto gerade nicht, weil die passenden Playlists einem anderen Boardsesh-Konto gehören. Deine Begehungen und Bewertungen kommen weiter an. Schreib dem Boardsesh-Support, damit wir klären, wem die Playlists gehören.",
+      "ambiguousAccountCircuits": "Circuits synchronisieren gerade nicht, weil die passenden Playlists mehreren Boardsesh-Konten gehören. Deine Begehungen und Bewertungen kommen weiter an. Schreib dem Boardsesh-Support, damit wir klären, wem die Playlists gehören."
     },
     "unsynced": {
       "title_one": "{{count}} Eintrag wartet auf die Sync",

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -192,7 +192,9 @@
       "error": "Error",
       "expired": "Expired",
       "syncing": "Syncing",
-      "duplicateAccountCircuits": "Circuits aren't syncing: another Boardsesh account is connected to this board login, so playlist sync is paused for both of you. Your sends and ratings still come through."
+      "duplicateAccountCircuits": "Circuits aren't syncing: another Boardsesh account is connected to this board login, so playlist sync is paused for both of you. Your sends and ratings still come through.",
+      "foreignAccountCircuits": "Circuits aren't syncing on this account because another Boardsesh account owns the matching playlists. Your sends and ratings still come through. Contact Boardsesh support to resolve playlist ownership.",
+      "ambiguousAccountCircuits": "Circuits aren't syncing because the matching playlists have multiple Boardsesh owners. Your sends and ratings still come through. Contact Boardsesh support to resolve playlist ownership."
     },
     "unsynced": {
       "title_one": "{{count}} item pending sync",

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -192,7 +192,9 @@
       "error": "Error",
       "expired": "Caducado",
       "syncing": "Sincronizando",
-      "duplicateAccountCircuits": "Los circuitos no se están sincronizando: otra cuenta de Boardsesh usa este mismo inicio de sesión del plafón, así que la sincronización de playlists está en pausa para las dos. Tus encadenes y valoraciones siguen llegando."
+      "duplicateAccountCircuits": "Los circuitos no se están sincronizando: otra cuenta de Boardsesh usa este mismo inicio de sesión del plafón, así que la sincronización de playlists está en pausa para las dos. Tus encadenes y valoraciones siguen llegando.",
+      "foreignAccountCircuits": "Los circuitos no se están sincronizando en esta cuenta porque otra cuenta de Boardsesh tiene las playlists correspondientes. Tus encadenes y valoraciones siguen llegando. Contacta con el soporte de Boardsesh para resolver la propiedad de las playlists.",
+      "ambiguousAccountCircuits": "Los circuitos no se están sincronizando porque las playlists correspondientes pertenecen a varias cuentas de Boardsesh. Tus encadenes y valoraciones siguen llegando. Contacta con el soporte de Boardsesh para resolver la propiedad de las playlists."
     },
     "unsynced": {
       "title_one": "{{count}} elemento pendiente de sincronizar",

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -192,7 +192,9 @@
       "error": "Erreur",
       "expired": "Expiré",
       "syncing": "Synchronisation",
-      "duplicateAccountCircuits": "Les circuits ne se synchronisent pas : un autre compte Boardsesh utilise les mêmes identifiants de board, donc la synchro des playlists est en pause des deux côtés. Vos croix et vos notes continuent d'arriver."
+      "duplicateAccountCircuits": "Les circuits ne se synchronisent pas : un autre compte Boardsesh utilise les mêmes identifiants de board, donc la synchro des playlists est en pause des deux côtés. Vos croix et vos notes continuent d'arriver.",
+      "foreignAccountCircuits": "Les circuits ne se synchronisent pas sur ce compte, car un autre compte Boardsesh possède les playlists correspondantes. Vos croix et vos notes continuent d'arriver. Contactez l'assistance Boardsesh pour régler la propriété des playlists.",
+      "ambiguousAccountCircuits": "Les circuits ne se synchronisent pas, car les playlists correspondantes appartiennent à plusieurs comptes Boardsesh. Vos croix et vos notes continuent d'arriver. Contactez l'assistance Boardsesh pour régler la propriété des playlists."
     },
     "unsynced": {
       "title_one": "{{count}} élément en attente de synchro",

--- a/packages/web/app/components/settings/__tests__/aurora-credentials-section.test.tsx
+++ b/packages/web/app/components/settings/__tests__/aurora-credentials-section.test.tsx
@@ -2,11 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
-import {
-  AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
-  DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
-  FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
-} from '@boardsesh/shared-schema/sync-error-codes';
+import { DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR } from '@boardsesh/shared-schema/sync-error-codes';
 
 // --- Hoisted mocks ---
 const mockSaveKilterViaPassword = vi.fn();
@@ -262,7 +258,7 @@ describe('AuroraCredentialsSection', () => {
   });
 
   describe('circuit playlist ownership warnings (#3950)', () => {
-    function mockConnectedCredential(syncError: string | null) {
+    function mockConnectedCredential(syncError: string | null, syncErrorReason?: 'foreign' | 'ambiguous') {
       mockGetAuroraCredentials.mockResolvedValue({
         credentials: [
           {
@@ -272,6 +268,7 @@ describe('AuroraCredentialsSection', () => {
             syncStatus: 'active',
             lastSyncAt: '2026-07-25T00:00:00.000Z',
             syncError,
+            syncErrorReason,
             createdAt: '2026-01-01T00:00:00.000Z',
           },
         ],
@@ -279,19 +276,19 @@ describe('AuroraCredentialsSection', () => {
     }
 
     it('shows distinct copy for a foreign owner', async () => {
-      mockConnectedCredential(FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR);
+      mockConnectedCredential(DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR, 'foreign');
       render(<AuroraCredentialsSection />);
 
       expect(await screen.findByText(tFromCatalog('settings', 'aurora.status.foreignAccountCircuits'))).toBeTruthy();
-      expect(screen.queryByText(FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR)).toBeNull();
+      expect(screen.queryByText(DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR)).toBeNull();
     });
 
     it('shows distinct copy for ambiguous owners', async () => {
-      mockConnectedCredential(AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR);
+      mockConnectedCredential(DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR, 'ambiguous');
       render(<AuroraCredentialsSection />);
 
       expect(await screen.findByText(tFromCatalog('settings', 'aurora.status.ambiguousAccountCircuits'))).toBeTruthy();
-      expect(screen.queryByText(AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR)).toBeNull();
+      expect(screen.queryByText(DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR)).toBeNull();
     });
 
     it('still localises the legacy generic value already stored in sync_error', async () => {
@@ -303,7 +300,7 @@ describe('AuroraCredentialsSection', () => {
     });
 
     it('keeps rendering an unknown legacy error verbatim', async () => {
-      mockConnectedCredential('Refresh token rejected by Keycloak');
+      mockConnectedCredential('Refresh token rejected by Keycloak', 'foreign');
       render(<AuroraCredentialsSection />);
 
       expect(await screen.findByText('Refresh token rejected by Keycloak')).toBeTruthy();

--- a/packages/web/app/components/settings/__tests__/aurora-credentials-section.test.tsx
+++ b/packages/web/app/components/settings/__tests__/aurora-credentials-section.test.tsx
@@ -2,6 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import {
+  AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+  DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+  FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR,
+} from '@boardsesh/shared-schema/sync-error-codes';
 
 // --- Hoisted mocks ---
 const mockSaveKilterViaPassword = vi.fn();
@@ -253,6 +258,55 @@ describe('AuroraCredentialsSection', () => {
       const reconnectIdx = buttons.findIndex((b) => b.textContent?.includes('Reconnect'));
       const unlinkIdx = buttons.findIndex((b) => b.textContent?.includes('Unlink'));
       expect(reconnectIdx).toBeLessThan(unlinkIdx);
+    });
+  });
+
+  describe('circuit playlist ownership warnings (#3950)', () => {
+    function mockConnectedCredential(syncError: string | null) {
+      mockGetAuroraCredentials.mockResolvedValue({
+        credentials: [
+          {
+            boardType: 'tension',
+            auroraUsername: 'climber',
+            auroraUserId: 144574,
+            syncStatus: 'active',
+            lastSyncAt: '2026-07-25T00:00:00.000Z',
+            syncError,
+            createdAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      });
+    }
+
+    it('shows distinct copy for a foreign owner', async () => {
+      mockConnectedCredential(FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR);
+      render(<AuroraCredentialsSection />);
+
+      expect(await screen.findByText(tFromCatalog('settings', 'aurora.status.foreignAccountCircuits'))).toBeTruthy();
+      expect(screen.queryByText(FOREIGN_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR)).toBeNull();
+    });
+
+    it('shows distinct copy for ambiguous owners', async () => {
+      mockConnectedCredential(AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR);
+      render(<AuroraCredentialsSection />);
+
+      expect(await screen.findByText(tFromCatalog('settings', 'aurora.status.ambiguousAccountCircuits'))).toBeTruthy();
+      expect(screen.queryByText(AMBIGUOUS_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR)).toBeNull();
+    });
+
+    it('still localises the legacy generic value already stored in sync_error', async () => {
+      mockConnectedCredential(DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR);
+      render(<AuroraCredentialsSection />);
+
+      expect(await screen.findByText(tFromCatalog('settings', 'aurora.status.duplicateAccountCircuits'))).toBeTruthy();
+      expect(screen.queryByText(DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR)).toBeNull();
+    });
+
+    it('keeps rendering an unknown legacy error verbatim', async () => {
+      mockConnectedCredential('Refresh token rejected by Keycloak');
+      render(<AuroraCredentialsSection />);
+
+      expect(await screen.findByText('Refresh token rejected by Keycloak')).toBeTruthy();
     });
   });
 });

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -38,7 +38,7 @@ import { useSession } from 'next-auth/react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Trans, useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
-import { DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR } from '@boardsesh/shared-schema/sync-error-codes';
+import { circuitPlaylistSyncWarningKind } from '@boardsesh/shared-schema/sync-error-codes';
 import {
   AuroraBackendError,
   deleteAuroraCredential,
@@ -248,6 +248,16 @@ export function BoardCredentialCard({
     return date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
   };
 
+  const circuitPlaylistWarning = circuitPlaylistSyncWarningKind(credential?.syncError ?? null);
+  const circuitPlaylistWarningCopy =
+    circuitPlaylistWarning === 'foreign'
+      ? t('aurora.status.foreignAccountCircuits')
+      : circuitPlaylistWarning === 'ambiguous'
+        ? t('aurora.status.ambiguousAccountCircuits')
+        : circuitPlaylistWarning === 'legacy'
+          ? t('aurora.status.duplicateAccountCircuits')
+          : null;
+
   if (!credential) {
     return (
       <Card className={styles.credentialCard}>
@@ -356,14 +366,8 @@ export function BoardCredentialCard({
                   syncing, only its playlist mirror is paused (#3526). Anything else
                   is legacy free text from an older path: render it verbatim rather
                   than swallow it. */}
-              <Typography
-                variant="body2"
-                component="span"
-                color={credential.syncError === DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR ? 'warning.main' : 'error'}
-              >
-                {credential.syncError === DUPLICATE_BOARD_ACCOUNT_CIRCUITS_SYNC_ERROR
-                  ? t('aurora.status.duplicateAccountCircuits')
-                  : credential.syncError}
+              <Typography variant="body2" component="span" color={circuitPlaylistWarning ? 'warning.main' : 'error'}>
+                {circuitPlaylistWarningCopy ?? credential.syncError}
               </Typography>
             </div>
           )}

--- a/packages/web/app/components/settings/aurora-credentials-section.tsx
+++ b/packages/web/app/components/settings/aurora-credentials-section.tsx
@@ -248,7 +248,10 @@ export function BoardCredentialCard({
     return date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
   };
 
-  const circuitPlaylistWarning = circuitPlaylistSyncWarningKind(credential?.syncError ?? null);
+  const circuitPlaylistWarning = circuitPlaylistSyncWarningKind(
+    credential?.syncError ?? null,
+    credential?.syncErrorReason,
+  );
   const circuitPlaylistWarningCopy =
     circuitPlaylistWarning === 'foreign'
       ? t('aurora.status.foreignAccountCircuits')

--- a/packages/web/app/lib/aurora-credentials/client.ts
+++ b/packages/web/app/lib/aurora-credentials/client.ts
@@ -1,5 +1,6 @@
 import { getBackendHttpUrl } from '@/app/lib/backend-url';
 import type { AuroraBoardName } from '@boardsesh/shared-schema';
+import type { CircuitPlaylistSyncErrorReason } from '@boardsesh/shared-schema/sync-error-codes';
 
 export type AuroraCredentialStatus = {
   boardType: string;
@@ -8,6 +9,7 @@ export type AuroraCredentialStatus = {
   lastSyncAt: string | null;
   syncStatus: string;
   syncError: string | null;
+  syncErrorReason?: CircuitPlaylistSyncErrorReason;
   createdAt: string;
 };
 

--- a/packages/web/app/lib/data-sync/aurora/__tests__/user-sync-circuits.test.ts
+++ b/packages/web/app/lib/data-sync/aurora/__tests__/user-sync-circuits.test.ts
@@ -25,7 +25,11 @@ import { upsertTableData } from '../user-sync';
  * exists because without it, deleting the guard block here passes every other
  * test in the repo.
  */
-type DbCall = { kind: 'select' | 'insert' | 'delete' | 'conflict' | 'execute'; table?: unknown; args: unknown[] };
+type DbCall = {
+  kind: 'select' | 'insert' | 'delete' | 'conflict' | 'execute' | 'transaction';
+  table?: unknown;
+  args: unknown[];
+};
 
 function createDbShim(opts: {
   owners?: Array<Record<string, unknown>>;
@@ -35,6 +39,14 @@ function createDbShim(opts: {
   const calls: DbCall[] = [];
   let selectIndex = 0;
   const db = {
+    // The circuits branch opens its own transaction so the advisory locks are
+    // always held by one. The shim records the call (a test asserts the locks
+    // run inside it) and hands the same handle back, standing in for the
+    // savepoint a real nested `db.transaction` would open.
+    transaction<T>(run: (tx: unknown) => Promise<T>) {
+      calls.push({ kind: 'transaction', args: [] });
+      return run(db);
+    },
     execute(statement: unknown) {
       calls.push({ kind: 'execute', args: [statement] });
       return Promise.resolve([]);
@@ -182,6 +194,19 @@ describe('web aurora proxy — circuits foreign-owner guard (#3526)', () => {
     expect(warn.mock.calls[0]?.[0]).toContain('"reason":"foreign"');
   });
 
+  it('opens its own transaction before taking any advisory lock', async () => {
+    const { db, calls } = createDbShim({ owners: [] });
+
+    await upsertTableData(db as never, 'tension', 'circuits', 144574, 'user-1', [circuit] as never);
+
+    // pg_advisory_xact_lock protects nothing outside an explicit transaction —
+    // the statement commits on its own and the lock drops immediately. The
+    // branch must make the handle transactional itself rather than trusting
+    // every caller to have done it.
+    expect(calls[0]).toEqual({ kind: 'transaction', args: [] });
+    expect(calls[1]?.kind).toBe('execute');
+  });
+
   it('takes the shared advisory locks in sorted UUID order before every source write', async () => {
     const { db, calls } = createDbShim({ owners: [], returning: [{ id: BigInt(1) }] });
     const laterCircuit = { ...circuit, uuid: 'z-circuit', name: 'later' };
@@ -195,7 +220,8 @@ describe('web aurora proxy — circuits foreign-owner guard (#3526)', () => {
     const executeCalls = calls.filter((call) => call.kind === 'execute');
     const firstInsertIndex = calls.findIndex((call) => call.kind === 'insert');
     expect(executeCalls).toHaveLength(2);
-    expect(calls.slice(0, firstInsertIndex).every((call) => call.kind === 'execute')).toBe(true);
+    expect(calls[0]?.kind).toBe('transaction');
+    expect(calls.slice(1, firstInsertIndex).every((call) => call.kind === 'execute')).toBe(true);
     const sourceWrites = calls
       .filter((call) => call.kind === 'insert' && call.table === boardCircuits)
       .map((call) => call.args[0] as { uuid?: string })
@@ -220,7 +246,7 @@ describe('web aurora proxy — circuits foreign-owner guard (#3526)', () => {
       { warn: vi.fn(), error },
     );
 
-    expect(calls).toHaveLength(0);
+    expect(calls.filter((call) => call.kind !== 'transaction')).toHaveLength(0);
     expect(error).toHaveBeenCalledTimes(1);
     const logLine = error.mock.calls[0]?.[0] ?? '';
     expect(JSON.parse(logLine)).toEqual({

--- a/packages/web/app/lib/data-sync/aurora/__tests__/user-sync-circuits.test.ts
+++ b/packages/web/app/lib/data-sync/aurora/__tests__/user-sync-circuits.test.ts
@@ -5,8 +5,13 @@ vi.mock('server-only', () => ({}));
 // The module imports getDb at load time, which opens a pool. Every test drives
 // upsertTableData with an explicit shim db, so the real one is never used.
 vi.mock('@/app/lib/db/db', () => ({ getDb: () => ({}) }));
+vi.mock('../../../api-wrappers/aurora/userSync', () => ({ userSync: vi.fn() }));
+vi.mock('@boardsesh/aurora-sync/apply-user-logbook', () => ({
+  applyAuroraAscents: vi.fn(),
+  applyAuroraBids: vi.fn(),
+}));
 
-import { playlists, playlistClimbs, playlistOwnership } from '../../../db/schema';
+import { boardCircuits, playlists, playlistClimbs, playlistOwnership } from '../../../db/schema';
 import { upsertTableData } from '../user-sync';
 
 /**
@@ -20,15 +25,25 @@ import { upsertTableData } from '../user-sync';
  * exists because without it, deleting the guard block here passes every other
  * test in the repo.
  */
-type DbCall = { kind: 'select' | 'insert' | 'delete' | 'conflict'; table?: unknown; args: unknown[] };
+type DbCall = { kind: 'select' | 'insert' | 'delete' | 'conflict' | 'execute'; table?: unknown; args: unknown[] };
 
-function createDbShim(opts: { owners?: Array<Record<string, unknown>>; returning?: Array<Record<string, unknown>> }) {
+function createDbShim(opts: {
+  owners?: Array<Record<string, unknown>>;
+  ownerResults?: Array<Array<Record<string, unknown>>>;
+  returning?: Array<Record<string, unknown>>;
+}) {
   const calls: DbCall[] = [];
+  let selectIndex = 0;
   const db = {
+    execute(statement: unknown) {
+      calls.push({ kind: 'execute', args: [statement] });
+      return Promise.resolve([]);
+    },
     select(cols: unknown) {
       calls.push({ kind: 'select', args: [cols] });
+      const rows = opts.ownerResults?.[selectIndex++] ?? opts.owners ?? [];
       const source = {
-        where: () => Promise.resolve(opts.owners ?? []),
+        where: () => Promise.resolve(rows),
         leftJoin: () => source,
         innerJoin: () => source,
       };
@@ -124,12 +139,119 @@ describe('web aurora proxy — circuits foreign-owner guard (#3526)', () => {
   });
 
   it('abandons the item when the race guard suppresses the upsert', async () => {
+    const error = vi.fn();
     const { db, calls, insertsInto } = createDbShim({ owners: [], returning: [] });
 
-    await upsertTableData(db as never, 'tension', 'circuits', 144574, 'user-1', [circuit] as never);
+    await upsertTableData(db as never, 'tension', 'circuits', 144574, 'user-1', [circuit] as never, {
+      warn: vi.fn(),
+      error,
+    });
 
     expect(insertsInto(playlistOwnership)).toHaveLength(0);
     expect(insertsInto(playlistClimbs)).toHaveLength(0);
     expect(calls.filter((call) => call.kind === 'delete')).toHaveLength(0);
+    expect(calls.filter((call) => call.kind === 'select')).toHaveLength(2);
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(error.mock.calls[0]?.[0] ?? '{}')).toEqual({
+      level: 'error',
+      event: 'aurora_circuit_playlist_suppressed_without_foreign_owner',
+      boardType: 'tension',
+      circuitUuid: 'circuit-1',
+      syncingUserId: 'user-1',
+      stage: 'suppressed-upsert',
+      reason: 'no-owner',
+    });
+  });
+
+  it('re-reads and reports a foreign owner when the SQL guard suppresses the upsert', async () => {
+    const warn = vi.fn();
+    const { db, calls, insertsInto } = createDbShim({
+      ownerResults: [[], [{ upstreamId: 'circuit-1', ownerUserId: 'user-2' }]],
+      returning: [],
+    });
+
+    await upsertTableData(db as never, 'tension', 'circuits', 144574, 'user-1', [circuit] as never, {
+      warn,
+      error: vi.fn(),
+    });
+
+    expect(calls.filter((call) => call.kind === 'select')).toHaveLength(2);
+    expect(insertsInto(playlistOwnership)).toHaveLength(0);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain('"stage":"suppressed-upsert"');
+    expect(warn.mock.calls[0]?.[0]).toContain('"reason":"foreign"');
+  });
+
+  it('takes the shared advisory locks in sorted UUID order before every source write', async () => {
+    const { db, calls } = createDbShim({ owners: [], returning: [{ id: BigInt(1) }] });
+    const laterCircuit = { ...circuit, uuid: 'z-circuit', name: 'later' };
+    const earlierCircuit = { ...circuit, uuid: 'a-circuit', name: 'earlier' };
+
+    await upsertTableData(db as never, 'tension', 'circuits', 144574, 'user-1', [
+      laterCircuit,
+      earlierCircuit,
+    ] as never);
+
+    const executeCalls = calls.filter((call) => call.kind === 'execute');
+    const firstInsertIndex = calls.findIndex((call) => call.kind === 'insert');
+    expect(executeCalls).toHaveLength(2);
+    expect(calls.slice(0, firstInsertIndex).every((call) => call.kind === 'execute')).toBe(true);
+    const sourceWrites = calls
+      .filter((call) => call.kind === 'insert' && call.table === boardCircuits)
+      .map((call) => call.args[0] as { uuid?: string })
+      .filter((row) => row.uuid === 'a-circuit' || row.uuid === 'z-circuit');
+    expect(sourceWrites.map((row) => row.uuid)).toEqual(['a-circuit', 'z-circuit']);
+  });
+
+  it('filters malformed UUIDs before locks or writes and reports only a safe count', async () => {
+    const error = vi.fn();
+    const { db, calls } = createDbShim({ owners: [] });
+
+    await upsertTableData(
+      db as never,
+      'tension',
+      'circuits',
+      144574,
+      'user-1',
+      [
+        { ...circuit, uuid: 42 },
+        { name: 'missing uuid', secret: 'do-not-log' },
+      ] as never,
+      { warn: vi.fn(), error },
+    );
+
+    expect(calls).toHaveLength(0);
+    expect(error).toHaveBeenCalledTimes(1);
+    const logLine = error.mock.calls[0]?.[0] ?? '';
+    expect(JSON.parse(logLine)).toEqual({
+      level: 'error',
+      event: 'aurora_circuit_playlist_malformed_payload',
+      boardType: 'tension',
+      rejectedCount: 2,
+    });
+    expect(logLine).not.toContain('do-not-log');
+  });
+
+  it('de-duplicates last-row-wins before locking and writing', async () => {
+    const { db, calls } = createDbShim({ owners: [] });
+
+    await upsertTableData(db as never, 'tension', 'circuits', 144574, '', [
+      { ...circuit, name: 'old' },
+      { ...circuit, name: 'new' },
+    ] as never);
+
+    expect(calls.filter((call) => call.kind === 'execute')).toHaveLength(1);
+    const sourceInsert = calls.find((call) => call.kind === 'insert');
+    expect(sourceInsert?.args[0]).toMatchObject({ uuid: 'circuit-1', name: 'new' });
+  });
+
+  it('promotes an existing viewer/editor edge to owner', async () => {
+    const { db, calls } = createDbShim({ owners: [] });
+
+    await upsertTableData(db as never, 'tension', 'circuits', 144574, 'user-1', [circuit] as never);
+
+    const ownershipConflict = calls.find((call) => call.kind === 'conflict' && call.table === playlistOwnership)
+      ?.args[0] as { set?: { role?: string } } | undefined;
+    expect(ownershipConflict?.set).toEqual({ role: 'owner' });
   });
 });

--- a/packages/web/app/lib/data-sync/aurora/__tests__/user-sync.cross-writer.integration.test.ts
+++ b/packages/web/app/lib/data-sync/aurora/__tests__/user-sync.cross-writer.integration.test.ts
@@ -1,0 +1,181 @@
+// @vitest-environment node
+// Real-PostgreSQL daemon↔legacy-web arbitration coverage for issue #3950.
+// It self-skips in the infra-less default test job and is required explicitly
+// by CI's named Aurora circuit database gate.
+
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import { and, eq, inArray } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { boardCircuits, boardUsers, playlistClimbs, playlistOwnership, playlists, users } from '@boardsesh/db/schema';
+import { upsertTableData as daemonUpsertTableData } from '@boardsesh/aurora-sync/sync';
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/app/lib/db/db', () => ({ getDb: () => ({}) }));
+
+import { upsertTableData as webUpsertTableData } from '../user-sync';
+
+function localDatabaseUrl(): string | null {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) return null;
+  try {
+    const hostname = new URL(databaseUrl).hostname.toLowerCase();
+    return ['localhost', '127.0.0.1', 'postgres'].includes(hostname) ? databaseUrl : null;
+  } catch {
+    return null;
+  }
+}
+
+const integrationRequired = process.env.REQUIRE_AURORA_CIRCUIT_INTEGRATION === '1';
+const describeIntegration = localDatabaseUrl() || integrationRequired ? describe : describe.skip;
+
+/** Release both claimants only after both outer transactions are open. */
+function createBarrier(participantCount: number): () => Promise<void> {
+  let arrived = 0;
+  let release: (() => void) | undefined;
+  const ready = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return async () => {
+    arrived += 1;
+    if (arrived === participantCount) release?.();
+    await ready;
+  };
+}
+
+describeIntegration('Aurora daemon ↔ web circuit ownership arbitration (#3950)', () => {
+  it('gives one concurrent cross-surface claimant sole ownership and preserves its climbs', async (testContext) => {
+    const databaseUrl = localDatabaseUrl();
+    if (!databaseUrl) {
+      if (integrationRequired) {
+        throw new Error('REQUIRE_AURORA_CIRCUIT_INTEGRATION=1 requires DATABASE_URL to point at local PostgreSQL');
+      }
+      testContext.skip('set DATABASE_URL to a local, migrated PostgreSQL database to run issue #3950 coverage');
+      return;
+    }
+
+    const client = postgres(databaseUrl, { max: 4, prepare: false, idle_timeout: 5, onnotice: () => {} });
+    const db = drizzle(client);
+    const [{ ready }] = await client<{ ready: boolean }[]>`
+      SELECT
+        to_regclass('public.board_circuits') IS NOT NULL
+        AND to_regclass('public.playlists_aurora_id_idx') IS NOT NULL
+        AND to_regclass('public.unique_playlist_ownership') IS NOT NULL AS ready
+    `;
+    if (!ready) {
+      await client.end();
+      const reason = 'local PostgreSQL schema is not current for daemon/web circuit arbitration';
+      if (integrationRequired) throw new Error(reason);
+      testContext.skip(reason);
+      return;
+    }
+
+    const testTag = randomUUID();
+    const circuitUuid = `issue-3950-cross-writer-${testTag}`;
+    const userIds = [`issue-3950-daemon-${testTag}`, `issue-3950-web-${testTag}`] as const;
+    const climbUuids = [`issue-3950-daemon-climb-${testTag}`, `issue-3950-web-climb-${testTag}`] as const;
+    let auroraUserId: number | undefined;
+
+    try {
+      await db.insert(users).values([
+        { id: userIds[0], email: `${userIds[0]}@example.invalid` },
+        { id: userIds[1], email: `${userIds[1]}@example.invalid` },
+      ]);
+
+      const candidateBase = 1_700_000_000 + (Number.parseInt(testTag.slice(0, 7), 16) % 100_000_000);
+      for (let attempt = 0; attempt < 20 && auroraUserId === undefined; attempt += 1) {
+        const inserted = await db
+          .insert(boardUsers)
+          .values({
+            boardType: 'tension',
+            id: candidateBase + attempt,
+            username: `issue-3950-cross-writer-${testTag}`,
+          })
+          .onConflictDoNothing()
+          .returning({ id: boardUsers.id });
+        auroraUserId = inserted[0]?.id;
+      }
+      if (auroraUserId === undefined) throw new Error('Could not allocate a board user fixture');
+      const claimedAuroraUserId = auroraUserId;
+
+      const awaitBothTransactions = createBarrier(2);
+      const daemonLogs: string[] = [];
+      const webWarnings: string[] = [];
+      const daemonRow = {
+        uuid: circuitUuid,
+        name: 'Daemon claim',
+        description: '',
+        color: '',
+        is_public: '',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        climbs: [{ climb_uuid: climbUuids[0] }],
+      };
+      const webRow = {
+        ...daemonRow,
+        name: 'Web claim',
+        climbs: [{ climb_uuid: climbUuids[1] }],
+      };
+
+      const daemonClaim = db.transaction(async (transaction) => {
+        await awaitBothTransactions();
+        return daemonUpsertTableData(
+          transaction as never,
+          'tension',
+          'circuits',
+          claimedAuroraUserId,
+          userIds[0],
+          [daemonRow] as never,
+          (message) => daemonLogs.push(message),
+        );
+      });
+      const webClaim = db.transaction(async (transaction) => {
+        await awaitBothTransactions();
+        await webUpsertTableData(
+          transaction as never,
+          'tension',
+          'circuits',
+          claimedAuroraUserId,
+          userIds[1],
+          [webRow] as never,
+          { warn: (message) => webWarnings.push(message), error: (message) => webWarnings.push(message) },
+        );
+      });
+
+      const [daemonOutcome] = await Promise.all([daemonClaim, webClaim]);
+      const ownerRows = await db
+        .select({ userId: playlistOwnership.userId })
+        .from(playlists)
+        .innerJoin(playlistOwnership, eq(playlistOwnership.playlistId, playlists.id))
+        .where(and(eq(playlists.auroraId, circuitUuid), eq(playlistOwnership.role, 'owner')));
+      expect(ownerRows).toHaveLength(1);
+      expect(userIds).toContain(ownerRows[0]?.userId);
+
+      const winnerIndex = ownerRows[0]?.userId === userIds[0] ? 0 : 1;
+      const climbRows = await db
+        .select({ climbUuid: playlistClimbs.climbUuid })
+        .from(playlists)
+        .innerJoin(playlistClimbs, eq(playlistClimbs.playlistId, playlists.id))
+        .where(eq(playlists.auroraId, circuitUuid));
+      expect(climbRows).toEqual([{ climbUuid: climbUuids[winnerIndex] }]);
+
+      if (winnerIndex === 0) {
+        expect(webWarnings.some((message) => message.includes('"reason":"foreign"'))).toBe(true);
+      } else {
+        expect(daemonOutcome.skipped).toBe(1);
+        expect(daemonLogs.some((message) => message.includes('"reason":"foreign"'))).toBe(true);
+      }
+    } finally {
+      await db.delete(playlists).where(eq(playlists.auroraId, circuitUuid));
+      await db
+        .delete(boardCircuits)
+        .where(and(eq(boardCircuits.boardType, 'tension'), eq(boardCircuits.uuid, circuitUuid)));
+      if (auroraUserId !== undefined) {
+        await db.delete(boardUsers).where(and(eq(boardUsers.boardType, 'tension'), eq(boardUsers.id, auroraUserId)));
+      }
+      await db.delete(users).where(inArray(users.id, [...userIds]));
+      await client.end();
+    }
+  }, 20_000);
+});

--- a/packages/web/app/lib/data-sync/aurora/__tests__/user-sync.cross-writer.integration.test.ts
+++ b/packages/web/app/lib/data-sync/aurora/__tests__/user-sync.cross-writer.integration.test.ts
@@ -16,12 +16,14 @@ vi.mock('@/app/lib/db/db', () => ({ getDb: () => ({}) }));
 
 import { upsertTableData as webUpsertTableData } from '../user-sync';
 
+const LOCAL_DATABASE_HOSTS = new Set(['localhost', '127.0.0.1', 'postgres', '[::1]', '::1']);
+
 function localDatabaseUrl(): string | null {
   const databaseUrl = process.env.DATABASE_URL;
   if (!databaseUrl) return null;
   try {
     const hostname = new URL(databaseUrl).hostname.toLowerCase();
-    return ['localhost', '127.0.0.1', 'postgres'].includes(hostname) ? databaseUrl : null;
+    return LOCAL_DATABASE_HOSTS.has(hostname) ? databaseUrl : null;
   } catch {
     return null;
   }

--- a/packages/web/app/lib/data-sync/aurora/user-sync.ts
+++ b/packages/web/app/lib/data-sync/aurora/user-sync.ts
@@ -9,11 +9,7 @@ import {
 import { eq, and, inArray, asc } from 'drizzle-orm';
 import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
 import { foreignPlaylistOwnerGuard, selectUpstreamPlaylistOwners } from '@boardsesh/db/queries';
-import {
-  resolveUpstreamPlaylistWrite,
-  canWriteUpstreamPlaylist,
-  upstreamPlaylistSkipLogLine,
-} from '@boardsesh/sync-runtime';
+import { resolveUpstreamPlaylistWrite, upstreamPlaylistSkipLogLine } from '@boardsesh/sync-runtime';
 import { normalizePlaylistColor } from '@boardsesh/shared-schema';
 import { UNIFIED_TABLES } from '../../db/queries/util/table-select';
 import { auroraCredentials, playlists, playlistClimbs, playlistOwnership } from '../../db/schema';
@@ -341,7 +337,7 @@ export async function upsertTableData(
 
       for (const item of circuitItems) {
         const decision = resolveUpstreamPlaylistWrite(ownersByAuroraId.get(item.uuid) ?? [], nextAuthUserId);
-        if (!canWriteUpstreamPlaylist(decision)) {
+        if (decision === 'foreign' || decision === 'ambiguous') {
           // Refuse the whole dual-write — upsert, ownership grant AND the
           // playlist_climbs replace below. Skipping only the upsert would still
           // wipe the other user's climbs further down.

--- a/packages/web/app/lib/data-sync/aurora/user-sync.ts
+++ b/packages/web/app/lib/data-sync/aurora/user-sync.ts
@@ -275,163 +275,172 @@ export async function upsertTableData(
     }
 
     case 'circuits': {
-      const circuitsSchema = UNIFIED_TABLES.circuits;
-      const { items: circuitItems, rejectedCount } = normalizeAuroraCircuitItems(data);
-      if (rejectedCount > 0) {
-        logger.error(
-          JSON.stringify({
-            level: 'error',
-            event: 'aurora_circuit_playlist_malformed_payload',
-            boardType: boardName,
-            rejectedCount,
-          }),
-        );
-      }
+      // `pg_advisory_xact_lock` only holds for the life of an explicit
+      // transaction: run outside one, every statement commits on its own and
+      // drops the lock immediately, so arbitration would be a no-op. The
+      // daemon defends itself by opening its own transaction; do the same here
+      // (a savepoint when the caller already supplied one, as `syncUserData`
+      // does) so a future direct caller passing a plain handle cannot silently
+      // void it.
+      await db.transaction(async (circuitsTx) => {
+        const circuitsSchema = UNIFIED_TABLES.circuits;
+        const { items: circuitItems, rejectedCount } = normalizeAuroraCircuitItems(data);
+        if (rejectedCount > 0) {
+          logger.error(
+            JSON.stringify({
+              level: 'error',
+              event: 'aurora_circuit_playlist_malformed_payload',
+              boardType: boardName,
+              rejectedCount,
+            }),
+          );
+        }
 
-      // This function is called with the route's transaction handle. Take the
-      // exact same complete, sorted lock set as the daemon before ANY source or
-      // playlist write. That serializes daemon↔web as well as web↔web claims.
-      for (const item of circuitItems) {
-        await db.execute(auroraCircuitAdvisoryLockStatement(boardName, item.uuid));
-      }
+        // Take the exact same complete, sorted lock set as the daemon before ANY
+        // source or playlist write. That serializes daemon↔web as well as
+        // web↔web claims.
+        for (const item of circuitItems) {
+          await circuitsTx.execute(auroraCircuitAdvisoryLockStatement(boardName, item.uuid));
+        }
 
-      // Write source rows only after every lock is held. Keeping source writes
-      // in the same normalized order avoids row/advisory lock inversions across
-      // multi-circuit payloads.
-      for (const item of circuitItems) {
-        await db
-          .insert(circuitsSchema)
-          .values({
-            boardType: boardName,
-            uuid: item.uuid,
-            name: item.name,
-            description: item.description,
-            color: item.color,
-            userId: Number(auroraUserId),
-            isPublic: Boolean(item.is_public),
-            createdAt: item.created_at,
-            updatedAt: item.updated_at,
-          })
-          .onConflictDoUpdate({
-            target: [circuitsSchema.boardType, circuitsSchema.uuid],
-            set: {
+        // Write source rows only after every lock is held. Keeping source writes
+        // in the same normalized order avoids row/advisory lock inversions across
+        // multi-circuit payloads.
+        for (const item of circuitItems) {
+          await circuitsTx
+            .insert(circuitsSchema)
+            .values({
+              boardType: boardName,
+              uuid: item.uuid,
               name: item.name,
               description: item.description,
               color: item.color,
+              userId: Number(auroraUserId),
               isPublic: Boolean(item.is_public),
+              createdAt: item.created_at,
               updatedAt: item.updated_at,
-            },
-          });
-      }
-
-      if (!nextAuthUserId) break;
-
-      // The lock set makes this single fresh owner query stable for the rest of
-      // the transaction. A second query is reserved for the unexpected SQL
-      // guard suppression path, where it explains why `.returning()` was empty.
-      const ownersByAuroraId = await selectUpstreamPlaylistOwners(
-        db,
-        playlists.auroraId,
-        circuitItems.map((item) => item.uuid),
-      );
-
-      for (const item of circuitItems) {
-        const decision = resolveUpstreamPlaylistWrite(ownersByAuroraId.get(item.uuid) ?? [], nextAuthUserId);
-        if (decision === 'foreign' || decision === 'ambiguous') {
-          // Refuse the whole dual-write — upsert, ownership grant AND the
-          // playlist_climbs replace below. Skipping only the upsert would still
-          // wipe the other user's climbs further down.
-          logCircuitPlaylistRefusal(logger, {
-            boardName,
-            circuitUuid: item.uuid,
-            syncingUserId: nextAuthUserId,
-            stage: 'ownership-check',
-            reason: decision,
-          });
-          continue;
+            })
+            .onConflictDoUpdate({
+              target: [circuitsSchema.boardType, circuitsSchema.uuid],
+              set: {
+                name: item.name,
+                description: item.description,
+                color: item.color,
+                isPublic: Boolean(item.is_public),
+                updatedAt: item.updated_at,
+              },
+            });
         }
 
-        // Aurora may omit the hash and legacy payloads may use shorthand;
-        // persist one canonical representation for every downstream client.
-        const formattedColor = normalizePlaylistColor(item.color);
+        if (!nextAuthUserId) return;
 
-        const [playlist] = await db
-          .insert(playlists)
-          .values({
-            uuid: item.uuid,
-            boardType: boardName,
-            layoutId: null,
-            name: item.name || 'Untitled Circuit',
-            description: item.description || null,
-            isPublic: Boolean(item.is_public),
-            color: formattedColor,
-            auroraType: 'circuits',
-            auroraId: item.uuid,
-            auroraSyncedAt: new Date(),
-            createdAt: item.created_at ? new Date(item.created_at) : new Date(),
-            updatedAt: item.updated_at ? new Date(item.updated_at) : new Date(),
-          })
-          .onConflictDoUpdate({
-            target: playlists.auroraId,
-            set: {
+        // The lock set makes this single fresh owner query stable for the rest of
+        // the transaction. A second query is reserved for the unexpected SQL
+        // guard suppression path, where it explains why `.returning()` was empty.
+        const ownersByAuroraId = await selectUpstreamPlaylistOwners(
+          circuitsTx,
+          playlists.auroraId,
+          circuitItems.map((item) => item.uuid),
+        );
+
+        for (const item of circuitItems) {
+          const decision = resolveUpstreamPlaylistWrite(ownersByAuroraId.get(item.uuid) ?? [], nextAuthUserId);
+          if (decision === 'foreign' || decision === 'ambiguous') {
+            // Refuse the whole dual-write — upsert, ownership grant AND the
+            // playlist_climbs replace below. Skipping only the upsert would still
+            // wipe the other user's climbs further down.
+            logCircuitPlaylistRefusal(logger, {
+              boardName,
+              circuitUuid: item.uuid,
+              syncingUserId: nextAuthUserId,
+              stage: 'ownership-check',
+              reason: decision,
+            });
+            continue;
+          }
+
+          // Aurora may omit the hash and legacy payloads may use shorthand;
+          // persist one canonical representation for every downstream client.
+          const formattedColor = normalizePlaylistColor(item.color);
+
+          const [playlist] = await circuitsTx
+            .insert(playlists)
+            .values({
+              uuid: item.uuid,
+              boardType: boardName,
+              layoutId: null,
               name: item.name || 'Untitled Circuit',
               description: item.description || null,
               isPublic: Boolean(item.is_public),
               color: formattedColor,
-              updatedAt: item.updated_at ? new Date(item.updated_at) : new Date(),
+              auroraType: 'circuits',
+              auroraId: item.uuid,
               auroraSyncedAt: new Date(),
-            },
-            // Defence in depth: the advisory lock is primary; this correlated
-            // predicate still refuses a caller that bypasses the protocol.
-            setWhere: foreignPlaylistOwnerGuard(nextAuthUserId),
-          })
-          .returning({ id: playlists.id });
+              createdAt: item.created_at ? new Date(item.created_at) : new Date(),
+              updatedAt: item.updated_at ? new Date(item.updated_at) : new Date(),
+            })
+            .onConflictDoUpdate({
+              target: playlists.auroraId,
+              set: {
+                name: item.name || 'Untitled Circuit',
+                description: item.description || null,
+                isPublic: Boolean(item.is_public),
+                color: formattedColor,
+                updatedAt: item.updated_at ? new Date(item.updated_at) : new Date(),
+                auroraSyncedAt: new Date(),
+              },
+              // Defence in depth: the advisory lock is primary; this correlated
+              // predicate still refuses a caller that bypasses the protocol.
+              setWhere: foreignPlaylistOwnerGuard(nextAuthUserId),
+            })
+            .returning({ id: playlists.id });
 
-        if (!playlist) {
-          const freshOwners = await selectUpstreamPlaylistOwners(db, playlists.auroraId, [item.uuid]);
-          const suppressedDecision = resolveUpstreamPlaylistWrite(freshOwners.get(item.uuid) ?? [], nextAuthUserId);
-          logCircuitPlaylistRefusal(logger, {
-            boardName,
-            circuitUuid: item.uuid,
-            syncingUserId: nextAuthUserId,
-            stage: 'suppressed-upsert',
-            reason: suppressedDecision === 'adopt' ? 'no-owner' : suppressedDecision,
-          });
-          continue;
-        }
+          if (!playlist) {
+            const freshOwners = await selectUpstreamPlaylistOwners(circuitsTx, playlists.auroraId, [item.uuid]);
+            const suppressedDecision = resolveUpstreamPlaylistWrite(freshOwners.get(item.uuid) ?? [], nextAuthUserId);
+            logCircuitPlaylistRefusal(logger, {
+              boardName,
+              circuitUuid: item.uuid,
+              syncingUserId: nextAuthUserId,
+              stage: 'suppressed-upsert',
+              reason: suppressedDecision === 'adopt' ? 'no-owner' : suppressedDecision,
+            });
+            continue;
+          }
 
-        await db
-          .insert(playlistOwnership)
-          .values({
-            playlistId: playlist.id,
-            userId: nextAuthUserId,
-            role: 'owner',
-          })
-          .onConflictDoUpdate({
-            target: [playlistOwnership.playlistId, playlistOwnership.userId],
-            set: { role: 'owner' },
-          });
+          await circuitsTx
+            .insert(playlistOwnership)
+            .values({
+              playlistId: playlist.id,
+              userId: nextAuthUserId,
+              role: 'owner',
+            })
+            .onConflictDoUpdate({
+              target: [playlistOwnership.playlistId, playlistOwnership.userId],
+              set: { role: 'owner' },
+            });
 
-        if (item.climbs && Array.isArray(item.climbs)) {
-          await db.delete(playlistClimbs).where(eq(playlistClimbs.playlistId, playlist.id));
+          if (item.climbs && Array.isArray(item.climbs)) {
+            await circuitsTx.delete(playlistClimbs).where(eq(playlistClimbs.playlistId, playlist.id));
 
-          for (let i = 0; i < item.climbs.length; i++) {
-            const climb = item.climbs[i];
-            const climbUuid = climb.climb_uuid || climb.uuid || climb;
-            const climbAngle = climb.angle ?? null;
-            const climbPosition = climb.position ?? i;
+            for (let i = 0; i < item.climbs.length; i++) {
+              const climb = item.climbs[i];
+              const climbUuid = climb.climb_uuid || climb.uuid || climb;
+              const climbAngle = climb.angle ?? null;
+              const climbPosition = climb.position ?? i;
 
-            if (typeof climbUuid === 'string') {
-              await db.insert(playlistClimbs).values({
-                playlistId: playlist.id,
-                climbUuid,
-                angle: climbAngle,
-                position: climbPosition,
-              });
+              if (typeof climbUuid === 'string') {
+                await circuitsTx.insert(playlistClimbs).values({
+                  playlistId: playlist.id,
+                  climbUuid,
+                  angle: climbAngle,
+                  position: climbPosition,
+                });
+              }
             }
           }
         }
-      }
+      });
       break;
     }
 

--- a/packages/web/app/lib/data-sync/aurora/user-sync.ts
+++ b/packages/web/app/lib/data-sync/aurora/user-sync.ts
@@ -21,6 +21,65 @@ import { auroraCredentials, playlists, playlistClimbs, playlistOwnership } from 
 // transitively pull the aurora daemon's postgres-js client — apply-user-logbook
 // is self-contained (drizzle-orm + @boardsesh/db + shared-schema only).
 import { applyAuroraAscents, applyAuroraBids } from '@boardsesh/aurora-sync/apply-user-logbook';
+import {
+  auroraCircuitAdvisoryLockStatement,
+  normalizeAuroraCircuitItems,
+} from '@boardsesh/aurora-sync/circuit-arbitration';
+
+export type AuroraProxySyncLogger = {
+  warn: (message: string) => void;
+  error: (message: string) => void;
+};
+
+const DEFAULT_AURORA_PROXY_SYNC_LOGGER: AuroraProxySyncLogger = {
+  warn: console.warn,
+  error: console.error,
+};
+
+function logCircuitPlaylistRefusal(
+  logger: AuroraProxySyncLogger,
+  input: {
+    boardName: AuroraBoardName;
+    circuitUuid: string;
+    syncingUserId: string;
+    stage: 'ownership-check' | 'suppressed-upsert';
+    reason: 'foreign' | 'ambiguous' | 'no-owner' | 'own';
+  },
+): void {
+  const structuredContext = JSON.stringify({
+    event: 'aurora_circuit_playlist_refused',
+    boardType: input.boardName,
+    circuitUuid: input.circuitUuid,
+    syncingUserId: input.syncingUserId,
+    stage: input.stage,
+    reason: input.reason,
+  });
+
+  if (input.reason === 'foreign' || input.reason === 'ambiguous') {
+    logger.warn(
+      `${upstreamPlaylistSkipLogLine({
+        syncTag: 'aurora-proxy',
+        upstreamIdColumn: 'aurora_id',
+        upstreamId: input.circuitUuid,
+        syncingUserId: input.syncingUserId,
+        decision: input.reason,
+      })} ${structuredContext}`,
+    );
+    return;
+  }
+
+  logger.error(
+    JSON.stringify({
+      level: 'error',
+      event: 'aurora_circuit_playlist_suppressed_without_foreign_owner',
+      boardType: input.boardName,
+      circuitUuid: input.circuitUuid,
+      syncingUserId: input.syncingUserId,
+      stage: input.stage,
+      reason: input.reason,
+    }),
+  );
+}
 
 /**
  * Get NextAuth user ID from Aurora user ID.
@@ -62,6 +121,7 @@ export async function upsertTableData(
   auroraUserId: number,
   nextAuthUserId: string,
   data: Record<string, string>[],
+  logger: AuroraProxySyncLogger = DEFAULT_AURORA_PROXY_SYNC_LOGGER,
 ) {
   if (data.length === 0) return;
 
@@ -220,24 +280,29 @@ export async function upsertTableData(
 
     case 'circuits': {
       const circuitsSchema = UNIFIED_TABLES.circuits;
-      // Who already owns the playlists behind these circuit uuids?
-      // `playlists_aurora_id_idx` is a GLOBAL unique index, so the
-      // `ON CONFLICT (aurora_id) DO UPDATE` below lands on whichever Boardsesh
-      // user's row got there first, and the ownership insert then hands this
-      // user an `owner` edge on it. That is how the 8 cross-linked tension
-      // playlists in prod were created (#3526 / #3541), and this legacy proxy
-      // route is the third writer of that shape — the other two live in
-      // `@boardsesh/aurora-sync`. Same guard, same helper.
-      const ownersByAuroraId = nextAuthUserId
-        ? await selectUpstreamPlaylistOwners(
-            db,
-            playlists.auroraId,
-            data.map((item) => item.uuid).filter((uuid): uuid is string => typeof uuid === 'string'),
-          )
-        : new Map<string, string[]>();
+      const { items: circuitItems, rejectedCount } = normalizeAuroraCircuitItems(data);
+      if (rejectedCount > 0) {
+        logger.error(
+          JSON.stringify({
+            level: 'error',
+            event: 'aurora_circuit_playlist_malformed_payload',
+            boardType: boardName,
+            rejectedCount,
+          }),
+        );
+      }
 
-      for (const item of data) {
-        // 1. Write to unified circuits table
+      // This function is called with the route's transaction handle. Take the
+      // exact same complete, sorted lock set as the daemon before ANY source or
+      // playlist write. That serializes daemon↔web as well as web↔web claims.
+      for (const item of circuitItems) {
+        await db.execute(auroraCircuitAdvisoryLockStatement(boardName, item.uuid));
+      }
+
+      // Write source rows only after every lock is held. Keeping source writes
+      // in the same normalized order avoids row/advisory lock inversions across
+      // multi-circuit payloads.
+      for (const item of circuitItems) {
         await db
           .insert(circuitsSchema)
           .values({
@@ -261,98 +326,112 @@ export async function upsertTableData(
               updatedAt: item.updated_at,
             },
           });
+      }
 
-        // 2. Dual write to playlists table (only if NextAuth user exists)
-        if (nextAuthUserId) {
-          const decision = resolveUpstreamPlaylistWrite(ownersByAuroraId.get(item.uuid) ?? [], nextAuthUserId);
-          if (!canWriteUpstreamPlaylist(decision)) {
-            // Refuse the whole dual-write — upsert, ownership grant AND the
-            // playlist_climbs replace below. Skipping only the upsert would
-            // still wipe the other user's climbs further down.
-            console.warn(
-              upstreamPlaylistSkipLogLine({
-                syncTag: 'aurora-proxy',
-                upstreamIdColumn: 'aurora_id',
-                upstreamId: item.uuid,
-                syncingUserId: nextAuthUserId,
-                decision,
-              }),
-            );
-            continue;
-          }
+      if (!nextAuthUserId) break;
 
-          // Aurora may omit the hash and legacy payloads may use shorthand;
-          // persist one canonical representation for every downstream client.
-          const formattedColor = normalizePlaylistColor(item.color);
+      // The lock set makes this single fresh owner query stable for the rest of
+      // the transaction. A second query is reserved for the unexpected SQL
+      // guard suppression path, where it explains why `.returning()` was empty.
+      const ownersByAuroraId = await selectUpstreamPlaylistOwners(
+        db,
+        playlists.auroraId,
+        circuitItems.map((item) => item.uuid),
+      );
 
-          // Insert/update playlist
-          const [playlist] = await db
-            .insert(playlists)
-            .values({
-              uuid: item.uuid, // Use same UUID as Aurora circuit
-              boardType: boardName,
-              layoutId: null, // Nullable for Aurora-synced circuits
+      for (const item of circuitItems) {
+        const decision = resolveUpstreamPlaylistWrite(ownersByAuroraId.get(item.uuid) ?? [], nextAuthUserId);
+        if (!canWriteUpstreamPlaylist(decision)) {
+          // Refuse the whole dual-write — upsert, ownership grant AND the
+          // playlist_climbs replace below. Skipping only the upsert would still
+          // wipe the other user's climbs further down.
+          logCircuitPlaylistRefusal(logger, {
+            boardName,
+            circuitUuid: item.uuid,
+            syncingUserId: nextAuthUserId,
+            stage: 'ownership-check',
+            reason: decision,
+          });
+          continue;
+        }
+
+        // Aurora may omit the hash and legacy payloads may use shorthand;
+        // persist one canonical representation for every downstream client.
+        const formattedColor = normalizePlaylistColor(item.color);
+
+        const [playlist] = await db
+          .insert(playlists)
+          .values({
+            uuid: item.uuid,
+            boardType: boardName,
+            layoutId: null,
+            name: item.name || 'Untitled Circuit',
+            description: item.description || null,
+            isPublic: Boolean(item.is_public),
+            color: formattedColor,
+            auroraType: 'circuits',
+            auroraId: item.uuid,
+            auroraSyncedAt: new Date(),
+            createdAt: item.created_at ? new Date(item.created_at) : new Date(),
+            updatedAt: item.updated_at ? new Date(item.updated_at) : new Date(),
+          })
+          .onConflictDoUpdate({
+            target: playlists.auroraId,
+            set: {
               name: item.name || 'Untitled Circuit',
               description: item.description || null,
               isPublic: Boolean(item.is_public),
               color: formattedColor,
-              auroraType: 'circuits',
-              auroraId: item.uuid,
-              auroraSyncedAt: new Date(),
-              createdAt: item.created_at ? new Date(item.created_at) : new Date(),
               updatedAt: item.updated_at ? new Date(item.updated_at) : new Date(),
-            })
-            .onConflictDoUpdate({
-              target: playlists.auroraId,
-              set: {
-                name: item.name || 'Untitled Circuit',
-                description: item.description || null,
-                isPublic: Boolean(item.is_public),
-                color: formattedColor,
-                updatedAt: item.updated_at ? new Date(item.updated_at) : new Date(),
-                auroraSyncedAt: new Date(),
-              },
-              // SQL-level twin of the decision gate above, evaluated at
-              // statement time against the conflicting row.
-              setWhere: foreignPlaylistOwnerGuard(nextAuthUserId),
-            })
-            .returning({ id: playlists.id });
+              auroraSyncedAt: new Date(),
+            },
+            // Defence in depth: the advisory lock is primary; this correlated
+            // predicate still refuses a caller that bypasses the protocol.
+            setWhere: foreignPlaylistOwnerGuard(nextAuthUserId),
+          })
+          .returning({ id: playlists.id });
 
-          // Empty when the guard suppressed the DO UPDATE — abandon the item
-          // rather than dereferencing an undefined id.
-          if (!playlist) continue;
+        if (!playlist) {
+          const freshOwners = await selectUpstreamPlaylistOwners(db, playlists.auroraId, [item.uuid]);
+          const suppressedDecision = resolveUpstreamPlaylistWrite(freshOwners.get(item.uuid) ?? [], nextAuthUserId);
+          logCircuitPlaylistRefusal(logger, {
+            boardName,
+            circuitUuid: item.uuid,
+            syncingUserId: nextAuthUserId,
+            stage: 'suppressed-upsert',
+            reason: suppressedDecision === 'adopt' ? 'no-owner' : suppressedDecision,
+          });
+          continue;
+        }
 
-          // 3. Create ownership if not exists
-          await db
-            .insert(playlistOwnership)
-            .values({
-              playlistId: playlist.id,
-              userId: nextAuthUserId,
-              role: 'owner',
-            })
-            .onConflictDoNothing();
+        await db
+          .insert(playlistOwnership)
+          .values({
+            playlistId: playlist.id,
+            userId: nextAuthUserId,
+            role: 'owner',
+          })
+          .onConflictDoUpdate({
+            target: [playlistOwnership.playlistId, playlistOwnership.userId],
+            set: { role: 'owner' },
+          });
 
-          // 4. Sync playlist climbs (from nested climbs array)
-          if (item.climbs && Array.isArray(item.climbs)) {
-            // Delete existing climbs for this playlist to handle removals
-            await db.delete(playlistClimbs).where(eq(playlistClimbs.playlistId, playlist.id));
+        if (item.climbs && Array.isArray(item.climbs)) {
+          await db.delete(playlistClimbs).where(eq(playlistClimbs.playlistId, playlist.id));
 
-            // Insert new climbs
-            for (let i = 0; i < item.climbs.length; i++) {
-              const climb = item.climbs[i];
-              // Handle different possible structures of climb data
-              const climbUuid = climb.climb_uuid || climb.uuid || climb;
-              const climbAngle = climb.angle ?? null;
-              const climbPosition = climb.position ?? i;
+          for (let i = 0; i < item.climbs.length; i++) {
+            const climb = item.climbs[i];
+            const climbUuid = climb.climb_uuid || climb.uuid || climb;
+            const climbAngle = climb.angle ?? null;
+            const climbPosition = climb.position ?? i;
 
-              if (typeof climbUuid === 'string') {
-                await db.insert(playlistClimbs).values({
-                  playlistId: playlist.id,
-                  climbUuid: climbUuid,
-                  angle: climbAngle,
-                  position: climbPosition,
-                });
-              }
+            if (typeof climbUuid === 'string') {
+              await db.insert(playlistClimbs).values({
+                playlistId: playlist.id,
+                climbUuid,
+                angle: climbAngle,
+                position: climbPosition,
+              });
             }
           }
         }

--- a/scripts/prepare-aurora-circuit-integration-db.test.ts
+++ b/scripts/prepare-aurora-circuit-integration-db.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  columnMatchesCanonical,
+  indexMatchesCanonical,
+  requireCompatibilityOptIn,
+  requireLocalDatabaseUrl,
+  type PlaylistColumnDefinition,
+  type PlaylistIndexDefinition,
+} from './prepare-aurora-circuit-integration-db';
+
+const canonicalColumn: PlaylistColumnDefinition = {
+  columnName: 'kilter_id',
+  dataType: 'text',
+  nullable: true,
+};
+
+const canonicalIndex: PlaylistIndexDefinition = {
+  indexName: 'playlists_kilter_id_idx',
+  relationSchema: 'public',
+  relationName: 'playlists',
+  relationKind: 'i',
+  unique: true,
+  valid: true,
+  predicate: null,
+  expressions: null,
+  keyColumnCount: 1,
+  attributeCount: 1,
+  keyColumns: ['kilter_id'],
+};
+
+describe('Aurora circuit schema compatibility guards', () => {
+  it('requires an explicit opt-in', () => {
+    expect(() => requireCompatibilityOptIn({})).toThrow('ALLOW_AURORA_CIRCUIT_SCHEMA_COMPAT=1');
+    expect(() => requireCompatibilityOptIn({ ALLOW_AURORA_CIRCUIT_SCHEMA_COMPAT: '1' })).not.toThrow();
+  });
+
+  it('allows only local PostgreSQL URLs', () => {
+    expect(requireLocalDatabaseUrl('postgresql://postgres:password@localhost:5433/main')).toContain('localhost');
+    expect(requireLocalDatabaseUrl('postgres://postgres:password@127.0.0.1/main')).toContain('127.0.0.1');
+    expect(() => requireLocalDatabaseUrl('postgresql://postgres:password@example.com/main')).toThrow('non-local');
+    expect(() => requireLocalDatabaseUrl('https://localhost/main')).toThrow('postgres');
+  });
+
+  it('rejects wrong playlist column types or nullability', () => {
+    expect(columnMatchesCanonical(canonicalColumn, canonicalColumn)).toBe(true);
+    expect(columnMatchesCanonical({ ...canonicalColumn, nullable: false }, canonicalColumn)).toBe(false);
+    expect(columnMatchesCanonical({ ...canonicalColumn, dataType: 'uuid' }, canonicalColumn)).toBe(false);
+  });
+
+  it('requires the exact canonical unique single-column index', () => {
+    const expectedIndex = { indexName: 'playlists_kilter_id_idx', columnName: 'kilter_id' } as const;
+    expect(indexMatchesCanonical(canonicalIndex, expectedIndex)).toBe(true);
+    expect(indexMatchesCanonical({ ...canonicalIndex, unique: false }, expectedIndex)).toBe(false);
+    expect(indexMatchesCanonical({ ...canonicalIndex, predicate: 'kilter_id IS NOT NULL' }, expectedIndex)).toBe(false);
+    expect(indexMatchesCanonical({ ...canonicalIndex, keyColumns: ['kilter_id', 'uuid'] }, expectedIndex)).toBe(false);
+  });
+});

--- a/scripts/prepare-aurora-circuit-integration-db.test.ts
+++ b/scripts/prepare-aurora-circuit-integration-db.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   columnMatchesCanonical,
   indexMatchesCanonical,
+  ledgerSnapshotsMatch,
   requireCompatibilityOptIn,
   requireLocalDatabaseUrl,
   type PlaylistColumnDefinition,
@@ -12,6 +13,9 @@ import {
 const canonicalColumn: PlaylistColumnDefinition = {
   columnName: 'kilter_id',
   dataType: 'text',
+  underlyingTypeSchema: 'pg_catalog',
+  underlyingTypeName: 'text',
+  formattedType: 'text',
   nullable: true,
 };
 
@@ -20,13 +24,19 @@ const canonicalIndex: PlaylistIndexDefinition = {
   relationSchema: 'public',
   relationName: 'playlists',
   relationKind: 'i',
+  accessMethod: 'btree',
   unique: true,
+  ready: true,
   valid: true,
+  nullsNotDistinct: false,
   predicate: null,
   expressions: null,
   keyColumnCount: 1,
   attributeCount: 1,
   keyColumns: ['kilter_id'],
+  keyOpclasses: ['pg_catalog.text_ops'],
+  keyCollations: ['pg_catalog.default'],
+  keyOptions: [0],
 };
 
 describe('Aurora circuit schema compatibility guards', () => {
@@ -46,6 +56,30 @@ describe('Aurora circuit schema compatibility guards', () => {
     expect(columnMatchesCanonical(canonicalColumn, canonicalColumn)).toBe(true);
     expect(columnMatchesCanonical({ ...canonicalColumn, nullable: false }, canonicalColumn)).toBe(false);
     expect(columnMatchesCanonical({ ...canonicalColumn, dataType: 'uuid' }, canonicalColumn)).toBe(false);
+    expect(columnMatchesCanonical({ ...canonicalColumn, underlyingTypeSchema: 'custom' }, canonicalColumn)).toBe(false);
+    expect(columnMatchesCanonical({ ...canonicalColumn, underlyingTypeName: 'varchar' }, canonicalColumn)).toBe(false);
+    expect(columnMatchesCanonical({ ...canonicalColumn, formattedType: 'character varying' }, canonicalColumn)).toBe(
+      false,
+    );
+  });
+
+  it('rejects noncanonical timestamp precision', () => {
+    const canonicalTimestamp: PlaylistColumnDefinition = {
+      columnName: 'kilter_synced_at',
+      dataType: 'timestamp without time zone',
+      underlyingTypeSchema: 'pg_catalog',
+      underlyingTypeName: 'timestamp',
+      formattedType: 'timestamp without time zone',
+      nullable: true,
+    };
+
+    expect(columnMatchesCanonical(canonicalTimestamp, canonicalTimestamp)).toBe(true);
+    expect(
+      columnMatchesCanonical(
+        { ...canonicalTimestamp, formattedType: 'timestamp(0) without time zone' },
+        canonicalTimestamp,
+      ),
+    ).toBe(false);
   });
 
   it('requires the exact canonical unique single-column index', () => {
@@ -53,6 +87,39 @@ describe('Aurora circuit schema compatibility guards', () => {
     expect(indexMatchesCanonical(canonicalIndex, expectedIndex)).toBe(true);
     expect(indexMatchesCanonical({ ...canonicalIndex, unique: false }, expectedIndex)).toBe(false);
     expect(indexMatchesCanonical({ ...canonicalIndex, predicate: 'kilter_id IS NOT NULL' }, expectedIndex)).toBe(false);
+    expect(indexMatchesCanonical({ ...canonicalIndex, expressions: 'lower(kilter_id)' }, expectedIndex)).toBe(false);
     expect(indexMatchesCanonical({ ...canonicalIndex, keyColumns: ['kilter_id', 'uuid'] }, expectedIndex)).toBe(false);
+    expect(indexMatchesCanonical({ ...canonicalIndex, attributeCount: 2 }, expectedIndex)).toBe(false);
+    expect(indexMatchesCanonical({ ...canonicalIndex, nullsNotDistinct: true }, expectedIndex)).toBe(false);
+    expect(indexMatchesCanonical({ ...canonicalIndex, accessMethod: 'hash' }, expectedIndex)).toBe(false);
+    expect(indexMatchesCanonical({ ...canonicalIndex, ready: false }, expectedIndex)).toBe(false);
+    expect(indexMatchesCanonical({ ...canonicalIndex, valid: false }, expectedIndex)).toBe(false);
+    expect(
+      indexMatchesCanonical({ ...canonicalIndex, keyOpclasses: ['pg_catalog.text_pattern_ops'] }, expectedIndex),
+    ).toBe(false);
+    expect(indexMatchesCanonical({ ...canonicalIndex, keyCollations: ['public.custom'] }, expectedIndex)).toBe(false);
+    expect(indexMatchesCanonical({ ...canonicalIndex, keyOptions: [1] }, expectedIndex)).toBe(false);
+    expect(indexMatchesCanonical({ ...canonicalIndex, keyOptions: [2] }, expectedIndex)).toBe(false);
+  });
+
+  it('detects changes to complete ledger rows even when created_at is null', () => {
+    const before = {
+      row_count: '1',
+      ordered_rows: '[{"id":1,"hash":"original","created_at":null}]',
+    };
+
+    expect(ledgerSnapshotsMatch(before, before)).toBe(true);
+    expect(
+      ledgerSnapshotsMatch(before, {
+        row_count: '1',
+        ordered_rows: '[{"id":1,"hash":"changed","created_at":null}]',
+      }),
+    ).toBe(false);
+    expect(
+      ledgerSnapshotsMatch(before, {
+        row_count: '1',
+        ordered_rows: '[{"id":2,"hash":"original","created_at":null}]',
+      }),
+    ).toBe(false);
   });
 });

--- a/scripts/prepare-aurora-circuit-integration-db.ts
+++ b/scripts/prepare-aurora-circuit-integration-db.ts
@@ -322,7 +322,8 @@ async function readNamedIndex(transaction: TransactionSql, indexName: string): P
   return indexes[0] ?? null;
 }
 
-async function ensurePlaylistExists(transaction: TransactionSql): Promise<void> {
+/** Serialize the narrow compatibility DDL on the fresh, isolated CI database. */
+async function lockPlaylistTableForCompatibilityPatch(transaction: TransactionSql): Promise<void> {
   await transaction.unsafe('LOCK TABLE public.playlists IN ACCESS EXCLUSIVE MODE');
 }
 
@@ -352,7 +353,7 @@ export async function prepareAuroraCircuitIntegrationDatabase(databaseUrl: strin
   const client = postgres(databaseUrl, { max: 1, prepare: false, onnotice: () => undefined });
   try {
     await client.begin(async (transaction) => {
-      await ensurePlaylistExists(transaction);
+      await lockPlaylistTableForCompatibilityPatch(transaction);
       const ledgerBefore = await snapshotLedger(transaction);
       const columnsBefore = await readPlaylistColumns(transaction);
 

--- a/scripts/prepare-aurora-circuit-integration-db.ts
+++ b/scripts/prepare-aurora-circuit-integration-db.ts
@@ -274,7 +274,10 @@ async function readNamedIndex(transaction: TransactionSql, indexName: string): P
         '{}'::text[]
       ) AS "keyOpclasses",
       COALESCE(
-        array_agg(collation_namespace.nspname || '.' || collation.collname ORDER BY index_key.ordinality)
+        array_agg(
+          collation_namespace.nspname || '.' || index_collation.collname
+          ORDER BY index_key.ordinality
+        )
           FILTER (WHERE index_key.ordinality <= index_data.indnkeyatts),
         '{}'::text[]
       ) AS "keyCollations",
@@ -294,8 +297,9 @@ async function readNamedIndex(transaction: TransactionSql, indexName: string): P
       AND attribute.attnum = index_key.attnum
     LEFT JOIN pg_opclass AS opclass ON opclass.oid = index_data.indclass[index_key.ordinality::int - 1]
     LEFT JOIN pg_namespace AS opclass_namespace ON opclass_namespace.oid = opclass.opcnamespace
-    LEFT JOIN pg_collation AS collation ON collation.oid = index_data.indcollation[index_key.ordinality::int - 1]
-    LEFT JOIN pg_namespace AS collation_namespace ON collation_namespace.oid = collation.collnamespace
+    LEFT JOIN pg_collation AS index_collation
+      ON index_collation.oid = index_data.indcollation[index_key.ordinality::int - 1]
+    LEFT JOIN pg_namespace AS collation_namespace ON collation_namespace.oid = index_collation.collnamespace
     WHERE index_namespace.nspname = 'public'
       AND index_class.relname = ${indexName}
     GROUP BY

--- a/scripts/prepare-aurora-circuit-integration-db.ts
+++ b/scripts/prepare-aurora-circuit-integration-db.ts
@@ -20,6 +20,9 @@ const LOCAL_DATABASE_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]', '::1'])
 export type PlaylistColumnDefinition = {
   readonly columnName: string;
   readonly dataType: string;
+  readonly underlyingTypeSchema: string;
+  readonly underlyingTypeName: string;
+  readonly formattedType: string;
   readonly nullable: boolean;
 };
 
@@ -28,31 +31,68 @@ export type PlaylistIndexDefinition = {
   readonly relationSchema: string | null;
   readonly relationName: string | null;
   readonly relationKind: string | null;
+  readonly accessMethod: string | null;
   readonly unique: boolean | null;
+  readonly ready: boolean | null;
   readonly valid: boolean | null;
+  readonly nullsNotDistinct: boolean | null;
   readonly predicate: string | null;
   readonly expressions: string | null;
   readonly keyColumnCount: number | null;
   readonly attributeCount: number | null;
   readonly keyColumns: readonly string[];
+  readonly keyOpclasses: readonly string[];
+  readonly keyCollations: readonly string[];
+  readonly keyOptions: readonly number[];
 };
 
-type LedgerSnapshot = {
+export type LedgerSnapshot = {
   readonly row_count: string;
-  readonly fingerprint: string;
+  readonly ordered_rows: string;
 };
 
 type ColumnRow = {
   readonly column_name: string;
   readonly data_type: string;
+  readonly udt_schema: string;
+  readonly udt_name: string;
+  readonly formatted_type: string;
   readonly is_nullable: 'YES' | 'NO';
 };
 
 const REQUIRED_COLUMNS: readonly PlaylistColumnDefinition[] = [
-  { columnName: 'kilter_type', dataType: 'text', nullable: true },
-  { columnName: 'kilter_id', dataType: 'text', nullable: true },
-  { columnName: 'kilter_synced_at', dataType: 'timestamp without time zone', nullable: true },
-  { columnName: 'generated_recommendation', dataType: 'text', nullable: true },
+  {
+    columnName: 'kilter_type',
+    dataType: 'text',
+    underlyingTypeSchema: 'pg_catalog',
+    underlyingTypeName: 'text',
+    formattedType: 'text',
+    nullable: true,
+  },
+  {
+    columnName: 'kilter_id',
+    dataType: 'text',
+    underlyingTypeSchema: 'pg_catalog',
+    underlyingTypeName: 'text',
+    formattedType: 'text',
+    nullable: true,
+  },
+  {
+    columnName: 'kilter_synced_at',
+    dataType: 'timestamp without time zone',
+    underlyingTypeSchema: 'pg_catalog',
+    underlyingTypeName: 'timestamp',
+    formattedType: 'timestamp without time zone',
+    nullable: true,
+  },
+  {
+    columnName: 'generated_recommendation',
+    dataType: 'text',
+    underlyingTypeSchema: 'pg_catalog',
+    underlyingTypeName: 'text',
+    formattedType: 'text',
+    nullable: true,
+  },
 ];
 
 const REQUIRED_INDEXES = [
@@ -92,6 +132,9 @@ export function columnMatchesCanonical(
   return (
     actualColumn.columnName === expectedColumn.columnName &&
     actualColumn.dataType === expectedColumn.dataType &&
+    actualColumn.underlyingTypeSchema === expectedColumn.underlyingTypeSchema &&
+    actualColumn.underlyingTypeName === expectedColumn.underlyingTypeName &&
+    actualColumn.formattedType === expectedColumn.formattedType &&
     actualColumn.nullable === expectedColumn.nullable
   );
 }
@@ -105,15 +148,28 @@ export function indexMatchesCanonical(
     actualIndex.relationSchema === 'public' &&
     actualIndex.relationName === 'playlists' &&
     actualIndex.relationKind === 'i' &&
+    actualIndex.accessMethod === 'btree' &&
     actualIndex.unique === true &&
+    actualIndex.ready === true &&
     actualIndex.valid === true &&
+    actualIndex.nullsNotDistinct === false &&
     actualIndex.predicate === null &&
     actualIndex.expressions === null &&
     actualIndex.keyColumnCount === 1 &&
     actualIndex.attributeCount === 1 &&
     actualIndex.keyColumns.length === 1 &&
-    actualIndex.keyColumns[0] === expectedIndex.columnName
+    actualIndex.keyColumns[0] === expectedIndex.columnName &&
+    actualIndex.keyOpclasses.length === 1 &&
+    actualIndex.keyOpclasses[0] === 'pg_catalog.text_ops' &&
+    actualIndex.keyCollations.length === 1 &&
+    actualIndex.keyCollations[0] === 'pg_catalog.default' &&
+    actualIndex.keyOptions.length === 1 &&
+    actualIndex.keyOptions[0] === 0
   );
+}
+
+export function ledgerSnapshotsMatch(before: LedgerSnapshot, after: LedgerSnapshot): boolean {
+  return before.row_count === after.row_count && before.ordered_rows === after.ordered_rows;
 }
 
 function expectedColumnByName(columnName: string): PlaylistColumnDefinition {
@@ -126,6 +182,9 @@ function toPlaylistColumnDefinition(column: ColumnRow): PlaylistColumnDefinition
   return {
     columnName: column.column_name,
     dataType: column.data_type,
+    underlyingTypeSchema: column.udt_schema,
+    underlyingTypeName: column.udt_name,
+    formattedType: column.formatted_type,
     nullable: column.is_nullable === 'YES',
   };
 }
@@ -134,8 +193,8 @@ function assertCanonicalColumn(column: PlaylistColumnDefinition): void {
   const expectedColumn = expectedColumnByName(column.columnName);
   if (!columnMatchesCanonical(column, expectedColumn)) {
     throw new Error(
-      `playlists.${column.columnName} is ${column.dataType} ${column.nullable ? 'NULL' : 'NOT NULL'}; expected ` +
-        `${expectedColumn.dataType} ${expectedColumn.nullable ? 'NULL' : 'NOT NULL'}.`,
+      `playlists.${column.columnName} is ${column.formattedType} ${column.nullable ? 'NULL' : 'NOT NULL'}; expected ` +
+        `${expectedColumn.formattedType} ${expectedColumn.nullable ? 'NULL' : 'NOT NULL'}.`,
     );
   }
 }
@@ -152,8 +211,11 @@ async function snapshotLedger(transaction: TransactionSql): Promise<LedgerSnapsh
   const [ledger] = await transaction<LedgerSnapshot[]>`
     SELECT
       count(*)::text AS row_count,
-      COALESCE(md5(string_agg(hash || ':' || created_at::text, ',' ORDER BY created_at, hash)), '') AS fingerprint
-    FROM drizzle."__drizzle_migrations"
+      COALESCE(
+        jsonb_agg(to_jsonb(migration_row) ORDER BY migration_row.id),
+        '[]'::jsonb
+      )::text AS ordered_rows
+    FROM drizzle."__drizzle_migrations" AS migration_row
   `;
   if (!ledger) throw new Error('Could not snapshot drizzle.__drizzle_migrations.');
   return ledger;
@@ -161,11 +223,26 @@ async function snapshotLedger(transaction: TransactionSql): Promise<LedgerSnapsh
 
 async function readPlaylistColumns(transaction: TransactionSql): Promise<Map<string, PlaylistColumnDefinition>> {
   const columns = await transaction<ColumnRow[]>`
-    SELECT column_name, data_type, is_nullable
-    FROM information_schema.columns
-    WHERE table_schema = 'public'
-      AND table_name = 'playlists'
-      AND column_name IN ('kilter_type', 'kilter_id', 'kilter_synced_at', 'generated_recommendation')
+    SELECT
+      columns.column_name,
+      columns.data_type,
+      columns.udt_schema,
+      columns.udt_name,
+      format_type(attribute.atttypid, attribute.atttypmod) AS formatted_type,
+      columns.is_nullable
+    FROM information_schema.columns AS columns
+    JOIN pg_catalog.pg_namespace AS table_namespace
+      ON table_namespace.nspname = columns.table_schema
+    JOIN pg_catalog.pg_class AS table_class
+      ON table_class.relnamespace = table_namespace.oid
+      AND table_class.relname = columns.table_name
+    JOIN pg_catalog.pg_attribute AS attribute
+      ON attribute.attrelid = table_class.oid
+      AND attribute.attname = columns.column_name
+      AND NOT attribute.attisdropped
+    WHERE columns.table_schema = 'public'
+      AND columns.table_name = 'playlists'
+      AND columns.column_name IN ('kilter_type', 'kilter_id', 'kilter_synced_at', 'generated_recommendation')
   `;
   return new Map(columns.map((column) => [column.column_name, toPlaylistColumnDefinition(column)]));
 }
@@ -177,8 +254,11 @@ async function readNamedIndex(transaction: TransactionSql, indexName: string): P
       index_namespace.nspname AS "relationSchema",
       table_class.relname AS "relationName",
       index_class.relkind::text AS "relationKind",
+      access_method.amname AS "accessMethod",
       index_data.indisunique AS unique,
+      index_data.indisready AS ready,
       index_data.indisvalid AS valid,
+      index_data.indnullsnotdistinct AS "nullsNotDistinct",
       pg_get_expr(index_data.indpred, index_data.indrelid) AS predicate,
       pg_get_expr(index_data.indexprs, index_data.indrelid) AS expressions,
       index_data.indnkeyatts::int AS "keyColumnCount",
@@ -187,15 +267,35 @@ async function readNamedIndex(transaction: TransactionSql, indexName: string): P
         array_agg(attribute.attname ORDER BY index_key.ordinality)
           FILTER (WHERE index_key.ordinality <= index_data.indnkeyatts),
         '{}'::text[]
-      ) AS "keyColumns"
+      ) AS "keyColumns",
+      COALESCE(
+        array_agg(opclass_namespace.nspname || '.' || opclass.opcname ORDER BY index_key.ordinality)
+          FILTER (WHERE index_key.ordinality <= index_data.indnkeyatts),
+        '{}'::text[]
+      ) AS "keyOpclasses",
+      COALESCE(
+        array_agg(collation_namespace.nspname || '.' || collation.collname ORDER BY index_key.ordinality)
+          FILTER (WHERE index_key.ordinality <= index_data.indnkeyatts),
+        '{}'::text[]
+      ) AS "keyCollations",
+      COALESCE(
+        array_agg(index_data.indoption[index_key.ordinality::int - 1]::int ORDER BY index_key.ordinality)
+          FILTER (WHERE index_key.ordinality <= index_data.indnkeyatts),
+        '{}'::int[]
+      ) AS "keyOptions"
     FROM pg_class AS index_class
     JOIN pg_namespace AS index_namespace ON index_namespace.oid = index_class.relnamespace
+    JOIN pg_am AS access_method ON access_method.oid = index_class.relam
     LEFT JOIN pg_index AS index_data ON index_data.indexrelid = index_class.oid
     LEFT JOIN pg_class AS table_class ON table_class.oid = index_data.indrelid
     LEFT JOIN LATERAL unnest(index_data.indkey::smallint[]) WITH ORDINALITY AS index_key(attnum, ordinality) ON true
     LEFT JOIN pg_attribute AS attribute
       ON attribute.attrelid = index_data.indrelid
       AND attribute.attnum = index_key.attnum
+    LEFT JOIN pg_opclass AS opclass ON opclass.oid = index_data.indclass[index_key.ordinality::int - 1]
+    LEFT JOIN pg_namespace AS opclass_namespace ON opclass_namespace.oid = opclass.opcnamespace
+    LEFT JOIN pg_collation AS collation ON collation.oid = index_data.indcollation[index_key.ordinality::int - 1]
+    LEFT JOIN pg_namespace AS collation_namespace ON collation_namespace.oid = collation.collnamespace
     WHERE index_namespace.nspname = 'public'
       AND index_class.relname = ${indexName}
     GROUP BY
@@ -203,8 +303,11 @@ async function readNamedIndex(transaction: TransactionSql, indexName: string): P
       index_namespace.nspname,
       table_class.relname,
       index_class.relkind,
+      access_method.amname,
       index_data.indisunique,
+      index_data.indisready,
       index_data.indisvalid,
+      index_data.indnullsnotdistinct,
       index_data.indpred,
       index_data.indexprs,
       index_data.indnkeyatts,
@@ -278,7 +381,7 @@ export async function prepareAuroraCircuitIntegrationDatabase(databaseUrl: strin
       }
 
       const ledgerAfter = await snapshotLedger(transaction);
-      if (ledgerBefore.row_count !== ledgerAfter.row_count || ledgerBefore.fingerprint !== ledgerAfter.fingerprint) {
+      if (!ledgerSnapshotsMatch(ledgerBefore, ledgerAfter)) {
         throw new Error('Aurora circuit schema preparation must not change the Drizzle migration ledger.');
       }
     });

--- a/scripts/prepare-aurora-circuit-integration-db.ts
+++ b/scripts/prepare-aurora-circuit-integration-db.ts
@@ -312,6 +312,7 @@ async function readNamedIndex(transaction: TransactionSql, indexName: string): P
       index_data.indisready,
       index_data.indisvalid,
       index_data.indnullsnotdistinct,
+      index_data.indrelid,
       index_data.indpred,
       index_data.indexprs,
       index_data.indnkeyatts,

--- a/scripts/prepare-aurora-circuit-integration-db.ts
+++ b/scripts/prepare-aurora-circuit-integration-db.ts
@@ -1,0 +1,303 @@
+/// <reference types="node" />
+
+/**
+ * Narrow, opt-in compatibility preparation for the real-PostgreSQL #3950 CI gate.
+ *
+ * The development image deliberately represents the production-shaped database,
+ * including a historical gap in the Drizzle ledger.  Running migrations here
+ * would therefore give CI a different failure mode from production.  This script
+ * only supplies the four backwards-compatible playlist fields that the two
+ * arbitration specifications need.  It never applies a migration or changes the
+ * migration ledger.
+ */
+
+import { fileURLToPath } from 'node:url';
+
+import postgres, { type TransactionSql } from 'postgres';
+
+const LOCAL_DATABASE_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+
+export type PlaylistColumnDefinition = {
+  readonly columnName: string;
+  readonly dataType: string;
+  readonly nullable: boolean;
+};
+
+export type PlaylistIndexDefinition = {
+  readonly indexName: string;
+  readonly relationSchema: string | null;
+  readonly relationName: string | null;
+  readonly relationKind: string | null;
+  readonly unique: boolean | null;
+  readonly valid: boolean | null;
+  readonly predicate: string | null;
+  readonly expressions: string | null;
+  readonly keyColumnCount: number | null;
+  readonly attributeCount: number | null;
+  readonly keyColumns: readonly string[];
+};
+
+type LedgerSnapshot = {
+  readonly row_count: string;
+  readonly fingerprint: string;
+};
+
+type ColumnRow = {
+  readonly column_name: string;
+  readonly data_type: string;
+  readonly is_nullable: 'YES' | 'NO';
+};
+
+const REQUIRED_COLUMNS: readonly PlaylistColumnDefinition[] = [
+  { columnName: 'kilter_type', dataType: 'text', nullable: true },
+  { columnName: 'kilter_id', dataType: 'text', nullable: true },
+  { columnName: 'kilter_synced_at', dataType: 'timestamp without time zone', nullable: true },
+  { columnName: 'generated_recommendation', dataType: 'text', nullable: true },
+];
+
+const REQUIRED_INDEXES = [
+  { indexName: 'playlists_kilter_id_idx', columnName: 'kilter_id' },
+  { indexName: 'playlists_generated_recommendation_idx', columnName: 'generated_recommendation' },
+] as const;
+
+export function requireLocalDatabaseUrl(databaseUrl: string | undefined): string {
+  if (!databaseUrl) throw new Error('DATABASE_URL is required for Aurora circuit integration preparation.');
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(databaseUrl);
+  } catch {
+    throw new Error('DATABASE_URL must be a valid PostgreSQL connection URL.');
+  }
+
+  if (parsedUrl.protocol !== 'postgres:' && parsedUrl.protocol !== 'postgresql:') {
+    throw new Error('DATABASE_URL must use the postgres or postgresql protocol.');
+  }
+  if (!LOCAL_DATABASE_HOSTS.has(parsedUrl.hostname.toLowerCase())) {
+    throw new Error('Refusing Aurora circuit integration preparation against a non-local DATABASE_URL.');
+  }
+  return databaseUrl;
+}
+
+export function requireCompatibilityOptIn(environment: NodeJS.ProcessEnv): void {
+  if (environment.ALLOW_AURORA_CIRCUIT_SCHEMA_COMPAT !== '1') {
+    throw new Error('Set ALLOW_AURORA_CIRCUIT_SCHEMA_COMPAT=1 to allow the local CI schema compatibility gate.');
+  }
+}
+
+export function columnMatchesCanonical(
+  actualColumn: PlaylistColumnDefinition,
+  expectedColumn: PlaylistColumnDefinition,
+): boolean {
+  return (
+    actualColumn.columnName === expectedColumn.columnName &&
+    actualColumn.dataType === expectedColumn.dataType &&
+    actualColumn.nullable === expectedColumn.nullable
+  );
+}
+
+export function indexMatchesCanonical(
+  actualIndex: PlaylistIndexDefinition,
+  expectedIndex: (typeof REQUIRED_INDEXES)[number],
+): boolean {
+  return (
+    actualIndex.indexName === expectedIndex.indexName &&
+    actualIndex.relationSchema === 'public' &&
+    actualIndex.relationName === 'playlists' &&
+    actualIndex.relationKind === 'i' &&
+    actualIndex.unique === true &&
+    actualIndex.valid === true &&
+    actualIndex.predicate === null &&
+    actualIndex.expressions === null &&
+    actualIndex.keyColumnCount === 1 &&
+    actualIndex.attributeCount === 1 &&
+    actualIndex.keyColumns.length === 1 &&
+    actualIndex.keyColumns[0] === expectedIndex.columnName
+  );
+}
+
+function expectedColumnByName(columnName: string): PlaylistColumnDefinition {
+  const expectedColumn = REQUIRED_COLUMNS.find((column) => column.columnName === columnName);
+  if (!expectedColumn) throw new Error(`No canonical definition exists for playlists.${columnName}.`);
+  return expectedColumn;
+}
+
+function toPlaylistColumnDefinition(column: ColumnRow): PlaylistColumnDefinition {
+  return {
+    columnName: column.column_name,
+    dataType: column.data_type,
+    nullable: column.is_nullable === 'YES',
+  };
+}
+
+function assertCanonicalColumn(column: PlaylistColumnDefinition): void {
+  const expectedColumn = expectedColumnByName(column.columnName);
+  if (!columnMatchesCanonical(column, expectedColumn)) {
+    throw new Error(
+      `playlists.${column.columnName} is ${column.dataType} ${column.nullable ? 'NULL' : 'NOT NULL'}; expected ` +
+        `${expectedColumn.dataType} ${expectedColumn.nullable ? 'NULL' : 'NOT NULL'}.`,
+    );
+  }
+}
+
+function assertCanonicalIndex(index: PlaylistIndexDefinition, expectedIndex: (typeof REQUIRED_INDEXES)[number]): void {
+  if (!indexMatchesCanonical(index, expectedIndex)) {
+    throw new Error(
+      `${expectedIndex.indexName} exists but is not the required unique public.playlists(${expectedIndex.columnName}) index.`,
+    );
+  }
+}
+
+async function snapshotLedger(transaction: TransactionSql): Promise<LedgerSnapshot> {
+  const [ledger] = await transaction<LedgerSnapshot[]>`
+    SELECT
+      count(*)::text AS row_count,
+      COALESCE(md5(string_agg(hash || ':' || created_at::text, ',' ORDER BY created_at, hash)), '') AS fingerprint
+    FROM drizzle."__drizzle_migrations"
+  `;
+  if (!ledger) throw new Error('Could not snapshot drizzle.__drizzle_migrations.');
+  return ledger;
+}
+
+async function readPlaylistColumns(transaction: TransactionSql): Promise<Map<string, PlaylistColumnDefinition>> {
+  const columns = await transaction<ColumnRow[]>`
+    SELECT column_name, data_type, is_nullable
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'playlists'
+      AND column_name IN ('kilter_type', 'kilter_id', 'kilter_synced_at', 'generated_recommendation')
+  `;
+  return new Map(columns.map((column) => [column.column_name, toPlaylistColumnDefinition(column)]));
+}
+
+async function readNamedIndex(transaction: TransactionSql, indexName: string): Promise<PlaylistIndexDefinition | null> {
+  const indexes = await transaction<PlaylistIndexDefinition[]>`
+    SELECT
+      index_class.relname AS "indexName",
+      index_namespace.nspname AS "relationSchema",
+      table_class.relname AS "relationName",
+      index_class.relkind::text AS "relationKind",
+      index_data.indisunique AS unique,
+      index_data.indisvalid AS valid,
+      pg_get_expr(index_data.indpred, index_data.indrelid) AS predicate,
+      pg_get_expr(index_data.indexprs, index_data.indrelid) AS expressions,
+      index_data.indnkeyatts::int AS "keyColumnCount",
+      index_data.indnatts::int AS "attributeCount",
+      COALESCE(
+        array_agg(attribute.attname ORDER BY index_key.ordinality)
+          FILTER (WHERE index_key.ordinality <= index_data.indnkeyatts),
+        '{}'::text[]
+      ) AS "keyColumns"
+    FROM pg_class AS index_class
+    JOIN pg_namespace AS index_namespace ON index_namespace.oid = index_class.relnamespace
+    LEFT JOIN pg_index AS index_data ON index_data.indexrelid = index_class.oid
+    LEFT JOIN pg_class AS table_class ON table_class.oid = index_data.indrelid
+    LEFT JOIN LATERAL unnest(index_data.indkey::smallint[]) WITH ORDINALITY AS index_key(attnum, ordinality) ON true
+    LEFT JOIN pg_attribute AS attribute
+      ON attribute.attrelid = index_data.indrelid
+      AND attribute.attnum = index_key.attnum
+    WHERE index_namespace.nspname = 'public'
+      AND index_class.relname = ${indexName}
+    GROUP BY
+      index_class.relname,
+      index_namespace.nspname,
+      table_class.relname,
+      index_class.relkind,
+      index_data.indisunique,
+      index_data.indisvalid,
+      index_data.indpred,
+      index_data.indexprs,
+      index_data.indnkeyatts,
+      index_data.indnatts
+  `;
+  if (indexes.length > 1) throw new Error(`Found more than one public relation named ${indexName}.`);
+  return indexes[0] ?? null;
+}
+
+async function ensurePlaylistExists(transaction: TransactionSql): Promise<void> {
+  await transaction.unsafe('LOCK TABLE public.playlists IN ACCESS EXCLUSIVE MODE');
+}
+
+async function addMissingColumn(transaction: TransactionSql, column: PlaylistColumnDefinition): Promise<void> {
+  const statements: Record<string, string> = {
+    kilter_type: 'ALTER TABLE public.playlists ADD COLUMN kilter_type text',
+    kilter_id: 'ALTER TABLE public.playlists ADD COLUMN kilter_id text',
+    kilter_synced_at: 'ALTER TABLE public.playlists ADD COLUMN kilter_synced_at timestamp without time zone',
+    generated_recommendation: 'ALTER TABLE public.playlists ADD COLUMN generated_recommendation text',
+  };
+  await transaction.unsafe(statements[column.columnName] ?? 'SELECT 1/0');
+}
+
+async function createCanonicalIndex(
+  transaction: TransactionSql,
+  index: (typeof REQUIRED_INDEXES)[number],
+): Promise<void> {
+  const statements: Record<(typeof REQUIRED_INDEXES)[number]['indexName'], string> = {
+    playlists_kilter_id_idx: 'CREATE UNIQUE INDEX playlists_kilter_id_idx ON public.playlists USING btree (kilter_id)',
+    playlists_generated_recommendation_idx:
+      'CREATE UNIQUE INDEX playlists_generated_recommendation_idx ON public.playlists USING btree (generated_recommendation)',
+  };
+  await transaction.unsafe(statements[index.indexName]);
+}
+
+export async function prepareAuroraCircuitIntegrationDatabase(databaseUrl: string): Promise<void> {
+  const client = postgres(databaseUrl, { max: 1, prepare: false, onnotice: () => undefined });
+  try {
+    await client.begin(async (transaction) => {
+      await ensurePlaylistExists(transaction);
+      const ledgerBefore = await snapshotLedger(transaction);
+      const columnsBefore = await readPlaylistColumns(transaction);
+
+      for (const requiredColumn of REQUIRED_COLUMNS) {
+        const existingColumn = columnsBefore.get(requiredColumn.columnName);
+        if (existingColumn) assertCanonicalColumn(existingColumn);
+      }
+      for (const requiredColumn of REQUIRED_COLUMNS) {
+        if (!columnsBefore.has(requiredColumn.columnName)) await addMissingColumn(transaction, requiredColumn);
+      }
+
+      const columnsAfter = await readPlaylistColumns(transaction);
+      for (const requiredColumn of REQUIRED_COLUMNS) {
+        const actualColumn = columnsAfter.get(requiredColumn.columnName);
+        if (!actualColumn) throw new Error(`playlists.${requiredColumn.columnName} was not created.`);
+        assertCanonicalColumn(actualColumn);
+      }
+
+      for (const requiredIndex of REQUIRED_INDEXES) {
+        const existingIndex = await readNamedIndex(transaction, requiredIndex.indexName);
+        if (existingIndex) {
+          assertCanonicalIndex(existingIndex, requiredIndex);
+        } else {
+          await createCanonicalIndex(transaction, requiredIndex);
+        }
+      }
+      for (const requiredIndex of REQUIRED_INDEXES) {
+        const actualIndex = await readNamedIndex(transaction, requiredIndex.indexName);
+        if (!actualIndex) throw new Error(`${requiredIndex.indexName} was not created.`);
+        assertCanonicalIndex(actualIndex, requiredIndex);
+      }
+
+      const ledgerAfter = await snapshotLedger(transaction);
+      if (ledgerBefore.row_count !== ledgerAfter.row_count || ledgerBefore.fingerprint !== ledgerAfter.fingerprint) {
+        throw new Error('Aurora circuit schema preparation must not change the Drizzle migration ledger.');
+      }
+    });
+  } finally {
+    await client.end();
+  }
+}
+
+async function main(): Promise<void> {
+  requireCompatibilityOptIn(process.env);
+  const databaseUrl = requireLocalDatabaseUrl(process.env.DATABASE_URL);
+  await prepareAuroraCircuitIntegrationDatabase(databaseUrl);
+  console.info('[aurora-circuit-schema-compat] playlist compatibility verified without applying migrations.');
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath && fileURLToPath(import.meta.url) === invokedPath) {
+  void main().catch((error: unknown) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/prepare-aurora-circuit-integration-db.ts
+++ b/scripts/prepare-aurora-circuit-integration-db.ts
@@ -119,7 +119,10 @@ export function requireLocalDatabaseUrl(databaseUrl: string | undefined): string
   return databaseUrl;
 }
 
-export function requireCompatibilityOptIn(environment: NodeJS.ProcessEnv): void {
+// Reads one variable, so take the widest shape `process.env` satisfies rather
+// than `NodeJS.ProcessEnv` — the repo augments that type with a required
+// NODE_ENV, which the full-repo lint pass rejects for a bare test literal.
+export function requireCompatibilityOptIn(environment: Record<string, string | undefined>): void {
   if (environment.ALLOW_AURORA_CIRCUIT_SCHEMA_COMPAT !== '1') {
     throw new Error('Set ALLOW_AURORA_CIRCUIT_SCHEMA_COMPAT=1 to allow the local CI schema compatibility gate.');
   }


### PR DESCRIPTION
## Summary

- Acquire circuit arbitration locks in a stable order before any source or playlist writes, including callers that already own a transaction.
- Make race losses and existing foreign or ambiguous ownership visible through distinct persistent sync errors.
- Preserve legitimate orphan-adoption behavior while preventing a losing sync from changing another account's playlist or climbs.
- Show honest recovery guidance in web and mobile settings in English, Spanish, French, and German.

Closes #3950

## Release Notes

Playlist sync now tells you when another Boardsesh account owns the circuit or when ownership needs support to untangle, instead of silently skipping it.

## Test plan

- Aurora sync suite: 209 passed, 2 skipped without a fully migrated `DATABASE_URL`
- Web Aurora sync suite: 116 passed
- Shared sync-error tests: 2 passed
- i18n catalog completeness: settings.json at parity across `es`, `fr`, `de`
- Scoped `vp check` on the changed files: 0 errors
- `vp run typecheck`: clean
- Independent adversarial review: pass
- [x] Run the two concurrency cases against a fully migrated PostgreSQL schema — the new `aurora-circuit-arbitration` CI job boots the dev-DB image and executes both the daemon and the daemon/web cross-writer test with `REQUIRE_AURORA_CIRCUIT_INTEGRATION=1`
- [x] Confirm normal CI typecheck/test/mobile-bundle gates
- [ ] Start the full dev server after #3978's dev-DB migration-ledger mismatch is resolved; current `vp run dev` stops before startup because migration `0187_sad_freak` finds `board_climb_ingest_skips` already present
