### PR TITLE
fix(web): guard playlist rename edits against a newer concurrent change

### DIFF
--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -364,6 +364,14 @@ async function processMutation(mutation: PendingMutation) {
 
 Each mutation gets a client-generated UUID as an idempotency key. The backend's `saveTick` and `createPlaylist` accept this UUID and use `ON CONFLICT (uuid) DO NOTHING` for safe retry. Favorites use explicit `addFavorite`/`removeFavorite` (not `toggleFavorite`) so retries don't invert state. Follow/unfollow operations are naturally idempotent (follow when already following = no-op, unfollow when not following = no-op).
 
+### The one mutation that can't be auto-merged
+
+Every queued mutation above is idempotent or commutative, so replaying it is always safe. `updatePlaylist` is the exception: a queued rename replayed blind overwrites whatever the playlist is called now, including a rename made on another device while this one was offline (#1934).
+
+So it carries a `basedOn` snapshot — the `updatedAt` plus the metadata values the client last saw. The server compares that against the stored row inside a transaction holding a row lock and, when the two genuinely diverge, rejects with `PLAYLIST_UPDATE_CONFLICT` instead of writing. The error's extensions carry the server's current values, so the client can name both versions in a prompt and rebuild `basedOn` for a deliberate overwrite without a refetch. Omitting `basedOn` keeps the old last-write-wins behaviour, which is what shipped binaries and web still do.
+
+Two consequences for the queue. A rejection resolves to no HTTP status, so `isRetryable` returns false and the row dead-letters for a human to resolve instead of burning ten retries. And a climb added or reordered elsewhere bumps `playlists.updated_at` without touching the metadata, which is why the check compares fields rather than the bare timestamp — a timestamp alone would false-conflict on the same device's own queued climb add draining ahead of the rename. Any future mutation that can't be auto-merged should reuse this code rather than invent a shape.
+
 ### Dead letter handling
 
 Mutations that exceed `MAX_RETRY_COUNT` or fail with non-retryable errors are moved to `status = 'dead_letter'`. The app shows a badge/indicator when dead-letter mutations exist. Users can view failed mutations and choose to retry or discard them. This prevents silent data loss — the user always knows if a tick didn't sync.

--- a/packages/backend/src/__tests__/playlist-update-conflict.test.ts
+++ b/packages/backend/src/__tests__/playlist-update-conflict.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vite-plus/test';
+import { eq, sql } from 'drizzle-orm';
+import { GraphQLError } from 'graphql';
+import { PLAYLIST_UPDATE_CONFLICT_CODE } from '@boardsesh/shared-schema';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import * as dbSchema from '@boardsesh/db/schema';
+import { playlistMutations } from '../graphql/resolvers/playlists/mutations';
+import {
+  detectPlaylistUpdateConflict,
+  normalizePlaylistText,
+} from '../graphql/resolvers/playlists/helpers/update-conflict';
+
+// #1934: updatePlaylist is the one offline-replayable mutation that can't be
+// auto-merged, so it takes an optional `basedOn` snapshot and refuses a genuine
+// collision instead of quietly keeping whichever write landed last.
+
+describe('detectPlaylistUpdateConflict', () => {
+  const storedAt = new Date('2026-08-10T12:00:00.000Z');
+  const olderSnapshot = '2026-08-10T11:00:00.000Z';
+
+  function stored(overrides: Record<string, unknown> = {}) {
+    return {
+      name: 'Crimps',
+      description: null,
+      isPublic: false,
+      color: null,
+      icon: null,
+      updatedAt: storedAt,
+      ...overrides,
+    };
+  }
+
+  it('never conflicts without a basedOn snapshot (blind last-write-wins stays the default)', () => {
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ name: 'Renamed elsewhere' }),
+        incoming: { name: 'Mine' },
+      }),
+    ).toBe(false);
+  });
+
+  it('applies when the snapshot is as new as the stored row', () => {
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored(),
+        incoming: { name: 'Mine' },
+        basedOn: { updatedAt: storedAt.toISOString(), name: 'Crimps' },
+      }),
+    ).toBe(false);
+  });
+
+  it('conflicts when someone else renamed the playlist', () => {
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ name: 'Renamed elsewhere' }),
+        incoming: { name: 'Mine' },
+        basedOn: { updatedAt: olderSnapshot, name: 'Crimps' },
+      }),
+    ).toBe(true);
+  });
+
+  it('does not conflict when only the timestamp moved (a climb was added)', () => {
+    // addClimbToPlaylist/remove/reorder all bump playlists.updated_at, so a bare
+    // timestamp comparison would cry conflict on every climb add.
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored(),
+        incoming: { name: 'Mine' },
+        basedOn: { updatedAt: olderSnapshot, name: 'Crimps' },
+      }),
+    ).toBe(false);
+  });
+
+  it('treats an already-applied edit as a no-op success, not a conflict', () => {
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ name: 'Mine' }),
+        incoming: { name: 'Mine' },
+        basedOn: { updatedAt: olderSnapshot, name: 'Crimps' },
+      }),
+    ).toBe(false);
+  });
+
+  it("treats '' and null as the same value for description/colour/icon", () => {
+    expect(normalizePlaylistText('')).toBeNull();
+    expect(normalizePlaylistText(null)).toBeNull();
+    expect(normalizePlaylistText(undefined)).toBeUndefined();
+    expect(normalizePlaylistText('#123456')).toBe('#123456');
+
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ description: null, color: null }),
+        incoming: { description: '', color: '' },
+        basedOn: { updatedAt: olderSnapshot, description: '', color: '' },
+      }),
+    ).toBe(false);
+  });
+
+  it('treats a missing based-on field as divergent (conservative)', () => {
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ description: 'set elsewhere' }),
+        incoming: { description: 'mine' },
+        // No `description` in the snapshot: we can't prove the client saw the
+        // stored value, so refuse rather than overwrite.
+        basedOn: { updatedAt: olderSnapshot, name: 'Crimps' },
+      }),
+    ).toBe(true);
+  });
+
+  it('conflicts on visibility only when the client did not see the stored value', () => {
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ isPublic: true }),
+        incoming: { isPublic: false },
+        basedOn: { updatedAt: olderSnapshot, isPublic: true },
+      }),
+    ).toBe(false);
+
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ isPublic: true }),
+        incoming: { isPublic: false },
+        // isPublic absent from the snapshot.
+        basedOn: { updatedAt: olderSnapshot, name: 'Crimps' },
+      }),
+    ).toBe(true);
+  });
+});
+
+const PLAYLIST_UUID = 'pl-conflict-1934';
+const OWNER_ID = 'user-123'; // seeded by setup.ts
+
+function makeCtx(): ConnectionContext {
+  return {
+    connectionId: 'conn-1',
+    isAuthenticated: true,
+    userId: OWNER_ID,
+    sessionId: null,
+    boardPath: null,
+    controllerId: null,
+    controllerApiKey: null,
+  } as unknown as ConnectionContext;
+}
+
+// Read through drizzle (not raw `execute`) so `updated_at` arrives as the same
+// Date the resolver compares against, rather than a driver string.
+async function readPlaylist(): Promise<{ name: string; description: string | null; updatedAt: Date }> {
+  const [row] = await db
+    .select({
+      name: dbSchema.playlists.name,
+      description: dbSchema.playlists.description,
+      updatedAt: dbSchema.playlists.updatedAt,
+    })
+    .from(dbSchema.playlists)
+    .where(eq(dbSchema.playlists.id, 1n))
+    .limit(1);
+  return row;
+}
+
+describe('updatePlaylist — compare-and-swap against a real DB (#1934)', () => {
+  // Playlist tables aren't in setup.ts's per-file reset list, so own the reset.
+  beforeEach(async () => {
+    await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
+    await db.execute(sql`
+      INSERT INTO playlists (id, uuid, board_type, layout_id, name, is_public, created_at, updated_at)
+      VALUES (1, ${PLAYLIST_UUID}, 'kilter', 1, 'Crimps', false, now() - interval '1 hour', now() - interval '1 hour')
+    `);
+    await db.execute(sql`INSERT INTO playlist_ownership (playlist_id, user_id) VALUES (1, ${OWNER_ID})`);
+  });
+
+  afterAll(async () => {
+    await db.execute(sql`TRUNCATE TABLE playlist_climbs, playlist_ownership, playlists RESTART IDENTITY CASCADE`);
+  });
+
+  it('applies without a basedOn snapshot (unchanged behaviour for web and shipped binaries)', async () => {
+    await playlistMutations.updatePlaylist(
+      null,
+      { input: { playlistId: PLAYLIST_UUID, name: 'Blind write' } },
+      makeCtx(),
+    );
+
+    expect((await readPlaylist()).name).toBe('Blind write');
+  });
+
+  it('applies when the snapshot matches the stored updatedAt', async () => {
+    const before = await readPlaylist();
+
+    await playlistMutations.updatePlaylist(
+      null,
+      {
+        input: {
+          playlistId: PLAYLIST_UUID,
+          name: 'Fresh edit',
+          basedOn: { updatedAt: before.updatedAt.toISOString(), name: 'Crimps' },
+        },
+      },
+      makeCtx(),
+    );
+
+    expect((await readPlaylist()).name).toBe('Fresh edit');
+  });
+
+  it('throws PLAYLIST_UPDATE_CONFLICT carrying the server values when another writer renamed it', async () => {
+    const before = await readPlaylist();
+    // Another device renames the playlist and sets a description.
+    await db.execute(
+      sql`UPDATE playlists SET name = 'Renamed on the other phone', description = 'theirs', updated_at = now() WHERE id = 1`,
+    );
+
+    const failure = await playlistMutations
+      .updatePlaylist(
+        null,
+        {
+          input: {
+            playlistId: PLAYLIST_UUID,
+            name: 'Renamed on this phone',
+            basedOn: { updatedAt: before.updatedAt.toISOString(), name: 'Crimps', description: null },
+          },
+        },
+        makeCtx(),
+      )
+      .then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+    expect(failure).toBeInstanceOf(GraphQLError);
+    const extensions = (failure as GraphQLError).extensions;
+    expect(extensions.code).toBe(PLAYLIST_UPDATE_CONFLICT_CODE);
+    expect(extensions.playlistUuid).toBe(PLAYLIST_UUID);
+    expect(extensions.serverName).toBe('Renamed on the other phone');
+    expect(extensions.serverDescription).toBe('theirs');
+    expect(extensions.serverIsPublic).toBe(false);
+    expect(extensions.serverColor).toBeNull();
+    expect(extensions.serverIcon).toBeNull();
+    expect(typeof extensions.serverUpdatedAt).toBe('string');
+
+    // Nothing was written.
+    expect((await readPlaylist()).name).toBe('Renamed on the other phone');
+  });
+
+  it('applies when only a climb add bumped updatedAt (the false-conflict this design prevents)', async () => {
+    const before = await readPlaylist();
+
+    await playlistMutations.addClimbToPlaylist(
+      null,
+      { input: { playlistId: PLAYLIST_UUID, climbUuid: '11111111-1111-1111-1111-111111111111', angle: 40 } },
+      makeCtx(),
+    );
+
+    const bumped = await readPlaylist();
+    expect(bumped.updatedAt.getTime()).toBeGreaterThan(before.updatedAt.getTime());
+
+    await playlistMutations.updatePlaylist(
+      null,
+      {
+        input: {
+          playlistId: PLAYLIST_UUID,
+          name: 'Renamed after the add',
+          basedOn: { updatedAt: before.updatedAt.toISOString(), name: 'Crimps', description: null },
+        },
+      },
+      makeCtx(),
+    );
+
+    expect((await readPlaylist()).name).toBe('Renamed after the add');
+  });
+
+  it('is a no-op success when a stale re-send asks for values that already landed', async () => {
+    const before = await readPlaylist();
+    await db.execute(sql`UPDATE playlists SET name = 'Same rename', updated_at = now() WHERE id = 1`);
+
+    // The outbox replays the rename it already delivered — it can't know the
+    // first attempt succeeded, and a bogus prompt here would be pure noise.
+    await playlistMutations.updatePlaylist(
+      null,
+      {
+        input: {
+          playlistId: PLAYLIST_UUID,
+          name: 'Same rename',
+          basedOn: { updatedAt: before.updatedAt.toISOString(), name: 'Crimps', description: null },
+        },
+      },
+      makeCtx(),
+    );
+
+    expect((await readPlaylist()).name).toBe('Same rename');
+  });
+
+  it('applies a "keep mine" retry rebased on the values from the conflict error', async () => {
+    const before = await readPlaylist();
+    await db.execute(sql`UPDATE playlists SET name = 'Theirs', updated_at = now() WHERE id = 1`);
+
+    const failure = await playlistMutations
+      .updatePlaylist(
+        null,
+        {
+          input: {
+            playlistId: PLAYLIST_UUID,
+            name: 'Mine',
+            basedOn: { updatedAt: before.updatedAt.toISOString(), name: 'Crimps', description: null },
+          },
+        },
+        makeCtx(),
+      )
+      .then(
+        () => null,
+        (error: unknown) => error as GraphQLError,
+      );
+
+    const extensions = (failure as GraphQLError).extensions;
+
+    await playlistMutations.updatePlaylist(
+      null,
+      {
+        input: {
+          playlistId: PLAYLIST_UUID,
+          name: 'Mine',
+          basedOn: {
+            updatedAt: extensions.serverUpdatedAt as string,
+            name: extensions.serverName as string,
+            description: extensions.serverDescription as string | null,
+            isPublic: extensions.serverIsPublic as boolean,
+            color: extensions.serverColor as string | null,
+            icon: extensions.serverIcon as string | null,
+          },
+        },
+      },
+      makeCtx(),
+    );
+
+    expect((await readPlaylist()).name).toBe('Mine');
+  });
+
+  it('still rejects a non-owner', async () => {
+    await expect(
+      playlistMutations.updatePlaylist(null, { input: { playlistId: PLAYLIST_UUID, name: 'Not mine' } }, {
+        ...makeCtx(),
+        userId: 'not-the-owner',
+      } as ConnectionContext),
+    ).rejects.toThrow('do not have permission');
+
+    expect((await readPlaylist()).name).toBe('Crimps');
+  });
+});

--- a/packages/backend/src/__tests__/playlist-update-conflict.test.ts
+++ b/packages/backend/src/__tests__/playlist-update-conflict.test.ts
@@ -155,6 +155,17 @@ describe('detectPlaylistUpdateConflict', () => {
         basedOn: { updatedAt: olderSnapshot, name: 'Crimps' },
       }),
     ).toBe(true);
+
+    // An unknown snapshot value can't manufacture a conflict on its own: if the
+    // stored visibility already equals what this edit sends, there is nothing to
+    // decide between.
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ isPublic: true }),
+        incoming: { isPublic: true },
+        basedOn: { updatedAt: olderSnapshot, isPublic: null },
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/backend/src/__tests__/playlist-update-conflict.test.ts
+++ b/packages/backend/src/__tests__/playlist-update-conflict.test.ts
@@ -97,6 +97,35 @@ describe('detectPlaylistUpdateConflict', () => {
     ).toBe(false);
   });
 
+  it('conflicts on a colour or icon someone else changed, same as a rename', () => {
+    // name/description/colour/icon share one loop; pin colour and icon so a
+    // future field-list edit can't quietly drop them from the check.
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ color: '#1F2937' }),
+        incoming: { color: '#6D28D9' },
+        basedOn: { updatedAt: olderSnapshot, color: '#8C4A52' },
+      }),
+    ).toBe(true);
+
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ icon: '🪨' }),
+        incoming: { icon: '💀' },
+        basedOn: { updatedAt: olderSnapshot, icon: '🔥' },
+      }),
+    ).toBe(true);
+
+    // ...and not when the other device set it to what this edit already sends.
+    expect(
+      detectPlaylistUpdateConflict({
+        stored: stored({ color: '#6D28D9' }),
+        incoming: { color: '#6D28D9' },
+        basedOn: { updatedAt: olderSnapshot, color: '#8C4A52' },
+      }),
+    ).toBe(false);
+  });
+
   it('treats a missing based-on field as divergent (conservative)', () => {
     expect(
       detectPlaylistUpdateConflict({

--- a/packages/backend/src/__tests__/playlist-update.test.ts
+++ b/packages/backend/src/__tests__/playlist-update.test.ts
@@ -1,15 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 
-const { mockDb } = vi.hoisted(() => {
+const { mockDb, mockTx } = vi.hoisted(() => {
+  // The compare-and-swap added in #1934 runs the ownership check, the locked
+  // read and the write inside one transaction, so the mock needs a `tx` of its
+  // own; everything after the commit still goes through `db`.
+  const mockTx = {
+    select: vi.fn(),
+    update: vi.fn(),
+  };
   const mockDb = {
     execute: vi.fn(),
     select: vi.fn(),
     insert: vi.fn(),
     delete: vi.fn(),
     update: vi.fn(),
+    transaction: vi.fn(async (callback: (tx: typeof mockTx) => unknown) => callback(mockTx)),
   };
-  return { mockDb };
+  return { mockDb, mockTx };
 });
 
 vi.mock('../db/client', () => ({ db: mockDb }));
@@ -38,7 +46,7 @@ function makeCtx(overrides: Partial<ConnectionContext> = {}): ConnectionContext 
 
 function createMockChain(resolveValue: unknown = []): Record<string, unknown> {
   const chain: Record<string, unknown> = {};
-  const methods = ['select', 'from', 'where', 'innerJoin', 'limit', 'set', 'update', 'returning'];
+  const methods = ['select', 'from', 'where', 'innerJoin', 'limit', 'set', 'update', 'returning', 'for'];
   chain.then = (resolve: (value: unknown) => unknown) => Promise.resolve(resolveValue).then(resolve);
   for (const method of methods) chain[method] = vi.fn((..._args: unknown[]) => chain);
   return chain;
@@ -58,11 +66,16 @@ const updatedRow = {
   updatedAt: new Date(),
 };
 
-/** Mock the resolver's db sequence: ownership select → update → climbCount select → pin select. */
+/**
+ * Mock the resolver's db sequence: inside the transaction, ownership select →
+ * locked playlist select → update; after it commits, climbCount select → pin
+ * select.
+ */
 function primeDb() {
-  mockDb.select.mockReturnValueOnce(createMockChain([{ playlists: { id: 1 } }])); // ownership
+  mockTx.select.mockReturnValueOnce(createMockChain([{ playlistId: 1 }])); // ownership
+  mockTx.select.mockReturnValueOnce(createMockChain([updatedRow])); // locked read
   const updateChain = createMockChain([updatedRow]);
-  mockDb.update.mockReturnValueOnce(updateChain);
+  mockTx.update.mockReturnValueOnce(updateChain);
   mockDb.select.mockReturnValueOnce(createMockChain([{ count: 0 }])); // climbCount
   mockDb.select.mockReturnValueOnce(createMockChain([])); // pin lookup
   return updateChain;

--- a/packages/backend/src/graphql/resolvers/playlists/helpers/update-conflict.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/helpers/update-conflict.ts
@@ -1,0 +1,109 @@
+/**
+ * Compare-and-swap rule for `updatePlaylist` (#1934).
+ *
+ * A playlist rename is the one offline-replayable mutation that can't be
+ * auto-merged (see the doc block on PLAYLIST_UPDATE_CONFLICT_CODE in
+ * @boardsesh/shared-schema), so the server has to be able to say "this changed
+ * somewhere else" instead of quietly keeping whichever write landed last.
+ *
+ * Pure and dependency-free so the rule can be unit-tested without a database.
+ */
+
+/** The metadata fields an edit can carry. Shared by stored / incoming / based-on. */
+export type PlaylistMetadataFields = {
+  name?: string | null;
+  description?: string | null;
+  isPublic?: boolean | null;
+  color?: string | null;
+  icon?: string | null;
+};
+
+export type PlaylistUpdateConflictArgs = {
+  /** The row as it is in the database right now. */
+  stored: PlaylistMetadataFields & { updatedAt: Date };
+  /** The fields this edit wants to write (absent = leave unchanged). */
+  incoming: PlaylistMetadataFields;
+  /** What the client last saw, or undefined for blind last-write-wins. */
+  basedOn?: (PlaylistMetadataFields & { updatedAt: string }) | null;
+};
+
+const TEXT_FIELDS = ['name', 'description', 'color', 'icon'] as const;
+
+/**
+ * Collapse the '' clear signal and NULL to one value, mirroring the resolver's
+ * `|| null` write path — a description cleared to '' is stored as NULL, so a
+ * client that still holds the '' it typed must compare equal to the NULL on disk.
+ *
+ * `undefined` is preserved: it means "this field wasn't sent", which is a
+ * different question from "this field is empty".
+ */
+export function normalizePlaylistText(value: string | null | undefined): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null || value === '') return null;
+  return value;
+}
+
+function valuesMatch(left: string | null | undefined, right: string | null | undefined): boolean {
+  // undefined never matches: an absent based-on field can't prove the client saw
+  // the stored value, and an absent incoming field isn't being written at all.
+  if (left === undefined || right === undefined) return false;
+  return left === right;
+}
+
+/**
+ * Whether this edit must be refused as a conflict.
+ *
+ * Three stages, in order:
+ *
+ * 1. No `basedOn` → never a conflict. Pre-#1934 clients and web send no
+ *    snapshot and keep today's blind last-write-wins behaviour.
+ *
+ * 2. The stored row is no newer than the snapshot → apply. This is the fast
+ *    path: nothing has happened since the client read the playlist.
+ *
+ * 3. The stored row IS newer → conflict only when some field this edit writes
+ *    disagrees with BOTH the stored value and the value the client saw.
+ *
+ * Stage 3 is what makes the check usable at all. `addClimbToPlaylist`,
+ * `removeClimbFromPlaylist` and `reorderPlaylistClimb` all bump
+ * `playlists.updated_at` (that column drives library ordering, so they can't
+ * stop), which means a bare timestamp comparison would report a conflict every
+ * time someone adds a climb — including when the same device's own outbox
+ * drains an add ahead of the rename. Comparing the actual values keeps the
+ * timestamp as a cheap gate and lets the field check decide.
+ *
+ * It also makes an ambiguous re-send a no-op success: if the rename already
+ * landed, the incoming values equal the stored ones, so there is nothing to
+ * disagree about.
+ */
+export function detectPlaylistUpdateConflict({ stored, incoming, basedOn }: PlaylistUpdateConflictArgs): boolean {
+  // Stage 1 — opt-in only.
+  if (!basedOn) return false;
+
+  // Stage 2 — nothing moved. `updated_at` is a `timestamp` without time zone and
+  // round-trips Date → toISOString → parse at millisecond precision; any sub-ms
+  // drift only pushes the decision into stage 3, where identical values apply.
+  const basedOnUpdatedAt = Date.parse(basedOn.updatedAt);
+  if (!Number.isNaN(basedOnUpdatedAt) && stored.updatedAt.getTime() <= basedOnUpdatedAt) return false;
+
+  // Stage 3 — the row moved, so check whether it moved in a way this edit cares about.
+  for (const field of TEXT_FIELDS) {
+    const incomingValue = normalizePlaylistText(incoming[field]);
+    if (incomingValue === undefined) continue; // not being written
+    const storedValue = normalizePlaylistText(stored[field]);
+    if (valuesMatch(storedValue, incomingValue)) continue; // already what we want
+    if (valuesMatch(storedValue, normalizePlaylistText(basedOn[field]))) continue; // nobody else touched it
+    return true;
+  }
+
+  // isPublic is non-null on the server, so a null in the snapshot means the
+  // client had no value for it — the conservative case, same as an absent field.
+  if (incoming.isPublic !== undefined && incoming.isPublic !== null) {
+    const storedIsPublic = stored.isPublic ?? false;
+    const sawIsPublic = basedOn.isPublic ?? undefined;
+    const clientSawStoredValue = sawIsPublic !== undefined && sawIsPublic === storedIsPublic;
+    if (storedIsPublic !== incoming.isPublic && !clientSawStoredValue) return true;
+  }
+
+  return false;
+}

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -1,6 +1,8 @@
 import { eq, and, asc, inArray, sql } from 'drizzle-orm';
+import { GraphQLError } from 'graphql';
 import { v4 as uuidv4 } from 'uuid';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { PLAYLIST_UPDATE_CONFLICT_CODE } from '@boardsesh/shared-schema';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, validateInput } from '../shared/helpers';
@@ -16,6 +18,7 @@ import {
 import { getPlaylistFollowStats } from './queries';
 import { verifyPlaylistAccess } from './helpers/enrichment';
 import { computePlaylistReorderWrites } from './helpers/reorder';
+import { detectPlaylistUpdateConflict } from './helpers/update-conflict';
 
 function playlistResult(playlist: dbSchema.Playlist, climbCount: number): Record<string, unknown> {
   return {
@@ -149,26 +152,6 @@ export const playlistMutations = {
 
     const userId = ctx.userId!;
 
-    // Check ownership
-    const ownership = await db
-      .select()
-      .from(dbSchema.playlistOwnership)
-      .innerJoin(dbSchema.playlists, eq(dbSchema.playlists.id, dbSchema.playlistOwnership.playlistId))
-      .where(
-        and(
-          eq(dbSchema.playlists.uuid, validatedInput.playlistId),
-          eq(dbSchema.playlistOwnership.userId, userId),
-          eq(dbSchema.playlistOwnership.role, 'owner'),
-        ),
-      )
-      .limit(1);
-
-    if (ownership.length === 0) {
-      throw new Error('Playlist not found or you do not have permission to edit it');
-    }
-
-    const playlistId = ownership[0].playlists.id;
-
     // Build update object (only update provided fields)
     const updateData: Record<string, unknown> = {
       updatedAt: new Date(),
@@ -183,14 +166,74 @@ export const playlistMutations = {
     if (validatedInput.color !== undefined) updateData.color = validatedInput.color || null;
     if (validatedInput.icon !== undefined) updateData.icon = validatedInput.icon || null;
 
-    // Update playlist
-    const [updated] = await db
-      .update(dbSchema.playlists)
-      .set(updateData)
-      .where(eq(dbSchema.playlists.id, playlistId))
-      .returning();
+    // Ownership check, conflict check and the write all happen inside one
+    // transaction with the playlist row locked (#1934). Splitting them would
+    // leave a read-then-write window in which the very edit the client is being
+    // compared against could land, which is exactly the race the check exists to
+    // catch. Same `for('update')` pattern as reorderPlaylistClimb below.
+    const updated = await db.transaction(async (tx) => {
+      const ownership = await tx
+        .select({ playlistId: dbSchema.playlists.id })
+        .from(dbSchema.playlistOwnership)
+        .innerJoin(dbSchema.playlists, eq(dbSchema.playlists.id, dbSchema.playlistOwnership.playlistId))
+        .where(
+          and(
+            eq(dbSchema.playlists.uuid, validatedInput.playlistId),
+            eq(dbSchema.playlistOwnership.userId, userId),
+            eq(dbSchema.playlistOwnership.role, 'owner'),
+          ),
+        )
+        .limit(1);
 
-    // Get climb count and follow stats
+      if (ownership.length === 0) {
+        throw new Error('Playlist not found or you do not have permission to edit it');
+      }
+
+      const lockedPlaylistId = ownership[0].playlistId;
+
+      const [stored] = await tx
+        .select()
+        .from(dbSchema.playlists)
+        .where(eq(dbSchema.playlists.id, lockedPlaylistId))
+        .for('update')
+        .limit(1);
+
+      if (!stored) {
+        throw new Error('Playlist not found or you do not have permission to edit it');
+      }
+
+      if (detectPlaylistUpdateConflict({ stored, incoming: validatedInput, basedOn: validatedInput.basedOn })) {
+        // The extensions carry the server's current values so the client can name
+        // both versions in its prompt and rebuild `basedOn` for a "keep mine"
+        // retry without a refetch. GraphQLError extensions survive yoga's
+        // maskError untouched (mask-error.ts only rewrites DB/driver leaks).
+        throw new GraphQLError('This playlist changed somewhere else', {
+          extensions: {
+            code: PLAYLIST_UPDATE_CONFLICT_CODE,
+            playlistUuid: stored.uuid,
+            serverUpdatedAt: stored.updatedAt.toISOString(),
+            serverName: stored.name,
+            serverDescription: stored.description,
+            serverIsPublic: stored.isPublic,
+            serverColor: stored.color,
+            serverIcon: stored.icon,
+          },
+        });
+      }
+
+      const [updatedRow] = await tx
+        .update(dbSchema.playlists)
+        .set(updateData)
+        .where(eq(dbSchema.playlists.id, lockedPlaylistId))
+        .returning();
+
+      return updatedRow;
+    });
+
+    const playlistId = updated.id;
+
+    // Climb count, follow stats and the pin lookup stay OUTSIDE the transaction
+    // so the row lock is held for the compare-and-swap only.
     const climbCount = await db
       .select({ count: sql<number>`count(*)::int` })
       .from(dbSchema.playlistClimbs)

--- a/packages/backend/src/graphql/resolvers/playlists/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/playlists/mutations.ts
@@ -170,7 +170,11 @@ export const playlistMutations = {
     // transaction with the playlist row locked (#1934). Splitting them would
     // leave a read-then-write window in which the very edit the client is being
     // compared against could land, which is exactly the race the check exists to
-    // catch. Same `for('update')` pattern as reorderPlaylistClimb below.
+    // catch. Same `for('update')` pattern as reorderPlaylistClimb below, which
+    // runs its ownership check outside the transaction entirely. To be precise
+    // about what the lock covers: the playlist row, not the ownership row. An
+    // ownership revoke committing mid-edit races this check exactly as it races
+    // every other playlist mutation; closing that is a separate job.
     const updated = await db.transaction(async (tx) => {
       const ownership = await tx
         .select({ playlistId: dbSchema.playlists.id })

--- a/packages/backend/src/validation/schemas/playlists.ts
+++ b/packages/backend/src/validation/schemas/playlists.ts
@@ -26,6 +26,30 @@ export const CreatePlaylistInputSchema = z.object({
   icon: PlaylistIconSchema,
 });
 
+// The snapshot the client based its edit on (#1934). `updatedAt` must parse as a
+// date: an unparseable string would make every comparison read "stored is newer"
+// and turn every edit into a conflict, so reject it at the door.
+//
+// Every metadata field is nullish, not optional — a client mirroring what it read
+// sends `description: null` for a playlist that has none, and that null is
+// meaningful ("I saw no description"). An ABSENT field is the conservative case:
+// the comparison can't prove the client saw the stored value, so it counts as
+// divergent.
+export const PlaylistRevisionInputSchema = z.object({
+  updatedAt: z
+    .string()
+    .min(1)
+    .refine((updatedAt) => !Number.isNaN(Date.parse(updatedAt)), 'basedOn.updatedAt must be a parseable date'),
+  name: PlaylistNameSchema.nullish(),
+  description: z.string().max(500, 'Playlist description too long').nullish(),
+  isPublic: z.boolean().nullish(),
+  color: z
+    .string()
+    .refine((color) => color === '' || isValidPlaylistColor(color), 'Invalid color format (must be hex)')
+    .nullish(),
+  icon: z.string().max(50, 'Icon name too long').nullish(),
+});
+
 export const UpdatePlaylistInputSchema = z.object({
   playlistId: z.string().min(1),
   name: PlaylistNameSchema.optional(),
@@ -33,6 +57,7 @@ export const UpdatePlaylistInputSchema = z.object({
   isPublic: z.boolean().optional(),
   color: PlaylistColorSchema,
   icon: PlaylistIconSchema,
+  basedOn: PlaylistRevisionInputSchema.optional(),
 });
 
 export const AddClimbToPlaylistInputSchema = z.object({

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -445,6 +445,11 @@ export default function PlaylistDetail() {
                   // Read the cache at press time rather than reusing the row
                   // captured at submit, so a climb added while the prompt was up
                   // isn't rolled back.
+                  // `?? undefined` because `Playlist` types the optional text
+                  // fields as `string | undefined`; a save response puts the
+                  // server's raw `null` in the same slots. Both mean "unset" to
+                  // every consumer — nothing compares these to `null` — but if
+                  // that ever stops being true, fix it in the type, not here.
                   const current = queryClient.getQueryData<Playlist>(['playlist', playlistUuid]) ?? playlist;
                   cacheUpdatedPlaylist({
                     ...current,

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -475,6 +475,15 @@ export default function PlaylistDetail() {
                       icon: conflict.serverIcon,
                     });
                   } catch (retryError) {
+                    // A third device can land between this prompt and the retry.
+                    // Say so inline rather than prompting again — a prompt chain
+                    // has no natural end — and don't report it: it's still an
+                    // expected outcome, not a fault. Saving from the still-open
+                    // sheet re-prompts with the newest server values.
+                    if (readPlaylistUpdateConflict(retryError)) {
+                      setEditError(t('edit.conflict.changedAgain'));
+                      return;
+                    }
                     console.error('Failed to update playlist:', retryError);
                     reportHandledError(retryError, { tags: { source: 'playlist', op: 'update-keep-mine' } });
                     setEditError(t('edit.messages.updateFailed'));

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -18,6 +18,7 @@ import {
   type GetPlaylistClimbsInput,
   type GetPlaylistClimbsQueryResponse,
   type Playlist,
+  type PlaylistRevision,
 } from '@boardsesh/graphql/operations/playlists';
 import { Text } from '../../../src/components/Text';
 import { Icon } from '../../../src/components/Icon';
@@ -42,6 +43,7 @@ import { usePlaylistRenderBoard } from '../../../src/lib/playlists/use-playlist-
 import { resolvePlaylistClimbRenderBoard } from '../../../src/lib/playlists/playlist-climb-render-board';
 import { recordPlaylistOpen } from '../../../src/lib/playlists/recents-store';
 import { reportHandledError } from '../../../src/lib/error-reporting';
+import { readPlaylistUpdateConflict } from '../../../src/lib/graphql/extract-error-message';
 import { toQueueClimbs } from '../../../src/lib/climb-types';
 import { hapticSelection } from '../../../src/lib/haptics';
 import { useAuth } from '../../../src/providers/auth-provider';
@@ -370,12 +372,26 @@ export default function PlaylistDetail() {
     }
   }, [playlist, isFollowing, followPlaylist, unfollowPlaylist, queryClient, playlistUuid, showToast, t]);
 
+  // Both caches that hold this playlist: the detail hero, and the
+  // Add-to-Playlist picker's list (the shelves refetch on focus, but that cache
+  // wouldn't until its staleTime lapses).
+  const cacheUpdatedPlaylist = useCallback(
+    (updated: Playlist) => {
+      queryClient.setQueryData(['playlist', playlistUuid], updated);
+      queryClient.setQueryData<Playlist[]>(['userPlaylists'], (prev) =>
+        prev?.map((entry) => (entry.uuid === updated.uuid || entry.id === updated.id ? updated : entry)),
+      );
+    },
+    [queryClient, playlistUuid],
+  );
+
   const handleEditSubmit = useCallback(
     async (values: PlaylistFormValues) => {
       if (!playlist) return;
       setSavingEdit(true);
       setEditError(null);
-      try {
+
+      const saveEdit = async (basedOn: PlaylistRevision | undefined) => {
         const updated = await updatePlaylist({
           playlistId: playlist.uuid,
           name: values.name,
@@ -385,16 +401,89 @@ export default function PlaylistDetail() {
           color: values.color,
           icon: values.icon,
           isPublic: values.isPublic,
+          basedOn,
         });
-        queryClient.setQueryData(['playlist', playlistUuid], updated);
-        // Also patch the Add-to-Playlist picker's react-query list (the shelves
-        // refetch on focus, but this cache wouldn't until its staleTime lapses).
-        queryClient.setQueryData<Playlist[]>(['userPlaylists'], (prev) =>
-          prev?.map((entry) => (entry.uuid === updated.uuid || entry.id === updated.id ? updated : entry)),
-        );
+        cacheUpdatedPlaylist(updated);
         setEditVisible(false);
         showToast(t('edit.messages.updated'), 'success');
+      };
+
+      try {
+        // What this edit is based on. The server compares it against the stored
+        // row and refuses rather than silently overwriting a rename made on
+        // another device (#1934). A cached row from before this field shipped
+        // has no updatedAt, and falls back to last-write-wins.
+        await saveEdit(
+          playlist.updatedAt
+            ? {
+                updatedAt: playlist.updatedAt,
+                name: playlist.name,
+                description: playlist.description ?? null,
+                isPublic: playlist.isPublic,
+                color: playlist.color ?? null,
+                icon: playlist.icon ?? null,
+              }
+            : undefined,
+        );
       } catch (err) {
+        // Checked BEFORE reporting: a conflict is an expected outcome the
+        // climber resolves, not a fault (same treatment as the beta-link
+        // validation rejections).
+        const conflict = readPlaylistUpdateConflict(err);
+        if (conflict) {
+          Alert.alert(
+            t('edit.conflict.title'),
+            t('edit.conflict.message', { serverName: conflict.serverName, yourName: values.name }),
+            [
+              { text: t('edit.conflict.cancel'), style: 'cancel' },
+              {
+                text: t('edit.conflict.keepTheirs'),
+                onPress: () => {
+                  queryClient.setQueryData<Playlist | null>(['playlist', playlistUuid], (prev) =>
+                    prev
+                      ? {
+                          ...prev,
+                          name: conflict.serverName,
+                          description: conflict.serverDescription ?? undefined,
+                          isPublic: conflict.serverIsPublic,
+                          color: conflict.serverColor ?? undefined,
+                          icon: conflict.serverIcon ?? undefined,
+                          updatedAt: conflict.serverUpdatedAt,
+                        }
+                      : prev,
+                  );
+                  setEditVisible(false);
+                },
+              },
+              {
+                text: t('edit.conflict.keepMine'),
+                style: 'destructive',
+                onPress: async () => {
+                  setSavingEdit(true);
+                  try {
+                    // Re-based on the server's own values, so the retry compares
+                    // clean and overwrites deliberately rather than by accident.
+                    await saveEdit({
+                      updatedAt: conflict.serverUpdatedAt,
+                      name: conflict.serverName,
+                      description: conflict.serverDescription,
+                      isPublic: conflict.serverIsPublic,
+                      color: conflict.serverColor,
+                      icon: conflict.serverIcon,
+                    });
+                  } catch (retryError) {
+                    console.error('Failed to update playlist:', retryError);
+                    reportHandledError(retryError, { tags: { source: 'playlist', op: 'update-keep-mine' } });
+                    setEditError(t('edit.messages.updateFailed'));
+                  } finally {
+                    setSavingEdit(false);
+                  }
+                },
+              },
+            ],
+          );
+          return;
+        }
         console.error('Failed to update playlist:', err);
         reportHandledError(err, { tags: { source: 'playlist', op: 'update' } });
         // Inline, not a toast: the sheet is still open, so a root toast would be
@@ -404,7 +493,7 @@ export default function PlaylistDetail() {
         setSavingEdit(false);
       }
     },
-    [playlist, updatePlaylist, queryClient, playlistUuid, showToast, t],
+    [playlist, updatePlaylist, cacheUpdatedPlaylist, queryClient, playlistUuid, showToast, t],
   );
 
   const handleDelete = useCallback(() => {

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -439,19 +439,22 @@ export default function PlaylistDetail() {
               {
                 text: t('edit.conflict.keepTheirs'),
                 onPress: () => {
-                  queryClient.setQueryData<Playlist | null>(['playlist', playlistUuid], (prev) =>
-                    prev
-                      ? {
-                          ...prev,
-                          name: conflict.serverName,
-                          description: conflict.serverDescription ?? undefined,
-                          isPublic: conflict.serverIsPublic,
-                          color: conflict.serverColor ?? undefined,
-                          icon: conflict.serverIcon ?? undefined,
-                          updatedAt: conflict.serverUpdatedAt,
-                        }
-                      : prev,
-                  );
+                  // Adopting theirs has to land in BOTH caches, same as a
+                  // successful save — patching only the detail hero would leave
+                  // the library list and Add-to-Playlist picker on the old name.
+                  // Read the cache at press time rather than reusing the row
+                  // captured at submit, so a climb added while the prompt was up
+                  // isn't rolled back.
+                  const current = queryClient.getQueryData<Playlist>(['playlist', playlistUuid]) ?? playlist;
+                  cacheUpdatedPlaylist({
+                    ...current,
+                    name: conflict.serverName,
+                    description: conflict.serverDescription ?? undefined,
+                    isPublic: conflict.serverIsPublic,
+                    color: conflict.serverColor ?? undefined,
+                    icon: conflict.serverIcon ?? undefined,
+                    updatedAt: conflict.serverUpdatedAt,
+                  });
                   setEditVisible(false);
                 },
               },
@@ -482,6 +485,9 @@ export default function PlaylistDetail() {
               },
             ],
           );
+          // The `finally` below still runs on this return, so the submit button
+          // stops spinning while the prompt is up: dismissing the alert leaves an
+          // editable sheet with the edit intact, not a frozen one.
           return;
         }
         console.error('Failed to update playlist:', err);

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -433,7 +433,13 @@ export default function PlaylistDetail() {
         if (conflict) {
           Alert.alert(
             t('edit.conflict.title'),
-            t('edit.conflict.message', { serverName: conflict.serverName, yourName: values.name }),
+            // The server also conflicts on description, colour, icon and
+            // visibility, so the two names can be identical. Quoting them back
+            // would read as "saved as X now, your edit says X" — say the details
+            // diverged instead.
+            conflict.serverName === values.name
+              ? t('edit.conflict.messageDetails')
+              : t('edit.conflict.message', { serverName: conflict.serverName, yourName: values.name }),
             [
               { text: t('edit.conflict.cancel'), style: 'cancel' },
               {

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -148,14 +148,16 @@ vi.mock('../../../../src/components/playlist', () => ({
   // without the real gorhom sheet.
   PlaylistFormSheet: ({
     submitError,
+    submitting,
     onSubmit,
   }: {
     submitError?: string | null;
+    submitting?: boolean;
     onSubmit?: (values: unknown) => void;
   }) =>
     createElement(
       'div',
-      null,
+      { 'data-form-sheet': 'true', 'data-submitting': submitting ? 'true' : 'false' },
       submitError ? createElement('span', { 'data-edit-error': 'true' }, submitError) : null,
       createElement(
         'button',
@@ -480,6 +482,60 @@ describe('PlaylistDetail edit conflict (#1934)', () => {
       expect(cached?.color).toBe('#1F2937');
     });
     // Adopting theirs is a local decision — nothing more is sent.
+    expect(updatePlaylistMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('"Use theirs" also refreshes the library list, not just the detail hero', async () => {
+    requestMock.mockResolvedValue({ playlist: cachedPlaylist });
+    updatePlaylistMock.mockRejectedValue(conflictError);
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    // The library / Add-to-Playlist cache still holds the pre-conflict row.
+    queryClient.setQueryData(['userPlaylists'], [{ uuid: 'p-1', id: 'p-1', name: 'Old name', color: '#6D28D9' }]);
+
+    const { findByText } = renderDetail(queryClient);
+    fireEvent.click(await findByText('form-submit'));
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    const buttons = alertMock.mock.calls[0][2] as Array<{ text: string; onPress?: () => void }>;
+    buttons.find((button) => button.text === 'edit.conflict.keepTheirs')?.onPress?.();
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<Array<{ name: string; color: string }>>(['userPlaylists']);
+      expect(cached?.[0].name).toBe('Renamed on the other phone');
+      expect(cached?.[0].color).toBe('#1F2937');
+    });
+    // Only the metadata the server reported moves; the rest of the row survives.
+    expect(queryClient.getQueryData<{ climbCount: number }>(['playlist', 'p-1'])?.climbCount).toBe(3);
+  });
+
+  it('leaves an editable sheet — not one stuck mid-save — when the prompt is dismissed', async () => {
+    requestMock.mockResolvedValue({ playlist: cachedPlaylist });
+    let rejectUpdate: (reason: unknown) => void = () => {};
+    updatePlaylistMock.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectUpdate = reject;
+      }),
+    );
+
+    const { findByText, container } = renderDetail();
+    const submitting = () => container.querySelector('[data-form-sheet]')?.getAttribute('data-submitting');
+
+    fireEvent.click(await findByText('form-submit'));
+    // In flight: the sheet's submit button spins.
+    await waitFor(() => expect(submitting()).toBe('true'));
+
+    rejectUpdate(conflictError);
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    const buttons = alertMock.mock.calls[0][2] as Array<{ text: string; style?: string; onPress?: () => void }>;
+    const cancel = buttons.find((button) => button.text === 'edit.conflict.cancel');
+    expect(cancel?.style).toBe('cancel');
+    cancel?.onPress?.();
+
+    // Dismissed with the edit intact and the button live again, ready to retry.
+    await waitFor(() => expect(submitting()).toBe('false'));
+    expect(container.querySelector('[data-edit-error="true"]')).toBeNull();
     expect(updatePlaylistMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -485,6 +485,39 @@ describe('PlaylistDetail edit conflict (#1934)', () => {
     expect(updatePlaylistMock).toHaveBeenCalledTimes(1);
   });
 
+  it('does not quote two identical names back when the details are what diverged', async () => {
+    requestMock.mockResolvedValue({ playlist: cachedPlaylist });
+    // Both devices kept the name and changed the colour: the name-vs-name
+    // wording would read "saved as Bad climbs now, your edit says Bad climbs".
+    updatePlaylistMock.mockRejectedValue({
+      response: {
+        errors: [
+          {
+            message: 'This playlist changed somewhere else',
+            extensions: {
+              ...conflictError.response.errors[0].extensions,
+              serverName: 'Bad climbs',
+              serverColor: '#8C4A52',
+            },
+          },
+        ],
+      },
+    });
+
+    const { findByText } = renderDetail();
+    fireEvent.click(await findByText('form-submit'));
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    expect(alertMock.mock.calls[0][1]).toBe('edit.conflict.messageDetails');
+    // Keep mine / Use theirs still resolve the whole record.
+    const buttons = alertMock.mock.calls[0][2] as Array<{ text: string }>;
+    expect(buttons.map((button) => button.text)).toEqual([
+      'edit.conflict.cancel',
+      'edit.conflict.keepTheirs',
+      'edit.conflict.keepMine',
+    ]);
+  });
+
   it('"Keep mine" losing a second race says so inline instead of reporting a fault', async () => {
     requestMock.mockResolvedValue({ playlist: cachedPlaylist });
     // A third device lands between the prompt and the retry.

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -485,6 +485,27 @@ describe('PlaylistDetail edit conflict (#1934)', () => {
     expect(updatePlaylistMock).toHaveBeenCalledTimes(1);
   });
 
+  it('"Keep mine" losing a second race says so inline instead of reporting a fault', async () => {
+    requestMock.mockResolvedValue({ playlist: cachedPlaylist });
+    // A third device lands between the prompt and the retry.
+    updatePlaylistMock.mockRejectedValue(conflictError);
+
+    const { findByText, container } = renderDetail();
+    fireEvent.click(await findByText('form-submit'));
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    const buttons = alertMock.mock.calls[0][2] as Array<{ text: string; onPress?: () => void }>;
+    buttons.find((button) => button.text === 'edit.conflict.keepMine')?.onPress?.();
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-edit-error="true"]')?.textContent).toBe('edit.conflict.changedAgain');
+    });
+    // Still an expected outcome, not a fault — and no second prompt, which would
+    // have no natural end.
+    expect(reportHandledErrorMock).not.toHaveBeenCalled();
+    expect(alertMock).toHaveBeenCalledTimes(1);
+  });
+
   it('"Use theirs" also refreshes the library list, not just the detail hero', async () => {
     requestMock.mockResolvedValue({ playlist: cachedPlaylist });
     updatePlaylistMock.mockRejectedValue(conflictError);

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -44,6 +44,11 @@ vi.mock('../../../../src/lib/graphql/client', () => ({
 const climbsRefetch = vi.hoisted(() => vi.fn());
 const updatePlaylistMock = vi.hoisted(() => vi.fn());
 const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
+// A playlist-update conflict is an expected, user-resolvable outcome, so the
+// screen must NOT report it — spy on the reporter to prove that.
+const reportHandledErrorMock = vi.hoisted(() => vi.fn());
+const alertMock = vi.hoisted(() => vi.fn());
+vi.mock('../../../../src/lib/error-reporting', () => ({ reportHandledError: reportHandledErrorMock }));
 vi.mock('@boardsesh/playlists-react', () => ({
   usePlaylistClimbs: () => ({
     query: {
@@ -87,7 +92,7 @@ vi.mock('react-native', () => ({
     accessibilityLabel?: string;
   }) => createElement('button', { onClick: onPress, 'aria-label': accessibilityLabel }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1, absoluteFill: {} },
-  Alert: { alert: vi.fn() },
+  Alert: { alert: alertMock },
   Platform: { OS: 'ios' },
 }));
 
@@ -188,6 +193,8 @@ beforeEach(() => {
   climbsRefetch.mockClear();
   updatePlaylistMock.mockReset();
   toast.showToast.mockClear();
+  alertMock.mockReset();
+  reportHandledErrorMock.mockReset();
   playlistMocks.allClimbs = [];
   playlistMocks.activationOptions = null;
   playlistMocks.renderBoardResult = { renderBoard: null, banner: null };
@@ -347,5 +354,132 @@ describe('PlaylistDetail edit cache propagation', () => {
     });
     // A root toast would render behind the native sheet and be invisible.
     expect(toast.showToast).not.toHaveBeenCalledWith('edit.messages.updateFailed', 'error');
+  });
+});
+
+describe('PlaylistDetail edit conflict (#1934)', () => {
+  const cachedPlaylist = {
+    uuid: 'p-1',
+    id: 'p-1',
+    name: 'Old name',
+    icon: '🔥',
+    color: '#6D28D9',
+    description: '',
+    updatedAt: '2026-08-10T11:00:00.000Z',
+    climbCount: 3,
+    boardType: 'kilter',
+    layoutId: 1,
+    isPublic: false,
+    userRole: 'owner',
+    isPinnedByMe: false,
+    isFollowedByMe: false,
+    followerCount: 0,
+  };
+
+  // graphql-request's ClientError shape, as the backend's GraphQLError arrives.
+  const conflictError = {
+    response: {
+      errors: [
+        {
+          message: 'This playlist changed somewhere else',
+          extensions: {
+            code: 'PLAYLIST_UPDATE_CONFLICT',
+            playlistUuid: 'p-1',
+            serverUpdatedAt: '2026-08-10T12:30:00.000Z',
+            serverName: 'Renamed on the other phone',
+            serverDescription: null,
+            serverIsPublic: false,
+            serverColor: '#1F2937',
+            serverIcon: null,
+          },
+        },
+      ],
+    },
+  };
+
+  it('sends the cached playlist as basedOn so the server can refuse a collision', async () => {
+    requestMock.mockResolvedValue({ playlist: cachedPlaylist });
+    updatePlaylistMock.mockResolvedValue({ ...cachedPlaylist, name: 'Bad climbs' });
+
+    const { findByText } = renderDetail();
+    fireEvent.click(await findByText('form-submit'));
+
+    await waitFor(() => expect(updatePlaylistMock).toHaveBeenCalledTimes(1));
+    expect(updatePlaylistMock.mock.calls[0][0]).toMatchObject({
+      playlistId: 'p-1',
+      name: 'Bad climbs',
+      basedOn: {
+        updatedAt: '2026-08-10T11:00:00.000Z',
+        name: 'Old name',
+        description: '',
+        isPublic: false,
+        color: '#6D28D9',
+        icon: '🔥',
+      },
+    });
+  });
+
+  it('prompts instead of reporting a fault, and keeps the inline error clear', async () => {
+    requestMock.mockResolvedValue({ playlist: cachedPlaylist });
+    updatePlaylistMock.mockRejectedValue(conflictError);
+
+    const { findByText, container } = renderDetail();
+    fireEvent.click(await findByText('form-submit'));
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    expect(alertMock.mock.calls[0][0]).toBe('edit.conflict.title');
+    // A conflict is the climber's decision to make, not a fault to triage.
+    expect(reportHandledErrorMock).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-edit-error="true"]')).toBeNull();
+  });
+
+  it('"Keep mine" retries rebased on the server values from the conflict', async () => {
+    requestMock.mockResolvedValue({ playlist: cachedPlaylist });
+    updatePlaylistMock.mockRejectedValueOnce(conflictError);
+    updatePlaylistMock.mockResolvedValueOnce({ ...cachedPlaylist, name: 'Bad climbs' });
+
+    const { findByText } = renderDetail();
+    fireEvent.click(await findByText('form-submit'));
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    const buttons = alertMock.mock.calls[0][2] as Array<{ text: string; onPress?: () => void }>;
+    const keepMine = buttons.find((button) => button.text === 'edit.conflict.keepMine');
+    keepMine?.onPress?.();
+
+    await waitFor(() => expect(updatePlaylistMock).toHaveBeenCalledTimes(2));
+    // Rebased on what the server reported, so the second attempt overwrites
+    // deliberately rather than tripping the same check again.
+    expect(updatePlaylistMock.mock.calls[1][0]).toMatchObject({
+      name: 'Bad climbs',
+      basedOn: {
+        updatedAt: '2026-08-10T12:30:00.000Z',
+        name: 'Renamed on the other phone',
+        description: null,
+        isPublic: false,
+        color: '#1F2937',
+        icon: null,
+      },
+    });
+  });
+
+  it('"Use theirs" adopts the server version in the cache without another write', async () => {
+    requestMock.mockResolvedValue({ playlist: cachedPlaylist });
+    updatePlaylistMock.mockRejectedValue(conflictError);
+
+    const { queryClient, findByText } = renderDetail();
+    fireEvent.click(await findByText('form-submit'));
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledTimes(1));
+    const buttons = alertMock.mock.calls[0][2] as Array<{ text: string; onPress?: () => void }>;
+    buttons.find((button) => button.text === 'edit.conflict.keepTheirs')?.onPress?.();
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<{ name: string; updatedAt: string; color: string }>(['playlist', 'p-1']);
+      expect(cached?.name).toBe('Renamed on the other phone');
+      expect(cached?.updatedAt).toBe('2026-08-10T12:30:00.000Z');
+      expect(cached?.color).toBe('#1F2937');
+    });
+    // Adopting theirs is a local decision — nothing more is sent.
+    expect(updatePlaylistMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/src/lib/graphql/extract-error-message.ts
+++ b/packages/mobile/src/lib/graphql/extract-error-message.ts
@@ -83,12 +83,15 @@ export function isExpectedBetaValidationError(error: unknown): boolean {
   );
 }
 
-// The board-mutation rejections clients branch on are parsed in
+// The board- and playlist-mutation rejections clients branch on are parsed in
 // @boardsesh/graphql so web and mobile read the same shapes. Re-exported here so
-// board screens keep a single import for GraphQL error handling.
+// screens keep a single import for GraphQL error handling.
 export {
   isDuplicateBoardError,
   readDuplicateBoardError,
   isBoardLimitError,
+  isPlaylistUpdateConflictError,
+  readPlaylistUpdateConflict,
   type DuplicateBoardError,
+  type PlaylistUpdateConflict,
 } from '@boardsesh/graphql/errors';

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -1853,6 +1853,29 @@ input CreatePlaylistInput {
 }
 
 """
+The playlist as the client last saw it, sent alongside an edit so the server
+can refuse to silently overwrite someone else's change.
+
+Carries the metadata values as well as the timestamp on purpose: adding,
+removing or reordering a climb also bumps `updatedAt`, so a bare timestamp
+comparison would report a conflict for edits that don't actually collide.
+"""
+input PlaylistRevisionInput {
+  "The playlist's updatedAt when the client read it (ISO 8601)"
+  updatedAt: String!
+  "Name the client saw"
+  name: String
+  "Description the client saw"
+  description: String
+  "Visibility the client saw"
+  isPublic: Boolean
+  "Color the client saw"
+  color: String
+  "Icon the client saw"
+  icon: String
+}
+
+"""
 Input for updating a playlist.
 """
 input UpdatePlaylistInput {
@@ -1868,6 +1891,12 @@ input UpdatePlaylistInput {
   color: String
   "New icon"
   icon: String
+  """
+  Omit for blind last-write-wins (what pre-#1934 clients and web send).
+  Supply it to get a PLAYLIST_UPDATE_CONFLICT error instead of a silent
+  overwrite when the playlist changed somewhere else.
+  """
+  basedOn: PlaylistRevisionInput
 }
 
 """

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -4417,6 +4417,29 @@ export type PlaylistCreator = {
 };
 
 /**
+ * The playlist as the client last saw it, sent alongside an edit so the server
+ * can refuse to silently overwrite someone else's change.
+ *
+ * Carries the metadata values as well as the timestamp on purpose: adding,
+ * removing or reordering a climb also bumps `updatedAt`, so a bare timestamp
+ * comparison would report a conflict for edits that don't actually collide.
+ */
+export type PlaylistRevisionInput = {
+  /** Color the client saw */
+  color?: InputMaybe<Scalars['String']['input']>;
+  /** Description the client saw */
+  description?: InputMaybe<Scalars['String']['input']>;
+  /** Icon the client saw */
+  icon?: InputMaybe<Scalars['String']['input']>;
+  /** Visibility the client saw */
+  isPublic?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Name the client saw */
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** The playlist's updatedAt when the client read it (ISO 8601) */
+  updatedAt: Scalars['String']['input'];
+};
+
+/**
  * A popular board configuration (board type + layout + size + hold sets),
  * derived from the catalog of valid configurations ranked by climb count.
  */
@@ -7531,6 +7554,12 @@ export type UpdateGymKioskInput = {
 
 /** Input for updating a playlist. */
 export type UpdatePlaylistInput = {
+  /**
+   * Omit for blind last-write-wins (what pre-#1934 clients and web send).
+   * Supply it to get a PLAYLIST_UPDATE_CONFLICT error instead of a silent
+   * overwrite when the playlist changed somewhere else.
+   */
+  basedOn?: InputMaybe<PlaylistRevisionInput>;
   /** New color */
   color?: InputMaybe<Scalars['String']['input']>;
   /** New description */
@@ -8197,6 +8226,7 @@ export type ResolversTypes = ResolversObject<{
   PlaylistClimb: ResolverTypeWrapper<PlaylistClimb>;
   PlaylistClimbsResult: ResolverTypeWrapper<PlaylistClimbsResult>;
   PlaylistCreator: ResolverTypeWrapper<PlaylistCreator>;
+  PlaylistRevisionInput: PlaylistRevisionInput;
   PopularBoardConfig: ResolverTypeWrapper<PopularBoardConfig>;
   PopularBoardConfigConnection: ResolverTypeWrapper<PopularBoardConfigConnection>;
   PopularBoardConfigsInput: PopularBoardConfigsInput;
@@ -8547,6 +8577,7 @@ export type ResolversParentTypes = ResolversObject<{
   PlaylistClimb: PlaylistClimb;
   PlaylistClimbsResult: PlaylistClimbsResult;
   PlaylistCreator: PlaylistCreator;
+  PlaylistRevisionInput: PlaylistRevisionInput;
   PopularBoardConfig: PopularBoardConfig;
   PopularBoardConfigConnection: PopularBoardConfigConnection;
   PopularBoardConfigsInput: PopularBoardConfigsInput;

--- a/packages/shared-schema/src/index.ts
+++ b/packages/shared-schema/src/index.ts
@@ -12,3 +12,4 @@ export * from './aurora-import';
 export * from './moonboard-import';
 export * from './instagram-caption-parse';
 export * from './sync-error-codes';
+export * from './playlist-conflict';

--- a/packages/shared-schema/src/playlist-conflict.ts
+++ b/packages/shared-schema/src/playlist-conflict.ts
@@ -1,0 +1,56 @@
+/**
+ * ⚠️ READ THIS BEFORE ADDING ANOTHER OFFLINE-REPLAYABLE MUTATION ⚠️
+ *
+ * `updatePlaylist` is the ONE queued mutation that must never be auto-merged.
+ *
+ * Every other mutation the offline outbox replays is either idempotent (a tick
+ * upsert keyed by uuid, a favourite toggle, a playlist create keyed by a
+ * client-generated uuid) or commutative (adding, removing and reordering climbs
+ * inside a playlist — two devices doing both still converge on a sane list).
+ * Those can be replayed blind: the worst case is a redundant write.
+ *
+ * A playlist rename cannot. Two devices editing the same name produce two
+ * different intents, and picking one silently destroys the other. So the server
+ * refuses the write and hands the client both versions to choose between, using
+ * the code and extension shape below.
+ *
+ * If you add a mutation with the same property — a whole-record edit where the
+ * loser's intent is unrecoverable — REUSE `PLAYLIST_UPDATE_CONFLICT_CODE`'s
+ * shape (a code plus the server's current values) rather than inventing a new
+ * one, and give it a typed reader next to `readPlaylistUpdateConflict` in
+ * `@boardsesh/graphql/errors`. Clients already know how to prompt on this shape;
+ * a second shape means a second prompt to build and a second thing to forget.
+ *
+ * A conflict resolves to no HTTP/GraphQL numeric status, so the outbox's
+ * `isRetryable` returns false and the row dead-letters for the UI to resolve
+ * instead of burning its retry budget.
+ */
+
+/**
+ * The server refused a playlist metadata edit because the stored record moved on
+ * from the snapshot the client based its edit on, and the two disagree about at
+ * least one field being written.
+ *
+ * Only raised when the client opts in by sending `UpdatePlaylistInput.basedOn`.
+ * Omit it and the mutation stays blind last-write-wins, which is what pre-#1934
+ * clients (and web) do.
+ */
+export const PLAYLIST_UPDATE_CONFLICT_CODE = 'PLAYLIST_UPDATE_CONFLICT';
+
+/**
+ * What the server attaches to a `PLAYLIST_UPDATE_CONFLICT` error: the playlist's
+ * current stored values, so the client can name both versions in the prompt
+ * without a refetch, and rebuild `basedOn` for a "keep mine" retry.
+ */
+export type PlaylistUpdateConflictExtensions = {
+  code: typeof PLAYLIST_UPDATE_CONFLICT_CODE;
+  /** The playlist the edit targeted (its uuid, the client-facing id). */
+  playlistUuid: string;
+  /** The stored `updated_at`, ISO 8601 — the token a retry must be based on. */
+  serverUpdatedAt: string;
+  serverName: string;
+  serverDescription: string | null;
+  serverIsPublic: boolean;
+  serverColor: string | null;
+  serverIcon: string | null;
+};

--- a/packages/shared-schema/src/schema/playlists.ts
+++ b/packages/shared-schema/src/schema/playlists.ts
@@ -92,6 +92,29 @@ export const playlistsTypeDefs = /* GraphQL */ `
   }
 
   """
+  The playlist as the client last saw it, sent alongside an edit so the server
+  can refuse to silently overwrite someone else's change.
+
+  Carries the metadata values as well as the timestamp on purpose: adding,
+  removing or reordering a climb also bumps \`updatedAt\`, so a bare timestamp
+  comparison would report a conflict for edits that don't actually collide.
+  """
+  input PlaylistRevisionInput {
+    "The playlist's updatedAt when the client read it (ISO 8601)"
+    updatedAt: String!
+    "Name the client saw"
+    name: String
+    "Description the client saw"
+    description: String
+    "Visibility the client saw"
+    isPublic: Boolean
+    "Color the client saw"
+    color: String
+    "Icon the client saw"
+    icon: String
+  }
+
+  """
   Input for updating a playlist.
   """
   input UpdatePlaylistInput {
@@ -107,6 +130,12 @@ export const playlistsTypeDefs = /* GraphQL */ `
     color: String
     "New icon"
     icon: String
+    """
+    Omit for blind last-write-wins (what pre-#1934 clients and web send).
+    Supply it to get a PLAYLIST_UPDATE_CONFLICT error instead of a silent
+    overwrite when the playlist changed somewhere else.
+    """
+    basedOn: PlaylistRevisionInput
   }
 
   """

--- a/packages/shared/graphql/src/__tests__/errors.test.ts
+++ b/packages/shared/graphql/src/__tests__/errors.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { PLAYLIST_UPDATE_CONFLICT_CODE } from '@boardsesh/shared-schema';
+
+import { isPlaylistUpdateConflictError, readPlaylistUpdateConflict } from '../errors';
+
+const conflictExtensions = {
+  code: PLAYLIST_UPDATE_CONFLICT_CODE,
+  playlistUuid: 'pl-1',
+  serverUpdatedAt: '2026-08-10T12:00:00.000Z',
+  serverName: 'Renamed on the other phone',
+  serverDescription: 'theirs',
+  serverIsPublic: true,
+  serverColor: '#6D28D9',
+  serverIcon: '🔥',
+};
+
+describe('readPlaylistUpdateConflict', () => {
+  it('reads a graphql-request ClientError (response.errors[])', () => {
+    const clientError = {
+      response: { errors: [{ message: 'This playlist changed somewhere else', extensions: conflictExtensions }] },
+    };
+
+    expect(isPlaylistUpdateConflictError(clientError)).toBe(true);
+    expect(readPlaylistUpdateConflict(clientError)).toEqual({
+      playlistUuid: 'pl-1',
+      serverUpdatedAt: '2026-08-10T12:00:00.000Z',
+      serverName: 'Renamed on the other phone',
+      serverDescription: 'theirs',
+      serverIsPublic: true,
+      serverColor: '#6D28D9',
+      serverIcon: '🔥',
+    });
+  });
+
+  it('reads a re-thrown error carrying graphqlErrors[]', () => {
+    const rethrown = Object.assign(new Error('update failed'), {
+      graphqlErrors: [{ message: 'nope', extensions: conflictExtensions }],
+    });
+
+    expect(isPlaylistUpdateConflictError(rethrown)).toBe(true);
+    expect(readPlaylistUpdateConflict(rethrown)?.serverName).toBe('Renamed on the other phone');
+  });
+
+  it('reports absent optional server values as null, not undefined', () => {
+    const clientError = {
+      response: {
+        errors: [
+          {
+            extensions: {
+              code: PLAYLIST_UPDATE_CONFLICT_CODE,
+              playlistUuid: 'pl-1',
+              serverUpdatedAt: '2026-08-10T12:00:00.000Z',
+              serverName: 'Bare',
+              serverDescription: null,
+              serverIsPublic: false,
+              serverColor: null,
+              serverIcon: null,
+            },
+          },
+        ],
+      },
+    };
+
+    expect(readPlaylistUpdateConflict(clientError)).toEqual({
+      playlistUuid: 'pl-1',
+      serverUpdatedAt: '2026-08-10T12:00:00.000Z',
+      serverName: 'Bare',
+      serverDescription: null,
+      serverIsPublic: false,
+      serverColor: null,
+      serverIcon: null,
+    });
+  });
+
+  it('returns null for an unrelated error code', () => {
+    const otherError = { response: { errors: [{ extensions: { code: 'BOARD_LIMIT_REACHED' } }] } };
+
+    expect(isPlaylistUpdateConflictError(otherError)).toBe(false);
+    expect(readPlaylistUpdateConflict(otherError)).toBeNull();
+  });
+
+  it('returns null for a conflict whose identity extensions did not survive', () => {
+    // A proxy that strips extensions, or an older server: the caller can still
+    // tell it IS a conflict, but there is nothing to show or retry against.
+    const strippedError = { response: { errors: [{ extensions: { code: PLAYLIST_UPDATE_CONFLICT_CODE } }] } };
+
+    expect(isPlaylistUpdateConflictError(strippedError)).toBe(true);
+    expect(readPlaylistUpdateConflict(strippedError)).toBeNull();
+  });
+
+  it('returns null for a plain error with no GraphQL payload', () => {
+    expect(isPlaylistUpdateConflictError(new Error('network down'))).toBe(false);
+    expect(readPlaylistUpdateConflict(new Error('network down'))).toBeNull();
+  });
+});

--- a/packages/shared/graphql/src/errors.ts
+++ b/packages/shared/graphql/src/errors.ts
@@ -3,6 +3,8 @@
 // errors carrying `response.errors[]`; some call sites re-throw with
 // `graphqlErrors`, so both shapes are accepted.
 
+import { PLAYLIST_UPDATE_CONFLICT_CODE } from '@boardsesh/shared-schema';
+
 type GraphqlErrorLike = {
   message?: string;
   extensions?: {
@@ -85,4 +87,57 @@ export function readDuplicateBoardError(error: unknown): DuplicateBoardError | n
  */
 export function isBoardLimitError(error: unknown): boolean {
   return getGraphqlErrors(error).some((graphqlError) => graphqlError.extensions?.code === 'BOARD_LIMIT_REACHED');
+}
+
+/** The playlist as it stands on the server, per a rejected edit. */
+export type PlaylistUpdateConflict = {
+  playlistUuid: string;
+  /** The stored `updatedAt` — feed it back as `basedOn.updatedAt` to retry. */
+  serverUpdatedAt: string;
+  serverName: string;
+  serverDescription: string | null;
+  serverIsPublic: boolean;
+  serverColor: string | null;
+  serverIcon: string | null;
+};
+
+/**
+ * The server refusing a playlist edit because the playlist changed somewhere
+ * else since the client read it (#1934). Only raised for clients that opt in by
+ * sending `UpdatePlaylistInput.basedOn`.
+ *
+ * Expected and user-resolvable, not a fault to report: the climber picks a
+ * version. Use `readPlaylistUpdateConflict` to get the values to show them.
+ */
+export function isPlaylistUpdateConflictError(error: unknown): boolean {
+  return getGraphqlErrors(error).some(
+    (graphqlError) => graphqlError.extensions?.code === PLAYLIST_UPDATE_CONFLICT_CODE,
+  );
+}
+
+/**
+ * The server's current version of the playlist whose edit was refused, or null
+ * when the error is something else — or is a conflict whose identity extensions
+ * didn't survive (a proxy that strips them, an older server). Callers that only
+ * need to decide whether to prompt should use `isPlaylistUpdateConflictError`.
+ */
+export function readPlaylistUpdateConflict(error: unknown): PlaylistUpdateConflict | null {
+  for (const graphqlError of getGraphqlErrors(error)) {
+    if (graphqlError.extensions?.code !== PLAYLIST_UPDATE_CONFLICT_CODE) continue;
+    const playlistUuid = asString(graphqlError.extensions.playlistUuid);
+    const serverUpdatedAt = asString(graphqlError.extensions.serverUpdatedAt);
+    const serverName = asString(graphqlError.extensions.serverName);
+    // Without these three there is nothing to show and nothing to retry against.
+    if (!playlistUuid || !serverUpdatedAt || !serverName) continue;
+    return {
+      playlistUuid,
+      serverUpdatedAt,
+      serverName,
+      serverDescription: asString(graphqlError.extensions.serverDescription),
+      serverIsPublic: graphqlError.extensions.serverIsPublic === true,
+      serverColor: asString(graphqlError.extensions.serverColor),
+      serverIcon: asString(graphqlError.extensions.serverIcon),
+    };
+  }
+  return null;
 }

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -4414,6 +4414,29 @@ export type PlaylistCreator = {
 };
 
 /**
+ * The playlist as the client last saw it, sent alongside an edit so the server
+ * can refuse to silently overwrite someone else's change.
+ *
+ * Carries the metadata values as well as the timestamp on purpose: adding,
+ * removing or reordering a climb also bumps `updatedAt`, so a bare timestamp
+ * comparison would report a conflict for edits that don't actually collide.
+ */
+export type PlaylistRevisionInput = {
+  /** Color the client saw */
+  color?: InputMaybe<Scalars['String']['input']>;
+  /** Description the client saw */
+  description?: InputMaybe<Scalars['String']['input']>;
+  /** Icon the client saw */
+  icon?: InputMaybe<Scalars['String']['input']>;
+  /** Visibility the client saw */
+  isPublic?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Name the client saw */
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** The playlist's updatedAt when the client read it (ISO 8601) */
+  updatedAt: Scalars['String']['input'];
+};
+
+/**
  * A popular board configuration (board type + layout + size + hold sets),
  * derived from the catalog of valid configurations ranked by climb count.
  */
@@ -7528,6 +7551,12 @@ export type UpdateGymKioskInput = {
 
 /** Input for updating a playlist. */
 export type UpdatePlaylistInput = {
+  /**
+   * Omit for blind last-write-wins (what pre-#1934 clients and web send).
+   * Supply it to get a PLAYLIST_UPDATE_CONFLICT error instead of a silent
+   * overwrite when the playlist changed somewhere else.
+   */
+  basedOn?: InputMaybe<PlaylistRevisionInput>;
   /** New color */
   color?: InputMaybe<Scalars['String']['input']>;
   /** New description */

--- a/packages/shared/graphql/src/operations/playlists.ts
+++ b/packages/shared/graphql/src/operations/playlists.ts
@@ -331,6 +331,25 @@ export type CreatePlaylistMutationResponse = {
   createPlaylist: Playlist;
 };
 
+/**
+ * The playlist as the client last saw it. Send it with an edit to get a
+ * PLAYLIST_UPDATE_CONFLICT error (read it with `readPlaylistUpdateConflict`)
+ * instead of silently overwriting a change made somewhere else (#1934).
+ *
+ * Every field the edit writes should be included, not just `updatedAt`: adding
+ * or reordering a climb bumps the playlist's `updatedAt` too, so the server
+ * compares values as well as the timestamp to avoid crying conflict over an
+ * edit that doesn't actually collide.
+ */
+export type PlaylistRevision = {
+  updatedAt: string;
+  name?: string | null;
+  description?: string | null;
+  isPublic?: boolean | null;
+  color?: string | null;
+  icon?: string | null;
+};
+
 export type UpdatePlaylistInput = {
   playlistId: string;
   name?: string;
@@ -338,6 +357,8 @@ export type UpdatePlaylistInput = {
   isPublic?: boolean;
   color?: string;
   icon?: string;
+  /** Omit for blind last-write-wins (what web still does). */
+  basedOn?: PlaylistRevision;
 };
 
 export type UpdatePlaylistMutationVariables = {

--- a/packages/shared/i18n/locales/de/playlists.json
+++ b/packages/shared/i18n/locales/de/playlists.json
@@ -204,6 +204,7 @@
     "conflict": {
       "title": "Woanders geändert",
       "message": "Diese Playlist heißt jetzt „{{serverName}}“. Deine Änderung sagt „{{yourName}}“.",
+      "changedAgain": "Sie hat sich noch mal geändert, während du überlegt hast. Speichere noch einmal, um sie zu übernehmen.",
       "keepMine": "Meine behalten",
       "keepTheirs": "Die andere nehmen",
       "cancel": "Abbrechen"

--- a/packages/shared/i18n/locales/de/playlists.json
+++ b/packages/shared/i18n/locales/de/playlists.json
@@ -204,6 +204,7 @@
     "conflict": {
       "title": "Woanders geändert",
       "message": "Diese Playlist heißt jetzt „{{serverName}}“. Deine Änderung sagt „{{yourName}}“.",
+      "messageDetails": "Jemand anders hat die Details dieser Playlist geändert, während du bearbeitet hast. Der Name ist gleich – wähle, welche Version vom Rest bleibt.",
       "changedAgain": "Sie hat sich noch mal geändert, während du überlegt hast. Speichere noch einmal, um sie zu übernehmen.",
       "keepMine": "Meine behalten",
       "keepTheirs": "Die andere nehmen",

--- a/packages/shared/i18n/locales/de/playlists.json
+++ b/packages/shared/i18n/locales/de/playlists.json
@@ -200,6 +200,13 @@
     "messages": {
       "updated": "Playlist aktualisiert",
       "updateFailed": "Die Playlist ließ sich nicht aktualisieren"
+    },
+    "conflict": {
+      "title": "Woanders geändert",
+      "message": "Diese Playlist heißt jetzt „{{serverName}}“. Deine Änderung sagt „{{yourName}}“.",
+      "keepMine": "Meine behalten",
+      "keepTheirs": "Die andere nehmen",
+      "cancel": "Abbrechen"
     }
   },
   "create": {

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -200,6 +200,13 @@
     "messages": {
       "updated": "Playlist updated successfully",
       "updateFailed": "Failed to update playlist"
+    },
+    "conflict": {
+      "title": "Changed somewhere else",
+      "message": "This playlist is saved as “{{serverName}}” now. Your edit says “{{yourName}}”.",
+      "keepMine": "Keep mine",
+      "keepTheirs": "Use theirs",
+      "cancel": "Cancel"
     }
   },
   "create": {

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -204,6 +204,7 @@
     "conflict": {
       "title": "Changed somewhere else",
       "message": "This playlist is saved as “{{serverName}}” now. Your edit says “{{yourName}}”.",
+      "changedAgain": "It changed again while you were deciding. Save again to pick it up.",
       "keepMine": "Keep mine",
       "keepTheirs": "Use theirs",
       "cancel": "Cancel"

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -204,6 +204,7 @@
     "conflict": {
       "title": "Changed somewhere else",
       "message": "This playlist is saved as “{{serverName}}” now. Your edit says “{{yourName}}”.",
+      "messageDetails": "Someone else changed this playlist’s details while you were editing. The name matches, so pick which version of the rest to keep.",
       "changedAgain": "It changed again while you were deciding. Save again to pick it up.",
       "keepMine": "Keep mine",
       "keepTheirs": "Use theirs",

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -204,6 +204,7 @@
     "conflict": {
       "title": "Cambió en otro sitio",
       "message": "Esta lista ahora se llama «{{serverName}}». Tu edición dice «{{yourName}}».",
+      "messageDetails": "Otra persona cambió los detalles de esta lista mientras editabas. El nombre coincide, así que elige con qué versión del resto te quedas.",
       "changedAgain": "Volvió a cambiar mientras decidías. Guarda otra vez para verlo.",
       "keepMine": "Quedarme con la mía",
       "keepTheirs": "Usar la otra",

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -200,6 +200,13 @@
     "messages": {
       "updated": "Lista actualizada correctamente",
       "updateFailed": "No se pudo actualizar la lista"
+    },
+    "conflict": {
+      "title": "Cambió en otro sitio",
+      "message": "Esta lista ahora se llama «{{serverName}}». Tu edición dice «{{yourName}}».",
+      "keepMine": "Quedarme con la mía",
+      "keepTheirs": "Usar la otra",
+      "cancel": "Cancelar"
     }
   },
   "create": {

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -204,6 +204,7 @@
     "conflict": {
       "title": "Cambió en otro sitio",
       "message": "Esta lista ahora se llama «{{serverName}}». Tu edición dice «{{yourName}}».",
+      "changedAgain": "Volvió a cambiar mientras decidías. Guarda otra vez para verlo.",
       "keepMine": "Quedarme con la mía",
       "keepTheirs": "Usar la otra",
       "cancel": "Cancelar"

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -204,6 +204,7 @@
     "conflict": {
       "title": "Modifiée ailleurs",
       "message": "Cette playlist s’appelle maintenant « {{serverName}} ». Votre modification dit « {{yourName}} ».",
+      "changedAgain": "Elle a encore changé pendant que vous décidiez. Enregistrez à nouveau pour la reprendre.",
       "keepMine": "Garder la mienne",
       "keepTheirs": "Garder l’autre",
       "cancel": "Annuler"

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -200,6 +200,13 @@
     "messages": {
       "updated": "Playlist mise à jour",
       "updateFailed": "Impossible de mettre à jour la playlist"
+    },
+    "conflict": {
+      "title": "Modifiée ailleurs",
+      "message": "Cette playlist s’appelle maintenant « {{serverName}} ». Votre modification dit « {{yourName}} ».",
+      "keepMine": "Garder la mienne",
+      "keepTheirs": "Garder l’autre",
+      "cancel": "Annuler"
     }
   },
   "create": {

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -204,6 +204,7 @@
     "conflict": {
       "title": "Modifiée ailleurs",
       "message": "Cette playlist s’appelle maintenant « {{serverName}} ». Votre modification dit « {{yourName}} ».",
+      "messageDetails": "Quelqu’un a modifié les détails de cette playlist pendant votre édition. Le nom est identique : choisissez quelle version garder pour le reste.",
       "changedAgain": "Elle a encore changé pendant que vous décidiez. Enregistrez à nouveau pour la reprendre.",
       "keepMine": "Garder la mienne",
       "keepTheirs": "Garder l’autre",

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
@@ -348,3 +348,31 @@ describe('isNetworkError / isRetryable — resolved status beats the English-pro
     expect(isRetryable(error)).toBe(true);
   });
 });
+
+describe('PLAYLIST_UPDATE_CONFLICT (#1934)', () => {
+  // A rename the server refused is a decision for the climber, not something to
+  // replay. It must dead-letter so the UI can surface it, rather than looping.
+  const conflictError = {
+    response: {
+      errors: [
+        {
+          message: 'This playlist changed somewhere else',
+          extensions: {
+            code: 'PLAYLIST_UPDATE_CONFLICT',
+            playlistUuid: 'pl-1',
+            serverUpdatedAt: '2026-08-10T12:00:00.000Z',
+            serverName: 'Renamed on the other phone',
+          },
+        },
+      ],
+    },
+  };
+
+  it('is not a network error and not retryable, so the drainer dead-letters it', () => {
+    // The string code resolves no numeric status, which is exactly what routes
+    // it to the dead-letter branch instead of the retry budget.
+    expect(getErrorStatus(conflictError)).toBeNull();
+    expect(isNetworkError(conflictError)).toBe(false);
+    expect(isRetryable(conflictError)).toBe(false);
+  });
+});

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/handlers.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/handlers.test.ts
@@ -92,3 +92,30 @@ describe('boardsesh_ticks update dispatch', () => {
     expect(variables).toEqual({ uuid: 'tick-uuid-3', input: { angle: 25 } });
   });
 });
+
+describe('playlists update dispatch', () => {
+  it('carries the basedOn snapshot through to UpdatePlaylistInput (#1934)', async () => {
+    const graphqlFetch = vi.fn().mockResolvedValue({});
+    const basedOn = {
+      updatedAt: '2026-08-10T11:00:00.000Z',
+      name: 'Crimps',
+      description: null,
+      isPublic: false,
+      color: '#6D28D9',
+      icon: '🔥',
+    };
+    const mutation = pendingMutation({
+      table_name: 'playlists',
+      operation: 'update',
+      payload: JSON.stringify({ playlistId: 'pl-1', name: 'Renamed offline', basedOn }),
+    });
+
+    await processMutation(mutation, graphqlFetch);
+
+    const [query, variables] = graphqlFetch.mock.calls[0];
+    expect(query).toContain('UpdatePlaylist');
+    // A rename is the one replay the server can't auto-merge, so the snapshot
+    // must survive the queue round-trip intact.
+    expect(variables).toEqual({ input: { playlistId: 'pl-1', name: 'Renamed offline', basedOn } });
+  });
+});

--- a/packages/shared/offline-sync/src/mutation-queue/handlers.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/handlers.ts
@@ -114,6 +114,22 @@ function buildDispatch(mutation: PendingMutation): MutationDispatch {
             mutationName: 'CreatePlaylist',
             variables: { input: { uuid: mutation.idempotency_key, ...payload } },
           };
+        // ⚠️ The ONLY queued mutation that cannot be auto-merged (#1934).
+        //
+        // Everything else this file dispatches is idempotent (uuid-keyed tick
+        // and playlist creates, favourite toggles) or commutative (climb
+        // add/remove/reorder). A playlist rename is neither: two devices editing
+        // the name produce two intents and replaying blind destroys one.
+        //
+        // So the payload must carry `basedOn` — the playlist as the enqueuing
+        // device saw it — and the server answers a genuine collision with
+        // PLAYLIST_UPDATE_CONFLICT. That error resolves to no HTTP/GraphQL
+        // numeric status, so `isRetryable` returns false and the drainer
+        // dead-letters the row for the UI to resolve instead of burning retries.
+        //
+        // Adding another whole-record edit here? Give it the same treatment
+        // rather than a new error shape — see PLAYLIST_UPDATE_CONFLICT_CODE's
+        // doc block in @boardsesh/shared-schema.
         case 'update':
           return {
             mutationName: 'UpdatePlaylist',

--- a/packages/web/app/components/library/__tests__/playlist-edit-drawer.test.tsx
+++ b/packages/web/app/components/library/__tests__/playlist-edit-drawer.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import React from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import { createTestQueryClient } from '@/app/test-utils/test-providers';
 import PlaylistEditDrawer from '../playlist-edit-drawer';
 import type { Playlist } from '@boardsesh/graphql/operations/playlists';
 
@@ -74,7 +76,12 @@ describe('PlaylistEditDrawer', () => {
   function renderDrawer(playlist: Playlist) {
     const onClose = vi.fn();
     const onSuccess = vi.fn();
-    render(<PlaylistEditDrawer open playlist={playlist} onClose={onClose} onSuccess={onSuccess} />);
+    const queryClient = createTestQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <PlaylistEditDrawer open playlist={playlist} onClose={onClose} onSuccess={onSuccess} />
+      </QueryClientProvider>,
+    );
     return { onClose, onSuccess };
   }
 
@@ -103,6 +110,14 @@ describe('PlaylistEditDrawer', () => {
         color: '#ff0000',
         icon: '',
         isPublic: false,
+        basedOn: {
+          updatedAt: '2026-01-01T00:00:00Z',
+          name: 'Crimp circuit',
+          description: 'Ten hard ones',
+          isPublic: false,
+          color: '#ff0000',
+          icon: '🔥',
+        },
       },
     });
     expect(token).toBe('test-token');
@@ -129,6 +144,14 @@ describe('PlaylistEditDrawer', () => {
         color: '#ff0000',
         icon: '🔥',
         isPublic: false,
+        basedOn: {
+          updatedAt: '2026-01-01T00:00:00Z',
+          name: 'Crimp circuit',
+          description: 'Ten hard ones',
+          isPublic: false,
+          color: '#ff0000',
+          icon: '🔥',
+        },
       },
     });
   });
@@ -152,6 +175,38 @@ describe('PlaylistEditDrawer', () => {
         color: '',
         icon: '',
         isPublic: false,
+        basedOn: {
+          updatedAt: '2026-01-01T00:00:00Z',
+          name: 'Crimp circuit',
+          description: null,
+          isPublic: false,
+          color: null,
+          icon: null,
+        },
+      },
+    });
+  });
+
+  it('sends no basedOn when the playlist has no updatedAt (a stale pre-field cache)', async () => {
+    const playlist = createPlaylist({ updatedAt: '' });
+    mockExecuteGraphQL.mockResolvedValueOnce({ updatePlaylist: playlist });
+    renderDrawer(playlist);
+
+    await waitFor(() => expect(getDescriptionField().value).toBe('Ten hard ones'));
+    fireEvent.click(getSave());
+
+    await waitFor(() => expect(mockExecuteGraphQL).toHaveBeenCalledTimes(1));
+
+    const [, variables] = mockExecuteGraphQL.mock.calls[0];
+    expect(variables).toEqual({
+      input: {
+        playlistId: 'pl-uuid-1',
+        name: 'Crimp circuit',
+        description: 'Ten hard ones',
+        color: '#ff0000',
+        icon: '🔥',
+        isPublic: false,
+        basedOn: undefined,
       },
     });
   });
@@ -168,5 +223,165 @@ describe('PlaylistEditDrawer', () => {
     );
     expect(onSuccess).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  function conflictError(overrides?: Partial<Record<string, unknown>>) {
+    return {
+      response: {
+        errors: [
+          {
+            message: 'Playlist changed since you loaded it',
+            extensions: {
+              code: 'PLAYLIST_UPDATE_CONFLICT',
+              playlistUuid: 'pl-uuid-1',
+              serverUpdatedAt: '2026-01-02T00:00:00Z',
+              serverName: 'Crimp circuit',
+              serverDescription: 'Rewritten by someone else',
+              serverIsPublic: true,
+              serverColor: '#00ff00',
+              serverIcon: '⭐',
+              ...overrides,
+            },
+          },
+        ],
+      },
+    };
+  }
+
+  it('renders the conflict dialog quoting both names when the mutation is refused', async () => {
+    const playlist = createPlaylist();
+    mockExecuteGraphQL.mockRejectedValueOnce(conflictError({ serverName: 'Someone else renamed this' }));
+    renderDrawer(playlist);
+
+    await waitFor(() => expect(getDescriptionField().value).toBe('Ten hard ones'));
+    fireEvent.change(screen.getByPlaceholderText(tFromCatalog('playlists', 'edit.fields.namePlaceholder')), {
+      target: { value: 'My new name' },
+    });
+    fireEvent.click(getSave());
+
+    await waitFor(() => expect(screen.getByText(tFromCatalog('playlists', 'edit.conflict.title'))).toBeTruthy());
+    expect(
+      screen.getByText(
+        tFromCatalog('playlists', 'edit.conflict.message', {
+          serverName: 'Someone else renamed this',
+          yourName: 'My new name',
+        }),
+      ),
+    ).toBeTruthy();
+    // Only one attempt so far — the dialog is a resolution step, not a retry.
+    expect(mockExecuteGraphQL).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the messageDetails wording when the server kept the same name', async () => {
+    const playlist = createPlaylist();
+    mockExecuteGraphQL.mockRejectedValueOnce(conflictError({ serverName: 'Crimp circuit' }));
+    renderDrawer(playlist);
+
+    await waitFor(() => expect(getDescriptionField().value).toBe('Ten hard ones'));
+    fireEvent.click(getSave());
+
+    await waitFor(() =>
+      expect(screen.getByText(tFromCatalog('playlists', 'edit.conflict.messageDetails'))).toBeTruthy(),
+    );
+  });
+
+  it('"Use theirs" adopts the server values without a second mutation call', async () => {
+    const playlist = createPlaylist();
+    mockExecuteGraphQL.mockRejectedValueOnce(conflictError());
+    const { onSuccess, onClose } = renderDrawer(playlist);
+
+    await waitFor(() => expect(getDescriptionField().value).toBe('Ten hard ones'));
+    fireEvent.click(getSave());
+    await waitFor(() => expect(screen.getByText(tFromCatalog('playlists', 'edit.conflict.title'))).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: tFromCatalog('playlists', 'edit.conflict.keepTheirs') }));
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+    expect(onSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Crimp circuit',
+        description: 'Rewritten by someone else',
+        isPublic: true,
+        color: '#00ff00',
+        icon: '⭐',
+        updatedAt: '2026-01-02T00:00:00Z',
+      }),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(mockExecuteGraphQL).toHaveBeenCalledTimes(1);
+  });
+
+  it('"Keep mine" retries the mutation basedOn the server values', async () => {
+    const playlist = createPlaylist();
+    mockExecuteGraphQL.mockRejectedValueOnce(conflictError());
+    mockExecuteGraphQL.mockResolvedValueOnce({ updatePlaylist: playlist });
+    const { onSuccess } = renderDrawer(playlist);
+
+    await waitFor(() => expect(getDescriptionField().value).toBe('Ten hard ones'));
+    fireEvent.click(getSave());
+    await waitFor(() => expect(screen.getByText(tFromCatalog('playlists', 'edit.conflict.title'))).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: tFromCatalog('playlists', 'edit.conflict.keepMine') }));
+
+    await waitFor(() => expect(mockExecuteGraphQL).toHaveBeenCalledTimes(2));
+    const [, variables] = mockExecuteGraphQL.mock.calls[1];
+    expect((variables as { input: { basedOn: unknown } }).input.basedOn).toEqual({
+      updatedAt: '2026-01-02T00:00:00Z',
+      name: 'Crimp circuit',
+      description: 'Rewritten by someone else',
+      isPublic: true,
+      color: '#00ff00',
+      icon: '⭐',
+    });
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+  });
+
+  it('shows the changedAgain message inline when the retry conflicts again, without calling onSuccess', async () => {
+    const playlist = createPlaylist();
+    mockExecuteGraphQL.mockRejectedValueOnce(conflictError());
+    mockExecuteGraphQL.mockRejectedValueOnce(conflictError({ serverUpdatedAt: '2026-01-03T00:00:00Z' }));
+    const { onSuccess } = renderDrawer(playlist);
+
+    await waitFor(() => expect(getDescriptionField().value).toBe('Ten hard ones'));
+    fireEvent.click(getSave());
+    await waitFor(() => expect(screen.getByText(tFromCatalog('playlists', 'edit.conflict.title'))).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: tFromCatalog('playlists', 'edit.conflict.keepMine') }));
+
+    await waitFor(() =>
+      expect(mockShowMessage).toHaveBeenCalledWith(tFromCatalog('playlists', 'edit.conflict.changedAgain'), 'error'),
+    );
+    expect(onSuccess).not.toHaveBeenCalled();
+    // The dialog itself closes rather than chaining another prompt. MUI's
+    // Dialog stays mounted through its exit transition, so give it room to
+    // finish rather than asserting removal synchronously.
+    await waitFor(() => expect(screen.queryByText(tFromCatalog('playlists', 'edit.conflict.title'))).toBeNull(), {
+      timeout: 2000,
+    });
+  });
+
+  it('cancelling the conflict dialog keeps the drawer open with the edit intact', async () => {
+    const playlist = createPlaylist();
+    mockExecuteGraphQL.mockRejectedValueOnce(conflictError());
+    const { onClose } = renderDrawer(playlist);
+
+    await waitFor(() => expect(getDescriptionField().value).toBe('Ten hard ones'));
+    fireEvent.change(screen.getByPlaceholderText(tFromCatalog('playlists', 'edit.fields.namePlaceholder')), {
+      target: { value: 'My new name' },
+    });
+    fireEvent.click(getSave());
+    await waitFor(() => expect(screen.getByText(tFromCatalog('playlists', 'edit.conflict.title'))).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: tFromCatalog('playlists', 'edit.conflict.cancel') }));
+
+    // MUI's Dialog stays mounted through its exit transition, so give it
+    // room to finish rather than asserting removal synchronously.
+    await waitFor(() => expect(screen.queryByText(tFromCatalog('playlists', 'edit.conflict.title'))).toBeNull(), {
+      timeout: 2000,
+    });
+    expect(onClose).not.toHaveBeenCalled();
+    expect(
+      (screen.getByPlaceholderText(tFromCatalog('playlists', 'edit.fields.namePlaceholder')) as HTMLInputElement).value,
+    ).toBe('My new name');
   });
 });

--- a/packages/web/app/components/library/playlist-edit-drawer.tsx
+++ b/packages/web/app/components/library/playlist-edit-drawer.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import dynamic from 'next/dynamic';
+import { useQueryClient } from '@tanstack/react-query';
 import { useSnackbar } from '@/app/components/providers/snackbar-provider';
 import MuiButton from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
@@ -13,14 +14,21 @@ import MuiSwitch from '@mui/material/Switch';
 import SwipeableDrawer from '@/app/components/swipeable-drawer/swipeable-drawer';
 import Popover from '@mui/material/Popover';
 import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
 import { PublicOutlined, LockOutlined, CloseOutlined } from '@mui/icons-material';
 import { executeGraphQL } from '@/app/lib/graphql/client';
 import {
   type UpdatePlaylistMutationResponse,
   type UpdatePlaylistMutationVariables,
   type Playlist,
+  type PlaylistRevision,
   UPDATE_PLAYLIST,
 } from '@boardsesh/graphql/operations/playlists';
+import { readPlaylistUpdateConflict, type PlaylistUpdateConflict } from '@boardsesh/graphql/errors';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { themeTokens } from '@/app/theme/theme-config';
 
@@ -64,6 +72,12 @@ type PlaylistEditDrawerProps = {
 
 const INITIAL_FORM_VALUES = { name: '', description: '', color: '', icon: '', isPublic: false };
 
+// The conflict payload plus the name the climber actually typed, so the
+// dialog can decide between the name-vs-name wording and the "details
+// changed" wording (the server also conflicts on description/colour/icon/
+// visibility, so both sides can carry the same name).
+type PendingConflict = { data: PlaylistUpdateConflict; submittedName: string };
+
 export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess }: PlaylistEditDrawerProps) {
   const { t } = useTranslation('playlists');
   const [formValues, setFormValues] = useState(INITIAL_FORM_VALUES);
@@ -71,8 +85,10 @@ export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess 
   const [loading, setLoading] = useState(false);
   const [isPublic, setIsPublic] = useState(playlist.isPublic);
   const [emojiAnchor, setEmojiAnchor] = useState<HTMLElement | null>(null);
+  const [conflict, setConflict] = useState<PendingConflict | null>(null);
   const { token } = useWsAuthToken();
   const { showMessage } = useSnackbar();
+  const queryClient = useQueryClient();
 
   // Reset form when drawer opens with new playlist
   useEffect(() => {
@@ -86,8 +102,16 @@ export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess 
       });
       setFormErrors({});
       setIsPublic(playlist.isPublic);
+      setConflict(null);
     }
   }, [open, playlist]);
+
+  // The only web cache of the playlist library ('use-climb-actions-data.tsx')
+  // is keyed ['userPlaylists', token] — invalidate the whole prefix so the
+  // Add-to-Playlist picker picks up a rename alongside the detail page.
+  const invalidatePlaylistLists = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ['userPlaylists'] });
+  }, [queryClient]);
 
   const validateForm = (): boolean => {
     const errors: Record<string, string> = {};
@@ -103,14 +127,11 @@ export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess 
     return Object.keys(errors).length === 0;
   };
 
-  const handleSubmit = useCallback(async () => {
-    if (!validateForm()) {
-      return;
-    }
-
-    try {
-      setLoading(true);
-
+  // Sends the mutation with the given conflict snapshot. Used both for the
+  // first attempt (basedOn the loaded playlist) and for a "Keep mine" retry
+  // (basedOn the server's own values, so the overwrite is deliberate).
+  const saveEdit = useCallback(
+    async (basedOn: PlaylistRevision | undefined) => {
       // Extract and validate hex color
       let colorHex: string | undefined;
       if (!formValues.color) {
@@ -132,26 +153,123 @@ export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess 
             color: colorHex,
             icon: formValues.icon,
             isPublic: formValues.isPublic,
+            basedOn,
           },
         },
         token,
       );
 
+      invalidatePlaylistLists();
       showMessage(t('edit.messages.updated'), 'success');
       onSuccess(response.updatePlaylist);
       onClose();
+    },
+    [formValues, playlist.uuid, token, onSuccess, onClose, showMessage, t, invalidatePlaylistLists],
+  );
+
+  const handleSubmit = useCallback(async () => {
+    if (!validateForm()) {
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setConflict(null);
+
+      // What this edit is based on. The server compares it against the
+      // stored row and refuses rather than silently overwriting a rename
+      // made on another device or client (#1934, #4267). A playlist without
+      // updatedAt (a stale pre-field cache/SSR payload) falls back to the
+      // old last-write-wins.
+      await saveEdit(
+        playlist.updatedAt
+          ? {
+              updatedAt: playlist.updatedAt,
+              name: playlist.name,
+              description: playlist.description ?? null,
+              isPublic: playlist.isPublic,
+              color: playlist.color ?? null,
+              icon: playlist.icon ?? null,
+            }
+          : undefined,
+      );
     } catch (error) {
+      // Checked BEFORE reporting: a conflict is an expected outcome the
+      // climber resolves, not a fault.
+      const conflictData = readPlaylistUpdateConflict(error);
+      if (conflictData) {
+        setConflict({ data: conflictData, submittedName: formValues.name });
+        return;
+      }
       console.error('Error updating playlist:', error);
       showMessage(t('edit.messages.updateFailed'), 'error');
     } finally {
       setLoading(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formValues, playlist.uuid, token, onSuccess, onClose, showMessage]);
+  }, [saveEdit, playlist, formValues.name, showMessage, t]);
+
+  // "Use theirs": no network call — adopt the server's version by merging the
+  // conflict payload over the currently loaded playlist, same shape a
+  // successful save would hand back.
+  const handleUseTheirs = useCallback(() => {
+    if (!conflict) return;
+    const adopted: Playlist = {
+      ...playlist,
+      name: conflict.data.serverName,
+      description: conflict.data.serverDescription ?? undefined,
+      isPublic: conflict.data.serverIsPublic,
+      color: conflict.data.serverColor ?? undefined,
+      icon: conflict.data.serverIcon ?? undefined,
+      updatedAt: conflict.data.serverUpdatedAt,
+    };
+    invalidatePlaylistLists();
+    setConflict(null);
+    onSuccess(adopted);
+    onClose();
+  }, [conflict, playlist, invalidatePlaylistLists, onSuccess, onClose]);
+
+  // "Keep mine": retry the save re-based on the server's own values, so the
+  // overwrite is deliberate rather than an accidental repeat of the same
+  // conflict.
+  const handleKeepMine = useCallback(async () => {
+    if (!conflict) return;
+    setLoading(true);
+    try {
+      await saveEdit({
+        updatedAt: conflict.data.serverUpdatedAt,
+        name: conflict.data.serverName,
+        description: conflict.data.serverDescription,
+        isPublic: conflict.data.serverIsPublic,
+        color: conflict.data.serverColor,
+        icon: conflict.data.serverIcon,
+      });
+      setConflict(null);
+    } catch (retryError) {
+      // A third device can land between this prompt and the retry. Say so
+      // inline rather than chaining another prompt — a prompt chain has no
+      // natural end. Saving again from the still-open drawer re-prompts with
+      // the newest server values.
+      if (readPlaylistUpdateConflict(retryError)) {
+        setConflict(null);
+        showMessage(t('edit.conflict.changedAgain'), 'error');
+        return;
+      }
+      console.error('Error updating playlist:', retryError);
+      showMessage(t('edit.messages.updateFailed'), 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [conflict, saveEdit, showMessage, t]);
+
+  const handleConflictCancel = useCallback(() => {
+    setConflict(null);
+  }, []);
 
   const handleCancel = useCallback(() => {
     setFormValues(INITIAL_FORM_VALUES);
     setFormErrors({});
+    setConflict(null);
     onClose();
   }, [onClose]);
 
@@ -160,139 +278,169 @@ export default function PlaylistEditDrawer({ open, playlist, onClose, onSuccess 
     setFormValues((prev) => ({ ...prev, isPublic: checked }));
   }, []);
 
+  // The server also conflicts on description, colour, icon and visibility,
+  // so the two names can be identical. Quoting them back would read as
+  // "saved as X now, your edit says X" — say the details diverged instead.
+  const conflictMessage = conflict
+    ? conflict.data.serverName === conflict.submittedName
+      ? t('edit.conflict.messageDetails')
+      : t('edit.conflict.message', { serverName: conflict.data.serverName, yourName: conflict.submittedName })
+    : '';
+
   return (
-    <SwipeableDrawer
-      title={t('edit.title')}
-      open={open}
-      onClose={handleCancel}
-      placement="bottom"
-      styles={{
-        wrapper: { height: 'auto' },
-        body: {
-          paddingBottom: `${themeTokens.spacing[6]}px`,
-        },
-      }}
-      extra={
-        <Stack direction="row" spacing={1}>
-          <MuiButton variant="outlined" onClick={handleCancel}>
-            {t('edit.actions.cancel')}
-          </MuiButton>
-          <MuiButton variant="contained" onClick={handleSubmit} disabled={loading}>
-            {loading ? t('edit.actions.saving') : t('edit.actions.save')}
-          </MuiButton>
-        </Stack>
-      }
-    >
-      <Box sx={{ maxWidth: 600, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
-        <Box>
-          <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-            {t('edit.fields.name')}
-          </Typography>
-          <TextField
-            placeholder={t('edit.fields.namePlaceholder')}
-            slotProps={{ htmlInput: { maxLength: 100 } }}
-            fullWidth
-            size="small"
-            value={formValues.name}
-            onChange={(e) => {
-              setFormValues((prev) => ({ ...prev, name: e.target.value }));
-              setFormErrors((prev) => ({ ...prev, name: '' }));
-            }}
-            error={!!formErrors.name}
-            helperText={formErrors.name}
-          />
-        </Box>
-
-        <Box>
-          <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-            {t('edit.fields.description')}
-          </Typography>
-          <TextField
-            placeholder={t('edit.fields.descriptionPlaceholder')}
-            multiline
-            rows={3}
-            slotProps={{ htmlInput: { maxLength: 500 } }}
-            fullWidth
-            size="small"
-            value={formValues.description}
-            onChange={(e) => {
-              setFormValues((prev) => ({ ...prev, description: e.target.value }));
-              setFormErrors((prev) => ({ ...prev, description: '' }));
-            }}
-            error={!!formErrors.description}
-            helperText={formErrors.description}
-          />
-        </Box>
-
-        <Box>
-          <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-            {t('edit.fields.color')}
-          </Typography>
-          <TextField
-            type="color"
-            value={formValues.color || '#000000'}
-            onChange={(e) => setFormValues((prev) => ({ ...prev, color: e.target.value }))}
-            size="small"
-            sx={{ width: 80 }}
-          />
-        </Box>
-
-        <Box>
-          <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-            {t('edit.fields.icon')}
-          </Typography>
-          <Stack direction="row" spacing={1} alignItems="center">
-            <MuiButton
-              variant="outlined"
-              onClick={(e) => setEmojiAnchor(e.currentTarget)}
-              sx={{ minWidth: 48, height: 48, fontSize: 24, lineHeight: 1 }}
-            >
-              {formValues.icon || '+'}
+    <>
+      <SwipeableDrawer
+        title={t('edit.title')}
+        open={open}
+        onClose={handleCancel}
+        placement="bottom"
+        styles={{
+          wrapper: { height: 'auto' },
+          body: {
+            paddingBottom: `${themeTokens.spacing[6]}px`,
+          },
+        }}
+        extra={
+          <Stack direction="row" spacing={1}>
+            <MuiButton variant="outlined" onClick={handleCancel}>
+              {t('edit.actions.cancel')}
             </MuiButton>
-            {formValues.icon && (
-              <MuiButton
-                variant="text"
-                size="small"
-                startIcon={<CloseOutlined />}
-                onClick={() => setFormValues((prev) => ({ ...prev, icon: '' }))}
-              >
-                {t('edit.fields.removeIcon')}
-              </MuiButton>
-            )}
+            <MuiButton variant="contained" onClick={handleSubmit} disabled={loading}>
+              {loading ? t('edit.actions.saving') : t('edit.actions.save')}
+            </MuiButton>
           </Stack>
-          <Popover
-            open={Boolean(emojiAnchor)}
-            anchorEl={emojiAnchor}
-            onClose={() => setEmojiAnchor(null)}
-            anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-          >
-            <EmojiPicker
-              onEmojiSelect={(emoji: { native: string }) => {
-                setFormValues((prev) => ({ ...prev, icon: emoji.native }));
-                setEmojiAnchor(null);
-              }}
-              theme="light"
-              previewPosition="none"
-            />
-          </Popover>
-        </Box>
-
-        <Box>
-          <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
-            {t('edit.fields.visibility')}
-          </Typography>
-          <Stack spacing={0.5}>
-            <Stack direction="row" spacing={1} alignItems="center">
-              <LockOutlined sx={{ fontSize: 18, color: isPublic ? 'text.disabled' : 'text.secondary' }} />
-              <MuiSwitch checked={isPublic} onChange={(_, checked) => handleVisibilityChange(checked)} />
-              <PublicOutlined sx={{ fontSize: 18, color: isPublic ? 'text.secondary' : 'text.disabled' }} />
-            </Stack>
-            <Typography variant="body2" component="span" color="text.secondary" sx={{ fontSize: 12 }}>
-              {isPublic ? t('edit.fields.publicHint') : t('edit.fields.privateHint')}
+        }
+      >
+        <Box sx={{ maxWidth: 600, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <Box>
+            <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
+              {t('edit.fields.name')}
             </Typography>
-          </Stack>
+            <TextField
+              placeholder={t('edit.fields.namePlaceholder')}
+              slotProps={{ htmlInput: { maxLength: 100 } }}
+              fullWidth
+              size="small"
+              value={formValues.name}
+              onChange={(e) => {
+                setFormValues((prev) => ({ ...prev, name: e.target.value }));
+                setFormErrors((prev) => ({ ...prev, name: '' }));
+              }}
+              error={!!formErrors.name}
+              helperText={formErrors.name}
+            />
+          </Box>
+
+          <Box>
+            <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
+              {t('edit.fields.description')}
+            </Typography>
+            <TextField
+              placeholder={t('edit.fields.descriptionPlaceholder')}
+              multiline
+              rows={3}
+              slotProps={{ htmlInput: { maxLength: 500 } }}
+              fullWidth
+              size="small"
+              value={formValues.description}
+              onChange={(e) => {
+                setFormValues((prev) => ({ ...prev, description: e.target.value }));
+                setFormErrors((prev) => ({ ...prev, description: '' }));
+              }}
+              error={!!formErrors.description}
+              helperText={formErrors.description}
+            />
+          </Box>
+
+          <Box>
+            <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
+              {t('edit.fields.color')}
+            </Typography>
+            <TextField
+              type="color"
+              value={formValues.color || '#000000'}
+              onChange={(e) => setFormValues((prev) => ({ ...prev, color: e.target.value }))}
+              size="small"
+              sx={{ width: 80 }}
+            />
+          </Box>
+
+          <Box>
+            <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
+              {t('edit.fields.icon')}
+            </Typography>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <MuiButton
+                variant="outlined"
+                onClick={(e) => setEmojiAnchor(e.currentTarget)}
+                sx={{ minWidth: 48, height: 48, fontSize: 24, lineHeight: 1 }}
+              >
+                {formValues.icon || '+'}
+              </MuiButton>
+              {formValues.icon && (
+                <MuiButton
+                  variant="text"
+                  size="small"
+                  startIcon={<CloseOutlined />}
+                  onClick={() => setFormValues((prev) => ({ ...prev, icon: '' }))}
+                >
+                  {t('edit.fields.removeIcon')}
+                </MuiButton>
+              )}
+            </Stack>
+            <Popover
+              open={Boolean(emojiAnchor)}
+              anchorEl={emojiAnchor}
+              onClose={() => setEmojiAnchor(null)}
+              anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+            >
+              <EmojiPicker
+                onEmojiSelect={(emoji: { native: string }) => {
+                  setFormValues((prev) => ({ ...prev, icon: emoji.native }));
+                  setEmojiAnchor(null);
+                }}
+                theme="light"
+                previewPosition="none"
+              />
+            </Popover>
+          </Box>
+
+          <Box>
+            <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
+              {t('edit.fields.visibility')}
+            </Typography>
+            <Stack spacing={0.5}>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <LockOutlined sx={{ fontSize: 18, color: isPublic ? 'text.disabled' : 'text.secondary' }} />
+                <MuiSwitch checked={isPublic} onChange={(_, checked) => handleVisibilityChange(checked)} />
+                <PublicOutlined sx={{ fontSize: 18, color: isPublic ? 'text.secondary' : 'text.disabled' }} />
+              </Stack>
+              <Typography variant="body2" component="span" color="text.secondary" sx={{ fontSize: 12 }}>
+                {isPublic ? t('edit.fields.publicHint') : t('edit.fields.privateHint')}
+              </Typography>
+            </Stack>
+          </Box>
         </Box>
-      </Box>
-    </SwipeableDrawer>
+      </SwipeableDrawer>
+      <Dialog
+        open={conflict !== null}
+        onClose={handleConflictCancel}
+        maxWidth="xs"
+        fullWidth
+        aria-labelledby="playlist-edit-conflict-title"
+      >
+        <DialogTitle id="playlist-edit-conflict-title">{t('edit.conflict.title')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{conflictMessage}</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <MuiButton onClick={handleConflictCancel}>{t('edit.conflict.cancel')}</MuiButton>
+          <MuiButton onClick={handleUseTheirs}>{t('edit.conflict.keepTheirs')}</MuiButton>
+          <MuiButton color="error" onClick={handleKeepMine} disabled={loading}>
+            {t('edit.conflict.keepMine')}
+          </MuiButton>
+        </DialogActions>
+      </Dialog>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Closes #4267.

Since #1934 / PR #4252, the backend refuses `updatePlaylist` when the
caller's `basedOn` snapshot doesn't match the stored row, but only clients
that opt in by sending `basedOn` get that protection. Web's
`PlaylistEditDrawer` never did, so a web edit still silently overwrote a
rename made on another device or tab, with no indication to the user that
anything was clobbered.

This PR makes the drawer opt in and handle the rejection:

- `handleSubmit` now sends `basedOn` built from the playlist prop
  (`updatedAt`, `name`, `description`, `isPublic`, `color`, `icon`). A
  playlist without `updatedAt` (a stale pre-field cache) falls back to no
  `basedOn` — the old last-write-wins — same as mobile's fallback.
- On a `PLAYLIST_UPDATE_CONFLICT` rejection (read via
  `readPlaylistUpdateConflict` from `@boardsesh/graphql/errors`), a MUI
  Dialog offers **Cancel / Use theirs / Keep mine**, mirroring the mobile
  three-way alert added in #4252:
  - **Cancel** closes the dialog only; the drawer stays open with the edit
    intact.
  - **Use theirs** adopts the server's values with no extra network call and
    closes the drawer.
  - **Keep mine** retries the mutation rebased on the server's own values,
    so the overwrite is deliberate. If *that* retry conflicts again (a
    third device), it doesn't re-prompt — it shows
    `edit.conflict.changedAgain` via the snackbar and leaves the drawer
    open.
  - When the server's name matches what you typed (the conflict is only on
    description/colour/icon/visibility), the dialog uses the
    `messageDetails` wording instead of quoting the same name twice.
- Both a successful save and "Use theirs" invalidate the
  `['userPlaylists']` react-query cache (the only other web cache of the
  playlist list, in `use-climb-actions-data.tsx`), so the Add-to-Playlist
  picker picks up the change alongside the playlist detail page.

No backend or shared-package changes — this is a web-only consumer of the
substrate PR #4252 already shipped (conflict check, `PlaylistRevision`
input, typed error readers, and the shared `edit.conflict.*` i18n keys).
Zero new i18n keys were added; the shared catalogs (en-US/de/es/fr) already
cover them.

**⚠️ This PR is stacked on `fix/1934-playlist-rename-lww-conflict` (#4252),
which is still open.** The base branch here is `fix/1934-playlist-rename-lww-conflict`,
not `main` — please don't merge this until #4252 lands, and retarget this PR's
base to `main` once it does (the diff will shrink to just the two files
listed below).

## Known limitation

The guarantee is per-client: an old client that never sends `basedOn`
(a stale mobile build, a third-party caller) still overwrites silently.
Restated from the issue, not new to this PR.

## Files changed

- `packages/web/app/components/library/playlist-edit-drawer.tsx`
- `packages/web/app/components/library/__tests__/playlist-edit-drawer.test.tsx`

## Validation

- `vp check` — clean (0 new errors/warnings; repo baseline of 30
  pre-existing errors / 298 warnings, confirmed identical on the base
  branch before this change and unrelated to these two files).
- `vp run typecheck:web` — clean (`next build` + `tsc --noEmit` both pass).
- `vp run typecheck:shared` — clean.
- `vp test run --project web --reporter=agent packages/web/app/components/library/__tests__/playlist-edit-drawer.test.tsx`
  — 11/11 passing (4 pre-existing + 7 new: basedOn on submit, no basedOn
  when `updatedAt` is missing, conflict dialog wording for both the
  name-differs and same-name cases, Use theirs, Keep mine retry, a second
  conflict on retry, and cancel preserving form state).
- `vp run check:i18n` — clean (no hardcoded strings; only existing
  `edit.conflict.*` keys reused).

## Open questions for @marcodejongh

- None — the plan's judgement calls (dialog copy, wording branch,
  cache-invalidation scope) all reuse #4252's already-agreed patterns
  verbatim, so there's nothing new to decide here beyond re-reviewing
  #4252 itself.
