### PR TITLE
fix(mobile): stop a playlist rename from silently overwriting another device

### DIFF
--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -366,6 +366,14 @@ async function processMutation(mutation: PendingMutation) {
 
 Each mutation gets a client-generated UUID as an idempotency key. The backend's `saveTick` and `createPlaylist` accept this UUID and use `ON CONFLICT (uuid) DO NOTHING` for safe retry. Favorites use explicit `addFavorite`/`removeFavorite` (not `toggleFavorite`) so retries don't invert state. Follow/unfollow operations are naturally idempotent (follow when already following = no-op, unfollow when not following = no-op).
 
+### The one mutation that can't be auto-merged
+
+Every queued mutation above is idempotent or commutative, so replaying it is always safe. `updatePlaylist` is the exception: a queued rename replayed blind overwrites whatever the playlist is called now, including a rename made on another device while this one was offline (#1934).
+
+So it carries a `basedOn` snapshot — the `updatedAt` plus the metadata values the client last saw. The server compares that against the stored row inside a transaction holding a row lock and, when the two genuinely diverge, rejects with `PLAYLIST_UPDATE_CONFLICT` instead of writing. The error's extensions carry the server's current values, so the client can name both versions in a prompt and rebuild `basedOn` for a deliberate overwrite without a refetch. Omitting `basedOn` keeps the old last-write-wins behaviour, which is what shipped binaries and web still do.
+
+Two consequences for the queue. A rejection resolves to no HTTP status, so `isRetryable` returns false and the row dead-letters for a human to resolve instead of burning ten retries. And a climb added or reordered elsewhere bumps `playlists.updated_at` without touching the metadata, which is why the check compares fields rather than the bare timestamp — a timestamp alone would false-conflict on the same device's own queued climb add draining ahead of the rename. Any future mutation that can't be auto-merged should reuse this code rather than invent a shape.
+
 ### Dead letter handling
 
 Mutations that exceed `MAX_RETRY_COUNT` or fail with non-retryable errors are moved to `status = 'dead_letter'`. The app shows a badge/indicator when dead-letter mutations exist. Users can view failed mutations and choose to retry or discard them. This prevents silent data loss — the user always knows if a tick didn't sync.

--- a/packages/backend/src/__tests__/playlist-update-conflict.test.ts
+++ b/packages/backend/src/__tests__/playlist-update-conflict.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vite-plus/test';
+import { eq, sql } from 'drizzle-orm';
+import { GraphQLError } from 'graphql';
+import { PLAYLIST_UPDATE_CONFLICT_CODE } from '@boardsesh/shared-schema';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import * as dbSchema from '@boardsesh/db/schema';
+import { playlistMutations } from '../graphql/resolvers/playlists/mutations';
+import {
+  detectPlaylistUpdateConflict,
+  normalizePlaylistText,
+} from '../graphql/resolvers/playlists/helpers/update-conflict';
+
+// #1934: updatePlaylist is the one offline-replayable mutation that can't be
+// auto-merged, so it takes an optional `basedOn` snapshot and refuses a genuine
+// collision instead of quietly keeping whichever write landed last.
+
+describe('detectPlaylistUpdateConflict', () => {
+  const storedAt = new Date('2026-08-10T12:00:00.000Z');
+  const olderSnapshot = '2026-08-10T11:00:00.000Z';
+
+  function stored(overrides: Record<string, unknown> = {}) {
+    return {
+      name: 'Crimps',
+      description: null,
+      isPublic: false,
+      color: null,
+      icon: null,
+      updatedAt: storedAt,
+      ...overrides,
+    };
+  }
+
+  it('never conflicts without a basedOn snapshot (blind last-write-wins stays the default)', () => {
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ name: 'Renamed elsewhere' }),
+        incoming: { name: 'Mine' },
+      }),
+    ).toBe(false);
+  });
+
+  it('applies when the snapshot is as new as the stored row', () => {
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored(),
+        incoming: { name: 'Mine' },
+        basedOn: { updatedAt: storedAt.toISOString(), name: 'Crimps' },
+      }),
+    ).toBe(false);
+  });
+
+  it('conflicts when someone else renamed the playlist', () => {
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ name: 'Renamed elsewhere' }),
+        incoming: { name: 'Mine' },
+        basedOn: { updatedAt: olderSnapshot, name: 'Crimps' },
+      }),
+    ).toBe(true);
+  });
+
+  it('does not conflict when only the timestamp moved (a climb was added)', () => {
+    // addClimbToPlaylist/remove/reorder all bump playlists.updated_at, so a bare
+    // timestamp comparison would cry conflict on every climb add.
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored(),
+        incoming: { name: 'Mine' },
+        basedOn: { updatedAt: olderSnapshot, name: 'Crimps' },
+      }),
+    ).toBe(false);
+  });
+
+  it('treats an already-applied edit as a no-op success, not a conflict', () => {
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ name: 'Mine' }),
+        incoming: { name: 'Mine' },
+        basedOn: { updatedAt: olderSnapshot, name: 'Crimps' },
+      }),
+    ).toBe(false);
+  });
+
+  it("treats '' and null as the same value for description/colour/icon", () => {
+    expect(normalizePlaylistText('')).toBeNull();
+    expect(normalizePlaylistText(null)).toBeNull();
+    expect(normalizePlaylistText(undefined)).toBeUndefined();
+    expect(normalizePlaylistText('#123456')).toBe('#123456');
+
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ description: null, color: null }),
+        incoming: { description: '', color: '' },
+        basedOn: { updatedAt: olderSnapshot, description: '', color: '' },
+      }),
+    ).toBe(false);
+  });
+
+  it('treats a missing based-on field as divergent (conservative)', () => {
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ description: 'set elsewhere' }),
+        incoming: { description: 'mine' },
+        // No `description` in the snapshot: we can't prove the client saw the
+        // stored value, so refuse rather than overwrite.
+        basedOn: { updatedAt: olderSnapshot, name: 'Crimps' },
+      }),
+    ).toBe(true);
+  });
+
+  it('conflicts on visibility only when the client did not see the stored value', () => {
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ isPublic: true }),
+        incoming: { isPublic: false },
+        basedOn: { updatedAt: olderSnapshot, isPublic: true },
+      }),
+    ).toBe(false);
+
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ isPublic: true }),
+        incoming: { isPublic: false },
+        // isPublic absent from the snapshot.
+        basedOn: { updatedAt: olderSnapshot, name: 'Crimps' },
+      }),
+    ).toBe(true);
+  });
+});
+
+const PLAYLIST_UUID = 'pl-conflict-1934';
+const OWNER_ID = 'user-123'; // seeded by setup.ts
+
+function makeCtx(): ConnectionContext {
+  return {
+    connectionId: 'conn-1',
+    isAuthenticated: true,
+    userId: OWNER_ID,
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+  } as unknown as ConnectionContext;
+}
+
+// Read through drizzle (not raw `execute`) so `updated_at` arrives as the same
+// Date the resolver compares against, rather than a driver string.
+async function readPlaylist(): Promise<{ name: string; description: string | null; updatedAt: Date }> {
+  const [row] = await db
+    .select({
+      name: dbSchema.playlists.name,
+      description: dbSchema.playlists.description,
+      updatedAt: dbSchema.playlists.updatedAt,
+    })
+    .from(dbSchema.playlists)
+    .where(eq(dbSchema.playlists.id, 1n))
+    .limit(1);
+  return row;
+}
+
+describe('updatePlaylist — compare-and-swap against a real DB (#1934)', () => {
+  // Playlist tables aren't in setup.ts's per-file reset list, so own the reset.
+  beforeEach(async () => {
+    await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
+    await db.execute(sql`
+      INSERT INTO playlists (id, uuid, board_type, layout_id, name, is_public, created_at, updated_at)
+      VALUES (1, ${PLAYLIST_UUID}, 'kilter', 1, 'Crimps', false, now() - interval '1 hour', now() - interval '1 hour')
+    `);
+    await db.execute(sql`INSERT INTO playlist_ownership (playlist_id, user_id) VALUES (1, ${OWNER_ID})`);
+  });
+
+  afterAll(async () => {
+    await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
+  });
+
+  it('applies without a basedOn snapshot (unchanged behaviour for web and shipped binaries)', async () => {
+    await playlistMutations.updatePlaylist(
+      null,
+      { input: { playlistId: PLAYLIST_UUID, name: 'Blind write' } },
+      makeCtx(),
+    );
+
+    expect((await readPlaylist()).name).toBe('Blind write');
+  });
+
+  it('applies when the snapshot matches the stored updatedAt', async () => {
+    const before = await readPlaylist();
+
+    await playlistMutations.updatePlaylist(
+      null,
+      {
+        input: {
+          playlistId: PLAYLIST_UUID,
+          name: 'Fresh edit',
+          basedOn: { updatedAt: before.updatedAt.toISOString(), name: 'Crimps' },
+        },
+      },
+      makeCtx(),
+    );
+
+    expect((await readPlaylist()).name).toBe('Fresh edit');
+  });
+
+  it('throws PLAYLIST_UPDATE_CONFLICT carrying the server values when another writer renamed it', async () => {
+    const before = await readPlaylist();
+    // Another device renames the playlist and sets a description.
+    await db.execute(
+      sql`UPDATE playlists SET name = 'Renamed on the other phone', description = 'theirs', updated_at = now() WHERE id = 1`,
+    );
+
+    const failure = await playlistMutations
+      .updatePlaylist(
+        null,
+        {
+          input: {
+            playlistId: PLAYLIST_UUID,
+            name: 'Renamed on this phone',
+            basedOn: { updatedAt: before.updatedAt.toISOString(), name: 'Crimps', description: null },
+          },
+        },
+        makeCtx(),
+      )
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+    expect(failure).toBeInstanceOf(GraphQLError);
+    const extensions = (failure as GraphQLError).extensions;
+    expect(extensions.code).toBe(PLAYLIST_UPDATE_CONFLICT_CODE);
+    expect(extensions.playlistUuid).toBe(PLAYLIST_UUID);
+    expect(extensions.serverName).toBe('Renamed on the other phone');
+    expect(extensions.serverDescription).toBe('theirs');
+    expect(extensions.serverIsPublic).toBe(false);
+    expect(extensions.serverColor).toBeNull();
+    expect(extensions.serverIcon).toBeNull();
+    expect(typeof extensions.serverUpdatedAt).toBe('string');
+
+    // Nothing was written.
+    expect((await readPlaylist()).name).toBe('Renamed on the other phone');
+  });
+
+  it('applies when only a climb add bumped updatedAt (the false-conflict this design prevents)', async () => {
+    const before = await readPlaylist();
+
+    await playlistMutations.addClimbToPlaylist(
+      null,
+      { input: { playlistId: PLAYLIST_UUID, climbUuid: '11111111-1111-1111-1111-111111111111', angle: 40 } },
+      makeCtx(),
+    );
+
+    const bumped = await readPlaylist();
+    expect(bumped.updatedAt.getTime()).toBeGreaterThan(before.updatedAt.getTime());
+
+    await playlistMutations.updatePlaylist(
+      null,
+      {
+        input: {
+          playlistId: PLAYLIST_UUID,
+          name: 'Renamed after the add',
+          basedOn: { updatedAt: before.updatedAt.toISOString(), name: 'Crimps', description: null },
+        },
+      },
+      makeCtx(),
+    );
+
+    expect((await readPlaylist()).name).toBe('Renamed after the add');
+  });
+
+  it('is a no-op success when a stale re-send asks for values that already landed', async () => {
+    const before = await readPlaylist();
+    await db.execute(sql`UPDATE playlists SET name = 'Same rename', updated_at = now() WHERE id = 1`);
+
+    // The outbox replays the rename it already delivered — it can't know the
+    // first attempt succeeded, and a bogus prompt here would be pure noise.
+    await playlistMutations.updatePlaylist(
+      null,
+      {
+        input: {
+          playlistId: PLAYLIST_UUID,
+          name: 'Same rename',
+          basedOn: { updatedAt: before.updatedAt.toISOString(), name: 'Crimps', description: null },
+        },
+      },
+      makeCtx(),
+    );
+
+    expect((await readPlaylist()).name).toBe('Same rename');
+  });
+
+  it('applies a "keep mine" retry rebased on the values from the conflict error', async () => {
+    const before = await readPlaylist();
+    await db.execute(sql`UPDATE playlists SET name = 'Theirs', updated_at = now() WHERE id = 1`);
+
+    const failure = await playlistMutations
+      .updatePlaylist(
+        null,
+        {
+          input: {
+            playlistId: PLAYLIST_UUID,
+            name: 'Mine',
+            basedOn: { updatedAt: before.updatedAt.toISOString(), name: 'Crimps', description: null },
+          },
+        },
+        makeCtx(),
+      )
+      .then(
+        () => null,
+        (error: unknown) => error as GraphQLError,
+      );
+
+    const extensions = (failure as GraphQLError).extensions;
+
+    await playlistMutations.updatePlaylist(
+      null,
+      {
+        input: {
+          playlistId: PLAYLIST_UUID,
+          name: 'Mine',
+          basedOn: {
+            updatedAt: extensions.serverUpdatedAt as string,
+            name: extensions.serverName as string,
+            description: extensions.serverDescription as string | null,
+            isPublic: extensions.serverIsPublic as boolean,
+            color: extensions.serverColor as string | null,
+            icon: extensions.serverIcon as string | null,
+          },
+        },
+      },
+      makeCtx(),
+    );
+
+    expect((await readPlaylist()).name).toBe('Mine');
+  });
+
+  it('still rejects a non-owner', async () => {
+    await expect(
+      playlistMutations.updatePlaylist(null, { input: { playlistId: PLAYLIST_UUID, name: 'Not mine' } }, {
+        ...makeCtx(),
+        userId: 'not-the-owner',
+      } as ConnectionContext),
+    ).rejects.toThrow('do not have permission');
+
+    expect((await readPlaylist()).name).toBe('Crimps');
+  });
+});

--- a/packages/backend/src/__tests__/playlist-update-conflict.test.ts
+++ b/packages/backend/src/__tests__/playlist-update-conflict.test.ts
@@ -155,6 +155,17 @@ describe('detectPlaylistUpdateConflict', () => {
         basedOn: { updatedAt: olderSnapshot, name: 'Crimps' },
       }),
     ).toBe(true);
+
+    // An unknown snapshot value can't manufacture a conflict on its own: if the
+    // stored visibility already equals what this edit sends, there is nothing to
+    // decide between.
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ isPublic: true }),
+        incoming: { isPublic: true },
+        basedOn: { updatedAt: olderSnapshot, isPublic: null },
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/backend/src/__tests__/playlist-update-conflict.test.ts
+++ b/packages/backend/src/__tests__/playlist-update-conflict.test.ts
@@ -97,6 +97,35 @@ describe('detectPlaylistUpdateConflict', () => {
     ).toBe(false);
   });
 
+  it('conflicts on a colour or icon someone else changed, same as a rename', () => {
+    // name/description/colour/icon share one loop; pin colour and icon so a
+    // future field-list edit can't quietly drop them from the check.
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ color: '#1F2937' }),
+        incoming: { color: '#6D28D9' },
+        basedOn: { updatedAt: olderSnapshot, color: '#8C4A52' },
+      }),
+    ).toBe(true);
+
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ icon: '🪨' }),
+        incoming: { icon: '💀' },
+        basedOn: { updatedAt: olderSnapshot, icon: '🔥' },
+      }),
+    ).toBe(true);
+
+    // ...and not when the other device set it to what this edit already sends.
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ color: '#6D28D9' }),
+        incoming: { color: '#6D28D9' },
+        basedOn: { updatedAt: olderSnapshot, color: '#8C4A52' },
+      }),
+    ).toBe(false);
+  });
+
   it('treats a missing based-on field as divergent (conservative)', () => {
     expect(
       detectPlaylistUpdateConflict({

--- a/packages/backend/src/__tests__/playlist-update.test.ts
+++ b/packages/backend/src/__tests__/playlist-update.test.ts
@@ -1,15 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 
-const { mockDb } = vi.hoisted(() => {
+const { mockDb, mockTx } = vi.hoisted(() => {
+  // The compare-and-swap added in #1934 runs the ownership check, the locked
+  // read and the write inside one transaction, so the mock needs a `tx` of its
+  // own; everything after the commit still goes through `db`.
+  const mockTx = {
+    select: vi.fn(),
+    update: vi.fn(),
+  };
   const mockDb = {
     execute: vi.fn(),
     select: vi.fn(),
     insert: vi.fn(),
     delete: vi.fn(),
     update: vi.fn(),
+    transaction: vi.fn(async (callback: (tx: typeof mockTx) => unknown) => callback(mockTx)),
   };
-  return { mockDb };
+  return { mockDb, mockTx };
 });
 
 vi.mock('../db/client', () => ({ db: mockDb }));
@@ -38,7 +46,7 @@ function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext 
 
 function createMockChain(resolveValue: unknown = []): Record<string, unknown> {
   const chain: Record<string, unknown> = {};
-  const methods = ['select', 'from', 'where', 'innerJoin', 'limit', 'set', 'update', 'returning'];
+  const methods = ['select', 'from', 'where', 'innerJoin', 'limit', 'set', 'update', 'returning', 'for'];
   chain.then = (resolve: (value: unknown) => unknown) => Promise.resolve(resolveValue).then(resolve);
   for (const method of methods) chain[method] = vi.fn((..._args: unknown[]) => chain);
   return chain;
@@ -58,11 +66,16 @@ const updatedRow = {
   updatedAt: new Date(),
 };
 
-/** Mock the resolver's db sequence: ownership select → update → climbCount select → pin select. */
+/**
+ * Mock the resolver's db sequence: inside the transaction, ownership select →
+ * locked playlist select → update; after it commits, climbCount select → pin
+ * select.
+ */
 function primeDb() {
-  mockDb.select.mockReturnValueOnce(createMockChain([{ playlists: { id: 1 } }])); // ownership
+  mockTx.select.mockReturnValueOnce(createMockChain([{ playlistId: 1 }])); // ownership
+  mockTx.select.mockReturnValueOnce(createMockChain([updatedRow])); // locked read
   const updateChain = createMockChain([updatedRow]);
-  mockDb.update.mockReturnValueOnce(updateChain);
+  mockTx.update.mockReturnValueOnce(updateChain);
   mockDb.select.mockReturnValueOnce(createMockChain([{ count: 0 }])); // climbCount
   mockDb.select.mockReturnValueOnce(createMockChain([])); // pin lookup
   return updateChain;

--- a/packages/backend/src/__tests__/playlist-update.test.ts
+++ b/packages/backend/src/__tests__/playlist-update.test.ts
@@ -113,6 +113,40 @@ describe('updatePlaylist mutation — clearing optional fields', () => {
     expect('icon' in setArg).toBe(false);
   });
 
+  // The stamp has to happen after the FOR UPDATE read, not when the resolver
+  // was entered: an edit that queued behind a concurrent writer would otherwise
+  // commit a timestamp minted before it started waiting, writing an updated_at
+  // older than the row it replaces. That column orders the library and is the
+  // token the next client's basedOn is compared against.
+  it('stamps updatedAt after the row lock, not before the transaction opens', async () => {
+    vi.useFakeTimers();
+    try {
+      const enteredAt = new Date('2026-08-19T00:00:00.000Z');
+      vi.setSystemTime(enteredAt);
+
+      const ctx = makeCtx();
+      const updateChain = createMockChain([updatedRow]);
+      mockTx.select.mockReturnValueOnce(createMockChain([{ playlistId: 1 }])); // ownership
+      mockTx.select.mockImplementationOnce(() => {
+        // Stand in for the lock wait: the writer ahead of us commits, and only
+        // then does this transaction get its locked read.
+        vi.setSystemTime(new Date(enteredAt.getTime() + 5_000));
+        return createMockChain([updatedRow]);
+      });
+      mockTx.update.mockReturnValueOnce(updateChain);
+      mockDb.select.mockReturnValueOnce(createMockChain([{ count: 0 }])); // climbCount
+      mockDb.select.mockReturnValueOnce(createMockChain([])); // pin lookup
+
+      await playlistMutations.updatePlaylist(null, { input: { playlistId: 'p-uuid', name: 'Renamed' } }, ctx);
+
+      const setArg = (updateChain.set as ReturnType<typeof vi.fn>).mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg.updatedAt).toBeInstanceOf(Date);
+      expect((setArg.updatedAt as Date).getTime()).toBe(enteredAt.getTime() + 5_000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps a real colour value', async () => {
     const ctx = makeCtx();
     const updateChain = primeDb();

--- a/packages/backend/src/graphql/resolvers/playlists/helpers/update-conflict.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/helpers/update-conflict.ts
@@ -1,0 +1,109 @@
+/**
+ * Compare-and-swap rule for `updatePlaylist` (#1934).
+ *
+ * A playlist rename is the one offline-replayable mutation that can't be
+ * auto-merged (see the doc block on PLAYLIST_UPDATE_CONFLICT_CODE in
+ * @boardsesh/shared-schema), so the server has to be able to say "this changed
+ * somewhere else" instead of quietly keeping whichever write landed last.
+ *
+ * Pure and dependency-free so the rule can be unit-tested without a database.
+ */
+
+/** The metadata fields an edit can carry. Shared by stored / incoming / based-on. */
+export type PlaylistMetadataFields = {
+  name?: string | null;
+  description?: string | null;
+  isPublic?: boolean | null;
+  color?: string | null;
+  icon?: string | null;
+};
+
+export type PlaylistUpdateConflictArgs = {
+  /** The row as it is in the database right now. */
+  stored: PlaylistMetadataFields & { updatedAt: Date };
+  /** The fields this edit wants to write (absent = leave unchanged). */
+  incoming: PlaylistMetadataFields;
+  /** What the client last saw, or undefined for blind last-write-wins. */
+  basedOn?: (PlaylistMetadataFields & { updatedAt: string }) | null;
+};
+
+const TEXT_FIELDS = ['name', 'description', 'color', 'icon'] as const;
+
+/**
+ * Collapse the '' clear signal and NULL to one value, mirroring the resolver's
+ * `|| null` write path — a description cleared to '' is stored as NULL, so a
+ * client that still holds the '' it typed must compare equal to the NULL on disk.
+ *
+ * `undefined` is preserved: it means "this field wasn't sent", which is a
+ * different question from "this field is empty".
+ */
+export function normalizePlaylistText(value: string | null | undefined): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null || value === '') return null;
+  return value;
+}
+
+function valuesMatch(left: string | null | undefined, right: string | null | undefined): boolean {
+  // undefined never matches: an absent based-on field can't prove the client saw
+  // the stored value, and an absent incoming field isn't being written at all.
+  if (left === undefined || right === undefined) return false;
+  return left === right;
+}
+
+/**
+ * Whether this edit must be refused as a conflict.
+ *
+ * Three stages, in order:
+ *
+ * 1. No `basedOn` → never a conflict. Pre-#1934 clients and web send no
+ *    snapshot and keep today's blind last-write-wins behaviour.
+ *
+ * 2. The stored row is no newer than the snapshot → apply. This is the fast
+ *    path: nothing has happened since the client read the playlist.
+ *
+ * 3. The stored row IS newer → conflict only when some field this edit writes
+ *    disagrees with BOTH the stored value and the value the client saw.
+ *
+ * Stage 3 is what makes the check usable at all. `addClimbToPlaylist`,
+ * `removeClimbFromPlaylist` and `reorderPlaylistClimb` all bump
+ * `playlists.updated_at` (that column drives library ordering, so they can't
+ * stop), which means a bare timestamp comparison would report a conflict every
+ * time someone adds a climb — including when the same device's own outbox
+ * drains an add ahead of the rename. Comparing the actual values keeps the
+ * timestamp as a cheap gate and lets the field check decide.
+ *
+ * It also makes an ambiguous re-send a no-op success: if the rename already
+ * landed, the incoming values equal the stored ones, so there is nothing to
+ * disagree about.
+ */
+export function detectPlaylistUpdateConflict({ stored, incoming, basedOn }: PlaylistUpdateConflictArgs): boolean {
+  // Stage 1 — opt-in only.
+  if (!basedOn) return false;
+
+  // Stage 2 — nothing moved. `updated_at` is a `timestamp` without time zone and
+  // round-trips Date → toISOString → parse at millisecond precision; any sub-ms
+  // drift only pushes the decision into stage 3, where identical values apply.
+  const basedOnUpdatedAt = Date.parse(basedOn.updatedAt);
+  if (!Number.isNaN(basedOnUpdatedAt) && stored.updatedAt.getTime() <= basedOnUpdatedAt) return false;
+
+  // Stage 3 — the row moved, so check whether it moved in a way this edit cares about.
+  for (const field of TEXT_FIELDS) {
+    const incomingValue = normalizePlaylistText(incoming[field]);
+    if (incomingValue === undefined) continue; // not being written
+    const storedValue = normalizePlaylistText(stored[field]);
+    if (valuesMatch(storedValue, incomingValue)) continue; // already what we want
+    if (valuesMatch(storedValue, normalizePlaylistText(basedOn[field]))) continue; // nobody else touched it
+    return true;
+  }
+
+  // isPublic is non-null on the server, so a null in the snapshot means the
+  // client had no value for it — the conservative case, same as an absent field.
+  if (incoming.isPublic !== undefined && incoming.isPublic !== null) {
+    const storedIsPublic = stored.isPublic ?? false;
+    const sawIsPublic = basedOn.isPublic ?? undefined;
+    const clientSawStoredValue = sawIsPublic !== undefined && sawIsPublic === storedIsPublic;
+    if (storedIsPublic !== incoming.isPublic && !clientSawStoredValue) return true;
+  }
+
+  return false;
+}

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -222,10 +222,13 @@ export const playlistMutations = {
 
     const userId = ctx.userId!;
 
-    // Build update object (only update provided fields)
-    const updateData: Record<string, unknown> = {
-      updatedAt: new Date(),
-    };
+    // Build update object (only update provided fields). `updatedAt` is stamped
+    // inside the transaction below, once the row lock is actually held: an edit
+    // that queued behind a concurrent writer would otherwise commit the
+    // timestamp it minted before it started waiting, writing an updated_at older
+    // than the row it replaces. That column orders the library and is the token
+    // the next client's `basedOn` is compared against.
+    const updateData: Record<string, unknown> = {};
 
     // Normalize the empty-string "clear" signal to NULL so a cleared field is
     // stored as NULL, not '' (matches createPlaylist's `|| null`). `undefined`
@@ -297,7 +300,7 @@ export const playlistMutations = {
 
       const [updatedRow] = await tx
         .update(dbSchema.playlists)
-        .set(updateData)
+        .set({ ...updateData, updatedAt: new Date() })
         .where(eq(dbSchema.playlists.id, lockedPlaylistId))
         .returning();
 

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -240,7 +240,11 @@ export const playlistMutations = {
     // transaction with the playlist row locked (#1934). Splitting them would
     // leave a read-then-write window in which the very edit the client is being
     // compared against could land, which is exactly the race the check exists to
-    // catch. Same `for('update')` pattern as reorderPlaylistClimb below.
+    // catch. Same `for('update')` pattern as reorderPlaylistClimb below, which
+    // runs its ownership check outside the transaction entirely. To be precise
+    // about what the lock covers: the playlist row, not the ownership row. An
+    // ownership revoke committing mid-edit races this check exactly as it races
+    // every other playlist mutation; closing that is a separate job.
     const updated = await db.transaction(async (tx) => {
       const ownership = await tx
         .select({ playlistId: dbSchema.playlists.id })

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -2,6 +2,7 @@ import { eq, and, asc, inArray, sql } from 'drizzle-orm';
 import { GraphQLError } from 'graphql';
 import { v4 as uuidv4 } from 'uuid';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { PLAYLIST_UPDATE_CONFLICT_CODE } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, validateInput } from '../shared/helpers';
@@ -18,6 +19,7 @@ import { UNIFIED_TABLES } from '../../../db/queries/util/table-select';
 import { getPlaylistFollowStats } from './queries';
 import { verifyPlaylistAccess } from './helpers/enrichment';
 import { computePlaylistReorderWrites } from './helpers/reorder';
+import { detectPlaylistUpdateConflict } from './helpers/update-conflict';
 import { logger } from '../../../utils/logger';
 
 type ClimbBoardScope = { boardType: string; layoutId: number };
@@ -220,26 +222,6 @@ export const playlistMutations = {
 
     const userId = ctx.userId!;
 
-    // Check ownership
-    const ownership = await db
-      .select()
-      .from(dbSchema.playlistOwnership)
-      .innerJoin(dbSchema.playlists, eq(dbSchema.playlists.id, dbSchema.playlistOwnership.playlistId))
-      .where(
-        and(
-          eq(dbSchema.playlists.uuid, validatedInput.playlistId),
-          eq(dbSchema.playlistOwnership.userId, userId),
-          eq(dbSchema.playlistOwnership.role, 'owner'),
-        ),
-      )
-      .limit(1);
-
-    if (ownership.length === 0) {
-      throw new Error('Playlist not found or you do not have permission to edit it');
-    }
-
-    const playlistId = ownership[0].playlists.id;
-
     // Build update object (only update provided fields)
     const updateData: Record<string, unknown> = {
       updatedAt: new Date(),
@@ -254,14 +236,74 @@ export const playlistMutations = {
     if (validatedInput.color !== undefined) updateData.color = validatedInput.color || null;
     if (validatedInput.icon !== undefined) updateData.icon = validatedInput.icon || null;
 
-    // Update playlist
-    const [updated] = await db
-      .update(dbSchema.playlists)
-      .set(updateData)
-      .where(eq(dbSchema.playlists.id, playlistId))
-      .returning();
+    // Ownership check, conflict check and the write all happen inside one
+    // transaction with the playlist row locked (#1934). Splitting them would
+    // leave a read-then-write window in which the very edit the client is being
+    // compared against could land, which is exactly the race the check exists to
+    // catch. Same `for('update')` pattern as reorderPlaylistClimb below.
+    const updated = await db.transaction(async (tx) => {
+      const ownership = await tx
+        .select({ playlistId: dbSchema.playlists.id })
+        .from(dbSchema.playlistOwnership)
+        .innerJoin(dbSchema.playlists, eq(dbSchema.playlists.id, dbSchema.playlistOwnership.playlistId))
+        .where(
+          and(
+            eq(dbSchema.playlists.uuid, validatedInput.playlistId),
+            eq(dbSchema.playlistOwnership.userId, userId),
+            eq(dbSchema.playlistOwnership.role, 'owner'),
+          ),
+        )
+        .limit(1);
 
-    // Get climb count and follow stats
+      if (ownership.length === 0) {
+        throw new Error('Playlist not found or you do not have permission to edit it');
+      }
+
+      const lockedPlaylistId = ownership[0].playlistId;
+
+      const [stored] = await tx
+        .select()
+        .from(dbSchema.playlists)
+        .where(eq(dbSchema.playlists.id, lockedPlaylistId))
+        .for('update')
+        .limit(1);
+
+      if (!stored) {
+        throw new Error('Playlist not found or you do not have permission to edit it');
+      }
+
+      if (detectPlaylistUpdateConflict({ stored, incoming: validatedInput, basedOn: validatedInput.basedOn })) {
+        // The extensions carry the server's current values so the client can name
+        // both versions in its prompt and rebuild `basedOn` for a "keep mine"
+        // retry without a refetch. GraphQLError extensions survive yoga's
+        // maskError untouched (mask-error.ts only rewrites DB/driver leaks).
+        throw new GraphQLError('This playlist changed somewhere else', {
+          extensions: {
+            code: PLAYLIST_UPDATE_CONFLICT_CODE,
+            playlistUuid: stored.uuid,
+            serverUpdatedAt: stored.updatedAt.toISOString(),
+            serverName: stored.name,
+            serverDescription: stored.description,
+            serverIsPublic: stored.isPublic,
+            serverColor: stored.color,
+            serverIcon: stored.icon,
+          },
+        });
+      }
+
+      const [updatedRow] = await tx
+        .update(dbSchema.playlists)
+        .set(updateData)
+        .where(eq(dbSchema.playlists.id, lockedPlaylistId))
+        .returning();
+
+      return updatedRow;
+    });
+
+    const playlistId = updated.id;
+
+    // Climb count, follow stats and the pin lookup stay OUTSIDE the transaction
+    // so the row lock is held for the compare-and-swap only.
     const climbCount = await db
       .select({ count: sql<number>`count(*)::int` })
       .from(dbSchema.playlistClimbs)

--- a/packages/backend/src/validation/schemas/playlists.ts
+++ b/packages/backend/src/validation/schemas/playlists.ts
@@ -26,6 +26,30 @@ export const CreatePlaylistInputSchema = z.object({
   icon: PlaylistIconSchema,
 });
 
+// The snapshot the client based its edit on (#1934). `updatedAt` must parse as a
+// date: an unparseable string would make every comparison read "stored is newer"
+// and turn every edit into a conflict, so reject it at the door.
+//
+// Every metadata field is nullish, not optional — a client mirroring what it read
+// sends `description: null` for a playlist that has none, and that null is
+// meaningful ("I saw no description"). An ABSENT field is the conservative case:
+// the comparison can't prove the client saw the stored value, so it counts as
+// divergent.
+export const PlaylistRevisionInputSchema = z.object({
+  updatedAt: z
+    .string()
+    .min(1)
+    .refine((updatedAt) => !Number.isNaN(Date.parse(updatedAt)), 'basedOn.updatedAt must be a parseable date'),
+  name: PlaylistNameSchema.nullish(),
+  description: z.string().max(500, 'Playlist description too long').nullish(),
+  isPublic: z.boolean().nullish(),
+  color: z
+    .string()
+    .refine((color) => color === '' || isValidPlaylistColor(color), 'Invalid color format (must be hex)')
+    .nullish(),
+  icon: z.string().max(50, 'Icon name too long').nullish(),
+});
+
 export const UpdatePlaylistInputSchema = z.object({
   playlistId: z.string().min(1),
   name: PlaylistNameSchema.optional(),
@@ -33,6 +57,7 @@ export const UpdatePlaylistInputSchema = z.object({
   isPublic: z.boolean().optional(),
   color: PlaylistColorSchema,
   icon: PlaylistIconSchema,
+  basedOn: PlaylistRevisionInputSchema.optional(),
 });
 
 export const AddClimbToPlaylistInputSchema = z.object({

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -408,6 +408,39 @@ export default function PlaylistDetail() {
     [queryClient, playlistUuid],
   );
 
+  // The playlist as it looked when the edit sheet was opened, kept in a ref
+  // rather than read off the live query at submit time (#1934).
+  //
+  // The detail query refetches on app foreground and on reconnect — the query
+  // provider bridges React Query's focusManager to AppState and onlineManager to
+  // NetInfo, and the global staleTime is five minutes. So a sheet left open
+  // while the climber gets interrupted can have another device's rename land in
+  // the cache underneath it. PlaylistFormSheet seeds its fields only on the
+  // visible false→true edge, so the typed name survives that refetch — and a
+  // snapshot read at submit time would not. It would arrive at the server
+  // already matching the stored row, the compare-and-swap would see nothing to
+  // decide, and the other device's rename would be overwritten with no prompt:
+  // the exact silent loss this change exists to stop.
+  //
+  // Capturing at open can't invent a false conflict either. A bump this device
+  // caused itself (adding a climb) moves updated_at without moving the metadata,
+  // and the server's field comparison still applies the edit.
+  const editBasedOnRef = useRef<PlaylistRevision | null>(null);
+
+  const capturePlaylistRevision = useCallback((source: Playlist | null | undefined): PlaylistRevision | null => {
+    // A cached row from before `updatedAt` shipped in the fragment has nothing to
+    // compare against, so it falls back to last-write-wins.
+    if (!source?.updatedAt) return null;
+    return {
+      updatedAt: source.updatedAt,
+      name: source.name,
+      description: source.description ?? null,
+      isPublic: source.isPublic,
+      color: source.color ?? null,
+      icon: source.icon ?? null,
+    };
+  }, []);
+
   const handleEditSubmit = useCallback(
     async (values: PlaylistFormValues) => {
       if (!playlist) return;
@@ -432,22 +465,12 @@ export default function PlaylistDetail() {
       };
 
       try {
-        // What this edit is based on. The server compares it against the stored
-        // row and refuses rather than silently overwriting a rename made on
-        // another device (#1934). A cached row from before this field shipped
-        // has no updatedAt, and falls back to last-write-wins.
-        await saveEdit(
-          playlist.updatedAt
-            ? {
-                updatedAt: playlist.updatedAt,
-                name: playlist.name,
-                description: playlist.description ?? null,
-                isPublic: playlist.isPublic,
-                color: playlist.color ?? null,
-                icon: playlist.icon ?? null,
-              }
-            : undefined,
-        );
+        // What this edit is based on: the version the sheet was opened on. The
+        // server compares it against the stored row and refuses rather than
+        // silently overwriting a rename made on another device (#1934). The
+        // fallback covers a sheet that somehow became visible without going
+        // through openEditDetails — blind last-write-wins, as before.
+        await saveEdit(editBasedOnRef.current ?? capturePlaylistRevision(playlist) ?? undefined);
       } catch (err) {
         // Checked BEFORE reporting: a conflict is an expected outcome the
         // climber resolves, not a fault (same treatment as the beta-link
@@ -542,7 +565,7 @@ export default function PlaylistDetail() {
         setSavingEdit(false);
       }
     },
-    [playlist, updatePlaylist, cacheUpdatedPlaylist, queryClient, playlistUuid, showToast, t],
+    [playlist, updatePlaylist, cacheUpdatedPlaylist, capturePlaylistRevision, queryClient, playlistUuid, showToast, t],
   );
 
   const handleDelete = useCallback(() => {
@@ -572,8 +595,10 @@ export default function PlaylistDetail() {
   // involved, so no sheet-handoff dance is needed.
   const openEditDetails = useCallback(() => {
     setEditError(null);
+    // Snapshot now, not at submit — see editBasedOnRef.
+    editBasedOnRef.current = capturePlaylistRevision(playlist);
     setEditVisible(true);
-  }, []);
+  }, [playlist, capturePlaylistRevision]);
 
   // Collapsed overflow menu (owner): Pin toggles in place; Delete confirms; Edit
   // enters the climbs edit mode once the menu sheet has dismissed (deferred via

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -456,7 +456,13 @@ export default function PlaylistDetail() {
         if (conflict) {
           Alert.alert(
             t('edit.conflict.title'),
-            t('edit.conflict.message', { serverName: conflict.serverName, yourName: values.name }),
+            // The server also conflicts on description, colour, icon and
+            // visibility, so the two names can be identical. Quoting them back
+            // would read as "saved as X now, your edit says X" — say the details
+            // diverged instead.
+            conflict.serverName === values.name
+              ? t('edit.conflict.messageDetails')
+              : t('edit.conflict.message', { serverName: conflict.serverName, yourName: values.name }),
             [
               { text: t('edit.conflict.cancel'), style: 'cancel' },
               {

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -462,19 +462,22 @@ export default function PlaylistDetail() {
               {
                 text: t('edit.conflict.keepTheirs'),
                 onPress: () => {
-                  queryClient.setQueryData<Playlist | null>(['playlist', playlistUuid], (prev) =>
-                    prev
-                      ? {
-                          ...prev,
-                          name: conflict.serverName,
-                          description: conflict.serverDescription ?? undefined,
-                          isPublic: conflict.serverIsPublic,
-                          color: conflict.serverColor ?? undefined,
-                          icon: conflict.serverIcon ?? undefined,
-                          updatedAt: conflict.serverUpdatedAt,
-                        }
-                      : prev,
-                  );
+                  // Adopting theirs has to land in BOTH caches, same as a
+                  // successful save — patching only the detail hero would leave
+                  // the library list and Add-to-Playlist picker on the old name.
+                  // Read the cache at press time rather than reusing the row
+                  // captured at submit, so a climb added while the prompt was up
+                  // isn't rolled back.
+                  const current = queryClient.getQueryData<Playlist>(['playlist', playlistUuid]) ?? playlist;
+                  cacheUpdatedPlaylist({
+                    ...current,
+                    name: conflict.serverName,
+                    description: conflict.serverDescription ?? undefined,
+                    isPublic: conflict.serverIsPublic,
+                    color: conflict.serverColor ?? undefined,
+                    icon: conflict.serverIcon ?? undefined,
+                    updatedAt: conflict.serverUpdatedAt,
+                  });
                   setEditVisible(false);
                 },
               },
@@ -505,6 +508,9 @@ export default function PlaylistDetail() {
               },
             ],
           );
+          // The `finally` below still runs on this return, so the submit button
+          // stops spinning while the prompt is up: dismissing the alert leaves an
+          // editable sheet with the edit intact, not a frozen one.
           return;
         }
         console.error('Failed to update playlist:', err);

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -468,6 +468,11 @@ export default function PlaylistDetail() {
                   // Read the cache at press time rather than reusing the row
                   // captured at submit, so a climb added while the prompt was up
                   // isn't rolled back.
+                  // `?? undefined` because `Playlist` types the optional text
+                  // fields as `string | undefined`; a save response puts the
+                  // server's raw `null` in the same slots. Both mean "unset" to
+                  // every consumer — nothing compares these to `null` — but if
+                  // that ever stops being true, fix it in the type, not here.
                   const current = queryClient.getQueryData<Playlist>(['playlist', playlistUuid]) ?? playlist;
                   cacheUpdatedPlaylist({
                     ...current,

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -498,6 +498,15 @@ export default function PlaylistDetail() {
                       icon: conflict.serverIcon,
                     });
                   } catch (retryError) {
+                    // A third device can land between this prompt and the retry.
+                    // Say so inline rather than prompting again — a prompt chain
+                    // has no natural end — and don't report it: it's still an
+                    // expected outcome, not a fault. Saving from the still-open
+                    // sheet re-prompts with the newest server values.
+                    if (readPlaylistUpdateConflict(retryError)) {
+                      setEditError(t('edit.conflict.changedAgain'));
+                      return;
+                    }
                     console.error('Failed to update playlist:', retryError);
                     reportHandledError(retryError, { tags: { source: 'playlist', op: 'update-keep-mine' } });
                     setEditError(t('edit.messages.updateFailed'));

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -19,6 +19,7 @@ import {
   type GetPlaylistClimbsInput,
   type GetPlaylistClimbsQueryResponse,
   type Playlist,
+  type PlaylistRevision,
 } from '@boardsesh/graphql/operations/playlists';
 import { Text } from '../../../src/components/Text';
 import { Icon } from '../../../src/components/Icon';
@@ -46,6 +47,7 @@ import { usePlaylistRenderBoard } from '../../../src/lib/playlists/use-playlist-
 import { resolvePlaylistClimbRenderBoard } from '../../../src/lib/playlists/playlist-climb-render-board';
 import { recordPlaylistOpen } from '../../../src/lib/playlists/recents-store';
 import { reportHandledError } from '../../../src/lib/error-reporting';
+import { readPlaylistUpdateConflict } from '../../../src/lib/graphql/extract-error-message';
 import { toQueueClimbs } from '../../../src/lib/climb-types';
 import { hapticSelection } from '../../../src/lib/haptics';
 import { useAuth } from '../../../src/providers/auth-provider';
@@ -393,12 +395,26 @@ export default function PlaylistDetail() {
     }
   }, [playlist, isFollowing, followPlaylist, unfollowPlaylist, queryClient, playlistUuid, showToast, t]);
 
+  // Both caches that hold this playlist: the detail hero, and the
+  // Add-to-Playlist picker's list (the shelves refetch on focus, but that cache
+  // wouldn't until its staleTime lapses).
+  const cacheUpdatedPlaylist = useCallback(
+    (updated: Playlist) => {
+      queryClient.setQueryData(['playlist', playlistUuid], updated);
+      queryClient.setQueryData<Playlist[]>(['userPlaylists'], (prev) =>
+        prev?.map((entry) => (entry.uuid === updated.uuid || entry.id === updated.id ? updated : entry)),
+      );
+    },
+    [queryClient, playlistUuid],
+  );
+
   const handleEditSubmit = useCallback(
     async (values: PlaylistFormValues) => {
       if (!playlist) return;
       setSavingEdit(true);
       setEditError(null);
-      try {
+
+      const saveEdit = async (basedOn: PlaylistRevision | undefined) => {
         const updated = await updatePlaylist({
           playlistId: playlist.uuid,
           name: values.name,
@@ -408,16 +424,89 @@ export default function PlaylistDetail() {
           color: values.color,
           icon: values.icon,
           isPublic: values.isPublic,
+          basedOn,
         });
-        queryClient.setQueryData(['playlist', playlistUuid], updated);
-        // Also patch the Add-to-Playlist picker's react-query list (the shelves
-        // refetch on focus, but this cache wouldn't until its staleTime lapses).
-        queryClient.setQueryData<Playlist[]>(['userPlaylists'], (prev) =>
-          prev?.map((entry) => (entry.uuid === updated.uuid || entry.id === updated.id ? updated : entry)),
-        );
+        cacheUpdatedPlaylist(updated);
         setEditVisible(false);
         showToast(t('edit.messages.updated'), 'success');
+      };
+
+      try {
+        // What this edit is based on. The server compares it against the stored
+        // row and refuses rather than silently overwriting a rename made on
+        // another device (#1934). A cached row from before this field shipped
+        // has no updatedAt, and falls back to last-write-wins.
+        await saveEdit(
+          playlist.updatedAt
+            ? {
+                updatedAt: playlist.updatedAt,
+                name: playlist.name,
+                description: playlist.description ?? null,
+                isPublic: playlist.isPublic,
+                color: playlist.color ?? null,
+                icon: playlist.icon ?? null,
+              }
+            : undefined,
+        );
       } catch (err) {
+        // Checked BEFORE reporting: a conflict is an expected outcome the
+        // climber resolves, not a fault (same treatment as the beta-link
+        // validation rejections).
+        const conflict = readPlaylistUpdateConflict(err);
+        if (conflict) {
+          Alert.alert(
+            t('edit.conflict.title'),
+            t('edit.conflict.message', { serverName: conflict.serverName, yourName: values.name }),
+            [
+              { text: t('edit.conflict.cancel'), style: 'cancel' },
+              {
+                text: t('edit.conflict.keepTheirs'),
+                onPress: () => {
+                  queryClient.setQueryData<Playlist | null>(['playlist', playlistUuid], (prev) =>
+                    prev
+                      ? {
+                          ...prev,
+                          name: conflict.serverName,
+                          description: conflict.serverDescription ?? undefined,
+                          isPublic: conflict.serverIsPublic,
+                          color: conflict.serverColor ?? undefined,
+                          icon: conflict.serverIcon ?? undefined,
+                          updatedAt: conflict.serverUpdatedAt,
+                        }
+                      : prev,
+                  );
+                  setEditVisible(false);
+                },
+              },
+              {
+                text: t('edit.conflict.keepMine'),
+                style: 'destructive',
+                onPress: async () => {
+                  setSavingEdit(true);
+                  try {
+                    // Re-based on the server's own values, so the retry compares
+                    // clean and overwrites deliberately rather than by accident.
+                    await saveEdit({
+                      updatedAt: conflict.serverUpdatedAt,
+                      name: conflict.serverName,
+                      description: conflict.serverDescription,
+                      isPublic: conflict.serverIsPublic,
+                      color: conflict.serverColor,
+                      icon: conflict.serverIcon,
+                    });
+                  } catch (retryError) {
+                    console.error('Failed to update playlist:', retryError);
+                    reportHandledError(retryError, { tags: { source: 'playlist', op: 'update-keep-mine' } });
+                    setEditError(t('edit.messages.updateFailed'));
+                  } finally {
+                    setSavingEdit(false);
+                  }
+                },
+              },
+            ],
+          );
+          return;
+        }
         console.error('Failed to update playlist:', err);
         reportHandledError(err, { tags: { source: 'playlist', op: 'update' } });
         // Inline, not a toast: the sheet is still open, so a root toast would be
@@ -427,7 +516,7 @@ export default function PlaylistDetail() {
         setSavingEdit(false);
       }
     },
-    [playlist, updatePlaylist, queryClient, playlistUuid, showToast, t],
+    [playlist, updatePlaylist, cacheUpdatedPlaylist, queryClient, playlistUuid, showToast, t],
   );
 
   const handleDelete = useCallback(() => {

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -594,6 +594,39 @@ describe('PlaylistDetail edit conflict (#1934)', () => {
     expect(updatePlaylistMock).toHaveBeenCalledTimes(1);
   });
 
+  it('does not quote two identical names back when the details are what diverged', async () => {
+    requestMock.mockResolvedValue({ playlist: cachedPlaylist });
+    // Both devices kept the name and changed the colour: the name-vs-name
+    // wording would read "saved as Bad climbs now, your edit says Bad climbs".
+    updatePlaylistMock.mockRejectedValue({
+      response: {
+        errors: [
+          {
+            message: 'This playlist changed somewhere else',
+            extensions: {
+              ...conflictError.response.errors[0].extensions,
+              serverName: 'Bad climbs',
+              serverColor: '#8C4A52',
+            },
+          },
+        ],
+      },
+    });
+
+    const { findByText } = renderDetail();
+    fireEvent.click(await findByText('form-submit'));
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    expect(alertMock.mock.calls[0][1]).toBe('edit.conflict.messageDetails');
+    // Keep mine / Use theirs still resolve the whole record.
+    const buttons = alertMock.mock.calls[0][2] as Array<{ text: string }>;
+    expect(buttons.map((button) => button.text)).toEqual([
+      'edit.conflict.cancel',
+      'edit.conflict.keepTheirs',
+      'edit.conflict.keepMine',
+    ]);
+  });
+
   it('"Keep mine" losing a second race says so inline instead of reporting a fault', async () => {
     requestMock.mockResolvedValue({ playlist: cachedPlaylist });
     // A third device lands between the prompt and the retry.

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -78,6 +78,11 @@ vi.mock('../../../../src/components/you/CommentSheet', () => ({
 const climbsRefetch = vi.hoisted(() => vi.fn());
 const updatePlaylistMock = vi.hoisted(() => vi.fn());
 const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
+// A playlist-update conflict is an expected, user-resolvable outcome, so the
+// screen must NOT report it — spy on the reporter to prove that.
+const reportHandledErrorMock = vi.hoisted(() => vi.fn());
+const alertMock = vi.hoisted(() => vi.fn());
+vi.mock('../../../../src/lib/error-reporting', () => ({ reportHandledError: reportHandledErrorMock }));
 vi.mock('@boardsesh/playlists-react', () => ({
   usePlaylistClimbs: () => ({
     query: {
@@ -121,7 +126,7 @@ vi.mock('react-native', () => ({
     accessibilityLabel?: string;
   }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1, absoluteFill: {} },
-  Alert: { alert: vi.fn() },
+  Alert: { alert: alertMock },
   Platform: { OS: 'ios' },
 }));
 
@@ -239,6 +244,8 @@ beforeEach(() => {
   climbsRefetch.mockClear();
   updatePlaylistMock.mockReset();
   toast.showToast.mockClear();
+  alertMock.mockReset();
+  reportHandledErrorMock.mockReset();
   playlistMocks.allClimbs = [];
   playlistMocks.activationOptions = null;
   playlistMocks.renderBoardResult = { renderBoard: null, banner: null };
@@ -456,5 +463,132 @@ describe('PlaylistDetail discussion thread', () => {
     fireEvent.click(container.querySelector('[data-owner-edit="true"]') as HTMLButtonElement);
 
     await waitFor(() => expect(container.querySelector('[data-discussion-row="true"]')).toBeNull());
+  });
+});
+
+describe('PlaylistDetail edit conflict (#1934)', () => {
+  const cachedPlaylist = {
+    uuid: 'p-1',
+    id: 'p-1',
+    name: 'Old name',
+    icon: '🔥',
+    color: '#6D28D9',
+    description: '',
+    updatedAt: '2026-08-10T11:00:00.000Z',
+    climbCount: 3,
+    boardType: 'kilter',
+    layoutId: 1,
+    isPublic: false,
+    userRole: 'owner',
+    isPinnedByMe: false,
+    isFollowedByMe: false,
+    followerCount: 0,
+  };
+
+  // graphql-request's ClientError shape, as the backend's GraphQLError arrives.
+  const conflictError = {
+    response: {
+      errors: [
+        {
+          message: 'This playlist changed somewhere else',
+          extensions: {
+            code: 'PLAYLIST_UPDATE_CONFLICT',
+            playlistUuid: 'p-1',
+            serverUpdatedAt: '2026-08-10T12:30:00.000Z',
+            serverName: 'Renamed on the other phone',
+            serverDescription: null,
+            serverIsPublic: false,
+            serverColor: '#1F2937',
+            serverIcon: null,
+          },
+        },
+      ],
+    },
+  };
+
+  it('sends the cached playlist as basedOn so the server can refuse a collision', async () => {
+    requestMock.mockResolvedValue({ playlist: cachedPlaylist });
+    updatePlaylistMock.mockResolvedValue({ ...cachedPlaylist, name: 'Bad climbs' });
+
+    const { findByText } = renderDetail();
+    fireEvent.click(await findByText('form-submit'));
+
+    await waitFor(() => expect(updatePlaylistMock).toHaveBeenCalledTimes(1));
+    expect(updatePlaylistMock.mock.calls[0][0]).toMatchObject({
+      playlistId: 'p-1',
+      name: 'Bad climbs',
+      basedOn: {
+        updatedAt: '2026-08-10T11:00:00.000Z',
+        name: 'Old name',
+        description: '',
+        isPublic: false,
+        color: '#6D28D9',
+        icon: '🔥',
+      },
+    });
+  });
+
+  it('prompts instead of reporting a fault, and keeps the inline error clear', async () => {
+    requestMock.mockResolvedValue({ playlist: cachedPlaylist });
+    updatePlaylistMock.mockRejectedValue(conflictError);
+
+    const { findByText, container } = renderDetail();
+    fireEvent.click(await findByText('form-submit'));
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    expect(alertMock.mock.calls[0][0]).toBe('edit.conflict.title');
+    // A conflict is the climber's decision to make, not a fault to triage.
+    expect(reportHandledErrorMock).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-edit-error="true"]')).toBeNull();
+  });
+
+  it('"Keep mine" retries rebased on the server values from the conflict', async () => {
+    requestMock.mockResolvedValue({ playlist: cachedPlaylist });
+    updatePlaylistMock.mockRejectedValueOnce(conflictError);
+    updatePlaylistMock.mockResolvedValueOnce({ ...cachedPlaylist, name: 'Bad climbs' });
+
+    const { findByText } = renderDetail();
+    fireEvent.click(await findByText('form-submit'));
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    const buttons = alertMock.mock.calls[0][2] as Array<{ text: string; onPress?: () => void }>;
+    const keepMine = buttons.find((button) => button.text === 'edit.conflict.keepMine');
+    keepMine?.onPress?.();
+
+    await waitFor(() => expect(updatePlaylistMock).toHaveBeenCalledTimes(2));
+    // Rebased on what the server reported, so the second attempt overwrites
+    // deliberately rather than tripping the same check again.
+    expect(updatePlaylistMock.mock.calls[1][0]).toMatchObject({
+      name: 'Bad climbs',
+      basedOn: {
+        updatedAt: '2026-08-10T12:30:00.000Z',
+        name: 'Renamed on the other phone',
+        description: null,
+        isPublic: false,
+        color: '#1F2937',
+        icon: null,
+      },
+    });
+  });
+
+  it('"Use theirs" adopts the server version in the cache without another write', async () => {
+    requestMock.mockResolvedValue({ playlist: cachedPlaylist });
+    updatePlaylistMock.mockRejectedValue(conflictError);
+
+    const { queryClient, findByText } = renderDetail();
+    fireEvent.click(await findByText('form-submit'));
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    const buttons = alertMock.mock.calls[0][2] as Array<{ text: string; onPress?: () => void }>;
+    buttons.find((button) => button.text === 'edit.conflict.keepTheirs')?.onPress?.();
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<{ name: string; updatedAt: string; color: string }>(['playlist', 'p-1']);
+      expect(cached?.name).toBe('Renamed on the other phone');
+      expect(cached?.updatedAt).toBe('2026-08-10T12:30:00.000Z');
+      expect(cached?.color).toBe('#1F2937');
+    });
+    // Adopting theirs is a local decision — nothing more is sent.
+    expect(updatePlaylistMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -594,6 +594,27 @@ describe('PlaylistDetail edit conflict (#1934)', () => {
     expect(updatePlaylistMock).toHaveBeenCalledTimes(1);
   });
 
+  it('"Keep mine" losing a second race says so inline instead of reporting a fault', async () => {
+    requestMock.mockResolvedValue({ playlist: cachedPlaylist });
+    // A third device lands between the prompt and the retry.
+    updatePlaylistMock.mockRejectedValue(conflictError);
+
+    const { findByText, container } = renderDetail();
+    fireEvent.click(await findByText('form-submit'));
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    const buttons = alertMock.mock.calls[0][2] as Array<{ text: string; onPress?: () => void }>;
+    buttons.find((button) => button.text === 'edit.conflict.keepMine')?.onPress?.();
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-edit-error="true"]')?.textContent).toBe('edit.conflict.changedAgain');
+    });
+    // Still an expected outcome, not a fault — and no second prompt, which would
+    // have no natural end.
+    expect(reportHandledErrorMock).not.toHaveBeenCalled();
+    expect(alertMock).toHaveBeenCalledTimes(1);
+  });
+
   it('"Use theirs" also refreshes the library list, not just the detail hero', async () => {
     requestMock.mockResolvedValue({ playlist: cachedPlaylist });
     updatePlaylistMock.mockRejectedValue(conflictError);

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { Climb } from '@boardsesh/queue';
@@ -180,11 +180,22 @@ vi.mock('../../../../src/components/playlist', () => ({
     hero,
     headerSlot,
     actions,
+    onEditDetails,
   }: {
     hero: { name: string };
     headerSlot?: ReactNode;
     actions?: (collapsed: boolean) => ReactNode;
-  }) => createElement('div', { 'data-detail-view': 'true', 'data-hero-name': hero.name }, actions?.(false), headerSlot),
+    onEditDetails?: () => void;
+  }) =>
+    createElement(
+      'div',
+      { 'data-detail-view': 'true', 'data-hero-name': hero.name },
+      actions?.(false),
+      headerSlot,
+      // The cog that opens the details sheet. Driving it matters: that press is
+      // where the basedOn snapshot is taken (#1934).
+      createElement('button', { 'data-open-edit-details': 'true', onClick: onEditDetails }, 'open-edit-details'),
+    ),
   PlaylistDiscussionRow: ({ commentCount, onPress }: { commentCount: number; onPress: () => void }) =>
     createElement(
       'button',
@@ -513,6 +524,7 @@ describe('PlaylistDetail edit conflict (#1934)', () => {
     updatePlaylistMock.mockResolvedValue({ ...cachedPlaylist, name: 'Bad climbs' });
 
     const { findByText } = renderDetail();
+    fireEvent.click(await findByText('open-edit-details'));
     fireEvent.click(await findByText('form-submit'));
 
     await waitFor(() => expect(updatePlaylistMock).toHaveBeenCalledTimes(1));
@@ -535,6 +547,7 @@ describe('PlaylistDetail edit conflict (#1934)', () => {
     updatePlaylistMock.mockRejectedValue(conflictError);
 
     const { findByText, container } = renderDetail();
+    fireEvent.click(await findByText('open-edit-details'));
     fireEvent.click(await findByText('form-submit'));
 
     await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
@@ -550,6 +563,7 @@ describe('PlaylistDetail edit conflict (#1934)', () => {
     updatePlaylistMock.mockResolvedValueOnce({ ...cachedPlaylist, name: 'Bad climbs' });
 
     const { findByText } = renderDetail();
+    fireEvent.click(await findByText('open-edit-details'));
     fireEvent.click(await findByText('form-submit'));
 
     await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
@@ -578,6 +592,7 @@ describe('PlaylistDetail edit conflict (#1934)', () => {
     updatePlaylistMock.mockRejectedValue(conflictError);
 
     const { queryClient, findByText } = renderDetail();
+    fireEvent.click(await findByText('open-edit-details'));
     fireEvent.click(await findByText('form-submit'));
 
     await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
@@ -614,6 +629,7 @@ describe('PlaylistDetail edit conflict (#1934)', () => {
     });
 
     const { findByText } = renderDetail();
+    fireEvent.click(await findByText('open-edit-details'));
     fireEvent.click(await findByText('form-submit'));
 
     await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
@@ -633,6 +649,7 @@ describe('PlaylistDetail edit conflict (#1934)', () => {
     updatePlaylistMock.mockRejectedValue(conflictError);
 
     const { findByText, container } = renderDetail();
+    fireEvent.click(await findByText('open-edit-details'));
     fireEvent.click(await findByText('form-submit'));
 
     await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
@@ -657,6 +674,7 @@ describe('PlaylistDetail edit conflict (#1934)', () => {
     queryClient.setQueryData(['userPlaylists'], [{ uuid: 'p-1', id: 'p-1', name: 'Old name', color: '#6D28D9' }]);
 
     const { findByText } = renderDetail(queryClient);
+    fireEvent.click(await findByText('open-edit-details'));
     fireEvent.click(await findByText('form-submit'));
 
     await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
@@ -684,6 +702,7 @@ describe('PlaylistDetail edit conflict (#1934)', () => {
     const { findByText, container } = renderDetail();
     const submitting = () => container.querySelector('[data-form-sheet]')?.getAttribute('data-submitting');
 
+    fireEvent.click(await findByText('open-edit-details'));
     fireEvent.click(await findByText('form-submit'));
     // In flight: the sheet's submit button spins.
     await waitFor(() => expect(submitting()).toBe('true'));
@@ -700,5 +719,40 @@ describe('PlaylistDetail edit conflict (#1934)', () => {
     await waitFor(() => expect(submitting()).toBe('false'));
     expect(container.querySelector('[data-edit-error="true"]')).toBeNull();
     expect(updatePlaylistMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the snapshot the sheet was opened on when the playlist refetches underneath it', async () => {
+    requestMock.mockResolvedValue({ playlist: cachedPlaylist });
+    updatePlaylistMock.mockResolvedValue({ ...cachedPlaylist, name: 'Bad climbs' });
+
+    const { queryClient, findByText } = renderDetail();
+    fireEvent.click(await findByText('open-edit-details'));
+
+    // Mid-edit, the app comes back to the foreground and the detail query
+    // refetches, picking up the other phone's rename. The form keeps the typed
+    // name (it seeds only on the open edge), so the snapshot has to keep the
+    // version the sheet was opened on too. Send the refreshed row instead and
+    // the server sees a basedOn that already matches what it has stored, decides
+    // there is nothing to arbitrate, and overwrites the other rename in silence.
+    await act(async () => {
+      queryClient.setQueryData(['playlist', 'p-1'], {
+        ...cachedPlaylist,
+        name: 'Renamed on the other phone',
+        updatedAt: '2026-08-10T12:30:00.000Z',
+      });
+    });
+
+    fireEvent.click(await findByText('form-submit'));
+
+    await waitFor(() => expect(updatePlaylistMock).toHaveBeenCalledTimes(1));
+    const sent = updatePlaylistMock.mock.calls[0][0] as { basedOn?: Record<string, unknown> };
+    expect(sent.basedOn).toEqual({
+      updatedAt: '2026-08-10T11:00:00.000Z',
+      name: 'Old name',
+      description: '',
+      isPublic: false,
+      color: '#6D28D9',
+      icon: '🔥',
+    });
   });
 });

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -196,14 +196,16 @@ vi.mock('../../../../src/components/playlist', () => ({
   // without the real gorhom sheet.
   PlaylistFormSheet: ({
     submitError,
+    submitting,
     onSubmit,
   }: {
     submitError?: string | null;
+    submitting?: boolean;
     onSubmit?: (values: unknown) => void;
   }) =>
     createElement(
       'div',
-      null,
+      { 'data-form-sheet': 'true', 'data-submitting': submitting ? 'true' : 'false' },
       submitError ? createElement('span', { 'data-edit-error': 'true' }, submitError) : null,
       createElement(
         'button',
@@ -589,6 +591,60 @@ describe('PlaylistDetail edit conflict (#1934)', () => {
       expect(cached?.color).toBe('#1F2937');
     });
     // Adopting theirs is a local decision — nothing more is sent.
+    expect(updatePlaylistMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('"Use theirs" also refreshes the library list, not just the detail hero', async () => {
+    requestMock.mockResolvedValue({ playlist: cachedPlaylist });
+    updatePlaylistMock.mockRejectedValue(conflictError);
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    // The library / Add-to-Playlist cache still holds the pre-conflict row.
+    queryClient.setQueryData(['userPlaylists'], [{ uuid: 'p-1', id: 'p-1', name: 'Old name', color: '#6D28D9' }]);
+
+    const { findByText } = renderDetail(queryClient);
+    fireEvent.click(await findByText('form-submit'));
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    const buttons = alertMock.mock.calls[0][2] as Array<{ text: string; onPress?: () => void }>;
+    buttons.find((button) => button.text === 'edit.conflict.keepTheirs')?.onPress?.();
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<Array<{ name: string; color: string }>>(['userPlaylists']);
+      expect(cached?.[0].name).toBe('Renamed on the other phone');
+      expect(cached?.[0].color).toBe('#1F2937');
+    });
+    // Only the metadata the server reported moves; the rest of the row survives.
+    expect(queryClient.getQueryData<{ climbCount: number }>(['playlist', 'p-1'])?.climbCount).toBe(3);
+  });
+
+  it('leaves an editable sheet — not one stuck mid-save — when the prompt is dismissed', async () => {
+    requestMock.mockResolvedValue({ playlist: cachedPlaylist });
+    let rejectUpdate: (reason: unknown) => void = () => {};
+    updatePlaylistMock.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectUpdate = reject;
+      }),
+    );
+
+    const { findByText, container } = renderDetail();
+    const submitting = () => container.querySelector('[data-form-sheet]')?.getAttribute('data-submitting');
+
+    fireEvent.click(await findByText('form-submit'));
+    // In flight: the sheet's submit button spins.
+    await waitFor(() => expect(submitting()).toBe('true'));
+
+    rejectUpdate(conflictError);
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    const buttons = alertMock.mock.calls[0][2] as Array<{ text: string; style?: string; onPress?: () => void }>;
+    const cancel = buttons.find((button) => button.text === 'edit.conflict.cancel');
+    expect(cancel?.style).toBe('cancel');
+    cancel?.onPress?.();
+
+    // Dismissed with the edit intact and the button live again, ready to retry.
+    await waitFor(() => expect(submitting()).toBe('false'));
+    expect(container.querySelector('[data-edit-error="true"]')).toBeNull();
     expect(updatePlaylistMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/src/lib/graphql/extract-error-message.ts
+++ b/packages/mobile/src/lib/graphql/extract-error-message.ts
@@ -83,12 +83,15 @@ export function isExpectedBetaValidationError(error: unknown): boolean {
   );
 }
 
-// The board-mutation rejections clients branch on are parsed in
+// The board- and playlist-mutation rejections clients branch on are parsed in
 // @boardsesh/graphql so web and mobile read the same shapes. Re-exported here so
-// board screens keep a single import for GraphQL error handling.
+// screens keep a single import for GraphQL error handling.
 export {
   isDuplicateBoardError,
   readDuplicateBoardError,
   isBoardLimitError,
+  isPlaylistUpdateConflictError,
+  readPlaylistUpdateConflict,
   type DuplicateBoardError,
+  type PlaylistUpdateConflict,
 } from '@boardsesh/graphql/errors';

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -1894,6 +1894,29 @@ input CreatePlaylistInput {
 }
 
 """
+The playlist as the client last saw it, sent alongside an edit so the server
+can refuse to silently overwrite someone else's change.
+
+Carries the metadata values as well as the timestamp on purpose: adding,
+removing or reordering a climb also bumps `updatedAt`, so a bare timestamp
+comparison would report a conflict for edits that don't actually collide.
+"""
+input PlaylistRevisionInput {
+  "The playlist's updatedAt when the client read it (ISO 8601)"
+  updatedAt: String!
+  "Name the client saw"
+  name: String
+  "Description the client saw"
+  description: String
+  "Visibility the client saw"
+  isPublic: Boolean
+  "Color the client saw"
+  color: String
+  "Icon the client saw"
+  icon: String
+}
+
+"""
 Input for updating a playlist.
 """
 input UpdatePlaylistInput {
@@ -1909,6 +1932,12 @@ input UpdatePlaylistInput {
   color: String
   "New icon"
   icon: String
+  """
+  Omit for blind last-write-wins (what pre-#1934 clients and web send).
+  Supply it to get a PLAYLIST_UPDATE_CONFLICT error instead of a silent
+  overwrite when the playlist changed somewhere else.
+  """
+  basedOn: PlaylistRevisionInput
 }
 
 """

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -4634,6 +4634,29 @@ export type PlaylistCreator = {
 };
 
 /**
+ * The playlist as the client last saw it, sent alongside an edit so the server
+ * can refuse to silently overwrite someone else's change.
+ *
+ * Carries the metadata values as well as the timestamp on purpose: adding,
+ * removing or reordering a climb also bumps `updatedAt`, so a bare timestamp
+ * comparison would report a conflict for edits that don't actually collide.
+ */
+export type PlaylistRevisionInput = {
+  /** Color the client saw */
+  color?: InputMaybe<Scalars['String']['input']>;
+  /** Description the client saw */
+  description?: InputMaybe<Scalars['String']['input']>;
+  /** Icon the client saw */
+  icon?: InputMaybe<Scalars['String']['input']>;
+  /** Visibility the client saw */
+  isPublic?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Name the client saw */
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** The playlist's updatedAt when the client read it (ISO 8601) */
+  updatedAt: Scalars['String']['input'];
+};
+
+/**
  * A popular board configuration (board type + layout + size + hold sets),
  * derived from the catalog of valid configurations ranked by climb count.
  */
@@ -7828,6 +7851,12 @@ export type UpdateGymKioskInput = {
 
 /** Input for updating a playlist. */
 export type UpdatePlaylistInput = {
+  /**
+   * Omit for blind last-write-wins (what pre-#1934 clients and web send).
+   * Supply it to get a PLAYLIST_UPDATE_CONFLICT error instead of a silent
+   * overwrite when the playlist changed somewhere else.
+   */
+  basedOn?: InputMaybe<PlaylistRevisionInput>;
   /** New color */
   color?: InputMaybe<Scalars['String']['input']>;
   /** New description */
@@ -8507,6 +8536,7 @@ export type ResolversTypes = ResolversObject<{
   PlaylistClimb: ResolverTypeWrapper<PlaylistClimb>;
   PlaylistClimbsResult: ResolverTypeWrapper<PlaylistClimbsResult>;
   PlaylistCreator: ResolverTypeWrapper<PlaylistCreator>;
+  PlaylistRevisionInput: PlaylistRevisionInput;
   PopularBoardConfig: ResolverTypeWrapper<PopularBoardConfig>;
   PopularBoardConfigConnection: ResolverTypeWrapper<PopularBoardConfigConnection>;
   PopularBoardConfigsInput: PopularBoardConfigsInput;
@@ -8871,6 +8901,7 @@ export type ResolversParentTypes = ResolversObject<{
   PlaylistClimb: PlaylistClimb;
   PlaylistClimbsResult: PlaylistClimbsResult;
   PlaylistCreator: PlaylistCreator;
+  PlaylistRevisionInput: PlaylistRevisionInput;
   PopularBoardConfig: PopularBoardConfig;
   PopularBoardConfigConnection: PopularBoardConfigConnection;
   PopularBoardConfigsInput: PopularBoardConfigsInput;

--- a/packages/shared-schema/src/index.ts
+++ b/packages/shared-schema/src/index.ts
@@ -12,3 +12,4 @@ export * from './aurora-import';
 export * from './moonboard-import';
 export * from './instagram-caption-parse';
 export * from './sync-error-codes';
+export * from './playlist-conflict';

--- a/packages/shared-schema/src/playlist-conflict.ts
+++ b/packages/shared-schema/src/playlist-conflict.ts
@@ -1,0 +1,56 @@
+/**
+ * ⚠️ READ THIS BEFORE ADDING ANOTHER OFFLINE-REPLAYABLE MUTATION ⚠️
+ *
+ * `updatePlaylist` is the ONE queued mutation that must never be auto-merged.
+ *
+ * Every other mutation the offline outbox replays is either idempotent (a tick
+ * upsert keyed by uuid, a favourite toggle, a playlist create keyed by a
+ * client-generated uuid) or commutative (adding, removing and reordering climbs
+ * inside a playlist — two devices doing both still converge on a sane list).
+ * Those can be replayed blind: the worst case is a redundant write.
+ *
+ * A playlist rename cannot. Two devices editing the same name produce two
+ * different intents, and picking one silently destroys the other. So the server
+ * refuses the write and hands the client both versions to choose between, using
+ * the code and extension shape below.
+ *
+ * If you add a mutation with the same property — a whole-record edit where the
+ * loser's intent is unrecoverable — REUSE `PLAYLIST_UPDATE_CONFLICT_CODE`'s
+ * shape (a code plus the server's current values) rather than inventing a new
+ * one, and give it a typed reader next to `readPlaylistUpdateConflict` in
+ * `@boardsesh/graphql/errors`. Clients already know how to prompt on this shape;
+ * a second shape means a second prompt to build and a second thing to forget.
+ *
+ * A conflict resolves to no HTTP/GraphQL numeric status, so the outbox's
+ * `isRetryable` returns false and the row dead-letters for the UI to resolve
+ * instead of burning its retry budget.
+ */
+
+/**
+ * The server refused a playlist metadata edit because the stored record moved on
+ * from the snapshot the client based its edit on, and the two disagree about at
+ * least one field being written.
+ *
+ * Only raised when the client opts in by sending `UpdatePlaylistInput.basedOn`.
+ * Omit it and the mutation stays blind last-write-wins, which is what pre-#1934
+ * clients (and web) do.
+ */
+export const PLAYLIST_UPDATE_CONFLICT_CODE = 'PLAYLIST_UPDATE_CONFLICT';
+
+/**
+ * What the server attaches to a `PLAYLIST_UPDATE_CONFLICT` error: the playlist's
+ * current stored values, so the client can name both versions in the prompt
+ * without a refetch, and rebuild `basedOn` for a "keep mine" retry.
+ */
+export type PlaylistUpdateConflictExtensions = {
+  code: typeof PLAYLIST_UPDATE_CONFLICT_CODE;
+  /** The playlist the edit targeted (its uuid, the client-facing id). */
+  playlistUuid: string;
+  /** The stored `updated_at`, ISO 8601 — the token a retry must be based on. */
+  serverUpdatedAt: string;
+  serverName: string;
+  serverDescription: string | null;
+  serverIsPublic: boolean;
+  serverColor: string | null;
+  serverIcon: string | null;
+};

--- a/packages/shared-schema/src/schema/playlists.ts
+++ b/packages/shared-schema/src/schema/playlists.ts
@@ -99,6 +99,29 @@ export const playlistsTypeDefs = /* GraphQL */ `
   }
 
   """
+  The playlist as the client last saw it, sent alongside an edit so the server
+  can refuse to silently overwrite someone else's change.
+
+  Carries the metadata values as well as the timestamp on purpose: adding,
+  removing or reordering a climb also bumps \`updatedAt\`, so a bare timestamp
+  comparison would report a conflict for edits that don't actually collide.
+  """
+  input PlaylistRevisionInput {
+    "The playlist's updatedAt when the client read it (ISO 8601)"
+    updatedAt: String!
+    "Name the client saw"
+    name: String
+    "Description the client saw"
+    description: String
+    "Visibility the client saw"
+    isPublic: Boolean
+    "Color the client saw"
+    color: String
+    "Icon the client saw"
+    icon: String
+  }
+
+  """
   Input for updating a playlist.
   """
   input UpdatePlaylistInput {
@@ -114,6 +137,12 @@ export const playlistsTypeDefs = /* GraphQL */ `
     color: String
     "New icon"
     icon: String
+    """
+    Omit for blind last-write-wins (what pre-#1934 clients and web send).
+    Supply it to get a PLAYLIST_UPDATE_CONFLICT error instead of a silent
+    overwrite when the playlist changed somewhere else.
+    """
+    basedOn: PlaylistRevisionInput
   }
 
   """

--- a/packages/shared/graphql/src/__tests__/errors.test.ts
+++ b/packages/shared/graphql/src/__tests__/errors.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { PLAYLIST_UPDATE_CONFLICT_CODE } from '@boardsesh/shared-schema';
+
+import { isPlaylistUpdateConflictError, readPlaylistUpdateConflict } from '../errors';
+
+const conflictExtensions = {
+  code: PLAYLIST_UPDATE_CONFLICT_CODE,
+  playlistUuid: 'pl-1',
+  serverUpdatedAt: '2026-08-10T12:00:00.000Z',
+  serverName: 'Renamed on the other phone',
+  serverDescription: 'theirs',
+  serverIsPublic: true,
+  serverColor: '#6D28D9',
+  serverIcon: '🔥',
+};
+
+describe('readPlaylistUpdateConflict', () => {
+  it('reads a graphql-request ClientError (response.errors[])', () => {
+    const clientError = {
+      response: { errors: [{ message: 'This playlist changed somewhere else', extensions: conflictExtensions }] },
+    };
+
+    expect(isPlaylistUpdateConflictError(clientError)).toBe(true);
+    expect(readPlaylistUpdateConflict(clientError)).toEqual({
+      playlistUuid: 'pl-1',
+      serverUpdatedAt: '2026-08-10T12:00:00.000Z',
+      serverName: 'Renamed on the other phone',
+      serverDescription: 'theirs',
+      serverIsPublic: true,
+      serverColor: '#6D28D9',
+      serverIcon: '🔥',
+    });
+  });
+
+  it('reads a re-thrown error carrying graphqlErrors[]', () => {
+    const rethrown = Object.assign(new Error('update failed'), {
+      graphqlErrors: [{ message: 'nope', extensions: conflictExtensions }],
+    });
+
+    expect(isPlaylistUpdateConflictError(rethrown)).toBe(true);
+    expect(readPlaylistUpdateConflict(rethrown)?.serverName).toBe('Renamed on the other phone');
+  });
+
+  it('reports absent optional server values as null, not undefined', () => {
+    const clientError = {
+      response: {
+        errors: [
+          {
+            extensions: {
+              code: PLAYLIST_UPDATE_CONFLICT_CODE,
+              playlistUuid: 'pl-1',
+              serverUpdatedAt: '2026-08-10T12:00:00.000Z',
+              serverName: 'Bare',
+              serverDescription: null,
+              serverIsPublic: false,
+              serverColor: null,
+              serverIcon: null,
+            },
+          },
+        ],
+      },
+    };
+
+    expect(readPlaylistUpdateConflict(clientError)).toEqual({
+      playlistUuid: 'pl-1',
+      serverUpdatedAt: '2026-08-10T12:00:00.000Z',
+      serverName: 'Bare',
+      serverDescription: null,
+      serverIsPublic: false,
+      serverColor: null,
+      serverIcon: null,
+    });
+  });
+
+  it('returns null for an unrelated error code', () => {
+    const otherError = { response: { errors: [{ extensions: { code: 'BOARD_LIMIT_REACHED' } }] } };
+
+    expect(isPlaylistUpdateConflictError(otherError)).toBe(false);
+    expect(readPlaylistUpdateConflict(otherError)).toBeNull();
+  });
+
+  it('returns null for a conflict whose identity extensions did not survive', () => {
+    // A proxy that strips extensions, or an older server: the caller can still
+    // tell it IS a conflict, but there is nothing to show or retry against.
+    const strippedError = { response: { errors: [{ extensions: { code: PLAYLIST_UPDATE_CONFLICT_CODE } }] } };
+
+    expect(isPlaylistUpdateConflictError(strippedError)).toBe(true);
+    expect(readPlaylistUpdateConflict(strippedError)).toBeNull();
+  });
+
+  it('returns null for a plain error with no GraphQL payload', () => {
+    expect(isPlaylistUpdateConflictError(new Error('network down'))).toBe(false);
+    expect(readPlaylistUpdateConflict(new Error('network down'))).toBeNull();
+  });
+});

--- a/packages/shared/graphql/src/errors.ts
+++ b/packages/shared/graphql/src/errors.ts
@@ -3,6 +3,8 @@
 // errors carrying `response.errors[]`; some call sites re-throw with
 // `graphqlErrors`, so both shapes are accepted.
 
+import { PLAYLIST_UPDATE_CONFLICT_CODE } from '@boardsesh/shared-schema';
+
 type GraphqlErrorLike = {
   message?: string;
   extensions?: {
@@ -85,4 +87,57 @@ export function readDuplicateBoardError(error: unknown): DuplicateBoardError | n
  */
 export function isBoardLimitError(error: unknown): boolean {
   return getGraphqlErrors(error).some((graphqlError) => graphqlError.extensions?.code === 'BOARD_LIMIT_REACHED');
+}
+
+/** The playlist as it stands on the server, per a rejected edit. */
+export type PlaylistUpdateConflict = {
+  playlistUuid: string;
+  /** The stored `updatedAt` — feed it back as `basedOn.updatedAt` to retry. */
+  serverUpdatedAt: string;
+  serverName: string;
+  serverDescription: string | null;
+  serverIsPublic: boolean;
+  serverColor: string | null;
+  serverIcon: string | null;
+};
+
+/**
+ * The server refusing a playlist edit because the playlist changed somewhere
+ * else since the client read it (#1934). Only raised for clients that opt in by
+ * sending `UpdatePlaylistInput.basedOn`.
+ *
+ * Expected and user-resolvable, not a fault to report: the climber picks a
+ * version. Use `readPlaylistUpdateConflict` to get the values to show them.
+ */
+export function isPlaylistUpdateConflictError(error: unknown): boolean {
+  return getGraphqlErrors(error).some(
+    (graphqlError) => graphqlError.extensions?.code === PLAYLIST_UPDATE_CONFLICT_CODE,
+  );
+}
+
+/**
+ * The server's current version of the playlist whose edit was refused, or null
+ * when the error is something else — or is a conflict whose identity extensions
+ * didn't survive (a proxy that strips them, an older server). Callers that only
+ * need to decide whether to prompt should use `isPlaylistUpdateConflictError`.
+ */
+export function readPlaylistUpdateConflict(error: unknown): PlaylistUpdateConflict | null {
+  for (const graphqlError of getGraphqlErrors(error)) {
+    if (graphqlError.extensions?.code !== PLAYLIST_UPDATE_CONFLICT_CODE) continue;
+    const playlistUuid = asString(graphqlError.extensions.playlistUuid);
+    const serverUpdatedAt = asString(graphqlError.extensions.serverUpdatedAt);
+    const serverName = asString(graphqlError.extensions.serverName);
+    // Without these three there is nothing to show and nothing to retry against.
+    if (!playlistUuid || !serverUpdatedAt || !serverName) continue;
+    return {
+      playlistUuid,
+      serverUpdatedAt,
+      serverName,
+      serverDescription: asString(graphqlError.extensions.serverDescription),
+      serverIsPublic: graphqlError.extensions.serverIsPublic === true,
+      serverColor: asString(graphqlError.extensions.serverColor),
+      serverIcon: asString(graphqlError.extensions.serverIcon),
+    };
+  }
+  return null;
 }

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -4631,6 +4631,29 @@ export type PlaylistCreator = {
 };
 
 /**
+ * The playlist as the client last saw it, sent alongside an edit so the server
+ * can refuse to silently overwrite someone else's change.
+ *
+ * Carries the metadata values as well as the timestamp on purpose: adding,
+ * removing or reordering a climb also bumps `updatedAt`, so a bare timestamp
+ * comparison would report a conflict for edits that don't actually collide.
+ */
+export type PlaylistRevisionInput = {
+  /** Color the client saw */
+  color?: InputMaybe<Scalars['String']['input']>;
+  /** Description the client saw */
+  description?: InputMaybe<Scalars['String']['input']>;
+  /** Icon the client saw */
+  icon?: InputMaybe<Scalars['String']['input']>;
+  /** Visibility the client saw */
+  isPublic?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Name the client saw */
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** The playlist's updatedAt when the client read it (ISO 8601) */
+  updatedAt: Scalars['String']['input'];
+};
+
+/**
  * A popular board configuration (board type + layout + size + hold sets),
  * derived from the catalog of valid configurations ranked by climb count.
  */
@@ -7825,6 +7848,12 @@ export type UpdateGymKioskInput = {
 
 /** Input for updating a playlist. */
 export type UpdatePlaylistInput = {
+  /**
+   * Omit for blind last-write-wins (what pre-#1934 clients and web send).
+   * Supply it to get a PLAYLIST_UPDATE_CONFLICT error instead of a silent
+   * overwrite when the playlist changed somewhere else.
+   */
+  basedOn?: InputMaybe<PlaylistRevisionInput>;
   /** New color */
   color?: InputMaybe<Scalars['String']['input']>;
   /** New description */

--- a/packages/shared/graphql/src/operations/playlists.ts
+++ b/packages/shared/graphql/src/operations/playlists.ts
@@ -332,6 +332,25 @@ export type CreatePlaylistMutationResponse = {
   createPlaylist: Playlist;
 };
 
+/**
+ * The playlist as the client last saw it. Send it with an edit to get a
+ * PLAYLIST_UPDATE_CONFLICT error (read it with `readPlaylistUpdateConflict`)
+ * instead of silently overwriting a change made somewhere else (#1934).
+ *
+ * Every field the edit writes should be included, not just `updatedAt`: adding
+ * or reordering a climb bumps the playlist's `updatedAt` too, so the server
+ * compares values as well as the timestamp to avoid crying conflict over an
+ * edit that doesn't actually collide.
+ */
+export type PlaylistRevision = {
+  updatedAt: string;
+  name?: string | null;
+  description?: string | null;
+  isPublic?: boolean | null;
+  color?: string | null;
+  icon?: string | null;
+};
+
 export type UpdatePlaylistInput = {
   playlistId: string;
   name?: string;
@@ -339,6 +358,8 @@ export type UpdatePlaylistInput = {
   isPublic?: boolean;
   color?: string;
   icon?: string;
+  /** Omit for blind last-write-wins (what web still does). */
+  basedOn?: PlaylistRevision;
 };
 
 export type UpdatePlaylistMutationVariables = {

--- a/packages/shared/i18n/locales/de/playlists.json
+++ b/packages/shared/i18n/locales/de/playlists.json
@@ -204,6 +204,7 @@
     "conflict": {
       "title": "Woanders geändert",
       "message": "Diese Playlist heißt jetzt „{{serverName}}“. Deine Änderung sagt „{{yourName}}“.",
+      "changedAgain": "Sie hat sich noch mal geändert, während du überlegt hast. Speichere noch einmal, um sie zu übernehmen.",
       "keepMine": "Meine behalten",
       "keepTheirs": "Die andere nehmen",
       "cancel": "Abbrechen"

--- a/packages/shared/i18n/locales/de/playlists.json
+++ b/packages/shared/i18n/locales/de/playlists.json
@@ -204,6 +204,7 @@
     "conflict": {
       "title": "Woanders geändert",
       "message": "Diese Playlist heißt jetzt „{{serverName}}“. Deine Änderung sagt „{{yourName}}“.",
+      "messageDetails": "Jemand anders hat die Details dieser Playlist geändert, während du bearbeitet hast. Der Name ist gleich – wähle, welche Version vom Rest bleibt.",
       "changedAgain": "Sie hat sich noch mal geändert, während du überlegt hast. Speichere noch einmal, um sie zu übernehmen.",
       "keepMine": "Meine behalten",
       "keepTheirs": "Die andere nehmen",

--- a/packages/shared/i18n/locales/de/playlists.json
+++ b/packages/shared/i18n/locales/de/playlists.json
@@ -200,6 +200,13 @@
     "messages": {
       "updated": "Playlist aktualisiert",
       "updateFailed": "Die Playlist ließ sich nicht aktualisieren"
+    },
+    "conflict": {
+      "title": "Woanders geändert",
+      "message": "Diese Playlist heißt jetzt „{{serverName}}“. Deine Änderung sagt „{{yourName}}“.",
+      "keepMine": "Meine behalten",
+      "keepTheirs": "Die andere nehmen",
+      "cancel": "Abbrechen"
     }
   },
   "create": {

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -200,6 +200,13 @@
     "messages": {
       "updated": "Playlist updated successfully",
       "updateFailed": "Failed to update playlist"
+    },
+    "conflict": {
+      "title": "Changed somewhere else",
+      "message": "This playlist is saved as “{{serverName}}” now. Your edit says “{{yourName}}”.",
+      "keepMine": "Keep mine",
+      "keepTheirs": "Use theirs",
+      "cancel": "Cancel"
     }
   },
   "create": {

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -204,6 +204,7 @@
     "conflict": {
       "title": "Changed somewhere else",
       "message": "This playlist is saved as “{{serverName}}” now. Your edit says “{{yourName}}”.",
+      "changedAgain": "It changed again while you were deciding. Save again to pick it up.",
       "keepMine": "Keep mine",
       "keepTheirs": "Use theirs",
       "cancel": "Cancel"

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -204,6 +204,7 @@
     "conflict": {
       "title": "Changed somewhere else",
       "message": "This playlist is saved as “{{serverName}}” now. Your edit says “{{yourName}}”.",
+      "messageDetails": "Someone else changed this playlist’s details while you were editing. The name matches, so pick which version of the rest to keep.",
       "changedAgain": "It changed again while you were deciding. Save again to pick it up.",
       "keepMine": "Keep mine",
       "keepTheirs": "Use theirs",

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -204,6 +204,7 @@
     "conflict": {
       "title": "Cambió en otro sitio",
       "message": "Esta lista ahora se llama «{{serverName}}». Tu edición dice «{{yourName}}».",
+      "messageDetails": "Otra persona cambió los detalles de esta lista mientras editabas. El nombre coincide, así que elige con qué versión del resto te quedas.",
       "changedAgain": "Volvió a cambiar mientras decidías. Guarda otra vez para verlo.",
       "keepMine": "Quedarme con la mía",
       "keepTheirs": "Usar la otra",

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -200,6 +200,13 @@
     "messages": {
       "updated": "Lista actualizada correctamente",
       "updateFailed": "No se pudo actualizar la lista"
+    },
+    "conflict": {
+      "title": "Cambió en otro sitio",
+      "message": "Esta lista ahora se llama «{{serverName}}». Tu edición dice «{{yourName}}».",
+      "keepMine": "Quedarme con la mía",
+      "keepTheirs": "Usar la otra",
+      "cancel": "Cancelar"
     }
   },
   "create": {

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -204,6 +204,7 @@
     "conflict": {
       "title": "Cambió en otro sitio",
       "message": "Esta lista ahora se llama «{{serverName}}». Tu edición dice «{{yourName}}».",
+      "changedAgain": "Volvió a cambiar mientras decidías. Guarda otra vez para verlo.",
       "keepMine": "Quedarme con la mía",
       "keepTheirs": "Usar la otra",
       "cancel": "Cancelar"

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -204,6 +204,7 @@
     "conflict": {
       "title": "Modifiée ailleurs",
       "message": "Cette playlist s’appelle maintenant « {{serverName}} ». Votre modification dit « {{yourName}} ».",
+      "changedAgain": "Elle a encore changé pendant que vous décidiez. Enregistrez à nouveau pour la reprendre.",
       "keepMine": "Garder la mienne",
       "keepTheirs": "Garder l’autre",
       "cancel": "Annuler"

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -200,6 +200,13 @@
     "messages": {
       "updated": "Playlist mise à jour",
       "updateFailed": "Impossible de mettre à jour la playlist"
+    },
+    "conflict": {
+      "title": "Modifiée ailleurs",
+      "message": "Cette playlist s’appelle maintenant « {{serverName}} ». Votre modification dit « {{yourName}} ».",
+      "keepMine": "Garder la mienne",
+      "keepTheirs": "Garder l’autre",
+      "cancel": "Annuler"
     }
   },
   "create": {

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -204,6 +204,7 @@
     "conflict": {
       "title": "Modifiée ailleurs",
       "message": "Cette playlist s’appelle maintenant « {{serverName}} ». Votre modification dit « {{yourName}} ».",
+      "messageDetails": "Quelqu’un a modifié les détails de cette playlist pendant votre édition. Le nom est identique : choisissez quelle version garder pour le reste.",
       "changedAgain": "Elle a encore changé pendant que vous décidiez. Enregistrez à nouveau pour la reprendre.",
       "keepMine": "Garder la mienne",
       "keepTheirs": "Garder l’autre",

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
@@ -348,3 +348,31 @@ describe('isNetworkError / isRetryable — resolved status beats the English-pro
     expect(isRetryable(error)).toBe(true);
   });
 });
+
+describe('PLAYLIST_UPDATE_CONFLICT (#1934)', () => {
+  // A rename the server refused is a decision for the climber, not something to
+  // replay. It must dead-letter so the UI can surface it, rather than looping.
+  const conflictError = {
+    response: {
+      errors: [
+        {
+          message: 'This playlist changed somewhere else',
+          extensions: {
+            code: 'PLAYLIST_UPDATE_CONFLICT',
+            playlistUuid: 'pl-1',
+            serverUpdatedAt: '2026-08-10T12:00:00.000Z',
+            serverName: 'Renamed on the other phone',
+          },
+        },
+      ],
+    },
+  };
+
+  it('is not a network error and not retryable, so the drainer dead-letters it', () => {
+    // The string code resolves no numeric status, which is exactly what routes
+    // it to the dead-letter branch instead of the retry budget.
+    expect(getErrorStatus(conflictError)).toBeNull();
+    expect(isNetworkError(conflictError)).toBe(false);
+    expect(isRetryable(conflictError)).toBe(false);
+  });
+});

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/handlers.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/handlers.test.ts
@@ -92,3 +92,30 @@ describe('boardsesh_ticks update dispatch', () => {
     expect(variables).toEqual({ uuid: 'tick-uuid-3', input: { angle: 25 } });
   });
 });
+
+describe('playlists update dispatch', () => {
+  it('carries the basedOn snapshot through to UpdatePlaylistInput (#1934)', async () => {
+    const graphqlFetch = vi.fn().mockResolvedValue({});
+    const basedOn = {
+      updatedAt: '2026-08-10T11:00:00.000Z',
+      name: 'Crimps',
+      description: null,
+      isPublic: false,
+      color: '#6D28D9',
+      icon: '🔥',
+    };
+    const mutation = pendingMutation({
+      table_name: 'playlists',
+      operation: 'update',
+      payload: JSON.stringify({ playlistId: 'pl-1', name: 'Renamed offline', basedOn }),
+    });
+
+    await processMutation(mutation, graphqlFetch);
+
+    const [query, variables] = graphqlFetch.mock.calls[0];
+    expect(query).toContain('UpdatePlaylist');
+    // A rename is the one replay the server can't auto-merge, so the snapshot
+    // must survive the queue round-trip intact.
+    expect(variables).toEqual({ input: { playlistId: 'pl-1', name: 'Renamed offline', basedOn } });
+  });
+});

--- a/packages/shared/offline-sync/src/mutation-queue/handlers.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/handlers.ts
@@ -114,6 +114,22 @@ function buildDispatch(mutation: PendingMutation): MutationDispatch {
             mutationName: 'CreatePlaylist',
             variables: { input: { uuid: mutation.idempotency_key, ...payload } },
           };
+        // ⚠️ The ONLY queued mutation that cannot be auto-merged (#1934).
+        //
+        // Everything else this file dispatches is idempotent (uuid-keyed tick
+        // and playlist creates, favourite toggles) or commutative (climb
+        // add/remove/reorder). A playlist rename is neither: two devices editing
+        // the name produce two intents and replaying blind destroys one.
+        //
+        // So the payload must carry `basedOn` — the playlist as the enqueuing
+        // device saw it — and the server answers a genuine collision with
+        // PLAYLIST_UPDATE_CONFLICT. That error resolves to no HTTP/GraphQL
+        // numeric status, so `isRetryable` returns false and the drainer
+        // dead-letters the row for the UI to resolve instead of burning retries.
+        //
+        // Adding another whole-record edit here? Give it the same treatment
+        // rather than a new error shape — see PLAYLIST_UPDATE_CONFLICT_CODE's
+        // doc block in @boardsesh/shared-schema.
         case 'update':
           return {
             mutationName: 'UpdatePlaylist',


### PR DESCRIPTION
## Summary

`updatePlaylist` was blind last-write-wins. It checked ownership, stamped a fresh `updatedAt` and overwrote whatever arrived, with no based-on check anywhere in the stack — so two devices renaming the same playlist meant one climber's edit vanished with nothing to show for it.

`UpdatePlaylistInput` now takes an **optional** `basedOn` snapshot. When it's present, the ownership check, a `FOR UPDATE` read and the write all happen inside one transaction, and a genuine collision throws `PLAYLIST_UPDATE_CONFLICT` carrying the server's current values. Omit `basedOn` and nothing changes — every shipped store binary keeps today's behaviour.

Mobile's playlist edit sheet sends the snapshot and prompts on a conflict: **Keep mine** (retries rebased on the server's own values, so the overwrite is deliberate), **Use theirs** (adopts the server version into the cache, sends nothing), **Cancel** (sheet stays open with the edit intact).

### Why `basedOn` carries values, not just a timestamp

A bare `updated_at` comparison — the issue's literal wording — isn't usable here. `addClimbToPlaylist`, `removeClimbFromPlaylist` and `reorderPlaylistClimb` all bump `playlists.updated_at`, and that column drives library ordering (`queries/user-playlists.ts`, `queries/discover.ts`), so they can't stop bumping it. A timestamp-only check would report a conflict on every climb add, including one from the same device's own outbox draining ahead of the rename.

So the timestamp stays as the cheap gate and a field-level comparison decides: conflict only when a field this edit writes disagrees with **both** the stored value and the value the client saw. That also turns an ambiguous outbox re-send of an already-applied rename into a no-op success rather than a bogus prompt.

Both sides of every comparison are server-authored — `basedOn.updatedAt` is a value the client echoes back from a previous server response, never a local clock reading — so device clock skew can't affect the outcome.

The alternative — a dedicated `metadata_updated_at` column bumped only by `updatePlaylist` — is conceptually cleaner but costs a migration, the renumber-bot dance, a new nullable `Playlist` field, and edits to six row→GraphQL mappers where a missed one silently degrades the check. Not worth it for this.

### Why the snapshot is taken when the sheet opens

The client captures `basedOn` on the press that opens the edit sheet, not on the press that saves. The detail query refetches on app foreground and on reconnect (the query provider bridges React Query's `focusManager` to `AppState` and `onlineManager` to NetInfo; global `staleTime` is five minutes), so a sheet left open while the climber gets interrupted can have another device's rename land in the cache underneath it. `PlaylistFormSheet` seeds its fields only on the visible false→true edge, so the typed name survives that refetch — and a snapshot read at save time would not. It would reach the server already matching the stored row, the compare-and-swap would find nothing to arbitrate, and the other device's rename would be overwritten in silence.

Capturing at open can't invent a false conflict either: a bump this device caused itself (adding a climb) moves `updated_at` without moving the metadata, and the server's field comparison still applies the edit.

### Flagged loudly, as the issue asks

`PLAYLIST_UPDATE_CONFLICT_CODE` in `@boardsesh/shared-schema` carries a doc block saying this is the one offline-replayable mutation that can't be auto-merged, that every other queued mutation is idempotent or commutative, and that any future non-mergeable mutation must reuse this shape rather than invent one. The offline outbox's `playlists`/`update` branch carries the matching warning, including why a conflict dead-letters (it resolves to no numeric status, so `isRetryable` is false) instead of burning retries.

### Out of scope

- Enqueueing playlist metadata edits into the offline outbox — nothing calls `enqueue()` for the `playlists` table today, so the conflict is reachable via two online devices or a stale react-query cache. The server rule and the queue's handling land here; wiring offline rename is its own issue.
- Web. This is no longer a gap: #4467 deleted `packages/web/app/components/library/` from `main`, and nothing under `packages/web` calls `updatePlaylist` any more (the one near-miss, `playlist-detail-content.tsx`, calls `updatePlaylistLastAccessed`). The mobile app is the mutation's only client, so the opt-in guarantee is now total rather than per-client. That also makes #4267 and its stacked PR #4303 obsolete — see the review comment below.
- Conflict detection for climb add/remove/reorder and `deletePlaylist` — those auto-merge correctly.
- Locking `playlist_ownership` alongside the playlist row. An ownership revoke racing an edit predates this PR and is shared with all four playlist mutations (the other three check ownership outside their transaction entirely); closing it means a consistent lock order across all four.
- No migration, no drizzle schema change, no new `Playlist` output field.

Closes #1934

## Release Notes

- Rename a playlist on two devices at once and neither edit disappears — Boardsesh now asks which one you want to keep.

## Test plan

- `vp run typecheck` — pass.
- `vp run test:mobile` — 684 files, 6557 tests pass. The `#1934` block in `app/(tabs)/discover/__tests__/playlist-uuid.test.tsx` drives the real cog that opens the sheet and covers: the snapshot sent with the edit; a conflict prompting without calling `reportHandledError`; "Keep mine" retrying with the server-derived snapshot; "Use theirs" patching both caches with no second write; the dismiss path leaving an editable sheet; a second race reported inline rather than as a fault; the prompt not quoting two identical names; and a refetch landing under the open sheet **not** moving the snapshot (fails on a revert).
- `vp check` — no errors or warnings in any touched file. The 2 errors and 324 warnings the run reports all reproduce on clean `main` (`scripts/`, `packages/mobile/src/web-shims/`, unresolvable local-only modules) and are tracked in #4488.
- `vp test run --project offline-sync --project graphql --project shared-schema` — `packages/shared/graphql/src/__tests__/errors.test.ts` (both error shapes, stripped extensions, unrelated codes), a `basedOn` round-trip through the outbox dispatcher, and a case pinning that a conflict is neither a network error nor retryable.
- `vp test run --project i18n` — catalog parity across en-US/es/fr/de.
- `vp run check:mobile-bundle` — OK.
- Backend: `packages/backend/src/__tests__/playlist-update-conflict.test.ts` carries 9 unit cases for the rule plus real-DB cases (no `basedOn` applies; matching snapshot applies; another writer's rename throws with the server's name/description/visibility/colour/icon; a climb add that only bumped `updated_at` applies with **no** conflict; a stale re-send of already-applied values is a no-op success; a "keep mine" retry rebased on the error payload applies; a non-owner is still rejected). `playlist-update.test.ts` adds a case pinning that the write's `updatedAt` is stamped after the `FOR UPDATE` read, not when the resolver was entered — an edit queued behind a concurrent writer would otherwise commit a timestamp older than the row it replaces, and that column orders the library.
