### PR TITLE
fix(mobile): migrate ios keychain items to an after-first-unlock namespace

### DIFF
--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -93,6 +93,7 @@ import { BoardOpenRecorder } from '../src/components/board-activity/BoardOpenRec
 import { OtaUpdateTracker } from '../src/components/analytics/OtaUpdateTracker';
 import { LowPowerModeTracker } from '../src/components/analytics/LowPowerModeTracker';
 import { InstallReferrerTracker } from '../src/components/analytics/InstallReferrerTracker';
+import { KeychainNamespaceMigration } from '../src/components/KeychainNamespaceMigration';
 import { OnboardingGate } from '../src/components/onboarding/OnboardingGate';
 import { AccessoryOnboardingTip } from '../src/components/onboarding/AccessoryOnboardingTip';
 import { ConnectivityBanner } from '../src/components/connectivity/ConnectivityBanner';
@@ -869,6 +870,7 @@ function RootLayout() {
                                                               <OtaUpdateTracker />
                                                               <LowPowerModeTracker />
                                                               <InstallReferrerTracker />
+                                                              <KeychainNamespaceMigration />
                                                             </ShareTargetProvider>
                                                           </DeepLinkProvider>
                                                         </DrawerHostProvider>

--- a/packages/mobile/src/components/KeychainNamespaceMigration.tsx
+++ b/packages/mobile/src/components/KeychainNamespaceMigration.tsx
@@ -1,29 +1,50 @@
 // Migrates the non-credential SecureStore keys into the v2 keychain namespace
-// (#4103) once per launch, off the render path. The three auth keys do NOT come
-// through here — auth-store drives those from its own first read, so they are
-// migrated before AuthProvider decides whether to render anything.
+// (#4103), off the render path. The three auth keys do NOT come through here —
+// auth-store drives those from its own first read, so they are migrated before
+// AuthProvider decides whether to render anything.
 //
 // Mounted next to InstallReferrerTracker and shaped the same way: fire-and-forget
 // after mount, renders nothing, never blocks the splash or the auth gate. There
 // is no foreground gate: nothing here is destructive, so a background launch
-// either migrates a key or reports it as retry-next-launch, and the v2 item
-// itself records which.
+// either migrates a key or reports it as retry-later, and the v2 item itself
+// records which.
+//
+// A pass that did not complete does not latch, and this component re-runs it on
+// AppState `active`. The case that matters is a process cold-launched in the
+// background on a locked phone, where every key comes back legacy-read-failed;
+// without the foreground retry those keys would wait for the next cold start.
+// Once a pass completes the runner resolves immediately, so this is a no-op in
+// the steady state. The auth keys get the same retry for free — auth-provider
+// re-runs checkAuth on AppState `active`, which lands in getStoredCredential.
 //
 // This can only ever help the NEXT launch for values read during module eval or
 // early render — by the time any component effect runs, the whole module graph
 // has already been evaluated. That is inherent to a JS-level fix.
 
 import { useEffect } from 'react';
-import { createOnceRunner, migrateSecureKeysToV2 } from '../lib/keychain-namespace-migration';
+import { AppState } from 'react-native';
+import { createOnceRunner, isMigrationComplete, migrateSecureKeysToV2 } from '../lib/keychain-namespace-migration';
 import { PREFERENCE_SECURE_KEYS } from '../lib/preference-secure-keys';
 
-const migratePreferenceKeys = createOnceRunner(async () => {
-  await migrateSecureKeysToV2(PREFERENCE_SECURE_KEYS, 'preferences');
-});
+const migratePreferenceKeys = createOnceRunner(async () =>
+  isMigrationComplete(await migrateSecureKeysToV2(PREFERENCE_SECURE_KEYS, 'preferences')),
+);
+
+function runPreferenceKeyMigration(): void {
+  void migratePreferenceKeys().catch(() => undefined);
+}
 
 export function KeychainNamespaceMigration(): null {
   useEffect(() => {
-    void migratePreferenceKeys().catch(() => undefined);
+    runPreferenceKeyMigration();
+  }, []);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (nextAppState) => {
+      if (nextAppState !== 'active') return;
+      runPreferenceKeyMigration();
+    });
+    return () => subscription.remove();
   }, []);
 
   return null;

--- a/packages/mobile/src/components/KeychainNamespaceMigration.tsx
+++ b/packages/mobile/src/components/KeychainNamespaceMigration.tsx
@@ -1,0 +1,30 @@
+// Migrates the non-credential SecureStore keys into the v2 keychain namespace
+// (#4103) once per launch, off the render path. The three auth keys do NOT come
+// through here — auth-store drives those from its own first read, so they are
+// migrated before AuthProvider decides whether to render anything.
+//
+// Mounted next to InstallReferrerTracker and shaped the same way: fire-and-forget
+// after mount, renders nothing, never blocks the splash or the auth gate. There
+// is no foreground gate: nothing here is destructive, so a background launch
+// either migrates a key or reports it as retry-next-launch, and the v2 item
+// itself records which.
+//
+// This can only ever help the NEXT launch for values read during module eval or
+// early render — by the time any component effect runs, the whole module graph
+// has already been evaluated. That is inherent to a JS-level fix.
+
+import { useEffect } from 'react';
+import { createOnceRunner, migrateSecureKeysToV2 } from '../lib/keychain-namespace-migration';
+import { PREFERENCE_SECURE_KEYS } from '../lib/preference-secure-keys';
+
+const migratePreferenceKeys = createOnceRunner(async () => {
+  await migrateSecureKeysToV2(PREFERENCE_SECURE_KEYS, 'preferences');
+});
+
+export function KeychainNamespaceMigration(): null {
+  useEffect(() => {
+    void migratePreferenceKeys().catch(() => undefined);
+  }, []);
+
+  return null;
+}

--- a/packages/mobile/src/components/KeychainNamespaceMigration.tsx
+++ b/packages/mobile/src/components/KeychainNamespaceMigration.tsx
@@ -5,9 +5,11 @@
 //
 // Mounted next to InstallReferrerTracker and shaped the same way: fire-and-forget
 // after mount, renders nothing, never blocks the splash or the auth gate. There
-// is no foreground gate: nothing here is destructive, so a background launch
-// either migrates a key or reports it as retry-later, and the v2 item itself
-// records which.
+// is no foreground gate, because a background launch can only ever copy a key
+// forward or report it as retry-later, and the v2 item itself records which. The
+// one way a pass could change what a user sees is by racing a store that clears
+// or rewrites the same key mid-copy; migrateKey stands down on any key this
+// process has already written or deleted, so that cannot happen.
 //
 // A pass that did not complete does not latch, and this component re-runs it on
 // AppState `active`. The case that matters is a process cold-launched in the

--- a/packages/mobile/src/lib/__tests__/keychain-namespace-migration.test.ts
+++ b/packages/mobile/src/lib/__tests__/keychain-namespace-migration.test.ts
@@ -19,6 +19,10 @@ vi.mock('expo-secure-store', () => {
   const lockedServices = new Set<string>();
   const writeFailureKeys = new Set<string>();
   const droppedWriteKeys = new Set<string>();
+  // Fires once the legacy read has produced its value but before the caller
+  // resumes — the exact window a migration pass is in when the app mutates the
+  // same key underneath it.
+  const legacyReadHooks = new Map<string, () => void>();
 
   const serviceOf = (options?: { keychainService?: string }) => options?.keychainService ?? 'app';
   const itemKey = (key: string, options?: { keychainService?: string }) => `${serviceOf(options)}::${key}`;
@@ -27,7 +31,15 @@ vi.mock('expo-secure-store', () => {
     AFTER_FIRST_UNLOCK,
     getItemAsync: vi.fn(async (key: string, options?: { keychainService?: string }) => {
       if (lockedServices.has(serviceOf(options))) throw new Error('User interaction is not allowed.');
-      return items.get(itemKey(key, options))?.value ?? null;
+      const storedValue = items.get(itemKey(key, options))?.value ?? null;
+      if (serviceOf(options) === 'app') {
+        const hook = legacyReadHooks.get(key);
+        if (hook) {
+          legacyReadHooks.delete(key);
+          hook();
+        }
+      }
+      return storedValue;
     }),
     setItemAsync: vi.fn(
       async (key: string, value: string, options?: { keychainService?: string; keychainAccessible?: string }) => {
@@ -57,6 +69,7 @@ vi.mock('expo-secure-store', () => {
     __unlockService: (service: string) => lockedServices.delete(service),
     __failWriteFor: (key: string, service = V2_SERVICE) => writeFailureKeys.add(`${service}::${key}`),
     __dropWriteFor: (key: string, service = V2_SERVICE) => droppedWriteKeys.add(`${service}::${key}`),
+    __onceOnLegacyRead: (key: string, hook: () => void) => legacyReadHooks.set(key, hook),
     __clearWriteHooks: () => {
       writeFailureKeys.clear();
       droppedWriteKeys.clear();
@@ -66,6 +79,7 @@ vi.mock('expo-secure-store', () => {
       lockedServices.clear();
       writeFailureKeys.clear();
       droppedWriteKeys.clear();
+      legacyReadHooks.clear();
     },
   };
 });
@@ -79,6 +93,7 @@ type SecureStoreFake = {
   __unlockService: (service: string) => void;
   __failWriteFor: (key: string, service?: string) => void;
   __dropWriteFor: (key: string, service?: string) => void;
+  __onceOnLegacyRead: (key: string, hook: () => void) => void;
   __clearWriteHooks: () => void;
   __reset: () => void;
   getItemAsync: ReturnType<typeof vi.fn>;
@@ -224,6 +239,7 @@ describe('migrateSecureKeysToV2', () => {
       migrated: 1,
       already_v2: 0,
       absent: 0,
+      superseded: 0,
       failed: 1,
       failures: 'theme_override:v2-write-failed',
     });
@@ -273,8 +289,101 @@ describe('migrateSecureKeysToV2', () => {
   });
 });
 
+describe('migrateSecureKeysToV2 against a concurrent app mutation', () => {
+  // migrateKey is a read of legacy followed by a write of that value into v2, and
+  // readSecureValue prefers v2. A store that clears or rewrites the key inside
+  // that window would be undone by the write: a cleared preference would come
+  // back, a just-saved one would revert. The auth scope is serialized by
+  // auth-store's credential mutation queue; these 16 preference keys are not, so
+  // the guard is secure-store-io's touched-key registry.
+  const RECENT_FILTERS_KEY = 'boardsesh_recent_filters';
+
+  it('does not resurrect a preference cleared while the pass was mid-copy', async () => {
+    const store = await secureStore();
+    const { deleteSecureValue, readSecureValue } = await import('../secure-store-io');
+    const { migrateSecureKeysToV2 } = await import('../keychain-namespace-migration');
+    store.__seedLegacy(RECENT_FILTERS_KEY, '["A","B"]');
+
+    // The user taps "Clear recents" after the legacy read has handed the pass
+    // ["A","B"] and before it writes that value into v2.
+    const pendingClears: Promise<void>[] = [];
+    store.__onceOnLegacyRead(RECENT_FILTERS_KEY, () => {
+      pendingClears.push(deleteSecureValue(RECENT_FILTERS_KEY));
+    });
+
+    const outcomes = await migrateSecureKeysToV2([RECENT_FILTERS_KEY], 'preferences');
+    await Promise.all(pendingClears);
+
+    expect(outcomes).toEqual([{ key: RECENT_FILTERS_KEY, status: 'superseded' }]);
+    expect(store.__get(RECENT_FILTERS_KEY)).toBeNull();
+    expect(store.__get(RECENT_FILTERS_KEY, 'app')).toBeNull();
+    await expect(readSecureValue(RECENT_FILTERS_KEY)).resolves.toBeNull();
+  });
+
+  it('does not revert a preference saved while the pass was mid-copy', async () => {
+    const store = await secureStore();
+    const { readSecureValue, writeSecureValue } = await import('../secure-store-io');
+    const { migrateSecureKeysToV2 } = await import('../keychain-namespace-migration');
+    store.__seedLegacy(RECENT_FILTERS_KEY, '["A","B"]');
+
+    const pendingWrites: Promise<void>[] = [];
+    store.__onceOnLegacyRead(RECENT_FILTERS_KEY, () => {
+      pendingWrites.push(writeSecureValue(RECENT_FILTERS_KEY, '["C"]'));
+    });
+
+    const outcomes = await migrateSecureKeysToV2([RECENT_FILTERS_KEY], 'preferences');
+    await Promise.all(pendingWrites);
+
+    expect(outcomes).toEqual([{ key: RECENT_FILTERS_KEY, status: 'superseded' }]);
+    // The app's write is authoritative in both namespaces; the stale legacy blob
+    // the pass was carrying never lands.
+    await expect(readSecureValue(RECENT_FILTERS_KEY)).resolves.toBe('["C"]');
+    expect(store.__get(RECENT_FILTERS_KEY)).toEqual({ value: '["C"]', accessible: AFTER_FIRST_UNLOCK });
+  });
+
+  it('needs no copy at all for a key the app already wrote this process', async () => {
+    const store = await secureStore();
+    const { writeSecureValue } = await import('../secure-store-io');
+    const { isMigrationComplete, migrateSecureKeysToV2 } = await import('../keychain-namespace-migration');
+    store.__seedLegacy(RECENT_FILTERS_KEY, '["A","B"]');
+
+    // The claim that makes standing down safe: writeSecureValue writes v2 first,
+    // so an app write leaves the key migrated by construction. This one does not
+    // even reach the touched-key check — the v2 read short-circuits first.
+    await writeSecureValue(RECENT_FILTERS_KEY, '["C"]');
+    store.setItemAsync.mockClear();
+    const outcomes = await migrateSecureKeysToV2([RECENT_FILTERS_KEY], 'preferences');
+
+    expect(outcomes).toEqual([{ key: RECENT_FILTERS_KEY, status: 'already-v2' }]);
+    expect(store.setItemAsync).not.toHaveBeenCalled();
+    expect(isMigrationComplete(outcomes)).toBe(true);
+  });
+
+  it('leaves untouched keys in the same pass fully migrated', async () => {
+    const store = await secureStore();
+    const { deleteSecureValue } = await import('../secure-store-io');
+    const { migrateSecureKeysToV2 } = await import('../keychain-namespace-migration');
+    store.__seedLegacy(RECENT_FILTERS_KEY, '["A","B"]');
+    store.__seedLegacy('theme_override', '"dark"');
+
+    const pendingClears: Promise<void>[] = [];
+    store.__onceOnLegacyRead(RECENT_FILTERS_KEY, () => {
+      pendingClears.push(deleteSecureValue(RECENT_FILTERS_KEY));
+    });
+
+    const outcomes = await migrateSecureKeysToV2([RECENT_FILTERS_KEY, 'theme_override'], 'preferences');
+    await Promise.all(pendingClears);
+
+    expect(outcomes).toEqual([
+      { key: RECENT_FILTERS_KEY, status: 'superseded' },
+      { key: 'theme_override', status: 'migrated' },
+    ]);
+    expect(store.__get('theme_override')).toEqual({ value: '"dark"', accessible: AFTER_FIRST_UNLOCK });
+  });
+});
+
 describe('isMigrationComplete', () => {
-  it('accepts the three terminal statuses and rejects every retryable one', async () => {
+  it('accepts the four terminal statuses and rejects every retryable one', async () => {
     const { isMigrationComplete } = await import('../keychain-namespace-migration');
 
     expect(isMigrationComplete([])).toBe(true);
@@ -283,6 +392,11 @@ describe('isMigrationComplete', () => {
         { key: 'a', status: 'already-v2' },
         { key: 'b', status: 'migrated' },
         { key: 'c', status: 'absent' },
+        // Terminal too: the app's own write already put the key in v2, or its
+        // delete removed it from both namespaces. Retrying would find the same
+        // mark and stand down again, so a retryable `superseded` would keep the
+        // pass permanently incomplete.
+        { key: 'd', status: 'superseded' },
       ]),
     ).toBe(true);
     for (const status of ['v2-read-failed', 'legacy-read-failed', 'v2-write-failed', 'verify-mismatch'] as const) {

--- a/packages/mobile/src/lib/__tests__/keychain-namespace-migration.test.ts
+++ b/packages/mobile/src/lib/__tests__/keychain-namespace-migration.test.ts
@@ -18,6 +18,7 @@ vi.mock('expo-secure-store', () => {
   const items = new Map<string, StoredItem>();
   const lockedServices = new Set<string>();
   const writeFailureKeys = new Set<string>();
+  const droppedWriteKeys = new Set<string>();
 
   const serviceOf = (options?: { keychainService?: string }) => options?.keychainService ?? 'app';
   const itemKey = (key: string, options?: { keychainService?: string }) => `${serviceOf(options)}::${key}`;
@@ -35,6 +36,10 @@ vi.mock('expo-secure-store', () => {
         const existing = items.get(itemKey(key, options));
         // The bug being fixed: an existing item keeps its original accessibility
         // because expo-secure-store's update() sends kSecValueData only.
+        // A write that reports success but leaves nothing behind — the case the
+        // read-back exists to catch, and the only shape it can physically take
+        // (SecItemAdd either stores the bytes it was handed or returns an error).
+        if (droppedWriteKeys.has(itemKey(key, options))) return;
         items.set(itemKey(key, options), {
           value,
           accessible: existing ? existing.accessible : options?.keychainAccessible,
@@ -49,11 +54,18 @@ vi.mock('expo-secure-store', () => {
     },
     __get: (key: string, service = V2_SERVICE) => items.get(`${service}::${key}`) ?? null,
     __lockService: (service: string) => lockedServices.add(service),
+    __unlockService: (service: string) => lockedServices.delete(service),
     __failWriteFor: (key: string, service = V2_SERVICE) => writeFailureKeys.add(`${service}::${key}`),
+    __dropWriteFor: (key: string, service = V2_SERVICE) => droppedWriteKeys.add(`${service}::${key}`),
+    __clearWriteHooks: () => {
+      writeFailureKeys.clear();
+      droppedWriteKeys.clear();
+    },
     __reset: () => {
       items.clear();
       lockedServices.clear();
       writeFailureKeys.clear();
+      droppedWriteKeys.clear();
     },
   };
 });
@@ -64,7 +76,10 @@ type SecureStoreFake = {
   __seedLegacy: (key: string, value: string, accessible?: string) => void;
   __get: (key: string, service?: string) => StoredItem | null;
   __lockService: (service: string) => void;
+  __unlockService: (service: string) => void;
   __failWriteFor: (key: string, service?: string) => void;
+  __dropWriteFor: (key: string, service?: string) => void;
+  __clearWriteHooks: () => void;
   __reset: () => void;
   getItemAsync: ReturnType<typeof vi.fn>;
   setItemAsync: ReturnType<typeof vi.fn>;
@@ -171,6 +186,28 @@ describe('migrateSecureKeysToV2', () => {
     ]);
   });
 
+  it('reports verify-mismatch and leaves legacy intact when the read-back disagrees', async () => {
+    const store = await secureStore();
+    store.__seedLegacy('boardsesh_jwt', 'jwt-value');
+    // The write reports success but nothing lands. Without the read-back this
+    // pass would report `migrated` while the next launch still read legacy.
+    store.__dropWriteFor('boardsesh_jwt');
+    const { migrateSecureKeysToV2 } = await import('../keychain-namespace-migration');
+
+    const outcomes = await migrateSecureKeysToV2(['boardsesh_jwt'], 'auth');
+
+    expect(outcomes).toEqual([{ key: 'boardsesh_jwt', status: 'verify-mismatch' }]);
+    // Nothing was destroyed: legacy is byte-identical to the seed.
+    expect(store.__get('boardsesh_jwt', 'app')).toEqual({ value: 'jwt-value', accessible: 'when-unlocked' });
+    expect(store.deleteItemAsync).not.toHaveBeenCalled();
+
+    // And a later pass with the write behaving picks the key back up.
+    store.__clearWriteHooks();
+    await expect(migrateSecureKeysToV2(['boardsesh_jwt'], 'auth')).resolves.toEqual([
+      { key: 'boardsesh_jwt', status: 'migrated' },
+    ]);
+  });
+
   it('reports per-key outcomes to analytics, with key names but never values', async () => {
     const store = await secureStore();
     store.__seedLegacy('boardsesh_jwt', 'jwt-value');
@@ -192,12 +229,77 @@ describe('migrateSecureKeysToV2', () => {
     });
     expect(JSON.stringify(vi.mocked(track).mock.calls)).not.toContain('jwt-value');
   });
+
+  it('reports an incomplete scope once per process, and again when it completes', async () => {
+    const store = await secureStore();
+    store.__seedLegacy('boardsesh_jwt', 'jwt-value');
+    store.__lockService('app');
+    const { migrateSecureKeysToV2 } = await import('../keychain-namespace-migration');
+    const { track } = await import('../analytics');
+
+    // A locked background wake retries on every token read, and every retry
+    // fails identically. One stuck device must not become a stream of events.
+    await migrateSecureKeysToV2(['boardsesh_jwt'], 'auth');
+    await migrateSecureKeysToV2(['boardsesh_jwt'], 'auth');
+
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenLastCalledWith(
+      'Keychain Namespace Migration',
+      expect.objectContaining({ scope: 'auth', failed: 1, failures: 'boardsesh_jwt:legacy-read-failed' }),
+    );
+
+    store.__unlockService('app');
+    await migrateSecureKeysToV2(['boardsesh_jwt'], 'auth');
+
+    expect(track).toHaveBeenCalledTimes(2);
+    expect(track).toHaveBeenLastCalledWith(
+      'Keychain Namespace Migration',
+      expect.objectContaining({ scope: 'auth', migrated: 1, failed: 0, failures: '' }),
+    );
+    expect(JSON.stringify(vi.mocked(track).mock.calls)).not.toContain('jwt-value');
+  });
+
+  it('bounds incomplete reports per scope, not across scopes', async () => {
+    const store = await secureStore();
+    store.__seedLegacy('boardsesh_jwt', 'jwt-value');
+    store.__lockService('app');
+    const { migrateSecureKeysToV2 } = await import('../keychain-namespace-migration');
+    const { track } = await import('../analytics');
+
+    await migrateSecureKeysToV2(['boardsesh_jwt'], 'auth');
+    await migrateSecureKeysToV2(['boardsesh_jwt'], 'preferences');
+
+    expect(track).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('isMigrationComplete', () => {
+  it('accepts the three terminal statuses and rejects every retryable one', async () => {
+    const { isMigrationComplete } = await import('../keychain-namespace-migration');
+
+    expect(isMigrationComplete([])).toBe(true);
+    expect(
+      isMigrationComplete([
+        { key: 'a', status: 'already-v2' },
+        { key: 'b', status: 'migrated' },
+        { key: 'c', status: 'absent' },
+      ]),
+    ).toBe(true);
+    for (const status of ['v2-read-failed', 'legacy-read-failed', 'v2-write-failed', 'verify-mismatch'] as const) {
+      expect(
+        isMigrationComplete([
+          { key: 'a', status: 'migrated' },
+          { key: 'b', status },
+        ]),
+      ).toBe(false);
+    }
+  });
 });
 
 describe('createOnceRunner', () => {
   it('shares one in-flight run across concurrent callers', async () => {
     const { createOnceRunner } = await import('../keychain-namespace-migration');
-    const task = vi.fn(async () => {});
+    const task = vi.fn(async () => true);
     const runOnce = createOnceRunner(task);
 
     await Promise.all([runOnce(), runOnce(), runOnce()]);
@@ -205,9 +307,9 @@ describe('createOnceRunner', () => {
     expect(task).toHaveBeenCalledTimes(1);
   });
 
-  it('does not re-run after success', async () => {
+  it('latches on a complete pass and never runs again', async () => {
     const { createOnceRunner } = await import('../keychain-namespace-migration');
-    const task = vi.fn(async () => {});
+    const task = vi.fn(async () => true);
     const runOnce = createOnceRunner(task);
 
     await runOnce();
@@ -216,16 +318,66 @@ describe('createOnceRunner', () => {
     expect(task).toHaveBeenCalledTimes(1);
   });
 
-  it('retries after a failure instead of latching completed', async () => {
+  it('does NOT latch on an incomplete pass, so the next caller retries', async () => {
+    const { createOnceRunner } = await import('../keychain-namespace-migration');
+    // migrateSecureKeysToV2 never rejects — a locked keychain resolves as an
+    // outcome — so `false` is the only signal that the work still needs doing.
+    const task = vi.fn<() => Promise<boolean>>().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const runOnce = createOnceRunner(task);
+
+    await runOnce();
+    await runOnce();
+    await runOnce();
+
+    expect(task).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries after a rejection instead of latching completed', async () => {
     const { createOnceRunner } = await import('../keychain-namespace-migration');
     const task = vi
-      .fn<() => Promise<void>>()
+      .fn<() => Promise<boolean>>()
       .mockRejectedValueOnce(new Error('keychain locked'))
-      .mockResolvedValueOnce(undefined);
+      .mockResolvedValueOnce(true);
     const runOnce = createOnceRunner(task);
 
     await expect(runOnce()).rejects.toThrow('keychain locked');
     await expect(runOnce()).resolves.toBeUndefined();
     expect(task).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries a fully failed migration pass in the SAME process once the keychain unlocks', async () => {
+    // The latch bug this guards: a process cold-launched in the background on a
+    // locked phone gets nothing but legacy-read-failed, and used to burn its one
+    // attempt on it and never retry for the whole process lifetime.
+    const store = await secureStore();
+    store.__seedLegacy('boardsesh_jwt', 'jwt-value');
+    store.__seedLegacy('boardsesh_refresh_token', 'refresh-value');
+    store.__seedLegacy('boardsesh_token_expires_at', '2026-09-01T00:00:00.000Z');
+    store.__lockService('app');
+    const { createOnceRunner, isMigrationComplete, migrateSecureKeysToV2 } =
+      await import('../keychain-namespace-migration');
+    const keys = ['boardsesh_jwt', 'boardsesh_refresh_token', 'boardsesh_token_expires_at'];
+    const outcomesPerPass: string[][] = [];
+    const runOnce = createOnceRunner(async () => {
+      const outcomes = await migrateSecureKeysToV2(keys, 'auth');
+      outcomesPerPass.push(outcomes.map((outcome) => outcome.status));
+      return isMigrationComplete(outcomes);
+    });
+
+    await runOnce();
+    expect(outcomesPerPass[0]).toEqual(['legacy-read-failed', 'legacy-read-failed', 'legacy-read-failed']);
+    expect(store.__get('boardsesh_jwt')).toBeNull();
+
+    store.__unlockService('app');
+    await runOnce();
+
+    expect(outcomesPerPass[1]).toEqual(['migrated', 'migrated', 'migrated']);
+    for (const key of keys) {
+      expect(store.__get(key)?.accessible).toBe(AFTER_FIRST_UNLOCK);
+    }
+
+    // And now it latches.
+    await runOnce();
+    expect(outcomesPerPass).toHaveLength(2);
   });
 });

--- a/packages/mobile/src/lib/__tests__/keychain-namespace-migration.test.ts
+++ b/packages/mobile/src/lib/__tests__/keychain-namespace-migration.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The v2 keychain-namespace migration (#4103). The fake below models the one
+// property the real iOS keychain has that makes this design necessary: an item
+// is identified by (key, keychainService), so writing under the v2 service is a
+// fresh insert that carries its own accessibility, while writing under the
+// legacy service only overwrites the value of an item that already exists.
+const AFTER_FIRST_UNLOCK = 'after-first-unlock';
+const V2_SERVICE = 'boardsesh.v2';
+
+type StoredItem = { value: string; accessible: string | undefined };
+
+// babel-preset-expo replaces this at build time; set it so USES_V2_NAMESPACE
+// resolves to the iOS path under test.
+process.env.EXPO_OS = 'ios';
+
+vi.mock('expo-secure-store', () => {
+  const items = new Map<string, StoredItem>();
+  const lockedServices = new Set<string>();
+  const writeFailureKeys = new Set<string>();
+
+  const serviceOf = (options?: { keychainService?: string }) => options?.keychainService ?? 'app';
+  const itemKey = (key: string, options?: { keychainService?: string }) => `${serviceOf(options)}::${key}`;
+
+  return {
+    AFTER_FIRST_UNLOCK,
+    getItemAsync: vi.fn(async (key: string, options?: { keychainService?: string }) => {
+      if (lockedServices.has(serviceOf(options))) throw new Error('User interaction is not allowed.');
+      return items.get(itemKey(key, options))?.value ?? null;
+    }),
+    setItemAsync: vi.fn(
+      async (key: string, value: string, options?: { keychainService?: string; keychainAccessible?: string }) => {
+        if (writeFailureKeys.has(itemKey(key, options))) throw new Error('write failed');
+        if (lockedServices.has(serviceOf(options))) throw new Error('User interaction is not allowed.');
+        const existing = items.get(itemKey(key, options));
+        // The bug being fixed: an existing item keeps its original accessibility
+        // because expo-secure-store's update() sends kSecValueData only.
+        items.set(itemKey(key, options), {
+          value,
+          accessible: existing ? existing.accessible : options?.keychainAccessible,
+        });
+      },
+    ),
+    deleteItemAsync: vi.fn(async (key: string, options?: { keychainService?: string }) => {
+      items.delete(itemKey(key, options));
+    }),
+    __seedLegacy: (key: string, value: string, accessible = 'when-unlocked') => {
+      items.set(`app::${key}`, { value, accessible });
+    },
+    __get: (key: string, service = V2_SERVICE) => items.get(`${service}::${key}`) ?? null,
+    __lockService: (service: string) => lockedServices.add(service),
+    __failWriteFor: (key: string, service = V2_SERVICE) => writeFailureKeys.add(`${service}::${key}`),
+    __reset: () => {
+      items.clear();
+      lockedServices.clear();
+      writeFailureKeys.clear();
+    },
+  };
+});
+
+vi.mock('../analytics', () => ({ track: vi.fn() }));
+
+type SecureStoreFake = {
+  __seedLegacy: (key: string, value: string, accessible?: string) => void;
+  __get: (key: string, service?: string) => StoredItem | null;
+  __lockService: (service: string) => void;
+  __failWriteFor: (key: string, service?: string) => void;
+  __reset: () => void;
+  getItemAsync: ReturnType<typeof vi.fn>;
+  setItemAsync: ReturnType<typeof vi.fn>;
+  deleteItemAsync: ReturnType<typeof vi.fn>;
+};
+
+async function secureStore(): Promise<SecureStoreFake> {
+  return (await import('expo-secure-store')) as unknown as SecureStoreFake;
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  (await secureStore()).__reset();
+  vi.clearAllMocks();
+});
+
+describe('migrateSecureKeysToV2', () => {
+  it('copies a legacy value into v2 with AFTER_FIRST_UNLOCK applied', async () => {
+    const store = await secureStore();
+    store.__seedLegacy('boardsesh_jwt', 'jwt-value');
+    const { migrateSecureKeysToV2 } = await import('../keychain-namespace-migration');
+
+    const outcomes = await migrateSecureKeysToV2(['boardsesh_jwt'], 'auth');
+
+    expect(outcomes).toEqual([{ key: 'boardsesh_jwt', status: 'migrated' }]);
+    expect(store.__get('boardsesh_jwt')).toEqual({ value: 'jwt-value', accessible: AFTER_FIRST_UNLOCK });
+  });
+
+  it('leaves the legacy copy in place so an OTA rollback still finds the value', async () => {
+    const store = await secureStore();
+    store.__seedLegacy('boardsesh_jwt', 'jwt-value');
+    const { migrateSecureKeysToV2 } = await import('../keychain-namespace-migration');
+
+    await migrateSecureKeysToV2(['boardsesh_jwt'], 'auth');
+
+    expect(store.__get('boardsesh_jwt', 'app')).toEqual({ value: 'jwt-value', accessible: 'when-unlocked' });
+    expect(store.deleteItemAsync).not.toHaveBeenCalled();
+  });
+
+  it('reports already-v2 and rewrites nothing on a second pass', async () => {
+    const store = await secureStore();
+    store.__seedLegacy('boardsesh_jwt', 'jwt-value');
+    const { migrateSecureKeysToV2 } = await import('../keychain-namespace-migration');
+
+    await migrateSecureKeysToV2(['boardsesh_jwt'], 'auth');
+    store.setItemAsync.mockClear();
+    const outcomes = await migrateSecureKeysToV2(['boardsesh_jwt'], 'auth');
+
+    expect(outcomes).toEqual([{ key: 'boardsesh_jwt', status: 'already-v2' }]);
+    expect(store.setItemAsync).not.toHaveBeenCalled();
+  });
+
+  it('reports absent when nothing is stored under either namespace', async () => {
+    const { migrateSecureKeysToV2 } = await import('../keychain-namespace-migration');
+
+    await expect(migrateSecureKeysToV2(['boardsesh_jwt'], 'auth')).resolves.toEqual([
+      { key: 'boardsesh_jwt', status: 'absent' },
+    ]);
+  });
+
+  it('aborts without touching anything when the legacy namespace is locked', async () => {
+    const store = await secureStore();
+    store.__seedLegacy('boardsesh_jwt', 'jwt-value');
+    store.__lockService('app');
+    const { migrateSecureKeysToV2 } = await import('../keychain-namespace-migration');
+
+    const outcomes = await migrateSecureKeysToV2(['boardsesh_jwt'], 'auth');
+
+    expect(outcomes).toEqual([{ key: 'boardsesh_jwt', status: 'legacy-read-failed' }]);
+    expect(store.__get('boardsesh_jwt')).toBeNull();
+    expect(store.deleteItemAsync).not.toHaveBeenCalled();
+  });
+
+  it('retries a key that failed a previous pass, because v2 presence is the record', async () => {
+    const store = await secureStore();
+    store.__seedLegacy('boardsesh_jwt', 'jwt-value');
+    store.__failWriteFor('boardsesh_jwt');
+    const { migrateSecureKeysToV2 } = await import('../keychain-namespace-migration');
+
+    const firstPass = await migrateSecureKeysToV2(['boardsesh_jwt'], 'auth');
+    expect(firstPass).toEqual([{ key: 'boardsesh_jwt', status: 'v2-write-failed' }]);
+
+    // A fresh process with the write no longer failing picks the key back up.
+    vi.resetModules();
+    store.__reset();
+    store.__seedLegacy('boardsesh_jwt', 'jwt-value');
+    const { migrateSecureKeysToV2: retry } = await import('../keychain-namespace-migration');
+
+    await expect(retry(['boardsesh_jwt'], 'auth')).resolves.toEqual([{ key: 'boardsesh_jwt', status: 'migrated' }]);
+  });
+
+  it('never rejects, and keeps going after one key fails', async () => {
+    const store = await secureStore();
+    store.__seedLegacy('boardsesh_jwt', 'jwt-value');
+    store.__seedLegacy('theme_override', '"dark"');
+    store.__failWriteFor('boardsesh_jwt');
+    const { migrateSecureKeysToV2 } = await import('../keychain-namespace-migration');
+
+    const outcomes = await migrateSecureKeysToV2(['boardsesh_jwt', 'theme_override'], 'preferences');
+
+    expect(outcomes).toEqual([
+      { key: 'boardsesh_jwt', status: 'v2-write-failed' },
+      { key: 'theme_override', status: 'migrated' },
+    ]);
+  });
+
+  it('reports per-key outcomes to analytics, with key names but never values', async () => {
+    const store = await secureStore();
+    store.__seedLegacy('boardsesh_jwt', 'jwt-value');
+    store.__seedLegacy('theme_override', '"dark"');
+    store.__failWriteFor('theme_override');
+    const { migrateSecureKeysToV2 } = await import('../keychain-namespace-migration');
+    const { track } = await import('../analytics');
+
+    await migrateSecureKeysToV2(['boardsesh_jwt', 'theme_override'], 'auth');
+
+    expect(track).toHaveBeenCalledWith('Keychain Namespace Migration', {
+      scope: 'auth',
+      keys: 2,
+      migrated: 1,
+      already_v2: 0,
+      absent: 0,
+      failed: 1,
+      failures: 'theme_override:v2-write-failed',
+    });
+    expect(JSON.stringify(vi.mocked(track).mock.calls)).not.toContain('jwt-value');
+  });
+});
+
+describe('createOnceRunner', () => {
+  it('shares one in-flight run across concurrent callers', async () => {
+    const { createOnceRunner } = await import('../keychain-namespace-migration');
+    const task = vi.fn(async () => {});
+    const runOnce = createOnceRunner(task);
+
+    await Promise.all([runOnce(), runOnce(), runOnce()]);
+
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-run after success', async () => {
+    const { createOnceRunner } = await import('../keychain-namespace-migration');
+    const task = vi.fn(async () => {});
+    const runOnce = createOnceRunner(task);
+
+    await runOnce();
+    await runOnce();
+
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries after a failure instead of latching completed', async () => {
+    const { createOnceRunner } = await import('../keychain-namespace-migration');
+    const task = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('keychain locked'))
+      .mockResolvedValueOnce(undefined);
+    const runOnce = createOnceRunner(task);
+
+    await expect(runOnce()).rejects.toThrow('keychain locked');
+    await expect(runOnce()).resolves.toBeUndefined();
+    expect(task).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/preference-secure-keys.test.ts
+++ b/packages/mobile/src/lib/__tests__/preference-secure-keys.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// PREFERENCE_SECURE_KEYS drives which SecureStore keys the #4103 keychain
+// migration copies into the v2 namespace. Its entries are imported from the
+// modules that own them, which makes a platform fork a real hazard: Metro
+// resolves `./session-store` to session-store.web.ts on the browser target, and
+// that fork used to declare the session keys privately. An import through it
+// resolves to `undefined` there, punching a silent hole in this list that tsc
+// (which resolves the native file) cannot see.
+//
+// These assertions are the guard. Repointing any entry at a module with a
+// `.web.ts` sibling that does not re-export the key fails the undefined check.
+
+vi.mock('expo-secure-store', () => ({
+  AFTER_FIRST_UNLOCK: 'after-first-unlock',
+  getItemAsync: vi.fn(async () => null),
+  setItemAsync: vi.fn(async () => undefined),
+  deleteItemAsync: vi.fn(async () => undefined),
+}));
+
+describe('PREFERENCE_SECURE_KEYS', () => {
+  it('has no undefined or empty entries', async () => {
+    const { PREFERENCE_SECURE_KEYS } = await import('../preference-secure-keys');
+
+    expect(PREFERENCE_SECURE_KEYS.length).toBeGreaterThan(0);
+    for (const key of PREFERENCE_SECURE_KEYS) {
+      expect(typeof key).toBe('string');
+      expect(key).not.toBe('');
+    }
+  });
+
+  it('lists every key exactly once', async () => {
+    const { PREFERENCE_SECURE_KEYS } = await import('../preference-secure-keys');
+
+    expect(new Set(PREFERENCE_SECURE_KEYS).size).toBe(PREFERENCE_SECURE_KEYS.length);
+  });
+
+  it('covers both party-session keys from the fork-free key module', async () => {
+    const { PREFERENCE_SECURE_KEYS } = await import('../preference-secure-keys');
+    const { CREATED_SESSION_ID_KEY, SESSION_ID_KEY } = await import('../session-store-keys');
+
+    expect(PREFERENCE_SECURE_KEYS).toContain(SESSION_ID_KEY);
+    expect(PREFERENCE_SECURE_KEYS).toContain(CREATED_SESSION_ID_KEY);
+  });
+
+  it('excludes the two keys the migration deliberately skips', async () => {
+    const { PREFERENCE_SECURE_KEYS } = await import('../preference-secure-keys');
+
+    // boardsesh_party_profile is read synchronously at module eval, before any
+    // async migration could run; boardsesh_dev_metro_hosts is dev-only and
+    // already read-and-deleted on its way to AsyncStorage.
+    expect(PREFERENCE_SECURE_KEYS).not.toContain('boardsesh_party_profile');
+    expect(PREFERENCE_SECURE_KEYS).not.toContain('boardsesh_dev_metro_hosts');
+  });
+});

--- a/packages/mobile/src/lib/__tests__/preference-secure-keys.test.ts
+++ b/packages/mobile/src/lib/__tests__/preference-secure-keys.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect, vi } from 'vitest';
 
 // PREFERENCE_SECURE_KEYS drives which SecureStore keys the #4103 keychain
@@ -5,11 +8,19 @@ import { describe, it, expect, vi } from 'vitest';
 // modules that own them, which makes a platform fork a real hazard: Metro
 // resolves `./session-store` to session-store.web.ts on the browser target, and
 // that fork used to declare the session keys privately. An import through it
-// resolves to `undefined` there, punching a silent hole in this list that tsc
-// (which resolves the native file) cannot see.
+// resolves to `undefined` there, punching a silent hole in the list.
 //
-// These assertions are the guard. Repointing any entry at a module with a
-// `.web.ts` sibling that does not re-export the key fails the undefined check.
+// Importing the list and inspecting its values cannot catch that. Vitest and tsc
+// both resolve `./session-store` to the NATIVE file, whose exports are perfectly
+// defined, so re-pointing an import at a forked module passes every value
+// assertion while the browser bundle quietly loses two keys. The guard has to be
+// structural, which is what the first test is: it reads the source and fails on
+// an import of any module that has a `.web` sibling.
+//
+// The value assertions after it are a second, weaker net. They catch a renamed
+// or deleted constant, not a fork.
+
+const LIB_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 vi.mock('expo-secure-store', () => ({
   AFTER_FIRST_UNLOCK: 'after-first-unlock',
@@ -18,11 +29,54 @@ vi.mock('expo-secure-store', () => ({
   deleteItemAsync: vi.fn(async () => undefined),
 }));
 
+describe('preference-secure-keys imports', () => {
+  it('pulls no key through a module that has a platform fork', () => {
+    const source = readFileSync(resolve(LIB_DIR, 'preference-secure-keys.ts'), 'utf8');
+    const relativeSpecifiers = [...source.matchAll(/from '(\.[^']+)'/g)].map((match) => match[1]);
+
+    expect(relativeSpecifiers.length).toBeGreaterThan(0);
+    const forkedSpecifiers = relativeSpecifiers.filter((specifier) =>
+      ['.web.ts', '.web.tsx'].some((suffix) => existsSync(resolve(LIB_DIR, `${specifier}${suffix}`))),
+    );
+
+    // A hit here means Metro resolves that import to a fork on the browser
+    // target, and every key the fork does not re-export becomes `undefined` in
+    // the list below. The fix is to move those constants into a fork-free module
+    // of their own, the way session-store-keys.ts already does for the two
+    // session ids.
+    expect(forkedSpecifiers).toEqual([]);
+  });
+});
+
 describe('PREFERENCE_SECURE_KEYS', () => {
+  it('is exactly the sixteen preference keys the migration covers', async () => {
+    const { PREFERENCE_SECURE_KEYS } = await import('../preference-secure-keys');
+
+    // Pinned as literals so a renamed or deleted constant lands as a diff on
+    // this line instead of as a silent hole in the migration list.
+    expect(PREFERENCE_SECURE_KEYS).toEqual([
+      'boardsesh_active_session_id',
+      'boardsesh_created_session_id',
+      'boardsesh_last_used_grade',
+      'boardsesh_recent_filters',
+      'boardsesh_last_search_by_board',
+      'locale_override',
+      'theme_override',
+      'ui_variant',
+      'changelog_last_seen',
+      'onboarding_seen',
+      'onboarding_board_tip_pending',
+      'onboarding_tip_workout_seen',
+      'onboarding_tip_crew_seen',
+      'onboarding_tip_record_seen',
+      'onboarding_tip_accessory_seen',
+      'onboarding_tip_quickactions_seen',
+    ]);
+  });
+
   it('has no undefined or empty entries', async () => {
     const { PREFERENCE_SECURE_KEYS } = await import('../preference-secure-keys');
 
-    expect(PREFERENCE_SECURE_KEYS.length).toBeGreaterThan(0);
     for (const key of PREFERENCE_SECURE_KEYS) {
       expect(typeof key).toBe('string');
       expect(key).not.toBe('');

--- a/packages/mobile/src/lib/__tests__/secure-store-namespace.test.ts
+++ b/packages/mobile/src/lib/__tests__/secure-store-namespace.test.ts
@@ -263,6 +263,28 @@ describe('auth-store over the v2 namespace', () => {
     });
   });
 
+  it('treats a surviving tombstone as already cleared on a second sign-out', async () => {
+    const store = await secureStore();
+    store.__seed(LEGACY_SERVICE, 'boardsesh_jwt', 'legacy-jwt');
+    // A keychain that refuses deletion: the first sign-out cannot remove the
+    // credential, so it overwrites it with the tombstone instead.
+    store.__makeUndeletable(LEGACY_SERVICE);
+    store.__makeUndeletable(V2_SERVICE);
+    const { clearTokens, getAuthToken } = await import('../auth-store');
+
+    await expect(clearTokens()).resolves.toBeUndefined();
+    expect(store.__get(LEGACY_SERVICE, 'boardsesh_jwt')).toBe('__boardsesh_auth_credential_cleared__');
+
+    // Now the device has not been unlocked since boot, so writes reject too. The
+    // stored state is already correct, and the second sign-out has to recognise
+    // that instead of re-writing an identical tombstone and failing on it.
+    store.__failWriteFor(V2_SERVICE, 'boardsesh_jwt');
+    store.__failWriteFor(LEGACY_SERVICE, 'boardsesh_jwt');
+
+    await expect(clearTokens()).resolves.toBeUndefined();
+    await expect(getAuthToken()).resolves.toBeNull();
+  });
+
   it('does not resurrect the session when sign-out races the first-read migration', async () => {
     const store = await secureStore();
     store.__seed(LEGACY_SERVICE, 'boardsesh_jwt', 'legacy-jwt');

--- a/packages/mobile/src/lib/__tests__/secure-store-namespace.test.ts
+++ b/packages/mobile/src/lib/__tests__/secure-store-namespace.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// secure-store-io + auth-store against a keychain fake that models the two
+// properties which drive the #4103 design:
+//   * an item is identified by (key, keychainService), so v2 and legacy are
+//     genuinely separate items
+//   * deletion never reports failure — expo-secure-store's iOS
+//     deleteValueWithKeyAsync discards every SecItemDelete status and never
+//     throws, so a delete that silently did nothing is indistinguishable from
+//     one that worked
+const AFTER_FIRST_UNLOCK = 'after-first-unlock';
+const V2_SERVICE = 'boardsesh.v2';
+const LEGACY_SERVICE = 'app';
+
+process.env.EXPO_OS = 'ios';
+
+vi.mock('expo-secure-store', () => {
+  const items = new Map<string, string>();
+  const lockedServices = new Set<string>();
+  const undeletableServices = new Set<string>();
+
+  const serviceOf = (options?: { keychainService?: string }) => options?.keychainService ?? LEGACY_SERVICE;
+  const itemKey = (key: string, options?: { keychainService?: string }) => `${serviceOf(options)}::${key}`;
+
+  return {
+    AFTER_FIRST_UNLOCK,
+    getItemAsync: vi.fn(async (key: string, options?: { keychainService?: string }) => {
+      if (lockedServices.has(serviceOf(options))) throw new Error('User interaction is not allowed.');
+      return items.get(itemKey(key, options)) ?? null;
+    }),
+    setItemAsync: vi.fn(async (key: string, value: string, options?: { keychainService?: string }) => {
+      if (lockedServices.has(serviceOf(options))) throw new Error('User interaction is not allowed.');
+      items.set(itemKey(key, options), value);
+    }),
+    deleteItemAsync: vi.fn(async (key: string, options?: { keychainService?: string }) => {
+      // Never throws, exactly like the real module.
+      if (undeletableServices.has(serviceOf(options))) return;
+      items.delete(itemKey(key, options));
+    }),
+    __seed: (service: string, key: string, value: string) => items.set(`${service}::${key}`, value),
+    __get: (service: string, key: string) => items.get(`${service}::${key}`) ?? null,
+    __lockService: (service: string) => lockedServices.add(service),
+    __makeUndeletable: (service: string) => undeletableServices.add(service),
+    __reset: () => {
+      items.clear();
+      lockedServices.clear();
+      undeletableServices.clear();
+    },
+  };
+});
+
+vi.mock('../analytics', () => ({ track: vi.fn() }));
+
+type SecureStoreFake = {
+  __seed: (service: string, key: string, value: string) => void;
+  __get: (service: string, key: string) => string | null;
+  __lockService: (service: string) => void;
+  __makeUndeletable: (service: string) => void;
+  __reset: () => void;
+  getItemAsync: ReturnType<typeof vi.fn>;
+};
+
+async function secureStore(): Promise<SecureStoreFake> {
+  return (await import('expo-secure-store')) as unknown as SecureStoreFake;
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  (await secureStore()).__reset();
+  vi.clearAllMocks();
+});
+
+describe('readSecureValue', () => {
+  it('prefers v2 and never touches the legacy namespace once a key has migrated', async () => {
+    const store = await secureStore();
+    store.__seed(V2_SERVICE, 'k', 'v2-value');
+    store.__seed(LEGACY_SERVICE, 'k', 'legacy-value');
+    // The legacy namespace is what rejects on a locked device. If the read still
+    // consulted it after a v2 hit, the whole fix would be inert.
+    store.__lockService(LEGACY_SERVICE);
+    const { readSecureValue } = await import('../secure-store-io');
+
+    await expect(readSecureValue('k')).resolves.toBe('v2-value');
+  });
+
+  it('falls back to legacy for a key that has not migrated yet', async () => {
+    const store = await secureStore();
+    store.__seed(LEGACY_SERVICE, 'k', 'legacy-value');
+    const { readSecureValue } = await import('../secure-store-io');
+
+    await expect(readSecureValue('k')).resolves.toBe('legacy-value');
+  });
+});
+
+describe('writeSecureValue', () => {
+  it('mirrors into legacy so an OTA rollback still finds the value', async () => {
+    const store = await secureStore();
+    const { writeSecureValue } = await import('../secure-store-io');
+
+    await writeSecureValue('k', 'fresh');
+
+    expect(store.__get(V2_SERVICE, 'k')).toBe('fresh');
+    expect(store.__get(LEGACY_SERVICE, 'k')).toBe('fresh');
+  });
+
+  it('still succeeds when the legacy mirror rejects on a locked device', async () => {
+    const store = await secureStore();
+    store.__lockService(LEGACY_SERVICE);
+    const { writeSecureValue } = await import('../secure-store-io');
+
+    await expect(writeSecureValue('k', 'fresh')).resolves.toBeUndefined();
+    expect(store.__get(V2_SERVICE, 'k')).toBe('fresh');
+  });
+});
+
+describe('deleteSecureValue', () => {
+  it('clears both namespaces', async () => {
+    const store = await secureStore();
+    store.__seed(V2_SERVICE, 'k', 'a');
+    store.__seed(LEGACY_SERVICE, 'k', 'b');
+    const { deleteSecureValue } = await import('../secure-store-io');
+
+    await deleteSecureValue('k');
+
+    expect(store.__get(V2_SERVICE, 'k')).toBeNull();
+    expect(store.__get(LEGACY_SERVICE, 'k')).toBeNull();
+  });
+});
+
+describe('auth-store over the v2 namespace', () => {
+  it('migrates a pre-fix credential on the first read and returns it', async () => {
+    const store = await secureStore();
+    store.__seed(LEGACY_SERVICE, 'boardsesh_jwt', 'legacy-jwt');
+    const { getAuthToken } = await import('../auth-store');
+
+    await expect(getAuthToken()).resolves.toBe('legacy-jwt');
+    expect(store.__get(V2_SERVICE, 'boardsesh_jwt')).toBe('legacy-jwt');
+  });
+
+  it('reads through without signing out when the legacy keychain is locked', async () => {
+    const store = await secureStore();
+    store.__seed(LEGACY_SERVICE, 'boardsesh_jwt', 'legacy-jwt');
+    store.__lockService(LEGACY_SERVICE);
+    const { getAuthToken } = await import('../auth-store');
+
+    // Same rejection the app already surfaces today — crucially NOT a null,
+    // which auth-interceptor treats as a confirmed logout.
+    await expect(getAuthToken()).rejects.toThrow('User interaction is not allowed.');
+  });
+
+  it('does not resurrect a signed-out session when the legacy delete silently fails', async () => {
+    const store = await secureStore();
+    store.__seed(LEGACY_SERVICE, 'boardsesh_jwt', 'legacy-jwt');
+    store.__seed(LEGACY_SERVICE, 'boardsesh_refresh_token', 'legacy-refresh');
+    // The delete reports success while the item survives — the case JS cannot
+    // detect from the return value.
+    store.__makeUndeletable(LEGACY_SERVICE);
+    const { clearTokens, getAuthToken, getRefreshToken } = await import('../auth-store');
+
+    await clearTokens();
+
+    await expect(getAuthToken()).resolves.toBeNull();
+    await expect(getRefreshToken()).resolves.toBeNull();
+    // The tombstone is written to v2 AND mirrored into legacy, so the credential
+    // that survived deletion is overwritten rather than merely shadowed — it is
+    // unreachable even through the read fallback.
+    expect(store.__get(LEGACY_SERVICE, 'boardsesh_jwt')).toBe('__boardsesh_auth_credential_cleared__');
+    expect(store.__get(V2_SERVICE, 'boardsesh_jwt')).toBe('__boardsesh_auth_credential_cleared__');
+  });
+
+  it('leaves nothing behind when deletion actually works', async () => {
+    const store = await secureStore();
+    store.__seed(LEGACY_SERVICE, 'boardsesh_jwt', 'legacy-jwt');
+    const { clearTokens, getAuthToken } = await import('../auth-store');
+
+    await clearTokens();
+
+    await expect(getAuthToken()).resolves.toBeNull();
+    expect(store.__get(V2_SERVICE, 'boardsesh_jwt')).toBeNull();
+    expect(store.__get(LEGACY_SERVICE, 'boardsesh_jwt')).toBeNull();
+  });
+
+  it('writes new tokens into v2 and mirrors them to legacy', async () => {
+    const store = await secureStore();
+    const { storeTokens } = await import('../auth-store');
+
+    await storeTokens('jwt', 'refresh', '2026-09-01T00:00:00.000Z');
+
+    expect(store.__get(V2_SERVICE, 'boardsesh_jwt')).toBe('jwt');
+    expect(store.__get(LEGACY_SERVICE, 'boardsesh_jwt')).toBe('jwt');
+  });
+
+  it('runs the credential migration once across concurrent cold-start reads', async () => {
+    const store = await secureStore();
+    store.__seed(LEGACY_SERVICE, 'boardsesh_jwt', 'legacy-jwt');
+    const { getAuthToken, getRefreshToken, getTokenExpiresAt } = await import('../auth-store');
+
+    await Promise.all([getAuthToken(), getRefreshToken(), getTokenExpiresAt(), getAuthToken()]);
+
+    // Three auth keys, each probed once in v2 by the single migration pass.
+    const v2Probes = store.getItemAsync.mock.calls.filter(
+      (call) => (call[1] as { keychainService?: string } | undefined)?.keychainService === V2_SERVICE,
+    );
+    const migrationProbes = v2Probes.filter((call) => call[0] === 'boardsesh_jwt');
+    // One migration probe + one verify + the reads themselves; without the
+    // once-runner each of the four callers would start its own pass.
+    expect(migrationProbes.length).toBeLessThanOrEqual(4);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/secure-store-namespace.test.ts
+++ b/packages/mobile/src/lib/__tests__/secure-store-namespace.test.ts
@@ -18,6 +18,7 @@ vi.mock('expo-secure-store', () => {
   const items = new Map<string, string>();
   const lockedServices = new Set<string>();
   const undeletableServices = new Set<string>();
+  const writeFailureKeys = new Set<string>();
 
   const serviceOf = (options?: { keychainService?: string }) => options?.keychainService ?? LEGACY_SERVICE;
   const itemKey = (key: string, options?: { keychainService?: string }) => `${serviceOf(options)}::${key}`;
@@ -29,6 +30,7 @@ vi.mock('expo-secure-store', () => {
       return items.get(itemKey(key, options)) ?? null;
     }),
     setItemAsync: vi.fn(async (key: string, value: string, options?: { keychainService?: string }) => {
+      if (writeFailureKeys.has(itemKey(key, options))) throw new Error('write failed');
       if (lockedServices.has(serviceOf(options))) throw new Error('User interaction is not allowed.');
       items.set(itemKey(key, options), value);
     }),
@@ -41,10 +43,12 @@ vi.mock('expo-secure-store', () => {
     __get: (service: string, key: string) => items.get(`${service}::${key}`) ?? null,
     __lockService: (service: string) => lockedServices.add(service),
     __makeUndeletable: (service: string) => undeletableServices.add(service),
+    __failWriteFor: (service: string, key: string) => writeFailureKeys.add(`${service}::${key}`),
     __reset: () => {
       items.clear();
       lockedServices.clear();
       undeletableServices.clear();
+      writeFailureKeys.clear();
     },
   };
 });
@@ -56,6 +60,7 @@ type SecureStoreFake = {
   __get: (service: string, key: string) => string | null;
   __lockService: (service: string) => void;
   __makeUndeletable: (service: string) => void;
+  __failWriteFor: (service: string, key: string) => void;
   __reset: () => void;
   getItemAsync: ReturnType<typeof vi.fn>;
 };
@@ -110,6 +115,43 @@ describe('writeSecureValue', () => {
 
     await expect(writeSecureValue('k', 'fresh')).resolves.toBeUndefined();
     expect(store.__get(V2_SERVICE, 'k')).toBe('fresh');
+  });
+});
+
+describe('writeSecureValueToEitherNamespace', () => {
+  it('still lands in legacy when the v2 write rejects', async () => {
+    const store = await secureStore();
+    store.__failWriteFor(V2_SERVICE, 'k');
+    const { writeSecureValueToEitherNamespace } = await import('../secure-store-io');
+
+    await expect(writeSecureValueToEitherNamespace('k', 'fresh')).resolves.toBeUndefined();
+
+    expect(store.__get(V2_SERVICE, 'k')).toBeNull();
+    expect(store.__get(LEGACY_SERVICE, 'k')).toBe('fresh');
+  });
+
+  it('still lands in v2 when the legacy write rejects', async () => {
+    const store = await secureStore();
+    store.__lockService(LEGACY_SERVICE);
+    const { writeSecureValueToEitherNamespace } = await import('../secure-store-io');
+
+    await expect(writeSecureValueToEitherNamespace('k', 'fresh')).resolves.toBeUndefined();
+
+    expect(store.__get(V2_SERVICE, 'k')).toBe('fresh');
+  });
+
+  it('rejects with both causes only when neither namespace accepts the write', async () => {
+    const store = await secureStore();
+    store.__failWriteFor(V2_SERVICE, 'k');
+    store.__failWriteFor(LEGACY_SERVICE, 'k');
+    const { writeSecureValueToEitherNamespace } = await import('../secure-store-io');
+
+    await expect(writeSecureValueToEitherNamespace('k', 'fresh')).rejects.toMatchObject({
+      name: 'SecureStoreWriteError',
+      failures: [expect.any(Error), expect.any(Error)],
+    });
+    expect(store.__get(V2_SERVICE, 'k')).toBeNull();
+    expect(store.__get(LEGACY_SERVICE, 'k')).toBeNull();
   });
 });
 
@@ -188,6 +230,60 @@ describe('auth-store over the v2 namespace', () => {
 
     expect(store.__get(V2_SERVICE, 'boardsesh_jwt')).toBe('jwt');
     expect(store.__get(LEGACY_SERVICE, 'boardsesh_jwt')).toBe('jwt');
+  });
+
+  it('tombstones through legacy when the v2 write is the one that fails', async () => {
+    const store = await secureStore();
+    store.__seed(LEGACY_SERVICE, 'boardsesh_jwt', 'legacy-jwt');
+    // Deletion silently does nothing AND the v2 tombstone write rejects. A
+    // v2-first-then-mirror writer would throw before the legacy write ran,
+    // leaving the surviving legacy credential readable through the fallback.
+    store.__makeUndeletable(LEGACY_SERVICE);
+    store.__failWriteFor(V2_SERVICE, 'boardsesh_jwt');
+    const { clearTokens, getAuthToken } = await import('../auth-store');
+
+    await expect(clearTokens()).resolves.toBeUndefined();
+
+    expect(store.__get(LEGACY_SERVICE, 'boardsesh_jwt')).toBe('__boardsesh_auth_credential_cleared__');
+    await expect(getAuthToken()).resolves.toBeNull();
+  });
+
+  it('fails the sign-out cleanup only when BOTH namespaces reject the tombstone', async () => {
+    const store = await secureStore();
+    store.__seed(LEGACY_SERVICE, 'boardsesh_jwt', 'legacy-jwt');
+    store.__makeUndeletable(LEGACY_SERVICE);
+    store.__makeUndeletable(V2_SERVICE);
+    store.__failWriteFor(V2_SERVICE, 'boardsesh_jwt');
+    store.__failWriteFor(LEGACY_SERVICE, 'boardsesh_jwt');
+    const { clearTokens } = await import('../auth-store');
+
+    await expect(clearTokens()).rejects.toMatchObject({
+      name: 'AuthCredentialCleanupError',
+      failures: [expect.anything()],
+    });
+  });
+
+  it('does not resurrect the session when sign-out races the first-read migration', async () => {
+    const store = await secureStore();
+    store.__seed(LEGACY_SERVICE, 'boardsesh_jwt', 'legacy-jwt');
+    store.__seed(LEGACY_SERVICE, 'boardsesh_refresh_token', 'legacy-refresh');
+    const { clearTokens, getAuthToken, getRefreshToken } = await import('../auth-store');
+
+    // No await between them: the migration pass and the sign-out both land on
+    // the credential mutation queue. Settling at all is half the assertion —
+    // a self-enqueueing read inside the queue would deadlock here.
+    const pendingRead = getAuthToken();
+    const pendingSignOut = clearTokens();
+    await Promise.allSettled([pendingRead, pendingSignOut]);
+
+    await expect(getAuthToken()).resolves.toBeNull();
+    await expect(getRefreshToken()).resolves.toBeNull();
+    for (const service of [V2_SERVICE, LEGACY_SERVICE]) {
+      for (const key of ['boardsesh_jwt', 'boardsesh_refresh_token']) {
+        const stored = store.__get(service, key);
+        expect(stored === null || stored === '__boardsesh_auth_credential_cleared__').toBe(true);
+      }
+    }
   });
 
   it('runs the credential migration once across concurrent cold-start reads', async () => {

--- a/packages/mobile/src/lib/__tests__/secure-store-namespace.test.ts
+++ b/packages/mobile/src/lib/__tests__/secure-store-namespace.test.ts
@@ -248,6 +248,31 @@ describe('auth-store over the v2 namespace', () => {
     await expect(getAuthToken()).resolves.toBeNull();
   });
 
+  it('refuses to report a sign-out when the legacy tombstone lands behind a live v2 credential', async () => {
+    const store = await secureStore();
+    // The post-migration steady state: the credential exists in BOTH namespaces,
+    // which the tombstone test above cannot reach because it seeds legacy alone.
+    store.__seed(V2_SERVICE, 'boardsesh_jwt', 'v2-jwt');
+    store.__seed(LEGACY_SERVICE, 'boardsesh_jwt', 'legacy-jwt');
+    // v2 refuses both the delete and the tombstone write; legacy accepts both.
+    // writeSecureValueToEitherNamespace is satisfied by that one legacy write,
+    // but readSecureValue consults v2 FIRST, so the tombstone it just landed is
+    // shadowed by the credential it was meant to retire.
+    store.__makeUndeletable(V2_SERVICE);
+    store.__failWriteFor(V2_SERVICE, 'boardsesh_jwt');
+    const { clearTokens, getAuthToken } = await import('../auth-store');
+
+    // Nothing in JS can remove an item the keychain refuses to delete or
+    // overwrite, so failing loudly is the whole remedy: a resolved clearTokens
+    // here would tell the caller the session is gone while the very next
+    // getAuthToken hands back the live credential.
+    await expect(clearTokens()).rejects.toMatchObject({ name: 'AuthCredentialCleanupError' });
+
+    expect(store.__get(LEGACY_SERVICE, 'boardsesh_jwt')).toBe('__boardsesh_auth_credential_cleared__');
+    expect(store.__get(V2_SERVICE, 'boardsesh_jwt')).toBe('v2-jwt');
+    await expect(getAuthToken()).resolves.toBe('v2-jwt');
+  });
+
   it('fails the sign-out cleanup only when BOTH namespaces reject the tombstone', async () => {
     const store = await secureStore();
     store.__seed(LEGACY_SERVICE, 'boardsesh_jwt', 'legacy-jwt');

--- a/packages/mobile/src/lib/__tests__/secure-store-non-ios.test.ts
+++ b/packages/mobile/src/lib/__tests__/secure-store-non-ios.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The other half of #4103: what the namespace helpers do when there is no v2
+// namespace. The whole design rests on the claim that Android and expo-web keep
+// byte-for-byte their pre-PR behaviour — one SecureStore call per operation,
+// against the default service, with no keychainService attribute anywhere. Every
+// other suite in this directory sets EXPO_OS to 'ios', so nothing was pinning
+// that claim; a future edit could drop the USES_V2_NAMESPACE gates and only iOS
+// tests would notice.
+//
+// The gates matter more on Android than the "harmless extra call" framing
+// suggests. keychainService there selects the KeyStore alias AND the
+// SharedPreferences storage key (SecureStoreOptions.kt:12, SecureStoreModule.kt:92,
+// 102, 179), so a v2 service reaching Android would strand every existing value
+// behind a name nothing reads.
+const AFTER_FIRST_UNLOCK = 'after-first-unlock';
+
+// babel-preset-expo replaces this at build time. 'android' here selects the
+// non-iOS branch of USES_V2_NAMESPACE; expo-web takes the same branch.
+process.env.EXPO_OS = 'android';
+
+// No keychainService — the default service, exactly as before this PR.
+const LEGACY_OPTIONS = { keychainAccessible: AFTER_FIRST_UNLOCK };
+
+vi.mock('expo-secure-store', () => {
+  let storage: Record<string, string> = {};
+  const rejectingKeys = new Set<string>();
+
+  return {
+    AFTER_FIRST_UNLOCK,
+    getItemAsync: vi.fn(async (key: string) => storage[key] ?? null),
+    setItemAsync: vi.fn(async (key: string, value: string) => {
+      if (rejectingKeys.has(key)) throw new Error('write failed');
+      storage[key] = value;
+    }),
+    deleteItemAsync: vi.fn(async (key: string) => {
+      delete storage[key];
+    }),
+    __seed: (key: string, value: string) => {
+      storage[key] = value;
+    },
+    __get: (key: string) => storage[key] ?? null,
+    __failWriteFor: (key: string) => rejectingKeys.add(key),
+    __reset: () => {
+      storage = {};
+      rejectingKeys.clear();
+    },
+  };
+});
+
+vi.mock('../analytics', () => ({ track: vi.fn() }));
+
+type SecureStoreFake = {
+  __seed: (key: string, value: string) => void;
+  __get: (key: string) => string | null;
+  __failWriteFor: (key: string) => void;
+  __reset: () => void;
+  getItemAsync: ReturnType<typeof vi.fn>;
+  setItemAsync: ReturnType<typeof vi.fn>;
+  deleteItemAsync: ReturnType<typeof vi.fn>;
+};
+
+async function secureStore(): Promise<SecureStoreFake> {
+  return (await import('expo-secure-store')) as unknown as SecureStoreFake;
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  (await secureStore()).__reset();
+  vi.clearAllMocks();
+});
+
+describe('secure-store-io off iOS', () => {
+  it('exposes no v2 keychain service at all', async () => {
+    const { SECURE_STORE_V2_OPTIONS, USES_V2_NAMESPACE } = await import('../secure-store-options');
+
+    expect(USES_V2_NAMESPACE).toBe(false);
+    expect(SECURE_STORE_V2_OPTIONS).toEqual(LEGACY_OPTIONS);
+    expect('keychainService' in SECURE_STORE_V2_OPTIONS).toBe(false);
+  });
+
+  it('reads once, against the default service', async () => {
+    const store = await secureStore();
+    store.__seed('boardsesh_jwt', 'token-1');
+    const { readSecureValue } = await import('../secure-store-io');
+
+    await expect(readSecureValue('boardsesh_jwt')).resolves.toBe('token-1');
+
+    expect(store.getItemAsync).toHaveBeenCalledTimes(1);
+    expect(store.getItemAsync).toHaveBeenCalledWith('boardsesh_jwt', LEGACY_OPTIONS);
+  });
+
+  it('reads once even on a miss, instead of falling through to a second lookup', async () => {
+    const store = await secureStore();
+    const { readSecureValue } = await import('../secure-store-io');
+
+    await expect(readSecureValue('boardsesh_jwt')).resolves.toBeNull();
+
+    // The iOS path would try legacy here. Off iOS both namespaces are the same
+    // item, so a second call could only ever return the same null.
+    expect(store.getItemAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes once, with no mirror', async () => {
+    const store = await secureStore();
+    const { writeSecureValue } = await import('../secure-store-io');
+
+    await writeSecureValue('boardsesh_jwt', 'token-1');
+
+    expect(store.setItemAsync).toHaveBeenCalledTimes(1);
+    expect(store.setItemAsync).toHaveBeenCalledWith('boardsesh_jwt', 'token-1', LEGACY_OPTIONS);
+    expect(store.__get('boardsesh_jwt')).toBe('token-1');
+  });
+
+  it('deletes once, with no second namespace to clear', async () => {
+    const store = await secureStore();
+    store.__seed('boardsesh_jwt', 'token-1');
+    const { deleteSecureValue } = await import('../secure-store-io');
+
+    await deleteSecureValue('boardsesh_jwt');
+
+    expect(store.deleteItemAsync).toHaveBeenCalledTimes(1);
+    expect(store.deleteItemAsync).toHaveBeenCalledWith('boardsesh_jwt', LEGACY_OPTIONS);
+    expect(store.__get('boardsesh_jwt')).toBeNull();
+  });
+
+  it('writes the tombstone once and still surfaces a rejection', async () => {
+    const store = await secureStore();
+    const { writeSecureValueToEitherNamespace, SecureStoreWriteError } = await import('../secure-store-io');
+
+    await writeSecureValueToEitherNamespace('boardsesh_jwt', 'cleared');
+    expect(store.setItemAsync).toHaveBeenCalledTimes(1);
+    expect(store.__get('boardsesh_jwt')).toBe('cleared');
+
+    // With one namespace there is no "either": the single write failing is the
+    // whole operation failing, and clearStoredCredential must still hear about
+    // it rather than reporting a sign-out that did not happen.
+    store.__failWriteFor('boardsesh_refresh_token');
+    await expect(writeSecureValueToEitherNamespace('boardsesh_refresh_token', 'cleared')).rejects.toBeInstanceOf(
+      SecureStoreWriteError,
+    );
+  });
+});
+
+describe('migrateSecureKeysToV2 off iOS', () => {
+  it('does nothing at all — no outcomes and no keychain calls', async () => {
+    const store = await secureStore();
+    store.__seed('boardsesh_jwt', 'token-1');
+    const { migrateSecureKeysToV2 } = await import('../keychain-namespace-migration');
+
+    await expect(migrateSecureKeysToV2(['boardsesh_jwt'], 'auth')).resolves.toEqual([]);
+
+    expect(store.getItemAsync).not.toHaveBeenCalled();
+    expect(store.setItemAsync).not.toHaveBeenCalled();
+    expect(store.deleteItemAsync).not.toHaveBeenCalled();
+  });
+
+  it('reports nothing to analytics, so no Android device emits a migration event', async () => {
+    const { migrateSecureKeysToV2 } = await import('../keychain-namespace-migration');
+    const { track } = await import('../analytics');
+
+    await migrateSecureKeysToV2(['boardsesh_jwt'], 'auth');
+
+    expect(track).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/secure-store-writers.test.ts
+++ b/packages/mobile/src/lib/__tests__/secure-store-writers.test.ts
@@ -1,11 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Guards the SecureStore-writer contract from issue #3602: every write must carry
-// keychainAccessible: AFTER_FIRST_UNLOCK so a locked-device background read stays
-// accessible. The shared SECURE_STORE_WRITE_OPTIONS constant is unit-tested via
-// auth-store; this pins the wiring for the other writers so a future edit that
-// drops the option from one call site is caught (the review's stated risk).
+// Guards the SecureStore-writer contract from issues #3602 and #4103: every write
+// must carry keychainAccessible: AFTER_FIRST_UNLOCK so a locked-device background
+// read stays accessible, and must land in the v2 keychain namespace — the only
+// namespace where that accessibility is actually applied, since an existing legacy
+// item takes expo-secure-store's update() path, which never touches
+// kSecAttrAccessible. Each write is then mirrored back into the legacy namespace so
+// an OTA rollback to JS that predates v2 still finds the current value.
+//
+// This pins the wiring for the non-auth writers so a future edit that drops a call
+// site out of secure-store-io is caught (the review's stated risk).
 const AFTER_FIRST_UNLOCK = 'after-first-unlock';
+
+// babel-preset-expo replaces this at build time; set it so the v2 namespace is
+// active under test.
+process.env.EXPO_OS = 'ios';
 
 vi.mock('expo-secure-store', () => {
   let storage: Record<string, string> = {};
@@ -33,20 +42,26 @@ async function secureStore() {
   };
 }
 
-const EXPECTED_OPTIONS = { keychainAccessible: AFTER_FIRST_UNLOCK };
+const V2_OPTIONS = { keychainAccessible: AFTER_FIRST_UNLOCK, keychainService: 'boardsesh.v2' };
+const LEGACY_OPTIONS = { keychainAccessible: AFTER_FIRST_UNLOCK };
+
+function expectDualNamespaceWrite(setItemAsync: ReturnType<typeof vi.fn>, key: string, value: string): void {
+  expect(setItemAsync).toHaveBeenNthCalledWith(1, key, value, V2_OPTIONS);
+  expect(setItemAsync).toHaveBeenNthCalledWith(2, key, value, LEGACY_OPTIONS);
+}
 
 beforeEach(async () => {
   (await secureStore()).__reset();
 });
 
-describe('SecureStore writers pass AFTER_FIRST_UNLOCK', () => {
+describe('SecureStore writers write v2 first, then mirror to legacy', () => {
   it('session-store setStoredSessionId', async () => {
     const store = await secureStore();
     const { setStoredSessionId } = await import('../session-store');
 
     await setStoredSessionId('session-123');
 
-    expect(store.setItemAsync).toHaveBeenCalledWith('boardsesh_active_session_id', 'session-123', EXPECTED_OPTIONS);
+    expectDualNamespaceWrite(store.setItemAsync, 'boardsesh_active_session_id', 'session-123');
   });
 
   it('last-grade-store setLastUsedGradeId', async () => {
@@ -55,7 +70,7 @@ describe('SecureStore writers pass AFTER_FIRST_UNLOCK', () => {
 
     await setLastUsedGradeId(22);
 
-    expect(store.setItemAsync).toHaveBeenCalledWith('boardsesh_last_used_grade', '22', EXPECTED_OPTIONS);
+    expectDualNamespaceWrite(store.setItemAsync, 'boardsesh_last_used_grade', '22');
   });
 
   it('secure-store-adapter secureStorePreferences.set', async () => {
@@ -64,6 +79,6 @@ describe('SecureStore writers pass AFTER_FIRST_UNLOCK', () => {
 
     await secureStorePreferences.set('some_pref', { enabled: true });
 
-    expect(store.setItemAsync).toHaveBeenCalledWith('some_pref', JSON.stringify({ enabled: true }), EXPECTED_OPTIONS);
+    expectDualNamespaceWrite(store.setItemAsync, 'some_pref', JSON.stringify({ enabled: true }));
   });
 });

--- a/packages/mobile/src/lib/auth-store.ts
+++ b/packages/mobile/src/lib/auth-store.ts
@@ -6,9 +6,9 @@ import {
   writeSecureValueToEitherNamespace,
 } from './secure-store-io';
 
-export const JWT_KEY = 'boardsesh_jwt';
-export const REFRESH_TOKEN_KEY = 'boardsesh_refresh_token';
-export const EXPIRES_AT_KEY = 'boardsesh_token_expires_at';
+const JWT_KEY = 'boardsesh_jwt';
+const REFRESH_TOKEN_KEY = 'boardsesh_refresh_token';
+const EXPIRES_AT_KEY = 'boardsesh_token_expires_at';
 const CLEARED_CREDENTIAL = '__boardsesh_auth_credential_cleared__';
 const AUTH_SECURE_KEYS = [JWT_KEY, REFRESH_TOKEN_KEY, EXPIRES_AT_KEY] as const;
 let credentialGeneration = 0;

--- a/packages/mobile/src/lib/auth-store.ts
+++ b/packages/mobile/src/lib/auth-store.ts
@@ -1,5 +1,10 @@
-import { createOnceRunner, migrateSecureKeysToV2 } from './keychain-namespace-migration';
-import { deleteSecureValue, readSecureValue, writeSecureValue } from './secure-store-io';
+import { createOnceRunner, isMigrationComplete, migrateSecureKeysToV2 } from './keychain-namespace-migration';
+import {
+  deleteSecureValue,
+  readSecureValue,
+  writeSecureValue,
+  writeSecureValueToEitherNamespace,
+} from './secure-store-io';
 
 export const JWT_KEY = 'boardsesh_jwt';
 export const REFRESH_TOKEN_KEY = 'boardsesh_refresh_token';
@@ -30,11 +35,23 @@ class AuthCredentialCleanupError extends Error {
 // carries it across unchanged: it must stay visible to getStoredCredential in v2,
 // or a signed-out user whose deletion never physically landed would read the live
 // legacy credential through the fallback and be signed back in.
-const ensureAuthCredentialsMigrated = createOnceRunner(async () => {
-  await serializeCredentialMutation(async () => {
-    await migrateSecureKeysToV2(AUTH_SECURE_KEYS, 'auth');
-  });
-});
+//
+// The pass reports whether it COMPLETED, and only a complete pass latches. A
+// process cold-launched in the background on a locked phone (BGTask, push, Live
+// Activity — every BOARDSESH-C3 event carries in_foreground: false) gets nothing
+// but legacy-read-failed, and must be free to try again once the phone is
+// unlocked. auth-provider.tsx re-runs checkAuth on every AppState `active`,
+// which lands back here through getStoredCredential; that is the retry.
+//
+// HAZARD: this enqueues on the same credentialMutationQueue as sign-in and
+// sign-out, so calling getAuthToken() from INSIDE a serialized mutation would
+// deadlock. No caller does today — clearStoredCredential reads through
+// readSecureValue directly and writeCredentialForGeneration never reads. The
+// queue is not optional: without it a sign-out's delete could interleave between
+// the migration's legacy read and its v2 write and resurrect the credential.
+const ensureAuthCredentialsMigrated = createOnceRunner(() =>
+  serializeCredentialMutation(async () => isMigrationComplete(await migrateSecureKeysToV2(AUTH_SECURE_KEYS, 'auth'))),
+);
 
 async function getStoredCredential(key: string): Promise<string | null> {
   // Best-effort. A keychain that refuses the migration refuses the read below
@@ -67,9 +84,12 @@ async function clearStoredCredential(key: string): Promise<void> {
     // Some keychain failures reject deletion while still permitting an overwrite.
     // Persist a value that every getter treats as absent so credentials cannot be
     // restored on relaunch merely because physical deletion was unavailable.
-    // Written to v2 (and mirrored to legacy) so it shadows any legacy credential
-    // the failed deletion left behind.
-    await writeSecureValue(key, CLEARED_CREDENTIAL);
+    // Written to v2 AND legacy independently, so it shadows any legacy credential
+    // the failed deletion left behind. Unlike a normal credential write this
+    // must not insist on v2: if the v2 write is the one that rejects, a
+    // v2-first-then-mirror writer would throw before the legacy write ran and
+    // leave the surviving legacy credential readable through the read fallback.
+    await writeSecureValueToEitherNamespace(key, CLEARED_CREDENTIAL);
   } catch (error) {
     failures.push(error);
     throw new AuthCredentialCleanupError(`Failed to clear stored auth credential: ${key}`, failures);

--- a/packages/mobile/src/lib/auth-store.ts
+++ b/packages/mobile/src/lib/auth-store.ts
@@ -74,6 +74,13 @@ async function clearStoredCredential(key: string): Promise<void> {
       // throws (SecureStoreModule.swift:43-51). That was survivable while one
       // item existed; across two namespaces a half-completed delete would leave
       // the legacy copy for the read fallback to find. Confirm by reading.
+      //
+      // A throw from that read-back is treated as a failed attempt even though
+      // the delete may well have worked. That is the safe direction: we cannot
+      // tell "deleted" from "still there but unreadable", and retrying, then
+      // tombstoning, lands the same correct end state either way. The cost of
+      // being wrong here is one redundant tombstone write, not a session that
+      // comes back.
       if ((await readSecureValue(key)) === null) return;
     } catch (error) {
       failures.push(error);

--- a/packages/mobile/src/lib/auth-store.ts
+++ b/packages/mobile/src/lib/auth-store.ts
@@ -81,7 +81,17 @@ async function clearStoredCredential(key: string): Promise<void> {
       // tombstoning, lands the same correct end state either way. The cost of
       // being wrong here is one redundant tombstone write, not a session that
       // comes back.
-      if ((await readSecureValue(key)) === null) return;
+      //
+      // A surviving tombstone counts as cleared. It can only be there because an
+      // earlier sign-out already found deletion impossible and overwrote the
+      // credential with it, so the credential is gone and getStoredCredential
+      // already reads this as null. Treating it as "still present" would spend
+      // the second attempt re-deleting a value that is already inert and then
+      // re-write an identical tombstone — and on a device not unlocked since
+      // boot that write rejects, turning an already-correct state into an
+      // AuthCredentialCleanupError.
+      const remaining = await readSecureValue(key);
+      if (remaining === null || remaining === CLEARED_CREDENTIAL) return;
     } catch (error) {
       failures.push(error);
     }

--- a/packages/mobile/src/lib/auth-store.ts
+++ b/packages/mobile/src/lib/auth-store.ts
@@ -1,10 +1,11 @@
-import * as SecureStore from 'expo-secure-store';
-import { SECURE_STORE_WRITE_OPTIONS } from './secure-store-options';
+import { createOnceRunner, migrateSecureKeysToV2 } from './keychain-namespace-migration';
+import { deleteSecureValue, readSecureValue, writeSecureValue } from './secure-store-io';
 
-const JWT_KEY = 'boardsesh_jwt';
-const REFRESH_TOKEN_KEY = 'boardsesh_refresh_token';
-const EXPIRES_AT_KEY = 'boardsesh_token_expires_at';
+export const JWT_KEY = 'boardsesh_jwt';
+export const REFRESH_TOKEN_KEY = 'boardsesh_refresh_token';
+export const EXPIRES_AT_KEY = 'boardsesh_token_expires_at';
 const CLEARED_CREDENTIAL = '__boardsesh_auth_credential_cleared__';
+const AUTH_SECURE_KEYS = [JWT_KEY, REFRESH_TOKEN_KEY, EXPIRES_AT_KEY] as const;
 let credentialGeneration = 0;
 let credentialMutationQueue: Promise<void> = Promise.resolve();
 
@@ -18,8 +19,29 @@ class AuthCredentialCleanupError extends Error {
   }
 }
 
+// Copies the three credential keys into the v2 keychain namespace (#4103), which
+// is the only way to reset their accessibility class so a locked-device
+// background read stops failing. Serialized through the credential mutation queue
+// so it can never interleave with a sign-in or sign-out write, and driven from
+// getStoredCredential rather than a mounted component so it runs off the app's
+// first token read — before AuthProvider has decided whether to render children.
+//
+// The migration treats the CLEARED_CREDENTIAL tombstone as an opaque value and
+// carries it across unchanged: it must stay visible to getStoredCredential in v2,
+// or a signed-out user whose deletion never physically landed would read the live
+// legacy credential through the fallback and be signed back in.
+const ensureAuthCredentialsMigrated = createOnceRunner(async () => {
+  await serializeCredentialMutation(async () => {
+    await migrateSecureKeysToV2(AUTH_SECURE_KEYS, 'auth');
+  });
+});
+
 async function getStoredCredential(key: string): Promise<string | null> {
-  const storedCredential = await SecureStore.getItemAsync(key);
+  // Best-effort. A keychain that refuses the migration refuses the read below
+  // too, which is exactly today's behaviour — the migration must never change
+  // the outcome of the read it precedes.
+  await ensureAuthCredentialsMigrated().catch(() => undefined);
+  const storedCredential = await readSecureValue(key);
   return storedCredential === CLEARED_CREDENTIAL ? null : storedCredential;
 }
 
@@ -27,8 +49,15 @@ async function clearStoredCredential(key: string): Promise<void> {
   const failures: unknown[] = [];
   for (let attempt = 0; attempt < 2; attempt += 1) {
     try {
-      await SecureStore.deleteItemAsync(key);
-      return;
+      // Clears BOTH namespaces. Deleting only v2 would let the legacy copy
+      // resurface through readSecureValue's fallback on the next launch.
+      await deleteSecureValue(key);
+      // Deletion cannot be trusted from its result: expo-secure-store's iOS
+      // deleteValueWithKeyAsync discards every SecItemDelete status and never
+      // throws (SecureStoreModule.swift:43-51). That was survivable while one
+      // item existed; across two namespaces a half-completed delete would leave
+      // the legacy copy for the read fallback to find. Confirm by reading.
+      if ((await readSecureValue(key)) === null) return;
     } catch (error) {
       failures.push(error);
     }
@@ -38,7 +67,9 @@ async function clearStoredCredential(key: string): Promise<void> {
     // Some keychain failures reject deletion while still permitting an overwrite.
     // Persist a value that every getter treats as absent so credentials cannot be
     // restored on relaunch merely because physical deletion was unavailable.
-    await SecureStore.setItemAsync(key, CLEARED_CREDENTIAL, SECURE_STORE_WRITE_OPTIONS);
+    // Written to v2 (and mirrored to legacy) so it shadows any legacy credential
+    // the failed deletion left behind.
+    await writeSecureValue(key, CLEARED_CREDENTIAL);
   } catch (error) {
     failures.push(error);
     throw new AuthCredentialCleanupError(`Failed to clear stored auth credential: ${key}`, failures);
@@ -56,7 +87,7 @@ function serializeCredentialMutation<Result>(mutation: () => Promise<Result>): P
 
 async function writeCredentialForGeneration(generation: number, key: string, credential: string): Promise<boolean> {
   if (generation !== credentialGeneration) return false;
-  await SecureStore.setItemAsync(key, credential, SECURE_STORE_WRITE_OPTIONS);
+  await writeSecureValue(key, credential);
   return generation === credentialGeneration;
 }
 

--- a/packages/mobile/src/lib/auth-store.ts
+++ b/packages/mobile/src/lib/auth-store.ts
@@ -62,6 +62,30 @@ async function getStoredCredential(key: string): Promise<string | null> {
   return storedCredential === CLEARED_CREDENTIAL ? null : storedCredential;
 }
 
+/**
+ * Whether `key` now reads as absent through the exact path the getters use.
+ *
+ * This is the only definition of "cleared" in the file, and both the delete
+ * loop and the tombstone write below check against it, so neither can drift
+ * into believing something the getters disagree with. It reads through
+ * readSecureValue on purpose: what matters is not which namespace holds what,
+ * but what a subsequent getAuthToken would return, which is v2 when v2 has
+ * anything and legacy only otherwise.
+ *
+ * A surviving tombstone counts as cleared. It can only be there because an
+ * earlier sign-out already found deletion impossible and overwrote the
+ * credential with it, so the credential is gone and getStoredCredential already
+ * reads this as null.
+ *
+ * Throws are NOT caught here — a read that fails leaves us unable to tell
+ * "deleted" from "still there but unreadable", and each caller has its own
+ * (identical, conservative) answer for that: treat it as not cleared.
+ */
+async function isStoredCredentialCleared(key: string): Promise<boolean> {
+  const remaining = await readSecureValue(key);
+  return remaining === null || remaining === CLEARED_CREDENTIAL;
+}
+
 async function clearStoredCredential(key: string): Promise<void> {
   const failures: unknown[] = [];
   for (let attempt = 0; attempt < 2; attempt += 1) {
@@ -76,22 +100,17 @@ async function clearStoredCredential(key: string): Promise<void> {
       // the legacy copy for the read fallback to find. Confirm by reading.
       //
       // A throw from that read-back is treated as a failed attempt even though
-      // the delete may well have worked. That is the safe direction: we cannot
-      // tell "deleted" from "still there but unreadable", and retrying, then
-      // tombstoning, lands the same correct end state either way. The cost of
-      // being wrong here is one redundant tombstone write, not a session that
+      // the delete may well have worked. That is the safe direction: retrying,
+      // then tombstoning, lands the same correct end state either way, and the
+      // cost of being wrong is one redundant tombstone write, not a session that
       // comes back.
       //
-      // A surviving tombstone counts as cleared. It can only be there because an
-      // earlier sign-out already found deletion impossible and overwrote the
-      // credential with it, so the credential is gone and getStoredCredential
-      // already reads this as null. Treating it as "still present" would spend
-      // the second attempt re-deleting a value that is already inert and then
-      // re-write an identical tombstone — and on a device not unlocked since
-      // boot that write rejects, turning an already-correct state into an
+      // Recognising an already-present tombstone as cleared is what stops the
+      // second attempt from re-deleting a value that is already inert and then
+      // re-writing an identical tombstone — on a device not unlocked since boot
+      // that write rejects, turning an already-correct state into an
       // AuthCredentialCleanupError.
-      const remaining = await readSecureValue(key);
-      if (remaining === null || remaining === CLEARED_CREDENTIAL) return;
+      if (await isStoredCredentialCleared(key)) return;
     } catch (error) {
       failures.push(error);
     }
@@ -107,10 +126,24 @@ async function clearStoredCredential(key: string): Promise<void> {
     // v2-first-then-mirror writer would throw before the legacy write ran and
     // leave the surviving legacy credential readable through the read fallback.
     await writeSecureValueToEitherNamespace(key, CLEARED_CREDENTIAL);
+    // A landed tombstone is not the same as a cleared credential, and the gap
+    // between them is a session that survives its own sign-out. That writer is
+    // satisfied by EITHER namespace accepting, so with both namespaces live —
+    // the post-migration steady state — a rejected v2 write plus an accepted
+    // legacy one leaves the tombstone sitting behind the credential it was
+    // meant to retire, because readSecureValue consults v2 first. Returning
+    // there would report a sign-out that getAuthToken immediately contradicts.
+    //
+    // There is no stronger remedy available: nothing in JS can remove a keychain
+    // item that refuses both deletion and overwrite. Failing loudly is the
+    // remedy, and it hands the caller the same AuthCredentialCleanupError it
+    // already handles for a doubly-rejected tombstone.
+    if (await isStoredCredentialCleared(key)) return;
+    failures.push(new Error(`Stored auth credential outlived its cleanup tombstone: ${key}`));
   } catch (error) {
     failures.push(error);
-    throw new AuthCredentialCleanupError(`Failed to clear stored auth credential: ${key}`, failures);
   }
+  throw new AuthCredentialCleanupError(`Failed to clear stored auth credential: ${key}`, failures);
 }
 
 function serializeCredentialMutation<Result>(mutation: () => Promise<Result>): Promise<Result> {

--- a/packages/mobile/src/lib/i18n/locale-preference-key.ts
+++ b/packages/mobile/src/lib/i18n/locale-preference-key.ts
@@ -1,0 +1,14 @@
+// The SecureStore key for the user's explicit language choice, split out from
+// locale-preference.ts so it can be read without that module's graph.
+//
+// preference-secure-keys.ts needs this literal to decide what the #4103 keychain
+// migration covers, and locale-preference.ts reaches i18next, react-i18next and
+// the whole catalog set through ./config. Importing the key from there would
+// drag all of it — including react-native's Flow entry, which Rolldown parses at
+// collection time — into any graph that only wanted a string.
+//
+// The key uses only [\w.-] to satisfy expo-secure-store's validator (`:` and
+// other punctuation throw at the platform boundary), matching
+// THEME_OVERRIDE_KEY's constraint.
+
+export const LOCALE_OVERRIDE_KEY = 'locale_override';

--- a/packages/mobile/src/lib/i18n/locale-preference.ts
+++ b/packages/mobile/src/lib/i18n/locale-preference.ts
@@ -6,16 +6,17 @@
 //
 // Mobile-only on purpose: the web app carries locale in the URL prefix + a
 // cookie (a different shape), so this does NOT live in
-// `@boardsesh/key-value-storage`. The storage key uses only [\w.-] to satisfy
-// expo-secure-store's validator (`:` and other punctuation throw at the
-// platform boundary), matching THEME_OVERRIDE_KEY's constraint.
+// `@boardsesh/key-value-storage`. The key literal itself lives in
+// ./locale-preference-key so the migration key list can read it without pulling
+// in i18next and the catalogs through ./config.
 
 import { SUPPORTED_LOCALES, type Locale } from '@boardsesh/i18n';
 import { secureStorePreferences } from '../preferences/secure-store-adapter';
 import { SCREENSHOT_LOCALE_OVERRIDE } from '../screenshot-mode';
 import { detectDeviceLocale } from './config';
+import { LOCALE_OVERRIDE_KEY } from './locale-preference-key';
 
-export const LOCALE_OVERRIDE_KEY = 'locale_override';
+export { LOCALE_OVERRIDE_KEY };
 
 export type LocaleOverride = 'system' | Locale;
 

--- a/packages/mobile/src/lib/keychain-namespace-migration.ts
+++ b/packages/mobile/src/lib/keychain-namespace-migration.ts
@@ -81,8 +81,27 @@ async function migrateKey(key: string): Promise<SecureKeyMigrationOutcome> {
   return { key, status: 'migrated' };
 }
 
+/** True when every key in the pass reached a terminal, retry-free state. */
+export function isMigrationComplete(outcomes: readonly SecureKeyMigrationOutcome[]): boolean {
+  return outcomes.every((outcome) => SUCCESS_STATUSES.includes(outcome.status));
+}
+
+// An incomplete pass is retried on the next token read (auth) or the next
+// foreground (preferences), and on a locked background wake every one of those
+// retries fails identically. Emitting each of them would turn a single stuck
+// device into a stream of identical events, so only the first incomplete pass
+// per scope is reported. The entry is cleared when the scope completes, so a
+// later regression is still visible.
+const reportedIncompleteScopes = new Set<string>();
+
 function reportOutcomes(scope: string, outcomes: readonly SecureKeyMigrationOutcome[]): void {
   const failures = outcomes.filter((outcome) => !SUCCESS_STATUSES.includes(outcome.status));
+  if (failures.length === 0) {
+    reportedIncompleteScopes.delete(scope);
+  } else {
+    if (reportedIncompleteScopes.has(scope)) return;
+    reportedIncompleteScopes.add(scope);
+  }
   track('Keychain Namespace Migration', {
     scope,
     keys: outcomes.length,
@@ -119,13 +138,26 @@ export async function migrateSecureKeysToV2(
 }
 
 /**
- * Run `task` at most once per process, sharing the in-flight promise with
- * concurrent callers and allowing a retry after failure. Mirrors
- * metro-target-store's migration guard: `completed` flips only on success, so a
- * transient failure can't permanently skip the work, and a boolean alone would
- * let the six near-simultaneous cold-start auth readers each start a pass.
+ * Run `task` until it reports completion, at most once at a time, sharing the
+ * in-flight promise with concurrent callers.
+ *
+ * `task` resolves `true` to latch (never run again this process) and `false` to
+ * ask for a retry on the next call; a rejection also retries. The boolean is
+ * what keeps a background cold launch on a locked phone from burning the single
+ * attempt: migrateSecureKeysToV2 never rejects — a locked keychain is an
+ * expected outcome it resolves, not an error — so a void task would latch on a
+ * pass where every key came back legacy-read-failed and never retry, even after
+ * the user unlocks and foregrounds the app. Signalling that with a thrown
+ * sentinel would work too, but throwing for a normal, expected outcome is
+ * exactly the control flow a later edit "helpfully" deletes.
+ *
+ * The retry hooks are real: auth re-runs through auth-provider.tsx's AppState
+ * `active` -> checkAuth -> getAuthToken path, and preferences re-run from
+ * KeychainNamespaceMigration's own AppState listener. The shared in-flight
+ * promise is what stops the six near-simultaneous cold-start auth readers from
+ * each starting a pass.
  */
-export function createOnceRunner(task: () => Promise<void>): () => Promise<void> {
+export function createOnceRunner(task: () => Promise<boolean>): () => Promise<void> {
   let completed = false;
   let inFlight: Promise<void> | null = null;
 
@@ -133,8 +165,8 @@ export function createOnceRunner(task: () => Promise<void>): () => Promise<void>
     if (completed) return Promise.resolve();
     if (inFlight !== null) return inFlight;
     inFlight = task().then(
-      () => {
-        completed = true;
+      (didComplete: boolean) => {
+        completed = didComplete;
         inFlight = null;
       },
       (error: unknown) => {

--- a/packages/mobile/src/lib/keychain-namespace-migration.ts
+++ b/packages/mobile/src/lib/keychain-namespace-migration.ts
@@ -1,0 +1,147 @@
+// One-way copy of SecureStore values from the legacy keychain service into the v2
+// service, which is what actually resets kSecAttrAccessible to AFTER_FIRST_UNLOCK
+// for items written before #3602 shipped. Background reads on a locked device
+// (token refresh, WS reconnect, Live Activity) stop failing once a key is here.
+// See secure-store-options.ts for why rewriting in place cannot work.
+//
+// Per key: read v2 → present means done. Else read legacy → null means nothing to
+// move. Else write v2 and READ IT BACK before calling it migrated.
+//
+// Every step is safe to interrupt because nothing is destroyed. A key is either
+// legacy-only (retry next launch) or in both namespaces (v2 wins on read) —
+// never neither, so there is no window where a credential does not exist and no
+// orphan copy that could resurrect a signed-out session. Progress is recorded by
+// the v2 item itself, per key, so a partial pass simply resumes: keys that
+// aborted still have no v2 item and get retried, while keys that made it are
+// skipped by the first read. There is no marker to write, and no way for a
+// swallowed failure to mark work as done that never happened.
+//
+// The legacy copy is deliberately NOT deleted here. It is phase 1's rollback
+// path: JS that predates this change reads only the legacy namespace, so
+// deleting it would strand anyone who lands back on an older bundle between the
+// migration and their next token write. Legacy cleanup belongs to phase 2, after
+// this has soaked — a leftover legacy copy is inert while readers prefer v2.
+//
+// All calls here are RAW SecureStore on purpose: routing them through
+// secure-store-io would re-enter the auth read path that awaits this migration.
+
+import * as SecureStore from 'expo-secure-store';
+import { track } from './analytics';
+import { SECURE_STORE_V2_OPTIONS, USES_V2_NAMESPACE } from './secure-store-options';
+
+export type SecureKeyMigrationStatus =
+  | 'already-v2'
+  | 'migrated'
+  | 'absent'
+  | 'v2-read-failed'
+  | 'legacy-read-failed'
+  | 'v2-write-failed'
+  | 'verify-mismatch';
+
+export type SecureKeyMigrationOutcome = { key: string; status: SecureKeyMigrationStatus };
+
+const SUCCESS_STATUSES: readonly SecureKeyMigrationStatus[] = ['already-v2', 'migrated', 'absent'];
+
+async function migrateKey(key: string): Promise<SecureKeyMigrationOutcome> {
+  let existingV2: string | null;
+  try {
+    existingV2 = await SecureStore.getItemAsync(key, SECURE_STORE_V2_OPTIONS);
+  } catch {
+    return { key, status: 'v2-read-failed' };
+  }
+  if (existingV2 !== null) return { key, status: 'already-v2' };
+
+  let legacyValue: string | null;
+  try {
+    legacyValue = await SecureStore.getItemAsync(key);
+  } catch {
+    // The locked-device case this whole migration exists to fix. Nothing has
+    // been touched; the next foreground launch retries.
+    return { key, status: 'legacy-read-failed' };
+  }
+  if (legacyValue === null) return { key, status: 'absent' };
+
+  try {
+    await SecureStore.setItemAsync(key, legacyValue, SECURE_STORE_V2_OPTIONS);
+  } catch {
+    return { key, status: 'v2-write-failed' };
+  }
+
+  // Read back through the same namespace before reporting success. A write that
+  // reported no error but did not land would otherwise leave the key looking
+  // migrated to this pass while the next launch still reads legacy.
+  let verifiedValue: string | null;
+  try {
+    verifiedValue = await SecureStore.getItemAsync(key, SECURE_STORE_V2_OPTIONS);
+  } catch {
+    return { key, status: 'verify-mismatch' };
+  }
+  if (verifiedValue !== legacyValue) return { key, status: 'verify-mismatch' };
+
+  return { key, status: 'migrated' };
+}
+
+function reportOutcomes(scope: string, outcomes: readonly SecureKeyMigrationOutcome[]): void {
+  const failures = outcomes.filter((outcome) => !SUCCESS_STATUSES.includes(outcome.status));
+  track('Keychain Namespace Migration', {
+    scope,
+    keys: outcomes.length,
+    migrated: outcomes.filter((outcome) => outcome.status === 'migrated').length,
+    already_v2: outcomes.filter((outcome) => outcome.status === 'already-v2').length,
+    absent: outcomes.filter((outcome) => outcome.status === 'absent').length,
+    failed: failures.length,
+    // Key names only — never values. Bounded by the fixed key list, and only
+    // non-success keys appear, so a healthy pass sends an empty string.
+    failures: failures.map((outcome) => `${outcome.key}:${outcome.status}`).join(','),
+  });
+}
+
+/**
+ * Migrate the given keys into the v2 namespace. Resolves with one outcome per
+ * key; never rejects, because a per-key failure is a retry-next-launch, not an
+ * error the caller can act on. No-op off iOS.
+ */
+export async function migrateSecureKeysToV2(
+  keys: readonly string[],
+  scope: string,
+): Promise<SecureKeyMigrationOutcome[]> {
+  if (!USES_V2_NAMESPACE) return [];
+
+  const outcomes: SecureKeyMigrationOutcome[] = [];
+  // Sequential: these are keychain round-trips on a cold start, and the auth
+  // scope runs inside the credential mutation queue where ordering matters.
+  for (const key of keys) {
+    outcomes.push(await migrateKey(key));
+  }
+
+  reportOutcomes(scope, outcomes);
+  return outcomes;
+}
+
+/**
+ * Run `task` at most once per process, sharing the in-flight promise with
+ * concurrent callers and allowing a retry after failure. Mirrors
+ * metro-target-store's migration guard: `completed` flips only on success, so a
+ * transient failure can't permanently skip the work, and a boolean alone would
+ * let the six near-simultaneous cold-start auth readers each start a pass.
+ */
+export function createOnceRunner(task: () => Promise<void>): () => Promise<void> {
+  let completed = false;
+  let inFlight: Promise<void> | null = null;
+
+  return function runOnce(): Promise<void> {
+    if (completed) return Promise.resolve();
+    if (inFlight !== null) return inFlight;
+    inFlight = task().then(
+      () => {
+        completed = true;
+        inFlight = null;
+      },
+      (error: unknown) => {
+        inFlight = null;
+        throw error;
+      },
+    );
+    return inFlight;
+  };
+}

--- a/packages/mobile/src/lib/keychain-namespace-migration.ts
+++ b/packages/mobile/src/lib/keychain-namespace-migration.ts
@@ -22,17 +22,28 @@
 // migration and their next token write. Legacy cleanup belongs to phase 2, after
 // this has soaked — a leftover legacy copy is inert while readers prefer v2.
 //
-// All calls here are RAW SecureStore on purpose: routing them through
+// Nothing is destroyed, but the copy is not inert either: it is a read of legacy
+// followed by a write of that value into v2, and a store that clears or rewrites
+// the same key in between would be silently undone by the write. The auth scope
+// avoids that by running inside auth-store's credential mutation queue; the 16
+// preference keys have no such queue, so migrateKey stands down on any key this
+// process has written or deleted (secure-store-io's touched-key registry).
+//
+// The SecureStore calls here are RAW on purpose: routing them through
 // secure-store-io would re-enter the auth read path that awaits this migration.
+// The one thing imported from that module is a synchronous predicate, which
+// performs no I/O and cannot re-enter anything.
 
 import * as SecureStore from 'expo-secure-store';
 import { track } from './analytics';
 import { SECURE_STORE_V2_OPTIONS, USES_V2_NAMESPACE } from './secure-store-options';
+import { wasSecureKeyTouchedThisProcess } from './secure-store-io';
 
 export type SecureKeyMigrationStatus =
   | 'already-v2'
   | 'migrated'
   | 'absent'
+  | 'superseded'
   | 'v2-read-failed'
   | 'legacy-read-failed'
   | 'v2-write-failed'
@@ -40,7 +51,16 @@ export type SecureKeyMigrationStatus =
 
 export type SecureKeyMigrationOutcome = { key: string; status: SecureKeyMigrationStatus };
 
-const SUCCESS_STATUSES: readonly SecureKeyMigrationStatus[] = ['already-v2', 'migrated', 'absent'];
+// `superseded` sits with the successes because the app's own write already put
+// the key in v2 (writeSecureValue writes v2 first), or its delete removed the key
+// from both namespaces — either way there is nothing left for a retry to do, and
+// treating it as a failure would keep the pass permanently incomplete and hide
+// the completion signal phase 2 (#4128) gates on. The one gap is a
+// writeSecureValueToEitherNamespace whose v2 half was rejected while legacy
+// succeeded, which needs a keychain refusing v2 writes — a device that has not
+// been unlocked since boot, where the migration was going to fail anyway. The
+// next launch starts with an empty registry and picks it back up.
+const SUCCESS_STATUSES: readonly SecureKeyMigrationStatus[] = ['already-v2', 'migrated', 'absent', 'superseded'];
 
 async function migrateKey(key: string): Promise<SecureKeyMigrationOutcome> {
   let existingV2: string | null;
@@ -60,6 +80,13 @@ async function migrateKey(key: string): Promise<SecureKeyMigrationOutcome> {
     return { key, status: 'legacy-read-failed' };
   }
   if (legacyValue === null) return { key, status: 'absent' };
+
+  // Last statement before the write, and deliberately so: the app marks a key
+  // synchronously on entry to any write or delete, so a mutation that started at
+  // any point since this pass began is visible here. Writing `legacyValue` now
+  // would resurrect a preference the user just cleared, or revert one they just
+  // saved, because readSecureValue prefers the v2 copy this write would create.
+  if (wasSecureKeyTouchedThisProcess(key)) return { key, status: 'superseded' };
 
   try {
     await SecureStore.setItemAsync(key, legacyValue, SECURE_STORE_V2_OPTIONS);
@@ -108,6 +135,7 @@ function reportOutcomes(scope: string, outcomes: readonly SecureKeyMigrationOutc
     migrated: outcomes.filter((outcome) => outcome.status === 'migrated').length,
     already_v2: outcomes.filter((outcome) => outcome.status === 'already-v2').length,
     absent: outcomes.filter((outcome) => outcome.status === 'absent').length,
+    superseded: outcomes.filter((outcome) => outcome.status === 'superseded').length,
     failed: failures.length,
     // Key names only — never values. Bounded by the fixed key list, and only
     // non-success keys appear, so a healthy pass sends an empty string.

--- a/packages/mobile/src/lib/last-grade-store.ts
+++ b/packages/mobile/src/lib/last-grade-store.ts
@@ -1,5 +1,4 @@
-import * as SecureStore from 'expo-secure-store';
-import { SECURE_STORE_WRITE_OPTIONS } from './secure-store-options';
+import { readSecureValue, writeSecureValue } from './secure-store-io';
 
 // Remembers the last grade the climber actually filtered by, so the grade rail
 // can open centred on it even after the filter is cleared. Deliberately a
@@ -7,12 +6,12 @@ import { SECURE_STORE_WRITE_OPTIONS } from './secure-store-options';
 // the current board's grade band before centring, so a value from another board
 // family with a different difficulty scale just falls through to the band
 // default. Mirrors web's `lastUsedGrade` (user-preferences-db.ts) in spirit.
-const LAST_GRADE_KEY = 'boardsesh_last_used_grade';
+export const LAST_GRADE_KEY = 'boardsesh_last_used_grade';
 
 /** The last-used difficulty id, or `undefined` if none was ever stored. */
 export async function getLastUsedGradeId(): Promise<number | undefined> {
   try {
-    const value = await SecureStore.getItemAsync(LAST_GRADE_KEY);
+    const value = await readSecureValue(LAST_GRADE_KEY);
     if (!value) return undefined;
     const parsed = Number.parseInt(value, 10);
     return Number.isFinite(parsed) ? parsed : undefined;
@@ -23,7 +22,7 @@ export async function getLastUsedGradeId(): Promise<number | undefined> {
 
 export async function setLastUsedGradeId(difficultyId: number): Promise<void> {
   try {
-    await SecureStore.setItemAsync(LAST_GRADE_KEY, String(difficultyId), SECURE_STORE_WRITE_OPTIONS);
+    await writeSecureValue(LAST_GRADE_KEY, String(difficultyId));
   } catch {
     // Storage failure is non-critical.
   }

--- a/packages/mobile/src/lib/last-search-store.ts
+++ b/packages/mobile/src/lib/last-search-store.ts
@@ -1,5 +1,4 @@
-import * as SecureStore from 'expo-secure-store';
-import { SECURE_STORE_WRITE_OPTIONS } from './secure-store-options';
+import { deleteSecureValue, readSecureValue, writeSecureValue } from './secure-store-io';
 import {
   SORT_OPTIONS,
   STATUS_FILTER_VALUES,
@@ -23,7 +22,7 @@ export type LastSearch = {
 // One secure-store key holds a JSON map of boardConfigKey -> LastSearch so we
 // can remember the last applied search per board config. Capped to bound
 // growth when a user hops across many board configs.
-const LAST_SEARCH_KEY = 'boardsesh_last_search_by_board';
+export const LAST_SEARCH_KEY = 'boardsesh_last_search_by_board';
 const MAX_BOARDS = 20;
 
 type LastSearchMap = Record<string, LastSearch>;
@@ -87,7 +86,7 @@ function stripAuthGatedFields(filters: ClimbFilters): ClimbFilters {
 
 async function readMap(): Promise<LastSearchMap> {
   try {
-    const value = await SecureStore.getItemAsync(LAST_SEARCH_KEY);
+    const value = await readSecureValue(LAST_SEARCH_KEY);
     if (!value) return {};
     const parsed: unknown = JSON.parse(value);
     if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
@@ -152,14 +151,14 @@ export async function saveLastSearch(
       const map = await readMap();
       if (key in map) {
         delete map[key];
-        await SecureStore.setItemAsync(LAST_SEARCH_KEY, JSON.stringify(map), SECURE_STORE_WRITE_OPTIONS);
+        await writeSecureValue(LAST_SEARCH_KEY, JSON.stringify(map));
       }
       return;
     }
     const map = await readMap();
     map[key] = { filters, boardFilters, searchText, updatedAt: Date.now() };
     const capped = capMap(map);
-    await SecureStore.setItemAsync(LAST_SEARCH_KEY, JSON.stringify(capped), SECURE_STORE_WRITE_OPTIONS);
+    await writeSecureValue(LAST_SEARCH_KEY, JSON.stringify(capped));
   } catch {
     // Storage failure is non-critical.
   }
@@ -171,7 +170,7 @@ export async function clearLastSearch(board: BoardSearchConfig): Promise<void> {
     const key = boardConfigKey(board);
     if (!(key in map)) return;
     delete map[key];
-    await SecureStore.setItemAsync(LAST_SEARCH_KEY, JSON.stringify(map), SECURE_STORE_WRITE_OPTIONS);
+    await writeSecureValue(LAST_SEARCH_KEY, JSON.stringify(map));
   } catch {
     // Storage failure is non-critical.
   }
@@ -179,7 +178,7 @@ export async function clearLastSearch(board: BoardSearchConfig): Promise<void> {
 
 export async function clearAllLastSearches(): Promise<void> {
   try {
-    await SecureStore.deleteItemAsync(LAST_SEARCH_KEY);
+    await deleteSecureValue(LAST_SEARCH_KEY);
   } catch {
     // Storage failure is non-critical.
   }

--- a/packages/mobile/src/lib/party-profile-store.ts
+++ b/packages/mobile/src/lib/party-profile-store.ts
@@ -3,6 +3,15 @@ import { randomUUID } from 'expo-crypto';
 import type { PartyProfile, PartyProfileStorage } from '@boardsesh/party-profile';
 import { SECURE_STORE_WRITE_OPTIONS } from './secure-store-options';
 
+// Deliberately NOT migrated to the v2 keychain namespace (#4103), which is why
+// this file still writes through SECURE_STORE_WRITE_OPTIONS rather than
+// secure-store-io. A locked-device read here already fails safe: getItem throws,
+// the catch returns null, and PostHog falls back to its own anonymous id — no
+// Sentry event and no user-visible effect, so this key is not part of the
+// background-read failures #4103 fixes. Migrating it would only restore
+// analytics linkage on locked background launches, which does not justify
+// touching the identity key inside a change to credential storage. See
+// preference-secure-keys.ts.
 const PARTY_PROFILE_KEY = 'boardsesh_party_profile';
 
 export const partyProfileStorage: PartyProfileStorage = {

--- a/packages/mobile/src/lib/preference-secure-keys.ts
+++ b/packages/mobile/src/lib/preference-secure-keys.ts
@@ -16,13 +16,17 @@
 //   react-i18next and every catalog through ./config, which is a lot of module
 //   graph to load for one string.
 //
-// Nothing forces a NEW SecureStore key into this list — it is maintained by
-// hand, and preference-secure-keys.test.ts can only catch a key that is here but
-// broken, not one that was never added. Adding a key to a store means adding it
-// here too, or it stays WHEN_UNLOCKED on iOS and its background read keeps
-// failing. Phase 2 (#4128) retires the list entirely, so a completeness check
-// against every `*_KEY` export in the repo would be scaffolding with a short
-// shelf life.
+// preference-secure-keys.test.ts guards the two ways an entry here can go wrong:
+// it pins the sixteen literals so a rename shows up as a diff, and it reads this
+// file's imports and fails if any of them names a module with a `.web` sibling —
+// the fork hazard above, which no value assertion can see because Vitest and tsc
+// both resolve to the native file.
+//
+// What nothing guards is a NEW key: the list is maintained by hand, so adding a
+// SecureStore key to a store means adding it here too, or it stays WHEN_UNLOCKED
+// on iOS and its background read keeps failing. Phase 2 (#4128) retires the list
+// entirely, so a completeness check against every `*_KEY` export in the repo
+// would be scaffolding with a short shelf life.
 //
 // Two keys are deliberately absent:
 //

--- a/packages/mobile/src/lib/preference-secure-keys.ts
+++ b/packages/mobile/src/lib/preference-secure-keys.ts
@@ -16,6 +16,14 @@
 //   react-i18next and every catalog through ./config, which is a lot of module
 //   graph to load for one string.
 //
+// Nothing forces a NEW SecureStore key into this list — it is maintained by
+// hand, and preference-secure-keys.test.ts can only catch a key that is here but
+// broken, not one that was never added. Adding a key to a store means adding it
+// here too, or it stays WHEN_UNLOCKED on iOS and its background read keeps
+// failing. Phase 2 (#4128) retires the list entirely, so a completeness check
+// against every `*_KEY` export in the repo would be scaffolding with a short
+// shelf life.
+//
 // Two keys are deliberately absent:
 //
 // * boardsesh_party_profile — the analytics id, read synchronously at

--- a/packages/mobile/src/lib/preference-secure-keys.ts
+++ b/packages/mobile/src/lib/preference-secure-keys.ts
@@ -5,7 +5,16 @@
 //
 // Every literal is imported from the module that owns it rather than restated
 // here: a re-declared key is how a store silently drops out of migration
-// coverage after a rename.
+// coverage after a rename. Two of those literals live in a module of their own
+// rather than with their store, because importing them from the store would be
+// unsafe or expensive:
+//
+// * session-store-keys.ts — session-store.ts has a session-store.web.ts sibling,
+//   and Metro resolves `./session-store` to that fork on the browser target,
+//   where the keys are not exported. This list would silently get `undefined`.
+// * i18n/locale-preference-key.ts — locale-preference.ts reaches i18next,
+//   react-i18next and every catalog through ./config, which is a lot of module
+//   graph to load for one string.
 //
 // Two keys are deliberately absent:
 //
@@ -32,11 +41,11 @@ import {
   THEME_OVERRIDE_KEY,
   UI_VARIANT_KEY,
 } from '@boardsesh/key-value-storage';
-import { LOCALE_OVERRIDE_KEY } from './i18n/locale-preference';
+import { LOCALE_OVERRIDE_KEY } from './i18n/locale-preference-key';
 import { LAST_GRADE_KEY } from './last-grade-store';
 import { LAST_SEARCH_KEY } from './last-search-store';
 import { RECENT_FILTERS_KEY } from './recent-filter-store';
-import { CREATED_SESSION_ID_KEY, SESSION_ID_KEY } from './session-store';
+import { CREATED_SESSION_ID_KEY, SESSION_ID_KEY } from './session-store-keys';
 
 export const PREFERENCE_SECURE_KEYS: readonly string[] = [
   SESSION_ID_KEY,

--- a/packages/mobile/src/lib/preference-secure-keys.ts
+++ b/packages/mobile/src/lib/preference-secure-keys.ts
@@ -1,0 +1,58 @@
+// The non-credential SecureStore keys migrated into the v2 keychain namespace
+// (#4103). Kept in its own module so auth-store — loaded on the app's very first
+// token read — pulls in the migration engine without dragging every preference
+// store and the i18n config into that path.
+//
+// Every literal is imported from the module that owns it rather than restated
+// here: a re-declared key is how a store silently drops out of migration
+// coverage after a rename.
+//
+// Two keys are deliberately absent:
+//
+// * boardsesh_party_profile — the analytics id, read synchronously at
+//   module-eval time (party-profile-store.ts:38) before any migration could run,
+//   with its failure already swallowed into a null that falls back to PostHog's
+//   own anonymous id. It contributes nothing to the background-read failures
+//   this fixes; the only gain would be analytics linkage on locked background
+//   launches. Not worth widening the blast radius of a change to credential
+//   storage. Revisit in phase 2 if that linkage turns out to matter.
+//
+// * boardsesh_dev_metro_hosts — dev-only, and already read-and-deleted on its way
+//   to AsyncStorage (metro-target-store.ts:25). Nothing writes it any more.
+
+import {
+  CHANGELOG_LAST_SEEN_KEY,
+  ONBOARDING_BOARD_TIP_KEY,
+  ONBOARDING_SEEN_KEY,
+  ONBOARDING_TIP_ACCESSORY_KEY,
+  ONBOARDING_TIP_CREW_KEY,
+  ONBOARDING_TIP_QUICKACTIONS_KEY,
+  ONBOARDING_TIP_RECORD_KEY,
+  ONBOARDING_TIP_WORKOUT_KEY,
+  THEME_OVERRIDE_KEY,
+  UI_VARIANT_KEY,
+} from '@boardsesh/key-value-storage';
+import { LOCALE_OVERRIDE_KEY } from './i18n/locale-preference';
+import { LAST_GRADE_KEY } from './last-grade-store';
+import { LAST_SEARCH_KEY } from './last-search-store';
+import { RECENT_FILTERS_KEY } from './recent-filter-store';
+import { CREATED_SESSION_ID_KEY, SESSION_ID_KEY } from './session-store';
+
+export const PREFERENCE_SECURE_KEYS: readonly string[] = [
+  SESSION_ID_KEY,
+  CREATED_SESSION_ID_KEY,
+  LAST_GRADE_KEY,
+  RECENT_FILTERS_KEY,
+  LAST_SEARCH_KEY,
+  LOCALE_OVERRIDE_KEY,
+  THEME_OVERRIDE_KEY,
+  UI_VARIANT_KEY,
+  CHANGELOG_LAST_SEEN_KEY,
+  ONBOARDING_SEEN_KEY,
+  ONBOARDING_BOARD_TIP_KEY,
+  ONBOARDING_TIP_WORKOUT_KEY,
+  ONBOARDING_TIP_CREW_KEY,
+  ONBOARDING_TIP_RECORD_KEY,
+  ONBOARDING_TIP_ACCESSORY_KEY,
+  ONBOARDING_TIP_QUICKACTIONS_KEY,
+];

--- a/packages/mobile/src/lib/preferences/secure-store-adapter.ts
+++ b/packages/mobile/src/lib/preferences/secure-store-adapter.ts
@@ -5,13 +5,12 @@
 // AsyncStorage. The exception is active-board-store, which uses AsyncStorage
 // because the stored UserBoard payload can exceed SecureStore's iOS 2 KB limit.
 
-import * as SecureStore from 'expo-secure-store';
 import type { KeyValueStorage } from '@boardsesh/key-value-storage';
-import { SECURE_STORE_WRITE_OPTIONS } from '../secure-store-options';
+import { deleteSecureValue, readSecureValue, writeSecureValue } from '../secure-store-io';
 
 export const secureStorePreferences: KeyValueStorage = {
   async get<T>(key: string): Promise<T | null> {
-    const raw = await SecureStore.getItemAsync(key);
+    const raw = await readSecureValue(key);
     if (raw === null) return null;
     try {
       return JSON.parse(raw) as T;
@@ -23,9 +22,9 @@ export const secureStorePreferences: KeyValueStorage = {
     }
   },
   async set<T>(key: string, value: T): Promise<void> {
-    await SecureStore.setItemAsync(key, JSON.stringify(value), SECURE_STORE_WRITE_OPTIONS);
+    await writeSecureValue(key, JSON.stringify(value));
   },
   async remove(key: string): Promise<void> {
-    await SecureStore.deleteItemAsync(key);
+    await deleteSecureValue(key);
   },
 };

--- a/packages/mobile/src/lib/recent-filter-store.ts
+++ b/packages/mobile/src/lib/recent-filter-store.ts
@@ -1,8 +1,7 @@
-import * as SecureStore from 'expo-secure-store';
 import { SORT_OPTIONS, STATUS_FILTER_VALUES, normalizeRetiredStatus } from '@boardsesh/climb-filters';
 import type { ClimbFilters } from './climb-filter-types';
 import { getFilterKey } from './filter-key';
-import { SECURE_STORE_WRITE_OPTIONS } from './secure-store-options';
+import { deleteSecureValue, readSecureValue, writeSecureValue } from './secure-store-io';
 
 export { getFilterKey };
 
@@ -14,7 +13,7 @@ export type RecentFilter = {
   timestamp: number;
 };
 
-const RECENT_FILTERS_KEY = 'boardsesh_recent_filters';
+export const RECENT_FILTERS_KEY = 'boardsesh_recent_filters';
 const MAX_ITEMS = 10;
 
 // Fields the backend only honours for authenticated users. When loading
@@ -79,7 +78,7 @@ function stripAuthGatedFields(filters: ClimbFilters): ClimbFilters {
  */
 export async function getRecentFilters(options?: { isAuthenticated?: boolean }): Promise<RecentFilter[]> {
   try {
-    const value = await SecureStore.getItemAsync(RECENT_FILTERS_KEY);
+    const value = await readSecureValue(RECENT_FILTERS_KEY);
     if (!value) return [];
     const parsed: unknown = JSON.parse(value);
     if (!Array.isArray(parsed)) return [];
@@ -109,7 +108,7 @@ export async function addRecentFilter(label: string, filters: ClimbFilters, sear
     };
 
     const updated = [newEntry, ...deduplicated].slice(0, MAX_ITEMS);
-    await SecureStore.setItemAsync(RECENT_FILTERS_KEY, JSON.stringify(updated), SECURE_STORE_WRITE_OPTIONS);
+    await writeSecureValue(RECENT_FILTERS_KEY, JSON.stringify(updated));
   } catch {
     // Storage failure is non-critical
   }
@@ -117,7 +116,7 @@ export async function addRecentFilter(label: string, filters: ClimbFilters, sear
 
 export async function clearRecentFilters(): Promise<void> {
   try {
-    await SecureStore.deleteItemAsync(RECENT_FILTERS_KEY);
+    await deleteSecureValue(RECENT_FILTERS_KEY);
   } catch {
     // Storage failure is non-critical
   }

--- a/packages/mobile/src/lib/secure-store-io.ts
+++ b/packages/mobile/src/lib/secure-store-io.ts
@@ -18,9 +18,40 @@
 // Phase 2, once this has soaked, drops the mirror, deletes the legacy copies and
 // collapses the read back to a single call. Tracked as the follow-up issue on the
 // #4103 PR.
+//
+// Every mutation also records its key here so a migration pass running
+// concurrently can stand down — see touchedSecureKeys below.
 
 import * as SecureStore from 'expo-secure-store';
 import { SECURE_STORE_V2_OPTIONS, SECURE_STORE_WRITE_OPTIONS, USES_V2_NAMESPACE } from './secure-store-options';
+
+// Keys this process has written or deleted. The migration pass reads it to avoid
+// racing the app: migrateKey reads legacy, then writes that value into v2, and a
+// store that deletes or rewrites the same key in between would be undone by the
+// write that follows — a cleared preference reappearing, or a just-saved one
+// reverting to the legacy blob. The auth scope is immune because its pass runs
+// inside auth-store's credential mutation queue; nothing plays that role for the
+// 16 preference keys, and this set is what does instead.
+//
+// The handshake is exact, not probabilistic. Each mutation below marks its key
+// SYNCHRONOUSLY, before its first await, so the mark is in place by the time the
+// mutation's first native call is even enqueued. migrateKey checks after its last
+// await and immediately before its write. So either the app got in first and the
+// migration sees the mark and stands down, or the app started after the check —
+// in which case its native call is queued behind the migration's write on
+// expo-modules-core's serial AsyncFunction queue (AsyncFunctionDefinition.swift:20
+// creates a plain, non-concurrent DispatchQueue; :161 dispatches every async
+// module call onto it) and therefore lands last, which is the outcome we want.
+//
+// Skipping loses nothing: a key this process wrote went to v2 first, so it is
+// already migrated by construction, and a key this process deleted is gone from
+// both namespaces with nothing left to copy.
+const touchedSecureKeys = new Set<string>();
+
+/** True when this process has written or deleted `key` since launch. */
+export function wasSecureKeyTouchedThisProcess(key: string): boolean {
+  return touchedSecureKeys.has(key);
+}
 
 /** Raised when a value could not be written to any keychain namespace. */
 export class SecureStoreWriteError extends Error {
@@ -59,6 +90,7 @@ export async function readSecureValue(key: string): Promise<string | null> {
 
 /** Write to v2, then mirror into legacy for rollback safety (best-effort). */
 export async function writeSecureValue(key: string, value: string): Promise<void> {
+  touchedSecureKeys.add(key);
   await SecureStore.setItemAsync(key, value, SECURE_STORE_V2_OPTIONS);
   if (!USES_V2_NAMESPACE) return;
   try {
@@ -83,6 +115,7 @@ export async function writeSecureValue(key: string, value: string): Promise<void
  * readable through readSecureValue's fallback.
  */
 export async function writeSecureValueToEitherNamespace(key: string, value: string): Promise<void> {
+  touchedSecureKeys.add(key);
   const failures: unknown[] = [];
 
   try {
@@ -115,6 +148,7 @@ export async function writeSecureValueToEitherNamespace(key: string, value: stri
  * all, so the call is byte-for-byte today's single-namespace delete.
  */
 export async function deleteSecureValue(key: string): Promise<void> {
+  touchedSecureKeys.add(key);
   await SecureStore.deleteItemAsync(key, SECURE_STORE_V2_OPTIONS);
   if (USES_V2_NAMESPACE) await SecureStore.deleteItemAsync(key);
 }

--- a/packages/mobile/src/lib/secure-store-io.ts
+++ b/packages/mobile/src/lib/secure-store-io.ts
@@ -33,7 +33,21 @@ export class SecureStoreWriteError extends Error {
   }
 }
 
-/** Read v2, falling back to the pre-migration legacy namespace. */
+/**
+ * Read v2, falling back to the pre-migration legacy namespace.
+ *
+ * A v2 THROW propagates rather than falling through to legacy, and that is
+ * deliberate. On a locked device a v2 miss is `errSecItemNotFound` (a null, not
+ * a throw), because the item simply is not there yet — so the fallback still
+ * runs for every unmigrated key. A v2 throw means the item exists and could not
+ * be read, and swallowing that to hand back a stale legacy copy would be worse
+ * than surfacing it. It also keeps auth-store's contract intact: a throw becomes
+ * `unavailable` in auth-session.ts, a null becomes a real sign-out (#4001).
+ *
+ * Only `keychainService` distinguishes the namespaces on a lookup;
+ * `keychainAccessible` rides along in the shared options constant and is ignored
+ * on read and delete (it is applied at insert time — see secure-store-options).
+ */
 export async function readSecureValue(key: string): Promise<string | null> {
   const v2Value = await SecureStore.getItemAsync(key, SECURE_STORE_V2_OPTIONS);
   // A v2 hit ends the read: it is both the current value and the proof this key
@@ -93,7 +107,13 @@ export async function writeSecureValueToEitherNamespace(key: string, value: stri
   if (failures.length === 2) throw new SecureStoreWriteError(key, failures);
 }
 
-/** Delete from both namespaces so a cleared value cannot resurface via fallback. */
+/**
+ * Delete from both namespaces so a cleared value cannot resurface via fallback.
+ *
+ * Passes the same options constant the writes use: only `keychainService`
+ * selects which item to delete, and off iOS that constant carries no service at
+ * all, so the call is byte-for-byte today's single-namespace delete.
+ */
 export async function deleteSecureValue(key: string): Promise<void> {
   await SecureStore.deleteItemAsync(key, SECURE_STORE_V2_OPTIONS);
   if (USES_V2_NAMESPACE) await SecureStore.deleteItemAsync(key);

--- a/packages/mobile/src/lib/secure-store-io.ts
+++ b/packages/mobile/src/lib/secure-store-io.ts
@@ -1,11 +1,13 @@
 // Namespace-aware SecureStore access. Every non-excluded SecureStore key in the
-// app goes through these three helpers so the v2 migration (#4103) has exactly
-// one read path, one write path, and one delete path to reason about.
+// app goes through these helpers so the v2 migration (#4103) has exactly one
+// read path and one delete path to reason about, and two write paths that
+// differ only in how hard they insist on the v2 namespace.
 //
 // Phase 1 (this release) runs both namespaces at once:
-//   read   — v2 first, legacy as fallback
-//   write  — v2, then mirror to legacy best-effort
-//   delete — both, so nothing outlives a clear
+//   read           — v2 first, legacy as fallback
+//   write          — v2 (authoritative), then mirror to legacy best-effort
+//   write-to-either — v2 and legacy independently; fails only if both reject
+//   delete         — both, so nothing outlives a clear
 //
 // The mirror is what makes an OTA rollback safe: JS that predates this change
 // only knows the legacy namespace, and would sign a user out if their current
@@ -19,6 +21,17 @@
 
 import * as SecureStore from 'expo-secure-store';
 import { SECURE_STORE_V2_OPTIONS, SECURE_STORE_WRITE_OPTIONS, USES_V2_NAMESPACE } from './secure-store-options';
+
+/** Raised when a value could not be written to any keychain namespace. */
+export class SecureStoreWriteError extends Error {
+  readonly failures: readonly unknown[];
+
+  constructor(key: string, failures: readonly unknown[]) {
+    super(`Failed to write SecureStore key to any namespace: ${key}`);
+    this.name = 'SecureStoreWriteError';
+    this.failures = failures;
+  }
+}
 
 /** Read v2, falling back to the pre-migration legacy namespace. */
 export async function readSecureValue(key: string): Promise<string | null> {
@@ -40,6 +53,44 @@ export async function writeSecureValue(key: string, value: string): Promise<void
     // Rollback insurance only. The authoritative v2 write already landed, and a
     // stale legacy copy is harmless while readSecureValue prefers v2.
   }
+}
+
+/**
+ * Write to whichever namespace will accept the value, failing only when BOTH
+ * reject.
+ *
+ * Deliberately weaker than writeSecureValue, which must fail loudly when the
+ * authoritative v2 write fails because writeCredentialForGeneration returns a
+ * boolean the sign-in flow trusts. This writer exists for the sign-out
+ * tombstone, where the goal is the opposite: the tombstone shadows a credential
+ * that physical deletion could not remove, so landing it in EITHER namespace is
+ * strictly better than landing it in neither. Requiring v2 there would let a
+ * rejected v2 write skip the legacy mirror and leave the original credential
+ * readable through readSecureValue's fallback.
+ */
+export async function writeSecureValueToEitherNamespace(key: string, value: string): Promise<void> {
+  const failures: unknown[] = [];
+
+  try {
+    await SecureStore.setItemAsync(key, value, SECURE_STORE_V2_OPTIONS);
+  } catch (error) {
+    failures.push(error);
+  }
+
+  if (!USES_V2_NAMESPACE) {
+    if (failures.length > 0) throw new SecureStoreWriteError(key, failures);
+    return;
+  }
+
+  try {
+    await SecureStore.setItemAsync(key, value, SECURE_STORE_WRITE_OPTIONS);
+  } catch (error) {
+    failures.push(error);
+  }
+
+  // One landed write is enough: readSecureValue consults v2 first and legacy
+  // second, so either copy is reachable.
+  if (failures.length === 2) throw new SecureStoreWriteError(key, failures);
 }
 
 /** Delete from both namespaces so a cleared value cannot resurface via fallback. */

--- a/packages/mobile/src/lib/secure-store-io.ts
+++ b/packages/mobile/src/lib/secure-store-io.ts
@@ -1,0 +1,49 @@
+// Namespace-aware SecureStore access. Every non-excluded SecureStore key in the
+// app goes through these three helpers so the v2 migration (#4103) has exactly
+// one read path, one write path, and one delete path to reason about.
+//
+// Phase 1 (this release) runs both namespaces at once:
+//   read   — v2 first, legacy as fallback
+//   write  — v2, then mirror to legacy best-effort
+//   delete — both, so nothing outlives a clear
+//
+// The mirror is what makes an OTA rollback safe: JS that predates this change
+// only knows the legacy namespace, and would sign a user out if their current
+// token existed solely in v2. It is deliberately best-effort — mirroring into a
+// legacy item that is still WHEN_UNLOCKED throws on a locked device, and that
+// must never fail the real (v2) write which just succeeded.
+//
+// Phase 2, once this has soaked, drops the mirror, deletes the legacy copies and
+// collapses the read back to a single call. Tracked as the follow-up issue on the
+// #4103 PR.
+
+import * as SecureStore from 'expo-secure-store';
+import { SECURE_STORE_V2_OPTIONS, SECURE_STORE_WRITE_OPTIONS, USES_V2_NAMESPACE } from './secure-store-options';
+
+/** Read v2, falling back to the pre-migration legacy namespace. */
+export async function readSecureValue(key: string): Promise<string | null> {
+  const v2Value = await SecureStore.getItemAsync(key, SECURE_STORE_V2_OPTIONS);
+  // A v2 hit ends the read: it is both the current value and the proof this key
+  // already migrated, so the legacy copy is never consulted again. That is the
+  // whole fix — the legacy read is the one that rejects on a locked device.
+  if (v2Value !== null || !USES_V2_NAMESPACE) return v2Value;
+  return SecureStore.getItemAsync(key);
+}
+
+/** Write to v2, then mirror into legacy for rollback safety (best-effort). */
+export async function writeSecureValue(key: string, value: string): Promise<void> {
+  await SecureStore.setItemAsync(key, value, SECURE_STORE_V2_OPTIONS);
+  if (!USES_V2_NAMESPACE) return;
+  try {
+    await SecureStore.setItemAsync(key, value, SECURE_STORE_WRITE_OPTIONS);
+  } catch {
+    // Rollback insurance only. The authoritative v2 write already landed, and a
+    // stale legacy copy is harmless while readSecureValue prefers v2.
+  }
+}
+
+/** Delete from both namespaces so a cleared value cannot resurface via fallback. */
+export async function deleteSecureValue(key: string): Promise<void> {
+  await SecureStore.deleteItemAsync(key, SECURE_STORE_V2_OPTIONS);
+  if (USES_V2_NAMESPACE) await SecureStore.deleteItemAsync(key);
+}

--- a/packages/mobile/src/lib/secure-store-options.ts
+++ b/packages/mobile/src/lib/secure-store-options.ts
@@ -16,4 +16,42 @@ import * as SecureStore from 'expo-secure-store';
 // exports it.
 const keychainAccessible = 'AFTER_FIRST_UNLOCK' in SecureStore ? SecureStore.AFTER_FIRST_UNLOCK : undefined;
 
+// Legacy namespace: the default keychain service ("app"). Items written here
+// before #3602 shipped carry kSecAttrAccessibleWhenUnlocked and CANNOT be
+// upgraded in place — expo-secure-store's iOS set() only reaches SecItemAdd for an
+// item that doesn't exist yet; an existing item takes the errSecDuplicateItem
+// branch into update(), whose update dictionary is kSecValueData ONLY
+// (SecureStoreModule.swift:127-144). Accessibility is left untouched, and JS
+// cannot read kSecAttrAccessible back to notice. Delete-then-add is no better:
+// deleteValueWithKeyAsync discards all three SecItemDelete statuses and never
+// throws, so a failed delete silently degrades the re-add into that same no-op
+// update, and the read-back sees the right value either way. See issue #4103.
 export const SECURE_STORE_WRITE_OPTIONS: SecureStore.SecureStoreOptions = { keychainAccessible };
+
+// v2 namespace: a keychain service we have never used, so every write into it is a
+// guaranteed-fresh SecItemAdd that applies kSecAttrAccessible at
+// SecureStoreModule.swift:98. Copying a value here is what actually resets
+// accessibility, and the presence of a v2 item IS the durable per-key record that
+// the key has migrated — nothing to keep in sync, and it stays true after a
+// restore onto a new device (AFTER_FIRST_UNLOCK items travel in encrypted
+// backups, so a version marker would arrive claiming work that never happened).
+export const V2_KEYCHAIN_SERVICE = 'boardsesh.v2';
+
+// iOS ONLY. On Android keychainService selects both the KeyStore alias and the
+// SharedPreferences storage key (SecureStoreOptions.kt:12, SecureStoreModule.kt:92,
+// 102, 179), so setting it would strand every existing Android value behind a name
+// nothing reads. Android's KeyStore has no accessibility class to fix in the first
+// place, and the web shim ignores options entirely — on both platforms these
+// helpers stay byte-for-byte today's behaviour.
+//
+// Read from process.env.EXPO_OS, which babel-preset-expo replaces with the build
+// platform (configs/expo.js:214), rather than react-native's Platform: every
+// SecureStore-backed store imports this module, and a static `react-native`
+// import would drag RN 0.86's Flow entry into their pure test graphs, where
+// Rolldown parses it at collection time before any vi.mock applies. That trap is
+// documented at packages/mobile/vite.config.ts:284-298.
+export const USES_V2_NAMESPACE = process.env.EXPO_OS === 'ios';
+
+export const SECURE_STORE_V2_OPTIONS: SecureStore.SecureStoreOptions = USES_V2_NAMESPACE
+  ? { keychainAccessible, keychainService: V2_KEYCHAIN_SERVICE }
+  : { keychainAccessible };

--- a/packages/mobile/src/lib/session-store-keys.ts
+++ b/packages/mobile/src/lib/session-store-keys.ts
@@ -1,0 +1,16 @@
+// The SecureStore key names for the party-session ids, owned here rather than by
+// either session-store fork.
+//
+// session-store.ts has a session-store.web.ts sibling, and Metro resolves
+// `./session-store` to whichever fork matches the build target. A key declared
+// inside one fork is therefore invisible to the other — and to
+// preference-secure-keys.ts, which imports these names to decide what the #4103
+// keychain migration covers. Importing them through a forked module silently
+// yields `undefined` on the target whose fork does not export them, punching
+// holes in the migration list that neither tsc nor the native bundle can see.
+//
+// Both forks and the migration key list read from here so that cannot happen.
+
+export const SESSION_ID_KEY = 'boardsesh_active_session_id';
+
+export const CREATED_SESSION_ID_KEY = 'boardsesh_created_session_id';

--- a/packages/mobile/src/lib/session-store.ts
+++ b/packages/mobile/src/lib/session-store.ts
@@ -1,7 +1,6 @@
 import { deleteSecureValue, readSecureValue, writeSecureValue } from './secure-store-io';
+import { CREATED_SESSION_ID_KEY, SESSION_ID_KEY } from './session-store-keys';
 import type { UserStorageOwner } from './user-storage-owner';
-
-export const SESSION_ID_KEY = 'boardsesh_active_session_id';
 
 export async function getStoredSessionId(_owner?: UserStorageOwner | null): Promise<string | null> {
   try {
@@ -47,8 +46,6 @@ export async function clearStoredSessionId(_owner?: UserStorageOwner | null): Pr
  * leading with Leave, and End is still one tap away. A signal that degrades
  * toward offering the destructive action would be worse than no signal at all.
  */
-export const CREATED_SESSION_ID_KEY = 'boardsesh_created_session_id';
-
 export async function getStoredCreatedSessionId(): Promise<string | null> {
   try {
     return await readSecureValue(CREATED_SESSION_ID_KEY);

--- a/packages/mobile/src/lib/session-store.ts
+++ b/packages/mobile/src/lib/session-store.ts
@@ -1,23 +1,22 @@
-import * as SecureStore from 'expo-secure-store';
-import { SECURE_STORE_WRITE_OPTIONS } from './secure-store-options';
+import { deleteSecureValue, readSecureValue, writeSecureValue } from './secure-store-io';
 import type { UserStorageOwner } from './user-storage-owner';
 
-const SESSION_ID_KEY = 'boardsesh_active_session_id';
+export const SESSION_ID_KEY = 'boardsesh_active_session_id';
 
 export async function getStoredSessionId(_owner?: UserStorageOwner | null): Promise<string | null> {
   try {
-    return await SecureStore.getItemAsync(SESSION_ID_KEY);
+    return await readSecureValue(SESSION_ID_KEY);
   } catch {
     return null;
   }
 }
 
 export async function setStoredSessionId(sessionId: string, _owner?: UserStorageOwner | null): Promise<void> {
-  await SecureStore.setItemAsync(SESSION_ID_KEY, sessionId, SECURE_STORE_WRITE_OPTIONS);
+  await writeSecureValue(SESSION_ID_KEY, sessionId);
 }
 
 export async function clearStoredSessionId(_owner?: UserStorageOwner | null): Promise<void> {
-  await SecureStore.deleteItemAsync(SESSION_ID_KEY);
+  await deleteSecureValue(SESSION_ID_KEY);
 }
 
 /**
@@ -48,20 +47,20 @@ export async function clearStoredSessionId(_owner?: UserStorageOwner | null): Pr
  * leading with Leave, and End is still one tap away. A signal that degrades
  * toward offering the destructive action would be worse than no signal at all.
  */
-const CREATED_SESSION_ID_KEY = 'boardsesh_created_session_id';
+export const CREATED_SESSION_ID_KEY = 'boardsesh_created_session_id';
 
 export async function getStoredCreatedSessionId(): Promise<string | null> {
   try {
-    return await SecureStore.getItemAsync(CREATED_SESSION_ID_KEY);
+    return await readSecureValue(CREATED_SESSION_ID_KEY);
   } catch {
     return null;
   }
 }
 
 export async function setStoredCreatedSessionId(sessionId: string): Promise<void> {
-  await SecureStore.setItemAsync(CREATED_SESSION_ID_KEY, sessionId, SECURE_STORE_WRITE_OPTIONS);
+  await writeSecureValue(CREATED_SESSION_ID_KEY, sessionId);
 }
 
 export async function clearStoredCreatedSessionId(): Promise<void> {
-  await SecureStore.deleteItemAsync(CREATED_SESSION_ID_KEY);
+  await deleteSecureValue(CREATED_SESSION_ID_KEY);
 }

--- a/packages/mobile/src/lib/session-store.web.ts
+++ b/packages/mobile/src/lib/session-store.web.ts
@@ -1,9 +1,8 @@
 import * as SecureStore from 'expo-secure-store';
 import { SECURE_STORE_WRITE_OPTIONS } from './secure-store-options';
+import { CREATED_SESSION_ID_KEY, SESSION_ID_KEY } from './session-store-keys';
 import { userScopedStorageKey } from './user-storage-owner.web';
 import type { UserStorageOwner } from './user-storage-owner';
-
-const SESSION_ID_KEY = 'boardsesh_active_session_id';
 
 export async function getStoredSessionId(owner?: UserStorageOwner | null): Promise<string | null> {
   const storageKey = userScopedStorageKey(SESSION_ID_KEY, owner);
@@ -34,8 +33,6 @@ export function clearStoredSessionId(owner?: UserStorageOwner | null): Promise<v
  * harmless). Scoped per signed-in user like the active-session keys above,
  * via the current owner set by setCurrentUserStorageOwner.
  */
-const CREATED_SESSION_ID_KEY = 'boardsesh_created_session_id';
-
 export async function getStoredCreatedSessionId(): Promise<string | null> {
   const storageKey = userScopedStorageKey(CREATED_SESSION_ID_KEY);
   if (!storageKey) return null;


### PR DESCRIPTION
## Summary

Fixes a bug where users signing in before mid-July could get stuck in a permanent sign-out loop: iOS credentials written under the old `WHEN_UNLOCKED` keychain accessibility class fail to read when the app wakes in the background on a locked phone, and the failed read prevents the very refresh that would have fixed the item. Since updating an existing keychain item on iOS never re-applies the accessibility attribute, the fix migrates the 19 affected keys (3 auth, 16 preference) to a brand-new keychain service, `boardsesh.v2`, where every write is a fresh `SecItemAdd` that gets the correct attribute. Readers check v2 first and fall back to legacy, writers write v2 and mirror to legacy, and nothing is deleted from the old namespace yet (that cleanup is deferred to a follow-up, #4128), so the change is non-destructive and safe to roll back. Sign-out is verified rather than assumed: it now re-reads through the same path the getters use and fails loudly if a credential outlives its tombstone. It is JS-only and ships over the air with no native fingerprint change.

Author-side verification on this round: `vp check` (0 errors), `vp run typecheck:mobile`, `vp run test:mobile` (866 files / 9413 tests), `vp run check:mobile-bundle` — all green on the rebased branch. Not device-verified; see the note at the end of Automated coverage.

---

Closes #4103

## Why the #3602 fix never took

`keychainAccessible` is applied when an item is **created**. On iOS, `setItemAsync` on a key that already exists returns `errSecDuplicateItem` and falls through to `update()`, whose update dictionary is `kSecValueData` only — `kSecAttrAccessible` is never sent, so the item keeps whatever class it was born with:

```swift
// expo-secure-store SecureStoreModule.swift:127-144
let updateDictionary = [kSecValueData as String: valueData]
let status = SecItemUpdate(query as CFDictionary, updateDictionary as CFDictionary)
```

Every credential written before 01bb11a9e is therefore still `WHEN_UNLOCKED`, and per item the failure is self-sustaining: the background read fails → the refresh that would rewrite the token never runs → the item is never rewritten. #3602 could only change how *new* items are born, so an affected device stays affected until it reinstalls.

The obvious repair — read it back and write it again — is a no-op for exactly this reason. Delete-then-add is worse, because it can't be verified from JS: `deleteValueWithKeyAsync` (`SecureStoreModule.swift:43-51`) discards all three `SecItemDelete` statuses and never throws, so a silently failed delete degrades the re-add straight back into that same no-op `update()`, and the read-back looks identical either way. It would have reported success and changed nothing.

## What this does instead

Copy values into a keychain **service** we have never used, `boardsesh.v2`. A write there is a guaranteed-fresh `SecItemAdd`, which is the one path that applies `kSecAttrAccessible` (`SecureStoreModule.swift:98`).

Per key: read v2 → present means done. Else read legacy → null means nothing to move. Else write v2 and **read it back** before calling it migrated.

The presence of the v2 item *is* the completion record — per key, durable, nothing to keep in sync. A partial pass resumes by itself: keys that aborted still have no v2 item, keys that landed are skipped by the first read. It also stays honest after a restore onto a new device, where a version marker would arrive claiming work that never happened (`AFTER_FIRST_UNLOCK` items travel in encrypted backups).

Nothing is ever destroyed, so every interruption leaves a key either legacy-only (retry later) or in both namespaces (v2 wins on read) — never neither, and with no orphan copy that could resurrect a signed-out session.

**Phase 1 (this PR).** Readers try v2 then legacy; writers write v2 and mirror to legacy best-effort; the auth keys migrate from `auth-store`'s own first read (inside the credential mutation queue, so it can't interleave with a sign-in or sign-out), and the other 16 from a root component. **Phase 2**, after this soaks: drop the mirror, delete the legacy copies, collapse the readers. Filed as #4128.

### One deliberate deviation from the agreed design

The adopted design said to delete the legacy copy after verifying the v2 write. **I did not**, because it contradicts phase 1's other stated requirement — rollback safety. JS that predates this change reads only the legacy namespace, so deleting the legacy copy would sign out anyone who lands back on an older bundle between the migration and their next token write. The verdict's own note that "legacy copy remaining is harmless — v2 wins on read" makes skipping it safe, and phase 2 already owns legacy cleanup. Flagging it explicitly rather than quietly choosing.

### Also fixed while in here

Sign-out now clears **both** namespaces and confirms the result by reading, instead of trusting a delete that cannot report failure. With two namespaces a half-completed delete is newly possible, and without the check the surviving legacy copy would be reachable through the read fallback. The tombstone is written to v2 and to legacy, so a credential that survives deletion is overwritten rather than merely shadowed.

## This ships over the air

**JS-only. No native fingerprint change.** Every file here is TS/TSX under `packages/mobile/src` and `packages/mobile/app`. Nothing touches `app.config.ts`, `plugins/`, `modules/`, `patches/`, or any dependency.

The one thing that looks like it might be native isn't: `boardsesh.v2` is a **runtime argument**, not native configuration. It is a plain TS string constant (`secure-store-options.ts`) handed to `SecureStore.setItemAsync` as `options.keychainService` on each call, which expo-secure-store turns into a `kSecAttrService` value inside `query()` at call time. There is no Info.plist entry, no entitlement, no keychain-sharing group and no build setting behind it — a keychain service is just a string attribute on the item, so a new one costs nothing at the native layer. (The app-group keychain in `modules/live-activity/ios/SharedKeychain.swift` *is* native config, and this PR does not touch it — see Scope.)

Confirmed, not assumed: the `mobile-ota-check` gate on commit `615eacc` reports **✅ Ships over-the-air**, iOS fingerprint `183bcf484292` and Android `a6f256fdaf25`, both matching `main`.

## Changes in this round

**Sign-out could report success while the session survived.** This was the last open P1 on the PR, and the review thread is now answered and resolved. `writeSecureValueToEitherNamespace` is satisfied by *either* namespace accepting the tombstone — correct for the write itself, wrong as the caller's verdict. In the post-migration steady state, where both namespaces are live, a v2 item that refuses deletion **and** refuses the tombstone write, next to a writable legacy item, left the tombstone in legacy while `readSecureValue` went on preferring the live v2 credential. `clearStoredCredential` returned success; the next `getAuthToken()` handed back the token.

`clearStoredCredential` now re-reads through the same path the getters use and raises `AuthCredentialCleanupError` unless the key reads as absent. The delete loop's existing check was extracted as `isStoredCredentialCleared` and both call sites share it, so "cleared" has exactly one definition here and it is the getters' own.

Nothing in JS can remove a keychain item that refuses both deletion and overwrite, so failing loudly is the whole remedy — and it hands the caller the same error it already handles for a doubly-rejected tombstone.

**The guard was confirmed red first.** The only tombstone test before this seeded legacy alone, i.e. the *pre*-migration state. The new one seeds **both** namespaces, makes v2 undeletable and fails the v2 write. Before the fix `clearTokens()` resolved while `getAuthToken()` resolved `v2-jwt`; after it, `clearTokens()` rejects with `AuthCredentialCleanupError`.

Requiring a legacy tombstone as well was considered and rejected. Legacy items are `WHEN_UNLOCKED`, so that write rejects on **every** locked device — demanding it would fail sign-out for the exact population this PR exists to unblock, in exchange for a case that also needs legacy deletion to have silently failed *and* the user to land back on pre-#4103 JS before their next write. On this build that state already reads as absent. Phase 2 (#4128) deletes the legacy copies and retires the window.

**Rebased onto current `main` (`545f6905d`)** — clean, no conflicts, only `app/_layout.tsx` overlapped. Re-derived the migration list from the writers instead of trusting it: the 16 preference keys still account for every production `SecureStore` writer that routes through `secure-store-io` (10 from `@boardsesh/key-value-storage`, 6 store-owned), and the only raw callers remain the two documented exclusions plus the web fork. No drift.

### Previous round: rebase + defect re-verification

Rebased onto `main` (`f45406284`) — clean, and no semantic drift: nothing in the 50 intervening commits touched `secure-store-*`, `session-store*`, `auth-store`, or `preference-secure-keys`, and the set of files making raw `SecureStore` calls was unchanged. Re-ran the OTA gate against that fresh base rather than trusting the four-day-old verdict, since a stale base is the usual cause of a false "native change".

Re-verified the three defects from the last round are actually in the diff, since the run that was meant to confirm them died mid-pass:

1. **Tombstone** — `clearStoredCredential` (`auth-store.ts:99`) calls `writeSecureValueToEitherNamespace`, which attempts v2 and legacy independently and throws only when both reject. `writeSecureValue` keeps its v2-must-succeed semantics for the sign-in path. ✅
2. **Migration latch** — `createOnceRunner` takes a `() => Promise<boolean>` and assigns `completed = didComplete`, so a pass where every key came back `legacy-read-failed` does not latch. Both call sites wrap their pass in `isMigrationComplete`, and `KeychainNamespaceMigration` has its own AppState `active` listener. ✅
3. **`.web` fork drift** — `preference-secure-keys.ts` imports the two session keys from `./session-store-keys`, a fork-free module that `session-store.ts` and `session-store.web.ts` both read from. No import in that file resolves through a module with a `.web` sibling, and the structural test enforces it. ✅
4. **`verify-mismatch`** — covered at `keychain-namespace-migration.test.ts:204`. ✅

Two more things came out of this round's review, both taken:

**The non-iOS path had no test coverage.** Every existing suite pins `EXPO_OS = 'ios'`, so nothing guarded the property the whole design rests on — that Android and expo-web keep byte-for-byte their pre-PR behaviour. That matters more than "one redundant call": on Android `keychainService` selects both the KeyStore alias and the SharedPreferences storage key (`SecureStoreOptions.kt:12`, `SecureStoreModule.kt:92, 102, 179`), so a v2 service reaching Android would strand every existing value behind a name nothing reads. New `secure-store-non-ios.test.ts` (8 tests) sets `EXPO_OS = 'android'` and asserts one SecureStore call per read, write and delete against the default service with no `keychainService` attribute, plus a migration pass that makes no keychain calls and emits no analytics event. Deleting the `if (!USES_V2_NAMESPACE) return;` gate in `writeSecureValue` fails it.

**A repeat sign-out could fail on an already-correct state.** The review flagged a double sign-out as wasteful-but-not-a-bug; the described trigger doesn't actually fire (on a healthy keychain no tombstone is ever written — the delete works, the read-back returns `null`, and the first attempt returns), but following it through found something real. The tombstone only exists where deletion already failed once, and there the loop always exhausted both attempts and then re-wrote it. If the phone also hasn't been unlocked since boot that write rejects, so `clearTokens` raised `AuthCredentialCleanupError` for a credential that was already gone — overwritten by the tombstone, and already read as `null` by `getStoredCredential`. A false cleanup failure on exactly the locked-device population this PR is about. `clearStoredCredential` now treats a surviving tombstone as cleared; the attempt-0 delete still runs, so nothing stops trying to physically remove the item.

## Earlier rounds of review

**Round 1.** The sign-out tombstone could land in neither namespace (fixed, above); `verify-mismatch` had no test (fixed — the fake gained a hook that lets a write report success while nothing lands, the only physical shape that failure can take).

**Found while fixing those, not raised by review.** The once-runner latched on a totally failed pass: `migrateSecureKeysToV2` never rejects — a locked keychain is an outcome it resolves, not an error — so the runner set `completed = true` even when every key failed. That is precisely the shape of the events we're seeing (every BOARDSESH-C3 event carries `in_foreground: false`, i.e. a process cold-launched in the background on a locked phone), so it would have given up before the user ever unlocked. Auth now retries through auth-provider's existing AppState `active` → `checkAuth` → `getAuthToken` path, and the 16 preference keys retry from the component's own listener. Incomplete passes report to PostHog once per scope per process so a stuck device can't stream identical events.

Also found: the migration key list could silently lose a key to a platform fork (the `.web` drift above), which is why `session-store-keys.ts` exists.

**Round 2** was four fair reads of under-commented code — the v2-throw-does-not-fall-back contract, the write-time option passed to `deleteItemAsync`, the tombstone written when a delete's read-back throws, and the absence of a compile-time completeness guard. All four are deliberate; all four are now documented at the source. Comment-only commit.

**Round 3** came back ready with two minor findings, both fixed:

- The preference pass could undo a preference the user had just changed. `migrateKey` reads legacy, then writes that value into v2, and `readSecureValue` prefers v2 — so a store that clears or rewrites the same key inside that window gets silently reverted. `secure-store-io` now keeps a set of keys this process has written or deleted; every writer and the deleter mark their key **synchronously, before their first await**, and `migrateKey` checks it as the **last statement before its write**. That ordering closes the window rather than narrowing it, and standing down loses nothing (new `superseded` outcome).
- The fork-hazard test could not fail for the fork hazard — every assertion inspected values, and no value assertion can see a `.web.ts` fork, because Vitest and tsc both resolve to the native file. The guard is now structural: it reads `preference-secure-keys.ts`, extracts its relative import specifiers, and fails if any names a module with a `.web` sibling.

**Round 4** raised no blockers beyond the device gate, plus two phase-2 simplification notes. One was a misread: `deleteSecureValue` does not make two identical calls on Android, because the second delete is behind `if (USES_V2_NAMESPACE)` and `process.env.EXPO_OS` is inlined by babel-preset-expo, so the call is dead-stripped off iOS. The other (an inert `keychainAccessible` on reads) is correct and deliberate — one shared options constant rather than four, and phase 2 collapses both.

## Scope

19 keys migrate — 3 auth, 16 preference. Two are deliberately excluded, both with a comment at the source:

- **`boardsesh_party_profile`** — the analytics id, read synchronously at module-eval time before any migration can run (and now written there too, via `getOrCreatePartyProfileIdSync`), with its failure already swallowed into a null that falls back to PostHog's own anonymous id. It produces no Sentry events and no user-visible effect, so the only gain would be analytics linkage on locked background launches — not worth touching the identity key inside a change to credential storage.
- **`boardsesh_dev_metro_hosts`** — dev-only, already read-and-deleted on its way to AsyncStorage. Nothing writes it any more.

**`modules/live-activity/ios/SharedKeychain.swift` needs no migration** and is not touched here. It is a separate app-group keychain (`group.com.boardsesh.app`, `bs_auth_token`) that expo-secure-store cannot see, and it already writes `AfterFirstUnlockThisDeviceOnly` (`SharedKeychain.swift:76`). Noting it so this doesn't get re-opened.

## Note for @marcodejongh — the endgame

The clean fix is one line of native: make expo-secure-store's `update()` carry `kSecAttrAccessible`, which is exactly what our own `SharedKeychain.set` already does (`SharedKeychain.swift:74-80`). That would fix every item atomically through a plain `setItemAsync` and let us delete all of this compat code. It needs a `patches/**` entry, which *is* a fingerprint input (native train, plus the guard for Bun patches silently dropping on a version bump) — so it's the next-train endgame, not the OTA fix. Worth doing to retire phase 2 entirely.

## Verification — watch BOARDSESH-C3, not 7P

Figures below are the issue's 2026-09-08 measurement.

**BOARDSESH-7P cannot receive this OTA.** Its remaining traffic sits on native fingerprints this update physically cannot reach: 51 events over 30 days across `49a581a4…` (2.2.2+3, 37), `b9e3e1b9…` (2.1.0+3, 12) and `08f1cf33…` (2.2.0+7, 2); 7 events / 7 users over the last 7 days. Production OTAs publish per-fingerprint, so those users only get this when they take an App Store binary update. An earlier version of this PR body claimed 7P's user count should decay; that was wrong, and this corrects it.

**BOARDSESH-C3 is the group to watch.** Same error (`KeyChainException: User interaction is not allowed.` at `SecureStoreModule.swift:168`). **883 events across 484 unique users over 30 days**, and **208 events / 140 users over the last 7**. The bulk sits on the current store build, which already carries the #3602 fix and whose fingerprint matches this branch. That is the population this reaches, and its rate is what should fall.

**Not purely an auth-session failure.** Of the 883 events, 831 are `source: auth-session` / `auth_stage: token-read`, but 32 are `source: offline-sync` `kind: cycle` (~28 users) and 16 are `source: react-query` `kind: query` (~15 users). Those **~47 users** had sync and query work already in flight that died on a mid-flight keychain read.

**Two framings retired.** The "183 → 283 users after #3602 shipped" comparison is gone: it summed per-release unique-user buckets and double-counted anyone who upgraded mid-window. And this does drain on its own — the same 7-day window measured 235 events / 175 users on 2026-08-14 against 208 / 140 now, roughly a 20% fall in affected users over 3.5 weeks, because a fresh install writes via `SecItemAdd` and ordinary fleet churn retires affected devices. It drains slowly, without a fix; it is not frozen. Quote 484 users/30d rather than a percentage — the MAU denominator is unverified.

**PostHog `Keychain Namespace Migration`** — fired after a pass, carrying per-key outcomes (`migrated` / `already-v2` / `absent` / `superseded` / the abort reason). Key names only, never values. Direct evidence the migration ran, independent of Sentry decay, and the gate #4128 is waiting on.

## Test plan

1. Load OTA preview `pr-4127` from What's New → app reloads.
2. Sign in on iOS, force-quit, reopen → still signed in.
3. Lock the phone, wait for a background wake → no sign-out.
4. Change theme in Settings, relaunch → the theme persists.
5. Sign out, relaunch → still signed out.

## Risk

Risk: 4/5 — OTA-shipped change to credential storage and sign-out. Non-destructive by construction (a key ends every interruption either legacy-only or in both namespaces), but not device-verified.

## Automated coverage

- `vp check` (0 errors), `vp run typecheck:mobile`, `vp run test:mobile` (866 files / 9413 tests), `vp run check:mobile-bundle` — all pass on the rebased branch.
- Sign-out refuses to report success when a tombstone lands in legacy behind a live v2 credential: seeds both namespaces, v2 undeletable, v2 write failing. Reverting the post-write verification makes it resolve instead of raising `AuthCredentialCleanupError`.
- Non-iOS coverage: one call per read/write/delete against the default service, no `keychainService` anywhere, and a migration pass that is a complete no-op including analytics.
- Repeat sign-out on a keychain that refuses both deletion and writes resolves instead of raising `AuthCredentialCleanupError`; reverting the one-line tombstone check fails it.
- Concurrent-mutation guard: four tests driven by a fake hook that fires after the legacy read produces its value but before the caller resumes — the real window, not a proxy for it. Reverting the guard fails three of them; re-pointing the session-key import at the forked module fails the structural test first.
- The tombstone reaching legacy when the v2 write rejects; the tombstone failing only when both namespaces reject; sign-out racing the first-read migration (which doubles as a deadlock guard on the shared credential mutation queue); `verify-mismatch`; the boolean once-runner contract, including a full pass that fails, then retries and completes in the *same* module instance once the keychain unlocks; the analytics bounding; and the `PREFERENCE_SECURE_KEYS` shape guard.
- The interruption matrix (locked keychain, failed v2 write — each leaves legacy intact and retries), rollback safety (legacy copy survives; a reader on old JS still authenticates), idempotency, the once-runner under concurrent cold-start readers, and the resurrection case — a legacy delete that silently does nothing must not sign the user back in.
- The `#4001` invariant is re-asserted: a locked legacy keychain still **rejects** rather than resolving `null`, because `auth-session.ts` turns a throw into `unavailable` and a `null` into a real sign-out.
- The keychain fake models the two properties that drive the design: an item is identified by `(key, keychainService)`, and deletion never reports failure.

**Still not device-verified**, and that is the one open call — it needs a phone, which this loop does not have. The change is non-destructive by construction — a key ends every interruption either legacy-only or in both namespaces — so the worst case is "no better than today", not "worse", which is not the shape of the #3602 regression. If you want the on-device pass first: install the store/TestFlight build, sign in, load OTA channel `pr-4127` from What's New → Try a preview, foreground once, lock the phone, wait for a background wake, then check that no new BOARDSESH-C3 event arrives for that device and that a `Keychain Namespace Migration` event landed with `migrated: 3, failed: 0`.

## Release Notes

Staying signed in now survives a locked phone. If the app woke up in the background — refreshing your session, reconnecting to a party, updating a Live Activity — it could quietly fail to read your login and bounce you to the sign-in screen. Anyone who installed before mid-July was stuck in that loop for good; now iOS can reach your credentials once the phone has been unlocked since its last restart, and if the app happens to wake while the phone is still locked it tries again the moment you open it.

