### PR TITLE
fix(mobile): show that the workout shelf scrolls

### DIFF
--- a/packages/mobile/src/components/session-screen/pre-session/WorkoutTypeShelf.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/WorkoutTypeShelf.tsx
@@ -15,8 +15,9 @@ const CHART_HEIGHT = 82;
 
 // Mirrors the ScrollView's contentContainerStyle below, so the peek math
 // below accounts for exactly the padding/gap the row actually renders.
+// Exported so tests can assert against it instead of hardcoding the token.
 const SHELF_HORIZONTAL_INSET = spacing[4];
-const TILE_GAP = spacing[3];
+export const TILE_GAP = spacing[3];
 
 // Deliberately not a whole number: sizing tiles so a whole number of them
 // fills the screen edge-to-edge is what caused #4278 — on a 375pt phone the

--- a/packages/mobile/src/components/session-screen/pre-session/WorkoutTypeShelf.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/WorkoutTypeShelf.tsx
@@ -1,5 +1,5 @@
-import { memo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { memo, useMemo } from 'react';
+import { StyleSheet, useWindowDimensions, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import type { ColoredBar } from '../../you/profile-chart-colors';
 import { StackedBarChart } from '../../you/YouCharts';
@@ -11,8 +11,36 @@ import { useTheme } from '../../../providers/theme-provider';
 import { withAlpha } from '../../../theme/colors';
 import { borderRadius, spacing } from '../../../theme/tokens';
 
-const TILE_WIDTH = 168;
 const CHART_HEIGHT = 82;
+
+// Mirrors the ScrollView's contentContainerStyle below, so the peek math
+// below accounts for exactly the padding/gap the row actually renders.
+const SHELF_HORIZONTAL_INSET = spacing[4];
+const TILE_GAP = spacing[3];
+
+// Deliberately not a whole number: sizing tiles so a whole number of them
+// fills the screen edge-to-edge is what caused #4278 — on a 375pt phone the
+// old hardcoded TILE_WIDTH happened to fit exactly 2 tiles with no partial
+// tile showing, so the row looked complete even though 3 more workout types
+// were off-screen. Targeting "a bit past 2 tiles" means the row always ends
+// mid-tile on common phone widths, so the cut-off tile itself signals there's
+// more to scroll to, on top of the restored scroll indicator below.
+const VISIBLE_TILES_TARGET = 2.35;
+
+/** Pure so it can be unit tested at fixed device widths without rendering. */
+export function computeTileWidth(windowWidth: number): number {
+  const fullGapCount = Math.floor(VISIBLE_TILES_TARGET);
+  const availableWidth = windowWidth - SHELF_HORIZONTAL_INSET * 2 - TILE_GAP * fullGapCount;
+  return Math.round(availableWidth / VISIBLE_TILES_TARGET);
+}
+
+/** Tile width derived from the viewport so a partial tile always peeks at
+ *  the trailing edge, instead of a hardcoded width that only avoided a full
+ *  peek by accident on some screen sizes and not others. */
+function useTileWidth(): number {
+  const { width: windowWidth } = useWindowDimensions();
+  return useMemo(() => computeTileWidth(windowWidth), [windowWidth]);
+}
 
 export type WorkoutTypeShelfItem = {
   key: string;
@@ -29,22 +57,28 @@ type WorkoutTypeShelfProps = {
 };
 
 export const WorkoutTypeShelf = memo(function WorkoutTypeShelf({ items }: WorkoutTypeShelfProps) {
+  const tileWidth = useTileWidth();
+  const snapInterval = tileWidth + TILE_GAP;
+
   return (
     <ScrollView
       horizontal
-      showsHorizontalScrollIndicator={false}
+      showsHorizontalScrollIndicator
       contentContainerStyle={styles.content}
       keyboardShouldPersistTaps="handled"
       nestedScrollEnabled
+      snapToInterval={snapInterval}
+      snapToAlignment="start"
+      decelerationRate="fast"
     >
       {items.map((item) => (
-        <WorkoutTypeTile item={item} key={item.key} />
+        <WorkoutTypeTile item={item} key={item.key} tileWidth={tileWidth} />
       ))}
     </ScrollView>
   );
 });
 
-function WorkoutTypeTile({ item }: { item: WorkoutTypeShelfItem }) {
+function WorkoutTypeTile({ item, tileWidth }: { item: WorkoutTypeShelfItem; tileWidth: number }) {
   const { systemColors, brandColors } = useTheme();
   const selectedBackground = withAlpha(brandColors.primary, 0.08);
 
@@ -59,6 +93,7 @@ function WorkoutTypeTile({ item }: { item: WorkoutTypeShelfItem }) {
       style={[
         styles.tile,
         {
+          width: tileWidth,
           backgroundColor: item.selected ? selectedBackground : systemColors.secondaryBackground,
           borderColor: item.selected ? brandColors.primary : systemColors.separator,
         },
@@ -103,11 +138,10 @@ function WorkoutTypeTile({ item }: { item: WorkoutTypeShelfItem }) {
 
 const styles = StyleSheet.create({
   content: {
-    paddingHorizontal: spacing[4],
-    gap: spacing[3],
+    paddingHorizontal: SHELF_HORIZONTAL_INSET,
+    gap: TILE_GAP,
   },
   tile: {
-    width: TILE_WIDTH,
     borderWidth: StyleSheet.hairlineWidth,
     borderRadius: borderRadius.lg,
     paddingHorizontal: spacing[3],

--- a/packages/mobile/src/components/session-screen/pre-session/WorkoutTypeShelf.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/WorkoutTypeShelf.tsx
@@ -13,71 +13,48 @@ import { borderRadius, spacing } from '../../../theme/tokens';
 
 const CHART_HEIGHT = 82;
 
-// Mirrors the ScrollView's contentContainerStyle below, so the peek math
-// accounts for exactly the padding/gap the row actually renders.
-// Exported so tests can assert against it instead of hardcoding the token.
+// Mirrors the ScrollView's contentContainerStyle below so the peek math uses
+// the padding/gap the row actually renders. Exported for the tests.
 export const SHELF_HORIZONTAL_INSET = spacing[4];
 export const TILE_GAP = spacing[3];
 
-// Deliberately not a whole number of tiles: sizing tiles so a whole number of
-// them fills the row edge-to-edge is what caused #4278 — on a 375pt phone the
-// old hardcoded TILE_WIDTH happened to fit exactly 2 tiles with no partial tile
-// showing, so the row looked complete even though 3 more workout types were
-// off-screen. Leaving a fixed fraction of the next tile in view means the
-// cut-off tile itself signals there's more to scroll to.
+// #4278: a whole number of tiles filled a 375pt row exactly, so the shelf looked
+// complete with 3 workout types off-screen. A partial tile is the scroll cue.
 const PEEK_FRACTION = 0.35;
 
 /** Never squeeze below two whole tiles, however narrow the container gets. */
 const MIN_WHOLE_TILES = 2;
 
-/** Tiles stop growing here. The chart inside each tile is drawn for a
- *  phone-sized tile; a 480pt-wide one just stretches it. 168 is the width the
- *  shelf shipped with before #4278, which read fine on iPad — wide containers
- *  gain more tiles in view rather than bigger ones. */
+// Tiles stop growing here (the pre-#4278 width): the chart is drawn for a
+// phone-sized tile, so wide containers gain more tiles rather than bigger ones.
 export const TILE_MAX_WIDTH = 168;
 
-/** Floor for degenerate containers (a Slide Over pane, a first layout pass that
- *  reports a hairline width) so a tile never collapses to nothing. */
+// Floor for degenerate containers (Slide Over, a hairline first layout pass).
 export const TILE_MIN_WIDTH = 104;
 
-/**
- * Tile width for a shelf `containerWidth` points wide holding `itemCount` tiles.
- *
- * Only the LEADING inset sits between the viewport edge and the first tile — the
- * trailing one lives at the far end of the content, past everything the user can
- * see — so the visible row is `inset + n*(tile + gap) + peek`.
- *
- * Widens the whole-tile count until tiles stop exceeding {@link TILE_MAX_WIDTH},
- * which keeps the peek proportional at every width instead of clamping the tile
- * and letting the leftover land back on a whole number of tiles (the #4278 bug,
- * one container width over).
- *
- * Pure so it can be unit tested at fixed widths without rendering.
- */
+// Visible row is `inset + n*(tile + gap) + peek` — only the LEADING inset is on
+// screen, the trailing one sits past the end of the content.
+
 export function computeTileWidth(containerWidth: number, itemCount: number): number {
   const availableWidth = containerWidth - SHELF_HORIZONTAL_INSET;
-  // Showing every item but one as a whole tile is the widest the ladder can go
-  // and still have a tile left over to peek with.
+  // All but one item whole is the widest the ladder can go and still have a peek.
   const maxWholeTiles = Math.max(MIN_WHOLE_TILES, itemCount - 1);
 
+  // Widen the tile count, not the tile: clamping the tile instead would park the
+  // leftover back on a whole number of tiles — the #4278 bug, one width over.
   for (let wholeTiles = MIN_WHOLE_TILES; wholeTiles <= maxWholeTiles; wholeTiles += 1) {
     const tileWidth = Math.round((availableWidth - TILE_GAP * wholeTiles) / (wholeTiles + PEEK_FRACTION));
     if (tileWidth <= TILE_MAX_WIDTH) return Math.max(TILE_MIN_WIDTH, tileWidth);
   }
 
-  // Wider than `itemCount` capped tiles: every workout type is already on screen,
-  // so there is nothing hidden for a peek to advertise.
+  // Every workout type already fits, so there is nothing for a peek to advertise.
   return TILE_MAX_WIDTH;
 }
 
-/**
- * The shelf's own box, which is NOT the window: on the iPad adaptive shell it
- * renders inside `shellContent` — a flex column between the sidebar and the
- * play/wall panes (`app/(tabs)/_layout.tsx`) — so on an 11" landscape iPad the
- * window is 1194pt while the shelf gets 399. Sizing tiles off the window there
- * produced a single tile wider than the pane it lives in. The window is only the
- * first-paint estimate, used until onLayout reports the real box.
- */
+// The shelf's own box, which is NOT the window: on the iPad adaptive shell it
+// sits in `shellContent` between the sidebar and the play/wall panes, so an 11"
+// landscape iPad reports 1194 while the shelf gets 399. Window is the first-paint
+// estimate only, until onLayout reports the real box.
 function useShelfWidth(): { containerWidth: number; onLayout: (event: LayoutChangeEvent) => void } {
   const { width: windowWidth } = useWindowDimensions();
   const [measuredWidth, setMeasuredWidth] = useState<number | null>(null);

--- a/packages/mobile/src/components/session-screen/pre-session/WorkoutTypeShelf.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/WorkoutTypeShelf.tsx
@@ -1,5 +1,5 @@
-import { memo, useMemo } from 'react';
-import { StyleSheet, useWindowDimensions, View } from 'react-native';
+import { memo, useCallback, useMemo, useState } from 'react';
+import { type LayoutChangeEvent, StyleSheet, useWindowDimensions, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import type { ColoredBar } from '../../you/profile-chart-colors';
 import { StackedBarChart } from '../../you/YouCharts';
@@ -14,33 +14,81 @@ import { borderRadius, spacing } from '../../../theme/tokens';
 const CHART_HEIGHT = 82;
 
 // Mirrors the ScrollView's contentContainerStyle below, so the peek math
-// below accounts for exactly the padding/gap the row actually renders.
+// accounts for exactly the padding/gap the row actually renders.
 // Exported so tests can assert against it instead of hardcoding the token.
-const SHELF_HORIZONTAL_INSET = spacing[4];
+export const SHELF_HORIZONTAL_INSET = spacing[4];
 export const TILE_GAP = spacing[3];
 
-// Deliberately not a whole number: sizing tiles so a whole number of them
-// fills the screen edge-to-edge is what caused #4278 — on a 375pt phone the
-// old hardcoded TILE_WIDTH happened to fit exactly 2 tiles with no partial
-// tile showing, so the row looked complete even though 3 more workout types
-// were off-screen. Targeting "a bit past 2 tiles" means the row always ends
-// mid-tile on common phone widths, so the cut-off tile itself signals there's
-// more to scroll to, on top of the restored scroll indicator below.
-const VISIBLE_TILES_TARGET = 2.35;
+// Deliberately not a whole number of tiles: sizing tiles so a whole number of
+// them fills the row edge-to-edge is what caused #4278 — on a 375pt phone the
+// old hardcoded TILE_WIDTH happened to fit exactly 2 tiles with no partial tile
+// showing, so the row looked complete even though 3 more workout types were
+// off-screen. Leaving a fixed fraction of the next tile in view means the
+// cut-off tile itself signals there's more to scroll to.
+const PEEK_FRACTION = 0.35;
 
-/** Pure so it can be unit tested at fixed device widths without rendering. */
-export function computeTileWidth(windowWidth: number): number {
-  const fullGapCount = Math.floor(VISIBLE_TILES_TARGET);
-  const availableWidth = windowWidth - SHELF_HORIZONTAL_INSET * 2 - TILE_GAP * fullGapCount;
-  return Math.round(availableWidth / VISIBLE_TILES_TARGET);
+/** Never squeeze below two whole tiles, however narrow the container gets. */
+const MIN_WHOLE_TILES = 2;
+
+/** Tiles stop growing here. The chart inside each tile is drawn for a
+ *  phone-sized tile; a 480pt-wide one just stretches it. 168 is the width the
+ *  shelf shipped with before #4278, which read fine on iPad — wide containers
+ *  gain more tiles in view rather than bigger ones. */
+export const TILE_MAX_WIDTH = 168;
+
+/** Floor for degenerate containers (a Slide Over pane, a first layout pass that
+ *  reports a hairline width) so a tile never collapses to nothing. */
+export const TILE_MIN_WIDTH = 104;
+
+/**
+ * Tile width for a shelf `containerWidth` points wide holding `itemCount` tiles.
+ *
+ * Only the LEADING inset sits between the viewport edge and the first tile — the
+ * trailing one lives at the far end of the content, past everything the user can
+ * see — so the visible row is `inset + n*(tile + gap) + peek`.
+ *
+ * Widens the whole-tile count until tiles stop exceeding {@link TILE_MAX_WIDTH},
+ * which keeps the peek proportional at every width instead of clamping the tile
+ * and letting the leftover land back on a whole number of tiles (the #4278 bug,
+ * one container width over).
+ *
+ * Pure so it can be unit tested at fixed widths without rendering.
+ */
+export function computeTileWidth(containerWidth: number, itemCount: number): number {
+  const availableWidth = containerWidth - SHELF_HORIZONTAL_INSET;
+  // Showing every item but one as a whole tile is the widest the ladder can go
+  // and still have a tile left over to peek with.
+  const maxWholeTiles = Math.max(MIN_WHOLE_TILES, itemCount - 1);
+
+  for (let wholeTiles = MIN_WHOLE_TILES; wholeTiles <= maxWholeTiles; wholeTiles += 1) {
+    const tileWidth = Math.round((availableWidth - TILE_GAP * wholeTiles) / (wholeTiles + PEEK_FRACTION));
+    if (tileWidth <= TILE_MAX_WIDTH) return Math.max(TILE_MIN_WIDTH, tileWidth);
+  }
+
+  // Wider than `itemCount` capped tiles: every workout type is already on screen,
+  // so there is nothing hidden for a peek to advertise.
+  return TILE_MAX_WIDTH;
 }
 
-/** Tile width derived from the viewport so a partial tile always peeks at
- *  the trailing edge, instead of a hardcoded width that only avoided a full
- *  peek by accident on some screen sizes and not others. */
-function useTileWidth(): number {
+/**
+ * The shelf's own box, which is NOT the window: on the iPad adaptive shell it
+ * renders inside `shellContent` — a flex column between the sidebar and the
+ * play/wall panes (`app/(tabs)/_layout.tsx`) — so on an 11" landscape iPad the
+ * window is 1194pt while the shelf gets 399. Sizing tiles off the window there
+ * produced a single tile wider than the pane it lives in. The window is only the
+ * first-paint estimate, used until onLayout reports the real box.
+ */
+function useShelfWidth(): { containerWidth: number; onLayout: (event: LayoutChangeEvent) => void } {
   const { width: windowWidth } = useWindowDimensions();
-  return useMemo(() => computeTileWidth(windowWidth), [windowWidth]);
+  const [measuredWidth, setMeasuredWidth] = useState<number | null>(null);
+
+  const onLayout = useCallback((event: LayoutChangeEvent) => {
+    const { width } = event.nativeEvent.layout;
+    if (width <= 0) return;
+    setMeasuredWidth((previous) => (previous !== null && Math.abs(previous - width) < 1 ? previous : width));
+  }, []);
+
+  return { containerWidth: measuredWidth ?? windowWidth, onLayout };
 }
 
 export type WorkoutTypeShelfItem = {
@@ -58,7 +106,9 @@ type WorkoutTypeShelfProps = {
 };
 
 export const WorkoutTypeShelf = memo(function WorkoutTypeShelf({ items }: WorkoutTypeShelfProps) {
-  const tileWidth = useTileWidth();
+  const { containerWidth, onLayout } = useShelfWidth();
+  const itemCount = items.length;
+  const tileWidth = useMemo(() => computeTileWidth(containerWidth, itemCount), [containerWidth, itemCount]);
   const snapInterval = tileWidth + TILE_GAP;
 
   return (
@@ -68,6 +118,7 @@ export const WorkoutTypeShelf = memo(function WorkoutTypeShelf({ items }: Workou
       contentContainerStyle={styles.content}
       keyboardShouldPersistTaps="handled"
       nestedScrollEnabled
+      onLayout={onLayout}
       snapToInterval={snapInterval}
       snapToAlignment="start"
       decelerationRate="fast"

--- a/packages/mobile/src/components/session-screen/pre-session/WorkoutTypeShelf.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/WorkoutTypeShelf.tsx
@@ -34,7 +34,6 @@ export const TILE_MIN_WIDTH = 104;
 
 // Visible row is `inset + n*(tile + gap) + peek` — only the LEADING inset is on
 // screen, the trailing one sits past the end of the content.
-
 export function computeTileWidth(containerWidth: number, itemCount: number): number {
   const availableWidth = containerWidth - SHELF_HORIZONTAL_INSET;
   // All but one item whole is the widest the ladder can go and still have a peek.

--- a/packages/mobile/src/components/session-screen/pre-session/WorkoutTypeShelf.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/WorkoutTypeShelf.tsx
@@ -33,8 +33,8 @@ const PEEK_FRACTION = 0.35;
 // The band a peek has to land in to read as a cut-off card: under the floor it is
 // a sliver you skim past, over the ceiling it reads as another whole card and the
 // row looks finished again.
-const MIN_PEEK_FRACTION = 0.2;
-const MAX_PEEK_FRACTION = 0.5;
+export const MIN_PEEK_FRACTION = 0.2;
+export const MAX_PEEK_FRACTION = 0.5;
 
 /** Never squeeze below two whole tiles, however narrow the container gets. */
 const MIN_WHOLE_TILES = 2;

--- a/packages/mobile/src/components/session-screen/pre-session/WorkoutTypeShelf.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/WorkoutTypeShelf.tsx
@@ -1,6 +1,13 @@
-import { memo, useCallback, useMemo, useState } from 'react';
-import { type LayoutChangeEvent, StyleSheet, useWindowDimensions, View } from 'react-native';
+import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import {
+  type LayoutChangeEvent,
+  type ScrollView as RNScrollView,
+  StyleSheet,
+  useWindowDimensions,
+  View,
+} from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
+import { useFocusEffect } from 'expo-router';
 import type { ColoredBar } from '../../you/profile-chart-colors';
 import { StackedBarChart } from '../../you/YouCharts';
 import { Icon } from '../../Icon';
@@ -18,19 +25,30 @@ const CHART_HEIGHT = 82;
 export const SHELF_HORIZONTAL_INSET = spacing[4];
 export const TILE_GAP = spacing[3];
 
-// #4278: a whole number of tiles filled a 375pt row exactly, so the shelf looked
-// complete with 3 workout types off-screen. A partial tile is the scroll cue.
+// A whole number of tiles filling the row exactly is what made the shelf look
+// complete with three workout types off-screen. A partial tile is the scroll cue,
+// so the row is sized to end mid-tile.
 const PEEK_FRACTION = 0.35;
+
+// The band a peek has to land in to read as a cut-off card: under the floor it is
+// a sliver you skim past, over the ceiling it reads as another whole card and the
+// row looks finished again.
+const MIN_PEEK_FRACTION = 0.2;
+const MAX_PEEK_FRACTION = 0.5;
 
 /** Never squeeze below two whole tiles, however narrow the container gets. */
 const MIN_WHOLE_TILES = 2;
 
-// Tiles stop growing here (the pre-#4278 width): the chart is drawn for a
-// phone-sized tile, so wide containers gain more tiles rather than bigger ones.
+// Tiles stop growing here (the width the shelf shipped with): the chart is drawn
+// for a phone-sized tile, so wide containers gain more tiles, not bigger ones.
 export const TILE_MAX_WIDTH = 168;
 
 // Floor for degenerate containers (Slide Over, a hairline first layout pass).
 export const TILE_MIN_WIDTH = 104;
+
+// Long enough for the tab transition to settle — a flash fired mid-push is drawn
+// under the incoming screen and nobody sees it.
+export const INDICATOR_FLASH_DELAY_MS = 350;
 
 // Visible row is `inset + n*(tile + gap) + peek` — only the LEADING inset is on
 // screen, the trailing one sits past the end of the content.
@@ -39,14 +57,27 @@ export function computeTileWidth(containerWidth: number, itemCount: number): num
   // All but one item whole is the widest the ladder can go and still have a peek.
   const maxWholeTiles = Math.max(MIN_WHOLE_TILES, itemCount - 1);
 
-  // Widen the tile count, not the tile: clamping the tile instead would park the
-  // leftover back on a whole number of tiles — the #4278 bug, one width over.
+  // Widen the tile count, not the tile: clamping the tile at every width would
+  // park the leftover back on a whole number of tiles — the same bug, one width
+  // over.
   for (let wholeTiles = MIN_WHOLE_TILES; wholeTiles <= maxWholeTiles; wholeTiles += 1) {
     const tileWidth = Math.round((availableWidth - TILE_GAP * wholeTiles) / (wholeTiles + PEEK_FRACTION));
     if (tileWidth <= TILE_MAX_WIDTH) return Math.max(TILE_MIN_WIDTH, tileWidth);
+
+    // The ideal tile is over the cap, but where capping it already leaves a peek
+    // inside the band, capping wins: stepping up a tile buys one more column at
+    // the price of shrinking every tile. 440pt (iPhone 16 Pro Max) is the case —
+    // stepping up took tiles from 168 to 116 and the peek from 64pt down to 40.
+    const cappedPeek = availableWidth - wholeTiles * (TILE_MAX_WIDTH + TILE_GAP);
+    if (cappedPeek >= TILE_MAX_WIDTH * MIN_PEEK_FRACTION && cappedPeek <= TILE_MAX_WIDTH * MAX_PEEK_FRACTION) {
+      return TILE_MAX_WIDTH;
+    }
   }
 
-  // Every workout type already fits, so there is nothing for a peek to advertise.
+  // Past four whole tiles there is no rung left to climb — the fifth workout type
+  // is the peek. Cap the tile and let the leftover be however wide it lands: it is
+  // over half a tile on some tablet widths, which still reads as clipped, and on a
+  // container wide enough for all five the row simply doesn't scroll.
   return TILE_MAX_WIDTH;
 }
 
@@ -86,9 +117,23 @@ export const WorkoutTypeShelf = memo(function WorkoutTypeShelf({ items }: Workou
   const itemCount = items.length;
   const tileWidth = useMemo(() => computeTileWidth(containerWidth, itemCount), [containerWidth, itemCount]);
   const snapInterval = tileWidth + TILE_GAP;
+  const scrollRef = useRef<RNScrollView>(null);
+
+  // The peek only helps where the row previously ended flush; on a 430pt phone a
+  // slice of the next tile was already showing and it still read as a finished
+  // row. iOS paints the scroll indicator only during an active drag, so at rest
+  // nothing says the rail moves. Flashing it each time the screen comes forward
+  // puts the platform's own bar under the row for a beat, on every width.
+  useFocusEffect(
+    useCallback(() => {
+      const flash = setTimeout(() => scrollRef.current?.flashScrollIndicators(), INDICATOR_FLASH_DELAY_MS);
+      return () => clearTimeout(flash);
+    }, []),
+  );
 
   return (
     <ScrollView
+      ref={scrollRef}
       horizontal
       showsHorizontalScrollIndicator
       contentContainerStyle={styles.content}

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-type-shelf.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-type-shelf.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
-import { createElement, type ReactNode } from 'react';
+import { createElement, type ReactNode, type Ref } from 'react';
 import { act, render } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   computeTileWidth,
+  INDICATOR_FLASH_DELAY_MS,
   SHELF_HORIZONTAL_INSET,
   TILE_GAP,
   TILE_MAX_WIDTH,
@@ -29,6 +30,12 @@ const scrollViewProps = vi.hoisted(() => ({
   latest: null as Record<string, unknown> | null,
 }));
 
+// Stands in for the native scroll view the shelf holds a ref to, so the test can
+// see whether the shelf asked the platform to flash its indicator.
+const scrollViewInstance = vi.hoisted(() => ({
+  flashScrollIndicators: vi.fn(),
+}));
+
 vi.mock('react-native', () => ({
   View: ({ children, pointerEvents }: ViewProps) =>
     createElement('div', { 'data-pointer-events': pointerEvents ?? '' }, children),
@@ -37,11 +44,23 @@ vi.mock('react-native', () => ({
 }));
 
 vi.mock('react-native-gesture-handler', () => ({
-  ScrollView: ({ children, ...props }: { children?: ReactNode } & Record<string, unknown>) => {
+  ScrollView: ({ children, ref, ...props }: { children?: ReactNode; ref?: Ref<unknown> } & Record<string, unknown>) => {
     scrollViewProps.latest = props;
+    if (ref != null && typeof ref === 'object') ref.current = scrollViewInstance;
     return createElement('div', null, children);
   },
 }));
+
+// The real hook runs its effect every time the Record tab comes forward; in a
+// bare render there is one such moment, so a plain mount effect is the analogue.
+vi.mock('expo-router', async () => {
+  const { useEffect } = await import('react');
+  return {
+    useFocusEffect: (effect: () => void | (() => void)) => {
+      useEffect(effect, [effect]);
+    },
+  };
+});
 
 vi.mock('../../../PressableSurface', () => ({
   PressableSurface: ({ children, onPress, style }: { children?: ReactNode; onPress?: () => void; style?: unknown }) =>
@@ -85,13 +104,24 @@ vi.mock('../../../../theme/tokens', () => ({
 }));
 
 beforeEach(() => {
+  vi.useFakeTimers();
   windowDimensions.width = 375;
   scrollViewProps.latest = null;
   chartProps.latest = null;
+  scrollViewInstance.flashScrollIndicators.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 /** The five workout types the real shelf renders. */
 const WORKOUT_TYPE_COUNT = 5;
+
+// The band the component prefers when it picks a tile width; mirrored here so the
+// assertions read against a stated rule, not against whatever the formula does.
+const MIN_PEEK_FRACTION = 0.2;
+const MAX_PEEK_FRACTION = 0.5;
 
 function item(overrides?: Partial<WorkoutTypeShelfItem>): WorkoutTypeShelfItem {
   return {
@@ -203,6 +233,30 @@ describe('WorkoutTypeShelf', () => {
 
     expect(renderedTileWidth(container)).toBe(computeTileWidth(375, WORKOUT_TYPE_COUNT));
   });
+
+  // The peek is the only cue on a phone where the row already ended mid-tile
+  // before any of this, and iOS hides the indicator whenever nobody is dragging.
+  it('flashes the scroll indicator once the screen has settled', () => {
+    render(createElement(WorkoutTypeShelf, { items: workoutTypes() }));
+
+    expect(scrollViewInstance.flashScrollIndicators).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(INDICATOR_FLASH_DELAY_MS);
+    });
+
+    expect(scrollViewInstance.flashScrollIndicators).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops a pending flash when the screen goes away before it fires', () => {
+    const { unmount } = render(createElement(WorkoutTypeShelf, { items: workoutTypes() }));
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(INDICATOR_FLASH_DELAY_MS);
+    });
+
+    expect(scrollViewInstance.flashScrollIndicators).not.toHaveBeenCalled();
+  });
 });
 
 // Content is `[inset][tile][gap]…[inset]` and the viewport shows its first
@@ -255,11 +309,30 @@ describe('computeTileWidth', () => {
       return;
     }
 
-    // Something is hidden, so a slice of the next tile has to be showing: more
-    // than a gap's worth (a sliver you would miss), less than a whole tile
-    // (which is just another complete-looking row).
-    expect(peek).toBeGreaterThan(TILE_GAP);
+    // Something is hidden, so a slice of the next tile has to be showing, and it
+    // has to be a slice you read as cut off: a fifth of a tile at the least, and
+    // never a whole one — a whole one is just another complete-looking row.
+    expect(peek).toBeGreaterThanOrEqual(tileWidth * MIN_PEEK_FRACTION);
     expect(peek).toBeLessThan(tileWidth);
+  });
+
+  // 440pt is the width where "add a column instead of widening the tile" turned
+  // against itself: two 168pt tiles overshoot by 2pt, and stepping up to three
+  // shrank every tile to 116 and cut the peek from 64pt to 40.
+  it('keeps the shipped tile width where capping already leaves a readable peek', () => {
+    expect(computeTileWidth(440, WORKOUT_TYPE_COUNT)).toBe(TILE_MAX_WIDTH);
+
+    const { tileWidth, wholeTiles, peek } = shelfLayout(440, WORKOUT_TYPE_COUNT);
+    expect(wholeTiles).toBe(2);
+    expect(peek).toBeGreaterThanOrEqual(tileWidth * MIN_PEEK_FRACTION);
+    expect(peek).toBeLessThanOrEqual(tileWidth * MAX_PEEK_FRACTION);
+  });
+
+  // The other side of that trade: capping everywhere is the original bug one
+  // width over, so a container that would leave a sliver still shrinks the tile.
+  it('shrinks the tile where capping would leave the row looking flush', () => {
+    expect(computeTileWidth(380, WORKOUT_TYPE_COUNT)).toBeLessThan(TILE_MAX_WIDTH);
+    expect(computeTileWidth(376, WORKOUT_TYPE_COUNT)).toBeLessThan(TILE_MAX_WIDTH);
   });
 
   it('never lets a tile outgrow the pane it renders in', () => {

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-type-shelf.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-type-shelf.test.tsx
@@ -328,11 +328,20 @@ describe('computeTileWidth', () => {
     expect(peek).toBeLessThanOrEqual(tileWidth * MAX_PEEK_FRACTION);
   });
 
-  // The other side of that trade: capping everywhere is the original bug one
-  // width over, so a container that would leave a sliver still shrinks the tile.
-  it('shrinks the tile where capping would leave the row looking flush', () => {
-    expect(computeTileWidth(380, WORKOUT_TYPE_COUNT)).toBeLessThan(TILE_MAX_WIDTH);
-    expect(computeTileWidth(376, WORKOUT_TYPE_COUNT)).toBeLessThan(TILE_MAX_WIDTH);
+  // The other side of that trade. Capping wherever the tile overshoots is the
+  // original bug one width over: 580pt fits three capped tiles with 24pt to
+  // spare, 744pt fits four with 8pt. Both have to shrink the tile instead.
+  it.each([
+    [580, 'iPad 13" portrait content pane'],
+    [744, 'iPad mini full width'],
+  ])('shrinks the tile at %dpt (%s), where capping would leave a sliver', (containerWidth) => {
+    const cappedTiles = Math.floor((containerWidth - SHELF_HORIZONTAL_INSET) / (TILE_MAX_WIDTH + TILE_GAP));
+    const cappedPeek = containerWidth - SHELF_HORIZONTAL_INSET - cappedTiles * (TILE_MAX_WIDTH + TILE_GAP);
+    expect(cappedPeek).toBeLessThan(TILE_MAX_WIDTH * MIN_PEEK_FRACTION);
+
+    expect(computeTileWidth(containerWidth, WORKOUT_TYPE_COUNT)).toBeLessThan(TILE_MAX_WIDTH);
+    const { tileWidth, peek } = shelfLayout(containerWidth, WORKOUT_TYPE_COUNT);
+    expect(peek).toBeGreaterThanOrEqual(tileWidth * MIN_PEEK_FRACTION);
   });
 
   it('never lets a tile outgrow the pane it renders in', () => {

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-type-shelf.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-type-shelf.test.tsx
@@ -1,8 +1,16 @@
 // @vitest-environment jsdom
 import { createElement, type ReactNode } from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { computeTileWidth, TILE_GAP, WorkoutTypeShelf, type WorkoutTypeShelfItem } from '../WorkoutTypeShelf';
+import {
+  computeTileWidth,
+  SHELF_HORIZONTAL_INSET,
+  TILE_GAP,
+  TILE_MAX_WIDTH,
+  TILE_MIN_WIDTH,
+  WorkoutTypeShelf,
+  type WorkoutTypeShelfItem,
+} from '../WorkoutTypeShelf';
 
 type ViewProps = {
   children?: ReactNode;
@@ -78,7 +86,12 @@ vi.mock('../../../../theme/tokens', () => ({
 
 beforeEach(() => {
   windowDimensions.width = 375;
+  scrollViewProps.latest = null;
+  chartProps.latest = null;
 });
+
+/** The five workout types the real shelf renders. */
+const WORKOUT_TYPE_COUNT = 5;
 
 function item(overrides?: Partial<WorkoutTypeShelfItem>): WorkoutTypeShelfItem {
   return {
@@ -98,6 +111,38 @@ function item(overrides?: Partial<WorkoutTypeShelfItem>): WorkoutTypeShelfItem {
   };
 }
 
+function workoutTypes(): WorkoutTypeShelfItem[] {
+  return Array.from({ length: WORKOUT_TYPE_COUNT }, (_unused, index) =>
+    item({ key: `workout-${index}`, label: `Workout ${index}` }),
+  );
+}
+
+function widthOfTile(tile: Element): number {
+  const style = JSON.parse(tile.getAttribute('data-style') ?? 'null') as Array<Record<string, unknown>> | null;
+  if (style == null) throw new Error('tile has no style');
+  const width = style.map((entry) => entry?.width).find((candidate) => candidate != null);
+  if (typeof width !== 'number') throw new Error('tile has no numeric width');
+  return width;
+}
+
+/** Width the component actually put on a rendered tile, read back out of the
+ *  style the tile hands to PressableSurface. */
+function renderedTileWidth(container: HTMLElement): number {
+  const tile = container.querySelector('button');
+  if (tile == null) throw new Error('no tile rendered');
+  return widthOfTile(tile);
+}
+
+/** Report the container's measured width to the shelf, the way onLayout does. */
+function measureShelf(width: number): void {
+  const onLayout = scrollViewProps.latest?.onLayout;
+  if (typeof onLayout !== 'function') throw new Error('shelf does not measure its container');
+  const notifyLayout = onLayout as (event: { nativeEvent: { layout: { width: number; height: number } } }) => void;
+  act(() => {
+    notifyLayout({ nativeEvent: { layout: { width, height: 140 } } });
+  });
+}
+
 describe('WorkoutTypeShelf', () => {
   it('lets chart touches pass through to the tile press target', () => {
     const { getByTestId } = render(createElement(WorkoutTypeShelf, { items: [item()] }));
@@ -115,35 +160,121 @@ describe('WorkoutTypeShelf', () => {
   });
 
   it('snaps to tile boundaries', () => {
-    render(createElement(WorkoutTypeShelf, { items: [item()] }));
+    render(createElement(WorkoutTypeShelf, { items: workoutTypes() }));
 
-    const expectedTileWidth = computeTileWidth(375);
+    const expectedTileWidth = computeTileWidth(375, WORKOUT_TYPE_COUNT);
     expect(scrollViewProps.latest?.snapToInterval).toBe(expectedTileWidth + TILE_GAP);
     expect(scrollViewProps.latest?.snapToAlignment).toBe('start');
     expect(scrollViewProps.latest?.decelerationRate).toBe('fast');
   });
+
+  it('puts the computed width on every rendered tile', () => {
+    const { container } = render(createElement(WorkoutTypeShelf, { items: workoutTypes() }));
+
+    const expectedTileWidth = computeTileWidth(375, WORKOUT_TYPE_COUNT);
+    const widths = Array.from(container.querySelectorAll('button')).map(widthOfTile);
+
+    expect(widths).toEqual(Array.from({ length: WORKOUT_TYPE_COUNT }, () => expectedTileWidth));
+  });
+
+  // The regression this guards: the shelf renders inside `shellContent` on the
+  // iPad adaptive shell, a pane far narrower than the window. Sizing off
+  // useWindowDimensions() there made a single tile wider than the whole pane.
+  it('sizes tiles from the measured container, not the window', () => {
+    windowDimensions.width = 1194; // iPad 11" landscape
+    const { container } = render(createElement(WorkoutTypeShelf, { items: workoutTypes() }));
+
+    const paneWidth = 399; // shellContent, between the sidebar and the play/wall panes
+    measureShelf(paneWidth);
+
+    expect(renderedTileWidth(container)).toBe(computeTileWidth(paneWidth, WORKOUT_TYPE_COUNT));
+    expect(renderedTileWidth(container)).not.toBe(computeTileWidth(1194, WORKOUT_TYPE_COUNT));
+    expect(renderedTileWidth(container)).toBeLessThan(paneWidth);
+  });
+
+  it('falls back to the window width until the container reports its box', () => {
+    windowDimensions.width = 390;
+    const { container } = render(createElement(WorkoutTypeShelf, { items: workoutTypes() }));
+
+    expect(renderedTileWidth(container)).toBe(computeTileWidth(390, WORKOUT_TYPE_COUNT));
+  });
+
+  it('ignores a zero-width layout pass instead of collapsing the tiles', () => {
+    const { container } = render(createElement(WorkoutTypeShelf, { items: workoutTypes() }));
+    measureShelf(0);
+
+    expect(renderedTileWidth(container)).toBe(computeTileWidth(375, WORKOUT_TYPE_COUNT));
+  });
 });
 
+/**
+ * What the row actually puts on screen at rest. Content is laid out as
+ * `[inset][tile][gap][tile][gap]…[inset]`, and the viewport shows the first
+ * `containerWidth` points of it — so only the LEADING inset is on screen, and
+ * the peek is whatever of the next tile is left after the whole ones.
+ */
+function shelfLayout(containerWidth: number, itemCount: number) {
+  const tileWidth = computeTileWidth(containerWidth, itemCount);
+  const pitch = tileWidth + TILE_GAP;
+  const contentWidth = SHELF_HORIZONTAL_INSET * 2 + itemCount * tileWidth + (itemCount - 1) * TILE_GAP;
+  const wholeTiles = Math.min(itemCount, Math.floor((containerWidth - SHELF_HORIZONTAL_INSET + TILE_GAP) / pitch));
+
+  return {
+    tileWidth,
+    wholeTiles,
+    peek: containerWidth - (SHELF_HORIZONTAL_INSET + wholeTiles * pitch),
+    scrolls: contentWidth > containerWidth,
+  };
+}
+
 describe('computeTileWidth', () => {
-  // A whole number of tiles fitting the screen exactly is what caused #4278:
-  // the row looked "done" with no visual cue that 3 more workout types were
-  // off-screen. These sizes must always leave a partial tile peeking.
+  // A whole number of tiles filling the row exactly is what caused #4278: the row
+  // looked "done" with no cue that more workout types were off-screen. Phones,
+  // the iPad panes (`shellContent`, between the sidebar and the play/wall
+  // columns) and full-width tablet/desktop windows all have to leave a partial
+  // tile peeking whenever something is hidden.
   it.each([
-    [375, 136], // iPhone SE / mini-width devices
-    [390, 142], // iPhone 14/15/16
-    [430, 159], // iPhone 16 Pro Max
-  ])('leaves a partial tile peeking at %dpt wide (tile width %dpx)', (windowWidth, expectedTileWidth) => {
-    const tileWidth = computeTileWidth(windowWidth);
-    expect(tileWidth).toBe(expectedTileWidth);
+    [320, 'iPad Slide Over / small split'],
+    [375, 'iPhone SE / mini'],
+    [390, 'iPhone 14/15/16'],
+    [430, 'iPhone 16 Pro Max'],
+    [440, 'just past two max-width tiles'],
+    [399, 'iPad 11" landscape content pane'],
+    [418, 'iPad 11" portrait content pane'],
+    [485, 'iPad 13" landscape content pane'],
+    [580, 'iPad 13" portrait content pane'],
+    [648, 'iPad mini portrait content pane'],
+    [744, 'iPad mini full width'],
+    [834, 'iPad 11" portrait full width'],
+    [1024, 'iPad 13" portrait full width'],
+    [1194, 'iPad 11" landscape full width'],
+    [1366, 'iPad 13" landscape full width / desktop browser'],
+  ])('keeps tiles sane and the peek visible at %dpt (%s)', (containerWidth) => {
+    const { tileWidth, wholeTiles, peek, scrolls } = shelfLayout(containerWidth, WORKOUT_TYPE_COUNT);
 
-    const horizontalInset = 16;
-    const contentWidth = windowWidth - horizontalInset * 2;
-    const twoTilesAndOneGap = tileWidth * 2 + TILE_GAP;
-    const peek = contentWidth - twoTilesAndOneGap;
+    // A tile has to fit the box it renders in, and must not stretch its chart.
+    expect(tileWidth).toBeLessThanOrEqual(TILE_MAX_WIDTH);
+    expect(tileWidth).toBeGreaterThanOrEqual(TILE_MIN_WIDTH);
+    expect(tileWidth).toBeLessThan(containerWidth);
+    expect(wholeTiles).toBeGreaterThanOrEqual(2);
 
-    // A peek must be visible (not zero/negative) and must be less than a
-    // full tile (otherwise it's just a 3rd whole tile, reproducing the bug).
-    expect(peek).toBeGreaterThan(0);
+    if (!scrolls) {
+      // Every workout type is already on screen — nothing for a peek to advertise.
+      expect(wholeTiles).toBe(WORKOUT_TYPE_COUNT);
+      return;
+    }
+
+    // Something is hidden, so a slice of the next tile has to be showing: more
+    // than a gap's worth (a sliver you would miss), less than a whole tile
+    // (which is just another complete-looking row).
+    expect(peek).toBeGreaterThan(TILE_GAP);
     expect(peek).toBeLessThan(tileWidth);
+  });
+
+  it('never lets a tile outgrow the pane it renders in', () => {
+    // 1194pt window, 399pt pane: deriving the width from the window gave 484 —
+    // wider than the pane itself, one clipped tile and no peek at all.
+    expect(computeTileWidth(399, WORKOUT_TYPE_COUNT)).toBeLessThan(399);
+    expect(computeTileWidth(485, WORKOUT_TYPE_COUNT)).toBeLessThan(485);
   });
 });

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-type-shelf.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-type-shelf.test.tsx
@@ -125,8 +125,7 @@ function widthOfTile(tile: Element): number {
   return width;
 }
 
-/** Width the component actually put on a rendered tile, read back out of the
- *  style the tile hands to PressableSurface. */
+/** Width the component put on a rendered tile, read back off its style. */
 function renderedTileWidth(container: HTMLElement): number {
   const tile = container.querySelector('button');
   if (tile == null) throw new Error('no tile rendered');
@@ -177,9 +176,8 @@ describe('WorkoutTypeShelf', () => {
     expect(widths).toEqual(Array.from({ length: WORKOUT_TYPE_COUNT }, () => expectedTileWidth));
   });
 
-  // The regression this guards: the shelf renders inside `shellContent` on the
-  // iPad adaptive shell, a pane far narrower than the window. Sizing off
-  // useWindowDimensions() there made a single tile wider than the whole pane.
+  // Guards the iPad regression: `shellContent` is far narrower than the window,
+  // so sizing off useWindowDimensions() made a tile wider than the whole pane.
   it('sizes tiles from the measured container, not the window', () => {
     windowDimensions.width = 1194; // iPad 11" landscape
     const { container } = render(createElement(WorkoutTypeShelf, { items: workoutTypes() }));
@@ -207,12 +205,8 @@ describe('WorkoutTypeShelf', () => {
   });
 });
 
-/**
- * What the row actually puts on screen at rest. Content is laid out as
- * `[inset][tile][gap][tile][gap]…[inset]`, and the viewport shows the first
- * `containerWidth` points of it — so only the LEADING inset is on screen, and
- * the peek is whatever of the next tile is left after the whole ones.
- */
+// Content is `[inset][tile][gap]…[inset]` and the viewport shows its first
+// `containerWidth` points, so only the leading inset counts against the peek.
 function shelfLayout(containerWidth: number, itemCount: number) {
   const tileWidth = computeTileWidth(containerWidth, itemCount);
   const pitch = tileWidth + TILE_GAP;
@@ -228,11 +222,8 @@ function shelfLayout(containerWidth: number, itemCount: number) {
 }
 
 describe('computeTileWidth', () => {
-  // A whole number of tiles filling the row exactly is what caused #4278: the row
-  // looked "done" with no cue that more workout types were off-screen. Phones,
-  // the iPad panes (`shellContent`, between the sidebar and the play/wall
-  // columns) and full-width tablet/desktop windows all have to leave a partial
-  // tile peeking whenever something is hidden.
+  // #4278 was a row of whole tiles that looked "done" with more off-screen.
+  // Phones, the iPad `shellContent` panes and full-width tablets all need a peek.
   it.each([
     [320, 'iPad Slide Over / small split'],
     [375, 'iPhone SE / mini'],

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-type-shelf.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-type-shelf.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import { createElement, type ReactNode } from 'react';
 import { render } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
-import { computeTileWidth, WorkoutTypeShelf, type WorkoutTypeShelfItem } from '../WorkoutTypeShelf';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computeTileWidth, TILE_GAP, WorkoutTypeShelf, type WorkoutTypeShelfItem } from '../WorkoutTypeShelf';
 
 type ViewProps = {
   children?: ReactNode;
@@ -76,6 +76,10 @@ vi.mock('../../../../theme/tokens', () => ({
   borderRadius: { md: 8, lg: 12 },
 }));
 
+beforeEach(() => {
+  windowDimensions.width = 375;
+});
+
 function item(overrides?: Partial<WorkoutTypeShelfItem>): WorkoutTypeShelfItem {
   return {
     key: 'volume',
@@ -111,11 +115,10 @@ describe('WorkoutTypeShelf', () => {
   });
 
   it('snaps to tile boundaries', () => {
-    windowDimensions.width = 375;
     render(createElement(WorkoutTypeShelf, { items: [item()] }));
 
     const expectedTileWidth = computeTileWidth(375);
-    expect(scrollViewProps.latest?.snapToInterval).toBe(expectedTileWidth + 12);
+    expect(scrollViewProps.latest?.snapToInterval).toBe(expectedTileWidth + TILE_GAP);
     expect(scrollViewProps.latest?.snapToAlignment).toBe('start');
     expect(scrollViewProps.latest?.decelerationRate).toBe('fast');
   });
@@ -134,9 +137,8 @@ describe('computeTileWidth', () => {
     expect(tileWidth).toBe(expectedTileWidth);
 
     const horizontalInset = 16;
-    const tileGap = 12;
     const contentWidth = windowWidth - horizontalInset * 2;
-    const twoTilesAndOneGap = tileWidth * 2 + tileGap;
+    const twoTilesAndOneGap = tileWidth * 2 + TILE_GAP;
     const peek = contentWidth - twoTilesAndOneGap;
 
     // A peek must be visible (not zero/negative) and must be less than a

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-type-shelf.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-type-shelf.test.tsx
@@ -2,7 +2,7 @@
 import { createElement, type ReactNode } from 'react';
 import { render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { WorkoutTypeShelf, type WorkoutTypeShelfItem } from '../WorkoutTypeShelf';
+import { computeTileWidth, WorkoutTypeShelf, type WorkoutTypeShelfItem } from '../WorkoutTypeShelf';
 
 type ViewProps = {
   children?: ReactNode;
@@ -13,19 +13,31 @@ const chartProps = vi.hoisted(() => ({
   latest: null as Record<string, unknown> | null,
 }));
 
+const windowDimensions = vi.hoisted(() => ({
+  width: 375,
+}));
+
+const scrollViewProps = vi.hoisted(() => ({
+  latest: null as Record<string, unknown> | null,
+}));
+
 vi.mock('react-native', () => ({
   View: ({ children, pointerEvents }: ViewProps) =>
     createElement('div', { 'data-pointer-events': pointerEvents ?? '' }, children),
   StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  useWindowDimensions: () => ({ width: windowDimensions.width, height: 800 }),
 }));
 
 vi.mock('react-native-gesture-handler', () => ({
-  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  ScrollView: ({ children, ...props }: { children?: ReactNode } & Record<string, unknown>) => {
+    scrollViewProps.latest = props;
+    return createElement('div', null, children);
+  },
 }));
 
 vi.mock('../../../PressableSurface', () => ({
-  PressableSurface: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
-    createElement('button', { onClick: onPress }, children),
+  PressableSurface: ({ children, onPress, style }: { children?: ReactNode; onPress?: () => void; style?: unknown }) =>
+    createElement('button', { onClick: onPress, 'data-style': JSON.stringify(style) }, children),
 }));
 
 vi.mock('../../../Text', () => ({
@@ -90,5 +102,46 @@ describe('WorkoutTypeShelf', () => {
     expect(chartProps.latest?.fitYAxisToData).toBe(true);
     expect(chartProps.latest?.interactive).toBe(false);
     expect(chartProps.latest?.zoomable).toBe(false);
+  });
+
+  it('restores the platform scroll indicator so the row signals it scrolls', () => {
+    render(createElement(WorkoutTypeShelf, { items: [item()] }));
+
+    expect(scrollViewProps.latest?.showsHorizontalScrollIndicator).toBe(true);
+  });
+
+  it('snaps to tile boundaries', () => {
+    windowDimensions.width = 375;
+    render(createElement(WorkoutTypeShelf, { items: [item()] }));
+
+    const expectedTileWidth = computeTileWidth(375);
+    expect(scrollViewProps.latest?.snapToInterval).toBe(expectedTileWidth + 12);
+    expect(scrollViewProps.latest?.snapToAlignment).toBe('start');
+    expect(scrollViewProps.latest?.decelerationRate).toBe('fast');
+  });
+});
+
+describe('computeTileWidth', () => {
+  // A whole number of tiles fitting the screen exactly is what caused #4278:
+  // the row looked "done" with no visual cue that 3 more workout types were
+  // off-screen. These sizes must always leave a partial tile peeking.
+  it.each([
+    [375, 136], // iPhone SE / mini-width devices
+    [390, 142], // iPhone 14/15/16
+    [430, 159], // iPhone 16 Pro Max
+  ])('leaves a partial tile peeking at %dpt wide (tile width %dpx)', (windowWidth, expectedTileWidth) => {
+    const tileWidth = computeTileWidth(windowWidth);
+    expect(tileWidth).toBe(expectedTileWidth);
+
+    const horizontalInset = 16;
+    const tileGap = 12;
+    const contentWidth = windowWidth - horizontalInset * 2;
+    const twoTilesAndOneGap = tileWidth * 2 + tileGap;
+    const peek = contentWidth - twoTilesAndOneGap;
+
+    // A peek must be visible (not zero/negative) and must be less than a
+    // full tile (otherwise it's just a 3rd whole tile, reproducing the bug).
+    expect(peek).toBeGreaterThan(0);
+    expect(peek).toBeLessThan(tileWidth);
   });
 });

--- a/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-type-shelf.test.tsx
+++ b/packages/mobile/src/components/session-screen/pre-session/__tests__/workout-type-shelf.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   computeTileWidth,
   INDICATOR_FLASH_DELAY_MS,
+  MAX_PEEK_FRACTION,
+  MIN_PEEK_FRACTION,
   SHELF_HORIZONTAL_INSET,
   TILE_GAP,
   TILE_MAX_WIDTH,
@@ -117,11 +119,6 @@ afterEach(() => {
 
 /** The five workout types the real shelf renders. */
 const WORKOUT_TYPE_COUNT = 5;
-
-// The band the component prefers when it picks a tile width; mirrored here so the
-// assertions read against a stated rule, not against whatever the formula does.
-const MIN_PEEK_FRACTION = 0.2;
-const MAX_PEEK_FRACTION = 0.5;
 
 function item(overrides?: Partial<WorkoutTypeShelfItem>): WorkoutTypeShelfItem {
   return {


### PR DESCRIPTION
## Summary

The pre-session workout shelf (`WorkoutTypeShelf`) hid the fact that it scrolls. On the reporter's 375pt device a hardcoded `TILE_WIDTH = 168` fit tiles edge-to-edge with no partial tile in view (tile 3 started at x=376, 1pt off-screen), and `showsHorizontalScrollIndicator={false}` disabled the platform's own "more content" cue. It took the reporter three sessions to find the other workout types.

- Tile width is derived from the shelf's **own measured container**, sized so a fraction of the next tile stays in view. The row ends mid-tile, and that cut-off tile is the affordance.
- The rail **flashes its scroll indicator** when the Record screen comes forward. iOS paints the indicator only during an active drag, so at rest a rail that scrolls looked exactly like one that doesn't — on wide phones that was the *only* thing left to change (see below).
- `snapToInterval` / `snapToAlignment="start"` / `decelerationRate="fast"` settle the rail on tile boundaries instead of leaving a tile straddling the edge after a fling.
- Kept the `ScrollView` (5 static tiles, no virtualization needed) and left `GeneratorPickerCard`'s shelf logic, the chart rendering and tile content untouched.

### Why QA saw no change on `e77380e`

The geometry fix only moves anything where the row previously ended flush. It didn't on the tester's phone:

| Device width | Before: tile / peek | After `e77380e`: tile / peek |
|---|---|---|
| 375 (SE, mini, iPhone X–11 Pro) | 168 / **0** | 143 / 49 |
| 390 (14, 15, 16) | 168 / 14 | 149 / 52 |
| 402 (16 Pro) | 168 / 26 | 154 / 54 |
| **430 (14 Pro Max, 15 Plus, 16 Plus)** | **168 / 54** | **166 / 58** |

At 430pt a 54pt slice of the next tile was already showing before this PR, and the row still read as finished — which is the reporter's whole complaint. Two points of tile and four of peek is not a visible difference, so "I don't see any change?" was accurate on that hardware.

The indicator flash is the part that lands on every width. It's the platform's own affordance and it's visible at rest-time-zero rather than only mid-drag.

### The 440pt tile cliff

440pt (iPhone 16 Pro Max) also had a regression of its own: two 168pt tiles overshoot the cap by 2pt, so the ladder stepped up to three tiles — shrinking every tile from 168 to 116 and *cutting* the peek from 64pt to 40. Capping now wins whenever the leftover already lands in the peek band (a fifth to a half of a tile). The ladder still shrinks the tile where capping would leave a sliver: 580pt fits three capped tiles with 24pt to spare, 744pt fits four with 8pt, and both still shrink.

### Why the container and not the window

An earlier revision read `useWindowDimensions()`. That's wrong on the iPad adaptive shell, where the shelf renders inside `shellContent` — a flex column between `TabletSidebar`, `IpadPlayPane` and `IpadWallColumn` (`app/(tabs)/_layout.tsx`). On an 11" landscape iPad the window is 1194pt while the shelf gets 399, and the window-derived tile came out **484pt — wider than the pane it lives in**. The shelf measures itself with `onLayout` and only falls back to the window for the first paint.

### How the width is picked

Visible row at rest is `leadingInset + n*(tile + gap) + peek` — only the leading 16pt inset is on screen; the trailing one sits at the far end of the content.

`tile = round((containerWidth - 16 - n*12) / (n + 0.35))`, with `n` (whole tiles in view) raised from 2 until the tile stops exceeding `TILE_MAX_WIDTH = 168` — the width the shelf shipped with. So wide surfaces gain *more* tiles, not bigger ones.

| Surface | Shelf container | Tile | Whole tiles | Peek |
|---|---|---|---|---|
| iPhone SE / mini (375) | 375 | 143 | 2 | 49 |
| iPhone 14/15/16 (390) | 390 | 149 | 2 | 52 |
| iPhone 16 Plus (430) | 430 | 166 | 2 | 58 |
| iPhone 16 Pro Max (440) | 440 | 168 | 2 | 64 |
| iPad 11" landscape (1194) | 399 | 153 | 2 | 53 |
| iPad 11" portrait (834) | 418 | 161 | 2 | 56 |
| iPad 13" landscape (1366) | 485 | 129 | 3 | 46 |
| iPad 13" portrait (1024) | 580 | 158 | 3 | 54 |
| iPad mini portrait (744) | 648 | 134 | 4 | 48 |

Where the container is wide enough for all five tiles at 168, the row doesn't scroll and there is nothing to advertise.

### Alternative considered, not built

The reporter also suggested turning the row into a grid (#2 in the issue). That's the larger change and a different visual language for the page. This PR takes the smaller "peek rail" fix; say the word and I'll redo it as a grid.

## Test plan

1. Open Record tab → workout row's scroll bar flashes.
2. Look at the row's right edge → a tile is cut off.
3. Flick the row sideways → it stops on a tile edge.
4. Leave the tab, come back → the bar flashes again.

## Risk

Risk: 2/5 — sizing and a scroll-indicator flash on one existing row; no data, no network, no native code.

## Testing

- `vp run typecheck:mobile` — clean.
- `vp check` — 0 errors.
- `vp run test:mobile` — 786 files, 8154 passed.
- Every new guard was checked against a reverted fix:
  - dropping `flashScrollIndicators()` → the flash test fails
  - dropping the timer cleanup → the unmount test fails
  - removing the cap-vs-step-up rule → the 440pt test fails
  - capping unconditionally → 4 tests fail at 580pt and 744pt
- No iOS simulator in this environment, so the tables above are there to sanity-check against the code.

Closes #4278

## Release Notes

The workout picker on the session start screen now shows you there's more to it: the scroll bar flashes when you land on the screen, the next workout tile is cut off at the edge instead of the row looking complete, and a flick settles on a tile boundary. On iPad the tiles size to the pane they're in rather than the whole window.
