### PR TITLE
feat(mobile): keep your profile and boards ready on a cold start

### DIFF
--- a/docs/offline-reads.md
+++ b/docs/offline-reads.md
@@ -26,6 +26,26 @@ Only for keys that have no local table and do not deserve one: `['profile']`, `[
 
 Budgets: target under 100 KB serialized, hard cap 512 KB with lowest-priority-first eviction, 64 KB per entry, `maxAge` 14 days for identity and config keys and 24 hours for `publicProfile`.
 
+#### How the persisted cache works
+
+Shipped in [#4353](https://github.com/boardsesh/boardsesh/issues/4353) as `packages/mobile/src/lib/query-persist/`.
+
+**The envelope.** `{ version, userId, savedAt, evicted?, queries }`. There is deliberately **no `mutations` field**: `pending_mutations` in SQLite is the one outbox, and a second persisted outbox is a double-submit hazard. The type makes it unrepresentable, and `dehydrateAllowlisted` additionally hard-codes `shouldDehydrateMutation: () => false` — two independent defences, one test each. `version` is bumped only when the persisted _value_ shape breaks; a changed query key yields a different `queryHash`, so a stale entry is simply never found and ages out.
+
+**The six rules.** Each pins an exact head **and an exact arity**, which is what makes the allowlist a gate rather than a prefix filter (`['profile', x]` misses; a future `['profileSettings']` cannot slip through). Priorities, lowest evicting first: `profile` 60, `myBoards` 50, `myGyms` 40, `grades` 30, `angles` 20, `publicProfile` 10. `publicProfile` also carries a guard rejecting any id but the blob owner's. The allowlist is re-applied on the **restore** path, not only on dehydrate, so a future or tampered blob cannot smuggle a non-allowlisted key — or another climber's public profile — into memory.
+
+**Native restores synchronously, web asynchronously.** On native, MMKV's read is synchronous, so `QueryProvider`'s `useState` lazy initializer hydrates before React's first render: no `isRestoring` frame, no `IsRestoringProvider`, no splash flicker. On web the storage key is `userScopedStorageKey(...)`, which returns `null` until `setCurrentUserStorageOwner` runs, so there is genuinely nothing readable before auth resolves — the restore is awaited inside `handleResolvedAuthenticatedTransition`, which precedes `setIsLoading(false)` while children sit behind `AppLoadingSplash`. `hydrate`'s `dataUpdatedAt >` guard means a late restore can never clobber a live fetch either way.
+
+**The native owner sentinel.** A short `queryCacheOwnerV1` key holds the user id next to the blob, in a **dedicated** `boardsesh-query-cache` MMKV instance (so a 512 KB blob never lands in `boardsesh-settings`, whose `clearAll()` would take it with it). A blob with no sentinel hydrates **nothing** and is deleted. That is not fussiness: `persistedQueryCacheExists` answers from the sentinel rather than reading up to 512 KB of JSON, so allowing a sentinel-less blob to hydrate would let hydrated data be invisible to the sign-out wipe. Presence and hydratability have to agree exactly.
+
+**Merge-on-write.** React Query's 30-minute `gcTime` deletes any entry with no observer, so a replace-on-write persister would erode toward "only what you looked at in the last 30 minutes" — `['angles', board, layout]` for a board you did not open today would vanish. Each write merges: fresh entries win by `queryHash`, previously written entries survive when absent from the fresh set and still inside their rule's `maxAge`. The merge set is **seeded from what the restore hydrated**, which closes the same hole at the other end.
+
+**The writer is paused, never stopped.** It subscribes to the query cache once for the app's lifetime and is gated purely by a runtime owner read at **write-fire time**, never at schedule time. `suspendCacheWriter()` clears the owner, the pending throttle and the merge set; `setPersistOwner(userId)` at the auth boundary re-arms it. A latched stop would be unshippable: `clearPersistedUserStores` runs on the light signed-out path too, which fires on every logged-out cold start and every anonymous foreground check, so the writer would be dead from the first anonymous launch and the first sign-in would persist nothing. Reading the owner at fire time also closes the race a stop was meant to cover — a write queued mid-sign-out finds a null owner and does nothing.
+
+**The sign-out contract.** The blob is deleted **inside `clearPersistedUserStores`** — one call site, cross-platform, not a parallel delete that can drift. `suspendCacheWriter()` is its first synchronous statement. And `handleSignedOutTransition`'s `needsFullCleanup` now also fires when a persisted blob exists, so a token that expired while the app was killed no longer relaunches into the previous session's cached profile. That widening is safe because it can only fire on a **confirmed** logout: `resolveAuthSession` returns `anonymous` only for an absent token or a server-rejected refresh, while an unreachable refresh stays authenticated-degraded — so an offline cold start still restores normally.
+
+**Telemetry.** One event, `Offline Query Cache Restored`, at most once per launch and only when a blob existed. `outcome` is one of `hydrated | unreadable | owner_mismatch | owner_missing | empty`; `owner_mismatch` is also a Sentry report (`source: 'query-persist'`) and should be ~0, while `owner_missing` is a torn write and deliberately silent.
+
 ### Bucket 3 — honest offline states, no storage at all
 
 Feeds (`sessionGroupedFeed`, `activityFeed`), session detail, board presence, `searchUsers`, `bulkVoteSummaries`, `comments`, `gymMembers`, `nearbyBoards`/`nearbyGyms`, `betaLinkPreview`.
@@ -110,11 +130,11 @@ Invalidation stays gated on rows actually landing (`if (totalProcessed > 0)`), a
 
 ## Delivery
 
-| Step                                                                     | State                                                                                                                                                     |
-| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| This decision                                                            | shipped                                                                                                                                                   |
-| Honest offline states on network-only screens                            | shipped                                                                                                                                                   |
-| One invalidation map for sync and the drainer                            | shipped                                                                                                                                                   |
-| User scoping: owner stamp, completeness marker, row predicates           | shipped                                                                                                                                                   |
-| `localFirstWhileOnline` + the local logbook, playlists and likes readers | [#4352](https://github.com/boardsesh/boardsesh/issues/4352) — ordering constraint against [#4312](https://github.com/boardsesh/boardsesh/issues/4312)     |
-| The allowlisted persisted cache                                          | [#4353](https://github.com/boardsesh/boardsesh/issues/4353) — follows the logout-wipe work in [#3621](https://github.com/boardsesh/boardsesh/issues/3621) |
+| Step                                                                     | State                                                                                                                                                 |
+| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| This decision                                                            | shipped                                                                                                                                               |
+| Honest offline states on network-only screens                            | shipped                                                                                                                                               |
+| One invalidation map for sync and the drainer                            | shipped                                                                                                                                               |
+| User scoping: owner stamp, completeness marker, row predicates           | shipped                                                                                                                                               |
+| `localFirstWhileOnline` + the local logbook, playlists and likes readers | [#4352](https://github.com/boardsesh/boardsesh/issues/4352) — ordering constraint against [#4312](https://github.com/boardsesh/boardsesh/issues/4312) |
+| The allowlisted persisted cache                                          | shipped — [#4353](https://github.com/boardsesh/boardsesh/issues/4353); see "How the persisted cache works" above                                      |

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -132,6 +132,13 @@ export default function BoardSelection() {
   // real, and retries never pause. Same belt-and-braces reasoning as
   // offlineAwareRequest's network-failure catch.
   const isLocalOnly = isOffline || (isError && myBoards.length === 0);
+  // PRECEDENCE, three tiers: live `myBoards` query > persisted `myBoards` cache >
+  // `offlineBoardsV1` MMKV cards. Tier 2 is `cachedMyBoards` below, warm on a cold
+  // start since #4353 (`src/lib/query-persist`), so board names and owned/followed
+  // grouping are fresher offline. Tier 3 stays the last resort: it outlives the
+  // cache's 14-day maxAge and is pruned deliberately, so it is the only tier that
+  // still answers once the persisted cache expires. No logic changes here — the
+  // persisted cache only makes the middle tier warm.
   const offlineRows = useMemo(
     () =>
       isLocalOnly

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -358,6 +358,17 @@ export default function ManageBoards() {
   // would briefly look like a missing identity and flip the screen to the offline
   // list on its way to the normal one.
   const noUserIdAvailable = !currentUserId && !isProfileLoading && !isStoredUserIdLoading;
+  // PRECEDENCE, three tiers: live `myBoards` query > persisted `myBoards` cache >
+  // `offlineBoardsV1` MMKV cards. Tier 2 arrives below as `cachedMyBoards`, warm
+  // on a cold start since #4353 (`src/lib/query-persist`). Tier 3 is the last
+  // resort on purpose: it survives the cache's 14-day maxAge and is pruned
+  // deliberately by `useRememberDownloadedBoards`, so it is the only tier that
+  // still answers after the persisted cache expires.
+  //
+  // With `['profile']` persisted, `currentUserId = profile?.id ?? storedUserId`
+  // now resolves from disk on a cold start too, so the `!currentUserId` hard-error
+  // branch further down is reachable only when the profile blob AND the keychain
+  // read are both gone — the general fix for what #4309 worked around per-screen.
   const shouldUseOfflineList = isOffline || noUserIdAvailable || (isError && myBoards.length === 0);
   const offlineItems = useMemo(() => {
     if (!shouldUseOfflineList) return EMPTY_ITEMS;

--- a/packages/mobile/src/lib/query-persist/__tests__/allowlist.test.ts
+++ b/packages/mobile/src/lib/query-persist/__tests__/allowlist.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { matchPersistRule, PERSISTED_QUERY_RULES } from '../allowlist';
+
+const OWNER = 'user-1';
+
+describe('matchPersistRule', () => {
+  // T-01: the six allowlisted shapes match, and everything the decision doc
+  // excludes misses. Arity is what makes this a gate rather than a prefix
+  // filter, so the near-misses matter as much as the hits.
+  it('matches exactly the six allowlisted key shapes', () => {
+    expect(matchPersistRule(['profile'], OWNER)?.head).toBe('profile');
+    expect(matchPersistRule(['myBoards', undefined], OWNER)?.head).toBe('myBoards');
+    expect(matchPersistRule(['myBoards', { boardType: 'kilter' }], OWNER)?.head).toBe('myBoards');
+    expect(matchPersistRule(['myGyms'], OWNER)?.head).toBe('myGyms');
+    expect(matchPersistRule(['grades', 'kilter'], OWNER)?.head).toBe('grades');
+    expect(matchPersistRule(['angles', 'kilter', 8], OWNER)?.head).toBe('angles');
+    expect(matchPersistRule(['publicProfile', OWNER], OWNER)?.head).toBe('publicProfile');
+  });
+
+  it('rejects wrong arity, near-miss heads, and every SQLite-owned key', () => {
+    // Wrong arity on an allowlisted head.
+    expect(matchPersistRule(['profile', 'x'], OWNER)).toBeUndefined();
+    expect(matchPersistRule(['myBoards'], OWNER)).toBeUndefined();
+    expect(matchPersistRule(['angles', 'kilter'], OWNER)).toBeUndefined();
+    // A future key that would slip through a prefix check.
+    expect(matchPersistRule(['profileSettings'], OWNER)).toBeUndefined();
+    // SQLite owns these.
+    expect(matchPersistRule(['searchClimbs', { query: 'x' }], OWNER)).toBeUndefined();
+    expect(matchPersistRule(['infiniteSearchClimbs', { query: 'x' }], OWNER)).toBeUndefined();
+    expect(matchPersistRule(['logbook', 'kilter'], OWNER)).toBeUndefined();
+    expect(matchPersistRule(['userTicks', 'u1'], OWNER)).toBeUndefined();
+    // Already AsyncStorage-backed; double-storing it is explicitly out of scope.
+    expect(matchPersistRule(['activeBoard'], OWNER)).toBeUndefined();
+    // "Now" semantics.
+    expect(matchPersistRule(['sessionGroupedFeed'], OWNER)).toBeUndefined();
+    // A non-string head can never match.
+    expect(matchPersistRule([42], OWNER)).toBeUndefined();
+    expect(matchPersistRule([], OWNER)).toBeUndefined();
+  });
+
+  // T-02: publicProfile is the only rule with a guard — someone else's public
+  // profile is another climber's data and must never land on this device's disk.
+  it('persists only the owner’s own publicProfile', () => {
+    expect(matchPersistRule(['publicProfile', OWNER], OWNER)).toBeDefined();
+    expect(matchPersistRule(['publicProfile', 'someone-else'], OWNER)).toBeUndefined();
+  });
+
+  it('gives publicProfile the shortest maxAge and the lowest priority', () => {
+    const publicProfile = PERSISTED_QUERY_RULES.find((rule) => rule.head === 'publicProfile');
+    const profile = PERSISTED_QUERY_RULES.find((rule) => rule.head === 'profile');
+    expect(publicProfile?.maxAgeMs).toBe(24 * 60 * 60 * 1000);
+    expect(profile?.maxAgeMs).toBe(14 * 24 * 60 * 60 * 1000);
+    // `profile` is the entry the feature exists for, so it evicts last.
+    const priorities = PERSISTED_QUERY_RULES.map((rule) => rule.priority);
+    expect(profile?.priority).toBe(Math.max(...priorities));
+    expect(publicProfile?.priority).toBe(Math.min(...priorities));
+  });
+});

--- a/packages/mobile/src/lib/query-persist/__tests__/auth-boundary.test.ts
+++ b/packages/mobile/src/lib/query-persist/__tests__/auth-boundary.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+
+// The storage fork is what differs between native and web, so it is mocked
+// rather than imported: `supportsSync` flips this suite between the native
+// (restore already happened at mount) and web (restore happens here) paths.
+const storageState = vi.hoisted(() => ({
+  supportsSync: true,
+  raw: null as string | null,
+}));
+const readPersistedCacheAsyncMock = vi.hoisted(() => vi.fn(async (_owner?: unknown) => storageState.raw));
+const clearPersistedQueryCacheMock = vi.hoisted(() => vi.fn(async (_owner?: unknown) => {}));
+const writeCacheOwnerMock = vi.hoisted(() => vi.fn((_userId: string) => {}));
+
+vi.mock('../storage', () => ({
+  get SUPPORTS_SYNC_RESTORE() {
+    return storageState.supportsSync;
+  },
+  get REQUIRES_OWNER_HINT() {
+    return storageState.supportsSync;
+  },
+  readPersistedCacheSync: () => storageState.raw,
+  readCacheOwnerSync: () => null,
+  readPersistedCacheAsync: readPersistedCacheAsyncMock,
+  writePersistedCache: vi.fn(),
+  writeCacheOwner: writeCacheOwnerMock,
+  persistedQueryCacheExists: vi.fn(async () => storageState.raw !== null),
+  clearPersistedQueryCache: clearPersistedQueryCacheMock,
+}));
+
+const trackMock = vi.hoisted(() => vi.fn());
+vi.mock('../../analytics', () => ({ track: trackMock }));
+
+const reportHandledErrorMock = vi.hoisted(() => vi.fn());
+vi.mock('../../error-reporting', () => ({ reportHandledError: reportHandledErrorMock }));
+
+import { adoptPersistedQueryCache, decideOwnerTransition } from '../auth-boundary';
+import { PERSISTED_CACHE_VERSION, serializePersistedCache, type PersistedQueryEntry } from '../envelope';
+import { getPersistOwner, resetQueryPersistRuntime, setLastRestore, suspendCacheWriter } from '../runtime';
+import { restorePersistedCache } from '../restore';
+
+const OWNER = 'user-1';
+
+function blobFor(userId: string, now = Date.now()): string {
+  return serializePersistedCache({
+    version: PERSISTED_CACHE_VERSION,
+    userId,
+    savedAt: now,
+    queries: [
+      {
+        queryHash: '["profile"]',
+        queryKey: ['profile'],
+        state: { data: { id: userId }, dataUpdatedAt: now, status: 'success', fetchStatus: 'idle' },
+      },
+    ] as unknown as PersistedQueryEntry[],
+  });
+}
+
+beforeEach(() => {
+  resetQueryPersistRuntime();
+  storageState.supportsSync = true;
+  storageState.raw = null;
+  readPersistedCacheAsyncMock.mockClear();
+  clearPersistedQueryCacheMock.mockClear();
+  writeCacheOwnerMock.mockClear();
+  trackMock.mockClear();
+  reportHandledErrorMock.mockClear();
+});
+
+// T-14
+describe('decideOwnerTransition', () => {
+  it('covers the whole truth table', () => {
+    expect(decideOwnerTransition({ resolvedUserId: undefined, hydratedUserId: undefined })).toBe('evict');
+    expect(decideOwnerTransition({ resolvedUserId: undefined, hydratedUserId: OWNER })).toBe('evict');
+    expect(decideOwnerTransition({ resolvedUserId: OWNER, hydratedUserId: undefined })).toBe('adopt');
+    expect(decideOwnerTransition({ resolvedUserId: OWNER, hydratedUserId: OWNER })).toBe('adopt');
+    expect(decideOwnerTransition({ resolvedUserId: OWNER, hydratedUserId: 'user-2' })).toBe('evict-then-adopt');
+  });
+});
+
+describe('adoptPersistedQueryCache (native, restore already done at mount)', () => {
+  it('adopts what the mount-time restore hydrated and reports it once', async () => {
+    const client = new QueryClient();
+    setLastRestore(
+      restorePersistedCache(client, {
+        raw: blobFor(OWNER),
+        ownerHint: OWNER,
+        requireOwnerHint: true,
+        now: Date.now(),
+      }),
+    );
+
+    await adoptPersistedQueryCache(client, OWNER, undefined);
+
+    expect(getPersistOwner()).toBe(OWNER);
+    expect(writeCacheOwnerMock).toHaveBeenCalledWith(OWNER);
+    expect(clearPersistedQueryCacheMock).not.toHaveBeenCalled();
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    const [eventName, properties] = trackMock.mock.calls[0];
+    expect(eventName).toBe('Offline Query Cache Restored');
+    expect(properties).toMatchObject({ outcome: 'hydrated', entryCount: 1 });
+    expect(properties.bytes).toBeGreaterThan(0);
+  });
+
+  // T-23 — the C3 regression test.
+  it('is a no-op on every later foreground for the same user', async () => {
+    const client = new QueryClient();
+    setLastRestore(
+      restorePersistedCache(client, {
+        raw: blobFor(OWNER),
+        ownerHint: OWNER,
+        requireOwnerHint: true,
+        now: Date.now(),
+      }),
+    );
+
+    await adoptPersistedQueryCache(client, OWNER, undefined);
+    trackMock.mockClear();
+    writeCacheOwnerMock.mockClear();
+
+    await adoptPersistedQueryCache(client, OWNER, undefined);
+    await adoptPersistedQueryCache(client, OWNER, undefined);
+
+    expect(trackMock).not.toHaveBeenCalled();
+    expect(writeCacheOwnerMock).not.toHaveBeenCalled();
+    expect(clearPersistedQueryCacheMock).not.toHaveBeenCalled();
+    expect(reportHandledErrorMock).not.toHaveBeenCalled();
+    expect(client.getQueryData(['profile'])).toEqual({ id: OWNER });
+  });
+
+  it('evicts precisely and alarms when the blob belongs to someone else', async () => {
+    const client = new QueryClient();
+    // A blob stamped user-2 that the mount-time restore hydrated because the
+    // owner sentinel agreed with it — auth then resolves user-1.
+    const restore = restorePersistedCache(client, {
+      raw: blobFor('user-2'),
+      ownerHint: 'user-2',
+      requireOwnerHint: true,
+      now: Date.now(),
+    });
+    setLastRestore(restore);
+    // Something fetched after the restore must survive the eviction.
+    client.setQueryData(['myGyms'], [{ id: 'gym-1' }]);
+
+    await adoptPersistedQueryCache(client, OWNER, undefined);
+
+    expect(client.getQueryData(['profile'])).toBeUndefined();
+    expect(client.getQueryData(['myGyms'])).toEqual([{ id: 'gym-1' }]);
+    expect(clearPersistedQueryCacheMock).toHaveBeenCalledTimes(1);
+    expect(reportHandledErrorMock).toHaveBeenCalledTimes(1);
+    expect(getPersistOwner()).toBe(OWNER);
+  });
+
+  it('stays silent for a torn write with no owner sentinel', async () => {
+    const client = new QueryClient();
+    setLastRestore(
+      restorePersistedCache(client, {
+        raw: blobFor(OWNER),
+        ownerHint: null,
+        requireOwnerHint: true,
+        now: Date.now(),
+      }),
+    );
+
+    await adoptPersistedQueryCache(client, OWNER, undefined);
+
+    // Deleted and re-armed, but NOT reported: a torn write is not a leak, and
+    // keeping owner_mismatch meaningful is the point.
+    expect(clearPersistedQueryCacheMock).toHaveBeenCalledTimes(1);
+    expect(reportHandledErrorMock).not.toHaveBeenCalled();
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock.mock.calls[0][1]).toMatchObject({ outcome: 'owner_missing' });
+    expect(trackMock.mock.calls[0][1].entryCount).toBeUndefined();
+  });
+
+  it('emits nothing at all when there was no blob', async () => {
+    const client = new QueryClient();
+    setLastRestore(
+      restorePersistedCache(client, { raw: null, ownerHint: OWNER, requireOwnerHint: true, now: Date.now() }),
+    );
+
+    await adoptPersistedQueryCache(client, OWNER, undefined);
+
+    expect(trackMock).not.toHaveBeenCalled();
+    expect(getPersistOwner()).toBe(OWNER);
+  });
+
+  // T-24 — an in-launch account switch must not leave a phantom mismatch behind.
+  it('does not re-decide against a departed user after a sign-out', async () => {
+    const client = new QueryClient();
+    setLastRestore(
+      restorePersistedCache(client, {
+        raw: blobFor(OWNER),
+        ownerHint: OWNER,
+        requireOwnerHint: true,
+        now: Date.now(),
+      }),
+    );
+    await adoptPersistedQueryCache(client, OWNER, undefined);
+
+    // Sign-out: suspendCacheWriter clears owner + lastRestore.
+    suspendCacheWriter();
+    clearPersistedQueryCacheMock.mockClear();
+    reportHandledErrorMock.mockClear();
+    trackMock.mockClear();
+
+    // User B signs in on the same launch; nothing is on disk for them.
+    await adoptPersistedQueryCache(client, 'user-2', undefined);
+    await adoptPersistedQueryCache(client, 'user-2', undefined);
+    await adoptPersistedQueryCache(client, 'user-2', undefined);
+
+    expect(getPersistOwner()).toBe('user-2');
+    expect(clearPersistedQueryCacheMock).not.toHaveBeenCalled();
+    expect(reportHandledErrorMock).not.toHaveBeenCalled();
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('adoptPersistedQueryCache (web, async restore at the auth boundary)', () => {
+  beforeEach(() => {
+    storageState.supportsSync = false;
+  });
+
+  // T-21 — the C2 regression test. `undefined` is the only correct owner
+  // argument: it resolves the account `handleAuthenticatedTransition` just
+  // published. A captured owner is `null` on every web cold start, and
+  // `userScopedStorageKey(base, null)` returns null, so the read and the
+  // mismatch-path delete would both silently no-op.
+  it('reads the blob with an undefined owner so the post-transition key resolves', async () => {
+    storageState.raw = blobFor(OWNER);
+    const client = new QueryClient();
+
+    await adoptPersistedQueryCache(client, OWNER, undefined);
+
+    expect(readPersistedCacheAsyncMock).toHaveBeenCalledTimes(1);
+    expect(readPersistedCacheAsyncMock).toHaveBeenCalledWith(undefined);
+    expect(client.getQueryData(['profile'])).toEqual({ id: OWNER });
+    expect(getPersistOwner()).toBe(OWNER);
+  });
+
+  it('reads storage exactly once across repeated foreground checks', async () => {
+    storageState.raw = blobFor(OWNER);
+    const client = new QueryClient();
+
+    await adoptPersistedQueryCache(client, OWNER, undefined);
+    await adoptPersistedQueryCache(client, OWNER, undefined);
+    await adoptPersistedQueryCache(client, OWNER, undefined);
+
+    expect(readPersistedCacheAsyncMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts without reading when auth could not name the user', async () => {
+    storageState.raw = blobFor(OWNER);
+    const client = new QueryClient();
+
+    await adoptPersistedQueryCache(client, undefined, undefined);
+
+    expect(readPersistedCacheAsyncMock).not.toHaveBeenCalled();
+    expect(clearPersistedQueryCacheMock).toHaveBeenCalledTimes(1);
+    expect(getPersistOwner()).toBeNull();
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/query-persist/__tests__/auth-boundary.test.ts
+++ b/packages/mobile/src/lib/query-persist/__tests__/auth-boundary.test.ts
@@ -149,6 +149,11 @@ describe('adoptPersistedQueryCache (native, restore already done at mount)', () 
     expect(clearPersistedQueryCacheMock).toHaveBeenCalledTimes(1);
     expect(reportHandledErrorMock).toHaveBeenCalledTimes(1);
     expect(getPersistOwner()).toBe(OWNER);
+    // The event reports the DISAGREEMENT, not the restore's own 'hydrated':
+    // those entries were evicted moments later, so calling the launch hydrated
+    // would hide the alarm from the funnel.
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock.mock.calls[0][1]).toEqual({ outcome: 'owner_mismatch' });
   });
 
   it('stays silent for a torn write with no owner sentinel', async () => {

--- a/packages/mobile/src/lib/query-persist/__tests__/budget.test.ts
+++ b/packages/mobile/src/lib/query-persist/__tests__/budget.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { applyBudget, PERSIST_MAX_BYTES, PERSIST_MAX_ENTRY_BYTES, type BudgetCandidate } from '../budget';
+import { PERSISTED_QUERY_RULES } from '../allowlist';
+import type { PersistedQueryEntry } from '../envelope';
+
+function entry(queryKey: readonly unknown[], payloadBytes: number, dataUpdatedAt = 1000): PersistedQueryEntry {
+  return {
+    queryHash: JSON.stringify(queryKey),
+    queryKey: queryKey as unknown[],
+    state: {
+      data: 'x'.repeat(payloadBytes),
+      dataUpdateCount: 1,
+      dataUpdatedAt,
+      error: null,
+      errorUpdateCount: 0,
+      errorUpdatedAt: 0,
+      fetchFailureCount: 0,
+      fetchFailureReason: null,
+      fetchMeta: null,
+      isInvalidated: false,
+      status: 'success',
+      fetchStatus: 'idle',
+    },
+  } as unknown as PersistedQueryEntry;
+}
+
+function priorityOf(head: string): number {
+  const rule = PERSISTED_QUERY_RULES.find((candidate) => candidate.head === head);
+  if (!rule) throw new Error(`no rule for ${head}`);
+  return rule.priority;
+}
+
+function candidate(head: string, queryKey: readonly unknown[], payloadBytes: number, at = 1000): BudgetCandidate {
+  return { entry: entry(queryKey, payloadBytes, at), priority: priorityOf(head) };
+}
+
+describe('applyBudget', () => {
+  // T-07 (first half)
+  it('drops any single entry over the 64 KB per-entry cap', () => {
+    const result = applyBudget([
+      candidate('profile', ['profile'], 200),
+      candidate('myBoards', ['myBoards', undefined], 70 * 1024),
+    ]);
+
+    expect(result.droppedOversize).toBe(1);
+    expect(result.droppedEvicted).toBe(0);
+    expect(result.kept.map((kept) => kept.queryKey[0])).toEqual(['profile']);
+    expect(result.bytes).toBeLessThan(PERSIST_MAX_ENTRY_BYTES);
+  });
+
+  // T-07 (second half): lowest priority evicts first, and `['profile']` — the
+  // entry the whole feature exists for — is the last thing standing.
+  it('evicts lowest-priority-first until the 512 KB cap fits, keeping profile', () => {
+    const payload = 60 * 1024;
+    const candidates: BudgetCandidate[] = [
+      candidate('profile', ['profile'], payload),
+      candidate('myBoards', ['myBoards', undefined], payload),
+      candidate('myBoards', ['myBoards', { boardType: 'kilter' }], payload),
+      candidate('myGyms', ['myGyms'], payload),
+      candidate('grades', ['grades', 'kilter'], payload),
+      candidate('grades', ['grades', 'tension'], payload),
+      candidate('angles', ['angles', 'kilter', 8], payload),
+      candidate('angles', ['angles', 'tension', 10], payload),
+      candidate('publicProfile', ['publicProfile', 'user-1'], payload),
+      candidate('publicProfile', ['publicProfile', 'user-1', 'variant'], payload),
+    ];
+
+    const result = applyBudget(candidates);
+
+    expect(result.bytes).toBeLessThanOrEqual(PERSIST_MAX_BYTES);
+    expect(result.droppedOversize).toBe(0);
+    expect(result.droppedEvicted).toBeGreaterThan(0);
+
+    const keptHashes = new Set(result.kept.map((kept) => kept.queryHash));
+    const keptPriorities = candidates.filter((one) => keptHashes.has(one.entry.queryHash)).map((one) => one.priority);
+    const evictedPriorities = candidates
+      .filter((one) => !keptHashes.has(one.entry.queryHash))
+      .map((one) => one.priority);
+    // Everything evicted ranks at or below everything kept.
+    expect(Math.max(...evictedPriorities)).toBeLessThanOrEqual(Math.min(...keptPriorities));
+    // publicProfile is the lowest rule, so it goes first; profile never goes.
+    expect(result.kept.some((kept) => kept.queryKey[0] === 'publicProfile')).toBe(false);
+    expect(result.kept.some((kept) => kept.queryKey[0] === 'profile')).toBe(true);
+  });
+
+  it('evicts the older entry first within one priority', () => {
+    const payload = 60 * 1024;
+    const candidates: BudgetCandidate[] = [
+      candidate('profile', ['profile'], payload),
+      ...Array.from({ length: 8 }, (_unused, index) =>
+        candidate('grades', ['grades', `board-${index}`], payload, 5000 + index),
+      ),
+      candidate('grades', ['grades', 'oldest'], payload, 1),
+    ];
+
+    const result = applyBudget(candidates);
+    expect(result.kept.some((kept) => kept.queryKey[1] === 'oldest')).toBe(false);
+  });
+
+  it('reports two empty-array bytes for an empty candidate set', () => {
+    expect(applyBudget([])).toEqual({ kept: [], droppedOversize: 0, droppedEvicted: 0, bytes: 2 });
+  });
+});

--- a/packages/mobile/src/lib/query-persist/__tests__/cold-start-budget.test.ts
+++ b/packages/mobile/src/lib/query-persist/__tests__/cold-start-budget.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { myBoardsQueryKey } from '../../graphql/query-keys';
+import { dehydrateAllowlisted } from '../dehydrate';
+import { PERSIST_TARGET_BYTES, PERSIST_MAX_ENTRY_BYTES, applyBudget, envelopeBytes } from '../budget';
+import { PERSISTED_QUERY_RULES } from '../allowlist';
+
+const OWNER = 'a1b2c3d4-e5f6-4789-abcd-0123456789ab';
+
+// A board with every field the GraphQL type carries populated the way a real
+// one is — long names, an owner avatar URL, set names, a location. Skimping on
+// these would make the budget assertion measure a fixture rather than a phone.
+function board(index: number, boardType: 'kilter' | 'tension'): UserBoard {
+  return {
+    __typename: 'UserBoard',
+    angle: 40,
+    boardId: 1000 + index,
+    boardType,
+    canEdit: true,
+    commentCount: 12,
+    createdAt: '2025-11-03T09:14:22.000Z',
+    description: 'Home wall in the garage. 12x12 with the full commercial set, adjustable 20-50 degrees.',
+    followerCount: 34,
+    gymId: 77,
+    gymName: 'Beta Bloc Amsterdam Noord',
+    gymUuid: 'f0e1d2c3-b4a5-4968-8877-665544332211',
+    hideLocation: false,
+    isAngleAdjustable: true,
+    isFollowedByMe: index % 2 === 0,
+    isOwned: index % 2 === 1,
+    isPublic: true,
+    isUnlisted: false,
+    latitude: 52.3791283,
+    layoutId: 8,
+    layoutName: 'Kilter Board Original Layout',
+    locationName: 'Amsterdam, Noord-Holland, Netherlands',
+    longitude: 4.9003269,
+    name: `Beta Bloc ${boardType === 'kilter' ? 'Kilter' : 'Tension'} Board ${index + 1}`,
+    ownerAvatarUrl: `https://images.boardsesh.com/avatars/${OWNER}/512.jpg`,
+    ownerDisplayName: 'Marco de Jongh',
+    ownerId: OWNER,
+    serialNumber: `KB-2024-${1000 + index}`,
+    setIds: '20,21,22,23',
+    setNames: ['Original School Holds', 'Bolt Ons', 'Wooden Holds', 'Screw Ons'],
+    sizeDescription: '12 x 12 with kickboard',
+    sizeId: 17,
+    sizeName: '12 x 12',
+    slug: `beta-bloc-${boardType}-board-${index + 1}`,
+    timerName: 'Rogue Echo Timer',
+    totalAscents: 18422,
+    uniqueClimbers: 431,
+    uuid: `b0000000-0000-4000-8000-00000000000${index}`,
+  } as unknown as UserBoard;
+}
+
+function grades(): unknown[] {
+  // The full V0–V17 / 5.6–5.15 ladder both Aurora boards return.
+  return Array.from({ length: 24 }, (_unused, index) => ({
+    __typename: 'Grade',
+    difficultyId: 10 + index,
+    difficultyName: `V${index}`,
+    frenchName: `${6 + Math.floor(index / 3)}${'abc'[index % 3]}+`,
+    boardseshName: `V${index}`,
+  }));
+}
+
+describe('cold-start budget', () => {
+  // T-19: a realistically populated allowlisted cache — profile + 6 boards +
+  // 3 gyms + 24 grades for two boards + ~9 angles for two boards — must fit the
+  // 100 KB target. The synchronous MMKV read plus JSON.parse before first render
+  // is what this bounds; the on-device gate measures what it costs.
+  it('serializes a fully populated allowlisted cache under the 100 KB target', () => {
+    const client = new QueryClient();
+
+    client.setQueryData(['profile'], {
+      __typename: 'Profile',
+      id: OWNER,
+      username: 'marcodejongh',
+      name: 'Marco de Jongh',
+      email: 'marco@example.com',
+      avatarUrl: `https://images.boardsesh.com/avatars/${OWNER}/512.jpg`,
+      bio: 'Kilter at 40, Tension at 10. Building Boardsesh in the evenings.',
+      location: 'Amsterdam, Netherlands',
+      createdAt: '2024-02-11T18:03:41.000Z',
+      isPublic: true,
+      followerCount: 212,
+      followingCount: 178,
+      totalAscents: 3841,
+    });
+    client.setQueryData(myBoardsQueryKey(), [
+      board(0, 'kilter'),
+      board(1, 'kilter'),
+      board(2, 'kilter'),
+      board(3, 'tension'),
+      board(4, 'tension'),
+      board(5, 'tension'),
+    ]);
+    client.setQueryData(
+      ['myGyms'],
+      [
+        {
+          __typename: 'Gym',
+          id: 77,
+          uuid: 'f0e1d2c3-b4a5-4968-8877-665544332211',
+          name: 'Beta Bloc Amsterdam Noord',
+          city: 'Amsterdam',
+          country: 'Netherlands',
+          memberCount: 843,
+          role: 'member',
+        },
+        {
+          __typename: 'Gym',
+          id: 78,
+          uuid: 'f0e1d2c3-b4a5-4968-8877-665544332212',
+          name: 'Klimmuur Centraal',
+          city: 'Amsterdam',
+          country: 'Netherlands',
+          memberCount: 1204,
+          role: 'admin',
+        },
+        {
+          __typename: 'Gym',
+          id: 79,
+          uuid: 'f0e1d2c3-b4a5-4968-8877-665544332213',
+          name: 'Monk Bouldergym Rotterdam',
+          city: 'Rotterdam',
+          country: 'Netherlands',
+          memberCount: 662,
+          role: 'member',
+        },
+      ],
+    );
+    for (const boardType of ['kilter', 'tension'] as const) {
+      client.setQueryData(['grades', boardType], grades());
+      client.setQueryData(
+        ['angles', boardType, 8],
+        Array.from({ length: 9 }, (_unused, index) => 20 + index * 5),
+      );
+    }
+    client.setQueryData(['publicProfile', OWNER], {
+      __typename: 'PublicUserProfile',
+      id: OWNER,
+      username: 'marcodejongh',
+      name: 'Marco de Jongh',
+      avatarUrl: `https://images.boardsesh.com/avatars/${OWNER}/512.jpg`,
+      bio: 'Kilter at 40, Tension at 10.',
+      followerCount: 212,
+      followingCount: 178,
+      totalAscents: 3841,
+      isFollowedByMe: false,
+    });
+
+    const entries = dehydrateAllowlisted(client, OWNER);
+    // 1 profile + 1 myBoards + 1 myGyms + 2 grades + 2 angles + 1 publicProfile
+    expect(entries).toHaveLength(8);
+
+    const bytes = envelopeBytes(OWNER, Date.now(), entries);
+    expect(bytes, `populated cold-start cache serialized to ${bytes} bytes`).toBeLessThan(PERSIST_TARGET_BYTES);
+
+    // Nothing in a realistic cache should be anywhere near the per-entry cap
+    // either, and no eviction should be needed to fit.
+    const budgeted = applyBudget(
+      entries.map((entry) => ({
+        entry,
+        priority: PERSISTED_QUERY_RULES.find((rule) => rule.head === entry.queryKey[0])?.priority ?? 0,
+      })),
+    );
+    expect(budgeted.droppedOversize).toBe(0);
+    expect(budgeted.droppedEvicted).toBe(0);
+    for (const entry of entries) {
+      expect(JSON.stringify(entry).length).toBeLessThan(PERSIST_MAX_ENTRY_BYTES);
+    }
+  });
+});

--- a/packages/mobile/src/lib/query-persist/__tests__/dehydrate.test.ts
+++ b/packages/mobile/src/lib/query-persist/__tests__/dehydrate.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { QueryClient, dehydrate, onlineManager } from '@tanstack/react-query';
+import { dehydrateAllowlisted } from '../dehydrate';
+
+afterEach(() => {
+  onlineManager.setOnline(true);
+});
+
+const OWNER = 'user-1';
+
+function heads(entries: readonly { queryKey: readonly unknown[] }[]): string[] {
+  return entries.map((entry) => String(entry.queryKey[0])).sort();
+}
+
+describe('dehydrateAllowlisted', () => {
+  // T-04: the hard-coded `shouldDehydrateMutation: () => false`. Asserted
+  // against a client whose mutation query-core's own default WOULD dehydrate
+  // (a paused mutation), so the test fails if the option is ever loosened.
+  it('dehydrates zero mutations from a client holding a paused mutation', async () => {
+    onlineManager.setOnline(false);
+    const client = new QueryClient({ defaultOptions: { mutations: { networkMode: 'online', retry: false } } });
+    const mutation = client.getMutationCache().build(client, { mutationFn: async () => 'ok' });
+    // Never awaited: while offline this mutation stays paused, which is exactly
+    // the state query-core's default `shouldDehydrateMutation` persists.
+    void mutation.execute(undefined).catch(() => {});
+    await Promise.resolve();
+
+    // Sanity: query-core's default dehydrate does keep this one, so the
+    // assertion below is about our option and not about an empty cache.
+    expect(dehydrate(client).mutations.length).toBeGreaterThan(0);
+
+    const state = dehydrate(client, {
+      shouldDehydrateMutation: () => false,
+      shouldDehydrateQuery: () => false,
+    });
+    expect(state.mutations).toEqual([]);
+    // The exported helper returns queries only — there is nowhere for a
+    // mutation to go.
+    expect(dehydrateAllowlisted(client, OWNER)).toEqual([]);
+  });
+
+  // T-06
+  it('keeps only successful, idle, allowlisted entries', async () => {
+    const client = new QueryClient();
+    client.setQueryData(['profile'], { id: OWNER });
+    client.setQueryData(['myBoards', undefined], [{ uuid: 'board-1' }]);
+    client.setQueryData(['myGyms'], [{ id: 'gym-1' }]);
+    client.setQueryData(['grades', 'kilter'], [{ difficultyId: 10 }]);
+    client.setQueryData(['angles', 'kilter', 8], [40, 45]);
+    client.setQueryData(['publicProfile', OWNER], { id: OWNER });
+    // Not allowlisted: SQLite owns it.
+    client.setQueryData(['infiniteSearchClimbs', { query: 'x' }], { pages: [] });
+    // Not allowlisted: someone else's public profile.
+    client.setQueryData(['publicProfile', 'stranger'], { id: 'stranger' });
+
+    expect(heads(dehydrateAllowlisted(client, OWNER))).toEqual([
+      'angles',
+      'grades',
+      'myBoards',
+      'myGyms',
+      'profile',
+      'publicProfile',
+    ]);
+  });
+
+  it('excludes errored and in-flight allowlisted entries', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    await client
+      .fetchQuery({
+        queryKey: ['myGyms'],
+        queryFn: async () => {
+          throw new Error('nope');
+        },
+      })
+      .catch(() => {});
+    // Never settles: stays `pending`/`fetching`, which is also the state that
+    // makes query-core attach a non-serializable `promise`.
+    void client.prefetchQuery({ queryKey: ['grades', 'kilter'], queryFn: () => new Promise(() => {}) });
+
+    const entries = dehydrateAllowlisted(client, OWNER);
+    expect(entries).toEqual([]);
+  });
+});

--- a/packages/mobile/src/lib/query-persist/__tests__/envelope.test.ts
+++ b/packages/mobile/src/lib/query-persist/__tests__/envelope.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import {
+  PERSISTED_CACHE_VERSION,
+  parsePersistedCache,
+  serializePersistedCache,
+  utf8ByteLength,
+  type PersistedCacheEnvelope,
+} from '../envelope';
+import { dehydrateAllowlisted } from '../dehydrate';
+
+const OWNER = 'user-1';
+
+function envelope(overrides: Partial<PersistedCacheEnvelope> = {}): PersistedCacheEnvelope {
+  return { version: PERSISTED_CACHE_VERSION, userId: OWNER, savedAt: 1000, queries: [], ...overrides };
+}
+
+describe('persisted cache envelope', () => {
+  // T-03
+  it('round-trips and classifies every unreadable shape', () => {
+    const parsed = parsePersistedCache(serializePersistedCache(envelope({ savedAt: 42 })));
+    expect(parsed.status).toBe('ok');
+    if (parsed.status === 'ok') expect(parsed.envelope.savedAt).toBe(42);
+
+    expect(parsePersistedCache(null)).toEqual({ status: 'absent' });
+    expect(parsePersistedCache('')).toEqual({ status: 'absent' });
+    expect(parsePersistedCache('{not json')).toEqual({ status: 'unreadable', reason: 'json' });
+    expect(parsePersistedCache(JSON.stringify({ version: 2, userId: OWNER, savedAt: 1, queries: [] }))).toEqual({
+      status: 'unreadable',
+      reason: 'version',
+    });
+    expect(
+      parsePersistedCache(JSON.stringify({ version: PERSISTED_CACHE_VERSION, userId: OWNER, savedAt: 1 })),
+    ).toEqual({ status: 'unreadable', reason: 'shape' });
+    expect(parsePersistedCache(JSON.stringify({ version: PERSISTED_CACHE_VERSION, savedAt: 1, queries: [] }))).toEqual({
+      status: 'unreadable',
+      reason: 'shape',
+    });
+    expect(parsePersistedCache('"a string"')).toEqual({ status: 'unreadable', reason: 'shape' });
+  });
+
+  it('carries the evicted flag through a round trip and defaults it absent', () => {
+    const withFlag = parsePersistedCache(serializePersistedCache(envelope({ evicted: true })));
+    expect(withFlag.status === 'ok' && withFlag.envelope.evicted).toBe(true);
+    const without = parsePersistedCache(serializePersistedCache(envelope()));
+    expect(without.status === 'ok' && without.envelope.evicted).toBeUndefined();
+  });
+
+  it('counts UTF-8 bytes the way Buffer.byteLength does', () => {
+    for (const sample of ['plain ascii', 'café ñandú', '🧗‍♀️ send it', '{"a":"日本語"}', '']) {
+      expect(utf8ByteLength(sample)).toBe(Buffer.byteLength(sample, 'utf8'));
+    }
+  });
+
+  // T-05: the second of the two defences against a persisted mutation outbox —
+  // the envelope type has no `mutations` field, so even a client full of
+  // mutations serializes without one. (The first is the hard-coded
+  // `shouldDehydrateMutation: () => false` asserted in dehydrate.test.ts.)
+  it('never serializes a mutations key, even from a client holding mutations', async () => {
+    const client = new QueryClient();
+    client.setQueryData(['profile'], { id: OWNER, name: 'Marco' });
+    const mutation = client.getMutationCache().build(client, { mutationFn: async () => 'ok' });
+    await mutation.execute(undefined);
+
+    const serialized = serializePersistedCache(envelope({ queries: dehydrateAllowlisted(client, OWNER) }));
+    expect(serialized).not.toContain('mutations');
+    expect(JSON.parse(serialized)).not.toHaveProperty('mutations');
+  });
+});

--- a/packages/mobile/src/lib/query-persist/__tests__/restore.test.ts
+++ b/packages/mobile/src/lib/query-persist/__tests__/restore.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import { myBoardsQueryKey } from '../../graphql/query-keys';
+import { dehydrateAllowlisted } from '../dehydrate';
+import {
+  PERSISTED_CACHE_VERSION,
+  serializePersistedCache,
+  type PersistedCacheEnvelope,
+  type PersistedQueryEntry,
+} from '../envelope';
+import { restorePersistedCache } from '../restore';
+import { getLastWrittenQueries, resetQueryPersistRuntime } from '../runtime';
+
+const OWNER = 'user-1';
+// Real wall-clock, because two of these tests compare a hand-built entry
+// against one produced by `dehydrate`/`setQueryData`, which stamp `Date.now()`.
+const NOW = Date.now();
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+function entry(queryKey: readonly unknown[], data: unknown, dataUpdatedAt = NOW): PersistedQueryEntry {
+  return {
+    queryHash: JSON.stringify(queryKey),
+    queryKey: queryKey as unknown[],
+    state: {
+      data,
+      dataUpdateCount: 1,
+      dataUpdatedAt,
+      error: null,
+      errorUpdateCount: 0,
+      errorUpdatedAt: 0,
+      fetchFailureCount: 0,
+      fetchFailureReason: null,
+      fetchMeta: null,
+      isInvalidated: false,
+      status: 'success',
+      fetchStatus: 'idle',
+    },
+  } as unknown as PersistedQueryEntry;
+}
+
+function blob(queries: readonly PersistedQueryEntry[], overrides: Partial<PersistedCacheEnvelope> = {}): string {
+  return serializePersistedCache({
+    version: PERSISTED_CACHE_VERSION,
+    userId: OWNER,
+    savedAt: NOW,
+    queries,
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  resetQueryPersistRuntime();
+});
+
+describe('restorePersistedCache', () => {
+  it('reports absent and unreadable without touching the client', () => {
+    const client = new QueryClient();
+    expect(
+      restorePersistedCache(client, { raw: null, ownerHint: OWNER, requireOwnerHint: false, now: NOW }).outcome,
+    ).toBe('absent');
+    expect(
+      restorePersistedCache(client, { raw: '{broken', ownerHint: OWNER, requireOwnerHint: false, now: NOW }).outcome,
+    ).toBe('unreadable');
+    expect(client.getQueryCache().getAll()).toHaveLength(0);
+  });
+
+  // T-10: the allowlist is re-applied on the RESTORE path, so a blob written by
+  // a future build (or tampered with on a rooted device) cannot smuggle a
+  // non-allowlisted key — or another climber's public profile — into memory.
+  it('refuses non-allowlisted and cross-user entries that a blob claims', () => {
+    const client = new QueryClient();
+    const outcome = restorePersistedCache(client, {
+      raw: blob([
+        entry(['infiniteSearchClimbs', { query: 'crimps' }], { pages: [] }),
+        entry(['publicProfile', 'stranger'], { id: 'stranger' }),
+        entry(['profile'], { id: OWNER }),
+      ]),
+      ownerHint: OWNER,
+      requireOwnerHint: false,
+      now: NOW,
+    });
+
+    expect(outcome.outcome).toBe('hydrated');
+    expect(outcome.entryCount).toBe(1);
+    expect(outcome.droppedCount).toBe(2);
+    expect(client.getQueryData(['infiniteSearchClimbs', { query: 'crimps' }])).toBeUndefined();
+    expect(client.getQueryData(['publicProfile', 'stranger'])).toBeUndefined();
+    expect(client.getQueryData(['profile'])).toEqual({ id: OWNER });
+  });
+
+  // T-11: JSON turns `undefined` into `null`, but `hashKey` produces
+  // `["myBoards",null]` for both, so every reader still finds the entry.
+  it('survives the undefined→null round trip on myBoardsQueryKey()', () => {
+    const source = new QueryClient();
+    source.setQueryData(myBoardsQueryKey(), [{ uuid: 'board-1', name: 'Home wall' }]);
+    const raw = blob(dehydrateAllowlisted(source, OWNER));
+    expect(raw).toContain('"myBoards",null');
+
+    const client = new QueryClient();
+    restorePersistedCache(client, { raw, ownerHint: OWNER, requireOwnerHint: false, now: NOW });
+    expect(client.getQueryData(myBoardsQueryKey())).toEqual([{ uuid: 'board-1', name: 'Home wall' }]);
+  });
+
+  // T-12
+  it('hydrates nothing on an owner mismatch', () => {
+    const client = new QueryClient();
+    const outcome = restorePersistedCache(client, {
+      raw: blob([entry(['profile'], { id: OWNER })]),
+      ownerHint: 'someone-else',
+      requireOwnerHint: false,
+      now: NOW,
+    });
+
+    expect(outcome.outcome).toBe('owner_mismatch');
+    expect(outcome.userId).toBe(OWNER);
+    expect(outcome.hydratedHashes).toEqual([]);
+    expect(client.getQueryData(['profile'])).toBeUndefined();
+  });
+
+  it('hydrates nothing when the platform requires an owner hint and none is there', () => {
+    const client = new QueryClient();
+    const outcome = restorePersistedCache(client, {
+      raw: blob([entry(['profile'], { id: OWNER })]),
+      ownerHint: null,
+      requireOwnerHint: true,
+      now: NOW,
+    });
+
+    expect(outcome.outcome).toBe('owner_missing');
+    expect(client.getQueryData(['profile'])).toBeUndefined();
+  });
+
+  it('drops entries past their own rule’s maxAge and keeps the rest', () => {
+    const client = new QueryClient();
+    const outcome = restorePersistedCache(client, {
+      raw: blob([
+        entry(['profile'], { id: OWNER }, NOW - 15 * DAY),
+        entry(['publicProfile', OWNER], { id: OWNER }, NOW - 25 * HOUR),
+        entry(['grades', 'kilter'], [{ difficultyId: 10 }], NOW - 13 * DAY),
+      ]),
+      ownerHint: OWNER,
+      requireOwnerHint: false,
+      now: NOW,
+    });
+
+    expect(outcome.outcome).toBe('hydrated');
+    expect(outcome.entryCount).toBe(1);
+    expect(outcome.droppedCount).toBe(2);
+    expect(outcome.oldestEntryAgeHours).toBe(13 * 24);
+    expect(client.getQueryData(['profile'])).toBeUndefined();
+    expect(client.getQueryData(['publicProfile', OWNER])).toBeUndefined();
+    expect(client.getQueryData(['grades', 'kilter'])).toEqual([{ difficultyId: 10 }]);
+  });
+
+  it('reports empty when the blob parsed and was owned but nothing survived', () => {
+    const client = new QueryClient();
+    const outcome = restorePersistedCache(client, {
+      raw: blob([entry(['profile'], { id: OWNER }, NOW - 15 * DAY)]),
+      ownerHint: OWNER,
+      requireOwnerHint: false,
+      now: NOW,
+    });
+
+    expect(outcome.outcome).toBe('empty');
+    expect(outcome.entryCount).toBe(0);
+    expect(outcome.droppedCount).toBeGreaterThan(0);
+    expect(outcome.bytes).toBeGreaterThan(0);
+  });
+
+  // T-13: `hydrate` refuses to overwrite an entry with a fresher
+  // `dataUpdatedAt`, which is what makes a late web restore incapable of
+  // clobbering a live fetch — and why no IsRestoringProvider is needed.
+  it('never clobbers a fresher live entry', () => {
+    const client = new QueryClient();
+    client.setQueryData(['profile'], { id: OWNER, name: 'fresh' });
+    const liveUpdatedAt = client.getQueryState(['profile'])?.dataUpdatedAt;
+
+    restorePersistedCache(client, {
+      raw: blob([entry(['profile'], { id: OWNER, name: 'stale' }, NOW - DAY)]),
+      ownerHint: OWNER,
+      requireOwnerHint: false,
+      now: NOW,
+    });
+
+    expect(client.getQueryData(['profile'])).toEqual({ id: OWNER, name: 'fresh' });
+    expect(client.getQueryState(['profile'])?.dataUpdatedAt).toBe(liveUpdatedAt);
+  });
+
+  // T-08b: without this the merge set stays empty until the first write, so a gc
+  // `removed` event more than 30 minutes into a launch triggers a first write
+  // that drops every mount-hydrated entry from disk.
+  it('seeds the writer’s merge set from what it hydrated', () => {
+    const client = new QueryClient();
+    restorePersistedCache(client, {
+      raw: blob([entry(['profile'], { id: OWNER }), entry(['myGyms'], [{ id: 'gym-1' }])]),
+      ownerHint: OWNER,
+      requireOwnerHint: false,
+      now: NOW,
+    });
+
+    expect(
+      getLastWrittenQueries()
+        .map((one) => one.queryKey[0])
+        .sort(),
+    ).toEqual(['myGyms', 'profile']);
+  });
+
+  it('carries the evicted flag out of the blob it read', () => {
+    const client = new QueryClient();
+    const outcome = restorePersistedCache(client, {
+      raw: blob([entry(['profile'], { id: OWNER })], { evicted: true }),
+      ownerHint: OWNER,
+      requireOwnerHint: false,
+      now: NOW,
+    });
+    expect(outcome.evicted).toBe(true);
+  });
+});

--- a/packages/mobile/src/lib/query-persist/__tests__/storage-native.test.ts
+++ b/packages/mobile/src/lib/query-persist/__tests__/storage-native.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// The shared vitest MMKV stub (test/react-native-mmkv-stub.ts) ignores `id` and
+// shares ONE process-wide Map across every "instance", so an isolation
+// assertion against it would false-pass. This suite registers its own mock with
+// a map per id — the same pattern settings/__tests__/offline-boards.test.ts uses.
+const instances = vi.hoisted(() => new Map<string, Map<string, string>>());
+vi.mock('react-native-mmkv', () => ({
+  createMMKV: ({ id }: { id: string }) => {
+    const store = instances.get(id) ?? new Map<string, string>();
+    instances.set(id, store);
+    return {
+      getString: (key: string) => store.get(key),
+      set: (key: string, value: string) => {
+        store.set(key, value);
+      },
+      remove: (key: string) => {
+        store.delete(key);
+      },
+      clearAll: () => {
+        store.clear();
+      },
+    };
+  },
+}));
+
+import {
+  REQUIRES_OWNER_HINT,
+  SUPPORTS_SYNC_RESTORE,
+  clearPersistedQueryCache,
+  persistedQueryCacheExists,
+  readCacheOwnerSync,
+  readPersistedCacheAsync,
+  readPersistedCacheSync,
+  writeCacheOwner,
+  writePersistedCache,
+} from '../storage';
+import { setSetting } from '../../../settings';
+
+const QUERY_CACHE_ID = 'boardsesh-query-cache';
+const SETTINGS_ID = 'boardsesh-settings';
+
+beforeEach(() => {
+  for (const store of instances.values()) store.clear();
+});
+
+// T-16b
+describe('native query-cache storage', () => {
+  it('declares the native restore contract', () => {
+    expect(SUPPORTS_SYNC_RESTORE).toBe(true);
+    // Without a mandatory owner sentinel a blob could hydrate while
+    // `persistedQueryCacheExists` answered "no" about it.
+    expect(REQUIRES_OWNER_HINT).toBe(true);
+  });
+
+  it('keeps the blob out of the settings instance', async () => {
+    writePersistedCache('{"version":1}');
+    writeCacheOwner('user-1');
+    setSetting('syncEnabledBoards', []);
+
+    expect([...(instances.get(QUERY_CACHE_ID)?.values() ?? [])]).toContain('{"version":1}');
+    expect([...(instances.get(SETTINGS_ID)?.values() ?? [])]).not.toContain('{"version":1}');
+    // ...and the settings instance is where the setting landed, so the two are
+    // genuinely separate files rather than one shared map.
+    expect(instances.get(SETTINGS_ID)?.size).toBeGreaterThan(0);
+  });
+
+  it('reads back synchronously and asynchronously', async () => {
+    writePersistedCache('{"version":1}');
+    writeCacheOwner('user-1');
+
+    expect(readPersistedCacheSync()).toBe('{"version":1}');
+    expect(readCacheOwnerSync()).toBe('user-1');
+    expect(await readPersistedCacheAsync()).toBe('{"version":1}');
+  });
+
+  it('answers presence from the short owner sentinel, not the blob', async () => {
+    expect(await persistedQueryCacheExists()).toBe(false);
+    // A blob with no sentinel is deliberately NOT "present": presence and
+    // hydratability have to agree, and a sentinel-less blob hydrates nothing.
+    writePersistedCache('{"version":1}');
+    expect(await persistedQueryCacheExists()).toBe(false);
+    writeCacheOwner('user-1');
+    expect(await persistedQueryCacheExists()).toBe(true);
+  });
+
+  it('clears both the blob and the owner key', async () => {
+    writePersistedCache('{"version":1}');
+    writeCacheOwner('user-1');
+
+    await clearPersistedQueryCache();
+
+    expect(readPersistedCacheSync()).toBeNull();
+    expect(readCacheOwnerSync()).toBeNull();
+    expect(await persistedQueryCacheExists()).toBe(false);
+    expect(instances.get(QUERY_CACHE_ID)?.size).toBe(0);
+  });
+});

--- a/packages/mobile/src/lib/query-persist/__tests__/storage-web-sweep.test.ts
+++ b/packages/mobile/src/lib/query-persist/__tests__/storage-web-sweep.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// `sweepOrphanedUserStorage` is the ONLY thing that ever reclaims a persisted
+// query cache orphaned by cookie expiry — otherwise up to 512 KB of profile data
+// per abandoned login sits in IndexedDB forever. It matches raw AsyncStorage
+// keys by the `:user:<id>:auth-session:<sid>` suffix, so this suite captures the
+// predicate it builds and runs the query-cache keys through it.
+const preferenceState = vi.hoisted(() => ({
+  index: {} as Record<string, number>,
+  removePredicate: null as ((key: string) => boolean) | null,
+}));
+
+vi.mock('../../preference-store', () => ({
+  getPreference: async () => preferenceState.index,
+  setPreference: async () => {},
+  removePreference: async () => {},
+  removePreferencesMatching: async (matchesKey: (key: string) => boolean) => {
+    preferenceState.removePredicate = matchesKey;
+  },
+}));
+
+import { sweepOrphanedUserStorage, userScopedStorageKey } from '../../user-storage-owner.web';
+import { QUERY_CACHE_STORAGE_BASES } from '../storage.web';
+
+const ORPHAN_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+const NOW = 1_800_000_000_000;
+const CURRENT_OWNER = { userId: 'user-1', authSessionId: 'login-2' };
+const STALE_OWNER = { userId: 'user-1', authSessionId: 'login-1' };
+const OTHER_USER = { userId: 'user-2', authSessionId: 'login-9' };
+
+beforeEach(() => {
+  preferenceState.index = {};
+  preferenceState.removePredicate = null;
+});
+
+// T-22
+describe('web query-cache keys and the orphan sweep', () => {
+  it('builds login-scoped keys and no key at all without an owner', () => {
+    for (const base of QUERY_CACHE_STORAGE_BASES) {
+      expect(userScopedStorageKey(base, CURRENT_OWNER)).toBe(`${base}:user:user-1:auth-session:login-2`);
+      // A null owner means "no readable blob" rather than an unscoped one — a
+      // cross-login read is not merely checked, it is unexpressible.
+      expect(userScopedStorageKey(base, null)).toBeNull();
+    }
+  });
+
+  it('reclaims both the blob and the meta key of a stale login', async () => {
+    preferenceState.index = {
+      'user-1:login-1': NOW - ORPHAN_RETENTION_MS - 1,
+    };
+
+    await sweepOrphanedUserStorage(CURRENT_OWNER, NOW);
+
+    const matches = preferenceState.removePredicate;
+    expect(matches).not.toBeNull();
+    for (const base of QUERY_CACHE_STORAGE_BASES) {
+      const staleKey = userScopedStorageKey(base, STALE_OWNER);
+      const liveKey = userScopedStorageKey(base, CURRENT_OWNER);
+      const otherUserKey = userScopedStorageKey(base, OTHER_USER);
+      expect(staleKey).not.toBeNull();
+      expect(matches?.(staleKey as string)).toBe(true);
+      // The login that is active right now, and any other account, are left alone.
+      expect(matches?.(liveKey as string)).toBe(false);
+      expect(matches?.(otherUserKey as string)).toBe(false);
+    }
+  });
+
+  it('leaves a recently active login alone', async () => {
+    preferenceState.index = { 'user-1:login-1': NOW - 1000 };
+    await sweepOrphanedUserStorage(CURRENT_OWNER, NOW);
+    expect(preferenceState.removePredicate).toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/query-persist/__tests__/writer.test.ts
+++ b/packages/mobile/src/lib/query-persist/__tests__/writer.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import { parsePersistedCache, serializePersistedCache, PERSISTED_CACHE_VERSION } from '../envelope';
+import { restorePersistedCache } from '../restore';
+import {
+  getLastWrittenQueries,
+  resetQueryPersistRuntime,
+  setLastWrittenQueries,
+  setPersistOwner,
+  setCacheWriter,
+  suspendCacheWriter,
+} from '../runtime';
+import { createCacheWriter, type CacheWriter } from '../writer';
+
+const OWNER = 'user-1';
+const DAY = 24 * 60 * 60 * 1000;
+
+type Harness = {
+  client: QueryClient;
+  writer: CacheWriter;
+  writes: string[];
+  fireScheduled: () => void;
+  scheduled: () => boolean;
+  cancelled: number;
+  stop: () => void;
+};
+
+function createHarness(now: () => number = Date.now): Harness {
+  const client = new QueryClient();
+  const writes: string[] = [];
+  let pending: (() => void) | null = null;
+  const state = { cancelled: 0 };
+
+  const writer = createCacheWriter({
+    client,
+    write: (serialized) => {
+      writes.push(serialized);
+    },
+    getOwner: () => {
+      // Mirrors the real wiring: the writer reads the runtime owner at fire time.
+      return runtimeOwner;
+    },
+    now,
+    schedule: (callback) => {
+      pending = callback;
+      return 'handle';
+    },
+    cancel: () => {
+      state.cancelled += 1;
+      pending = null;
+    },
+  });
+  const unsubscribe = writer.start();
+  setCacheWriter(writer);
+
+  return {
+    client,
+    writer,
+    writes,
+    fireScheduled: () => {
+      const callback = pending;
+      pending = null;
+      callback?.();
+    },
+    scheduled: () => pending !== null,
+    get cancelled() {
+      return state.cancelled;
+    },
+    stop: () => {
+      unsubscribe();
+      setCacheWriter(null);
+    },
+  };
+}
+
+// The real writer reads `getPersistOwner()`; the harness proxies it so a test can
+// flip ownership between scheduling and firing.
+let runtimeOwner: string | null = null;
+
+function armOwner(userId: string): void {
+  runtimeOwner = userId;
+  setPersistOwner(userId);
+}
+
+function disarmOwner(): void {
+  runtimeOwner = null;
+  suspendCacheWriter();
+}
+
+function keysIn(serialized: string): string[] {
+  const parsed = parsePersistedCache(serialized);
+  if (parsed.status !== 'ok') throw new Error(`unreadable write: ${parsed.status}`);
+  return parsed.envelope.queries.map((entry) => String(entry.queryKey[0])).sort();
+}
+
+beforeEach(() => {
+  runtimeOwner = null;
+  resetQueryPersistRuntime();
+});
+
+describe('createCacheWriter', () => {
+  // T-09
+  it('writes nothing while no owner is set, and writes once the owner arrives', () => {
+    const harness = createHarness();
+    harness.client.setQueryData(['profile'], { id: OWNER });
+    expect(harness.scheduled()).toBe(true);
+    harness.fireScheduled();
+    expect(harness.writes).toHaveLength(0);
+
+    armOwner(OWNER);
+    harness.client.setQueryData(['myGyms'], [{ id: 'gym-1' }]);
+    harness.fireScheduled();
+    expect(harness.writes).toHaveLength(1);
+    expect(keysIn(harness.writes[0])).toEqual(['myGyms', 'profile']);
+    harness.stop();
+  });
+
+  it('coalesces a burst into one trailing-edge write', () => {
+    const harness = createHarness();
+    armOwner(OWNER);
+    harness.client.setQueryData(['profile'], { id: OWNER });
+    harness.client.setQueryData(['myGyms'], []);
+    harness.client.setQueryData(['grades', 'kilter'], []);
+    expect(harness.scheduled()).toBe(true);
+    harness.fireScheduled();
+    expect(harness.writes).toHaveLength(1);
+    harness.stop();
+  });
+
+  it('flush() writes immediately and cancels the pending timer', () => {
+    const harness = createHarness();
+    armOwner(OWNER);
+    harness.client.setQueryData(['profile'], { id: OWNER });
+    harness.writer.flush();
+
+    expect(harness.writes).toHaveLength(1);
+    expect(harness.scheduled()).toBe(false);
+    expect(harness.cancelled).toBe(1);
+    harness.stop();
+  });
+
+  // T-09b, first half — the C1 regression test. `suspendCacheWriter` is a PAUSE:
+  // a queued write that fires after it does nothing, and the next
+  // `setPersistOwner` re-arms the same subscription with no restart call.
+  it('is paused (not killed) by suspendCacheWriter and re-arms on the next owner', () => {
+    const harness = createHarness();
+    armOwner(OWNER);
+    harness.client.setQueryData(['profile'], { id: OWNER });
+
+    disarmOwner();
+    harness.fireScheduled();
+    expect(harness.writes).toHaveLength(0);
+
+    // Same writer instance, no restart: setting an owner is the whole re-arm.
+    armOwner('user-2');
+    harness.client.setQueryData(['myGyms'], [{ id: 'gym-2' }]);
+    harness.fireScheduled();
+    expect(harness.writes).toHaveLength(1);
+    const parsed = parsePersistedCache(harness.writes[0]);
+    expect(parsed.status === 'ok' && parsed.envelope.userId).toBe('user-2');
+    harness.stop();
+  });
+
+  // T-09b, second half — the shape of a real logged-out launch → sign-in →
+  // background. The light signed-out path calls `suspendCacheWriter` on every
+  // anonymous launch, so this is the sequence a latched stop would break.
+  it('still persists for the first sign-in after an anonymous launch', () => {
+    const harness = createHarness();
+    // Anonymous cold start: clearPersistedUserStores → suspendCacheWriter.
+    disarmOwner();
+    harness.fireScheduled();
+    expect(harness.writes).toHaveLength(0);
+
+    // Sign-in: the auth boundary sets the owner.
+    armOwner(OWNER);
+    harness.client.setQueryData(['profile'], { id: OWNER });
+    harness.client.setQueryData(['myBoards', undefined], [{ uuid: 'board-1' }]);
+    // Backgrounding flushes — the guaranteed write point before any cold start.
+    harness.writer.flush();
+
+    expect(harness.writes).toHaveLength(1);
+    expect(keysIn(harness.writes[0])).toEqual(['myBoards', 'profile']);
+    harness.stop();
+  });
+
+  // T-08: React Query's 30-minute gcTime removes unobserved entries. Without
+  // merge-on-write the blob would erode toward "only what you looked at in the
+  // last 30 minutes".
+  it('carries a gc’d entry forward, but not one past its maxAge', () => {
+    const now = Date.now();
+    const harness = createHarness(() => now);
+    armOwner(OWNER);
+    setLastWrittenQueries([
+      {
+        queryHash: '["angles","kilter",8]',
+        queryKey: ['angles', 'kilter', 8],
+        state: { data: [40, 45], dataUpdatedAt: now - DAY, status: 'success', fetchStatus: 'idle' },
+      },
+      {
+        queryHash: '["grades","tension"]',
+        queryKey: ['grades', 'tension'],
+        state: { data: [], dataUpdatedAt: now - 15 * DAY, status: 'success', fetchStatus: 'idle' },
+      },
+    ] as unknown as ReturnType<typeof getLastWrittenQueries>);
+
+    harness.client.setQueryData(['profile'], { id: OWNER });
+    harness.fireScheduled();
+
+    // The day-old angles entry survives even though the client never held it;
+    // the 15-day-old grades entry is past its rule's 14-day maxAge.
+    expect(keysIn(harness.writes[0])).toEqual(['angles', 'profile']);
+    harness.stop();
+  });
+
+  it('lets a fresh entry win over the previously written one with the same hash', () => {
+    const harness = createHarness();
+    armOwner(OWNER);
+    setLastWrittenQueries([
+      {
+        queryHash: '["profile"]',
+        queryKey: ['profile'],
+        state: { data: { id: OWNER, name: 'old' }, dataUpdatedAt: Date.now(), status: 'success', fetchStatus: 'idle' },
+      },
+    ] as unknown as ReturnType<typeof getLastWrittenQueries>);
+
+    harness.client.setQueryData(['profile'], { id: OWNER, name: 'new' });
+    harness.fireScheduled();
+
+    const parsed = parsePersistedCache(harness.writes[0]);
+    expect(parsed.status === 'ok' && parsed.envelope.queries).toHaveLength(1);
+    expect(harness.writes[0]).toContain('"new"');
+    harness.stop();
+  });
+
+  // T-08b end-to-end: a restore seeds the merge set, so a first write triggered
+  // from an EMPTY client still contains what was hydrated at mount.
+  it('writes what the restore hydrated even when the client has since been emptied', () => {
+    const now = Date.now();
+    const raw = serializePersistedCache({
+      version: PERSISTED_CACHE_VERSION,
+      userId: OWNER,
+      savedAt: now,
+      queries: [
+        {
+          queryHash: '["profile"]',
+          queryKey: ['profile'],
+          state: { data: { id: OWNER }, dataUpdatedAt: now, status: 'success', fetchStatus: 'idle' },
+        },
+        {
+          queryHash: '["myGyms"]',
+          queryKey: ['myGyms'],
+          state: { data: [{ id: 'gym-1' }], dataUpdatedAt: now, status: 'success', fetchStatus: 'idle' },
+        },
+      ] as unknown as ReturnType<typeof getLastWrittenQueries>,
+    });
+
+    const harness = createHarness(() => now);
+    restorePersistedCache(harness.client, { raw, ownerHint: OWNER, requireOwnerHint: false, now });
+    armOwner(OWNER);
+    // The 30-minute gc sweep: every hydrated entry leaves the in-memory cache.
+    harness.client.clear();
+    harness.writer.flush();
+
+    expect(keysIn(harness.writes[0])).toEqual(['myGyms', 'profile']);
+    harness.stop();
+  });
+
+  it('reports the write failure through onError instead of throwing', () => {
+    const client = new QueryClient();
+    const onError = vi.fn();
+    let pending: (() => void) | null = null;
+    const writer = createCacheWriter({
+      client,
+      write: () => {
+        throw new Error('mmkv full');
+      },
+      getOwner: () => OWNER,
+      now: Date.now,
+      schedule: (callback) => {
+        pending = callback;
+        return 'handle';
+      },
+      cancel: () => {
+        pending = null;
+      },
+      onError,
+    });
+    const unsubscribe = writer.start();
+    client.setQueryData(['profile'], { id: OWNER });
+    expect(() => (pending as unknown as () => void)()).not.toThrow();
+    expect(onError).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+});

--- a/packages/mobile/src/lib/query-persist/allowlist.ts
+++ b/packages/mobile/src/lib/query-persist/allowlist.ts
@@ -1,0 +1,59 @@
+// The allowlist. This is a HARD GATE on the dehydrate path, not a filter that
+// someone can forget to update: every rule pins both the exact first key element
+// and the exact key length, so `['profile', somethingNew]` misses, and a future
+// `['profileSettings']` key cannot slip through on a prefix match.
+//
+// What is deliberately NOT here (issue #4353 / docs/offline-reads.md):
+//  - anything SQLite already owns (`searchClimbs`, `infiniteSearchClimbs`,
+//    `searchClimbsCount`, `climb`, `boardseshGrade`, `localTicks`, `logbook`),
+//  - `['activeBoard']` — already AsyncStorage-backed in `use-active-board.ts`,
+//    so persisting it here would double-store it,
+//  - everything with "now" semantics: feeds, sessions, `searchUsers`,
+//    `comments`, `bulkVoteSummaries`.
+
+const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+export type PersistRule = {
+  /** Exact first key element. */
+  readonly head: string;
+  /** Exact key length — arity is what makes this a gate rather than a prefix filter. */
+  readonly arity: number;
+  /** Measured from `state.dataUpdatedAt`; older entries are dropped on restore. */
+  readonly maxAgeMs: number;
+  /** LOWEST evicts first when the 512 KB cap is hit. */
+  readonly priority: number;
+  /** Extra per-rule check; a `false` return rejects the key. */
+  readonly guard?: (queryKey: readonly unknown[], ownerUserId: string) => boolean;
+};
+
+export const PERSISTED_QUERY_RULES: readonly PersistRule[] = [
+  // Highest priority: the entry that decides whether /boards/manage can render
+  // at all (`currentUserId = profile?.id ?? storedUserId`).
+  { head: 'profile', arity: 1, maxAgeMs: FOURTEEN_DAYS_MS, priority: 60 },
+  // Every `['myBoards', input]` variant, not just the plain roster: `useMyBoards`
+  // is called with `undefined` on manage/index/more and with an input elsewhere.
+  // Arity is the gate; the 64 KB per-entry cap and priority-50 eviction bound it.
+  { head: 'myBoards', arity: 2, maxAgeMs: FOURTEEN_DAYS_MS, priority: 50 },
+  { head: 'myGyms', arity: 1, maxAgeMs: FOURTEEN_DAYS_MS, priority: 40 },
+  { head: 'grades', arity: 2, maxAgeMs: FOURTEEN_DAYS_MS, priority: 30 },
+  { head: 'angles', arity: 3, maxAgeMs: FOURTEEN_DAYS_MS, priority: 20 },
+  // Only the signed-in user's own public profile, and only for a day: it carries
+  // follower counts and recent activity, which go stale fast.
+  {
+    head: 'publicProfile',
+    arity: 2,
+    maxAgeMs: ONE_DAY_MS,
+    priority: 10,
+    guard: (queryKey, ownerUserId) => queryKey[1] === ownerUserId,
+  },
+];
+
+/** The rule this key persists under, or undefined when it is not allowlisted. */
+export function matchPersistRule(queryKey: readonly unknown[], ownerUserId: string): PersistRule | undefined {
+  const head = queryKey[0];
+  if (typeof head !== 'string') return undefined;
+  return PERSISTED_QUERY_RULES.find(
+    (rule) => rule.head === head && queryKey.length === rule.arity && rule.guard?.(queryKey, ownerUserId) !== false,
+  );
+}

--- a/packages/mobile/src/lib/query-persist/auth-boundary.ts
+++ b/packages/mobile/src/lib/query-persist/auth-boundary.ts
@@ -1,0 +1,135 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { SHARED_EVENTS, type AnalyticsEventProperties } from '@boardsesh/analytics';
+import { track } from '../analytics';
+import { reportHandledError } from '../error-reporting';
+import type { UserStorageOwner } from '../user-storage-owner';
+import { getLastRestore, getPersistOwner, markRestoreReported, setLastRestore, setPersistOwner } from './runtime';
+import { restorePersistedCache, type RestoreOutcome } from './restore';
+import { SUPPORTS_SYNC_RESTORE, clearPersistedQueryCache, readPersistedCacheAsync, writeCacheOwner } from './storage';
+
+export type OwnerTransition = 'adopt' | 'evict-then-adopt' | 'evict';
+
+/**
+ * Pure. `resolvedUserId === undefined` → `evict`: we cannot prove who this
+ * device belongs to, so we do not serve the blob. Otherwise adopt, evicting
+ * first when the blob is stamped with someone else.
+ */
+export function decideOwnerTransition(input: {
+  resolvedUserId: string | undefined;
+  hydratedUserId: string | undefined;
+}): OwnerTransition {
+  if (input.resolvedUserId === undefined) return 'evict';
+  if (input.hydratedUserId === undefined) return 'adopt';
+  return input.hydratedUserId === input.resolvedUserId ? 'adopt' : 'evict-then-adopt';
+}
+
+function restoreEventProperties(outcome: RestoreOutcome): AnalyticsEventProperties {
+  // Absent-when-unknown throughout, never 0-when-unknown. `entryCount` and
+  // `bytes` are facts only when the blob was actually parsed and owned; on
+  // `unreadable` / `owner_mismatch` / `owner_missing` nothing was inspected, so
+  // the honest answer is "no property".
+  const measured = outcome.outcome === 'hydrated' || outcome.outcome === 'empty';
+  return {
+    outcome: outcome.outcome,
+    ...(measured ? { entryCount: outcome.entryCount, bytes: outcome.bytes } : {}),
+    ...(outcome.droppedCount > 0 ? { droppedCount: outcome.droppedCount } : {}),
+    ...(outcome.outcome === 'hydrated' && outcome.oldestEntryAgeHours !== undefined
+      ? { oldestEntryAgeHours: outcome.oldestEntryAgeHours }
+      : {}),
+    ...(outcome.evicted === true ? { evicted: true } : {}),
+  };
+}
+
+/**
+ * Reconcile the persisted cache with the account auth just resolved.
+ *
+ * @param owner ALWAYS pass `undefined` from the auth boundary. This runs after
+ * `handleAuthenticatedTransition` has called `setCurrentUserStorageOwner`, so
+ * `undefined` resolves the account that just authenticated. Passing an
+ * explicitly captured owner is the bug this comment exists to prevent: on web a
+ * pre-transition owner is `null` on every cold start, and
+ * `userScopedStorageKey(base, null)` returns null — the read, and the
+ * mismatch-path delete, would both silently no-op.
+ */
+export async function adoptPersistedQueryCache(
+  client: QueryClient,
+  resolvedUserId: string | undefined,
+  owner?: UserStorageOwner | null,
+): Promise<void> {
+  // Idempotence gate. `checkAuth` runs on every foreground, so without this a
+  // day-old blob would be re-hydrated over a live session (resurrecting entries
+  // that session had invalidated) and an in-launch account switch would re-fire
+  // the owner-mismatch alarm on every foreground after it.
+  if (resolvedUserId !== undefined && getPersistOwner() === resolvedUserId) return;
+
+  let restore: RestoreOutcome | null;
+  if (SUPPORTS_SYNC_RESTORE) {
+    // Native already restored synchronously in QueryProvider's lazy initializer.
+    restore = getLastRestore();
+  } else if (resolvedUserId === undefined) {
+    restore = null;
+  } else {
+    restore = restorePersistedCache(client, {
+      raw: await readPersistedCacheAsync(owner),
+      ownerHint: resolvedUserId,
+      requireOwnerHint: false,
+      now: Date.now(),
+    });
+    setLastRestore(restore);
+  }
+
+  const transition = decideOwnerTransition({
+    // The blob's OWN stamp, whatever the outcome — that is what decides whether
+    // the bytes on disk belong to the account auth just resolved.
+    resolvedUserId,
+    hydratedUserId: restore?.userId,
+  });
+  // A blob that exists but did not hydrate — a torn write, a corrupted or
+  // future-versioned file, or one whose entries have all aged out — is dead
+  // weight that will never be read again, so it goes too.
+  const hasUnusableBlob = restore !== null && restore.outcome !== 'absent' && restore.outcome !== 'hydrated';
+  // The P0 alarm: bytes on this device belong to an account other than the one
+  // auth just resolved, which means a sign-out wipe failed. Two ways to see it —
+  // the blob's stamp disagreeing with resolved auth (`evict-then-adopt`), and
+  // the restore having already caught the stamp disagreeing with the platform's
+  // owner hint. `owner_missing` is a torn write, not a leak, and stays silent so
+  // this signal keeps meaning something.
+  const ownerDisagreement = transition === 'evict-then-adopt' || restore?.outcome === 'owner_mismatch';
+
+  if (transition !== 'adopt' || hasUnusableBlob) {
+    if (restore) {
+      // Precise removal, not `client.clear()`: anything legitimately fetched
+      // since the restore must survive.
+      for (const queryHash of restore.hydratedHashes) {
+        client.removeQueries({ predicate: (query) => query.queryHash === queryHash });
+      }
+    }
+    await clearPersistedQueryCache(owner);
+    if (ownerDisagreement) {
+      reportHandledError(new Error('Persisted query cache owner mismatch'), {
+        tags: { source: 'query-persist' },
+      });
+    }
+  }
+
+  if (transition !== 'evict' && resolvedUserId !== undefined) {
+    setPersistOwner(resolvedUserId);
+    writeCacheOwner(resolvedUserId);
+  }
+
+  // Fired at most once per launch, and only when a blob existed at all, so a
+  // first-run or signed-out launch emits nothing.
+  if (restore && restore.outcome !== 'absent' && markRestoreReported()) {
+    track(
+      SHARED_EVENTS.OfflineQueryCacheRestored,
+      // An owner disagreement is reported as such even when the restore itself
+      // said 'hydrated' — those entries were evicted again moments later, so
+      // calling the launch 'hydrated' would hide the alarm from the funnel.
+      ownerDisagreement ? { outcome: 'owner_mismatch' as const } : restoreEventProperties(restore),
+    );
+  }
+
+  // Consumed. A later transition must see "nothing was restored" rather than
+  // re-deciding against a user who has already left.
+  setLastRestore(null);
+}

--- a/packages/mobile/src/lib/query-persist/budget.ts
+++ b/packages/mobile/src/lib/query-persist/budget.ts
@@ -1,0 +1,84 @@
+import { serializePersistedCache, utf8ByteLength, type PersistedQueryEntry } from './envelope';
+
+/**
+ * Asserted by a test against a realistic populated cache (profile + 6 boards +
+ * 3 gyms + grades/angles for two boards), not enforced at runtime. If a real
+ * device drifts past it, the `bytes` property on the restore event says so long
+ * before the hard cap does.
+ */
+export const PERSIST_TARGET_BYTES = 100 * 1024;
+/** Hard cap. Past this, entries are evicted lowest-priority-first until it fits. */
+export const PERSIST_MAX_BYTES = 512 * 1024;
+/** One entry this big is a bug in the allowlist, not something to make room for. */
+export const PERSIST_MAX_ENTRY_BYTES = 64 * 1024;
+
+export type BudgetCandidate = {
+  readonly entry: PersistedQueryEntry;
+  readonly priority: number;
+};
+
+export type BudgetResult = {
+  readonly kept: readonly PersistedQueryEntry[];
+  readonly droppedOversize: number;
+  readonly droppedEvicted: number;
+  /** Serialized size of the kept entries, including the JSON array delimiters. */
+  readonly bytes: number;
+};
+
+/** Serialized size of one entry, measured once and reused by every pass below. */
+function entryBytes(entry: PersistedQueryEntry): number {
+  return utf8ByteLength(JSON.stringify(entry));
+}
+
+/**
+ * The array's own bytes: `[` + `]` plus one comma between entries. Close enough
+ * that the caller can add the envelope's fixed overhead and compare against a
+ * cap without re-stringifying the whole blob on every candidate drop.
+ */
+function totalBytes(sizes: readonly number[]): number {
+  if (sizes.length === 0) return 2;
+  return sizes.reduce((sum, size) => sum + size, 0) + sizes.length + 1;
+}
+
+/**
+ * Drop what cannot fit, in two passes:
+ *  1. any single entry over `PERSIST_MAX_ENTRY_BYTES`,
+ *  2. while the rest still exceeds `PERSIST_MAX_BYTES`, evict ascending by
+ *     priority and, within a priority, oldest `dataUpdatedAt` first.
+ *
+ * Lowest priority first is what keeps `['profile']` — the entry the whole
+ * feature exists for — as the last thing standing.
+ */
+export function applyBudget(candidates: readonly BudgetCandidate[]): BudgetResult {
+  const sized = candidates
+    .map((candidate) => ({ ...candidate, bytes: entryBytes(candidate.entry) }))
+    .filter((candidate) => candidate.bytes <= PERSIST_MAX_ENTRY_BYTES);
+  const droppedOversize = candidates.length - sized.length;
+
+  // Ascending: the head of this list is what gets evicted first.
+  sized.sort((left, right) => {
+    if (left.priority !== right.priority) return left.priority - right.priority;
+    return (left.entry.state.dataUpdatedAt ?? 0) - (right.entry.state.dataUpdatedAt ?? 0);
+  });
+
+  let firstKeptIndex = 0;
+  while (
+    firstKeptIndex < sized.length &&
+    totalBytes(sized.slice(firstKeptIndex).map((candidate) => candidate.bytes)) > PERSIST_MAX_BYTES
+  ) {
+    firstKeptIndex += 1;
+  }
+
+  const keptCandidates = sized.slice(firstKeptIndex);
+  return {
+    kept: keptCandidates.map((candidate) => candidate.entry),
+    droppedOversize,
+    droppedEvicted: firstKeptIndex,
+    bytes: totalBytes(keptCandidates.map((candidate) => candidate.bytes)),
+  };
+}
+
+/** Serialized size of a whole envelope — used by tests and by the restore path. */
+export function envelopeBytes(userId: string, savedAt: number, queries: readonly PersistedQueryEntry[]): number {
+  return utf8ByteLength(serializePersistedCache({ version: 1, userId, savedAt, queries }));
+}

--- a/packages/mobile/src/lib/query-persist/dehydrate.ts
+++ b/packages/mobile/src/lib/query-persist/dehydrate.ts
@@ -1,0 +1,28 @@
+import { dehydrate, type QueryClient } from '@tanstack/react-query';
+import { matchPersistRule } from './allowlist';
+import type { PersistedQueryEntry } from './envelope';
+
+/**
+ * Dehydrate exactly the allowlisted entries and nothing else.
+ *
+ * The allowlist check lives INSIDE `shouldDehydrateQuery`, so a non-allowlisted
+ * key is never serialized in the first place — there is no post-filter step to
+ * forget. `status === 'success'` does double duty: it keeps errored and
+ * in-flight entries out, and it guarantees query-core's `dehydrateQuery` never
+ * attaches the non-serializable `promise` it adds for pending queries.
+ */
+export function dehydrateAllowlisted(client: QueryClient, ownerUserId: string): PersistedQueryEntry[] {
+  const state = dehydrate(client, {
+    // Hard-coded false, never a variable and never a parameter: `pending_mutations`
+    // in SQLite is the outbox, and a second persisted outbox is a double-submit
+    // hazard. `PersistedCacheEnvelope` has no `mutations` field either, so this
+    // is one of two independent defences (issue #4353).
+    shouldDehydrateMutation: () => false,
+    shouldDehydrateQuery: (query) =>
+      query.state.status === 'success' &&
+      query.state.data !== undefined &&
+      query.state.fetchStatus === 'idle' &&
+      matchPersistRule(query.queryKey, ownerUserId) !== undefined,
+  });
+  return state.queries;
+}

--- a/packages/mobile/src/lib/query-persist/envelope.ts
+++ b/packages/mobile/src/lib/query-persist/envelope.ts
@@ -1,0 +1,111 @@
+import type { DehydratedState } from '@tanstack/react-query';
+
+/** `DehydratedQuery` is not exported by query-core; derive it from the state. */
+export type PersistedQueryEntry = DehydratedState['queries'][number];
+
+/**
+ * Bump ONLY when the persisted *value* shape breaks (a changed envelope field, a
+ * transform applied to `state.data`). A changed query KEY shape needs no bump:
+ * a different key yields a different `queryHash`, so the stale entry is simply
+ * never found and ages out under its rule's `maxAge`.
+ *
+ * A blob stamped with any other version parses as `unreadable: 'version'` and is
+ * discarded, which is the intended migration story — this is a cache, not a
+ * source of truth, so re-fetching once is the correct upgrade path.
+ */
+export const PERSISTED_CACHE_VERSION = 1;
+
+/**
+ * What lands on disk.
+ *
+ * **There is deliberately no `mutations` field.** `pending_mutations` in SQLite
+ * is the outbox; a second persisted outbox is a genuine double-submit hazard.
+ * The type makes it unrepresentable, and `dehydrateAllowlisted` additionally
+ * hard-codes `shouldDehydrateMutation: () => false`. Two independent defences.
+ */
+export type PersistedCacheEnvelope = {
+  readonly version: typeof PERSISTED_CACHE_VERSION;
+  /** The account this blob belongs to. Re-checked against resolved auth before anything hydrates. */
+  readonly userId: string;
+  readonly savedAt: number;
+  /** Set only when the write that produced this blob had to evict to fit the 512 KB cap. */
+  readonly evicted?: true;
+  readonly queries: readonly PersistedQueryEntry[];
+};
+
+export type ParsedCache =
+  | { status: 'absent' }
+  | { status: 'unreadable'; reason: 'json' | 'shape' | 'version' }
+  | { status: 'ok'; envelope: PersistedCacheEnvelope };
+
+export function serializePersistedCache(envelope: PersistedCacheEnvelope): string {
+  return JSON.stringify(envelope);
+}
+
+export function parsePersistedCache(raw: string | null | undefined): ParsedCache {
+  if (raw === null || raw === undefined || raw === '') return { status: 'absent' };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { status: 'unreadable', reason: 'json' };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) return { status: 'unreadable', reason: 'shape' };
+  const candidate = parsed as Partial<PersistedCacheEnvelope>;
+  // Version is checked before shape so a future build's envelope reads as a
+  // version mismatch (expected, silent) rather than corruption (an alarm).
+  if (candidate.version !== PERSISTED_CACHE_VERSION) return { status: 'unreadable', reason: 'version' };
+  if (typeof candidate.userId !== 'string' || candidate.userId.length === 0) {
+    return { status: 'unreadable', reason: 'shape' };
+  }
+  if (typeof candidate.savedAt !== 'number' || !Array.isArray(candidate.queries)) {
+    return { status: 'unreadable', reason: 'shape' };
+  }
+
+  return {
+    status: 'ok',
+    envelope: {
+      version: PERSISTED_CACHE_VERSION,
+      userId: candidate.userId,
+      savedAt: candidate.savedAt,
+      ...(candidate.evicted === true ? { evicted: true as const } : {}),
+      queries: candidate.queries,
+    },
+  };
+}
+
+/**
+ * UTF-8 byte length, counted by hand rather than via `TextEncoder`.
+ *
+ * Same reasoning as `jwt-user-id.ts`'s hand-rolled `utf8Decode`: this runs on
+ * Hermes, on Node (vitest) and in jsdom, and the budget assertions have to agree
+ * across all three. A code-unit loop with explicit surrogate-pair handling is
+ * deterministic everywhere; `TextEncoder`'s presence is not.
+ */
+export function utf8ByteLength(value: string): number {
+  let bytes = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit < 0x80) {
+      bytes += 1;
+    } else if (codeUnit < 0x800) {
+      bytes += 2;
+    } else if (codeUnit >= 0xd800 && codeUnit <= 0xdbff && index + 1 < value.length) {
+      const trailUnit = value.charCodeAt(index + 1);
+      if (trailUnit >= 0xdc00 && trailUnit <= 0xdfff) {
+        // A well-formed surrogate pair is one 4-byte code point.
+        bytes += 4;
+        index += 1;
+        continue;
+      }
+      // A lone high surrogate: JSON.stringify emits it as-is, and UTF-8
+      // encoders substitute U+FFFD, which is 3 bytes either way.
+      bytes += 3;
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}

--- a/packages/mobile/src/lib/query-persist/index.ts
+++ b/packages/mobile/src/lib/query-persist/index.ts
@@ -1,0 +1,71 @@
+/**
+ * An in-house, allowlisted, user-scoped persister for the React Query cache
+ * (issue #4353, stage 2 of the `docs/offline-reads.md` decision).
+ *
+ * Six keys only — `['profile']`, `['myBoards', …]`, `['myGyms']`,
+ * `['grades', board]`, `['angles', board, layout]`, `['publicProfile', selfId]` —
+ * so a cold start with no signal already knows who you are and which walls are
+ * yours, instead of rendering "Something went wrong" on My Boards.
+ *
+ * Shape of the thing:
+ *  - the allowlist is a hard gate on the DEHYDRATE path and is re-applied on the
+ *    restore path, so neither a new query key nor a tampered blob can widen it;
+ *  - the envelope type has no `mutations` field, and `dehydrateAllowlisted`
+ *    hard-codes `shouldDehydrateMutation: () => false` — SQLite's
+ *    `pending_mutations` is the one outbox;
+ *  - native restores SYNCHRONOUSLY from MMKV inside `QueryProvider`'s lazy
+ *    initializer (no `isRestoring` frame); web restores asynchronously at the
+ *    auth boundary, awaited before the loading gate releases;
+ *  - the writer is armed purely by a runtime owner read at write-fire time, so
+ *    sign-out is a pause (`suspendCacheWriter`) that any later sign-in re-arms.
+ *
+ * Deliberately in `packages/mobile` rather than `packages/shared`: web has its
+ * own IndexedDB stack and its climbing surfaces are deprecated (#3122).
+ * Promoting it later is a file move plus a `package.json`.
+ */
+export { PERSISTED_QUERY_RULES, matchPersistRule, type PersistRule } from './allowlist';
+export {
+  PERSISTED_CACHE_VERSION,
+  parsePersistedCache,
+  serializePersistedCache,
+  utf8ByteLength,
+  type ParsedCache,
+  type PersistedCacheEnvelope,
+  type PersistedQueryEntry,
+} from './envelope';
+export {
+  PERSIST_MAX_BYTES,
+  PERSIST_MAX_ENTRY_BYTES,
+  PERSIST_TARGET_BYTES,
+  applyBudget,
+  envelopeBytes,
+  type BudgetCandidate,
+  type BudgetResult,
+} from './budget';
+export { dehydrateAllowlisted } from './dehydrate';
+export { restorePersistedCache, type RestoreInput, type RestoreOutcome } from './restore';
+export { createCacheWriter, type CacheWriter, type CacheWriterInput } from './writer';
+export {
+  getLastRestore,
+  getLastWrittenQueries,
+  getPersistOwner,
+  markRestoreReported,
+  resetQueryPersistRuntime,
+  setCacheWriter,
+  setLastRestore,
+  setLastWrittenQueries,
+  setPersistOwner,
+  suspendCacheWriter,
+} from './runtime';
+export { adoptPersistedQueryCache, decideOwnerTransition, type OwnerTransition } from './auth-boundary';
+export {
+  REQUIRES_OWNER_HINT,
+  SUPPORTS_SYNC_RESTORE,
+  clearPersistedQueryCache,
+  persistedQueryCacheExists,
+  readCacheOwnerSync,
+  readPersistedCacheAsync,
+  readPersistedCacheSync,
+  writeCacheOwner,
+  writePersistedCache,
+} from './storage';

--- a/packages/mobile/src/lib/query-persist/restore.ts
+++ b/packages/mobile/src/lib/query-persist/restore.ts
@@ -1,0 +1,117 @@
+import { hydrate, type QueryClient } from '@tanstack/react-query';
+import { matchPersistRule } from './allowlist';
+import { PERSIST_MAX_ENTRY_BYTES } from './budget';
+import { parsePersistedCache, utf8ByteLength, type PersistedQueryEntry } from './envelope';
+import { setLastWrittenQueries } from './runtime';
+
+export type RestoreOutcome = {
+  readonly outcome: 'hydrated' | 'absent' | 'unreadable' | 'owner_mismatch' | 'owner_missing' | 'empty';
+  /** The blob's own stamped owner, when it parsed. */
+  readonly userId?: string;
+  /** Hashes actually put into the cache — what an evict has to remove again. */
+  readonly hydratedHashes: readonly string[];
+  readonly entryCount: number;
+  readonly droppedCount: number;
+  readonly bytes: number;
+  readonly oldestEntryAgeHours?: number;
+  readonly evicted?: true;
+};
+
+export type RestoreInput = {
+  readonly raw: string | null;
+  /** Who auth says this device belongs to; `null` means "we could not tell". */
+  readonly ownerHint: string | null;
+  /**
+   * When true, a `null` ownerHint hydrates NOTHING. Native sets this: its
+   * presence check (`persistedQueryCacheExists`) is defined as the short owner
+   * sentinel existing, so a blob that could hydrate without one would be
+   * invisible to the sign-out wipe.
+   */
+  readonly requireOwnerHint: boolean;
+  readonly now: number;
+};
+
+const EMPTY_HASHES: readonly string[] = [];
+
+function outcomeOnly(
+  outcome: RestoreOutcome['outcome'],
+  extra?: Partial<Omit<RestoreOutcome, 'outcome' | 'hydratedHashes'>>,
+): RestoreOutcome {
+  return { outcome, hydratedHashes: EMPTY_HASHES, entryCount: 0, droppedCount: 0, bytes: 0, ...extra };
+}
+
+/**
+ * Parse a persisted blob and hydrate what still qualifies.
+ *
+ * The allowlist is re-applied HERE, not only on the dehydrate path: a blob
+ * written by a future build (or tampered with on a rooted device) must not be
+ * able to smuggle a non-allowlisted key — or another climber's `publicProfile` —
+ * into memory. Ownership is checked before a single entry is inspected.
+ */
+export function restorePersistedCache(client: QueryClient, input: RestoreInput): RestoreOutcome {
+  const parsed = parsePersistedCache(input.raw);
+  if (parsed.status === 'absent') return outcomeOnly('absent');
+  if (parsed.status === 'unreadable') return outcomeOnly('unreadable');
+
+  const { envelope } = parsed;
+  const blobBytes = utf8ByteLength(input.raw ?? '');
+
+  if (input.requireOwnerHint && input.ownerHint === null) {
+    // A torn write or an older build: the blob is there but the sentinel that
+    // proves who it belongs to is not. Not a leak, so not a Sentry alarm — but
+    // nothing hydrates and the caller deletes it.
+    return outcomeOnly('owner_missing', { userId: envelope.userId, bytes: blobBytes });
+  }
+  if (input.ownerHint !== null && envelope.userId !== input.ownerHint) {
+    return outcomeOnly('owner_mismatch', { userId: envelope.userId, bytes: blobBytes });
+  }
+
+  let droppedCount = 0;
+  const kept: PersistedQueryEntry[] = [];
+  for (const entry of envelope.queries) {
+    const rule = Array.isArray(entry?.queryKey) ? matchPersistRule(entry.queryKey, envelope.userId) : undefined;
+    if (!rule) {
+      droppedCount += 1;
+      continue;
+    }
+    const updatedAt = entry.state?.dataUpdatedAt ?? 0;
+    if (input.now - updatedAt > rule.maxAgeMs) {
+      droppedCount += 1;
+      continue;
+    }
+    if (utf8ByteLength(JSON.stringify(entry)) > PERSIST_MAX_ENTRY_BYTES) {
+      droppedCount += 1;
+      continue;
+    }
+    kept.push(entry);
+  }
+
+  if (kept.length === 0) {
+    return outcomeOnly('empty', { userId: envelope.userId, droppedCount, bytes: blobBytes });
+  }
+
+  // `mutations: []` is explicit rather than omitted so the shape of what we hand
+  // React Query is impossible to misread at the call site.
+  hydrate(client, { mutations: [], queries: kept });
+  // Seed the merge set from what we just hydrated. Without this the writer's
+  // previous-set is empty until its first write, so a gc `removed` event more
+  // than 30 minutes into a launch would trigger a first write that drops every
+  // mount-hydrated entry from disk — the exact erosion merge-on-write exists to
+  // prevent.
+  setLastWrittenQueries(kept);
+
+  const oldestUpdatedAt = kept.reduce(
+    (oldest, entry) => Math.min(oldest, entry.state?.dataUpdatedAt ?? input.now),
+    input.now,
+  );
+  return {
+    outcome: 'hydrated',
+    userId: envelope.userId,
+    hydratedHashes: kept.map((entry) => entry.queryHash),
+    entryCount: kept.length,
+    droppedCount,
+    bytes: blobBytes,
+    oldestEntryAgeHours: Math.max(0, Math.round((input.now - oldestUpdatedAt) / (60 * 60 * 1000))),
+    ...(envelope.evicted === true ? { evicted: true as const } : {}),
+  };
+}

--- a/packages/mobile/src/lib/query-persist/runtime.ts
+++ b/packages/mobile/src/lib/query-persist/runtime.ts
@@ -1,0 +1,84 @@
+import type { PersistedQueryEntry } from './envelope';
+import type { RestoreOutcome } from './restore';
+import type { CacheWriter } from './writer';
+
+// The only mutable state in this module tree. Module singletons rather than
+// React state on purpose: the writer subscribes to the query cache outside
+// React, and the auth boundary is a callback deep inside AuthProvider that
+// cannot reach a hook.
+
+let persistOwner: string | null = null;
+let lastRestore: RestoreOutcome | null = null;
+let lastWrittenQueries: readonly PersistedQueryEntry[] = [];
+let cacheWriter: CacheWriter | null = null;
+let restoreReported = false;
+
+/** Read at write-FIRE time (never at schedule time) — see `createCacheWriter`. */
+export function getPersistOwner(): string | null {
+  return persistOwner;
+}
+
+/**
+ * Arm the writer for `userId`. There is no separate "start" call: setting an
+ * owner is what makes writes happen, and clearing it is what stops them.
+ */
+export function setPersistOwner(userId: string): void {
+  persistOwner = userId;
+}
+
+export function getLastRestore(): RestoreOutcome | null {
+  return lastRestore;
+}
+
+export function setLastRestore(outcome: RestoreOutcome | null): void {
+  lastRestore = outcome;
+}
+
+/** The previous write's entries, merged forward so gc cannot erode the blob. */
+export function getLastWrittenQueries(): readonly PersistedQueryEntry[] {
+  return lastWrittenQueries;
+}
+
+export function setLastWrittenQueries(entries: readonly PersistedQueryEntry[]): void {
+  lastWrittenQueries = entries;
+}
+
+export function setCacheWriter(writer: CacheWriter | null): void {
+  cacheWriter = writer;
+}
+
+/**
+ * Sign-out / anonymous-transition entry point. SYNCHRONOUS and idempotent:
+ * clears the owner (so any queued or future write is a no-op), cancels the
+ * pending throttle, and clears the merge set + lastRestore so the next account
+ * starts from nothing.
+ *
+ * Deliberately a PAUSE, not a permanent stop. `clearPersistedUserStores` runs on
+ * the LIGHT signed-out path too, which fires on every logged-out cold start and
+ * every anonymous foreground re-check — a latched stop would therefore be dead
+ * from the first anonymous launch onward, and the first sign-in after it would
+ * persist nothing. The writer stays subscribed for the app's lifetime and
+ * `setPersistOwner` re-arms it.
+ */
+export function suspendCacheWriter(): void {
+  persistOwner = null;
+  lastRestore = null;
+  lastWrittenQueries = [];
+  cacheWriter?.suspend();
+}
+
+/** True the first time it is called in a launch; false forever after. */
+export function markRestoreReported(): boolean {
+  if (restoreReported) return false;
+  restoreReported = true;
+  return true;
+}
+
+/** Tests only. */
+export function resetQueryPersistRuntime(): void {
+  persistOwner = null;
+  lastRestore = null;
+  lastWrittenQueries = [];
+  cacheWriter = null;
+  restoreReported = false;
+}

--- a/packages/mobile/src/lib/query-persist/storage.ts
+++ b/packages/mobile/src/lib/query-persist/storage.ts
@@ -1,0 +1,58 @@
+import { createMMKV } from 'react-native-mmkv';
+import type { UserStorageOwner } from '../user-storage-owner';
+
+// A DEDICATED MMKV instance, not `boardsesh-settings`. Two reasons: a blob up to
+// 512 KB has no business sharing the settings file, and `resetAllSettings()`
+// calls `clearAll()` on that instance — which would silently take the query
+// cache with it.
+const storage = createMMKV({ id: 'boardsesh-query-cache' });
+
+const CACHE_KEY = 'queryCacheV1';
+const OWNER_KEY = 'queryCacheOwnerV1';
+
+/** Native reads MMKV synchronously, so the restore happens before first render. */
+export const SUPPORTS_SYNC_RESTORE = true;
+/**
+ * A blob with no owner sentinel hydrates NOTHING on native. Presence
+ * (`persistedQueryCacheExists`) is defined as the sentinel existing, so allowing
+ * a sentinel-less blob to hydrate would make hydrated data invisible to the
+ * sign-out wipe. Making the hint mandatory keeps presence and hydratability in
+ * exact agreement.
+ */
+export const REQUIRES_OWNER_HINT = true;
+
+export function readPersistedCacheSync(): string | null {
+  return storage.getString(CACHE_KEY) ?? null;
+}
+
+export function readCacheOwnerSync(): string | null {
+  return storage.getString(OWNER_KEY) ?? null;
+}
+
+export async function readPersistedCacheAsync(_owner?: UserStorageOwner | null): Promise<string | null> {
+  return readPersistedCacheSync();
+}
+
+export function writePersistedCache(serialized: string, _owner?: UserStorageOwner | null): void {
+  storage.set(CACHE_KEY, serialized);
+}
+
+export function writeCacheOwner(userId: string): void {
+  storage.set(OWNER_KEY, userId);
+}
+
+/**
+ * Cheap on purpose: the short owner sentinel, never the blob. This is called on
+ * every anonymous transition, and reading up to 512 KB of JSON just to answer a
+ * boolean would be wasteful. `getString(...) !== undefined` rather than
+ * `contains(...)` because the shared vitest MMKV stub implements only
+ * getString/set/remove/clearAll.
+ */
+export async function persistedQueryCacheExists(_owner?: UserStorageOwner | null): Promise<boolean> {
+  return storage.getString(OWNER_KEY) !== undefined;
+}
+
+export async function clearPersistedQueryCache(_owner?: UserStorageOwner | null): Promise<void> {
+  storage.remove(CACHE_KEY);
+  storage.remove(OWNER_KEY);
+}

--- a/packages/mobile/src/lib/query-persist/storage.web.ts
+++ b/packages/mobile/src/lib/query-persist/storage.web.ts
@@ -1,0 +1,88 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { userScopedStorageKey } from '../user-storage-owner.web';
+import type { UserStorageOwner } from '../user-storage-owner';
+import { utf8ByteLength } from './envelope';
+
+// Web keys are LOGIN-scoped via `userScopedStorageKey`, which means three things
+// on purpose:
+//
+// 1. They carry the exact `:user:<id>:auth-session:<sid>` suffix and live in the
+//    plain AsyncStorage keyspace, so `sweepOrphanedUserStorage` →
+//    `removePreferencesMatching` can reclaim them. That sweep is the only thing
+//    that ever cleans up a blob orphaned by cookie expiry — otherwise up to
+//    512 KB of profile data per abandoned login sits there forever.
+// 2. A null key (no resolvable owner) makes every read/write/delete a silent
+//    no-op, exactly like `session-store.web.ts`. A cross-login read is not
+//    merely checked, it is unexpressible.
+// 3. The blob is written with `AsyncStorage.setItem` DIRECTLY rather than
+//    through `preference-store`. `setPreference` would `JSON.stringify` an
+//    already-serialized JSON string, adding escaping overhead and forcing a
+//    `JSON.parse` on read just to recover the string before parsing it again —
+//    which both makes the byte budget disagree with what is actually stored and
+//    costs real milliseconds on a cold start. `removePreferencesMatching`
+//    operates on raw keys, so bypassing the wrapper costs nothing in sweep
+//    coverage.
+const BLOB_BASE = 'boardsesh_query_cache_v1';
+const META_BASE = 'boardsesh_query_cache_meta_v1';
+
+/** No MMKV mirror on web: its web build is `localStorage` on the Next app's origin. */
+export const SUPPORTS_SYNC_RESTORE = false;
+/** The login-scoped key already proves ownership; the blob's stamp is the belt to that braces. */
+export const REQUIRES_OWNER_HINT = false;
+
+// No `userId` field: on web the owning account is already in the key itself.
+type CacheMeta = { savedAt: number; bytes: number };
+
+export function readPersistedCacheSync(): string | null {
+  return null;
+}
+
+export function readCacheOwnerSync(): string | null {
+  return null;
+}
+
+export async function readPersistedCacheAsync(owner?: UserStorageOwner | null): Promise<string | null> {
+  const storageKey = userScopedStorageKey(BLOB_BASE, owner);
+  if (!storageKey) return null;
+  try {
+    return await AsyncStorage.getItem(storageKey);
+  } catch {
+    return null;
+  }
+}
+
+export async function writePersistedCache(serialized: string, owner?: UserStorageOwner | null): Promise<void> {
+  const storageKey = userScopedStorageKey(BLOB_BASE, owner);
+  const metaKey = userScopedStorageKey(META_BASE, owner);
+  if (!storageKey || !metaKey) return;
+  await AsyncStorage.setItem(storageKey, serialized);
+  // ~80 bytes, so `persistedQueryCacheExists` is a small read rather than a
+  // 512 KB one.
+  const meta: CacheMeta = { savedAt: Date.now(), bytes: utf8ByteLength(serialized) };
+  await AsyncStorage.setItem(metaKey, JSON.stringify(meta));
+}
+
+export function writeCacheOwner(_userId: string): void {
+  // No-op: the web key itself is login-scoped, so ownership is in the key.
+}
+
+export async function persistedQueryCacheExists(owner?: UserStorageOwner | null): Promise<boolean> {
+  const metaKey = userScopedStorageKey(META_BASE, owner);
+  if (!metaKey) return false;
+  try {
+    return (await AsyncStorage.getItem(metaKey)) !== null;
+  } catch {
+    return false;
+  }
+}
+
+export async function clearPersistedQueryCache(owner?: UserStorageOwner | null): Promise<void> {
+  const storageKey = userScopedStorageKey(BLOB_BASE, owner);
+  const metaKey = userScopedStorageKey(META_BASE, owner);
+  const keys = [storageKey, metaKey].filter((key): key is string => key !== null);
+  if (keys.length === 0) return;
+  await Promise.all(keys.map((key) => AsyncStorage.removeItem(key)));
+}
+
+/** Exported for the sweep test: the exact bases `sweepOrphanedUserStorage` must match. */
+export const QUERY_CACHE_STORAGE_BASES = [BLOB_BASE, META_BASE] as const;

--- a/packages/mobile/src/lib/query-persist/writer.ts
+++ b/packages/mobile/src/lib/query-persist/writer.ts
@@ -1,0 +1,127 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { matchPersistRule } from './allowlist';
+import { applyBudget, type BudgetCandidate } from './budget';
+import { dehydrateAllowlisted } from './dehydrate';
+import { PERSISTED_CACHE_VERSION, serializePersistedCache, type PersistedQueryEntry } from './envelope';
+import { getLastWrittenQueries, setLastWrittenQueries } from './runtime';
+
+const DEFAULT_THROTTLE_MS = 1000;
+
+export type CacheWriter = {
+  /** Subscribe to the query cache. Returns the unsubscribe. */
+  start(): () => void;
+  /** Write now (if an owner is set), cancelling any pending throttle. */
+  flush(): void;
+  /** Cancel the pending throttle. Stays subscribed — see `suspendCacheWriter`. */
+  suspend(): void;
+};
+
+export type CacheWriterInput = {
+  client: QueryClient;
+  write: (serialized: string) => void | Promise<void>;
+  /** Read at FIRE time, never at schedule time. */
+  getOwner: () => string | null;
+  now: () => number;
+  schedule: (callback: () => void, delayMs: number) => unknown;
+  cancel: (handle: unknown) => void;
+  throttleMs?: number;
+  onError?: (error: unknown) => void;
+};
+
+/**
+ * Merge the fresh dehydrate with the previous write.
+ *
+ * React Query's 30-minute `gcTime` deletes any entry with no observer, so a
+ * replace-on-write persister would erode toward "only what you looked at in the
+ * last 30 minutes" — `['angles', board, layout]` for a board you did not open
+ * today would vanish from disk. Fresh entries win by `queryHash`; previously
+ * written entries survive when they are absent from the fresh set AND still
+ * inside their rule's `maxAge`.
+ */
+function mergeWithPrevious(
+  fresh: readonly PersistedQueryEntry[],
+  previous: readonly PersistedQueryEntry[],
+  ownerUserId: string,
+  now: number,
+): PersistedQueryEntry[] {
+  const freshHashes = new Set(fresh.map((entry) => entry.queryHash));
+  const merged = [...fresh];
+  for (const entry of previous) {
+    if (freshHashes.has(entry.queryHash)) continue;
+    const rule = Array.isArray(entry.queryKey) ? matchPersistRule(entry.queryKey, ownerUserId) : undefined;
+    if (!rule) continue;
+    if (now - (entry.state?.dataUpdatedAt ?? 0) > rule.maxAgeMs) continue;
+    merged.push(entry);
+  }
+  return merged;
+}
+
+export function createCacheWriter(input: CacheWriterInput): CacheWriter {
+  const throttleMs = input.throttleMs ?? DEFAULT_THROTTLE_MS;
+  let pendingHandle: unknown = null;
+
+  function cancelPending(): void {
+    if (pendingHandle === null) return;
+    input.cancel(pendingHandle);
+    pendingHandle = null;
+  }
+
+  function writeNow(): void {
+    // THE owner read. Doing it here rather than at schedule time is the whole
+    // correctness story: a write queued moments before sign-out finds a null
+    // owner and does nothing, so it cannot re-create the blob between the delete
+    // and the next tick — and re-arming after any anonymous transition is just
+    // `setPersistOwner`, with no latched "stopped" state to get stuck in.
+    const ownerUserId = input.getOwner();
+    if (ownerUserId === null) return;
+
+    try {
+      const now = input.now();
+      const fresh = dehydrateAllowlisted(input.client, ownerUserId);
+      const merged = mergeWithPrevious(fresh, getLastWrittenQueries(), ownerUserId, now);
+      const candidates: BudgetCandidate[] = [];
+      for (const entry of merged) {
+        const rule = Array.isArray(entry.queryKey) ? matchPersistRule(entry.queryKey, ownerUserId) : undefined;
+        if (!rule) continue;
+        candidates.push({ entry, priority: rule.priority });
+      }
+      const budgeted = applyBudget(candidates);
+      const serialized = serializePersistedCache({
+        version: PERSISTED_CACHE_VERSION,
+        userId: ownerUserId,
+        savedAt: now,
+        ...(budgeted.droppedEvicted > 0 ? { evicted: true as const } : {}),
+        queries: budgeted.kept,
+      });
+      setLastWrittenQueries(budgeted.kept);
+      const written = input.write(serialized);
+      if (written && typeof written.then === 'function') {
+        void written.catch((error: unknown) => input.onError?.(error));
+      }
+    } catch (error) {
+      input.onError?.(error);
+    }
+  }
+
+  return {
+    start() {
+      const unsubscribe = input.client.getQueryCache().subscribe(() => {
+        // Trailing edge: the first event of a burst schedules one write
+        // `throttleMs` later, and every further event in that window rides it.
+        if (pendingHandle !== null) return;
+        pendingHandle = input.schedule(() => {
+          pendingHandle = null;
+          writeNow();
+        }, throttleMs);
+      });
+      return unsubscribe;
+    },
+    flush() {
+      cancelPending();
+      writeNow();
+    },
+    suspend() {
+      cancelPending();
+    },
+  };
+}

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -148,6 +148,14 @@ beforeEach(() => {
   clearAllCreateClimbDraftsMock.mockResolvedValue(undefined);
   clearSessionCommentDraftMock.mockReset();
   clearSessionCommentDraftMock.mockResolvedValue(undefined);
+  queryPersistCalls.length = 0;
+  suspendCacheWriterMock.mockReset();
+  clearPersistedQueryCacheMock.mockReset();
+  clearPersistedQueryCacheMock.mockResolvedValue(undefined);
+  persistedQueryCacheExistsMock.mockReset();
+  persistedQueryCacheExistsMock.mockResolvedValue(false);
+  adoptPersistedQueryCacheMock.mockReset();
+  adoptPersistedQueryCacheMock.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -240,6 +248,34 @@ vi.mock('../../lib/create-climb-draft-store', () => ({
 const clearSessionCommentDraftMock = vi.fn();
 vi.mock('../../lib/session-comment-draft-store', () => ({
   clearSessionCommentDraft: (...args: unknown[]) => clearSessionCommentDraftMock(...args),
+}));
+
+// The persisted React Query cache (#4353). Sign-out has to pause the writer
+// BEFORE it deletes the blob, and a logged-out cold start with a blob on disk
+// has to run the full cleanup rather than the light persisted-store sweep — both
+// are asserted below, so every call is recorded in order.
+const queryPersistCalls = vi.hoisted(() => [] as string[]);
+const suspendCacheWriterMock = vi.hoisted(() => vi.fn());
+const clearPersistedQueryCacheMock = vi.hoisted(() => vi.fn(async (_owner?: unknown) => {}));
+const persistedQueryCacheExistsMock = vi.hoisted(() => vi.fn(async (_owner?: unknown) => false));
+const adoptPersistedQueryCacheMock = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => {}));
+vi.mock('../../lib/query-persist', () => ({
+  suspendCacheWriter: () => {
+    queryPersistCalls.push('suspendCacheWriter');
+    suspendCacheWriterMock();
+  },
+  clearPersistedQueryCache: (owner?: unknown) => {
+    queryPersistCalls.push('clearPersistedQueryCache');
+    return clearPersistedQueryCacheMock(owner);
+  },
+  persistedQueryCacheExists: (owner?: unknown) => {
+    queryPersistCalls.push('persistedQueryCacheExists');
+    return persistedQueryCacheExistsMock(owner);
+  },
+  adoptPersistedQueryCache: (...args: unknown[]) => {
+    queryPersistCalls.push('adoptPersistedQueryCache');
+    return adoptPersistedQueryCacheMock(...args);
+  },
 }));
 
 vi.mock('../../lib/user-storage-owner', () => ({
@@ -1747,6 +1783,16 @@ describe('AuthProvider.checkAuth signed-out cleanup', () => {
     ensureFreshTokenMock.mockResolvedValue(true);
     clearStoredSessionIdMock.mockResolvedValue(undefined);
     clearStoredActiveBoardMock.mockResolvedValue(undefined);
+    clearOfflineBoardsMock.mockReset();
+    setSettingMock.mockReset();
+    clearUserDataMock.mockReset();
+    purgeLocalDataForSignOutMock.mockReset();
+    purgeLocalDataForSignOutMock.mockResolvedValue({
+      pendingDiscarded: 0,
+      deadLettersDiscarded: 0,
+      hadDownloads: false,
+      vacuumed: true,
+    });
   });
 
   // The #2685 bug: an expiry-triggered logout (token within the expiry window,
@@ -1848,6 +1894,82 @@ describe('AuthProvider.checkAuth signed-out cleanup', () => {
     expect(clearStoredSessionIdMock).toHaveBeenCalledTimes(1);
     expect(resetHttpClientMock).not.toHaveBeenCalled();
     expect(disposeWsClientMock).not.toHaveBeenCalled();
+    // The persisted query cache dies on this path too, on BOTH platforms.
+    expect(clearPersistedQueryCacheMock).toHaveBeenCalledTimes(1);
+    // ...and the writer is paused before the delete, so a write queued moments
+    // ago can't re-create the blob on the next tick.
+    expect(queryPersistCalls.indexOf('suspendCacheWriter')).toBeLessThan(
+      queryPersistCalls.indexOf('clearPersistedQueryCache'),
+    );
+  });
+
+  // T-15: the #4353 sharp edge. Once something actually hydrates at cold start,
+  // a user whose token expired while the app was killed would otherwise relaunch
+  // into the previous session's cached profile — the light sweep never touches
+  // the in-memory cache or the clients.
+  it('runs the FULL cleanup on a logged-out cold start when a persisted blob exists', async () => {
+    getAuthTokenMock.mockResolvedValue(null);
+    persistedQueryCacheExistsMock.mockResolvedValue(true);
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(['profile'], { id: 'user-1' });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{null}</AuthProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(resetHttpClientMock).toHaveBeenCalledTimes(1));
+    expect(disposeWsClientMock).toHaveBeenCalledTimes(1);
+    expect(clearOfflineBoardsMock).toHaveBeenCalledTimes(1);
+    expect(setSettingMock).toHaveBeenCalledWith('syncEnabledBoards', []);
+    // queryClient.clear() ran, so nothing of the departed user survives.
+    expect(queryClient.getQueryData(['profile'])).toBeUndefined();
+    // Downloaded catalogs are kept: purgeOfflineBoards stays false on this path.
+    expect(purgeLocalDataForSignOutMock).not.toHaveBeenCalled();
+    expect(clearUserDataMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the light sweep on a logged-out cold start with no persisted blob', async () => {
+    getAuthTokenMock.mockResolvedValue(null);
+    persistedQueryCacheExistsMock.mockResolvedValue(false);
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(['profile'], { id: 'user-1' });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{null}</AuthProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(clearStoredActiveBoardMock).toHaveBeenCalledTimes(1));
+    expect(resetHttpClientMock).not.toHaveBeenCalled();
+    expect(disposeWsClientMock).not.toHaveBeenCalled();
+    expect(clearOfflineBoardsMock).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData(['profile'])).toEqual({ id: 'user-1' });
+  });
+
+  // The auth boundary must pass `undefined` as the owner, never a captured one:
+  // on web a pre-transition owner is null on every cold start and
+  // `userScopedStorageKey(base, null)` returns null, so the read and the
+  // mismatch-path delete would both silently no-op (#4353).
+  it('adopts the persisted cache with an undefined owner once auth resolves', async () => {
+    platformState.OS = 'web';
+    getAuthTokenMock.mockResolvedValue('jwt-token');
+    isTokenExpiringSoonMock.mockResolvedValue(false);
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{null}</AuthProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => expect(adoptPersistedQueryCacheMock).toHaveBeenCalled());
+    expect(adoptPersistedQueryCacheMock).toHaveBeenCalledWith(queryClient, 'user-1', undefined);
+    // ...and it happens after the storage owner is published, so the scoped key
+    // resolves to the account that just authenticated.
+    expect(userStorageOwnerState.current).toEqual({ userId: 'user-1', authSessionId: 'login-1' });
   });
 
   it('bounds a hung web cold-start cleanup so the loading gate still releases', async () => {

--- a/packages/mobile/src/providers/__tests__/pre-auth-query-cache-audit.test.ts
+++ b/packages/mobile/src/providers/__tests__/pre-auth-query-cache-audit.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, resolve, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Everything between <QueryProvider> and <AuthProvider> in app/_layout.tsx
+// mounts BEFORE auth resolves. `AppLoadingSplash` gates AuthProvider's CHILDREN,
+// not its siblings, so the "nothing paints first" invariant covers paint but not
+// effects — and now that QueryProvider hydrates user-scoped entries at mount, a
+// query side effect up here would touch another account's data on a shared
+// device (issue #4353).
+//
+// This guard is the durable half of that promise: it walks the real source, not
+// a mock, so a new pre-auth provider or a rename cannot silently leave it
+// checking nothing.
+const MOBILE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+const PRE_AUTH_MODULES = [
+  'src/components/analytics/AnalyticsProvider.tsx',
+  'src/providers/i18n-provider.tsx',
+  'src/providers/query-provider.tsx',
+  'src/providers/database-provider.tsx',
+  'src/providers/theme-provider.tsx',
+  'src/providers/material-theme-provider.tsx',
+  'src/providers/dialog-provider.tsx',
+  'src/providers/feature-flags-provider.tsx',
+  'src/providers/offline-downloads-enabled.ts',
+  'src/components/offline-sync-bridge.tsx',
+];
+
+// The JSX tags that live between QueryProvider and AuthProvider, mapped to the
+// module the guard walks from.
+const TAG_TO_MODULE: Record<string, string> = {
+  DatabaseProvider: 'src/providers/database-provider.tsx',
+  ThemeProvider: 'src/providers/theme-provider.tsx',
+  MaterialThemeProvider: 'src/providers/material-theme-provider.tsx',
+  DialogProvider: 'src/providers/dialog-provider.tsx',
+  FeatureFlagsProvider: 'src/providers/feature-flags-provider.tsx',
+  OfflineEngineFlagSync: 'src/components/offline-sync-bridge.tsx',
+};
+
+// `src/components/offline-sync-bridge.tsx` is the one documented exemption from
+// the file walk, because it holds TWO exports with different mount points.
+// `OfflineSyncBridge` legitimately uses useQueryClient/invalidateQueries, but it
+// mounts INSIDE AuthProvider and only ever touches ['searchClimbs' |
+// 'infiniteSearchClimbs' | 'searchClimbsCount' | 'climb'], none of them
+// allowlisted — and its imports (auth-provider, the sync adapter, the
+// active-board hook) are what would otherwise drag the whole app into this walk.
+// `OfflineEngineFlagSync`, the export that actually mounts pre-auth, gets its
+// own targeted assertion below instead, plus its two real dependencies as walk
+// seeds.
+const BRIDGE_FILE = 'src/components/offline-sync-bridge.tsx';
+const WALK_SEEDS = [
+  ...PRE_AUTH_MODULES.filter((modulePath) => modulePath !== BRIDGE_FILE),
+  'src/lib/offline-engine.ts',
+  'src/lib/analytics-offline-engine-state.ts',
+];
+
+const FORBIDDEN_QUERY_APIS = [
+  'useQuery',
+  'useInfiniteQuery',
+  'useSuspenseQuery',
+  'useQueryClient',
+  'getQueryData',
+  'setQueryData',
+  'fetchQuery',
+  'prefetchQuery',
+  'ensureQueryData',
+  'invalidateQueries',
+  'removeQueries',
+  'resetQueries',
+];
+
+const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.native.ts', '.native.tsx', '/index.ts', '/index.tsx'];
+
+function resolveRelativeImport(fromFile: string, specifier: string): string | null {
+  const base = resolve(MOBILE_ROOT, dirname(fromFile), specifier);
+  for (const extension of ['', ...SOURCE_EXTENSIONS]) {
+    const candidate = `${base}${extension}`;
+    if (existsSync(candidate) && !candidate.endsWith('/')) {
+      // Skip directories that only exist as directories.
+      try {
+        readFileSync(candidate, 'utf8');
+        return relative(MOBILE_ROOT, candidate);
+      } catch {
+        // A directory: keep trying the /index candidates.
+      }
+    }
+  }
+  return null;
+}
+
+function collectTransitiveSources(seeds: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const queue = [...seeds];
+  while (queue.length > 0) {
+    const current = queue.shift() as string;
+    if (seen.has(current)) continue;
+    seen.add(current);
+    const source = readFileSync(resolve(MOBILE_ROOT, current), 'utf8');
+    for (const match of source.matchAll(/(?:from|import)\s*\(?\s*['"](\.[^'"]+)['"]/g)) {
+      const resolved = resolveRelativeImport(current, match[1]);
+      if (resolved && !seen.has(resolved)) queue.push(resolved);
+    }
+  }
+  return [...seen];
+}
+
+describe('pre-auth providers never touch the query cache', () => {
+  // First: the list is real. A rename would otherwise silently empty the guard.
+  it('lists only paths that exist on disk', () => {
+    for (const modulePath of PRE_AUTH_MODULES) {
+      expect(existsSync(resolve(MOBILE_ROOT, modulePath)), `${modulePath} is missing`).toBe(true);
+    }
+  });
+
+  // Second: the list still matches what _layout.tsx actually mounts pre-auth.
+  it('covers every provider mounted between QueryProvider and AuthProvider', () => {
+    const layout = readFileSync(resolve(MOBILE_ROOT, 'app/_layout.tsx'), 'utf8');
+    const start = layout.indexOf('<QueryProvider>');
+    const end = layout.indexOf('<AuthProvider');
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const preAuthJsx = layout
+      .slice(start + '<QueryProvider>'.length, end)
+      // Drop JSX comments so their prose can't look like a tag.
+      .replace(/\{\/\*[\s\S]*?\*\/\}/g, '');
+    const mountedTags = [...preAuthJsx.matchAll(/<([A-Z][A-Za-z0-9_]*)/g)].map((match) => match[1]);
+    expect(mountedTags.length).toBeGreaterThan(0);
+
+    for (const tag of new Set(mountedTags)) {
+      const modulePath = TAG_TO_MODULE[tag];
+      expect(modulePath, `<${tag}> mounts pre-auth but this guard does not cover it`).toBeDefined();
+      expect(PRE_AUTH_MODULES).toContain(modulePath);
+    }
+  });
+
+  // T-17
+  it('has no query-cache reference anywhere in the pre-auth import graph', () => {
+    const sources = collectTransitiveSources(WALK_SEEDS);
+    // Sanity: the walk actually reached past the seeds.
+    expect(sources.length).toBeGreaterThan(WALK_SEEDS.length);
+
+    const offenders: string[] = [];
+    for (const sourcePath of sources) {
+      // The persister itself is the thing hydrating the cache; it is reached
+      // from query-provider.tsx by design and is not a pre-auth side effect.
+      if (sourcePath.startsWith('src/lib/query-persist/')) continue;
+      const source = readFileSync(resolve(MOBILE_ROOT, sourcePath), 'utf8');
+      for (const api of FORBIDDEN_QUERY_APIS) {
+        if (new RegExp(`\\b${api}\\s*[(<]`).test(source)) offenders.push(`${sourcePath} → ${api}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps OfflineEngineFlagSync itself free of query-cache calls', () => {
+    const source = readFileSync(resolve(MOBILE_ROOT, BRIDGE_FILE), 'utf8');
+    const start = source.indexOf('export function OfflineEngineFlagSync(');
+    expect(start).toBeGreaterThan(-1);
+    // Up to the next top-level export — the component plus nothing else.
+    const nextExport = source.indexOf('\nexport ', start + 1);
+    const body = source.slice(start, nextExport === -1 ? source.length : nextExport);
+    expect(body).toContain('return null;');
+
+    for (const api of FORBIDDEN_QUERY_APIS) {
+      expect(new RegExp(`\\b${api}\\s*[(<]`).test(body), `OfflineEngineFlagSync calls ${api}`).toBe(false);
+    }
+  });
+});

--- a/packages/mobile/src/providers/__tests__/query-provider-persist.test.tsx
+++ b/packages/mobile/src/providers/__tests__/query-provider-persist.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { useQueryClient, type QueryClient } from '@tanstack/react-query';
+
+// The real react-native entry is Flow source Rolldown can't parse; stub the two
+// members QueryProvider touches. The AppState listener is captured so the
+// background-flush contract can be exercised.
+const appStateState = vi.hoisted(() => ({ listener: null as ((status: string) => void) | null }));
+vi.mock('react-native', () => ({
+  AppState: {
+    addEventListener: (_event: string, listener: (status: string) => void) => {
+      appStateState.listener = listener;
+      return { remove: () => {} };
+    },
+  },
+  Platform: { OS: 'ios' },
+}));
+
+// A per-id MMKV mock so the seeded blob is genuinely in the query-cache
+// instance (the shared stub shares one map across every id).
+const instances = vi.hoisted(() => new Map<string, Map<string, string>>());
+vi.mock('react-native-mmkv', () => ({
+  createMMKV: ({ id }: { id: string }) => {
+    const store = instances.get(id) ?? new Map<string, string>();
+    instances.set(id, store);
+    return {
+      getString: (key: string) => store.get(key),
+      set: (key: string, value: string) => {
+        store.set(key, value);
+      },
+      remove: (key: string) => {
+        store.delete(key);
+      },
+      clearAll: () => {
+        store.clear();
+      },
+    };
+  },
+}));
+
+// The analytics barrel reaches posthog-react-native; FeatureFlagsProvider is
+// what imports these two readers from it.
+vi.mock('../../lib/analytics', () => ({
+  readPosthogFeatureFlags: () => ({}),
+  subscribePosthogFeatureFlags: () => () => {},
+}));
+
+import { QueryProvider } from '../query-provider';
+import { FeatureFlagsProvider } from '../feature-flags-provider';
+import { PERSISTED_CACHE_VERSION, serializePersistedCache, type PersistedQueryEntry } from '../../lib/query-persist';
+import { getPersistOwner, resetQueryPersistRuntime, setPersistOwner } from '../../lib/query-persist';
+
+const OWNER = 'user-1';
+const CACHE_STORE_ID = 'boardsesh-query-cache';
+
+const SEEDED_AT = Date.now();
+
+function persistedEntry(queryKey: readonly unknown[], data: unknown): PersistedQueryEntry {
+  return {
+    queryHash: JSON.stringify(queryKey),
+    queryKey: queryKey as unknown[],
+    state: { data, dataUpdatedAt: SEEDED_AT, status: 'success', fetchStatus: 'idle' },
+  } as unknown as PersistedQueryEntry;
+}
+
+const ALL_ALLOWLISTED_ENTRIES: readonly (readonly [readonly unknown[], unknown])[] = [
+  [['profile'], { id: OWNER, name: 'Marco' }],
+  [['myBoards', null], [{ uuid: 'board-1' }]],
+  [['myGyms'], [{ id: 'gym-1' }]],
+  [['grades', 'kilter'], [{ difficultyId: 10 }]],
+  [
+    ['angles', 'kilter', 8],
+    [40, 45],
+  ],
+  [['publicProfile', OWNER], { id: OWNER }],
+];
+
+function seedBlob(userId: string, entries: readonly (readonly [readonly unknown[], unknown])[]): void {
+  const store = instances.get(CACHE_STORE_ID) ?? new Map<string, string>();
+  instances.set(CACHE_STORE_ID, store);
+  store.set(
+    'queryCacheV1',
+    serializePersistedCache({
+      version: PERSISTED_CACHE_VERSION,
+      userId,
+      savedAt: SEEDED_AT,
+      queries: entries.map(([queryKey, data]) => persistedEntry(queryKey, data)),
+    }),
+  );
+  store.set('queryCacheOwnerV1', userId);
+}
+
+let firstRenderProfile: unknown = 'not-rendered';
+let capturedClient: QueryClient | null = null;
+
+function ProfileProbe() {
+  const client = useQueryClient();
+  capturedClient = client;
+  // Read during RENDER, not in an effect: this is what "no isRestoring frame"
+  // means — the first render pass already sees the persisted profile.
+  if (firstRenderProfile === 'not-rendered') firstRenderProfile = client.getQueryData(['profile']);
+  return null;
+}
+
+beforeEach(() => {
+  for (const store of instances.values()) store.clear();
+  resetQueryPersistRuntime();
+  appStateState.listener = null;
+  firstRenderProfile = 'not-rendered';
+  capturedClient = null;
+});
+
+// T-20
+describe('QueryProvider persisted-cache restore', () => {
+  it('has the persisted profile in the cache on the very first render pass', () => {
+    seedBlob(OWNER, ALL_ALLOWLISTED_ENTRIES);
+
+    render(
+      <QueryProvider>
+        <ProfileProbe />
+      </QueryProvider>,
+    );
+
+    expect(firstRenderProfile).toEqual({ id: OWNER, name: 'Marco' });
+  });
+
+  it('hydrates nothing when the owner sentinel is missing', () => {
+    seedBlob(OWNER, ALL_ALLOWLISTED_ENTRIES);
+    instances.get(CACHE_STORE_ID)?.delete('queryCacheOwnerV1');
+
+    render(
+      <QueryProvider>
+        <ProfileProbe />
+      </QueryProvider>,
+    );
+
+    expect(firstRenderProfile).toBeUndefined();
+  });
+
+  // T-18 (narrowed to QueryProvider + FeatureFlagsProvider, per the plan's own
+  // escape hatch: the rest of the pre-auth stack needs the offline-sync-bridge
+  // mock recipe, and T-17's source-graph guard is the durable check). Mounting
+  // pre-auth providers over a hydrated cache must not observe, refetch, or
+  // otherwise touch a single allowlisted entry — `AppLoadingSplash` gates
+  // AuthProvider's children, not its siblings' effects.
+  it('leaves every hydrated entry untouched while pre-auth providers mount', async () => {
+    seedBlob(OWNER, ALL_ALLOWLISTED_ENTRIES);
+
+    render(
+      <QueryProvider>
+        <FeatureFlagsProvider flags={{ 'offline-board-downloads': true }}>
+          <ProfileProbe />
+        </FeatureFlagsProvider>
+      </QueryProvider>,
+    );
+    await new Promise((resolveTick) => setTimeout(resolveTick, 0));
+
+    const client = capturedClient;
+    expect(client).not.toBeNull();
+    for (const [queryKey] of ALL_ALLOWLISTED_ENTRIES) {
+      const cached = client?.getQueryCache().find({ queryKey: queryKey as unknown[] });
+      expect(cached, `${JSON.stringify(queryKey)} disappeared`).toBeDefined();
+      // No observer means nothing up here subscribed; an untouched
+      // `dataUpdatedAt` means nothing refetched or overwrote it either.
+      expect(cached?.getObserversCount()).toBe(0);
+      expect(cached?.state.fetchStatus).toBe('idle');
+      expect(cached?.state.dataUpdatedAt).toBe(SEEDED_AT);
+    }
+  });
+
+  it('writes on background only once an owner is armed', () => {
+    render(
+      <QueryProvider>
+        <ProfileProbe />
+      </QueryProvider>,
+    );
+
+    capturedClient?.setQueryData(['profile'], { id: OWNER, name: 'Marco' });
+    // Backgrounded while signed out: the owner gate makes this a no-op.
+    appStateState.listener?.('background');
+    expect(instances.get(CACHE_STORE_ID)?.get('queryCacheV1')).toBeUndefined();
+
+    setPersistOwner(OWNER);
+    expect(getPersistOwner()).toBe(OWNER);
+    appStateState.listener?.('background');
+    expect(instances.get(CACHE_STORE_ID)?.get('queryCacheV1')).toContain('"profile"');
+  });
+});

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -34,6 +34,13 @@ import { clearSessionCommentDraft } from '../lib/session-comment-draft-store';
 import { setCurrentUserStorageOwner, type UserStorageOwner } from '../lib/user-storage-owner';
 import { ACTIVE_BOARD_QUERY_KEY, clearStoredActiveBoardCoordinated } from '../lib/graphql/use-active-board';
 import { resetActiveBoardSelfHealValidationCache } from '../lib/boards/active-board-self-heal-validation-cache';
+import { userIdFromJwt } from '../lib/jwt-user-id';
+import {
+  adoptPersistedQueryCache,
+  clearPersistedQueryCache,
+  persistedQueryCacheExists,
+  suspendCacheWriter,
+} from '../lib/query-persist';
 import { clearUserData, purgeLocalDataForSignOut, getDatabaseHandle } from '../db';
 import { resetSyncStatus } from '../sync/sync-status';
 import { setSetting, clearOfflineBoards } from '../settings';
@@ -186,10 +193,23 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
     // the active-board write generation, so neither validation nor storage
     // state can leak into the next account.
     resetActiveBoardSelfHealValidationCache();
+    // The persisted query cache (#4353) is deleted here too, and CROSS-PLATFORM
+    // unlike the two web-only draft stores below: it holds profile and board data
+    // that has to die with the account on every platform.
+    //
+    // FIRST, and synchronously, before any promise below is constructed: a write
+    // queued moments ago must not re-create the blob between the delete and the
+    // next tick. This is a PAUSE, not a stop — `clearPersistedUserStores` also
+    // runs on the light signed-out path (every logged-out cold start, every
+    // anonymous foreground check), so a latched stop would leave the writer dead
+    // for the rest of the process. `setPersistOwner` at the auth boundary
+    // re-arms it.
+    suspendCacheWriter();
     return Promise.allSettled([
       clearStoredSessionId(owner),
       clearStoredActiveBoardCoordinated(owner),
       clearStoredQueueSnapshot(owner),
+      clearPersistedQueryCache(owner),
       // Create-climb and session-recap drafts are wiped for account
       // isolation only on web (the new surface). Native sign-out keeps its
       // origin behavior and leaves these drafts intact, so shipping this via
@@ -378,10 +398,8 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
         return true;
       }
 
-      const needsFullCleanup =
-        forceFullCleanup ||
-        authStateRef.current.isAuthenticated ||
-        (Platform.OS === 'web' && previousStorageOwner !== null);
+      // Captured BEFORE the web publish block below, which mutates authStateRef.
+      const wasAuthenticatedThisSession = authStateRef.current.isAuthenticated;
       // On web, publish the confirmed anonymous state before any storage await.
       // This unmounts authenticated consumers promptly, while epoch checks stop
       // this transition from writing after a newer login. Native keeps its
@@ -391,6 +409,27 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
         authStateRef.current = { ...authStateRef.current, isAuthenticated: false };
         setIsAuthenticated(false);
       }
+
+      // A persisted query-cache blob means a previous session's profile and
+      // board list are still on this device, so a logged-out cold start (token
+      // expired while the app was killed) has to run the FULL cleanup, not just
+      // the persisted-store sweep — otherwise the relaunch hydrates the departed
+      // user's identity. Awaited after the web publish above so the "no storage
+      // await before publishing anonymous" invariant holds. On native this reads
+      // a short MMKV owner sentinel, not the blob.
+      //
+      // Safe because it can only fire on a CONFIRMED logout: `resolveAuthSession`
+      // returns `anonymous` for an absent token or a server-rejected refresh,
+      // while an unreachable refresh stays authenticated-degraded. An offline
+      // cold start therefore never trips it.
+      const persistedCacheExists = await persistedQueryCacheExists(previousStorageOwner);
+      if (!isAuthTransitionCurrent(transitionEpoch)) return false;
+
+      const needsFullCleanup =
+        forceFullCleanup ||
+        wasAuthenticatedThisSession ||
+        (Platform.OS === 'web' && previousStorageOwner !== null) ||
+        persistedCacheExists;
 
       let completed: boolean;
       if (needsFullCleanup) {
@@ -495,9 +534,25 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
         updateNativeSessionDegraded(degradation !== undefined);
       }
 
-      return handleAuthenticatedTransition(transitionEpoch, authSession);
+      if (!(await handleAuthenticatedTransition(transitionEpoch, authSession))) return false;
+
+      // `userId` is web-only on AuthSessionResult; on native the JWT this device
+      // already holds carries the same id as `sub` (jwt-user-id.ts). Storage
+      // scoping only — never an authorization decision.
+      const resolvedUserId = Platform.OS === 'web' ? authSession.userId : userIdFromJwt(authSession.token);
+      // `undefined` (NOT a captured owner) so the web key resolves the account
+      // handleAuthenticatedTransition just published via setCurrentUserStorageOwner.
+      // See adoptPersistedQueryCache's doc comment for why a captured owner is a bug.
+      //
+      // Awaiting here is what removes the restoring frame on web:
+      // checkAuthForTransition only calls setIsLoading(false) in its finally, and
+      // AuthProvider renders <AppLoadingSplash /> (not children) while isLoading.
+      // Adopt short-circuits on a matching owner, so the repeated foreground
+      // checkAuth calls cost one string comparison.
+      await adoptPersistedQueryCache(queryClient, resolvedUserId, undefined);
+      return true;
     },
-    [handleAuthenticatedTransition, updateNativeSessionDegraded],
+    [handleAuthenticatedTransition, queryClient, updateNativeSessionDegraded],
   );
 
   const checkAuthForTransition = useCallback(

--- a/packages/mobile/src/providers/query-provider.tsx
+++ b/packages/mobile/src/providers/query-provider.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { AppState, Platform } from 'react-native';
 import NetInfo from '@react-native-community/netinfo';
 import {
@@ -11,6 +11,18 @@ import {
 } from '@tanstack/react-query';
 import { reportHandledError } from '../lib/error-reporting';
 import { isGraphqlRateLimitedError } from '../lib/graphql/extract-error-message';
+import {
+  REQUIRES_OWNER_HINT,
+  SUPPORTS_SYNC_RESTORE,
+  createCacheWriter,
+  getPersistOwner,
+  readCacheOwnerSync,
+  readPersistedCacheSync,
+  restorePersistedCache,
+  setCacheWriter,
+  setLastRestore,
+  writePersistedCache,
+} from '../lib/query-persist';
 
 // React Query keys `refetchOnReconnect` / `refetchOnWindowFocus` off a browser's
 // `navigator.onLine` and window-focus events, neither of which exists on React
@@ -115,7 +127,54 @@ export function createQueryClient(): QueryClient {
 }
 
 export function QueryProvider({ children }: { children: ReactNode }) {
-  const [queryClient] = useState(createQueryClient);
+  const [queryClient] = useState(() => {
+    const client = createQueryClient();
+    // NATIVE ONLY, and deliberately inside the lazy initializer: MMKV's read is
+    // synchronous, so the allowlisted cache is in place before React's first
+    // render — no `isRestoring` frame, no IsRestoringProvider, no splash flicker.
+    // The web fork returns null here and restores from the auth boundary
+    // instead, because its storage key is login-scoped and there is nothing
+    // readable until auth resolves. `hydrate` refuses to overwrite fresher data
+    // (`state.dataUpdatedAt >`), so a late web restore can never clobber a live
+    // fetch.
+    if (SUPPORTS_SYNC_RESTORE) {
+      setLastRestore(
+        restorePersistedCache(client, {
+          raw: readPersistedCacheSync(),
+          ownerHint: readCacheOwnerSync(),
+          requireOwnerHint: REQUIRES_OWNER_HINT,
+          now: Date.now(),
+        }),
+      );
+    }
+    return client;
+  });
+
+  useEffect(() => {
+    const writer = createCacheWriter({
+      client: queryClient,
+      write: writePersistedCache,
+      // Read at FIRE time inside the writer, never at schedule time.
+      getOwner: getPersistOwner,
+      now: Date.now,
+      schedule: setTimeout,
+      cancel: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+      onError: (error) => reportHandledError(error, { tags: { source: 'query-persist' } }),
+    });
+    const unsubscribe = writer.start();
+    setCacheWriter(writer);
+    // Backgrounding is the guaranteed flush point: the app cannot reach a cold
+    // start without first being backgrounded or killed. `flush` re-reads the
+    // owner, so a background during sign-out writes nothing.
+    const appStateSubscription = AppState.addEventListener('change', (status) => {
+      if (status !== 'active') writer.flush();
+    });
+    return () => {
+      appStateSubscription.remove();
+      unsubscribe();
+      setCacheWriter(null);
+    };
+  }, [queryClient]);
 
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -836,6 +836,19 @@ export const SHARED_EVENTS = {
   // the funnel can never read a climber who backed out as one who never arrived.
   BoardLookStepShown: 'Board Look Step Shown',
   BoardLookStepResolved: 'Board Look Step Resolved',
+  // Offline — the allowlisted persisted React Query cache (issue #4353) at cold
+  // start. Fired at most ONCE per launch, and only when a blob existed at all,
+  // so a first-run or signed-out launch emits nothing. This is how the
+  // cold-start win is judged from fleet data: the share of launches reaching
+  // `outcome: 'hydrated'` with a `['profile']` entry is the same population that
+  // used to hit "Something went wrong" on My Boards with no signal.
+  // Props, absent-when-unknown: { outcome: 'hydrated' | 'unreadable' |
+  // 'owner_mismatch' | 'owner_missing' | 'empty', entryCount, bytes,
+  // droppedCount, oldestEntryAgeHours, evicted }. `entryCount`/`bytes` are
+  // present only when the blob was parsed and owned ('hydrated' / 'empty');
+  // `droppedCount` only when > 0; `oldestEntryAgeHours` only on 'hydrated';
+  // `evicted` only when the previous write hit the 512 KB cap.
+  OfflineQueryCacheRestored: 'Offline Query Cache Restored',
 } as const;
 
 export type SharedEventKey = keyof typeof SHARED_EVENTS;


### PR DESCRIPTION
## Summary

Refs #4353. Stage 2 of the #4002 decision (`docs/offline-reads.md`): an in-house, allowlisted, user-scoped persisted React Query cache for `packages/mobile`, wired into the #3621 sign-out wipe.

Nothing persisted the query cache before this, so every cold start was empty — and `/boards/manage` renders a hard "Something went wrong" when `currentUserId` can't resolve, which offline it could not. #4309 worked around that one screen by decoding the JWT `sub`; this is the general fix.

**⚠️ THIS PR STAYS DRAFT until the on-device QA gate below has been run.** A synchronous MMKV read plus `JSON.parse` before first render is small but unmeasurable in vitest, and the relaunch ordering of `resolveAuthSession` → `handleSignedOutTransition` is the one behaviour no test can fully prove.

### What landed

New module `packages/mobile/src/lib/query-persist/` — pure TS with storage injected or behind a `.web.ts` fork:

- **`allowlist.ts`** — six rules (`profile`, `myBoards`, `myGyms`, `grades`, `angles`, `publicProfile`-self), each pinned on an exact head **and an exact arity**. Arity is what makes it a gate rather than a prefix filter: `['profile', x]` misses, and a future `['profileSettings']` cannot slip through. `publicProfile` additionally guards on the owner's own id.
- **`envelope.ts`** — `{ version, userId, savedAt, evicted?, queries }`. **No `mutations` field**, so a persisted outbox alongside SQLite's `pending_mutations` is unrepresentable — and `dehydrate.ts` hard-codes `shouldDehydrateMutation: () => false` on top. Two independent defences, one test each.
- **`budget.ts`** — 64 KB per entry, 512 KB cap with lowest-priority-first eviction (so `['profile']` is the last thing standing), and a 100 KB target asserted against a realistic populated fixture.
- **`restore.ts`** — re-applies the allowlist and per-rule `maxAge` **on the restore path too**, so a future or tampered blob can't smuggle a non-allowlisted key (or another climber's public profile) into memory. Seeds the writer's merge set from what it hydrated.
- **`writer.ts`** — 1 s trailing-edge throttle, merge-on-write against the previous set, and the owner read at write-**fire** time.
- **`runtime.ts`** — module singletons. `suspendCacheWriter()` is a **pause**, not a stop: it clears the owner, the pending throttle and the merge set, and `setPersistOwner` re-arms the same subscription.
- **`auth-boundary.ts`** — pure `decideOwnerTransition` plus an idempotent `adoptPersistedQueryCache` that short-circuits on a matching owner and consumes `lastRestore` once.
- **`storage.ts` / `storage.web.ts`** — native uses a **dedicated** `boardsesh-query-cache` MMKV instance (so a 512 KB blob never lands in `boardsesh-settings`, whose `clearAll()` would take it with it) plus a short owner sentinel; web uses login-scoped `userScopedStorageKey` blob + meta keys in the raw AsyncStorage keyspace, so `sweepOrphanedUserStorage` can reclaim them.

Wiring:

- `QueryProvider` restores **synchronously** inside its `useState` lazy initializer on native — no `isRestoring` frame, no `IsRestoringProvider` — and flushes on AppState background. Web restores asynchronously at the auth boundary, awaited before `setIsLoading(false)` releases the tree.
- `clearPersistedUserStores` calls `suspendCacheWriter()` as its first synchronous statement and deletes the blob — one call site, **both platforms**.
- `handleSignedOutTransition`'s `needsFullCleanup` now also fires when a persisted blob exists, so a token that expired while the app was killed no longer relaunches into the previous session's profile.
- One new permanent event name: `Offline Query Cache Restored`.
- Comment-only precedence documentation on `/boards/manage` and `/boards/index` — no logic change; `offlineBoardRows({ cachedMyBoards })` already prefers a warm `['myBoards']` entry, this just makes it warm at cold start.

### Why in-house rather than `@tanstack/react-query-persist-client`

`dehydrate` / `hydrate` are already exported by the pinned `@tanstack/react-query@5.101.4`, so the dependency buys ~150 lines and costs `package.json` + `bun.lock` churn — which per #4122 trips the OTA "native change" check as a false positive. It also doesn't give the allowlist as a hard gate, a `userId` stamp validated at the auth boundary, or a synchronous native restore. **This PR is JS/TS only: no `package.json`, no `bun.lock`, no native fingerprint movement.**

### Why the writer pauses instead of stopping

`clearPersistedUserStores` runs on the **light** signed-out path too, which fires on every logged-out cold start and every anonymous foreground `checkAuth`. A latched stop would therefore be dead from the first anonymous launch, and the first sign-in after it would persist nothing — the epic's exact target user (sign in today, gym tomorrow with no signal). Reading the owner at fire time also closes the race a stop was meant to cover: a write queued mid-sign-out finds a null owner and does nothing.

## Release Notes

- Open the app with no signal and it already knows who you are — your profile, your board list and your gyms are on the phone now, so My Boards comes up with your walls grouped the way you left them instead of "Something went wrong".
- Signing out still wipes all of it, and so does a session that expired while the app was closed.

## Test plan

All commands run in the worktree, foreground, literal outcomes:

- `vp run typecheck:mobile` — **PASS** (`tsc --noEmit`, Done in 29.51 s)
- `vp run test:mobile` — **PASS**, 657 files / 5954 tests passed
- `vp test run --reporter=agent packages/shared/analytics` — **PASS**, 4 files / 23 tests
- `vp run check:mobile-bundle` — **PASS**, `[mobile-bundle] android bundle: OK (4.0 KB)`
- `vp check` — lint clean; the only formatting failures are two pre-existing, untouched files (`docs/design/web-reposition/gyms-directory.html`, `homepage-marketing.html`) that already fail on `main`. Everything this PR touches is formatted.

New tests (24 cases across 11 files):

| Area | What it pins |
| --- | --- |
| `allowlist.test.ts` | the six shapes match; wrong arity, `profileSettings`, every SQLite-owned key, `activeBoard`, feeds all miss; `publicProfile` only for the owner |
| `envelope.test.ts` | round trip; `json` / `shape` / `version` classification; `utf8ByteLength` == `Buffer.byteLength`; a serialized envelope has no `mutations` key even from a client holding mutations |
| `dehydrate.test.ts` | zero mutations dehydrated from a client holding a **paused** mutation (query-core's own default keeps it, asserted as a control); only successful idle allowlisted entries survive |
| `budget.test.ts` | 70 KB entry dropped oversize; a 600 KB set evicts lowest-priority-first and keeps `['profile']`; oldest-first within a priority |
| `restore.test.ts` | `['infiniteSearchClimbs']` and a stranger's `publicProfile` in a hand-crafted blob hydrate neither; `['myBoards', undefined]` survives the `undefined→null` round trip; owner mismatch / missing hint hydrate nothing; 15-day `profile` and 25-hour `publicProfile` dropped while a 13-day `grades` survives; a fresher live entry is never clobbered; the merge set is seeded from the restore |
| `writer.test.ts` | no write with a null owner; the first write after the owner arrives; `flush()` cancels the pending timer; **the C1 regression**: suspend → nothing written → `setPersistOwner` → a write lands; a gc'd entry carried forward but not one past its maxAge; a restore-seeded merge set survives `client.clear()` |
| `auth-boundary.test.ts` | `decideOwnerTransition` truth table; **the C2 regression**: `readPersistedCacheAsync` called with literal `undefined`; **the C3 regression**: a second and third adopt for the same user perform zero reads, hydrates and emits; an account switch reports nothing |
| `storage-native.test.ts` | own per-`id` MMKV mock (the shared stub shares one process-wide map): the blob never lands in `boardsesh-settings`; presence answers from the sentinel, not the blob; clear removes both keys |
| `storage-web-sweep.test.ts` | `sweepOrphanedUserStorage`'s predicate matches both query-cache keys of a stale login and neither the live login's nor another user's |
| `cold-start-budget.test.ts` | profile + 6 fully-populated boards + 3 gyms + 24 grades × 2 boards + 9 angles × 2 boards serializes under 100 KB |
| `query-provider-persist.test.tsx` | `getQueryData(['profile'])` is non-undefined during the **first render pass**; a missing sentinel hydrates nothing; background writes only once armed; pre-auth providers leave all six hydrated entries at 0 observers / idle / unchanged `dataUpdatedAt` |
| `pre-auth-query-cache-audit.test.ts` | every listed pre-auth path exists on disk; every JSX tag between `<QueryProvider>` and `<AuthProvider` is covered; no query-cache API anywhere in that import graph; `OfflineEngineFlagSync` itself is clean |
| `auth-provider.test.tsx` (extended) | sign-out suspends the writer **before** deleting the blob; a logged-out cold start with a blob runs the full `runSignedOutCleanup`, without one keeps the light sweep; the auth boundary adopts with `undefined` |

### Device QA gate (required before this leaves draft)

JS-only, so a `pr-<number>` OTA reaches an existing TestFlight/store binary — no new build. Run on the **slowest Android device available**, not the x86_64 emulator.

1. Sign in; visit My Boards, My gyms, the Climbs tab on **two** boards, and your own profile on You. Background the app once so the flush writes.
2. `adb shell run-as com.boardsesh.app ls -l files/mmkv/` — a `boardsesh-query-cache` file must exist, separate from `boardsesh-settings`.
3. **Performance gate.** Force-stop, airplane mode, 5× `adb shell am start -W`; then 5 more runs with `files/mmkv/boardsesh-query-cache*` deleted between launches. **Accept if the median `TotalTime` regression is ≤ 30 ms.** Over that, cut grades/angles retention — do not raise the bar.
4. Still in airplane mode: `/boards/manage` renders with the correct "Your boards" / "Following" headers and **no** error panel. PostHog shows `Offline Query Cache Restored { outcome: 'hydrated' }` with a plausible `entryCount`/`bytes` and no `evicted`.
5. **Writer re-arm.** Sign out, sign back in as the same user, visit My Boards + My gyms, background: the MMKV file must reappear with a fresh mtime. Cold start in airplane mode — the board list must render. (A dead writer looks exactly like a passing step 4 and a failing step 5.)
6. **No duplicate adopt.** Background/foreground 3×: exactly **one** `Offline Query Cache Restored` for the launch, and **zero** `Persisted query cache owner mismatch` in Sentry.
7. **Sign-out wipe.** Back online, sign out: the MMKV file is gone; a cold start shows the login screen with no cached profile.
8. **Expired session, ONLINE.** Revoke the refresh token server-side, force-stop, cold start **with network**. Expect: signed out, no profile/board list from cache, blob gone, `syncEnabledBoards` cleared, downloaded catalogs still on disk. (Meaningless offline — only a server-*rejected* refresh resolves `anonymous`; an unreachable one stays authenticated-degraded.)
9. **Offline grace.** Sign in, let the access token near expiry, force-stop, airplane mode, cold start. Expect: still **signed in**, `/boards/manage` renders from cache, blob still on disk. This is the behaviour that would be destroyed by "fixing" step 8, so it is a gate.

## Decisions for Marco

Both flagged `needsMarco` in the plan; the defaults below are what shipped.

**1. Stale Home / session feeds behind a "last updated 3 h ago" banner, or keep them off the allowlist?**
Shipped: **kept off.** The allowlist is exactly the decision doc's six keys. Offline, feeds keep the honest "no signal" state from #4349.
Why: feeds have "now" semantics and are unbounded — the two properties Bucket 3 exists for. They'd blow the 100 KB target on their own and reintroduce the merge question the provenance rule was written to eliminate. Adding them later is an allowlist entry plus a banner; removing them after they ship is a regression users notice. This is the issue's own stated open question.

**2. Should `/boards/manage` show the full persisted board roster offline, or keep showing only downloaded boards?**
Shipped: **current behaviour unchanged.** When `shouldUseOfflineList` is true the screen still renders `offlineBoardRows(...)`, which filters to scopes with a completeness marker. The persisted cache only makes the `cachedMyBoards` tier warm, so names and owned/followed grouping are fresher; comments only, no logic change.
Why: the issue is explicit that #3897/#4309's MMKV path and its tests stay untouched, and `offlineBoardRows` already documents why an undownloaded board is hidden (activating it lands you on an empty climb list). Showing the whole roster offline needs a per-row "not downloaded" affordance and a new empty state — a separate product change. Flagged because a reader of the precedence comment might reasonably expect the full roster.

## Risks

1. **Highest — the `needsFullCleanup` widening.** A logged-out cold start with a blob now runs the full `runSignedOutCleanup`: `syncEnabledBoards` is emptied and `clearOfflineBoards()` runs. Downloaded catalogs survive (`purgeOfflineBoards` stays false), so re-enabling a board resumes instantly. This is identical to the treatment an in-session token expiry already gets, extended to the killed-app case, and it can only fire on a **confirmed** logout. Pinned both ways by tests and by QA steps 8 and 9.
2. The `handleSignedOutTransition` restructure adds an `await` to a function with a documented "publish anonymous before any storage await" invariant on web — mitigated by capturing `wasAuthenticatedThisSession` before the publish block and re-checking `isAuthTransitionCurrent` after the await. The existing web-transition tests stay green.
3. The owner-gate-at-fire-time is the whole correctness story for sign-out safety and re-arming. If a future edit moves the owner read back to schedule time, both the leak window and the dead-writer bug return. The writer test and the `runtime.ts` doc comment are the guards.
4. A synchronous MMKV read + `JSON.parse` of up to 512 KB on the JS thread before first render — unmeasurable in vitest, hence the mandatory device gate above.
5. `Offline Query Cache Restored` is permanent once shipped.
6. Stale profile/board names for up to 14 days offline; every screen refetches on mount when there is signal.

## Deviations from the plan

- **`DehydratedQuery` is not exported** by `@tanstack/query-core@5.101.4` (only `DehydratedState` is). Derived it as `DehydratedState['queries'][number]` and exported it as `PersistedQueryEntry`.
- **Sentry alarm condition widened.** The plan reported `owner_mismatch` only when `restorePersistedCache` returned that outcome. That misses the actual cross-user leak: a blob whose MMKV sentinel *agrees* with it but disagrees with resolved auth hydrates as `'hydrated'`, then gets evicted. The alarm now fires on `transition === 'evict-then-adopt' || outcome === 'owner_mismatch'`, and that case reports `outcome: 'owner_mismatch'` to PostHog so the funnel doesn't hide it as a successful hydrate.
- **An unusable blob is deleted, not just skipped.** The plan's evict branch keyed purely off `decideOwnerTransition`, which left a torn (`owner_missing`), corrupt (`unreadable`) or fully-aged-out (`empty`) blob on disk. Added an explicit `hasUnusableBlob` clause so those are cleaned up too. `owner_missing` remains deliberately silent in Sentry.
- **T-18 narrowed**, using the plan's own escape hatch: it mounts `QueryProvider` + `FeatureFlagsProvider` over the six hydrated entries rather than the full pre-auth stack, because `DatabaseProvider` / `OfflineEngineFlagSync` need the whole offline-sync-bridge mock recipe under vitest. T-17's source-graph guard is the durable check and covers `OfflineEngineFlagSync` with its own targeted assertion.
- **T-17's walk excludes `offline-sync-bridge.tsx` as a seed**, not just as a file. Walking from it drags `auth-provider.tsx` and the sync adapter into the graph — neither of which mounts pre-auth. `OfflineEngineFlagSync`'s own function body is asserted directly instead, and its two real dependencies are added as walk seeds.
- **Web meta value carries no `userId`** (just `{ savedAt, bytes }`): on web the owning account is already in the key itself, so duplicating it would be a second place to get wrong.
