### PR TITLE
fix(sync): run recurring MoonBoard location sync

### DIFF
--- a/Dockerfile.sync
+++ b/Dockerfile.sync
@@ -9,12 +9,12 @@
 # scheduler directly via tsx.
 # Sibling of Dockerfile.backend. The actual command is supplied by the container
 # `command:` (e.g. docker-compose, or Railway's custom start command), so one
-# image serves every CLI. kilter and aurora expose a long-running `daemon`;
-# moonboard is locations-only (no daemon subcommand); the scheduler's `start`
-# runs the cron loop and a /health server (see docs/scheduler.md):
+# image serves every CLI. kilter, aurora, and moonboard expose a long-running
+# `daemon`; the scheduler's `start` runs the cron loop and a /health server
+# (see docs/scheduler.md):
 #   node --import tsx packages/kilter-sync/src/cli/index.ts daemon
 #   node --import tsx packages/aurora-sync/src/cli/index.ts daemon
-#   node --import tsx packages/moonboard-sync/src/cli/index.ts locations
+#   node --import tsx packages/moonboard-sync/src/cli/index.ts daemon --skip-if-missing-credentials
 #   node --import tsx packages/scheduler/src/cli/index.ts start
 FROM node:22-alpine
 

--- a/docs/branch-deploys.md
+++ b/docs/branch-deploys.md
@@ -1234,14 +1234,14 @@ After API consolidation:
 
 ### Current State
 
-Sync runs as **long-lived daemon CLIs on a VM**, not as HTTP crons:
+Aurora and Kilter sync run as **long-lived daemon CLIs on a VM**, not as HTTP crons:
 
 - `aurora-sync daemon` (Kilter/Tension via the Aurora API)
 - `kilter-sync daemon` (Kilter Grips via Keycloak + PowerSync + REST)
 
-The daemons loop internally (one user per cycle, quiet hours, shared/catalog sync piggybacked) and authenticate with stored per-user credentials — nothing fronts them, so there is no `CRON_SECRET`. The earlier Vercel crons (`/api/internal/user-sync-cron`, etc.) and backend handlers (`/sync-cron`, `/kilter-sync-cron`) were removed. Shared/catalog cooldowns are persisted in Postgres with per-board compare-and-set claims, so they survive restarts and coordinate overlapping daemon instances.
+Those daemons loop internally with quiet hours and provider-specific cadence and authenticate with stored per-user credentials — nothing fronts them, so there is no `CRON_SECRET`. The earlier Vercel crons (`/api/internal/user-sync-cron`, etc.) and backend handlers (`/sync-cron`, `/kilter-sync-cron`) were removed. Shared/catalog cooldowns are persisted in Postgres with per-board compare-and-set claims, so they survive restarts and coordinate overlapping daemon instances.
 
-MoonBoard public locations use a separate manual CLI, `moonboard-sync locations`, because there is no per-user MoonBoard daemon yet.
+The repository image and runner are ready for `moonboard-sync daemon` to sync public MoonBoard gym locations every six to eight hours, but it is **not running in production yet**. Production enablement still requires a separate sync-host service command, `MOONBOARD_USERNAME` / `MOONBOARD_PASSWORD`, and the operator checks under [MoonBoard Sync: First production run](./moonboard-sync.md#first-production-run). CI does not perform those external deployment or data-validation steps.
 
 ### Branch Deploy Sync Strategy
 
@@ -1263,7 +1263,7 @@ What changed → what gets deployed:
 | `packages/aurora-sync`    |    Yes     |    Yes    |      Yes       | Daemon is not run on branch deploys |
 | `packages/kilter-sync`    |    Yes     |    Yes    |      Yes       | Daemon is not run on branch deploys |
 | `packages/location-sync`  |    Yes     |    Yes    |      Yes       | Shared public location writer       |
-| `packages/moonboard-sync` |    Yes     |    Yes    |      Yes       | Manual CLI is not run automatically |
+| `packages/moonboard-sync` |    Yes     |    Yes    |      Yes       | Daemon is not run on branch deploys |
 | Multiple packages         |    Yes     |    Yes    |      Yes       | Full stack always deployed together |
 
 **Implementation:** The `dorny/paths-filter` step from Phase 1 (Section 1.3) drives this matrix. The build-images job builds both web and backend images. The deploy job invokes the Ansible playbook on a self-hosted runner.

--- a/docs/moonboard-sync.md
+++ b/docs/moonboard-sync.md
@@ -1,6 +1,6 @@
 # MoonBoard Sync
 
-`@boardsesh/moonboard-sync` is the MoonBoard-specific public location sync CLI. It exists because MoonBoard locations are not available through Aurora or Kilter Grips APIs.
+`@boardsesh/moonboard-sync` is the MoonBoard-specific public location sync CLI and daemon. It exists because MoonBoard locations are not available through Aurora or Kilter Grips APIs.
 
 ## Public board locations
 
@@ -38,7 +38,18 @@ When the sync first runs against a database whose MoonBoard gyms were seeded wit
 ```bash
 moonboard-sync locations
 moonboard-sync locations --username <email> --password <password> -v
+moonboard-sync daemon --skip-if-missing-credentials
 ```
+
+`daemon` runs one location sync immediately during active hours, then repeats every six to eight hours with jitter. It uses the shared Postgres daemon lease under the `moonboard-sync` key, so a second container stays in standby during a rolling deploy and takes over when the active process releases or loses the lease. The location writes remain idempotent because the lease is an overlap reduction mechanism, not a correctness lock.
+
+The combined `boardsesh-sync` image includes this command. The production sync host must run a separate service with:
+
+```bash
+bunx tsx packages/moonboard-sync/src/cli/index.ts daemon --skip-if-missing-credentials
+```
+
+Branch deploys do not run this daemon; they continue using the location snapshot in the dev database image.
 
 Environment variables:
 
@@ -55,3 +66,15 @@ op run --env-file=packages/moonboard-sync/.env.1password -- vp exec moonboard-sy
 ```
 
 The root `vp run db:seed-locations` task runs the Aurora, Kilter, and MoonBoard location CLIs instead of the removed GeoJSON seed script. Credentialed providers are safe in clean dev environments: Kilter and MoonBoard skip with a successful exit when their credentials are not configured.
+
+## First production run
+
+The first scheduled run needs an operator check because production's April 2026 MoonBoard seed predates source aliases:
+
+1. Record the current MoonBoard gym, board, and `moonboard:` source-alias counts.
+2. Configure `MOONBOARD_USERNAME` and `MOONBOARD_PASSWORD` on the sync host and start the daemon service.
+3. Confirm the sync adopts the seeded gyms through name-and-location matching and creates aliases without creating a second set of gyms.
+4. Inspect `/admin/gym-duplicates` for the rare pin correction that crossed a coarse source-key cell. Verify and merge any real twins manually.
+5. Check a later daemon cycle updates the same aliases and leaves duplicate counts stable.
+
+The repository provides the runner and container command. Sync-host service configuration, credentials, and these production data checks are deployment steps and are not performed by CI.

--- a/packages/db/src/queries/sync/daemon-lease.ts
+++ b/packages/db/src/queries/sync/daemon-lease.ts
@@ -7,6 +7,7 @@ type DrizzleDb = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
 /** Daemon identities that take a lease. One row in `sync_daemon_leases` each. */
 export const AURORA_SYNC_DAEMON = 'aurora-sync';
 export const KILTER_SYNC_DAEMON = 'kilter-sync';
+export const MOONBOARD_SYNC_DAEMON = 'moonboard-sync';
 
 /**
  * How long a lease survives without a heartbeat before another instance may

--- a/packages/moonboard-sync/package.json
+++ b/packages/moonboard-sync/package.json
@@ -23,6 +23,11 @@
       "types": "./src/sync/index.ts",
       "import": "./src/sync/index.ts",
       "default": "./src/sync/index.ts"
+    },
+    "./runner": {
+      "types": "./src/runner/index.ts",
+      "import": "./src/runner/index.ts",
+      "default": "./src/runner/index.ts"
     }
   },
   "scripts": {
@@ -33,11 +38,13 @@
     "typecheck": "tsc --noEmit",
     "lint": "vp lint",
     "lint-fix": "vp lint --fix",
+    "sync:daemon": "tsx src/cli/index.ts daemon --skip-if-missing-credentials",
     "sync:locations": "tsx src/cli/index.ts locations --skip-if-missing-credentials"
   },
   "dependencies": {
     "@boardsesh/db": "workspace:*",
     "@boardsesh/location-sync": "workspace:*",
+    "@boardsesh/sync-runtime": "workspace:*",
     "commander": "^15.0.0",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2"

--- a/packages/moonboard-sync/src/cli/index.ts
+++ b/packages/moonboard-sync/src/cli/index.ts
@@ -2,56 +2,98 @@
 /* eslint-disable no-console */
 import 'dotenv/config';
 import { Command } from 'commander';
-import { createDb, closePool } from '@boardsesh/db/client';
-import { syncMoonBoardLocations } from '../sync/locations-sync';
+import { MoonBoardSyncRunner } from '../runner/sync-runner';
+
+type CredentialOptions = {
+  username?: string;
+  password?: string;
+  skipIfMissingCredentials?: boolean;
+  verbose?: boolean;
+};
+
+function resolveCredentials(options: CredentialOptions): { username: string; password: string } | null {
+  const username = options.username ?? process.env.MOONBOARD_USERNAME;
+  const password = options.password ?? process.env.MOONBOARD_PASSWORD;
+  if (username && password) return { username, password };
+
+  if (options.skipIfMissingCredentials) {
+    console.log('Skipping MoonBoard location sync: MOONBOARD_USERNAME/MOONBOARD_PASSWORD are not configured.');
+    return null;
+  }
+
+  console.error(
+    'MoonBoard credentials are required: pass --username/--password or set MOONBOARD_USERNAME/MOONBOARD_PASSWORD.',
+  );
+  process.exitCode = 1;
+  return null;
+}
+
+function createRunner(credentials: { username: string; password: string }, verbose = false): MoonBoardSyncRunner {
+  return new MoonBoardSyncRunner({
+    ...credentials,
+    onLog: verbose ? (message) => console.info(message) : undefined,
+  });
+}
+
+function addCredentialOptions(command: Command): Command {
+  return command
+    .option('--username <username>', 'MoonBoard username; defaults to MOONBOARD_USERNAME')
+    .option('--password <password>', 'MoonBoard password; defaults to MOONBOARD_PASSWORD')
+    .option('--skip-if-missing-credentials', 'exit successfully when MoonBoard credentials are not configured')
+    .option('-v, --verbose', 'verbose logging');
+}
 
 const program = new Command();
 program.name('moonboard-sync').description('MoonBoard sync utility for Boardsesh').version('1.0.0');
 
-program
-  .command('locations')
-  .description('Sync public MoonBoard gym locations into gyms / user_boards')
-  .option('--username <username>', 'MoonBoard username; defaults to MOONBOARD_USERNAME')
-  .option('--password <password>', 'MoonBoard password; defaults to MOONBOARD_PASSWORD')
-  .option('--skip-if-missing-credentials', 'exit successfully when MoonBoard credentials are not configured')
-  .option('-v, --verbose', 'verbose logging')
-  .action(
-    async (options: {
-      username?: string;
-      password?: string;
-      skipIfMissingCredentials?: boolean;
-      verbose?: boolean;
-    }) => {
-      const username = options.username ?? process.env.MOONBOARD_USERNAME;
-      const password = options.password ?? process.env.MOONBOARD_PASSWORD;
-      if (!username || !password) {
-        if (options.skipIfMissingCredentials) {
-          console.log('Skipping MoonBoard location sync: MOONBOARD_USERNAME/MOONBOARD_PASSWORD are not configured.');
-          return;
-        }
-        console.error(
-          'MoonBoard credentials are required: pass --username/--password or set MOONBOARD_USERNAME/MOONBOARD_PASSWORD.',
-        );
-        process.exit(1);
-      }
+addCredentialOptions(
+  program.command('locations').description('Sync public MoonBoard gym locations into gyms / user_boards'),
+).action(async (options: CredentialOptions) => {
+  const credentials = resolveCredentials(options);
+  if (!credentials) return;
 
-      try {
-        const db = createDb();
-        const summary = await syncMoonBoardLocations({
-          db,
-          username,
-          password,
-          log: options.verbose ? (message) => console.info(message) : undefined,
-        });
-        console.info('✓ MoonBoard location sync complete:', JSON.stringify(summary, null, 2));
-        await closePool();
-      } catch (error) {
-        console.error('✗ MoonBoard location sync failed:', error instanceof Error ? error.message : error);
-        await closePool();
-        process.exit(1);
-      }
-    },
-  );
+  const runner = createRunner(credentials, options.verbose);
+  try {
+    const summary = await runner.syncLocations();
+    console.info('✓ MoonBoard location sync complete:', JSON.stringify(summary, null, 2));
+  } catch (error) {
+    console.error('✗ MoonBoard location sync failed:', error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  } finally {
+    await runner.stop();
+  }
+});
+
+addCredentialOptions(
+  program.command('daemon').description('Run the recurring MoonBoard public-location sync daemon'),
+).action(async (options: CredentialOptions) => {
+  const credentials = resolveCredentials(options);
+  if (!credentials) return;
+
+  const runner = createRunner(credentials, options.verbose);
+  const handleSignal = (signal: string) => () => {
+    console.info(`Received ${signal}. Stopping MoonBoard location sync daemon...`);
+    // Abort the loop but let an in-flight location apply settle. The action's
+    // finally block performs lease and pool cleanup after runDaemon resolves.
+    runner.requestStop();
+  };
+  const handleSigint = handleSignal('SIGINT');
+  const handleSigterm = handleSignal('SIGTERM');
+  process.on('SIGINT', handleSigint);
+  process.on('SIGTERM', handleSigterm);
+
+  try {
+    console.info('Starting MoonBoard location sync daemon...');
+    await runner.runDaemon();
+  } catch (error) {
+    console.error('MoonBoard location sync daemon exited with error:', error);
+    process.exitCode = 1;
+  } finally {
+    process.off('SIGINT', handleSigint);
+    process.off('SIGTERM', handleSigterm);
+    await runner.stop();
+  }
+});
 
 program.parseAsync(process.argv).catch((error) => {
   console.error(error);

--- a/packages/moonboard-sync/src/index.ts
+++ b/packages/moonboard-sync/src/index.ts
@@ -1,2 +1,3 @@
 export * from './api';
+export * from './runner';
 export * from './sync';

--- a/packages/moonboard-sync/src/runner/index.ts
+++ b/packages/moonboard-sync/src/runner/index.ts
@@ -1,0 +1,6 @@
+export {
+  DEFAULT_MOONBOARD_DAEMON_OPTIONS,
+  MoonBoardSyncRunner,
+  type MoonBoardSyncRunnerConfig,
+  type MoonBoardDaemonRuntime,
+} from './sync-runner';

--- a/packages/moonboard-sync/src/runner/sync-runner.test.ts
+++ b/packages/moonboard-sync/src/runner/sync-runner.test.ts
@@ -101,6 +101,25 @@ describe('MoonBoardSyncRunner', () => {
     await runner.stop();
   });
 
+  it('closes Postgres when lease cleanup rejects', async () => {
+    const leaseError = new Error('lease cleanup failed');
+    const leaseStop = vi.fn().mockRejectedValue(leaseError);
+    const runner = new MoonBoardSyncRunner({
+      username: 'sync@example.com',
+      password: 'secret',
+    });
+    const runnerInternals = runner as unknown as {
+      lease: { stop: () => Promise<void> } | null;
+    };
+
+    await runner.syncLocations();
+    runnerInternals.lease = { stop: leaseStop };
+
+    await expect(runner.stop()).rejects.toBe(leaseError);
+    expect(leaseStop).toHaveBeenCalledOnce();
+    expect(runnerHarness.closePool).toHaveBeenCalledOnce();
+  });
+
   it('takes the MoonBoard daemon lease, runs immediately, and waits six to eight hours', async () => {
     const logs: string[] = [];
     const runner = new MoonBoardSyncRunner({

--- a/packages/moonboard-sync/src/runner/sync-runner.test.ts
+++ b/packages/moonboard-sync/src/runner/sync-runner.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const runnerHarness = vi.hoisted(() => ({
   database: { kind: 'test-database' },
@@ -62,6 +62,10 @@ describe('MoonBoardSyncRunner', () => {
     runnerHarness.syncMoonBoardLocations.mockResolvedValue(EMPTY_SUMMARY);
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('stops a fresh runner without initializing sync resources', async () => {
     const runner = new MoonBoardSyncRunner({
       username: 'sync@example.com',
@@ -123,6 +127,9 @@ describe('MoonBoardSyncRunner', () => {
       username: 'sync@example.com',
       password: 'secret',
     });
+    // DaemonLease.stop intentionally absorbs its own I/O failures, so no
+    // public runner path can induce this defensive rejection branch. The
+    // rejection and call-count assertions below make field drift fail loudly.
     const runnerInternals = runner as unknown as {
       lease: { stop: () => Promise<void> } | null;
     };
@@ -168,16 +175,14 @@ describe('MoonBoardSyncRunner', () => {
     await runner.stop();
   });
 
-  it('logs a failed cycle and stays alive for a later retry', async () => {
+  it('reports a failed cycle once without callbacks and stays alive for a later retry', async () => {
     const cycleError = new Error('MoonBoard is temporarily unavailable');
-    const errors: Error[] = [];
-    const logs: string[] = [];
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleInfo = vi.spyOn(console, 'info').mockImplementation(() => {});
     runnerHarness.syncMoonBoardLocations.mockRejectedValueOnce(cycleError);
     const runner = new MoonBoardSyncRunner({
       username: 'sync@example.com',
       password: 'secret',
-      onError: (error) => errors.push(error),
-      onLog: (message) => logs.push(message),
     });
     const sleep = vi.fn(async () => {
       runner.requestStop();
@@ -193,8 +198,85 @@ describe('MoonBoardSyncRunner', () => {
       },
     );
 
-    expect(errors).toEqual([cycleError]);
-    expect(logs).toContain('[MoonBoardSyncRunner] Daemon cycle error: MoonBoard is temporarily unavailable');
+    expect(consoleError).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith('[MoonBoardSyncRunner] Error:', cycleError);
+    expect(consoleInfo.mock.calls.filter(([message]) => String(message).includes('Daemon cycle error'))).toHaveLength(
+      0,
+    );
+    expect(sleep).toHaveBeenCalledOnce();
+    await runner.stop();
+  });
+
+  it('does not duplicate a verbose CLI cycle failure through onLog', async () => {
+    const cycleError = new Error('MoonBoard is temporarily unavailable');
+    const onLog = vi.fn();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleInfo = vi.spyOn(console, 'info').mockImplementation(() => {});
+    runnerHarness.syncMoonBoardLocations.mockRejectedValueOnce(cycleError);
+    const runner = new MoonBoardSyncRunner({
+      username: 'sync@example.com',
+      password: 'secret',
+      onLog,
+    });
+    const sleep = vi.fn(async () => {
+      runner.requestStop();
+      throw abortError();
+    });
+
+    await runner.runDaemon(
+      {},
+      {
+        now: () => new Date('2026-06-01T09:00:00.000Z'),
+        random: () => 0,
+        sleep,
+      },
+    );
+
+    expect(consoleError).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith('[MoonBoardSyncRunner] Error:', cycleError);
+    expect(onLog.mock.calls.filter(([message]) => String(message).includes('Daemon cycle error'))).toHaveLength(0);
+    expect(onLog).toHaveBeenCalledWith('[SyncRunner] Waiting 360 minute(s) before the next daemon sync cycle');
+    expect(consoleInfo).not.toHaveBeenCalled();
+    expect(sleep).toHaveBeenCalledOnce();
+    await runner.stop();
+  });
+
+  it('fans a failed cycle out once to injected error and log consumers', async () => {
+    const cycleError = new Error('MoonBoard is temporarily unavailable');
+    const onError = vi.fn();
+    const onLog = vi.fn();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleInfo = vi.spyOn(console, 'info').mockImplementation(() => {});
+    runnerHarness.syncMoonBoardLocations.mockRejectedValueOnce(cycleError);
+    const runner = new MoonBoardSyncRunner({
+      username: 'sync@example.com',
+      password: 'secret',
+      onError,
+      onLog,
+    });
+    const sleep = vi.fn(async () => {
+      runner.requestStop();
+      throw abortError();
+    });
+
+    await runner.runDaemon(
+      {},
+      {
+        now: () => new Date('2026-06-01T09:00:00.000Z'),
+        random: () => 0,
+        sleep,
+      },
+    );
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError).toHaveBeenCalledWith(cycleError);
+    expect(
+      onLog.mock.calls.filter(
+        ([message]) => message === '[MoonBoardSyncRunner] Daemon cycle error: MoonBoard is temporarily unavailable',
+      ),
+    ).toHaveLength(1);
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(consoleInfo).not.toHaveBeenCalled();
     expect(sleep).toHaveBeenCalledOnce();
     await runner.stop();
   });

--- a/packages/moonboard-sync/src/runner/sync-runner.test.ts
+++ b/packages/moonboard-sync/src/runner/sync-runner.test.ts
@@ -62,6 +62,21 @@ describe('MoonBoardSyncRunner', () => {
     runnerHarness.syncMoonBoardLocations.mockResolvedValue(EMPTY_SUMMARY);
   });
 
+  it('stops a fresh runner without initializing sync resources', async () => {
+    const runner = new MoonBoardSyncRunner({
+      username: 'sync@example.com',
+      password: 'secret',
+    });
+
+    await expect(runner.stop()).resolves.toBeUndefined();
+
+    expect(runnerHarness.createDb).not.toHaveBeenCalled();
+    expect(runnerHarness.acquireOrRenewDaemonLease).not.toHaveBeenCalled();
+    expect(runnerHarness.releaseDaemonLease).not.toHaveBeenCalled();
+    expect(runnerHarness.syncMoonBoardLocations).not.toHaveBeenCalled();
+    expect(runnerHarness.closePool).not.toHaveBeenCalled();
+  });
+
   it('runs the existing location sync with configured credentials and database', async () => {
     const logs: string[] = [];
     const runner = new MoonBoardSyncRunner({

--- a/packages/moonboard-sync/src/runner/sync-runner.test.ts
+++ b/packages/moonboard-sync/src/runner/sync-runner.test.ts
@@ -1,0 +1,328 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runnerHarness = vi.hoisted(() => ({
+  database: { kind: 'test-database' },
+  createDb: vi.fn(),
+  closePool: vi.fn(),
+  acquireOrRenewDaemonLease: vi.fn(),
+  releaseDaemonLease: vi.fn(),
+  syncMoonBoardLocations: vi.fn(),
+}));
+
+vi.mock('@boardsesh/db/client', () => ({
+  createDb: runnerHarness.createDb,
+  closePool: runnerHarness.closePool,
+}));
+
+vi.mock('@boardsesh/db/queries', () => ({
+  MOONBOARD_SYNC_DAEMON: 'moonboard-sync',
+  acquireOrRenewDaemonLease: runnerHarness.acquireOrRenewDaemonLease,
+  releaseDaemonLease: runnerHarness.releaseDaemonLease,
+}));
+
+vi.mock('../sync/locations-sync', () => ({
+  syncMoonBoardLocations: runnerHarness.syncMoonBoardLocations,
+}));
+
+import { DEFAULT_MOONBOARD_DAEMON_OPTIONS, MoonBoardSyncRunner } from './sync-runner';
+
+const EMPTY_SUMMARY = {
+  boardsSeen: 0,
+  boardsUpserted: 0,
+  boardsSkipped: 0,
+  gymsSeen: 0,
+  gymsUpserted: 0,
+  skipped: [],
+};
+
+function abortError(): Error {
+  const error = new Error('daemon stopped');
+  error.name = 'AbortError';
+  return error;
+}
+
+function createDeferred<DeferredResult>() {
+  let resolvePromise!: (result: DeferredResult | PromiseLike<DeferredResult>) => void;
+  let rejectPromise!: (reason?: unknown) => void;
+  const promise = new Promise<DeferredResult>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+
+  return { promise, resolve: resolvePromise, reject: rejectPromise };
+}
+
+describe('MoonBoardSyncRunner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runnerHarness.createDb.mockReturnValue(runnerHarness.database);
+    runnerHarness.closePool.mockResolvedValue(undefined);
+    runnerHarness.acquireOrRenewDaemonLease.mockResolvedValue(true);
+    runnerHarness.releaseDaemonLease.mockResolvedValue(undefined);
+    runnerHarness.syncMoonBoardLocations.mockResolvedValue(EMPTY_SUMMARY);
+  });
+
+  it('runs the existing location sync with configured credentials and database', async () => {
+    const logs: string[] = [];
+    const runner = new MoonBoardSyncRunner({
+      username: 'sync@example.com',
+      password: 'secret',
+      onLog: (message) => logs.push(message),
+    });
+
+    await expect(runner.syncLocations()).resolves.toEqual(EMPTY_SUMMARY);
+
+    expect(runnerHarness.syncMoonBoardLocations).toHaveBeenCalledWith({
+      db: runnerHarness.database,
+      username: 'sync@example.com',
+      password: 'secret',
+      log: expect.any(Function),
+    });
+    const syncOptions = runnerHarness.syncMoonBoardLocations.mock.calls[0]?.[0] as
+      | { log: (message: string) => void }
+      | undefined;
+    expect(syncOptions).toBeDefined();
+    syncOptions?.log('location detail');
+    expect(logs).toContain('location detail');
+
+    await runner.stop();
+    expect(runnerHarness.closePool).toHaveBeenCalledOnce();
+  });
+
+  it('keeps detailed location logging behind the CLI verbose callback', async () => {
+    const runner = new MoonBoardSyncRunner({
+      username: 'sync@example.com',
+      password: 'secret',
+    });
+
+    await runner.syncLocations();
+
+    expect(runnerHarness.syncMoonBoardLocations).toHaveBeenCalledWith(expect.objectContaining({ log: undefined }));
+    await runner.stop();
+  });
+
+  it('takes the MoonBoard daemon lease, runs immediately, and waits six to eight hours', async () => {
+    const logs: string[] = [];
+    const runner = new MoonBoardSyncRunner({
+      username: 'sync@example.com',
+      password: 'secret',
+      onLog: (message) => logs.push(message),
+    });
+    const sleep = vi.fn(async (_milliseconds: number, signal?: AbortSignal) => {
+      runner.requestStop();
+      expect(signal?.aborted).toBe(true);
+      throw abortError();
+    });
+
+    await runner.runDaemon(
+      {},
+      {
+        now: () => new Date('2026-06-01T09:00:00.000Z'),
+        random: () => 0,
+        sleep,
+      },
+    );
+
+    expect(runnerHarness.acquireOrRenewDaemonLease).toHaveBeenCalledWith(
+      runnerHarness.database,
+      expect.objectContaining({ daemonName: 'moonboard-sync', holderId: expect.any(String) }),
+    );
+    expect(runnerHarness.syncMoonBoardLocations).toHaveBeenCalledOnce();
+    expect(sleep).toHaveBeenCalledWith(6 * 60 * 60_000, expect.any(AbortSignal));
+    expect(runnerHarness.releaseDaemonLease).toHaveBeenCalledOnce();
+    expect(logs).toContain('[SyncRunner] Waiting 360 minute(s) before the next daemon sync cycle');
+    await runner.stop();
+  });
+
+  it('logs a failed cycle and stays alive for a later retry', async () => {
+    const cycleError = new Error('MoonBoard is temporarily unavailable');
+    const errors: Error[] = [];
+    const logs: string[] = [];
+    runnerHarness.syncMoonBoardLocations.mockRejectedValueOnce(cycleError);
+    const runner = new MoonBoardSyncRunner({
+      username: 'sync@example.com',
+      password: 'secret',
+      onError: (error) => errors.push(error),
+      onLog: (message) => logs.push(message),
+    });
+    const sleep = vi.fn(async () => {
+      runner.requestStop();
+      throw abortError();
+    });
+
+    await runner.runDaemon(
+      {},
+      {
+        now: () => new Date('2026-06-01T09:00:00.000Z'),
+        random: () => 0,
+        sleep,
+      },
+    );
+
+    expect(errors).toEqual([cycleError]);
+    expect(logs).toContain('[MoonBoardSyncRunner] Daemon cycle error: MoonBoard is temporarily unavailable');
+    expect(sleep).toHaveBeenCalledOnce();
+    await runner.stop();
+  });
+
+  it('waits for an active location write before releasing the lease and closing Postgres', async () => {
+    const lifecycleEvents: string[] = [];
+    const activeSync = createDeferred<typeof EMPTY_SUMMARY>();
+    runnerHarness.syncMoonBoardLocations.mockImplementationOnce(async () => {
+      lifecycleEvents.push('sync-started');
+      const summary = await activeSync.promise;
+      lifecycleEvents.push('sync-finished');
+      return summary;
+    });
+    runnerHarness.releaseDaemonLease.mockImplementationOnce(async () => {
+      lifecycleEvents.push('lease-released');
+    });
+    runnerHarness.closePool.mockImplementationOnce(async () => {
+      lifecycleEvents.push('pool-closed');
+    });
+    const runner = new MoonBoardSyncRunner({
+      username: 'sync@example.com',
+      password: 'secret',
+    });
+
+    const daemonCompletion = runner.runDaemon({}, { now: () => new Date('2026-06-01T09:00:00.000Z') });
+    await vi.waitFor(() => expect(runnerHarness.syncMoonBoardLocations).toHaveBeenCalledOnce());
+
+    const stopCompletion = runner.stop();
+    await Promise.resolve();
+
+    expect(lifecycleEvents).toEqual(['sync-started']);
+    expect(runnerHarness.releaseDaemonLease).not.toHaveBeenCalled();
+    expect(runnerHarness.closePool).not.toHaveBeenCalled();
+
+    activeSync.resolve(EMPTY_SUMMARY);
+
+    await expect(stopCompletion).resolves.toBeUndefined();
+    await expect(daemonCompletion).resolves.toBeUndefined();
+    expect(lifecycleEvents).toEqual(['sync-started', 'sync-finished', 'lease-released', 'pool-closed']);
+    expect(runnerHarness.releaseDaemonLease).toHaveBeenCalledOnce();
+    expect(runnerHarness.closePool).toHaveBeenCalledOnce();
+  });
+
+  it('waits for an in-flight heartbeat cleanup before closing Postgres', async () => {
+    vi.useFakeTimers();
+    const lifecycleEvents: string[] = [];
+    const activeSync = createDeferred<typeof EMPTY_SUMMARY>();
+    const syncStarted = createDeferred<void>();
+    const heartbeatRenewal = createDeferred<boolean>();
+    const heartbeatStarted = createDeferred<void>();
+    const firstReleaseStarted = createDeferred<void>();
+    runnerHarness.syncMoonBoardLocations.mockImplementationOnce(async () => {
+      lifecycleEvents.push('sync-started');
+      syncStarted.resolve();
+      const summary = await activeSync.promise;
+      lifecycleEvents.push('sync-finished');
+      return summary;
+    });
+    runnerHarness.acquireOrRenewDaemonLease.mockResolvedValueOnce(true).mockImplementationOnce(async () => {
+      lifecycleEvents.push('heartbeat-started');
+      heartbeatStarted.resolve();
+      const stillHeld = await heartbeatRenewal.promise;
+      lifecycleEvents.push('heartbeat-finished');
+      return stillHeld;
+    });
+    runnerHarness.releaseDaemonLease.mockImplementation(async () => {
+      lifecycleEvents.push(`lease-release-${runnerHarness.releaseDaemonLease.mock.calls.length}`);
+      if (runnerHarness.releaseDaemonLease.mock.calls.length === 1) {
+        firstReleaseStarted.resolve();
+      }
+    });
+    runnerHarness.closePool.mockImplementationOnce(async () => {
+      lifecycleEvents.push('pool-closed');
+    });
+    const runner = new MoonBoardSyncRunner({
+      username: 'sync@example.com',
+      password: 'secret',
+    });
+    let daemonCompletion: Promise<void> | undefined;
+    let stopCompletion: Promise<void> | undefined;
+
+    try {
+      daemonCompletion = runner.runDaemon({}, { now: () => new Date('2026-06-01T09:00:00.000Z') });
+      await syncStarted.promise;
+      await vi.advanceTimersByTimeAsync(30_000);
+      await heartbeatStarted.promise;
+
+      stopCompletion = runner.stop();
+      activeSync.resolve(EMPTY_SUMMARY);
+      await firstReleaseStarted.promise;
+      await Promise.resolve();
+
+      expect(runnerHarness.closePool).not.toHaveBeenCalled();
+      expect(lifecycleEvents).toEqual(['sync-started', 'heartbeat-started', 'sync-finished', 'lease-release-1']);
+
+      heartbeatRenewal.resolve(true);
+      await expect(stopCompletion).resolves.toBeUndefined();
+      await expect(daemonCompletion).resolves.toBeUndefined();
+      expect(lifecycleEvents).toEqual([
+        'sync-started',
+        'heartbeat-started',
+        'sync-finished',
+        'lease-release-1',
+        'heartbeat-finished',
+        'lease-release-2',
+        'pool-closed',
+      ]);
+    } finally {
+      activeSync.resolve(EMPTY_SUMMARY);
+      heartbeatRenewal.resolve(true);
+      await stopCompletion?.catch(() => {});
+      await daemonCompletion?.catch(() => {});
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not start a location write when shutdown arrives during lease acquisition', async () => {
+    const leaseAcquisition = createDeferred<boolean>();
+    runnerHarness.acquireOrRenewDaemonLease.mockReturnValueOnce(leaseAcquisition.promise);
+    const runner = new MoonBoardSyncRunner({
+      username: 'sync@example.com',
+      password: 'secret',
+    });
+
+    const daemonCompletion = runner.runDaemon({}, { now: () => new Date('2026-06-01T09:00:00.000Z') });
+    await vi.waitFor(() => expect(runnerHarness.acquireOrRenewDaemonLease).toHaveBeenCalledOnce());
+
+    runner.requestStop();
+    leaseAcquisition.resolve(true);
+
+    await expect(daemonCompletion).resolves.toBeUndefined();
+    expect(runnerHarness.syncMoonBoardLocations).not.toHaveBeenCalled();
+    expect(runnerHarness.releaseDaemonLease).toHaveBeenCalledOnce();
+    await runner.stop();
+  });
+
+  it('rejects a concurrent daemon run without replacing the active controller', async () => {
+    const activeSync = createDeferred<typeof EMPTY_SUMMARY>();
+    runnerHarness.syncMoonBoardLocations.mockReturnValueOnce(activeSync.promise);
+    const runner = new MoonBoardSyncRunner({
+      username: 'sync@example.com',
+      password: 'secret',
+    });
+
+    const firstDaemonCompletion = runner.runDaemon({}, { now: () => new Date('2026-06-01T09:00:00.000Z') });
+    await vi.waitFor(() => expect(runnerHarness.syncMoonBoardLocations).toHaveBeenCalledOnce());
+
+    await expect(runner.runDaemon()).rejects.toThrow('MoonBoard daemon mode is already running');
+    expect(runnerHarness.acquireOrRenewDaemonLease).toHaveBeenCalledOnce();
+
+    runner.requestStop();
+    activeSync.resolve(EMPTY_SUMMARY);
+
+    await expect(firstDaemonCompletion).resolves.toBeUndefined();
+    expect(runnerHarness.releaseDaemonLease).toHaveBeenCalledOnce();
+    await runner.stop();
+  });
+
+  it('uses a jittered six-to-eight-hour recurring cadence by default', () => {
+    expect(DEFAULT_MOONBOARD_DAEMON_OPTIONS).toEqual({
+      minDelayMinutes: 360,
+      maxDelayMinutes: 480,
+    });
+  });
+});

--- a/packages/moonboard-sync/src/runner/sync-runner.ts
+++ b/packages/moonboard-sync/src/runner/sync-runner.ts
@@ -149,12 +149,15 @@ export class MoonBoardSyncRunner {
         } finally {
           // runDaemon normally released this lease already. The extra stop is
           // needed for one-shot use and is idempotent when a daemon just ended.
-          await this.lease?.stop();
-          if (this.database) {
-            try {
-              await closePool();
-            } finally {
-              this.database = null;
+          try {
+            await this.lease?.stop();
+          } finally {
+            if (this.database) {
+              try {
+                await closePool();
+              } finally {
+                this.database = null;
+              }
             }
           }
         }

--- a/packages/moonboard-sync/src/runner/sync-runner.ts
+++ b/packages/moonboard-sync/src/runner/sync-runner.ts
@@ -1,0 +1,224 @@
+import { randomUUID } from 'node:crypto';
+import { hostname } from 'node:os';
+
+import { closePool, createDb, type DbInstance } from '@boardsesh/db/client';
+import { acquireOrRenewDaemonLease, MOONBOARD_SYNC_DAEMON, releaseDaemonLease } from '@boardsesh/db/queries';
+import {
+  DaemonLease,
+  resolveDaemonOptions,
+  runDaemonLoop,
+  type DaemonLoopRuntime,
+  type DaemonOptions,
+  type ResolvedDaemonOptions,
+} from '@boardsesh/sync-runtime';
+
+import { syncMoonBoardLocations } from '../sync/locations-sync';
+
+/**
+ * MoonBoard's public map changes much less often than climb/user data. A six to
+ * eight hour jitter keeps new public boards reasonably fresh without repeatedly
+ * logging in to the upstream service on a tight user-sync cadence.
+ */
+export const DEFAULT_MOONBOARD_DAEMON_OPTIONS: DaemonOptions = {
+  minDelayMinutes: 6 * 60,
+  maxDelayMinutes: 8 * 60,
+};
+
+export type MoonBoardSyncRunnerConfig = {
+  username: string;
+  password: string;
+  onLog?: (message: string) => void;
+  onError?: (error: Error) => void;
+};
+
+/** Test/runtime hooks that cannot replace the runner's signal, lease, or error reporting. */
+export type MoonBoardDaemonRuntime = Pick<DaemonLoopRuntime, 'now' | 'random' | 'sleep'>;
+
+type ActiveDaemonRun = {
+  controller: AbortController;
+  completion: Promise<void>;
+};
+
+type RunnerStop = {
+  completion: Promise<void>;
+};
+
+export class MoonBoardSyncRunner {
+  private readonly config: MoonBoardSyncRunnerConfig;
+  private readonly leaseHolderId = randomUUID();
+  private activeDaemonRun: ActiveDaemonRun | null = null;
+  private runnerStop: RunnerStop | null = null;
+  private database: DbInstance | null = null;
+  private lease: DaemonLease | null = null;
+
+  constructor(config: MoonBoardSyncRunnerConfig) {
+    this.config = config;
+  }
+
+  async syncLocations() {
+    return syncMoonBoardLocations({
+      db: this.getDatabase(),
+      username: this.config.username,
+      password: this.config.password,
+      // Preserve the one-shot CLI's `--verbose` contract. Daemon lifecycle
+      // messages still use this.log and remain visible without verbose mode.
+      log: this.config.onLog,
+    });
+  }
+
+  async runDaemon(options: DaemonOptions = {}, runtime: MoonBoardDaemonRuntime = {}): Promise<void> {
+    if (this.activeDaemonRun) {
+      throw new Error('MoonBoard daemon mode is already running');
+    }
+    if (this.runnerStop) {
+      throw new Error('MoonBoard sync runner is stopping');
+    }
+
+    const resolved: ResolvedDaemonOptions = resolveDaemonOptions({
+      ...DEFAULT_MOONBOARD_DAEMON_OPTIONS,
+      ...options,
+    });
+    const controller = new AbortController();
+    const lease = this.getLease();
+    const activeDaemonRun: ActiveDaemonRun = {
+      controller,
+      // Start on the next microtask so the active-run identity is installed
+      // before any injected runtime or database callback can re-enter the runner.
+      completion: Promise.resolve().then(async () => {
+        try {
+          await runDaemonLoop(
+            async () => {
+              // A stop requested while lease acquisition was in flight must not
+              // start a fresh location write after the signal arrived.
+              if (controller.signal.aborted) return;
+              await this.syncLocations();
+              // A location apply is idempotent, but stop after a stale holder notices
+              // a lease takeover rather than starting another overlapping cycle.
+              lease.assertStillHeld();
+            },
+            resolved,
+            {
+              ...runtime,
+              signal: controller.signal,
+              acquireSlot: lease.acquire,
+              onLog: (message) => this.log(message),
+              onCycleError: (error) => {
+                const normalizedError = error instanceof Error ? error : new Error(String(error));
+                this.handleError(normalizedError);
+                this.log(`[MoonBoardSyncRunner] Daemon cycle error: ${normalizedError.message}`);
+              },
+            },
+          );
+        } finally {
+          // Keep the lease until runDaemonLoop has allowed an active location
+          // write to settle. This must complete before stop() closes Postgres.
+          await lease.stop();
+        }
+      }),
+    };
+    this.activeDaemonRun = activeDaemonRun;
+
+    try {
+      await activeDaemonRun.completion;
+    } finally {
+      // A rejected reentrant call must never clear or replace another run's
+      // controller. Clear only the run whose completion we just observed.
+      if (this.activeDaemonRun === activeDaemonRun) {
+        this.activeDaemonRun = null;
+      }
+    }
+  }
+
+  /** Request loop shutdown without releasing the lease or closing Postgres. */
+  requestStop(): void {
+    this.activeDaemonRun?.controller.abort();
+  }
+
+  stop(): Promise<void> {
+    if (this.runnerStop) {
+      return this.runnerStop.completion;
+    }
+
+    const activeDaemonRun = this.activeDaemonRun;
+    const runnerStop: RunnerStop = {
+      // Defer cleanup until after runnerStop is installed. This prevents a new
+      // daemon run from starting between the active run settling and pool close.
+      completion: Promise.resolve().then(async () => {
+        try {
+          await activeDaemonRun?.completion;
+        } finally {
+          // runDaemon normally released this lease already. The extra stop is
+          // needed for one-shot use and is idempotent when a daemon just ended.
+          await this.lease?.stop();
+          if (this.database) {
+            try {
+              await closePool();
+            } finally {
+              this.database = null;
+            }
+          }
+        }
+      }),
+    };
+    this.runnerStop = runnerStop;
+    runnerStop.completion = runnerStop.completion.finally(() => {
+      if (this.runnerStop === runnerStop) {
+        this.runnerStop = null;
+      }
+    });
+    // Install the shared cleanup promise before abort dispatches synchronous
+    // listeners, so even a reentrant stop() call observes the same cleanup.
+    activeDaemonRun?.controller.abort();
+
+    return runnerStop.completion;
+  }
+
+  private getDatabase(): DbInstance {
+    if (!this.database) {
+      this.database = createDb();
+    }
+    return this.database;
+  }
+
+  private getLease(): DaemonLease {
+    if (!this.lease) {
+      this.lease = new DaemonLease(
+        MOONBOARD_SYNC_DAEMON,
+        {
+          acquireOrRenew: () =>
+            acquireOrRenewDaemonLease(this.getDatabase(), {
+              daemonName: MOONBOARD_SYNC_DAEMON,
+              holderId: this.leaseHolderId,
+              hostname: hostname(),
+            }),
+          release: () =>
+            releaseDaemonLease(this.getDatabase(), {
+              daemonName: MOONBOARD_SYNC_DAEMON,
+              holderId: this.leaseHolderId,
+            }),
+        },
+        {
+          onLog: (message) => this.log(message),
+          onError: (error) => this.handleError(error instanceof Error ? error : new Error(String(error))),
+        },
+      );
+    }
+    return this.lease;
+  }
+
+  private log(message: string): void {
+    if (this.config.onLog) {
+      this.config.onLog(message);
+    } else {
+      console.info(message);
+    }
+  }
+
+  private handleError(error: Error): void {
+    if (this.config.onError) {
+      this.config.onError(error);
+    } else {
+      console.error('[MoonBoardSyncRunner] Error:', error);
+    }
+  }
+}

--- a/packages/moonboard-sync/src/runner/sync-runner.ts
+++ b/packages/moonboard-sync/src/runner/sync-runner.ts
@@ -105,7 +105,12 @@ export class MoonBoardSyncRunner {
               onCycleError: (error) => {
                 const normalizedError = error instanceof Error ? error : new Error(String(error));
                 this.handleError(normalizedError);
-                this.log(`[MoonBoardSyncRunner] Daemon cycle error: ${normalizedError.message}`);
+                // Without an injected error sink, handleError already writes the
+                // full error to stderr. Fan out a concise operational log only
+                // when the structured error was handed to an external consumer.
+                if (this.config.onError) {
+                  this.log(`[MoonBoardSyncRunner] Daemon cycle error: ${normalizedError.message}`);
+                }
               },
             },
           );

--- a/packages/sync-runtime/src/lease.test.ts
+++ b/packages/sync-runtime/src/lease.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vite-plus/test';
+import { describe, expect, it, vi } from 'vitest';
 
 import { DaemonLease, DaemonLeaseLostError } from './lease';
 import { runDaemonLoop } from './daemon';

--- a/packages/sync-runtime/src/lease.test.ts
+++ b/packages/sync-runtime/src/lease.test.ts
@@ -166,13 +166,21 @@ describe('DaemonLease', () => {
 
     await lease.acquire();
     heartbeat!(); // renew now parked in flight
-    await lease.stop(); // releases while that renew is still pending
+    let stopSettled = false;
+    const stopCompletion = lease.stop().then(() => {
+      stopSettled = true;
+    });
+    await vi.waitFor(() => expect(release).toHaveBeenCalledTimes(1));
+    await Promise.resolve();
     expect(release).toHaveBeenCalledTimes(1);
+    expect(stopSettled).toBe(false);
 
     // The parked renew resolves as "we still hold it" — i.e. it re-created the
     // row after the DELETE. A compensating release must clear the zombie.
     resolveRenew!(true);
-    await vi.waitFor(() => expect(release).toHaveBeenCalledTimes(2));
+    await stopCompletion;
+    expect(release).toHaveBeenCalledTimes(2);
+    expect(stopSettled).toBe(true);
     expect(lease.isHeld()).toBe(false);
   });
 

--- a/packages/sync-runtime/src/lease.ts
+++ b/packages/sync-runtime/src/lease.ts
@@ -55,6 +55,7 @@ export class DaemonLease {
 
   private held = false;
   private heartbeat: ReturnType<typeof setInterval> | null = null;
+  private readonly inFlightHeartbeats = new Set<Promise<void>>();
 
   constructor(daemonName: string, io: DaemonLeaseIo, runtime: DaemonLeaseRuntime = {}) {
     this.daemonName = daemonName;
@@ -104,21 +105,35 @@ export class DaemonLease {
   /** Release on shutdown so a rolling deploy hands over immediately, not after a TTL. */
   async stop(): Promise<void> {
     this.stopHeartbeat();
-    if (!this.held) return;
-    this.held = false;
-    try {
-      await this.io.release();
-      this.log(`[SyncRunner] Released the ${this.daemonName} daemon lease`);
-    } catch (error) {
-      // A failed release just means the next instance waits out the TTL.
-      this.onError(error);
+    if (this.held) {
+      this.held = false;
+      try {
+        await this.io.release();
+        this.log(`[SyncRunner] Released the ${this.daemonName} daemon lease`);
+      } catch (error) {
+        // A failed release just means the next instance waits out the TTL.
+        this.onError(error);
+      }
+    }
+
+    // A heartbeat may already be awaiting its renew query when shutdown starts.
+    // It observes held=false after that query and, if the renew re-created our
+    // row after the release above, performs a compensating release in beat(). Do
+    // not let callers close their database pool until that cleanup has settled.
+    while (this.inFlightHeartbeats.size > 0) {
+      await Promise.allSettled(this.inFlightHeartbeats);
     }
   }
 
   private startHeartbeat(): void {
     if (this.heartbeat) return;
     this.heartbeat = this.startTimer(() => {
-      void this.beat();
+      const heartbeatCompletion = this.beat();
+      this.inFlightHeartbeats.add(heartbeatCompletion);
+      void heartbeatCompletion.then(
+        () => this.inFlightHeartbeats.delete(heartbeatCompletion),
+        () => this.inFlightHeartbeats.delete(heartbeatCompletion),
+      );
     }, this.heartbeatMs);
     // Never keep the process alive just to renew a lease.
     (this.heartbeat as { unref?: () => void }).unref?.();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -853,6 +853,9 @@ importers:
       '@boardsesh/location-sync':
         specifier: workspace:*
         version: link:../location-sync
+      '@boardsesh/sync-runtime':
+        specifier: workspace:*
+        version: link:../sync-runtime
       commander:
         specifier: ^15.0.0
         version: 15.0.0


### PR DESCRIPTION
## Summary

- add a recurring MoonBoard location-sync daemon with an immediate daytime run, a randomized six-to-eight-hour cadence, and Sydney quiet hours
- use the shared database lease so rolling deploys keep one active worker, while signals and reentrant starts drain sync writes, heartbeats, lease release, and the pool in order
- wire the daemon into the sync image and document the separate-service deployment contract

Part of #3863. This deliberately does not close the issue: the production sync-host service, credentials, first-run adoption checks, and a later recurring-cycle check still need to be completed.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project sync-runtime --reporter=agent` (25 passed)
- `vp test run --project moonboard-sync --reporter=agent` (17 passed, 1 credentialed integration skipped)
- `vp run typecheck:sync-runtime`
- `vp run typecheck:moonboard-sync`
- scoped `vp check` on the daemon, lease, CLI, tests, and docs
- `git diff --check`
- pre-commit hook passed on all 13 intended files
- independent adversarial review: no remaining P0-P2 findings
- `vp run dev` started with `.boardsesh/qa-notes.md`; backend healthy and web available at `https://vibetunnel-2.tailedd9d5.ts.net:3001`

## Production gates kept on #3863

- provision a separate production sync-host service and configure `DATABASE_URL`, `MOONBOARD_USERNAME`, and `MOONBOARD_PASSWORD`
- record baseline MoonBoard gym, board, and source-alias counts
- verify the first run adopts seeded locations without duplicate gyms, then inspect `/admin/gym-duplicates`
- confirm a later scheduled cycle updates the same aliases with one active lease holder
