### PR TITLE
fix: chunk bulkVoteSummaries requests past the 100-ID cap

### DIFF
--- a/packages/backend/src/__tests__/social-validation.test.ts
+++ b/packages/backend/src/__tests__/social-validation.test.ts
@@ -311,9 +311,11 @@ describe('Social Validation Schemas', () => {
 
   // Regression coverage for issue #4102: a paginating feed handed this schema
   // its whole accumulated list and every request past ~100 rows was rejected
-  // outright. The clients now batch by BULK_VOTE_SUMMARY_CHUNK_SIZE, so these
-  // cases derive their boundary from that same constant — raising one without
-  // the other fails here.
+  // outright. The clients now batch by BULK_VOTE_SUMMARY_CHUNK_SIZE, which is
+  // the same constant this schema's `.max()` reads, so the derived cases below
+  // show client and server agreeing at the boundary for whatever the constant
+  // says. They pass for any value of it by construction — the literal case
+  // pins what that value actually is on the wire.
   describe('BulkVoteSummaryInputSchema', () => {
     it('should accept a populated entityIds array', () => {
       const result = BulkVoteSummaryInputSchema.safeParse({
@@ -346,6 +348,19 @@ describe('Social Validation Schemas', () => {
       const result = BulkVoteSummaryInputSchema.safeParse({
         entityType: 'tick',
         entityIds: Array.from({ length: BULK_VOTE_SUMMARY_CHUNK_SIZE + 1 }, (_unused, index) => `id-${index}`),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    // The two cases above move with the constant. This one does not: it states
+    // the cap this endpoint accepts today, so widening it is a deliberate edit
+    // here rather than a silent side effect of changing a client constant.
+    it('should reject 101 entityIds — the wire cap is 100', () => {
+      expect(BULK_VOTE_SUMMARY_CHUNK_SIZE).toBe(100);
+
+      const result = BulkVoteSummaryInputSchema.safeParse({
+        entityType: 'tick',
+        entityIds: Array.from({ length: 101 }, (_unused, index) => `id-${index}`),
       });
       expect(result.success).toBe(false);
     });

--- a/packages/backend/src/__tests__/social-validation.test.ts
+++ b/packages/backend/src/__tests__/social-validation.test.ts
@@ -11,6 +11,7 @@ import {
   BulkVoteSummaryInputSchema,
   VoteInputSchema,
 } from '../validation/schemas';
+import { BULK_VOTE_SUMMARY_CHUNK_SIZE } from '@boardsesh/shared-schema';
 
 describe('Social Validation Schemas', () => {
   describe('FollowInputSchema', () => {
@@ -308,6 +309,11 @@ describe('Social Validation Schemas', () => {
     });
   });
 
+  // Regression coverage for issue #4102: a paginating feed handed this schema
+  // its whole accumulated list and every request past ~100 rows was rejected
+  // outright. The clients now batch by BULK_VOTE_SUMMARY_CHUNK_SIZE, so these
+  // cases derive their boundary from that same constant — raising one without
+  // the other fails here.
   describe('BulkVoteSummaryInputSchema', () => {
     it('should accept a populated entityIds array', () => {
       const result = BulkVoteSummaryInputSchema.safeParse({
@@ -328,10 +334,18 @@ describe('Social Validation Schemas', () => {
       }
     });
 
-    it('should reject more than 100 entityIds', () => {
+    it('should accept exactly the shared chunk size, so clients can batch right up to it', () => {
       const result = BulkVoteSummaryInputSchema.safeParse({
         entityType: 'tick',
-        entityIds: Array.from({ length: 101 }, (_unused, index) => `id-${index}`),
+        entityIds: Array.from({ length: BULK_VOTE_SUMMARY_CHUNK_SIZE }, (_unused, index) => `id-${index}`),
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject one entityId more than the shared chunk size', () => {
+      const result = BulkVoteSummaryInputSchema.safeParse({
+        entityType: 'tick',
+        entityIds: Array.from({ length: BULK_VOTE_SUMMARY_CHUNK_SIZE + 1 }, (_unused, index) => `id-${index}`),
       });
       expect(result.success).toBe(false);
     });

--- a/packages/backend/src/validation/schemas/comments.ts
+++ b/packages/backend/src/validation/schemas/comments.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { BULK_VOTE_SUMMARY_CHUNK_SIZE } from '@boardsesh/shared-schema';
 
 /**
  * Social entity type validation schema
@@ -75,5 +76,7 @@ export const CommentsInputSchema = z.object({
 export const BulkVoteSummaryInputSchema = z.object({
   entityType: SocialEntityTypeSchema,
   // Empty arrays are a valid no-op: the resolver returns []. (No `.min(1)` here.)
-  entityIds: z.array(z.string().min(1).max(200)).max(100),
+  // The cap lives in @boardsesh/shared-schema so the clients that have to
+  // batch around it can't drift from what this rejects.
+  entityIds: z.array(z.string().min(1).max(200)).max(BULK_VOTE_SUMMARY_CHUNK_SIZE),
 });

--- a/packages/mobile/src/components/session/SessionDetailScreen.tsx
+++ b/packages/mobile/src/components/session/SessionDetailScreen.tsx
@@ -49,9 +49,8 @@ export default function SessionDetailScreen() {
 
   const { data: session, isPending } = useSessionDetail(sessionId);
   const { data: voteSummaries } = useBulkVoteSummaries('session', sessionId ? [sessionId] : [], !!sessionId);
-  // `.at(0)` rather than `[0]`: the array is always present now that the hook
-  // merges its chunks, but it is empty until the request resolves, and `.at`
-  // is the indexed read TypeScript types as `VoteSummary | undefined` without
+  // `.at(0)`, not `[0]`: the list is empty until the chunk resolves, and `.at`
+  // is the indexed read typed `VoteSummary | undefined` without
   // `noUncheckedIndexedAccess`.
   const sessionVoteSummary = voteSummaries.at(0);
   const { data: profile } = useProfile();

--- a/packages/mobile/src/components/session/SessionDetailScreen.tsx
+++ b/packages/mobile/src/components/session/SessionDetailScreen.tsx
@@ -49,7 +49,7 @@ export default function SessionDetailScreen() {
 
   const { data: session, isPending } = useSessionDetail(sessionId);
   const { data: voteSummaries } = useBulkVoteSummaries('session', sessionId ? [sessionId] : [], !!sessionId);
-  const sessionVoteSummary = voteSummaries?.[0];
+  const sessionVoteSummary = voteSummaries[0];
   const { data: profile } = useProfile();
 
   // Only the session's creator can rename it / edit the recap (the server enforces

--- a/packages/mobile/src/components/session/SessionDetailScreen.tsx
+++ b/packages/mobile/src/components/session/SessionDetailScreen.tsx
@@ -49,7 +49,11 @@ export default function SessionDetailScreen() {
 
   const { data: session, isPending } = useSessionDetail(sessionId);
   const { data: voteSummaries } = useBulkVoteSummaries('session', sessionId ? [sessionId] : [], !!sessionId);
-  const sessionVoteSummary = voteSummaries[0];
+  // `.at(0)` rather than `[0]`: the array is always present now that the hook
+  // merges its chunks, but it is empty until the request resolves, and `.at`
+  // is the indexed read TypeScript types as `VoteSummary | undefined` without
+  // `noUncheckedIndexedAccess`.
+  const sessionVoteSummary = voteSummaries.at(0);
   const { data: profile } = useProfile();
 
   // Only the session's creator can rename it / edit the recap (the server enforces

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/use-social.test.tsx
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/use-social.test.tsx
@@ -3,8 +3,14 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { FOLLOW_USER, GET_FOLLOWERS, SEARCH_USERS, UNFOLLOW_USER } from '@boardsesh/graphql/operations';
-import type { FollowConnection, UserSearchConnection } from '@boardsesh/shared-schema';
+import {
+  FOLLOW_USER,
+  GET_BULK_VOTE_SUMMARIES,
+  GET_FOLLOWERS,
+  SEARCH_USERS,
+  UNFOLLOW_USER,
+} from '@boardsesh/graphql/operations';
+import type { FollowConnection, UserSearchConnection, VoteSummary } from '@boardsesh/shared-schema';
 
 const requestMock = vi.hoisted(() => vi.fn());
 
@@ -12,7 +18,7 @@ vi.mock('../../client', () => ({
   getHttpClient: () => ({ request: requestMock }),
 }));
 
-import { useFollowers, useSearchUsers, useToggleUserFollow } from '../use-social';
+import { useBulkVoteSummaries, useFollowers, useSearchUsers, useToggleUserFollow } from '../use-social';
 
 function makeWrapper() {
   const queryClient = new QueryClient({
@@ -36,6 +42,10 @@ function makeFollowConnection(offset: number): FollowConnection {
     totalCount: 90,
     hasMore: offset < 60,
   };
+}
+
+function makeVoteSummary(entityId: string): VoteSummary {
+  return { entityType: 'tick', entityId, upvotes: 1, downvotes: 0, voteScore: 1, userVote: 0 };
 }
 
 function makeSearchConnection(offset: number): UserSearchConnection {
@@ -157,5 +167,88 @@ describe('useToggleUserFollow', () => {
     });
 
     expect(requestMock).toHaveBeenCalledWith(UNFOLLOW_USER, { input: { userId: 'target-user' } });
+  });
+});
+
+describe('useBulkVoteSummaries', () => {
+  // Regression coverage for #4102: a paginating feed (e.g. SessionsTab) can
+  // hand this hook well over 100 entity ids, which the backend's
+  // BulkVoteSummaryInputSchema rejects outright (`.max(100)`). The hook must
+  // chunk internally so no single request ever exceeds the cap.
+  it('splits a list over the backend 100-ID cap into multiple <=100-ID requests and merges the results', async () => {
+    const entityIds = Array.from({ length: 135 }, (_, index) => `tick-${String(index).padStart(3, '0')}`);
+    requestMock.mockImplementation((_query: unknown, variables: { input: { entityIds: string[] } }) =>
+      Promise.resolve({
+        bulkVoteSummaries: variables.input.entityIds.map((entityId) => makeVoteSummary(entityId)),
+      }),
+    );
+    const { Wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useBulkVoteSummaries('tick', entityIds), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.data).toHaveLength(135));
+
+    expect(requestMock).toHaveBeenCalledTimes(2);
+    for (const [query, variables] of requestMock.mock.calls as [unknown, { input: { entityIds: string[] } }][]) {
+      expect(query).toBe(GET_BULK_VOTE_SUMMARIES);
+      expect(variables.input.entityIds.length).toBeLessThanOrEqual(100);
+    }
+    const requestedIds = (requestMock.mock.calls as [unknown, { input: { entityIds: string[] } }][]).flatMap(
+      ([, variables]) => variables.input.entityIds,
+    );
+    expect(new Set(requestedIds).size).toBe(135);
+  });
+
+  it("keeps a resolved chunk's rows when a sibling chunk's request fails, instead of blanking everything", async () => {
+    const entityIds = Array.from({ length: 135 }, (_, index) => `tick-${String(index).padStart(3, '0')}`);
+    requestMock.mockImplementation((_query: unknown, variables: { input: { entityIds: string[] } }) => {
+      // The second chunk (ids 100-134) fails; the first chunk (0-99) resolves.
+      if (variables.input.entityIds.includes('tick-100')) {
+        return Promise.reject(new Error('chunk 2 failed'));
+      }
+      return Promise.resolve({
+        bulkVoteSummaries: variables.input.entityIds.map((entityId) => makeVoteSummary(entityId)),
+      });
+    });
+    const { Wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useBulkVoteSummaries('tick', entityIds), { wrapper: Wrapper });
+
+    await waitFor(() => expect(requestMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(result.current.data).toHaveLength(100));
+
+    const returnedIds = new Set(result.current.data.map((summary) => summary.entityId));
+    expect(returnedIds.has('tick-000')).toBe(true);
+    expect(returnedIds.has('tick-099')).toBe(true);
+    // The failed chunk's rows are simply absent, not blanking the rows that did load.
+    expect(returnedIds.has('tick-100')).toBe(false);
+  });
+
+  // The Home feed rebuilds its vote map from `.data` and feeds the result to
+  // FlashList as `extraData`, so a `.data` array that changes identity on every
+  // parent render re-invokes `renderItem` for every mounted row. `useQueries`
+  // only holds identity when it is given a `combine` — see
+  // combineVoteSummaryChunks in use-social.ts.
+  it('holds the identity of data and refetch across re-renders, so the feed does not re-render every row', async () => {
+    const entityIds = Array.from({ length: 135 }, (_, index) => `tick-${String(index).padStart(3, '0')}`);
+    requestMock.mockImplementation((_query: unknown, variables: { input: { entityIds: string[] } }) =>
+      Promise.resolve({
+        bulkVoteSummaries: variables.input.entityIds.map((entityId) => makeVoteSummary(entityId)),
+      }),
+    );
+    const { Wrapper } = makeWrapper();
+
+    // A fresh array each render, the way a caller passing `ids.filter(...)` inline would.
+    const { result, rerender } = renderHook(() => useBulkVoteSummaries('tick', [...entityIds]), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.data).toHaveLength(135));
+    const settledData = result.current.data;
+    const settledResult = result.current;
+
+    rerender();
+    rerender();
+
+    expect(result.current.data).toBe(settledData);
+    expect(result.current).toBe(settledResult);
   });
 });

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/use-update-profile.test.tsx
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/use-update-profile.test.tsx
@@ -34,8 +34,6 @@ vi.mock('../use-social', () => ({
   useUserClimbs: vi.fn(),
   useVote: vi.fn(),
   useBulkVoteSummaries: vi.fn(),
-  useChunkedBulkVoteSummaries: vi.fn(),
-  useGroupedBulkVoteSummaries: vi.fn(),
   useComments: vi.fn(),
   useAddComment: vi.fn(),
 }));

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -1527,8 +1527,6 @@ export {
   useUserClimbs,
   useVote,
   useBulkVoteSummaries,
-  useChunkedBulkVoteSummaries,
-  useGroupedBulkVoteSummaries,
   useComments,
   useAddComment,
 } from './use-social';

--- a/packages/mobile/src/lib/graphql/hooks/use-social.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-social.ts
@@ -213,8 +213,10 @@ type BulkVoteSummaryChunkResult = {
 /** One ≤100-ID request, cached and retried independently of its siblings. */
 function bulkVoteSummaryChunkQuery(entityType: SocialEntityType, chunk: string[], enabled: boolean) {
   return {
-    // Sorted so two callers holding the same IDs in different orders share a
-    // cache entry (the request itself keeps the caller's order).
+    // Sorted so the key is order-independent *within* a chunk (the request
+    // itself keeps the caller's order). Chunk boundaries still follow the
+    // caller's order, which is what keeps an append-only feed's earlier
+    // chunks cached as it pages.
     queryKey: ['bulkVoteSummaries', entityType, [...chunk].sort()],
     queryFn: async (): Promise<BulkVoteSummaries> => {
       const response = await getHttpClient().request<GetBulkVoteSummariesQueryResponse>(GET_BULK_VOTE_SUMMARIES, {
@@ -251,28 +253,6 @@ function combineVoteSummaryChunks(results: BulkVoteSummaryChunkResult[]) {
 }
 
 /**
- * Shared chunked-query construction for the bulk-vote-summary hooks — one
- * query per ≤100-ID chunk, merged back into a single stable list.
- */
-function useBulkVoteSummaryChunks(entityType: SocialEntityType, chunks: string[][], enabled: boolean) {
-  return useQueries({
-    queries: chunks.map((chunk) => bulkVoteSummaryChunkQuery(entityType, chunk, enabled)),
-    combine: combineVoteSummaryChunks,
-  });
-}
-
-/**
- * Splits an ID list into ≤100-ID chunks, once per list change rather than per
- * render. Memoized on the array reference, so a caller that builds its list
- * inline (`ticks.map((tick) => tick.uuid)`) re-chunks every render — harmless,
- * since `useQueries` matches its observers by query hash either way, and the
- * feed screens that hand over the long lists already memoize them.
- */
-function useVoteSummaryChunks(entityIds: string[]): string[][] {
-  return useMemo(() => batchVoteSummaryEntityIds(entityIds), [entityIds]);
-}
-
-/**
  * Accurate vote state (count + `userVote`) for a batch of entities. Chunks
  * internally so callers never need to worry about the backend's 100-ID cap
  * (`BulkVoteSummaryInputSchema`) — a caller handing this an unbounded,
@@ -286,8 +266,16 @@ function useVoteSummaryChunks(entityIds: string[]): string[][] {
  * needs per-chunk state should use `useQueries` directly.
  */
 export function useBulkVoteSummaries(entityType: SocialEntityType, entityIds: string[], enabled = true) {
-  const chunks = useVoteSummaryChunks(entityIds);
-  const { summaries, refetchChunks } = useBulkVoteSummaryChunks(entityType, chunks, enabled);
+  // Chunked once per list change rather than per render. Memoized on the array
+  // reference, so a caller that builds its list inline
+  // (`ticks.map((tick) => tick.uuid)`) re-chunks every render — harmless,
+  // since `useQueries` matches its observers by query hash either way, and the
+  // feed screens that hand over the long lists already memoize them.
+  const chunks = useMemo(() => batchVoteSummaryEntityIds(entityIds), [entityIds]);
+  const { summaries, refetchChunks } = useQueries({
+    queries: chunks.map((chunk) => bulkVoteSummaryChunkQuery(entityType, chunk, enabled)),
+    combine: combineVoteSummaryChunks,
+  });
 
   // Callers keep this object in `useCallback`/`useMemo` deps (Home's
   // pull-to-refresh handler does), so it only changes when the vote data or
@@ -299,21 +287,6 @@ export function useBulkVoteSummaries(entityType: SocialEntityType, entityIds: st
     }),
     [summaries, refetchChunks],
   );
-}
-
-/** Accurate vote state for more than one backend-safe batch of entities. */
-export function useChunkedBulkVoteSummaries(entityType: SocialEntityType, entityIds: string[], enabled = true) {
-  const chunks = useVoteSummaryChunks(entityIds);
-  return useBulkVoteSummaryChunks(entityType, chunks, enabled).summaries;
-}
-
-/** Accurate vote state for stable groups, such as individual feed pages. */
-export function useGroupedBulkVoteSummaries(entityType: SocialEntityType, entityIdGroups: string[][], enabled = true) {
-  const chunks = useMemo(
-    () => entityIdGroups.flatMap((entityIds) => batchVoteSummaryEntityIds(entityIds)),
-    [entityIdGroups],
-  );
-  return useBulkVoteSummaryChunks(entityType, chunks, enabled).summaries;
 }
 
 /** Comment thread for a social entity. */

--- a/packages/mobile/src/lib/graphql/hooks/use-social.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-social.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useInfiniteQuery, useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   VOTE,
@@ -32,33 +33,11 @@ import {
   type GetUserClimbsQueryResponse,
   type GetUserClimbsQueryVariables,
 } from '@boardsesh/graphql/operations';
-import type { SocialEntityType } from '@boardsesh/shared-schema';
+import { batchVoteSummaryEntityIds, type SocialEntityType } from '@boardsesh/shared-schema';
 import { getHttpClient } from '../client';
 import { NOTIFICATION_ACTORS_QUERY_KEY } from '../notification-actors-key';
 
-const BULK_VOTE_SUMMARY_CHUNK_SIZE = 100;
 const SOCIAL_PAGE_SIZE = 30;
-
-function dedupeEntityIds(entityIds: string[]): string[] {
-  const seenIds = new Set<string>();
-  const dedupedIds: string[] = [];
-
-  for (const entityId of entityIds) {
-    if (seenIds.has(entityId)) continue;
-    seenIds.add(entityId);
-    dedupedIds.push(entityId);
-  }
-
-  return dedupedIds;
-}
-
-function chunkEntityIds(entityIds: string[]): string[][] {
-  const chunks: string[][] = [];
-  for (let startIndex = 0; startIndex < entityIds.length; startIndex += BULK_VOTE_SUMMARY_CHUNK_SIZE) {
-    chunks.push(entityIds.slice(startIndex, startIndex + BULK_VOTE_SUMMARY_CHUNK_SIZE));
-  }
-  return chunks;
-}
 
 /** Public social profile for a user, including follower/following counts. */
 export function usePublicProfile(userId: string | undefined, enabled = true) {
@@ -224,72 +203,117 @@ export function useVote() {
   });
 }
 
-/** Accurate vote state (count + `userVote`) for a batch of entities. */
-export function useBulkVoteSummaries(entityType: SocialEntityType, entityIds: string[], enabled = true) {
-  // Key off a sorted copy so the cache identity tracks the *set* of ids, not the
-  // array order or reference. React Query hashes keys by value, so a fresh array
-  // each render is already a cache hit — the sort additionally makes a reordered
-  // (but identical) id list resolve to the same query instead of a refetch.
-  const sortedIds = [...entityIds].sort();
-  return useQuery({
-    queryKey: ['bulkVoteSummaries', entityType, sortedIds],
-    queryFn: async () => {
-      // `enabled` gates automatic fetches, but a manual `refetch()` (e.g. pull-to-refresh)
-      // bypasses it — short-circuit here so we never send the backend an empty list.
-      if (entityIds.length === 0) return [];
+type BulkVoteSummaries = GetBulkVoteSummariesQueryResponse['bulkVoteSummaries'];
+
+type BulkVoteSummaryChunkResult = {
+  data: BulkVoteSummaries | undefined;
+  refetch: () => Promise<unknown>;
+};
+
+/** One ≤100-ID request, cached and retried independently of its siblings. */
+function bulkVoteSummaryChunkQuery(entityType: SocialEntityType, chunk: string[], enabled: boolean) {
+  return {
+    // Sorted so two callers holding the same IDs in different orders share a
+    // cache entry (the request itself keeps the caller's order).
+    queryKey: ['bulkVoteSummaries', entityType, [...chunk].sort()],
+    queryFn: async (): Promise<BulkVoteSummaries> => {
       const response = await getHttpClient().request<GetBulkVoteSummariesQueryResponse>(GET_BULK_VOTE_SUMMARIES, {
-        input: { entityType, entityIds },
+        input: { entityType, entityIds: chunk },
       });
       return response.bulkVoteSummaries;
     },
-    enabled: enabled && entityIds.length > 0,
+    enabled,
+  };
+}
+
+/**
+ * Merges the per-chunk results into one summary list plus the chunks' own
+ * `refetch` handles.
+ *
+ * Passing this to `useQueries` as `combine` is what keeps the merged value
+ * referentially stable. Without a `combine`, `useQueries` hands back a
+ * freshly mapped array on every render, so `.data` would change identity even
+ * when no vote moved — which churns the Home feed's `summaryMap` and, through
+ * FlashList `extraData`, re-invokes `renderItem` for every mounted row on any
+ * unrelated parent render. With `combine`, react-query runs the merge through
+ * `replaceEqualDeep` and hands back the previous value when nothing changed.
+ *
+ * Declared at module scope so its identity never changes: react-query re-runs
+ * `combine` whenever the function itself does.
+ */
+function combineVoteSummaryChunks(results: BulkVoteSummaryChunkResult[]) {
+  return {
+    summaries: results.flatMap((result) => result.data ?? []),
+    // Each `refetch` is bound to its chunk's observer and so is stable across
+    // renders, which lets `replaceEqualDeep` keep this array's identity too.
+    refetchChunks: results.map((result) => result.refetch),
+  };
+}
+
+/**
+ * Shared chunked-query construction for the bulk-vote-summary hooks — one
+ * query per ≤100-ID chunk, merged back into a single stable list.
+ */
+function useBulkVoteSummaryChunks(entityType: SocialEntityType, chunks: string[][], enabled: boolean) {
+  return useQueries({
+    queries: chunks.map((chunk) => bulkVoteSummaryChunkQuery(entityType, chunk, enabled)),
+    combine: combineVoteSummaryChunks,
   });
+}
+
+/**
+ * Splits an ID list into ≤100-ID chunks, once per list change rather than per
+ * render. Memoized on the array reference, so a caller that builds its list
+ * inline (`ticks.map((tick) => tick.uuid)`) re-chunks every render — harmless,
+ * since `useQueries` matches its observers by query hash either way, and the
+ * feed screens that hand over the long lists already memoize them.
+ */
+function useVoteSummaryChunks(entityIds: string[]): string[][] {
+  return useMemo(() => batchVoteSummaryEntityIds(entityIds), [entityIds]);
+}
+
+/**
+ * Accurate vote state (count + `userVote`) for a batch of entities. Chunks
+ * internally so callers never need to worry about the backend's 100-ID cap
+ * (`BulkVoteSummaryInputSchema`) — a caller handing this an unbounded,
+ * paginating list (e.g. a feed) used to blow the cap outright once it passed
+ * 100 rows, failing the whole query. A failed chunk contributes no rows
+ * rather than blanking the ones that did load. `refetch` re-runs every
+ * chunk (e.g. for pull-to-refresh).
+ *
+ * Returns `{ data, refetch }` rather than a `UseQueryResult` — there is no
+ * single query behind it to report `isLoading`/`isError` for. A caller that
+ * needs per-chunk state should use `useQueries` directly.
+ */
+export function useBulkVoteSummaries(entityType: SocialEntityType, entityIds: string[], enabled = true) {
+  const chunks = useVoteSummaryChunks(entityIds);
+  const { summaries, refetchChunks } = useBulkVoteSummaryChunks(entityType, chunks, enabled);
+
+  // Callers keep this object in `useCallback`/`useMemo` deps (Home's
+  // pull-to-refresh handler does), so it only changes when the vote data or
+  // the chunk set actually does.
+  return useMemo(
+    () => ({
+      data: summaries,
+      refetch: () => Promise.all(refetchChunks.map((refetchChunk) => refetchChunk())),
+    }),
+    [summaries, refetchChunks],
+  );
 }
 
 /** Accurate vote state for more than one backend-safe batch of entities. */
 export function useChunkedBulkVoteSummaries(entityType: SocialEntityType, entityIds: string[], enabled = true) {
-  const chunks = chunkEntityIds(dedupeEntityIds(entityIds));
-  const results = useQueries({
-    queries: chunks.map((chunk) => {
-      const sortedIds = [...chunk].sort();
-      return {
-        queryKey: ['bulkVoteSummaries', entityType, sortedIds],
-        queryFn: async () => {
-          if (chunk.length === 0) return [];
-          const response = await getHttpClient().request<GetBulkVoteSummariesQueryResponse>(GET_BULK_VOTE_SUMMARIES, {
-            input: { entityType, entityIds: chunk },
-          });
-          return response.bulkVoteSummaries;
-        },
-        enabled: enabled && chunk.length > 0,
-      };
-    }),
-  });
-
-  return results.flatMap((result) => result.data ?? []);
+  const chunks = useVoteSummaryChunks(entityIds);
+  return useBulkVoteSummaryChunks(entityType, chunks, enabled).summaries;
 }
 
 /** Accurate vote state for stable groups, such as individual feed pages. */
 export function useGroupedBulkVoteSummaries(entityType: SocialEntityType, entityIdGroups: string[][], enabled = true) {
-  const chunks = entityIdGroups.flatMap((entityIds) => chunkEntityIds(dedupeEntityIds(entityIds)));
-  const results = useQueries({
-    queries: chunks.map((chunk) => {
-      const sortedIds = [...chunk].sort();
-      return {
-        queryKey: ['bulkVoteSummaries', entityType, sortedIds],
-        queryFn: async () => {
-          if (chunk.length === 0) return [];
-          const response = await getHttpClient().request<GetBulkVoteSummariesQueryResponse>(GET_BULK_VOTE_SUMMARIES, {
-            input: { entityType, entityIds: chunk },
-          });
-          return response.bulkVoteSummaries;
-        },
-        enabled: enabled && chunk.length > 0,
-      };
-    }),
-  });
-
-  return results.flatMap((result) => result.data ?? []);
+  const chunks = useMemo(
+    () => entityIdGroups.flatMap((entityIds) => batchVoteSummaryEntityIds(entityIds)),
+    [entityIdGroups],
+  );
+  return useBulkVoteSummaryChunks(entityType, chunks, enabled).summaries;
 }
 
 /** Comment thread for a social entity. */

--- a/packages/shared-schema/src/__tests__/vote-summary-batching.test.ts
+++ b/packages/shared-schema/src/__tests__/vote-summary-batching.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { BULK_VOTE_SUMMARY_CHUNK_SIZE, batchVoteSummaryEntityIds } from '../vote-summary-batching';
+
+function makeEntityIds(count: number, prefix = 'tick'): string[] {
+  return Array.from({ length: count }, (_, index) => `${prefix}-${String(index).padStart(3, '0')}`);
+}
+
+describe('batchVoteSummaryEntityIds', () => {
+  it('returns no batches for an empty list, so callers can skip the request', () => {
+    expect(batchVoteSummaryEntityIds([])).toEqual([]);
+  });
+
+  it('keeps a list at the cap as a single batch', () => {
+    const batches = batchVoteSummaryEntityIds(makeEntityIds(BULK_VOTE_SUMMARY_CHUNK_SIZE));
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(BULK_VOTE_SUMMARY_CHUNK_SIZE);
+  });
+
+  it('splits a list over the cap so no batch can be rejected by the backend', () => {
+    const entityIds = makeEntityIds(235);
+
+    const batches = batchVoteSummaryEntityIds(entityIds);
+
+    expect(batches.map((batch) => batch.length)).toEqual([100, 100, 35]);
+    for (const batch of batches) {
+      expect(batch.length).toBeLessThanOrEqual(BULK_VOTE_SUMMARY_CHUNK_SIZE);
+    }
+    expect(batches.flat()).toEqual(entityIds);
+  });
+
+  it('drops duplicates in first-seen order before batching', () => {
+    const batches = batchVoteSummaryEntityIds(['tick-b', 'tick-a', 'tick-b', 'tick-c', 'tick-a']);
+
+    expect(batches).toEqual([['tick-b', 'tick-a', 'tick-c']]);
+  });
+
+  it('counts an entity once against the cap even when the caller repeats it', () => {
+    const duplicatedIds = makeEntityIds(100).flatMap((entityId) => [entityId, entityId]);
+
+    expect(batchVoteSummaryEntityIds(duplicatedIds)).toHaveLength(1);
+  });
+});

--- a/packages/shared-schema/src/index.ts
+++ b/packages/shared-schema/src/index.ts
@@ -13,3 +13,4 @@ export * from './aurora-import';
 export * from './moonboard-import';
 export * from './instagram-caption-parse';
 export * from './sync-error-codes';
+export * from './vote-summary-batching';

--- a/packages/shared-schema/src/vote-summary-batching.ts
+++ b/packages/shared-schema/src/vote-summary-batching.ts
@@ -1,0 +1,28 @@
+/**
+ * Batching rules for `bulkVoteSummaries`, shared by the backend validator and
+ * every client that builds a vote-summary request.
+ */
+
+/**
+ * Hard cap on how many entity IDs a single `bulkVoteSummaries` request may
+ * carry. The backend rejects an over-cap request outright (see
+ * `BulkVoteSummaryInputSchema`), so a caller with an unbounded list — a
+ * paginating feed, a long logbook — has to split it with
+ * {@link batchVoteSummaryEntityIds} instead of handing the whole list over.
+ */
+export const BULK_VOTE_SUMMARY_CHUNK_SIZE = 100;
+
+/**
+ * Splits entity IDs into batches the backend will accept, dropping duplicates
+ * (in first-seen order) so a feed that shows the same entity twice doesn't
+ * spend cap headroom on it. Empty input yields no batches at all, which lets
+ * callers skip the request entirely.
+ */
+export function batchVoteSummaryEntityIds(entityIds: readonly string[]): string[][] {
+  const uniqueIds = Array.from(new Set(entityIds));
+  const batches: string[][] = [];
+  for (let startIndex = 0; startIndex < uniqueIds.length; startIndex += BULK_VOTE_SUMMARY_CHUNK_SIZE) {
+    batches.push(uniqueIds.slice(startIndex, startIndex + BULK_VOTE_SUMMARY_CHUNK_SIZE));
+  }
+  return batches;
+}

--- a/packages/web/app/components/social/__tests__/vote-summary-context.test.tsx
+++ b/packages/web/app/components/social/__tests__/vote-summary-context.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi, beforeEach } from 'vite-plus/test';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { GET_BULK_VOTE_SUMMARIES } from '@boardsesh/graphql/operations';
+import type { VoteSummary } from '@boardsesh/shared-schema';
+import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
+import { createTestQueryClient } from '@/app/test-utils/test-providers';
+import { VoteSummaryProvider, useVoteSummaryContext } from '../vote-summary-context';
+
+const mockRequest = vi.fn();
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: vi.fn(),
+}));
+
+const mockUseWsAuthToken = vi.mocked(useWsAuthToken);
+
+function makeVoteSummary(entityId: string): VoteSummary {
+  return { entityType: 'tick', entityId, upvotes: 1, downvotes: 0, voteScore: 1, userVote: 0 };
+}
+
+function makeWrapper(entityIds: string[]) {
+  const queryClient = createTestQueryClient();
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <VoteSummaryProvider entityType="tick" entityIds={entityIds}>
+        {children}
+      </VoteSummaryProvider>
+    </QueryClientProvider>
+  );
+  return Wrapper;
+}
+
+beforeEach(() => {
+  mockRequest.mockReset();
+  mockUseWsAuthToken.mockReturnValue({ token: 'test-token', isAuthenticated: true, isLoading: false, error: null });
+});
+
+// Regression coverage for #4102: any of the seven VoteSummaryProvider call
+// sites (logbook, feeds, session detail) can pass more than 100 entity ids,
+// which the backend's BulkVoteSummaryInputSchema rejects outright
+// (`.max(100)`). The provider must chunk internally so no single request
+// ever exceeds the cap, and callers no longer need to slice their own lists.
+describe('VoteSummaryProvider', () => {
+  it('splits entity ids over the backend 100-ID cap into multiple <=100-ID requests', async () => {
+    const entityIds = Array.from({ length: 135 }, (_, index) => `tick-${String(index).padStart(3, '0')}`);
+    mockRequest.mockImplementation((_query: unknown, variables: { input: { entityIds: string[] } }) =>
+      Promise.resolve({
+        bulkVoteSummaries: variables.input.entityIds.map((entityId) => makeVoteSummary(entityId)),
+      }),
+    );
+
+    const { result } = renderHook(() => useVoteSummaryContext(), { wrapper: makeWrapper(entityIds) });
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2));
+    for (const [query, variables] of mockRequest.mock.calls as [unknown, { input: { entityIds: string[] } }][]) {
+      expect(query).toBe(GET_BULK_VOTE_SUMMARIES);
+      expect(variables.input.entityIds.length).toBeLessThanOrEqual(100);
+    }
+
+    await waitFor(() => expect(result.current?.getVoteSummary('tick-000')).toBeDefined());
+    expect(result.current?.getVoteSummary('tick-134')).toBeDefined();
+  });
+
+  it("keeps a resolved chunk's summaries available when a sibling chunk's request fails", async () => {
+    const entityIds = Array.from({ length: 135 }, (_, index) => `tick-${String(index).padStart(3, '0')}`);
+    mockRequest.mockImplementation((_query: unknown, variables: { input: { entityIds: string[] } }) => {
+      // The second chunk (ids 100-134) fails; the first chunk (0-99) resolves.
+      if (variables.input.entityIds.includes('tick-100')) {
+        return Promise.reject(new Error('chunk 2 failed'));
+      }
+      return Promise.resolve({
+        bulkVoteSummaries: variables.input.entityIds.map((entityId) => makeVoteSummary(entityId)),
+      });
+    });
+
+    const { result } = renderHook(() => useVoteSummaryContext(), { wrapper: makeWrapper(entityIds) });
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(result.current?.getVoteSummary('tick-000')).toBeDefined());
+
+    expect(result.current?.getVoteSummary('tick-099')).toBeDefined();
+    // The failed chunk's rows are simply absent, not blanking the rows that did load.
+    expect(result.current?.getVoteSummary('tick-100')).toBeUndefined();
+  });
+
+  // The provider wraps surfaces with 100+ VoteButtons, and every one of them
+  // re-renders whenever the context value changes identity. `useQueries` only
+  // holds identity when it is given a `combine` — see combineVoteSummaryChunks
+  // in vote-summary-context.tsx.
+  it('holds the context value identity across provider re-renders, so VoteButtons do not re-render', async () => {
+    const entityIds = Array.from({ length: 135 }, (_, index) => `tick-${String(index).padStart(3, '0')}`);
+    mockRequest.mockImplementation((_query: unknown, variables: { input: { entityIds: string[] } }) =>
+      Promise.resolve({
+        bulkVoteSummaries: variables.input.entityIds.map((entityId) => makeVoteSummary(entityId)),
+      }),
+    );
+    const queryClient = createTestQueryClient();
+    // A fresh array on every provider render, the way a caller passing
+    // `ticks.map((tick) => tick.uuid)` inline would.
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <VoteSummaryProvider entityType="tick" entityIds={[...entityIds]}>
+          {children}
+        </VoteSummaryProvider>
+      </QueryClientProvider>
+    );
+
+    const { result, rerender } = renderHook(() => useVoteSummaryContext(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current?.getVoteSummary('tick-134')).toBeDefined());
+    const settledValue = result.current;
+
+    rerender();
+    rerender();
+
+    expect(result.current).toBe(settledValue);
+  });
+});

--- a/packages/web/app/components/social/__tests__/vote-summary-context.test.tsx
+++ b/packages/web/app/components/social/__tests__/vote-summary-context.test.tsx
@@ -42,11 +42,12 @@ beforeEach(() => {
   mockUseWsAuthToken.mockReturnValue({ token: 'test-token', isAuthenticated: true, isLoading: false, error: null });
 });
 
-// Regression coverage for #4102: any of the seven VoteSummaryProvider call
-// sites (logbook, feeds, session detail) can pass more than 100 entity ids,
-// which the backend's BulkVoteSummaryInputSchema rejects outright
-// (`.max(100)`). The provider must chunk internally so no single request
-// ever exceeds the cap, and callers no longer need to slice their own lists.
+// Regression coverage for #4102: any of the four VoteSummaryProvider call
+// sites (activity feed, global ascents, following ascents, session detail)
+// can pass more than 100 entity ids, which the backend's
+// BulkVoteSummaryInputSchema rejects outright (`.max(100)`). The provider
+// must chunk internally so no single request ever exceeds the cap, and
+// callers no longer need to slice their own lists.
 describe('VoteSummaryProvider', () => {
   it('splits entity ids over the backend 100-ID cap into multiple <=100-ID requests', async () => {
     const entityIds = Array.from({ length: 135 }, (_, index) => `tick-${String(index).padStart(3, '0')}`);

--- a/packages/web/app/components/social/vote-summary-context.tsx
+++ b/packages/web/app/components/social/vote-summary-context.tsx
@@ -55,11 +55,16 @@ type VoteSummaryProviderProps = {
  * VoteButtons with this provider to avoid N+1 individual requests.
  *
  * Chunks internally so callers never need to slice their entityIds list
- * before handing it here — a caller-side cap used to silently drop rows
- * past 100 to a `0` vote display instead of fetching their real count.
- * If one chunk's request fails, the rows it covered simply stay
- * unhydrated (VoteButton falls back to its own single-entity fetch);
- * chunks that did resolve still populate the map.
+ * before handing it here — the backend rejects an over-cap request outright
+ * (`BulkVoteSummaryInputSchema`), so a paginating feed used to lose every
+ * vote count on the page that pushed it past 100.
+ *
+ * Chunks fetch, cache and retry independently, so a failed chunk still
+ * leaves its siblings populating the map. The rows that chunk covered do
+ * NOT recover on their own: VoteButton skips its single-entity fallback
+ * whenever a provider is above it (vote-button.tsx), so those buttons keep
+ * showing their `initial*` props until this provider remounts or the
+ * chunk's query is invalidated.
  */
 export function VoteSummaryProvider({ entityType, entityIds, children }: VoteSummaryProviderProps) {
   const { token, isAuthenticated, isLoading: isAuthLoading } = useWsAuthToken();

--- a/packages/web/app/components/social/vote-summary-context.tsx
+++ b/packages/web/app/components/social/vote-summary-context.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { createContext, useContext, useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQueries } from '@tanstack/react-query';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
 import {
@@ -9,7 +9,25 @@ import {
   type GetBulkVoteSummariesQueryVariables,
   type GetBulkVoteSummariesQueryResponse,
 } from '@boardsesh/graphql/operations';
-import type { SocialEntityType, VoteSummary } from '@boardsesh/shared-schema';
+import { batchVoteSummaryEntityIds, type SocialEntityType, type VoteSummary } from '@boardsesh/shared-schema';
+
+/**
+ * Merges the per-chunk results into one summary list.
+ *
+ * Passing this to `useQueries` as `combine` is what keeps the merged list
+ * referentially stable. Without a `combine`, `useQueries` hands back a freshly
+ * mapped array on every render, which would rebuild `summariesMap` and re-mint
+ * the context value on every provider render — re-rendering every VoteButton
+ * beneath a provider that can wrap 100+ of them. With `combine`, react-query
+ * runs the merge through `replaceEqualDeep` and hands back the previous value
+ * when no vote changed.
+ *
+ * Declared at module scope so its identity never changes: react-query re-runs
+ * `combine` whenever the function itself does.
+ */
+function combineVoteSummaryChunks(results: { data: VoteSummary[] | undefined }[]): VoteSummary[] {
+  return results.flatMap((result) => result.data ?? []);
+}
 
 type VoteSummaryContextValue = {
   getVoteSummary: (entityId: string) => VoteSummary | undefined;
@@ -33,43 +51,59 @@ type VoteSummaryProviderProps = {
 
 /**
  * Batch-fetches vote summaries (including userVote) for a list of entities
- * in a single GET_BULK_VOTE_SUMMARIES request and provides them via context.
- * Wrap groups of VoteButtons with this provider to avoid N+1 individual requests.
+ * via GET_BULK_VOTE_SUMMARIES and provides them via context. Wrap groups of
+ * VoteButtons with this provider to avoid N+1 individual requests.
+ *
+ * Chunks internally so callers never need to slice their entityIds list
+ * before handing it here — a caller-side cap used to silently drop rows
+ * past 100 to a `0` vote display instead of fetching their real count.
+ * If one chunk's request fails, the rows it covered simply stay
+ * unhydrated (VoteButton falls back to its own single-entity fetch);
+ * chunks that did resolve still populate the map.
  */
 export function VoteSummaryProvider({ entityType, entityIds, children }: VoteSummaryProviderProps) {
   const { token, isAuthenticated, isLoading: isAuthLoading } = useWsAuthToken();
 
-  const sortedIds = useMemo(() => [...entityIds].sort(), [entityIds]);
-  const queryKey = useMemo(
-    () => ['bulkVoteSummaries', entityType, sortedIds.join(',')] as const,
-    [entityType, sortedIds],
-  );
+  const chunks = useMemo(() => batchVoteSummaryEntityIds(entityIds), [entityIds]);
 
-  const { data: summariesMap } = useQuery({
-    queryKey,
-    queryFn: async (): Promise<Map<string, VoteSummary>> => {
-      if (sortedIds.length === 0) return new Map();
-      const client = createGraphQLHttpClient(token);
-      const response = await client.request<GetBulkVoteSummariesQueryResponse, GetBulkVoteSummariesQueryVariables>(
-        GET_BULK_VOTE_SUMMARIES,
-        {
-          input: { entityType, entityIds: sortedIds },
+  const summaries = useQueries({
+    queries: chunks.map((chunk) => {
+      // Sorted so the key is order-independent *within* a chunk; each chunk
+      // caches independently under its own (entityType, sortedChunkIds) key.
+      // Chunk boundaries still follow the caller's order, which is what keeps
+      // an append-only feed's earlier chunks cached as it pages.
+      const sortedIds = [...chunk].sort();
+      return {
+        queryKey: ['bulkVoteSummaries', entityType, sortedIds.join(',')] as const,
+        queryFn: async (): Promise<VoteSummary[]> => {
+          const client = createGraphQLHttpClient(token);
+          const response = await client.request<GetBulkVoteSummariesQueryResponse, GetBulkVoteSummariesQueryVariables>(
+            GET_BULK_VOTE_SUMMARIES,
+            {
+              input: { entityType, entityIds: sortedIds },
+            },
+          );
+          return response.bulkVoteSummaries;
         },
-      );
-      const map = new Map<string, VoteSummary>();
-      for (const summary of response.bulkVoteSummaries) {
-        map.set(summary.entityId, summary);
-      }
-      return map;
-    },
-    enabled: isAuthenticated && !isAuthLoading && sortedIds.length > 0 && !!token,
-    staleTime: 5 * 60 * 1000,
-    refetchOnWindowFocus: false,
+        enabled: isAuthenticated && !isAuthLoading && !!token,
+        staleTime: 5 * 60 * 1000,
+        refetchOnWindowFocus: false,
+      };
+    }),
+    combine: combineVoteSummaryChunks,
   });
+
+  const summariesMap = useMemo(() => {
+    const map = new Map<string, VoteSummary>();
+    for (const summary of summaries) {
+      map.set(summary.entityId, summary);
+    }
+    return map;
+  }, [summaries]);
 
   const value = useMemo<VoteSummaryContextValue>(
     () => ({
-      getVoteSummary: (entityId: string) => summariesMap?.get(entityId),
+      getVoteSummary: (entityId: string) => summariesMap.get(entityId),
     }),
     [summariesMap],
   );


### PR DESCRIPTION
## Summary

`bulkVoteSummaries` rejects any request over 100 entity IDs (`BulkVoteSummaryInputSchema.entityIds.max(100)` in `packages/backend/src/validation/schemas/comments.ts`), but the paginating feeds hand it an unbounded list that grows with every page. Once the list crosses 100 the whole query is rejected outright, so every vote button on screen loses its count and the viewer's own vote state (Sentry BOARDSESH-CJ, and the bulk of BOARDSESH-7H).

- **Mobile:** `useBulkVoteSummaries` (`packages/mobile/src/lib/graphql/hooks/use-social.ts`) now chunks internally — one `useQueries` entry per ≤100-ID batch, merged back into a single list, no caller changes needed. `SOCIAL_PAGE_SIZE` is 30, so the Home feed (`app/(tabs)/home/index.tsx`) and You → Sessions (`SessionsTab.tsx`) both blow the cap on roughly the fourth page.
- **Web:** `VoteSummaryProvider` (`packages/web/app/components/social/vote-summary-context.tsx`) does the same chunking, which covers all four surviving providers at once: the activity feed, the global-ascents feed, the following-ascents feed and session detail. Those feeds page at `limit: 20`, so they cross the cap around the sixth page.
- **Backend cap left as-is.** Kept the hard reject rather than raising it or making the server silently truncate. A truncating server would turn a loud failure into quietly wrong counts; batching is what the callers actually needed.
- **Partial-failure isolation:** a chunk whose request fails contributes no rows, but the chunks that did resolve still render. One bad request no longer blanks the whole batch. Covered by tests on both sides.

### One home for the 100-ID cap

The chunk helpers and the cap were copied between web and mobile, and the number itself was written out in three places. They now live in `@boardsesh/shared-schema` as `batchVoteSummaryEntityIds` / `BULK_VOTE_SUMMARY_CHUNK_SIZE`, imported by both clients, and `BulkVoteSummaryInputSchema` reads the same constant.

The drift protection is structural rather than test-enforced: there is one constant with three consumers, so the client batch size and the server cap cannot disagree by construction. `social-validation.test.ts` derives its accept/reject boundary from that same constant, which documents the agreement but passes for any value of it — so it also carries one literal case (`101 IDs must be rejected; the constant is 100`) that a deliberate cap change has to acknowledge instead of sliding through.

### Keeping the merged results referentially stable

The `useQuery` → `useQueries` move would have quietly dropped React Query's structural sharing. Without a `combine`, `useQueries` hands back a freshly mapped array on every render (verified in the installed query-core 5.101.4: `#combineResult` returns its raw `input` unless `combine` is set), so the flattened summaries changed identity even when no vote had moved.

- **Mobile:** that churned the Home feed's `summaryMap`, which FlashList reads as `extraData` — the documented single signal that re-invokes `renderItem` — so every mounted row re-rendered on any unrelated parent render (mode switch, comment sheet, `isFetchingNextPage` flip).
- **Web:** it re-minted the `VoteSummaryProvider` context value on every provider render, re-rendering every `VoteButton` under a provider that can wrap 100+ of them.

Both sides now pass a module-scope `combine`, so React Query runs the merge through `replaceEqualDeep` and returns the previous value when nothing changed. Mobile's `combine` also carries the per-chunk `refetch` handles (each bound to its own observer, so stable across renders), which lets `useBulkVoteSummaries` memoize the `{ data, refetch }` object Home lists in its pull-to-refresh deps.

### Two orphaned hooks deleted

`useChunkedBulkVoteSummaries` and `useGroupedBulkVoteSummaries` had no caller anywhere in the repo — only their definitions, the hooks-barrel re-export and a `vi.mock` stub referenced them. Now that `useBulkVoteSummaries` chunks on its own there is no reason for them to grow one, so both are gone. Their two single-caller wrappers fold into `useBulkVoteSummaries`.

### Notes for the reviewer

- `useBulkVoteSummaries` returns `{ data, refetch }` rather than a `UseQueryResult`. There is no single query behind it to report `isLoading` / `isError` for, and an aggregate status across independently-retrying chunks would be a fiction. All three callers were checked: none reads anything but `.data` and `.refetch`.
- **A failed chunk does not self-heal.** Its rows keep whatever `initial*` props they were rendered with until the provider remounts or the chunk's query is invalidated — `VoteButton` skips its own single-entity fallback whenever a provider is above it, and relaxing that would fire one request per button on every cold render, which is the N+1 the provider exists to prevent.
- The mobile hook sends `entityIds` in the caller's order while the web provider sends them sorted. Both key on the sorted chunk, so both are correct; aligning them is cosmetic.
- This branch had already been rebased onto a `main` that dropped its edits to `logbook-view.tsx` and `crew-logbook-view.tsx` — those files were deleted from `packages/web` by #4467, along with the `VOTE_SUMMARY_BATCH_LIMIT` slice that used to truncate a long logbook to 100 rows. Nothing on web truncates any more, so that arm of the issue is gone with the surface.
- **Ships over the air.** No native config, plugin, module or native dependency is touched, so the Expo fingerprint does not move.
- This PR was carried forward across several review rounds (Claude Review, an independent Fable pass, and a follow-up review against the installed `@tanstack/query-core`) before this session rebased it onto current `main` (clean, no conflicts) and rewrote the Test plan / Risk sections to match the current PR template. The implementation is unchanged from what was already reviewed and marked ready to merge.

### Author-side verification (this session)

- `vp run typecheck` — pending in CI (local `vp install` is contending with ~15 other agents' installs in this sandbox).
- `vp check` — pending in CI, same reason.
- Read through the full diff against current `main`: `vote-summary-batching.ts`, the backend schema, both hooks/providers, and every caller (`SessionsTab.tsx`, `home/index.tsx`, `SessionDetailScreen.tsx`, `activity-feed.tsx`, `global-ascents-feed.tsx`, `following-ascents-feed.tsx`, `session-detail-content.tsx`) — every previously-unchunked caller now goes through a chunking entry point, and the two dead hooks stay deleted.
- `packages/shared-schema/src/__tests__/vote-summary-batching.test.ts` — empty input yields no batches, exactly-at-cap stays one batch, 235 IDs split `[100, 100, 35]` with `batches.flat()` equal to the input, duplicates dropped in first-seen order, duplicates don't eat cap headroom.
- `packages/backend/src/__tests__/social-validation.test.ts` — accepts exactly `BULK_VOTE_SUMMARY_CHUNK_SIZE` IDs and rejects one more (both derived from the shared constant), plus a literal case pinning the wire cap at 100.
- Mobile and web regression tests both drive 135 IDs through the real entry point and assert: exactly 2 requests, `entityIds.length <= 100` on every one of them, all 135 IDs covered; a failing sibling chunk leaves the resolved chunk's 100 rows intact with `tick-100` absent; and the returned value holds identity across re-renders that pass a fresh `[...entityIds]` array each time.
- No visual change — data fetching only, no markup touched.

Closes #4102

## Release Notes

- Like counts and your own likes keep loading as you scroll deep into the Home feed and your Sessions list. Past about the fourth page they used to stop showing up entirely.

## Test plan

1. Scroll Home past 100 posts. Like counts stay visible, not blank.
2. In Sessions, scroll past several pages of ticks. Vote counts stay visible.
3. Tap a heart far down a long list. It fills in.
4. On web, scroll a long ascents feed. Counts stay real, not zero.

## Risk

Risk: 2/5 — touches the vote-count fetch path on every feed on both platforms, but it's data-only (no markup changes), each chunk fetches and fails independently, and the logic carries unit + integration-style tests reviewed across several independent passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSwiTWgtzw4iyotNLPf5sA
