### PR TITLE
feat(repo): add packages/scheduler and move the cleanup cron off Vercel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,7 @@ Read relevant `docs/` before working on the matching area; update docs when the 
 - `docs/board-render-analytics.md` — the classic-vs-Boardsesh / glow-falloff A/B event contract (issue #2202): the seven events (incl. the paired board-look step events), the common-props builder, the `climb-view-session.ts` state machine, the stratification rule (never pool across `board_name` or `glow_falloff_source`), and the PostHog experiment setup steps
 - `docs/logging.md` — backend structured logger (winston)
 - `docs/crowdsourced-qa.md` — the PR test-plan + risk gate (`@boardsesh/pr-body`, `pr-test-plan.yml`), and the tester loop that turns it into `qa-approved` / `qa-declined` labels
+- `docs/scheduler.md` — the Railway cron scheduler (`packages/scheduler`): which job runs on Vercel vs the scheduler, env vars, Railway setup, cutover order and runbook
 - `docs/db-connectivity.md` — Postgres connect retries (what is retried and why it can't double-execute a write), the retry budgets, and the `/health` vs `/health/db` split
 - `docs/og-climb.md` — backend-served climb OG share cards (`GET /og/climb`: caches, env vars, timings)
 - `docs/cloudflare.md` — the boardsesh.com Cloudflare zone: config-as-code (`vp run cf:apply`), token scopes/secrets, CI auto-apply, og edge caching

--- a/Dockerfile.sync
+++ b/Dockerfile.sync
@@ -1,11 +1,14 @@
-# Sync CLIs - runs any sync CLI (kilter/aurora/moonboard) directly via tsx.
+# Long-lived Node CLIs - runs any sync CLI (kilter/aurora/moonboard) or the cron
+# scheduler directly via tsx.
 # Sibling of Dockerfile.backend. The actual command is supplied by the container
-# `command:` (e.g. docker-compose), so one image serves every sync CLI. kilter
-# and aurora expose a long-running `daemon`; moonboard is locations-only (no
-# daemon subcommand):
+# `command:` (e.g. docker-compose, or Railway's custom start command), so one
+# image serves every CLI. kilter and aurora expose a long-running `daemon`;
+# moonboard is locations-only (no daemon subcommand); the scheduler's `start`
+# runs the cron loop and a /health server (see docs/scheduler.md):
 #   node --import tsx packages/kilter-sync/src/cli/index.ts daemon
 #   node --import tsx packages/aurora-sync/src/cli/index.ts daemon
 #   node --import tsx packages/moonboard-sync/src/cli/index.ts locations
+#   node --import tsx packages/scheduler/src/cli/index.ts start
 FROM node:22-alpine
 
 WORKDIR /app

--- a/docs/branch-deploys.md
+++ b/docs/branch-deploys.md
@@ -1523,7 +1523,8 @@ Backend-affecting paths are defined in two places that must stay in sync:
 | `packages/kilter-sync/`                       | Kilter Grips user/catalog sync and public location sync                       |
 | `packages/location-sync/`                     | Shared public `gyms` / `user_boards` location writer                          |
 | `packages/moonboard-sync/`                    | MoonBoard public location sync CLI                                            |
-| `packages/web/vercel.json`                    | Build command (migration skip), cron definitions                              |
+| `packages/scheduler/`                         | Cron jobs moved off Vercel — see `docs/scheduler.md`                          |
+| `packages/web/vercel.json`                    | Build command (migration skip), remaining Vercel cron definitions             |
 | `.github/workflows/branch-deploy.yml`         | Build images + trigger Ansible deploy on PR open/sync                         |
 | `.github/workflows/branch-deploy-cleanup.yml` | Trigger Ansible cleanup + GHCR delete on PR close                             |
 | `.github/workflows/branch-deploy-sweep.yml`   | Trigger Ansible sweep on push to main / daily                                 |

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -126,7 +126,10 @@ not firing; check the container is actually running and its clock is sane.
 **A job is failing.** `lastError` carries the HTTP status and a truncated body.
 401 → the two `CRON_SECRET`s have drifted apart. 403 with an HTML body → a
 Vercel WAF/bot rule is blocking Railway egress. 5xx → the route itself; look at
-the web logs. A request that never reached the app reads
+the web logs. A 502 or 503 is retried once after 2s before it counts as a
+failure (a deploy swap or a cold instance clears in seconds); 504 is not, since
+the request reached the route and retrying would stack a second run on the
+first. A request that never reached the app reads
 `fetch failed: <cause>` — `ECONNREFUSED`/`ECONNRESET` means the connection was
 refused or dropped (egress blocked at the network layer rather than by a WAF
 page), `ENOTFOUND` means `BOARDSESH_WEB_URL` is wrong or DNS is broken.

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -56,7 +56,7 @@ to UTC.
 | `CRON_SECRET`             | yes      | —                           | **Copy** the Vercel project value, don't regenerate: the remaining Vercel crons authenticate with the same secret. Rotating it means updating both places at once. |
 | `BOARDSESH_WEB_URL`       | no       | `https://www.boardsesh.com` | Same env name the backend uses (`packages/backend/src/lib/web-revalidate.ts`).                                                                                     |
 | `PORT`                    | no       | `8080`                      | Health server.                                                                                                                                                     |
-| `SCHEDULER_DISABLED_JOBS` | no       | —                           | Comma-separated job names to leave unscheduled — an env-flip kill switch, no redeploy needed. `run <job>` still works on a disabled job.                           |
+| `SCHEDULER_DISABLED_JOBS` | no       | —                           | Comma-separated job names to leave unscheduled. Read once at startup, so set it and restart the service — no code change, no image rebuild. `run <job>` still works on a disabled job. |
 
 A missing `CRON_SECRET` throws at startup, so a misconfigured service
 crash-loops loudly instead of 401ing quietly at 05:00.
@@ -123,7 +123,10 @@ not firing; check the container is actually running and its clock is sane.
 **A job is failing.** `lastError` carries the HTTP status and a truncated body.
 401 → the two `CRON_SECRET`s have drifted apart. 403 with an HTML body → a
 Vercel WAF/bot rule is blocking Railway egress. 5xx → the route itself; look at
-the web logs.
+the web logs. A request that never reached the app reads
+`fetch failed: <cause>` — `ECONNREFUSED`/`ECONNRESET` means the connection was
+refused or dropped (egress blocked at the network layer rather than by a WAF
+page), `ENOTFOUND` means `BOARDSESH_WEB_URL` is wrong or DNS is broken.
 
 **A job is stuck.** A tick whose predecessor is still in flight is skipped and
 warned, never queued, so a slow run can't stack up. Each run is also bounded by

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -1,0 +1,127 @@
+# Scheduler service (`packages/scheduler`)
+
+A long-lived Node container that fires Boardsesh's scheduled jobs, taking them
+off Vercel crons one at a time. Part of the Phase 0a hosting move (#1859 →
+#1860 → #1874).
+
+## What it is (and isn't)
+
+The scheduler **triggers** existing `/api/internal/*` routes over HTTP with
+`Authorization: Bearer $CRON_SECRET`. It does not reimplement the jobs.
+
+That's not laziness — two of the three job families can't run outside Next:
+
+- `prewarm-heatmap` warms `cachedGetHoldHeatmapData`, a Next cache entry whose
+  key has to match a real first-visit request byte for byte.
+- `profile-percentiles` ends with `revalidateTag(USER_CLIMB_PERCENTILE_CACHE_TAG)`.
+
+Neither is reachable from a plain Node process, so the routes stay the single
+implementation and only the trigger moves.
+
+## Job ownership
+
+Update this table as each job migrates. `packages/scheduler/src/__tests__/registry.test.ts`
+diffs the "Vercel" rows against `packages/web/vercel.json` and fails if the two
+sides drift, so a job can't end up double-scheduled or unscheduled.
+
+| Path                                        | Schedule (UTC) | Runs on                       |
+| ------------------------------------------- | -------------- | ----------------------------- |
+| `/api/internal/cleanup`                     | `0 5 * * *`    | **Scheduler** (job `cleanup`) |
+| `/api/internal/prewarm-heatmap/kilter`      | `0 4 * * 0`    | Vercel cron                   |
+| `/api/internal/prewarm-heatmap/tension`     | `15 4 * * 0`   | Vercel cron                   |
+| `/api/internal/prewarm-heatmap/decoy`       | `30 4 * * 0`   | Vercel cron                   |
+| `/api/internal/prewarm-heatmap/touchstone`  | `45 4 * * 0`   | Vercel cron                   |
+| `/api/internal/prewarm-heatmap/grasshopper` | `0 5 * * 0`    | Vercel cron                   |
+| `/api/internal/profile-percentiles`         | `0 6 * * 0`    | Vercel cron                   |
+
+`packages/web/vercel.json` itself stays until the Phase 1 cutover; it is not
+deleted when the last cron leaves it.
+
+The GitHub-Actions-scheduled jobs (`refresh-recommendations`,
+`refresh-climb-grades`, `refresh-content-model`, `refresh-hold-features`,
+`export-board-snapshots`, `refresh-acknowledgements`) are a separate thing and
+are not in scope here.
+
+## Environment
+
+| Variable                  | Required | Default                     | Notes                                                                                                                                                              |
+| ------------------------- | -------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `CRON_SECRET`             | yes      | —                           | **Copy** the Vercel project value, don't regenerate: the remaining Vercel crons authenticate with the same secret. Rotating it means updating both places at once. |
+| `BOARDSESH_WEB_URL`       | no       | `https://www.boardsesh.com` | Same env name the backend uses (`packages/backend/src/lib/web-revalidate.ts`).                                                                                     |
+| `PORT`                    | no       | `8080`                      | Health server.                                                                                                                                                     |
+| `SCHEDULER_DISABLED_JOBS` | no       | —                           | Comma-separated job names to leave unscheduled — an env-flip kill switch, no redeploy needed. `run <job>` still works on a disabled job.                           |
+
+A missing `CRON_SECRET` throws at startup, so a misconfigured service
+crash-loops loudly instead of 401ing quietly at 05:00.
+
+## Railway service setup
+
+The scheduler ships inside the existing combined `boardsesh-sync` image —
+`Dockerfile.sync` already runs any CLI via `tsx`, and
+`.github/workflows/sync-deploy.yml` already rebuilds on `packages/**`. No new
+Dockerfile, no new workflow.
+
+1. **New service** in the Boardsesh Railway project, name it `scheduler`.
+2. **Source → Docker Image**: `ghcr.io/boardsesh/boardsesh-sync:production`.
+3. **Custom start command**: `bunx tsx packages/scheduler/src/cli/index.ts start`
+4. **Variables**:
+   - `CRON_SECRET` — same value as the Vercel project env var.
+   - `BOARDSESH_WEB_URL=https://www.boardsesh.com`
+   - `PORT=8080` (or let Railway inject its own `PORT`).
+5. **Healthcheck path**: `/health`.
+6. **Replicas: 1.** Two instances would double-fire every job; there is no
+   leader election in this slice. If it ever needs more than one, `DaemonLease`
+   in `packages/sync-runtime` is the existing Postgres-backed tool.
+
+## Cutover order (matters)
+
+Do it in this order, or cleanup silently stops running:
+
+1. Deploy the Railway service with the env above.
+2. Shell into it (or use a one-off run) and confirm a manual trigger works
+   against production:
+   `bunx tsx packages/scheduler/src/cli/index.ts run cleanup`
+   It must print the route's JSON and exit 0. **This is the step that catches a
+   Vercel WAF / bot rule blocking Railway egress IPs** — nothing local can.
+3. Only then merge the PR that drops the entry from `packages/web/vercel.json`.
+
+Between steps 1 and 3 both schedulers may fire the job. That's safe:
+`/api/internal/cleanup` deletes rows older than a fixed age in deadline-bounded
+batches, so a double run is a no-op on the second pass.
+
+If the PR merges before the service exists, the 180-day feed-item and 90-day
+notification retention pauses. Harmless for weeks — the job is delete-by-age
+and catches up on its next run — but it should not be left that way.
+
+## Runbook
+
+**Is it ticking?** `GET /health` returns every job with `lastRunAt`,
+`lastSuccessAt`, `lastDurationMs`, `lastError`, `runCount`, `failureCount` and
+`skippedCount`. `lastRunAt` older than the job's interval means the ticker is
+not firing; check the container is actually running and its clock is sane.
+
+**A job is failing.** `lastError` carries the HTTP status and a truncated body.
+401 → the two `CRON_SECRET`s have drifted apart. 403 with an HTML body → a
+Vercel WAF/bot rule is blocking Railway egress. 5xx → the route itself; look at
+the web logs.
+
+**A job is stuck.** A tick whose predecessor is still in flight is skipped and
+warned, never queued, so a slow run can't stack up. Each run is also bounded by
+the job's `timeoutMs` (120s for `cleanup`) via `AbortController`. If a job is
+misbehaving, set `SCHEDULER_DISABLED_JOBS=<name>` and restart — no code change,
+no redeploy.
+
+**Run one now.** `bunx tsx packages/scheduler/src/cli/index.ts run <job>` runs a
+single job and exits non-zero on failure. It never starts the recurring
+schedule, and it works on a job held back by `SCHEDULER_DISABLED_JOBS`.
+
+## Follow-ups
+
+- One PR per remaining job (`profile-percentiles`, then the five
+  `prewarm-heatmap` boards), each moving one row in the table above.
+- Sentry cron monitors around job runs (#1876). The runner already records
+  `lastError` and logs failures, so the hook-up point exists.
+- A dedicated `Dockerfile.scheduler` + `scheduler-deploy.yml` +
+  `boardsesh-scheduler` image, if the scheduler should release on its own
+  cadence instead of riding the sync image. Mechanical, but a second PR's worth
+  of workflow wiring.

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -42,6 +42,13 @@ The GitHub-Actions-scheduled jobs (`refresh-recommendations`,
 `export-board-snapshots`, `refresh-acknowledgements`) are a separate thing and
 are not in scope here.
 
+**Keep new jobs on UTC.** Every job declares its own IANA zone, and the ticker
+honours it — but UTC has no DST gaps. A job scheduled inside a spring-forward
+gap (say 02:30 `America/New_York`) simply does not run that day, because that
+wall-clock minute doesn't exist; fall-back is safe and runs once, not twice.
+That's standard crontab behaviour, and the reason the registry pins everything
+to UTC.
+
 ## Environment
 
 | Variable                  | Required | Default                     | Notes                                                                                                                                                              |
@@ -92,6 +99,19 @@ batches, so a double run is a no-op on the second pass.
 If the PR merges before the service exists, the 180-day feed-item and 90-day
 notification retention pauses. Harmless for weeks — the job is delete-by-age
 and catches up on its next run — but it should not be left that way.
+
+## Health endpoints
+
+Split the way the backend splits `/health` from `/health/db`:
+
+- `GET /health` — **liveness**, and what Railway's healthcheck polls. 200
+  whenever the process is up. It deliberately stays green on a failing job:
+  restarting the container cannot fix a rotated `CRON_SECRET` or a WAF rule,
+  and a restart would wipe the `lastError` that tells you which it is. The body
+  still carries `status: 'degraded'` and `degraded: true`.
+- `GET /health/jobs` — **job health**. 503 when a scheduled job's last run
+  failed, 200 otherwise. Point an alert here. Do **not** point Railway's
+  healthcheck at it.
 
 ## Runbook
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -70,7 +70,10 @@ Dockerfile, no new workflow.
 
 1. **New service** in the Boardsesh Railway project, name it `scheduler`.
 2. **Source → Docker Image**: `ghcr.io/boardsesh/boardsesh-sync:production`.
-3. **Custom start command**: `bunx tsx packages/scheduler/src/cli/index.ts start`
+3. **Custom start command**:
+   `node --import tsx packages/scheduler/src/cli/index.ts start`
+   — the same shape `Dockerfile.sync` documents for the sync daemons. The image
+   ships Node and `tsx`; it has no `vp`, and nothing in this repo runs on Bun.
 4. **Variables**:
    - `CRON_SECRET` — same value as the Vercel project env var.
    - `BOARDSESH_WEB_URL=https://www.boardsesh.com`
@@ -87,7 +90,7 @@ Do it in this order, or cleanup silently stops running:
 1. Deploy the Railway service with the env above.
 2. Shell into it (or use a one-off run) and confirm a manual trigger works
    against production:
-   `bunx tsx packages/scheduler/src/cli/index.ts run cleanup`
+   `node --import tsx packages/scheduler/src/cli/index.ts run cleanup`
    It must print the route's JSON and exit 0. **This is the step that catches a
    Vercel WAF / bot rule blocking Railway egress IPs** — nothing local can.
 3. Only then merge the PR that drops the entry from `packages/web/vercel.json`.
@@ -134,7 +137,7 @@ the job's `timeoutMs` (120s for `cleanup`) via `AbortController`. If a job is
 misbehaving, set `SCHEDULER_DISABLED_JOBS=<name>` and restart — no code change,
 no redeploy.
 
-**Run one now.** `bunx tsx packages/scheduler/src/cli/index.ts run <job>` runs a
+**Run one now.** `node --import tsx packages/scheduler/src/cli/index.ts run <job>` runs a
 single job and exits non-zero on failure. It never starts the recurring
 schedule, and it works on a job held back by `SCHEDULER_DISABLED_JOBS`.
 

--- a/packages/scheduler/README.md
+++ b/packages/scheduler/README.md
@@ -11,10 +11,20 @@ plain Node process cannot reach, so the routes stay the single implementation.
 
 ## Commands
 
+Locally, from the repo root:
+
 ```bash
 vp exec tsx packages/scheduler/src/cli/index.ts start       # cron loop + /health server
 vp exec tsx packages/scheduler/src/cli/index.ts run cleanup # one-shot, exits non-zero on failure
 vp exec tsx packages/scheduler/src/cli/index.ts list        # registered jobs and schedules
+```
+
+Inside the `boardsesh-sync` image (Railway start command, one-off runs) there is
+no `vp`, so use the form `Dockerfile.sync` documents:
+
+```bash
+node --import tsx packages/scheduler/src/cli/index.ts start
+node --import tsx packages/scheduler/src/cli/index.ts run cleanup
 ```
 
 ## Environment

--- a/packages/scheduler/README.md
+++ b/packages/scheduler/README.md
@@ -1,0 +1,50 @@
+# @boardsesh/scheduler
+
+Long-lived cron service that fires Boardsesh's scheduled jobs. Replaces the
+Vercel `crons` entries in `packages/web/vercel.json`, one job at a time.
+
+It is a **trigger, not a reimplementation**: each job makes an HTTP request to
+the existing `/api/internal/*` route with `Authorization: Bearer $CRON_SECRET`
+— the exact header `requireCronAuth` already validates. Several of those routes
+touch Next-only primitives (`unstable_cache` warm-up, `revalidateTag`) that a
+plain Node process cannot reach, so the routes stay the single implementation.
+
+## Commands
+
+```bash
+vp exec tsx packages/scheduler/src/cli/index.ts start       # cron loop + /health server
+vp exec tsx packages/scheduler/src/cli/index.ts run cleanup # one-shot, exits non-zero on failure
+vp exec tsx packages/scheduler/src/cli/index.ts list        # registered jobs and schedules
+```
+
+## Environment
+
+| Variable                  | Required | Default                     | Notes                                                                                                |
+| ------------------------- | -------- | --------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `CRON_SECRET`             | yes      | —                           | Same value as the Vercel project env var. Not renamed; see `packages/web/app/lib/auth/cron-auth.ts`. |
+| `BOARDSESH_WEB_URL`       | no       | `https://www.boardsesh.com` | Same name the backend uses for web callbacks.                                                        |
+| `PORT`                    | no       | `8080`                      | Health server port (`GET /health`).                                                                  |
+| `SCHEDULER_DISABLED_JOBS` | no       | —                           | Comma-separated job names to leave unscheduled. `run <job>` still works.                             |
+
+A missing `CRON_SECRET` throws at startup, not on the first tick.
+
+## Adding a job
+
+1. Add a `JobDefinition` to `src/jobs/registry.ts` with an explicit
+   `timezone: 'UTC'` — Vercel crons are UTC and a container's local zone is not
+   guaranteed to be.
+2. Remove the matching entry from `packages/web/vercel.json` and from
+   `VERCEL_OWNED_CRON_PATHS`. `src/__tests__/registry.test.ts` diffs both sides,
+   so editing only one fails CI.
+3. Deploy the scheduler and confirm a manual `run <job>` returns 200 in
+   production **before** merging the `vercel.json` removal.
+
+Ownership table, Railway setup and the runbook live in `docs/scheduler.md`.
+
+## Cron support
+
+`src/cron/` implements the five standard numeric fields
+(`minute hour day-of-month month day-of-week`) with `*`, `a`, `a-b`, lists and
+`/step`, evaluated once a minute in each job's declared IANA timezone. Month and
+weekday names, `@daily` shorthands, seconds and Quartz extensions (`L`, `W`,
+`#`) throw at parse time rather than being silently reinterpreted.

--- a/packages/scheduler/README.md
+++ b/packages/scheduler/README.md
@@ -23,7 +23,7 @@ vp exec tsx packages/scheduler/src/cli/index.ts list        # registered jobs an
 | ------------------------- | -------- | --------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `CRON_SECRET`             | yes      | —                           | Same value as the Vercel project env var. Not renamed; see `packages/web/app/lib/auth/cron-auth.ts`. |
 | `BOARDSESH_WEB_URL`       | no       | `https://www.boardsesh.com` | Same name the backend uses for web callbacks.                                                        |
-| `PORT`                    | no       | `8080`                      | Health server port (`GET /health`).                                                                  |
+| `PORT`                    | no       | `8080`                      | Health server port (`GET /health` liveness, `GET /health/jobs` job health).                          |
 | `SCHEDULER_DISABLED_JOBS` | no       | —                           | Comma-separated job names to leave unscheduled. `run <job>` still works.                             |
 
 A missing `CRON_SECRET` throws at startup, not on the first tick.
@@ -31,8 +31,8 @@ A missing `CRON_SECRET` throws at startup, not on the first tick.
 ## Adding a job
 
 1. Add a `JobDefinition` to `src/jobs/registry.ts` with an explicit
-   `timezone: 'UTC'` — Vercel crons are UTC and a container's local zone is not
-   guaranteed to be.
+   `timezone: 'UTC'` — Vercel crons are UTC, a container's local zone is not
+   guaranteed to be, and UTC has no DST gap for a schedule to fall into.
 2. Remove the matching entry from `packages/web/vercel.json` and from
    `VERCEL_OWNED_CRON_PATHS`. `src/__tests__/registry.test.ts` diffs both sides,
    so editing only one fails CI.

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@boardsesh/scheduler",
+  "version": "1.0.0",
+  "description": "Long-lived cron scheduler that triggers Boardsesh's scheduled web jobs",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "dev": "tsx watch src/cli/index.ts start",
+    "build": "tsc",
+    "start": "node dist/cli/index.js start",
+    "test": "vp test",
+    "typecheck": "tsc --noEmit",
+    "lint": "vp lint",
+    "lint-fix": "vp lint --fix"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^25.9.5",
+    "tsx": "^4.23.1",
+    "typescript": "~7.0.2",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/scheduler/src/__tests__/config.test.ts
+++ b/packages/scheduler/src/__tests__/config.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { loadSchedulerConfig, SchedulerConfigError } from '../config';
+
+describe('loadSchedulerConfig', () => {
+  it('throws when CRON_SECRET is missing', () => {
+    expect(() => loadSchedulerConfig({})).toThrow(SchedulerConfigError);
+    expect(() => loadSchedulerConfig({ CRON_SECRET: '   ' })).toThrow(/CRON_SECRET is required/);
+  });
+
+  it('defaults the web base URL to production', () => {
+    const config = loadSchedulerConfig({ CRON_SECRET: 'secret' });
+    expect(config.webBaseUrl).toBe('https://www.boardsesh.com');
+    expect(config.port).toBe(8080);
+    expect(config.disabledJobs).toEqual([]);
+  });
+
+  it('strips trailing slashes so paths never double up', () => {
+    const config = loadSchedulerConfig({ CRON_SECRET: 'secret', BOARDSESH_WEB_URL: 'https://example.com//' });
+    expect(config.webBaseUrl).toBe('https://example.com');
+    expect(`${config.webBaseUrl}/api/internal/cleanup`).toBe('https://example.com/api/internal/cleanup');
+  });
+
+  it('rejects a base URL without a scheme', () => {
+    expect(() => loadSchedulerConfig({ CRON_SECRET: 'secret', BOARDSESH_WEB_URL: 'www.boardsesh.com' })).toThrow(
+      /must start with http/,
+    );
+  });
+
+  it('parses SCHEDULER_DISABLED_JOBS into trimmed names', () => {
+    const config = loadSchedulerConfig({
+      CRON_SECRET: 'secret',
+      SCHEDULER_DISABLED_JOBS: ' cleanup , ,profile-percentiles ',
+    });
+    expect(config.disabledJobs).toEqual(['cleanup', 'profile-percentiles']);
+  });
+
+  it('rejects a non-numeric or out-of-range PORT', () => {
+    expect(() => loadSchedulerConfig({ CRON_SECRET: 'secret', PORT: 'eight' })).toThrow(/PORT must be an integer/);
+    expect(() => loadSchedulerConfig({ CRON_SECRET: 'secret', PORT: '0' })).toThrow(/PORT must be an integer/);
+    expect(loadSchedulerConfig({ CRON_SECRET: 'secret', PORT: '3001' }).port).toBe(3001);
+  });
+});

--- a/packages/scheduler/src/__tests__/cron-expression.test.ts
+++ b/packages/scheduler/src/__tests__/cron-expression.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CronExpressionError,
+  isValidCronExpression,
+  matchesCronExpression,
+  parseCronExpression,
+  type CronTimeFields,
+} from '../cron/expression';
+import { getZonedMinuteKey, getZonedTimeFields } from '../cron/zoned-time';
+
+const at = (fields: Partial<CronTimeFields>): CronTimeFields => ({
+  minute: 0,
+  hour: 0,
+  dayOfMonth: 1,
+  month: 1,
+  dayOfWeek: 0,
+  ...fields,
+});
+
+describe('parseCronExpression', () => {
+  it('parses the daily cleanup slot', () => {
+    const expression = parseCronExpression('0 5 * * *');
+    expect([...expression.minutes]).toEqual([0]);
+    expect([...expression.hours]).toEqual([5]);
+    expect(expression.restrictsDayOfMonth).toBe(false);
+    expect(expression.restrictsDayOfWeek).toBe(false);
+  });
+
+  it('parses the weekly prewarm slots still owned by Vercel', () => {
+    const expression = parseCronExpression('45 4 * * 0');
+    expect([...expression.minutes]).toEqual([45]);
+    expect([...expression.hours]).toEqual([4]);
+    expect([...expression.daysOfWeek]).toEqual([0]);
+    expect(expression.restrictsDayOfWeek).toBe(true);
+  });
+
+  it('expands steps, ranges and lists', () => {
+    expect([...parseCronExpression('*/15 * * * *').minutes]).toEqual([0, 15, 30, 45]);
+    expect([...parseCronExpression('0 9-11 * * *').hours]).toEqual([9, 10, 11]);
+    expect([...parseCronExpression('0 0 * * 1,3,5').daysOfWeek]).toEqual([1, 3, 5]);
+    expect([...parseCronExpression('0 0-23/6 * * *').hours]).toEqual([0, 6, 12, 18]);
+    expect([...parseCronExpression('0 20/2 * * *').hours]).toEqual([20, 22]);
+  });
+
+  it('normalises day-of-week 7 to Sunday', () => {
+    expect([...parseCronExpression('0 0 * * 7').daysOfWeek]).toEqual([0]);
+  });
+
+  it('rejects malformed expressions instead of guessing', () => {
+    expect(() => parseCronExpression('0 5 * *')).toThrow(CronExpressionError);
+    expect(() => parseCronExpression('0 5 * * * *')).toThrow(/exactly 5 fields/);
+    expect(() => parseCronExpression('60 5 * * *')).toThrow(/out of range/);
+    expect(() => parseCronExpression('0 5 * JAN *')).toThrow(CronExpressionError);
+    expect(() => parseCronExpression('@daily')).toThrow(CronExpressionError);
+    expect(() => parseCronExpression('0 9-5 * * *')).toThrow(/inverted/);
+    expect(() => parseCronExpression('0 */0 * * *')).toThrow(/step must be >= 1/);
+    expect(isValidCronExpression('0 5 * * *')).toBe(true);
+    expect(isValidCronExpression('nonsense')).toBe(false);
+  });
+});
+
+describe('matchesCronExpression', () => {
+  it('matches only the declared minute of the declared hour', () => {
+    const expression = parseCronExpression('0 5 * * *');
+    expect(matchesCronExpression(expression, at({ hour: 5, minute: 0 }))).toBe(true);
+    expect(matchesCronExpression(expression, at({ hour: 5, minute: 1 }))).toBe(false);
+    expect(matchesCronExpression(expression, at({ hour: 4, minute: 0 }))).toBe(false);
+  });
+
+  it('applies OR semantics when both day fields are restricted', () => {
+    const expression = parseCronExpression('0 0 13 * 5');
+    expect(matchesCronExpression(expression, at({ dayOfMonth: 13, dayOfWeek: 2 }))).toBe(true);
+    expect(matchesCronExpression(expression, at({ dayOfMonth: 4, dayOfWeek: 5 }))).toBe(true);
+    expect(matchesCronExpression(expression, at({ dayOfMonth: 4, dayOfWeek: 2 }))).toBe(false);
+  });
+
+  it('applies AND semantics when only one day field is restricted', () => {
+    const dayOfWeekOnly = parseCronExpression('0 4 * * 0');
+    expect(matchesCronExpression(dayOfWeekOnly, at({ hour: 4, dayOfMonth: 17, dayOfWeek: 0 }))).toBe(true);
+    expect(matchesCronExpression(dayOfWeekOnly, at({ hour: 4, dayOfMonth: 17, dayOfWeek: 1 }))).toBe(false);
+
+    const dayOfMonthOnly = parseCronExpression('0 4 1 * *');
+    expect(matchesCronExpression(dayOfMonthOnly, at({ hour: 4, dayOfMonth: 1, dayOfWeek: 3 }))).toBe(true);
+    expect(matchesCronExpression(dayOfMonthOnly, at({ hour: 4, dayOfMonth: 2, dayOfWeek: 3 }))).toBe(false);
+  });
+});
+
+describe('getZonedTimeFields', () => {
+  it('resolves UTC fields independently of the host timezone', () => {
+    // 2026-08-11T05:00:00Z is a Tuesday.
+    const fields = getZonedTimeFields(new Date('2026-08-11T05:00:00Z'), 'UTC');
+    expect(fields).toEqual({ minute: 0, hour: 5, dayOfMonth: 11, month: 8, dayOfWeek: 2 });
+  });
+
+  it('shifts the wall clock for a non-UTC zone', () => {
+    const sydney = getZonedTimeFields(new Date('2026-08-11T05:00:00Z'), 'Australia/Sydney');
+    expect(sydney.hour).toBe(15);
+    expect(sydney.dayOfMonth).toBe(11);
+  });
+
+  it('produces a minute key that is stable within a minute and changes across minutes', () => {
+    const firstKey = getZonedMinuteKey(new Date('2026-08-11T05:00:00Z'), 'UTC');
+    const sameMinuteKey = getZonedMinuteKey(new Date('2026-08-11T05:00:59Z'), 'UTC');
+    const nextMinuteKey = getZonedMinuteKey(new Date('2026-08-11T05:01:00Z'), 'UTC');
+    expect(sameMinuteKey).toBe(firstKey);
+    expect(nextMinuteKey).not.toBe(firstKey);
+  });
+
+  it('rejects an unknown timezone rather than silently using the host zone', () => {
+    expect(() => getZonedTimeFields(new Date(), 'Mars/Olympus_Mons')).toThrow();
+  });
+});

--- a/packages/scheduler/src/__tests__/cron-scheduler.test.ts
+++ b/packages/scheduler/src/__tests__/cron-scheduler.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMinuteTicker } from '../cron/scheduler';
+
+// The ticker wakes 500ms after each minute boundary, so a test that wants
+// `count` ticks has to advance past that offset.
+const advanceMinutes = (count: number) => vi.advanceTimersByTime(count * 60_000 + 500);
+
+describe('createMinuteTicker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires a job in its matching minute and not in the next one', () => {
+    vi.setSystemTime(new Date('2026-08-11T04:59:00Z'));
+    const ticker = createMinuteTicker();
+    const handler = vi.fn();
+    ticker.schedule('0 5 * * *', handler, { timezone: 'UTC' });
+
+    advanceMinutes(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    advanceMinutes(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    ticker.stop();
+  });
+
+  it('does not fire outside the matching minute', () => {
+    vi.setSystemTime(new Date('2026-08-11T01:00:00Z'));
+    const ticker = createMinuteTicker();
+    const handler = vi.fn();
+    ticker.schedule('0 5 * * *', handler, { timezone: 'UTC' });
+
+    advanceMinutes(30);
+    expect(handler).not.toHaveBeenCalled();
+
+    ticker.stop();
+  });
+
+  it('evaluates the schedule in the declared timezone, not the host zone', () => {
+    // 19:00 UTC is 05:00 the next day in Sydney, so the UTC-scheduled job must
+    // stay quiet while the Sydney-scheduled one fires.
+    vi.setSystemTime(new Date('2026-08-11T18:59:00Z'));
+    const ticker = createMinuteTicker();
+    const utcHandler = vi.fn();
+    const sydneyHandler = vi.fn();
+    ticker.schedule('0 5 * * *', utcHandler, { timezone: 'UTC' });
+    ticker.schedule('0 5 * * *', sydneyHandler, { timezone: 'Australia/Sydney' });
+
+    advanceMinutes(1);
+    expect(utcHandler).not.toHaveBeenCalled();
+    expect(sydneyHandler).toHaveBeenCalledTimes(1);
+
+    ticker.stop();
+  });
+
+  it('keeps ticking after a handler throws', () => {
+    vi.setSystemTime(new Date('2026-08-11T04:58:00Z'));
+    const onHandlerError = vi.fn();
+    const ticker = createMinuteTicker({ onHandlerError });
+    const throwingHandler = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const healthyHandler = vi.fn();
+    ticker.schedule('* * * * *', throwingHandler, { timezone: 'UTC' });
+    ticker.schedule('* * * * *', healthyHandler, { timezone: 'UTC' });
+
+    advanceMinutes(3);
+    expect(throwingHandler).toHaveBeenCalledTimes(3);
+    expect(healthyHandler).toHaveBeenCalledTimes(3);
+    expect(onHandlerError).toHaveBeenCalledTimes(3);
+
+    ticker.stop();
+  });
+
+  it('stops firing once the task is stopped', () => {
+    vi.setSystemTime(new Date('2026-08-11T04:58:00Z'));
+    const ticker = createMinuteTicker();
+    const handler = vi.fn();
+    const task = ticker.schedule('* * * * *', handler, { timezone: 'UTC' });
+
+    advanceMinutes(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    task.stop();
+    expect(vi.getTimerCount()).toBe(0);
+
+    advanceMinutes(5);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    ticker.stop();
+  });
+
+  it('clears every timer on stop() and refuses further registration', () => {
+    vi.setSystemTime(new Date('2026-08-11T04:58:00Z'));
+    const ticker = createMinuteTicker();
+    ticker.schedule('* * * * *', vi.fn(), { timezone: 'UTC' });
+    expect(vi.getTimerCount()).toBe(1);
+
+    ticker.stop();
+    expect(vi.getTimerCount()).toBe(0);
+    expect(() => ticker.schedule('* * * * *', vi.fn(), { timezone: 'UTC' })).toThrow(/stopped ticker/);
+  });
+
+  it('rejects an invalid expression or timezone at registration time', () => {
+    const ticker = createMinuteTicker();
+    expect(() => ticker.schedule('not a cron', vi.fn(), { timezone: 'UTC' })).toThrow();
+    expect(() => ticker.schedule('0 5 * * *', vi.fn(), { timezone: 'Mars/Olympus_Mons' })).toThrow();
+    ticker.stop();
+  });
+});

--- a/packages/scheduler/src/__tests__/health-server.test.ts
+++ b/packages/scheduler/src/__tests__/health-server.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createHealthServer, type HealthServer } from '../health-server';
+import type { SchedulerLogger } from '../logger';
+import type { JobStatus } from '../runner';
+
+const silentLogger: SchedulerLogger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+const jobStatus: JobStatus = {
+  name: 'cleanup',
+  schedule: '0 5 * * *',
+  timezone: 'UTC',
+  scheduled: true,
+  running: false,
+  lastRunAt: '2026-08-11T05:00:00.000Z',
+  lastSuccessAt: '2026-08-11T05:00:04.000Z',
+  lastDurationMs: 4000,
+  lastError: null,
+  runCount: 1,
+  failureCount: 0,
+  skippedCount: 0,
+};
+
+let openServer: HealthServer | null = null;
+
+afterEach(async () => {
+  await openServer?.stop();
+  openServer = null;
+});
+
+async function startServer(getStatus: () => JobStatus[]): Promise<string> {
+  const server = createHealthServer({ port: 0, getStatus, logger: silentLogger });
+  openServer = server;
+  const port = await server.start();
+  return `http://127.0.0.1:${port}`;
+}
+
+describe('createHealthServer', () => {
+  it('serves the runner status map on GET /health', async () => {
+    const baseUrl = await startServer(() => [jobStatus]);
+
+    const response = await fetch(`${baseUrl}/health`);
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    await expect(response.json()).resolves.toEqual({ status: 'ok', jobs: [jobStatus] });
+  });
+
+  it('reflects a failing job so ops can see it without reading logs', async () => {
+    const baseUrl = await startServer(() => [{ ...jobStatus, lastError: 'HTTP 500', failureCount: 2 }]);
+
+    const body = (await (await fetch(`${baseUrl}/health`)).json()) as { jobs: JobStatus[] };
+    expect(body.jobs[0].lastError).toBe('HTTP 500');
+    expect(body.jobs[0].failureCount).toBe(2);
+  });
+
+  it('ignores a query string on the health path', async () => {
+    const baseUrl = await startServer(() => [jobStatus]);
+
+    expect((await fetch(`${baseUrl}/health?verbose=1`)).status).toBe(200);
+  });
+
+  it('404s any other path', async () => {
+    const baseUrl = await startServer(() => [jobStatus]);
+
+    const response = await fetch(`${baseUrl}/anything-else`);
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: 'Not found' });
+  });
+
+  it('closes cleanly and stops accepting connections', async () => {
+    const baseUrl = await startServer(() => [jobStatus]);
+    const server = openServer;
+    openServer = null;
+
+    await server?.stop();
+    await expect(fetch(`${baseUrl}/health`)).rejects.toThrow();
+    // A second stop must be a no-op rather than hanging.
+    await expect(server?.stop()).resolves.toBeUndefined();
+  });
+});

--- a/packages/scheduler/src/__tests__/health-server.test.ts
+++ b/packages/scheduler/src/__tests__/health-server.test.ts
@@ -45,15 +45,47 @@ describe('createHealthServer', () => {
     const response = await fetch(`${baseUrl}/health`);
     expect(response.status).toBe(200);
     expect(response.headers.get('content-type')).toContain('application/json');
-    await expect(response.json()).resolves.toEqual({ status: 'ok', jobs: [jobStatus] });
+    await expect(response.json()).resolves.toEqual({ status: 'ok', degraded: false, jobs: [jobStatus] });
   });
 
   it('reflects a failing job so ops can see it without reading logs', async () => {
     const baseUrl = await startServer(() => [{ ...jobStatus, lastError: 'HTTP 500', failureCount: 2 }]);
 
-    const body = (await (await fetch(`${baseUrl}/health`)).json()) as { jobs: JobStatus[] };
+    const body = (await (await fetch(`${baseUrl}/health`)).json()) as { jobs: JobStatus[]; degraded: boolean };
     expect(body.jobs[0].lastError).toBe('HTTP 500');
     expect(body.jobs[0].failureCount).toBe(2);
+    expect(body.degraded).toBe(true);
+  });
+
+  it('keeps /health at 200 while a job is failing — a restart cannot fix a bad secret', async () => {
+    const baseUrl = await startServer(() => [{ ...jobStatus, lastError: 'HTTP 401' }]);
+
+    // Railway polls /health; going red here would restart-loop the container
+    // and wipe the lastError that says what actually broke.
+    expect((await fetch(`${baseUrl}/health`)).status).toBe(200);
+  });
+
+  it('503s /health/jobs when a scheduled job last failed', async () => {
+    const baseUrl = await startServer(() => [{ ...jobStatus, lastError: 'HTTP 401' }]);
+
+    const response = await fetch(`${baseUrl}/health/jobs`);
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as { status: string; degraded: boolean };
+    expect(body).toMatchObject({ status: 'degraded', degraded: true });
+  });
+
+  it('200s /health/jobs when every scheduled job is healthy', async () => {
+    const baseUrl = await startServer(() => [jobStatus]);
+
+    expect((await fetch(`${baseUrl}/health/jobs`)).status).toBe(200);
+  });
+
+  it('stays healthy before the first tick and ignores a disabled job failure', async () => {
+    const neverRun = { ...jobStatus, lastRunAt: null, lastSuccessAt: null, lastDurationMs: null, runCount: 0 };
+    const disabledAndBroken = { ...jobStatus, name: 'other', scheduled: false, lastError: 'HTTP 500' };
+    const baseUrl = await startServer(() => [neverRun, disabledAndBroken]);
+
+    expect((await fetch(`${baseUrl}/health/jobs`)).status).toBe(200);
   });
 
   it('ignores a query string on the health path', async () => {

--- a/packages/scheduler/src/__tests__/logger.test.ts
+++ b/packages/scheduler/src/__tests__/logger.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { consoleLogger, describeError } from '../logger';
+
+describe('describeError', () => {
+  it('returns a plain error message unchanged', () => {
+    expect(describeError(new Error('web returned HTTP 500'))).toBe('web returned HTTP 500');
+  });
+
+  it('unwraps the cause fetch hides behind "fetch failed"', () => {
+    // What Node actually throws when the web host refuses the connection: the
+    // runbook needs ECONNREFUSED, not the useless outer message.
+    const connectionRefused = new Error('connect ECONNREFUSED 10.0.0.1:443');
+    const fetchFailure = new Error('fetch failed', { cause: connectionRefused });
+
+    expect(describeError(fetchFailure)).toBe('fetch failed: connect ECONNREFUSED 10.0.0.1:443');
+  });
+
+  it('walks a nested cause chain but stops before a pathological one', () => {
+    const chained = new Error('one', {
+      cause: new Error('two', {
+        cause: new Error('three', { cause: new Error('four', { cause: new Error('five') }) }),
+      }),
+    });
+
+    // Three links deep, then it stops — "five" never makes it into the line.
+    expect(describeError(chained)).toBe('one: two: three: four');
+  });
+
+  it('skips a repeated or empty message instead of doubling it up', () => {
+    expect(describeError(new Error('fetch failed', { cause: new Error('fetch failed') }))).toBe('fetch failed');
+    expect(describeError(new Error('fetch failed', { cause: new Error('') }))).toBe('fetch failed');
+  });
+
+  it('falls back to the error name when there is no message at all', () => {
+    expect(describeError(new TypeError())).toBe('TypeError');
+  });
+
+  it('ignores a non-Error cause and stringifies a non-Error throw', () => {
+    expect(describeError(new Error('outer', { cause: 'a string cause' }))).toBe('outer');
+    expect(describeError('not an error')).toBe('not an error');
+  });
+});
+
+describe('consoleLogger', () => {
+  it('writes one JSON line per entry, tagged with the service', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+
+    consoleLogger.info('job tick', { job: 'cleanup' });
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const line = JSON.parse(infoSpy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(line).toMatchObject({ level: 'info', service: 'scheduler', message: 'job tick', job: 'cleanup' });
+    expect(typeof line.time).toBe('string');
+
+    infoSpy.mockRestore();
+  });
+});

--- a/packages/scheduler/src/__tests__/registry.test.ts
+++ b/packages/scheduler/src/__tests__/registry.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { isValidCronExpression } from '../cron/expression';
+import { assertValidTimeZone } from '../cron/zoned-time';
+import { findJob, JOBS, VERCEL_OWNED_CRON_PATHS } from '../jobs/registry';
+
+type VercelConfig = { crons?: { path: string; schedule: string }[] };
+
+const vercelConfigUrl = new URL('../../../web/vercel.json', import.meta.url);
+const vercelConfig = JSON.parse(readFileSync(vercelConfigUrl, 'utf8')) as VercelConfig;
+const vercelCronPaths = (vercelConfig.crons ?? []).map((cron) => cron.path);
+
+describe('job registry', () => {
+  it('has unique job names', () => {
+    const jobNames = JOBS.map((job) => job.name);
+    expect(new Set(jobNames).size).toBe(jobNames.length);
+  });
+
+  it('declares a parseable schedule and a real timezone for every job', () => {
+    for (const job of JOBS) {
+      expect(isValidCronExpression(job.schedule), `${job.name} schedule ${job.schedule}`).toBe(true);
+      expect(() => assertValidTimeZone(job.timezone)).not.toThrow();
+      expect(job.timeoutMs).toBeGreaterThan(0);
+    }
+  });
+
+  it('pins every job to UTC, the zone Vercel crons ran in', () => {
+    // node-style cron evaluates in the host zone by default; a container whose
+    // TZ is not UTC would silently move the job off its slot.
+    for (const job of JOBS) {
+      expect(job.timezone).toBe('UTC');
+    }
+  });
+
+  it('never schedules a path that vercel.json still owns', () => {
+    const schedulerPaths = JOBS.map((job) => job.webPath).filter((path): path is string => path !== undefined);
+    const doubleScheduled = schedulerPaths.filter((path) => vercelCronPaths.includes(path));
+    expect(doubleScheduled).toEqual([]);
+  });
+
+  it('keeps VERCEL_OWNED_CRON_PATHS in step with vercel.json', () => {
+    // If this fails, a cron moved on one side only: either add the job here and
+    // drop it from vercel.json, or drop it from this list.
+    expect([...vercelCronPaths].sort()).toEqual([...VERCEL_OWNED_CRON_PATHS].sort());
+  });
+
+  it('has taken the cleanup cron off Vercel', () => {
+    expect(vercelCronPaths).not.toContain('/api/internal/cleanup');
+    expect(findJob('cleanup')?.webPath).toBe('/api/internal/cleanup');
+  });
+
+  it('keeps the cleanup job on the slot vercel.json used', () => {
+    expect(findJob('cleanup')?.schedule).toBe('0 5 * * *');
+  });
+
+  it('returns undefined for an unknown job name', () => {
+    expect(findJob('nope')).toBeUndefined();
+  });
+});

--- a/packages/scheduler/src/__tests__/runner.test.ts
+++ b/packages/scheduler/src/__tests__/runner.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SchedulerConfig } from '../config';
+import type { CronScheduleOptions, CronScheduler, CronTask } from '../cron/scheduler';
+import type { JobDefinition } from '../jobs/types';
+import type { LogFields, SchedulerLogger } from '../logger';
+import { createScheduler } from '../runner';
+
+type RecordedRegistration = {
+  expression: string;
+  handler: () => void;
+  options: CronScheduleOptions;
+  stopped: boolean;
+};
+
+function createFakeCron() {
+  const registrations: RecordedRegistration[] = [];
+
+  const cron: CronScheduler = {
+    schedule(expression, handler, options): CronTask {
+      const registration: RecordedRegistration = { expression, handler, options, stopped: false };
+      registrations.push(registration);
+      return {
+        expression,
+        timezone: options.timezone,
+        stop() {
+          registration.stopped = true;
+        },
+      };
+    },
+    stop() {
+      for (const registration of registrations) {
+        registration.stopped = true;
+      }
+    },
+  };
+
+  return { cron, registrations };
+}
+
+type RecordedLog = { level: 'info' | 'warn' | 'error'; message: string; fields?: LogFields };
+
+function createRecordingLogger() {
+  const logs: RecordedLog[] = [];
+  const logger: SchedulerLogger = {
+    info: (message, fields) => logs.push({ level: 'info', message, fields }),
+    warn: (message, fields) => logs.push({ level: 'warn', message, fields }),
+    error: (message, fields) => logs.push({ level: 'error', message, fields }),
+  };
+  return { logger, logs };
+}
+
+const baseConfig: SchedulerConfig = {
+  webBaseUrl: 'https://web.test',
+  cronSecret: 'secret',
+  port: 8080,
+  disabledJobs: [],
+};
+
+const defineJob = (overrides: Partial<JobDefinition> = {}): JobDefinition => ({
+  name: 'cleanup',
+  schedule: '0 5 * * *',
+  timezone: 'UTC',
+  timeoutMs: 120_000,
+  run: async () => ({ ok: true }),
+  ...overrides,
+});
+
+describe('createScheduler', () => {
+  it('registers each job with its exact expression and timezone', () => {
+    const { cron, registrations } = createFakeCron();
+    const { logger } = createRecordingLogger();
+
+    createScheduler({
+      jobs: [defineJob(), defineJob({ name: 'other', schedule: '30 4 * * 0', timezone: 'UTC' })],
+      config: baseConfig,
+      cron,
+      logger,
+    });
+
+    expect(registrations).toHaveLength(2);
+    expect(registrations[0].expression).toBe('0 5 * * *');
+    expect(registrations[0].options).toEqual({ timezone: 'UTC' });
+    expect(registrations[1].expression).toBe('30 4 * * 0');
+    expect(registrations[1].options).toEqual({ timezone: 'UTC' });
+  });
+
+  it('skips and warns on a tick whose predecessor is still in flight', async () => {
+    const { cron, registrations } = createFakeCron();
+    const { logger, logs } = createRecordingLogger();
+    let releaseFirstRun: () => void = () => undefined;
+    const run = vi.fn(
+      () =>
+        new Promise<unknown>((resolve) => {
+          releaseFirstRun = () => resolve({ ok: true });
+        }),
+    );
+
+    const scheduler = createScheduler({ jobs: [defineJob({ run })], config: baseConfig, cron, logger });
+
+    registrations[0].handler();
+    registrations[0].handler();
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(logs.some((log) => log.level === 'warn' && log.message.includes('still in flight'))).toBe(true);
+    expect(scheduler.getStatus()[0].skippedCount).toBe(1);
+
+    releaseFirstRun();
+    await vi.waitFor(() => expect(scheduler.getStatus()[0].running).toBe(false));
+
+    // Once the first run finishes the next tick is accepted again.
+    registrations[0].handler();
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it('catches a rejecting job, records it, and stays scheduled', async () => {
+    const { cron, registrations } = createFakeCron();
+    const { logger, logs } = createRecordingLogger();
+    const run = vi.fn().mockRejectedValue(new Error('web returned HTTP 500'));
+
+    const scheduler = createScheduler({ jobs: [defineJob({ run })], config: baseConfig, cron, logger });
+
+    expect(() => registrations[0].handler()).not.toThrow();
+    await vi.waitFor(() => expect(scheduler.getStatus()[0].failureCount).toBe(1));
+
+    const status = scheduler.getStatus()[0];
+    expect(status.lastError).toBe('web returned HTTP 500');
+    expect(status.running).toBe(false);
+    expect(registrations[0].stopped).toBe(false);
+    expect(logs.some((log) => log.level === 'error' && log.message === 'job failed')).toBe(true);
+
+    run.mockResolvedValueOnce({ ok: true });
+    registrations[0].handler();
+    await vi.waitFor(() => expect(scheduler.getStatus()[0].lastError).toBeNull());
+  });
+
+  it('passes the job timeout and a shutdown signal into the run context', async () => {
+    const { cron } = createFakeCron();
+    const { logger } = createRecordingLogger();
+    const run = vi.fn().mockResolvedValue(null);
+
+    const scheduler = createScheduler({
+      jobs: [defineJob({ run, timeoutMs: 4_242 })],
+      config: baseConfig,
+      cron,
+      logger,
+    });
+    await scheduler.runJob('cleanup');
+
+    const runContext = run.mock.calls[0][0];
+    expect(runContext.timeoutMs).toBe(4_242);
+    expect(runContext.config).toBe(baseConfig);
+    expect(runContext.shutdownSignal.aborted).toBe(false);
+
+    scheduler.stop();
+    expect(runContext.shutdownSignal.aborted).toBe(true);
+  });
+
+  it('leaves SCHEDULER_DISABLED_JOBS entries unregistered but still runnable on demand', async () => {
+    const { cron, registrations } = createFakeCron();
+    const { logger, logs } = createRecordingLogger();
+    const run = vi.fn().mockResolvedValue({ ok: true });
+
+    const scheduler = createScheduler({
+      jobs: [defineJob({ run }), defineJob({ name: 'other', run })],
+      config: { ...baseConfig, disabledJobs: ['cleanup'] },
+      cron,
+      logger,
+    });
+
+    expect(registrations).toHaveLength(1);
+    expect(scheduler.scheduledJobs.map((job) => job.name)).toEqual(['other']);
+    expect(scheduler.getStatus().find((status) => status.name === 'cleanup')?.scheduled).toBe(false);
+    expect(logs.some((log) => log.level === 'warn' && log.message.includes('disabled'))).toBe(true);
+
+    await expect(scheduler.runJob('cleanup')).resolves.toEqual({ ok: true });
+  });
+
+  it('warns when SCHEDULER_DISABLED_JOBS names a job that does not exist', () => {
+    const { cron } = createFakeCron();
+    const { logger, logs } = createRecordingLogger();
+
+    createScheduler({ jobs: [defineJob()], config: { ...baseConfig, disabledJobs: ['typo'] }, cron, logger });
+
+    expect(logs.some((log) => log.level === 'warn' && log.message.includes('no such job'))).toBe(true);
+  });
+
+  it('registers nothing when registerSchedules is false', () => {
+    const { cron, registrations } = createFakeCron();
+    const { logger } = createRecordingLogger();
+
+    createScheduler({ jobs: [defineJob()], config: baseConfig, cron, logger, registerSchedules: false });
+
+    expect(registrations).toHaveLength(0);
+  });
+
+  it('rejects duplicate job names', () => {
+    const { cron } = createFakeCron();
+    const { logger } = createRecordingLogger();
+
+    expect(() => createScheduler({ jobs: [defineJob(), defineJob()], config: baseConfig, cron, logger })).toThrow(
+      /duplicate job name/,
+    );
+  });
+
+  it('throws a helpful error for an unknown job name', async () => {
+    const { cron } = createFakeCron();
+    const { logger } = createRecordingLogger();
+    const scheduler = createScheduler({ jobs: [defineJob()], config: baseConfig, cron, logger });
+
+    await expect(scheduler.runJob('nope')).rejects.toThrow(/unknown job "nope"; known jobs: cleanup/);
+  });
+
+  it('destroys every registered task on stop()', () => {
+    const { cron, registrations } = createFakeCron();
+    const { logger } = createRecordingLogger();
+    const scheduler = createScheduler({
+      jobs: [defineJob(), defineJob({ name: 'other' })],
+      config: baseConfig,
+      cron,
+      logger,
+    });
+
+    scheduler.stop();
+    expect(registrations.every((registration) => registration.stopped)).toBe(true);
+  });
+
+  it('records duration and success timestamps', async () => {
+    const { cron } = createFakeCron();
+    const { logger } = createRecordingLogger();
+    const scheduler = createScheduler({ jobs: [defineJob()], config: baseConfig, cron, logger });
+
+    await scheduler.runJob('cleanup');
+
+    const status = scheduler.getStatus()[0];
+    expect(status.runCount).toBe(1);
+    expect(status.failureCount).toBe(0);
+    expect(status.lastRunAt).not.toBeNull();
+    expect(status.lastSuccessAt).not.toBeNull();
+    expect(status.lastDurationMs).not.toBeNull();
+  });
+});

--- a/packages/scheduler/src/__tests__/trigger-web-cron.test.ts
+++ b/packages/scheduler/src/__tests__/trigger-web-cron.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SchedulerConfig } from '../config';
+import type { SchedulerLogger } from '../logger';
+import { triggerWebCron, WebCronRequestError } from '../jobs/trigger-web-cron';
+
+const config: SchedulerConfig = {
+  webBaseUrl: 'https://web.test',
+  cronSecret: 'super-secret',
+  port: 8080,
+  disabledJobs: [],
+};
+
+const silentLogger: SchedulerLogger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+const context = (overrides: Partial<{ timeoutMs: number; shutdownSignal: AbortSignal }> = {}) => ({
+  config,
+  logger: silentLogger,
+  timeoutMs: 120_000,
+  ...overrides,
+});
+
+describe('triggerWebCron', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('calls the web route with the bearer header requireCronAuth expects', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify({ feedItemsDeleted: 3 }), { status: 200 }));
+
+    const result = await triggerWebCron('/api/internal/cleanup')(context());
+
+    expect(result).toEqual({ feedItemsDeleted: 3 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [requestUrl, requestInit] = fetchMock.mock.calls[0];
+    expect(requestUrl).toBe('https://web.test/api/internal/cleanup');
+    const headers = (requestInit?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer super-secret');
+    expect(requestInit?.method).toBe('GET');
+  });
+
+  it('throws with the status on a 401', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 }),
+    );
+
+    await expect(triggerWebCron('/api/internal/cleanup')(context())).rejects.toThrow(WebCronRequestError);
+    await expect(triggerWebCron('/api/internal/cleanup')(context())).rejects.toThrow(/HTTP 401/);
+  });
+
+  it('throws with the status and body on a 500', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('Cleanup failed', { status: 500 }));
+
+    await expect(triggerWebCron('/api/internal/cleanup')(context())).rejects.toThrow(/HTTP 500: Cleanup failed/);
+  });
+
+  it('truncates a huge error body instead of logging the whole page', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('x'.repeat(5000), { status: 502 }));
+
+    const error = await triggerWebCron('/api/internal/cleanup')(context()).catch((thrown: unknown) => thrown);
+    expect(error).toBeInstanceOf(WebCronRequestError);
+    expect((error as Error).message.length).toBeLessThan(600);
+  });
+
+  it('aborts a hung request at timeoutMs instead of blocking the tick forever', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      (_input, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+        }),
+    );
+
+    const pending = triggerWebCron('/api/internal/cleanup')(context({ timeoutMs: 1_000 }));
+    const assertion = expect(pending).rejects.toThrow(/aborted/);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await assertion;
+  });
+
+  it('aborts in flight when the process is shutting down', async () => {
+    const shutdownController = new AbortController();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      (_input, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+        }),
+    );
+
+    const pending = triggerWebCron('/api/internal/cleanup')(context({ shutdownSignal: shutdownController.signal }));
+    const assertion = expect(pending).rejects.toThrow(/aborted/);
+    shutdownController.abort(new Error('stopping'));
+    await assertion;
+  });
+
+  it('returns null for an empty 200 body', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 200 }));
+
+    await expect(triggerWebCron('/api/internal/cleanup')(context())).resolves.toBeNull();
+  });
+});

--- a/packages/scheduler/src/__tests__/trigger-web-cron.test.ts
+++ b/packages/scheduler/src/__tests__/trigger-web-cron.test.ts
@@ -16,7 +16,9 @@ const silentLogger: SchedulerLogger = {
   error: () => undefined,
 };
 
-const context = (overrides: Partial<{ timeoutMs: number; shutdownSignal: AbortSignal }> = {}) => ({
+const context = (
+  overrides: Partial<{ timeoutMs: number; shutdownSignal: AbortSignal; logger: SchedulerLogger }> = {},
+) => ({
   config,
   logger: silentLogger,
   timeoutMs: 120_000,
@@ -64,7 +66,7 @@ describe('triggerWebCron', () => {
   });
 
   it('truncates a huge error body instead of logging the whole page', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('x'.repeat(5000), { status: 502 }));
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('x'.repeat(5000), { status: 500 }));
 
     const error = await triggerWebCron('/api/internal/cleanup')(context()).catch((thrown: unknown) => thrown);
     expect(error).toBeInstanceOf(WebCronRequestError);
@@ -105,5 +107,58 @@ describe('triggerWebCron', () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 200 }));
 
     await expect(triggerWebCron('/api/internal/cleanup')(context())).resolves.toBeNull();
+  });
+
+  it('retries a 503 once and reports the second attempt as the result', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('no healthy upstream', { status: 503 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ feedItemsDeleted: 1 }), { status: 200 }));
+    const warnings: string[] = [];
+
+    const result = await triggerWebCron('/api/internal/cleanup', { retryDelayMs: 1 })(
+      context({ logger: { ...silentLogger, warn: (message) => warnings.push(message) } }),
+    );
+
+    expect(result).toEqual({ feedItemsDeleted: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(warnings).toEqual(['web cron request failed on a retryable status; retrying once']);
+  });
+
+  it('retries a 502 exactly once before giving up', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(() => Promise.resolve(new Response('Bad gateway', { status: 502 })));
+
+    await expect(triggerWebCron('/api/internal/cleanup', { retryDelayMs: 1 })(context())).rejects.toThrow(
+      /HTTP 502: Bad gateway/,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a status the app itself produced', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(() => Promise.resolve(new Response('Cleanup failed', { status: 500 })));
+
+    await expect(triggerWebCron('/api/internal/cleanup', { retryDelayMs: 1 })(context())).rejects.toThrow(/HTTP 500/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('abandons the retry wait when the process is shutting down', async () => {
+    const shutdownController = new AbortController();
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(() => Promise.resolve(new Response('no healthy upstream', { status: 503 })));
+    // Shut down at the exact moment the retry is announced, so the run is
+    // waiting out a minute-long backoff it must not finish.
+    const logger: SchedulerLogger = { ...silentLogger, warn: () => shutdownController.abort() };
+
+    await expect(
+      triggerWebCron('/api/internal/cleanup', { retryDelayMs: 60_000 })(
+        context({ shutdownSignal: shutdownController.signal, logger }),
+      ),
+    ).rejects.toThrow(/aborted by shutdown/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/scheduler/src/cli/index.ts
+++ b/packages/scheduler/src/cli/index.ts
@@ -55,7 +55,16 @@ async function runStart(): Promise<void> {
     consoleLogger.info('shutting down', { signal });
     scheduler.stop();
     cron.stop();
-    void healthServer.stop().then(() => process.exit(0));
+    // Without the catch a rejected stop() leaves the process alive with its
+    // signal handler already latched, so Railway waits out the whole stop
+    // grace period and SIGKILLs instead of the container exiting on SIGTERM.
+    void healthServer
+      .stop()
+      .then(() => process.exit(0))
+      .catch((error: unknown) => {
+        consoleLogger.error('shutdown failed', { error: describeError(error) });
+        process.exit(1);
+      });
   };
 
   process.on('SIGINT', handleSignal);

--- a/packages/scheduler/src/cli/index.ts
+++ b/packages/scheduler/src/cli/index.ts
@@ -8,10 +8,13 @@ import { createScheduler } from '../runner';
 
 const USAGE = `Boardsesh scheduler
 
-Usage:
-  scheduler start           Run the cron scheduler and health server (long-lived)
-  scheduler run <job>       Run one job immediately and exit
-  scheduler list            List known jobs and their schedules
+Usage (inside the boardsesh-sync image, from /app):
+  node --import tsx packages/scheduler/src/cli/index.ts <command>
+
+Commands:
+  start                     Run the cron scheduler and health server (long-lived)
+  run <job>                 Run one job immediately and exit
+  list                      List known jobs and their schedules
 
 Environment:
   CRON_SECRET               Required. Same value as the Vercel project env var.

--- a/packages/scheduler/src/cli/index.ts
+++ b/packages/scheduler/src/cli/index.ts
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+import { loadSchedulerConfig, SchedulerConfigError } from '../config';
+import { createMinuteTicker } from '../cron/scheduler';
+import { createHealthServer } from '../health-server';
+import { JOBS } from '../jobs/registry';
+import { consoleLogger, describeError } from '../logger';
+import { createScheduler } from '../runner';
+
+const USAGE = `Boardsesh scheduler
+
+Usage:
+  scheduler start           Run the cron scheduler and health server (long-lived)
+  scheduler run <job>       Run one job immediately and exit
+  scheduler list            List known jobs and their schedules
+
+Environment:
+  CRON_SECRET               Required. Same value as the Vercel project env var.
+  BOARDSESH_WEB_URL         Web app base URL (default https://www.boardsesh.com)
+  PORT                      Health server port (default 8080)
+  SCHEDULER_DISABLED_JOBS   Comma-separated job names to leave unscheduled
+`;
+
+function printUsage(): void {
+  process.stdout.write(USAGE);
+}
+
+async function runStart(): Promise<void> {
+  const config = loadSchedulerConfig();
+  const cron = createMinuteTicker({
+    onHandlerError: (error, expression) =>
+      consoleLogger.error('cron handler threw', { expression, error: describeError(error) }),
+  });
+  const scheduler = createScheduler({ jobs: JOBS, config, cron, logger: consoleLogger });
+  const healthServer = createHealthServer({
+    port: config.port,
+    getStatus: () => scheduler.getStatus(),
+    logger: consoleLogger,
+  });
+
+  await healthServer.start();
+  consoleLogger.info('scheduler started', {
+    webBaseUrl: config.webBaseUrl,
+    scheduledJobs: scheduler.scheduledJobs.map((job) => job.name),
+  });
+
+  let shuttingDown = false;
+  const handleSignal = (signal: NodeJS.Signals) => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    consoleLogger.info('shutting down', { signal });
+    scheduler.stop();
+    cron.stop();
+    void healthServer.stop().then(() => process.exit(0));
+  };
+
+  process.on('SIGINT', handleSignal);
+  process.on('SIGTERM', handleSignal);
+}
+
+async function runOneJob(jobName: string | undefined): Promise<void> {
+  if (!jobName) {
+    process.stderr.write('scheduler run: a job name is required\n');
+    printUsage();
+    process.exit(1);
+  }
+
+  const config = loadSchedulerConfig();
+  // A one-shot run needs no ticker. `registerSchedules: false` keeps `run`
+  // from also starting the recurring schedule, and keeps a job held back by
+  // SCHEDULER_DISABLED_JOBS runnable on demand — the env flag only silences
+  // the schedule, not an operator's explicit run.
+  const scheduler = createScheduler({
+    jobs: JOBS,
+    config,
+    cron: {
+      schedule: () => {
+        throw new Error('one-shot run must not register cron tasks');
+      },
+      stop: () => undefined,
+    },
+    logger: consoleLogger,
+    registerSchedules: false,
+  });
+
+  try {
+    const result = await scheduler.runJob(jobName);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    process.exit(0);
+  } catch (error) {
+    process.stderr.write(`scheduler run ${jobName} failed: ${describeError(error)}\n`);
+    process.exit(1);
+  }
+}
+
+function runList(): void {
+  for (const job of JOBS) {
+    process.stdout.write(`${job.name}\t${job.schedule}\t${job.timezone}\t${job.webPath ?? ''}\n`);
+  }
+}
+
+async function main(): Promise<void> {
+  const [command, ...commandArgs] = process.argv.slice(2);
+
+  switch (command) {
+    case 'start':
+      await runStart();
+      return;
+    case 'run':
+      await runOneJob(commandArgs[0]);
+      return;
+    case 'list':
+      runList();
+      return;
+    case undefined:
+    case '--help':
+    case '-h':
+    case 'help':
+      printUsage();
+      return;
+    default:
+      process.stderr.write(`scheduler: unknown command ${JSON.stringify(command)}\n`);
+      printUsage();
+      process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  if (error instanceof SchedulerConfigError) {
+    process.stderr.write(`scheduler: ${error.message}\n`);
+  } else {
+    process.stderr.write(`scheduler: ${describeError(error)}\n`);
+  }
+  process.exit(1);
+});

--- a/packages/scheduler/src/config.ts
+++ b/packages/scheduler/src/config.ts
@@ -1,0 +1,76 @@
+/**
+ * Scheduler environment parsing.
+ *
+ * Everything is read once at startup and fails fast: a missing `CRON_SECRET`
+ * must surface as a crash-looping container, not as a 401 discovered days
+ * later in the web logs.
+ */
+export type SchedulerConfig = {
+  /** Base URL of the Next app the jobs are triggered against, no trailing slash. */
+  readonly webBaseUrl: string;
+  /** Shared secret sent as `Authorization: Bearer <secret>`; see cron-auth.ts. */
+  readonly cronSecret: string;
+  /** Port the health server listens on. */
+  readonly port: number;
+  /** Job names that must not be scheduled (env-flip kill switch). */
+  readonly disabledJobs: readonly string[];
+};
+
+export class SchedulerConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SchedulerConfigError';
+  }
+}
+
+const DEFAULT_WEB_BASE_URL = 'https://www.boardsesh.com';
+const DEFAULT_PORT = 8080;
+
+function parsePort(rawPort: string | undefined): number {
+  if (rawPort === undefined || rawPort.trim() === '') {
+    return DEFAULT_PORT;
+  }
+
+  const port = Number(rawPort);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new SchedulerConfigError(`PORT must be an integer between 1 and 65535, got ${JSON.stringify(rawPort)}`);
+  }
+  return port;
+}
+
+function parseDisabledJobs(rawDisabledJobs: string | undefined): readonly string[] {
+  if (!rawDisabledJobs) {
+    return [];
+  }
+  return rawDisabledJobs
+    .split(',')
+    .map((jobName) => jobName.trim())
+    .filter((jobName) => jobName.length > 0);
+}
+
+export function loadSchedulerConfig(env: NodeJS.ProcessEnv = process.env): SchedulerConfig {
+  const cronSecret = env.CRON_SECRET?.trim();
+  if (!cronSecret) {
+    throw new SchedulerConfigError(
+      'CRON_SECRET is required. Use the same value as the Vercel project env var — the remaining Vercel crons authenticate with it too.',
+    );
+  }
+
+  // `BOARDSESH_WEB_URL` is already the backend → web convention
+  // (packages/backend/src/lib/web-revalidate.ts); reuse the name rather than
+  // inventing a second one.
+  const rawWebBaseUrl = env.BOARDSESH_WEB_URL?.trim() || DEFAULT_WEB_BASE_URL;
+  const webBaseUrl = rawWebBaseUrl.replace(/\/+$/, '');
+  if (!/^https?:\/\//.test(webBaseUrl)) {
+    throw new SchedulerConfigError(
+      `BOARDSESH_WEB_URL must start with http:// or https://, got ${JSON.stringify(rawWebBaseUrl)}`,
+    );
+  }
+
+  return {
+    webBaseUrl,
+    cronSecret,
+    port: parsePort(env.PORT),
+    disabledJobs: parseDisabledJobs(env.SCHEDULER_DISABLED_JOBS),
+  };
+}

--- a/packages/scheduler/src/cron/expression.ts
+++ b/packages/scheduler/src/cron/expression.ts
@@ -1,0 +1,176 @@
+/**
+ * A deliberately small standard-cron parser.
+ *
+ * Scope is exactly what `packages/web/vercel.json` uses: five numeric fields
+ * (`minute hour day-of-month month day-of-week`) with `*`, `a`, `a-b`, lists,
+ * and `/step`. Month/weekday names, `@daily` shorthands, `L`/`W`/`#` and
+ * seconds are NOT supported — they throw, so a schedule that silently means
+ * something else can never reach production. `registry.test.ts` asserts every
+ * registered schedule parses.
+ */
+export type CronFieldName = 'minute' | 'hour' | 'dayOfMonth' | 'month' | 'dayOfWeek';
+
+export type CronExpression = {
+  readonly source: string;
+  readonly minutes: ReadonlySet<number>;
+  readonly hours: ReadonlySet<number>;
+  readonly daysOfMonth: ReadonlySet<number>;
+  readonly months: ReadonlySet<number>;
+  readonly daysOfWeek: ReadonlySet<number>;
+  /** True when the day-of-month field is anything other than `*`. */
+  readonly restrictsDayOfMonth: boolean;
+  /** True when the day-of-week field is anything other than `*`. */
+  readonly restrictsDayOfWeek: boolean;
+};
+
+/** Wall-clock fields of a single minute, already resolved into a timezone. */
+export type CronTimeFields = {
+  readonly minute: number;
+  readonly hour: number;
+  readonly dayOfMonth: number;
+  readonly month: number;
+  /** 0 = Sunday. */
+  readonly dayOfWeek: number;
+};
+
+export class CronExpressionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CronExpressionError';
+  }
+}
+
+const FIELD_BOUNDS: Record<CronFieldName, { min: number; max: number }> = {
+  minute: { min: 0, max: 59 },
+  hour: { min: 0, max: 23 },
+  dayOfMonth: { min: 1, max: 31 },
+  month: { min: 1, max: 12 },
+  // 7 is accepted as an alias for Sunday and normalised to 0.
+  dayOfWeek: { min: 0, max: 7 },
+};
+
+function parseInteger(token: string, fieldName: CronFieldName, expression: string): number {
+  if (!/^\d+$/.test(token)) {
+    throw new CronExpressionError(
+      `invalid ${fieldName} value ${JSON.stringify(token)} in cron ${JSON.stringify(expression)}`,
+    );
+  }
+  return Number(token);
+}
+
+function parseField(rawField: string, fieldName: CronFieldName, expression: string): Set<number> {
+  const { min, max } = FIELD_BOUNDS[fieldName];
+  const values = new Set<number>();
+
+  for (const listEntry of rawField.split(',')) {
+    if (listEntry === '') {
+      throw new CronExpressionError(`empty ${fieldName} entry in cron ${JSON.stringify(expression)}`);
+    }
+
+    const [rangePart, stepPart, ...extraParts] = listEntry.split('/');
+    if (extraParts.length > 0) {
+      throw new CronExpressionError(
+        `invalid ${fieldName} step ${JSON.stringify(listEntry)} in cron ${JSON.stringify(expression)}`,
+      );
+    }
+
+    let step = 1;
+    if (stepPart !== undefined) {
+      step = parseInteger(stepPart, fieldName, expression);
+      if (step < 1) {
+        throw new CronExpressionError(`${fieldName} step must be >= 1 in cron ${JSON.stringify(expression)}`);
+      }
+    }
+
+    let rangeStart: number;
+    let rangeEnd: number;
+
+    if (rangePart === '*') {
+      rangeStart = min;
+      rangeEnd = max;
+    } else if (rangePart.includes('-')) {
+      const [startToken, endToken, ...extraRangeTokens] = rangePart.split('-');
+      if (extraRangeTokens.length > 0) {
+        throw new CronExpressionError(
+          `invalid ${fieldName} range ${JSON.stringify(rangePart)} in cron ${JSON.stringify(expression)}`,
+        );
+      }
+      rangeStart = parseInteger(startToken, fieldName, expression);
+      rangeEnd = parseInteger(endToken, fieldName, expression);
+      if (rangeEnd < rangeStart) {
+        throw new CronExpressionError(
+          `${fieldName} range ${JSON.stringify(rangePart)} is inverted in cron ${JSON.stringify(expression)}`,
+        );
+      }
+    } else {
+      rangeStart = parseInteger(rangePart, fieldName, expression);
+      // `5/2` (a bare value with a step) means "from 5 to the field max".
+      rangeEnd = stepPart === undefined ? rangeStart : max;
+    }
+
+    if (rangeStart < min || rangeEnd > max) {
+      throw new CronExpressionError(
+        `${fieldName} value out of range (${min}-${max}) in cron ${JSON.stringify(expression)}`,
+      );
+    }
+
+    for (let value = rangeStart; value <= rangeEnd; value += step) {
+      values.add(fieldName === 'dayOfWeek' && value === 7 ? 0 : value);
+    }
+  }
+
+  return values;
+}
+
+export function parseCronExpression(expression: string): CronExpression {
+  const fields = expression.trim().split(/\s+/);
+  if (fields.length !== 5) {
+    throw new CronExpressionError(
+      `cron ${JSON.stringify(expression)} must have exactly 5 fields (minute hour day-of-month month day-of-week), got ${fields.length}`,
+    );
+  }
+
+  const [rawMinute, rawHour, rawDayOfMonth, rawMonth, rawDayOfWeek] = fields;
+
+  return {
+    source: expression,
+    minutes: parseField(rawMinute, 'minute', expression),
+    hours: parseField(rawHour, 'hour', expression),
+    daysOfMonth: parseField(rawDayOfMonth, 'dayOfMonth', expression),
+    months: parseField(rawMonth, 'month', expression),
+    daysOfWeek: parseField(rawDayOfWeek, 'dayOfWeek', expression),
+    restrictsDayOfMonth: rawDayOfMonth !== '*',
+    restrictsDayOfWeek: rawDayOfWeek !== '*',
+  };
+}
+
+export function isValidCronExpression(expression: string): boolean {
+  try {
+    parseCronExpression(expression);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function matchesCronExpression(expression: CronExpression, time: CronTimeFields): boolean {
+  if (!expression.minutes.has(time.minute)) return false;
+  if (!expression.hours.has(time.hour)) return false;
+  if (!expression.months.has(time.month)) return false;
+
+  const dayOfMonthMatches = expression.daysOfMonth.has(time.dayOfMonth);
+  const dayOfWeekMatches = expression.daysOfWeek.has(time.dayOfWeek);
+
+  // Standard cron day semantics: when both day fields are restricted the day
+  // matches if EITHER does; when only one is restricted, that one decides.
+  if (expression.restrictsDayOfMonth && expression.restrictsDayOfWeek) {
+    return dayOfMonthMatches || dayOfWeekMatches;
+  }
+  if (expression.restrictsDayOfMonth) {
+    return dayOfMonthMatches;
+  }
+  if (expression.restrictsDayOfWeek) {
+    return dayOfWeekMatches;
+  }
+  return true;
+}

--- a/packages/scheduler/src/cron/scheduler.ts
+++ b/packages/scheduler/src/cron/scheduler.ts
@@ -1,0 +1,133 @@
+import { matchesCronExpression, parseCronExpression } from './expression';
+import { assertValidTimeZone, getZonedMinuteKey, getZonedTimeFields } from './zoned-time';
+
+/** Handle returned by {@link CronScheduler.schedule}. */
+export type CronTask = {
+  readonly expression: string;
+  readonly timezone: string;
+  stop(): void;
+};
+
+export type CronScheduleOptions = {
+  /** IANA timezone the expression is evaluated in. Required — never implicit. */
+  readonly timezone: string;
+};
+
+/**
+ * The tiny slice of a cron library the runner depends on. Injected so tests
+ * can drive ticks directly instead of waiting on wall-clock time.
+ */
+export type CronScheduler = {
+  schedule(expression: string, handler: () => void, options: CronScheduleOptions): CronTask;
+  stop(): void;
+};
+
+const MINUTE_MS = 60_000;
+// Wake a little after the minute boundary so a timer that fires marginally
+// early can't evaluate the previous minute twice.
+const TICK_OFFSET_MS = 500;
+
+type RegisteredTask = {
+  readonly expression: ReturnType<typeof parseCronExpression>;
+  readonly timezone: string;
+  readonly handler: () => void;
+  lastFiredMinuteKey: string | null;
+};
+
+export type MinuteTickerOptions = {
+  /** Injected for tests; defaults to `Date.now`. */
+  readonly now?: () => number;
+  /** Called (and swallowed) when a handler throws synchronously. */
+  readonly onHandlerError?: (error: unknown, expression: string) => void;
+};
+
+/**
+ * A once-per-minute cron ticker.
+ *
+ * One shared timer wakes just after each minute boundary and fires every task
+ * whose expression matches the current wall clock in that task's timezone.
+ * Missed minutes (process paused, host suspended) are skipped rather than
+ * replayed — same behaviour as a system crontab.
+ */
+export function createMinuteTicker(options: MinuteTickerOptions = {}): CronScheduler {
+  const now = options.now ?? (() => Date.now());
+  const tasks = new Set<RegisteredTask>();
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+
+  const runTick = () => {
+    const instant = new Date(now());
+    for (const task of tasks) {
+      const minuteKey = getZonedMinuteKey(instant, task.timezone);
+      if (task.lastFiredMinuteKey === minuteKey) {
+        continue;
+      }
+      if (!matchesCronExpression(task.expression, getZonedTimeFields(instant, task.timezone))) {
+        continue;
+      }
+
+      task.lastFiredMinuteKey = minuteKey;
+      try {
+        task.handler();
+      } catch (error) {
+        options.onHandlerError?.(error, task.expression.source);
+      }
+    }
+  };
+
+  const scheduleNextTick = () => {
+    if (stopped || tasks.size === 0) {
+      return;
+    }
+    const millisecondsIntoMinute = now() % MINUTE_MS;
+    const delay = MINUTE_MS - millisecondsIntoMinute + TICK_OFFSET_MS;
+    timer = setTimeout(() => {
+      timer = null;
+      runTick();
+      scheduleNextTick();
+    }, delay);
+  };
+
+  const stopTimer = () => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  return {
+    schedule(expression, handler, scheduleOptions) {
+      if (stopped) {
+        throw new Error('cannot schedule on a stopped ticker');
+      }
+      assertValidTimeZone(scheduleOptions.timezone);
+
+      const task: RegisteredTask = {
+        expression: parseCronExpression(expression),
+        timezone: scheduleOptions.timezone,
+        handler,
+        lastFiredMinuteKey: null,
+      };
+      tasks.add(task);
+      if (timer === null) {
+        scheduleNextTick();
+      }
+
+      return {
+        expression,
+        timezone: scheduleOptions.timezone,
+        stop() {
+          tasks.delete(task);
+          if (tasks.size === 0) {
+            stopTimer();
+          }
+        },
+      };
+    },
+    stop() {
+      stopped = true;
+      tasks.clear();
+      stopTimer();
+    },
+  };
+}

--- a/packages/scheduler/src/cron/scheduler.ts
+++ b/packages/scheduler/src/cron/scheduler.ts
@@ -48,6 +48,13 @@ export type MinuteTickerOptions = {
  * whose expression matches the current wall clock in that task's timezone.
  * Missed minutes (process paused, host suspended) are skipped rather than
  * replayed — same behaviour as a system crontab.
+ *
+ * DST, for whoever adds the first job in a non-UTC zone: "fall back" is safe —
+ * the repeated hour produces the same `lastFiredMinuteKey`, so the job runs
+ * once, not twice. "Spring forward" **skips** a job scheduled inside the gap
+ * (e.g. 02:30 America/New_York), because that wall-clock minute does not exist
+ * that day. That matches system crontabs, and it is the reason every job in
+ * the registry is pinned to UTC, which has no gaps.
  */
 export function createMinuteTicker(options: MinuteTickerOptions = {}): CronScheduler {
   const now = options.now ?? (() => Date.now());

--- a/packages/scheduler/src/cron/zoned-time.ts
+++ b/packages/scheduler/src/cron/zoned-time.ts
@@ -1,0 +1,79 @@
+import type { CronTimeFields } from './expression';
+
+const WEEKDAY_INDEX_BY_SHORT_NAME: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getFormatter(timeZone: string): Intl.DateTimeFormat {
+  const cached = formatterCache.get(timeZone);
+  if (cached) {
+    return cached;
+  }
+
+  // Throws RangeError for an unknown zone, which is what we want at
+  // registration time rather than silently falling back to the container's
+  // local zone (the exact drift the UTC job option exists to prevent).
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hourCycle: 'h23',
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    weekday: 'short',
+  });
+  formatterCache.set(timeZone, formatter);
+  return formatter;
+}
+
+/**
+ * Resolves an instant into the wall-clock fields a cron expression matches
+ * against, in the given IANA timezone.
+ *
+ * Vercel crons run in UTC and the containers we deploy to may not; every job
+ * declares its zone explicitly so the schedule can't drift with the host.
+ */
+export function getZonedTimeFields(instant: Date, timeZone: string): CronTimeFields {
+  const parts = getFormatter(timeZone).formatToParts(instant);
+  const partValues: Record<string, string> = {};
+  for (const part of parts) {
+    partValues[part.type] = part.value;
+  }
+
+  const dayOfWeek = WEEKDAY_INDEX_BY_SHORT_NAME[partValues.weekday];
+  if (dayOfWeek === undefined) {
+    throw new Error(`could not resolve weekday for timezone ${timeZone}`);
+  }
+
+  return {
+    minute: Number(partValues.minute),
+    hour: Number(partValues.hour),
+    dayOfMonth: Number(partValues.day),
+    month: Number(partValues.month),
+    dayOfWeek,
+  };
+}
+
+/** Stable key for "which minute is it here", used to avoid double-firing a tick. */
+export function getZonedMinuteKey(instant: Date, timeZone: string): string {
+  const parts = getFormatter(timeZone).formatToParts(instant);
+  const partValues: Record<string, string> = {};
+  for (const part of parts) {
+    partValues[part.type] = part.value;
+  }
+  return `${partValues.year}-${partValues.month}-${partValues.day}-${partValues.hour}-${partValues.minute}`;
+}
+
+/** Throws if the zone is not one Intl recognises. */
+export function assertValidTimeZone(timeZone: string): void {
+  getFormatter(timeZone);
+}

--- a/packages/scheduler/src/health-server.ts
+++ b/packages/scheduler/src/health-server.ts
@@ -1,0 +1,77 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { describeError, type SchedulerLogger } from './logger';
+import type { JobStatus } from './runner';
+
+export type HealthServer = {
+  /** Resolves with the bound port (useful when starting on port 0 in tests). */
+  start(): Promise<number>;
+  stop(): Promise<void>;
+};
+
+export type CreateHealthServerOptions = {
+  readonly port: number;
+  readonly getStatus: () => JobStatus[];
+  readonly logger: SchedulerLogger;
+};
+
+/**
+ * `GET /health` for Railway's healthcheck (`healthcheckPath = "/health"` in
+ * railway.toml) and for a cheap ops answer to "are the crons actually
+ * ticking?" — the per-job `lastRunAt` / `lastError` come straight off the
+ * runner's status map.
+ */
+export function createHealthServer({ port, getStatus, logger }: CreateHealthServerOptions): HealthServer {
+  const server: Server = createServer((request, response) => {
+    const requestPath = (request.url ?? '/').split('?')[0];
+
+    if (request.method === 'GET' && requestPath === '/health') {
+      const body = JSON.stringify({ status: 'ok', jobs: getStatus() });
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end(body);
+      return;
+    }
+
+    response.writeHead(404, { 'Content-Type': 'application/json' });
+    response.end(JSON.stringify({ error: 'Not found' }));
+  });
+
+  return {
+    start() {
+      return new Promise<number>((resolve, reject) => {
+        const onError = (error: Error) => {
+          server.off('listening', onListening);
+          reject(error);
+        };
+        const onListening = () => {
+          server.off('error', onError);
+          const address = server.address();
+          const boundPort = typeof address === 'object' && address !== null ? (address as AddressInfo).port : port;
+          logger.info('health server listening', { port: boundPort });
+          resolve(boundPort);
+        };
+
+        server.once('error', onError);
+        server.once('listening', onListening);
+        server.listen(port);
+      });
+    },
+    stop() {
+      return new Promise<void>((resolve) => {
+        if (!server.listening) {
+          resolve();
+          return;
+        }
+        server.close((error) => {
+          if (error) {
+            logger.warn('health server close failed', { error: describeError(error) });
+          }
+          resolve();
+        });
+        // Idle keep-alive sockets would otherwise hold the close open until
+        // their timeout; the scheduler has no long-lived clients to drain.
+        server.closeIdleConnections();
+      });
+    },
+  };
+}

--- a/packages/scheduler/src/health-server.ts
+++ b/packages/scheduler/src/health-server.ts
@@ -15,19 +15,35 @@ export type CreateHealthServerOptions = {
   readonly logger: SchedulerLogger;
 };
 
+/** A scheduled job whose most recent run failed and has not since succeeded. */
+function isDegraded(jobs: JobStatus[]): boolean {
+  return jobs.some((job) => job.scheduled && job.lastError !== null);
+}
+
 /**
- * `GET /health` for Railway's healthcheck (`healthcheckPath = "/health"` in
- * railway.toml) and for a cheap ops answer to "are the crons actually
- * ticking?" — the per-job `lastRunAt` / `lastError` come straight off the
- * runner's status map.
+ * Two endpoints, split the way `packages/backend` splits `/health` from
+ * `/health/db` (see docs/db-connectivity.md):
+ *
+ * - `GET /health` — liveness. 200 whenever the process is up, which is what
+ *   Railway's `healthcheckPath = "/health"` polls. It deliberately does NOT go
+ *   red on a failing job: restarting the container cannot fix a rotated
+ *   `CRON_SECRET` or a WAF rule, and a restart would wipe the `lastError` that
+ *   says which of the two it is. The body still reports `status: 'degraded'`
+ *   so a human or a log scrape can see it.
+ * - `GET /health/jobs` — job health. 503 when a scheduled job's last run
+ *   failed, 200 otherwise. Point an alert at this one; Railway must not, or it
+ *   will restart-loop on a problem restarts don't solve.
  */
 export function createHealthServer({ port, getStatus, logger }: CreateHealthServerOptions): HealthServer {
   const server: Server = createServer((request, response) => {
     const requestPath = (request.url ?? '/').split('?')[0];
 
-    if (request.method === 'GET' && requestPath === '/health') {
-      const body = JSON.stringify({ status: 'ok', jobs: getStatus() });
-      response.writeHead(200, { 'Content-Type': 'application/json' });
+    if (request.method === 'GET' && (requestPath === '/health' || requestPath === '/health/jobs')) {
+      const jobs = getStatus();
+      const degraded = isDegraded(jobs);
+      const body = JSON.stringify({ status: degraded ? 'degraded' : 'ok', degraded, jobs });
+      const statusCode = requestPath === '/health/jobs' && degraded ? 503 : 200;
+      response.writeHead(statusCode, { 'Content-Type': 'application/json' });
       response.end(body);
       return;
     }

--- a/packages/scheduler/src/index.ts
+++ b/packages/scheduler/src/index.ts
@@ -1,0 +1,23 @@
+export { loadSchedulerConfig, SchedulerConfigError, type SchedulerConfig } from './config';
+export {
+  createMinuteTicker,
+  type CronScheduler,
+  type CronScheduleOptions,
+  type CronTask,
+  type MinuteTickerOptions,
+} from './cron/scheduler';
+export {
+  CronExpressionError,
+  isValidCronExpression,
+  matchesCronExpression,
+  parseCronExpression,
+  type CronExpression,
+  type CronTimeFields,
+} from './cron/expression';
+export { assertValidTimeZone, getZonedMinuteKey, getZonedTimeFields } from './cron/zoned-time';
+export { createHealthServer, type CreateHealthServerOptions, type HealthServer } from './health-server';
+export { findJob, JOBS, VERCEL_OWNED_CRON_PATHS } from './jobs/registry';
+export { triggerWebCron, WebCronRequestError } from './jobs/trigger-web-cron';
+export type { JobContext, JobDefinition, JobRun } from './jobs/types';
+export { consoleLogger, describeError, type LogFields, type SchedulerLogger } from './logger';
+export { createScheduler, type CreateSchedulerOptions, type JobStatus, type Scheduler } from './runner';

--- a/packages/scheduler/src/jobs/registry.ts
+++ b/packages/scheduler/src/jobs/registry.ts
@@ -1,0 +1,41 @@
+import { triggerWebCron } from './trigger-web-cron';
+import type { JobDefinition } from './types';
+
+/**
+ * `/api/internal/*` cron paths still owned by `packages/web/vercel.json`.
+ *
+ * This is a checked-in mirror of that file's `crons` array, minus whatever has
+ * already moved here. `registry.test.ts` diffs it against the real vercel.json
+ * and against {@link JOBS}, so a migration PR that only edits one side fails
+ * CI instead of leaving a job double-scheduled or unscheduled.
+ */
+export const VERCEL_OWNED_CRON_PATHS: readonly string[] = [
+  '/api/internal/prewarm-heatmap/kilter',
+  '/api/internal/prewarm-heatmap/tension',
+  '/api/internal/prewarm-heatmap/decoy',
+  '/api/internal/prewarm-heatmap/touchstone',
+  '/api/internal/prewarm-heatmap/grasshopper',
+  '/api/internal/profile-percentiles',
+];
+
+// `/api/internal/cleanup` declares `maxDuration = 60`; give the request room to
+// finish plus headroom rather than cutting a legitimate run short.
+const CLEANUP_TIMEOUT_MS = 120_000;
+
+export const JOBS: readonly JobDefinition[] = [
+  {
+    name: 'cleanup',
+    // Same slot the Vercel cron used: 05:00 UTC daily.
+    schedule: '0 5 * * *',
+    // Load-bearing: Vercel crons are UTC and a container's local zone is not
+    // guaranteed to be. Without this the job silently drifts off its slot.
+    timezone: 'UTC',
+    timeoutMs: CLEANUP_TIMEOUT_MS,
+    webPath: '/api/internal/cleanup',
+    run: triggerWebCron('/api/internal/cleanup'),
+  },
+];
+
+export function findJob(jobName: string): JobDefinition | undefined {
+  return JOBS.find((job) => job.name === jobName);
+}

--- a/packages/scheduler/src/jobs/trigger-web-cron.ts
+++ b/packages/scheduler/src/jobs/trigger-web-cron.ts
@@ -1,0 +1,71 @@
+import type { JobContext, JobRun } from './types';
+
+const MAX_ERROR_BODY_CHARS = 500;
+
+export class WebCronRequestError extends Error {
+  readonly status: number;
+
+  constructor(path: string, status: number, body: string) {
+    const truncatedBody = body.length > MAX_ERROR_BODY_CHARS ? `${body.slice(0, MAX_ERROR_BODY_CHARS)}…` : body;
+    super(`${path} returned HTTP ${status}${truncatedBody ? `: ${truncatedBody}` : ''}`);
+    this.name = 'WebCronRequestError';
+    this.status = status;
+  }
+}
+
+/**
+ * Builds a job that triggers one of the web app's `/api/internal/*` cron
+ * routes.
+ *
+ * The routes stay the single implementation — several of them touch Next-only
+ * primitives (`unstable_cache` warm-up, `revalidateTag`) that a plain Node
+ * process cannot reach — so the scheduler is a trigger, not a reimplementation.
+ * The header is byte-identical to what Vercel auto-injects, which is what
+ * `requireCronAuth` (packages/web/app/lib/auth/cron-auth.ts) validates.
+ */
+export function triggerWebCron(path: string): JobRun {
+  return async (context: JobContext): Promise<unknown> => {
+    const { config, timeoutMs, shutdownSignal } = context;
+    const url = `${config.webBaseUrl}${path}`;
+
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => {
+      controller.abort(new Error(`${path} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    const abortOnShutdown = () => controller.abort(new Error(`${path} aborted by shutdown`));
+    if (shutdownSignal?.aborted) {
+      abortOnShutdown();
+    } else {
+      shutdownSignal?.addEventListener('abort', abortOnShutdown, { once: true });
+    }
+
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${config.cronSecret}`,
+          Accept: 'application/json',
+        },
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        throw new WebCronRequestError(path, response.status, body.trim());
+      }
+
+      const rawBody = await response.text();
+      if (rawBody.trim() === '') {
+        return null;
+      }
+      try {
+        return JSON.parse(rawBody) as unknown;
+      } catch {
+        return rawBody.length > MAX_ERROR_BODY_CHARS ? `${rawBody.slice(0, MAX_ERROR_BODY_CHARS)}…` : rawBody;
+      }
+    } finally {
+      clearTimeout(timeoutHandle);
+      shutdownSignal?.removeEventListener('abort', abortOnShutdown);
+    }
+  };
+}

--- a/packages/scheduler/src/jobs/trigger-web-cron.ts
+++ b/packages/scheduler/src/jobs/trigger-web-cron.ts
@@ -2,6 +2,54 @@ import type { JobContext, JobRun } from './types';
 
 const MAX_ERROR_BODY_CHARS = 500;
 
+/**
+ * Statuses worth one retry: the edge answered, the app did not. Vercel serves
+ * 502/503 during a deploy swap and when no instance is warm — a daily job that
+ * lands in that window would otherwise page for a condition that clears in
+ * seconds.
+ *
+ * 504 is deliberately not in the list. A gateway timeout means the request
+ * reached the route and it was still working, so retrying stacks a second run
+ * on top of the first rather than replacing a failed one.
+ */
+const RETRYABLE_STATUSES: ReadonlySet<number> = new Set([502, 503]);
+
+const DEFAULT_RETRY_DELAY_MS = 2_000;
+
+export type TriggerWebCronOptions = {
+  /** Wait before the single 502/503 retry. Shortened in tests. */
+  readonly retryDelayMs?: number;
+};
+
+function abortReason(signal: AbortSignal, fallbackMessage: string): Error {
+  return signal.reason instanceof Error ? signal.reason : new Error(fallbackMessage);
+}
+
+/**
+ * Sleeps, but gives up the moment the run is aborted — a retry wait must stay
+ * inside the job's `timeoutMs` and must not hold up shutdown.
+ */
+function delay(durationMs: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(abortReason(signal, 'aborted while waiting to retry'));
+      return;
+    }
+
+    let timeoutHandle: ReturnType<typeof setTimeout>;
+    const onAbort = () => {
+      clearTimeout(timeoutHandle);
+      reject(abortReason(signal, 'aborted while waiting to retry'));
+    };
+
+    timeoutHandle = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, durationMs);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
 export class WebCronRequestError extends Error {
   readonly status: number;
 
@@ -22,10 +70,17 @@ export class WebCronRequestError extends Error {
  * process cannot reach — so the scheduler is a trigger, not a reimplementation.
  * The header is byte-identical to what Vercel auto-injects, which is what
  * `requireCronAuth` (packages/web/app/lib/auth/cron-auth.ts) validates.
+ *
+ * A 502/503 is retried once after {@link DEFAULT_RETRY_DELAY_MS}; everything
+ * else fails on the first response. The whole thing — both attempts and the
+ * wait between them — stays inside the job's `timeoutMs`.
  */
-export function triggerWebCron(path: string): JobRun {
+export function triggerWebCron(
+  path: string,
+  { retryDelayMs = DEFAULT_RETRY_DELAY_MS }: TriggerWebCronOptions = {},
+): JobRun {
   return async (context: JobContext): Promise<unknown> => {
-    const { config, timeoutMs, shutdownSignal } = context;
+    const { config, logger, timeoutMs, shutdownSignal } = context;
     const url = `${config.webBaseUrl}${path}`;
 
     const controller = new AbortController();
@@ -40,28 +95,41 @@ export function triggerWebCron(path: string): JobRun {
     }
 
     try {
-      const response = await fetch(url, {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${config.cronSecret}`,
-          Accept: 'application/json',
-        },
-        signal: controller.signal,
-      });
+      let retried = false;
+      for (;;) {
+        const response = await fetch(url, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${config.cronSecret}`,
+            Accept: 'application/json',
+          },
+          signal: controller.signal,
+        });
 
-      if (!response.ok) {
-        const body = await response.text().catch(() => '');
-        throw new WebCronRequestError(path, response.status, body.trim());
-      }
+        if (!response.ok) {
+          const body = await response.text().catch(() => '');
+          if (!retried && RETRYABLE_STATUSES.has(response.status)) {
+            retried = true;
+            logger.warn('web cron request failed on a retryable status; retrying once', {
+              path,
+              status: response.status,
+              retryDelayMs,
+            });
+            await delay(retryDelayMs, controller.signal);
+            continue;
+          }
+          throw new WebCronRequestError(path, response.status, body.trim());
+        }
 
-      const rawBody = await response.text();
-      if (rawBody.trim() === '') {
-        return null;
-      }
-      try {
-        return JSON.parse(rawBody) as unknown;
-      } catch {
-        return rawBody.length > MAX_ERROR_BODY_CHARS ? `${rawBody.slice(0, MAX_ERROR_BODY_CHARS)}…` : rawBody;
+        const rawBody = await response.text();
+        if (rawBody.trim() === '') {
+          return null;
+        }
+        try {
+          return JSON.parse(rawBody) as unknown;
+        } catch {
+          return rawBody.length > MAX_ERROR_BODY_CHARS ? `${rawBody.slice(0, MAX_ERROR_BODY_CHARS)}…` : rawBody;
+        }
       }
     } finally {
       clearTimeout(timeoutHandle);

--- a/packages/scheduler/src/jobs/types.ts
+++ b/packages/scheduler/src/jobs/types.ts
@@ -25,5 +25,14 @@ export type JobDefinition = {
    * and in `packages/web/vercel.json`.
    */
   readonly webPath?: string;
+  /**
+   * Must tolerate running concurrently with itself. The runner skips a *tick*
+   * whose predecessor is still in flight, but `scheduler run <job>` (the
+   * operator's on-demand trigger) goes straight to `run` and deliberately does
+   * not check that guard — an operator debugging a stuck job needs the run to
+   * happen, not to be silently swallowed. So a job must either be idempotent
+   * or safe to overlap; `cleanup` is both, because it deletes rows older than
+   * a fixed age in batches and a second pass finds nothing left.
+   */
   readonly run: JobRun;
 };

--- a/packages/scheduler/src/jobs/types.ts
+++ b/packages/scheduler/src/jobs/types.ts
@@ -1,0 +1,29 @@
+import type { SchedulerConfig } from '../config';
+import type { SchedulerLogger } from '../logger';
+
+export type JobContext = {
+  readonly config: SchedulerConfig;
+  readonly logger: SchedulerLogger;
+  /** Hard ceiling for a single run, from the job definition. */
+  readonly timeoutMs: number;
+  /** Aborted when the process is shutting down. */
+  readonly shutdownSignal?: AbortSignal;
+};
+
+export type JobRun = (context: JobContext) => Promise<unknown>;
+
+export type JobDefinition = {
+  readonly name: string;
+  /** Standard 5-field cron expression. */
+  readonly schedule: string;
+  /** IANA timezone the schedule is evaluated in. */
+  readonly timezone: string;
+  readonly timeoutMs: number;
+  /**
+   * The `/api/internal/*` path this job triggers, when it is an HTTP trigger.
+   * Used by the drift guard that keeps a path from being scheduled both here
+   * and in `packages/web/vercel.json`.
+   */
+  readonly webPath?: string;
+  readonly run: JobRun;
+};

--- a/packages/scheduler/src/logger.ts
+++ b/packages/scheduler/src/logger.ts
@@ -27,10 +27,32 @@ export const consoleLogger: SchedulerLogger = {
   },
 };
 
-/** Turns an unknown thrown value into a log-safe message. */
+// A wrapped error can nest (fetch → undici → the socket error); three links is
+// plenty and keeps a pathological chain out of the log line.
+const MAX_CAUSE_DEPTH = 3;
+
+/**
+ * Turns an unknown thrown value into a log-safe message.
+ *
+ * The `cause` chain is unwrapped because `fetch` rejects with a bare
+ * `fetch failed` and hides the actual reason — `ECONNREFUSED`, `ENOTFOUND`, a
+ * TLS failure — in `cause`. `docs/scheduler.md`'s runbook reads `lastError` to
+ * tell a blocked egress IP from a DNS problem, and `fetch failed` on its own
+ * answers neither.
+ */
 export function describeError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
+  if (!(error instanceof Error)) {
+    return String(error);
   }
-  return String(error);
+
+  const messages = [error.message];
+  let cause: unknown = error.cause;
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH && cause instanceof Error; depth += 1) {
+    if (cause.message !== '' && !messages.includes(cause.message)) {
+      messages.push(cause.message);
+    }
+    cause = cause.cause;
+  }
+
+  return messages.filter((message) => message !== '').join(': ') || error.name;
 }

--- a/packages/scheduler/src/logger.ts
+++ b/packages/scheduler/src/logger.ts
@@ -1,0 +1,36 @@
+/**
+ * Minimal structured logger. Every scheduler entry point takes a logger so
+ * tests can capture output instead of writing to stdout, and so the Railway
+ * log stream gets one JSON object per line (searchable by `job`/`event`).
+ */
+export type LogFields = Record<string, unknown>;
+
+export type SchedulerLogger = {
+  info(message: string, fields?: LogFields): void;
+  warn(message: string, fields?: LogFields): void;
+  error(message: string, fields?: LogFields): void;
+};
+
+function serialize(level: string, message: string, fields?: LogFields): string {
+  return JSON.stringify({ level, service: 'scheduler', time: new Date().toISOString(), message, ...fields });
+}
+
+export const consoleLogger: SchedulerLogger = {
+  info(message, fields) {
+    console.info(serialize('info', message, fields));
+  },
+  warn(message, fields) {
+    console.warn(serialize('warn', message, fields));
+  },
+  error(message, fields) {
+    console.error(serialize('error', message, fields));
+  },
+};
+
+/** Turns an unknown thrown value into a log-safe message. */
+export function describeError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}

--- a/packages/scheduler/src/runner.ts
+++ b/packages/scheduler/src/runner.ts
@@ -1,0 +1,191 @@
+import type { SchedulerConfig } from './config';
+import type { CronScheduler, CronTask } from './cron/scheduler';
+import { describeError, type SchedulerLogger } from './logger';
+import type { JobDefinition } from './jobs/types';
+
+export type JobStatus = {
+  readonly name: string;
+  readonly schedule: string;
+  readonly timezone: string;
+  readonly scheduled: boolean;
+  readonly running: boolean;
+  readonly lastRunAt: string | null;
+  readonly lastSuccessAt: string | null;
+  readonly lastDurationMs: number | null;
+  readonly lastError: string | null;
+  readonly runCount: number;
+  readonly failureCount: number;
+  readonly skippedCount: number;
+};
+
+export type Scheduler = {
+  /** Every known job, including ones held back by SCHEDULER_DISABLED_JOBS. */
+  readonly jobs: readonly JobDefinition[];
+  /** Jobs actually registered with the cron ticker. */
+  readonly scheduledJobs: readonly JobDefinition[];
+  getStatus(): JobStatus[];
+  /** Runs one job now. Throws on failure — used by `scheduler run <job>`. */
+  runJob(jobName: string): Promise<unknown>;
+  stop(): void;
+};
+
+export type CreateSchedulerOptions = {
+  readonly jobs: readonly JobDefinition[];
+  readonly config: SchedulerConfig;
+  readonly cron: CronScheduler;
+  readonly logger: SchedulerLogger;
+  /**
+   * Set false for the one-shot `scheduler run <job>` path so an operator's
+   * manual run can never also start the recurring schedule. Defaults to true.
+   */
+  readonly registerSchedules?: boolean;
+};
+
+type MutableJobState = {
+  running: boolean;
+  lastRunAt: string | null;
+  lastSuccessAt: string | null;
+  lastDurationMs: number | null;
+  lastError: string | null;
+  runCount: number;
+  failureCount: number;
+  skippedCount: number;
+};
+
+function createInitialState(): MutableJobState {
+  return {
+    running: false,
+    lastRunAt: null,
+    lastSuccessAt: null,
+    lastDurationMs: null,
+    lastError: null,
+    runCount: 0,
+    failureCount: 0,
+    skippedCount: 0,
+  };
+}
+
+export function createScheduler({
+  jobs,
+  config,
+  cron,
+  logger,
+  registerSchedules = true,
+}: CreateSchedulerOptions): Scheduler {
+  const duplicateName = jobs.find((job, index) => jobs.findIndex((other) => other.name === job.name) !== index);
+  if (duplicateName) {
+    throw new Error(`duplicate job name ${JSON.stringify(duplicateName.name)}`);
+  }
+
+  const stateByJobName = new Map<string, MutableJobState>(jobs.map((job) => [job.name, createInitialState()]));
+  const shutdownController = new AbortController();
+  const tasks: CronTask[] = [];
+
+  const disabledJobNames = new Set(config.disabledJobs);
+  const unknownDisabled = [...disabledJobNames].filter((jobName) => !jobs.some((job) => job.name === jobName));
+  if (unknownDisabled.length > 0) {
+    logger.warn('SCHEDULER_DISABLED_JOBS names no such job', { jobs: unknownDisabled });
+  }
+
+  const scheduledJobs = jobs.filter((job) => !disabledJobNames.has(job.name));
+
+  const executeJob = async (job: JobDefinition): Promise<unknown> => {
+    const state = stateByJobName.get(job.name);
+    if (!state) {
+      throw new Error(`no state for job ${job.name}`);
+    }
+
+    state.running = true;
+    state.lastRunAt = new Date().toISOString();
+    state.runCount += 1;
+    const startedAt = Date.now();
+
+    try {
+      const result = await job.run({
+        config,
+        logger,
+        timeoutMs: job.timeoutMs,
+        shutdownSignal: shutdownController.signal,
+      });
+      state.lastDurationMs = Date.now() - startedAt;
+      state.lastSuccessAt = new Date().toISOString();
+      state.lastError = null;
+      logger.info('job succeeded', { job: job.name, durationMs: state.lastDurationMs, result });
+      return result;
+    } catch (error) {
+      state.lastDurationMs = Date.now() - startedAt;
+      state.lastError = describeError(error);
+      state.failureCount += 1;
+      logger.error('job failed', { job: job.name, durationMs: state.lastDurationMs, error: state.lastError });
+      throw error;
+    } finally {
+      state.running = false;
+    }
+  };
+
+  for (const job of registerSchedules ? scheduledJobs : []) {
+    const handler = () => {
+      const state = stateByJobName.get(job.name);
+      if (state?.running) {
+        state.skippedCount += 1;
+        logger.warn('job tick skipped; previous run still in flight', { job: job.name, schedule: job.schedule });
+        return;
+      }
+
+      logger.info('job tick', { job: job.name, schedule: job.schedule, timezone: job.timezone });
+      // A throwing job must never escape into the cron callback — an unhandled
+      // rejection here would take the whole scheduler process down.
+      void executeJob(job).catch(() => undefined);
+    };
+
+    tasks.push(cron.schedule(job.schedule, handler, { timezone: job.timezone }));
+    logger.info('job scheduled', { job: job.name, schedule: job.schedule, timezone: job.timezone });
+  }
+
+  if (registerSchedules) {
+    for (const jobName of disabledJobNames) {
+      if (jobs.some((job) => job.name === jobName)) {
+        logger.warn('job disabled by SCHEDULER_DISABLED_JOBS', { job: jobName });
+      }
+    }
+  }
+
+  return {
+    jobs,
+    scheduledJobs,
+    getStatus() {
+      return jobs.map((job) => {
+        const state = stateByJobName.get(job.name) ?? createInitialState();
+        return {
+          name: job.name,
+          schedule: job.schedule,
+          timezone: job.timezone,
+          scheduled: !disabledJobNames.has(job.name),
+          running: state.running,
+          lastRunAt: state.lastRunAt,
+          lastSuccessAt: state.lastSuccessAt,
+          lastDurationMs: state.lastDurationMs,
+          lastError: state.lastError,
+          runCount: state.runCount,
+          failureCount: state.failureCount,
+          skippedCount: state.skippedCount,
+        };
+      });
+    },
+    async runJob(jobName) {
+      const job = jobs.find((candidate) => candidate.name === jobName);
+      if (!job) {
+        const knownNames = jobs.map((candidate) => candidate.name).join(', ');
+        throw new Error(`unknown job ${JSON.stringify(jobName)}; known jobs: ${knownNames}`);
+      }
+      return executeJob(job);
+    },
+    stop() {
+      shutdownController.abort(new Error('scheduler stopping'));
+      for (const task of tasks) {
+        task.stop();
+      }
+      tasks.length = 0;
+    },
+  };
+}

--- a/packages/scheduler/src/runner.ts
+++ b/packages/scheduler/src/runner.ts
@@ -24,7 +24,13 @@ export type Scheduler = {
   /** Jobs actually registered with the cron ticker. */
   readonly scheduledJobs: readonly JobDefinition[];
   getStatus(): JobStatus[];
-  /** Runs one job now. Throws on failure — used by `scheduler run <job>`. */
+  /**
+   * Runs one job now. Throws on failure — used by `scheduler run <job>`.
+   *
+   * Bypasses the tick-level in-flight guard on purpose: an operator asking for
+   * a run gets one even if a scheduled run is still going. `JobDefinition.run`
+   * documents the contract that makes that safe.
+   */
   runJob(jobName: string): Promise<unknown>;
   stop(): void;
 };

--- a/packages/scheduler/tsconfig.json
+++ b/packages/scheduler/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "resolveJsonModule": true,
+    // This package has no runtime dependencies, so nothing drags @types/node in
+    // transitively the way the sync CLIs do via drizzle/@boardsesh/db. Name it
+    // explicitly or `process`, `node:http` and `NodeJS.*` all fail to resolve.
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/scheduler/vite.config.ts
+++ b/packages/scheduler/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  test: {
+    name: 'scheduler',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/web/app/__tests__/rest-surface-inventory.test.ts
+++ b/packages/web/app/__tests__/rest-surface-inventory.test.ts
@@ -68,10 +68,12 @@ const VERDICTS: Record<string, Verdict> = {
   // NODE_ENV=development) — the only machine-readable way to confirm which
   // QA notes a running dev server started with.
   'app/api/internal/dev-metadata/route.ts': 'keep-external',
-  // Vercel cron targets. Their only trigger is Vercel's scheduler reading
-  // packages/web/vercel.json — no in-repo code ever calls them, which is the
-  // intended steady state, not evidence of deadness. Pinned against that file
-  // by `classifies every Vercel cron target as an external surface` below.
+  // Cron targets. Their only trigger is a scheduler outside the web app — no
+  // in-repo code ever calls them, which is the intended steady state, not
+  // evidence of deadness. The two below are pinned against packages/web/vercel.json
+  // by `classifies every Vercel cron target as an external surface`; cleanup
+  // has moved to the Railway scheduler (packages/scheduler, docs/scheduler.md)
+  // and so is deliberately absent from that file.
   'app/api/internal/cleanup/route.ts': 'keep-external',
   'app/api/internal/prewarm-heatmap/[board_name]/route.ts': 'keep-external',
   'app/api/internal/profile-percentiles/route.ts': 'keep-external',

--- a/packages/web/app/api/internal/cleanup/route.ts
+++ b/packages/web/app/api/internal/cleanup/route.ts
@@ -13,6 +13,10 @@ const BATCH_SIZE = 5000;
 const DEADLINE_MS = (maxDuration - 10) * 1000;
 
 export async function GET(request: Request) {
+  // Triggered by the Railway scheduler (packages/scheduler, job `cleanup`)
+  // rather than a Vercel cron — it sends the identical
+  // `Authorization: Bearer $CRON_SECRET` header. This route stays the single
+  // implementation; only the trigger moved. See docs/scheduler.md.
   const authError = requireCronAuth(request);
   if (authError) {
     return authError;

--- a/packages/web/app/lib/auth/cron-auth.ts
+++ b/packages/web/app/lib/auth/cron-auth.ts
@@ -12,6 +12,13 @@ import { NextResponse } from 'next/server';
  * Renaming it (e.g. to `CRON_TOKEN`) would silently break that auto-injection
  * and 401 every cron run.
  *
+ * There is a second caller now: the Railway scheduler (`packages/scheduler`)
+ * sends the identical `Authorization: Bearer $CRON_SECRET` header for the jobs
+ * that have moved off Vercel. It reads the same secret from its own env, so
+ * the name stays `CRON_SECRET` on both sides — rotating it means updating the
+ * Vercel project env AND the Railway service env together, or one of the two
+ * schedulers starts 401ing. `docs/scheduler.md` tracks which job runs where.
+ *
  * Comparison is constant-time to avoid leaking the secret's value through
  * response-timing side channels, mirroring the pattern used for the native
  * OAuth transfer token in `native-oauth-transfer.ts`.

--- a/packages/web/vercel.json
+++ b/packages/web/vercel.json
@@ -28,10 +28,6 @@
     {
       "path": "/api/internal/profile-percentiles",
       "schedule": "0 6 * * 0"
-    },
-    {
-      "path": "/api/internal/cleanup",
-      "schedule": "0 5 * * *"
     }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -866,6 +866,21 @@ importers:
         specifier: ^4.1.10
         version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.6(bufferutil@4.1.0))(jsdom@28.1.0(canvas@3.2.3)(supports-color@8.1.1))(vite@8.2.2(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
+  packages/scheduler:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.5
+        version: 25.9.5
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.12
+      typescript:
+        specifier: ~7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.6(bufferutil@4.1.0))(jsdom@28.1.0(canvas@3.2.3)(supports-color@8.1.1))(vite@8.2.2(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+
   packages/shared-schema:
     dependencies:
       graphql:

--- a/scripts/check-service-deploy-inputs.test.mjs
+++ b/scripts/check-service-deploy-inputs.test.mjs
@@ -456,7 +456,7 @@ void test('rejects a resurrected bun.lock', () => {
 
 void test('passes when Dockerfile.sync and the sync packages are present', () => {
   withFixtureRepo((repoRoot) => {
-    // Dockerfile.sync is optional, so the base fixture skips it. Add the sync
+    // Dockerfile.sync is optional, so the base fixture skips it. Add the
     // workspaces the `sync` service roots from plus a valid Dockerfile.sync so
     // the optional sync validation (requireDockerContextFile + the generated
     // `sync` context) actually runs and is asserted green.
@@ -466,6 +466,7 @@ void test('passes when Dockerfile.sync and the sync packages are present', () =>
     });
     writePackage(repoRoot, 'packages/aurora-sync', { name: '@boardsesh/aurora-sync' });
     writePackage(repoRoot, 'packages/moonboard-sync', { name: '@boardsesh/moonboard-sync' });
+    writePackage(repoRoot, 'packages/scheduler', { name: '@boardsesh/scheduler' });
 
     writeFixtureFile(repoRoot, 'Dockerfile.sync', dockerfileLines());
 

--- a/scripts/check-service-deploy-inputs.test.mjs
+++ b/scripts/check-service-deploy-inputs.test.mjs
@@ -103,6 +103,10 @@ function createFixtureRepo() {
   writePackage(repoRoot, 'packages/kilter-sync', { name: '@boardsesh/kilter-sync' });
   writePackage(repoRoot, 'packages/aurora-sync', { name: '@boardsesh/aurora-sync' });
   writePackage(repoRoot, 'packages/moonboard-sync', { name: '@boardsesh/moonboard-sync' });
+  // The `sync` service roots from the scheduler too (it rides the same image),
+  // and the base fixture writes Dockerfile.sync — so every fixture test
+  // generates the sync context and needs this workspace to exist.
+  writePackage(repoRoot, 'packages/scheduler', { name: '@boardsesh/scheduler' });
 
   writeFixtureFile(repoRoot, 'Dockerfile.backend', dockerfileLines());
   writeFixtureFile(repoRoot, 'Dockerfile.web', dockerfileLines());

--- a/scripts/create-service-docker-context.mjs
+++ b/scripts/create-service-docker-context.mjs
@@ -48,10 +48,17 @@ const services = {
   },
   sync: {
     dockerfile: 'Dockerfile.sync',
-    // All sync CLIs in one image. The source layer is the union of these roots'
-    // transitive workspace deps; the daemon/CLI to run is chosen by the container
-    // command, not baked into the image.
-    rootPackageNames: ['@boardsesh/kilter-sync', '@boardsesh/aurora-sync', '@boardsesh/moonboard-sync'],
+    // All sync CLIs plus the cron scheduler in one image. The source layer is
+    // the union of these roots' transitive workspace deps; the daemon/CLI to run
+    // is chosen by the container command, not baked into the image. The
+    // scheduler rides along because it is another long-lived Node CLI with the
+    // same shape — see docs/scheduler.md for the split-it-out follow-up.
+    rootPackageNames: [
+      '@boardsesh/kilter-sync',
+      '@boardsesh/aurora-sync',
+      '@boardsesh/moonboard-sync',
+      '@boardsesh/scheduler',
+    ],
   },
 };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -124,6 +124,7 @@ export default defineConfig({
       './packages/location-sync/vite.config.ts',
       './packages/moonboard-sync/vite.config.ts',
       './packages/sync-runtime/vite.config.ts',
+      './packages/scheduler/vite.config.ts',
       './packages/crypto/vite.config.ts',
       './packages/shared/ble-protocol/vite.config.ts',
       './packages/shared/board-config/vite.config.ts',
@@ -317,6 +318,12 @@ export default defineConfig({
         dependsOn: ['db:up'],
         cache: false,
       },
+      // Runs the cron scheduler against a local web server. Needs CRON_SECRET
+      // and (usually) BOARDSESH_WEB_URL=http://localhost:3000 in the env.
+      'scheduler:dev': {
+        command: 'pnpm --filter @boardsesh/scheduler run dev',
+        cache: false,
+      },
       'seed:beta-links': {
         command: 'pnpm --filter @boardsesh/db run db:seed-beta-links',
         dependsOn: ['db:up'],
@@ -429,6 +436,9 @@ export default defineConfig({
       },
       'build:sync-runtime': {
         command: 'pnpm --filter @boardsesh/sync-runtime run build',
+      },
+      'build:scheduler': {
+        command: 'pnpm --filter @boardsesh/scheduler run build',
       },
       'build:location-sync': {
         command: 'pnpm --filter @boardsesh/location-sync run build',
@@ -793,6 +803,13 @@ export default defineConfig({
       // transitively via build:backend today, and build:shared/build:db via
       // build:web: spelling them out means an unrelated edit to someone else's
       // dependsOn cannot quietly drop one of them out of the typecheck graph.
+      // `scheduler` follows the same plain-`tsc` build/typecheck pattern, so the
+      // aggregate `typecheck` task below depends on `build:scheduler` rather
+      // than this standalone task (kept for `vp run typecheck:scheduler`).
+      'typecheck:scheduler': {
+        command: 'pnpm --filter @boardsesh/scheduler run typecheck',
+        dependsOn: ['build:scheduler'],
+      },
       typecheck: {
         command: 'true',
         dependsOn: [
@@ -836,6 +853,7 @@ export default defineConfig({
           'build:location-sync',
           'build:moonboard-sync',
           'build:sync-runtime',
+          'build:scheduler',
         ],
       },
       // Footgun-proof scoped test runs. `vp test --project <name> run` (the


### PR DESCRIPTION
> ⚠️ **Merge gate: the Railway service has to exist first.** This PR removes
> the only trigger for `/api/internal/cleanup`. Merging before the scheduler is
> deployed pauses the 180-day feed-item and 90-day notification retention. It
> stays a draft until step 6 of the checklist below has passed against
> production.

## Summary

Closes #1874.

Adds `packages/scheduler`, a long-lived Node service that takes over the cron
jobs currently declared in `packages/web/vercel.json`, and migrates the first
one (`cleanup`).

The issue says "8 jobs"; the file actually declares **7** — five
`prewarm-heatmap` boards, `profile-percentiles`, and `cleanup`. This PR moves
`cleanup` only, the lowest blast radius of the seven, and leaves the other six
where they are. `vercel.json` itself stays — the issue assigns its deletion to a
Phase 1 child.

### The scheduler is a trigger, not a job reimplementation

Each job makes an HTTP request to the existing `/api/internal/*` route with
`Authorization: Bearer $CRON_SECRET` — byte-identical to what Vercel
auto-injects, and exactly what `requireCronAuth` already validates.

That isn't a shortcut. Two of the three job families cannot run outside Next:
`prewarm-heatmap` warms `cachedGetHoldHeatmapData`, a Next cache entry whose key
must match a real first-visit request; `profile-percentiles` ends with
`revalidateTag(USER_CLIMB_PERCENTILE_CACHE_TAG)`. Neither is reachable from a
plain Node process. So the routes stay the single implementation.

This also settles the issue's `CRON_TOKEN` wording: `cron-auth.ts` documents
that the env var must stay `CRON_SECRET` or Vercel's auto-injection silently
401s every remaining cron. The scheduler sends the same value under the same
name; nothing is renamed. That doc comment now records the second caller.

### What's in the package

- `src/config.ts` — env parse that fails fast. A missing `CRON_SECRET` throws at
  startup, not at 05:00.
- `src/cron/` — a five-field cron parser and a once-a-minute ticker, each job
  evaluated in its declared IANA timezone.
- `src/jobs/` — `triggerWebCron(path)` plus the registry (one entry today). A
  502/503 from the edge is retried once after 2s, inside the job's `timeoutMs`;
  504 is not, because the request reached the route and a retry would stack a
  second run on the first.
- `src/runner.ts` — per-job in-flight guard (a tick whose predecessor is still
  running is skipped and warned, never queued), try/catch so a throwing job
  can't kill the process, and a status map. `scheduler run <job>` deliberately
  bypasses that guard — an operator asking for a run gets one — so
  `JobDefinition.run` documents that a job has to tolerate overlapping itself.
- `src/health-server.ts` — `GET /health` (liveness, what Railway polls) and
  `GET /health/jobs` (503 when a scheduled job's last run failed — point an
  alert here, not Railway: restarting can't fix a bad secret or a WAF rule and
  would wipe the `lastError` that says which).
- `src/cli/index.ts` — `start`, `run <job>` (the on-demand trigger), `list`.

### Deploy: no new image, no new workflow

`Dockerfile.sync` is already documented as "runs any CLI directly via tsx" and
`.github/workflows/sync-deploy.yml` already triggers on `packages/**`, so adding
`@boardsesh/scheduler` to the sync context's root packages is the whole thing.
`scripts/check-service-deploy-inputs.mjs` derives its expectations from the same
walk, so only its fixture needed the extra workspace.

## Marco: deploy checklist (infra, not in this PR)

**Do this before merging**, or the 180-day feed-item / 90-day notification
retention silently stops — the `vercel.json` edit removes the only trigger.
Harmless for weeks (delete-by-age catches up next run), but it shouldn't sit
that way.

1. **New Railway service**, name `scheduler`.
2. **Source → Docker Image**: `ghcr.io/boardsesh/boardsesh-sync:production`
3. **Custom start command**:
   `node --import tsx packages/scheduler/src/cli/index.ts start`
4. **Variables**:
   - `CRON_SECRET` — **copy** the Vercel project value, don't regenerate. The
     six remaining Vercel crons authenticate with the same secret.
   - `BOARDSESH_WEB_URL=https://www.boardsesh.com`
   - `PORT=8080`
5. **Healthcheck path** `/health`. **Replicas: 1** — two instances double-fire
   every job; there's no leader election in this slice.
6. **Verify against production** before merging:
   `node --import tsx packages/scheduler/src/cli/index.ts run cleanup` must
   return the route's JSON and exit 0. This is the step that catches a Vercel
   WAF/bot rule blocking Railway egress IPs — nothing local can.

Between steps 1 and merge both schedulers may fire the job. That's safe:
`/api/internal/cleanup` deletes rows older than a fixed age in deadline-bounded
batches, so the second pass is a no-op.

Full runbook: `docs/scheduler.md`.

## Two decisions worth your call

1. **Image topology.** This rides the existing `boardsesh-sync` image, which
   keeps the slice to one PR but couples scheduler releases to the sync deploy
   and gives the container a misleading name. A dedicated
   `Dockerfile.scheduler` + `scheduler-deploy.yml` is mechanical but a second
   PR's worth of wiring — say the word.
2. **Migration pace for the remaining six.** One PR each (safer) or one batch
   once `cleanup` has run cleanly for a week.

Also: sibling issue #1875 (`user-sync-cron` sleeper) looks already moot —
`docs/aurora-sync.md` and `docs/branch-deploys.md` both record that the
`/api/internal/user-sync-cron` route and the backend `POST /sync-cron` handler
were removed in favour of the long-lived daemons, and grep confirms no such
route exists. Worth closing.

### Deviations from the plan

- **No `node-cron`, `commander` or `dotenv`.** The loop I'm running under
  forbids new npm dependencies, so `src/cron/` implements the five standard
  numeric fields (`*`, `a`, `a-b`, lists, `/step`) and a minute ticker in ~200
  tested lines, and the CLI parses its own argv. Month/weekday names, `@daily`
  shorthands and Quartz extensions throw at parse time rather than being
  silently reinterpreted. `pnpm-lock.yaml` gains only the new workspace entry —
  zero new resolved packages. The runner takes the cron scheduler as an injected
  interface, so swapping in `node-cron` later is a one-file change.
- **`"types": ["node"]` in the package tsconfig.** Unlike the sync CLIs, this
  package has no runtime deps to drag `@types/node` in transitively, so
  `process` / `node:http` / `NodeJS.*` don't resolve without naming it.
- **`registerSchedules: false`** on the runner instead of faking a disabled-jobs
  list, so `run <job>` can never also start the recurring schedule and still
  works on a job held back by `SCHEDULER_DISABLED_JOBS`.

### Rebased and finished (2026-09-01)

The branch was written under Bun in August and has been rebased onto
post-pnpm `main`. Five commits on top of the original six:

- The Railway start command and the runbook still reached for a Bun launcher.
  The image has neither Bun nor `vp`; everything now says
  `node --import tsx packages/scheduler/src/cli/index.ts <cmd>`, the form
  `Dockerfile.sync`'s header already documents for the sync daemons.
- `main`'s deploy-input fixture grew its own `Dockerfile.sync`, so every test in
  `check-service-deploy-inputs.test.mjs` now generates the `sync` context and 15
  of 17 red'd on the new workspace. The fixture declares `packages/scheduler`
  alongside the three sync packages.
- One retry on a 502/503, so a daily job that lands in a deploy swap isn't
  written off for 24 hours.
- `healthServer.stop()` had no `.catch`: a rejected close left the process alive
  with its signal handler latched, so Railway would SIGKILL it at the end of the
  stop grace period rather than the container exiting on SIGTERM.
- `vercel.json` lost `refresh-sitemap-climbs` on `main` (#4852) while this
  branch sat. `VERCEL_OWNED_CRON_PATHS` matches today's file (six entries) and
  both drift guards — `registry.test.ts` and web's `rest-surface-inventory` —
  are green against it.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.
2. Railway scheduler service: /health returns 200 and /health/jobs returns 200.
3. Next 05:00 UTC: cleanup job reports success on /health/jobs.

## Risk

Risk: 3/5 — new long-lived service; merging before the Railway service exists pauses the retention cron (harmless for weeks).

## Validation run on this branch

- `vp test run --project scheduler` — 8 files, 71 tests.
- `vp test run --project scripts` — 82 files, 1334 tests.
- `vp run check:service-deploy-inputs` — 17/17, and the generated sync context
  lists `packages/scheduler` among its source packages.
- `vp test run --project web` on the cron / REST-surface / cleanup files — 4
  files, 18 tests (the cleanup route's own tests stay green untouched: proof
  only the trigger moved).
- `vp run typecheck:scheduler`, `vp run typecheck:web` — clean. `vp check` is
  clean on every touched file; its only two repo-wide errors are the
  pre-existing `@gorhom/bottom-sheet` TS2307s in
  `packages/mobile/src/web-shims/`, whose isolated install is a web-task-only
  dependency.

What the tests pin down:

- `0 5 * * *` fires exactly once in the 05:00 UTC minute and not in 05:01.
- The same expression in `Australia/Sydney` fires at 19:00 UTC while the
  UTC-scheduled one stays quiet — the timezone is the job's, not the host's.
- A tick whose predecessor is still in flight is skipped and warned.
- A rejecting job is caught, recorded, and the next tick still fires.
- A hung request aborts at the job's `timeoutMs` instead of blocking forever.
- A 503 is retried once and the second attempt's result is returned; a 502
  retries exactly once before giving up; a 500 never retries; the retry wait
  abandons itself on shutdown.
- `registry.test.ts` reads `packages/web/vercel.json` and fails if any path is
  scheduled on both sides, or if the checked-in Vercel-owned list drifts from
  the file — so a future migration PR that edits one side only fails CI.

Real image, not just the CLI: built `.docker-context/sync` locally and ran the
image.

- `node --import tsx packages/scheduler/src/cli/index.ts list` prints
  `cleanup 0 5 * * * UTC /api/internal/cleanup`.
- `start` boots, `/health` returns 200 with the live status map, `/health/jobs`
  returns 200, an unknown path 404s, and SIGTERM exits 0.
- `run cleanup` with no `CRON_SECRET` fails at config parse before any request.

Not verifiable locally: whether Vercel's WAF lets Railway egress through. That's
step 6 of the deploy checklist, deliberately ordered before the merge.
