### PR TITLE
fix(mobile): render whole route in multi-frame climb thumbnails

### DIFF
--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
+import { toFlatFrames } from '@boardsesh/board-constants/hold-states';
 
 // In-flight render race regression (play-drawer "unlit holds"): a slow native
 // render must not clobber nativeRender state after the hook's props have moved
@@ -567,5 +568,90 @@ describe('capability-fallback render rejections', () => {
     expect(reported.message).toBe('Board overlay render failed: render_failed');
     expect((reported.cause as Error).message).toBe('some native failure');
     expect((options.extra as Record<string, unknown>).renderErrorMessage).toBe('some native failure');
+  });
+});
+
+// Issue #3988: mobile in-app thumbnails (ClimbListThumbnail, BoardImageNative)
+// only ever showed frame 0 of a multi-frame climb, because frames_parser.rs
+// discards everything after the first comma. Web/backend/share-card static
+// renders already collapse multi-frame climbs to the union of every frame via
+// toFlatFrames. The hook now applies the same flatten before handing the
+// config to the native renderer, so the Rust core only ever sees a
+// single-frame string and doesn't need to learn the frames grammar itself.
+describe('multi-frame flatten before the native renderer (issue #3988)', () => {
+  beforeEach(() => {
+    pendingRenders.clear();
+    existingOverlayUris.clear();
+    _resetWarmupForTests();
+    _inflightRendersForTests.clear();
+    fakeNativeModule.renderHoldsOverlay.mockClear();
+    reportErrorMock.mockClear();
+    _setNativeModuleForTests(fakeNativeModule as unknown as Parameters<typeof _setNativeModuleForTests>[0]);
+  });
+
+  // Real catalog climb from the aurora-frames-oracle fixture (issue #3947,
+  // packages/board-constants/src/__tests__/__fixtures__/aurora-frames-oracle.json),
+  // "FRE 20250608" on kilter. All 10 frames are absolute (unquoted, no `x`
+  // clear tokens), so frame-0-only rendering shows 5 lit holds where the
+  // union — what the web card and share card already show — shows the whole
+  // route.
+  const MULTI_FRAME_CATALOG_FRAMES =
+    'p1169r12p1205r13p1219r13p1256r13p1289r15,p1289r15p1308r15p1340r13p1374r13p1388r13,p1335r13p1349r13p1354r15p1368r13p1388r15,p1348r15p1349r15p1363r13p1380r13p1383r13,p1297r13p1311r13p1347r15p1363r15,p1247r13p1267r13p1278r15p1281r13p1297r15,p1251r15p1267r15p1284r13p1302r13p1322r13p1337r13,p1322r15p1371r15p1375r13p1390r13p1393r13,p1288r13p1302r13p1323r13p1356r15p1393r15,p1225r14p1257r13p1275r13p1288r15p1289r15';
+
+  it('hands the Rust renderer the flattened union, pinned exactly against toFlatFrames', async () => {
+    const expectedFlat = toFlatFrames(MULTI_FRAME_CATALOG_FRAMES, BASE.boardName);
+    // Sanity: this fixture climb really is multi-frame and really does
+    // collapse to something other than its first frame alone — otherwise the
+    // rest of this test would pass even with the pre-#3988 frame-0 bug.
+    expect(expectedFlat).not.toBe(MULTI_FRAME_CATALOG_FRAMES.split(',')[0]);
+    const flatCacheKey = cacheKeyFor(expectedFlat);
+
+    renderHook(() => useNativeClimbRender({ ...BASE, frames: MULTI_FRAME_CATALOG_FRAMES }));
+
+    await waitFor(() => expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1));
+    const [configJson, cacheKeyArg] = fakeNativeModule.renderHoldsOverlay.mock.calls[0];
+    expect(cacheKeyArg).toBe(flatCacheKey);
+    const parsedConfig = JSON.parse(configJson as string) as { frames: string };
+    // The exact pin the issue's "done when" asks for: the mobile static
+    // render path matches toFlatFrames, the same function web/backend/share
+    // cards already use.
+    expect(parsedConfig.frames).toBe(expectedFlat);
+  });
+
+  it('passes a single-frame string through byte-identical, with the same cache key as before this change', async () => {
+    const singleFrame = 'p1169r12p1205r13p1219r13';
+    // toFlatFrames's fast path (no comma, no `x`) returns the input
+    // untouched, so this is the exact key the hook produced pre-#3988 too —
+    // guards against invalidating cached thumbnails for the 99.9% of the
+    // catalog that's single-frame.
+    const preExistingCacheKey = cacheKeyFor(singleFrame);
+    expect(toFlatFrames(singleFrame, BASE.boardName)).toBe(singleFrame);
+
+    renderHook(() => useNativeClimbRender({ ...BASE, frames: singleFrame }));
+
+    await waitFor(() => expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1));
+    const [configJson, cacheKeyArg] = fakeNativeModule.renderHoldsOverlay.mock.calls[0];
+    expect(cacheKeyArg).toBe(preExistingCacheKey);
+    const parsedConfig = JSON.parse(configJson as string) as { frames: string };
+    expect(parsedConfig.frames).toBe(singleFrame);
+  });
+
+  it('leaves a comma-free playback-snapshot string untouched (PlayDrawer currentFrameOverride shape)', async () => {
+    // accumulatedMapsToFrameStrings (packages/board-constants) only ever
+    // emits `p{id}r{code}` — no commas, no `x` tokens — for the per-frame
+    // snapshot PlayDrawer passes down through SwipeBoardCarousel while
+    // animating a climb. The flatten must be a no-op on that shape, or the
+    // animation would render the whole route on every frame instead of just
+    // the current one.
+    const snapshotFrame = 'p1500r13p1501r14p1502r15';
+    const snapshotCacheKey = cacheKeyFor(snapshotFrame);
+
+    renderHook(() => useNativeClimbRender({ ...BASE, frames: snapshotFrame }));
+
+    await waitFor(() => expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1));
+    const [configJson, cacheKeyArg] = fakeNativeModule.renderHoldsOverlay.mock.calls[0];
+    expect(cacheKeyArg).toBe(snapshotCacheKey);
+    const parsedConfig = JSON.parse(configJson as string) as { frames: string };
+    expect(parsedConfig.frames).toBe(snapshotFrame);
   });
 });

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
@@ -38,11 +38,22 @@ function mockHolds(ids: number[]) {
   return ids.map((id) => ({ id, mirroredHoldId: null, cx: 100, cy: 200, r: 20 }));
 }
 
+// 1100/1200/1300/1400 are the race and capability-fallback suites' two climbs.
+// The rest are every placement id the issue-#3988 suite lights: the real
+// 10-frame catalog climb ("FRE 20250608", kilter) across ALL its frames — the
+// union is what reaches the renderer now, so frame 0's five ids are not enough
+// — plus the 1500-1502 PlayDrawer per-frame snapshot. Inlined rather than
+// derived from the fixture strings because this factory runs at import time,
+// before the suites' consts exist.
 vi.mock('../../lib/board-details', () => ({
   getBoardRenderData: vi.fn(() => ({
     boardWidth: 1000,
     boardHeight: 1200,
-    holdsData: mockHolds([1100, 1200, 1300, 1400]),
+    holdsData: mockHolds([
+      1100, 1169, 1200, 1205, 1219, 1225, 1247, 1251, 1256, 1257, 1267, 1275, 1278, 1281, 1284, 1288, 1289, 1297, 1300,
+      1302, 1308, 1311, 1322, 1323, 1335, 1337, 1340, 1347, 1348, 1349, 1354, 1356, 1363, 1368, 1371, 1374, 1375, 1380,
+      1383, 1388, 1390, 1393, 1400, 1500, 1501, 1502,
+    ]),
   })),
 }));
 

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -17,6 +17,7 @@ import {
   getBoardStrokeWidthMultiplier,
   getHoldDisplayColor,
   parseFramesSegments,
+  toFlatFrames,
 } from '@boardsesh/board-constants/hold-states';
 import {
   getWallLightness,
@@ -1662,6 +1663,17 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     [holdColorOverride, storedHoldRenderSignature, holdShapeOverrides, brushThickness, shapeSize],
   );
 
+  // Collapse a multi-frame route/circuit string to one static union snapshot —
+  // the same flatten web/backend/share-card static renders already apply via
+  // toFlatFrames (issue #3988). Without this the Rust renderer
+  // (frames_parser.rs) only ever sees frame 0, since it discards everything
+  // after the first comma. Single-frame strings (99.9% of the catalog) hit
+  // toFlatFrames's fast path and come back byte-identical, so cache keys for
+  // the vast majority of climbs are unaffected. Playback's currentFrameOverride
+  // snapshots (PlayDrawer -> SwipeBoardCarousel -> BoardImageNative) are
+  // comma-free, x-free `p{id}r{code}` strings and also pass through unchanged.
+  const flatFrames = useMemo(() => toFlatFrames(frames, boardName), [frames, boardName]);
+
   // Small surfaces that pass a renderWidth want the bundled thumb-sized
   // background too, so neither the overlay nor the photo is a large source the
   // main thread has to downscale. The play-drawer carousel overrides this to
@@ -1772,8 +1784,17 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
   // builders' inputs — a stale key would collide two climbs' overlays.
   const currentCacheKey = useMemo(
     () =>
-      buildCacheKey(boardName, layoutId, sizeId, setIds, frames, filledStyle, renderWidth, effectiveRenderSignature),
-    [boardName, layoutId, sizeId, setIds, frames, filledStyle, renderWidth, effectiveRenderSignature],
+      buildCacheKey(
+        boardName,
+        layoutId,
+        sizeId,
+        setIds,
+        flatFrames,
+        filledStyle,
+        renderWidth,
+        effectiveRenderSignature,
+      ),
+    [boardName, layoutId, sizeId, setIds, flatFrames, filledStyle, renderWidth, effectiveRenderSignature],
   );
   const currentBoardKey = useMemo(
     () => buildBoardKey(boardName, layoutId, sizeId, setIds, variant, colorScheme),
@@ -1980,7 +2001,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     // effectiveOverrideSignature has already stepped away from anything the
     // renderer refused, so this only trips on the pathological case where the
     // fallback itself was somehow recorded.
-    if (!frames || unsupportedRenderSignatures.has(effectiveOverrideSignature)) return;
+    if (!flatFrames || unsupportedRenderSignatures.has(effectiveOverrideSignature)) return;
 
     // Frame 0's lit placement ids, parsed ONCE: the hold-match check right below
     // needs them, and so does the Aura outline attachment inside getBoardConfig.
@@ -2137,7 +2158,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     const renderPromise = getOrStartInflightRender(currentCacheKey, () => {
       const configJson = JSON.stringify({
         ...boardConfig.configBase,
-        frames,
+        frames: flatFrames,
       });
       return nativeModule.renderHoldsOverlay(configJson, currentCacheKey);
     });
@@ -2259,7 +2280,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     currentCacheKey,
-    frames,
+    flatFrames,
     boardName,
     layoutId,
     sizeId,
@@ -2539,9 +2560,9 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
   // Only surface the native URI if it matches the *current* cache key —
   // a stale render (from before a prop change) would otherwise show.
   const candidateOverlayUri =
-    frames && nativeRender?.key === currentCacheKey ? (nativeRender.entry?.uri ?? null) : null;
+    flatFrames && nativeRender?.key === currentCacheKey ? (nativeRender.entry?.uri ?? null) : null;
   const overlayLoadKey =
-    frames && nativeRender?.key === currentCacheKey && nativeRender.entry
+    flatFrames && nativeRender?.key === currentCacheKey && nativeRender.entry
       ? `${nativeRender.entry.generation}:${nativeRender.loadAttempt}`
       : null;
   const verifiedOverlayFile =

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -2003,9 +2003,18 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     // fallback itself was somehow recorded.
     if (!flatFrames || unsupportedRenderSignatures.has(effectiveOverrideSignature)) return;
 
-    // Frame 0's lit placement ids, parsed ONCE: the hold-match check right below
-    // needs them, and so does the Aura outline attachment inside getBoardConfig.
-    const litHoldIds = parseLitHoldIds(frames);
+    // The lit placement ids the renderer will actually draw, parsed ONCE: the
+    // hold-match check right below needs them, and so does the Aura outline
+    // attachment inside getBoardConfig.
+    //
+    // Parsed off `flatFrames`, not `frames`. A multi-frame route is flattened to
+    // the union of its frames before it reaches the renderer (issue #3988), so
+    // frame 0 of the raw string under-reports the lit set: the hold-match guard
+    // would judge holds nobody draws (and could skip a route whose frame 0 sits
+    // off this board while its union does not), and withLitHoldGeometry would
+    // attach traced silhouettes to frame 0's holds alone, leaving the rest of
+    // the drawn route falling back to plain rings.
+    const litHoldIds = parseLitHoldIds(flatFrames);
 
     // Does this climb's frames even name holds this board can draw?
     //


### PR DESCRIPTION
## Summary

This fixes mobile in-app climb thumbnails — climb list rows, board carousels, reaction menus, wall hero, device cards, and board discovery cards — so multi-frame routes and circuits show every hold instead of just the first frame. It flattens the `frames` string with the existing `toFlatFrames` helper inside `useNativeClimbRender`, the single choke point every mobile static render goes through, matching what web cards, the backend OG share card, and the mobile share card already do. Single-frame climbs (the vast majority of the catalog) come out byte-identical so no cached thumbnail PNGs are invalidated, but 709 multi-frame climbs will render visually busier, and the author flags this needs a device eyeball before merge. The Rust renderer core is left untouched so the fix ships JS-only via OTA.

---

## What

Mobile in-app static climb renders — `ClimbListThumbnail`, `BoardImageNative`, and everything above them (climb list rows, `AccessoryClimbThumbnail`, `SwipeBoardCarousel` including its neighbor peeks, `ClimbReactionMenu`, `WallHeroStage`, `DeviceCard`, board discovery cards/forms) — handed the raw, possibly multi-frame `frames` string straight to the Rust renderer. `frames_parser.rs` only ever reads frame 0 (splits on the first comma and drops the rest), so a multi-frame climb (route or circuit — 709 in the catalog) showed only its first frame in the mobile app.

Web climb cards, the backend OG share card, and the mobile share card already collapse a multi-frame climb to the union of every frame via `toFlatFrames` (`@boardsesh/board-constants/hold-states`). Mobile in-app thumbnails and the play-drawer board were the one static surface left showing a fragment instead of the whole route.

This flattens once, at the single choke point every mobile static render goes through — `useNativeClimbRender` — instead of at each of the two call sites. `flatFrames = useMemo(() => toFlatFrames(frames, boardName), [frames, boardName])` feeds the cache key, the effect's `!frames` guard, and the native config JSON's `frames` field. Raw `frames.length` is kept for the Sentry `framesLength` extra.

Closes #3988

## Why this is safe for the 99.9% single-frame case

`toFlatFrames` has a fast path: a string with no `,` and no `x` returns unchanged. So:

- Single-frame climbs (the overwhelming majority of the catalog) produce a byte-identical string, which means the cache key formula is unchanged and **no existing cached thumbnail PNGs are invalidated**.
- PlayDrawer's per-frame animation override (`currentFrameOverride`, from `useClimbFrames` → `accumulatedMapsToFrameStrings`, which only ever emits comma-free `p{id}r{code}` strings) also passes through the flatten untouched, so the in-progress play view still animates frame-by-frame instead of collapsing to the union.

## Visual change (intentional, needs sign-off)

This is a real visual change for the 709 multi-frame climbs in the catalog: 611 of them render busier than before (median goes from 20 to 42 lit holds, worst case 225 on "Happy New Year! 🎉", `F142693E7BF54FBEA3DC936E263DEEF5`). This direction was maintainer-settled in #3986 ("Option 1 first" — flatten at the call site, matches what web/backend/share-card already show) and is exactly what the issue's "done when" asks for: mobile thumbnails now match web cards for the same climb.

**Visual evidence is owed, not attached.** This dev host is Linux and can't run the iOS/Android simulator screenshot flow (`vp run check:mobile-simulator` / `vp run mobile:screenshot` are macOS-only). @marcodejongh — please eyeball "Happy New Year! 🎉" in the mobile climb list on a device/simulator before merging; this PR should not be auto-merged.

## What did NOT change

- `packages/board-renderer/core/src/frames_parser.rs` — untouched, on purpose. Editing the Rust core (even a comment) risks moving the native fingerprint and would force a non-OTA-compatible build; the fix stays JS-only so it rides OTA.
- `ClimbListThumbnail.tsx` / `BoardImageNative.tsx` — still pass the raw `frames` prop straight through; the flatten lives entirely inside the hook.

## Rebase follow-up

`main` grew a second consumer of the raw `frames` string between the flatten and the renderer: the `no_matching_holds` guard (#5098) parses frame 0's lit placement ids and hands them to both the skip/evict decision and `withLitHoldGeometry` inside `getBoardConfig`. Those ids now come off `flatFrames` too.

The renderer is given the union of every frame, so frame 0 alone under-reported what actually gets drawn. The guard judged holds nobody paints (and would skip a route whose frame 0 sits off this board while its union does not), and the Aura outline pass attached traced silhouettes to frame 0's holds only, leaving the rest of the route on plain fallback rings — the same "fragment of the route" symptom this issue is about. Single-frame strings are unaffected: `toFlatFrames` returns them untouched, so `litHoldIds` comes out identical.

That guard is also why the three new tests went red on CI. The suite mocks `getBoardRenderData` with one hold per placement id, and a config matching NONE of the lit ids is answered before the render ever starts, so the fixture climbs never reached `renderHoldsOverlay` and asserted 0 calls. The fixture board now carries every id those strings light, across all ten frames.

One thing worth an eye during the device pass: for Kilter, `toFlatFrames` re-emits the union using the canonical product-7 role codes (42/43/44/45) rather than the catalog string's product-1 codes (12/13/14/15). `HOLD_STATE_MAP.kilter` carries both sets with identical colours and the hook ships the whole map to the renderer, so this is a no-op for what you see — but it is why the pinned expectation in test 1 is not a substring of the input.

## Tests

Extended `packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx` (already renders the real hook against a mocked native module) with three cases:

1. A real multi-frame catalog climb (`aurora-frames-oracle.json`'s "FRE 20250608", 10 absolute frames) — asserts the `frames` field in the JSON config handed to `renderHoldsOverlay` equals `toFlatFrames(raw, boardName)` exactly, and that the cache key matches. This is the issue's requested pin of the mobile path against the web path.
2. A single-frame string passes through byte-identical, with the exact pre-change cache key — guards against invalidating cached thumbnails for the rest of the catalog.
3. A comma-free playback-snapshot-shaped string (the `p{id}r{code}`-only shape `PlayDrawer`'s `currentFrameOverride` produces) is left untouched — guards the animation path.

## Validation

Rebased onto `main` at `4213de4a0` (34 commits), clean — no conflicts.

- `vp run typecheck:mobile` — clean.
- `vp test run --project mobile src/hooks/__tests__/use-native-climb-render-race.test.tsx --reporter=agent` — 20/20 pass.
- `vp run test:mobile` (full suite) — 8268/8268 pass across 797 files.
- `vp check` — 0 errors. The 339 warnings are pre-existing repo-wide; none in the two touched files.
- `vp run check:mobile-bundle` — `[mobile-bundle] android bundle: OK`.
- `vp run check:pr-test-plan` against this description — `OK — 3 steps, risk 2/5`.
- Mutation check: putting the raw `frames` back into the native config JSON turns test 1 red on the exact union string, so the pin fails for the reason it claims to.

Still owed: the device eyeball pass below. This host is Linux, so the simulator screenshot flows stay unavailable.

## Release Notes

- Mobile: route and circuit thumbnails in the climb list now show every hold in the route, not just the first frame.

## Open questions for @marcodejongh

- Please do the device eyeball pass on "Happy New Year! 🎉" (or any multi-frame route) called out in the issue's done-when before merging — this changes the default look of 709 climbs' thumbnails.

## Test plan

1. Signed in, Kilter selected.
2. Climbs tab, open a multi-frame route, thumbnail shows every hold.
3. Open a boulder, its thumbnail looks the same as before.

## Risk

Risk: 2/5 — changes the look of 709 route thumbnails; single-frame climbs are byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQS6oJQe1isqM6CZurcnLg
