### PR TITLE
fix(mobile): retry transient Android BLE connects

### DIFF
--- a/packages/mobile/src/lib/ble/__tests__/adapter-factory.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter-factory.test.ts
@@ -60,6 +60,7 @@ describe('createBluetoothAdapter', () => {
     harness.module.boardBleNative = null;
     createBluetoothAdapter(noopPicker, 'aurora');
     expect(RNBleAdapter).toHaveBeenCalledTimes(1);
+    expect(RNBleAdapter).toHaveBeenCalledWith(noopPicker, 'aurora', { enableAndroidConnectRetry: false });
     expect(NativeIosBleAdapter).not.toHaveBeenCalled();
   });
 
@@ -68,6 +69,7 @@ describe('createBluetoothAdapter', () => {
     harness.module.boardBleNative = { _placeholder: true };
     createBluetoothAdapter(noopPicker, 'aurora');
     expect(RNBleAdapter).toHaveBeenCalledTimes(1);
+    expect(RNBleAdapter).toHaveBeenCalledWith(noopPicker, 'aurora', { enableAndroidConnectRetry: true });
     expect(NativeIosBleAdapter).not.toHaveBeenCalled();
   });
 
@@ -79,7 +81,10 @@ describe('createBluetoothAdapter', () => {
     harness.module.boardBleNative = { _placeholder: true };
     createBluetoothAdapter(noopPicker, 'moonboard', { preferWriteWithResponse: true });
     expect(RNBleAdapter).toHaveBeenCalledTimes(1);
-    expect(RNBleAdapter).toHaveBeenCalledWith(noopPicker, 'moonboard', { preferWriteWithResponse: true });
+    expect(RNBleAdapter).toHaveBeenCalledWith(noopPicker, 'moonboard', {
+      preferWriteWithResponse: true,
+      enableAndroidConnectRetry: false,
+    });
     expect(NativeIosBleAdapter).not.toHaveBeenCalled();
   });
 

--- a/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
@@ -1368,7 +1368,7 @@ describe('RNBleAdapter', () => {
       }
     });
 
-    it('does not retry denied Android statuses or post-connect MTU/discovery failures', async () => {
+    it('does not retry denied Android statuses', async () => {
       const deniedError = androidConnectError(201, 19);
       const firstSelection = setupSelectedDevice('denied-device');
       mockBleManager.connectToDevice.mockRejectedValue(deniedError);
@@ -1377,8 +1377,9 @@ describe('RNBleAdapter', () => {
         deniedError,
       );
       expect(mockBleManager.connectToDevice).toHaveBeenCalledOnce();
+    });
 
-      vi.clearAllMocks();
+    it('does not retry a post-connect discovery failure', async () => {
       const secondSelection = setupSelectedDevice('discovery-device');
       const discoveryError = new Error('service discovery failed');
       secondSelection.connectedDevice.discoverAllServicesAndCharacteristics.mockRejectedValue(discoveryError);

--- a/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
@@ -1178,10 +1178,48 @@ describe('RNBleAdapter', () => {
       expect(adapter.getLastConnectAttemptCount()).toBe(1);
     });
 
-    it('reports zero connect attempts before the flow ever reaches the GATT connect', () => {
-      expect(
-        new RNBleAdapter(createMockDevicePicker(), 'aurora', { enableAndroidConnectRetry: true }).getLastConnectAttemptCount(),
-      ).toBe(0);
+    it('reports zero connect attempts when the picker is cancelled before the GATT connect', async () => {
+      // Drives the real flow into the documented 0 bucket instead of reading the
+      // field initializer back: this fails if any pre-connect stage bumps it.
+      setupSelectedDevice('cancelled-device');
+      const cancellingPicker = vi.fn<DevicePickerFn>(() => Promise.reject(new Error('Device selection cancelled')));
+
+      const adapter = new RNBleAdapter(cancellingPicker, 'aurora', { enableAndroidConnectRetry: true });
+      await expect(adapter.requestAndConnect()).rejects.toThrow('Device selection cancelled');
+
+      expect(mockBleManager.connectToDevice).not.toHaveBeenCalled();
+      expect(adapter.getLastConnectAttemptCount()).toBe(0);
+      expect(adapter.getLastConnectRetrySucceeded()).toBe(false);
+    });
+
+    it('starts the attempt count and the retry flag over on the next connect', async () => {
+      vi.useFakeTimers();
+      try {
+        const { devicePicker, connectedDevice } = setupSelectedDevice();
+        mockBleManager.cancelDeviceConnection.mockResolvedValue(undefined);
+        mockBleManager.connectToDevice
+          .mockRejectedValueOnce(androidConnectError(201, 133))
+          .mockResolvedValueOnce(connectedDevice);
+
+        const adapter = new RNBleAdapter(devicePicker, 'aurora', { enableAndroidConnectRetry: true });
+        const recovered = adapter.requestAndConnect();
+        await vi.advanceTimersByTimeAsync(500);
+        await recovered;
+        expect(adapter.getLastConnectAttemptCount()).toBe(2);
+        expect(adapter.getLastConnectRetrySucceeded()).toBe(true);
+
+        // Same adapter, a clean second connect. Both fields are per-connect: drop
+        // the reset in connectSelectedDevice and this reports three attempts and
+        // a retry that never ran on this connect.
+        mockBleManager.connectToDevice.mockResolvedValue(connectedDevice);
+        await adapter.requestAndConnect();
+
+        expect(mockBleManager.connectToDevice).toHaveBeenCalledTimes(3);
+        expect(adapter.getLastConnectAttemptCount()).toBe(1);
+        expect(adapter.getLastConnectRetrySucceeded()).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('is disabled by default and preserves the exact first connect error', async () => {
@@ -1313,6 +1351,9 @@ describe('RNBleAdapter', () => {
         expect(mockBleManager.connectToDevice).toHaveBeenCalledTimes(2);
         expect(mockBleManager.cancelDeviceConnection).toHaveBeenCalledTimes(2);
         expect(adapter.getLastConnectAttemptCount()).toBe(2);
+        // The retry genuinely lost — the counterpart to the discovery-failure
+        // case below, where the same count of 2 comes with a saved connect.
+        expect(adapter.getLastConnectRetrySucceeded()).toBe(false);
       } finally {
         vi.useRealTimers();
       }
@@ -1328,7 +1369,7 @@ describe('RNBleAdapter', () => {
           .mockRejectedValueOnce(deniedSecondError);
         mockBleManager.cancelDeviceConnection.mockResolvedValue(undefined);
 
-        const adapter = new RNBleAdapter(devicePicker, 'aurora', true);
+        const adapter = new RNBleAdapter(devicePicker, 'aurora', { enableAndroidConnectRetry: true });
         const settled = adapter.requestAndConnect().catch((error: unknown) => error);
         await vi.advanceTimersByTimeAsync(500);
 
@@ -1426,6 +1467,33 @@ describe('RNBleAdapter', () => {
       expect(mockBleManager.connectToDevice).toHaveBeenCalledOnce();
       expect(secondSelection.connectedDevice.requestMTU).toHaveBeenCalledOnce();
       expect(secondSelection.connectedDevice.discoverAllServicesAndCharacteristics).toHaveBeenCalledOnce();
+    });
+
+    it('still reports the retry as a save when the recovered connect fails during discovery', async () => {
+      vi.useFakeTimers();
+      try {
+        const discoveryError = new Error('service discovery failed');
+        const { devicePicker, connectedDevice } = setupSelectedDevice('recovered-then-broken');
+        connectedDevice.discoverAllServicesAndCharacteristics.mockRejectedValue(discoveryError);
+        mockBleManager.cancelDeviceConnection.mockResolvedValue(undefined);
+        mockBleManager.connectToDevice
+          .mockRejectedValueOnce(androidConnectError(201, 133))
+          .mockResolvedValueOnce(connectedDevice);
+
+        const adapter = new RNBleAdapter(devicePicker, 'aurora', { enableAndroidConnectRetry: true });
+        const settled = adapter.requestAndConnect().catch((error: unknown) => error);
+        await vi.advanceTimersByTimeAsync(500);
+
+        await expect(settled).resolves.toBe(discoveryError);
+        // The retry won the GATT connect and discovery broke afterwards. This is
+        // the case `connectAttempts: 2` alone can't tell from a retry that lost —
+        // the failure event carries the flag so the hit rate isn't undercounted.
+        expect(mockBleManager.connectToDevice).toHaveBeenCalledTimes(2);
+        expect(adapter.getLastConnectAttemptCount()).toBe(2);
+        expect(adapter.getLastConnectRetrySucceeded()).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
@@ -44,6 +44,15 @@ vi.mock('@boardsesh/ble-protocol', () => ({
   effectiveChunkSizeForMtu: (mtu: number) => Math.min(Math.max(mtu - 3, 20), 244),
   INTER_CHUNK_DELAY_MS: 0,
   parseSerialNumber: vi.fn(),
+  isRetryableAndroidConnectError: (error: unknown) => {
+    if (!(error instanceof Error) || error.name !== 'BleError') return false;
+    const bleError = error as Error & { errorCode?: unknown; androidErrorCode?: unknown; iosErrorCode?: unknown };
+    if (bleError.errorCode !== 200 && bleError.errorCode !== 201 && bleError.errorCode !== 205) return false;
+    if (/user cancell?ed|Device selection cancelled/i.test(bleError.message)) return false;
+    if (bleError.iosErrorCode !== undefined && bleError.iosErrorCode !== null) return false;
+    if (bleError.androidErrorCode === undefined || bleError.androidErrorCode === null) return true;
+    return bleError.androidErrorCode === 133 || bleError.androidErrorCode === 147;
+  },
 }));
 
 // ── Import after mocks ─────────────────────────────────────────────────
@@ -58,6 +67,54 @@ import { State } from 'react-native-ble-plx';
 
 function createMockDevicePicker(): DevicePickerFn {
   return vi.fn();
+}
+
+function androidConnectError(errorCode = 201, androidErrorCode?: number): Error {
+  const error = new Error('Android GATT connect failed') as Error & {
+    errorCode: number;
+    androidErrorCode: number | null;
+    iosErrorCode: null;
+  };
+  error.name = 'BleError';
+  error.errorCode = errorCode;
+  error.androidErrorCode = androidErrorCode ?? null;
+  error.iosErrorCode = null;
+  return error;
+}
+
+function setupSelectedDevice(deviceId = 'retry-device') {
+  const devicePicker = vi.fn<DevicePickerFn>(() => Promise.resolve(deviceId));
+  mockBleManager.startDeviceScan.mockImplementation(
+    (_uuids: unknown, _opts: unknown, callback: (error: unknown, device: unknown) => void) => {
+      callback(null, {
+        id: deviceId,
+        localName: 'Kilter Board#RETRY@3',
+        name: 'Kilter Board#RETRY@3',
+        rssi: -40,
+        serviceUUIDs: ['aurora-uuid'],
+      });
+    },
+  );
+  mockBleManager.onDeviceDisconnected.mockReturnValue({ remove: vi.fn() });
+
+  const characteristic = {
+    uuid: 'uart-write-uuid',
+    isWritableWithoutResponse: true,
+    writeWithoutResponse: vi.fn().mockResolvedValue(undefined),
+    writeWithResponse: vi.fn().mockResolvedValue(undefined),
+  };
+  const deviceWithServices = {
+    id: deviceId,
+    characteristicsForService: vi.fn().mockResolvedValue([characteristic]),
+    discoverAllServicesAndCharacteristics: vi.fn().mockReturnThis(),
+  };
+  const connectedDevice = {
+    id: deviceId,
+    mtu: 23,
+    requestMTU: vi.fn().mockResolvedValue({ mtu: 247 }),
+    discoverAllServicesAndCharacteristics: vi.fn().mockResolvedValue(deviceWithServices),
+  };
+  return { devicePicker, connectedDevice, deviceWithServices };
 }
 
 // Wires up the scan → auto-pick → connect → discover flow for a single board so
@@ -1111,6 +1168,233 @@ describe('RNBleAdapter', () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+  });
+
+  describe('requestAndConnect — Android GATT retry (#4143)', () => {
+    it('reports retrySucceeded=false for an ordinary first-attempt success', async () => {
+      const { devicePicker, connectedDevice } = setupSelectedDevice();
+      mockBleManager.connectToDevice.mockResolvedValue(connectedDevice);
+
+      await expect(new RNBleAdapter(devicePicker, 'aurora', { enableAndroidConnectRetry: true }).requestAndConnect()).resolves.toMatchObject({
+        retrySucceeded: false,
+      });
+      expect(mockBleManager.connectToDevice).toHaveBeenCalledOnce();
+      expect(mockBleManager.cancelDeviceConnection).not.toHaveBeenCalled();
+    });
+
+    it('is disabled by default and preserves the exact first connect error', async () => {
+      const firstError = androidConnectError(201, 133);
+      const { devicePicker } = setupSelectedDevice();
+      mockBleManager.connectToDevice.mockRejectedValue(firstError);
+
+      const adapter = new RNBleAdapter(devicePicker, 'aurora');
+      await expect(adapter.requestAndConnect()).rejects.toBe(firstError);
+
+      expect(mockBleManager.connectToDevice).toHaveBeenCalledOnce();
+      expect(mockBleManager.cancelDeviceConnection).not.toHaveBeenCalled();
+    });
+
+    it('retries the same selected id once after cleanup and 500ms, then reports recovery diagnostics', async () => {
+      vi.useFakeTimers();
+      try {
+        const firstError = androidConnectError(201, 133);
+        const { devicePicker, connectedDevice, deviceWithServices } = setupSelectedDevice();
+        mockBleManager.cancelDeviceConnection.mockResolvedValue(undefined);
+        mockBleManager.connectToDevice.mockRejectedValueOnce(firstError).mockResolvedValueOnce(connectedDevice);
+
+        const adapter = new RNBleAdapter(devicePicker, 'aurora', { enableAndroidConnectRetry: true });
+        const connectionPromise = adapter.requestAndConnect();
+        await vi.advanceTimersByTimeAsync(499);
+        expect(mockBleManager.connectToDevice).toHaveBeenCalledOnce();
+
+        await vi.advanceTimersByTimeAsync(1);
+        const connection = await connectionPromise;
+
+        expect(connection).toMatchObject({ deviceId: 'retry-device', retrySucceeded: true });
+        expect(mockBleManager.connectToDevice).toHaveBeenCalledTimes(2);
+        expect(mockBleManager.connectToDevice).toHaveBeenNthCalledWith(1, 'retry-device');
+        expect(mockBleManager.connectToDevice).toHaveBeenNthCalledWith(2, 'retry-device');
+        expect(mockBleManager.cancelDeviceConnection).toHaveBeenCalledOnce();
+        expect(mockBleManager.startDeviceScan).toHaveBeenCalledOnce();
+        expect(devicePicker).toHaveBeenCalledOnce();
+        expect(connectedDevice.requestMTU).toHaveBeenCalledOnce();
+        expect(connectedDevice.discoverAllServicesAndCharacteristics).toHaveBeenCalledOnce();
+        expect(deviceWithServices.characteristicsForService).toHaveBeenCalledOnce();
+        expect(mockBleManager.onDeviceDisconnected).toHaveBeenCalledOnce();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('continues to the retry when stale-handle cleanup rejects', async () => {
+      vi.useFakeTimers();
+      try {
+        const { devicePicker, connectedDevice } = setupSelectedDevice();
+        mockBleManager.connectToDevice
+          .mockRejectedValueOnce(androidConnectError(200))
+          .mockResolvedValueOnce(connectedDevice);
+        mockBleManager.cancelDeviceConnection.mockRejectedValue(new Error('already disconnected'));
+
+        const connectionPromise = new RNBleAdapter(devicePicker, 'aurora', { enableAndroidConnectRetry: true }).requestAndConnect();
+        await vi.advanceTimersByTimeAsync(500);
+
+        await expect(connectionPromise).resolves.toMatchObject({ retrySucceeded: true });
+        expect(mockBleManager.connectToDevice).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('surfaces the original first error when cleanup hangs through the shared deadline', async () => {
+      vi.useFakeTimers();
+      try {
+        const firstError = androidConnectError(205, 147);
+        const { devicePicker } = setupSelectedDevice();
+        mockBleManager.connectToDevice.mockRejectedValue(firstError);
+        mockBleManager.cancelDeviceConnection.mockImplementation(() => new Promise(() => {}));
+
+        const settled = new RNBleAdapter(devicePicker, 'aurora', { enableAndroidConnectRetry: true })
+          .requestAndConnect()
+          .catch((error: unknown) => error);
+        await vi.advanceTimersByTimeAsync(12_000);
+
+        await expect(settled).resolves.toBe(firstError);
+        expect(mockBleManager.connectToDevice).toHaveBeenCalledOnce();
+        expect(mockBleManager.cancelDeviceConnection).toHaveBeenCalledOnce();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it.each([11_500, 11_750, 11_999])(
+      'does not begin attempt two or leak a timer when attempt one fails after %ims',
+      async (firstFailureDelayMs) => {
+        vi.useFakeTimers();
+        try {
+          const firstError = androidConnectError(201, 133);
+          const { devicePicker } = setupSelectedDevice();
+          mockBleManager.connectToDevice.mockImplementationOnce(
+            () => new Promise((_resolve, reject) => setTimeout(() => reject(firstError), firstFailureDelayMs)),
+          );
+          mockBleManager.cancelDeviceConnection.mockResolvedValue(undefined);
+
+          const settled = new RNBleAdapter(devicePicker, 'aurora', { enableAndroidConnectRetry: true })
+            .requestAndConnect()
+            .catch((error: unknown) => error);
+          await vi.advanceTimersByTimeAsync(12_000);
+
+          await expect(settled).resolves.toBe(firstError);
+          expect(mockBleManager.connectToDevice).toHaveBeenCalledOnce();
+          expect(vi.getTimerCount()).toBe(0);
+        } finally {
+          vi.useRealTimers();
+        }
+      },
+    );
+
+    it('propagates the exact second error, performs exhausted cleanup, and never makes a third attempt', async () => {
+      vi.useFakeTimers();
+      try {
+        const secondError = androidConnectError(201, 147);
+        const { devicePicker } = setupSelectedDevice();
+        mockBleManager.connectToDevice
+          .mockRejectedValueOnce(androidConnectError(201, 133))
+          .mockRejectedValueOnce(secondError);
+        mockBleManager.cancelDeviceConnection.mockResolvedValue(undefined);
+
+        const settled = new RNBleAdapter(devicePicker, 'aurora', { enableAndroidConnectRetry: true })
+          .requestAndConnect()
+          .catch((error: unknown) => error);
+        await vi.advanceTimersByTimeAsync(500);
+
+        await expect(settled).resolves.toBe(secondError);
+        expect(mockBleManager.connectToDevice).toHaveBeenCalledTimes(2);
+        expect(mockBleManager.cancelDeviceConnection).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('bounds a hanging exhausted cleanup and still surfaces the exact second error by 12 seconds', async () => {
+      vi.useFakeTimers();
+      try {
+        const secondError = androidConnectError(205, 133);
+        const { devicePicker } = setupSelectedDevice();
+        mockBleManager.connectToDevice
+          .mockRejectedValueOnce(androidConnectError(201, 133))
+          .mockRejectedValueOnce(secondError);
+        mockBleManager.cancelDeviceConnection
+          .mockResolvedValueOnce(undefined)
+          .mockImplementationOnce(() => new Promise(() => {}));
+
+        const settled = new RNBleAdapter(devicePicker, 'aurora', { enableAndroidConnectRetry: true })
+          .requestAndConnect()
+          .catch((error: unknown) => error);
+        await vi.advanceTimersByTimeAsync(12_000);
+
+        await expect(settled).resolves.toBe(secondError);
+        expect(mockBleManager.connectToDevice).toHaveBeenCalledTimes(2);
+        expect(mockBleManager.cancelDeviceConnection).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('keeps the existing timeout terminal behavior when attempt two hangs, with no late unhandled rejection', async () => {
+      vi.useFakeTimers();
+      try {
+        let rejectLateAttempt!: (error: Error) => void;
+        const { devicePicker } = setupSelectedDevice();
+        mockBleManager.connectToDevice.mockRejectedValueOnce(androidConnectError(201, 133)).mockImplementationOnce(
+          () =>
+            new Promise((_resolve, reject) => {
+              rejectLateAttempt = reject;
+            }),
+        );
+        mockBleManager.cancelDeviceConnection.mockResolvedValue(undefined);
+
+        const settled = new RNBleAdapter(devicePicker, 'aurora', { enableAndroidConnectRetry: true })
+          .requestAndConnect()
+          .catch((error: unknown) => error);
+        await vi.advanceTimersByTimeAsync(12_000);
+        const error = await settled;
+
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toMatch(/timed out/i);
+        expect(mockBleManager.connectToDevice).toHaveBeenCalledTimes(2);
+        expect(mockBleManager.cancelDeviceConnection).toHaveBeenCalledTimes(2);
+
+        // The deadline race retains a rejection handler after timeout wins.
+        rejectLateAttempt(new Error('native operation settled late'));
+        await Promise.resolve();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not retry denied Android statuses or post-connect MTU/discovery failures', async () => {
+      const deniedError = androidConnectError(201, 19);
+      const firstSelection = setupSelectedDevice('denied-device');
+      mockBleManager.connectToDevice.mockRejectedValue(deniedError);
+
+      await expect(new RNBleAdapter(firstSelection.devicePicker, 'aurora', { enableAndroidConnectRetry: true }).requestAndConnect()).rejects.toBe(
+        deniedError,
+      );
+      expect(mockBleManager.connectToDevice).toHaveBeenCalledOnce();
+
+      vi.clearAllMocks();
+      const secondSelection = setupSelectedDevice('discovery-device');
+      const discoveryError = new Error('service discovery failed');
+      secondSelection.connectedDevice.discoverAllServicesAndCharacteristics.mockRejectedValue(discoveryError);
+      mockBleManager.connectToDevice.mockResolvedValue(secondSelection.connectedDevice);
+
+      await expect(new RNBleAdapter(secondSelection.devicePicker, 'aurora', { enableAndroidConnectRetry: true }).requestAndConnect()).rejects.toBe(
+        discoveryError,
+      );
+      expect(mockBleManager.connectToDevice).toHaveBeenCalledOnce();
+      expect(secondSelection.connectedDevice.requestMTU).toHaveBeenCalledOnce();
+      expect(secondSelection.connectedDevice.discoverAllServicesAndCharacteristics).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
@@ -1171,11 +1171,17 @@ describe('RNBleAdapter', () => {
       const { devicePicker, connectedDevice } = setupSelectedDevice();
       mockBleManager.connectToDevice.mockResolvedValue(connectedDevice);
 
-      await expect(new RNBleAdapter(devicePicker, 'aurora', { enableAndroidConnectRetry: true }).requestAndConnect()).resolves.toMatchObject({
-        retrySucceeded: false,
-      });
+      const adapter = new RNBleAdapter(devicePicker, 'aurora', { enableAndroidConnectRetry: true });
+      await expect(adapter.requestAndConnect()).resolves.toMatchObject({ retrySucceeded: false });
       expect(mockBleManager.connectToDevice).toHaveBeenCalledOnce();
       expect(mockBleManager.cancelDeviceConnection).not.toHaveBeenCalled();
+      expect(adapter.getLastConnectAttemptCount()).toBe(1);
+    });
+
+    it('reports zero connect attempts before the flow ever reaches the GATT connect', () => {
+      expect(
+        new RNBleAdapter(createMockDevicePicker(), 'aurora', { enableAndroidConnectRetry: true }).getLastConnectAttemptCount(),
+      ).toBe(0);
     });
 
     it('is disabled by default and preserves the exact first connect error', async () => {
@@ -1217,6 +1223,7 @@ describe('RNBleAdapter', () => {
         expect(connectedDevice.discoverAllServicesAndCharacteristics).toHaveBeenCalledOnce();
         expect(deviceWithServices.characteristicsForService).toHaveBeenCalledOnce();
         expect(mockBleManager.onDeviceDisconnected).toHaveBeenCalledOnce();
+        expect(adapter.getLastConnectAttemptCount()).toBe(2);
       } finally {
         vi.useRealTimers();
       }
@@ -1274,13 +1281,13 @@ describe('RNBleAdapter', () => {
           );
           mockBleManager.cancelDeviceConnection.mockResolvedValue(undefined);
 
-          const settled = new RNBleAdapter(devicePicker, 'aurora', { enableAndroidConnectRetry: true })
-            .requestAndConnect()
-            .catch((error: unknown) => error);
+          const adapter = new RNBleAdapter(devicePicker, 'aurora', { enableAndroidConnectRetry: true });
+          const settled = adapter.requestAndConnect().catch((error: unknown) => error);
           await vi.advanceTimersByTimeAsync(12_000);
 
           await expect(settled).resolves.toBe(firstError);
           expect(mockBleManager.connectToDevice).toHaveBeenCalledOnce();
+          expect(adapter.getLastConnectAttemptCount()).toBe(1);
           expect(vi.getTimerCount()).toBe(0);
         } finally {
           vi.useRealTimers();
@@ -1298,20 +1305,20 @@ describe('RNBleAdapter', () => {
           .mockRejectedValueOnce(secondError);
         mockBleManager.cancelDeviceConnection.mockResolvedValue(undefined);
 
-        const settled = new RNBleAdapter(devicePicker, 'aurora', { enableAndroidConnectRetry: true })
-          .requestAndConnect()
-          .catch((error: unknown) => error);
+        const adapter = new RNBleAdapter(devicePicker, 'aurora', { enableAndroidConnectRetry: true });
+        const settled = adapter.requestAndConnect().catch((error: unknown) => error);
         await vi.advanceTimersByTimeAsync(500);
 
         await expect(settled).resolves.toBe(secondError);
         expect(mockBleManager.connectToDevice).toHaveBeenCalledTimes(2);
         expect(mockBleManager.cancelDeviceConnection).toHaveBeenCalledTimes(2);
+        expect(adapter.getLastConnectAttemptCount()).toBe(2);
       } finally {
         vi.useRealTimers();
       }
     });
 
-    it('bounds a hanging exhausted cleanup and still surfaces the exact second error by 12 seconds', async () => {
+    it('surfaces the second error immediately even when the exhausted cleanup hangs', async () => {
       vi.useFakeTimers();
       try {
         const secondError = androidConnectError(205, 133);
@@ -1326,11 +1333,14 @@ describe('RNBleAdapter', () => {
         const settled = new RNBleAdapter(devicePicker, 'aurora', { enableAndroidConnectRetry: true })
           .requestAndConnect()
           .catch((error: unknown) => error);
-        await vi.advanceTimersByTimeAsync(12_000);
+        // Only the 500ms backoff, not the 12s ceiling: the exhausted-handle
+        // cleanup is fire-and-forget, so it can't hold the alert back.
+        await vi.advanceTimersByTimeAsync(500);
 
         await expect(settled).resolves.toBe(secondError);
         expect(mockBleManager.connectToDevice).toHaveBeenCalledTimes(2);
         expect(mockBleManager.cancelDeviceConnection).toHaveBeenCalledTimes(2);
+        expect(vi.getTimerCount()).toBe(0);
       } finally {
         vi.useRealTimers();
       }
@@ -1373,10 +1383,10 @@ describe('RNBleAdapter', () => {
       const firstSelection = setupSelectedDevice('denied-device');
       mockBleManager.connectToDevice.mockRejectedValue(deniedError);
 
-      await expect(new RNBleAdapter(firstSelection.devicePicker, 'aurora', { enableAndroidConnectRetry: true }).requestAndConnect()).rejects.toBe(
-        deniedError,
-      );
+      const adapter = new RNBleAdapter(firstSelection.devicePicker, 'aurora', { enableAndroidConnectRetry: true });
+      await expect(adapter.requestAndConnect()).rejects.toBe(deniedError);
       expect(mockBleManager.connectToDevice).toHaveBeenCalledOnce();
+      expect(adapter.getLastConnectAttemptCount()).toBe(1);
     });
 
     it('does not retry a post-connect discovery failure', async () => {

--- a/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
@@ -31,29 +31,24 @@ vi.mock('../ble-manager', () => ({
   bleManager: mockBleManager,
 }));
 
-vi.mock('@boardsesh/ble-protocol', () => ({
-  AURORA_ADVERTISED_SERVICE_UUID: 'aurora-uuid',
-  UART_SERVICE_UUID: 'uart-uuid',
-  UART_WRITE_CHARACTERISTIC_UUID: 'uart-write-uuid',
-  REDBEARLAB_SERVICE_UUID: 'redbearlab-uuid',
-  REDBEARLAB_WRITE_CHARACTERISTIC_UUID: 'redbearlab-write-uuid',
-  splitMessages: vi.fn((passedData: Uint8Array) => [passedData]),
-  // Real chunk-sizing maths so the #3230 assertions (mtu 247 → 244, fallback
-  // 23 → 20) exercise the actual clamp the adapter passes to splitMessages.
-  MAX_BLUETOOTH_MESSAGE_SIZE: 20,
-  effectiveChunkSizeForMtu: (mtu: number) => Math.min(Math.max(mtu - 3, 20), 244),
-  INTER_CHUNK_DELAY_MS: 0,
-  parseSerialNumber: vi.fn(),
-  isRetryableAndroidConnectError: (error: unknown) => {
-    if (!(error instanceof Error) || error.name !== 'BleError') return false;
-    const bleError = error as Error & { errorCode?: unknown; androidErrorCode?: unknown; iosErrorCode?: unknown };
-    if (bleError.errorCode !== 200 && bleError.errorCode !== 201 && bleError.errorCode !== 205) return false;
-    if (/user cancell?ed|Device selection cancelled/i.test(bleError.message)) return false;
-    if (bleError.iosErrorCode !== undefined && bleError.iosErrorCode !== null) return false;
-    if (bleError.androidErrorCode === undefined || bleError.androidErrorCode === null) return true;
-    return bleError.androidErrorCode === 133 || bleError.androidErrorCode === 147;
-  },
-}));
+vi.mock('@boardsesh/ble-protocol', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@boardsesh/ble-protocol')>();
+  return {
+    AURORA_ADVERTISED_SERVICE_UUID: 'aurora-uuid',
+    UART_SERVICE_UUID: 'uart-uuid',
+    UART_WRITE_CHARACTERISTIC_UUID: 'uart-write-uuid',
+    REDBEARLAB_SERVICE_UUID: 'redbearlab-uuid',
+    REDBEARLAB_WRITE_CHARACTERISTIC_UUID: 'redbearlab-write-uuid',
+    splitMessages: vi.fn((passedData: Uint8Array) => [passedData]),
+    // Real chunk-sizing maths so the #3230 assertions (mtu 247 → 244, fallback
+    // 23 → 20) exercise the actual clamp the adapter passes to splitMessages.
+    MAX_BLUETOOTH_MESSAGE_SIZE: 20,
+    effectiveChunkSizeForMtu: (mtu: number) => Math.min(Math.max(mtu - 3, 20), 244),
+    INTER_CHUNK_DELAY_MS: 0,
+    parseSerialNumber: vi.fn(),
+    isRetryableAndroidConnectError: actual.isRetryableAndroidConnectError,
+  };
+});
 
 // ── Import after mocks ─────────────────────────────────────────────────
 

--- a/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/adapter.test.ts
@@ -1318,6 +1318,31 @@ describe('RNBleAdapter', () => {
       }
     });
 
+    it('still closes the handle when attempt two fails with a non-retryable error', async () => {
+      vi.useFakeTimers();
+      try {
+        const deniedSecondError = androidConnectError(201, 19);
+        const { devicePicker } = setupSelectedDevice();
+        mockBleManager.connectToDevice
+          .mockRejectedValueOnce(androidConnectError(201, 133))
+          .mockRejectedValueOnce(deniedSecondError);
+        mockBleManager.cancelDeviceConnection.mockResolvedValue(undefined);
+
+        const adapter = new RNBleAdapter(devicePicker, 'aurora', true);
+        const settled = adapter.requestAndConnect().catch((error: unknown) => error);
+        await vi.advanceTimersByTimeAsync(500);
+
+        await expect(settled).resolves.toBe(deniedSecondError);
+        expect(mockBleManager.connectToDevice).toHaveBeenCalledTimes(2);
+        // Cleanup is not conditional on the second error being retryable — a
+        // denied status strands a native GATT handle just the same.
+        expect(mockBleManager.cancelDeviceConnection).toHaveBeenCalledTimes(2);
+        expect(adapter.getLastConnectAttemptCount()).toBe(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('surfaces the second error immediately even when the exhausted cleanup hangs', async () => {
       vi.useFakeTimers();
       try {

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -384,6 +384,7 @@ describe('useBoardBluetooth', () => {
       // terminal attempt-two error and must emit its existing failure path once.
       ...makeFakeAdapter({ requestAndConnect: vi.fn().mockRejectedValue(finalError) }),
       getLastConnectAttemptCount: vi.fn(() => 2),
+      getLastConnectRetrySucceeded: vi.fn(() => false),
     };
     vi.mocked(createBluetoothAdapter).mockReturnValue(
       fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
@@ -401,6 +402,7 @@ describe('useBoardBluetooth', () => {
       bleErrorCode: 201,
       androidErrorCode: 147,
       connectAttempts: 2,
+      retrySucceeded: false,
     });
     expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Success')).toBeUndefined();
     expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Disconnected')).toBeUndefined();
@@ -409,6 +411,34 @@ describe('useBoardBluetooth', () => {
     expect(Alert.alert).toHaveBeenCalledWith('ble.connectionFailedTitle', 'bluetooth.connectFailed');
     expect(reportHandledError).toHaveBeenCalledTimes(1);
     expect(reportHandledError).toHaveBeenCalledWith(finalError, expect.any(Object));
+  });
+
+  it('marks a failure that followed a recovered connect as a retry that saved the GATT connect', async () => {
+    // Two attempts and a failure event, but the retry did NOT lose: it recovered
+    // the GATT connect and discovery broke afterwards. Counting saves as
+    // (success ∧ attempts=2) / (attempts=2) would miss this one.
+    const fakeAdapter = {
+      ...makeFakeAdapter({
+        requestAndConnect: vi.fn().mockRejectedValue(new Error('UART service was not found')),
+      }),
+      getLastConnectAttemptCount: vi.fn(() => 2),
+      getLastConnectRetrySucceeded: vi.fn(() => true),
+    };
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    const failure = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed');
+    expect(failure?.[1]).toMatchObject({
+      failureReason: 'service_missing',
+      connectAttempts: 2,
+      retrySucceeded: true,
+    });
   });
 
   it('tags a service_missing failure with the services the board exposed (#3480)', async () => {

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -288,7 +288,7 @@ describe('useBoardBluetooth', () => {
     expect(result.current.isConnected).toBe(true);
     const successEvents = mockTrack.mock.calls.filter(([name]) => name === 'Bluetooth Connection Success');
     expect(successEvents).toHaveLength(1);
-    expect(successEvents[0]?.[1]).toMatchObject({ retry_succeeded: true });
+    expect(successEvents[0]?.[1]).toMatchObject({ retrySucceeded: true });
     expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed')).toBeUndefined();
   });
 
@@ -330,8 +330,28 @@ describe('useBoardBluetooth', () => {
     });
 
     expect(Alert.alert).not.toHaveBeenCalled();
-    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed')).toBeUndefined();
     expect(reportHandledError).not.toHaveBeenCalled();
+  });
+
+  it('reports zero connect attempts when the flow never reaches the GATT connect', async () => {
+    const fakeAdapter = {
+      ...makeFakeAdapter({
+        requestAndConnect: vi.fn().mockRejectedValue(new Error('Device selection cancelled')),
+      }),
+      getLastConnectAttemptCount: vi.fn(() => 0),
+    };
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    const failure = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed');
+    expect(failure?.[1]).toMatchObject({ failureReason: 'user_cancelled', connectAttempts: 0 });
   });
 
   it('maps a connect timeout to the connect-failed copy', async () => {
@@ -359,11 +379,12 @@ describe('useBoardBluetooth', () => {
     finalError.name = 'BleError';
     finalError.errorCode = 201;
     finalError.androidErrorCode = 147;
-    const fakeAdapter = makeFakeAdapter({
+    const fakeAdapter = {
       // The adapter owns attempt one and its retry; the hook sees only the exact
       // terminal attempt-two error and must emit its existing failure path once.
-      requestAndConnect: vi.fn().mockRejectedValue(finalError),
-    });
+      ...makeFakeAdapter({ requestAndConnect: vi.fn().mockRejectedValue(finalError) }),
+      getLastConnectAttemptCount: vi.fn(() => 2),
+    };
     vi.mocked(createBluetoothAdapter).mockReturnValue(
       fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
     );
@@ -379,6 +400,7 @@ describe('useBoardBluetooth', () => {
       failureReason: 'connect_failed',
       bleErrorCode: 201,
       androidErrorCode: 147,
+      connectAttempts: 2,
     });
     expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Success')).toBeUndefined();
     expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Disconnected')).toBeUndefined();
@@ -1048,8 +1070,8 @@ describe('useBoardBluetooth', () => {
     expect(successCall?.[1]).toMatchObject({ apiLevel: 2, deviceNamePresent: false });
   });
 
-  it('always emits a literal retry_succeeded boolean on connection success', async () => {
-    const ordinaryAdapter = makeFakeAdapter();
+  it('always emits a literal retrySucceeded boolean on connection success', async () => {
+    const ordinaryAdapter = { ...makeFakeAdapter(), getLastConnectAttemptCount: vi.fn(() => 1) };
     vi.mocked(createBluetoothAdapter).mockReturnValue(
       ordinaryAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
     );
@@ -1059,7 +1081,8 @@ describe('useBoardBluetooth', () => {
       await ordinaryHook.result.current.connect();
     });
     expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Success')?.[1]).toMatchObject({
-      retry_succeeded: false,
+      retrySucceeded: false,
+      connectAttempts: 1,
     });
 
     ordinaryHook.unmount();
@@ -1067,13 +1090,16 @@ describe('useBoardBluetooth', () => {
     resetReactNativePermissionHarness();
     mockBleManager.state.mockResolvedValue('PoweredOn');
 
-    const recoveredAdapter = makeFakeAdapter({
-      requestAndConnect: vi.fn().mockResolvedValue({
-        deviceId: 'retry-device',
-        deviceName: 'Kilter Board#RETRY@3',
-        retrySucceeded: true,
+    const recoveredAdapter = {
+      ...makeFakeAdapter({
+        requestAndConnect: vi.fn().mockResolvedValue({
+          deviceId: 'retry-device',
+          deviceName: 'Kilter Board#RETRY@3',
+          retrySucceeded: true,
+        }),
       }),
-    });
+      getLastConnectAttemptCount: vi.fn(() => 2),
+    };
     vi.mocked(createBluetoothAdapter).mockReturnValue(
       recoveredAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
     );
@@ -1084,7 +1110,7 @@ describe('useBoardBluetooth', () => {
     });
 
     const recoveredSuccess = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Success');
-    expect(recoveredSuccess?.[1]).toMatchObject({ retry_succeeded: true });
+    expect(recoveredSuccess?.[1]).toMatchObject({ retrySucceeded: true, connectAttempts: 2 });
     expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed')).toBeUndefined();
     expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Disconnected')).toBeUndefined();
     expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Stolen')).toBeUndefined();

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -251,11 +251,11 @@ describe('useBoardBluetooth', () => {
   });
 
   it('ignores a second connect while one is already in flight', async () => {
-    let resolveRequest!: (connection: { deviceId: string; deviceName?: string }) => void;
+    let resolveRequest!: (connection: { deviceId: string; deviceName?: string; retrySucceeded?: boolean }) => void;
     const fakeAdapter = makeFakeAdapter({
       requestAndConnect: vi.fn(
         () =>
-          new Promise<{ deviceId: string; deviceName?: string }>((resolve) => {
+          new Promise<{ deviceId: string; deviceName?: string; retrySucceeded?: boolean }>((resolve) => {
             resolveRequest = resolve;
           }),
       ),
@@ -282,10 +282,14 @@ describe('useBoardBluetooth', () => {
     });
 
     await act(async () => {
-      resolveRequest({ deviceId: 'device-1', deviceName: 'MoonBoard' });
+      resolveRequest({ deviceId: 'device-1', deviceName: 'MoonBoard', retrySucceeded: true });
       await firstConnect;
     });
     expect(result.current.isConnected).toBe(true);
+    const successEvents = mockTrack.mock.calls.filter(([name]) => name === 'Bluetooth Connection Success');
+    expect(successEvents).toHaveLength(1);
+    expect(successEvents[0]?.[1]).toMatchObject({ retry_succeeded: true });
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed')).toBeUndefined();
   });
 
   it('alerts on a "cancelled"-flavoured native failure instead of staying silent', async () => {
@@ -326,6 +330,8 @@ describe('useBoardBluetooth', () => {
     });
 
     expect(Alert.alert).not.toHaveBeenCalled();
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed')).toBeUndefined();
+    expect(reportHandledError).not.toHaveBeenCalled();
   });
 
   it('maps a connect timeout to the connect-failed copy', async () => {
@@ -343,6 +349,44 @@ describe('useBoardBluetooth', () => {
     });
 
     expect(Alert.alert).toHaveBeenCalledWith('ble.connectionFailedTitle', 'bluetooth.connectFailed');
+  });
+
+  it('emits one final failure with the exhausted retry error raw codes', async () => {
+    const finalError = new Error('Device retry-device was disconnected') as Error & {
+      errorCode: number;
+      androidErrorCode: number;
+    };
+    finalError.name = 'BleError';
+    finalError.errorCode = 201;
+    finalError.androidErrorCode = 147;
+    const fakeAdapter = makeFakeAdapter({
+      // The adapter owns attempt one and its retry; the hook sees only the exact
+      // terminal attempt-two error and must emit its existing failure path once.
+      requestAndConnect: vi.fn().mockRejectedValue(finalError),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    const failureEvents = mockTrack.mock.calls.filter(([name]) => name === 'Bluetooth Connection Failed');
+    expect(failureEvents).toHaveLength(1);
+    expect(failureEvents[0]?.[1]).toMatchObject({
+      failureReason: 'connect_failed',
+      bleErrorCode: 201,
+      androidErrorCode: 147,
+    });
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Success')).toBeUndefined();
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Disconnected')).toBeUndefined();
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Stolen')).toBeUndefined();
+    expect(Alert.alert).toHaveBeenCalledTimes(1);
+    expect(Alert.alert).toHaveBeenCalledWith('ble.connectionFailedTitle', 'bluetooth.connectFailed');
+    expect(reportHandledError).toHaveBeenCalledTimes(1);
+    expect(reportHandledError).toHaveBeenCalledWith(finalError, expect.any(Object));
   });
 
   it('tags a service_missing failure with the services the board exposed (#3480)', async () => {
@@ -1002,6 +1046,51 @@ describe('useBoardBluetooth', () => {
     const successCall = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Success');
     expect(successCall).toBeDefined();
     expect(successCall?.[1]).toMatchObject({ apiLevel: 2, deviceNamePresent: false });
+  });
+
+  it('always emits a literal retry_succeeded boolean on connection success', async () => {
+    const ordinaryAdapter = makeFakeAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      ordinaryAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    const ordinaryHook = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await ordinaryHook.result.current.connect();
+    });
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Success')?.[1]).toMatchObject({
+      retry_succeeded: false,
+    });
+
+    ordinaryHook.unmount();
+    vi.clearAllMocks();
+    resetReactNativePermissionHarness();
+    mockBleManager.state.mockResolvedValue('PoweredOn');
+
+    const recoveredAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockResolvedValue({
+        deviceId: 'retry-device',
+        deviceName: 'Kilter Board#RETRY@3',
+        retrySucceeded: true,
+      }),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      recoveredAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+    const recoveredHook = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await recoveredHook.result.current.connect();
+    });
+
+    const recoveredSuccess = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Success');
+    expect(recoveredSuccess?.[1]).toMatchObject({ retry_succeeded: true });
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed')).toBeUndefined();
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Disconnected')).toBeUndefined();
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Stolen')).toBeUndefined();
+    expect(Alert.alert).not.toHaveBeenCalled();
+    expect(reportHandledError).not.toHaveBeenCalled();
+    recoveredHook.unmount();
   });
 
   it('attaches per-write transport diagnostics to the send-success event (#3230)', async () => {
@@ -2154,7 +2243,13 @@ describe('useBoardBluetooth config-switch teardown', () => {
   it('tears down the live connection when the board config switches', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-08-01T00:00:00.000Z'));
-    const fakeAdapter = makeFakeAdapter();
+    const fakeAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockResolvedValue({
+        deviceId: 'retry-device',
+        deviceName: 'Kilter Board#123@3',
+        retrySucceeded: true,
+      }),
+    });
     vi.mocked(createBluetoothAdapter).mockReturnValue(
       fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
     );
@@ -2207,6 +2302,11 @@ describe('useBoardBluetooth config-switch teardown', () => {
       boardId: 41,
       inSession: true,
     });
+    const successEvents = mockTrack.mock.calls.filter(([name]) => name === 'Bluetooth Connection Success');
+    expect(successEvents).toHaveLength(1);
+    expect(successEvents[0]?.[1]).toMatchObject({ retrySucceeded: true });
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed')).toBeUndefined();
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Stolen')).toBeUndefined();
   });
 
   it('treats a set-ids-only change as a config switch and preserves the old set attribution', async () => {

--- a/packages/mobile/src/lib/ble/adapter-factory.ts
+++ b/packages/mobile/src/lib/ble/adapter-factory.ts
@@ -31,7 +31,12 @@ export function createBluetoothAdapter(
   if (Platform.OS === 'ios' && boardBleNative && !options?.preferWriteWithResponse) {
     return new NativeIosBleAdapter(devicePicker, scanFamily, options);
   }
-  return new RNBleAdapter(devicePicker, scanFamily, options);
+  // Android retries one transient first GATT connect failure (isRetryableAndroidConnectError)
+  // before surfacing it — see RNBleAdapter.connectSelectedDevice. iOS never sets this.
+  return new RNBleAdapter(devicePicker, scanFamily, {
+    ...options,
+    enableAndroidConnectRetry: Platform.OS === 'android',
+  });
 }
 
 // `true` iff the runtime adapter is the native iOS one — used by the

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -148,6 +148,12 @@ export class RNBleAdapter implements BluetoothAdapter {
   // reached the GATT connect at all (picker cancelled, board not found, scan
   // error), 1 means a single attempt, and 2 means the retry ran.
   private lastConnectAttemptCount = 0;
+  // Whether the retry of the most recent connect won the GATT connect. Read on
+  // the failure path too, where the thrown error carries no result object: a
+  // recovered GATT connect can still fail later at MTU negotiation or service
+  // discovery, and `lastConnectAttemptCount === 2` alone can't tell that apart
+  // from a retry that lost.
+  private lastConnectRetrySucceeded = false;
 
   constructor(
     private readonly devicePicker: DevicePickerFn,
@@ -170,6 +176,7 @@ export class RNBleAdapter implements BluetoothAdapter {
     // silently freeze the clock and pass for the wrong reason.
     const deadlineMs = performance.now() + CONNECTION_TIMEOUT_MS;
     this.lastConnectAttemptCount = 0;
+    this.lastConnectRetrySucceeded = false;
     const attemptConnect = () => {
       this.lastConnectAttemptCount += 1;
       return settleBeforeDeadline(() => bleManager.connectToDevice(selectedDeviceId), deadlineMs);
@@ -207,6 +214,7 @@ export class RNBleAdapter implements BluetoothAdapter {
       throw connectionTimeoutError();
     }
     if (secondAttempt.kind === 'fulfilled') {
+      this.lastConnectRetrySucceeded = true;
       return { connected: secondAttempt.result, retrySucceeded: true };
     }
 
@@ -576,10 +584,20 @@ export class RNBleAdapter implements BluetoothAdapter {
   }
 
   // 0 when the flow never reached the GATT connect, 1 for a single attempt,
-  // 2 when the Android retry ran. Pairs with `retrySucceeded` to give the retry
-  // a denominator: 2 + success is a save, 2 + failure is a retry that lost.
+  // 2 when the retry ran. This is the retry denominator only — on its own it
+  // says nothing about the outcome, because the connect can still fail after a
+  // recovered GATT connect. Read it with getLastConnectRetrySucceeded().
   getLastConnectAttemptCount(): number {
     return this.lastConnectAttemptCount;
+  }
+
+  // True when the retry of the most recent connect won its GATT connect, even
+  // if a later stage then failed. Together with getLastConnectAttemptCount()
+  // this makes the retry hit rate unambiguous on both events:
+  // 2 + true = the retry recovered the GATT connect (a save, whether or not
+  // MTU/discovery then failed); 2 + false = the retry ran and lost.
+  getLastConnectRetrySucceeded(): boolean {
+    return this.lastConnectRetrySucceeded;
   }
 }
 

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -9,6 +9,7 @@ import {
   INTER_CHUNK_DELAY_MS,
   MAX_BLUETOOTH_MESSAGE_SIZE,
   parseSerialNumber,
+  isRetryableAndroidConnectError,
 } from '@boardsesh/ble-protocol';
 import { bleManager } from './ble-manager';
 import { uint8ArrayToBase64, base64ToHex, serviceDataToHex } from './base64';
@@ -29,6 +30,7 @@ import type {
 import { SCAN_TIMEOUT_MS, SERIAL_RECONNECT_GRACE_MS } from '@boardsesh/ble-protocol/scan-constants';
 
 const CONNECTION_TIMEOUT_MS = 12_000;
+const ANDROID_CONNECT_RETRY_BACKOFF_MS = 500;
 
 // The ATT MTU requested after connect. 247 (chunk 244) is the DLE-friendly
 // sweet spot: the iOS-26.5 failure cohort clusters at ATT 512 (#3230), so
@@ -38,6 +40,69 @@ const REQUESTED_ATT_MTU = 247;
 const DEFAULT_ATT_MTU = 23;
 
 const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** Wait the full retry backoff only when it fits inside the shared deadline.
+ * Whichever timer wins clears the other, so a deadline during backoff cannot
+ * leave a 500ms timer alive after the connect sequence has already settled. */
+function waitForRetryBackoffBeforeDeadline(deadlineMs: number): Promise<boolean> {
+  const remainingMs = deadlineMs - Date.now();
+  if (remainingMs <= 0) return Promise.resolve(false);
+
+  return new Promise<boolean>((resolve) => {
+    let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+    let backoffTimer: ReturnType<typeof setTimeout> | null = null;
+    let settled = false;
+    const settle = (completedFullBackoff: boolean) => {
+      if (settled) return;
+      settled = true;
+      if (deadlineTimer !== null) clearTimeout(deadlineTimer);
+      if (backoffTimer !== null) clearTimeout(backoffTimer);
+      resolve(completedFullBackoff);
+    };
+
+    // Schedule the deadline first so an exact tie preserves the existing
+    // semantics: no second attempt begins once the shared budget is exhausted.
+    deadlineTimer = setTimeout(() => settle(false), remainingMs);
+    backoffTimer = setTimeout(() => settle(true), ANDROID_CONNECT_RETRY_BACKOFF_MS);
+  });
+}
+
+type DeadlineSettlement<T> =
+  | { kind: 'fulfilled'; result: T }
+  | { kind: 'rejected'; error: unknown }
+  | { kind: 'deadline' };
+
+/**
+ * Settle one connect-stage operation without extending the stage's shared
+ * deadline. Both fulfillment and rejection handlers stay attached after the
+ * deadline wins, so a late native promise cannot become an unhandled rejection.
+ */
+async function settleBeforeDeadline<T>(
+  operation: () => Promise<T>,
+  deadlineMs: number,
+): Promise<DeadlineSettlement<T>> {
+  const remainingMs = deadlineMs - Date.now();
+  if (remainingMs <= 0) return { kind: 'deadline' };
+
+  let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+  const operationSettlement = Promise.resolve()
+    .then(operation)
+    .then(
+      (result): DeadlineSettlement<T> => ({ kind: 'fulfilled', result }),
+      (error: unknown): DeadlineSettlement<T> => ({ kind: 'rejected', error }),
+    );
+  const deadlineSettlement = new Promise<DeadlineSettlement<T>>((resolve) => {
+    deadlineTimer = setTimeout(() => resolve({ kind: 'deadline' }), remainingMs);
+  });
+
+  return Promise.race([operationSettlement, deadlineSettlement]).finally(() => {
+    if (deadlineTimer !== null) clearTimeout(deadlineTimer);
+  });
+}
+
+function connectionTimeoutError(): Error {
+  return new Error('Connection timed out — board may be powered off');
+}
 
 /**
  * Find a write characteristic by service + characteristic UUID, returning
@@ -71,6 +136,9 @@ export class RNBleAdapter implements BluetoothAdapter {
   // Board-level demand for acknowledged writes (see BleAdapterOptions). Fixed
   // for the adapter's lifetime — the board it was built for doesn't change.
   private readonly preferWriteWithResponse: boolean;
+  // Whether a transient first GATT connect failure gets one in-budget retry
+  // (see BleAdapterOptions.enableAndroidConnectRetry) — Android only.
+  private readonly enableAndroidConnectRetry: boolean;
 
   constructor(
     private readonly devicePicker: DevicePickerFn,
@@ -78,6 +146,59 @@ export class RNBleAdapter implements BluetoothAdapter {
     options?: BleAdapterOptions,
   ) {
     this.preferWriteWithResponse = options?.preferWriteWithResponse ?? false;
+    this.enableAndroidConnectRetry = options?.enableAndroidConnectRetry ?? false;
+  }
+
+  /** Connect the already-selected peripheral, optionally recovering one known
+   * Android GATT handshake failure without rescanning or reopening the picker. */
+  private async connectSelectedDevice(
+    selectedDeviceId: string,
+  ): Promise<{ connected: Device; retrySucceeded: boolean }> {
+    const deadlineMs = Date.now() + CONNECTION_TIMEOUT_MS;
+    const attemptConnect = () => settleBeforeDeadline(() => bleManager.connectToDevice(selectedDeviceId), deadlineMs);
+    const cancelWithoutWaiting = () => {
+      void bleManager.cancelDeviceConnection(selectedDeviceId).catch(() => {});
+    };
+
+    const firstAttempt = await attemptConnect();
+    if (firstAttempt.kind === 'deadline') {
+      cancelWithoutWaiting();
+      throw connectionTimeoutError();
+    }
+    if (firstAttempt.kind === 'fulfilled') {
+      return { connected: firstAttempt.result, retrySucceeded: false };
+    }
+
+    const firstError = firstAttempt.error;
+    if (!this.enableAndroidConnectRetry || !isRetryableAndroidConnectError(firstError)) {
+      throw firstError;
+    }
+
+    // Close the failed native GATT handle before retrying. A rejection generally
+    // means it was already closed, so it must not block the retry. A hanging
+    // cleanup is bounded by the original connect deadline.
+    const cleanup = await settleBeforeDeadline(() => bleManager.cancelDeviceConnection(selectedDeviceId), deadlineMs);
+    if (cleanup.kind === 'deadline') throw firstError;
+
+    const completedBackoff = await waitForRetryBackoffBeforeDeadline(deadlineMs);
+    if (!completedBackoff) throw firstError;
+
+    const secondAttempt = await attemptConnect();
+    if (secondAttempt.kind === 'deadline') {
+      cancelWithoutWaiting();
+      throw connectionTimeoutError();
+    }
+    if (secondAttempt.kind === 'fulfilled') {
+      return { connected: secondAttempt.result, retrySucceeded: true };
+    }
+
+    const secondError = secondAttempt.error;
+    if (isRetryableAndroidConnectError(secondError)) {
+      // No third attempt. Give the exhausted handle the same bounded cleanup as
+      // the first while preserving the exact second error for telemetry.
+      await settleBeforeDeadline(() => bleManager.cancelDeviceConnection(selectedDeviceId), deadlineMs);
+    }
+    throw secondError;
   }
 
   async isAvailable(): Promise<boolean> {
@@ -251,18 +372,7 @@ export class RNBleAdapter implements BluetoothAdapter {
       }
     }
 
-    let connectionTimeoutId: ReturnType<typeof setTimeout> | null = null;
-    const connected = await Promise.race([
-      bleManager.connectToDevice(selectedDeviceId),
-      new Promise<never>((_resolve, reject) => {
-        connectionTimeoutId = setTimeout(() => {
-          bleManager.cancelDeviceConnection(selectedDeviceId).catch(() => {});
-          reject(new Error('Connection timed out — board may be powered off'));
-        }, CONNECTION_TIMEOUT_MS);
-      }),
-    ]).finally(() => {
-      if (connectionTimeoutId != null) clearTimeout(connectionTimeoutId);
-    });
+    const { connected, retrySucceeded } = await this.connectSelectedDevice(selectedDeviceId);
 
     // Negotiate MTU before service discovery (Android requires this order
     // for best results; iOS handles MTU automatically but the call is safe).
@@ -324,6 +434,7 @@ export class RNBleAdapter implements BluetoothAdapter {
       deviceName: selectedDeviceName,
       manufacturerData: selectedManufacturerData,
       serviceData: selectedServiceData,
+      retrySucceeded,
     };
   }
 

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -45,7 +45,7 @@ const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve,
  * Whichever timer wins clears the other, so a deadline during backoff cannot
  * leave a 500ms timer alive after the connect sequence has already settled. */
 function waitForRetryBackoffBeforeDeadline(deadlineMs: number): Promise<boolean> {
-  const remainingMs = deadlineMs - Date.now();
+  const remainingMs = deadlineMs - performance.now();
   if (remainingMs <= 0) return Promise.resolve(false);
 
   return new Promise<boolean>((resolve) => {
@@ -81,7 +81,7 @@ async function settleBeforeDeadline<T>(
   operation: () => Promise<T>,
   deadlineMs: number,
 ): Promise<DeadlineSettlement<T>> {
-  const remainingMs = deadlineMs - Date.now();
+  const remainingMs = deadlineMs - performance.now();
   if (remainingMs <= 0) return { kind: 'deadline' };
 
   let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
@@ -139,6 +139,12 @@ export class RNBleAdapter implements BluetoothAdapter {
   // Whether a transient first GATT connect failure gets one in-budget retry
   // (see BleAdapterOptions.enableAndroidConnectRetry) — Android only.
   private readonly enableAndroidConnectRetry: boolean;
+  // GATT connect attempts made by the most recent connect, for analytics.
+  // Domain is 0/1/2: the adapter is constructed per connect
+  // (use-board-bluetooth.ts createBluetoothAdapter), so 0 means the flow never
+  // reached the GATT connect at all (picker cancelled, board not found, scan
+  // error), 1 means a single attempt, and 2 means the retry ran.
+  private lastConnectAttemptCount = 0;
 
   constructor(
     private readonly devicePicker: DevicePickerFn,
@@ -154,8 +160,17 @@ export class RNBleAdapter implements BluetoothAdapter {
   private async connectSelectedDevice(
     selectedDeviceId: string,
   ): Promise<{ connected: Device; retrySucceeded: boolean }> {
-    const deadlineMs = Date.now() + CONNECTION_TIMEOUT_MS;
-    const attemptConnect = () => settleBeforeDeadline(() => bleManager.connectToDevice(selectedDeviceId), deadlineMs);
+    // Monotonic clock so a mid-connect wall-clock correction cannot stretch or
+    // collapse the budget. The deadline arithmetic here relies on Vitest faking
+    // `performance.now` alongside the timers — it does by default, so never add
+    // an explicit `toFake` list that omits `performance` or the boundary tests
+    // silently freeze the clock and pass for the wrong reason.
+    const deadlineMs = performance.now() + CONNECTION_TIMEOUT_MS;
+    this.lastConnectAttemptCount = 0;
+    const attemptConnect = () => {
+      this.lastConnectAttemptCount += 1;
+      return settleBeforeDeadline(() => bleManager.connectToDevice(selectedDeviceId), deadlineMs);
+    };
     const cancelWithoutWaiting = () => {
       void bleManager.cancelDeviceConnection(selectedDeviceId).catch(() => {});
     };
@@ -194,9 +209,10 @@ export class RNBleAdapter implements BluetoothAdapter {
 
     const secondError = secondAttempt.error;
     if (isRetryableAndroidConnectError(secondError)) {
-      // No third attempt. Give the exhausted handle the same bounded cleanup as
-      // the first while preserving the exact second error for telemetry.
-      await settleBeforeDeadline(() => bleManager.cancelDeviceConnection(selectedDeviceId), deadlineMs);
+      // No third attempt. Close the exhausted handle without waiting: we already
+      // have the terminal error, so awaiting a cleanup that may hang would only
+      // keep the climber on a spinner before we can show it.
+      cancelWithoutWaiting();
     }
     throw secondError;
   }
@@ -556,6 +572,13 @@ export class RNBleAdapter implements BluetoothAdapter {
   // carries the MTU/chunking story; the park/resume fields are iOS-native-only.
   async getLastWriteDiagnostics(): Promise<BleWriteDiagnostics | null> {
     return this.lastWriteDiagnostics;
+  }
+
+  // 0 when the flow never reached the GATT connect, 1 for a single attempt,
+  // 2 when the Android retry ran. Pairs with `retrySucceeded` to give the retry
+  // a denominator: 2 + success is a save, 2 + failure is a retry that lost.
+  getLastConnectAttemptCount(): number {
+    return this.lastConnectAttemptCount;
   }
 }
 

--- a/packages/mobile/src/lib/ble/adapter.ts
+++ b/packages/mobile/src/lib/ble/adapter.ts
@@ -60,8 +60,11 @@ function waitForRetryBackoffBeforeDeadline(deadlineMs: number): Promise<boolean>
       resolve(completedFullBackoff);
     };
 
-    // Schedule the deadline first so an exact tie preserves the existing
-    // semantics: no second attempt begins once the shared budget is exhausted.
+    // Scheduled first, so on an exact-millisecond tie the deadline settles
+    // before the backoff and no second attempt begins on an exhausted budget.
+    // Both real runtimes and Vitest's fake timers run same-expiry timers in
+    // insertion order; `settle` is idempotent either way, so the tie-break is a
+    // preference, not something correctness rests on.
     deadlineTimer = setTimeout(() => settle(false), remainingMs);
     backoffTimer = setTimeout(() => settle(true), ANDROID_CONNECT_RETRY_BACKOFF_MS);
   });
@@ -207,14 +210,12 @@ export class RNBleAdapter implements BluetoothAdapter {
       return { connected: secondAttempt.result, retrySucceeded: true };
     }
 
-    const secondError = secondAttempt.error;
-    if (isRetryableAndroidConnectError(secondError)) {
-      // No third attempt. Close the exhausted handle without waiting: we already
-      // have the terminal error, so awaiting a cleanup that may hang would only
-      // keep the climber on a spinner before we can show it.
-      cancelWithoutWaiting();
-    }
-    throw secondError;
+    // No third attempt. Close whatever handle attempt two left behind, whatever
+    // it failed with — a non-retryable second error strands one just as readily.
+    // Without waiting: we already hold the terminal error, so awaiting a cleanup
+    // that may hang would only keep the climber on a spinner before we show it.
+    cancelWithoutWaiting();
+    throw secondAttempt.error;
   }
 
   async isAvailable(): Promise<boolean> {

--- a/packages/mobile/src/lib/ble/types.ts
+++ b/packages/mobile/src/lib/ble/types.ts
@@ -152,4 +152,8 @@ export type BluetoothAdapter = {
   // Diagnostics of the adapter's most recent failed connect, for tagging a
   // service_missing report. Optional: only native iOS reports it.
   getLastConnectDiagnostics?(): Promise<BleConnectDiagnostics | null>;
+  // GATT connect attempts the adapter's most recent connect made: 0 when it
+  // never reached the connect, 1 for a single attempt, 2 when the Android retry
+  // ran. Optional: only the ble-plx adapter counts them.
+  getLastConnectAttemptCount?(): number;
 };

--- a/packages/mobile/src/lib/ble/types.ts
+++ b/packages/mobile/src/lib/ble/types.ts
@@ -1,6 +1,9 @@
 export type BleConnection = {
   deviceId: string;
   deviceName?: string;
+  // True only when the Android ble-plx adapter recovered a transient first
+  // GATT connect failure with its single in-budget retry.
+  retrySucceeded?: boolean;
   // Advertisement recon payload of the connected device, threaded through so the
   // `Bluetooth Connection Success` event can carry it. See `AdvertisementRecon`.
   manufacturerData?: string;
@@ -128,6 +131,10 @@ export type BleConnectDiagnostics = {
  */
 export type BleAdapterOptions = {
   preferWriteWithResponse?: boolean;
+  // RNBleAdapter only: retry one transient first GATT connect failure before
+  // surfacing it. Android only — set by createBluetoothAdapter from Platform.OS,
+  // never by a board's own preferences.
+  enableAndroidConnectRetry?: boolean;
 };
 
 export type BluetoothAdapter = {

--- a/packages/mobile/src/lib/ble/types.ts
+++ b/packages/mobile/src/lib/ble/types.ts
@@ -156,4 +156,8 @@ export type BluetoothAdapter = {
   // never reached the connect, 1 for a single attempt, 2 when the Android retry
   // ran. Optional: only the ble-plx adapter counts them.
   getLastConnectAttemptCount?(): number;
+  // Whether that retry won its GATT connect, even if the connect then failed
+  // downstream (MTU, discovery). Needed on the failure path, where the thrown
+  // error carries no `retrySucceeded`. Optional: only the ble-plx adapter retries.
+  getLastConnectRetrySucceeded?(): boolean;
 };

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -1607,9 +1607,16 @@ export function useBoardBluetooth({
           sizeId,
           failureReason: failureCategory === 'unknown' ? classifyBleFailureReason(error) : failureCategory,
           // 0 = never reached the GATT connect (picker cancelled, board not
-          // found, scan error), 1 = one attempt, 2 = the Android retry ran and
-          // lost. Key is dropped on native iOS and web.
+          // found, scan error), 1 = one attempt, 2 = the Android retry ran.
+          // Key is dropped on native iOS and web.
           connectAttempts: connectAdapter?.getLastConnectAttemptCount?.(),
+          // 2 alone does NOT mean the retry lost: a recovered GATT connect can
+          // still fail at MTU negotiation or service discovery, and that lands
+          // here too. `retrySucceeded: true` on a failure event is exactly that
+          // case — the retry saved the connect, something later broke it — so
+          // the retry hit rate is `retrySucceeded` over `connectAttempts = 2`
+          // across BOTH events, not success events over attempts = 2.
+          retrySucceeded: connectAdapter?.getLastConnectRetrySucceeded?.(),
           // Raw ble-plx codes (Android) so the real connect-failure cause and the
           // low-level GATT status are visible for re-measurement (#3608). Empty on
           // web / native iOS.

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -1508,7 +1508,11 @@ export function useBoardBluetooth({
           deviceNamePresent: !!connection.deviceName,
           boardId: analyticsBoardId ?? undefined,
           connectedViaMismatchOverride: getConnectedViaMismatchOverride?.() ?? false,
-          retry_succeeded: connection.retrySucceeded === true,
+          retrySucceeded: connection.retrySucceeded === true,
+          // Denominator for retrySucceeded: 0 = never reached the GATT connect,
+          // 1 = one attempt, 2 = the Android retry ran. Key is dropped on native
+          // iOS and web, whose adapters don't count attempts.
+          connectAttempts: connectAdapter?.getLastConnectAttemptCount?.(),
           bleChosenWriteType: connectionDiagnostics?.chosenWriteType,
           bleSupportsWithoutResponse: connectionDiagnostics?.supportsWriteWithoutResponse,
           bleCharProperties: connectionDiagnostics?.characteristicProperties,
@@ -1597,18 +1601,20 @@ export function useBoardBluetooth({
             Alert.alert(t('ble.connectionFailedTitle'), tCommon('bluetooth.unknownError'));
         }
 
-        if (failureCategory !== 'user_cancelled') {
-          track(SHARED_EVENTS.BluetoothConnectionFailed, {
-            boardName,
-            layoutId,
-            sizeId,
-            failureReason: failureCategory === 'unknown' ? classifyBleFailureReason(error) : failureCategory,
-            // Raw ble-plx codes (Android) so the real connect-failure cause and the
-            // low-level GATT status are visible for re-measurement (#3608). Empty on
-            // web / native iOS.
-            ...blePlxErrorCodes(error),
-          });
-        }
+        track(SHARED_EVENTS.BluetoothConnectionFailed, {
+          boardName,
+          layoutId,
+          sizeId,
+          failureReason: failureCategory === 'unknown' ? classifyBleFailureReason(error) : failureCategory,
+          // 0 = never reached the GATT connect (picker cancelled, board not
+          // found, scan error), 1 = one attempt, 2 = the Android retry ran and
+          // lost. Key is dropped on native iOS and web.
+          connectAttempts: connectAdapter?.getLastConnectAttemptCount?.(),
+          // Raw ble-plx codes (Android) so the real connect-failure cause and the
+          // low-level GATT status are visible for re-measurement (#3608). Empty on
+          // web / native iOS.
+          ...blePlxErrorCodes(error),
+        });
       } finally {
         connectInFlightRef.current = false;
         setLoading(false);

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -1508,6 +1508,7 @@ export function useBoardBluetooth({
           deviceNamePresent: !!connection.deviceName,
           boardId: analyticsBoardId ?? undefined,
           connectedViaMismatchOverride: getConnectedViaMismatchOverride?.() ?? false,
+          retry_succeeded: connection.retrySucceeded === true,
           bleChosenWriteType: connectionDiagnostics?.chosenWriteType,
           bleSupportsWithoutResponse: connectionDiagnostics?.supportsWriteWithoutResponse,
           bleCharProperties: connectionDiagnostics?.characteristicProperties,
@@ -1596,16 +1597,18 @@ export function useBoardBluetooth({
             Alert.alert(t('ble.connectionFailedTitle'), tCommon('bluetooth.unknownError'));
         }
 
-        track(SHARED_EVENTS.BluetoothConnectionFailed, {
-          boardName,
-          layoutId,
-          sizeId,
-          failureReason: failureCategory === 'unknown' ? classifyBleFailureReason(error) : failureCategory,
-          // Raw ble-plx codes (Android) so the real connect-failure cause and the
-          // low-level GATT status are visible for re-measurement (#3608). Empty on
-          // web / native iOS.
-          ...blePlxErrorCodes(error),
-        });
+        if (failureCategory !== 'user_cancelled') {
+          track(SHARED_EVENTS.BluetoothConnectionFailed, {
+            boardName,
+            layoutId,
+            sizeId,
+            failureReason: failureCategory === 'unknown' ? classifyBleFailureReason(error) : failureCategory,
+            // Raw ble-plx codes (Android) so the real connect-failure cause and the
+            // low-level GATT status are visible for re-measurement (#3608). Empty on
+            // web / native iOS.
+            ...blePlxErrorCodes(error),
+          });
+        }
       } finally {
         connectInFlightRef.current = false;
         setLoading(false);

--- a/packages/shared/ble-protocol/src/__tests__/connection-error.test.ts
+++ b/packages/shared/ble-protocol/src/__tests__/connection-error.test.ts
@@ -6,6 +6,7 @@ import {
   isBleWriteRecoveryFailedError,
   isBleWriteTimeoutError,
   isDisconnectionError,
+  isRetryableAndroidConnectError,
   type BleFailureCategory,
   type BleSendFailureReason,
 } from '../connection-error';
@@ -28,17 +29,19 @@ function bleError(message: string): Error {
 function bleErrorWithCode(
   errorCode: number,
   message: string,
-  extra?: { androidErrorCode?: number; iosErrorCode?: number },
+  extra?: { androidErrorCode?: number | null; iosErrorCode?: number | null },
 ): Error {
   const error = new Error(message) as Error & {
     errorCode: number;
-    androidErrorCode?: number;
-    iosErrorCode?: number;
+    androidErrorCode: number | null;
+    iosErrorCode: number | null;
   };
   error.name = 'BleError';
   error.errorCode = errorCode;
-  if (extra?.androidErrorCode !== undefined) error.androidErrorCode = extra.androidErrorCode;
-  if (extra?.iosErrorCode !== undefined) error.iosErrorCode = extra.iosErrorCode;
+  // This is the real ble-plx runtime shape: both properties exist and the
+  // inactive/omitted platform code is null (never an absent property).
+  error.androidErrorCode = extra?.androidErrorCode ?? null;
+  error.iosErrorCode = extra?.iosErrorCode ?? null;
   return error;
 }
 
@@ -437,5 +440,105 @@ describe('blePlxErrorCodes (#3608)', () => {
     cbError.name = 'CBError';
     cbError.errorCode = 7;
     expect(blePlxErrorCodes(cbError)).toEqual({});
+  });
+});
+
+describe('isRetryableAndroidConnectError (#4143)', () => {
+  it.each([200, 201, 205])('allows ble-plx connect code %i with its canonical null Android status', (errorCode) => {
+    expect(isRetryableAndroidConnectError(bleErrorWithCode(errorCode, 'connect failed'))).toBe(true);
+  });
+
+  it.each([200, 201, 205])(
+    'denies explicit user cancellation for connect code %i with null or absent platform fields',
+    (errorCode) => {
+      for (const message of [
+        'Device selection cancelled',
+        'The user cancelled the request',
+        'The user canceled the request',
+      ]) {
+        expect(isRetryableAndroidConnectError(bleErrorWithCode(errorCode, message))).toBe(false);
+
+        const absentPlatformFields = bleErrorWithCode(errorCode, message) as Error & {
+          androidErrorCode?: number | null;
+          iosErrorCode?: number | null;
+        };
+        delete absentPlatformFields.androidErrorCode;
+        delete absentPlatformFields.iosErrorCode;
+        expect(isRetryableAndroidConnectError(absentPlatformFields)).toBe(false);
+      }
+    },
+  );
+
+  it.each(['Operation was cancelled', 'Connection cancelled by peer'])(
+    'does not mistake the technical failure "%s" for a picker dismissal',
+    (message) => {
+      expect(isRetryableAndroidConnectError(bleErrorWithCode(201, message))).toBe(true);
+    },
+  );
+
+  it('also allows an older structural BleError shape which omitted the Android field entirely', () => {
+    const error = bleErrorWithCode(201, 'connect failed') as Error & { androidErrorCode?: number | null };
+    delete error.androidErrorCode;
+    expect(isRetryableAndroidConnectError(error)).toBe(true);
+  });
+
+  it.each([200, 201, 205])('allows ble-plx connect code %i with Android GATT status 133 or 147', (errorCode) => {
+    expect(
+      isRetryableAndroidConnectError(bleErrorWithCode(errorCode, 'connect failed', { androidErrorCode: 133 })),
+    ).toBe(true);
+    expect(
+      isRetryableAndroidConnectError(bleErrorWithCode(errorCode, 'connect failed', { androidErrorCode: 147 })),
+    ).toBe(true);
+  });
+
+  it.each([0, 2, 3, 100, 101, 102, 204, 206, 300, 302, 400, 404])(
+    'denies non-connect or terminal ble-plx code %i',
+    (errorCode) => {
+      expect(isRetryableAndroidConnectError(bleErrorWithCode(errorCode, 'opaque'))).toBe(false);
+      // An allowlisted low-level status cannot turn a non-allowlisted outer
+      // operation into a connect retry.
+      expect(isRetryableAndroidConnectError(bleErrorWithCode(errorCode, 'opaque', { androidErrorCode: 133 }))).toBe(
+        false,
+      );
+    },
+  );
+
+  it.each([0, 1, 8, 19, 22, 62, 257])(
+    'lets a present non-transient Android status %i veto an otherwise allowlisted connect error',
+    (androidErrorCode) => {
+      expect(isRetryableAndroidConnectError(bleErrorWithCode(201, 'disconnected', { androidErrorCode }))).toBe(false);
+    },
+  );
+
+  it('denies a malformed Android status instead of treating it as absent', () => {
+    const error = bleErrorWithCode(201, 'disconnected') as Error & { androidErrorCode: unknown };
+    error.androidErrorCode = '133';
+    expect(isRetryableAndroidConnectError(error)).toBe(false);
+  });
+
+  it('denies a real ble-plx iOS shape even when its outer code is otherwise eligible', () => {
+    expect(isRetryableAndroidConnectError(bleErrorWithCode(201, 'iOS disconnected', { iosErrorCode: 7 }))).toBe(false);
+  });
+
+  it('denies a malformed populated iOS status conservatively', () => {
+    const error = bleErrorWithCode(201, 'iOS disconnected') as Error & { iosErrorCode: unknown };
+    error.iosErrorCode = '7';
+    expect(isRetryableAndroidConnectError(error)).toBe(false);
+  });
+
+  it('requires the real BleError name and numeric outer code', () => {
+    const plainError = new Error('GATT 133') as Error & { errorCode?: unknown; androidErrorCode?: number };
+    plainError.errorCode = 201;
+    plainError.androidErrorCode = 133;
+    expect(isRetryableAndroidConnectError(plainError)).toBe(false);
+
+    plainError.name = 'CBError';
+    expect(isRetryableAndroidConnectError(plainError)).toBe(false);
+
+    plainError.name = 'BleError';
+    plainError.errorCode = '201';
+    expect(isRetryableAndroidConnectError(plainError)).toBe(false);
+    expect(isRetryableAndroidConnectError('GATT 133')).toBe(false);
+    expect(isRetryableAndroidConnectError(null)).toBe(false);
   });
 });

--- a/packages/shared/ble-protocol/src/connection-error.ts
+++ b/packages/shared/ble-protocol/src/connection-error.ts
@@ -73,6 +73,42 @@ function isBlePlxError(error: unknown): error is BlePlxErrorShape {
   return errorName(error) === BLE_PLX_ERROR_NAME;
 }
 
+// Only these ble-plx connect errors can represent Android's transient GATT
+// handshake failure. Keep this narrower than BLE_PLX_CODE_TO_CATEGORY below:
+// timeout, MTU, discovery and lookup errors are terminal and must not replay the
+// selected-device connect.
+const RETRYABLE_ANDROID_CONNECT_ERROR_CODES = new Set([200, 201, 205]);
+const RETRYABLE_ANDROID_GATT_STATUSES = new Set([133, 147]);
+
+/**
+ * True only for the small set of Android GATT connect failures which are known
+ * to recover after closing the stale GATT handle and trying the same peripheral
+ * once more. This is structural so the shared package stays pure TypeScript.
+ *
+ * The outer ble-plx code establishes that the failure came from the connection
+ * step. When Android also supplied its lower-level GATT status, that status is
+ * authoritative: only 133 (generic GATT error) and 147 may retry. A missing
+ * Android status is allowed because some devices/OS versions omit it entirely.
+ */
+export function isRetryableAndroidConnectError(error: unknown): boolean {
+  if (!isBlePlxError(error) || typeof error.errorCode !== 'number') return false;
+  if (!RETRYABLE_ANDROID_CONNECT_ERROR_CODES.has(error.errorCode)) return false;
+  // A chooser dismissal is never a failed GATT handshake. Keep this identical
+  // to classifyBleFailure's deliberately narrow user-cancel wording: a broad
+  // `cancel` match would also catch genuine technical failures such as
+  // "Operation was cancelled" and "Connection cancelled by peer".
+  if (/user cancell?ed|Device selection cancelled/i.test(errorMessage(error))) return false;
+  // ble-plx always carries both platform fields and uses null for the inactive
+  // platform. Reject a populated iOS field so this Android-only predicate stays
+  // safe even when called independently of the platform-gated adapter factory.
+  if (error.iosErrorCode !== undefined && error.iosErrorCode !== null) return false;
+  // On Android, ble-plx represents an omitted native GATT status as null. Keep
+  // accepting an actually-absent property too for structurally equivalent test
+  // doubles and older library shapes.
+  if (error.androidErrorCode === undefined || error.androidErrorCode === null) return true;
+  return typeof error.androidErrorCode === 'number' && RETRYABLE_ANDROID_GATT_STATUSES.has(error.androidErrorCode);
+}
+
 /**
  * Maps a ble-plx (`react-native-ble-plx`) numeric `BleErrorCode` to a connect
  * failure category. The code is a far more reliable signal than ble-plx's English

--- a/packages/shared/ble-protocol/src/connection-error.ts
+++ b/packages/shared/ble-protocol/src/connection-error.ts
@@ -55,6 +55,19 @@ function errorMessage(error: unknown): string {
   return String(error);
 }
 
+// The only wording we accept as "the climber dismissed the picker". Deliberately
+// narrow: a bare `cancel` would also match genuine technical failures such as
+// CoreBluetooth's "operation cancelled" and ble-plx's "Connection cancelled by
+// peer", which would then show the climber nothing at all.
+//
+// One constant on purpose. Both classifyBleFailure and
+// isRetryableAndroidConnectError need the same answer, and broadening it in only
+// one of them would let a cancelled connect burn the 500ms backoff plus a doomed
+// second connect (or, the other way round, silently swallow a real failure).
+// No `g` flag, so `.test` carries no lastIndex state and this instance is safe
+// to share across call sites.
+const USER_CANCEL_MESSAGE_PATTERN = /user cancell?ed|Device selection cancelled/i;
+
 // The three numeric codes `react-native-ble-plx` puts on every thrown `BleError`.
 // Read structurally (this package is platform-agnostic pure TS and must not depend
 // on react-native-ble-plx) after gating on the error name below.
@@ -93,11 +106,9 @@ const RETRYABLE_ANDROID_GATT_STATUSES = new Set([133, 147]);
 export function isRetryableAndroidConnectError(error: unknown): boolean {
   if (!isBlePlxError(error) || typeof error.errorCode !== 'number') return false;
   if (!RETRYABLE_ANDROID_CONNECT_ERROR_CODES.has(error.errorCode)) return false;
-  // A chooser dismissal is never a failed GATT handshake. Keep this identical
-  // to classifyBleFailure's deliberately narrow user-cancel wording: a broad
-  // `cancel` match would also catch genuine technical failures such as
-  // "Operation was cancelled" and "Connection cancelled by peer".
-  if (/user cancell?ed|Device selection cancelled/i.test(errorMessage(error))) return false;
+  // A chooser dismissal is never a failed GATT handshake, so it must never
+  // replay the connect. Same pattern classifyBleFailure uses, by construction.
+  if (USER_CANCEL_MESSAGE_PATTERN.test(errorMessage(error))) return false;
   // ble-plx always carries both platform fields and uses null for the inactive
   // platform. Reject a populated iOS field so this Android-only predicate stays
   // safe even when called independently of the platform-gated adapter factory.
@@ -172,11 +183,10 @@ export function classifyBleFailure(error: unknown, pairingStage?: string): BleFa
     if (codeCategory) return codeCategory;
   }
 
-  // User dismissed the picker. Match only explicit user-cancel signals — a bare
-  // "cancel" would also swallow real failures like CoreBluetooth's
-  // "operation cancelled" / "Connection cancelled by peer", silently showing
-  // the user nothing. NotFoundError is the Web Bluetooth chooser-dismissed name.
-  if (name === 'NotFoundError' || /user cancell?ed|Device selection cancelled/i.test(message)) {
+  // User dismissed the picker. Match only explicit user-cancel signals — see
+  // USER_CANCEL_MESSAGE_PATTERN for why the wording is this narrow.
+  // NotFoundError is the Web Bluetooth chooser-dismissed name.
+  if (name === 'NotFoundError' || USER_CANCEL_MESSAGE_PATTERN.test(message)) {
     return 'user_cancelled';
   }
 


### PR DESCRIPTION
## Summary

`RNBleAdapter.requestAndConnect` made exactly one GATT connect attempt, so Android's canonical transient handshake failure — GATT status 133 — was terminal on the first tap. This adds one bounded retry.

- retry the **already-selected** device id once after a 500 ms backoff when ble-plx reports an eligible connect error with GATT 133/147 or no native status — no rescan, no second picker
- one absolute 12-second budget shared across the first attempt, stale-handle cleanup, backoff, retry, and exhausted cleanup, so a dead board fails no later than it does today
- terminal failures are rethrown by identity: iOS-shaped, malformed, picker-cancel, permission, discovery, MTU
- gated on `Platform.OS === 'android'` at the factory; iOS and the Expo browser target keep the single-shot path
- emits `retrySucceeded` and `connectAttempts` on both the success and failure events so the retry has a measurable hit rate

Closes #4143.

## Why this allowlist

Measured against the fleet (PostHog, `Bluetooth Connection Failed`, 90 days, grouped by `failureReason` × `bleErrorCode` × `androidErrorCode`):

| bleErrorCode | androidErrorCode | events | users |
| --- | --- | --- | --- |
| 201 | 133 | 360 | 138 |
| 201 | null | 38 | 15 |
| 205 | null | 32 | 15 |
| 201 | 147 | 3 | 3 |
| 3 (OperationTimedOut) | null | 2 | 1 |
| null (iOS / web) | null | 317 | 170 |

433 of the 752 `connect_failed` events — effectively every Android one — fall inside the `{200, 201, 205} × {133, 147, null}` allowlist, and the one ineligible bucket (OperationTimedOut) is correctly excluded. That table is also the pre-fix baseline the new `retrySucceeded` / `connectAttempts` split reads against. Note 1,615 of the 8,778 90-day failure events carry a null `failureReason` (older builds predating that property), so scope any before/after read to events that carry it.

## Review comments addressed

1. **Exhausted cleanup blocked the failure alert** (`adapter.ts`) — the final `cancelDeviceConnection` is now fire-and-forget, same as the first-attempt deadline branch. We already have the terminal error at that point, so nothing should hold the alert back. Its test now advances 500 ms instead of 12 s and asserts zero pending timers.
2. **`retry_succeeded` naming + missing denominator** (`use-board-bluetooth.ts`) — renamed to `retrySucceeded` to match every sibling property in that payload, and both the success and failure events now carry `connectAttempts`. Domain is **0/1/2**, not 1/2: `createBluetoothAdapter` runs per connect, so anything that never reaches the GATT connect (picker cancel, board not found, scan error) reports 0, and that is the dominant bucket. 1 = a single attempt (ineligible error, or the first failure landed too late for the backoff to fit the budget); 2 + success = the retry saved it; 2 + failure = the retry ran and lost. The key is dropped on native iOS and web. This is a getter on the adapter rather than a field on `BleConnection` as the comment suggested — the failure path only ever sees a thrown error and has no connection object to carry it.
3. **Picker-cancel telemetry gate** — reverted; `Bluetooth Connection Failed` fires unconditionally again. One half of the original rationale is stale (`packages/web/app/components/board-bluetooth-control/` no longer exists on `main`, and the only emitters left are in the mobile hook), but the out-of-scope half stands on its own: `user_cancelled` is 5,380 of ~8,778 of that event's 90-day volume, so the gate would delete the only measure of picker-dismissal rate. Worth its own issue.
4. **Wall-clock deadline** (`adapter.ts`) — all three `Date.now()` reads swapped for `performance.now()`. To be precise about the guarantee: RN 0.86's `setUpPerformance` falls back to `global.nativePerformanceNow || Date.now` when `NativePerformance` is absent, so this is monotonic on every real Hermes runtime and never worse than today. There is a comment at the deadline assignment noting the arithmetic depends on Vitest faking `performance.now` — it does by default, and an explicit `toFake` list omitting `performance` would silently freeze the clock and pass the boundary tests for the wrong reason.

The rebase onto `main` resolved one conflicted file (`use-board-bluetooth.test.ts`), keeping both `main`'s new config-switch attribution test and this branch's retry assertions.

## QA

- `vp run typecheck:mobile`, `vp run typecheck:ble-protocol`
- `vp run test:mobile`, `vp test run --project ble-protocol`
- `vp check`
- `vp run check:mobile-bundle`
- boundary stress at 11.5 s / 11.75 s / 11.999 s proves no second attempt begins and no timer leaks

## Still owed before merge

- **Fable BLE review** — CLAUDE.md hard rule for anything touching `packages/mobile/src/lib/ble` or `packages/shared/ble-protocol`. The existing Sol review is not a substitute.
- **Real-device Android QA** — reproduce ble-plx 133 / 147 / null-status failures against an actual board and confirm recovery, plus timeout, double-tap, picker dismissal, config switching, two-phone takeover. Two things no unit test can see: a recovered connect must not reopen the picker, and must not double-fire the success haptic.

TS-only, so it ships over the air — no new build needed.

## Release Notes

Android now retries a transient board connection once, so a brief GATT hiccup is less likely to send you back to the connect button.
