### PR TITLE
fix(mobile): stop one locked write permanently breaking favorites

### DIFF
--- a/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
+++ b/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
@@ -83,9 +83,9 @@ vi.mock('../../lib/error-reporting', () => ({
 
 // The gauge itself is unit-tested in offline/__tests__/outbox-telemetry.test.ts;
 // what matters here is WHERE the bridge calls it from — both flag branches, once.
-const reportOutboxBacklogOnceMock = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => {}));
+const recoverAndReportOutboxOnceMock = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => {}));
 vi.mock('../../offline/outbox-telemetry', () => ({
-  reportOutboxBacklogOnce: reportOutboxBacklogOnceMock,
+  recoverAndReportOutboxOnce: recoverAndReportOutboxOnceMock,
 }));
 
 // Stub the settings barrel so the static import graph never pulls
@@ -375,8 +375,8 @@ describe('OfflineSyncBridge — outbox backlog gauge', () => {
   it('reads the backlog once for a signed-in launch', async () => {
     render(<Harness flags={FLAG_ON} queryClient={makeQueryClient()} />);
 
-    await waitFor(() => expect(reportOutboxBacklogOnceMock).toHaveBeenCalledTimes(1));
-    expect(reportOutboxBacklogOnceMock).toHaveBeenCalledWith(fakeDb);
+    await waitFor(() => expect(recoverAndReportOutboxOnceMock).toHaveBeenCalledTimes(1));
+    expect(recoverAndReportOutboxOnceMock).toHaveBeenCalledWith(fakeDb);
   });
 
   it('does not read anything while signed out', async () => {
@@ -384,18 +384,18 @@ describe('OfflineSyncBridge — outbox backlog gauge', () => {
     render(<Harness flags={FLAG_ON} queryClient={makeQueryClient()} />);
 
     await waitFor(() => expect(startBackgroundTrackingMock).toHaveBeenCalled());
-    expect(reportOutboxBacklogOnceMock).not.toHaveBeenCalled();
+    expect(recoverAndReportOutboxOnceMock).not.toHaveBeenCalled();
   });
 
   it('does not re-read when unrelated feature flags change', async () => {
     const queryClient = makeQueryClient();
     const { rerender } = render(<Harness flags={FLAG_ON} queryClient={queryClient} />);
-    await waitFor(() => expect(reportOutboxBacklogOnceMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(recoverAndReportOutboxOnceMock).toHaveBeenCalledTimes(1));
 
     rerender(<Harness flags={FLAG_OFF} queryClient={queryClient} />);
     await waitFor(() => expect(startSyncSchedulerMock).toHaveBeenCalledTimes(1));
 
-    expect(reportOutboxBacklogOnceMock).toHaveBeenCalledTimes(1);
+    expect(recoverAndReportOutboxOnceMock).toHaveBeenCalledTimes(1);
   });
 
   it('waits for a stamped schema before reading the outbox', async () => {
@@ -405,11 +405,11 @@ describe('OfflineSyncBridge — outbox backlog gauge', () => {
     setSchemaReady(false);
     render(<Harness flags={FLAG_ON} queryClient={makeQueryClient()} />);
     await waitFor(() => expect(setupNotificationHandlersMock).toHaveBeenCalledTimes(1));
-    expect(reportOutboxBacklogOnceMock).not.toHaveBeenCalled();
+    expect(recoverAndReportOutboxOnceMock).not.toHaveBeenCalled();
 
     act(() => setSchemaReady(true));
 
-    await waitFor(() => expect(reportOutboxBacklogOnceMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(recoverAndReportOutboxOnceMock).toHaveBeenCalledTimes(1));
   });
 });
 

--- a/packages/mobile/src/components/offline-sync-bridge.tsx
+++ b/packages/mobile/src/components/offline-sync-bridge.tsx
@@ -10,7 +10,7 @@ import {
   type GraphQLFetch,
 } from '@boardsesh/offline-sync';
 import { startSyncScheduler, drainMutationQueue, startBackgroundTracking } from '../offline/offline-sync-adapter';
-import { reportOutboxBacklogOnce } from '../offline/outbox-telemetry';
+import { recoverAndReportOutboxOnce } from '../offline/outbox-telemetry';
 import { sweepDelistedDownloadTerminals } from '../offline/abandoned-download-terminals';
 import { getSetting } from '../settings';
 import { setupNotificationHandlers } from '../notifications';
@@ -150,15 +150,16 @@ export function OfflineSyncBridge() {
   // see startBackgroundTracking's doc.
   useEffect(() => startBackgroundTracking(), []);
 
-  // How much unsynced work this launch inherited. reportOutboxBacklogOnce
-  // self-guards against this effect re-running on auth changes and swallows its
-  // own errors.
+  // How much unsynced work this launch inherited — and, in the same pass, the
+  // dead letters a lost local write lock manufactured put back in the queue
+  // (#4331). recoverAndReportOutboxOnce self-guards against this effect re-running
+  // on auth changes and swallows its own errors.
   // Gated on the schema like every other db effect: pending_mutations does not
   // exist yet on a contended launch, and a gauge that throws there would report
   // no backlog rather than the backlog it could not read.
   useEffect(() => {
     if (!isAuthenticated || !schemaReady) return;
-    void reportOutboxBacklogOnce(db);
+    void recoverAndReportOutboxOnce(db);
   }, [db, isAuthenticated, schemaReady]);
 
   // Push-then-pull sync loop (foreground + reconnect triggers). Returns its own

--- a/packages/mobile/src/hooks/__tests__/use-offline-mutations.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-offline-mutations.test.ts
@@ -47,8 +47,10 @@ vi.mock('@react-native-community/netinfo', () => ({
 // The reporter itself is unit-tested in offline/__tests__/outbox-telemetry.test.ts;
 // here we prove the write primitives feed it the right enqueue outcome.
 const reportEnqueueSuppressedMock = vi.hoisted(() => vi.fn());
+const reportEnqueueRevivedMock = vi.hoisted(() => vi.fn());
 vi.mock('../../offline/outbox-telemetry', () => ({
   reportEnqueueSuppressed: reportEnqueueSuppressedMock,
+  reportEnqueueRevived: reportEnqueueRevivedMock,
 }));
 
 // The retry ladder emits one analytics event per contended write; the event's
@@ -66,7 +68,7 @@ import {
   useOfflineUnfollowUser,
   type SaveTickInput,
 } from '../use-offline-mutations';
-import { runMigrations, type GraphQLFetch } from '@boardsesh/offline-sync';
+import { getDeadLetterCount, runMigrations, type GraphQLFetch } from '@boardsesh/offline-sync';
 import { createTestDatabase, __resetDrainerStateForTests, type TestSqliteDb } from '@boardsesh/offline-sync/testing';
 
 type Row = Record<string, unknown>;
@@ -124,6 +126,7 @@ let db: TestSqliteDb;
 beforeEach(async () => {
   invalidateQueries.mockClear();
   reportEnqueueSuppressedMock.mockClear();
+  reportEnqueueRevivedMock.mockClear();
   __resetDrainerStateForTests();
   db = createTestDatabase();
   await runMigrations(db);
@@ -334,6 +337,7 @@ describe('retry ladder across every local write', () => {
     await addFavoriteLocal(withFailingTransactions(db, 1, LOCK_MESSAGE), favorite);
 
     expect(reportEnqueueSuppressedMock).not.toHaveBeenCalled();
+    expect(reportEnqueueRevivedMock).not.toHaveBeenCalled();
   });
 });
 
@@ -459,46 +463,56 @@ describe('useOfflineUnfollowUser', () => {
   });
 });
 
-// Issue #4315. `enqueue` is INSERT OR IGNORE against a UNIQUE idempotency key,
-// and the cancel DELETEs in these primitives match only status = 'pending'. So
-// once a favorite/follow key dead-letters it owns that key forever: every later
-// tap writes the local row, gets silently dropped at enqueue time, and produces
-// no queue row to drain and therefore no dead-letter event anywhere. Making the
-// swallow countable is the point; reviving the row is a separate behaviour
-// change with its own issue.
-describe('enqueue suppressed by a dead-lettered key', () => {
+// Issue #4331. `enqueue` is INSERT OR IGNORE against a UNIQUE idempotency key,
+// so a dead-lettered favorite/follow used to own that key forever: every later
+// tap wrote the local row, was dropped at enqueue time, and produced no queue
+// row to drain — the heart stayed filled and the server never heard about it.
+// These call sites now opt into `reviveDeadLetter`, and their cancel DELETEs
+// clear a dead-lettered OPPOSITE key as well as a pending one.
+describe('a dead-lettered key no longer swallows the next write', () => {
   const favorite = { boardName: 'kilter', climbUuid: 'climb-9', angle: 40 };
 
   async function deadLetterExistingRow(idempotencyKey: string) {
-    await db.runAsync("UPDATE pending_mutations SET status = 'dead_letter' WHERE idempotency_key = ?", [
-      idempotencyKey,
-    ]);
+    await db.runAsync(
+      "UPDATE pending_mutations SET status = 'dead_letter', retry_count = 3, last_error = ? WHERE idempotency_key = ?",
+      [LOCK_MESSAGE, idempotencyKey],
+    );
   }
 
-  it('reports when a favorite add is swallowed by a dead-lettered row', async () => {
+  function readRow(idempotencyKey: string) {
+    return db.getFirstAsync<Row>('SELECT * FROM pending_mutations WHERE idempotency_key = ?', [idempotencyKey]);
+  }
+
+  it('a repeat favorite add revives the row instead of vanishing', async () => {
     await addFavoriteLocal(db, favorite);
     await deadLetterExistingRow(favoriteAddKey(favorite));
     reportEnqueueSuppressedMock.mockClear();
 
     await addFavoriteLocal(db, favorite);
 
-    expect(reportEnqueueSuppressedMock).toHaveBeenCalledWith('user_favorites', 'create', 'dead_letter');
-    // The local row still exists, so the UI shows a favorite that will never sync.
+    expect(reportEnqueueRevivedMock).toHaveBeenCalledWith('user_favorites', 'create');
+    expect(reportEnqueueSuppressedMock).not.toHaveBeenCalled();
+    expect(await readRow(favoriteAddKey(favorite))).toMatchObject({
+      status: 'pending',
+      retry_count: 0,
+      last_error: null,
+    });
     const rows = await db.getAllAsync<Row>('SELECT * FROM user_favorites');
     expect(rows).toHaveLength(1);
   });
 
-  it('reports when a favorite remove is swallowed', async () => {
+  it('a repeat favorite remove revives its own key', async () => {
     await removeFavoriteLocal(db, favorite);
     await deadLetterExistingRow(favoriteRemoveKey(favorite));
     reportEnqueueSuppressedMock.mockClear();
 
     await removeFavoriteLocal(db, favorite);
 
-    expect(reportEnqueueSuppressedMock).toHaveBeenCalledWith('user_favorites', 'delete', 'dead_letter');
+    expect(reportEnqueueRevivedMock).toHaveBeenCalledWith('user_favorites', 'delete');
+    expect(await readRow(favoriteRemoveKey(favorite))).toMatchObject({ status: 'pending' });
   });
 
-  it('reports when a follow is swallowed', async () => {
+  it('a repeat follow revives its own key', async () => {
     const followUser = useOfflineFollowUser(db, parkedGraphqlFetch);
     await followUser('user-42');
     await deadLetterExistingRow('add:user_follows:user-42');
@@ -506,7 +520,39 @@ describe('enqueue suppressed by a dead-lettered key', () => {
 
     await followUser('user-42');
 
-    expect(reportEnqueueSuppressedMock).toHaveBeenCalledWith('user_follows', 'create', 'dead_letter');
+    expect(reportEnqueueRevivedMock).toHaveBeenCalledWith('user_follows', 'create');
+    expect(await readRow('add:user_follows:user-42')).toMatchObject({ status: 'pending' });
+  });
+
+  it('a repeat unfollow revives its own key', async () => {
+    const unfollowUser = useOfflineUnfollowUser(db, parkedGraphqlFetch);
+    await unfollowUser('user-42');
+    await deadLetterExistingRow('del:user_follows:user-42');
+    reportEnqueueSuppressedMock.mockClear();
+
+    await unfollowUser('user-42');
+
+    expect(reportEnqueueRevivedMock).toHaveBeenCalledWith('user_follows', 'delete');
+    expect(await readRow('del:user_follows:user-42')).toMatchObject({ status: 'pending' });
+  });
+
+  // A dead letter is not in flight, so the cancel DELETE may clear it. Leaving
+  // it behind would keep the "Sync issues" badge lit for an action the user has
+  // since reversed — and poison the key on the next toggle back.
+  it('removing a favorite clears a dead-lettered add, and adding clears a dead-lettered remove', async () => {
+    await addFavoriteLocal(db, favorite);
+    await deadLetterExistingRow(favoriteAddKey(favorite));
+
+    await removeFavoriteLocal(db, favorite);
+
+    expect(await readRow(favoriteAddKey(favorite))).toBeNull();
+    expect(await getDeadLetterCount(db)).toBe(0);
+
+    await deadLetterExistingRow(favoriteRemoveKey(favorite));
+    await addFavoriteLocal(db, favorite);
+
+    expect(await readRow(favoriteRemoveKey(favorite))).toBeNull();
+    expect(await getDeadLetterCount(db)).toBe(0);
   });
 
   it('reports a live pending duplicate as pending, not as a loss', async () => {
@@ -516,10 +562,12 @@ describe('enqueue suppressed by a dead-lettered key', () => {
     await addFavoriteLocal(db, favorite);
 
     expect(reportEnqueueSuppressedMock).toHaveBeenCalledWith('user_favorites', 'create', 'pending');
+    expect(reportEnqueueRevivedMock).not.toHaveBeenCalled();
   });
 
   it('never fires on a fresh insert', async () => {
     await addFavoriteLocal(db, favorite);
     expect(reportEnqueueSuppressedMock).not.toHaveBeenCalled();
+    expect(reportEnqueueRevivedMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/hooks/use-offline-mutations.ts
+++ b/packages/mobile/src/hooks/use-offline-mutations.ts
@@ -14,7 +14,7 @@ import {
   type SqlExecutor,
 } from '@boardsesh/offline-sync';
 import { drainMutationQueue } from '../offline/offline-sync-adapter';
-import { reportEnqueueSuppressed } from '../offline/outbox-telemetry';
+import { reportEnqueueRevived, reportEnqueueSuppressed } from '../offline/outbox-telemetry';
 import { localWriteRetryOptions } from '../offline/local-write-telemetry';
 import { takeInjectedWriteFault } from '../offline/dev/write-fault-injection';
 import type { SaveTickMutationVariables } from '../lib/graphql/operations';
@@ -143,10 +143,11 @@ export async function writeTickLocal(
         ],
       );
 
-      // No suppressed-enqueue check here, and that is a property of the key, not
-      // an oversight: every tick gets a fresh uuid, so this INSERT OR IGNORE can
-      // never collide with an existing row. A future tick key derived from
-      // climb+angle would inherit the favorites blind spot below — re-check then.
+      // No suppressed-enqueue check and no `reviveDeadLetter`, and that is a
+      // property of the key, not an oversight: every tick gets a fresh uuid, so
+      // this INSERT OR IGNORE can never collide with an existing row. A future
+      // tick key derived from climb+angle would inherit the deterministic-key
+      // handling the favorites below need — re-check then.
       await enqueue(txn, 'boardsesh_ticks', 'create', input, tickUuid);
     },
     budgetMs,
@@ -215,22 +216,28 @@ export async function addFavoriteLocal(db: OfflineDatabase, input: FavoriteInput
       [input.boardName, input.climbUuid, input.angle, ownerUserId, now, now],
     );
 
-    await txn.runAsync(`DELETE FROM pending_mutations WHERE idempotency_key = ? AND status = 'pending'`, [
-      favoriteRemoveKey(input),
-    ]);
+    // Clears a DEAD-LETTERED opposite key as well as a pending one (#4331): a
+    // dead letter is by definition not in flight, and leaving it would keep the
+    // "Sync issues" badge lit for a remove this add has just superseded — and
+    // poison the key when the user toggles back.
+    await txn.runAsync(
+      `DELETE FROM pending_mutations WHERE idempotency_key = ? AND status IN ('pending', 'dead_letter')`,
+      [favoriteRemoveKey(input)],
+    );
     // A retry re-runs this and reassigns the holder — last attempt wins, which
     // is the outcome that matters. Re-running `enqueue` against a row a previous
-    // attempt committed reports `pending`, and reportEnqueueSuppressed only
-    // fires on `dead_letter`, so a retry can never fake a suppressed-enqueue.
-    enqueueOutcome.result = await enqueue(txn, 'user_favorites', 'create', input, favoriteAddKey(input));
+    // attempt committed reports `pending`, and neither the revived nor the
+    // suppressed report fires on `pending`, so a retry can never fake either.
+    enqueueOutcome.result = await enqueue(txn, 'user_favorites', 'create', input, favoriteAddKey(input), {
+      reviveDeadLetter: true,
+    });
   });
 
-  // The cancel DELETE above matches only `status = 'pending'`, so a
-  // dead-lettered add keeps owning this UNIQUE key forever and every later add
-  // for the same climb/angle is dropped right here — local row written, nothing
-  // queued, nothing to drain. Reviving that row is a behaviour change with its
-  // own issue; this makes the swallow countable.
-  reportSuppressedEnqueue('user_favorites', 'create', enqueueOutcome);
+  // With `reviveDeadLetter`, a dead-lettered add no longer owns this UNIQUE key
+  // forever — the row is reset to pending carrying THIS add and drains normally.
+  // A suppressed report from here is now an alarm for a case that should be
+  // unreachable, not the expected outcome.
+  reportEnqueueOutcome('user_favorites', 'create', enqueueOutcome);
 }
 
 type EnqueueOutcome = { result: EnqueueResult | null };
@@ -239,9 +246,20 @@ function newEnqueueOutcome(): EnqueueOutcome {
   return { result: null };
 }
 
-function reportSuppressedEnqueue(tableName: string, operation: 'create' | 'delete', outcome: EnqueueOutcome): void {
+/**
+ * Report what the enqueue did, once the write's transaction has committed.
+ *
+ * Three outcomes, only two of which say anything: a fresh insert is the normal
+ * case, a REVIVED dead letter is a recovery worth counting (#4331), and a
+ * suppression that still happened is the alarm it always was.
+ */
+function reportEnqueueOutcome(tableName: string, operation: 'create' | 'delete', outcome: EnqueueOutcome): void {
   const { result } = outcome;
   if (result === null || result.inserted) return;
+  if (result.revived) {
+    reportEnqueueRevived(tableName, operation);
+    return;
+  }
   reportEnqueueSuppressed(tableName, operation, result.existingStatus);
 }
 
@@ -261,13 +279,18 @@ export async function removeFavoriteLocal(db: OfflineDatabase, input: FavoriteIn
     // sent (TOCTOU between peekPending and markCompleted). The server's
     // removeFavorite is an idempotent no-op when nothing exists, so the extra
     // remove is harmless in the truly-canceled case and corrective in the race.
-    await txn.runAsync(`DELETE FROM pending_mutations WHERE idempotency_key = ? AND status = 'pending'`, [
-      favoriteAddKey(input),
-    ]);
-    enqueueOutcome.result = await enqueue(txn, 'user_favorites', 'delete', input, favoriteRemoveKey(input));
+    // A dead-lettered add is cleared too (#4331) — it is not in flight, and it
+    // would otherwise outlive the favorite the user just removed.
+    await txn.runAsync(
+      `DELETE FROM pending_mutations WHERE idempotency_key = ? AND status IN ('pending', 'dead_letter')`,
+      [favoriteAddKey(input)],
+    );
+    enqueueOutcome.result = await enqueue(txn, 'user_favorites', 'delete', input, favoriteRemoveKey(input), {
+      reviveDeadLetter: true,
+    });
   });
 
-  reportSuppressedEnqueue('user_favorites', 'delete', enqueueOutcome);
+  reportEnqueueOutcome('user_favorites', 'delete', enqueueOutcome);
 }
 
 export function useOfflineFollowUser(db: OfflineDatabase, graphqlFetch: GraphQLFetch) {
@@ -290,13 +313,16 @@ export function useOfflineFollowUser(db: OfflineDatabase, graphqlFetch: GraphQLF
         // without this, offline follow→unfollow→follow leaves [add, del] in
         // the queue (the second add is INSERT OR IGNOREd away) and drains to
         // UNFOLLOWED — the opposite of the user's last action.
-        await txn.runAsync(`DELETE FROM pending_mutations WHERE idempotency_key = ? AND status = 'pending'`, [
-          `del:user_follows:${followingId}`,
-        ]);
-        enqueueOutcome.result = await enqueue(txn, 'user_follows', 'create', { followingId }, idempotencyKey);
+        await txn.runAsync(
+          `DELETE FROM pending_mutations WHERE idempotency_key = ? AND status IN ('pending', 'dead_letter')`,
+          [`del:user_follows:${followingId}`],
+        );
+        enqueueOutcome.result = await enqueue(txn, 'user_follows', 'create', { followingId }, idempotencyKey, {
+          reviveDeadLetter: true,
+        });
       });
 
-      reportSuppressedEnqueue('user_follows', 'create', enqueueOutcome);
+      reportEnqueueOutcome('user_follows', 'create', enqueueOutcome);
 
       void queryClient.invalidateQueries({ queryKey: ['followers'] });
       void queryClient.invalidateQueries({ queryKey: ['following'] });
@@ -321,13 +347,16 @@ export function useOfflineUnfollowUser(db: OfflineDatabase, graphqlFetch: GraphQ
         // Cancel a not-yet-drained follow, but ALWAYS enqueue the unfollow —
         // same TOCTOU reasoning as removeFavoriteLocal: the canceled add may
         // already be in flight, and the server unfollow is an idempotent no-op.
-        await txn.runAsync(`DELETE FROM pending_mutations WHERE idempotency_key = ? AND status = 'pending'`, [
-          `add:user_follows:${followingId}`,
-        ]);
-        enqueueOutcome.result = await enqueue(txn, 'user_follows', 'delete', { followingId }, idempotencyKey);
+        await txn.runAsync(
+          `DELETE FROM pending_mutations WHERE idempotency_key = ? AND status IN ('pending', 'dead_letter')`,
+          [`add:user_follows:${followingId}`],
+        );
+        enqueueOutcome.result = await enqueue(txn, 'user_follows', 'delete', { followingId }, idempotencyKey, {
+          reviveDeadLetter: true,
+        });
       });
 
-      reportSuppressedEnqueue('user_follows', 'delete', enqueueOutcome);
+      reportEnqueueOutcome('user_follows', 'delete', enqueueOutcome);
 
       void queryClient.invalidateQueries({ queryKey: ['followers'] });
       void queryClient.invalidateQueries({ queryKey: ['following'] });

--- a/packages/mobile/src/offline/__tests__/outbox-telemetry.test.ts
+++ b/packages/mobile/src/offline/__tests__/outbox-telemetry.test.ts
@@ -1,13 +1,24 @@
 // Issue #4315: the three offline-write losses the drainer's own telemetry can
 // never see — a backlog that predates the per-mutation events, sign-out
 // deleting the whole outbox, and an enqueue swallowed at INSERT time.
+//
+// Issue #4331 adds the launch recovery sweep that puts back the dead letters a
+// lost local write lock manufactured, plus the revived-enqueue counterpart to
+// the suppressed report.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const getOutboxSummaryMock = vi.hoisted(() => vi.fn());
+const getDeadLettersMock = vi.hoisted(() => vi.fn());
+const retryDeadLetterMock = vi.hoisted(() => vi.fn());
 vi.mock('@boardsesh/offline-sync', async () => {
   const actual = await vi.importActual<typeof import('@boardsesh/offline-sync')>('@boardsesh/offline-sync');
-  return { ...actual, getOutboxSummary: getOutboxSummaryMock };
+  return {
+    ...actual,
+    getOutboxSummary: getOutboxSummaryMock,
+    getDeadLetters: getDeadLettersMock,
+    retryDeadLetter: retryDeadLetterMock,
+  };
 });
 
 const trackMock = vi.hoisted(() => vi.fn());
@@ -19,8 +30,9 @@ vi.mock('../../lib/error-reporting', () => ({ reportHandledError: reportHandledE
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import type { SqlExecutor } from '@boardsesh/offline-sync';
 import {
-  reportOutboxBacklogOnce,
+  recoverAndReportOutboxOnce,
   reportOutboxDiscardedOnSignOut,
+  reportEnqueueRevived,
   reportEnqueueSuppressed,
   __resetOutboxTelemetryForTests,
 } from '../outbox-telemetry';
@@ -29,13 +41,35 @@ const db = {} as SqlExecutor;
 
 const emptyOutbox = { pendingCount: 0, deadLetterCount: 0, oldestPendingAt: null, oldestDeadLetterAt: null };
 
+// The lock message Android actually emits, minus the raw control byte (never put
+// one in a source file — see lock-errors.ts).
+const LOCK_ERROR =
+  "Call to function 'NativeStatement.finalizeAsync' has been rejected. → Caused by: database is locked";
+
+function deadLetterRow(id: number, lastError: string | null) {
+  return {
+    id,
+    table_name: 'user_favorites',
+    operation: 'create',
+    payload: '{}',
+    idempotency_key: `add:user_favorites:kilter:climb-${id}:40`,
+    created_at: '2026-07-20 00:00:00',
+    retry_count: 0,
+    max_retries: 10,
+    last_error: lastError,
+    status: 'dead_letter',
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   __resetOutboxTelemetryForTests();
   getOutboxSummaryMock.mockResolvedValue(emptyOutbox);
+  getDeadLettersMock.mockResolvedValue([]);
+  retryDeadLetterMock.mockResolvedValue(undefined);
 });
 
-describe('reportOutboxBacklogOnce', () => {
+describe('recoverAndReportOutboxOnce', () => {
   it('emits once with counts and ages when work is queued', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-08-12T00:00:00Z'));
@@ -46,27 +80,28 @@ describe('reportOutboxBacklogOnce', () => {
       oldestDeadLetterAt: '2026-08-02 00:00:00',
     });
 
-    await reportOutboxBacklogOnce(db);
+    await recoverAndReportOutboxOnce(db);
 
     expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineOutboxBacklogDetected, {
       pendingCount: 4,
       deadLetterCount: 1,
       oldestPendingAgeDays: 2,
       oldestDeadLetterAgeDays: 10,
+      deadLettersRevived: 0,
     });
     vi.useRealTimers();
   });
 
   it('stays silent on an empty outbox', async () => {
-    await reportOutboxBacklogOnce(db);
+    await recoverAndReportOutboxOnce(db);
     expect(trackMock).not.toHaveBeenCalled();
   });
 
   it('does not fire twice when the bridge effect re-runs', async () => {
     getOutboxSummaryMock.mockResolvedValue({ ...emptyOutbox, deadLetterCount: 2 });
 
-    await reportOutboxBacklogOnce(db);
-    await reportOutboxBacklogOnce(db);
+    await recoverAndReportOutboxOnce(db);
+    await recoverAndReportOutboxOnce(db);
 
     expect(trackMock).toHaveBeenCalledTimes(1);
     expect(getOutboxSummaryMock).toHaveBeenCalledTimes(1);
@@ -74,8 +109,78 @@ describe('reportOutboxBacklogOnce', () => {
 
   it('swallows a failed read rather than taking the sync bridge down', async () => {
     getOutboxSummaryMock.mockRejectedValue(new Error('database is locked'));
-    await expect(reportOutboxBacklogOnce(db)).resolves.toBeUndefined();
+    await expect(recoverAndReportOutboxOnce(db)).resolves.toBeUndefined();
     expect(trackMock).not.toHaveBeenCalled();
+  });
+
+  it('skips the dead-letter read entirely when nothing dead-lettered', async () => {
+    getOutboxSummaryMock.mockResolvedValue({ ...emptyOutbox, pendingCount: 3 });
+
+    await recoverAndReportOutboxOnce(db);
+
+    expect(getDeadLettersMock).not.toHaveBeenCalled();
+    expect(trackMock).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineOutboxBacklogDetected,
+      expect.objectContaining({ deadLettersRevived: 0 }),
+    );
+  });
+});
+
+// The recovery half of the fix: devices are still carrying rows a lost write
+// lock dead-lettered, some a month old, and only the ones a LOCAL lock created
+// may be re-sent — those were accepted by the server before the local DELETE
+// failed.
+describe('recoverAndReportOutboxOnce — lock-caused dead letters', () => {
+  beforeEach(() => {
+    getOutboxSummaryMock.mockResolvedValue({ ...emptyOutbox, deadLetterCount: 3 });
+  });
+
+  it('puts back every dead letter whose last error was a local lock', async () => {
+    getDeadLettersMock.mockResolvedValue([deadLetterRow(1, LOCK_ERROR), deadLetterRow(2, LOCK_ERROR)]);
+
+    await recoverAndReportOutboxOnce(db);
+
+    expect(retryDeadLetterMock).toHaveBeenCalledTimes(2);
+    expect(retryDeadLetterMock).toHaveBeenCalledWith(db, 1);
+    expect(retryDeadLetterMock).toHaveBeenCalledWith(db, 2);
+    expect(trackMock).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineOutboxBacklogDetected,
+      expect.objectContaining({ deadLetterCount: 3, deadLettersRevived: 2 }),
+    );
+  });
+
+  it.each([
+    ['a server rejection', 'Response not successful: Received status code 400'],
+    ['a validation failure', 'climb not found'],
+    ['a broken database', 'database or disk is full'],
+    ['no recorded error at all', null],
+  ])('leaves a dead letter from %s alone', async (_label, lastError) => {
+    getDeadLettersMock.mockResolvedValue([deadLetterRow(7, lastError)]);
+
+    await recoverAndReportOutboxOnce(db);
+
+    expect(retryDeadLetterMock).not.toHaveBeenCalled();
+    expect(trackMock).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineOutboxBacklogDetected,
+      expect.objectContaining({ deadLettersRevived: 0 }),
+    );
+  });
+
+  it('sweeps at most once even when the bridge effect re-runs', async () => {
+    getDeadLettersMock.mockResolvedValue([deadLetterRow(1, LOCK_ERROR)]);
+
+    await recoverAndReportOutboxOnce(db);
+    await recoverAndReportOutboxOnce(db);
+
+    expect(getDeadLettersMock).toHaveBeenCalledTimes(1);
+    expect(retryDeadLetterMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows a failed revive rather than taking the sync bridge down', async () => {
+    getDeadLettersMock.mockResolvedValue([deadLetterRow(1, LOCK_ERROR)]);
+    retryDeadLetterMock.mockRejectedValue(new Error('database is locked'));
+
+    await expect(recoverAndReportOutboxOnce(db)).resolves.toBeUndefined();
   });
 });
 
@@ -103,6 +208,18 @@ describe('reportOutboxDiscardedOnSignOut', () => {
   it('never throws, so a wedged database cannot block sign-out', async () => {
     getOutboxSummaryMock.mockRejectedValue(new Error('database is locked'));
     await expect(reportOutboxDiscardedOnSignOut(db)).resolves.toBeUndefined();
+  });
+});
+
+describe('reportEnqueueRevived', () => {
+  it('counts the recovery without raising a Sentry error', () => {
+    reportEnqueueRevived('user_favorites', 'create');
+
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineMutationRevived, {
+      tableName: 'user_favorites',
+      operation: 'create',
+    });
+    expect(reportHandledErrorMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/mobile/src/offline/__tests__/outbox-telemetry.test.ts
+++ b/packages/mobile/src/offline/__tests__/outbox-telemetry.test.ts
@@ -183,6 +183,22 @@ describe('recoverAndReportOutboxOnce — lock-caused dead letters', () => {
     await expect(recoverAndReportOutboxOnce(db)).resolves.toBeUndefined();
   });
 
+  // The ceiling is a guard against a pathological outbox, not a real limit —
+  // the fleet's worst device carries 3 dead letters. Whatever it skips is picked
+  // up by the next launch.
+  it('stops at the per-launch ceiling', async () => {
+    const manyDeadLetters = Array.from({ length: 60 }, (_unused, index) => deadLetterRow(index + 1, LOCK_ERROR));
+    getDeadLettersMock.mockResolvedValue(manyDeadLetters);
+
+    await recoverAndReportOutboxOnce(db);
+
+    expect(retryDeadLetterMock).toHaveBeenCalledTimes(50);
+    expect(trackMock).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineOutboxBacklogDetected,
+      expect.objectContaining({ deadLettersRevived: 50 }),
+    );
+  });
+
   // The sweep runs once per runtime, so one contended UPDATE aborting the loop
   // would strand every row behind it until the next launch.
   it('keeps sweeping the rows behind one that could not be revived', async () => {

--- a/packages/mobile/src/offline/__tests__/outbox-telemetry.test.ts
+++ b/packages/mobile/src/offline/__tests__/outbox-telemetry.test.ts
@@ -186,12 +186,16 @@ describe('recoverAndReportOutboxOnce — lock-caused dead letters', () => {
   // The ceiling is a guard against a pathological outbox, not a real limit —
   // the fleet's worst device carries 3 dead letters. Whatever it skips is picked
   // up by the next launch.
-  it('stops at the per-launch ceiling', async () => {
-    const manyDeadLetters = Array.from({ length: 60 }, (_unused, index) => deadLetterRow(index + 1, LOCK_ERROR));
-    getDeadLettersMock.mockResolvedValue(manyDeadLetters);
+  it('asks the query for at most a launch ceiling of rows', async () => {
+    // The LIMIT rides the SELECT, so a pathological outbox is never read into
+    // memory just to be trimmed afterwards.
+    getDeadLettersMock.mockResolvedValue(
+      Array.from({ length: 50 }, (_unused, index) => deadLetterRow(index + 1, LOCK_ERROR)),
+    );
 
     await recoverAndReportOutboxOnce(db);
 
+    expect(getDeadLettersMock).toHaveBeenCalledWith(db, 50);
     expect(retryDeadLetterMock).toHaveBeenCalledTimes(50);
     expect(trackMock).toHaveBeenCalledWith(
       SHARED_EVENTS.OfflineOutboxBacklogDetected,

--- a/packages/mobile/src/offline/__tests__/outbox-telemetry.test.ts
+++ b/packages/mobile/src/offline/__tests__/outbox-telemetry.test.ts
@@ -182,6 +182,26 @@ describe('recoverAndReportOutboxOnce — lock-caused dead letters', () => {
 
     await expect(recoverAndReportOutboxOnce(db)).resolves.toBeUndefined();
   });
+
+  // The sweep runs once per runtime, so one contended UPDATE aborting the loop
+  // would strand every row behind it until the next launch.
+  it('keeps sweeping the rows behind one that could not be revived', async () => {
+    getDeadLettersMock.mockResolvedValue([
+      deadLetterRow(1, LOCK_ERROR),
+      deadLetterRow(2, LOCK_ERROR),
+      deadLetterRow(3, LOCK_ERROR),
+    ]);
+    retryDeadLetterMock.mockRejectedValueOnce(new Error('database is locked')).mockResolvedValue(undefined);
+
+    await recoverAndReportOutboxOnce(db);
+
+    expect(retryDeadLetterMock).toHaveBeenCalledTimes(3);
+    expect(trackMock).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineOutboxBacklogDetected,
+      // Only the two that actually went back in the queue are counted.
+      expect.objectContaining({ deadLettersRevived: 2 }),
+    );
+  });
 });
 
 describe('reportOutboxDiscardedOnSignOut', () => {

--- a/packages/mobile/src/offline/outbox-telemetry.ts
+++ b/packages/mobile/src/offline/outbox-telemetry.ts
@@ -12,8 +12,19 @@
 //      idempotency key silently drops a repeat favorite/follow whenever the
 //      existing row is already a dead letter. The drop happens at enqueue time,
 //      so no drain and no dead-letter event ever mentions it.
+//
+// The launch pass also HEALS one specific kind of dead letter — see
+// `reviveLockedDeadLetters` (#4331).
 
-import { getOutboxSummary, queueTimestampAgeDays, type OutboxSummary, type SqlExecutor } from '@boardsesh/offline-sync';
+import {
+  getDeadLetters,
+  getOutboxSummary,
+  isDatabaseLockedError,
+  queueTimestampAgeDays,
+  retryDeadLetter,
+  type OutboxSummary,
+  type SqlExecutor,
+} from '@boardsesh/offline-sync';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../lib/analytics';
 import { reportHandledError } from '../lib/error-reporting';
@@ -40,17 +51,64 @@ function toGaugeProps(summary: OutboxSummary): OutboxGaugeProps {
 let hasReportedOutboxBacklog = false;
 
 /**
- * Report the outbox backlog this launch inherited, at most once per runtime and
- * only when something is actually queued. Never throws: a failed read must not
- * take the sync bridge down with it.
+ * A ceiling on the launch sweep, not a real limit: production devices carry
+ * single-digit dead letters. It only stops a pathologically large outbox from
+ * turning app launch into hundreds of UPDATEs; anything past it is picked up by
+ * the next launch.
  */
-export async function reportOutboxBacklogOnce(db: SqlExecutor): Promise<void> {
+const MAX_DEAD_LETTERS_REVIVED_PER_LAUNCH = 50;
+
+/**
+ * Put back the dead letters a lost local write lock manufactured (#4331).
+ *
+ * Until this release, a `database is locked` thrown by the drainer's outbox
+ * DELETE — the only local write in that try block, and one that runs AFTER the
+ * server has accepted the mutation — was classified non-retryable and
+ * force-dead-lettered the row. Every `Offline Mutation Dead Lettered` event in a
+ * 45-day window was one of these, with no server status attached, and the row
+ * then held its deterministic idempotency key until the user found More → Sync
+ * issues → Retry. Devices are still carrying rows up to a month old.
+ *
+ * So this re-sends ONLY writes the server never rejected: the filter is the same
+ * `isDatabaseLockedError` predicate the drainer and the write ladder use, read
+ * off the row's stored `last_error`. A dead letter from a 4xx, a validation
+ * failure, or a broken database is left exactly where it is. Every handled
+ * mutation is idempotent server-side, so a revived write that did land is a
+ * no-op.
+ */
+async function reviveLockedDeadLetters(db: SqlExecutor): Promise<number> {
+  const deadLetters = await getDeadLetters(db);
+  let revived = 0;
+  for (const row of deadLetters) {
+    if (revived >= MAX_DEAD_LETTERS_REVIVED_PER_LAUNCH) break;
+    // `last_error` is the raw driver message markDeadLetter stored; the
+    // predicate takes a string as readily as an Error.
+    if (!isDatabaseLockedError(row.last_error)) continue;
+    await retryDeadLetter(db, row.id);
+    revived += 1;
+  }
+  return revived;
+}
+
+/**
+ * Report the outbox backlog this launch inherited AND put back the dead letters
+ * a local write lock manufactured, at most once per runtime and only when
+ * something is actually queued. Never throws: neither a failed read nor a failed
+ * revive may take the sync bridge down with it.
+ *
+ * The counts on the event are read BEFORE the sweep, so they describe what the
+ * launch inherited; `deadLettersRevived` says how many of them went back into
+ * the queue. Revived rows are left for the scheduler's next drain — the same
+ * trigger that drains anything else queued at launch.
+ */
+export async function recoverAndReportOutboxOnce(db: SqlExecutor): Promise<void> {
   if (hasReportedOutboxBacklog) return;
   hasReportedOutboxBacklog = true;
   try {
     const summary = await getOutboxSummary(db);
     if (summary.pendingCount === 0 && summary.deadLetterCount === 0) return;
-    track(SHARED_EVENTS.OfflineOutboxBacklogDetected, toGaugeProps(summary));
+    const deadLettersRevived = summary.deadLetterCount === 0 ? 0 : await reviveLockedDeadLetters(db);
+    track(SHARED_EVENTS.OfflineOutboxBacklogDetected, { ...toGaugeProps(summary), deadLettersRevived });
   } catch (error) {
     if (__DEV__) console.warn('[OutboxTelemetry] backlog gauge failed:', error);
   }
@@ -73,12 +131,30 @@ export async function reportOutboxDiscardedOnSignOut(db: SqlExecutor): Promise<v
 }
 
 /**
+ * Report a repeat favorite/follow that reclaimed the idempotency key its
+ * dead-lettered predecessor was holding (#4331). A recovery, not a defect, so it
+ * gets the PostHog event and no Sentry report — the user's write is on its way.
+ */
+export function reportEnqueueRevived(tableName: string, operation: 'create' | 'delete'): void {
+  try {
+    track(SHARED_EVENTS.OfflineMutationRevived, { tableName, operation });
+  } catch (error) {
+    if (__DEV__) console.warn('[OutboxTelemetry] revived-enqueue report failed:', error);
+  }
+}
+
+/**
  * Report a repeat write that `INSERT OR IGNORE` swallowed because a
  * dead-lettered row already holds its idempotency key.
  *
  * Only the dead-letter case is reported. A suppression against a `pending` row
  * is correct dedup — a double-tapped favorite while offline — and reporting it
  * would bury the signal under the common case.
+ *
+ * Since #4331 the favorite/follow call sites revive that row instead, so this
+ * should no longer fire from them at all: it stays wired as the alarm for a
+ * revive that didn't take (and for any deterministic-key call site added later
+ * that forgets to opt in).
  */
 export function reportEnqueueSuppressed(
   tableName: string,

--- a/packages/mobile/src/offline/outbox-telemetry.ts
+++ b/packages/mobile/src/offline/outbox-telemetry.ts
@@ -84,8 +84,16 @@ async function reviveLockedDeadLetters(db: SqlExecutor): Promise<number> {
     // `last_error` is the raw driver message markDeadLetter stored; the
     // predicate takes a string as readily as an Error.
     if (!isDatabaseLockedError(row.last_error)) continue;
-    await retryDeadLetter(db, row.id);
-    revived += 1;
+    try {
+      await retryDeadLetter(db, row.id);
+      revived += 1;
+    } catch (error) {
+      // Per row, not per sweep: the failure this exists to recover from is a
+      // held write lock, and the sweep runs once per runtime — letting one
+      // contended UPDATE abort the loop would strand every row behind it until
+      // the next launch.
+      if (__DEV__) console.warn('[OutboxTelemetry] could not revive dead letter', row.id, error);
+    }
   }
   return revived;
 }

--- a/packages/mobile/src/offline/outbox-telemetry.ts
+++ b/packages/mobile/src/offline/outbox-telemetry.ts
@@ -54,7 +54,7 @@ let hasReportedOutboxBacklog = false;
  * A ceiling on the launch sweep, not a real limit: production devices carry
  * single-digit dead letters. It only stops a pathologically large outbox from
  * turning app launch into hundreds of UPDATEs; anything past it is picked up by
- * the next launch.
+ * the next launch. Applied as the SQL LIMIT, so it also bounds the read.
  */
 const MAX_DEAD_LETTERS_REVIVED_PER_LAUNCH = 50;
 
@@ -77,10 +77,11 @@ const MAX_DEAD_LETTERS_REVIVED_PER_LAUNCH = 50;
  * no-op.
  */
 async function reviveLockedDeadLetters(db: SqlExecutor): Promise<number> {
-  const deadLetters = await getDeadLetters(db);
+  // The ceiling rides the query, so a pathological outbox is never materialised
+  // just to be trimmed by the loop below.
+  const deadLetters = await getDeadLetters(db, MAX_DEAD_LETTERS_REVIVED_PER_LAUNCH);
   let revived = 0;
   for (const row of deadLetters) {
-    if (revived >= MAX_DEAD_LETTERS_REVIVED_PER_LAUNCH) break;
     // `last_error` is the raw driver message markDeadLetter stored; the
     // predicate takes a string as readily as an Error.
     if (!isDatabaseLockedError(row.last_error)) continue;

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -620,7 +620,10 @@ export const SHARED_EVENTS = {
   // launch. Per-mutation events only count from ship day, so without this every
   // backlog that accumulated earlier is invisible. Fires at most once per app
   // launch, and only when something is queued. Props: { pendingCount,
-  // deadLetterCount, oldestPendingAgeDays, oldestDeadLetterAgeDays }.
+  // deadLetterCount, oldestPendingAgeDays, oldestDeadLetterAgeDays,
+  // deadLettersRevived }. The counts are what the launch INHERITED, read before
+  // the same pass revives lock-caused dead letters (#4331); `deadLettersRevived`
+  // is how many of that `deadLetterCount` it put back in the queue.
   OfflineOutboxBacklogDetected: 'Offline Outbox Backlog Detected',
   // Offline sync — sign-out deletes the whole outbox, dead letters included, so
   // this is the size of what the user just lost. Emitted before the analytics
@@ -631,8 +634,17 @@ export const SHARED_EVENTS = {
   // dead-lettered row already owns that deterministic idempotency key
   // (favorites, follows). The user's repeat action is dropped at enqueue time,
   // so neither a drain nor a dead-letter event can ever report it. Props:
-  // { tableName, operation, existingStatus }.
+  // { tableName, operation, existingStatus }. Should now be unreachable from
+  // the favorite/follow call sites, which revive the dead letter instead
+  // (#4331) — a non-zero count there means a revive UPDATE didn't take.
   OfflineMutationEnqueueSuppressed: 'Offline Mutation Enqueue Suppressed',
+  // Offline sync — a repeat favorite/follow reclaimed the deterministic
+  // idempotency key its dead-lettered predecessor was holding: the row is back
+  // to pending, carrying the CURRENT intent, and drains normally. A recovery
+  // rather than a defect, so it carries no Sentry event. Props: { tableName,
+  // operation }. Its rate should roughly track how often those writes used to
+  // dead-letter.
+  OfflineMutationRevived: 'Offline Mutation Revived',
   // Offline sync — the FIRST attempt of a local SQLite write (tick, favorite,
   // follow) threw, so the retry ladder ran. Silent on a clean write, so its raw
   // count is the contention rate. `outcome: 'recovered'` means a later attempt

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -36,7 +36,7 @@ export {
   discardDeadLetter,
   clearAll,
 } from './mutation-queue/queue';
-export type { PendingMutation, EnqueueResult, OutboxSummary } from './mutation-queue/queue';
+export type { PendingMutation, EnqueueResult, EnqueueOptions, OutboxSummary } from './mutation-queue/queue';
 export { parseQueueTimestamp, queueTimestampAgeDays } from './mutation-queue/queue-timestamps';
 export {
   drainMutationQueue,

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer-local-lock.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/drainer-local-lock.test.ts
@@ -1,0 +1,150 @@
+// Issue #4331. The drainer's per-mutation `try` wraps the send AND the outbox
+// DELETE that follows it — and `processMutation` is the only network call in
+// there, so a SQLite `database is locked` thrown inside that try can only have
+// come from `markCompleted`, i.e. AFTER the server accepted the write. The old
+// classification resolved no HTTP status for it, called it non-retryable, and
+// force-dead-lettered the row with retry_count 0. For a favorite or a follow,
+// whose idempotency key is deterministic, that dead row then owned the key
+// forever.
+//
+// These run the REAL drainer, the REAL queue SQL and the REAL DDL through
+// node:sqlite; only the network handler is mocked, and the lock is injected by
+// making the outbox DELETE throw the production driver message.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { OfflineDatabase, QueryInvalidator, SqlRunResult, SqlValue } from '../../database';
+
+vi.mock('../handlers', () => ({
+  processMutation: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { drainMutationQueue, __resetDrainerStateForTests } from '../drainer';
+import { processMutation } from '../handlers';
+import { enqueue } from '../queue';
+import { ensureMutationQueueTable } from '../schema';
+import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
+
+const mockProcessMutation = processMutation as ReturnType<typeof vi.fn>;
+
+// The two shapes production actually reports. Android prints the SQLite result
+// code as a raw U+0005 control byte, which is built here rather than written as
+// a literal so no control byte lands in a source file (see db/lock-errors.ts).
+const ANDROID_LOCK_MESSAGE = `Call to function 'NativeStatement.finalizeAsync' has been rejected. → Caused by: Error code ${String.fromCharCode(5)}: database is locked`;
+const IOS_LOCK_MESSAGE = 'SQLiteErrorException: Error code 5: database is locked';
+
+type QueueRow = { id: number; status: string; retry_count: number; last_error: string | null };
+
+// Delegates every method rather than spreading the adapter: its methods live on
+// the prototype, so a spread would produce an object with no `runAsync` at all.
+function withFailingOutboxDelete(base: TestSqliteDb, failures: number, message: string): OfflineDatabase {
+  let remaining = failures;
+  return {
+    execAsync: (source: string) => base.execAsync(source),
+    runAsync: (source: string, ...params: SqlValue[]): Promise<SqlRunResult> => {
+      if (remaining > 0 && source.includes('DELETE FROM pending_mutations')) {
+        remaining -= 1;
+        return Promise.reject(new Error(message));
+      }
+      return base.runAsync(source, ...params);
+    },
+    getFirstAsync: <T>(source: string, ...params: SqlValue[]) => base.getFirstAsync<T>(source, ...params),
+    getAllAsync: <T>(source: string, ...params: SqlValue[]) => base.getAllAsync<T>(source, ...params),
+    withExclusiveTransactionAsync: (task) => base.withExclusiveTransactionAsync(task),
+  } as OfflineDatabase;
+}
+
+function createRecordingQueryClient(): QueryInvalidator {
+  return { invalidateQueries: vi.fn() };
+}
+
+const graphqlFetch = vi.fn().mockResolvedValue({});
+
+let db: TestSqliteDb;
+
+async function readQueue(): Promise<QueueRow[]> {
+  return db.getAllAsync<QueueRow>('SELECT id, status, retry_count, last_error FROM pending_mutations');
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  __resetDrainerStateForTests();
+  mockProcessMutation.mockResolvedValue(undefined);
+  db = createTestDatabase();
+  await ensureMutationQueueTable(db);
+  await enqueue(db, 'user_favorites', 'create', { boardName: 'kilter', climbUuid: 'c1', angle: 40 }, 'add:fav:c1:40');
+});
+
+afterEach(() => {
+  __resetDrainerStateForTests();
+});
+
+describe('a local write lock lost while clearing the outbox', () => {
+  it.each([
+    ['the Android shape', ANDROID_LOCK_MESSAGE],
+    ['the iOS shape', IOS_LOCK_MESSAGE],
+  ])('leaves the row pending and never dead-letters it — %s', async (_label, message) => {
+    const onMutationDeadLettered = vi.fn();
+    // Enough failures to outlast the local retry ladder, so the lock reaches
+    // the drainer's own classification.
+    const lockedDb = withFailingOutboxDelete(db, 10, message);
+
+    await drainMutationQueue(lockedDb, createRecordingQueryClient(), graphqlFetch, {
+      isOnline: () => true,
+      maxCycleAttempts: 0,
+      sleep: async () => {},
+      onMutationDeadLettered,
+    });
+
+    // The server has the write; the row survives to be re-sent, unmarked.
+    expect(mockProcessMutation).toHaveBeenCalledTimes(1);
+    expect(await readQueue()).toEqual([{ id: 1, status: 'pending', retry_count: 0, last_error: null }]);
+    expect(onMutationDeadLettered).not.toHaveBeenCalled();
+  });
+
+  it('completes normally when the lock clears on the retry', async () => {
+    const onMutationDeadLettered = vi.fn();
+    const lockedDb = withFailingOutboxDelete(db, 1, ANDROID_LOCK_MESSAGE);
+
+    await drainMutationQueue(lockedDb, createRecordingQueryClient(), graphqlFetch, {
+      isOnline: () => true,
+      sleep: async () => {},
+      onMutationDeadLettered,
+    });
+
+    // One send, one row cleared: the lost lock never became a queue-lifecycle
+    // decision at all.
+    expect(mockProcessMutation).toHaveBeenCalledTimes(1);
+    expect(await readQueue()).toEqual([]);
+    expect(onMutationDeadLettered).not.toHaveBeenCalled();
+  });
+
+  it('re-sends the still-pending row on the next drain', async () => {
+    const lockedDb = withFailingOutboxDelete(db, 10, ANDROID_LOCK_MESSAGE);
+    const drainOptions = { isOnline: () => true, maxCycleAttempts: 0, sleep: async () => {} };
+
+    await drainMutationQueue(lockedDb, createRecordingQueryClient(), graphqlFetch, drainOptions);
+    // The lock has cleared by the time the scheduler fires again.
+    await drainMutationQueue(db, createRecordingQueryClient(), graphqlFetch, drainOptions);
+
+    expect(mockProcessMutation).toHaveBeenCalledTimes(2);
+    expect(await readQueue()).toEqual([]);
+  });
+});
+
+describe('a genuine non-retryable failure', () => {
+  it('still dead-letters immediately, so the lock branch swallowed nothing', async () => {
+    const onMutationDeadLettered = vi.fn();
+    mockProcessMutation.mockRejectedValue(new Error('Cannot read property "climbUuid" of undefined'));
+
+    await drainMutationQueue(db, createRecordingQueryClient(), graphqlFetch, {
+      isOnline: () => true,
+      sleep: async () => {},
+      onMutationDeadLettered,
+    });
+
+    const rows = await readQueue();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('dead_letter');
+    expect(onMutationDeadLettered).toHaveBeenCalledWith(expect.objectContaining({ reason: 'non_retryable' }));
+  });
+});

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/enqueue-revive.integration.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/enqueue-revive.integration.test.ts
@@ -1,0 +1,131 @@
+// Issue #4331. `enqueue` is INSERT OR IGNORE against a UNIQUE idempotency key,
+// so a dead-lettered row used to own a deterministic key (a favorite, a follow)
+// forever: every later write for that target was dropped at INSERT time, and
+// nothing was left to drain. `reviveDeadLetter` is the escape hatch — the row
+// goes back to pending carrying the CURRENT intent.
+//
+// Run against the REAL pending_mutations DDL through node:sqlite, because the
+// whole behaviour is in what the UPDATE does to a row the engine will later read
+// back.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { enqueue, peekPending, getDeadLetterCount, markDeadLetter } from '../queue';
+import { ensureMutationQueueTable } from '../schema';
+import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
+
+const FAVORITE_KEY = 'add:user_favorites:kilter:c1:40';
+
+type QueueRow = {
+  id: number;
+  table_name: string;
+  operation: string;
+  payload: string;
+  status: string;
+  retry_count: number;
+  last_error: string | null;
+  created_at: string;
+};
+
+let db: TestSqliteDb;
+
+async function readRow(idempotencyKey: string): Promise<QueueRow | null> {
+  return db.getFirstAsync<QueueRow>('SELECT * FROM pending_mutations WHERE idempotency_key = ?', [idempotencyKey]);
+}
+
+beforeEach(async () => {
+  db = createTestDatabase();
+  await ensureMutationQueueTable(db);
+});
+
+describe('enqueue against a dead-lettered key', () => {
+  beforeEach(async () => {
+    await enqueue(db, 'user_favorites', 'create', { climbUuid: 'c1', angle: 40 }, FAVORITE_KEY);
+    const queued = await readRow(FAVORITE_KEY);
+    await markDeadLetter(db, queued!.id, 'Error code 5: database is locked');
+    // Burn a retry too, so the reset is visible rather than a coincidence.
+    await db.runAsync('UPDATE pending_mutations SET retry_count = 3 WHERE idempotency_key = ?', [FAVORITE_KEY]);
+  });
+
+  it('revives the row with the payload of the NEW write when the caller opts in', async () => {
+    const result = await enqueue(
+      db,
+      'user_favorites',
+      'create',
+      { climbUuid: 'c1', angle: 40, source: 'retap' },
+      FAVORITE_KEY,
+      { reviveDeadLetter: true },
+    );
+
+    expect(result).toEqual({ inserted: false, revived: true, existingStatus: 'dead_letter' });
+
+    const row = await readRow(FAVORITE_KEY);
+    expect(row).toMatchObject({
+      status: 'pending',
+      retry_count: 0,
+      last_error: null,
+      table_name: 'user_favorites',
+      operation: 'create',
+    });
+    // The revived row replays what the user just did, not what died.
+    expect(JSON.parse(row!.payload)).toEqual({ climbUuid: 'c1', angle: 40, source: 'retap' });
+    expect(await getDeadLetterCount(db)).toBe(0);
+  });
+
+  it('makes the revived row drainable again — the whole point', async () => {
+    expect(await peekPending(db, 10)).toHaveLength(0);
+
+    await enqueue(db, 'user_favorites', 'create', { climbUuid: 'c1', angle: 40 }, FAVORITE_KEY, {
+      reviveDeadLetter: true,
+    });
+
+    const pending = await peekPending(db, 10);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].idempotency_key).toBe(FAVORITE_KEY);
+  });
+
+  it('re-stamps created_at so FIFO order and queue-age telemetry stop reporting the weeks it spent dead', async () => {
+    await db.runAsync("UPDATE pending_mutations SET created_at = '2026-07-01 00:00:00' WHERE idempotency_key = ?", [
+      FAVORITE_KEY,
+    ]);
+
+    await enqueue(db, 'user_favorites', 'create', { climbUuid: 'c1', angle: 40 }, FAVORITE_KEY, {
+      reviveDeadLetter: true,
+    });
+
+    const row = await readRow(FAVORITE_KEY);
+    expect(row!.created_at).not.toBe('2026-07-01 00:00:00');
+  });
+
+  it('leaves the dead letter exactly as it was without the opt-in (the tick path contract)', async () => {
+    const before = await readRow(FAVORITE_KEY);
+
+    const result = await enqueue(db, 'user_favorites', 'create', { climbUuid: 'c1', angle: 99 }, FAVORITE_KEY);
+
+    expect(result).toEqual({ inserted: false, revived: false, existingStatus: 'dead_letter' });
+    expect(await readRow(FAVORITE_KEY)).toEqual(before);
+    expect(await getDeadLetterCount(db)).toBe(1);
+  });
+});
+
+describe('enqueue against a live pending row', () => {
+  it('is still plain dedup, opt-in or not — a double tap must not reset anything', async () => {
+    await enqueue(db, 'user_favorites', 'create', { climbUuid: 'c1', angle: 40 }, FAVORITE_KEY);
+    const before = await readRow(FAVORITE_KEY);
+
+    const result = await enqueue(db, 'user_favorites', 'create', { climbUuid: 'c1', angle: 99 }, FAVORITE_KEY, {
+      reviveDeadLetter: true,
+    });
+
+    expect(result).toEqual({ inserted: false, revived: false, existingStatus: 'pending' });
+    expect(await readRow(FAVORITE_KEY)).toEqual(before);
+  });
+
+  it('reports a fresh insert on a key nothing owns', async () => {
+    await expect(
+      enqueue(db, 'user_follows', 'create', { followingId: 'u-1' }, 'add:user_follows:u-1', {
+        reviveDeadLetter: true,
+      }),
+    ).resolves.toEqual({ inserted: true, revived: false, existingStatus: null });
+  });
+});

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/error-classification.test.ts
@@ -159,6 +159,38 @@ describe('isRetryable', () => {
     expect(isRetryable(new TypeError('Network request failed'))).toBe(true);
   });
 
+  // Issue #4331: a lost local write lock resolves no HTTP status, so the
+  // "no status ⇒ dead-letter" rule above used to give up on a write the server
+  // had already accepted. Contention is transient by definition.
+  describe('local SQLite write-lock contention', () => {
+    const lockShapes: [string, unknown][] = [
+      ['the iOS message', new Error('SQLiteErrorException: Error code 5: database is locked')],
+      [
+        'the Android message with a raw control byte for the code',
+        new Error(
+          `Call to function 'NativeStatement.finalizeAsync' has been rejected. → Caused by: Error code ${String.fromCharCode(5)}: database is locked`,
+        ),
+      ],
+      [
+        'a wrapped cause chain',
+        new Error('Calling the execAsync function has failed', { cause: new Error('SQLITE_BUSY') }),
+      ],
+      ['a driver code property', Object.assign(new Error('write failed'), { code: 'SQLITE_BUSY' })],
+    ];
+
+    it.each(lockShapes)('is retryable — %s', (_label, error) => {
+      expect(isRetryable(error)).toBe(true);
+    });
+
+    it('is not mistaken for a transport failure (it must not stop the drain cycle)', () => {
+      expect(isNetworkError(new Error('Error code 5: database is locked'))).toBe(false);
+    });
+
+    it('does not swallow a genuinely broken database', () => {
+      expect(isRetryable(new Error('database or disk is full'))).toBe(false);
+    });
+  });
+
   it('GraphQL error with 5xx extension is retryable', () => {
     const graphqlError = {
       errors: [{ message: 'internal', extensions: { status: 503 } }],

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/queue-fifo.integration.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/queue-fifo.integration.test.ts
@@ -78,6 +78,7 @@ describe('enqueue suppression against real SQLite', () => {
   it('reports a fresh insert', async () => {
     await expect(enqueue(db, 'user_favorites', 'create', { climbUuid: 'climb-1' }, key)).resolves.toEqual({
       inserted: true,
+      revived: false,
       existingStatus: null,
     });
   });
@@ -89,6 +90,7 @@ describe('enqueue suppression against real SQLite', () => {
 
     await expect(enqueue(db, 'user_favorites', 'create', {}, key)).resolves.toEqual({
       inserted: false,
+      revived: false,
       existingStatus: 'pending',
     });
 
@@ -105,6 +107,7 @@ describe('enqueue suppression against real SQLite', () => {
 
     await expect(enqueue(db, 'user_favorites', 'create', {}, key)).resolves.toEqual({
       inserted: false,
+      revived: false,
       existingStatus: 'dead_letter',
     });
   });

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/queue.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/queue.test.ts
@@ -101,6 +101,7 @@ describe('mutation queue', () => {
 
       await expect(enqueue(db, 'user_favorites', 'create', {}, 'add:user_favorites:kilter:abc:40')).resolves.toEqual({
         inserted: true,
+        revived: false,
         existingStatus: null,
       });
 
@@ -111,24 +112,30 @@ describe('mutation queue', () => {
       (db.runAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ changes: 0, lastInsertRowId: 0 });
       (db.getFirstAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ status: 'pending' });
 
-      await expect(enqueue(db, 'user_favorites', 'create', {}, 'add:user_favorites:kilter:abc:40')).resolves.toEqual({
+      await expect(
+        enqueue(db, 'user_favorites', 'create', {}, 'add:user_favorites:kilter:abc:40', { reviveDeadLetter: true }),
+      ).resolves.toEqual({
         inserted: false,
+        revived: false,
         existingStatus: 'pending',
       });
     });
 
-    it('reports a suppression against a dead-lettered row — the silent-loss case', async () => {
+    it('reports a suppression against a dead-lettered row when the caller does not opt into reviving', async () => {
       (db.runAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ changes: 0, lastInsertRowId: 0 });
       (db.getFirstAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ status: 'dead_letter' });
 
       await expect(enqueue(db, 'user_favorites', 'create', {}, 'add:user_favorites:kilter:abc:40')).resolves.toEqual({
         inserted: false,
+        revived: false,
         existingStatus: 'dead_letter',
       });
 
       expect(db.getFirstAsync).toHaveBeenCalledWith('SELECT status FROM pending_mutations WHERE idempotency_key = ?', [
         'add:user_favorites:kilter:abc:40',
       ]);
+      // Exactly one write: the INSERT. No revive UPDATE was attempted.
+      expect(db.runAsync).toHaveBeenCalledTimes(1);
     });
 
     it('degrades to "inserted" when the driver reports no changes count', async () => {
@@ -136,6 +143,7 @@ describe('mutation queue', () => {
 
       await expect(enqueue(db, 'boardsesh_ticks', 'create', {}, 'uuid-1')).resolves.toEqual({
         inserted: true,
+        revived: false,
         existingStatus: null,
       });
     });

--- a/packages/shared/offline-sync/src/mutation-queue/__tests__/queue.test.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/__tests__/queue.test.ts
@@ -18,6 +18,7 @@ import {
   getPendingCount,
   getDeadLetterCount,
   getOutboxSummary,
+  getDeadLetters,
   retryDeadLetter,
   discardDeadLetter,
   clearAll,
@@ -138,6 +139,22 @@ describe('mutation queue', () => {
       expect(db.runAsync).toHaveBeenCalledTimes(1);
     });
 
+    // The SELECT says dead_letter, the UPDATE matches nothing — the row's status
+    // moved in between (a concurrent drain retry, a cancel DELETE). Reporting a
+    // suppression is the right alarm: nothing was queued for this write.
+    it('reports a suppression when the revive UPDATE matches no row', async () => {
+      (db.runAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ changes: 0, lastInsertRowId: 0 });
+      (db.getFirstAsync as ReturnType<typeof vi.fn>).mockResolvedValue({ status: 'dead_letter' });
+
+      await expect(
+        enqueue(db, 'user_favorites', 'create', {}, 'add:user_favorites:kilter:abc:40', { reviveDeadLetter: true }),
+      ).resolves.toEqual({
+        inserted: false,
+        revived: false,
+        existingStatus: 'dead_letter',
+      });
+    });
+
     it('degrades to "inserted" when the driver reports no changes count', async () => {
       (db.runAsync as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
@@ -174,6 +191,14 @@ describe('mutation queue', () => {
         oldestDeadLetterAt: null,
       });
     });
+  });
+
+  it('getDeadLetters is unbounded by default and takes a LIMIT for callers that act on the rows', async () => {
+    await getDeadLetters(db);
+    expect(db.getAllAsync).toHaveBeenLastCalledWith(expect.not.stringContaining('LIMIT'));
+
+    await getDeadLetters(db, 50);
+    expect(db.getAllAsync).toHaveBeenLastCalledWith(expect.stringContaining('LIMIT ?'), [50]);
   });
 
   it('markDeadLetter sets status to dead_letter with error', async () => {

--- a/packages/shared/offline-sync/src/mutation-queue/drainer.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/drainer.ts
@@ -523,6 +523,11 @@ export async function drainMutationQueue(
             // `retryableHit` rather than an outright cycle break because a
             // snapshot import can hold the lock for minutes — the in-cycle
             // backoff degrades into the scheduler's next trigger either way.
+            // Adding another local write to this try block does NOT break the
+            // outcome, only the reasoning: a lock thrown before the send would
+            // leave the row pending and replay it, and every handler is
+            // idempotent (that is what makes the whole outbox re-drainable), so
+            // the worst case is one redundant send rather than a lost write.
             retryableHit = true;
             break;
           }

--- a/packages/shared/offline-sync/src/mutation-queue/drainer.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/drainer.ts
@@ -3,6 +3,8 @@ import type { GraphQLFetch } from './handlers';
 import { processMutation } from './handlers';
 import { peekPending, markCompleted, recordFailure, markDeadLetter } from './queue';
 import { isGraphQLEmptyResponseError, isRetryable, isNetworkError, getErrorStatus } from './error-classification';
+import { isDatabaseLockedError } from '../db/lock-errors';
+import { runLocalWriteWithRetry } from '../db/write-retry';
 import { invalidateKeysForTable } from '../sync/invalidate-keys';
 import { parseQueueTimestamp } from './queue-timestamps';
 
@@ -478,7 +480,14 @@ export async function drainMutationQueue(
             networkStop = true; // reuse the "end cycle now" path
             break;
           }
-          await markCompleted(db, mutation.id);
+          // The send has landed; this DELETE is the only thing standing between
+          // the server's acceptance and the row being cleared. Losing the
+          // single-writer lock here (a snapshot import, a VACUUM, a concurrent
+          // favorite write) is transient, so spend one short retry on it rather
+          // than letting a lost lock become a queue-lifecycle decision. The
+          // DELETE is idempotent, so a retry after an attempt that actually
+          // committed is a no-op.
+          await runLocalWriteWithRetry(() => markCompleted(db, mutation.id));
           invalidateForTable(queryClient, mutation.table_name);
           notifyMutationStatus(options, {
             tableName: mutation.table_name,
@@ -496,6 +505,24 @@ export async function drainMutationQueue(
             // without consuming the mutation's persistent retry/dead-letter
             // budget. Unlike a reachability failure, this does not require an
             // offline→online transition before another attempt can succeed.
+            retryableHit = true;
+            break;
+          }
+
+          if (isDatabaseLockedError(error)) {
+            // Local SQLite write-lock contention, and the ONLY local write
+            // inside this try is `markCompleted` — `processMutation` just calls
+            // graphqlFetch. So a lock here means the server has ALREADY ACCEPTED
+            // this write and only the local DELETE failed. Treat it exactly like
+            // the ambiguous-response case above: leave the row pending, burn no
+            // retry_count, fire no dead-letter, and re-send on the next pass —
+            // the same idempotent-resend invariant the backgrounded branch above
+            // documents. Force-dead-lettering here is what silently lost
+            // favorites and follows for weeks (#4331): the dead row then owned
+            // its deterministic idempotency key forever.
+            // `retryableHit` rather than an outright cycle break because a
+            // snapshot import can hold the lock for minutes — the in-cycle
+            // backoff degrades into the scheduler's next trigger either way.
             retryableHit = true;
             break;
           }
@@ -548,7 +575,12 @@ export async function drainMutationQueue(
             break;
           } else {
             // Non-retryable (validation / 4xx): retrying can't help, so
-            // dead-letter immediately regardless of retry_count.
+            // dead-letter immediately regardless of retry_count. Reaching here
+            // means a SERVER verdict (or a genuinely broken local write — a
+            // full disk, a corrupt file); lock contention was classified as
+            // retryable above and never lands in this branch, because for a
+            // deterministic key (favorites, follows) a dead letter owns that key
+            // until something revives it (#4331).
             await markDeadLetter(db, mutation.id, errorMessage);
             invalidateForTable(queryClient, mutation.table_name);
             notifyMutationStatus(options, {

--- a/packages/shared/offline-sync/src/mutation-queue/drainer.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/drainer.ts
@@ -487,6 +487,12 @@ export async function drainMutationQueue(
           // than letting a lost lock become a queue-lifecycle decision. The
           // DELETE is idempotent, so a retry after an attempt that actually
           // committed is a no-op.
+          // Unlike the mobile write path (#4332), this one genuinely does wait:
+          // a standalone DELETE in autocommit consults the connection's
+          // `busy_timeout` (armed on the main connection at open), because there
+          // is no read-then-upgrade inside a deferred transaction for SQLite to
+          // skip the busy handler on. So the ladder below is a second chance
+          // after a real wait, not the only one.
           await runLocalWriteWithRetry(() => markCompleted(db, mutation.id));
           invalidateForTable(queryClient, mutation.table_name);
           notifyMutationStatus(options, {

--- a/packages/shared/offline-sync/src/mutation-queue/error-classification.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/error-classification.ts
@@ -1,3 +1,5 @@
+import { isDatabaseLockedError } from '../db/lock-errors';
+
 type GraphqlErrorEntry = {
   extensions?: { code?: unknown; status?: unknown };
 };
@@ -229,6 +231,21 @@ export function isNetworkError(error: unknown): boolean {
 }
 
 export function isRetryable(error: unknown): boolean {
+  // Local SQLite write-lock contention is ALWAYS retryable. It is not a server
+  // verdict at all: another connection (a snapshot import, a VACUUM, another
+  // write) held the file for a moment, and a holder always lets go. It reaches
+  // classification because the drainer's per-mutation try wraps the local
+  // bookkeeping write as well as the send, so a lock thrown by `markCompleted`
+  // resolved no status, fell through to `return false` below, and
+  // force-dead-lettered a write the server had ALREADY accepted (#4331 — every
+  // `Offline Mutation Dead Lettered` event in a 45-day window carried
+  // `database is locked` and no server status). The drainer handles a lock
+  // ahead of this call so it doesn't burn the persistent retry budget either;
+  // this is the verdict the rest of the engine sees.
+  if (isDatabaseLockedError(error)) {
+    return true;
+  }
+
   // Network failures always retry — the request never reached the server, so
   // replaying it is safe. `isNetworkError` itself now defers to a resolved status
   // for the English-prose-only case (#4027), so this check is already

--- a/packages/shared/offline-sync/src/mutation-queue/queue.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/queue.ts
@@ -16,16 +16,40 @@ export type PendingMutation = {
 /**
  * What an enqueue actually did. `idempotency_key` is UNIQUE and the INSERT is
  * `OR IGNORE`, so a duplicate key is dropped silently — which is correct dedup
- * for a double-tapped favorite (`existingStatus: 'pending'`) but SILENT DATA
- * LOSS once the existing row is a dead letter: every later add for that
- * climb/angle is swallowed at enqueue time, so no drain runs and no
- * dead-letter event can ever fire for it. Callers that use a deterministic key
- * (favorites, follows) inspect this to report the second case.
+ * for a double-tapped favorite (`existingStatus: 'pending'`) but was SILENT
+ * DATA LOSS once the existing row was a dead letter: every later add for that
+ * climb/angle was swallowed at enqueue time, so no drain ran and no dead-letter
+ * event could ever fire for it (#4331).
+ *
+ * Callers with a deterministic key opt into `reviveDeadLetter` to take the
+ * escape hatch instead — see `EnqueueOptions`.
  */
 export type EnqueueResult = {
   inserted: boolean;
+  /**
+   * A dead-lettered row already owned this key and was reset to `pending` with
+   * the payload of THIS write. Mutually exclusive with `inserted`.
+   */
+  revived: boolean;
   /** Status of the row that won the UNIQUE key, when nothing was inserted. */
   existingStatus: string | null;
+};
+
+export type EnqueueOptions = {
+  /**
+   * When a DEAD-LETTERED row already owns this idempotency key, reset it to
+   * `pending` and overwrite it with this write instead of dropping the write.
+   *
+   * Off by default, because it is only correct for a DETERMINISTIC key, where
+   * the colliding row represents the same user intent for the same target. A
+   * per-write uuid (ticks) can never collide, so it never needs this.
+   *
+   * Opt in from EVERY deterministic-key call site. `setter_follows`,
+   * `playlist_follows` and `user_playlist_pins` have drainer handlers but no
+   * enqueue call site yet — whoever adds one MUST pass this, or that key
+   * inherits the favorites/follows blind spot the moment it dead-letters.
+   */
+  reviveDeadLetter?: boolean;
 };
 
 export async function enqueue(
@@ -34,16 +58,18 @@ export async function enqueue(
   operation: 'create' | 'update' | 'delete',
   payload: Record<string, unknown>,
   idempotencyKey: string,
+  options: EnqueueOptions = {},
 ): Promise<EnqueueResult> {
+  const serializedPayload = JSON.stringify(payload);
   const result = await db.runAsync(
     `INSERT OR IGNORE INTO pending_mutations (table_name, operation, payload, idempotency_key)
      VALUES (?, ?, ?, ?)`,
-    [tableName, operation, JSON.stringify(payload), idempotencyKey],
+    [tableName, operation, serializedPayload, idempotencyKey],
   );
   // Anything other than an explicit `changes: 0` counts as inserted. A driver
   // (or test double) that doesn't report `changes` degrades to losing the
   // suppression signal rather than inventing a data-loss report for every write.
-  if (result?.changes !== 0) return { inserted: true, existingStatus: null };
+  if (result?.changes !== 0) return { inserted: true, revived: false, existingStatus: null };
 
   // Only the suppressed path pays for the extra lookup: a single indexed hit on
   // the UNIQUE column, inside the transaction the caller already opened.
@@ -51,7 +77,28 @@ export async function enqueue(
     'SELECT status FROM pending_mutations WHERE idempotency_key = ?',
     [idempotencyKey],
   );
-  return { inserted: false, existingStatus: existing?.status ?? null };
+  const existingStatus = existing?.status ?? null;
+
+  if (!options.reviveDeadLetter || existingStatus !== 'dead_letter') {
+    return { inserted: false, revived: false, existingStatus };
+  }
+
+  // Overwrite table/operation/payload as well as the status: the revived row
+  // must replay the CURRENT intent, not the one that died (an add key revived
+  // by a later add carries the later add's payload). `created_at` is bumped so
+  // peekPending's FIFO stays honest and queue-age telemetry stops reporting the
+  // weeks the row spent dead. Guarded on `status = 'dead_letter'` so it can
+  // never touch a row a concurrent drain has in flight.
+  const revive = await db.runAsync(
+    `UPDATE pending_mutations
+     SET table_name = ?, operation = ?, payload = ?, status = 'pending',
+         retry_count = 0, last_error = NULL, created_at = datetime('now')
+     WHERE idempotency_key = ? AND status = 'dead_letter'`,
+    [tableName, operation, serializedPayload, idempotencyKey],
+  );
+  // Same defensive read as the INSERT above: a driver that reports no `changes`
+  // count degrades to "revived", matching the row state we just wrote.
+  return { inserted: false, revived: revive?.changes !== 0, existingStatus };
 }
 
 export async function peekPending(db: SqlExecutor, limit: number = 10): Promise<PendingMutation[]> {

--- a/packages/shared/offline-sync/src/mutation-queue/queue.ts
+++ b/packages/shared/offline-sync/src/mutation-queue/queue.ts
@@ -218,9 +218,21 @@ export async function getOutboxSummary(db: SqlExecutor): Promise<OutboxSummary> 
   return summary;
 }
 
-export async function getDeadLetters(db: SqlExecutor): Promise<PendingMutation[]> {
+/**
+ * `limit` is for callers that act on the rows rather than display them (the
+ * launch recovery sweep), so their ceiling is enforced by the query instead of
+ * only by the loop that walks the result. Unbounded by default: the Sync-issues
+ * screen shows the user everything they have.
+ */
+export async function getDeadLetters(db: SqlExecutor, limit?: number): Promise<PendingMutation[]> {
+  if (limit === undefined) {
+    return db.getAllAsync<PendingMutation>(
+      `SELECT * FROM pending_mutations WHERE status = 'dead_letter' ORDER BY created_at ASC`,
+    );
+  }
   return db.getAllAsync<PendingMutation>(
-    `SELECT * FROM pending_mutations WHERE status = 'dead_letter' ORDER BY created_at ASC`,
+    `SELECT * FROM pending_mutations WHERE status = 'dead_letter' ORDER BY created_at ASC LIMIT ?`,
+    [limit],
   );
 }
 


### PR DESCRIPTION
## Summary

Closes #4331.

Two defects compose into "a favorite silently never reaches the server, forever".

**1. A local SQLite lock manufactured the dead letter.** `drainMutationQueue`'s per-mutation `try` contains exactly one local write — `markCompleted`, the outbox DELETE — because `processMutation` only calls `graphqlFetch`. So a `database is locked` thrown in there means **the server already accepted the write** and only the local bookkeeping failed. It resolved no HTTP/GraphQL status, `isRetryable` returned false, and the drainer force-dead-lettered the row with `retry_count: 0`.

This is not a hypothesis. Over 90 days there are **7 `Offline Mutation Dead Lettered` events, from 7 distinct users, and all 7 carry `database is locked`** — zero carry a server status. Sentry BOARDSESH-EC has the matching shape (`status: null`, `retryCount: 0`, expo-sqlite's `NativeStatement.finalizeAsync ... database is locked`). That also settles the question #4329 deferred this fix on: there is no "rejection mix" to worry about, because there are no rejections.

**2. The dead row then owned the key forever.** `enqueue` is `INSERT OR IGNORE` against a UNIQUE `idempotency_key`, and favorite/follow keys are deterministic (`add:user_favorites:<board>:<climb>:<angle>`). The cancel DELETEs matched only `status = 'pending'`, so every later favorite for that climb wrote the local row, was dropped at enqueue time, and produced nothing to drain. The heart shows filled, so nobody re-taps — `Offline Mutation Enqueue Suppressed` has fired **zero** times since #4329 shipped. The only escape was More → Sync issues → Retry, which people are not finding: 15 distinct users report at least one dead letter at launch, the oldest 31 days old.

### What changed

- **`error-classification.ts`** — `isRetryable` now returns true for SQLite lock contention. That misclassification is the actual defect: a lock is local contention with no server verdict attached, and holders always let go.
- **`drainer.ts`** — `markCompleted` runs through the existing `runLocalWriteWithRetry` ladder (the DELETE is idempotent, so a retry after a commit-then-throw is a no-op). A lock that still escapes is handled next to the ambiguous-GraphQL-response branch: stay pending, burn no `retry_count`, fire no dead-letter, re-send next pass. `retryableHit` rather than an outright cycle break, because a snapshot import can hold the lock for minutes and the scheduler retries either way.
- **`queue.ts`** — `enqueue(..., { reviveDeadLetter: true })`: when a dead-lettered row owns the key, one UPDATE puts it back to `pending` carrying the **current** payload, `retry_count: 0`, `last_error: NULL`, fresh `created_at`. Off by default, so the tick path (fresh uuid per write, can never collide) is untouched. `EnqueueResult` gains `revived`.
- **`use-offline-mutations.ts`** — the four deterministic-key call sites (favorite add/remove, follow/unfollow) opt in, and their cancel DELETEs widen to `status IN ('pending', 'dead_letter')` so a dead letter from the opposite direction is cleared rather than left to poison the next toggle.
- **Telemetry** — new `Offline Mutation Revived` (PostHog only; a recovery, not a defect). `Offline Mutation Enqueue Suppressed` stays wired as the alarm for a case that should now be unreachable from those call sites.

### The recovery sweep, and its scope

A code-only fix leaves the ~15 users already carrying poisoned rows stuck until they happen to re-toggle that exact favorite. So once per runtime, next to the existing launch backlog gauge, the app reads its dead letters, keeps only the ones whose stored `last_error` matches `isDatabaseLockedError` — the same predicate the drainer and the write ladder use — and puts those back in the queue.

**Say it plainly: this re-sends writes the server never rejected.** That is the whole basis for it being safe, and the measurement above is the evidence: 7 of 7 dead letters in 90 days are local lock errors, none carries a server status, and every handled mutation is idempotent server-side, so a revived write that did land is a no-op.

Scope: only lock-class dead letters. A 4xx, a validation failure, a full disk, or a row with no recorded error is left exactly where it is. Bounded at 50 rows per launch — the real numbers are at most 3 dead letters per device, 73 across the whole fleet. The count rides the existing gauge as `deadLettersRevived` rather than a new event.

Steps 1–2 (stop manufacturing the dead letter) are the fix; the revive hatch and the sweep are the safety net for what already shipped. If a reviewer wants the sweep split out, say so and I'll pull it into its own PR rather than drop it.

## Release Notes

- Favorites and follows now stick. A single unlucky moment of database contention used to strand one for good — the heart stayed filled while the server never heard about it.
- Anything already stuck from that bug is sent on the next launch.

## Test plan

- `vp run test:offline-sync` — 34 files / 733 tests green, including two new suites:
  - `drainer-local-lock.test.ts` — real drainer, real queue SQL, real DDL through node:sqlite, mocking only the network handler. Both production lock shapes (Android's raw-control-byte message and the iOS one) leave the row `pending` / `retry_count 0` with no dead-letter event, a lock that clears on the retry completes the mutation, the still-pending row re-sends on the next drain, and a genuine non-retryable **still** dead-letters (proof the new branch swallowed nothing).
  - `enqueue-revive.integration.test.ts` — revive against the real DDL: payload replaced, status/retry/last_error reset, `created_at` re-stamped, row drainable again; the dead letter untouched without the opt-in; a live pending duplicate still plain dedup.
- `vp run test:mobile` — includes the rewritten `use-offline-mutations` dead-letter suite (all four call sites revive; a dead-lettered add is cleared by a remove and vice versa) and the launch-sweep tests in `outbox-telemetry.test.ts` (lock errors revived, server rejections left alone, sweeps once per runtime, never throws).
- `vp run typecheck:mobile`, `vp check`, `vp run check:mobile-bundle`.
- Not device-tested: reproducing a real `SQLITE_BUSY` on the drain path needs a snapshot import racing a drain. The lock shapes in the tests are the exact production strings from Sentry.
