### PR TITLE
fix(mobile): resolve create-climb hold taps by proximity at rest

### DIFF
--- a/packages/mobile/src/components/create-climb/HoldTarget.tsx
+++ b/packages/mobile/src/components/create-climb/HoldTarget.tsx
@@ -1,111 +1,46 @@
-import React, { type MutableRefObject, useMemo } from 'react';
+import React from 'react';
 import { View } from 'react-native';
-import { Gesture, GestureDetector, type GestureType } from 'react-native-gesture-handler';
-import { runOnJS, type SharedValue } from 'react-native-reanimated';
 
 type HoldTargetProps = {
-  holdId: number;
   leftPct: number;
   topPct: number;
-  tapDiameter: number;
   /** Diameter of the faint discoverability dot, in device px. */
   dotDiameter: number;
-  showDot: boolean;
   dotColor: string;
-  onPaint: (holdId: number) => void;
-  onLongPress: (holdId: number) => void;
-  /** The board's ancestor pinch, so this per-hold tap/long-press declares itself
-   *  simultaneous with it. Without that, two fingers on two hold targets each
-   *  claim a pointer and the pinch can't acquire both — zoom stalls on Android. */
-  pinchRef?: MutableRefObject<GestureType | undefined>;
-  /** True while a pinch is in progress. Because the tap/long-press are
-   *  simultaneous with the pinch (above), RNGH no longer fails them when the
-   *  pinch activates, so a small/slow pinch could otherwise paint a hold or open
-   *  the role sheet — gate both callbacks on this. */
-  isPinchingSV?: SharedValue<boolean>;
 };
 
 /**
- * One hold's transparent tap target plus an optional discoverability dot. A
- * `GestureDetector` (not Pressable) is used so the per-hold tap/long-press
- * compose cleanly with the board's ancestor pinch/pan gestures. A quick
- * stationary touch paints; a 400ms press opens the role sheet; a drag falls
- * through to the pan gesture (the Tap fails on movement > maxDistance).
+ * One hold's discoverability dot. Purely visual — `pointerEvents="none"`, no
+ * gesture of its own.
  *
- * `React.memo` leaf with primitive props — the static tap layer never
- * re-renders when holds are painted.
+ * It used to own a transparent tap target inflated to
+ * `max(ringDiameter * 1.6, 44)` px with its own `GestureDetector`. Those squares
+ * overlap heavily at fit-to-screen and overlapping sibling Views are arbitrated
+ * by z-order, so the last hold in the list won every touch inside its square
+ * however far off-centre the finger landed (#4496). Boards now resolve a tap
+ * through one full-bleed overlay — `useRestHoldTapGesture` at rest,
+ * `useZoomedHoldTapGesture` while zoomed — which picks the nearest hold centre.
+ * Don't re-add a per-hold detector here: it would sit above the overlay and
+ * start winning touches by z-order again.
+ *
+ * `React.memo` leaf with primitive props — the marker layer never re-renders
+ * when holds are painted.
  */
-export const HoldTarget = React.memo(function HoldTarget({
-  holdId,
-  leftPct,
-  topPct,
-  tapDiameter,
-  dotDiameter,
-  showDot,
-  dotColor,
-  onPaint,
-  onLongPress,
-  pinchRef,
-  isPinchingSV,
-}: HoldTargetProps) {
-  const gesture = useMemo(() => {
-    const tap = Gesture.Tap()
-      .maxDuration(300)
-      .maxDistance(15)
-      .onStart(() => {
-        'worklet';
-        // Bail if a pinch is active — see isPinchingSV. The tap recognizes on
-        // finger-lift, so without this a finger that's part of a small pinch
-        // would paint the hold it happened to be resting on.
-        if (isPinchingSV?.value) return;
-        runOnJS(onPaint)(holdId);
-      });
-    const longPress = Gesture.LongPress()
-      .minDuration(400)
-      .onStart(() => {
-        'worklet';
-        if (isPinchingSV?.value) return;
-        runOnJS(onLongPress)(holdId);
-      });
-    // Let the ancestor pinch recognize even while this finger sits on the hold —
-    // applied per-leg because the relation method lives on the individual
-    // gestures, not the Exclusive composite.
-    if (pinchRef) {
-      tap.simultaneousWithExternalGesture(pinchRef);
-      longPress.simultaneousWithExternalGesture(pinchRef);
-    }
-    // Long-press wins; tap fires only if the long-press fails (released early).
-    return Gesture.Exclusive(longPress, tap);
-  }, [holdId, onPaint, onLongPress, pinchRef, isPinchingSV]);
-
+export const HoldTarget = React.memo(function HoldTarget({ leftPct, topPct, dotDiameter, dotColor }: HoldTargetProps) {
   return (
-    <GestureDetector gesture={gesture}>
-      <View
-        collapsable={false}
-        style={{
-          position: 'absolute',
-          left: `${leftPct}%`,
-          top: `${topPct}%`,
-          width: tapDiameter,
-          height: tapDiameter,
-          marginLeft: -tapDiameter / 2,
-          marginTop: -tapDiameter / 2,
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        {showDot ? (
-          <View
-            pointerEvents="none"
-            style={{
-              width: dotDiameter,
-              height: dotDiameter,
-              borderRadius: dotDiameter / 2,
-              backgroundColor: dotColor,
-            }}
-          />
-        ) : null}
-      </View>
-    </GestureDetector>
+    <View
+      pointerEvents="none"
+      style={{
+        position: 'absolute',
+        left: `${leftPct}%`,
+        top: `${topPct}%`,
+        width: dotDiameter,
+        height: dotDiameter,
+        marginLeft: -dotDiameter / 2,
+        marginTop: -dotDiameter / 2,
+        borderRadius: dotDiameter / 2,
+        backgroundColor: dotColor,
+      }}
+    />
   );
 });

--- a/packages/mobile/src/components/create-climb/HoldTargetLayer.tsx
+++ b/packages/mobile/src/components/create-climb/HoldTargetLayer.tsx
@@ -1,7 +1,5 @@
-import React, { type MutableRefObject, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
-import type { GestureType } from 'react-native-gesture-handler';
-import type { SharedValue } from 'react-native-reanimated';
 import type { BoardHoldTarget } from '../../lib/create-board-holds';
 import { holdGeometry, holdMarkerAppearance } from './holdLayout';
 import { HoldTarget } from './HoldTarget';
@@ -14,26 +12,25 @@ type HoldTargetLayerProps = {
   mirrored: boolean;
   /** When true, every hold gets a brighter, larger discoverability dot. */
   showAllHolds: boolean;
-  /** When false, tap targets remain but their discoverability dots are hidden. */
+  /** When false the layer draws nothing: the dots are all it renders. */
   showHoldMarkers?: boolean;
-  onPaint: (holdId: number) => void;
-  onLongPress: (holdId: number) => void;
-  /** The board's ancestor pinch, forwarded to each hold so per-hold gestures
-   *  declare themselves simultaneous with it (reliable pinch-to-zoom). */
-  pinchRef?: MutableRefObject<GestureType | undefined>;
-  /** Forwarded to each hold so its tap/long-press bail while a pinch is active. */
-  isPinchingSV?: SharedValue<boolean>;
 };
 
 /**
- * Static, memoized layer of one tap target per hold. Intentionally independent
- * of the painted state so it never re-renders when a hold is painted.
+ * Static, memoized layer of one discoverability dot per hold, drawn ABOVE the
+ * board — right on a surface that renders no holds of its own (the search filter
+ * board) and wrong on one that does, so the create board draws its dots with
+ * `HoldMarkerLayer` underneath the rendered overlay instead. Independent of the
+ * painted state, so it never re-renders when a hold is painted.
  *
- * The dots it carries are drawn ABOVE the board's holds, which is right on a
- * surface that renders no holds of its own (the search filter board) and wrong
- * on one that does: the create board turns them off here and draws them with
- * `HoldMarkerLayer` underneath the rendered overlay instead, so a dot cannot
- * sit in the middle of a lit hold's fill.
+ * Markers only: `pointerEvents="none"` throughout, no gestures. Taps are
+ * arbitrated by the board's single full-bleed overlay (`useRestHoldTapGesture`
+ * at rest, `useZoomedHoldTapGesture` while zoomed), which resolves a point to
+ * the *nearest* hold centre. Per-hold detectors used to live here and were
+ * arbitrated by view z-order over tap squares inflated to
+ * `max(ringDiameter * 1.6, 44)` px so small holds stayed reachable; at
+ * fit-to-screen those overlap so heavily that the last-rendered hold won every
+ * touch inside its square, however far off-centre the finger landed (#4496).
  */
 export const HoldTargetLayer = React.memo(function HoldTargetLayer({
   holdTargets,
@@ -43,49 +40,29 @@ export const HoldTargetLayer = React.memo(function HoldTargetLayer({
   mirrored,
   showAllHolds,
   showHoldMarkers = true,
-  onPaint,
-  onLongPress,
-  pinchRef,
-  isPinchingSV,
 }: HoldTargetLayerProps) {
   const targets = useMemo(() => {
     if (measuredWidth <= 0) return null;
+    // Nothing to draw — skip the per-hold Views entirely rather than mounting
+    // hundreds of invisible boxes.
+    if (!showHoldMarkers) return null;
     return holdTargets.map((hold) => {
       const geometry = holdGeometry(hold, boardWidth, boardHeight, measuredWidth, mirrored);
       const marker = holdMarkerAppearance(geometry, showAllHolds);
       return (
         <HoldTarget
           key={hold.id}
-          holdId={hold.id}
           leftPct={geometry.leftPct}
           topPct={geometry.topPct}
-          tapDiameter={geometry.tapDiameter}
           dotDiameter={marker.diameter}
-          showDot={showHoldMarkers}
           dotColor={marker.color}
-          onPaint={onPaint}
-          onLongPress={onLongPress}
-          pinchRef={pinchRef}
-          isPinchingSV={isPinchingSV}
         />
       );
     });
-  }, [
-    holdTargets,
-    boardWidth,
-    boardHeight,
-    measuredWidth,
-    mirrored,
-    showAllHolds,
-    showHoldMarkers,
-    onPaint,
-    onLongPress,
-    pinchRef,
-    isPinchingSV,
-  ]);
+  }, [holdTargets, boardWidth, boardHeight, measuredWidth, mirrored, showAllHolds, showHoldMarkers]);
 
   return (
-    <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
+    <View pointerEvents="none" style={StyleSheet.absoluteFill}>
       {targets}
     </View>
   );

--- a/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
+++ b/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
@@ -18,9 +18,9 @@ import { spacing } from '../../theme/tokens';
 import { EDITING_VEIL_OPACITY } from '../../lib/board-render-settings';
 import type { BoardHoldTarget } from '../../lib/create-board-holds';
 import { HoldMarkerLayer } from './HoldMarkerLayer';
-import { HoldTargetLayer } from './HoldTargetLayer';
 import { PaintedHoldsLayer } from './PaintedHoldsLayer';
 import { buildHoldHitTargets } from './holdLayout';
+import { useRestHoldTapGesture } from './use-rest-hold-tap-gesture';
 import { useZoomedHoldTapGesture, PAN_ACTIVATION_OFFSET } from './use-zoomed-hold-tap-gesture';
 
 /** Imperative handle on the board's zoom, mirroring `FilterBoardControls`. */
@@ -81,10 +81,11 @@ type InteractiveCreateBoardProps = {
  * mirrors the climber's own Aura settings exactly (mark style, glow, fill) rather
  * than the small-surface `filledStyle`/thumbnail treatment, with one deliberate
  * exception: the veil is off here — the glow lands on an unwashed wall, so the
- * unlit holds you still have to find and tap stay readable. Tap targets are plain
- * RN Views placed INSIDE the zoom-transformed Animated.View, so RNGH hit-tests
- * them in board-local space and taps land correctly at any zoom level with zero
- * manual coordinate math.
+ * unlit holds you still have to find and tap stay readable. The at-rest tap
+ * surface is one full-bleed View placed INSIDE the zoom-transformed
+ * Animated.View, so RNGH hands the gesture board-local coordinates with zero
+ * manual coordinate math, and `useRestHoldTapGesture` resolves them to the
+ * nearest hold centre.
  * PaintedHoldsLayer survives as the fallback for a build with no native renderer,
  * where no overlay ever arrives.
  *
@@ -98,8 +99,8 @@ type InteractiveCreateBoardProps = {
  * (`@expo/ui/community/bottom-sheet`) hosts its content inside a Jetpack Compose
  * `ModalBottomSheet` via a native `RNHostView` bridge — a separate surface the
  * app's single root-level GestureHandlerRootView (app/_layout.tsx) doesn't cover.
- * Without a nested root here, every per-hold Gesture.Tap()/LongPress() and the
- * pinch/pan gestures silently never receive touches on Android, so no hold can be
+ * Without a nested root here, the tap/long-press overlay and the pinch/pan
+ * gestures silently never receive touches on Android, so no hold can be
  * painted (#4320). RNGH's own docs call out nesting a root per-Modal for exactly
  * this reason; iOS isn't affected since its modal presentation doesn't split the
  * touch-dispatch tree the same way.
@@ -125,9 +126,9 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
   onInteractionActiveChange,
   scrollRef,
 }: InteractiveCreateBoardProps) {
-  // Shared with the per-hold detectors and the zoomed overlay so they mark
-  // themselves simultaneous with the pinch — otherwise two fingers landing on
-  // two hold targets each claim a pointer and pinch-to-zoom stalls on Android.
+  // Shared with both tap overlays so they mark themselves simultaneous with the
+  // pinch — otherwise a finger resting on the overlay claims the pointer and
+  // pinch-to-zoom stalls on Android.
   const pinchRef = useRef<GestureType | undefined>(undefined);
   const {
     pinchGesture,
@@ -171,12 +172,23 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
     return map;
   }, [holdTargets]);
 
-  // Hit circles for resolving a tap to a hold while zoomed (the pan overlay sits
-  // above the per-hold detectors, so it resolves taps itself — see #2687).
+  // Hit circles both tap overlays resolve a point against, so the two zoom
+  // levels agree on which hold a touch belongs to.
   const hitTargets = useMemo(
     () => buildHoldHitTargets(holdTargets, boardWidth, boardHeight, renderWidth, renderHeight, mirrored),
     [holdTargets, boardWidth, boardHeight, renderWidth, renderHeight, mirrored],
   );
+
+  // At rest the same circles feed a single full-bleed overlay, so a tap goes to
+  // the NEAREST hold instead of whichever inflated per-hold square happened to
+  // render last (#4496).
+  const restGesture = useRestHoldTapGesture({
+    hitTargets,
+    onTap: onPaint,
+    onLongPress: onLongPressHold,
+    pinchRef,
+    isPinchingSV,
+  });
 
   const overlayGesture = useZoomedHoldTapGesture({
     zoomPanGesture,
@@ -256,29 +268,28 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
               underOverlay={underOverlay}
               emptyOverlayFallback={paintedHoldsFallback}
             />
-            <HoldTargetLayer
-              holdTargets={holdTargets}
-              boardWidth={boardWidth}
-              boardHeight={boardHeight}
-              measuredWidth={renderWidth}
-              mirrored={mirrored}
-              showAllHolds={showAllHolds}
-              // The dots are drawn by HoldMarkerLayer, under the holds overlay.
-              // These targets stay transparent and on top, where the touches are.
-              showHoldMarkers={false}
-              onPaint={onPaint}
-              onLongPress={onLongPressHold}
-              pinchRef={pinchRef}
-              isPinchingSV={isPinchingSV}
-            />
+
+            {/* At-rest tap overlay: one full-bleed detector inside the (identity)
+                zoom transform, so its local x/y are already board-local px. It
+                replaces the per-hold detectors HoldTargetLayer used to mount,
+                whose overlapping inflated squares resolved by z-order rather
+                than by distance (#4496). Race(longPress, tap) with a small
+                movement budget on both legs, so a drag still reaches the
+                CreateDrawer's scroll instead of becoming a whole-board
+                long-press. The dots stay in HoldMarkerLayer, under the holds. */}
+            {!isZoomed && restGesture ? (
+              <GestureDetector gesture={restGesture}>
+                <View collapsable={false} style={StyleSheet.absoluteFill} />
+              </GestureDetector>
+            ) : null}
           </Animated.View>
 
           {/* Pan-while-zoomed overlay: only mounted when zoomed so it doesn't
               claim 1-finger touches at rest (which would block the drawer's
               scroll/close). 2-finger pinches fall through via maxPointers(1).
-              The overlay sits above the per-hold detectors, so its gesture also
-              resolves taps/long-presses to holds (Race with the pan) — without
-              that, painting and the role sheet are dead while zoomed (#2687). */}
+              It replaces the at-rest overlay above, so its gesture also resolves
+              taps/long-presses to holds (Race with the pan) — without that,
+              painting and the role sheet are dead while zoomed (#2687). */}
           {isZoomed ? (
             <GestureDetector gesture={overlayGesture}>
               <View style={StyleSheet.absoluteFill}>

--- a/packages/mobile/src/components/create-climb/__tests__/HoldTarget.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/HoldTarget.test.tsx
@@ -2,99 +2,56 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
-import type { SharedValue } from 'react-native-reanimated';
 
-// Capture the tap / long-press onStart worklets (and the pinch relation) so the
-// test can invoke them and assert the per-hold pinch gate without real gestures.
-const tapStartCallbacks: (() => void)[] = [];
-const longPressStartCallbacks: (() => void)[] = [];
-const simultaneousCalls: unknown[] = [];
+// If HoldTarget ever reaches for RNGH again this records it, so a reinstated
+// per-hold detector fails the suite instead of quietly competing with the
+// board's full-bleed overlay (#4496).
+const gestureUse = { count: 0 };
 
 vi.mock('react-native', () => ({
-  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  View: ({ children, pointerEvents }: { children?: ReactNode; pointerEvents?: string }) =>
+    createElement('div', { 'data-pointer-events': pointerEvents }, children),
 }));
 
-vi.mock('react-native-reanimated', () => ({ runOnJS: (fn: unknown) => fn }));
-
-vi.mock('react-native-gesture-handler', () => {
-  const makeGesture = (recordStart: (cb: () => void) => void) => {
-    const gesture: Record<string, unknown> = {
-      maxDuration: () => gesture,
-      maxDistance: () => gesture,
-      minDuration: () => gesture,
-      onStart: (cb: () => void) => {
-        recordStart(cb);
-        return gesture;
-      },
-      simultaneousWithExternalGesture: (ref: unknown) => {
-        simultaneousCalls.push(ref);
-        return gesture;
-      },
-    };
-    return gesture;
-  };
-  return {
-    Gesture: {
-      Tap: () => makeGesture((cb) => tapStartCallbacks.push(cb)),
-      LongPress: () => makeGesture((cb) => longPressStartCallbacks.push(cb)),
-      Exclusive: (...members: unknown[]) => ({ composed: 'exclusive', members }),
+vi.mock('react-native-gesture-handler', () => ({
+  Gesture: {
+    Tap: () => {
+      gestureUse.count += 1;
+      throw new Error('HoldTarget must stay a marker — see #4496');
     },
-    GestureDetector: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
-  };
-});
+    LongPress: () => {
+      gestureUse.count += 1;
+      throw new Error('HoldTarget must stay a marker — see #4496');
+    },
+  },
+  GestureDetector: ({ children }: { children?: ReactNode }) => {
+    gestureUse.count += 1;
+    return createElement('div', { 'data-gesture': 'true' }, children);
+  },
+}));
 
 import { HoldTarget } from '../HoldTarget';
 
-function renderHoldTarget(overrides: { isPinchingSV?: SharedValue<boolean> } = {}) {
-  tapStartCallbacks.length = 0;
-  longPressStartCallbacks.length = 0;
-  simultaneousCalls.length = 0;
-  const onPaint = vi.fn();
-  const onLongPress = vi.fn();
-  render(
-    <HoldTarget
-      holdId={7}
-      leftPct={10}
-      topPct={20}
-      tapDiameter={30}
-      dotDiameter={6}
-      showDot
-      dotColor="#fff"
-      onPaint={onPaint}
-      onLongPress={onLongPress}
-      {...overrides}
-    />,
-  );
-  return { onPaint, onLongPress };
+function renderHoldTarget() {
+  gestureUse.count = 0;
+  return render(<HoldTarget leftPct={10} topPct={20} dotDiameter={6} dotColor="#fff" />);
 }
 
 describe('HoldTarget', () => {
-  it('paints on tap and opens the role sheet on long-press when no pinch is active', () => {
-    const { onPaint, onLongPress } = renderHoldTarget({
-      isPinchingSV: { value: false } as unknown as SharedValue<boolean>,
-    });
-    tapStartCallbacks.at(-1)?.();
-    longPressStartCallbacks.at(-1)?.();
-    expect(onPaint).toHaveBeenCalledWith(7);
-    expect(onLongPress).toHaveBeenCalledWith(7);
+  it('renders an inert marker: no gesture detector, no hit-testing', () => {
+    // Per-hold detectors used to own an inflated square each; overlapping
+    // squares are arbitrated by z-order, so the last hold in the list won every
+    // touch inside its square (#4496). Taps now belong to the board's single
+    // full-bleed overlay, and this layer must never take one back.
+    const { container } = renderHoldTarget();
+    expect(container.querySelector('[data-gesture="true"]')).toBeNull();
+    expect(gestureUse.count).toBe(0);
+    expect(container.firstElementChild?.getAttribute('data-pointer-events')).toBe('none');
   });
 
-  it('does not paint or open the role sheet while a pinch is active', () => {
-    // tap/long-press are simultaneousWithExternalGesture(pinch), so RNGH no
-    // longer fails them when the pinch activates — the gate is what prevents an
-    // accidental paint / role-sheet open during a small or slow pinch.
-    const { onPaint, onLongPress } = renderHoldTarget({
-      isPinchingSV: { value: true } as unknown as SharedValue<boolean>,
-    });
-    tapStartCallbacks.at(-1)?.();
-    longPressStartCallbacks.at(-1)?.();
-    expect(onPaint).not.toHaveBeenCalled();
-    expect(onLongPress).not.toHaveBeenCalled();
-  });
-
-  it('still paints when no pinch gate is wired (gate is optional)', () => {
-    const { onPaint } = renderHoldTarget();
-    tapStartCallbacks.at(-1)?.();
-    expect(onPaint).toHaveBeenCalledWith(7);
+  it('draws exactly one dot per hold, with no wrapper box around it', () => {
+    // The old inflated tap square wrapped the dot; nothing needs it now.
+    const { container } = renderHoldTarget();
+    expect(container.querySelectorAll('div').length).toBe(1);
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/InteractiveCreateBoard.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/InteractiveCreateBoard.test.tsx
@@ -37,7 +37,6 @@ vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
 vi.mock('../../../theme/tokens', () => ({ overlays: { scrim: '#000', onScrim: '#fff' }, spacing: { 2: 8 } }));
-vi.mock('../HoldTargetLayer', () => ({ HoldTargetLayer: () => createElement('div') }));
 vi.mock('../HoldMarkerLayer', () => ({ HoldMarkerLayer: () => createElement('div') }));
 vi.mock('../PaintedHoldsLayer', () => ({ PaintedHoldsLayer: () => createElement('div') }));
 vi.mock('../holdLayout', () => ({ buildHoldHitTargets: () => [] }));
@@ -45,6 +44,7 @@ vi.mock('../use-zoomed-hold-tap-gesture', () => ({
   useZoomedHoldTapGesture: () => ({}),
   PAN_ACTIVATION_OFFSET: 8,
 }));
+vi.mock('../use-rest-hold-tap-gesture', () => ({ useRestHoldTapGesture: () => ({}) }));
 
 const zoomPanState = { isZoomed: false, isPinching: false };
 let lastUseZoomPanGestureOptions: Record<string, unknown> | null = null;

--- a/packages/mobile/src/components/create-climb/__tests__/interactive-create-board-layers.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/interactive-create-board-layers.test.tsx
@@ -44,6 +44,7 @@ vi.mock('../../play-drawer/use-zoom-pan-gesture', () => ({
   }),
 }));
 vi.mock('../use-zoomed-hold-tap-gesture', () => ({ useZoomedHoldTapGesture: () => ({}), PAN_ACTIVATION_OFFSET: 8 }));
+vi.mock('../use-rest-hold-tap-gesture', () => ({ useRestHoldTapGesture: () => ({}) }));
 
 // The board image records what it was handed: this test is about which layer
 // each mark lands in, and BoardImageNative owns the slot between the two.
@@ -54,15 +55,17 @@ vi.mock('../../BoardImageNative', () => ({
     return createElement('div', { 'data-testid': 'board-image' }, props.underOverlay as ReactNode);
   },
 }));
-const holdTargetLayerProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }));
+// The board no longer imports this. Mocked anyway so the "only one dot layer"
+// assertion below is a real probe: if it is ever mounted again, it shows up.
 vi.mock('../HoldTargetLayer', () => ({
-  HoldTargetLayer: (props: Record<string, unknown>) => {
-    holdTargetLayerProps.current = props;
-    return createElement('div', { 'data-testid': 'hold-targets' });
-  },
+  HoldTargetLayer: () => createElement('div', { 'data-testid': 'hold-targets' }),
 }));
+const holdMarkerLayerProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }));
 vi.mock('../HoldMarkerLayer', () => ({
-  HoldMarkerLayer: () => createElement('div', { 'data-testid': 'hold-markers' }),
+  HoldMarkerLayer: (props: Record<string, unknown>) => {
+    holdMarkerLayerProps.current = props;
+    return createElement('div', { 'data-testid': 'hold-markers' });
+  },
 }));
 vi.mock('../PaintedHoldsLayer', () => ({
   PaintedHoldsLayer: () => createElement('div', { 'data-testid': 'painted-holds' }),
@@ -88,15 +91,17 @@ const BOARD_PROPS = {
 
 describe('InteractiveCreateBoard layer order', () => {
   it('draws the discoverability dots under the rendered holds, not over them', () => {
-    const { getByTestId } = render(createElement(InteractiveCreateBoard, { ...BOARD_PROPS, showAllHolds: true }));
+    const { container, getByTestId } = render(
+      createElement(InteractiveCreateBoard, { ...BOARD_PROPS, showAllHolds: true }),
+    );
 
     // The marks go in the board image's under-overlay slot. Above the overlay a
     // dot would sit in the middle of a lit hold's fill and its role glyph.
     expect(getByTestId('board-image').querySelector('[data-testid="hold-markers"]')).not.toBeNull();
-    // ...and the tap targets, which have to stay on top to catch the touch,
-    // carry no dot of their own.
-    expect(holdTargetLayerProps.current?.showHoldMarkers).toBe(false);
-    expect(holdTargetLayerProps.current?.showAllHolds).toBe(true);
+    expect(holdMarkerLayerProps.current?.showAllHolds).toBe(true);
+    // ...and they are the ONLY dots: the layer that used to draw a second set on
+    // top of the holds is gone, along with its per-hold hit-testing (#4496).
+    expect(container.querySelector('[data-testid="hold-targets"]')).toBeNull();
   });
 
   it('keeps the caller overlay under the holds too, where its own contract puts it', () => {

--- a/packages/mobile/src/components/create-climb/__tests__/interactive-create-board-taps.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/interactive-create-board-taps.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { BoardHoldTarget } from '../../../lib/create-board-holds';
+
+// What this test is about: which gesture surface the create board mounts at each
+// zoom level, and what it hands that surface. The overlays' own arbitration is
+// covered by use-rest-hold-tap-gesture / use-zoomed-hold-tap-gesture.
+
+const zoomState = vi.hoisted(() => ({ isZoomed: false, resetZoom: vi.fn() }));
+const restTapCalls = vi.hoisted(() => [] as Record<string, unknown>[]);
+const zoomedTapCalls = vi.hoisted(() => [] as Record<string, unknown>[]);
+
+type ChildrenProps = { children?: ReactNode };
+
+vi.mock('react-native', () => ({
+  View: ({ children }: ChildrenProps) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: { position: 'absolute' } },
+  PixelRatio: { get: () => 3 },
+}));
+
+vi.mock('react-native-reanimated', () => ({
+  default: { View: ({ children }: ChildrenProps) => createElement('div', { 'data-animated': 'true' }, children) },
+}));
+
+vi.mock('react-native-gesture-handler', () => ({
+  GestureDetector: ({ children }: ChildrenProps) => createElement('div', { 'data-gesture': 'true' }, children),
+  GestureHandlerRootView: ({ children }: ChildrenProps) => createElement('div', { 'data-rngh-root': 'true' }, children),
+}));
+
+vi.mock('../../play-drawer/use-zoom-pan-gesture', () => ({
+  useZoomPanGesture: () => ({
+    pinchGesture: {},
+    zoomPanGesture: {},
+    isZoomed: zoomState.isZoomed,
+    isPinching: false,
+    isPinchingSV: { value: false },
+    scaleSV: { value: 1 },
+    translateXSV: { value: 0 },
+    translateYSV: { value: 0 },
+    containerWidthSV: { value: 300 },
+    containerHeightSV: { value: 400 },
+    resetZoom: zoomState.resetZoom,
+    animatedZoomStyle: {},
+  }),
+}));
+
+vi.mock('../use-rest-hold-tap-gesture', () => ({
+  useRestHoldTapGesture: (options: Record<string, unknown>) => {
+    restTapCalls.push(options);
+    return options.onTap ? { composed: 'race' } : null;
+  },
+}));
+vi.mock('../use-zoomed-hold-tap-gesture', () => ({
+  useZoomedHoldTapGesture: (options: Record<string, unknown>) => {
+    zoomedTapCalls.push(options);
+    return { composed: 'zoomed' };
+  },
+  PAN_ACTIVATION_OFFSET: 8,
+}));
+
+// Renders its under-overlay slot, because that is where the board puts the
+// discoverability dots (under the rendered holds — see #4978). A mock that
+// drops the slot would hide the marker layer from this suite entirely.
+vi.mock('../../BoardImageNative', () => ({
+  BoardImageNative: ({ underOverlay }: { underOverlay?: ReactNode }) =>
+    createElement('div', { 'data-board-image': 'true' }, underOverlay),
+}));
+// Stubbed so the suite doesn't pull the real Icon (and @expo/vector-icons' Flow
+// source) in through the board's zoomed chrome.
+vi.mock('../../board-controls/ResetZoomButton', () => ({
+  ResetZoomButton: ({ onPress }: { onPress?: () => void }) =>
+    createElement('button', { 'data-reset-zoom': 'true', onClick: onPress }),
+}));
+vi.mock('../HoldMarkerLayer', () => ({
+  HoldMarkerLayer: () => createElement('div', { 'data-hold-markers': 'true' }),
+}));
+// The board no longer imports this. Mocked anyway so the "no per-hold layer"
+// assertion below is a real probe: if it is ever mounted again, it shows up.
+vi.mock('../HoldTargetLayer', () => ({
+  HoldTargetLayer: () => createElement('div', { 'data-hold-layer': 'true' }),
+}));
+vi.mock('../PaintedHoldsLayer', () => ({
+  PaintedHoldsLayer: () => createElement('div', { 'data-painted': 'true' }),
+}));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 2: 8 } }));
+
+import { InteractiveCreateBoard } from '../InteractiveCreateBoard';
+
+const holdTargets: BoardHoldTarget[] = [
+  { id: 10, cx: 100, cy: 100, r: 20 },
+  { id: 20, cx: 120, cy: 100, r: 8 },
+];
+
+function renderBoard(onPaint = vi.fn(), onLongPressHold = vi.fn()) {
+  const result = render(
+    <InteractiveCreateBoard
+      frames="p1r12"
+      boardName="kilter"
+      layoutId={1}
+      sizeId={10}
+      setIds="1,2"
+      boardWidth={1000}
+      boardHeight={1000}
+      holdTargets={holdTargets}
+      litUpHoldsMap={{}}
+      onPaint={onPaint}
+      onLongPressHold={onLongPressHold}
+      renderWidth={300}
+      renderHeight={400}
+    />,
+  );
+  return { ...result, onPaint, onLongPressHold };
+}
+
+describe('InteractiveCreateBoard hold taps', () => {
+  beforeEach(() => {
+    zoomState.isZoomed = false;
+    zoomState.resetZoom.mockClear();
+    restTapCalls.length = 0;
+    zoomedTapCalls.length = 0;
+  });
+
+  it('mounts no per-hold hit-testing layer, so nothing competes with the overlay', () => {
+    // HoldTargetLayer used to sit here with one inflated square per hold
+    // (max(ringDiameter * 1.6, 44) px). They overlap at fit-to-screen and
+    // overlapping siblings resolve by z-order, so the last hold in the list won
+    // every touch inside its square (#4496). The dots it drew live in
+    // HoldMarkerLayer now, under the rendered holds and with no gesture at all.
+    const { container } = renderBoard();
+    expect(container.querySelector('[data-board-image="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-hold-markers="true"]')).not.toBeNull();
+    expect(container.querySelector('[data-hold-layer="true"]')).toBeNull();
+  });
+
+  it('feeds the at-rest overlay one hit circle per hold plus both hold handlers', () => {
+    const { onPaint, onLongPressHold } = renderBoard();
+    const restOptions = restTapCalls.at(-1);
+    expect(restOptions?.onTap).toBe(onPaint);
+    expect(restOptions?.onLongPress).toBe(onLongPressHold);
+    expect(restOptions?.hitTargets).toHaveLength(holdTargets.length);
+    // Same circles the zoomed overlay resolves against, so both zoom levels
+    // agree on which hold a point belongs to.
+    expect(zoomedTapCalls.at(-1)?.hitTargets).toBe(restOptions?.hitTargets);
+    // The pinch relation is what keeps a two-finger zoom alive while a finger
+    // rests on the overlay.
+    expect(restOptions?.pinchRef).toBeDefined();
+    expect(restOptions?.isPinchingSV).toBeDefined();
+  });
+
+  it('swaps the at-rest overlay for the pan overlay once zoomed', () => {
+    const notZoomed = renderBoard();
+    // No reset button at rest — it mounts with the pan overlay.
+    expect(notZoomed.container.querySelectorAll('[data-reset-zoom="true"]').length).toBe(0);
+    const restCount = notZoomed.container.querySelectorAll('[data-gesture="true"]').length;
+    notZoomed.unmount();
+
+    zoomState.isZoomed = true;
+    const zoomed = renderBoard();
+    expect(zoomed.container.querySelectorAll('[data-reset-zoom="true"]').length).toBe(1);
+    // Still one overlay: the zoomed pan replaces the at-rest tap surface rather
+    // than stacking on top of it.
+    expect(zoomed.container.querySelectorAll('[data-gesture="true"]').length).toBe(restCount);
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/use-rest-hold-tap-gesture.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/use-rest-hold-tap-gesture.test.ts
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { SharedValue } from 'react-native-reanimated';
+import type { GestureType } from 'react-native-gesture-handler';
+import type { HoldHitTarget } from '../holdLayout';
+
+// Chainable gesture builder per Gesture.Tap()/LongPress() call, mirroring
+// use-zoomed-hold-tap-gesture.test.ts. Each builder records the config calls we
+// care about (maxDistance / minDuration), the pinch relation, and the onStart
+// worklet so a test can invoke it without driving real gestures.
+type TapEvent = { x: number; y: number };
+type GestureRecord = {
+  kind: 'tap' | 'longPress';
+  maxDistance?: number;
+  maxDuration?: number;
+  minDuration?: number;
+};
+const raceCalls: unknown[][] = [];
+const exclusiveCalls: unknown[][] = [];
+const simultaneousCalls: unknown[] = [];
+const built: GestureRecord[] = [];
+const tapStartCallbacks: ((event: TapEvent) => void)[] = [];
+const longPressStartCallbacks: ((event: TapEvent) => void)[] = [];
+
+vi.mock('react-native-gesture-handler', () => {
+  const makeGesture = (kind: 'tap' | 'longPress', recordStart: (cb: (event: TapEvent) => void) => void) => {
+    const record: GestureRecord = { kind };
+    built.push(record);
+    const gesture: Record<string, unknown> = {
+      record,
+      maxDuration: (ms: number) => {
+        record.maxDuration = ms;
+        return gesture;
+      },
+      maxDistance: (px: number) => {
+        record.maxDistance = px;
+        return gesture;
+      },
+      minDuration: (ms: number) => {
+        record.minDuration = ms;
+        return gesture;
+      },
+      onStart: (cb: (event: TapEvent) => void) => {
+        recordStart(cb);
+        return gesture;
+      },
+      simultaneousWithExternalGesture: (ref: unknown) => {
+        simultaneousCalls.push(ref);
+        return gesture;
+      },
+    };
+    return gesture;
+  };
+  return {
+    Gesture: {
+      Tap: () => makeGesture('tap', (cb) => tapStartCallbacks.push(cb)),
+      LongPress: () => makeGesture('longPress', (cb) => longPressStartCallbacks.push(cb)),
+      Race: (...members: unknown[]) => {
+        raceCalls.push(members);
+        return { composed: 'race', members };
+      },
+      Exclusive: (...members: unknown[]) => {
+        exclusiveCalls.push(members);
+        return { composed: 'exclusive', members };
+      },
+    },
+  };
+});
+
+vi.mock('react-native-reanimated', () => ({ runOnJS: (fn: unknown) => fn }));
+
+import {
+  useRestHoldTapGesture,
+  REST_TAP_MAX_DURATION_MS,
+  REST_TAP_MAX_DISTANCE_PX,
+  REST_LONG_PRESS_MIN_DURATION_MS,
+  REST_LONG_PRESS_MAX_DISTANCE_PX,
+} from '../use-rest-hold-tap-gesture';
+
+// The real #4496 geometry, to scale: on Kilter layout 1 at a 340 dp board every
+// hold's hit circle is 44 dp across (MIN_TAP_DIAMETER wins over the 18.9 dp ring)
+// and neighbours sit 13.4 dp apart, so each hold's circle swallows several
+// neighbouring CENTRES. Radii are equal because `r` is a per-board constant
+// (`xSpacing * 4` on Aurora boards) — there is no big-hold/small-hold asymmetry.
+// Hold 2 is the later entry, i.e. the one z-order used to hand every shared
+// touch to.
+const HIT_RADIUS = 22;
+const overlappingTargets: HoldHitTarget[] = [
+  { holdId: 1, x: 100, y: 100, radius: HIT_RADIUS },
+  { holdId: 2, x: 113.4, y: 100, radius: HIT_RADIUS },
+];
+
+function reset() {
+  raceCalls.length = 0;
+  exclusiveCalls.length = 0;
+  simultaneousCalls.length = 0;
+  built.length = 0;
+  tapStartCallbacks.length = 0;
+  longPressStartCallbacks.length = 0;
+}
+
+function baseOptions(overrides: Record<string, unknown> = {}) {
+  return { hitTargets: overlappingTargets, ...overrides };
+}
+
+describe('useRestHoldTapGesture', () => {
+  // Recorded gesture config is module-level, so every test starts from a clean
+  // slate rather than relying on each one remembering to call reset().
+  beforeEach(reset);
+
+  it('returns null when no tap handler is wired (zone mode mounts no overlay)', () => {
+    const { result } = renderHook(() => useRestHoldTapGesture(baseOptions()));
+    expect(result.current).toBeNull();
+  });
+
+  it('composes long-press + tap with Race, never Exclusive', () => {
+    const { result } = renderHook(() => useRestHoldTapGesture(baseOptions({ onTap: vi.fn() })));
+    expect((result.current as { composed?: string } | null)?.composed).toBe('race');
+    expect(exclusiveCalls).toHaveLength(0);
+    // Long-press first: with Race the first leg to ACTIVATE wins, but ordering
+    // documents the intent that a held finger beats the tap.
+    expect(raceCalls.at(-1)).toHaveLength(2);
+  });
+
+  it('fails both legs on movement so a drag reaches the parent scroll', () => {
+    renderHook(() => useRestHoldTapGesture(baseOptions({ onTap: vi.fn() })));
+    const tap = built.find((entry) => entry.kind === 'tap');
+    const longPress = built.find((entry) => entry.kind === 'longPress');
+    expect(tap?.maxDuration).toBe(REST_TAP_MAX_DURATION_MS);
+    expect(tap?.maxDistance).toBe(REST_TAP_MAX_DISTANCE_PX);
+    expect(longPress?.minDuration).toBe(REST_LONG_PRESS_MIN_DURATION_MS);
+    // Without an explicit budget the long-press would keep tracking a drag and
+    // turn a scroll into a whole-board long-press.
+    expect(longPress?.maxDistance).toBe(REST_LONG_PRESS_MAX_DISTANCE_PX);
+  });
+
+  it('resolves a tap to the nearest hold centre, not to the last-rendered hold', () => {
+    const onTap = vi.fn();
+    renderHook(() => useRestHoldTapGesture(baseOptions({ onTap })));
+
+    // (104,100) is inside BOTH circles — 4px from hold 1, 9.4px from hold 2.
+    // Z-order handed it to hold 2 (rendered later); distance gives it to hold 1.
+    tapStartCallbacks.at(-1)?.({ x: 104, y: 100 });
+    expect(onTap).toHaveBeenCalledWith(1);
+
+    // (110,100) is also inside both, but nearer hold 2 — the arbitration flips
+    // at the midpoint, which is what makes the partition a Voronoi one.
+    onTap.mockClear();
+    tapStartCallbacks.at(-1)?.({ x: 110, y: 100 });
+    expect(onTap).toHaveBeenCalledWith(2);
+  });
+
+  it('ignores a tap that lands outside every hit circle', () => {
+    const onTap = vi.fn();
+    renderHook(() => useRestHoldTapGesture(baseOptions({ onTap })));
+    tapStartCallbacks.at(-1)?.({ x: 400, y: 400 });
+    expect(onTap).not.toHaveBeenCalled();
+  });
+
+  it('routes a long-press to its own handler and falls back to onTap when omitted', () => {
+    const onTap = vi.fn();
+    const onLongPress = vi.fn();
+    renderHook(() => useRestHoldTapGesture(baseOptions({ onTap, onLongPress })));
+    longPressStartCallbacks.at(-1)?.({ x: 104, y: 100 });
+    expect(onLongPress).toHaveBeenCalledWith(1);
+    expect(onTap).not.toHaveBeenCalled();
+
+    reset();
+    const tapOnly = vi.fn();
+    renderHook(() => useRestHoldTapGesture(baseOptions({ onTap: tapOnly })));
+    longPressStartCallbacks.at(-1)?.({ x: 104, y: 100 });
+    expect(tapOnly).toHaveBeenCalledWith(1);
+  });
+
+  it('bails out of tap + long-press while a pinch is active', () => {
+    const onTap = vi.fn();
+    const onLongPress = vi.fn();
+    const isPinchingSV = { value: true } as unknown as SharedValue<boolean>;
+    renderHook(() => useRestHoldTapGesture(baseOptions({ onTap, onLongPress, isPinchingSV })));
+    tapStartCallbacks.at(-1)?.({ x: 104, y: 100 });
+    longPressStartCallbacks.at(-1)?.({ x: 104, y: 100 });
+    expect(onTap).not.toHaveBeenCalled();
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('declares both legs simultaneous with the pinch when pinchRef is provided', () => {
+    const pinchRef = { current: undefined } as unknown as { current: GestureType | undefined };
+    renderHook(() => useRestHoldTapGesture(baseOptions({ onTap: vi.fn(), pinchRef })));
+    expect(simultaneousCalls.filter((ref) => ref === pinchRef)).toHaveLength(2);
+  });
+
+  it('wires no pinch relation when pinchRef is omitted', () => {
+    renderHook(() => useRestHoldTapGesture(baseOptions({ onTap: vi.fn() })));
+    expect(simultaneousCalls).toHaveLength(0);
+  });
+
+  it('keeps the composed gesture stable across re-renders and still sees fresh hit targets', () => {
+    const onTap = vi.fn();
+    let hitTargets = overlappingTargets;
+    const { result, rerender } = renderHook(() => useRestHoldTapGesture({ hitTargets, onTap }));
+    const first = result.current;
+
+    // A relayout produces a new hit-target array; the gesture object must NOT be
+    // rebuilt (that has wedged iOS RNGH before) but must resolve against the new
+    // geometry through the ref.
+    hitTargets = [{ holdId: 99, x: 104, y: 100, radius: HIT_RADIUS }];
+    rerender();
+    expect(result.current).toBe(first);
+
+    tapStartCallbacks.at(-1)?.({ x: 104, y: 100 });
+    expect(onTap).toHaveBeenCalledWith(99);
+  });
+});

--- a/packages/mobile/src/components/create-climb/use-rest-hold-tap-gesture.ts
+++ b/packages/mobile/src/components/create-climb/use-rest-hold-tap-gesture.ts
@@ -1,0 +1,148 @@
+import { type MutableRefObject, useCallback, useMemo, useRef } from 'react';
+import { Gesture, type ComposedGesture, type GestureType } from 'react-native-gesture-handler';
+import { runOnJS, type SharedValue } from 'react-native-reanimated';
+import { resolveHoldAtPoint, type HoldHitTarget } from './holdLayout';
+
+// Match the zoomed overlay (use-zoomed-hold-tap-gesture) so a tap at rest
+// behaves exactly like a tap while zoomed. Keep in sync.
+export const REST_TAP_MAX_DURATION_MS = 300;
+export const REST_TAP_MAX_DISTANCE_PX = 15;
+export const REST_LONG_PRESS_MIN_DURATION_MS = 400;
+
+/**
+ * Movement budget (px) before the long-press leg gives up, mirroring the zoomed
+ * board's `panActivationOffset`. At rest there is no pan to hand the drag to —
+ * the drag belongs to whatever scroll container hosts the board (the create
+ * board lives inside a BottomSheetScrollView). RNGH only yields the touch to
+ * that scroll while this overlay's legs are still un-activated, so the
+ * long-press must fail on the same small offset the zoomed pan activates on.
+ * RNGH's default is 10px; 8 keeps it identical to PAN_ACTIVATION_OFFSET.
+ */
+export const REST_LONG_PRESS_MAX_DISTANCE_PX = 8;
+
+type UseRestHoldTapGestureOptions = {
+  /** Hold hit circles in board-local render px (from buildHoldHitTargets). */
+  hitTargets: HoldHitTarget[];
+  /** Tap handler (paint / open picker). When omitted the hook returns null and
+   *  the caller should mount no overlay — used by zone mode, which has no
+   *  per-hold taps. */
+  onTap?: (holdId: number) => void;
+  /** Long-press handler (role sheet). Falls back to onTap when omitted. */
+  onLongPress?: (holdId: number) => void;
+  /** The board's ancestor pinch. Both legs declare themselves simultaneous with
+   *  it so a finger resting on the overlay can't stall pinch-to-zoom. */
+  pinchRef?: MutableRefObject<GestureType | undefined>;
+  /** True while a pinch is in progress. The legs are simultaneous with the pinch
+   *  (above), so RNGH won't fail them when it activates — gate both callbacks on
+   *  this or a small/slow pinch paints the hold under a finger. */
+  isPinchingSV?: SharedValue<boolean>;
+};
+
+/**
+ * Resolve an at-rest (un-zoomed) board tap to the hold **nearest** the touch
+ * point, as one full-bleed overlay instead of one detector per hold.
+ *
+ * Why this exists (#4496): HoldTargetLayer used to give every hold its own
+ * absolutely-positioned square View + GestureDetector, inflated to
+ * `max(ringDiameter * 1.6, 44)` px so small holds stay tappable. At fit-to-screen
+ * those squares overlap heavily, and overlapping sibling Views are arbitrated by
+ * **z-order** — the last hold in the list wins every touch inside its square,
+ * however far off-centre. Sets are concatenated in `set_ids` order, so on Kilter
+ * layout 1 (Bolt Ons, then Screw Ons) the screw-ons render last and sit on top:
+ * at a 340 dp board, 289 of 323 bolt-on centres (90%) fall inside some screw-on's
+ * 44 dp hit circle, so tapping the dead centre of a bolt-on handed the touch to a
+ * screw-on nine times in ten. That is the reported "only screw-ons get selected"
+ * plus the felt offset. Zooming "fixed" it only because the squares stop
+ * overlapping. One overlay + `resolveHoldAtPoint` replaces z-order with
+ * nearest-centre, which is what the user is actually aiming at.
+ *
+ * Residual limit, on purpose: every hold on a board shares one hit radius
+ * (`r = xSpacing * 4` for Aurora boards, a constant cell radius for MoonBoard),
+ * so nearest-centre is a plain Voronoi partition of the board. That removes the
+ * bias but not the fineness: on Kilter layout 1 at 340 dp the holds sit 13.4 dp
+ * apart, so each cell is only ~6.7 dp (~1.1 mm) wide — far under a fingertip. A
+ * miss is now unbiased and deterministic rather than systematically the same
+ * neighbour, and zooming still gives you room, but landing on one specific hold
+ * at fit-to-screen still takes care. A precision affordance (auto-zoom on first
+ * tap, confirm-and-nudge) is the open half of #4496 and is not attempted here.
+ *
+ * Composition is `Gesture.Race(longPress, tap)`, never `Exclusive`: Exclusive
+ * makes the tap wait for the long-press to fail, which only happens on
+ * finger-up, so a composite that later grows a pan leg deadlocks. With Race the
+ * first leg to activate wins — a quick release activates the tap, a 400ms hold
+ * activates the long-press and cancels the tap. Both legs fail on movement
+ * (`maxDistance`), which is what lets a drag reach the parent scroll instead of
+ * turning into a whole-board long-press. See REST_LONG_PRESS_MAX_DISTANCE_PX.
+ *
+ * The composed gesture is built ONCE per mount: its deps are only stable shared
+ * values, and the JS handlers read render-scoped values (hitTargets, callbacks)
+ * through a ref. Rebuilding a live gesture mid-session has wedged iOS RNGH
+ * before (see use-carousel-gesture / use-zoom-pan-gesture).
+ */
+export function useRestHoldTapGesture({
+  hitTargets,
+  onTap,
+  onLongPress,
+  pinchRef,
+  isPinchingSV,
+}: UseRestHoldTapGestureOptions): ComposedGesture | null {
+  const hasTap = onTap != null;
+
+  const callbacksRef = useRef({ hitTargets, onTap, onLongPress });
+  callbacksRef.current = { hitTargets, onTap, onLongPress };
+
+  // Identity-stable for the life of the hook: both read every render-scoped
+  // value through callbacksRef, so neither needs a dep. That stability is what
+  // makes the capture in the gesture memo below safe — a fresh function per
+  // render would be captured once and go stale, or force the whole composite to
+  // rebuild mid-session.
+  const handleTap = useCallback((boardX: number, boardY: number) => {
+    const current = callbacksRef.current;
+    if (!current.onTap) return;
+    const holdId = resolveHoldAtPoint(boardX, boardY, current.hitTargets);
+    if (holdId != null) current.onTap(holdId);
+  }, []);
+  const handleLongPress = useCallback((boardX: number, boardY: number) => {
+    const current = callbacksRef.current;
+    const handler = current.onLongPress ?? current.onTap;
+    if (!handler) return;
+    const holdId = resolveHoldAtPoint(boardX, boardY, current.hitTargets);
+    if (holdId != null) handler(holdId);
+  }, []);
+
+  return useMemo(() => {
+    if (!hasTap) return null;
+
+    // The overlay sits inside the board's zoom transform and is only mounted
+    // while un-zoomed (scale 1, no translation), so the gesture's local x/y are
+    // already board-local render px — no inverse transform needed here.
+    const tap = Gesture.Tap()
+      .maxDuration(REST_TAP_MAX_DURATION_MS)
+      .maxDistance(REST_TAP_MAX_DISTANCE_PX)
+      .onStart((event) => {
+        'worklet';
+        if (isPinchingSV?.value) return;
+        runOnJS(handleTap)(event.x, event.y);
+      });
+
+    const longPress = Gesture.LongPress()
+      .minDuration(REST_LONG_PRESS_MIN_DURATION_MS)
+      .maxDistance(REST_LONG_PRESS_MAX_DISTANCE_PX)
+      .onStart((event) => {
+        'worklet';
+        if (isPinchingSV?.value) return;
+        runOnJS(handleLongPress)(event.x, event.y);
+      });
+
+    // Applied per-leg — the relation method is on the individual gestures, not
+    // the Race composite.
+    if (pinchRef) {
+      tap.simultaneousWithExternalGesture(pinchRef);
+      longPress.simultaneousWithExternalGesture(pinchRef);
+    }
+
+    return Gesture.Race(longPress, tap);
+    // handleTap/handleLongPress are useCallback([]) — listed for honesty, they
+    // never change, so this composite is still built once per mount.
+  }, [hasTap, pinchRef, isPinchingSV, handleTap, handleLongPress]);
+}

--- a/packages/mobile/src/components/create-climb/use-zoomed-hold-tap-gesture.ts
+++ b/packages/mobile/src/components/create-climb/use-zoomed-hold-tap-gesture.ts
@@ -3,16 +3,16 @@ import { Gesture, type ComposedGesture, type GestureType } from 'react-native-ge
 import { runOnJS, type SharedValue } from 'react-native-reanimated';
 import { resolveHoldAtPoint, type HoldHitTarget } from './holdLayout';
 
-// Match the per-hold detectors in HoldTarget.tsx so a tap while zoomed behaves
-// identically to a tap at rest. Keep in sync. As in HoldTarget, a release in the
-// 300–400ms gap between maxDuration and minDuration fires neither tap nor
-// long-press — intentional parity with the at-rest behaviour, not a new dead zone.
+// Match the at-rest overlay (use-rest-hold-tap-gesture) so a tap while zoomed
+// behaves identically to a tap at rest. Keep in sync. As at rest, a release in
+// the 300–400ms gap between maxDuration and minDuration fires neither tap nor
+// long-press — intentional parity, not a new dead zone.
 const TAP_MAX_DURATION_MS = 300;
 const TAP_MAX_DISTANCE_PX = 15;
 const LONG_PRESS_MIN_DURATION_MS = 400;
 
 // Tap/LongPress default to a single pointer, so a 2-finger pinch fails them and
-// falls through to the ancestor pinch — same as HoldTarget.tsx at rest.
+// falls through to the ancestor pinch — same as the at-rest overlay.
 
 /** Default drag distance (px) before the zoom-pan activates. Boards that compose
  *  this hook pass it to useZoomPanGesture's `panActivationOffset`, so a stationary
@@ -34,7 +34,7 @@ type UseZoomedHoldTapGestureOptions = {
    *  pan unchanged — used by zone mode, which has no per-hold taps. */
   onTap?: (holdId: number) => void;
   /** Long-press handler (role sheet). Falls back to onTap when omitted, matching
-   *  HoldTargetLayer which wires both. */
+   *  the at-rest overlay. */
   onLongPress?: (holdId: number) => void;
   /** The board's ancestor pinch. The overlay's tap/long-press declare themselves
    *  simultaneous with it so a pinch-to-zoom-further while already zoomed isn't

--- a/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
+++ b/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
@@ -1,5 +1,4 @@
 import React, {
-  useCallback,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -8,14 +7,15 @@ import React, {
   type RefObject,
 } from 'react';
 import { View, StyleSheet } from 'react-native';
-import Animated, { runOnJS, type SharedValue } from 'react-native-reanimated';
-import { Gesture, GestureDetector, type GestureType } from 'react-native-gesture-handler';
+import Animated, { type SharedValue } from 'react-native-reanimated';
+import { GestureDetector, type GestureType } from 'react-native-gesture-handler';
 import type { BoardName, HoldsFilter } from '@boardsesh/shared-schema';
 import { BoardImageNative } from '../BoardImageNative';
 import { ResetZoomButton } from '../board-controls/ResetZoomButton';
 import { useZoomPanGesture } from '../play-drawer/use-zoom-pan-gesture';
 import { HoldTargetLayer } from '../create-climb/HoldTargetLayer';
-import { holdGeometry, buildHoldHitTargets, resolveHoldAtPoint } from '../create-climb/holdLayout';
+import { holdGeometry, buildHoldHitTargets } from '../create-climb/holdLayout';
+import { useRestHoldTapGesture } from '../create-climb/use-rest-hold-tap-gesture';
 import { useZoomedHoldTapGesture, PAN_ACTIVATION_OFFSET } from '../create-climb/use-zoomed-hold-tap-gesture';
 import { spacing } from '../../theme/tokens';
 import type { BoardHoldTarget } from '../../lib/create-board-holds';
@@ -123,16 +123,14 @@ export type FilterBoardControls = {
   resetZoom: () => void;
 };
 
-const TAP_MAX_DURATION_MS = 300;
-const TAP_MAX_DISTANCE_PX = 15;
-const LONG_PRESS_MIN_DURATION_MS = 400;
-
 /**
  * Full-bleed interactive board for the search hold filter, built on the same
- * no-SVG gesture model as `InteractiveCreateBoard`: the board PNG plus plain RN
- * tap targets and filter rings INSIDE the zoom-transformed view, so taps and
- * rings track holds at any zoom with no manual coordinate math. Pinch is always
- * live; the 1-finger pan only mounts while zoomed.
+ * no-SVG gesture model as `InteractiveCreateBoard`: the board PNG plus one
+ * full-bleed tap overlay and the filter rings INSIDE the zoom-transformed view,
+ * so taps and rings track holds at any zoom with no manual coordinate math. The
+ * overlay resolves a touch to the nearest hold centre (#4496); the dots below it
+ * are markers only. Pinch is always live; the 1-finger pan only mounts while
+ * zoomed.
  *
  * Unlike the create board this lives on a full-screen route (not a bottom
  * sheet), so the pan overlay can stay simpler — there's no parent scroll to
@@ -157,9 +155,9 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
   renderAboveBoard,
   controlRef,
 }: InteractiveFilterBoardProps) {
-  // Shared with the per-hold detectors and the rest/zoom tap overlays so they
-  // mark themselves simultaneous with the pinch — same Android pinch-stall fix
-  // as the create board (two fingers on two hold targets must not block pinch).
+  // Shared with the rest/zoom tap overlays so they mark themselves simultaneous
+  // with the pinch — same Android pinch-stall fix as the create board (a finger
+  // resting on an overlay must not block pinch).
   const pinchRef = useRef<GestureType | undefined>(undefined);
   const {
     pinchGesture,
@@ -182,10 +180,6 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
     pinchRef,
   });
 
-  // The picker uses a long-press-style commit, but holds here only need a single
-  // tap to open the picker, so we route both tap and "long press" to the same
-  // handler (HoldTargetLayer requires both).
-
   const transformContext = useMemo<FilterBoardTransformContext>(
     () => ({
       pinchGesture,
@@ -203,48 +197,24 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
 
   useImperativeHandle(controlRef, () => ({ zoomTo, resetZoom }), [zoomTo, resetZoom]);
 
-  // Hit circles so the zoomed pan overlay can resolve a tap to a hold itself
-  // (it sits above the per-hold detectors — see #2687). Zone mode passes no
-  // onHoldTap, so the hook returns the bare pan and this is unused.
+  // Hit circles both tap overlays resolve a point against. Zone mode passes no
+  // onHoldTap, so the rest overlay is null and the zoomed hook returns the bare
+  // pan.
   const hitTargets = useMemo(
     () => buildHoldHitTargets(holdTargets, boardWidth, boardHeight, renderWidth, renderHeight, mirrored),
     [holdTargets, boardWidth, boardHeight, renderWidth, renderHeight, mirrored],
   );
-  const hasHoldTap = onHoldTap != null;
-  const holdTapResolutionRef = useRef({ hitTargets, onHoldTap });
-  holdTapResolutionRef.current = { hitTargets, onHoldTap };
-  const handleRestHoldTap = useCallback((boardX: number, boardY: number) => {
-    const current = holdTapResolutionRef.current;
-    if (!current.onHoldTap) return;
-    const holdId = resolveHoldAtPoint(boardX, boardY, current.hitTargets);
-    if (holdId != null) current.onHoldTap(holdId);
-  }, []);
-  const restHoldTapGesture = useMemo(() => {
-    if (!hasHoldTap) return null;
-
-    const tap = Gesture.Tap()
-      .maxDuration(TAP_MAX_DURATION_MS)
-      .maxDistance(TAP_MAX_DISTANCE_PX)
-      .onStart((event) => {
-        'worklet';
-        // Bail if a pinch is active (see isPinchingSV) so a small pinch over the
-        // board doesn't also open the hold picker on release.
-        if (isPinchingSV?.value) return;
-        runOnJS(handleRestHoldTap)(event.x, event.y);
-      });
-    const longPress = Gesture.LongPress()
-      .minDuration(LONG_PRESS_MIN_DURATION_MS)
-      .onStart((event) => {
-        'worklet';
-        if (isPinchingSV?.value) return;
-        runOnJS(handleRestHoldTap)(event.x, event.y);
-      });
-    // Let the ancestor pinch recognize even while a finger sits on this overlay
-    // — applied per-leg (the relation method is on the individual gestures).
-    tap.simultaneousWithExternalGesture(pinchRef);
-    longPress.simultaneousWithExternalGesture(pinchRef);
-    return Gesture.Exclusive(longPress, tap);
-  }, [hasHoldTap, handleRestHoldTap, isPinchingSV]);
+  // At rest, one full-bleed overlay resolves the tap to the nearest hold centre.
+  // HoldTargetLayer below is markers only, so nothing competes for the touch
+  // (#4496).
+  const restHoldTapGesture = useRestHoldTapGesture({
+    hitTargets,
+    // The picker opens on a single tap, so a long press routes to the same
+    // handler (the hook falls back to onTap when onLongPress is omitted).
+    onTap: onHoldTap,
+    pinchRef,
+    isPinchingSV,
+  });
 
   const overlayGesture = useZoomedHoldTapGesture({
     zoomPanGesture,
@@ -254,8 +224,8 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
     containerWidthSV,
     containerHeightSV,
     hitTargets,
-    // Long-press falls back to onTap in the hook, so a held hold opens the
-    // picker too — same as HoldTargetLayer wiring both to onHoldTap at rest.
+    // The picker opens on a single tap, so a long press routes to the same
+    // handler (the hook falls back to onTap when onLongPress is omitted).
     onTap: onHoldTap,
     pinchRef,
     isPinchingSV,
@@ -330,10 +300,6 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
                 mirrored={mirrored}
                 showAllHolds
                 showHoldMarkers={showHoldMarkers}
-                onPaint={onHoldTap}
-                onLongPress={onHoldTap}
-                pinchRef={pinchRef}
-                isPinchingSV={isPinchingSV}
               />
             ) : null}
             {!isZoomed && restHoldTapGesture ? (

--- a/packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import type { HoldsFilter } from '@boardsesh/shared-schema';
 import type { BoardHoldTarget } from '../../../lib/create-board-holds';
@@ -57,6 +57,7 @@ vi.mock('react-native-gesture-handler', () => {
       Tap: createGesture,
       LongPress: createGesture,
       Exclusive: (...gestures: unknown[]) => ({ gestures }),
+      Race: (...gestures: unknown[]) => ({ gestures }),
     },
     GestureDetector: ({ children, gesture }: ChildrenProps & { gesture?: { zoomedPanOverlay?: boolean } }) =>
       createElement(
@@ -92,6 +93,17 @@ vi.mock('../../create-climb/use-zoomed-hold-tap-gesture', () => ({
   PAN_ACTIVATION_OFFSET: 8,
 }));
 
+// The at-rest overlay's arbitration is covered by use-rest-hold-tap-gesture's
+// own tests; here we only assert this board wires it (and stops relying on the
+// per-hold detectors).
+const restTapCalls = vi.hoisted(() => [] as Record<string, unknown>[]);
+vi.mock('../../create-climb/use-rest-hold-tap-gesture', () => ({
+  useRestHoldTapGesture: (options: Record<string, unknown>) => {
+    restTapCalls.push(options);
+    return options.onTap ? { composed: 'race' } : null;
+  },
+}));
+
 vi.mock('../../BoardImageNative', () => ({
   BoardImageNative: () => createElement('div', { 'data-board-image': 'true' }),
 }));
@@ -106,27 +118,28 @@ vi.mock('../../Text', () => ({
   Text: ({ children }: ChildrenProps) => createElement('span', null, children),
 }));
 
-// HoldTargetLayer renders a tap button per hold so the test can fire a tap and
-// assert it routes back through onHoldTap (wired to onPaint).
+// HoldTargetLayer is markers only — it takes no handlers and never hit-tests.
+// The mock records the props it was handed so a test can assert that.
 type HoldTargetLayerMockProps = {
   holdTargets: BoardHoldTarget[];
   showAllHolds: boolean;
   showHoldMarkers?: boolean;
-  onPaint: (id: number) => void;
 };
+const holdLayerProps = vi.hoisted(() => [] as Record<string, unknown>[]);
 vi.mock('../../create-climb/HoldTargetLayer', () => ({
-  HoldTargetLayer: ({ holdTargets, showAllHolds, showHoldMarkers, onPaint }: HoldTargetLayerMockProps) =>
-    createElement(
+  HoldTargetLayer: (props: HoldTargetLayerMockProps & Record<string, unknown>) => {
+    holdLayerProps.push(props);
+    const { holdTargets: holds, showAllHolds, showHoldMarkers } = props;
+    return createElement(
       'div',
       {
         'data-hold-layer': 'true',
         'data-show-all-holds': String(showAllHolds),
         'data-show-hold-markers': String(showHoldMarkers),
       },
-      holdTargets.map((hold) =>
-        createElement('button', { key: hold.id, 'data-hold-id': hold.id, onClick: () => onPaint(hold.id) }),
-      ),
-    ),
+      holds.map((hold) => createElement('div', { key: hold.id, 'data-hold-id': hold.id })),
+    );
+  },
 }));
 
 vi.mock('../../../theme/tokens', () => ({
@@ -180,29 +193,39 @@ describe('InteractiveFilterBoard', () => {
   beforeEach(() => {
     zoomState.isZoomed = false;
     zoomState.resetZoom.mockClear();
+    restTapCalls.length = 0;
+    holdLayerProps.length = 0;
   });
 
-  it('renders the board image, filter rings, and a tap target per hold', () => {
+  it('renders the board image, filter rings, and a marker per hold', () => {
     const { container } = renderBoard();
     expect(container.querySelector('[data-board-image="true"]')).not.toBeNull();
     expect(container.querySelector('[data-rings="true"]')).not.toBeNull();
     expect(container.querySelectorAll('[data-hold-id]').length).toBe(holdTargets.length);
   });
 
-  it('routes a hold tap to onHoldTap with the hold id', () => {
-    const { container, onHoldTap } = renderBoard();
-    const tapTarget = container.querySelector('[data-hold-id="20"]') as HTMLButtonElement;
-    fireEvent.click(tapTarget);
-    expect(onHoldTap).toHaveBeenCalledTimes(1);
-    expect(onHoldTap).toHaveBeenCalledWith(20);
+  it('arbitrates at-rest taps through the nearest-hold overlay, not per-hold z-order', () => {
+    const { onHoldTap } = renderBoard();
+    // The hold layer takes no handlers, so nothing under the overlay hit-tests
+    // and z-order can't decide the winner any more (#4496).
+    const layerProps = holdLayerProps.at(-1) ?? {};
+    for (const gestureProp of ['onPaint', 'onLongPress', 'pinchRef', 'isPinchingSV', 'interactive']) {
+      expect(layerProps).not.toHaveProperty(gestureProp);
+    }
+    const restOptions = restTapCalls.at(-1);
+    expect(restOptions?.onTap).toBe(onHoldTap);
+    // One hit circle per hold, so the overlay can resolve by distance.
+    expect(restOptions?.hitTargets).toHaveLength(holdTargets.length);
+    expect(restOptions?.pinchRef).toBeDefined();
   });
 
-  it('can hide visible hold markers while keeping tap targets', () => {
+  it('can hide the hold markers while the overlay keeps taking taps', () => {
     const { container } = renderBoard({ showHoldMarkers: false });
     const holdLayer = container.querySelector('[data-hold-layer="true"]');
     expect(holdLayer?.getAttribute('data-show-all-holds')).toBe('true');
     expect(holdLayer?.getAttribute('data-show-hold-markers')).toBe('false');
-    expect(container.querySelectorAll('[data-hold-id]').length).toBe(holdTargets.length);
+    // The overlay is independent of the markers, so taps keep working.
+    expect(restTapCalls.at(-1)?.onTap).toBeDefined();
   });
 
   it('shows no reset control while not zoomed', () => {


### PR DESCRIPTION
## Summary

Refs #4496

At fit-to-screen, the create board resolved a tap by **view z-order over grossly oversized square hit boxes**, not by proximity.

`holdGeometry` inflates every hold's tap target to `Math.max(ringDiameter * 1.6, 44)` px (`holdLayout.ts`, `MIN_TAP_DIAMETER = 44`) so small holds stay reachable, and `HoldTarget` rendered that as an absolutely-positioned **square** `View` with its own `GestureDetector`. Overlapping sibling views are arbitrated by render order, so the last hold in the list won every touch inside its square, however far off-centre the finger landed.

### The measurement

Sets are concatenated in `set_ids` order (`board-details.ts`), and Kilter layout 1 is `[1 Bolt Ons, 20 Screw Ons]` — so screw-ons render last and sit on top. At a 340 dp board (size 10, 1080 px source):

| | |
| --- | --- |
| painted ring | 18.9 dp |
| hit circle | **44 dp** (the a11y floor wins) |
| nearest-neighbour spacing | 13.4 dp |
| other hold centres inside one hit circle | 5 (median), 6 (max) |
| bolt-on centres inside *some* screw-on's hit circle | **289 / 323 (90%)** |

So tapping the dead centre of a bolt-on handed the touch to a screw-on nine times out of ten. That is all three reported symptoms: only screw-ons get selected, the hit region feels shifted, zooming fixes it (the squares stop overlapping).

### What changed

- New `useRestHoldTapGesture` (`packages/mobile/src/components/create-climb/use-rest-hold-tap-gesture.ts`): one full-bleed overlay that resolves an at-rest tap to the **nearest hold centre** via the existing `resolveHoldAtPoint`. It's the at-rest twin of `useZoomedHoldTapGesture` and shares the same hit circles, so a point resolves to the same hold whether you're zoomed or not.
- `InteractiveCreateBoard` mounts that overlay while un-zoomed; the existing zoomed pan overlay takes over above `ZOOM_THRESHOLD`. Exactly one tap surface is live at a time.
- The create board drops `HoldTargetLayer` altogether. #4978 moved the board's hold drawing to the real renderer and its discoverability dots to `HoldMarkerLayer`, *under* the rendered holds — so the layer up top was already down to nothing but per-hold hit-testing, and with the overlay in place it had nothing left to do.
- `HoldTarget` / `HoldTargetLayer` lose their gesture path entirely. The layer is markers only now — one dot per hold, `pointerEvents="none"` throughout, no `onPaint` / `onLongPress` / `pinchRef` / `isPinchingSV` props to wire. There's no `interactive` flag either: a board can't accidentally opt back into the broken mode.
- `InteractiveFilterBoard` (the search hold filter) had a hand-rolled copy of the same at-rest arbitration; it now calls the shared hook, so the two can't drift. Its old composition was `Gesture.Exclusive(longPress, tap)`; the shared hook uses `Gesture.Race`.

### Which change is load-bearing

The overlay is. A topmost full-bleed detector beats the per-hold detectors underneath — which is exactly why `InteractiveFilterBoard` was already fine before this PR: it has mounted its own rest overlay above `HoldTargetLayer` since #2687. The create board had no such overlay, so its per-hold squares owned every at-rest touch. Deleting the per-hold gesture path doesn't fix the bug, it removes the way back into it (and hundreds of `GestureDetector`s per board along with it).

### Not swallowing the sheet scroll

The create board lives inside `CreateDrawer`'s scroll view, so a full-bleed gesture at rest could easily eat scrolling.

- Composition is `Gesture.Race(longPress, tap)`, never `Exclusive`. With `Exclusive` the tap waits for the long-press to fail, which only happens on finger-up; `Race` lets the first leg to *activate* win — quick release is a tap, a 400 ms hold is a long-press.
- Both legs fail on movement. The long-press gets an explicit `maxDistance` of 8 px, matching the zoomed board's `PAN_ACTIVATION_OFFSET`, so a drag started inside the 400 ms window cancels the overlay and reaches the scroll view instead of becoming a whole-board long-press. RNGH's default is 10 px; the named constant makes the intent and the parity explicit.
- Both legs stay `simultaneousWithExternalGesture(pinchRef)` and bail on `isPinchingSV`, so pinch-to-zoom still works and a small pinch doesn't paint the hold under a finger.

### What's left of #4496 — why this is `Refs`, not `Closes`

The issue is "hold selection is inaccurate **and** imprecise". This fixes the inaccurate half: the systematic bias to screw-ons and the felt offset are gone, and the 90% mis-hit rate on bolt-on centres goes to 0.

The imprecise half is not fixed. Every hold on a board shares one hit radius (`r = xSpacing * 4` on Aurora boards, one cell radius on MoonBoard), so nearest-centre is a plain Voronoi partition — each hold's cell is half the 13.4 dp spacing, about **6.7 dp (~1.1 mm)** at fit-to-screen. That's well under a fingertip. Misses are now unbiased and deterministic instead of always landing on the same neighbour, and zooming still gives you room, but going for one specific hold in a dense cluster at full-board zoom still takes care.

Closing that half needs a precision affordance rather than better arbitration — auto-zoom on first tap, tap-to-magnify, or confirm-and-nudge. Left open for that.

### About the web half of the report

The reporter also saw this on the web app. The www climbing surface that rendered an interactive board moved to the Expo app in #4435, so that renderer no longer exists in `packages/web`. The Expo browser build (`/app`) runs this same React Native code and picks up the fix here. The one hold-picking surface left in `packages/web` is the MoonBoard import editor (`board-litup-holds.tsx`), which hit-tests real SVG `<circle>` elements at their true radius with no inflation — it doesn't have this bug, so there's no follow-up to file.

**Author verification**

- The genuine regression tests are the three that fail against the old code: `HoldTarget.test.tsx` (the component must render no `GestureDetector` and never touch RNGH), and the assertions in `interactive-create-board-taps.test.tsx` / `interactive-filter-board.test.tsx` that the create board mounts no per-hold layer and the filter board's layer is handed no gesture props at all.
- `use-rest-hold-tap-gesture.test.ts` is unit coverage of the new hook, **not** a regression test for the bug: `resolveHoldAtPoint` already did nearest-centre before this PR, so its assertions would pass against `main` too. The bug lived in which native view received the touch, which no unit test can reach. Its fixture uses the real geometry (equal 22 dp radii, 13.4 dp apart) rather than an invented big-hold/small-hold pair.
- `interactive-create-board-layers.test.tsx` keeps #4978's depth contract honest across this change: the dots stay in the board image's under-overlay slot, and there is now no second dot layer above the holds.
- Rebased onto `main` after #4978 (renderer-drawn create board) and #5107 (pinch/pan) landed; typecheck, lint and the mobile suite are re-run on the rebased tree before this leaves draft.
- Still owed, device QA: real-finger check on a Kilter board that bolt-ons are selectable at rest, and that the create drawer still scrolls under a press-then-drag.

## Release Notes

- Tapping holds in the climb creator now picks the hold you actually touched
- Before, at full-board zoom a handful of screw-ons grabbed every tap and the whole board felt offset — on a Kilter original, 9 out of 10 bolt-on centres were inside a screw-on's hit circle, so bolt-ons were basically unselectable unless you pinched in first
- Dense clusters are still tight at full-board zoom, so pinch in when you're going for one specific hold

## Test plan

1. Signed in, Kilter original board selected.
2. Climbs tab → + → at full-board zoom tap a bolt-on next to a screw-on → the bolt-on paints.
3. Long-press a hold → the role sheet opens.
4. Press then drag on the board → the sheet still scrolls.

## Risk

Risk: 2/5 — gesture routing on the create and filter boards, covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQS6oJQe1isqM6CZurcnLg
