### PR TITLE
chore(db): add legacy timestamp audit tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,12 @@ jobs:
               - 'packages/db/scripts/migration-journal.ts'
               - 'packages/db/scripts/verify-migration-journal.ts'
               - 'packages/db/scripts/migration-journal-verification.integration.test.ts'
+              # packages/db is a node:test package, not a vitest project, so
+              # nothing in it reaches test-default. The db-migrations job is
+              # where CI executes its suites; keep this gate in step with the
+              # `Run the legacy-timestamp audit unit suites` step below.
+              - 'packages/db/scripts/audit-legacy-tick-timestamps*'
+              - 'packages/db/scripts/legacy-timestamp-audit-core*'
               # Defines the test:migration-journal script this job's new step
               # invokes, so editing it has to run the job that depends on it.
               - 'packages/db/package.json'
@@ -601,6 +607,13 @@ jobs:
         env:
           MIGRATION_JOURNAL_DB_URL: postgres://postgres:postgres@localhost:5432/postgres
         run: vp run test:db:migration-journal
+      # packages/db runs on node:test, so its suites are invisible to
+      # test-default's vitest project list. Without this step the audit tooling
+      # in packages/db/scripts would have zero CI coverage. No database needed:
+      # these two suites are pure unit tests (the audit's own integration test
+      # self-skips without LEGACY_TIMESTAMP_AUDIT_DB_URL).
+      - name: Run the legacy-timestamp audit unit suites
+        run: vp run test:db:legacy-timestamp-audit
 
   codegen-drift:
     needs: [changes]

--- a/docs/legacy-timestamp-audit.md
+++ b/docs/legacy-timestamp-audit.md
@@ -9,7 +9,7 @@ not a backfill:
   Boardsesh command;
 - every database read occurs on one reserved PostgreSQL connection in one
   `SERIALIZABLE READ ONLY DEFERRABLE` snapshot, after the command sets and
-  verifies `TimeZone=UTC`;
+  verifies `TimeZone=UTC` and a five-minute statement timeout;
 - a failed scan leaves no file at the requested output path.
 
 This phase does **not** repair historical rows or close #3909. Release notes for
@@ -80,6 +80,15 @@ discarded; system/global config is disabled; and the output-relative path is
 passed after `--` with literal pathspec handling. The command stages a
 mode-`0600` partial file, syncs it, and publishes it with an exclusive hard link
 so a racing file is never overwritten.
+
+Database startup is limited to 30 seconds. Inside the transaction, PostgreSQL
+aborts any individual statement or cursor fetch that runs for more than 300
+seconds. The client separately rejects any awaited database response after 330
+seconds and force-closes that connection, covering a network path that cannot
+deliver the server timeout. The client timer stops before local group analysis
+or artifact writes and starts fresh for every database response, so these are
+per-response and per-fetch bounds rather than a total audit deadline. A timeout
+removes the partial artifact; rerun the audit to obtain a new complete snapshot.
 
 ## What counts as evidence
 
@@ -248,6 +257,7 @@ The header records:
 - source revisions and the exact scan-query digest;
 - PostgreSQL snapshot token, server version, transaction settings, and a digest
   of the inspected `boardsesh_ticks` schema;
+- the server-observed statement timeout and the client connect/response bounds;
 - explicit safety flags recording the candidate/Kilter sync guards, the
   unchanged-native requirement, and the single-artifact scope of the records
   digest.
@@ -263,12 +273,14 @@ records. Completion time, duration, and random run id are in a separate
 
 ## Query-plan check
 
-The scan is cursor-paged in batches of 500 and retains only one natural-key group
-in memory (hard limit 10,000 rows). It performs no per-row query, uses binary
-search over time-sorted semantics-compatible anchors, and stores only linear
-degree/sole-edge state even when a dense group has a quadratic number of logical
-edges. Its stable order follows the leading columns of
-`boardsesh_ticks_user_climb_lookup_idx`, with `id` as the final tie-break.
+The scan uses a transaction-local SQL cursor and awaits each `FETCH FORWARD 500`
+response before processing that batch. It completes the batch's local artifact
+writes before fetching again, including the final short batch, and retains only
+one natural-key group in memory (hard limit 10,000 rows). It performs no per-row
+query, uses binary search over time-sorted semantics-compatible anchors, and
+stores only linear degree/sole-edge state even when a dense group has a
+quadratic number of logical edges. Its stable order follows the leading columns
+of `boardsesh_ticks_user_climb_lookup_idx`, with `id` as the final tie-break.
 
 Before a production audit, run the opt-in integration test against a current
 **local** migrated database:

--- a/docs/legacy-timestamp-audit.md
+++ b/docs/legacy-timestamp-audit.md
@@ -12,6 +12,12 @@ not a backfill:
   verifies `TimeZone=UTC` and a five-minute statement timeout;
 - a failed scan leaves no file at the requested output path.
 
+That snapshot also decides where the audit runs: point `DB_URL` at the
+**primary**. PostgreSQL refuses serializable isolation on a hot standby
+(`cannot use serializable mode in a hot standby`), so a read-replica URL fails
+closed on `BEGIN`, before any row is read. Replicas are still the right place
+for the plain-`EXPLAIN` plan review in [Query-plan check](#query-plan-check).
+
 This phase does **not** repair historical rows or close #3909. Release notes for
 the audit-only PR are `none`.
 
@@ -295,6 +301,8 @@ It executes `EXPLAIN (FORMAT JSON, COSTS true)` for the exact exported query and
 asserts there is no modifying plan node, then exercises the real snapshot
 settings. On a production read replica, inspect the same plain `EXPLAIN` (never
 `EXPLAIN ANALYZE` on the full scan) for unexpected sequential scans, large disk
-sorts, or a row estimate that makes the 500-row cursor unsuitable. Record that
-review beside the deployment-policy evidence; do not alter session planner
+sorts, or a row estimate that makes the 500-row cursor unsuitable. That
+inspection is the only replica-side step: the audit run itself needs the
+primary, because its serializable snapshot cannot be taken on a standby. Record
+that review beside the deployment-policy evidence; do not alter session planner
 settings just to force a preferred-looking plan.

--- a/docs/legacy-timestamp-audit.md
+++ b/docs/legacy-timestamp-audit.md
@@ -1,0 +1,288 @@
+# Legacy timestamp audit (#3909)
+
+`vp run db:audit-legacy-timestamps` collects evidence about Aurora/JSON ticks
+whose local wall-clock time may have been relabelled as UTC. It is deliberately
+not a backfill:
+
+- there is no `--apply` option, generated SQL, delete, update, or migration;
+- the output is an evidence-only JSONL artifact, not an input accepted by any
+  Boardsesh command;
+- every database read occurs on one reserved PostgreSQL connection in one
+  `SERIALIZABLE READ ONLY DEFERRABLE` snapshot, after the command sets and
+  verifies `TimeZone=UTC`;
+- a failed scan leaves no file at the requested output path.
+
+This phase does **not** repair historical rows or close #3909. Release notes for
+the audit-only PR are `none`.
+
+## Verified deployment policy is required
+
+The timestamp-normalizer source lineage has six distinct points:
+
+- `8fe79f60d` introduced the JSON importer with the unsafe
+  `new Date(naiveTimestamp)` normalizer;
+- `79185b916800b866173da01e4ec34743b0015218` fixed naive JSON timestamps on
+  March 28, 2026, and is the source revision that must anchor JSON deployment
+  evidence;
+- `45cef340a` moved the already-fixed JSON importer into `@boardsesh/aurora-sync`;
+- `71937db6a` fixed the live Aurora pull and extracted the normalizer shared by
+  the live pull and JSON importer;
+- `ad4b39c08` made that shared normalizer safe for space-separated timestamps
+  carrying an explicit UTC-offset suffix;
+- `cdf1406dfb53f1865513fd005d39b13f469a74e1` made the still-active legacy web
+  `saveAscent` proxy use the shared normalizer when it writes
+  `boardsesh_ticks.origin='native'`; its parent lineage already contains the
+  explicit-offset fix above.
+
+These revisions are code provenance, not deployment timestamps. In particular,
+the July revisions do not mark the beginning of naive-JSON safety: that line
+starts with a verified deployment containing `79185b916...`. A commit
+date, merge time, container build time, or migration timestamp must never be
+used as the data cutoff. Before running the audit, obtain independently verified
+rollout instants from deployment records:
+
+- the last instant at which the old live-pull code is known to have been active;
+- the first instant at which all live-pull instances are known to have had the
+  fixed code;
+- the last verified old and first verified fixed JSON-import deployments;
+- the first instant after migration 0156 had completed and every active writer
+  stamped `origin` itself;
+- the first instant when migration 0146's `updated_at` guard was active and
+  every native writer that could still receive traffic independently wrote safe
+  UTC timestamps, or had been retired. This includes both GraphQL `saveTick`
+  and the legacy web `saveAscent` proxy; no single writer's fix establishes the
+  boundary for the others.
+
+The open interval in either writer's last-old/first-fixed pair is an uncertain
+rollout cohort. Its rows always abstain. Use a non-secret policy slug that points
+a human reviewer to the deployment record; do not put credentials or free-form
+incident notes in it.
+
+```sh
+vp run db:audit-legacy-timestamps -- \
+  --output /secure/new-legacy-timestamp-audit.jsonl \
+  --policy-id verified-deploy-record-YYYYMMDD \
+  --live-old-code-active-through <ISO-with-Z-or-offset> \
+  --live-fixed-code-active-from <ISO-with-Z-or-offset> \
+  --json-old-code-active-through <ISO-with-Z-or-offset> \
+  --json-fixed-code-active-from <ISO-with-Z-or-offset> \
+  --origin-writers-active-from <ISO-with-Z-or-offset> \
+  --native-safe-generation-active-from <ISO-with-Z-or-offset>
+```
+
+The output must be a new untracked regular file under a real (not symlinked)
+directory. Stdout, an existing path, a symlink, or a Git-tracked path is refused.
+Tracking is checked in the repository containing the resolved output parent,
+even when the command is run from a different repository. An indeterminate Git
+probe fails closed. Repository and index probes run with a minimal environment:
+inherited `GIT_*` repository, ceiling, index, config, and pathspec controls are
+discarded; system/global config is disabled; and the output-relative path is
+passed after `--` with literal pathspec handling. The command stages a
+mode-`0600` partial file, syncs it, and publishes it with an exclusive hard link
+so a racing file is never overwritten.
+
+## What counts as evidence
+
+Candidates and anchors are partitioned by the exact
+`(user, board, climb, angle)` key. The analyzer evaluates the complete bipartite
+candidate-to-anchor graph for that key before it applies cohort filters. It
+streams endpoint degree counts and retains only the sole edge that could be
+usable for each candidate, rather than retaining a quadratic edge array. An
+edge requires all of the following:
+
+- matching attempt-versus-ascent semantics;
+- the same attempt count and mirror flag;
+- a timestamp delta within 60 seconds of an explicit current IANA UTC offset;
+- a non-detached `kilter_pull` graph anchor or any `native` graph anchor,
+  including native rows from before origin writers were verified. A native
+  graph anchor is usable evidence only when its origin is independently
+  writer-stamped, it was created at or after the verified safe-save instant,
+  and its stored `created_at` exactly equals `updated_at`. A Kilter graph anchor
+  is usable only when it is writer-stamped, has a source sync stamp, and its
+  `updated_at` is not later than `kilter_synced_at`.
+
+The offset allowlist spans `-12:00` through `+14:00` and includes real half- and
+quarter-hour zones such as `+05:45`, `+08:45`, and `+12:45`. It is not “every 15
+minutes.” A candidate is correction evidence only when both endpoint degrees are
+exactly one. Multiple candidates for one anchor, multiple anchors for one
+candidate, semantic disagreement, missing anchors, or an uncertain writer rollout
+all abstain. An offset observed for one climb is never extrapolated to another
+climb, another date, or an entire user, so DST and travel do not need guessed
+account-level rules. A historical Kilter row whose `origin` may have come from
+migration 0156 remains in the graph so it can make another match ambiguous, but
+a clean edge to that row is classified as
+`heuristic_only_anchor_abstention`. It cannot become correction evidence, an
+aligned control, or a post-fix invariant violation.
+
+Every Aurora/JSON candidate and every non-detached Kilter anchor participates in
+the graph before timestamp provenance is judged. That includes rows with a
+missing sync stamp, a later local edit, or a JSON placeholder that a live pull
+has claimed. They can increase endpoint degree and force
+`ambiguous_abstention`. A reciprocal clean edge to an Aurora candidate with
+`updated_at > aurora_synced_at`, or to any JSON candidate without the exact
+still-synthetic import stamps, is `candidate_timestamp_unverified_abstention`.
+An Aurora row with no sync stamp stays in the existing
+`rollout_uncertain_abstention` cohort. A clean edge to a Kilter anchor with
+`updated_at > kilter_synced_at` (or no sync stamp) is
+`kilter_timestamp_unverified_anchor_abstention`. These rows cannot become
+correction evidence, aligned controls, or post-fix invariant violations.
+
+Every native row remains in the graph, including rows created before the
+origin-writer instant, before the verified safe-save boundary, or with a later
+`updated_at`. This preserves its ability to make a match ambiguous. A clean edge
+to a pre-origin row is `heuristic_only_anchor_abstention`; a clean edge to a
+writer-stamped but pre-safe or edited row is
+`native_timestamp_unverified_anchor_abstention`. Neither can become correction
+evidence, an aligned control, or a post-fix invariant violation.
+
+For a clean edge:
+
+```text
+raw delta = suspect climbed_at - anchor climbed_at
+offset    = closest allowed IANA offset within 60 seconds
+target    = suspect climbed_at - offset
+residual  = raw delta - offset
+```
+
+The target deliberately preserves seconds. For example, a `+10:00:17` raw gap
+proposes subtracting exactly ten hours, leaving the target 17 seconds after its
+anchor and recording `residual_seconds=17`; it does not snap to the anchor.
+
+Definite post-fix live-pull rows that have not been edited since their source
+sync, and definite still-synthetic JSON reimports whose exact import-owned
+timestamps remain intact, are controls. A reciprocal nonzero match in either
+post-fix control cohort is an invariant failure and suppresses **all** effective
+correction proposals in the artifact. The detailed pair remains evidence for
+investigating the policy or writer, but the summary reports zero effective
+proposals.
+
+## Why `created_at` and `origin` are not simple cutoffs
+
+For JSON imports, `created_at` comes from the Aurora export record. It says when
+Aurora created that record, not when Boardsesh imported it, so the audit never
+uses JSON `created_at` as an import timestamp. A JSON row later claimed by a live
+sync gets a real Aurora id and a later sync stamp but retains `origin=json_import`
+and may retain the bad `climbed_at`; claimed JSON is therefore included by
+origin and remains an ambiguity vertex. The claim intentionally advances
+`aurora_synced_at` without advancing `updated_at`, so the ordinary
+`updated_at <= aurora_synced_at` edit guard cannot prove that a claimed JSON
+timestamp is untouched. A JSON row can support a proposal or control only when
+it still has its synthetic id and exact import-owned
+`updated_at = aurora_synced_at` stamps. Any claimed, locally edited, or otherwise
+unverifiable JSON row stays ambiguity-only.
+
+The synthetic `json-import-*` Aurora id is generated from fields which include
+`climbed_at`. A future correction cannot regenerate or silently replace that id
+without analyzing idempotency and collision behavior. This audit reports neither
+the synthetic nor real Aurora id.
+
+`origin` was writer-stamped only after migration 0156; older values were inferred
+from surrogate columns, including a `created_at - climbed_at > 1 hour` heuristic
+for Kilter pulls. Migration 0156 did not persist a per-row marker saying whether
+it assigned the origin. The database therefore cannot prove that fact directly.
+The audit calls a Kilter anchor `writer_stamped` only when its writer-owned
+`created_at` is at or after the operator-supplied instant proven to be both after
+0156 completion and after every old writer was retired. Earlier rows are
+`legacy_origin_may_be_heuristic` and always abstain from a clean match. If that
+deployment evidence cannot be obtained, do not choose a guessed historical
+boundary; use a conservative later proven instant, accepting that more rows will
+abstain.
+
+Live Aurora candidates use the same conservative edit guard as the sync writer:
+`aurora_synced_at` must be present and `updated_at` must not be later. A later
+`updated_at` proves that some locally editable content changed after the source
+sync; the audit has no field history with which to exclude `climbed_at`. A
+missing source sync stamp is likewise unverified. Kilter anchors apply the same
+rule against `kilter_synced_at`. These edit checks are proposal/control gates,
+not graph filters.
+
+Native timestamps need a separate guard. The current GraphQL `saveTick` writer
+parses `climbedAt` through `Date.toISOString()` and explicitly assigns one `now`
+value to both `created_at` and `updated_at`. It was not the only native writer:
+the still-routable Next.js `/api/v1/[board_name]/proxy/saveAscent` endpoint calls
+the legacy web `saveAscent` helper, which also inserts `origin='native'`.
+Revision `cdf1406dfb53f1865513fd005d39b13f469a74e1` changed that helper from direct
+`Date` parsing to the shared `normalizeTimestamp`; the shared helper already
+contained `ad4b39c08`'s explicit-offset-suffix fix. That source revision is not
+a deployment boundary, and this route is not retired in the audited source.
+The route accepts a string while its documented contract requires an
+ISO-8601 zone; the normalizer also safely pins Aurora's space-separated naive
+form to UTC, but explicitly warns that a zoneless ISO `T` form is host-dependent.
+Deployment evidence must therefore establish that every active instance had the
+fixed writer and that callers used a supported timestamp form, or establish a
+later instant when an unsafe writer/input path was tightened or retired. If
+that cannot be proved, the operator must choose a later defensible boundary or
+omit native anchors as proposal evidence; a commit timestamp is never enough.
+
+`updateTick` can later replace `climbed_at`; every call explicitly advances
+`updated_at`. Migration 0146 also installs
+`trg_boardsesh_ticks_set_updated_at`, which advances `updated_at` for
+client-visible changes including `climbed_at`, while deliberately ignoring
+Aurora/Kilter bookkeeping columns. There is no edit-history column saying which
+field changed, and a later `updated_at` must never be interpreted as proof that
+the timestamp was normalized safely. The audit therefore accepts only exact
+`created_at = updated_at` on a row created at or after the independently
+verified all-writers-safe-or-retired boundary. Every other native anchor remains
+ambiguity-only. This can create false-negative abstentions after harmless edits,
+which is intentional.
+
+Any future apply design must also examine rows adjacent to both the original and
+target `climbed_at`. Moving a row can change day/session buckets, first-ascent and
+flash ordering, duplicate-natural-key relationships, and downstream grade-model
+inputs. `created_at` remains a separate provenance value and must not be shifted
+along with `climbed_at` merely to make the two fields look adjacent. The audit
+does not resolve those apply-time risks.
+
+## Artifact privacy and integrity
+
+The JSONL contains no database URL, database name, raw user id, comment, session
+id, or raw climb/tick UUID. Identifiers are HMAC pseudonyms scoped to the run; the
+secret is never written. The same database identifier intentionally receives a
+different pseudonym in another run. Aggregate cells from one through four are
+rendered as `"<5"`. Pair records contain exact timestamps only where an edge
+supplies useful evidence.
+
+The header records:
+
+- the verified policy and its SHA-256 digest;
+- source revisions and the exact scan-query digest;
+- PostgreSQL snapshot token, server version, transaction settings, and a digest
+  of the inspected `boardsesh_ticks` schema;
+- explicit safety flags recording the candidate/Kilter sync guards, the
+  unchanged-native requirement, and the single-artifact scope of the records
+  digest.
+
+The final audit summary records whether post-fix controls suppressed proposals.
+
+Every non-runtime record is canonical JSON (recursively sorted keys) and feeds a
+streaming SHA-256 digest. `records_digest` stores that digest as an integrity
+check for this exact artifact. It is not a reproducible cross-run dataset hash:
+the random HMAC secret changes the pseudonyms and pseudonym scope in the hashed
+records. Completion time, duration, and random run id are in a separate
+`runtime_footer` and do not add further digest variation.
+
+## Query-plan check
+
+The scan is cursor-paged in batches of 500 and retains only one natural-key group
+in memory (hard limit 10,000 rows). It performs no per-row query, uses binary
+search over time-sorted semantics-compatible anchors, and stores only linear
+degree/sole-edge state even when a dense group has a quadratic number of logical
+edges. Its stable order follows the leading columns of
+`boardsesh_ticks_user_climb_lookup_idx`, with `id` as the final tie-break.
+
+Before a production audit, run the opt-in integration test against a current
+**local** migrated database:
+
+```sh
+LEGACY_TIMESTAMP_AUDIT_DB_URL=<local-url> \
+  vp exec --filter @boardsesh/db -- \
+  tsx --test scripts/audit-legacy-tick-timestamps.integration.test.ts
+```
+
+It executes `EXPLAIN (FORMAT JSON, COSTS true)` for the exact exported query and
+asserts there is no modifying plan node, then exercises the real snapshot
+settings. On a production read replica, inspect the same plain `EXPLAIN` (never
+`EXPLAIN ANALYZE` on the full scan) for unexpected sequential scans, large disk
+sorts, or a row estimate that makes the 500-row cursor unsuitable. Record that
+review beside the deployment-policy evidence; do not alter session planner
+settings just to force a preferred-looking plan.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -83,6 +83,7 @@
     "test": "tsx --test 'scripts/**/*.test.ts' 'src/**/*.test.ts'",
     "test:explain": "tsx --test src/queries/climbs/__tests__/search-climbs-explain.integration.test.ts",
     "test:migration-journal": "tsx --test scripts/migration-journal-verification.integration.test.ts",
+    "test:legacy-timestamp-audit": "tsx --test scripts/legacy-timestamp-audit-core.test.ts scripts/audit-legacy-tick-timestamps.test.ts",
     "db:verify-journal": "tsx scripts/verify-migration-journal.ts",
     "db:studio": "drizzle-kit studio",
     "db:import-moonboard": "tsx scripts/import-moonboard-problems.ts",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -99,6 +99,7 @@
     "db:dedupe-gyms": "tsx scripts/dedupe-gym-locations.ts",
     "db:dedupe-serial-boards": "tsx scripts/dedupe-serial-boards.ts",
     "db:dedupe-beta-links": "tsx scripts/dedupe-beta-links.ts",
+    "db:audit-legacy-timestamps": "tsx scripts/audit-legacy-tick-timestamps.ts",
     "db:refresh-climb-grades": "tsx scripts/refresh-climb-grades.ts",
     "db:seed-social": "tsx scripts/seed-social.ts",
     "db:create-test-user": "tsx scripts/create-test-user.ts",

--- a/packages/db/scripts/audit-legacy-tick-timestamps.integration.test.ts
+++ b/packages/db/scripts/audit-legacy-tick-timestamps.integration.test.ts
@@ -2,7 +2,12 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { randomBytes } from 'node:crypto';
 import postgres from 'postgres';
-import { AUDIT_SCAN_QUERY, runDatabaseAudit, type ArtifactSink } from './audit-legacy-tick-timestamps.js';
+import {
+  AUDIT_SCAN_QUERY,
+  AUDIT_STATEMENT_TIMEOUT_MS,
+  runDatabaseAudit,
+  type ArtifactSink,
+} from './audit-legacy-tick-timestamps.js';
 import { assertPrivacySafeRecord, type AuditPolicy } from './legacy-timestamp-audit-core.js';
 
 const DATABASE_URL = process.env.LEGACY_TIMESTAMP_AUDIT_DB_URL;
@@ -37,14 +42,17 @@ if (!DATABASE_URL || !isExplicitLocalDatabase(DATABASE_URL)) {
   });
 } else {
   void describe('legacy timestamp audit PostgreSQL contract', () => {
-    void it('scans a real schema in a serializable, read-only, deferrable UTC snapshot', async () => {
-      let emittedRecords = 0;
+    void it('scans through an explicit cursor in a bounded serializable, read-only, deferrable UTC snapshot', async () => {
+      let recordWritesStarted = 0;
+      let recordWritesCompleted = 0;
       let metadataVerified = false;
       const sink: ArtifactSink = {
         async writeCanonicalRecord(record) {
           assert.equal(metadataVerified, true, 'metadata callback must run before evidence is emitted');
           assertPrivacySafeRecord(record);
-          emittedRecords += 1;
+          recordWritesStarted += 1;
+          await new Promise<void>((resolveWrite) => setImmediate(resolveWrite));
+          recordWritesCompleted += 1;
         },
       };
       const { counters, metadata } = await runDatabaseAudit(DATABASE_URL, policy, sink, randomBytes(32), async () => {
@@ -54,9 +62,15 @@ if (!DATABASE_URL || !isExplicitLocalDatabase(DATABASE_URL)) {
       assert.equal(metadata.transactionIsolation, 'serializable');
       assert.equal(metadata.transactionReadOnly, 'on');
       assert.equal(metadata.transactionDeferrable, 'on');
+      assert.equal(metadata.statementTimeoutMs, AUDIT_STATEMENT_TIMEOUT_MS);
       assert.equal(metadata.timeZone, 'UTC');
       assert.match(metadata.schemaSha256, /^[a-f0-9]{64}$/);
-      assert.ok(counters.scannedRows >= emittedRecords);
+      assert.equal(
+        recordWritesCompleted,
+        recordWritesStarted,
+        'every fetched batch must finish local writes before return',
+      );
+      assert.ok(counters.scannedRows >= recordWritesCompleted);
     });
 
     void it('has a read-only EXPLAIN shape with no modifying plan nodes', async () => {

--- a/packages/db/scripts/audit-legacy-tick-timestamps.integration.test.ts
+++ b/packages/db/scripts/audit-legacy-tick-timestamps.integration.test.ts
@@ -1,0 +1,74 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { randomBytes } from 'node:crypto';
+import postgres from 'postgres';
+import { AUDIT_SCAN_QUERY, runDatabaseAudit, type ArtifactSink } from './audit-legacy-tick-timestamps.js';
+import { assertPrivacySafeRecord, type AuditPolicy } from './legacy-timestamp-audit-core.js';
+
+const DATABASE_URL = process.env.LEGACY_TIMESTAMP_AUDIT_DB_URL;
+
+function isExplicitLocalDatabase(databaseUrl: string): boolean {
+  try {
+    return ['localhost', '127.0.0.1', '::1', 'postgres'].includes(
+      new URL(databaseUrl).hostname.replace(/^\[|\]$/g, ''),
+    );
+  } catch {
+    return false;
+  }
+}
+
+const policy: AuditPolicy = {
+  policyId: 'integration-test-policy',
+  liveOldCodeActiveThroughEpochSeconds: Date.parse('2026-07-08T00:00:00Z') / 1000,
+  liveFixedCodeActiveFromEpochSeconds: Date.parse('2026-07-08T01:00:00Z') / 1000,
+  jsonOldCodeActiveThroughEpochSeconds: Date.parse('2026-07-08T00:00:00Z') / 1000,
+  jsonFixedCodeActiveFromEpochSeconds: Date.parse('2026-07-08T01:00:00Z') / 1000,
+  originWritersActiveFromEpochSeconds: Date.parse('2026-07-08T01:00:00Z') / 1000,
+  nativeSafeGenerationActiveFromEpochSeconds: Date.parse('2026-07-08T01:00:00Z') / 1000,
+};
+
+if (!DATABASE_URL || !isExplicitLocalDatabase(DATABASE_URL)) {
+  void describe('legacy timestamp audit PostgreSQL contract', () => {
+    void it(
+      'skipped — set LEGACY_TIMESTAMP_AUDIT_DB_URL to an explicitly local, migrated PostgreSQL database',
+      { skip: true },
+      () => {},
+    );
+  });
+} else {
+  void describe('legacy timestamp audit PostgreSQL contract', () => {
+    void it('scans a real schema in a serializable, read-only, deferrable UTC snapshot', async () => {
+      let emittedRecords = 0;
+      let metadataVerified = false;
+      const sink: ArtifactSink = {
+        async writeCanonicalRecord(record) {
+          assert.equal(metadataVerified, true, 'metadata callback must run before evidence is emitted');
+          assertPrivacySafeRecord(record);
+          emittedRecords += 1;
+        },
+      };
+      const { counters, metadata } = await runDatabaseAudit(DATABASE_URL, policy, sink, randomBytes(32), async () => {
+        metadataVerified = true;
+      });
+      assert.equal(metadataVerified, true);
+      assert.equal(metadata.transactionIsolation, 'serializable');
+      assert.equal(metadata.transactionReadOnly, 'on');
+      assert.equal(metadata.transactionDeferrable, 'on');
+      assert.equal(metadata.timeZone, 'UTC');
+      assert.match(metadata.schemaSha256, /^[a-f0-9]{64}$/);
+      assert.ok(counters.scannedRows >= emittedRecords);
+    });
+
+    void it('has a read-only EXPLAIN shape with no modifying plan nodes', async () => {
+      const client = postgres(DATABASE_URL, { max: 1, prepare: false });
+      try {
+        const rows = await client.unsafe(`EXPLAIN (FORMAT JSON, COSTS true) ${AUDIT_SCAN_QUERY}`);
+        const planText = JSON.stringify(rows[0]?.['QUERY PLAN']);
+        assert.match(planText, /boardsesh_ticks/);
+        assert.doesNotMatch(planText, /ModifyTable|Insert|Update|Delete/);
+      } finally {
+        await client.end();
+      }
+    });
+  });
+}

--- a/packages/db/scripts/audit-legacy-tick-timestamps.test.ts
+++ b/packages/db/scripts/audit-legacy-tick-timestamps.test.ts
@@ -1,0 +1,315 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, readdir, stat, symlink, unlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import {
+  CliUsageError,
+  EXPLICIT_OFFSET_SUFFIX_FIX_SOURCE_REVISION,
+  JSON_BUG_INTRO_SOURCE_REVISION,
+  JSON_IMPORT_MOVE_SOURCE_REVISION,
+  JSON_NAIVE_UTC_FIX_SOURCE_REVISION,
+  LEGACY_WEB_SAVE_ASCENT_NORMALIZER_FIX_SOURCE_REVISION,
+  LIVE_PULL_SHARED_NORMALIZER_FIX_SOURCE_REVISION,
+  AUDIT_SCAN_QUERY,
+  buildAuditSummary,
+  parseArgs,
+  parseDatabaseRow,
+  runAuditCommand,
+  validateOutputPath,
+  writeAuditArtifact,
+} from './audit-legacy-tick-timestamps.js';
+
+function validArgs(outputPath: string): string[] {
+  return [
+    '--output',
+    outputPath,
+    '--policy-id',
+    'verified-deploy-test',
+    '--live-old-code-active-through',
+    '2026-07-08T00:00:00Z',
+    '--live-fixed-code-active-from',
+    '2026-07-08T01:00:00Z',
+    '--json-old-code-active-through',
+    '2026-07-08T00:00:00Z',
+    '--json-fixed-code-active-from',
+    '2026-07-08T01:00:00Z',
+    '--origin-writers-active-from',
+    '2026-07-08T01:00:00Z',
+    '--native-safe-generation-active-from',
+    '2026-07-08T01:00:00Z',
+  ];
+}
+
+async function withProcessEnvironment(name: string, replacement: string, action: () => Promise<void>): Promise<void> {
+  const original = process.env[name];
+  process.env[name] = replacement;
+  try {
+    await action();
+  } finally {
+    if (original === undefined) delete process.env[name];
+    else process.env[name] = original;
+  }
+}
+
+void describe('legacy timestamp audit CLI', () => {
+  void it('parses a complete verified deployment policy', () => {
+    const parsed = parseArgs(validArgs('/tmp/audit.jsonl'));
+    assert.equal(parsed.outputPath, '/tmp/audit.jsonl');
+    assert.equal(parsed.policy.policyId, 'verified-deploy-test');
+    assert.ok(parsed.policy.liveOldCodeActiveThroughEpochSeconds < parsed.policy.liveFixedCodeActiveFromEpochSeconds);
+  });
+
+  void it("tolerates vp's standalone argument separator", () => {
+    assert.deepEqual(parseArgs(['--', ...validArgs('/tmp/a.jsonl')]), parseArgs(validArgs('/tmp/a.jsonl')));
+  });
+
+  void it('rejects apply, unknown, duplicate, missing and stdout arguments', () => {
+    assert.throws(() => parseArgs(['--apply', ...validArgs('/tmp/a.jsonl')]), /permanently audit-only/);
+    assert.throws(() => parseArgs([...validArgs('/tmp/a.jsonl'), '--mystery', 'x']), /Unknown argument/);
+    assert.throws(
+      () => parseArgs([...validArgs('/tmp/a.jsonl'), '--output', '/tmp/b.jsonl']),
+      /only be specified once/,
+    );
+    assert.throws(() => parseArgs(validArgs('/tmp/a.jsonl').slice(0, -1)), /requires a value/);
+    assert.throws(() => parseArgs(validArgs('-')), /not stdout/);
+    assert.throws(() => parseArgs(validArgs('/dev/stdout')), /not stdout/);
+  });
+
+  void it('requires explicit timezone offsets and a non-overlapping rollout window', () => {
+    const missingZone = validArgs('/tmp/a.jsonl');
+    missingZone[missingZone.indexOf('--live-fixed-code-active-from') + 1] = '2026-07-08 01:00:00';
+    assert.throws(() => parseArgs(missingZone), /explicit Z/);
+
+    const overlap = validArgs('/tmp/a.jsonl');
+    overlap[overlap.indexOf('--live-old-code-active-through') + 1] = '2026-07-08T02:00:00Z';
+    assert.throws(() => parseArgs(overlap), /must precede/);
+
+    const jsonOverlap = validArgs('/tmp/a.jsonl');
+    jsonOverlap[jsonOverlap.indexOf('--json-old-code-active-through') + 1] = '2026-07-08T02:00:00Z';
+    assert.throws(() => parseArgs(jsonOverlap), /json-old-code-active-through must precede/);
+  });
+
+  void it('does not allow native proposal eligibility before origin writers were verified active', () => {
+    const unsafe = validArgs('/tmp/a.jsonl');
+    unsafe[unsafe.indexOf('--native-safe-generation-active-from') + 1] = '2026-07-08T00:30:00Z';
+    assert.throws(() => parseArgs(unsafe), /must not precede/);
+  });
+
+  void it('suppresses every effective proposal when a post-fix control invariant fails', () => {
+    const summary = buildAuditSummary({
+      scannedRows: 20,
+      groups: 10,
+      anchors: 10,
+      edges: 7,
+      correctionEvidence: 6,
+      postFixInvariantViolations: 1,
+      alignedControls: 5,
+      ambiguousAbstentions: 0,
+      heuristicOnlyAnchorAbstentions: 0,
+      candidateTimestampUnverifiedAbstentions: 0,
+      kilterTimestampUnverifiedAnchorAbstentions: 0,
+      nativeTimestampUnverifiedAnchorAbstentions: 5,
+      noAnchorAbstentions: 3,
+      rolloutUncertainAbstentions: 0,
+    });
+    assert.equal(summary.proposals_suppressed, true);
+    assert.equal(summary.effective_correction_proposals, 0);
+    assert.equal(summary.post_fix_control_invariant, 'failed');
+    assert.equal((summary.counts as Record<string, unknown>).nativeTimestampUnverifiedAnchorAbstentions, 5);
+  });
+
+  void it('projects native equality and Kilter sync evidence while scanning every native row', () => {
+    assert.match(AUDIT_SCAN_QUERY, /\(created_at = updated_at\) AS "createdAtEqualsUpdatedAt"/);
+    assert.match(AUDIT_SCAN_QUERY, /kilter_synced_at AT TIME ZONE 'UTC'/);
+    assert.match(AUDIT_SCAN_QUERY, /origin IN \('json_import', 'aurora_pull', 'kilter_pull', 'native'\)/);
+    assert.doesNotMatch(AUDIT_SCAN_QUERY, /\$\d+/);
+    const parsed = parseDatabaseRow({
+      angle: 40,
+      attemptCount: 2,
+      auroraIdIsSyntheticJson: false,
+      auroraSyncedAtEpochSeconds: null,
+      boardType: 'kilter',
+      climbedAtEpochSeconds: 100,
+      climbUuid: 'climb',
+      createdAtEpochSeconds: 200,
+      createdAtEqualsUpdatedAt: true,
+      id: '1',
+      isMirror: false,
+      kilterDetachedAtEpochSeconds: null,
+      kilterSyncedAtEpochSeconds: 199,
+      origin: 'native',
+      status: 'send',
+      updatedAtEpochSeconds: 200,
+      userId: 'user',
+      uuid: 'tick',
+    });
+    assert.equal(parsed.createdAtEqualsUpdatedAt, true);
+    assert.equal(parsed.kilterSyncedAtEpochSeconds, 199);
+  });
+
+  void it('records each timestamp-normalizer revision under its distinct historical role', () => {
+    assert.equal(JSON_BUG_INTRO_SOURCE_REVISION, '8fe79f60dd017180d325ba3501a8a2a96f7fcb28');
+    assert.equal(JSON_NAIVE_UTC_FIX_SOURCE_REVISION, '79185b916800b866173da01e4ec34743b0015218');
+    assert.equal(JSON_IMPORT_MOVE_SOURCE_REVISION, '45cef340a8055d5c263fac3d863dcf82886fb47b');
+    assert.equal(LIVE_PULL_SHARED_NORMALIZER_FIX_SOURCE_REVISION, '71937db6a372ececfe4fa543978ea5cd3bd78a88');
+    assert.equal(EXPLICIT_OFFSET_SUFFIX_FIX_SOURCE_REVISION, 'ad4b39c086b3e2b091bf1d16e5e529fe012d2cf1');
+    assert.equal(LEGACY_WEB_SAVE_ASCENT_NORMALIZER_FIX_SOURCE_REVISION, 'cdf1406dfb53f1865513fd005d39b13f469a74e1');
+  });
+});
+
+void describe('JSONL output safety', () => {
+  void it('rejects existing and symlink output targets', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-output-'));
+    const existing = join(directory, 'existing.jsonl');
+    const symlinkPath = join(directory, 'symlink.jsonl');
+    await writeFile(existing, 'do not overwrite');
+    await symlink(existing, symlinkPath);
+    await assert.rejects(validateOutputPath(existing, directory), /existing output path/);
+    await assert.rejects(validateOutputPath(symlinkPath, directory), /symlink output path/);
+  });
+
+  void it('rejects an invalid output before resolving any database configuration', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-preflight-'));
+    const existing = join(directory, 'existing.jsonl');
+    await writeFile(existing, 'do not overwrite');
+    await assert.rejects(runAuditCommand(parseArgs(validArgs(existing))), /existing output path/);
+  });
+
+  void it('rejects a tracked path even when the working-tree file is absent', async () => {
+    const repository = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-repo-'));
+    spawnSync('git', ['init', '-q'], { cwd: repository });
+    const tracked = join(repository, 'report.jsonl');
+    await writeFile(tracked, 'tracked');
+    spawnSync('git', ['add', 'report.jsonl'], { cwd: repository });
+    await unlink(tracked);
+    await assert.rejects(validateOutputPath(tracked, repository), /tracked output path/);
+  });
+
+  void it('rejects a tracked output in the repository containing its parent even when cwd is another repository', async () => {
+    const callerRepository = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-caller-repo-'));
+    const outputRepository = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-output-repo-'));
+    spawnSync('git', ['init', '-q'], { cwd: callerRepository });
+    spawnSync('git', ['init', '-q'], { cwd: outputRepository });
+    const tracked = join(outputRepository, 'external-report.jsonl');
+    await writeFile(tracked, 'tracked');
+    spawnSync('git', ['add', 'external-report.jsonl'], { cwd: outputRepository });
+    await unlink(tracked);
+    await assert.rejects(validateOutputPath(tracked, callerRepository), /tracked output path/);
+  });
+
+  void it('fails closed when the output parent has an indeterminate Git repository probe', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-broken-repo-'));
+    await writeFile(join(directory, '.git'), 'gitdir: /definitely/missing/boardsesh-audit-gitdir\n');
+    await assert.rejects(validateOutputPath(join(directory, 'report.jsonl'), directory), /Could not determine Git/);
+  });
+
+  void it('ignores an inherited Git ceiling that would hide the containing repository', async () => {
+    const repository = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-ceiling-repo-'));
+    spawnSync('git', ['init', '-q'], { cwd: repository });
+    const nestedDirectory = join(repository, 'nested');
+    await mkdir(nestedDirectory);
+    const tracked = join(nestedDirectory, 'report.jsonl');
+    await writeFile(tracked, 'tracked');
+    spawnSync('git', ['add', 'nested/report.jsonl'], { cwd: repository });
+    await unlink(tracked);
+    await withProcessEnvironment('GIT_CEILING_DIRECTORIES', repository, async () => {
+      await assert.rejects(validateOutputPath(tracked, nestedDirectory), /tracked output path/);
+    });
+  });
+
+  void it('ignores an inherited alternate Git index that would hide a tracked output', async () => {
+    const repository = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-index-repo-'));
+    spawnSync('git', ['init', '-q'], { cwd: repository });
+    const tracked = join(repository, 'report.jsonl');
+    await writeFile(tracked, 'tracked');
+    spawnSync('git', ['add', 'report.jsonl'], { cwd: repository });
+    await unlink(tracked);
+    await withProcessEnvironment('GIT_INDEX_FILE', join(repository, 'empty-alternate-index'), async () => {
+      await assert.rejects(validateOutputPath(tracked, repository), /tracked output path/);
+    });
+  });
+
+  void it('treats pathspec-magic output filenames literally', async () => {
+    const repository = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-pathspec-repo-'));
+    spawnSync('git', ['init', '-q'], { cwd: repository });
+    const filename = ':(literal)report.jsonl';
+    const tracked = join(repository, filename);
+    await writeFile(tracked, 'tracked');
+    spawnSync('git', ['--literal-pathspecs', 'add', '--', filename], { cwd: repository });
+    await unlink(tracked);
+    await assert.rejects(validateOutputPath(tracked, repository), /tracked output path/);
+  });
+
+  void it('allows a real non-repository output only after conclusive repository discovery', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-non-repo-'));
+    const output = join(directory, 'report.jsonl');
+    assert.equal(await validateOutputPath(output, directory), output);
+  });
+
+  void it('publishes atomically, hashes canonical records, and excludes the runtime footer from the digest', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-artifact-'));
+    const first = join(directory, 'first.jsonl');
+    const second = join(directory, 'second.jsonl');
+    const firstResult = await writeAuditArtifact(
+      first,
+      async (sink) => {
+        await sink.writeCanonicalRecord({ z: 2, a: 1, type: 'test' });
+        return { duration_ms: 10, run_id: 'first-run' };
+      },
+      { cwd: directory, completedAt: () => '2026-01-01T00:00:00.000Z' },
+    );
+    const secondResult = await writeAuditArtifact(
+      second,
+      async (sink) => {
+        await sink.writeCanonicalRecord({ a: 1, type: 'test', z: 2 });
+        return { duration_ms: 99, run_id: 'second-run' };
+      },
+      { cwd: directory, completedAt: () => '2027-01-01T00:00:00.000Z' },
+    );
+    assert.equal(firstResult.digest, secondResult.digest, 'runtime footer must not affect the records digest');
+    assert.equal((await stat(first)).mode & 0o777, 0o600);
+    const lines = (await readFile(first, 'utf8')).trim().split('\n');
+    assert.equal(lines.length, 3);
+    assert.equal(lines[0], '{"a":1,"type":"test","z":2}');
+    assert.equal(JSON.parse(lines[1]).type, 'records_digest');
+    assert.equal(JSON.parse(lines[2]).type, 'runtime_footer');
+  });
+
+  void it('leaves no requested output or partial file when production fails', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-failure-'));
+    const output = join(directory, 'failed.jsonl');
+    await assert.rejects(
+      writeAuditArtifact(
+        output,
+        async (sink) => {
+          await sink.writeCanonicalRecord({ type: 'before_failure' });
+          throw new Error('fixture failure');
+        },
+        { cwd: directory },
+      ),
+      /fixture failure/,
+    );
+    assert.equal(await readdir(directory).then((entries) => entries.length), 0);
+  });
+
+  void it('rejects unsafe fields before publication', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-privacy-'));
+    await assert.rejects(
+      writeAuditArtifact(
+        join(directory, 'unsafe.jsonl'),
+        async (sink) => {
+          await sink.writeCanonicalRecord({ type: 'unsafe', userId: 'raw-user' });
+          return {};
+        },
+        { cwd: directory },
+      ),
+      /forbidden raw field/,
+    );
+  });
+
+  void it('surfaces usage errors as a dedicated type', () => {
+    assert.throws(() => parseArgs([]), CliUsageError);
+  });
+});

--- a/packages/db/scripts/audit-legacy-tick-timestamps.test.ts
+++ b/packages/db/scripts/audit-legacy-tick-timestamps.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, readdir, stat, symlink, unlink, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, realpath, stat, symlink, unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -57,6 +57,15 @@ function createControlledTimeoutScheduler(): {
       },
     },
   };
+}
+
+// `validateOutputPath` refuses to write beneath a symlinked directory, and on
+// macOS `os.tmpdir()` is `/var/folders/...` — `/var` being a symlink to
+// `/private/var`. Without the realpath, every fixture below would trip that
+// guard instead of the behaviour it means to assert, so the suite would pass on
+// Linux/CI and fail on a Mac.
+async function createFixtureDirectory(prefix: string): Promise<string> {
+  return realpath(await mkdtemp(join(tmpdir(), prefix)));
 }
 
 function validArgs(outputPath: string): string[] {
@@ -252,7 +261,7 @@ void describe('JSONL output safety', () => {
   });
 
   void it('rejects existing and symlink output targets', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-output-'));
+    const directory = await createFixtureDirectory('boardsesh-tick-audit-output-');
     const existing = join(directory, 'existing.jsonl');
     const symlinkPath = join(directory, 'symlink.jsonl');
     await writeFile(existing, 'do not overwrite');
@@ -262,14 +271,14 @@ void describe('JSONL output safety', () => {
   });
 
   void it('rejects an invalid output before resolving any database configuration', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-preflight-'));
+    const directory = await createFixtureDirectory('boardsesh-tick-audit-preflight-');
     const existing = join(directory, 'existing.jsonl');
     await writeFile(existing, 'do not overwrite');
     await assert.rejects(runAuditCommand(parseArgs(validArgs(existing))), /existing output path/);
   });
 
   void it('rejects a tracked path even when the working-tree file is absent', async () => {
-    const repository = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-repo-'));
+    const repository = await createFixtureDirectory('boardsesh-tick-audit-repo-');
     spawnSync('git', ['init', '-q'], { cwd: repository });
     const tracked = join(repository, 'report.jsonl');
     await writeFile(tracked, 'tracked');
@@ -279,8 +288,8 @@ void describe('JSONL output safety', () => {
   });
 
   void it('rejects a tracked output in the repository containing its parent even when cwd is another repository', async () => {
-    const callerRepository = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-caller-repo-'));
-    const outputRepository = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-output-repo-'));
+    const callerRepository = await createFixtureDirectory('boardsesh-tick-audit-caller-repo-');
+    const outputRepository = await createFixtureDirectory('boardsesh-tick-audit-output-repo-');
     spawnSync('git', ['init', '-q'], { cwd: callerRepository });
     spawnSync('git', ['init', '-q'], { cwd: outputRepository });
     const tracked = join(outputRepository, 'external-report.jsonl');
@@ -291,13 +300,13 @@ void describe('JSONL output safety', () => {
   });
 
   void it('fails closed when the output parent has an indeterminate Git repository probe', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-broken-repo-'));
+    const directory = await createFixtureDirectory('boardsesh-tick-audit-broken-repo-');
     await writeFile(join(directory, '.git'), 'gitdir: /definitely/missing/boardsesh-audit-gitdir\n');
     await assert.rejects(validateOutputPath(join(directory, 'report.jsonl'), directory), /Could not determine Git/);
   });
 
   void it('ignores an inherited Git ceiling that would hide the containing repository', async () => {
-    const repository = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-ceiling-repo-'));
+    const repository = await createFixtureDirectory('boardsesh-tick-audit-ceiling-repo-');
     spawnSync('git', ['init', '-q'], { cwd: repository });
     const nestedDirectory = join(repository, 'nested');
     await mkdir(nestedDirectory);
@@ -311,7 +320,7 @@ void describe('JSONL output safety', () => {
   });
 
   void it('ignores an inherited alternate Git index that would hide a tracked output', async () => {
-    const repository = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-index-repo-'));
+    const repository = await createFixtureDirectory('boardsesh-tick-audit-index-repo-');
     spawnSync('git', ['init', '-q'], { cwd: repository });
     const tracked = join(repository, 'report.jsonl');
     await writeFile(tracked, 'tracked');
@@ -323,7 +332,7 @@ void describe('JSONL output safety', () => {
   });
 
   void it('treats pathspec-magic output filenames literally', async () => {
-    const repository = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-pathspec-repo-'));
+    const repository = await createFixtureDirectory('boardsesh-tick-audit-pathspec-repo-');
     spawnSync('git', ['init', '-q'], { cwd: repository });
     const filename = ':(literal)report.jsonl';
     const tracked = join(repository, filename);
@@ -334,13 +343,13 @@ void describe('JSONL output safety', () => {
   });
 
   void it('allows a real non-repository output only after conclusive repository discovery', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-non-repo-'));
+    const directory = await createFixtureDirectory('boardsesh-tick-audit-non-repo-');
     const output = join(directory, 'report.jsonl');
     assert.equal(await validateOutputPath(output, directory), output);
   });
 
   void it('publishes atomically, hashes canonical records, and excludes the runtime footer from the digest', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-artifact-'));
+    const directory = await createFixtureDirectory('boardsesh-tick-audit-artifact-');
     const first = join(directory, 'first.jsonl');
     const second = join(directory, 'second.jsonl');
     const firstResult = await writeAuditArtifact(
@@ -369,7 +378,7 @@ void describe('JSONL output safety', () => {
   });
 
   void it('leaves no requested output or partial file when production fails', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-failure-'));
+    const directory = await createFixtureDirectory('boardsesh-tick-audit-failure-');
     const output = join(directory, 'failed.jsonl');
     await assert.rejects(
       writeAuditArtifact(
@@ -386,7 +395,7 @@ void describe('JSONL output safety', () => {
   });
 
   void it('rejects unsafe fields before publication', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-privacy-'));
+    const directory = await createFixtureDirectory('boardsesh-tick-audit-privacy-');
     await assert.rejects(
       writeAuditArtifact(
         join(directory, 'unsafe.jsonl'),

--- a/packages/db/scripts/audit-legacy-tick-timestamps.test.ts
+++ b/packages/db/scripts/audit-legacy-tick-timestamps.test.ts
@@ -5,7 +5,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import {
+  AUDIT_CONNECT_TIMEOUT_SECONDS,
+  AUDIT_DATABASE_RESPONSE_TIMEOUT_MS,
+  AUDIT_STATEMENT_TIMEOUT_MS,
   CliUsageError,
+  DatabaseResponseTimeoutError,
   EXPLICIT_OFFSET_SUFFIX_FIX_SOURCE_REVISION,
   JSON_BUG_INTRO_SOURCE_REVISION,
   JSON_IMPORT_MOVE_SOURCE_REVISION,
@@ -13,13 +17,47 @@ import {
   LEGACY_WEB_SAVE_ASCENT_NORMALIZER_FIX_SOURCE_REVISION,
   LIVE_PULL_SHARED_NORMALIZER_FIX_SOURCE_REVISION,
   AUDIT_SCAN_QUERY,
+  awaitDatabaseResponse,
   buildAuditSummary,
   parseArgs,
   parseDatabaseRow,
+  requireNoFollowFlag,
   runAuditCommand,
   validateOutputPath,
   writeAuditArtifact,
+  type DatabaseResponseTimeoutScheduler,
 } from './audit-legacy-tick-timestamps.js';
+
+function createControlledTimeoutScheduler(): {
+  cancelCount: () => number;
+  fire: () => void;
+  scheduledTimeoutMs: () => number | null;
+  scheduler: DatabaseResponseTimeoutScheduler;
+} {
+  let scheduledCallback: (() => void) | null = null;
+  let scheduledDelay: number | null = null;
+  let cancellations = 0;
+  const timeoutHandle = Symbol('controlled-database-response-timeout');
+  return {
+    cancelCount: () => cancellations,
+    fire: () => {
+      if (!scheduledCallback) throw new Error('No database response timeout is scheduled');
+      scheduledCallback();
+    },
+    scheduledTimeoutMs: () => scheduledDelay,
+    scheduler: {
+      schedule(callback, timeoutMs) {
+        scheduledCallback = callback;
+        scheduledDelay = timeoutMs;
+        return timeoutHandle;
+      },
+      cancel(handle) {
+        assert.equal(handle, timeoutHandle);
+        cancellations += 1;
+      },
+    },
+  };
+}
 
 function validArgs(outputPath: string): string[] {
   return [
@@ -160,7 +198,59 @@ void describe('legacy timestamp audit CLI', () => {
   });
 });
 
+void describe('database response bounds', () => {
+  void it('uses the reviewed production timeout values', () => {
+    assert.equal(AUDIT_CONNECT_TIMEOUT_SECONDS, 30);
+    assert.equal(AUDIT_STATEMENT_TIMEOUT_MS, 300_000);
+    assert.equal(AUDIT_DATABASE_RESPONSE_TIMEOUT_MS, 330_000);
+  });
+
+  void it('clears the response timer without force-closing when PostgreSQL settles', async () => {
+    const controlledTimeout = createControlledTimeoutScheduler();
+    let forceCloseCalls = 0;
+    const result = await awaitDatabaseResponse(
+      'complete a fixture query',
+      Promise.resolve(42),
+      () => {
+        forceCloseCalls += 1;
+      },
+      { scheduler: controlledTimeout.scheduler, timeoutMs: 123 },
+    );
+
+    assert.equal(result, 42);
+    assert.equal(controlledTimeout.scheduledTimeoutMs(), 123);
+    assert.equal(controlledTimeout.cancelCount(), 1);
+    assert.equal(forceCloseCalls, 0);
+  });
+
+  void it('rejects a stalled response and force-closes exactly once', async () => {
+    const controlledTimeout = createControlledTimeoutScheduler();
+    let forceCloseCalls = 0;
+    const stalledResponse = new Promise<never>(() => undefined);
+    const response = awaitDatabaseResponse(
+      'fetch a fixture cursor batch',
+      stalledResponse,
+      () => {
+        forceCloseCalls += 1;
+      },
+      { scheduler: controlledTimeout.scheduler, timeoutMs: 456 },
+    );
+    const rejection = assert.rejects(response, DatabaseResponseTimeoutError);
+
+    controlledTimeout.fire();
+    controlledTimeout.fire();
+    await rejection;
+    assert.equal(controlledTimeout.cancelCount(), 0);
+    assert.equal(forceCloseCalls, 1);
+  });
+});
+
 void describe('JSONL output safety', () => {
+  void it('fails closed when O_NOFOLLOW is unavailable', () => {
+    assert.equal(requireNoFollowFlag(0x20_000), 0x20_000);
+    assert.throws(() => requireNoFollowFlag(undefined), /requires O_NOFOLLOW support/);
+  });
+
   void it('rejects existing and symlink output targets', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'boardsesh-tick-audit-output-'));
     const existing = join(directory, 'existing.jsonl');

--- a/packages/db/scripts/audit-legacy-tick-timestamps.test.ts
+++ b/packages/db/scripts/audit-legacy-tick-timestamps.test.ts
@@ -75,6 +75,7 @@ void describe('legacy timestamp audit CLI', () => {
     assert.throws(() => parseArgs(validArgs('/tmp/a.jsonl').slice(0, -1)), /requires a value/);
     assert.throws(() => parseArgs(validArgs('-')), /not stdout/);
     assert.throws(() => parseArgs(validArgs('/dev/stdout')), /not stdout/);
+    assert.throws(() => parseArgs(validArgs('/dev/fd/1')), /not stdout/);
   });
 
   void it('requires explicit timezone offsets and a non-overlapping rollout window', () => {

--- a/packages/db/scripts/audit-legacy-tick-timestamps.ts
+++ b/packages/db/scripts/audit-legacy-tick-timestamps.ts
@@ -1,0 +1,856 @@
+/**
+ * Read-only evidence collection for issue #3909.
+ *
+ * This command has no apply mode and emits no SQL. It classifies only
+ * reciprocal one-to-one candidate/anchor pairs from one serializable,
+ * read-only, deferrable PostgreSQL snapshot. The JSONL artifact is evidence for
+ * a separately reviewed correction design; it is not an executable backfill.
+ */
+import { constants as fsConstants } from 'node:fs';
+import { access, link, lstat, open, realpath, unlink } from 'node:fs/promises';
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
+import { basename, dirname, isAbsolute, relative, resolve, sep } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+import postgres from 'postgres';
+import {
+  AUDIT_POLICY_VERSION,
+  SMALL_CELL_THRESHOLD,
+  analyzeTickGroup,
+  anchorTimestampEvidence,
+  assertPrivacySafeRecord,
+  candidateTimestampEvidence,
+  canonicalJson,
+  epochSecondsToIso,
+  groupKey,
+  originEvidence,
+  pseudonymize,
+  redactSmallCell,
+  sha256Hex,
+  type AuditPolicy,
+  type AuditTick,
+  type CandidateGraphResult,
+  type TickOrigin,
+  type TickStatus,
+} from './legacy-timestamp-audit-core.js';
+
+export const JSON_BUG_INTRO_SOURCE_REVISION = '8fe79f60dd017180d325ba3501a8a2a96f7fcb28';
+export const JSON_NAIVE_UTC_FIX_SOURCE_REVISION = '79185b916800b866173da01e4ec34743b0015218';
+export const JSON_IMPORT_MOVE_SOURCE_REVISION = '45cef340a8055d5c263fac3d863dcf82886fb47b';
+export const LIVE_PULL_SHARED_NORMALIZER_FIX_SOURCE_REVISION = '71937db6a372ececfe4fa543978ea5cd3bd78a88';
+export const EXPLICIT_OFFSET_SUFFIX_FIX_SOURCE_REVISION = 'ad4b39c086b3e2b091bf1d16e5e529fe012d2cf1';
+export const LEGACY_WEB_SAVE_ASCENT_NORMALIZER_FIX_SOURCE_REVISION = 'cdf1406dfb53f1865513fd005d39b13f469a74e1';
+export const AUDIT_FORMAT_VERSION = 1;
+export const AUDIT_CURSOR_ROWS = 500;
+export const MAX_ROWS_PER_NATURAL_KEY = 10_000;
+
+// Explicit epoch conversion avoids session-dependent parsing of timestamp
+// without time zone. The ORDER BY follows boardsesh_ticks_user_climb_lookup_idx
+// through (user_id, board_type, angle, climb_uuid); id makes the stream stable.
+// Native deliberately has no created_at cutoff: even an ineligible historical
+// row must contribute graph degree and can force an ambiguity abstention.
+export const AUDIT_SCAN_QUERY = `
+SELECT
+  id::text AS "id",
+  uuid AS "uuid",
+  user_id AS "userId",
+  board_type AS "boardType",
+  climb_uuid AS "climbUuid",
+  angle AS "angle",
+  COALESCE(is_mirror, false) AS "isMirror",
+  origin::text AS "origin",
+  status::text AS "status",
+  attempt_count AS "attemptCount",
+  EXTRACT(EPOCH FROM climbed_at AT TIME ZONE 'UTC')::double precision AS "climbedAtEpochSeconds",
+  EXTRACT(EPOCH FROM created_at AT TIME ZONE 'UTC')::double precision AS "createdAtEpochSeconds",
+  EXTRACT(EPOCH FROM updated_at AT TIME ZONE 'UTC')::double precision AS "updatedAtEpochSeconds",
+  (created_at = updated_at) AS "createdAtEqualsUpdatedAt",
+  CASE WHEN aurora_synced_at IS NULL THEN NULL
+       ELSE EXTRACT(EPOCH FROM aurora_synced_at AT TIME ZONE 'UTC')::double precision END
+    AS "auroraSyncedAtEpochSeconds",
+  COALESCE(aurora_id LIKE 'json-import-%', false) AS "auroraIdIsSyntheticJson",
+  CASE WHEN kilter_synced_at IS NULL THEN NULL
+       ELSE EXTRACT(EPOCH FROM kilter_synced_at AT TIME ZONE 'UTC')::double precision END
+    AS "kilterSyncedAtEpochSeconds",
+  CASE WHEN kilter_detached_at IS NULL THEN NULL
+       ELSE EXTRACT(EPOCH FROM kilter_detached_at AT TIME ZONE 'UTC')::double precision END
+    AS "kilterDetachedAtEpochSeconds"
+FROM boardsesh_ticks
+WHERE origin IN ('json_import', 'aurora_pull', 'kilter_pull', 'native')
+ORDER BY user_id, board_type, angle, climb_uuid, id
+`;
+
+export const AUDIT_QUERY_SHA256 = sha256Hex(AUDIT_SCAN_QUERY);
+
+type CliArgs = {
+  outputPath: string;
+  policy: AuditPolicy;
+};
+
+export class CliUsageError extends Error {}
+
+const OPTION_NAMES = [
+  '--output',
+  '--policy-id',
+  '--live-old-code-active-through',
+  '--live-fixed-code-active-from',
+  '--json-old-code-active-through',
+  '--json-fixed-code-active-from',
+  '--origin-writers-active-from',
+  '--native-safe-generation-active-from',
+] as const;
+
+const GIT_ENVIRONMENT_PASSTHROUGH = ['PATH', 'PATHEXT', 'SYSTEMROOT', 'WINDIR', 'TMPDIR', 'TMP', 'TEMP'] as const;
+
+/**
+ * Git's repository, index, config, and pathspec behavior is extensively
+ * environment-configurable. Audit output protection must describe the output
+ * parent on disk, not a caller-selected alternate Git view, so pass only the
+ * process values needed to locate and run Git plus fixed defensive settings.
+ */
+function gitProbeEnvironment(): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {};
+  for (const name of GIT_ENVIRONMENT_PASSTHROUGH) {
+    const inheritedValue = process.env[name];
+    if (inheritedValue !== undefined) environment[name] = inheritedValue;
+  }
+  return {
+    ...environment,
+    GIT_ATTR_NOSYSTEM: '1',
+    GIT_CONFIG_GLOBAL: '/dev/null',
+    GIT_CONFIG_NOSYSTEM: '1',
+    GIT_DISCOVERY_ACROSS_FILESYSTEM: '1',
+    GIT_LITERAL_PATHSPECS: '1',
+    GIT_OPTIONAL_LOCKS: '0',
+    GIT_TERMINAL_PROMPT: '0',
+    LANG: 'C',
+    LC_ALL: 'C',
+  };
+}
+
+function parseInstant(option: string, rawValue: string): number {
+  if (!/(?:Z|[+-]\d{2}:?\d{2})$/i.test(rawValue)) {
+    throw new CliUsageError(`${option} must include an explicit Z or numeric UTC offset`);
+  }
+  const epochMilliseconds = Date.parse(rawValue);
+  if (!Number.isFinite(epochMilliseconds)) throw new CliUsageError(`${option} is not a valid timestamp`);
+  return epochMilliseconds / 1000;
+}
+
+function requireOption(options: Map<string, string>, option: (typeof OPTION_NAMES)[number]): string {
+  const value = options.get(option);
+  if (!value) throw new CliUsageError(`Missing required option ${option}`);
+  return value;
+}
+
+export function parseArgs(rawArgs: string[]): CliArgs {
+  const args = rawArgs.filter((argument) => argument !== '--');
+  if (args.includes('--apply')) {
+    throw new CliUsageError('--apply is forbidden: this command is permanently audit-only');
+  }
+  if (args.includes('--help')) {
+    throw new CliUsageError('help');
+  }
+
+  const options = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 2) {
+    const option = args[index];
+    const value = args[index + 1];
+    if (!OPTION_NAMES.includes(option as (typeof OPTION_NAMES)[number])) {
+      throw new CliUsageError(`Unknown argument: ${option}`);
+    }
+    if (!value || value.startsWith('--')) throw new CliUsageError(`${option} requires a value`);
+    if (options.has(option)) throw new CliUsageError(`${option} may only be specified once`);
+    options.set(option, value);
+  }
+
+  const outputPath = requireOption(options, '--output');
+  if (outputPath === '-' || outputPath === '/dev/stdout' || outputPath === '/proc/self/fd/1') {
+    throw new CliUsageError('--output must be a new regular file, not stdout');
+  }
+  const policyId = requireOption(options, '--policy-id');
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._/-]{2,127}$/.test(policyId)) {
+    throw new CliUsageError('--policy-id must be a 3-128 character non-secret slug');
+  }
+
+  const policy: AuditPolicy = {
+    policyId,
+    liveOldCodeActiveThroughEpochSeconds: parseInstant(
+      '--live-old-code-active-through',
+      requireOption(options, '--live-old-code-active-through'),
+    ),
+    liveFixedCodeActiveFromEpochSeconds: parseInstant(
+      '--live-fixed-code-active-from',
+      requireOption(options, '--live-fixed-code-active-from'),
+    ),
+    jsonOldCodeActiveThroughEpochSeconds: parseInstant(
+      '--json-old-code-active-through',
+      requireOption(options, '--json-old-code-active-through'),
+    ),
+    jsonFixedCodeActiveFromEpochSeconds: parseInstant(
+      '--json-fixed-code-active-from',
+      requireOption(options, '--json-fixed-code-active-from'),
+    ),
+    originWritersActiveFromEpochSeconds: parseInstant(
+      '--origin-writers-active-from',
+      requireOption(options, '--origin-writers-active-from'),
+    ),
+    nativeSafeGenerationActiveFromEpochSeconds: parseInstant(
+      '--native-safe-generation-active-from',
+      requireOption(options, '--native-safe-generation-active-from'),
+    ),
+  };
+
+  if (policy.liveOldCodeActiveThroughEpochSeconds >= policy.liveFixedCodeActiveFromEpochSeconds) {
+    throw new CliUsageError(
+      '--live-old-code-active-through must precede --live-fixed-code-active-from; the gap is the abstained rollout window',
+    );
+  }
+  if (policy.jsonOldCodeActiveThroughEpochSeconds >= policy.jsonFixedCodeActiveFromEpochSeconds) {
+    throw new CliUsageError(
+      '--json-old-code-active-through must precede --json-fixed-code-active-from; the gap is the abstained rollout window',
+    );
+  }
+  if (policy.nativeSafeGenerationActiveFromEpochSeconds < policy.originWritersActiveFromEpochSeconds) {
+    throw new CliUsageError('--native-safe-generation-active-from must not precede --origin-writers-active-from');
+  }
+  return { outputPath, policy };
+}
+
+export function helpText(): string {
+  return `Usage:
+  vp run db:audit-legacy-timestamps -- \\
+    --output /secure/new-report.jsonl \\
+    --policy-id verified-deploy-record-YYYYMMDD \\
+    --live-old-code-active-through <ISO-with-offset> \\
+    --live-fixed-code-active-from <ISO-with-offset> \\
+    --json-old-code-active-through <ISO-with-offset> \\
+    --json-fixed-code-active-from <ISO-with-offset> \\
+    --origin-writers-active-from <ISO-with-offset> \\
+    --native-safe-generation-active-from <ISO-with-offset>
+
+The live-pull and JSON code instants must come from deployment evidence, not Git
+commit timestamps. JSON fixed-code evidence is anchored by the deployed build
+containing 79185b916800b866173da01e4ec34743b0015218; the July live-pull fixes do
+not define the start of JSON safety. The origin-writer instant must be after
+migration 0156 completed and all old writers were retired. Each open rollout
+interval is uncertain and always abstains. There is intentionally no --apply
+mode and no stdout mode. The native safe-save instant must be after every active
+native writer was verified safe or retired, including the still-active legacy
+web saveAscent path whose shared-normalizer source fix is
+cdf1406dfb53f1865513fd005d39b13f469a74e1. A native row can support evidence
+only when it was created at or after that instant and created_at exactly equals
+updated_at; pre-origin, pre-safe, edited, or otherwise unverifiable native rows
+stay ambiguity-only. Aurora candidates without a sync stamp rollout-abstain;
+Aurora candidates or Kilter anchors edited after their source sync, and Kilter
+anchors without a sync stamp, also stay ambiguity-only. JSON candidates must
+retain their synthetic id and exact import-owned updated/sync stamps; claimed or
+otherwise unverifiable JSON rows never support proposals or controls.`;
+}
+
+function pathIsWithin(parentPath: string, childPath: string): boolean {
+  const relativePath = relative(parentPath, childPath);
+  return (
+    relativePath === '' || (!relativePath.startsWith(`..${sep}`) && relativePath !== '..' && !isAbsolute(relativePath))
+  );
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+export async function validateOutputPath(rawOutputPath: string, cwd = process.cwd()): Promise<string> {
+  const outputPath = resolve(cwd, rawOutputPath);
+  if (await pathExists(outputPath)) {
+    const outputState = await lstat(outputPath);
+    throw new CliUsageError(
+      outputState.isSymbolicLink()
+        ? `Refusing symlink output path: ${outputPath}`
+        : `Refusing existing output path: ${outputPath}`,
+    );
+  }
+
+  const outputParent = dirname(outputPath);
+  await access(outputParent, fsConstants.W_OK);
+  const realParent = await realpath(outputParent);
+  if (realParent !== resolve(outputParent)) {
+    throw new CliUsageError(`Refusing output beneath a symlinked directory: ${outputParent}`);
+  }
+
+  // Probe from the resolved output parent, not the caller's cwd: an absolute
+  // output may belong to a different repository. Only Git's specific
+  // "not a repository" result is safe to treat as untracked; every other
+  // failure is indeterminate and therefore refused.
+  const gitEnvironment = gitProbeEnvironment();
+  const repositoryProbe = spawnSync('git', ['--literal-pathspecs', 'rev-parse', '--show-toplevel'], {
+    cwd: realParent,
+    env: gitEnvironment,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (repositoryProbe.error || repositoryProbe.signal !== null || repositoryProbe.status === null) {
+    throw new CliUsageError(`Could not determine Git tracking status for output path: ${outputPath}`);
+  }
+  if (repositoryProbe.status !== 0) {
+    const outsideRepository =
+      /^fatal: not a git repository \(or any (?:of the parent directories|parent up to mount point)/i.test(
+        repositoryProbe.stderr,
+      );
+    if (repositoryProbe.status === 128 && outsideRepository) return outputPath;
+    throw new CliUsageError(`Could not determine Git tracking status for output path: ${outputPath}`);
+  }
+
+  const repositoryRootOutput = repositoryProbe.stdout.trim();
+  if (!repositoryRootOutput) {
+    throw new CliUsageError(`Could not determine Git tracking status for output path: ${outputPath}`);
+  }
+  const repositoryRoot = resolve(repositoryRootOutput);
+  if (!pathIsWithin(repositoryRoot, outputPath)) {
+    throw new CliUsageError(`Could not determine Git tracking status for output path: ${outputPath}`);
+  }
+  const repositoryRelativePath = relative(repositoryRoot, outputPath);
+  const trackedProbe = spawnSync(
+    'git',
+    ['--literal-pathspecs', 'ls-files', '--error-unmatch', '--', repositoryRelativePath],
+    {
+      cwd: repositoryRoot,
+      env: gitEnvironment,
+      encoding: 'utf8',
+      stdio: ['ignore', 'ignore', 'pipe'],
+    },
+  );
+  if (trackedProbe.error || trackedProbe.signal !== null || trackedProbe.status === null) {
+    throw new CliUsageError(`Could not determine Git tracking status for output path: ${outputPath}`);
+  }
+  if (trackedProbe.status === 0) {
+    throw new CliUsageError(`Refusing tracked output path: ${outputPath}`);
+  }
+  if (trackedProbe.status !== 1) {
+    throw new CliUsageError(`Could not determine Git tracking status for output path: ${outputPath}`);
+  }
+  return outputPath;
+}
+
+export type ArtifactSink = {
+  writeCanonicalRecord(record: Record<string, unknown>): Promise<void>;
+};
+
+export async function writeAuditArtifact(
+  rawOutputPath: string,
+  producer: (sink: ArtifactSink) => Promise<Record<string, unknown>>,
+  options: { cwd?: string; completedAt?: () => string } = {},
+): Promise<{ outputPath: string; digest: string }> {
+  const outputPath = await validateOutputPath(rawOutputPath, options.cwd);
+  const partialPath = resolve(dirname(outputPath), `.${basename(outputPath)}.${process.pid}.${randomUUID()}.partial`);
+  const file = await open(
+    partialPath,
+    fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY | (fsConstants.O_NOFOLLOW ?? 0),
+    0o600,
+  );
+  const recordsHash = createHash('sha256');
+  let published = false;
+
+  try {
+    const sink: ArtifactSink = {
+      async writeCanonicalRecord(record) {
+        assertPrivacySafeRecord(record);
+        const line = canonicalJson(record);
+        recordsHash.update(`${line}\n`);
+        await file.writeFile(`${line}\n`, 'utf8');
+      },
+    };
+    const runtimeFields = await producer(sink);
+    const digest = recordsHash.digest('hex');
+    const digestRecord = canonicalJson({ algorithm: 'sha256', digest, type: 'records_digest' });
+    await file.writeFile(`${digestRecord}\n`, 'utf8');
+    assertPrivacySafeRecord(runtimeFields);
+    const runtimeFooter = canonicalJson({
+      ...runtimeFields,
+      completed_at: (options.completedAt ?? (() => new Date().toISOString()))(),
+      type: 'runtime_footer',
+    });
+    await file.writeFile(`${runtimeFooter}\n`, 'utf8');
+    await file.sync();
+    await file.close();
+
+    // Hard-link publication is atomic and fails rather than replacing a path
+    // created after validation. The partial inode is never visible at the
+    // requested output name until every byte has been synced.
+    await link(partialPath, outputPath);
+    published = true;
+    await unlink(partialPath);
+    return { outputPath, digest };
+  } catch (error: unknown) {
+    await file.close().catch(() => undefined);
+    await unlink(partialPath).catch(() => undefined);
+    if (published) await unlink(outputPath).catch(() => undefined);
+    throw error;
+  }
+}
+
+export type DatabaseAuditMetadata = {
+  snapshot: string;
+  schemaSha256: string;
+  serverVersion: string;
+  transactionIsolation: string;
+  transactionReadOnly: string;
+  transactionDeferrable: string;
+  timeZone: string;
+};
+
+export type AuditCounters = {
+  scannedRows: number;
+  groups: number;
+  anchors: number;
+  edges: number;
+  correctionEvidence: number;
+  postFixInvariantViolations: number;
+  alignedControls: number;
+  ambiguousAbstentions: number;
+  heuristicOnlyAnchorAbstentions: number;
+  candidateTimestampUnverifiedAbstentions: number;
+  kilterTimestampUnverifiedAnchorAbstentions: number;
+  nativeTimestampUnverifiedAnchorAbstentions: number;
+  noAnchorAbstentions: number;
+  rolloutUncertainAbstentions: number;
+};
+
+function emptyCounters(): AuditCounters {
+  return {
+    scannedRows: 0,
+    groups: 0,
+    anchors: 0,
+    edges: 0,
+    correctionEvidence: 0,
+    postFixInvariantViolations: 0,
+    alignedControls: 0,
+    ambiguousAbstentions: 0,
+    heuristicOnlyAnchorAbstentions: 0,
+    candidateTimestampUnverifiedAbstentions: 0,
+    kilterTimestampUnverifiedAnchorAbstentions: 0,
+    nativeTimestampUnverifiedAnchorAbstentions: 0,
+    noAnchorAbstentions: 0,
+    rolloutUncertainAbstentions: 0,
+  };
+}
+
+function asFiniteNumber(value: unknown, field: string): number {
+  const numericValue = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numericValue)) throw new Error(`Database returned invalid ${field}`);
+  return numericValue;
+}
+
+function asNullableFiniteNumber(value: unknown, field: string): number | null {
+  return value === null || value === undefined ? null : asFiniteNumber(value, field);
+}
+
+function asBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== 'boolean') throw new Error(`Database returned invalid ${field}`);
+  return value;
+}
+
+const ORIGINS = new Set<TickOrigin>(['native', 'aurora_pull', 'kilter_pull', 'json_import']);
+const STATUSES = new Set<TickStatus>(['flash', 'send', 'attempt']);
+
+export function parseDatabaseRow(row: Record<string, unknown>): AuditTick {
+  const origin = String(row.origin) as TickOrigin;
+  const status = String(row.status) as TickStatus;
+  if (!ORIGINS.has(origin)) throw new Error(`Unexpected tick origin: ${String(row.origin)}`);
+  if (!STATUSES.has(status)) throw new Error(`Unexpected tick status: ${String(row.status)}`);
+  return {
+    id: String(row.id),
+    uuid: String(row.uuid),
+    userId: String(row.userId),
+    boardType: String(row.boardType),
+    climbUuid: String(row.climbUuid),
+    angle: asFiniteNumber(row.angle, 'angle'),
+    isMirror: row.isMirror === true,
+    origin,
+    status,
+    attemptCount: asFiniteNumber(row.attemptCount, 'attemptCount'),
+    climbedAtEpochSeconds: asFiniteNumber(row.climbedAtEpochSeconds, 'climbedAtEpochSeconds'),
+    createdAtEpochSeconds: asFiniteNumber(row.createdAtEpochSeconds, 'createdAtEpochSeconds'),
+    updatedAtEpochSeconds: asFiniteNumber(row.updatedAtEpochSeconds, 'updatedAtEpochSeconds'),
+    createdAtEqualsUpdatedAt: asBoolean(row.createdAtEqualsUpdatedAt, 'createdAtEqualsUpdatedAt'),
+    auroraSyncedAtEpochSeconds: asNullableFiniteNumber(row.auroraSyncedAtEpochSeconds, 'auroraSyncedAtEpochSeconds'),
+    auroraIdIsSyntheticJson: row.auroraIdIsSyntheticJson === true,
+    kilterSyncedAtEpochSeconds: asNullableFiniteNumber(row.kilterSyncedAtEpochSeconds, 'kilterSyncedAtEpochSeconds'),
+    kilterDetachedAtEpochSeconds: asNullableFiniteNumber(
+      row.kilterDetachedAtEpochSeconds,
+      'kilterDetachedAtEpochSeconds',
+    ),
+  };
+}
+
+function incrementClassification(counters: AuditCounters, result: CandidateGraphResult): void {
+  switch (result.classification) {
+    case 'correction_evidence':
+      counters.correctionEvidence += 1;
+      break;
+    case 'post_fix_invariant_violation':
+      counters.postFixInvariantViolations += 1;
+      break;
+    case 'aligned_control':
+      counters.alignedControls += 1;
+      break;
+    case 'ambiguous_abstention':
+      counters.ambiguousAbstentions += 1;
+      break;
+    case 'heuristic_only_anchor_abstention':
+      counters.heuristicOnlyAnchorAbstentions += 1;
+      break;
+    case 'candidate_timestamp_unverified_abstention':
+      counters.candidateTimestampUnverifiedAbstentions += 1;
+      break;
+    case 'kilter_timestamp_unverified_anchor_abstention':
+      counters.kilterTimestampUnverifiedAnchorAbstentions += 1;
+      break;
+    case 'native_timestamp_unverified_anchor_abstention':
+      counters.nativeTimestampUnverifiedAnchorAbstentions += 1;
+      break;
+    case 'no_anchor_abstention':
+      counters.noAnchorAbstentions += 1;
+      break;
+    case 'rollout_uncertain_abstention':
+      counters.rolloutUncertainAbstentions += 1;
+      break;
+  }
+}
+
+function detailedEvidenceRecord(
+  result: CandidateGraphResult,
+  anchors: AuditTick[],
+  policy: AuditPolicy,
+  pseudonymSecret: Uint8Array,
+): Record<string, unknown> | null {
+  // No-anchor and rollout-uncertain rows are represented only by privacy-
+  // redacted aggregates. A clean heuristic or timestamp-unverified candidate
+  // or anchor edge is emitted so reviewers can see why it abstained, but it
+  // never contributes a proposal or control violation.
+  if (result.classification === 'no_anchor_abstention' || result.classification === 'rollout_uncertain_abstention') {
+    return null;
+  }
+  const candidate = result.candidate;
+  const base: Record<string, unknown> = {
+    angle: candidate.angle,
+    board_type: candidate.boardType,
+    candidate_degree: result.candidateDegree,
+    candidate_key: pseudonymize(pseudonymSecret, 'tick', candidate.uuid),
+    candidate_origin: candidate.origin,
+    classification: result.classification,
+    climb_key: pseudonymize(pseudonymSecret, 'climb', candidate.climbUuid),
+    cohort: result.candidateClass.cohort,
+    candidate_timestamp_evidence: candidateTimestampEvidence(candidate),
+    origin_evidence: originEvidence(candidate, policy),
+    reciprocal: result.reciprocal,
+    type: 'candidate_evidence',
+    user_key: pseudonymize(pseudonymSecret, 'user', candidate.userId),
+  };
+  if (!result.edge) return base;
+  const anchor = anchors[result.edge.anchorIndex];
+  return {
+    ...base,
+    anchor_climbed_at: epochSecondsToIso(anchor.climbedAtEpochSeconds),
+    anchor_key: pseudonymize(pseudonymSecret, 'tick', anchor.uuid),
+    anchor_origin: anchor.origin,
+    anchor_origin_evidence: originEvidence(anchor, policy),
+    anchor_timestamp_evidence: anchorTimestampEvidence(anchor, policy),
+    inferred_offset_seconds: result.edge.offsetSeconds,
+    original_climbed_at: epochSecondsToIso(candidate.climbedAtEpochSeconds),
+    raw_delta_seconds: result.edge.offsetSeconds + result.edge.residualSeconds,
+    residual_seconds: result.edge.residualSeconds,
+    target_climbed_at: epochSecondsToIso(result.edge.targetEpochSeconds),
+  };
+}
+
+function redactedCounters(counters: AuditCounters): Record<string, number | '<5'> {
+  return Object.fromEntries(Object.entries(counters).map(([name, count]) => [name, redactSmallCell(count)])) as Record<
+    string,
+    number | '<5'
+  >;
+}
+
+export function buildAuditSummary(counters: AuditCounters): Record<string, unknown> {
+  const proposalsSuppressed = counters.postFixInvariantViolations > 0;
+  return {
+    counts: redactedCounters(counters),
+    effective_correction_proposals: proposalsSuppressed ? 0 : redactSmallCell(counters.correctionEvidence),
+    evidence_only: true,
+    post_fix_control_invariant: proposalsSuppressed ? 'failed' : 'passed',
+    proposals_suppressed: proposalsSuppressed,
+    type: 'audit_summary',
+  };
+}
+
+async function readMetadata(connection: postgres.ReservedSql): Promise<DatabaseAuditMetadata> {
+  const [state] = await connection.unsafe<Array<Record<string, unknown>>>(`
+    SELECT
+      pg_current_snapshot()::text AS "snapshot",
+      current_setting('server_version_num') AS "serverVersion",
+      current_setting('transaction_isolation') AS "transactionIsolation",
+      current_setting('transaction_read_only') AS "transactionReadOnly",
+      current_setting('transaction_deferrable') AS "transactionDeferrable",
+      current_setting('TimeZone') AS "timeZone"
+  `);
+  if (!state) throw new Error('Could not read PostgreSQL snapshot settings');
+  const metadata = {
+    snapshot: String(state.snapshot),
+    serverVersion: String(state.serverVersion),
+    transactionIsolation: String(state.transactionIsolation),
+    transactionReadOnly: String(state.transactionReadOnly),
+    transactionDeferrable: String(state.transactionDeferrable),
+    timeZone: String(state.timeZone),
+    schemaSha256: '',
+  };
+  if (
+    metadata.transactionIsolation !== 'serializable' ||
+    metadata.transactionReadOnly !== 'on' ||
+    metadata.transactionDeferrable !== 'on' ||
+    metadata.timeZone !== 'UTC'
+  ) {
+    throw new Error(`Unsafe audit transaction settings: ${canonicalJson(metadata)}`);
+  }
+
+  const schemaRows = await connection.unsafe<Array<Record<string, unknown>>>(`
+    SELECT column_name AS "columnName", data_type AS "dataType", udt_name AS "udtName", is_nullable AS "nullable"
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'boardsesh_ticks'
+    ORDER BY ordinal_position
+  `);
+  const requiredColumns = new Set([
+    'id',
+    'uuid',
+    'user_id',
+    'board_type',
+    'climb_uuid',
+    'angle',
+    'is_mirror',
+    'origin',
+    'status',
+    'attempt_count',
+    'climbed_at',
+    'created_at',
+    'updated_at',
+    'aurora_id',
+    'aurora_synced_at',
+    'kilter_synced_at',
+    'kilter_detached_at',
+  ]);
+  for (const row of schemaRows) requiredColumns.delete(String(row.columnName));
+  if (requiredColumns.size > 0)
+    throw new Error(`boardsesh_ticks schema is missing: ${[...requiredColumns].join(', ')}`);
+
+  const expectedSchema = new Map<string, { dataType: string; udtName?: string }>([
+    ['id', { dataType: 'bigint' }],
+    ['uuid', { dataType: 'text' }],
+    ['user_id', { dataType: 'text' }],
+    ['board_type', { dataType: 'text' }],
+    ['climb_uuid', { dataType: 'text' }],
+    ['angle', { dataType: 'integer' }],
+    ['is_mirror', { dataType: 'boolean' }],
+    ['origin', { dataType: 'USER-DEFINED', udtName: 'tick_origin' }],
+    ['status', { dataType: 'USER-DEFINED', udtName: 'tick_status' }],
+    ['attempt_count', { dataType: 'integer' }],
+    ['climbed_at', { dataType: 'timestamp without time zone' }],
+    ['created_at', { dataType: 'timestamp without time zone' }],
+    ['updated_at', { dataType: 'timestamp without time zone' }],
+    ['aurora_id', { dataType: 'text' }],
+    ['aurora_synced_at', { dataType: 'timestamp without time zone' }],
+    ['kilter_synced_at', { dataType: 'timestamp without time zone' }],
+    ['kilter_detached_at', { dataType: 'timestamp without time zone' }],
+  ]);
+  for (const row of schemaRows) {
+    const columnName = String(row.columnName);
+    const expected = expectedSchema.get(columnName);
+    if (!expected) continue;
+    if (row.dataType !== expected.dataType || (expected.udtName && row.udtName !== expected.udtName)) {
+      throw new Error(`boardsesh_ticks.${columnName} has an unexpected database type; audit aborted`);
+    }
+  }
+  metadata.schemaSha256 = sha256Hex(canonicalJson(schemaRows));
+  return metadata;
+}
+
+export async function runDatabaseAudit(
+  databaseUrl: string,
+  policy: AuditPolicy,
+  sink: ArtifactSink,
+  pseudonymSecret: Uint8Array,
+  onMetadata?: (metadata: DatabaseAuditMetadata) => Promise<void>,
+): Promise<{ counters: AuditCounters; metadata: DatabaseAuditMetadata }> {
+  const client = postgres(databaseUrl, { max: 1, prepare: false, idle_timeout: 5 });
+  const connection = await client.reserve().catch(async (error: unknown) => {
+    await client.end().catch(() => undefined);
+    throw error;
+  });
+  const counters = emptyCounters();
+  let transactionOpen = false;
+  let currentGroupKey: string | null = null;
+  let currentGroup: AuditTick[] = [];
+
+  const flushGroup = async (): Promise<void> => {
+    if (currentGroup.length === 0) return;
+    counters.groups += 1;
+    const analysis = analyzeTickGroup(currentGroup, policy);
+    counters.anchors += analysis.anchors.length;
+    counters.edges += analysis.edgeCount;
+    for (const result of analysis.candidates) {
+      incrementClassification(counters, result);
+      const record = detailedEvidenceRecord(result, analysis.anchors, policy, pseudonymSecret);
+      if (record) await sink.writeCanonicalRecord(record);
+    }
+    currentGroup = [];
+  };
+
+  try {
+    await connection.unsafe('BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE READ ONLY DEFERRABLE');
+    transactionOpen = true;
+    await connection.unsafe(`SET LOCAL TIME ZONE 'UTC'`);
+    const metadata = await readMetadata(connection);
+    await onMetadata?.(metadata);
+
+    await connection.unsafe(AUDIT_SCAN_QUERY).cursor(AUDIT_CURSOR_ROWS, async (databaseRows) => {
+      for (const databaseRow of databaseRows) {
+        const tick = parseDatabaseRow(databaseRow as Record<string, unknown>);
+        counters.scannedRows += 1;
+        const nextGroupKey = groupKey(tick);
+        if (currentGroupKey !== null && nextGroupKey !== currentGroupKey) await flushGroup();
+        currentGroupKey = nextGroupKey;
+        currentGroup.push(tick);
+        if (currentGroup.length > MAX_ROWS_PER_NATURAL_KEY) {
+          throw new Error(`Natural-key group exceeded the ${MAX_ROWS_PER_NATURAL_KEY}-row safety bound; audit aborted`);
+        }
+      }
+    });
+    await flushGroup();
+    await connection.unsafe('ROLLBACK');
+    transactionOpen = false;
+    return { counters, metadata };
+  } finally {
+    if (transactionOpen) await connection.unsafe('ROLLBACK').catch(() => undefined);
+    connection.release();
+    await client.end();
+  }
+}
+
+async function resolveDatabaseUrl(databaseUrl: string | undefined): Promise<string> {
+  if (databaseUrl) return databaseUrl;
+  // Keep dotenv loading and database configuration entirely off --help and
+  // invalid-output paths. Output validation and exclusive staging happen
+  // before this dynamic import runs.
+  const { getScriptDatabaseUrl } = await import('./db-connection.js');
+  return getScriptDatabaseUrl();
+}
+
+export async function runAuditCommand(cliArgs: CliArgs, databaseUrl?: string): Promise<string> {
+  const startedAt = Date.now();
+  const pseudonymSecret = randomBytes(32);
+  const pseudonymScope = pseudonymize(pseudonymSecret, 'scope', 'legacy-timestamp-audit');
+  const policyRecord = {
+    ...cliArgs.policy,
+    jsonOldCodeActiveThroughEpochSeconds: epochSecondsToIso(cliArgs.policy.jsonOldCodeActiveThroughEpochSeconds),
+    jsonFixedCodeActiveFromEpochSeconds: epochSecondsToIso(cliArgs.policy.jsonFixedCodeActiveFromEpochSeconds),
+    liveFixedCodeActiveFromEpochSeconds: epochSecondsToIso(cliArgs.policy.liveFixedCodeActiveFromEpochSeconds),
+    liveOldCodeActiveThroughEpochSeconds: epochSecondsToIso(cliArgs.policy.liveOldCodeActiveThroughEpochSeconds),
+    nativeSafeGenerationActiveFromEpochSeconds: epochSecondsToIso(
+      cliArgs.policy.nativeSafeGenerationActiveFromEpochSeconds,
+    ),
+    originWritersActiveFromEpochSeconds: epochSecondsToIso(cliArgs.policy.originWritersActiveFromEpochSeconds),
+  };
+  const policySha256 = sha256Hex(canonicalJson(policyRecord));
+
+  const { outputPath } = await writeAuditArtifact(cliArgs.outputPath, async (sink) => {
+    const resolvedDatabaseUrl = await resolveDatabaseUrl(databaseUrl);
+    const { counters } = await runDatabaseAudit(
+      resolvedDatabaseUrl,
+      cliArgs.policy,
+      sink,
+      pseudonymSecret,
+      async (metadata) => {
+        // Snapshot and schema provenance are only available after BEGIN. Emit
+        // the header as soon as they are verified, before the cursor can emit
+        // any evidence records.
+        await sink.writeCanonicalRecord({
+          format_version: AUDIT_FORMAT_VERSION,
+          mode: 'audit_only_evidence',
+          policy: policyRecord,
+          policy_sha256: policySha256,
+          policy_version: AUDIT_POLICY_VERSION,
+          privacy: {
+            cross_run_pseudonym_stability: false,
+            identifiers: 'run_scoped_hmac_sha256_24',
+            pseudonym_scope: pseudonymScope,
+            small_cell_threshold: SMALL_CELL_THRESHOLD,
+          },
+          provenance: {
+            query_sha256: AUDIT_QUERY_SHA256,
+            schema_sha256: metadata.schemaSha256,
+            snapshot: metadata.snapshot,
+            timestamp_normalizer_lineage: {
+              explicit_offset_suffixes_fixed: EXPLICIT_OFFSET_SUFFIX_FIX_SOURCE_REVISION,
+              fixed_json_import_moved: JSON_IMPORT_MOVE_SOURCE_REVISION,
+              json_bug_introduced: JSON_BUG_INTRO_SOURCE_REVISION,
+              json_deployment_evidence_anchor: JSON_NAIVE_UTC_FIX_SOURCE_REVISION,
+              json_naive_utc_fixed: JSON_NAIVE_UTC_FIX_SOURCE_REVISION,
+              legacy_web_save_ascent_shared_normalizer_adopted: LEGACY_WEB_SAVE_ASCENT_NORMALIZER_FIX_SOURCE_REVISION,
+              live_pull_fixed_and_shared_normalizer_extracted: LIVE_PULL_SHARED_NORMALIZER_FIX_SOURCE_REVISION,
+            },
+          },
+          safety: {
+            artifact_is_executable: false,
+            aurora_candidate_requires_updated_at_not_after_sync: true,
+            created_at_used_as_json_import_time: false,
+            json_candidate_requires_exact_synthetic_import_provenance: true,
+            kilter_anchor_requires_updated_at_not_after_sync: true,
+            native_anchor_requires_created_at_equals_updated_at: true,
+            records_digest_reproducible_across_runs: false,
+            records_digest_scope: 'single_artifact_integrity',
+            per_user_offset_extrapolation: false,
+            transaction: {
+              deferrable: metadata.transactionDeferrable,
+              isolation: metadata.transactionIsolation,
+              read_only: metadata.transactionReadOnly,
+              time_zone: metadata.timeZone,
+            },
+          },
+          server_version: metadata.serverVersion,
+          type: 'audit_header',
+        });
+      },
+    );
+    await sink.writeCanonicalRecord(buildAuditSummary(counters));
+    return {
+      duration_ms: Date.now() - startedAt,
+      policy_sha256: policySha256,
+      query_sha256: AUDIT_QUERY_SHA256,
+      run_id: randomUUID(),
+    };
+  });
+  return outputPath;
+}
+
+async function main(): Promise<void> {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    const outputPath = await runAuditCommand(args);
+    console.info(`[legacy-timestamp-audit] Wrote audit-only evidence to ${outputPath}`);
+  } catch (error: unknown) {
+    if (error instanceof CliUsageError) {
+      if (error.message !== 'help') console.error(`[legacy-timestamp-audit] ${error.message}`);
+      console.error(helpText());
+      process.exitCode = error.message === 'help' ? 0 : 2;
+      return;
+    }
+    console.error(`[legacy-timestamp-audit] failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}
+
+const isDirectRun = process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false;
+if (isDirectRun) void main();

--- a/packages/db/scripts/audit-legacy-tick-timestamps.ts
+++ b/packages/db/scripts/audit-legacy-tick-timestamps.ts
@@ -101,6 +101,7 @@ const OPTION_NAMES = [
 ] as const;
 
 const GIT_ENVIRONMENT_PASSTHROUGH = ['PATH', 'PATHEXT', 'SYSTEMROOT', 'WINDIR', 'TMPDIR', 'TMP', 'TEMP'] as const;
+const GIT_PROBE_TIMEOUT_MS = 5_000;
 
 /**
  * Git's repository, index, config, and pathspec behavior is extensively
@@ -165,7 +166,12 @@ export function parseArgs(rawArgs: string[]): CliArgs {
   }
 
   const outputPath = requireOption(options, '--output');
-  if (outputPath === '-' || outputPath === '/dev/stdout' || outputPath === '/proc/self/fd/1') {
+  if (
+    outputPath === '-' ||
+    outputPath === '/dev/stdout' ||
+    outputPath === '/dev/fd/1' ||
+    outputPath === '/proc/self/fd/1'
+  ) {
     throw new CliUsageError('--output must be a new regular file, not stdout');
   }
   const policyId = requireOption(options, '--policy-id');
@@ -293,6 +299,7 @@ export async function validateOutputPath(rawOutputPath: string, cwd = process.cw
     env: gitEnvironment,
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: GIT_PROBE_TIMEOUT_MS,
   });
   if (repositoryProbe.error || repositoryProbe.signal !== null || repositoryProbe.status === null) {
     throw new CliUsageError(`Could not determine Git tracking status for output path: ${outputPath}`);
@@ -323,6 +330,7 @@ export async function validateOutputPath(rawOutputPath: string, cwd = process.cw
       env: gitEnvironment,
       encoding: 'utf8',
       stdio: ['ignore', 'ignore', 'pipe'],
+      timeout: GIT_PROBE_TIMEOUT_MS,
     },
   );
   if (trackedProbe.error || trackedProbe.signal !== null || trackedProbe.status === null) {
@@ -354,7 +362,6 @@ export async function writeAuditArtifact(
     0o600,
   );
   const recordsHash = createHash('sha256');
-  let published = false;
 
   try {
     const sink: ArtifactSink = {
@@ -383,13 +390,13 @@ export async function writeAuditArtifact(
     // created after validation. The partial inode is never visible at the
     // requested output name until every byte has been synced.
     await link(partialPath, outputPath);
-    published = true;
-    await unlink(partialPath);
+    // The requested output is now a complete, durable artifact. A failure to
+    // remove the private staging link must not delete or fail that publication.
+    await unlink(partialPath).catch(() => undefined);
     return { outputPath, digest };
   } catch (error: unknown) {
     await file.close().catch(() => undefined);
     await unlink(partialPath).catch(() => undefined);
-    if (published) await unlink(outputPath).catch(() => undefined);
     throw error;
   }
 }

--- a/packages/db/scripts/audit-legacy-tick-timestamps.ts
+++ b/packages/db/scripts/audit-legacy-tick-timestamps.ts
@@ -1,11 +1,4 @@
-/**
- * Read-only evidence collection for issue #3909.
- *
- * This command has no apply mode and emits no SQL. It classifies only
- * reciprocal one-to-one candidate/anchor pairs from one serializable,
- * read-only, deferrable PostgreSQL snapshot. The JSONL artifact is evidence for
- * a separately reviewed correction design; it is not an executable backfill.
- */
+// Read-only evidence collection for #3909; it has no apply path and emits only a review artifact.
 import { constants as fsConstants } from 'node:fs';
 import { access, link, lstat, open, realpath, unlink } from 'node:fs/promises';
 import { createHash, randomBytes, randomUUID } from 'node:crypto';
@@ -43,6 +36,10 @@ export const LEGACY_WEB_SAVE_ASCENT_NORMALIZER_FIX_SOURCE_REVISION = 'cdf1406dfb
 export const AUDIT_FORMAT_VERSION = 1;
 export const AUDIT_CURSOR_ROWS = 500;
 export const MAX_ROWS_PER_NATURAL_KEY = 10_000;
+export const AUDIT_CONNECT_TIMEOUT_SECONDS = 30;
+export const AUDIT_STATEMENT_TIMEOUT_MS = 300_000;
+export const AUDIT_DATABASE_RESPONSE_TIMEOUT_MS = 330_000;
+export const AUDIT_SHUTDOWN_TIMEOUT_SECONDS = 5;
 
 // Explicit epoch conversion avoids session-dependent parsing of timestamp
 // without time zone. The ORDER BY follows boardsesh_ticks_user_climb_lookup_idx
@@ -82,12 +79,75 @@ ORDER BY user_id, board_type, angle, climb_uuid, id
 
 export const AUDIT_QUERY_SHA256 = sha256Hex(AUDIT_SCAN_QUERY);
 
+const AUDIT_CURSOR_NAME = 'legacy_timestamp_audit_cursor';
+const AUDIT_DECLARE_CURSOR_QUERY = `DECLARE ${AUDIT_CURSOR_NAME} NO SCROLL CURSOR FOR ${AUDIT_SCAN_QUERY}`;
+const AUDIT_FETCH_CURSOR_QUERY = `FETCH FORWARD ${AUDIT_CURSOR_ROWS} FROM ${AUDIT_CURSOR_NAME}`;
+
 type CliArgs = {
   outputPath: string;
   policy: AuditPolicy;
 };
 
 export class CliUsageError extends Error {}
+
+export class DatabaseResponseTimeoutError extends Error {
+  constructor(operation: string, timeoutMs: number) {
+    super(`PostgreSQL did not respond to ${operation} within ${timeoutMs}ms`);
+    this.name = 'DatabaseResponseTimeoutError';
+  }
+}
+
+export type DatabaseResponseTimeoutScheduler = {
+  schedule(callback: () => void, timeoutMs: number): unknown;
+  cancel(handle: unknown): void;
+};
+
+const SYSTEM_DATABASE_RESPONSE_TIMEOUT_SCHEDULER: DatabaseResponseTimeoutScheduler = {
+  schedule: (callback, timeoutMs) => setTimeout(callback, timeoutMs),
+  cancel: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+export function awaitDatabaseResponse<T>(
+  operation: string,
+  response: PromiseLike<T>,
+  onTimeout: () => void,
+  options: { timeoutMs?: number; scheduler?: DatabaseResponseTimeoutScheduler } = {},
+): Promise<T> {
+  const timeoutMs = options.timeoutMs ?? AUDIT_DATABASE_RESPONSE_TIMEOUT_MS;
+  const scheduler = options.scheduler ?? SYSTEM_DATABASE_RESPONSE_TIMEOUT_SCHEDULER;
+
+  return new Promise<T>((resolveResponse, rejectResponse) => {
+    let settled = false;
+    const timeoutHandle = scheduler.schedule(() => {
+      if (settled) return;
+      settled = true;
+      rejectResponse(new DatabaseResponseTimeoutError(operation, timeoutMs));
+      onTimeout();
+    }, timeoutMs);
+
+    void Promise.resolve(response).then(
+      (result) => {
+        if (settled) return;
+        settled = true;
+        scheduler.cancel(timeoutHandle);
+        resolveResponse(result);
+      },
+      (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        scheduler.cancel(timeoutHandle);
+        rejectResponse(error);
+      },
+    );
+  });
+}
+
+export function requireNoFollowFlag(noFollowFlag: number | undefined): number {
+  if (typeof noFollowFlag !== 'number') {
+    throw new Error('Audit artifact staging requires O_NOFOLLOW support');
+  }
+  return noFollowFlag;
+}
 
 const OPTION_NAMES = [
   '--output',
@@ -354,11 +414,12 @@ export async function writeAuditArtifact(
   producer: (sink: ArtifactSink) => Promise<Record<string, unknown>>,
   options: { cwd?: string; completedAt?: () => string } = {},
 ): Promise<{ outputPath: string; digest: string }> {
+  const noFollowFlag = requireNoFollowFlag(fsConstants.O_NOFOLLOW);
   const outputPath = await validateOutputPath(rawOutputPath, options.cwd);
   const partialPath = resolve(dirname(outputPath), `.${basename(outputPath)}.${process.pid}.${randomUUID()}.partial`);
   const file = await open(
     partialPath,
-    fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY | (fsConstants.O_NOFOLLOW ?? 0),
+    fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY | noFollowFlag,
     0o600,
   );
   const recordsHash = createHash('sha256');
@@ -405,6 +466,7 @@ export type DatabaseAuditMetadata = {
   snapshot: string;
   schemaSha256: string;
   serverVersion: string;
+  statementTimeoutMs: number;
   transactionIsolation: string;
   transactionReadOnly: string;
   transactionDeferrable: string;
@@ -595,20 +657,31 @@ export function buildAuditSummary(counters: AuditCounters): Record<string, unkno
   };
 }
 
-async function readMetadata(connection: postgres.ReservedSql): Promise<DatabaseAuditMetadata> {
-  const [state] = await connection.unsafe<Array<Record<string, unknown>>>(`
+type DatabaseResponseAwaiter = <T>(operation: string, response: PromiseLike<T>) => Promise<T>;
+
+async function readMetadata(
+  connection: postgres.ReservedSql,
+  awaitResponse: DatabaseResponseAwaiter,
+): Promise<DatabaseAuditMetadata> {
+  const [state] = await awaitResponse(
+    'read audit snapshot settings',
+    connection.unsafe<Array<Record<string, unknown>>>(`
     SELECT
       pg_current_snapshot()::text AS "snapshot",
       current_setting('server_version_num') AS "serverVersion",
+      (EXTRACT(EPOCH FROM current_setting('statement_timeout')::interval) * 1000)::double precision
+        AS "statementTimeoutMs",
       current_setting('transaction_isolation') AS "transactionIsolation",
       current_setting('transaction_read_only') AS "transactionReadOnly",
       current_setting('transaction_deferrable') AS "transactionDeferrable",
       current_setting('TimeZone') AS "timeZone"
-  `);
+  `),
+  );
   if (!state) throw new Error('Could not read PostgreSQL snapshot settings');
   const metadata = {
     snapshot: String(state.snapshot),
     serverVersion: String(state.serverVersion),
+    statementTimeoutMs: asFiniteNumber(state.statementTimeoutMs, 'statement_timeout'),
     transactionIsolation: String(state.transactionIsolation),
     transactionReadOnly: String(state.transactionReadOnly),
     transactionDeferrable: String(state.transactionDeferrable),
@@ -619,17 +692,21 @@ async function readMetadata(connection: postgres.ReservedSql): Promise<DatabaseA
     metadata.transactionIsolation !== 'serializable' ||
     metadata.transactionReadOnly !== 'on' ||
     metadata.transactionDeferrable !== 'on' ||
+    metadata.statementTimeoutMs !== AUDIT_STATEMENT_TIMEOUT_MS ||
     metadata.timeZone !== 'UTC'
   ) {
     throw new Error(`Unsafe audit transaction settings: ${canonicalJson(metadata)}`);
   }
 
-  const schemaRows = await connection.unsafe<Array<Record<string, unknown>>>(`
-    SELECT column_name AS "columnName", data_type AS "dataType", udt_name AS "udtName", is_nullable AS "nullable"
-    FROM information_schema.columns
-    WHERE table_schema = 'public' AND table_name = 'boardsesh_ticks'
-    ORDER BY ordinal_position
-  `);
+  const schemaRows = await awaitResponse(
+    'read boardsesh_ticks schema',
+    connection.unsafe<Array<Record<string, unknown>>>(`
+      SELECT column_name AS "columnName", data_type AS "dataType", udt_name AS "udtName", is_nullable AS "nullable"
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'boardsesh_ticks'
+      ORDER BY ordinal_position
+    `),
+  );
   const requiredColumns = new Set([
     'id',
     'uuid',
@@ -691,15 +768,26 @@ export async function runDatabaseAudit(
   pseudonymSecret: Uint8Array,
   onMetadata?: (metadata: DatabaseAuditMetadata) => Promise<void>,
 ): Promise<{ counters: AuditCounters; metadata: DatabaseAuditMetadata }> {
-  const client = postgres(databaseUrl, { max: 1, prepare: false, idle_timeout: 5 });
-  const connection = await client.reserve().catch(async (error: unknown) => {
-    await client.end().catch(() => undefined);
-    throw error;
+  const client = postgres(databaseUrl, {
+    connect_timeout: AUDIT_CONNECT_TIMEOUT_SECONDS,
+    idle_timeout: 5,
+    max: 1,
+    prepare: false,
   });
+  let connection: postgres.ReservedSql | null = null;
+  let forceClosed = false;
   const counters = emptyCounters();
   let transactionOpen = false;
   let currentGroupKey: string | null = null;
   let currentGroup: AuditTick[] = [];
+
+  const forceCloseClient = (): void => {
+    if (forceClosed) return;
+    forceClosed = true;
+    void client.end({ timeout: 0 }).catch(() => undefined);
+  };
+  const awaitResponse: DatabaseResponseAwaiter = (operation, response) =>
+    awaitDatabaseResponse(operation, response, forceCloseClient);
 
   const flushGroup = async (): Promise<void> => {
     if (currentGroup.length === 0) return;
@@ -716,13 +804,28 @@ export async function runDatabaseAudit(
   };
 
   try {
-    await connection.unsafe('BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE READ ONLY DEFERRABLE');
+    const reservedConnection = await awaitResponse('reserve the audit connection', client.reserve());
+    connection = reservedConnection;
+    await awaitResponse(
+      'begin the audit transaction',
+      reservedConnection.unsafe('BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE READ ONLY DEFERRABLE'),
+    );
     transactionOpen = true;
-    await connection.unsafe(`SET LOCAL TIME ZONE 'UTC'`);
-    const metadata = await readMetadata(connection);
+    await awaitResponse(
+      'set the audit statement timeout',
+      reservedConnection.unsafe(`SET LOCAL statement_timeout = ${AUDIT_STATEMENT_TIMEOUT_MS}`),
+    );
+    await awaitResponse('set the audit time zone', reservedConnection.unsafe(`SET LOCAL TIME ZONE 'UTC'`));
+    const metadata = await readMetadata(reservedConnection, awaitResponse);
     await onMetadata?.(metadata);
 
-    await connection.unsafe(AUDIT_SCAN_QUERY).cursor(AUDIT_CURSOR_ROWS, async (databaseRows) => {
+    await awaitResponse('declare the audit cursor', reservedConnection.unsafe(AUDIT_DECLARE_CURSOR_QUERY));
+    while (true) {
+      const databaseRows = await awaitResponse(
+        'fetch an audit cursor batch',
+        reservedConnection.unsafe<Array<Record<string, unknown>>>(AUDIT_FETCH_CURSOR_QUERY),
+      );
+      if (databaseRows.length === 0) break;
       for (const databaseRow of databaseRows) {
         const tick = parseDatabaseRow(databaseRow as Record<string, unknown>);
         counters.scannedRows += 1;
@@ -734,15 +837,19 @@ export async function runDatabaseAudit(
           throw new Error(`Natural-key group exceeded the ${MAX_ROWS_PER_NATURAL_KEY}-row safety bound; audit aborted`);
         }
       }
-    });
+    }
     await flushGroup();
-    await connection.unsafe('ROLLBACK');
+    await awaitResponse('roll back the completed audit transaction', reservedConnection.unsafe('ROLLBACK'));
     transactionOpen = false;
     return { counters, metadata };
   } finally {
-    if (transactionOpen) await connection.unsafe('ROLLBACK').catch(() => undefined);
-    connection.release();
-    await client.end();
+    if (connection !== null && transactionOpen && !forceClosed) {
+      await awaitResponse('roll back the failed audit transaction', connection.unsafe('ROLLBACK')).catch(
+        () => undefined,
+      );
+    }
+    if (connection !== null && !forceClosed) connection.release();
+    if (!forceClosed) await client.end({ timeout: AUDIT_SHUTDOWN_TIMEOUT_SECONDS });
   }
 }
 
@@ -819,6 +926,11 @@ export async function runAuditCommand(cliArgs: CliArgs, databaseUrl?: string): P
             records_digest_reproducible_across_runs: false,
             records_digest_scope: 'single_artifact_integrity',
             per_user_offset_extrapolation: false,
+            timeouts: {
+              client_connect_seconds: AUDIT_CONNECT_TIMEOUT_SECONDS,
+              client_response_ms: AUDIT_DATABASE_RESPONSE_TIMEOUT_MS,
+              server_statement_ms: metadata.statementTimeoutMs,
+            },
             transaction: {
               deferrable: metadata.transactionDeferrable,
               isolation: metadata.transactionIsolation,

--- a/packages/db/scripts/legacy-timestamp-audit-core.test.ts
+++ b/packages/db/scripts/legacy-timestamp-audit-core.test.ts
@@ -1,0 +1,771 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ALLOWED_IANA_UTC_OFFSET_SECONDS,
+  analyzeTickGroup,
+  anchorTimestampEvidence,
+  assertPrivacySafeRecord,
+  canonicalJson,
+  candidateTimestampEvidence,
+  classifyCandidate,
+  inferAllowedOffset,
+  isAnchorEligibleForAmbiguityGraph,
+  originEvidence,
+  pseudonymize,
+  redactSmallCell,
+  type AuditPolicy,
+  type AuditTick,
+} from './legacy-timestamp-audit-core.js';
+
+const HOUR = 3600;
+const policy: AuditPolicy = {
+  policyId: 'test-policy',
+  liveOldCodeActiveThroughEpochSeconds: 100,
+  liveFixedCodeActiveFromEpochSeconds: 200,
+  jsonOldCodeActiveThroughEpochSeconds: 100,
+  jsonFixedCodeActiveFromEpochSeconds: 200,
+  originWritersActiveFromEpochSeconds: 50,
+  nativeSafeGenerationActiveFromEpochSeconds: 60,
+};
+
+function tick(overrides: Partial<AuditTick> = {}): AuditTick {
+  return {
+    id: '1',
+    uuid: 'tick-1',
+    userId: 'user-1',
+    boardType: 'kilter',
+    climbUuid: 'climb-1',
+    angle: 40,
+    isMirror: false,
+    origin: 'json_import',
+    status: 'send',
+    attemptCount: 2,
+    climbedAtEpochSeconds: 20 * HOUR,
+    createdAtEpochSeconds: 1,
+    updatedAtEpochSeconds: 1,
+    createdAtEqualsUpdatedAt: false,
+    auroraSyncedAtEpochSeconds: 1,
+    auroraIdIsSyntheticJson: true,
+    kilterSyncedAtEpochSeconds: null,
+    kilterDetachedAtEpochSeconds: null,
+    ...overrides,
+  };
+}
+
+function anchor(overrides: Partial<AuditTick> = {}): AuditTick {
+  return tick({
+    id: '2',
+    uuid: 'anchor-1',
+    origin: 'kilter_pull',
+    climbedAtEpochSeconds: 10 * HOUR,
+    createdAtEpochSeconds: 50,
+    kilterSyncedAtEpochSeconds: 50,
+    ...overrides,
+  });
+}
+
+void describe('allowed IANA UTC offsets', () => {
+  void it('contains both world bounds and the current quarter-hour zones', () => {
+    for (const expected of [
+      -12 * HOUR,
+      -(2 * HOUR + 30 * 60),
+      14 * HOUR,
+      5 * HOUR + 45 * 60,
+      8 * HOUR + 45 * 60,
+      12 * HOUR + 45 * 60,
+    ]) {
+      assert.ok(ALLOWED_IANA_UTC_OFFSET_SECONDS.includes(expected as never));
+    }
+  });
+
+  void it('does not treat arbitrary quarter-hour values as a real timezone', () => {
+    assert.equal(inferAllowedOffset(7 * HOUR + 15 * 60), null);
+  });
+
+  void it('accepts up to sixty seconds of residual and rejects the next second', () => {
+    assert.deepEqual(inferAllowedOffset(10 * HOUR + 60), {
+      offsetSeconds: 10 * HOUR,
+      residualSeconds: 60,
+    });
+    assert.equal(inferAllowedOffset(10 * HOUR + 61), null);
+  });
+
+  void it('handles negative offsets without changing their sign', () => {
+    assert.deepEqual(inferAllowedOffset(-3 * HOUR - 30 * 60 - 7), {
+      offsetSeconds: -(3 * HOUR + 30 * 60),
+      residualSeconds: -7,
+    });
+  });
+});
+
+void describe('cohort and anchor policy', () => {
+  void it('keeps a claimed JSON row suspect by origin even after a later live claim', () => {
+    const claimed = tick({
+      auroraIdIsSyntheticJson: false,
+      auroraSyncedAtEpochSeconds: 300,
+      updatedAtEpochSeconds: 300,
+      createdAtEpochSeconds: 300,
+    });
+    assert.deepEqual(classifyCandidate(claimed, policy), {
+      role: 'suspect',
+      cohort: 'json_timing_unknown',
+    });
+  });
+
+  void it('never uses JSON created_at to prove that an import ran after the fix', () => {
+    const exportedAfterFixButImportedAtUnknownTime = tick({
+      createdAtEpochSeconds: 300,
+      updatedAtEpochSeconds: 10,
+      auroraSyncedAtEpochSeconds: 10,
+      auroraIdIsSyntheticJson: true,
+    });
+    assert.equal(classifyCandidate(exportedAfterFixButImportedAtUnknownTime, policy)?.role, 'suspect');
+  });
+
+  void it('recognizes only still-synthetic, import-owned stamps as a JSON post-fix control', () => {
+    const control = tick({
+      createdAtEpochSeconds: 1,
+      updatedAtEpochSeconds: 250,
+      auroraSyncedAtEpochSeconds: 250,
+      auroraIdIsSyntheticJson: true,
+    });
+    assert.deepEqual(classifyCandidate(control, policy), {
+      role: 'post_fix_control',
+      cohort: 'json_post_fix_control',
+    });
+  });
+
+  void it('uses import-owned stamps to separate JSON pre-fix and uncertain rollout cohorts', () => {
+    const preFix = tick({
+      updatedAtEpochSeconds: 90,
+      auroraSyncedAtEpochSeconds: 90,
+      auroraIdIsSyntheticJson: true,
+    });
+    const uncertain = tick({
+      updatedAtEpochSeconds: 150,
+      auroraSyncedAtEpochSeconds: 150,
+      auroraIdIsSyntheticJson: true,
+    });
+    assert.deepEqual(classifyCandidate(preFix, policy), { role: 'suspect', cohort: 'json_pre_fix' });
+    assert.deepEqual(classifyCandidate(uncertain, policy), {
+      role: 'uncertain',
+      cohort: 'json_rollout_uncertain',
+    });
+  });
+
+  void it('requires exact still-synthetic JSON import provenance for timestamp evidence', () => {
+    assert.equal(candidateTimestampEvidence(tick()), 'json_synthetic_import_owned_timestamps');
+    assert.equal(candidateTimestampEvidence(tick({ updatedAtEpochSeconds: 1.5 })), 'json_import_provenance_unverified');
+    assert.equal(
+      candidateTimestampEvidence(
+        tick({
+          auroraIdIsSyntheticJson: false,
+          updatedAtEpochSeconds: 90,
+          auroraSyncedAtEpochSeconds: 250,
+        }),
+      ),
+      'json_import_provenance_unverified',
+    );
+  });
+
+  void it('treats live Aurora timestamps as unverified after a local edit or without a sync stamp', () => {
+    assert.equal(
+      candidateTimestampEvidence(
+        tick({ origin: 'aurora_pull', updatedAtEpochSeconds: 90, auroraSyncedAtEpochSeconds: 90 }),
+      ),
+      'aurora_unchanged_since_sync',
+    );
+    assert.equal(
+      candidateTimestampEvidence(
+        tick({ origin: 'aurora_pull', updatedAtEpochSeconds: 91, auroraSyncedAtEpochSeconds: 90 }),
+      ),
+      'aurora_timestamp_edit_cannot_be_excluded',
+    );
+    assert.equal(
+      candidateTimestampEvidence(tick({ origin: 'aurora_pull', auroraSyncedAtEpochSeconds: null })),
+      'aurora_sync_stamp_missing',
+    );
+  });
+
+  void it('abstains inside the verified live rollout gap', () => {
+    assert.deepEqual(classifyCandidate(tick({ origin: 'aurora_pull', auroraSyncedAtEpochSeconds: 150 }), policy), {
+      role: 'uncertain',
+      cohort: 'aurora_rollout_uncertain',
+    });
+  });
+
+  void it('keeps Kilter and every native row in the ambiguity graph', () => {
+    assert.equal(isAnchorEligibleForAmbiguityGraph(anchor()), true);
+    assert.equal(isAnchorEligibleForAmbiguityGraph(anchor({ kilterDetachedAtEpochSeconds: 99 })), false);
+    assert.equal(
+      isAnchorEligibleForAmbiguityGraph(anchor({ origin: 'native', createdAtEpochSeconds: Number.MIN_SAFE_INTEGER })),
+      true,
+    );
+    assert.equal(isAnchorEligibleForAmbiguityGraph(anchor({ origin: 'native', createdAtEpochSeconds: 50 })), true);
+  });
+
+  void it('requires a post-boundary native anchor to retain its exact insert-time updated_at', () => {
+    const safeNative = anchor({
+      origin: 'native',
+      createdAtEpochSeconds: 60,
+      updatedAtEpochSeconds: 60,
+      createdAtEqualsUpdatedAt: true,
+    });
+    assert.equal(anchorTimestampEvidence(safeNative, policy), 'native_unchanged_since_verified_safe_save');
+    assert.equal(
+      anchorTimestampEvidence({ ...safeNative, updatedAtEpochSeconds: 61, createdAtEqualsUpdatedAt: false }, policy),
+      'native_timestamp_edit_cannot_be_excluded',
+    );
+    assert.equal(
+      anchorTimestampEvidence(
+        {
+          ...safeNative,
+          createdAtEpochSeconds: 59,
+          updatedAtEpochSeconds: 59,
+          createdAtEqualsUpdatedAt: true,
+        },
+        policy,
+      ),
+      'native_before_verified_safe_save',
+    );
+  });
+
+  void it('requires a Kilter anchor not to be newer than its source sync stamp', () => {
+    assert.equal(anchorTimestampEvidence(anchor(), policy), 'kilter_unchanged_since_sync');
+    assert.equal(
+      anchorTimestampEvidence(anchor({ updatedAtEpochSeconds: 51 }), policy),
+      'kilter_timestamp_edit_cannot_be_excluded',
+    );
+    assert.equal(
+      anchorTimestampEvidence(anchor({ kilterSyncedAtEpochSeconds: null }), policy),
+      'kilter_sync_stamp_missing',
+    );
+  });
+
+  void it('distinguishes deployment-proven writer stamps from migration-0156 heuristic Kilter origins', () => {
+    assert.equal(originEvidence(anchor({ createdAtEpochSeconds: 49 }), policy), 'legacy_origin_may_be_heuristic');
+    assert.equal(originEvidence(anchor({ createdAtEpochSeconds: 50 }), policy), 'writer_stamped');
+  });
+});
+
+void describe('complete bipartite ambiguity graph', () => {
+  void it('subtracts the inferred offset while preserving source seconds and reporting residual separately', () => {
+    const analysis = analyzeTickGroup(
+      [tick({ climbedAtEpochSeconds: 20 * HOUR + 17 }), anchor({ climbedAtEpochSeconds: 10 * HOUR })],
+      policy,
+    );
+    const [result] = analysis.candidates;
+    assert.equal(result.classification, 'correction_evidence');
+    assert.equal(result.edge?.offsetSeconds, 10 * HOUR);
+    assert.equal(result.edge?.residualSeconds, 17);
+    assert.equal(result.edge?.targetEpochSeconds, 10 * HOUR + 17);
+  });
+
+  void it('abstains both candidates when two candidates share one anchor', () => {
+    const analysis = analyzeTickGroup(
+      [
+        tick({ id: '1', uuid: 'candidate-a', climbedAtEpochSeconds: 20 * HOUR }),
+        tick({ id: '2', uuid: 'candidate-b', climbedAtEpochSeconds: 20 * HOUR + 1 }),
+        anchor({ id: '3', uuid: 'anchor' }),
+      ],
+      policy,
+    );
+    assert.equal(analysis.edgeCount, 2);
+    assert.deepEqual(
+      analysis.candidates.map(({ classification }) => classification),
+      ['ambiguous_abstention', 'ambiguous_abstention'],
+    );
+  });
+
+  void it('abstains when one candidate can match two anchors', () => {
+    const analysis = analyzeTickGroup(
+      [
+        tick(),
+        anchor({ id: '2', uuid: 'anchor-a', climbedAtEpochSeconds: 10 * HOUR }),
+        anchor({ id: '3', uuid: 'anchor-b', climbedAtEpochSeconds: 10 * HOUR + 1 }),
+      ],
+      policy,
+    );
+    assert.equal(analysis.edgeCount, 2);
+    assert.equal(analysis.candidates[0].candidateDegree, 2);
+    assert.equal(analysis.candidates[0].classification, 'ambiguous_abstention');
+  });
+
+  void it('builds the graph before rollout filtering, so an uncertain competitor keeps the anchor ambiguous', () => {
+    const analysis = analyzeTickGroup(
+      [
+        tick({ id: '1', uuid: 'suspect' }),
+        tick({
+          id: '2',
+          uuid: 'uncertain',
+          origin: 'aurora_pull',
+          auroraSyncedAtEpochSeconds: 150,
+        }),
+        anchor({ id: '3', uuid: 'anchor' }),
+      ],
+      policy,
+    );
+    const suspect = analysis.candidates.find(({ candidate }) => candidate.uuid === 'suspect');
+    const uncertain = analysis.candidates.find(({ candidate }) => candidate.uuid === 'uncertain');
+    assert.equal(suspect?.classification, 'ambiguous_abstention');
+    assert.equal(uncertain?.classification, 'rollout_uncertain_abstention');
+  });
+
+  void it('does not pair attempts with ascents or tolerate attempt-count/mirror differences', () => {
+    for (const incompatible of [
+      anchor({ status: 'attempt' }),
+      anchor({ attemptCount: 3 }),
+      anchor({ isMirror: true }),
+    ]) {
+      const analysis = analyzeTickGroup([tick(), incompatible], policy);
+      assert.equal(analysis.edgeCount, 0);
+      assert.equal(analysis.candidates[0].classification, 'no_anchor_abstention');
+    }
+  });
+
+  void it('flags a reciprocal nonzero post-fix control as an invariant violation', () => {
+    const analysis = analyzeTickGroup(
+      [
+        tick({
+          origin: 'aurora_pull',
+          auroraSyncedAtEpochSeconds: 250,
+          climbedAtEpochSeconds: 20 * HOUR,
+        }),
+        anchor(),
+      ],
+      policy,
+    );
+    assert.equal(analysis.candidates[0].classification, 'post_fix_invariant_violation');
+  });
+
+  void it('keeps an edited pre-fix Aurora candidate in the graph but never proposes from it', () => {
+    const analysis = analyzeTickGroup(
+      [
+        tick({
+          origin: 'aurora_pull',
+          auroraSyncedAtEpochSeconds: 90,
+          updatedAtEpochSeconds: 91,
+        }),
+        anchor(),
+      ],
+      policy,
+    );
+    assert.equal(analysis.edgeCount, 1);
+    assert.equal(analysis.candidates[0].reciprocal, true);
+    assert.equal(analysis.candidates[0].candidateClass.cohort, 'aurora_pre_fix');
+    assert.equal(analysis.candidates[0].classification, 'candidate_timestamp_unverified_abstention');
+  });
+
+  void it('still allows an unedited pre-fix Aurora candidate to support a proposal', () => {
+    const analysis = analyzeTickGroup(
+      [
+        tick({
+          origin: 'aurora_pull',
+          auroraSyncedAtEpochSeconds: 90,
+          updatedAtEpochSeconds: 90,
+        }),
+        anchor(),
+      ],
+      policy,
+    );
+    assert.equal(analysis.candidates[0].candidateClass.cohort, 'aurora_pre_fix');
+    assert.equal(analysis.candidates[0].classification, 'correction_evidence');
+  });
+
+  void it('never lets an edited post-fix Aurora candidate create an invariant violation', () => {
+    const analysis = analyzeTickGroup(
+      [
+        tick({
+          origin: 'aurora_pull',
+          auroraSyncedAtEpochSeconds: 250,
+          updatedAtEpochSeconds: 251,
+        }),
+        anchor(),
+      ],
+      policy,
+    );
+    assert.equal(analysis.edgeCount, 1);
+    assert.equal(analysis.candidates[0].candidateClass.cohort, 'aurora_post_fix_control');
+    assert.equal(analysis.candidates[0].classification, 'candidate_timestamp_unverified_abstention');
+  });
+
+  void it('never counts an edited Aurora candidate as an aligned control', () => {
+    const analysis = analyzeTickGroup(
+      [
+        tick({
+          origin: 'aurora_pull',
+          climbedAtEpochSeconds: 10 * HOUR,
+          auroraSyncedAtEpochSeconds: 250,
+          updatedAtEpochSeconds: 251,
+        }),
+        anchor(),
+      ],
+      policy,
+    );
+    assert.equal(analysis.candidates[0].classification, 'candidate_timestamp_unverified_abstention');
+  });
+
+  void it('keeps an Aurora candidate without a sync stamp in the graph but rollout-abstains', () => {
+    const analysis = analyzeTickGroup(
+      [tick({ origin: 'aurora_pull', auroraSyncedAtEpochSeconds: null }), anchor()],
+      policy,
+    );
+    assert.equal(analysis.edgeCount, 1);
+    assert.equal(analysis.candidates[0].candidateDegree, 1);
+    assert.equal(analysis.candidates[0].classification, 'rollout_uncertain_abstention');
+  });
+
+  void it('lets an edited Aurora candidate make a clean candidate-to-anchor match ambiguous', () => {
+    const analysis = analyzeTickGroup(
+      [
+        tick({ id: 'valid', uuid: 'valid' }),
+        tick({
+          id: 'edited',
+          uuid: 'edited',
+          origin: 'aurora_pull',
+          auroraSyncedAtEpochSeconds: 90,
+          updatedAtEpochSeconds: 91,
+        }),
+        anchor(),
+      ],
+      policy,
+    );
+    assert.equal(analysis.edgeCount, 2);
+    assert.ok(analysis.candidates.every(({ classification }) => classification === 'ambiguous_abstention'));
+  });
+
+  void it('keeps an edited synthetic JSON row in the graph but never proposes from it', () => {
+    const analysis = analyzeTickGroup(
+      [tick({ auroraSyncedAtEpochSeconds: 90, updatedAtEpochSeconds: 91, auroraIdIsSyntheticJson: true }), anchor()],
+      policy,
+    );
+    assert.equal(analysis.edgeCount, 1);
+    assert.equal(analysis.candidates[0].candidateClass.cohort, 'json_timing_unknown');
+    assert.equal(analysis.candidates[0].classification, 'candidate_timestamp_unverified_abstention');
+  });
+
+  void it('keeps a claimed JSON row in the graph but never treats its later claim stamp as edit proof', () => {
+    const analysis = analyzeTickGroup(
+      [
+        tick({
+          auroraIdIsSyntheticJson: false,
+          updatedAtEpochSeconds: 90,
+          auroraSyncedAtEpochSeconds: 250,
+        }),
+        anchor(),
+      ],
+      policy,
+    );
+    assert.equal(analysis.edgeCount, 1);
+    assert.equal(analysis.candidates[0].candidateClass.cohort, 'json_timing_unknown');
+    assert.equal(analysis.candidates[0].classification, 'candidate_timestamp_unverified_abstention');
+  });
+
+  void it('allows exact still-synthetic JSON import stamps to form a post-fix control', () => {
+    const analysis = analyzeTickGroup(
+      [tick({ updatedAtEpochSeconds: 250, auroraSyncedAtEpochSeconds: 250 }), anchor()],
+      policy,
+    );
+    assert.equal(analysis.candidates[0].candidateClass.cohort, 'json_post_fix_control');
+    assert.equal(analysis.candidates[0].classification, 'post_fix_invariant_violation');
+  });
+
+  void it('does not extrapolate an offset to another climb for the same user', () => {
+    const anchored = analyzeTickGroup([tick(), anchor()], policy);
+    const unanchored = analyzeTickGroup([tick({ climbUuid: 'another-climb' })], policy);
+    assert.equal(anchored.candidates[0].classification, 'correction_evidence');
+    assert.equal(unanchored.candidates[0].classification, 'no_anchor_abstention');
+  });
+
+  void it('keeps a heuristic Kilter anchor in the graph but abstains from an otherwise clean proposal', () => {
+    const analysis = analyzeTickGroup(
+      [tick(), anchor({ createdAtEpochSeconds: policy.originWritersActiveFromEpochSeconds - 1 })],
+      policy,
+    );
+    assert.equal(analysis.edgeCount, 1);
+    assert.equal(analysis.candidates[0].reciprocal, true);
+    assert.equal(analysis.candidates[0].classification, 'heuristic_only_anchor_abstention');
+  });
+
+  void it('lets a heuristic Kilter anchor keep a writer-stamped anchor ambiguous', () => {
+    const analysis = analyzeTickGroup(
+      [
+        tick(),
+        anchor({ id: 'writer', uuid: 'writer', createdAtEpochSeconds: policy.originWritersActiveFromEpochSeconds }),
+        anchor({
+          id: 'heuristic',
+          uuid: 'heuristic',
+          climbedAtEpochSeconds: 10 * HOUR + 1,
+          createdAtEpochSeconds: policy.originWritersActiveFromEpochSeconds - 1,
+        }),
+      ],
+      policy,
+    );
+    assert.equal(analysis.edgeCount, 2);
+    assert.equal(analysis.candidates[0].classification, 'ambiguous_abstention');
+  });
+
+  void it('keeps an edited Kilter anchor in the graph but never proposes from it', () => {
+    const analysis = analyzeTickGroup(
+      [tick(), anchor({ updatedAtEpochSeconds: 51, kilterSyncedAtEpochSeconds: 50 })],
+      policy,
+    );
+    assert.equal(analysis.edgeCount, 1);
+    assert.equal(analysis.candidates[0].reciprocal, true);
+    assert.equal(analysis.candidates[0].classification, 'kilter_timestamp_unverified_anchor_abstention');
+  });
+
+  void it('keeps a Kilter anchor without a sync stamp in the graph but never proposes from it', () => {
+    const analysis = analyzeTickGroup([tick(), anchor({ kilterSyncedAtEpochSeconds: null })], policy);
+    assert.equal(analysis.edgeCount, 1);
+    assert.equal(analysis.candidates[0].reciprocal, true);
+    assert.equal(analysis.candidates[0].classification, 'kilter_timestamp_unverified_anchor_abstention');
+  });
+
+  void it('never lets an edited Kilter anchor create a post-fix invariant violation', () => {
+    const analysis = analyzeTickGroup(
+      [
+        tick({
+          origin: 'aurora_pull',
+          auroraSyncedAtEpochSeconds: 250,
+          updatedAtEpochSeconds: 250,
+        }),
+        anchor({ updatedAtEpochSeconds: 51, kilterSyncedAtEpochSeconds: 50 }),
+      ],
+      policy,
+    );
+    assert.equal(analysis.candidates[0].classification, 'kilter_timestamp_unverified_anchor_abstention');
+  });
+
+  void it('never counts an edited Kilter anchor as an aligned control', () => {
+    const analysis = analyzeTickGroup(
+      [tick({ climbedAtEpochSeconds: 10 * HOUR }), anchor({ updatedAtEpochSeconds: 51 })],
+      policy,
+    );
+    assert.equal(analysis.candidates[0].classification, 'kilter_timestamp_unverified_anchor_abstention');
+  });
+
+  void it('lets an edited Kilter anchor keep a clean Kilter anchor ambiguous', () => {
+    const analysis = analyzeTickGroup(
+      [
+        tick(),
+        anchor({ id: 'clean-kilter', uuid: 'clean-kilter' }),
+        anchor({
+          id: 'edited-kilter',
+          uuid: 'edited-kilter',
+          climbedAtEpochSeconds: 10 * HOUR + 1,
+          updatedAtEpochSeconds: 51,
+          kilterSyncedAtEpochSeconds: 50,
+        }),
+      ],
+      policy,
+    );
+    assert.equal(analysis.edgeCount, 2);
+    assert.equal(analysis.candidates[0].classification, 'ambiguous_abstention');
+  });
+
+  void it('lets a matching pre-origin native row keep a strong Kilter anchor ambiguous', () => {
+    const analysis = analyzeTickGroup(
+      [
+        tick(),
+        anchor({ id: 'strong-kilter', uuid: 'strong-kilter' }),
+        anchor({
+          id: 'pre-origin-native',
+          uuid: 'pre-origin-native',
+          origin: 'native',
+          climbedAtEpochSeconds: 10 * HOUR + 1,
+          createdAtEpochSeconds: policy.originWritersActiveFromEpochSeconds - 1,
+          updatedAtEpochSeconds: policy.originWritersActiveFromEpochSeconds - 1,
+          createdAtEqualsUpdatedAt: true,
+        }),
+      ],
+      policy,
+    );
+    assert.equal(analysis.edgeCount, 2);
+    assert.equal(analysis.candidates[0].candidateDegree, 2);
+    assert.equal(analysis.candidates[0].classification, 'ambiguous_abstention');
+    assert.equal(
+      analysis.candidates.some(({ classification }) => classification === 'correction_evidence'),
+      false,
+    );
+  });
+
+  void it('never proposes from a reciprocal pre-origin native row', () => {
+    const boundary = policy.originWritersActiveFromEpochSeconds - 1;
+    const analysis = analyzeTickGroup(
+      [
+        tick(),
+        anchor({
+          origin: 'native',
+          createdAtEpochSeconds: boundary,
+          updatedAtEpochSeconds: boundary,
+          createdAtEqualsUpdatedAt: true,
+        }),
+      ],
+      policy,
+    );
+    assert.equal(analysis.edgeCount, 1);
+    assert.equal(analysis.candidates[0].classification, 'heuristic_only_anchor_abstention');
+  });
+
+  void it('does not let a heuristic Kilter anchor create a post-fix control violation', () => {
+    const analysis = analyzeTickGroup(
+      [
+        tick({ origin: 'aurora_pull', auroraSyncedAtEpochSeconds: 250 }),
+        anchor({ createdAtEpochSeconds: policy.originWritersActiveFromEpochSeconds - 1 }),
+      ],
+      policy,
+    );
+    assert.equal(analysis.candidates[0].classification, 'heuristic_only_anchor_abstention');
+  });
+
+  void it('allows only an unchanged post-boundary native anchor to support a proposal', () => {
+    const unchangedNative = anchor({
+      origin: 'native',
+      createdAtEpochSeconds: policy.nativeSafeGenerationActiveFromEpochSeconds,
+      updatedAtEpochSeconds: policy.nativeSafeGenerationActiveFromEpochSeconds,
+      createdAtEqualsUpdatedAt: true,
+    });
+    const analysis = analyzeTickGroup([tick(), unchangedNative], policy);
+    assert.equal(analysis.candidates[0].classification, 'correction_evidence');
+  });
+
+  void it('keeps an edited post-boundary native anchor in the graph but abstains', () => {
+    const editedNative = anchor({
+      origin: 'native',
+      createdAtEpochSeconds: policy.nativeSafeGenerationActiveFromEpochSeconds,
+      updatedAtEpochSeconds: policy.nativeSafeGenerationActiveFromEpochSeconds + 1,
+      createdAtEqualsUpdatedAt: false,
+    });
+    const analysis = analyzeTickGroup([tick(), editedNative], policy);
+    assert.equal(analysis.edgeCount, 1);
+    assert.equal(analysis.candidates[0].reciprocal, true);
+    assert.equal(analysis.candidates[0].classification, 'native_timestamp_unverified_anchor_abstention');
+  });
+
+  void it('lets an edited native anchor keep a clean Kilter anchor ambiguous', () => {
+    const analysis = analyzeTickGroup(
+      [
+        tick(),
+        anchor({ id: 'clean', uuid: 'clean' }),
+        anchor({
+          id: 'edited-native',
+          uuid: 'edited-native',
+          origin: 'native',
+          climbedAtEpochSeconds: 10 * HOUR + 1,
+          createdAtEpochSeconds: policy.nativeSafeGenerationActiveFromEpochSeconds,
+          updatedAtEpochSeconds: policy.nativeSafeGenerationActiveFromEpochSeconds + 1,
+          createdAtEqualsUpdatedAt: false,
+        }),
+      ],
+      policy,
+    );
+    assert.equal(analysis.edgeCount, 2);
+    assert.equal(analysis.candidates[0].classification, 'ambiguous_abstention');
+  });
+
+  void it('does not let an edited native anchor create a post-fix control violation', () => {
+    const analysis = analyzeTickGroup(
+      [
+        tick({ origin: 'aurora_pull', auroraSyncedAtEpochSeconds: 250 }),
+        anchor({
+          origin: 'native',
+          createdAtEpochSeconds: policy.nativeSafeGenerationActiveFromEpochSeconds,
+          updatedAtEpochSeconds: policy.nativeSafeGenerationActiveFromEpochSeconds + 1,
+          createdAtEqualsUpdatedAt: false,
+        }),
+      ],
+      policy,
+    );
+    assert.equal(analysis.candidates[0].classification, 'native_timestamp_unverified_anchor_abstention');
+  });
+
+  void it('does not count an edited native anchor as an aligned control', () => {
+    const nativeClimbedAt = 10 * HOUR;
+    const analysis = analyzeTickGroup(
+      [
+        tick({ climbedAtEpochSeconds: nativeClimbedAt }),
+        anchor({
+          origin: 'native',
+          climbedAtEpochSeconds: nativeClimbedAt,
+          createdAtEpochSeconds: policy.nativeSafeGenerationActiveFromEpochSeconds,
+          updatedAtEpochSeconds: policy.nativeSafeGenerationActiveFromEpochSeconds + 1,
+          createdAtEqualsUpdatedAt: false,
+        }),
+      ],
+      policy,
+    );
+    assert.equal(analysis.candidates[0].classification, 'native_timestamp_unverified_anchor_abstention');
+  });
+
+  void it('retains a pre-safe-save native anchor for ambiguity but never proposes from it', () => {
+    const analysis = analyzeTickGroup(
+      [
+        tick(),
+        anchor({
+          origin: 'native',
+          createdAtEpochSeconds: policy.nativeSafeGenerationActiveFromEpochSeconds - 1,
+          updatedAtEpochSeconds: policy.nativeSafeGenerationActiveFromEpochSeconds - 1,
+          createdAtEqualsUpdatedAt: true,
+        }),
+      ],
+      policy,
+    );
+    assert.equal(analysis.edgeCount, 1);
+    assert.equal(analysis.candidates[0].classification, 'native_timestamp_unverified_anchor_abstention');
+  });
+
+  void it('counts a dense ambiguity graph without retaining its quadratic edge set', () => {
+    const nodeCount = 300;
+    const candidates = Array.from({ length: nodeCount }, (_, index) =>
+      tick({ id: `candidate-${index}`, uuid: `candidate-${index}` }),
+    );
+    const anchors = Array.from({ length: nodeCount }, (_, index) =>
+      anchor({ id: `anchor-${index}`, uuid: `anchor-${index}` }),
+    );
+    const analysis = analyzeTickGroup([...candidates, ...anchors], policy);
+    assert.equal(analysis.edgeCount, nodeCount * nodeCount);
+    assert.equal('edges' in analysis, false);
+    assert.ok(
+      analysis.candidates.every(
+        (candidate) => candidate.candidateDegree === nodeCount && candidate.classification === 'ambiguous_abstention',
+      ),
+    );
+  });
+});
+
+void describe('artifact primitives', () => {
+  void it('canonicalizes object keys recursively', () => {
+    assert.equal(canonicalJson({ z: 1, a: { y: 2, b: 3 } }), '{"a":{"b":3,"y":2},"z":1}');
+  });
+
+  void it('rejects raw identifiers, comments, session ids, and DSNs', () => {
+    for (const unsafe of [
+      { userId: 'raw' },
+      { user_id: 'raw' },
+      { uuid: 'raw' },
+      { candidate_uuid: 'raw' },
+      { comment: 'beta' },
+      { sessionId: 'raw' },
+      { note: 'postgres://user:password@host/db' },
+    ]) {
+      assert.throws(() => assertPrivacySafeRecord(unsafe));
+    }
+    assert.doesNotThrow(() => assertPrivacySafeRecord({ user_key: 'pseudo', candidate_key: 'pseudo' }));
+  });
+
+  void it('redacts nonzero small aggregate cells', () => {
+    assert.equal(redactSmallCell(0), 0);
+    assert.equal(redactSmallCell(1), '<5');
+    assert.equal(redactSmallCell(4), '<5');
+    assert.equal(redactSmallCell(5), 5);
+  });
+
+  void it('keeps pseudonyms stable only within one run secret', () => {
+    const firstRunSecret = new Uint8Array(32).fill(1);
+    const secondRunSecret = new Uint8Array(32).fill(2);
+    const firstPseudonym = pseudonymize(firstRunSecret, 'tick', 'raw-tick-id');
+    assert.equal(pseudonymize(firstRunSecret, 'tick', 'raw-tick-id'), firstPseudonym);
+    assert.notEqual(pseudonymize(secondRunSecret, 'tick', 'raw-tick-id'), firstPseudonym);
+  });
+});

--- a/packages/db/scripts/legacy-timestamp-audit-core.test.ts
+++ b/packages/db/scripts/legacy-timestamp-audit-core.test.ts
@@ -741,6 +741,7 @@ void describe('artifact primitives', () => {
 
   void it('rejects raw identifiers, comments, session ids, and DSNs', () => {
     for (const unsafe of [
+      { id: 'raw' },
       { userId: 'raw' },
       { user_id: 'raw' },
       { uuid: 'raw' },

--- a/packages/db/scripts/legacy-timestamp-audit-core.ts
+++ b/packages/db/scripts/legacy-timestamp-audit-core.ts
@@ -1,0 +1,565 @@
+import { createHash, createHmac } from 'node:crypto';
+
+export const AUDIT_POLICY_VERSION = 'legacy-timestamp-audit/v1' as const;
+export const RESIDUAL_TOLERANCE_SECONDS = 60;
+export const SMALL_CELL_THRESHOLD = 5;
+
+// Current civil UTC offsets represented by the IANA timezone database. This is
+// intentionally an explicit allowlist, not "any multiple of 15 minutes": most
+// quarter-hour values are not real zones. It includes the current quarter-hour
+// zones (Eucla, Nepal and the Chatham Islands) and the -12:00/+14:00 bounds.
+export const ALLOWED_IANA_UTC_OFFSET_SECONDS = [
+  -12 * 3600,
+  -11 * 3600,
+  -10 * 3600,
+  -(9 * 3600 + 30 * 60),
+  -9 * 3600,
+  -8 * 3600,
+  -7 * 3600,
+  -6 * 3600,
+  -5 * 3600,
+  -4 * 3600,
+  -(3 * 3600 + 30 * 60),
+  -3 * 3600,
+  -(2 * 3600 + 30 * 60),
+  -2 * 3600,
+  -1 * 3600,
+  0,
+  1 * 3600,
+  2 * 3600,
+  3 * 3600,
+  3 * 3600 + 30 * 60,
+  4 * 3600,
+  4 * 3600 + 30 * 60,
+  5 * 3600,
+  5 * 3600 + 30 * 60,
+  5 * 3600 + 45 * 60,
+  6 * 3600,
+  6 * 3600 + 30 * 60,
+  7 * 3600,
+  8 * 3600,
+  8 * 3600 + 45 * 60,
+  9 * 3600,
+  9 * 3600 + 30 * 60,
+  10 * 3600,
+  10 * 3600 + 30 * 60,
+  11 * 3600,
+  12 * 3600,
+  12 * 3600 + 45 * 60,
+  13 * 3600,
+  13 * 3600 + 45 * 60,
+  14 * 3600,
+] as const;
+
+export type TickOrigin = 'native' | 'aurora_pull' | 'kilter_pull' | 'json_import';
+export type TickStatus = 'flash' | 'send' | 'attempt';
+
+export type AuditPolicy = {
+  policyId: string;
+  liveOldCodeActiveThroughEpochSeconds: number;
+  liveFixedCodeActiveFromEpochSeconds: number;
+  jsonOldCodeActiveThroughEpochSeconds: number;
+  jsonFixedCodeActiveFromEpochSeconds: number;
+  originWritersActiveFromEpochSeconds: number;
+  nativeSafeGenerationActiveFromEpochSeconds: number;
+};
+
+/** Private scan row. Raw identifiers must never cross the output mapper. */
+export type AuditTick = {
+  id: string;
+  uuid: string;
+  userId: string;
+  boardType: string;
+  climbUuid: string;
+  angle: number;
+  isMirror: boolean;
+  origin: TickOrigin;
+  status: TickStatus;
+  attemptCount: number;
+  climbedAtEpochSeconds: number;
+  createdAtEpochSeconds: number;
+  updatedAtEpochSeconds: number;
+  createdAtEqualsUpdatedAt: boolean;
+  auroraSyncedAtEpochSeconds: number | null;
+  auroraIdIsSyntheticJson: boolean;
+  kilterSyncedAtEpochSeconds: number | null;
+  kilterDetachedAtEpochSeconds: number | null;
+};
+
+export type CandidateCohort =
+  | 'json_timing_unknown'
+  | 'json_pre_fix'
+  | 'json_rollout_uncertain'
+  | 'aurora_pre_fix'
+  | 'aurora_rollout_uncertain'
+  | 'aurora_post_fix_control'
+  | 'json_post_fix_control';
+
+export type CandidateRole = 'suspect' | 'post_fix_control' | 'uncertain';
+
+export type CandidateClassification = {
+  role: CandidateRole;
+  cohort: CandidateCohort;
+};
+
+export type OriginEvidence = 'writer_stamped' | 'legacy_origin_may_be_heuristic';
+
+export type CandidateTimestampEvidence =
+  | 'aurora_unchanged_since_sync'
+  | 'aurora_sync_stamp_missing'
+  | 'aurora_timestamp_edit_cannot_be_excluded'
+  | 'json_synthetic_import_owned_timestamps'
+  | 'json_import_provenance_unverified';
+
+export type AnchorTimestampEvidence =
+  | 'kilter_unchanged_since_sync'
+  | 'kilter_sync_stamp_missing'
+  | 'kilter_timestamp_edit_cannot_be_excluded'
+  | 'native_unchanged_since_verified_safe_save'
+  | 'native_before_verified_safe_save'
+  | 'native_timestamp_edit_cannot_be_excluded';
+
+export type OffsetMatch = {
+  offsetSeconds: number;
+  residualSeconds: number;
+  targetEpochSeconds: number;
+};
+
+export type OffsetInference = Omit<OffsetMatch, 'targetEpochSeconds'>;
+
+export type MatchEdge = OffsetMatch & {
+  candidateIndex: number;
+  anchorIndex: number;
+};
+
+export type CandidateGraphResult = {
+  candidate: AuditTick;
+  candidateClass: CandidateClassification;
+  candidateDegree: number;
+  edge: MatchEdge | null;
+  reciprocal: boolean;
+  classification:
+    | 'correction_evidence'
+    | 'aligned_control'
+    | 'post_fix_invariant_violation'
+    | 'ambiguous_abstention'
+    | 'heuristic_only_anchor_abstention'
+    | 'candidate_timestamp_unverified_abstention'
+    | 'kilter_timestamp_unverified_anchor_abstention'
+    | 'native_timestamp_unverified_anchor_abstention'
+    | 'no_anchor_abstention'
+    | 'rollout_uncertain_abstention';
+};
+
+export type GroupAnalysis = {
+  candidates: CandidateGraphResult[];
+  anchors: AuditTick[];
+  edgeCount: number;
+};
+
+function hasExactSyntheticJsonImportProvenance(tick: AuditTick): boolean {
+  return (
+    tick.origin === 'json_import' &&
+    tick.auroraIdIsSyntheticJson &&
+    tick.auroraSyncedAtEpochSeconds !== null &&
+    tick.updatedAtEpochSeconds === tick.auroraSyncedAtEpochSeconds
+  );
+}
+
+export function classifyCandidate(tick: AuditTick, policy: AuditPolicy): CandidateClassification | null {
+  if (tick.origin === 'json_import') {
+    // created_at is Aurora export content, not the import execution time. A
+    // claimed JSON row also carries a real aurora_id and a later sync stamp
+    // while keeping the original bad climbed_at. Only a still-synthetic row
+    // whose import-owned updated/synced stamps agree can enter a verified JSON
+    // deployment cohort; every other JSON row stays timing-unknown.
+    const hasImportOwnedExecutionStamp = hasExactSyntheticJsonImportProvenance(tick);
+    if (!hasImportOwnedExecutionStamp || tick.auroraSyncedAtEpochSeconds === null) {
+      return { role: 'suspect', cohort: 'json_timing_unknown' };
+    }
+    if (tick.auroraSyncedAtEpochSeconds <= policy.jsonOldCodeActiveThroughEpochSeconds) {
+      return { role: 'suspect', cohort: 'json_pre_fix' };
+    }
+    if (tick.auroraSyncedAtEpochSeconds >= policy.jsonFixedCodeActiveFromEpochSeconds) {
+      return { role: 'post_fix_control', cohort: 'json_post_fix_control' };
+    }
+    return { role: 'uncertain', cohort: 'json_rollout_uncertain' };
+  }
+
+  if (tick.origin !== 'aurora_pull') return null;
+  if (
+    tick.auroraSyncedAtEpochSeconds !== null &&
+    tick.auroraSyncedAtEpochSeconds <= policy.liveOldCodeActiveThroughEpochSeconds
+  ) {
+    return { role: 'suspect', cohort: 'aurora_pre_fix' };
+  }
+  if (
+    tick.auroraSyncedAtEpochSeconds !== null &&
+    tick.auroraSyncedAtEpochSeconds >= policy.liveFixedCodeActiveFromEpochSeconds
+  ) {
+    return { role: 'post_fix_control', cohort: 'aurora_post_fix_control' };
+  }
+  return { role: 'uncertain', cohort: 'aurora_rollout_uncertain' };
+}
+
+/**
+ * Prove that a candidate's stored climbed_at still represents its source
+ * timestamp. Rows failing this check remain graph vertices, but cannot support
+ * a correction, aligned control, or post-fix invariant result.
+ */
+export function candidateTimestampEvidence(tick: AuditTick): CandidateTimestampEvidence {
+  if (tick.origin === 'json_import') {
+    return hasExactSyntheticJsonImportProvenance(tick)
+      ? 'json_synthetic_import_owned_timestamps'
+      : 'json_import_provenance_unverified';
+  }
+  if (tick.origin !== 'aurora_pull') {
+    throw new Error(`Candidate timestamp evidence requested for non-candidate origin: ${tick.origin}`);
+  }
+  if (tick.auroraSyncedAtEpochSeconds === null) return 'aurora_sync_stamp_missing';
+  if (tick.updatedAtEpochSeconds > tick.auroraSyncedAtEpochSeconds) {
+    return 'aurora_timestamp_edit_cannot_be_excluded';
+  }
+  return 'aurora_unchanged_since_sync';
+}
+
+function candidateTimestampIsEligible(tick: AuditTick): boolean {
+  const evidence = candidateTimestampEvidence(tick);
+  return evidence === 'aurora_unchanged_since_sync' || evidence === 'json_synthetic_import_owned_timestamps';
+}
+
+/**
+ * Keep every plausible anchor in the graph so a migration-0156 heuristic row,
+ * including any historical native row, can still make an otherwise-clean
+ * match ambiguous. Eligibility for the graph does not by itself make an anchor
+ * strong enough to support a proposal.
+ */
+export function isAnchorEligibleForAmbiguityGraph(tick: AuditTick): boolean {
+  if (tick.origin === 'kilter_pull') return tick.kilterDetachedAtEpochSeconds === null;
+  return tick.origin === 'native';
+}
+
+export function originEvidence(tick: AuditTick, policy: AuditPolicy): OriginEvidence {
+  // JSON created_at is never consulted here: it is export data. For native and
+  // Kilter rows created_at is generated by their writer. Migration 0156 did
+  // not persist whether a Kilter origin was backfilled, so created_at is useful
+  // only after an independently verified instant when 0156 had completed and
+  // every active writer stamped origin itself. Without that deployment proof,
+  // a historical Kilter origin remains heuristic and can only add ambiguity.
+  if (tick.origin !== 'json_import' && tick.createdAtEpochSeconds >= policy.originWritersActiveFromEpochSeconds) {
+    return 'writer_stamped';
+  }
+  return 'legacy_origin_may_be_heuristic';
+}
+
+export function anchorTimestampEvidence(tick: AuditTick, policy: AuditPolicy): AnchorTimestampEvidence {
+  if (tick.origin === 'kilter_pull') {
+    if (tick.kilterSyncedAtEpochSeconds === null) return 'kilter_sync_stamp_missing';
+    if (tick.updatedAtEpochSeconds > tick.kilterSyncedAtEpochSeconds) {
+      return 'kilter_timestamp_edit_cannot_be_excluded';
+    }
+    return 'kilter_unchanged_since_sync';
+  }
+  if (tick.origin !== 'native') {
+    throw new Error(`Anchor timestamp evidence requested for non-anchor origin: ${tick.origin}`);
+  }
+  if (tick.createdAtEpochSeconds < policy.nativeSafeGenerationActiveFromEpochSeconds) {
+    return 'native_before_verified_safe_save';
+  }
+  if (!tick.createdAtEqualsUpdatedAt) return 'native_timestamp_edit_cannot_be_excluded';
+  return 'native_unchanged_since_verified_safe_save';
+}
+
+export function inferAllowedOffset(rawDeltaSeconds: number): OffsetInference | null {
+  if (!Number.isFinite(rawDeltaSeconds)) return null;
+  let bestOffset: number | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  let tied = false;
+
+  for (const offsetSeconds of ALLOWED_IANA_UTC_OFFSET_SECONDS) {
+    const distance = Math.abs(rawDeltaSeconds - offsetSeconds);
+    if (distance < bestDistance) {
+      bestOffset = offsetSeconds;
+      bestDistance = distance;
+      tied = false;
+    } else if (distance === bestDistance) {
+      tied = true;
+    }
+  }
+
+  if (bestOffset === null || tied || bestDistance > RESIDUAL_TOLERANCE_SECONDS) return null;
+  return {
+    offsetSeconds: bestOffset,
+    residualSeconds: rawDeltaSeconds - bestOffset,
+  };
+}
+
+function ascentSemantics(status: TickStatus): 'attempt' | 'ascent' {
+  return status === 'attempt' ? 'attempt' : 'ascent';
+}
+
+export function areSemanticsCompatible(candidate: AuditTick, anchor: AuditTick): boolean {
+  return (
+    ascentSemantics(candidate.status) === ascentSemantics(anchor.status) &&
+    candidate.attemptCount === anchor.attemptCount &&
+    candidate.isMirror === anchor.isMirror
+  );
+}
+
+function compareTickIdentity(first: AuditTick, second: AuditTick): number {
+  return (
+    first.climbedAtEpochSeconds - second.climbedAtEpochSeconds ||
+    first.origin.localeCompare(second.origin) ||
+    first.id.localeCompare(second.id)
+  );
+}
+
+function semanticsKey(tick: AuditTick): string {
+  return `${ascentSemantics(tick.status)}\0${tick.attemptCount}\0${tick.isMirror ? '1' : '0'}`;
+}
+
+function lowerBoundByClimbedAt(
+  rows: Array<{ anchor: AuditTick; anchorIndex: number }>,
+  targetEpochSeconds: number,
+): number {
+  let low = 0;
+  let high = rows.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if (rows[middle].anchor.climbedAtEpochSeconds < targetEpochSeconds) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
+/**
+ * Analyze the complete candidate↔anchor graph for one exact
+ * (user, board, climb, angle) key before deciding which edges are usable.
+ * Degrees are counted as edges stream past; only a candidate's sole edge is
+ * retained. This preserves reciprocal/ambiguity decisions without materializing
+ * a potentially quadratic edge array.
+ */
+export function analyzeTickGroup(rows: AuditTick[], policy: AuditPolicy): GroupAnalysis {
+  const candidates = rows
+    .map((candidate) => ({ candidate, candidateClass: classifyCandidate(candidate, policy) }))
+    .filter(
+      (entry): entry is { candidate: AuditTick; candidateClass: CandidateClassification } =>
+        entry.candidateClass !== null,
+    )
+    .sort((first, second) => compareTickIdentity(first.candidate, second.candidate));
+  const anchors = rows.filter(isAnchorEligibleForAmbiguityGraph).sort(compareTickIdentity);
+  const candidateDegrees = Array.from({ length: candidates.length }, () => 0);
+  const anchorDegrees = Array.from({ length: anchors.length }, () => 0);
+  const soleCandidateEdges = Array<MatchEdge | null>(candidates.length).fill(null);
+  let edgeCount = 0;
+
+  const anchorsBySemantics = new Map<string, Array<{ anchor: AuditTick; anchorIndex: number }>>();
+  anchors.forEach((anchor, anchorIndex) => {
+    const key = semanticsKey(anchor);
+    const existing = anchorsBySemantics.get(key);
+    if (existing) existing.push({ anchor, anchorIndex });
+    else anchorsBySemantics.set(key, [{ anchor, anchorIndex }]);
+  });
+
+  for (let candidateIndex = 0; candidateIndex < candidates.length; candidateIndex += 1) {
+    const candidate = candidates[candidateIndex].candidate;
+    const compatibleAnchors = anchorsBySemantics.get(semanticsKey(candidate)) ?? [];
+    for (const offsetSeconds of ALLOWED_IANA_UTC_OFFSET_SECONDS) {
+      const expectedAnchorEpochSeconds = candidate.climbedAtEpochSeconds - offsetSeconds;
+      let compatibleIndex = lowerBoundByClimbedAt(
+        compatibleAnchors,
+        expectedAnchorEpochSeconds - RESIDUAL_TOLERANCE_SECONDS,
+      );
+      while (
+        compatibleIndex < compatibleAnchors.length &&
+        compatibleAnchors[compatibleIndex].anchor.climbedAtEpochSeconds <=
+          expectedAnchorEpochSeconds + RESIDUAL_TOLERANCE_SECONDS
+      ) {
+        const { anchor, anchorIndex } = compatibleAnchors[compatibleIndex];
+        if (candidate.uuid !== anchor.uuid && areSemanticsCompatible(candidate, anchor)) {
+          const rawDeltaSeconds = candidate.climbedAtEpochSeconds - anchor.climbedAtEpochSeconds;
+          const inferred = inferAllowedOffset(rawDeltaSeconds);
+          // The closest-allowlisted-offset check prevents overlapping windows
+          // from emitting the same pair twice.
+          if (inferred?.offsetSeconds === offsetSeconds) {
+            const edge: MatchEdge = {
+              candidateIndex,
+              anchorIndex,
+              offsetSeconds,
+              residualSeconds: inferred.residualSeconds,
+              // Subtract only the civil offset. Do not snap to the anchor:
+              // source seconds remain visible in the target and residual.
+              targetEpochSeconds: candidate.climbedAtEpochSeconds - offsetSeconds,
+            };
+            edgeCount += 1;
+            candidateDegrees[candidateIndex] += 1;
+            anchorDegrees[anchorIndex] += 1;
+            soleCandidateEdges[candidateIndex] = candidateDegrees[candidateIndex] === 1 ? edge : null;
+          }
+        }
+        compatibleIndex += 1;
+      }
+    }
+  }
+
+  const results: CandidateGraphResult[] = candidates.map(({ candidate, candidateClass }, candidateIndex) => {
+    if (candidateClass.role === 'uncertain') {
+      return {
+        candidate,
+        candidateClass,
+        candidateDegree: candidateDegrees[candidateIndex],
+        edge: null,
+        reciprocal: false,
+        classification: 'rollout_uncertain_abstention',
+      };
+    }
+    const candidateDegree = candidateDegrees[candidateIndex];
+    const onlyEdge = candidateDegree === 1 ? soleCandidateEdges[candidateIndex] : null;
+    const reciprocal = onlyEdge !== null && anchorDegrees[onlyEdge.anchorIndex] === 1;
+    if (!onlyEdge) {
+      return {
+        candidate,
+        candidateClass,
+        candidateDegree,
+        edge: null,
+        reciprocal: false,
+        classification: candidateDegree === 0 ? 'no_anchor_abstention' : 'ambiguous_abstention',
+      };
+    }
+    if (!reciprocal) {
+      return {
+        candidate,
+        candidateClass,
+        candidateDegree: 1,
+        edge: onlyEdge,
+        reciprocal: false,
+        classification: 'ambiguous_abstention',
+      };
+    }
+    const anchor = anchors[onlyEdge.anchorIndex];
+    if (originEvidence(anchor, policy) !== 'writer_stamped') {
+      return {
+        candidate,
+        candidateClass,
+        candidateDegree: 1,
+        edge: onlyEdge,
+        reciprocal: true,
+        classification: 'heuristic_only_anchor_abstention',
+      };
+    }
+    if (
+      anchor.origin === 'native' &&
+      anchorTimestampEvidence(anchor, policy) !== 'native_unchanged_since_verified_safe_save'
+    ) {
+      return {
+        candidate,
+        candidateClass,
+        candidateDegree: 1,
+        edge: onlyEdge,
+        reciprocal: true,
+        classification: 'native_timestamp_unverified_anchor_abstention',
+      };
+    }
+    if (anchor.origin === 'kilter_pull' && anchorTimestampEvidence(anchor, policy) !== 'kilter_unchanged_since_sync') {
+      return {
+        candidate,
+        candidateClass,
+        candidateDegree: 1,
+        edge: onlyEdge,
+        reciprocal: true,
+        classification: 'kilter_timestamp_unverified_anchor_abstention',
+      };
+    }
+    if (!candidateTimestampIsEligible(candidate)) {
+      return {
+        candidate,
+        candidateClass,
+        candidateDegree: 1,
+        edge: onlyEdge,
+        reciprocal: true,
+        classification: 'candidate_timestamp_unverified_abstention',
+      };
+    }
+    if (onlyEdge.offsetSeconds === 0) {
+      return {
+        candidate,
+        candidateClass,
+        candidateDegree: 1,
+        edge: onlyEdge,
+        reciprocal: true,
+        classification: 'aligned_control',
+      };
+    }
+    return {
+      candidate,
+      candidateClass,
+      candidateDegree: 1,
+      edge: onlyEdge,
+      reciprocal: true,
+      classification:
+        candidateClass.role === 'post_fix_control' ? 'post_fix_invariant_violation' : 'correction_evidence',
+    };
+  });
+
+  return { candidates: results, anchors, edgeCount };
+}
+
+export function groupKey(tick: AuditTick): string {
+  return `${tick.userId}\0${tick.boardType}\0${tick.angle}\0${tick.climbUuid}`;
+}
+
+export function pseudonymize(secret: Uint8Array, namespace: string, rawIdentifier: string): string {
+  return createHmac('sha256', secret).update(namespace).update('\0').update(rawIdentifier).digest('hex').slice(0, 24);
+}
+
+export function epochSecondsToIso(epochSeconds: number): string {
+  if (!Number.isFinite(epochSeconds)) throw new Error('Cannot render a non-finite epoch value');
+  return new Date(epochSeconds * 1000).toISOString();
+}
+
+export function redactSmallCell(count: number): number | '<5' {
+  return count > 0 && count < SMALL_CELL_THRESHOLD ? '<5' : count;
+}
+
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+    .join(',')}}`;
+}
+
+const FORBIDDEN_OUTPUT_KEYS = new Set([
+  'userid',
+  'rawuserid',
+  'comment',
+  'comments',
+  'sessionid',
+  'dsn',
+  'databaseurl',
+]);
+const DSN_PATTERN = /(?:postgres(?:ql)?:\/\/|password\s*=)/i;
+
+export function assertPrivacySafeRecord(value: unknown, path = '$'): void {
+  if (typeof value === 'string' && DSN_PATTERN.test(value)) {
+    throw new Error(`Audit output contains a database credential/DSN at ${path}`);
+  }
+  if (value === null || typeof value !== 'object') return;
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertPrivacySafeRecord(item, `${path}[${index}]`));
+    return;
+  }
+  for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    const normalizedKey = key.toLowerCase().replace(/[^a-z0-9]/g, '');
+    if (FORBIDDEN_OUTPUT_KEYS.has(normalizedKey) || normalizedKey.endsWith('uuid')) {
+      throw new Error(`Audit output contains forbidden raw field ${path}.${key}`);
+    }
+    assertPrivacySafeRecord(nested, `${path}.${key}`);
+  }
+}
+
+export function sha256Hex(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}

--- a/packages/db/scripts/legacy-timestamp-audit-core.ts
+++ b/packages/db/scripts/legacy-timestamp-audit-core.ts
@@ -532,6 +532,7 @@ export function canonicalJson(value: unknown): string {
 }
 
 const FORBIDDEN_OUTPUT_KEYS = new Set([
+  'id',
   'userid',
   'rawuserid',
   'comment',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -247,6 +247,13 @@ export default defineConfig({
         // flags with `vp run db:dedupe-beta-links -- --apply`.
         cache: false,
       },
+      'db:audit-legacy-timestamps': {
+        command: 'bun run --filter=@boardsesh/db db:audit-legacy-timestamps',
+        // Audit-only and intentionally detached from db:up: operators may aim
+        // it at a read replica. The command itself verifies SERIALIZABLE READ
+        // ONLY DEFERRABLE + UTC before it reads a row and has no apply mode.
+        cache: false,
+      },
       'db:refresh-climb-grades': {
         command: 'pnpm --filter @boardsesh/db run db:refresh-climb-grades',
         // No db:up dependency: this often targets a remote DB_URL and supports

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -249,9 +249,7 @@ export default defineConfig({
       },
       'db:audit-legacy-timestamps': {
         command: 'bun run --filter=@boardsesh/db db:audit-legacy-timestamps',
-        // Audit-only and intentionally detached from db:up: operators may aim
-        // it at a read replica. The command itself verifies SERIALIZABLE READ
-        // ONLY DEFERRABLE + UTC before it reads a row and has no apply mode.
+        // No db:up: this read-only audit may target a replica and verifies transaction safety itself.
         cache: false,
       },
       'db:refresh-climb-grades': {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -249,7 +249,12 @@ export default defineConfig({
       },
       'db:audit-legacy-timestamps': {
         command: 'bun run --filter=@boardsesh/db db:audit-legacy-timestamps',
-        // No db:up: this read-only audit may target a replica and verifies transaction safety itself.
+        // No db:up: a maintainer points this read-only audit at DB_URL by hand
+        // (usually a remote database), and it verifies its own transaction
+        // safety. It must target the primary, not a hot standby: its
+        // SERIALIZABLE READ ONLY DEFERRABLE snapshot is rejected there
+        // ("cannot use serializable mode in a hot standby"). Replicas are only
+        // for the plain-EXPLAIN plan review in docs/legacy-timestamp-audit.md.
         cache: false,
       },
       'db:refresh-climb-grades': {
@@ -307,6 +312,15 @@ export default defineConfig({
       'test:postgres18-dev-db-image': {
         command: 'bash scripts/dev-db-image-smoke.sh',
         cache: false,
+      },
+      // The legacy-timestamp audit's two unit suites, also run from ci.yml's
+      // db-migrations job. They need no database and no db:up. Scoped rather
+      // than the whole `test:db` suite because packages/db has never run in CI
+      // and three create-climb-filters MoonBoard assertions are already failing
+      // on main (float formatting: `16.92` vs `16.919999999999998`); widening
+      // this to `test:db` has to come with fixing those first.
+      'test:db:legacy-timestamp-audit': {
+        command: 'bun run --filter=@boardsesh/db test:legacy-timestamp-audit',
       },
       'locations:aurora': {
         command: 'pnpm --filter @boardsesh/aurora-sync run sync:locations',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -317,8 +317,8 @@ export default defineConfig({
       // db-migrations job. They need no database and no db:up. Scoped rather
       // than the whole `test:db` suite because packages/db has never run in CI
       // and three create-climb-filters MoonBoard assertions are already failing
-      // on main (float formatting: `16.92` vs `16.919999999999998`); widening
-      // this to `test:db` has to come with fixing those first.
+      // on main (float formatting: `16.92` vs `16.919999999999998`, tracked in
+      // #4049); widening this to `test:db` has to come with fixing those first.
       'test:db:legacy-timestamp-audit': {
         command: 'bun run --filter=@boardsesh/db test:legacy-timestamp-audit',
       },


### PR DESCRIPTION
## Summary

- Add a read-only, fail-closed audit for legacy timestamp-offset corruption.
- Require verified deployment windows and provenance-safe Aurora, JSON, Kilter, and native evidence before proposing a correction.
- Keep every plausible row in the ambiguity graph while preventing edited or claimed rows from acting as proof.
- Emit a bounded, privacy-preserving, checksummed JSONL artifact with no apply path.
- Document the audit policy, output contract, review steps, and future approval gates.

Refs #3909. This audit-only PR intentionally leaves the issue open; production access and any repair require separate approval.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- Audit CLI/core suite: 77 passed, 1 explicitly local-PostgreSQL integration test skipped
- New CI step runs those two suites (`vp run test:db:legacy-timestamp-audit`) from the `db-migrations` job — `packages/db` is a `node:test` package and never reached `test-default`'s vitest project list
- Output-safety fixtures re-verified under a symlinked `TMPDIR` (the macOS `/var` → `/private/var` case): 10 failures before the `realpath()` fix, 0 after
- `vp run typecheck:db`
- Full `vp run typecheck`
- Scoped `vp check` and `git diff --check`
- CLI help through `vp node --import tsx ... -- --help`
- Independent adversarial review: PASS
- No database, production, Docker, or dev-server access; `.boardsesh/qa-notes.md` records that this phase has no user-facing runtime flow
