### PR TITLE
test(mobile): catch web-fork export drift with a usage-based parity check

### DIFF
--- a/packages/mobile/src/__tests__/web-fork-export-parity.test.ts
+++ b/packages/mobile/src/__tests__/web-fork-export-parity.test.ts
@@ -1,0 +1,499 @@
+/**
+ * Web-fork export parity (issue #4242).
+ *
+ * `X.ts` / `X.web.ts` (or `.tsx`) pairs let a module diverge for the Expo web
+ * target while keeping one import path for callers — Metro swaps in the
+ * `.web` file when bundling for the browser. Nothing forces the two files to
+ * export the same names. When the native side gains an export and the web
+ * fork doesn't, every neutral (non-forked) caller that imports the new name
+ * still typechecks against `X.ts` but crashes at runtime on web, because
+ * Metro resolved `X.web.ts` and that name isn't there.
+ *
+ * That's exactly what happened to `session-store.ts` / `session-store.web.ts`
+ * (Sentry BOARDSESH-BW): #3502 added `getStoredCreatedSessionId` and its
+ * siblings to the native file; the `.web` fork didn't get them for 9 days,
+ * until #4199 backfilled it. This test would have caught that the moment the
+ * regression landed.
+ *
+ * The check is usage-based, not "every fork pair must export the same set".
+ * A blind superset check fails today on three real, harmless divergences:
+ * `auth-store.ts`'s `storeTokensForGeneration`/`clearTokensForGeneration`,
+ * `auth.ts`'s `oauthNativeSignIn`, and `share-target-provider.tsx`'s
+ * `extractSharedLink`. Each is only ever imported by a module that is *itself*
+ * a fork pair's native side (`auth-interceptor.ts`, `auth.ts` importing from
+ * `auth-store.ts`) or not imported outside its own file at all — so Metro-web
+ * never resolves into the gap. Flagging those would just teach people to
+ * ignore the test. Instead this walks the real import graph: for every fork
+ * pair, does any *platform-neutral* module (one Metro bundles unchanged for
+ * every platform) import a name from the native side that the web fork lacks?
+ *
+ * Deliberately not modelled (none of these occur in any current fork-pair
+ * usage — see .boardsesh/plan-4242.json for the verification):
+ *   - `export default`, `export *`, `export class`, destructuring exports
+ *   - `import * as ns` namespace access into a forked module
+ *   - dynamic `require('./forked-module')` / `import('./forked-module')`
+ *     (the one real case, `use-native-climb-render.ts`'s board-renderer
+ *     `require`, is a pair that's already export-symmetric today)
+ *   - the separate ios/android/web three-way split (`Button`, `SwitchRow`,
+ *     `AppMenu`, …), which has no bare `X.ts` native file to diff against —
+ *     those ship a hand-written `.d.ts` ambient contract instead.
+ * A future contributor exercising one of those patterns against a forked
+ * module won't get coverage from this test.
+ *
+ * No new dependency: `.boardsesh/DECISIONS.md` for #4242 requires reusing the
+ * repo's existing `typescript` package for AST work, with `bun.lock`
+ * untouched. The pinned `typescript@~7.0.2` (TypeScript's native port) does
+ * not expose a source-text parser from its default entry point — its `"."`
+ * export resolves only to `lib/version.cjs` (`{version, versionMajorMinor}`);
+ * see the same gap documented in `packages/web/scripts/check-orphaned-i18n-keys.ts`
+ * and `packages/web/app/__tests__/import-graph-invariant.test.ts`, both of
+ * which route around it via the `typescript-compiler-api` (pinned TS 6.x)
+ * devDependency alias. Adding that same alias to `packages/mobile` would
+ * touch `bun.lock`, which is exactly what's ruled out here. So this file
+ * extracts exports and named imports with line-anchored regexes over the
+ * statement-starting keyword instead of a real AST walk — verified safe
+ * against every one of the 36 real fork pairs in the repo today (no
+ * `export default`/`export *`/`export class`/destructuring export, and no
+ * mixed `import Default, { … }` import, appears in any of them).
+ */
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const MOBILE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/** Directories that never contribute fork pairs or importers. */
+const SKIPPED_DIR_NAMES = new Set(['node_modules', '__tests__', 'web-runtime', 'dist', 'ios', 'android']);
+
+// ---------------------------------------------------------------------------
+// File discovery
+// ---------------------------------------------------------------------------
+
+function toMobileRelative(mobileRoot: string, absolutePath: string): string {
+  return relative(mobileRoot, absolutePath).split(sep).join('/');
+}
+
+function isSourceFile(fileName: string): boolean {
+  return fileName.endsWith('.ts') || fileName.endsWith('.tsx');
+}
+
+function isTestFile(fileName: string): boolean {
+  return /\.(test|spec)\.[jt]sx?$/.test(fileName);
+}
+
+/** `.web.`, `.ios.`, `.android.` — a platform fork of some kind. */
+function isPlatformSuffixed(fileName: string): boolean {
+  return /\.(web|ios|android)\.tsx?$/.test(fileName);
+}
+
+function listSourceFiles(absoluteDir: string, collected: string[] = []): string[] {
+  if (!existsSync(absoluteDir)) return collected;
+  for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+    const absolutePath = join(absoluteDir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIPPED_DIR_NAMES.has(entry.name)) continue;
+      listSourceFiles(absolutePath, collected);
+      continue;
+    }
+    if (isSourceFile(entry.name)) collected.push(absolutePath);
+  }
+  return collected;
+}
+
+// ---------------------------------------------------------------------------
+// Export extraction
+// ---------------------------------------------------------------------------
+
+/** Value-level export identifiers a neutral module could import by name. */
+function extractExportNames(sourceText: string): Set<string> {
+  const names = new Set<string>();
+
+  for (const match of sourceText.matchAll(/^export\s+async\s+function\s*\*?\s*([A-Za-z_$][\w$]*)/gm)) {
+    names.add(match[1]);
+  }
+  for (const match of sourceText.matchAll(/^export\s+function\s*\*?\s*([A-Za-z_$][\w$]*)/gm)) {
+    names.add(match[1]);
+  }
+  for (const match of sourceText.matchAll(/^export\s+(?:const|let|var)\s+([A-Za-z_$][\w$]*)/gm)) {
+    names.add(match[1]);
+  }
+  for (const match of sourceText.matchAll(/^export\s+class\s+([A-Za-z_$][\w$]*)/gm)) {
+    names.add(match[1]);
+  }
+  // `export { a, b as c }` and `export { a } from '...'`. `export type { … }`
+  // is a separate, type-only statement and is skipped by the `(type\s+)?`
+  // capture below when present.
+  for (const match of sourceText.matchAll(/^export\s+(type\s+)?\{([^}]*)\}(?:\s*from\s*['"][^'"]+['"])?/gm)) {
+    const [, isTypeOnlyStatement, braceContent] = match;
+    if (isTypeOnlyStatement) continue;
+    for (const name of parseSpecifierExportedNames(braceContent)) names.add(name);
+  }
+
+  return names;
+}
+
+/**
+ * `{ a, b as c, type d }` -> ['a', 'c'] — the name a consumer would import,
+ * skipping individually type-only specifiers.
+ */
+function parseSpecifierExportedNames(braceContent: string): string[] {
+  const names: string[] = [];
+  for (const rawSpecifier of braceContent.split(',')) {
+    const specifier = rawSpecifier.trim().replace(/\s+/g, ' ');
+    if (specifier.length === 0) continue;
+    if (specifier.startsWith('type ')) continue;
+    const asMatch = /^(.+?)\s+as\s+(.+)$/.exec(specifier);
+    names.push(asMatch ? asMatch[2] : specifier);
+  }
+  return names;
+}
+
+/**
+ * `{ a, b as c, type d }` -> ['a', 'b'] — the name being pulled from the
+ * *source* module (left of `as`), skipping individually type-only specifiers.
+ * Mirrors `parseSpecifierExportedNames` but keeps the pre-`as` identifier.
+ */
+function parseSpecifierSourceNames(braceContent: string): string[] {
+  const names: string[] = [];
+  for (const rawSpecifier of braceContent.split(',')) {
+    const specifier = rawSpecifier.trim().replace(/\s+/g, ' ');
+    if (specifier.length === 0) continue;
+    if (specifier.startsWith('type ')) continue;
+    const asMatch = /^(.+?)\s+as\s+(.+)$/.exec(specifier);
+    names.push(asMatch ? asMatch[1] : specifier);
+  }
+  return names;
+}
+
+// ---------------------------------------------------------------------------
+// Import (and re-export) extraction
+// ---------------------------------------------------------------------------
+
+type NamedEdge = { names: string[]; specifier: string; line: number };
+
+function lineOf(sourceText: string, index: number): number {
+  let line = 1;
+  for (let position = 0; position < index; position += 1) {
+    if (sourceText.charCodeAt(position) === 10 /* \n */) line += 1;
+  }
+  return line;
+}
+
+/**
+ * Named `import { a, b as c } from '...'` and re-export `export { a } from
+ * '...'` edges. `import type { … }` / `export type { … } from '...'`
+ * (statement-level) are skipped, as are `import * as ns` and default-only
+ * imports (neither has a `{ … }` for the regex to match) — see the module
+ * doc comment for why that scope cut is safe today.
+ */
+function extractNamedEdges(sourceText: string): NamedEdge[] {
+  const edges: NamedEdge[] = [];
+
+  const importPattern = /^import\s+(type\s+)?(?:[A-Za-z_$][\w$]*\s*,\s*)?\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/gm;
+  for (const match of sourceText.matchAll(importPattern)) {
+    const [, isTypeOnlyStatement, braceContent, specifier] = match;
+    if (isTypeOnlyStatement) continue;
+    const names = parseSpecifierSourceNames(braceContent);
+    if (names.length === 0) continue;
+    edges.push({ names, specifier, line: lineOf(sourceText, match.index ?? 0) });
+  }
+
+  const reExportPattern = /^export\s+(type\s+)?\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/gm;
+  for (const match of sourceText.matchAll(reExportPattern)) {
+    const [, isTypeOnlyStatement, braceContent, specifier] = match;
+    if (isTypeOnlyStatement) continue;
+    const names = parseSpecifierSourceNames(braceContent);
+    if (names.length === 0) continue;
+    edges.push({ names, specifier, line: lineOf(sourceText, match.index ?? 0) });
+  }
+
+  return edges;
+}
+
+// ---------------------------------------------------------------------------
+// Fork-pair discovery
+// ---------------------------------------------------------------------------
+
+type ForkPair = { nativePath: string; webPath: string; nativeExports: Set<string>; webExports: Set<string> };
+
+/** `foo.web.tsx` -> `{ base: 'foo', preferredExt: '.tsx' }`; null if not a `.web` file. */
+function webForkBase(absolutePath: string): { base: string; preferredExt: '.ts' | '.tsx' } | null {
+  if (absolutePath.endsWith('.web.tsx'))
+    return { base: absolutePath.slice(0, -'.web.tsx'.length), preferredExt: '.tsx' };
+  if (absolutePath.endsWith('.web.ts')) return { base: absolutePath.slice(0, -'.web.ts'.length), preferredExt: '.ts' };
+  return null;
+}
+
+/**
+ * Pairs a `.web.ts(x)` file with its native `X.ts`/`X.tsx` sibling. Files
+ * with no native sibling (the ios/android/web three-way components, and the
+ * two web-only files `auth-cookie-lock.web.ts` / `overlay-cache-store.web.ts`)
+ * are skipped — there's nothing to diff their exports against.
+ */
+function discoverForkPairs(allSourceFiles: string[]): ForkPair[] {
+  const pairs: ForkPair[] = [];
+  for (const filePath of allSourceFiles) {
+    const forkBase = webForkBase(filePath);
+    if (!forkBase) continue;
+
+    const candidateExtensions: Array<'.ts' | '.tsx'> =
+      forkBase.preferredExt === '.tsx' ? ['.tsx', '.ts'] : ['.ts', '.tsx'];
+    const nativePath = candidateExtensions.map((ext) => forkBase.base + ext).find((candidate) => existsSync(candidate));
+    if (!nativePath) continue;
+
+    pairs.push({
+      nativePath,
+      webPath: filePath,
+      nativeExports: extractExportNames(readFileSync(nativePath, 'utf8')),
+      webExports: extractExportNames(readFileSync(filePath, 'utf8')),
+    });
+  }
+  return pairs;
+}
+
+// ---------------------------------------------------------------------------
+// Specifier resolution
+// ---------------------------------------------------------------------------
+
+function resolveToFile(candidateBase: string): string | null {
+  if (existsSync(candidateBase) && statSync(candidateBase).isFile()) return candidateBase;
+
+  for (const extension of ['.ts', '.tsx']) {
+    const withExtension = `${candidateBase}${extension}`;
+    if (existsSync(withExtension)) return withExtension;
+  }
+
+  if (existsSync(candidateBase) && statSync(candidateBase).isDirectory()) {
+    for (const extension of ['.ts', '.tsx']) {
+      const indexFile = join(candidateBase, `index${extension}`);
+      if (existsSync(indexFile)) return indexFile;
+    }
+  }
+
+  return null;
+}
+
+/** Relative imports resolve against the importer; `@/...` against `src/`; bare packages resolve to null. */
+function resolveSpecifier(specifier: string, importerAbsolutePath: string, mobileRoot: string): string | null {
+  if (specifier.startsWith('./') || specifier.startsWith('../')) {
+    return resolveToFile(resolve(dirname(importerAbsolutePath), specifier));
+  }
+  if (specifier.startsWith('@/')) {
+    return resolveToFile(join(mobileRoot, 'src', specifier.slice('@/'.length)));
+  }
+  return null; // bare package
+}
+
+// ---------------------------------------------------------------------------
+// Violation search
+// ---------------------------------------------------------------------------
+
+type Violation = { importer: string; line: number; name: string; nativePath: string; webPath: string };
+
+/**
+ * Discovers fork pairs under `roots` (default: real `src` + `modules`), then
+ * walks every platform-neutral module under `importerRoots` (default: real
+ * `src` + `app` — `modules` is fork-pair source material, not itself scanned
+ * for importers) for named imports / re-exports that reach into a fork
+ * pair's native side for a name the web fork lacks.
+ */
+function findViolations(
+  mobileRoot: string,
+  forkPairRoots: string[],
+  importerRoots: string[],
+): { violations: Violation[]; forkPairs: ForkPair[] } {
+  const forkPairSourceFiles = forkPairRoots.flatMap((root) => listSourceFiles(root));
+  const forkPairs = discoverForkPairs(forkPairSourceFiles);
+  const nativePathToPair = new Map(forkPairs.map((pair) => [pair.nativePath, pair]));
+
+  const importerFiles = importerRoots
+    .flatMap((root) => listSourceFiles(root))
+    .filter((filePath) => {
+      const fileName = basename(filePath);
+      if (isTestFile(fileName)) return false;
+      if (isPlatformSuffixed(fileName)) return false;
+      // The native side of a fork pair is never bundled for web (its `.web`
+      // sibling is used instead), so its own imports don't reach Metro-web.
+      if (nativePathToPair.has(filePath)) return false;
+      return true;
+    });
+
+  const violations: Violation[] = [];
+  for (const importerPath of importerFiles) {
+    const sourceText = readFileSync(importerPath, 'utf8');
+    for (const edge of extractNamedEdges(sourceText)) {
+      const targetPath = resolveSpecifier(edge.specifier, importerPath, mobileRoot);
+      if (targetPath === null) continue;
+
+      const pair = nativePathToPair.get(targetPath);
+      if (!pair) continue;
+
+      for (const name of edge.names) {
+        if (pair.nativeExports.has(name) && !pair.webExports.has(name)) {
+          violations.push({
+            importer: toMobileRelative(mobileRoot, importerPath),
+            line: edge.line,
+            name,
+            nativePath: toMobileRelative(mobileRoot, pair.nativePath),
+            webPath: toMobileRelative(mobileRoot, pair.webPath),
+          });
+        }
+      }
+    }
+  }
+
+  return {
+    violations: violations.sort(
+      (left, right) =>
+        left.importer.localeCompare(right.importer) || left.line - right.line || left.name.localeCompare(right.name),
+    ),
+    forkPairs,
+  };
+}
+
+function describeViolation(violation: Violation): string {
+  return [
+    `  packages/mobile/${violation.importer}:${violation.line}`,
+    `    imports '${violation.name}' from ${violation.nativePath}`,
+    `    which the web fork ${violation.webPath} does not export`,
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+
+describe('web-fork export parity: neutral importers never reach a gap in a .web fork', () => {
+  const realRoots = {
+    mobileRoot: MOBILE_ROOT,
+    forkPairRoots: [join(MOBILE_ROOT, 'src'), join(MOBILE_ROOT, 'modules')],
+    importerRoots: [join(MOBILE_ROOT, 'src'), join(MOBILE_ROOT, 'app')],
+  };
+
+  it('has no unallowed gap across the real repo', () => {
+    const { violations, forkPairs } = findViolations(
+      realRoots.mobileRoot,
+      realRoots.forkPairRoots,
+      realRoots.importerRoots,
+    );
+
+    // Sanity check the discovery itself found the fork pairs this test is
+    // meant to guard — an empty result here would mean the walk is broken,
+    // not that the repo has no forks.
+    expect(forkPairs.length).toBeGreaterThan(20);
+
+    const report = violations.map(describeViolation).join('\n\n');
+    expect(
+      violations,
+      violations.length === 0
+        ? ''
+        : [
+            `${violations.length} neutral import(s) reach past a gap in a .web fork:`,
+            '',
+            report,
+            '',
+            'Add the missing export(s) to the .web fork, or make the importer stop',
+            'depending on the platform-specific behaviour.',
+          ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('catches a session-store-shaped regression: native export dropped from the web fork and imported by a neutral caller', () => {
+    const fixtureDir = mkdtempSync(join(tmpdir(), 'web-fork-export-parity-regression-'));
+    try {
+      writeFileSync(
+        join(fixtureDir, 'store.ts'),
+        [`export function foo(): void {}`, ``, `export function bar(): void {}`, ``].join('\n'),
+      );
+      // The regression: the web fork never picked up `bar`.
+      writeFileSync(join(fixtureDir, 'store.web.ts'), [`export function foo(): void {}`, ``].join('\n'));
+      writeFileSync(join(fixtureDir, 'caller.ts'), [`import { bar } from './store';`, ``, `bar();`, ``].join('\n'));
+
+      const { violations } = findViolations(fixtureDir, [fixtureDir], [fixtureDir]);
+
+      expect(violations).toEqual([
+        {
+          importer: 'caller.ts',
+          line: 1,
+          name: 'bar',
+          nativePath: 'store.ts',
+          webPath: 'store.web.ts',
+        },
+      ]);
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not flag a native-only export nothing neutral imports (locks in the usage-based design)', () => {
+    // Mirrors the real, currently-harmless repo divergences (auth-store.ts's
+    // storeTokensForGeneration, auth.ts's oauthNativeSignIn,
+    // share-target-provider.tsx's extractSharedLink): the web fork is missing
+    // an export, but the only importer is itself a fork pair's native side —
+    // so it never reaches Metro-web and must not be flagged. A future
+    // contributor "fixing" this into a blind full-export-superset check
+    // would immediately red all three real cases; this test exists to stop
+    // that.
+    const fixtureDir = mkdtempSync(join(tmpdir(), 'web-fork-export-parity-harmless-'));
+    try {
+      writeFileSync(
+        join(fixtureDir, 'store.ts'),
+        [`export function foo(): void {}`, ``, `export function nativeOnly(): void {}`, ``].join('\n'),
+      );
+      writeFileSync(join(fixtureDir, 'store.web.ts'), [`export function foo(): void {}`, ``].join('\n'));
+      // `other.ts` is itself the native side of its own fork pair, so it's
+      // excluded from the "neutral importer" scan below.
+      writeFileSync(
+        join(fixtureDir, 'other.ts'),
+        [`import { nativeOnly } from './store';`, ``, `nativeOnly();`, ``].join('\n'),
+      );
+      writeFileSync(join(fixtureDir, 'other.web.ts'), [`export {};`, ``].join('\n'));
+
+      const { violations } = findViolations(fixtureDir, [fixtureDir], [fixtureDir]);
+
+      expect(violations).toEqual([]);
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves the edge kinds a grep would miss: multi-line import lists, aliases, and export-from re-exports', () => {
+    const fixtureDir = mkdtempSync(join(tmpdir(), 'web-fork-export-parity-edge-kinds-'));
+    try {
+      writeFileSync(join(fixtureDir, 'store.ts'), [`export function onlyNative(): void {}`, ``].join('\n'));
+      writeFileSync(join(fixtureDir, 'store.web.ts'), [`export {};`, ``].join('\n'));
+
+      writeFileSync(
+        join(fixtureDir, 'multiline-caller.ts'),
+        [`import {`, `  onlyNative as renamed,`, `} from './store';`, ``, `renamed();`, ``].join('\n'),
+      );
+      writeFileSync(join(fixtureDir, 're-export-caller.ts'), [`export { onlyNative } from './store';`, ``].join('\n'));
+      // Type-only imports never reach the runtime bundle and must not be flagged.
+      writeFileSync(
+        join(fixtureDir, 'type-only-caller.ts'),
+        [`import type { onlyNative } from './store';`, ``].join('\n'),
+      );
+
+      const { violations } = findViolations(fixtureDir, [fixtureDir], [fixtureDir]);
+
+      expect(violations).toEqual([
+        {
+          importer: 'multiline-caller.ts',
+          line: 1,
+          name: 'onlyNative',
+          nativePath: 'store.ts',
+          webPath: 'store.web.ts',
+        },
+        {
+          importer: 're-export-caller.ts',
+          line: 1,
+          name: 'onlyNative',
+          nativePath: 'store.ts',
+          webPath: 'store.web.ts',
+        },
+      ]);
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/mobile/src/__tests__/web-fork-export-parity.test.ts
+++ b/packages/mobile/src/__tests__/web-fork-export-parity.test.ts
@@ -56,7 +56,16 @@
  * `export default`/`export *`/`export class`/destructuring export, and no
  * mixed `import Default, { … }` import, appears in any of them).
  */
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -293,11 +302,16 @@ function resolveSpecifier(specifier: string, importerAbsolutePath: string, mobil
 type Violation = { importer: string; line: number; name: string; nativePath: string; webPath: string };
 
 /**
- * Discovers fork pairs under `roots` (default: real `src` + `modules`), then
- * walks every platform-neutral module under `importerRoots` (default: real
- * `src` + `app` — `modules` is fork-pair source material, not itself scanned
- * for importers) for named imports / re-exports that reach into a fork
- * pair's native side for a name the web fork lacks.
+ * Discovers fork pairs under `forkPairRoots`, then walks every
+ * platform-neutral module under `importerRoots` for named imports /
+ * re-exports that reach into a fork pair's native side for a name the web
+ * fork lacks. Against the real repo both roots are the same three trees
+ * (`src`, `app`, `modules`): Metro applies the `.web` platform extension in
+ * all of them, so a fork pair can live in any one, and a module in any one
+ * can be the neutral importer that falls into the gap. Keeping the two root
+ * lists identical also keeps the "is this importer itself a fork native
+ * side?" exclusion honest — a pair discovered in one list but not the other
+ * would make its native side look neutral.
  */
 function findViolations(
   mobileRoot: string,
@@ -364,11 +378,8 @@ function describeViolation(violation: Violation): string {
 // ---------------------------------------------------------------------------
 
 describe('web-fork export parity: neutral importers never reach a gap in a .web fork', () => {
-  const realRoots = {
-    mobileRoot: MOBILE_ROOT,
-    forkPairRoots: [join(MOBILE_ROOT, 'src'), join(MOBILE_ROOT, 'modules')],
-    importerRoots: [join(MOBILE_ROOT, 'src'), join(MOBILE_ROOT, 'app')],
-  };
+  const realTrees = [join(MOBILE_ROOT, 'src'), join(MOBILE_ROOT, 'app'), join(MOBILE_ROOT, 'modules')];
+  const realRoots = { mobileRoot: MOBILE_ROOT, forkPairRoots: realTrees, importerRoots: realTrees };
 
   it('has no unallowed gap across the real repo', () => {
     const { violations, forkPairs } = findViolations(
@@ -452,6 +463,45 @@ describe('web-fork export parity: neutral importers never reach a gap in a .web 
       const { violations } = findViolations(fixtureDir, [fixtureDir], [fixtureDir]);
 
       expect(violations).toEqual([]);
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  it('spans trees: a fork pair in one root is checked against an importer in another', () => {
+    // The real run scans `src`, `app` and `modules` as both fork-pair source
+    // and importer source. Dropping a tree from either list silently loses
+    // coverage — a pair in an unscanned tree is invisible, and its native
+    // side then looks like a neutral importer. This locks that in.
+    const fixtureDir = mkdtempSync(join(tmpdir(), 'web-fork-export-parity-cross-tree-'));
+    try {
+      const treeWithPair = join(fixtureDir, 'src');
+      const treeWithImporter = join(fixtureDir, 'app');
+      mkdirSync(treeWithPair);
+      mkdirSync(treeWithImporter);
+
+      writeFileSync(join(treeWithPair, 'store.ts'), [`export function onlyNative(): void {}`, ``].join('\n'));
+      writeFileSync(join(treeWithPair, 'store.web.ts'), [`export {};`, ``].join('\n'));
+      writeFileSync(
+        join(treeWithImporter, 'screen.ts'),
+        [`import { onlyNative } from '../src/store';`, ``, `onlyNative();`, ``].join('\n'),
+      );
+
+      const { violations } = findViolations(
+        fixtureDir,
+        [treeWithPair, treeWithImporter],
+        [treeWithPair, treeWithImporter],
+      );
+
+      expect(violations).toEqual([
+        {
+          importer: 'app/screen.ts',
+          line: 1,
+          name: 'onlyNative',
+          nativePath: 'src/store.ts',
+          webPath: 'src/store.web.ts',
+        },
+      ]);
     } finally {
       rmSync(fixtureDir, { recursive: true, force: true });
     }

--- a/packages/mobile/src/__tests__/web-fork-export-parity.test.ts
+++ b/packages/mobile/src/__tests__/web-fork-export-parity.test.ts
@@ -24,8 +24,12 @@
  * `auth-store.ts`) or not imported outside its own file at all — so Metro-web
  * never resolves into the gap. Flagging those would just teach people to
  * ignore the test. Instead this walks the real import graph: for every fork
- * pair, does any *platform-neutral* module (one Metro bundles unchanged for
- * every platform) import a name from the contract side that the web fork lacks?
+ * pair, does any module that Metro-web actually bundles import a name from the
+ * contract side that the web fork lacks? That's every platform-neutral module
+ * plus the `.web` forks themselves — a `.web` file importing a sibling fork
+ * through its unsuffixed path gets that sibling's `.web` implementation and
+ * falls into exactly the same gap. Only `.ios`/`.android` forks are out of
+ * scope; they never reach the browser.
  *
  * Two kinds of pair are checked, both keyed on the same question — what does a
  * caller typecheck against, and what does Metro-web actually bundle?
@@ -117,9 +121,15 @@ function isTestFile(fileName: string): boolean {
   return /\.(test|spec)\.[jt]sx?$/.test(fileName);
 }
 
-/** `.web.`, `.ios.`, `.android.` — a platform fork of some kind. */
-function isPlatformSuffixed(fileName: string): boolean {
-  return /\.(web|ios|android)\.tsx?$/.test(fileName);
+/**
+ * `.ios.` / `.android.` — a fork Metro never puts in the web bundle, so its
+ * imports can't be the ones that fall into a `.web` gap. Note `.web.` files
+ * are deliberately *not* here: they are bundled on web, and when one imports
+ * a sibling fork through the unsuffixed path Metro hands it that sibling's
+ * `.web` implementation, which is exactly the resolution this test guards.
+ */
+function isNativeOnlyFork(fileName: string): boolean {
+  return /\.(ios|android)\.tsx?$/.test(fileName);
 }
 
 function listSourceFiles(absoluteDir: string, collected: string[] = []): string[] {
@@ -380,7 +390,11 @@ function findViolations(
     .filter((filePath) => {
       const fileName = basename(filePath);
       if (isTestFile(fileName)) return false;
-      if (isPlatformSuffixed(fileName)) return false;
+      // `.ios`/`.android` forks never enter the web bundle. `.web` forks do,
+      // and they can import a *sibling* fork through its unsuffixed path —
+      // Metro then hands them that sibling's `.web` file, so they fall into
+      // the same gap as any neutral module and stay in scope here.
+      if (isNativeOnlyFork(fileName)) return false;
       // A declaration file emits nothing at runtime, so it can't be the module
       // that falls into a gap — it's only ever a pair's contract side.
       if (fileName.endsWith('.d.ts')) return false;
@@ -399,6 +413,9 @@ function findViolations(
 
       const pair = contractPathToPair.get(targetPath);
       if (!pair) continue;
+      // A `.web` fork importing its own contract path resolves back to itself
+      // under Metro-web. That's a self-cycle, not a parity gap.
+      if (pair.webPath === importerPath) continue;
 
       for (const name of edge.names) {
         if (pair.contractExports.has(name) && !pair.webExports.has(name)) {
@@ -465,7 +482,7 @@ rather than letting this check quietly stop scanning it.`,
     // modules this test is meant to guard. Both walks return an empty list for
     // a tree that isn't there, and an empty importer list yields zero
     // violations — which reads exactly like a pass. Floors sit well under
-    // today's counts (56 pairs, 13 of them `.d.ts`-contract, 890 importers) so
+    // today's counts (56 pairs, 13 of them `.d.ts`-contract, 948 importers) so
     // ordinary churn doesn't trip them.
     expect(forkPairs.length).toBeGreaterThan(20);
     expect(importerCount).toBeGreaterThan(200);
@@ -567,6 +584,46 @@ rather than letting this check quietly stop scanning it.`,
           name: 'BUTTON_HEIGHT',
           contractPath: 'Button.d.ts',
           webPath: 'Button.web.tsx',
+        },
+      ]);
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  it('treats a .web fork as an importer too: it is in the web bundle and resolves siblings to their .web files', () => {
+    // Metro-web bundles `.web` files, so one importing a sibling fork through
+    // the unsuffixed path gets that sibling's `.web` implementation — the same
+    // resolution a neutral module gets, and the same crash if the name is
+    // missing. Excluding `.web` importers alongside the genuinely native-only
+    // `.ios`/`.android` ones would let that regression through.
+    const fixtureDir = mkdtempSync(join(tmpdir(), 'web-fork-export-parity-web-importer-'));
+    try {
+      writeFileSync(join(fixtureDir, 'store.ts'), [`export function onlyNative(): void {}`, ``].join('\n'));
+      writeFileSync(join(fixtureDir, 'store.web.ts'), [`export {};`, ``].join('\n'));
+
+      // The web side of another pair, reaching into the gap.
+      writeFileSync(
+        join(fixtureDir, 'consumer.web.ts'),
+        [`import { onlyNative } from './store';`, ``, `onlyNative();`, ``].join('\n'),
+      );
+      writeFileSync(join(fixtureDir, 'consumer.ts'), [`export {};`, ``].join('\n'));
+      // The ios side of the same pair must stay out of scope: Metro never puts
+      // it in the web bundle.
+      writeFileSync(
+        join(fixtureDir, 'consumer.ios.ts'),
+        [`import { onlyNative } from './store';`, ``, `onlyNative();`, ``].join('\n'),
+      );
+
+      const { violations } = findViolations(fixtureDir, [fixtureDir], [fixtureDir]);
+
+      expect(violations).toEqual([
+        {
+          importer: 'consumer.web.ts',
+          line: 1,
+          name: 'onlyNative',
+          contractPath: 'store.ts',
+          webPath: 'store.web.ts',
         },
       ]);
     } finally {

--- a/packages/mobile/src/__tests__/web-fork-export-parity.test.ts
+++ b/packages/mobile/src/__tests__/web-fork-export-parity.test.ts
@@ -25,18 +25,40 @@
  * never resolves into the gap. Flagging those would just teach people to
  * ignore the test. Instead this walks the real import graph: for every fork
  * pair, does any *platform-neutral* module (one Metro bundles unchanged for
- * every platform) import a name from the native side that the web fork lacks?
+ * every platform) import a name from the contract side that the web fork lacks?
+ *
+ * Two kinds of pair are checked, both keyed on the same question — what does a
+ * caller typecheck against, and what does Metro-web actually bundle?
+ *   - `X.ts`/`X.tsx` + `X.web.ts(x)` — the store/provider forks. The bare file
+ *     is both the native implementation and the type contract.
+ *   - `X.d.ts` + `X.web.tsx` — the ios/android/web three-way primitives
+ *     (`Button`, `SwitchRow`, `AppMenu`, `MoreForm`, …). There is no bare
+ *     `X.ts`; the hand-written ambient `.d.ts` is the contract every caller
+ *     typechecks against, while Metro-web resolves `X.web.tsx`. A name
+ *     declared in the `.d.ts` and implemented in `X.ios.tsx` but missing from
+ *     `X.web.tsx` is the same silent runtime crash, in the files that churn
+ *     most — every native-control migration touches them.
  *
  * Deliberately not modelled (none of these occur in any current fork-pair
- * usage — see .boardsesh/plan-4242.json for the verification):
- *   - `export default`, `export *`, `export class`, destructuring exports
- *   - `import * as ns` namespace access into a forked module
+ * usage — re-verified across `src` + `app` + `modules` on every pair):
+ *   - `export default`, `export *`, destructuring exports
+ *   - `import * as ns` namespace access into a forked module, and default-only
+ *     `import Default from './forked-module'`. A mixed
+ *     `import Default, { … }` *is* handled — only its named half is checked.
  *   - dynamic `require('./forked-module')` / `import('./forked-module')`
  *     (the one real case, `use-native-climb-render.ts`'s board-renderer
  *     `require`, is a pair that's already export-symmetric today)
- *   - the separate ios/android/web three-way split (`Button`, `SwitchRow`,
- *     `AppMenu`, …), which has no bare `X.ts` native file to diff against —
- *     those ship a hand-written `.d.ts` ambient contract instead.
+ *   - the *other* web-fork mechanism: `metro.config.js`'s `WEB_SHIM_MODULES`
+ *     redirects seven bare specifiers (`expo-secure-store`, `expo-sqlite`,
+ *     `@expo/ui/community/bottom-sheet`, `@react-native-community/blur`, …)
+ *     to `src/web-shims/*` on the web platform only. Same drift class, but
+ *     callers reach those through namespace/default imports of a *bare*
+ *     specifier, so none of the resolution machinery here applies. Checked by
+ *     hand when this landed: every member currently used is present in its
+ *     shim.
+ *   - signature drift: the same name on both sides with a different parameter
+ *     list or return type typechecks clean (callers only ever resolve the
+ *     contract file) and still breaks web at runtime.
  * A future contributor exercising one of those patterns against a forked
  * module won't get coverage from this test.
  *
@@ -52,9 +74,12 @@
  * touch `bun.lock`, which is exactly what's ruled out here. So this file
  * extracts exports and named imports with line-anchored regexes over the
  * statement-starting keyword instead of a real AST walk — verified safe
- * against every one of the 36 real fork pairs in the repo today (no
- * `export default`/`export *`/`export class`/destructuring export, and no
- * mixed `import Default, { … }` import, appears in any of them).
+ * against every real fork pair in the repo (no `export default`, `export *`
+ * or destructuring export appears in any of them). Note the failure modes are
+ * asymmetric but self-limiting: an export shape the regexes miss is missed on
+ * *both* sides of a pair, so it yields a silent pass rather than a false
+ * alarm, and the fork-pair / importer-count floors in the real-repo test keep
+ * the discovery itself from quietly collapsing to nothing.
  */
 import {
   existsSync,
@@ -115,21 +140,29 @@ function listSourceFiles(absoluteDir: string, collected: string[] = []): string[
 // Export extraction
 // ---------------------------------------------------------------------------
 
+/**
+ * Statement-starting declarations that publish a *value* under a name. `enum`
+ * is here because it emits a runtime object; `type`/`interface` are not,
+ * because they vanish at build time and a web fork missing one can't crash
+ * anything. `declare` is optional throughout so the same patterns read an
+ * ambient `X.d.ts` contract and a real implementation file.
+ */
+const VALUE_EXPORT_PATTERNS: RegExp[] = [
+  /^export\s+(?:declare\s+)?async\s+function\s*\*?\s*([A-Za-z_$][\w$]*)/gm,
+  /^export\s+(?:declare\s+)?function\s*\*?\s*([A-Za-z_$][\w$]*)/gm,
+  // The `(?!enum\s)` guard keeps `export const enum Foo` out of this pattern,
+  // which would otherwise capture the literal word `enum` as the export name.
+  /^export\s+(?:declare\s+)?(?:const|let|var)\s+(?!enum\s)([A-Za-z_$][\w$]*)/gm,
+  /^export\s+(?:declare\s+)?(?:abstract\s+)?class\s+([A-Za-z_$][\w$]*)/gm,
+  /^export\s+(?:declare\s+)?(?:const\s+)?enum\s+([A-Za-z_$][\w$]*)/gm,
+];
+
 /** Value-level export identifiers a neutral module could import by name. */
 function extractExportNames(sourceText: string): Set<string> {
   const names = new Set<string>();
 
-  for (const match of sourceText.matchAll(/^export\s+async\s+function\s*\*?\s*([A-Za-z_$][\w$]*)/gm)) {
-    names.add(match[1]);
-  }
-  for (const match of sourceText.matchAll(/^export\s+function\s*\*?\s*([A-Za-z_$][\w$]*)/gm)) {
-    names.add(match[1]);
-  }
-  for (const match of sourceText.matchAll(/^export\s+(?:const|let|var)\s+([A-Za-z_$][\w$]*)/gm)) {
-    names.add(match[1]);
-  }
-  for (const match of sourceText.matchAll(/^export\s+class\s+([A-Za-z_$][\w$]*)/gm)) {
-    names.add(match[1]);
+  for (const pattern of VALUE_EXPORT_PATTERNS) {
+    for (const match of sourceText.matchAll(pattern)) names.add(match[1]);
   }
   // `export { a, b as c }` and `export { a } from '...'`. `export type { … }`
   // is a separate, type-only statement and is skipped by the `(type\s+)?`
@@ -225,7 +258,13 @@ function extractNamedEdges(sourceText: string): NamedEdge[] {
 // Fork-pair discovery
 // ---------------------------------------------------------------------------
 
-type ForkPair = { nativePath: string; webPath: string; nativeExports: Set<string>; webExports: Set<string> };
+/**
+ * `contractPath` is the file a caller typechecks against: the bare native
+ * `X.ts(x)` for a store-style fork, or the hand-written ambient `X.d.ts` for
+ * an ios/android/web three-way primitive that has no bare implementation.
+ * `webPath` is what Metro actually bundles for the browser.
+ */
+type ForkPair = { contractPath: string; webPath: string; contractExports: Set<string>; webExports: Set<string> };
 
 /** `foo.web.tsx` -> `{ base: 'foo', preferredExt: '.tsx' }`; null if not a `.web` file. */
 function webForkBase(absolutePath: string): { base: string; preferredExt: '.ts' | '.tsx' } | null {
@@ -236,10 +275,16 @@ function webForkBase(absolutePath: string): { base: string; preferredExt: '.ts' 
 }
 
 /**
- * Pairs a `.web.ts(x)` file with its native `X.ts`/`X.tsx` sibling. Files
- * with no native sibling (the ios/android/web three-way components, and the
- * two web-only files `auth-cookie-lock.web.ts` / `overlay-cache-store.web.ts`)
- * are skipped — there's nothing to diff their exports against.
+ * Pairs a `.web.ts(x)` file with the module a caller typechecks against:
+ * the bare native `X.ts`/`X.tsx` sibling when there is one, otherwise the
+ * hand-written ambient `X.d.ts`. The `.d.ts` case covers the ios/android/web
+ * three-way primitives (`Button`, `SwitchRow`, `MoreForm`, …) — they have no
+ * bare implementation file, but their declaration file is exactly the export
+ * list every caller compiles against, so a name it declares that
+ * `X.web.tsx` doesn't implement is the same web-only runtime crash.
+ *
+ * A `.web` file with neither sibling (`auth-cookie-lock.web.ts`,
+ * `overlay-cache-store.web.ts`) is web-only: nothing to diff against.
  */
 function discoverForkPairs(allSourceFiles: string[]): ForkPair[] {
   const pairs: ForkPair[] = [];
@@ -247,15 +292,17 @@ function discoverForkPairs(allSourceFiles: string[]): ForkPair[] {
     const forkBase = webForkBase(filePath);
     if (!forkBase) continue;
 
-    const candidateExtensions: Array<'.ts' | '.tsx'> =
-      forkBase.preferredExt === '.tsx' ? ['.tsx', '.ts'] : ['.ts', '.tsx'];
-    const nativePath = candidateExtensions.map((ext) => forkBase.base + ext).find((candidate) => existsSync(candidate));
-    if (!nativePath) continue;
+    const candidateExtensions: Array<'.ts' | '.tsx' | '.d.ts'> =
+      forkBase.preferredExt === '.tsx' ? ['.tsx', '.ts', '.d.ts'] : ['.ts', '.tsx', '.d.ts'];
+    const contractPath = candidateExtensions
+      .map((ext) => forkBase.base + ext)
+      .find((candidate) => existsSync(candidate));
+    if (!contractPath) continue;
 
     pairs.push({
-      nativePath,
+      contractPath,
       webPath: filePath,
-      nativeExports: extractExportNames(readFileSync(nativePath, 'utf8')),
+      contractExports: extractExportNames(readFileSync(contractPath, 'utf8')),
       webExports: extractExportNames(readFileSync(filePath, 'utf8')),
     });
   }
@@ -269,7 +316,9 @@ function discoverForkPairs(allSourceFiles: string[]): ForkPair[] {
 function resolveToFile(candidateBase: string): string | null {
   if (existsSync(candidateBase) && statSync(candidateBase).isFile()) return candidateBase;
 
-  for (const extension of ['.ts', '.tsx']) {
+  // `.d.ts` last: it only wins when there is no implementation file at all,
+  // which is exactly the ios/android/web three-way case.
+  for (const extension of ['.ts', '.tsx', '.d.ts']) {
     const withExtension = `${candidateBase}${extension}`;
     if (existsSync(withExtension)) return withExtension;
   }
@@ -299,12 +348,12 @@ function resolveSpecifier(specifier: string, importerAbsolutePath: string, mobil
 // Violation search
 // ---------------------------------------------------------------------------
 
-type Violation = { importer: string; line: number; name: string; nativePath: string; webPath: string };
+type Violation = { importer: string; line: number; name: string; contractPath: string; webPath: string };
 
 /**
  * Discovers fork pairs under `forkPairRoots`, then walks every
  * platform-neutral module under `importerRoots` for named imports /
- * re-exports that reach into a fork pair's native side for a name the web
+ * re-exports that reach into a fork pair's contract side for a name the web
  * fork lacks. Against the real repo both roots are the same three trees
  * (`src`, `app`, `modules`): Metro applies the `.web` platform extension in
  * all of them, so a fork pair can live in any one, and a module in any one
@@ -312,15 +361,19 @@ type Violation = { importer: string; line: number; name: string; nativePath: str
  * lists identical also keeps the "is this importer itself a fork native
  * side?" exclusion honest — a pair discovered in one list but not the other
  * would make its native side look neutral.
+ *
+ * `importerCount` comes back so callers can assert the walk actually found
+ * something: an empty importer list produces zero violations, which reads as
+ * a pass.
  */
 function findViolations(
   mobileRoot: string,
   forkPairRoots: string[],
   importerRoots: string[],
-): { violations: Violation[]; forkPairs: ForkPair[] } {
+): { violations: Violation[]; forkPairs: ForkPair[]; importerCount: number } {
   const forkPairSourceFiles = forkPairRoots.flatMap((root) => listSourceFiles(root));
   const forkPairs = discoverForkPairs(forkPairSourceFiles);
-  const nativePathToPair = new Map(forkPairs.map((pair) => [pair.nativePath, pair]));
+  const contractPathToPair = new Map(forkPairs.map((pair) => [pair.contractPath, pair]));
 
   const importerFiles = importerRoots
     .flatMap((root) => listSourceFiles(root))
@@ -328,9 +381,12 @@ function findViolations(
       const fileName = basename(filePath);
       if (isTestFile(fileName)) return false;
       if (isPlatformSuffixed(fileName)) return false;
+      // A declaration file emits nothing at runtime, so it can't be the module
+      // that falls into a gap — it's only ever a pair's contract side.
+      if (fileName.endsWith('.d.ts')) return false;
       // The native side of a fork pair is never bundled for web (its `.web`
       // sibling is used instead), so its own imports don't reach Metro-web.
-      if (nativePathToPair.has(filePath)) return false;
+      if (contractPathToPair.has(filePath)) return false;
       return true;
     });
 
@@ -341,16 +397,16 @@ function findViolations(
       const targetPath = resolveSpecifier(edge.specifier, importerPath, mobileRoot);
       if (targetPath === null) continue;
 
-      const pair = nativePathToPair.get(targetPath);
+      const pair = contractPathToPair.get(targetPath);
       if (!pair) continue;
 
       for (const name of edge.names) {
-        if (pair.nativeExports.has(name) && !pair.webExports.has(name)) {
+        if (pair.contractExports.has(name) && !pair.webExports.has(name)) {
           violations.push({
             importer: toMobileRelative(mobileRoot, importerPath),
             line: edge.line,
             name,
-            nativePath: toMobileRelative(mobileRoot, pair.nativePath),
+            contractPath: toMobileRelative(mobileRoot, pair.contractPath),
             webPath: toMobileRelative(mobileRoot, pair.webPath),
           });
         }
@@ -364,13 +420,14 @@ function findViolations(
         left.importer.localeCompare(right.importer) || left.line - right.line || left.name.localeCompare(right.name),
     ),
     forkPairs,
+    importerCount: importerFiles.length,
   };
 }
 
 function describeViolation(violation: Violation): string {
   return [
     `  packages/mobile/${violation.importer}:${violation.line}`,
-    `    imports '${violation.name}' from ${violation.nativePath}`,
+    `    imports '${violation.name}' from ${violation.contractPath}`,
     `    which the web fork ${violation.webPath} does not export`,
   ].join('\n');
 }
@@ -381,19 +438,52 @@ describe('web-fork export parity: neutral importers never reach a gap in a .web 
   const realTrees = [join(MOBILE_ROOT, 'src'), join(MOBILE_ROOT, 'app'), join(MOBILE_ROOT, 'modules')];
   const realRoots = { mobileRoot: MOBILE_ROOT, forkPairRoots: realTrees, importerRoots: realTrees };
 
+  it('scans every tree it claims to — a missing root must fail, not silently skip', () => {
+    // `listSourceFiles` returns [] for a directory that doesn't exist, so a
+    // renamed or moved tree would drop out of both lists with no failure: the
+    // real-repo check below would keep passing while covering nothing there.
+    // Most fork pairs live under `src`, so even the fork-pair floor wouldn't
+    // notice. Name the roots explicitly instead.
+    for (const root of realTrees) {
+      expect(
+        existsSync(root),
+        `${toMobileRelative(MOBILE_ROOT, root)} is no longer a directory under packages/mobile —
+update realTrees (and confirm Metro still applies .web resolution there)
+rather than letting this check quietly stop scanning it.`,
+      ).toBe(true);
+    }
+  });
+
   it('has no unallowed gap across the real repo', () => {
-    const { violations, forkPairs } = findViolations(
+    const { violations, forkPairs, importerCount } = findViolations(
       realRoots.mobileRoot,
       realRoots.forkPairRoots,
       realRoots.importerRoots,
     );
 
-    // Sanity check the discovery itself found the fork pairs this test is
-    // meant to guard — an empty result here would mean the walk is broken,
-    // not that the repo has no forks.
+    // Sanity check the discovery itself found the fork pairs and the neutral
+    // modules this test is meant to guard. Both walks return an empty list for
+    // a tree that isn't there, and an empty importer list yields zero
+    // violations — which reads exactly like a pass. Floors sit well under
+    // today's counts (56 pairs, 13 of them `.d.ts`-contract, 890 importers) so
+    // ordinary churn doesn't trip them.
     expect(forkPairs.length).toBeGreaterThan(20);
+    expect(importerCount).toBeGreaterThan(200);
+    // The ios/android/web primitives only pair through their ambient `.d.ts`.
+    // Without this they'd drop out of the check the moment that resolution
+    // broke, and nothing else here would notice.
+    expect(forkPairs.filter((pair) => pair.contractPath.endsWith('.d.ts')).length).toBeGreaterThan(5);
 
-    const report = violations.map(describeViolation).join('\n\n');
+    // One missing export on a widely-used primitive (Button has 72 neutral
+    // importers) would otherwise print a wall of near-identical entries. The
+    // first handful names the gap; the count above says how wide it is.
+    const REPORTED_VIOLATION_LIMIT = 15;
+    const report = [
+      ...violations.slice(0, REPORTED_VIOLATION_LIMIT).map(describeViolation),
+      ...(violations.length > REPORTED_VIOLATION_LIMIT
+        ? [`  … and ${violations.length - REPORTED_VIOLATION_LIMIT} more`]
+        : []),
+    ].join('\n\n');
     expect(
       violations,
       violations.length === 0
@@ -427,10 +517,91 @@ describe('web-fork export parity: neutral importers never reach a gap in a .web 
           importer: 'caller.ts',
           line: 1,
           name: 'bar',
-          nativePath: 'store.ts',
+          contractPath: 'store.ts',
           webPath: 'store.web.ts',
         },
       ]);
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  it('catches a Button-shaped regression: a .d.ts contract the .web fork does not implement', () => {
+    // The ios/android/web three-way primitives (Button, SwitchRow, MoreForm,
+    // …) have no bare `X.ts` — the hand-written `X.d.ts` is what every caller
+    // compiles against, while Metro-web resolves `X.web.tsx`. Add a control to
+    // the `.d.ts` + the native implementations and forget the web one and you
+    // get the identical crash the store forks produce, so the `.d.ts` counts
+    // as a contract side here.
+    const fixtureDir = mkdtempSync(join(tmpdir(), 'web-fork-export-parity-ambient-'));
+    try {
+      writeFileSync(
+        join(fixtureDir, 'Button.d.ts'),
+        [
+          `export declare function Button(props: { title: string }): null;`,
+          `export declare const BUTTON_HEIGHT: number;`,
+          ``,
+        ].join('\n'),
+      );
+      writeFileSync(
+        join(fixtureDir, 'Button.ios.tsx'),
+        [`export function Button(): null { return null; }`, ``].join('\n'),
+      );
+      // The regression: the web implementation never picked up BUTTON_HEIGHT.
+      writeFileSync(
+        join(fixtureDir, 'Button.web.tsx'),
+        [`export function Button(): null { return null; }`, ``].join('\n'),
+      );
+      writeFileSync(
+        join(fixtureDir, 'screen.tsx'),
+        [`import { Button, BUTTON_HEIGHT } from './Button';`, ``, `void [Button, BUTTON_HEIGHT];`, ``].join('\n'),
+      );
+
+      const { violations, forkPairs } = findViolations(fixtureDir, [fixtureDir], [fixtureDir]);
+
+      expect(forkPairs.map((pair) => pair.contractPath.endsWith('Button.d.ts'))).toEqual([true]);
+      expect(violations).toEqual([
+        {
+          importer: 'screen.tsx',
+          line: 1,
+          name: 'BUTTON_HEIGHT',
+          contractPath: 'Button.d.ts',
+          webPath: 'Button.web.tsx',
+        },
+      ]);
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  it('extracts the value-export shapes a crash can hide behind: enum, abstract class, declare', () => {
+    // Each of these emits a runtime value, so a web fork missing one is a real
+    // crash. Missing them in `extractExportNames` is a silent pass, not a
+    // visible failure, which is the worst way for a guard to break.
+    const fixtureDir = mkdtempSync(join(tmpdir(), 'web-fork-export-parity-shapes-'));
+    try {
+      writeFileSync(
+        join(fixtureDir, 'shapes.ts'),
+        [
+          `export enum Direction { Up, Down }`,
+          `export const enum Fixed { One }`,
+          `export abstract class Base {}`,
+          // A type-only export must NOT be treated as a value: it vanishes at
+          // build time, so a web fork lacking it cannot crash anything.
+          `export type Only = 'type';`,
+          ``,
+        ].join('\n'),
+      );
+      writeFileSync(join(fixtureDir, 'shapes.web.ts'), [`export type Only = 'type';`, ``].join('\n'));
+      writeFileSync(
+        join(fixtureDir, 'caller.ts'),
+        [`import { Direction, Fixed, Base } from './shapes';`, ``, `void [Direction, Fixed, Base];`, ``].join('\n'),
+      );
+      writeFileSync(join(fixtureDir, 'type-caller.ts'), [`import { Only } from './shapes';`, ``].join('\n'));
+
+      const { violations } = findViolations(fixtureDir, [fixtureDir], [fixtureDir]);
+
+      expect(violations.map((violation) => violation.name)).toEqual(['Base', 'Direction', 'Fixed']);
     } finally {
       rmSync(fixtureDir, { recursive: true, force: true });
     }
@@ -498,7 +669,7 @@ describe('web-fork export parity: neutral importers never reach a gap in a .web 
           importer: 'app/screen.ts',
           line: 1,
           name: 'onlyNative',
-          nativePath: 'src/store.ts',
+          contractPath: 'src/store.ts',
           webPath: 'src/store.web.ts',
         },
       ]);
@@ -531,14 +702,14 @@ describe('web-fork export parity: neutral importers never reach a gap in a .web 
           importer: 'multiline-caller.ts',
           line: 1,
           name: 'onlyNative',
-          nativePath: 'store.ts',
+          contractPath: 'store.ts',
           webPath: 'store.web.ts',
         },
         {
           importer: 're-export-caller.ts',
           line: 1,
           name: 'onlyNative',
-          nativePath: 'store.ts',
+          contractPath: 'store.ts',
           webPath: 'store.web.ts',
         },
       ]);


### PR DESCRIPTION
## Summary

Adds a static test that catches a `.web.ts(x)` fork missing an export its counterpart declares — the exact bug class behind Sentry issue BOARDSESH-BW. `session-store.web.ts` shipped without `getStoredCreatedSessionId` / `setStoredCreatedSessionId` / `clearStoredCreatedSessionId` for 9 days after #3502 added them to the native `session-store.ts`, until #4199 backfilled the `.web` fork. Nothing on the test side caught it; `web-runtime-dependency-parity.test.ts` only compares `package.json` dependency *versions*, not module export shapes.

`packages/mobile/src/__tests__/web-fork-export-parity.test.ts` walks every fork pair under `packages/mobile/src`, `app` and `modules`, then checks every *platform-neutral* module (one that isn't itself a fork's platform side, so Metro bundles it unchanged everywhere) for a named import that reaches into the pair's contract side for a name the `.web` fork is missing.

Two pair shapes are covered, both keyed on the same question — what does a caller typecheck against, and what does Metro-web actually bundle?

- **`X.ts`/`X.tsx` + `X.web.ts(x)`** — the store and provider forks. The bare file is both the native implementation and the type contract.
- **`X.d.ts` + `X.web.tsx`** — the ios/android/web three-way primitives (`Button`, `SwitchRow`, `AppMenu`, `MoreForm`, `SegmentedControl`, …). They have no bare implementation file; the hand-written ambient `.d.ts` is what every caller compiles against while Metro-web resolves `X.web.tsx`. Declaring a name in the `.d.ts` and implementing it in `X.ios.tsx` but not `X.web.tsx` is the identical silent crash, in the files that churn most.

56 pairs today (43 bare + 13 ambient) against 948 importer modules. Importers are every module Metro-web bundles: the platform-neutral ones plus the `.web` forks themselves, since a `.web` file importing a sibling fork through its unsuffixed path gets that sibling's `.web` implementation and falls into the same gap. Only `.ios`/`.android` forks are out of scope.

The check is usage-based, not a blind export-set-equality check — three real fork pairs have harmless divergences (`auth-store.ts`'s `storeTokensForGeneration`/`clearTokensForGeneration`, `auth.ts`'s `oauthNativeSignIn`, `share-target-provider.tsx`'s `extractSharedLink`) because the missing names are only ever imported by another forked module, which never reaches the web bundle. A blind superset check would immediately red all three; a fixture locks in that it must not.

This is test-infrastructure only — no runtime code changes.

### Deviation from plan

The plan called for adding `typescript-compiler-api` (aliased `typescript@6.0.3`) as a new `packages/mobile` devDependency to get a real `ts.createSourceFile` / `ts.forEachChild` AST walk, mirroring `packages/web`'s existing workaround for the same gap. `.boardsesh/DECISIONS.md` for this issue is binding and rules that out: no new dependencies, use the repo's existing `typescript` package, `bun.lock` untouched. Verified the pinned `typescript@~7.0.2` genuinely can't do this — its `"."` export resolves only to `lib/version.cjs` (`{version, versionMajorMinor}`), no parser at all; `./unstable/ast` is enums/type-guards with no `createSourceFile`; `./unstable/sync`/`./unstable/async` expose TS7's new native `Project`/`Program`/`Checker` API, a different and much heavier surface. So the test extracts exports and imports with line-anchored regexes over the statement-starting keyword instead — zero new dependencies, `bun.lock` untouched. Scope limits are documented inline in the test file.

Closes #4242

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project mobile web-fork-export-parity --reporter=agent` — 9 passing tests: the real-repo check, plus fixtures for a session-store-shaped regression, a `Button`-shaped `.d.ts`-contract regression, a `.web` fork reaching into a sibling's gap (with the `.ios` sibling staying out of scope), the value-export shapes (`enum`, `const enum`, `abstract class`, `declare`) with a type-only export that must *not* be flagged, a native-only export nothing neutral imports, cross-tree pairing, and the edge kinds a grep would miss (multi-line import lists, aliases, `export … from` re-exports).
- **Mutation-checked twice against the real repo, not just fixtures.** Dropping `export` from `getStoredCreatedSessionId` in `session-store.web.ts` turns the real-repo test red with the exact `use-session-exit-options.ts:4` report. Dropping `export` from `Button` in `Button.web.tsx` reports all 72 neutral importers against `Button.d.ts`. Restoring either turns it green.
- `vp run typecheck:mobile`, `vp check`, `vp run test:mobile` — clean.

### Takeover review pass (bug-batch loop `moarbugs100500`)

Adopted in-flight and re-reviewed adversarially against current `main` (rebased, 448 commits). Full write-up in [this comment](https://github.com/boardsesh/boardsesh/pull/4265#issuecomment-5348804238). Four things changed:

1. **`.d.ts`-contract pairs are now checked.** 15 of the 51 `.web` files had no bare sibling and were skipped entirely; 13 of them ship an ambient `.d.ts` that is exactly the export list callers compile against. Zero live drift found — this is pure coverage, +26% of the fork surface.
2. **The real-repo run can no longer lose a tree in silence.** `listSourceFiles` returns `[]` for a directory that doesn't exist and 34 of the pairs live under `src`, so `app/` and `modules/` could both be renamed with the check still green. Roots are now asserted to exist, and the importer count has a floor alongside the fork-pair floor.
3. **`export enum`, `export const enum`, `export abstract class` and `export declare …` are extracted.** All emit runtime values, so a web fork missing one is a real crash; none were matched before. Zero occurrences in the tree today, so this was a silent false-negative waiting for future code.
4. **Two doc-comment claims that contradicted the code are fixed** (`export class` was listed as unmodelled but is matched; mixed `import Default, { … }` was listed as a scope cut but is handled).
5. **`.web` forks now count as importers** — Codex caught this one. The old filter dropped `.web` files alongside `.ios`/`.android`, but Metro-web *does* bundle them, and one importing a sibling fork through the unsuffixed path resolves to that sibling's `.web` file. Zero live drift; fixture added, and the `.ios` sibling is asserted to stay out of scope.

One gap left open on purpose and flagged for a decision: `metro.config.js`'s `WEB_SHIM_MODULES` redirects seven *bare* specifiers (`expo-secure-store`, `expo-sqlite`, `@expo/ui/community/bottom-sheet`, …) to `src/web-shims/*` on web only. Same drift class, bigger blast radius, different mechanism — checked by hand as drift-free today and documented in the test's scope-cut list. Worth a follow-up issue rather than growing this PR.
