### PR TITLE
fix(mobile): [native-train] stop a stale BLE connect re-lighting the board on arrival

### DIFF
--- a/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
+++ b/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
@@ -1174,7 +1174,8 @@ final class BoardBleDisconnectTests: XCTestCase {
             manager.write(data: Data([0x01])) { _, _ in }
         }
         fireLatestOneShot(label: "writeAckWatchdog")
-        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.rewindWriteStallRecovery(by: 3 * 86_400) })
+        let threeDays: TimeInterval = 3 * 86_400
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.rewindWriteStallRecovery(by: threeDays) })
 
         // The user taps the board in the picker while the stall is still parked.
         manager.testHooks.sync {

--- a/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
+++ b/packages/mobile/ios-tests/BoardBleDisconnectTests.swift
@@ -1116,4 +1116,78 @@ final class BoardBleDisconnectTests: XCTestCase {
         manager.testHooks.fireDidDisconnect(peripheral: recoveringPeripheral, error: nil)
         XCTAssertEqual(connectedPeripheralIds, [winningPeripheral.identifier])
     }
+
+    /// The phone suspended between the stall's cancel and its `didDisconnect`.
+    /// Both watchdogs bounding that gap are GCD work items that thaw alongside
+    /// the callback, so the arriving disconnect must be judged by the STALL's
+    /// wall clock. A recovery that old is abandoned outright rather than
+    /// reconnected: these boards are last-connection-wins, so grabbing the link
+    /// back days later takes the wall from whoever is on it now (#4499).
+    func testStaleWriteStallRecoveryDoesNotStealTheBoardBack() {
+        let peripheral = FakeWritablePeripheral()
+        var disconnectEvents: [(String, [String: Any]?)] = []
+        installConnection(peripheral: peripheral) { deviceId, body in
+            disconnectEvents.append((deviceId, body))
+        }
+
+        manager.testHooks.sync {
+            manager.write(data: Data([0x01])) { _, _ in }
+        }
+        fireLatestOneShot(label: "writeAckWatchdog")
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.writeStallRecoveringPeripheralId },
+            peripheral.identifier
+        )
+        XCTAssertTrue(connectedPeripheralIds.isEmpty)
+
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.rewindWriteStallRecovery(by: 3600) })
+
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+
+        // Nothing was grabbed.
+        XCTAssertTrue(connectedPeripheralIds.isEmpty)
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.writeStallRecoveringPeripheralId })
+        XCTAssertEqual(manager.testHooks.sync { manager.testHooks.writeStallRecoveries }, 0)
+        XCTAssertFalse(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+
+        // JS hears about it, so the lightbulb reflects a dark wall.
+        XCTAssertEqual(disconnectEvents.count, 1)
+        XCTAssertEqual(disconnectEvents.first?.0, peripheral.identifier.uuidString)
+        XCTAssertEqual(
+            disconnectEvents.first?.1?["context"] as? String,
+            "write_stall_recovery_stale"
+        )
+    }
+
+    /// The staleness guard lives in the recovery arm on purpose, so a queued
+    /// USER connect still wins the barrier no matter how old the stall is — a
+    /// human asked for that one. This fails if the check is ever hoisted to the
+    /// top of consumeManagerCancellationBarrierOnBleQueue.
+    func testStaleWriteStallStillHonoursAQueuedUserConnect() {
+        let peripheral = FakeWritablePeripheral()
+        var disconnectEvents: [(String, [String: Any]?)] = []
+        installConnection(peripheral: peripheral) { deviceId, body in
+            disconnectEvents.append((deviceId, body))
+        }
+
+        manager.testHooks.sync {
+            manager.write(data: Data([0x01])) { _, _ in }
+        }
+        fireLatestOneShot(label: "writeAckWatchdog")
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.rewindWriteStallRecovery(by: 3 * 86_400) })
+
+        // The user taps the board in the picker while the stall is still parked.
+        manager.testHooks.sync {
+            manager.connect(deviceId: peripheral.identifier.uuidString) { _ in }
+        }
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.deferredConnectPeripheralId },
+            peripheral.identifier
+        )
+
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier])
+        XCTAssertTrue(disconnectEvents.isEmpty)
+    }
 }

--- a/packages/mobile/ios-tests/BoardBleRelightAuthorizationTests.swift
+++ b/packages/mobile/ios-tests/BoardBleRelightAuthorizationTests.swift
@@ -403,6 +403,37 @@ final class BoardBleRelightAuthorizationTests: XCTestCase {
         XCTAssertEqual(suppressions, 1)
     }
 
+    func testUnexpectedDropForgetsWhoAskedSoAConfigureCannotUseADeadLinksAuthorization() {
+        let peripheral = FakeWritablePeripheral()
+        installConnection(peripheral: peripheral)
+        manager.testHooks.sync {
+            manager.testHooks.setConnectRequest(origin: .userConnect, requestedAt: Date())
+        }
+        manager.testHooks.fireConnectionReady(
+            peripheral: peripheral,
+            characteristic: makeWriteCharacteristic()
+        )
+        XCTAssertEqual(attempts, 1)
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.implicitRelightAuthorizedForConnection })
+
+        // The board drops on its own: out of range, powered off at the wall. No
+        // disconnect() call and no write stall, so this reaches the tail of
+        // handleDidDisconnectOnBleQueue rather than the cancellation barrier.
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.connectRequestOrigin })
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.connectRequestedAt })
+        XCTAssertFalse(manager.testHooks.sync { manager.testHooks.implicitRelightAuthorizedForConnection })
+
+        // A background configureBoard landing in the window between the drop and
+        // the next connect must not inherit the dead link's authorization.
+        manager.testHooks.sync {
+            manager.testHooks.configure(moonboardConfiguration(), appActive: false)
+        }
+        XCTAssertEqual(attempts, 1)
+        XCTAssertEqual(suppressions, 1)
+    }
+
     func testBluetoothTurningOffForgetsWhoAsked() {
         let peripheral = FakeWritablePeripheral()
         installConnection(peripheral: peripheral)

--- a/packages/mobile/ios-tests/BoardBleRelightAuthorizationTests.swift
+++ b/packages/mobile/ios-tests/BoardBleRelightAuthorizationTests.swift
@@ -1,0 +1,418 @@
+import CoreBluetooth
+import XCTest
+
+/// Coverage for the implicit re-light gate (#4499): a connect request that
+/// CoreBluetooth honours long after it was made must not repaint the wall from
+/// the persisted shared queue.
+///
+/// `displaySharedCurrentItemOnBleQueue` reads the app-group defaults, which is
+/// exactly the dev-machine leak `setConfiguration` exists to avoid — so every
+/// assertion here is on the manager's own attempt/suppression counters, never on
+/// bytes written to the fake peripheral.
+@available(iOS 17.0, *)
+final class BoardBleRelightAuthorizationTests: XCTestCase {
+    private var scheduler: FakeBleTimerScheduler!
+    private var manager: BoardBleManager!
+    private var cancelledPeripheralIds: [UUID] = []
+    private var connectedPeripheralIds: [UUID] = []
+    private var savedBoardConfigData: Data?
+    private var savedLastPeripheralUuid: String?
+    private let uartWriteCharacteristicUuid = CBUUID(string: "6E400002-B5A3-F393-E0A9-E50E24DCCA9E")
+
+    override func setUp() {
+        super.setUp()
+        // This suite drives `configure()` and the real connection success point,
+        // both of which persist into the app group. Snapshot and restore so a
+        // dev machine's own board config / last board survives the run.
+        savedBoardConfigData = SharedConstants.sharedDefaults?.data(forKey: SharedConstants.bleBoardConfigKey)
+        savedLastPeripheralUuid = SharedConstants.sharedDefaults?
+            .string(forKey: SharedConstants.bleLastPeripheralUuidKey)
+        cancelledPeripheralIds = []
+        connectedPeripheralIds = []
+        scheduler = FakeBleTimerScheduler()
+        manager = BoardBleManager(timerScheduler: scheduler, createCentralManagerEagerly: false)
+        manager.testHooks.sync {
+            manager.testHooks.setConfiguration(nil)
+            manager.testHooks.setStopScanOverride {}
+            manager.testHooks.setCancelPeripheralConnectionOverride { [weak self] peripheral in
+                self?.cancelledPeripheralIds.append(peripheral.identifier)
+            }
+            manager.testHooks.setConnectPeripheralOverride { [weak self] peripheral in
+                self?.connectedPeripheralIds.append(peripheral.identifier)
+            }
+            manager.testHooks.setCentralState(.poweredOn)
+        }
+    }
+
+    override func tearDown() {
+        manager.testHooks.sync {
+            manager.testHooks.setStopScanOverride(nil)
+            manager.testHooks.setCancelPeripheralConnectionOverride(nil)
+            manager.testHooks.setConnectPeripheralOverride(nil)
+            manager.testHooks.setCentralState(nil)
+        }
+        manager = nil
+        scheduler = nil
+        restore(savedBoardConfigData, forKey: SharedConstants.bleBoardConfigKey)
+        restore(savedLastPeripheralUuid, forKey: SharedConstants.bleLastPeripheralUuidKey)
+        super.tearDown()
+    }
+
+    private func restore<Value>(_ value: Value?, forKey key: String) {
+        guard let defaults = SharedConstants.sharedDefaults else { return }
+        if let value {
+            defaults.set(value, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+    }
+
+    private func makeWriteCharacteristic() -> CBMutableCharacteristic {
+        CBMutableCharacteristic(
+            type: uartWriteCharacteristicUuid,
+            properties: .write,
+            value: nil,
+            permissions: [.writeable]
+        )
+    }
+
+    private func moonboardConfiguration() -> BoardBleConfiguration {
+        BoardBleConfiguration(
+            boardName: "moonboard",
+            layoutId: 0,
+            sizeId: 0,
+            apiLevel: nil,
+            deviceName: nil,
+            colorOverrides: [:],
+            numRows: nil
+        )
+    }
+
+    private func installConnection(peripheral: FakeWritablePeripheral) {
+        manager.testHooks.sync {
+            manager.testHooks.setConfiguration(moonboardConfiguration())
+            manager.testHooks.setConnection(
+                peripheral: peripheral,
+                characteristic: makeWriteCharacteristic()
+            )
+        }
+    }
+
+    private func fireLatestOneShot(label: String) {
+        manager.testHooks.sync {
+            guard let timer = scheduler.lastOneShot(label: label) else {
+                XCTFail("expected a scheduled \(label) timer")
+                return
+            }
+            timer.fire()
+        }
+    }
+
+    private var attempts: Int { manager.testHooks.sync { manager.testHooks.implicitRelightAttempts } }
+    private var suppressions: Int { manager.testHooks.sync { manager.testHooks.implicitRelightSuppressions } }
+
+    // MARK: - The pure decision
+
+    func testRelightDecisionMatrixAcrossOriginsAndAges() {
+        let now = Date()
+        let maxAge: TimeInterval = 120
+        let authorizedOrigins: [BoardBleConnectOrigin] = [.userConnect, .liveActivityIntent, .writeStallRecovery]
+
+        for origin in authorizedOrigins {
+            // Fresh, and exactly on the bound, are both honoured.
+            for age in [0, 1, maxAge] as [TimeInterval] {
+                XCTAssertTrue(
+                    BoardBleManager.shouldPerformImplicitRelight(
+                        origin: origin,
+                        requestedAt: now.addingTimeInterval(-age),
+                        now: now,
+                        maxRequestAge: maxAge
+                    ),
+                    "\(origin.rawValue) at age \(age) should authorise a re-light"
+                )
+            }
+            // Past the bound, and a backwards clock jump, both fail closed.
+            for age in [maxAge + 0.001, 3600, 86_400 * 3, -1] as [TimeInterval] {
+                XCTAssertFalse(
+                    BoardBleManager.shouldPerformImplicitRelight(
+                        origin: origin,
+                        requestedAt: now.addingTimeInterval(-age),
+                        now: now,
+                        maxRequestAge: maxAge
+                    ),
+                    "\(origin.rawValue) at age \(age) should not authorise a re-light"
+                )
+            }
+            // A missing stamp is unknowable, so it fails closed too.
+            XCTAssertFalse(
+                BoardBleManager.shouldPerformImplicitRelight(
+                    origin: origin,
+                    requestedAt: nil,
+                    now: now,
+                    maxRequestAge: maxAge
+                )
+            )
+        }
+
+        // A restored link is never authorised, at any age.
+        for age in [0, 1, maxAge, maxAge + 1] as [TimeInterval] {
+            XCTAssertFalse(
+                BoardBleManager.shouldPerformImplicitRelight(
+                    origin: .restored,
+                    requestedAt: now.addingTimeInterval(-age),
+                    now: now,
+                    maxRequestAge: maxAge
+                )
+            )
+        }
+
+        // No origin at all — the state a disconnect leaves behind.
+        XCTAssertFalse(
+            BoardBleManager.shouldPerformImplicitRelight(
+                origin: nil,
+                requestedAt: now,
+                now: now,
+                maxRequestAge: maxAge
+            )
+        )
+    }
+
+    func testConfiguredMaxRequestAgeIsTheDocumentedTwoMinutes() {
+        XCTAssertEqual(manager.testHooks.sync { manager.testHooks.implicitRelightMaxRequestAge }, 120)
+    }
+
+    // MARK: - The connect paths
+
+    func testFreshUserConnectRelightsOnce() {
+        let peripheral = FakeWritablePeripheral()
+        manager.testHooks.sync {
+            manager.testHooks.setConfiguration(moonboardConfiguration())
+            manager.testHooks.setDiscoveredPeripheral(peripheral)
+            manager.connect(deviceId: peripheral.identifier.uuidString) { _ in }
+        }
+
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.connectRequestOrigin },
+            BoardBleConnectOrigin.userConnect
+        )
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier])
+
+        manager.testHooks.fireConnectionReady(
+            peripheral: peripheral,
+            characteristic: makeWriteCharacteristic()
+        )
+
+        XCTAssertEqual(attempts, 1)
+        XCTAssertEqual(suppressions, 0)
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.implicitRelightAuthorizedForConnection })
+    }
+
+    func testFreshWriteStallRecoveryStillRelights() {
+        let peripheral = FakeWritablePeripheral()
+        installConnection(peripheral: peripheral)
+
+        manager.testHooks.sync { manager.write(data: Data([0x01])) { _, _ in } }
+        fireLatestOneShot(label: "writeAckWatchdog")
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier])
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.connectRequestOrigin },
+            BoardBleConnectOrigin.writeStallRecovery
+        )
+
+        manager.testHooks.fireConnectionReady(
+            peripheral: peripheral,
+            characteristic: makeWriteCharacteristic()
+        )
+
+        // The #3181 regression guard: an unwedged link repaints the wall.
+        XCTAssertEqual(attempts, 1)
+        XCTAssertEqual(suppressions, 0)
+    }
+
+    func testStaleWriteStallRecoveryIsSuppressedButKeepsTheLink() {
+        let peripheral = FakeWritablePeripheral()
+        var connectedEvents: [String] = []
+        installConnection(peripheral: peripheral)
+        manager.testHooks.sync {
+            manager.setEventHandlers(
+                onScanResult: nil,
+                onDisconnect: nil,
+                onConnected: { deviceId, _ in connectedEvents.append(deviceId) }
+            )
+            manager.write(data: Data([0x01])) { _, _ in }
+        }
+        fireLatestOneShot(label: "writeAckWatchdog")
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+
+        // The phone suspended inside the connect window; CoreBluetooth honours
+        // the request an hour later, when the board is back in range.
+        manager.testHooks.sync {
+            manager.testHooks.setConnectRequest(
+                origin: .writeStallRecovery,
+                requestedAt: Date(timeIntervalSinceNow: -3600)
+            )
+        }
+        let cancelsBeforeReady = cancelledPeripheralIds.count
+
+        manager.testHooks.fireConnectionReady(
+            peripheral: peripheral,
+            characteristic: makeWriteCharacteristic()
+        )
+
+        XCTAssertEqual(attempts, 0)
+        XCTAssertEqual(suppressions, 1)
+        XCTAssertFalse(manager.testHooks.sync { manager.testHooks.implicitRelightAuthorizedForConnection })
+        // The link is kept, not reversed: the pending connect settles, JS still
+        // hears about it, and nothing is cancelled.
+        XCTAssertFalse(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.writeStallRecoveringPeripheralId })
+        XCTAssertEqual(connectedEvents, [peripheral.identifier.uuidString])
+        XCTAssertEqual(cancelledPeripheralIds.count, cancelsBeforeReady)
+        XCTAssertEqual(manager.connectedDeviceId, peripheral.identifier.uuidString)
+    }
+
+    func testRestoredConnectionIsSuppressedAndRetained() {
+        let peripheral = FakeWritablePeripheral()
+        var connectedEvents: [String] = []
+        manager.testHooks.sync {
+            manager.testHooks.setConfiguration(moonboardConfiguration())
+            manager.setEventHandlers(
+                onScanResult: nil,
+                onDisconnect: nil,
+                onConnected: { deviceId, _ in connectedEvents.append(deviceId) }
+            )
+            manager.testHooks.setConnectRequest(origin: .restored, requestedAt: nil)
+        }
+
+        manager.testHooks.fireConnectionReady(
+            peripheral: peripheral,
+            characteristic: makeWriteCharacteristic()
+        )
+
+        XCTAssertEqual(attempts, 0)
+        XCTAssertEqual(suppressions, 1)
+        XCTAssertEqual(connectedEvents, [peripheral.identifier.uuidString])
+        XCTAssertEqual(manager.connectedDeviceId, peripheral.identifier.uuidString)
+        XCTAssertTrue(cancelledPeripheralIds.isEmpty)
+    }
+
+    func testLiveActivityReconnectOnAnAlreadyLiveLinkRelights() {
+        let peripheral = FakeWritablePeripheral()
+        var reconnectResults: [Result<Void, Error>] = []
+        installConnection(peripheral: peripheral)
+
+        manager.testHooks.sync {
+            manager.reconnectToLastKnownBoard(origin: .liveActivityIntent) { reconnectResults.append($0) }
+        }
+
+        XCTAssertEqual(reconnectResults.count, 1)
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.connectRequestOrigin },
+            BoardBleConnectOrigin.liveActivityIntent
+        )
+        XCTAssertEqual(attempts, 1)
+        XCTAssertEqual(suppressions, 0)
+    }
+
+    // MARK: - configureBoard
+
+    func testForegroundConfigureRelightsEvenOnASuppressedConnection() {
+        let peripheral = FakeWritablePeripheral()
+        installConnection(peripheral: peripheral)
+        manager.testHooks.sync {
+            manager.testHooks.setConnectRequest(origin: .restored, requestedAt: nil)
+        }
+        manager.testHooks.fireConnectionReady(
+            peripheral: peripheral,
+            characteristic: makeWriteCharacteristic()
+        )
+        XCTAssertEqual(attempts, 0)
+
+        // The user opened the app on the restored link and changed a colour.
+        manager.testHooks.sync {
+            manager.testHooks.configure(moonboardConfiguration(), appActive: true)
+        }
+
+        XCTAssertEqual(attempts, 1)
+    }
+
+    func testBackgroundConfigureIsSuppressedOnASuppressedConnection() {
+        let peripheral = FakeWritablePeripheral()
+        installConnection(peripheral: peripheral)
+        manager.testHooks.sync {
+            manager.testHooks.setConnectRequest(origin: .restored, requestedAt: nil)
+        }
+        manager.testHooks.fireConnectionReady(
+            peripheral: peripheral,
+            characteristic: makeWriteCharacteristic()
+        )
+        let suppressionsAfterConnect = suppressions
+
+        // A background BLE wake booted React Native, which adopted the
+        // connection and pushed its config.
+        manager.testHooks.sync {
+            manager.testHooks.configure(moonboardConfiguration(), appActive: false)
+        }
+
+        XCTAssertEqual(attempts, 0)
+        XCTAssertEqual(suppressions, suppressionsAfterConnect + 1)
+    }
+
+    func testBackgroundConfigureStillRelightsAnAuthorizedConnection() {
+        let peripheral = FakeWritablePeripheral()
+        installConnection(peripheral: peripheral)
+        manager.testHooks.sync {
+            manager.testHooks.setConnectRequest(origin: .liveActivityIntent, requestedAt: Date())
+        }
+        manager.testHooks.fireConnectionReady(
+            peripheral: peripheral,
+            characteristic: makeWriteCharacteristic()
+        )
+        XCTAssertEqual(attempts, 1)
+
+        // The lightbulb reconnect JS adopts while still backgrounded.
+        manager.testHooks.sync {
+            manager.testHooks.configure(moonboardConfiguration(), appActive: false)
+        }
+
+        XCTAssertEqual(attempts, 2)
+    }
+
+    // MARK: - Provenance lifecycle
+
+    func testDisconnectForgetsWhoAskedSoALaterConnectCannotInheritIt() {
+        let peripheral = FakeWritablePeripheral()
+        installConnection(peripheral: peripheral)
+        manager.testHooks.sync {
+            manager.testHooks.setConnectRequest(origin: .userConnect, requestedAt: Date())
+            manager.disconnect()
+        }
+
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.connectRequestOrigin })
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.connectRequestedAt })
+
+        manager.testHooks.fireConnectionReady(
+            peripheral: peripheral,
+            characteristic: makeWriteCharacteristic()
+        )
+
+        XCTAssertEqual(attempts, 0)
+        XCTAssertEqual(suppressions, 1)
+    }
+
+    func testBluetoothTurningOffForgetsWhoAsked() {
+        let peripheral = FakeWritablePeripheral()
+        installConnection(peripheral: peripheral)
+        manager.testHooks.sync {
+            manager.testHooks.setConnectRequest(origin: .userConnect, requestedAt: Date())
+        }
+
+        manager.testHooks.fireCentralStateUpdate(.poweredOff)
+
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.connectRequestOrigin })
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.connectRequestedAt })
+    }
+}

--- a/packages/mobile/ios-tests/BoardBleRelightAuthorizationTests.swift
+++ b/packages/mobile/ios-tests/BoardBleRelightAuthorizationTests.swift
@@ -181,6 +181,45 @@ final class BoardBleRelightAuthorizationTests: XCTestCase {
         XCTAssertEqual(manager.testHooks.sync { manager.testHooks.implicitRelightMaxRequestAge }, 120)
     }
 
+    func testWriteStallRecoveryFreshnessMatrix() {
+        let now = Date()
+        let maxAge: TimeInterval = 120
+
+        // Fresh, and exactly on the bound — both still ours to finish. The bound
+        // is inclusive, matching shouldPerformImplicitRelight.
+        for age in [TimeInterval(0), 1, 24, maxAge] {
+            XCTAssertTrue(
+                BoardBleManager.writeStallRecoveryIsFresh(
+                    requestedAt: now.addingTimeInterval(-age),
+                    now: now,
+                    maxRequestAge: maxAge
+                ),
+                "expected a \(age)s-old stall to still be recoverable"
+            )
+        }
+
+        // Past the bound: the suspension case this guard exists for.
+        for age in [maxAge + 0.001, 3600, 86_400 * 3] {
+            XCTAssertFalse(
+                BoardBleManager.writeStallRecoveryIsFresh(
+                    requestedAt: now.addingTimeInterval(-age),
+                    now: now,
+                    maxRequestAge: maxAge
+                ),
+                "expected a \(age)s-old stall to be abandoned"
+            )
+        }
+
+        // Clock moved backwards: the age is unknowable, so fail closed.
+        XCTAssertFalse(
+            BoardBleManager.writeStallRecoveryIsFresh(
+                requestedAt: now.addingTimeInterval(30),
+                now: now,
+                maxRequestAge: maxAge
+            )
+        )
+    }
+
     // MARK: - The connect paths
 
     func testFreshUserConnectRelightsOnce() {
@@ -272,6 +311,138 @@ final class BoardBleRelightAuthorizationTests: XCTestCase {
         XCTAssertEqual(connectedEvents, [peripheral.identifier.uuidString])
         XCTAssertEqual(cancelledPeripheralIds.count, cancelsBeforeReady)
         XCTAssertEqual(manager.connectedDeviceId, peripheral.identifier.uuidString)
+    }
+
+    /// Pins the carry itself, independent of what a stale recovery then does:
+    /// the reconnect must inherit the STALL's stamp, not mint a new one on the
+    /// didDisconnect that triggered it. Fails against the old code, where the
+    /// age at the success point would read ~0 no matter how long the gap was.
+    func testWriteStallReconnectInheritsTheStallsTimestamp() {
+        let peripheral = FakeWritablePeripheral()
+        installConnection(peripheral: peripheral)
+
+        manager.testHooks.sync { manager.write(data: Data([0x01])) { _, _ in } }
+        fireLatestOneShot(label: "writeAckWatchdog")
+        XCTAssertNotNil(manager.testHooks.sync { manager.testHooks.writeStallRecoveryRequestedAt })
+
+        // A gap well inside the budget, so the reconnect still goes out and the
+        // only thing under test is which clock it was stamped with.
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.rewindWriteStallRecovery(by: 60) })
+
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier])
+        guard let requestedAt = manager.testHooks.sync({ manager.testHooks.connectRequestedAt }) else {
+            return XCTFail("expected the reconnect to carry a stamp")
+        }
+        // Loose bound: the assertion is "the stall's clock, not this callback's",
+        // and anything above ~0 can only have come from the carried stamp.
+        XCTAssertGreaterThan(Date().timeIntervalSince(requestedAt), 30)
+    }
+
+    /// The hole the connect-window test above cannot reach: the phone suspends
+    /// between the stall's cancel and its `didDisconnect`. Both watchdogs
+    /// bounding that gap are GCD work items, so they thaw alongside the callback
+    /// rather than expiring during it — which is why the arriving disconnect
+    /// must be judged by the stall's own wall clock and not re-stamped (#4499).
+    func testWriteStallStrandedAcrossASuspensionNeverReconnects() {
+        let peripheral = FakeWritablePeripheral()
+        var disconnectEvents: [(String, [String: Any]?)] = []
+        installConnection(peripheral: peripheral)
+        manager.testHooks.sync {
+            manager.setEventHandlers(
+                onScanResult: nil,
+                onDisconnect: { deviceId, body in disconnectEvents.append((deviceId, body)) },
+                onConnected: nil
+            )
+            manager.write(data: Data([0x01])) { _, _ in }
+        }
+        fireLatestOneShot(label: "writeAckWatchdog")
+
+        // The stall cycled the link and is waiting on didDisconnect.
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.writeStallRecoveringPeripheralId },
+            peripheral.identifier
+        )
+        XCTAssertEqual(cancelledPeripheralIds, [peripheral.identifier])
+        XCTAssertTrue(connectedPeripheralIds.isEmpty)
+
+        // Suspended for an hour. The stamp is the stall's, so rewinding it is
+        // the same thing as the process having been frozen since.
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.rewindWriteStallRecovery(by: 3600) })
+
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+
+        // No reconnect is issued at all — not one that connects and stays quiet.
+        XCTAssertTrue(connectedPeripheralIds.isEmpty)
+        XCTAssertFalse(manager.testHooks.sync { manager.testHooks.hasPendingConnect })
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.writeStallRecoveringPeripheralId })
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.writeStallRecoveryRequestedAt })
+        XCTAssertEqual(manager.testHooks.sync { manager.testHooks.writeStallRecoveries }, 0)
+
+        // And the wall was never repainted.
+        XCTAssertEqual(attempts, 0)
+        XCTAssertEqual(disconnectEvents.count, 1)
+        XCTAssertEqual(
+            disconnectEvents.first?.1?["context"] as? String,
+            "write_stall_recovery_stale"
+        )
+    }
+
+    /// The other side of the bound: a recovery that used its whole budget is
+    /// still the recovery we asked for, and still repaints the wall (#3181).
+    func testWriteStallOnTheFreshnessBoundStillReconnectsAndRelights() {
+        let peripheral = FakeWritablePeripheral()
+        installConnection(peripheral: peripheral)
+
+        manager.testHooks.sync { manager.write(data: Data([0x01])) { _, _ in } }
+        fireLatestOneShot(label: "writeAckWatchdog")
+
+        let maxRequestAge = manager.testHooks.sync { manager.testHooks.implicitRelightMaxRequestAge }
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.rewindWriteStallRecovery(by: maxRequestAge) })
+
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+
+        XCTAssertEqual(connectedPeripheralIds, [peripheral.identifier])
+        XCTAssertEqual(
+            manager.testHooks.sync { manager.testHooks.connectRequestOrigin },
+            BoardBleConnectOrigin.writeStallRecovery
+        )
+
+        manager.testHooks.fireConnectionReady(
+            peripheral: peripheral,
+            characteristic: makeWriteCharacteristic()
+        )
+
+        XCTAssertEqual(attempts, 1)
+        XCTAssertEqual(suppressions, 0)
+    }
+
+    /// An abandoned recovery leaves no link, so it must leave no provenance
+    /// either — otherwise a `configure(appActive: false)` landing afterwards
+    /// passes the authorisation latch against a board nobody is connected to.
+    func testAbandonedWriteStallRecoveryForgetsWhoAsked() {
+        let peripheral = FakeWritablePeripheral()
+        installConnection(peripheral: peripheral)
+
+        manager.testHooks.sync { manager.write(data: Data([0x01])) { _, _ in } }
+        fireLatestOneShot(label: "writeAckWatchdog")
+        XCTAssertTrue(manager.testHooks.sync { manager.testHooks.rewindWriteStallRecovery(by: 3600) })
+        manager.testHooks.fireDidDisconnect(peripheral: peripheral, error: nil)
+
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.connectRequestOrigin })
+        XCTAssertNil(manager.testHooks.sync { manager.testHooks.connectRequestedAt })
+        XCTAssertFalse(manager.testHooks.sync { manager.testHooks.implicitRelightAuthorizedForConnection })
+
+        let attemptsBeforeConfigure = attempts
+        let suppressionsBeforeConfigure = suppressions
+        manager.testHooks.sync {
+            manager.testHooks.configure(moonboardConfiguration(), appActive: false)
+        }
+        XCTAssertEqual(attempts, attemptsBeforeConfigure)
+        // The gate was reached and refused, rather than skipped — without the
+        // provenance clear this connection would still read as authorised.
+        XCTAssertEqual(suppressions, suppressionsBeforeConfigure + 1)
     }
 
     func testRestoredConnectionIsSuppressedAndRetained() {

--- a/packages/mobile/ios-tests/BoardBleRelightAuthorizationTests.swift
+++ b/packages/mobile/ios-tests/BoardBleRelightAuthorizationTests.swift
@@ -187,7 +187,8 @@ final class BoardBleRelightAuthorizationTests: XCTestCase {
 
         // Fresh, and exactly on the bound — both still ours to finish. The bound
         // is inclusive, matching shouldPerformImplicitRelight.
-        for age in [TimeInterval(0), 1, 24, maxAge] {
+        let freshAges: [TimeInterval] = [0, 1, 24, maxAge]
+        for age in freshAges {
             XCTAssertTrue(
                 BoardBleManager.writeStallRecoveryIsFresh(
                     requestedAt: now.addingTimeInterval(-age),
@@ -199,7 +200,8 @@ final class BoardBleRelightAuthorizationTests: XCTestCase {
         }
 
         // Past the bound: the suspension case this guard exists for.
-        for age in [maxAge + 0.001, 3600, 86_400 * 3] {
+        let staleAges: [TimeInterval] = [maxAge + 0.001, 3600, 86_400 * 3]
+        for age in staleAges {
             XCTAssertFalse(
                 BoardBleManager.writeStallRecoveryIsFresh(
                     requestedAt: now.addingTimeInterval(-age),
@@ -337,7 +339,8 @@ final class BoardBleRelightAuthorizationTests: XCTestCase {
         }
         // Loose bound: the assertion is "the stall's clock, not this callback's",
         // and anything above ~0 can only have come from the carried stamp.
-        XCTAssertGreaterThan(Date().timeIntervalSince(requestedAt), 30)
+        let carriedAge: TimeInterval = Date().timeIntervalSince(requestedAt)
+        XCTAssertGreaterThan(carriedAge, TimeInterval(30))
     }
 
     /// The hole the connect-window test above cannot reach: the phone suspends

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -2034,12 +2034,20 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             // write is skipped — but the gate's verdict is still recorded, so
             // `configure(_:)` and the diagnostics see this connection's
             // provenance rather than the previous connection's.
-            implicitRelightAuthorizedForConnection = Self.shouldPerformImplicitRelight(
+            let authorized = Self.shouldPerformImplicitRelight(
                 origin: connectRequestOrigin,
                 requestedAt: connectRequestedAt,
                 now: Date(),
                 maxRequestAge: implicitRelightMaxRequestAge
             )
+            implicitRelightAuthorizedForConnection = authorized
+            // The counters track writes attempted vs written, and this branch
+            // issues neither — the intent's explicit displayCurrentItem does.
+            // Log the verdict anyway so Console.app still shows what the gate
+            // decided for this connection.
+            if !authorized {
+                logger.error("Implicit BLE re-light unauthorised for \(connectedDeviceId, privacy: .public) (origin=\(self.connectRequestOrigin?.rawValue ?? "none", privacy: .public)); an awaiting intent owns this write")
+            }
         } else {
             performImplicitRelightIfAuthorizedOnBleQueue(deviceId: connectedDeviceId)
         }

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -44,6 +44,25 @@ enum BoardBleWriteOrigin: String {
     case native
 }
 
+/// Who asked for the connection currently being brought up. Stamped at every
+/// `connectOnBleQueue` CALL SITE — never inside it, because that funnel is
+/// shared by the automatic paths, so a flag set there could not tell a human
+/// apart from a retry. Read at the single write-ready success point to decide
+/// whether the wall may be re-lit from the persisted shared queue without
+/// anyone asking for it (#4499).
+enum BoardBleConnectOrigin: String {
+    /// `connect(deviceId:)` over the JS bridge — the in-app device picker or an
+    /// in-app silent reconnect the user triggered.
+    case userConnect
+    /// The Live Activity lightbulb / `ReconnectBoardIntent`.
+    case liveActivityIntent
+    /// Automatic link cycling after a write stall (#3181).
+    case writeStallRecovery
+    /// CoreBluetooth state restoration adopted a link this process never
+    /// requested. Never authorises an implicit re-light.
+    case restored
+}
+
 enum BoardBleWriteTypeSource: String {
     case defaultWithoutResponse
     case watchdogFallback
@@ -205,6 +224,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private struct DeferredConnectRequest {
         let deviceId: String
         let peripheralId: UUID
+        let origin: BoardBleConnectOrigin
+        let requestedAt: Date
         let completion: (Result<Void, Error>) -> Void
     }
 
@@ -248,6 +269,15 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     // with-response via the stall fallback stay ack-only (no fixed delay).
     private let kilterBoxChunkDelay: TimeInterval = 0.100
     private let connectTimeout: TimeInterval = 8
+    // How old a connect request may be before its success stops authorising an
+    // implicit re-light of the wall (#4499). Deliberately WALL CLOCK, not
+    // DispatchTime: every in-process deadline in this file is a GCD work item
+    // that cannot fire while the app is suspended, and CoreBluetooth's own
+    // `connect(_:)` has no timeout at all — so a request can sit pending in the
+    // system and be honoured days later, when the board comes back into range.
+    // 120 s is ~15x connectTimeout: generous enough for a legitimate connect
+    // that spans a short suspend/resume, far below the hours-to-days failure.
+    private let implicitRelightMaxRequestAge: TimeInterval = 120
     // How long a write parked on `canSendWriteWithoutResponse` may wait for
     // peripheralIsReady before the queue is failed. Generous: a healthy link
     // drains its transmit buffer in milliseconds.
@@ -283,6 +313,19 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private var connectedPeripheral: WritableBlePeripheral?
     private var writeCharacteristic: CBCharacteristic?
     private var pendingConnectCompletion: ((Result<Void, Error>) -> Void)?
+    // Provenance of the connection currently being brought up (or held). See
+    // BoardBleConnectOrigin and shouldPerformImplicitRelight (#4499).
+    private var connectRequestOrigin: BoardBleConnectOrigin?
+    private var connectRequestedAt: Date?
+    // Whether the CURRENT connection's success point authorised an implicit
+    // re-light. Read by `configure(_:)` so a colour change pushed by a
+    // backgrounded JS adopt can't repaint a wall the gate just kept dark.
+    private var implicitRelightAuthorizedForConnection = false
+    // Counters for the Swift suite and for `getConnectedDevice` diagnostics —
+    // the bug is not reproducible on demand, so the only way to learn whether
+    // the gate fires in the wild is to report it.
+    private var implicitRelightAttempts = 0
+    private var implicitRelightSuppressions = 0
     private var connectTimeoutTimer: BleOneShotTimer?
     private var scanRequested = false
     private var scanServices: [CBUUID] = []
@@ -290,6 +333,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     // falling back to a scan: connect as soon as this UUID advertises.
     private var reconnectScanTargetUuid: UUID?
     private var reconnectScanCompletion: ((Result<Void, Error>) -> Void)?
+    private var reconnectScanOrigin: BoardBleConnectOrigin?
+    private var reconnectScanRequestedAt: Date?
     private var reconnectScanTimeoutWorkItem: DispatchWorkItem?
     private var intentionalDisconnectGenerations: [UUID: UInt64] = [:]
     // CoreBluetooth's terminal callback for a manager-initiated cancellation can
@@ -502,6 +547,16 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         }
     }
 
+    /// How the current connection came to be, and whether its success point was
+    /// allowed to re-light the wall (#4499). Reported to JS through
+    /// `getConnectedDevice` → Sentry tags: the bug is not reproducible on
+    /// demand, so field reports are the only way to see the gate working.
+    var connectRelightProvenance: (origin: String?, implicitRelightSuppressed: Bool) {
+        runOnBleQueueSync {
+            (connectRequestOrigin?.rawValue, !implicitRelightAuthorizedForConnection)
+        }
+    }
+
     /// Service UUIDs discovered on the peripheral for the most recent connect
     /// that failed in service/characteristic discovery, or nil if there is no
     /// such failure to report. Clear-on-read so a single failure is attributed
@@ -526,11 +581,30 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         }
     }
 
-    func configure(_ configuration: BoardBleConfiguration) {
+    /// Push the board configuration JS holds into native, and re-light so a
+    /// colour / mirroring change takes effect on the wall immediately.
+    ///
+    /// `appActive` is the discriminator the connect gate can't supply: this is a
+    /// JS-only entry point, and JS calls it from its adopt path too — a
+    /// background BLE wake boots React Native, which would otherwise repaint a
+    /// wall the connect gate just kept dark (#4499). It defaults to `true` at
+    /// the bridge so an older JS bundle running against this binary keeps
+    /// today's behaviour instead of silently losing mid-session re-lights.
+    func configure(_ configuration: BoardBleConfiguration, appActive: Bool = true) {
         runOnBleQueue { [weak self] in
             guard let self else { return }
             self.configuration = configuration
             self.writeConfiguration(configuration)
+            // Foreground: the user is looking at the app and just changed
+            // something, so re-light regardless of how the link came to be.
+            // Background: only re-light onto a connection the gate already
+            // authorised (a lightbulb reconnect, a write-stall recovery).
+            guard appActive || self.implicitRelightAuthorizedForConnection else {
+                self.implicitRelightSuppressions += 1
+                self.logger.error("Suppressed configureBoard re-light while backgrounded on an unauthorised connection (#4499)")
+                return
+            }
+            self.implicitRelightAttempts += 1
             self.displaySharedCurrentItemOnBleQueue()
         }
     }
@@ -548,8 +622,17 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     func connect(deviceId: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        // Stamped here, before the queue hop, so the age measured at the success
+        // point is the age of the USER's request rather than of the moment the
+        // serial queue happened to get to it.
+        let requestedAt = Date()
         runOnBleQueue { [weak self] in
-            self?.connectOnBleQueue(deviceId: deviceId, completion: completion)
+            self?.connectOnBleQueue(
+                deviceId: deviceId,
+                origin: .userConnect,
+                requestedAt: requestedAt,
+                completion: completion
+            )
         }
     }
 
@@ -569,9 +652,17 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     /// event (fired from didDiscoverCharacteristicsFor) and adopts the
     /// connection; if the event fired while JS was suspended, the foreground
     /// `getConnectedDevice` check in useBoardBluetooth picks it up instead.
-    func reconnectToLastKnownBoard(completion: @escaping (Result<Void, Error>) -> Void) {
+    func reconnectToLastKnownBoard(
+        origin: BoardBleConnectOrigin,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        let requestedAt = Date()
         runOnBleQueue { [weak self] in
-            self?.reconnectToLastKnownBoardOnBleQueue(completion: completion)
+            self?.reconnectToLastKnownBoardOnBleQueue(
+                origin: origin,
+                requestedAt: requestedAt,
+                completion: completion
+            )
         }
     }
 
@@ -733,7 +824,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         }
     }
 
-    private func connectOnBleQueue(deviceId: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    private func connectOnBleQueue(
+        deviceId: String,
+        origin: BoardBleConnectOrigin,
+        requestedAt: Date,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
         // Supersede any in-flight reconnect-by-last-known scan: this is a no-op
         // when called from the reconnect path itself (which already nils the scan
         // state first), but settles a stranded scan immediately when an unrelated
@@ -744,6 +840,11 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             completion(.failure(BoardBleError.bluetoothUnavailable))
             return
         }
+
+        // Record who asked, and when, before ANY arm below can succeed —
+        // including the already-connected fast path, which re-lights too.
+        connectRequestOrigin = origin
+        connectRequestedAt = requestedAt
 
         let requestedPeripheralId = UUID(uuidString: deviceId)
         if let recoveringPeripheralId = writeStallRecoveringPeripheralId,
@@ -781,6 +882,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                 deferConnectUntilCancellationSettles(
                     deviceId: deviceId,
                     peripheralId: peripheralId,
+                    origin: origin,
+                    requestedAt: requestedAt,
                     completion: completion
                 )
                 return
@@ -794,7 +897,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
         if connectedPeripheral?.identifier.uuidString == deviceId, writeCharacteristic != nil {
             completion(.success(()))
-            displaySharedCurrentItemOnBleQueue()
+            performImplicitRelightIfAuthorizedOnBleQueue(deviceId: deviceId)
             return
         }
 
@@ -854,6 +957,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private func deferConnectUntilCancellationSettles(
         deviceId: String,
         peripheralId: UUID,
+        origin: BoardBleConnectOrigin,
+        requestedAt: Date,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         failDeferredConnect(BoardBleError.superseded)
@@ -874,6 +979,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         deferredConnectRequest = DeferredConnectRequest(
             deviceId: deviceId,
             peripheralId: peripheralId,
+            origin: origin,
+            requestedAt: requestedAt,
             completion: completion
         )
     }
@@ -884,11 +991,19 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         deferredConnectRequest.completion(.failure(error))
     }
 
-    private func reconnectToLastKnownBoardOnBleQueue(completion: @escaping (Result<Void, Error>) -> Void) {
+    private func reconnectToLastKnownBoardOnBleQueue(
+        origin: BoardBleConnectOrigin,
+        requestedAt: Date,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
         // Already connected — re-light the wall and report success.
-        if connectedPeripheral != nil, writeCharacteristic != nil {
+        if let connectedPeripheral, writeCharacteristic != nil {
+            connectRequestOrigin = origin
+            connectRequestedAt = requestedAt
             completion(.success(()))
-            displaySharedCurrentItemOnBleQueue()
+            performImplicitRelightIfAuthorizedOnBleQueue(
+                deviceId: connectedPeripheral.identifier.uuidString
+            )
             return
         }
         guard centralStateOnBleQueue == .poweredOn else {
@@ -910,17 +1025,36 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             if let name = peripheral.name {
                 discoveredNames[uuidString] = name
             }
-            connectOnBleQueue(deviceId: uuidString, completion: completion)
+            connectOnBleQueue(
+                deviceId: uuidString,
+                origin: origin,
+                requestedAt: requestedAt,
+                completion: completion
+            )
             return
         }
 
         // Fallback: scan, and connect when the stored UUID advertises.
-        beginReconnectScanOnBleQueue(targetUuid: uuid, completion: completion)
+        beginReconnectScanOnBleQueue(
+            targetUuid: uuid,
+            origin: origin,
+            requestedAt: requestedAt,
+            completion: completion
+        )
     }
 
-    private func beginReconnectScanOnBleQueue(targetUuid: UUID, completion: @escaping (Result<Void, Error>) -> Void) {
+    private func beginReconnectScanOnBleQueue(
+        targetUuid: UUID,
+        origin: BoardBleConnectOrigin,
+        requestedAt: Date,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
         reconnectScanTargetUuid = targetUuid
         reconnectScanCompletion = completion
+        // Carried through the scan so the eventual connect is attributed to the
+        // request that started the scan, not to the advertisement that ended it.
+        reconnectScanOrigin = origin
+        reconnectScanRequestedAt = requestedAt
 
         let timeout = DispatchWorkItem { [weak self] in
             self?.failReconnectScan(BoardBleError.connectTimedOut)
@@ -949,6 +1083,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         guard let completion = reconnectScanCompletion else { return }
         reconnectScanCompletion = nil
         reconnectScanTargetUuid = nil
+        reconnectScanOrigin = nil
+        reconnectScanRequestedAt = nil
         reconnectScanTimeoutWorkItem?.cancel()
         reconnectScanTimeoutWorkItem = nil
         stopScanOnBleQueue()
@@ -977,6 +1113,9 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // A deliberate disconnect forgets the board so the widget lightbulb won't
         // silently reconnect to it later. An unexpected drop leaves it intact.
         clearLastConnectedPeripheral()
+        // Forget who asked, so a later restored or long-parked connect cannot
+        // inherit this request's human provenance and re-light the wall (#4499).
+        clearConnectProvenanceOnBleQueue()
         stopScanOnBleQueue()
         failQueuedWrites(BoardBleError.notConnected)
         completePendingConnect(.failure(BoardBleError.notConnected))
@@ -1257,6 +1396,9 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             failDeferredConnect(BoardBleError.bluetoothUnavailable)
             failReconnectScan(BoardBleError.bluetoothUnavailable)
             completePendingConnect(.failure(BoardBleError.bluetoothUnavailable))
+            // Every link generation is invalid below .poweredOn, so no request
+            // that predates this boundary may authorise a re-light (#4499).
+            clearConnectProvenanceOnBleQueue()
 
             // Below .poweredOn iOS invalidates every peripheral WITHOUT
             // delivering didDisconnectPeripheral, so an active link vanishes
@@ -1296,6 +1438,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
         let deviceId = peripheral.identifier.uuidString
         connectionGeneration += 1
+        // Restoration runs at launch, before this process can have issued any
+        // connect of its own, so this can never clobber a live request. Nobody
+        // in THIS process asked for the link, so it must not re-light (#4499).
+        connectRequestOrigin = .restored
+        connectRequestedAt = nil
+        implicitRelightAuthorizedForConnection = false
         discoveredPeripherals[deviceId] = peripheral
         peripheral.delegate = self
 
@@ -1381,11 +1529,24 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // scan and connects). Fires exactly once.
         if let targetUuid = reconnectScanTargetUuid, peripheral.identifier == targetUuid,
            let completion = reconnectScanCompletion {
+            // Both are set together with the completion this branch guards on,
+            // so neither fallback is reachable — `distantPast` keeps the
+            // unreachable one failing CLOSED (the connect still proceeds, it
+            // just won't re-light on its own).
+            let scanOrigin = reconnectScanOrigin ?? .userConnect
+            let scanRequestedAt = reconnectScanRequestedAt ?? .distantPast
             reconnectScanCompletion = nil
             reconnectScanTargetUuid = nil
+            reconnectScanOrigin = nil
+            reconnectScanRequestedAt = nil
             reconnectScanTimeoutWorkItem?.cancel()
             reconnectScanTimeoutWorkItem = nil
-            connectOnBleQueue(deviceId: deviceId, completion: completion)
+            connectOnBleQueue(
+                deviceId: deviceId,
+                origin: scanOrigin,
+                requestedAt: scanRequestedAt,
+                completion: completion
+            )
         }
     }
 
@@ -1544,7 +1705,11 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
         if let deferredRequest {
             let isJoiningWriteStallRecovery = writeStallRecoveringPeripheralId == peripheralId
-            connectOnBleQueue(deviceId: deferredRequest.deviceId) { [weak self] result in
+            connectOnBleQueue(
+                deviceId: deferredRequest.deviceId,
+                origin: deferredRequest.origin,
+                requestedAt: deferredRequest.requestedAt
+            ) { [weak self] result in
                 deferredRequest.completion(result)
                 if isJoiningWriteStallRecovery {
                     self?.finishWriteStallReconnectOnBleQueue(peripheralId: peripheralId, result: result)
@@ -1561,10 +1726,24 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             self?.finishWriteStallReconnectOnBleQueue(peripheralId: peripheralId, result: result)
         }
         let deviceId = peripheralId.uuidString
+        // Recovery re-lights on purpose (#3181) — repainting the wall the user is
+        // actively climbing is the whole point. It stays authorised, and the
+        // freshness bound is what separates this three-second recovery from the
+        // same request honoured three days later (#4499).
+        let requestedAt = Date()
         if discoveredPeripherals[deviceId] != nil {
-            connectOnBleQueue(deviceId: deviceId, completion: completion)
+            connectOnBleQueue(
+                deviceId: deviceId,
+                origin: .writeStallRecovery,
+                requestedAt: requestedAt,
+                completion: completion
+            )
         } else {
-            reconnectToLastKnownBoardOnBleQueue(completion: completion)
+            reconnectToLastKnownBoardOnBleQueue(
+                origin: .writeStallRecovery,
+                requestedAt: requestedAt,
+                completion: completion
+            )
         }
     }
 
@@ -1632,6 +1811,81 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return .select(match)
         }
         return hasRetriedFullDiscovery ? .fail : .retryFullDiscovery
+    }
+
+    /// Whether a connection that just became write-ready may re-light the wall
+    /// from the persisted shared queue WITHOUT anyone asking for it (#4499).
+    ///
+    /// Pure so the whole matrix is unit-testable without CoreBluetooth. Two
+    /// independent conditions must hold:
+    ///
+    /// 1. **Someone in this process asked.** `.restored` means CoreBluetooth
+    ///    handed us a link at launch that nobody here requested — the wall stays
+    ///    dark until the user does something.
+    /// 2. **They asked recently.** `CBCentralManager.connect(_:)` has no timeout;
+    ///    our only bound is a GCD work item that cannot fire while the process is
+    ///    suspended. A request can therefore be honoured hours or days later,
+    ///    when the board comes back into range — which is exactly the reported
+    ///    bug. Wall clock, not `DispatchTime`, because a mach-uptime deadline
+    ///    does not advance across device sleep either.
+    ///
+    /// A negative age means the wall clock moved backwards (a manual change or an
+    /// NTP correction). The real age is then unknowable, so this fails closed:
+    /// the worst case is one skipped re-light the user recovers with a re-tap.
+    static func shouldPerformImplicitRelight(
+        origin: BoardBleConnectOrigin?,
+        requestedAt: Date?,
+        now: Date,
+        maxRequestAge: TimeInterval
+    ) -> Bool {
+        guard let origin, let requestedAt else { return false }
+        let age = now.timeIntervalSince(requestedAt)
+        guard age >= 0, age <= maxRequestAge else { return false }
+        switch origin {
+        case .userConnect, .liveActivityIntent, .writeStallRecovery:
+            return true
+        case .restored:
+            return false
+        }
+    }
+
+    /// Evaluate the gate for the connection currently in hand, record the
+    /// verdict for `configure(_:)` and diagnostics, and re-light only when it
+    /// passes. The link itself is ALWAYS kept: the reported harm is the wall
+    /// lighting up, and a held-but-silent connection writes nothing. These
+    /// boards are last-connection-wins, so the next climber's connect displaces
+    /// us immediately; turning a successful connect into a failure would instead
+    /// invert the JS promise, the persisted last board, and the adoption event
+    /// for a strictly smaller harm.
+    @discardableResult
+    private func performImplicitRelightIfAuthorizedOnBleQueue(deviceId: String) -> Bool {
+        let origin = connectRequestOrigin
+        let requestedAt = connectRequestedAt
+        let authorized = Self.shouldPerformImplicitRelight(
+            origin: origin,
+            requestedAt: requestedAt,
+            now: Date(),
+            maxRequestAge: implicitRelightMaxRequestAge
+        )
+        implicitRelightAuthorizedForConnection = authorized
+        guard authorized else {
+            implicitRelightSuppressions += 1
+            let ageSeconds = requestedAt.map { Date().timeIntervalSince($0) } ?? -1
+            logger.error("Suppressed implicit BLE re-light for \(deviceId, privacy: .public): origin=\(origin?.rawValue ?? "none", privacy: .public) ageSeconds=\(ageSeconds, privacy: .public)")
+            return false
+        }
+        implicitRelightAttempts += 1
+        displaySharedCurrentItemOnBleQueue()
+        return true
+    }
+
+    /// Forget who asked for the current connection. Called wherever the request
+    /// stops being ours to honour, so a later restored or long-parked connect
+    /// cannot inherit a human origin.
+    private func clearConnectProvenanceOnBleQueue() {
+        connectRequestOrigin = nil
+        connectRequestedAt = nil
+        implicitRelightAuthorizedForConnection = false
     }
 
     /// The write characteristic UUID paired with a discovered service UUID.
@@ -1774,8 +2028,20 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // readiness — the intent's awaited code will issue its own
         // displayCurrentItem with the same shared state, and we'd otherwise
         // write the identical packet twice.
-        if !hadPendingReadyWaiters {
-            displaySharedCurrentItemOnBleQueue()
+        if hadPendingReadyWaiters {
+            // An intent is waiting on readiness and will issue its own
+            // displayCurrentItem with the same shared state, so the implicit
+            // write is skipped — but the gate's verdict is still recorded, so
+            // `configure(_:)` and the diagnostics see this connection's
+            // provenance rather than the previous connection's.
+            implicitRelightAuthorizedForConnection = Self.shouldPerformImplicitRelight(
+                origin: connectRequestOrigin,
+                requestedAt: connectRequestedAt,
+                now: Date(),
+                maxRequestAge: implicitRelightMaxRequestAge
+            )
+        } else {
+            performImplicitRelightIfAuthorizedOnBleQueue(deviceId: connectedDeviceId)
         }
     }
 
@@ -2863,6 +3129,26 @@ extension BoardBleManager {
                 )
             }
         }
+
+        /// Seed the connect provenance the implicit-re-light gate reads, so a
+        /// test can age a request past the freshness bound (or clear it) without
+        /// waiting or mutating the clock (#4499).
+        func setConnectRequest(origin: BoardBleConnectOrigin?, requestedAt: Date?) {
+            manager.connectRequestOrigin = origin
+            manager.connectRequestedAt = requestedAt
+        }
+
+        /// Drive `configure(_:)` with an explicit foreground flag.
+        func configure(_ configuration: BoardBleConfiguration, appActive: Bool) {
+            manager.configure(configuration, appActive: appActive)
+        }
+
+        var connectRequestOrigin: BoardBleConnectOrigin? { manager.connectRequestOrigin }
+        var connectRequestedAt: Date? { manager.connectRequestedAt }
+        var implicitRelightAuthorizedForConnection: Bool { manager.implicitRelightAuthorizedForConnection }
+        var implicitRelightAttempts: Int { manager.implicitRelightAttempts }
+        var implicitRelightSuppressions: Int { manager.implicitRelightSuppressions }
+        var implicitRelightMaxRequestAge: TimeInterval { manager.implicitRelightMaxRequestAge }
 
         /// Exercise the pure service-discovery decision (retry-then-fail
         /// fallback) without a real `CBPeripheral` (#3480).

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -601,7 +601,10 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             // authorised (a lightbulb reconnect, a write-stall recovery).
             guard appActive || self.implicitRelightAuthorizedForConnection else {
                 self.implicitRelightSuppressions += 1
-                self.logger.error("Suppressed configureBoard re-light while backgrounded on an unauthorised connection (#4499)")
+                // .info, not .error: this is the gate working as designed, and on a
+                // restored link every background adopt would otherwise write an
+                // error line into the error-rate signal.
+                self.logger.info("Suppressed configureBoard re-light while backgrounded on an unauthorised connection (#4499)")
                 return
             }
             self.implicitRelightAttempts += 1
@@ -1669,6 +1672,16 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         failQueuedWrites(error ?? BoardBleError.notConnected)
         onDisconnect?(deviceId, BoardBleEncoding.disconnectReasonBody(from: error))
 
+        // The link this request produced is gone, so the request stops being
+        // ours to honour: forget it, exactly as a deliberate disconnect does
+        // (#4499). Keeps "provenance describes the CURRENT connection" true for
+        // the window between an unexpected drop and the next connect, so a
+        // `configure(appActive: false)` arriving in that window cannot pass the
+        // authorisation latch against a dead link. Write-stall recovery is
+        // unaffected: its didDisconnect is consumed by the cancellation barrier
+        // above and returns long before here, re-stamping on its own reconnect.
+        clearConnectProvenanceOnBleQueue()
+
         // No auto-reconnect. These boards are last-connection-wins, so silently
         // re-grabbing the link would steal the wall back from whoever took it — a
         // ping-pong that flickers the LEDs. Reconnection is user-initiated only:
@@ -1871,7 +1884,9 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         guard authorized else {
             implicitRelightSuppressions += 1
             let ageSeconds = requestedAt.map { Date().timeIntervalSince($0) } ?? -1
-            logger.error("Suppressed implicit BLE re-light for \(deviceId, privacy: .public): origin=\(origin?.rawValue ?? "none", privacy: .public) ageSeconds=\(ageSeconds, privacy: .public)")
+            // .info: a refused re-light is the designed outcome of the gate, not a
+            // fault. The verdict still needs to be readable in Console.app.
+            logger.info("Suppressed implicit BLE re-light for \(deviceId, privacy: .public): origin=\(origin?.rawValue ?? "none", privacy: .public) ageSeconds=\(ageSeconds, privacy: .public)")
             return false
         }
         implicitRelightAttempts += 1
@@ -2046,7 +2061,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             // Log the verdict anyway so Console.app still shows what the gate
             // decided for this connection.
             if !authorized {
-                logger.error("Implicit BLE re-light unauthorised for \(connectedDeviceId, privacy: .public) (origin=\(self.connectRequestOrigin?.rawValue ?? "none", privacy: .public)); an awaiting intent owns this write")
+                logger.info("Implicit BLE re-light unauthorised for \(connectedDeviceId, privacy: .public) (origin=\(self.connectRequestOrigin?.rawValue ?? "none", privacy: .public)); an awaiting intent owns this write")
             }
         } else {
             performImplicitRelightIfAuthorizedOnBleQueue(deviceId: connectedDeviceId)

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -2099,12 +2099,20 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             // write is skipped — but the gate's verdict is still recorded, so
             // `configure(_:)` and the diagnostics see this connection's
             // provenance rather than the previous connection's.
-            implicitRelightAuthorizedForConnection = Self.shouldPerformImplicitRelight(
+            let authorized = Self.shouldPerformImplicitRelight(
                 origin: connectRequestOrigin,
                 requestedAt: connectRequestedAt,
                 now: Date(),
                 maxRequestAge: implicitRelightMaxRequestAge
             )
+            implicitRelightAuthorizedForConnection = authorized
+            // The counters track writes attempted vs written, and this branch
+            // issues neither — the intent's explicit displayCurrentItem does.
+            // Log the verdict anyway so Console.app still shows what the gate
+            // decided for this connection.
+            if !authorized {
+                logger.error("Implicit BLE re-light unauthorised for \(connectedDeviceId, privacy: .public) (origin=\(self.connectRequestOrigin?.rawValue ?? "none", privacy: .public)); an awaiting intent owns this write")
+            }
         } else {
             performImplicitRelightIfAuthorizedOnBleQueue(deviceId: connectedDeviceId)
         }

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -44,6 +44,25 @@ enum BoardBleWriteOrigin: String {
     case native
 }
 
+/// Who asked for the connection currently being brought up. Stamped at every
+/// `connectOnBleQueue` CALL SITE — never inside it, because that funnel is
+/// shared by the automatic paths, so a flag set there could not tell a human
+/// apart from a retry. Read at the single write-ready success point to decide
+/// whether the wall may be re-lit from the persisted shared queue without
+/// anyone asking for it (#4499).
+enum BoardBleConnectOrigin: String {
+    /// `connect(deviceId:)` over the JS bridge — the in-app device picker or an
+    /// in-app silent reconnect the user triggered.
+    case userConnect
+    /// The Live Activity lightbulb / `ReconnectBoardIntent`.
+    case liveActivityIntent
+    /// Automatic link cycling after a write stall (#3181).
+    case writeStallRecovery
+    /// CoreBluetooth state restoration adopted a link this process never
+    /// requested. Never authorises an implicit re-light.
+    case restored
+}
+
 enum BoardBleWriteTypeSource: String {
     case defaultWithoutResponse
     case watchdogFallback
@@ -208,6 +227,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private struct DeferredConnectRequest {
         let deviceId: String
         let peripheralId: UUID
+        let origin: BoardBleConnectOrigin
+        let requestedAt: Date
         let completion: (Result<Void, Error>) -> Void
     }
 
@@ -251,6 +272,15 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     // with-response via the stall fallback stay ack-only (no fixed delay).
     private let kilterBoxChunkDelay: TimeInterval = 0.100
     private let connectTimeout: TimeInterval = 8
+    // How old a connect request may be before its success stops authorising an
+    // implicit re-light of the wall (#4499). Deliberately WALL CLOCK, not
+    // DispatchTime: every in-process deadline in this file is a GCD work item
+    // that cannot fire while the app is suspended, and CoreBluetooth's own
+    // `connect(_:)` has no timeout at all — so a request can sit pending in the
+    // system and be honoured days later, when the board comes back into range.
+    // 120 s is ~15x connectTimeout: generous enough for a legitimate connect
+    // that spans a short suspend/resume, far below the hours-to-days failure.
+    private let implicitRelightMaxRequestAge: TimeInterval = 120
     // How long a write parked on `canSendWriteWithoutResponse` may wait for
     // peripheralIsReady before the queue is failed. Generous: a healthy link
     // drains its transmit buffer in milliseconds.
@@ -286,6 +316,19 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private var connectedPeripheral: WritableBlePeripheral?
     private var writeCharacteristic: CBCharacteristic?
     private var pendingConnectCompletion: ((Result<Void, Error>) -> Void)?
+    // Provenance of the connection currently being brought up (or held). See
+    // BoardBleConnectOrigin and shouldPerformImplicitRelight (#4499).
+    private var connectRequestOrigin: BoardBleConnectOrigin?
+    private var connectRequestedAt: Date?
+    // Whether the CURRENT connection's success point authorised an implicit
+    // re-light. Read by `configure(_:)` so a colour change pushed by a
+    // backgrounded JS adopt can't repaint a wall the gate just kept dark.
+    private var implicitRelightAuthorizedForConnection = false
+    // Counters for the Swift suite and for `getConnectedDevice` diagnostics —
+    // the bug is not reproducible on demand, so the only way to learn whether
+    // the gate fires in the wild is to report it.
+    private var implicitRelightAttempts = 0
+    private var implicitRelightSuppressions = 0
     private var connectTimeoutTimer: BleOneShotTimer?
     private var scanRequested = false
     private var scanServices: [CBUUID] = []
@@ -293,6 +336,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     // falling back to a scan: connect as soon as this UUID advertises.
     private var reconnectScanTargetUuid: UUID?
     private var reconnectScanCompletion: ((Result<Void, Error>) -> Void)?
+    private var reconnectScanOrigin: BoardBleConnectOrigin?
+    private var reconnectScanRequestedAt: Date?
     private var reconnectScanTimeoutWorkItem: DispatchWorkItem?
     private var intentionalDisconnectGenerations: [UUID: UInt64] = [:]
     // CoreBluetooth's terminal callback for a manager-initiated cancellation can
@@ -505,6 +550,16 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         }
     }
 
+    /// How the current connection came to be, and whether its success point was
+    /// allowed to re-light the wall (#4499). Reported to JS through
+    /// `getConnectedDevice` → Sentry tags: the bug is not reproducible on
+    /// demand, so field reports are the only way to see the gate working.
+    var connectRelightProvenance: (origin: String?, implicitRelightSuppressed: Bool) {
+        runOnBleQueueSync {
+            (connectRequestOrigin?.rawValue, !implicitRelightAuthorizedForConnection)
+        }
+    }
+
     /// Service UUIDs discovered on the peripheral for the most recent connect
     /// that failed in service/characteristic discovery, or nil if there is no
     /// such failure to report. Clear-on-read so a single failure is attributed
@@ -529,11 +584,30 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         }
     }
 
-    func configure(_ configuration: BoardBleConfiguration) {
+    /// Push the board configuration JS holds into native, and re-light so a
+    /// colour / mirroring change takes effect on the wall immediately.
+    ///
+    /// `appActive` is the discriminator the connect gate can't supply: this is a
+    /// JS-only entry point, and JS calls it from its adopt path too — a
+    /// background BLE wake boots React Native, which would otherwise repaint a
+    /// wall the connect gate just kept dark (#4499). It defaults to `true` at
+    /// the bridge so an older JS bundle running against this binary keeps
+    /// today's behaviour instead of silently losing mid-session re-lights.
+    func configure(_ configuration: BoardBleConfiguration, appActive: Bool = true) {
         runOnBleQueue { [weak self] in
             guard let self else { return }
             self.configuration = configuration
             self.writeConfiguration(configuration)
+            // Foreground: the user is looking at the app and just changed
+            // something, so re-light regardless of how the link came to be.
+            // Background: only re-light onto a connection the gate already
+            // authorised (a lightbulb reconnect, a write-stall recovery).
+            guard appActive || self.implicitRelightAuthorizedForConnection else {
+                self.implicitRelightSuppressions += 1
+                self.logger.error("Suppressed configureBoard re-light while backgrounded on an unauthorised connection (#4499)")
+                return
+            }
+            self.implicitRelightAttempts += 1
             self.displaySharedCurrentItemOnBleQueue()
         }
     }
@@ -551,8 +625,17 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     }
 
     func connect(deviceId: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        // Stamped here, before the queue hop, so the age measured at the success
+        // point is the age of the USER's request rather than of the moment the
+        // serial queue happened to get to it.
+        let requestedAt = Date()
         runOnBleQueue { [weak self] in
-            self?.connectOnBleQueue(deviceId: deviceId, completion: completion)
+            self?.connectOnBleQueue(
+                deviceId: deviceId,
+                origin: .userConnect,
+                requestedAt: requestedAt,
+                completion: completion
+            )
         }
     }
 
@@ -572,9 +655,17 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     /// event (fired from didDiscoverCharacteristicsFor) and adopts the
     /// connection; if the event fired while JS was suspended, the foreground
     /// `getConnectedDevice` check in useBoardBluetooth picks it up instead.
-    func reconnectToLastKnownBoard(completion: @escaping (Result<Void, Error>) -> Void) {
+    func reconnectToLastKnownBoard(
+        origin: BoardBleConnectOrigin,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        let requestedAt = Date()
         runOnBleQueue { [weak self] in
-            self?.reconnectToLastKnownBoardOnBleQueue(completion: completion)
+            self?.reconnectToLastKnownBoardOnBleQueue(
+                origin: origin,
+                requestedAt: requestedAt,
+                completion: completion
+            )
         }
     }
 
@@ -743,7 +834,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         }
     }
 
-    private func connectOnBleQueue(deviceId: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    private func connectOnBleQueue(
+        deviceId: String,
+        origin: BoardBleConnectOrigin,
+        requestedAt: Date,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
         // Supersede any in-flight reconnect-by-last-known scan: this is a no-op
         // when called from the reconnect path itself (which already nils the scan
         // state first), but settles a stranded scan immediately when an unrelated
@@ -754,6 +850,11 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             completion(.failure(BoardBleError.bluetoothUnavailable))
             return
         }
+
+        // Record who asked, and when, before ANY arm below can succeed —
+        // including the already-connected fast path, which re-lights too.
+        connectRequestOrigin = origin
+        connectRequestedAt = requestedAt
 
         let requestedPeripheralId = UUID(uuidString: deviceId)
         if let recoveringPeripheralId = writeStallRecoveringPeripheralId,
@@ -791,6 +892,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                 deferConnectUntilCancellationSettles(
                     deviceId: deviceId,
                     peripheralId: peripheralId,
+                    origin: origin,
+                    requestedAt: requestedAt,
                     completion: completion
                 )
                 return
@@ -804,7 +907,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
         if connectedPeripheral?.identifier.uuidString == deviceId, writeCharacteristic != nil {
             completion(.success(()))
-            displaySharedCurrentItemOnBleQueue()
+            performImplicitRelightIfAuthorizedOnBleQueue(deviceId: deviceId)
             return
         }
 
@@ -864,6 +967,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private func deferConnectUntilCancellationSettles(
         deviceId: String,
         peripheralId: UUID,
+        origin: BoardBleConnectOrigin,
+        requestedAt: Date,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         failDeferredConnect(BoardBleError.superseded)
@@ -884,6 +989,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         deferredConnectRequest = DeferredConnectRequest(
             deviceId: deviceId,
             peripheralId: peripheralId,
+            origin: origin,
+            requestedAt: requestedAt,
             completion: completion
         )
     }
@@ -894,11 +1001,19 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         deferredConnectRequest.completion(.failure(error))
     }
 
-    private func reconnectToLastKnownBoardOnBleQueue(completion: @escaping (Result<Void, Error>) -> Void) {
+    private func reconnectToLastKnownBoardOnBleQueue(
+        origin: BoardBleConnectOrigin,
+        requestedAt: Date,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
         // Already connected — re-light the wall and report success.
-        if connectedPeripheral != nil, writeCharacteristic != nil {
+        if let connectedPeripheral, writeCharacteristic != nil {
+            connectRequestOrigin = origin
+            connectRequestedAt = requestedAt
             completion(.success(()))
-            displaySharedCurrentItemOnBleQueue()
+            performImplicitRelightIfAuthorizedOnBleQueue(
+                deviceId: connectedPeripheral.identifier.uuidString
+            )
             return
         }
         guard centralStateOnBleQueue == .poweredOn else {
@@ -920,17 +1035,36 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             if let name = peripheral.name {
                 discoveredNames[uuidString] = name
             }
-            connectOnBleQueue(deviceId: uuidString, completion: completion)
+            connectOnBleQueue(
+                deviceId: uuidString,
+                origin: origin,
+                requestedAt: requestedAt,
+                completion: completion
+            )
             return
         }
 
         // Fallback: scan, and connect when the stored UUID advertises.
-        beginReconnectScanOnBleQueue(targetUuid: uuid, completion: completion)
+        beginReconnectScanOnBleQueue(
+            targetUuid: uuid,
+            origin: origin,
+            requestedAt: requestedAt,
+            completion: completion
+        )
     }
 
-    private func beginReconnectScanOnBleQueue(targetUuid: UUID, completion: @escaping (Result<Void, Error>) -> Void) {
+    private func beginReconnectScanOnBleQueue(
+        targetUuid: UUID,
+        origin: BoardBleConnectOrigin,
+        requestedAt: Date,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
         reconnectScanTargetUuid = targetUuid
         reconnectScanCompletion = completion
+        // Carried through the scan so the eventual connect is attributed to the
+        // request that started the scan, not to the advertisement that ended it.
+        reconnectScanOrigin = origin
+        reconnectScanRequestedAt = requestedAt
 
         let timeout = DispatchWorkItem { [weak self] in
             self?.failReconnectScan(BoardBleError.connectTimedOut)
@@ -959,6 +1093,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         guard let completion = reconnectScanCompletion else { return }
         reconnectScanCompletion = nil
         reconnectScanTargetUuid = nil
+        reconnectScanOrigin = nil
+        reconnectScanRequestedAt = nil
         reconnectScanTimeoutWorkItem?.cancel()
         reconnectScanTimeoutWorkItem = nil
         stopScanOnBleQueue()
@@ -987,6 +1123,9 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // A deliberate disconnect forgets the board so the widget lightbulb won't
         // silently reconnect to it later. An unexpected drop leaves it intact.
         clearLastConnectedPeripheral()
+        // Forget who asked, so a later restored or long-parked connect cannot
+        // inherit this request's human provenance and re-light the wall (#4499).
+        clearConnectProvenanceOnBleQueue()
         stopScanOnBleQueue()
         failQueuedWrites(BoardBleError.notConnected)
         completePendingConnect(.failure(BoardBleError.notConnected))
@@ -1322,6 +1461,9 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             failDeferredConnect(BoardBleError.bluetoothUnavailable)
             failReconnectScan(BoardBleError.bluetoothUnavailable)
             completePendingConnect(.failure(BoardBleError.bluetoothUnavailable))
+            // Every link generation is invalid below .poweredOn, so no request
+            // that predates this boundary may authorise a re-light (#4499).
+            clearConnectProvenanceOnBleQueue()
 
             // Below .poweredOn iOS invalidates every peripheral WITHOUT
             // delivering didDisconnectPeripheral, so an active link vanishes
@@ -1361,6 +1503,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
         let deviceId = peripheral.identifier.uuidString
         connectionGeneration += 1
+        // Restoration runs at launch, before this process can have issued any
+        // connect of its own, so this can never clobber a live request. Nobody
+        // in THIS process asked for the link, so it must not re-light (#4499).
+        connectRequestOrigin = .restored
+        connectRequestedAt = nil
+        implicitRelightAuthorizedForConnection = false
         discoveredPeripherals[deviceId] = peripheral
         peripheral.delegate = self
 
@@ -1446,11 +1594,24 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // scan and connects). Fires exactly once.
         if let targetUuid = reconnectScanTargetUuid, peripheral.identifier == targetUuid,
            let completion = reconnectScanCompletion {
+            // Both are set together with the completion this branch guards on,
+            // so neither fallback is reachable — `distantPast` keeps the
+            // unreachable one failing CLOSED (the connect still proceeds, it
+            // just won't re-light on its own).
+            let scanOrigin = reconnectScanOrigin ?? .userConnect
+            let scanRequestedAt = reconnectScanRequestedAt ?? .distantPast
             reconnectScanCompletion = nil
             reconnectScanTargetUuid = nil
+            reconnectScanOrigin = nil
+            reconnectScanRequestedAt = nil
             reconnectScanTimeoutWorkItem?.cancel()
             reconnectScanTimeoutWorkItem = nil
-            connectOnBleQueue(deviceId: deviceId, completion: completion)
+            connectOnBleQueue(
+                deviceId: deviceId,
+                origin: scanOrigin,
+                requestedAt: scanRequestedAt,
+                completion: completion
+            )
         }
     }
 
@@ -1609,7 +1770,11 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
         if let deferredRequest {
             let isJoiningWriteStallRecovery = writeStallRecoveringPeripheralId == peripheralId
-            connectOnBleQueue(deviceId: deferredRequest.deviceId) { [weak self] result in
+            connectOnBleQueue(
+                deviceId: deferredRequest.deviceId,
+                origin: deferredRequest.origin,
+                requestedAt: deferredRequest.requestedAt
+            ) { [weak self] result in
                 deferredRequest.completion(result)
                 if isJoiningWriteStallRecovery {
                     self?.finishWriteStallReconnectOnBleQueue(peripheralId: peripheralId, result: result)
@@ -1626,10 +1791,24 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             self?.finishWriteStallReconnectOnBleQueue(peripheralId: peripheralId, result: result)
         }
         let deviceId = peripheralId.uuidString
+        // Recovery re-lights on purpose (#3181) — repainting the wall the user is
+        // actively climbing is the whole point. It stays authorised, and the
+        // freshness bound is what separates this three-second recovery from the
+        // same request honoured three days later (#4499).
+        let requestedAt = Date()
         if discoveredPeripherals[deviceId] != nil {
-            connectOnBleQueue(deviceId: deviceId, completion: completion)
+            connectOnBleQueue(
+                deviceId: deviceId,
+                origin: .writeStallRecovery,
+                requestedAt: requestedAt,
+                completion: completion
+            )
         } else {
-            reconnectToLastKnownBoardOnBleQueue(completion: completion)
+            reconnectToLastKnownBoardOnBleQueue(
+                origin: .writeStallRecovery,
+                requestedAt: requestedAt,
+                completion: completion
+            )
         }
     }
 
@@ -1697,6 +1876,81 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             return .select(match)
         }
         return hasRetriedFullDiscovery ? .fail : .retryFullDiscovery
+    }
+
+    /// Whether a connection that just became write-ready may re-light the wall
+    /// from the persisted shared queue WITHOUT anyone asking for it (#4499).
+    ///
+    /// Pure so the whole matrix is unit-testable without CoreBluetooth. Two
+    /// independent conditions must hold:
+    ///
+    /// 1. **Someone in this process asked.** `.restored` means CoreBluetooth
+    ///    handed us a link at launch that nobody here requested — the wall stays
+    ///    dark until the user does something.
+    /// 2. **They asked recently.** `CBCentralManager.connect(_:)` has no timeout;
+    ///    our only bound is a GCD work item that cannot fire while the process is
+    ///    suspended. A request can therefore be honoured hours or days later,
+    ///    when the board comes back into range — which is exactly the reported
+    ///    bug. Wall clock, not `DispatchTime`, because a mach-uptime deadline
+    ///    does not advance across device sleep either.
+    ///
+    /// A negative age means the wall clock moved backwards (a manual change or an
+    /// NTP correction). The real age is then unknowable, so this fails closed:
+    /// the worst case is one skipped re-light the user recovers with a re-tap.
+    static func shouldPerformImplicitRelight(
+        origin: BoardBleConnectOrigin?,
+        requestedAt: Date?,
+        now: Date,
+        maxRequestAge: TimeInterval
+    ) -> Bool {
+        guard let origin, let requestedAt else { return false }
+        let age = now.timeIntervalSince(requestedAt)
+        guard age >= 0, age <= maxRequestAge else { return false }
+        switch origin {
+        case .userConnect, .liveActivityIntent, .writeStallRecovery:
+            return true
+        case .restored:
+            return false
+        }
+    }
+
+    /// Evaluate the gate for the connection currently in hand, record the
+    /// verdict for `configure(_:)` and diagnostics, and re-light only when it
+    /// passes. The link itself is ALWAYS kept: the reported harm is the wall
+    /// lighting up, and a held-but-silent connection writes nothing. These
+    /// boards are last-connection-wins, so the next climber's connect displaces
+    /// us immediately; turning a successful connect into a failure would instead
+    /// invert the JS promise, the persisted last board, and the adoption event
+    /// for a strictly smaller harm.
+    @discardableResult
+    private func performImplicitRelightIfAuthorizedOnBleQueue(deviceId: String) -> Bool {
+        let origin = connectRequestOrigin
+        let requestedAt = connectRequestedAt
+        let authorized = Self.shouldPerformImplicitRelight(
+            origin: origin,
+            requestedAt: requestedAt,
+            now: Date(),
+            maxRequestAge: implicitRelightMaxRequestAge
+        )
+        implicitRelightAuthorizedForConnection = authorized
+        guard authorized else {
+            implicitRelightSuppressions += 1
+            let ageSeconds = requestedAt.map { Date().timeIntervalSince($0) } ?? -1
+            logger.error("Suppressed implicit BLE re-light for \(deviceId, privacy: .public): origin=\(origin?.rawValue ?? "none", privacy: .public) ageSeconds=\(ageSeconds, privacy: .public)")
+            return false
+        }
+        implicitRelightAttempts += 1
+        displaySharedCurrentItemOnBleQueue()
+        return true
+    }
+
+    /// Forget who asked for the current connection. Called wherever the request
+    /// stops being ours to honour, so a later restored or long-parked connect
+    /// cannot inherit a human origin.
+    private func clearConnectProvenanceOnBleQueue() {
+        connectRequestOrigin = nil
+        connectRequestedAt = nil
+        implicitRelightAuthorizedForConnection = false
     }
 
     /// The write characteristic UUID paired with a discovered service UUID.
@@ -1839,8 +2093,20 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // readiness — the intent's awaited code will issue its own
         // displayCurrentItem with the same shared state, and we'd otherwise
         // write the identical packet twice.
-        if !hadPendingReadyWaiters {
-            displaySharedCurrentItemOnBleQueue()
+        if hadPendingReadyWaiters {
+            // An intent is waiting on readiness and will issue its own
+            // displayCurrentItem with the same shared state, so the implicit
+            // write is skipped — but the gate's verdict is still recorded, so
+            // `configure(_:)` and the diagnostics see this connection's
+            // provenance rather than the previous connection's.
+            implicitRelightAuthorizedForConnection = Self.shouldPerformImplicitRelight(
+                origin: connectRequestOrigin,
+                requestedAt: connectRequestedAt,
+                now: Date(),
+                maxRequestAge: implicitRelightMaxRequestAge
+            )
+        } else {
+            performImplicitRelightIfAuthorizedOnBleQueue(deviceId: connectedDeviceId)
         }
     }
 
@@ -2945,6 +3211,26 @@ extension BoardBleManager {
                 manager.displaySharedCurrentItemOnBleQueue(defaults: defaults)
             }
         }
+
+        /// Seed the connect provenance the implicit-re-light gate reads, so a
+        /// test can age a request past the freshness bound (or clear it) without
+        /// waiting or mutating the clock (#4499).
+        func setConnectRequest(origin: BoardBleConnectOrigin?, requestedAt: Date?) {
+            manager.connectRequestOrigin = origin
+            manager.connectRequestedAt = requestedAt
+        }
+
+        /// Drive `configure(_:)` with an explicit foreground flag.
+        func configure(_ configuration: BoardBleConfiguration, appActive: Bool) {
+            manager.configure(configuration, appActive: appActive)
+        }
+
+        var connectRequestOrigin: BoardBleConnectOrigin? { manager.connectRequestOrigin }
+        var connectRequestedAt: Date? { manager.connectRequestedAt }
+        var implicitRelightAuthorizedForConnection: Bool { manager.implicitRelightAuthorizedForConnection }
+        var implicitRelightAttempts: Int { manager.implicitRelightAttempts }
+        var implicitRelightSuppressions: Int { manager.implicitRelightSuppressions }
+        var implicitRelightMaxRequestAge: TimeInterval { manager.implicitRelightMaxRequestAge }
 
         /// Exercise the pure service-discovery decision (retry-then-fail
         /// fallback) without a real `CBPeripheral` (#3480).

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -435,8 +435,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     private var pendingWriteAck: (() -> Void)?
     private var pendingWriteAckWatchdog: BleOneShotTimer?
     // Write-stall recovery (#3181). `writeStallRecoveries` counts consecutive
-    // stalls (reset on any drained write). `writeStallRecoveringPeripheralId` is
-    // the board whose congested link we deliberately cycled; it is set across the
+    // stalls (reset on any drained write). `writeStallRecovery` describes the
+    // board whose congested link we deliberately cycled; it is set across the
     // whole recovery window (cancel → deferred reconnect → characteristics
     // discovered) so that: (1) only the matching didDisconnectPeripheral triggers
     // the reconnect — never an unrelated peripheral's intentional disconnect —
@@ -444,8 +444,20 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
     // the self-healing `writeTimedOut` rather than `notConnected`, which the JS
     // classifier would mistake for a hard drop and tear the link down. Cleared by
     // any successful (re)connect, a deliberate disconnect, or Bluetooth-off.
+    private struct WriteStallRecovery {
+        let peripheralId: UUID
+        // Wall clock at the moment the stall was DETECTED — not at the moment
+        // the deferred didDisconnect was consumed. Every deadline bounding that
+        // gap is a GCD work item that neither fires while the process is
+        // suspended nor advances across device sleep, so re-stamping on arrival
+        // would hand an hours-old stall a fresh re-light budget: exactly the
+        // #4499 failure this file's provenance gate exists to stop. Paired with
+        // the id in one value so no clear site can drop half of it.
+        let requestedAt: Date
+    }
+
     private var writeStallRecoveries = 0
-    private var writeStallRecoveringPeripheralId: UUID?
+    private var writeStallRecovery: WriteStallRecovery?
     // Fail-closed safety net for the recover window: if the cancel's
     // `didDisconnectPeripheral` never arrives (a wedged link while Bluetooth
     // stays on), this fires so the window can't strand forever (wall dark, JS
@@ -860,9 +872,9 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         connectRequestedAt = requestedAt
 
         let requestedPeripheralId = UUID(uuidString: deviceId)
-        if let recoveringPeripheralId = writeStallRecoveringPeripheralId,
+        if let recoveringPeripheralId = writeStallRecovery?.peripheralId,
            requestedPeripheralId != recoveringPeripheralId {
-            writeStallRecoveringPeripheralId = nil
+            writeStallRecovery = nil
             writeStallRecoveries = 0
             writeStallRecoveryWatchdog?.cancel()
             writeStallRecoveryWatchdog = nil
@@ -925,8 +937,8 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         // DIFFERENT board supersedes any in-flight recovery: clear the recovery
         // window + watchdog so a stale didDisconnect for the old board can't hijack
         // this connect, and reset the budget for the new link (#3181).
-        if writeStallRecoveringPeripheralId != peripheral.identifier {
-            writeStallRecoveringPeripheralId = nil
+        if writeStallRecovery?.peripheralId != peripheral.identifier {
+            writeStallRecovery = nil
             writeStallRecoveries = 0
             writeStallRecoveryWatchdog?.cancel()
             writeStallRecoveryWatchdog = nil
@@ -1119,7 +1131,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         connectionGeneration += 1
         // A deliberate disconnect supersedes any in-flight write-stall recovery
         // (#3181): drop the recovery window and reset the budget.
-        writeStallRecoveringPeripheralId = nil
+        writeStallRecovery = nil
         writeStallRecoveries = 0
         // Settle any in-flight reconnect-by-last-known scan before tearing down.
         failReconnectScan(BoardBleError.notConnected)
@@ -1155,7 +1167,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             // (a warning JS rides out with `isConnected` kept) rather than
             // `notConnected`, which the JS classifier treats as a hard drop and
             // would tear the connection down mid-recovery (#3181).
-            completion?(writeStallRecoveringPeripheralId != nil ? BoardBleError.writeTimedOut : BoardBleError.notConnected, nil)
+            completion?(writeStallRecovery != nil ? BoardBleError.writeTimedOut : BoardBleError.notConnected, nil)
             return
         }
 
@@ -1447,7 +1459,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             // disconnect could be mistaken for a stall recovery, writes would
             // keep parking on the window, or a post-power-on session would start
             // with a depleted budget (#3181).
-            writeStallRecoveringPeripheralId = nil
+            writeStallRecovery = nil
             writeStallRecoveries = 0
             writeStallRecoveryWatchdog?.cancel()
             writeStallRecoveryWatchdog = nil
@@ -1775,14 +1787,20 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             deferredRequest = nil
         }
 
-        if writeStallRecoveringPeripheralId == peripheralId {
+        if writeStallRecovery?.peripheralId == peripheralId {
             // The normal connection timeout owns the deadline from here.
             writeStallRecoveryWatchdog?.cancel()
             writeStallRecoveryWatchdog = nil
         }
 
         if let deferredRequest {
-            let isJoiningWriteStallRecovery = writeStallRecoveringPeripheralId == peripheralId
+            let isJoiningWriteStallRecovery = writeStallRecovery?.peripheralId == peripheralId
+            // Replayed with the USER's original stamp, so a days-late replay is
+            // already gate-suppressed at the success point and never re-lights.
+            // It does still take the link — accepted, unlike the stall-recovery
+            // arm below: a queued connect began as an explicit human request,
+            // and the picker showing a board it cannot reach is worse than a
+            // silent link. Deliberate asymmetry, not an oversight (#4499).
             connectOnBleQueue(
                 deviceId: deferredRequest.deviceId,
                 origin: deferredRequest.origin,
@@ -1793,33 +1811,57 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
                     self?.finishWriteStallReconnectOnBleQueue(peripheralId: peripheralId, result: result)
                 }
             }
-        } else if writeStallRecoveringPeripheralId == peripheralId {
+        } else if writeStallRecovery?.peripheralId == peripheralId {
             beginWriteStallReconnectOnBleQueue(peripheralId: peripheralId)
         }
         return true
     }
 
     private func beginWriteStallReconnectOnBleQueue(peripheralId: UUID) {
+        guard let recovery = writeStallRecovery, recovery.peripheralId == peripheralId else { return }
+        let deviceId = peripheralId.uuidString
+
+        // Recovery re-lights on purpose (#3181) — repainting the wall the user is
+        // actively climbing is the whole point. What separates that three-second
+        // recovery from the same one honoured three days later is the STALL's
+        // wall clock, carried here from handleWriteStall. Stamping `Date()` at
+        // this point instead would mint a brand-new freshness budget for a
+        // didDisconnect that thawed out of a suspension, because the two
+        // watchdogs bounding the cancel → didDisconnect gap are GCD work items
+        // that thaw alongside it (#4499).
+        guard Self.writeStallRecoveryIsFresh(
+            requestedAt: recovery.requestedAt,
+            now: Date(),
+            maxRequestAge: implicitRelightMaxRequestAge
+        ) else {
+            // Don't reconnect at all — not even silently. These boards are
+            // last-connection-wins, so a days-late reconnect takes the wall from
+            // whoever is on it now, which is the same harm that makes an
+            // unexpected drop refuse to auto-reconnect (see
+            // handleDidDisconnectOnBleQueue). Gate-suppressing the re-light would
+            // stop the repaint but not the theft.
+            logger.info("Abandoning stale BLE write-stall recovery for \(deviceId, privacy: .public)")
+            abandonWriteStallRecoveryOnBleQueue(
+                peripheralId: peripheralId,
+                context: "write_stall_recovery_stale"
+            )
+            return
+        }
+
         let completion: (Result<Void, Error>) -> Void = { [weak self] result in
             self?.finishWriteStallReconnectOnBleQueue(peripheralId: peripheralId, result: result)
         }
-        let deviceId = peripheralId.uuidString
-        // Recovery re-lights on purpose (#3181) — repainting the wall the user is
-        // actively climbing is the whole point. It stays authorised, and the
-        // freshness bound is what separates this three-second recovery from the
-        // same request honoured three days later (#4499).
-        let requestedAt = Date()
         if discoveredPeripherals[deviceId] != nil {
             connectOnBleQueue(
                 deviceId: deviceId,
                 origin: .writeStallRecovery,
-                requestedAt: requestedAt,
+                requestedAt: recovery.requestedAt,
                 completion: completion
             )
         } else {
             reconnectToLastKnownBoardOnBleQueue(
                 origin: .writeStallRecovery,
-                requestedAt: requestedAt,
+                requestedAt: recovery.requestedAt,
                 completion: completion
             )
         }
@@ -1827,15 +1869,32 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
 
     private func finishWriteStallReconnectOnBleQueue(peripheralId: UUID, result: Result<Void, Error>) {
         guard case .failure(let error) = result,
-              writeStallRecoveringPeripheralId == peripheralId
+              writeStallRecovery?.peripheralId == peripheralId
         else { return }
         logger.error("BLE write-stall reconnect failed: \(error.localizedDescription, privacy: .public)")
-        writeStallRecoveringPeripheralId = nil
+        writeStallRecovery = nil
         writeStallRecoveries = 0
         onDisconnect?(peripheralId.uuidString, [
             "context": "write_stall_recovery_failed",
             "errorDescription": error.localizedDescription,
         ])
+    }
+
+    /// Give up on an in-flight write-stall recovery and tell JS the link is
+    /// gone. Shared by the no-`didDisconnect` watchdog and the stale-arrival
+    /// guard: both mean the recovery we started is no longer ours to finish, and
+    /// no reconnect is coming.
+    private func abandonWriteStallRecoveryOnBleQueue(peripheralId: UUID, context: String) {
+        writeStallRecovery = nil
+        writeStallRecoveries = 0
+        writeCharacteristic = nil
+        connectedPeripheral = nil
+        // No link is coming, so the request stops being ours to honour — the
+        // same invariant handleDidDisconnectOnBleQueue keeps after an unexpected
+        // drop, so a `configure(appActive: false)` landing here cannot pass the
+        // authorisation latch against a dead link (#4499).
+        clearConnectProvenanceOnBleQueue()
+        onDisconnect?(peripheralId.uuidString, ["context": context])
     }
 
     // MARK: - CBPeripheralDelegate
@@ -1925,6 +1984,25 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         case .restored:
             return false
         }
+    }
+
+    /// Whether a write-stall recovery that was deferred to `didDisconnect` is
+    /// still the recovery we asked for (#4499).
+    ///
+    /// Same wall-clock reasoning as `shouldPerformImplicitRelight`, for the same
+    /// reason: the two deadlines bounding the cancel → `didDisconnect` gap
+    /// (`writeStallRecoveryWatchdog` and the cancellation barrier's watchdog) are
+    /// GCD work items, so a suspended process thaws them alongside the very
+    /// callback they were meant to bound. The stall's own clock is the only
+    /// honest measure of how long ago we asked. A negative age (the wall clock
+    /// moved backwards) is unknowable, so it fails closed like its sibling.
+    static func writeStallRecoveryIsFresh(
+        requestedAt: Date,
+        now: Date,
+        maxRequestAge: TimeInterval
+    ) -> Bool {
+        let age = now.timeIntervalSince(requestedAt)
+        return age >= 0 && age <= maxRequestAge
     }
 
     /// Evaluate the gate for the connection currently in hand, record the
@@ -2074,7 +2152,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         writeCharacteristic = characteristic
         // Any successful (re)connect closes a write-stall recovery window (#3181)
         // — writes flow normally again from here.
-        writeStallRecoveringPeripheralId = nil
+        writeStallRecovery = nil
         // A fresh link re-earns normal backpressure: drop any stuck-false gate
         // bypass so a healthy connection isn't permanently ungated.
         bypassCanSendWriteWithoutResponse = false
@@ -2884,7 +2962,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             logger.error("BLE write-stall recovery budget exhausted; surfacing disconnect for \(deviceId, privacy: .public)")
             failQueuedWrites(BoardBleError.writeRecoveryFailed)
             writeStallRecoveries = 0
-            writeStallRecoveringPeripheralId = nil
+            writeStallRecovery = nil
             cancelConnectionIntentionallyOnBleQueue(peripheral)
             onDisconnect?(deviceId, ["context": "write_stall_budget_exhausted"])
             return
@@ -2901,7 +2979,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         failQueuedWrites(BoardBleError.writeTimedOut)
         writeStallRecoveries += 1
         logger.error("BLE write-stall recovery \(self.writeStallRecoveries, privacy: .public)/\(self.maxWriteStallRecoveries, privacy: .public): cycling the connection for \(deviceId, privacy: .public)")
-        writeStallRecoveringPeripheralId = peripheral.identifier
+        // Stamped HERE, at detection, and carried through the cancellation
+        // barrier into the reconnect — the reconnect must never re-stamp (#4499).
+        writeStallRecovery = WriteStallRecovery(
+            peripheralId: peripheral.identifier,
+            requestedAt: Date()
+        )
         cancelConnectionIntentionallyOnBleQueue(peripheral)
         // NOTE: bleLastPeripheralUuidKey is intentionally NOT cleared so the
         // deferred reconnectToLastKnownBoard can find this board.
@@ -2912,13 +2995,12 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         let recoveringId = peripheral.identifier
         writeStallRecoveryWatchdog?.cancel()
         writeStallRecoveryWatchdog = timerScheduler.scheduleOneShot(after: connectTimeout, label: "writeStallRecoveryWatchdog") { [weak self] in
-            guard let self, self.writeStallRecoveringPeripheralId == recoveringId else { return }
+            guard let self, self.writeStallRecovery?.peripheralId == recoveringId else { return }
             self.logger.error("BLE write-stall recovery stalled before reconnect (no didDisconnect); surfacing disconnect for \(recoveringId.uuidString, privacy: .public)")
-            self.writeStallRecoveringPeripheralId = nil
-            self.writeStallRecoveries = 0
-            self.writeCharacteristic = nil
-            self.connectedPeripheral = nil
-            self.onDisconnect?(recoveringId.uuidString, ["context": "write_stall_recovery_timeout"])
+            self.abandonWriteStallRecoveryOnBleQueue(
+                peripheralId: recoveringId,
+                context: "write_stall_recovery_timeout"
+            )
         }
     }
 
@@ -3285,7 +3367,22 @@ extension BoardBleManager {
         var writeGeneration: UInt64 { manager.writeGeneration }
         var currentTelemetry: BoardBleWriteTelemetry? { manager.currentWriteTelemetry }
         var writeStallRecoveries: Int { manager.writeStallRecoveries }
-        var writeStallRecoveringPeripheralId: UUID? { manager.writeStallRecoveringPeripheralId }
+        var writeStallRecoveringPeripheralId: UUID? { manager.writeStallRecovery?.peripheralId }
+        var writeStallRecoveryRequestedAt: Date? { manager.writeStallRecovery?.requestedAt }
+
+        /// Rewind the stall's stamp so a test can model a suspension inside the
+        /// cancel → `didDisconnect` gap without mutating the clock (#4499).
+        /// Returns false when no recovery is in flight, so a test can assert the
+        /// setup it thought it had.
+        @discardableResult
+        func rewindWriteStallRecovery(by interval: TimeInterval) -> Bool {
+            guard let recovery = manager.writeStallRecovery else { return false }
+            manager.writeStallRecovery = .init(
+                peripheralId: recovery.peripheralId,
+                requestedAt: recovery.requestedAt.addingTimeInterval(-interval)
+            )
+            return true
+        }
         var bypassCanSendWriteWithoutResponse: Bool { manager.bypassCanSendWriteWithoutResponse }
         var forceWriteWithResponse: Bool { manager.forceWriteWithResponse }
         var forceWriteWithResponseSource: BoardBleWriteTypeSource? { manager.forceWriteWithResponseSource }

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -604,7 +604,10 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             // authorised (a lightbulb reconnect, a write-stall recovery).
             guard appActive || self.implicitRelightAuthorizedForConnection else {
                 self.implicitRelightSuppressions += 1
-                self.logger.error("Suppressed configureBoard re-light while backgrounded on an unauthorised connection (#4499)")
+                // .info, not .error: this is the gate working as designed, and on a
+                // restored link every background adopt would otherwise write an
+                // error line into the error-rate signal.
+                self.logger.info("Suppressed configureBoard re-light while backgrounded on an unauthorised connection (#4499)")
                 return
             }
             self.implicitRelightAttempts += 1
@@ -1734,6 +1737,16 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         failQueuedWrites(error ?? BoardBleError.notConnected)
         onDisconnect?(deviceId, BoardBleEncoding.disconnectReasonBody(from: error))
 
+        // The link this request produced is gone, so the request stops being
+        // ours to honour: forget it, exactly as a deliberate disconnect does
+        // (#4499). Keeps "provenance describes the CURRENT connection" true for
+        // the window between an unexpected drop and the next connect, so a
+        // `configure(appActive: false)` arriving in that window cannot pass the
+        // authorisation latch against a dead link. Write-stall recovery is
+        // unaffected: its didDisconnect is consumed by the cancellation barrier
+        // above and returns long before here, re-stamping on its own reconnect.
+        clearConnectProvenanceOnBleQueue()
+
         // No auto-reconnect. These boards are last-connection-wins, so silently
         // re-grabbing the link would steal the wall back from whoever took it — a
         // ping-pong that flickers the LEDs. Reconnection is user-initiated only:
@@ -1936,7 +1949,9 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         guard authorized else {
             implicitRelightSuppressions += 1
             let ageSeconds = requestedAt.map { Date().timeIntervalSince($0) } ?? -1
-            logger.error("Suppressed implicit BLE re-light for \(deviceId, privacy: .public): origin=\(origin?.rawValue ?? "none", privacy: .public) ageSeconds=\(ageSeconds, privacy: .public)")
+            // .info: a refused re-light is the designed outcome of the gate, not a
+            // fault. The verdict still needs to be readable in Console.app.
+            logger.info("Suppressed implicit BLE re-light for \(deviceId, privacy: .public): origin=\(origin?.rawValue ?? "none", privacy: .public) ageSeconds=\(ageSeconds, privacy: .public)")
             return false
         }
         implicitRelightAttempts += 1
@@ -2111,7 +2126,7 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
             // Log the verdict anyway so Console.app still shows what the gate
             // decided for this connection.
             if !authorized {
-                logger.error("Implicit BLE re-light unauthorised for \(connectedDeviceId, privacy: .public) (origin=\(self.connectRequestOrigin?.rawValue ?? "none", privacy: .public)); an awaiting intent owns this write")
+                logger.info("Implicit BLE re-light unauthorised for \(connectedDeviceId, privacy: .public) (origin=\(self.connectRequestOrigin?.rawValue ?? "none", privacy: .public)); an awaiting intent owns this write")
             }
         } else {
             performImplicitRelightIfAuthorizedOnBleQueue(deviceId: connectedDeviceId)

--- a/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
@@ -198,6 +198,7 @@ public class BoardBleModule: Module {
         AsyncFunction("getConnectedDevice") { () -> [String: Any]? in
             guard let device = BoardBleManager.shared.connectedDeviceInfo else { return nil }
             let diagnostics = device.diagnostics
+            let provenance = BoardBleManager.shared.connectRelightProvenance
             return [
                 "deviceId": device.deviceId,
                 "name": device.name ?? "",
@@ -206,7 +207,11 @@ public class BoardBleModule: Module {
                 "supportsWriteWithoutResponse": diagnostics.supportsWriteWithoutResponse,
                 "chosenWriteType": diagnostics.chosenWriteType,
                 "maxWriteWithResponse": diagnostics.maxWriteWithResponse,
-                "maxWriteWithoutResponse": diagnostics.maxWriteWithoutResponse
+                "maxWriteWithoutResponse": diagnostics.maxWriteWithoutResponse,
+                // Implicit re-light provenance (additive; older JS ignores it).
+                // See BoardBleManager.shouldPerformImplicitRelight (#4499).
+                "connectOrigin": provenance.origin ?? "",
+                "implicitRelightSuppressed": provenance.implicitRelightSuppressed
             ]
         }
 
@@ -221,7 +226,8 @@ public class BoardBleModule: Module {
                     colorOverrides: options.colorOverrides ?? [:],
                     numRows: options.numRows,
                     lightAdjacentHolds: options.lightAdjacentHolds
-                )
+                ),
+                appActive: options.appActive
             )
         }
     }
@@ -273,6 +279,10 @@ struct ConfigureBoardOptions: Record {
     @Field var colorOverrides: [String: String]?
     // MoonBoard grid rows (18 standard, 12 Mini) — see #3392.
     @Field var numRows: Int?
+    // Whether the JS caller was in the foreground when it pushed this config.
+    // Defaults to true so an older JS bundle running against this binary keeps
+    // today's behaviour (mid-session colour re-lights still land) — see #4499.
+    @Field var appActive: Bool = true
     // MoonBoard "V2" additional-LED feature — see BoardBleConfiguration.
     @Field var lightAdjacentHolds: Bool?
 }

--- a/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleModule.swift
@@ -208,6 +208,7 @@ public class BoardBleModule: Module {
         AsyncFunction("getConnectedDevice") { () -> [String: Any]? in
             guard let device = BoardBleManager.shared.connectedDeviceInfo else { return nil }
             let diagnostics = device.diagnostics
+            let provenance = BoardBleManager.shared.connectRelightProvenance
             return [
                 "deviceId": device.deviceId,
                 "name": device.name ?? "",
@@ -216,7 +217,11 @@ public class BoardBleModule: Module {
                 "supportsWriteWithoutResponse": diagnostics.supportsWriteWithoutResponse,
                 "chosenWriteType": diagnostics.chosenWriteType,
                 "maxWriteWithResponse": diagnostics.maxWriteWithResponse,
-                "maxWriteWithoutResponse": diagnostics.maxWriteWithoutResponse
+                "maxWriteWithoutResponse": diagnostics.maxWriteWithoutResponse,
+                // Implicit re-light provenance (additive; older JS ignores it).
+                // See BoardBleManager.shouldPerformImplicitRelight (#4499).
+                "connectOrigin": provenance.origin ?? "",
+                "implicitRelightSuppressed": provenance.implicitRelightSuppressed
             ]
         }
 
@@ -231,7 +236,8 @@ public class BoardBleModule: Module {
                     colorOverrides: options.colorOverrides ?? [:],
                     numRows: options.numRows,
                     lightAdjacentHolds: options.lightAdjacentHolds
-                )
+                ),
+                appActive: options.appActive
             )
         }
     }
@@ -283,6 +289,10 @@ struct ConfigureBoardOptions: Record {
     @Field var colorOverrides: [String: String]?
     // MoonBoard grid rows (18 standard, 12 Mini) — see #3392.
     @Field var numRows: Int?
+    // Whether the JS caller was in the foreground when it pushed this config.
+    // Defaults to true so an older JS bundle running against this binary keeps
+    // today's behaviour (mid-session colour re-lights still land) — see #4499.
+    @Field var appActive: Bool = true
     // MoonBoard "V2" additional-LED feature — see BoardBleConfiguration.
     @Field var lightAdjacentHolds: Bool?
 }

--- a/packages/mobile/modules/live-activity/ios/LiveActivityBleBridge.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityBleBridge.swift
@@ -42,7 +42,7 @@ enum LiveActivityBleBridge {
         task.begin(name: "ble-reconnect-intent")
         defer { task.end() }
         return await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-            BoardBleManager.shared.reconnectToLastKnownBoard { result in
+            BoardBleManager.shared.reconnectToLastKnownBoard(origin: .liveActivityIntent) { result in
                 switch result {
                 case .success:
                     continuation.resume(returning: true)

--- a/packages/mobile/modules/live-activity/ios/LiveActivityBleBridge.swift
+++ b/packages/mobile/modules/live-activity/ios/LiveActivityBleBridge.swift
@@ -47,7 +47,7 @@ enum LiveActivityBleBridge {
         task.begin(name: "ble-reconnect-intent")
         defer { task.end() }
         return await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-            BoardBleManager.shared.reconnectToLastKnownBoard { result in
+            BoardBleManager.shared.reconnectToLastKnownBoard(origin: .liveActivityIntent) { result in
                 switch result {
                 case .success:
                     continuation.resume(returning: true)

--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -59,6 +59,19 @@ export type NativeBleConnectedDevice = {
   chosenWriteType?: 'withoutResponse' | 'withResponse';
   maxWriteWithResponse?: number;
   maxWriteWithoutResponse?: number;
+  /**
+   * How the current connection came to be: a JS `connect`, the Live Activity
+   * lightbulb, automatic write-stall recovery, or a CoreBluetooth state
+   * restoration nobody in this process asked for. Empty string when the binary
+   * has no provenance recorded. See #4499.
+   */
+  connectOrigin?: string;
+  /**
+   * True when this connection's success point was NOT allowed to re-light the
+   * wall from the persisted queue — either nobody asked for it, or the request
+   * that produced it was too old to still mean anything. See #4499.
+   */
+  implicitRelightSuppressed?: boolean;
 };
 
 /**
@@ -127,6 +140,15 @@ export type NativeBleConfigureBoardOptions = {
    * (makeMoonboardPacket). No-op on Aurora boards; older binaries ignore it.
    */
   lightAdjacentHolds?: boolean;
+  /**
+   * Whether the app was in the foreground when this configuration was pushed.
+   * Native re-lights the wall on every `configureBoard` so a colour change
+   * lands immediately; a background BLE wake also boots React Native, which
+   * would otherwise repaint a wall the native connect gate deliberately kept
+   * dark. Native defaults it to `true`, so an older JS bundle keeps today's
+   * behaviour. See #4499.
+   */
+  appActive?: boolean;
 };
 
 type BoardBleNativeModule = {

--- a/packages/mobile/modules/live-activity/src/index.ts
+++ b/packages/mobile/modules/live-activity/src/index.ts
@@ -59,6 +59,19 @@ export type NativeBleConnectedDevice = {
   chosenWriteType?: 'withoutResponse' | 'withResponse';
   maxWriteWithResponse?: number;
   maxWriteWithoutResponse?: number;
+  /**
+   * How the current connection came to be: a JS `connect`, the Live Activity
+   * lightbulb, automatic write-stall recovery, or a CoreBluetooth state
+   * restoration nobody in this process asked for. Empty string when the binary
+   * has no provenance recorded. See #4499.
+   */
+  connectOrigin?: string;
+  /**
+   * True when this connection's success point was NOT allowed to re-light the
+   * wall from the persisted queue — either nobody asked for it, or the request
+   * that produced it was too old to still mean anything. See #4499.
+   */
+  implicitRelightSuppressed?: boolean;
 };
 
 /**
@@ -129,6 +142,15 @@ export type NativeBleConfigureBoardOptions = {
    * (makeMoonboardPacket). No-op on Aurora boards; older binaries ignore it.
    */
   lightAdjacentHolds?: boolean;
+  /**
+   * Whether the app was in the foreground when this configuration was pushed.
+   * Native re-lights the wall on every `configureBoard` so a colour change
+   * lands immediately; a background BLE wake also boots React Native, which
+   * would otherwise repaint a wall the native connect gate deliberately kept
+   * dark. Native defaults it to `true`, so an older JS bundle keeps today's
+   * behaviour. See #4499.
+   */
+  appActive?: boolean;
 };
 
 type BoardBleNativeModule = {

--- a/packages/mobile/src/lib/__tests__/sentry.test.ts
+++ b/packages/mobile/src/lib/__tests__/sentry.test.ts
@@ -235,16 +235,34 @@ describe('applyBleDiagnosticsToScope', () => {
   it('clears every BLE tag (sets undefined) when given null', () => {
     const scope = makeScope();
     applyBleDiagnosticsToScope(scope, null);
-    expect(scope.setTag).toHaveBeenCalledTimes(5);
+    expect(scope.setTag).toHaveBeenCalledTimes(7);
     for (const key of [
       'ble_chosen_write_type',
       'ble_supports_without_response',
       'ble_char_properties',
       'ble_max_with_response',
       'ble_max_without_response',
+      'ble_connect_origin',
+      'ble_relight_suppressed',
     ]) {
       expect(scope.setTag).toHaveBeenCalledWith(key, undefined);
     }
+  });
+
+  // #4499 — the zombie reconnect is not reproducible on demand, so these two
+  // tags are the only way to see the gate firing in the field.
+  it('tags how the connection came to be and whether the re-light was suppressed', () => {
+    const scope = makeScope();
+    applyBleDiagnosticsToScope(scope, { connectOrigin: 'restored', implicitRelightSuppressed: true });
+    expect(scope.setTag).toHaveBeenCalledWith('ble_connect_origin', 'restored');
+    expect(scope.setTag).toHaveBeenCalledWith('ble_relight_suppressed', 'true');
+  });
+
+  it('treats the empty connect origin the bridge sends for an unknown link as absent', () => {
+    const scope = makeScope();
+    applyBleDiagnosticsToScope(scope, { connectOrigin: '', implicitRelightSuppressed: false });
+    expect(scope.setTag).toHaveBeenCalledTimes(1);
+    expect(scope.setTag).toHaveBeenCalledWith('ble_relight_suppressed', 'false');
   });
 });
 

--- a/packages/mobile/src/lib/ble/__tests__/disconnect-category.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/disconnect-category.test.ts
@@ -22,6 +22,7 @@ describe('classifyBleDisconnect', () => {
     expect(classifyBleDisconnect({ source: 'native-ios', context: 'write_stall_recovery_timeout' })).toBe(
       'app_recovery',
     );
+    expect(classifyBleDisconnect({ source: 'native-ios', context: 'write_stall_recovery_stale' })).toBe('app_recovery');
   });
 
   it('maps the central-state marker to bluetooth_off', () => {

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -1774,6 +1774,112 @@ describe('useBoardBluetooth native connection adoption', () => {
     });
   });
 
+  // #4499, JS half. Native keeps the wall dark on an off-screen wake, but the
+  // auto-sender mounts the moment `isConnected` flips and would push the
+  // restored queue's current climb over the same link. The gate is what the
+  // auto-sender asks before every write.
+  it('arms the off-screen-adopt send gate when native reports a suppressed re-light', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+    vi.mocked(getNativeBleConnectedDevice).mockResolvedValue({
+      deviceId: 'native-dev',
+      name: 'Kilter Board#9@3',
+      connectOrigin: 'restored',
+      implicitRelightSuppressed: true,
+    });
+    mockAppState.currentState = 'background';
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      connectedListener?.({ deviceId: 'native-dev', deviceName: 'Kilter Board#9@3' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+    expect(result.current.consumeBackgroundAdoptSendGate()).toBe(true);
+    await waitFor(() => {
+      expect(mockTrack).toHaveBeenCalledWith(
+        'BLE Implicit Relight Suppressed',
+        expect.objectContaining({ surface: 'native_connect', connectOrigin: 'restored' }),
+      );
+    });
+  });
+
+  it('releases the send gate once the app is back on screen', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+    mockAppState.currentState = 'background';
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      connectedListener?.({ deviceId: 'native-dev', deviceName: 'Kilter Board#9@3' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+    expect(result.current.consumeBackgroundAdoptSendGate()).toBe(true);
+
+    mockAppState.currentState = 'active';
+    expect(result.current.consumeBackgroundAdoptSendGate()).toBe(false);
+    // One-way: the gate is spent, so a later trip to the background doesn't
+    // re-arm it and strand a session the user is actually driving.
+    mockAppState.currentState = 'background';
+    expect(result.current.consumeBackgroundAdoptSendGate()).toBe(false);
+  });
+
+  // A lightbulb reconnect or a #3181 write-stall recovery IS an authorised
+  // connection: native re-lit the wall itself, and a phone in a pocket must keep
+  // driving it for a party peer. Only the unauthorised wake stays silent.
+  it('leaves the send gate open when native authorised the re-light', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+    vi.mocked(getNativeBleConnectedDevice).mockResolvedValue({
+      deviceId: 'native-dev',
+      name: 'Kilter Board#9@3',
+      connectOrigin: 'liveActivityIntent',
+      implicitRelightSuppressed: false,
+    });
+    mockAppState.currentState = 'background';
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      connectedListener?.({ deviceId: 'native-dev', deviceName: 'Kilter Board#9@3' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.consumeBackgroundAdoptSendGate()).toBe(false);
+    });
+    expect(mockTrack).not.toHaveBeenCalledWith('BLE Implicit Relight Suppressed', expect.anything());
+  });
+
+  it('never arms the send gate for an adopt that happens on screen', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+    vi.mocked(getNativeBleConnectedDevice).mockResolvedValue({
+      deviceId: 'native-dev',
+      name: 'Kilter Board#9@3',
+      connectOrigin: 'restored',
+      implicitRelightSuppressed: true,
+    });
+    mockAppState.currentState = 'active';
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      connectedListener?.({ deviceId: 'native-dev', deviceName: 'Kilter Board#9@3' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+    expect(result.current.consumeBackgroundAdoptSendGate()).toBe(false);
+  });
+
   it('adopts a natively-connected board matching the active config', async () => {
     const adapter = makeAdoptableAdapter();
     vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -1731,6 +1731,22 @@ describe('useBoardBluetooth native connection adoption', () => {
     }
   });
 
+  it('tells native the app was on screen for a deliberate connect, including during a call overlay', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+    // `inactive` is iOS's "on screen but not receiving events" — a call banner
+    // or the app switcher. The user is still looking at the app.
+    mockAppState.currentState = 'inactive';
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(adapter.configureBoard).toHaveBeenCalledWith(expect.objectContaining({ appActive: true }));
+  });
+
   it('tells native the app was in the foreground when the user changes colours on screen', async () => {
     const adapter = makeAdoptableAdapter();
     vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -15,11 +15,18 @@ const mockBleManager = vi.hoisted(() => ({
   onStateChange: vi.fn(),
 }));
 
+// Mutable so a test can put the app in the background and assert what the hook
+// tells native about it (`appActive` on configureBoard — see #4499).
+const mockAppState = vi.hoisted(() => ({
+  currentState: 'active' as 'active' | 'background' | 'inactive',
+  addEventListener: vi.fn(() => ({ remove: vi.fn() })),
+}));
+
 vi.mock('react-native', async () => {
   const { reactNativePermissionHarness: harness } = await import('./react-native-permissions-test-harness');
   return {
     Alert: { alert: vi.fn() },
-    AppState: { addEventListener: vi.fn(() => ({ remove: vi.fn() })) },
+    AppState: mockAppState,
     Platform: harness.platform,
     PermissionsAndroid: harness.permissionsAndroid,
   };
@@ -1693,11 +1700,62 @@ describe('useBoardBluetooth native connection adoption', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    mockAppState.currentState = 'active';
     vi.mocked(subscribeNativeBleConnected).mockImplementation(() => null);
     vi.mocked(getNativeBleConnectedDevice).mockImplementation(async () => null);
     vi.mocked(isNativeIosBleAdapter).mockReturnValue(false);
     vi.mocked(parseBoardTypeFromDeviceName).mockReset();
     vi.mocked(parseSerialNumber).mockReset();
+  });
+
+  // #4499: native re-lights the wall on every configureBoard, and a background
+  // BLE wake boots React Native — which adopts and immediately pushes a config.
+  // Telling native whether we were actually on screen is what stops that
+  // repainting a wall the native connect gate deliberately left dark.
+  it('tells native the app was backgrounded when it adopts from a background wake', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+    mockAppState.currentState = 'background';
+
+    renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      connectedListener?.({ deviceId: 'native-dev', deviceName: 'Kilter Board#9@3' });
+    });
+
+    await waitFor(() => {
+      expect(adapter.configureBoard).toHaveBeenCalledWith(expect.objectContaining({ appActive: false }));
+    });
+    for (const call of adapter.configureBoard.mock.calls) {
+      expect(call[0]).toMatchObject({ appActive: false });
+    }
+  });
+
+  it('tells native the app was in the foreground when the user changes colours on screen', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+    mockAppState.currentState = 'active';
+
+    const { rerender } = renderHook((props) => useBoardBluetooth(props), {
+      initialProps: {
+        boardName: 'kilter' as const,
+        layoutId: 1,
+        sizeId: 1,
+        ledColorOverrides: { HAND: '#111111' },
+      },
+    });
+
+    await act(async () => {
+      connectedListener?.({ deviceId: 'native-dev', deviceName: 'Kilter Board#9@3' });
+    });
+
+    rerender({ boardName: 'kilter', layoutId: 1, sizeId: 1, ledColorOverrides: { HAND: '#222222' } });
+
+    await waitFor(() => {
+      expect(adapter.configureBoard).toHaveBeenCalledWith(
+        expect.objectContaining({ colorOverrides: { HAND: '#222222' }, appActive: true }),
+      );
+    });
   });
 
   it('adopts a natively-connected board matching the active config', async () => {

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -2225,6 +2225,112 @@ describe('useBoardBluetooth native connection adoption', () => {
     });
   });
 
+  // #4499, JS half. Native keeps the wall dark on an off-screen wake, but the
+  // auto-sender mounts the moment `isConnected` flips and would push the
+  // restored queue's current climb over the same link. The gate is what the
+  // auto-sender asks before every write.
+  it('arms the off-screen-adopt send gate when native reports a suppressed re-light', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+    vi.mocked(getNativeBleConnectedDevice).mockResolvedValue({
+      deviceId: 'native-dev',
+      name: 'Kilter Board#9@3',
+      connectOrigin: 'restored',
+      implicitRelightSuppressed: true,
+    });
+    mockAppState.currentState = 'background';
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      connectedListener?.({ deviceId: 'native-dev', deviceName: 'Kilter Board#9@3' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+    expect(result.current.consumeBackgroundAdoptSendGate()).toBe(true);
+    await waitFor(() => {
+      expect(mockTrack).toHaveBeenCalledWith(
+        'BLE Implicit Relight Suppressed',
+        expect.objectContaining({ surface: 'native_connect', connectOrigin: 'restored' }),
+      );
+    });
+  });
+
+  it('releases the send gate once the app is back on screen', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+    mockAppState.currentState = 'background';
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      connectedListener?.({ deviceId: 'native-dev', deviceName: 'Kilter Board#9@3' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+    expect(result.current.consumeBackgroundAdoptSendGate()).toBe(true);
+
+    mockAppState.currentState = 'active';
+    expect(result.current.consumeBackgroundAdoptSendGate()).toBe(false);
+    // One-way: the gate is spent, so a later trip to the background doesn't
+    // re-arm it and strand a session the user is actually driving.
+    mockAppState.currentState = 'background';
+    expect(result.current.consumeBackgroundAdoptSendGate()).toBe(false);
+  });
+
+  // A lightbulb reconnect or a #3181 write-stall recovery IS an authorised
+  // connection: native re-lit the wall itself, and a phone in a pocket must keep
+  // driving it for a party peer. Only the unauthorised wake stays silent.
+  it('leaves the send gate open when native authorised the re-light', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+    vi.mocked(getNativeBleConnectedDevice).mockResolvedValue({
+      deviceId: 'native-dev',
+      name: 'Kilter Board#9@3',
+      connectOrigin: 'liveActivityIntent',
+      implicitRelightSuppressed: false,
+    });
+    mockAppState.currentState = 'background';
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      connectedListener?.({ deviceId: 'native-dev', deviceName: 'Kilter Board#9@3' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.consumeBackgroundAdoptSendGate()).toBe(false);
+    });
+    expect(mockTrack).not.toHaveBeenCalledWith('BLE Implicit Relight Suppressed', expect.anything());
+  });
+
+  it('never arms the send gate for an adopt that happens on screen', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+    vi.mocked(getNativeBleConnectedDevice).mockResolvedValue({
+      deviceId: 'native-dev',
+      name: 'Kilter Board#9@3',
+      connectOrigin: 'restored',
+      implicitRelightSuppressed: true,
+    });
+    mockAppState.currentState = 'active';
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      connectedListener?.({ deviceId: 'native-dev', deviceName: 'Kilter Board#9@3' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+    expect(result.current.consumeBackgroundAdoptSendGate()).toBe(false);
+  });
+
   it('adopts a natively-connected board matching the active config', async () => {
     const adapter = makeAdoptableAdapter();
     vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -15,11 +15,18 @@ const mockBleManager = vi.hoisted(() => ({
   onStateChange: vi.fn(),
 }));
 
+// Mutable so a test can put the app in the background and assert what the hook
+// tells native about it (`appActive` on configureBoard — see #4499).
+const mockAppState = vi.hoisted(() => ({
+  currentState: 'active' as 'active' | 'background' | 'inactive',
+  addEventListener: vi.fn(() => ({ remove: vi.fn() })),
+}));
+
 vi.mock('react-native', async () => {
   const { reactNativePermissionHarness: harness } = await import('./react-native-permissions-test-harness');
   return {
     Alert: { alert: vi.fn() },
-    AppState: { addEventListener: vi.fn(() => ({ remove: vi.fn() })) },
+    AppState: mockAppState,
     Platform: harness.platform,
     PermissionsAndroid: harness.permissionsAndroid,
   };
@@ -2144,11 +2151,62 @@ describe('useBoardBluetooth native connection adoption', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    mockAppState.currentState = 'active';
     vi.mocked(subscribeNativeBleConnected).mockImplementation(() => null);
     vi.mocked(getNativeBleConnectedDevice).mockImplementation(async () => null);
     vi.mocked(isNativeIosBleAdapter).mockReturnValue(false);
     vi.mocked(parseBoardTypeFromDeviceName).mockReset();
     vi.mocked(parseSerialNumber).mockReset();
+  });
+
+  // #4499: native re-lights the wall on every configureBoard, and a background
+  // BLE wake boots React Native — which adopts and immediately pushes a config.
+  // Telling native whether we were actually on screen is what stops that
+  // repainting a wall the native connect gate deliberately left dark.
+  it('tells native the app was backgrounded when it adopts from a background wake', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+    mockAppState.currentState = 'background';
+
+    renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      connectedListener?.({ deviceId: 'native-dev', deviceName: 'Kilter Board#9@3' });
+    });
+
+    await waitFor(() => {
+      expect(adapter.configureBoard).toHaveBeenCalledWith(expect.objectContaining({ appActive: false }));
+    });
+    for (const call of adapter.configureBoard.mock.calls) {
+      expect(call[0]).toMatchObject({ appActive: false });
+    }
+  });
+
+  it('tells native the app was in the foreground when the user changes colours on screen', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+    mockAppState.currentState = 'active';
+
+    const { rerender } = renderHook((props) => useBoardBluetooth(props), {
+      initialProps: {
+        boardName: 'kilter' as const,
+        layoutId: 1,
+        sizeId: 1,
+        ledColorOverrides: { HAND: '#111111' },
+      },
+    });
+
+    await act(async () => {
+      connectedListener?.({ deviceId: 'native-dev', deviceName: 'Kilter Board#9@3' });
+    });
+
+    rerender({ boardName: 'kilter', layoutId: 1, sizeId: 1, ledColorOverrides: { HAND: '#222222' } });
+
+    await waitFor(() => {
+      expect(adapter.configureBoard).toHaveBeenCalledWith(
+        expect.objectContaining({ colorOverrides: { HAND: '#222222' }, appActive: true }),
+      );
+    });
   });
 
   it('adopts a natively-connected board matching the active config', async () => {

--- a/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-bluetooth.test.ts
@@ -2182,6 +2182,22 @@ describe('useBoardBluetooth native connection adoption', () => {
     }
   });
 
+  it('tells native the app was on screen for a deliberate connect, including during a call overlay', async () => {
+    const adapter = makeAdoptableAdapter();
+    vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);
+    // `inactive` is iOS's "on screen but not receiving events" — a call banner
+    // or the app switcher. The user is still looking at the app.
+    mockAppState.currentState = 'inactive';
+
+    const { result } = renderHook(() => useBoardBluetooth({ boardName: 'kilter', layoutId: 1, sizeId: 1 }));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(adapter.configureBoard).toHaveBeenCalledWith(expect.objectContaining({ appActive: true }));
+  });
+
   it('tells native the app was in the foreground when the user changes colours on screen', async () => {
     const adapter = makeAdoptableAdapter();
     vi.mocked(createBluetoothAdapter).mockReturnValue(adapter as unknown as ReturnType<typeof createBluetoothAdapter>);

--- a/packages/mobile/src/lib/ble/disconnect-category.ts
+++ b/packages/mobile/src/lib/ble/disconnect-category.ts
@@ -38,6 +38,12 @@ const APP_RECOVERY_CONTEXTS = new Set([
   'write_stall_recovery_failed',
   'write_stall_budget_exhausted',
   'write_stall_recovery_timeout',
+  // The cancel's didDisconnect arrived so long after the stall that the
+  // recovery was abandoned rather than reconnected — the phone was suspended
+  // through the window no watchdog can bound (#4499). Kept distinct from
+  // _timeout, which is the opposite failure (no didDisconnect at all while the
+  // radio stayed on): same bucket, different signature to query on.
+  'write_stall_recovery_stale',
 ]);
 
 export function classifyBleDisconnect(info: BleDisconnectInfo | null | undefined): BleDisconnectCategory {

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -137,13 +137,19 @@ export async function dispatchMoonboardPacket(
   return true;
 }
 
-// Whether the app is in the foreground right now. Native re-lights the wall on
-// every configureBoard so a colour change lands immediately, but a background
-// BLE wake also boots React Native — and the adopt path below pushes a config as
-// soon as it adopts. Passing the real foreground state lets native keep the wall
-// dark when nobody asked for the connection (#4499).
+// Whether the app is on screen right now. Native re-lights the wall on every
+// configureBoard so a colour change lands immediately, but a background BLE wake
+// also boots React Native — and the adopt path below pushes a config as soon as
+// it adopts. Passing the real foreground state lets native keep the wall dark
+// when nobody asked for the connection (#4499).
+//
+// `inactive` counts as on screen: iOS reports it while a call banner or the app
+// switcher is overlaid, and the user is still looking at us. Only `background`
+// is the wake-with-nobody-there case — a CoreBluetooth background launch reports
+// `background`, never `inactive` — so widening here can't reopen the bug, and it
+// stops a colour change landing during a call overlay from being dropped.
 function isAppActive(): boolean {
-  return AppState.currentState === 'active';
+  return AppState.currentState === 'active' || AppState.currentState === 'inactive';
 }
 
 // MoonBoard grid rows for the native configureBoard payload, so native

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -545,6 +545,21 @@ export function useBoardBluetooth({
   // byte-identical current climb doesn't get re-sent immediately on connect —
   // a redundant full-frame write plus a doubled success haptic.
   const connectInitialSendRef = useRef<BleConnectInitialSend | null>(null);
+  // #4499, JS half. A background BLE wake — CoreBluetooth state restoration
+  // after a jetsam kill, or a connect parked across suspension and honoured days
+  // later — boots React Native, and the adopt path below flips `isConnected`.
+  // That mounts the auto-sender, whose first drain would push the restored
+  // queue's current climb and re-light the wall the native connect gate just
+  // kept dark. So the adopt path arms this gate whenever it adopts off screen,
+  // and the auto-sender refuses its write while it is armed.
+  //
+  // Native's own verdict releases it: `implicitRelightSuppressed === false`
+  // means the gate authorised this connection (a Live Activity lightbulb
+  // reconnect, a #3181 write-stall recovery), so a phone in a pocket keeps
+  // driving the wall for a party peer. Only the unauthorised off-screen adopt —
+  // the reported bug — stays silent, and it releases the moment the app is back
+  // on screen.
+  const backgroundAdoptSendGateRef = useRef(false);
   const configuredDeviceNameRef = useRef<string | undefined>(undefined);
   // The physical-link lifetime belongs to the adapter generation, not React's
   // rendered `isConnected` edge. It begins as soon as the adapter identity and
@@ -710,6 +725,7 @@ export function useBoardBluetooth({
       adapterRef.current = null;
       configuredDeviceNameRef.current = undefined;
       connectedConfigIdentityRef.current = null;
+      backgroundAdoptSendGateRef.current = false;
       writeAbortRef.current?.abort();
       writeAbortRef.current = null;
       writeChainRef.current = Promise.resolve();
@@ -1071,6 +1087,9 @@ export function useBoardBluetooth({
       // A deliberate connect re-arms native-connection adoption after an
       // earlier explicit disconnect suppressed it.
       adoptionSuppressedRef.current = false;
+      // The user asked for this link, so the off-screen-adopt gate from any
+      // previous connection must not survive into it (#4499).
+      backgroundAdoptSendGateRef.current = false;
 
       setLoading(true);
 
@@ -1479,6 +1498,7 @@ export function useBoardBluetooth({
       // app could otherwise see getConnectedDevice still report the device this
       // teardown is closing and silently re-adopt it.
       adoptionSuppressedRef.current = true;
+      backgroundAdoptSendGateRef.current = false;
       unsubDisconnectRef.current?.();
       unsubDisconnectRef.current = null;
       const adapter = adapterRef.current;
@@ -1579,6 +1599,11 @@ export function useBoardBluetooth({
 
       const adapter = createBluetoothAdapter(devicePicker, scanFamilyForBoard(boardName));
       if (!isNativeIosBleAdapter(adapter) || typeof adapter.configureBoard !== 'function') return;
+      // Arm the JS re-light gate before anything can flip `isConnected`: an
+      // adopt that happens while the app is off screen is a wake nobody asked
+      // for until native's verdict says otherwise (#4499).
+      const adoptedOffScreen = !isAppActive();
+      backgroundAdoptSendGateRef.current = adoptedOffScreen;
       adapter.adoptConnection(deviceId);
       apiLevelRef.current = parseApiLevel(deviceName);
       configuredDeviceNameRef.current = deviceName;
@@ -1623,7 +1648,25 @@ export function useBoardBluetooth({
       // (widget reconnect / state restoration paths, not just JS connect).
       // Fire-and-forget; a native rejection is intentionally ignored.
       void getNativeBleConnectedDevice()
-        .then(setBleDiagnosticsTags)
+        .then((device) => {
+          setBleDiagnosticsTags(device);
+          if (!adoptedOffScreen) return;
+          // Native authorised this connection's implicit re-light (lightbulb
+          // reconnect, write-stall recovery), so the auto-sender may drive the
+          // wall even though we adopted off screen. `undefined` is an older
+          // binary with no verdict to report: stay armed, fail closed.
+          if (device?.implicitRelightSuppressed === false) {
+            backgroundAdoptSendGateRef.current = false;
+            return;
+          }
+          track(SHARED_EVENTS.BleImplicitRelightSuppressed, {
+            surface: 'native_connect',
+            connectOrigin: device?.connectOrigin || undefined,
+            boardName,
+            layoutId,
+            sizeId,
+          });
+        })
         .catch(() => {});
     };
 
@@ -1761,6 +1804,23 @@ export function useBoardBluetooth({
     };
   }, [consumeConnectionLifetime, writeActivityStore]);
 
+  // Asked by the auto-sender immediately before each write it is about to make:
+  // `true` means refuse this one (#4499). Kept in the hook rather than read from
+  // a ref by the provider so the AppState reading and the gate's release rule
+  // stay in one place, next to the adopt path that arms it.
+  //
+  // The release is checked here, not at arm time, because the queue snapshot can
+  // hydrate long after the adopt: the user may already be back on screen by the
+  // time a write is first on the table, and then they should get their wall.
+  const consumeBackgroundAdoptSendGate = useCallback(() => {
+    if (!backgroundAdoptSendGateRef.current) return false;
+    if (isAppActive()) {
+      backgroundAdoptSendGateRef.current = false;
+      return false;
+    }
+    return true;
+  }, []);
+
   return {
     isConnected,
     loading,
@@ -1771,5 +1831,6 @@ export function useBoardBluetooth({
     reconnectSerialForCurrentBoard,
     reconnectDeviceIdForCurrentBoard,
     connectInitialSendRef,
+    consumeBackgroundAdoptSendGate,
   };
 }

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -1655,6 +1655,14 @@ export function useBoardBluetooth({
           // reconnect, write-stall recovery), so the auto-sender may drive the
           // wall even though we adopted off screen. `undefined` is an older
           // binary with no verdict to report: stay armed, fail closed.
+          //
+          // The release is asynchronous and can land after the auto-sender's
+          // first drain. That is safe by construction: arming happens
+          // synchronously above, before `setIsConnected`, so the gate can only
+          // ever fail closed. On an authorised link the cost is at most one
+          // skipped JS write, and native already re-lit the wall itself at its
+          // own success point — every later write (a party peer's climb change)
+          // sees the released gate.
           if (device?.implicitRelightSuppressed === false) {
             backgroundAdoptSendGateRef.current = false;
             return;

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -137,6 +137,15 @@ export async function dispatchMoonboardPacket(
   return true;
 }
 
+// Whether the app is in the foreground right now. Native re-lights the wall on
+// every configureBoard so a colour change lands immediately, but a background
+// BLE wake also boots React Native — and the adopt path below pushes a config as
+// soon as it adopts. Passing the real foreground state lets native keep the wall
+// dark when nobody asked for the connection (#4499).
+function isAppActive(): boolean {
+  return AppState.currentState === 'active';
+}
+
 // MoonBoard grid rows for the native configureBoard payload, so native
 // re-encodes (widget intents, reconnect re-light) use the same serpentine grid
 // as the JS send path — Mini strips are 12 rows, standard 18 (#3392). Undefined
@@ -1177,6 +1186,7 @@ export function useBoardBluetooth({
               colorOverrides: sanitizedColorOverrides,
               numRows: moonboardNumRowsForNative(boardName, layoutId),
               lightAdjacentHolds: moonboardLightAdjacentHolds,
+              appActive: isAppActive(),
             });
           } catch (error) {
             console.warn('[BLE] Failed to push board configuration to native side:', error);
@@ -1590,6 +1600,7 @@ export function useBoardBluetooth({
           colorOverrides: sanitizedColorOverrides,
           numRows: moonboardNumRowsForNative(boardName, layoutId),
           lightAdjacentHolds: moonboardLightAdjacentHolds,
+          appActive: isAppActive(),
         })
         .catch(() => {});
 
@@ -1670,6 +1681,7 @@ export function useBoardBluetooth({
         colorOverrides: sanitizedColorOverrides,
         numRows: moonboardNumRowsForNative(boardName, layoutId),
         lightAdjacentHolds: moonboardLightAdjacentHolds,
+        appActive: isAppActive(),
       })
       .catch(() => {});
   }, [boardName, layoutId, sizeId, isConnected, sanitizedColorOverrides, moonboardLightAdjacentHolds]);

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -214,6 +214,15 @@ export async function dispatchWoodsPacket(
   };
 }
 
+// Whether the app is in the foreground right now. Native re-lights the wall on
+// every configureBoard so a colour change lands immediately, but a background
+// BLE wake also boots React Native — and the adopt path below pushes a config as
+// soon as it adopts. Passing the real foreground state lets native keep the wall
+// dark when nobody asked for the connection (#4499).
+function isAppActive(): boolean {
+  return AppState.currentState === 'active';
+}
+
 // MoonBoard grid rows for the native configureBoard payload, so native
 // re-encodes (widget intents, reconnect re-light) use the same serpentine grid
 // as the JS send path — Mini strips are 12 rows, standard 18 (#3392). Undefined
@@ -1493,6 +1502,7 @@ export function useBoardBluetooth({
               colorOverrides: sanitizedColorOverrides,
               numRows: moonboardNumRowsForNative(boardName, layoutId),
               lightAdjacentHolds: moonboardLightAdjacentHolds,
+              appActive: isAppActive(),
             });
           } catch (error) {
             console.warn('[BLE] Failed to push board configuration to native side:', error);
@@ -1918,6 +1928,7 @@ export function useBoardBluetooth({
           colorOverrides: sanitizedColorOverrides,
           numRows: moonboardNumRowsForNative(boardName, layoutId),
           lightAdjacentHolds: moonboardLightAdjacentHolds,
+          appActive: isAppActive(),
         })
         .catch(() => {});
 
@@ -1998,6 +2009,7 @@ export function useBoardBluetooth({
         colorOverrides: sanitizedColorOverrides,
         numRows: moonboardNumRowsForNative(boardName, layoutId),
         lightAdjacentHolds: moonboardLightAdjacentHolds,
+        appActive: isAppActive(),
       })
       .catch(() => {});
   }, [boardName, layoutId, sizeId, isConnected, sanitizedColorOverrides, moonboardLightAdjacentHolds]);

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -214,13 +214,19 @@ export async function dispatchWoodsPacket(
   };
 }
 
-// Whether the app is in the foreground right now. Native re-lights the wall on
-// every configureBoard so a colour change lands immediately, but a background
-// BLE wake also boots React Native — and the adopt path below pushes a config as
-// soon as it adopts. Passing the real foreground state lets native keep the wall
-// dark when nobody asked for the connection (#4499).
+// Whether the app is on screen right now. Native re-lights the wall on every
+// configureBoard so a colour change lands immediately, but a background BLE wake
+// also boots React Native — and the adopt path below pushes a config as soon as
+// it adopts. Passing the real foreground state lets native keep the wall dark
+// when nobody asked for the connection (#4499).
+//
+// `inactive` counts as on screen: iOS reports it while a call banner or the app
+// switcher is overlaid, and the user is still looking at us. Only `background`
+// is the wake-with-nobody-there case — a CoreBluetooth background launch reports
+// `background`, never `inactive` — so widening here can't reopen the bug, and it
+// stops a colour change landing during a call overlay from being dropped.
 function isAppActive(): boolean {
-  return AppState.currentState === 'active';
+  return AppState.currentState === 'active' || AppState.currentState === 'inactive';
 }
 
 // MoonBoard grid rows for the native configureBoard payload, so native

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -649,6 +649,21 @@ export function useBoardBluetooth({
   // byte-identical current climb doesn't get re-sent immediately on connect —
   // a redundant full-frame write plus a doubled success haptic.
   const connectInitialSendRef = useRef<BleConnectInitialSend | null>(null);
+  // #4499, JS half. A background BLE wake — CoreBluetooth state restoration
+  // after a jetsam kill, or a connect parked across suspension and honoured days
+  // later — boots React Native, and the adopt path below flips `isConnected`.
+  // That mounts the auto-sender, whose first drain would push the restored
+  // queue's current climb and re-light the wall the native connect gate just
+  // kept dark. So the adopt path arms this gate whenever it adopts off screen,
+  // and the auto-sender refuses its write while it is armed.
+  //
+  // Native's own verdict releases it: `implicitRelightSuppressed === false`
+  // means the gate authorised this connection (a Live Activity lightbulb
+  // reconnect, a #3181 write-stall recovery), so a phone in a pocket keeps
+  // driving the wall for a party peer. Only the unauthorised off-screen adopt —
+  // the reported bug — stays silent, and it releases the moment the app is back
+  // on screen.
+  const backgroundAdoptSendGateRef = useRef(false);
   const configuredDeviceNameRef = useRef<string | undefined>(undefined);
   // The physical-link lifetime belongs to the adapter generation, not React's
   // rendered `isConnected` edge. It begins as soon as the adapter identity and
@@ -816,6 +831,7 @@ export function useBoardBluetooth({
       adapterRef.current = null;
       configuredDeviceNameRef.current = undefined;
       connectedConfigIdentityRef.current = null;
+      backgroundAdoptSendGateRef.current = false;
       writeAbortRef.current?.abort();
       writeAbortRef.current = null;
       writeChainRef.current = Promise.resolve();
@@ -1353,6 +1369,9 @@ export function useBoardBluetooth({
       // A deliberate connect re-arms native-connection adoption after an
       // earlier explicit disconnect suppressed it.
       adoptionSuppressedRef.current = false;
+      // The user asked for this link, so the off-screen-adopt gate from any
+      // previous connection must not survive into it (#4499).
+      backgroundAdoptSendGateRef.current = false;
 
       setLoading(true);
 
@@ -1795,6 +1814,7 @@ export function useBoardBluetooth({
       // app could otherwise see getConnectedDevice still report the device this
       // teardown is closing and silently re-adopt it.
       adoptionSuppressedRef.current = true;
+      backgroundAdoptSendGateRef.current = false;
       unsubDisconnectRef.current?.();
       unsubDisconnectRef.current = null;
       const adapter = adapterRef.current;
@@ -1906,6 +1926,11 @@ export function useBoardBluetooth({
         adapterOptionsForBoard(boardName),
       );
       if (!isNativeIosBleAdapter(adapter) || typeof adapter.configureBoard !== 'function') return;
+      // Arm the JS re-light gate before anything can flip `isConnected`: an
+      // adopt that happens while the app is off screen is a wake nobody asked
+      // for until native's verdict says otherwise (#4499).
+      const adoptedOffScreen = !isAppActive();
+      backgroundAdoptSendGateRef.current = adoptedOffScreen;
       adapter.adoptConnection(deviceId);
       apiLevelRef.current = parseApiLevel(deviceName);
       configuredDeviceNameRef.current = deviceName;
@@ -1951,7 +1976,25 @@ export function useBoardBluetooth({
       // (widget reconnect / state restoration paths, not just JS connect).
       // Fire-and-forget; a native rejection is intentionally ignored.
       void getNativeBleConnectedDevice()
-        .then(setBleDiagnosticsTags)
+        .then((device) => {
+          setBleDiagnosticsTags(device);
+          if (!adoptedOffScreen) return;
+          // Native authorised this connection's implicit re-light (lightbulb
+          // reconnect, write-stall recovery), so the auto-sender may drive the
+          // wall even though we adopted off screen. `undefined` is an older
+          // binary with no verdict to report: stay armed, fail closed.
+          if (device?.implicitRelightSuppressed === false) {
+            backgroundAdoptSendGateRef.current = false;
+            return;
+          }
+          track(SHARED_EVENTS.BleImplicitRelightSuppressed, {
+            surface: 'native_connect',
+            connectOrigin: device?.connectOrigin || undefined,
+            boardName,
+            layoutId,
+            sizeId,
+          });
+        })
         .catch(() => {});
     };
 
@@ -2089,6 +2132,23 @@ export function useBoardBluetooth({
     };
   }, [consumeConnectionLifetime, writeActivityStore]);
 
+  // Asked by the auto-sender immediately before each write it is about to make:
+  // `true` means refuse this one (#4499). Kept in the hook rather than read from
+  // a ref by the provider so the AppState reading and the gate's release rule
+  // stay in one place, next to the adopt path that arms it.
+  //
+  // The release is checked here, not at arm time, because the queue snapshot can
+  // hydrate long after the adopt: the user may already be back on screen by the
+  // time a write is first on the table, and then they should get their wall.
+  const consumeBackgroundAdoptSendGate = useCallback(() => {
+    if (!backgroundAdoptSendGateRef.current) return false;
+    if (isAppActive()) {
+      backgroundAdoptSendGateRef.current = false;
+      return false;
+    }
+    return true;
+  }, []);
+
   return {
     isConnected,
     loading,
@@ -2099,5 +2159,6 @@ export function useBoardBluetooth({
     reconnectSerialForCurrentBoard,
     reconnectDeviceIdForCurrentBoard,
     connectInitialSendRef,
+    consumeBackgroundAdoptSendGate,
   };
 }

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -1983,6 +1983,14 @@ export function useBoardBluetooth({
           // reconnect, write-stall recovery), so the auto-sender may drive the
           // wall even though we adopted off screen. `undefined` is an older
           // binary with no verdict to report: stay armed, fail closed.
+          //
+          // The release is asynchronous and can land after the auto-sender's
+          // first drain. That is safe by construction: arming happens
+          // synchronously above, before `setIsConnected`, so the gate can only
+          // ever fail closed. On an authorised link the cost is at most one
+          // skipped JS write, and native already re-lit the wall itself at its
+          // own success point — every later write (a party peer's climb change)
+          // sees the released gate.
           if (device?.implicitRelightSuppressed === false) {
             backgroundAdoptSendGateRef.current = false;
             return;

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -312,6 +312,8 @@ const BLE_DIAGNOSTIC_TAG_KEYS = [
   'ble_char_properties',
   'ble_max_with_response',
   'ble_max_without_response',
+  'ble_connect_origin',
+  'ble_relight_suppressed',
 ] as const;
 
 export type BleConnectionDiagnostics = {
@@ -322,6 +324,11 @@ export type BleConnectionDiagnostics = {
   chosenWriteType?: 'withoutResponse' | 'withResponse';
   maxWriteWithResponse?: number;
   maxWriteWithoutResponse?: number;
+  // How the connection came to be, and whether its success point was allowed to
+  // re-light the wall. The #4499 zombie-reconnect is not reproducible on demand,
+  // so these tags are how we see the gate working in the field.
+  connectOrigin?: string;
+  implicitRelightSuppressed?: boolean;
 };
 
 // A scope whose tags accept `undefined` (the clear value) — wider than
@@ -356,6 +363,12 @@ export function applyBleDiagnosticsToScope(scope: TagScope, diagnostics: BleConn
   }
   if (diagnostics.maxWriteWithoutResponse !== undefined) {
     scope.setTag('ble_max_without_response', diagnostics.maxWriteWithoutResponse);
+  }
+  // The native bridge sends '' when it has no provenance to report; treat that
+  // as absent rather than tagging an empty string.
+  if (diagnostics.connectOrigin) scope.setTag('ble_connect_origin', diagnostics.connectOrigin);
+  if (diagnostics.implicitRelightSuppressed !== undefined) {
+    scope.setTag('ble_relight_suppressed', String(diagnostics.implicitRelightSuppressed));
   }
 }
 

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -330,6 +330,8 @@ const BLE_DIAGNOSTIC_TAG_KEYS = [
   'ble_char_properties',
   'ble_max_with_response',
   'ble_max_without_response',
+  'ble_connect_origin',
+  'ble_relight_suppressed',
 ] as const;
 
 export type BleConnectionDiagnostics = {
@@ -340,6 +342,11 @@ export type BleConnectionDiagnostics = {
   chosenWriteType?: 'withoutResponse' | 'withResponse';
   maxWriteWithResponse?: number;
   maxWriteWithoutResponse?: number;
+  // How the connection came to be, and whether its success point was allowed to
+  // re-light the wall. The #4499 zombie-reconnect is not reproducible on demand,
+  // so these tags are how we see the gate working in the field.
+  connectOrigin?: string;
+  implicitRelightSuppressed?: boolean;
 };
 
 // A scope whose tags accept `undefined` (the clear value) — wider than
@@ -374,6 +381,12 @@ export function applyBleDiagnosticsToScope(scope: TagScope, diagnostics: BleConn
   }
   if (diagnostics.maxWriteWithoutResponse !== undefined) {
     scope.setTag('ble_max_without_response', diagnostics.maxWriteWithoutResponse);
+  }
+  // The native bridge sends '' when it has no provenance to report; treat that
+  // as absent rather than tagging an empty string.
+  if (diagnostics.connectOrigin) scope.setTag('ble_connect_origin', diagnostics.connectOrigin);
+  if (diagnostics.implicitRelightSuppressed !== undefined) {
+    scope.setTag('ble_relight_suppressed', String(diagnostics.implicitRelightSuppressed));
   }
 }
 

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
@@ -54,6 +54,9 @@ const bluetooth = vi.hoisted(() => {
           encodingSignature: string;
         } | null,
       },
+      // #4499 off-screen-adopt gate. `false` = let the write through, which is
+      // what every test here that isn't specifically about the gate wants.
+      consumeBackgroundAdoptSendGate: vi.fn(() => false),
     },
     useBoardBluetooth: vi.fn((options: BluetoothHookOptions) => {
       mock.options = options;
@@ -356,6 +359,8 @@ describe('BluetoothProvider mismatch switch', () => {
     bluetooth.state.sendFramesToBoard.mockClear();
     bluetooth.state.sendFramesToBoard.mockResolvedValue(true);
     bluetooth.state.connectInitialSendRef.current = null;
+    bluetooth.state.consumeBackgroundAdoptSendGate.mockReset();
+    bluetooth.state.consumeBackgroundAdoptSendGate.mockReturnValue(false);
     bluetooth.useBoardBluetooth.mockClear();
     presence.enabled = false;
     presence.boardId = null;

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-mismatch-switch.test.tsx
@@ -54,6 +54,9 @@ const bluetooth = vi.hoisted(() => {
           encodingSignature: string;
         } | null,
       },
+      // #4499 off-screen-adopt gate. `false` = let the write through, which is
+      // what every test here that isn't specifically about the gate wants.
+      consumeBackgroundAdoptSendGate: vi.fn(() => false),
     },
     useBoardBluetooth: vi.fn((options: BluetoothHookOptions) => {
       mock.options = options;
@@ -357,6 +360,8 @@ describe('BluetoothProvider mismatch switch', () => {
     bluetooth.state.sendFramesToBoard.mockClear();
     bluetooth.state.sendFramesToBoard.mockResolvedValue(true);
     bluetooth.state.connectInitialSendRef.current = null;
+    bluetooth.state.consumeBackgroundAdoptSendGate.mockReset();
+    bluetooth.state.consumeBackgroundAdoptSendGate.mockReturnValue(false);
     bluetooth.useBoardBluetooth.mockClear();
     presence.enabled = false;
     presence.boardId = null;

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -81,6 +81,9 @@ const bluetooth = vi.hoisted(() => {
           encodingSignature: string;
         } | null,
       },
+      // #4499 off-screen-adopt gate. `false` = let the write through, which is
+      // what every test here that isn't specifically about the gate wants.
+      consumeBackgroundAdoptSendGate: vi.fn(() => false),
     },
     useBoardBluetooth: vi.fn((options: BluetoothHookOptions) => {
       mock.options = options;
@@ -375,6 +378,8 @@ describe('BluetoothProvider wall-confirm integration', () => {
     bluetooth.state.sendFramesToBoard.mockReset();
     bluetooth.state.sendFramesToBoard.mockResolvedValue(true);
     bluetooth.state.connectInitialSendRef.current = null;
+    bluetooth.state.consumeBackgroundAdoptSendGate.mockReset();
+    bluetooth.state.consumeBackgroundAdoptSendGate.mockReturnValue(false);
     bluetooth.useBoardBluetooth.mockClear();
     presence.enabled = false;
     presence.boardId = null;
@@ -412,6 +417,62 @@ describe('BluetoothProvider wall-confirm integration', () => {
 
     expect(wallConfirm.emitWallConfirm).toHaveBeenCalledWith('climb-1');
     expect(queue.confirmClimbOnWall).toHaveBeenCalledWith('climb-1');
+  });
+
+  // #4499. A CoreBluetooth state restoration (or a connect parked across
+  // suspension and honoured days later) boots React Native in the background,
+  // the hook adopts the link, and the auto-sender mounts with the restored queue
+  // snapshot and a null dedup signature. The native connect gate keeps the wall
+  // dark, but this write would repaint it anyway — the verbatim report.
+  it('refuses the first auto-send after adopting a link off screen', async () => {
+    bluetooth.state.consumeBackgroundAdoptSendGate.mockReturnValue(true);
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(bluetooth.state.consumeBackgroundAdoptSendGate).toHaveBeenCalled();
+    });
+    expect(bluetooth.state.sendFramesToBoard).not.toHaveBeenCalled();
+    expect(wallConfirm.emitWallConfirm).not.toHaveBeenCalled();
+    expect(analytics.track).toHaveBeenCalledWith(
+      'BLE Implicit Relight Suppressed',
+      expect.objectContaining({ surface: 'js_auto_send', climbUuid: 'climb-1' }),
+    );
+  });
+
+  // Nothing is recorded as being on the wall when the gate refuses, so the next
+  // climb the user picks still writes rather than being deduped into silence.
+  it('still writes the next climb after a refused off-screen auto-send', async () => {
+    bluetooth.state.consumeBackgroundAdoptSendGate.mockReturnValue(true);
+
+    const { rerender } = renderProvider();
+
+    await waitFor(() => {
+      expect(bluetooth.state.consumeBackgroundAdoptSendGate).toHaveBeenCalled();
+    });
+    expect(bluetooth.state.sendFramesToBoard).not.toHaveBeenCalled();
+
+    // The user opens the app: the hook releases the gate, and they navigate.
+    bluetooth.state.consumeBackgroundAdoptSendGate.mockReturnValue(false);
+    queue.currentClimbQueueItem = makeQueueItem('climb-2');
+    rerender(
+      createElement(BluetoothProvider, {
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,20',
+        children: createElement('div', null),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith(
+        'p1r12',
+        false,
+        expect.any(AbortSignal),
+        expect.objectContaining({ sendSource: 'auto', targetQueueItemUuid: 'queue-climb-2' }),
+      );
+    });
   });
 
   it('writes updated MoonBoard packets when the control sheet toggles adjacent holds', async () => {

--- a/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
+++ b/packages/mobile/src/providers/__tests__/bluetooth-provider-wall-confirm.test.tsx
@@ -81,6 +81,9 @@ const bluetooth = vi.hoisted(() => {
           encodingSignature: string;
         } | null,
       },
+      // #4499 off-screen-adopt gate. `false` = let the write through, which is
+      // what every test here that isn't specifically about the gate wants.
+      consumeBackgroundAdoptSendGate: vi.fn(() => false),
     },
     useBoardBluetooth: vi.fn((options: BluetoothHookOptions) => {
       mock.options = options;
@@ -379,6 +382,8 @@ describe('BluetoothProvider wall-confirm integration', () => {
     bluetooth.state.sendFramesToBoard.mockReset();
     bluetooth.state.sendFramesToBoard.mockResolvedValue(true);
     bluetooth.state.connectInitialSendRef.current = null;
+    bluetooth.state.consumeBackgroundAdoptSendGate.mockReset();
+    bluetooth.state.consumeBackgroundAdoptSendGate.mockReturnValue(false);
     bluetooth.useBoardBluetooth.mockClear();
     presence.enabled = false;
     presence.boardId = null;
@@ -416,6 +421,62 @@ describe('BluetoothProvider wall-confirm integration', () => {
 
     expect(wallConfirm.emitWallConfirm).toHaveBeenCalledWith('climb-1');
     expect(queue.confirmClimbOnWall).toHaveBeenCalledWith('climb-1');
+  });
+
+  // #4499. A CoreBluetooth state restoration (or a connect parked across
+  // suspension and honoured days later) boots React Native in the background,
+  // the hook adopts the link, and the auto-sender mounts with the restored queue
+  // snapshot and a null dedup signature. The native connect gate keeps the wall
+  // dark, but this write would repaint it anyway — the verbatim report.
+  it('refuses the first auto-send after adopting a link off screen', async () => {
+    bluetooth.state.consumeBackgroundAdoptSendGate.mockReturnValue(true);
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(bluetooth.state.consumeBackgroundAdoptSendGate).toHaveBeenCalled();
+    });
+    expect(bluetooth.state.sendFramesToBoard).not.toHaveBeenCalled();
+    expect(wallConfirm.emitWallConfirm).not.toHaveBeenCalled();
+    expect(analytics.track).toHaveBeenCalledWith(
+      'BLE Implicit Relight Suppressed',
+      expect.objectContaining({ surface: 'js_auto_send', climbUuid: 'climb-1' }),
+    );
+  });
+
+  // Nothing is recorded as being on the wall when the gate refuses, so the next
+  // climb the user picks still writes rather than being deduped into silence.
+  it('still writes the next climb after a refused off-screen auto-send', async () => {
+    bluetooth.state.consumeBackgroundAdoptSendGate.mockReturnValue(true);
+
+    const { rerender } = renderProvider();
+
+    await waitFor(() => {
+      expect(bluetooth.state.consumeBackgroundAdoptSendGate).toHaveBeenCalled();
+    });
+    expect(bluetooth.state.sendFramesToBoard).not.toHaveBeenCalled();
+
+    // The user opens the app: the hook releases the gate, and they navigate.
+    bluetooth.state.consumeBackgroundAdoptSendGate.mockReturnValue(false);
+    queue.currentClimbQueueItem = makeQueueItem('climb-2');
+    rerender(
+      createElement(BluetoothProvider, {
+        boardName: 'kilter',
+        layoutId: 1,
+        sizeId: 10,
+        setIds: '1,20',
+        children: createElement('div', null),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(bluetooth.state.sendFramesToBoard).toHaveBeenCalledWith(
+        'p1r12',
+        false,
+        expect.any(AbortSignal),
+        expect.objectContaining({ sendSource: 'auto', targetQueueItemUuid: 'queue-climb-2' }),
+      );
+    });
   });
 
   it('writes updated MoonBoard packets when the control sheet toggles adjacent holds', async () => {

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -208,6 +208,8 @@ function BluetoothAutoSender({
   activeConfig,
   onSkipSpillClimb,
   onUnresolvedCurrentClimb,
+  consumeBackgroundAdoptSendGate,
+  onBackgroundAdoptSendSuppressed,
 }: {
   sendFramesToBoard: SendFramesToBoard;
   /**
@@ -245,6 +247,15 @@ function BluetoothAutoSender({
   // unresolved-current-climb window without the AutoSender owning analytics/board
   // context. Fired once per queue-item uuid.
   onUnresolvedCurrentClimb: (item: ClimbQueueItem) => void;
+  // Asked immediately before each write: `true` means refuse this one. The hook
+  // arms the gate when it adopts a native connection while the app is off screen
+  // and native's connect gate did not authorise an implicit re-light (#4499) — a
+  // CoreBluetooth state restoration boots React Native, restores the queue
+  // snapshot, and the drain below would otherwise repaint the wall the native
+  // gate deliberately kept dark. It releases itself once the app is on screen.
+  consumeBackgroundAdoptSendGate: () => boolean;
+  // Reports a refused write so the gate is measurable in the field.
+  onBackgroundAdoptSendSuppressed: (item: ClimbQueueItem) => void;
 }) {
   type AutoSendRequest = {
     item: ClimbQueueItem;
@@ -274,6 +285,14 @@ function BluetoothAutoSender({
   useEffect(() => {
     onUnresolvedCurrentClimbRef.current = onUnresolvedCurrentClimb;
   }, [onUnresolvedCurrentClimb]);
+  const consumeBackgroundAdoptSendGateRef = useRef(consumeBackgroundAdoptSendGate);
+  useEffect(() => {
+    consumeBackgroundAdoptSendGateRef.current = consumeBackgroundAdoptSendGate;
+  }, [consumeBackgroundAdoptSendGate]);
+  const onBackgroundAdoptSendSuppressedRef = useRef(onBackgroundAdoptSendSuppressed);
+  useEffect(() => {
+    onBackgroundAdoptSendSuppressedRef.current = onBackgroundAdoptSendSuppressed;
+  }, [onBackgroundAdoptSendSuppressed]);
   const queueRef = useRef(state.queue);
   queueRef.current = state.queue;
   // Dedup spill reports: the async drain can re-enter for the same incompatible
@@ -411,6 +430,20 @@ function BluetoothAutoSender({
             continue;
           }
           lastUnresolvedReportedUuidRef.current = null;
+
+          // #4499 off-screen-adopt gate. The wall must not light for a
+          // connection nobody asked for, and adopting one boots this component
+          // with a restored queue and a null dedup signature — the write would
+          // otherwise go straight out. Deliberately checked here, not at mount:
+          // the queue snapshot can hydrate after the adopt, so the first drain
+          // is the first moment a write is actually on the table. Nothing is
+          // recorded as sent, so a later user action still repaints.
+          if (consumeBackgroundAdoptSendGateRef.current()) {
+            onBackgroundAdoptSendSuppressedRef.current(item);
+            toSend = pendingSendRef.current;
+            pendingSendRef.current = null;
+            continue;
+          }
 
           // connect() may have just written these exact frames as its
           // initialFrames (connect-and-light flows like the play drawer).
@@ -970,6 +1003,7 @@ export function BluetoothProvider({
     reconnectSerialForCurrentBoard,
     reconnectDeviceIdForCurrentBoard,
     connectInitialSendRef,
+    consumeBackgroundAdoptSendGate,
   } = useBoardBluetooth({
     boardName,
     layoutId,
@@ -1434,6 +1468,20 @@ export function BluetoothProvider({
     });
   }, []);
 
+  // The auto-sender refused to light the wall for a link adopted off screen
+  // that native's connect gate did not authorise (#4499). Reported once per
+  // refusal so the gate's real-world hit rate — and the freshness bound it
+  // depends on — can be read off analytics instead of guessed at.
+  const handleBackgroundAdoptSendSuppressed = useCallback((item: ClimbQueueItem) => {
+    track(SHARED_EVENTS.BleImplicitRelightSuppressed, {
+      surface: 'js_auto_send',
+      boardName: boardNameRef.current,
+      layoutId: layoutIdRef.current,
+      sizeId: sizeIdRef.current,
+      climbUuid: item.climb.uuid,
+    });
+  }, []);
+
   // Bumped by `reassertWall()` to force the auto-sender to re-push the current
   // climb once, bypassing the byte-identical dedup.
   const [reassertNonce, setReassertNonce] = useState(0);
@@ -1595,6 +1643,8 @@ export function BluetoothProvider({
             reassertNonce={reassertNonce}
             connectInitialSendRef={connectInitialSendRef}
             lastPhysicalFramesRef={lastPhysicalFramesRef}
+            consumeBackgroundAdoptSendGate={consumeBackgroundAdoptSendGate}
+            onBackgroundAdoptSendSuppressed={handleBackgroundAdoptSendSuppressed}
             colorSignature={holdColorSignature}
             encodingSignature={encodingSignature}
             activeConfig={currentBoardConfig}

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -316,6 +316,8 @@ function BluetoothAutoSender({
   activeConfig,
   onSkipSpillClimb,
   onUnresolvedCurrentClimb,
+  consumeBackgroundAdoptSendGate,
+  onBackgroundAdoptSendSuppressed,
 }: {
   sendFramesToBoard: SendFramesToBoard;
   /**
@@ -360,6 +362,15 @@ function BluetoothAutoSender({
   // unresolved-current-climb window without the AutoSender owning analytics/board
   // context. Fired once per queue-item uuid.
   onUnresolvedCurrentClimb: (item: ClimbQueueItem) => void;
+  // Asked immediately before each write: `true` means refuse this one. The hook
+  // arms the gate when it adopts a native connection while the app is off screen
+  // and native's connect gate did not authorise an implicit re-light (#4499) — a
+  // CoreBluetooth state restoration boots React Native, restores the queue
+  // snapshot, and the drain below would otherwise repaint the wall the native
+  // gate deliberately kept dark. It releases itself once the app is on screen.
+  consumeBackgroundAdoptSendGate: () => boolean;
+  // Reports a refused write so the gate is measurable in the field.
+  onBackgroundAdoptSendSuppressed: (item: ClimbQueueItem) => void;
 }) {
   type AutoSendRequest = {
     item: ClimbQueueItem;
@@ -389,6 +400,14 @@ function BluetoothAutoSender({
   useEffect(() => {
     onUnresolvedCurrentClimbRef.current = onUnresolvedCurrentClimb;
   }, [onUnresolvedCurrentClimb]);
+  const consumeBackgroundAdoptSendGateRef = useRef(consumeBackgroundAdoptSendGate);
+  useEffect(() => {
+    consumeBackgroundAdoptSendGateRef.current = consumeBackgroundAdoptSendGate;
+  }, [consumeBackgroundAdoptSendGate]);
+  const onBackgroundAdoptSendSuppressedRef = useRef(onBackgroundAdoptSendSuppressed);
+  useEffect(() => {
+    onBackgroundAdoptSendSuppressedRef.current = onBackgroundAdoptSendSuppressed;
+  }, [onBackgroundAdoptSendSuppressed]);
   const queueRef = useRef(state.queue);
   queueRef.current = state.queue;
   // Dedup spill reports: the async drain can re-enter for the same incompatible
@@ -526,6 +545,20 @@ function BluetoothAutoSender({
             continue;
           }
           lastUnresolvedReportedUuidRef.current = null;
+
+          // #4499 off-screen-adopt gate. The wall must not light for a
+          // connection nobody asked for, and adopting one boots this component
+          // with a restored queue and a null dedup signature — the write would
+          // otherwise go straight out. Deliberately checked here, not at mount:
+          // the queue snapshot can hydrate after the adopt, so the first drain
+          // is the first moment a write is actually on the table. Nothing is
+          // recorded as sent, so a later user action still repaints.
+          if (consumeBackgroundAdoptSendGateRef.current()) {
+            onBackgroundAdoptSendSuppressedRef.current(item);
+            toSend = pendingSendRef.current;
+            pendingSendRef.current = null;
+            continue;
+          }
 
           // The orientation to put on the wall. The play drawer's mirror toggle
           // is drawer-local and never reaches `climb.mirrored`, so a live intent
@@ -1263,6 +1296,7 @@ export function BluetoothProvider({
     reconnectSerialForCurrentBoard,
     reconnectDeviceIdForCurrentBoard,
     connectInitialSendRef,
+    consumeBackgroundAdoptSendGate,
   } = useBoardBluetooth({
     boardName,
     layoutId,
@@ -1944,6 +1978,20 @@ export function BluetoothProvider({
     });
   }, []);
 
+  // The auto-sender refused to light the wall for a link adopted off screen
+  // that native's connect gate did not authorise (#4499). Reported once per
+  // refusal so the gate's real-world hit rate — and the freshness bound it
+  // depends on — can be read off analytics instead of guessed at.
+  const handleBackgroundAdoptSendSuppressed = useCallback((item: ClimbQueueItem) => {
+    track(SHARED_EVENTS.BleImplicitRelightSuppressed, {
+      surface: 'js_auto_send',
+      boardName: boardNameRef.current,
+      layoutId: layoutIdRef.current,
+      sizeId: sizeIdRef.current,
+      climbUuid: item.climb.uuid,
+    });
+  }, []);
+
   // Bumped by `reassertWall()` to force the auto-sender to re-push the current
   // climb once, bypassing the byte-identical dedup.
   const [reassertNonce, setReassertNonce] = useState(0);
@@ -2180,6 +2228,8 @@ export function BluetoothProvider({
             connectInitialSendRef={connectInitialSendRef}
             lastPhysicalFramesRef={lastPhysicalFramesRef}
             mirrorIntentRef={mirrorIntentRef}
+            consumeBackgroundAdoptSendGate={consumeBackgroundAdoptSendGate}
+            onBackgroundAdoptSendSuppressed={handleBackgroundAdoptSendSuppressed}
             colorSignature={holdColorSignature}
             encodingSignature={encodingSignature}
             activeConfig={currentBoardConfig}

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -269,7 +269,9 @@ export const SHARED_EVENTS = {
   // This is the field signal for tuning the native gate's freshness bound: the
   // ble_relight_suppressed Sentry tag only ever rides a captured error, so it
   // covers the sessions that also crashed rather than the ones that fired.
-  // Props: surface, connectOrigin (native only), boardName, layoutId, sizeId.
+  // Props: surface, boardName, layoutId, sizeId, plus connectOrigin on
+  // 'native_connect' and climbUuid (the climb that was not written) on
+  // 'js_auto_send'.
   BleImplicitRelightSuppressed: 'BLE Implicit Relight Suppressed',
   // Search
   // Fired once per resolved search/filter result set, keyed on the search text +

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -258,6 +258,19 @@ export const SHARED_EVENTS = {
   // 'switch_setup' | 'switch_failed'.
   BleBoardConfigMismatchShown: 'BLE Board Config Mismatch Shown',
   BleBoardConfigMismatchResolved: 'BLE Board Config Mismatch Resolved',
+  // The implicit "re-light the wall from the persisted queue" write was refused
+  // because nobody in this process asked for the connection, or the request that
+  // produced it was too old to still mean anything (#4499). Two surfaces report:
+  //  - 'native_connect' — the iOS connect gate's verdict, read off
+  //    getConnectedDevice when JS adopts the link. Carries connectOrigin
+  //    ('userConnect' | 'liveActivityIntent' | 'writeStallRecovery' | 'restored').
+  //  - 'js_auto_send' — the auto-sender's first drain after adopting a link while
+  //    the app was off screen and native had not authorised a re-light.
+  // This is the field signal for tuning the native gate's freshness bound: the
+  // ble_relight_suppressed Sentry tag only ever rides a captured error, so it
+  // covers the sessions that also crashed rather than the ones that fired.
+  // Props: surface, connectOrigin (native only), boardName, layoutId, sizeId.
+  BleImplicitRelightSuppressed: 'BLE Implicit Relight Suppressed',
   // Search
   // Fired once per resolved search/filter result set, keyed on the search text +
   // filter signature (not per keystroke, not per page). Carries hasQuery,

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -283,7 +283,9 @@ export const SHARED_EVENTS = {
   // This is the field signal for tuning the native gate's freshness bound: the
   // ble_relight_suppressed Sentry tag only ever rides a captured error, so it
   // covers the sessions that also crashed rather than the ones that fired.
-  // Props: surface, connectOrigin (native only), boardName, layoutId, sizeId.
+  // Props: surface, boardName, layoutId, sizeId, plus connectOrigin on
+  // 'native_connect' and climbUuid (the climb that was not written) on
+  // 'js_auto_send'.
   BleImplicitRelightSuppressed: 'BLE Implicit Relight Suppressed',
   // Search
   // Fired once per resolved search/filter result set, keyed on the search text +

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -272,6 +272,19 @@ export const SHARED_EVENTS = {
   // 'switch_setup' | 'switch_failed'.
   BleBoardConfigMismatchShown: 'BLE Board Config Mismatch Shown',
   BleBoardConfigMismatchResolved: 'BLE Board Config Mismatch Resolved',
+  // The implicit "re-light the wall from the persisted queue" write was refused
+  // because nobody in this process asked for the connection, or the request that
+  // produced it was too old to still mean anything (#4499). Two surfaces report:
+  //  - 'native_connect' — the iOS connect gate's verdict, read off
+  //    getConnectedDevice when JS adopts the link. Carries connectOrigin
+  //    ('userConnect' | 'liveActivityIntent' | 'writeStallRecovery' | 'restored').
+  //  - 'js_auto_send' — the auto-sender's first drain after adopting a link while
+  //    the app was off screen and native had not authorised a re-light.
+  // This is the field signal for tuning the native gate's freshness bound: the
+  // ble_relight_suppressed Sentry tag only ever rides a captured error, so it
+  // covers the sessions that also crashed rather than the ones that fired.
+  // Props: surface, connectOrigin (native only), boardName, layoutId, sizeId.
+  BleImplicitRelightSuppressed: 'BLE Implicit Relight Suppressed',
   // Search
   // Fired once per resolved search/filter result set, keyed on the search text +
   // filter signature (not per keystroke, not per page). Carries hasQuery,

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -34,6 +34,10 @@ const TEST_SOURCE_FILES = [
     projectPath: 'BoardseshTests/BoardBleServiceDiscoveryTests.swift',
   },
   {
+    sourcePath: '../ios-tests/BoardBleRelightAuthorizationTests.swift',
+    projectPath: 'BoardseshTests/BoardBleRelightAuthorizationTests.swift',
+  },
+  {
     sourcePath: '../ios-tests/BoardRendererErrorClassificationTests.swift',
     projectPath: 'BoardseshTests/BoardRendererErrorClassificationTests.swift',
   },

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -38,6 +38,10 @@ const TEST_SOURCE_FILES = [
     projectPath: 'BoardseshTests/BoardBleServiceDiscoveryTests.swift',
   },
   {
+    sourcePath: '../ios-tests/BoardBleRelightAuthorizationTests.swift',
+    projectPath: 'BoardseshTests/BoardBleRelightAuthorizationTests.swift',
+  },
+  {
     sourcePath: '../ios-tests/BoardRendererErrorClassificationTests.swift',
     projectPath: 'BoardseshTests/BoardRendererErrorClassificationTests.swift',
   },


### PR DESCRIPTION
## Summary

This fixes a bug where a phone would silently relight the climbing wall with the user's last climb hours or days after the app was last used, with no one asking for it. The root cause is that iOS can revive a pending Bluetooth connect or restore a suspended one long after it was requested, and the code treated any successful connect as a reason to repaint the wall. The fix stamps every connect request with who asked and when, then gates the automatic relight to only fresh, legitimate triggers (a user tap, the Live Activity lightbulb, or a write-stall recovery) while leaving state-restored connections silent; a matching gate is added on the JS side so the auto-sender can't write to a board a background restore woke up. It's a native-fingerprint change targeting `release/next-ota`, requires the mandatory Bluetooth/Fable review, and ships with new Swift and JS tests plus a device QA checklist.

---

Closes #4499

## What was happening

Marco's board lights up his last climb, in his custom colours, when he walks into the gym — app never opened.

A connect request can be honoured by CoreBluetooth arbitrarily far in the future. `CBCentralManager.connect(_:)` has no timeout of its own; the only bound in `BoardBleManager` is `connectTimeoutTimer`, a GCD work item on a `DispatchTime` deadline. That work item cannot run while the process is suspended, and the deadline itself does not advance across device sleep. The app declares `bluetooth-central` and a restore identifier, so a pending connect (and a filtered background scan) survives suspension and outlives termination.

Two paths produce one: walking out of range makes writes stall before the drop lands, `handleWriteStall` cycles the link (#3181), `didDisconnect` fires the recovery reconnect, and the phone then suspends inside the 8 s window with the `connect()` parked. State restoration is the second producer.

Both converge on `finishConnectionSetupOnBleQueue`, whose tail called `displaySharedCurrentItemOnBleQueue()` unconditionally — loading the app-group shared queue and writing the last climb with the persisted `colorOverrides`. Exactly the reported symptom. Nothing recorded *who* asked for the connection or *when*, so the success point could not tell "the recovery reconnect I asked for 3 seconds ago" from "the recovery reconnect I asked for on Thursday".

## The fix

**Provenance is a parameter, not a flag.** `connectOnBleQueue` is the shared funnel for six callers, so anything set inside it is set by the automatic paths too. Each call site now stamps a `BoardBleConnectOrigin` (`userConnect` / `liveActivityIntent` / `writeStallRecovery` / `restored`) and a wall-clock `Date`. `DispatchTime` is disqualified by the same evidence that makes the bug possible.

**One gate at the single success point.** `shouldPerformImplicitRelight(origin:requestedAt:now:maxRequestAge:)` is pure and exhaustively unit-tested. A restored link never re-lights. Everything else re-lights only if the request is under 120 s old (~15x `connectTimeout`); a negative age — a backwards clock jump — fails closed.

`writeStallRecovery` stays authorised on purpose. Repainting the wall after an unwedge is the whole point of #3181; the freshness bound is what separates the three-second recovery from the three-day zombie, which is why origin alone is not enough.

**The recovery is judged by the stall's own clock.** Codex review caught the one door this left open. The recovery's reconnect is deferred to the cancel's `didDisconnect`, and it used to stamp `Date()` when that callback was *consumed* — so a phone suspended inside the cancel &rarr; disconnect gap thawed both watchdogs and the callback together, and an hours-old stall collected a brand-new 120 s budget. The stamp is now taken in `handleWriteStall` and carried through the barrier, the way `DeferredConnectRequest` already carried a user connect's.

A recovery past the bound is **abandoned**, not reconnected-with-the-relight-suppressed. Suppressing would stop the repaint but not the theft: on a last-connection-wins board a days-late reconnect takes the wall from whoever is on it now, which is exactly why an unexpected drop never auto-reconnects. `handleWriteStall`'s carve-out from that rule is premised on the window being brief and the climber still being on the wall, and a three-day-old recovery falsifies both. The abandon shares the no-`didDisconnect` watchdog's fail-closed body (which now clears provenance too) and emits a new `write_stall_recovery_stale` marker, registered in `disconnect-category.ts` so it buckets as `app_recovery` rather than `unknown`.

**The link is kept when the gate refuses.** `completePendingConnect(.success)`, `persistLastConnectedPeripheral`, and `onConnected` all still fire. The reported harm is the wall lighting up; a held-but-silent link writes nothing, and these boards are last-connection-wins, so the next climber's connect displaces us immediately. Turning a *successful* connect into a failure would invert three subsystems' contracts for a strictly smaller harm. Tearing down provably-abandoned links is a follow-up, not this PR.

**`configureBoard` had the same hole, with a different discriminator.** It re-lights too, and JS calls it from the adopt path — a background BLE wake boots React Native. Provenance is the wrong tool here (a user opening the app on a restored link and changing a colour must still repaint), so it takes `appActive` instead: foreground always re-lights, background only re-lights onto a connection the connect gate already authorised. The native field defaults to `true` so an older JS bundle on this binary keeps today's behaviour.

**The JS auto-sender needed the same gate.** The `configureBoard` premise cuts both ways: if a background BLE wake boots React Native, then on that same wake `onConnected` fires, `adopt()` flips `isConnected`, and `BluetoothAutoSender` mounts against the queue snapshot `useQueuePersistence` just restored — with a null dedup signature and no `AppState` check anywhere between it and `adapter.write`. The native gate does not intercept it: an explicit JS write is deliberately ungated, which is what makes the lightbulb and the widget work. So on state restoration — the likeliest producer of the report — the wall lit up anyway.

`adopt()` now arms a gate whenever it adopts off screen, and the auto-sender asks it before each write. Native's own verdict releases it: `implicitRelightSuppressed === false` means the connect gate authorised this link (a lightbulb reconnect, a #3181 write-stall recovery), so a phone in a pocket keeps driving the wall for a party peer. Only the unauthorised off-screen adopt stays silent, and it releases the moment the app is back on screen. Nothing is recorded as being on the wall when it refuses, so the next climb the user picks still writes rather than being deduped into a dark wall.

**Made observable.** `getConnectedDevice` now reports `connectOrigin` and `implicitRelightSuppressed`. Both ride the existing global BLE Sentry tags, which is useful for reading a `ble-send` error report in context — but those tags only travel attached to a captured event, so they cannot answer "how often does the gate fire". A new `BLE Implicit Relight Suppressed` analytics event does: `surface: 'native_connect'` carries the native verdict and its `connectOrigin`, `surface: 'js_auto_send'` carries the JS refusal. That is the signal for tuning 120 s with data rather than taste.

## Base and Bluetooth review

- **Native-fingerprint change.** `packages/mobile/modules` is in the canonical native-input set, so this moves the Expo fingerprint and no OTA can reach shipped store binaries. The #4457 train (`release/next-ota`) has since been cut and the branch is gone, so this targets `main` and rides the next native build from there.
- **Bluetooth change — requires a Fable review before merge** (CLAUDE.md).
- The small JS half rides in the same PR: it is only meaningful paired with the native gate, and it is inert (defaults preserve today's behaviour) if an older JS bundle is OTA'd onto the new binary.

## Tests

New `packages/mobile/ios-tests/BoardBleRelightAuthorizationTests.swift` (registered in `scripts/prepare-rn-ios-tests.mjs`), 15 cases:

- the decision matrix — four origins x {fresh, on the bound, past it, negative age, nil stamp, nil origin}
- fresh `userConnect` through the real `connect()` then `fireConnectionReady`
- fresh `writeStallRecovery` driven through the real stall, cancel, `didDisconnect`, reconnect path (the #3181 regression guard)
- the same recovery with the stamp rewound an hour: suppressed, connect still succeeds, `onConnected` still fires, nothing cancelled, link retained
- the stall-clock matrix: fresh, on the bound, past it, and a backwards clock
- a recovery whose stamp is rewound 60 s reconnects carrying the **stall's** age, not ~0 &mdash; the pin that fails against the re-stamping code
- a recovery stranded three days across a suspension: no connect is issued at all, `write_stall_recovery_stale` reaches JS, the wall is never painted
- an abandoned recovery forgets who asked, so a background `configure` is refused by the gate rather than skipping it
- exactly on the bound, a recovery still reconnects and still re-lights (#3181)
- `restored`: suppressed and retained
- `liveActivityIntent` on a live link: re-lights
- `configure(appActive: true)` on a suppressed connection re-lights; `appActive: false` is suppressed; `appActive: false` on an *authorised* connection still re-lights
- `disconnect()` and Bluetooth-off both forget who asked

Assertions are on the manager's attempt/suppression counters, never on bytes: `displaySharedCurrentItemOnBleQueue` reads the app-group defaults, which is exactly the dev-machine leak the `setConfiguration` hook exists to avoid. The suite snapshots and restores the two app-group keys it touches.

Plus `testUnexpectedDropForgetsWhoAskedSoAConfigureCannotUseADeadLinksAuthorization`: a link that drops on its own now clears provenance too, so a `configure(appActive: false)` landing between the drop and the next connect cannot pass the authorisation latch against a dead link. Fails against the old code (the configure re-lights).

`BoardBleDisconnectTests.swift` adds two: a stale recovery consumes the barrier without grabbing the board back, and &mdash; pinning the guard's placement &mdash; a queued **user** connect still wins the barrier however old the stall is, since a human asked for that one.

JS: `disconnect-category.test.ts` pins the new marker to `app_recovery`. `use-board-bluetooth.test.ts` covers the `appActive` plumbing (background adopt sends `false`, foreground colour change sends `true`) and the new send gate — armed on an off-screen adopt native did not authorise, left open when native did authorise, never armed for an on-screen adopt, and released one-way once the app is back on screen. `bluetooth-provider-wall-confirm.test.tsx` drives the real provider and auto-sender: the first auto-send after an off-screen adopt is refused (no write, no wall confirm, one analytics event), and the next climb the user picks still writes. Both fail against the ungated auto-sender. Two cases in `sentry.test.ts` for the new tags.

## Log levels

`logger.error` at the three designed-outcome sites is now `logger.info`. A refused re-light is the gate working as intended, not a fault; on a restored link every background adopt would otherwise write an error line into exactly the error-rate signal this campaign has been cleaning up. The verdicts are still readable in Console.app.

## Validation

- `vp run typecheck` — pass (all packages)
- `vp run test:mobile` — 680 files / 6530 tests pass
- `vp check --fix` — clean on every file this PR touches (pre-commit hook passed)
- `vp run check:mobile-bundle` — OK
- The Swift suite is macOS-only; it runs in `ios-rn-ci.yml`, and the native gate will fire because `packages/mobile/modules` changed.

## Test plan

1. Connect a board, walk out of range, return next day → wall stays dark.
2. Backgrounded, tap the Live Activity lightbulb → wall lights your climb.
3. Mid-climb, unplug and replug the board controller → wall repaints itself.
4. Force-quit, relaunch beside a live board → wall stays dark.
5. With the app open, change hold colours → wall repaints now.

## Risk

Risk: 5/5 — BLE connect lifecycle on the native path, plus the JS auto-sender gate.

## Device QA (before merge)

- [ ] The actual repro: connect, walk out of range without disconnecting, leave it overnight, walk back in with the app closed — wall stays dark.
- [ ] Live Activity lightbulb reconnect with the app backgrounded — wall lights.
- [ ] Write-stall recovery mid-session (unplug/re-plug the controller) — wall repaints.
- [ ] Force-quit then relaunch onto a live board — wall stays dark until you ask.
- [ ] Colour change on a restored connection, app in foreground — wall repaints.
- [ ] Force-quit, then trigger a CoreBluetooth state-restoration relaunch with a queue already saved — wall stays dark (this is the JS auto-sender gate; the native gate alone did not cover it).

## Known residual risks

- `AppState.currentState` on a CoreBluetooth-restoration background launch *should* read `background`, but I have not proven it for that specific relaunch. If it ever reads `active`, the `configureBoard` gate leaks — the connect gate still holds, so the wall stays dark on the certain path. That is what the first QA item covers.
- 120 s is a judgement call. Too tight regresses a slow-but-legitimate connect into a dark wall (recoverable with a re-tap); too loose leaves a narrow window. Don't widen it without the Sentry data. It now also bounds the write-stall recovery end to end: a healthy one spends ~24 s of it worst case (8 s to the disconnect, 8 s to reconnect, 8 s more via the scan fallback), so tightening it below ~30 s would start eating into #3181.
- A write-stall recovery that spans a >2 min suspension now ends with the board disconnected in the UI instead of silently reconnected. That is honest &mdash; it matches what the wall shows &mdash; and the lightbulb reconnects on one tap.
- The deferred **user** connect arm replays days-late too. Its stamp is the user's original, so it is correctly gate-suppressed and never re-lights, but it does still take the link. Left alone on purpose: it began as an explicit human request, and a picker that shows a board it refuses to reach is worse. Deliberate asymmetry, not an oversight.
- We keep the zombie link. Deliberate, see above; a phone in a pocket can hold a silent connection until displaced.
- Attribution is inferred from reading the code, not from a captured log — the incident had no telemetry. The diagnostics exist so the next occurrence does.

## Release Notes

Your board stays dark until you ask for it. If you walked off without disconnecting, the app no longer lights up your last climb when you wander back into range days later. The lightbulb, the widget, and mid-climb reconnects still light it instantly.
</content>
</invoke>



