### PR TITLE
feat(backend): expose Gym.canClaimByDomain so claim UIs can route (#4018)

### DIFF
--- a/packages/backend/src/__tests__/find-similar-gyms-and-auto-gym.test.ts
+++ b/packages/backend/src/__tests__/find-similar-gyms-and-auto-gym.test.ts
@@ -62,12 +62,23 @@ const insertGym = async (opts: {
   longitude?: number | null;
   deleted?: boolean;
   isPublic?: boolean;
+  website?: string | null;
+  websiteVouchedByOwner?: boolean;
 }): Promise<{ id: number; uuid: string }> => {
-  const { ownerId, name, latitude = null, longitude = null, deleted = false, isPublic = true } = opts;
+  const {
+    ownerId,
+    name,
+    latitude = null,
+    longitude = null,
+    deleted = false,
+    isPublic = true,
+    website = null,
+    websiteVouchedByOwner = false,
+  } = opts;
   const uuid = uuidv4();
   const result = await db.execute(sql`
-    INSERT INTO gyms (uuid, name, slug, owner_id, is_public, latitude, longitude, deleted_at, created_at, updated_at)
-    VALUES (${uuid}, ${name}, ${uuid}, ${ownerId}, ${isPublic}, ${latitude}, ${longitude}, ${deleted ? sql`now()` : null}, now(), now())
+    INSERT INTO gyms (uuid, name, slug, owner_id, is_public, latitude, longitude, website, website_vouched_by_owner, deleted_at, created_at, updated_at)
+    VALUES (${uuid}, ${name}, ${uuid}, ${ownerId}, ${isPublic}, ${latitude}, ${longitude}, ${website}, ${websiteVouchedByOwner}, ${deleted ? sql`now()` : null}, now(), now())
     RETURNING id
   `);
   return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid };
@@ -205,6 +216,55 @@ describe('findSimilarGyms — matching tiers', () => {
     expect(own.providerOrigins).toEqual([]);
     // The querier owns this gym, so they cannot claim it.
     expect(own.isClaimable).toBe(false);
+  });
+
+  it('reports canClaimByDomain per listing, independently of isClaimable (#4018)', async () => {
+    // The two flags answer different questions — "may this viewer claim?" vs
+    // "can the website on file drive the email claim?" — and the suggestion card
+    // routes on the second. Conflating them puts a climber back on a dead-end
+    // email form, which is the bug.
+    const vouched = await insertGym({
+      ownerId: OTHER,
+      name: 'Boulder Bar',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+      website: 'https://www.bonsist.bg',
+      websiteVouchedByOwner: true,
+    });
+    const unvouched = await insertGym({
+      ownerId: OTHER,
+      name: 'Boulder Bar',
+      latitude: LAT_120M,
+      longitude: BASE.longitude,
+      website: 'https://www.bonsist.bg',
+      websiteVouchedByOwner: false,
+    });
+    const freeProvider = await insertGym({
+      ownerId: OTHER,
+      name: 'Boulder Bar',
+      latitude: LAT_300M,
+      longitude: BASE.longitude,
+      website: 'https://mygym.wixsite.com',
+      websiteVouchedByOwner: true,
+    });
+
+    const byUuid = new Map(
+      (
+        await findSimilarGyms(
+          { name: 'Boulder Bar', latitude: BASE.latitude, longitude: BASE.longitude },
+          authCtx(QUERIER),
+        )
+      ).map((gym) => [gym.uuid, gym]),
+    );
+
+    // All three are claimable by this viewer; only the first can go by email.
+    expect(byUuid.get(vouched.uuid)!.isClaimable).toBe(true);
+    expect(byUuid.get(unvouched.uuid)!.isClaimable).toBe(true);
+    expect(byUuid.get(freeProvider.uuid)!.isClaimable).toBe(true);
+
+    expect(byUuid.get(vouched.uuid)!.canClaimByDomain).toBe(true);
+    expect(byUuid.get(unvouched.uuid)!.canClaimByDomain).toBe(false);
+    expect(byUuid.get(freeProvider.uuid)!.canClaimByDomain).toBe(false);
   });
 
   it("never enumerates another user's private gym, but includes the viewer's own private gym", async () => {

--- a/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
@@ -1356,7 +1356,12 @@ describe('canClaimByDomain advertises the requestGymClaim domain gate without be
     // canClaim and canClaimByDomain answer different questions: one is about the
     // viewer, one about the listing. An editor gets canClaim=false (the UI hides
     // the call-out entirely) while canClaimByDomain still describes the website.
-    const claimGym = await insertGym({ ownerId: OWNER, name: 'Editor View', website: 'https://www.bonsist.bg' });
+    const claimGym = await insertGym({
+      ownerId: OWNER,
+      name: 'Editor View',
+      website: 'https://www.bonsist.bg',
+      websiteVouchedByOwner: true,
+    });
     await socialGymMutations.grantGymWriteAccess(
       null,
       { input: { gymUuid: claimGym.uuid, userId: EDITOR_TARGET } },
@@ -1403,7 +1408,12 @@ describe('canClaimByDomain advertises the requestGymClaim domain gate without be
     // snake_case keys through mapRawGymRow. A camelCase read of
     // website_vouched_by_owner there is `undefined` — falsy — and every gym in
     // the proximity results would silently route to admin review.
-    const claimGym = await insertGym({ ownerId: OWNER, name: 'Proximity Row', website: 'https://www.bonsist.bg' });
+    const claimGym = await insertGym({
+      ownerId: OWNER,
+      name: 'Proximity Row',
+      website: 'https://www.bonsist.bg',
+      websiteVouchedByOwner: true,
+    });
     const rawRow = Array.from(
       (await db.execute(sql`SELECT * FROM gyms WHERE id = ${claimGym.id}`)) as Iterable<Record<string, unknown>>,
     )[0];

--- a/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
@@ -1256,6 +1256,164 @@ describe('requestGymClaim — the website must be owner-vouched to self-verify (
   });
 });
 
+// ============================================================================
+// #4018 — Gym.canClaimByDomain. Both claim UIs used to pick their form from
+// isClaimableDomain(website) alone, so an un-vouched gym with a company-looking
+// website opened the email form and only the mutation said no. The field
+// advertises the gate; requestGymClaim still IS the gate.
+// ============================================================================
+
+describe('canClaimByDomain advertises the requestGymClaim domain gate without becoming it (#4018)', () => {
+  type DomainCase = {
+    label: string;
+    website: string | null;
+    websiteVouchedByOwner: boolean;
+    claimEmail: string;
+    canClaimByDomain: boolean;
+    /** The refusal requestGymClaim must give when the capability is false. */
+    refusal?: RegExp;
+  };
+
+  const domainCases: DomainCase[] = [
+    {
+      label: 'a real company domain the owner put there',
+      website: 'https://www.bonsist.bg',
+      websiteVouchedByOwner: true,
+      claimEmail: 'manager@bonsist.bg',
+      canClaimByDomain: true,
+    },
+    {
+      label: 'a free-provider website, even when the owner put it there',
+      website: 'https://gmail.com',
+      websiteVouchedByOwner: true,
+      claimEmail: 'manager@gmail.com',
+      canClaimByDomain: false,
+      refusal: /no verifiable website domain/,
+    },
+    {
+      label: 'a real company domain nobody with ownership vouched for',
+      website: 'https://www.bonsist.bg',
+      websiteVouchedByOwner: false,
+      claimEmail: 'manager@bonsist.bg',
+      canClaimByDomain: false,
+      refusal: /hasn't been confirmed by the gym's owner/,
+    },
+    {
+      label: 'no website at all',
+      website: null,
+      websiteVouchedByOwner: false,
+      claimEmail: 'manager@bonsist.bg',
+      canClaimByDomain: false,
+      refusal: /no verifiable website domain/,
+    },
+  ];
+
+  for (const [index, domainCase] of domainCases.entries()) {
+    it(`is ${domainCase.canClaimByDomain} for ${domainCase.label}, and requestGymClaim agrees`, async () => {
+      const claimGym = await insertGym({
+        ownerId: OWNER,
+        name: `CanClaimByDomain ${index}`,
+        website: domainCase.website,
+        websiteVouchedByOwner: domainCase.websiteVouchedByOwner,
+      });
+
+      // A fresh claimant per case: applyRateLimit's tier-1 bucket is per-process
+      // and never reset between tests, so a shared fixture account would make
+      // the four cases order-dependent.
+      const claimant = `gw-domain-cap-${uuidv4()}`;
+      await insertUser(claimant);
+
+      const enriched = await socialGymQueries.gym(null, { gymUuid: claimGym.uuid }, authCtx(claimant));
+      expect(enriched).not.toBeNull();
+      expect(enriched!.canClaimByDomain).toBe(domainCase.canClaimByDomain);
+      // Viewer-independent, like isClaimed: the public gym page renders for
+      // signed-out visitors, so a viewer-dependent value here would route the
+      // anonymous "claim this gym" call-out at the wrong form.
+      expect((await socialGymQueries.gym(null, { gymUuid: claimGym.uuid }, anonCtx()))!.canClaimByDomain).toBe(
+        domainCase.canClaimByDomain,
+      );
+
+      // The pairing is the point: the field cannot quietly drift from the gate
+      // it advertises, because the same case exercises both.
+      const attempt = socialGymClaimMutations.requestGymClaim(
+        null,
+        { input: { gymUuid: claimGym.uuid, claimEmail: domainCase.claimEmail } },
+        authCtx(claimant),
+      );
+
+      if (domainCase.canClaimByDomain) {
+        await expect(attempt).resolves.toEqual({ status: 'email_sent', email: domainCase.claimEmail });
+        expect(sendGymClaimVerificationEmail).toHaveBeenCalledTimes(1);
+      } else {
+        await expect(attempt).rejects.toThrow(domainCase.refusal!);
+        expect(await claimRowCount(claimGym.id)).toBe(0);
+        expect(sendGymClaimVerificationEmail).not.toHaveBeenCalled();
+      }
+    });
+  }
+
+  it('stays false for someone who can already edit the gym, without ever claiming otherwise', async () => {
+    // canClaim and canClaimByDomain answer different questions: one is about the
+    // viewer, one about the listing. An editor gets canClaim=false (the UI hides
+    // the call-out entirely) while canClaimByDomain still describes the website.
+    const claimGym = await insertGym({ ownerId: OWNER, name: 'Editor View', website: 'https://www.bonsist.bg' });
+    await socialGymMutations.grantGymWriteAccess(
+      null,
+      { input: { gymUuid: claimGym.uuid, userId: EDITOR_TARGET } },
+      authCtx(OWNER),
+    );
+
+    const asEditor = await socialGymQueries.gym(null, { gymUuid: claimGym.uuid }, authCtx(EDITOR_TARGET));
+    expect(asEditor!.canClaim).toBe(false);
+    expect(asEditor!.canClaimByDomain).toBe(true);
+  });
+
+  it('flips to false the moment an editor rewrites the website, exactly as the mutation does', async () => {
+    const claimGym = await insertGym({ ownerId: OWNER, name: 'Rewrite Watch', website: null });
+    await socialGymMutations.updateGym(
+      null,
+      { input: { gymUuid: claimGym.uuid, website: 'https://bonsist.bg' } },
+      authCtx(OWNER),
+    );
+    await socialGymMutations.grantGymWriteAccess(
+      null,
+      { input: { gymUuid: claimGym.uuid, userId: EDITOR_TARGET } },
+      authCtx(OWNER),
+    );
+    expect((await socialGymQueries.gym(null, { gymUuid: claimGym.uuid }, anonCtx()))!.canClaimByDomain).toBe(true);
+
+    await socialGymMutations.updateGym(
+      null,
+      { input: { gymUuid: claimGym.uuid, website: 'https://attacker-owned.example' } },
+      authCtx(EDITOR_TARGET),
+    );
+
+    expect((await socialGymQueries.gym(null, { gymUuid: claimGym.uuid }, anonCtx()))!.canClaimByDomain).toBe(false);
+    await expect(
+      socialGymClaimMutations.requestGymClaim(
+        null,
+        { input: { gymUuid: claimGym.uuid, claimEmail: 'boss@attacker-owned.example' } },
+        authCtx(SECOND_TARGET),
+      ),
+    ).rejects.toThrow(/hasn't been confirmed by the gym's owner/);
+  });
+
+  it('survives the raw snake_case proximity row the PostGIS search path maps', async () => {
+    // searchGyms' PostGIS branch is a raw `SELECT *`, so enrichGym gets
+    // snake_case keys through mapRawGymRow. A camelCase read of
+    // website_vouched_by_owner there is `undefined` — falsy — and every gym in
+    // the proximity results would silently route to admin review.
+    const claimGym = await insertGym({ ownerId: OWNER, name: 'Proximity Row', website: 'https://www.bonsist.bg' });
+    const rawRow = Array.from(
+      (await db.execute(sql`SELECT * FROM gyms WHERE id = ${claimGym.id}`)) as Iterable<Record<string, unknown>>,
+    )[0];
+    expect(Object.keys(rawRow)).toContain('website_vouched_by_owner');
+
+    const enriched = await enrichGym(mapRawGymRow(rawRow), CLAIMANT);
+    expect(enriched.canClaimByDomain).toBe(true);
+  });
+});
+
 describe('requestGymClaim — admin-review path', () => {
   it('creates a pending admin claim + notifies the team when no email is given', async () => {
     const claimGym = await insertGym({ ownerId: OWNER, name: 'No Website Gym' });

--- a/packages/backend/src/graphql/resolvers/social/gym-claims.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-claims.ts
@@ -561,9 +561,11 @@ export const socialGymClaimMutations = {
       // leader is display-only here — otherwise that person could point it at a
       // domain they control and a second account of theirs would self-verify in.
       // Checked before the email match so a prober can't learn whether their
-      // address would have matched.
-      // TODO(#4018): both claim dialogs still offer the email form on an
-      // un-vouched gym, so this refusal only surfaces after submit.
+      // address would have matched. `Gym.canClaimByDomain` (enrichGym) mirrors
+      // this pair of conditions off the same `isClaimableDomain` helper so the
+      // claim UIs can open the admin-review form instead of dead-ending here on
+      // submit (#4018) — the UI has no enforcement role, this is still the only
+      // place the decision is made.
       if (!gym.websiteVouchedByOwner) {
         throw new Error(
           "This gym's website hasn't been confirmed by the gym's owner, so we can't verify you by email. Request admin review instead.",

--- a/packages/backend/src/graphql/resolvers/social/gym-matching.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-matching.ts
@@ -1,6 +1,7 @@
 import { and, eq, inArray, isNull, or, sql, type SQL } from 'drizzle-orm';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { distanceMeters, isGenericGymName, normalizeGymName } from '@boardsesh/db/queries';
+import { isClaimableDomain } from '@boardsesh/gym-claim';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
@@ -48,6 +49,8 @@ export type GymNameMatch = {
   name: string;
   address: string | null;
   website: string | null;
+  /** Whether the gym's OWNER put `website` on the listing — the provenance half of the domain-claim rule (#3431). */
+  websiteVouchedByOwner: boolean;
   ownerId: string;
   latitude: number | null;
   longitude: number | null;
@@ -62,6 +65,7 @@ const gymColumns = {
   name: dbSchema.gyms.name,
   address: dbSchema.gyms.address,
   website: dbSchema.gyms.website,
+  websiteVouchedByOwner: dbSchema.gyms.websiteVouchedByOwner,
   ownerId: dbSchema.gyms.ownerId,
   latitude: dbSchema.gyms.latitude,
   longitude: dbSchema.gyms.longitude,
@@ -537,6 +541,12 @@ export type SimilarGymResult = {
   distanceMeters: number | null;
   ownerType: 'SYSTEM' | 'USER';
   isClaimable: boolean;
+  /**
+   * Whether the website on file can drive the self-service email claim — a real
+   * (non-free-provider) domain the gym's OWNER put there. Answers a different
+   * question from `isClaimable`, which is about the viewer's standing.
+   */
+  canClaimByDomain: boolean;
   providerOrigins: string[];
 };
 
@@ -575,6 +585,9 @@ export const socialGymMatchQueries = {
       distanceMeters: candidate.distanceMeters,
       ownerType: candidate.ownerId === SYSTEM_BOARD_OWNER_ID ? 'SYSTEM' : 'USER',
       isClaimable: claimableByGym.get(candidate.id) ?? false,
+      // Same expression enrichGym uses, from the same helper requestGymClaim
+      // uses, so the three can't drift apart (#4018).
+      canClaimByDomain: isClaimableDomain(candidate.website) && candidate.websiteVouchedByOwner,
       providerOrigins: originsByGym.get(candidate.id) ?? [],
     }));
   },

--- a/packages/backend/src/graphql/resolvers/social/gyms.ts
+++ b/packages/backend/src/graphql/resolvers/social/gyms.ts
@@ -22,6 +22,7 @@ import {
   UUIDSchema,
 } from '../../../validation/schemas';
 import { distanceMeters } from '@boardsesh/db/queries';
+import { isClaimableDomain } from '@boardsesh/gym-claim';
 import { logger } from '../../../utils/logger';
 import { PROXIMITY_MATCH_RADIUS_METERS } from './gym-matching';
 import { syncLocationGeography } from './location-geography';
@@ -376,6 +377,17 @@ export async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenti
   // while looking correct in a logged-in dev session.
   const isClaimed = gym.ownerId !== SYSTEM_BOARD_OWNER_ID;
 
+  // Whether the website on file can drive the self-service email claim. Both
+  // halves of the rule requestGymClaim enforces, in the same order and from the
+  // same helper so the advertised capability can't drift from the gate: the
+  // website has to be a real organisational domain, AND the gym's own owner has
+  // to have put it there (#3431). Viewer-independent, like isClaimed — it
+  // describes the listing, not who is asking, so it stays correct for anonymous
+  // SSR. This carries NO enforcement: the decision lives in requestGymClaim and
+  // stays there. It exists so a claim UI opens the form that can succeed instead
+  // of dead-ending a climber on submit (#4018).
+  const canClaimByDomain = isClaimableDomain(gym.website) && gym.websiteVouchedByOwner;
+
   return {
     uuid: gym.uuid,
     slug: gym.slug,
@@ -412,6 +424,7 @@ export async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenti
     canGrantAccess,
     canClaim,
     isClaimed,
+    canClaimByDomain,
   };
 }
 

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2862,6 +2862,14 @@ type Gym {
   "Whether a real person owns this gym, as opposed to the system import user. Viewer-independent — unlike canClaim, which is false for every signed-out viewer."
   isClaimed: Boolean!
   """
+  Whether this gym's website can drive the self-service email claim: a real
+  (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
+  the two refusals in requestGymClaim, so a claim UI can open the form that
+  can actually succeed instead of dead-ending on submit. Viewer-independent —
+  unlike canClaim, this says nothing about who is asking.
+  """
+  canClaimByDomain: Boolean!
+  """
   The viewer's own unresolved claim on this gym, so a claimant who already
   filed sees "under review" instead of the claim call-out. A lazy field
   resolver with its own query — deliberately NOT part of enrichGym, which
@@ -2913,6 +2921,13 @@ type SimilarGym {
   ownerType: GymOwnerType!
   "Whether the current viewer can start an ownership claim for this gym."
   isClaimable: Boolean!
+  """
+  Whether this gym's website can drive the self-service email claim: a real
+  (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
+  the two refusals in requestGymClaim. Answers a different question from
+  isClaimable, which is about the viewer's standing, not the website.
+  """
+  canClaimByDomain: Boolean!
   "Upstream provider origins for a synced gym (e.g. \"kilter\", \"tension\"), from source-key prefixes. Empty for user-created gyms."
   providerOrigins: [String!]!
 }

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -2473,6 +2473,14 @@ export type Gym = {
   brandPrimaryColor?: Maybe<Scalars['String']['output']>;
   /** Whether the current viewer may start an ownership claim for this gym (signed-in and not already the owner/gym admin) */
   canClaim: Scalars['Boolean']['output'];
+  /**
+   * Whether this gym's website can drive the self-service email claim: a real
+   * (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
+   * the two refusals in requestGymClaim, so a claim UI can open the form that
+   * can actually succeed instead of dead-ending on submit. Viewer-independent —
+   * unlike canClaim, this says nothing about who is asking.
+   */
+  canClaimByDomain: Scalars['Boolean']['output'];
   /** Whether the current viewer may edit this gym (owner, gym admin, gym editor, or community admin/leader for one of its board types) */
   canEdit: Scalars['Boolean']['output'];
   /** Whether the current viewer may grant/revoke write access to other users (owner, gym admin, or community admin/leader for one of its board types) */
@@ -7463,6 +7471,13 @@ export type SimilarGym = {
   __typename?: 'SimilarGym';
   /** Physical address */
   address?: Maybe<Scalars['String']['output']>;
+  /**
+   * Whether this gym's website can drive the self-service email claim: a real
+   * (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
+   * the two refusals in requestGymClaim. Answers a different question from
+   * isClaimable, which is about the viewer's standing, not the website.
+   */
+  canClaimByDomain: Scalars['Boolean']['output'];
   /** Distance in metres from the supplied coordinates; null when no coordinates were given. */
   distanceMeters?: Maybe<Scalars['Float']['output']>;
   /** Whether the current viewer can start an ownership claim for this gym. */
@@ -10468,6 +10483,7 @@ export type GymResolvers<
   brandBackgroundColor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   brandPrimaryColor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   canClaim?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  canClaimByDomain?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   canEdit?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   canGrantAccess?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   commentCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -13336,6 +13352,7 @@ export type SimilarGymResolvers<
   ParentType extends ResolversParentTypes['SimilarGym'] = ResolversParentTypes['SimilarGym'],
 > = ResolversObject<{
   address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  canClaimByDomain?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   distanceMeters?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   isClaimable?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/packages/shared-schema/src/schema/gyms.ts
+++ b/packages/shared-schema/src/schema/gyms.ts
@@ -136,6 +136,14 @@ export const gymsTypeDefs = /* GraphQL */ `
     "Whether a real person owns this gym, as opposed to the system import user. Viewer-independent — unlike canClaim, which is false for every signed-out viewer."
     isClaimed: Boolean!
     """
+    Whether this gym's website can drive the self-service email claim: a real
+    (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
+    the two refusals in requestGymClaim, so a claim UI can open the form that
+    can actually succeed instead of dead-ending on submit. Viewer-independent —
+    unlike canClaim, this says nothing about who is asking.
+    """
+    canClaimByDomain: Boolean!
+    """
     The viewer's own unresolved claim on this gym, so a claimant who already
     filed sees "under review" instead of the claim call-out. A lazy field
     resolver with its own query — deliberately NOT part of enrichGym, which
@@ -187,6 +195,13 @@ export const gymsTypeDefs = /* GraphQL */ `
     ownerType: GymOwnerType!
     "Whether the current viewer can start an ownership claim for this gym."
     isClaimable: Boolean!
+    """
+    Whether this gym's website can drive the self-service email claim: a real
+    (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
+    the two refusals in requestGymClaim. Answers a different question from
+    isClaimable, which is about the viewer's standing, not the website.
+    """
+    canClaimByDomain: Boolean!
     "Upstream provider origins for a synced gym (e.g. \\"kilter\\", \\"tension\\"), from source-key prefixes. Empty for user-created gyms."
     providerOrigins: [String!]!
   }

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -107,8 +107,15 @@ export type Gym = {
    * Whether this gym's website can drive the self-service email claim: a real
    * (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
    * the two refusals in requestGymClaim, so a claim UI can open the form that
-   * can succeed. Viewer-independent, and required here because GYM_FIELDS
-   * selects it — every document typed `Gym` genuinely returns it.
+   * can succeed. Viewer-independent — it describes the listing, not the viewer.
+   *
+   * Required rather than optional even though NO document selects it yet:
+   * enrichGym always returns it, and requiring it is what forces every `Gym`
+   * fixture — and the client PR that follows — to acknowledge the field instead
+   * of silently reading `undefined` and routing a claimable gym to admin
+   * review. GYM_FIELDS starts selecting it one PR later, on purpose: a field
+   * the deployed backend cannot answer fails validation for the WHOLE document
+   * (same hazard as `myPendingClaim` below).
    */
   canClaimByDomain: boolean;
   /**

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -104,6 +104,14 @@ export type Gym = {
    */
   isClaimed: boolean;
   /**
+   * Whether this gym's website can drive the self-service email claim: a real
+   * (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
+   * the two refusals in requestGymClaim, so a claim UI can open the form that
+   * can succeed. Viewer-independent, and required here because GYM_FIELDS
+   * selects it — every document typed `Gym` genuinely returns it.
+   */
+  canClaimByDomain: boolean;
+  /**
    * The viewer's unresolved claim on this gym, or null when they have none.
    * OPTIONAL on purpose: only GET_GYM_BY_SLUG selects it. Adding it to the
    * shared GYM_FIELDS would put it in documents the mobile app ships, where a
@@ -145,6 +153,12 @@ export type SimilarGym = {
   distanceMeters?: number | null;
   ownerType: GymOwnerType;
   isClaimable: boolean;
+  /**
+   * Whether this gym's website can drive the self-service email claim: a real
+   * (non-free-provider) domain that the gym's OWNER put on the listing. A
+   * different question from `isClaimable`, which is about the viewer's standing.
+   */
+  canClaimByDomain: boolean;
   /** Upstream provider origins for a synced gym (e.g. "kilter"); empty for user-created gyms. */
   providerOrigins: string[];
 };

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -2470,6 +2470,14 @@ export type Gym = {
   brandPrimaryColor?: Maybe<Scalars['String']['output']>;
   /** Whether the current viewer may start an ownership claim for this gym (signed-in and not already the owner/gym admin) */
   canClaim: Scalars['Boolean']['output'];
+  /**
+   * Whether this gym's website can drive the self-service email claim: a real
+   * (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
+   * the two refusals in requestGymClaim, so a claim UI can open the form that
+   * can actually succeed instead of dead-ending on submit. Viewer-independent —
+   * unlike canClaim, this says nothing about who is asking.
+   */
+  canClaimByDomain: Scalars['Boolean']['output'];
   /** Whether the current viewer may edit this gym (owner, gym admin, gym editor, or community admin/leader for one of its board types) */
   canEdit: Scalars['Boolean']['output'];
   /** Whether the current viewer may grant/revoke write access to other users (owner, gym admin, or community admin/leader for one of its board types) */
@@ -7460,6 +7468,13 @@ export type SimilarGym = {
   __typename?: 'SimilarGym';
   /** Physical address */
   address?: Maybe<Scalars['String']['output']>;
+  /**
+   * Whether this gym's website can drive the self-service email claim: a real
+   * (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
+   * the two refusals in requestGymClaim. Answers a different question from
+   * isClaimable, which is about the viewer's standing, not the website.
+   */
+  canClaimByDomain: Scalars['Boolean']['output'];
   /** Distance in metres from the supplied coordinates; null when no coordinates were given. */
   distanceMeters?: Maybe<Scalars['Float']['output']>;
   /** Whether the current viewer can start an ownership claim for this gym. */

--- a/packages/web/app/components/gym-entity/__tests__/report-duplicate-dialog.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/report-duplicate-dialog.test.tsx
@@ -45,6 +45,7 @@ const gymFixture = (overrides: Partial<SimilarGym> = {}): SimilarGym => ({
   distanceMeters: 60,
   ownerType: 'SYSTEM',
   isClaimable: false,
+  canClaimByDomain: false,
   providerOrigins: ['kilter'],
   ...overrides,
 });

--- a/packages/web/app/components/gym-entity/__tests__/similar-gym-suggestions.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/similar-gym-suggestions.test.tsx
@@ -54,6 +54,7 @@ const gymFixture = (overrides: Partial<SimilarGym> = {}): SimilarGym => ({
   distanceMeters: 60,
   ownerType: 'SYSTEM',
   isClaimable: true,
+  canClaimByDomain: false,
   providerOrigins: ['kilter'],
   ...overrides,
 });

--- a/packages/web/app/components/kiosk/embed/__tests__/embed-access.test.ts
+++ b/packages/web/app/components/kiosk/embed/__tests__/embed-access.test.ts
@@ -62,6 +62,7 @@ function makeGym(overrides: Partial<Gym> = {}): Gym {
     canGrantAccess: false,
     canClaim: false,
     isClaimed: true,
+    canClaimByDomain: false,
     ...overrides,
   };
 }

--- a/packages/web/app/lib/__tests__/gym-role.test.ts
+++ b/packages/web/app/lib/__tests__/gym-role.test.ts
@@ -22,6 +22,7 @@ function makeGym(overrides?: Partial<Gym>): Gym {
     canGrantAccess: true,
     canClaim: false,
     isClaimed: true,
+    canClaimByDomain: false,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

**Read this first: #4018 is a UI-routing / dead-end-form defect, not a security hole.** A reviewer who
sees "claim" and "vouched" will reasonably brace for the worst, so: the backend gate shipped in #3431
is real, it is correctly ordered — the vouch check runs **before** the email-domain match, so a prober
cannot learn whether their address would have matched — and it is covered end-to-end by
`gym-write-access-and-claims.test.ts`. Nothing in this PR moves, duplicates, or relaxes that decision.
`requestGymClaim` stays the only enforcement point.

The bug is that neither claim UI can see half the rule. Both pick their form from
`isClaimableDomain(website)` alone and never read `gyms.website_vouched_by_owner`, because that column
isn't exposed on the GraphQL `Gym` / `SimilarGym` types at all. So on an un-vouched gym with a
corporate-looking website, the dialog opens on the email form, a climber types their work address,
and only the mutation tells them no.

This PR adds the missing capability field so a client can route to the form that can succeed. **It is
backend-only on purpose** — no client document selects it yet.

### What changed

- `Gym.canClaimByDomain: Boolean!` and `SimilarGym.canClaimByDomain: Boolean!` in the SDL + the
  hand-written TS types, plus the regenerated `packages/shared-schema/src/generated/*` and
  `packages/shared/graphql/src/generated/*` (`vp run codegen`, never hand-edited).
- Computed in `enrichGym` and in `findSimilarGyms` as
  `isClaimableDomain(gym.website) && gym.websiteVouchedByOwner` — imported from `@boardsesh/gym-claim`,
  the *same* helper `requestGymClaim` uses, so the advertised capability cannot drift from the gate.
  No extra query: `websiteVouchedByOwner` is already on the row, and `gym-matching`'s `gymColumns`
  gains one column.
- The `// TODO(#4018)` above the vouch refusal is resolved and the comment reworded.

### Two PRs, and why this one is first

**PR 2 (the client half) must not merge until this PR is deployed.** The production mobile OTA
auto-publishes on every push to `main` and can reach devices *before* the backend deploys, and an
unknown field fails validation for the **whole** GraphQL document — not just the field. Landing the
`GYM_FIELDS` selection first would break every mobile gym view for the length of the deploy window.
This is the same hazard already documented at `packages/shared/graphql/src/operations/gyms.ts:108-123`
for `myPendingClaim`.

- **PR 1 (this one)** — base `main`. Schema + resolvers + tests.
- **PR 2** — #4572, base `fix/4018-claim-vouched-domain` (this branch). Carries `Closes #4018`.

### One deliberate disclosure worth an explicit nod

`canClaimByDomain` is **viewer-independent** (like `isClaimed`, and unlike `canClaim`). It has to be:
the public gym page server-renders its claim call-out for signed-out visitors — the gym owner who just
googled their own gym — so a viewer-dependent value would route the anonymous arm at the wrong form.
The consequence is that any viewer can tell whether a gym's website is owner-confirmed. That reads as
a feature rather than a leak (it's the same trust signal we'd want to render as a badge), but it is a
deliberate choice, not an accident. Flagging it for a reviewer's yes/no.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

`vp test run --project backend gym-write-access-and-claims find-similar-gyms --reporter=agent` —
**2 files, 136 tests, all passing.**

New coverage in `gym-write-access-and-claims.test.ts`, a table over four listings — (vouched +
company domain), (vouched + `gmail.com`), (un-vouched + company domain), (no website) — asserting
`canClaimByDomain` is `true / false / false / false`. Each case **also** fires `requestGymClaim` with
a matching claim email in the same test and asserts it resolves iff the capability was true, with the
specific refusal otherwise. That pairing is the point: the field can't drift from the gate it
advertises without a test going red. Plus:

- the value is identical for an authenticated and an anonymous viewer (the anonymous-SSR property above);
- an editor gets `canClaim: false` with `canClaimByDomain: true` — the two flags answer different questions;
- it flips to `false` the instant an editor rewrites the website, matching the mutation;
- it survives `mapRawGymRow`, so the PostGIS proximity branch of `searchGyms` (a raw `SELECT *`) doesn't
  silently read `undefined` for `website_vouched_by_owner` and route every nearby gym to admin review.

In `find-similar-gyms-and-auto-gym.test.ts`: a candidate with an un-vouched company website comes back
`isClaimable: true, canClaimByDomain: false`, so a regression that conflates the two fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016552Be7ctNKKH8QM9rkryN
