### PR TITLE
test(backend): cover the searchGyms proximity path against PostGIS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,7 +217,7 @@ Web types in `packages/web/app/lib/types.ts`; shared types in `packages/shared-s
 
 ### Testing
 
-Vitest via `vp test`. Backend tests auto-start postgres+redis via `packages/backend/docker-compose.test.yml`; set `SKIP_TEST_INFRA=1` to skip, `CI=1` for caller-provided services. `packages/db` uses Node's native test runner (`tsx --test`).
+Vitest via `vp test`. Backend tests auto-start postgres+redis via `packages/backend/docker-compose.test.yml` (a PostGIS image — `gyms`/`user_boards` carry a `location` geography and the proximity queries are tested against it); set `SKIP_TEST_INFRA=1` to skip, `CI=1` for caller-provided services, `BOARDSESH_TEST_DATABASE_URL` to point the suite at your own Postgres. `packages/db` uses Node's native test runner (`tsx --test`).
 
 ## Development Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,7 @@ Web types in `packages/web/app/lib/types.ts`; shared types in `packages/shared-s
 
 ### Testing
 
-Vitest via `vp test`. Backend tests auto-start postgres+redis via `packages/backend/docker-compose.test.yml`; set `SKIP_TEST_INFRA=1` to skip, `CI=1` for caller-provided services. `packages/db` uses Node's native test runner (`tsx --test`).
+Vitest via `vp test`. Backend tests auto-start postgres+redis via `packages/backend/docker-compose.test.yml` (a PostGIS image — `gyms`/`user_boards` carry a `location` geography and the proximity queries are tested against it); set `SKIP_TEST_INFRA=1` to skip, `CI=1` for caller-provided services, `BOARDSESH_TEST_DATABASE_URL` to point the suite at your own Postgres. `packages/db` uses Node's native test runner (`tsx --test`).
 
 ## Development Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,7 +187,7 @@ The backend is `packages/backend/`: a GraphQL-WS server on port 8080, backed by 
 
 Run it with `vp run dev:backend` (it starts the database first). Use the structured Winston logger, not `console.*` (a lint rule blocks `console` in backend source). See [docs/logging.md](./docs/logging.md).
 
-Tests run with `vp test run --project backend`. Vitest auto-starts Postgres and Redis from `packages/backend/docker-compose.test.yml`. The Postgres image carries PostGIS, because `gyms` and `user_boards` have a `location` geography that the proximity search queries. Set `SKIP_TEST_INFRA=1` to skip the Docker spin-up, `CI=1` when the caller already provides those services, or `BOARDSESH_TEST_DATABASE_URL` to run the suite against a Postgres of your own.
+Tests run with `vp test run --project backend`. Vitest auto-starts Postgres and Redis from `packages/backend/docker-compose.test.yml`. The Postgres image carries PostGIS, because `gyms` and `user_boards` have a `location` geography that the proximity search queries. Set `SKIP_TEST_INFRA=1` to skip the Docker spin-up, `CI=1` when the caller already provides those services, or `BOARDSESH_TEST_DATABASE_URL` to run the suite against a Postgres of your own — point that one at a throwaway server, because whatever it names inherits the whole harness, including the sweep that drops every `boardsesh_backend_test_w*` database it finds.
 
 ## Environment variables
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,7 +187,7 @@ The backend is `packages/backend/`: a GraphQL-WS server on port 8080, backed by 
 
 Run it with `vp run dev:backend` (it starts the database first). Use the structured Winston logger, not `console.*` (a lint rule blocks `console` in backend source). See [docs/logging.md](./docs/logging.md).
 
-Tests run with `vp test run --project backend`. Vitest auto-starts Postgres and Redis from `packages/backend/docker-compose.test.yml`. Set `SKIP_TEST_INFRA=1` to skip the Docker spin-up, or `CI=1` when the caller already provides those services.
+Tests run with `vp test run --project backend`. Vitest auto-starts Postgres and Redis from `packages/backend/docker-compose.test.yml`. The Postgres image carries PostGIS, because `gyms` and `user_boards` have a `location` geography that the proximity search queries. Set `SKIP_TEST_INFRA=1` to skip the Docker spin-up, `CI=1` when the caller already provides those services, or `BOARDSESH_TEST_DATABASE_URL` to run the suite against a Postgres of your own.
 
 ## Environment variables
 

--- a/packages/backend/docker-compose.test.yml
+++ b/packages/backend/docker-compose.test.yml
@@ -2,7 +2,12 @@ version: '3.8'
 
 services:
   db:
-    image: postgres:15
+    # PostGIS, because gyms/user_boards carry a `location` geography and the
+    # proximity branch of searchGyms is tested against it. Postgres 18 also lines
+    # this up with the CI service image (18.4 + PostGIS 3.6). Public Docker Hub
+    # build rather than our ghcr one so running the backend suite never needs a
+    # `docker login ghcr.io`.
+    image: postgis/postgis:18-3.6
     ports:
       - '5433:5432'
     environment:

--- a/packages/backend/src/__tests__/global-setup.ts
+++ b/packages/backend/src/__tests__/global-setup.ts
@@ -8,8 +8,14 @@ const REDIS_PORT = 6380;
 const COMPOSE_FILE = fileURLToPath(new URL('../../docker-compose.test.yml', import.meta.url));
 
 const WORKER_DB_PREFIX = 'boardsesh_backend_test';
+// Escape hatch for pointing the suite at a Postgres of your own — see the note
+// on getConfiguredDatabaseUrl in worker-db.ts. When it is set we leave docker
+// alone entirely: whatever the URL names is the caller's to manage.
+const databaseUrlOverride = process.env.BOARDSESH_TEST_DATABASE_URL;
 const baseConnectionString = (
-  process.env.DATABASE_URL || `postgresql://postgres:postgres@localhost:${PG_PORT}/${WORKER_DB_PREFIX}`
+  databaseUrlOverride ||
+  process.env.DATABASE_URL ||
+  `postgresql://postgres:postgres@localhost:${PG_PORT}/${WORKER_DB_PREFIX}`
 ).replace(/\/[^/]+$/, '/postgres');
 
 async function isPortOpen(host: string, port: number, timeoutMs = 500): Promise<boolean> {
@@ -28,6 +34,10 @@ async function isPortOpen(host: string, port: number, timeoutMs = 500): Promise<
 
 async function ensureInfra(): Promise<void> {
   if (process.env.CI) return;
+  if (databaseUrlOverride) {
+    console.info('[test-infra] BOARDSESH_TEST_DATABASE_URL set — skipping docker orchestration');
+    return;
+  }
   if (process.env.SKIP_TEST_INFRA === '1') {
     console.info('[test-infra] SKIP_TEST_INFRA=1 — skipping docker orchestration');
     return;
@@ -90,8 +100,10 @@ export default async function globalSetup() {
   // `test-default` CI job runs without postgres, so probe the port first
   // and skip the cleanup when nothing is listening — backend tests still
   // run their `dropStaleWorkerDatabases` step in the dedicated
-  // `test-backend` job where postgres IS started.
-  if (!(await isPortOpen('127.0.0.1', PG_PORT))) {
+  // `test-backend` job where postgres IS started. An override URL points
+  // somewhere other than :5433, so the probe would be answering about the wrong
+  // server — skip it and let the connection itself report a problem.
+  if (!databaseUrlOverride && !(await isPortOpen('127.0.0.1', PG_PORT))) {
     return;
   }
   await dropStaleWorkerDatabases();

--- a/packages/backend/src/__tests__/location-geography-degradation.test.ts
+++ b/packages/backend/src/__tests__/location-geography-degradation.test.ts
@@ -1,29 +1,34 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from 'vite-plus/test';
 import { sql } from 'drizzle-orm';
+import postgres from 'postgres';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../db/client';
 import { logger } from '../utils/logger';
 import { socialBoardMutations } from '../graphql/resolvers/social/boards';
 import { socialGymMutations } from '../graphql/resolvers/social/gyms';
 import { resetAllRateLimits } from '../utils/rate-limiter';
+import { getWorkerDatabaseUrl } from './worker-db';
+import { POSTGIS_SCHEMA_SQL, POSTGIS_TEARDOWN_SQL } from './schema-sql';
 
 /**
- * Real-DB coverage for board/gym mutations on a database WITHOUT PostGIS.
+ * Real-DB coverage for board/gym mutations on a database WITHOUT PostGIS — the
+ * deployment #4218 reports.
  *
- * IMPORTANT: this file only tests anything because the per-worker backend test
- * DB is a plain `postgres` image and `schema-sql.ts` declares `user_boards` and
- * `gyms` with latitude/longitude but no `location` column — it IS the
- * no-PostGIS deployment #4218 reports. If PostGIS is ever added to the test
- * image, every case here would pass vacuously — so the first case below asserts
- * the premise and fails loudly instead of going quietly green.
+ * The test database used to BE that deployment by accident. Since #4507 it
+ * carries PostGIS (the proximity queries need somewhere real to run), so this
+ * file builds its own no-PostGIS world instead: `beforeAll` drops the `location`
+ * columns and their derivation triggers, `afterAll` puts them back from the same
+ * DDL string schema-sql.ts applies, so there is no second copy to drift. Files
+ * run one at a time within a worker, so the window is this file only.
+ *
+ * Dropping the column beats stubbing the write: the resolver still issues the
+ * real statement and still gets a real SQLSTATE back from the real driver.
  *
  * On main, updateBoard/updateGym/createGym issued unguarded
  * `UPDATE ... SET location = ST_MakePoint(...)` statements, so saving an edit
- * with coordinates threw (42704 `type "geography" does not exist` here, 42703
- * undefined-column where the type exists but the column doesn't) after the row
- * had already been updated: the user saw a failure for a save that had landed.
- * Every case below except the premise probe and `createBoard` (already guarded)
- * fails against main.
+ * with coordinates threw after the row had already been updated: the user saw a
+ * failure for a save that had landed. Every case below except the premise probe
+ * and `createBoard` (already guarded) fails against main.
  */
 
 const OWNER = 'geo-degrade-owner';
@@ -86,6 +91,36 @@ function warnedGeographyFailures(warnSpy: { mock: { calls: unknown[][] } }): Geo
   });
 }
 
+/** Multi-statement DDL, so it goes through postgres.js directly rather than `db.execute`. */
+async function applySchemaStatements(statements: string): Promise<void> {
+  const client = postgres(getWorkerDatabaseUrl(), { max: 1, onnotice: () => {} });
+  try {
+    await client.unsafe(statements);
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+/**
+ * Whether the server under test has PostGIS at all. It decides which SQLSTATE
+ * the guarded write comes back with: with the extension installed and only the
+ * column removed the `::geography` cast still resolves, so the failure is the
+ * undefined column; on a server with no PostGIS the cast itself is what fails.
+ */
+let hasPostGis = false;
+
+beforeAll(async () => {
+  const extension = await db.execute(
+    sql`SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'postgis') AS present`,
+  );
+  hasPostGis = Array.from(extension as Iterable<{ present: boolean }>)[0]?.present === true;
+  await applySchemaStatements(POSTGIS_TEARDOWN_SQL);
+});
+
+afterAll(async () => {
+  await applySchemaStatements(POSTGIS_SCHEMA_SQL);
+});
+
 beforeEach(async () => {
   resetAllRateLimits();
   await db.execute(sql`
@@ -118,9 +153,21 @@ describe('location geography writes degrade without PostGIS', () => {
     // the empty `location` result below is a real absence rather than a query
     // that silently returns nothing.
     expect(await tablesWithColumn('latitude')).toEqual(['gyms', 'user_boards']);
-    // If this ever fails, the test DB grew PostGIS and every case below is now
-    // vacuous — drop the column here (or stub the write) before trusting them.
+    // The beforeAll teardown is what every case below stands on: with the column
+    // still there the geography writes all succeed and the file passes vacuously.
+    // If this fails, the teardown stopped working — fix it before trusting them.
     expect(await tablesWithColumn('location')).toEqual([]);
+  });
+
+  it('leaves no derivation trigger to write the geography behind the resolver', async () => {
+    // The other half of the teardown. `gyms_set_location` derives `location` from
+    // lat/lng on every insert, so a surviving trigger would both hide the guarded
+    // write's failure and error inside the trigger body against the dropped column.
+    const triggers = await db.execute(sql`
+      SELECT tgname FROM pg_trigger
+      WHERE tgname IN ('gyms_set_location', 'user_boards_set_location')
+    `);
+    expect(Array.from(triggers as Iterable<{ tgname: string }>)).toEqual([]);
   });
 
   it('updateBoard saves new coordinates instead of failing on the missing column', async () => {
@@ -189,7 +236,10 @@ describe('location geography writes degrade without PostGIS', () => {
     expect(warnedGeographyFailures(warnSpy)).toContainEqual({
       table: 'user_boards',
       operation: 'updateBoard',
-      code: '42704', // type "geography" does not exist
+      // Both are the #4218 deployment, one column-shaped and one extension-shaped:
+      // with PostGIS installed the `::geography` cast resolves and the undefined
+      // column is what fails; with no PostGIS the cast fails first.
+      code: hasPostGis ? '42703' : '42704',
     });
   });
 

--- a/packages/backend/src/__tests__/location-geography-degradation.test.ts
+++ b/packages/backend/src/__tests__/location-geography-degradation.test.ts
@@ -252,6 +252,9 @@ describe('location geography writes degrade without PostGIS', () => {
     expect(warnedGeographyFailures(warnSpy)).toContainEqual({
       table: 'gyms',
       operation: 'updateGym',
+      // Unconditional, unlike the ST_MakePoint case above: clearing writes
+      // `SET location = NULL` with no geography cast, so the undefined column is
+      // the only thing that can fail, whether or not the extension is installed.
       code: '42703', // column "location" does not exist
     });
   });

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -3,6 +3,80 @@
  * template DB) and by worker-db (to hydrate newly-minted per-worker DBs).
  */
 
+/**
+ * The PostGIS surface, split out so a test that needs to simulate a deployment
+ * WITHOUT it can tear it down and put it back verbatim
+ * (location-geography-degradation.test.ts) rather than keeping a second copy of
+ * this DDL that drifts.
+ *
+ * Production carries a `location` geography on gyms and user_boards
+ * (drizzle/0052, 0054, 0127) that the proximity branches of searchGyms and
+ * searchBoards query with ST_DWithin / ST_Distance. That column lives OUTSIDE
+ * the Drizzle schema, so nothing generates it — it only reaches this database by
+ * being written here. It is appended at the very END of schemaSQL because
+ * "user_boards" is dropped and recreated in the middle, which would take the
+ * column and its trigger with it.
+ *
+ * Guarded because worker-db.ts applies schemaSQL through postgres.js `unsafe()`
+ * — one simple query, so one implicit transaction. A bare CREATE EXTENSION
+ * against a server without PostGIS aborts that transaction and rolls back all
+ * 70-odd tables, taking every backend test with it. The EXCEPTION handler opens
+ * a subtransaction so the failure stays local and the proximity tests self-skip
+ * instead. Every statement is idempotent: worker DBs outlive a run, so a stale
+ * one heals on the next apply.
+ */
+export const POSTGIS_SCHEMA_SQL = `
+  DO $$
+  BEGIN
+    EXECUTE 'CREATE EXTENSION IF NOT EXISTS postgis';
+  EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'postgis unavailable (%): proximity coverage self-skips', SQLERRM;
+  END $$;
+
+  DO $$
+  BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'postgis') THEN
+      EXECUTE 'ALTER TABLE "gyms" ADD COLUMN IF NOT EXISTS "location" geography(Point, 4326)';
+      EXECUTE 'ALTER TABLE "user_boards" ADD COLUMN IF NOT EXISTS "location" geography(Point, 4326)';
+      -- Index predicates mirror production (0054 and 0052) so a query the planner
+      -- can only satisfy via the GIST index here can there too.
+      EXECUTE 'CREATE INDEX IF NOT EXISTS "gyms_location_idx" ON "gyms" USING GIST ("location") WHERE deleted_at IS NULL AND is_public = true';
+      EXECUTE 'CREATE INDEX IF NOT EXISTS "user_boards_location_gist_idx" ON "user_boards" USING GIST ("location") WHERE is_public = true AND deleted_at IS NULL';
+      -- Verbatim from 0127. This is what lets a test seed plain lat/lng and get a
+      -- geography for free — so the tests exercise the same derivation production
+      -- relies on rather than a hand-written stand-in.
+      EXECUTE $fn$
+        CREATE OR REPLACE FUNCTION set_location_from_coordinates() RETURNS trigger AS $body$
+        BEGIN
+          IF NEW.latitude IS NOT NULL AND NEW.longitude IS NOT NULL THEN
+            NEW.location := ST_MakePoint(NEW.longitude, NEW.latitude)::geography;
+          ELSE
+            NEW.location := NULL;
+          END IF;
+          RETURN NEW;
+        END;
+        $body$ LANGUAGE plpgsql
+      $fn$;
+      EXECUTE 'CREATE OR REPLACE TRIGGER gyms_set_location BEFORE INSERT OR UPDATE OF latitude, longitude ON gyms FOR EACH ROW EXECUTE FUNCTION set_location_from_coordinates()';
+      EXECUTE 'CREATE OR REPLACE TRIGGER user_boards_set_location BEFORE INSERT OR UPDATE OF latitude, longitude ON user_boards FOR EACH ROW EXECUTE FUNCTION set_location_from_coordinates()';
+    END IF;
+  END $$;
+`;
+
+/**
+ * The inverse of POSTGIS_SCHEMA_SQL, minus the extension itself. Leaves the
+ * database looking like one where PostGIS was never migrated onto these tables:
+ * no `location` column (its GIST index goes with it) and no derivation trigger,
+ * which has to go too or every insert carrying coordinates would fail inside the
+ * trigger body rather than in the statement under test.
+ */
+export const POSTGIS_TEARDOWN_SQL = `
+  DROP TRIGGER IF EXISTS gyms_set_location ON gyms;
+  DROP TRIGGER IF EXISTS user_boards_set_location ON user_boards;
+  ALTER TABLE "gyms" DROP COLUMN IF EXISTS "location";
+  ALTER TABLE "user_boards" DROP COLUMN IF EXISTS "location";
+`;
+
 export const schemaSQL = `
   DROP TABLE IF EXISTS "board_session_queues" CASCADE;
   DROP TABLE IF EXISTS "session_health_kit_workouts" CASCADE;
@@ -1547,55 +1621,4 @@ export const schemaSQL = `
             'aurora_type','aurora_id','aurora_synced_at','aurora_sync_error',
             'kilter_type','kilter_id','kilter_synced_at','kilter_sync_error']))
     EXECUTE FUNCTION set_updated_at();
-
-  -- PostGIS. Production carries a \`location\` geography on gyms and user_boards
-  -- (drizzle/0052, 0054, 0127) that the proximity branches of searchGyms and
-  -- searchBoards query with ST_DWithin / ST_Distance. The column lives OUTSIDE
-  -- the Drizzle schema, so nothing generates it — it only reaches this database
-  -- by being written here. Must stay at the very END of schemaSQL: "user_boards"
-  -- is dropped and recreated above, which would take the column and its trigger
-  -- with it.
-  --
-  -- Guarded because worker-db.ts applies this whole string through postgres.js
-  -- \`unsafe()\` — one simple query, so one implicit transaction. A bare
-  -- CREATE EXTENSION against a server without PostGIS aborts the transaction and
-  -- rolls back all 70-odd tables, taking every backend test with it. The
-  -- EXCEPTION handler opens a subtransaction so the failure stays local, and the
-  -- proximity tests self-skip instead. Every statement is idempotent: worker DBs
-  -- outlive a run, so a stale one heals on the next apply.
-  DO $$
-  BEGIN
-    EXECUTE 'CREATE EXTENSION IF NOT EXISTS postgis';
-  EXCEPTION WHEN OTHERS THEN
-    RAISE NOTICE 'postgis unavailable (%): proximity coverage self-skips', SQLERRM;
-  END $$;
-
-  DO $$
-  BEGIN
-    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'postgis') THEN
-      EXECUTE 'ALTER TABLE "gyms" ADD COLUMN IF NOT EXISTS "location" geography(Point, 4326)';
-      EXECUTE 'ALTER TABLE "user_boards" ADD COLUMN IF NOT EXISTS "location" geography(Point, 4326)';
-      -- Index predicates mirror production (0054 and 0052) so a query that the
-      -- planner can only satisfy via the GIST index here also can there.
-      EXECUTE 'CREATE INDEX IF NOT EXISTS "gyms_location_idx" ON "gyms" USING GIST ("location") WHERE deleted_at IS NULL AND is_public = true';
-      EXECUTE 'CREATE INDEX IF NOT EXISTS "user_boards_location_gist_idx" ON "user_boards" USING GIST ("location") WHERE is_public = true AND deleted_at IS NULL';
-      -- Verbatim from 0127. This is what lets a test seed plain lat/lng and get
-      -- a geography for free — and it means the tests exercise the same
-      -- derivation production relies on rather than a hand-written one.
-      EXECUTE $fn$
-        CREATE OR REPLACE FUNCTION set_location_from_coordinates() RETURNS trigger AS $body$
-        BEGIN
-          IF NEW.latitude IS NOT NULL AND NEW.longitude IS NOT NULL THEN
-            NEW.location := ST_MakePoint(NEW.longitude, NEW.latitude)::geography;
-          ELSE
-            NEW.location := NULL;
-          END IF;
-          RETURN NEW;
-        END;
-        $body$ LANGUAGE plpgsql
-      $fn$;
-      EXECUTE 'CREATE OR REPLACE TRIGGER gyms_set_location BEFORE INSERT OR UPDATE OF latitude, longitude ON gyms FOR EACH ROW EXECUTE FUNCTION set_location_from_coordinates()';
-      EXECUTE 'CREATE OR REPLACE TRIGGER user_boards_set_location BEFORE INSERT OR UPDATE OF latitude, longitude ON user_boards FOR EACH ROW EXECUTE FUNCTION set_location_from_coordinates()';
-    END IF;
-  END $$;
-`;
+${POSTGIS_SCHEMA_SQL}`;

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -1547,4 +1547,55 @@ export const schemaSQL = `
             'aurora_type','aurora_id','aurora_synced_at','aurora_sync_error',
             'kilter_type','kilter_id','kilter_synced_at','kilter_sync_error']))
     EXECUTE FUNCTION set_updated_at();
+
+  -- PostGIS. Production carries a \`location\` geography on gyms and user_boards
+  -- (drizzle/0052, 0054, 0127) that the proximity branches of searchGyms and
+  -- searchBoards query with ST_DWithin / ST_Distance. The column lives OUTSIDE
+  -- the Drizzle schema, so nothing generates it — it only reaches this database
+  -- by being written here. Must stay at the very END of schemaSQL: "user_boards"
+  -- is dropped and recreated above, which would take the column and its trigger
+  -- with it.
+  --
+  -- Guarded because worker-db.ts applies this whole string through postgres.js
+  -- \`unsafe()\` — one simple query, so one implicit transaction. A bare
+  -- CREATE EXTENSION against a server without PostGIS aborts the transaction and
+  -- rolls back all 70-odd tables, taking every backend test with it. The
+  -- EXCEPTION handler opens a subtransaction so the failure stays local, and the
+  -- proximity tests self-skip instead. Every statement is idempotent: worker DBs
+  -- outlive a run, so a stale one heals on the next apply.
+  DO $$
+  BEGIN
+    EXECUTE 'CREATE EXTENSION IF NOT EXISTS postgis';
+  EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'postgis unavailable (%): proximity coverage self-skips', SQLERRM;
+  END $$;
+
+  DO $$
+  BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'postgis') THEN
+      EXECUTE 'ALTER TABLE "gyms" ADD COLUMN IF NOT EXISTS "location" geography(Point, 4326)';
+      EXECUTE 'ALTER TABLE "user_boards" ADD COLUMN IF NOT EXISTS "location" geography(Point, 4326)';
+      -- Index predicates mirror production (0054 and 0052) so a query that the
+      -- planner can only satisfy via the GIST index here also can there.
+      EXECUTE 'CREATE INDEX IF NOT EXISTS "gyms_location_idx" ON "gyms" USING GIST ("location") WHERE deleted_at IS NULL AND is_public = true';
+      EXECUTE 'CREATE INDEX IF NOT EXISTS "user_boards_location_gist_idx" ON "user_boards" USING GIST ("location") WHERE is_public = true AND deleted_at IS NULL';
+      -- Verbatim from 0127. This is what lets a test seed plain lat/lng and get
+      -- a geography for free — and it means the tests exercise the same
+      -- derivation production relies on rather than a hand-written one.
+      EXECUTE $fn$
+        CREATE OR REPLACE FUNCTION set_location_from_coordinates() RETURNS trigger AS $body$
+        BEGIN
+          IF NEW.latitude IS NOT NULL AND NEW.longitude IS NOT NULL THEN
+            NEW.location := ST_MakePoint(NEW.longitude, NEW.latitude)::geography;
+          ELSE
+            NEW.location := NULL;
+          END IF;
+          RETURN NEW;
+        END;
+        $body$ LANGUAGE plpgsql
+      $fn$;
+      EXECUTE 'CREATE OR REPLACE TRIGGER gyms_set_location BEFORE INSERT OR UPDATE OF latitude, longitude ON gyms FOR EACH ROW EXECUTE FUNCTION set_location_from_coordinates()';
+      EXECUTE 'CREATE OR REPLACE TRIGGER user_boards_set_location BEFORE INSERT OR UPDATE OF latitude, longitude ON user_boards FOR EACH ROW EXECUTE FUNCTION set_location_from_coordinates()';
+    END IF;
+  END $$;
 `;

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -20,17 +20,27 @@
  * Guarded because worker-db.ts applies schemaSQL through postgres.js `unsafe()`
  * — one simple query, so one implicit transaction. A bare CREATE EXTENSION
  * against a server without PostGIS aborts that transaction and rolls back all
- * 70-odd tables, taking every backend test with it. The EXCEPTION handler opens
- * a subtransaction so the failure stays local and the proximity tests self-skip
- * instead. Every statement is idempotent: worker DBs outlive a run, so a stale
- * one heals on the next apply.
+ * 70-odd tables, taking every backend test with it. So the extension gets its
+ * own DO block: a `pg_available_extensions` precheck first, then a broad handler
+ * behind it as the last resort. The handler covers exactly ONE statement we did
+ * not write, so it cannot mask a mistake in the DDL below — that lives in the
+ * second block, which has no handler at all and fails the whole apply loudly.
+ * Every statement is idempotent: worker DBs outlive a run, so a stale one heals
+ * on the next apply.
  */
 export const POSTGIS_SCHEMA_SQL = `
   DO $$
   BEGIN
-    EXECUTE 'CREATE EXTENSION IF NOT EXISTS postgis';
+    IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'postgis') THEN
+      EXECUTE 'CREATE EXTENSION IF NOT EXISTS postgis';
+    ELSE
+      RAISE NOTICE 'postgis is not installed on this server: proximity coverage self-skips';
+    END IF;
   EXCEPTION WHEN OTHERS THEN
-    RAISE NOTICE 'postgis unavailable (%): proximity coverage self-skips', SQLERRM;
+    -- Reached only if the precheck said yes and CREATE still failed (no
+    -- privilege to create extensions, a half-installed package). Still not worth
+    -- taking all 70 tables down for. SQLSTATE 0A000 is the plain "not available".
+    RAISE NOTICE 'postgis unavailable (% %): proximity coverage self-skips', SQLSTATE, SQLERRM;
   END $$;
 
   DO $$

--- a/packages/backend/src/__tests__/search-gyms-proximity.test.ts
+++ b/packages/backend/src/__tests__/search-gyms-proximity.test.ts
@@ -37,6 +37,12 @@ const METRES_PER_DEGREE_LATITUDE = 111_276;
 /** Latitude that sits `metres` due north of the search point. */
 const latitudeNorthOf = (metres: number) => SEARCH_LAT + metres / METRES_PER_DEGREE_LATITUDE;
 
+// `gyms.hours_updated_at` is `timestamp` WITHOUT time zone, so the driver hands
+// back a wall-clock reading carrying no offset and `new Date(...)` resolves it in
+// the process's zone. Written and asserted in that same zone-free form, so the
+// assertion below does not quietly depend on the host running UTC.
+const HOURS_UPDATED_AT = '2026-02-03 10:30:00';
+
 const anonCtx = (): ConnectionContext => ({ connectionId: 'conn-anon', isAuthenticated: false }) as ConnectionContext;
 
 type SearchResult = {
@@ -63,6 +69,18 @@ const searchNearby = (input: Record<string, unknown>) =>
     { input: { latitude: SEARCH_LAT, longitude: SEARCH_LON, ...input } },
     anonCtx(),
   ) as Promise<SearchResult>;
+
+/** The Drizzle branch — no coordinates, so `useProximity` is false. */
+const searchText = (input: Record<string, unknown>) =>
+  socialGymQueries.searchGyms(null, { input }, anonCtx()) as Promise<SearchResult>;
+
+/** Drop the two `timestamp` (no time zone) fields the branches disagree on — see #4588. */
+const withoutTimestamps = (gym: SearchResult['gyms'][number]) => {
+  const comparable: Record<string, unknown> = { ...gym };
+  delete comparable.hoursUpdatedAt;
+  delete comparable.createdAt;
+  return comparable;
+};
 
 const insertGym = async (opts: {
   name: string;
@@ -142,7 +160,7 @@ describe('searchGyms proximity', () => {
   // Unconditional, so the whole file can never go quietly dark: if the CI
   // database ever loses PostGIS, every other test here would report a tidy
   // "skipped" and the job would stay green with zero proximity coverage.
-  it('runs against a PostGIS database in CI', () => {
+  it('asserts PostGIS is present when running in CI', () => {
     if (!process.env.CI) return;
     expect(hasPostGis).toBe(true);
   });
@@ -360,10 +378,11 @@ describe('searchGyms proximity', () => {
       address: 'Jan Rebelstraat 20',
       website: 'https://example.com',
       hours: 'Mon-Fri 09:00-23:00',
-      hoursUpdatedAt: '2026-02-03T10:30:00.000Z',
+      hoursUpdatedAt: HOURS_UPDATED_AT,
     });
 
     const [mapped] = (await searchNearby({ radiusKm: 10, limit: 50 })).gyms;
+    const [viaTextPath] = (await searchText({ limit: 50 })).gyms;
 
     expect(mapped.uuid).toBe(gym.uuid);
     expect(mapped.slug).toBe('fully-populated');
@@ -371,12 +390,27 @@ describe('searchGyms proximity', () => {
     expect(mapped.address).toBe('Jan Rebelstraat 20');
     expect(mapped.website).toBe('https://example.com');
     expect(mapped.hours).toBe('Mon-Fri 09:00-23:00');
-    expect(mapped.hoursUpdatedAt).toBe('2026-02-03T10:30:00.000Z');
     expect(mapped.latitude).toBeCloseTo(latitudeNorthOf(1_000), 6);
     expect(mapped.longitude).toBeCloseTo(SEARCH_LON, 6);
-    // `db.execute` hands back timestamps as strings while the Drizzle path
+
+    // Every non-timestamp field must match the Drizzle branch exactly, so a
+    // column added to `gyms` later has to be carried by both or this fails
+    // rather than going quietly null on the proximity path only.
+    expect(withoutTimestamps(mapped)).toEqual(withoutTimestamps(viaTextPath));
+
+    // The timestamps do NOT match off UTC, and that is a real defect rather than
+    // a test artefact: `hours_updated_at` is `timestamp` WITHOUT time zone, and
+    // mapRawGymRow's `new Date(string)` resolves the offset-less reading in the
+    // process's zone while Drizzle reads the same column as UTC. Identical on a
+    // UTC host (Railway, CI), which is why nobody has hit it. Tracked in #4588 —
+    // both branches are pinned exactly, so the fix collapses these two into one
+    // equality instead of having to re-derive what changed.
+    expect(mapped.hoursUpdatedAt).toBe(new Date(HOURS_UPDATED_AT).toISOString());
+    expect(viaTextPath.hoursUpdatedAt).toBe(`${HOURS_UPDATED_AT.replace(' ', 'T')}.000Z`);
+
+    // `db.execute` hands back timestamps as strings while the Drizzle branch
     // hydrates them to Date, and the response calls `.toISOString()` on this —
-    // an uncoerced string would 500 the whole query, not merely drop a field.
+    // an uncoerced string would 500 the whole query, not merely skew a field.
     expect(() => new Date(mapped.createdAt).toISOString()).not.toThrow();
     expect(Number.isNaN(Date.parse(mapped.createdAt))).toBe(false);
   });
@@ -391,7 +425,7 @@ describe('searchGyms proximity', () => {
     await insertGym({ name: 'Gamma', metresNorth: 200_000 });
 
     const proximity = await searchNearby({ radiusKm: 500, limit: 50 });
-    const textOnly = (await socialGymQueries.searchGyms(null, { input: { limit: 50 } }, anonCtx())) as SearchResult;
+    const textOnly = await searchText({ limit: 50 });
 
     expect(proximity.totalCount).toBe(textOnly.totalCount);
     expect(proximity.gyms.map((gym) => gym.uuid).sort()).toEqual(textOnly.gyms.map((gym) => gym.uuid).sort());

--- a/packages/backend/src/__tests__/search-gyms-proximity.test.ts
+++ b/packages/backend/src/__tests__/search-gyms-proximity.test.ts
@@ -1,0 +1,399 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vite-plus/test';
+import { v4 as uuidv4 } from 'uuid';
+import { sql } from 'drizzle-orm';
+import { rowsFromResult } from '@boardsesh/db/client';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { socialGymQueries } from '../graphql/resolvers/social/gyms';
+
+/**
+ * Real-database coverage for `searchGyms`'s PostGIS proximity branch — the one
+ * mobile's `useNearbyGyms` picker and the web directory's "near me" view both
+ * run in production, and the only branch of the resolver that had never touched
+ * a real database.
+ *
+ * Why it could not exist before: `gyms.location` is a `geography(Point, 4326)`
+ * added by raw migration (drizzle/0052, 0054, 0127), so it lives outside the
+ * Drizzle schema and never reached the hand-maintained test DDL. The tail of
+ * schema-sql.ts now creates the extension, both `location` columns, the GIST
+ * indexes and the 0127 derivation trigger — guarded, so a server without PostGIS
+ * still gets its 70-odd tables and these tests self-skip.
+ *
+ * Everything here seeds plain `latitude`/`longitude` and lets the trigger derive
+ * the geography, because that is exactly what production does — a test that set
+ * `location` by hand would pass while the derivation the resolver depends on was
+ * broken.
+ */
+
+const OWNER = 'proximity-owner';
+
+// Amsterdam. Every fixture is placed due north of it, so the distance between a
+// gym and the search point is a plain meridian arc: 1 degree of latitude here is
+// ~111.28 km, which is what makes the boundary pair below predictable.
+const SEARCH_LAT = 52.3791;
+const SEARCH_LON = 4.9003;
+const METRES_PER_DEGREE_LATITUDE = 111_276;
+
+/** Latitude that sits `metres` due north of the search point. */
+const latitudeNorthOf = (metres: number) => SEARCH_LAT + metres / METRES_PER_DEGREE_LATITUDE;
+
+const anonCtx = (): ConnectionContext => ({ connectionId: 'conn-anon', isAuthenticated: false }) as ConnectionContext;
+
+type SearchResult = {
+  gyms: Array<{
+    uuid: string;
+    slug: string | null;
+    name: string;
+    hours: string | null;
+    hoursUpdatedAt: string | null;
+    createdAt: string;
+    latitude: number | null;
+    longitude: number | null;
+    address: string | null;
+    website: string | null;
+    boardTypes: string[];
+  }>;
+  totalCount: number;
+  hasMore: boolean;
+};
+
+const searchNearby = (input: Record<string, unknown>) =>
+  socialGymQueries.searchGyms(
+    null,
+    { input: { latitude: SEARCH_LAT, longitude: SEARCH_LON, ...input } },
+    anonCtx(),
+  ) as Promise<SearchResult>;
+
+const insertGym = async (opts: {
+  name: string;
+  /** Metres due north of the search point. Omit for a gym with no coordinates. */
+  metresNorth?: number;
+  slug?: string | null;
+  isPublic?: boolean;
+  softDeleted?: boolean;
+  address?: string | null;
+  hours?: string | null;
+  hoursUpdatedAt?: string | null;
+  website?: string | null;
+}): Promise<{ id: number; uuid: string }> => {
+  const { name, metresNorth, isPublic = true, softDeleted = false } = opts;
+  const uuid = uuidv4();
+  const slug = opts.slug === undefined ? uuid : opts.slug;
+  const hasCoordinates = metresNorth !== undefined;
+  const result = await db.execute(sql`
+    INSERT INTO gyms (uuid, name, slug, owner_id, is_public, latitude, longitude,
+                      address, website, hours, hours_updated_at, deleted_at, created_at, updated_at)
+    VALUES (${uuid}, ${name}, ${slug}, ${OWNER}, ${isPublic},
+            ${hasCoordinates ? latitudeNorthOf(metresNorth) : null},
+            ${hasCoordinates ? SEARCH_LON : null},
+            ${opts.address ?? null}, ${opts.website ?? null}, ${opts.hours ?? null},
+            ${opts.hoursUpdatedAt ? sql`${opts.hoursUpdatedAt}::timestamp` : sql`NULL`},
+            ${softDeleted ? sql`now()` : sql`NULL`}, now(), now())
+    RETURNING id
+  `);
+  return { id: Number(rowsFromResult<{ id: number }>(result)[0].id), uuid };
+};
+
+const insertBoard = async (gymId: number, boardType: string): Promise<void> => {
+  const uuid = uuidv4();
+  await db.execute(sql`
+    INSERT INTO user_boards
+      (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, angle, gym_id, is_public, created_at, updated_at)
+    VALUES (${uuid}, ${uuid}, ${OWNER}, ${boardType}, 1, 10, '1,2', 'Wall', 40, ${gymId}, true, now(), now())
+  `);
+};
+
+const locationTextOf = async (gymUuid: string): Promise<string | null> => {
+  const result = await db.execute(sql`SELECT ST_AsText(location::geometry) AS wkt FROM gyms WHERE uuid = ${gymUuid}`);
+  return rowsFromResult<{ wkt: string | null }>(result)[0]?.wkt ?? null;
+};
+
+/**
+ * Whether this worker's database actually has PostGIS. Only knowable after the
+ * schema apply, which is why the tests below skip at runtime rather than through
+ * `it.skipIf` (evaluated while the file is still being collected).
+ */
+let hasPostGis = false;
+
+const requirePostGis = (ctx: { skip: () => void }) => {
+  if (!hasPostGis) ctx.skip();
+};
+
+beforeAll(async () => {
+  const result = await db.execute(sql`SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'postgis') AS present`);
+  hasPostGis = rowsFromResult<{ present: boolean }>(result)[0]?.present === true;
+});
+
+beforeEach(async () => {
+  await db.execute(sql`
+    TRUNCATE TABLE
+      "community_roles", "gym_members", "gym_follows", "gym_claims",
+      "board_follows", "boardsesh_ticks", "user_boards", "gyms", "notifications"
+    RESTART IDENTITY CASCADE
+  `);
+  await db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${OWNER}, ${OWNER + '@test.com'}, 'Proximity Owner', now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+});
+
+describe('searchGyms proximity', () => {
+  // Unconditional, so the whole file can never go quietly dark: if the CI
+  // database ever loses PostGIS, every other test here would report a tidy
+  // "skipped" and the job would stay green with zero proximity coverage.
+  it('runs against a PostGIS database in CI', () => {
+    if (!process.env.CI) return;
+    expect(hasPostGis).toBe(true);
+  });
+
+  it('derives the geography from latitude/longitude on insert', async (ctx) => {
+    requirePostGis(ctx);
+    // The resolver filters `location IS NOT NULL` and nothing in the write path
+    // sets that column — the 0127 trigger does. If it stops firing, proximity
+    // search returns nothing at all and every assertion below would still pass
+    // for the wrong reason, so pin the derivation itself first.
+    const gym = await insertGym({ name: 'Derived', metresNorth: 0 });
+    expect(await locationTextOf(gym.uuid)).toBe(`POINT(${SEARCH_LON} ${SEARCH_LAT})`);
+  });
+
+  it('keeps a gym just inside the radius and drops the one just outside it', async (ctx) => {
+    requirePostGis(ctx);
+    // ~100m either side of a 10km radius. A sloppier pair (5km vs 60km) passes
+    // even if the radius is out by a factor of two.
+    const inside = await insertGym({ name: 'Inside Edge', metresNorth: 9_900 });
+    await insertGym({ name: 'Outside Edge', metresNorth: 10_100 });
+
+    const result = await searchNearby({ radiusKm: 10, limit: 50 });
+
+    expect(result.gyms.map((gym) => gym.uuid)).toEqual([inside.uuid]);
+    expect(result.totalCount).toBe(1);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('widening the radius pulls the far gym back in', async (ctx) => {
+    requirePostGis(ctx);
+    // The mirror of the case above: proves the cut-off tracks `radiusKm` rather
+    // than the excluded gym being unreachable for some other reason.
+    const inside = await insertGym({ name: 'Inside Edge', metresNorth: 9_900 });
+    const outside = await insertGym({ name: 'Outside Edge', metresNorth: 10_100 });
+
+    const result = await searchNearby({ radiusKm: 11, limit: 50 });
+
+    expect(result.gyms.map((gym) => gym.uuid).sort()).toEqual([inside.uuid, outside.uuid].sort());
+    expect(result.totalCount).toBe(2);
+  });
+
+  it('returns gyms nearest first', async (ctx) => {
+    requirePostGis(ctx);
+    // Inserted furthest-first, so a resolver that fell back to insertion order
+    // or created_at would produce the exact reverse of the expectation.
+    const far = await insertGym({ name: 'Far', metresNorth: 30_000 });
+    const middle = await insertGym({ name: 'Middle', metresNorth: 12_000 });
+    const near = await insertGym({ name: 'Near', metresNorth: 400 });
+
+    const result = await searchNearby({ radiusKm: 50, limit: 50 });
+
+    expect(result.gyms.map((gym) => gym.uuid)).toEqual([near.uuid, middle.uuid, far.uuid]);
+  });
+
+  it('pages by distance with totalCount reporting the whole match set', async (ctx) => {
+    requirePostGis(ctx);
+    // The count and the rows are two separate `db.execute` statements that agree
+    // only because they interpolate the same filter clause. Paging is where a
+    // disagreement surfaces: a predicate on one and not the other leaves the
+    // directory advertising a page that does not exist.
+    const distances = [500, 1_500, 2_500, 3_500];
+    const seeded = [];
+    for (const metresNorth of distances) {
+      seeded.push(await insertGym({ name: `Gym at ${metresNorth}m`, metresNorth }));
+    }
+
+    const firstPage = await searchNearby({ radiusKm: 10, limit: 2, offset: 0 });
+    expect(firstPage.totalCount).toBe(4);
+    expect(firstPage.hasMore).toBe(true);
+    expect(firstPage.gyms.map((gym) => gym.uuid)).toEqual([seeded[0].uuid, seeded[1].uuid]);
+
+    const secondPage = await searchNearby({ radiusKm: 10, limit: 2, offset: 2 });
+    expect(secondPage.totalCount).toBe(4);
+    expect(secondPage.hasMore).toBe(false);
+    expect(secondPage.gyms.map((gym) => gym.uuid)).toEqual([seeded[2].uuid, seeded[3].uuid]);
+
+    // And a single-row window lands on the second-nearest, not the second-inserted.
+    const window = await searchNearby({ radiusKm: 10, limit: 1, offset: 1 });
+    expect(window.gyms.map((gym) => gym.uuid)).toEqual([seeded[1].uuid]);
+    expect(window.totalCount).toBe(4);
+  });
+
+  it('pages cleanly over gyms sharing one distance — no duplicates, no skips', async (ctx) => {
+    requirePostGis(ctx);
+    // A bulk import parks several gyms on one address, so `distance_meters` ties
+    // exactly. Without `gyms.id` as a second sort key those rows have no defined
+    // order and Postgres may return them differently per OFFSET page: one gym
+    // appears twice, another never appears.
+    const seeded = [];
+    for (let index = 0; index < 6; index++) {
+      seeded.push(await insertGym({ name: `Same Address ${index}`, metresNorth: 1_000 }));
+    }
+
+    const walk = async () => {
+      const uuids: string[] = [];
+      for (let offset = 0; offset < 6; offset += 2) {
+        const page = await searchNearby({ radiusKm: 10, limit: 2, offset });
+        expect(page.totalCount).toBe(6);
+        uuids.push(...page.gyms.map((gym) => gym.uuid));
+      }
+      return uuids;
+    };
+
+    const firstWalk = await walk();
+    expect(firstWalk).toHaveLength(6);
+    expect(new Set(firstWalk).size).toBe(6);
+    // Stable, not merely unique — a shuffled-but-complete result would pass the
+    // uniqueness check alone while still breaking infinite scroll.
+    expect(await walk()).toEqual(firstWalk);
+  });
+
+  it('never returns a gym with no coordinates', async (ctx) => {
+    requirePostGis(ctx);
+    const located = await insertGym({ name: 'Located', metresNorth: 1_000 });
+    const unlocated = await insertGym({ name: 'No Coordinates' });
+
+    expect(await locationTextOf(unlocated.uuid)).toBeNull();
+
+    const result = await searchNearby({ radiusKm: 500, limit: 50 });
+    expect(result.gyms.map((gym) => gym.uuid)).toEqual([located.uuid]);
+    // The count statement carries `location IS NOT NULL` too — if only the rows
+    // statement did, the directory would show one card under a header of two.
+    expect(result.totalCount).toBe(1);
+  });
+
+  it('drops a gym as soon as its coordinates are cleared', async (ctx) => {
+    requirePostGis(ctx);
+    // The UPDATE arm of the trigger. Clearing lat/lng has to clear the geography,
+    // or a gym that removed its address stays pinned to the map forever.
+    const gym = await insertGym({ name: 'Moving Out', metresNorth: 1_000 });
+    expect((await searchNearby({ radiusKm: 10, limit: 50 })).totalCount).toBe(1);
+
+    await db.execute(sql`UPDATE gyms SET latitude = NULL, longitude = NULL WHERE id = ${gym.id}`);
+
+    expect(await locationTextOf(gym.uuid)).toBeNull();
+    const result = await searchNearby({ radiusKm: 10, limit: 50 });
+    expect(result.gyms).toHaveLength(0);
+    expect(result.totalCount).toBe(0);
+  });
+
+  it('leaves private and soft-deleted gyms out of both the rows and the count', async (ctx) => {
+    requirePostGis(ctx);
+    const visible = await insertGym({ name: 'Visible', metresNorth: 1_000 });
+    await insertGym({ name: 'Private', metresNorth: 1_100, isPublic: false });
+    await insertGym({ name: 'Deleted', metresNorth: 1_200, softDeleted: true });
+
+    const result = await searchNearby({ radiusKm: 10, limit: 50 });
+    expect(result.gyms.map((gym) => gym.uuid)).toEqual([visible.uuid]);
+    expect(result.totalCount).toBe(1);
+  });
+
+  it('requireSlug drops a slugless gym from the rows and the count together', async (ctx) => {
+    requirePostGis(ctx);
+    const slugged = await insertGym({ name: 'Slugged', metresNorth: 1_000, slug: 'slugged-gym' });
+    await insertGym({ name: 'Null Slug', metresNorth: 1_100, slug: null });
+    await insertGym({ name: 'Empty Slug', metresNorth: 1_200, slug: '' });
+
+    const unfiltered = await searchNearby({ radiusKm: 10, limit: 50 });
+    expect(unfiltered.totalCount).toBe(3);
+
+    const filtered = await searchNearby({ radiusKm: 10, limit: 50, requireSlug: true });
+    expect(filtered.gyms.map((gym) => gym.uuid)).toEqual([slugged.uuid]);
+    // The point the rendered-SQL test in search-gyms-require-slug-sql.test.ts
+    // could only approximate: the predicate reaches the count statement too, so
+    // `totalCount` falls by exactly the two excluded rows.
+    expect(filtered.totalCount).toBe(1);
+    expect(filtered.hasMore).toBe(false);
+  });
+
+  it('ANDs a text query with the radius rather than widening it', async (ctx) => {
+    requirePostGis(ctx);
+    const nearMatch = await insertGym({ name: 'Klimmuur Centraal', metresNorth: 1_000 });
+    await insertGym({ name: 'Other Gym', metresNorth: 1_100 });
+    await insertGym({ name: 'Klimmuur Noord', metresNorth: 40_000 });
+
+    const result = await searchNearby({ radiusKm: 10, limit: 50, query: 'Klimmuur' });
+    expect(result.gyms.map((gym) => gym.uuid)).toEqual([nearMatch.uuid]);
+    expect(result.totalCount).toBe(1);
+  });
+
+  it('matches a text query against the address on the proximity path', async (ctx) => {
+    requirePostGis(ctx);
+    const byAddress = await insertGym({ name: 'Anonymous Gym', metresNorth: 1_000, address: 'Jan Rebelstraat 20' });
+    await insertGym({ name: 'Another Gym', metresNorth: 1_100, address: 'Overtoom 1' });
+
+    const result = await searchNearby({ radiusKm: 10, limit: 50, query: 'Rebelstraat' });
+    expect(result.gyms.map((gym) => gym.uuid)).toEqual([byAddress.uuid]);
+  });
+
+  it('applies the boardTypes filter inside the radius', async (ctx) => {
+    requirePostGis(ctx);
+    const kilterGym = await insertGym({ name: 'Kilter Gym', metresNorth: 1_000 });
+    const tensionGym = await insertGym({ name: 'Tension Gym', metresNorth: 1_100 });
+    await insertGym({ name: 'Boardless Gym', metresNorth: 1_200 });
+    await insertBoard(kilterGym.id, 'kilter');
+    await insertBoard(tensionGym.id, 'tension');
+
+    const result = await searchNearby({ radiusKm: 10, limit: 50, boardTypes: ['kilter'] });
+    expect(result.gyms.map((gym) => gym.uuid)).toEqual([kilterGym.uuid]);
+    expect(result.gyms[0].boardTypes).toEqual(['kilter']);
+    expect(result.totalCount).toBe(1);
+  });
+
+  it('maps every column the response reads off the raw SELECT *', async (ctx) => {
+    requirePostGis(ctx);
+    // This branch hydrates rows by hand from snake_case keys (`mapRawGymRow`)
+    // instead of going through the Drizzle query builder, and it has silently
+    // lost fields that way twice (#3431 website_vouched_by_owner, then
+    // hours_updated_at). A camelCase typo type-checks and maps to null forever
+    // here while the text-search path keeps rendering the field correctly.
+    const gym = await insertGym({
+      name: 'Fully Populated',
+      metresNorth: 1_000,
+      slug: 'fully-populated',
+      address: 'Jan Rebelstraat 20',
+      website: 'https://example.com',
+      hours: 'Mon-Fri 09:00-23:00',
+      hoursUpdatedAt: '2026-02-03T10:30:00.000Z',
+    });
+
+    const [mapped] = (await searchNearby({ radiusKm: 10, limit: 50 })).gyms;
+
+    expect(mapped.uuid).toBe(gym.uuid);
+    expect(mapped.slug).toBe('fully-populated');
+    expect(mapped.name).toBe('Fully Populated');
+    expect(mapped.address).toBe('Jan Rebelstraat 20');
+    expect(mapped.website).toBe('https://example.com');
+    expect(mapped.hours).toBe('Mon-Fri 09:00-23:00');
+    expect(mapped.hoursUpdatedAt).toBe('2026-02-03T10:30:00.000Z');
+    expect(mapped.latitude).toBeCloseTo(latitudeNorthOf(1_000), 6);
+    expect(mapped.longitude).toBeCloseTo(SEARCH_LON, 6);
+    // `db.execute` hands back timestamps as strings while the Drizzle path
+    // hydrates them to Date, and the response calls `.toISOString()` on this —
+    // an uncoerced string would 500 the whole query, not merely drop a field.
+    expect(() => new Date(mapped.createdAt).toISOString()).not.toThrow();
+    expect(Number.isNaN(Date.parse(mapped.createdAt))).toBe(false);
+  });
+
+  it('agrees with the text path about which gyms exist', async (ctx) => {
+    requirePostGis(ctx);
+    // The two branches share nothing but their intent, so pin them against each
+    // other: with a radius wide enough to cover every fixture, the proximity
+    // branch must return the same set the Drizzle branch does.
+    await insertGym({ name: 'Alpha', metresNorth: 1_000 });
+    await insertGym({ name: 'Beta', metresNorth: 60_000 });
+    await insertGym({ name: 'Gamma', metresNorth: 200_000 });
+
+    const proximity = await searchNearby({ radiusKm: 500, limit: 50 });
+    const textOnly = (await socialGymQueries.searchGyms(null, { input: { limit: 50 } }, anonCtx())) as SearchResult;
+
+    expect(proximity.totalCount).toBe(textOnly.totalCount);
+    expect(proximity.gyms.map((gym) => gym.uuid).sort()).toEqual(textOnly.gyms.map((gym) => gym.uuid).sort());
+  });
+});

--- a/packages/backend/src/__tests__/search-gyms-proximity.test.ts
+++ b/packages/backend/src/__tests__/search-gyms-proximity.test.ts
@@ -83,6 +83,9 @@ const searchText = (input: Record<string, unknown>) =>
 const withoutFieldsDivergingOnBug4588 = (gym: SearchResult['gyms'][number]) => {
   const comparable: Record<string, unknown> = { ...gym };
   delete comparable.hoursUpdatedAt;
+  // Same defect, same cause: `created_at` is `timestamp` without time zone too,
+  // so it skews by the host offset in exactly the same way. Checked separately
+  // below for the thing that would actually 500 the query — that it parses.
   delete comparable.createdAt;
   return comparable;
 };

--- a/packages/backend/src/__tests__/search-gyms-proximity.test.ts
+++ b/packages/backend/src/__tests__/search-gyms-proximity.test.ts
@@ -74,8 +74,13 @@ const searchNearby = (input: Record<string, unknown>) =>
 const searchText = (input: Record<string, unknown>) =>
   socialGymQueries.searchGyms(null, { input }, anonCtx()) as Promise<SearchResult>;
 
-/** Drop the two `timestamp` (no time zone) fields the branches disagree on — see #4588. */
-const withoutTimestamps = (gym: SearchResult['gyms'][number]) => {
+/**
+ * Drop the two fields the branches are KNOWN to disagree on, so the rest can be
+ * compared strictly. Not a convenience — it is carving a known bug (#4588,
+ * `timestamp` without time zone read in two different zones) out of an otherwise
+ * exact equality. Delete this helper when #4588 lands.
+ */
+const withoutFieldsDivergingOnBug4588 = (gym: SearchResult['gyms'][number]) => {
   const comparable: Record<string, unknown> = { ...gym };
   delete comparable.hoursUpdatedAt;
   delete comparable.createdAt;
@@ -160,8 +165,12 @@ describe('searchGyms proximity', () => {
   // Unconditional, so the whole file can never go quietly dark: if the CI
   // database ever loses PostGIS, every other test here would report a tidy
   // "skipped" and the job would stay green with zero proximity coverage.
-  it('asserts PostGIS is present when running in CI', () => {
-    if (!process.env.CI) return;
+  it('asserts PostGIS is present when running in CI', (ctx) => {
+    // Reports as skipped off CI rather than passing as a no-op — the rest of the
+    // file already signals that way. Under CI it always runs, which is the whole
+    // point: without it, a CI database that lost PostGIS would skip all fifteen
+    // cases below and leave the job green with zero proximity coverage.
+    if (!process.env.CI) ctx.skip();
     expect(hasPostGis).toBe(true);
   });
 
@@ -396,7 +405,7 @@ describe('searchGyms proximity', () => {
     // Every non-timestamp field must match the Drizzle branch exactly, so a
     // column added to `gyms` later has to be carried by both or this fails
     // rather than going quietly null on the proximity path only.
-    expect(withoutTimestamps(mapped)).toEqual(withoutTimestamps(viaTextPath));
+    expect(withoutFieldsDivergingOnBug4588(mapped)).toEqual(withoutFieldsDivergingOnBug4588(viaTextPath));
 
     // The timestamps do NOT match off UTC, and that is a real defect rather than
     // a test artefact: `hours_updated_at` is `timestamp` WITHOUT time zone, and

--- a/packages/backend/src/__tests__/search-gyms-require-slug-sql.test.ts
+++ b/packages/backend/src/__tests__/search-gyms-require-slug-sql.test.ts
@@ -180,12 +180,10 @@ describe('searchGyms requireSlug — rendered SQL', () => {
   });
 
   // The count-vs-rows agreement stated as one assertion rather than two
-  // substring checks. Ideally this would be a behavioural test against a real
-  // DB, but the backend test DB is plain `postgres:15` with no PostGIS — no
-  // `gyms.location` column, and `pg_available_extensions` lists no postgis — so
-  // ST_DWithin/ST_MakePoint cannot run there at all. Comparing the two WHERE
-  // clauses proves the same property the data test would: the set the count
-  // describes is the set the rows come from.
+  // substring checks. search-gyms-proximity.test.ts now proves the same property
+  // behaviourally against real PostGIS, so this is no longer the only evidence —
+  // it stays as the cheap structural guard, holding every rendered combination to
+  // a byte-identical WHERE including the ones no fixture covers.
   it.each([
     ['requireSlug omitted', PROXIMITY_INPUT],
     ['requireSlug true', { ...PROXIMITY_INPUT, requireSlug: true }],

--- a/packages/backend/src/__tests__/worker-db.ts
+++ b/packages/backend/src/__tests__/worker-db.ts
@@ -16,9 +16,26 @@ import { schemaSQL } from './schema-sql';
 const PG_PORT = 5433;
 const WORKER_DB_PREFIX = 'boardsesh_backend_test';
 
+/**
+ * Point the suite at a different Postgres server without editing the compose
+ * file. The :5433 container is shared by every checkout on a dev machine, so
+ * restarting it on a new image under a parallel run is not something running the
+ * tests should demand.
+ *
+ * It needs a variable of its own rather than reusing DATABASE_URL: `test.env` in
+ * vite.config.ts writes DATABASE_URL during worker init, before setupFiles import
+ * this module, so an exported DATABASE_URL is overwritten before we read it.
+ */
+function getConfiguredDatabaseUrl(): string {
+  return (
+    process.env.BOARDSESH_TEST_DATABASE_URL ||
+    process.env.DATABASE_URL ||
+    `postgresql://postgres:postgres@localhost:${PG_PORT}/${WORKER_DB_PREFIX}`
+  );
+}
+
 function getBaseConnection(): string {
-  const raw = process.env.DATABASE_URL || `postgresql://postgres:postgres@localhost:${PG_PORT}/${WORKER_DB_PREFIX}`;
-  return raw.replace(/\/[^/]+$/, '/postgres');
+  return getConfiguredDatabaseUrl().replace(/\/[^/]+$/, '/postgres');
 }
 
 export function getWorkerDatabaseName(): string {
@@ -29,8 +46,7 @@ export function getWorkerDatabaseName(): string {
 
 function buildWorkerDatabaseUrl(): string {
   const name = getWorkerDatabaseName();
-  const raw = process.env.DATABASE_URL || `postgresql://postgres:postgres@localhost:${PG_PORT}/${WORKER_DB_PREFIX}`;
-  return raw.replace(/\/[^/]+$/, `/${name}`);
+  return getConfiguredDatabaseUrl().replace(/\/[^/]+$/, `/${name}`);
 }
 
 /** Redis ships with 16 logical databases (`databases 16`) unless configured otherwise. */

--- a/packages/backend/src/__tests__/worker-db.ts
+++ b/packages/backend/src/__tests__/worker-db.ts
@@ -25,6 +25,10 @@ const WORKER_DB_PREFIX = 'boardsesh_backend_test';
  * It needs a variable of its own rather than reusing DATABASE_URL: `test.env` in
  * vite.config.ts writes DATABASE_URL during worker init, before setupFiles import
  * this module, so an exported DATABASE_URL is overwritten before we read it.
+ *
+ * Point it at a throwaway server only. Whatever it names inherits the whole test
+ * harness, including globalSetup's `dropStaleWorkerDatabases`, which DROPs every
+ * `boardsesh_backend_test_w*` database it finds there.
  */
 function getConfiguredDatabaseUrl(): string {
   return (

--- a/packages/backend/src/graphql/resolvers/social/gym-matching.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-matching.ts
@@ -15,10 +15,11 @@ import { getUserCommunityRoles, rolesGrantAdminOrLeader } from './roles';
 //
 // Both the createBoard auto-gym guard and the findSimilarGyms read resolver need
 // to answer "is there already a live gym at these coordinates with (roughly) this
-// name?". The production `gyms` table carries a PostGIS `location` geography, but
-// the backend test DB is plain postgres (no PostGIS / pg_trgm), so everything
-// here stays portable: a cheap lat/lng bounding-box prefilter in SQL, then an
-// exact Haversine refine in JS (`distanceMeters` from @boardsesh/db/queries). The
+// name?". The production `gyms` table carries a PostGIS `location` geography,
+// but nothing here depends on the extension being installed — a self-hosted
+// deployment can be missing it, and the test DB has no pg_trgm — so everything
+// stays portable: a cheap lat/lng bounding-box prefilter in SQL, then an exact
+// Haversine refine in JS (`distanceMeters` from @boardsesh/db/queries). The
 // bounding box is padded (BOUNDING_BOX_SAFETY_FACTOR) so it stays a superset of
 // the true circle even where a metre-per-degree of latitude runs short of the
 // 111_320 average (~0.7% at the equator) — otherwise the prefilter could drop a

--- a/packages/backend/src/graphql/resolvers/social/location-geography.ts
+++ b/packages/backend/src/graphql/resolvers/social/location-geography.ts
@@ -19,9 +19,10 @@ type SyncLocationGeographyArgs = {
  *
  * These columns are denormalizations used by proximity search. The write runs
  * outside the caller's transaction and never throws: inside a transaction a
- * PostGIS failure (the column is absent in the backend test DB, and the
- * extension can be missing on any self-hosted deployment) rolled the whole
- * thing back and silently cost the user their gym. Out here the worst case is
+ * PostGIS failure (the extension can be missing on any self-hosted deployment,
+ * and the backend test DB skips it too when its server has no PostGIS package)
+ * rolled the whole thing back and silently cost the user their gym. Out here the
+ * worst case is
  * a null `location` that a backfill can repair — the row id is logged so that
  * backfill is a one-liner.
  *

--- a/packages/db/src/__tests__/location-trigger.integration.test.ts
+++ b/packages/db/src/__tests__/location-trigger.integration.test.ts
@@ -14,8 +14,10 @@ import postgres from 'postgres';
  *
  * Opt-in: set LOCATION_TRIGGER_DB_URL to a PostGIS dev DB migrated to >= 0127
  * (`vp run db:up`, then the URL from .boardsesh/dev-db.env). Self-skips
- * otherwise so CI and dataless machines stay green. The backend test DB
- * (plain postgres:15, no PostGIS) cannot run this.
+ * otherwise so CI and dataless machines stay green. `packages/db` runs on
+ * Node's test runner and is not part of the Vitest projects, so this file is not
+ * in CI at all; the backend suite covers the same triggers through
+ * search-gyms-proximity.test.ts, whose test DB does carry PostGIS.
  *
  *   LOCATION_TRIGGER_DB_URL=postgres://postgres:password@localhost:5432/main pnpm --filter @boardsesh/db run test
  */


### PR DESCRIPTION
## Summary

Closes #4507.

`searchGyms` has two branches. The text branch has real-database coverage; the proximity branch — the one mobile's `useNearbyGyms` picker and the web directory's "near me" view actually run — had never touched a database. It could only be asserted at the rendered-SQL level, so nothing in the suite would catch a query that renders correctly and returns the wrong rows.

**The issue's premise is half wrong, and it's the expensive half.** The issue reads it as "swap the CI service image under all 259 backend test files". CI's `test-backend` Postgres has been `ghcr.io/boardsesh/boardsesh-postgres-postgis:latest` since 2026-02-14 (`236d8d4d2`, ci.yml:652) — Postgres 18.4 + PostGIS 3.6.4. **No CI change is needed.** Only the *local* `packages/backend/docker-compose.test.yml` was still `postgres:15`.

The real gap was inside the repo: `gyms.location` is a `geography(Point, 4326)` added by raw migration (`drizzle/0052`, `0054`, `0127`), so it lives outside the Drizzle schema and nothing generates it. It could only reach the test database by being written into `schema-sql.ts` by hand, and it never was — no `CREATE EXTENSION`, no `location` column, no derivation trigger.

### What changed

- **`schema-sql.ts`** now creates the extension, both `location` columns, the two GIST indexes (predicates copied from `0054`/`0052`) and the `0127` derivation trigger, at the very end of the string — `user_boards` is dropped and recreated above, which would otherwise take the column and its trigger with it.

  It is wrapped in a `DO … EXCEPTION` block, and that guard is load-bearing rather than defensive padding. `worker-db.ts` applies the whole 60KB string through postgres.js `unsafe()` — one simple query, so one implicit transaction. A bare `CREATE EXTENSION postgis` against a server without it aborts that transaction and rolls back **all 72 tables**, taking every backend test with it. I reproduced both sides: unguarded → `ERROR: extension "postgis" is not available` and 0 tables; guarded → 72 tables, a `NOTICE`, and `gyms.location` simply absent. That matters for anyone whose local container predates this PR.

- **Local compose image** → `postgis/postgis:18-3.6`. Also brings local Postgres in line with CI's 18.x (it was 15).

- **`BOARDSESH_TEST_DATABASE_URL`** points the backend suite at a Postgres of your own. It needs its own variable: `test.env.DATABASE_URL` in `vite.config.ts` is written into `process.env` during worker init, before `setupFiles` run, so an exported `DATABASE_URL` is clobbered back to `:5433`. Without this there was no way to verify a change like this except by restarting the shared `:5433` container under every other checkout on the machine.

- **16 new tests** in `search-gyms-proximity.test.ts`. Every fixture seeds plain `latitude`/`longitude` and lets the trigger derive the geography — the same derivation production depends on, so a test that set `location` by hand would pass while the trigger was broken. Coverage: the radius cut-off proved from **both** sides with a pair ~100 m either side of a 10 km boundary (a 5 km-vs-60 km pair passes even if the radius is out by 2×), nearest-first ordering seeded furthest-first, `totalCount`/rows agreement under paging, stable paging over gyms at an identical distance, NULL coordinates (insert **and** the UPDATE arm that clears them), private and soft-deleted gyms, `requireSlug` dropping rows from the count too, text-query-ANDed-with-radius, address matching, `boardTypes`, and cross-checking the proximity branch against the text branch. Plus the snake_case row mapping (`mapRawGymRow` off a `SELECT *`), which has already silently lost two fields (#3431 `website_vouched_by_owner`, then `hours_updated_at`) and had never executed against a real row.

  The tests self-skip on a server without PostGIS, and one **unconditional** guard test asserts `hasPostGis` is true when `CI` is set — so the file can't quietly go dark into a green build.

- **`location-geography-degradation.test.ts` now builds its own no-PostGIS world.** That file only tested anything because the test DB happened to lack the extension, and its premise probe said so in as many words — it fired the moment PostGIS arrived, which is exactly what a good premise probe is for. Rather than weaken it, `beforeAll` drops the `location` columns and their triggers and `afterAll` restores them from the same exported DDL string, so there is no second copy to drift. The SQLSTATE it expects now follows the server: with PostGIS installed the `::geography` cast resolves and the undefined column is what fails (42703); with no PostGIS the cast fails first (42704). A new case asserts the trigger teardown too — a surviving trigger would write the geography behind the resolver's back and hide the very failure the file exists to prove.

### The coverage found a real bug on its way in

Pinning the proximity row against the Drizzle row field-by-field (rather than against literals) surfaced **#4588**: `hours_updated_at` is `timestamp` **without** time zone, and `mapRawGymRow` coerces it with `new Date(string)`, which resolves the offset-less reading in the Node process's zone — while the Drizzle branch reads the same column as UTC. Same gym, same column, two different instants:

```
TZ=Asia/Tokyo
  proximity branch → 2026-02-03T01:30:00.000Z
  text branch      → 2026-02-03T10:30:00.000Z
```

Nine hours apart, exactly the host offset. Identical on a UTC host, which is why it has never surfaced — Railway and GitHub runners are both UTC. That is the third defect in this same hand-rolled mapping (after #3431 and `hours_updated_at` itself), and the first one a test has ever been able to see.

Not fixed here, for the same reason as the other behaviour questions below: it changes what a live resolver returns. Both branches are pinned exactly instead, so the fix collapses two assertions into one equality rather than making someone re-derive what changed.

### For you to decide: local vs CI image

CI uses `ghcr.io/boardsesh/boardsesh-postgres-postgis` (private — an anonymous manifest fetch 403s; the job passes credentials). Pointing the compose file at it would make every contributor `docker login ghcr.io` before running the backend suite, so this uses the public Docker Hub `postgis/postgis:18-3.6` instead. **Local and CI are therefore close but not identical: 18.6 + PostGIS 3.6.4 locally, 18.4 + 3.6.4 in CI.** If you'd rather have exact parity, making the ghcr package public is a one-click change and the compose file can point at it — your call, not a blocker for this PR.

### Deliberately not in scope

- **`searchGyms` hard-fails without PostGIS**, which contradicts the portability doctrine stated a few files over in `gym-matching.ts` ("everything here stays portable… a cheap lat/lng bounding-box prefilter in SQL, then an exact Haversine refine in JS"). That's a behaviour change to a live query, so it's #4562 rather than something smuggled into a test PR.
- **`myGyms` orders without a unique tiebreaker** — the latent flaw #4505 fixed in `searchGyms`'s two orderings — filed as #4564.
- **`searchBoards`'s proximity path** (`boards.ts:1253-1300`) has the same gap plus a `hideLocation` privacy predicate with a follower escape hatch that has never run against a real database. The DDL here unblocks it (`user_boards.location` is created too); filed as #4565 to keep this PR reviewable. I nearly folded it in — the fixture work is cheap now — but the escape hatch reads `follower_id = owner_id AND following_id = viewer`, i.e. *the board owner follows the searching user*, which is not the rule you would guess and not obviously the intended one. A test would cement whichever way it currently falls, so that question wants answering before it gets pinned, not after.
- **The timestamp divergence above** (#4588) — a live resolver's output.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- Negative control, shared `postgres:15`: sent `schemaSQL` as **one** simple query (same semantics as `unsafe()`) to a scratch DB. Guarded version → 72 tables, `NOTICE: postgis unavailable …`, no `gyms.location`. Unguarded version → whole apply rolled back, 0 tables.
- Positive, PostGIS 3.6.3: same string → 75 relations, both `location` columns, both triggers, both GIST indexes. Re-applied to confirm idempotency (worker DBs outlive a run).
- Verified the trigger derives `POINT(4.9003 52.3791)` from plain lat/lng, clears the geography when lat/lng go NULL, and that the verbatim resolver SQL returns count=2 / rows nearest-first with the 60 km gym cut from a 10 km radius.
- `vp test run --project backend search-gyms-proximity` against a throwaway `postgis/postgis:18-3.6` container (18.6 + PostGIS 3.6.4) via `BOARDSESH_TEST_DATABASE_URL` — **16 passed**, none skipped.
- Full `vp test run --project backend` against a throwaway plain `postgres:15` — the degradation path: the bootstrap still applies cleanly for all 259 files and the proximity file reports skipped rather than red.
- Both throwaway containers ran on their own ports and were removed; the shared `:5433` container was never restarted.
- `TZ=Asia/Tokyo` against the same container — the run that found #4588, and green now that both branches are pinned.
- On a throwaway plain `postgres:15` via the override: **12 passed, 15 skipped** — the degradation suite runs and the proximity cases self-skip, which is the designed behaviour on a server without the extension.
- `vp run typecheck:backend`, and `vp check` via the pre-commit hook.
- CI is the authoritative signal here, since its Postgres already carries PostGIS. Confirmed in the job log that the proximity tests **executed** rather than skipped (`✓ … asserts PostGIS is present when running in CI`, then all 15 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016552Be7ctNKKH8QM9rkryN
