### PR TITLE
fix(db): select pending dev-db migrations per hash and arm the journal check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -734,10 +734,10 @@ jobs:
         with:
           name: built-packages
       # The pinned image's ledger was stamped with the image build clock, not
-      # each journal entry's `when` (#4211). That is a high-water mark drizzle
-      # can never clear, so without this repair the next step silently skips
-      # every migration written after the image was built — including the one a
-      # PR is adding. Must stay ahead of db:migrate.
+      # each journal entry's `when` (#4211). That mark only moves up, so without
+      # this repair the next step silently skips any journal entry whose `when`
+      # predates the pinned image's build — including a PR's own migration when
+      # the branch is older than the pin. Must stay ahead of db:migrate.
       - name: Normalize the dev-db image migration ledger
         env:
           DATABASE_URL: postgres://postgres:password@localhost:5432/main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -733,6 +733,15 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: built-packages
+      # The pinned image's ledger was stamped with the image build clock, not
+      # each journal entry's `when` (#4211). That is a high-water mark drizzle
+      # can never clear, so without this repair the next step silently skips
+      # every migration written after the image was built — including the one a
+      # PR is adding. Must stay ahead of db:migrate.
+      - name: Normalize the dev-db image migration ledger
+        env:
+          DATABASE_URL: postgres://postgres:password@localhost:5432/main
+        run: bun run --filter=@boardsesh/db db:normalize-ledger
       - name: Apply the full migration journal
         env:
           DATABASE_URL: postgres://postgres:password@localhost:5432/main

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -323,9 +323,11 @@ jobs:
 
       # The dev-db image's ledger was stamped with its build clock, not each
       # journal entry's `when` (#4211). drizzle-kit migrate reads max(created_at)
-      # once and applies only entries above it, so without this repair a PR's new
-      # migration silently never runs here and surfaces as an unrelated-looking
-      # app failure. Must stay ahead of the migrate step.
+      # once and applies only entries above it, so a PR's migration is skipped
+      # whenever it was generated before the image was built — and this job runs
+      # `:latest`, rebuilt on every db-touching merge to main, so that is most
+      # open PRs. It surfaces as an unrelated-looking app failure rather than a
+      # migration error. Must stay ahead of the migrate step.
       - name: Normalize the dev-db image migration ledger
         run: bun run --filter=@boardsesh/db db:normalize-ledger
         env:
@@ -582,8 +584,9 @@ jobs:
           rm built-packages.tar
 
       # Same repair as the shard job above: the image's ledger high-water mark is
-      # a build timestamp, so drizzle-kit migrate would skip a PR's new migration
-      # (#4211). Must stay ahead of the migrate step.
+      # its build timestamp, so drizzle-kit migrate would skip a PR's migration
+      # whenever the branch predates the `:latest` image (#4211). Must stay ahead
+      # of the migrate step.
       - name: Normalize the dev-db image migration ledger
         run: bun run --filter=@boardsesh/db db:normalize-ledger
         env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -321,6 +321,16 @@ jobs:
           tar -xf built-packages.tar
           rm built-packages.tar
 
+      # The dev-db image's ledger was stamped with its build clock, not each
+      # journal entry's `when` (#4211). drizzle-kit migrate reads max(created_at)
+      # once and applies only entries above it, so without this repair a PR's new
+      # migration silently never runs here and surfaces as an unrelated-looking
+      # app failure. Must stay ahead of the migrate step.
+      - name: Normalize the dev-db image migration ledger
+        run: bun run --filter=@boardsesh/db db:normalize-ledger
+        env:
+          DATABASE_URL: postgresql://postgres:password@postgres:5432/main
+
       - name: Run database migrations
         run: bunx drizzle-kit migrate
         working-directory: packages/db
@@ -570,6 +580,14 @@ jobs:
         run: |
           tar -xf built-packages.tar
           rm built-packages.tar
+
+      # Same repair as the shard job above: the image's ledger high-water mark is
+      # a build timestamp, so drizzle-kit migrate would skip a PR's new migration
+      # (#4211). Must stay ahead of the migrate step.
+      - name: Normalize the dev-db image migration ledger
+        run: bun run --filter=@boardsesh/db db:normalize-ledger
+        env:
+          DATABASE_URL: postgresql://postgres:password@postgres:5432/main
 
       - name: Run database migrations
         run: bunx drizzle-kit migrate

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -123,8 +123,33 @@ later died on `relation "location_sync_gym_sources" does not exist`.
 With `VERIFY_MIGRATION_JOURNAL=1`, `packages/db/scripts/migrate.ts` now checks **every**
 journal entry against the ledger, keyed on the migration hash, and throws with the missing
 tags named. `production-deploy.yml` and `db-migration-renumber.yml` both set it. It stays
-opt-in for now because the `boardsesh-dev-db` image is missing `0187_sad_freak`'s ledger
-row, so a default-on check would redden every developer's `vp run db:migrate`.
+opt-in, because a dev database can still carry gaps the developer did not cause and a
+default-on check would redden every `vp run db:migrate`.
+
+#### Ledger timestamps on the dev DB (`vp run db:normalize-ledger`)
+
+The `boardsesh-dev-db` image applies the journal itself, in a psql loop. Until #4211 it
+stamped each ledger row with the image's **build clock** instead of the journal entry's
+`when`, which put the high-water mark years above every journal entry — so the next
+migration anyone wrote was skipped on that database forever. `vp run db:migrate` said
+nothing, the table never appeared, and `db:verify-journal` reported it as a real gap.
+
+The image now writes `when`, and fails its own build if the ledger's high-water mark is not
+the journal's newest `when`. That only helps images built after the fix, though: CI pins a
+digest and developers keep a persistent `db_data` volume. So a database already on disk is
+repaired in place:
+
+```
+DATABASE_URL=postgres://... vp run db:normalize-ledger        # add -- --dry-run to plan only
+```
+
+It rewrites `created_at` to each entry's `when` — exactly the value drizzle writes itself —
+so it is a no-op on any drizzle-managed database, and it refuses a non-local target without
+`--force`. `vp run db:up` runs it automatically, as do the CI jobs that boot the image. One
+gap: the tailnet/remote fast path in `scripts/dev-db-up.sh` returns before that point, so on
+a shared remote dev DB run the command by hand once.
+
+A gate firing on a dev database is therefore a real gap again, not ledger noise.
 
 Run it read-only against any database, without applying anything:
 

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -14,11 +14,14 @@ packages/db/drizzle/
 
 Three properties matter more than they look:
 
-**Order comes from `when`, not from the number.** `packages/db/scripts/migrate.ts` and
-`scripts/dev-db-up.sh` both select entries whose `when` is newer than the last applied
-migration. A migration whose `when` is at or below an already-applied timestamp is
+**Order comes from `when`, not from the number.** Drizzle's own applier selects entries
+whose `when` is newer than the last applied migration, from a `max(created_at)` mark it
+reads once. A migration whose `when` is at or below an already-applied timestamp is
 skipped _forever_, silently — green PR, green deploy, DDL that never happened. The
-number is for humans; `when` is what runs.
+number is for humans; `when` is what runs. The two dev appliers used to repeat that
+selection and now ask the per-entry, hash-keyed question instead (#3979), so a renumbered
+or collapsed migration still lands on a dev database; production is guarded by the
+journal-vs-ledger check below rather than by a different applier.
 
 **A `.sql` with no journal entry is inert.** Nothing applies it. It looks like a
 migration in review and does nothing in production.
@@ -107,7 +110,7 @@ It deliberately ignores six duplicate numbers that main has carried since 2024
 (`0025`, `0048`–`0052`). Both sides are journalled and applied in production; they order
 correctly by `when` and cannot be fixed now.
 
-### The journal-vs-ledger check (`VERIFY_MIGRATION_JOURNAL=1`)
+### The journal-vs-ledger check (on by default; `VERIFY_MIGRATION_JOURNAL=0` opts out)
 
 `check:db-migrations` reads files. It cannot see whether a database actually ran them, and
 one failure mode only shows up there.
@@ -120,11 +123,27 @@ because the mark only ever moves up. Production hit this with `0129_numerous_sta
 `location_sync_gym_sources` was never created, and the first Kilter location sync days
 later died on `relation "location_sync_gym_sources" does not exist`.
 
-With `VERIFY_MIGRATION_JOURNAL=1`, `packages/db/scripts/migrate.ts` now checks **every**
-journal entry against the ledger, keyed on the migration hash, and throws with the missing
-tags named. `production-deploy.yml` and `db-migration-renumber.yml` both set it. It stays
-opt-in, because a dev database can still carry gaps the developer did not cause and a
-default-on check would redden every `vp run db:migrate`.
+`packages/db/scripts/migrate.ts` checks **every** journal entry against the ledger, keyed on
+the migration hash, and throws with the missing tags named. `ci.yml`, `production-deploy.yml`
+and `db-migration-renumber.yml` pass the literal `1`; everywhere else it runs because it is
+now the default.
+
+It shipped opt-in (#2933) for one reason: the `boardsesh-dev-db` image was missing
+`0187_sad_freak`'s ledger row, so a default-on check would have reddened every developer's
+`vp run db:migrate` for a defect in the image rather than in their branch. Three things
+closed that (#3978): the image carries every journal entry's row, its build fails if the
+ledger's high-water mark is not the journal's newest `when`, and `vp run db:up` fills a stale
+volume's gaps hash-by-hash before `db:migrate` runs. Opt-in also meant the check was off in
+the one place a gap is created — the branch author's machine, on the branch that creates it.
+
+`VERIFY_MIGRATION_JOURNAL=0` is the escape hatch, for the one shape this cannot help: a
+database with a gap nobody can repair right now, where `db:migrate` has to run anyway.
+
+Two dev databases are outside `db:up`'s repair path and can still carry a real gap: a
+shared tailnet dev DB reached through `scripts/dev-db-discover.ts`, and a `db_data` volume
+that predates a migration renumber or collapse. Both report it now instead of hiding it —
+`db:up` names the migration it could not apply and hands over
+`docker compose down -v && vp run db:up`.
 
 #### Ledger timestamps on the dev DB (`vp run db:normalize-ledger`)
 

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -130,9 +130,17 @@ default-on check would redden every `vp run db:migrate`.
 
 The `boardsesh-dev-db` image applies the journal itself, in a psql loop. Until #4211 it
 stamped each ledger row with the image's **build clock** instead of the journal entry's
-`when`, which put the high-water mark years above every journal entry — so the next
-migration anyone wrote was skipped on that database forever. `vp run db:migrate` said
-nothing, the table never appeared, and `db:verify-journal` reported it as a real gap.
+`when`, which drags the high-water mark forward to the moment the image was built.
+
+What that skips is not the newest migrations — a migration generated today has a `when`
+later than any image built yesterday, so it still applies. It is the migrations whose `when`
+sits _below_ the build clock and that the image did not itself apply: a branch's migration,
+generated before the image was built and applied to that database afterwards. On the two e2e
+jobs, which run `boardsesh-dev-db:latest`, that is most open PRs — the image is rebuilt on
+every db-touching merge to `main`, so any branch older than the last such merge lands under
+the mark. The migration is skipped with no error at all: `vp run db:migrate` says nothing,
+the table never appears, and `db:verify-journal` reports it as a real gap. The mark only ever
+moves up, so it never recovers.
 
 The image now writes `when`, and fails its own build if the ledger's high-water mark is not
 the journal's newest `when`. That only helps images built after the fix, though: CI pins a

--- a/packages/db/docker/Dockerfile.dev-db
+++ b/packages/db/docker/Dockerfile.dev-db
@@ -243,20 +243,29 @@ RUN set -e && \
     gosu postgres psql -h /var/run/postgresql main -v ON_ERROR_STOP=1 -c "CREATE TABLE IF NOT EXISTS \"__drizzle_migrations\" (id SERIAL PRIMARY KEY, hash text NOT NULL, created_at bigint)" && \
     gosu postgres psql -h /var/run/postgresql main -v ON_ERROR_STOP=1 -c "CREATE SCHEMA IF NOT EXISTS drizzle" && \
     gosu postgres psql -h /var/run/postgresql main -v ON_ERROR_STOP=1 -c "CREATE TABLE IF NOT EXISTS drizzle.\"__drizzle_migrations\" (id SERIAL PRIMARY KEY, hash text NOT NULL, created_at bigint)" && \
+    # created_at is the journal entry's own `when`, never the build clock (#4211). \
+    # drizzle's migrate() reads max(created_at) once and applies only entries \
+    # whose `when` is strictly greater, so a build timestamp would become a \
+    # high-water mark no later migration can clear — every migration added after \
+    # the image was built would be skipped on that database forever. `when` is \
+    # exactly what drizzle writes itself (it inserts folderMillis, which it copies \
+    # from the journal's `when`). \
     applied=0 && \
-    for tag in $(jq -r '.entries[].tag' /drizzle/meta/_journal.json); do \
+    jq -r '.entries[] | "\(.tag) \(.when)"' /drizzle/meta/_journal.json > /tmp/journal_entries.txt && \
+    while read -r tag when; do \
       sql_file="/drizzle/${tag}.sql"; \
       if [ -f "$sql_file" ]; then \
         hash=$(sha256sum "$sql_file" | cut -d' ' -f1); \
         applied=$((applied + 1)); \
         echo "  [$applied/$migration_count] Applying: $tag"; \
         gosu postgres psql -h /var/run/postgresql main -v ON_ERROR_STOP=1 -f "$sql_file" || { echo "  WARNING: migration $tag had errors, continuing..."; true; }; \
-        gosu postgres psql -h /var/run/postgresql main -v ON_ERROR_STOP=1 -c "INSERT INTO \"__drizzle_migrations\" (hash, created_at) VALUES ('$hash', $(date +%s)000)" && \
-        gosu postgres psql -h /var/run/postgresql main -v ON_ERROR_STOP=1 -c "INSERT INTO drizzle.\"__drizzle_migrations\" (hash, created_at) VALUES ('$hash', $(date +%s)000)"; \
+        gosu postgres psql -h /var/run/postgresql main -v ON_ERROR_STOP=1 -c "INSERT INTO \"__drizzle_migrations\" (hash, created_at) VALUES ('$hash', $when)" && \
+        gosu postgres psql -h /var/run/postgresql main -v ON_ERROR_STOP=1 -c "INSERT INTO drizzle.\"__drizzle_migrations\" (hash, created_at) VALUES ('$hash', $when)"; \
       else \
         echo "  ERROR: Migration file not found: $sql_file" && false; \
       fi; \
-    done && \
+    done < /tmp/journal_entries.txt && \
+    rm -f /tmp/journal_entries.txt && \
     echo ">>> All $applied migrations applied successfully." && \
     \
     # ── Verify database state ────────────────────────────────────────── \
@@ -267,6 +276,16 @@ RUN set -e && \
     echo "  Public tables: $table_count" && \
     if [ "$recorded" -ne "$migration_count" ]; then \
       echo "ERROR: Migration count mismatch! Expected $migration_count, got $recorded" && false; \
+    fi && \
+    \
+    # The ledger's high-water mark must equal the journal's newest `when`, or \
+    # this image ships a database that silently skips the next migration anyone \
+    # writes (#4211). One psql call, and it makes that regression unshippable. \
+    ledger_max=$(gosu postgres psql -h /var/run/postgresql main -t -A -c "SELECT COALESCE(max(created_at), 0) FROM drizzle.\"__drizzle_migrations\"") && \
+    journal_max=$(jq -r '[.entries[].when] | max' /drizzle/meta/_journal.json) && \
+    echo "  Ledger high-water mark: $ledger_max (journal newest when: $journal_max)" && \
+    if [ "$ledger_max" != "$journal_max" ]; then \
+      echo "ERROR: ledger created_at high-water mark $ledger_max != journal newest when $journal_max — drizzle would skip later migrations" && false; \
     fi && \
     \
     # ── Import direct Aurora boards into unified tables ──────────────── \

--- a/packages/db/docker/Dockerfile.dev-db
+++ b/packages/db/docker/Dockerfile.dev-db
@@ -246,8 +246,10 @@ RUN set -e && \
     # created_at is the journal entry's own `when`, never the build clock (#4211). \
     # drizzle's migrate() reads max(created_at) once and applies only entries \
     # whose `when` is strictly greater, so a build timestamp would become a \
-    # high-water mark no later migration can clear — every migration added after \
-    # the image was built would be skipped on that database forever. `when` is \
+    # high-water mark that only moves up — and every journal entry with an \
+    # earlier `when` that this loop did not apply (a branch's migration, written \
+    # before this image was built) would be skipped on that database for good. \
+    # `when` is \
     # exactly what drizzle writes itself (it inserts folderMillis, which it copies \
     # from the journal's `when`). \
     applied=0 && \

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -74,6 +74,7 @@
     "test:explain": "tsx --test src/queries/climbs/__tests__/search-climbs-explain.integration.test.ts",
     "test:migration-journal": "tsx --test scripts/migration-journal-verification.integration.test.ts",
     "db:verify-journal": "tsx scripts/verify-migration-journal.ts",
+    "db:normalize-ledger": "tsx scripts/normalize-ledger-timestamps.ts",
     "db:studio": "drizzle-kit studio",
     "db:import-moonboard": "tsx scripts/import-moonboard-problems.ts",
     "db:import-moonboard-2024": "tsx scripts/import-moonboard-2024.ts",

--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -75,12 +75,15 @@ async function runMigrations() {
     // count mismatch that *would* have caught it was a console.warn. See
     // scripts/lib/migration-ledger.ts for the mechanism.
     //
-    // Still behind the env gate: the boardsesh-dev-db image is missing
-    // 0187_sad_freak's ledger row, so a default-on check would redden every
-    // developer's `vp run db:migrate` today. Both places that matter
-    // (production-deploy.yml, db-migration-renumber.yml) already set it. The
-    // gate itself is `runMigrationJournalGate` so it has test coverage; this
-    // file connects on import and offers no seam of its own.
+    // On by default since #3978. It shipped opt-in because the boardsesh-dev-db
+    // image was missing 0187_sad_freak's ledger row, and a default-on check
+    // would have reddened every developer's `vp run db:migrate` for a defect in
+    // the image. The image carries every journal entry's row now, and `vp run
+    // db:up` reconciles a stale volume per hash before this runs (#3979).
+    // Opt-in also meant the check was off on the one machine where a gap is
+    // created — the branch author's. VERIFY_MIGRATION_JOURNAL=0 is the escape
+    // hatch. The gate itself is `runMigrationJournalGate` so it has test
+    // coverage; this file connects on import and offers no seam of its own.
     const report = await runMigrationJournalGate(process.env, readLedgerHashesWith(client), migrationsFolder);
     if (report) {
       // Named on every armed run, not only on failure: production's pre-gate

--- a/packages/db/scripts/migration-journal-verification.integration.test.ts
+++ b/packages/db/scripts/migration-journal-verification.integration.test.ts
@@ -277,14 +277,22 @@ describe('migration journal verification (#2933)', () => {
       'migrate.ts runs the check through runMigrationJournalGate — it must throw, not report',
     );
 
-    // Gate off: the same broken database passes untouched. That is what keeps
-    // `vp run db:migrate` usable against the dev-db image (#3978) — and it must
-    // not read the ledger at all, so a future default-on flip is a visible change.
+    // An unset env now *arms* the gate (#3978): the same broken database fails.
+    await assert.rejects(
+      withScratchClient(scratchUrl, (client) =>
+        runMigrationJournalGate({}, readLedgerHashesWith(client), migrationsFolder),
+      ),
+      /0002_stale_when/,
+      'the check is on by default — an unset VERIFY_MIGRATION_JOURNAL must not disarm it',
+    );
+
+    // The escape hatch: `=0` passes the same broken database untouched, and must
+    // not read the ledger at all, so re-arming it stays a visible change.
     let ledgerReads = 0;
     const gateOff = await withScratchClient(scratchUrl, (client) => {
       const readHashes = readLedgerHashesWith(client);
       return runMigrationJournalGate(
-        {},
+        { VERIFY_MIGRATION_JOURNAL: '0' },
         () => {
           ledgerReads += 1;
           return readHashes();
@@ -292,7 +300,7 @@ describe('migration journal verification (#2933)', () => {
         migrationsFolder,
       );
     });
-    assert.equal(gateOff, null, 'an unset VERIFY_MIGRATION_JOURNAL must skip the check');
+    assert.equal(gateOff, null, 'VERIFY_MIGRATION_JOURNAL=0 must skip the check');
     assert.equal(ledgerReads, 0, 'the gate must not query the ledger when it is off');
 
     // And it never self-heals: a third deploy does not create the table either.
@@ -395,28 +403,30 @@ describe('migration journal verification (#2933)', () => {
     );
   });
 
-  it('only arms the deploy gate on an exact VERIFY_MIGRATION_JOURNAL=1', async () => {
+  it('arms the deploy gate by default and stands down only on VERIFY_MIGRATION_JOURNAL=0', async () => {
     // No database needed: the ledger reader is a stub, so this pins the env
-    // contract on its own. `production-deploy.yml` and `db-migration-renumber.yml`
-    // both pass the literal '1'; anything else must leave the check off rather
-    // than half-on.
+    // contract on its own. `ci.yml`, `production-deploy.yml` and
+    // `db-migration-renumber.yml` all pass the literal '1' and must stay armed
+    // without an edit; everything else that is not the exact escape hatch has to
+    // arm too, rather than leaving the check half-on (#3978).
     const migrationsFolder = makeTempFolder('gate');
     writeMigrationsFolder(migrationsFolder, PHASE_ONE);
     const emptyLedger = async () => [];
 
-    for (const value of [undefined, '', '0', 'true', 'yes']) {
-      const report = await runMigrationJournalGate(
-        value === undefined ? {} : { VERIFY_MIGRATION_JOURNAL: value },
-        emptyLedger,
-        migrationsFolder,
+    for (const value of [undefined, '', '1', 'true', 'yes']) {
+      await assert.rejects(
+        runMigrationJournalGate(
+          value === undefined ? {} : { VERIFY_MIGRATION_JOURNAL: value },
+          emptyLedger,
+          migrationsFolder,
+        ),
+        /Missing: 0000_a, 0001_b/,
+        `VERIFY_MIGRATION_JOURNAL=${String(value)} must arm the gate`,
       );
-      assert.equal(report, null, `VERIFY_MIGRATION_JOURNAL=${String(value)} must not arm the gate`);
     }
 
-    await assert.rejects(
-      runMigrationJournalGate({ VERIFY_MIGRATION_JOURNAL: '1' }, emptyLedger, migrationsFolder),
-      /Missing: 0000_a, 0001_b/,
-    );
+    const report = await runMigrationJournalGate({ VERIFY_MIGRATION_JOURNAL: '0' }, emptyLedger, migrationsFolder);
+    assert.equal(report, null, 'VERIFY_MIGRATION_JOURNAL=0 is the escape hatch');
   });
 
   it('tolerates a baselined gap and still fails on the one beside it', async (context) => {

--- a/packages/db/scripts/migration-journal-verification.integration.test.ts
+++ b/packages/db/scripts/migration-journal-verification.integration.test.ts
@@ -27,6 +27,7 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
 import { findUnappliedMigrations } from '../../../scripts/lib/migration-ledger.js';
 import { PRODUCTION_LEDGER_BASELINE, type LedgerBaseline } from '../../../scripts/lib/migration-ledger-baseline.js';
+import { DRIZZLE_LEDGER_TABLE, normalizeLedgerTable } from './normalize-ledger-timestamps.js';
 import {
   DRIZZLE_MIGRATIONS_FOLDER,
   assertMigrationJournalApplied,
@@ -603,6 +604,101 @@ describe('migration journal verification (#2933)', () => {
         `${spelling} must resolve to the production baseline`,
       );
     }
+  });
+
+  it('unblocks a build-clock-stamped ledger so drizzle applies the next migration (#4211)', async (context) => {
+    const adminUrl = localDatabaseUrl();
+    if (!adminUrl) {
+      context.skip('set DATABASE_URL to a local Postgres to run');
+      return;
+    }
+    // The dev-db image's exact shape: the journal is applied by a psql loop that
+    // stamps every ledger row with the image's build clock instead of the
+    // entry's `when`. That single value is a high-water mark drizzle can never
+    // clear, so every migration written after the image was built is skipped —
+    // on that deploy and on every one after it.
+    const migrationsFolder = makeTempFolder('build-clock');
+    const scratchUrl = await createScratchDatabase(adminUrl, 'build_clock');
+    writeMigrationsFolder(migrationsFolder, PHASE_ONE);
+    await applyMigrations(scratchUrl, migrationsFolder);
+
+    // As drizzle left it, there is nothing to repair — the normaliser writes the
+    // same value drizzle already wrote.
+    const drizzleManagedPlan = await withScratchClient(scratchUrl, (client) =>
+      normalizeLedgerTable(client, DRIZZLE_LEDGER_TABLE, readExpectedMigrations(migrationsFolder), { dryRun: true }),
+    );
+    assert.deepEqual(drizzleManagedPlan, [], 'a drizzle-managed ledger must need no repair');
+
+    const BUILD_CLOCK = 1_800_000_000_000;
+    await withScratchClient(scratchUrl, async (client) => {
+      await client`UPDATE drizzle."__drizzle_migrations" SET created_at = ${BUILD_CLOCK}`;
+    });
+
+    // A new migration lands, appended above every journal `when` but far below
+    // the build clock.
+    const laterEntry = { tag: '0002_later', when: 4000, sql: 'CREATE TABLE mjv_t_later (id int);' };
+    writeMigrationsFolder(migrationsFolder, [...PHASE_ONE, laterEntry]);
+    await applyMigrations(scratchUrl, migrationsFolder);
+
+    assert.equal(
+      await tableExists(scratchUrl, 'mjv_t_later'),
+      false,
+      'the build-clock high-water mark is expected to make drizzle skip the new migration',
+    );
+    await assert.rejects(
+      withScratchClient(scratchUrl, (client) =>
+        assertMigrationJournalApplied(readLedgerHashesWith(client), migrationsFolder),
+      ),
+      /0002_later/,
+      'the gate must see the skip as a real gap',
+    );
+
+    // The repair: rewrite created_at to each entry's own `when`.
+    const repairs = await withScratchClient(scratchUrl, (client) =>
+      normalizeLedgerTable(client, DRIZZLE_LEDGER_TABLE, readExpectedMigrations(migrationsFolder)),
+    );
+    assert.deepEqual(
+      repairs.map((repair) => ({ tag: repair.tag, to: repair.to })),
+      [
+        { tag: '0000_a', to: 1000 },
+        { tag: '0001_b', to: 3000 },
+      ],
+      'only the two rows the image stamped exist, and each takes its own journal when',
+    );
+
+    await applyMigrations(scratchUrl, migrationsFolder);
+    assert.equal(await tableExists(scratchUrl, 'mjv_t_later'), true, 'the repaired ledger must let the migration run');
+    await assert.doesNotReject(
+      withScratchClient(scratchUrl, (client) =>
+        assertMigrationJournalApplied(readLedgerHashesWith(client), migrationsFolder),
+      ),
+    );
+
+    // And drizzle's own row for the newly applied migration already carries the
+    // journal `when`, so a second pass finds nothing to do.
+    const secondPass = await withScratchClient(scratchUrl, (client) =>
+      normalizeLedgerTable(client, DRIZZLE_LEDGER_TABLE, readExpectedMigrations(migrationsFolder), { dryRun: true }),
+    );
+    assert.deepEqual(secondPass, [], 'the repair must be idempotent');
+  });
+
+  it('leaves a ledger table it cannot find alone (#4211)', async (context) => {
+    const adminUrl = localDatabaseUrl();
+    if (!adminUrl) {
+      context.skip('set DATABASE_URL to a local Postgres to run');
+      return;
+    }
+    // Older images have no legacy public."__drizzle_migrations" (and a brand new
+    // database has no drizzle schema at all). `vp run db:up` runs the normaliser
+    // unconditionally, so an absent table must be a quiet no-op, not a crash.
+    const migrationsFolder = makeTempFolder('absent-table');
+    const scratchUrl = await createScratchDatabase(adminUrl, 'absent_table');
+    writeMigrationsFolder(migrationsFolder, PHASE_ONE);
+
+    const plan = await withScratchClient(scratchUrl, (client) =>
+      normalizeLedgerTable(client, DRIZZLE_LEDGER_TABLE, readExpectedMigrations(migrationsFolder)),
+    );
+    assert.deepEqual(plan, []);
   });
 
   it('keeps findUnappliedMigrations multiset-aware for byte-identical migrations', () => {

--- a/packages/db/scripts/migration-journal-verification.integration.test.ts
+++ b/packages/db/scripts/migration-journal-verification.integration.test.ts
@@ -614,9 +614,11 @@ describe('migration journal verification (#2933)', () => {
     }
     // The dev-db image's exact shape: the journal is applied by a psql loop that
     // stamps every ledger row with the image's build clock instead of the
-    // entry's `when`. That single value is a high-water mark drizzle can never
-    // clear, so every migration written after the image was built is skipped —
-    // on that deploy and on every one after it.
+    // entry's `when`. That single value becomes a high-water mark that only ever
+    // moves up, so every journal entry with an earlier `when` that the image did
+    // not itself apply — `0002_later` below, standing in for a branch's
+    // migration written before the image was built — is skipped on that deploy
+    // and on every one after it.
     const migrationsFolder = makeTempFolder('build-clock');
     const scratchUrl = await createScratchDatabase(adminUrl, 'build_clock');
     writeMigrationsFolder(migrationsFolder, PHASE_ONE);

--- a/packages/db/scripts/migration-journal.ts
+++ b/packages/db/scripts/migration-journal.ts
@@ -7,7 +7,10 @@ import {
   findUnappliedMigrations,
   formatBaselinedGapWarning,
   formatMigrationGapError,
+  isMigrationJournalGateArmed,
   partitionMissingMigrations,
+  VERIFY_MIGRATION_JOURNAL_ENV,
+  VERIFY_MIGRATION_JOURNAL_OFF,
   type ExpectedMigration,
   type ExpectedMigrationWithWhen,
 } from '../../../scripts/lib/migration-ledger.js';
@@ -237,12 +240,18 @@ export function describeBaselinedGap(report: MigrationJournalReport): string | n
   );
 }
 
-/** Env var that turns the deploy gate on. Set by production-deploy.yml and db-migration-renumber.yml. */
-export const VERIFY_MIGRATION_JOURNAL_ENV = 'VERIFY_MIGRATION_JOURNAL';
+export { VERIFY_MIGRATION_JOURNAL_ENV, VERIFY_MIGRATION_JOURNAL_OFF };
 
 /**
- * The deploy gate exactly as `migrate.ts` runs it: verify when
- * `VERIFY_MIGRATION_JOURNAL=1`, otherwise do nothing and touch no database.
+ * The deploy gate exactly as `migrate.ts` runs it: verify unless
+ * `VERIFY_MIGRATION_JOURNAL=0`, in which case do nothing and touch no database.
+ *
+ * The check is on by default since #3978 — the dev-db image that forced the
+ * original opt-in now carries every journal entry's ledger row, and `vp run
+ * db:up` reconciles the rest per hash before this ever runs. See
+ * `isMigrationJournalGateArmed` in `scripts/lib/migration-ledger.ts` for the
+ * reasoning and for the unit coverage of the env contract, which lives there
+ * because this package runs on `tsx --test` and is outside the CI test graph.
  *
  * This lives here rather than inline in `migrate.ts` so the fail-closed
  * behaviour — the whole point of #2933 — is reachable from a test. `migrate.ts`
@@ -259,7 +268,7 @@ export async function runMigrationJournalGate(
   migrationsFolder: string = DRIZZLE_MIGRATIONS_FOLDER,
   baselineOverride?: LedgerBaseline,
 ): Promise<MigrationJournalReport | null> {
-  if (env[VERIFY_MIGRATION_JOURNAL_ENV] !== '1') {
+  if (!isMigrationJournalGateArmed(env)) {
     return null;
   }
   return assertMigrationJournalApplied(readLedgerHashes, migrationsFolder, baselineOverride);

--- a/packages/db/scripts/migration-journal.ts
+++ b/packages/db/scripts/migration-journal.ts
@@ -9,6 +9,7 @@ import {
   formatMigrationGapError,
   partitionMissingMigrations,
   type ExpectedMigration,
+  type ExpectedMigrationWithWhen,
 } from '../../../scripts/lib/migration-ledger.js';
 import {
   EMPTY_LEDGER_BASELINE,
@@ -141,7 +142,7 @@ export function readExpectedMigrations(
   readFiles: (config: {
     migrationsFolder: string;
   }) => readonly { folderMillis: number; hash: string }[] = readMigrationFiles,
-): ExpectedMigration[] {
+): ExpectedMigrationWithWhen[] {
   const journalPath = path.join(migrationsFolder, 'meta', '_journal.json');
   const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8')) as MigrationJournal;
   const migrationFiles = readFiles({ migrationsFolder });
@@ -160,7 +161,12 @@ export function readExpectedMigrations(
           `when ${journalEntry.when}. readMigrationFiles no longer returns journal order.`,
       );
     }
-    return { tag: journalEntry.tag, hash: migrationFile.hash };
+    // `when` rides along for `normalize-ledger-timestamps.ts`: it is the exact
+    // value drizzle stamps into `created_at` (it inserts `folderMillis`, which
+    // the assertion just above pins to this same `when`), so the normaliser
+    // never has to re-derive a timestamp any more than this module re-derives a
+    // hash.
+    return { tag: journalEntry.tag, hash: migrationFile.hash, when: journalEntry.when };
   });
 }
 

--- a/packages/db/scripts/normalize-ledger-timestamps.ts
+++ b/packages/db/scripts/normalize-ledger-timestamps.ts
@@ -6,10 +6,14 @@
  * psql loop and stamps both ledger tables with the image's *build* wall clock
  * (`$(date +%s)000`). Drizzle's applier is a single high-water mark — it reads
  * `max(created_at)` once and applies only entries whose `when` is strictly
- * greater — so a build timestamp sitting ~13 orders of magnitude of wall clock
- * above every journal `when` means the next migration anyone adds is skipped on
- * that database forever. `vp run db:migrate` reports success, the table never
- * appears, and `VERIFY_MIGRATION_JOURNAL=1` (correctly) calls it a gap.
+ * greater — so that build timestamp becomes the mark, and every journal entry
+ * whose `when` predates the image build but which the image did not itself apply
+ * is skipped. Concretely, that is a branch's migration generated before the
+ * image was built: on the e2e jobs, which run `:latest`, most open PRs. (Not the
+ * newest migrations — a `when` later than the build clock still applies, which
+ * is why the bug reads as intermittent.) `vp run db:migrate` reports success,
+ * the table never appears, and `VERIFY_MIGRATION_JOURNAL=1` (correctly) calls it
+ * a gap. The mark only ever moves up, so the skip is permanent.
  *
  * `Dockerfile.dev-db` now stamps `when`, but that only helps images built after
  * this lands: CI pins a digest and developers keep a persistent `db_data`

--- a/packages/db/scripts/normalize-ledger-timestamps.ts
+++ b/packages/db/scripts/normalize-ledger-timestamps.ts
@@ -1,0 +1,177 @@
+/**
+ * Repairs `created_at` in drizzle's applied-migration ledger so every row
+ * carries its journal entry's `when` — the value drizzle itself writes.
+ *
+ * Why this exists (#4211): the `boardsesh-dev-db` image applies the journal in a
+ * psql loop and stamps both ledger tables with the image's *build* wall clock
+ * (`$(date +%s)000`). Drizzle's applier is a single high-water mark — it reads
+ * `max(created_at)` once and applies only entries whose `when` is strictly
+ * greater — so a build timestamp sitting ~13 orders of magnitude of wall clock
+ * above every journal `when` means the next migration anyone adds is skipped on
+ * that database forever. `vp run db:migrate` reports success, the table never
+ * appears, and `VERIFY_MIGRATION_JOURNAL=1` (correctly) calls it a gap.
+ *
+ * `Dockerfile.dev-db` now stamps `when`, but that only helps images built after
+ * this lands: CI pins a digest and developers keep a persistent `db_data`
+ * volume. This script fixes what is already on disk, in place.
+ *
+ * It is a *dev/CI* tool. Production's ledger is written by drizzle and is
+ * already `when`-valued, so there is nothing to repair there — the URL guard
+ * below refuses a non-local target unless `--force`, so this can never be
+ * mistaken for a production ledger-mutation tool.
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://… vp run db:normalize-ledger
+ *   DATABASE_URL=postgres://… vp run db:normalize-ledger -- --dry-run
+ */
+import postgres from 'postgres';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describeDatabaseHost, getScriptDatabaseUrl, isLocalDatabaseUrl } from './db-connection.js';
+import { readExpectedMigrations } from './migration-journal.js';
+import {
+  planLedgerTimestampRepairs,
+  type ExpectedMigrationWithWhen,
+  type LedgerTimestampRepair,
+  type LedgerTimestampRow,
+} from '../../../scripts/lib/migration-ledger.js';
+
+/** A ledger table, qualified. Both are literals in this module — never user input. */
+export interface LedgerTable {
+  schema: string;
+  table: string;
+}
+
+/** Where drizzle 0.45 keeps the ledger. */
+export const DRIZZLE_LEDGER_TABLE: LedgerTable = { schema: 'drizzle', table: '__drizzle_migrations' };
+
+/**
+ * Where older drizzle kept it, and where the dev-db image still writes a copy.
+ * `scripts/dev-db-up.sh`'s `sync_drizzle_migration_tracker` seeds the drizzle
+ * table from this one when the drizzle table is empty, so leaving this one
+ * build-stamped would re-introduce the bad high-water mark on the next fresh
+ * volume.
+ */
+export const LEGACY_LEDGER_TABLE: LedgerTable = { schema: 'public', table: '__drizzle_migrations' };
+
+function qualify(table: LedgerTable): string {
+  return `"${table.schema}"."${table.table}"`;
+}
+
+/** Postgres client surface this module needs. Narrow on purpose so tests can pass a scratch client. */
+export type LedgerClient = Pick<postgres.Sql, 'unsafe' | 'begin'>;
+
+/** False when the table does not exist — an older image has no `drizzle` schema at all. */
+export async function ledgerTableExists(client: LedgerClient, table: LedgerTable): Promise<boolean> {
+  const rows = await client.unsafe<{ present: string | null }[]>('SELECT to_regclass($1)::text AS present', [
+    `${table.schema}.${table.table}`,
+  ]);
+  return rows[0]?.present != null;
+}
+
+/**
+ * `id`-ordered ledger rows. `created_at` is a bigint, which postgres.js hands
+ * back as a string, so it is converted here rather than in the pure planner.
+ */
+export async function readLedgerTimestampRows(client: LedgerClient, table: LedgerTable): Promise<LedgerTimestampRow[]> {
+  const rows = await client.unsafe<{ id: number; hash: string; created_at: string | number | null }[]>(
+    `SELECT id, hash, created_at FROM ${qualify(table)} ORDER BY id`,
+  );
+  return rows.map((row) => ({ id: Number(row.id), hash: row.hash, createdAt: Number(row.created_at ?? 0) }));
+}
+
+/**
+ * Applies the whole plan in one transaction: a half-repaired ledger has a
+ * high-water mark nobody predicted, which is the failure mode this fixes.
+ */
+export async function applyLedgerTimestampRepairs(
+  client: LedgerClient,
+  table: LedgerTable,
+  repairs: readonly LedgerTimestampRepair[],
+): Promise<void> {
+  if (repairs.length === 0) return;
+  await client.begin(async (tx) => {
+    for (const repair of repairs) {
+      await tx.unsafe(`UPDATE ${qualify(table)} SET created_at = $1 WHERE id = $2`, [repair.to, repair.id]);
+    }
+  });
+}
+
+/**
+ * Plan-and-apply for one table. Returns the plan (empty when the table is
+ * absent or already correct) so callers can report it.
+ */
+export async function normalizeLedgerTable(
+  client: LedgerClient,
+  table: LedgerTable,
+  expected: readonly ExpectedMigrationWithWhen[],
+  options: { dryRun?: boolean } = {},
+): Promise<LedgerTimestampRepair[]> {
+  if (!(await ledgerTableExists(client, table))) return [];
+  const repairs = planLedgerTimestampRepairs(expected, await readLedgerTimestampRows(client, table));
+  if (!options.dryRun) {
+    await applyLedgerTimestampRepairs(client, table, repairs);
+  }
+  return repairs;
+}
+
+function reportTable(table: LedgerTable, repairs: readonly LedgerTimestampRepair[], dryRun: boolean): void {
+  const qualified = `${table.schema}.${table.table}`;
+  if (repairs.length === 0) {
+    console.info(`   ${qualified}: already carries the journal's timestamps.`);
+    return;
+  }
+  console.info(`   ${qualified}: ${dryRun ? 'would repair' : 'repaired'} ${repairs.length} row(s).`);
+  for (const repair of repairs) {
+    console.info(`     • ${repair.tag}: ${repair.from} → ${repair.to}`);
+  }
+}
+
+async function normalizeLedgerTimestamps(argv: readonly string[]): Promise<void> {
+  const dryRun = argv.includes('--dry-run');
+  const force = argv.includes('--force');
+  const databaseUrl = getScriptDatabaseUrl();
+
+  if (!isLocalDatabaseUrl(databaseUrl) && !force) {
+    console.error(
+      `❌ Refusing to normalise the migration ledger on ${describeDatabaseHost(databaseUrl)}: this is a dev/CI ` +
+        'repair for databases whose ledger was stamped by something other than drizzle. Production ledgers are ' +
+        'already written by drizzle. Pass --force if you are certain.',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.info(
+    `🕒 Normalising migration ledger timestamps on: ${describeDatabaseHost(databaseUrl)}${dryRun ? ' (dry run)' : ''}`,
+  );
+
+  const client = postgres(databaseUrl, { max: 1 });
+  try {
+    const expected = readExpectedMigrations();
+    let repairedRows = 0;
+    for (const table of [DRIZZLE_LEDGER_TABLE, LEGACY_LEDGER_TABLE]) {
+      const repairs = await normalizeLedgerTable(client, table, expected, { dryRun });
+      repairedRows += repairs.length;
+      reportTable(table, repairs, dryRun);
+    }
+    console.info(
+      repairedRows === 0
+        ? '✅ Nothing to repair — every ledger row already carries its journal `when`.'
+        : `✅ ${dryRun ? 'Planned' : 'Wrote'} ${repairedRows} ledger timestamp repair(s).`,
+    );
+  } catch (error) {
+    console.error('❌ Migration ledger timestamp normalisation failed:', error);
+    process.exitCode = 1;
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+// Only when run as a script. The exported helpers above are imported by
+// packages/db/scripts/migration-journal-verification.integration.test.ts, which
+// must not connect to the developer's dev database on import.
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+if (invokedPath === path.resolve(fileURLToPath(import.meta.url))) {
+  void normalizeLedgerTimestamps(process.argv.slice(2));
+}

--- a/scripts/__tests__/ci-location-sync-workflow.test.ts
+++ b/scripts/__tests__/ci-location-sync-workflow.test.ts
@@ -82,6 +82,17 @@ describe('location-sync CI integration contract', () => {
     expect(integrationJob).not.toContain('--changed');
   });
 
+  it('repairs the image ledger timestamps before applying the journal', () => {
+    // The pinned image stamps `created_at` with its build clock (#4211), which is
+    // a high-water mark drizzle can never clear. Ordered after db:migrate the
+    // repair is useless: the migrations it would have unblocked are already
+    // skipped by then, and the ledger only ever moves up.
+    const normalizeIndex = integrationJob.indexOf('run: bun run --filter=@boardsesh/db db:normalize-ledger');
+    const migrateIndex = integrationJob.indexOf('run: bun run --filter=@boardsesh/db db:migrate');
+    expect(normalizeIndex).toBeGreaterThan(-1);
+    expect(migrateIndex).toBeGreaterThan(normalizeIndex);
+  });
+
   it('publishes JUnit and makes both report and aggregate status depend on the job', () => {
     expect(integrationJob).toContain('--reporter=junit');
     expect(integrationJob).toContain('name: test-results-location-sync');

--- a/scripts/__tests__/dev-db-image-ledger.test.ts
+++ b/scripts/__tests__/dev-db-image-ledger.test.ts
@@ -1,0 +1,53 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * File-text guard for #4211.
+ *
+ * `Dockerfile.dev-db` applies the migration journal in a psql loop and writes
+ * drizzle's ledger by hand. It used to stamp `created_at` with the image's build
+ * clock, which becomes a high-water mark drizzle's applier can never clear — so
+ * every migration written after the image was built is silently skipped on that
+ * database, forever.
+ *
+ * Building the image to check this takes tens of minutes and hits the network
+ * hard (six APK downloads, pgloader, the MoonBoard import), so the practical
+ * coverage is this text guard plus the in-build assertion it requires: the
+ * ledger's high-water mark must equal the journal's newest `when`.
+ */
+const DOCKERFILE_PATH = 'packages/db/docker/Dockerfile.dev-db';
+const dockerfileSource = readFileSync(DOCKERFILE_PATH, 'utf8');
+
+/** Non-comment lines only — the `date +%s` ban must not be satisfiable by a comment. */
+const executableLines = dockerfileSource
+  .split('\n')
+  .filter((line) => !line.trimStart().startsWith('#'))
+  .join('\n');
+
+describe('dev-db image migration ledger', () => {
+  it('never stamps ledger rows with the build clock', () => {
+    const ledgerInserts = executableLines
+      .split('\n')
+      .filter((line) => line.includes('INSERT INTO') && line.includes('__drizzle_migrations'));
+    expect(ledgerInserts.length).toBeGreaterThan(0);
+    for (const insert of ledgerInserts) {
+      expect(insert).not.toContain('date +%s');
+      expect(insert).toContain('$when');
+    }
+  });
+
+  it('reads the when of each entry out of the journal', () => {
+    expect(executableLines).toContain(`jq -r '.entries[] | "\\(.tag) \\(.when)"' /drizzle/meta/_journal.json`);
+    expect(executableLines).toContain('while read -r tag when; do');
+  });
+
+  it('fails the build when the ledger high-water mark is not the newest journal when', () => {
+    expect(executableLines).toContain(
+      'ledger_max=$(gosu postgres psql -h /var/run/postgresql main -t -A -c "SELECT COALESCE(max(created_at), 0) FROM drizzle.\\"__drizzle_migrations\\"")',
+    );
+    expect(executableLines).toContain(`journal_max=$(jq -r '[.entries[].when] | max' /drizzle/meta/_journal.json)`);
+    expect(executableLines).toContain('if [ "$ledger_max" != "$journal_max" ]; then');
+  });
+});

--- a/scripts/__tests__/dev-db-image-ledger.test.ts
+++ b/scripts/__tests__/dev-db-image-ledger.test.ts
@@ -1,16 +1,20 @@
 /// <reference types="node" />
 
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
+
+const WORKFLOWS_DIR = '.github/workflows';
 
 /**
  * File-text guard for #4211.
  *
  * `Dockerfile.dev-db` applies the migration journal in a psql loop and writes
  * drizzle's ledger by hand. It used to stamp `created_at` with the image's build
- * clock, which becomes a high-water mark drizzle's applier can never clear — so
- * every migration written after the image was built is silently skipped on that
- * database, forever.
+ * clock, which becomes a high-water mark that only ever moves up — so every
+ * journal entry with an earlier `when` that the image did not itself apply (a
+ * branch's migration, written before the image was built) is silently skipped on
+ * that database, for good.
  *
  * Building the image to check this takes tens of minutes and hits the network
  * hard (six APK downloads, pgloader, the MoonBoard import), so the practical
@@ -49,5 +53,132 @@ describe('dev-db image migration ledger', () => {
     );
     expect(executableLines).toContain(`journal_max=$(jq -r '[.entries[].when] | max' /drizzle/meta/_journal.json)`);
     expect(executableLines).toContain('if [ "$ledger_max" != "$journal_max" ]; then');
+  });
+});
+
+/**
+ * `vp run db:up` repairs the container it just started — and only that one.
+ *
+ * `getScriptDatabaseUrl()` reads `DB_URL || DATABASE_URL || POSTGRES_URL`, and
+ * its dotenv chain fills whichever of the three the caller leaves unset from
+ * `.env.local` / `packages/web/.env.local`. A `DB_URL` naming a remote or
+ * production database is a normal thing to have there (docs/db-migrations.md's
+ * own `db:verify-journal` example is invoked with `DB_URL`), and it would beat a
+ * lone `DATABASE_URL=…localhost` on the normaliser's own command line: `db:up`
+ * would then either die on the non-local guard under `set -e`, or — for the
+ * tailnet MagicDNS/CGNAT hosts `isLocalDatabaseUrl` deliberately accepts —
+ * quietly rewrite some other database's ledger.
+ */
+describe('dev-db-up.sh ledger normalisation target', () => {
+  const devDbUpSource = readFileSync('scripts/dev-db-up.sh', 'utf8');
+  const normalizeFunction = devDbUpSource.slice(
+    devDbUpSource.indexOf('normalize_ledger_timestamps() {'),
+    devDbUpSource.indexOf('prepare_docker_postgres() {'),
+  );
+
+  it('pins every name getScriptDatabaseUrl reads to the local container', () => {
+    expect(normalizeFunction).toContain('db:normalize-ledger');
+    for (const envName of ['DB_URL', 'DATABASE_URL', 'POSTGRES_URL']) {
+      expect(normalizeFunction).toContain(`${envName}="$dev_db_ledger_url"`);
+    }
+    expect(normalizeFunction).toContain('dev_db_ledger_url="postgresql://postgres:password@localhost:5432/main"');
+  });
+
+  it('runs the repair before the pending-migration apply', () => {
+    // After the apply the repair is useless: the migrations it would have
+    // unblocked have already been skipped, and the ledger only moves up.
+    const prepare = devDbUpSource.slice(devDbUpSource.indexOf('prepare_docker_postgres() {'));
+    const normalizeIndex = prepare.indexOf('normalize_ledger_timestamps');
+    const applyIndex = prepare.indexOf('run_pending_drizzle_sql_migrations');
+    expect(normalizeIndex).toBeGreaterThan(-1);
+    expect(applyIndex).toBeGreaterThan(normalizeIndex);
+  });
+});
+
+/**
+ * The repair has to be wired into *every* CI job that boots the image and then
+ * applies migrations — three of them today, and the next one is easy to add
+ * without noticing this exists. `ci-location-sync-workflow.test.ts` pins the
+ * ordering for its own job only, so this sweeps the rest.
+ *
+ * The exemption below is the one case that is genuinely safe, and it is listed
+ * rather than skipped so that a reviewer sees the reasoning instead of the gap.
+ */
+const RENUMBER_EXEMPTION = { workflow: 'db-migration-renumber.yml', job: 'renumber' };
+
+/** Job bodies keyed `<workflow file>#<job name>`, split on the 2-space job keys under `jobs:`. */
+function readWorkflowJobs(): Map<string, string> {
+  const jobs = new Map<string, string>();
+  for (const fileName of readdirSync(WORKFLOWS_DIR).filter((name) => name.endsWith('.yml'))) {
+    const lines = readFileSync(path.join(WORKFLOWS_DIR, fileName), 'utf8').split('\n');
+    const jobsIndex = lines.findIndex((line) => line === 'jobs:');
+    if (jobsIndex < 0) continue;
+
+    let currentJob: string | null = null;
+    let currentStart = 0;
+    const flush = (endIndex: number) => {
+      if (currentJob) jobs.set(`${fileName}#${currentJob}`, lines.slice(currentStart, endIndex).join('\n'));
+    };
+    for (let index = jobsIndex + 1; index < lines.length; index += 1) {
+      const jobKey = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(lines[index]);
+      if (jobKey) {
+        flush(index);
+        currentJob = jobKey[1];
+        currentStart = index;
+      }
+    }
+    flush(lines.length);
+  }
+  return jobs;
+}
+
+describe('CI jobs that boot the dev-db image', () => {
+  // `db:migrate` and `bunx drizzle-kit migrate` are the same applier; both read
+  // max(created_at) once, so both are blocked by a build-clock high-water mark.
+  const MIGRATE_INVOCATIONS = ['db:migrate', 'drizzle-kit migrate'];
+
+  // The steps here are commented, and those comments name the very commands this
+  // guard orders — "Must stay ahead of db:migrate" sits *above* the normalise
+  // step. Ordering on the raw text would read that comment as the migrate step
+  // and fail every correctly-wired job.
+  function withoutComments(body: string): string {
+    return body
+      .split('\n')
+      .filter((line) => !line.trimStart().startsWith('#'))
+      .join('\n');
+  }
+
+  it('normalize the ledger before applying migrations', () => {
+    const jobsBootingTheImage = [...readWorkflowJobs()]
+      .map(([id, body]) => [id, withoutComments(body)] as const)
+      .filter(
+        ([, body]) => body.includes('boardsesh-dev-db') && MIGRATE_INVOCATIONS.some((step) => body.includes(step)),
+      );
+    // If this drops to zero the sweep has stopped sweeping — most likely the job
+    // key regex stopped matching after a workflow reformat.
+    expect(jobsBootingTheImage.length).toBeGreaterThanOrEqual(3);
+
+    const unrepaired = jobsBootingTheImage
+      .filter(([id]) => id !== `${RENUMBER_EXEMPTION.workflow}#${RENUMBER_EXEMPTION.job}`)
+      .filter(([, body]) => {
+        const normalizeIndex = body.indexOf('db:normalize-ledger');
+        const migrateIndex = Math.min(
+          ...MIGRATE_INVOCATIONS.map((step) => body.indexOf(step)).filter((index) => index >= 0),
+        );
+        return normalizeIndex < 0 || normalizeIndex > migrateIndex;
+      })
+      .map(([id]) => id);
+    expect(unrepaired).toEqual([]);
+  });
+
+  it('exempts only the renumber job, which writes its own fresh `when`', () => {
+    // `scripts/db-renumber-migration.ts` stamps the migration it moves with
+    // `nextWhen(maxWhen(mainJournal), Date.now())` — a value taken at workflow
+    // run time, so it is always above the build clock of an image built earlier.
+    // Nothing there can land under the mark, which is why this job alone needs no
+    // repair. Change that script's `when` derivation and this exemption dies.
+    const renumberSource = readFileSync('scripts/db-renumber-migration.ts', 'utf8');
+    expect(renumberSource).toContain('nextWhen(maxWhen(mainJournal), Date.now())');
+    expect(readWorkflowJobs().has(`${RENUMBER_EXEMPTION.workflow}#${RENUMBER_EXEMPTION.job}`)).toBe(true);
   });
 });

--- a/scripts/__tests__/dev-db-up-migration-selection.test.ts
+++ b/scripts/__tests__/dev-db-up-migration-selection.test.ts
@@ -1,0 +1,65 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * File-text guard for #3979.
+ *
+ * `scripts/dev-db-up.sh` is POSIX `sh` and root `scripts/` is not typechecked,
+ * so the invariants that keep its pending-migration selection correct have no
+ * other home. Running the script for real needs Docker, the pre-built image, and
+ * a few minutes; these assertions cost a file read and catch the two ways the
+ * fix could be undone — reintroducing the high-water mark, or dropping the
+ * per-hash selector back into an inline `bun --eval`.
+ */
+const DEV_DB_UP_PATH = 'scripts/dev-db-up.sh';
+const devDbUpSource = readFileSync(DEV_DB_UP_PATH, 'utf8');
+
+/** Non-comment lines only — none of these bans may be satisfied by prose in a comment. */
+const executableLines = devDbUpSource
+  .split('\n')
+  .filter((line) => !line.trimStart().startsWith('#'))
+  .join('\n');
+
+const applyFunction = devDbUpSource.slice(devDbUpSource.indexOf('run_pending_drizzle_sql_migrations() {'));
+
+describe('dev-db-up.sh pending-migration selection', () => {
+  it('never selects on a created_at high-water mark', () => {
+    // The bug itself: one `max(created_at)` snapshot, then `when > mark`. The
+    // mark only ever moves up, so anything at or below it is skipped on this run
+    // and on every run after it.
+    expect(executableLines).not.toContain('LAST_MIGRATION_CREATED_AT');
+    expect(executableLines).not.toContain('last_migration_created_at');
+    expect(executableLines).not.toContain('ORDER BY created_at DESC');
+    expect(executableLines).not.toContain('entry.when <= lastAppliedAt');
+  });
+
+  it('feeds the ledger hashes to the per-hash selector', () => {
+    expect(executableLines).toContain('SELECT hash FROM drizzle.\\"__drizzle_migrations\\"');
+    expect(executableLines).toContain('scripts/dev-db-pending-migrations.ts');
+  });
+
+  it('still records created_at as the journal when, the value drizzle writes', () => {
+    // Anything else re-creates #4211: a ledger row whose timestamp is not the
+    // journal's `when` gives drizzle's own applier a mark nobody predicted, and
+    // gives the normaliser above a repair to make on every subsequent run.
+    expect(applyFunction).toContain('INSERT INTO drizzle."__drizzle_migrations" (hash, created_at) VALUES (%s, %s);');
+    expect(applyFunction).toContain("while IFS='|' read -r tag created_at hash; do");
+  });
+
+  it('keeps every migration in a transaction that aborts on the first error', () => {
+    expect(applyFunction).toContain('ON_ERROR_STOP=1');
+    expect(applyFunction).toContain("printf 'BEGIN;\\n'");
+    expect(applyFunction).toContain("printf 'COMMIT;\\n'");
+  });
+
+  it('explains a residue database instead of leaving the raw psql error', () => {
+    // #3978's shape: the volume carries a superseded branch version of a
+    // migration's objects but not its ledger row, so the apply dies on
+    // "already exists". Nothing can repair that in place, so the failure has to
+    // hand over the reset command rather than a bare SQL error.
+    expect(applyFunction).toContain('docker compose down -v && vp run db:up');
+    expect(applyFunction).toContain('exit 1');
+  });
+});

--- a/scripts/dev-db-discover.ts
+++ b/scripts/dev-db-discover.ts
@@ -268,6 +268,30 @@ async function ensureMigrationTracker(client: postgres.Sql): Promise<void> {
   `;
 }
 
+/**
+ * The one apply failure a developer cannot read off the raw psql error: the
+ * database carries a superseded branch version of the migration's objects but
+ * not its ledger row, so the first `CREATE` dies on "already exists". Nothing
+ * repairs that in place — the two versions can differ in which objects they
+ * created, so no probe can tell what is already there. `scripts/dev-db-up.sh`
+ * prints the same thing for the local-container path.
+ *
+ * This one is a shared remote, so the reset is somebody's call rather than a
+ * command to run: the peer hosting it may be mid-session on it.
+ */
+function explainMigrationFailure(tag: string): string {
+  return [
+    '',
+    `[dev-db] Could not apply ${tag} to the remote dev database.`,
+    '         If postgres reported "already exists", that database carries this',
+    "         migration's objects without its ledger row — it ran a superseded version",
+    '         on another branch, before the migration was renumbered or collapsed (#3978).',
+    '         Whoever hosts it has to reset it (docker compose down -v && vp run db:up)',
+    '         or repair the ledger by hand; see docs/db-migrations.md.',
+    '',
+  ].join('\n');
+}
+
 async function runPendingMigrations(connectionString: string): Promise<void> {
   const client = postgres(connectionString, {
     max: 1,
@@ -309,6 +333,7 @@ async function runPendingMigrations(connectionString: string): Promise<void> {
         await client.unsafe('COMMIT');
       } catch (migrationError) {
         await client.unsafe('ROLLBACK').catch(() => undefined);
+        console.error(explainMigrationFailure(migration.tag));
         throw migrationError;
       }
     }

--- a/scripts/dev-db-discover.ts
+++ b/scripts/dev-db-discover.ts
@@ -1,10 +1,10 @@
 import { execFileSync } from 'node:child_process';
-import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createConnection } from 'node:net';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import postgres from 'postgres';
+import { readJournalMigrations, selectPendingMigrations } from './lib/dev-db-pending-migrations.js';
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDirectory, '..');
@@ -46,17 +46,8 @@ type TailscaleStatus = {
   Peer?: Record<string, TailscaleNode>;
 };
 
-type MigrationJournalEntry = {
-  tag: string;
-  when: number;
-};
-
-type MigrationJournal = {
-  entries: MigrationJournalEntry[];
-};
-
-type MigrationTrackerRow = {
-  created_at: number | string | null;
+type LedgerHashRow = {
+  hash: string;
 };
 
 type BoardseshShapeRow = {
@@ -277,16 +268,6 @@ async function ensureMigrationTracker(client: postgres.Sql): Promise<void> {
   `;
 }
 
-function loadMigrationJournal(): MigrationJournal {
-  const journalPath = join(drizzleDirectory, 'meta', '_journal.json');
-  const journal = JSON.parse(readFileSync(journalPath, 'utf8')) as MigrationJournal;
-  return {
-    entries: journal.entries.filter(
-      (entry): entry is MigrationJournalEntry => typeof entry.tag === 'string' && typeof entry.when === 'number',
-    ),
-  };
-}
-
 async function runPendingMigrations(connectionString: string): Promise<void> {
   const client = postgres(connectionString, {
     max: 1,
@@ -298,14 +279,15 @@ async function runPendingMigrations(connectionString: string): Promise<void> {
 
   try {
     await ensureMigrationTracker(client);
-    const migrationTrackerRows = await client<MigrationTrackerRow[]>`
-      SELECT COALESCE(
-        (SELECT created_at FROM drizzle."__drizzle_migrations" ORDER BY created_at DESC LIMIT 1),
-        0
-      ) AS created_at
-    `;
-    const lastMigrationCreatedAt = Number(migrationTrackerRows[0]?.created_at ?? 0);
-    const pendingMigrations = loadMigrationJournal().entries.filter((entry) => entry.when > lastMigrationCreatedAt);
+    // Per-entry and hash-keyed, not `when > max(created_at)` (#3979). The old
+    // high-water mark only ever moved up, so a migration landing at or below it
+    // — renumbered by a rebase, collapsed with another branch's, or simply older
+    // than the peer's image build — was skipped here on every run, for good.
+    const ledgerRows = await client<LedgerHashRow[]>`SELECT hash FROM drizzle."__drizzle_migrations"`;
+    const pendingMigrations = selectPendingMigrations(
+      readJournalMigrations(drizzleDirectory),
+      ledgerRows.map((row) => row.hash),
+    );
 
     if (pendingMigrations.length === 0) {
       console.info('  No pending migrations.');
@@ -314,9 +296,7 @@ async function runPendingMigrations(connectionString: string): Promise<void> {
 
     console.info(`  Applying ${pendingMigrations.length} pending migration(s) from ${drizzleDirectory}...`);
     for (const migration of pendingMigrations) {
-      const migrationFile = join(drizzleDirectory, `${migration.tag}.sql`);
-      const migrationSql = readFileSync(migrationFile, 'utf8');
-      const migrationHash = createHash('sha256').update(migrationSql).digest('hex');
+      const migrationSql = readFileSync(join(drizzleDirectory, `${migration.tag}.sql`), 'utf8');
       console.info(`    -> ${migration.tag}`);
 
       await client.unsafe('BEGIN');
@@ -324,7 +304,7 @@ async function runPendingMigrations(connectionString: string): Promise<void> {
         await client.unsafe(migrationSql);
         await client`
           INSERT INTO drizzle."__drizzle_migrations" (hash, created_at)
-          VALUES (${migrationHash}, ${migration.when})
+          VALUES (${migration.hash}, ${migration.when})
         `;
         await client.unsafe('COMMIT');
       } catch (migrationError) {

--- a/scripts/dev-db-pending-migrations.ts
+++ b/scripts/dev-db-pending-migrations.ts
@@ -1,0 +1,47 @@
+/// <reference types="node" />
+
+/**
+ * Prints the journal migrations a dev database still needs, one
+ * `tag|when|hash` line each, in journal order.
+ *
+ * `scripts/dev-db-up.sh` pipes `SELECT hash FROM drizzle."__drizzle_migrations"`
+ * into this on stdin and reads the lines back with `IFS='|' read`. It replaced an
+ * inline `bun --eval` block that selected on `when > max(created_at)` — a single
+ * high-water mark that only ever moves up, so any migration landing at or below
+ * it was skipped on that run and every run after (#3979). The selection is a
+ * per-entry hash diff now; see `scripts/lib/dev-db-pending-migrations.ts` for why
+ * that is the only question worth asking.
+ *
+ * It is a pure read: file reads plus stdin. Nothing here connects to a database,
+ * which is what keeps the shell script the only place that decides *which*
+ * database is being repaired.
+ *
+ * Usage:
+ *   psql -t -A -c 'SELECT hash FROM drizzle."__drizzle_migrations"' |
+ *     DRIZZLE_DIR=packages/db/drizzle bun scripts/dev-db-pending-migrations.ts
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  formatPendingMigrations,
+  parseLedgerHashes,
+  readJournalMigrations,
+  selectPendingMigrations,
+} from './lib/dev-db-pending-migrations.js';
+import { DRIZZLE_DIR } from './lib/drizzle-migrations.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function main(): void {
+  const drizzleDir = process.env.DRIZZLE_DIR ?? path.join(repoRoot, DRIZZLE_DIR);
+  // fd 0 rather than a stream: the caller always pipes, the payload is a few
+  // hundred short lines, and a synchronous read keeps this a single expression
+  // the shell can capture in a `$(...)`.
+  const ledgerHashes = parseLedgerHashes(readFileSync(0, 'utf8'));
+  const pending = selectPendingMigrations(readJournalMigrations(drizzleDir), ledgerHashes);
+  if (pending.length === 0) return;
+  process.stdout.write(`${formatPendingMigrations(pending)}\n`);
+}
+
+main();

--- a/scripts/dev-db-up.sh
+++ b/scripts/dev-db-up.sh
@@ -127,18 +127,33 @@ sync_drizzle_migration_tracker() {
 
 normalize_ledger_timestamps() {
   # Images built before #4211 stamped every ledger row with the image's build
-  # clock instead of the journal entry's `when`. That timestamp is a high-water
-  # mark no later migration can clear, so both drizzle's migrate() and the
-  # pending-migration selection below would skip every migration written after
-  # the image was built — silently, forever. Rewriting created_at to `when`
-  # writes exactly the value drizzle writes, so it is a no-op once the image
-  # (or a `docker compose down -v`) is current.
+  # clock instead of the journal entry's `when`. That timestamp becomes a
+  # high-water mark that only moves up, so both drizzle's migrate() and the
+  # pending-migration selection below skip every journal entry whose `when` is
+  # below it and that the image did not itself apply — silently, and for good.
+  # In practice that is a migration you generated on a branch before pulling a
+  # newer image, which is why a checkout can look migrated and not be.
+  # Rewriting created_at to `when` writes exactly the value drizzle writes, so
+  # it is a no-op once the image (or a `docker compose down -v`) is current.
   #
-  # DATABASE_URL is passed explicitly: .boardsesh/dev-db.env is not written
-  # until write_dev_db_env below, so the dotenv chain in db-connection.ts has
-  # nothing to load yet.
+  # The target is passed explicitly: .boardsesh/dev-db.env is not written until
+  # write_dev_db_env below, so the dotenv chain in db-connection.ts has nothing
+  # to load yet.
+  #
+  # All THREE names are pinned, not just DATABASE_URL. getScriptDatabaseUrl()
+  # reads `DB_URL || DATABASE_URL || POSTGRES_URL`, and its dotenv chain fills
+  # whichever of them this shell leaves unset from .env.local / web/.env.local —
+  # where a DB_URL naming a remote or production database is a normal thing to
+  # have (docs/db-migrations.md's own db:verify-journal example is invoked with
+  # DB_URL). Setting DATABASE_URL alone would lose to such a DB_URL: `vp run
+  # db:up` would then either die on the non-local guard, or — for the tailnet
+  # MagicDNS/CGNAT hosts that guard deliberately accepts — quietly repair the
+  # ledger of a database other than the container this script just started.
   echo "Normalizing migration ledger timestamps..."
-  DATABASE_URL=postgresql://postgres:password@localhost:5432/main \
+  dev_db_ledger_url="postgresql://postgres:password@localhost:5432/main"
+  DB_URL="$dev_db_ledger_url" \
+    DATABASE_URL="$dev_db_ledger_url" \
+    POSTGRES_URL="$dev_db_ledger_url" \
     bun run --filter=@boardsesh/db db:normalize-ledger
 }
 

--- a/scripts/dev-db-up.sh
+++ b/scripts/dev-db-up.sh
@@ -167,25 +167,22 @@ prepare_docker_postgres() {
 }
 
 run_pending_drizzle_sql_migrations() {
-  last_migration_created_at=$(docker exec -u postgres "$PG_CONTAINER" psql -U postgres -d main -t -A -c \
-    "SELECT COALESCE((SELECT created_at FROM drizzle.\"__drizzle_migrations\" ORDER BY created_at DESC LIMIT 1), 0);")
+  # Which migrations are pending is a per-entry, hash-keyed question — never
+  # "is this entry's `when` above the ledger's newest created_at" (#3979). That
+  # mark only ever moves up, so a migration landing at or below it was skipped
+  # on that run and on every run after it: silently, permanently, and for the
+  # entirely ordinary reasons a dev database hits (a rebase renumbered the
+  # migration, two branches collapsed theirs into one, or the pre-built image
+  # was built after the branch's `when` was minted). Same defect #2933 found in
+  # drizzle's own applier; scripts/lib/dev-db-pending-migrations.ts reuses the
+  # reconciliation #3977 put in front of the production path.
+  ledger_hashes=$(docker exec -u postgres "$PG_CONTAINER" psql -U postgres -d main -t -A -c \
+    "SELECT hash FROM drizzle.\"__drizzle_migrations\";")
 
-  pending_migrations=$(DRIZZLE_DIR="$DRIZZLE_DIR" LAST_MIGRATION_CREATED_AT="$last_migration_created_at" bun --eval '
-    const fs = require("node:fs");
-    const path = require("node:path");
-    const crypto = require("node:crypto");
-
-    const drizzleDir = process.env.DRIZZLE_DIR;
-    const lastAppliedAt = Number(process.env.LAST_MIGRATION_CREATED_AT ?? 0);
-    const journal = JSON.parse(fs.readFileSync(path.join(drizzleDir, "meta", "_journal.json"), "utf8"));
-
-    for (const entry of journal.entries) {
-      if (entry.when <= lastAppliedAt) continue;
-      const sql = fs.readFileSync(path.join(drizzleDir, `${entry.tag}.sql`), "utf8");
-      const hash = crypto.createHash("sha256").update(sql).digest("hex");
-      process.stdout.write(`${entry.tag}|${entry.when}|${hash}\n`);
-    }
-  ')
+  # An empty ledger prints one blank line here, which the reader drops — so a
+  # fresh tracker selects the whole journal rather than nothing.
+  pending_migrations=$(printf '%s\n' "$ledger_hashes" \
+    | DRIZZLE_DIR="$DRIZZLE_DIR" bun "$REPO_ROOT/scripts/dev-db-pending-migrations.ts")
 
   if [ -z "$pending_migrations" ]; then
     echo "  No pending migrations."
@@ -200,12 +197,30 @@ run_pending_drizzle_sql_migrations() {
     migration_file="$DRIZZLE_DIR/$tag.sql"
     echo "    → $tag"
 
-    {
+    # created_at is the journal's own `when` — the value drizzle writes itself,
+    # so the row is indistinguishable from one drizzle wrote and the ledger
+    # normaliser above has nothing to repair on the next run.
+    if ! {
       printf 'BEGIN;\n'
       cat "$migration_file"
       printf '\nINSERT INTO drizzle."__drizzle_migrations" (hash, created_at) VALUES (%s, %s);\n' "'$hash'" "$created_at"
       printf 'COMMIT;\n'
-    } | docker exec -i -u postgres "$PG_CONTAINER" psql -v ON_ERROR_STOP=1 -U postgres -d main > /dev/null
+    } | docker exec -i -u postgres "$PG_CONTAINER" psql -v ON_ERROR_STOP=1 -U postgres -d main > /dev/null; then
+      echo "" >&2
+      echo "ERROR: could not apply $tag to the dev database." >&2
+      echo "       If psql reported \"already exists\", this database carries that migration's" >&2
+      echo "       objects without its ledger row — a volume that ran a superseded version of" >&2
+      echo "       the migration on another branch, before it was renumbered or collapsed" >&2
+      echo "       (#3978). Nothing repairs that in place: the two versions can differ in" >&2
+      echo "       which objects they created, so no probe can tell what is already there." >&2
+      echo "" >&2
+      echo "       Reset the volume and pull a current image:" >&2
+      echo "         docker compose down -v && vp run db:up" >&2
+      echo "" >&2
+      echo "       The pre-built image ships the board data, the test user, and the seed" >&2
+      echo "       data, so a reset costs a pull rather than a re-import." >&2
+      exit 1
+    fi
   done
 }
 

--- a/scripts/dev-db-up.sh
+++ b/scripts/dev-db-up.sh
@@ -125,10 +125,28 @@ sync_drizzle_migration_tracker() {
   echo "  drizzle.__drizzle_migrations has $DRIZZLE_COUNT records."
 }
 
+normalize_ledger_timestamps() {
+  # Images built before #4211 stamped every ledger row with the image's build
+  # clock instead of the journal entry's `when`. That timestamp is a high-water
+  # mark no later migration can clear, so both drizzle's migrate() and the
+  # pending-migration selection below would skip every migration written after
+  # the image was built — silently, forever. Rewriting created_at to `when`
+  # writes exactly the value drizzle writes, so it is a no-op once the image
+  # (or a `docker compose down -v`) is current.
+  #
+  # DATABASE_URL is passed explicitly: .boardsesh/dev-db.env is not written
+  # until write_dev_db_env below, so the dotenv chain in db-connection.ts has
+  # nothing to load yet.
+  echo "Normalizing migration ledger timestamps..."
+  DATABASE_URL=postgresql://postgres:password@localhost:5432/main \
+    bun run --filter=@boardsesh/db db:normalize-ledger
+}
+
 prepare_docker_postgres() {
   ensure_postgres_network_access
   ensure_postgres_password
   sync_drizzle_migration_tracker
+  normalize_ledger_timestamps
   run_pending_drizzle_sql_migrations
   write_dev_db_env "localhost" "$1" "$(detect_local_redis_url)"
 }

--- a/scripts/lib/dev-db-pending-migrations.test.ts
+++ b/scripts/lib/dev-db-pending-migrations.test.ts
@@ -1,0 +1,150 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatPendingMigrations,
+  hashMigrationFile,
+  parseLedgerHashes,
+  readJournalMigrations,
+  selectPendingMigrations,
+} from './dev-db-pending-migrations';
+import type { ExpectedMigrationWithWhen } from './migration-ledger';
+
+function entry(tag: string, when: number, hash = `hash-of-${tag}`): ExpectedMigrationWithWhen {
+  return { tag, when, hash };
+}
+
+/** A throwaway `packages/db/drizzle`-shaped folder: `meta/_journal.json` plus the `.sql` files. */
+function writeMigrationsFolder(entries: readonly { tag: string; when: number; body: string }[]): string {
+  const folder = mkdtempSync(join(tmpdir(), 'dev-db-pending-'));
+  mkdirSync(join(folder, 'meta'), { recursive: true });
+  writeFileSync(
+    join(folder, 'meta', '_journal.json'),
+    JSON.stringify({
+      version: '7',
+      dialect: 'postgresql',
+      entries: entries.map((item, index) => ({
+        idx: index,
+        version: '7',
+        when: item.when,
+        tag: item.tag,
+        breakpoints: true,
+      })),
+    }),
+  );
+  for (const item of entries) {
+    writeFileSync(join(folder, `${item.tag}.sql`), item.body);
+  }
+  return folder;
+}
+
+describe('selectPendingMigrations', () => {
+  it('selects a migration whose when is below the newest applied entry (#3979)', () => {
+    // The whole bug. `0002_stale_when` was renumbered onto a `when` older than
+    // the already-applied `0001_b`, so the old `when > max(created_at)` filter
+    // skipped it on that run — and, because the mark only moves up, on every run
+    // after it. Its hash is absent, so the hash-keyed question gets it right.
+    const journal = [entry('0000_a', 1000), entry('0001_b', 3000), entry('0002_stale_when', 2000)];
+    const pending = selectPendingMigrations(journal, ['hash-of-0000_a', 'hash-of-0001_b']);
+    expect(pending.map((migration) => migration.tag)).toEqual(['0002_stale_when']);
+  });
+
+  it('selects nothing when every journal hash has a ledger row', () => {
+    const journal = [entry('0000_a', 1000), entry('0001_b', 3000)];
+    expect(selectPendingMigrations(journal, ['hash-of-0001_b', 'hash-of-0000_a'])).toEqual([]);
+  });
+
+  it('selects the whole journal against an empty ledger', () => {
+    // A fresh tracker — the shell script creates the table before this runs, so
+    // "no rows" is a normal state and must not read as "nothing to do".
+    const journal = [entry('0000_a', 1000), entry('0001_b', 3000)];
+    expect(selectPendingMigrations(journal, []).map((migration) => migration.tag)).toEqual(['0000_a', '0001_b']);
+  });
+
+  it('needs one ledger row per byte-identical .sql, not one per hash', () => {
+    // Duplicate-content migrations have shipped here before (0177_illegal_omega_red).
+    // A Set-based diff would call the second one applied and skip it forever.
+    const shared = 'sha-of-identical-bodies';
+    const journal = [entry('0000_a', 1000, shared), entry('0001_b', 2000, shared)];
+    expect(selectPendingMigrations(journal, [shared]).map((migration) => migration.tag)).toEqual(['0001_b']);
+    expect(selectPendingMigrations(journal, [shared, shared])).toEqual([]);
+  });
+
+  it('ignores ledger hashes that belong to no journal entry', () => {
+    // Renumber residue. The shared dev database carries three such rows; failing
+    // or re-applying on them would break `vp run db:up` for a non-problem.
+    const journal = [entry('0000_a', 1000), entry('0001_b', 2000)];
+    const ledger = ['hash-of-0000_a', 'hash-of-a-renumbered-away-migration', 'hash-of-0001_b'];
+    expect(selectPendingMigrations(journal, ledger)).toEqual([]);
+  });
+
+  it('returns pending entries in journal order, carrying when and hash', () => {
+    const journal = [entry('0000_a', 1000), entry('0001_b', 3000), entry('0002_c', 2000)];
+    expect(selectPendingMigrations(journal, ['hash-of-0001_b'])).toEqual([
+      entry('0000_a', 1000),
+      entry('0002_c', 2000),
+    ]);
+  });
+});
+
+describe('parseLedgerHashes', () => {
+  it('reads the one-hash-per-line output psql -t -A writes', () => {
+    expect(parseLedgerHashes('aaa\nbbb\nccc\n')).toEqual(['aaa', 'bbb', 'ccc']);
+  });
+
+  it('reads an empty ledger as no hashes rather than one blank hash', () => {
+    // `printf '%s\n' "$ledger_hashes"` emits a single blank line for an empty
+    // ledger. Keeping it would leave one journal entry paired with '' and skipped.
+    expect(parseLedgerHashes('')).toEqual([]);
+    expect(parseLedgerHashes('\n')).toEqual([]);
+    expect(parseLedgerHashes('  \n')).toEqual([]);
+  });
+});
+
+describe('readJournalMigrations', () => {
+  it('hashes each .sql exactly as drizzle and the image build do', () => {
+    const folder = writeMigrationsFolder([
+      { tag: '0000_a', when: 1000, body: 'CREATE TABLE a (id int);\n' },
+      { tag: '0001_b', when: 2000, body: 'CREATE TABLE b (id int);\n' },
+    ]);
+    const journal = readJournalMigrations(folder);
+    expect(journal.map((migration) => migration.tag)).toEqual(['0000_a', '0001_b']);
+    expect(journal.map((migration) => migration.when)).toEqual([1000, 2000]);
+    // sha256 over the raw file bytes — what drizzle 0.45's readMigrationFiles
+    // computes, and what Dockerfile.dev-db writes with sha256sum. A row this
+    // applier inserts must be indistinguishable from one drizzle inserted.
+    expect(journal[0].hash).toBe(hashMigrationFile(join(folder, '0000_a.sql')));
+    expect(journal[0].hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(journal[0].hash).not.toBe(journal[1].hash);
+  });
+
+  it('gives byte-identical migrations the same hash', () => {
+    const folder = writeMigrationsFolder([
+      { tag: '0000_a', when: 1000, body: 'SELECT 1;\n' },
+      { tag: '0001_b', when: 2000, body: 'SELECT 1;\n' },
+    ]);
+    const journal = readJournalMigrations(folder);
+    expect(journal[0].hash).toBe(journal[1].hash);
+  });
+
+  it('refuses a malformed journal rather than selecting a truncated set', () => {
+    const folder = mkdtempSync(join(tmpdir(), 'dev-db-pending-bad-'));
+    mkdirSync(join(folder, 'meta'), { recursive: true });
+    writeFileSync(join(folder, 'meta', '_journal.json'), JSON.stringify({ entries: [{ idx: 0, tag: '0000_a' }] }));
+    expect(() => readJournalMigrations(folder)).toThrow(/malformed/);
+  });
+});
+
+describe('formatPendingMigrations', () => {
+  it('writes the tag|when|hash lines dev-db-up.sh reads back with IFS', () => {
+    expect(formatPendingMigrations([entry('0000_a', 1000), entry('0001_b', 2000)])).toBe(
+      '0000_a|1000|hash-of-0000_a\n0001_b|2000|hash-of-0001_b',
+    );
+  });
+
+  it('writes nothing for an empty selection', () => {
+    expect(formatPendingMigrations([])).toBe('');
+  });
+});

--- a/scripts/lib/dev-db-pending-migrations.ts
+++ b/scripts/lib/dev-db-pending-migrations.ts
@@ -27,13 +27,16 @@
  * `packages/db` reads its hashes from drizzle's own `readMigrationFiles`, which
  * is the only way to be certain they match. Root `scripts/` cannot: `drizzle-orm`
  * is a `packages/db` dependency and Bun's isolated linker gives the repo root no
- * hoisted copy. So the sha256 is derived here from the raw `.sql` bytes — which
- * is exactly what drizzle 0.45's `readMigrationFiles` does, what
- * `packages/db/docker/Dockerfile.dev-db` writes with `sha256sum`, and what the
- * `bun --eval` block this replaces already computed. A drizzle bump that changed
- * the derivation would break the parity; `packages/db`'s journal-verification
- * integration test runs against drizzle's real hashes and is where that would
- * surface.
+ * hoisted copy. So the sha256 is re-derived here — the same derivation drizzle
+ * 0.45 uses and the same one the `bun --eval` block this replaces already
+ * computed: `readFileSync(file, 'utf8')`, then `sha256` of that string. Note that
+ * this is the file decoded as UTF-8 and re-encoded, not the bytes on disk;
+ * `Dockerfile.dev-db` writes `sha256sum` of the raw bytes and agrees with it only
+ * because every migration is UTF-8 with no BOM (`check:db-migrations` reads the
+ * folder the same way, and a BOM would break drizzle's own hash first). A drizzle
+ * bump that changed the derivation would break the parity; `packages/db`'s
+ * journal-verification integration test runs against drizzle's real hashes and is
+ * where that would surface.
  */
 import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
@@ -80,7 +83,7 @@ export function readJournalMigrations(drizzleDir: string): ExpectedMigrationWith
   }));
 }
 
-/** sha256 over the raw file bytes — see the hash-parity note in the module header. */
+/** sha256 of the file read as UTF-8 — see the hash-parity note in the module header. */
 export function hashMigrationFile(migrationFilePath: string): string {
   return createHash('sha256').update(readFileSync(migrationFilePath, 'utf8')).digest('hex');
 }

--- a/scripts/lib/dev-db-pending-migrations.ts
+++ b/scripts/lib/dev-db-pending-migrations.ts
@@ -1,0 +1,106 @@
+/// <reference types="node" />
+
+/**
+ * Which journal migrations a *dev* database still needs — keyed on the ledger
+ * hash, never on a `created_at` high-water mark.
+ *
+ * Why this exists (#3979): `scripts/dev-db-up.sh` and `scripts/dev-db-discover.ts`
+ * each reimplemented drizzle's applier, and each reimplemented its bug. Both read
+ * `max(created_at)` from `drizzle."__drizzle_migrations"` once, before the loop,
+ * and applied only journal entries whose `when` was strictly greater. A migration
+ * whose `when` lands at or below that mark is skipped on that run and on every
+ * run after it, because the mark only ever moves up — the same defect #2933
+ * reported in `packages/db/scripts/migrate.ts` and #3977 fixed there.
+ *
+ * On a dev database the mark sits below a branch's migration for entirely
+ * ordinary reasons: a rebase renumbered it, two branches collapsed their
+ * migrations into one, or the pre-built image was built after the branch's `when`
+ * was minted. The result is a checkout that reports "No pending migrations." and
+ * a schema that is missing the table the branch just added.
+ *
+ * The selection here asks the per-entry question instead, through the same
+ * `findUnappliedMigrations()` the production gate uses, so the two paths cannot
+ * drift into disagreeing about what "applied" means.
+ *
+ * ## Hash parity with drizzle
+ *
+ * `packages/db` reads its hashes from drizzle's own `readMigrationFiles`, which
+ * is the only way to be certain they match. Root `scripts/` cannot: `drizzle-orm`
+ * is a `packages/db` dependency and Bun's isolated linker gives the repo root no
+ * hoisted copy. So the sha256 is derived here from the raw `.sql` bytes — which
+ * is exactly what drizzle 0.45's `readMigrationFiles` does, what
+ * `packages/db/docker/Dockerfile.dev-db` writes with `sha256sum`, and what the
+ * `bun --eval` block this replaces already computed. A drizzle bump that changed
+ * the derivation would break the parity; `packages/db`'s journal-verification
+ * integration test runs against drizzle's real hashes and is where that would
+ * surface.
+ */
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parseJournal } from './drizzle-migrations.js';
+import { findUnappliedMigrations, type ExpectedMigrationWithWhen } from './migration-ledger.js';
+
+/**
+ * The separator between the three fields of one output line. `dev-db-up.sh`
+ * reads them back with `IFS='|' read -r tag when hash`, and none of the three
+ * can contain a pipe: tags match `NNNN_suffix`, `when` is digits, the hash is
+ * hex.
+ */
+export const PENDING_MIGRATION_SEPARATOR = '|';
+
+/**
+ * Journal entries with no matching ledger row, in journal order.
+ *
+ * Delegates the comparison to `findUnappliedMigrations` rather than repeating
+ * its multiset walk: byte-identical `.sql` files share a hash, and two such
+ * entries need two ledger rows rather than one. Re-selecting by tag afterwards
+ * is exact because journal tags are unique — `scripts/check-db-migrations.ts`
+ * fails a PR that introduces a duplicate.
+ */
+export function selectPendingMigrations(
+  expected: readonly ExpectedMigrationWithWhen[],
+  ledgerHashes: readonly string[],
+): ExpectedMigrationWithWhen[] {
+  const pendingTags = new Set(findUnappliedMigrations(expected, ledgerHashes));
+  return expected.filter((migration) => pendingTags.has(migration.tag));
+}
+
+/**
+ * Every journal entry paired with its `.sql`'s sha256 and the journal's own
+ * `when` — the value drizzle stamps into `created_at`, so a row this applier
+ * writes is indistinguishable from one drizzle wrote.
+ */
+export function readJournalMigrations(drizzleDir: string): ExpectedMigrationWithWhen[] {
+  const journal = parseJournal(readFileSync(join(drizzleDir, 'meta', '_journal.json'), 'utf8'));
+  return journal.entries.map((entry) => ({
+    tag: entry.tag,
+    when: entry.when,
+    hash: hashMigrationFile(join(drizzleDir, `${entry.tag}.sql`)),
+  }));
+}
+
+/** sha256 over the raw file bytes — see the hash-parity note in the module header. */
+export function hashMigrationFile(migrationFilePath: string): string {
+  return createHash('sha256').update(readFileSync(migrationFilePath, 'utf8')).digest('hex');
+}
+
+/**
+ * Ledger hashes as `psql -t -A` prints them: one per line, with a trailing
+ * newline and — for an empty ledger — a single blank line. Blank lines are
+ * dropped rather than treated as a hash, which is what makes "fresh tracker,
+ * nothing applied" select the whole journal instead of nothing.
+ */
+export function parseLedgerHashes(psqlOutput: string): string[] {
+  return psqlOutput
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/** One `tag|when|hash` line per pending migration, in journal order. */
+export function formatPendingMigrations(pending: readonly ExpectedMigrationWithWhen[]): string {
+  return pending
+    .map((migration) => [migration.tag, migration.when, migration.hash].join(PENDING_MIGRATION_SEPARATOR))
+    .join('\n');
+}

--- a/scripts/lib/migration-ledger.test.ts
+++ b/scripts/lib/migration-ledger.test.ts
@@ -5,8 +5,10 @@ import {
   formatBaselinedGapWarning,
   formatEditedBaselineNote,
   formatMigrationGapError,
+  isMigrationJournalGateArmed,
   partitionMissingMigrations,
   planLedgerTimestampRepairs,
+  VERIFY_MIGRATION_JOURNAL_ENV,
   type ExpectedMigration,
   type ExpectedMigrationWithWhen,
   type LedgerTimestampRow,
@@ -262,5 +264,28 @@ describe('formatMigrationGapError', () => {
   it('reads correctly for a single missing migration', () => {
     const message = formatMigrationGapError(['0129_numerous_star_brand'], 131, 130);
     expect(message).toContain('1 of 131 journal migration has no row');
+  });
+});
+
+describe('isMigrationJournalGateArmed', () => {
+  it('runs the check when nothing is set (#3978)', () => {
+    // The flip. Opt-in left the check off on the one machine where a gap is
+    // created — the branch author's — and the dev-db image that forced the
+    // opt-in now carries every journal entry's ledger row.
+    expect(isMigrationJournalGateArmed({})).toBe(true);
+  });
+
+  it('keeps running for the literal 1 the workflows already pass', () => {
+    // ci.yml, production-deploy.yml and db-migration-renumber.yml all set '1'.
+    // Those must stay armed without an edit, or the flip silently disarms the
+    // production deploy gate.
+    expect(isMigrationJournalGateArmed({ [VERIFY_MIGRATION_JOURNAL_ENV]: '1' })).toBe(true);
+  });
+
+  it('only stands down for the exact escape hatch', () => {
+    expect(isMigrationJournalGateArmed({ [VERIFY_MIGRATION_JOURNAL_ENV]: '0' })).toBe(false);
+    for (const value of ['', 'false', 'no', 'off', '00', ' 0']) {
+      expect(isMigrationJournalGateArmed({ [VERIFY_MIGRATION_JOURNAL_ENV]: value })).toBe(true);
+    }
   });
 });

--- a/scripts/lib/migration-ledger.test.ts
+++ b/scripts/lib/migration-ledger.test.ts
@@ -6,7 +6,10 @@ import {
   formatEditedBaselineNote,
   formatMigrationGapError,
   partitionMissingMigrations,
+  planLedgerTimestampRepairs,
   type ExpectedMigration,
+  type ExpectedMigrationWithWhen,
+  type LedgerTimestampRow,
 } from './migration-ledger';
 
 function expectedFrom(...tags: string[]): ExpectedMigration[] {
@@ -65,6 +68,85 @@ describe('findUnappliedMigrations', () => {
 
   it('returns nothing for an empty journal', () => {
     expect(findUnappliedMigrations([], hashesFor('0000_a'))).toEqual([]);
+  });
+});
+
+describe('planLedgerTimestampRepairs', () => {
+  // The dev-db image's shape: every row stamped with one build-time value,
+  // ~13 orders of magnitude of wall clock above every journal `when`.
+  const BUILD_CLOCK = 1_800_000_000_000;
+
+  function journal(...entries: [tag: string, when: number][]): ExpectedMigrationWithWhen[] {
+    return entries.map(([tag, when]) => ({ tag, hash: `hash-of-${tag}`, when }));
+  }
+
+  function ledgerRows(...rows: [tag: string, createdAt: number][]): LedgerTimestampRow[] {
+    return rows.map(([tag, createdAt], index) => ({ id: index + 1, hash: `hash-of-${tag}`, createdAt }));
+  }
+
+  it('plans nothing when every row already carries its journal `when`', () => {
+    // The no-op case is the important one: this runs on every `vp run db:up`
+    // and on a drizzle-managed database there is nothing to write.
+    const expected = journal(['0000_a', 1000], ['0001_b', 2000]);
+    expect(planLedgerTimestampRepairs(expected, ledgerRows(['0000_a', 1000], ['0001_b', 2000]))).toEqual([]);
+  });
+
+  it('rewrites a uniformly build-stamped ledger to the journal when of each entry', () => {
+    const expected = journal(['0000_a', 1000], ['0001_b', 2000], ['0002_c', 3000]);
+    const rows = ledgerRows(['0000_a', BUILD_CLOCK], ['0001_b', BUILD_CLOCK], ['0002_c', BUILD_CLOCK]);
+    expect(planLedgerTimestampRepairs(expected, rows)).toEqual([
+      { id: 1, tag: '0000_a', from: BUILD_CLOCK, to: 1000 },
+      { id: 2, tag: '0001_b', from: BUILD_CLOCK, to: 2000 },
+      { id: 3, tag: '0002_c', from: BUILD_CLOCK, to: 3000 },
+    ]);
+  });
+
+  it('gives byte-identical migrations distinct `when`s, in id order', () => {
+    // A Map<hash, when> would stamp both rows with the first entry's `when`,
+    // leaving the second migration's row wrong and the high-water mark short.
+    const duplicateHash = 'identical-sql-body';
+    const expected: ExpectedMigrationWithWhen[] = [
+      { tag: '0000_original', hash: duplicateHash, when: 1000 },
+      { tag: '0001_copy', hash: duplicateHash, when: 2000 },
+    ];
+    const rows: LedgerTimestampRow[] = [
+      { id: 7, hash: duplicateHash, createdAt: BUILD_CLOCK },
+      { id: 3, hash: duplicateHash, createdAt: BUILD_CLOCK },
+    ];
+    // Sorted by id, so the row inserted first (id 3) pairs with the first entry.
+    expect(planLedgerTimestampRepairs(expected, rows)).toEqual([
+      { id: 3, tag: '0000_original', from: BUILD_CLOCK, to: 1000 },
+      { id: 7, tag: '0001_copy', from: BUILD_CLOCK, to: 2000 },
+    ]);
+  });
+
+  it('leaves a ledger row whose hash is in no journal entry alone', () => {
+    // Renumber residue. Inventing a timestamp for it would be a guess.
+    const expected = journal(['0000_a', 1000]);
+    const rows: LedgerTimestampRow[] = [
+      { id: 1, hash: 'hash-of-0000_a', createdAt: BUILD_CLOCK },
+      { id: 2, hash: 'hash-of-a-renumbered-away-migration', createdAt: BUILD_CLOCK },
+    ];
+    expect(planLedgerTimestampRepairs(expected, rows)).toEqual([{ id: 1, tag: '0000_a', from: BUILD_CLOCK, to: 1000 }]);
+  });
+
+  it('repairs only the rows a short ledger actually has', () => {
+    // The normal state right after a new migration lands: the image predates it,
+    // so it has no row yet — and must not gain a bogus one from this repair.
+    const expected = journal(['0000_a', 1000], ['0001_b', 2000], ['0002_new', 3000]);
+    const rows = ledgerRows(['0000_a', BUILD_CLOCK], ['0001_b', BUILD_CLOCK]);
+    expect(planLedgerTimestampRepairs(expected, rows).map((repair) => repair.tag)).toEqual(['0000_a', '0001_b']);
+  });
+
+  it('repairs a duplicate-hash row only as far as the journal has entries for it', () => {
+    // Three rows, two entries: the third is residue of a copy that was removed.
+    const duplicateHash = 'identical-sql-body';
+    const expected: ExpectedMigrationWithWhen[] = [
+      { tag: '0000_original', hash: duplicateHash, when: 1000 },
+      { tag: '0001_copy', hash: duplicateHash, when: 2000 },
+    ];
+    const rows: LedgerTimestampRow[] = [1, 2, 3].map((id) => ({ id, hash: duplicateHash, createdAt: BUILD_CLOCK }));
+    expect(planLedgerTimestampRepairs(expected, rows).map((repair) => repair.id)).toEqual([1, 2]);
   });
 });
 

--- a/scripts/lib/migration-ledger.ts
+++ b/scripts/lib/migration-ledger.ts
@@ -41,6 +41,86 @@ export interface ExpectedMigration {
 }
 
 /**
+ * The same entry with the journal's own `when` attached — the value drizzle
+ * writes into `created_at` when it applies a migration itself
+ * (`PgDialect.migrate()` inserts `migration.folderMillis`, which
+ * `readMigrationFiles` copies straight from `journalEntry.when`).
+ *
+ * Only the timestamp planner below needs it; everything else keys on `hash`.
+ */
+export interface ExpectedMigrationWithWhen extends ExpectedMigration {
+  when: number;
+}
+
+/** One row of `drizzle."__drizzle_migrations"`, as the normaliser reads it. */
+export interface LedgerTimestampRow {
+  id: number;
+  hash: string;
+  createdAt: number;
+}
+
+/** A single `UPDATE … SET created_at = to WHERE id = id`, with the tag for the log line. */
+export interface LedgerTimestampRepair {
+  id: number;
+  tag: string;
+  from: number;
+  to: number;
+}
+
+/**
+ * Ledger rows whose `created_at` is not the journal `when` drizzle would have
+ * written, paired with the value they should carry.
+ *
+ * Why any row is ever wrong: the `boardsesh-dev-db` image applies the journal in
+ * a psql loop and stamps each ledger row with the image's *build* wall clock
+ * instead of the entry's `when`. That makes the ledger's high-water mark a build
+ * timestamp — far above every journal `when` — so drizzle's applier skips any
+ * migration added afterwards, forever, and `VERIFY_MIGRATION_JOURNAL=1` reports
+ * it as a genuine gap. Rewriting `created_at` to `when` writes exactly the value
+ * drizzle itself writes, so this is a no-op on any drizzle-managed database and a
+ * repair only where something else did the stamping.
+ *
+ * Pairing is positional within a hash, not a `Map<hash, when>` lookup:
+ * byte-identical `.sql` files share a hash (see the `0177_illegal_omega_red`
+ * note in `scripts/lib/drizzle-migrations.ts`), and a map would stamp both ledger
+ * rows with the first entry's `when`. The k-th ledger row bearing hash H (in `id`
+ * order — the order they were inserted) pairs with the k-th journal entry bearing
+ * hash H.
+ *
+ * Ledger rows whose hash matches no journal entry are left alone, the same rule
+ * `findUnappliedMigrations` applies in the other direction: those are renumber
+ * residue, and inventing a timestamp for them would be a guess.
+ */
+export function planLedgerTimestampRepairs(
+  expected: readonly ExpectedMigrationWithWhen[],
+  ledgerRows: readonly LedgerTimestampRow[],
+): LedgerTimestampRepair[] {
+  const entriesByHash = new Map<string, ExpectedMigrationWithWhen[]>();
+  for (const migration of expected) {
+    const entries = entriesByHash.get(migration.hash);
+    if (entries) {
+      entries.push(migration);
+    } else {
+      entriesByHash.set(migration.hash, [migration]);
+    }
+  }
+
+  const nextIndexByHash = new Map<string, number>();
+  const repairs: LedgerTimestampRepair[] = [];
+  for (const row of [...ledgerRows].sort((left, right) => left.id - right.id)) {
+    const entries = entriesByHash.get(row.hash);
+    if (!entries) continue;
+    const nextIndex = nextIndexByHash.get(row.hash) ?? 0;
+    const entry = entries[nextIndex];
+    if (!entry) continue;
+    nextIndexByHash.set(row.hash, nextIndex + 1);
+    if (row.createdAt === entry.when) continue;
+    repairs.push({ id: row.id, tag: entry.tag, from: row.createdAt, to: entry.when });
+  }
+  return repairs;
+}
+
+/**
  * Journal-order list of tags that have no matching row in the ledger.
  *
  * Multiset-aware on purpose: two byte-identical `.sql` files share a hash, and

--- a/scripts/lib/migration-ledger.ts
+++ b/scripts/lib/migration-ledger.ts
@@ -34,6 +34,40 @@
  * drift from what the migrator actually inserts.
  */
 
+/** Env var that controls the journal-vs-ledger check in `packages/db/scripts/migrate.ts`. */
+export const VERIFY_MIGRATION_JOURNAL_ENV = 'VERIFY_MIGRATION_JOURNAL';
+
+/** The one value that turns the check off. Anything else — including unset — leaves it on. */
+export const VERIFY_MIGRATION_JOURNAL_OFF = '0';
+
+/**
+ * Whether `migrate.ts` runs the per-entry check. On by default since #3978.
+ *
+ * It shipped opt-in (`=1`) for one reason: the `boardsesh-dev-db` image was
+ * missing `0187_sad_freak`'s ledger row, so a default-on check would have
+ * reddened every developer's `vp run db:migrate` for a defect in the image
+ * rather than in their branch. The image carries the row now (190 of 190 journal
+ * entries recorded on `:latest`), the image build asserts the ledger's
+ * high-water mark equals the journal's newest `when` on every publish (#4211),
+ * and `vp run db:up` now fills any remaining gap hash-by-hash before
+ * `db:migrate` ever runs (#3979) — so the condition that justified the opt-in is
+ * gone. Leaving it opt-in means the check is off in exactly the place a gap is
+ * created: a developer's machine, on the branch that creates it.
+ *
+ * `0` remains an escape hatch for the one shape this cannot help — a database
+ * with a gap nobody can repair right now, where the operator needs `db:migrate`
+ * to run anyway. The three workflows that already pass the literal `1`
+ * (`ci.yml`, `production-deploy.yml`, `db-migration-renumber.yml`) keep working
+ * unchanged.
+ *
+ * Lives here, in a dependency-free module, so the decision has unit coverage in
+ * the `scripts` Vitest project — `packages/db` runs on `tsx --test` and is not
+ * part of the CI test graph.
+ */
+export function isMigrationJournalGateArmed(env: Record<string, string | undefined>): boolean {
+  return env[VERIFY_MIGRATION_JOURNAL_ENV] !== VERIFY_MIGRATION_JOURNAL_OFF;
+}
+
 /** One journal entry paired with the hash drizzle would record for its `.sql`. */
 export interface ExpectedMigration {
   tag: string;

--- a/scripts/lib/migration-ledger.ts
+++ b/scripts/lib/migration-ledger.ts
@@ -74,9 +74,10 @@ export interface LedgerTimestampRepair {
  * Why any row is ever wrong: the `boardsesh-dev-db` image applies the journal in
  * a psql loop and stamps each ledger row with the image's *build* wall clock
  * instead of the entry's `when`. That makes the ledger's high-water mark a build
- * timestamp — far above every journal `when` — so drizzle's applier skips any
- * migration added afterwards, forever, and `VERIFY_MIGRATION_JOURNAL=1` reports
- * it as a genuine gap. Rewriting `created_at` to `when` writes exactly the value
+ * timestamp, so drizzle's applier skips every journal entry whose `when` predates
+ * the image build and which the image did not itself apply — a branch's migration
+ * generated before that build — permanently, and `VERIFY_MIGRATION_JOURNAL=1`
+ * reports it as a genuine gap. Rewriting `created_at` to `when` writes the value
  * drizzle itself writes, so this is a no-op on any drizzle-managed database and a
  * repair only where something else did the stamping.
  *

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -171,6 +171,15 @@ export default defineConfig({
         command: 'bun run --filter=@boardsesh/db db:verify-journal',
         cache: false,
       },
+      // Rewrites created_at in drizzle's ledger to each entry's journal `when`
+      // (#4211), repairing a database whose ledger was stamped with the dev-db
+      // image's build clock instead — that timestamp is a high-water mark no
+      // later migration can clear, so drizzle silently skips them forever. No
+      // db:up dependency: db:up itself runs this, and a dependency would cycle.
+      'db:normalize-ledger': {
+        command: 'bun run --filter=@boardsesh/db db:normalize-ledger',
+        cache: false,
+      },
       'db:studio': {
         command: 'bun run --filter=@boardsesh/db db:studio',
         dependsOn: ['db:up'],


### PR DESCRIPTION
## Summary

This PR fixes a migration-tracking bug in the dev-db scripts where both `dev-db-up.sh` and `dev-db-discover.ts` decided which migrations to apply using a single "last applied" timestamp snapshot, so a migration landing below that watermark (from a rebase renumbering it, branches collapsing theirs into one, or a pre-built image being older than the branch) got silently skipped forever. It replaces that logic with the same hash-keyed `findUnappliedMigrations()` selector the production migration gate already uses, so the dev and deploy paths can no longer disagree about what counts as applied. It also flips the journal-vs-ledger verification check from opt-in (`VERIFY_MIGRATION_JOURNAL=1`) to on by default, since the dev-db image now records every migration reliably, closing the gap where the check was off exactly where the drift gets introduced. One case is deliberately left unfixed: a database that ran a superseded branch version of a collapsed migration's DDL without its ledger row still needs a manual volume reset — it now fails loudly with a named migration and a fix, instead of silently succeeding.

---

Closes #3979
Refs #3978

> **Stacked on #4274** (`fix/4211-dev-db-ledger-timestamps`), which this extends rather than duplicates — the ledger normaliser it added runs immediately before the selection rewritten here. Base is that branch, so the diff stays at 12 files; **retarget to `main` once #4274 merges.**

## The bug (#3979)

`scripts/dev-db-up.sh` and `scripts/dev-db-discover.ts` each reimplemented drizzle's applier, and each reimplemented its bug:

```sh
last_migration_created_at=$(psql -c "SELECT ... ORDER BY created_at DESC LIMIT 1")
# then, in the bun --eval:
if (entry.when <= lastAppliedAt) continue;
```

One `max(created_at)` snapshot, taken before the loop, then `when > mark`. The mark only ever moves up, so a migration landing at or below it is skipped on that run **and on every run after it**. Same defect #2933 found in `packages/db/scripts/migrate.ts` and #3977 fixed there; the dev scripts were deliberately left out of that scope.

A dev database lands below the mark for entirely ordinary reasons: a rebase renumbered the migration, two branches collapsed theirs into one, or the pre-built image was built after the branch's `when` was minted. The symptom is a checkout that prints `No pending migrations.` and a schema missing the table the branch just added.

## The fix

Both appliers now ask the per-entry, hash-keyed question through the same `findUnappliedMigrations()` the production gate uses, so the dev and deploy paths cannot drift into disagreeing about what "applied" means.

- `scripts/lib/dev-db-pending-migrations.ts` — pure selection + journal hashing.
- `scripts/dev-db-pending-migrations.ts` — thin CLI; `dev-db-up.sh` pipes `SELECT hash FROM drizzle."__drizzle_migrations"` into it and reads `tag|when|hash` back. Replaces the inline `bun --eval`.
- `scripts/dev-db-discover.ts` (tailnet path) uses the same helper directly.

Ledger rows still record `created_at` as the journal's own `when`, so a row this applier writes is indistinguishable from one drizzle wrote and #4274's normaliser has nothing to repair on the next run.

**Hash parity:** root `scripts/` cannot import drizzle's `readMigrationFiles` (drizzle-orm is a `packages/db` dep, and Bun's isolated linker gives the root no hoisted copy), so the sha256 is derived from the raw `.sql` bytes — which is what drizzle 0.45 does, what `Dockerfile.dev-db` writes with `sha256sum`, and what the `--eval` this replaces already computed. `packages/db`'s journal-verification integration test runs against drizzle's real hashes and is where a future drizzle bump would surface.

## Arming the journal check (#3978)

The journal-vs-ledger check shipped behind `VERIFY_MIGRATION_JOURNAL=1` for one stated reason: the dev-db image was missing `0187_sad_freak`'s ledger row, and a default-on check would have reddened every developer's `vp run db:migrate` for a defect in the image. That reason is gone:

- `ghcr.io/boardsesh/boardsesh-dev-db:latest` records **190 of 190** journal entries (verified below).
- The image build fails if its ledger's high-water mark is not the journal's newest `when` (#4211).
- `vp run db:up` now fills a stale volume's gaps hash-by-hash *before* `db:migrate` runs.

Opt-in also meant the check was off in the one place a gap is created — the branch author's machine, on the branch that creates it. It now runs unless `VERIFY_MIGRATION_JOURNAL=0`. `ci.yml`, `production-deploy.yml` and `db-migration-renumber.yml` keep passing the literal `1` and stay armed without an edit.

The env decision moved into `scripts/lib/migration-ledger.ts` so it has unit coverage in the `scripts` Vitest project — `packages/db` runs on `tsx --test` and is outside the CI test graph.

## What #3978 does *not* fix, and why

No automatic repair for a `db_data` volume that carries a **superseded branch version** of a collapsed migration's objects without its ledger row. The four branch-local "0187"s each created a different subset of what `0187_sad_freak` creates, so no probe can tell what is already there, and inserting the ledger row without completing the DDL would mark the migration applied forever with part of it missing.

That shape used to hide below the high-water mark. It now fails with the migration named and the remedy spelled out:

```
ERROR: could not apply 0187_sad_freak to the dev database.
       If psql reported "already exists", this database carries that migration's
       objects without its ledger row — a volume that ran a superseded version of
       the migration on another branch, before it was renumbered or collapsed
       (#3978). ...
       Reset the volume and pull a current image:
         docker compose down -v && vp run db:up
```

Loud beats hidden, and the pre-built image ships the board data, the test user, and the seed data — a reset costs a pull, not a re-import. Leaving #3978 open (`Refs`, not `Closes`) so you can decide whether that residual case warrants a one-shot repair script.

## Verified locally

Against the running `boardsesh-dev-db:latest` container:

| check | result |
| --- | --- |
| `vp run db:verify-journal` | `✅ All 190 unbaselined journal migrations are recorded (193 ledger rows)` |
| `vp run db:up` | `No pending migrations.` |
| `vp run db:up` again | identical — nothing applied, nothing repaired |
| `vp run db:migrate` (nothing set) | gate armed, `✅ Verified all 190 unbaselined journal migrations are recorded` |
| selector, ledger with 0187's hash withheld | `0187_sad_freak\|1785047020870\|439223b0…` — named, despite its `when` sitting 594s **below** the ledger's mark of 1785641394370. This is the exact case the old filter hid. |
| selector, empty ledger | 190 entries selected, not 0 |
| `vp run test:db:migration-journal` (real Postgres) | 16/16 |
| `vp run check:db-migrations` | `190 migrations, journal consistent.` |
| `vp check`, `vp run typecheck`, `vp run typecheck:db` | clean (the 30 pre-existing repo-wide lint errors are untouched — mobile `@gorhom`, Sentry `ProcessEnv`) |
| `vp test run --project scripts` | 749 pass; the one failure, `prepare-rn-ios-tests`, fails identically on a stashed clean tree |

## For @marcodejongh before merge

The default flip reddens `vp run db:migrate` for any dev database carrying a gap this doesn't cover. I only ran read-only checks against this machine's local container, per instruction — **nothing was pointed at the tailnet-shared or production database**. Worth ticking off:

- [ ] `DB_URL=… vp run db:verify-journal` against the tailnet-shared dev DB (read-only; it is one `SELECT hash`).
- [ ] Same against any long-lived personal `db_data` volume.
- [ ] If either shows a gap, either repair it per `docs/db-migrations.md` or hold this PR — `VERIFY_MIGRATION_JOURNAL=0` is the unblock, but shipping with a known red is worse than waiting.

Production is unaffected: it already runs the gate with the literal `1`, and its baseline is untouched.

## Release Notes

- [x] No release note needed — dev tooling only, no user-facing surface.
