### PR TITLE
fix(repo): make stale worktree cleanup recoverable

### DIFF
--- a/scripts/__tests__/cleanup-merged-worktrees.test.ts
+++ b/scripts/__tests__/cleanup-merged-worktrees.test.ts
@@ -126,6 +126,17 @@ async function createFixture(headAgeSeconds: number, candidateRelativePath = 'fe
     '#!/bin/sh\n' +
       'if [ "$1" = auth ] && [ "$2" = status ]; then exit 0; fi\n' +
       'if [ "$1" = pr ] && [ "$2" = list ]; then\n' +
+      '  if [ -n "${GH_PR_COUNT:-}" ]; then\n' +
+      '    printf "["\n' +
+      '    pr_index=1\n' +
+      '    while [ "$pr_index" -le "$GH_PR_COUNT" ]; do\n' +
+      '      if [ "$pr_index" -gt 1 ]; then printf ","; fi\n' +
+      '      printf \'{"createdAt":"2026-01-01T00:00:00Z","headRefName":"unrelated","isCrossRepository":false,"mergeCommit":null,"mergedAt":null,"number":%s,"state":"CLOSED","url":"https://github.com/boardsesh/boardsesh/pull/%s"}\' "$pr_index" "$pr_index"\n' +
+      '      pr_index=$((pr_index + 1))\n' +
+      '    done\n' +
+      '    printf "]\\n"\n' +
+      '    exit 0\n' +
+      '  fi\n' +
       '  printf "%s\\n" "$GH_PR_JSON"\n' +
       '  exit 0\n' +
       'fi\n' +
@@ -515,6 +526,17 @@ describe('cleanup-merged-worktrees safety policy', () => {
     expect(result.stdout).toContain('PR #41 merged; inactive 1d');
     expect(result.stdout).toContain('Removed: 1');
     expect(runGit(['rev-parse', 'feature'], fixture.primaryWorktree)).toBe(fixture.candidateHead);
+  });
+
+  it('warns when the bounded PR metadata window is full', async () => {
+    const fixture = await createFixture(24 * 60 * 60);
+    const result = runCleanup(fixture, [], [], { GH_PR_COUNT: '1000' });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toContain(
+      'only the newest 1000 PRs were loaded; older unmatched branches will use the conservative no-PR policy',
+    );
+    expect(result.stdout).toContain('no PR; inactive for 1d, minimum is 7d');
   });
 
   it('revalidates HEAD for a no-PR candidate immediately before applying removal', async () => {

--- a/scripts/__tests__/cleanup-merged-worktrees.test.ts
+++ b/scripts/__tests__/cleanup-merged-worktrees.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 
 import { spawn, spawnSync } from 'node:child_process';
-import { access, chmod, cp, mkdtemp, mkdir, rm, utimes, writeFile } from 'node:fs/promises';
+import { access, chmod, cp, mkdtemp, mkdir, readFile, rm, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -126,7 +126,6 @@ async function createFixture(headAgeSeconds: number, candidateRelativePath = 'fe
     '#!/bin/sh\n' +
       'if [ "$1" = auth ] && [ "$2" = status ]; then exit 0; fi\n' +
       'if [ "$1" = pr ] && [ "$2" = list ]; then\n' +
-      '  if [ -n "${GH_PR_JSON_FILE:-}" ]; then cat "$GH_PR_JSON_FILE"; exit 0; fi\n' +
       '  printf "%s\\n" "$GH_PR_JSON"\n' +
       '  exit 0\n' +
       'fi\n' +
@@ -354,19 +353,26 @@ describe('cleanup-merged-worktrees safety policy', () => {
 
   it('uses lsof CWD records when procfs is unavailable', async () => {
     const fixture = await createFixture(8 * 24 * 60 * 60);
+    const lsofCountFile = join(dirname(fixture.primaryWorktree), 'lsof-count');
     await writeExecutable(
       join(fixture.stubBinDirectory, 'lsof'),
-      '#!/bin/sh\nprintf "p12345\\nn%s/active-subdirectory\\n" "$LSOF_ACTIVE_WORKTREE"\n',
+      '#!/bin/sh\n' +
+        'count=0\n' +
+        'if [ -f "$LSOF_COUNT_FILE" ]; then IFS= read -r count < "$LSOF_COUNT_FILE"; fi\n' +
+        'printf "%s\\n" "$((count + 1))" > "$LSOF_COUNT_FILE"\n' +
+        'printf "p12345\\nn%s/active-subdirectory\\n" "$LSOF_ACTIVE_WORKTREE"\n',
     );
 
     const result = runCleanup(fixture, [], ['--apply'], {
       LSOF_ACTIVE_WORKTREE: fixture.candidateWorktree,
+      LSOF_COUNT_FILE: lsofCountFile,
       WORKTREE_CWD_PROC_ROOT_OVERRIDE: '/proc-not-mounted-for-test',
     });
 
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toContain('a live process has its CWD in this worktree');
     expect(result.stdout).toContain('Eligible for removal: 0');
+    expect(await readFile(lsofCountFile, 'utf8')).toBe('1\n');
     expect(runGit(['worktree', 'list', '--porcelain'], fixture.primaryWorktree)).toContain(fixture.candidateWorktree);
   });
 
@@ -416,22 +422,6 @@ describe('cleanup-merged-worktrees safety policy', () => {
     expect(runGit(['rev-parse', recoveryRef], fixture.primaryWorktree)).toBe(fixture.candidateHead);
     await expect(access(fixture.candidateWorktree)).rejects.toThrow();
   }, 15_000);
-
-  it('fails closed when the PR metadata query reaches its safety limit', async () => {
-    const fixture = await createFixture(8 * 24 * 60 * 60);
-    const pullRequestFile = join(dirname(fixture.primaryWorktree), 'pull-requests.json');
-    const pullRequests = Array.from({ length: 10_000 }, (_, index) => ({
-      ...mergedPullRequest(fixture.candidateHead),
-      number: index + 1,
-    }));
-    await writeFile(pullRequestFile, JSON.stringify(pullRequests), 'utf8');
-
-    const result = runCleanup(fixture, [], ['--apply'], { GH_PR_JSON_FILE: pullRequestFile });
-
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain('reached the 10000-PR safety limit; no worktrees were changed');
-    expect(runGit(['worktree', 'list', '--porcelain'], fixture.primaryWorktree)).toContain(fixture.candidateWorktree);
-  });
 
   it('preserves an unreachable detached commit even when its final tree matches main', async () => {
     const fixture = await createFixture(8 * 24 * 60 * 60);

--- a/scripts/__tests__/cleanup-merged-worktrees.test.ts
+++ b/scripts/__tests__/cleanup-merged-worktrees.test.ts
@@ -126,6 +126,7 @@ async function createFixture(headAgeSeconds: number, candidateRelativePath = 'fe
     '#!/bin/sh\n' +
       'if [ "$1" = auth ] && [ "$2" = status ]; then exit 0; fi\n' +
       'if [ "$1" = pr ] && [ "$2" = list ]; then\n' +
+      '  if [ -n "${GH_PR_JSON_FILE:-}" ]; then cat "$GH_PR_JSON_FILE"; exit 0; fi\n' +
       '  printf "%s\\n" "$GH_PR_JSON"\n' +
       '  exit 0\n' +
       'fi\n' +
@@ -351,6 +352,38 @@ describe('cleanup-merged-worktrees safety policy', () => {
     }
   });
 
+  it('uses lsof CWD records when procfs is unavailable', async () => {
+    const fixture = await createFixture(8 * 24 * 60 * 60);
+    await writeExecutable(
+      join(fixture.stubBinDirectory, 'lsof'),
+      '#!/bin/sh\nprintf "p12345\\nn%s/active-subdirectory\\n" "$LSOF_ACTIVE_WORKTREE"\n',
+    );
+
+    const result = runCleanup(fixture, [], ['--apply'], {
+      LSOF_ACTIVE_WORKTREE: fixture.candidateWorktree,
+      WORKTREE_CWD_PROC_ROOT_OVERRIDE: '/proc-not-mounted-for-test',
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('a live process has its CWD in this worktree');
+    expect(result.stdout).toContain('Eligible for removal: 0');
+    expect(runGit(['worktree', 'list', '--porcelain'], fixture.primaryWorktree)).toContain(fixture.candidateWorktree);
+  });
+
+  it('warns and fails closed when live process CWDs cannot be enumerated', async () => {
+    const fixture = await createFixture(8 * 24 * 60 * 60);
+    await writeExecutable(join(fixture.stubBinDirectory, 'lsof'), '#!/bin/sh\nexit 1\n');
+
+    const result = runCleanup(fixture, [], ['--apply'], {
+      WORKTREE_CWD_PROC_ROOT_OVERRIDE: '/proc-not-mounted-for-test',
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toContain('live process CWDs could not be enumerated');
+    expect(result.stdout).toContain('Eligible for removal: 0');
+    expect(result.stdout).toContain('Skipped — in use:      1');
+  });
+
   it('never removes a Git-locked worktree', async () => {
     const fixture = await createFixture(8 * 24 * 60 * 60);
     runGit(['worktree', 'lock', '--reason', 'active agent', fixture.candidateWorktree], fixture.primaryWorktree);
@@ -383,6 +416,22 @@ describe('cleanup-merged-worktrees safety policy', () => {
     expect(runGit(['rev-parse', recoveryRef], fixture.primaryWorktree)).toBe(fixture.candidateHead);
     await expect(access(fixture.candidateWorktree)).rejects.toThrow();
   }, 15_000);
+
+  it('fails closed when the PR metadata query reaches its safety limit', async () => {
+    const fixture = await createFixture(8 * 24 * 60 * 60);
+    const pullRequestFile = join(dirname(fixture.primaryWorktree), 'pull-requests.json');
+    const pullRequests = Array.from({ length: 10_000 }, (_, index) => ({
+      ...mergedPullRequest(fixture.candidateHead),
+      number: index + 1,
+    }));
+    await writeFile(pullRequestFile, JSON.stringify(pullRequests), 'utf8');
+
+    const result = runCleanup(fixture, [], ['--apply'], { GH_PR_JSON_FILE: pullRequestFile });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('reached the 10000-PR safety limit; no worktrees were changed');
+    expect(runGit(['worktree', 'list', '--porcelain'], fixture.primaryWorktree)).toContain(fixture.candidateWorktree);
+  });
 
   it('preserves an unreachable detached commit even when its final tree matches main', async () => {
     const fixture = await createFixture(8 * 24 * 60 * 60);

--- a/scripts/__tests__/cleanup-merged-worktrees.test.ts
+++ b/scripts/__tests__/cleanup-merged-worktrees.test.ts
@@ -1,12 +1,14 @@
 /// <reference types="node" />
 
-import { spawnSync } from 'node:child_process';
-import { access, chmod, cp, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { spawn, spawnSync } from 'node:child_process';
+import { access, chmod, cp, mkdtemp, mkdir, rm, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { describe, expect, it, onTestFinished } from 'vitest';
+import { describe, expect, it, onTestFinished, vi } from 'vitest';
+
+vi.setConfig({ testTimeout: 15_000 });
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const cleanupScript = join(repositoryRoot, 'scripts/cleanup-merged-worktrees.sh');
@@ -21,11 +23,14 @@ type Fixture = {
 };
 
 type PullRequest = {
+  createdAt: string;
+  headRefName: string;
   headRefOid?: string;
+  isCrossRepository: boolean;
   mergeCommit: null | { oid: string };
   mergedAt: null | string;
   number: number;
-  state: 'MERGED' | 'OPEN';
+  state: 'CLOSED' | 'MERGED' | 'OPEN';
   url: string;
 };
 
@@ -55,13 +60,27 @@ async function writeExecutable(path: string, contents: string): Promise<void> {
   await chmod(path, 0o755);
 }
 
-async function createFixture(headAgeSeconds: number): Promise<Fixture> {
+async function setWorktreeInactivity(worktree: string, inactivitySeconds: number): Promise<void> {
+  const activityTimestamp = new Date(Date.now() - inactivitySeconds * 1000);
+  const administrativeHead = runGit(['rev-parse', '--path-format=absolute', '--git-path', 'HEAD'], worktree);
+  await utimes(administrativeHead, activityTimestamp, activityTimestamp);
+  const branchRef = run('git', ['symbolic-ref', '--quiet', 'HEAD'], worktree);
+  if (branchRef.status === 0) {
+    const branchRefPath = runGit(
+      ['rev-parse', '--path-format=absolute', '--git-path', branchRef.stdout.trim()],
+      worktree,
+    );
+    await utimes(branchRefPath, activityTimestamp, activityTimestamp);
+  }
+}
+
+async function createFixture(headAgeSeconds: number, candidateRelativePath = 'feature'): Promise<Fixture> {
   const rootDirectory = await mkdtemp(join(tmpdir(), 'boardsesh-worktree-cleanup-'));
   onTestFinished(() => rm(rootDirectory, { force: true, recursive: true }));
 
   const bareRepository = join(rootDirectory, 'origin.git');
   const primaryWorktree = join(rootDirectory, 'main');
-  const candidateWorktree = join(rootDirectory, 'feature');
+  const candidateWorktree = join(rootDirectory, candidateRelativePath);
   const stubBinDirectory = join(rootDirectory, 'stub-bin');
   const scriptPath = join(primaryWorktree, 'scripts/cleanup-merged-worktrees.sh');
   const realGitResult = run('sh', ['-c', 'command -v git'], rootDirectory);
@@ -80,6 +99,7 @@ async function createFixture(headAgeSeconds: number): Promise<Fixture> {
   runGit(['-c', 'core.hooksPath=/dev/null', 'commit', '-m', 'chore: seed cleanup fixture'], primaryWorktree);
   runGit(['push', '-u', 'origin', 'main'], primaryWorktree);
 
+  await mkdir(dirname(candidateWorktree), { recursive: true });
   runGit(['worktree', 'add', '-b', 'feature', candidateWorktree, 'main'], primaryWorktree);
   await writeFile(join(candidateWorktree, 'feature.txt'), 'finished feature\n', 'utf8');
   runGit(['add', 'feature.txt'], candidateWorktree);
@@ -95,6 +115,7 @@ async function createFixture(headAgeSeconds: number): Promise<Fixture> {
     commitEnvironment,
   );
   const candidateHead = runGit(['rev-parse', 'HEAD'], candidateWorktree);
+  await setWorktreeInactivity(candidateWorktree, headAgeSeconds);
 
   await mkdir(dirname(scriptPath), { recursive: true });
   await mkdir(stubBinDirectory, { recursive: true });
@@ -105,12 +126,7 @@ async function createFixture(headAgeSeconds: number): Promise<Fixture> {
     '#!/bin/sh\n' +
       'if [ "$1" = auth ] && [ "$2" = status ]; then exit 0; fi\n' +
       'if [ "$1" = pr ] && [ "$2" = list ]; then\n' +
-      '  while [ "$#" -gt 0 ]; do\n' +
-      '    if [ "$1" = --head ]; then shift; head_branch="$1"; break; fi\n' +
-      '    shift\n' +
-      '  done\n' +
-      '  if [ "$head_branch" = feature ]; then printf "%s\\n" "$GH_PR_JSON"; exit 0; fi\n' +
-      '  printf "%s\\n" "${GH_OTHER_PR_JSON:-[]}"\n' +
+      '  printf "%s\\n" "$GH_PR_JSON"\n' +
       '  exit 0\n' +
       'fi\n' +
       'exit 1\n',
@@ -118,6 +134,15 @@ async function createFixture(headAgeSeconds: number): Promise<Fixture> {
   await writeExecutable(
     join(stubBinDirectory, 'git'),
     '#!/bin/sh\n' +
+      'if [ -n "${GIT_DIRTY_ON_STATUS_COUNT_FILE:-}" ] && [ -n "${GIT_MUTATE_WORKTREE:-}" ] && ' +
+      '[ "$#" -eq 4 ] && [ "$1" = -C ] && [ "$2" = "$GIT_MUTATE_WORKTREE" ] && ' +
+      '[ "$3" = status ] && [ "$4" = --porcelain ]; then\n' +
+      '  status_count=0\n' +
+      '  if [ -f "$GIT_DIRTY_ON_STATUS_COUNT_FILE" ]; then IFS= read -r status_count < "$GIT_DIRTY_ON_STATUS_COUNT_FILE"; fi\n' +
+      '  status_count=$((status_count + 1))\n' +
+      '  printf "%s\\n" "$status_count" > "$GIT_DIRTY_ON_STATUS_COUNT_FILE"\n' +
+      '  if [ "$status_count" -eq 2 ]; then printf "%s\\n" "changed during apply" > "$GIT_MUTATE_WORKTREE/apply-dirty.txt"; fi\n' +
+      'fi\n' +
       'if [ -n "${GIT_MUTATE_WORKTREE:-}" ] && [ -n "${GIT_MUTATE_COUNT_FILE:-}" ] && ' +
       '[ "$#" -eq 4 ] && [ "$1" = -C ] && [ "$2" = "$GIT_MUTATE_WORKTREE" ] && ' +
       '[ "$3" = rev-parse ] && [ "$4" = HEAD ]; then\n' +
@@ -145,6 +170,9 @@ async function createFixture(headAgeSeconds: number): Promise<Fixture> {
 function openPullRequest(headRefOid?: string): PullRequest {
   return {
     ...(headRefOid === undefined ? {} : { headRefOid }),
+    createdAt: '2026-02-01T00:00:00Z',
+    headRefName: 'feature',
+    isCrossRepository: false,
     mergeCommit: null,
     mergedAt: null,
     number: 42,
@@ -155,7 +183,10 @@ function openPullRequest(headRefOid?: string): PullRequest {
 
 function mergedPullRequest(headRefOid: string): PullRequest {
   return {
+    createdAt: '2026-01-01T00:00:00Z',
+    headRefName: 'feature',
     headRefOid,
+    isCrossRepository: false,
     mergeCommit: { oid: headRefOid },
     mergedAt: '2026-01-01T00:00:00Z',
     number: 41,
@@ -172,33 +203,34 @@ function runCleanup(
 ) {
   return run('bash', [fixture.scriptPath, ...args], fixture.primaryWorktree, {
     GH_PR_JSON: JSON.stringify(pullRequests),
+    GITHUB_REPOSITORY_OVERRIDE: 'boardsesh/cleanup-fixture',
     PATH: `${fixture.stubBinDirectory}:${process.env.PATH ?? ''}`,
     REAL_GIT_PATH: fixture.realGitPath,
     ...extraEnvironment,
   });
 }
 
-describe('cleanup-merged-worktrees open PR handling', () => {
+describe('cleanup-merged-worktrees safety policy', () => {
   it('shows both dry-run and apply invocations in help output', () => {
     const result = run('bash', [cleanupScript, '--help'], repositoryRoot);
 
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toContain('./cleanup-merged-worktrees.sh           # dry-run');
     expect(result.stdout).toContain(
-      './cleanup-merged-worktrees.sh --apply   # remove worktrees; preserve open-PR branches',
+      './cleanup-merged-worktrees.sh --apply   # remove worktrees; preserve recovery refs',
     );
   });
 
-  it('removes a clean, in-sync open PR worktree once HEAD is 48 hours old', async () => {
+  it('removes a clean, in-sync open PR worktree after 48 hours of worktree inactivity', async () => {
     const fixture = await createFixture(48 * 60 * 60);
 
     const result = runCleanup(fixture, [openPullRequest(fixture.candidateHead)], ['--apply']);
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain('PR #42 OPEN and in sync, HEAD 48h old');
+    expect(result.stdout).toContain('PR #42 OPEN and in sync; preserving branch; inactive 2d');
     expect(result.stdout).toContain('Eligible for removal: 1');
     expect(result.stdout).toContain('Removed: 1');
-    expect(result.stdout).toContain('preserved local branch feature (PR remains open)');
+    expect(result.stdout).toContain('preserved local branch feature');
     expect(runGit(['worktree', 'list', '--porcelain'], fixture.primaryWorktree)).not.toContain(
       fixture.candidateWorktree,
     );
@@ -206,8 +238,13 @@ describe('cleanup-merged-worktrees open PR handling', () => {
     expect(runGit(['rev-parse', 'feature'], fixture.primaryWorktree)).toBe(fixture.candidateHead);
   });
 
-  it('continues deleting the local branch after removing a merged-PR worktree', async () => {
+  it('deletes a merged branch only when its content is represented in main', async () => {
     const fixture = await createFixture(72 * 60 * 60);
+    runGit(
+      ['-c', 'core.hooksPath=/dev/null', 'merge', '--no-ff', 'feature', '-m', 'merge fixture feature'],
+      fixture.primaryWorktree,
+    );
+    runGit(['push', 'origin', 'main'], fixture.primaryWorktree);
 
     const result = runCleanup(fixture, [mergedPullRequest(fixture.candidateHead)], ['--apply']);
 
@@ -219,104 +256,233 @@ describe('cleanup-merged-worktrees open PR handling', () => {
     ).not.toBe(0);
   });
 
-  it('continues deleting an old no-PR branch whose content matches main', async () => {
+  it('removes a stale merged worktree with a divergent tip but preserves its branch', async () => {
+    const fixture = await createFixture(72 * 60 * 60);
+    const differentPullRequestHead = '0000000000000000000000000000000000000000';
+
+    const result = runCleanup(fixture, [mergedPullRequest(differentPullRequestHead)], ['--apply']);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('preserving branch with unique or divergent content');
+    expect(result.stdout).toContain('Removed: 1');
+    expect(runGit(['rev-parse', 'feature'], fixture.primaryWorktree)).toBe(fixture.candidateHead);
+  });
+
+  it('applies an inactivity floor even when the PR is merged', async () => {
+    const fixture = await createFixture(30 * 24 * 60 * 60);
+    await setWorktreeInactivity(fixture.candidateWorktree, 23 * 60 * 60);
+
+    const result = runCleanup(fixture, [mergedPullRequest(fixture.candidateHead)]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('MERGED; inactive for 23h, minimum is 1d');
+    expect(result.stdout).toContain('Eligible for removal: 0');
+    expect(result.stdout).toContain('Skipped — too fresh:  1');
+  });
+
+  it('preserves a stale no-PR branch even when its content matches main', async () => {
     const fixture = await createFixture(8 * 24 * 60 * 60);
     runGit(['-c', 'core.hooksPath=/dev/null', 'cherry-pick', fixture.candidateHead], fixture.primaryWorktree);
     runGit(['push', 'origin', 'main'], fixture.primaryWorktree);
+    runGit(['config', 'diff.external', ''], fixture.primaryWorktree);
 
     const result = runCleanup(fixture, [], ['--apply']);
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain('no PR; tree matches origin/main, HEAD 8d old');
-    expect(result.stdout).toContain('deleted branch feature');
-    expect(
-      run('git', ['show-ref', '--verify', '--quiet', 'refs/heads/feature'], fixture.primaryWorktree).status,
-    ).not.toBe(0);
+    expect(result.stdout).toContain('no PR; content is in origin/main; preserving branch; inactive 8d');
+    expect(result.stdout).toContain('preserved local branch feature');
+    expect(runGit(['rev-parse', 'feature'], fixture.primaryWorktree)).toBe(fixture.candidateHead);
   });
 
-  it('keeps an in-sync open PR worktree whose HEAD is younger than 48 hours', async () => {
+  it('removes a stale clean no-PR worktree with unique commits and preserves its branch', async () => {
+    const fixture = await createFixture(8 * 24 * 60 * 60);
+
+    const result = runCleanup(fixture, [], ['--apply']);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('no PR; unique content; preserving branch; inactive 8d');
+    expect(result.stdout).toContain('Removed: 1');
+    expect(runGit(['rev-parse', 'feature'], fixture.primaryWorktree)).toBe(fixture.candidateHead);
+    await expect(access(fixture.candidateWorktree)).rejects.toThrow();
+  });
+
+  it('keeps an in-sync open PR worktree whose administrative activity is younger than 48 hours', async () => {
     const fixture = await createFixture(47 * 60 * 60);
 
     const result = runCleanup(fixture, [openPullRequest(fixture.candidateHead)]);
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain('PR #42 OPEN and in sync, but HEAD is 47h old');
+    expect(result.stdout).toContain('OPEN; inactive for 1d, minimum is 2d');
     expect(result.stdout).toContain('Eligible for removal: 0');
     expect(result.stdout).toContain('Skipped — too fresh:  1');
   });
 
-  it('keeps an old open PR worktree when its local HEAD is not the PR head', async () => {
-    const fixture = await createFixture(72 * 60 * 60);
-    const historicalMergedPullRequest: PullRequest = {
-      headRefOid: fixture.candidateHead,
-      mergeCommit: { oid: fixture.candidateHead },
-      mergedAt: '2026-01-01T00:00:00Z',
-      number: 12,
-      state: 'MERGED',
-      url: 'https://github.com/boardsesh/boardsesh/pull/12',
-    };
-
-    const result = runCleanup(fixture, [
-      historicalMergedPullRequest,
-      openPullRequest('0000000000000000000000000000000000000000'),
-    ]);
-
-    expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain('PR #42 OPEN, but local HEAD is not in sync with PR head');
-    expect(result.stdout).toContain('Eligible for removal: 0');
-    expect(result.stdout).toContain('Skipped — open PR:    1');
-  });
-
-  it('keeps an old open PR worktree when GitHub omits the PR head OID', async () => {
-    const fixture = await createFixture(72 * 60 * 60);
-
-    const result = runCleanup(fixture, [openPullRequest()]);
-
-    expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain('PR #42 OPEN, but local HEAD is not in sync with PR head');
-    expect(result.stdout).toContain('Eligible for removal: 0');
-  });
-
-  it('keeps an old, in-sync open PR worktree when it has uncommitted changes', async () => {
+  it('fails closed on dirty worktrees', async () => {
     const fixture = await createFixture(72 * 60 * 60);
     await writeFile(join(fixture.candidateWorktree, 'uncommitted.txt'), 'keep me\n', 'utf8');
 
     const result = runCleanup(fixture, [openPullRequest(fixture.candidateHead)]);
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain('PR #42 OPEN, but 1 uncommitted file(s)');
+    expect(result.stdout).toContain('[feature] (1 uncommitted file(s))');
     expect(result.stdout).toContain('Eligible for removal: 0');
     expect(result.stdout).toContain('Skipped — dirty:      1');
   });
 
-  it('fails closed when status cannot be read for an open PR worktree', async () => {
-    const fixture = await createFixture(72 * 60 * 60);
-    await rm(fixture.candidateWorktree, { force: true, recursive: true });
+  it('never removes a worktree when a live process CWD is in a subdirectory', async () => {
+    const fixture = await createFixture(8 * 24 * 60 * 60);
+    const processDirectory = join(fixture.candidateWorktree, 'empty-process-directory');
+    await mkdir(processDirectory);
+    const liveProcess = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+      cwd: processDirectory,
+      stdio: 'ignore',
+    });
 
-    const result = runCleanup(fixture, [openPullRequest(fixture.candidateHead)]);
+    try {
+      const result = runCleanup(fixture, [], ['--apply']);
 
-    expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain('PR #42 OPEN; failed to read status');
-    expect(result.stdout).toContain('Eligible for removal: 0');
-    expect(result.stdout).toContain('Skipped — open PR:    1');
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain('a live process has its CWD in this worktree');
+      expect(result.stdout).toContain('Eligible for removal: 0');
+      expect(result.stdout).toContain('Skipped — in use:      1');
+      expect(runGit(['worktree', 'list', '--porcelain'], fixture.primaryWorktree)).toContain(fixture.candidateWorktree);
+    } finally {
+      liveProcess.kill('SIGKILL');
+    }
   });
 
-  it('keeps an in-sync open PR worktree whose HEAD timestamp is in the future', async () => {
-    const fixture = await createFixture(-90 * 60);
+  it('never removes a Git-locked worktree', async () => {
+    const fixture = await createFixture(8 * 24 * 60 * 60);
+    runGit(['worktree', 'lock', '--reason', 'active agent', fixture.candidateWorktree], fixture.primaryWorktree);
 
-    const result = runCleanup(fixture, [openPullRequest(fixture.candidateHead)]);
+    const result = runCleanup(fixture, [], ['--apply']);
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain('PR #42 OPEN and in sync, but HEAD is -1h old');
+    expect(result.stdout).toContain('worktree is locked');
     expect(result.stdout).toContain('Eligible for removal: 0');
-    expect(result.stdout).toContain('Skipped — too fresh:  1');
+    expect(result.stdout).toContain('Skipped — locked:      1');
+    expect(runGit(['worktree', 'list', '--porcelain'], fixture.primaryWorktree)).toContain(fixture.candidateWorktree);
   });
 
-  it('revalidates an open PR worktree immediately before applying removal', async () => {
-    const fixture = await createFixture(72 * 60 * 60);
+  it('creates a recovery branch before removing stale detached unique content', async () => {
+    const fixture = await createFixture(8 * 24 * 60 * 60);
+    runGit(['switch', '--detach'], fixture.candidateWorktree);
+    runGit(['branch', '-D', 'feature'], fixture.primaryWorktree);
+    await setWorktreeInactivity(fixture.candidateWorktree, 8 * 24 * 60 * 60);
+
+    const result = runCleanup(fixture, [], ['--apply']);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('unique content will get a recovery branch');
+    expect(result.stdout).toContain('preserved detached HEAD as recovery/worktree-feature-');
+    const recoveryRef = runGit(
+      ['for-each-ref', '--format=%(refname)', 'refs/heads/recovery/worktree-feature-*'],
+      fixture.primaryWorktree,
+    );
+    expect(recoveryRef).toMatch(/^refs\/heads\/recovery\/worktree-feature-/);
+    expect(runGit(['rev-parse', recoveryRef], fixture.primaryWorktree)).toBe(fixture.candidateHead);
+    await expect(access(fixture.candidateWorktree)).rejects.toThrow();
+  }, 15_000);
+
+  it('preserves an unreachable detached commit even when its final tree matches main', async () => {
+    const fixture = await createFixture(8 * 24 * 60 * 60);
+    runGit(['rm', 'feature.txt'], fixture.candidateWorktree);
+    const staleCommitTimestamp = Math.floor(Date.now() / 1000) - 8 * 24 * 60 * 60;
+    runGit(
+      ['-c', 'core.hooksPath=/dev/null', 'commit', '-m', 'revert: return to main tree'],
+      fixture.candidateWorktree,
+      {
+        GIT_AUTHOR_DATE: `@${staleCommitTimestamp} +0000`,
+        GIT_COMMITTER_DATE: `@${staleCommitTimestamp} +0000`,
+      },
+    );
+    const netZeroHead = runGit(['rev-parse', 'HEAD'], fixture.candidateWorktree);
+    runGit(['switch', '--detach'], fixture.candidateWorktree);
+    runGit(['branch', '-D', 'feature'], fixture.primaryWorktree);
+    await setWorktreeInactivity(fixture.candidateWorktree, 8 * 24 * 60 * 60);
+
+    const result = runCleanup(fixture, [], ['--apply']);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('unique content will get a recovery branch');
+    const recoveryRef = runGit(
+      ['for-each-ref', '--format=%(refname)', 'refs/heads/recovery/worktree-feature-*'],
+      fixture.primaryWorktree,
+    );
+    expect(runGit(['rev-parse', recoveryRef], fixture.primaryWorktree)).toBe(netZeroHead);
+  }, 15_000);
+
+  it('treats a recent commit as activity after its branch ref is packed', async () => {
+    const fixture = await createFixture(30 * 24 * 60 * 60);
+    runGit(
+      ['-c', 'core.hooksPath=/dev/null', 'commit', '--allow-empty', '-m', 'test: recent packed commit'],
+      fixture.candidateWorktree,
+    );
+    runGit(['pack-refs', '--all'], fixture.primaryWorktree);
+    const activityTimestamp = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const administrativeHead = runGit(
+      ['rev-parse', '--path-format=absolute', '--git-path', 'HEAD'],
+      fixture.candidateWorktree,
+    );
+    await utimes(administrativeHead, activityTimestamp, activityTimestamp);
+
+    const result = runCleanup(fixture, []);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('no PR; inactive for 0h, minimum is 7d');
+    expect(result.stdout).toContain('Eligible for removal: 0');
+  });
+
+  it('uses the 48-hour floor for clean Claude agent worktrees and preserves their branches', async () => {
+    const fixture = await createFixture(49 * 60 * 60, '.claude/worktrees/feature');
+
+    const result = runCleanup(fixture, [], ['--apply']);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('no PR; unique content; preserving branch; inactive 2d');
+    expect(result.stdout).toContain('Removed: 1');
+    expect(runGit(['rev-parse', 'feature'], fixture.primaryWorktree)).toBe(fixture.candidateHead);
+  }, 15_000);
+
+  it('treats a closed unmerged PR like stale no-PR work and preserves its branch', async () => {
+    const fixture = await createFixture(8 * 24 * 60 * 60);
+    const closedPullRequest: PullRequest = {
+      createdAt: '2026-03-01T00:00:00Z',
+      headRefName: 'feature',
+      headRefOid: fixture.candidateHead,
+      isCrossRepository: false,
+      mergeCommit: null,
+      mergedAt: null,
+      number: 43,
+      state: 'CLOSED',
+      url: 'https://github.com/boardsesh/boardsesh/pull/43',
+    };
+
+    const result = runCleanup(fixture, [mergedPullRequest(fixture.candidateHead), closedPullRequest], ['--apply']);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('PR #43 closed without merge; preserving branch');
+    expect(runGit(['rev-parse', 'feature'], fixture.primaryWorktree)).toBe(fixture.candidateHead);
+  });
+
+  it('prefers a PR whose head OID matches when a branch name was reused', async () => {
+    const fixture = await createFixture(30 * 60 * 60);
+    const newerOpenPullRequest = openPullRequest('0000000000000000000000000000000000000000');
+    newerOpenPullRequest.createdAt = '2026-04-01T00:00:00Z';
+
+    const result = runCleanup(fixture, [mergedPullRequest(fixture.candidateHead), newerOpenPullRequest], ['--apply']);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('PR #41 merged; inactive 1d');
+    expect(result.stdout).toContain('Removed: 1');
+    expect(runGit(['rev-parse', 'feature'], fixture.primaryWorktree)).toBe(fixture.candidateHead);
+  });
+
+  it('revalidates HEAD for a no-PR candidate immediately before applying removal', async () => {
+    const fixture = await createFixture(8 * 24 * 60 * 60);
     const mutationCountPath = join(dirname(fixture.primaryWorktree), 'git-mutation-count');
 
-    const result = runCleanup(fixture, [openPullRequest(fixture.candidateHead)], ['--apply'], {
+    const result = runCleanup(fixture, [], ['--apply'], {
       GIT_MUTATE_COUNT_FILE: mutationCountPath,
       GIT_MUTATE_WORKTREE: fixture.candidateWorktree,
     });
@@ -329,5 +495,22 @@ describe('cleanup-merged-worktrees open PR handling', () => {
     const advancedHead = runGit(['rev-parse', 'HEAD'], fixture.candidateWorktree);
     expect(advancedHead).not.toBe(fixture.candidateHead);
     expect(runGit(['rev-parse', 'feature'], fixture.primaryWorktree)).toBe(advancedHead);
+  });
+
+  it('revalidates cleanliness for every candidate immediately before applying removal', async () => {
+    const fixture = await createFixture(8 * 24 * 60 * 60);
+    const statusCountPath = join(dirname(fixture.primaryWorktree), 'git-status-count');
+
+    const result = runCleanup(fixture, [], ['--apply'], {
+      GIT_DIRTY_ON_STATUS_COUNT_FILE: statusCountPath,
+      GIT_MUTATE_WORKTREE: fixture.candidateWorktree,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('Eligible for removal: 1');
+    expect(result.stdout).toContain('worktree changed after eligibility scan');
+    expect(result.stdout).toContain('Removed: 0');
+    expect(result.stdout).toContain('Skipped after scan: 1');
+    await expect(access(join(fixture.candidateWorktree, 'apply-dirty.txt'))).resolves.toBeUndefined();
   });
 });

--- a/scripts/cleanup-merged-worktrees.sh
+++ b/scripts/cleanup-merged-worktrees.sh
@@ -162,6 +162,10 @@ if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$ALL_PR_JSON"; then
   echo "GitHub PR metadata was not a valid JSON array; no worktrees were changed" >&2
   exit 1
 fi
+PR_METADATA_COUNT=$(jq 'length' <<<"$ALL_PR_JSON")
+if [ "$PR_METADATA_COUNT" -ge "$PR_METADATA_LIMIT" ]; then
+  echo "Warning: only the newest $PR_METADATA_LIMIT PRs were loaded; older unmatched branches will use the conservative no-PR policy" >&2
+fi
 
 # Returns 0 (true) if the working tree at $1 is clean.
 worktree_clean() {

--- a/scripts/cleanup-merged-worktrees.sh
+++ b/scripts/cleanup-merged-worktrees.sh
@@ -117,6 +117,9 @@ skipped_in_use=0
 skipped_locked=0
 PROCESS_CWD_WARNING_SHOWN=0
 PROCESS_CWD_PROC_ROOT="${WORKTREE_CWD_PROC_ROOT_OVERRIDE:-/proc}"
+PROCESS_CWD_SNAPSHOT_READY=0
+PROCESS_CWD_SNAPSHOT_TRUSTED=0
+declare -a PROCESS_CWD_SNAPSHOT=()
 
 # Every removal has an inactivity floor. Agent worktrees are intentionally
 # shorter-lived because a live process CWD is checked both during the scan and
@@ -139,8 +142,9 @@ else
   echo "Warning: upstream main could not be refreshed; all local refs will be preserved" >&2
 fi
 
-# Fetch PR metadata once. Per-worktree `gh pr list --head` calls make cleanup of
-# large agent-worktree collections unnecessarily slow.
+# Fetch only the newest PR metadata once. Older unmatched PR branches follow
+# the more conservative no-PR policy: seven days of inactivity and no ref
+# deletion. This avoids downloading the repository's full PR history.
 GITHUB_REPOSITORY="${GITHUB_REPOSITORY_OVERRIDE:-}"
 if [ -z "$GITHUB_REPOSITORY" ]; then
   GITHUB_REPOSITORY=$(github_repository_from_origin) || {
@@ -148,7 +152,7 @@ if [ -z "$GITHUB_REPOSITORY" ]; then
     exit 1
   }
 fi
-PR_METADATA_LIMIT=10000
+PR_METADATA_LIMIT=1000
 if ! ALL_PR_JSON=$(gh pr list --repo "$GITHUB_REPOSITORY" --state all --limit "$PR_METADATA_LIMIT" \
   --json number,state,createdAt,mergedAt,url,headRefName,headRefOid,mergeCommit,isCrossRepository); then
   echo "Could not load GitHub PR metadata; no worktrees were changed" >&2
@@ -156,11 +160,6 @@ if ! ALL_PR_JSON=$(gh pr list --repo "$GITHUB_REPOSITORY" --state all --limit "$
 fi
 if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$ALL_PR_JSON"; then
   echo "GitHub PR metadata was not a valid JSON array; no worktrees were changed" >&2
-  exit 1
-fi
-PR_METADATA_COUNT=$(jq 'length' <<<"$ALL_PR_JSON")
-if [ "$PR_METADATA_COUNT" -ge "$PR_METADATA_LIMIT" ]; then
-  echo "GitHub PR metadata reached the ${PR_METADATA_LIMIT}-PR safety limit; no worktrees were changed" >&2
   exit 1
 fi
 
@@ -201,42 +200,55 @@ warn_process_cwd_scan_unavailable() {
   fi
 }
 
-worktree_in_use() {
-  local path="$1"
-  local canonical_path process_cwd cwd_link
-  canonical_path=$(canonical_directory "$path") || return 0
-
+refresh_process_cwd_snapshot() {
+  local process_cwd cwd_link lsof_output
+  PROCESS_CWD_SNAPSHOT=()
+  PROCESS_CWD_SNAPSHOT_READY=1
+  PROCESS_CWD_SNAPSHOT_TRUSTED=0
   if [ -d "$PROCESS_CWD_PROC_ROOT" ] \
      && readlink "$PROCESS_CWD_PROC_ROOT/self/cwd" >/dev/null 2>&1; then
     for cwd_link in "$PROCESS_CWD_PROC_ROOT"/[0-9]*/cwd; do
       process_cwd=$(readlink "$cwd_link" 2>/dev/null) || continue
       process_cwd="${process_cwd% (deleted)}"
-      if path_contains "$canonical_path" "$process_cwd"; then
-        return 0
-      fi
+      PROCESS_CWD_SNAPSHOT+=("$process_cwd")
     done
-    return 1
+    PROCESS_CWD_SNAPSHOT_TRUSTED=1
+    return 0
   fi
 
   if command -v lsof >/dev/null 2>&1; then
-    local lsof_output
     if ! lsof_output=$(lsof -a -d cwd -Fn 2>/dev/null); then
       warn_process_cwd_scan_unavailable
-      return 0
+      return 1
     fi
     while IFS= read -r process_cwd; do
       [[ "$process_cwd" == n* ]] || continue
       process_cwd="${process_cwd#n}"
       process_cwd="${process_cwd% (deleted)}"
-      if path_contains "$canonical_path" "$process_cwd"; then
-        return 0
-      fi
+      PROCESS_CWD_SNAPSHOT+=("$process_cwd")
     done <<<"$lsof_output"
-    return 1
+    PROCESS_CWD_SNAPSHOT_TRUSTED=1
+    return 0
   fi
 
   warn_process_cwd_scan_unavailable
-  return 0
+  return 1
+}
+
+worktree_in_use() {
+  local path="$1"
+  local canonical_path process_cwd
+  canonical_path=$(canonical_directory "$path") || return 0
+  if [ "$PROCESS_CWD_SNAPSHOT_READY" -eq 0 ]; then
+    refresh_process_cwd_snapshot || return 0
+  fi
+  [ "$PROCESS_CWD_SNAPSHOT_TRUSTED" -eq 1 ] || return 0
+  for process_cwd in "${PROCESS_CWD_SNAPSHOT[@]}"; do
+    if path_contains "$canonical_path" "$process_cwd"; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 # Returns 0 if HEAD at $1 has no content beyond UPSTREAM_MAIN — either it's an
@@ -578,8 +590,8 @@ for i in "${!TO_REMOVE_PATHS[@]}"; do
   # Every candidate is revalidated. This is deliberately redundant with the
   # scan because a process, edit, commit, or checkout can happen while GitHub
   # metadata is being inspected.
-  if worktree_in_use "$path" || worktree_locked "$path"; then
-    printf "  %s!%s skipped %s (worktree is in use or locked)\n" \
+  if worktree_locked "$path"; then
+    printf "  %s!%s skipped %s (worktree is locked)\n" \
       "$C_YELLOW" "$C_RESET" "$path"
     skipped_during_apply=$((skipped_during_apply + 1))
     continue
@@ -616,7 +628,8 @@ for i in "${!TO_REMOVE_PATHS[@]}"; do
   if [ "$branch_action" = "recover-detached" ]; then
     recovery_path=$(canonical_directory "$path" || printf '%s' "$path")
     recovery_path_hash=$(printf '%s' "$recovery_path" | git_root hash-object --stdin)
-    recovery_slug=$(basename "$path" | tr -cs 'A-Za-z0-9._-' '-')
+    recovery_slug_source="$(basename "$path")-$(basename "$(dirname "$path")")"
+    recovery_slug=$(printf '%s' "$recovery_slug_source" | tr -cs 'A-Za-z0-9._-' '-')
     recovery_slug="${recovery_slug#-}"
     recovery_slug="${recovery_slug%-}"
     recovery_base="recovery/worktree-${recovery_slug:-detached}-${recovery_path_hash:0:10}-${current_head:0:12}"
@@ -647,6 +660,9 @@ for i in "${!TO_REMOVE_PATHS[@]}"; do
   final_head=$(git -C "$path" rev-parse HEAD 2>/dev/null || echo "")
   final_branch=$(git -C "$path" symbolic-ref --quiet --short HEAD 2>/dev/null || echo "")
   final_inactivity=$(worktree_inactivity_seconds "$path" || echo 0)
+  if ! refresh_process_cwd_snapshot; then
+    : # An untrusted snapshot makes worktree_in_use fail closed below.
+  fi
   if worktree_in_use "$path" || worktree_locked "$path" || ! worktree_clean "$path" \
      || [ "$final_head" != "$expected_head" ] || [ "$final_branch" != "$branch" ] \
      || [ "$final_inactivity" -lt "$minimum_inactivity" ]; then

--- a/scripts/cleanup-merged-worktrees.sh
+++ b/scripts/cleanup-merged-worktrees.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 #
 # Cleanup inactive git worktrees that have no uncommitted work to preserve.
-#
-# Eligible worktrees either have a merged PR, or have an open PR whose head is
-# exactly in sync with a local HEAD commit that is at least 48 hours old.
+# Local branches are retained unless a merged worktree is fully represented in
+# upstream main. Detached work with unique commits gets a recovery branch.
+# Ignored dependency/build artifacts are treated as disposable worktree data.
 #
 # Usage:
 #   ./cleanup-merged-worktrees.sh           # dry-run: show what would be removed
-#   ./cleanup-merged-worktrees.sh --apply   # remove worktrees; preserve open-PR branches
+#   ./cleanup-merged-worktrees.sh --apply   # remove worktrees; preserve recovery refs
 
 set -euo pipefail
 
@@ -36,6 +36,11 @@ if ! gh auth status >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v jq >/dev/null; then
+  echo "jq not found in PATH" >&2
+  exit 1
+fi
+
 # Skip the worktree we were invoked from, just in case it shows up in the list.
 INVOCATION_PWD="${PWD_AT_INVOCATION:-$PWD}"
 
@@ -57,6 +62,36 @@ fi
 
 git_root() { git "${GIT_REPO_ARGS[@]}" "$@"; }
 
+github_repository_from_origin() {
+  local origin_url remote_host remote_path without_scheme
+  origin_url=$(git_root remote get-url origin 2>/dev/null) || return 1
+  case "$origin_url" in
+    git@*:*)
+      remote_host="${origin_url#git@}"
+      remote_host="${remote_host%%:*}"
+      remote_path="${origin_url#*:}"
+      ;;
+    ssh://git@*/*)
+      without_scheme="${origin_url#ssh://git@}"
+      remote_host="${without_scheme%%/*}"
+      remote_path="${without_scheme#*/}"
+      ;;
+    http://*|https://*)
+      without_scheme="${origin_url#*://}"
+      remote_host="${without_scheme%%/*}"
+      remote_path="${without_scheme#*/}"
+      ;;
+    *) return 1 ;;
+  esac
+  remote_path="${remote_path%.git}"
+  [ -n "$remote_host" ] && [ -n "$remote_path" ] || return 1
+  if [ "$remote_host" = "github.com" ]; then
+    printf '%s\n' "$remote_path"
+  else
+    printf '%s/%s\n' "$remote_host" "$remote_path"
+  fi
+}
+
 # Colors (only when stdout is a TTY).
 if [ -t 1 ]; then
   C_RED=$'\033[0;31m'; C_GREEN=$'\033[0;32m'; C_YELLOW=$'\033[0;33m'
@@ -67,9 +102,9 @@ fi
 
 declare -a TO_REMOVE_PATHS=()
 declare -a TO_REMOVE_BRANCHES=()
-# Non-empty only for open-PR candidates. The OID is used for apply-time
-# revalidation and also marks the associated local branch for preservation.
 declare -a TO_REMOVE_EXPECTED_HEADS=()
+declare -a TO_REMOVE_BRANCH_ACTIONS=()
+declare -a TO_REMOVE_MIN_INACTIVE_SECONDS=()
 
 skipped_no_branch=0
 skipped_no_pr=0
@@ -78,23 +113,47 @@ skipped_dirty=0
 skipped_unmerged_commits=0
 skipped_too_fresh=0
 skipped_main=0
+skipped_in_use=0
+skipped_locked=0
 
-# Branches with no PR but no extra content vs main need to be at least this old
-# (HEAD commit timestamp) before we'll remove them. 7 days = 604800 seconds.
-NO_PR_MIN_AGE_SECONDS=$((7 * 24 * 60 * 60))
+# Every removal has an inactivity floor. Agent worktrees are intentionally
+# shorter-lived because a live process CWD is checked both during the scan and
+# immediately before removal.
+MERGED_MIN_INACTIVE_SECONDS=$((24 * 60 * 60))
+OPEN_PR_MIN_INACTIVE_SECONDS=$((48 * 60 * 60))
+NO_PR_MIN_INACTIVE_SECONDS=$((7 * 24 * 60 * 60))
+AGENT_MIN_INACTIVE_SECONDS=$((48 * 60 * 60))
 
-# Open PR worktrees are eligible only when their local HEAD exactly matches the
-# PR head and the shared commit has been inactive for at least 48 hours.
-OPEN_PR_MIN_AGE_SECONDS=$((48 * 60 * 60))
-
-# Resolve the upstream main reference (origin/main, or origin/master as fallback).
-# Used to check whether a branch with no PR has any content not already in main.
-git_root fetch --quiet origin main 2>/dev/null || git_root fetch --quiet origin master 2>/dev/null || true
+# Resolve a freshly fetched upstream main reference. A stale remote-tracking ref
+# is never used to justify deleting a branch or omitting detached recovery.
 UPSTREAM_MAIN=""
-if git_root rev-parse --verify --quiet refs/remotes/origin/main >/dev/null; then
+if git_root fetch --quiet origin main 2>/dev/null \
+   && git_root rev-parse --verify --quiet refs/remotes/origin/main >/dev/null; then
   UPSTREAM_MAIN="origin/main"
-elif git_root rev-parse --verify --quiet refs/remotes/origin/master >/dev/null; then
+elif git_root fetch --quiet origin master 2>/dev/null \
+     && git_root rev-parse --verify --quiet refs/remotes/origin/master >/dev/null; then
   UPSTREAM_MAIN="origin/master"
+else
+  echo "Warning: upstream main could not be refreshed; all local refs will be preserved" >&2
+fi
+
+# Fetch PR metadata once. Per-worktree `gh pr list --head` calls make cleanup of
+# large agent-worktree collections unnecessarily slow.
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY_OVERRIDE:-}"
+if [ -z "$GITHUB_REPOSITORY" ]; then
+  GITHUB_REPOSITORY=$(github_repository_from_origin) || {
+    echo "Could not derive a GitHub repository from the selected repo's origin" >&2
+    exit 1
+  }
+fi
+if ! ALL_PR_JSON=$(gh pr list --repo "$GITHUB_REPOSITORY" --state all --limit 10000 \
+  --json number,state,createdAt,mergedAt,url,headRefName,headRefOid,mergeCommit,isCrossRepository); then
+  echo "Could not load GitHub PR metadata; no worktrees were changed" >&2
+  exit 1
+fi
+if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$ALL_PR_JSON"; then
+  echo "GitHub PR metadata was not a valid JSON array; no worktrees were changed" >&2
+  exit 1
 fi
 
 # Returns 0 (true) if the working tree at $1 is clean.
@@ -104,6 +163,64 @@ worktree_clean() {
   [ -z "$dirty" ]
 }
 
+# Returns 0 when Git has explicitly locked this worktree. Treat a failure to
+# resolve its administrative lock path as locked so cleanup fails closed.
+worktree_locked() {
+  local path="$1"
+  local lock_path
+  lock_path=$(git -C "$path" rev-parse --path-format=absolute --git-path locked 2>/dev/null) || return 0
+  [ -e "$lock_path" ]
+}
+
+canonical_directory() {
+  (cd "$1" 2>/dev/null && pwd -P)
+}
+
+# Returns 0 when $2 is $1 or is nested below it.
+path_contains() {
+  local root_path="$1"
+  local possible_child="$2"
+  [ "$possible_child" = "$root_path" ] || [[ "$possible_child" == "$root_path"/* ]]
+}
+
+# Returns 0 if any live process has its CWD at or below this worktree. On
+# systems without /proc, use lsof. If neither mechanism is available, fail
+# closed and report the worktree as in use.
+worktree_in_use() {
+  local path="$1"
+  local canonical_path process_cwd cwd_link
+  canonical_path=$(canonical_directory "$path") || return 0
+
+  if [ -d /proc ]; then
+    readlink /proc/self/cwd >/dev/null 2>&1 || return 0
+    for cwd_link in /proc/[0-9]*/cwd; do
+      process_cwd=$(readlink "$cwd_link" 2>/dev/null) || continue
+      process_cwd="${process_cwd% (deleted)}"
+      if path_contains "$canonical_path" "$process_cwd"; then
+        return 0
+      fi
+    done
+    return 1
+  fi
+
+  if command -v lsof >/dev/null 2>&1; then
+    local lsof_output
+    if ! lsof_output=$(lsof -a -d cwd -Fn 2>/dev/null); then
+      return 0
+    fi
+    while IFS= read -r process_cwd; do
+      process_cwd="${process_cwd#n}"
+      process_cwd="${process_cwd% (deleted)}"
+      if path_contains "$canonical_path" "$process_cwd"; then
+        return 0
+      fi
+    done <<<"$lsof_output"
+    return 1
+  fi
+
+  return 0
+}
+
 # Returns 0 if HEAD at $1 has no content beyond UPSTREAM_MAIN — either it's an
 # ancestor of main, or the trees are identical (squash/rebase scenario).
 content_matches_main() {
@@ -111,33 +228,113 @@ content_matches_main() {
   [ -z "$UPSTREAM_MAIN" ] && return 1
   local local_oid
   local_oid=$(git -C "$path" rev-parse HEAD 2>/dev/null) || return 1
+  content_oid_matches_main "$local_oid"
+}
+
+content_oid_matches_main() {
+  local local_oid="$1"
+  [ -z "$UPSTREAM_MAIN" ] && return 1
   if git_root merge-base --is-ancestor "$local_oid" "$UPSTREAM_MAIN" 2>/dev/null; then
     return 0
   fi
-  git -C "$path" diff --quiet "$UPSTREAM_MAIN" HEAD 2>/dev/null
+  git_root diff --no-ext-diff --quiet "$UPSTREAM_MAIN" "$local_oid" 2>/dev/null
 }
 
-# Echoes the age in seconds of HEAD at $1 (commit timestamp vs. now).
-head_age_seconds() {
+oid_reachable_from_main() {
+  local local_oid="$1"
+  [ -n "$UPSTREAM_MAIN" ] \
+    && git_root merge-base --is-ancestor "$local_oid" "$UPSTREAM_MAIN" 2>/dev/null
+}
+
+# Echoes the number of seconds since this worktree's administrative HEAD or
+# attached branch ref was touched. Worktree-prune operations can rewrite every
+# HEAD reflog at once, so reflog mtimes are not an activity signal.
+worktree_inactivity_seconds() {
   local path="$1"
-  local commit_ts now_ts
+  local head_path branch_ref branch_ref_path latest_ts file_ts commit_ts now_ts activity_path
+  head_path=$(git -C "$path" rev-parse --path-format=absolute --git-path HEAD 2>/dev/null || echo "")
+  branch_ref=$(git -C "$path" symbolic-ref --quiet HEAD 2>/dev/null || echo "")
+  branch_ref_path=""
+  if [ -n "$branch_ref" ]; then
+    branch_ref_path=$(git -C "$path" rev-parse --path-format=absolute --git-path "$branch_ref" 2>/dev/null || echo "")
+  fi
+  latest_ts=0
+  for activity_path in "$head_path" "$branch_ref_path"; do
+    [ -f "$activity_path" ] || continue
+    file_ts=$(stat -c %Y "$activity_path" 2>/dev/null || stat -f %m "$activity_path" 2>/dev/null || echo 0)
+    if [ "$file_ts" -gt "$latest_ts" ]; then
+      latest_ts="$file_ts"
+    fi
+  done
   commit_ts=$(git -C "$path" log -1 --format=%ct HEAD 2>/dev/null) || return 1
+  if [ "$commit_ts" -gt "$latest_ts" ]; then
+    latest_ts="$commit_ts"
+  fi
   now_ts=$(date +%s)
-  echo $((now_ts - commit_ts))
+  echo $((now_ts - latest_ts))
+}
+
+minimum_inactivity_seconds() {
+  local path="$1"
+  local pr_state="$2"
+  if [[ "$path" == */.claude/worktrees/* ]]; then
+    echo "$AGENT_MIN_INACTIVE_SECONDS"
+  elif [ "$pr_state" = "MERGED" ]; then
+    echo "$MERGED_MIN_INACTIVE_SECONDS"
+  elif [ "$pr_state" = "OPEN" ]; then
+    echo "$OPEN_PR_MIN_INACTIVE_SECONDS"
+  else
+    echo "$NO_PR_MIN_INACTIVE_SECONDS"
+  fi
+}
+
+format_inactivity() {
+  local inactivity="$1"
+  if [ "$inactivity" -ge 86400 ] || [ "$inactivity" -le -86400 ]; then
+    echo "$((inactivity / 86400))d"
+  else
+    echo "$((inactivity / 3600))h"
+  fi
+}
+
+queue_removal() {
+  local path="$1"
+  local branch="$2"
+  local branch_action="$3"
+  local minimum_inactivity="$4"
+  local reason="$5"
+  local expected_head="${6:-}"
+  if [ -z "$expected_head" ]; then
+    expected_head=$(git -C "$path" rev-parse HEAD 2>/dev/null || echo "")
+  fi
+  if [ -z "$expected_head" ]; then
+    printf "%s» skip%s %s %s(failed to read HEAD)%s\n" \
+      "$C_RED" "$C_RESET" "$path" "$C_RED" "$C_RESET"
+    return
+  fi
+  TO_REMOVE_PATHS+=("$path")
+  TO_REMOVE_BRANCHES+=("$branch")
+  TO_REMOVE_EXPECTED_HEADS+=("$expected_head")
+  TO_REMOVE_BRANCH_ACTIONS+=("$branch_action")
+  TO_REMOVE_MIN_INACTIVE_SECONDS+=("$minimum_inactivity")
+  printf "%s✓ remove%s %s%s %s(%s)%s\n" \
+    "$C_GREEN" "$C_RESET" "$path" "${branch:+ [$branch]}" "$C_DIM" "$reason" "$C_RESET"
 }
 
 # Parse `git worktree list --porcelain` into (path, branch) pairs.
 current_path=""
 current_branch=""
+current_bare=0
 
 flush_entry() {
   local path="$1"
   local branch="$2"
+  local is_bare="${3:-0}"
 
   [ -z "$path" ] && return
 
   # The bare repo has no working tree — nothing to inspect, just skip.
-  if [ "$(basename "$path")" = ".bare" ]; then
+  if [ "$is_bare" = 1 ] || [ "$(basename "$path")" = ".bare" ]; then
     skipped_no_branch=$((skipped_no_branch + 1))
     printf "%s» skip%s %s %s(bare repo)%s\n" "$C_DIM" "$C_RESET" "$path" "$C_DIM" "$C_RESET"
     return
@@ -152,163 +349,16 @@ flush_entry() {
     return
   fi
 
-  # Skip the worktree we were invoked from.
-  if [ "$path" = "$INVOCATION_PWD" ]; then
+  # Skip the worktree we were invoked from, including invocation from one of
+  # its subdirectories.
+  local canonical_path canonical_invocation
+  canonical_path=$(canonical_directory "$path" || echo "$path")
+  canonical_invocation=$(canonical_directory "$INVOCATION_PWD" || echo "$INVOCATION_PWD")
+  if path_contains "$canonical_path" "$canonical_invocation"; then
     printf "%s» skip%s %s %s(current worktree)%s\n" "$C_DIM" "$C_RESET" "$path" "$C_DIM" "$C_RESET"
     return
   fi
 
-  # Detached HEAD: no branch to query, no PR to look up. Eligible only if the
-  # tree matches main, the working dir is clean, and the HEAD commit is at
-  # least NO_PR_MIN_AGE_SECONDS old.
-  if [ -z "$branch" ]; then
-    if ! worktree_clean "$path"; then
-      skipped_dirty=$((skipped_dirty + 1))
-      printf "%s» keep%s %s %s(detached; uncommitted changes)%s\n" \
-        "$C_YELLOW" "$C_RESET" "$path" "$C_YELLOW" "$C_RESET"
-      return
-    fi
-    if ! content_matches_main "$path"; then
-      skipped_no_branch=$((skipped_no_branch + 1))
-      printf "%s» keep%s %s %s(detached; has content not in %s)%s\n" \
-        "$C_YELLOW" "$C_RESET" "$path" "$C_YELLOW" "$UPSTREAM_MAIN" "$C_RESET"
-      return
-    fi
-    local age
-    age=$(head_age_seconds "$path") || age=0
-    if [ "$age" -lt "$NO_PR_MIN_AGE_SECONDS" ]; then
-      skipped_too_fresh=$((skipped_too_fresh + 1))
-      printf "%s» keep%s %s %s(detached; tree matches %s but HEAD is %s old)%s\n" \
-        "$C_YELLOW" "$C_RESET" "$path" "$C_YELLOW" "$UPSTREAM_MAIN" \
-        "$((age / 86400))d" "$C_RESET"
-      return
-    fi
-    TO_REMOVE_PATHS+=("$path")
-    TO_REMOVE_BRANCHES+=("")
-    TO_REMOVE_EXPECTED_HEADS+=("")
-    printf "%s✓ remove%s %s %s(detached; tree matches %s, HEAD %s old)%s\n" \
-      "$C_GREEN" "$C_RESET" "$path" "$C_DIM" "$UPSTREAM_MAIN" \
-      "$((age / 86400))d" "$C_RESET"
-    return
-  fi
-
-  # Look up PR(s) for this branch. An OPEN PR takes precedence over a
-  # historical MERGED PR because branch names can be reused.
-  local pr_json
-  pr_json=$(gh pr list --head "$branch" --state all \
-    --json number,state,mergedAt,url,headRefOid,mergeCommit 2>/dev/null || echo "[]")
-
-  local merged_pr open_pr
-  merged_pr=$(echo "$pr_json" | jq -r '[.[] | select(.state == "MERGED")] | first // empty')
-  open_pr=$(echo "$pr_json" | jq -r '[.[] | select(.state == "OPEN")] | first // empty')
-
-  if [ -z "$merged_pr" ] && [ -z "$open_pr" ]; then
-    # No PR found by branch name. Fall back to checking whether the branch has
-    # any content not already in origin/main — branches often get renamed
-    # locally (e.g. `pr-1487` tracking `claude/test-create-climb-form-Dry5Q`)
-    # so the head-name lookup misses real merges. The content check catches
-    # both squash/rebase merges and renamed-but-merged cases. We additionally
-    # require the HEAD commit to be at least NO_PR_MIN_AGE_SECONDS old, since
-    # without a PR signal the only confirmation that work is "done" is age.
-    if [ -z "$UPSTREAM_MAIN" ]; then
-      skipped_no_pr=$((skipped_no_pr + 1))
-      printf "%s» skip%s %s [%s] %s(no PR found, no upstream main to compare)%s\n" \
-        "$C_DIM" "$C_RESET" "$path" "$branch" "$C_DIM" "$C_RESET"
-      return
-    fi
-
-    if ! worktree_clean "$path"; then
-      skipped_dirty=$((skipped_dirty + 1))
-      local dirty file_count
-      dirty=$(git -C "$path" status --porcelain 2>/dev/null)
-      file_count=$(echo "$dirty" | wc -l | tr -d ' ')
-      printf "%s» keep%s %s [%s] %s(no PR; %s uncommitted file(s))%s\n" \
-        "$C_YELLOW" "$C_RESET" "$path" "$branch" "$C_YELLOW" "$file_count" "$C_RESET"
-      return
-    fi
-
-    if ! content_matches_main "$path"; then
-      local ahead_count
-      ahead_count=$(git -C "$path" rev-list --count "${UPSTREAM_MAIN}..HEAD" 2>/dev/null || echo "?")
-      skipped_no_pr=$((skipped_no_pr + 1))
-      printf "%s» keep%s %s [%s] %s(no PR; has content not in %s, %s commit(s) ahead)%s\n" \
-        "$C_YELLOW" "$C_RESET" "$path" "$branch" "$C_YELLOW" "$UPSTREAM_MAIN" "$ahead_count" "$C_RESET"
-      return
-    fi
-
-    local age
-    age=$(head_age_seconds "$path") || age=0
-    if [ "$age" -lt "$NO_PR_MIN_AGE_SECONDS" ]; then
-      skipped_too_fresh=$((skipped_too_fresh + 1))
-      printf "%s» keep%s %s [%s] %s(no PR; tree matches %s but HEAD is %s old)%s\n" \
-        "$C_YELLOW" "$C_RESET" "$path" "$branch" "$C_YELLOW" "$UPSTREAM_MAIN" \
-        "$((age / 86400))d" "$C_RESET"
-      return
-    fi
-
-    TO_REMOVE_PATHS+=("$path")
-    TO_REMOVE_BRANCHES+=("$branch")
-    TO_REMOVE_EXPECTED_HEADS+=("")
-    printf "%s✓ remove%s %s [%s] %s(no PR; tree matches %s, HEAD %s old)%s\n" \
-      "$C_GREEN" "$C_RESET" "$path" "$branch" "$C_DIM" "$UPSTREAM_MAIN" \
-      "$((age / 86400))d" "$C_RESET"
-    return
-  fi
-
-  if [ -n "$open_pr" ]; then
-    local pr_num pr_url pr_head_oid local_oid dirty age
-    pr_num=$(echo "$open_pr" | jq -r '.number')
-    pr_url=$(echo "$open_pr" | jq -r '.url')
-    pr_head_oid=$(echo "$open_pr" | jq -r '.headRefOid // empty')
-
-    if ! dirty=$(git -C "$path" status --porcelain 2>/dev/null); then
-      skipped_open_pr=$((skipped_open_pr + 1))
-      printf "%s» skip%s %s [%s] %s(PR #%s OPEN; failed to read status)%s\n" \
-        "$C_RED" "$C_RESET" "$path" "$branch" "$C_RED" "$pr_num" "$C_RESET"
-      return
-    fi
-
-    if [ -n "$dirty" ]; then
-      skipped_dirty=$((skipped_dirty + 1))
-      local file_count
-      file_count=$(echo "$dirty" | wc -l | tr -d ' ')
-      printf "%s» keep%s %s [%s] %s(PR #%s OPEN, but %s uncommitted file(s))%s\n" \
-        "$C_YELLOW" "$C_RESET" "$path" "$branch" "$C_YELLOW" "$pr_num" "$file_count" "$C_RESET"
-      return
-    fi
-
-    local_oid=$(git -C "$path" rev-parse HEAD 2>/dev/null || echo "")
-    if [ -z "$pr_head_oid" ] || [ -z "$local_oid" ] || [ "$local_oid" != "$pr_head_oid" ]; then
-      skipped_open_pr=$((skipped_open_pr + 1))
-      printf "%s» keep%s %s [%s] %s(PR #%s OPEN, but local HEAD is not in sync with PR head: %s)%s\n" \
-        "$C_YELLOW" "$C_RESET" "$path" "$branch" "$C_YELLOW" "$pr_num" "$pr_url" "$C_RESET"
-      return
-    fi
-
-    age=$(head_age_seconds "$path") || age=0
-    if [ "$age" -lt "$OPEN_PR_MIN_AGE_SECONDS" ]; then
-      skipped_too_fresh=$((skipped_too_fresh + 1))
-      printf "%s» keep%s %s [%s] %s(PR #%s OPEN and in sync, but HEAD is %sh old)%s\n" \
-        "$C_YELLOW" "$C_RESET" "$path" "$branch" "$C_YELLOW" "$pr_num" \
-        "$((age / 3600))" "$C_RESET"
-      return
-    fi
-
-    TO_REMOVE_PATHS+=("$path")
-    TO_REMOVE_BRANCHES+=("$branch")
-    TO_REMOVE_EXPECTED_HEADS+=("$local_oid")
-    printf "%s✓ remove%s %s [%s] %s(PR #%s OPEN and in sync, HEAD %sh old)%s\n" \
-      "$C_GREEN" "$C_RESET" "$path" "$branch" "$C_DIM" "$pr_num" \
-      "$((age / 3600))" "$C_RESET"
-    return
-  fi
-
-  local pr_num pr_url pr_head_oid
-  pr_num=$(echo "$merged_pr" | jq -r '.number')
-  pr_url=$(echo "$merged_pr" | jq -r '.url')
-  pr_head_oid=$(echo "$merged_pr" | jq -r '.headRefOid // empty')
-
-  # Check for any uncommitted changes (staged, unstaged, or untracked).
   local dirty
   if ! dirty=$(git -C "$path" status --porcelain 2>/dev/null); then
     printf "%s» skip%s %s %s(failed to read status)%s\n" \
@@ -316,61 +366,158 @@ flush_entry() {
     return
   fi
 
+  if worktree_in_use "$path"; then
+    skipped_in_use=$((skipped_in_use + 1))
+    printf "%s» keep%s %s %s(a live process has its CWD in this worktree)%s\n" \
+      "$C_YELLOW" "$C_RESET" "$path" "$C_YELLOW" "$C_RESET"
+    return
+  fi
+  if worktree_locked "$path"; then
+    skipped_locked=$((skipped_locked + 1))
+    printf "%s» keep%s %s %s(worktree is locked)%s\n" \
+      "$C_YELLOW" "$C_RESET" "$path" "$C_YELLOW" "$C_RESET"
+    return
+  fi
   if [ -n "$dirty" ]; then
     skipped_dirty=$((skipped_dirty + 1))
     local file_count
     file_count=$(echo "$dirty" | wc -l | tr -d ' ')
-    printf "%s» keep%s %s [%s] %s(PR #%s merged, but %s uncommitted file(s))%s\n" \
-      "$C_YELLOW" "$C_RESET" "$path" "$branch" "$C_YELLOW" "$pr_num" "$file_count" "$C_RESET"
+    printf "%s» keep%s %s%s %s(%s uncommitted file(s))%s\n" \
+      "$C_YELLOW" "$C_RESET" "$path" "${branch:+ [$branch]}" \
+      "$C_YELLOW" "$file_count" "$C_RESET"
     return
   fi
 
-  # Check the local branch tip against the PR's head commit. If the local tip is
-  # *ahead* of the PR head, there are local commits that were never part of the
-  # merged PR — refuse to drop them. If they match, or the local tip is behind,
-  # the branch carries no extra work and is safe to remove.
-  if [ -n "$pr_head_oid" ]; then
-    local local_oid
-    local_oid=$(git -C "$path" rev-parse HEAD 2>/dev/null || echo "")
-    if [ -n "$local_oid" ] && [ "$local_oid" != "$pr_head_oid" ]; then
-      # Is the PR head an ancestor of the local tip? If so, local has extra commits.
-      if git_root merge-base --is-ancestor "$pr_head_oid" "$local_oid" 2>/dev/null; then
-        skipped_unmerged_commits=$((skipped_unmerged_commits + 1))
-        local extra_count
-        extra_count=$(git_root rev-list --count "${pr_head_oid}..${local_oid}" 2>/dev/null || echo "?")
-        printf "%s» keep%s %s [%s] %s(PR #%s merged, but %s local commit(s) ahead of PR head)%s\n" \
-          "$C_YELLOW" "$C_RESET" "$path" "$branch" "$C_YELLOW" "$pr_num" "$extra_count" "$C_RESET"
-        return
-      fi
-      # Otherwise the local tip diverges from the PR head in some other way
-      # (different history, e.g. force-pushed or rebased). Be conservative.
-      if ! git_root merge-base --is-ancestor "$local_oid" "$pr_head_oid" 2>/dev/null; then
-        skipped_unmerged_commits=$((skipped_unmerged_commits + 1))
-        printf "%s» keep%s %s [%s] %s(PR #%s merged, but local tip %s diverges from PR head %s)%s\n" \
-          "$C_YELLOW" "$C_RESET" "$path" "$branch" "$C_YELLOW" "$pr_num" \
-          "${local_oid:0:8}" "${pr_head_oid:0:8}" "$C_RESET"
-        return
-      fi
+  # A stale detached worktree is removable even when it has unique content:
+  # apply mode creates a recovery branch before removing it.
+  if [ -z "$branch" ]; then
+    local minimum_inactivity inactivity inactivity_label branch_action reason
+    minimum_inactivity=$(minimum_inactivity_seconds "$path" "NONE")
+    inactivity=$(worktree_inactivity_seconds "$path") || inactivity=0
+    inactivity_label=$(format_inactivity "$inactivity")
+    if [ "$inactivity" -lt "$minimum_inactivity" ]; then
+      skipped_too_fresh=$((skipped_too_fresh + 1))
+      printf "%s» keep%s %s %s(detached; inactive for %s, minimum is %s)%s\n" \
+        "$C_YELLOW" "$C_RESET" "$path" "$C_YELLOW" "$inactivity_label" \
+        "$(format_inactivity "$minimum_inactivity")" "$C_RESET"
+      return
     fi
+    local detached_oid
+    detached_oid=$(git -C "$path" rev-parse HEAD 2>/dev/null || echo "")
+    if oid_reachable_from_main "$detached_oid"; then
+      branch_action="none"
+      reason="detached; commit is reachable from ${UPSTREAM_MAIN}; inactive ${inactivity_label}"
+    else
+      branch_action="recover-detached"
+      reason="detached; unique content will get a recovery branch; inactive ${inactivity_label}"
+    fi
+    queue_removal "$path" "" "$branch_action" "$minimum_inactivity" "$reason"
+    return
   fi
 
-  TO_REMOVE_PATHS+=("$path")
-  TO_REMOVE_BRANCHES+=("$branch")
-  TO_REMOVE_EXPECTED_HEADS+=("")
-  printf "%s✓ remove%s %s [%s] %s(PR #%s merged)%s\n" \
-    "$C_GREEN" "$C_RESET" "$path" "$branch" "$C_DIM" "$pr_num" "$C_RESET"
+  # Look up PR(s) for this branch. An OPEN PR takes precedence over a
+  # historical MERGED PR unless a PR head exactly matches this checkout. The
+  # OID match disambiguates reused branch names and same-named fork branches.
+  local pr_json local_oid
+  local_oid=$(git -C "$path" rev-parse HEAD 2>/dev/null || echo "")
+  pr_json=$(echo "$ALL_PR_JSON" | jq -c --arg branch "$branch" \
+    '[.[] | select(.headRefName == $branch)]')
+
+  local exact_head_pr open_pr latest_non_open_pr
+  exact_head_pr=$(echo "$pr_json" | jq -r --arg oid "$local_oid" \
+    '[.[] | select(.headRefOid == $oid)] | max_by(.createdAt) // empty')
+  open_pr=$(echo "$pr_json" | jq -r \
+    '[.[] | select(.state == "OPEN" and .isCrossRepository == false)] | max_by(.createdAt) // empty')
+  latest_non_open_pr=$(echo "$pr_json" | jq -r \
+    '[.[] | select((.state == "MERGED" or .state == "CLOSED") and .isCrossRepository == false)] | max_by(.createdAt) // empty')
+
+  local pr_state selected_pr
+  if [ -n "$exact_head_pr" ]; then
+    pr_state=$(echo "$exact_head_pr" | jq -r '.state')
+    selected_pr="$exact_head_pr"
+  elif [ -n "$open_pr" ]; then
+    pr_state="OPEN"
+    selected_pr="$open_pr"
+  elif [ -n "$latest_non_open_pr" ]; then
+    pr_state=$(echo "$latest_non_open_pr" | jq -r '.state')
+    selected_pr="$latest_non_open_pr"
+  else
+    pr_state="NONE"
+    selected_pr=""
+  fi
+
+  local minimum_inactivity inactivity inactivity_label
+  minimum_inactivity=$(minimum_inactivity_seconds "$path" "$pr_state")
+  inactivity=$(worktree_inactivity_seconds "$path") || inactivity=0
+  inactivity_label=$(format_inactivity "$inactivity")
+  if [ "$inactivity" -lt "$minimum_inactivity" ]; then
+    skipped_too_fresh=$((skipped_too_fresh + 1))
+    printf "%s» keep%s %s [%s] %s(%s; inactive for %s, minimum is %s)%s\n" \
+      "$C_YELLOW" "$C_RESET" "$path" "$branch" "$C_YELLOW" \
+      "${pr_state/NONE/no PR}" "$inactivity_label" \
+      "$(format_inactivity "$minimum_inactivity")" "$C_RESET"
+    return
+  fi
+
+  local pr_num pr_head_oid branch_action reason
+  branch_action="preserve"
+  case "$pr_state" in
+    NONE)
+      if content_matches_main "$path"; then
+        reason="no PR; content is in ${UPSTREAM_MAIN}; preserving branch; inactive ${inactivity_label}"
+      else
+        reason="no PR; unique content; preserving branch; inactive ${inactivity_label}"
+      fi
+      ;;
+    CLOSED)
+      pr_num=$(echo "$selected_pr" | jq -r '.number')
+      reason="PR #${pr_num} closed without merge; preserving branch; inactive ${inactivity_label}"
+      ;;
+    OPEN)
+      pr_num=$(echo "$selected_pr" | jq -r '.number')
+      pr_head_oid=$(echo "$selected_pr" | jq -r '.headRefOid // empty')
+      if [ -n "$pr_head_oid" ] && [ "$local_oid" = "$pr_head_oid" ]; then
+        reason="PR #${pr_num} OPEN and in sync; preserving branch; inactive ${inactivity_label}"
+      else
+        reason="PR #${pr_num} OPEN with a different local tip; preserving branch; inactive ${inactivity_label}"
+      fi
+      ;;
+    MERGED)
+      pr_num=$(echo "$selected_pr" | jq -r '.number')
+      pr_head_oid=$(echo "$selected_pr" | jq -r '.headRefOid // empty')
+      reason="PR #${pr_num} merged; inactive ${inactivity_label}"
+
+      # Deleting the local branch is only useful when both its history/content
+      # are already represented in main and it has not diverged from the PR.
+      # Claude agent branches are always retained because their worktrees are
+      # collected on the shorter inactivity schedule.
+      if [[ "$path" != */.claude/worktrees/* ]] \
+         && content_matches_main "$path" \
+         && { [ -z "$pr_head_oid" ] || [ "$local_oid" = "$pr_head_oid" ] \
+              || git_root merge-base --is-ancestor "$local_oid" "$pr_head_oid" 2>/dev/null; }; then
+        branch_action="delete"
+      else
+        reason="${reason}; preserving branch with unique or divergent content"
+      fi
+      ;;
+  esac
+
+  queue_removal "$path" "$branch" "$branch_action" "$minimum_inactivity" "$reason" "$local_oid"
 }
 
 while IFS= read -r line; do
   if [[ "$line" == worktree\ * ]]; then
-    flush_entry "$current_path" "$current_branch"
+    flush_entry "$current_path" "$current_branch" "$current_bare"
     current_path="${line#worktree }"
     current_branch=""
+    current_bare=0
   elif [[ "$line" == branch\ refs/heads/* ]]; then
     current_branch="${line#branch refs/heads/}"
+  elif [ "$line" = "bare" ]; then
+    current_bare=1
   fi
 done < <(git_root worktree list --porcelain)
-flush_entry "$current_path" "$current_branch"
+flush_entry "$current_path" "$current_branch" "$current_bare"
 
 echo
 echo "─────────────────────────────────────"
@@ -382,6 +529,8 @@ printf "Skipped — extra commits: %s%d%s\n" "$C_YELLOW" "$skipped_unmerged_comm
 printf "Skipped — too fresh:  %s%d%s\n" "$C_YELLOW" "$skipped_too_fresh" "$C_RESET"
 printf "Skipped — main:       %d\n" "$skipped_main"
 printf "Skipped — detached:   %d\n" "$skipped_no_branch"
+printf "Skipped — in use:      %s%d%s\n" "$C_YELLOW" "$skipped_in_use" "$C_RESET"
+printf "Skipped — locked:      %s%d%s\n" "$C_YELLOW" "$skipped_locked" "$C_RESET"
 echo "─────────────────────────────────────"
 
 if [ "${#TO_REMOVE_PATHS[@]}" -eq 0 ]; then
@@ -391,7 +540,7 @@ fi
 
 if [ "$APPLY" -eq 0 ]; then
   echo
-  printf "%sDry run.%s Re-run with %s--apply%s to remove eligible worktrees; open-PR branches are preserved.\n" \
+  printf "%sDry run.%s Re-run with %s--apply%s to remove eligible worktrees; recovery refs are preserved.\n" \
     "$C_BLUE" "$C_RESET" "$C_BLUE" "$C_RESET"
   exit 0
 fi
@@ -405,36 +554,101 @@ for i in "${!TO_REMOVE_PATHS[@]}"; do
   path="${TO_REMOVE_PATHS[$i]}"
   branch="${TO_REMOVE_BRANCHES[$i]}"
   expected_head="${TO_REMOVE_EXPECTED_HEADS[$i]}"
+  branch_action="${TO_REMOVE_BRANCH_ACTIONS[$i]}"
+  minimum_inactivity="${TO_REMOVE_MIN_INACTIVE_SECONDS[$i]}"
 
-  # Open-PR eligibility depends on the worktree still being clean and exactly
-  # at the PR head observed during the scan. Fail closed if anything changed
-  # before removal so a commit made during this run cannot be discarded.
-  if [ -n "$expected_head" ]; then
-    if ! worktree_clean "$path"; then
-      printf "  %s!%s skipped %s (worktree changed after eligibility scan)\n" \
-        "$C_YELLOW" "$C_RESET" "$path"
-      skipped_during_apply=$((skipped_during_apply + 1))
-      continue
+  # Every candidate is revalidated. This is deliberately redundant with the
+  # scan because a process, edit, commit, or checkout can happen while GitHub
+  # metadata is being inspected.
+  if worktree_in_use "$path" || worktree_locked "$path"; then
+    printf "  %s!%s skipped %s (worktree is in use or locked)\n" \
+      "$C_YELLOW" "$C_RESET" "$path"
+    skipped_during_apply=$((skipped_during_apply + 1))
+    continue
+  fi
+  if ! worktree_clean "$path"; then
+    printf "  %s!%s skipped %s (worktree changed after eligibility scan)\n" \
+      "$C_YELLOW" "$C_RESET" "$path"
+    skipped_during_apply=$((skipped_during_apply + 1))
+    continue
+  fi
+  current_head=$(git -C "$path" rev-parse HEAD 2>/dev/null || echo "")
+  if [ "$current_head" != "$expected_head" ]; then
+    printf "  %s!%s skipped %s (worktree changed after eligibility scan)\n" \
+      "$C_YELLOW" "$C_RESET" "$path"
+    skipped_during_apply=$((skipped_during_apply + 1))
+    continue
+  fi
+  current_branch=$(git -C "$path" symbolic-ref --quiet --short HEAD 2>/dev/null || echo "")
+  if [ "$current_branch" != "$branch" ]; then
+    printf "  %s!%s skipped %s (checkout changed after eligibility scan)\n" \
+      "$C_YELLOW" "$C_RESET" "$path"
+    skipped_during_apply=$((skipped_during_apply + 1))
+    continue
+  fi
+  current_inactivity=$(worktree_inactivity_seconds "$path" || echo 0)
+  if [ "$current_inactivity" -lt "$minimum_inactivity" ]; then
+    printf "  %s!%s skipped %s (worktree became active after eligibility scan)\n" \
+      "$C_YELLOW" "$C_RESET" "$path"
+    skipped_during_apply=$((skipped_during_apply + 1))
+    continue
+  fi
+
+  recovery_branch=""
+  if [ "$branch_action" = "recover-detached" ]; then
+    recovery_slug=$(basename "$path" | tr -cs 'A-Za-z0-9._-' '-')
+    recovery_slug="${recovery_slug#-}"
+    recovery_slug="${recovery_slug%-}"
+    recovery_base="recovery/worktree-${recovery_slug:-detached}-${current_head:0:12}"
+    recovery_branch="$recovery_base"
+    recovery_suffix=1
+    while git_root show-ref --verify --quiet "refs/heads/$recovery_branch"; do
+      recovery_oid=$(git_root rev-parse "refs/heads/$recovery_branch" 2>/dev/null || echo "")
+      if [ "$recovery_oid" = "$current_head" ]; then
+        break
+      fi
+      recovery_branch="${recovery_base}-${recovery_suffix}"
+      recovery_suffix=$((recovery_suffix + 1))
+    done
+    if ! git_root show-ref --verify --quiet "refs/heads/$recovery_branch"; then
+      if ! git_root branch "$recovery_branch" "$current_head"; then
+        printf "  %s!%s skipped %s (could not create detached recovery branch)\n" \
+          "$C_YELLOW" "$C_RESET" "$path"
+        skipped_during_apply=$((skipped_during_apply + 1))
+        continue
+      fi
     fi
-    current_head=$(git -C "$path" rev-parse HEAD 2>/dev/null || echo "")
-    if [ "$current_head" != "$expected_head" ]; then
-      printf "  %s!%s skipped %s (worktree changed after eligibility scan)\n" \
-        "$C_YELLOW" "$C_RESET" "$path"
-      skipped_during_apply=$((skipped_during_apply + 1))
-      continue
-    fi
+    printf "  %s✓%s preserved detached HEAD as %s\n" \
+      "$C_GREEN" "$C_RESET" "$recovery_branch"
+  fi
+
+  # Repeat every volatile check as close as possible to the destructive
+  # operation. The earlier revalidation can itself take time on a large repo.
+  final_head=$(git -C "$path" rev-parse HEAD 2>/dev/null || echo "")
+  final_branch=$(git -C "$path" symbolic-ref --quiet --short HEAD 2>/dev/null || echo "")
+  final_inactivity=$(worktree_inactivity_seconds "$path" || echo 0)
+  if worktree_in_use "$path" || worktree_locked "$path" || ! worktree_clean "$path" \
+     || [ "$final_head" != "$expected_head" ] || [ "$final_branch" != "$branch" ] \
+     || [ "$final_inactivity" -lt "$minimum_inactivity" ]; then
+    printf "  %s!%s skipped %s (worktree changed or became in use before removal)\n" \
+      "$C_YELLOW" "$C_RESET" "$path"
+    skipped_during_apply=$((skipped_during_apply + 1))
+    continue
   fi
 
   if git_root worktree remove "$path"; then
     printf "  %s✓%s removed worktree %s\n" "$C_GREEN" "$C_RESET" "$path"
     if [ -n "$branch" ]; then
-      if [ -n "$expected_head" ]; then
-        printf "  %s✓%s preserved local branch %s (PR remains open)\n" \
-          "$C_GREEN" "$C_RESET" "$branch"
-      elif git_root branch -D "$branch" >/dev/null 2>&1; then
+      branch_head=$(git_root rev-parse "refs/heads/$branch" 2>/dev/null || echo "")
+      if [ "$branch_action" = "delete" ] && [ "$branch_head" = "$expected_head" ] \
+         && content_oid_matches_main "$branch_head" \
+         && git_root branch -D "$branch" >/dev/null 2>&1; then
         printf "  %s✓%s deleted branch %s\n" "$C_GREEN" "$C_RESET" "$branch"
+      elif [ "$branch_action" = "delete" ]; then
+        printf "  %s!%s could not delete branch %s (worktree was removed; branch retained)\n" \
+          "$C_YELLOW" "$C_RESET" "$branch"
       else
-        printf "  %s!%s could not delete branch %s (may have unmerged commits)\n" "$C_YELLOW" "$C_RESET" "$branch"
+        printf "  %s✓%s preserved local branch %s\n" "$C_GREEN" "$C_RESET" "$branch"
       fi
     fi
     removed=$((removed + 1))
@@ -448,5 +662,3 @@ echo
 printf "Done. Removed: %s%d%s   Failed: %s%d%s   Skipped after scan: %s%d%s\n" \
   "$C_GREEN" "$removed" "$C_RESET" "$C_RED" "$failed" "$C_RESET" \
   "$C_YELLOW" "$skipped_during_apply" "$C_RESET"
-
-git_root worktree prune

--- a/scripts/cleanup-merged-worktrees.sh
+++ b/scripts/cleanup-merged-worktrees.sh
@@ -115,6 +115,8 @@ skipped_too_fresh=0
 skipped_main=0
 skipped_in_use=0
 skipped_locked=0
+PROCESS_CWD_WARNING_SHOWN=0
+PROCESS_CWD_PROC_ROOT="${WORKTREE_CWD_PROC_ROOT_OVERRIDE:-/proc}"
 
 # Every removal has an inactivity floor. Agent worktrees are intentionally
 # shorter-lived because a live process CWD is checked both during the scan and
@@ -146,13 +148,19 @@ if [ -z "$GITHUB_REPOSITORY" ]; then
     exit 1
   }
 fi
-if ! ALL_PR_JSON=$(gh pr list --repo "$GITHUB_REPOSITORY" --state all --limit 10000 \
+PR_METADATA_LIMIT=10000
+if ! ALL_PR_JSON=$(gh pr list --repo "$GITHUB_REPOSITORY" --state all --limit "$PR_METADATA_LIMIT" \
   --json number,state,createdAt,mergedAt,url,headRefName,headRefOid,mergeCommit,isCrossRepository); then
   echo "Could not load GitHub PR metadata; no worktrees were changed" >&2
   exit 1
 fi
 if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$ALL_PR_JSON"; then
   echo "GitHub PR metadata was not a valid JSON array; no worktrees were changed" >&2
+  exit 1
+fi
+PR_METADATA_COUNT=$(jq 'length' <<<"$ALL_PR_JSON")
+if [ "$PR_METADATA_COUNT" -ge "$PR_METADATA_LIMIT" ]; then
+  echo "GitHub PR metadata reached the ${PR_METADATA_LIMIT}-PR safety limit; no worktrees were changed" >&2
   exit 1
 fi
 
@@ -186,14 +194,21 @@ path_contains() {
 # Returns 0 if any live process has its CWD at or below this worktree. On
 # systems without /proc, use lsof. If neither mechanism is available, fail
 # closed and report the worktree as in use.
+warn_process_cwd_scan_unavailable() {
+  if [ "$PROCESS_CWD_WARNING_SHOWN" -eq 0 ]; then
+    echo "Warning: live process CWDs could not be enumerated; affected worktrees will be preserved" >&2
+    PROCESS_CWD_WARNING_SHOWN=1
+  fi
+}
+
 worktree_in_use() {
   local path="$1"
   local canonical_path process_cwd cwd_link
   canonical_path=$(canonical_directory "$path") || return 0
 
-  if [ -d /proc ]; then
-    readlink /proc/self/cwd >/dev/null 2>&1 || return 0
-    for cwd_link in /proc/[0-9]*/cwd; do
+  if [ -d "$PROCESS_CWD_PROC_ROOT" ] \
+     && readlink "$PROCESS_CWD_PROC_ROOT/self/cwd" >/dev/null 2>&1; then
+    for cwd_link in "$PROCESS_CWD_PROC_ROOT"/[0-9]*/cwd; do
       process_cwd=$(readlink "$cwd_link" 2>/dev/null) || continue
       process_cwd="${process_cwd% (deleted)}"
       if path_contains "$canonical_path" "$process_cwd"; then
@@ -206,9 +221,11 @@ worktree_in_use() {
   if command -v lsof >/dev/null 2>&1; then
     local lsof_output
     if ! lsof_output=$(lsof -a -d cwd -Fn 2>/dev/null); then
+      warn_process_cwd_scan_unavailable
       return 0
     fi
     while IFS= read -r process_cwd; do
+      [[ "$process_cwd" == n* ]] || continue
       process_cwd="${process_cwd#n}"
       process_cwd="${process_cwd% (deleted)}"
       if path_contains "$canonical_path" "$process_cwd"; then
@@ -218,6 +235,7 @@ worktree_in_use() {
     return 1
   fi
 
+  warn_process_cwd_scan_unavailable
   return 0
 }
 
@@ -596,10 +614,12 @@ for i in "${!TO_REMOVE_PATHS[@]}"; do
 
   recovery_branch=""
   if [ "$branch_action" = "recover-detached" ]; then
+    recovery_path=$(canonical_directory "$path" || printf '%s' "$path")
+    recovery_path_hash=$(printf '%s' "$recovery_path" | git_root hash-object --stdin)
     recovery_slug=$(basename "$path" | tr -cs 'A-Za-z0-9._-' '-')
     recovery_slug="${recovery_slug#-}"
     recovery_slug="${recovery_slug%-}"
-    recovery_base="recovery/worktree-${recovery_slug:-detached}-${current_head:0:12}"
+    recovery_base="recovery/worktree-${recovery_slug:-detached}-${recovery_path_hash:0:10}-${current_head:0:12}"
     recovery_branch="$recovery_base"
     recovery_suffix=1
     while git_root show-ref --verify --quiet "refs/heads/$recovery_branch"; do


### PR DESCRIPTION
## Summary

- Separate checkout removal from branch deletion so stale no-PR and divergent merged worktrees can be reclaimed without losing their refs.
- Protect live-process, locked, dirty, current, and recently active worktrees, with apply-time revalidation before each destructive step.
- Create recovery branches for unreachable detached heads and fail closed when upstream or GitHub metadata cannot be refreshed reliably.
- Batch and correctly scope PR metadata lookup, including branch reuse and cross-repository PR handling.

The old cleanup policy treated preserving a branch and preserving its checkout as the same decision. That retained dozens of abandoned directories while still lacking active-process and lock protection for otherwise eligible worktrees.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check scripts/cleanup-merged-worktrees.sh scripts/__tests__/cleanup-merged-worktrees.test.ts`
- `vp run typecheck`
- `vp test run --project scripts scripts/__tests__/cleanup-merged-worktrees.test.ts --reporter=agent` (22 tests)
- `bash -n scripts/cleanup-merged-worktrees.sh`
- Real repository dry run after cleanup: 0 eligible in 14 seconds; every remaining worktree protected as active, fresh, dirty/current, main, or bare.
- Real guarded apply: 101 stale clean worktrees removed with 0 failures; 28 dirty stale worktrees archived and checksum-verified before separate removal.
