### PR TITLE
fix(db): repair stale board climb holds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,7 @@ Read relevant `docs/` before working on the matching area; update docs when the 
 - `docs/db-migrations.md` — migration numbering, `when`-not-number apply order, the collision/renumber bot, and when it hands work back
 - `docs/feature-flags.md` — client vs server flags, why a server gate fails closed, the resolution reasons, the `/api/internal/feature-flags` diagnostic, and the `FEATURE_FLAG_OVERRIDES` kill switch; the "Mobile flags" section covers the mobile-only catalog, multivariate flags, and precedence
 - `docs/board-render-analytics.md` — the classic-vs-Boardsesh / glow-falloff A/B event contract (issue #2202): the eight events (incl. the paired board-look step events and `Board Render Failed`), the common-props builder, the `climb-view-session.ts` state machine, the stratification rule (never pool across `board_name` or `glow_falloff_source`), and the PostHog experiment setup steps
+- `docs/board-climb-holds-repair.md` — guarded `board_climb_holds` data repair: approval gates, dry-run-then-apply workflow, digest and count guards, the lock window, and the popular-config cache bust
 - `docs/logging.md` — backend structured logger (winston)
 - `docs/crowdsourced-qa.md` — the PR test-plan + risk gate (`@boardsesh/pr-body`, `pr-test-plan.yml`), and the tester loop that turns it into `qa-approved` / `qa-declined` labels
 - `docs/scheduler.md` — the Railway cron scheduler (`packages/scheduler`): which job runs on Vercel vs the scheduler, env vars, Railway setup, cutover order and runbook

--- a/docs/board-climb-holds-repair.md
+++ b/docs/board-climb-holds-repair.md
@@ -2,6 +2,12 @@
 
 This repair rebuilds stale materialized hold rows for multi-frame Aurora-family climbs and removes globally invalid rows (`hold_id <= 0`, an empty state, or a state containing `=`) elsewhere. A valid frame sequence that projects to no canonical holds is cleaned to an empty row set. The repair also migrates fingerprints only when the old value is provably derived from the old rows or the historical per-frame Grips tokens; independent fingerprints are left alone. It does not change climb frames or run against MoonBoard multi-frame data.
 
+## Kilter rollout bridge
+
+Deploy the catalog-sync compatibility bridge before running this repair. During each sync it reads catalog-owned multi-frame Kilter rows once, proves which stored fingerprints came from the historical raw frame events, and adds their current projected fingerprints to the in-memory dedup index without changing the database. Existing stored fingerprint owners always win, and empty or unproven projections add no key.
+
+That dual-key bridge prevents the Kilter daemon from creating a second canonical in the interval between deploy and repair, so the daemon does not need to stay paused for that whole rollout interval. The repair migrates proven legacy fingerprints to the projected key; after migration the stored key is already primary and the bridge is a no-op. Writers should still be paused for the short approved apply window below, when the repair takes table locks.
+
 ## Approval gates
 
 Production access is never implicit. Get explicit operator approval separately for:
@@ -10,7 +16,7 @@ Production access is never implicit. Get explicit operator approval separately f
 2. the production apply, including its short table-lock window; and
 3. the post-commit cache action.
 
-Pause catalog and sync writers for the approved apply window. The transaction takes `SHARE ROW EXCLUSIVE` locks on `board_climbs` and `board_climb_holds`, uses a five-second lock timeout and a two-minute statement timeout, and rolls back on any manifest or verification mismatch.
+Pause catalog and sync writers only for the approved apply window. The transaction takes `SHARE ROW EXCLUSIVE` locks on `board_climbs` and `board_climb_holds`, uses a five-second lock timeout and a two-minute statement timeout, and rolls back on any manifest or verification mismatch.
 
 ## Target database
 

--- a/docs/board-climb-holds-repair.md
+++ b/docs/board-climb-holds-repair.md
@@ -16,7 +16,7 @@ Production access is never implicit. Get explicit operator approval separately f
 2. the production apply, including its short table-lock window; and
 3. the post-commit cache action.
 
-Pause catalog and sync writers only for the approved apply window. The transaction takes `SHARE ROW EXCLUSIVE` locks on `board_climbs` and `board_climb_holds`, uses a five-second lock timeout and a two-minute statement timeout, and rolls back on any manifest or verification mismatch.
+Pause catalog and sync writers only for the approved apply window. The transaction takes `SHARE ROW EXCLUSIVE` locks on `board_climbs` and `board_climb_holds`, uses a five-second lock timeout and a two-minute statement timeout, and rolls back on any manifest or verification mismatch. The statement timeout applies to each statement; if the large batch delete or insert times out, the entire transaction rolls back.
 
 ## Target database
 

--- a/docs/board-climb-holds-repair.md
+++ b/docs/board-climb-holds-repair.md
@@ -34,6 +34,8 @@ vp run db:repair-board-climb-holds -- --report-limit 100
 
 Record the printed SHA-256 and the exact `scanned`, `changed`, `invalid_rows`, `fingerprint_updates`, and `affected` counts. `affected` includes fingerprint-only migrations, so use it for the apply ceiling even when the materialized rows are already canonical. Review every blocker and diagnostic, especially unknown roles, nonpositive IDs, missing placements, malformed frames, and `frames_count` mismatches. Do not apply while any blocker exists.
 
+A leading empty frame is the delayed-start encoding — the wall stays dark for one pace tick — and both Aurora and our own Kilter Grips importer emit it, so it is accepted rather than blocked. An empty unquoted frame anywhere after frame 0 is still corruption and still blocks. `frames_count` is compared against the raw comma-delimited slot count, which is what Aurora and Grips record.
+
 Missing placements are automatic blockers, not overridable warnings. Repair or resync the affected board's placement catalog, then run a new dry-run and review its new digest and counts. The apply command has no override for missing placement IDs.
 
 ## Apply

--- a/docs/board-climb-holds-repair.md
+++ b/docs/board-climb-holds-repair.md
@@ -28,6 +28,8 @@ vp run db:repair-board-climb-holds -- --report-limit 100
 
 Record the printed SHA-256 and the exact `scanned`, `changed`, `invalid_rows`, `fingerprint_updates`, and `affected` counts. `affected` includes fingerprint-only migrations, so use it for the apply ceiling even when the materialized rows are already canonical. Review every blocker and diagnostic, especially unknown roles, nonpositive IDs, missing placements, malformed frames, and `frames_count` mismatches. Do not apply while any blocker exists.
 
+Missing placements are automatic blockers, not overridable warnings. Repair or resync the affected board's placement catalog, then run a new dry-run and review its new digest and counts. The apply command has no override for missing placement IDs.
+
 ## Apply
 
 After approval, pass every reviewed guard back verbatim. `--max-affected` is a ceiling and should normally equal the reviewed affected count.

--- a/docs/board-climb-holds-repair.md
+++ b/docs/board-climb-holds-repair.md
@@ -1,0 +1,53 @@
+# Repairing `board_climb_holds`
+
+This repair rebuilds stale materialized hold rows for multi-frame Aurora-family climbs and removes globally invalid rows (`hold_id <= 0`, an empty state, or a state containing `=`) elsewhere. A valid frame sequence that projects to no canonical holds is cleaned to an empty row set. The repair also migrates fingerprints only when the old value is provably derived from the old rows or the historical per-frame Grips tokens; independent fingerprints are left alone. It does not change climb frames or run against MoonBoard multi-frame data.
+
+## Approval gates
+
+Production access is never implicit. Get explicit operator approval separately for:
+
+1. the production dry-run;
+2. the production apply, including its short table-lock window; and
+3. the post-commit cache action.
+
+Pause catalog and sync writers for the approved apply window. The transaction takes `SHARE ROW EXCLUSIVE` locks on `board_climbs` and `board_climb_holds`, uses a five-second lock timeout and a two-minute statement timeout, and rolls back on any manifest or verification mismatch.
+
+## Target database
+
+Inject the approved direct PostgreSQL connection as `DB_URL` through the operator's secret manager before each command. Do not rely on the repository's auto-loaded development env files, and do not paste production credentials into this runbook or shell history.
+
+The script prints `database_host=...` before doing any work. Verify that host against the approved target before accepting a dry-run report. Verify it again immediately before apply; a digest from one host must never authorize writes to another.
+
+## Dry-run
+
+Run the report first. Dry-run performs only reads and takes no table or advisory locks.
+
+```sh
+vp run db:repair-board-climb-holds -- --report-limit 100
+```
+
+Record the printed SHA-256 and the exact `scanned`, `changed`, `invalid_rows`, `fingerprint_updates`, and `affected` counts. `affected` includes fingerprint-only migrations, so use it for the apply ceiling even when the materialized rows are already canonical. Review every blocker and diagnostic, especially unknown roles, nonpositive IDs, missing placements, malformed frames, and `frames_count` mismatches. Do not apply while any blocker exists.
+
+## Apply
+
+After approval, pass every reviewed guard back verbatim. `--max-affected` is a ceiling and should normally equal the reviewed affected count.
+
+Confirm the printed `database_host` is still the approved target before allowing the transaction to continue.
+
+```sh
+vp run db:repair-board-climb-holds -- --apply \
+  --expected-digest <sha256> \
+  --expected-scanned <count> \
+  --expected-changed <count> \
+  --expected-invalid <count> \
+  --max-affected <count> \
+  --report-limit 100
+```
+
+After the locks are acquired, the script rebuilds the manifest inside the repeatable-read transaction. Any drift aborts before writes. It then verifies the exact projected rows for every rebuilt climb and requires the global invalid-row count to be zero before commit. A second approved dry-run should report `changed=0`, `invalid_rows=0`, and a new stable digest for that clean state.
+
+## Popular-config cache
+
+The database script never touches Redis. After a successful, approved production apply, request separate approval before changing the cache.
+
+Inspect the lock key `boardsesh:popular-board-configs:lock`. Never delete or overwrite that lock. If it exists, wait for its 120-second TTL to expire. Then delete only `boardsesh:popular-board-configs`, warm or restart one backend instance, and verify that the rebuilt value exists and has the expected TTL. Counts may move in either direction because repaired valid rows can change config membership.

--- a/docs/board-climb-holds-repair.md
+++ b/docs/board-climb-holds-repair.md
@@ -16,7 +16,7 @@ Production access is never implicit. Get explicit operator approval separately f
 2. the production apply, including its short table-lock window; and
 3. the post-commit cache action.
 
-Pause catalog and sync writers only for the approved apply window. The transaction takes `SHARE ROW EXCLUSIVE` locks on `board_climbs` and `board_climb_holds`, uses a five-second lock timeout and a two-minute statement timeout, and rolls back on any manifest or verification mismatch. The statement timeout applies to each statement; if the large batch delete or insert times out, the entire transaction rolls back.
+Pause catalog and sync writers only for the approved apply window. The transaction takes `SHARE ROW EXCLUSIVE` locks on `board_climbs` and `board_climb_holds`, uses a five-second lock timeout and a two-minute statement timeout, and rolls back on any manifest or verification mismatch. Placement lookups, changed-climb identities, fingerprint updates, inserts, invalid-row deletes, and exact-row verification are split into bounded PostgreSQL JSON parameters: at most 500 identities or 5,000 mutation rows, and at most 1 MiB per parameter. All batches still run under the same locks in one transaction; a failure in a later batch rolls back every earlier batch.
 
 ## Target database
 
@@ -52,7 +52,7 @@ vp run db:repair-board-climb-holds -- --apply \
   --report-limit 100
 ```
 
-After the locks are acquired, the script rebuilds the manifest inside the repeatable-read transaction. Any drift aborts before writes. It then verifies the exact projected rows for every rebuilt climb and requires the global invalid-row count to be zero before commit. A second approved dry-run should report `changed=0`, `invalid_rows=0`, and a new stable digest for that clean state.
+After the locks are acquired, the script rebuilds the manifest inside the repeatable-read transaction. Any drift aborts before writes. It then verifies the exact projected rows for every rebuilt climb, including climbs whose authoritative projection is empty, and requires the global invalid-row count to be zero before commit. Only multi-frame projection is restricted to the Aurora-family board allowlist; invalid stored rows are discovered, deleted, and verified across all board types. A second approved dry-run should report `changed=0`, `invalid_rows=0`, and a new stable digest for that clean state.
 
 ## Popular-config cache
 

--- a/packages/aurora-sync/src/sync/shared-sync.test.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.test.ts
@@ -273,6 +273,12 @@ describe('board_climb_holds writes', () => {
         frames: null,
       }),
     ).toBeNull();
+    expect(
+      resolveAuthoritativeClimbFrames('decoy', 'p1r1p2r2', {
+        boardType: 'decoy',
+        frames: '',
+      }),
+    ).toBe('');
     expect(resolveAuthoritativeClimbFrames('decoy', 'p1r1p2r2', undefined)).toBe('p1r1p2r2');
 
     mockProjectStoredRows.mockImplementation((frames: string) => ({

--- a/packages/aurora-sync/src/sync/shared-sync.test.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.test.ts
@@ -3,11 +3,11 @@ import { notifications, setterFollows, userBoardMappings, userFollows } from '@b
 import type { ClimbStats, SyncData } from '../api/sync-api-types';
 import type { SyncOptions } from '../api/types';
 
-const { mockSharedSync, mockPopulateDenormalizedColumns, mockConvertLitUpHolds, mockSnapshotHistory } = vi.hoisted(
+const { mockSharedSync, mockPopulateDenormalizedColumns, mockProjectStoredRows, mockSnapshotHistory } = vi.hoisted(
   () => ({
     mockSharedSync: vi.fn(),
     mockPopulateDenormalizedColumns: vi.fn().mockResolvedValue(undefined),
-    mockConvertLitUpHolds: vi.fn().mockReturnValue({}),
+    mockProjectStoredRows: vi.fn().mockReturnValue({ rows: [], frameCount: 0, diagnostics: {} }),
     mockSnapshotHistory: vi.fn().mockResolvedValue({ written: 0, skipped: true }),
   }),
 );
@@ -33,9 +33,7 @@ vi.mock('@boardsesh/db/queries', async (importOriginal) => {
 
 vi.mock('@boardsesh/board-constants/hold-states', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@boardsesh/board-constants/hold-states')>();
-  // Only the parser is stubbed. `isSentinelHoldState` stays real so this file
-  // tests the writer against the same predicate production uses.
-  return { ...actual, convertLitUpHoldsStringToMap: mockConvertLitUpHolds };
+  return { ...actual, projectAuroraFramesToStoredRows: mockProjectStoredRows };
 });
 
 // drizzle() returns a client we never actually issue queries against; the
@@ -57,7 +55,9 @@ import {
   createSetterSyncNotifications,
   healRequiredSetIds,
   parseDifficultyFields,
+  projectAuthoritativeClimbRows,
   REQUIRED_SET_ID_DRAIN_LIMIT,
+  resolveAuthoritativeClimbFrames,
   shouldHealRequiredSetIds,
   syncSharedData,
 } from './shared-sync';
@@ -200,7 +200,7 @@ describe('syncSharedData loop', () => {
 describe('board_climb_holds writes', () => {
   beforeEach(() => {
     mockSharedSync.mockReset();
-    mockConvertLitUpHolds.mockReset();
+    mockProjectStoredRows.mockReset();
     mockPopulateDenormalizedColumns.mockReset();
     mockPopulateDenormalizedColumns.mockResolvedValue(undefined);
     shimInsertedRows.length = 0;
@@ -211,11 +211,10 @@ describe('board_climb_holds writes', () => {
     // than a real hold state. `backfill-board-climb-holds.ts` already drops
     // those; if this writer keeps them they poison the fingerprint backfill
     // and the similarity signatures built on top of it.
-    mockConvertLitUpHolds.mockReturnValue({
-      0: {
-        100: { state: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
-        200: { state: '200=999', color: '#FFF', displayColor: '#FFF' },
-      },
+    mockProjectStoredRows.mockReturnValue({
+      rows: [{ holdId: 100, frameNumber: 0, holdState: 'STARTING' }],
+      frameCount: 1,
+      diagnostics: { skippedUnknownRoleTokens: 1, skippedNonpositiveHoldIdTokens: 0 },
     });
     mockSharedSync.mockResolvedValueOnce(
       complete({
@@ -231,13 +230,14 @@ describe('board_climb_holds writes', () => {
     ]);
   });
 
-  it('writes one row per (frame, hold) for the states that do resolve', async () => {
-    mockConvertLitUpHolds.mockReturnValue({
-      0: { 100: { state: 'STARTING', color: '#00FF00', displayColor: '#00FF00' } },
-      1: {
-        100: { state: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
-        300: { state: 'HAND', color: '#0000FF', displayColor: '#4444FF' },
-      },
+  it('writes one first-valid row per hold for the states that resolve', async () => {
+    mockProjectStoredRows.mockReturnValue({
+      rows: [
+        { holdId: 100, frameNumber: 0, holdState: 'STARTING' },
+        { holdId: 300, frameNumber: 1, holdState: 'HAND' },
+      ],
+      frameCount: 2,
+      diagnostics: { skippedUnknownRoleTokens: 0, skippedNonpositiveHoldIdTokens: 0 },
     });
     mockSharedSync.mockResolvedValueOnce(
       complete({
@@ -250,9 +250,48 @@ describe('board_climb_holds writes', () => {
     const holdRows = shimInsertedRows.filter((row) => 'holdId' in row && row.climbUuid === 'CLIMB-2');
     expect(holdRows).toEqual([
       { boardType: 'decoy', climbUuid: 'CLIMB-2', frameNumber: 0, holdId: 100, holdState: 'STARTING' },
-      { boardType: 'decoy', climbUuid: 'CLIMB-2', frameNumber: 1, holdId: 100, holdState: 'STARTING' },
       { boardType: 'decoy', climbUuid: 'CLIMB-2', frameNumber: 1, holdId: 300, holdState: 'HAND' },
     ]);
+  });
+
+  it('projects persisted frames for an existing UUID and skips cross-board or null sources', () => {
+    expect(
+      resolveAuthoritativeClimbFrames('decoy', 'p1r1p2r2', {
+        boardType: 'decoy',
+        frames: 'p1r1',
+      }),
+    ).toBe('p1r1');
+    expect(
+      resolveAuthoritativeClimbFrames('decoy', 'p1r1p2r2', {
+        boardType: 'tension',
+        frames: 'p1r1',
+      }),
+    ).toBeNull();
+    expect(
+      resolveAuthoritativeClimbFrames('decoy', 'p1r1p2r2', {
+        boardType: 'decoy',
+        frames: null,
+      }),
+    ).toBeNull();
+    expect(resolveAuthoritativeClimbFrames('decoy', 'p1r1p2r2', undefined)).toBe('p1r1p2r2');
+
+    mockProjectStoredRows.mockImplementation((frames: string) => ({
+      rows: frames.includes('p2r2')
+        ? [
+            { holdId: 1, frameNumber: 0, holdState: 'STARTING' },
+            { holdId: 2, frameNumber: 0, holdState: 'HAND' },
+          ]
+        : [{ holdId: 1, frameNumber: 0, holdState: 'STARTING' }],
+      frameCount: 1,
+      diagnostics: { skippedUnknownRoleTokens: 0, skippedNonpositiveHoldIdTokens: 0 },
+    }));
+    expect(
+      projectAuthoritativeClimbRows('decoy', 'p1r1p2r2', {
+        boardType: 'decoy',
+        frames: 'p1r1',
+      }),
+    ).toEqual([{ holdId: 1, frameNumber: 0, holdState: 'STARTING' }]);
+    expect(mockProjectStoredRows).toHaveBeenLastCalledWith('p1r1', 'decoy');
   });
 });
 

--- a/packages/aurora-sync/src/sync/shared-sync.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.ts
@@ -60,7 +60,10 @@ type ExistingClimbFrameSource = {
  * so the hold writer must project that same persisted value. Projecting a
  * changed incoming blob would otherwise add rows that disagree with the
  * `board_climbs` row. A UUID owned by another board is a global-PK collision,
- * not a climb this sync may attach holds to.
+ * not a climb this sync may attach holds to. A legacy same-board row whose
+ * persisted frames are NULL likewise projects no rows here: the conflict
+ * policy cannot make the incoming blob authoritative, so repair/backfill owns
+ * recovery instead of silently diverging from `board_climbs`.
  */
 export function resolveAuthoritativeClimbFrames(
   board: AuroraBoardName,

--- a/packages/aurora-sync/src/sync/shared-sync.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.ts
@@ -24,7 +24,7 @@ import type {
 } from '../api/sync-api-types';
 import { UNIFIED_TABLES } from '../db/table-select';
 import { normalizeQualityTo5, isNoMatchClimb, CLIMB_CHARACTERISTICS } from '@boardsesh/shared-schema';
-import { convertLitUpHoldsStringToMap, isSentinelHoldState } from '@boardsesh/board-constants/hold-states';
+import { projectAuroraFramesToStoredRows } from '@boardsesh/board-constants/hold-states';
 import {
   populateDenormalizedColumns,
   blendedQualityAverageSql,
@@ -47,6 +47,39 @@ export type NewClimbInfo = {
   layoutId: number;
   name?: string;
 };
+
+type ExistingClimbFrameSource = {
+  boardType: string;
+  frames: string | null;
+};
+
+/**
+ * Pick the frame blob that is authoritative for `board_climb_holds`.
+ *
+ * The climb conflict policy deliberately preserves frames on existing UUIDs,
+ * so the hold writer must project that same persisted value. Projecting a
+ * changed incoming blob would otherwise add rows that disagree with the
+ * `board_climbs` row. A UUID owned by another board is a global-PK collision,
+ * not a climb this sync may attach holds to.
+ */
+export function resolveAuthoritativeClimbFrames(
+  board: AuroraBoardName,
+  incomingFrames: string,
+  existing: ExistingClimbFrameSource | undefined,
+): string | null {
+  if (!existing) return incomingFrames;
+  if (existing.boardType !== board) return null;
+  return existing.frames;
+}
+
+export function projectAuthoritativeClimbRows(
+  board: AuroraBoardName,
+  incomingFrames: string,
+  existing: ExistingClimbFrameSource | undefined,
+) {
+  const frames = resolveAuthoritativeClimbFrames(board, incomingFrames, existing);
+  return frames ? projectAuroraFramesToStoredRows(frames, board).rows : [];
+}
 
 // Tables we actually want to process and store, in FK-safe upsert order.
 // SHARED_SYNC_TABLES matches the Android app's request order for indistinguishability,
@@ -703,10 +736,11 @@ async function upsertClimbs(db: DrizzleDb, board: AuroraBoardName, data: Climb[]
 
   const uuids = data.map((c) => c.uuid);
   const existingRows = await db
-    .select({ uuid: climbsSchema.uuid })
+    .select({ uuid: climbsSchema.uuid, boardType: climbsSchema.boardType, frames: climbsSchema.frames })
     .from(climbsSchema)
     .where(inArray(climbsSchema.uuid, uuids));
-  const existingUuids = new Set(existingRows.map((r) => r.uuid));
+  const existingByUuid = new Map(existingRows.map((row) => [row.uuid, row]));
+  const existingUuids = new Set(existingByUuid.keys());
 
   // Climbs: chunked multi-row upsert. The conflict policy splits on ownership:
   //   - NON-user climbs (board_climbs.user_id IS NULL — Aurora catalog rows):
@@ -772,23 +806,13 @@ async function upsertClimbs(db: DrizzleDb, board: AuroraBoardName, data: Climb[]
   // N climbs; flattening turns it into ceil(totalHolds/BATCH_SIZE) round-trips
   // regardless of climb count.
   const allHolds = data.flatMap((item) => {
-    const holdsByFrame = convertLitUpHoldsStringToMap(item.frames, board);
-    return Object.entries(holdsByFrame).flatMap(([frameNumber, holds]) =>
-      Object.entries(holds)
-        // An unmapped role code decodes to the `{holdId}={code}` sentinel
-        // rather than a real hold state. `backfill-board-climb-holds.ts`
-        // already drops those; the two hold writers should agree, or the
-        // sentinel poisons `backfill-hold-fingerprints` and the similarity
-        // signatures downstream of it (issue #3948).
-        .filter(([, { state }]) => !isSentinelHoldState(state))
-        .map(([holdId, { state }]) => ({
-          boardType: board,
-          climbUuid: item.uuid,
-          frameNumber: Number(frameNumber),
-          holdId: Number(holdId),
-          holdState: state,
-        })),
-    );
+    return projectAuthoritativeClimbRows(board, item.frames, existingByUuid.get(item.uuid)).map((row) => ({
+      boardType: board,
+      climbUuid: item.uuid,
+      frameNumber: row.frameNumber,
+      holdId: row.holdId,
+      holdState: row.holdState,
+    }));
   });
 
   if (allHolds.length > 0) {

--- a/packages/backend/src/__tests__/climb-similar-resolver.test.ts
+++ b/packages/backend/src/__tests__/climb-similar-resolver.test.ts
@@ -57,12 +57,11 @@ function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext 
   } as ConnectionContext;
 }
 
-// The shape varies by select: the board_climb_holds branch yields
-// (holdId, holdState) rows; the legacy-frames fallback yields (frames)
-// rows. Keep the helper polymorphic so callers can drive either path.
+// The joined target rows vary by fixture: materialized holds populate the hold
+// columns, while missing materialized holds leave those columns null.
 function mockSelectChain(rows: ReadonlyArray<Record<string, unknown>>) {
   const chain: Record<string, unknown> = {};
-  for (const method of ['from', 'where', 'limit']) {
+  for (const method of ['from', 'leftJoin', 'where']) {
     chain[method] = vi.fn(() => chain);
   }
   chain.then = (resolve: (value: unknown) => unknown) => Promise.resolve(rows).then(resolve);
@@ -122,14 +121,11 @@ describe('climbQueries.similarClimbs', () => {
   });
 
   it('climbUuid path reads the target climbs holds and passes them through with excludeUuid set to the target', async () => {
-    mockDb.select
-      .mockReturnValueOnce(mockSelectChain([{ frames: 'p4122r42p4182r43', framesCount: 1 }]))
-      .mockReturnValueOnce(
-        mockSelectChain([
-          { holdId: 4122, holdState: 'STARTING' },
-          { holdId: 4182, holdState: 'HAND' },
-        ]),
-      );
+    const selectChain = mockSelectChain([
+      { frames: 'p4122r42p4182r43', framesCount: 1, holdId: 4122, holdState: 'STARTING' },
+      { frames: 'p4122r42p4182r43', framesCount: 1, holdId: 4182, holdState: 'HAND' },
+    ]);
+    mockDb.select.mockReturnValueOnce(selectChain);
 
     await climbQueries.similarClimbs(
       {},
@@ -160,7 +156,9 @@ describe('climbQueries.similarClimbs', () => {
       { holdId: 4122, holdState: 'STARTING' },
       { holdId: 4182, holdState: 'HAND' },
     ]);
-    // parseFramesToHoldEntries must NOT have been called on the climbUuid path.
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+    expect(selectChain.leftJoin).toHaveBeenCalledTimes(1);
+    // A materialized single-frame target must not fall back to parsing.
     expect(parseFramesToHoldEntriesMock).not.toHaveBeenCalled();
   });
 
@@ -198,10 +196,8 @@ describe('climbQueries.similarClimbs', () => {
     expect(mockDb.select).not.toHaveBeenCalled();
   });
 
-  it('short-circuits to an empty array when the target has no holds, without calling the helper', async () => {
-    // First select: board_climbs lookup → no row. Second select: holds → none.
-    // Both empty → resolver returns [] without hitting findSimilarClimbs.
-    mockDb.select.mockReturnValueOnce(mockSelectChain([])).mockReturnValueOnce(mockSelectChain([]));
+  it('short-circuits to an empty array when the target climb is missing', async () => {
+    mockDb.select.mockReturnValueOnce(mockSelectChain([]));
 
     const result = await climbQueries.similarClimbs(
       {},
@@ -210,20 +206,36 @@ describe('climbQueries.similarClimbs', () => {
     );
 
     expect(result).toEqual([]);
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+    expect(parseFramesToHoldEntriesMock).not.toHaveBeenCalled();
+    expect(findSimilarClimbsMock).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits when an existing target has neither materialized holds nor frames', async () => {
+    mockDb.select.mockReturnValueOnce(
+      mockSelectChain([{ frames: null, framesCount: 1, holdId: null, holdState: null }]),
+    );
+
+    const result = await climbQueries.similarClimbs(
+      {},
+      { input: { boardType: 'kilter', layoutId: 8, climbUuid: 'no-holds-or-frames' } },
+      makeCtx(),
+    );
+
+    expect(result).toEqual([]);
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+    expect(parseFramesToHoldEntriesMock).not.toHaveBeenCalled();
     expect(findSimilarClimbsMock).not.toHaveBeenCalled();
   });
 
   it('falls back to parsing board_climbs.frames when board_climb_holds is empty (legacy MoonBoard climbs)', async () => {
     findSimilarClimbsMock.mockResolvedValue([]);
-    // First select: board_climb_holds → no rows (legacy state).
-    // Second select: board_climbs → returns the frames blob the gate
-    // recorded in the legacy import. The resolver should parse that and
-    // pass the resulting holds to findSimilarClimbs, so the duplicate
-    // drawer doesn't silently surface "no identical climbs" for a match
-    // that absolutely exists.
-    mockDb.select
-      .mockReturnValueOnce(mockSelectChain([{ frames: 'p1r12p2r13', framesCount: 1 }]))
-      .mockReturnValueOnce(mockSelectChain([]));
+    // The LEFT JOIN keeps the climb row and returns null hold columns when the
+    // legacy target has no materialized rows. Parse its frames without a
+    // second query so the duplicate drawer still finds the exact match.
+    mockDb.select.mockReturnValueOnce(
+      mockSelectChain([{ frames: 'p1r12p2r13', framesCount: 1, holdId: null, holdState: null }]),
+    );
     parseFramesToHoldEntriesMock.mockReturnValueOnce([
       { frameNumber: 0, holdId: 1, holdState: 'STARTING' },
       { frameNumber: 0, holdId: 2, holdState: 'HAND' },
@@ -235,6 +247,7 @@ describe('climbQueries.similarClimbs', () => {
       makeCtx(),
     );
 
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
     expect(parseFramesToHoldEntriesMock).toHaveBeenCalledWith('moonboard', 'p1r12p2r13');
     expect(findSimilarClimbsMock).toHaveBeenCalledTimes(1);
     const args = findSimilarClimbsMock.mock.calls[0][0];
@@ -243,7 +256,9 @@ describe('climbQueries.similarClimbs', () => {
   });
 
   it('parses board_climbs.frames directly for a multi-frame target', async () => {
-    mockDb.select.mockReturnValueOnce(mockSelectChain([{ frames: 'p1r12,"x1p2r13', framesCount: 2 }]));
+    mockDb.select.mockReturnValueOnce(
+      mockSelectChain([{ frames: 'p1r12,"x1p2r13', framesCount: 2, holdId: 999, holdState: 'HAND' }]),
+    );
     parseFramesToHoldEntriesMock.mockReturnValueOnce([
       { frameNumber: 0, holdId: 1, holdState: 'STARTING' },
       { frameNumber: 1, holdId: 2, holdState: 'HAND' },
@@ -264,7 +279,9 @@ describe('climbQueries.similarClimbs', () => {
   });
 
   it('does not parse a multi-frame target twice when its authoritative projection is empty', async () => {
-    mockDb.select.mockReturnValueOnce(mockSelectChain([{ frames: 'x1,"', framesCount: 2 }]));
+    mockDb.select.mockReturnValueOnce(
+      mockSelectChain([{ frames: 'x1,"', framesCount: 2, holdId: 999, holdState: 'HAND' }]),
+    );
     parseFramesToHoldEntriesMock.mockReturnValueOnce([]);
 
     const result = await climbQueries.similarClimbs(
@@ -281,12 +298,12 @@ describe('climbQueries.similarClimbs', () => {
   });
 
   it('filters nonpositive and noncanonical materialized rows for a single-frame target', async () => {
-    mockDb.select.mockReturnValueOnce(mockSelectChain([{ frames: 'p1r12', framesCount: 1 }])).mockReturnValueOnce(
+    mockDb.select.mockReturnValueOnce(
       mockSelectChain([
-        { holdId: 0, holdState: '0=undefined' },
-        { holdId: -1, holdState: 'HAND' },
-        { holdId: 1, holdState: 'STARTING' },
-        { holdId: 2, holdState: '2=999' },
+        { frames: 'p1r12', framesCount: 1, holdId: 0, holdState: '0=undefined' },
+        { frames: 'p1r12', framesCount: 1, holdId: -1, holdState: 'HAND' },
+        { frames: 'p1r12', framesCount: 1, holdId: 1, holdState: 'STARTING' },
+        { frames: 'p1r12', framesCount: 1, holdId: 2, holdState: '2=999' },
       ]),
     );
 
@@ -296,7 +313,35 @@ describe('climbQueries.similarClimbs', () => {
       makeCtx(),
     );
 
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
     expect(findSimilarClimbsMock.mock.calls[0][0].holds).toEqual([{ holdId: 1, holdState: 'STARTING' }]);
     expect(parseFramesToHoldEntriesMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to frames when every single-frame materialized row is invalid', async () => {
+    mockDb.select.mockReturnValueOnce(
+      mockSelectChain([
+        { frames: 'p1r12p2r13', framesCount: 1, holdId: 0, holdState: '0=undefined' },
+        { frames: 'p1r12p2r13', framesCount: 1, holdId: 2, holdState: '2=999' },
+      ]),
+    );
+    parseFramesToHoldEntriesMock.mockReturnValueOnce([
+      { frameNumber: 0, holdId: 1, holdState: 'STARTING' },
+      { frameNumber: 0, holdId: 2, holdState: 'HAND' },
+    ]);
+
+    await climbQueries.similarClimbs(
+      {},
+      { input: { boardType: 'kilter', layoutId: 1, climbUuid: 'invalid-materialized' } },
+      makeCtx(),
+    );
+
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+    expect(parseFramesToHoldEntriesMock).toHaveBeenCalledTimes(1);
+    expect(parseFramesToHoldEntriesMock).toHaveBeenCalledWith('kilter', 'p1r12p2r13');
+    expect(findSimilarClimbsMock.mock.calls[0][0].holds).toEqual([
+      { holdId: 1, holdState: 'STARTING' },
+      { holdId: 2, holdState: 'HAND' },
+    ]);
   });
 });

--- a/packages/backend/src/__tests__/climb-similar-resolver.test.ts
+++ b/packages/backend/src/__tests__/climb-similar-resolver.test.ts
@@ -263,6 +263,23 @@ describe('climbQueries.similarClimbs', () => {
     ]);
   });
 
+  it('does not parse a multi-frame target twice when its authoritative projection is empty', async () => {
+    mockDb.select.mockReturnValueOnce(mockSelectChain([{ frames: 'x1,"', framesCount: 2 }]));
+    parseFramesToHoldEntriesMock.mockReturnValueOnce([]);
+
+    const result = await climbQueries.similarClimbs(
+      {},
+      { input: { boardType: 'kilter', layoutId: 1, climbUuid: 'empty-animated' } },
+      makeCtx(),
+    );
+
+    expect(result).toEqual([]);
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+    expect(parseFramesToHoldEntriesMock).toHaveBeenCalledTimes(1);
+    expect(parseFramesToHoldEntriesMock).toHaveBeenCalledWith('kilter', 'x1,"');
+    expect(findSimilarClimbsMock).not.toHaveBeenCalled();
+  });
+
   it('filters nonpositive and noncanonical materialized rows for a single-frame target', async () => {
     mockDb.select.mockReturnValueOnce(mockSelectChain([{ frames: 'p1r12', framesCount: 1 }])).mockReturnValueOnce(
       mockSelectChain([

--- a/packages/backend/src/__tests__/climb-similar-resolver.test.ts
+++ b/packages/backend/src/__tests__/climb-similar-resolver.test.ts
@@ -122,12 +122,14 @@ describe('climbQueries.similarClimbs', () => {
   });
 
   it('climbUuid path reads the target climbs holds and passes them through with excludeUuid set to the target', async () => {
-    mockDb.select.mockReturnValueOnce(
-      mockSelectChain([
-        { holdId: 4122, holdState: 'STARTING' },
-        { holdId: 4182, holdState: 'HAND' },
-      ]),
-    );
+    mockDb.select
+      .mockReturnValueOnce(mockSelectChain([{ frames: 'p4122r42p4182r43', framesCount: 1 }]))
+      .mockReturnValueOnce(
+        mockSelectChain([
+          { holdId: 4122, holdState: 'STARTING' },
+          { holdId: 4182, holdState: 'HAND' },
+        ]),
+      );
 
     await climbQueries.similarClimbs(
       {},
@@ -197,8 +199,7 @@ describe('climbQueries.similarClimbs', () => {
   });
 
   it('short-circuits to an empty array when the target has no holds, without calling the helper', async () => {
-    // First select: board_climb_holds lookup → no rows.
-    // Second select: legacy frames-fallback on board_climbs → no row.
+    // First select: board_climbs lookup → no row. Second select: holds → none.
     // Both empty → resolver returns [] without hitting findSimilarClimbs.
     mockDb.select.mockReturnValueOnce(mockSelectChain([])).mockReturnValueOnce(mockSelectChain([]));
 
@@ -221,8 +222,8 @@ describe('climbQueries.similarClimbs', () => {
     // drawer doesn't silently surface "no identical climbs" for a match
     // that absolutely exists.
     mockDb.select
-      .mockReturnValueOnce(mockSelectChain([]))
-      .mockReturnValueOnce(mockSelectChain([{ frames: 'p1r12p2r13' }]));
+      .mockReturnValueOnce(mockSelectChain([{ frames: 'p1r12p2r13', framesCount: 1 }]))
+      .mockReturnValueOnce(mockSelectChain([]));
     parseFramesToHoldEntriesMock.mockReturnValueOnce([
       { frameNumber: 0, holdId: 1, holdState: 'STARTING' },
       { frameNumber: 0, holdId: 2, holdState: 'HAND' },
@@ -239,5 +240,46 @@ describe('climbQueries.similarClimbs', () => {
     const args = findSimilarClimbsMock.mock.calls[0][0];
     expect(args.holds).toHaveLength(2);
     expect(args.excludeUuid).toBe('legacy-mb');
+  });
+
+  it('parses board_climbs.frames directly for a multi-frame target', async () => {
+    mockDb.select.mockReturnValueOnce(mockSelectChain([{ frames: 'p1r12,"x1p2r13', framesCount: 2 }]));
+    parseFramesToHoldEntriesMock.mockReturnValueOnce([
+      { frameNumber: 0, holdId: 1, holdState: 'STARTING' },
+      { frameNumber: 1, holdId: 2, holdState: 'HAND' },
+    ]);
+
+    await climbQueries.similarClimbs(
+      {},
+      { input: { boardType: 'kilter', layoutId: 1, climbUuid: 'animated' } },
+      makeCtx(),
+    );
+
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+    expect(parseFramesToHoldEntriesMock).toHaveBeenCalledWith('kilter', 'p1r12,"x1p2r13');
+    expect(findSimilarClimbsMock.mock.calls[0][0].holds).toEqual([
+      { holdId: 1, holdState: 'STARTING' },
+      { holdId: 2, holdState: 'HAND' },
+    ]);
+  });
+
+  it('filters nonpositive and noncanonical materialized rows for a single-frame target', async () => {
+    mockDb.select.mockReturnValueOnce(mockSelectChain([{ frames: 'p1r12', framesCount: 1 }])).mockReturnValueOnce(
+      mockSelectChain([
+        { holdId: 0, holdState: '0=undefined' },
+        { holdId: -1, holdState: 'HAND' },
+        { holdId: 1, holdState: 'STARTING' },
+        { holdId: 2, holdState: '2=999' },
+      ]),
+    );
+
+    await climbQueries.similarClimbs(
+      {},
+      { input: { boardType: 'kilter', layoutId: 1, climbUuid: 'single' } },
+      makeCtx(),
+    );
+
+    expect(findSimilarClimbsMock.mock.calls[0][0].holds).toEqual([{ holdId: 1, holdState: 'STARTING' }]);
+    expect(parseFramesToHoldEntriesMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/__tests__/climb-similarity.test.ts
+++ b/packages/backend/src/__tests__/climb-similarity.test.ts
@@ -73,6 +73,13 @@ describe('parseFramesToHoldEntries', () => {
       { frameNumber: 1, holdId: 30, holdState: 'FINISH' },
     ]);
   });
+
+  it('uses same-frame last-token-wins and cross-frame first-valid-wins for Aurora rows', () => {
+    expect(parseFramesToHoldEntries('tension', 'p10r1p10r2,"p10r3p20r999,"p20r2')).toEqual([
+      { frameNumber: 0, holdId: 10, holdState: 'HAND' },
+      { frameNumber: 2, holdId: 20, holdState: 'HAND' },
+    ]);
+  });
 });
 
 describe('buildHoldSignature', () => {
@@ -187,7 +194,7 @@ describe('findExactDuplicateMatch', () => {
     expect(match).toBeNull();
   });
 
-  it('emits SQL that restricts the join to the canonical hold states', async () => {
+  it('emits SQL that restricts the join to positive IDs and canonical hold states', async () => {
     mockDb.execute.mockResolvedValueOnce([]);
     await findExactDuplicateMatch({
       boardType: 'kilter',
@@ -200,6 +207,7 @@ describe('findExactDuplicateMatch', () => {
     // longer signature, miss the candidate's, and slip past the gate.
     const [query] = mockDb.execute.mock.calls[0];
     const { sql: rendered, params } = new PgDialect().sqlToQuery(query as SQL);
+    expect(rendered).toContain('"hold_id" > 0');
     expect(rendered).toContain('hold_state" IN (');
     // Drizzle parameterises the inlined state names; check the param values.
     for (const state of ['STARTING', 'HAND', 'FINISH', 'FOOT']) {
@@ -242,6 +250,19 @@ describe('findSimilarClimbs', () => {
     expect(result).toEqual([]);
     expect(mockDb.execute).not.toHaveBeenCalled();
     expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+
+  it('excludes nonpositive materialized hold IDs from candidate overlap and size scans', async () => {
+    mockDb.execute.mockResolvedValueOnce([]);
+    await findSimilarClimbs({
+      boardType: 'kilter',
+      layoutId: 1,
+      holds: [{ holdId: 1, holdState: 'STARTING' }],
+      threshold: 0.5,
+    });
+    const [query] = mockDb.execute.mock.calls[0];
+    const compiled = new PgDialect().sqlToQuery(query as SQL).sql;
+    expect(compiled.match(/hold_id > 0/g)).toHaveLength(2);
   });
 
   it('maps each row to the SimilarClimbResult shape', async () => {

--- a/packages/backend/src/__tests__/popular-configs-invalid-holds.test.ts
+++ b/packages/backend/src/__tests__/popular-configs-invalid-holds.test.ts
@@ -3,10 +3,10 @@ import { PgDialect } from 'drizzle-orm/pg-core';
 import { POPULAR_CONFIGS_QUERY } from '../graphql/resolvers/social/boards';
 
 describe('popular board configs invalid-hold safeguard', () => {
-  it('renders all invalid-row guards inside the resolver query', () => {
+  it('scopes structural guards and placement exclusion to the climb-count hold subquery', () => {
     const query = new PgDialect().sqlToQuery(POPULAR_CONFIGS_QUERY);
     expect(query.sql.replace(/\s+/g, ' ')).toContain(
-      "bch.hold_id > 0 AND bch.hold_state <> '' AND bch.hold_state NOT LIKE '%=%' AND NOT EXISTS",
+      "AND NOT EXISTS ( SELECT 1 FROM board_climb_holds bch WHERE bch.climb_uuid = bc.uuid AND bch.board_type = bc.board_type AND bch.hold_id > 0 AND bch.hold_state <> '' AND bch.hold_state NOT LIKE '%=%' AND NOT EXISTS ( SELECT 1 FROM board_placements bp WHERE bp.board_type = bch.board_type AND bp.layout_id = bc.layout_id AND bp.id = bch.hold_id AND bp.set_id = ANY(configs.set_ids) ) )",
     );
   });
 });

--- a/packages/backend/src/__tests__/popular-configs-invalid-holds.test.ts
+++ b/packages/backend/src/__tests__/popular-configs-invalid-holds.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { POPULAR_CONFIGS_QUERY } from '../graphql/resolvers/social/boards';
+
+describe('popular board configs invalid-hold safeguard', () => {
+  it('renders all invalid-row guards inside the resolver query', () => {
+    const query = new PgDialect().sqlToQuery(POPULAR_CONFIGS_QUERY);
+    expect(query.sql.replace(/\s+/g, ' ')).toContain(
+      "bch.hold_id > 0 AND bch.hold_state <> '' AND bch.hold_state NOT LIKE '%=%' AND NOT EXISTS",
+    );
+  });
+});

--- a/packages/backend/src/graphql/resolvers/climbs/climb-similarity.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/climb-similarity.ts
@@ -4,7 +4,9 @@ import * as dbSchema from '@boardsesh/db/schema';
 import {
   STATE_TO_PRIMARY_CODE,
   convertLitUpHoldsStringToMap,
+  isAuroraBoardName,
   isSentinelHoldState,
+  projectAuroraFramesToStoredRows,
 } from '@boardsesh/board-constants/hold-states';
 import type { BoardName } from '@boardsesh/board-constants';
 import { executeRows } from '@boardsesh/db/client';
@@ -74,15 +76,21 @@ export type SimilarClimbResult = {
 const KNOWN_HOLD_STATES: ReadonlyArray<string> = Array.from(
   new Set(Object.values(STATE_TO_PRIMARY_CODE).flatMap((perBoard) => Object.keys(perBoard))),
 ).sort();
+const KNOWN_HOLD_STATE_SET = new Set(KNOWN_HOLD_STATES);
 const KNOWN_HOLD_STATES_SQL = sql`(${sql.join(
   KNOWN_HOLD_STATES.map((state) => sql`${state}`),
   sql`, `,
 )})`;
 
+export function isCanonicalStoredHold(row: NormalizedHold): boolean {
+  return Number.isSafeInteger(row.holdId) && row.holdId > 0 && KNOWN_HOLD_STATE_SET.has(row.holdState);
+}
+
 /**
  * Parse the Aurora-style frame string ("p<id>r<role>p<id>r<role>...,p<id>r<role>...")
- * into a flat list of holds with their state name. Multi-frame strings (comma
- * separated) are flattened with the frame index preserved.
+ * into the one-row-per-hold shape persisted by board_climb_holds. Aurora
+ * boards use the shared first-valid projector; MoonBoard keeps its existing
+ * decoded-map path.
  *
  * Returns only holds whose state code resolves to a named state (STARTING /
  * HAND / FINISH / FOOT) — unknown codes (the synthetic "1=42" sentinel) are
@@ -90,6 +98,9 @@ const KNOWN_HOLD_STATES_SQL = sql`(${sql.join(
  */
 export function parseFramesToHoldEntries(boardType: BoardName, frames: string | null | undefined): NormalizedHoldRow[] {
   if (!frames) return [];
+  if (isAuroraBoardName(boardType)) {
+    return projectAuroraFramesToStoredRows(frames, boardType).rows;
+  }
   const frameMap = convertLitUpHoldsStringToMap(frames, boardType);
   const rows: NormalizedHoldRow[] = [];
   for (const [frameIndexKey, holdsMap] of Object.entries(frameMap)) {
@@ -97,7 +108,7 @@ export function parseFramesToHoldEntries(boardType: BoardName, frames: string | 
     for (const [holdIdKey, hold] of Object.entries(holdsMap)) {
       if (isSentinelHoldState(hold.state)) continue;
       const holdId = Number(holdIdKey);
-      if (!Number.isFinite(holdId)) continue;
+      if (!Number.isSafeInteger(holdId) || holdId <= 0) continue;
       rows.push({ frameNumber, holdId, holdState: hold.state });
     }
   }
@@ -177,8 +188,9 @@ export async function findExactDuplicateMatch({
         ${dbSchema.boardClimbs.angle} AS angle
       FROM ${dbSchema.boardClimbs}
       INNER JOIN ${dbSchema.boardClimbHolds}
-        ON ${dbSchema.boardClimbHolds.climbUuid} = ${dbSchema.boardClimbs.uuid}
+       ON ${dbSchema.boardClimbHolds.climbUuid} = ${dbSchema.boardClimbs.uuid}
        AND ${dbSchema.boardClimbHolds.boardType} = ${dbSchema.boardClimbs.boardType}
+       AND ${dbSchema.boardClimbHolds.holdId} > 0
        AND ${dbSchema.boardClimbHolds.holdState} IN ${KNOWN_HOLD_STATES_SQL}
       LEFT JOIN ${dbSchema.boardClimbStats}
         ON ${dbSchema.boardClimbStats.boardType} = ${dbSchema.boardClimbs.boardType}
@@ -285,7 +297,7 @@ export async function findSimilarClimbs({
 }: FindSimilarClimbsArgs): Promise<SimilarClimbResult[]> {
   // Reduce to unique hold positions on the target. State is intentionally
   // dropped — see the docblock above.
-  const targetHoldIds = Array.from(new Set(holds.map(({ holdId }) => holdId)));
+  const targetHoldIds = Array.from(new Set(holds.map(({ holdId }) => holdId).filter((holdId) => holdId > 0)));
   if (targetHoldIds.length === 0) return [];
 
   const targetSize = targetHoldIds.length;
@@ -340,6 +352,7 @@ export async function findSimilarClimbs({
           ON c.uuid = h.climb_uuid
          AND c.board_type = h.board_type
         WHERE h.board_type = ${boardType}
+          AND h.hold_id > 0
           AND h.hold_state IN ${KNOWN_HOLD_STATES_SQL}
           AND c.layout_id = ${layoutId}
           AND c.is_draft = FALSE
@@ -367,6 +380,7 @@ export async function findSimilarClimbs({
         SELECT climb_uuid AS uuid, COUNT(DISTINCT hold_id) AS n
         FROM ${dbSchema.boardClimbHolds}
         WHERE board_type = ${boardType}
+          AND hold_id > 0
           AND hold_state IN ${KNOWN_HOLD_STATES_SQL}
           AND climb_uuid IN (SELECT uuid FROM candidate_overlaps)
         GROUP BY climb_uuid

--- a/packages/backend/src/graphql/resolvers/climbs/climb-similarity.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/climb-similarity.ts
@@ -82,7 +82,7 @@ const KNOWN_HOLD_STATES_SQL = sql`(${sql.join(
   sql`, `,
 )})`;
 
-export function isCanonicalStoredHold(row: NormalizedHold): boolean {
+export function isSupportedSimilarityHold(row: NormalizedHold): boolean {
   return Number.isSafeInteger(row.holdId) && row.holdId > 0 && KNOWN_HOLD_STATE_SET.has(row.holdState);
 }
 

--- a/packages/backend/src/graphql/resolvers/climbs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/queries.ts
@@ -24,7 +24,7 @@ import { applyRateLimit, requireAuthenticated, validateInput } from '../shared/h
 import { findMoonBoardDuplicateMatches } from './moonboard-duplicates';
 import {
   findSimilarClimbs,
-  isCanonicalStoredHold,
+  isSupportedSimilarityHold,
   parseFramesToHoldEntries,
   type NormalizedHold,
 } from './climb-similarity';
@@ -91,15 +91,9 @@ export const climbQueries = {
         .where(and(eq(dbSchema.boardClimbs.boardType, boardType), eq(dbSchema.boardClimbs.uuid, validated.climbUuid)))
         .limit(1);
 
-      if ((climbRow?.framesCount ?? 1) > 1 && climbRow?.frames) {
-        // Historical multi-frame rows may reflect only fragments of the
-        // animation. The canonical frames text is the target signature until
-        // the repair has been run everywhere.
-        holds = parseFramesToHoldEntries(boardType, climbRow.frames).map(({ holdId, holdState }) => ({
-          holdId,
-          holdState,
-        }));
-      } else {
+      const useAuthoritativeFrames = (climbRow?.framesCount ?? 1) > 1 && Boolean(climbRow?.frames);
+      holds = [];
+      if (!useAuthoritativeFrames) {
         const targetHoldRows = await db
           .select({
             holdId: dbSchema.boardClimbHolds.holdId,
@@ -114,16 +108,14 @@ export const climbQueries = {
           );
         holds = targetHoldRows
           .map((row) => ({ holdId: row.holdId, holdState: row.holdState }))
-          .filter(isCanonicalStoredHold);
+          .filter(isSupportedSimilarityHold);
       }
 
-      // Legacy fallback: pre-existing climbs (especially MoonBoard imports)
-      // carry their hold pattern in board_climbs.frames but have no rows in
-      // board_climb_holds yet (backfill follow-up #1). Without this fallback
-      // a MoonBoard duplicate-publish that points the UI at the existing
-      // climb via `climbUuid` would surface an empty "no identical climbs"
-      // state for the exact match it just rejected.
-      if (holds.length === 0 && climbRow?.frames && (climbRow.framesCount ?? 1) <= 1) {
+      // Multi-frame rows may reflect only fragments of an animation, so their
+      // canonical frames text is always authoritative. For single-frame
+      // climbs this is only the legacy fallback: older MoonBoard imports can
+      // carry frames without materialized hold rows (backfill follow-up #1).
+      if (holds.length === 0 && climbRow?.frames) {
         holds = parseFramesToHoldEntries(boardType, climbRow.frames).map(({ holdId, holdState }) => ({
           holdId,
           holdState,

--- a/packages/backend/src/graphql/resolvers/climbs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/queries.ts
@@ -85,29 +85,31 @@ export const climbQueries = {
     let excludeUuid = validated.excludeClimbUuid ?? undefined;
 
     if (validated.climbUuid) {
-      const [climbRow] = await db
-        .select({ frames: dbSchema.boardClimbs.frames, framesCount: dbSchema.boardClimbs.framesCount })
+      const targetRows = await db
+        .select({
+          frames: dbSchema.boardClimbs.frames,
+          framesCount: dbSchema.boardClimbs.framesCount,
+          holdId: dbSchema.boardClimbHolds.holdId,
+          holdState: dbSchema.boardClimbHolds.holdState,
+        })
         .from(dbSchema.boardClimbs)
-        .where(and(eq(dbSchema.boardClimbs.boardType, boardType), eq(dbSchema.boardClimbs.uuid, validated.climbUuid)))
-        .limit(1);
+        .leftJoin(
+          dbSchema.boardClimbHolds,
+          and(
+            eq(dbSchema.boardClimbHolds.boardType, dbSchema.boardClimbs.boardType),
+            eq(dbSchema.boardClimbHolds.climbUuid, dbSchema.boardClimbs.uuid),
+          ),
+        )
+        .where(and(eq(dbSchema.boardClimbs.boardType, boardType), eq(dbSchema.boardClimbs.uuid, validated.climbUuid)));
 
+      const climbRow = targetRows[0];
       const useAuthoritativeFrames = (climbRow?.framesCount ?? 1) > 1 && Boolean(climbRow?.frames);
       holds = [];
       if (!useAuthoritativeFrames) {
-        const targetHoldRows = await db
-          .select({
-            holdId: dbSchema.boardClimbHolds.holdId,
-            holdState: dbSchema.boardClimbHolds.holdState,
-          })
-          .from(dbSchema.boardClimbHolds)
-          .where(
-            and(
-              eq(dbSchema.boardClimbHolds.boardType, boardType),
-              eq(dbSchema.boardClimbHolds.climbUuid, validated.climbUuid),
-            ),
-          );
-        holds = targetHoldRows
-          .map((row) => ({ holdId: row.holdId, holdState: row.holdState }))
+        holds = targetRows
+          .flatMap((row) =>
+            row.holdId === null || row.holdState === null ? [] : [{ holdId: row.holdId, holdState: row.holdState }],
+          )
           .filter(isSupportedSimilarityHold);
       }
 

--- a/packages/backend/src/graphql/resolvers/climbs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/queries.ts
@@ -22,7 +22,12 @@ import {
 import { isValidBoardName } from '../../../db/queries/util/table-select';
 import { applyRateLimit, requireAuthenticated, validateInput } from '../shared/helpers';
 import { findMoonBoardDuplicateMatches } from './moonboard-duplicates';
-import { findSimilarClimbs, parseFramesToHoldEntries, type NormalizedHold } from './climb-similarity';
+import {
+  findSimilarClimbs,
+  isCanonicalStoredHold,
+  parseFramesToHoldEntries,
+  type NormalizedHold,
+} from './climb-similarity';
 import {
   BoardNameSchema,
   CheckMoonBoardClimbDuplicatesInputSchema,
@@ -80,19 +85,37 @@ export const climbQueries = {
     let excludeUuid = validated.excludeClimbUuid ?? undefined;
 
     if (validated.climbUuid) {
-      const targetHoldRows = await db
-        .select({
-          holdId: dbSchema.boardClimbHolds.holdId,
-          holdState: dbSchema.boardClimbHolds.holdState,
-        })
-        .from(dbSchema.boardClimbHolds)
-        .where(
-          and(
-            eq(dbSchema.boardClimbHolds.boardType, boardType),
-            eq(dbSchema.boardClimbHolds.climbUuid, validated.climbUuid),
-          ),
-        );
-      holds = targetHoldRows.map((row) => ({ holdId: row.holdId, holdState: row.holdState }));
+      const [climbRow] = await db
+        .select({ frames: dbSchema.boardClimbs.frames, framesCount: dbSchema.boardClimbs.framesCount })
+        .from(dbSchema.boardClimbs)
+        .where(and(eq(dbSchema.boardClimbs.boardType, boardType), eq(dbSchema.boardClimbs.uuid, validated.climbUuid)))
+        .limit(1);
+
+      if ((climbRow?.framesCount ?? 1) > 1 && climbRow?.frames) {
+        // Historical multi-frame rows may reflect only fragments of the
+        // animation. The canonical frames text is the target signature until
+        // the repair has been run everywhere.
+        holds = parseFramesToHoldEntries(boardType, climbRow.frames).map(({ holdId, holdState }) => ({
+          holdId,
+          holdState,
+        }));
+      } else {
+        const targetHoldRows = await db
+          .select({
+            holdId: dbSchema.boardClimbHolds.holdId,
+            holdState: dbSchema.boardClimbHolds.holdState,
+          })
+          .from(dbSchema.boardClimbHolds)
+          .where(
+            and(
+              eq(dbSchema.boardClimbHolds.boardType, boardType),
+              eq(dbSchema.boardClimbHolds.climbUuid, validated.climbUuid),
+            ),
+          );
+        holds = targetHoldRows
+          .map((row) => ({ holdId: row.holdId, holdState: row.holdState }))
+          .filter(isCanonicalStoredHold);
+      }
 
       // Legacy fallback: pre-existing climbs (especially MoonBoard imports)
       // carry their hold pattern in board_climbs.frames but have no rows in
@@ -100,18 +123,11 @@ export const climbQueries = {
       // a MoonBoard duplicate-publish that points the UI at the existing
       // climb via `climbUuid` would surface an empty "no identical climbs"
       // state for the exact match it just rejected.
-      if (holds.length === 0) {
-        const [climbRow] = await db
-          .select({ frames: dbSchema.boardClimbs.frames })
-          .from(dbSchema.boardClimbs)
-          .where(and(eq(dbSchema.boardClimbs.boardType, boardType), eq(dbSchema.boardClimbs.uuid, validated.climbUuid)))
-          .limit(1);
-        if (climbRow?.frames) {
-          holds = parseFramesToHoldEntries(boardType, climbRow.frames).map(({ holdId, holdState }) => ({
-            holdId,
-            holdState,
-          }));
-        }
+      if (holds.length === 0 && climbRow?.frames) {
+        holds = parseFramesToHoldEntries(boardType, climbRow.frames).map(({ holdId, holdState }) => ({
+          holdId,
+          holdState,
+        }));
       }
 
       // Always exclude the target climb itself from its own similar list.

--- a/packages/backend/src/graphql/resolvers/climbs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/queries.ts
@@ -123,7 +123,7 @@ export const climbQueries = {
       // a MoonBoard duplicate-publish that points the UI at the existing
       // climb via `climbUuid` would surface an empty "no identical climbs"
       // state for the exact match it just rejected.
-      if (holds.length === 0 && climbRow?.frames) {
+      if (holds.length === 0 && climbRow?.frames && (climbRow.framesCount ?? 1) <= 1) {
         holds = parseFramesToHoldEntries(boardType, climbRow.frames).map(({ holdId, holdState }) => ({
           holdId,
           holdState,

--- a/packages/backend/src/graphql/resolvers/climbs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/queries.ts
@@ -116,19 +116,17 @@ export const climbQueries = {
       // climbs this is only the legacy fallback: older MoonBoard imports can
       // carry frames without materialized hold rows (backfill follow-up #1).
       if (holds.length === 0 && climbRow?.frames) {
-        holds = parseFramesToHoldEntries(boardType, climbRow.frames).map(({ holdId, holdState }) => ({
-          holdId,
-          holdState,
-        }));
+        holds = parseFramesToHoldEntries(boardType, climbRow.frames)
+          .map(({ holdId, holdState }) => ({ holdId, holdState }))
+          .filter(isSupportedSimilarityHold);
       }
 
       // Always exclude the target climb itself from its own similar list.
       excludeUuid = validated.climbUuid;
     } else {
-      holds = parseFramesToHoldEntries(boardType, validated.frames ?? '').map(({ holdId, holdState }) => ({
-        holdId,
-        holdState,
-      }));
+      holds = parseFramesToHoldEntries(boardType, validated.frames ?? '')
+        .map(({ holdId, holdState }) => ({ holdId, holdState }))
+        .filter(isSupportedSimilarityHold);
     }
 
     if (holds.length === 0) return [];

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -784,9 +784,12 @@ export function dropPopularConfigsFallback(): void {
   fallbackGeneration += 1;
 }
 
-// Invalid/sentinel rows must not make an otherwise valid climb fail the
-// negative placement-exclusion check below.
-export const POPULAR_CONFIGS_CANONICAL_HOLD_PREDICATE = sql`bch.hold_id > 0 AND bch.hold_state <> '' AND bch.hold_state NOT LIKE '%=%'`;
+// Structurally corrupt/sentinel rows must not make an otherwise valid climb
+// fail the negative placement-exclusion check below. This intentionally does
+// not require a currently known state name: a well-formed state introduced by
+// a future board still belongs to a placement and must count here. Similarity
+// matching is stricter because both sides must use states its parser supports.
+export const POPULAR_CONFIGS_STRUCTURALLY_VALID_HOLD_PREDICATE = sql`bch.hold_id > 0 AND bch.hold_state <> '' AND bch.hold_state NOT LIKE '%=%'`;
 
 /** Exported so regression tests render the exact query the resolver executes. */
 export const POPULAR_CONFIGS_QUERY = sql`
@@ -848,7 +851,7 @@ export const POPULAR_CONFIGS_QUERY = sql`
         SELECT 1 FROM board_climb_holds bch
         WHERE bch.climb_uuid = bc.uuid
           AND bch.board_type = bc.board_type
-          AND ${POPULAR_CONFIGS_CANONICAL_HOLD_PREDICATE}
+          AND ${POPULAR_CONFIGS_STRUCTURALLY_VALID_HOLD_PREDICATE}
           AND NOT EXISTS (
             SELECT 1 FROM board_placements bp
             WHERE bp.board_type = bch.board_type

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -784,6 +784,85 @@ export function dropPopularConfigsFallback(): void {
   fallbackGeneration += 1;
 }
 
+// Invalid/sentinel rows must not make an otherwise valid climb fail the
+// negative placement-exclusion check below.
+export const POPULAR_CONFIGS_CANONICAL_HOLD_PREDICATE = sql`bch.hold_id > 0 AND bch.hold_state <> '' AND bch.hold_state NOT LIKE '%=%'`;
+
+/** Exported so regression tests render the exact query the resolver executes. */
+export const POPULAR_CONFIGS_QUERY = sql`
+  SELECT
+    configs.board_type,
+    configs.layout_id,
+    bl.name AS layout_name,
+    configs.size_id,
+    bps.name AS size_name,
+    bps.description AS size_description,
+    configs.set_ids,
+    configs.set_names,
+    COALESCE(cc.climb_count, 0) AS climb_count,
+    COALESCE(cc.total_ascents, 0) AS total_ascents,
+    COALESCE(ub_counts.board_count, 0) AS board_count
+  FROM (
+    SELECT
+      psls.board_type,
+      psls.layout_id,
+      psls.product_size_id AS size_id,
+      array_agg(DISTINCT psls.set_id ORDER BY psls.set_id) AS set_ids,
+      array_agg(DISTINCT bs.name ORDER BY bs.name) AS set_names
+    FROM board_product_sizes_layouts_sets psls
+    JOIN board_sets bs ON bs.board_type = psls.board_type AND bs.id = psls.set_id
+    WHERE psls.is_listed = true
+    GROUP BY psls.board_type, psls.layout_id, psls.product_size_id
+  ) configs
+  JOIN board_layouts bl ON bl.board_type = configs.board_type AND bl.id = configs.layout_id
+  JOIN board_product_sizes bps ON bps.board_type = configs.board_type AND bps.id = configs.size_id
+  LEFT JOIN (
+    SELECT
+      ub.board_type,
+      ub.layout_id,
+      ub.size_id,
+      COUNT(*)::int AS board_count
+    FROM user_boards ub
+    WHERE ub.deleted_at IS NULL
+    GROUP BY ub.board_type, ub.layout_id, ub.size_id
+  ) ub_counts
+    ON ub_counts.board_type = configs.board_type
+    AND ub_counts.layout_id = configs.layout_id
+    AND ub_counts.size_id = configs.size_id
+  LEFT JOIN LATERAL (
+    SELECT
+      COUNT(DISTINCT bc.uuid)::int AS climb_count,
+      COALESCE(SUM(bcs.ascensionist_count), 0)::int AS total_ascents
+    FROM board_climbs bc
+    LEFT JOIN board_climb_stats bcs
+      ON bcs.board_type = bc.board_type AND bcs.climb_uuid = bc.uuid
+    WHERE bc.board_type = configs.board_type
+      AND bc.layout_id = configs.layout_id
+      AND bc.is_listed = true
+      AND bc.is_draft = false
+      AND bc.edge_left > bps.edge_left
+      AND bc.edge_right < bps.edge_right
+      AND bc.edge_bottom > bps.edge_bottom
+      AND bc.edge_top < bps.edge_top
+      AND NOT EXISTS (
+        SELECT 1 FROM board_climb_holds bch
+        WHERE bch.climb_uuid = bc.uuid
+          AND bch.board_type = bc.board_type
+          AND ${POPULAR_CONFIGS_CANONICAL_HOLD_PREDICATE}
+          AND NOT EXISTS (
+            SELECT 1 FROM board_placements bp
+            WHERE bp.board_type = bch.board_type
+              AND bp.layout_id = bc.layout_id
+              AND bp.id = bch.hold_id
+              AND bp.set_id = ANY(configs.set_ids)
+          )
+      )
+  ) cc ON true
+  WHERE bl.is_listed = true
+    AND bps.is_listed = true
+  ORDER BY board_count DESC, total_ascents DESC, configs.board_type, bl.name
+`;
+
 async function getPopularConfigs(): Promise<CachedPopularConfig[]> {
   // Try Redis cache first
   if (redisClientManager.isRedisConnected()) {
@@ -825,78 +904,7 @@ async function runPopularConfigsQuery(): Promise<CachedPopularConfig[]> {
   //
   // Making this statement cheap is its own piece of work; what is fixed here is
   // that a cold window can no longer run more than one copy of it at a time.
-  const result = await db.execute(sql`
-    SELECT
-      configs.board_type,
-      configs.layout_id,
-      bl.name AS layout_name,
-      configs.size_id,
-      bps.name AS size_name,
-      bps.description AS size_description,
-      configs.set_ids,
-      configs.set_names,
-      COALESCE(cc.climb_count, 0) AS climb_count,
-      COALESCE(cc.total_ascents, 0) AS total_ascents,
-      COALESCE(ub_counts.board_count, 0) AS board_count
-    FROM (
-      SELECT
-        psls.board_type,
-        psls.layout_id,
-        psls.product_size_id AS size_id,
-        array_agg(DISTINCT psls.set_id ORDER BY psls.set_id) AS set_ids,
-        array_agg(DISTINCT bs.name ORDER BY bs.name) AS set_names
-      FROM board_product_sizes_layouts_sets psls
-      JOIN board_sets bs ON bs.board_type = psls.board_type AND bs.id = psls.set_id
-      WHERE psls.is_listed = true
-      GROUP BY psls.board_type, psls.layout_id, psls.product_size_id
-    ) configs
-    JOIN board_layouts bl ON bl.board_type = configs.board_type AND bl.id = configs.layout_id
-    JOIN board_product_sizes bps ON bps.board_type = configs.board_type AND bps.id = configs.size_id
-    LEFT JOIN (
-      SELECT
-        ub.board_type,
-        ub.layout_id,
-        ub.size_id,
-        COUNT(*)::int AS board_count
-      FROM user_boards ub
-      WHERE ub.deleted_at IS NULL
-      GROUP BY ub.board_type, ub.layout_id, ub.size_id
-    ) ub_counts
-      ON ub_counts.board_type = configs.board_type
-      AND ub_counts.layout_id = configs.layout_id
-      AND ub_counts.size_id = configs.size_id
-    LEFT JOIN LATERAL (
-      SELECT
-        COUNT(DISTINCT bc.uuid)::int AS climb_count,
-        COALESCE(SUM(bcs.ascensionist_count), 0)::int AS total_ascents
-      FROM board_climbs bc
-      LEFT JOIN board_climb_stats bcs
-        ON bcs.board_type = bc.board_type AND bcs.climb_uuid = bc.uuid
-      WHERE bc.board_type = configs.board_type
-        AND bc.layout_id = configs.layout_id
-        AND bc.is_listed = true
-        AND bc.is_draft = false
-        AND bc.edge_left > bps.edge_left
-        AND bc.edge_right < bps.edge_right
-        AND bc.edge_bottom > bps.edge_bottom
-        AND bc.edge_top < bps.edge_top
-        AND NOT EXISTS (
-          SELECT 1 FROM board_climb_holds bch
-          WHERE bch.climb_uuid = bc.uuid
-            AND bch.board_type = bc.board_type
-            AND NOT EXISTS (
-              SELECT 1 FROM board_placements bp
-              WHERE bp.board_type = bch.board_type
-                AND bp.layout_id = bc.layout_id
-                AND bp.id = bch.hold_id
-                AND bp.set_id = ANY(configs.set_ids)
-            )
-        )
-    ) cc ON true
-    WHERE bl.is_listed = true
-      AND bps.is_listed = true
-    ORDER BY board_count DESC, total_ascents DESC, configs.board_type, bl.name
-  `);
+  const result = await db.execute(POPULAR_CONFIGS_QUERY);
 
   const rows = rowsFromResult<Record<string, unknown>>(result);
 

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -789,6 +789,7 @@ export function dropPopularConfigsFallback(): void {
 // not require a currently known state name: a well-formed state introduced by
 // a future board still belongs to a placement and must count here. Similarity
 // matching is stricter because both sides must use states its parser supports.
+// `hold_state` is NOT NULL in the schema, so excluding SQL NULL here is intentional.
 export const POPULAR_CONFIGS_STRUCTURALLY_VALID_HOLD_PREDICATE = sql`bch.hold_id > 0 AND bch.hold_state <> '' AND bch.hold_state NOT LIKE '%=%'`;
 
 /** Exported so regression tests render the exact query the resolver executes. */

--- a/packages/board-constants/src/__tests__/hold-states.test.ts
+++ b/packages/board-constants/src/__tests__/hold-states.test.ts
@@ -12,6 +12,7 @@ import {
   encodeMapsToFramesString,
   flattenFramesToUnion,
   isSentinelHoldState,
+  legacyAuroraRawFrameHoldEvents,
   projectAuroraFramesToStoredRows,
   toFlatFrames,
 } from '../hold-states';
@@ -411,6 +412,31 @@ describe('projectAuroraFramesToStoredRows', () => {
       { holdId: 1, frameNumber: 0, holdState: 'STARTING' },
       { holdId: 2, frameNumber: 0, holdState: 'HAND' },
       { holdId: 3, frameNumber: 4, holdState: 'HAND' },
+    ]);
+  });
+});
+
+describe('legacyAuroraRawFrameHoldEvents', () => {
+  it('preserves raw frame positions, repeated holds, and unknown sentinels without sanitising IDs', () => {
+    expect(legacyAuroraRawFrameHoldEvents('p1r1p0r2,,","x1p1r2p-2r999', 'tension')).toEqual([
+      { holdId: 1, frameNumber: 0, holdState: 'STARTING' },
+      { holdId: 0, frameNumber: 0, holdState: 'HAND' },
+      { holdId: 1, frameNumber: 3, holdState: 'HAND' },
+      { holdId: -2, frameNumber: 3, holdState: '-2=999' },
+    ]);
+  });
+
+  it('keeps the leading empty frame in a delayed-start Kilter animation', () => {
+    expect(legacyAuroraRawFrameHoldEvents(',"p100r13', 'kilter')).toEqual([
+      { holdId: 100, frameNumber: 1, holdState: 'HAND' },
+    ]);
+  });
+
+  it('ignores off tokens while keeping every cross-frame set event', () => {
+    expect(legacyAuroraRawFrameHoldEvents('p1r1,"x1p1r2,"x1p1r3', 'tension')).toEqual([
+      { holdId: 1, frameNumber: 0, holdState: 'STARTING' },
+      { holdId: 1, frameNumber: 1, holdState: 'HAND' },
+      { holdId: 1, frameNumber: 2, holdState: 'FINISH' },
     ]);
   });
 });

--- a/packages/board-constants/src/__tests__/hold-states.test.ts
+++ b/packages/board-constants/src/__tests__/hold-states.test.ts
@@ -397,11 +397,11 @@ describe('projectAuroraFramesToStoredRows', () => {
   });
 
   it('skips an unknown first occurrence and accepts the later valid role', () => {
-    const projection = projectAuroraFramesToStoredRows('p1r999,"p1r2p0r2p-2r2', 'tension');
+    const projection = projectAuroraFramesToStoredRows('p1r999,"p1r2p0r2p-2r2x0x-3p-4r999', 'tension');
     expect(projection.rows).toEqual([{ holdId: 1, frameNumber: 1, holdState: 'HAND' }]);
     expect(projection.diagnostics).toEqual({
       skippedUnknownRoleTokens: 1,
-      skippedNonpositiveHoldIdTokens: 2,
+      skippedNonpositiveHoldIdTokens: 5,
     });
   });
 

--- a/packages/board-constants/src/__tests__/hold-states.test.ts
+++ b/packages/board-constants/src/__tests__/hold-states.test.ts
@@ -12,6 +12,7 @@ import {
   encodeMapsToFramesString,
   flattenFramesToUnion,
   isSentinelHoldState,
+  projectAuroraFramesToStoredRows,
   toFlatFrames,
 } from '../hold-states';
 import type { BoardName } from '@boardsesh/shared-schema';
@@ -383,6 +384,34 @@ describe('accumulateFramesToMaps', () => {
     expect(Object.keys(result[1])).toEqual(['100']);
     expect(result[1]).toEqual(result[0]);
     expect(Object.keys(result[2])).toEqual(['300']);
+  });
+});
+
+describe('projectAuroraFramesToStoredRows', () => {
+  it('keeps the first valid accumulated occurrence while same-frame last token wins', () => {
+    expect(projectAuroraFramesToStoredRows('p1r1p1r2,"p1r3p2r2', 'tension').rows).toEqual([
+      { holdId: 1, frameNumber: 0, holdState: 'HAND' },
+      { holdId: 2, frameNumber: 1, holdState: 'HAND' },
+    ]);
+  });
+
+  it('skips an unknown first occurrence and accepts the later valid role', () => {
+    const projection = projectAuroraFramesToStoredRows('p1r999,"p1r2p0r2p-2r2', 'tension');
+    expect(projection.rows).toEqual([{ holdId: 1, frameNumber: 1, holdState: 'HAND' }]);
+    expect(projection.diagnostics).toEqual({
+      skippedUnknownRoleTokens: 1,
+      skippedNonpositiveHoldIdTokens: 2,
+    });
+  });
+
+  it('handles hold frames, off/re-add, and later absolute frames deterministically', () => {
+    const projection = projectAuroraFramesToStoredRows('p1r1p2r2,","x1,"p1r3,p3r2', 'tension');
+    expect(projection.frameCount).toBe(5);
+    expect(projection.rows).toEqual([
+      { holdId: 1, frameNumber: 0, holdState: 'STARTING' },
+      { holdId: 2, frameNumber: 0, holdState: 'HAND' },
+      { holdId: 3, frameNumber: 4, holdState: 'HAND' },
+    ]);
   });
 });
 

--- a/packages/board-constants/src/hold-states.ts
+++ b/packages/board-constants/src/hold-states.ts
@@ -1,4 +1,10 @@
-import type { BoardName, HoldState, LitUpHoldsMap } from '@boardsesh/shared-schema';
+import {
+  AURORA_BOARDS,
+  type AuroraBoardName,
+  type BoardName,
+  type HoldState,
+  type LitUpHoldsMap,
+} from '@boardsesh/shared-schema';
 
 export type HoldCode = number;
 export type HoldColor = string;
@@ -329,8 +335,9 @@ function tokeniseFrameDelta(
   frame: string,
 ): Array<{ kind: 'set'; holdId: number; roleCode: number } | { kind: 'off'; holdId: number }> {
   const tokens: Array<{ kind: 'set'; holdId: number; roleCode: number } | { kind: 'off'; holdId: number }> = [];
-  // Matches either `p<digits>r<digits>` or `x<digits>` greedily across the frame.
-  const re = /p(\d+)r(\d+)|x(\d+)/g;
+  // Recognise signed raw hold IDs so repair diagnostics can explicitly report
+  // nonpositive values instead of silently treating a minus sign as junk.
+  const re = /p(-?\d+)r(\d+)|x(-?\d+)/g;
   let match: RegExpExecArray | null;
   while ((match = re.exec(frame)) !== null) {
     if (match[1] !== undefined && match[2] !== undefined) {
@@ -340,6 +347,72 @@ function tokeniseFrameDelta(
     }
   }
   return tokens;
+}
+
+export type StoredClimbHoldRow = {
+  holdId: number;
+  frameNumber: number;
+  holdState: HoldState;
+};
+
+export type StoredClimbHoldProjection = {
+  rows: StoredClimbHoldRow[];
+  frameCount: number;
+  diagnostics: {
+    skippedUnknownRoleTokens: number;
+    skippedNonpositiveHoldIdTokens: number;
+  };
+};
+
+/** True for boards whose climb frames use Aurora's p/r/x grammar. */
+export function isAuroraBoardName(board: string): board is AuroraBoardName {
+  return (AURORA_BOARDS as readonly string[]).includes(board);
+}
+
+/**
+ * Project Aurora frames to the one-row-per-hold shape stored by
+ * `board_climb_holds`.
+ *
+ * The table primary key omits frame_number. Its historical writers inserted
+ * frames in ascending order with `ON CONFLICT DO NOTHING`, so the first valid
+ * accumulated occurrence of a hold is the canonical stored row. This helper
+ * makes that behaviour explicit and shared. The frame parser has already
+ * applied token order within each frame, so the last token in one frame wins.
+ * Unknown-role sentinels and nonpositive hold IDs never become stored rows;
+ * an unknown occurrence does not prevent a later valid occurrence from
+ * becoming the first stored row.
+ */
+export function projectAuroraFramesToStoredRows(frames: string, board: AuroraBoardName): StoredClimbHoldProjection {
+  const maps = accumulateFramesToMaps(frames, board);
+  const rowsByHoldId = new Map<number, StoredClimbHoldRow>();
+
+  for (const [frameNumber, map] of maps.entries()) {
+    for (const [holdIdKey, hold] of Object.entries(map)) {
+      const holdId = Number(holdIdKey);
+      if (!Number.isSafeInteger(holdId) || holdId <= 0 || isSentinelHoldState(hold.state)) continue;
+      if (!rowsByHoldId.has(holdId)) {
+        rowsByHoldId.set(holdId, { holdId, frameNumber, holdState: hold.state });
+      }
+    }
+  }
+
+  let skippedUnknownRoleTokens = 0;
+  let skippedNonpositiveHoldIdTokens = 0;
+  for (const segment of parseFramesSegments(frames)) {
+    for (const token of tokeniseFrameDelta(segment.body)) {
+      if (!Number.isSafeInteger(token.holdId) || token.holdId <= 0) {
+        skippedNonpositiveHoldIdTokens += 1;
+      } else if (token.kind === 'set' && !HOLD_STATE_MAP[board][token.roleCode]) {
+        skippedUnknownRoleTokens += 1;
+      }
+    }
+  }
+
+  return {
+    rows: Array.from(rowsByHoldId.values()).sort((left, right) => left.holdId - right.holdId),
+    frameCount: maps.length,
+    diagnostics: { skippedUnknownRoleTokens, skippedNonpositiveHoldIdTokens },
+  };
 }
 
 /**

--- a/packages/board-constants/src/hold-states.ts
+++ b/packages/board-constants/src/hold-states.ts
@@ -411,7 +411,11 @@ export function isAuroraBoardName(board: string): board is AuroraBoardName {
  * becoming the first stored row.
  */
 export function projectAuroraFramesToStoredRows(frames: string, board: AuroraBoardName): StoredClimbHoldProjection {
-  const maps = accumulateFramesToMaps(frames, board);
+  const diagnostics: StoredClimbHoldProjection['diagnostics'] = {
+    skippedUnknownRoleTokens: 0,
+    skippedNonpositiveHoldIdTokens: 0,
+  };
+  const maps = accumulateFramesToMapsInternal(frames, board, diagnostics);
   const rowsByHoldId = new Map<number, StoredClimbHoldRow>();
 
   for (const [frameNumber, map] of maps.entries()) {
@@ -424,22 +428,10 @@ export function projectAuroraFramesToStoredRows(frames: string, board: AuroraBoa
     }
   }
 
-  let skippedUnknownRoleTokens = 0;
-  let skippedNonpositiveHoldIdTokens = 0;
-  for (const segment of parseFramesSegments(frames)) {
-    for (const token of tokeniseFrameDelta(segment.body)) {
-      if (!Number.isSafeInteger(token.holdId) || token.holdId <= 0) {
-        skippedNonpositiveHoldIdTokens += 1;
-      } else if (token.kind === 'set' && !HOLD_STATE_MAP[board][token.roleCode]) {
-        skippedUnknownRoleTokens += 1;
-      }
-    }
-  }
-
   return {
     rows: Array.from(rowsByHoldId.values()).sort((left, right) => left.holdId - right.holdId),
     frameCount: maps.length,
-    diagnostics: { skippedUnknownRoleTokens, skippedNonpositiveHoldIdTokens },
+    diagnostics,
   };
 }
 
@@ -458,6 +450,14 @@ export function projectAuroraFramesToStoredRows(frames: string, board: AuroraBoa
  * equivalent to `convertLitUpHoldsStringToMap(frames, board)[0]`.
  */
 export function accumulateFramesToMaps(frames: string, board: BoardName): LitUpHoldsMap[] {
+  return accumulateFramesToMapsInternal(frames, board);
+}
+
+function accumulateFramesToMapsInternal(
+  frames: string,
+  board: BoardName,
+  diagnostics?: StoredClimbHoldProjection['diagnostics'],
+): LitUpHoldsMap[] {
   const segments = parseFramesSegments(frames);
   const result: LitUpHoldsMap[] = [];
   let accumulator: LitUpHoldsMap = {};
@@ -465,6 +465,13 @@ export function accumulateFramesToMaps(frames: string, board: BoardName): LitUpH
     // An absolute frame restates the whole lit set, so nothing carries over.
     if (segment.absolute && index > 0) accumulator = {};
     for (const token of tokeniseFrameDelta(segment.body)) {
+      if (diagnostics) {
+        if (!Number.isSafeInteger(token.holdId) || token.holdId <= 0) {
+          diagnostics.skippedNonpositiveHoldIdTokens += 1;
+        } else if (token.kind === 'set' && !HOLD_STATE_MAP[board][token.roleCode]) {
+          diagnostics.skippedUnknownRoleTokens += 1;
+        }
+      }
       if (token.kind === 'off') {
         delete accumulator[token.holdId];
         continue;

--- a/packages/board-constants/src/hold-states.ts
+++ b/packages/board-constants/src/hold-states.ts
@@ -364,6 +364,34 @@ export type StoredClimbHoldProjection = {
   };
 };
 
+/**
+ * Reproduce the raw per-frame `p` events used by Kilter's catalog fingerprint
+ * writer before the canonical stored-row projector landed in 6e93b223c.
+ *
+ * This is deliberately not a projection: repeated holds remain repeated,
+ * frame numbers preserve each raw comma-delimited slot (including empty
+ * unquoted slots), unknown roles keep the historical `{holdId}={roleCode}`
+ * sentinel, and nonpositive IDs are not sanitised. Compatibility callers must
+ * validate the resulting fingerprint against a stored value before trusting
+ * it. Do not use `parseFramesSegments` here: its canonical parser intentionally
+ * drops empty unquoted segments and therefore renumbers later events.
+ */
+export function legacyAuroraRawFrameHoldEvents(frames: string, board: AuroraBoardName): StoredClimbHoldRow[] {
+  const events: StoredClimbHoldRow[] = [];
+  const setToken = /p(-?\d+)r(\d+)/g;
+  for (const [frameNumber, segment] of frames.split(',').entries()) {
+    setToken.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = setToken.exec(segment)) !== null) {
+      const holdId = Number(match[1]);
+      const roleCode = Number(match[2]);
+      const holdState = HOLD_STATE_MAP[board][roleCode]?.name ?? (`${holdId}=${roleCode}` as HoldState);
+      events.push({ holdId, frameNumber, holdState });
+    }
+  }
+  return events;
+}
+
 /** True for boards whose climb frames use Aurora's p/r/x grammar. */
 export function isAuroraBoardName(board: string): board is AuroraBoardName {
   return (AURORA_BOARDS as readonly string[]).includes(board);

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -100,6 +100,7 @@
     "db:dedupe-serial-boards": "tsx scripts/dedupe-serial-boards.ts",
     "db:dedupe-beta-links": "tsx scripts/dedupe-beta-links.ts",
     "db:refresh-climb-grades": "tsx scripts/refresh-climb-grades.ts",
+    "db:repair-board-climb-holds": "tsx scripts/repair-board-climb-holds.ts",
     "db:seed-social": "tsx scripts/seed-social.ts",
     "db:create-test-user": "tsx scripts/create-test-user.ts",
     "db:seed-beta-links": "tsx scripts/seed-dev-beta-links.ts",

--- a/packages/db/scripts/aurora-board-import-helpers.test.ts
+++ b/packages/db/scripts/aurora-board-import-helpers.test.ts
@@ -1,6 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { dedupeSourceClimbHolds, deriveClimbHoldsFromFrames } from './aurora-board-import-helpers.js';
+import {
+  dedupeSourceClimbHolds,
+  deriveClimbHoldsFromFrames,
+  resolveImportedClimbHolds,
+} from './aurora-board-import-helpers.js';
 
 void test('deriveClimbHoldsFromFrames maps aurora role codes', () => {
   const holds = deriveClimbHoldsFromFrames(
@@ -19,7 +23,7 @@ void test('deriveClimbHoldsFromFrames maps aurora role codes', () => {
   ]);
 });
 
-void test('deriveClimbHoldsFromFrames prefers meaningful non-foot states for duplicate holds', () => {
+void test('deriveClimbHoldsFromFrames keeps the first valid accumulated row per hold', () => {
   const holds = deriveClimbHoldsFromFrames(
     {
       uuid: 'climb-2',
@@ -29,35 +33,22 @@ void test('deriveClimbHoldsFromFrames prefers meaningful non-foot states for dup
   );
 
   assert.deepEqual(holds, [
-    { climbUuid: 'climb-2', holdId: 200, frameNumber: 1, holdState: 'HAND' },
+    { climbUuid: 'climb-2', holdId: 200, frameNumber: 0, holdState: 'FOOT' },
     { climbUuid: 'climb-2', holdId: 201, frameNumber: 0, holdState: 'HAND' },
-    { climbUuid: 'climb-2', holdId: 202, frameNumber: 1, holdState: 'OFF' },
     { climbUuid: 'climb-2', holdId: 203, frameNumber: 2, holdState: 'FINISH' },
   ]);
 });
 
-void test('deriveClimbHoldsFromFrames prefers FOOT over OFF', () => {
-  // FOOT in frame 0, OFF in frame 1 -> FOOT wins
-  const holds1 = deriveClimbHoldsFromFrames(
+void test('deriveClimbHoldsFromFrames skips nonpositive and unknown roles until a later valid state', () => {
+  const holds = deriveClimbHoldsFromFrames(
     {
       uuid: 'climb-4',
-      frames: 'p401r4,p401x1',
+      frames: 'p0r2p401r999,"p401r2',
     },
     'decoy',
   );
 
-  assert.deepEqual(holds1, [{ climbUuid: 'climb-4', holdId: 401, frameNumber: 0, holdState: 'FOOT' }]);
-
-  // OFF in frame 0, FOOT in frame 1 -> FOOT wins
-  const holds2 = deriveClimbHoldsFromFrames(
-    {
-      uuid: 'climb-5',
-      frames: 'p501x1,p501r4',
-    },
-    'decoy',
-  );
-
-  assert.deepEqual(holds2, [{ climbUuid: 'climb-5', holdId: 501, frameNumber: 1, holdState: 'FOOT' }]);
+  assert.deepEqual(holds, [{ climbUuid: 'climb-4', holdId: 401, frameNumber: 1, holdState: 'HAND' }]);
 });
 
 void test('dedupeSourceClimbHolds keeps the newest source hold row per climb and hold', () => {
@@ -88,5 +79,46 @@ void test('dedupeSourceClimbHolds keeps the newest source hold row per climb and
   assert.deepEqual(holds, [
     { climbUuid: 'climb-3', holdId: 301, frameNumber: 1, holdState: 'FINISH' },
     { climbUuid: 'climb-3', holdId: 302, frameNumber: 0, holdState: 'STARTING' },
+  ]);
+});
+
+void test('dedupeSourceClimbHolds drops invalid identities, frames, and non-lit states', () => {
+  const holds = dedupeSourceClimbHolds([
+    { climb_uuid: 'climb-6', hold_id: 0, frame_number: 0, hold_state: 'HAND' },
+    { climb_uuid: 'climb-6', hold_id: -1, frame_number: 0, hold_state: 'HAND' },
+    { climb_uuid: 'climb-6', hold_id: 601, frame_number: -1, hold_state: 'HAND' },
+    { climb_uuid: 'climb-6', hold_id: 602, frame_number: 0, hold_state: 'OFF' },
+    { climb_uuid: 'climb-6', hold_id: 603, frame_number: 0, hold_state: 'STARTING' },
+  ]);
+
+  assert.deepEqual(holds, [{ climbUuid: 'climb-6', holdId: 603, frameNumber: 0, holdState: 'STARTING' }]);
+});
+
+void test('resolveImportedClimbHolds prefers canonical frames and uses source rows only without frames', () => {
+  const holds = resolveImportedClimbHolds(
+    [
+      { uuid: 'canonical-frames', frames: 'p701r1' },
+      { uuid: 'source-fallback', frames: null },
+    ],
+    [
+      {
+        climb_uuid: 'canonical-frames',
+        hold_id: 701,
+        frame_number: 4,
+        hold_state: 'FINISH',
+      },
+      {
+        climb_uuid: 'source-fallback',
+        hold_id: 702,
+        frame_number: 0,
+        hold_state: 'HAND',
+      },
+    ],
+    'decoy',
+  );
+
+  assert.deepEqual(holds, [
+    { climbUuid: 'canonical-frames', holdId: 701, frameNumber: 0, holdState: 'STARTING' },
+    { climbUuid: 'source-fallback', holdId: 702, frameNumber: 0, holdState: 'HAND' },
   ]);
 });

--- a/packages/db/scripts/aurora-board-import-helpers.ts
+++ b/packages/db/scripts/aurora-board-import-helpers.ts
@@ -1,7 +1,9 @@
+import { projectAuroraFramesToStoredRows } from '@boardsesh/board-constants/hold-states';
+
 export const DIRECT_AURORA_BOARDS = ['decoy', 'touchstone', 'grasshopper', 'soill'] as const;
 
 export type DirectAuroraBoard = (typeof DIRECT_AURORA_BOARDS)[number];
-export type ImportedHoldState = 'STARTING' | 'HAND' | 'FINISH' | 'FOOT' | 'OFF';
+export type ImportedHoldState = 'STARTING' | 'HAND' | 'FINISH' | 'FOOT';
 
 export type SourceClimbRow = {
   uuid: string;
@@ -23,41 +25,6 @@ export type DerivedClimbHold = {
   holdState: ImportedHoldState;
 };
 
-const AURORA_HOLD_STATE_MAP: Record<DirectAuroraBoard, Record<number, ImportedHoldState>> = {
-  decoy: {
-    1: 'STARTING',
-    2: 'HAND',
-    3: 'FINISH',
-    4: 'FOOT',
-  },
-  touchstone: {
-    1: 'STARTING',
-    2: 'HAND',
-    3: 'FINISH',
-    4: 'FOOT',
-  },
-  grasshopper: {
-    1: 'STARTING',
-    2: 'HAND',
-    3: 'FINISH',
-    4: 'FOOT',
-  },
-  soill: {
-    1: 'STARTING',
-    2: 'HAND',
-    3: 'FINISH',
-    4: 'FOOT',
-  },
-};
-
-const HOLD_STATE_PRIORITY: Record<ImportedHoldState, number> = {
-  OFF: 0,
-  FOOT: 1,
-  HAND: 2,
-  FINISH: 3,
-  STARTING: 4,
-};
-
 function toNumber(value: unknown): number | null {
   if (value === null || value === undefined || value === '') {
     return null;
@@ -72,30 +39,11 @@ function asImportedHoldState(value: string | null | undefined): ImportedHoldStat
     return null;
   }
 
-  if (value === 'STARTING' || value === 'HAND' || value === 'FINISH' || value === 'FOOT' || value === 'OFF') {
+  if (value === 'STARTING' || value === 'HAND' || value === 'FINISH' || value === 'FOOT') {
     return value;
   }
 
   return null;
-}
-
-function choosePreferredHold(existing: DerivedClimbHold | undefined, candidate: DerivedClimbHold): DerivedClimbHold {
-  if (!existing) {
-    return candidate;
-  }
-
-  const existingPriority = HOLD_STATE_PRIORITY[existing.holdState];
-  const candidatePriority = HOLD_STATE_PRIORITY[candidate.holdState];
-
-  if (candidatePriority > existingPriority) {
-    return candidate;
-  }
-
-  if (candidatePriority < existingPriority) {
-    return existing;
-  }
-
-  return candidate.frameNumber < existing.frameNumber ? candidate : existing;
 }
 
 export function deriveClimbHoldsFromFrames(climb: SourceClimbRow, boardName: DirectAuroraBoard): DerivedClimbHold[] {
@@ -103,53 +51,10 @@ export function deriveClimbHoldsFromFrames(climb: SourceClimbRow, boardName: Dir
     return [];
   }
 
-  const holdMap = new Map<number, DerivedClimbHold>();
-  const frames = climb.frames.split(',');
-
-  frames.forEach((framePart, frameIndex) => {
-    for (const token of framePart.split('p')) {
-      if (!token || token === '""') {
-        continue;
-      }
-
-      const match = token.match(/^(\d+)([rx])(\d+)$/);
-      if (!match) {
-        continue;
-      }
-
-      const [, holdIdRaw, marker, stateRaw] = match;
-      const holdId = Number(holdIdRaw);
-
-      if (!Number.isFinite(holdId)) {
-        continue;
-      }
-
-      let holdState: ImportedHoldState | null = null;
-
-      if (marker === 'x') {
-        holdState = 'OFF';
-      } else {
-        holdState = AURORA_HOLD_STATE_MAP[boardName][Number(stateRaw)] ?? null;
-      }
-
-      if (!holdState) {
-        continue;
-      }
-
-      const candidate: DerivedClimbHold = {
-        climbUuid: climb.uuid,
-        holdId,
-        frameNumber: frameIndex,
-        holdState,
-      };
-
-      holdMap.set(holdId, choosePreferredHold(holdMap.get(holdId), candidate));
-    }
+  return projectAuroraFramesToStoredRows(climb.frames, boardName).rows.flatMap((row) => {
+    const holdState = asImportedHoldState(row.holdState);
+    return holdState ? [{ climbUuid: climb.uuid, ...row, holdState }] : [];
   });
-
-  return Array.from(holdMap.values()).sort(
-    (left, right) => left.holdId - right.holdId || left.frameNumber - right.frameNumber,
-  );
 }
 
 export function dedupeSourceClimbHolds(rows: SourceClimbHoldRow[]): DerivedClimbHold[] {
@@ -160,7 +65,16 @@ export function dedupeSourceClimbHolds(rows: SourceClimbHoldRow[]): DerivedClimb
       const frameNumber = toNumber(row.frame_number);
       const holdState = asImportedHoldState(row.hold_state);
 
-      if (!climbUuid || holdId === null || frameNumber === null || !holdState) {
+      if (
+        !climbUuid ||
+        holdId === null ||
+        !Number.isSafeInteger(holdId) ||
+        holdId <= 0 ||
+        frameNumber === null ||
+        !Number.isSafeInteger(frameNumber) ||
+        frameNumber < 0 ||
+        !holdState
+      ) {
         return null;
       }
 
@@ -212,4 +126,28 @@ export function dedupeSourceClimbHolds(rows: SourceClimbHoldRow[]): DerivedClimb
   }
 
   return deduped;
+}
+
+/**
+ * Resolve the rows a full-board import may materialize.
+ *
+ * `board_climbs.frames` is canonical whenever present, so a stale-but-valid
+ * source `climb_holds` table must not override it. Normalized source rows are
+ * retained only for legacy climbs whose frame blob is absent.
+ */
+export function resolveImportedClimbHolds(
+  climbs: SourceClimbRow[],
+  sourceRows: SourceClimbHoldRow[],
+  boardName: DirectAuroraBoard,
+): DerivedClimbHold[] {
+  const sourceRowsByClimb = new Map<string, DerivedClimbHold[]>();
+  for (const row of dedupeSourceClimbHolds(sourceRows)) {
+    const rows = sourceRowsByClimb.get(row.climbUuid) ?? [];
+    rows.push(row);
+    sourceRowsByClimb.set(row.climbUuid, rows);
+  }
+
+  return climbs.flatMap((climb) =>
+    climb.frames ? deriveClimbHoldsFromFrames(climb, boardName) : (sourceRowsByClimb.get(climb.uuid) ?? []),
+  );
 }

--- a/packages/db/scripts/backfill-board-climb-holds-helpers.test.ts
+++ b/packages/db/scripts/backfill-board-climb-holds-helpers.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { projectBackfillFrames } from './backfill-board-climb-holds-helpers.js';
+
+void test('backfill keeps one first-valid row per positive hold', () => {
+  assert.deepEqual(projectBackfillFrames('tension', 'p0r2p1r1p1r2,"p2r2'), [
+    { holdId: 1, frameNumber: 0, holdState: 'HAND' },
+    { holdId: 2, frameNumber: 1, holdState: 'HAND' },
+  ]);
+});
+
+void test('backfill skips unknown roles until the same hold has a valid state', () => {
+  assert.deepEqual(projectBackfillFrames('tension', 'p1r999,"p1r2'), [
+    { holdId: 1, frameNumber: 1, holdState: 'HAND' },
+  ]);
+});
+
+void test('backfill rejects non-Aurora board types', () => {
+  assert.deepEqual(projectBackfillFrames('moonboard', 'p1r42'), []);
+});

--- a/packages/db/scripts/backfill-board-climb-holds-helpers.ts
+++ b/packages/db/scripts/backfill-board-climb-holds-helpers.ts
@@ -1,0 +1,13 @@
+import { isAuroraBoardName, projectAuroraFramesToStoredRows } from '@boardsesh/board-constants/hold-states';
+
+export type BackfillHoldRow = {
+  holdId: number;
+  frameNumber: number;
+  holdState: string;
+};
+
+/** Project an Aurora frame blob to the canonical one-row-per-positive-hold shape. */
+export function projectBackfillFrames(boardType: string, frames: string): BackfillHoldRow[] {
+  if (!isAuroraBoardName(boardType)) return [];
+  return projectAuroraFramesToStoredRows(frames, boardType).rows;
+}

--- a/packages/db/scripts/backfill-board-climb-holds.test.ts
+++ b/packages/db/scripts/backfill-board-climb-holds.test.ts
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { type SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+import { runBackfillBoardClimbHolds, type BackfillQueryExecutor } from './backfill-board-climb-holds.js';
+
+type BatchRow = { uuid: string; frames: string };
+
+type RecordedQuery = {
+  sql: string;
+  params: unknown[];
+};
+
+function normalizeSql(statement: string): string {
+  return statement.replaceAll(/\s+/g, ' ').trim().toLowerCase();
+}
+
+function fakeBackfillExecutor(options: {
+  pages: BatchRow[][];
+  insertCounts?: number[];
+  remaining?: Array<{ board_type: string; remaining: string }>;
+}) {
+  const recordedQueries: RecordedQuery[] = [];
+  let nextPage = 0;
+  let nextInsertCount = 0;
+  const executor: BackfillQueryExecutor = {
+    execute(query) {
+      const compiled = new PgDialect().sqlToQuery(query as SQL);
+      const statement = normalizeSql(compiled.sql);
+      recordedQueries.push({ sql: statement, params: compiled.params.map((parameter): unknown => parameter) });
+      if (statement.includes('as eligible_count')) {
+        return Promise.resolve([{ board_type: 'tension', eligible_count: String(options.pages.flat().length) }]);
+      }
+      if (statement.includes('select bc.uuid, bc.frames')) {
+        const page = options.pages[nextPage] ?? [];
+        nextPage += 1;
+        return Promise.resolve(page);
+      }
+      if (statement.includes('insert into board_climb_holds')) {
+        const count = options.insertCounts?.[nextInsertCount] ?? 0;
+        nextInsertCount += 1;
+        return Promise.resolve({ count });
+      }
+      if (statement.includes('as remaining')) return Promise.resolve(options.remaining ?? []);
+      throw new Error(`unexpected query: ${statement}`);
+    },
+  };
+  return { executor, recordedQueries };
+}
+
+void test('keyset pagination advances past a full empty-projection page and inserts a later valid page', async () => {
+  const { executor, recordedQueries } = fakeBackfillExecutor({
+    pages: [
+      [
+        { uuid: 'a-raw', frames: 'p0r1' },
+        { uuid: 'B-RAW', frames: 'p1r999' },
+      ],
+      [{ uuid: 'c-raw', frames: 'p2r2' }],
+      [],
+    ],
+    insertCounts: [1],
+    remaining: [{ board_type: 'tension', remaining: '2' }],
+  });
+  const logs: string[] = [];
+
+  const result = await runBackfillBoardClimbHolds(executor, { batchSize: 2, dryRun: false }, (message) =>
+    logs.push(message),
+  );
+
+  assert.deepEqual(result.boards, [
+    { boardType: 'tension', totalEligible: 3, processed: 3, inserted: 1, skippedUnparseable: 2 },
+  ]);
+  assert.deepEqual(result.remaining, [{ board_type: 'tension', remaining: '2' }]);
+  assert.ok(logs.some((message) => message.includes('2 still missing (unparseable frames)')));
+
+  const pageQueries = recordedQueries.filter((query) => query.sql.includes('select bc.uuid, bc.frames'));
+  assert.equal(pageQueries.length, 3, 'a short page must still be followed by an empty fetch');
+  assert.deepEqual(
+    pageQueries.map((query) => query.params),
+    [
+      ['tension', 2],
+      ['tension', 'B-RAW', 2],
+      ['tension', 'c-raw', 2],
+    ],
+  );
+  assert.equal(pageQueries[0]?.sql.includes('bc.uuid >'), false);
+  for (const query of pageQueries.slice(1)) {
+    assert.match(query.sql, /bc\.uuid > \$2/);
+    assert.doesNotMatch(query.sql, /bc\.uuid >=|lower\(bc\.uuid\)/);
+  }
+  for (const query of pageQueries) assert.match(query.sql, /order by bc\.uuid asc/);
+
+  const insertQueries = recordedQueries.filter((query) => query.sql.includes('insert into board_climb_holds'));
+  assert.equal(insertQueries.length, 1);
+  assert.match(insertQueries[0]?.sql ?? '', /on conflict \(board_type, climb_uuid, hold_id\) do nothing/);
+  const verificationQuery = recordedQueries.find((query) => query.sql.includes('as remaining'));
+  assert.ok(verificationQuery);
+  assert.match(verificationQuery.sql, /not exists/);
+  assert.match(verificationQuery.sql, /bc\.board_type != 'moonboard'/);
+});
+
+void test('multiple full zero-projection pages advance monotonically and terminate only on the empty fetch', async () => {
+  const { executor, recordedQueries } = fakeBackfillExecutor({
+    pages: [
+      [
+        { uuid: 'a', frames: 'p0r1' },
+        { uuid: 'b', frames: 'p-1r2' },
+      ],
+      [
+        { uuid: 'c', frames: 'p2r999' },
+        { uuid: 'd', frames: 'x2' },
+      ],
+      [],
+    ],
+  });
+
+  const result = await runBackfillBoardClimbHolds(executor, { batchSize: 2, dryRun: false }, () => {});
+
+  assert.deepEqual(result.boards, [
+    { boardType: 'tension', totalEligible: 4, processed: 4, inserted: 0, skippedUnparseable: 4 },
+  ]);
+  const pageQueries = recordedQueries.filter((query) => query.sql.includes('select bc.uuid, bc.frames'));
+  assert.deepEqual(
+    pageQueries.map((query) => query.params),
+    [
+      ['tension', 2],
+      ['tension', 'b', 2],
+      ['tension', 'd', 2],
+    ],
+  );
+  assert.equal(
+    recordedQueries.some((query) => query.sql.includes('insert into board_climb_holds')),
+    false,
+  );
+});
+
+void test('a zero-count insert still advances beyond the page boundary without replaying it', async () => {
+  const { executor, recordedQueries } = fakeBackfillExecutor({
+    pages: [[{ uuid: 'boundary-row', frames: 'p2r2' }], []],
+    insertCounts: [0],
+  });
+
+  const result = await runBackfillBoardClimbHolds(executor, { batchSize: 1, dryRun: false }, () => {});
+
+  assert.deepEqual(result.boards, [
+    { boardType: 'tension', totalEligible: 1, processed: 1, inserted: 0, skippedUnparseable: 0 },
+  ]);
+  const pageQueries = recordedQueries.filter((query) => query.sql.includes('select bc.uuid, bc.frames'));
+  assert.deepEqual(
+    pageQueries.map((query) => query.params),
+    [
+      ['tension', 1],
+      ['tension', 'boundary-row', 1],
+    ],
+  );
+  assert.match(pageQueries[1]?.sql ?? '', /bc\.uuid > \$2/);
+  assert.equal(recordedQueries.filter((query) => query.sql.includes('insert into board_climb_holds')).length, 1);
+});

--- a/packages/db/scripts/backfill-board-climb-holds.ts
+++ b/packages/db/scripts/backfill-board-climb-holds.ts
@@ -17,19 +17,43 @@
  *   vp exec tsx packages/db/scripts/backfill-board-climb-holds.ts [--board kilter] [--batch-size 500] [--dry-run]
  */
 
-import { sql } from 'drizzle-orm';
+import { pathToFileURL } from 'node:url';
+import { sql, type SQLWrapper } from 'drizzle-orm';
 import { createScriptDb } from './db-connection.js';
 import { projectBackfillFrames } from './backfill-board-climb-holds-helpers.js';
 import { executeRows, executeCommandCount } from '../src/client/index.js';
 
-const args = process.argv.slice(2);
-const boardFilter = args.includes('--board') ? args[args.indexOf('--board') + 1] : undefined;
+export type BackfillQueryExecutor = {
+  execute(query: SQLWrapper | string): PromiseLike<unknown>;
+};
+
+export type BackfillOptions = {
+  boardFilter?: string;
+  batchSize: number;
+  dryRun: boolean;
+};
+
+export type BackfillBoardResult = {
+  boardType: string;
+  totalEligible: number;
+  processed: number;
+  inserted: number;
+  skippedUnparseable: number;
+};
+
+export type BackfillRunResult = {
+  boards: BackfillBoardResult[];
+  remaining: Array<{ board_type: string; remaining: string }>;
+  dryRun: boolean;
+};
+
+type BackfillLogger = (message: string) => void;
 
 // Parse --batch-size with explicit validation so `--batch-size foo` or a
 // trailing `--batch-size` doesn't silently produce NaN and stall the loop
 // (the SQL LIMIT clause would then ship with NaN, the runtime would
 // coerce, and progress reporting would be misleading either way).
-function parseBatchSize(): number {
+function parseBatchSize(args: string[]): number {
   if (!args.includes('--batch-size')) return 500;
   const raw = args[args.indexOf('--batch-size') + 1];
   const parsed = Number(raw);
@@ -39,21 +63,21 @@ function parseBatchSize(): number {
   }
   return parsed;
 }
-const batchSize = parseBatchSize();
-const dryRun = args.includes('--dry-run');
 
-async function main() {
-  const { db, close } = createScriptDb();
-
-  try {
-    // Find climbs with frames but no board_climb_holds rows, grouped by board.
-    // Restrict to single-frame climbs — multi-frame parsing is the same code
-    // path but the duplicate-gate / similar-climbs features only consume
-    // single-frame holds today, and backfilling multi-frame would silently
-    // double the row count for legitimate dynos that already have entries.
-    const boardTypes = await executeRows<{ board_type: string; eligible_count: string }>(
-      db,
-      sql`
+export async function runBackfillBoardClimbHolds(
+  executor: BackfillQueryExecutor,
+  options: BackfillOptions,
+  log: BackfillLogger = (message) => console.info(message),
+): Promise<BackfillRunResult> {
+  const { boardFilter, batchSize, dryRun } = options;
+  // Find climbs with frames but no board_climb_holds rows, grouped by board.
+  // Restrict to single-frame climbs — multi-frame parsing is the same code
+  // path but the duplicate-gate / similar-climbs features only consume
+  // single-frame holds today, and backfilling multi-frame would silently
+  // double the row count for legitimate dynos that already have entries.
+  const boardTypes = await executeRows<{ board_type: string; eligible_count: string }>(
+    executor,
+    sql`
         SELECT bc.board_type, COUNT(*) as eligible_count
         FROM board_climbs bc
         WHERE bc.frames IS NOT NULL
@@ -68,126 +92,134 @@ async function main() {
         GROUP BY bc.board_type
         ORDER BY bc.board_type
       `,
-    );
+  );
 
-    if (boardTypes.length === 0) {
-      console.info('No climbs need a holds backfill. Nothing to do.');
-      return;
-    }
+  if (boardTypes.length === 0) {
+    log('No climbs need a holds backfill. Nothing to do.');
+    return { boards: [], remaining: [], dryRun };
+  }
 
-    console.info('Climbs missing board_climb_holds rows:');
-    for (const bt of boardTypes) {
-      console.info(`  ${bt.board_type}: ${Number(bt.eligible_count).toLocaleString()}`);
-    }
-    console.info('');
+  log('Climbs missing board_climb_holds rows:');
+  for (const boardTypeRow of boardTypes) {
+    log(`  ${boardTypeRow.board_type}: ${Number(boardTypeRow.eligible_count).toLocaleString()}`);
+  }
+  log('');
 
-    if (dryRun) {
-      console.info('Dry run — no changes will be made.');
-      return;
-    }
+  if (dryRun) {
+    log('Dry run — no changes will be made.');
+    return { boards: [], remaining: [], dryRun };
+  }
 
-    for (const bt of boardTypes) {
-      if (boardFilter && bt.board_type !== boardFilter) continue;
+  const boardResults: BackfillBoardResult[] = [];
+  for (const boardTypeRow of boardTypes) {
+    if (boardFilter && boardTypeRow.board_type !== boardFilter) continue;
 
-      const totalEligible = Number(bt.eligible_count);
-      let processed = 0;
-      let inserted = 0;
-      let skippedUnparseable = 0;
+    const totalEligible = Number(boardTypeRow.eligible_count);
+    let processed = 0;
+    let inserted = 0;
+    let skippedUnparseable = 0;
+    let lastFetchedUuid: string | null = null;
 
-      console.info(`\nBackfilling ${bt.board_type} (${totalEligible.toLocaleString()} climbs)...`);
+    log(`\nBackfilling ${boardTypeRow.board_type} (${totalEligible.toLocaleString()} climbs)...`);
 
-      while (true) {
-        // The NOT EXISTS predicate doubles as the termination condition —
-        // once we insert holds for a batch, those climbs drop out of the
-        // next query naturally. No keyset cursor needed.
-        const batchRows = await executeRows<{ uuid: string; frames: string }>(
-          db,
-          sql`
+    while (true) {
+      const cursorPredicate: SQLWrapper =
+        lastFetchedUuid === null ? sql.empty() : sql`AND bc.uuid > ${lastFetchedUuid}`;
+      const batchRows: Array<{ uuid: string; frames: string }> = await executeRows<{ uuid: string; frames: string }>(
+        executor,
+        sql`
             SELECT bc.uuid, bc.frames
             FROM board_climbs bc
-            WHERE bc.board_type = ${bt.board_type}
+            WHERE bc.board_type = ${boardTypeRow.board_type}
               AND bc.frames IS NOT NULL
               AND bc.frames != ''
               AND bc.frames_count = 1
+              ${cursorPredicate}
               AND NOT EXISTS (
                 SELECT 1 FROM board_climb_holds h
                 WHERE h.board_type = bc.board_type
                   AND h.climb_uuid = bc.uuid
               )
+            ORDER BY bc.uuid ASC
             LIMIT ${batchSize}
           `,
-        );
+      );
 
-        if (batchRows.length === 0) break;
+      if (batchRows.length === 0) break;
+      lastFetchedUuid = batchRows[batchRows.length - 1]?.uuid ?? lastFetchedUuid;
 
-        const rowsToInsert: Array<{
-          board_type: string;
-          climb_uuid: string;
-          hold_id: number;
-          frame_number: number;
-          hold_state: string;
-        }> = [];
+      const rowsToInsert: Array<{
+        board_type: string;
+        climb_uuid: string;
+        hold_id: number;
+        frame_number: number;
+        hold_state: string;
+      }> = [];
 
-        for (const climb of batchRows) {
-          const parsed = projectBackfillFrames(bt.board_type, climb.frames);
-          if (parsed.length === 0) {
-            // Unparseable frames text — log and skip. These rows will stay
-            // out of the duplicate gate / similar-climbs index; without a
-            // real frame we can't do better here.
-            skippedUnparseable += 1;
-            continue;
-          }
-          for (const hold of parsed) {
-            rowsToInsert.push({
-              board_type: bt.board_type,
-              climb_uuid: climb.uuid,
-              hold_id: hold.holdId,
-              frame_number: hold.frameNumber,
-              hold_state: hold.holdState,
-            });
-          }
+      for (const climb of batchRows) {
+        const parsed = projectBackfillFrames(boardTypeRow.board_type, climb.frames);
+        if (parsed.length === 0) {
+          // Unparseable frames text — log and skip. These rows will stay
+          // out of the duplicate gate / similar-climbs index; without a
+          // real frame we can't do better here.
+          skippedUnparseable += 1;
+          continue;
         }
+        for (const hold of parsed) {
+          rowsToInsert.push({
+            board_type: boardTypeRow.board_type,
+            climb_uuid: climb.uuid,
+            hold_id: hold.holdId,
+            frame_number: hold.frameNumber,
+            hold_state: hold.holdState,
+          });
+        }
+      }
 
-        if (rowsToInsert.length > 0) {
-          // Build a single multi-row VALUES INSERT inside drizzle's sql
-          // template. Doing this in one statement (rather than per-row) keeps
-          // network round-trips proportional to batch count, not row count —
-          // a 500-climb batch with ~12 holds each is 6k row inserts that
-          // would otherwise be 6k separate round-trips.
-          const valuesFragments = rowsToInsert.map(
-            (row) =>
-              sql`(${row.board_type}, ${row.climb_uuid}, ${row.hold_id}, ${row.frame_number}, ${row.hold_state})`,
-          );
-          const insertCount = await executeCommandCount(
-            db,
-            sql`
+      if (rowsToInsert.length > 0) {
+        // Build a single multi-row VALUES INSERT inside drizzle's sql
+        // template. Doing this in one statement (rather than per-row) keeps
+        // network round-trips proportional to batch count, not row count —
+        // a 500-climb batch with ~12 holds each is 6k row inserts that
+        // would otherwise be 6k separate round-trips.
+        const valuesFragments = rowsToInsert.map(
+          (row) => sql`(${row.board_type}, ${row.climb_uuid}, ${row.hold_id}, ${row.frame_number}, ${row.hold_state})`,
+        );
+        const insertCount = await executeCommandCount(
+          executor,
+          sql`
               INSERT INTO board_climb_holds
                 (board_type, climb_uuid, hold_id, frame_number, hold_state)
               VALUES ${sql.join(valuesFragments, sql`, `)}
               ON CONFLICT (board_type, climb_uuid, hold_id) DO NOTHING
             `,
-          );
-          inserted += insertCount ?? 0;
-        }
-
-        processed += batchRows.length;
-        const pct = totalEligible > 0 ? ((processed / totalEligible) * 100).toFixed(1) : '100';
-        console.info(
-          `  ${processed.toLocaleString()} / ${totalEligible.toLocaleString()} (${pct}%) — ${inserted.toLocaleString()} hold rows inserted`,
         );
-
-        if (batchRows.length < batchSize) break;
+        inserted += insertCount ?? 0;
       }
 
-      console.info(
-        `  Done — ${processed.toLocaleString()} climbs processed, ${inserted.toLocaleString()} hold rows inserted, ${skippedUnparseable.toLocaleString()} skipped (unparseable frames).`,
+      processed += batchRows.length;
+      const pct = totalEligible > 0 ? ((processed / totalEligible) * 100).toFixed(1) : '100';
+      log(
+        `  ${processed.toLocaleString()} / ${totalEligible.toLocaleString()} (${pct}%) — ${inserted.toLocaleString()} hold rows inserted`,
       );
     }
 
-    console.info('\nVerification:');
-    const remaining = await executeRows<{ board_type: string; remaining: string }>(
-      db,
-      sql`
+    log(
+      `  Done — ${processed.toLocaleString()} climbs processed, ${inserted.toLocaleString()} hold rows inserted, ${skippedUnparseable.toLocaleString()} skipped (unparseable frames).`,
+    );
+    boardResults.push({
+      boardType: boardTypeRow.board_type,
+      totalEligible,
+      processed,
+      inserted,
+      skippedUnparseable,
+    });
+  }
+
+  log('\nVerification:');
+  const remaining = await executeRows<{ board_type: string; remaining: string }>(
+    executor,
+    sql`
         SELECT bc.board_type, COUNT(*) as remaining
         FROM board_climbs bc
         WHERE bc.frames IS NOT NULL
@@ -202,21 +234,37 @@ async function main() {
         GROUP BY bc.board_type
         ORDER BY bc.board_type
       `,
-    );
+  );
 
-    if (remaining.length === 0) {
-      console.info('  All eligible climbs have board_climb_holds rows.');
-    } else {
-      for (const r of remaining) {
-        console.info(`  ${r.board_type}: ${Number(r.remaining).toLocaleString()} still missing (unparseable frames)`);
-      }
+  if (remaining.length === 0) {
+    log('  All eligible climbs have board_climb_holds rows.');
+  } else {
+    for (const remainingRow of remaining) {
+      log(
+        `  ${remainingRow.board_type}: ${Number(remainingRow.remaining).toLocaleString()} still missing (unparseable frames)`,
+      );
     }
+  }
+  return { boards: boardResults, remaining, dryRun };
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const boardFilter = args.includes('--board') ? args[args.indexOf('--board') + 1] : undefined;
+  const batchSize = parseBatchSize(args);
+  const dryRun = args.includes('--dry-run');
+  const { db, close } = createScriptDb();
+
+  try {
+    await runBackfillBoardClimbHolds(db, { boardFilter, batchSize, dryRun });
   } finally {
     await close();
   }
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  void main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/packages/db/scripts/backfill-board-climb-holds.ts
+++ b/packages/db/scripts/backfill-board-climb-holds.ts
@@ -18,9 +18,8 @@
  */
 
 import { sql } from 'drizzle-orm';
-import { convertLitUpHoldsStringToMap, isSentinelHoldState } from '@boardsesh/board-constants/hold-states';
-import type { BoardName } from '@boardsesh/shared-schema';
 import { createScriptDb } from './db-connection.js';
+import { projectBackfillFrames } from './backfill-board-climb-holds-helpers.js';
 import { executeRows, executeCommandCount } from '../src/client/index.js';
 
 const args = process.argv.slice(2);
@@ -42,34 +41,6 @@ function parseBatchSize(): number {
 }
 const batchSize = parseBatchSize();
 const dryRun = args.includes('--dry-run');
-
-type ParsedHold = {
-  holdId: number;
-  frameNumber: number;
-  holdState: string;
-};
-
-/**
- * Mirrors `parseFramesToHoldEntries` in
- * `packages/backend/src/graphql/resolvers/climbs/climb-similarity.ts` — kept
- * inline here because `@boardsesh/db` does not depend on the backend
- * package. If you tweak the parser's behaviour, update both sites.
- */
-function parseFrames(boardType: BoardName, frames: string): ParsedHold[] {
-  if (!frames) return [];
-  const frameMap = convertLitUpHoldsStringToMap(frames, boardType);
-  const rows: ParsedHold[] = [];
-  for (const [frameIndexKey, holdsMap] of Object.entries(frameMap)) {
-    const frameNumber = Number(frameIndexKey);
-    for (const [holdIdKey, hold] of Object.entries(holdsMap)) {
-      if (isSentinelHoldState(hold.state)) continue;
-      const holdId = Number(holdIdKey);
-      if (!Number.isFinite(holdId)) continue;
-      rows.push({ frameNumber, holdId, holdState: hold.state });
-    }
-  }
-  return rows;
-}
 
 async function main() {
   const { db, close } = createScriptDb();
@@ -158,7 +129,7 @@ async function main() {
         }> = [];
 
         for (const climb of batchRows) {
-          const parsed = parseFrames(bt.board_type as BoardName, climb.frames);
+          const parsed = projectBackfillFrames(bt.board_type, climb.frames);
           if (parsed.length === 0) {
             // Unparseable frames text — log and skip. These rows will stay
             // out of the duplicate gate / similar-climbs index; without a

--- a/packages/db/scripts/import-aurora-board-unified.ts
+++ b/packages/db/scripts/import-aurora-board-unified.ts
@@ -36,9 +36,8 @@ import { normalizeQualityTo5 } from '@boardsesh/shared-schema';
 import { sanitizeFirstAscent } from '@boardsesh/sync-runtime';
 import { createScriptDb, getScriptDatabaseUrl } from './db-connection.js';
 import {
-  dedupeSourceClimbHolds,
-  deriveClimbHoldsFromFrames,
   DIRECT_AURORA_BOARDS,
+  resolveImportedClimbHolds,
   type DirectAuroraBoard,
 } from './aurora-board-import-helpers.js';
 
@@ -607,18 +606,17 @@ async function main() {
   }));
 
   const climbHoldsRows = availableTables.has('climb_holds') ? getRows('climb_holds', false) : [];
-  const importedClimbHolds =
-    climbHoldsRows.length > 0
-      ? dedupeSourceClimbHolds(
-          climbHoldsRows as Array<{
-            climb_uuid: string | null;
-            hold_id: number | null;
-            frame_number: number | null;
-            hold_state: string | null;
-            created_at?: string | null;
-          }>,
-        )
-      : sourceClimbRows.flatMap((row) => deriveClimbHoldsFromFrames(row, boardName));
+  const importedClimbHolds = resolveImportedClimbHolds(
+    sourceClimbRows,
+    climbHoldsRows as Array<{
+      climb_uuid: string | null;
+      hold_id: number | null;
+      frame_number: number | null;
+      hold_state: string | null;
+      created_at?: string | null;
+    }>,
+    boardName,
+  );
 
   if (sourceClimbRows.length > 0 && importedClimbHolds.length === 0) {
     throw new Error(`No climb holds could be imported for ${boardName}; aborting to avoid empty set-filter data`);
@@ -671,7 +669,7 @@ async function main() {
         tx,
         boardClimbHolds,
         mappedClimbHolds,
-        climbHoldsRows.length > 0 ? 'climb holds (source)' : 'climb holds (derived from frames)',
+        climbHoldsRows.length > 0 ? 'climb holds (frames with source fallback)' : 'climb holds (derived from frames)',
       );
 
       // Populate denormalized required_set_ids from climb_holds -> placements

--- a/packages/db/scripts/repair-board-climb-holds-helpers.test.ts
+++ b/packages/db/scripts/repair-board-climb-holds-helpers.test.ts
@@ -106,6 +106,34 @@ void test('manifest repairs stale multi-frame rows even when no sentinel is pres
   ]);
 });
 
+void test('manifest sorts and deduplicates missing placement blockers without hiding the mutation plan', () => {
+  const projectedRows = [
+    { holdId: 1, frameNumber: 0, holdState: 'STARTING' },
+    { holdId: 2, frameNumber: 1, holdState: 'HAND' },
+    { holdId: 3, frameNumber: 0, holdState: 'HAND' },
+  ];
+  const manifest = buildRepairManifest(
+    [
+      climb({
+        frames: 'p3r2p1r1,"p2r2p3r3',
+        rows: [],
+      }),
+    ],
+    new Set([placementKey('tension', 1, 1)]),
+  );
+
+  assert.deepEqual(manifest.entries[0]?.diagnostics.missingPlacementHoldIds, [2, 3]);
+  assert.deepEqual(manifest.entries[0]?.blockers, ['missing board placements: 2,3']);
+  assert.equal(manifest.entries[0]?.changed, true);
+  assert.deepEqual(manifest.entries[0]?.projectedRows, projectedRows);
+  assert.equal(manifest.entries[0]?.rowHashes.projected, fingerprintFromRepairRows(projectedRows));
+  assert.equal(manifest.counts.missingPlacements, 2);
+  assert.equal(manifest.counts.blockers, 1);
+  assert.equal(manifest.counts.changedMultiFrameClimbs, 1);
+  assert.equal(manifest.counts.affectedClimbs, 1);
+  assert.equal(manifest.counts.insertRows, 3);
+});
+
 void test('manifest deletes only invalid rows from a non-target single-frame climb', () => {
   const manifest = buildRepairManifest(
     [

--- a/packages/db/scripts/repair-board-climb-holds-helpers.test.ts
+++ b/packages/db/scripts/repair-board-climb-holds-helpers.test.ts
@@ -51,6 +51,44 @@ void test('strict projection rejects incomplete tokens, empty absolute frames, a
   assert.equal(countDrift.ok, false);
 });
 
+void test('strict projection accepts the delayed-start encoding our own catalog writer emits', () => {
+  // `decodeGripsClimbConcat('h10p13s2', …, 2)` writes exactly this pair, and
+  // catalog-sync stores frames_count 2 alongside it.
+  const result = strictlyProjectStoredRows('kilter', ',"p100r13', 2);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.deepEqual(result.rows, [{ holdId: 100, frameNumber: 0, holdState: 'HAND' }]);
+});
+
+void test('a delayed-start climb whose rows are already canonical plans no mutation', () => {
+  const manifest = buildRepairManifest(
+    [
+      {
+        boardType: 'kilter',
+        uuid: 'delayed-start',
+        layoutId: 1,
+        frames: ',"p100r13',
+        framesCount: 2,
+        holdFingerprint: fingerprintFromRepairRows([{ holdId: 100, frameNumber: 0, holdState: 'HAND' }]),
+        multiFrameTarget: true,
+        rows: [{ holdId: 100, frameNumber: 0, holdState: 'HAND' }],
+      },
+    ],
+    new Set([placementKey('kilter', 1, 100)]),
+  );
+
+  assert.equal(manifest.counts.blockers, 0);
+  assert.equal(manifest.counts.changedMultiFrameClimbs, 0);
+  assert.equal(manifest.counts.affectedClimbs, 0);
+  assert.equal(manifest.entries[0]?.fingerprint.classification, 'already-current');
+});
+
+void test('strict projection still blocks an empty absolute frame after frame 0', () => {
+  const trailing = strictlyProjectStoredRows('kilter', 'p1r13,', 2);
+  assert.equal(trailing.ok, false);
+  if (!trailing.ok) assert.match(trailing.errors.join('\n'), /frame 1 is an empty unquoted absolute frame/);
+});
+
 void test('strict projection blocks hold IDs that cannot enter an integer recordset', () => {
   const result = strictlyProjectStoredRows('tension', 'p2147483648r2', 1);
   assert.equal(result.ok, false);

--- a/packages/db/scripts/repair-board-climb-holds-helpers.test.ts
+++ b/packages/db/scripts/repair-board-climb-holds-helpers.test.ts
@@ -277,6 +277,25 @@ void test('an authoritative empty projection clears SHA256(empty) without touchi
   assert.equal(independentManifest.entries[0]?.fingerprint.shouldUpdate, false);
 });
 
+void test('an unchanged authoritative empty projection still clears its row-derived empty fingerprint', () => {
+  const emptyFingerprint = fingerprintFromRepairRows([]);
+  const manifest = buildRepairManifest(
+    [climb({ frames: 'x1,"', framesCount: 2, holdFingerprint: emptyFingerprint, rows: [] })],
+    placements,
+  );
+
+  assert.equal(manifest.counts.changedMultiFrameClimbs, 0);
+  assert.equal(manifest.counts.deleteRows, 0);
+  assert.equal(manifest.counts.fingerprintUpdates, 1);
+  assert.equal(manifest.counts.affectedClimbs, 1);
+  assert.deepEqual(manifest.entries[0]?.fingerprint, {
+    classification: 'row-derived',
+    old: emptyFingerprint,
+    projected: null,
+    shouldUpdate: true,
+  });
+});
+
 void test('blocked multi-frame input never plans a fingerprint-only mutation', () => {
   const invalidRows = [{ holdId: 0, frameNumber: 0, holdState: '0=999' }];
   const manifest = buildRepairManifest(

--- a/packages/db/scripts/repair-board-climb-holds-helpers.test.ts
+++ b/packages/db/scripts/repair-board-climb-holds-helpers.test.ts
@@ -1,0 +1,299 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildRepairManifest,
+  classifyFingerprint,
+  digestRepairManifest,
+  fingerprintFromLegacyFrameTokens,
+  fingerprintFromRepairRows,
+  placementKey,
+  strictlyProjectStoredRows,
+  type RepairClimbInput,
+  type RepairHoldRow,
+} from './repair-board-climb-holds-helpers.js';
+
+const placements = new Set([
+  placementKey('tension', 1, 1),
+  placementKey('tension', 1, 2),
+  placementKey('tension', 1, 3),
+]);
+
+function climb(overrides: Partial<RepairClimbInput> = {}): RepairClimbInput {
+  return {
+    boardType: 'tension',
+    uuid: 'climb-1',
+    layoutId: 1,
+    frames: 'p1r1,"p2r2',
+    framesCount: 2,
+    holdFingerprint: null,
+    multiFrameTarget: true,
+    rows: [],
+    ...overrides,
+  };
+}
+
+void test('strict projection accepts deltas, quoted hold frames, and later absolute frames', () => {
+  const result = strictlyProjectStoredRows('tension', 'p1r1,",p2r2', 3);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.deepEqual(result.rows, [
+    { holdId: 1, frameNumber: 0, holdState: 'STARTING' },
+    { holdId: 2, frameNumber: 2, holdState: 'HAND' },
+  ]);
+});
+
+void test('strict projection rejects incomplete tokens, empty absolute frames, and frame-count drift', () => {
+  const malformed = strictlyProjectStoredRows('tension', 'p1r1junk,"p2r2', 2);
+  assert.equal(malformed.ok, false);
+  const emptyAbsolute = strictlyProjectStoredRows('tension', 'p1r1,,p2r2', 3);
+  assert.equal(emptyAbsolute.ok, false);
+  const countDrift = strictlyProjectStoredRows('tension', 'p1r1,"p2r2', 3);
+  assert.equal(countDrift.ok, false);
+});
+
+void test('strict projection blocks hold IDs that cannot enter an integer recordset', () => {
+  const result = strictlyProjectStoredRows('tension', 'p2147483648r2', 1);
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.match(result.errors.join('\n'), /outside the PostgreSQL integer range/);
+});
+
+void test('strict projection rejects unsupported boards and accepts an empty valid projection for cleanup', () => {
+  assert.equal(strictlyProjectStoredRows('moonboard', 'p1r42,p2r43', 2).ok, false);
+  const emptyProjection = strictlyProjectStoredRows('tension', 'p0r1,"p1r999', 2);
+  assert.equal(emptyProjection.ok, true);
+  if (!emptyProjection.ok) return;
+  assert.deepEqual(emptyProjection.rows, []);
+  assert.equal(emptyProjection.skippedNonpositiveHoldIdTokens, 1);
+  assert.equal(emptyProjection.skippedUnknownRoleTokens, 1);
+});
+
+void test('manifest deletes stale rows when valid multi-frame input projects to no canonical holds', () => {
+  const manifest = buildRepairManifest(
+    [
+      climb({
+        frames: 'p0r1,"p1r999',
+        rows: [
+          { holdId: 0, frameNumber: 0, holdState: 'STARTING' },
+          { holdId: 1, frameNumber: 1, holdState: '1=999' },
+        ],
+      }),
+    ],
+    placements,
+  );
+  assert.equal(manifest.counts.blockers, 0);
+  assert.equal(manifest.counts.changedMultiFrameClimbs, 1);
+  assert.equal(manifest.counts.deleteRows, 2);
+  assert.equal(manifest.counts.insertRows, 0);
+  assert.deepEqual(manifest.entries[0]?.projectedRows, []);
+});
+
+void test('manifest repairs stale multi-frame rows even when no sentinel is present', () => {
+  const manifest = buildRepairManifest(
+    [
+      climb({
+        rows: [
+          { holdId: 1, frameNumber: 0, holdState: 'STARTING' },
+          { holdId: 2, frameNumber: 0, holdState: 'HAND' },
+        ],
+      }),
+    ],
+    placements,
+  );
+  assert.equal(manifest.counts.changedMultiFrameClimbs, 1);
+  assert.deepEqual(manifest.entries[0].projectedRows, [
+    { holdId: 1, frameNumber: 0, holdState: 'STARTING' },
+    { holdId: 2, frameNumber: 1, holdState: 'HAND' },
+  ]);
+});
+
+void test('manifest deletes only invalid rows from a non-target single-frame climb', () => {
+  const manifest = buildRepairManifest(
+    [
+      climb({
+        uuid: 'single',
+        frames: 'p1r1p2r2',
+        framesCount: 1,
+        multiFrameTarget: false,
+        rows: [
+          { holdId: 0, frameNumber: 0, holdState: '0=undefined' },
+          { holdId: 1, frameNumber: 0, holdState: 'STARTING' },
+        ],
+      }),
+    ],
+    placements,
+  );
+  assert.equal(manifest.counts.changedMultiFrameClimbs, 0);
+  assert.equal(manifest.counts.invalidRows, 1);
+  assert.equal(manifest.counts.deleteRows, 1);
+  assert.equal(manifest.counts.insertRows, 0);
+});
+
+void test('globally invalid cleanup includes negative hold IDs', () => {
+  const manifest = buildRepairManifest(
+    [
+      climb({
+        uuid: 'negative',
+        multiFrameTarget: false,
+        rows: [
+          { holdId: -7, frameNumber: 0, holdState: 'HAND' },
+          { holdId: 1, frameNumber: 0, holdState: 'STARTING' },
+        ],
+      }),
+    ],
+    placements,
+  );
+  assert.equal(manifest.counts.invalidRows, 1);
+  assert.equal(manifest.counts.deleteRows, 1);
+  assert.deepEqual(manifest.entries[0]?.invalidRows, [{ holdId: -7, frameNumber: 0, holdState: 'HAND' }]);
+});
+
+void test('invalid-only cleanup clears a proven row-derived fingerprint instead of hashing an empty hold set', () => {
+  const invalidRows = [{ holdId: 0, frameNumber: 0, holdState: 'HAND' }];
+  const manifest = buildRepairManifest(
+    [
+      {
+        boardType: 'kilter',
+        uuid: 'invalid-only',
+        layoutId: 1,
+        frames: 'p0r13',
+        framesCount: 1,
+        holdFingerprint: fingerprintFromRepairRows(invalidRows),
+        multiFrameTarget: false,
+        rows: invalidRows,
+      },
+    ],
+    new Set(),
+  );
+
+  assert.deepEqual(manifest.entries[0]?.fingerprint, {
+    classification: 'row-derived',
+    old: fingerprintFromRepairRows(invalidRows),
+    projected: null,
+    shouldUpdate: true,
+  });
+  assert.equal(manifest.counts.affectedClimbs, 1);
+  assert.equal(manifest.counts.deleteRows, 1);
+  assert.equal(manifest.counts.insertRows, 0);
+  assert.equal(manifest.counts.fingerprintUpdates, 1);
+});
+
+void test('malformed and frame-count mismatches are blockers and have no mutation plan', () => {
+  const manifest = buildRepairManifest(
+    [climb({ frames: 'p1r1bad,"p2r2' }), climb({ uuid: 'count', framesCount: 3 })],
+    placements,
+  );
+  assert.equal(manifest.counts.blockers, 2);
+  assert.equal(manifest.counts.affectedClimbs, 0);
+});
+
+void test('digest is stable across input and row order and changes on drift', () => {
+  const firstRows: RepairHoldRow[] = [
+    { holdId: 2, frameNumber: 1, holdState: 'HAND' },
+    { holdId: 1, frameNumber: 0, holdState: 'STARTING' },
+  ];
+  const first = buildRepairManifest(
+    [climb({ uuid: 'b', rows: firstRows }), climb({ uuid: 'a', rows: [] })],
+    placements,
+  );
+  const reordered = buildRepairManifest(
+    [climb({ uuid: 'a', rows: [] }), climb({ uuid: 'b', rows: [...firstRows].reverse() })],
+    placements,
+  );
+  assert.equal(digestRepairManifest(first), digestRepairManifest(reordered));
+  const drifted = buildRepairManifest([climb({ uuid: 'b', rows: firstRows.slice(1) })], placements);
+  assert.notEqual(digestRepairManifest(first), digestRepairManifest(drifted));
+});
+
+void test('fingerprints update only when the current value proves it came from exact old rows', () => {
+  const oldRows = [{ holdId: 1, frameNumber: 1, holdState: 'STARTING' }];
+  const projectedRows = [{ holdId: 1, frameNumber: 0, holdState: 'STARTING' }];
+  assert.equal(classifyFingerprint(null, oldRows, projectedRows), 'null');
+  assert.equal(
+    classifyFingerprint(fingerprintFromRepairRows(projectedRows), oldRows, projectedRows),
+    'already-current',
+  );
+  assert.equal(classifyFingerprint(fingerprintFromRepairRows(oldRows), oldRows, projectedRows), 'row-derived');
+  assert.equal(classifyFingerprint('independent-source-fingerprint', oldRows, projectedRows), 'independent');
+});
+
+void test('historical relight fingerprints are proven from frame tokens and migrated to projected rows', () => {
+  const frames = 'p1r1,"x1p1r2';
+  const oldRows = [{ holdId: 1, frameNumber: 0, holdState: 'STARTING' }];
+  const projectedRows = [{ holdId: 1, frameNumber: 0, holdState: 'STARTING' }];
+  const legacyFingerprint = fingerprintFromLegacyFrameTokens('tension', frames);
+  assert.equal(
+    legacyFingerprint,
+    fingerprintFromRepairRows([
+      { holdId: 1, frameNumber: 0, holdState: 'STARTING' },
+      { holdId: 1, frameNumber: 1, holdState: 'HAND' },
+    ]),
+  );
+  assert.equal(
+    classifyFingerprint(legacyFingerprint, oldRows, projectedRows, legacyFingerprint),
+    'legacy-frame-derived',
+  );
+
+  const manifest = buildRepairManifest(
+    [climb({ frames, holdFingerprint: legacyFingerprint, rows: oldRows })],
+    placements,
+  );
+  assert.equal(manifest.counts.changedMultiFrameClimbs, 0);
+  assert.equal(manifest.counts.fingerprintUpdates, 1);
+  assert.equal(manifest.counts.affectedClimbs, 1);
+  assert.deepEqual(manifest.entries[0]?.fingerprint, {
+    classification: 'legacy-frame-derived',
+    old: legacyFingerprint,
+    projected: fingerprintFromRepairRows(projectedRows),
+    shouldUpdate: true,
+  });
+});
+
+void test('an authoritative empty projection clears SHA256(empty) without touching independent fingerprints', () => {
+  const emptyFingerprint = fingerprintFromRepairRows([]);
+  const emptyManifest = buildRepairManifest(
+    [
+      climb({
+        frames: 'x1,"',
+        framesCount: 2,
+        holdFingerprint: emptyFingerprint,
+        rows: [{ holdId: 1, frameNumber: 0, holdState: 'STARTING' }],
+      }),
+    ],
+    placements,
+  );
+  assert.deepEqual(emptyManifest.entries[0]?.fingerprint, {
+    classification: 'row-derived',
+    old: emptyFingerprint,
+    projected: null,
+    shouldUpdate: true,
+  });
+  assert.equal(emptyManifest.counts.affectedClimbs, 1);
+
+  const independentManifest = buildRepairManifest(
+    [climb({ holdFingerprint: 'independent-source-fingerprint' })],
+    placements,
+  );
+  assert.equal(independentManifest.entries[0]?.fingerprint.classification, 'independent');
+  assert.equal(independentManifest.entries[0]?.fingerprint.shouldUpdate, false);
+});
+
+void test('blocked multi-frame input never plans a fingerprint-only mutation', () => {
+  const invalidRows = [{ holdId: 0, frameNumber: 0, holdState: '0=999' }];
+  const manifest = buildRepairManifest(
+    [climb({ frames: 'malformed', holdFingerprint: fingerprintFromRepairRows(invalidRows), rows: invalidRows })],
+    placements,
+  );
+  assert.ok(manifest.counts.blockers > 0);
+  assert.equal(manifest.counts.affectedClimbs, 0);
+  assert.equal(manifest.counts.fingerprintUpdates, 0);
+  assert.equal(manifest.entries[0]?.fingerprint.shouldUpdate, false);
+});
+
+void test('a logically repaired manifest is idempotent', () => {
+  const first = buildRepairManifest([climb()], placements);
+  const projectedRows = first.entries[0].projectedRows;
+  assert.ok(projectedRows);
+  const second = buildRepairManifest([climb({ rows: projectedRows })], placements);
+  assert.equal(second.counts.changedMultiFrameClimbs, 0);
+  assert.equal(second.counts.invalidRows, 0);
+});

--- a/packages/db/scripts/repair-board-climb-holds-helpers.ts
+++ b/packages/db/scripts/repair-board-climb-holds-helpers.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import {
   HOLD_STATE_MAP,
   isAuroraBoardName,
@@ -125,7 +125,7 @@ export function strictlyProjectStoredRows(
   }
 
   const parsedSegments = parseFramesSegments(frames);
-  if (!Number.isInteger(expectedFramesCount) || expectedFramesCount == null || expectedFramesCount <= 0) {
+  if (expectedFramesCount == null || !Number.isInteger(expectedFramesCount) || expectedFramesCount <= 0) {
     errors.push(`frames_count is invalid: ${String(expectedFramesCount)}`);
   } else if (parsedSegments.length !== expectedFramesCount) {
     errors.push(`frames_count mismatch: stored=${expectedFramesCount} parsed=${parsedSegments.length}`);

--- a/packages/db/scripts/repair-board-climb-holds-helpers.ts
+++ b/packages/db/scripts/repair-board-climb-holds-helpers.ts
@@ -2,7 +2,6 @@ import { createHash } from 'node:crypto';
 import {
   isAuroraBoardName,
   legacyAuroraRawFrameHoldEvents,
-  parseFramesSegments,
   projectAuroraFramesToStoredRows,
   type StoredClimbHoldRow,
 } from '@boardsesh/board-constants/hold-states';
@@ -100,7 +99,12 @@ export function strictlyProjectStoredRows(
     const quotedDelta = frameNumber > 0 && rawSegment.startsWith('"');
     const body = quotedDelta ? rawSegment.slice(1) : rawSegment;
     if (body.length === 0) {
-      if (!quotedDelta) errors.push(`frame ${frameNumber} is an empty unquoted absolute frame`);
+      // An empty frame 0 is the delayed-start encoding: the board stays dark
+      // for one pace tick before the first hold lights. Both the Grips
+      // importer (`,"p100r13` for `h10p13s2`) and the legacy Aurora catalog
+      // emit it. A mid-string empty unquoted segment is still corruption —
+      // it would decode as a full-wall blackout frame.
+      if (!quotedDelta && frameNumber > 0) errors.push(`frame ${frameNumber} is an empty unquoted absolute frame`);
       continue;
     }
     let offset = 0;
@@ -124,11 +128,14 @@ export function strictlyProjectStoredRows(
     }
   }
 
-  const parsedSegments = parseFramesSegments(frames);
+  // frames_count counts the raw comma-delimited slots, which is what Aurora
+  // and Kilter Grips both record. `parseFramesSegments` drops the leading
+  // empty slot of a delayed-start climb, so comparing against its length
+  // would flag every such climb as drift.
   if (expectedFramesCount == null || !Number.isInteger(expectedFramesCount) || expectedFramesCount <= 0) {
     errors.push(`frames_count is invalid: ${String(expectedFramesCount)}`);
-  } else if (parsedSegments.length !== expectedFramesCount) {
-    errors.push(`frames_count mismatch: stored=${expectedFramesCount} parsed=${parsedSegments.length}`);
+  } else if (rawSegments.length !== expectedFramesCount) {
+    errors.push(`frames_count mismatch: stored=${expectedFramesCount} parsed=${rawSegments.length}`);
   }
   if (errors.length > 0) return { ok: false, errors };
 

--- a/packages/db/scripts/repair-board-climb-holds-helpers.ts
+++ b/packages/db/scripts/repair-board-climb-holds-helpers.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import {
-  HOLD_STATE_MAP,
   isAuroraBoardName,
+  legacyAuroraRawFrameHoldEvents,
   parseFramesSegments,
   projectAuroraFramesToStoredRows,
   type StoredClimbHoldRow,
@@ -178,19 +178,7 @@ export function fingerprintFromRepairRows(rows: ReadonlyArray<RepairHoldRow>): s
  */
 export function fingerprintFromLegacyFrameTokens(boardType: string, frames: string | null): string | null {
   if (!isAuroraBoardName(boardType) || !frames) return null;
-
-  const legacyRows: RepairHoldRow[] = [];
-  const setToken = /p(-?\d+)r(\d+)/g;
-  for (const [frameNumber, segment] of parseFramesSegments(frames).entries()) {
-    setToken.lastIndex = 0;
-    let match: RegExpExecArray | null;
-    while ((match = setToken.exec(segment.body)) !== null) {
-      const holdId = Number(match[1]);
-      const roleCode = Number(match[2]);
-      const holdState = HOLD_STATE_MAP[boardType][roleCode]?.name ?? `${holdId}=${roleCode}`;
-      legacyRows.push({ holdId, frameNumber, holdState });
-    }
-  }
+  const legacyRows = legacyAuroraRawFrameHoldEvents(frames, boardType);
   return legacyRows.length > 0 ? fingerprintFromRepairRows(legacyRows) : null;
 }
 

--- a/packages/db/scripts/repair-board-climb-holds-helpers.ts
+++ b/packages/db/scripts/repair-board-climb-holds-helpers.ts
@@ -142,6 +142,9 @@ export function strictlyProjectStoredRows(
 }
 
 export function isInvalidStoredRow(row: RepairHoldRow): boolean {
+  // Delete only shapes proven to be corrupt. Unknown but well-formed state
+  // names may belong to a newer board definition and are preserved; readers
+  // that require parser symmetry apply their narrower supported-state filter.
   return row.holdId <= 0 || row.holdState.length === 0 || row.holdState.includes('=');
 }
 

--- a/packages/db/scripts/repair-board-climb-holds-helpers.ts
+++ b/packages/db/scripts/repair-board-climb-holds-helpers.ts
@@ -266,9 +266,16 @@ export function buildRepairManifest(
         ((fingerprintClassification === 'row-derived' &&
           (changed || invalidOnlyCleanup || hasAuthoritativeProjection)) ||
           (fingerprintClassification === 'legacy-frame-derived' && hasAuthoritativeProjection));
-      const missingPlacementHoldIds = (projectedRows ?? [])
-        .filter((row) => !existingPlacementKeys.has(placementKey(climb.boardType, climb.layoutId, row.holdId)))
-        .map((row) => row.holdId);
+      const missingPlacementHoldIds = Array.from(
+        new Set(
+          (projectedRows ?? [])
+            .filter((row) => !existingPlacementKeys.has(placementKey(climb.boardType, climb.layoutId, row.holdId)))
+            .map((row) => row.holdId),
+        ),
+      ).sort((left, right) => left - right);
+      if (missingPlacementHoldIds.length > 0) {
+        blockers.push(`missing board placements: ${missingPlacementHoldIds.join(',')}`);
+      }
 
       return {
         boardType: climb.boardType,

--- a/packages/db/scripts/repair-board-climb-holds-helpers.ts
+++ b/packages/db/scripts/repair-board-climb-holds-helpers.ts
@@ -1,0 +1,331 @@
+import { createHash } from 'crypto';
+import {
+  HOLD_STATE_MAP,
+  isAuroraBoardName,
+  parseFramesSegments,
+  projectAuroraFramesToStoredRows,
+  type StoredClimbHoldRow,
+} from '@boardsesh/board-constants/hold-states';
+
+export type RepairHoldRow = {
+  holdId: number;
+  frameNumber: number;
+  holdState: string;
+};
+
+export type RepairClimbInput = {
+  boardType: string;
+  uuid: string;
+  layoutId: number;
+  frames: string | null;
+  framesCount: number | null;
+  holdFingerprint: string | null;
+  multiFrameTarget: boolean;
+  rows: RepairHoldRow[];
+};
+
+export type FingerprintClassification =
+  | 'null'
+  | 'already-current'
+  | 'row-derived'
+  | 'legacy-frame-derived'
+  | 'independent';
+
+export type RepairManifestEntry = {
+  boardType: string;
+  uuid: string;
+  layoutId: number;
+  multiFrame: boolean;
+  oldRows: RepairHoldRow[];
+  projectedRows: RepairHoldRow[] | null;
+  invalidRows: RepairHoldRow[];
+  changed: boolean;
+  blockers: string[];
+  diagnostics: {
+    skippedUnknownRoleTokens: number;
+    skippedNonpositiveHoldIdTokens: number;
+    missingPlacementHoldIds: number[];
+  };
+  fingerprint: {
+    classification: FingerprintClassification;
+    old: string | null;
+    projected: string | null;
+    shouldUpdate: boolean;
+  };
+  rowHashes: { old: string; projected: string };
+};
+
+export type RepairManifest = {
+  version: 1;
+  counts: {
+    scannedClimbs: number;
+    scannedMultiFrameClimbs: number;
+    changedMultiFrameClimbs: number;
+    affectedClimbs: number;
+    invalidRows: number;
+    deleteRows: number;
+    insertRows: number;
+    fingerprintUpdates: number;
+    blockers: number;
+    skippedUnknownRoleTokens: number;
+    skippedNonpositiveHoldIdTokens: number;
+    missingPlacements: number;
+  };
+  entries: RepairManifestEntry[];
+};
+
+export type StrictProjectionResult =
+  | { ok: true; rows: StoredClimbHoldRow[]; skippedUnknownRoleTokens: number; skippedNonpositiveHoldIdTokens: number }
+  | { ok: false; errors: string[] };
+
+const TOKEN = /p(-?\d+)r(\d+)|x(-?\d+)/y;
+const POSTGRES_INTEGER_MAX = 2_147_483_647;
+
+/** Repair-only strict validation layered over the production frame parser. */
+export function strictlyProjectStoredRows(
+  boardType: string,
+  frames: string | null,
+  expectedFramesCount: number | null,
+): StrictProjectionResult {
+  if (!isAuroraBoardName(boardType)) {
+    return { ok: false, errors: [`unsupported board_type ${boardType}`] };
+  }
+  if (typeof frames !== 'string' || frames.length === 0) {
+    return { ok: false, errors: ['frames is empty'] };
+  }
+
+  const errors: string[] = [];
+  const rawSegments = frames.split(',');
+  for (const [frameNumber, rawSegment] of rawSegments.entries()) {
+    const quotedDelta = frameNumber > 0 && rawSegment.startsWith('"');
+    const body = quotedDelta ? rawSegment.slice(1) : rawSegment;
+    if (body.length === 0) {
+      if (!quotedDelta) errors.push(`frame ${frameNumber} is an empty unquoted absolute frame`);
+      continue;
+    }
+    let offset = 0;
+    while (offset < body.length) {
+      TOKEN.lastIndex = offset;
+      const match = TOKEN.exec(body);
+      if (!match || match.index !== offset) {
+        errors.push(`frame ${frameNumber} has malformed text at offset ${offset}`);
+        break;
+      }
+      const holdIdText = match[1] ?? match[3];
+      const roleCodeText = match[2];
+      const holdId = Number(holdIdText);
+      if (!Number.isSafeInteger(holdId) || holdId > POSTGRES_INTEGER_MAX) {
+        errors.push(`frame ${frameNumber} has a hold ID outside the PostgreSQL integer range at offset ${offset}`);
+      }
+      if (roleCodeText !== undefined && !Number.isSafeInteger(Number(roleCodeText))) {
+        errors.push(`frame ${frameNumber} has a role code outside the safe integer range at offset ${offset}`);
+      }
+      offset = TOKEN.lastIndex;
+    }
+  }
+
+  const parsedSegments = parseFramesSegments(frames);
+  if (!Number.isInteger(expectedFramesCount) || expectedFramesCount == null || expectedFramesCount <= 0) {
+    errors.push(`frames_count is invalid: ${String(expectedFramesCount)}`);
+  } else if (parsedSegments.length !== expectedFramesCount) {
+    errors.push(`frames_count mismatch: stored=${expectedFramesCount} parsed=${parsedSegments.length}`);
+  }
+  if (errors.length > 0) return { ok: false, errors };
+
+  const projection = projectAuroraFramesToStoredRows(frames, boardType);
+  return {
+    ok: true,
+    rows: projection.rows,
+    skippedUnknownRoleTokens: projection.diagnostics.skippedUnknownRoleTokens,
+    skippedNonpositiveHoldIdTokens: projection.diagnostics.skippedNonpositiveHoldIdTokens,
+  };
+}
+
+export function isInvalidStoredRow(row: RepairHoldRow): boolean {
+  return row.holdId <= 0 || row.holdState.length === 0 || row.holdState.includes('=');
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export function sortRepairRows(rows: ReadonlyArray<RepairHoldRow>): RepairHoldRow[] {
+  return [...rows].sort(
+    (left, right) =>
+      left.holdId - right.holdId ||
+      left.frameNumber - right.frameNumber ||
+      compareText(left.holdState, right.holdState),
+  );
+}
+
+export function fingerprintFromRepairRows(rows: ReadonlyArray<RepairHoldRow>): string {
+  const tuples = rows
+    .map((row) => `${row.holdId}:${row.holdState}:${row.frameNumber}`)
+    .sort()
+    .join('|');
+  return createHash('sha256').update(tuples).digest('hex');
+}
+
+/**
+ * Reproduce the fingerprint emitted by the historical Kilter Grips decoder.
+ * That decoder hashed every raw `p` event, even when a later relight reused a
+ * hold ID that the table primary key had already collapsed. Matching this
+ * digest proves the existing fingerprint came from the stored frames and is
+ * safe to migrate; arbitrary independent fingerprints remain untouched.
+ */
+export function fingerprintFromLegacyFrameTokens(boardType: string, frames: string | null): string | null {
+  if (!isAuroraBoardName(boardType) || !frames) return null;
+
+  const legacyRows: RepairHoldRow[] = [];
+  const setToken = /p(-?\d+)r(\d+)/g;
+  for (const [frameNumber, segment] of parseFramesSegments(frames).entries()) {
+    setToken.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = setToken.exec(segment.body)) !== null) {
+      const holdId = Number(match[1]);
+      const roleCode = Number(match[2]);
+      const holdState = HOLD_STATE_MAP[boardType][roleCode]?.name ?? `${holdId}=${roleCode}`;
+      legacyRows.push({ holdId, frameNumber, holdState });
+    }
+  }
+  return legacyRows.length > 0 ? fingerprintFromRepairRows(legacyRows) : null;
+}
+
+export function classifyFingerprint(
+  current: string | null,
+  oldRows: ReadonlyArray<RepairHoldRow>,
+  projectedRows: ReadonlyArray<RepairHoldRow>,
+  legacyFrameFingerprint: string | null = null,
+): FingerprintClassification {
+  if (current === null) return 'null';
+  const projected = fingerprintFromRepairRows(projectedRows);
+  // SHA256(empty) is not a valid climb identity. Treat the exact empty digest
+  // as proven empty-derived even when stale materialized rows still exist, so
+  // an authoritative empty projection can clear it to NULL.
+  if (current === projected) return projectedRows.length === 0 ? 'row-derived' : 'already-current';
+  if (current === fingerprintFromRepairRows(oldRows)) return 'row-derived';
+  return current === legacyFrameFingerprint ? 'legacy-frame-derived' : 'independent';
+}
+
+function sameRows(left: ReadonlyArray<RepairHoldRow>, right: ReadonlyArray<RepairHoldRow>): boolean {
+  return JSON.stringify(sortRepairRows(left)) === JSON.stringify(sortRepairRows(right));
+}
+
+export function placementKey(boardType: string, layoutId: number, holdId: number): string {
+  return `${boardType}\u0000${layoutId}\u0000${holdId}`;
+}
+
+export function buildRepairManifest(
+  climbs: ReadonlyArray<RepairClimbInput>,
+  existingPlacementKeys: ReadonlySet<string>,
+): RepairManifest {
+  const entries: RepairManifestEntry[] = climbs
+    .map((climb): RepairManifestEntry => {
+      const oldRows = sortRepairRows(climb.rows);
+      const invalidRows = oldRows.filter(isInvalidStoredRow);
+      const multiFrame = climb.multiFrameTarget;
+      const blockers: string[] = [];
+      let projectedRows: RepairHoldRow[] | null = null;
+      let skippedUnknownRoleTokens = 0;
+      let skippedNonpositiveHoldIdTokens = 0;
+
+      if (multiFrame) {
+        const projection = strictlyProjectStoredRows(climb.boardType, climb.frames, climb.framesCount);
+        if (!projection.ok) {
+          blockers.push(...projection.errors);
+        } else {
+          projectedRows = sortRepairRows(projection.rows);
+          skippedUnknownRoleTokens = projection.skippedUnknownRoleTokens;
+          skippedNonpositiveHoldIdTokens = projection.skippedNonpositiveHoldIdTokens;
+        }
+      }
+
+      const changed = multiFrame && projectedRows !== null && !sameRows(oldRows, projectedRows);
+      const invalidOnlyCleanup = !multiFrame && invalidRows.length > 0;
+      const rowsAfterRepair = changed
+        ? (projectedRows ?? oldRows)
+        : invalidOnlyCleanup
+          ? oldRows.filter((row) => !isInvalidStoredRow(row))
+          : oldRows;
+      const fingerprintClassification = classifyFingerprint(
+        climb.holdFingerprint,
+        oldRows,
+        rowsAfterRepair,
+        fingerprintFromLegacyFrameTokens(climb.boardType, climb.frames),
+      );
+      // The canonical backfill leaves no-hold climbs at NULL. SHA256(empty)
+      // looks like a real climb identity and can leak into dedup/grade joins.
+      const projectedFingerprint = rowsAfterRepair.length > 0 ? fingerprintFromRepairRows(rowsAfterRepair) : null;
+      const hasAuthoritativeProjection = multiFrame && projectedRows !== null;
+      const fingerprintNeedsUpdate = climb.holdFingerprint !== projectedFingerprint;
+      const shouldUpdateFingerprint =
+        fingerprintNeedsUpdate &&
+        ((fingerprintClassification === 'row-derived' &&
+          (changed || invalidOnlyCleanup || hasAuthoritativeProjection)) ||
+          (fingerprintClassification === 'legacy-frame-derived' && hasAuthoritativeProjection));
+      const missingPlacementHoldIds = (projectedRows ?? [])
+        .filter((row) => !existingPlacementKeys.has(placementKey(climb.boardType, climb.layoutId, row.holdId)))
+        .map((row) => row.holdId);
+
+      return {
+        boardType: climb.boardType,
+        uuid: climb.uuid,
+        layoutId: climb.layoutId,
+        multiFrame,
+        oldRows,
+        projectedRows,
+        invalidRows,
+        changed,
+        blockers,
+        diagnostics: {
+          skippedUnknownRoleTokens,
+          skippedNonpositiveHoldIdTokens,
+          missingPlacementHoldIds,
+        },
+        fingerprint: {
+          classification: fingerprintClassification,
+          old: climb.holdFingerprint,
+          projected: projectedFingerprint,
+          shouldUpdate: shouldUpdateFingerprint,
+        },
+        rowHashes: {
+          old: fingerprintFromRepairRows(oldRows),
+          projected: fingerprintFromRepairRows(rowsAfterRepair),
+        },
+      };
+    })
+    .sort((left, right) => compareText(left.boardType, right.boardType) || compareText(left.uuid, right.uuid));
+
+  const affectedEntries = entries.filter(
+    (entry) => entry.changed || (!entry.multiFrame && entry.invalidRows.length > 0) || entry.fingerprint.shouldUpdate,
+  );
+  return {
+    version: 1,
+    counts: {
+      scannedClimbs: entries.length,
+      scannedMultiFrameClimbs: entries.filter((entry) => entry.multiFrame).length,
+      changedMultiFrameClimbs: entries.filter((entry) => entry.changed).length,
+      affectedClimbs: affectedEntries.length,
+      invalidRows: entries.reduce((total, entry) => total + entry.invalidRows.length, 0),
+      deleteRows: entries.reduce(
+        (total, entry) =>
+          total + (entry.changed ? entry.oldRows.length : entry.multiFrame ? 0 : entry.invalidRows.length),
+        0,
+      ),
+      insertRows: entries.reduce((total, entry) => total + (entry.changed ? (entry.projectedRows?.length ?? 0) : 0), 0),
+      fingerprintUpdates: entries.filter((entry) => entry.fingerprint.shouldUpdate).length,
+      blockers: entries.reduce((total, entry) => total + entry.blockers.length, 0),
+      skippedUnknownRoleTokens: entries.reduce((total, entry) => total + entry.diagnostics.skippedUnknownRoleTokens, 0),
+      skippedNonpositiveHoldIdTokens: entries.reduce(
+        (total, entry) => total + entry.diagnostics.skippedNonpositiveHoldIdTokens,
+        0,
+      ),
+      missingPlacements: entries.reduce((total, entry) => total + entry.diagnostics.missingPlacementHoldIds.length, 0),
+    },
+    entries,
+  };
+}
+
+export function digestRepairManifest(manifest: RepairManifest): string {
+  return createHash('sha256').update(JSON.stringify(manifest)).digest('hex');
+}

--- a/packages/db/scripts/repair-board-climb-holds.test.ts
+++ b/packages/db/scripts/repair-board-climb-holds.test.ts
@@ -4,6 +4,7 @@ import { sql, type SQL } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
 import {
   applyRepairManifest,
+  fetchCandidateClimbs,
   getRepairOperatorHint,
   parseRepairArgs,
   runRepair,
@@ -179,6 +180,153 @@ void test('locked malformed/frame-count drift throws before mutation and rolls b
   );
 });
 
+void test('apply and verification batch changed identities while preserving empty projections', async () => {
+  const staleRows: RepairHoldRow[] = [{ holdId: 99, frameNumber: 0, holdState: 'HAND' }];
+  const manifest = buildRepairManifest(
+    [
+      {
+        boardType: 'tension',
+        uuid: 'batch-a',
+        layoutId: 1,
+        frames: 'p1r1,"p2r2',
+        framesCount: 2,
+        holdFingerprint: fingerprintFromRepairRows(staleRows),
+        multiFrameTarget: true,
+        rows: staleRows,
+      },
+      {
+        boardType: 'kilter',
+        uuid: 'batch-b',
+        layoutId: 1,
+        frames: 'p3r42,"p4r43',
+        framesCount: 2,
+        holdFingerprint: fingerprintFromRepairRows(staleRows),
+        multiFrameTarget: true,
+        rows: staleRows,
+      },
+      {
+        boardType: 'tension',
+        uuid: 'batch-empty',
+        layoutId: 1,
+        frames: 'p0r1,"',
+        framesCount: 2,
+        holdFingerprint: fingerprintFromRepairRows(staleRows),
+        multiFrameTarget: true,
+        rows: staleRows,
+      },
+    ],
+    new Set([
+      placementKey('tension', 1, 1),
+      placementKey('tension', 1, 2),
+      placementKey('kilter', 1, 3),
+      placementKey('kilter', 1, 4),
+    ]),
+  );
+  assert.equal(manifest.counts.changedMultiFrameClimbs, 3);
+  assert.equal(manifest.counts.fingerprintUpdates, 3);
+
+  const statements: string[] = [];
+  const projectedByIdentity = new Map(
+    manifest.entries.map((entry) => [`${entry.boardType}/${entry.uuid}`, entry.projectedRows ?? []]),
+  );
+  const executor = {
+    execute(query: unknown) {
+      const statement = renderedSql(query);
+      statements.push(statement);
+      if (statement.includes('delete from board_climb_holds stored') && statement.includes('using changed')) {
+        return Promise.resolve(Array.from({ length: manifest.counts.deleteRows }, () => ({ board_type: 'tension' })));
+      }
+      if (statement.includes('insert into board_climb_holds')) {
+        return Promise.resolve(
+          Array.from(projectedByIdentity.values())
+            .flat()
+            .map(() => ({ board_type: 'tension' })),
+        );
+      }
+      if (statement.includes('update board_climbs stored')) {
+        return Promise.resolve([
+          { board_type: 'tension', uuid: 'batch-a' },
+          { board_type: 'kilter', uuid: 'batch-b' },
+          { board_type: 'tension', uuid: 'batch-empty' },
+        ]);
+      }
+      if (statement.includes('inner join targets')) {
+        return Promise.resolve(
+          manifest.entries.flatMap((entry) =>
+            (entry.projectedRows ?? []).map((row) => ({
+              board_type: entry.boardType,
+              climb_uuid: entry.uuid,
+              hold_id: row.holdId,
+              frame_number: row.frameNumber,
+              hold_state: row.holdState,
+            })),
+          ),
+        );
+      }
+      if (statement.includes('select count(*)::integer as invalid_count')) {
+        return Promise.resolve([{ invalid_count: 0 }]);
+      }
+      throw new Error(`unexpected statement: ${statement}`);
+    },
+  };
+
+  await applyRepairManifest(executor, manifest);
+  await verifyAppliedRepair(executor, manifest);
+
+  assert.equal(statements.filter((statement) => statement.includes('using changed')).length, 1);
+  assert.equal(statements.filter((statement) => statement.includes('update board_climbs stored')).length, 1);
+  assert.equal(statements.filter((statement) => statement.includes('inner join targets')).length, 1);
+
+  const failedFingerprintExecutor = {
+    execute(query: unknown) {
+      const statement = renderedSql(query);
+      if (statement.includes('delete from board_climb_holds stored') && statement.includes('using changed')) {
+        return Promise.resolve(Array.from({ length: manifest.counts.deleteRows }, () => ({ board_type: 'tension' })));
+      }
+      if (statement.includes('insert into board_climb_holds')) {
+        return Promise.resolve(Array.from({ length: manifest.counts.insertRows }, () => ({ board_type: 'tension' })));
+      }
+      if (statement.includes('update board_climbs stored')) {
+        return Promise.resolve([
+          { board_type: 'kilter', uuid: 'batch-b' },
+          { board_type: 'tension', uuid: 'batch-a' },
+        ]);
+      }
+      throw new Error(`unexpected statement: ${statement}`);
+    },
+  };
+  await assert.rejects(
+    applyRepairManifest(failedFingerprintExecutor, manifest),
+    /fingerprint guard failed for tension\/batch-empty/,
+  );
+
+  const missingVerificationExecutor = {
+    execute(query: unknown) {
+      const statement = renderedSql(query);
+      if (statement.includes('inner join targets')) {
+        return Promise.resolve(
+          manifest.entries.flatMap((entry) =>
+            (entry.projectedRows ?? [])
+              .filter((_row, rowIndex) => entry.uuid !== 'batch-b' || rowIndex !== 0)
+              .map((row) => ({
+                board_type: entry.boardType,
+                climb_uuid: entry.uuid,
+                hold_id: row.holdId,
+                frame_number: row.frameNumber,
+                hold_state: row.holdState,
+              })),
+          ),
+        );
+      }
+      if (statement.includes('select count(*)::integer as invalid_count')) {
+        return Promise.resolve([{ invalid_count: 0 }]);
+      }
+      throw new Error(`unexpected statement: ${statement}`);
+    },
+  };
+  await assert.rejects(verifyAppliedRepair(missingVerificationExecutor, manifest), /kilter\/batch-b/);
+});
+
 void test('real Postgres apply deletes, inserts, updates fingerprints, verifies, and reruns idempotently', async (context) => {
   const databaseUrl = process.env.REPAIR_BOARD_CLIMB_HOLDS_TEST_DB_URL ?? process.env.DATABASE_URL;
   if (!databaseUrl || !isLocalDatabaseUrl(databaseUrl)) {
@@ -208,9 +356,11 @@ void test('real Postgres apply deletes, inserts, updates fingerprints, verifies,
       await transaction.execute(sql`
         CREATE TEMP TABLE board_climbs (
           board_type text NOT NULL,
-          uuid text NOT NULL,
-          hold_fingerprint text,
-          PRIMARY KEY (board_type, uuid)
+          uuid text PRIMARY KEY,
+          layout_id integer NOT NULL,
+          frames text,
+          frames_count integer,
+          hold_fingerprint text
         ) ON COMMIT DROP
       `);
       await transaction.execute(sql`
@@ -223,6 +373,41 @@ void test('real Postgres apply deletes, inserts, updates fingerprints, verifies,
           PRIMARY KEY (board_type, climb_uuid, hold_id)
         ) ON COMMIT DROP
       `);
+
+      const mismatchedUuid = 'repair-integration-mismatched-board';
+      await transaction.execute(sql`
+        INSERT INTO board_climbs (board_type, uuid, layout_id, frames, frames_count, hold_fingerprint)
+        VALUES ('tension', ${mismatchedUuid}, 1, 'p3r4', 1, 'parent-fingerprint')
+      `);
+      await transaction.execute(sql`
+        INSERT INTO board_climb_holds (board_type, climb_uuid, hold_id, frame_number, hold_state)
+        VALUES ('kilter', ${mismatchedUuid}, -7, 0, 'HAND')
+      `);
+      const mismatchedCandidates = await fetchCandidateClimbs(transaction);
+      assert.deepEqual(mismatchedCandidates, [
+        {
+          boardType: 'kilter',
+          uuid: mismatchedUuid,
+          layoutId: 1,
+          frames: 'p3r4',
+          framesCount: 1,
+          holdFingerprint: null,
+          multiFrameTarget: false,
+          rows: [{ holdId: -7, frameNumber: 0, holdState: 'HAND' }],
+        },
+      ]);
+      const mismatchedManifest = buildRepairManifest(mismatchedCandidates, new Set());
+      await applyRepairManifest(transaction, mismatchedManifest);
+      await verifyAppliedRepair(transaction, mismatchedManifest);
+      const [{ invalid_count: mismatchedRows } = { invalid_count: -1 }] = await executeRows<{
+        invalid_count: number;
+      }>(transaction, sql`SELECT COUNT(*)::integer AS invalid_count FROM board_climb_holds`);
+      assert.equal(mismatchedRows, 0);
+      const [{ hold_fingerprint: parentFingerprint }] = await executeRows<{ hold_fingerprint: string | null }>(
+        transaction,
+        sql`SELECT hold_fingerprint FROM board_climbs WHERE uuid = ${mismatchedUuid}`,
+      );
+      assert.equal(parentFingerprint, 'parent-fingerprint');
 
       const initialManifest = buildRepairManifest(
         [
@@ -254,10 +439,10 @@ void test('real Postgres apply deletes, inserts, updates fingerprints, verifies,
       assert.equal(initialManifest.counts.fingerprintUpdates, 1);
 
       await transaction.execute(sql`
-        INSERT INTO board_climbs (board_type, uuid, hold_fingerprint)
+        INSERT INTO board_climbs (board_type, uuid, layout_id, frames, frames_count, hold_fingerprint)
         VALUES
-          ('tension', ${multiUuid}, ${fingerprintFromRepairRows(staleRows)}),
-          ('tension', ${invalidUuid}, NULL)
+          ('tension', ${multiUuid}, 1, ${frames}, 2, ${fingerprintFromRepairRows(staleRows)}),
+          ('tension', ${invalidUuid}, 1, 'p3r4', 1, NULL)
       `);
       await transaction.execute(sql`
         INSERT INTO board_climb_holds (board_type, climb_uuid, hold_id, frame_number, hold_state)

--- a/packages/db/scripts/repair-board-climb-holds.test.ts
+++ b/packages/db/scripts/repair-board-climb-holds.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { AURORA_BOARDS } from '@boardsesh/shared-schema';
 import { sql, type SQL } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
 import {
@@ -20,12 +21,30 @@ import {
 import { createScriptDb, isLocalDatabaseUrl } from './db-connection.js';
 import { executeRows } from '../src/client/index.js';
 
+function compiledQuery(query: unknown) {
+  return new PgDialect().sqlToQuery(query as SQL);
+}
+
 function renderedSql(query: unknown): string {
-  return new PgDialect()
-    .sqlToQuery(query as SQL)
-    .sql.replaceAll(/\s+/g, ' ')
-    .trim()
-    .toLowerCase();
+  return compiledQuery(query).sql.replaceAll(/\s+/g, ' ').trim().toLowerCase();
+}
+
+function blockedRepairManifest() {
+  return buildRepairManifest(
+    [
+      {
+        boardType: 'tension',
+        uuid: 'blocked-missing-placement',
+        layoutId: 1,
+        frames: 'p1r1,"p2r2',
+        framesCount: 2,
+        holdFingerprint: null,
+        multiFrameTarget: true,
+        rows: [],
+      },
+    ],
+    new Set([placementKey('tension', 1, 1)]),
+  );
 }
 
 void test('dry-run issues reads only and never starts a transaction', async () => {
@@ -50,6 +69,36 @@ void test('dry-run issues reads only and never starts a transaction', async () =
   assert.equal(transactionStarted, false);
   assert.equal(executed.length, 1);
   assert.match(renderedSql(executed[0]), /invalid\.hold_id <= 0/);
+});
+
+void test('candidate query binds every Aurora board once and preserves both candidate paths', async () => {
+  let capturedQuery: unknown;
+  const executor = {
+    execute(query: unknown) {
+      capturedQuery = query;
+      return Promise.resolve([]);
+    },
+  };
+
+  assert.deepEqual(await fetchCandidateClimbs(executor), []);
+  assert.ok(capturedQuery);
+  const candidateQuery = compiledQuery(capturedQuery);
+  const boundParameters = candidateQuery.params.map((parameter): unknown => parameter);
+  assert.deepEqual(boundParameters, [...AURORA_BOARDS]);
+  assert.equal(
+    boundParameters.some((parameter) => String(parameter) === 'moonboard'),
+    false,
+  );
+
+  const statement = renderedSql(capturedQuery);
+  assert.match(statement, /where bc\.board_type in \([^)]*\) and bc\.frames_count > 1/);
+  assert.match(statement, /union all select invalid\.board_type/);
+  assert.match(statement, /from board_climb_holds invalid where invalid\.hold_id <= 0/);
+  assert.match(statement, /inner join board_climbs bc on bc\.uuid = candidate_identity\.uuid/);
+  assert.doesNotMatch(
+    statement,
+    /inner join board_climbs bc on bc\.uuid = candidate_identity\.uuid and bc\.board_type/,
+  );
 });
 
 void test('apply requires digest, exact count guards, and a maximum affected count', () => {
@@ -328,21 +377,7 @@ void test('apply and verification batch changed identities while preserving empt
 });
 
 void test('direct apply rejects a blocked manifest before executing a mutation', async () => {
-  const manifest = buildRepairManifest(
-    [
-      {
-        boardType: 'tension',
-        uuid: 'blocked-missing-placement',
-        layoutId: 1,
-        frames: 'p1r1,"p2r2',
-        framesCount: 2,
-        holdFingerprint: null,
-        multiFrameTarget: true,
-        rows: [],
-      },
-    ],
-    new Set([placementKey('tension', 1, 1)]),
-  );
+  const manifest = blockedRepairManifest();
   let executorCalls = 0;
   const executor = {
     execute() {
@@ -352,6 +387,48 @@ void test('direct apply rejects a blocked manifest before executing a mutation',
   };
 
   await assert.rejects(applyRepairManifest(executor, manifest), /refusing to apply.*1 blocker/);
+  assert.equal(executorCalls, 0);
+});
+
+void test('direct apply rejects an underreported blocker summary before executing a mutation', async () => {
+  const manifest = blockedRepairManifest();
+  const inconsistentManifest = {
+    ...manifest,
+    counts: { ...manifest.counts, blockers: manifest.counts.blockers - 1 },
+  };
+  let executorCalls = 0;
+  const executor = {
+    execute() {
+      executorCalls += 1;
+      return Promise.resolve([]);
+    },
+  };
+
+  await assert.rejects(
+    applyRepairManifest(executor, inconsistentManifest),
+    /inconsistent blocker counts: summary=0 entries=1/,
+  );
+  assert.equal(executorCalls, 0);
+});
+
+void test('direct apply rejects an overreported blocker summary before executing a mutation', async () => {
+  const manifest = blockedRepairManifest();
+  const inconsistentManifest = {
+    ...manifest,
+    counts: { ...manifest.counts, blockers: manifest.counts.blockers + 1 },
+  };
+  let executorCalls = 0;
+  const executor = {
+    execute() {
+      executorCalls += 1;
+      return Promise.resolve([]);
+    },
+  };
+
+  await assert.rejects(
+    applyRepairManifest(executor, inconsistentManifest),
+    /inconsistent blocker counts: summary=2 entries=1/,
+  );
   assert.equal(executorCalls, 0);
 });
 

--- a/packages/db/scripts/repair-board-climb-holds.test.ts
+++ b/packages/db/scripts/repair-board-climb-holds.test.ts
@@ -2,7 +2,13 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { sql, type SQL } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
-import { applyRepairManifest, parseRepairArgs, runRepair, verifyAppliedRepair } from './repair-board-climb-holds.js';
+import {
+  applyRepairManifest,
+  getRepairOperatorHint,
+  parseRepairArgs,
+  runRepair,
+  verifyAppliedRepair,
+} from './repair-board-climb-holds.js';
 import {
   buildRepairManifest,
   digestRepairManifest,
@@ -72,6 +78,20 @@ void test('apply requires digest, exact count guards, and a maximum affected cou
       reportLimit: 50,
     },
   );
+});
+
+void test('lock timeouts include actionable operator guidance without relabeling other failures', () => {
+  const lockTimeout = Object.assign(new Error('canceling statement due to lock timeout'), { code: '55P03' });
+  assert.equal(
+    getRepairOperatorHint(lockTimeout),
+    'could not acquire repair locks within 5 seconds; retry after write traffic drops',
+  );
+  assert.equal(
+    getRepairOperatorHint(new Error('wrapped query failure', { cause: lockTimeout })),
+    'could not acquire repair locks within 5 seconds; retry after write traffic drops',
+  );
+  assert.equal(getRepairOperatorHint(Object.assign(new Error('statement timeout'), { code: '57014' })), null);
+  assert.equal(getRepairOperatorHint('not a PostgreSQL error'), null);
 });
 
 void test('locked malformed/frame-count drift throws before mutation and rolls back', async () => {

--- a/packages/db/scripts/repair-board-climb-holds.test.ts
+++ b/packages/db/scripts/repair-board-climb-holds.test.ts
@@ -5,7 +5,9 @@ import { sql, type SQL } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
 import {
   applyRepairManifest,
+  DEFAULT_REPAIR_BATCH_LIMITS,
   fetchCandidateClimbs,
+  fetchExistingPlacementKeys,
   getRepairOperatorHint,
   parseRepairArgs,
   runRepair,
@@ -29,6 +31,14 @@ function renderedSql(query: unknown): string {
   return compiledQuery(query).sql.replaceAll(/\s+/g, ' ').trim().toLowerCase();
 }
 
+function jsonParameter(query: unknown): { json: string; records: Array<Record<string, unknown>> } {
+  const jsonParameter = compiledQuery(query).params.find(
+    (parameter) => typeof parameter === 'string' && parameter.startsWith('['),
+  );
+  if (typeof jsonParameter !== 'string') throw new Error('query did not contain a JSON array parameter');
+  return { json: jsonParameter, records: JSON.parse(jsonParameter) as Array<Record<string, unknown>> };
+}
+
 function blockedRepairManifest() {
   return buildRepairManifest(
     [
@@ -44,6 +54,56 @@ function blockedRepairManifest() {
       },
     ],
     new Set([placementKey('tension', 1, 1)]),
+  );
+}
+
+function twoChangedEntriesManifest(prefix: string) {
+  const staleRows: RepairHoldRow[] = [{ holdId: 99, frameNumber: 0, holdState: 'HAND' }];
+  return buildRepairManifest(
+    [
+      {
+        boardType: 'tension',
+        uuid: `${prefix}-a`,
+        layoutId: 1,
+        frames: 'p1r1,"p2r2',
+        framesCount: 2,
+        holdFingerprint: fingerprintFromRepairRows(staleRows),
+        multiFrameTarget: true,
+        rows: staleRows,
+      },
+      {
+        boardType: 'tension',
+        uuid: `${prefix}-b`,
+        layoutId: 1,
+        frames: 'p3r1,"p4r2',
+        framesCount: 2,
+        holdFingerprint: fingerprintFromRepairRows(staleRows),
+        multiFrameTarget: true,
+        rows: staleRows,
+      },
+    ],
+    new Set([
+      placementKey('tension', 1, 1),
+      placementKey('tension', 1, 2),
+      placementKey('tension', 1, 3),
+      placementKey('tension', 1, 4),
+    ]),
+  );
+}
+
+function twoInvalidOnlyEntriesManifest(prefix: string) {
+  return buildRepairManifest(
+    ['a', 'b'].map((suffix, index) => ({
+      boardType: 'moonboard',
+      uuid: `${prefix}-${suffix}`,
+      layoutId: 1,
+      frames: 'p1r1',
+      framesCount: 1,
+      holdFingerprint: null,
+      multiFrameTarget: false,
+      rows: [{ holdId: -1 - index, frameNumber: 0, holdState: 'HAND' }],
+    })),
+    new Set(),
   );
 }
 
@@ -71,7 +131,7 @@ void test('dry-run issues reads only and never starts a transaction', async () =
   assert.match(renderedSql(executed[0]), /invalid\.hold_id <= 0/);
 });
 
-void test('candidate query binds every Aurora board once and preserves both candidate paths', async () => {
+void test('candidate query scopes multi-frame projection to Aurora and preserves global invalid cleanup', async () => {
   let capturedQuery: unknown;
   const executor = {
     execute(query: unknown) {
@@ -94,6 +154,7 @@ void test('candidate query binds every Aurora board once and preserves both cand
   assert.match(statement, /where bc\.board_type in \([^)]*\) and bc\.frames_count > 1/);
   assert.match(statement, /union all select invalid\.board_type/);
   assert.match(statement, /from board_climb_holds invalid where invalid\.hold_id <= 0/);
+  assert.doesNotMatch(statement, /from board_climb_holds invalid where invalid\.board_type in/);
   assert.match(statement, /inner join board_climbs bc on bc\.uuid = candidate_identity\.uuid/);
   assert.doesNotMatch(
     statement,
@@ -229,6 +290,208 @@ void test('locked malformed/frame-count drift throws before mutation and rolls b
   );
 });
 
+void test('a late batch guard failure rejects the enclosing transaction after earlier batches ran', async () => {
+  const staleRows: RepairHoldRow[] = [{ holdId: 99, frameNumber: 0, holdState: 'HAND' }];
+  const climbs = [
+    {
+      boardType: 'tension',
+      uuid: 'late-batch-a',
+      layoutId: 1,
+      frames: 'p1r1,"p2r2',
+      framesCount: 2,
+      holdFingerprint: fingerprintFromRepairRows(staleRows),
+      multiFrameTarget: true,
+      rows: staleRows,
+    },
+    {
+      boardType: 'tension',
+      uuid: 'late-batch-b',
+      layoutId: 1,
+      frames: 'p3r1,"p4r2',
+      framesCount: 2,
+      holdFingerprint: fingerprintFromRepairRows(staleRows),
+      multiFrameTarget: true,
+      rows: staleRows,
+    },
+  ];
+  const placementKeys = new Set([
+    placementKey('tension', 1, 1),
+    placementKey('tension', 1, 2),
+    placementKey('tension', 1, 3),
+    placementKey('tension', 1, 4),
+  ]);
+  const manifest = buildRepairManifest(climbs, placementKeys);
+  const digest = digestRepairManifest(manifest);
+  const candidateRows = climbs.map((climb) => ({
+    board_type: climb.boardType,
+    uuid: climb.uuid,
+    layout_id: climb.layoutId,
+    frames: climb.frames,
+    frames_count: climb.framesCount,
+    hold_fingerprint: climb.holdFingerprint,
+    multi_frame_target: true,
+    hold_id: staleRows[0]?.holdId ?? null,
+    frame_number: staleRows[0]?.frameNumber ?? null,
+    hold_state: staleRows[0]?.holdState ?? null,
+  }));
+  let fingerprintBatch = 0;
+  let rolledBack = false;
+  let committed = false;
+  let closeCalled = false;
+  const mutationStatements: string[] = [];
+
+  const execute = (query: unknown): Promise<unknown[]> => {
+    const statement = renderedSql(query);
+    if (statement.includes('with candidate_keys as')) return Promise.resolve(candidateRows);
+    if (statement.includes('with projected as')) {
+      return Promise.resolve(jsonParameter(query).records);
+    }
+    if (statement.includes('set local') || statement.includes('lock table') || statement.includes('pg_advisory')) {
+      return Promise.resolve([]);
+    }
+    mutationStatements.push(statement);
+    const records = jsonParameter(query).records;
+    if (statement.includes('using changed')) {
+      return Promise.resolve([
+        { affected_count: records.reduce((total, record) => total + Number(record.expected_rows), 0) },
+      ]);
+    }
+    if (statement.includes('insert into board_climb_holds')) {
+      return Promise.resolve([{ affected_count: records.length }]);
+    }
+    if (statement.includes('update board_climbs stored')) {
+      fingerprintBatch += 1;
+      return Promise.resolve(
+        fingerprintBatch === 1 ? records.map((record) => ({ board_type: record.board_type, uuid: record.uuid })) : [],
+      );
+    }
+    throw new Error(`unexpected statement: ${statement}`);
+  };
+  const fakeDb = {
+    execute,
+    async transaction(callback: (executor: { execute: typeof execute }) => Promise<unknown>) {
+      try {
+        await callback({ execute });
+        committed = true;
+      } catch (error) {
+        rolledBack = true;
+        throw error;
+      }
+    },
+  };
+  const database = {
+    db: fakeDb,
+    close: async () => {
+      closeCalled = true;
+    },
+  } as unknown as Parameters<typeof runRepair>[1];
+  const args = parseRepairArgs([
+    '--apply',
+    '--expected-digest',
+    digest,
+    '--expected-scanned',
+    String(manifest.counts.scannedClimbs),
+    '--expected-changed',
+    String(manifest.counts.changedMultiFrameClimbs),
+    '--expected-invalid',
+    String(manifest.counts.invalidRows),
+    '--max-affected',
+    String(manifest.counts.affectedClimbs),
+  ]);
+
+  await assert.rejects(
+    runRepair(args, database, {
+      maxIdentityRecords: 1,
+      maxMutationRecords: 1,
+      maxParameterBytes: 1024,
+    }),
+    /fingerprint guard failed for tension\/late-batch-b/,
+  );
+  assert.equal(fingerprintBatch, 2, 'the guard fails in the second fingerprint batch');
+  assert.ok(mutationStatements.some((statement) => statement.includes('insert into board_climb_holds')));
+  assert.equal(rolledBack, true);
+  assert.equal(committed, false);
+  assert.equal(closeCalled, true);
+});
+
+void test('a later changed-delete short count identifies that identity batch', async () => {
+  const manifest = twoChangedEntriesManifest('short-delete');
+  let deleteBatch = 0;
+  const executor = {
+    execute(query: unknown) {
+      const statement = renderedSql(query);
+      assert.match(statement, /using changed/);
+      const records = jsonParameter(query).records;
+      deleteBatch += 1;
+      const expectedCount = records.reduce((total, record) => total + Number(record.expected_rows), 0);
+      return Promise.resolve([{ affected_count: deleteBatch === 1 ? expectedCount : expectedCount - 1 }]);
+    },
+  };
+
+  await assert.rejects(
+    applyRepairManifest(executor, manifest, {
+      maxIdentityRecords: 1,
+      maxMutationRecords: 5_000,
+      maxParameterBytes: 1024,
+    }),
+    /deleted changed-row count did not match.*tension\/short-delete-b.*expected=1 actual=0/,
+  );
+  assert.equal(deleteBatch, 2);
+});
+
+void test('a later insertion short count identifies the affected climb identity', async () => {
+  const manifest = twoChangedEntriesManifest('short-insert');
+  let insertBatch = 0;
+  const executor = {
+    execute(query: unknown) {
+      const statement = renderedSql(query);
+      const records = jsonParameter(query).records;
+      if (statement.includes('using changed')) {
+        return Promise.resolve([
+          { affected_count: records.reduce((total, record) => total + Number(record.expected_rows), 0) },
+        ]);
+      }
+      assert.match(statement, /insert into board_climb_holds/);
+      insertBatch += 1;
+      return Promise.resolve([{ affected_count: insertBatch === 1 ? records.length : records.length - 1 }]);
+    },
+  };
+
+  await assert.rejects(
+    applyRepairManifest(executor, manifest, {
+      maxIdentityRecords: 500,
+      maxMutationRecords: 2,
+      maxParameterBytes: 1024,
+    }),
+    /inserted row count did not match.*tension\/short-insert-b.*expected=2 actual=1/,
+  );
+  assert.equal(insertBatch, 2);
+});
+
+void test('a later global invalid-delete short count identifies its non-Aurora identity', async () => {
+  const manifest = twoInvalidOnlyEntriesManifest('short-invalid');
+  let invalidDeleteBatch = 0;
+  const executor = {
+    execute(query: unknown) {
+      const statement = renderedSql(query);
+      assert.match(statement, /using doomed/);
+      const records = jsonParameter(query).records;
+      invalidDeleteBatch += 1;
+      return Promise.resolve([{ affected_count: invalidDeleteBatch === 1 ? records.length : records.length - 1 }]);
+    },
+  };
+
+  await assert.rejects(
+    applyRepairManifest(executor, manifest, {
+      maxIdentityRecords: 500,
+      maxMutationRecords: 1,
+      maxParameterBytes: 1024,
+    }),
+    /deleted invalid row count did not match.*moonboard\/short-invalid-b.*expected=1 actual=0/,
+  );
+  assert.equal(invalidDeleteBatch, 2);
+});
+
 void test('apply and verification batch changed identities while preserving empty projections', async () => {
   const staleRows: RepairHoldRow[] = [{ holdId: 99, frameNumber: 0, holdState: 'HAND' }];
   const manifest = buildRepairManifest(
@@ -283,14 +546,10 @@ void test('apply and verification batch changed identities while preserving empt
       const statement = renderedSql(query);
       statements.push(statement);
       if (statement.includes('delete from board_climb_holds stored') && statement.includes('using changed')) {
-        return Promise.resolve(Array.from({ length: manifest.counts.deleteRows }, () => ({ board_type: 'tension' })));
+        return Promise.resolve([{ affected_count: manifest.counts.deleteRows }]);
       }
       if (statement.includes('insert into board_climb_holds')) {
-        return Promise.resolve(
-          Array.from(projectedByIdentity.values())
-            .flat()
-            .map(() => ({ board_type: 'tension' })),
-        );
+        return Promise.resolve([{ affected_count: Array.from(projectedByIdentity.values()).flat().length }]);
       }
       if (statement.includes('update board_climbs stored')) {
         return Promise.resolve([
@@ -330,10 +589,10 @@ void test('apply and verification batch changed identities while preserving empt
     execute(query: unknown) {
       const statement = renderedSql(query);
       if (statement.includes('delete from board_climb_holds stored') && statement.includes('using changed')) {
-        return Promise.resolve(Array.from({ length: manifest.counts.deleteRows }, () => ({ board_type: 'tension' })));
+        return Promise.resolve([{ affected_count: manifest.counts.deleteRows }]);
       }
       if (statement.includes('insert into board_climb_holds')) {
-        return Promise.resolve(Array.from({ length: manifest.counts.insertRows }, () => ({ board_type: 'tension' })));
+        return Promise.resolve([{ affected_count: manifest.counts.insertRows }]);
       }
       if (statement.includes('update board_climbs stored')) {
         return Promise.resolve([
@@ -374,6 +633,206 @@ void test('apply and verification batch changed identities while preserving empt
     },
   };
   await assert.rejects(verifyAppliedRepair(missingVerificationExecutor, manifest), /kilter\/batch-b/);
+});
+
+void test('placement lookup deduplicates references before record- and byte-bounded queries', async () => {
+  const climbs = [
+    {
+      boardType: 'tension',
+      uuid: 'placement-a',
+      layoutId: 1,
+      frames: 'p1r1p1r2,"p2r2',
+      framesCount: 2,
+      holdFingerprint: null,
+      multiFrameTarget: true,
+      rows: [],
+    },
+    {
+      boardType: 'tension',
+      uuid: 'placement-b',
+      layoutId: 1,
+      frames: 'p1r1,"p2r2',
+      framesCount: 2,
+      holdFingerprint: null,
+      multiFrameTarget: true,
+      rows: [],
+    },
+  ];
+  const payloads: string[] = [];
+  const executor = {
+    execute(query: unknown) {
+      const { json, records } = jsonParameter(query);
+      payloads.push(json);
+      return Promise.resolve(records);
+    },
+  };
+
+  const keys = await fetchExistingPlacementKeys(executor, climbs, {
+    maxIdentityRecords: 10,
+    maxMutationRecords: 1,
+    maxParameterBytes: 120,
+  });
+
+  assert.equal(payloads.length, 2, 'the repeated placements collapse to two unique references');
+  assert.ok(payloads.every((payload) => Buffer.byteLength(payload) <= 120));
+  assert.deepEqual(keys, new Set([placementKey('tension', 1, 1), placementKey('tension', 1, 2)]));
+});
+
+void test('apply and verification honor identity, mutation, and serialized-byte batch limits', async () => {
+  const staleRows: RepairHoldRow[] = [{ holdId: 99, frameNumber: 0, holdState: 'HAND' }];
+  const climbInputs = Array.from({ length: 5 }, (_unused, index) => ({
+    boardType: index % 2 === 0 ? 'tension' : 'kilter',
+    uuid: `bounded-${index}-${'u'.repeat(45)}`,
+    layoutId: 1,
+    frames: index === 4 ? 'p0r1,"' : `p${index + 1}r1,"p${index + 11}r2`,
+    framesCount: 2,
+    holdFingerprint: fingerprintFromRepairRows(staleRows),
+    multiFrameTarget: true,
+    rows: staleRows,
+  }));
+  const placementKeys = new Set<string>();
+  for (const [index, climb] of climbInputs.entries()) {
+    if (index === 4) continue;
+    placementKeys.add(placementKey(climb.boardType, 1, index + 1));
+    placementKeys.add(placementKey(climb.boardType, 1, index + 11));
+  }
+  const manifest = buildRepairManifest(climbInputs, placementKeys);
+  const projectedByIdentity = new Map(
+    manifest.entries.map((entry) => [`${entry.boardType}\u0000${entry.uuid}`, entry.projectedRows ?? []]),
+  );
+  const payloads: Array<{ statement: string; json: string }> = [];
+  const executor = {
+    execute(query: unknown) {
+      const statement = renderedSql(query);
+      if (statement.includes('select count(*)::integer as invalid_count')) {
+        return Promise.resolve([{ invalid_count: 0 }]);
+      }
+      const { json, records } = jsonParameter(query);
+      payloads.push({ statement, json });
+      if (statement.includes('inner join targets')) {
+        return Promise.resolve(
+          records.flatMap((record) => {
+            const boardType = String(record.board_type);
+            const climbUuid = String(record.climb_uuid);
+            return (projectedByIdentity.get(`${boardType}\u0000${climbUuid}`) ?? []).map((row) => ({
+              board_type: boardType,
+              climb_uuid: climbUuid,
+              hold_id: row.holdId,
+              frame_number: row.frameNumber,
+              hold_state: row.holdState,
+            }));
+          }),
+        );
+      }
+      if (statement.includes('using changed')) {
+        return Promise.resolve([
+          {
+            affected_count: records.reduce((total, record) => total + Number(record.expected_rows), 0),
+          },
+        ]);
+      }
+      if (statement.includes('update board_climbs stored')) {
+        return Promise.resolve(records.map((record) => ({ board_type: record.board_type, uuid: record.uuid })));
+      }
+      return Promise.resolve([{ affected_count: records.length }]);
+    },
+  };
+  const limits = { maxIdentityRecords: 2, maxMutationRecords: 3, maxParameterBytes: 400 };
+
+  await applyRepairManifest(executor, manifest, limits);
+  await verifyAppliedRepair(executor, manifest, limits);
+
+  assert.ok(payloads.length > 8, 'both record and byte limits create multiple statements');
+  assert.ok(payloads.every(({ json }) => Buffer.byteLength(json) <= limits.maxParameterBytes));
+  for (const { statement, json } of payloads) {
+    const count = (JSON.parse(json) as unknown[]).length;
+    const expectedLimit = statement.includes('insert into board_climb_holds') ? 3 : 2;
+    assert.ok(count <= expectedLimit, `${statement} exceeded its ${expectedLimit}-record batch cap`);
+  }
+  assert.ok(
+    payloads.filter(({ statement }) => statement.includes('inner join targets')).length >= 3,
+    'verification checks every identity batch, including the empty projection',
+  );
+});
+
+void test('an oversized single JSON record fails before executing SQL', async () => {
+  const staleRows: RepairHoldRow[] = [{ holdId: 99, frameNumber: 0, holdState: 'HAND' }];
+  const manifest = buildRepairManifest(
+    [
+      {
+        boardType: 'tension',
+        uuid: `oversized-${'u'.repeat(300)}`,
+        layoutId: 1,
+        frames: 'p1r1,"p2r2',
+        framesCount: 2,
+        holdFingerprint: fingerprintFromRepairRows(staleRows),
+        multiFrameTarget: true,
+        rows: staleRows,
+      },
+    ],
+    new Set([placementKey('tension', 1, 1), placementKey('tension', 1, 2)]),
+  );
+  let executorCalls = 0;
+
+  await assert.rejects(
+    applyRepairManifest(
+      {
+        execute() {
+          executorCalls += 1;
+          return Promise.resolve([]);
+        },
+      },
+      manifest,
+      { maxIdentityRecords: 500, maxMutationRecords: 5_000, maxParameterBytes: 128 },
+    ),
+    /one repair JSON record exceeds the 128-byte parameter limit/,
+  );
+  assert.equal(executorCalls, 0);
+});
+
+void test('apply and verification preserve global invalid cleanup for non-Aurora entries', async () => {
+  const manifest = buildRepairManifest(
+    [
+      {
+        boardType: 'moonboard',
+        uuid: 'unsupported',
+        layoutId: 1,
+        frames: 'p1r1',
+        framesCount: 1,
+        holdFingerprint: null,
+        multiFrameTarget: false,
+        rows: [{ holdId: -1, frameNumber: 0, holdState: 'HAND' }],
+      },
+    ],
+    new Set(),
+  );
+  const statements: string[] = [];
+  const executor = {
+    execute(query: unknown) {
+      const statement = renderedSql(query);
+      statements.push(statement);
+      if (statement.includes('delete from board_climb_holds stored')) {
+        return Promise.resolve([{ affected_count: 1 }]);
+      }
+      if (statement.includes('select count(*)::integer as invalid_count')) {
+        return Promise.resolve([{ invalid_count: 0 }]);
+      }
+      throw new Error(`unexpected statement: ${statement}`);
+    },
+  };
+
+  await applyRepairManifest(executor, manifest);
+  await verifyAppliedRepair(executor, manifest);
+  assert.equal(statements.filter((statement) => statement.includes('delete from board_climb_holds stored')).length, 1);
+  assert.doesNotMatch(
+    statements.find((statement) => statement.includes('select count(*)::integer as invalid_count')) ?? '',
+    /board_type in/,
+  );
+  assert.deepEqual(DEFAULT_REPAIR_BATCH_LIMITS, {
+    maxIdentityRecords: 500,
+    maxMutationRecords: 5_000,
+    maxParameterBytes: 1024 * 1024,
+  });
 });
 
 void test('direct apply rejects a blocked manifest before executing a mutation', async () => {
@@ -619,6 +1078,111 @@ void test('real Postgres apply deletes, inserts, updates fingerprints, verifies,
         /post-write global invalid row count is 1, expected 0/,
       );
     });
+  } finally {
+    await close();
+  }
+});
+
+void test('real Postgres rolls every earlier batch back when a later fingerprint batch fails', async (context) => {
+  const databaseUrl = process.env.REPAIR_BOARD_CLIMB_HOLDS_TEST_DB_URL ?? process.env.DATABASE_URL;
+  if (!databaseUrl || !isLocalDatabaseUrl(databaseUrl)) {
+    context.skip('set REPAIR_BOARD_CLIMB_HOLDS_TEST_DB_URL or DATABASE_URL to a local migrated Postgres');
+    return;
+  }
+
+  const { db, close } = createScriptDb(databaseUrl);
+  const staleRows: RepairHoldRow[] = [{ holdId: 99, frameNumber: 0, holdState: 'HAND' }];
+  const staleFingerprint = fingerprintFromRepairRows(staleRows);
+  const manifest = twoChangedEntriesManifest('rollback');
+  type StoredHoldSnapshot = {
+    board_type: string;
+    climb_uuid: string;
+    hold_id: number;
+    frame_number: number;
+    hold_state: string;
+  };
+  type StoredClimbSnapshot = { board_type: string; uuid: string; hold_fingerprint: string | null };
+
+  try {
+    await db.execute(sql`
+      CREATE TEMP TABLE board_climbs (
+        board_type text NOT NULL,
+        uuid text PRIMARY KEY,
+        layout_id integer NOT NULL,
+        frames text,
+        frames_count integer,
+        hold_fingerprint text
+      ) ON COMMIT PRESERVE ROWS
+    `);
+    await db.execute(sql`
+      CREATE TEMP TABLE board_climb_holds (
+        board_type text NOT NULL,
+        climb_uuid text NOT NULL,
+        hold_id integer NOT NULL,
+        frame_number integer NOT NULL,
+        hold_state text NOT NULL,
+        PRIMARY KEY (board_type, climb_uuid, hold_id)
+      ) ON COMMIT PRESERVE ROWS
+    `);
+    await db.execute(sql`
+      INSERT INTO board_climbs (board_type, uuid, layout_id, frames, frames_count, hold_fingerprint)
+      VALUES
+        ('tension', 'rollback-a', 1, 'p1r1,"p2r2', 2, ${staleFingerprint}),
+        ('tension', 'rollback-b', 1, 'p3r1,"p4r2', 2, 'forced-late-guard-mismatch')
+    `);
+    await db.execute(sql`
+      INSERT INTO board_climb_holds (board_type, climb_uuid, hold_id, frame_number, hold_state)
+      VALUES
+        ('tension', 'rollback-a', 99, 0, 'HAND'),
+        ('tension', 'rollback-b', 99, 0, 'HAND')
+    `);
+
+    const holdsBefore = await executeRows<StoredHoldSnapshot>(
+      db,
+      sql`
+        SELECT board_type, climb_uuid, hold_id, frame_number, hold_state
+        FROM board_climb_holds
+        ORDER BY board_type, climb_uuid, hold_id
+      `,
+    );
+    const climbsBefore = await executeRows<StoredClimbSnapshot>(
+      db,
+      sql`
+        SELECT board_type, uuid, hold_fingerprint
+        FROM board_climbs
+        ORDER BY board_type, uuid
+      `,
+    );
+
+    await assert.rejects(
+      db.transaction(async (transaction) => {
+        await applyRepairManifest(transaction, manifest, {
+          maxIdentityRecords: 1,
+          maxMutationRecords: 1,
+          maxParameterBytes: 1024,
+        });
+      }),
+      /fingerprint guard failed for tension\/rollback-b/,
+    );
+
+    const holdsAfter = await executeRows<StoredHoldSnapshot>(
+      db,
+      sql`
+        SELECT board_type, climb_uuid, hold_id, frame_number, hold_state
+        FROM board_climb_holds
+        ORDER BY board_type, climb_uuid, hold_id
+      `,
+    );
+    const climbsAfter = await executeRows<StoredClimbSnapshot>(
+      db,
+      sql`
+        SELECT board_type, uuid, hold_fingerprint
+        FROM board_climbs
+        ORDER BY board_type, uuid
+      `,
+    );
+    assert.deepEqual(Array.from(holdsAfter), Array.from(holdsBefore));
+    assert.deepEqual(Array.from(climbsAfter), Array.from(climbsBefore));
   } finally {
     await close();
   }

--- a/packages/db/scripts/repair-board-climb-holds.test.ts
+++ b/packages/db/scripts/repair-board-climb-holds.test.ts
@@ -327,6 +327,34 @@ void test('apply and verification batch changed identities while preserving empt
   await assert.rejects(verifyAppliedRepair(missingVerificationExecutor, manifest), /kilter\/batch-b/);
 });
 
+void test('direct apply rejects a blocked manifest before executing a mutation', async () => {
+  const manifest = buildRepairManifest(
+    [
+      {
+        boardType: 'tension',
+        uuid: 'blocked-missing-placement',
+        layoutId: 1,
+        frames: 'p1r1,"p2r2',
+        framesCount: 2,
+        holdFingerprint: null,
+        multiFrameTarget: true,
+        rows: [],
+      },
+    ],
+    new Set([placementKey('tension', 1, 1)]),
+  );
+  let executorCalls = 0;
+  const executor = {
+    execute() {
+      executorCalls += 1;
+      return Promise.resolve([]);
+    },
+  };
+
+  await assert.rejects(applyRepairManifest(executor, manifest), /refusing to apply.*1 blocker/);
+  assert.equal(executorCalls, 0);
+});
+
 void test('real Postgres apply deletes, inserts, updates fingerprints, verifies, and reruns idempotently', async (context) => {
   const databaseUrl = process.env.REPAIR_BOARD_CLIMB_HOLDS_TEST_DB_URL ?? process.env.DATABASE_URL;
   if (!databaseUrl || !isLocalDatabaseUrl(databaseUrl)) {

--- a/packages/db/scripts/repair-board-climb-holds.test.ts
+++ b/packages/db/scripts/repair-board-climb-holds.test.ts
@@ -1,0 +1,307 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { sql, type SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { applyRepairManifest, parseRepairArgs, runRepair, verifyAppliedRepair } from './repair-board-climb-holds.js';
+import {
+  buildRepairManifest,
+  digestRepairManifest,
+  fingerprintFromRepairRows,
+  placementKey,
+  type RepairHoldRow,
+} from './repair-board-climb-holds-helpers.js';
+import { createScriptDb, isLocalDatabaseUrl } from './db-connection.js';
+import { executeRows } from '../src/client/index.js';
+
+function renderedSql(query: unknown): string {
+  return new PgDialect()
+    .sqlToQuery(query as SQL)
+    .sql.replaceAll(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+void test('dry-run issues reads only and never starts a transaction', async () => {
+  const executed: unknown[] = [];
+  let transactionStarted = false;
+  const database = {
+    db: {
+      execute(query: unknown) {
+        executed.push(query);
+        return Promise.resolve([]);
+      },
+      transaction() {
+        transactionStarted = true;
+        throw new Error('dry-run must not start a transaction');
+      },
+    },
+    close: async () => undefined,
+  } as unknown as Parameters<typeof runRepair>[1];
+
+  const result = await runRepair(parseRepairArgs([]), database);
+  assert.equal(result.applied, false);
+  assert.equal(transactionStarted, false);
+  assert.equal(executed.length, 1);
+  assert.match(renderedSql(executed[0]), /invalid\.hold_id <= 0/);
+});
+
+void test('apply requires digest, exact count guards, and a maximum affected count', () => {
+  assert.throws(() => parseRepairArgs(['--apply']), /requires --expected-digest/);
+  assert.deepEqual(
+    parseRepairArgs([
+      '--apply',
+      '--expected-digest',
+      'abc',
+      '--expected-scanned',
+      '10',
+      '--expected-changed',
+      '2',
+      '--expected-invalid',
+      '1',
+      '--max-affected',
+      '3',
+    ]),
+    {
+      apply: true,
+      help: false,
+      expectedDigest: 'abc',
+      expectedScanned: 10,
+      expectedChanged: 2,
+      expectedInvalid: 1,
+      maxAffected: 3,
+      reportLimit: 50,
+    },
+  );
+});
+
+void test('locked malformed/frame-count drift throws before mutation and rolls back', async () => {
+  const emptyDigest = digestRepairManifest(buildRepairManifest([], new Set()));
+  let executeCount = 0;
+  let rolledBack = false;
+  let committed = false;
+  let transactionOptions: unknown;
+  const transactionStatements: string[] = [];
+  const fakeDb = {
+    execute(_query: unknown) {
+      executeCount += 1;
+      if (executeCount === 7) {
+        return Promise.resolve([
+          {
+            board_type: 'tension',
+            uuid: 'drifted',
+            layout_id: 1,
+            frames: 'p1r1junk,"p2r2',
+            frames_count: 3,
+            hold_fingerprint: null,
+            multi_frame_target: true,
+            hold_id: null,
+            frame_number: null,
+            hold_state: null,
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    },
+    async transaction(callback: (executor: unknown) => Promise<unknown>, options: unknown) {
+      transactionOptions = options;
+      const transactionExecutor = {
+        execute(query: unknown) {
+          transactionStatements.push(renderedSql(query));
+          return fakeDb.execute(query);
+        },
+      };
+      try {
+        await callback(transactionExecutor);
+        committed = true;
+      } catch (error) {
+        rolledBack = true;
+        throw error;
+      }
+    },
+  };
+  const database = {
+    db: fakeDb,
+    close: async () => undefined,
+  } as unknown as Parameters<typeof runRepair>[1];
+  const args = parseRepairArgs([
+    '--apply',
+    '--expected-digest',
+    emptyDigest,
+    '--expected-scanned',
+    '0',
+    '--expected-changed',
+    '0',
+    '--expected-invalid',
+    '0',
+    '--max-affected',
+    '0',
+  ]);
+
+  await assert.rejects(runRepair(args, database), /repair guard failed/);
+  assert.equal(rolledBack, true);
+  assert.equal(committed, false);
+  assert.deepEqual(transactionOptions, { isolationLevel: 'repeatable read' });
+  assert.deepEqual(transactionStatements.slice(0, 5), [
+    "set local lock_timeout = '5s'",
+    "set local statement_timeout = '120s'",
+    'lock table board_climbs in share row exclusive mode',
+    'lock table board_climb_holds in share row exclusive mode',
+    "select pg_advisory_xact_lock(hashtext('boardsesh:repair-board-climb-holds:v1'))",
+  ]);
+  assert.equal(executeCount, 7, 'no mutation or post-write query should run after locked drift is detected');
+});
+
+void test('real Postgres apply deletes, inserts, updates fingerprints, verifies, and reruns idempotently', async (context) => {
+  const databaseUrl = process.env.REPAIR_BOARD_CLIMB_HOLDS_TEST_DB_URL ?? process.env.DATABASE_URL;
+  if (!databaseUrl || !isLocalDatabaseUrl(databaseUrl)) {
+    context.skip('set REPAIR_BOARD_CLIMB_HOLDS_TEST_DB_URL or DATABASE_URL to a local migrated Postgres');
+    return;
+  }
+
+  const { db, close } = createScriptDb(databaseUrl);
+  const multiUuid = 'repair-integration-multi';
+  const invalidUuid = 'repair-integration-invalid';
+  const frames = 'p1r1,"p2r2';
+  const staleRows: RepairHoldRow[] = [{ holdId: 9, frameNumber: 0, holdState: 'HAND' }];
+  const invalidRows: RepairHoldRow[] = [
+    { holdId: -7, frameNumber: 0, holdState: 'HAND' },
+    { holdId: 3, frameNumber: 0, holdState: 'FOOT' },
+  ];
+  const placementKeys = new Set([
+    placementKey('tension', 1, 1),
+    placementKey('tension', 1, 2),
+    placementKey('tension', 1, 3),
+  ]);
+
+  try {
+    await db.transaction(async (transaction) => {
+      // Session-local tables shadow the real schema, so this exercises the
+      // production SQL without touching persistent development data.
+      await transaction.execute(sql`
+        CREATE TEMP TABLE board_climbs (
+          board_type text NOT NULL,
+          uuid text NOT NULL,
+          hold_fingerprint text,
+          PRIMARY KEY (board_type, uuid)
+        ) ON COMMIT DROP
+      `);
+      await transaction.execute(sql`
+        CREATE TEMP TABLE board_climb_holds (
+          board_type text NOT NULL,
+          climb_uuid text NOT NULL,
+          hold_id integer NOT NULL,
+          frame_number integer NOT NULL,
+          hold_state text NOT NULL,
+          PRIMARY KEY (board_type, climb_uuid, hold_id)
+        ) ON COMMIT DROP
+      `);
+
+      const initialManifest = buildRepairManifest(
+        [
+          {
+            boardType: 'tension',
+            uuid: multiUuid,
+            layoutId: 1,
+            frames,
+            framesCount: 2,
+            holdFingerprint: fingerprintFromRepairRows(staleRows),
+            multiFrameTarget: true,
+            rows: staleRows,
+          },
+          {
+            boardType: 'tension',
+            uuid: invalidUuid,
+            layoutId: 1,
+            frames: 'p3r4',
+            framesCount: 1,
+            holdFingerprint: null,
+            multiFrameTarget: false,
+            rows: invalidRows,
+          },
+        ],
+        placementKeys,
+      );
+      assert.equal(initialManifest.counts.changedMultiFrameClimbs, 1);
+      assert.equal(initialManifest.counts.invalidRows, 1);
+      assert.equal(initialManifest.counts.fingerprintUpdates, 1);
+
+      await transaction.execute(sql`
+        INSERT INTO board_climbs (board_type, uuid, hold_fingerprint)
+        VALUES
+          ('tension', ${multiUuid}, ${fingerprintFromRepairRows(staleRows)}),
+          ('tension', ${invalidUuid}, NULL)
+      `);
+      await transaction.execute(sql`
+        INSERT INTO board_climb_holds (board_type, climb_uuid, hold_id, frame_number, hold_state)
+        VALUES
+          ('tension', ${multiUuid}, 9, 0, 'HAND'),
+          ('tension', ${invalidUuid}, -7, 0, 'HAND'),
+          ('tension', ${invalidUuid}, 3, 0, 'FOOT')
+      `);
+
+      await applyRepairManifest(transaction, initialManifest);
+      await verifyAppliedRepair(transaction, initialManifest);
+
+      const materializedRows = await executeRows<{
+        climb_uuid: string;
+        hold_id: number;
+        frame_number: number;
+        hold_state: string;
+      }>(
+        transaction,
+        sql`
+          SELECT climb_uuid, hold_id, frame_number, hold_state
+          FROM board_climb_holds
+          ORDER BY climb_uuid, hold_id
+        `,
+      );
+      assert.deepEqual(Array.from(materializedRows), [
+        { climb_uuid: invalidUuid, hold_id: 3, frame_number: 0, hold_state: 'FOOT' },
+        { climb_uuid: multiUuid, hold_id: 1, frame_number: 0, hold_state: 'STARTING' },
+        { climb_uuid: multiUuid, hold_id: 2, frame_number: 1, hold_state: 'HAND' },
+      ]);
+
+      const [{ hold_fingerprint: repairedFingerprint }] = await executeRows<{ hold_fingerprint: string | null }>(
+        transaction,
+        sql`SELECT hold_fingerprint FROM board_climbs WHERE board_type = 'tension' AND uuid = ${multiUuid}`,
+      );
+      const repairedRows = materializedRows
+        .filter((row) => row.climb_uuid === multiUuid)
+        .map((row) => ({ holdId: row.hold_id, frameNumber: row.frame_number, holdState: row.hold_state }));
+      assert.equal(repairedFingerprint, fingerprintFromRepairRows(repairedRows));
+
+      const secondManifest = buildRepairManifest(
+        [
+          {
+            boardType: 'tension',
+            uuid: multiUuid,
+            layoutId: 1,
+            frames,
+            framesCount: 2,
+            holdFingerprint: repairedFingerprint,
+            multiFrameTarget: true,
+            rows: repairedRows,
+          },
+        ],
+        placementKeys,
+      );
+      assert.equal(secondManifest.counts.affectedClimbs, 0);
+      assert.equal(secondManifest.counts.deleteRows, 0);
+      assert.equal(secondManifest.counts.insertRows, 0);
+      assert.equal(secondManifest.counts.fingerprintUpdates, 0);
+      await applyRepairManifest(transaction, secondManifest);
+      await verifyAppliedRepair(transaction, secondManifest);
+
+      await transaction.execute(sql`
+        INSERT INTO board_climb_holds (board_type, climb_uuid, hold_id, frame_number, hold_state)
+        VALUES ('tension', ${invalidUuid}, -8, 0, 'HAND')
+      `);
+      await assert.rejects(
+        verifyAppliedRepair(transaction, secondManifest),
+        /post-write global invalid row count is 1, expected 0/,
+      );
+    });
+  } finally {
+    await close();
+  }
+});

--- a/packages/db/scripts/repair-board-climb-holds.test.ts
+++ b/packages/db/scripts/repair-board-climb-holds.test.ts
@@ -76,15 +76,18 @@ void test('apply requires digest, exact count guards, and a maximum affected cou
 
 void test('locked malformed/frame-count drift throws before mutation and rolls back', async () => {
   const emptyDigest = digestRepairManifest(buildRepairManifest([], new Set()));
-  let executeCount = 0;
+  let candidateQueryCount = 0;
   let rolledBack = false;
   let committed = false;
   let transactionOptions: unknown;
   const transactionStatements: string[] = [];
   const fakeDb = {
-    execute(_query: unknown) {
-      executeCount += 1;
-      if (executeCount === 7) {
+    execute(query: unknown) {
+      const statement = renderedSql(query);
+      if (statement.includes('with candidate_keys as')) {
+        candidateQueryCount += 1;
+      }
+      if (statement.includes('with candidate_keys as') && candidateQueryCount === 2) {
         return Promise.resolve([
           {
             board_type: 'tension',
@@ -148,7 +151,12 @@ void test('locked malformed/frame-count drift throws before mutation and rolls b
     'lock table board_climb_holds in share row exclusive mode',
     "select pg_advisory_xact_lock(hashtext('boardsesh:repair-board-climb-holds:v1'))",
   ]);
-  assert.equal(executeCount, 7, 'no mutation or post-write query should run after locked drift is detected');
+  assert.equal(candidateQueryCount, 2, 'the locked manifest must be rebuilt after the dry-run manifest');
+  assert.equal(
+    transactionStatements.some((statement) => /delete from|insert into|update board_climbs/.test(statement)),
+    false,
+    'no mutation should run after locked drift is detected',
+  );
 });
 
 void test('real Postgres apply deletes, inserts, updates fingerprints, verifies, and reruns idempotently', async (context) => {

--- a/packages/db/scripts/repair-board-climb-holds.ts
+++ b/packages/db/scripts/repair-board-climb-holds.ts
@@ -20,6 +20,55 @@ import {
 
 export type RepairQueryExecutor = { execute(query: SQLWrapper | string): PromiseLike<unknown> };
 
+export type RepairBatchLimits = {
+  maxIdentityRecords: number;
+  maxMutationRecords: number;
+  maxParameterBytes: number;
+};
+
+export const DEFAULT_REPAIR_BATCH_LIMITS: Readonly<RepairBatchLimits> = {
+  maxIdentityRecords: 500,
+  maxMutationRecords: 5_000,
+  maxParameterBytes: 1024 * 1024,
+};
+
+type JsonBatch<RecordType> = { records: RecordType[]; json: string };
+
+function validateBatchLimit(name: keyof RepairBatchLimits, limit: number): void {
+  if (!Number.isSafeInteger(limit) || limit <= 0) throw new Error(`${name} must be a positive integer`);
+}
+
+function* jsonBatches<RecordType>(
+  records: Iterable<RecordType>,
+  maxRecords: number,
+  maxParameterBytes: number,
+): Generator<JsonBatch<RecordType>> {
+  if (!Number.isSafeInteger(maxRecords) || maxRecords <= 0) throw new Error('batch record limit must be positive');
+  validateBatchLimit('maxParameterBytes', maxParameterBytes);
+  let batch: RecordType[] = [];
+  let serializedRecords: string[] = [];
+  let batchBytes = 2;
+
+  for (const record of records) {
+    const serializedRecord = JSON.stringify(record);
+    const recordBytes = Buffer.byteLength(serializedRecord);
+    if (recordBytes + 2 > maxParameterBytes) {
+      throw new Error(`one repair JSON record exceeds the ${maxParameterBytes}-byte parameter limit`);
+    }
+    const additionalBytes = recordBytes + (batch.length > 0 ? 1 : 0);
+    if (batch.length >= maxRecords || batchBytes + additionalBytes > maxParameterBytes) {
+      yield { records: batch, json: `[${serializedRecords.join(',')}]` };
+      batch = [];
+      serializedRecords = [];
+      batchBytes = 2;
+    }
+    batch.push(record);
+    serializedRecords.push(serializedRecord);
+    batchBytes += recordBytes + (batch.length > 1 ? 1 : 0);
+  }
+  if (batch.length > 0) yield { records: batch, json: `[${serializedRecords.join(',')}]` };
+}
+
 type ScriptArgs = {
   apply: boolean;
   expectedDigest: string | null;
@@ -206,42 +255,53 @@ export async function fetchCandidateClimbs(executor: RepairQueryExecutor): Promi
 
 type PlacementReference = { board_type: string; layout_id: number; hold_id: number };
 
-async function fetchExistingPlacementKeys(
+export async function fetchExistingPlacementKeys(
   executor: RepairQueryExecutor,
   climbs: ReadonlyArray<RepairClimbInput>,
+  batchLimits: RepairBatchLimits = DEFAULT_REPAIR_BATCH_LIMITS,
 ): Promise<Set<string>> {
   const preliminary = buildRepairManifest(climbs, new Set<string>());
-  const references: PlacementReference[] = preliminary.entries.flatMap((entry) =>
-    (entry.projectedRows ?? []).map((row) => ({
-      board_type: entry.boardType,
-      layout_id: entry.layoutId,
-      hold_id: row.holdId,
-    })),
-  );
-  if (references.length === 0) return new Set();
-  const rows = await executeRows<PlacementReference>(
-    executor,
-    sql`
-      WITH projected AS (
-        SELECT DISTINCT board_type, layout_id, hold_id
-        FROM jsonb_to_recordset(${JSON.stringify(references)}::jsonb)
-          AS row(board_type text, layout_id integer, hold_id integer)
-      )
-      SELECT projected.board_type, projected.layout_id, projected.hold_id
-      FROM projected
-      INNER JOIN board_placements placement
-        ON placement.board_type = projected.board_type
-       AND placement.layout_id = projected.layout_id
-       AND placement.id = projected.hold_id
-      ORDER BY projected.board_type, projected.layout_id, projected.hold_id
-    `,
-  );
-  return new Set(rows.map((row) => placementKey(row.board_type, row.layout_id, row.hold_id)));
+  const referencesByKey = new Map<string, PlacementReference>();
+  for (const entry of preliminary.entries) {
+    for (const row of entry.projectedRows ?? []) {
+      const key = placementKey(entry.boardType, entry.layoutId, row.holdId);
+      referencesByKey.set(key, { board_type: entry.boardType, layout_id: entry.layoutId, hold_id: row.holdId });
+    }
+  }
+  const existingKeys = new Set<string>();
+  for (const batch of jsonBatches(
+    referencesByKey.values(),
+    batchLimits.maxMutationRecords,
+    batchLimits.maxParameterBytes,
+  )) {
+    const rows = await executeRows<PlacementReference>(
+      executor,
+      sql`
+        WITH projected AS (
+          SELECT board_type, layout_id, hold_id
+          FROM jsonb_to_recordset(${batch.json}::jsonb)
+            AS row(board_type text, layout_id integer, hold_id integer)
+        )
+        SELECT projected.board_type, projected.layout_id, projected.hold_id
+        FROM projected
+        INNER JOIN board_placements placement
+          ON placement.board_type = projected.board_type
+         AND placement.layout_id = projected.layout_id
+         AND placement.id = projected.hold_id
+        ORDER BY projected.board_type, projected.layout_id, projected.hold_id
+      `,
+    );
+    for (const row of rows) existingKeys.add(placementKey(row.board_type, row.layout_id, row.hold_id));
+  }
+  return existingKeys;
 }
 
-async function buildManifest(executor: RepairQueryExecutor): Promise<RepairManifest> {
+async function buildManifest(
+  executor: RepairQueryExecutor,
+  batchLimits: RepairBatchLimits = DEFAULT_REPAIR_BATCH_LIMITS,
+): Promise<RepairManifest> {
   const climbs = await fetchCandidateClimbs(executor);
-  const placementKeys = await fetchExistingPlacementKeys(executor, climbs);
+  const placementKeys = await fetchExistingPlacementKeys(executor, climbs, batchLimits);
   return buildRepairManifest(climbs, placementKeys);
 }
 
@@ -296,13 +356,65 @@ function printManifest(manifest: RepairManifest, digest: string, reportLimit: nu
   if (!apply) console.info('[repair-board-climb-holds] dry-run only; no locks or writes were taken');
 }
 
-type MutationRow = RepairHoldRow & { boardType: string; climbUuid: string };
-
 function climbIdentityKey(boardType: string, climbUuid: string): string {
   return `${boardType}\u0000${climbUuid}`;
 }
 
-export async function applyRepairManifest(executor: RepairQueryExecutor, manifest: RepairManifest): Promise<void> {
+type AffectedCountRow = { affected_count: number };
+
+function mutationBatchIdentities(records: ReadonlyArray<{ board_type: string; climb_uuid: string }>): string {
+  return Array.from(new Set(records.map((record) => `${record.board_type}/${record.climb_uuid}`))).join(', ');
+}
+
+function mutationRows(entries: ReadonlyArray<RepairManifest['entries'][number]>): Generator<{
+  board_type: string;
+  climb_uuid: string;
+  hold_id: number;
+  frame_number: number;
+  hold_state: string;
+}> {
+  return (function* generateRows() {
+    for (const entry of entries) {
+      for (const row of entry.projectedRows ?? []) {
+        yield {
+          board_type: entry.boardType,
+          climb_uuid: entry.uuid,
+          hold_id: row.holdId,
+          frame_number: row.frameNumber,
+          hold_state: row.holdState,
+        };
+      }
+    }
+  })();
+}
+
+function invalidMutationRows(entries: ReadonlyArray<RepairManifest['entries'][number]>): Generator<{
+  board_type: string;
+  climb_uuid: string;
+  hold_id: number;
+  frame_number: number;
+  hold_state: string;
+}> {
+  return (function* generateRows() {
+    for (const entry of entries) {
+      for (const row of entry.invalidRows) {
+        yield {
+          board_type: entry.boardType,
+          climb_uuid: entry.uuid,
+          hold_id: row.holdId,
+          frame_number: row.frameNumber,
+          hold_state: row.holdState,
+        };
+      }
+    }
+  })();
+}
+
+export async function applyRepairManifest(
+  executor: RepairQueryExecutor,
+  manifest: RepairManifest,
+  batchLimits: RepairBatchLimits = DEFAULT_REPAIR_BATCH_LIMITS,
+): Promise<void> {
   const recomputedBlockerCount = manifest.entries.reduce((total, entry) => total + entry.blockers.length, 0);
   if (manifest.counts.blockers !== recomputedBlockerCount) {
     throw new Error(
@@ -316,99 +428,113 @@ export async function applyRepairManifest(executor: RepairQueryExecutor, manifes
   const changedEntries = manifest.entries.filter((entry) => entry.changed);
   const invalidOnlyEntries = manifest.entries.filter((entry) => !entry.multiFrame && entry.invalidRows.length > 0);
 
-  if (changedEntries.length > 0) {
-    const deleted = await executeRows<{ board_type: string }>(
+  for (const batch of jsonBatches(
+    changedEntries.map((entry) => ({
+      board_type: entry.boardType,
+      climb_uuid: entry.uuid,
+      expected_rows: entry.oldRows.length,
+    })),
+    batchLimits.maxIdentityRecords,
+    batchLimits.maxParameterBytes,
+  )) {
+    const [{ affected_count: deletedCount } = { affected_count: -1 }] = await executeRows<AffectedCountRow>(
       executor,
       sql`
         WITH changed AS (
-          SELECT *
-          FROM jsonb_to_recordset(${JSON.stringify(
-            changedEntries.map((entry) => ({ board_type: entry.boardType, climb_uuid: entry.uuid })),
-          )}::jsonb) AS row(board_type text, climb_uuid text)
+          SELECT board_type, climb_uuid
+          FROM jsonb_to_recordset(${batch.json}::jsonb)
+            AS row(board_type text, climb_uuid text, expected_rows integer)
+        ), deleted AS (
+          DELETE FROM board_climb_holds stored
+          USING changed
+          WHERE stored.board_type = changed.board_type
+            AND stored.climb_uuid = changed.climb_uuid
+          RETURNING 1
         )
-        DELETE FROM board_climb_holds stored
-        USING changed
-        WHERE stored.board_type = changed.board_type
-          AND stored.climb_uuid = changed.climb_uuid
-        RETURNING stored.board_type
+        SELECT COUNT(*)::integer AS affected_count FROM deleted
       `,
     );
-    const expectedDeletedRows = changedEntries.reduce((total, entry) => total + entry.oldRows.length, 0);
-    if (deleted.length !== expectedDeletedRows) {
-      throw new Error('deleted changed-row count did not match the manifest');
+    const expectedDeletedRows = batch.records.reduce((total, entry) => total + entry.expected_rows, 0);
+    if (deletedCount !== expectedDeletedRows) {
+      throw new Error(
+        `deleted changed-row count did not match the manifest for ${mutationBatchIdentities(batch.records)}: expected=${expectedDeletedRows} actual=${deletedCount}`,
+      );
     }
   }
-  const insertionRows: MutationRow[] = changedEntries.flatMap((entry) =>
-    (entry.projectedRows ?? []).map((row) => ({ ...row, boardType: entry.boardType, climbUuid: entry.uuid })),
-  );
-  if (insertionRows.length > 0) {
-    const returned = await executeRows<{ board_type: string }>(
+  for (const batch of jsonBatches(
+    mutationRows(changedEntries),
+    batchLimits.maxMutationRecords,
+    batchLimits.maxParameterBytes,
+  )) {
+    const [{ affected_count: insertedCount } = { affected_count: -1 }] = await executeRows<AffectedCountRow>(
       executor,
       sql`
-        INSERT INTO board_climb_holds (board_type, climb_uuid, hold_id, frame_number, hold_state)
-        SELECT board_type, climb_uuid, hold_id, frame_number, hold_state
-        FROM jsonb_to_recordset(${JSON.stringify(
-          insertionRows.map((row) => ({
-            board_type: row.boardType,
-            climb_uuid: row.climbUuid,
-            hold_id: row.holdId,
-            frame_number: row.frameNumber,
-            hold_state: row.holdState,
-          })),
-        )}::jsonb) AS row(board_type text, climb_uuid text, hold_id integer, frame_number integer, hold_state text)
-        RETURNING board_type
+        WITH inserted AS (
+          INSERT INTO board_climb_holds (board_type, climb_uuid, hold_id, frame_number, hold_state)
+          SELECT board_type, climb_uuid, hold_id, frame_number, hold_state
+          FROM jsonb_to_recordset(${batch.json}::jsonb)
+            AS row(board_type text, climb_uuid text, hold_id integer, frame_number integer, hold_state text)
+          RETURNING 1
+        )
+        SELECT COUNT(*)::integer AS affected_count FROM inserted
       `,
     );
-    if (returned.length !== insertionRows.length) throw new Error('inserted row count did not match the manifest');
+    if (insertedCount !== batch.records.length) {
+      throw new Error(
+        `inserted row count did not match the manifest for ${mutationBatchIdentities(batch.records)}: expected=${batch.records.length} actual=${insertedCount}`,
+      );
+    }
   }
 
-  const invalidRows = invalidOnlyEntries.flatMap((entry) =>
-    entry.invalidRows.map((row) => ({ ...row, boardType: entry.boardType, climbUuid: entry.uuid })),
-  );
-  if (invalidRows.length > 0) {
-    const deleted = await executeRows<{ board_type: string }>(
+  for (const batch of jsonBatches(
+    invalidMutationRows(invalidOnlyEntries),
+    batchLimits.maxMutationRecords,
+    batchLimits.maxParameterBytes,
+  )) {
+    const [{ affected_count: deletedCount } = { affected_count: -1 }] = await executeRows<AffectedCountRow>(
       executor,
       sql`
         WITH doomed AS (
-          SELECT *
-          FROM jsonb_to_recordset(${JSON.stringify(
-            invalidRows.map((row) => ({
-              board_type: row.boardType,
-              climb_uuid: row.climbUuid,
-              hold_id: row.holdId,
-              frame_number: row.frameNumber,
-              hold_state: row.holdState,
-            })),
-          )}::jsonb) AS row(board_type text, climb_uuid text, hold_id integer, frame_number integer, hold_state text)
+          SELECT board_type, climb_uuid, hold_id, frame_number, hold_state
+          FROM jsonb_to_recordset(${batch.json}::jsonb)
+            AS row(board_type text, climb_uuid text, hold_id integer, frame_number integer, hold_state text)
+        ), deleted AS (
+          DELETE FROM board_climb_holds stored
+          USING doomed
+          WHERE stored.board_type = doomed.board_type
+            AND stored.climb_uuid = doomed.climb_uuid
+            AND stored.hold_id = doomed.hold_id
+            AND stored.frame_number = doomed.frame_number
+            AND stored.hold_state = doomed.hold_state
+          RETURNING 1
         )
-        DELETE FROM board_climb_holds stored
-        USING doomed
-        WHERE stored.board_type = doomed.board_type
-          AND stored.climb_uuid = doomed.climb_uuid
-          AND stored.hold_id = doomed.hold_id
-          AND stored.frame_number = doomed.frame_number
-          AND stored.hold_state = doomed.hold_state
-        RETURNING stored.board_type
+        SELECT COUNT(*)::integer AS affected_count FROM deleted
       `,
     );
-    if (deleted.length !== invalidRows.length) throw new Error('deleted invalid row count did not match the manifest');
+    if (deletedCount !== batch.records.length) {
+      throw new Error(
+        `deleted invalid row count did not match the manifest for ${mutationBatchIdentities(batch.records)}: expected=${batch.records.length} actual=${deletedCount}`,
+      );
+    }
   }
 
   const fingerprintUpdates = manifest.entries.filter((candidate) => candidate.fingerprint.shouldUpdate);
-  if (fingerprintUpdates.length > 0) {
+  for (const batch of jsonBatches(
+    fingerprintUpdates.map((entry) => ({
+      board_type: entry.boardType,
+      uuid: entry.uuid,
+      old_fingerprint: entry.fingerprint.old,
+      projected_fingerprint: entry.fingerprint.projected,
+    })),
+    batchLimits.maxIdentityRecords,
+    batchLimits.maxParameterBytes,
+  )) {
     const updated = await executeRows<{ board_type: string; uuid: string }>(
       executor,
       sql`
         WITH changes AS (
-          SELECT *
-          FROM jsonb_to_recordset(${JSON.stringify(
-            fingerprintUpdates.map((entry) => ({
-              board_type: entry.boardType,
-              uuid: entry.uuid,
-              old_fingerprint: entry.fingerprint.old,
-              projected_fingerprint: entry.fingerprint.projected,
-            })),
-          )}::jsonb)
+          SELECT board_type, uuid, old_fingerprint, projected_fingerprint
+          FROM jsonb_to_recordset(${batch.json}::jsonb)
             AS row(board_type text, uuid text, old_fingerprint text, projected_fingerprint text)
         )
         UPDATE board_climbs stored
@@ -421,21 +547,32 @@ export async function applyRepairManifest(executor: RepairQueryExecutor, manifes
       `,
     );
     const updatedKeys = new Set(updated.map((row) => climbIdentityKey(row.board_type, row.uuid)));
-    const failedKeys = fingerprintUpdates
-      .filter((entry) => !updatedKeys.has(climbIdentityKey(entry.boardType, entry.uuid)))
-      .map((entry) => `${entry.boardType}/${entry.uuid}`);
-    if (updated.length !== fingerprintUpdates.length || failedKeys.length > 0) {
+    const failedKeys = batch.records
+      .filter((entry) => !updatedKeys.has(climbIdentityKey(entry.board_type, entry.uuid)))
+      .map((entry) => `${entry.board_type}/${entry.uuid}`);
+    if (updated.length !== batch.records.length || failedKeys.length > 0) {
       throw new Error(`fingerprint guard failed for ${failedKeys.join(', ') || 'unexpected duplicate identity'}`);
     }
   }
 }
 
-export async function verifyAppliedRepair(executor: RepairQueryExecutor, manifest: RepairManifest): Promise<void> {
+export async function verifyAppliedRepair(
+  executor: RepairQueryExecutor,
+  manifest: RepairManifest,
+  batchLimits: RepairBatchLimits = DEFAULT_REPAIR_BATCH_LIMITS,
+): Promise<void> {
   const changedEntries = manifest.entries.filter((entry) => entry.changed);
-  const actualRowsByIdentity = new Map<string, RepairHoldRow[]>(
-    changedEntries.map((entry) => [climbIdentityKey(entry.boardType, entry.uuid), []]),
+  const changedEntriesByIdentity = new Map(
+    changedEntries.map((entry) => [climbIdentityKey(entry.boardType, entry.uuid), entry]),
   );
-  if (changedEntries.length > 0) {
+  for (const batch of jsonBatches(
+    changedEntries.map((entry) => ({ board_type: entry.boardType, climb_uuid: entry.uuid })),
+    batchLimits.maxIdentityRecords,
+    batchLimits.maxParameterBytes,
+  )) {
+    const actualRowsByIdentity = new Map<string, RepairHoldRow[]>(
+      batch.records.map(({ board_type, climb_uuid }) => [climbIdentityKey(board_type, climb_uuid), []]),
+    );
     const actual = await executeRows<{
       board_type: string;
       climb_uuid: string;
@@ -446,10 +583,8 @@ export async function verifyAppliedRepair(executor: RepairQueryExecutor, manifes
       executor,
       sql`
         WITH targets AS (
-          SELECT *
-          FROM jsonb_to_recordset(${JSON.stringify(
-            changedEntries.map((entry) => ({ board_type: entry.boardType, climb_uuid: entry.uuid })),
-          )}::jsonb) AS row(board_type text, climb_uuid text)
+          SELECT board_type, climb_uuid
+          FROM jsonb_to_recordset(${batch.json}::jsonb) AS row(board_type text, climb_uuid text)
         )
         SELECT stored.board_type, stored.climb_uuid, stored.hold_id, stored.frame_number, stored.hold_state
         FROM board_climb_holds stored
@@ -464,11 +599,13 @@ export async function verifyAppliedRepair(executor: RepairQueryExecutor, manifes
       if (!identityRows) throw new Error(`post-write verification returned an unexpected identity`);
       identityRows.push({ holdId: row.hold_id, frameNumber: row.frame_number, holdState: row.hold_state });
     }
-  }
-  for (const entry of changedEntries) {
-    const actualRows = sortRepairRows(actualRowsByIdentity.get(climbIdentityKey(entry.boardType, entry.uuid)) ?? []);
-    if (JSON.stringify(actualRows) !== JSON.stringify(entry.projectedRows)) {
-      throw new Error(`post-write row verification failed for ${entry.boardType}/${entry.uuid}`);
+    for (const { board_type: boardType, climb_uuid: climbUuid } of batch.records) {
+      const entry = changedEntriesByIdentity.get(climbIdentityKey(boardType, climbUuid));
+      if (!entry) throw new Error('post-write verification lost a requested identity');
+      const actualRows = sortRepairRows(actualRowsByIdentity.get(climbIdentityKey(entry.boardType, entry.uuid)) ?? []);
+      if (JSON.stringify(actualRows) !== JSON.stringify(entry.projectedRows)) {
+        throw new Error(`post-write row verification failed for ${entry.boardType}/${entry.uuid}`);
+      }
     }
   }
   const [{ invalid_count: invalidCount } = { invalid_count: -1 }] = await executeRows<{ invalid_count: number }>(
@@ -485,9 +622,10 @@ export async function verifyAppliedRepair(executor: RepairQueryExecutor, manifes
 export async function runRepair(
   args: ScriptArgs,
   database: ReturnType<typeof createScriptDb> = createScriptDb(),
+  batchLimits: RepairBatchLimits = DEFAULT_REPAIR_BATCH_LIMITS,
 ): Promise<{ manifest: RepairManifest; digest: string; applied: boolean }> {
   try {
-    const initialManifest = await buildManifest(database.db);
+    const initialManifest = await buildManifest(database.db, batchLimits);
     const initialDigest = digestRepairManifest(initialManifest);
     printManifest(initialManifest, initialDigest, args.reportLimit, args.apply);
     if (!args.apply) return { manifest: initialManifest, digest: initialDigest, applied: false };
@@ -505,11 +643,11 @@ export async function runRepair(
         await transaction.execute(sql`LOCK TABLE board_climb_holds IN SHARE ROW EXCLUSIVE MODE`);
         await transaction.execute(sql`SELECT pg_advisory_xact_lock(hashtext('boardsesh:repair-board-climb-holds:v1'))`);
 
-        const lockedManifest = await buildManifest(transaction);
+        const lockedManifest = await buildManifest(transaction, batchLimits);
         const lockedDigest = digestRepairManifest(lockedManifest);
         verifyGuards(args, lockedManifest, lockedDigest);
-        await applyRepairManifest(transaction, lockedManifest);
-        await verifyAppliedRepair(transaction, lockedManifest);
+        await applyRepairManifest(transaction, lockedManifest, batchLimits);
+        await verifyAppliedRepair(transaction, lockedManifest, batchLimits);
       },
       { isolationLevel: 'repeatable read' },
     );

--- a/packages/db/scripts/repair-board-climb-holds.ts
+++ b/packages/db/scripts/repair-board-climb-holds.ts
@@ -4,6 +4,7 @@
  * See docs/board-climb-holds-repair.md before pointing this at a remote DB.
  */
 import { pathToFileURL } from 'node:url';
+import { AURORA_BOARDS } from '@boardsesh/shared-schema';
 import { sql, type SQLWrapper } from 'drizzle-orm';
 import { executeRows } from '../src/client/index.js';
 import { createScriptDb, describeDatabaseHost, getScriptDatabaseUrl } from './db-connection.js';
@@ -118,13 +119,17 @@ type CandidateJoinedRow = {
 };
 
 export async function fetchCandidateClimbs(executor: RepairQueryExecutor): Promise<RepairClimbInput[]> {
+  const auroraBoardList = sql.join(
+    AURORA_BOARDS.map((boardName) => sql`${boardName}`),
+    sql`, `,
+  );
   const joinedRows = await executeRows<CandidateJoinedRow>(
     executor,
     sql`
       WITH candidate_keys AS (
         SELECT bc.board_type, bc.uuid, TRUE AS multi_frame_target
         FROM board_climbs bc
-        WHERE bc.board_type IN ('kilter', 'tension', 'decoy', 'touchstone', 'grasshopper', 'soill')
+        WHERE bc.board_type IN (${auroraBoardList})
           AND bc.frames_count > 1
         UNION ALL
         SELECT invalid.board_type, invalid.climb_uuid AS uuid, FALSE AS multi_frame_target
@@ -298,11 +303,14 @@ function climbIdentityKey(boardType: string, climbUuid: string): string {
 }
 
 export async function applyRepairManifest(executor: RepairQueryExecutor, manifest: RepairManifest): Promise<void> {
-  const blockerCount = manifest.entries.reduce((total, entry) => total + entry.blockers.length, 0);
-  if (manifest.counts.blockers > 0 || blockerCount > 0) {
+  const recomputedBlockerCount = manifest.entries.reduce((total, entry) => total + entry.blockers.length, 0);
+  if (manifest.counts.blockers !== recomputedBlockerCount) {
     throw new Error(
-      `refusing to apply a repair manifest with ${Math.max(manifest.counts.blockers, blockerCount)} blocker(s)`,
+      `refusing to apply a repair manifest with inconsistent blocker counts: summary=${manifest.counts.blockers} entries=${recomputedBlockerCount}`,
     );
+  }
+  if (recomputedBlockerCount > 0) {
+    throw new Error(`refusing to apply a repair manifest with ${recomputedBlockerCount} blocker(s)`);
   }
 
   const changedEntries = manifest.entries.filter((entry) => entry.changed);

--- a/packages/db/scripts/repair-board-climb-holds.ts
+++ b/packages/db/scripts/repair-board-climb-holds.ts
@@ -298,6 +298,13 @@ function climbIdentityKey(boardType: string, climbUuid: string): string {
 }
 
 export async function applyRepairManifest(executor: RepairQueryExecutor, manifest: RepairManifest): Promise<void> {
+  const blockerCount = manifest.entries.reduce((total, entry) => total + entry.blockers.length, 0);
+  if (manifest.counts.blockers > 0 || blockerCount > 0) {
+    throw new Error(
+      `refusing to apply a repair manifest with ${Math.max(manifest.counts.blockers, blockerCount)} blocker(s)`,
+    );
+  }
+
   const changedEntries = manifest.entries.filter((entry) => entry.changed);
   const invalidOnlyEntries = manifest.entries.filter((entry) => !entry.multiFrame && entry.invalidRows.length > 0);
 

--- a/packages/db/scripts/repair-board-climb-holds.ts
+++ b/packages/db/scripts/repair-board-climb-holds.ts
@@ -1,0 +1,469 @@
+/**
+ * Repair historical `board_climb_holds` drift caused by multi-frame Aurora
+ * climbs being flattened through the old parser. Dry-run is the default.
+ * See docs/board-climb-holds-repair.md before pointing this at a remote DB.
+ */
+import { pathToFileURL } from 'node:url';
+import { sql, type SQLWrapper } from 'drizzle-orm';
+import { executeRows } from '../src/client/index.js';
+import { createScriptDb, describeDatabaseHost, getScriptDatabaseUrl } from './db-connection.js';
+import {
+  buildRepairManifest,
+  digestRepairManifest,
+  placementKey,
+  sortRepairRows,
+  type RepairClimbInput,
+  type RepairHoldRow,
+  type RepairManifest,
+} from './repair-board-climb-holds-helpers.js';
+
+export type RepairQueryExecutor = { execute(query: SQLWrapper | string): PromiseLike<unknown> };
+
+type ScriptArgs = {
+  apply: boolean;
+  expectedDigest: string | null;
+  expectedScanned: number | null;
+  expectedChanged: number | null;
+  expectedInvalid: number | null;
+  maxAffected: number | null;
+  reportLimit: number;
+  help: boolean;
+};
+
+const VALUE_FLAGS = new Set([
+  '--expected-digest',
+  '--expected-scanned',
+  '--expected-changed',
+  '--expected-invalid',
+  '--max-affected',
+  '--report-limit',
+]);
+
+function parseNonnegativeInteger(flag: string, raw: string | undefined): number {
+  const parsed = Number(raw);
+  if (!raw || !Number.isSafeInteger(parsed) || parsed < 0) throw new Error(`${flag} requires a nonnegative integer`);
+  return parsed;
+}
+
+export function parseRepairArgs(args: string[]): ScriptArgs {
+  const values = new Map<string, string>();
+  let apply = false;
+  let help = false;
+  for (let index = 0; index < args.length; index += 1) {
+    const current = args[index];
+    if (current === '--') continue;
+    if (current === '--apply') {
+      apply = true;
+      continue;
+    }
+    if (current === '--help') {
+      help = true;
+      continue;
+    }
+    if (!VALUE_FLAGS.has(current)) throw new Error(`unknown argument: ${current}`);
+    const optionValue = args[index + 1];
+    if (!optionValue || optionValue.startsWith('--')) throw new Error(`${current} requires a value`);
+    values.set(current, optionValue);
+    index += 1;
+  }
+
+  const parsed: ScriptArgs = {
+    apply,
+    help,
+    expectedDigest: values.get('--expected-digest') ?? null,
+    expectedScanned: values.has('--expected-scanned')
+      ? parseNonnegativeInteger('--expected-scanned', values.get('--expected-scanned'))
+      : null,
+    expectedChanged: values.has('--expected-changed')
+      ? parseNonnegativeInteger('--expected-changed', values.get('--expected-changed'))
+      : null,
+    expectedInvalid: values.has('--expected-invalid')
+      ? parseNonnegativeInteger('--expected-invalid', values.get('--expected-invalid'))
+      : null,
+    maxAffected: values.has('--max-affected')
+      ? parseNonnegativeInteger('--max-affected', values.get('--max-affected'))
+      : null,
+    reportLimit: values.has('--report-limit')
+      ? parseNonnegativeInteger('--report-limit', values.get('--report-limit'))
+      : 50,
+  };
+  if (
+    apply &&
+    [
+      parsed.expectedDigest,
+      parsed.expectedScanned,
+      parsed.expectedChanged,
+      parsed.expectedInvalid,
+      parsed.maxAffected,
+    ].some((value) => value === null)
+  ) {
+    throw new Error(
+      '--apply requires --expected-digest, --expected-scanned, --expected-changed, --expected-invalid, and --max-affected',
+    );
+  }
+  return parsed;
+}
+
+type CandidateJoinedRow = {
+  board_type: string;
+  uuid: string;
+  layout_id: number;
+  frames: string | null;
+  frames_count: number | null;
+  hold_fingerprint: string | null;
+  multi_frame_target: boolean;
+  hold_id: number | null;
+  frame_number: number | null;
+  hold_state: string | null;
+};
+
+async function fetchCandidateClimbs(executor: RepairQueryExecutor): Promise<RepairClimbInput[]> {
+  const joinedRows = await executeRows<CandidateJoinedRow>(
+    executor,
+    sql`
+      WITH candidate_keys AS (
+        SELECT bc.board_type, bc.uuid, TRUE AS multi_frame_target
+        FROM board_climbs bc
+        WHERE bc.board_type IN ('kilter', 'tension', 'decoy', 'touchstone', 'grasshopper', 'soill')
+          AND bc.frames_count > 1
+        UNION ALL
+        SELECT invalid.board_type, invalid.climb_uuid AS uuid, FALSE AS multi_frame_target
+        FROM board_climb_holds invalid
+        WHERE invalid.hold_id <= 0 OR invalid.hold_state = '' OR invalid.hold_state LIKE '%=%'
+      ),
+      candidate_identity AS (
+        SELECT board_type, uuid, BOOL_OR(multi_frame_target) AS multi_frame_target
+        FROM candidate_keys
+        GROUP BY board_type, uuid
+      ),
+      candidates AS (
+        SELECT
+          candidate_identity.board_type,
+          candidate_identity.uuid,
+          candidate_identity.multi_frame_target,
+          bc.layout_id,
+          bc.frames,
+          bc.frames_count,
+          CASE
+            WHEN bc.board_type = candidate_identity.board_type THEN bc.hold_fingerprint
+            ELSE NULL
+          END AS hold_fingerprint
+        FROM candidate_identity
+        INNER JOIN board_climbs bc ON bc.uuid = candidate_identity.uuid
+      )
+      SELECT
+        candidates.board_type,
+        candidates.uuid,
+        candidates.layout_id,
+        candidates.frames,
+        candidates.frames_count,
+        candidates.hold_fingerprint,
+        candidates.multi_frame_target,
+        holds.hold_id,
+        holds.frame_number,
+        holds.hold_state
+      FROM candidates
+      LEFT JOIN board_climb_holds holds
+        ON holds.board_type = candidates.board_type
+       AND holds.climb_uuid = candidates.uuid
+      ORDER BY candidates.board_type, candidates.uuid, holds.hold_id, holds.frame_number, holds.hold_state
+    `,
+  );
+
+  const climbs: RepairClimbInput[] = [];
+  for (const row of joinedRows) {
+    const previous = climbs[climbs.length - 1];
+    const climb =
+      previous?.boardType === row.board_type && previous.uuid === row.uuid
+        ? previous
+        : {
+            boardType: row.board_type,
+            uuid: row.uuid,
+            layoutId: row.layout_id,
+            frames: row.frames,
+            framesCount: row.frames_count,
+            holdFingerprint: row.hold_fingerprint,
+            multiFrameTarget: row.multi_frame_target,
+            rows: [],
+          };
+    if (climb !== previous) climbs.push(climb);
+    if (row.hold_id !== null && row.frame_number !== null && row.hold_state !== null) {
+      climb.rows.push({ holdId: row.hold_id, frameNumber: row.frame_number, holdState: row.hold_state });
+    }
+  }
+  return climbs;
+}
+
+type PlacementReference = { board_type: string; layout_id: number; hold_id: number };
+
+async function fetchExistingPlacementKeys(
+  executor: RepairQueryExecutor,
+  climbs: ReadonlyArray<RepairClimbInput>,
+): Promise<Set<string>> {
+  const preliminary = buildRepairManifest(climbs, new Set<string>());
+  const references: PlacementReference[] = preliminary.entries.flatMap((entry) =>
+    (entry.projectedRows ?? []).map((row) => ({
+      board_type: entry.boardType,
+      layout_id: entry.layoutId,
+      hold_id: row.holdId,
+    })),
+  );
+  if (references.length === 0) return new Set();
+  const rows = await executeRows<PlacementReference>(
+    executor,
+    sql`
+      WITH projected AS (
+        SELECT DISTINCT board_type, layout_id, hold_id
+        FROM jsonb_to_recordset(${JSON.stringify(references)}::jsonb)
+          AS row(board_type text, layout_id integer, hold_id integer)
+      )
+      SELECT projected.board_type, projected.layout_id, projected.hold_id
+      FROM projected
+      INNER JOIN board_placements placement
+        ON placement.board_type = projected.board_type
+       AND placement.layout_id = projected.layout_id
+       AND placement.id = projected.hold_id
+      ORDER BY projected.board_type, projected.layout_id, projected.hold_id
+    `,
+  );
+  return new Set(rows.map((row) => placementKey(row.board_type, row.layout_id, row.hold_id)));
+}
+
+async function buildManifest(executor: RepairQueryExecutor): Promise<RepairManifest> {
+  const climbs = await fetchCandidateClimbs(executor);
+  const placementKeys = await fetchExistingPlacementKeys(executor, climbs);
+  return buildRepairManifest(climbs, placementKeys);
+}
+
+function verifyGuards(args: ScriptArgs, manifest: RepairManifest, digest: string): void {
+  const mismatches: string[] = [];
+  if (args.expectedDigest !== digest) mismatches.push(`digest expected=${args.expectedDigest} actual=${digest}`);
+  if (args.expectedScanned !== manifest.counts.scannedClimbs) {
+    mismatches.push(`scanned expected=${args.expectedScanned} actual=${manifest.counts.scannedClimbs}`);
+  }
+  if (args.expectedChanged !== manifest.counts.changedMultiFrameClimbs) {
+    mismatches.push(`changed expected=${args.expectedChanged} actual=${manifest.counts.changedMultiFrameClimbs}`);
+  }
+  if (args.expectedInvalid !== manifest.counts.invalidRows) {
+    mismatches.push(`invalid expected=${args.expectedInvalid} actual=${manifest.counts.invalidRows}`);
+  }
+  if (args.maxAffected !== null && manifest.counts.affectedClimbs > args.maxAffected) {
+    mismatches.push(`affected=${manifest.counts.affectedClimbs} exceeds max=${args.maxAffected}`);
+  }
+  if (manifest.counts.blockers > 0) mismatches.push(`manifest has ${manifest.counts.blockers} blocker(s)`);
+  if (mismatches.length > 0) throw new Error(`repair guard failed: ${mismatches.join('; ')}`);
+}
+
+function printManifest(manifest: RepairManifest, digest: string, reportLimit: number, apply: boolean): void {
+  console.info(`[repair-board-climb-holds] manifest_sha256=${digest}`);
+  console.info(
+    `[repair-board-climb-holds] scanned=${manifest.counts.scannedClimbs} multi_frame=${manifest.counts.scannedMultiFrameClimbs} changed=${manifest.counts.changedMultiFrameClimbs} affected=${manifest.counts.affectedClimbs} invalid_rows=${manifest.counts.invalidRows}`,
+  );
+  console.info(
+    `[repair-board-climb-holds] delete_rows=${manifest.counts.deleteRows} insert_rows=${manifest.counts.insertRows} fingerprint_updates=${manifest.counts.fingerprintUpdates} blockers=${manifest.counts.blockers}`,
+  );
+  console.info(
+    `[repair-board-climb-holds] skipped_unknown_roles=${manifest.counts.skippedUnknownRoleTokens} skipped_nonpositive_ids=${manifest.counts.skippedNonpositiveHoldIdTokens} missing_placements=${manifest.counts.missingPlacements}`,
+  );
+  const noteworthy = manifest.entries.filter(
+    (entry) =>
+      entry.changed ||
+      entry.invalidRows.length > 0 ||
+      entry.fingerprint.shouldUpdate ||
+      entry.blockers.length > 0 ||
+      entry.diagnostics.skippedUnknownRoleTokens > 0 ||
+      entry.diagnostics.skippedNonpositiveHoldIdTokens > 0 ||
+      entry.diagnostics.missingPlacementHoldIds.length > 0,
+  );
+  for (const entry of noteworthy.slice(0, reportLimit)) {
+    console.info(
+      `[repair-board-climb-holds] ${entry.boardType}/${entry.uuid} changed=${entry.changed} invalid=${entry.invalidRows.length} old_rows=${entry.oldRows.length} projected_rows=${entry.projectedRows?.length ?? '-'} old_hash=${entry.rowHashes.old} projected_hash=${entry.rowHashes.projected} fingerprint=${entry.fingerprint.classification} unknown_roles=${entry.diagnostics.skippedUnknownRoleTokens} nonpositive=${entry.diagnostics.skippedNonpositiveHoldIdTokens} missing_placements=${entry.diagnostics.missingPlacementHoldIds.join(',') || '-'} blockers=${entry.blockers.join('|') || '-'}`,
+    );
+  }
+  if (noteworthy.length > reportLimit) {
+    console.info(`[repair-board-climb-holds] report truncated: ${noteworthy.length - reportLimit} additional climb(s)`);
+  }
+  if (!apply) console.info('[repair-board-climb-holds] dry-run only; no locks or writes were taken');
+}
+
+type MutationRow = RepairHoldRow & { boardType: string; climbUuid: string };
+
+export async function applyRepairManifest(executor: RepairQueryExecutor, manifest: RepairManifest): Promise<void> {
+  const changedEntries = manifest.entries.filter((entry) => entry.changed);
+  const invalidOnlyEntries = manifest.entries.filter((entry) => !entry.multiFrame && entry.invalidRows.length > 0);
+
+  for (const entry of changedEntries) {
+    await executor.execute(sql`
+      DELETE FROM board_climb_holds
+      WHERE board_type = ${entry.boardType} AND climb_uuid = ${entry.uuid}
+    `);
+  }
+  const insertionRows: MutationRow[] = changedEntries.flatMap((entry) =>
+    (entry.projectedRows ?? []).map((row) => ({ ...row, boardType: entry.boardType, climbUuid: entry.uuid })),
+  );
+  if (insertionRows.length > 0) {
+    const returned = await executeRows<{ board_type: string }>(
+      executor,
+      sql`
+        INSERT INTO board_climb_holds (board_type, climb_uuid, hold_id, frame_number, hold_state)
+        SELECT board_type, climb_uuid, hold_id, frame_number, hold_state
+        FROM jsonb_to_recordset(${JSON.stringify(
+          insertionRows.map((row) => ({
+            board_type: row.boardType,
+            climb_uuid: row.climbUuid,
+            hold_id: row.holdId,
+            frame_number: row.frameNumber,
+            hold_state: row.holdState,
+          })),
+        )}::jsonb) AS row(board_type text, climb_uuid text, hold_id integer, frame_number integer, hold_state text)
+        RETURNING board_type
+      `,
+    );
+    if (returned.length !== insertionRows.length) throw new Error('inserted row count did not match the manifest');
+  }
+
+  const invalidRows = invalidOnlyEntries.flatMap((entry) =>
+    entry.invalidRows.map((row) => ({ ...row, boardType: entry.boardType, climbUuid: entry.uuid })),
+  );
+  if (invalidRows.length > 0) {
+    const deleted = await executeRows<{ board_type: string }>(
+      executor,
+      sql`
+        WITH doomed AS (
+          SELECT *
+          FROM jsonb_to_recordset(${JSON.stringify(
+            invalidRows.map((row) => ({
+              board_type: row.boardType,
+              climb_uuid: row.climbUuid,
+              hold_id: row.holdId,
+              frame_number: row.frameNumber,
+              hold_state: row.holdState,
+            })),
+          )}::jsonb) AS row(board_type text, climb_uuid text, hold_id integer, frame_number integer, hold_state text)
+        )
+        DELETE FROM board_climb_holds stored
+        USING doomed
+        WHERE stored.board_type = doomed.board_type
+          AND stored.climb_uuid = doomed.climb_uuid
+          AND stored.hold_id = doomed.hold_id
+          AND stored.frame_number = doomed.frame_number
+          AND stored.hold_state = doomed.hold_state
+        RETURNING stored.board_type
+      `,
+    );
+    if (deleted.length !== invalidRows.length) throw new Error('deleted invalid row count did not match the manifest');
+  }
+
+  for (const entry of manifest.entries.filter((candidate) => candidate.fingerprint.shouldUpdate)) {
+    const updated = await executeRows<{ uuid: string }>(
+      executor,
+      sql`
+        UPDATE board_climbs
+        SET hold_fingerprint = ${entry.fingerprint.projected}
+        WHERE board_type = ${entry.boardType}
+          AND uuid = ${entry.uuid}
+          AND hold_fingerprint = ${entry.fingerprint.old}
+        RETURNING uuid
+      `,
+    );
+    if (updated.length !== 1) throw new Error(`fingerprint guard failed for ${entry.boardType}/${entry.uuid}`);
+  }
+}
+
+export async function verifyAppliedRepair(executor: RepairQueryExecutor, manifest: RepairManifest): Promise<void> {
+  const changedEntries = manifest.entries.filter((entry) => entry.changed);
+  for (const entry of changedEntries) {
+    const actual = await executeRows<{ hold_id: number; frame_number: number; hold_state: string }>(
+      executor,
+      sql`
+        SELECT hold_id, frame_number, hold_state
+        FROM board_climb_holds
+        WHERE board_type = ${entry.boardType} AND climb_uuid = ${entry.uuid}
+        ORDER BY hold_id, frame_number, hold_state
+      `,
+    );
+    const actualRows = sortRepairRows(
+      actual.map((row) => ({ holdId: row.hold_id, frameNumber: row.frame_number, holdState: row.hold_state })),
+    );
+    if (JSON.stringify(actualRows) !== JSON.stringify(entry.projectedRows)) {
+      throw new Error(`post-write row verification failed for ${entry.boardType}/${entry.uuid}`);
+    }
+  }
+  const [{ invalid_count: invalidCount } = { invalid_count: -1 }] = await executeRows<{ invalid_count: number }>(
+    executor,
+    sql`
+      SELECT COUNT(*)::integer AS invalid_count
+      FROM board_climb_holds
+      WHERE hold_id <= 0 OR hold_state = '' OR hold_state LIKE '%=%'
+    `,
+  );
+  if (invalidCount !== 0) throw new Error(`post-write global invalid row count is ${invalidCount}, expected 0`);
+}
+
+export async function runRepair(
+  args: ScriptArgs,
+  database: ReturnType<typeof createScriptDb> = createScriptDb(),
+): Promise<{ manifest: RepairManifest; digest: string; applied: boolean }> {
+  try {
+    const initialManifest = await buildManifest(database.db);
+    const initialDigest = digestRepairManifest(initialManifest);
+    printManifest(initialManifest, initialDigest, args.reportLimit, args.apply);
+    if (!args.apply) return { manifest: initialManifest, digest: initialDigest, applied: false };
+    verifyGuards(args, initialManifest, initialDigest);
+
+    await database.db.transaction(
+      async (transaction) => {
+        await transaction.execute(sql`SET LOCAL lock_timeout = '5s'`);
+        await transaction.execute(sql`SET LOCAL statement_timeout = '120s'`);
+        // At REPEATABLE READ, the first SELECT fixes the transaction snapshot.
+        // Take both writer-blocking table locks before the advisory-lock SELECT
+        // so the manifest sees commits from writers that were already in flight.
+        await transaction.execute(sql`LOCK TABLE board_climbs IN SHARE ROW EXCLUSIVE MODE`);
+        await transaction.execute(sql`LOCK TABLE board_climb_holds IN SHARE ROW EXCLUSIVE MODE`);
+        await transaction.execute(sql`SELECT pg_advisory_xact_lock(hashtext('boardsesh:repair-board-climb-holds:v1'))`);
+
+        const lockedManifest = await buildManifest(transaction);
+        const lockedDigest = digestRepairManifest(lockedManifest);
+        verifyGuards(args, lockedManifest, lockedDigest);
+        await applyRepairManifest(transaction, lockedManifest);
+        await verifyAppliedRepair(transaction, lockedManifest);
+      },
+      { isolationLevel: 'repeatable read' },
+    );
+    console.info('[repair-board-climb-holds] apply committed and post-write verification passed');
+    return { manifest: initialManifest, digest: initialDigest, applied: true };
+  } finally {
+    await database.close();
+  }
+}
+
+function printHelp(): void {
+  console.info(`Usage:
+  vp run db:repair-board-climb-holds
+  vp run db:repair-board-climb-holds -- --report-limit 100
+  vp run db:repair-board-climb-holds -- --apply \\
+    --expected-digest <sha256> --expected-scanned <n> \\
+    --expected-changed <n> --expected-invalid <n> --max-affected <n>
+
+Dry-run is the default. Apply guards must exactly match a reviewed dry-run.`);
+}
+
+async function main(): Promise<void> {
+  try {
+    const args = parseRepairArgs(process.argv.slice(2));
+    if (args.help) {
+      printHelp();
+      return;
+    }
+    const databaseUrl = getScriptDatabaseUrl();
+    console.info(`[repair-board-climb-holds] database_host=${describeDatabaseHost(databaseUrl)}`);
+    await runRepair(args, createScriptDb(databaseUrl));
+  } catch (error) {
+    console.error('[repair-board-climb-holds] failed:', error);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  void main();
+}

--- a/packages/db/scripts/repair-board-climb-holds.ts
+++ b/packages/db/scripts/repair-board-climb-holds.ts
@@ -415,9 +415,9 @@ export async function runRepair(
       async (transaction) => {
         await transaction.execute(sql`SET LOCAL lock_timeout = '5s'`);
         await transaction.execute(sql`SET LOCAL statement_timeout = '120s'`);
-        // At REPEATABLE READ, the first SELECT fixes the transaction snapshot.
-        // Take both writer-blocking table locks before the advisory-lock SELECT
-        // so the manifest sees commits from writers that were already in flight.
+        // At REPEATABLE READ, the advisory-lock SELECT below is the first
+        // snapshot-taking command. Take both writer-blocking table locks before
+        // it so the manifest sees commits from writers that were already in flight.
         await transaction.execute(sql`LOCK TABLE board_climbs IN SHARE ROW EXCLUSIVE MODE`);
         await transaction.execute(sql`LOCK TABLE board_climb_holds IN SHARE ROW EXCLUSIVE MODE`);
         await transaction.execute(sql`SELECT pg_advisory_xact_lock(hashtext('boardsesh:repair-board-climb-holds:v1'))`);
@@ -435,6 +435,20 @@ export async function runRepair(
   } finally {
     await database.close();
   }
+}
+
+export function getRepairOperatorHint(error: unknown): string | null {
+  let current: unknown = error;
+  const seen = new Set<object>();
+  for (let depth = 0; depth < 4 && typeof current === 'object' && current !== null; depth += 1) {
+    if (seen.has(current)) break;
+    seen.add(current);
+    if ('code' in current && current.code === '55P03') {
+      return 'could not acquire repair locks within 5 seconds; retry after write traffic drops';
+    }
+    current = 'cause' in current ? current.cause : undefined;
+  }
+  return null;
 }
 
 function printHelp(): void {
@@ -459,7 +473,12 @@ async function main(): Promise<void> {
     console.info(`[repair-board-climb-holds] database_host=${describeDatabaseHost(databaseUrl)}`);
     await runRepair(args, createScriptDb(databaseUrl));
   } catch (error) {
-    console.error('[repair-board-climb-holds] failed:', error);
+    const operatorHint = getRepairOperatorHint(error);
+    if (operatorHint) {
+      console.error(`[repair-board-climb-holds] failed: ${operatorHint}`, error);
+    } else {
+      console.error('[repair-board-climb-holds] failed:', error);
+    }
     process.exitCode = 1;
   }
 }

--- a/packages/db/scripts/repair-board-climb-holds.ts
+++ b/packages/db/scripts/repair-board-climb-holds.ts
@@ -489,9 +489,10 @@ export async function runRepair(
       async (transaction) => {
         await transaction.execute(sql`SET LOCAL lock_timeout = '5s'`);
         await transaction.execute(sql`SET LOCAL statement_timeout = '120s'`);
-        // At REPEATABLE READ, the advisory-lock SELECT below is the first
-        // snapshot-taking command. Take both writer-blocking table locks before
-        // it so the manifest sees commits from writers that were already in flight.
+        // LOCK TABLE does not freeze a REPEATABLE READ view; PostgreSQL freezes
+        // it at the first SELECT or data-modification statement. Keep both
+        // writer-blocking locks before the advisory-lock SELECT so the manifest
+        // includes writers that committed while lock acquisition waited.
         await transaction.execute(sql`LOCK TABLE board_climbs IN SHARE ROW EXCLUSIVE MODE`);
         await transaction.execute(sql`LOCK TABLE board_climb_holds IN SHARE ROW EXCLUSIVE MODE`);
         await transaction.execute(sql`SELECT pg_advisory_xact_lock(hashtext('boardsesh:repair-board-climb-holds:v1'))`);

--- a/packages/db/scripts/repair-board-climb-holds.ts
+++ b/packages/db/scripts/repair-board-climb-holds.ts
@@ -117,7 +117,7 @@ type CandidateJoinedRow = {
   hold_state: string | null;
 };
 
-async function fetchCandidateClimbs(executor: RepairQueryExecutor): Promise<RepairClimbInput[]> {
+export async function fetchCandidateClimbs(executor: RepairQueryExecutor): Promise<RepairClimbInput[]> {
   const joinedRows = await executeRows<CandidateJoinedRow>(
     executor,
     sql`
@@ -149,6 +149,11 @@ async function fetchCandidateClimbs(executor: RepairQueryExecutor): Promise<Repa
             ELSE NULL
           END AS hold_fingerprint
         FROM candidate_identity
+        -- board_climbs.uuid is the table's global primary key. This UUID-only
+        -- join is deliberate: a corrupt board_climb_holds row can carry a
+        -- different board_type from its parent while its FK still references
+        -- only uuid. Keeping that child identity lets the repair delete it;
+        -- joining board_type here would strand the invalid row.
         INNER JOIN board_climbs bc ON bc.uuid = candidate_identity.uuid
       )
       SELECT
@@ -288,15 +293,35 @@ function printManifest(manifest: RepairManifest, digest: string, reportLimit: nu
 
 type MutationRow = RepairHoldRow & { boardType: string; climbUuid: string };
 
+function climbIdentityKey(boardType: string, climbUuid: string): string {
+  return `${boardType}\u0000${climbUuid}`;
+}
+
 export async function applyRepairManifest(executor: RepairQueryExecutor, manifest: RepairManifest): Promise<void> {
   const changedEntries = manifest.entries.filter((entry) => entry.changed);
   const invalidOnlyEntries = manifest.entries.filter((entry) => !entry.multiFrame && entry.invalidRows.length > 0);
 
-  for (const entry of changedEntries) {
-    await executor.execute(sql`
-      DELETE FROM board_climb_holds
-      WHERE board_type = ${entry.boardType} AND climb_uuid = ${entry.uuid}
-    `);
+  if (changedEntries.length > 0) {
+    const deleted = await executeRows<{ board_type: string }>(
+      executor,
+      sql`
+        WITH changed AS (
+          SELECT *
+          FROM jsonb_to_recordset(${JSON.stringify(
+            changedEntries.map((entry) => ({ board_type: entry.boardType, climb_uuid: entry.uuid })),
+          )}::jsonb) AS row(board_type text, climb_uuid text)
+        )
+        DELETE FROM board_climb_holds stored
+        USING changed
+        WHERE stored.board_type = changed.board_type
+          AND stored.climb_uuid = changed.climb_uuid
+        RETURNING stored.board_type
+      `,
+    );
+    const expectedDeletedRows = changedEntries.reduce((total, entry) => total + entry.oldRows.length, 0);
+    if (deleted.length !== expectedDeletedRows) {
+      throw new Error('deleted changed-row count did not match the manifest');
+    }
   }
   const insertionRows: MutationRow[] = changedEntries.flatMap((entry) =>
     (entry.projectedRows ?? []).map((row) => ({ ...row, boardType: entry.boardType, climbUuid: entry.uuid })),
@@ -354,37 +379,79 @@ export async function applyRepairManifest(executor: RepairQueryExecutor, manifes
     if (deleted.length !== invalidRows.length) throw new Error('deleted invalid row count did not match the manifest');
   }
 
-  for (const entry of manifest.entries.filter((candidate) => candidate.fingerprint.shouldUpdate)) {
-    const updated = await executeRows<{ uuid: string }>(
+  const fingerprintUpdates = manifest.entries.filter((candidate) => candidate.fingerprint.shouldUpdate);
+  if (fingerprintUpdates.length > 0) {
+    const updated = await executeRows<{ board_type: string; uuid: string }>(
       executor,
       sql`
-        UPDATE board_climbs
-        SET hold_fingerprint = ${entry.fingerprint.projected}
-        WHERE board_type = ${entry.boardType}
-          AND uuid = ${entry.uuid}
-          AND hold_fingerprint = ${entry.fingerprint.old}
-        RETURNING uuid
+        WITH changes AS (
+          SELECT *
+          FROM jsonb_to_recordset(${JSON.stringify(
+            fingerprintUpdates.map((entry) => ({
+              board_type: entry.boardType,
+              uuid: entry.uuid,
+              old_fingerprint: entry.fingerprint.old,
+              projected_fingerprint: entry.fingerprint.projected,
+            })),
+          )}::jsonb)
+            AS row(board_type text, uuid text, old_fingerprint text, projected_fingerprint text)
+        )
+        UPDATE board_climbs stored
+        SET hold_fingerprint = changes.projected_fingerprint
+        FROM changes
+        WHERE stored.board_type = changes.board_type
+          AND stored.uuid = changes.uuid
+          AND stored.hold_fingerprint IS NOT DISTINCT FROM changes.old_fingerprint
+        RETURNING stored.board_type, stored.uuid
       `,
     );
-    if (updated.length !== 1) throw new Error(`fingerprint guard failed for ${entry.boardType}/${entry.uuid}`);
+    const updatedKeys = new Set(updated.map((row) => climbIdentityKey(row.board_type, row.uuid)));
+    const failedKeys = fingerprintUpdates
+      .filter((entry) => !updatedKeys.has(climbIdentityKey(entry.boardType, entry.uuid)))
+      .map((entry) => `${entry.boardType}/${entry.uuid}`);
+    if (updated.length !== fingerprintUpdates.length || failedKeys.length > 0) {
+      throw new Error(`fingerprint guard failed for ${failedKeys.join(', ') || 'unexpected duplicate identity'}`);
+    }
   }
 }
 
 export async function verifyAppliedRepair(executor: RepairQueryExecutor, manifest: RepairManifest): Promise<void> {
   const changedEntries = manifest.entries.filter((entry) => entry.changed);
-  for (const entry of changedEntries) {
-    const actual = await executeRows<{ hold_id: number; frame_number: number; hold_state: string }>(
+  const actualRowsByIdentity = new Map<string, RepairHoldRow[]>(
+    changedEntries.map((entry) => [climbIdentityKey(entry.boardType, entry.uuid), []]),
+  );
+  if (changedEntries.length > 0) {
+    const actual = await executeRows<{
+      board_type: string;
+      climb_uuid: string;
+      hold_id: number;
+      frame_number: number;
+      hold_state: string;
+    }>(
       executor,
       sql`
-        SELECT hold_id, frame_number, hold_state
-        FROM board_climb_holds
-        WHERE board_type = ${entry.boardType} AND climb_uuid = ${entry.uuid}
-        ORDER BY hold_id, frame_number, hold_state
+        WITH targets AS (
+          SELECT *
+          FROM jsonb_to_recordset(${JSON.stringify(
+            changedEntries.map((entry) => ({ board_type: entry.boardType, climb_uuid: entry.uuid })),
+          )}::jsonb) AS row(board_type text, climb_uuid text)
+        )
+        SELECT stored.board_type, stored.climb_uuid, stored.hold_id, stored.frame_number, stored.hold_state
+        FROM board_climb_holds stored
+        INNER JOIN targets
+          ON targets.board_type = stored.board_type
+         AND targets.climb_uuid = stored.climb_uuid
+        ORDER BY stored.board_type, stored.climb_uuid, stored.hold_id, stored.frame_number, stored.hold_state
       `,
     );
-    const actualRows = sortRepairRows(
-      actual.map((row) => ({ holdId: row.hold_id, frameNumber: row.frame_number, holdState: row.hold_state })),
-    );
+    for (const row of actual) {
+      const identityRows = actualRowsByIdentity.get(climbIdentityKey(row.board_type, row.climb_uuid));
+      if (!identityRows) throw new Error(`post-write verification returned an unexpected identity`);
+      identityRows.push({ holdId: row.hold_id, frameNumber: row.frame_number, holdState: row.hold_state });
+    }
+  }
+  for (const entry of changedEntries) {
+    const actualRows = sortRepairRows(actualRowsByIdentity.get(climbIdentityKey(entry.boardType, entry.uuid)) ?? []);
     if (JSON.stringify(actualRows) !== JSON.stringify(entry.projectedRows)) {
       throw new Error(`post-write row verification failed for ${entry.boardType}/${entry.uuid}`);
     }

--- a/packages/db/scripts/tsconfig.json
+++ b/packages/db/scripts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "..",
+    "types": ["node"]
+  },
+  "include": ["."]
+}

--- a/packages/db/scripts/tsconfig.json
+++ b/packages/db/scripts/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
-    "rootDir": "..",
+    // Scripts legitimately import sibling packages (`../../board-constants`,
+    // `../../../scripts/lib`), so the root has to be the monorepo root or
+    // every cross-package import trips TS6059 during type-aware lint.
+    "rootDir": "../../..",
     "types": ["node"]
   },
   "include": ["."]

--- a/packages/kilter-sync/src/sync/catalog-fingerprint-compat.test.ts
+++ b/packages/kilter-sync/src/sync/catalog-fingerprint-compat.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  legacyAuroraRawFrameHoldEvents,
+  projectAuroraFramesToStoredRows,
+} from '@boardsesh/board-constants/hold-states';
+
+import {
+  decideCatalogFingerprint,
+  enrichFingerprintOwnersWithLegacyCompatibility,
+  partitionLegacyFingerprintCompatibilityRows,
+  type LegacyFingerprintCompatibilityRow,
+} from './catalog-fingerprint-compat';
+import { decodeGripsClimbConcat } from './catalog-parse';
+import { fingerprintFromHolds } from './fingerprint';
+
+function legacyFingerprint(frames: string): string {
+  return fingerprintFromHolds(legacyAuroraRawFrameHoldEvents(frames, 'kilter'));
+}
+
+function projectedFingerprint(frames: string): string {
+  return fingerprintFromHolds(projectAuroraFramesToStoredRows(frames, 'kilter').rows);
+}
+
+function compatibilityRow(
+  uuid: string,
+  frames: string,
+  fingerprint = legacyFingerprint(frames),
+  layoutId = 1,
+): LegacyFingerprintCompatibilityRow {
+  return { layoutId, uuid, frames, fingerprint };
+}
+
+describe('legacy fingerprint compatibility index', () => {
+  it('partitions the single preload by layout without reordering rows', () => {
+    const rows = [compatibilityRow('layout-8-a', 'p1r12', undefined, 8), compatibilityRow('layout-1', 'p2r13')];
+    const partitioned = partitionLegacyFingerprintCompatibilityRows([
+      ...rows,
+      compatibilityRow('layout-8-b', 'p3r14', undefined, 8),
+    ]);
+
+    expect(partitioned.get(1)?.map((row) => row.uuid)).toEqual(['layout-1']);
+    expect(partitioned.get(8)?.map((row) => row.uuid)).toEqual(['layout-8-a', 'layout-8-b']);
+  });
+
+  it('bridges relights and unknown sentinels only after proving their legacy hashes', () => {
+    const relight = compatibilityRow('historical-relight', 'p1r12,"x1p1r13');
+    const unknownThenValid = compatibilityRow('historical-unknown', 'p2r999,"p2r13');
+    const storedOwners = new Map([
+      [relight.fingerprint, relight.uuid],
+      [unknownThenValid.fingerprint, unknownThenValid.uuid],
+    ]);
+
+    const enriched = enrichFingerprintOwnersWithLegacyCompatibility(storedOwners, [relight, unknownThenValid]);
+
+    expect(relight.fingerprint).not.toBe(projectedFingerprint(relight.frames));
+    expect(legacyAuroraRawFrameHoldEvents(unknownThenValid.frames, 'kilter')[0]?.holdState).toBe('2=999');
+    expect(enriched.get(projectedFingerprint(relight.frames))).toBe(relight.uuid);
+    expect(enriched.get(projectedFingerprint(unknownThenValid.frames))).toBe(unknownThenValid.uuid);
+    expect(storedOwners.has(projectedFingerprint(relight.frames))).toBe(false);
+  });
+
+  it('rejects independent fingerprints and rows that are not the stored fingerprint primary owner', () => {
+    const independent = compatibilityRow('independent', 'p1r12,"p1r13', 'independent-source');
+    const duplicateOwner = compatibilityRow('secondary-owner', 'p2r12,"p2r13');
+    const storedOwners = new Map([
+      [independent.fingerprint, independent.uuid],
+      [duplicateOwner.fingerprint, 'primary-owner'],
+    ]);
+
+    const enriched = enrichFingerprintOwnersWithLegacyCompatibility(storedOwners, [independent, duplicateOwner]);
+
+    expect(enriched.has(projectedFingerprint(independent.frames))).toBe(false);
+    expect(enriched.has(projectedFingerprint(duplicateOwner.frames))).toBe(false);
+  });
+
+  it('never replaces a projected primary owner or indexes an empty projection', () => {
+    const occupiedProjection = compatibilityRow('historical', 'p1r12,"p1r13');
+    const emptyProjection = compatibilityRow('invalid-only', 'p0r12,"p-2r13');
+    const existingProjectedOwner = 'already-current-owner';
+    const storedOwners = new Map([
+      [occupiedProjection.fingerprint, occupiedProjection.uuid],
+      [projectedFingerprint(occupiedProjection.frames), existingProjectedOwner],
+      [emptyProjection.fingerprint, emptyProjection.uuid],
+    ]);
+
+    const enriched = enrichFingerprintOwnersWithLegacyCompatibility(storedOwners, [
+      occupiedProjection,
+      emptyProjection,
+    ]);
+
+    expect(enriched.get(projectedFingerprint(occupiedProjection.frames))).toBe(existingProjectedOwner);
+    expect(projectAuroraFramesToStoredRows(emptyProjection.frames, 'kilter').rows).toEqual([]);
+    expect(enriched.has(fingerprintFromHolds([]))).toBe(false);
+  });
+
+  it('leaves current rows unchanged and keeps the first bridge when legacy encodings share a projection', () => {
+    const currentFrames = 'p1r12,"x1p1r13';
+    const current = compatibilityRow('already-repaired', currentFrames, projectedFingerprint(currentFrames));
+    const first = compatibilityRow('first-legacy-owner', 'p2r12,"x2p2r13');
+    const second = compatibilityRow('second-legacy-owner', 'p2r12,"x2p2r14');
+    const storedOwners = new Map([
+      [current.fingerprint, current.uuid],
+      [first.fingerprint, first.uuid],
+      [second.fingerprint, second.uuid],
+    ]);
+
+    const enriched = enrichFingerprintOwnersWithLegacyCompatibility(storedOwners, [current, first, second]);
+
+    expect(enriched.size).toBe(storedOwners.size + 1);
+    expect(enriched.get(projectedFingerprint(currentFrames))).toBe(current.uuid);
+    expect(projectedFingerprint(first.frames)).toBe(projectedFingerprint(second.frames));
+    expect(enriched.get(projectedFingerprint(first.frames))).toBe(first.uuid);
+  });
+
+  it('bridges a delayed-start animation using its original legacy frame ordinal', () => {
+    const decoded = decodeGripsClimbConcat('h10p13s2', new Map([[10, 100]]), 2);
+    if (!decoded.ok) throw new Error(`unexpected decode failure: ${decoded.reason}`);
+    expect(decoded.frames).toBe(',"p100r13');
+    expect(legacyAuroraRawFrameHoldEvents(decoded.frames, 'kilter')).toEqual([
+      { holdId: 100, frameNumber: 1, holdState: 'HAND' },
+    ]);
+    expect(decoded.holds).toEqual([{ holdId: 100, frameNumber: 0, holdState: 'HAND' }]);
+
+    const historical = compatibilityRow('historical-canonical', decoded.frames);
+    expect(historical.fingerprint).not.toBe(fingerprintFromHolds(decoded.holds));
+    const enriched = enrichFingerprintOwnersWithLegacyCompatibility(
+      new Map([[historical.fingerprint, historical.uuid]]),
+      [historical],
+    );
+    expect(enriched.get(fingerprintFromHolds(decoded.holds))).toBe(historical.uuid);
+
+    const decision = decideCatalogFingerprint(enriched, 'incoming-alias', decoded.holds);
+
+    expect(decision.canonicalUuid).toBe(historical.uuid);
+    expect(decision.canonicalToInsert).toBeNull();
+    expect(decision.holdRowsToInsert).toEqual([]);
+  });
+});

--- a/packages/kilter-sync/src/sync/catalog-fingerprint-compat.test.ts
+++ b/packages/kilter-sync/src/sync/catalog-fingerprint-compat.test.ts
@@ -112,6 +112,37 @@ describe('legacy fingerprint compatibility index', () => {
     expect(enriched.get(projectedFingerprint(first.frames))).toBe(first.uuid);
   });
 
+  it('never dedups two hold-less climbs onto each other', () => {
+    const firstEmpty = decodeGripsClimbConcat('h10p999', new Map([[10, 100]]), 1);
+    const secondEmpty = decodeGripsClimbConcat('h20p999', new Map([[20, 200]]), 1);
+    if (!firstEmpty.ok || !secondEmpty.ok) throw new Error('unexpected decode failure');
+    expect(firstEmpty.holds).toEqual([]);
+    expect(secondEmpty.holds).toEqual([]);
+
+    const fingerprintOwners = new Map<string, string>();
+    const firstDecision = decideCatalogFingerprint(fingerprintOwners, 'first-empty', firstEmpty.holds);
+    expect(firstDecision.fingerprint).toBeNull();
+    expect(firstDecision.canonicalToInsert).toBe('first-empty');
+    if (firstDecision.fingerprint !== null) fingerprintOwners.set(firstDecision.fingerprint, 'first-empty');
+
+    const secondDecision = decideCatalogFingerprint(fingerprintOwners, 'second-empty', secondEmpty.holds);
+
+    expect(fingerprintOwners.has(fingerprintFromHolds([]))).toBe(false);
+    expect(secondDecision.fingerprint).toBeNull();
+    expect(secondDecision.canonicalUuid).toBe('second-empty');
+    expect(secondDecision.canonicalToInsert).toBe('second-empty');
+  });
+
+  it('ignores a stored SHA256(empty) owner instead of aliasing onto it', () => {
+    const strandedEmptyOwner = new Map([[fingerprintFromHolds([]), 'stranded-empty-canonical']]);
+
+    const decision = decideCatalogFingerprint(strandedEmptyOwner, 'incoming-empty', []);
+
+    expect(decision.fingerprint).toBeNull();
+    expect(decision.canonicalUuid).toBe('incoming-empty');
+    expect(decision.canonicalToInsert).toBe('incoming-empty');
+  });
+
   it('bridges a delayed-start animation using its original legacy frame ordinal', () => {
     const decoded = decodeGripsClimbConcat('h10p13s2', new Map([[10, 100]]), 2);
     if (!decoded.ok) throw new Error(`unexpected decode failure: ${decoded.reason}`);

--- a/packages/kilter-sync/src/sync/catalog-fingerprint-compat.ts
+++ b/packages/kilter-sync/src/sync/catalog-fingerprint-compat.ts
@@ -1,0 +1,107 @@
+import {
+  legacyAuroraRawFrameHoldEvents,
+  projectAuroraFramesToStoredRows,
+} from '@boardsesh/board-constants/hold-states';
+
+import { fingerprintFromHolds, type HoldTuple } from './fingerprint';
+
+const KILTER = 'kilter';
+
+export type LegacyFingerprintCompatibilityRow = {
+  layoutId: number;
+  uuid: string;
+  frames: string;
+  fingerprint: string;
+};
+
+export type StoredFingerprintOwnerRow = {
+  uuid: string;
+  fingerprint: string | null;
+};
+
+/** Keep the first row for each stored fingerprint; callers define its stable order. */
+export function indexStoredFingerprintOwners(rows: ReadonlyArray<StoredFingerprintOwnerRow>): Map<string, string> {
+  const fingerprintOwners = new Map<string, string>();
+  for (const row of rows) {
+    if (row.fingerprint && !fingerprintOwners.has(row.fingerprint)) {
+      fingerprintOwners.set(row.fingerprint, row.uuid);
+    }
+  }
+  return fingerprintOwners;
+}
+
+/** Partition one catalog-wide preload into the rows needed by each layout group. */
+export function partitionLegacyFingerprintCompatibilityRows(
+  rows: ReadonlyArray<LegacyFingerprintCompatibilityRow>,
+): Map<number, LegacyFingerprintCompatibilityRow[]> {
+  const rowsByLayout = new Map<number, LegacyFingerprintCompatibilityRow[]>();
+  for (const row of rows) {
+    const layoutRows = rowsByLayout.get(row.layoutId) ?? [];
+    layoutRows.push(row);
+    rowsByLayout.set(row.layoutId, layoutRows);
+  }
+  return rowsByLayout;
+}
+
+/**
+ * Add temporary projected-hash lookup keys for rows whose stored fingerprint
+ * is proven to be the pre-6e93 raw-event hash. The stored index remains the
+ * authority: compatibility keys never replace an owner and never mutate the
+ * caller's map.
+ */
+export function enrichFingerprintOwnersWithLegacyCompatibility(
+  storedFingerprintOwners: ReadonlyMap<string, string>,
+  compatibilityRows: ReadonlyArray<LegacyFingerprintCompatibilityRow>,
+): Map<string, string> {
+  const enrichedFingerprintOwners = new Map(storedFingerprintOwners);
+
+  for (const row of compatibilityRows) {
+    const legacyEvents = legacyAuroraRawFrameHoldEvents(row.frames, KILTER);
+    if (legacyEvents.length === 0) continue;
+
+    const legacyFingerprint = fingerprintFromHolds(legacyEvents);
+    if (row.fingerprint !== legacyFingerprint) continue;
+    if (storedFingerprintOwners.get(row.fingerprint) !== row.uuid) continue;
+
+    const projectedRows = projectAuroraFramesToStoredRows(row.frames, KILTER).rows;
+    if (projectedRows.length === 0) continue;
+
+    const projectedFingerprint = fingerprintFromHolds(projectedRows);
+    if (enrichedFingerprintOwners.has(projectedFingerprint)) continue;
+    enrichedFingerprintOwners.set(projectedFingerprint, row.uuid);
+  }
+
+  return enrichedFingerprintOwners;
+}
+
+export type CatalogFingerprintDecision = {
+  fingerprint: string;
+  canonicalUuid: string;
+  canonicalToInsert: string | null;
+  holdRowsToInsert: HoldTuple[];
+};
+
+/** Pure fingerprint decision used by the catalog's alias-vs-canonical branch. */
+export function decideCatalogFingerprint(
+  fingerprintOwners: ReadonlyMap<string, string>,
+  incomingUuid: string,
+  projectedRows: ReadonlyArray<HoldTuple>,
+): CatalogFingerprintDecision {
+  const holdRowsToInsert = [...projectedRows];
+  const fingerprint = fingerprintFromHolds(holdRowsToInsert);
+  const existingCanonicalUuid = fingerprintOwners.get(fingerprint);
+  if (existingCanonicalUuid) {
+    return {
+      fingerprint,
+      canonicalUuid: existingCanonicalUuid,
+      canonicalToInsert: null,
+      holdRowsToInsert: [],
+    };
+  }
+  return {
+    fingerprint,
+    canonicalUuid: incomingUuid,
+    canonicalToInsert: incomingUuid,
+    holdRowsToInsert,
+  };
+}

--- a/packages/kilter-sync/src/sync/catalog-fingerprint-compat.ts
+++ b/packages/kilter-sync/src/sync/catalog-fingerprint-compat.ts
@@ -75,19 +75,37 @@ export function enrichFingerprintOwnersWithLegacyCompatibility(
 }
 
 export type CatalogFingerprintDecision = {
-  fingerprint: string;
+  /** `null` when the climb projects to no holds — see `decideCatalogFingerprint`. */
+  fingerprint: string | null;
   canonicalUuid: string;
   canonicalToInsert: string | null;
   holdRowsToInsert: HoldTuple[];
 };
 
-/** Pure fingerprint decision used by the catalog's alias-vs-canonical branch. */
+/**
+ * Pure fingerprint decision used by the catalog's alias-vs-canonical branch.
+ *
+ * A climb that projects to no stored rows — every token an unknown role or a
+ * nonpositive placement — has no hold identity to dedup on. Hashing it anyway
+ * yields SHA256(''), the constant the repair script clears back to NULL, and
+ * would make the first hold-less climb the canonical for every later one. Such
+ * a climb is inserted as its own canonical with a NULL fingerprint and never
+ * enters the owner index, matching `enrichFingerprintOwnersWithLegacyCompatibility`.
+ */
 export function decideCatalogFingerprint(
   fingerprintOwners: ReadonlyMap<string, string>,
   incomingUuid: string,
   projectedRows: ReadonlyArray<HoldTuple>,
 ): CatalogFingerprintDecision {
   const holdRowsToInsert = [...projectedRows];
+  if (holdRowsToInsert.length === 0) {
+    return {
+      fingerprint: null,
+      canonicalUuid: incomingUuid,
+      canonicalToInsert: incomingUuid,
+      holdRowsToInsert,
+    };
+  }
   const fingerprint = fingerprintFromHolds(holdRowsToInsert);
   const existingCanonicalUuid = fingerprintOwners.get(fingerprint);
   if (existingCanonicalUuid) {

--- a/packages/kilter-sync/src/sync/catalog-parse.test.ts
+++ b/packages/kilter-sync/src/sync/catalog-parse.test.ts
@@ -182,11 +182,29 @@ void describe('decodeGripsClimbConcat — holds and fingerprint', () => {
     ]);
   });
 
-  it('gives a real animated climb one hold row per lit token, never one per clear', () => {
+  it('gives a real animated climb one canonical row per placement', () => {
     const climb = fixtureClimb('DA658EAACBE54AC89DB4060ED07BAF6C');
     const result = decodeOk(climb.climbConcat, fixtureRemap(climb), climb.frameCount);
-    expect(result.holds).toHaveLength((climb.climbConcat.match(/h\d+p\d+/g) ?? []).length);
+    const holdIds = result.holds.map((hold) => hold.holdId);
+    expect(holdIds).toHaveLength(new Set(holdIds).size);
     expect(result.holds.every((hold) => hold.frameNumber < climb.frameCount)).toBe(true);
+
+    const relitPlacement = climb.holeToPlacement['1549'];
+    expect(result.holds.filter((hold) => hold.holdId === relitPlacement)).toEqual([
+      { holdId: relitPlacement, holdState: 'HAND', frameNumber: 13 },
+    ]);
+  });
+
+  it('skips an unknown first role but accepts the same placement when it later has a valid role', () => {
+    expect(decodeOk('h10p999e1h10p13s2', REMAP, 2).holds).toEqual([{ holdId: 100, holdState: 'HAND', frameNumber: 1 }]);
+  });
+
+  it('fingerprints a re-lit placement from the same canonical row the table stores', () => {
+    const decoded = decodeOk('h10p12e1h10p14s2', REMAP, 2);
+    expect(decoded.holds).toEqual([{ holdId: 100, holdState: 'STARTING', frameNumber: 0 }]);
+    expect(fingerprintFromHolds(decoded.holds)).toBe(
+      fingerprintFromHolds([{ holdId: 100, holdState: 'STARTING', frameNumber: 0 }]),
+    );
   });
 
   it('fingerprints identically regardless of hold order (sorted tuples)', () => {

--- a/packages/kilter-sync/src/sync/catalog-parse.ts
+++ b/packages/kilter-sync/src/sync/catalog-parse.ts
@@ -1,4 +1,4 @@
-import { HOLD_STATE_MAP } from '@boardsesh/board-constants/hold-states';
+import { projectAuroraFramesToStoredRows } from '@boardsesh/board-constants/hold-states';
 
 import { type HoldTuple } from './fingerprint';
 
@@ -151,7 +151,6 @@ export function decodeGripsClimbConcat(
   // holds on the wall.
   if (consumed !== climbConcat.length) return { ok: false, reason: 'unparsable_concat', offset: consumed };
 
-  const holds: HoldTuple[] = [];
   const frameStrings: string[] = [];
   for (let frameNumber = 0; frameNumber < totalFrames; frameNumber += 1) {
     const sets = setsByFrame.get(frameNumber);
@@ -176,27 +175,16 @@ export function decodeGripsClimbConcat(
         continue;
       }
       frameString += `p${entry.placementId}r${entry.roleCode}`;
-      holds.push({
-        holdId: entry.placementId,
-        frameNumber,
-        holdState: holdStateName(entry.placementId, entry.roleCode),
-      });
     }
     frameStrings.push(frameString);
   }
 
   // Aurora prefixes every frame after the first with a literal `"`.
   const frames = frameStrings.map((frameString, index) => (index === 0 ? frameString : `,"${frameString}`)).join('');
+  // Use the same first-valid projection as every other active Aurora writer.
+  // This matches the table's one-row-per-hold primary key, skips unknown-role
+  // sentinels/nonpositive IDs, and keeps the dedup fingerprint identical to
+  // the rows that are actually inserted.
+  const holds: HoldTuple[] = projectAuroraFramesToStoredRows(frames, KILTER_BOARD).rows;
   return { ok: true, frames, holds };
-}
-
-/**
- * Role code → hold-state name, mirroring `convertLitUpHoldsStringToMap` so a
- * decoded climb produces the same `board_climb_holds.hold_state` values the
- * rest of the catalog already stores. Unknown codes keep that function's
- * `{holdId}={code}` sentinel, which downstream readers (the fingerprint
- * backfill, the duplicate gate) already recognise and skip.
- */
-function holdStateName(placementId: number, roleCode: number): string {
-  return HOLD_STATE_MAP[KILTER_BOARD]?.[roleCode]?.name ?? `${placementId}=${roleCode}`;
 }

--- a/packages/kilter-sync/src/sync/catalog-sync-owner-order.test.ts
+++ b/packages/kilter-sync/src/sync/catalog-sync-owner-order.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import {
+  legacyAuroraRawFrameHoldEvents,
+  projectAuroraFramesToStoredRows,
+} from '@boardsesh/board-constants/hold-states';
+
+import {
+  enrichFingerprintOwnersWithLegacyCompatibility,
+  indexStoredFingerprintOwners,
+} from './catalog-fingerprint-compat';
+import { fingerprintFromHolds } from './fingerprint';
+import { existingCatalogLayoutRowsQuery } from './catalog-sync';
+
+const renderOnlyDb = drizzle({} as never);
+
+describe('catalog fingerprint owner ordering', () => {
+  it('orders the existing-layout query by raw UUID before first-owner indexing', () => {
+    const rendered = existingCatalogLayoutRowsQuery(renderOnlyDb, 42).toSQL();
+    const normalizedSql = rendered.sql.replaceAll(/\s+/g, ' ').trim().toLowerCase();
+
+    expect(normalizedSql).toContain('order by "board_climbs"."uuid"');
+    expect(normalizedSql).not.toContain('lower("board_climbs"."uuid")');
+    expect(rendered.params).toEqual(['kilter', 42]);
+  });
+
+  it('routes duplicate legacy owners to the stable first UUID', () => {
+    const frames = 'p100r12,"x100p100r13';
+    const legacyFingerprint = fingerprintFromHolds(legacyAuroraRawFrameHoldEvents(frames, 'kilter'));
+    const orderedExistingRows = [
+      { uuid: 'a-stable-owner', fingerprint: legacyFingerprint },
+      { uuid: 'z-secondary-owner', fingerprint: legacyFingerprint },
+    ];
+    const storedFingerprintOwners = indexStoredFingerprintOwners(orderedExistingRows);
+
+    const compatibilityRows = orderedExistingRows.map((row) => ({
+      layoutId: 42,
+      uuid: row.uuid,
+      frames,
+      fingerprint: row.fingerprint,
+    }));
+    const enriched = enrichFingerprintOwnersWithLegacyCompatibility(storedFingerprintOwners, compatibilityRows);
+    const projectedFingerprint = fingerprintFromHolds(projectAuroraFramesToStoredRows(frames, 'kilter').rows);
+
+    expect(storedFingerprintOwners.get(legacyFingerprint)).toBe('a-stable-owner');
+    expect(enriched.get(projectedFingerprint)).toBe('a-stable-owner');
+  });
+});

--- a/packages/kilter-sync/src/sync/catalog-sync.ts
+++ b/packages/kilter-sync/src/sync/catalog-sync.ts
@@ -655,8 +655,10 @@ async function syncBoardLayoutGroup(
         continue;
       }
 
-      // 3. Genuinely new canonical.
-      fingerprintToCanonical.set(fingerprint, fingerprintDecision.canonicalToInsert);
+      // 3. Genuinely new canonical. A hold-less climb carries a NULL
+      //    fingerprint and stays out of the owner index — SHA256('') is not an
+      //    identity, and indexing it would alias every later hold-less climb.
+      if (fingerprint !== null) fingerprintToCanonical.set(fingerprint, fingerprintDecision.canonicalToInsert);
       existingByLowerUuid.set(lowerUuid, climb.climbUuid);
       climbUuidToCanonical.set(lowerUuid, climb.climbUuid);
       newClimbInserts.push({

--- a/packages/kilter-sync/src/sync/catalog-sync.ts
+++ b/packages/kilter-sync/src/sync/catalog-sync.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { and, eq, gt, inArray, isNotNull, isNull, ne, sql } from 'drizzle-orm';
 import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
 import {
   boardClimbs,
@@ -34,7 +34,13 @@ import {
   summarizeSkipReasons,
   type ClimbIngestSkip,
 } from './catalog-backlog';
-import { fingerprintFromHolds } from './fingerprint';
+import {
+  decideCatalogFingerprint,
+  enrichFingerprintOwnersWithLegacyCompatibility,
+  indexStoredFingerprintOwners,
+  partitionLegacyFingerprintCompatibilityRows,
+  type LegacyFingerprintCompatibilityRow,
+} from './catalog-fingerprint-compat';
 import { createSetterSyncNotifications, type NewClimbInfo } from './notifications';
 import { reconcileDeletions, type DeletionReport } from './deletions';
 import { syncKilterLocations } from './locations-sync';
@@ -129,6 +135,61 @@ async function loadHoleToPlacement(db: DrizzleDb, layoutId: number): Promise<Map
     if (row.holeId != null) map.set(row.holeId, row.id);
   }
   return map;
+}
+
+/**
+ * Existing rows must reach the first-fingerprint-owner index in stable order.
+ * Duplicate stored fingerprints are legal, so UUID order is the tie-breaker
+ * shared with the compatibility preload below.
+ */
+export function existingCatalogLayoutRowsQuery(db: DrizzleDb, boardLayoutId: number) {
+  return db
+    .select({
+      uuid: boardClimbs.uuid,
+      fingerprint: boardClimbs.holdFingerprint,
+      isListed: boardClimbs.isListed,
+      userId: boardClimbs.userId,
+    })
+    .from(boardClimbs)
+    .where(and(eq(boardClimbs.boardType, KILTER), eq(boardClimbs.layoutId, boardLayoutId)))
+    .orderBy(boardClimbs.uuid);
+}
+
+/**
+ * Load every catalog-owned multi-frame row that could still carry the legacy
+ * raw-event fingerprint. One catalog-wide query keeps this compatibility
+ * bridge out of the per-layout hot loop; rows are partitioned in memory.
+ */
+async function loadLegacyFingerprintCompatibilityRows(
+  db: DrizzleDb,
+): Promise<Map<number, LegacyFingerprintCompatibilityRow[]>> {
+  const rows = await db
+    .select({
+      layoutId: boardClimbs.layoutId,
+      uuid: boardClimbs.uuid,
+      frames: boardClimbs.frames,
+      fingerprint: boardClimbs.holdFingerprint,
+    })
+    .from(boardClimbs)
+    .where(
+      and(
+        eq(boardClimbs.boardType, KILTER),
+        isNull(boardClimbs.userId),
+        gt(boardClimbs.framesCount, 1),
+        isNotNull(boardClimbs.frames),
+        ne(boardClimbs.frames, ''),
+        isNotNull(boardClimbs.holdFingerprint),
+      ),
+    )
+    .orderBy(boardClimbs.layoutId, boardClimbs.uuid);
+
+  return partitionLegacyFingerprintCompatibilityRows(
+    rows.flatMap((row) =>
+      row.frames && row.fingerprint
+        ? [{ layoutId: row.layoutId, uuid: row.uuid, frames: row.frames, fingerprint: row.fingerprint }]
+        : [],
+    ),
+  );
 }
 
 type GroupResult = {
@@ -442,6 +503,7 @@ async function syncBoardLayoutGroup(
   boardLayoutId: number,
   gripsLayoutUuids: string[],
   openSkips: Map<string, string>,
+  legacyFingerprintCompatibilityRows: ReadonlyArray<LegacyFingerprintCompatibilityRow>,
   log: (message: string) => void,
 ): Promise<GroupResult> {
   const result: GroupResult = {
@@ -462,27 +524,20 @@ async function syncBoardLayoutGroup(
   // Existing catalog for this layout: uuid identity + fingerprint → canonical,
   // carrying listing/ownership so the fold path can re-list a synced canonical
   // an incoming listed alias proves is back on the wall (never a user climb).
-  const existingRows = await db
-    .select({
-      uuid: boardClimbs.uuid,
-      fingerprint: boardClimbs.holdFingerprint,
-      isListed: boardClimbs.isListed,
-      userId: boardClimbs.userId,
-    })
-    .from(boardClimbs)
-    .where(and(eq(boardClimbs.boardType, KILTER), eq(boardClimbs.layoutId, boardLayoutId)));
+  const existingRows = await existingCatalogLayoutRowsQuery(db, boardLayoutId);
   const existingByLowerUuid = new Map<string, string>();
-  const fingerprintToCanonical = new Map<string, string>();
+  const storedFingerprintToCanonical = indexStoredFingerprintOwners(existingRows);
   // canonicalUuid → {isListed, userId} for DB-resident canonicals only. New
   // canonicals created this run are absent (already listed → never re-listed).
   const existingCanonicalMeta = new Map<string, { isListed: boolean | null; userId: string | null }>();
   for (const row of existingRows) {
     existingByLowerUuid.set(row.uuid.toLowerCase(), row.uuid);
     existingCanonicalMeta.set(row.uuid, { isListed: row.isListed, userId: row.userId });
-    if (row.fingerprint && !fingerprintToCanonical.has(row.fingerprint)) {
-      fingerprintToCanonical.set(row.fingerprint, row.uuid);
-    }
   }
+  const fingerprintToCanonical = enrichFingerprintOwnersWithLegacyCompatibility(
+    storedFingerprintToCanonical,
+    legacyFingerprintCompatibilityRows,
+  );
 
   // Existing self-aliases (alias_uuid = canonical_uuid) for this layout, so the
   // identity path only writes the ones actually missing (~6k historical gap;
@@ -576,14 +631,15 @@ async function syncBoardLayoutGroup(
         continue;
       }
       const { frames, holds } = decoded;
-      const fingerprint = fingerprintFromHolds(holds);
+      const fingerprintDecision = decideCatalogFingerprint(fingerprintToCanonical, climb.climbUuid, holds);
+      const { fingerprint } = fingerprintDecision;
       const resolvedByDecode = openSkips.get(lowerUuid);
       if (resolvedByDecode) result.resolvedSkipUuids.push(resolvedByDecode);
 
       // 2. Fingerprint dedup — a new UUID whose holds match an existing (or
       //    already-seen-this-run) canonical becomes an alias, not a new row.
-      const canonicalByFingerprint = fingerprintToCanonical.get(fingerprint);
-      if (canonicalByFingerprint) {
+      if (fingerprintDecision.canonicalToInsert === null) {
+        const canonicalByFingerprint = fingerprintDecision.canonicalUuid;
         climbUuidToCanonical.set(lowerUuid, canonicalByFingerprint);
         aliasRows.push({
           boardType: KILTER,
@@ -600,7 +656,7 @@ async function syncBoardLayoutGroup(
       }
 
       // 3. Genuinely new canonical.
-      fingerprintToCanonical.set(fingerprint, climb.climbUuid);
+      fingerprintToCanonical.set(fingerprint, fingerprintDecision.canonicalToInsert);
       existingByLowerUuid.set(lowerUuid, climb.climbUuid);
       climbUuidToCanonical.set(lowerUuid, climb.climbUuid);
       newClimbInserts.push({
@@ -626,7 +682,7 @@ async function syncBoardLayoutGroup(
         createdAt: climb.createdAt,
         holdFingerprint: fingerprint,
       });
-      for (const hold of holds) {
+      for (const hold of fingerprintDecision.holdRowsToInsert) {
         newHoldRows.push({
           boardType: KILTER,
           climbUuid: climb.climbUuid,
@@ -851,9 +907,18 @@ export async function syncKilterCatalog(args: SyncKilterCatalogArgs): Promise<Ki
   // The climbs already sitting unresolved in the backlog, so a run that finally
   // ingests one can stamp it resolved without scanning every climb it saw.
   const openSkips = await loadOpenSkips(args.db, KILTER);
+  const legacyFingerprintCompatibilityRowsByLayout = await loadLegacyFingerprintCompatibilityRows(args.db);
 
   for (const [boardLayoutId, gripsLayoutUuids] of byBoardLayout) {
-    const groupResult = await syncBoardLayoutGroup(args.db, state, boardLayoutId, gripsLayoutUuids, openSkips, log);
+    const groupResult = await syncBoardLayoutGroup(
+      args.db,
+      state,
+      boardLayoutId,
+      gripsLayoutUuids,
+      openSkips,
+      legacyFingerprintCompatibilityRowsByLayout.get(boardLayoutId) ?? [],
+      log,
+    );
     summary.gripsLayoutsProcessed += gripsLayoutUuids.length;
     summary.climbsSeen += groupResult.climbsSeen;
     summary.climbsUnmapped += groupResult.climbsUnmapped;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -268,6 +268,12 @@ export default defineConfig({
         // flags with `vp run db:dedupe-serial-boards -- --only-serial <s> --apply`.
         cache: false,
       },
+      'db:repair-board-climb-holds': {
+        command: 'pnpm --filter @boardsesh/db run db:repair-board-climb-holds',
+        // No db:up dependency. This is an operator-run, dry-run-by-default
+        // repair and must use the exact connection string being reviewed.
+        cache: false,
+      },
       'test:db': {
         command: 'pnpm --filter @boardsesh/db run test',
       },


### PR DESCRIPTION
## Summary

- repair stale and globally invalid `board_climb_holds` rows with a dry-run-first manifest, reviewed digest/count guards, writer-blocking transaction locks, and post-write verification
- project multi-frame Aurora climbs consistently across sync, Kilter Grips, unified imports, and backfills so the repaired rows do not drift again
- keep similar-climb matching and popular board counts correct while stale production rows await a separately approved repair run
- document the exact operator workflow, safeguards, and rollback boundary

Refs #3985

The issue stays open on purpose: this PR only lands the tooling and the guards. The production dry-run, the apply, the count verification, and the popular-config cache bust are separate operator steps that each need their own explicit approval, and #3985 tracks them until they are done.

## Release Notes

- Animated board climbs now keep the right holds for similar-climb matches and board counts after the guarded data repair is run.

## Test plan

- focused backend and active-writer suites: 134 tests passed
- focused DB helper/repair/import suites: 31 tests passed, including real PostgreSQL apply, verification, clean rerun, and rollback coverage
- full DB suite: 393 passed, 11 skipped, with the same pre-existing unrelated `create-climb-filters` assertion failures
- `vp test run --project kilter-sync`: 239 passed, 1 skipped
- `vp run typecheck` (whole monorepo)
- `vp check`: 0 errors
- `git diff --check`
- independent adversarial audit: no P0–P2 findings
- `vp run dev` loaded `.boardsesh/qa-notes.md`; homepage, backend health, and dev metadata returned 200

## Production gate

This PR does **not** run the production dry-run, apply the repair, refresh caches, or delete production data. Those operator actions remain a separate explicit approval after the dry-run digest and counts are reviewed.
