### PR TITLE
feat(mobile): on-screen sheet detent readout to unblock #3922

### DIFF
--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -31,7 +31,7 @@ import { drainMutationQueue } from '../../../src/offline/offline-sync-adapter';
 import { getHttpClient } from '../../../src/lib/graphql/client';
 import { hapticLight, hapticSelection } from '../../../src/lib/haptics';
 import { DevMetadataPanel } from '../../../src/components/DevMetadataPanel';
-import { useBottomChromeDiagnosticsEligible } from '../../../src/components/BottomChromeDebugOverlay';
+import { useDiagnosticsEligible } from '../../../src/hooks/use-diagnostics-eligible';
 import { MoreForm } from '../../../src/components/MoreForm';
 import type { MoreButtonRow, MoreFormModel, MoreRow, MoreSection } from '../../../src/components/MoreForm.types';
 import { isPreviewBuild } from '../../../src/lib/preview-build';
@@ -78,8 +78,9 @@ export default function MoreScreen() {
   const { localePreference, setLocalePreference } = useLocalePreference();
   const { enabled: sessionRecordingEnabled, setEnabled: setSessionRecordingPreference } =
     useSessionRecordingPreference();
-  const bottomChromeDiagnosticsEligible = useBottomChromeDiagnosticsEligible();
+  const diagnosticsEligible = useDiagnosticsEligible();
   const [bottomChromeDiagnostics, setBottomChromeDiagnostics] = useSetting('bottomChromeDiagnostics');
+  const [sheetDetentDiagnostics, setSheetDetentDiagnostics] = useSetting('sheetDetentDiagnostics');
   const { enabled: showPlaylistTags, setEnabled: setShowPlaylistTags } = useShowPlaylistTagsPreference();
   const { enabled: showBoardseshGrades, setEnabled: setShowBoardseshGrades } = useBoardseshGradesPreference();
   const { enabled: showQuickActionsButton, setEnabled: setShowQuickActionsButton } = useClimbQuickActionsButton();
@@ -646,9 +647,9 @@ export default function MoreScreen() {
           setSessionRecordingEnabled(next);
         },
       },
-      // Bottom-chrome geometry overlay — dev / preview builds / pr-channel OTA
-      // testers only, so regular production users never see the row.
-      ...(bottomChromeDiagnosticsEligible
+      // Geometry overlays — dev / preview builds / pr-channel OTA testers only,
+      // so regular production users never see these rows.
+      ...(diagnosticsEligible
         ? [
             {
               kind: 'toggle' as const,
@@ -661,6 +662,19 @@ export default function MoreScreen() {
               onValueChange: (next: boolean) => {
                 hapticSelection();
                 setBottomChromeDiagnostics(next);
+              },
+            },
+            {
+              kind: 'toggle' as const,
+              key: 'sheetDetentDiagnostics',
+              // i18n-ignore-next-line — tester-only diagnostics
+              label: 'Sheet detent readout',
+              // i18n-ignore-next-line
+              subtitle: 'Overlay measured sheet heights (#3922)',
+              value: sheetDetentDiagnostics,
+              onValueChange: (next: boolean) => {
+                hapticSelection();
+                setSheetDetentDiagnostics(next);
               },
             },
           ]

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -83,6 +83,7 @@ import { OnboardingGate } from '../src/components/onboarding/OnboardingGate';
 import { AccessoryOnboardingTip } from '../src/components/onboarding/AccessoryOnboardingTip';
 import { FreezeDebugOverlay } from '../src/components/FreezeDebugOverlay';
 import { BottomChromeDebugOverlay } from '../src/components/BottomChromeDebugOverlay';
+import { SheetDetentReadoutOverlay } from '../src/components/SheetDetentReadoutOverlay';
 import { WindowInsetPublisher } from '../src/hooks/use-window-bottom-inset';
 import { LiveActivityIntentDiagnostics } from '../src/components/LiveActivityIntentDiagnostics';
 // Side-effect import: instantiates the Android-only MemoryTrim native module
@@ -694,6 +695,9 @@ function RootLayout() {
                                                             pr-channel + settings toggle). Inside the metrics provider
                                                             so it reads the same derived values consumers position with. */}
                                                                   <BottomChromeDebugOverlay />
+                                                                  {/* Sheet detent numbers for #3922, on screen so they can
+                                                            come off a TestFlight build (same toggle gate). */}
+                                                                  <SheetDetentReadoutOverlay />
                                                                   {/* Root-sampled window inset for bottom-docked sheets —
                                                             here (outside the tabs) useSafeAreaInsets IS the window's. */}
                                                                   <WindowInsetPublisher />

--- a/packages/mobile/src/components/BottomChromeDebugOverlay.tsx
+++ b/packages/mobile/src/components/BottomChromeDebugOverlay.tsx
@@ -1,10 +1,7 @@
-import { useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useSetting } from '../settings';
-import { isPreviewBuild } from '../lib/preview-build';
-import { getPreference } from '../lib/preference-store';
-import { OTA_CHANNEL_OVERRIDE_KEY } from '../lib/channel-switch';
+import { useDiagnosticsEligible } from '../hooks/use-diagnostics-eligible';
 import { useBottomChromeMetrics } from '../hooks/use-bottom-chrome-metrics';
 import { useNativeTabBar } from '../hooks/use-bottom-accessory';
 import { useTheme } from '../providers/theme-provider';
@@ -35,34 +32,8 @@ import { usePublishedWindowInsetBottom } from '../lib/window-inset-store';
  * preview a production install can switch onto).
  */
 
-/**
- * Whether this session may surface bottom-chrome diagnostics at all. Also gates
- * the settings row that flips the persisted toggle, so production users outside
- * a pr- preview never see either.
- */
-export function useBottomChromeDiagnosticsEligible(): boolean {
-  const [hasPrChannelOverride, setHasPrChannelOverride] = useState(false);
-  useEffect(() => {
-    if (__DEV__ || isPreviewBuild()) return;
-    let cancelled = false;
-    getPreference<string>(OTA_CHANNEL_OVERRIDE_KEY)
-      .then((storedChannel) => {
-        if (!cancelled && storedChannel !== null && storedChannel.startsWith('pr-')) {
-          setHasPrChannelOverride(true);
-        }
-      })
-      // Best-effort mirror read (see preference-store.ts on rejections): a failed
-      // read just leaves the diagnostics hidden for this launch.
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-  return __DEV__ || isPreviewBuild() || hasPrChannelOverride;
-}
-
 export function BottomChromeDebugOverlay() {
-  const eligible = useBottomChromeDiagnosticsEligible();
+  const eligible = useDiagnosticsEligible();
   const [enabled] = useSetting('bottomChromeDiagnostics');
   if (!eligible || !enabled) return null;
   return <BottomChromeDebugOverlayInner />;

--- a/packages/mobile/src/components/SheetDetentReadoutOverlay.tsx
+++ b/packages/mobile/src/components/SheetDetentReadoutOverlay.tsx
@@ -1,9 +1,12 @@
+import { useEffect } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useSetting } from '../settings';
+import { useDiagnosticsEligible } from '../hooks/use-diagnostics-eligible';
 import {
   clearSheetDetentReadings,
+  setSheetDetentReadoutActive,
   useSheetDetentReadings,
-  useSheetDetentReadoutEnabled,
   type SheetDetentReading,
 } from './sheet-detent-readout';
 
@@ -20,15 +23,30 @@ import {
  *
  * Mounted at the root, behind the persisted toggle plus the diagnostics
  * eligibility gate, and reading a store the probe writes — so it never
- * participates in the sheet's own layout.
+ * participates in the sheet's own layout. It also resolves that gate ON BEHALF
+ * of the sheets: they reach the store through `sheet-detent-probe.ts` and so
+ * cannot import `../settings` without dragging MMKV into every sheet's module
+ * graph (which breaks Vitest's collection scan).
  *
  * A native iOS sheet presents above the root view, so this panel is covered
  * while a sheet is up. That is why readings survive dismissal: open the sheet,
  * close it, screenshot the panel.
  */
 export function SheetDetentReadoutOverlay() {
-  const enabled = useSheetDetentReadoutEnabled();
+  const eligible = useDiagnosticsEligible();
+  const [toggledOn] = useSetting('sheetDetentDiagnostics');
+  // A production install can flip nothing, because the row never renders — but a
+  // stale persisted `true` from an earlier preview must not turn it on either.
+  const enabled = eligible && toggledOn;
   const readings = useSheetDetentReadings();
+
+  // This root-mounted component owns the settings read for the whole feature and
+  // pushes the result down to the sheets, which cannot import MMKV themselves —
+  // see the module doc on sheet-detent-readout.ts.
+  useEffect(() => {
+    setSheetDetentReadoutActive(enabled);
+  }, [enabled]);
+
   if (!enabled) return null;
   return <SheetDetentReadoutPanel readings={readings} />;
 }

--- a/packages/mobile/src/components/SheetDetentReadoutOverlay.tsx
+++ b/packages/mobile/src/components/SheetDetentReadoutOverlay.tsx
@@ -1,0 +1,148 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+  clearSheetDetentReadings,
+  useSheetDetentReadings,
+  useSheetDetentReadoutEnabled,
+  type SheetDetentReading,
+} from './sheet-detent-readout';
+
+/**
+ * On-screen readout of the #3922 sheet-detent measurements.
+ *
+ * #3922 will not accept a column-height change without device numbers from an
+ * iPhone SE 3 / iOS 26 and an iPhone 16 / iOS 26.5 — a wrong guess clips the
+ * Apply/Save button on every `%`-detent sheet, which is worse than the dead gap
+ * it would be trying to close. The instrumentation that produces those numbers
+ * (PR #4082) prints to the console, which only exists in a dev client attached
+ * to Metro. This panel puts the same numbers on screen so they can come off a
+ * TestFlight or preview install instead.
+ *
+ * Mounted at the root, behind the persisted toggle plus the diagnostics
+ * eligibility gate, and reading a store the probe writes — so it never
+ * participates in the sheet's own layout.
+ *
+ * A native iOS sheet presents above the root view, so this panel is covered
+ * while a sheet is up. That is why readings survive dismissal: open the sheet,
+ * close it, screenshot the panel.
+ */
+export function SheetDetentReadoutOverlay() {
+  const enabled = useSheetDetentReadoutEnabled();
+  const readings = useSheetDetentReadings();
+  if (!enabled) return null;
+  return <SheetDetentReadoutPanel readings={readings} />;
+}
+
+function formatMeasurement(value: number | null): string {
+  return value === null ? '—' : String(Math.round(value * 10) / 10);
+}
+
+function SheetDetentReadoutPanel({ readings }: { readings: SheetDetentReading[] }) {
+  const insets = useSafeAreaInsets();
+  return (
+    // `box-none` on the wrapper and `auto` only on the Clear button: the panel
+    // must not swallow taps meant for the screen underneath it.
+    <View pointerEvents="box-none" style={[styles.root, { top: insets.top + 4 }]}>
+      <View style={styles.panel} pointerEvents="box-none">
+        <View style={styles.titleRow} pointerEvents="box-none">
+          {/* i18n-ignore-next-line — tester-only diagnostics */}
+          <Text style={styles.title}>SHEET DETENT #3922</Text>
+          <Pressable onPress={clearSheetDetentReadings} hitSlop={8} accessibilityRole="button">
+            {/* i18n-ignore-next-line */}
+            <Text style={styles.clear}>CLEAR</Text>
+          </Pressable>
+        </View>
+        {readings.length === 0 ? (
+          // i18n-ignore-next-line
+          <Text style={styles.hint}>Open a sheet, then close it to read the numbers.</Text>
+        ) : (
+          readings.map((reading) => (
+            // Keyed by sheet label, not sequence: a new reading for the same
+            // sheet replaces the old one in place rather than remounting a row.
+            <View key={reading.sheet} style={styles.reading} pointerEvents="none">
+              <Text style={styles.sheetName} selectable>
+                {`${reading.sheet}  #${reading.sequence}`}
+              </Text>
+              <Text style={styles.metrics} selectable>
+                {`win ${formatMeasurement(reading.window.width)}x${formatMeasurement(reading.window.height)}  ` +
+                  `ins ${formatMeasurement(reading.insets.top)}/${formatMeasurement(reading.insets.bottom)}`}
+              </Text>
+              <Text style={styles.metrics} selectable>
+                {`formula ${formatMeasurement(reading.formulaHeight)}  column ${formatMeasurement(reading.columnHeight)}`}
+              </Text>
+              <Text style={styles.metrics} selectable>
+                {`probe ${formatMeasurement(reading.probeHeight)}  padTop ${formatMeasurement(reading.sentinelY)}`}
+              </Text>
+              {/* The number every prior formula was trying to guess — the one
+                  that decides whether the fix is JS-side or upstream. */}
+              <Text style={styles.headline} selectable>
+                {`inFlow ${formatMeasurement(reading.availableInFlowHeight)}`}
+              </Text>
+            </View>
+          ))
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    position: 'absolute',
+    left: 8,
+    zIndex: 99999,
+    elevation: 99999,
+    alignItems: 'flex-start',
+  },
+  panel: {
+    backgroundColor: 'rgba(0, 0, 0, 0.82)',
+    borderColor: '#f59e0b',
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    maxWidth: 240,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+    marginBottom: 2,
+  },
+  title: {
+    color: '#f59e0b',
+    fontSize: 10,
+    fontWeight: '700',
+    letterSpacing: 1,
+  },
+  clear: {
+    color: '#f59e0b',
+    fontSize: 10,
+    fontWeight: '700',
+    letterSpacing: 1,
+  },
+  hint: {
+    color: '#d4d4d4',
+    fontSize: 11,
+  },
+  reading: {
+    marginTop: 4,
+  },
+  sheetName: {
+    color: '#f59e0b',
+    fontSize: 11,
+    fontWeight: '600',
+  },
+  metrics: {
+    color: '#ffffff',
+    fontSize: 11,
+    fontVariant: ['tabular-nums'],
+  },
+  headline: {
+    color: '#34d399',
+    fontSize: 12,
+    fontWeight: '700',
+    fontVariant: ['tabular-nums'],
+  },
+});

--- a/packages/mobile/src/components/__tests__/sheet-detent-probe.test.tsx
+++ b/packages/mobile/src/components/__tests__/sheet-detent-probe.test.tsx
@@ -16,7 +16,16 @@ vi.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 20, bottom: 0, left: 0, right: 0 }),
 }));
 
-import { useSheetDetentProbe } from '../sheet-detent-probe';
+// The readout module reaches MMKV (settings) and expo-updates (eligibility),
+// neither of which loads under vitest's node env. The store itself is covered by
+// sheet-detent-readout.test.ts.
+const readout = vi.hoisted(() => ({ enabled: false, publish: vi.fn() }));
+vi.mock('../sheet-detent-readout', () => ({
+  publishSheetDetentReading: readout.publish,
+  useSheetDetentReadoutEnabled: () => readout.enabled,
+}));
+
+import { useSheetDetentProbe, shouldInstrumentSheetDetent } from '../sheet-detent-probe';
 import { useSheetColumnStyle } from '../use-sheet-column-style';
 
 // A layout event carrying only the fields the probe reads.
@@ -32,6 +41,8 @@ let logSpy: ReturnType<typeof vi.spyOn>;
 beforeEach(() => {
   platformMock.OS = 'ios';
   platformMock.Version = '26.1';
+  readout.enabled = false;
+  readout.publish.mockClear();
   logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 });
 
@@ -179,5 +190,86 @@ describe('detent instrumentation gate', () => {
 
     expect(withBound.result.current.probeProps).not.toBeNull();
     expect(withoutBound.result.current.probeProps).toBeNull();
+  });
+});
+
+describe('shouldInstrumentSheetDetent', () => {
+  it('leaves a production session with the toggle off completely uninstrumented', () => {
+    // The regression that matters for shipping this OTA: a normal install must
+    // mount no probe views at all, so its sheet tree stays what it is today.
+    expect(shouldInstrumentSheetDetent(false, false, 541)).toBe(false);
+  });
+
+  it('instruments a dev client, and a distributed build once the tester toggle is on', () => {
+    expect(shouldInstrumentSheetDetent(true, false, 541)).toBe(true);
+    expect(shouldInstrumentSheetDetent(false, true, 541)).toBe(true);
+    expect(shouldInstrumentSheetDetent(true, true, 541)).toBe(true);
+  });
+
+  it('stays out of every unbounded column regardless of the toggle', () => {
+    // Android, web, enableDynamicSizing and non-% detents all yield flex:1, i.e.
+    // a null formula height — none of them is what #3922 is about.
+    expect(shouldInstrumentSheetDetent(true, true, null)).toBe(false);
+    expect(shouldInstrumentSheetDetent(false, true, null)).toBe(false);
+  });
+});
+
+describe('useSheetDetentProbe — on-screen readout', () => {
+  it('publishes nothing while the tester toggle is off', () => {
+    const { result } = renderHook(() => useSheetDetentProbe(FIXED_COLUMN, 'Sheet'));
+    result.current.probeProps?.onLayout(layout({ height: 548 }));
+    result.current.sentinelProps?.onLayout(layout({ y: 16 }));
+    result.current.onColumnLayout?.(layout({ height: 541 }));
+    expect(readout.publish).not.toHaveBeenCalled();
+    // The dev-client log is unaffected by the toggle.
+    expect(logSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('publishes each measurement as it lands, partial included', () => {
+    // A tester flipping the toggle mid-session gets the probe views mounted, but
+    // RN does not re-fire onLayout on the already-mounted column just because it
+    // gained a handler. Waiting for all three would leave the panel empty.
+    readout.enabled = true;
+    const { result } = renderHook(() => useSheetDetentProbe(FIXED_COLUMN, 'ClimbFilterSheet'));
+    result.current.probeProps?.onLayout(layout({ height: 548 }));
+    expect(readout.publish).toHaveBeenCalledTimes(1);
+    expect(readout.publish.mock.calls[0][0]).toMatchObject({
+      sheet: 'ClimbFilterSheet',
+      formulaHeight: 541,
+      probeHeight: 548,
+      columnHeight: null,
+      sentinelY: null,
+      // Not derivable yet — better an em-dash on screen than a wrong number.
+      availableInFlowHeight: null,
+    });
+
+    result.current.sentinelProps?.onLayout(layout({ y: 16 }));
+    expect(readout.publish.mock.calls[1][0]).toMatchObject({ availableInFlowHeight: 532 });
+  });
+
+  it('keeps publishing after the epoch has already logged once', () => {
+    // The log is one line per epoch; the overlay wants the current numbers, so a
+    // settle-animation relayout must still refresh the panel.
+    readout.enabled = true;
+    const { result } = renderHook(() => useSheetDetentProbe(FIXED_COLUMN, 'Sheet'));
+    result.current.probeProps?.onLayout(layout({ height: 548 }));
+    result.current.sentinelProps?.onLayout(layout({ y: 16 }));
+    result.current.onColumnLayout?.(layout({ height: 541 }));
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const publishesAfterFirstLog = readout.publish.mock.calls.length;
+
+    result.current.onColumnLayout?.(layout({ height: 541 }));
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(readout.publish.mock.calls.length).toBe(publishesAfterFirstLog + 1);
+  });
+
+  it('publishes the padding-corrected in-flow height, never the raw probe', () => {
+    readout.enabled = true;
+    const { result } = renderHook(() => useSheetDetentProbe(FIXED_COLUMN, 'Sheet'));
+    result.current.probeProps?.onLayout(layout({ height: 548 }));
+    result.current.sentinelProps?.onLayout(layout({ y: 16 }));
+    const published = readout.publish.mock.calls.at(-1)?.[0];
+    expect(published.availableInFlowHeight).toBe(532);
+    expect(published.availableInFlowHeight).not.toBe(published.probeHeight);
   });
 });

--- a/packages/mobile/src/components/__tests__/sheet-detent-probe.test.tsx
+++ b/packages/mobile/src/components/__tests__/sheet-detent-probe.test.tsx
@@ -16,13 +16,12 @@ vi.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 20, bottom: 0, left: 0, right: 0 }),
 }));
 
-// The readout module reaches MMKV (settings) and expo-updates (eligibility),
-// neither of which loads under vitest's node env. The store itself is covered by
-// sheet-detent-readout.test.ts.
+// The store itself is covered by sheet-detent-readout.test.ts; here we only care
+// what the probe does with the active flag it reads.
 const readout = vi.hoisted(() => ({ enabled: false, publish: vi.fn() }));
 vi.mock('../sheet-detent-readout', () => ({
   publishSheetDetentReading: readout.publish,
-  useSheetDetentReadoutEnabled: () => readout.enabled,
+  useSheetDetentReadoutActive: () => readout.enabled,
 }));
 
 import { useSheetDetentProbe, shouldInstrumentSheetDetent } from '../sheet-detent-probe';

--- a/packages/mobile/src/components/__tests__/sheet-detent-readout-overlay.test.tsx
+++ b/packages/mobile/src/components/__tests__/sheet-detent-readout-overlay.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+const overlay = vi.hoisted(() => ({ enabled: false }));
+
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: unknown) => styles },
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+  Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
+    createElement('button', { onClick: onPress }, children),
+}));
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 47, bottom: 34, left: 0, right: 0 }),
+}));
+
+// The store module reaches MMKV + expo-updates; drive it directly instead.
+const store = vi.hoisted(() => ({
+  readings: [] as unknown[],
+  clear: vi.fn(),
+}));
+vi.mock('../sheet-detent-readout', () => ({
+  useSheetDetentReadoutEnabled: () => overlay.enabled,
+  useSheetDetentReadings: () => store.readings,
+  clearSheetDetentReadings: store.clear,
+}));
+
+import { SheetDetentReadoutOverlay } from '../SheetDetentReadoutOverlay';
+
+beforeEach(() => {
+  overlay.enabled = false;
+  store.readings = [];
+  store.clear.mockClear();
+});
+
+describe('SheetDetentReadoutOverlay', () => {
+  it('renders nothing when the tester toggle is off', () => {
+    // The whole point of shipping this OTA: an ordinary install must see no
+    // extra surface at all.
+    store.readings = [sampleReading()];
+    const { container } = render(<SheetDetentReadoutOverlay />);
+    expect(container.textContent).toBe('');
+  });
+
+  it('shows the numbers #3922 is waiting on, padding-corrected', () => {
+    overlay.enabled = true;
+    store.readings = [sampleReading()];
+    const { container } = render(<SheetDetentReadoutOverlay />);
+
+    expect(container.textContent).toContain('ClimbFilterSheet');
+    expect(container.textContent).toContain('formula 541');
+    expect(container.textContent).toContain('column 390');
+    expect(container.textContent).toContain('probe 548');
+    expect(container.textContent).toContain('padTop 16');
+    // The verdict number: 548 would mean the native size report is right and the
+    // gap lives elsewhere; ~391 would mean the report itself is short.
+    expect(container.textContent).toContain('inFlow 532');
+  });
+
+  it('renders a missing measurement as an em dash rather than a zero', () => {
+    // A partial reading is the normal state right after the toggle is flipped.
+    overlay.enabled = true;
+    store.readings = [sampleReading({ columnHeight: null, availableInFlowHeight: null })];
+    const { container } = render(<SheetDetentReadoutOverlay />);
+    expect(container.textContent).toContain('column —');
+    expect(container.textContent).toContain('inFlow —');
+    expect(container.textContent).not.toContain('inFlow 0');
+  });
+
+  it('tells the tester what to do before any sheet has been opened', () => {
+    overlay.enabled = true;
+    const { container } = render(<SheetDetentReadoutOverlay />);
+    expect(container.textContent).toContain('Open a sheet');
+  });
+});
+
+function sampleReading(overrides: Record<string, unknown> = {}) {
+  return {
+    sheet: 'ClimbFilterSheet',
+    window: { width: 375, height: 667 },
+    insets: { top: 20, bottom: 0 },
+    formulaHeight: 541,
+    probeHeight: 548,
+    columnHeight: 390,
+    sentinelY: 16,
+    availableInFlowHeight: 532,
+    sequence: 3,
+    ...overrides,
+  };
+}

--- a/packages/mobile/src/components/__tests__/sheet-detent-readout-overlay.test.tsx
+++ b/packages/mobile/src/components/__tests__/sheet-detent-readout-overlay.test.tsx
@@ -3,8 +3,6 @@ import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
-const overlay = vi.hoisted(() => ({ enabled: false }));
-
 vi.mock('react-native', () => ({
   StyleSheet: { create: (styles: unknown) => styles },
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
@@ -16,36 +14,67 @@ vi.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 47, bottom: 34, left: 0, right: 0 }),
 }));
 
-// The store module reaches MMKV + expo-updates; drive it directly instead.
+// Settings reaches MMKV and eligibility reaches expo-updates; neither loads
+// under vitest's node env.
+const settings = vi.hoisted(() => ({ sheetDetentDiagnostics: false }));
+vi.mock('../../settings', () => ({
+  useSetting: (key: 'sheetDetentDiagnostics') => [settings[key], vi.fn()],
+}));
+const eligibility = vi.hoisted(() => ({ eligible: false }));
+vi.mock('../../hooks/use-diagnostics-eligible', () => ({
+  useDiagnosticsEligible: () => eligibility.eligible,
+}));
+
 const store = vi.hoisted(() => ({
   readings: [] as unknown[],
   clear: vi.fn(),
+  setActive: vi.fn(),
 }));
 vi.mock('../sheet-detent-readout', () => ({
-  useSheetDetentReadoutEnabled: () => overlay.enabled,
   useSheetDetentReadings: () => store.readings,
   clearSheetDetentReadings: store.clear,
+  setSheetDetentReadoutActive: store.setActive,
 }));
 
 import { SheetDetentReadoutOverlay } from '../SheetDetentReadoutOverlay';
 
 beforeEach(() => {
-  overlay.enabled = false;
+  settings.sheetDetentDiagnostics = false;
+  eligibility.eligible = false;
   store.readings = [];
   store.clear.mockClear();
+  store.setActive.mockClear();
 });
 
 describe('SheetDetentReadoutOverlay', () => {
-  it('renders nothing when the tester toggle is off', () => {
-    // The whole point of shipping this OTA: an ordinary install must see no
-    // extra surface at all.
+  it('renders nothing and instruments nothing on an ordinary install', () => {
+    // The whole point of shipping this OTA: a production session must see no
+    // extra surface, and its sheets must mount no probe views.
+    settings.sheetDetentDiagnostics = true;
     store.readings = [sampleReading()];
     const { container } = render(<SheetDetentReadoutOverlay />);
+
     expect(container.textContent).toBe('');
+    // A stale persisted `true` from an earlier preview must not switch it on.
+    expect(store.setActive).toHaveBeenCalledWith(false);
+  });
+
+  it('stays off for an eligible session until the tester flips the toggle', () => {
+    eligibility.eligible = true;
+    const { container } = render(<SheetDetentReadoutOverlay />);
+    expect(container.textContent).toBe('');
+    expect(store.setActive).toHaveBeenCalledWith(false);
+  });
+
+  it('turns the sheets on once both gates pass', () => {
+    eligibility.eligible = true;
+    settings.sheetDetentDiagnostics = true;
+    render(<SheetDetentReadoutOverlay />);
+    expect(store.setActive).toHaveBeenCalledWith(true);
   });
 
   it('shows the numbers #3922 is waiting on, padding-corrected', () => {
-    overlay.enabled = true;
+    enable();
     store.readings = [sampleReading()];
     const { container } = render(<SheetDetentReadoutOverlay />);
 
@@ -54,14 +83,14 @@ describe('SheetDetentReadoutOverlay', () => {
     expect(container.textContent).toContain('column 390');
     expect(container.textContent).toContain('probe 548');
     expect(container.textContent).toContain('padTop 16');
-    // The verdict number: 548 would mean the native size report is right and the
-    // gap lives elsewhere; ~391 would mean the report itself is short.
+    // The verdict number: ~548 means the native size report is right and the gap
+    // lives elsewhere; ~391 means the report itself is short of the detent.
     expect(container.textContent).toContain('inFlow 532');
   });
 
   it('renders a missing measurement as an em dash rather than a zero', () => {
     // A partial reading is the normal state right after the toggle is flipped.
-    overlay.enabled = true;
+    enable();
     store.readings = [sampleReading({ columnHeight: null, availableInFlowHeight: null })];
     const { container } = render(<SheetDetentReadoutOverlay />);
     expect(container.textContent).toContain('column —');
@@ -70,11 +99,16 @@ describe('SheetDetentReadoutOverlay', () => {
   });
 
   it('tells the tester what to do before any sheet has been opened', () => {
-    overlay.enabled = true;
+    enable();
     const { container } = render(<SheetDetentReadoutOverlay />);
     expect(container.textContent).toContain('Open a sheet');
   });
 });
+
+function enable(): void {
+  eligibility.eligible = true;
+  settings.sheetDetentDiagnostics = true;
+}
 
 function sampleReading(overrides: Record<string, unknown> = {}) {
   return {

--- a/packages/mobile/src/components/__tests__/sheet-detent-readout.test.ts
+++ b/packages/mobile/src/components/__tests__/sheet-detent-readout.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+// The store's own module graph reaches MMKV (settings) and expo-updates
+// (eligibility); neither loads under vitest's node env.
+const settings = vi.hoisted(() => ({ sheetDetentDiagnostics: false }));
+vi.mock('../../settings', () => ({
+  useSetting: (key: 'sheetDetentDiagnostics') => [settings[key], vi.fn()],
+}));
+const eligibility = vi.hoisted(() => ({ eligible: false }));
+vi.mock('../../hooks/use-diagnostics-eligible', () => ({
+  useDiagnosticsEligible: () => eligibility.eligible,
+}));
+
+import {
+  clearSheetDetentReadings,
+  publishSheetDetentReading,
+  useSheetDetentReadings,
+  useSheetDetentReadoutEnabled,
+  type SheetDetentReading,
+} from '../sheet-detent-readout';
+
+function reading(overrides: Partial<Omit<SheetDetentReading, 'sequence'>> = {}): Omit<SheetDetentReading, 'sequence'> {
+  return {
+    sheet: 'Sheet',
+    window: { width: 375, height: 667 },
+    insets: { top: 20, bottom: 0 },
+    formulaHeight: 541,
+    probeHeight: 548,
+    columnHeight: 541,
+    sentinelY: 16,
+    availableInFlowHeight: 532,
+    ...overrides,
+  };
+}
+
+function publish(overrides: Partial<Omit<SheetDetentReading, 'sequence'>> = {}): void {
+  act(() => publishSheetDetentReading(reading(overrides)));
+}
+
+// The store is module-level state shared by every sheet, so each case starts clean.
+beforeEach(() => {
+  clearSheetDetentReadings();
+  settings.sheetDetentDiagnostics = false;
+  eligibility.eligible = false;
+});
+
+describe('sheet detent readings store', () => {
+  it('keeps one entry per sheet, most recent first', () => {
+    const { result } = renderHook(() => useSheetDetentReadings());
+    publish({ sheet: 'Sheet' });
+    publish({ sheet: 'ClimbFilterSheet' });
+
+    expect(result.current.map((entry) => entry.sheet)).toEqual(['ClimbFilterSheet', 'Sheet']);
+  });
+
+  it('replaces a sheet reading in place rather than stacking every relayout', () => {
+    // Layout fires repeatedly during a present animation; the panel should show
+    // the current numbers, not a scrolling history that pushes the others out.
+    const { result } = renderHook(() => useSheetDetentReadings());
+    publish({ sheet: 'Sheet', columnHeight: 541 });
+    publish({ sheet: 'ModalSheet' });
+    publish({ sheet: 'Sheet', columnHeight: 390 });
+
+    expect(result.current).toHaveLength(2);
+    expect(result.current[0]).toMatchObject({ sheet: 'Sheet', columnHeight: 390 });
+  });
+
+  it('bumps the sequence so a tester can see readings still arriving', () => {
+    const { result } = renderHook(() => useSheetDetentReadings());
+    publish();
+    const first = result.current[0].sequence;
+    publish();
+    expect(result.current[0].sequence).toBe(first + 1);
+  });
+
+  it('caps the panel at four sheets, dropping the oldest', () => {
+    const { result } = renderHook(() => useSheetDetentReadings());
+    for (const sheet of ['a', 'b', 'c', 'd', 'e']) publish({ sheet });
+    expect(result.current.map((entry) => entry.sheet)).toEqual(['e', 'd', 'c', 'b']);
+  });
+
+  it('hands back a reference-stable snapshot across renders', () => {
+    // useSyncExternalStore loops render → forceStoreRerender if getSnapshot
+    // returns a fresh array on every call.
+    const { result, rerender } = renderHook(() => useSheetDetentReadings());
+    publish();
+    const snapshot = result.current;
+    rerender();
+    expect(result.current).toBe(snapshot);
+  });
+
+  it('empties the panel on clear', () => {
+    const { result } = renderHook(() => useSheetDetentReadings());
+    publish();
+    expect(result.current).toHaveLength(1);
+    act(() => clearSheetDetentReadings());
+    expect(result.current).toEqual([]);
+  });
+});
+
+describe('useSheetDetentReadoutEnabled', () => {
+  it('needs both the toggle and a diagnostics-eligible session', () => {
+    const { result, rerender } = renderHook(() => useSheetDetentReadoutEnabled());
+    expect(result.current).toBe(false);
+
+    settings.sheetDetentDiagnostics = true;
+    rerender();
+    // A production install can flip nothing, because the row never renders — but
+    // a stale persisted `true` from an earlier preview must not turn it on either.
+    expect(result.current).toBe(false);
+
+    eligibility.eligible = true;
+    rerender();
+    expect(result.current).toBe(true);
+
+    settings.sheetDetentDiagnostics = false;
+    rerender();
+    expect(result.current).toBe(false);
+  });
+});

--- a/packages/mobile/src/components/__tests__/sheet-detent-readout.test.ts
+++ b/packages/mobile/src/components/__tests__/sheet-detent-readout.test.ts
@@ -1,23 +1,13 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
-
-// The store's own module graph reaches MMKV (settings) and expo-updates
-// (eligibility); neither loads under vitest's node env.
-const settings = vi.hoisted(() => ({ sheetDetentDiagnostics: false }));
-vi.mock('../../settings', () => ({
-  useSetting: (key: 'sheetDetentDiagnostics') => [settings[key], vi.fn()],
-}));
-const eligibility = vi.hoisted(() => ({ eligible: false }));
-vi.mock('../../hooks/use-diagnostics-eligible', () => ({
-  useDiagnosticsEligible: () => eligibility.eligible,
-}));
 
 import {
   clearSheetDetentReadings,
   publishSheetDetentReading,
+  setSheetDetentReadoutActive,
   useSheetDetentReadings,
-  useSheetDetentReadoutEnabled,
+  useSheetDetentReadoutActive,
   type SheetDetentReading,
 } from '../sheet-detent-readout';
 
@@ -41,9 +31,8 @@ function publish(overrides: Partial<Omit<SheetDetentReading, 'sequence'>> = {}):
 
 // The store is module-level state shared by every sheet, so each case starts clean.
 beforeEach(() => {
-  clearSheetDetentReadings();
-  settings.sheetDetentDiagnostics = false;
-  eligibility.eligible = false;
+  act(() => setSheetDetentReadoutActive(false));
+  act(() => clearSheetDetentReadings());
 });
 
 describe('sheet detent readings store', () => {
@@ -100,23 +89,41 @@ describe('sheet detent readings store', () => {
   });
 });
 
-describe('useSheetDetentReadoutEnabled', () => {
-  it('needs both the toggle and a diagnostics-eligible session', () => {
-    const { result, rerender } = renderHook(() => useSheetDetentReadoutEnabled());
+describe('readout active flag', () => {
+  it('defaults off, so nothing instruments until the overlay says so', () => {
+    const { result } = renderHook(() => useSheetDetentReadoutActive());
     expect(result.current).toBe(false);
+  });
 
-    settings.sheetDetentDiagnostics = true;
-    rerender();
-    // A production install can flip nothing, because the row never renders — but
-    // a stale persisted `true` from an earlier preview must not turn it on either.
-    expect(result.current).toBe(false);
-
-    eligibility.eligible = true;
-    rerender();
+  it('propagates the overlay decision to every subscribed sheet', () => {
+    const { result } = renderHook(() => useSheetDetentReadoutActive());
+    act(() => setSheetDetentReadoutActive(true));
     expect(result.current).toBe(true);
-
-    settings.sheetDetentDiagnostics = false;
-    rerender();
+    act(() => setSheetDetentReadoutActive(false));
     expect(result.current).toBe(false);
+  });
+
+  it('drops stale readings when the tester turns the readout off', () => {
+    // Otherwise flipping the toggle back on shows numbers from a previous
+    // session's device state with no way to tell they are old.
+    const { result } = renderHook(() => useSheetDetentReadings());
+    act(() => setSheetDetentReadoutActive(true));
+    publish();
+    expect(result.current).toHaveLength(1);
+    act(() => setSheetDetentReadoutActive(false));
+    expect(result.current).toEqual([]);
+  });
+
+  it('does not notify subscribers when the flag is set to what it already is', () => {
+    // The overlay re-runs its effect on every settings change, including the
+    // unrelated ones.
+    let renders = 0;
+    renderHook(() => {
+      renders += 1;
+      return useSheetDetentReadoutActive();
+    });
+    const before = renders;
+    act(() => setSheetDetentReadoutActive(false));
+    expect(renders).toBe(before);
   });
 });

--- a/packages/mobile/src/components/sheet-detent-probe.ts
+++ b/packages/mobile/src/components/sheet-detent-probe.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { StyleSheet, useWindowDimensions, type LayoutChangeEvent, type StyleProp, type ViewStyle } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { publishSheetDetentReading, useSheetDetentReadoutEnabled } from './sheet-detent-readout';
+import { publishSheetDetentReading, useSheetDetentReadoutActive } from './sheet-detent-readout';
 
 /**
  * Instrumentation for the iOS sheet detent height (#3922).
@@ -131,7 +131,7 @@ export function shouldInstrumentSheetDetent(
 export function useSheetDetentProbe(columnStyle: ViewStyle, label: string): SheetDetentProbe {
   const window = useWindowDimensions();
   const insets = useSafeAreaInsets();
-  const readoutEnabled = useSheetDetentReadoutEnabled();
+  const readoutEnabled = useSheetDetentReadoutActive();
   const formulaHeight = typeof columnStyle.height === 'number' ? columnStyle.height : null;
 
   const epoch = useRef<ProbeEpoch>({

--- a/packages/mobile/src/components/sheet-detent-probe.ts
+++ b/packages/mobile/src/components/sheet-detent-probe.ts
@@ -1,9 +1,10 @@
 import { useCallback, useMemo, useRef } from 'react';
 import { StyleSheet, useWindowDimensions, type LayoutChangeEvent, type StyleProp, type ViewStyle } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { publishSheetDetentReading, useSheetDetentReadoutEnabled } from './sheet-detent-readout';
 
 /**
- * Development-only instrumentation for the iOS sheet detent height (#3922).
+ * Instrumentation for the iOS sheet detent height (#3922).
  *
  * `useSheetColumnStyle` computes the column height from `useWindowDimensions()`
  * plus tuned constants. Four merged revisions of that formula (#3352, #3371,
@@ -14,6 +15,14 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
  *
  * This hook collects those numbers. It is an OBSERVER: nothing it measures
  * feeds back into layout, so the rendered tree is byte-identical to main.
+ *
+ * It runs in a dev client (where it prints `[sheet-detent #3922]`), and — since
+ * a distributed build has no console to print to — also whenever a tester turns
+ * on the "Sheet detent readout" toggle (More → Diagnostics, dev / preview /
+ * `pr-` channel sessions only). In that case the same payload goes to
+ * `sheet-detent-readout.ts`, which an overlay renders on screen so the numbers
+ * can be screenshotted off a TestFlight build. With the toggle off, a
+ * production session mounts nothing and renders exactly as it does today.
  *
  * ## What gets measured, and why it takes three probes
  *
@@ -92,6 +101,27 @@ const IDLE: SheetDetentProbe = { probeProps: null, sentinelProps: null, onColumn
 const probeStyles = StyleSheet.create({ sentinel: { height: 0 } });
 
 /**
+ * Whether a sheet should mount the probe views at all.
+ *
+ * Split out as a pure function because Metro AND the test config replace
+ * `__DEV__` with a literal, so the production-with-toggle-off branch is
+ * unreachable from a test that reads the global.
+ *
+ * @param isDev the `__DEV__` compile-time constant.
+ * @param readoutEnabled tester toggle + diagnostics eligibility.
+ * @param formulaHeight null for every unbounded column — Android, web,
+ *   `enableDynamicSizing`, non-`%` detents — which #3922 does not touch.
+ */
+export function shouldInstrumentSheetDetent(
+  isDev: boolean,
+  readoutEnabled: boolean,
+  formulaHeight: number | null,
+): boolean {
+  if (formulaHeight == null) return false;
+  return isDev || readoutEnabled;
+}
+
+/**
  * @param columnStyle the style returned by `useSheetColumnStyle`. Instrumentation
  *   runs only when that style carries a numeric height — i.e. exactly the iOS
  *   fixed-detent sheets #3922 is about. Android, web, `enableDynamicSizing` and
@@ -101,6 +131,7 @@ const probeStyles = StyleSheet.create({ sentinel: { height: 0 } });
 export function useSheetDetentProbe(columnStyle: ViewStyle, label: string): SheetDetentProbe {
   const window = useWindowDimensions();
   const insets = useSafeAreaInsets();
+  const readoutEnabled = useSheetDetentReadoutEnabled();
   const formulaHeight = typeof columnStyle.height === 'number' ? columnStyle.height : null;
 
   const epoch = useRef<ProbeEpoch>({
@@ -113,11 +144,17 @@ export function useSheetDetentProbe(columnStyle: ViewStyle, label: string): Shee
 
   // Kept in a ref so the layout callbacks stay referentially stable: the probe
   // views must never remount, and a re-render must not re-arm the log.
-  const context = useRef({ window, insets, formulaHeight, label });
-  context.current = { window, insets, formulaHeight, label };
+  const context = useRef({ window, insets, formulaHeight, label, readoutEnabled });
+  context.current = { window, insets, formulaHeight, label, readoutEnabled };
 
   const record = useCallback((field: 'probeHeight' | 'columnHeight' | 'sentinelY', measured: number) => {
-    const { formulaHeight: key, window: dimensions, insets: safeArea, label: sheetLabel } = context.current;
+    const {
+      formulaHeight: key,
+      window: dimensions,
+      insets: safeArea,
+      label: sheetLabel,
+      readoutEnabled: publishToOverlay,
+    } = context.current;
     if (key == null) return;
     const current = epoch.current;
     if (current.key !== key) {
@@ -127,11 +164,9 @@ export function useSheetDetentProbe(columnStyle: ViewStyle, label: string): Shee
     }
     const next = epoch.current;
     next[field] = measured;
-    if (next.logged || next.probeHeight == null || next.columnHeight == null || next.sentinelY == null) {
-      return;
-    }
-    next.logged = true;
-    console.log('[sheet-detent #3922]', {
+    const availableInFlowHeight =
+      next.probeHeight == null || next.sentinelY == null ? null : next.probeHeight - next.sentinelY;
+    const payload = {
       sheet: sheetLabel,
       window: { width: dimensions.width, height: dimensions.height },
       insets: { top: safeArea.top, bottom: safeArea.bottom },
@@ -140,8 +175,19 @@ export function useSheetDetentProbe(columnStyle: ViewStyle, label: string): Shee
       columnHeight: next.columnHeight,
       sentinelY: next.sentinelY,
       // The number every prior formula was trying to guess.
-      availableInFlowHeight: next.probeHeight - next.sentinelY,
-    });
+      availableInFlowHeight,
+    };
+    // The overlay takes every measurement as it lands, partial included: when a
+    // tester flips the toggle while a sheet is already mounted, RN does not
+    // re-fire `onLayout` on the column just because it gained a handler, so
+    // waiting for all three would leave the panel permanently empty.
+    if (publishToOverlay) publishSheetDetentReading(payload);
+    // The log line stays all-or-nothing — one complete record per epoch.
+    if (next.logged || next.probeHeight == null || next.columnHeight == null || next.sentinelY == null) {
+      return;
+    }
+    next.logged = true;
+    if (__DEV__) console.log('[sheet-detent #3922]', payload);
   }, []);
 
   const onProbeLayout = useCallback(
@@ -166,8 +212,9 @@ export function useSheetDetentProbe(columnStyle: ViewStyle, label: string): Shee
     [onSentinelLayout],
   );
 
-  // `__DEV__` is a compile-time constant under Metro, so the whole thing drops
-  // out of release bundles and production sheets render exactly as they do now.
-  if (!__DEV__ || formulaHeight == null) return IDLE;
+  // Dev clients always instrument. A distributed build does so only while a
+  // diagnostics-eligible tester has the readout toggle on, so an ordinary
+  // production session mounts no probe views and renders exactly as it does now.
+  if (!shouldInstrumentSheetDetent(__DEV__, readoutEnabled, formulaHeight)) return IDLE;
   return { probeProps, sentinelProps, onColumnLayout };
 }

--- a/packages/mobile/src/components/sheet-detent-readout.ts
+++ b/packages/mobile/src/components/sheet-detent-readout.ts
@@ -1,6 +1,4 @@
 import { useSyncExternalStore } from 'react';
-import { useSetting } from '../settings';
-import { useDiagnosticsEligible } from '../hooks/use-diagnostics-eligible';
 
 /**
  * The on-screen half of the #3922 sheet-detent instrumentation.
@@ -14,13 +12,24 @@ import { useDiagnosticsEligible } from '../hooks/use-diagnostics-eligible';
  *
  * This store carries the same payload to a screen overlay, so a tester can flip
  * a toggle, open a sheet, and screenshot the numbers. It exists to UNBLOCK the
- * fix, not to be one: nothing here feeds back into layout, and the readings the
- * probe publishes are the probe's own — no second measurement path.
+ * fix, not to be one: nothing here feeds back into layout, and the readings it
+ * holds are the probe's own — no second measurement path.
  *
  * Readings persist after the sheet dismisses, deliberately. A native iOS sheet
  * presents over the root view, so a root-mounted overlay is behind it while the
  * sheet is up; keeping the last reading per sheet lets the tester close the
  * sheet and read the numbers with nothing covering them.
+ *
+ * ## Why the toggle is pushed in rather than read here
+ *
+ * This module has exactly one dependency: React. It must, because every sheet
+ * component reaches it through `sheet-detent-probe.ts`, and anything it imports
+ * lands in their static graph. Importing `../settings` (react-native-mmkv, whose
+ * react-native entry is Flow source) breaks Rolldown's collection-time scan with
+ * `SyntaxError: Unexpected token 'typeof'` — taking every sheet suite down with
+ * it. So `SheetDetentReadoutOverlay`, which is mounted once at the root and can
+ * afford those imports, resolves the toggle and pushes the result in via
+ * `setSheetDetentReadoutActive`.
  */
 
 export type SheetDetentReading = {
@@ -49,10 +58,20 @@ const MAX_READINGS = 4;
 
 let readings: SheetDetentReading[] = [];
 let sequence = 0;
-const listeners = new Set<() => void>();
+const readingListeners = new Set<() => void>();
 
-function getSnapshot(): SheetDetentReading[] {
+// Kept in its own subscription from the readings: the probe watches only this
+// flag, and must not re-render every instrumented sheet each time a measurement
+// lands.
+let active = false;
+const activeListeners = new Set<() => void>();
+
+function getReadings(): SheetDetentReading[] {
   return readings;
+}
+
+function getActive(): boolean {
+  return active;
 }
 
 /** Record a measurement for `reading.sheet`, replacing that sheet's previous one. */
@@ -62,36 +81,47 @@ export function publishSheetDetentReading(reading: Omit<SheetDetentReading, 'seq
     0,
     MAX_READINGS,
   );
-  for (const listener of listeners) listener();
+  for (const listener of readingListeners) listener();
 }
 
-/** Drop every recorded reading. Used by the overlay's Clear affordance and tests. */
+/** Drop every recorded reading. Backs the overlay's Clear affordance. */
 export function clearSheetDetentReadings(): void {
   if (readings.length === 0) return;
   readings = [];
-  for (const listener of listeners) listener();
+  for (const listener of readingListeners) listener();
 }
 
-function subscribe(onStoreChange: () => void): () => void {
-  listeners.add(onStoreChange);
+/**
+ * Turn the on-screen readout on or off. Called by `SheetDetentReadoutOverlay`,
+ * which owns the settings + eligibility read (see the module doc above).
+ */
+export function setSheetDetentReadoutActive(next: boolean): void {
+  if (active === next) return;
+  active = next;
+  if (!next) clearSheetDetentReadings();
+  for (const listener of activeListeners) listener();
+}
+
+function subscribeToReadings(onStoreChange: () => void): () => void {
+  readingListeners.add(onStoreChange);
   return () => {
-    listeners.delete(onStoreChange);
+    readingListeners.delete(onStoreChange);
+  };
+}
+
+function subscribeToActive(onStoreChange: () => void): () => void {
+  activeListeners.add(onStoreChange);
+  return () => {
+    activeListeners.delete(onStoreChange);
   };
 }
 
 /** Latest reading per instrumented sheet, most recent first. */
 export function useSheetDetentReadings(): SheetDetentReading[] {
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return useSyncExternalStore(subscribeToReadings, getReadings, getReadings);
 }
 
-/**
- * Whether the on-screen readout is on for this session. Requires BOTH the
- * persisted "Sheet detent readout" toggle (More → Diagnostics) and a
- * diagnostics-eligible session, so a regular production install never mounts
- * the probe views or the overlay.
- */
-export function useSheetDetentReadoutEnabled(): boolean {
-  const eligible = useDiagnosticsEligible();
-  const [enabled] = useSetting('sheetDetentDiagnostics');
-  return eligible && enabled;
+/** Whether sheets should instrument themselves for the on-screen readout. */
+export function useSheetDetentReadoutActive(): boolean {
+  return useSyncExternalStore(subscribeToActive, getActive, getActive);
 }

--- a/packages/mobile/src/components/sheet-detent-readout.ts
+++ b/packages/mobile/src/components/sheet-detent-readout.ts
@@ -1,0 +1,97 @@
+import { useSyncExternalStore } from 'react';
+import { useSetting } from '../settings';
+import { useDiagnosticsEligible } from '../hooks/use-diagnostics-eligible';
+
+/**
+ * The on-screen half of the #3922 sheet-detent instrumentation.
+ *
+ * `useSheetDetentProbe` (sheet-detent-probe.ts) already measures every iOS sheet
+ * with a fixed `%` detent and prints a `[sheet-detent #3922]` line. That line
+ * only exists in a dev client attached to Metro: a TestFlight/preview build has
+ * no console to print to, so the numbers #3922's acceptance criteria depend on
+ * — an iPhone SE 3 / iOS 26 and an iPhone 16 / iOS 26.5 readout — were
+ * unreachable for anyone testing on a distributed build.
+ *
+ * This store carries the same payload to a screen overlay, so a tester can flip
+ * a toggle, open a sheet, and screenshot the numbers. It exists to UNBLOCK the
+ * fix, not to be one: nothing here feeds back into layout, and the readings the
+ * probe publishes are the probe's own — no second measurement path.
+ *
+ * Readings persist after the sheet dismisses, deliberately. A native iOS sheet
+ * presents over the root view, so a root-mounted overlay is behind it while the
+ * sheet is up; keeping the last reading per sheet lets the tester close the
+ * sheet and read the numbers with nothing covering them.
+ */
+
+export type SheetDetentReading = {
+  /** Which sheet component produced it — `Sheet`, `ModalSheet`, `ClimbFilterSheet`. */
+  sheet: string;
+  window: { width: number; height: number };
+  insets: { top: number; bottom: number };
+  /** What `useSheetColumnStyle` computed for the current detent. */
+  formulaHeight: number;
+  /** Absolute-fill probe: the wrapper's PADDING box, one paddingTop long. */
+  probeHeight: number | null;
+  /** The height the view carrying the column style actually laid out at. */
+  columnHeight: number | null;
+  /** The wrapper's real paddingTop, measured rather than assumed. */
+  sentinelY: number | null;
+  /** `probeHeight − sentinelY` — the number every prior formula was guessing. */
+  availableInFlowHeight: number | null;
+  /** Bumped per publish so the overlay can show that readings are still arriving. */
+  sequence: number;
+};
+
+// Most recent first, one entry per sheet label. Small and fixed: three sheet
+// components are instrumented, and a fourth would push the oldest out rather
+// than grow the panel past a screenshot's worth of lines.
+const MAX_READINGS = 4;
+
+let readings: SheetDetentReading[] = [];
+let sequence = 0;
+const listeners = new Set<() => void>();
+
+function getSnapshot(): SheetDetentReading[] {
+  return readings;
+}
+
+/** Record a measurement for `reading.sheet`, replacing that sheet's previous one. */
+export function publishSheetDetentReading(reading: Omit<SheetDetentReading, 'sequence'>): void {
+  sequence += 1;
+  readings = [{ ...reading, sequence }, ...readings.filter((existing) => existing.sheet !== reading.sheet)].slice(
+    0,
+    MAX_READINGS,
+  );
+  for (const listener of listeners) listener();
+}
+
+/** Drop every recorded reading. Used by the overlay's Clear affordance and tests. */
+export function clearSheetDetentReadings(): void {
+  if (readings.length === 0) return;
+  readings = [];
+  for (const listener of listeners) listener();
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+  };
+}
+
+/** Latest reading per instrumented sheet, most recent first. */
+export function useSheetDetentReadings(): SheetDetentReading[] {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/**
+ * Whether the on-screen readout is on for this session. Requires BOTH the
+ * persisted "Sheet detent readout" toggle (More → Diagnostics) and a
+ * diagnostics-eligible session, so a regular production install never mounts
+ * the probe views or the overlay.
+ */
+export function useSheetDetentReadoutEnabled(): boolean {
+  const eligible = useDiagnosticsEligible();
+  const [enabled] = useSetting('sheetDetentDiagnostics');
+  return eligible && enabled;
+}

--- a/packages/mobile/src/hooks/use-diagnostics-eligible.ts
+++ b/packages/mobile/src/hooks/use-diagnostics-eligible.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { isPreviewBuild } from '../lib/preview-build';
+import { getPreference } from '../lib/preference-store';
+import { OTA_CHANNEL_OVERRIDE_KEY } from '../lib/channel-switch';
+
+/**
+ * Whether this session may surface tester diagnostics at all — the on-screen
+ * geometry overlays and the settings rows that flip them.
+ *
+ * True for a dev build, an EAS preview build, or a production install that has
+ * switched onto a `pr-<N>` OTA channel. Regular production users see neither the
+ * toggle nor the overlay, so a diagnostic can ship OTA without adding surface
+ * for everyone.
+ *
+ * Shared by the bottom-chrome overlay (`BottomChromeDebugOverlay`) and the sheet
+ * detent readout (`SheetDetentReadoutOverlay`, #3922).
+ */
+export function useDiagnosticsEligible(): boolean {
+  const [hasPrChannelOverride, setHasPrChannelOverride] = useState(false);
+  useEffect(() => {
+    if (__DEV__ || isPreviewBuild()) return;
+    let cancelled = false;
+    getPreference<string>(OTA_CHANNEL_OVERRIDE_KEY)
+      .then((storedChannel) => {
+        if (!cancelled && storedChannel !== null && storedChannel.startsWith('pr-')) {
+          setHasPrChannelOverride(true);
+        }
+      })
+      // Best-effort mirror read (see preference-store.ts on rejections): a failed
+      // read just leaves the diagnostics hidden for this launch.
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return __DEV__ || isPreviewBuild() || hasPrChannelOverride;
+}

--- a/packages/mobile/src/settings/defaults.ts
+++ b/packages/mobile/src/settings/defaults.ts
@@ -15,4 +15,5 @@ export const DEFAULT_SETTINGS: AppSettings = {
   notifyClimbComments: true,
   kioskHintSeen: false,
   bottomChromeDiagnostics: false,
+  sheetDetentDiagnostics: false,
 };

--- a/packages/mobile/src/settings/types.ts
+++ b/packages/mobile/src/settings/types.ts
@@ -25,6 +25,8 @@ export type AppSettings = {
   kioskHintSeen: boolean;
   /** Show the live bottom-chrome geometry overlay (dev / preview / pr-channel only). */
   bottomChromeDiagnostics: boolean;
+  /** Show the iOS sheet detent readout overlay (#3922; dev / preview / pr-channel only). */
+  sheetDetentDiagnostics: boolean;
 };
 
 export type SettingsKey = keyof AppSettings;


### PR DESCRIPTION
## Summary

This PR adds an on-screen diagnostic overlay so device measurements for issue #3922 can actually be captured — it does not fix the underlying sheet detent bug. Because `console.log` output is invisible on TestFlight/preview builds, a new "Sheet detent readout" toggle under More → Diagnostics shows live sheet measurements (formula, column, probe, padTop, inFlow) directly on screen, gated to dev/preview/OTA-preview builds only. It also refactors the diagnostics-eligibility check into a shared hook and fixes a static-import issue that was breaking test bundling.

---

Refs #3922. **This is not the fix** — it is the thing that makes the fix possible.

## Why not the fix

#3922 says, in bold, do not implement blind: no PR lands against it without an
iPhone SE 3 / iOS 26 readout, because a wrong column height clips the Apply/Save
button on every `%`-detent sheet (the filter sheet's Show-N-climbs button and all
three sheets in `AccessibilitySettingsScreen.tsx`), which is worse than the dead
gap it would be trying to close.

Three bug-batch passes have now claimed and released this issue at exactly that
gate. PR #4082 merged the instrumentation that produces the required numbers and
deliberately left the issue open. Ten days later no readout is attached, and the
reason is in #4082's own closing paragraph: `console.log` needs a dev client
attached to Metro. On a TestFlight or preview install it prints into the void.

#4082 offered to build the on-screen version if a dev-client run was
inconvenient. Apparently it was. So here it is.

## What this adds

- **More → Diagnostics → "Sheet detent readout"** — a toggle, default off, on the
  same eligibility gate as the existing "Bottom chrome diagnostics" row: dev
  builds, EAS preview builds, or a production install switched onto a `pr-<N>` OTA
  channel. A regular production user sees neither the row nor anything it controls.
- **A root overlay** (top-left, amber) showing the latest measurement per sheet:
  `formula`, `column`, `probe`, `padTop`, and the one that decides the issue,
  `inFlow`.
- `useSheetDetentProbe` now runs when that toggle is on, not only under `__DEV__`.

The measurement path itself is untouched. The overlay renders what the probe
already computed, including the padding-box correction (`probe − sentinelY`) that
sank the first fix attempt — the panel shows 532, never the raw 548.

## Reading it

On an iPhone SE 3 / iOS 26 (window 667):

| `inFlow` | verdict |
| --- | --- |
| ≈ 548 | native size report is right; the formula is ~7pt off and #3776's 142pt gap lives elsewhere in the tree |
| ≈ 391 | the SwiftUI → Yoga `setViewSize` report is itself short of the detent; the fix is upstream in `RNHostView.swift`, not in any JS formula |

And if `column ≠ formula`, the computed height never reaches the view at all,
which makes both branches moot.

## How to capture it

1. More → Diagnostics → **Sheet detent readout** on.
2. Climbs tab → filter button → let the sheet settle → **close it**.
3. Screenshot the panel.

Step 2's "close it" is not optional politeness: a native iOS sheet presents over
the root view, so the panel is behind it while the sheet is up. Readings survive
dismissal for exactly this reason.

Second pass on an iPhone 16 / iOS 26.5 covers #3568. The three `%`-detent sheets
under Settings → Accessibility fill out the other rows.

## Layout safety

Nothing here can move a sheet. The probe is `position: absolute`, the sentinel is
zero-height, both are `pointerEvents="none"`, and neither feeds a measurement back
into a style. With the toggle off no probe view mounts at all, so a production
session renders the tree it renders today. JS-only, so it ships OTA.

One structural change worth flagging: the readout store keeps React as its only
import. Every sheet reaches it through `sheet-detent-probe.ts`, so pulling
`../settings` in there dragged react-native-mmkv's Flow entry into Sheet,
ModalSheet and ClimbFilterSheet's static graph and killed five suites at
Rolldown's collection scan (`SyntaxError: Unexpected token 'typeof'`). The
root-mounted overlay resolves the toggle and pushes the flag down instead — second
commit, caught by the test run rather than by CI.

The diagnostics-eligibility hook moved out of `BottomChromeDebugOverlay.tsx` into
`src/hooks/use-diagnostics-eligible.ts` so both overlays share one gate. Behaviour
of the bottom-chrome row and overlay is unchanged.

## Validation

- `vp run typecheck:mobile`, `vp check` (clean on every file this branch touches)
- `vp run test:mobile` — sheet suites green, including the five the first commit
  broke
- `vp run check:mobile-bundle` — Android bundle OK
- New coverage: production-with-toggle-off mounts nothing; partial readings render
  as `—` rather than `0`; the padding correction is asserted, not assumed; turning
  the readout off drops stale readings

Device QA is what this PR is asking *for*, not claiming to have done. Notes in
`.boardsesh/qa-notes.md`.

## Release Notes

- [x] No release note needed

## Follow-up

Once the SE 3 numbers land on #3922, the column-height fix is a separate PR and
its shape depends on which branch of the table above they fall in. Whichever it
is, it should not claim to close #3776's 142pt gap without device confirmation —
a perfect measurement moves the column ~9pt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KFR5nP1XcEH64ekt2nK4r
