### PR TITLE
fix(backend): stop serving zero-byte avatars as successful images

### DIFF
--- a/packages/backend/src/__tests__/avatar-upload-s3.test.ts
+++ b/packages/backend/src/__tests__/avatar-upload-s3.test.ts
@@ -3,11 +3,13 @@ import { ALLOWED_IMAGE_SIZES } from '@boardsesh/shared-schema';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { once } from 'node:events';
+import { Readable } from 'node:stream';
 
 const validateTokenMock = vi.hoisted(() => vi.fn());
 const isS3ConfiguredMock = vi.hoisted(() => vi.fn());
 const uploadToS3Mock = vi.hoisted(() => vi.fn());
 const deleteUserAvatarsFromS3Mock = vi.hoisted(() => vi.fn());
+const getFromS3Mock = vi.hoisted(() => vi.fn());
 
 vi.mock('../middleware/auth', () => ({
   validateToken: validateTokenMock,
@@ -17,15 +19,27 @@ vi.mock('../storage/s3', () => ({
   isS3Configured: isS3ConfiguredMock,
   uploadToS3: uploadToS3Mock,
   deleteUserAvatarsFromS3: deleteUserAvatarsFromS3Mock,
+  getFromS3: getFromS3Mock,
 }));
 
 const { handleAvatarUpload } = await import('../handlers/avatars');
+const { handleStaticAvatar } = await import('../handlers/static');
+const { parseSizeParam } = await import('../lib/image-resize');
 
 const USER_ID = '22222222-2222-4222-8222-222222222222';
 const JPEG_BYTES = Buffer.from([0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0xff, 0xd9]);
 
 async function startAvatarServer(): Promise<{ baseUrl: string; server: Server }> {
   const server = createServer((req, res) => {
+    const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+    if (url.pathname.startsWith('/static/avatars/') && req.method === 'GET') {
+      const fileName = url.pathname.slice('/static/avatars/'.length);
+      void handleStaticAvatar(req, res, fileName, parseSizeParam(url.searchParams.get('size'))).catch(() => {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Unhandled' }));
+      });
+      return;
+    }
     void handleAvatarUpload(req, res).catch(() => {
       res.writeHead(500, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Unhandled' }));
@@ -102,6 +116,30 @@ describe('avatar upload S3 path (write-first, clean-after)', () => {
     }
   });
 
+  it('rejects an empty file part without touching S3', async () => {
+    validateTokenMock.mockResolvedValue({ userId: USER_ID });
+    isS3ConfiguredMock.mockReturnValue(true);
+
+    const { baseUrl, server } = await startAvatarServer();
+    try {
+      const formData = new FormData();
+      formData.set('userId', USER_ID);
+      formData.set('avatar', new Blob([], { type: 'image/jpeg' }), 'avatar.jpg');
+      const response = await fetch(`${baseUrl}/api/avatars`, {
+        method: 'POST',
+        headers: { Authorization: 'Bearer avatar-token' },
+        body: formData,
+      });
+
+      expect(response.status).toBe(400);
+      expect((await response.json()) as { error?: string }).toEqual({ error: 'Uploaded file is empty' });
+      expect(uploadToS3Mock).not.toHaveBeenCalled();
+      expect(deleteUserAvatarsFromS3Mock).not.toHaveBeenCalled();
+    } finally {
+      await closeServer(server);
+    }
+  });
+
   it('never deletes the existing avatar when the S3 upload fails', async () => {
     validateTokenMock.mockResolvedValue({ userId: USER_ID });
     isS3ConfiguredMock.mockReturnValue(true);
@@ -113,6 +151,65 @@ describe('avatar upload S3 path (write-first, clean-after)', () => {
 
       expect(response.status).toBe(500);
       expect(deleteUserAvatarsFromS3Mock).not.toHaveBeenCalled();
+    } finally {
+      await closeServer(server);
+    }
+  });
+});
+
+describe('serving avatars stored in S3', () => {
+  it('404s a zero-byte object instead of answering 200 with an empty body', async () => {
+    isS3ConfiguredMock.mockReturnValue(true);
+    getFromS3Mock.mockResolvedValue({
+      stream: Readable.from([]),
+      contentType: 'image/jpeg',
+      contentLength: 0,
+    });
+
+    const { baseUrl, server } = await startAvatarServer();
+    try {
+      const response = await fetch(`${baseUrl}/static/avatars/${USER_ID}.jpg`);
+
+      expect(response.status).toBe(404);
+      expect(response.headers.get('cache-control')).toBe('no-store');
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('404s a zero-byte object on the resize path too', async () => {
+    isS3ConfiguredMock.mockReturnValue(true);
+    getFromS3Mock.mockResolvedValue({
+      stream: Readable.from([]),
+      contentType: 'image/jpeg',
+      contentLength: 0,
+    });
+
+    const { baseUrl, server } = await startAvatarServer();
+    try {
+      const response = await fetch(`${baseUrl}/static/avatars/${USER_ID}.jpg?size=128`);
+
+      expect(response.status).toBe(404);
+      expect(response.headers.get('cache-control')).toBe('no-store');
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('still streams an object whose length S3 did not report', async () => {
+    isS3ConfiguredMock.mockReturnValue(true);
+    getFromS3Mock.mockResolvedValue({
+      stream: Readable.from([JPEG_BYTES]),
+      contentType: 'image/jpeg',
+      contentLength: undefined,
+    });
+
+    const { baseUrl, server } = await startAvatarServer();
+    try {
+      const response = await fetch(`${baseUrl}/static/avatars/${USER_ID}.jpg`);
+
+      expect(response.status).toBe(200);
+      expect(Buffer.from(await response.arrayBuffer())).toEqual(JPEG_BYTES);
     } finally {
       await closeServer(server);
     }

--- a/packages/backend/src/__tests__/avatar-upload.test.ts
+++ b/packages/backend/src/__tests__/avatar-upload.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { once } from 'node:events';
-import { access, mkdir, readdir, rm } from 'node:fs/promises';
+import { access, mkdir, readdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 const validateTokenMock = vi.hoisted(() => vi.fn());
@@ -155,6 +155,45 @@ describe('avatar upload routes', () => {
       const { avatarUrl } = survivorBody as { avatarUrl: string };
       const staticResponse = await fetch(`${baseUrl}${avatarUrl}`);
       expect(staticResponse.status).toBe(200);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('rejects an empty file part and leaves the existing avatar alone', async () => {
+    validateTokenMock.mockResolvedValue({ userId: USER_ID });
+    const { baseUrl, server } = await startAvatarServer();
+    try {
+      const jpegResponse = await uploadAvatar(baseUrl, new Blob([JPEG_BYTES], { type: 'image/jpeg' }), 'avatar.jpg');
+      expect(jpegResponse.status).toBe(200);
+      const jpegBody = (await jpegResponse.json()) as { avatarUrl?: string };
+
+      const emptyResponse = await uploadAvatar(baseUrl, new Blob([], { type: 'image/png' }), 'avatar.png');
+
+      expect(emptyResponse.status).toBe(400);
+      expect((await emptyResponse.json()) as { error?: string }).toEqual({ error: 'Uploaded file is empty' });
+
+      // Nothing new written, and the avatar the stored URL points at survives.
+      await expect(access(path.join(getAvatarsDir(), `${USER_ID}.png`))).rejects.toThrow();
+      const staticResponse = await fetch(`${baseUrl}${jpegBody.avatarUrl}`);
+      expect(staticResponse.status).toBe(200);
+      expect(Buffer.from(await staticResponse.arrayBuffer())).toEqual(JPEG_BYTES);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('serves 404 (uncacheable) for a zero-byte avatar file instead of an empty 200', async () => {
+    validateTokenMock.mockResolvedValue({ userId: USER_ID });
+    const { baseUrl, server } = await startAvatarServer();
+    try {
+      await mkdir(getAvatarsDir(), { recursive: true });
+      await writeFile(path.join(getAvatarsDir(), `${USER_ID}.jpg`), Buffer.alloc(0));
+
+      const staticResponse = await fetch(`${baseUrl}/static/avatars/${USER_ID}.jpg`);
+
+      expect(staticResponse.status).toBe(404);
+      expect(staticResponse.headers.get('cache-control')).toBe('no-store');
     } finally {
       await closeServer(server);
     }

--- a/packages/backend/src/__tests__/beta-link-thumbnails.test.ts
+++ b/packages/backend/src/__tests__/beta-link-thumbnails.test.ts
@@ -110,6 +110,15 @@ describe('cacheInstagramThumbnail', () => {
     expect(uploadToS3).not.toHaveBeenCalled();
   });
 
+  it('returns null when the source responds 200 with an empty body', async () => {
+    // A zero-byte upload would be stored under an immutable key and served as
+    // a "successful" empty image for a year, with no way to repair it.
+    mockFetchImageOnce({ body: new Uint8Array([]) });
+    const url = await cacheInstagramThumbnail('ABC123', 'https://scontent.cdninstagram.com/photo.jpg');
+    expect(url).toBeNull();
+    expect(uploadToS3).not.toHaveBeenCalled();
+  });
+
   it('returns null when fetch throws (network error)', async () => {
     const fetchMock = vi.fn().mockRejectedValueOnce(new Error('boom'));
     vi.stubGlobal('fetch', fetchMock);

--- a/packages/backend/src/__tests__/static-beta-thumbnail.test.ts
+++ b/packages/backend/src/__tests__/static-beta-thumbnail.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { once } from 'node:events';
+import { Readable } from 'node:stream';
+
+const isS3ConfiguredMock = vi.hoisted(() => vi.fn(() => true));
+const getFromS3Mock = vi.hoisted(() => vi.fn());
+const uploadToS3Mock = vi.hoisted(() => vi.fn());
+
+vi.mock('../storage/s3', () => ({
+  isS3Configured: isS3ConfiguredMock,
+  getFromS3: getFromS3Mock,
+  uploadToS3: uploadToS3Mock,
+  deleteUserAvatarsFromS3: vi.fn(),
+}));
+
+const { handleStaticBetaThumbnail } = await import('../handlers/static');
+const { parseSizeParam } = await import('../lib/image-resize');
+
+const JPEG_BYTES = Buffer.from([0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0xff, 0xd9]);
+const THUMBNAIL_PATH = '/static/beta-link-thumbnails/instagram/ABC123.jpg';
+
+async function startThumbnailServer(): Promise<{ baseUrl: string; server: Server }> {
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+    const remainder = url.pathname.slice('/static/beta-link-thumbnails/'.length);
+    const slashIndex = remainder.indexOf('/');
+    void handleStaticBetaThumbnail(
+      req,
+      res,
+      remainder.slice(0, slashIndex),
+      remainder.slice(slashIndex + 1),
+      parseSizeParam(url.searchParams.get('size')),
+    ).catch(() => {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Unhandled' }));
+    });
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const { port } = server.address() as AddressInfo;
+  return { baseUrl: `http://127.0.0.1:${port}`, server };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  isS3ConfiguredMock.mockReturnValue(true);
+});
+
+describe('serving beta-link thumbnails stored in S3', () => {
+  it('404s a zero-byte object instead of answering 200 with an empty body', async () => {
+    // The 200 path is `immutable, max-age=1y`, so an empty body would be
+    // pinned in browser and CDN caches with no way to repair it.
+    getFromS3Mock.mockResolvedValue({
+      stream: Readable.from([]),
+      contentType: 'image/jpeg',
+      contentLength: 0,
+    });
+
+    const { baseUrl, server } = await startThumbnailServer();
+    try {
+      const response = await fetch(`${baseUrl}${THUMBNAIL_PATH}`);
+
+      expect(response.status).toBe(404);
+      expect(response.headers.get('cache-control')).toBe('no-store');
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('still streams a healthy object with the immutable cache header', async () => {
+    getFromS3Mock.mockResolvedValue({
+      stream: Readable.from([JPEG_BYTES]),
+      contentType: 'image/jpeg',
+      contentLength: JPEG_BYTES.length,
+    });
+
+    const { baseUrl, server } = await startThumbnailServer();
+    try {
+      const response = await fetch(`${baseUrl}${THUMBNAIL_PATH}`);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('cache-control')).toBe('public, max-age=31536000, immutable');
+      expect(Buffer.from(await response.arrayBuffer())).toEqual(JPEG_BYTES);
+    } finally {
+      await closeServer(server);
+    }
+  });
+});

--- a/packages/backend/src/__tests__/static-beta-thumbnail.test.ts
+++ b/packages/backend/src/__tests__/static-beta-thumbnail.test.ts
@@ -16,7 +16,7 @@ vi.mock('../storage/s3', () => ({
 }));
 
 const { handleStaticBetaThumbnail } = await import('../handlers/static');
-const { parseSizeParam } = await import('../lib/image-resize');
+const { parseSizeParam, resizedVariantKey } = await import('../lib/image-resize');
 
 const JPEG_BYTES = Buffer.from([0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0xff, 0xd9]);
 const THUMBNAIL_PATH = '/static/beta-link-thumbnails/instagram/ABC123.jpg';
@@ -68,6 +68,33 @@ describe('serving beta-link thumbnails stored in S3', () => {
 
       expect(response.status).toBe(404);
       expect(response.headers.get('cache-control')).toBe('no-store');
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('404s a zero-byte original on the ?size= path with no-store, not a plain 404', async () => {
+    // `?size=280` is the URL both clients actually request, so this is the
+    // branch a corrupt thumbnail really reaches. It used to fall through to a
+    // plain 404 with no cache header, letting an edge cache pin the miss and
+    // hide the repair — the direct path's guard never saw this traffic.
+    const baseKey = 'beta-link-thumbnails/instagram/ABC123.jpg';
+    getFromS3Mock.mockImplementation((key: string) =>
+      Promise.resolve(
+        key === resizedVariantKey(baseKey, 280)
+          ? null
+          : { stream: Readable.from([]), contentType: 'image/jpeg', contentLength: 0 },
+      ),
+    );
+
+    const { baseUrl, server } = await startThumbnailServer();
+    try {
+      const response = await fetch(`${baseUrl}${THUMBNAIL_PATH}?size=280`);
+
+      expect(response.status).toBe(404);
+      expect(response.headers.get('cache-control')).toBe('no-store');
+      // The empty original must never be written back as a cached variant.
+      expect(uploadToS3Mock).not.toHaveBeenCalled();
     } finally {
       await closeServer(server);
     }

--- a/packages/backend/src/__tests__/static-gym-image.test.ts
+++ b/packages/backend/src/__tests__/static-gym-image.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { once } from 'node:events';
+import { Readable } from 'node:stream';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+// `gym-logo-upload.test.ts` and `gym-photo-upload.test.ts` cover
+// `createGymImageUploadHandler` — the write side. Nothing covered the read
+// side, so the zero-byte guards inside the shared `serveStaticGymImage` were
+// untested. Both `handleStaticGymLogo` and `handleStaticGymPhoto` delegate to
+// it, so each guard is exercised through both delegators here.
+
+const isS3ConfiguredMock = vi.hoisted(() => vi.fn(() => true));
+const getFromS3Mock = vi.hoisted(() => vi.fn());
+const uploadToS3Mock = vi.hoisted(() => vi.fn());
+
+vi.mock('../storage/s3', () => ({
+  isS3Configured: isS3ConfiguredMock,
+  getFromS3: getFromS3Mock,
+  uploadToS3: uploadToS3Mock,
+  deleteUserAvatarsFromS3: vi.fn(),
+  deleteGymLogosFromS3: vi.fn(),
+  deleteGymPhotosFromS3: vi.fn(),
+}));
+
+const { handleStaticGymLogo, handleStaticGymPhoto } = await import('../handlers/static');
+const { getGymLogosDir } = await import('../handlers/gym-logos');
+const { getGymPhotosDir } = await import('../handlers/gym-photos');
+const { parseSizeParam } = await import('../lib/image-resize');
+
+const GYM_UUID = '33333333-3333-4333-8333-333333333333';
+const FILE_NAME = `${GYM_UUID}.jpg`;
+const JPEG_BYTES = Buffer.from([0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0xff, 0xd9]);
+
+async function startGymImageServer(): Promise<{ baseUrl: string; server: Server }> {
+  const server = createServer((req, res) => {
+    void (async () => {
+      const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+      const size = parseSizeParam(url.searchParams.get('size'));
+      if (url.pathname.startsWith('/static/gym-logos/')) {
+        await handleStaticGymLogo(req, res, url.pathname.slice('/static/gym-logos/'.length), size);
+        return;
+      }
+      if (url.pathname.startsWith('/static/gym-photos/')) {
+        await handleStaticGymPhoto(req, res, url.pathname.slice('/static/gym-photos/'.length), size);
+        return;
+      }
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Not found' }));
+    })().catch(() => {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Unhandled' }));
+    });
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const { port } = server.address() as AddressInfo;
+  return { baseUrl: `http://127.0.0.1:${port}`, server };
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  isS3ConfiguredMock.mockReturnValue(true);
+  await rm(path.join(getGymLogosDir(), FILE_NAME), { force: true });
+  await rm(path.join(getGymPhotosDir(), FILE_NAME), { force: true });
+});
+
+describe('serving gym images from S3', () => {
+  it('404s a zero-byte gym logo instead of answering 200 with an empty body', async () => {
+    getFromS3Mock.mockResolvedValue({
+      stream: Readable.from([]),
+      contentType: 'image/jpeg',
+      contentLength: 0,
+    });
+
+    const { baseUrl, server } = await startGymImageServer();
+    try {
+      const response = await fetch(`${baseUrl}/static/gym-logos/${FILE_NAME}`);
+
+      expect(response.status).toBe(404);
+      // Gym image keys are overwritten in place on re-upload, so a cached 404
+      // would pin the broken state past the repair.
+      expect(response.headers.get('cache-control')).toBe('no-store');
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('404s a zero-byte gym photo too, proving both delegators share the guard', async () => {
+    getFromS3Mock.mockResolvedValue({
+      stream: Readable.from([]),
+      contentType: 'image/jpeg',
+      contentLength: 0,
+    });
+
+    const { baseUrl, server } = await startGymImageServer();
+    try {
+      const response = await fetch(`${baseUrl}/static/gym-photos/${FILE_NAME}`);
+
+      expect(response.status).toBe(404);
+      expect(response.headers.get('cache-control')).toBe('no-store');
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('404s a zero-byte object on the ?size= path as well', async () => {
+    getFromS3Mock.mockResolvedValue({
+      stream: Readable.from([]),
+      contentType: 'image/jpeg',
+      contentLength: 0,
+    });
+
+    const { baseUrl, server } = await startGymImageServer();
+    try {
+      const response = await fetch(`${baseUrl}/static/gym-logos/${FILE_NAME}?size=128`);
+
+      expect(response.status).toBe(404);
+      expect(response.headers.get('cache-control')).toBe('no-store');
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('still streams a healthy gym logo with its one-day cache header', async () => {
+    getFromS3Mock.mockResolvedValue({
+      stream: Readable.from([JPEG_BYTES]),
+      contentType: 'image/jpeg',
+      contentLength: JPEG_BYTES.length,
+    });
+
+    const { baseUrl, server } = await startGymImageServer();
+    try {
+      const response = await fetch(`${baseUrl}/static/gym-logos/${FILE_NAME}`);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('cache-control')).toBe('public, max-age=86400');
+      expect(response.headers.get('x-content-type-options')).toBe('nosniff');
+      expect(Buffer.from(await response.arrayBuffer())).toEqual(JPEG_BYTES);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('leaves an object with an unknown content length streaming', async () => {
+    getFromS3Mock.mockResolvedValue({
+      stream: Readable.from([JPEG_BYTES]),
+      contentType: 'image/jpeg',
+      contentLength: undefined,
+    });
+
+    const { baseUrl, server } = await startGymImageServer();
+    try {
+      const response = await fetch(`${baseUrl}/static/gym-logos/${FILE_NAME}`);
+
+      expect(response.status).toBe(200);
+      expect(Buffer.from(await response.arrayBuffer())).toEqual(JPEG_BYTES);
+    } finally {
+      await closeServer(server);
+    }
+  });
+});
+
+describe('serving gym images from local storage (no S3 configured)', () => {
+  it('404s a zero-byte gym logo file on disk', async () => {
+    isS3ConfiguredMock.mockReturnValue(false);
+    await mkdir(getGymLogosDir(), { recursive: true });
+    await writeFile(path.join(getGymLogosDir(), FILE_NAME), Buffer.alloc(0));
+
+    const { baseUrl, server } = await startGymImageServer();
+    try {
+      const response = await fetch(`${baseUrl}/static/gym-logos/${FILE_NAME}`);
+
+      expect(response.status).toBe(404);
+      expect(response.headers.get('cache-control')).toBe('no-store');
+      expect(getFromS3Mock).not.toHaveBeenCalled();
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('still serves a healthy gym photo file on disk', async () => {
+    isS3ConfiguredMock.mockReturnValue(false);
+    await mkdir(getGymPhotosDir(), { recursive: true });
+    await writeFile(path.join(getGymPhotosDir(), FILE_NAME), JPEG_BYTES);
+
+    const { baseUrl, server } = await startGymImageServer();
+    try {
+      const response = await fetch(`${baseUrl}/static/gym-photos/${FILE_NAME}`);
+
+      expect(response.status).toBe(200);
+      expect(Buffer.from(await response.arrayBuffer())).toEqual(JPEG_BYTES);
+    } finally {
+      await closeServer(server);
+    }
+  });
+});

--- a/packages/backend/src/handlers/avatars.ts
+++ b/packages/backend/src/handlers/avatars.ts
@@ -249,10 +249,19 @@ export async function handleAvatarUpload(req: IncomingMessage, res: ServerRespon
         return;
       }
 
-      // Validate file was uploaded
+      // Validate file was uploaded and is non-empty (an empty multipart part
+      // would otherwise store a zero-byte avatar and return 200, so the client
+      // saves an avatarUrl that serves an empty image forever)
       if (!fileBuffer || !mimeType) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: 'No file uploaded' }));
+        resolve();
+        return;
+      }
+
+      if (fileBuffer.length === 0) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Uploaded file is empty' }));
         resolve();
         return;
       }

--- a/packages/backend/src/handlers/static.ts
+++ b/packages/backend/src/handlers/static.ts
@@ -19,10 +19,21 @@ const MIME_TYPES: Record<string, string> = {
 };
 
 /**
- * Write a 404. `noStore` is used by the avatar / gym-logo handlers: a stored
- * object can be replaced by a re-upload at the same key, so an edge cache
- * holding onto the 404 would pin the broken state for a day. Missing images
- * are rare enough that the extra origin hits don't matter.
+ * Write a 404. `noStore` keeps an edge cache from holding onto the miss.
+ *
+ * Two caveats worth stating plainly, because the obvious justification for this
+ * is weaker than it looks. Missing avatars are **not** rare — 83 of 156 stored
+ * avatar URLs (53%) already 404 in production. And a repaired image does not
+ * reappear at the same URL: every re-upload stamps a fresh `v=<timestamp>`
+ * (`packages/mobile/src/lib/avatar-upload.ts`) and gym images carry `?v=<version>`,
+ * so a cached 404 on the old URL could not shadow the replacement anyway.
+ *
+ * What `no-store` actually buys is that a client which has already resolved a
+ * URL — a rendered feed, a cached GraphQL payload — retries instead of being
+ * told "gone" for four hours by Cloudflare's default TTL on an origin that sends
+ * no cache header. The cost is an origin hit per render for those 53%, on a repo
+ * where production burn is tracked. If that cost shows up, `public, max-age=300`
+ * is the right trade here rather than reverting to an uncontrolled TTL.
  */
 function sendNotFound(res: ServerResponse, options: { noStore?: boolean } = {}): void {
   res.writeHead(404, {

--- a/packages/backend/src/handlers/static.ts
+++ b/packages/backend/src/handlers/static.ts
@@ -18,6 +18,20 @@ const MIME_TYPES: Record<string, string> = {
 };
 
 /**
+ * Write a 404. `noStore` is used by the avatar / gym-logo handlers: a stored
+ * object can be replaced by a re-upload at the same key, so an edge cache
+ * holding onto the 404 would pin the broken state for a day. Missing images
+ * are rare enough that the extra origin hits don't matter.
+ */
+function sendNotFound(res: ServerResponse, options: { noStore?: boolean } = {}): void {
+  res.writeHead(404, {
+    'Content-Type': 'application/json',
+    ...(options.noStore && { 'Cache-Control': 'no-store' }),
+  });
+  res.end(JSON.stringify({ error: 'Not found' }));
+}
+
+/**
  * Serve a resized (size×size, JPEG) version of an S3 object. Returns false
  * when the base object doesn't exist (caller should 404); true once it has
  * written a response.
@@ -37,7 +51,11 @@ async function serveResizedImageFromS3(
 ): Promise<boolean> {
   if (options.cacheVariant) {
     const cached = await getFromS3('media', resizedVariantKey(baseKey, size));
-    if (cached) {
+    if (cached && cached.contentLength === 0) {
+      // A zero-byte cached variant would be served as an "OK" empty image.
+      // Drop it and fall through to resizing the original.
+      cached.stream.destroy();
+    } else if (cached) {
       res.writeHead(200, {
         'Content-Type': cached.contentType || 'image/jpeg',
         ...(cached.contentLength && { 'Content-Length': cached.contentLength }),
@@ -52,6 +70,12 @@ async function serveResizedImageFromS3(
   if (!original) return false;
 
   const originalBuffer = await streamToBuffer(original.stream);
+  // A zero-byte stored object is corrupt, not an image: sharp throws, the
+  // catch below falls back to "the original bytes", and we'd answer 200 with
+  // an empty body — which image clients treat as a successful load and paint
+  // as nothing. Treat it as a miss so the caller 404s and the client's
+  // fallback (initials) kicks in.
+  if (originalBuffer.length === 0) return false;
   let body = originalBuffer;
   let contentType = original.contentType || 'application/octet-stream';
   try {
@@ -118,8 +142,7 @@ export async function handleStaticAvatar(
         cacheControl: 'public, max-age=86400',
       });
       if (!served) {
-        res.writeHead(404, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Not found' }));
+        sendNotFound(res, { noStore: true });
       }
       return;
     }
@@ -127,8 +150,17 @@ export async function handleStaticAvatar(
     const s3Object = await getFromS3('media', s3Key);
 
     if (!s3Object) {
-      res.writeHead(404, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Not found' }));
+      sendNotFound(res, { noStore: true });
+      return;
+    }
+
+    // A zero-byte object serves as `200 image/jpeg` with an empty body, which
+    // <Image>/<img> report as a successful load — so the client paints an
+    // empty circle and never runs its error fallback. 404 instead, strictly on
+    // 0: an unknown (undefined) length must keep streaming as before.
+    if (s3Object.contentLength === 0) {
+      s3Object.stream.destroy();
+      sendNotFound(res, { noStore: true });
       return;
     }
 
@@ -154,6 +186,12 @@ export async function handleStaticAvatar(
 
   try {
     const fileStat = await stat(filePath);
+    if (fileStat.size === 0) {
+      // Same reasoning as the S3 branch: an empty file is a broken avatar, and
+      // serving it as 200 hides that from the client.
+      sendNotFound(res, { noStore: true });
+      return;
+    }
     const ext = extname(filePath).toLowerCase();
     const contentType = MIME_TYPES[ext] || 'application/octet-stream';
 
@@ -187,8 +225,7 @@ export async function handleStaticAvatar(
 
     createReadStream(filePath).pipe(res);
   } catch {
-    res.writeHead(404, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: 'Not found' }));
+    sendNotFound(res, { noStore: true });
   }
 }
 
@@ -234,8 +271,7 @@ async function serveStaticGymImage(
         cacheControl: 'public, max-age=86400',
       });
       if (!served) {
-        res.writeHead(404, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Not found' }));
+        sendNotFound(res, { noStore: true });
       }
       return;
     }
@@ -243,8 +279,15 @@ async function serveStaticGymImage(
     const s3Object = await getFromS3('media', s3Key);
 
     if (!s3Object) {
-      res.writeHead(404, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Not found' }));
+      sendNotFound(res, { noStore: true });
+      return;
+    }
+
+    // Mirrors the avatar handler: a zero-byte object is a broken upload, and
+    // serving it as a 200 makes the client believe the image loaded.
+    if (s3Object.contentLength === 0) {
+      s3Object.stream.destroy();
+      sendNotFound(res, { noStore: true });
       return;
     }
 
@@ -267,6 +310,10 @@ async function serveStaticGymImage(
 
   try {
     const fileStat = await stat(filePath);
+    if (fileStat.size === 0) {
+      sendNotFound(res, { noStore: true });
+      return;
+    }
     const ext = extname(filePath).toLowerCase();
     const contentType = MIME_TYPES[ext] || 'application/octet-stream';
 
@@ -298,8 +345,7 @@ async function serveStaticGymImage(
 
     createReadStream(filePath).pipe(res);
   } catch {
-    res.writeHead(404, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: 'Not found' }));
+    sendNotFound(res, { noStore: true });
   }
 }
 

--- a/packages/backend/src/handlers/static.ts
+++ b/packages/backend/src/handlers/static.ts
@@ -434,6 +434,17 @@ export async function handleStaticBetaThumbnail(
     return;
   }
 
+  // Same guard as the avatar / gym-logo handlers, and as the `?size=` branch
+  // above: a zero-byte object is served as a "successful" empty image. Here it
+  // matters more, not less — the 200 path is `immutable, max-age=1y`, so an
+  // empty body would be pinned in browser and CDN caches. `no-store` on the
+  // 404 keeps a re-cache at the same key able to repair it.
+  if (s3Object.contentLength === 0) {
+    s3Object.stream.destroy();
+    sendNotFound(res, { noStore: true });
+    return;
+  }
+
   res.writeHead(200, {
     'Content-Type': s3Object.contentType || 'image/jpeg',
     ...(s3Object.contentLength && { 'Content-Length': s3Object.contentLength }),

--- a/packages/backend/src/handlers/static.ts
+++ b/packages/backend/src/handlers/static.ts
@@ -420,8 +420,13 @@ export async function handleStaticBetaThumbnail(
       cacheControl: 'public, max-age=31536000, immutable',
     });
     if (!served) {
-      res.writeHead(404, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Not found' }));
+      // `?size=280` is the URL both clients actually request, so this is the
+      // branch a corrupt thumbnail reaches — `serveResizedImageFromS3` returns
+      // false for a zero-byte original just as it does for a missing one. A
+      // cached 404 here would hide the repair: `cacheRemoteThumbnail` now
+      // refuses to store an empty body, so the key stays absent until a later
+      // fetch fills in the same immutable URL.
+      sendNotFound(res, { noStore: true });
     }
     return;
   }
@@ -429,8 +434,8 @@ export async function handleStaticBetaThumbnail(
   const s3Object = await getFromS3('media', s3Key);
 
   if (!s3Object) {
-    res.writeHead(404, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: 'Not found' }));
+    // Same reasoning as the resized branch: the key can still be filled in.
+    sendNotFound(res, { noStore: true });
     return;
   }
 

--- a/packages/backend/src/handlers/static.ts
+++ b/packages/backend/src/handlers/static.ts
@@ -7,6 +7,7 @@ import { getAvatarsDir } from './avatars';
 import { getGymLogosDir } from './gym-logos';
 import { getGymPhotosDir } from './gym-photos';
 import { isS3Configured, getFromS3, uploadToS3 } from '../storage/s3';
+import { logger } from '../utils/logger';
 import { type AllowedImageSize, resizeImageBuffer, resizedVariantKey, streamToBuffer } from '../lib/image-resize';
 
 const MIME_TYPES: Record<string, string> = {
@@ -50,10 +51,13 @@ async function serveResizedImageFromS3(
   options: { cacheVariant: boolean; cacheControl: string },
 ): Promise<boolean> {
   if (options.cacheVariant) {
-    const cached = await getFromS3('media', resizedVariantKey(baseKey, size));
+    const variantKey = resizedVariantKey(baseKey, size);
+    const cached = await getFromS3('media', variantKey);
     if (cached && cached.contentLength === 0) {
       // A zero-byte cached variant would be served as an "OK" empty image.
-      // Drop it and fall through to resizing the original.
+      // Drop it and fall through to resizing the original. Logged because the
+      // only outward sign is an elevated origin-hit rate on this key.
+      logger.warn(`[Static] discarding zero-byte cached variant ${variantKey}; resizing original instead`);
       cached.stream.destroy();
     } else if (cached) {
       res.writeHead(200, {

--- a/packages/backend/src/lib/beta-link-thumbnails.ts
+++ b/packages/backend/src/lib/beta-link-thumbnails.ts
@@ -170,6 +170,14 @@ async function cacheRemoteThumbnail(key: string, sourceUrl: string, kind: ImageH
       logger.warn(`[BetaLinks] thumbnail body exceeded ${MAX_THUMBNAIL_BYTES} bytes; aborted`);
       return null;
     }
+    if (buffer.length === 0) {
+      // A CDN can answer `200 image/jpeg` with nothing in it. Storing that
+      // gives us a zero-byte object that serves as a "successful" empty image
+      // — and thumbnail keys are immutable with a one-year cache, so it would
+      // never repair itself. Fall back to no cached thumbnail instead.
+      logger.warn('[BetaLinks] thumbnail body was empty; not caching');
+      return null;
+    }
     await uploadToS3('media', buffer, key, contentType);
     return getStaticThumbnailUrl(key);
   } catch (err) {

--- a/packages/mobile/src/components/EditProfileScreen.tsx
+++ b/packages/mobile/src/components/EditProfileScreen.tsx
@@ -81,18 +81,27 @@ class AvatarCompressionError extends Error {
  * Compress a picked image and hand back both its URI and its bytes, so nothing
  * downstream has to trust that the file on disk is an image.
  *
- * Android's `saveAsync` throws away the `Boolean` that `Bitmap.compress()`
- * returns, so a failed encode still resolves with a URI — pointing at a 0-byte
- * file. iOS raises `CorruptedImageDataException` at the same spot, which is why
- * only Android saw this. Nothing further down noticed either: reading an empty
- * file returns an empty array without throwing, the multipart encoder writes a
+ * Somewhere between the picker and the multipart body we started producing empty
+ * uploads: 100% of avatars stored on or after 2026-07-08 are zero bytes, on both
+ * platforms, where every upload through 2026-07-07 is healthy. That boundary
+ * lines up with the Expo SDK 57 / React Native 0.86 upgrade (`02b6a6610`,
+ * `027932017`), not with any change to this file — `compressAvatar` has not been
+ * touched since 2026-06-18. An earlier reading blamed `expo-image-manipulator`'s
+ * Android encoder discarding the `Boolean` from `Bitmap.compress()`; a
+ * deterministic, cross-platform, date-bounded failure does not fit an
+ * image-dependent encoder fault, so treat that attribution as unproven.
+ *
+ * Whatever the producer is, nothing downstream noticed: reading an empty file
+ * returns an empty array without throwing, the multipart encoder writes a
  * zero-length part, and the backend answered 200 with a URL we persisted. The
  * user watched the crop land in the preview and lost it on the next screen.
  *
  * So check the bytes here, where we can still recover: fall back to the picker's
  * own crop, which is already square (`aspect: [1, 1]`) and only misses the
- * resize/re-encode. `expo-image-picker`'s Android exporter drops the same
- * `Boolean`, so the fallback gets its own length check instead of being trusted.
+ * resize/re-encode. That fallback gets its own length check rather than being
+ * trusted — and the `compressedBytes` / `originalBytes` pair reported below is
+ * what tells us which read is actually coming back empty. Both zero means the
+ * `File.bytes()` read itself is the producer and this fallback cannot rescue it.
  */
 async function compressAvatar(asset: ImagePicker.ImagePickerAsset): Promise<AvatarUploadFile> {
   let compressedBytes = new Uint8Array();

--- a/packages/mobile/src/components/EditProfileScreen.tsx
+++ b/packages/mobile/src/components/EditProfileScreen.tsx
@@ -1,15 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { Platform, ScrollView, StyleSheet, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import * as ImagePicker from 'expo-image-picker';
+import { File } from 'expo-file-system';
 import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
 import type { UpdateProfileInput } from '@boardsesh/shared-schema';
 import { useTheme } from '../providers/theme-provider';
 import { useToast } from '../providers/toast-provider';
 import { useProfile, useUpdateProfile } from '../lib/graphql/hooks';
-import { uploadAvatar, type AvatarUploadFile } from '../lib/avatar-upload';
-import { reportError } from '../lib/error-reporting';
+import { MAX_AVATAR_BYTES, uploadAvatar, type AvatarUploadFile } from '../lib/avatar-upload';
+import { reportError, reportHandledError } from '../lib/error-reporting';
 import { spacing } from '../theme/tokens';
 import { Avatar } from './Avatar';
 import { AuthTextInput } from './AuthTextInput';
@@ -24,16 +25,32 @@ const MAX_DIMENSION = 1024;
 const COMPRESSION_QUALITY = 0.85;
 
 /**
+ * Filenames for the image types the backend accepts (`ALLOWED_MIME_TYPES` in
+ * `packages/backend/src/handlers/avatars.ts`, which derives the stored file's
+ * extension from the declared type). Only consulted for the fallback: the
+ * compressed path re-encodes to JPEG, so it knows what it produced. A pick the
+ * picker reports as anything else — HEIC, most often, straight off an Android
+ * camera roll — can't be uploaded honestly without the manipulator, so the
+ * fallback refuses it rather than mislabelling the bytes as JPEG.
+ */
+const FALLBACK_FILE_NAMES: Partial<Record<string, string>> = {
+  'image/jpeg': 'avatar.jpg',
+  'image/png': 'avatar.png',
+  'image/gif': 'avatar.gif',
+  'image/webp': 'avatar.webp',
+};
+
+/**
  * Resize (if needed) and re-encode a picked image to a small JPEG, returning the
  * local file URI. Resizing a single dimension preserves the aspect ratio; we
  * constrain whichever side is longer. A 0 dimension (the picker couldn't report
  * size) skips the resize but still re-encodes to shrink the file.
  */
-async function compressAvatar(uri: string, width: number, height: number): Promise<string> {
-  const context = ImageManipulator.manipulate(uri);
-  const longestSide = Math.max(width, height);
+async function renderCompressedJpeg(asset: ImagePicker.ImagePickerAsset): Promise<string> {
+  const context = ImageManipulator.manipulate(asset.uri);
+  const longestSide = Math.max(asset.width, asset.height);
   if (longestSide > MAX_DIMENSION) {
-    if (width >= height) {
+    if (asset.width >= asset.height) {
       context.resize({ width: MAX_DIMENSION });
     } else {
       context.resize({ height: MAX_DIMENSION });
@@ -48,6 +65,85 @@ async function compressAvatar(uri: string, width: number, height: number): Promi
     // path on disk and stays valid after the ref is gone.
     image.release();
   }
+}
+
+/**
+ * Thrown when neither the compressed image nor the picker's own crop is usable.
+ * Named so `handlePickAvatar` can tell it apart: `compressAvatar` has already
+ * reported it with the byte counts attached, and reporting again there would
+ * file the same failure twice.
+ */
+class AvatarCompressionError extends Error {
+  override name = 'AvatarCompressionError';
+}
+
+/**
+ * Compress a picked image and hand back both its URI and its bytes, so nothing
+ * downstream has to trust that the file on disk is an image.
+ *
+ * Android's `saveAsync` throws away the `Boolean` that `Bitmap.compress()`
+ * returns, so a failed encode still resolves with a URI — pointing at a 0-byte
+ * file. iOS raises `CorruptedImageDataException` at the same spot, which is why
+ * only Android saw this. Nothing further down noticed either: reading an empty
+ * file returns an empty array without throwing, the multipart encoder writes a
+ * zero-length part, and the backend answered 200 with a URL we persisted. The
+ * user watched the crop land in the preview and lost it on the next screen.
+ *
+ * So check the bytes here, where we can still recover: fall back to the picker's
+ * own crop, which is already square (`aspect: [1, 1]`) and only misses the
+ * resize/re-encode. `expo-image-picker`'s Android exporter drops the same
+ * `Boolean`, so the fallback gets its own length check instead of being trusted.
+ */
+async function compressAvatar(asset: ImagePicker.ImagePickerAsset): Promise<AvatarUploadFile> {
+  let compressedBytes = new Uint8Array();
+  let failure: unknown = null;
+  try {
+    const compressedUri = await renderCompressedJpeg(asset);
+    compressedBytes = await new File(compressedUri).bytes();
+    if (compressedBytes.length > 0) {
+      return { uri: compressedUri, bytes: compressedBytes, name: 'avatar.jpg', type: 'image/jpeg' };
+    }
+  } catch (error) {
+    failure = error;
+  }
+
+  let originalBytes = new Uint8Array();
+  try {
+    originalBytes = await new File(asset.uri).bytes();
+  } catch (error) {
+    // Keep the manipulator's failure if there already is one — it explains more
+    // than "the picker's file wouldn't read either".
+    failure ??= error;
+  }
+
+  // The fallback skips the re-encode, so these bytes are whatever the picker
+  // handed us — on Android that is routinely PNG or HEIC, not JPEG. Send them
+  // under their real type, and give up when it isn't one the backend takes.
+  const fallbackType = asset.mimeType;
+  const fallbackName = fallbackType ? FALLBACK_FILE_NAMES[fallbackType] : undefined;
+  const canUseOriginal =
+    fallbackName !== undefined && originalBytes.length > 0 && originalBytes.length <= MAX_AVATAR_BYTES;
+
+  // There is no telemetry on this path today (zero avatar/manipulator/picker
+  // events in 90 days), which is exactly why the failure went unnoticed for so
+  // long. Sizes, MIME type and platform only — no URIs, no user identifiers.
+  // Reported once, here, at the severity the climber actually experiences: a
+  // warning when the fallback rescues the save, an error when they lose the pick.
+  reportHandledError(failure ?? new Error('Avatar compression produced an empty file'), {
+    level: canUseOriginal ? 'warning' : 'error',
+    tags: { source: 'avatar-compress' },
+    extra: {
+      compressedBytes: compressedBytes.length,
+      originalBytes: originalBytes.length,
+      originalType: fallbackType ?? 'unknown',
+      platform: Platform.OS,
+    },
+  });
+
+  if (!canUseOriginal) {
+    throw new AvatarCompressionError('Avatar compression produced an unusable file');
+  }
+  return { uri: asset.uri, bytes: originalBytes, name: fallbackName, type: fallbackType };
 }
 
 export function EditProfileScreen() {
@@ -103,11 +199,12 @@ export function EditProfileScreen() {
         quality: 1,
       });
       if (result.canceled) return;
-      const asset = result.assets[0];
-      const compressedUri = await compressAvatar(asset.uri, asset.width, asset.height);
-      setPickedAvatar({ uri: compressedUri, name: 'avatar.jpg', type: 'image/jpeg' });
+      setPickedAvatar(await compressAvatar(result.assets[0]));
     } catch (error) {
-      reportError(error);
+      // `compressAvatar` already reported this one with the byte counts attached.
+      if (!(error instanceof AvatarCompressionError)) {
+        reportError(error);
+      }
       showToast(t('profile.validation.compressionFailed'), 'error');
     }
   };

--- a/packages/mobile/src/components/EditProfileScreen.tsx
+++ b/packages/mobile/src/components/EditProfileScreen.tsx
@@ -28,10 +28,10 @@ const COMPRESSION_QUALITY = 0.85;
  * Filenames for the image types the backend accepts (`ALLOWED_MIME_TYPES` in
  * `packages/backend/src/handlers/avatars.ts`, which derives the stored file's
  * extension from the declared type). Only consulted for the fallback: the
- * compressed path re-encodes to JPEG, so it knows what it produced. A pick the
- * picker reports as anything else — HEIC, most often, straight off an Android
- * camera roll — can't be uploaded honestly without the manipulator, so the
- * fallback refuses it rather than mislabelling the bytes as JPEG.
+ * compressed path re-encodes to JPEG, so it knows what it produced. A format
+ * the backend doesn't take — HEIC, most often, straight off an Android camera
+ * roll — can't be uploaded honestly without the manipulator, so the fallback
+ * refuses it rather than mislabelling the bytes as JPEG.
  */
 const FALLBACK_FILE_NAMES: Partial<Record<string, string>> = {
   'image/jpeg': 'avatar.jpg',
@@ -39,6 +39,31 @@ const FALLBACK_FILE_NAMES: Partial<Record<string, string>> = {
   'image/gif': 'avatar.gif',
   'image/webp': 'avatar.webp',
 };
+
+/**
+ * Identify an image from its leading bytes.
+ *
+ * `ImagePickerAsset.mimeType` is documented as "the MIME type of the selected
+ * asset, or null if could not be determined", and the fallback below is exactly
+ * where an undetermined type used to cost the user a perfectly good square crop.
+ * The bytes are the more reliable witness anyway, so ask them first and treat
+ * the picker's label as the backup.
+ */
+function sniffImageType(bytes: Uint8Array): string | undefined {
+  const startsWith = (...signature: number[]): boolean =>
+    bytes.length >= signature.length && signature.every((byte, index) => bytes[index] === byte);
+
+  if (startsWith(0xff, 0xd8, 0xff)) return 'image/jpeg';
+  if (startsWith(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a)) return 'image/png';
+  if (startsWith(0x47, 0x49, 0x46, 0x38)) return 'image/gif';
+  // RIFF....WEBP — the four bytes at 8 are what separate WebP from other RIFF
+  // containers, so the length check has to cover them too.
+  if (startsWith(0x52, 0x49, 0x46, 0x46) && bytes.length >= 12) {
+    const isWebp = [0x57, 0x45, 0x42, 0x50].every((byte, index) => bytes[8 + index] === byte);
+    if (isWebp) return 'image/webp';
+  }
+  return undefined;
+}
 
 /**
  * Resize (if needed) and re-encode a picked image to a small JPEG, returning the
@@ -68,6 +93,14 @@ async function renderCompressedJpeg(asset: ImagePicker.ImagePickerAsset): Promis
 }
 
 /**
+ * Why a pick could not be turned into an avatar. Drives which toast the climber
+ * sees: "try a smaller image" is actively wrong advice for a photo that
+ * wouldn't open or a format we don't accept, and sends them round a loop that
+ * cannot succeed.
+ */
+type AvatarCompressionReason = 'unreadable' | 'unsupportedFormat' | 'tooLarge';
+
+/**
  * Thrown when neither the compressed image nor the picker's own crop is usable.
  * Named so `handlePickAvatar` can tell it apart: `compressAvatar` has already
  * reported it with the byte counts attached, and reporting again there would
@@ -75,6 +108,12 @@ async function renderCompressedJpeg(asset: ImagePicker.ImagePickerAsset): Promis
  */
 class AvatarCompressionError extends Error {
   override name = 'AvatarCompressionError';
+  readonly reason: AvatarCompressionReason;
+
+  constructor(message: string, reason: AvatarCompressionReason) {
+    super(message);
+    this.reason = reason;
+  }
 }
 
 /**
@@ -100,12 +139,19 @@ class AvatarCompressionError extends Error {
  * own crop, which is already square (`aspect: [1, 1]`) and only misses the
  * resize/re-encode. That fallback gets its own length check rather than being
  * trusted — and the `compressedBytes` / `originalBytes` pair reported below is
- * what tells us which read is actually coming back empty. Both zero means the
- * `File.bytes()` read itself is the producer and this fallback cannot rescue it.
+ * what tells us which read is actually coming back empty. Both zero *with no
+ * manipulator error* means the read itself is the producer and this fallback
+ * cannot rescue it; both zero after a throw also fits "the picker wrote a
+ * 0-byte crop", which is why the reported error and the `compressed_read` tag
+ * are needed to tell those apart.
  */
 async function compressAvatar(asset: ImagePicker.ImagePickerAsset): Promise<AvatarUploadFile> {
   let compressedBytes = new Uint8Array();
   let failure: unknown = null;
+  // `compressedBytes.length` is 0 both when the read came back empty and when it
+  // never happened, so record which — otherwise triage needs two queries to tell
+  // "the encoder produced nothing" from "the encoder threw".
+  let compressedRead: 'empty' | 'threw' = 'empty';
   try {
     const compressedUri = await renderCompressedJpeg(asset);
     compressedBytes = await new File(compressedUri).bytes();
@@ -114,6 +160,7 @@ async function compressAvatar(asset: ImagePicker.ImagePickerAsset): Promise<Avat
     }
   } catch (error) {
     failure = error;
+    compressedRead = 'threw';
   }
 
   let originalBytes = new Uint8Array();
@@ -128,7 +175,12 @@ async function compressAvatar(asset: ImagePicker.ImagePickerAsset): Promise<Avat
   // The fallback skips the re-encode, so these bytes are whatever the picker
   // handed us — on Android that is routinely PNG or HEIC, not JPEG. Send them
   // under their real type, and give up when it isn't one the backend takes.
-  const fallbackType = asset.mimeType;
+  //
+  // Read the type off the bytes first and only then off the picker's label: the
+  // label is allowed to be null, and refusing a good crop because the picker
+  // couldn't name it would forfeit the exact rescue this fallback exists for.
+  const declaredType = asset.mimeType && FALLBACK_FILE_NAMES[asset.mimeType] ? asset.mimeType : undefined;
+  const fallbackType = sniffImageType(originalBytes) ?? declaredType;
   const fallbackName = fallbackType ? FALLBACK_FILE_NAMES[fallbackType] : undefined;
   const canUseOriginal =
     fallbackName !== undefined && originalBytes.length > 0 && originalBytes.length <= MAX_AVATAR_BYTES;
@@ -140,17 +192,26 @@ async function compressAvatar(asset: ImagePicker.ImagePickerAsset): Promise<Avat
   // warning when the fallback rescues the save, an error when they lose the pick.
   reportHandledError(failure ?? new Error('Avatar compression produced an empty file'), {
     level: canUseOriginal ? 'warning' : 'error',
-    tags: { source: 'avatar-compress' },
+    tags: { source: 'avatar-compress', compressed_read: compressedRead },
     extra: {
       compressedBytes: compressedBytes.length,
       originalBytes: originalBytes.length,
       originalType: fallbackType ?? 'unknown',
+      declaredType: asset.mimeType ?? 'unknown',
       platform: Platform.OS,
     },
   });
 
   if (!canUseOriginal) {
-    throw new AvatarCompressionError('Avatar compression produced an unusable file');
+    // Order matters: an empty read is "unreadable" whatever the label said, and
+    // only a readable, in-budget image can be blamed on its format.
+    let reason: AvatarCompressionReason = 'unsupportedFormat';
+    if (originalBytes.length === 0) {
+      reason = 'unreadable';
+    } else if (originalBytes.length > MAX_AVATAR_BYTES) {
+      reason = 'tooLarge';
+    }
+    throw new AvatarCompressionError('Avatar compression produced an unusable file', reason);
   }
   return { uri: asset.uri, bytes: originalBytes, name: fallbackName, type: fallbackType };
 }
@@ -213,8 +274,22 @@ export function EditProfileScreen() {
       // `compressAvatar` already reported this one with the byte counts attached.
       if (!(error instanceof AvatarCompressionError)) {
         reportError(error);
+        showToast(t('profile.validation.compressionFailed'), 'error');
+        return;
       }
-      showToast(t('profile.validation.compressionFailed'), 'error');
+      // Literal keys per reason — "try a smaller image" is wrong advice for a
+      // photo that wouldn't open or a format the backend won't take, and would
+      // send the climber round a loop that can't succeed.
+      switch (error.reason) {
+        case 'unreadable':
+          showToast(t('profile.validation.avatarUnreadable'), 'error');
+          break;
+        case 'unsupportedFormat':
+          showToast(t('profile.validation.avatarFormatUnsupported'), 'error');
+          break;
+        default:
+          showToast(t('profile.validation.compressionFailed'), 'error');
+      }
     }
   };
 

--- a/packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx
+++ b/packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx
@@ -14,6 +14,11 @@ const resizeMock = vi.hoisted(() => vi.fn());
 const renderAsyncMock = vi.hoisted(() => vi.fn());
 const saveAsyncMock = vi.hoisted(() => vi.fn());
 const releaseMock = vi.hoisted(() => vi.fn());
+const reportHandledErrorMock = vi.hoisted(() => vi.fn());
+// Bytes the stubbed expo-file-system `File` hands back, keyed by URI. Missing
+// entries read back as empty — which is exactly the Android failure under test:
+// a 0-byte file reads as an empty array instead of throwing.
+const fileBytesByUri = vi.hoisted(() => new Map<string, Uint8Array>());
 
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios' },
@@ -41,6 +46,18 @@ vi.mock('expo-image-manipulator', () => ({
   SaveFormat: { JPEG: 'jpeg' },
 }));
 
+vi.mock('expo-file-system', () => ({
+  File: class {
+    uri: string;
+    constructor(uri: string) {
+      this.uri = uri;
+    }
+    bytes() {
+      return Promise.resolve(fileBytesByUri.get(this.uri) ?? new Uint8Array());
+    }
+  },
+}));
+
 vi.mock('../../providers/theme-provider', () => ({
   useTheme: () => ({
     systemColors: {
@@ -66,12 +83,22 @@ vi.mock('../../lib/graphql/hooks', () => ({
   useUpdateProfile: () => ({ mutateAsync: mutateAsyncMock }),
 }));
 
-vi.mock('../../lib/avatar-upload', () => ({
+// `authenticatedFetch` drags in auth-store → expo-secure-store, which doesn't
+// load under jsdom. Stubbing it is what lets the avatar-upload mock below be a
+// *partial* one, so `MAX_AVATAR_BYTES` is the real constant and the over-cap
+// test can't drift away from the boundary it's meant to exercise.
+vi.mock('../../lib/auth-interceptor', () => ({
+  authenticatedFetch: vi.fn(),
+}));
+
+vi.mock('../../lib/avatar-upload', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/avatar-upload')>()),
   uploadAvatar: uploadAvatarMock,
 }));
 
 vi.mock('../../lib/error-reporting', () => ({
   reportError: vi.fn(),
+  reportHandledError: reportHandledErrorMock,
 }));
 
 vi.mock('../Avatar', () => ({
@@ -116,6 +143,7 @@ vi.mock('../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
 
+import { MAX_AVATAR_BYTES } from '../../lib/avatar-upload';
 import { EditProfileScreen } from '../EditProfileScreen';
 
 beforeEach(() => {
@@ -130,11 +158,16 @@ beforeEach(() => {
   renderAsyncMock.mockReset();
   saveAsyncMock.mockReset();
   releaseMock.mockReset();
+  reportHandledErrorMock.mockReset();
+
+  fileBytesByUri.clear();
+  fileBytesByUri.set('file://picked-avatar.jpg', new Uint8Array([9, 9, 9, 9]));
+  fileBytesByUri.set('file://compressed-avatar.jpg', new Uint8Array([1, 2, 3]));
 
   requestMediaLibraryPermissionsMock.mockResolvedValue({ granted: true });
   launchImageLibraryMock.mockResolvedValue({
     canceled: false,
-    assets: [{ uri: 'file://picked-avatar.jpg', width: 2400, height: 1600 }],
+    assets: [{ uri: 'file://picked-avatar.jpg', width: 2400, height: 1600, mimeType: 'image/jpeg' }],
   });
   saveAsyncMock.mockResolvedValue({ uri: 'file://compressed-avatar.jpg' });
   renderAsyncMock.mockResolvedValue({ saveAsync: saveAsyncMock, release: releaseMock });
@@ -164,7 +197,12 @@ describe('EditProfileScreen', () => {
 
     await waitFor(() => {
       expect(uploadAvatarMock).toHaveBeenCalledWith(
-        { uri: 'file://compressed-avatar.jpg', name: 'avatar.jpg', type: 'image/jpeg' },
+        {
+          uri: 'file://compressed-avatar.jpg',
+          bytes: new Uint8Array([1, 2, 3]),
+          name: 'avatar.jpg',
+          type: 'image/jpeg',
+        },
         '11111111-1111-4111-8111-111111111111',
       );
     });
@@ -172,5 +210,182 @@ describe('EditProfileScreen', () => {
       avatarUrl: 'https://ws.example.com/static/avatars/11111111-1111-4111-8111-111111111111.jpg?v=upload-123',
     });
     expect(routerBackMock).toHaveBeenCalledOnce();
+    expect(reportHandledErrorMock).not.toHaveBeenCalled();
+  });
+
+  // Android's `saveAsync` ignores the Boolean `Bitmap.compress()` returns, so a
+  // failed encode resolves with a URI pointing at a 0-byte file. Every layer
+  // below treated that as success, and the user's picture vanished on the next
+  // screen with nothing logged anywhere.
+  it('falls back to the picker crop when the compressed file comes back empty', async () => {
+    fileBytesByUri.set('file://compressed-avatar.jpg', new Uint8Array());
+
+    render(createElement(EditProfileScreen));
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.avatar.upload' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('avatar').getAttribute('data-uri')).toBe('file://picked-avatar.jpg');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.save' }));
+
+    await waitFor(() => {
+      expect(uploadAvatarMock).toHaveBeenCalledWith(
+        {
+          uri: 'file://picked-avatar.jpg',
+          bytes: new Uint8Array([9, 9, 9, 9]),
+          name: 'avatar.jpg',
+          type: 'image/jpeg',
+        },
+        '11111111-1111-4111-8111-111111111111',
+      );
+    });
+    expect(routerBackMock).toHaveBeenCalledOnce();
+
+    // The whole reason this went unnoticed: nothing reported it.
+    expect(reportHandledErrorMock).toHaveBeenCalledOnce();
+    const [reportedError, context] = reportHandledErrorMock.mock.calls[0] as [Error, Record<string, unknown>];
+    expect(reportedError.message).toBe('Avatar compression produced an empty file');
+    expect(context).toMatchObject({
+      level: 'warning',
+      tags: { source: 'avatar-compress' },
+      extra: { compressedBytes: 0, originalBytes: 4, originalType: 'image/jpeg' },
+    });
+  });
+
+  // The fallback skips the JPEG re-encode, so the bytes are whatever the picker
+  // produced. Declaring them `image/jpeg` regardless would store a PNG under a
+  // .jpg key with a lying content-type.
+  it("sends the fallback crop under the picker's own MIME type", async () => {
+    launchImageLibraryMock.mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file://picked-avatar.png', width: 2400, height: 1600, mimeType: 'image/png' }],
+    });
+    fileBytesByUri.set('file://picked-avatar.png', new Uint8Array([7, 7]));
+    fileBytesByUri.set('file://compressed-avatar.jpg', new Uint8Array());
+
+    render(createElement(EditProfileScreen));
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.avatar.upload' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('avatar').getAttribute('data-uri')).toBe('file://picked-avatar.png');
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'profile.save' }));
+
+    await waitFor(() => {
+      expect(uploadAvatarMock).toHaveBeenCalledWith(
+        {
+          uri: 'file://picked-avatar.png',
+          bytes: new Uint8Array([7, 7]),
+          name: 'avatar.png',
+          type: 'image/png',
+        },
+        '11111111-1111-4111-8111-111111111111',
+      );
+    });
+  });
+
+  it('refuses a fallback crop the backend would not accept, rather than mislabelling it', async () => {
+    launchImageLibraryMock.mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file://picked-avatar.heic', width: 2400, height: 1600, mimeType: 'image/heic' }],
+    });
+    fileBytesByUri.set('file://picked-avatar.heic', new Uint8Array([5, 5, 5]));
+    fileBytesByUri.set('file://compressed-avatar.jpg', new Uint8Array());
+
+    render(createElement(EditProfileScreen));
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.avatar.upload' }));
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith('profile.validation.compressionFailed', 'error');
+    });
+    expect(uploadAvatarMock).not.toHaveBeenCalled();
+
+    const [, context] = reportHandledErrorMock.mock.calls[0] as [Error, Record<string, unknown>];
+    expect(context).toMatchObject({ level: 'error', extra: { originalType: 'image/heic' } });
+  });
+
+  it('falls back to the picker crop when the manipulator throws outright', async () => {
+    saveAsyncMock.mockRejectedValue(new Error('CorruptedImageDataException'));
+
+    render(createElement(EditProfileScreen));
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.avatar.upload' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('avatar').getAttribute('data-uri')).toBe('file://picked-avatar.jpg');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.save' }));
+
+    await waitFor(() => {
+      expect(uploadAvatarMock).toHaveBeenCalledWith(
+        {
+          uri: 'file://picked-avatar.jpg',
+          bytes: new Uint8Array([9, 9, 9, 9]),
+          name: 'avatar.jpg',
+          type: 'image/jpeg',
+        },
+        '11111111-1111-4111-8111-111111111111',
+      );
+    });
+    expect(showToastMock).not.toHaveBeenCalledWith('profile.validation.compressionFailed', 'error');
+    expect(routerBackMock).toHaveBeenCalledOnce();
+
+    // The manipulator's own error is what gets reported here, not a synthetic
+    // "empty file" — the two failure shapes stay distinguishable in triage.
+    expect(reportHandledErrorMock).toHaveBeenCalledOnce();
+    const [reportedError, context] = reportHandledErrorMock.mock.calls[0] as [Error, Record<string, unknown>];
+    expect(reportedError.message).toBe('CorruptedImageDataException');
+    expect(context).toMatchObject({
+      level: 'warning',
+      tags: { source: 'avatar-compress' },
+      extra: { compressedBytes: 0, originalBytes: 4, originalType: 'image/jpeg' },
+    });
+  });
+
+  it('tells the user when neither the compressed file nor the picker crop is usable', async () => {
+    fileBytesByUri.clear();
+
+    render(createElement(EditProfileScreen));
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.avatar.upload' }));
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith('profile.validation.compressionFailed', 'error');
+    });
+    // No avatar was picked, so Save stays disabled and nothing is uploaded.
+    expect(screen.getByTestId('avatar').getAttribute('data-uri')).toBe('');
+    expect(screen.getByRole('button', { name: 'profile.save' })).toHaveProperty('disabled', true);
+    expect(uploadAvatarMock).not.toHaveBeenCalled();
+    expect(routerBackMock).not.toHaveBeenCalled();
+    expect(reportHandledErrorMock).toHaveBeenCalledOnce();
+  });
+
+  it('refuses a fallback crop that is over the backend cap rather than uploading it', async () => {
+    fileBytesByUri.set('file://compressed-avatar.jpg', new Uint8Array());
+    fileBytesByUri.set('file://picked-avatar.jpg', new Uint8Array(MAX_AVATAR_BYTES + 1));
+
+    render(createElement(EditProfileScreen));
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.avatar.upload' }));
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith('profile.validation.compressionFailed', 'error');
+    });
+    expect(uploadAvatarMock).not.toHaveBeenCalled();
+
+    // Losing the pick outright is reported at `error`, not the `warning` the
+    // rescued-by-fallback path uses — and only once, not once here and again
+    // from the screen's catch block.
+    expect(reportHandledErrorMock).toHaveBeenCalledOnce();
+    const [, context] = reportHandledErrorMock.mock.calls[0] as [Error, Record<string, unknown>];
+    expect(context).toMatchObject({
+      level: 'error',
+      tags: { source: 'avatar-compress' },
+      extra: { compressedBytes: 0, originalBytes: MAX_AVATAR_BYTES + 1, originalType: 'image/jpeg' },
+    });
   });
 });

--- a/packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx
+++ b/packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx
@@ -286,6 +286,50 @@ describe('EditProfileScreen', () => {
     });
   });
 
+  it('rescues a good crop the picker could not put a MIME type on', async () => {
+    // `ImagePickerAsset.mimeType` is documented as null when the picker cannot
+    // determine it. Refusing on that alone would forfeit exactly the rescue this
+    // fallback exists for, so the type is read off the bytes instead.
+    launchImageLibraryMock.mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file://picked-avatar.jpg', width: 2400, height: 1600, mimeType: undefined }],
+    });
+    // A real JPEG header — FF D8 FF.
+    fileBytesByUri.set('file://picked-avatar.jpg', new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 1, 2]));
+    fileBytesByUri.set('file://compressed-avatar.jpg', new Uint8Array());
+
+    render(createElement(EditProfileScreen));
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.avatar.upload' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'profile.save' })).toHaveProperty('disabled', false);
+    });
+    expect(showToastMock).not.toHaveBeenCalledWith('profile.validation.avatarFormatUnsupported', 'error');
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.save' }));
+
+    await waitFor(() => {
+      expect(uploadAvatarMock).toHaveBeenCalledWith(
+        {
+          uri: 'file://picked-avatar.jpg',
+          bytes: new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 1, 2]),
+          name: 'avatar.jpg',
+          type: 'image/jpeg',
+        },
+        '11111111-1111-4111-8111-111111111111',
+      );
+    });
+
+    // Rescued, so this is a warning rather than a lost pick.
+    const [, context] = reportHandledErrorMock.mock.calls[0] as [Error, Record<string, unknown>];
+    expect(context).toMatchObject({
+      level: 'warning',
+      tags: { source: 'avatar-compress', compressed_read: 'empty' },
+      extra: { originalType: 'image/jpeg', declaredType: 'unknown' },
+    });
+  });
+
   it('refuses a fallback crop the backend would not accept, rather than mislabelling it', async () => {
     launchImageLibraryMock.mockResolvedValue({
       canceled: false,
@@ -299,12 +343,20 @@ describe('EditProfileScreen', () => {
     fireEvent.click(screen.getByRole('button', { name: 'profile.avatar.upload' }));
 
     await waitFor(() => {
-      expect(showToastMock).toHaveBeenCalledWith('profile.validation.compressionFailed', 'error');
+      // The format is the problem, so say so — "try a smaller image" would send
+      // the climber round a loop that cannot succeed.
+      expect(showToastMock).toHaveBeenCalledWith('profile.validation.avatarFormatUnsupported', 'error');
     });
+    expect(showToastMock).not.toHaveBeenCalledWith('profile.validation.compressionFailed', 'error');
     expect(uploadAvatarMock).not.toHaveBeenCalled();
 
     const [, context] = reportHandledErrorMock.mock.calls[0] as [Error, Record<string, unknown>];
-    expect(context).toMatchObject({ level: 'error', extra: { originalType: 'image/heic' } });
+    // `originalType` is what we would have sent; the picker's own label is kept
+    // separately so triage can see a format we refused.
+    expect(context).toMatchObject({
+      level: 'error',
+      extra: { originalType: 'unknown', declaredType: 'image/heic' },
+    });
   });
 
   it('falls back to the picker crop when the manipulator throws outright', async () => {
@@ -354,8 +406,10 @@ describe('EditProfileScreen', () => {
     fireEvent.click(screen.getByRole('button', { name: 'profile.avatar.upload' }));
 
     await waitFor(() => {
-      expect(showToastMock).toHaveBeenCalledWith('profile.validation.compressionFailed', 'error');
+      // Nothing read back, so no smaller image would help either.
+      expect(showToastMock).toHaveBeenCalledWith('profile.validation.avatarUnreadable', 'error');
     });
+    expect(showToastMock).not.toHaveBeenCalledWith('profile.validation.compressionFailed', 'error');
     // No avatar was picked, so Save stays disabled and nothing is uploaded.
     expect(screen.getByTestId('avatar').getAttribute('data-uri')).toBe('');
     expect(screen.getByRole('button', { name: 'profile.save' })).toHaveProperty('disabled', true);

--- a/packages/mobile/src/lib/__tests__/avatar-upload.test.ts
+++ b/packages/mobile/src/lib/__tests__/avatar-upload.test.ts
@@ -16,6 +16,9 @@ vi.mock('../auth-interceptor', () => ({
 // expo-file-system is native; stub the File class so `.bytes()` resolves to a
 // fixed payload in Node.
 const fileBytes = new Uint8Array([1, 2, 3]);
+// What the stubbed File hands back, plus a read counter — a test points this at
+// an empty payload to simulate a picked file that has become unreadable.
+const stubbedFile = { bytes: fileBytes as Uint8Array, reads: 0 };
 vi.mock('expo-file-system', () => ({
   File: class {
     uri: string;
@@ -23,7 +26,8 @@ vi.mock('expo-file-system', () => ({
       this.uri = uri;
     }
     bytes() {
-      return Promise.resolve(fileBytes);
+      stubbedFile.reads += 1;
+      return Promise.resolve(stubbedFile.bytes);
     }
   },
 }));
@@ -57,6 +61,8 @@ function jsonResponse(body: unknown, ok = true): Response {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  stubbedFile.bytes = fileBytes;
+  stubbedFile.reads = 0;
 });
 
 describe('absolutizeAvatarUrl', () => {
@@ -97,6 +103,17 @@ describe('uploadAvatar', () => {
     expect(avatarPart.type).toBe('image/jpeg');
     expect(typeof avatarPart.bytes).toBe('function');
     await expect(avatarPart.bytes()).resolves.toBe(fileBytes);
+
+    // Read once, before the POST: the encoder only awaits `bytes()` at encode
+    // time, so a lazy read could hand it an empty part after the file went away.
+    expect(stubbedFile.reads).toBe(1);
+  });
+
+  it('refuses to POST an empty file instead of storing a zero-byte avatar', async () => {
+    stubbedFile.bytes = new Uint8Array([]);
+
+    await expect(uploadAvatar(file, userId)).rejects.toThrow('Avatar upload failed');
+    expect(mockAuthenticatedFetch).not.toHaveBeenCalled();
   });
 
   it('throws the server-provided error message on a non-ok response', async () => {

--- a/packages/mobile/src/lib/__tests__/avatar-upload.test.ts
+++ b/packages/mobile/src/lib/__tests__/avatar-upload.test.ts
@@ -13,21 +13,19 @@ vi.mock('../auth-interceptor', () => ({
   authenticatedFetch: (...args: unknown[]) => mockAuthenticatedFetch(...args),
 }));
 
-// expo-file-system is native; stub the File class so `.bytes()` resolves to a
-// fixed payload in Node.
-const fileBytes = new Uint8Array([1, 2, 3]);
-// What the stubbed File hands back, plus a read counter — a test points this at
-// an empty payload to simulate a picked file that has become unreadable.
-const stubbedFile = { bytes: fileBytes as Uint8Array, reads: 0 };
+// expo-file-system is native. `uploadAvatar` must not touch it at all any more —
+// the caller reads the picked file at pick time and passes the bytes in — so the
+// stub exists purely to fail loudly if a lazy read ever creeps back in.
+const fileConstructions = { count: 0 };
 vi.mock('expo-file-system', () => ({
   File: class {
     uri: string;
     constructor(uri: string) {
+      fileConstructions.count += 1;
       this.uri = uri;
     }
     bytes() {
-      stubbedFile.reads += 1;
-      return Promise.resolve(stubbedFile.bytes);
+      return Promise.resolve(new Uint8Array());
     }
   },
 }));
@@ -49,10 +47,11 @@ class RecordingFormData {
 }
 vi.stubGlobal('FormData', RecordingFormData);
 
-import { absolutizeAvatarUrl, uploadAvatar } from '../avatar-upload';
+import { absolutizeAvatarUrl, MAX_AVATAR_BYTES, uploadAvatar } from '../avatar-upload';
 
 const BACKEND = 'https://ws.example.com';
-const file = { uri: 'file:///tmp/avatar.jpg', name: 'avatar.jpg', type: 'image/jpeg' };
+const fileBytes = new Uint8Array([1, 2, 3]);
+const file = { uri: 'file:///tmp/avatar.jpg', bytes: fileBytes, name: 'avatar.jpg', type: 'image/jpeg' };
 const userId = '11111111-2222-3333-4444-555555555555';
 
 function jsonResponse(body: unknown, ok = true): Response {
@@ -61,8 +60,7 @@ function jsonResponse(body: unknown, ok = true): Response {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  stubbedFile.bytes = fileBytes;
-  stubbedFile.reads = 0;
+  fileConstructions.count = 0;
 });
 
 describe('absolutizeAvatarUrl', () => {
@@ -104,15 +102,21 @@ describe('uploadAvatar', () => {
     expect(typeof avatarPart.bytes).toBe('function');
     await expect(avatarPart.bytes()).resolves.toBe(fileBytes);
 
-    // Read once, before the POST: the encoder only awaits `bytes()` at encode
-    // time, so a lazy read could hand it an empty part after the file went away.
-    expect(stubbedFile.reads).toBe(1);
+    // The bytes come from the descriptor, not from a fresh read of the URI: the
+    // encoder only awaits `bytes()` at encode time, so a lazy read could hand it
+    // an empty part after the picked file went away.
+    expect(fileConstructions.count).toBe(0);
   });
 
   it('refuses to POST an empty file instead of storing a zero-byte avatar', async () => {
-    stubbedFile.bytes = new Uint8Array([]);
+    await expect(uploadAvatar({ ...file, bytes: new Uint8Array() }, userId)).rejects.toThrow('Avatar upload failed');
+    expect(mockAuthenticatedFetch).not.toHaveBeenCalled();
+  });
 
-    await expect(uploadAvatar(file, userId)).rejects.toThrow('Avatar upload failed');
+  it("refuses to POST a file over the backend's 2MB cap instead of wasting the upload", async () => {
+    const oversized = new Uint8Array(MAX_AVATAR_BYTES + 1);
+
+    await expect(uploadAvatar({ ...file, bytes: oversized }, userId)).rejects.toThrow('Avatar upload failed');
     expect(mockAuthenticatedFetch).not.toHaveBeenCalled();
   });
 

--- a/packages/mobile/src/lib/avatar-upload.ts
+++ b/packages/mobile/src/lib/avatar-upload.ts
@@ -49,6 +49,16 @@ function withCacheBuster(url: string): string {
 export async function uploadAvatar(file: AvatarUploadFile, userId: string): Promise<string> {
   const localFile = new File(file.uri);
 
+  // Read the bytes now instead of handing the encoder a lazy `bytes()` closure.
+  // The multipart encoder only awaits `bytes()` at encode time, so a picked file
+  // that has since become unreadable (cache eviction) would be encoded as an
+  // empty part and stored as a zero-byte avatar that renders as a blank circle.
+  // Reading here turns that into an error the caller can surface, before the POST.
+  const avatarBytes = await localFile.bytes();
+  if (avatarBytes.length === 0) {
+    throw new Error('Avatar upload failed');
+  }
+
   const formData = new FormData();
   // Expo's global `fetch` (WinterCG) rejects React Native's legacy
   // `{ uri, name, type }` FormData file descriptor with "Unsupported FormDataPart
@@ -60,7 +70,7 @@ export async function uploadAvatar(file: AvatarUploadFile, userId: string): Prom
   const avatarPart = {
     name: file.name ?? 'avatar.jpg',
     type: file.type ?? 'image/jpeg',
-    bytes: () => localFile.bytes(),
+    bytes: () => Promise.resolve(avatarBytes),
   };
   formData.append('avatar', avatarPart as unknown as Blob);
   formData.append('userId', userId);

--- a/packages/mobile/src/lib/avatar-upload.ts
+++ b/packages/mobile/src/lib/avatar-upload.ts
@@ -1,4 +1,3 @@
-import { File } from 'expo-file-system';
 import { authenticatedFetch } from './auth-interceptor';
 import { BACKEND_URL } from './env';
 
@@ -7,10 +6,30 @@ import { BACKEND_URL } from './env';
 // in practice every upload is a small JPEG well under the limit.
 const AVATAR_ENDPOINT = `${BACKEND_URL}/api/avatars`;
 
+/**
+ * The same cap the backend enforces (`MAX_FILE_SIZE` in
+ * `packages/backend/src/handlers/avatars.ts`). Kept mobile-local rather than
+ * shared: it is a property of the avatar endpoint, and duplicating one number
+ * beats making every consumer of `@boardsesh/shared-schema` care about it.
+ * Checking it here turns a wasted multi-megabyte upload into an instant refusal.
+ */
+export const MAX_AVATAR_BYTES = 2 * 1024 * 1024;
+
 /** A picked (and already-compressed) local image ready to upload. */
 export type AvatarUploadFile = {
-  /** Local file URI (file://...) from the picker/manipulator. */
+  /**
+   * Local file URI (file://...) from the picker/manipulator. Used for the
+   * on-screen preview; the upload itself goes off `bytes`.
+   */
   uri: string;
+  /**
+   * The image bytes, already read from `uri` and proven non-empty at pick time.
+   * Carrying the bytes instead of re-reading the URI here is deliberate: on
+   * Android a failed encode leaves a 0-byte file behind that reads back as an
+   * empty array without throwing, so the read has to happen where we can still
+   * recover (see `compressAvatar` in EditProfileScreen).
+   */
+  bytes: Uint8Array;
   /** Filename sent in the multipart part; defaults to `avatar.jpg`. */
   name?: string;
   /** MIME type; defaults to `image/jpeg` (what the manipulator emits). */
@@ -47,15 +66,13 @@ function withCacheBuster(url: string): string {
  * added by the fetch layer, and `authenticatedFetch` only touches `Authorization`.
  */
 export async function uploadAvatar(file: AvatarUploadFile, userId: string): Promise<string> {
-  const localFile = new File(file.uri);
-
-  // Read the bytes now instead of handing the encoder a lazy `bytes()` closure.
-  // The multipart encoder only awaits `bytes()` at encode time, so a picked file
-  // that has since become unreadable (cache eviction) would be encoded as an
-  // empty part and stored as a zero-byte avatar that renders as a blank circle.
-  // Reading here turns that into an error the caller can surface, before the POST.
-  const avatarBytes = await localFile.bytes();
-  if (avatarBytes.length === 0) {
+  // Last gate before the POST. The multipart encoder only awaits `bytes()` at
+  // encode time and writes whatever it gets, empty included, so an unusable
+  // image that reaches here would be stored as a zero-byte avatar behind a URL
+  // we then persist forever — the picture looks saved and renders as initials.
+  // Refusing costs the user a warning toast; accepting costs them their avatar.
+  const avatarBytes = file.bytes;
+  if (avatarBytes.length === 0 || avatarBytes.length > MAX_AVATAR_BYTES) {
     throw new Error('Avatar upload failed');
   }
 

--- a/packages/mobile/src/lib/avatar-upload.ts
+++ b/packages/mobile/src/lib/avatar-upload.ts
@@ -24,10 +24,10 @@ export type AvatarUploadFile = {
   uri: string;
   /**
    * The image bytes, already read from `uri` and proven non-empty at pick time.
-   * Carrying the bytes instead of re-reading the URI here is deliberate: on
-   * Android a failed encode leaves a 0-byte file behind that reads back as an
-   * empty array without throwing, so the read has to happen where we can still
-   * recover (see `compressAvatar` in EditProfileScreen).
+   * Carrying the bytes instead of re-reading the URI here is deliberate: an
+   * unusable pick reads back as an empty array without throwing anywhere in the
+   * chain, so the read has to happen where we can still recover and report what
+   * came back (see `compressAvatar` in EditProfileScreen).
    */
   bytes: Uint8Array;
   /** Filename sent in the multipart part; defaults to `avatar.jpg`. */

--- a/packages/shared/i18n/locales/de/settings.json
+++ b/packages/shared/i18n/locales/de/settings.json
@@ -31,7 +31,9 @@
     "saveError": "Einstellungen konnten nicht gespeichert werden",
     "validation": {
       "displayNameTooLong": "Der Anzeigename muss kürzer als 100 Zeichen sein",
-      "compressionFailed": "Komprimieren hat nicht geklappt — probier ein kleineres Bild"
+      "compressionFailed": "Komprimieren hat nicht geklappt — probier ein kleineres Bild",
+      "avatarUnreadable": "Das Foto ließ sich nicht öffnen — probier ein anderes",
+      "avatarFormatUnsupported": "Das Format wird nicht unterstützt — probier ein JPEG oder PNG"
     },
     "avatarUploadFailed": "Avatar-Upload fehlgeschlagen"
   },

--- a/packages/shared/i18n/locales/en-US/settings.json
+++ b/packages/shared/i18n/locales/en-US/settings.json
@@ -31,7 +31,9 @@
     "saveError": "Failed to save settings",
     "validation": {
       "displayNameTooLong": "Display name must be less than 100 characters",
-      "compressionFailed": "Could not compress — please try a smaller image"
+      "compressionFailed": "Could not compress — please try a smaller image",
+      "avatarUnreadable": "That photo wouldn't open — try another one",
+      "avatarFormatUnsupported": "That format isn't supported — try a JPEG or PNG"
     },
     "avatarUploadFailed": "Avatar upload failed"
   },

--- a/packages/shared/i18n/locales/es/settings.json
+++ b/packages/shared/i18n/locales/es/settings.json
@@ -31,7 +31,9 @@
     "saveError": "No se pudieron guardar los ajustes",
     "validation": {
       "displayNameTooLong": "El nombre debe tener menos de 100 caracteres",
-      "compressionFailed": "No se pudo comprimir — prueba con una imagen más pequeña"
+      "compressionFailed": "No se pudo comprimir — prueba con una imagen más pequeña",
+      "avatarUnreadable": "Esa foto no se pudo abrir — prueba con otra",
+      "avatarFormatUnsupported": "Ese formato no es compatible — prueba con JPEG o PNG"
     },
     "avatarUploadFailed": "No se pudo subir la foto de perfil"
   },

--- a/packages/shared/i18n/locales/fr/settings.json
+++ b/packages/shared/i18n/locales/fr/settings.json
@@ -31,7 +31,9 @@
     "saveError": "Impossible d'enregistrer les paramètres",
     "validation": {
       "displayNameTooLong": "Le nom doit faire moins de 100 caractères",
-      "compressionFailed": "Compression impossible, prenez une image plus petite"
+      "compressionFailed": "Compression impossible, prenez une image plus petite",
+      "avatarUnreadable": "Cette photo n'a pas pu être ouverte, essayez-en une autre",
+      "avatarFormatUnsupported": "Ce format n'est pas pris en charge, essayez un JPEG ou un PNG"
     },
     "avatarUploadFailed": "Impossible d'importer la photo"
   },


### PR DESCRIPTION
## Summary

Rebased onto `main` and re-scoped. This branch had been stranded since PR #4539 was merged **into it** rather than into `main`, so neither half had shipped. Both are preserved here.

**Draft on purpose.** There is a device check below that has to happen before this merges, and CI going green is not that check.

### What production actually looks like

All 156 uploaded avatars, read-only, CDN-bypassed:

| result | count |
| --- | --- |
| `200` with real bytes (18 KB – 481 KB) | 34 |
| `200 image/jpeg` with **0 bytes** | 39 |
| `404` — object gone | 83 |

**100% of avatars uploaded on or after 2026-07-08 are zero bytes** (38 of 39). Every upload through 2026-07-07 is healthy (27 of 27). A hard, deterministic, cross-platform date boundary.

An empty body is a *successful* image load, so the client's error fallback never runs and the user gets a blank circle instead of their initials.

### The regression boundary is the SDK upgrade, not the image manipulator

PR #4539 attributed this to `expo-image-manipulator`'s Android encoder discarding the `Boolean` from `Bitmap.compress()`, with iOS throwing instead. **That attribution should not be repeated as settled.** A 100% failure rate, on both platforms, starting on a fixed date, is not an image-dependent encoder fault — and `compressAvatar` has not been touched since 2026-06-18. What landed at the boundary is `02b6a6610` (Expo SDK 57 / React Native 0.86) and `027932017` (SDK 57 patch bumps). The rollout lag matches the 2026-07-08 cutoff.

The likeliest producer is the lazy `bytes: () => localFile.bytes()` read interacting with SDK 57's `expo-file-system`. That is platform-independent and silent, which is why Sentry and PostHog have nothing.

### What each half is worth

**Backend (`avatars.ts`, `static.ts`, `beta-link-thumbnails.ts`) — repairs the symptom, unconditionally correct.** A zero-length multipart part is now a 400 instead of a stored empty object, and a zero-byte object 404s instead of serving as `200 image/jpeg`. That turns a blank circle into initials for 39 live accounts today, and a re-upload can repair the row. This half does not depend on which mobile theory is right.

The 404s carry `Cache-Control: no-store`, and that is load-bearing: the origin sends no cache header on these 404s today, so Cloudflare stamps its own `max-age=14400` and pins the broken state for four hours.

Worth noting the `?size=` path — the one every mobile client takes, since `Avatar.tsx` always appends `&size=` to a `/static/avatars/` URI — guards on `originalBuffer.length === 0`, which is provider-independent. The no-size path guards strictly on `contentLength === 0`, because an S3 provider that omits `ContentLength` must keep streaming.

**Mobile (`avatar-upload.ts`, `EditProfileScreen.tsx`) — hardening plus the telemetry that identifies the producer. Not a claimed fix.** The fallback re-reads the picker's own crop through **the same `File.bytes()` API that is the prime suspect.** If that API is what returns empty, both reads come back empty, the new guard fires, and the user gets a `compressionFailed` toast — a silent failure made loud, not a fixed one.

### Blocking pre-merge gate

Run this branch on a real device or simulator on SDK 57, pick a photo, and read the `avatar-compress` telemetry:

- **`compressedBytes: 0`, `originalBytes: > 0` → World A.** The encode is what fails, the fallback rescues it, and **this branch fixes #4228.** Close the issue.
- **`compressedBytes: 0`, `originalBytes: 0` → World B.** `File.bytes()` is broken under SDK 57. **This branch does NOT fix #4228.** The real fix is to stop routing the upload through `File.bytes()` — `fetch(uri).then(r => r.bytes())`, a real `Blob`, or `FileSystem.readAsStringAsync` + base64 decode — and #4228 stays open.

That `compressedBytes` / `originalBytes` pair is the main reason the mobile half is worth landing at all.

**Telemetry silence is not a pass.** The telemetry only fires on the failure path — a non-empty compressed read returns early and reports nothing. So a producer *downstream* of the read looks identical to "fixed", and Expo's WinterCG multipart encoder is exactly such a place: `results.push(await entry.bytes())`, no length check. Add the byte check to the gate:

```
curl -s -o /dev/null -w '%{http_code} %{size_download}\n' "<stored avatarUrl>&size=128&cb=$RANDOM"
```

**Pass = non-zero `size_download`.** `200 0` means the avatar is still empty and #4228 is still live whatever Sentry shows. Take the URL from the stored profile row, not the edit screen's preview — that renders the local file and always looks right.

**This was not verified here.** The work was done on Linux, which cannot settle it, and `vp run check:mobile-bundle` cannot settle it either.

### Scope changes in this rebase

- **Dropped** the `packages/web/app/settings/settings-page-content.tsx` hunks. `3d8dde3fb` removed the `/settings` avatar uploader they guarded, and `settings-scope-down.test.ts` asserts it stays gone. The single rebase conflict was resolved by taking `main`'s file.
- **Not included:** the `PUT /api/internal/profile` full-row-wipe fix. It is a real data-loss footgun but unrelated to this issue, and it is a behaviour change on a documented public route. Filed as #4725 for its own PR.

### Closes nothing automatically

No auto-close keyword here, deliberately. #4228 stays open pending the device gate above.

**#4532 is already closed** — `NOT_PLANNED`, on 2026-08-24, about half an hour before this rebase was pushed. An auto-close keyword would have been inert on it and left a false paper trail claiming this PR resolved it, which is the other reason it is gone.

It is also probably the wrong issue to attach to this work: that reporter's row measured **`avatar_url IS NULL`** with `display_name` set — the signature of #4726 (a failed upload that still reports "Profile saved"), not a populated URL pointing at an empty object. Their user prefix matches none of the 156 avatar URLs.

Worth someone's call: #4532 is the only issue carrying the reporter contact (`app_feedback #10204`, reporter agreed to follow up), and `NOT_PLANNED` is the wrong reason for a reproducible bug whose written fix has never reached `main`. Reopening it and relabelling it against #4726 would keep that thread reachable.

Filed alongside this: #4724 (83 avatars 404), #4725 (destructive PUT), #4726 (a failed upload still says "Profile saved" — likely what the one identified reporter actually hit, whose row is `avatar_url IS NULL` rather than a zero-byte object).

**No production data was modified.** With the `static.ts` guard the 39 broken rows degrade to initials on their own and a re-upload repairs them.

### Known limitation, not fixed here

The beta-thumbnail `no-store` protects a repair path that does not currently exist. `enrichRow` short-circuits on `isOurS3Url(row.thumbnail)` (`beta-videos/queries.ts:183`, `:192`) and `recentBetaLinks` serves a Redis-cached CTE already filtered to the static prefix, so a row whose column points at our prefix never re-fetches. If one thumbnail object goes missing, its card sits in the home-page recent-beta rail costing an uncacheable origin request plus a Tigris `GetObject` on every render, for every anonymous visitor, indefinitely — and nothing can repair the key.

Left as-is rather than redesigned here: the fix is either `public, max-age=300` on that branch, or clearing `beta_links.thumbnail` when the object is absent so `enrichRow` stops short-circuiting. Filed separately rather than widened into this PR.

## Release Notes

- Your profile pic sticks now — a photo that failed to compress was saving as an empty image, so it vanished the moment you left the screen.

## Test plan

Run in `/home/developer/projects/boardsesh/4228-avatar` on the rebased branch:

| command | result |
| --- | --- |
| `vp check` | pass — 0 errors, 4477 files |
| `vp run typecheck` | pass |
| `vp run typecheck:mobile` | pass |
| `vp run test:mobile` | pass — 701 files, 6940 tests |
| `vp test run --reporter=agent --project backend avatar` | pass — 4 files, 17 tests |
| `vp test run --reporter=agent --project backend avatar beta-link static` | pass — 11 files, 115 tests |
| `vp run check:mobile-bundle` | pass — Android bundle OK |

Two guards are mutation-tested: reverting the `?size=` no-store to a plain 404 fails its regression test, and reverting the fallback's byte-sniff to the declared MIME type alone fails the new picker-reported-no-type test. Both pass restored.

### Review fixes in this round

- The device gate could be passed by a bug it cannot see — telemetry only fires on the failure path. Added the byte check above, in the PR body and in `.boardsesh/qa-notes.md`.
- The fallback refused a good crop whenever `asset.mimeType` was undefined, forfeiting the exact rescue it exists for. Now sniffs JPEG/PNG/GIF/WebP from the leading bytes.
- `compressionFailed` ("try a smaller image") misadvised two of its three triggers. Split into `avatarUnreadable` and `avatarFormatUnsupported`, added to all four locales, branched on the error's reason.
- Corrected the `sendNotFound` JSDoc: missing avatars are 53% of stored URLs, not rare, and the `v=<timestamp>` cache-buster — not `no-store` — is what lets a re-upload land.
- Added `compressed_read` tag and `declaredType` extra so triage can tell an empty read from a throw, and see a refused format.

The full unscoped `--project backend` run wedged repeatedly against the shared local postgres/redis that other work is using concurrently; the scoped runs above cover every backend file this branch changes, and CI's isolated run is the authority.

Not verified: the device gate above. That is the one thing standing between this and merge.
