### PR TITLE
fix(db): stamp the dev-db migration ledger with journal timestamps, not the build clock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -805,10 +805,10 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       # The pinned image's ledger was stamped with the image build clock, not
-      # each journal entry's `when` (#4211). That is a high-water mark drizzle
-      # can never clear, so without this repair the next step silently skips
-      # every migration written after the image was built — including the one a
-      # PR is adding. Must stay ahead of db:migrate.
+      # each journal entry's `when` (#4211). That mark only moves up, so without
+      # this repair the next step silently skips any journal entry whose `when`
+      # predates the pinned image's build — including a PR's own migration when
+      # the branch is older than the pin. Must stay ahead of db:migrate.
       - name: Normalize the dev-db image migration ledger
         env:
           DATABASE_URL: postgres://postgres:password@localhost:5432/main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -804,6 +804,15 @@ jobs:
           cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
+      # The pinned image's ledger was stamped with the image build clock, not
+      # each journal entry's `when` (#4211). That is a high-water mark drizzle
+      # can never clear, so without this repair the next step silently skips
+      # every migration written after the image was built — including the one a
+      # PR is adding. Must stay ahead of db:migrate.
+      - name: Normalize the dev-db image migration ledger
+        env:
+          DATABASE_URL: postgres://postgres:password@localhost:5432/main
+        run: bun run --filter=@boardsesh/db db:normalize-ledger
       - name: Apply the full migration journal
         env:
           DATABASE_URL: postgres://postgres:password@localhost:5432/main

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -323,9 +323,11 @@ jobs:
 
       # The dev-db image's ledger was stamped with its build clock, not each
       # journal entry's `when` (#4211). drizzle-kit migrate reads max(created_at)
-      # once and applies only entries above it, so without this repair a PR's new
-      # migration silently never runs here and surfaces as an unrelated-looking
-      # app failure. Must stay ahead of the migrate step.
+      # once and applies only entries above it, so a PR's migration is skipped
+      # whenever it was generated before the image was built — and this job runs
+      # `:latest`, rebuilt on every db-touching merge to main, so that is most
+      # open PRs. It surfaces as an unrelated-looking app failure rather than a
+      # migration error. Must stay ahead of the migrate step.
       - name: Normalize the dev-db image migration ledger
         run: bun run --filter=@boardsesh/db db:normalize-ledger
         env:
@@ -582,8 +584,9 @@ jobs:
           rm built-packages.tar
 
       # Same repair as the shard job above: the image's ledger high-water mark is
-      # a build timestamp, so drizzle-kit migrate would skip a PR's new migration
-      # (#4211). Must stay ahead of the migrate step.
+      # its build timestamp, so drizzle-kit migrate would skip a PR's migration
+      # whenever the branch predates the `:latest` image (#4211). Must stay ahead
+      # of the migrate step.
       - name: Normalize the dev-db image migration ledger
         run: bun run --filter=@boardsesh/db db:normalize-ledger
         env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -321,6 +321,16 @@ jobs:
           tar -xf built-packages.tar
           rm built-packages.tar
 
+      # The dev-db image's ledger was stamped with its build clock, not each
+      # journal entry's `when` (#4211). drizzle-kit migrate reads max(created_at)
+      # once and applies only entries above it, so without this repair a PR's new
+      # migration silently never runs here and surfaces as an unrelated-looking
+      # app failure. Must stay ahead of the migrate step.
+      - name: Normalize the dev-db image migration ledger
+        run: bun run --filter=@boardsesh/db db:normalize-ledger
+        env:
+          DATABASE_URL: postgresql://postgres:password@postgres:5432/main
+
       - name: Run database migrations
         run: bunx drizzle-kit migrate
         working-directory: packages/db
@@ -570,6 +580,14 @@ jobs:
         run: |
           tar -xf built-packages.tar
           rm built-packages.tar
+
+      # Same repair as the shard job above: the image's ledger high-water mark is
+      # a build timestamp, so drizzle-kit migrate would skip a PR's new migration
+      # (#4211). Must stay ahead of the migrate step.
+      - name: Normalize the dev-db image migration ledger
+        run: bun run --filter=@boardsesh/db db:normalize-ledger
+        env:
+          DATABASE_URL: postgresql://postgres:password@postgres:5432/main
 
       - name: Run database migrations
         run: bunx drizzle-kit migrate

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -123,8 +123,33 @@ later died on `relation "location_sync_gym_sources" does not exist`.
 With `VERIFY_MIGRATION_JOURNAL=1`, `packages/db/scripts/migrate.ts` now checks **every**
 journal entry against the ledger, keyed on the migration hash, and throws with the missing
 tags named. `production-deploy.yml` and `db-migration-renumber.yml` both set it. It stays
-opt-in for now because the `boardsesh-dev-db` image is missing `0187_sad_freak`'s ledger
-row, so a default-on check would redden every developer's `vp run db:migrate`.
+opt-in, because a dev database can still carry gaps the developer did not cause and a
+default-on check would redden every `vp run db:migrate`.
+
+#### Ledger timestamps on the dev DB (`vp run db:normalize-ledger`)
+
+The `boardsesh-dev-db` image applies the journal itself, in a psql loop. Until #4211 it
+stamped each ledger row with the image's **build clock** instead of the journal entry's
+`when`, which put the high-water mark years above every journal entry — so the next
+migration anyone wrote was skipped on that database forever. `vp run db:migrate` said
+nothing, the table never appeared, and `db:verify-journal` reported it as a real gap.
+
+The image now writes `when`, and fails its own build if the ledger's high-water mark is not
+the journal's newest `when`. That only helps images built after the fix, though: CI pins a
+digest and developers keep a persistent `db_data` volume. So a database already on disk is
+repaired in place:
+
+```
+DATABASE_URL=postgres://... vp run db:normalize-ledger        # add -- --dry-run to plan only
+```
+
+It rewrites `created_at` to each entry's `when` — exactly the value drizzle writes itself —
+so it is a no-op on any drizzle-managed database, and it refuses a non-local target without
+`--force`. `vp run db:up` runs it automatically, as do the CI jobs that boot the image. One
+gap: the tailnet/remote fast path in `scripts/dev-db-up.sh` returns before that point, so on
+a shared remote dev DB run the command by hand once.
+
+A gate firing on a dev database is therefore a real gap again, not ledger noise.
 
 Run it read-only against any database, without applying anything:
 

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -130,9 +130,17 @@ default-on check would redden every `vp run db:migrate`.
 
 The `boardsesh-dev-db` image applies the journal itself, in a psql loop. Until #4211 it
 stamped each ledger row with the image's **build clock** instead of the journal entry's
-`when`, which put the high-water mark years above every journal entry — so the next
-migration anyone wrote was skipped on that database forever. `vp run db:migrate` said
-nothing, the table never appeared, and `db:verify-journal` reported it as a real gap.
+`when`, which drags the high-water mark forward to the moment the image was built.
+
+What that skips is not the newest migrations — a migration generated today has a `when`
+later than any image built yesterday, so it still applies. It is the migrations whose `when`
+sits _below_ the build clock and that the image did not itself apply: a branch's migration,
+generated before the image was built and applied to that database afterwards. On the two e2e
+jobs, which run `boardsesh-dev-db:latest`, that is most open PRs — the image is rebuilt on
+every db-touching merge to `main`, so any branch older than the last such merge lands under
+the mark. The migration is skipped with no error at all: `vp run db:migrate` says nothing,
+the table never appears, and `db:verify-journal` reports it as a real gap. The mark only ever
+moves up, so it never recovers.
 
 The image now writes `when`, and fails its own build if the ledger's high-water mark is not
 the journal's newest `when`. That only helps images built after the fix, though: CI pins a

--- a/packages/db/docker/Dockerfile.dev-db
+++ b/packages/db/docker/Dockerfile.dev-db
@@ -243,20 +243,29 @@ RUN set -e && \
     gosu postgres psql -h /var/run/postgresql main -v ON_ERROR_STOP=1 -c "CREATE TABLE IF NOT EXISTS \"__drizzle_migrations\" (id SERIAL PRIMARY KEY, hash text NOT NULL, created_at bigint)" && \
     gosu postgres psql -h /var/run/postgresql main -v ON_ERROR_STOP=1 -c "CREATE SCHEMA IF NOT EXISTS drizzle" && \
     gosu postgres psql -h /var/run/postgresql main -v ON_ERROR_STOP=1 -c "CREATE TABLE IF NOT EXISTS drizzle.\"__drizzle_migrations\" (id SERIAL PRIMARY KEY, hash text NOT NULL, created_at bigint)" && \
+    # created_at is the journal entry's own `when`, never the build clock (#4211). \
+    # drizzle's migrate() reads max(created_at) once and applies only entries \
+    # whose `when` is strictly greater, so a build timestamp would become a \
+    # high-water mark no later migration can clear — every migration added after \
+    # the image was built would be skipped on that database forever. `when` is \
+    # exactly what drizzle writes itself (it inserts folderMillis, which it copies \
+    # from the journal's `when`). \
     applied=0 && \
-    for tag in $(jq -r '.entries[].tag' /drizzle/meta/_journal.json); do \
+    jq -r '.entries[] | "\(.tag) \(.when)"' /drizzle/meta/_journal.json > /tmp/journal_entries.txt && \
+    while read -r tag when; do \
       sql_file="/drizzle/${tag}.sql"; \
       if [ -f "$sql_file" ]; then \
         hash=$(sha256sum "$sql_file" | cut -d' ' -f1); \
         applied=$((applied + 1)); \
         echo "  [$applied/$migration_count] Applying: $tag"; \
         gosu postgres psql -h /var/run/postgresql main -v ON_ERROR_STOP=1 -f "$sql_file" || { echo "  WARNING: migration $tag had errors, continuing..."; true; }; \
-        gosu postgres psql -h /var/run/postgresql main -v ON_ERROR_STOP=1 -c "INSERT INTO \"__drizzle_migrations\" (hash, created_at) VALUES ('$hash', $(date +%s)000)" && \
-        gosu postgres psql -h /var/run/postgresql main -v ON_ERROR_STOP=1 -c "INSERT INTO drizzle.\"__drizzle_migrations\" (hash, created_at) VALUES ('$hash', $(date +%s)000)"; \
+        gosu postgres psql -h /var/run/postgresql main -v ON_ERROR_STOP=1 -c "INSERT INTO \"__drizzle_migrations\" (hash, created_at) VALUES ('$hash', $when)" && \
+        gosu postgres psql -h /var/run/postgresql main -v ON_ERROR_STOP=1 -c "INSERT INTO drizzle.\"__drizzle_migrations\" (hash, created_at) VALUES ('$hash', $when)"; \
       else \
         echo "  ERROR: Migration file not found: $sql_file" && false; \
       fi; \
-    done && \
+    done < /tmp/journal_entries.txt && \
+    rm -f /tmp/journal_entries.txt && \
     echo ">>> All $applied migrations applied successfully." && \
     \
     # ── Verify database state ────────────────────────────────────────── \
@@ -267,6 +276,16 @@ RUN set -e && \
     echo "  Public tables: $table_count" && \
     if [ "$recorded" -ne "$migration_count" ]; then \
       echo "ERROR: Migration count mismatch! Expected $migration_count, got $recorded" && false; \
+    fi && \
+    \
+    # The ledger's high-water mark must equal the journal's newest `when`, or \
+    # this image ships a database that silently skips the next migration anyone \
+    # writes (#4211). One psql call, and it makes that regression unshippable. \
+    ledger_max=$(gosu postgres psql -h /var/run/postgresql main -t -A -c "SELECT COALESCE(max(created_at), 0) FROM drizzle.\"__drizzle_migrations\"") && \
+    journal_max=$(jq -r '[.entries[].when] | max' /drizzle/meta/_journal.json) && \
+    echo "  Ledger high-water mark: $ledger_max (journal newest when: $journal_max)" && \
+    if [ "$ledger_max" != "$journal_max" ]; then \
+      echo "ERROR: ledger created_at high-water mark $ledger_max != journal newest when $journal_max — drizzle would skip later migrations" && false; \
     fi && \
     \
     # ── Import direct Aurora boards into unified tables ──────────────── \

--- a/packages/db/docker/Dockerfile.dev-db
+++ b/packages/db/docker/Dockerfile.dev-db
@@ -246,8 +246,10 @@ RUN set -e && \
     # created_at is the journal entry's own `when`, never the build clock (#4211). \
     # drizzle's migrate() reads max(created_at) once and applies only entries \
     # whose `when` is strictly greater, so a build timestamp would become a \
-    # high-water mark no later migration can clear — every migration added after \
-    # the image was built would be skipped on that database forever. `when` is \
+    # high-water mark that only moves up — and every journal entry with an \
+    # earlier `when` that this loop did not apply (a branch's migration, written \
+    # before this image was built) would be skipped on that database for good. \
+    # `when` is \
     # exactly what drizzle writes itself (it inserts folderMillis, which it copies \
     # from the journal's `when`). \
     applied=0 && \

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -79,6 +79,7 @@
     "test:explain": "tsx --test src/queries/climbs/__tests__/search-climbs-explain.integration.test.ts",
     "test:migration-journal": "tsx --test scripts/migration-journal-verification.integration.test.ts",
     "db:verify-journal": "tsx scripts/verify-migration-journal.ts",
+    "db:normalize-ledger": "tsx scripts/normalize-ledger-timestamps.ts",
     "db:studio": "drizzle-kit studio",
     "db:import-moonboard": "tsx scripts/import-moonboard-problems.ts",
     "db:import-moonboard-2024": "tsx scripts/import-moonboard-2024.ts",

--- a/packages/db/scripts/migration-journal-verification.integration.test.ts
+++ b/packages/db/scripts/migration-journal-verification.integration.test.ts
@@ -27,6 +27,7 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
 import { findUnappliedMigrations } from '../../../scripts/lib/migration-ledger.js';
 import { PRODUCTION_LEDGER_BASELINE, type LedgerBaseline } from '../../../scripts/lib/migration-ledger-baseline.js';
+import { DRIZZLE_LEDGER_TABLE, normalizeLedgerTable } from './normalize-ledger-timestamps.js';
 import {
   DRIZZLE_MIGRATIONS_FOLDER,
   assertMigrationJournalApplied,
@@ -603,6 +604,101 @@ describe('migration journal verification (#2933)', () => {
         `${spelling} must resolve to the production baseline`,
       );
     }
+  });
+
+  it('unblocks a build-clock-stamped ledger so drizzle applies the next migration (#4211)', async (context) => {
+    const adminUrl = localDatabaseUrl();
+    if (!adminUrl) {
+      context.skip('set DATABASE_URL to a local Postgres to run');
+      return;
+    }
+    // The dev-db image's exact shape: the journal is applied by a psql loop that
+    // stamps every ledger row with the image's build clock instead of the
+    // entry's `when`. That single value is a high-water mark drizzle can never
+    // clear, so every migration written after the image was built is skipped —
+    // on that deploy and on every one after it.
+    const migrationsFolder = makeTempFolder('build-clock');
+    const scratchUrl = await createScratchDatabase(adminUrl, 'build_clock');
+    writeMigrationsFolder(migrationsFolder, PHASE_ONE);
+    await applyMigrations(scratchUrl, migrationsFolder);
+
+    // As drizzle left it, there is nothing to repair — the normaliser writes the
+    // same value drizzle already wrote.
+    const drizzleManagedPlan = await withScratchClient(scratchUrl, (client) =>
+      normalizeLedgerTable(client, DRIZZLE_LEDGER_TABLE, readExpectedMigrations(migrationsFolder), { dryRun: true }),
+    );
+    assert.deepEqual(drizzleManagedPlan, [], 'a drizzle-managed ledger must need no repair');
+
+    const BUILD_CLOCK = 1_800_000_000_000;
+    await withScratchClient(scratchUrl, async (client) => {
+      await client`UPDATE drizzle."__drizzle_migrations" SET created_at = ${BUILD_CLOCK}`;
+    });
+
+    // A new migration lands, appended above every journal `when` but far below
+    // the build clock.
+    const laterEntry = { tag: '0002_later', when: 4000, sql: 'CREATE TABLE mjv_t_later (id int);' };
+    writeMigrationsFolder(migrationsFolder, [...PHASE_ONE, laterEntry]);
+    await applyMigrations(scratchUrl, migrationsFolder);
+
+    assert.equal(
+      await tableExists(scratchUrl, 'mjv_t_later'),
+      false,
+      'the build-clock high-water mark is expected to make drizzle skip the new migration',
+    );
+    await assert.rejects(
+      withScratchClient(scratchUrl, (client) =>
+        assertMigrationJournalApplied(readLedgerHashesWith(client), migrationsFolder),
+      ),
+      /0002_later/,
+      'the gate must see the skip as a real gap',
+    );
+
+    // The repair: rewrite created_at to each entry's own `when`.
+    const repairs = await withScratchClient(scratchUrl, (client) =>
+      normalizeLedgerTable(client, DRIZZLE_LEDGER_TABLE, readExpectedMigrations(migrationsFolder)),
+    );
+    assert.deepEqual(
+      repairs.map((repair) => ({ tag: repair.tag, to: repair.to })),
+      [
+        { tag: '0000_a', to: 1000 },
+        { tag: '0001_b', to: 3000 },
+      ],
+      'only the two rows the image stamped exist, and each takes its own journal when',
+    );
+
+    await applyMigrations(scratchUrl, migrationsFolder);
+    assert.equal(await tableExists(scratchUrl, 'mjv_t_later'), true, 'the repaired ledger must let the migration run');
+    await assert.doesNotReject(
+      withScratchClient(scratchUrl, (client) =>
+        assertMigrationJournalApplied(readLedgerHashesWith(client), migrationsFolder),
+      ),
+    );
+
+    // And drizzle's own row for the newly applied migration already carries the
+    // journal `when`, so a second pass finds nothing to do.
+    const secondPass = await withScratchClient(scratchUrl, (client) =>
+      normalizeLedgerTable(client, DRIZZLE_LEDGER_TABLE, readExpectedMigrations(migrationsFolder), { dryRun: true }),
+    );
+    assert.deepEqual(secondPass, [], 'the repair must be idempotent');
+  });
+
+  it('leaves a ledger table it cannot find alone (#4211)', async (context) => {
+    const adminUrl = localDatabaseUrl();
+    if (!adminUrl) {
+      context.skip('set DATABASE_URL to a local Postgres to run');
+      return;
+    }
+    // Older images have no legacy public."__drizzle_migrations" (and a brand new
+    // database has no drizzle schema at all). `vp run db:up` runs the normaliser
+    // unconditionally, so an absent table must be a quiet no-op, not a crash.
+    const migrationsFolder = makeTempFolder('absent-table');
+    const scratchUrl = await createScratchDatabase(adminUrl, 'absent_table');
+    writeMigrationsFolder(migrationsFolder, PHASE_ONE);
+
+    const plan = await withScratchClient(scratchUrl, (client) =>
+      normalizeLedgerTable(client, DRIZZLE_LEDGER_TABLE, readExpectedMigrations(migrationsFolder)),
+    );
+    assert.deepEqual(plan, []);
   });
 
   it('keeps findUnappliedMigrations multiset-aware for byte-identical migrations', () => {

--- a/packages/db/scripts/migration-journal-verification.integration.test.ts
+++ b/packages/db/scripts/migration-journal-verification.integration.test.ts
@@ -614,9 +614,11 @@ describe('migration journal verification (#2933)', () => {
     }
     // The dev-db image's exact shape: the journal is applied by a psql loop that
     // stamps every ledger row with the image's build clock instead of the
-    // entry's `when`. That single value is a high-water mark drizzle can never
-    // clear, so every migration written after the image was built is skipped —
-    // on that deploy and on every one after it.
+    // entry's `when`. That single value becomes a high-water mark that only ever
+    // moves up, so every journal entry with an earlier `when` that the image did
+    // not itself apply — `0002_later` below, standing in for a branch's
+    // migration written before the image was built — is skipped on that deploy
+    // and on every one after it.
     const migrationsFolder = makeTempFolder('build-clock');
     const scratchUrl = await createScratchDatabase(adminUrl, 'build_clock');
     writeMigrationsFolder(migrationsFolder, PHASE_ONE);

--- a/packages/db/scripts/migration-journal.ts
+++ b/packages/db/scripts/migration-journal.ts
@@ -9,6 +9,7 @@ import {
   formatMigrationGapError,
   partitionMissingMigrations,
   type ExpectedMigration,
+  type ExpectedMigrationWithWhen,
 } from '../../../scripts/lib/migration-ledger.js';
 import {
   EMPTY_LEDGER_BASELINE,
@@ -141,7 +142,7 @@ export function readExpectedMigrations(
   readFiles: (config: {
     migrationsFolder: string;
   }) => readonly { folderMillis: number; hash: string }[] = readMigrationFiles,
-): ExpectedMigration[] {
+): ExpectedMigrationWithWhen[] {
   const journalPath = path.join(migrationsFolder, 'meta', '_journal.json');
   const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8')) as MigrationJournal;
   const migrationFiles = readFiles({ migrationsFolder });
@@ -160,7 +161,12 @@ export function readExpectedMigrations(
           `when ${journalEntry.when}. readMigrationFiles no longer returns journal order.`,
       );
     }
-    return { tag: journalEntry.tag, hash: migrationFile.hash };
+    // `when` rides along for `normalize-ledger-timestamps.ts`: it is the exact
+    // value drizzle stamps into `created_at` (it inserts `folderMillis`, which
+    // the assertion just above pins to this same `when`), so the normaliser
+    // never has to re-derive a timestamp any more than this module re-derives a
+    // hash.
+    return { tag: journalEntry.tag, hash: migrationFile.hash, when: journalEntry.when };
   });
 }
 

--- a/packages/db/scripts/normalize-ledger-timestamps.ts
+++ b/packages/db/scripts/normalize-ledger-timestamps.ts
@@ -6,10 +6,14 @@
  * psql loop and stamps both ledger tables with the image's *build* wall clock
  * (`$(date +%s)000`). Drizzle's applier is a single high-water mark — it reads
  * `max(created_at)` once and applies only entries whose `when` is strictly
- * greater — so a build timestamp sitting ~13 orders of magnitude of wall clock
- * above every journal `when` means the next migration anyone adds is skipped on
- * that database forever. `vp run db:migrate` reports success, the table never
- * appears, and `VERIFY_MIGRATION_JOURNAL=1` (correctly) calls it a gap.
+ * greater — so that build timestamp becomes the mark, and every journal entry
+ * whose `when` predates the image build but which the image did not itself apply
+ * is skipped. Concretely, that is a branch's migration generated before the
+ * image was built: on the e2e jobs, which run `:latest`, most open PRs. (Not the
+ * newest migrations — a `when` later than the build clock still applies, which
+ * is why the bug reads as intermittent.) `vp run db:migrate` reports success,
+ * the table never appears, and `VERIFY_MIGRATION_JOURNAL=1` (correctly) calls it
+ * a gap. The mark only ever moves up, so the skip is permanent.
  *
  * `Dockerfile.dev-db` now stamps `when`, but that only helps images built after
  * this lands: CI pins a digest and developers keep a persistent `db_data`

--- a/packages/db/scripts/normalize-ledger-timestamps.ts
+++ b/packages/db/scripts/normalize-ledger-timestamps.ts
@@ -1,0 +1,177 @@
+/**
+ * Repairs `created_at` in drizzle's applied-migration ledger so every row
+ * carries its journal entry's `when` — the value drizzle itself writes.
+ *
+ * Why this exists (#4211): the `boardsesh-dev-db` image applies the journal in a
+ * psql loop and stamps both ledger tables with the image's *build* wall clock
+ * (`$(date +%s)000`). Drizzle's applier is a single high-water mark — it reads
+ * `max(created_at)` once and applies only entries whose `when` is strictly
+ * greater — so a build timestamp sitting ~13 orders of magnitude of wall clock
+ * above every journal `when` means the next migration anyone adds is skipped on
+ * that database forever. `vp run db:migrate` reports success, the table never
+ * appears, and `VERIFY_MIGRATION_JOURNAL=1` (correctly) calls it a gap.
+ *
+ * `Dockerfile.dev-db` now stamps `when`, but that only helps images built after
+ * this lands: CI pins a digest and developers keep a persistent `db_data`
+ * volume. This script fixes what is already on disk, in place.
+ *
+ * It is a *dev/CI* tool. Production's ledger is written by drizzle and is
+ * already `when`-valued, so there is nothing to repair there — the URL guard
+ * below refuses a non-local target unless `--force`, so this can never be
+ * mistaken for a production ledger-mutation tool.
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://… vp run db:normalize-ledger
+ *   DATABASE_URL=postgres://… vp run db:normalize-ledger -- --dry-run
+ */
+import postgres from 'postgres';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describeDatabaseHost, getScriptDatabaseUrl, isLocalDatabaseUrl } from './db-connection.js';
+import { readExpectedMigrations } from './migration-journal.js';
+import {
+  planLedgerTimestampRepairs,
+  type ExpectedMigrationWithWhen,
+  type LedgerTimestampRepair,
+  type LedgerTimestampRow,
+} from '../../../scripts/lib/migration-ledger.js';
+
+/** A ledger table, qualified. Both are literals in this module — never user input. */
+export interface LedgerTable {
+  schema: string;
+  table: string;
+}
+
+/** Where drizzle 0.45 keeps the ledger. */
+export const DRIZZLE_LEDGER_TABLE: LedgerTable = { schema: 'drizzle', table: '__drizzle_migrations' };
+
+/**
+ * Where older drizzle kept it, and where the dev-db image still writes a copy.
+ * `scripts/dev-db-up.sh`'s `sync_drizzle_migration_tracker` seeds the drizzle
+ * table from this one when the drizzle table is empty, so leaving this one
+ * build-stamped would re-introduce the bad high-water mark on the next fresh
+ * volume.
+ */
+export const LEGACY_LEDGER_TABLE: LedgerTable = { schema: 'public', table: '__drizzle_migrations' };
+
+function qualify(table: LedgerTable): string {
+  return `"${table.schema}"."${table.table}"`;
+}
+
+/** Postgres client surface this module needs. Narrow on purpose so tests can pass a scratch client. */
+export type LedgerClient = Pick<postgres.Sql, 'unsafe' | 'begin'>;
+
+/** False when the table does not exist — an older image has no `drizzle` schema at all. */
+export async function ledgerTableExists(client: LedgerClient, table: LedgerTable): Promise<boolean> {
+  const rows = await client.unsafe<{ present: string | null }[]>('SELECT to_regclass($1)::text AS present', [
+    `${table.schema}.${table.table}`,
+  ]);
+  return rows[0]?.present != null;
+}
+
+/**
+ * `id`-ordered ledger rows. `created_at` is a bigint, which postgres.js hands
+ * back as a string, so it is converted here rather than in the pure planner.
+ */
+export async function readLedgerTimestampRows(client: LedgerClient, table: LedgerTable): Promise<LedgerTimestampRow[]> {
+  const rows = await client.unsafe<{ id: number; hash: string; created_at: string | number | null }[]>(
+    `SELECT id, hash, created_at FROM ${qualify(table)} ORDER BY id`,
+  );
+  return rows.map((row) => ({ id: Number(row.id), hash: row.hash, createdAt: Number(row.created_at ?? 0) }));
+}
+
+/**
+ * Applies the whole plan in one transaction: a half-repaired ledger has a
+ * high-water mark nobody predicted, which is the failure mode this fixes.
+ */
+export async function applyLedgerTimestampRepairs(
+  client: LedgerClient,
+  table: LedgerTable,
+  repairs: readonly LedgerTimestampRepair[],
+): Promise<void> {
+  if (repairs.length === 0) return;
+  await client.begin(async (tx) => {
+    for (const repair of repairs) {
+      await tx.unsafe(`UPDATE ${qualify(table)} SET created_at = $1 WHERE id = $2`, [repair.to, repair.id]);
+    }
+  });
+}
+
+/**
+ * Plan-and-apply for one table. Returns the plan (empty when the table is
+ * absent or already correct) so callers can report it.
+ */
+export async function normalizeLedgerTable(
+  client: LedgerClient,
+  table: LedgerTable,
+  expected: readonly ExpectedMigrationWithWhen[],
+  options: { dryRun?: boolean } = {},
+): Promise<LedgerTimestampRepair[]> {
+  if (!(await ledgerTableExists(client, table))) return [];
+  const repairs = planLedgerTimestampRepairs(expected, await readLedgerTimestampRows(client, table));
+  if (!options.dryRun) {
+    await applyLedgerTimestampRepairs(client, table, repairs);
+  }
+  return repairs;
+}
+
+function reportTable(table: LedgerTable, repairs: readonly LedgerTimestampRepair[], dryRun: boolean): void {
+  const qualified = `${table.schema}.${table.table}`;
+  if (repairs.length === 0) {
+    console.info(`   ${qualified}: already carries the journal's timestamps.`);
+    return;
+  }
+  console.info(`   ${qualified}: ${dryRun ? 'would repair' : 'repaired'} ${repairs.length} row(s).`);
+  for (const repair of repairs) {
+    console.info(`     • ${repair.tag}: ${repair.from} → ${repair.to}`);
+  }
+}
+
+async function normalizeLedgerTimestamps(argv: readonly string[]): Promise<void> {
+  const dryRun = argv.includes('--dry-run');
+  const force = argv.includes('--force');
+  const databaseUrl = getScriptDatabaseUrl();
+
+  if (!isLocalDatabaseUrl(databaseUrl) && !force) {
+    console.error(
+      `❌ Refusing to normalise the migration ledger on ${describeDatabaseHost(databaseUrl)}: this is a dev/CI ` +
+        'repair for databases whose ledger was stamped by something other than drizzle. Production ledgers are ' +
+        'already written by drizzle. Pass --force if you are certain.',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.info(
+    `🕒 Normalising migration ledger timestamps on: ${describeDatabaseHost(databaseUrl)}${dryRun ? ' (dry run)' : ''}`,
+  );
+
+  const client = postgres(databaseUrl, { max: 1 });
+  try {
+    const expected = readExpectedMigrations();
+    let repairedRows = 0;
+    for (const table of [DRIZZLE_LEDGER_TABLE, LEGACY_LEDGER_TABLE]) {
+      const repairs = await normalizeLedgerTable(client, table, expected, { dryRun });
+      repairedRows += repairs.length;
+      reportTable(table, repairs, dryRun);
+    }
+    console.info(
+      repairedRows === 0
+        ? '✅ Nothing to repair — every ledger row already carries its journal `when`.'
+        : `✅ ${dryRun ? 'Planned' : 'Wrote'} ${repairedRows} ledger timestamp repair(s).`,
+    );
+  } catch (error) {
+    console.error('❌ Migration ledger timestamp normalisation failed:', error);
+    process.exitCode = 1;
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+// Only when run as a script. The exported helpers above are imported by
+// packages/db/scripts/migration-journal-verification.integration.test.ts, which
+// must not connect to the developer's dev database on import.
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+if (invokedPath === path.resolve(fileURLToPath(import.meta.url))) {
+  void normalizeLedgerTimestamps(process.argv.slice(2));
+}

--- a/scripts/__tests__/ci-location-sync-workflow.test.ts
+++ b/scripts/__tests__/ci-location-sync-workflow.test.ts
@@ -82,6 +82,17 @@ describe('location-sync CI integration contract', () => {
     expect(integrationJob).not.toContain('--changed');
   });
 
+  it('repairs the image ledger timestamps before applying the journal', () => {
+    // The pinned image stamps `created_at` with its build clock (#4211), which is
+    // a high-water mark drizzle can never clear. Ordered after db:migrate the
+    // repair is useless: the migrations it would have unblocked are already
+    // skipped by then, and the ledger only ever moves up.
+    const normalizeIndex = integrationJob.indexOf('run: bun run --filter=@boardsesh/db db:normalize-ledger');
+    const migrateIndex = integrationJob.indexOf('run: bun run --filter=@boardsesh/db db:migrate');
+    expect(normalizeIndex).toBeGreaterThan(-1);
+    expect(migrateIndex).toBeGreaterThan(normalizeIndex);
+  });
+
   it('publishes JUnit and makes both report and aggregate status depend on the job', () => {
     expect(integrationJob).toContain('--reporter=junit');
     expect(integrationJob).toContain('name: test-results-location-sync');

--- a/scripts/__tests__/dev-db-image-ledger.test.ts
+++ b/scripts/__tests__/dev-db-image-ledger.test.ts
@@ -1,0 +1,53 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * File-text guard for #4211.
+ *
+ * `Dockerfile.dev-db` applies the migration journal in a psql loop and writes
+ * drizzle's ledger by hand. It used to stamp `created_at` with the image's build
+ * clock, which becomes a high-water mark drizzle's applier can never clear — so
+ * every migration written after the image was built is silently skipped on that
+ * database, forever.
+ *
+ * Building the image to check this takes tens of minutes and hits the network
+ * hard (six APK downloads, pgloader, the MoonBoard import), so the practical
+ * coverage is this text guard plus the in-build assertion it requires: the
+ * ledger's high-water mark must equal the journal's newest `when`.
+ */
+const DOCKERFILE_PATH = 'packages/db/docker/Dockerfile.dev-db';
+const dockerfileSource = readFileSync(DOCKERFILE_PATH, 'utf8');
+
+/** Non-comment lines only — the `date +%s` ban must not be satisfiable by a comment. */
+const executableLines = dockerfileSource
+  .split('\n')
+  .filter((line) => !line.trimStart().startsWith('#'))
+  .join('\n');
+
+describe('dev-db image migration ledger', () => {
+  it('never stamps ledger rows with the build clock', () => {
+    const ledgerInserts = executableLines
+      .split('\n')
+      .filter((line) => line.includes('INSERT INTO') && line.includes('__drizzle_migrations'));
+    expect(ledgerInserts.length).toBeGreaterThan(0);
+    for (const insert of ledgerInserts) {
+      expect(insert).not.toContain('date +%s');
+      expect(insert).toContain('$when');
+    }
+  });
+
+  it('reads the when of each entry out of the journal', () => {
+    expect(executableLines).toContain(`jq -r '.entries[] | "\\(.tag) \\(.when)"' /drizzle/meta/_journal.json`);
+    expect(executableLines).toContain('while read -r tag when; do');
+  });
+
+  it('fails the build when the ledger high-water mark is not the newest journal when', () => {
+    expect(executableLines).toContain(
+      'ledger_max=$(gosu postgres psql -h /var/run/postgresql main -t -A -c "SELECT COALESCE(max(created_at), 0) FROM drizzle.\\"__drizzle_migrations\\"")',
+    );
+    expect(executableLines).toContain(`journal_max=$(jq -r '[.entries[].when] | max' /drizzle/meta/_journal.json)`);
+    expect(executableLines).toContain('if [ "$ledger_max" != "$journal_max" ]; then');
+  });
+});

--- a/scripts/__tests__/dev-db-image-ledger.test.ts
+++ b/scripts/__tests__/dev-db-image-ledger.test.ts
@@ -1,16 +1,20 @@
 /// <reference types="node" />
 
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
+
+const WORKFLOWS_DIR = '.github/workflows';
 
 /**
  * File-text guard for #4211.
  *
  * `Dockerfile.dev-db` applies the migration journal in a psql loop and writes
  * drizzle's ledger by hand. It used to stamp `created_at` with the image's build
- * clock, which becomes a high-water mark drizzle's applier can never clear — so
- * every migration written after the image was built is silently skipped on that
- * database, forever.
+ * clock, which becomes a high-water mark that only ever moves up — so every
+ * journal entry with an earlier `when` that the image did not itself apply (a
+ * branch's migration, written before the image was built) is silently skipped on
+ * that database, for good.
  *
  * Building the image to check this takes tens of minutes and hits the network
  * hard (six APK downloads, pgloader, the MoonBoard import), so the practical
@@ -49,5 +53,132 @@ describe('dev-db image migration ledger', () => {
     );
     expect(executableLines).toContain(`journal_max=$(jq -r '[.entries[].when] | max' /drizzle/meta/_journal.json)`);
     expect(executableLines).toContain('if [ "$ledger_max" != "$journal_max" ]; then');
+  });
+});
+
+/**
+ * `vp run db:up` repairs the container it just started — and only that one.
+ *
+ * `getScriptDatabaseUrl()` reads `DB_URL || DATABASE_URL || POSTGRES_URL`, and
+ * its dotenv chain fills whichever of the three the caller leaves unset from
+ * `.env.local` / `packages/web/.env.local`. A `DB_URL` naming a remote or
+ * production database is a normal thing to have there (docs/db-migrations.md's
+ * own `db:verify-journal` example is invoked with `DB_URL`), and it would beat a
+ * lone `DATABASE_URL=…localhost` on the normaliser's own command line: `db:up`
+ * would then either die on the non-local guard under `set -e`, or — for the
+ * tailnet MagicDNS/CGNAT hosts `isLocalDatabaseUrl` deliberately accepts —
+ * quietly rewrite some other database's ledger.
+ */
+describe('dev-db-up.sh ledger normalisation target', () => {
+  const devDbUpSource = readFileSync('scripts/dev-db-up.sh', 'utf8');
+  const normalizeFunction = devDbUpSource.slice(
+    devDbUpSource.indexOf('normalize_ledger_timestamps() {'),
+    devDbUpSource.indexOf('prepare_docker_postgres() {'),
+  );
+
+  it('pins every name getScriptDatabaseUrl reads to the local container', () => {
+    expect(normalizeFunction).toContain('db:normalize-ledger');
+    for (const envName of ['DB_URL', 'DATABASE_URL', 'POSTGRES_URL']) {
+      expect(normalizeFunction).toContain(`${envName}="$dev_db_ledger_url"`);
+    }
+    expect(normalizeFunction).toContain('dev_db_ledger_url="postgresql://postgres:password@localhost:5432/main"');
+  });
+
+  it('runs the repair before the pending-migration apply', () => {
+    // After the apply the repair is useless: the migrations it would have
+    // unblocked have already been skipped, and the ledger only moves up.
+    const prepare = devDbUpSource.slice(devDbUpSource.indexOf('prepare_docker_postgres() {'));
+    const normalizeIndex = prepare.indexOf('normalize_ledger_timestamps');
+    const applyIndex = prepare.indexOf('run_pending_drizzle_sql_migrations');
+    expect(normalizeIndex).toBeGreaterThan(-1);
+    expect(applyIndex).toBeGreaterThan(normalizeIndex);
+  });
+});
+
+/**
+ * The repair has to be wired into *every* CI job that boots the image and then
+ * applies migrations — three of them today, and the next one is easy to add
+ * without noticing this exists. `ci-location-sync-workflow.test.ts` pins the
+ * ordering for its own job only, so this sweeps the rest.
+ *
+ * The exemption below is the one case that is genuinely safe, and it is listed
+ * rather than skipped so that a reviewer sees the reasoning instead of the gap.
+ */
+const RENUMBER_EXEMPTION = { workflow: 'db-migration-renumber.yml', job: 'renumber' };
+
+/** Job bodies keyed `<workflow file>#<job name>`, split on the 2-space job keys under `jobs:`. */
+function readWorkflowJobs(): Map<string, string> {
+  const jobs = new Map<string, string>();
+  for (const fileName of readdirSync(WORKFLOWS_DIR).filter((name) => name.endsWith('.yml'))) {
+    const lines = readFileSync(path.join(WORKFLOWS_DIR, fileName), 'utf8').split('\n');
+    const jobsIndex = lines.findIndex((line) => line === 'jobs:');
+    if (jobsIndex < 0) continue;
+
+    let currentJob: string | null = null;
+    let currentStart = 0;
+    const flush = (endIndex: number) => {
+      if (currentJob) jobs.set(`${fileName}#${currentJob}`, lines.slice(currentStart, endIndex).join('\n'));
+    };
+    for (let index = jobsIndex + 1; index < lines.length; index += 1) {
+      const jobKey = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(lines[index]);
+      if (jobKey) {
+        flush(index);
+        currentJob = jobKey[1];
+        currentStart = index;
+      }
+    }
+    flush(lines.length);
+  }
+  return jobs;
+}
+
+describe('CI jobs that boot the dev-db image', () => {
+  // `db:migrate` and `bunx drizzle-kit migrate` are the same applier; both read
+  // max(created_at) once, so both are blocked by a build-clock high-water mark.
+  const MIGRATE_INVOCATIONS = ['db:migrate', 'drizzle-kit migrate'];
+
+  // The steps here are commented, and those comments name the very commands this
+  // guard orders — "Must stay ahead of db:migrate" sits *above* the normalise
+  // step. Ordering on the raw text would read that comment as the migrate step
+  // and fail every correctly-wired job.
+  function withoutComments(body: string): string {
+    return body
+      .split('\n')
+      .filter((line) => !line.trimStart().startsWith('#'))
+      .join('\n');
+  }
+
+  it('normalize the ledger before applying migrations', () => {
+    const jobsBootingTheImage = [...readWorkflowJobs()]
+      .map(([id, body]) => [id, withoutComments(body)] as const)
+      .filter(
+        ([, body]) => body.includes('boardsesh-dev-db') && MIGRATE_INVOCATIONS.some((step) => body.includes(step)),
+      );
+    // If this drops to zero the sweep has stopped sweeping — most likely the job
+    // key regex stopped matching after a workflow reformat.
+    expect(jobsBootingTheImage.length).toBeGreaterThanOrEqual(3);
+
+    const unrepaired = jobsBootingTheImage
+      .filter(([id]) => id !== `${RENUMBER_EXEMPTION.workflow}#${RENUMBER_EXEMPTION.job}`)
+      .filter(([, body]) => {
+        const normalizeIndex = body.indexOf('db:normalize-ledger');
+        const migrateIndex = Math.min(
+          ...MIGRATE_INVOCATIONS.map((step) => body.indexOf(step)).filter((index) => index >= 0),
+        );
+        return normalizeIndex < 0 || normalizeIndex > migrateIndex;
+      })
+      .map(([id]) => id);
+    expect(unrepaired).toEqual([]);
+  });
+
+  it('exempts only the renumber job, which writes its own fresh `when`', () => {
+    // `scripts/db-renumber-migration.ts` stamps the migration it moves with
+    // `nextWhen(maxWhen(mainJournal), Date.now())` — a value taken at workflow
+    // run time, so it is always above the build clock of an image built earlier.
+    // Nothing there can land under the mark, which is why this job alone needs no
+    // repair. Change that script's `when` derivation and this exemption dies.
+    const renumberSource = readFileSync('scripts/db-renumber-migration.ts', 'utf8');
+    expect(renumberSource).toContain('nextWhen(maxWhen(mainJournal), Date.now())');
+    expect(readWorkflowJobs().has(`${RENUMBER_EXEMPTION.workflow}#${RENUMBER_EXEMPTION.job}`)).toBe(true);
   });
 });

--- a/scripts/dev-db-up.sh
+++ b/scripts/dev-db-up.sh
@@ -127,18 +127,33 @@ sync_drizzle_migration_tracker() {
 
 normalize_ledger_timestamps() {
   # Images built before #4211 stamped every ledger row with the image's build
-  # clock instead of the journal entry's `when`. That timestamp is a high-water
-  # mark no later migration can clear, so both drizzle's migrate() and the
-  # pending-migration selection below would skip every migration written after
-  # the image was built — silently, forever. Rewriting created_at to `when`
-  # writes exactly the value drizzle writes, so it is a no-op once the image
-  # (or a `docker compose down -v`) is current.
+  # clock instead of the journal entry's `when`. That timestamp becomes a
+  # high-water mark that only moves up, so both drizzle's migrate() and the
+  # pending-migration selection below skip every journal entry whose `when` is
+  # below it and that the image did not itself apply — silently, and for good.
+  # In practice that is a migration you generated on a branch before pulling a
+  # newer image, which is why a checkout can look migrated and not be.
+  # Rewriting created_at to `when` writes exactly the value drizzle writes, so
+  # it is a no-op once the image (or a `docker compose down -v`) is current.
   #
-  # DATABASE_URL is passed explicitly: .boardsesh/dev-db.env is not written
-  # until write_dev_db_env below, so the dotenv chain in db-connection.ts has
-  # nothing to load yet.
+  # The target is passed explicitly: .boardsesh/dev-db.env is not written until
+  # write_dev_db_env below, so the dotenv chain in db-connection.ts has nothing
+  # to load yet.
+  #
+  # All THREE names are pinned, not just DATABASE_URL. getScriptDatabaseUrl()
+  # reads `DB_URL || DATABASE_URL || POSTGRES_URL`, and its dotenv chain fills
+  # whichever of them this shell leaves unset from .env.local / web/.env.local —
+  # where a DB_URL naming a remote or production database is a normal thing to
+  # have (docs/db-migrations.md's own db:verify-journal example is invoked with
+  # DB_URL). Setting DATABASE_URL alone would lose to such a DB_URL: `vp run
+  # db:up` would then either die on the non-local guard, or — for the tailnet
+  # MagicDNS/CGNAT hosts that guard deliberately accepts — quietly repair the
+  # ledger of a database other than the container this script just started.
   echo "Normalizing migration ledger timestamps..."
-  DATABASE_URL=postgresql://postgres:password@localhost:5432/main \
+  dev_db_ledger_url="postgresql://postgres:password@localhost:5432/main"
+  DB_URL="$dev_db_ledger_url" \
+    DATABASE_URL="$dev_db_ledger_url" \
+    POSTGRES_URL="$dev_db_ledger_url" \
     bun run --filter=@boardsesh/db db:normalize-ledger
 }
 

--- a/scripts/dev-db-up.sh
+++ b/scripts/dev-db-up.sh
@@ -125,10 +125,28 @@ sync_drizzle_migration_tracker() {
   echo "  drizzle.__drizzle_migrations has $DRIZZLE_COUNT records."
 }
 
+normalize_ledger_timestamps() {
+  # Images built before #4211 stamped every ledger row with the image's build
+  # clock instead of the journal entry's `when`. That timestamp is a high-water
+  # mark no later migration can clear, so both drizzle's migrate() and the
+  # pending-migration selection below would skip every migration written after
+  # the image was built — silently, forever. Rewriting created_at to `when`
+  # writes exactly the value drizzle writes, so it is a no-op once the image
+  # (or a `docker compose down -v`) is current.
+  #
+  # DATABASE_URL is passed explicitly: .boardsesh/dev-db.env is not written
+  # until write_dev_db_env below, so the dotenv chain in db-connection.ts has
+  # nothing to load yet.
+  echo "Normalizing migration ledger timestamps..."
+  DATABASE_URL=postgresql://postgres:password@localhost:5432/main \
+    bun run --filter=@boardsesh/db db:normalize-ledger
+}
+
 prepare_docker_postgres() {
   ensure_postgres_network_access
   ensure_postgres_password
   sync_drizzle_migration_tracker
+  normalize_ledger_timestamps
   run_pending_drizzle_sql_migrations
   write_dev_db_env "localhost" "$1" "$(detect_local_redis_url)"
 }

--- a/scripts/lib/migration-ledger.test.ts
+++ b/scripts/lib/migration-ledger.test.ts
@@ -6,7 +6,10 @@ import {
   formatEditedBaselineNote,
   formatMigrationGapError,
   partitionMissingMigrations,
+  planLedgerTimestampRepairs,
   type ExpectedMigration,
+  type ExpectedMigrationWithWhen,
+  type LedgerTimestampRow,
 } from './migration-ledger';
 
 function expectedFrom(...tags: string[]): ExpectedMigration[] {
@@ -65,6 +68,85 @@ describe('findUnappliedMigrations', () => {
 
   it('returns nothing for an empty journal', () => {
     expect(findUnappliedMigrations([], hashesFor('0000_a'))).toEqual([]);
+  });
+});
+
+describe('planLedgerTimestampRepairs', () => {
+  // The dev-db image's shape: every row stamped with one build-time value,
+  // ~13 orders of magnitude of wall clock above every journal `when`.
+  const BUILD_CLOCK = 1_800_000_000_000;
+
+  function journal(...entries: [tag: string, when: number][]): ExpectedMigrationWithWhen[] {
+    return entries.map(([tag, when]) => ({ tag, hash: `hash-of-${tag}`, when }));
+  }
+
+  function ledgerRows(...rows: [tag: string, createdAt: number][]): LedgerTimestampRow[] {
+    return rows.map(([tag, createdAt], index) => ({ id: index + 1, hash: `hash-of-${tag}`, createdAt }));
+  }
+
+  it('plans nothing when every row already carries its journal `when`', () => {
+    // The no-op case is the important one: this runs on every `vp run db:up`
+    // and on a drizzle-managed database there is nothing to write.
+    const expected = journal(['0000_a', 1000], ['0001_b', 2000]);
+    expect(planLedgerTimestampRepairs(expected, ledgerRows(['0000_a', 1000], ['0001_b', 2000]))).toEqual([]);
+  });
+
+  it('rewrites a uniformly build-stamped ledger to the journal when of each entry', () => {
+    const expected = journal(['0000_a', 1000], ['0001_b', 2000], ['0002_c', 3000]);
+    const rows = ledgerRows(['0000_a', BUILD_CLOCK], ['0001_b', BUILD_CLOCK], ['0002_c', BUILD_CLOCK]);
+    expect(planLedgerTimestampRepairs(expected, rows)).toEqual([
+      { id: 1, tag: '0000_a', from: BUILD_CLOCK, to: 1000 },
+      { id: 2, tag: '0001_b', from: BUILD_CLOCK, to: 2000 },
+      { id: 3, tag: '0002_c', from: BUILD_CLOCK, to: 3000 },
+    ]);
+  });
+
+  it('gives byte-identical migrations distinct `when`s, in id order', () => {
+    // A Map<hash, when> would stamp both rows with the first entry's `when`,
+    // leaving the second migration's row wrong and the high-water mark short.
+    const duplicateHash = 'identical-sql-body';
+    const expected: ExpectedMigrationWithWhen[] = [
+      { tag: '0000_original', hash: duplicateHash, when: 1000 },
+      { tag: '0001_copy', hash: duplicateHash, when: 2000 },
+    ];
+    const rows: LedgerTimestampRow[] = [
+      { id: 7, hash: duplicateHash, createdAt: BUILD_CLOCK },
+      { id: 3, hash: duplicateHash, createdAt: BUILD_CLOCK },
+    ];
+    // Sorted by id, so the row inserted first (id 3) pairs with the first entry.
+    expect(planLedgerTimestampRepairs(expected, rows)).toEqual([
+      { id: 3, tag: '0000_original', from: BUILD_CLOCK, to: 1000 },
+      { id: 7, tag: '0001_copy', from: BUILD_CLOCK, to: 2000 },
+    ]);
+  });
+
+  it('leaves a ledger row whose hash is in no journal entry alone', () => {
+    // Renumber residue. Inventing a timestamp for it would be a guess.
+    const expected = journal(['0000_a', 1000]);
+    const rows: LedgerTimestampRow[] = [
+      { id: 1, hash: 'hash-of-0000_a', createdAt: BUILD_CLOCK },
+      { id: 2, hash: 'hash-of-a-renumbered-away-migration', createdAt: BUILD_CLOCK },
+    ];
+    expect(planLedgerTimestampRepairs(expected, rows)).toEqual([{ id: 1, tag: '0000_a', from: BUILD_CLOCK, to: 1000 }]);
+  });
+
+  it('repairs only the rows a short ledger actually has', () => {
+    // The normal state right after a new migration lands: the image predates it,
+    // so it has no row yet — and must not gain a bogus one from this repair.
+    const expected = journal(['0000_a', 1000], ['0001_b', 2000], ['0002_new', 3000]);
+    const rows = ledgerRows(['0000_a', BUILD_CLOCK], ['0001_b', BUILD_CLOCK]);
+    expect(planLedgerTimestampRepairs(expected, rows).map((repair) => repair.tag)).toEqual(['0000_a', '0001_b']);
+  });
+
+  it('repairs a duplicate-hash row only as far as the journal has entries for it', () => {
+    // Three rows, two entries: the third is residue of a copy that was removed.
+    const duplicateHash = 'identical-sql-body';
+    const expected: ExpectedMigrationWithWhen[] = [
+      { tag: '0000_original', hash: duplicateHash, when: 1000 },
+      { tag: '0001_copy', hash: duplicateHash, when: 2000 },
+    ];
+    const rows: LedgerTimestampRow[] = [1, 2, 3].map((id) => ({ id, hash: duplicateHash, createdAt: BUILD_CLOCK }));
+    expect(planLedgerTimestampRepairs(expected, rows).map((repair) => repair.id)).toEqual([1, 2]);
   });
 });
 

--- a/scripts/lib/migration-ledger.ts
+++ b/scripts/lib/migration-ledger.ts
@@ -41,6 +41,86 @@ export interface ExpectedMigration {
 }
 
 /**
+ * The same entry with the journal's own `when` attached — the value drizzle
+ * writes into `created_at` when it applies a migration itself
+ * (`PgDialect.migrate()` inserts `migration.folderMillis`, which
+ * `readMigrationFiles` copies straight from `journalEntry.when`).
+ *
+ * Only the timestamp planner below needs it; everything else keys on `hash`.
+ */
+export interface ExpectedMigrationWithWhen extends ExpectedMigration {
+  when: number;
+}
+
+/** One row of `drizzle."__drizzle_migrations"`, as the normaliser reads it. */
+export interface LedgerTimestampRow {
+  id: number;
+  hash: string;
+  createdAt: number;
+}
+
+/** A single `UPDATE … SET created_at = to WHERE id = id`, with the tag for the log line. */
+export interface LedgerTimestampRepair {
+  id: number;
+  tag: string;
+  from: number;
+  to: number;
+}
+
+/**
+ * Ledger rows whose `created_at` is not the journal `when` drizzle would have
+ * written, paired with the value they should carry.
+ *
+ * Why any row is ever wrong: the `boardsesh-dev-db` image applies the journal in
+ * a psql loop and stamps each ledger row with the image's *build* wall clock
+ * instead of the entry's `when`. That makes the ledger's high-water mark a build
+ * timestamp — far above every journal `when` — so drizzle's applier skips any
+ * migration added afterwards, forever, and `VERIFY_MIGRATION_JOURNAL=1` reports
+ * it as a genuine gap. Rewriting `created_at` to `when` writes exactly the value
+ * drizzle itself writes, so this is a no-op on any drizzle-managed database and a
+ * repair only where something else did the stamping.
+ *
+ * Pairing is positional within a hash, not a `Map<hash, when>` lookup:
+ * byte-identical `.sql` files share a hash (see the `0177_illegal_omega_red`
+ * note in `scripts/lib/drizzle-migrations.ts`), and a map would stamp both ledger
+ * rows with the first entry's `when`. The k-th ledger row bearing hash H (in `id`
+ * order — the order they were inserted) pairs with the k-th journal entry bearing
+ * hash H.
+ *
+ * Ledger rows whose hash matches no journal entry are left alone, the same rule
+ * `findUnappliedMigrations` applies in the other direction: those are renumber
+ * residue, and inventing a timestamp for them would be a guess.
+ */
+export function planLedgerTimestampRepairs(
+  expected: readonly ExpectedMigrationWithWhen[],
+  ledgerRows: readonly LedgerTimestampRow[],
+): LedgerTimestampRepair[] {
+  const entriesByHash = new Map<string, ExpectedMigrationWithWhen[]>();
+  for (const migration of expected) {
+    const entries = entriesByHash.get(migration.hash);
+    if (entries) {
+      entries.push(migration);
+    } else {
+      entriesByHash.set(migration.hash, [migration]);
+    }
+  }
+
+  const nextIndexByHash = new Map<string, number>();
+  const repairs: LedgerTimestampRepair[] = [];
+  for (const row of [...ledgerRows].sort((left, right) => left.id - right.id)) {
+    const entries = entriesByHash.get(row.hash);
+    if (!entries) continue;
+    const nextIndex = nextIndexByHash.get(row.hash) ?? 0;
+    const entry = entries[nextIndex];
+    if (!entry) continue;
+    nextIndexByHash.set(row.hash, nextIndex + 1);
+    if (row.createdAt === entry.when) continue;
+    repairs.push({ id: row.id, tag: entry.tag, from: row.createdAt, to: entry.when });
+  }
+  return repairs;
+}
+
+/**
  * Journal-order list of tags that have no matching row in the ledger.
  *
  * Multiset-aware on purpose: two byte-identical `.sql` files share a hash, and

--- a/scripts/lib/migration-ledger.ts
+++ b/scripts/lib/migration-ledger.ts
@@ -74,9 +74,10 @@ export interface LedgerTimestampRepair {
  * Why any row is ever wrong: the `boardsesh-dev-db` image applies the journal in
  * a psql loop and stamps each ledger row with the image's *build* wall clock
  * instead of the entry's `when`. That makes the ledger's high-water mark a build
- * timestamp — far above every journal `when` — so drizzle's applier skips any
- * migration added afterwards, forever, and `VERIFY_MIGRATION_JOURNAL=1` reports
- * it as a genuine gap. Rewriting `created_at` to `when` writes exactly the value
+ * timestamp, so drizzle's applier skips every journal entry whose `when` predates
+ * the image build and which the image did not itself apply — a branch's migration
+ * generated before that build — permanently, and `VERIFY_MIGRATION_JOURNAL=1`
+ * reports it as a genuine gap. Rewriting `created_at` to `when` writes the value
  * drizzle itself writes, so this is a no-op on any drizzle-managed database and a
  * repair only where something else did the stamping.
  *

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -171,6 +171,15 @@ export default defineConfig({
         command: 'bun run --filter=@boardsesh/db db:verify-journal',
         cache: false,
       },
+      // Rewrites created_at in drizzle's ledger to each entry's journal `when`
+      // (#4211), repairing a database whose ledger was stamped with the dev-db
+      // image's build clock instead — that timestamp is a high-water mark no
+      // later migration can clear, so drizzle silently skips them forever. No
+      // db:up dependency: db:up itself runs this, and a dependency would cycle.
+      'db:normalize-ledger': {
+        command: 'bun run --filter=@boardsesh/db db:normalize-ledger',
+        cache: false,
+      },
       'db:studio': {
         command: 'bun run --filter=@boardsesh/db db:studio',
         dependsOn: ['db:up'],


### PR DESCRIPTION
## Summary

Closes #4211.

The `boardsesh-dev-db` image applies the migration journal itself, in a psql loop, and wrote drizzle's ledger with the image's **build wall clock** (`$(date +%s)000`) instead of each journal entry's `when`. Drizzle's applier is a single high-water mark — `PgDialect.migrate()` reads `max(created_at)` once and applies only entries whose `when` is strictly greater — so the build timestamp becomes the mark, and the mark only ever moves up.

What that eats is not the newest migrations. A migration generated today has a `when` above any image built yesterday, so it still applies — which is why this reads as intermittent rather than broken. It eats the entries whose `when` sits *below* the build clock and that the image did not itself apply: a branch's migration, written before the image was built and applied to that database afterwards. On the two e2e jobs, which run `boardsesh-dev-db:latest` and therefore get a new image on every db-touching merge to `main`, that is most open PRs. The migration is skipped with no error of any kind: `vp run db:migrate` reports success, the table never appears, and `VERIFY_MIGRATION_JOURNAL=1` (correctly) calls it a gap.

It is not hypothetical. On this machine's dev DB, 92 of ~190 ledger rows carry `1778588631000`-ish build timestamps against journal `when`s a year and a half earlier; the `test-location-sync-integration` run on this PR repaired 189 rows stamped `1785545390000` against a journal whose newest `when` is `1785641394370`.

Three parts, because a Dockerfile fix alone reaches nobody:

1. **The source.** `Dockerfile.dev-db`'s loop now reads `when` alongside `tag` and writes it into both ledger tables. The build then asserts that the ledger's high-water mark equals the journal's newest `when` and fails if it doesn't — one psql call that makes this regression unshippable.
2. **The repair.** `vp run db:normalize-ledger` rewrites `created_at` to each entry's `when` on a database already on disk. That is exactly the value drizzle writes itself (it inserts `folderMillis`), so it's a no-op on any drizzle-managed database — and it refuses a non-local target without `--force`, so it can't be mistaken for a production ledger tool. Pairing is positional within a hash, not a `Map<hash, when>`: byte-identical `.sql` files share a hash and a map would stamp both rows with the first entry's `when`.
3. **The wiring.** `vp run db:up` runs the repair between the tracker sync and the pending-migration apply; so do the CI jobs that boot the image (`test-location-sync-integration`, and both e2e jobs before `drizzle-kit migrate`). Ordering is load-bearing and is now asserted — after `db:migrate` the repair is useless, since the migrations it would have unblocked are already skipped. `db:up` pins all three names `getScriptDatabaseUrl()` reads (`DB_URL`, `DATABASE_URL`, `POSTGRES_URL`) to the container it just started, so a `DB_URL` in `.env.local` can't redirect the repair at someone else's database. And `dev-db-image-ledger.test.ts` sweeps every workflow job that boots the image and applies migrations rather than trusting the audit — `db-migration-renumber.yml#renumber` is the one exemption, because `db-renumber-migration.ts` stamps `nextWhen(maxWhen(mainJournal), Date.now())` at run time and so can never land under an older image's clock.

The pinned digest in `ci.yml` is deliberately **not** bumped: the corrected image only exists once this merges and `dev-db-docker.yml` rebuilds. The normalise step is what makes those jobs deterministic meanwhile; repinning is a follow-up (and must also update the hard-coded digest in `scripts/__tests__/ci-location-sync-workflow.test.ts`).

One judgement call worth a reviewer's opinion rather than a guess: the follow-up could be a plain digest repin, or the larger change the issue floats — replacing the image's hand-rolled psql loop with drizzle's own migrator. The loop deliberately continues past per-migration errors and the image has no monorepo workspace install, so swapping appliers risks the whole build for a problem the `when` stamp plus the build assertion already close. Left out of scope here.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:db` — clean.
- `vp test run --project scripts` — 725 passed, including the new `planLedgerTimestampRepairs` cases (no-op on a correct ledger, full repair on a build-stamped one, duplicate-hash entries paired in `id` order, unmatched rows untouched, short ledger repairs only what's there) and the `Dockerfile.dev-db` text guard.
- `MIGRATION_JOURNAL_DB_URL=… vp run test:db:migration-journal` — 16 passed against a real Postgres, including the new end-to-end regression: stamp the ledger with a build clock → drizzle skips a later migration and the gate throws → run the repair → the migration applies, the gate passes, and a second pass plans nothing.
- `vp run check:db-migrations` — 190 migrations, journal consistent.
- `vp check` — no new errors (30 errors / 327 warnings vs. 30 / 325 on `origin/main`; the two extra are the `no-floating-promises` warning every `it()` in that node:test file already carries).
- Real dry run against the local dev DB: `DATABASE_URL=… vp run db:normalize-ledger -- --dry-run` planned 92 repairs with sensible `from → to` pairs and touched nothing.

Not covered: the image build itself (six APK downloads, pgloader, the MoonBoard import — tens of minutes, network-heavy). Coverage there is the text guard plus the in-build high-water-mark assertion; the first real proof is the post-merge `dev-db-docker.yml` run, which is worth watching.

