### PR TITLE
feat(mobile): show playlist tags on the selected climb

### DIFF
--- a/packages/mobile/src/components/ClimbPlaylistChips.tsx
+++ b/packages/mobile/src/components/ClimbPlaylistChips.tsx
@@ -21,17 +21,15 @@ const MAX_VISIBLE_CHIPS = 2;
 // sizes rather than letting it push the row taller than the board thumbnail.
 const CHIP_MAX_FONT_SCALE = 1.3;
 
-export type ResolvedPlaylistChip = { key: string; name: string; dotColor: string; emoji: string | null };
+type ResolvedPlaylistChip = { key: string; name: string; dotColor: string; emoji: string | null };
 
 /**
  * Turn a climb's playlist UUIDs into renderable chips against the playlists
  * provider's `uuid → Playlist` index — O(membership), never a scan of the whole
  * playlist array. UUIDs with no matching playlist (a stale membership, another
- * board's list) are dropped. Exported so a caller that also needs the names in
- * text form (the play drawer builds a VoiceOver label from them) resolves them
- * the same way.
+ * board's list) are dropped.
  */
-export function resolvePlaylistChips(
+function resolvePlaylistChips(
   playlistUuids: Iterable<string>,
   playlistsById: Map<string, Playlist> | undefined,
 ): ResolvedPlaylistChip[] {
@@ -60,12 +58,17 @@ type PlaylistChipsRowProps = {
   /** `start` for a left-aligned list row, `center` for a centered detail header. */
   align?: 'start' | 'center';
   /**
-   * VoiceOver label for the whole strip. Omit (the list-row default) to hide the
-   * chips from the accessibility tree, keeping the row one clean target. Pass one
-   * on a detail surface, where membership is information the climber would
+   * Builds the VoiceOver label for the whole strip from every playlist name,
+   * including the ones the "+N" token hides. Omit (the list-row default) to hide
+   * the chips from the accessibility tree, keeping the row one clean target; pass
+   * one on a detail surface, where membership is information the climber would
    * otherwise never hear.
+   *
+   * A formatter rather than a finished string so the caller doesn't have to
+   * resolve the names a second time, and so the translation lookup it needs stays
+   * out of this component — which renders once per visible list row.
    */
-  accessibilityLabel?: string;
+  describeForAccessibility?: (playlistNames: string[]) => string;
 };
 
 /**
@@ -81,7 +84,7 @@ type PlaylistChipsRowProps = {
 export const PlaylistChipsRow = React.memo(function PlaylistChipsRow({
   playlistUuids,
   align = 'start',
-  accessibilityLabel,
+  describeForAccessibility,
 }: PlaylistChipsRowProps) {
   const playlistsContext = usePlaylistsContextOptional();
   const { variant, systemColors, m3 } = useTheme();
@@ -92,6 +95,7 @@ export const PlaylistChipsRow = React.memo(function PlaylistChipsRow({
 
   if (chips.length === 0) return null;
 
+  const accessibilityLabel = describeForAccessibility?.(chips.map((chip) => chip.name));
   const visibleChips = chips.slice(0, MAX_VISIBLE_CHIPS);
   const overflowCount = chips.length - visibleChips.length;
 

--- a/packages/mobile/src/components/ClimbPlaylistChips.tsx
+++ b/packages/mobile/src/components/ClimbPlaylistChips.tsx
@@ -51,12 +51,34 @@ function resolvePlaylistChips(
   return resolved;
 }
 
+/**
+ * Width ceiling for the inline strip, in points. It shares the play-drawer
+ * header's stats line, whose centre column can fall to ~106pt when a wall-state
+ * pill is up in a long-worded locale — without a cap a long playlist name would
+ * squeeze "42 sends · 3.2★ · alexr" down to nothing. Capped, the name ellipsizes
+ * and the stats keep the rest; VoiceOver still hears every name in full.
+ */
+const INLINE_MAX_WIDTH = 88;
+
 type PlaylistChipsRowProps = {
   /** The playlist UUIDs to show. Pass a reference-stable value (the membership
    *  store's `Set`, or a React Query cache array) — it is a memo dependency. */
   playlistUuids: Iterable<string>;
-  /** `start` for a left-aligned list row, `center` for a centered detail header. */
-  align?: 'start' | 'center';
+  /**
+   * `start` — the list row's own third line: leading-aligned, with its own top
+   * margin. `inline` — a token sitting *inside* another line of text (the play
+   * drawer's stats subtitle): no margin of its own, and shrinkable, so the strip
+   * costs the host row no extra height.
+   */
+  align?: 'start' | 'inline';
+  /** How many playlists get a chip before the rest collapse into "+N". Defaults
+   *  to two (a list row has the full width to itself); the play drawer passes one,
+   *  because there it shares a line with the sends/quality/setter stats. */
+  maxVisible?: number;
+  /** Label colour for the `inline` variant, so the tag matches the caption text it
+   *  joins rather than introducing a second grey on the same line. Ignored by the
+   *  list variant, which is its own line and keeps the themed chip colour. */
+  inlineLabelColor?: string;
   /**
    * Builds the VoiceOver label for the whole strip from every playlist name,
    * including the ones the "+N" token hides. Omit (the list-row default) to hide
@@ -72,7 +94,8 @@ type PlaylistChipsRowProps = {
 };
 
 /**
- * The chips themselves: up to two playlist tags plus a "+N" token. Presentational
+ * The chips themselves: up to `maxVisible` playlist tags plus a "+N" token for the
+ * rest — two on a list row, one in the play-drawer header. Presentational
  * and membership-source-agnostic, so the climb list (fed by the shared external
  * store) and the play drawer (fed by a per-climb React Query fetch) render
  * identical strips.
@@ -84,6 +107,8 @@ type PlaylistChipsRowProps = {
 export const PlaylistChipsRow = React.memo(function PlaylistChipsRow({
   playlistUuids,
   align = 'start',
+  maxVisible = MAX_VISIBLE_CHIPS,
+  inlineLabelColor,
   describeForAccessibility,
 }: PlaylistChipsRowProps) {
   const playlistsContext = usePlaylistsContextOptional();
@@ -96,7 +121,7 @@ export const PlaylistChipsRow = React.memo(function PlaylistChipsRow({
   if (chips.length === 0) return null;
 
   const accessibilityLabel = describeForAccessibility?.(chips.map((chip) => chip.name));
-  const visibleChips = chips.slice(0, MAX_VISIBLE_CHIPS);
+  const visibleChips = chips.slice(0, maxVisible);
   const overflowCount = chips.length - visibleChips.length;
 
   // Quiet neutral container + a small leading colour dot — the name carries the
@@ -104,12 +129,29 @@ export const PlaylistChipsRow = React.memo(function PlaylistChipsRow({
   // playlist has no colour, and stays readable for colour-blind users). Liquid
   // Glass uses a capsule on the system fill; Material uses an 8dp M3 chip on
   // surfaceVariant, kept distinct from the app's capsule filter pills.
+  //
+  // Inline, none of that applies: the strip is riding *inside* a line of caption
+  // text, where a filled capsule reads as a tappable control (it isn't —
+  // `pointerEvents: 'none'`), spends 16pt of horizontal padding the line can't
+  // spare, and puts a second grey next to the stats. So inline drops the
+  // container entirely and keeps only the colour dot, in the caller's own caption
+  // colour — metadata, not a button.
+  const inline = align === 'inline';
   const containerColor = selectByVariant(variant, { liquidGlass: systemColors.fill, material: m3.surfaceVariant });
   const labelColor = selectByVariant(variant, {
     liquidGlass: systemColors.secondaryLabel,
     material: m3.onSurfaceVariant,
   });
   const chipRadius = selectByVariant(variant, { liquidGlass: borderRadius.full, material: borderRadius.md });
+  const resolvedLabelColor = inline ? (inlineLabelColor ?? labelColor) : labelColor;
+  // Inline labels keep `Text`'s default 1.5x Dynamic Type cap, matching the stats
+  // beside them — a tighter cap would render the playlist name visibly smaller
+  // than its own line. The list variant keeps 1.3x: it's the third line of a row
+  // whose height the thumbnail pins.
+  const labelMaxFontScale = inline ? undefined : CHIP_MAX_FONT_SCALE;
+  const chipStyle = inline
+    ? styles.chipInline
+    : [styles.chip, { backgroundColor: containerColor, borderRadius: chipRadius }];
 
   // No mount animation: FlashList recycles cells, so a recycled row scrolling
   // back into view would replay a fade for already-known membership (a visible
@@ -117,7 +159,7 @@ export const PlaylistChipsRow = React.memo(function PlaylistChipsRow({
   // no reflow — matches `AscentStatusGlyph`, which also just appears.
   return (
     <View
-      style={[styles.row, align === 'center' ? styles.rowCentered : null]}
+      style={[styles.row, align === 'inline' ? styles.rowInline : null]}
       pointerEvents="none"
       accessible={accessibilityLabel != null}
       accessibilityLabel={accessibilityLabel}
@@ -125,9 +167,9 @@ export const PlaylistChipsRow = React.memo(function PlaylistChipsRow({
       importantForAccessibility={accessibilityLabel == null ? 'no-hide-descendants' : 'yes'}
     >
       {visibleChips.map((chip) => (
-        <View key={chip.key} style={[styles.chip, { backgroundColor: containerColor, borderRadius: chipRadius }]}>
+        <View key={chip.key} style={chipStyle}>
           {chip.emoji ? (
-            <Text variant="caption1" maxFontSizeMultiplier={CHIP_MAX_FONT_SCALE} style={styles.emoji}>
+            <Text variant="caption1" maxFontSizeMultiplier={labelMaxFontScale} style={styles.emoji}>
               {chip.emoji}
             </Text>
           ) : (
@@ -135,9 +177,9 @@ export const PlaylistChipsRow = React.memo(function PlaylistChipsRow({
           )}
           <Text
             variant="caption1"
-            color={labelColor}
+            color={resolvedLabelColor}
             numberOfLines={1}
-            maxFontSizeMultiplier={CHIP_MAX_FONT_SCALE}
+            maxFontSizeMultiplier={labelMaxFontScale}
             style={styles.label}
           >
             {chip.name}
@@ -145,8 +187,19 @@ export const PlaylistChipsRow = React.memo(function PlaylistChipsRow({
         </View>
       ))}
       {overflowCount > 0 ? (
-        <View style={[styles.chip, styles.overflowChip, { backgroundColor: containerColor, borderRadius: chipRadius }]}>
-          <Text variant="caption1" color={labelColor} maxFontSizeMultiplier={CHIP_MAX_FONT_SCALE} style={styles.label}>
+        <View
+          style={
+            inline
+              ? styles.chipInline
+              : [styles.chip, styles.overflowChip, { backgroundColor: containerColor, borderRadius: chipRadius }]
+          }
+        >
+          <Text
+            variant="caption1"
+            color={resolvedLabelColor}
+            maxFontSizeMultiplier={labelMaxFontScale}
+            style={styles.label}
+          >
             {`+${overflowCount}`}
           </Text>
         </View>
@@ -184,10 +237,14 @@ const styles = StyleSheet.create({
     marginTop: spacing[1],
     overflow: 'hidden',
   },
-  // Detail surfaces (the play-drawer header) centre their column; list rows keep
-  // the default leading alignment.
-  rowCentered: {
-    justifyContent: 'center',
+  // Riding inside an existing line of text instead of adding one: no top margin
+  // (the host row owns the spacing), free to shrink, and capped so it can never
+  // crowd out the stats it sits beside.
+  rowInline: {
+    marginTop: 0,
+    flexShrink: 1,
+    minWidth: 0,
+    maxWidth: INLINE_MAX_WIDTH,
   },
   chip: {
     flexDirection: 'row',
@@ -203,6 +260,16 @@ const styles = StyleSheet.create({
   // The overflow counter never shrinks — it must always stay visible.
   overflowChip: {
     flexShrink: 0,
+  },
+  // No container: a dot and a name, sized by the caption line it joins. Carries
+  // no minHeight, so the host row stays exactly one caption tall — which is what
+  // keeps the board art below the header from losing a single point.
+  chipInline: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+    flexShrink: 1,
+    minWidth: 0,
   },
   dot: {
     width: 8,

--- a/packages/mobile/src/components/ClimbPlaylistChips.tsx
+++ b/packages/mobile/src/components/ClimbPlaylistChips.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
+import type { Playlist } from '@boardsesh/graphql/operations/playlists';
 import { Text } from './Text';
 import { useTheme } from '../providers/theme-provider';
 import { usePlaylistsContextOptional } from '../providers/playlists-provider';
@@ -20,49 +21,76 @@ const MAX_VISIBLE_CHIPS = 2;
 // sizes rather than letting it push the row taller than the board thumbnail.
 const CHIP_MAX_FONT_SCALE = 1.3;
 
-type ResolvedChip = { key: string; name: string; dotColor: string; emoji: string | null };
+export type ResolvedPlaylistChip = { key: string; name: string; dotColor: string; emoji: string | null };
 
 /**
- * Third row of a climb list item: small playlist-membership tags. Isolated and
- * `React.memo`'d over the primitive `climbUuid` (mirrors `AscentStatusGlyph`) so
- * a membership change re-renders only this strip — never the thumbnail, name, or
- * grade. Subscribes to its own climb's membership via `useClimbPlaylistMemberships`
- * and resolves names/colours from the playlists provider's `playlistsById` map.
- *
- * Renders nothing when: the user setting is off, no provider is mounted (e.g. a
- * preview/test host), the climb is in no playlists, or memberships haven't loaded
- * yet. Display-only — hidden from the accessibility tree and `pointerEvents="none"`
- * so the whole row stays one clean target (membership management lives in the
- * actions sheet).
+ * Turn a climb's playlist UUIDs into renderable chips against the playlists
+ * provider's `uuid → Playlist` index — O(membership), never a scan of the whole
+ * playlist array. UUIDs with no matching playlist (a stale membership, another
+ * board's list) are dropped. Exported so a caller that also needs the names in
+ * text form (the play drawer builds a VoiceOver label from them) resolves them
+ * the same way.
  */
-export const ClimbPlaylistChips = React.memo(function ClimbPlaylistChips({ climbUuid }: { climbUuid: string }) {
-  const { enabled } = useShowPlaylistTagsPreference();
-  const membership = useClimbPlaylistMemberships(climbUuid);
+export function resolvePlaylistChips(
+  playlistUuids: Iterable<string>,
+  playlistsById: Map<string, Playlist> | undefined,
+): ResolvedPlaylistChip[] {
+  if (!playlistsById) return [];
+  const resolved: ResolvedPlaylistChip[] = [];
+  let index = 0;
+  for (const playlistUuid of playlistUuids) {
+    const playlist = playlistsById.get(playlistUuid);
+    if (!playlist) continue;
+    const dotColor = normalizePlaylistColor(playlist.color) ?? PLAYLIST_COLORS[index % PLAYLIST_COLORS.length];
+    resolved.push({
+      key: playlistUuid,
+      name: playlist.name,
+      dotColor,
+      emoji: resolvePlaylistEmojiIcon(playlist.icon),
+    });
+    index += 1;
+  }
+  return resolved;
+}
+
+type PlaylistChipsRowProps = {
+  /** The playlist UUIDs to show. Pass a reference-stable value (the membership
+   *  store's `Set`, or a React Query cache array) — it is a memo dependency. */
+  playlistUuids: Iterable<string>;
+  /** `start` for a left-aligned list row, `center` for a centered detail header. */
+  align?: 'start' | 'center';
+  /**
+   * VoiceOver label for the whole strip. Omit (the list-row default) to hide the
+   * chips from the accessibility tree, keeping the row one clean target. Pass one
+   * on a detail surface, where membership is information the climber would
+   * otherwise never hear.
+   */
+  accessibilityLabel?: string;
+};
+
+/**
+ * The chips themselves: up to two playlist tags plus a "+N" token. Presentational
+ * and membership-source-agnostic, so the climb list (fed by the shared external
+ * store) and the play drawer (fed by a per-climb React Query fetch) render
+ * identical strips.
+ *
+ * Renders nothing when no playlists provider is mounted (e.g. a preview/test
+ * host), the climb is in no playlists, or memberships haven't loaded yet.
+ * Display-only: `pointerEvents="none"` so it never steals a tap from its host.
+ */
+export const PlaylistChipsRow = React.memo(function PlaylistChipsRow({
+  playlistUuids,
+  align = 'start',
+  accessibilityLabel,
+}: PlaylistChipsRowProps) {
   const playlistsContext = usePlaylistsContextOptional();
   const { variant, systemColors, m3 } = useTheme();
 
   const playlistsById = playlistsContext?.playlistsById;
 
-  const chips = useMemo<ResolvedChip[]>(() => {
-    if (!playlistsById || membership.size === 0) return [];
-    const resolved: ResolvedChip[] = [];
-    let index = 0;
-    for (const playlistUuid of membership) {
-      const playlist = playlistsById.get(playlistUuid);
-      if (!playlist) continue;
-      const dotColor = normalizePlaylistColor(playlist.color) ?? PLAYLIST_COLORS[index % PLAYLIST_COLORS.length];
-      resolved.push({
-        key: playlistUuid,
-        name: playlist.name,
-        dotColor,
-        emoji: resolvePlaylistEmojiIcon(playlist.icon),
-      });
-      index += 1;
-    }
-    return resolved;
-  }, [membership, playlistsById]);
+  const chips = useMemo(() => resolvePlaylistChips(playlistUuids, playlistsById), [playlistUuids, playlistsById]);
 
-  if (!enabled || chips.length === 0) return null;
+  if (chips.length === 0) return null;
 
   const visibleChips = chips.slice(0, MAX_VISIBLE_CHIPS);
   const overflowCount = chips.length - visibleChips.length;
@@ -85,10 +113,12 @@ export const ClimbPlaylistChips = React.memo(function ClimbPlaylistChips({ climb
   // no reflow — matches `AscentStatusGlyph`, which also just appears.
   return (
     <View
-      style={styles.row}
+      style={[styles.row, align === 'center' ? styles.rowCentered : null]}
       pointerEvents="none"
-      accessibilityElementsHidden
-      importantForAccessibility="no-hide-descendants"
+      accessible={accessibilityLabel != null}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityElementsHidden={accessibilityLabel == null}
+      importantForAccessibility={accessibilityLabel == null ? 'no-hide-descendants' : 'yes'}
     >
       {visibleChips.map((chip) => (
         <View key={chip.key} style={[styles.chip, { backgroundColor: containerColor, borderRadius: chipRadius }]}>
@@ -121,6 +151,27 @@ export const ClimbPlaylistChips = React.memo(function ClimbPlaylistChips({ climb
   );
 });
 
+/**
+ * Third row of a climb list item: small playlist-membership tags. Isolated and
+ * `React.memo`'d over the primitive `climbUuid` (mirrors `AscentStatusGlyph`) so
+ * a membership change re-renders only this strip — never the thumbnail, name, or
+ * grade. Subscribes to its own climb's membership via `useClimbPlaylistMemberships`,
+ * which the Climbs tab feeds in bulk through `useClimbListPlaylistMemberships`.
+ *
+ * Gated on the opt-in "Show playlist tags" setting. That gate is list-scoped by
+ * design: chips add a third line to every row, a density cost a detail header
+ * doesn't carry — the play drawer shows its chips unconditionally, via
+ * `PlayDrawerPlaylistChips`.
+ */
+export const ClimbPlaylistChips = React.memo(function ClimbPlaylistChips({ climbUuid }: { climbUuid: string }) {
+  const { enabled } = useShowPlaylistTagsPreference();
+  const membership = useClimbPlaylistMemberships(climbUuid);
+
+  if (!enabled) return null;
+
+  return <PlaylistChipsRow playlistUuids={membership} />;
+});
+
 const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
@@ -128,6 +179,11 @@ const styles = StyleSheet.create({
     gap: spacing[1],
     marginTop: spacing[1],
     overflow: 'hidden',
+  },
+  // Detail surfaces (the play-drawer header) centre their column; list rows keep
+  // the default leading alignment.
+  rowCentered: {
+    justifyContent: 'center',
   },
   chip: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/__tests__/climb-playlist-chips.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-playlist-chips.test.tsx
@@ -198,12 +198,38 @@ describe('PlaylistChipsRow', () => {
     expect(container.textContent).not.toContain('+1');
   });
 
-  it('left-aligns by default and centers on request', () => {
+  it('keeps its own top margin on a list row and drops it when inline', () => {
+    // The list row is the strip's own third line, so it owns the 4pt gap above
+    // it. Inline in the play drawer's stats row it must add NO height at all —
+    // the board art below is `flex: 1` in a fixed-height screen, so a stray
+    // margin here comes straight off the board.
+    //
     ctrl.playlistsById = new Map([['p1', playlist('p1', 'Sunday sends')]]);
-    const left = render(<PlaylistChipsRow playlistUuids={['p1']} />);
-    expect(rowStyle(left.container)).not.toContain('justifyContent');
-    const centered = render(<PlaylistChipsRow playlistUuids={['p1']} align="center" />);
-    expect(rowStyle(centered.container)).toContain('"justifyContent":"center"');
+    const listRow = render(<PlaylistChipsRow playlistUuids={['p1']} />);
+    expect(rowStyle(listRow.container)).toContain('"marginTop":4');
+    // The inline override is appended to the same style array, so the base row's
+    // marginTop:4 is still in the serialized string — only its ABSENCE from the
+    // list row's proves the two branches differ.
+    expect(rowStyle(listRow.container)).not.toContain('"marginTop":0');
+    const inline = render(<PlaylistChipsRow playlistUuids={['p1']} align="inline" />);
+    expect(rowStyle(inline.container)).toContain('"marginTop":0');
+  });
+
+  it('collapses to "+N" past the caller\'s visible cap', () => {
+    // The play drawer passes 1: its chips share a line with the sends/quality/
+    // setter stats, so a second full name would ellipsize both to noise.
+    ctrl.playlistsById = new Map([
+      ['p1', playlist('p1', 'Sunday sends')],
+      ['p2', playlist('p2', 'Project@40')],
+    ]);
+    const two = render(<PlaylistChipsRow playlistUuids={['p1', 'p2']} />);
+    expect(two.container.textContent).toContain('Project@40');
+    expect(two.container.textContent).not.toContain('+1');
+
+    const capped = render(<PlaylistChipsRow playlistUuids={['p1', 'p2']} maxVisible={1} />);
+    expect(capped.container.textContent).toContain('Sunday sends');
+    expect(capped.container.textContent).not.toContain('Project@40');
+    expect(capped.container.textContent).toContain('+1');
   });
 
   it('builds an accessibility label from every name, including the ones "+N" hides', () => {

--- a/packages/mobile/src/components/__tests__/climb-playlist-chips.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-playlist-chips.test.tsx
@@ -13,7 +13,29 @@ const ctrl = vi.hoisted(() => ({
 }));
 
 vi.mock('react-native', () => ({
-  View: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-view': 'true' }, children),
+  // Style and accessibility props ride through as data attributes so the
+  // alignment and accessibility-treatment assertions can read them.
+  View: ({
+    children,
+    style,
+    accessibilityLabel,
+    accessibilityElementsHidden,
+  }: {
+    children?: ReactNode;
+    style?: unknown;
+    accessibilityLabel?: string;
+    accessibilityElementsHidden?: boolean;
+  }) =>
+    createElement(
+      'div',
+      {
+        'data-view': 'true',
+        'data-style': JSON.stringify(style ?? null),
+        'aria-label': accessibilityLabel,
+        'data-a11y-hidden': accessibilityElementsHidden ? 'true' : 'false',
+      },
+      children,
+    ),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles },
 }));
 
@@ -52,7 +74,7 @@ vi.mock('../../lib/show-playlist-tags-preference', () => ({
   useShowPlaylistTagsPreference: () => ({ enabled: ctrl.enabled, loaded: true, setEnabled: vi.fn() }),
 }));
 
-import { ClimbPlaylistChips } from '../ClimbPlaylistChips';
+import { ClimbPlaylistChips, PlaylistChipsRow, resolvePlaylistChips } from '../ClimbPlaylistChips';
 
 function playlist(uuid: string, name: string, color?: string): Playlist {
   return {
@@ -75,6 +97,10 @@ function playlist(uuid: string, name: string, color?: string): Playlist {
 function setMemberships(entries: Array<[string, string]>, colors: Record<string, string | undefined> = {}) {
   ctrl.membership = new Set(entries.map(([uuid]) => uuid));
   ctrl.playlistsById = new Map(entries.map(([uuid, name]) => [uuid, playlist(uuid, name, colors[uuid])]));
+}
+
+function rowStyle(container: HTMLElement): string {
+  return container.querySelector('[data-view]')?.getAttribute('data-style') ?? '';
 }
 
 describe('ClimbPlaylistChips', () => {
@@ -136,5 +162,71 @@ describe('ClimbPlaylistChips', () => {
     setMemberships([['p1', 'Project@30']]);
     const { container } = render(<ClimbPlaylistChips climbUuid="c1" />);
     expect(container.textContent).toContain('Project@30');
+  });
+
+  it('hides the list-row strip from the accessibility tree', () => {
+    setMemberships([['p1', 'Project@30']]);
+    const { container } = render(<ClimbPlaylistChips climbUuid="c1" />);
+    expect(container.querySelector('[data-view]')?.getAttribute('data-a11y-hidden')).toBe('true');
+  });
+});
+
+describe('PlaylistChipsRow', () => {
+  beforeEach(() => {
+    ctrl.variant = 'liquidGlass';
+    ctrl.playlistsById = new Map();
+  });
+
+  it('renders chips from an explicit uuid list, independent of the membership store', () => {
+    // The play drawer feeds this from its own per-climb fetch — nothing in the
+    // shared store, and no "show playlist tags" setting involved.
+    ctrl.membership = new Set();
+    ctrl.playlistsById = new Map([['p1', playlist('p1', 'Sunday sends')]]);
+    const { container } = render(<PlaylistChipsRow playlistUuids={['p1']} />);
+    expect(container.textContent).toContain('Sunday sends');
+  });
+
+  it('renders nothing when the uuid list is empty', () => {
+    const { container } = render(<PlaylistChipsRow playlistUuids={[]} />);
+    expect(container.textContent).toBe('');
+  });
+
+  it('drops uuids with no matching playlist', () => {
+    ctrl.playlistsById = new Map([['p1', playlist('p1', 'Sunday sends')]]);
+    const { container } = render(<PlaylistChipsRow playlistUuids={['p1', 'gone']} />);
+    expect(container.textContent).toContain('Sunday sends');
+    expect(container.textContent).not.toContain('+1');
+  });
+
+  it('left-aligns by default and centers on request', () => {
+    ctrl.playlistsById = new Map([['p1', playlist('p1', 'Sunday sends')]]);
+    const left = render(<PlaylistChipsRow playlistUuids={['p1']} />);
+    expect(rowStyle(left.container)).not.toContain('justifyContent');
+    const centered = render(<PlaylistChipsRow playlistUuids={['p1']} align="center" />);
+    expect(rowStyle(centered.container)).toContain('"justifyContent":"center"');
+  });
+
+  it('exposes a supplied accessibility label instead of hiding the strip', () => {
+    ctrl.playlistsById = new Map([['p1', playlist('p1', 'Sunday sends')]]);
+    const { container } = render(
+      <PlaylistChipsRow playlistUuids={['p1']} accessibilityLabel="In playlists: Sunday sends" />,
+    );
+    const row = container.querySelector('[data-view]');
+    expect(row?.getAttribute('aria-label')).toBe('In playlists: Sunday sends');
+    expect(row?.getAttribute('data-a11y-hidden')).toBe('false');
+  });
+});
+
+describe('resolvePlaylistChips', () => {
+  it('returns nothing without a playlists index', () => {
+    expect(resolvePlaylistChips(['p1'], undefined)).toEqual([]);
+  });
+
+  it('resolves names in the order the uuids arrive', () => {
+    const byId = new Map([
+      ['p1', playlist('p1', 'One')],
+      ['p2', playlist('p2', 'Two')],
+    ]);
+    expect(resolvePlaylistChips(['p2', 'p1'], byId).map((chip) => chip.name)).toEqual(['Two', 'One']);
   });
 });

--- a/packages/mobile/src/components/__tests__/climb-playlist-chips.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-playlist-chips.test.tsx
@@ -74,7 +74,7 @@ vi.mock('../../lib/show-playlist-tags-preference', () => ({
   useShowPlaylistTagsPreference: () => ({ enabled: ctrl.enabled, loaded: true, setEnabled: vi.fn() }),
 }));
 
-import { ClimbPlaylistChips, PlaylistChipsRow, resolvePlaylistChips } from '../ClimbPlaylistChips';
+import { ClimbPlaylistChips, PlaylistChipsRow } from '../ClimbPlaylistChips';
 
 function playlist(uuid: string, name: string, color?: string): Playlist {
   return {
@@ -206,27 +206,20 @@ describe('PlaylistChipsRow', () => {
     expect(rowStyle(centered.container)).toContain('"justifyContent":"center"');
   });
 
-  it('exposes a supplied accessibility label instead of hiding the strip', () => {
-    ctrl.playlistsById = new Map([['p1', playlist('p1', 'Sunday sends')]]);
+  it('builds an accessibility label from every name, including the ones "+N" hides', () => {
+    ctrl.playlistsById = new Map([
+      ['p1', playlist('p1', 'Sunday sends')],
+      ['p2', playlist('p2', 'Project@40')],
+      ['p3', playlist('p3', 'Warmups')],
+    ]);
     const { container } = render(
-      <PlaylistChipsRow playlistUuids={['p1']} accessibilityLabel="In playlists: Sunday sends" />,
+      <PlaylistChipsRow
+        playlistUuids={['p1', 'p2', 'p3']}
+        describeForAccessibility={(names) => `In playlists: ${names.join(', ')}`}
+      />,
     );
     const row = container.querySelector('[data-view]');
-    expect(row?.getAttribute('aria-label')).toBe('In playlists: Sunday sends');
+    expect(row?.getAttribute('aria-label')).toBe('In playlists: Sunday sends, Project@40, Warmups');
     expect(row?.getAttribute('data-a11y-hidden')).toBe('false');
-  });
-});
-
-describe('resolvePlaylistChips', () => {
-  it('returns nothing without a playlists index', () => {
-    expect(resolvePlaylistChips(['p1'], undefined)).toEqual([]);
-  });
-
-  it('resolves names in the order the uuids arrive', () => {
-    const byId = new Map([
-      ['p1', playlist('p1', 'One')],
-      ['p2', playlist('p2', 'Two')],
-    ]);
-    expect(resolvePlaylistChips(['p2', 'p1'], byId).map((chip) => chip.name)).toEqual(['Two', 'One']);
   });
 });

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -1207,10 +1207,8 @@ export function PlayDrawer({
                                 ) : undefined
                               }
                               onLongPressName={handleCopyName}
-                              // Only the climb on screen fetches its playlist membership.
-                              // The peek below changes with every climb a fling passes,
-                              // so it renders from cache alone rather than firing a
-                              // request per climb flown past.
+                              // Only the climb on screen fetches its playlist
+                              // membership; a fling passes many climbs.
                               fetchPlaylistMembership
                             />
                           }

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -1207,6 +1207,11 @@ export function PlayDrawer({
                                 ) : undefined
                               }
                               onLongPressName={handleCopyName}
+                              // Only the climb on screen fetches its playlist membership.
+                              // The peek below changes with every climb a fling passes,
+                              // so it renders from cache alone rather than firing a
+                              // request per climb flown past.
+                              fetchPlaylistMembership
                             />
                           }
                           peek={

--- a/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
@@ -10,6 +10,7 @@ import { Text } from '../Text';
 import { MarqueeText } from '../MarqueeText';
 import { DrawerHeader } from '../DrawerHeader';
 import { ClimbAttributeIcons } from '../ClimbAttributeIcons';
+import { PlayDrawerPlaylistChips } from './PlayDrawerPlaylistChips';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { WALL_STATE_PILL_TOUCH_HEIGHT } from '../../theme/layout';
 import { useDisplayGrade } from '../../hooks/use-display-grade';
@@ -45,6 +46,11 @@ type PlayDrawerHeaderProps = {
   /** Long-press handler on the name (copies it to the clipboard). When omitted the
    *  name is a plain, non-interactive label — used for the swipe "peek" header. */
   onLongPressName?: () => void;
+  /** Playlist-membership tags, rendered under the subtitle. Must occupy a
+   *  constant height per climb (see `PlayDrawerPlaylistChips`) — the board art
+   *  below is `flex: 1` in a fixed-height first screen, so a header that grew for
+   *  one climb and shrank for the next would resize the board on every swipe. */
+  playlistChips?: ReactNode;
 };
 
 export const PlayDrawerHeader = memo(function PlayDrawerHeader({
@@ -60,6 +66,7 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
   boardName,
   leading,
   onLongPressName,
+  playlistChips,
 }: PlayDrawerHeaderProps) {
   const { t } = useTranslation('climbs');
   const resolvedGradeColor = useMemo(
@@ -142,6 +149,7 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
               {ruleLabels.parts.join(' · ')}
             </Text>
           ) : null}
+          {playlistChips}
         </>
       }
       trailing={
@@ -160,6 +168,9 @@ type LivePlayDrawerHeaderProps = {
   angle: number;
   leading?: ReactNode;
   onLongPressName?: () => void;
+  /** Whether this header may fetch the climb's playlist membership. True for the
+   *  climb on screen, false for the swipe "peek" (see `PlayDrawerPlaylistChips`). */
+  fetchPlaylistMembership?: boolean;
 };
 
 /** The only play-header child subscribed to the exact live-stat key. */
@@ -170,6 +181,7 @@ export const LivePlayDrawerHeader = memo(function LivePlayDrawerHeader({
   angle,
   leading,
   onLongPressName,
+  fetchPlaylistMembership = false,
 }: LivePlayDrawerHeaderProps) {
   const { resolveGrade } = useDisplayGrade();
   const liveStats = useEffectiveClimbStats(boardName, layoutId, climb.uuid, angle, {
@@ -196,6 +208,14 @@ export const LivePlayDrawerHeader = memo(function LivePlayDrawerHeader({
       boardName={boardName}
       leading={leading}
       onLongPressName={onLongPressName}
+      playlistChips={
+        <PlayDrawerPlaylistChips
+          climbUuid={climb.uuid}
+          boardName={boardName}
+          layoutId={layoutId}
+          fetchMembership={fetchPlaylistMembership}
+        />
+      }
     />
   );
 });

--- a/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
@@ -12,9 +12,35 @@ import { DrawerHeader } from '../DrawerHeader';
 import { ClimbAttributeIcons } from '../ClimbAttributeIcons';
 import { PlayDrawerPlaylistChips } from './PlayDrawerPlaylistChips';
 import { iosSystemColors } from '../../theme/ios-colors';
+import { spacing } from '../../theme/tokens';
 import { WALL_STATE_PILL_TOUCH_HEIGHT } from '../../theme/layout';
 import { useDisplayGrade } from '../../hooks/use-display-grade';
 import { resolveClimbRuleLabels } from './climb-rule-labels';
+
+/**
+ * Gap between the climb name and the stats line under it, in points.
+ *
+ * Small enough to matter: the play drawer's first screen is a FIXED height with
+ * the board art `flex: 1` inside it, so every point this header takes is a point
+ * the board renderer loses. The whole centre column has to fit under the
+ * `minRowHeight` floor the wall-state pill already sets:
+ *
+ *   body line height + THIS + caption1 line height  <=  WALL_STATE_PILL_TOUCH_HEIGHT
+ *   iOS (HIG scale)       22 + 2 + 16 = 40  <= 44
+ *   Android (M3 scale)    24 + 2 + 16 = 42  <= 44
+ *
+ * Both variants clear it with room to spare, which is why the playlist tags ride
+ * *inside* the stats line as caption text rather than taking a line, or a taller
+ * row, of their own — they cost the board renderer nothing. `PlaylistChipsRow`'s
+ * `inline` variant carries no container and no `minHeight` precisely so this stays
+ * true. See `play-drawer-header-layout-budget.test.tsx`, which pins the sum for
+ * both type scales.
+ *
+ * The climb-RULES line below is the deliberate exception: it is allowed to grow
+ * the header (and push the board down) because a truncated rule is worse than a
+ * shorter board. Membership in a playlist does not clear that bar.
+ */
+export const STATS_ROW_MARGIN_TOP = 2;
 
 type PlayDrawerHeaderProps = {
   name: string;
@@ -46,10 +72,11 @@ type PlayDrawerHeaderProps = {
   /** Long-press handler on the name (copies it to the clipboard). When omitted the
    *  name is a plain, non-interactive label — used for the swipe "peek" header. */
   onLongPressName?: () => void;
-  /** Playlist-membership tags, rendered under the subtitle. Must occupy a
-   *  constant height per climb (see `PlayDrawerPlaylistChips`) — the board art
-   *  below is `flex: 1` in a fixed-height first screen, so a header that grew for
-   *  one climb and shrank for the next would resize the board on every swipe. */
+  /** Playlist-membership tags. Rendered *inside* the stats row, not under it: the
+   *  board art below is `flex: 1` in a fixed-height first screen, so a line of its
+   *  own would come straight off the board — and a line that appeared for one climb
+   *  and not the next would resize the board on every swipe. See
+   *  `STATS_ROW_MARGIN_TOP`. */
   playlistChips?: ReactNode;
 };
 
@@ -131,9 +158,17 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
               characteristics={residualCharacteristics?.length ? residualCharacteristics : null}
             />
           </View>
-          <Text variant="caption1" style={styles.subtitleText} numberOfLines={1}>
-            {subtitleParts.join(' · ')}
-          </Text>
+          {/* Stats and playlist tags share ONE line, both `caption1`, so the row is
+              exactly one caption tall for a climb in a playlist and one in none —
+              no reserved height to keep in sync, and nothing off the board art.
+              The tag leads: it's the thing the climber came to check, and the
+              stats behind it ellipsize from the tail (the setter) under squeeze. */}
+          <View style={styles.subtitleRow}>
+            {playlistChips}
+            <Text variant="caption1" style={styles.subtitleText} numberOfLines={1}>
+              {subtitleParts.join(' · ')}
+            </Text>
+          </View>
           {/* Deliberately unbounded lines: at the largest Dynamic Type sizes, or
               on a narrow phone in German, "Matching allowed · Marked holds only"
               does not fit one line, and a truncated climb RULE is worse than a
@@ -149,7 +184,6 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
               {ruleLabels.parts.join(' · ')}
             </Text>
           ) : null}
-          {playlistChips}
         </>
       }
       trailing={
@@ -248,10 +282,21 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     textAlign: 'center',
   },
+  subtitleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[1],
+    marginTop: STATS_ROW_MARGIN_TOP,
+    alignSelf: 'stretch',
+  },
   subtitleText: {
     color: iosSystemColors.systemGray,
-    marginTop: 2,
     textAlign: 'center',
+    // Yields when a playlist tag shares the line, so a long setter name
+    // ellipsizes rather than shoving the tag out of the row.
+    flexShrink: 1,
+    minWidth: 0,
   },
   // Same grey as the subtitle it sits under — the rules are context, not a
   // second headline competing with the name and the grade.

--- a/packages/mobile/src/components/play-drawer/PlayDrawerPlaylistChips.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerPlaylistChips.tsx
@@ -69,6 +69,13 @@ export const PlayDrawerPlaylistChips = memo(function PlayDrawerPlaylistChips({
   // same rule the `playlistsForClimb` resolver applies, so this is exactly "can a
   // chip ever appear here" — and it does not vary per climb, which is what keeps
   // the reserved slot's height constant while swiping through the queue.
+  //
+  // It can still flip once, from false to true, if a climber opens a climb before
+  // the app-root playlists query has resolved: the slot appears and the board
+  // settles 30pt. Reserving the slot while that query is in flight would trade
+  // that for the same settle in reverse, and would charge it to everyone who has
+  // no playlists — the majority — instead of only to playlist owners inside a
+  // one-or-two-second window at cold start. This is the cheaper side of the trade.
   const hasBoardPlaylists = useMemo(
     () => (playlists ? filterPlaylistsByBoard(playlists, boardName, layoutId).length > 0 : false),
     [playlists, boardName, layoutId],

--- a/packages/mobile/src/components/play-drawer/PlayDrawerPlaylistChips.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerPlaylistChips.tsx
@@ -5,7 +5,7 @@ import { PlaylistChipsRow } from '../ClimbPlaylistChips';
 import { useClimbPlaylistMemberships } from '../../hooks/use-climb-playlist-memberships';
 import { useClimbPlaylistMembershipQuery } from '../../hooks/use-climb-playlist-membership-query';
 import { usePlaylistsContextOptional } from '../../providers/playlists-provider';
-import { filterPlaylistsByBoard } from '../../lib/sort-filter-playlists';
+import { hasPlaylistForBoard } from '../../lib/sort-filter-playlists';
 
 /**
  * Height of the reserved chips slot, in points.
@@ -77,7 +77,7 @@ export const PlayDrawerPlaylistChips = memo(function PlayDrawerPlaylistChips({
   // no playlists — the majority — instead of only to playlist owners inside a
   // one-or-two-second window at cold start. This is the cheaper side of the trade.
   const hasBoardPlaylists = useMemo(
-    () => (playlists ? filterPlaylistsByBoard(playlists, boardName, layoutId).length > 0 : false),
+    () => (playlists ? hasPlaylistForBoard(playlists, boardName, layoutId) : false),
     [playlists, boardName, layoutId],
   );
 
@@ -94,7 +94,9 @@ export const PlayDrawerPlaylistChips = memo(function PlayDrawerPlaylistChips({
   // every board/auth/preference change and would wipe them. React Query is the
   // durable cache here.
   const seededMembers = useClimbPlaylistMemberships(climbUuid);
-  const members = useMemo<Iterable<string>>(() => memberUuids ?? seededMembers, [memberUuids, seededMembers]);
+  // No memo needed: both sides are already reference-stable (a React Query cache
+  // array, the store's cached `Set`), so the coalesce is stable on its own.
+  const members: Iterable<string> = memberUuids ?? seededMembers;
 
   // Every playlist by name, not just the two that fit — a "+2" token tells a
   // VoiceOver user nothing. The list variant stays hidden from the accessibility

--- a/packages/mobile/src/components/play-drawer/PlayDrawerPlaylistChips.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerPlaylistChips.tsx
@@ -1,27 +1,18 @@
 import { memo, useCallback, useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { PlaylistChipsRow } from '../ClimbPlaylistChips';
 import { useClimbPlaylistMemberships } from '../../hooks/use-climb-playlist-memberships';
 import { useClimbPlaylistMembershipQuery } from '../../hooks/use-climb-playlist-membership-query';
 import { usePlaylistsContextOptional } from '../../providers/playlists-provider';
 import { hasPlaylistForBoard } from '../../lib/sort-filter-playlists';
+import { iosSystemColors } from '../../theme/ios-colors';
 
 /**
- * Height of the reserved chips slot, in points.
- *
- * The play drawer's first screen is a FIXED height and the board art under the
- * header is `flex: 1` inside it, so every point the header takes comes off the
- * board. If the strip's height varied per climb — present for a climb in a
- * playlist, absent for the next one — the board would resize on every swipe, and
- * again whenever a membership fetch landed. So the slot is constant whenever it
- * is rendered at all, and the chips paint inside it.
- *
- * Sized for the tallest chip the strip can produce: `caption1` (16pt line height)
- * scaled by the chips' 1.3 accessibility cap, plus 4pt of chip padding and the
- * row's 4pt top margin, rounded up for headroom.
+ * How many playlists get named here before the rest collapse into "+N". One, not
+ * the list row's two: these tags share the stats line with sends, quality and
+ * setter, and two full names would ellipsize both to noise.
  */
-export const PLAY_DRAWER_CHIPS_SLOT_HEIGHT = 30;
+const HEADER_MAX_VISIBLE_CHIPS = 1;
 
 type PlayDrawerPlaylistChipsProps = {
   climbUuid: string;
@@ -31,14 +22,14 @@ type PlayDrawerPlaylistChipsProps = {
    * Whether this header may fetch membership. True for the climb on screen;
    * false for the swipe "peek" header, whose climb changes continuously during a
    * fling — firing a request per peek would spray one per climb passed. The peek
-   * still paints from the cache/seed, and the reserved slot keeps both headers
-   * the same height, so nothing shifts as the swipe settles.
+   * still paints from the cache/seed, and the stats row it rides is a fixed
+   * height either way, so nothing shifts as the swipe settles.
    */
   fetchMembership: boolean;
 };
 
 /**
- * Playlist-membership tags under the climb name in the play drawer.
+ * Playlist-membership tags in the play drawer, riding the header's stats line.
  *
  * Not the list variant. `ClimbPlaylistChips` reads the shared
  * `playlistMembershipStore`, which is written by exactly one hook
@@ -48,11 +39,17 @@ type PlayDrawerPlaylistChipsProps = {
  * climber did come from the Climbs tab) and confirms with its own per-climb
  * fetch, sharing the query key the add-to-playlist picker writes to.
  *
+ * Costs the board art nothing. The drawer's first screen is a FIXED height with
+ * the board `flex: 1` inside it, so every point the header takes comes straight
+ * off the board — which is why these tags do NOT get a line of their own, and are
+ * not capsules. They render as `caption1` text inside the existing
+ * "42 sends · 3.2★ · setter" line, in that line's own grey, so the row is exactly
+ * one caption tall whether the climb is in a playlist or not. See
+ * `STATS_ROW_MARGIN_TOP` in `PlayDrawerHeader` for the full budget.
+ *
  * Shown unconditionally: the "Show playlist tags" setting is list-scoped, gating
- * a third line on every row, and a detail header carries no such density cost.
- * The slot only exists for climbers who actually have playlists on this
- * board+layout — the only people who can ever see a chip here — so it costs
- * everyone else no board space at all.
+ * a third line on every row, and a header that adds no line carries no such
+ * density cost.
  */
 export const PlayDrawerPlaylistChips = memo(function PlayDrawerPlaylistChips({
   climbUuid,
@@ -67,15 +64,8 @@ export const PlayDrawerPlaylistChips = memo(function PlayDrawerPlaylistChips({
 
   // Whether the climber has any playlist a chip could name. Board-scoped with the
   // same rule the `playlistsForClimb` resolver applies, so this is exactly "can a
-  // chip ever appear here" — and it does not vary per climb, which is what keeps
-  // the reserved slot's height constant while swiping through the queue.
-  //
-  // It can still flip once, from false to true, if a climber opens a climb before
-  // the app-root playlists query has resolved: the slot appears and the board
-  // settles 30pt. Reserving the slot while that query is in flight would trade
-  // that for the same settle in reverse, and would charge it to everyone who has
-  // no playlists — the majority — instead of only to playlist owners inside a
-  // one-or-two-second window at cold start. This is the cheaper side of the trade.
+  // chip ever appear here". It costs no height either way — it only decides
+  // whether the stats row shares its width.
   const hasBoardPlaylists = useMemo(
     () => (playlists ? hasPlaylistForBoard(playlists, boardName, layoutId) : false),
     [playlists, boardName, layoutId],
@@ -98,7 +88,7 @@ export const PlayDrawerPlaylistChips = memo(function PlayDrawerPlaylistChips({
   // array, the store's cached `Set`), so the coalesce is stable on its own.
   const members: Iterable<string> = memberUuids ?? seededMembers;
 
-  // Every playlist by name, not just the two that fit — a "+2" token tells a
+  // Every playlist by name, not just the one that fits — a "+2" token tells a
   // VoiceOver user nothing. The list variant stays hidden from the accessibility
   // tree (it would triple the length of every row); on a detail surface this is
   // the only place membership is announced at all.
@@ -107,24 +97,19 @@ export const PlayDrawerPlaylistChips = memo(function PlayDrawerPlaylistChips({
     [t],
   );
 
-  // No slot at all — not even an empty one — for a signed-out climber or one with
-  // no playlist on this board. They can never see a chip here, so they should not
-  // pay for the space either.
+  // Nothing at all for a signed-out climber or one with no playlist on this
+  // board: they can never see a chip here, so they should not pay the width
+  // either — the stats line keeps the room to itself.
   if (!isAuthenticated || !hasBoardPlaylists) return null;
 
   return (
-    <View style={styles.slot}>
-      <PlaylistChipsRow playlistUuids={members} align="center" describeForAccessibility={describeForAccessibility} />
-    </View>
+    <PlaylistChipsRow
+      playlistUuids={members}
+      align="inline"
+      maxVisible={HEADER_MAX_VISIBLE_CHIPS}
+      // The exact grey the stats text beside it uses — one line, one colour.
+      inlineLabelColor={iosSystemColors.systemGray}
+      describeForAccessibility={describeForAccessibility}
+    />
   );
-});
-
-const styles = StyleSheet.create({
-  slot: {
-    height: PLAY_DRAWER_CHIPS_SLOT_HEIGHT,
-    alignSelf: 'stretch',
-    justifyContent: 'flex-start',
-    // Backstop: an unusually tall chip clips rather than pushing the board art.
-    overflow: 'hidden',
-  },
 });

--- a/packages/mobile/src/components/play-drawer/PlayDrawerPlaylistChips.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerPlaylistChips.tsx
@@ -94,6 +94,11 @@ export const PlayDrawerPlaylistChips = memo(function PlayDrawerPlaylistChips({
   // VoiceOver user nothing. The list variant stays hidden from the accessibility
   // tree (it would triple the length of every row); on a detail surface this is
   // the only place membership is announced at all.
+  //
+  // This resolves the same names the chips row resolves for itself. Handing it
+  // pre-resolved chips instead would push that work onto every caller — including
+  // the FlashList rows, where it currently sits behind their own memo — to save a
+  // handful of Map lookups on a header that renders twice. Not worth the trade.
   const accessibilityLabel = useMemo(() => {
     const names = resolvePlaylistChips(members, playlistsById).map((chip) => chip.name);
     if (names.length === 0) return undefined;

--- a/packages/mobile/src/components/play-drawer/PlayDrawerPlaylistChips.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerPlaylistChips.tsx
@@ -1,0 +1,123 @@
+import { memo, useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { PlaylistChipsRow, resolvePlaylistChips } from '../ClimbPlaylistChips';
+import { useClimbPlaylistMemberships } from '../../hooks/use-climb-playlist-memberships';
+import { useClimbPlaylistMembershipQuery } from '../../hooks/use-climb-playlist-membership-query';
+import { usePlaylistsContextOptional } from '../../providers/playlists-provider';
+import { filterPlaylistsByBoard } from '../../lib/sort-filter-playlists';
+
+/**
+ * Height of the reserved chips slot, in points.
+ *
+ * The play drawer's first screen is a FIXED height and the board art under the
+ * header is `flex: 1` inside it, so every point the header takes comes off the
+ * board. If the strip's height varied per climb — present for a climb in a
+ * playlist, absent for the next one — the board would resize on every swipe, and
+ * again whenever a membership fetch landed. So the slot is constant whenever it
+ * is rendered at all, and the chips paint inside it.
+ *
+ * Sized for the tallest chip the strip can produce: `caption1` (16pt line height)
+ * scaled by the chips' 1.3 accessibility cap, plus 4pt of chip padding and the
+ * row's 4pt top margin, rounded up for headroom.
+ */
+export const PLAY_DRAWER_CHIPS_SLOT_HEIGHT = 30;
+
+type PlayDrawerPlaylistChipsProps = {
+  climbUuid: string;
+  boardName: string;
+  layoutId: number;
+  /**
+   * Whether this header may fetch membership. True for the climb on screen;
+   * false for the swipe "peek" header, whose climb changes continuously during a
+   * fling — firing a request per peek would spray one per climb passed. The peek
+   * still paints from the cache/seed, and the reserved slot keeps both headers
+   * the same height, so nothing shifts as the swipe settles.
+   */
+  fetchMembership: boolean;
+};
+
+/**
+ * Playlist-membership tags under the climb name in the play drawer.
+ *
+ * Not the list variant. `ClimbPlaylistChips` reads the shared
+ * `playlistMembershipStore`, which is written by exactly one hook
+ * (`useClimbListPlaylistMemberships`) running on the Climbs tab — so a drawer
+ * opened from the queue, from a playlist, or from a deep link would render an
+ * empty strip forever. This variant seeds from the store (instant when the
+ * climber did come from the Climbs tab) and confirms with its own per-climb
+ * fetch, sharing the query key the add-to-playlist picker writes to.
+ *
+ * Shown unconditionally: the "Show playlist tags" setting is list-scoped, gating
+ * a third line on every row, and a detail header carries no such density cost.
+ * The slot only exists for climbers who actually have playlists on this
+ * board+layout — the only people who can ever see a chip here — so it costs
+ * everyone else no board space at all.
+ */
+export const PlayDrawerPlaylistChips = memo(function PlayDrawerPlaylistChips({
+  climbUuid,
+  boardName,
+  layoutId,
+  fetchMembership,
+}: PlayDrawerPlaylistChipsProps) {
+  const { t } = useTranslation('climbs');
+  const playlistsContext = usePlaylistsContextOptional();
+  const playlists = playlistsContext?.playlists;
+  const playlistsById = playlistsContext?.playlistsById;
+  const isAuthenticated = playlistsContext?.isAuthenticated ?? false;
+
+  // Whether the climber has any playlist a chip could name. Board-scoped with the
+  // same rule the `playlistsForClimb` resolver applies, so this is exactly "can a
+  // chip ever appear here" — and it does not vary per climb, which is what keeps
+  // the reserved slot's height constant while swiping through the queue.
+  const hasBoardPlaylists = useMemo(
+    () => (playlists ? filterPlaylistsByBoard(playlists, boardName, layoutId).length > 0 : false),
+    [playlists, boardName, layoutId],
+  );
+
+  const { memberUuids } = useClimbPlaylistMembershipQuery({
+    climbUuid,
+    boardName,
+    layoutId,
+    enabled: fetchMembership && isAuthenticated && hasBoardPlaylists && layoutId > 0,
+  });
+
+  // The store seed paints immediately when the climber arrived from the Climbs
+  // tab with playlist tags on; the fetch above then confirms and wins. Results
+  // are deliberately NOT written back into the store: the Climbs tab resets it on
+  // every board/auth/preference change and would wipe them. React Query is the
+  // durable cache here.
+  const seededMembers = useClimbPlaylistMemberships(climbUuid);
+  const members = useMemo<Iterable<string>>(() => memberUuids ?? seededMembers, [memberUuids, seededMembers]);
+
+  // Every playlist by name, not just the two that fit — a "+2" token tells a
+  // VoiceOver user nothing. The list variant stays hidden from the accessibility
+  // tree (it would triple the length of every row); on a detail surface this is
+  // the only place membership is announced at all.
+  const accessibilityLabel = useMemo(() => {
+    const names = resolvePlaylistChips(members, playlistsById).map((chip) => chip.name);
+    if (names.length === 0) return undefined;
+    return t('mobile.detail.inPlaylists', { playlists: names.join(', ') });
+  }, [members, playlistsById, t]);
+
+  // No slot at all — not even an empty one — for a signed-out climber or one with
+  // no playlist on this board. They can never see a chip here, so they should not
+  // pay for the space either.
+  if (!isAuthenticated || !hasBoardPlaylists) return null;
+
+  return (
+    <View style={styles.slot}>
+      <PlaylistChipsRow playlistUuids={members} align="center" accessibilityLabel={accessibilityLabel} />
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  slot: {
+    height: PLAY_DRAWER_CHIPS_SLOT_HEIGHT,
+    alignSelf: 'stretch',
+    justifyContent: 'flex-start',
+    // Backstop: an unusually tall chip clips rather than pushing the board art.
+    overflow: 'hidden',
+  },
+});

--- a/packages/mobile/src/components/play-drawer/PlayDrawerPlaylistChips.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerPlaylistChips.tsx
@@ -1,7 +1,7 @@
-import { memo, useMemo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { PlaylistChipsRow, resolvePlaylistChips } from '../ClimbPlaylistChips';
+import { PlaylistChipsRow } from '../ClimbPlaylistChips';
 import { useClimbPlaylistMemberships } from '../../hooks/use-climb-playlist-memberships';
 import { useClimbPlaylistMembershipQuery } from '../../hooks/use-climb-playlist-membership-query';
 import { usePlaylistsContextOptional } from '../../providers/playlists-provider';
@@ -63,7 +63,6 @@ export const PlayDrawerPlaylistChips = memo(function PlayDrawerPlaylistChips({
   const { t } = useTranslation('climbs');
   const playlistsContext = usePlaylistsContextOptional();
   const playlists = playlistsContext?.playlists;
-  const playlistsById = playlistsContext?.playlistsById;
   const isAuthenticated = playlistsContext?.isAuthenticated ?? false;
 
   // Whether the climber has any playlist a chip could name. Board-scoped with the
@@ -94,16 +93,10 @@ export const PlayDrawerPlaylistChips = memo(function PlayDrawerPlaylistChips({
   // VoiceOver user nothing. The list variant stays hidden from the accessibility
   // tree (it would triple the length of every row); on a detail surface this is
   // the only place membership is announced at all.
-  //
-  // This resolves the same names the chips row resolves for itself. Handing it
-  // pre-resolved chips instead would push that work onto every caller — including
-  // the FlashList rows, where it currently sits behind their own memo — to save a
-  // handful of Map lookups on a header that renders twice. Not worth the trade.
-  const accessibilityLabel = useMemo(() => {
-    const names = resolvePlaylistChips(members, playlistsById).map((chip) => chip.name);
-    if (names.length === 0) return undefined;
-    return t('mobile.detail.inPlaylists', { playlists: names.join(', ') });
-  }, [members, playlistsById, t]);
+  const describeForAccessibility = useCallback(
+    (playlistNames: string[]) => t('mobile.detail.inPlaylists', { playlists: playlistNames.join(', ') }),
+    [t],
+  );
 
   // No slot at all — not even an empty one — for a signed-out climber or one with
   // no playlist on this board. They can never see a chip here, so they should not
@@ -112,7 +105,7 @@ export const PlayDrawerPlaylistChips = memo(function PlayDrawerPlaylistChips({
 
   return (
     <View style={styles.slot}>
-      <PlaylistChipsRow playlistUuids={members} align="center" accessibilityLabel={accessibilityLabel} />
+      <PlaylistChipsRow playlistUuids={members} align="center" describeForAccessibility={describeForAccessibility} />
     </View>
   );
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-climb-rules.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-climb-rules.test.tsx
@@ -71,6 +71,9 @@ vi.mock('../../ClimbAttributeIcons', () => ({
   ClimbAttributeIcons: ({ characteristics }: { characteristics?: string[] | null }) =>
     createElement('i', { 'data-attr-icons': characteristics === null ? 'null' : JSON.stringify(characteristics) }),
 }));
+// The header renders the playlist tags; unmocked they pull the playlists provider
+// and expo-secure-store into a presentational test. They have their own tests.
+vi.mock('../PlayDrawerPlaylistChips', () => ({ PlayDrawerPlaylistChips: () => null }));
 
 import { PlayDrawerHeader } from '../PlayDrawerHeader';
 

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-header-copy-name.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-header-copy-name.test.tsx
@@ -50,6 +50,9 @@ vi.mock('../../DrawerHeader', () => ({
   DrawerHeader: ({ center }: { center?: ReactNode }) => createElement('div', null, center),
 }));
 vi.mock('../../ClimbAttributeIcons', () => ({ ClimbAttributeIcons: () => createElement('i', null) }));
+// The playlist chips have their own test; here they would only drag React Query
+// and the playlists provider into a presentational header test.
+vi.mock('../PlayDrawerPlaylistChips', () => ({ PlayDrawerPlaylistChips: () => null }));
 
 import { PlayDrawerHeader } from '../PlayDrawerHeader';
 

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-header-layout-budget.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-header-layout-budget.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// react-native isn't satisfiable under jsdom. `View` keeps its style and `Text`
+// keeps its variant, so the assertions below can read the real layout values
+// rather than restating them.
+vi.mock('react-native', () => ({
+  View: ({ children, style }: { children?: ReactNode; style?: unknown }) =>
+    createElement('div', { 'data-view': 'true', 'data-style': JSON.stringify(style ?? null) }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+  Pressable: ({ children }: { children?: ReactNode }) => createElement('button', null, children),
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@boardsesh/board-constants/grade-colors', () => ({
+  getGradeColor: () => '#abcdef',
+  DEFAULT_GRADE_COLOR: '#000000',
+}));
+vi.mock('../../../lib/format-climb-stats', () => ({
+  formatSends: (count: number) => `${count} sends`,
+  formatQuality: (value: string) => value,
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children, variant }: { children?: ReactNode; variant?: string }) =>
+    createElement('span', { 'data-variant': variant ?? 'body' }, children),
+}));
+vi.mock('../../MarqueeText', () => ({
+  MarqueeText: ({ children, variant }: { children?: ReactNode; variant?: string }) =>
+    createElement('span', { 'data-variant': variant ?? 'body' }, children),
+}));
+// Render the centre column only — the flanks are DrawerHeader's own concern and
+// have their own test.
+vi.mock('../../DrawerHeader', () => ({
+  DrawerHeader: ({ center }: { center?: ReactNode }) => createElement('div', null, center),
+}));
+vi.mock('../../ClimbAttributeIcons', () => ({ ClimbAttributeIcons: () => createElement('i', null) }));
+// The live tags have their own test; here they'd only drag React Query, the
+// playlists provider and expo-secure-store into a presentational header test.
+// This file passes its own `playlistChips` node instead.
+vi.mock('../PlayDrawerPlaylistChips', () => ({ PlayDrawerPlaylistChips: () => null }));
+
+import { PlayDrawerHeader, STATS_ROW_MARGIN_TOP } from '../PlayDrawerHeader';
+import { WALL_STATE_PILL_TOUCH_HEIGHT } from '../../../theme/layout';
+import { textStyles, materialTextStyles, type TextVariant } from '../../../theme/typography';
+
+const baseProps = {
+  name: 'Hueco Madness',
+  difficulty: 'V5',
+  qualityAverage: '3.2',
+  ascensionistCount: 42,
+  setterUsername: 'alexr',
+};
+
+/** The stats row: the only view carrying the header's `STATS_ROW_MARGIN_TOP`. */
+function statsRow(container: HTMLElement): HTMLElement | null {
+  return (
+    Array.from(container.querySelectorAll<HTMLElement>('[data-view]')).find((node) =>
+      (node.getAttribute('data-style') ?? '').includes(`"marginTop":${STATS_ROW_MARGIN_TOP}`),
+    ) ?? null
+  );
+}
+
+function variantOf(node: Element | null | undefined): TextVariant {
+  return (node?.getAttribute('data-variant') ?? 'body') as TextVariant;
+}
+
+/**
+ * The centre column as the component actually builds it: the climb-name label's
+ * type variant and the stats label's type variant, read back off a real render —
+ * so swapping either label to a bigger variant moves the budget below instead of
+ * quietly passing. Rendered per test: RTL's auto-cleanup empties the container
+ * between them.
+ */
+function measureCentreColumn() {
+  const { container } = render(<PlayDrawerHeader {...baseProps} />);
+  return {
+    container,
+    nameVariant: variantOf(container.querySelector('button span')),
+    statsVariant: variantOf(statsRow(container)?.querySelector('span')),
+  };
+}
+
+describe('PlayDrawerHeader layout budget', () => {
+  it.each([
+    ['Liquid Glass (HIG scale, iOS)', textStyles],
+    ['Material (M3 scale, Android)', materialTextStyles],
+  ])('fits the whole centre column under the row floor on %s', (_label, scale) => {
+    // The play drawer's first screen is a FIXED height with the board art `flex: 1`
+    // inside it, so a taller header renders the board SMALLER — which is exactly
+    // what a chips line of its own did (QA declined PR #4560 for it). Name + stats
+    // is what every climb pays; keeping it under `minRowHeight` is what makes the
+    // playlist tags free. (The climb-RULES line is a deliberate exception and is
+    // not rendered here — these props carry no rules.)
+    //
+    // Both scales, not just the HIG one: Material is the resolved variant on every
+    // Android device, and its `body` line box is 2pt taller.
+    const { nameVariant, statsVariant } = measureCentreColumn();
+    const centreColumn = scale[nameVariant].lineHeight + STATS_ROW_MARGIN_TOP + scale[statsVariant].lineHeight;
+
+    expect(centreColumn).toBeLessThanOrEqual(WALL_STATE_PILL_TOUCH_HEIGHT);
+  });
+
+  it('gives the stats row no fixed height, so it is one caption line either way', () => {
+    // A pinned height is what broke Android the first time round: 20pt cleared the
+    // 44pt floor on the HIG scale and missed it on M3. The row is left to size to
+    // its content instead — and its content is `caption1` on both sides, tags or no
+    // tags, so it measures the same regardless.
+    const row = statsRow(measureCentreColumn().container);
+    expect(row).not.toBeNull();
+    expect(row?.getAttribute('data-style') ?? '').not.toContain('"height"');
+  });
+
+  it('puts the playlist tag inside the stats row, ahead of the stats', () => {
+    const withChips = render(<PlayDrawerHeader {...baseProps} playlistChips={<span>Sunday sends</span>} />);
+    const row = statsRow(withChips.container);
+    expect(row).not.toBeNull();
+    // Inside the row, not a sibling under it — a sibling is a third line, and a
+    // third line is board art.
+    const text = row?.textContent ?? '';
+    expect(text).toContain('Sunday sends');
+    expect(text).toContain('alexr');
+    // Tag first: the stats carry `numberOfLines={1}` and ellipsize from the tail,
+    // so trailing them means the setter is what a squeeze eats, not the tag.
+    expect(text.indexOf('Sunday sends')).toBeLessThan(text.indexOf('alexr'));
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-playlist-chips.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-playlist-chips.test.tsx
@@ -150,6 +150,16 @@ describe('PlayDrawerPlaylistChips', () => {
     expect(ctrl.queryArgs.some((args) => args.enabled)).toBe(false);
   });
 
+  it('renders nothing, and fetches nothing, for a playlist on another layout of this board', () => {
+    // Layout-scoped playlists don't cross layouts, so this climber still can't
+    // see a chip here — the slot must not appear and eat board art.
+    ctrl.playlists = [playlist('p8', 'Original layout list', 2)];
+    const { container } = renderChips();
+    expect(container.textContent).toBe('');
+    expect(ctrl.queryArgs.length).toBeGreaterThan(0);
+    expect(ctrl.queryArgs.some((args) => args.enabled)).toBe(false);
+  });
+
   it('keeps the reserved slot the same height whether or not the climb is in a playlist', () => {
     // Load-bearing: the board art below is `flex: 1` inside a fixed-height first
     // screen, so a per-climb header height would resize the board on every swipe.

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-playlist-chips.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-playlist-chips.test.tsx
@@ -160,6 +160,17 @@ describe('PlayDrawerPlaylistChips', () => {
     expect(ctrl.queryArgs.some((args) => args.enabled)).toBe(false);
   });
 
+  it('does not request membership before a real layout is known', () => {
+    // layoutId 0 is the "not resolved yet" placeholder; the resolver would reject
+    // it, so the fetch waits rather than burning a round trip. A board-wide
+    // playlist matches every layout, including 0 — so the layout guard is the only
+    // thing that can be holding the request back here.
+    ctrl.playlists = [playlist('p5', 'Kilter circuit', null)];
+    renderChips({ layoutId: 0 });
+    expect(ctrl.queryArgs.length).toBeGreaterThan(0);
+    expect(ctrl.queryArgs.some((args) => args.enabled)).toBe(false);
+  });
+
   it('keeps the reserved slot the same height whether or not the climb is in a playlist', () => {
     // Load-bearing: the board art below is `flex: 1` inside a fixed-height first
     // screen, so a per-climb header height would resize the board on every swipe.

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-playlist-chips.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-playlist-chips.test.tsx
@@ -32,6 +32,8 @@ vi.mock('react-native', () => ({
       children,
     ),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+  Platform: { OS: 'ios', select: (spec: Record<string, unknown>) => spec.ios ?? spec.default },
+  PlatformColor: (name: string) => name,
 }));
 
 vi.mock('react-i18next', () => ({
@@ -91,7 +93,7 @@ vi.mock('../../../lib/show-playlist-tags-preference', () => ({
   useShowPlaylistTagsPreference: () => ({ enabled: false, loaded: true, setEnabled: vi.fn() }),
 }));
 
-import { PlayDrawerPlaylistChips, PLAY_DRAWER_CHIPS_SLOT_HEIGHT } from '../PlayDrawerPlaylistChips';
+import { PlayDrawerPlaylistChips } from '../PlayDrawerPlaylistChips';
 
 function playlist(uuid: string, name: string, layoutId: number | null = 1): Playlist {
   return {
@@ -116,7 +118,7 @@ function renderChips(overrides: Partial<typeof baseProps> = {}) {
   return render(createElement(PlayDrawerPlaylistChips, { ...baseProps, ...overrides }));
 }
 
-function slotStyle(container: HTMLElement): string {
+function rowStyle(container: HTMLElement): string {
   return container.querySelector('[data-view]')?.getAttribute('data-style') ?? '';
 }
 
@@ -141,8 +143,8 @@ describe('PlayDrawerPlaylistChips', () => {
   });
 
   it('renders nothing, and fetches nothing, when the climber has no playlist on this board', () => {
-    // Playlists on another board can never produce a chip here, so no slot and
-    // no request.
+    // Playlists on another board can never produce a tag here, so nothing renders
+    // and nothing is requested.
     ctrl.playlists = [{ ...playlist('p9', 'Tension list'), boardType: 'tension' }];
     const { container } = renderChips();
     expect(container.textContent).toBe('');
@@ -152,7 +154,7 @@ describe('PlayDrawerPlaylistChips', () => {
 
   it('renders nothing, and fetches nothing, for a playlist on another layout of this board', () => {
     // Layout-scoped playlists don't cross layouts, so this climber still can't
-    // see a chip here — the slot must not appear and eat board art.
+    // see a tag here — nothing should render, and nothing should be fetched.
     ctrl.playlists = [playlist('p8', 'Original layout list', 2)];
     const { container } = renderChips();
     expect(container.textContent).toBe('');
@@ -171,16 +173,32 @@ describe('PlayDrawerPlaylistChips', () => {
     expect(ctrl.queryArgs.some((args) => args.enabled)).toBe(false);
   });
 
-  it('keeps the reserved slot the same height whether or not the climb is in a playlist', () => {
-    // Load-bearing: the board art below is `flex: 1` inside a fixed-height first
-    // screen, so a per-climb header height would resize the board on every swipe.
-    const empty = renderChips();
-    expect(slotStyle(empty.container)).toContain(`"height":${PLAY_DRAWER_CHIPS_SLOT_HEIGHT}`);
-
+  it('sets no height and no margin of its own', () => {
+    // Half of what keeps the board art whole. The strip rides inside the header's
+    // existing stats line, so it must contribute no vertical space itself: no
+    // fixed height, no top margin, and no chip `minHeight` taller than the caption
+    // it sits in. That the header actually NESTS it in that line — rather than
+    // dropping it below as a third line, the shape QA declined — is pinned by
+    // `play-drawer-header-layout-budget.test.tsx`, which renders the real header.
     ctrl.memberUuids = ['p1'];
-    const filled = renderChips();
-    expect(slotStyle(filled.container)).toContain(`"height":${PLAY_DRAWER_CHIPS_SLOT_HEIGHT}`);
-    expect(filled.container.textContent).toContain('Sunday sends');
+    const { container } = renderChips();
+    expect(container.textContent).toContain('Sunday sends');
+    expect(rowStyle(container)).toContain('"marginTop":0');
+    expect(rowStyle(container)).not.toContain('"height"');
+    // The chip itself: no capsule padding, no minHeight — a dot and a name, as
+    // tall as the caption line and no taller.
+    const chip = container.querySelectorAll('[data-view]')[1];
+    expect(chip?.getAttribute('data-style') ?? '').not.toContain('minHeight');
+  });
+
+  it('shows one playlist by name and collapses the rest, to share the stats line', () => {
+    // Two full names beside "42 sends · 3.2★ · setter" ellipsize both to noise on
+    // a phone-width centre column, so the header caps at one and counts the rest.
+    ctrl.memberUuids = ['p1', 'p2'];
+    const { container } = renderChips();
+    expect(container.textContent).toContain('Sunday sends');
+    expect(container.textContent).not.toContain('Project@40');
+    expect(container.textContent).toContain('+1');
   });
 
   it('paints from the shared store seed before its own fetch resolves', () => {
@@ -234,7 +252,7 @@ describe('PlayDrawerPlaylistChips', () => {
     ];
     ctrl.memberUuids = ['p1', 'p2', 'p3', 'p4'];
     const { container } = renderChips();
-    expect(container.textContent).toContain('+2');
+    expect(container.textContent).toContain('+3');
     const label = container.querySelector('[aria-label]')?.getAttribute('aria-label') ?? '';
     expect(label).toBe('mobile.detail.inPlaylists|Sunday sends, Project@40, Warmups, Benchmarks');
   });

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-playlist-chips.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-playlist-chips.test.tsx
@@ -1,0 +1,212 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { Playlist } from '@boardsesh/graphql/operations/playlists';
+
+type MembershipQueryArgs = { climbUuid: string; boardName: string; layoutId: number; enabled: boolean };
+
+const ctrl = vi.hoisted(() => ({
+  playlists: [] as Playlist[],
+  isAuthenticated: true,
+  // What the shared membership store (fed only by the Climbs tab) already holds.
+  seeded: new Set<string>(),
+  // What this climb's own fetch has returned, if anything.
+  memberUuids: undefined as string[] | undefined,
+  queryArgs: [] as MembershipQueryArgs[],
+}));
+
+vi.mock('react-native', () => ({
+  View: ({
+    children,
+    style,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    style?: unknown;
+    accessibilityLabel?: string;
+  }) =>
+    createElement(
+      'div',
+      { 'data-view': 'true', 'data-style': JSON.stringify(style ?? null), 'aria-label': accessibilityLabel },
+      children,
+    ),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      options?.playlists == null ? key : `${key}|${String(options.playlists)}`,
+  }),
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+
+vi.mock('../../../theme/variants', () => ({
+  selectByVariant: (variant: 'material' | 'liquidGlass', byVariant: Record<string, unknown>) => byVariant[variant],
+}));
+
+// The real tokens module transitively loads ios-colors → PlatformColor, which
+// isn't available under jsdom.
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8 },
+  borderRadius: { md: 8, full: 9999 },
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    variant: 'liquidGlass' as const,
+    systemColors: { fill: '#222', secondaryLabel: '#aaa' },
+    m3: { surfaceVariant: '#333', onSurfaceVariant: '#ccc' },
+  }),
+}));
+
+vi.mock('../../../providers/playlists-provider', () => ({
+  usePlaylistsContextOptional: () => ({
+    playlists: ctrl.playlists,
+    playlistsById: new Map(ctrl.playlists.map((entry) => [entry.uuid, entry] as const)),
+    isAuthenticated: ctrl.isAuthenticated,
+  }),
+}));
+
+vi.mock('../../../hooks/use-climb-playlist-memberships', () => ({
+  useClimbPlaylistMemberships: () => ctrl.seeded,
+}));
+
+vi.mock('../../../hooks/use-climb-playlist-membership-query', () => ({
+  useClimbPlaylistMembershipQuery: (args: MembershipQueryArgs) => {
+    ctrl.queryArgs.push(args);
+    return {
+      membershipKey: ['playlistsForClimb', args.boardName, args.layoutId, args.climbUuid],
+      memberUuids: ctrl.memberUuids,
+    };
+  },
+}));
+
+// The list variant lives in the same module as the shared chips row.
+vi.mock('../../../lib/show-playlist-tags-preference', () => ({
+  useShowPlaylistTagsPreference: () => ({ enabled: false, loaded: true, setEnabled: vi.fn() }),
+}));
+
+import { PlayDrawerPlaylistChips, PLAY_DRAWER_CHIPS_SLOT_HEIGHT } from '../PlayDrawerPlaylistChips';
+
+function playlist(uuid: string, name: string, layoutId: number | null = 1): Playlist {
+  return {
+    id: uuid,
+    uuid,
+    boardType: 'kilter',
+    layoutId,
+    name,
+    isPublic: false,
+    createdAt: '',
+    updatedAt: '',
+    climbCount: 0,
+    followerCount: 0,
+    isFollowedByMe: false,
+    isPinnedByMe: false,
+  };
+}
+
+const baseProps = { climbUuid: 'c1', boardName: 'kilter', layoutId: 1, fetchMembership: true };
+
+function renderChips(overrides: Partial<typeof baseProps> = {}) {
+  return render(createElement(PlayDrawerPlaylistChips, { ...baseProps, ...overrides }));
+}
+
+function slotStyle(container: HTMLElement): string {
+  return container.querySelector('[data-view]')?.getAttribute('data-style') ?? '';
+}
+
+describe('PlayDrawerPlaylistChips', () => {
+  beforeEach(() => {
+    ctrl.playlists = [playlist('p1', 'Sunday sends'), playlist('p2', 'Project@40')];
+    ctrl.isAuthenticated = true;
+    ctrl.seeded = new Set();
+    ctrl.memberUuids = undefined;
+    ctrl.queryArgs = [];
+  });
+
+  it('renders nothing, and fetches nothing, when the climber is signed out', () => {
+    ctrl.isAuthenticated = false;
+    ctrl.memberUuids = ['p1'];
+    const { container } = renderChips();
+    expect(container.textContent).toBe('');
+    expect(ctrl.queryArgs.every((args) => args.enabled)).toBe(false);
+  });
+
+  it('renders nothing, and fetches nothing, when the climber has no playlist on this board', () => {
+    // Playlists on another board can never produce a chip here, so no slot and
+    // no request.
+    ctrl.playlists = [{ ...playlist('p9', 'Tension list'), boardType: 'tension' }];
+    const { container } = renderChips();
+    expect(container.textContent).toBe('');
+    expect(ctrl.queryArgs.every((args) => args.enabled)).toBe(false);
+  });
+
+  it('keeps the reserved slot the same height whether or not the climb is in a playlist', () => {
+    // Load-bearing: the board art below is `flex: 1` inside a fixed-height first
+    // screen, so a per-climb header height would resize the board on every swipe.
+    const empty = renderChips();
+    expect(slotStyle(empty.container)).toContain(`"height":${PLAY_DRAWER_CHIPS_SLOT_HEIGHT}`);
+
+    ctrl.memberUuids = ['p1'];
+    const filled = renderChips();
+    expect(slotStyle(filled.container)).toContain(`"height":${PLAY_DRAWER_CHIPS_SLOT_HEIGHT}`);
+    expect(filled.container.textContent).toContain('Sunday sends');
+  });
+
+  it('paints from the shared store seed before its own fetch resolves', () => {
+    // The Climbs-tab path: membership is already in the store, so the chips are
+    // there on the first frame.
+    ctrl.seeded = new Set(['p2']);
+    const { container } = renderChips();
+    expect(container.textContent).toContain('Project@40');
+  });
+
+  it('lets the fetch result win over a stale seed', () => {
+    ctrl.seeded = new Set(['p2']);
+    ctrl.memberUuids = ['p1'];
+    const { container } = renderChips();
+    expect(container.textContent).toContain('Sunday sends');
+    expect(container.textContent).not.toContain('Project@40');
+  });
+
+  it('renders from cache without requesting when the header is a swipe peek', () => {
+    // A fling passes many climbs; the peek header must not fire a request per one.
+    ctrl.memberUuids = ['p1'];
+    const { container } = renderChips({ fetchMembership: false });
+    expect(ctrl.queryArgs.every((args) => args.enabled)).toBe(false);
+    expect(container.textContent).toContain('Sunday sends');
+  });
+
+  it('requests membership for the climb on screen', () => {
+    renderChips();
+    expect(ctrl.queryArgs.some((args) => args.enabled && args.climbUuid === 'c1')).toBe(true);
+  });
+
+  it('announces every playlist by name, including the ones the "+N" token hides', () => {
+    ctrl.playlists = [
+      playlist('p1', 'Sunday sends'),
+      playlist('p2', 'Project@40'),
+      playlist('p3', 'Warmups'),
+      playlist('p4', 'Benchmarks'),
+    ];
+    ctrl.memberUuids = ['p1', 'p2', 'p3', 'p4'];
+    const { container } = renderChips();
+    expect(container.textContent).toContain('+2');
+    const label = container.querySelector('[aria-label]')?.getAttribute('aria-label') ?? '';
+    expect(label).toBe('mobile.detail.inPlaylists|Sunday sends, Project@40, Warmups, Benchmarks');
+  });
+
+  it('matches a board-wide playlist with no layout of its own', () => {
+    // Synced circuits arrive with a null layoutId and are legitimate on every
+    // layout of their board — the same rule the backend resolver applies.
+    ctrl.playlists = [playlist('p5', 'Kilter circuit', null)];
+    ctrl.memberUuids = ['p5'];
+    const { container } = renderChips();
+    expect(container.textContent).toContain('Kilter circuit');
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-playlist-chips.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-playlist-chips.test.tsx
@@ -178,13 +178,25 @@ describe('PlayDrawerPlaylistChips', () => {
     expect(container.textContent).not.toContain('Project@40');
   });
 
-  it('renders from cache without requesting when the header is a swipe peek', () => {
+  it('still paints, without requesting, when the header is a swipe peek', () => {
     // A fling passes many climbs; the peek header must not fire a request per one.
-    ctrl.memberUuids = ['p1'];
+    // With nothing cached (`memberUuids` undefined, which is what a disabled query
+    // returns on a cold entry) it falls through to the store seed rather than
+    // going blank.
+    ctrl.seeded = new Set(['p1']);
     const { container } = renderChips({ fetchMembership: false });
     expect(ctrl.queryArgs.length).toBeGreaterThan(0);
     expect(ctrl.queryArgs.some((args) => args.enabled)).toBe(false);
     expect(container.textContent).toContain('Sunday sends');
+  });
+
+  it('paints a warm cache entry on a peek header without requesting', () => {
+    // A disabled React Query still serves cached data — the climb was the current
+    // one a swipe ago, so swiping back must not blank its chips.
+    ctrl.memberUuids = ['p2'];
+    const { container } = renderChips({ fetchMembership: false });
+    expect(ctrl.queryArgs.some((args) => args.enabled)).toBe(false);
+    expect(container.textContent).toContain('Project@40');
   });
 
   it('requests membership for the climb on screen', () => {

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-playlist-chips.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-playlist-chips.test.tsx
@@ -134,7 +134,10 @@ describe('PlayDrawerPlaylistChips', () => {
     ctrl.memberUuids = ['p1'];
     const { container } = renderChips();
     expect(container.textContent).toBe('');
-    expect(ctrl.queryArgs.every((args) => args.enabled)).toBe(false);
+    // `some`, not `every`: "no request was enabled", asserted against a hook
+    // that was definitely called (hooks run before the early return).
+    expect(ctrl.queryArgs.length).toBeGreaterThan(0);
+    expect(ctrl.queryArgs.some((args) => args.enabled)).toBe(false);
   });
 
   it('renders nothing, and fetches nothing, when the climber has no playlist on this board', () => {
@@ -143,7 +146,8 @@ describe('PlayDrawerPlaylistChips', () => {
     ctrl.playlists = [{ ...playlist('p9', 'Tension list'), boardType: 'tension' }];
     const { container } = renderChips();
     expect(container.textContent).toBe('');
-    expect(ctrl.queryArgs.every((args) => args.enabled)).toBe(false);
+    expect(ctrl.queryArgs.length).toBeGreaterThan(0);
+    expect(ctrl.queryArgs.some((args) => args.enabled)).toBe(false);
   });
 
   it('keeps the reserved slot the same height whether or not the climb is in a playlist', () => {
@@ -178,7 +182,8 @@ describe('PlayDrawerPlaylistChips', () => {
     // A fling passes many climbs; the peek header must not fire a request per one.
     ctrl.memberUuids = ['p1'];
     const { container } = renderChips({ fetchMembership: false });
-    expect(ctrl.queryArgs.every((args) => args.enabled)).toBe(false);
+    expect(ctrl.queryArgs.length).toBeGreaterThan(0);
+    expect(ctrl.queryArgs.some((args) => args.enabled)).toBe(false);
     expect(container.textContent).toContain('Sunday sends');
   });
 

--- a/packages/mobile/src/components/play-drawer/index.ts
+++ b/packages/mobile/src/components/play-drawer/index.ts
@@ -1,5 +1,6 @@
 export { PlayDrawer, type PlayDrawerOpenOptions, type PlayDrawerOpenTarget } from './PlayDrawer';
 export { PlayDrawerHeader } from './PlayDrawerHeader';
+export { PlayDrawerPlaylistChips } from './PlayDrawerPlaylistChips';
 export { PlayDrawerActionBar } from './PlayDrawerActionBar';
 export { SwipeBoardCarousel } from './SwipeBoardCarousel';
 export { QuickTickBar } from './QuickTickBar';

--- a/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
+++ b/packages/mobile/src/components/playlist/InlinePlaylistPicker.tsx
@@ -12,18 +12,14 @@ import {
   type TextInputProps,
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
-import {
-  GET_PLAYLISTS_FOR_CLIMB,
-  type GetPlaylistsForClimbQueryResponse,
-} from '@boardsesh/graphql/operations/playlists';
 import { playlistMembershipStore } from '@boardsesh/climb-actions';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { ListRow } from '../ListRow';
 import { useClimbPlaylistMemberships } from '../../hooks/use-climb-playlist-memberships';
-import { getHttpClient } from '../../lib/graphql/client';
+import { useClimbPlaylistMembershipQuery } from '../../hooks/use-climb-playlist-membership-query';
 import { usePlaylistsContext, type Playlist } from '../../providers/playlists-provider';
 import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
@@ -138,25 +134,13 @@ export function InlinePlaylistPicker({
   // populated behind an opt-in setting, so fetch the single climb's memberships
   // directly — the source of truth for the checkmarks. Optimistic writes go
   // through `setQueryData` on this key so they survive the host unmounting and
-  // re-mounting the picker (the reaction overlay does exactly that on back).
-  const membershipKey = useMemo(
-    () => ['playlistsForClimb', boardName, layoutId, climb.uuid] as const,
-    [boardName, layoutId, climb.uuid],
-  );
-  const { data: memberUuids } = useQuery({
-    queryKey: membershipKey,
-    queryFn: async (): Promise<string[]> => {
-      const response = await getHttpClient().request<GetPlaylistsForClimbQueryResponse>(GET_PLAYLISTS_FOR_CLIMB, {
-        input: { boardType: boardName, layoutId, climbUuid: climb.uuid },
-      });
-      return response.playlistsForClimb;
-    },
+  // re-mounting the picker (the reaction overlay does exactly that on back), and
+  // so the play-drawer header's chips pick up a toggle without a refetch.
+  const { membershipKey, memberUuids } = useClimbPlaylistMembershipQuery({
+    climbUuid: climb.uuid,
+    boardName,
+    layoutId,
     enabled: isAuthenticated,
-    staleTime: 30 * 1000,
-    // Optimistic toggle writes are the source of truth while the picker is open;
-    // don't let a focus/reconnect refetch land a stale response over a checkmark.
-    refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
   });
 
   // Seed checkmarks from the shared membership store (the climb list populates it

--- a/packages/mobile/src/hooks/__tests__/use-climb-playlist-membership-query.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-climb-playlist-membership-query.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+type QueryOptions = {
+  queryKey: readonly unknown[];
+  queryFn: () => Promise<string[]>;
+  enabled: boolean;
+  staleTime: number;
+  refetchOnWindowFocus: boolean;
+  refetchOnReconnect: boolean;
+};
+
+const ctrl = vi.hoisted(() => ({
+  options: [] as QueryOptions[],
+  data: undefined as string[] | undefined,
+  requests: [] as unknown[],
+  response: { playlistsForClimb: [] as string[] },
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (options: QueryOptions) => {
+    ctrl.options.push(options);
+    return { data: ctrl.data };
+  },
+}));
+
+vi.mock('@boardsesh/graphql/operations/playlists', () => ({
+  GET_PLAYLISTS_FOR_CLIMB: 'query GetPlaylistsForClimb',
+}));
+
+vi.mock('../../lib/graphql/client', () => ({
+  getHttpClient: () => ({
+    request: async (_document: unknown, variables: unknown) => {
+      ctrl.requests.push(variables);
+      return ctrl.response;
+    },
+  }),
+}));
+
+import { useClimbPlaylistMembershipQuery } from '../use-climb-playlist-membership-query';
+
+const baseArgs = { climbUuid: 'climb-1', boardName: 'kilter', layoutId: 8, enabled: true };
+
+function latestOptions(): QueryOptions {
+  const options = ctrl.options.at(-1);
+  if (!options) throw new Error('useQuery was never called');
+  return options;
+}
+
+describe('useClimbPlaylistMembershipQuery', () => {
+  beforeEach(() => {
+    ctrl.options = [];
+    ctrl.data = undefined;
+    ctrl.requests = [];
+    ctrl.response = { playlistsForClimb: [] };
+  });
+
+  it('keys the cache by board, layout and climb', () => {
+    // The add-to-playlist picker and the play-drawer chips must land on the SAME
+    // entry — that is what makes an optimistic toggle in the sheet show up in the
+    // header with no refetch. A change to this shape silently breaks that.
+    renderHook(() => useClimbPlaylistMembershipQuery(baseArgs));
+    expect(latestOptions().queryKey).toEqual(['playlistsForClimb', 'kilter', 8, 'climb-1']);
+  });
+
+  it('exposes the same key it queries under', () => {
+    const { result } = renderHook(() => useClimbPlaylistMembershipQuery(baseArgs));
+    expect(result.current.membershipKey).toEqual(latestOptions().queryKey);
+  });
+
+  it('holds a 30s stale window and never refetches on focus or reconnect', () => {
+    // Load-bearing: optimistic toggle writes are the source of truth while a
+    // climber is working, and a focus/reconnect refetch must not land a stale
+    // membership set over a checkmark they just tapped.
+    renderHook(() => useClimbPlaylistMembershipQuery(baseArgs));
+    const options = latestOptions();
+    expect(options.staleTime).toBe(30_000);
+    expect(options.refetchOnWindowFocus).toBe(false);
+    expect(options.refetchOnReconnect).toBe(false);
+  });
+
+  it('passes the caller gate straight through to the query', () => {
+    renderHook(() => useClimbPlaylistMembershipQuery({ ...baseArgs, enabled: false }));
+    expect(latestOptions().enabled).toBe(false);
+  });
+
+  it('still serves cached data while disabled', () => {
+    // How the swipe "peek" header paints without requesting anything.
+    ctrl.data = ['playlist-1'];
+    const { result } = renderHook(() => useClimbPlaylistMembershipQuery({ ...baseArgs, enabled: false }));
+    expect(result.current.memberUuids).toEqual(['playlist-1']);
+  });
+
+  it('sends the climb and its board scope, and unwraps the response', async () => {
+    ctrl.response = { playlistsForClimb: ['playlist-1', 'playlist-2'] };
+    renderHook(() => useClimbPlaylistMembershipQuery(baseArgs));
+    await expect(latestOptions().queryFn()).resolves.toEqual(['playlist-1', 'playlist-2']);
+    expect(ctrl.requests).toEqual([{ input: { boardType: 'kilter', layoutId: 8, climbUuid: 'climb-1' } }]);
+  });
+
+  it('keeps the key referentially stable across re-renders with the same climb', () => {
+    // The key is a dependency of the picker's optimistic-write callbacks; a fresh
+    // array each render would churn them and every memoized row below.
+    const { result, rerender } = renderHook(() => useClimbPlaylistMembershipQuery(baseArgs));
+    const first = result.current.membershipKey;
+    rerender();
+    expect(result.current.membershipKey).toBe(first);
+  });
+});

--- a/packages/mobile/src/hooks/use-climb-playlist-membership-query.ts
+++ b/packages/mobile/src/hooks/use-climb-playlist-membership-query.ts
@@ -1,0 +1,71 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  GET_PLAYLISTS_FOR_CLIMB,
+  type GetPlaylistsForClimbQueryResponse,
+} from '@boardsesh/graphql/operations/playlists';
+import { getHttpClient } from '../lib/graphql/client';
+
+type UseClimbPlaylistMembershipQueryArgs = {
+  climbUuid: string;
+  boardName: string;
+  layoutId: number;
+  /** Fetch gate. Cached data is still returned when false — the caller just
+   *  doesn't trigger a request of its own (see the play drawer's peek header). */
+  enabled: boolean;
+};
+
+type ClimbPlaylistMembershipQueryResult = {
+  /** React Query key for this climb's membership. Exported so callers can write
+   *  optimistic updates (`setQueryData`) / cancel in-flight fetches against the
+   *  same entry every other surface reads. */
+  membershipKey: readonly ['playlistsForClimb', string, number, string];
+  /** The playlist UUIDs this climb belongs to, or undefined before the first
+   *  response (and while disabled with nothing cached). */
+  memberUuids: string[] | undefined;
+};
+
+/**
+ * One climb's playlist membership, fetched directly rather than read from the
+ * shared `playlistMembershipStore`.
+ *
+ * The store is fed by exactly one hook (`useClimbListPlaylistMemberships`) called
+ * from the Climbs tab, so any surface a climber can reach another way — the play
+ * drawer opened from the queue, from a playlist, or from a deep link — has no
+ * membership at all. Those surfaces need their own per-climb fetch.
+ *
+ * Every caller shares one query key, so the add-to-playlist picker's optimistic
+ * writes land on the same cache entry the play-drawer chips read: toggle a
+ * playlist in the sheet and the header updates with no refetch.
+ *
+ * `staleTime` 30s with focus/reconnect refetching off, matching the picker's
+ * original settings: optimistic toggle writes are the source of truth while a
+ * climber is working, and a late refetch must not land a stale set over them.
+ */
+export function useClimbPlaylistMembershipQuery({
+  climbUuid,
+  boardName,
+  layoutId,
+  enabled,
+}: UseClimbPlaylistMembershipQueryArgs): ClimbPlaylistMembershipQueryResult {
+  const membershipKey = useMemo(
+    () => ['playlistsForClimb', boardName, layoutId, climbUuid] as const,
+    [boardName, layoutId, climbUuid],
+  );
+
+  const { data: memberUuids } = useQuery({
+    queryKey: membershipKey,
+    queryFn: async (): Promise<string[]> => {
+      const response = await getHttpClient().request<GetPlaylistsForClimbQueryResponse>(GET_PLAYLISTS_FOR_CLIMB, {
+        input: { boardType: boardName, layoutId, climbUuid },
+      });
+      return response.playlistsForClimb;
+    },
+    enabled,
+    staleTime: 30 * 1000,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+
+  return { membershipKey, memberUuids };
+}

--- a/packages/mobile/src/lib/__tests__/sort-filter-playlists.test.ts
+++ b/packages/mobile/src/lib/__tests__/sort-filter-playlists.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import type { Playlist } from '@boardsesh/graphql/operations/playlists';
-import { filterPlaylistsByBoard, sortAndFilterPlaylists, sortPlaylistsByName } from '../sort-filter-playlists';
+import {
+  filterPlaylistsByBoard,
+  hasPlaylistForBoard,
+  sortAndFilterPlaylists,
+  sortPlaylistsByName,
+} from '../sort-filter-playlists';
 
 // A minimal Playlist factory — the helper only reads `name`, so the rest is
 // padding to satisfy the type.
@@ -96,5 +101,36 @@ describe('filterPlaylistsByBoard', () => {
     const input = [playlist('a', { boardType: 'tension' }), playlist('b', { boardType: 'kilter', layoutId: 1 })];
     filterPlaylistsByBoard(input, 'kilter', 1);
     expect(names(input)).toEqual(['a', 'b']);
+  });
+});
+
+describe('hasPlaylistForBoard', () => {
+  // Agrees with filterPlaylistsByBoard by construction (shared predicate); these
+  // pin the agreement, since the play drawer reserves or drops a layout slot on
+  // this answer alone.
+  it('is false with no playlists at all', () => {
+    expect(hasPlaylistForBoard([], 'kilter', 9)).toBe(false);
+  });
+
+  it('is true for a playlist on this board and layout', () => {
+    expect(hasPlaylistForBoard([playlist('Kilter 9', { boardType: 'kilter', layoutId: 9 })], 'kilter', 9)).toBe(true);
+  });
+
+  it('is true for a board-wide playlist with no layout of its own', () => {
+    expect(hasPlaylistForBoard([playlist('Circuit', { boardType: 'kilter', layoutId: null })], 'kilter', 9)).toBe(true);
+  });
+
+  it('is false for another board, and for another layout of this board', () => {
+    expect(hasPlaylistForBoard([playlist('Tension', { boardType: 'tension', layoutId: 9 })], 'kilter', 9)).toBe(false);
+    expect(hasPlaylistForBoard([playlist('Layout 8', { boardType: 'kilter', layoutId: 8 })], 'kilter', 9)).toBe(false);
+  });
+
+  it('finds a match past non-matching entries', () => {
+    const input = [
+      playlist('Tension', { boardType: 'tension', layoutId: 9 }),
+      playlist('Layout 8', { boardType: 'kilter', layoutId: 8 }),
+      playlist('Kilter 9', { boardType: 'kilter', layoutId: 9 }),
+    ];
+    expect(hasPlaylistForBoard(input, 'kilter', 9)).toBe(true);
   });
 });

--- a/packages/mobile/src/lib/sort-filter-playlists.ts
+++ b/packages/mobile/src/lib/sort-filter-playlists.ts
@@ -29,8 +29,8 @@ export function filterPlaylistsByBoard(playlists: Playlist[], boardName: string,
 /**
  * Whether the climber has any playlist on this board+layout, by the same rule
  * `filterPlaylistsByBoard` applies. Short-circuits and allocates nothing — for
- * callers that only need the yes/no, like the play drawer deciding whether to
- * reserve its playlist-chips slot.
+ * callers that only need the yes/no, like the play drawer deciding whether a
+ * playlist tag can appear on this climb at all.
  */
 export function hasPlaylistForBoard(playlists: Playlist[], boardName: string, layoutId: number): boolean {
   return playlists.some((playlist) => matchesBoard(playlist, boardName, layoutId));

--- a/packages/mobile/src/lib/sort-filter-playlists.ts
+++ b/packages/mobile/src/lib/sort-filter-playlists.ts
@@ -23,9 +23,21 @@ export function sortPlaylistsByName(playlists: Playlist[]): Playlist[] {
  * dropping a climber's circuits from the add-to-playlist picker.
  */
 export function filterPlaylistsByBoard(playlists: Playlist[], boardName: string, layoutId: number): Playlist[] {
-  return playlists.filter(
-    (playlist) => playlist.boardType === boardName && (playlist.layoutId == null || playlist.layoutId === layoutId),
-  );
+  return playlists.filter((playlist) => matchesBoard(playlist, boardName, layoutId));
+}
+
+/**
+ * Whether the climber has any playlist on this board+layout, by the same rule
+ * `filterPlaylistsByBoard` applies. Short-circuits and allocates nothing — for
+ * callers that only need the yes/no, like the play drawer deciding whether to
+ * reserve its playlist-chips slot.
+ */
+export function hasPlaylistForBoard(playlists: Playlist[], boardName: string, layoutId: number): boolean {
+  return playlists.some((playlist) => matchesBoard(playlist, boardName, layoutId));
+}
+
+function matchesBoard(playlist: Playlist, boardName: string, layoutId: number): boolean {
+  return playlist.boardType === boardName && (playlist.layoutId == null || playlist.layoutId === layoutId);
 }
 
 /**

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -294,7 +294,8 @@
     },
     "detail": {
       "notFound": "Boulder nicht gefunden",
-      "backToHome": "Zurück zum Start"
+      "backToHome": "Zurück zum Start",
+      "inPlaylists": "In Playlists: {{playlists}}"
     },
     "logAscent": {
       "errorMessage": "Deine Begehung konnte nicht gespeichert werden. Versuch es nochmal.",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -294,7 +294,8 @@
     },
     "detail": {
       "notFound": "Climb not found",
-      "backToHome": "Back to Home"
+      "backToHome": "Back to Home",
+      "inPlaylists": "In playlists: {{playlists}}"
     },
     "logAscent": {
       "errorMessage": "Could not save your ascent. Please try again.",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -294,7 +294,8 @@
     },
     "detail": {
       "notFound": "Bloque no encontrado",
-      "backToHome": "Volver al inicio"
+      "backToHome": "Volver al inicio",
+      "inPlaylists": "En playlists: {{playlists}}"
     },
     "logAscent": {
       "errorMessage": "No se pudo guardar tu ascenso. Inténtalo de nuevo.",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -294,7 +294,8 @@
     },
     "detail": {
       "notFound": "Bloc introuvable",
-      "backToHome": "Retour à l'accueil"
+      "backToHome": "Retour à l'accueil",
+      "inPlaylists": "Dans les playlists : {{playlists}}"
     },
     "logAscent": {
       "errorMessage": "Impossible de sauvegarder votre ascension. Veuillez réessayer.",


### PR DESCRIPTION
## Summary

Playlist tags only ever appeared on Climbs-tab rows. Open a climb and the membership vanished — exactly where a climber wants to know whether this one is already in a project list. This puts the tag on the header's stats line, beside the sends/quality/setter.

Refs #4533. That report bundled two unrelated asks; this ships the first. The second — "sorted playlists please! By grade" — is now #4558.

### QA decline: the tags were eating the board

The first cut gave the tags a 30pt line of their own under the stats. QA declined it, correctly: the drawer's first screen is a **fixed height** and the board art inside it is `flex: 1`, so those 30pt came straight off the board renderer. Every climber with a playlist on the board got a visibly smaller board.

The tags now ride **inside** the existing stats line as caption text — not a line of their own, and not a capsule:

```
body line height + 2 + caption1 line height   <=  44
iOS  (HIG scale)   22 + 2 + 16 = 40           ✓
Android (M3 scale) 24 + 2 + 16 = 42           ✓
```

44 is `WALL_STATE_PILL_TOUCH_HEIGHT`, the `minRowHeight` floor `DrawerHeader` already sets for the wall-state pill — so the centre column fits under a ceiling that was there before this PR and the board keeps every point it has today: signed out, no playlists, in one playlist, in five, mid-swipe.

Dropping the capsule is what makes it fit. A filled pill sitting in a grey caption line reads as a tappable control (it isn't — `pointerEvents: 'none'`), spends 16pt of horizontal padding the line can't spare, and puts a second grey next to the stats. Inline is a colour dot plus the name in the stats' own grey, capped at 88pt so a long playlist name can't crowd them out. The header names one playlist then `+N`; the list rows keep two, and keep the chip.

**Both type scales, not just the HIG one.** A first attempt pinned the row at 20pt: 22+2+20 = 44 cleared the floor on iOS and 24+2+20 = **46** missed it on Material — the resolved variant on every Android device. That would have shipped the same regression to Android, 2pt at a time, and a HIG-only assertion could not have seen it. `play-drawer-header-layout-budget.test.tsx` now reads the name and stats *type variants back off a real render* and checks the sum against **both** scales. Mutation-checked both ways: switch the stats label to `subheadline` and only the Material case goes red (`expected 46 to be less than or equal to 44`); move the tag back below the row and the nesting assertion goes red.

One thing this does **not** claim: the header is not always 68pt. The climb-**rules** line that landed on main since is a deliberate exception — a truncated rule is worse than a shorter board. Playlist membership doesn't clear that bar.

### The part that isn't obvious

Dropping the list's `<ClimbPlaylistChips>` into the header would have rendered an empty strip forever.

The list chips read the shared `playlistMembershipStore`, and that store has exactly one feeder: `useClimbListPlaylistMemberships`, called from the Climbs tab and nowhere else. A drawer opened from the queue, from a playlist, or from a deep link has no membership data at all. So the drawer needs its own per-climb fetch. That query already existed inside `InlinePlaylistPicker`; it's lifted into `useClimbPlaylistMembershipQuery` and shared key-for-key, which buys a second thing for free — toggle a playlist in the add-to-playlist sheet and the header updates with no refetch, because the picker's optimistic `setQueryData` lands on the entry the tag reads.

The store seed still paints first when the climber did arrive from the Climbs tab, so the tag is there on the first frame; the fetch confirms behind it. Results are deliberately not written back into the store — the Climbs tab resets it on every board/auth/preference change and would wipe them.

Only the climb on screen fetches. The swipe "peek" header renders from cache, so flinging through a queue doesn't spray a request per climb it passes.

### Two smaller calls

- **Shown unconditionally.** The "Show playlist tags" setting stays list-scoped — it exists because tags add a third line to every row, a density cost a header that adds no line doesn't carry. Its copy still describes the list, and is unchanged.
- **Announced to VoiceOver**, unlike the list strip (which stays hidden so a row remains one clean target). The label names every playlist, including the ones the `+N` token hides — one new key, `climbs:mobile.detail.inPlaylists`, in all four locales.

## Release Notes

- See which playlists a climb is in without leaving it — the tag now sits with the stats when you open a climb, not just on the list.

## Test plan

1. Open a queued climb. Its playlist tag sits beside the stats.
2. Swipe through the queue. The board art never changes size.
3. Add the climb to a playlist. The tag appears immediately.
4. Sign out, reopen a climb. Header and board look untouched.

## Risk

Risk: 3/5 — play-drawer header layout, with the board art `flex: 1` directly under it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyzmXaX2P2BVnPXEAVua2K
