### PR TITLE
feat(db): add a dry-run repair for cross-linked playlist ownership

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -99,6 +99,7 @@
     "db:dedupe-gyms": "tsx scripts/dedupe-gym-locations.ts",
     "db:dedupe-serial-boards": "tsx scripts/dedupe-serial-boards.ts",
     "db:dedupe-beta-links": "tsx scripts/dedupe-beta-links.ts",
+    "db:repair-cross-linked-playlists": "tsx scripts/repair-cross-linked-playlists.ts",
     "db:refresh-climb-grades": "tsx scripts/refresh-climb-grades.ts",
     "db:seed-social": "tsx scripts/seed-social.ts",
     "db:create-test-user": "tsx scripts/create-test-user.ts",

--- a/packages/db/scripts/repair-cross-linked-playlists-args.test.ts
+++ b/packages/db/scripts/repair-cross-linked-playlists-args.test.ts
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseArgs } from './repair-cross-linked-playlists.js';
+import { DEFAULT_MIN_OWNERSHIP_SPREAD_MINUTES } from './repair-cross-linked-playlists-helpers.js';
+
+test('defaults are read-only: no apply, no merge candidates, full scope', () => {
+  assert.deepEqual(parseArgs([]), {
+    apply: false,
+    playlistIds: null,
+    includeMergeCandidates: false,
+    minSpreadMinutes: DEFAULT_MIN_OWNERSHIP_SPREAD_MINUTES,
+    help: false,
+  });
+});
+
+test('the vp-forwarded `--` separator is skipped rather than rejected', () => {
+  assert.equal(parseArgs(['--', '--apply']).apply, true);
+});
+
+test('--playlist-ids accepts both `=value` and separate-argument forms', () => {
+  assert.deepEqual(parseArgs(['--playlist-ids=12,34']).playlistIds, ['12', '34']);
+  assert.deepEqual(parseArgs(['--playlist-ids', ' 12 , 34 ']).playlistIds, ['12', '34']);
+});
+
+test('--min-spread-minutes overrides the default threshold', () => {
+  assert.equal(parseArgs(['--min-spread-minutes=90']).minSpreadMinutes, 90);
+  assert.equal(parseArgs(['--min-spread-minutes', '0']).minSpreadMinutes, 0);
+});
+
+test('--include-merge-candidates and --apply are independent opt-ins', () => {
+  const parsed = parseArgs(['--apply', '--include-merge-candidates']);
+  assert.equal(parsed.apply, true);
+  assert.equal(parsed.includeMergeCandidates, true);
+});

--- a/packages/db/scripts/repair-cross-linked-playlists-args.test.ts
+++ b/packages/db/scripts/repair-cross-linked-playlists-args.test.ts
@@ -1,7 +1,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseArgs } from './repair-cross-linked-playlists.js';
-import { DEFAULT_MIN_OWNERSHIP_SPREAD_MINUTES } from './repair-cross-linked-playlists-helpers.js';
+import { countPlannedDeletions, parseArgs } from './repair-cross-linked-playlists.js';
+import {
+  DEFAULT_MIN_OWNERSHIP_SPREAD_MINUTES,
+  type CrossLinkRepairPlan,
+} from './repair-cross-linked-playlists-helpers.js';
 
 test('defaults are read-only: no apply, no merge candidates, full scope', () => {
   assert.deepEqual(parseArgs([]), {
@@ -31,4 +34,23 @@ test('--include-merge-candidates and --apply are independent opt-ins', () => {
   const parsed = parseArgs(['--apply', '--include-merge-candidates']);
   assert.equal(parsed.apply, true);
   assert.equal(parsed.includeMergeCandidates, true);
+});
+
+test('the dry-run preview counts only the plans --apply is allowed to write', () => {
+  const attachments = {
+    pinnedPlaylistIds: new Set(['1', '3']),
+    followedPlaylistUuids: new Set(['uuid-1']),
+  };
+  const planFor = (playlistId: string, playlistUuid: string): CrossLinkRepairPlan =>
+    ({
+      playlist: { playlistId, playlistUuid },
+    }) as CrossLinkRepairPlan;
+
+  assert.deepEqual(countPlannedDeletions([planFor('1', 'uuid-1'), planFor('2', 'uuid-2')], attachments), {
+    ownershipRows: 2,
+    pins: 1,
+    follows: 1,
+  });
+  // A refused/deferred plan never reaches this list, so the preview is zero.
+  assert.deepEqual(countPlannedDeletions([], attachments), { ownershipRows: 0, pins: 0, follows: 0 });
 });

--- a/packages/db/scripts/repair-cross-linked-playlists-helpers.test.ts
+++ b/packages/db/scripts/repair-cross-linked-playlists-helpers.test.ts
@@ -243,3 +243,19 @@ test('summarize and selectApplyablePlans keep merge candidates out unless opted 
     ['101', '102'],
   );
 });
+
+test('a duplicate ownership row for one user is refused, not treated as the adopter', () => {
+  const plan = classifyCrossLinkedPlaylist(
+    playlist({
+      owners: [
+        owner(),
+        owner({ createdAt: new Date('2026-03-29T11:00:00Z') }),
+        owner({ userId: 'user-adopter', userEmail: 'test22@boardsesh.com', createdAt: ADOPTER_AT }),
+      ],
+    }),
+  );
+
+  assert.equal(plan.action, 'refuse');
+  assert.equal(plan.adopter, null);
+  assert.match(plan.reason, /3 ownership rows for 2 users/);
+});

--- a/packages/db/scripts/repair-cross-linked-playlists-helpers.test.ts
+++ b/packages/db/scripts/repair-cross-linked-playlists-helpers.test.ts
@@ -1,0 +1,245 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  DEFAULT_MIN_OWNERSHIP_SPREAD_MINUTES,
+  classifyCrossLinkedPlaylist,
+  isDuplicateAccountEmailPair,
+  isJsonImportCircuit,
+  planCrossLinkedPlaylistRepairs,
+  selectApplyablePlans,
+  summarizeRepairPlans,
+  type CrossLinkedPlaylist,
+  type PlaylistOwnerRow,
+} from './repair-cross-linked-playlists-helpers.js';
+
+const CREATOR_AT = new Date('2026-03-29T10:00:00Z');
+const ADOPTER_AT = new Date('2026-03-29T12:00:00Z');
+
+function owner(overrides: Partial<PlaylistOwnerRow> = {}): PlaylistOwnerRow {
+  return {
+    userId: 'user-creator',
+    userEmail: 'm.jongh88@gmail.com',
+    role: 'owner',
+    createdAt: CREATOR_AT,
+    ...overrides,
+  };
+}
+
+function playlist(overrides: Partial<CrossLinkedPlaylist> = {}): CrossLinkedPlaylist {
+  return {
+    playlistId: '101',
+    playlistUuid: 'playlist-uuid-101',
+    name: 'Warmups',
+    boardType: 'kilter',
+    auroraId: 'json-import-circuit-0123456789abcdef0123456789abcdef',
+    kilterId: null,
+    isPublic: false,
+    climbCount: 7,
+    owners: [owner(), owner({ userId: 'user-adopter', userEmail: 'test22@boardsesh.com', createdAt: ADOPTER_AT })],
+    ...overrides,
+  };
+}
+
+test('the creator is the earliest ownership row regardless of input order', () => {
+  const reversedOrder = playlist({
+    owners: [owner({ userId: 'user-adopter', userEmail: 'test22@boardsesh.com', createdAt: ADOPTER_AT }), owner()],
+  });
+
+  const plan = classifyCrossLinkedPlaylist(reversedOrder);
+
+  assert.equal(plan.action, 'revoke-adopter');
+  assert.equal(plan.cause, 'json-import');
+  assert.equal(plan.creator?.userId, 'user-creator');
+  assert.equal(plan.adopter?.userId, 'user-adopter');
+  assert.equal(plan.spreadMinutes, 120);
+});
+
+test('case-variant emails are deferred to merge-accounts.ts instead of being revoked', () => {
+  const plan = classifyCrossLinkedPlaylist(
+    playlist({
+      auroraId: 'circuit-uuid-from-aurora',
+      owners: [
+        owner({ userId: 'user-lower', userEmail: 'pmbmosk@gmail.com' }),
+        owner({ userId: 'user-upper', userEmail: 'Pmbmosk@gmail.com', createdAt: ADOPTER_AT }),
+      ],
+    }),
+  );
+
+  assert.equal(plan.action, 'defer-to-account-merge');
+  assert.equal(plan.cause, 'duplicate-accounts');
+  assert.equal(plan.creator?.userId, 'user-lower');
+  assert.equal(plan.adopter?.userId, 'user-upper');
+});
+
+test('a non-json-import circuit owned by two genuinely different people is refused', () => {
+  const plan = classifyCrossLinkedPlaylist(
+    playlist({
+      auroraId: 'circuit-uuid-from-aurora',
+      owners: [owner(), owner({ userId: 'user-other', userEmail: 'someone@example.com', createdAt: ADOPTER_AT })],
+    }),
+  );
+
+  assert.equal(plan.action, 'refuse');
+  assert.equal(plan.cause, 'unknown');
+  // Creator/adopter are still reported so a human can decide.
+  assert.equal(plan.creator?.userId, 'user-creator');
+  assert.equal(plan.adopter?.userId, 'user-other');
+});
+
+test('a three-way cross-link is refused without picking a creator', () => {
+  const plan = classifyCrossLinkedPlaylist(
+    playlist({
+      owners: [
+        owner(),
+        owner({ userId: 'user-adopter', userEmail: 'test22@boardsesh.com', createdAt: ADOPTER_AT }),
+        owner({ userId: 'user-third', userEmail: 'third@example.com', createdAt: new Date('2026-03-30T12:00:00Z') }),
+      ],
+    }),
+  );
+
+  assert.equal(plan.action, 'refuse');
+  assert.equal(plan.creator, null);
+  assert.equal(plan.adopter, null);
+  assert.match(plan.reason, /three-way/);
+});
+
+test('deliberate sharing (an editor or viewer row) is refused, not revoked', () => {
+  const plan = classifyCrossLinkedPlaylist(
+    playlist({
+      owners: [
+        owner(),
+        owner({ userId: 'user-editor', userEmail: 'mate@example.com', role: 'editor', createdAt: ADOPTER_AT }),
+      ],
+    }),
+  );
+
+  assert.equal(plan.action, 'refuse');
+  assert.match(plan.reason, /editor/);
+});
+
+test('ownership rows closer together than the threshold are refused', () => {
+  const plan = classifyCrossLinkedPlaylist(
+    playlist({
+      owners: [
+        owner(),
+        owner({
+          userId: 'user-adopter',
+          userEmail: 'test22@boardsesh.com',
+          createdAt: new Date(CREATOR_AT.getTime() + 5 * 60_000),
+        }),
+      ],
+    }),
+  );
+
+  assert.equal(plan.action, 'refuse');
+  assert.equal(plan.spreadMinutes, 5);
+  assert.match(plan.reason, new RegExp(`threshold ${DEFAULT_MIN_OWNERSHIP_SPREAD_MINUTES} min`));
+});
+
+test('a sub-threshold duplicate-account pair is refused but still named as a merge candidate', () => {
+  const plan = classifyCrossLinkedPlaylist(
+    playlist({
+      auroraId: 'circuit-uuid-from-aurora',
+      owners: [
+        owner({ userId: 'user-lower', userEmail: 'pmbmosk@gmail.com' }),
+        owner({
+          userId: 'user-upper',
+          userEmail: 'Pmbmosk@gmail.com',
+          createdAt: new Date(CREATOR_AT.getTime() + 60_000),
+        }),
+      ],
+    }),
+  );
+
+  assert.equal(plan.action, 'refuse');
+  assert.equal(plan.cause, 'duplicate-accounts');
+  assert.match(plan.reason, /merge-accounts\.ts/);
+});
+
+test('the spread threshold is configurable', () => {
+  const closePair = playlist({
+    owners: [
+      owner(),
+      owner({
+        userId: 'user-adopter',
+        userEmail: 'test22@boardsesh.com',
+        createdAt: new Date(CREATOR_AT.getTime() + 5 * 60_000),
+      }),
+    ],
+  });
+
+  assert.equal(classifyCrossLinkedPlaylist(closePair, { minSpreadMinutes: 1 }).action, 'revoke-adopter');
+  assert.equal(classifyCrossLinkedPlaylist(closePair, { minSpreadMinutes: 60 }).action, 'refuse');
+});
+
+test('a single-owner playlist is refused rather than repaired', () => {
+  const plan = classifyCrossLinkedPlaylist(playlist({ owners: [owner()] }));
+
+  assert.equal(plan.action, 'refuse');
+  assert.match(plan.reason, /not a cross-link/);
+});
+
+test('an unreadable created_at is refused instead of ordered arbitrarily', () => {
+  const plan = classifyCrossLinkedPlaylist(
+    playlist({
+      owners: [
+        owner(),
+        owner({ userId: 'user-adopter', userEmail: 'test22@boardsesh.com', createdAt: new Date('not a date') }),
+      ],
+    }),
+  );
+
+  assert.equal(plan.action, 'refuse');
+  assert.match(plan.reason, /created_at/);
+});
+
+test('isJsonImportCircuit only matches the importer prefix', () => {
+  assert.equal(isJsonImportCircuit('json-import-circuit-abc'), true);
+  assert.equal(isJsonImportCircuit('circuit-uuid-from-aurora'), false);
+  assert.equal(isJsonImportCircuit(null), false);
+});
+
+test('isDuplicateAccountEmailPair ignores case and surrounding whitespace, but not a missing email', () => {
+  assert.equal(isDuplicateAccountEmailPair('Pmbmosk@gmail.com', ' pmbmosk@gmail.com '), true);
+  assert.equal(isDuplicateAccountEmailPair('a@example.com', 'b@example.com'), false);
+  assert.equal(isDuplicateAccountEmailPair(null, 'a@example.com'), false);
+  assert.equal(isDuplicateAccountEmailPair('a@example.com', null), false);
+});
+
+test('summarize and selectApplyablePlans keep merge candidates out unless opted in', () => {
+  const plans = planCrossLinkedPlaylistRepairs([
+    playlist(),
+    playlist({
+      playlistId: '102',
+      playlistUuid: 'playlist-uuid-102',
+      auroraId: 'circuit-uuid-from-aurora',
+      owners: [
+        owner({ userId: 'user-lower', userEmail: 'pmbmosk@gmail.com' }),
+        owner({ userId: 'user-upper', userEmail: 'Pmbmosk@gmail.com', createdAt: ADOPTER_AT }),
+      ],
+    }),
+    playlist({
+      playlistId: '103',
+      playlistUuid: 'playlist-uuid-103',
+      auroraId: 'circuit-uuid-from-aurora',
+      owners: [owner(), owner({ userId: 'user-other', userEmail: 'someone@example.com', createdAt: ADOPTER_AT })],
+    }),
+  ]);
+
+  assert.deepEqual(summarizeRepairPlans(plans), {
+    playlists: 3,
+    ownershipRows: 6,
+    revokeAdopter: 1,
+    deferToAccountMerge: 1,
+    refused: 1,
+  });
+
+  assert.deepEqual(
+    selectApplyablePlans(plans, { includeMergeCandidates: false }).map((plan) => plan.playlist.playlistId),
+    ['101'],
+  );
+  assert.deepEqual(
+    selectApplyablePlans(plans, { includeMergeCandidates: true }).map((plan) => plan.playlist.playlistId),
+    ['101', '102'],
+  );
+});

--- a/packages/db/scripts/repair-cross-linked-playlists-helpers.ts
+++ b/packages/db/scripts/repair-cross-linked-playlists-helpers.ts
@@ -61,11 +61,13 @@ export type CrossLinkedPlaylist = {
  * What the script will do with a playlist.
  *
  * - `revoke-adopter`: delete the later ownership row (Marco's Option A). The
- *   only action that writes.
+ *   only action the apply path writes by default.
  * - `defer-to-account-merge`: the two owners are the same person's duplicate
  *   accounts (case-variant emails). `merge-accounts.ts` from PR #3278 collapses
  *   these correctly as a side effect of merging the accounts, and also moves the
- *   ticks and credentials this script deliberately never touches.
+ *   ticks and credentials this script deliberately never touches. Skipped unless
+ *   `--include-merge-candidates` opts in, which routes it through the same
+ *   revoke path as above.
  * - `refuse`: not safe to decide automatically. Reported, never written.
  */
 export type CrossLinkRepairAction = 'revoke-adopter' | 'defer-to-account-merge' | 'refuse';

--- a/packages/db/scripts/repair-cross-linked-playlists-helpers.ts
+++ b/packages/db/scripts/repair-cross-linked-playlists-helpers.ts
@@ -145,6 +145,17 @@ export function classifyCrossLinkedPlaylist(
     );
   }
 
+  // `unique_playlist_ownership` on (playlist_id, user_id) makes this
+  // impossible, but the two-row shape below is the whole basis for calling one
+  // row the creator — keep the invariant local rather than resting it on a
+  // constraint the reader has to go and look up.
+  if (playlist.owners.length > distinctUserIds.size) {
+    return refusal(
+      playlist,
+      `${playlist.owners.length} ownership rows for ${distinctUserIds.size} users — a duplicate row makes creator vs adopter ambiguous`,
+    );
+  }
+
   const nonOwnerRoles = playlist.owners.filter((owner) => owner.role !== 'owner');
   if (nonOwnerRoles.length > 0) {
     const roleList = [...new Set(nonOwnerRoles.map((owner) => owner.role))].sort().join(', ');

--- a/packages/db/scripts/repair-cross-linked-playlists-helpers.ts
+++ b/packages/db/scripts/repair-cross-linked-playlists-helpers.ts
@@ -1,0 +1,257 @@
+/**
+ * Pure classification logic for the cross-linked-playlist repair command
+ * (#3541). Kept DB-free so it unit-tests without a database (mirrors
+ * dedupe-beta-links-helpers.ts); the command module does all the I/O.
+ *
+ * Background: three now-fixed defects let one Aurora account attach a second
+ * Boardsesh user's `owner` row onto a playlist someone else created —
+ *
+ *   1. the original JSON importer (8fe79f60d) derived `playlists.aurora_id`
+ *      from `${boardType}:${name}:${created_at}` with no user id, so two
+ *      people importing a circuit with the same name and creation timestamp
+ *      collided on the global `playlists_aurora_id_idx` (fixed in 45cef340a,
+ *      which added the user id to the hash);
+ *   2. Aurora `user-sync`'s circuits path upserted on that same global index
+ *      and then unconditionally inserted an `owner` row (fixed by the
+ *      `foreignPlaylistOwnerGuard` setWhere, PR #3931);
+ *   3. board links were not rejected when the same Aurora account was already
+ *      linked to another Boardsesh user (fixed in 458a1490f).
+ *
+ * The guards stop NEW cross-links; they do not clean up the rows that already
+ * exist. This module decides, per playlist, whether a cross-link is safe to
+ * repair automatically and which of the two owners created it.
+ */
+
+/** Playlists imported from an Aurora JSON export carry this `aurora_id` prefix. */
+export const JSON_IMPORT_CIRCUIT_AURORA_ID_PREFIX = 'json-import-circuit-';
+
+/**
+ * Two ownership rows must be at least this far apart in time before the
+ * earlier one is trusted as "the creator". Marco's 2026-07-25 read-only
+ * analysis of the 44 prod rows found a minimum spread of 100 minutes and a
+ * maximum of 96 days, so 30 minutes clears every real pair with room to spare
+ * while still refusing anything that would be a coin flip.
+ */
+export const DEFAULT_MIN_OWNERSHIP_SPREAD_MINUTES = 30;
+
+const MILLISECONDS_PER_MINUTE = 60_000;
+
+export type PlaylistOwnerRow = {
+  userId: string;
+  userEmail: string | null;
+  role: string;
+  createdAt: Date;
+};
+
+export type CrossLinkedPlaylist = {
+  /** `playlists.id` as a decimal string — the column is a bigint. */
+  playlistId: string;
+  playlistUuid: string;
+  name: string;
+  boardType: string;
+  auroraId: string | null;
+  kilterId: string | null;
+  isPublic: boolean;
+  climbCount: number;
+  /** Every ownership row on the playlist, in any order. */
+  owners: PlaylistOwnerRow[];
+};
+
+/**
+ * What the script will do with a playlist.
+ *
+ * - `revoke-adopter`: delete the later ownership row (Marco's Option A). The
+ *   only action that writes.
+ * - `defer-to-account-merge`: the two owners are the same person's duplicate
+ *   accounts (case-variant emails). `merge-accounts.ts` from PR #3278 collapses
+ *   these correctly as a side effect of merging the accounts, and also moves the
+ *   ticks and credentials this script deliberately never touches.
+ * - `refuse`: not safe to decide automatically. Reported, never written.
+ */
+export type CrossLinkRepairAction = 'revoke-adopter' | 'defer-to-account-merge' | 'refuse';
+
+export type CrossLinkCause =
+  | 'json-import'
+  | 'duplicate-accounts'
+  /** A cross-link this module cannot attribute to a known defect. Always refused. */
+  | 'unknown';
+
+export type CrossLinkRepairPlan = {
+  playlist: CrossLinkedPlaylist;
+  action: CrossLinkRepairAction;
+  cause: CrossLinkCause;
+  /** Human-readable justification, printed verbatim in the audit report. */
+  reason: string;
+  /** Earliest ownership row. Null when the playlist was refused before ordering. */
+  creator: PlaylistOwnerRow | null;
+  /** Later ownership row — the one `revoke-adopter` deletes. */
+  adopter: PlaylistOwnerRow | null;
+  /** Minutes between the two ownership rows, or null when not applicable. */
+  spreadMinutes: number | null;
+};
+
+export type ClassifyOptions = {
+  minSpreadMinutes?: number;
+};
+
+export function isJsonImportCircuit(auroraId: string | null): boolean {
+  return auroraId !== null && auroraId.startsWith(JSON_IMPORT_CIRCUIT_AURORA_ID_PREFIX);
+}
+
+/**
+ * True when two emails differ only by case (or whitespace) — i.e. the two
+ * Boardsesh accounts exist only because `users.email` used to be
+ * case-sensitive. `Pmbmosk@gmail.com` vs `pmbmosk@gmail.com` is the pair this
+ * issue is about.
+ */
+export function isDuplicateAccountEmailPair(firstEmail: string | null, secondEmail: string | null): boolean {
+  if (!firstEmail || !secondEmail) return false;
+  return firstEmail.trim().toLowerCase() === secondEmail.trim().toLowerCase();
+}
+
+function sortOwnersByCreatedAt(owners: PlaylistOwnerRow[]): PlaylistOwnerRow[] {
+  return [...owners].sort((first, second) => first.createdAt.getTime() - second.createdAt.getTime());
+}
+
+function refusal(playlist: CrossLinkedPlaylist, reason: string): CrossLinkRepairPlan {
+  return { playlist, action: 'refuse', cause: 'unknown', reason, creator: null, adopter: null, spreadMinutes: null };
+}
+
+/**
+ * Decide what to do with one multi-owner playlist.
+ *
+ * Refuses (never writes) when the shape is anything other than exactly two
+ * `owner` rows separated by a clear margin: three-way cross-links, shared
+ * playlists using the collaboration roles the schema already allows
+ * (`editor`/`viewer`), invalid timestamps, and near-simultaneous rows all fall
+ * out here rather than guessing.
+ */
+export function classifyCrossLinkedPlaylist(
+  playlist: CrossLinkedPlaylist,
+  options: ClassifyOptions = {},
+): CrossLinkRepairPlan {
+  const minSpreadMinutes = options.minSpreadMinutes ?? DEFAULT_MIN_OWNERSHIP_SPREAD_MINUTES;
+
+  const distinctUserIds = new Set(playlist.owners.map((owner) => owner.userId));
+  if (distinctUserIds.size < 2) {
+    return refusal(playlist, `only ${distinctUserIds.size} distinct owner(s) — not a cross-link`);
+  }
+  if (distinctUserIds.size > 2) {
+    return refusal(
+      playlist,
+      `${distinctUserIds.size} distinct owners — repairing a three-way cross-link needs a human`,
+    );
+  }
+
+  const nonOwnerRoles = playlist.owners.filter((owner) => owner.role !== 'owner');
+  if (nonOwnerRoles.length > 0) {
+    const roleList = [...new Set(nonOwnerRoles.map((owner) => owner.role))].sort().join(', ');
+    return refusal(
+      playlist,
+      `non-owner role(s) present (${roleList}) — looks like deliberate sharing, not a cross-link`,
+    );
+  }
+
+  const invalidTimestamps = playlist.owners.filter((owner) => Number.isNaN(owner.createdAt.getTime()));
+  if (invalidTimestamps.length > 0) {
+    return refusal(playlist, 'ownership row with an unreadable created_at — cannot order creator vs adopter');
+  }
+
+  const [creator, adopter] = sortOwnersByCreatedAt(playlist.owners);
+  const spreadMinutes = (adopter.createdAt.getTime() - creator.createdAt.getTime()) / MILLISECONDS_PER_MINUTE;
+  const isDuplicateAccounts = isDuplicateAccountEmailPair(creator.userEmail, adopter.userEmail);
+
+  // The spread check comes before the cause checks, including the
+  // duplicate-account one: every action below either deletes the adopter's row
+  // or can be opted into deleting it (--include-merge-candidates), so an
+  // unorderable pair must be refused whatever caused it.
+  if (spreadMinutes < minSpreadMinutes) {
+    const duplicateAccountNote = isDuplicateAccounts
+      ? '; the two owners are case-variant emails, so merge-accounts.ts (#3278) can still collapse this pair'
+      : '';
+    return {
+      playlist,
+      action: 'refuse',
+      cause: isDuplicateAccounts ? 'duplicate-accounts' : 'unknown',
+      reason: `ownership rows are only ${spreadMinutes.toFixed(1)} min apart (threshold ${minSpreadMinutes} min) — creator is a coin flip${duplicateAccountNote}`,
+      creator,
+      adopter,
+      spreadMinutes,
+    };
+  }
+
+  if (isDuplicateAccounts) {
+    return {
+      playlist,
+      action: 'defer-to-account-merge',
+      cause: 'duplicate-accounts',
+      reason: `both owners are the same email up to case (${creator.userEmail} / ${adopter.userEmail}) — merge the accounts with merge-accounts.ts (#3278) instead, which also moves their ticks and credentials`,
+      creator,
+      adopter,
+      spreadMinutes,
+    };
+  }
+
+  if (!isJsonImportCircuit(playlist.auroraId)) {
+    return {
+      playlist,
+      action: 'refuse',
+      cause: 'unknown',
+      reason: `aurora_id ${playlist.auroraId ?? '(null)'} is not a JSON-import circuit and the owners are different people — no known defect explains this cross-link`,
+      creator,
+      adopter,
+      spreadMinutes,
+    };
+  }
+
+  return {
+    playlist,
+    action: 'revoke-adopter',
+    cause: 'json-import',
+    reason: `JSON-import residue: the pre-45cef340a importer hashed aurora_id without a user id, so ${adopter.userEmail ?? adopter.userId}'s import adopted ${creator.userEmail ?? creator.userId}'s playlist`,
+    creator,
+    adopter,
+    spreadMinutes,
+  };
+}
+
+export function planCrossLinkedPlaylistRepairs(
+  playlists: CrossLinkedPlaylist[],
+  options: ClassifyOptions = {},
+): CrossLinkRepairPlan[] {
+  return playlists.map((playlist) => classifyCrossLinkedPlaylist(playlist, options));
+}
+
+export type RepairPlanSummary = {
+  playlists: number;
+  ownershipRows: number;
+  revokeAdopter: number;
+  deferToAccountMerge: number;
+  refused: number;
+};
+
+export function summarizeRepairPlans(plans: CrossLinkRepairPlan[]): RepairPlanSummary {
+  return {
+    playlists: plans.length,
+    ownershipRows: plans.reduce((total, plan) => total + plan.playlist.owners.length, 0),
+    revokeAdopter: plans.filter((plan) => plan.action === 'revoke-adopter').length,
+    deferToAccountMerge: plans.filter((plan) => plan.action === 'defer-to-account-merge').length,
+    refused: plans.filter((plan) => plan.action === 'refuse').length,
+  };
+}
+
+/**
+ * The plans the apply path is allowed to write, honouring the
+ * `--include-merge-candidates` opt-in. Duplicate-account pairs stay off by
+ * default: `merge-accounts.ts` (#3278) is the right tool for them, and running
+ * it after this script would find the ownership rows already deduped.
+ */
+export function selectApplyablePlans(
+  plans: CrossLinkRepairPlan[],
+  { includeMergeCandidates }: { includeMergeCandidates: boolean },
+): CrossLinkRepairPlan[] {
+  return plans.filter((plan) => {
+    if (plan.action === 'revoke-adopter') return true;
+    return includeMergeCandidates && plan.action === 'defer-to-account-merge';
+  });
+}

--- a/packages/db/scripts/repair-cross-linked-playlists.integration.test.ts
+++ b/packages/db/scripts/repair-cross-linked-playlists.integration.test.ts
@@ -1,9 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { createScriptDb, isLocalDatabaseUrl } from './db-connection.js';
 import { playlistClimbs, playlistOwnership, playlists, userPlaylistPins } from '../src/schema/app/playlists.js';
 import { playlistFollows } from '../src/schema/app/follows.js';
+import { syncDeletions } from '../src/schema/app/sync-deletions.js';
 import { users } from '../src/schema/auth/users.js';
 import { applyRepairPlans, loadAdopterAttachments, loadCrossLinkedPlaylists } from './repair-cross-linked-playlists.js';
 import { planCrossLinkedPlaylistRepairs, selectApplyablePlans } from './repair-cross-linked-playlists-helpers.js';
@@ -166,6 +167,7 @@ void describe('repair-cross-linked-playlists apply path', () => {
           ownershipRowsDeleted: 1,
           pinsDeleted: 1,
           followsDeleted: 1,
+          tombstonesWritten: 1,
           skippedByDrift: [],
         });
 
@@ -217,6 +219,26 @@ void describe('repair-cross-linked-playlists apply path', () => {
           "an unrelated user's follow is left alone",
         );
 
+        // The offline pull joins playlist_ownership, which has no delete
+        // trigger — without this tombstone the adopter's device would keep the
+        // playlist (and its climbs) forever. Scoped to the adopter, so the
+        // creator's devices never see it.
+        const playlistTombstones = await transaction
+          .select({ recordId: syncDeletions.recordId, userId: syncDeletions.userId })
+          .from(syncDeletions)
+          .where(and(eq(syncDeletions.tableName, 'playlists'), eq(syncDeletions.recordId, `${tag}-json-import`)));
+        assert.deepEqual(
+          playlistTombstones,
+          [{ recordId: `${tag}-json-import`, userId: adopterUserId }],
+          'exactly one adopter-scoped playlists tombstone is written',
+        );
+
+        const creatorScopedTombstones = await transaction
+          .select({ id: syncDeletions.id })
+          .from(syncDeletions)
+          .where(and(eq(syncDeletions.tableName, 'playlists'), eq(syncDeletions.userId, creatorUserId)));
+        assert.equal(creatorScopedTombstones.length, 0, "the creator's clients must not be told to drop the playlist");
+
         // --- idempotence: the playlist is no longer cross-linked -------------
         const afterRepair = await loadCrossLinkedPlaylists(transaction, [String(jsonImportPlaylistId)]);
         assert.deepEqual(afterRepair, []);
@@ -230,6 +252,7 @@ void describe('repair-cross-linked-playlists apply path', () => {
           ownershipRowsDeleted: 0,
           pinsDeleted: 0,
           followsDeleted: 0,
+          tombstonesWritten: 0,
           skippedByDrift: [String(jsonImportPlaylistId)],
         });
 

--- a/packages/db/scripts/repair-cross-linked-playlists.integration.test.ts
+++ b/packages/db/scripts/repair-cross-linked-playlists.integration.test.ts
@@ -1,0 +1,259 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { eq, inArray } from 'drizzle-orm';
+import { createScriptDb, isLocalDatabaseUrl } from './db-connection.js';
+import { playlistClimbs, playlistOwnership, playlists, userPlaylistPins } from '../src/schema/app/playlists.js';
+import { playlistFollows } from '../src/schema/app/follows.js';
+import { users } from '../src/schema/auth/users.js';
+import { applyRepairPlans, loadAdopterAttachments, loadCrossLinkedPlaylists } from './repair-cross-linked-playlists.js';
+import { planCrossLinkedPlaylistRepairs, selectApplyablePlans } from './repair-cross-linked-playlists-helpers.js';
+
+/**
+ * Only ever runs against a local database. `.env.local` carries a real
+ * (read-only) production credential and db-connection.ts loads it into
+ * process.env on import, so the local check is not optional — isLocalDatabaseUrl
+ * fails closed on anything it can't positively identify as local/dev.
+ */
+function repairTestDatabaseUrl(): string | null {
+  const candidateUrl =
+    process.env.REPAIR_CROSS_LINKED_PLAYLISTS_DB_URL ?? process.env.DATABASE_URL ?? process.env.POSTGRES_URL ?? null;
+  if (!candidateUrl) {
+    return null;
+  }
+  return isLocalDatabaseUrl(candidateUrl) ? candidateUrl : null;
+}
+
+const CREATOR_OWNED_AT = new Date('2026-03-29T08:00:00Z');
+const ADOPTER_OWNED_AT = new Date('2026-03-29T14:00:00Z');
+
+void describe('repair-cross-linked-playlists apply path', () => {
+  void it('revokes only the adopter ownership row and its pin/follow, leaving everything else intact', async (testContext) => {
+    const databaseUrl = repairTestDatabaseUrl();
+    if (!databaseUrl) {
+      testContext.skip(
+        'set REPAIR_CROSS_LINKED_PLAYLISTS_DB_URL (or DATABASE_URL) to a local migrated database to run this integration test',
+      );
+      return;
+    }
+
+    const { db, close } = createScriptDb(databaseUrl);
+    const rollbackMarker = new Error('rollback repair fixture');
+
+    try {
+      await db.transaction(async (transaction) => {
+        const tag = `repair-xlink-${Date.now()}`;
+        const creatorUserId = `${tag}-creator`;
+        const adopterUserId = `${tag}-adopter`;
+        const lowercaseUserId = `${tag}-lower`;
+        const uppercaseUserId = `${tag}-upper`;
+        const strangerUserId = `${tag}-stranger`;
+
+        await transaction.insert(users).values([
+          { id: creatorUserId, email: `${tag}-creator@example.test`, name: 'Creator' },
+          { id: adopterUserId, email: `${tag}-adopter@example.test`, name: 'Adopter' },
+          { id: lowercaseUserId, email: `${tag}-dupe@example.test`, name: 'Dupe lower' },
+          { id: uppercaseUserId, email: `${tag}-DUPE@example.test`, name: 'Dupe upper' },
+          { id: strangerUserId, email: `${tag}-stranger@example.test`, name: 'Stranger' },
+        ]);
+
+        async function insertPlaylist(suffix: string, auroraId: string): Promise<bigint> {
+          const [inserted] = await transaction
+            .insert(playlists)
+            .values({
+              uuid: `${tag}-${suffix}`,
+              boardType: 'kilter',
+              name: `Fixture ${suffix}`,
+              auroraType: 'circuits',
+              auroraId,
+              isPublic: false,
+            })
+            .returning({ id: playlists.id });
+          assert.ok(inserted, `expected an inserted playlist for ${suffix}`);
+          return inserted.id;
+        }
+
+        // 1. json-import residue: repairable.
+        const jsonImportPlaylistId = await insertPlaylist('json-import', `json-import-circuit-${tag}`);
+        // 2. two accounts of the same person: deferred to merge-accounts.ts (#3278).
+        const mergeCandidatePlaylistId = await insertPlaylist('merge-candidate', `circuit-${tag}-merge`);
+        // 3. two genuinely different people on a real Aurora circuit: refused.
+        const unknownCausePlaylistId = await insertPlaylist('unknown-cause', `circuit-${tag}-unknown`);
+        // 4. a healthy single-owner playlist: must never be picked up at all.
+        const singleOwnerPlaylistId = await insertPlaylist('single-owner', `circuit-${tag}-single`);
+
+        await transaction.insert(playlistOwnership).values([
+          { playlistId: jsonImportPlaylistId, userId: creatorUserId, role: 'owner', createdAt: CREATOR_OWNED_AT },
+          { playlistId: jsonImportPlaylistId, userId: adopterUserId, role: 'owner', createdAt: ADOPTER_OWNED_AT },
+          { playlistId: mergeCandidatePlaylistId, userId: lowercaseUserId, role: 'owner', createdAt: CREATOR_OWNED_AT },
+          { playlistId: mergeCandidatePlaylistId, userId: uppercaseUserId, role: 'owner', createdAt: ADOPTER_OWNED_AT },
+          { playlistId: unknownCausePlaylistId, userId: creatorUserId, role: 'owner', createdAt: CREATOR_OWNED_AT },
+          { playlistId: unknownCausePlaylistId, userId: strangerUserId, role: 'owner', createdAt: ADOPTER_OWNED_AT },
+          { playlistId: singleOwnerPlaylistId, userId: creatorUserId, role: 'owner', createdAt: CREATOR_OWNED_AT },
+        ]);
+
+        await transaction.insert(playlistClimbs).values([
+          { playlistId: jsonImportPlaylistId, climbUuid: `${tag}-climb-a`, angle: 40, position: 0 },
+          { playlistId: jsonImportPlaylistId, climbUuid: `${tag}-climb-b`, angle: 40, position: 1 },
+        ]);
+
+        await transaction.insert(userPlaylistPins).values([
+          { playlistId: jsonImportPlaylistId, userId: adopterUserId },
+          { playlistId: jsonImportPlaylistId, userId: creatorUserId },
+          { playlistId: mergeCandidatePlaylistId, userId: uppercaseUserId },
+        ]);
+
+        await transaction.insert(playlistFollows).values([
+          { playlistUuid: `${tag}-json-import`, followerId: adopterUserId },
+          { playlistUuid: `${tag}-json-import`, followerId: strangerUserId },
+        ]);
+
+        const fixturePlaylistIds = [
+          jsonImportPlaylistId,
+          mergeCandidatePlaylistId,
+          unknownCausePlaylistId,
+          singleOwnerPlaylistId,
+        ];
+        const fixtureIdFilter = fixturePlaylistIds.map(String);
+
+        async function countOwnershipRows(): Promise<number> {
+          const rows = await transaction
+            .select({ id: playlistOwnership.id })
+            .from(playlistOwnership)
+            .where(inArray(playlistOwnership.playlistId, fixturePlaylistIds));
+          return rows.length;
+        }
+
+        // --- dry-run: plan everything, write nothing -------------------------
+        const crossLinked = await loadCrossLinkedPlaylists(transaction, fixtureIdFilter);
+        assert.deepEqual(
+          crossLinked.map((playlist) => playlist.playlistId).sort(),
+          [jsonImportPlaylistId, mergeCandidatePlaylistId, unknownCausePlaylistId].map(String).sort(),
+          'the single-owner playlist must not be reported as cross-linked',
+        );
+
+        const jsonImportReport = crossLinked.find((playlist) => playlist.playlistId === String(jsonImportPlaylistId));
+        assert.equal(jsonImportReport?.climbCount, 2);
+        assert.equal(jsonImportReport?.owners.length, 2);
+
+        const plans = planCrossLinkedPlaylistRepairs(crossLinked);
+        const actionByPlaylistId = new Map(plans.map((plan) => [plan.playlist.playlistId, plan.action]));
+        assert.equal(actionByPlaylistId.get(String(jsonImportPlaylistId)), 'revoke-adopter');
+        assert.equal(actionByPlaylistId.get(String(mergeCandidatePlaylistId)), 'defer-to-account-merge');
+        assert.equal(actionByPlaylistId.get(String(unknownCausePlaylistId)), 'refuse');
+
+        const attachments = await loadAdopterAttachments(transaction, plans);
+        assert.equal(attachments.pinnedPlaylistIds.has(String(jsonImportPlaylistId)), true);
+        assert.equal(attachments.followedPlaylistUuids.has(`${tag}-json-import`), true);
+
+        assert.equal(await countOwnershipRows(), 7, 'planning and reporting must not write');
+
+        // --- scoping ---------------------------------------------------------
+        const scopedToOnePlaylist = await loadCrossLinkedPlaylists(transaction, [String(mergeCandidatePlaylistId)]);
+        assert.deepEqual(
+          scopedToOnePlaylist.map((playlist) => playlist.playlistId),
+          [String(mergeCandidatePlaylistId)],
+        );
+
+        // --- apply -----------------------------------------------------------
+        const applyablePlans = selectApplyablePlans(plans, { includeMergeCandidates: false });
+        assert.deepEqual(
+          applyablePlans.map((plan) => plan.playlist.playlistId),
+          [String(jsonImportPlaylistId)],
+        );
+
+        const counts = await applyRepairPlans(transaction, applyablePlans);
+        assert.deepEqual(counts, {
+          ownershipRowsDeleted: 1,
+          pinsDeleted: 1,
+          followsDeleted: 1,
+          skippedByDrift: [],
+        });
+
+        const survivingOwners = await transaction
+          .select({ playlistId: playlistOwnership.playlistId, userId: playlistOwnership.userId })
+          .from(playlistOwnership)
+          .where(inArray(playlistOwnership.playlistId, fixturePlaylistIds));
+        assert.deepEqual(
+          survivingOwners.map((owner) => `${owner.playlistId}:${owner.userId}`).sort(),
+          [
+            `${jsonImportPlaylistId}:${creatorUserId}`,
+            `${mergeCandidatePlaylistId}:${lowercaseUserId}`,
+            `${mergeCandidatePlaylistId}:${uppercaseUserId}`,
+            `${singleOwnerPlaylistId}:${creatorUserId}`,
+            `${unknownCausePlaylistId}:${creatorUserId}`,
+            `${unknownCausePlaylistId}:${strangerUserId}`,
+          ].sort(),
+        );
+
+        const survivingPlaylists = await transaction
+          .select({ id: playlists.id })
+          .from(playlists)
+          .where(inArray(playlists.id, fixturePlaylistIds));
+        assert.equal(survivingPlaylists.length, 4, 'no playlist may be deleted');
+
+        const survivingClimbs = await transaction
+          .select({ id: playlistClimbs.id })
+          .from(playlistClimbs)
+          .where(eq(playlistClimbs.playlistId, jsonImportPlaylistId));
+        assert.equal(survivingClimbs.length, 2, 'playlist_climbs must be untouched');
+
+        const survivingPins = await transaction
+          .select({ playlistId: userPlaylistPins.playlistId, userId: userPlaylistPins.userId })
+          .from(userPlaylistPins)
+          .where(inArray(userPlaylistPins.playlistId, fixturePlaylistIds));
+        assert.deepEqual(
+          survivingPins.map((pin) => `${pin.playlistId}:${pin.userId}`).sort(),
+          [`${jsonImportPlaylistId}:${creatorUserId}`, `${mergeCandidatePlaylistId}:${uppercaseUserId}`].sort(),
+          "only the adopter's pin is removed",
+        );
+
+        const survivingFollows = await transaction
+          .select({ followerId: playlistFollows.followerId })
+          .from(playlistFollows)
+          .where(eq(playlistFollows.playlistUuid, `${tag}-json-import`));
+        assert.deepEqual(
+          survivingFollows.map((follow) => follow.followerId),
+          [strangerUserId],
+          "an unrelated user's follow is left alone",
+        );
+
+        // --- idempotence: the playlist is no longer cross-linked -------------
+        const afterRepair = await loadCrossLinkedPlaylists(transaction, [String(jsonImportPlaylistId)]);
+        assert.deepEqual(afterRepair, []);
+
+        // --- drift guard: a stale plan is skipped, not applied ---------------
+        const stalePlans = selectApplyablePlans(planCrossLinkedPlaylistRepairs(crossLinked), {
+          includeMergeCandidates: false,
+        });
+        const staleCounts = await applyRepairPlans(transaction, stalePlans);
+        assert.deepEqual(staleCounts, {
+          ownershipRowsDeleted: 0,
+          pinsDeleted: 0,
+          followsDeleted: 0,
+          skippedByDrift: [String(jsonImportPlaylistId)],
+        });
+
+        // --- opting in surfaces the merge candidate, still not the refusal ---
+        const withMergeCandidates = selectApplyablePlans(plans, { includeMergeCandidates: true });
+        assert.deepEqual(
+          withMergeCandidates.map((plan) => plan.playlist.playlistId).sort(),
+          [String(jsonImportPlaylistId), String(mergeCandidatePlaylistId)].sort(),
+        );
+
+        const survivingUsers = await transaction
+          .select({ id: users.id })
+          .from(users)
+          .where(inArray(users.id, [creatorUserId, adopterUserId, lowercaseUserId, uppercaseUserId, strangerUserId]));
+        assert.equal(survivingUsers.length, 5, 'no user row may be deleted');
+
+        throw rollbackMarker;
+      });
+    } catch (error: unknown) {
+      if (error !== rollbackMarker) {
+        throw error;
+      }
+    } finally {
+      await close();
+    }
+  });
+});

--- a/packages/db/scripts/repair-cross-linked-playlists.integration.test.ts
+++ b/packages/db/scripts/repair-cross-linked-playlists.integration.test.ts
@@ -263,6 +263,29 @@ void describe('repair-cross-linked-playlists apply path', () => {
           [String(jsonImportPlaylistId), String(mergeCandidatePlaylistId)].sort(),
         );
 
+        // The opt-in widens the write set, so exercise it end-to-end rather than
+        // trusting that a defer-to-account-merge plan walks the same revoke path.
+        // The json-import plan rides along and is drift-skipped: it was already
+        // repaired above.
+        const mergeCandidateCounts = await applyRepairPlans(transaction, withMergeCandidates);
+        assert.deepEqual(mergeCandidateCounts, {
+          ownershipRowsDeleted: 1,
+          pinsDeleted: 1,
+          followsDeleted: 0,
+          tombstonesWritten: 1,
+          skippedByDrift: [String(jsonImportPlaylistId)],
+        });
+
+        const mergeCandidateOwners = await transaction
+          .select({ userId: playlistOwnership.userId })
+          .from(playlistOwnership)
+          .where(eq(playlistOwnership.playlistId, mergeCandidatePlaylistId));
+        assert.deepEqual(
+          mergeCandidateOwners.map((owner) => owner.userId),
+          [lowercaseUserId],
+          'the earlier of the two duplicate accounts keeps the playlist',
+        );
+
         const survivingUsers = await transaction
           .select({ id: users.id })
           .from(users)

--- a/packages/db/scripts/repair-cross-linked-playlists.ts
+++ b/packages/db/scripts/repair-cross-linked-playlists.ts
@@ -1,0 +1,618 @@
+/**
+ * Audit — and, with --apply, repair — playlists that carry `playlist_ownership`
+ * rows for two different Boardsesh users (#3541).
+ *
+ * These exist because one Aurora account could once be linked to two Boardsesh
+ * users, and both the JSON importer and the Aurora circuits sync keyed playlists
+ * on the GLOBAL `playlists_aurora_id_idx`. All three source defects are fixed
+ * (see the header of repair-cross-linked-playlists-helpers.ts), so this script
+ * exists purely to clean up the rows that were written before the guards landed.
+ *
+ * SAFETY
+ *   - Dry-run by default. --apply is the only mode that writes.
+ *   - The only rows it ever deletes are `playlist_ownership`, `user_playlist_pins`
+ *     and `playlist_follows` rows belonging to the LATER of the two owners.
+ *     It never deletes a playlist, a playlist_climbs row, a tick, a credential,
+ *     or a user.
+ *   - Duplicate-account pairs (two accounts with case-variant emails) are
+ *     reported but NOT touched: merge-accounts.ts (#3278) is the right tool for
+ *     those, because it also moves the ticks and credentials this script leaves
+ *     alone. --include-merge-candidates opts in anyway.
+ *   - Anything the helpers can't attribute to a known defect is refused, printed,
+ *     and left for a human.
+ *
+ * Usage:
+ *   vp run db:repair-cross-linked-playlists
+ *   vp run db:repair-cross-linked-playlists --playlist-ids 12,34
+ *   vp run db:repair-cross-linked-playlists --apply
+ *   vp run db:repair-cross-linked-playlists --apply --include-merge-candidates
+ *
+ * (A `--` separator before the flags also works — `vp` forwards it to the script
+ * verbatim and parseArgs skips it — but it isn't needed.)
+ */
+import { and, eq, inArray, isNotNull, or, sql } from 'drizzle-orm';
+import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
+import { pathToFileURL } from 'node:url';
+import { createScriptDb } from './db-connection.js';
+import { playlistClimbs, playlistOwnership, playlists, userPlaylistPins } from '../src/schema/app/playlists.js';
+import { playlistFollows } from '../src/schema/app/follows.js';
+import { auroraCredentials, userBoardMappings } from '../src/schema/auth/mappings.js';
+import { users } from '../src/schema/auth/users.js';
+import {
+  DEFAULT_MIN_OWNERSHIP_SPREAD_MINUTES,
+  planCrossLinkedPlaylistRepairs,
+  selectApplyablePlans,
+  summarizeRepairPlans,
+  type CrossLinkRepairPlan,
+  type CrossLinkedPlaylist,
+  type PlaylistOwnerRow,
+} from './repair-cross-linked-playlists-helpers.js';
+
+const LOG_TAG = '[repair-cross-linked-playlists]';
+
+const APPLY_FLAG = '--apply';
+const PLAYLIST_IDS_FLAG = '--playlist-ids';
+const INCLUDE_MERGE_CANDIDATES_FLAG = '--include-merge-candidates';
+const MIN_SPREAD_MINUTES_FLAG = '--min-spread-minutes';
+const HELP_FLAG = '--help';
+const ARG_SEPARATOR = '--';
+
+type DrizzleDb = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
+
+export type ScriptArgs = {
+  apply: boolean;
+  playlistIds: string[] | null;
+  includeMergeCandidates: boolean;
+  minSpreadMinutes: number;
+  help: boolean;
+};
+
+/**
+ * One board account (an Aurora numeric id, or a Kilter Keycloak subject) that
+ * resolves to more than one Boardsesh user. Reported only — repairing these
+ * means moving ticks and credentials, which is merge-accounts.ts's job (#3278).
+ */
+export type CrossLinkedBoardAccount = {
+  source: 'aurora_credentials' | 'user_board_mappings';
+  boardType: string;
+  boardAccountKey: string;
+  userIds: string[];
+};
+
+export type AdopterAttachments = {
+  /** `user_playlist_pins` rows the adopter holds on the cross-linked playlist. */
+  pinnedPlaylistIds: Set<string>;
+  /** `playlist_follows` rows the adopter holds, keyed by playlist uuid. */
+  followedPlaylistUuids: Set<string>;
+};
+
+export type AppliedRepairCounts = {
+  ownershipRowsDeleted: number;
+  pinsDeleted: number;
+  followsDeleted: number;
+  /** Playlist ids skipped because their ownership rows changed after the plan was built. */
+  skippedByDrift: string[];
+};
+
+function readOptionValue(args: string[], optionIndex: number, flagName: string): { value: string; consumed: number } {
+  const currentArg = args[optionIndex];
+  const inlineSeparatorIndex = currentArg.indexOf('=');
+  if (inlineSeparatorIndex !== -1) {
+    return { value: currentArg.slice(inlineSeparatorIndex + 1), consumed: 0 };
+  }
+  const nextArg = args[optionIndex + 1];
+  if (!nextArg || nextArg.startsWith('--')) {
+    console.error(`${LOG_TAG} ${flagName} requires a value.`);
+    process.exit(2);
+  }
+  return { value: nextArg, consumed: 1 };
+}
+
+function parsePlaylistIds(rawValue: string): string[] {
+  const parsedIds = rawValue
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  if (parsedIds.length === 0) {
+    console.error(`${LOG_TAG} ${PLAYLIST_IDS_FLAG} requires at least one id.`);
+    process.exit(2);
+  }
+  for (const playlistId of parsedIds) {
+    if (!/^\d+$/.test(playlistId)) {
+      console.error(`${LOG_TAG} ${PLAYLIST_IDS_FLAG}: "${playlistId}" is not a playlist id.`);
+      process.exit(2);
+    }
+  }
+  return parsedIds;
+}
+
+function parseNonNegativeNumber(rawValue: string, flagName: string): number {
+  const parsedValue = Number(rawValue);
+  if (!Number.isFinite(parsedValue) || parsedValue < 0) {
+    console.error(`${LOG_TAG} ${flagName} requires a non-negative number of minutes.`);
+    process.exit(2);
+  }
+  return parsedValue;
+}
+
+export function parseArgs(args: string[]): ScriptArgs {
+  const parsedArgs: ScriptArgs = {
+    apply: false,
+    playlistIds: null,
+    includeMergeCandidates: false,
+    minSpreadMinutes: DEFAULT_MIN_OWNERSHIP_SPREAD_MINUTES,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index++) {
+    const currentArg = args[index];
+    const flagName = currentArg.split('=')[0];
+
+    if (currentArg === ARG_SEPARATOR) {
+      // `vp run db:repair-cross-linked-playlists -- --apply` forwards the
+      // separator verbatim; tolerate it rather than rejecting it.
+      continue;
+    }
+    if (currentArg === APPLY_FLAG) {
+      parsedArgs.apply = true;
+      continue;
+    }
+    if (currentArg === INCLUDE_MERGE_CANDIDATES_FLAG) {
+      parsedArgs.includeMergeCandidates = true;
+      continue;
+    }
+    if (currentArg === HELP_FLAG) {
+      parsedArgs.help = true;
+      continue;
+    }
+    if (flagName === PLAYLIST_IDS_FLAG) {
+      const { value, consumed } = readOptionValue(args, index, PLAYLIST_IDS_FLAG);
+      parsedArgs.playlistIds = parsePlaylistIds(value);
+      index += consumed;
+      continue;
+    }
+    if (flagName === MIN_SPREAD_MINUTES_FLAG) {
+      const { value, consumed } = readOptionValue(args, index, MIN_SPREAD_MINUTES_FLAG);
+      parsedArgs.minSpreadMinutes = parseNonNegativeNumber(value, MIN_SPREAD_MINUTES_FLAG);
+      index += consumed;
+      continue;
+    }
+
+    console.error(`${LOG_TAG} Unknown argument: ${currentArg}`);
+    process.exit(2);
+  }
+
+  return parsedArgs;
+}
+
+function printHelp(): void {
+  console.info(`Usage:
+  vp run db:repair-cross-linked-playlists
+  vp run db:repair-cross-linked-playlists --playlist-ids 12,34
+  vp run db:repair-cross-linked-playlists --apply
+  vp run db:repair-cross-linked-playlists --apply --include-merge-candidates
+
+Options:
+  --apply                       Delete the later owner's playlist_ownership row (plus that
+                                user's pin/follow on the same playlist). Omit for dry-run.
+  --playlist-ids <a,b,c>        Restrict the run to these playlists.id values.
+  --include-merge-candidates    Also repair pairs whose two owners are the same email up to
+                                case. Off by default — merge-accounts.ts (#3278) handles those
+                                better because it moves their ticks and credentials too.
+  --min-spread-minutes <n>      Refuse a pair whose two ownership rows are closer together
+                                than this (default ${DEFAULT_MIN_OWNERSHIP_SPREAD_MINUTES}).
+  --help                        Show this help text.
+
+This script never deletes a playlist, a playlist_climbs row, a tick, a board
+credential, or a user.`);
+}
+
+/** playlists.id is a bigint column; the helpers carry it as a decimal string. */
+function toPlaylistIdKey(playlistId: bigint | number | string): string {
+  return String(playlistId);
+}
+
+export async function loadCrossLinkedPlaylists(
+  commandDb: DrizzleDb,
+  playlistIdFilter: string[] | null,
+): Promise<CrossLinkedPlaylist[]> {
+  const scopedPlaylistIds = playlistIdFilter?.map((playlistId) => BigInt(playlistId)) ?? null;
+  if (scopedPlaylistIds !== null && scopedPlaylistIds.length === 0) {
+    return [];
+  }
+
+  const multiOwnerRows = await commandDb
+    .select({ playlistId: playlistOwnership.playlistId })
+    .from(playlistOwnership)
+    .where(scopedPlaylistIds ? inArray(playlistOwnership.playlistId, scopedPlaylistIds) : undefined)
+    .groupBy(playlistOwnership.playlistId)
+    .having(sql`count(distinct ${playlistOwnership.userId}) > 1`);
+
+  const crossLinkedIds = multiOwnerRows.map((row) => row.playlistId);
+  if (crossLinkedIds.length === 0) {
+    return [];
+  }
+
+  const ownerRows = await commandDb
+    .select({
+      playlistId: playlists.id,
+      playlistUuid: playlists.uuid,
+      name: playlists.name,
+      boardType: playlists.boardType,
+      auroraId: playlists.auroraId,
+      kilterId: playlists.kilterId,
+      isPublic: playlists.isPublic,
+      ownerUserId: playlistOwnership.userId,
+      ownerEmail: users.email,
+      ownerRole: playlistOwnership.role,
+      ownerCreatedAt: playlistOwnership.createdAt,
+    })
+    .from(playlistOwnership)
+    .innerJoin(playlists, eq(playlists.id, playlistOwnership.playlistId))
+    .leftJoin(users, eq(users.id, playlistOwnership.userId))
+    .where(inArray(playlistOwnership.playlistId, crossLinkedIds))
+    .orderBy(playlistOwnership.playlistId, playlistOwnership.createdAt);
+
+  const climbCountRows = await commandDb
+    .select({ playlistId: playlistClimbs.playlistId, climbCount: sql<number>`count(*)::int` })
+    .from(playlistClimbs)
+    .where(inArray(playlistClimbs.playlistId, crossLinkedIds))
+    .groupBy(playlistClimbs.playlistId);
+
+  const climbCountByPlaylistId = new Map(
+    climbCountRows.map((row) => [toPlaylistIdKey(row.playlistId), Number(row.climbCount)]),
+  );
+
+  const crossLinkedByPlaylistId = new Map<string, CrossLinkedPlaylist>();
+  for (const row of ownerRows) {
+    const playlistIdKey = toPlaylistIdKey(row.playlistId);
+    let crossLinked = crossLinkedByPlaylistId.get(playlistIdKey);
+    if (!crossLinked) {
+      crossLinked = {
+        playlistId: playlistIdKey,
+        playlistUuid: row.playlistUuid,
+        name: row.name,
+        boardType: row.boardType,
+        auroraId: row.auroraId,
+        kilterId: row.kilterId,
+        isPublic: row.isPublic,
+        climbCount: climbCountByPlaylistId.get(playlistIdKey) ?? 0,
+        owners: [],
+      };
+      crossLinkedByPlaylistId.set(playlistIdKey, crossLinked);
+    }
+    crossLinked.owners.push({
+      userId: row.ownerUserId,
+      userEmail: row.ownerEmail,
+      role: row.ownerRole,
+      createdAt: new Date(row.ownerCreatedAt),
+    });
+  }
+
+  return [...crossLinkedByPlaylistId.values()];
+}
+
+/**
+ * The pins and follows the LATER owner holds on the cross-linked playlists.
+ * These ride along with the revoked ownership row: leaving them behind would
+ * keep the playlist on the adopter's Pinned grid with no way to open it.
+ */
+export async function loadAdopterAttachments(
+  commandDb: DrizzleDb,
+  plans: CrossLinkRepairPlan[],
+): Promise<AdopterAttachments> {
+  const adopterPlans = plans.filter((plan): plan is CrossLinkRepairPlan & { adopter: PlaylistOwnerRow } =>
+    Boolean(plan.adopter),
+  );
+  if (adopterPlans.length === 0) {
+    return { pinnedPlaylistIds: new Set(), followedPlaylistUuids: new Set() };
+  }
+
+  const playlistIds = adopterPlans.map((plan) => BigInt(plan.playlist.playlistId));
+  const playlistUuids = adopterPlans.map((plan) => plan.playlist.playlistUuid);
+  const adopterUserIds = [...new Set(adopterPlans.map((plan) => plan.adopter.userId))];
+
+  const pinRows = await commandDb
+    .select({ playlistId: userPlaylistPins.playlistId, userId: userPlaylistPins.userId })
+    .from(userPlaylistPins)
+    .where(and(inArray(userPlaylistPins.playlistId, playlistIds), inArray(userPlaylistPins.userId, adopterUserIds)));
+
+  const followRows = await commandDb
+    .select({ playlistUuid: playlistFollows.playlistUuid, followerId: playlistFollows.followerId })
+    .from(playlistFollows)
+    .where(
+      and(inArray(playlistFollows.playlistUuid, playlistUuids), inArray(playlistFollows.followerId, adopterUserIds)),
+    );
+
+  const adopterUserIdByPlaylistId = new Map(
+    adopterPlans.map((plan) => [plan.playlist.playlistId, plan.adopter.userId]),
+  );
+  const adopterUserIdByPlaylistUuid = new Map(
+    adopterPlans.map((plan) => [plan.playlist.playlistUuid, plan.adopter.userId]),
+  );
+
+  return {
+    pinnedPlaylistIds: new Set(
+      pinRows
+        .filter((row) => adopterUserIdByPlaylistId.get(toPlaylistIdKey(row.playlistId)) === row.userId)
+        .map((row) => toPlaylistIdKey(row.playlistId)),
+    ),
+    followedPlaylistUuids: new Set(
+      followRows
+        .filter((row) => adopterUserIdByPlaylistUuid.get(row.playlistUuid) === row.followerId)
+        .map((row) => row.playlistUuid),
+    ),
+  };
+}
+
+/**
+ * Board accounts (Aurora numeric ids and Kilter subject strings) that resolve to
+ * more than one Boardsesh user. This is the upstream cause of the circuits-side
+ * cross-links, and repairing it means moving ticks and credentials — out of
+ * scope here, so it is audited and handed to merge-accounts.ts (#3278).
+ */
+export async function loadCrossLinkedBoardAccounts(commandDb: DrizzleDb): Promise<CrossLinkedBoardAccount[]> {
+  const credentialRows = await commandDb
+    .select({
+      boardType: auroraCredentials.boardType,
+      boardAccountKey: sql<string>`${auroraCredentials.auroraUserId}::text`,
+      userIds: sql<string[]>`array_agg(distinct ${auroraCredentials.userId})`,
+    })
+    .from(auroraCredentials)
+    .where(isNotNull(auroraCredentials.auroraUserId))
+    .groupBy(auroraCredentials.boardType, auroraCredentials.auroraUserId)
+    .having(sql`count(distinct ${auroraCredentials.userId}) > 1`);
+
+  const mappingAccountKey = sql<string>`coalesce(${userBoardMappings.boardUserIdText}, ${userBoardMappings.boardUserId}::text)`;
+  const mappingRows = await commandDb
+    .select({
+      boardType: userBoardMappings.boardType,
+      boardAccountKey: mappingAccountKey,
+      userIds: sql<string[]>`array_agg(distinct ${userBoardMappings.userId})`,
+    })
+    .from(userBoardMappings)
+    .where(or(isNotNull(userBoardMappings.boardUserId), isNotNull(userBoardMappings.boardUserIdText)))
+    .groupBy(userBoardMappings.boardType, mappingAccountKey)
+    .having(sql`count(distinct ${userBoardMappings.userId}) > 1`);
+
+  return [
+    ...credentialRows.map((row) => ({
+      source: 'aurora_credentials' as const,
+      boardType: row.boardType,
+      boardAccountKey: row.boardAccountKey,
+      userIds: [...row.userIds].sort(),
+    })),
+    ...mappingRows.map((row) => ({
+      source: 'user_board_mappings' as const,
+      boardType: row.boardType,
+      boardAccountKey: row.boardAccountKey,
+      userIds: [...row.userIds].sort(),
+    })),
+  ];
+}
+
+async function loadEmailsByUserId(commandDb: DrizzleDb, userIds: string[]): Promise<Map<string, string>> {
+  if (userIds.length === 0) {
+    return new Map();
+  }
+  const userRows = await commandDb
+    .select({ id: users.id, email: users.email })
+    .from(users)
+    .where(inArray(users.id, userIds));
+  return new Map(userRows.map((row) => [row.id, row.email]));
+}
+
+function describeOwner(owner: PlaylistOwnerRow): string {
+  return `${owner.userEmail ?? '(no email)'} [${owner.userId}] role=${owner.role} at ${owner.createdAt.toISOString()}`;
+}
+
+function printRepairReport(
+  plans: CrossLinkRepairPlan[],
+  attachments: AdopterAttachments,
+  scriptArgs: ScriptArgs,
+): void {
+  const summary = summarizeRepairPlans(plans);
+  console.info(
+    `${LOG_TAG} ${summary.playlists} cross-linked playlist(s), ${summary.ownershipRows} ownership row(s): ` +
+      `${summary.revokeAdopter} repairable, ${summary.deferToAccountMerge} deferred to merge-accounts.ts (#3278), ` +
+      `${summary.refused} refused.`,
+  );
+
+  for (const [planIndex, plan] of plans.entries()) {
+    const { playlist } = plan;
+    console.info('');
+    console.info(
+      `${LOG_TAG} ${planIndex + 1}. playlist #${playlist.playlistId} "${playlist.name}" (${playlist.boardType}, ${playlist.playlistUuid})`,
+    );
+    console.info(
+      `  action=${plan.action} cause=${plan.cause} climbs=${playlist.climbCount} public=${playlist.isPublic} ` +
+        `aurora_id=${playlist.auroraId ?? '(null)'} kilter_id=${playlist.kilterId ?? '(null)'}`,
+    );
+    if (plan.creator) {
+      console.info(`  creator: ${describeOwner(plan.creator)}`);
+    }
+    if (plan.adopter) {
+      const pinned = attachments.pinnedPlaylistIds.has(playlist.playlistId) ? ' (holds a pin)' : '';
+      const followed = attachments.followedPlaylistUuids.has(playlist.playlistUuid) ? ' (holds a follow)' : '';
+      console.info(`  adopter: ${describeOwner(plan.adopter)}${pinned}${followed}`);
+    }
+    if (plan.spreadMinutes !== null) {
+      console.info(`  spread: ${plan.spreadMinutes.toFixed(1)} min`);
+    }
+    console.info(`  reason: ${plan.reason}`);
+  }
+
+  if (!scriptArgs.apply) {
+    console.info('');
+    console.info(`${LOG_TAG} Dry-run only. Re-run with --apply to delete the adopter ownership rows above.`);
+  }
+}
+
+function printBoardAccountReport(boardAccounts: CrossLinkedBoardAccount[], emailsByUserId: Map<string, string>): void {
+  console.info('');
+  if (boardAccounts.length === 0) {
+    console.info(`${LOG_TAG} No board account is linked to more than one Boardsesh user.`);
+    return;
+  }
+
+  console.info(
+    `${LOG_TAG} ${boardAccounts.length} board account(s) linked to more than one Boardsesh user. ` +
+      `This script will NOT touch credentials, mappings, or ticks — use merge-accounts.ts (#3278) ` +
+      `or unlink the duplicate by hand.`,
+  );
+  for (const boardAccount of boardAccounts) {
+    const describedUsers = boardAccount.userIds
+      .map((userId) => `${emailsByUserId.get(userId) ?? '(no email)'} [${userId}]`)
+      .join(', ');
+    console.info(
+      `  ${boardAccount.source} ${boardAccount.boardType} account ${boardAccount.boardAccountKey} -> ${describedUsers}`,
+    );
+  }
+}
+
+/**
+ * Delete the adopter's ownership row (and their pin/follow on the same playlist)
+ * for every plan handed in. Must run inside a transaction — the caller owns the
+ * transaction so the integration test can roll the whole thing back.
+ *
+ * Re-reads and locks each playlist's ownership rows first: if they no longer
+ * match the plan (a concurrent sync, a manual fix, a second run), the playlist is
+ * skipped rather than repaired against stale facts.
+ */
+export async function applyRepairPlans(
+  transaction: DrizzleDb,
+  plans: CrossLinkRepairPlan[],
+): Promise<AppliedRepairCounts> {
+  await transaction.execute(sql`SELECT pg_advisory_xact_lock(hashtext('boardsesh:cross-linked-playlist-repair'))`);
+
+  const counts: AppliedRepairCounts = {
+    ownershipRowsDeleted: 0,
+    pinsDeleted: 0,
+    followsDeleted: 0,
+    skippedByDrift: [],
+  };
+
+  for (const plan of plans) {
+    const { adopter } = plan;
+    if (!adopter) {
+      counts.skippedByDrift.push(plan.playlist.playlistId);
+      continue;
+    }
+
+    const playlistId = BigInt(plan.playlist.playlistId);
+    const lockedOwners = await transaction
+      .select({
+        userId: playlistOwnership.userId,
+        role: playlistOwnership.role,
+        createdAt: playlistOwnership.createdAt,
+      })
+      .from(playlistOwnership)
+      .where(eq(playlistOwnership.playlistId, playlistId))
+      .for('update');
+
+    const plannedUserIds = plan.playlist.owners.map((owner) => owner.userId).sort();
+    const lockedUserIds = lockedOwners.map((owner) => owner.userId).sort();
+    const latestLockedOwner = [...lockedOwners].sort(
+      (first, second) => new Date(second.createdAt).getTime() - new Date(first.createdAt).getTime(),
+    )[0];
+
+    const stillMatchesPlan =
+      lockedUserIds.length === plannedUserIds.length &&
+      lockedUserIds.every((userId, index) => userId === plannedUserIds[index]) &&
+      latestLockedOwner?.userId === adopter.userId;
+
+    if (!stillMatchesPlan) {
+      console.warn(
+        `${LOG_TAG} playlist #${plan.playlist.playlistId}: ownership changed since the plan was built — skipping.`,
+      );
+      counts.skippedByDrift.push(plan.playlist.playlistId);
+      continue;
+    }
+
+    const deletedOwnership = await transaction
+      .delete(playlistOwnership)
+      .where(and(eq(playlistOwnership.playlistId, playlistId), eq(playlistOwnership.userId, adopter.userId)))
+      .returning({ id: playlistOwnership.id });
+    counts.ownershipRowsDeleted += deletedOwnership.length;
+
+    const deletedPins = await transaction
+      .delete(userPlaylistPins)
+      .where(and(eq(userPlaylistPins.playlistId, playlistId), eq(userPlaylistPins.userId, adopter.userId)))
+      .returning({ id: userPlaylistPins.id });
+    counts.pinsDeleted += deletedPins.length;
+
+    const deletedFollows = await transaction
+      .delete(playlistFollows)
+      .where(
+        and(
+          eq(playlistFollows.playlistUuid, plan.playlist.playlistUuid),
+          eq(playlistFollows.followerId, adopter.userId),
+        ),
+      )
+      .returning({ id: playlistFollows.id });
+    counts.followsDeleted += deletedFollows.length;
+  }
+
+  return counts;
+}
+
+async function main(): Promise<void> {
+  const scriptArgs = parseArgs(process.argv.slice(2));
+  if (scriptArgs.help) {
+    printHelp();
+    return;
+  }
+
+  const { db, close } = createScriptDb();
+
+  try {
+    const crossLinkedPlaylists = await loadCrossLinkedPlaylists(db, scriptArgs.playlistIds);
+    const plans = planCrossLinkedPlaylistRepairs(crossLinkedPlaylists, {
+      minSpreadMinutes: scriptArgs.minSpreadMinutes,
+    });
+    const attachments = await loadAdopterAttachments(db, plans);
+    printRepairReport(plans, attachments, scriptArgs);
+
+    const boardAccounts = await loadCrossLinkedBoardAccounts(db);
+    const boardAccountUserIds = [...new Set(boardAccounts.flatMap((boardAccount) => boardAccount.userIds))];
+    printBoardAccountReport(boardAccounts, await loadEmailsByUserId(db, boardAccountUserIds));
+
+    const applyablePlans = selectApplyablePlans(plans, {
+      includeMergeCandidates: scriptArgs.includeMergeCandidates,
+    });
+
+    if (!scriptArgs.apply) {
+      return;
+    }
+    if (applyablePlans.length === 0) {
+      console.info('');
+      console.info(`${LOG_TAG} Nothing to apply.`);
+      return;
+    }
+
+    const counts = await db.transaction(async (transaction) => applyRepairPlans(transaction, applyablePlans));
+
+    console.info('');
+    console.info(
+      `${LOG_TAG} Repair complete: ${counts.ownershipRowsDeleted} ownership row(s), ${counts.pinsDeleted} pin(s), ` +
+        `${counts.followsDeleted} follow(s) deleted. No playlist, climb, tick, or credential was touched.`,
+    );
+    if (counts.skippedByDrift.length > 0) {
+      console.info(
+        `${LOG_TAG} Skipped ${counts.skippedByDrift.length} playlist(s): ${counts.skippedByDrift.join(', ')}`,
+      );
+    }
+  } finally {
+    await close();
+  }
+}
+
+const isDirectRun = process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false;
+
+if (isDirectRun) {
+  main().catch((error: unknown) => {
+    console.error(`${LOG_TAG} failed:`, error);
+    process.exit(1);
+  });
+}

--- a/packages/db/scripts/repair-cross-linked-playlists.ts
+++ b/packages/db/scripts/repair-cross-linked-playlists.ts
@@ -544,6 +544,13 @@ export async function applyRepairPlans(
   for (const plan of plans) {
     const { adopter } = plan;
     if (!adopter) {
+      // Unreachable: selectApplyablePlans only passes revoke-adopter and
+      // defer-to-account-merge plans, and classifyCrossLinkedPlaylist always
+      // sets an adopter on both. Warn rather than fold it into the drift count
+      // so an unexpected shape is visible instead of looking like a lost race.
+      console.warn(
+        `${LOG_TAG} playlist #${plan.playlist.playlistId}: plan has no adopter — skipping (this should not happen).`,
+      );
       counts.skippedByDrift.push(plan.playlist.playlistId);
       continue;
     }

--- a/packages/db/scripts/repair-cross-linked-playlists.ts
+++ b/packages/db/scripts/repair-cross-linked-playlists.ts
@@ -20,6 +20,11 @@
  *     alone. --include-merge-candidates opts in anyway.
  *   - Anything the helpers can't attribute to a known defect is refused, printed,
  *     and left for a human.
+ *   - The one row --apply ADDS is an append-only `sync_deletions` tombstone
+ *     scoped to the adopter, so their offline clients drop the playlist they
+ *     just lost access to. Without it the revoke is invisible on-device: the
+ *     offline pull is gated on playlist_ownership and that table has no delete
+ *     trigger, so the local copy would linger forever.
  *
  * Usage:
  *   vp run db:repair-cross-linked-playlists
@@ -33,9 +38,10 @@
 import { and, eq, inArray, isNotNull, or, sql } from 'drizzle-orm';
 import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
 import { pathToFileURL } from 'node:url';
-import { createScriptDb } from './db-connection.js';
+import { createScriptDb, describeDatabaseHost, getScriptDatabaseUrl } from './db-connection.js';
 import { playlistClimbs, playlistOwnership, playlists, userPlaylistPins } from '../src/schema/app/playlists.js';
 import { playlistFollows } from '../src/schema/app/follows.js';
+import { syncDeletions } from '../src/schema/app/sync-deletions.js';
 import { auroraCredentials, userBoardMappings } from '../src/schema/auth/mappings.js';
 import { users } from '../src/schema/auth/users.js';
 import {
@@ -90,6 +96,8 @@ export type AppliedRepairCounts = {
   ownershipRowsDeleted: number;
   pinsDeleted: number;
   followsDeleted: number;
+  /** Append-only `sync_deletions` rows written so the adopter's offline clients drop the playlist. */
+  tombstonesWritten: number;
   /** Playlist ids skipped because their ownership rows changed after the plan was built. */
   skippedByDrift: string[];
 };
@@ -195,7 +203,9 @@ function printHelp(): void {
 
 Options:
   --apply                       Delete the later owner's playlist_ownership row (plus that
-                                user's pin/follow on the same playlist). Omit for dry-run.
+                                user's pin/follow on the same playlist) and write an
+                                adopter-scoped sync_deletions tombstone so their offline
+                                clients drop the playlist too. Omit for dry-run.
   --playlist-ids <a,b,c>        Restrict the run to these playlists.id values.
   --include-merge-candidates    Also repair pairs whose two owners are the same email up to
                                 case. Off by default — merge-accounts.ts (#3278) handles those
@@ -205,7 +215,8 @@ Options:
   --help                        Show this help text.
 
 This script never deletes a playlist, a playlist_climbs row, a tick, a board
-credential, or a user.`);
+credential, or a user. The only row it ever adds is an append-only
+sync_deletions tombstone.`);
 }
 
 /** playlists.id is a bigint column; the helpers carry it as a decimal string. */
@@ -407,8 +418,25 @@ function describeOwner(owner: PlaylistOwnerRow): string {
   return `${owner.userEmail ?? '(no email)'} [${owner.userId}] role=${owner.role} at ${owner.createdAt.toISOString()}`;
 }
 
+/**
+ * What --apply would touch, counted from the plans it is actually allowed to
+ * write. The dry-run prints this so the totals can be checked against a
+ * pg_dump (or against the by-hand sample above) before anyone writes.
+ */
+export function countPlannedDeletions(
+  applyablePlans: CrossLinkRepairPlan[],
+  attachments: AdopterAttachments,
+): { ownershipRows: number; pins: number; follows: number } {
+  return {
+    ownershipRows: applyablePlans.length,
+    pins: applyablePlans.filter((plan) => attachments.pinnedPlaylistIds.has(plan.playlist.playlistId)).length,
+    follows: applyablePlans.filter((plan) => attachments.followedPlaylistUuids.has(plan.playlist.playlistUuid)).length,
+  };
+}
+
 function printRepairReport(
   plans: CrossLinkRepairPlan[],
+  applyablePlans: CrossLinkRepairPlan[],
   attachments: AdopterAttachments,
   scriptArgs: ScriptArgs,
 ): void {
@@ -443,9 +471,27 @@ function printRepairReport(
     console.info(`  reason: ${plan.reason}`);
   }
 
+  const plannedDeletions = countPlannedDeletions(applyablePlans, attachments);
+  const deferredButExcluded = scriptArgs.includeMergeCandidates
+    ? 0
+    : plans.filter((plan) => plan.action === 'defer-to-account-merge').length;
+
+  console.info('');
+  console.info(
+    `${LOG_TAG} ${scriptArgs.apply ? 'Applying to' : 'A --apply run would touch'} ${applyablePlans.length} playlist(s): ` +
+      `${plannedDeletions.ownershipRows} ownership row(s), ${plannedDeletions.pins} pin(s), ` +
+      `${plannedDeletions.follows} follow(s) deleted, plus ${applyablePlans.length} adopter-scoped ` +
+      `sync_deletions tombstone(s) so their offline clients drop the playlist. ` +
+      `${summarizeRepairPlans(plans).refused} refused playlist(s) are reported only and never written.`,
+  );
+  if (deferredButExcluded > 0) {
+    console.info(
+      `${LOG_TAG} ${deferredButExcluded} duplicate-account playlist(s) are excluded — pass ` +
+        `${INCLUDE_MERGE_CANDIDATES_FLAG} to include them, or merge the accounts with merge-accounts.ts (#3278).`,
+    );
+  }
   if (!scriptArgs.apply) {
-    console.info('');
-    console.info(`${LOG_TAG} Dry-run only. Re-run with --apply to delete the adopter ownership rows above.`);
+    console.info(`${LOG_TAG} Dry-run only. Nothing was written. Take a pg_dump before re-running with ${APPLY_FLAG}.`);
   }
 }
 
@@ -473,8 +519,9 @@ function printBoardAccountReport(boardAccounts: CrossLinkedBoardAccount[], email
 
 /**
  * Delete the adopter's ownership row (and their pin/follow on the same playlist)
- * for every plan handed in. Must run inside a transaction — the caller owns the
- * transaction so the integration test can roll the whole thing back.
+ * for every plan handed in, then tombstone the playlist for that adopter so
+ * their offline clients drop it. Must run inside a transaction — the caller owns
+ * the transaction so the integration test can roll the whole thing back.
  *
  * Re-reads and locks each playlist's ownership rows first: if they no longer
  * match the plan (a concurrent sync, a manual fix, a second run), the playlist is
@@ -490,6 +537,7 @@ export async function applyRepairPlans(
     ownershipRowsDeleted: 0,
     pinsDeleted: 0,
     followsDeleted: 0,
+    tombstonesWritten: 0,
     skippedByDrift: [],
   };
 
@@ -552,6 +600,23 @@ export async function applyRepairPlans(
       )
       .returning({ id: playlistFollows.id });
     counts.followsDeleted += deletedFollows.length;
+
+    // The offline pull joins playlist_ownership (syncPlaylists /
+    // syncPlaylistClimbs), and playlist_ownership carries no delete trigger, so
+    // revoking the row alone just makes the playlist stop arriving — the
+    // adopter's local SQLite copy and its playlist_climbs rows would survive
+    // forever. This adopter-scoped tombstone is what removes them; pull-client
+    // cascades the local climbs off a `playlists` tombstone, matching 0144's
+    // "no child tombstones for a whole-playlist delete" rule. The creator's
+    // devices never see it. Append-only: it deletes nothing.
+    if (deletedOwnership.length > 0) {
+      await transaction.insert(syncDeletions).values({
+        tableName: 'playlists',
+        recordId: plan.playlist.playlistUuid,
+        userId: adopter.userId,
+      });
+      counts.tombstonesWritten += 1;
+    }
   }
 
   return counts;
@@ -564,6 +629,14 @@ async function main(): Promise<void> {
     return;
   }
 
+  // Name the target before doing anything: db-connection.ts loads .env.local,
+  // which in this repo can hold a real production credential, so "which
+  // database am I about to write to" must not be something the operator has to
+  // infer from their shell history.
+  console.info(
+    `${LOG_TAG} ${scriptArgs.apply ? 'WRITE MODE (--apply)' : 'Read-only audit (dry-run)'} against ${describeDatabaseHost(getScriptDatabaseUrl())}`,
+  );
+
   const { db, close } = createScriptDb();
 
   try {
@@ -572,15 +645,14 @@ async function main(): Promise<void> {
       minSpreadMinutes: scriptArgs.minSpreadMinutes,
     });
     const attachments = await loadAdopterAttachments(db, plans);
-    printRepairReport(plans, attachments, scriptArgs);
+    const applyablePlans = selectApplyablePlans(plans, {
+      includeMergeCandidates: scriptArgs.includeMergeCandidates,
+    });
+    printRepairReport(plans, applyablePlans, attachments, scriptArgs);
 
     const boardAccounts = await loadCrossLinkedBoardAccounts(db);
     const boardAccountUserIds = [...new Set(boardAccounts.flatMap((boardAccount) => boardAccount.userIds))];
     printBoardAccountReport(boardAccounts, await loadEmailsByUserId(db, boardAccountUserIds));
-
-    const applyablePlans = selectApplyablePlans(plans, {
-      includeMergeCandidates: scriptArgs.includeMergeCandidates,
-    });
 
     if (!scriptArgs.apply) {
       return;
@@ -596,7 +668,8 @@ async function main(): Promise<void> {
     console.info('');
     console.info(
       `${LOG_TAG} Repair complete: ${counts.ownershipRowsDeleted} ownership row(s), ${counts.pinsDeleted} pin(s), ` +
-        `${counts.followsDeleted} follow(s) deleted. No playlist, climb, tick, or credential was touched.`,
+        `${counts.followsDeleted} follow(s) deleted, ${counts.tombstonesWritten} sync_deletions tombstone(s) written. ` +
+        `No playlist, climb, tick, or credential was touched.`,
     );
     if (counts.skippedByDrift.length > 0) {
       console.info(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -247,6 +247,15 @@ export default defineConfig({
         // flags with `vp run db:dedupe-beta-links -- --apply`.
         cache: false,
       },
+      'db:repair-cross-linked-playlists': {
+        command: 'bun run --filter=@boardsesh/db db:repair-cross-linked-playlists',
+        // No db:up dependency, same rationale as db:dedupe-gyms: a maintainer
+        // runs this by hand against DB_URL, usually a remote database. Audit-only
+        // by default; --apply is the sole write path and deletes nothing beyond
+        // the later owner's playlist_ownership/pin/follow rows. Forward flags
+        // with `vp run db:repair-cross-linked-playlists -- --apply`.
+        cache: false,
+      },
       'db:refresh-climb-grades': {
         command: 'pnpm --filter @boardsesh/db run db:refresh-climb-grades',
         // No db:up dependency: this often targets a remote DB_URL and supports


### PR DESCRIPTION
## Summary

Adds a one-off, dry-run-by-default script (`vp run db:repair-cross-linked-playlists`) that finds playlists whose `playlist_ownership` rows got split across two different Boardsesh users, a bug already fixed at the source in earlier PRs but never cleaned up in prod. It reports each cross-linked playlist with the creator/adopter details, classifies the cause, and only under `--apply` deletes the later owner's ownership row, pin, and follow inside a locked transaction, plus writes a tombstone so the adopter's phone stops syncing the playlist. Ambiguous or risky cases (case-variant emails, three-plus owners, non-owner roles, low-confidence timestamps) are refused rather than guessed at. It's tooling only — no schema migration, no production writes yet, and the PR ends with a read-only checklist for the reviewer to run against prod and decide on the remaining edge cases.

---

Closes #3541

## What this is

Tooling only. A dry-run-by-default one-off script that audits — and, behind `--apply`, repairs — playlists carrying `playlist_ownership` rows for two different Boardsesh users.

**No production database was touched while writing this PR, not even read-only.** Every number below comes from your 2026-07-25 comment, not from a fresh query. The script reports live state; treat the counts in the checklist as "verify", not "assume".

## Why it exists

The three source defects are already fixed and merged:

1. the pre-`45cef340a` JSON importer hashed `playlists.aurora_id` from `${boardType}:${name}:${created_at}` with no user id, so two importers collided on the global `playlists_aurora_id_idx`;
2. aurora-sync's circuits path upserted on that same global index and then inserted an `owner` row unconditionally — guarded since PR #3931's `foreignPlaylistOwnerGuard` `setWhere`;
3. board links didn't reject an Aurora account already linked to another Boardsesh user — fixed in `458a1490f`.

The guards stop new cross-links. They don't clean up the rows already in prod, which is what #3541 tracks. Per your comment, this is data rather than schema, so it's a `scripts/` one-off, **not** a Drizzle migration.

## What the script does

`vp run db:repair-cross-linked-playlists` (dry-run) names the target database host and the mode on its first line, then prints, per cross-linked playlist: creator vs adopter (email, user id, role, timestamp), the spread between the two ownership rows, the classified cause, climb count, and whether the adopter holds a pin or a follow. It closes with a preview of exactly what `--apply` would write — ownership rows, pins, follows and tombstones, counted from the plans it is allowed to touch rather than from every playlist reported. It then lists every board account (`aurora_credentials` and `user_board_mappings`, Aurora numeric ids and Kilter subject strings) that resolves to more than one Boardsesh user, labelled as out of scope.

Classification, all in `repair-cross-linked-playlists-helpers.ts` so it unit-tests without a database:

| Case | Action |
|---|---|
| `aurora_id` starts with `json-import-circuit-`, two `owner` rows, different people | `revoke-adopter` — the only action that writes |
| Owners' emails are the same up to case (`Pmbmosk@` / `pmbmosk@`) | `defer-to-account-merge` — reported, skipped |
| >2 distinct owners, any `editor`/`viewer` row, unreadable `created_at`, or rows closer than `--min-spread-minutes` (default 30) | `refuse` — reported, never written |
| Anything else | `refuse` |

Creator selection is `min(playlist_ownership.created_at)`, the rule your analysis validated on all 44 rows. The 30-minute threshold sits well under the 100-minute minimum spread you observed, so it clears every real pair while refusing anything that would be a coin flip.

`--apply` implements Option A (revoke) only. Per playlist, inside one transaction under a `pg_advisory_xact_lock`, it re-reads the ownership rows `FOR UPDATE`, aborts that playlist if they no longer match the plan, then deletes the later `playlist_ownership` row plus that same user's `user_playlist_pins` and `playlist_follows` row for that playlist. It deletes **no playlist, no `playlist_climbs` row, no tick, no credential, no user**. Option B (fork) is not implemented — say the word if you'd rather have it.

It also writes exactly one row: an adopter-scoped `sync_deletions` tombstone (`table_name='playlists'`, `record_id=<playlist uuid>`). Without it the revoke never reaches a phone. `syncPlaylists` and `syncPlaylistClimbs` join `playlist_ownership`, and that table has no delete trigger (`0144_offline_sync_backend.sql` covers `playlists`, `playlist_climbs` and the three `*_follows` tables, not ownership), so the adopter's next pull would simply stop returning the playlist while their local SQLite copy and its climb rows lingered forever. The client's deletion applier drops the local playlist and cascades its local climbs, matching 0144's "no child tombstones for a whole-playlist delete" rule. Scoped to the adopter, so the creator's devices are untouched; `sync_deletions` is append-only, so this adds no deletion surface.

The 8 tension playlists are deliberately left frozen: `merge-accounts.ts` from #3278 collapses them correctly as a side effect of merging the accounts, and also moves the 229 ticks and the credentials this script never touches. `--include-merge-candidates` opts in anyway if you want them handled here.

## Flags

```
--apply                      write; omit for dry-run
--playlist-ids <a,b,c>       scope to specific playlists.id values
--include-merge-candidates   also repair case-variant-email pairs (off by default)
--min-spread-minutes <n>     ambiguity threshold (default 30)
--help
```

## Validation

- `packages/db/scripts/repair-cross-linked-playlists-helpers.test.ts` + `-args.test.ts` — 19 unit tests: creator = earliest row regardless of input order, case-variant classification, three-way / non-`owner`-role / sub-threshold / invalid-timestamp / single-owner refusals, configurable threshold, `selectApplyablePlans` gating, arg parsing (`--playlist-ids=a,b` and `--playlist-ids a,b`, the vp-forwarded `--` separator), and the dry-run write preview counting only applyable plans. All pass.
- `packages/db/scripts/repair-cross-linked-playlists.integration.test.ts` — real Postgres, whole fixture inside a rolled-back transaction. Seeds four playlists (json-import residue, case-variant pair, two-strangers, healthy single-owner) plus climbs, pins and follows; asserts planning writes nothing, the single-owner playlist is never reported, `--apply` deletes exactly one ownership row + one pin + one follow, and the playlist / its 2 climbs / the creator's pin / an unrelated follower / all 5 user rows survive. Also covers `--playlist-ids` scoping, the merge-candidate opt-in, the drift guard, and that exactly one adopter-scoped `playlists` tombstone is written while the creator gets none. Passes against the local dev DB.
- CLI smoke test against the local dev DB: dry-run and `--help` both clean; dev DB reports 0 cross-links and 0 multi-user board accounts, which exercises both query paths.
- `vp run typecheck:db` clean. `packages/db/tsconfig.json` only includes `src/**/*`, so I also ran `tsc --noEmit` over `scripts/repair-cross-linked-playlists*.ts` with the same strict options — clean.
- `vp check` clean. `vp run test:db` after the rebase: 451 pass / 3 fail / 19 skipped — the three failures are all in `src/queries/climbs/__tests__/create-climb-filters.test.ts`, untouched by this branch and failing identically at the merge base.

`packages/db` tests run under `tsx --test` and aren't in CI's vitest projects (known gap), so CI won't execute either file. The unit tests are the durable net; run them locally with `vp run test:db`.

## Read-only checklist for you

1. Dry-run against prod with the read-only credential:
   `PGOPTIONS='-c default_transaction_read_only=on -c statement_timeout=30s' DB_URL=<read-only> vp run db:repair-cross-linked-playlists`
   Nothing in the dry-run path writes, and `--apply` is a separate opt-in.
2. Check the live counts against your 2026-07-25 analysis — 44 playlists / 88 ownership rows / 259 climbs / 2 pins / 0 follows, split 36 `json-import` + 8 merge candidates. Prod has drifted since (duplicate-by-case account sets went 23 → 27), so expect differences and trust the script's output over the old numbers.
3. **Decision needed:** apply Option A to the 36 `json-import` playlists, or leave them. Your own analysis says both are fine — they're your account plus a test account, and nothing user-facing depends on them.
4. **Decision needed:** the tension pair (`pmbmosk@gmail.com` / `Pmbmosk@gmail.com`, tension `aurora_user_id=144574`). #3278 is still open; merging it and running `merge-accounts.ts` is your recommendation and also restores the 229-tick logbook to the surviving account. Those 8 playlists stay frozen behind the #3526 guard until then. This script won't unfreeze them.
5. `pg_dump` before any `--apply`. The script deletes rows and there is no undo.
6. Anything the script refuses is a real refusal — it prints creator and adopter so you can decide by hand, but it will not guess.

## Notes

- No Drizzle migration, per your ruling that this is data, not schema.
- No change to the sync guards; #3931, `458a1490f` and the `apply-user-logbook.ts` tick guard already cover the write side.
- The `0147_playlists_tombstone_owner_guard.sql` `LIMIT 1`-without-`ORDER BY` quirk you flagged needs no code change: it only misbehaves on a playlist with two owners, so it stops mattering once these are cleaned up.

## Release Notes

- [x] No release note needed
