### PR TITLE
fix(mobile): keep the tick sheet's action row aligned under the keyboard

### DIFF
--- a/packages/mobile/src/components/Button.android.tsx
+++ b/packages/mobile/src/components/Button.android.tsx
@@ -23,11 +23,17 @@ import {
   Text,
   TextButton,
 } from '@expo/ui/jetpack-compose';
-import { defaultMinSize, fillMaxWidth, padding, size } from '@expo/ui/jetpack-compose/modifiers';
+import {
+  defaultMinSize,
+  fillMaxWidth,
+  height as heightModifier,
+  padding,
+  size,
+} from '@expo/ui/jetpack-compose/modifiers';
 import type { ImageSourcePropType } from 'react-native';
 import { useTheme } from '../providers/theme-provider';
 import { brandAccentColor } from '../theme/expo-ui-modifiers';
-import { isFullWidthStyle, makeButtonPressHandler } from './Button.logic';
+import { buttonFillAxes, buttonMatchContents, makeButtonPressHandler, pinnedButtonHeight } from './Button.logic';
 import { sizeConfig, type ButtonProps } from './Button.types';
 import type { IconName } from './icon-map';
 
@@ -131,7 +137,8 @@ export function Button({
           ? TextButton
           : ComposeButton;
 
-  const isFullWidth = isFullWidthStyle(style);
+  const fills = buttonFillAxes(style);
+  const pinnedHeight = pinnedButtonHeight(style);
   const iconSource = icon ? BUTTON_ICON_SOURCE[icon] : undefined;
 
   // Compose has no discrete height buckets: a button is exactly its content plus
@@ -139,18 +146,18 @@ export function Button({
   // that sit in a row of 44dp controls pass `minHeight`; `defaultMinSize` is the
   // Compose idiom for exactly that (a floor, not a fixed height, so a long label
   // or large Dynamic Type still grows the button).
+  //
+  // A pinned `height` is the caller asking for one height across a row of buttons
+  // whose native styles measure differently (the tick bar). Compose takes it
+  // directly; the Host stops measuring that axis so the value survives.
   const composeModifiers = [
-    ...(isFullWidth ? [fillMaxWidth()] : []),
+    ...(fills.width ? [fillMaxWidth()] : []),
+    ...(pinnedHeight != null ? [heightModifier(pinnedHeight)] : []),
     ...(minHeight != null ? [defaultMinSize({ minHeight })] : []),
   ];
 
   return (
-    <Host
-      matchContents={isFullWidth ? { vertical: true } : true}
-      colorScheme={colorScheme}
-      style={style}
-      testID={testID}
-    >
+    <Host matchContents={buttonMatchContents(style)} colorScheme={colorScheme} style={style} testID={testID}>
       <Comp
         onClick={handlePress}
         enabled={!(disabled || loading)}

--- a/packages/mobile/src/components/Button.ios.tsx
+++ b/packages/mobile/src/components/Button.ios.tsx
@@ -40,7 +40,7 @@ import { useGlassCapability } from '../hooks/use-glass-capability';
 import { useTheme } from '../providers/theme-provider';
 import { brandAccentColor } from '../theme/expo-ui-modifiers';
 import { overlays } from '../theme/tokens';
-import { isFullWidthStyle, makeButtonPressHandler } from './Button.logic';
+import { buttonFillAxes, buttonMatchContents, makeButtonPressHandler } from './Button.logic';
 import { useButtonSurface } from './Button.surface';
 import { iconMap } from './icon-map';
 import type { ButtonProps, ButtonSize } from './Button.types';
@@ -117,16 +117,21 @@ export function Button({
     }
   }
 
-  // A footer button styled to fill its row needs the native Button to stretch (it
-  // content-hugs otherwise); an inline button hugs its content in BOTH axes.
-  const isFullWidth = isFullWidthStyle(style);
+  // Which axes the caller sized for us: a positive `flex`/`width: '100%'` across,
+  // a pinned `height` down. An unsized axis is measured by SwiftUI instead
+  // (`matchContents`), which is the inline, content-hugging case.
+  const fills = buttonFillAxes(style);
+  const fillFrame = {
+    ...(fills.width ? { maxWidth: Infinity } : {}),
+    ...(fills.height ? { maxHeight: Infinity } : {}),
+  };
 
   const modifiers: ModifierConfig[] = [
     styleModifier,
     buttonBorderShape('roundedRectangle', radii.button),
     controlSize(CONTROL_SIZE[size]),
     font({ textStyle: TEXT_STYLE[size], weight: 'semibold' }),
-    frame({ minHeight, ...(isFullWidth ? { maxWidth: Infinity } : {}) }),
+    frame({ minHeight, ...fillFrame }),
     disabledModifier(disabled || loading),
     accessibilityLabelModifier(accessibilityLabel ?? title),
   ];
@@ -141,14 +146,12 @@ export function Button({
   const buttonRole = isDestructive ? 'destructive' : role === 'cancel' ? 'cancel' : undefined;
 
   return (
-    <Host
-      matchContents={isFullWidth ? { vertical: true } : true}
-      colorScheme={colorScheme}
-      style={style}
-      testID={testID}
-    >
+    <Host matchContents={buttonMatchContents(style)} colorScheme={colorScheme} style={style} testID={testID}>
       <SwiftUIButton role={buttonRole} onPress={handlePress} modifiers={modifiers}>
-        <HStack spacing={6}>
+        {/* The fill frame is repeated on the LABEL because that is the view
+            `.buttonStyle()` paints its background around — see buttonFillAxes.
+            The copy on the Button itself only keeps the tap target honest. */}
+        <HStack spacing={6} modifiers={fills.width || fills.height ? [frame(fillFrame)] : undefined}>
           {loading ? (
             <ProgressView modifiers={[tint(spinnerColor)]} />
           ) : icon ? (

--- a/packages/mobile/src/components/Button.logic.ts
+++ b/packages/mobile/src/components/Button.logic.ts
@@ -42,3 +42,44 @@ export function makeButtonPressHandler(
     onPress();
   };
 }
+
+/**
+ * The height a caller has pinned on a Button, if any. A row that pairs two
+ * buttons of DIFFERENT native styles (the tick bar's tonal Attempt beside the
+ * filled Send) can't get them to one height any other way: each style derives
+ * its own padding, so the two pills measure differently from the same label.
+ *
+ * Only a number counts. A percentage or `auto` can't be handed to a native
+ * fixed-height modifier, and `undefined` is the normal "size yourself" case.
+ */
+export function pinnedButtonHeight(style: ViewStyle | undefined): number | undefined {
+  return typeof style?.height === 'number' ? style.height : undefined;
+}
+
+/**
+ * Which axes the native control must fill to match the RN box it was given.
+ *
+ * The iOS half of this is the load-bearing part: `.buttonStyle()` paints its
+ * background around the button's LABEL, and every modifier applied to the
+ * `Button` itself lands outside that paint. So a `frame(maxWidth: .infinity)`
+ * on the button widens only the tap area and leaves a pill hugging its text,
+ * centred in the leftover space — growing the LABEL is what grows the pill.
+ * Returned as one record so both platform files ask the same question.
+ */
+export function buttonFillAxes(style: ViewStyle | undefined): { width: boolean; height: boolean } {
+  return { width: isFullWidthStyle(style), height: pinnedButtonHeight(style) != null };
+}
+
+/**
+ * `Host`'s `matchContents` for a Button: which axes the SwiftUI/Compose content
+ * measures for itself, overwriting the RN style with `setStyleSize`.
+ *
+ * An axis the caller has sized — a positive `flex` across, a pinned `height`
+ * down — must NOT be measured, or the native size is written back over the one
+ * Yoga was told to use. That is why a `height` on a Button's style used to do
+ * nothing at all.
+ */
+export function buttonMatchContents(style: ViewStyle | undefined): { horizontal: boolean; vertical: boolean } {
+  const fills = buttonFillAxes(style);
+  return { horizontal: !fills.width, vertical: !fills.height };
+}

--- a/packages/mobile/src/components/__tests__/Button.logic.test.ts
+++ b/packages/mobile/src/components/__tests__/Button.logic.test.ts
@@ -5,7 +5,13 @@ import { describe, it, expect, vi } from 'vitest';
 // tests inject their own haptic fn, so this just keeps the default import safe.
 vi.mock('../../lib/haptics', () => ({ hapticLight: vi.fn() }));
 
-import { isFullWidthStyle, makeButtonPressHandler } from '../Button.logic';
+import {
+  buttonFillAxes,
+  buttonMatchContents,
+  isFullWidthStyle,
+  makeButtonPressHandler,
+  pinnedButtonHeight,
+} from '../Button.logic';
 
 // The Button is a native @expo/ui control split across Button.ios.tsx /
 // Button.android.tsx, which can't mount under vitest. The press/haptic guard that
@@ -72,5 +78,59 @@ describe('isFullWidthStyle', () => {
   it('is false for a fixed pixel width or a non-stretch alignSelf', () => {
     expect(isFullWidthStyle({ width: 120 })).toBe(false);
     expect(isFullWidthStyle({ alignSelf: 'flex-start' })).toBe(false);
+  });
+});
+
+describe('pinnedButtonHeight', () => {
+  it('is undefined when the caller left the height to the native control', () => {
+    expect(pinnedButtonHeight(undefined)).toBeUndefined();
+    expect(pinnedButtonHeight({ flex: 1 })).toBeUndefined();
+  });
+
+  it('reads a numeric height', () => {
+    expect(pinnedButtonHeight({ flex: 1, height: 56 })).toBe(56);
+  });
+
+  // Neither can be handed to a native fixed-height modifier, so neither counts.
+  it("ignores a percentage or 'auto' height", () => {
+    expect(pinnedButtonHeight({ height: '100%' })).toBeUndefined();
+    expect(pinnedButtonHeight({ height: 'auto' })).toBeUndefined();
+  });
+});
+
+describe('buttonFillAxes', () => {
+  it('fills neither axis for an inline button', () => {
+    expect(buttonFillAxes(undefined)).toEqual({ width: false, height: false });
+  });
+
+  it('fills width only for a flexed button with no pinned height', () => {
+    expect(buttonFillAxes({ flex: 1 })).toEqual({ width: true, height: false });
+  });
+
+  it('fills both axes for a flexed button with a pinned height', () => {
+    expect(buttonFillAxes({ flex: 2, height: 56 })).toEqual({ width: true, height: true });
+  });
+
+  it('fills height only for an inline button with a pinned height', () => {
+    expect(buttonFillAxes({ height: 56 })).toEqual({ width: false, height: true });
+  });
+});
+
+describe('buttonMatchContents', () => {
+  // The regression this guards: Host writes the measured native size back over
+  // the RN style (`setStyleSize`) for every axis it matches, so an axis the
+  // caller sized must not be matched — that is why a `height` on a Button's
+  // style silently did nothing.
+  it('measures both axes for an inline button', () => {
+    expect(buttonMatchContents(undefined)).toEqual({ horizontal: true, vertical: true });
+  });
+
+  it('leaves the width to Yoga when the button is flexed', () => {
+    expect(buttonMatchContents({ flex: 1 })).toEqual({ horizontal: false, vertical: true });
+  });
+
+  it('leaves the height to Yoga when the caller pinned one', () => {
+    expect(buttonMatchContents({ flex: 1, height: 56 })).toEqual({ horizontal: false, vertical: false });
+    expect(buttonMatchContents({ height: 56 })).toEqual({ horizontal: true, vertical: false });
   });
 });

--- a/packages/mobile/src/components/tick/TickActionBar.tsx
+++ b/packages/mobile/src/components/tick/TickActionBar.tsx
@@ -109,15 +109,31 @@ const styles = StyleSheet.create({
   },
   row: {
     flexDirection: 'row',
+    // Both matter once the keyboard is up. The sheet's column is a FIXED height
+    // on iOS (the #3330 detent bound) and ModalSheet's KeyboardAvoidingView pads
+    // the bottom by the keyboard height, so everything inside gets squeezed into
+    // what's left. Without `flexShrink: 0` this row is a candidate for that
+    // squeeze; without `alignItems: 'center'` the default `stretch` then hands
+    // each native button host whatever odd height the squeezed row ended up
+    // with, and the two buttons stop lining up.
+    alignItems: 'center',
+    flexShrink: 0,
     minHeight: TICK_ACTION_HEIGHT,
   },
+  // Explicit height rather than relying on the row: `alignItems: 'center'` sizes
+  // each child to its own content, and a SwiftUI/Compose button host measures
+  // from its label, so the tonal Attempt and the filled Send (which also carries
+  // an icon and a spinner) would otherwise settle at slightly different heights.
   secondaryButton: {
     flex: 1,
+    height: TICK_ACTION_HEIGHT,
   },
   primaryButtonPaired: {
     flex: 2,
+    height: TICK_ACTION_HEIGHT,
   },
   primaryButtonAlone: {
     flex: 1,
+    height: TICK_ACTION_HEIGHT,
   },
 });

--- a/packages/mobile/src/components/tick/TickActionBar.tsx
+++ b/packages/mobile/src/components/tick/TickActionBar.tsx
@@ -17,7 +17,7 @@ import { Icon } from '../Icon';
 import { Button } from '../Button';
 import { useTheme } from '../../providers/theme-provider';
 import type { IconName } from '../icon-map';
-import { TICK_ACTION_HEIGHT, TICK_ERROR_SLOT_HEIGHT, TICK_STACK_FONT_SCALE } from './tick-sheet-metrics';
+import { TICK_ACTION_HEIGHT, TICK_ERROR_SLOT_HEIGHT, tickActionHeight } from './tick-sheet-metrics';
 
 const ERROR_ICON_SIZE = 13;
 
@@ -45,7 +45,7 @@ type TickActionBarProps = {
 export const TickActionBar = React.memo(function TickActionBar({ primary, secondary, error }: TickActionBarProps) {
   const { brandColors, spacing } = useTheme();
   const { fontScale } = useWindowDimensions();
-  const buttonStyles = tickButtonStyles(fontScale);
+  const buttonStyles = tickButtonStyles(tickActionHeight(fontScale));
 
   return (
     <View>
@@ -117,19 +117,11 @@ const styles = StyleSheet.create({
 });
 
 /**
- * The two buttons' styles. Both carry the SAME pinned height, because the tonal
- * Attempt and the filled Send are different native controls and each derives its
- * own padding — left to measure themselves they land ~7pt apart and the row
- * reads crooked. The 1:2 flex split makes the defining action the bigger object;
- * a lone primary fills the bar instead of hugging its label.
- *
- * Above the same OS text scale where a tick row stacks, the height is dropped: a
- * label that big needs more room than 56pt leaves, and two buttons of matching
- * height are not worth a clipped one. The row's `minHeight` still holds the
- * floor.
+ * The two buttons' styles: one shared height (see `tickActionHeight`), and the
+ * 1:2 flex split that makes the defining action the bigger object. A lone
+ * primary takes the whole bar instead of hugging its label.
  */
-function tickButtonStyles(fontScale: number) {
-  const height = fontScale > TICK_STACK_FONT_SCALE ? undefined : TICK_ACTION_HEIGHT;
+function tickButtonStyles(height: number) {
   return {
     secondary: { flex: 1, height },
     primaryPaired: { flex: 2, height },

--- a/packages/mobile/src/components/tick/TickActionBar.tsx
+++ b/packages/mobile/src/components/tick/TickActionBar.tsx
@@ -11,13 +11,13 @@
 // It adds NO padding of its own: Sheet/ModalSheet's footer bar already applies
 // the gutter, the top inset and the window bottom inset.
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, useWindowDimensions, View } from 'react-native';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { Button } from '../Button';
 import { useTheme } from '../../providers/theme-provider';
 import type { IconName } from '../icon-map';
-import { TICK_ACTION_HEIGHT, TICK_ERROR_SLOT_HEIGHT } from './tick-sheet-metrics';
+import { TICK_ACTION_HEIGHT, TICK_ERROR_SLOT_HEIGHT, TICK_STACK_FONT_SCALE } from './tick-sheet-metrics';
 
 const ERROR_ICON_SIZE = 13;
 
@@ -44,6 +44,8 @@ type TickActionBarProps = {
 
 export const TickActionBar = React.memo(function TickActionBar({ primary, secondary, error }: TickActionBarProps) {
   const { brandColors, spacing } = useTheme();
+  const { fontScale } = useWindowDimensions();
+  const buttonStyles = tickButtonStyles(fontScale);
 
   return (
     <View>
@@ -76,7 +78,7 @@ export const TickActionBar = React.memo(function TickActionBar({ primary, second
             disabled={secondary.disabled}
             variant="tonal"
             size="large"
-            style={styles.secondaryButton}
+            style={buttonStyles.secondary}
           />
         ) : null}
         <Button
@@ -88,9 +90,7 @@ export const TickActionBar = React.memo(function TickActionBar({ primary, second
           icon={primary.icon}
           variant="filled"
           size="large"
-          // 2:1 beside a secondary so the defining action reads as the bigger
-          // object; 1 on its own so it fills the bar instead of hugging its label.
-          style={secondary ? styles.primaryButtonPaired : styles.primaryButtonAlone}
+          style={secondary ? buttonStyles.primaryPaired : buttonStyles.primaryAlone}
         />
       </View>
     </View>
@@ -109,31 +109,30 @@ const styles = StyleSheet.create({
   },
   row: {
     flexDirection: 'row',
-    // Both matter once the keyboard is up. The sheet's column is a FIXED height
-    // on iOS (the #3330 detent bound) and ModalSheet's KeyboardAvoidingView pads
-    // the bottom by the keyboard height, so everything inside gets squeezed into
-    // what's left. Without `flexShrink: 0` this row is a candidate for that
-    // squeeze; without `alignItems: 'center'` the default `stretch` then hands
-    // each native button host whatever odd height the squeezed row ended up
-    // with, and the two buttons stop lining up.
     alignItems: 'center',
+    // Never the row that gives when the keyboard squeezes the column.
     flexShrink: 0,
     minHeight: TICK_ACTION_HEIGHT,
   },
-  // Explicit height rather than relying on the row: `alignItems: 'center'` sizes
-  // each child to its own content, and a SwiftUI/Compose button host measures
-  // from its label, so the tonal Attempt and the filled Send (which also carries
-  // an icon and a spinner) would otherwise settle at slightly different heights.
-  secondaryButton: {
-    flex: 1,
-    height: TICK_ACTION_HEIGHT,
-  },
-  primaryButtonPaired: {
-    flex: 2,
-    height: TICK_ACTION_HEIGHT,
-  },
-  primaryButtonAlone: {
-    flex: 1,
-    height: TICK_ACTION_HEIGHT,
-  },
 });
+
+/**
+ * The two buttons' styles. Both carry the SAME pinned height, because the tonal
+ * Attempt and the filled Send are different native controls and each derives its
+ * own padding — left to measure themselves they land ~7pt apart and the row
+ * reads crooked. The 1:2 flex split makes the defining action the bigger object;
+ * a lone primary fills the bar instead of hugging its label.
+ *
+ * Above the same OS text scale where a tick row stacks, the height is dropped: a
+ * label that big needs more room than 56pt leaves, and two buttons of matching
+ * height are not worth a clipped one. The row's `minHeight` still holds the
+ * floor.
+ */
+function tickButtonStyles(fontScale: number) {
+  const height = fontScale > TICK_STACK_FONT_SCALE ? undefined : TICK_ACTION_HEIGHT;
+  return {
+    secondary: { flex: 1, height },
+    primaryPaired: { flex: 2, height },
+    primaryAlone: { flex: 1, height },
+  };
+}

--- a/packages/mobile/src/components/tick/TickActionBar.tsx
+++ b/packages/mobile/src/components/tick/TickActionBar.tsx
@@ -10,7 +10,7 @@
 //
 // It adds NO padding of its own: Sheet/ModalSheet's footer bar already applies
 // the gutter, the top inset and the window bottom inset.
-import React from 'react';
+import React, { useMemo } from 'react';
 import { StyleSheet, useWindowDimensions, View } from 'react-native';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
@@ -45,7 +45,9 @@ type TickActionBarProps = {
 export const TickActionBar = React.memo(function TickActionBar({ primary, secondary, error }: TickActionBarProps) {
   const { brandColors, spacing } = useTheme();
   const { fontScale } = useWindowDimensions();
-  const buttonStyles = tickButtonStyles(tickActionHeight(fontScale));
+  // Memoized: `Button` is a native host, so a fresh style object every render is
+  // a fresh prop on both of them.
+  const buttonStyles = useMemo(() => tickButtonStyles(tickActionHeight(fontScale)), [fontScale]);
 
   return (
     <View>

--- a/packages/mobile/src/components/tick/__tests__/tick-action-bar.test.tsx
+++ b/packages/mobile/src/components/tick/__tests__/tick-action-bar.test.tsx
@@ -6,6 +6,9 @@ import { flattenStyle } from '../../../../test/flatten-style';
 import type { ButtonProps } from '../../Button.types';
 
 const buttonCalls = vi.hoisted(() => ({ props: [] as Record<string, unknown>[] }));
+// The OS text scale the component reads. Every test but the Dynamic-Type one
+// leaves it at 1.
+const screen = vi.hoisted(() => ({ fontScale: 1 }));
 
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios', select: (options: Record<string, unknown>) => options.ios ?? options.default },
@@ -34,6 +37,7 @@ vi.mock('react-native', () => ({
       children,
     ),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  useWindowDimensions: () => ({ width: 390, height: 844, scale: 3, fontScale: screen.fontScale }),
 }));
 
 // Capture what the native Button primitive is handed — the 1:2 split lives in
@@ -61,7 +65,7 @@ vi.mock('../../../providers/theme-provider', async () => {
 });
 
 import { TickActionBar } from '../TickActionBar';
-import { TICK_ACTION_HEIGHT, TICK_ERROR_SLOT_HEIGHT } from '../tick-sheet-metrics';
+import { TICK_ACTION_HEIGHT, TICK_ERROR_SLOT_HEIGHT, TICK_STACK_FONT_SCALE } from '../tick-sheet-metrics';
 import { brandColors } from '../../../theme/colors';
 
 function renderBar(props: Partial<Parameters<typeof TickActionBar>[0]> = {}) {
@@ -81,7 +85,17 @@ function styleOf(container: HTMLElement, testID: string): Record<string, unknown
 describe('TickActionBar', () => {
   beforeEach(() => {
     buttonCalls.props.length = 0;
+    screen.fontScale = 1;
   });
+
+  // The style each Button was handed, by role. Reading the spy by index breaks
+  // the moment a render order or a render count changes; the title is what the
+  // assertion actually means.
+  function buttonStyle(title: string): Record<string, unknown> {
+    const call = buttonCalls.props.find((props) => props.title === title);
+    expect(call, `no Button rendered with title ${title}`).toBeDefined();
+    return flattenStyle(call?.style);
+  }
 
   it('gives the primary twice the secondary width when both are present', () => {
     renderBar({ secondary: { title: 'Attempt', onPress: vi.fn() } });
@@ -113,11 +127,8 @@ describe('TickActionBar', () => {
   });
 
   it('holds its shape when the keyboard squeezes the column', () => {
-    // The sheet's column is a fixed height on iOS (the #3330 detent bound) and
-    // ModalSheet's KeyboardAvoidingView pads the bottom by the keyboard height,
-    // so everything inside is competing for what's left. This row must not be
-    // what gives: a shrunk row stretches the native button hosts to whatever
-    // height is left over and the two buttons stop lining up.
+    // ModalSheet pads the bottom by the keyboard height INSIDE a fixed-height
+    // column, so everything above competes for what is left. Not this row.
     const { container } = renderBar();
     const row = styleOf(container, 'tick-action-row');
 
@@ -126,18 +137,28 @@ describe('TickActionBar', () => {
     expect(row.minHeight).toBe(TICK_ACTION_HEIGHT);
   });
 
-  it('gives both buttons the same explicit height, not whatever their labels measure', () => {
-    // `alignItems: 'center'` sizes each child to its own content, and a native
-    // button host measures from its label — the filled primary also carries an
-    // icon and a spinner, so the two would settle at different heights.
-    const paired = renderBar({ secondary: { title: 'Attempt', onPress: vi.fn() } });
-    const [secondary, primary] = buttonCalls.props;
-    expect(flattenStyle(secondary.style).height).toBe(TICK_ACTION_HEIGHT);
-    expect(flattenStyle(primary.style).height).toBe(TICK_ACTION_HEIGHT);
-    paired.unmount();
+  it('pins both buttons to one height, so the tonal and filled pills cannot measure apart', () => {
+    renderBar({ secondary: { title: 'Attempt', onPress: vi.fn() } });
 
+    expect(buttonStyle('Attempt').height).toBe(TICK_ACTION_HEIGHT);
+    expect(buttonStyle('Send').height).toBe(TICK_ACTION_HEIGHT);
+  });
+
+  it('pins the height of a lone primary too', () => {
     renderBar();
-    expect(flattenStyle(buttonCalls.props[0].style).height).toBe(TICK_ACTION_HEIGHT);
+
+    expect(buttonStyle('Send').height).toBe(TICK_ACTION_HEIGHT);
+  });
+
+  it('drops the pinned height above the stack text scale, rather than clip a big label', () => {
+    screen.fontScale = TICK_STACK_FONT_SCALE + 0.1;
+    renderBar({ secondary: { title: 'Attempt', onPress: vi.fn() } });
+
+    expect(buttonStyle('Attempt').height).toBeUndefined();
+    expect(buttonStyle('Send').height).toBeUndefined();
+    // The flex split is not what Dynamic Type relaxes.
+    expect(buttonStyle('Attempt').flex).toBe(1);
+    expect(buttonStyle('Send').flex).toBe(2);
   });
 
   it('announces a failure: these used to go through showToast, which announced', () => {

--- a/packages/mobile/src/components/tick/__tests__/tick-action-bar.test.tsx
+++ b/packages/mobile/src/components/tick/__tests__/tick-action-bar.test.tsx
@@ -61,7 +61,7 @@ vi.mock('../../../providers/theme-provider', async () => {
 });
 
 import { TickActionBar } from '../TickActionBar';
-import { TICK_ERROR_SLOT_HEIGHT } from '../tick-sheet-metrics';
+import { TICK_ACTION_HEIGHT, TICK_ERROR_SLOT_HEIGHT } from '../tick-sheet-metrics';
 import { brandColors } from '../../../theme/colors';
 
 function renderBar(props: Partial<Parameters<typeof TickActionBar>[0]> = {}) {
@@ -110,6 +110,34 @@ describe('TickActionBar', () => {
     const failed = renderBar({ error: "Couldn't save your tick" });
     expect(styleOf(failed.container, 'tick-action-error-slot')).toEqual(restSlot);
     expect(styleOf(failed.container, 'tick-action-row')).toEqual(restRow);
+  });
+
+  it('holds its shape when the keyboard squeezes the column', () => {
+    // The sheet's column is a fixed height on iOS (the #3330 detent bound) and
+    // ModalSheet's KeyboardAvoidingView pads the bottom by the keyboard height,
+    // so everything inside is competing for what's left. This row must not be
+    // what gives: a shrunk row stretches the native button hosts to whatever
+    // height is left over and the two buttons stop lining up.
+    const { container } = renderBar();
+    const row = styleOf(container, 'tick-action-row');
+
+    expect(row.flexShrink).toBe(0);
+    expect(row.alignItems).toBe('center');
+    expect(row.minHeight).toBe(TICK_ACTION_HEIGHT);
+  });
+
+  it('gives both buttons the same explicit height, not whatever their labels measure', () => {
+    // `alignItems: 'center'` sizes each child to its own content, and a native
+    // button host measures from its label — the filled primary also carries an
+    // icon and a spinner, so the two would settle at different heights.
+    const paired = renderBar({ secondary: { title: 'Attempt', onPress: vi.fn() } });
+    const [secondary, primary] = buttonCalls.props;
+    expect(flattenStyle(secondary.style).height).toBe(TICK_ACTION_HEIGHT);
+    expect(flattenStyle(primary.style).height).toBe(TICK_ACTION_HEIGHT);
+    paired.unmount();
+
+    renderBar();
+    expect(flattenStyle(buttonCalls.props[0].style).height).toBe(TICK_ACTION_HEIGHT);
   });
 
   it('announces a failure: these used to go through showToast, which announced', () => {

--- a/packages/mobile/src/components/tick/__tests__/tick-action-bar.test.tsx
+++ b/packages/mobile/src/components/tick/__tests__/tick-action-bar.test.tsx
@@ -65,7 +65,7 @@ vi.mock('../../../providers/theme-provider', async () => {
 });
 
 import { TickActionBar } from '../TickActionBar';
-import { TICK_ACTION_HEIGHT, TICK_ERROR_SLOT_HEIGHT, TICK_STACK_FONT_SCALE } from '../tick-sheet-metrics';
+import { TICK_ACTION_HEIGHT, TICK_ERROR_SLOT_HEIGHT, tickActionHeight } from '../tick-sheet-metrics';
 import { brandColors } from '../../../theme/colors';
 
 function renderBar(props: Partial<Parameters<typeof TickActionBar>[0]> = {}) {
@@ -150,13 +150,15 @@ describe('TickActionBar', () => {
     expect(buttonStyle('Send').height).toBe(TICK_ACTION_HEIGHT);
   });
 
-  it('drops the pinned height above the stack text scale, rather than clip a big label', () => {
-    screen.fontScale = TICK_STACK_FONT_SCALE + 0.1;
+  it('grows the shared height with the OS text scale, and still shares it', () => {
+    screen.fontScale = 2;
     renderBar({ secondary: { title: 'Attempt', onPress: vi.fn() } });
 
-    expect(buttonStyle('Attempt').height).toBeUndefined();
-    expect(buttonStyle('Send').height).toBeUndefined();
-    // The flex split is not what Dynamic Type relaxes.
+    const grown = tickActionHeight(2);
+    expect(grown).toBeGreaterThan(TICK_ACTION_HEIGHT);
+    expect(buttonStyle('Attempt').height).toBe(grown);
+    expect(buttonStyle('Send').height).toBe(grown);
+    // The flex split is not what the text scale moves.
     expect(buttonStyle('Attempt').flex).toBe(1);
     expect(buttonStyle('Send').flex).toBe(2);
   });

--- a/packages/mobile/src/components/tick/__tests__/tick-sheet-metrics.test.ts
+++ b/packages/mobile/src/components/tick/__tests__/tick-sheet-metrics.test.ts
@@ -14,6 +14,7 @@ import {
   CREATE_TICK_SNAP_POINTS,
   EDIT_TICK_SNAP_POINTS,
   TICK_ACTION_HEIGHT,
+  TICK_ACTION_LABEL_HEIGHT,
   TICK_ANGLE_ROW_HEIGHT,
   TICK_CONTROL_ORIGIN,
   TICK_GUTTER,
@@ -22,6 +23,7 @@ import {
   TICK_LABEL_MIN_WIDTH,
   TICK_RAIL_ROW_HEIGHT,
   TICK_ROW_HEIGHT,
+  tickActionHeight,
 } from '../tick-sheet-metrics';
 
 function percentToNumber(snapPoint: string): number {
@@ -56,5 +58,30 @@ describe('tick sheet metrics', () => {
       expect(percentToNumber(snapPoints[0])).toBeLessThan(percentToNumber(snapPoints[1]));
       expect(snapPoints[1]).toBe('92%');
     }
+  });
+});
+
+// The action row pins ONE height across two different native controls, so this
+// value is the whole reason the tonal Attempt and the filled Send line up. It has
+// to hold at every text scale: a button that only sometimes carries a height
+// would flip `Host`'s `matchContents` mid-life, and nothing else sizes that axis.
+describe('tickActionHeight', () => {
+  it('is the hero height at the default text size', () => {
+    expect(tickActionHeight(1)).toBe(TICK_ACTION_HEIGHT);
+  });
+
+  it('never goes below the hero floor, however small the text', () => {
+    expect(tickActionHeight(0.85)).toBe(TICK_ACTION_HEIGHT);
+  });
+
+  it('grows by the label line alone, not by the whole button', () => {
+    // A native button's padding does not scale, so doubling the text adds one
+    // more line — not another 56pt.
+    expect(tickActionHeight(2)).toBe(TICK_ACTION_HEIGHT + TICK_ACTION_LABEL_HEIGHT);
+    expect(tickActionHeight(3)).toBe(TICK_ACTION_HEIGHT + TICK_ACTION_LABEL_HEIGHT * 2);
+  });
+
+  it('is a whole number of points at an awkward scale', () => {
+    expect(Number.isInteger(tickActionHeight(1.35))).toBe(true);
   });
 });

--- a/packages/mobile/src/components/tick/tick-sheet-metrics.ts
+++ b/packages/mobile/src/components/tick/tick-sheet-metrics.ts
@@ -43,6 +43,28 @@ export const TICK_HEADER_HEIGHT = 56;
  *  the same object as every other defining action. */
 export const TICK_ACTION_HEIGHT = glassSize.hero; // 56
 
+/** How much of TICK_ACTION_HEIGHT is label rather than the native control's own
+ *  padding: one `body` line, 17pt at the system 1.29 line height. Only this part
+ *  grows with the OS text scale — a SwiftUI/Compose button's padding is fixed —
+ *  so a scaled action height adds the growth of this line alone. */
+export const TICK_ACTION_LABEL_HEIGHT = 22;
+
+/**
+ * The action row's button height at a given OS text scale.
+ *
+ * The row pins ONE height across both buttons because the tonal Attempt and the
+ * filled Send are different native controls: each derives its own padding, so
+ * left to measure themselves they land ~7pt apart and the row reads crooked.
+ * The pin has to hold at every text scale — a button that only sometimes carries
+ * a height would flip `Host`'s `matchContents` mid-life, and the axis it stops
+ * measuring is the axis nothing else sizes.
+ *
+ * Never below TICK_ACTION_HEIGHT: that is the hero floor, not a measurement.
+ */
+export function tickActionHeight(fontScale: number): number {
+  return Math.round(TICK_ACTION_HEIGHT + TICK_ACTION_LABEL_HEIGHT * (Math.max(1, fontScale) - 1));
+}
+
 /** Always-reserved height of the action bar's error slot. Reserved even when
  *  empty so a failed save prints its reason without moving the buttons under
  *  the climber's thumb. One `footnote` line. */

--- a/packages/mobile/src/components/tick/tick-sheet-metrics.ts
+++ b/packages/mobile/src/components/tick/tick-sheet-metrics.ts
@@ -44,9 +44,16 @@ export const TICK_HEADER_HEIGHT = 56;
 export const TICK_ACTION_HEIGHT = glassSize.hero; // 56
 
 /** How much of TICK_ACTION_HEIGHT is label rather than the native control's own
- *  padding: one `body` line, 17pt at the system 1.29 line height. Only this part
- *  grows with the OS text scale — a SwiftUI/Compose button's padding is fixed —
- *  so a scaled action height adds the growth of this line alone. */
+ *  padding. Only the label grows with the OS text scale — a SwiftUI/Compose
+ *  button's padding is fixed — so a scaled action height adds the growth of this
+ *  one line and nothing else.
+ *
+ *  Approximate, and deliberately one number for both platforms: an iOS `body`
+ *  line is 17pt at the system 1.29 leading (~22) and a Compose `bodyLarge` line
+ *  is 24sp, so Android under-grows by ~2dp per full step of scale. The button is
+ *  exactly this tall either way; the slack is padding, not a clipped label. A
+ *  per-platform constant would buy those 2dp at the cost of two numbers that can
+ *  drift apart. */
 export const TICK_ACTION_LABEL_HEIGHT = 22;
 
 /**


### PR DESCRIPTION
## Summary

Reported after #4215 merged: the Attempt / Send buttons sit oddly in the tick sheet. The first pass here centred the row, which fixed a real vertical stagger — but QA declined it, and the screenshot shows why: neither button ever filled its slot.

Measuring that screenshot (iPhone 16 Pro Max, 3x) against the layout the code asks for:

| | asked for | rendered |
| --- | --- | --- |
| Attempt width | 114pt | **101pt** |
| Send width | 228pt | **112pt** |
| Attempt height | 56pt | **48.7pt** |
| Send height | 56pt | **55.3pt** |

77pt of dead space between the two buttons, 58pt more to the right of Send, and one pill visibly shorter than the other.

Two causes, both in the shared `Button`:

**The pinned height never reached the screen.** `Host` writes the measured native size back over the RN style — `HostView.swift` calls `setStyleSize` with the SwiftUI content size for every axis `matchContents` covers — so a `height` on a Button's style is overwritten on first layout. `buttonMatchContents` now stops measuring an axis the caller has sized.

**`.buttonStyle()` paints around the LABEL.** Every modifier in the `modifiers` array is applied outside that paint (`View+ModifierArray.swift` reduces them onto the Button itself), so `frame(maxWidth: .infinity)` widened only the tap area and left a pill hugging its text, centred in the leftover space. Growing the label is what grows the background, so the fill frame is now repeated on the SwiftUI `HStack`.

Android already filled correctly — a Compose modifier applies to the container, so `fillMaxWidth()` worked — and gains the matching `height` modifier so a pinned height behaves the same on both platforms.

The tick action row is the only caller pinning a height today, so the vertical half of this is scoped to it. The pin holds at every OS text scale and grows with it — by the label line alone, since a native button's padding does not scale. It cannot be conditional: a button that only sometimes carries a height would flip `matchContents` on a live component, and the axis it stops measuring is the axis nothing else sizes.

Also addresses the two review notes from the earlier pass: the StyleSheet comment blocks are gone, and the test no longer indexes into the cumulative Button spy — it looks each button up by title.

## Release Notes

- Fixed the Attempt and Send buttons in the tick sheet: they now fill the row evenly instead of floating at odd sizes

## Test plan

1. Open a climb → Log a tick.
2. Attempt and Send fill the row, no gaps.
3. Both buttons are the same height.
4. Tap the note field: buttons stay put.
5. Close the keyboard: still even.

## Risk

Risk: 3/5 — touches the shared Button used on ~98 screens. Full-width buttons everywhere now fill their box instead of hugging their label, which is what the code always asked for and what Android already did. Ships OTA.

## Verification

`vp run typecheck:mobile`, `vp run test:mobile` (8,145 passing) and `vp run check:mobile-bundle` are clean. Three mutations of the new guards each fail a test.

Measured on an Android emulator (uiautomator bounds, 810x1800 @ density 320), the same tick sheet before and after:

| | before | after |
| --- | --- | --- |
| Attempt / Send host | 48.0dp | **56.0dp** |
| Native button | 44.5dp | **56.0dp** |
| Widths | 241 / 481 px | 241 / 481 px (2:1, unchanged) |

That is the pinned height reaching the screen for the first time — the half of the fix that is platform-shared. Holds with the keyboard open too.

The SwiftUI label-frame half is iOS-only and has no unit test: the native `@expo/ui` tree cannot mount under vitest, and there is no iOS simulator on this box. That one is what QA is confirming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuSbhLaMGVofXGkjk1o3ob
