### PR TITLE
fix(mobile): stop counting sign-in and board-connect cancels as failures

### DIFF
--- a/POSTHOG_INVENTORY.md
+++ b/POSTHOG_INVENTORY.md
@@ -153,12 +153,13 @@ Boardsesh has comprehensive PostHog instrumentation across both web (Next.js) an
 | Onboarding Tour Skipped       | onboarding-tour-provider.tsx:260                  | `skippedAtStep`, `durationSeconds`                         | User closed tour early             |
 | Favorite Toggle (via button)  | favorite-button.tsx:59,83                         | `climbUuid`, `isFavorited`                                 | Quick favorite button              |
 
-### 2.8 Bluetooth / Hardware (10 events)
+### 2.8 Bluetooth / Hardware (11 events)
 
 | Event Name                      | File:Line                              | Properties                                                        | Context                                             |
 | ------------------------------- | -------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------- |
 | Bluetooth Connection Success    | use-board-bluetooth.ts:390             | `boardLayout`                                                     | Device paired and connected                         |
 | Bluetooth Connection Failed     | use-board-bluetooth.ts:415             | `boardLayout`                                                     | BLE connection attempt failed                       |
+| Bluetooth Connection Cancelled  | use-board-bluetooth.ts:1406            | `boardName`, `layoutId`, `sizeId`                                 | Climber dismissed the device picker (not a failure) |
 | Bluetooth Disconnected          | use-board-bluetooth.ts:181,371,455,480 | `boardLayout`, `reason`                                           | Device lost connection                              |
 | Climb Sent to Board Success     | bluetooth-context.tsx:106              | `climbUuid`, `boardLayout`                                        | LED frames transmitted                              |
 | Climb Sent to Board Failure     | bluetooth-context.tsx:111,119          | `climbUuid`, `boardLayout`, `error_reason`                        | Frame transmission failed                           |

--- a/packages/mobile/src/lib/__tests__/auth-apple-cancel.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth-apple-cancel.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// auth.ts pulls in several native modules at import time; mock them so
+// signInWithApple can be driven in a plain node test. Only the Apple module
+// carries behaviour here — everything else is a stub to satisfy the import
+// graph. Mirrors the harness in auth-google-web.test.ts.
+const signInAsyncMock = vi.fn();
+vi.mock('expo-apple-authentication', () => ({
+  signInAsync: (...args: unknown[]) => signInAsyncMock(...args),
+  AppleAuthenticationScope: { FULL_NAME: 0, EMAIL: 1 },
+}));
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  AppState: { currentState: 'active', addEventListener: () => ({ remove: () => {} }) },
+  Linking: { addEventListener: () => ({ remove: () => {} }) },
+}));
+vi.mock('expo-web-browser', () => ({ openBrowserAsync: vi.fn(), dismissBrowser: vi.fn() }));
+vi.mock('expo-crypto', () => ({
+  getRandomBytes: () => new Uint8Array(16),
+  digestStringAsync: vi.fn(),
+  CryptoDigestAlgorithm: { SHA256: 'SHA256' },
+  CryptoEncoding: { HEX: 'HEX' },
+}));
+vi.mock('@react-native-google-signin/google-signin', () => ({
+  GoogleSignin: { configure: vi.fn(), hasPlayServices: vi.fn(), signIn: vi.fn() },
+  statusCodes: {},
+}));
+vi.mock('../abort-timeout', () => ({ createTimeoutSignal: () => undefined }));
+vi.mock('../env', () => ({ BACKEND_URL: 'https://backend.test', WEB_BASE_URL: 'https://web.test' }));
+vi.mock('../auth-store', () => ({
+  captureAuthCredentialGeneration: vi.fn(() => 1),
+  storeTokens: vi.fn(),
+  clearTokensForGeneration: vi.fn(),
+  getRefreshToken: vi.fn(),
+  isAuthCredentialGenerationCurrent: vi.fn(),
+}));
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+const { signInWithApple } = await import('../auth');
+
+/**
+ * The integration point for #3088: `useNativeOAuthSignIn` only skips the iOS
+ * browser fallback when signInWithApple hands it `{ cancelled: true }` — every
+ * other outcome (including a throw) reaches the hook's outer catch, where
+ * `willFallBack = Platform.OS === 'ios'` is unconditionally true. So the cancel
+ * has to be recognised *here*; the predicate's own unit tests can't prove it is
+ * wired in. See use-native-oauth-sign-in.test.tsx for the hook half.
+ */
+describe('signInWithApple — backing out of the system sheet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports the coded cancel as a cancel, without hitting the backend', async () => {
+    signInAsyncMock.mockRejectedValue(
+      Object.assign(new Error('The operation was canceled'), {
+        code: 'ERR_REQUEST_CANCELED',
+      }),
+    );
+
+    await expect(signInWithApple()).resolves.toEqual({ success: false, cancelled: true });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('reports a message-only cancel as a cancel, so iOS never runs the browser fallback', async () => {
+    // The shape that escaped before #3088: some builds of
+    // expo-apple-authentication reject with no usable `.code`. 49 events / 44
+    // users in 30 days threw past this catch and opened a web sign-in.
+    signInAsyncMock.mockRejectedValue(new Error('The user canceled the authorization attempt'));
+
+    await expect(signInWithApple()).resolves.toEqual({ success: false, cancelled: true });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('still rethrows a real Apple failure so the caller can fall back', async () => {
+    const failure = new Error('The authorization attempt failed for an unknown reason');
+    signInAsyncMock.mockRejectedValue(failure);
+
+    await expect(signInWithApple()).rejects.toBe(failure);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/auth.test.ts
+++ b/packages/mobile/src/lib/__tests__/auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   classifyNativeAuthFailureReason,
+  isAppleSignInCancellation,
   isRecoverableAndroidGoogleSignInError,
   nativeSignInErrorCode,
 } from '../native-auth-analytics';
@@ -129,5 +130,28 @@ describe('isRecoverableAndroidGoogleSignInError', () => {
     expect(isRecoverableAndroidGoogleSignInError(undefined)).toBe(false);
     expect(isRecoverableAndroidGoogleSignInError(null)).toBe(false);
     expect(isRecoverableAndroidGoogleSignInError('DEVELOPER_ERROR')).toBe(false);
+  });
+});
+
+describe('isAppleSignInCancellation', () => {
+  it('treats the coded cancel and the message-only cancel as the same intent', () => {
+    expect(isAppleSignInCancellation({ code: 'ERR_REQUEST_CANCELED' })).toBe(true);
+    // Some builds reject with no usable `.code` — 49 events / 44 users in 30
+    // days reached the sign-in hook's outer catch this way and bounced the
+    // climber into the browser OAuth fallback (#3088).
+    expect(isAppleSignInCancellation(new Error('The user canceled the authorization attempt'))).toBe(true);
+    expect(isAppleSignInCancellation(new Error('The user cancelled the authorization attempt'))).toBe(true);
+  });
+
+  it('keeps real Apple failures classified as failures', () => {
+    expect(isAppleSignInCancellation(new Error('The authorization attempt failed for an unknown reason'))).toBe(false);
+    expect(isAppleSignInCancellation({ code: 'ERR_REQUEST_UNKNOWN' })).toBe(false);
+    expect(isAppleSignInCancellation(new Error('The user canceled a different thing entirely'))).toBe(false);
+  });
+
+  it('handles non-object throws without blowing up', () => {
+    expect(isAppleSignInCancellation(null)).toBe(false);
+    expect(isAppleSignInCancellation(undefined)).toBe(false);
+    expect(isAppleSignInCancellation('The user canceled the authorization attempt')).toBe(false);
   });
 });

--- a/packages/mobile/src/lib/auth.ts
+++ b/packages/mobile/src/lib/auth.ts
@@ -12,7 +12,7 @@ import {
   storeTokens,
 } from './auth-store';
 import { raceBrowserSignIn } from './auth-session-race';
-import { nativeSignInErrorCode } from './native-auth-analytics';
+import { isAppleSignInCancellation, nativeSignInErrorCode } from './native-auth-analytics';
 import { parseDeepLinkQueryParams } from './deep-link-query';
 import { BACKEND_URL, WEB_BASE_URL } from './env';
 
@@ -101,12 +101,6 @@ function generateNonce(): string {
   return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
 }
 
-// expo-apple-authentication rejects with a CodedError whose `.code` is
-// `ERR_REQUEST_CANCELED` when the user dismisses the system sheet.
-function isAppleCancellation(error: unknown): boolean {
-  return typeof error === 'object' && error !== null && (error as { code?: unknown }).code === 'ERR_REQUEST_CANCELED';
-}
-
 export async function signInWithApple(): Promise<OAuthSignInResult> {
   const rawNonce = generateNonce();
   // Hand Apple the hash; the token's `nonce` claim will be this value (Apple
@@ -124,7 +118,11 @@ export async function signInWithApple(): Promise<OAuthSignInResult> {
       nonce: hashedNonce,
     });
   } catch (error) {
-    if (isAppleCancellation(error)) return { success: false, cancelled: true };
+    // Matches the `.code` AND Apple's cancel message, because some builds reject
+    // with the message only. Without the message arm the cancel escapes to the
+    // caller's outer catch, where iOS unconditionally runs the browser OAuth
+    // fallback — backing out of the Apple sheet then opened a web sign-in (#3088).
+    if (isAppleSignInCancellation(error)) return { success: false, cancelled: true };
     throw error;
   }
 

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -352,11 +352,18 @@ describe('useBoardBluetooth', () => {
     expect(Alert.alert).toHaveBeenCalledWith('ble.connectionFailedTitle', 'bluetooth.connectFailed');
   });
 
-  // Guards the #3088 cancel/failure split from over-matching: a real
-  // environmental failure must keep landing on 'Bluetooth Connection Failed'.
-  it('still reports an environmental connect failure as a failure', async () => {
+  // The #3088 split has to send every connect rejection to exactly one of the
+  // two events. The dismissal row is the one that discriminates — before the
+  // split it fired 'Bluetooth Connection Failed' like every other shape. The
+  // rest guard the split from over-matching: ble-plx's "Operation was
+  // cancelled" is our own connect-timeout abort, not a climber backing out.
+  it.each([
+    ['Device selection cancelled', 'Bluetooth Connection Cancelled', undefined],
+    ['Operation was cancelled', 'Bluetooth Connection Failed', 'write_failed'],
+    ['Connection timed out — board may be powered off', 'Bluetooth Connection Failed', 'connect_failed'],
+  ] as const)('routes a "%s" connect rejection to %s', async (message, expectedEvent, expectedFailureReason) => {
     const fakeAdapter = makeFakeAdapter({
-      requestAndConnect: vi.fn().mockRejectedValue(new Error('Connection timed out — board may be powered off')),
+      requestAndConnect: vi.fn().mockRejectedValue(new Error(message)),
     });
     vi.mocked(createBluetoothAdapter).mockReturnValue(
       fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
@@ -368,9 +375,11 @@ describe('useBoardBluetooth', () => {
       await result.current.connect();
     });
 
-    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Cancelled')).toBeUndefined();
-    const failure = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed');
-    expect(failure?.[1]).toMatchObject({ failureReason: 'connect_failed' });
+    const outcomes = mockTrack.mock.calls.filter(
+      ([name]) => name === 'Bluetooth Connection Cancelled' || name === 'Bluetooth Connection Failed',
+    );
+    expect(outcomes.map(([name]) => name)).toEqual([expectedEvent]);
+    expect((outcomes[0]?.[1] as { failureReason?: unknown } | undefined)?.failureReason).toBe(expectedFailureReason);
   });
 
   it('tags a service_missing failure with the services the board exposed (#3480)', async () => {

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -311,7 +311,7 @@ describe('useBoardBluetooth', () => {
     expect(Alert.alert).toHaveBeenCalledWith('ble.connectionFailedTitle', 'bluetooth.unknownError');
   });
 
-  it('stays silent when the user dismisses the device picker', async () => {
+  it('stays silent when the user dismisses the device picker, and counts it as a cancel not a failure', async () => {
     const fakeAdapter = makeFakeAdapter({
       requestAndConnect: vi.fn().mockRejectedValue(new Error('Device selection cancelled')),
     });
@@ -326,6 +326,13 @@ describe('useBoardBluetooth', () => {
     });
 
     expect(Alert.alert).not.toHaveBeenCalled();
+    // #3088: a dismissal used to fire 'Bluetooth Connection Failed', which was
+    // 70% of that event's volume and inflated the reported connect-failure rate.
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed')).toBeUndefined();
+    const cancelled = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Cancelled');
+    expect(cancelled?.[1]).toMatchObject({ boardName: 'kilter', layoutId: 1, sizeId: 1 });
+    // A dismissal has no failure cause to report.
+    expect(cancelled?.[1]).not.toHaveProperty('failureReason');
   });
 
   it('maps a connect timeout to the connect-failed copy', async () => {
@@ -343,6 +350,27 @@ describe('useBoardBluetooth', () => {
     });
 
     expect(Alert.alert).toHaveBeenCalledWith('ble.connectionFailedTitle', 'bluetooth.connectFailed');
+  });
+
+  // Guards the #3088 cancel/failure split from over-matching: a real
+  // environmental failure must keep landing on 'Bluetooth Connection Failed'.
+  it('still reports an environmental connect failure as a failure', async () => {
+    const fakeAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockRejectedValue(new Error('Connection timed out — board may be powered off')),
+    });
+    vi.mocked(createBluetoothAdapter).mockReturnValue(
+      fakeAdapter as unknown as ReturnType<typeof createBluetoothAdapter>,
+    );
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Cancelled')).toBeUndefined();
+    const failure = mockTrack.mock.calls.find(([name]) => name === 'Bluetooth Connection Failed');
+    expect(failure?.[1]).toMatchObject({ failureReason: 'connect_failed' });
   });
 
   it('tags a service_missing failure with the services the board exposed (#3480)', async () => {

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -1596,16 +1596,35 @@ export function useBoardBluetooth({
             Alert.alert(t('ble.connectionFailedTitle'), tCommon('bluetooth.unknownError'));
         }
 
-        track(SHARED_EVENTS.BluetoothConnectionFailed, {
-          boardName,
-          layoutId,
-          sizeId,
-          failureReason: failureCategory === 'unknown' ? classifyBleFailureReason(error) : failureCategory,
-          // Raw ble-plx codes (Android) so the real connect-failure cause and the
-          // low-level GATT status are visible for re-measurement (#3608). Empty on
-          // web / native iOS.
-          ...blePlxErrorCodes(error),
-        });
+        // A dismissed picker gets its own event rather than being counted as a
+        // connect failure (#3088) — it used to be 2,478 of 3,467 'Bluetooth
+        // Connection Failed' events, so the reported failure rate read 15.5%
+        // against a real 5.0%. Branch on `failureCategory`, matching the alert
+        // switch above; deliberately NOT on `reportLevel === null`, since that
+        // knob governs error tracking, not analytics. No failureReason and no
+        // ble-plx codes here: a dismissal has neither.
+        // Known fidelity gap: the unmount cleanup also rejects the picker with
+        // 'Device selection cancelled' (to keep the alert suppressed), so a
+        // provider teardown mid-picker lands here too. That's app teardown, not
+        // a dismissal, and it's rare enough not to warrant a source prop.
+        if (failureCategory === 'user_cancelled') {
+          track(SHARED_EVENTS.BluetoothConnectionCancelled, {
+            boardName,
+            layoutId,
+            sizeId,
+          });
+        } else {
+          track(SHARED_EVENTS.BluetoothConnectionFailed, {
+            boardName,
+            layoutId,
+            sizeId,
+            failureReason: failureCategory === 'unknown' ? classifyBleFailureReason(error) : failureCategory,
+            // Raw ble-plx codes (Android) so the real connect-failure cause and the
+            // low-level GATT status are visible for re-measurement (#3608). Empty on
+            // web / native iOS.
+            ...blePlxErrorCodes(error),
+          });
+        }
       } finally {
         connectInFlightRef.current = false;
         setLoading(false);

--- a/packages/mobile/src/lib/native-auth-analytics.ts
+++ b/packages/mobile/src/lib/native-auth-analytics.ts
@@ -83,3 +83,30 @@ export function isRecoverableAndroidGoogleSignInError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : '';
   return message.includes('DEVELOPER_ERROR') || message.includes('INTERNAL_ERROR');
 }
+
+// Apple's own English description for `ASAuthorizationError.canceled`. Some
+// builds of expo-apple-authentication reject with this message and no usable
+// `.code`, so the code check alone misses them.
+const APPLE_CANCELLATION_MESSAGE = /user cance(?:l|ll)ed the authorization attempt/i;
+
+/**
+ * Whether a thrown Sign in with Apple error is the climber backing out of the
+ * system sheet rather than a real failure.
+ *
+ * expo-apple-authentication usually rejects with a CodedError whose `.code` is
+ * `ERR_REQUEST_CANCELED`, but not always: 49 events across 44 users in 30 days
+ * reached the sign-in hook's outer catch with `failure_reason: 'exception'` and
+ * the bare message "The user canceled the authorization attempt" (#3088). That
+ * escape made a cancel look like a failure, which tipped iOS into the browser
+ * OAuth fallback — so dismissing the Apple sheet dumped the climber into a web
+ * sign-in. Hence the message fallback.
+ *
+ * Deliberately narrow. "The authorization attempt failed for an unknown reason"
+ * and `ERR_REQUEST_UNKNOWN` are real failures and must keep classifying as such.
+ */
+export function isAppleSignInCancellation(error: unknown): boolean {
+  if (nativeSignInErrorCode(error) === 'ERR_REQUEST_CANCELED') return true;
+  if (typeof error !== 'object' || error === null) return false;
+  const message = (error as { message?: unknown }).message;
+  return typeof message === 'string' && APPLE_CANCELLATION_MESSAGE.test(message);
+}

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -191,6 +191,13 @@ export const SHARED_EVENTS = {
   // Bluetooth / hardware
   BluetoothConnectionSuccess: 'Bluetooth Connection Success',
   BluetoothConnectionFailed: 'Bluetooth Connection Failed',
+  // A climber dismissing the device picker is intent, not a failure. Kept
+  // distinct from BluetoothConnectionFailed so the failure metric isn't inflated
+  // by cancels: over 30 days 2,478 of 3,467 'Bluetooth Connection Failed' events
+  // carried failureReason 'user_cancelled' (#3088), which read as a 15.5%
+  // connect-failure rate where the real one is 5.0%. Same split as
+  // LoginCancelled / LoginFailed above. Props: { boardName, layoutId, sizeId }.
+  BluetoothConnectionCancelled: 'Bluetooth Connection Cancelled',
   BluetoothDisconnected: 'Bluetooth Disconnected',
   // BLE lifecycle telemetry — added so a session recording (and PostHog) shows
   // what the radio actually did. BluetoothConnectionStolen is the tug-of-war


### PR DESCRIPTION
## Summary

Fixes the one still-live item from issue #3088: dismissing the Bluetooth board picker was being logged as a `Bluetooth Connection Failed` event, which made 71% of "failures" actually be users just cancelling and inflated the reported failure rate from ~5% to ~15.5%. Cancels now fire a separate `Bluetooth Connection Cancelled` event instead, mirroring the existing `LoginCancelled`/`LoginFailed` split for auth. While verifying that fix, the same "user intent counted as a failure" bug was found in Sign in with Apple: backing out of the Apple sheet on some builds threw the user into a browser-based OAuth fallback instead of just closing, because the cancellation check only matched one error shape; it now also matches the message-only cancellation. The other two checklist items from #3088 are scoped out with reasons (one deferred to PR #4127, one already obsolete after the web BLE code was deleted).

---

Refs #3088

Issue #3088 is a three-item checklist about error-tracking hygiene. Two of the three items are already gone or already owned elsewhere, so this PR fixes the one that is still live — plus the same defect one file over in the Apple sign-in path, which turned out to be the only user-visible bug in the bundle.

## What changed

### 1. Dismissing the board picker no longer counts as a connect failure

`use-board-bluetooth.ts` fired `Bluetooth Connection Failed` unconditionally in the connect `catch`, after the `switch (failureCategory)` whose `case 'user_cancelled': break;` only suppressed the alert. So every picker dismissal was recorded as a Bluetooth failure.

30 days of mobile `Bluetooth Connection Failed` (PostHog project 412845):

| failureReason | events | users |
| --- | --- | --- |
| `user_cancelled` | **2,478** | 831 |
| `connect_failed` | 489 | 200 |
| `board_not_found` | 219 | 134 |
| `write_failed` | 218 | 85 |
| `disconnected` | 45 | 22 |
| `unavailable` | 13 | 10 |
| `service_missing` | 5 | 4 |

2,478 of 3,467 events — 71% — were cancels. Against 18,859 successes that reads as a 15.5% connect-failure rate where the real technical failure rate is 5.0%.

Cancels now fire a new `Bluetooth Connection Cancelled` event instead, mirroring the `LoginCancelled` / `LoginFailed` split that already exists for auth. The branch keys off `failureCategory`, matching the alert switch — deliberately not off `bleConnectReportLevel`, which governs error tracking rather than analytics. `classifyBleFailure` itself is untouched; its `user_cancelled` predicate is already deliberately tight and the comment there explains why widening it is dangerous.

### 2. Backing out of Sign in with Apple no longer opens a browser sign-in

Found while verifying the above, and it is the same "user intent counted as a failure" defect. `isAppleCancellation` in `packages/mobile/src/lib/auth.ts` matched only `error.code === 'ERR_REQUEST_CANCELED'`. Some builds of `expo-apple-authentication` reject with no usable `.code` and the message `The user canceled the authorization attempt`.

That path is visible in PostHog: `Login Failed` with `auth_method: apple`, `failure_reason: 'exception'`, `failure_detail: 'The user canceled the authorization attempt'` — 49 events / 44 users in 30 days. The `failure_reason: 'exception'` proves it reached the outer `catch (oauthError)` in `use-native-oauth-sign-in.ts`, where `willFallBack = Platform.OS === 'ios'` is unconditionally true and `runWebFallback()` runs. Corroborated by 164 `Login Attempted` events with `flow: web_fallback, auth_method: apple` across 91 users in the same window.

So on iOS, dismissing the Apple sheet dropped the climber into an in-app browser OAuth flow instead of just closing.

The predicate moved to `native-auth-analytics.ts` (pure, no Expo imports, already covered by `auth.test.ts`) as `isAppleSignInCancellation`, and now also matches Apple's `ASAuthorizationError.canceled` description. Kept tight: `The authorization attempt failed for an unknown reason` (65 ev / 24 users) and `ERR_REQUEST_UNKNOWN` (9 ev / 9 users) still classify as failures.

`use-native-oauth-sign-in.ts` is untouched — it already does the right thing once it gets `{ cancelled: true }`.

## Scoped out, with reasons

### Item 1 (locked-keychain SecureStore error) — deferred to #4127, deliberately not suppressed

The issue asks to stop logging `User interaction is not allowed` as an error. That would be wrong right now: it is a live bug, not expected noise.

- **BOARDSESH-7P** — `getValueWithKeyAsync` → `User interaction is not allowed` — 863 events / **408 users**, first seen 2026-06-24, still firing today.
- **BOARDSESH-C3** — same cause, the `FunctionCallException` title shape — 454 events / **304 users**, **first seen 2026-08-04**, last seen today, on release `com.boardsesh.app@2.3.1+2`.

`AFTER_FIRST_UNLOCK` already shipped (`secure-store-options.ts`, commit `01bb11a9e`) and every writer passes it. It did not help, because `keychainAccessible` only applies at write time and iOS `setItemAsync` on an existing key falls through to `SecItemUpdate` with a `kSecValueData`-only dictionary, so `kSecAttrAccessible` is never re-applied. **PR #4127 fixes exactly that**, by copying items into a fresh `boardsesh.v2` keychain service to force a `SecItemAdd`. It is open and blocked on review only.

Downgrading the log here would relabel a live sign-out bug as expected noise, and it would blur the one signal #4127 is going to be judged on ("BOARDSESH-7P user count should decay"). Land #4127, let it soak, then decide whether the residual — a genuine pre-first-unlock background prewarm, irreducible even after the migration — is worth a `warning` downgrade.

Two corrections for whoever writes that matcher:

- The issue body says `checkAuth()` uses raw `reportError` and bypasses the noise policy. That is stale. The read path goes through `reportHandledError` at `auth-provider.tsx:503` with `tags: { source: 'auth-session', auth_stage }`. Routing is already right; the only gap is that `reportHandledError` has no keychain branch.
- `User interaction is not allowed` is **not** on the top-level JS `error.message` in either group — Sentry renders it as `→ Caused by:`, the linked-exception chain it builds from `Error.cause`. A `/User interaction is not allowed/i` test against `error.message` alone would be a silent no-op on 100% of both groups. It needs a bounded `.cause` walk, modelled on `isLocaleIndependentTransportSignal` in `@boardsesh/offline-sync`.

### Item 2's error-tracking half — already resolved

`search_issues(org=boardsesh, "Device selection cancelled", 30d)` returns zero issues. PostHog no longer does error autocapture at all (`posthog-client.ts`: "PostHog is product analytics only — error/crash reporting goes to Sentry"), and the connect catch is already silent for cancels via `bleConnectReportLevel('user_cancelled') === null`. Only the analytics half was still broken, and that is what this PR fixes.

### Item 3 (web double-log) — obsolete

`packages/web/app/components/board-bluetooth-control/` was deleted in #4467 (`d5a8336c8`, 2026-08-15). Repo-wide there is no `Pairing Failed` string, no `BluetoothConnectionFailed` reference in `packages/web`, and no `navigator.bluetooth` under `packages/web/app`. The events still trickling in — `lib=js`, 80 `Bluetooth Connection Failed` all with null `failureReason` and exactly 80 `Pairing Failed`, 18 users, last seen 2026-08-14 — come from clients on the old bundle (Capacitor WebView, cached deploys). The 1:1 pathology is real but there is no source left to change; it drains on its own.

## Marco: two PostHog actions when this ships

Neither is doable from the PR, and both are cheap. The new event name splits the historical series, so the headline BLE reliability number steps up ~10 points purely from the rename — gradually, as the OTA lands, which looks exactly like a real reliability win at the moment the #3806 / #3811 Android connect work is being judged.

1. **Annotate the split** on the OTA release date, so the step is legible on every BLE chart.
2. **Update the four rate insights on dashboard 1693744** that count raw `Bluetooth Connection Failed` as the failure leg. Add `Bluetooth Connection Cancelled` as a third series wherever the denominator is meant to be *total connect attempts*:
   - `u328nqyy` — [Headline] BLE connect success rate (30d) — computes `A/(A+B)*100`, no `$lib` filter
   - `OTcwh8XQ` — [Bluetooth] BLE connect success rate over time
   - `7YJQy9oC` — BLE connect success rate by app version × OS
   - `8XP2ma0e` — [Reliability] Bluetooth & board-send outcomes per day

Insights that already exclude `failureReason = 'user_cancelled'` need no change and stay correct *through* the rollout overlap, because old clients keep emitting the tagged Failed event. That property is what makes this a clean migration.

## Tests

- `use-board-bluetooth.test.ts`: the picker-dismissal test asserts `Bluetooth Connection Cancelled` fires with the board props and no `failureReason`, and that `Bluetooth Connection Failed` does **not**. A routing table then pins each connect rejection to exactly one of the two events — the dismissal row is the discriminator, and ble-plx's "Operation was cancelled" (our own connect-timeout abort, not a climber backing out) plus a GATT timeout guard the split from over-matching.
- `auth-apple-cancel.test.ts`: drives `signInWithApple` itself with a mocked `expo-apple-authentication`, so the predicate is asserted *wired in*. A message-only cancel resolves `{ cancelled: true }` — the only outcome that stops `useNativeOAuthSignIn` running the iOS browser fallback — and a real Apple failure still rethrows.
- `auth.test.ts`: `isAppleSignInCancellation` over the coded cancel, both spellings of the message-only cancel, the two real-failure shapes that must stay failures, and `null` / `undefined` / a bare string.

Every new test was checked against the old behaviour by reverting both source fixes: 4 tests fail, including at least one from each new file.

## Known gaps

- The unmount cleanup also rejects the picker with `Device selection cancelled` (to keep the alert suppressed), so a provider teardown mid-picker emits a Cancelled event too. That is app teardown, not a dismissal, and it is rare enough not to warrant a `cancelSource` prop. Documented in a code comment.
- Apple's cancel message is English, so on a localised device the message arm won't fire and the `.code` arm has to carry it. This strictly improves on today's behaviour and cannot regress it; the real fix is upstream in `expo-apple-authentication` setting `ERR_REQUEST_CANCELED` for `ASAuthorizationError.canceled`.
- `POSTHOG_INVENTORY.md` gets the new event, but the rest of its Bluetooth table still describes the deleted web implementation (file paths, `boardLayout` props). Not rewritten here.
- The keychain bug stays live until #4127 lands, which is why item 1 stays on #3088's checklist rather than being closed out.

JS-only, no native inputs touched, so this rides OTA.

**This touches `packages/mobile/src/lib/ble/`, so per CLAUDE.md it needs a Fable review before merge.**

## Release Notes

Backing out of Sign in with Apple now just closes the sheet. It used to throw you straight into a browser sign-in instead of letting you go.
