### PR TITLE
fix(mobile): stop iOS clearing the board on connect when no session is running

### DIFF
--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -1732,6 +1732,35 @@ describe('useBoardBluetooth', () => {
     );
   });
 
+  it('numbers connection generations from 1 so 0 stays the "no link yet" sentinel', async () => {
+    // BluetoothProvider seeds its connectionGeneration state at 0 and feeds it
+    // from this handle. A first connect reported as 0 would set the same value
+    // back, the auto-sender's drain effect would not re-fire, and a link change
+    // could no longer retire its "already on the wall" caches (#4413).
+    const firstAdapter = makeFakeAdapter();
+    const secondAdapter = makeFakeAdapter({
+      requestAndConnect: vi.fn().mockResolvedValue({ deviceId: 'device-2', deviceName: 'Kilter Board#456@3' }),
+    });
+    vi.mocked(createBluetoothAdapter)
+      .mockReturnValueOnce(firstAdapter as unknown as ReturnType<typeof createBluetoothAdapter>)
+      .mockReturnValueOnce(secondAdapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+    const generations: number[] = [];
+    const onConnectSuccess = vi.fn((_serial: string | null, connection: BleConnectionHandle) => {
+      generations.push(connection.generation);
+    });
+
+    const { result } = renderHook(() =>
+      useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1, onConnectSuccess }),
+    );
+
+    await act(async () => {
+      await result.current.connect();
+      await result.current.connect();
+    });
+
+    expect(generations).toEqual([1, 2]);
+  });
+
   it('attributes adapter replacement to the old generation', async () => {
     const firstAdapter = makeFakeAdapter();
     const secondAdapter = makeFakeAdapter({

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -793,6 +793,10 @@ export function useBoardBluetooth({
       adapterRef.current = null;
       configuredDeviceNameRef.current = undefined;
       connectedConfigIdentityRef.current = null;
+      // The seed describes what THIS link physically wrote. Left behind, the
+      // next generation's first drain could consume it and record a climb as
+      // already lit on a wall this app never wrote to.
+      connectInitialSendRef.current = null;
       writeAbortRef.current?.abort();
       writeAbortRef.current = null;
       writeChainRef.current = Promise.resolve();
@@ -1657,6 +1661,9 @@ export function useBoardBluetooth({
       adapterRef.current = null;
       configuredDeviceNameRef.current = undefined;
       connectedConfigIdentityRef.current = null;
+      // Same reason as clearConnectionAfterDrop: a seed set by this generation
+      // must never be consumed by the next one's first drain.
+      connectInitialSendRef.current = null;
       // Cancel every in-flight and queued write of this connection generation,
       // and unblock the write chain for the next connect.
       writeAbortRef.current?.abort();

--- a/packages/mobile/src/lib/live-activity/__tests__/use-live-activity-shared-queue-mirror.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/use-live-activity-shared-queue-mirror.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+
+// iOS is the platform under test: only there does the native BoardBleManager
+// relight the wall from the App-Group queue copy on connect, and only there
+// does an EMPTY copy mean "clear the wall" (#4413). Platform.OS is read at
+// module load, so it must be stubbed before the hook is imported.
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
+
+vi.mock('../../auth-store', () => ({
+  getAuthToken: vi.fn().mockResolvedValue('token-123'),
+}));
+
+vi.mock('../../env', () => ({
+  BACKEND_URL: 'https://backend.test',
+  WEB_BASE_URL: 'https://web.test',
+}));
+
+// The hook lazily imports the bundled board-art manifest when it actually
+// starts an Activity. No test here starts one, but stub it so a future case
+// that does can't reach expo-asset.
+vi.mock('../../background-image-cache', () => ({
+  ensureBackgroundsCached: vi.fn().mockResolvedValue({ paths: [], missingCount: 0 }),
+}));
+
+const plugin = vi.hoisted(() => ({
+  isLiveActivityAvailable: vi.fn(),
+  startLiveActivitySession: vi.fn(),
+  endLiveActivitySession: vi.fn(),
+  updateLiveActivity: vi.fn(),
+  updateLiveActivityClimb: vi.fn(),
+}));
+
+vi.mock('../live-activity-plugin', () => plugin);
+
+import { useLiveActivity } from '../use-live-activity';
+
+function makeQueueItem(uuid: string, frames: string): ClimbQueueItem {
+  return {
+    uuid: `queue-${uuid}`,
+    climb: {
+      uuid,
+      name: `Climb ${uuid}`,
+      difficulty: 'V4',
+      angle: 40,
+      frames,
+      setter_username: 'setter',
+      mirrored: false,
+    },
+  } as unknown as ClimbQueueItem;
+}
+
+const firstItem = makeQueueItem('climb-1', 'p1r1');
+const secondItem = makeQueueItem('climb-2', 'p2r2');
+// One stable array identity across rerenders, mirroring the reducer-owned queue:
+// a fresh array would re-run the full queue sync and mask the lightweight
+// climb-navigation push the mirror also has to make.
+const soloQueue = [firstItem, secondItem];
+
+type HookProps = Parameters<typeof useLiveActivity>[0];
+
+// A climber who never started a session: sessionId null, so no Live Activity is
+// raised — the exact population whose App-Group queue copy was always empty.
+function soloProps(overrides: Partial<HookProps> = {}): HookProps {
+  return {
+    queue: soloQueue,
+    currentClimbQueueItem: firstItem,
+    board: { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' },
+    sessionId: null,
+    isSessionActive: false,
+    widgetNavigationAllowed: false,
+    isPartySession: false,
+    boardConnection: 'connectedByMe',
+    ...overrides,
+  };
+}
+
+function Harness(props: HookProps) {
+  useLiveActivity(props);
+  return null;
+}
+
+describe('useLiveActivity shared queue-state mirror (iOS)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plugin.isLiveActivityAvailable.mockResolvedValue(true);
+    plugin.updateLiveActivity.mockResolvedValue(undefined);
+    plugin.updateLiveActivityClimb.mockResolvedValue(undefined);
+    plugin.startLiveActivitySession.mockResolvedValue(undefined);
+    plugin.endLiveActivitySession.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('publishes the queue and current index with no session, without starting an Activity', async () => {
+    render(<Harness {...soloProps()} />);
+
+    await waitFor(() => {
+      expect(plugin.updateLiveActivity).toHaveBeenCalled();
+    });
+
+    const payload = plugin.updateLiveActivity.mock.calls[0][0];
+    expect(payload.currentIndex).toBe(0);
+    expect(payload.climbUuid).toBe('climb-1');
+    expect(payload.queue.map((entry: { climbUuid: string }) => entry.climbUuid)).toEqual(['climb-1', 'climb-2']);
+    // No session means no lock-screen widget — the mirror must not raise one.
+    expect(plugin.startLiveActivitySession).not.toHaveBeenCalled();
+  });
+
+  it('publishes the new index when the climber navigates with no session', async () => {
+    const { rerender } = render(<Harness {...soloProps()} />);
+
+    await waitFor(() => {
+      expect(plugin.updateLiveActivity).toHaveBeenCalled();
+    });
+
+    rerender(<Harness {...soloProps({ currentClimbQueueItem: secondItem })} />);
+
+    await waitFor(() => {
+      expect(plugin.updateLiveActivityClimb).toHaveBeenCalled();
+    });
+    const payload = plugin.updateLiveActivityClimb.mock.calls.at(-1)?.[0];
+    expect(payload.currentIndex).toBe(1);
+    expect(payload.climbUuid).toBe('climb-2');
+  });
+
+  it('still publishes when Live Activities are unavailable', async () => {
+    // A climber who denied Live Activities in Settings still connects over BLE,
+    // so the wall relight must not inherit ActivityKit's authorization.
+    plugin.isLiveActivityAvailable.mockResolvedValue(false);
+
+    render(<Harness {...soloProps()} />);
+
+    await waitFor(() => {
+      expect(plugin.updateLiveActivity).toHaveBeenCalled();
+    });
+    expect(plugin.startLiveActivitySession).not.toHaveBeenCalled();
+  });
+
+  it('does not publish before a board is selected', async () => {
+    render(<Harness {...soloProps({ board: null })} />);
+
+    await waitFor(() => {
+      expect(plugin.isLiveActivityAvailable).toHaveBeenCalled();
+    });
+    expect(plugin.updateLiveActivity).not.toHaveBeenCalled();
+    expect(plugin.updateLiveActivityClimb).not.toHaveBeenCalled();
+  });
+
+  it('leaves the previous copy alone when the queue empties', async () => {
+    // Known gap, tracked in #4544: with nothing queued there is no item to
+    // publish, so the App-Group copy keeps whatever it last held (and an
+    // untouched copy at connect relights that instead of clearing the wall).
+    const { rerender } = render(<Harness {...soloProps()} />);
+
+    await waitFor(() => {
+      expect(plugin.updateLiveActivity).toHaveBeenCalled();
+    });
+    const callsAfterFirstSync = plugin.updateLiveActivity.mock.calls.length;
+
+    rerender(<Harness {...soloProps({ queue: [], currentClimbQueueItem: null })} />);
+
+    await waitFor(() => {
+      expect(plugin.updateLiveActivity.mock.calls.length).toBe(callsAfterFirstSync);
+    });
+  });
+
+  it('re-publishes after a session ends, because endSession wipes the shared keys', async () => {
+    const inSession = soloProps({ sessionId: 'session-1', isSessionActive: true });
+    const { rerender } = render(<Harness {...inSession} />);
+
+    await waitFor(() => {
+      expect(plugin.startLiveActivitySession).toHaveBeenCalled();
+    });
+    plugin.updateLiveActivity.mockClear();
+
+    rerender(<Harness {...soloProps()} />);
+
+    await waitFor(() => {
+      expect(plugin.endLiveActivitySession).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(plugin.updateLiveActivity).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/mobile/src/lib/live-activity/__tests__/use-live-activity-shared-queue-mirror.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/use-live-activity-shared-queue-mirror.test.tsx
@@ -205,5 +205,32 @@ describe('useLiveActivity shared queue-state mirror (iOS)', () => {
     await waitFor(() => {
       expect(plugin.updateLiveActivity).toHaveBeenCalled();
     });
+    // The re-publish must not raise a fresh lock-screen widget for what is now
+    // a solo queue — only the App-Group copy is being restored.
+    expect(plugin.startLiveActivitySession).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-publishes after a failed start, which also wiped the shared keys', async () => {
+    // Native startSession writes the App-Group state before the Activity.request
+    // that throws, and the hook's catch tears it down with endSession — so this
+    // path wipes the queue copy just like a real session end, and the mirror has
+    // to restore it. Covers the second of the two wipe-nonce sites.
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    plugin.startLiveActivitySession.mockRejectedValue(new Error('permission denied'));
+
+    render(<Harness {...soloProps({ sessionId: 'session-1', isSessionActive: true })} />);
+
+    await waitFor(() => {
+      expect(plugin.endLiveActivitySession).toHaveBeenCalled();
+    });
+
+    // Two publishes and no more: the mount seed, then the restore after the
+    // failed start's endSession wiped the keys. (Counting rather than clearing
+    // the mock — the rejection settles in microtasks, so there is no safe point
+    // between "start was attempted" and "teardown ran" to reset a baseline at.)
+    await waitFor(() => {
+      expect(plugin.updateLiveActivity).toHaveBeenCalledTimes(2);
+    });
+    expect(plugin.updateLiveActivity.mock.calls.at(-1)?.[0].climbUuid).toBe('climb-1');
   });
 });

--- a/packages/mobile/src/lib/live-activity/__tests__/use-live-activity-shared-queue-mirror.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/use-live-activity-shared-queue-mirror.test.tsx
@@ -169,6 +169,25 @@ describe('useLiveActivity shared queue-state mirror (iOS)', () => {
     });
   });
 
+  it('does not churn the App Group on re-renders that change nothing', async () => {
+    // The mirror now runs for every iOS climber rather than only during a
+    // session, so its cadence has to be one write per real queue/navigation
+    // change — not one per render.
+    const { rerender } = render(<Harness {...soloProps()} />);
+
+    await waitFor(() => {
+      expect(plugin.updateLiveActivity).toHaveBeenCalledTimes(1);
+    });
+
+    for (let renderPass = 0; renderPass < 5; renderPass += 1) {
+      rerender(<Harness {...soloProps()} />);
+    }
+    await waitFor(() => {
+      expect(plugin.updateLiveActivity).toHaveBeenCalledTimes(1);
+    });
+    expect(plugin.updateLiveActivityClimb).not.toHaveBeenCalled();
+  });
+
   it('re-publishes after a session ends, because endSession wipes the shared keys', async () => {
     const inSession = soloProps({ sessionId: 'session-1', isSessionActive: true });
     const { rerender } = render(<Harness {...inSession} />);

--- a/packages/mobile/src/lib/live-activity/__tests__/use-live-activity.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/use-live-activity.test.tsx
@@ -389,15 +389,17 @@ describe('useLiveActivity Android session gating', () => {
   });
 
   it('pushes nothing to the session-presence surface without an active session', async () => {
-    render(<Harness {...activeProps({ sessionId: null, isSessionActive: false })} />);
+    const { rerender } = render(<Harness {...activeProps({ sessionId: null, isSessionActive: false })} />);
 
     await waitFor(() => expect(plugin.isLiveActivityAvailable).toHaveBeenCalled());
-    await act(async () => {
-      await Promise.resolve();
-    });
-
     expect(plugin.startLiveActivitySession).not.toHaveBeenCalled();
     expect(plugin.updateLiveActivity).not.toHaveBeenCalled();
     expect(plugin.updateLiveActivityClimb).not.toHaveBeenCalled();
+
+    // Activating proves the harness really would have observed a push above,
+    // so the assertions are a live gate rather than a timing coincidence.
+    rerender(<Harness {...activeProps()} />);
+    await waitFor(() => expect(plugin.startLiveActivitySession).toHaveBeenCalled());
+    await waitFor(() => expect(plugin.updateLiveActivity).toHaveBeenCalled());
   });
 });

--- a/packages/mobile/src/lib/live-activity/__tests__/use-live-activity.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/use-live-activity.test.tsx
@@ -369,3 +369,35 @@ describe('useLiveActivity auth-token gating', () => {
     );
   });
 });
+
+// This file stubs Platform.OS as 'android'. The iOS shared-queue mirror (#4413)
+// deliberately does NOT extend here: every Android board write goes through JS,
+// so there is no native relight to feed, and pushing state without a session
+// would put a foreground-service notification in front of a solo queue.
+describe('useLiveActivity Android session gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plugin.isLiveActivityAvailable.mockResolvedValue(true);
+    plugin.updateLiveActivity.mockResolvedValue(undefined);
+    plugin.updateLiveActivityClimb.mockResolvedValue(undefined);
+    plugin.endLiveActivitySession.mockResolvedValue(undefined);
+    plugin.startLiveActivitySession.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('pushes nothing to the session-presence surface without an active session', async () => {
+    render(<Harness {...activeProps({ sessionId: null, isSessionActive: false })} />);
+
+    await waitFor(() => expect(plugin.isLiveActivityAvailable).toHaveBeenCalled());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(plugin.startLiveActivitySession).not.toHaveBeenCalled();
+    expect(plugin.updateLiveActivity).not.toHaveBeenCalled();
+    expect(plugin.updateLiveActivityClimb).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/live-activity/use-live-activity.ts
+++ b/packages/mobile/src/lib/live-activity/use-live-activity.ts
@@ -58,6 +58,25 @@ type UseLiveActivityOptions = {
 // presence surface; everything else short-circuits at the plugin layer.
 const supportsSessionPresence = Platform.OS === 'ios' || Platform.OS === 'android';
 
+// iOS keeps a copy of the queue + current index in the App Group so the native
+// BoardBleManager can drive the wall without JS (widget intents, CoreBluetooth
+// state restoration). It relights from that copy the instant a BLE link becomes
+// write-ready — and an EMPTY copy does not mean "leave the wall alone", it means
+// "clear it": displayCurrentItemOnBleQueue falls through to clearBoardOnBleQueue
+// when the current index is out of range.
+//
+// Live Activities only run for explicitly started sessions, so climbers who just
+// connect and climb — the large majority — had an empty copy, and every connect
+// darked their board (#4413). Mirror the shared state on iOS whether or not an
+// Activity is running: the ActivityKit push that rides along is a no-op when
+// there is no activity (LiveActivityManager.updateActivity returns early), and
+// the native relight then paints the current climb instead of a clear-all.
+//
+// Android's foreground service has no native BLE relight — every write there
+// goes through JS — so it stays gated on a real session and never raises a
+// notification for a solo queue.
+const mirrorsSharedQueueStateWhenIdle = Platform.OS === 'ios';
+
 // Retry budget for a failed native start (transient ActivityKit rejections).
 // Attempt n waits n × START_RETRY_DELAY_MS; the budget resets on a successful
 // start or a deactivation.
@@ -392,8 +411,11 @@ export function useLiveActivity({
   const queueSyncedRef = useRef(false);
 
   // Effect 1: Queue sync — sends the full queue when items change.
+  // Also runs while no Activity is live on iOS, so the App-Group copy the native
+  // BLE relight reads is never empty (see mirrorsSharedQueueStateWhenIdle).
   useEffect(() => {
-    if (!isActiveRef.current || !stableBoard) return;
+    if (!isActiveRef.current && !mirrorsSharedQueueStateWhenIdle) return;
+    if (!stableBoard) return;
 
     const displayItem = currentClimbRef.current ?? (queueRef.current.length > 0 ? queueRef.current[0] : null);
     if (!displayItem) return;
@@ -439,13 +461,18 @@ export function useLiveActivity({
     holderDisplayName,
     isPartySession,
     serializedQueue,
+    // A session ending wipes the App-Group queue keys (endSession), so re-push
+    // the mirrored copy the moment shouldBeActive flips — otherwise the next BLE
+    // connect reads an empty queue and clears the wall.
+    shouldBeActive,
     stableBoard,
     widgetNavigationAllowed,
   ]);
 
   // Effect 2: Climb navigation — lightweight update with only scalar data.
   useEffect(() => {
-    if (!isActiveRef.current || !stableBoard) return;
+    if (!isActiveRef.current && !mirrorsSharedQueueStateWhenIdle) return;
+    if (!stableBoard) return;
     if (queueSyncedRef.current) return;
 
     const displayItem = currentClimbQueueItem ?? (queue.length > 0 ? queue[0] : null);
@@ -481,6 +508,8 @@ export function useLiveActivity({
     holderDisplayName,
     isPartySession,
     queue,
+    // See Effect 1: a session end wipes the shared copy, so re-push on the flip.
+    shouldBeActive,
     stableBoard,
     widgetNavigationAllowed,
   ]);

--- a/packages/mobile/src/lib/live-activity/use-live-activity.ts
+++ b/packages/mobile/src/lib/live-activity/use-live-activity.ts
@@ -287,6 +287,12 @@ export function useLiveActivity({
   // mirroring them has to re-publish once the teardown has run. Bumped ONLY on
   // teardown — putting shouldBeActive in the sync effects' deps instead would
   // also re-fire on activation and double the Activity's initial update.
+  //
+  // Exactly TWO call sites, and they are mutually exclusive by construction:
+  // the start-failure catch below (which ends a session JS never saw start, so
+  // shouldBeActive is still true) and the deactivation effect further down
+  // (shouldBeActive true -> false). Keep them disjoint — a bump from both in one
+  // teardown would re-publish twice for no gain.
   const [sharedStateWipeNonce, setSharedStateWipeNonce] = useState(0);
   const startFailureCountRef = useRef(0);
   const startRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -370,6 +376,10 @@ export function useLiveActivity({
           // tear those down here — JS otherwise believes nothing is active and
           // never reaches the teardown paths. endSession is idempotent.
           void endLiveActivitySession();
+          // Wipe-nonce site 1 of 2 (see the useState declaration): that
+          // endSession just cleared the App-Group queue keys, and
+          // shouldBeActive is still true here, so the deactivation effect will
+          // not fire for this teardown.
           setSharedStateWipeNonce((nonce) => nonce + 1);
           startFailureCountRef.current += 1;
           if (startFailureCountRef.current <= MAX_START_RETRIES) {
@@ -409,6 +419,7 @@ export function useLiveActivity({
   // so the re-publish is dispatched behind the endSession it has to survive.
   const wasActiveRef = useRef(shouldBeActive);
   useEffect(() => {
+    // Wipe-nonce site 2 of 2 (see the useState declaration).
     if (wasActiveRef.current && !shouldBeActive) {
       setSharedStateWipeNonce((nonce) => nonce + 1);
     }

--- a/packages/mobile/src/lib/live-activity/use-live-activity.ts
+++ b/packages/mobile/src/lib/live-activity/use-live-activity.ts
@@ -283,6 +283,11 @@ export function useLiveActivity({
   // reactivate. Bounded: the nonce re-fires the start effect, the counter
   // stops after MAX_START_RETRIES, and both reset on success or deactivation.
   const [startRetryNonce, setStartRetryNonce] = useState(0);
+  // Native endSession removes the App-Group queue keys outright, so anything
+  // mirroring them has to re-publish once the teardown has run. Bumped ONLY on
+  // teardown — putting shouldBeActive in the sync effects' deps instead would
+  // also re-fire on activation and double the Activity's initial update.
+  const [sharedStateWipeNonce, setSharedStateWipeNonce] = useState(0);
   const startFailureCountRef = useRef(0);
   const startRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const clearStartRetry = () => {
@@ -365,6 +370,7 @@ export function useLiveActivity({
           // tear those down here — JS otherwise believes nothing is active and
           // never reaches the teardown paths. endSession is idempotent.
           void endLiveActivitySession();
+          setSharedStateWipeNonce((nonce) => nonce + 1);
           startFailureCountRef.current += 1;
           if (startFailureCountRef.current <= MAX_START_RETRIES) {
             const attempt = startFailureCountRef.current;
@@ -395,6 +401,19 @@ export function useLiveActivity({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- startRetryNonce re-fires the start after a failed attempt
   }, [shouldBeActive, stableBoard, available, startRetryNonce]);
+
+  // Native endSession removes the App-Group queue keys outright. On a real
+  // deactivation the teardown runs from the effect CLEANUP above (React runs it
+  // before the effect body, so the body's own end branch never sees
+  // isActiveRef true) — watch the transition here instead, after that effect,
+  // so the re-publish is dispatched behind the endSession it has to survive.
+  const wasActiveRef = useRef(shouldBeActive);
+  useEffect(() => {
+    if (wasActiveRef.current && !shouldBeActive) {
+      setSharedStateWipeNonce((nonce) => nonce + 1);
+    }
+    wasActiveRef.current = shouldBeActive;
+  }, [shouldBeActive]);
 
   // Stable scalar trigger for the on-device thumbnail backgrounds: the paths array
   // has a fresh identity each render, so depending on it directly would churn the
@@ -461,10 +480,10 @@ export function useLiveActivity({
     holderDisplayName,
     isPartySession,
     serializedQueue,
-    // A session ending wipes the App-Group queue keys (endSession), so re-push
-    // the mirrored copy the moment shouldBeActive flips — otherwise the next BLE
-    // connect reads an empty queue and clears the wall.
-    shouldBeActive,
+    // endSession wipes the App-Group queue keys, so re-push the mirrored copy
+    // once the teardown has run — otherwise the next BLE connect reads an empty
+    // queue and clears the wall.
+    sharedStateWipeNonce,
     stableBoard,
     widgetNavigationAllowed,
   ]);
@@ -508,8 +527,8 @@ export function useLiveActivity({
     holderDisplayName,
     isPartySession,
     queue,
-    // See Effect 1: a session end wipes the shared copy, so re-push on the flip.
-    shouldBeActive,
+    // See Effect 1: a session end wipes the shared copy, so re-push afterwards.
+    sharedStateWipeNonce,
     stableBoard,
     widgetNavigationAllowed,
   ]);

--- a/packages/mobile/src/providers/__tests__/bluetooth-auto-sender.test.ts
+++ b/packages/mobile/src/providers/__tests__/bluetooth-auto-sender.test.ts
@@ -55,6 +55,13 @@ type DrainContext = {
    * re-drive the loop with the most-recent climb (the lightbulb re-take path).
    */
   reassert: () => void;
+  /**
+   * Simulate a new physical BLE link (a `connectionGeneration` bump): retire the
+   * "already on the wall" caches once and re-drive the loop with the most-recent
+   * climb. The component sees this even when the rendered `isConnected` flag
+   * never flipped, so the sender was never remounted.
+   */
+  newConnectionGeneration: () => void;
 };
 
 type DrainLoopOptions = {
@@ -77,6 +84,7 @@ function createDrainLoop(
   let lastSentSignature: string | null = null;
   let lastEnqueuedItem: ClimbQueueItem | null = null;
   let reassertPending = false;
+  let connectionChangedPending = false;
   // Mirror of lastSkipReportedUuidRef / lastUnresolvedReportedUuidRef: report a
   // given spill / unresolved uuid once, clear it when a sendable climb is seen.
   let lastSpillReported: string | null = null;
@@ -140,6 +148,15 @@ function createDrainLoop(
           continue;
         }
         lastUnresolvedReported = null;
+
+        // A new physical link retires everything we believed about the wall.
+        // In the component this sits BEFORE the connect-initial-send seed so a
+        // connect that DID write its own initialFrames still suppresses the
+        // duplicate; here (no seed modelled) it just clears the dedup.
+        if (connectionChangedPending) {
+          connectionChangedPending = false;
+          lastSentSignature = null;
+        }
 
         // Honour a pending reassert when the climb is picked up (survives an
         // in-flight write that re-set the signature on completion).
@@ -216,6 +233,22 @@ function createDrainLoop(
       // signature when it picks the climb up (mirrors the component, and
       // survives an in-flight write).
       reassertPending = true;
+      if (!lastEnqueuedItem) return;
+      const item = lastEnqueuedItem;
+      if (isWriting) {
+        pendingClimb = item;
+        return;
+      }
+      isWriting = true;
+      void drain(item);
+    },
+
+    newConnectionGeneration() {
+      if (abortController.signal.aborted) return;
+      // Mirrors the component: the prop change flags a pending link change and
+      // re-drives the drain via the effect's connectionGeneration dep, so the
+      // current climb is re-sent even though nothing about it changed.
+      connectionChangedPending = true;
       if (!lastEnqueuedItem) return;
       const item = lastEnqueuedItem;
       if (isWriting) {
@@ -444,6 +477,62 @@ describe('BluetoothAutoSender drain loop', () => {
       await loop.flush();
 
       // The reasserted climb re-fires after the in-flight write completed.
+      loop.resolveCurrentWrite();
+      await loop.flush();
+
+      expect(loop.sendCallCount()).toBe(2);
+      expect(loop.sentUuids()).toEqual(['climb-A', 'climb-A']);
+    });
+  });
+
+  describe('new connection generation (relight after a link change — #4413)', () => {
+    it('re-sends the unchanged current climb over a brand-new link', async () => {
+      const loop = createDrainLoop('instant');
+
+      loop.enqueue(makeQueueItem('climb-A', 'p1r15'));
+      await loop.flush();
+      expect(loop.sendCallCount()).toBe(1);
+
+      // A connect that lands while the app already renders `isConnected` never
+      // remounts the sender, so without the generation bump nothing here would
+      // re-drive the loop and the wall would keep whatever it was left showing.
+      loop.newConnectionGeneration();
+      await loop.flush();
+
+      expect(loop.sendCallCount()).toBe(2);
+      expect(loop.sentUuids()).toEqual(['climb-A', 'climb-A']);
+    });
+
+    it('resumes deduping byte-identical broadcasts on the same link', async () => {
+      const loop = createDrainLoop('instant');
+
+      loop.enqueue(makeQueueItem('climb-A', 'p1r15'));
+      await loop.flush();
+
+      loop.newConnectionGeneration();
+      await loop.flush();
+      expect(loop.sendCallCount()).toBe(2);
+
+      // One-shot: no further link change, so the re-broadcast is suppressed
+      // again and the success haptic doesn't double-fire.
+      loop.enqueue(makeQueueItem('climb-A', 'p1r15'));
+      await loop.flush();
+      expect(loop.sendCallCount()).toBe(2);
+    });
+
+    it('re-pushes after the in-flight write completes when the link changes mid-write', async () => {
+      const loop = createDrainLoop('deferred');
+
+      loop.enqueue(makeQueueItem('climb-A', 'p1r15'));
+      expect(loop.sendCallCount()).toBe(1);
+
+      // The link is replaced while the previous write is still hanging. The
+      // completing write re-sets the dedup signature, so the flag has to be
+      // consumed on pickup rather than at request time.
+      loop.newConnectionGeneration();
+
+      loop.resolveCurrentWrite();
+      await loop.flush();
       loop.resolveCurrentWrite();
       await loop.flush();
 

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -608,6 +608,91 @@ describe('BluetoothProvider wall-confirm integration', () => {
     expect(bluetooth.state.connectInitialSendRef.current).toBeNull();
   });
 
+  it('re-lights the unchanged climb when a new link opens with no rendered disconnect (#4413)', async () => {
+    // The reported shape: the app already renders `isConnected`, so a connect
+    // that completes flips nothing, the AutoSender is never remounted, and its
+    // dedup still claims this climb is up there. On iOS the native
+    // BoardBleManager has meanwhile relit — or, with no App-Group queue state,
+    // CLEARED — the wall at connection-ready, so JS has to write again.
+    renderProvider();
+
+    await waitFor(() => {
+      expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      bluetooth.options?.onConnectSuccess?.(null, makeConnectionHandle(2));
+    });
+
+    await waitFor(() => {
+      expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledTimes(2);
+    });
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenNthCalledWith(
+      2,
+      'p1r12',
+      false,
+      expect.any(AbortSignal),
+      expect.objectContaining({ sendSource: 'auto' }),
+    );
+
+    // Still the same link, so the sender settles back into dedup.
+    await act(async () => {
+      bluetooth.options?.onConnectSuccess?.(null, makeConnectionHandle(2));
+    });
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps suppressing the duplicate when the new link wrote the climb itself', async () => {
+    // A reconnect that DID carry initialFrames already put these frames on the
+    // wall, so the link change must not cost a redundant full-frame write plus
+    // a second success haptic. The seed block runs after the link-change reset,
+    // which is why that reset clears the signature rather than forcing a write.
+    renderProvider();
+
+    await waitFor(() => {
+      expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledTimes(1);
+    });
+
+    bluetooth.state.connectInitialSendRef.current = { frames: 'p1r12', mirrored: false, colorSignature: 'default' };
+    await act(async () => {
+      bluetooth.options?.onConnectSuccess?.(null, makeConnectionHandle(2));
+    });
+
+    await waitFor(() => {
+      expect(bluetooth.state.connectInitialSendRef.current).toBeNull();
+    });
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledTimes(1);
+  });
+
+  it('records the suppressed re-broadcast so a stuck dedup is visible in analytics', async () => {
+    const firstItem = makeQueueItem('climb-1');
+    queue.currentClimbQueueItem = firstItem;
+    const { rerender } = renderProvider();
+
+    await waitFor(() => {
+      expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledTimes(1);
+    });
+
+    queue.currentClimbQueueItem = { ...firstItem };
+    rerender(
+      createElement(BluetoothProvider, {
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,20',
+        children: createElement('div', null),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(analytics.track).toHaveBeenCalledWith(
+        'Climb Sent to Board Skipped',
+        expect.objectContaining({ skipReason: 'dedup', climbUuid: 'climb-1', wallConfirmed: true }),
+      );
+    });
+    expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps the local wall confirm in solo mode without sending a session mutation', async () => {
     queue.sessionId = null;
 

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -682,6 +682,12 @@ export function BluetoothProvider({
   // rendered `isConnected` flag, which a connect that starts while the app
   // already believes it is connected never flips — so without this the sender's
   // "already on the wall" caches would outlive the link they describe.
+  //
+  // 0 is the "no link yet" sentinel and is never a real generation: the hook
+  // hands out `nextConnectionGenerationRef.current + 1`, so the first connect is
+  // 1. That is asserted in use-board-bluetooth.test.ts — were it ever to start
+  // at 0, the first connect would set the same value back and the drain effect
+  // would not re-fire.
   const [connectionGeneration, setConnectionGeneration] = useState(0);
   const pendingReportSignatureRef = useRef<string | null>(null);
   const pendingWallReportRef = useRef<PendingWallReport | null>(null);

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -201,6 +201,7 @@ function BluetoothAutoSender({
   sendFramesToBoard,
   onWallConfirmed,
   reassertNonce,
+  connectionGeneration,
   connectInitialSendRef,
   lastPhysicalFramesRef,
   colorSignature,
@@ -208,6 +209,7 @@ function BluetoothAutoSender({
   activeConfig,
   onSkipSpillClimb,
   onUnresolvedCurrentClimb,
+  onDuplicateSendSkipped,
 }: {
   sendFramesToBoard: SendFramesToBoard;
   /**
@@ -217,6 +219,12 @@ function BluetoothAutoSender({
    */
   onWallConfirmed: (item: ClimbQueueItem) => void;
   reassertNonce: number;
+  // The physical BLE connection this sender is writing over. The dedup caches
+  // below describe a specific link's wall, so a new link must retire them: a
+  // connect that lands while the app already believed itself connected renders
+  // no isConnected false→true edge, leaves this component mounted, and would
+  // otherwise keep suppressing writes over a board whose LEDs are no longer ours.
+  connectionGeneration: number;
   // One-shot seed: what connect() already wrote as initialFrames, so the
   // freshly mounted AutoSender doesn't repeat a byte-identical first send.
   connectInitialSendRef: React.MutableRefObject<BleConnectInitialSend | null>;
@@ -245,6 +253,11 @@ function BluetoothAutoSender({
   // unresolved-current-climb window without the AutoSender owning analytics/board
   // context. Fired once per queue-item uuid.
   onUnresolvedCurrentClimb: (item: ClimbQueueItem) => void;
+  // Called when a re-broadcast was suppressed because the wall already shows
+  // these exact frames. The only suppression that emitted nothing at all, which
+  // is why a stuck dedup was invisible in analytics (#4413). `wallConfirmed`
+  // records whether the physical-frames check let the confirm through.
+  onDuplicateSendSkipped: (item: ClimbQueueItem, wallConfirmed: boolean) => void;
 }) {
   type AutoSendRequest = {
     item: ClimbQueueItem;
@@ -274,6 +287,10 @@ function BluetoothAutoSender({
   useEffect(() => {
     onUnresolvedCurrentClimbRef.current = onUnresolvedCurrentClimb;
   }, [onUnresolvedCurrentClimb]);
+  const onDuplicateSendSkippedRef = useRef(onDuplicateSendSkipped);
+  useEffect(() => {
+    onDuplicateSendSkippedRef.current = onDuplicateSendSkipped;
+  }, [onDuplicateSendSkipped]);
   const queueRef = useRef(state.queue);
   queueRef.current = state.queue;
   // Dedup spill reports: the async drain can re-enter for the same incompatible
@@ -305,6 +322,14 @@ function BluetoothAutoSender({
   // signature, and clearing it again at the top of the next loop iteration is
   // what actually forces the re-push.
   const reassertPendingRef = useRef(false);
+  // Last connection generation acted on. Initialised from the prop so a first
+  // mount is NOT treated as a link change — that would clear the connect-initial
+  // -send seed and repeat connect()'s write (plus its success haptic).
+  const lastConnectionGenerationRef = useRef(connectionGeneration);
+  // Set when a new physical link is seen, consumed inside the drain loop (same
+  // shape as reassertPendingRef, for the same reason: a link change landing
+  // *during* an in-flight write must survive that write re-setting the caches).
+  const connectionChangedPendingRef = useRef(false);
 
   // Single AbortController scoped to the AutoSender's lifetime. Aborted
   // exactly once on unmount so the in-flight drain loop cancels the
@@ -331,6 +356,16 @@ function BluetoothAutoSender({
     if (reassertNonce !== lastReassertNonceRef.current) {
       lastReassertNonceRef.current = reassertNonce;
       reassertPendingRef.current = true;
+    }
+
+    // A new physical link means the wall's contents are unknown to us: the box
+    // may have been taken over and re-lit by another climber, and on iOS the
+    // native BoardBleManager relights from App-Group state at connection-ready.
+    // Retire the dedup caches so the current climb is written again rather than
+    // suppressed as "already up there".
+    if (connectionGeneration !== lastConnectionGenerationRef.current) {
+      lastConnectionGenerationRef.current = connectionGeneration;
+      connectionChangedPendingRef.current = true;
     }
 
     const sendRequest: AutoSendRequest = {
@@ -412,6 +447,20 @@ function BluetoothAutoSender({
           }
           lastUnresolvedReportedUuidRef.current = null;
 
+          // A link change retires everything we believed about the wall. Placed
+          // BEFORE the seed block on purpose: the seed needs
+          // `lastSentSignatureRef.current === null`, so clearing here keeps a
+          // connect that DID write initialFrames suppressing its own duplicate
+          // (and its second haptic), while a connect that wrote nothing still
+          // gets a real write. lastPhysicalFramesRef goes too — across a new
+          // link the wall's contents are unknown, and the dedup branch below
+          // must not report a phantom climb to board presence over a dark wall.
+          if (connectionChangedPendingRef.current) {
+            connectionChangedPendingRef.current = false;
+            lastSentSignatureRef.current = null;
+            lastPhysicalFramesRef.current = null;
+          }
+
           // connect() may have just written these exact frames as its
           // initialFrames (connect-and-light flows like the play drawer).
           // Seed the dedup signature so this freshly mounted AutoSender
@@ -455,9 +504,12 @@ function BluetoothAutoSender({
             // but only CONFIRM it if the wall still physically shows these frames.
             // A relight/undo may have changed the wall out from under us, in which
             // case confirming here would report a climb that isn't lit (a phantom).
-            if (physicalFramesSignature(item.climb.frames, !!item.climb.mirrored) === lastPhysicalFramesRef.current) {
+            const wallConfirmed =
+              physicalFramesSignature(item.climb.frames, !!item.climb.mirrored) === lastPhysicalFramesRef.current;
+            if (wallConfirmed) {
               onWallConfirmedRef.current(item);
             }
+            onDuplicateSendSkippedRef.current(item, wallConfirmed);
             toSend = pendingSendRef.current;
             pendingSendRef.current = null;
             continue;
@@ -499,7 +551,17 @@ function BluetoothAutoSender({
     };
 
     void drain();
-  }, [currentClimbQueueItem, sendFramesToBoard, reassertNonce, colorSignature, encodingSignature]);
+    // connectionGeneration is a dep so a NEW physical link re-drives the drain
+    // even when the current climb never changed — the reconnect-without-a-
+    // rendered-disconnect case, where nothing else in this list moves.
+  }, [
+    currentClimbQueueItem,
+    sendFramesToBoard,
+    reassertNonce,
+    colorSignature,
+    encodingSignature,
+    connectionGeneration,
+  ]);
 
   return null;
 }
@@ -615,6 +677,12 @@ export function BluetoothProvider({
   // write path (auto-sender, undo, kiosk relight). Shared with the AutoSender so
   // its dedup-report branch never confirms a queue climb the wall isn't showing.
   const lastPhysicalFramesRef = useRef<string | null>(null);
+  // Monotonic id of the physical BLE link the auto-sender is writing over, fed
+  // from BleConnectionHandle.generation. The auto-sender is mounted on the
+  // rendered `isConnected` flag, which a connect that starts while the app
+  // already believes it is connected never flips — so without this the sender's
+  // "already on the wall" caches would outlive the link they describe.
+  const [connectionGeneration, setConnectionGeneration] = useState(0);
   const pendingReportSignatureRef = useRef<string | null>(null);
   const pendingWallReportRef = useRef<PendingWallReport | null>(null);
   const pendingPresenceResolveRef = useRef(false);
@@ -811,6 +879,12 @@ export function BluetoothProvider({
 
   const handleConnectSuccess = useCallback(
     (serial: string | null, connection: BleConnectionHandle) => {
+      // Publish the new physical link to the auto-sender. Called on BOTH
+      // generation-creating paths (connect() and the iOS native adoption), right
+      // after setIsConnected(true) — so it also fires on a connect that produced
+      // no rendered isConnected edge, which is the case the auto-sender's own
+      // mount/unmount cycle cannot see. Monotonic: never reset on disconnect.
+      setConnectionGeneration(connection.generation);
       lastAcceptedReportSignatureRef.current = null;
       lastAcceptedWallSignatureRef.current = null;
       pendingReportSignatureRef.current = null;
@@ -1439,6 +1513,24 @@ export function BluetoothProvider({
     });
   }, []);
 
+  // The auto-sender suppressed a byte-identical re-broadcast because the wall
+  // already shows these frames. Until now this was the one suppression that
+  // emitted nothing, so a dedup stuck over a wall someone else had taken looked
+  // exactly like "no send was ever requested" in analytics (#4413).
+  // `wallConfirmed` false means we skipped the write AND withheld the confirm —
+  // i.e. we believe the wall no longer shows this climb.
+  const handleDuplicateSendSkipped = useCallback((item: ClimbQueueItem, wallConfirmed: boolean) => {
+    track(SHARED_EVENTS.ClimbSentToBoardSkipped, {
+      skipReason: 'dedup',
+      boardName: boardNameRef.current,
+      layoutId: layoutIdRef.current,
+      sizeId: sizeIdRef.current,
+      climbUuid: item.climb.uuid,
+      wallConfirmed,
+      inSession: sessionIdRef.current != null,
+    });
+  }, []);
+
   // Bumped by `reassertWall()` to force the auto-sender to re-push the current
   // climb once, bypassing the byte-identical dedup.
   const [reassertNonce, setReassertNonce] = useState(0);
@@ -1598,6 +1690,7 @@ export function BluetoothProvider({
             sendFramesToBoard={sendFramesToBoardWithActivityReset}
             onWallConfirmed={handleWallConfirmed}
             reassertNonce={reassertNonce}
+            connectionGeneration={connectionGeneration}
             connectInitialSendRef={connectInitialSendRef}
             lastPhysicalFramesRef={lastPhysicalFramesRef}
             colorSignature={holdColorSignature}
@@ -1605,6 +1698,7 @@ export function BluetoothProvider({
             activeConfig={currentBoardConfig}
             onSkipSpillClimb={handleSkipSpillClimb}
             onUnresolvedCurrentClimb={handleUnresolvedCurrentClimb}
+            onDuplicateSendSkipped={handleDuplicateSendSkipped}
           />
         )}
         <BlePickerHostContext.Provider value={pickerHostValue}>{children}</BlePickerHostContext.Provider>


### PR DESCRIPTION
## Summary

**On iOS, the native BLE layer writes a clear-all packet to the board on essentially every connect — for roughly 84% of our iOS Bluetooth climbers.** `BoardBleManager.displaySharedCurrentItemOnBleQueue()` paints the queue + current index held in the App Group, and when that copy is empty it falls through to `clearBoardOnBleQueue()`. The copy is only ever written while a Live Activity is running, and Live Activities only run for explicitly started sessions (`LiveActivityBridge` passes `isSessionActive: sessionId !== null` — "a solo queue never raises the lock-screen widget"). PostHog, 60 days: 1761 distinct people fired `Bluetooth Connection Success` on iOS; only 281 of them ever fired `Live Activity Started`.

It usually goes unnoticed because the JS auto-sender repaints over the clear a microtask later. #4413 is the case where nothing repaints: when a connect completes while the app already renders `isConnected === true`, there is no `false → true` edge, `{isConnected && <BluetoothAutoSender …>}` never remounts, nothing in its effect deps moves, and the native clear is the last thing the board hears. That is exactly what native's two "already connected" early-return branches do — clear the wall and return success. It also explains the reported workaround: swiping right then left mints a different current climb, which moves the effect deps and forces a fresh write over the top of the clear.

Two changes, both JS, so this ships over the air to phones already running the store build:

1. **Mirror the App-Group queue state on iOS whether or not a Live Activity is running** (`use-live-activity.ts`). The native relight then paints the current climb instead of clearing. The ActivityKit push that rides along is a verified no-op with no activity — `LiveActivityManager.updateActivity` returns early on `currentActivity == nil`. Android stays gated on a real session: every Android board write goes through JS, so there is no native relight to feed, and pushing without a session would put a foreground-service notification in front of a solo queue. Because `endSession` wipes the App-Group keys, the mirror re-publishes once on the active → inactive transition.

2. **Retire the auto-sender's "already on the wall" caches on every new physical link.** `BleConnectionHandle.generation` is already handed to the provider on both generation-creating paths (`connect()` and the iOS native adoption), so it becomes `connectionGeneration` state, a prop, and an effect dep. On a change the drain loop clears `lastSentSignatureRef` *and* `lastPhysicalFramesRef` — placed before the connect-initial-send seed, so a connect that genuinely wrote its own `initialFrames` still suppresses the duplicate write and its second haptic, while a reconnect that wrote nothing gets a real write. `lastPhysicalFramesRef` matters independently: without the reset the dedup branch could report a phantom "on the wall" to board presence over a dark wall.

Also in here, both small:

- `connectInitialSendRef` is now cleared in `clearConnectionAfterDrop` and `teardownConnection`, so a seed set by one generation can never be consumed by the next one's first drain.
- The dedup branch emits `Climb Sent to Board Skipped` with `skipReason: 'dedup'` and a `wallConfirmed` property. It was the one suppression that emitted nothing at all, which is why a dedup stuck over a wall someone else had taken was invisible in analytics (7 `Skipped` events across all reasons in 60 days).

`ble-needs-fable-review` — per CLAUDE.md this touches Bluetooth and needs a Fable review before merge. **Not auto-mergeable.**

**What I could not verify without hardware:** that the reporters' specific black wall was this clear rather than the board's own behaviour on displacement. The mechanism, its reach, and the fact that it fires on every iOS connect are all established from the code and from telemetry; two phones on a real Aurora box are still the only way to close that last gap.

**Deliberately not fixed here:** the correct native invariant is that `displaySharedCurrentItemOnBleQueue` should never clear — absence of shared state should mean "leave the wall alone". That is a change under `packages/mobile/modules/live-activity/ios/`, which moves the Expo fingerprint and would make this un-mergeable to main. Tracked in #4544.

**What this does when there is no current climb**, since the mirror can only publish an item it has. Two sub-cases, and only one of them is still a clear:

- **Never had a queue this install** (fresh install, or a board just selected with nothing picked yet) — the App-Group copy is still absent, so a connect still clears the wall. Unchanged from today, and it needs the native invariant to fix, so it belongs to #4544. Low stakes on its own: with no current climb the JS side has nothing to light either, so the alternative is a wall showing the previous climber's problem.
- **Had a queue, then emptied it** — the sync effect fires but finds no item to publish and returns, so the copy keeps the last climb and a connect relights *that* rather than clearing. Asserted in `leaves the previous copy alone when the queue empties`.

**Write cadence.** The mirror now runs for every iOS climber rather than only during a session, so it had to stay one App-Group write per real change, not one per render. Every dependency of both sync effects is stable by value (`serializedQueue` is memoised on the reducer-owned array; the rest are strings, booleans, and the memoised `stableBoard`), and `does not churn the App Group on re-renders that change nothing` pins it: five identical re-renders produce exactly one write. The failed-start case asserts an exact count of two as well.

Full investigation, including everything that was ruled out and with what evidence, is in [this comment on #4413](https://github.com/boardsesh/boardsesh/issues/4413#issuecomment-5341800554).

Closes #4413

## Release Notes

- Your climb stays lit when you reconnect to the board — no more black wall after someone else takes a turn between your goes.

## Test plan

- [x] `vp run typecheck:mobile`
- [x] `vp run typecheck` (full)
- [x] `vp check`
- [x] `vp run test:mobile` — 6555 passing, rebased on `main`. One unrelated timeout in `web-public-assets-are-web-only.test.ts`, a filesystem-scanning test that tripped its 5s budget while a full `next build` was running alongside it; it passes in 3.2s on its own and nothing in this diff touches `packages/mobile/public`.
- [x] `vp run check:mobile-bundle`

New coverage:

- `use-live-activity-shared-queue-mirror.test.tsx` (new, iOS) — publishes queue + index with no session without starting an Activity; publishes the new index on climb navigation; still publishes when Live Activities are unavailable (a climber who denied them in Settings still connects over BLE); no publish before a board is selected; the empty-queue gap is asserted as documented behaviour and pointed at #4544; re-publishes after a session ends; and five identical re-renders produce exactly one write, so the mirror costs one App-Group write per real queue/navigation change rather than one per render.
- `use-live-activity.test.tsx` — Android gate: nothing is pushed to the session-presence surface without an active session.
- `bluetooth-auto-sender.test.ts` — the pure drain-loop model gains `newConnectionGeneration()`: re-sends the unchanged climb over a new link, resumes deduping on the same link, and survives a link change landing mid-write.
- `use-board-bluetooth.test.ts` — connection generations are numbered from 1, so `BluetoothProvider`'s `0` stays a "no link yet" sentinel that a first connect always moves off.
- `bluetooth-provider-wall-confirm.test.tsx` — over the real provider: a new generation with `isConnected` held true produces a second `sendFramesToBoard` with the same frames and only one per link change; a new link that carried `initialFrames` still suppresses the duplicate; the dedup skip is recorded in analytics.

Not automatable — needs two phones and a real Aurora box:

- Phone A connects and lights climb 1. Phone B connects, displacing A. A reconnects via the lightbulb without changing the climb: the wall must re-light with no swipe.
- Same, with A's app still showing "connected" when B takes over.
- Connect-and-light from the play drawer: exactly one write and one success haptic, not two.
- A solo iOS climber (no session at all) connecting to a board that another climber left lit: the wall should now show their current climb rather than going dark.
