### PR TITLE
fix(web): route the gym claim form off the server's capability flag (#4018)

### DIFF
--- a/packages/backend/src/__tests__/find-similar-gyms-and-auto-gym.test.ts
+++ b/packages/backend/src/__tests__/find-similar-gyms-and-auto-gym.test.ts
@@ -62,12 +62,23 @@ const insertGym = async (opts: {
   longitude?: number | null;
   deleted?: boolean;
   isPublic?: boolean;
+  website?: string | null;
+  websiteVouchedByOwner?: boolean;
 }): Promise<{ id: number; uuid: string }> => {
-  const { ownerId, name, latitude = null, longitude = null, deleted = false, isPublic = true } = opts;
+  const {
+    ownerId,
+    name,
+    latitude = null,
+    longitude = null,
+    deleted = false,
+    isPublic = true,
+    website = null,
+    websiteVouchedByOwner = false,
+  } = opts;
   const uuid = uuidv4();
   const result = await db.execute(sql`
-    INSERT INTO gyms (uuid, name, slug, owner_id, is_public, latitude, longitude, deleted_at, created_at, updated_at)
-    VALUES (${uuid}, ${name}, ${uuid}, ${ownerId}, ${isPublic}, ${latitude}, ${longitude}, ${deleted ? sql`now()` : null}, now(), now())
+    INSERT INTO gyms (uuid, name, slug, owner_id, is_public, latitude, longitude, website, website_vouched_by_owner, deleted_at, created_at, updated_at)
+    VALUES (${uuid}, ${name}, ${uuid}, ${ownerId}, ${isPublic}, ${latitude}, ${longitude}, ${website}, ${websiteVouchedByOwner}, ${deleted ? sql`now()` : null}, now(), now())
     RETURNING id
   `);
   return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid };
@@ -205,6 +216,55 @@ describe('findSimilarGyms — matching tiers', () => {
     expect(own.providerOrigins).toEqual([]);
     // The querier owns this gym, so they cannot claim it.
     expect(own.isClaimable).toBe(false);
+  });
+
+  it('reports canClaimByDomain per listing, independently of isClaimable (#4018)', async () => {
+    // The two flags answer different questions — "may this viewer claim?" vs
+    // "can the website on file drive the email claim?" — and the suggestion card
+    // routes on the second. Conflating them puts a climber back on a dead-end
+    // email form, which is the bug.
+    const vouched = await insertGym({
+      ownerId: OTHER,
+      name: 'Boulder Bar',
+      latitude: LAT_60M,
+      longitude: BASE.longitude,
+      website: 'https://www.bonsist.bg',
+      websiteVouchedByOwner: true,
+    });
+    const unvouched = await insertGym({
+      ownerId: OTHER,
+      name: 'Boulder Bar',
+      latitude: LAT_120M,
+      longitude: BASE.longitude,
+      website: 'https://www.bonsist.bg',
+      websiteVouchedByOwner: false,
+    });
+    const freeProvider = await insertGym({
+      ownerId: OTHER,
+      name: 'Boulder Bar',
+      latitude: LAT_300M,
+      longitude: BASE.longitude,
+      website: 'https://mygym.wixsite.com',
+      websiteVouchedByOwner: true,
+    });
+
+    const byUuid = new Map(
+      (
+        await findSimilarGyms(
+          { name: 'Boulder Bar', latitude: BASE.latitude, longitude: BASE.longitude },
+          authCtx(QUERIER),
+        )
+      ).map((gym) => [gym.uuid, gym]),
+    );
+
+    // All three are claimable by this viewer; only the first can go by email.
+    expect(byUuid.get(vouched.uuid)!.isClaimable).toBe(true);
+    expect(byUuid.get(unvouched.uuid)!.isClaimable).toBe(true);
+    expect(byUuid.get(freeProvider.uuid)!.isClaimable).toBe(true);
+
+    expect(byUuid.get(vouched.uuid)!.canClaimByDomain).toBe(true);
+    expect(byUuid.get(unvouched.uuid)!.canClaimByDomain).toBe(false);
+    expect(byUuid.get(freeProvider.uuid)!.canClaimByDomain).toBe(false);
   });
 
   it("never enumerates another user's private gym, but includes the viewer's own private gym", async () => {

--- a/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
@@ -1356,7 +1356,12 @@ describe('canClaimByDomain advertises the requestGymClaim domain gate without be
     // canClaim and canClaimByDomain answer different questions: one is about the
     // viewer, one about the listing. An editor gets canClaim=false (the UI hides
     // the call-out entirely) while canClaimByDomain still describes the website.
-    const claimGym = await insertGym({ ownerId: OWNER, name: 'Editor View', website: 'https://www.bonsist.bg' });
+    const claimGym = await insertGym({
+      ownerId: OWNER,
+      name: 'Editor View',
+      website: 'https://www.bonsist.bg',
+      websiteVouchedByOwner: true,
+    });
     await socialGymMutations.grantGymWriteAccess(
       null,
       { input: { gymUuid: claimGym.uuid, userId: EDITOR_TARGET } },
@@ -1403,7 +1408,12 @@ describe('canClaimByDomain advertises the requestGymClaim domain gate without be
     // snake_case keys through mapRawGymRow. A camelCase read of
     // website_vouched_by_owner there is `undefined` — falsy — and every gym in
     // the proximity results would silently route to admin review.
-    const claimGym = await insertGym({ ownerId: OWNER, name: 'Proximity Row', website: 'https://www.bonsist.bg' });
+    const claimGym = await insertGym({
+      ownerId: OWNER,
+      name: 'Proximity Row',
+      website: 'https://www.bonsist.bg',
+      websiteVouchedByOwner: true,
+    });
     const rawRow = Array.from(
       (await db.execute(sql`SELECT * FROM gyms WHERE id = ${claimGym.id}`)) as Iterable<Record<string, unknown>>,
     )[0];

--- a/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
@@ -1256,6 +1256,164 @@ describe('requestGymClaim — the website must be owner-vouched to self-verify (
   });
 });
 
+// ============================================================================
+// #4018 — Gym.canClaimByDomain. Both claim UIs used to pick their form from
+// isClaimableDomain(website) alone, so an un-vouched gym with a company-looking
+// website opened the email form and only the mutation said no. The field
+// advertises the gate; requestGymClaim still IS the gate.
+// ============================================================================
+
+describe('canClaimByDomain advertises the requestGymClaim domain gate without becoming it (#4018)', () => {
+  type DomainCase = {
+    label: string;
+    website: string | null;
+    websiteVouchedByOwner: boolean;
+    claimEmail: string;
+    canClaimByDomain: boolean;
+    /** The refusal requestGymClaim must give when the capability is false. */
+    refusal?: RegExp;
+  };
+
+  const domainCases: DomainCase[] = [
+    {
+      label: 'a real company domain the owner put there',
+      website: 'https://www.bonsist.bg',
+      websiteVouchedByOwner: true,
+      claimEmail: 'manager@bonsist.bg',
+      canClaimByDomain: true,
+    },
+    {
+      label: 'a free-provider website, even when the owner put it there',
+      website: 'https://gmail.com',
+      websiteVouchedByOwner: true,
+      claimEmail: 'manager@gmail.com',
+      canClaimByDomain: false,
+      refusal: /no verifiable website domain/,
+    },
+    {
+      label: 'a real company domain nobody with ownership vouched for',
+      website: 'https://www.bonsist.bg',
+      websiteVouchedByOwner: false,
+      claimEmail: 'manager@bonsist.bg',
+      canClaimByDomain: false,
+      refusal: /hasn't been confirmed by the gym's owner/,
+    },
+    {
+      label: 'no website at all',
+      website: null,
+      websiteVouchedByOwner: false,
+      claimEmail: 'manager@bonsist.bg',
+      canClaimByDomain: false,
+      refusal: /no verifiable website domain/,
+    },
+  ];
+
+  for (const [index, domainCase] of domainCases.entries()) {
+    it(`is ${domainCase.canClaimByDomain} for ${domainCase.label}, and requestGymClaim agrees`, async () => {
+      const claimGym = await insertGym({
+        ownerId: OWNER,
+        name: `CanClaimByDomain ${index}`,
+        website: domainCase.website,
+        websiteVouchedByOwner: domainCase.websiteVouchedByOwner,
+      });
+
+      // A fresh claimant per case: applyRateLimit's tier-1 bucket is per-process
+      // and never reset between tests, so a shared fixture account would make
+      // the four cases order-dependent.
+      const claimant = `gw-domain-cap-${uuidv4()}`;
+      await insertUser(claimant);
+
+      const enriched = await socialGymQueries.gym(null, { gymUuid: claimGym.uuid }, authCtx(claimant));
+      expect(enriched).not.toBeNull();
+      expect(enriched!.canClaimByDomain).toBe(domainCase.canClaimByDomain);
+      // Viewer-independent, like isClaimed: the public gym page renders for
+      // signed-out visitors, so a viewer-dependent value here would route the
+      // anonymous "claim this gym" call-out at the wrong form.
+      expect((await socialGymQueries.gym(null, { gymUuid: claimGym.uuid }, anonCtx()))!.canClaimByDomain).toBe(
+        domainCase.canClaimByDomain,
+      );
+
+      // The pairing is the point: the field cannot quietly drift from the gate
+      // it advertises, because the same case exercises both.
+      const attempt = socialGymClaimMutations.requestGymClaim(
+        null,
+        { input: { gymUuid: claimGym.uuid, claimEmail: domainCase.claimEmail } },
+        authCtx(claimant),
+      );
+
+      if (domainCase.canClaimByDomain) {
+        await expect(attempt).resolves.toEqual({ status: 'email_sent', email: domainCase.claimEmail });
+        expect(sendGymClaimVerificationEmail).toHaveBeenCalledTimes(1);
+      } else {
+        await expect(attempt).rejects.toThrow(domainCase.refusal!);
+        expect(await claimRowCount(claimGym.id)).toBe(0);
+        expect(sendGymClaimVerificationEmail).not.toHaveBeenCalled();
+      }
+    });
+  }
+
+  it('stays false for someone who can already edit the gym, without ever claiming otherwise', async () => {
+    // canClaim and canClaimByDomain answer different questions: one is about the
+    // viewer, one about the listing. An editor gets canClaim=false (the UI hides
+    // the call-out entirely) while canClaimByDomain still describes the website.
+    const claimGym = await insertGym({ ownerId: OWNER, name: 'Editor View', website: 'https://www.bonsist.bg' });
+    await socialGymMutations.grantGymWriteAccess(
+      null,
+      { input: { gymUuid: claimGym.uuid, userId: EDITOR_TARGET } },
+      authCtx(OWNER),
+    );
+
+    const asEditor = await socialGymQueries.gym(null, { gymUuid: claimGym.uuid }, authCtx(EDITOR_TARGET));
+    expect(asEditor!.canClaim).toBe(false);
+    expect(asEditor!.canClaimByDomain).toBe(true);
+  });
+
+  it('flips to false the moment an editor rewrites the website, exactly as the mutation does', async () => {
+    const claimGym = await insertGym({ ownerId: OWNER, name: 'Rewrite Watch', website: null });
+    await socialGymMutations.updateGym(
+      null,
+      { input: { gymUuid: claimGym.uuid, website: 'https://bonsist.bg' } },
+      authCtx(OWNER),
+    );
+    await socialGymMutations.grantGymWriteAccess(
+      null,
+      { input: { gymUuid: claimGym.uuid, userId: EDITOR_TARGET } },
+      authCtx(OWNER),
+    );
+    expect((await socialGymQueries.gym(null, { gymUuid: claimGym.uuid }, anonCtx()))!.canClaimByDomain).toBe(true);
+
+    await socialGymMutations.updateGym(
+      null,
+      { input: { gymUuid: claimGym.uuid, website: 'https://attacker-owned.example' } },
+      authCtx(EDITOR_TARGET),
+    );
+
+    expect((await socialGymQueries.gym(null, { gymUuid: claimGym.uuid }, anonCtx()))!.canClaimByDomain).toBe(false);
+    await expect(
+      socialGymClaimMutations.requestGymClaim(
+        null,
+        { input: { gymUuid: claimGym.uuid, claimEmail: 'boss@attacker-owned.example' } },
+        authCtx(SECOND_TARGET),
+      ),
+    ).rejects.toThrow(/hasn't been confirmed by the gym's owner/);
+  });
+
+  it('survives the raw snake_case proximity row the PostGIS search path maps', async () => {
+    // searchGyms' PostGIS branch is a raw `SELECT *`, so enrichGym gets
+    // snake_case keys through mapRawGymRow. A camelCase read of
+    // website_vouched_by_owner there is `undefined` — falsy — and every gym in
+    // the proximity results would silently route to admin review.
+    const claimGym = await insertGym({ ownerId: OWNER, name: 'Proximity Row', website: 'https://www.bonsist.bg' });
+    const rawRow = Array.from(
+      (await db.execute(sql`SELECT * FROM gyms WHERE id = ${claimGym.id}`)) as Iterable<Record<string, unknown>>,
+    )[0];
+    expect(Object.keys(rawRow)).toContain('website_vouched_by_owner');
+
+    const enriched = await enrichGym(mapRawGymRow(rawRow), CLAIMANT);
+    expect(enriched.canClaimByDomain).toBe(true);
+  });
+});
+
 describe('requestGymClaim — admin-review path', () => {
   it('creates a pending admin claim + notifies the team when no email is given', async () => {
     const claimGym = await insertGym({ ownerId: OWNER, name: 'No Website Gym' });

--- a/packages/backend/src/graphql/resolvers/social/gym-claims.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-claims.ts
@@ -561,9 +561,11 @@ export const socialGymClaimMutations = {
       // leader is display-only here — otherwise that person could point it at a
       // domain they control and a second account of theirs would self-verify in.
       // Checked before the email match so a prober can't learn whether their
-      // address would have matched.
-      // TODO(#4018): both claim dialogs still offer the email form on an
-      // un-vouched gym, so this refusal only surfaces after submit.
+      // address would have matched. `Gym.canClaimByDomain` (enrichGym) mirrors
+      // this pair of conditions off the same `isClaimableDomain` helper so the
+      // claim UIs can open the admin-review form instead of dead-ending here on
+      // submit (#4018) — the UI has no enforcement role, this is still the only
+      // place the decision is made.
       if (!gym.websiteVouchedByOwner) {
         throw new Error(
           "This gym's website hasn't been confirmed by the gym's owner, so we can't verify you by email. Request admin review instead.",

--- a/packages/backend/src/graphql/resolvers/social/gym-matching.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-matching.ts
@@ -1,6 +1,7 @@
 import { and, eq, inArray, isNull, or, sql, type SQL } from 'drizzle-orm';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { distanceMeters, isGenericGymName, normalizeGymName } from '@boardsesh/db/queries';
+import { isClaimableDomain } from '@boardsesh/gym-claim';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
@@ -48,6 +49,8 @@ export type GymNameMatch = {
   name: string;
   address: string | null;
   website: string | null;
+  /** Whether the gym's OWNER put `website` on the listing — the provenance half of the domain-claim rule (#3431). */
+  websiteVouchedByOwner: boolean;
   ownerId: string;
   latitude: number | null;
   longitude: number | null;
@@ -62,6 +65,7 @@ const gymColumns = {
   name: dbSchema.gyms.name,
   address: dbSchema.gyms.address,
   website: dbSchema.gyms.website,
+  websiteVouchedByOwner: dbSchema.gyms.websiteVouchedByOwner,
   ownerId: dbSchema.gyms.ownerId,
   latitude: dbSchema.gyms.latitude,
   longitude: dbSchema.gyms.longitude,
@@ -537,6 +541,12 @@ export type SimilarGymResult = {
   distanceMeters: number | null;
   ownerType: 'SYSTEM' | 'USER';
   isClaimable: boolean;
+  /**
+   * Whether the website on file can drive the self-service email claim — a real
+   * (non-free-provider) domain the gym's OWNER put there. Answers a different
+   * question from `isClaimable`, which is about the viewer's standing.
+   */
+  canClaimByDomain: boolean;
   providerOrigins: string[];
 };
 
@@ -575,6 +585,9 @@ export const socialGymMatchQueries = {
       distanceMeters: candidate.distanceMeters,
       ownerType: candidate.ownerId === SYSTEM_BOARD_OWNER_ID ? 'SYSTEM' : 'USER',
       isClaimable: claimableByGym.get(candidate.id) ?? false,
+      // Same expression enrichGym uses, from the same helper requestGymClaim
+      // uses, so the three can't drift apart (#4018).
+      canClaimByDomain: isClaimableDomain(candidate.website) && candidate.websiteVouchedByOwner,
       providerOrigins: originsByGym.get(candidate.id) ?? [],
     }));
   },

--- a/packages/backend/src/graphql/resolvers/social/gyms.ts
+++ b/packages/backend/src/graphql/resolvers/social/gyms.ts
@@ -22,6 +22,7 @@ import {
   UUIDSchema,
 } from '../../../validation/schemas';
 import { distanceMeters } from '@boardsesh/db/queries';
+import { isClaimableDomain } from '@boardsesh/gym-claim';
 import { logger } from '../../../utils/logger';
 import { PROXIMITY_MATCH_RADIUS_METERS } from './gym-matching';
 import { syncLocationGeography } from './location-geography';
@@ -376,6 +377,17 @@ export async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenti
   // while looking correct in a logged-in dev session.
   const isClaimed = gym.ownerId !== SYSTEM_BOARD_OWNER_ID;
 
+  // Whether the website on file can drive the self-service email claim. Both
+  // halves of the rule requestGymClaim enforces, in the same order and from the
+  // same helper so the advertised capability can't drift from the gate: the
+  // website has to be a real organisational domain, AND the gym's own owner has
+  // to have put it there (#3431). Viewer-independent, like isClaimed — it
+  // describes the listing, not who is asking, so it stays correct for anonymous
+  // SSR. This carries NO enforcement: the decision lives in requestGymClaim and
+  // stays there. It exists so a claim UI opens the form that can succeed instead
+  // of dead-ending a climber on submit (#4018).
+  const canClaimByDomain = isClaimableDomain(gym.website) && gym.websiteVouchedByOwner;
+
   return {
     uuid: gym.uuid,
     slug: gym.slug,
@@ -412,6 +424,7 @@ export async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenti
     canGrantAccess,
     canClaim,
     isClaimed,
+    canClaimByDomain,
   };
 }
 

--- a/packages/mobile/src/components/gym-directory/ClaimGymSheet.tsx
+++ b/packages/mobile/src/components/gym-directory/ClaimGymSheet.tsx
@@ -3,12 +3,7 @@ import { StyleSheet, View } from 'react-native';
 import { BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import type { Gym } from '@boardsesh/shared-schema';
-import {
-  extractDomain,
-  isClaimableDomain,
-  GYM_CLAIM_MESSAGE_MAX_LENGTH,
-  GYM_CLAIM_SUPPORT_EMAIL,
-} from '@boardsesh/gym-claim';
+import { extractDomain, GYM_CLAIM_MESSAGE_MAX_LENGTH, GYM_CLAIM_SUPPORT_EMAIL } from '@boardsesh/gym-claim';
 import { ModalSheet } from '../ModalSheet';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
@@ -51,13 +46,18 @@ export function ClaimGymSheet({ sheetRef, gym, onClosed }: ClaimGymSheetProps) {
   const { systemColors, brandColors } = useTheme();
   const requestClaim = useRequestGymClaim();
 
+  // Display only: the domain printed in the copy and the placeholder.
   const domain = useMemo(() => extractDomain(gym.website), [gym.website]);
-  // A gym with a free/consumer-provider website (gmail.com, wixsite.com, …) can't
-  // be domain-proof claimed — anyone can get such an address — so start in and
-  // only offer admin review for those, matching the web dialog and the backend.
-  const canUseDomain = useMemo(() => isClaimableDomain(gym.website), [gym.website]);
+  // Which claim path can actually succeed, decided by the server. It is both
+  // halves of the rule requestGymClaim enforces: the website is a real
+  // (non-free-provider) domain — anyone can get a gmail.com/wixsite.com address —
+  // AND the gym's own owner put it there. This sheet used to derive only the
+  // first half from `gym.website`, so an un-vouched gym with a corporate-looking
+  // website opened the email form and the climber only heard "no" after
+  // submitting (#4018).
+  const canClaimByDomain = gym.canClaimByDomain;
 
-  const [mode, setMode] = useState<ClaimMode>(canUseDomain ? 'domain' : 'admin');
+  const [mode, setMode] = useState<ClaimMode>(canClaimByDomain ? 'domain' : 'admin');
   const [claimEmail, setClaimEmail] = useState('');
   const [message, setMessage] = useState('');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -67,14 +67,14 @@ export function ClaimGymSheet({ sheetRef, gym, onClosed }: ClaimGymSheetProps) {
   const [manageError, setManageError] = useState<string | null>(null);
 
   const resetState = useCallback(() => {
-    setMode(canUseDomain ? 'domain' : 'admin');
+    setMode(canClaimByDomain ? 'domain' : 'admin');
     setClaimEmail('');
     setMessage('');
     setErrorMessage(null);
     setConfirmation(null);
     setManageError(null);
     requestClaim.reset();
-  }, [canUseDomain, requestClaim]);
+  }, [canClaimByDomain, requestClaim]);
 
   const handleFullyDismissed = useCallback(() => {
     resetState();
@@ -188,7 +188,7 @@ export function ClaimGymSheet({ sheetRef, gym, onClosed }: ClaimGymSheetProps) {
             size="large"
           />
         </View>
-      ) : mode === 'domain' && canUseDomain && domain ? (
+      ) : mode === 'domain' && canClaimByDomain && domain ? (
         <>
           <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.description}>
             {t('mobile.gymClaim.domain.description', { gym: gym.name, domain })}
@@ -275,7 +275,7 @@ export function ClaimGymSheet({ sheetRef, gym, onClosed }: ClaimGymSheetProps) {
             loading={requestClaim.isPending}
             style={styles.submitButton}
           />
-          {canUseDomain ? (
+          {canClaimByDomain ? (
             <Button
               title={t('mobile.gymClaim.switchToDomain')}
               onPress={() => switchMode('domain')}

--- a/packages/mobile/src/components/gym-directory/__tests__/claim-gym-sheet.test.tsx
+++ b/packages/mobile/src/components/gym-directory/__tests__/claim-gym-sheet.test.tsx
@@ -69,7 +69,13 @@ import { ClaimGymSheet } from '../ClaimGymSheet';
 
 // No website, so the sheet opens in admin-review mode — the only path that can
 // come back `approved`.
-const gym = { uuid: 'gym-uuid-1', slug: null, name: 'Bonsist', website: null } as unknown as Gym;
+const gym = {
+  uuid: 'gym-uuid-1',
+  slug: null,
+  name: 'Bonsist',
+  website: null,
+  canClaimByDomain: false,
+} as unknown as Gym;
 const dismissMock = vi.fn();
 const sheetRef = { current: { dismiss: dismissMock } } as unknown as RefObject<ManagedSheetHandle | null>;
 
@@ -160,5 +166,43 @@ describe('ClaimGymSheet — claim outcome', () => {
     await waitFor(() => expect(screen.getByText('mobile.gymClaim.admin.sent')).toBeTruthy());
 
     expect(screen.queryByText('mobile.gymClaim.approved.manageCta')).toBeNull();
+  });
+});
+
+// A company-looking website is only half the rule: the gym's OWNER has to have
+// put it there. The sheet used to read only the first half off `gym.website`,
+// so an un-vouched listing opened the email form and the climber only heard
+// "no" after typing their work address (#4018).
+describe('ClaimGymSheet — which form opens comes from canClaimByDomain, not the website', () => {
+  beforeEach(() => {
+    mockMutateAsync.mockClear();
+  });
+
+  it('opens admin review on an un-vouched gym, even though the website looks claimable', () => {
+    renderSheet({ website: 'https://bonsist.bg', canClaimByDomain: false });
+
+    expect(screen.queryByText('mobile.gymClaim.domain.emailLabel')).toBeNull();
+    expect(screen.queryByText('mobile.gymClaim.domain.submit')).toBeNull();
+    // …and no offer to switch to a path that would be refused.
+    expect(screen.queryByText('mobile.gymClaim.switchToDomain')).toBeNull();
+    expect(screen.getByText('mobile.gymClaim.admin.submit')).toBeTruthy();
+  });
+
+  it('sends an admin-review claim with no claimEmail from that state', async () => {
+    mockMutateAsync.mockResolvedValueOnce({ status: 'admin_review', email: null });
+
+    renderSheet({ website: 'https://bonsist.bg', canClaimByDomain: false });
+    submit();
+
+    await waitFor(() => expect(mockMutateAsync).toHaveBeenCalledTimes(1));
+    const [input] = mockMutateAsync.mock.calls[0] as [Record<string, unknown>];
+    expect(input.gymUuid).toBe('gym-uuid-1');
+    expect('claimEmail' in input).toBe(false);
+  });
+
+  it('opens the email form on the same website once it is owner-vouched', () => {
+    renderSheet({ website: 'https://bonsist.bg', canClaimByDomain: true });
+
+    expect(screen.getByText('mobile.gymClaim.domain.submit')).toBeTruthy();
   });
 });

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2862,6 +2862,14 @@ type Gym {
   "Whether a real person owns this gym, as opposed to the system import user. Viewer-independent — unlike canClaim, which is false for every signed-out viewer."
   isClaimed: Boolean!
   """
+  Whether this gym's website can drive the self-service email claim: a real
+  (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
+  the two refusals in requestGymClaim, so a claim UI can open the form that
+  can actually succeed instead of dead-ending on submit. Viewer-independent —
+  unlike canClaim, this says nothing about who is asking.
+  """
+  canClaimByDomain: Boolean!
+  """
   The viewer's own unresolved claim on this gym, so a claimant who already
   filed sees "under review" instead of the claim call-out. A lazy field
   resolver with its own query — deliberately NOT part of enrichGym, which
@@ -2913,6 +2921,13 @@ type SimilarGym {
   ownerType: GymOwnerType!
   "Whether the current viewer can start an ownership claim for this gym."
   isClaimable: Boolean!
+  """
+  Whether this gym's website can drive the self-service email claim: a real
+  (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
+  the two refusals in requestGymClaim. Answers a different question from
+  isClaimable, which is about the viewer's standing, not the website.
+  """
+  canClaimByDomain: Boolean!
   "Upstream provider origins for a synced gym (e.g. \"kilter\", \"tension\"), from source-key prefixes. Empty for user-created gyms."
   providerOrigins: [String!]!
 }

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -2473,6 +2473,14 @@ export type Gym = {
   brandPrimaryColor?: Maybe<Scalars['String']['output']>;
   /** Whether the current viewer may start an ownership claim for this gym (signed-in and not already the owner/gym admin) */
   canClaim: Scalars['Boolean']['output'];
+  /**
+   * Whether this gym's website can drive the self-service email claim: a real
+   * (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
+   * the two refusals in requestGymClaim, so a claim UI can open the form that
+   * can actually succeed instead of dead-ending on submit. Viewer-independent —
+   * unlike canClaim, this says nothing about who is asking.
+   */
+  canClaimByDomain: Scalars['Boolean']['output'];
   /** Whether the current viewer may edit this gym (owner, gym admin, gym editor, or community admin/leader for one of its board types) */
   canEdit: Scalars['Boolean']['output'];
   /** Whether the current viewer may grant/revoke write access to other users (owner, gym admin, or community admin/leader for one of its board types) */
@@ -7463,6 +7471,13 @@ export type SimilarGym = {
   __typename?: 'SimilarGym';
   /** Physical address */
   address?: Maybe<Scalars['String']['output']>;
+  /**
+   * Whether this gym's website can drive the self-service email claim: a real
+   * (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
+   * the two refusals in requestGymClaim. Answers a different question from
+   * isClaimable, which is about the viewer's standing, not the website.
+   */
+  canClaimByDomain: Scalars['Boolean']['output'];
   /** Distance in metres from the supplied coordinates; null when no coordinates were given. */
   distanceMeters?: Maybe<Scalars['Float']['output']>;
   /** Whether the current viewer can start an ownership claim for this gym. */
@@ -10468,6 +10483,7 @@ export type GymResolvers<
   brandBackgroundColor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   brandPrimaryColor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   canClaim?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  canClaimByDomain?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   canEdit?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   canGrantAccess?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   commentCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -13336,6 +13352,7 @@ export type SimilarGymResolvers<
   ParentType extends ResolversParentTypes['SimilarGym'] = ResolversParentTypes['SimilarGym'],
 > = ResolversObject<{
   address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  canClaimByDomain?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   distanceMeters?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   isClaimable?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/packages/shared-schema/src/schema/gyms.ts
+++ b/packages/shared-schema/src/schema/gyms.ts
@@ -136,6 +136,14 @@ export const gymsTypeDefs = /* GraphQL */ `
     "Whether a real person owns this gym, as opposed to the system import user. Viewer-independent — unlike canClaim, which is false for every signed-out viewer."
     isClaimed: Boolean!
     """
+    Whether this gym's website can drive the self-service email claim: a real
+    (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
+    the two refusals in requestGymClaim, so a claim UI can open the form that
+    can actually succeed instead of dead-ending on submit. Viewer-independent —
+    unlike canClaim, this says nothing about who is asking.
+    """
+    canClaimByDomain: Boolean!
+    """
     The viewer's own unresolved claim on this gym, so a claimant who already
     filed sees "under review" instead of the claim call-out. A lazy field
     resolver with its own query — deliberately NOT part of enrichGym, which
@@ -187,6 +195,13 @@ export const gymsTypeDefs = /* GraphQL */ `
     ownerType: GymOwnerType!
     "Whether the current viewer can start an ownership claim for this gym."
     isClaimable: Boolean!
+    """
+    Whether this gym's website can drive the self-service email claim: a real
+    (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
+    the two refusals in requestGymClaim. Answers a different question from
+    isClaimable, which is about the viewer's standing, not the website.
+    """
+    canClaimByDomain: Boolean!
     "Upstream provider origins for a synced gym (e.g. \\"kilter\\", \\"tension\\"), from source-key prefixes. Empty for user-created gyms."
     providerOrigins: [String!]!
   }

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -107,8 +107,15 @@ export type Gym = {
    * Whether this gym's website can drive the self-service email claim: a real
    * (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
    * the two refusals in requestGymClaim, so a claim UI can open the form that
-   * can succeed. Viewer-independent, and required here because GYM_FIELDS
-   * selects it — every document typed `Gym` genuinely returns it.
+   * can succeed. Viewer-independent — it describes the listing, not the viewer.
+   *
+   * Required rather than optional even though NO document selects it yet:
+   * enrichGym always returns it, and requiring it is what forces every `Gym`
+   * fixture — and the client PR that follows — to acknowledge the field instead
+   * of silently reading `undefined` and routing a claimable gym to admin
+   * review. GYM_FIELDS starts selecting it one PR later, on purpose: a field
+   * the deployed backend cannot answer fails validation for the WHOLE document
+   * (same hazard as `myPendingClaim` below).
    */
   canClaimByDomain: boolean;
   /**

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -104,6 +104,14 @@ export type Gym = {
    */
   isClaimed: boolean;
   /**
+   * Whether this gym's website can drive the self-service email claim: a real
+   * (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
+   * the two refusals in requestGymClaim, so a claim UI can open the form that
+   * can succeed. Viewer-independent, and required here because GYM_FIELDS
+   * selects it — every document typed `Gym` genuinely returns it.
+   */
+  canClaimByDomain: boolean;
+  /**
    * The viewer's unresolved claim on this gym, or null when they have none.
    * OPTIONAL on purpose: only GET_GYM_BY_SLUG selects it. Adding it to the
    * shared GYM_FIELDS would put it in documents the mobile app ships, where a
@@ -145,6 +153,12 @@ export type SimilarGym = {
   distanceMeters?: number | null;
   ownerType: GymOwnerType;
   isClaimable: boolean;
+  /**
+   * Whether this gym's website can drive the self-service email claim: a real
+   * (non-free-provider) domain that the gym's OWNER put on the listing. A
+   * different question from `isClaimable`, which is about the viewer's standing.
+   */
+  canClaimByDomain: boolean;
   /** Upstream provider origins for a synced gym (e.g. "kilter"); empty for user-created gyms. */
   providerOrigins: string[];
 };

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -2470,6 +2470,14 @@ export type Gym = {
   brandPrimaryColor?: Maybe<Scalars['String']['output']>;
   /** Whether the current viewer may start an ownership claim for this gym (signed-in and not already the owner/gym admin) */
   canClaim: Scalars['Boolean']['output'];
+  /**
+   * Whether this gym's website can drive the self-service email claim: a real
+   * (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
+   * the two refusals in requestGymClaim, so a claim UI can open the form that
+   * can actually succeed instead of dead-ending on submit. Viewer-independent —
+   * unlike canClaim, this says nothing about who is asking.
+   */
+  canClaimByDomain: Scalars['Boolean']['output'];
   /** Whether the current viewer may edit this gym (owner, gym admin, gym editor, or community admin/leader for one of its board types) */
   canEdit: Scalars['Boolean']['output'];
   /** Whether the current viewer may grant/revoke write access to other users (owner, gym admin, or community admin/leader for one of its board types) */
@@ -7460,6 +7468,13 @@ export type SimilarGym = {
   __typename?: 'SimilarGym';
   /** Physical address */
   address?: Maybe<Scalars['String']['output']>;
+  /**
+   * Whether this gym's website can drive the self-service email claim: a real
+   * (non-free-provider) domain that the gym's OWNER put on the listing. Mirrors
+   * the two refusals in requestGymClaim. Answers a different question from
+   * isClaimable, which is about the viewer's standing, not the website.
+   */
+  canClaimByDomain: Scalars['Boolean']['output'];
   /** Distance in metres from the supplied coordinates; null when no coordinates were given. */
   distanceMeters?: Maybe<Scalars['Float']['output']>;
   /** Whether the current viewer can start an ownership claim for this gym. */

--- a/packages/shared/graphql/src/operations/gyms.ts
+++ b/packages/shared/graphql/src/operations/gyms.ts
@@ -87,6 +87,7 @@ const GYM_FIELDS = `
   canGrantAccess
   canClaim
   isClaimed
+  canClaimByDomain
 `;
 
 export const GET_GYM = gql`
@@ -203,6 +204,7 @@ export const FIND_SIMILAR_GYMS = gql`
       distanceMeters
       ownerType
       isClaimable
+      canClaimByDomain
       providerOrigins
     }
   }

--- a/packages/web/app/components/gym-entity/__tests__/claim-gym-dialog-analytics.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/claim-gym-dialog-analytics.test.tsx
@@ -34,7 +34,14 @@ const ClaimGymDialog = (await import('../claim-gym-dialog')).default;
 const renderAdminDialog = (gymUuid = 'gym-uuid-1') =>
   render(
     <QueryClientProvider client={createTestQueryClient()}>
-      <ClaimGymDialog gymUuid={gymUuid} gymName="Bonsist" website={null} open onClose={vi.fn()} />
+      <ClaimGymDialog
+        gymUuid={gymUuid}
+        gymName="Bonsist"
+        website={null}
+        canClaimByDomain={false}
+        open
+        onClose={vi.fn()}
+      />
     </QueryClientProvider>,
   );
 
@@ -72,6 +79,7 @@ describe('ClaimGymDialog — submit event', () => {
           gymUuid="gym-uuid-domain"
           gymName="Bonsist"
           website="https://bonsist.com"
+          canClaimByDomain
           open
           onClose={vi.fn()}
         />
@@ -137,7 +145,14 @@ describe('ClaimGymDialog — reuse across gyms', () => {
 
     const { rerender } = render(
       <QueryClientProvider client={createTestQueryClient()}>
-        <ClaimGymDialog gymUuid="first-gym" gymName="First" website={null} open onClose={vi.fn()} />
+        <ClaimGymDialog
+          gymUuid="first-gym"
+          gymName="First"
+          website={null}
+          canClaimByDomain={false}
+          open
+          onClose={vi.fn()}
+        />
       </QueryClientProvider>,
     );
     await submitAdminClaim();
@@ -145,12 +160,26 @@ describe('ClaimGymDialog — reuse across gyms', () => {
 
     rerender(
       <QueryClientProvider client={createTestQueryClient()}>
-        <ClaimGymDialog gymUuid="second-gym" gymName="Second" website={null} open={false} onClose={vi.fn()} />
+        <ClaimGymDialog
+          gymUuid="second-gym"
+          gymName="Second"
+          website={null}
+          canClaimByDomain={false}
+          open={false}
+          onClose={vi.fn()}
+        />
       </QueryClientProvider>,
     );
     rerender(
       <QueryClientProvider client={createTestQueryClient()}>
-        <ClaimGymDialog gymUuid="second-gym" gymName="Second" website={null} open onClose={vi.fn()} />
+        <ClaimGymDialog
+          gymUuid="second-gym"
+          gymName="Second"
+          website={null}
+          canClaimByDomain={false}
+          open
+          onClose={vi.fn()}
+        />
       </QueryClientProvider>,
     );
     await submitAdminClaim();

--- a/packages/web/app/components/gym-entity/__tests__/claim-gym-dialog-token-gating.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/claim-gym-dialog-token-gating.test.tsx
@@ -52,14 +52,18 @@ const ClaimGymDialog = (await import('../claim-gym-dialog')).default;
 // property" — read the DOM property instead.
 const isDisabled = (label: string) => (screen.getByRole('button', { name: label }) as HTMLButtonElement).disabled;
 
-const renderDialog = (website: string | null) =>
+// Both arguments are passed explicitly rather than deriving the capability from
+// the website: deriving it here would re-create in the test the exact coupling
+// the component just dropped, so a regression that went back to reading
+// `isClaimableDomain(website)` would still pass.
+const renderDialog = (website: string | null, canClaimByDomain: boolean) =>
   render(
     <QueryClientProvider client={createTestQueryClient()}>
       <ClaimGymDialog
         gymUuid="gym-uuid-1"
         gymName="Bonsist"
         website={website}
-        canClaimByDomain={website !== null}
+        canClaimByDomain={canClaimByDomain}
         open
         onClose={vi.fn()}
       />
@@ -76,7 +80,7 @@ const TOKEN_FAILURE_COPY = "We couldn't confirm you're logged in. Reload the pag
 
 describe('ClaimGymDialog — submit gating on the ws auth token', () => {
   it('disables the admin-review submit while the token is still null', () => {
-    renderDialog(null);
+    renderDialog(null, false);
 
     expect(isDisabled('Request review')).toBe(true);
   });
@@ -84,7 +88,7 @@ describe('ClaimGymDialog — submit gating on the ws auth token', () => {
   it('enables the admin-review submit once the token lands', () => {
     authTokenState.token = 'test-token';
 
-    renderDialog(null);
+    renderDialog(null, false);
 
     expect(isDisabled('Request review')).toBe(false);
   });
@@ -95,7 +99,7 @@ describe('ClaimGymDialog — submit gating on the ws auth token', () => {
     // strictly worse than the silent no-op the disabled state replaced.
     authTokenState.error = 'Failed to fetch auth token: 500';
 
-    renderDialog(null);
+    renderDialog(null, false);
 
     expect(screen.getByText(TOKEN_FAILURE_COPY)).toBeTruthy();
     expect(isDisabled('Request review')).toBe(true);
@@ -104,7 +108,7 @@ describe('ClaimGymDialog — submit gating on the ws auth token', () => {
   it('stays quiet while the token is still in flight', () => {
     authTokenState.isLoading = true;
 
-    renderDialog(null);
+    renderDialog(null, false);
 
     expect(screen.queryByText(TOKEN_FAILURE_COPY)).toBeNull();
     expect(isDisabled('Request review')).toBe(true);
@@ -113,13 +117,13 @@ describe('ClaimGymDialog — submit gating on the ws auth token', () => {
   it('shows no failure copy once the token lands', () => {
     authTokenState.token = 'test-token';
 
-    renderDialog(null);
+    renderDialog(null, false);
 
     expect(screen.queryByText(TOKEN_FAILURE_COPY)).toBeNull();
   });
 
   it('disables the domain submit with a null token even when the email is filled in', () => {
-    renderDialog('https://bonsist.example');
+    renderDialog('https://bonsist.example', true);
 
     fireEvent.change(screen.getByLabelText('Work email'), { target: { value: 'owner@bonsist.example' } });
 

--- a/packages/web/app/components/gym-entity/__tests__/claim-gym-dialog-token-gating.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/claim-gym-dialog-token-gating.test.tsx
@@ -55,7 +55,14 @@ const isDisabled = (label: string) => (screen.getByRole('button', { name: label 
 const renderDialog = (website: string | null) =>
   render(
     <QueryClientProvider client={createTestQueryClient()}>
-      <ClaimGymDialog gymUuid="gym-uuid-1" gymName="Bonsist" website={website} open onClose={vi.fn()} />
+      <ClaimGymDialog
+        gymUuid="gym-uuid-1"
+        gymName="Bonsist"
+        website={website}
+        canClaimByDomain={website !== null}
+        open
+        onClose={vi.fn()}
+      />
     </QueryClientProvider>,
   );
 

--- a/packages/web/app/components/gym-entity/__tests__/claim-gym-dialog.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/claim-gym-dialog.test.tsx
@@ -35,7 +35,14 @@ const GYM_UUID = 'gym-uuid-1';
 const renderDialog = () =>
   render(
     <QueryClientProvider client={createTestQueryClient()}>
-      <ClaimGymDialog gymUuid={GYM_UUID} gymName="Bonsist" website={null} open onClose={vi.fn()} />
+      <ClaimGymDialog
+        gymUuid={GYM_UUID}
+        gymName="Bonsist"
+        website={null}
+        canClaimByDomain={false}
+        open
+        onClose={vi.fn()}
+      />
     </QueryClientProvider>,
   );
 
@@ -86,5 +93,55 @@ describe('ClaimGymDialog — auto-approved claim', () => {
     await screen.findByText("Your claim is in the review queue. We'll email you as soon as it's decided.");
     // Nothing was transferred, so there is nothing to refresh.
     expect(mockRefresh).not.toHaveBeenCalled();
+  });
+});
+
+// A company-looking website is only half the rule: the gym's OWNER has to have
+// put it there. The dialog used to read the first half off `website` alone, so
+// an un-vouched listing opened the email form and the climber only heard "no"
+// after typing their work address (#4018).
+describe('ClaimGymDialog — which form opens comes from canClaimByDomain, not the website', () => {
+  const renderWithCapability = (canClaimByDomain: boolean) =>
+    render(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <ClaimGymDialog
+          gymUuid={GYM_UUID}
+          gymName="Bonsist"
+          website="https://bonsist.bg"
+          canClaimByDomain={canClaimByDomain}
+          open
+          onClose={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+  it('opens admin review on an un-vouched gym, even though the website looks claimable', () => {
+    renderWithCapability(false);
+
+    // No jest-dom here, so assert on the queried node itself.
+    expect(screen.queryByLabelText('Work email')).toBeNull();
+    expect(screen.queryByText('Send verification email')).toBeNull();
+    // …and no offer to switch to a path that would be refused.
+    expect(screen.queryByText('Verify with a work email instead')).toBeNull();
+    expect(screen.getByLabelText('Message (optional)')).not.toBeNull();
+  });
+
+  it('sends an admin-review claim with no claimEmail from that state', async () => {
+    mockRequest.mockResolvedValueOnce({ requestGymClaim: { status: 'admin_review', email: null } });
+
+    renderWithCapability(false);
+    fireEvent.click(await screen.findByText('Request review'));
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
+    const [, variables] = mockRequest.mock.calls[0] as [unknown, { input: Record<string, unknown> }];
+    expect(variables.input.gymUuid).toBe(GYM_UUID);
+    expect('claimEmail' in variables.input).toBe(false);
+  });
+
+  it('opens the email form on the same website once it is owner-vouched', async () => {
+    renderWithCapability(true);
+
+    expect(await screen.findByLabelText('Work email')).not.toBeNull();
+    expect(screen.queryByText('Send verification email')).not.toBeNull();
   });
 });

--- a/packages/web/app/components/gym-entity/__tests__/report-duplicate-dialog.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/report-duplicate-dialog.test.tsx
@@ -45,6 +45,7 @@ const gymFixture = (overrides: Partial<SimilarGym> = {}): SimilarGym => ({
   distanceMeters: 60,
   ownerType: 'SYSTEM',
   isClaimable: false,
+  canClaimByDomain: false,
   providerOrigins: ['kilter'],
   ...overrides,
 });

--- a/packages/web/app/components/gym-entity/__tests__/similar-gym-suggestions.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/similar-gym-suggestions.test.tsx
@@ -54,6 +54,7 @@ const gymFixture = (overrides: Partial<SimilarGym> = {}): SimilarGym => ({
   distanceMeters: 60,
   ownerType: 'SYSTEM',
   isClaimable: true,
+  canClaimByDomain: false,
   providerOrigins: ['kilter'],
   ...overrides,
 });

--- a/packages/web/app/components/gym-entity/claim-gym-dialog.tsx
+++ b/packages/web/app/components/gym-entity/claim-gym-dialog.tsx
@@ -19,7 +19,6 @@ import CircularProgress from '@mui/material/CircularProgress';
 import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutline';
 import {
   extractDomain,
-  isClaimableDomain,
   emailDomainMatchesWebsite,
   GYM_CLAIM_MESSAGE_MAX_LENGTH,
   GYM_CLAIM_SUPPORT_EMAIL,
@@ -39,6 +38,17 @@ type ClaimGymDialogProps = {
   gymUuid: string;
   gymName: string;
   website?: string | null;
+  /**
+   * `Gym.canClaimByDomain`, straight off the server. BOTH halves of the rule
+   * requestGymClaim enforces: the website is a real (non-free-provider) domain
+   * AND the gym's own owner put it there. Deriving it here from `website` alone
+   * — as this dialog used to — opens the email form on a gym whose website
+   * nobody with ownership vouched for, so the climber fills in a work address
+   * and only the mutation says no (#4018). Required, not defaulted: a missing
+   * value must be a compile error, never a silent `false` that hides the email
+   * path from a gym that can use it.
+   */
+  canClaimByDomain: boolean;
   open: boolean;
   onClose: () => void;
 };
@@ -50,15 +60,23 @@ function graphqlErrorMessage(error: unknown): string | null {
   return response?.errors?.[0]?.message ?? null;
 }
 
-export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClose }: ClaimGymDialogProps) {
+export default function ClaimGymDialog({
+  gymUuid,
+  gymName,
+  website,
+  canClaimByDomain,
+  open,
+  onClose,
+}: ClaimGymDialogProps) {
   const { t } = useTranslation('boards');
   const { token, isLoading: tokenLoading } = useWsAuthToken();
   const router = useRouter();
   const queryClient = useQueryClient();
+  // Still derived locally, and only for display: the domain we print in the
+  // copy and the placeholder. The routing decision is the server's.
   const domain = extractDomain(website);
-  const canUseDomain = isClaimableDomain(website);
 
-  const [mode, setMode] = useState<Mode>(canUseDomain ? 'domain' : 'admin');
+  const [mode, setMode] = useState<Mode>(canClaimByDomain ? 'domain' : 'admin');
   const [email, setEmail] = useState('');
   const [message, setMessage] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -68,7 +86,7 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
   const [approved, setApproved] = useState(false);
 
   const reset = useCallback(() => {
-    setMode(canUseDomain ? 'domain' : 'admin');
+    setMode(canClaimByDomain ? 'domain' : 'admin');
     setEmail('');
     setMessage('');
     setSubmitting(false);
@@ -76,7 +94,7 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
     setSentTo(null);
     setAdminSent(false);
     setApproved(false);
-  }, [canUseDomain]);
+  }, [canClaimByDomain]);
 
   // A single GymDetail/ClaimGymDialog instance is reused across gyms, so re-init
   // every time it opens — otherwise mode/inputs leak from the previously shown gym.
@@ -186,7 +204,7 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
         <DialogContentText>{t('claimGym.admin.sent')}</DialogContentText>
       </Box>
     );
-  } else if (mode === 'domain' && canUseDomain && domain) {
+  } else if (mode === 'domain' && canClaimByDomain && domain) {
     body = (
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
         <DialogContentText>{t('claimGym.domain.description', { gym: gymName, domain })}</DialogContentText>
@@ -229,7 +247,7 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
           placeholder={t('claimGym.admin.messagePlaceholder')}
           slotProps={{ htmlInput: { maxLength: GYM_CLAIM_MESSAGE_MAX_LENGTH } }}
         />
-        {canUseDomain && (
+        {canClaimByDomain && (
           <MuiLink
             component="button"
             type="button"
@@ -246,7 +264,7 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
 
   let primaryAction: React.ReactNode = null;
   if (!succeeded) {
-    if (mode === 'domain' && canUseDomain && domain) {
+    if (mode === 'domain' && canClaimByDomain && domain) {
       primaryAction = (
         <MuiButton
           variant="contained"

--- a/packages/web/app/components/gym-entity/gym-detail.tsx
+++ b/packages/web/app/components/gym-entity/gym-detail.tsx
@@ -399,6 +399,7 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
           gymUuid={gym.uuid}
           gymName={gym.name}
           website={gym.website}
+          canClaimByDomain={gym.canClaimByDomain}
           open={showClaimDialog}
           onClose={() => setShowClaimDialog(false)}
         />

--- a/packages/web/app/components/gym-entity/similar-gym-suggestions.tsx
+++ b/packages/web/app/components/gym-entity/similar-gym-suggestions.tsx
@@ -208,6 +208,7 @@ export default function SimilarGymSuggestions({ name, latitude, longitude }: Sim
           gymUuid={claimTarget.uuid}
           gymName={claimTarget.name}
           website={claimTarget.website}
+          canClaimByDomain={claimTarget.canClaimByDomain}
           open={claimTarget !== null}
           onClose={() => setClaimTarget(null)}
         />

--- a/packages/web/app/components/home-gym-card/__tests__/home-gym-card.test.tsx
+++ b/packages/web/app/components/home-gym-card/__tests__/home-gym-card.test.tsx
@@ -76,6 +76,7 @@ function makeGym(overrides?: Record<string, unknown>) {
     canEdit: true,
     canGrantAccess: true,
     canClaim: false,
+    canClaimByDomain: false,
     createdAt: '2024-01-01',
     boardTypes: ['kilter'],
     ...overrides,

--- a/packages/web/app/components/kiosk/embed/__tests__/embed-access.test.ts
+++ b/packages/web/app/components/kiosk/embed/__tests__/embed-access.test.ts
@@ -62,6 +62,7 @@ function makeGym(overrides: Partial<Gym> = {}): Gym {
     canGrantAccess: false,
     canClaim: false,
     isClaimed: true,
+    canClaimByDomain: false,
     ...overrides,
   };
 }

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-claim-cta.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-claim-cta.test.tsx
@@ -49,6 +49,7 @@ const renderCta = (props: Partial<React.ComponentProps<typeof GymClaimCta>> = {}
       gymName="Boulderwelt"
       gymSlug="boulderwelt"
       website={null}
+      canClaimByDomain={false}
       viewerState="signed-in"
       {...props}
     />,
@@ -273,7 +274,14 @@ function GatedClaimCta({
   });
   if (!isPublic || variant === 'hidden') return null;
   return (
-    <GymClaimCta gymUuid="gym-1" gymName="Boulderwelt" gymSlug="boulderwelt" website={null} viewerState={variant} />
+    <GymClaimCta
+      gymUuid="gym-1"
+      gymName="Boulderwelt"
+      gymSlug="boulderwelt"
+      website={null}
+      canClaimByDomain={false}
+      viewerState={variant}
+    />
   );
 }
 

--- a/packages/web/app/gym/[gym_slug]/gym-claim-cta.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-claim-cta.tsx
@@ -21,6 +21,14 @@ type GymClaimCtaProps = {
   gymSlug: string;
   website?: string | null;
   /**
+   * `Gym.canClaimByDomain` off the server page, forwarded to the dialog. It
+   * decides which claim form opens: the email one only when the website is a
+   * real domain the gym's OWNER put there. Viewer-independent, so the anonymous
+   * arm — the gym owner who just googled their own gym — routes as correctly as
+   * the signed-in one.
+   */
+  canClaimByDomain: boolean;
+  /**
    * Derived on the SERVER from the request's auth cookie and passed down, not
    * read here with `useSession()`. next-auth starts at `status: 'loading'` on
    * every page load and settles after a round-trip, so a tap that beats
@@ -41,7 +49,15 @@ type GymClaimCtaProps = {
  * visitor — the gym owner who just googled their own gym — gets the call-out
  * server-rendered and crawlable instead of gated behind a session.
  */
-export default function GymClaimCta({ gymUuid, gymName, gymSlug, website, viewerState, claimParam }: GymClaimCtaProps) {
+export default function GymClaimCta({
+  gymUuid,
+  gymName,
+  gymSlug,
+  website,
+  canClaimByDomain,
+  viewerState,
+  claimParam,
+}: GymClaimCtaProps) {
   const { t } = useTranslation('kiosk');
   const { openAuthModal } = useAuthModal();
   const router = useRouter();
@@ -114,6 +130,7 @@ export default function GymClaimCta({ gymUuid, gymName, gymSlug, website, viewer
         gymUuid={gymUuid}
         gymName={gymName}
         website={website}
+        canClaimByDomain={canClaimByDomain}
         open={open}
         onClose={() => setOpen(false)}
       />

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -437,6 +437,7 @@ export default async function GymPage(props: GymRouteProps) {
             gymName={gym.name}
             gymSlug={gym_slug}
             website={gym.website}
+            canClaimByDomain={gym.canClaimByDomain}
             viewerState={claimSurface.viewerState}
             claimParam={claimParam}
           />

--- a/packages/web/app/lib/__tests__/gym-role.test.ts
+++ b/packages/web/app/lib/__tests__/gym-role.test.ts
@@ -22,6 +22,7 @@ function makeGym(overrides?: Partial<Gym>): Gym {
     canGrantAccess: true,
     canClaim: false,
     isClaimed: true,
+    canClaimByDomain: false,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Closes #4018.

**Read this first: #4018 is a UI-routing / dead-end-form defect, not a security hole.** A reviewer who
sees "claim" and "vouched" will reasonably brace for the worst, so: the backend gate shipped in #3431
is real, it is correctly ordered — the vouch check runs **before** the email-domain match, so a prober
cannot learn whether their address would have matched — and it is covered end-to-end by
`gym-write-access-and-claims.test.ts`. Nothing in either PR moves, duplicates, or relaxes that
decision. `requestGymClaim` stays the only enforcement point; the UI gains no enforcement role. What
changes is which form a climber lands on.

### The bug

A gym's website may drive the self-service email claim only when **two** things hold: it's a real
organisational domain (not `gmail.com` / `wixsite.com`, where anyone can get an address), **and** the
gym's own owner put it on the listing. Both claim UIs saw only the first half — they called
`isClaimableDomain(website)` and never read `website_vouched_by_owner`, because it wasn't on the
GraphQL type. So on an un-vouched gym with a corporate-looking website, the dialog opened on the email
form, the climber typed their work address, and the mutation refused.

The population is narrow but real: the location sync never writes `gyms.website` at all, so an
un-vouched non-null website can only have been typed by a non-owner human — a gym editor, or a
community leader covering the listing.

**Not sizeable from telemetry, and please don't read the silence as "nobody hits this":** the gym
funnel events (`Gym Claim Submitted` / `Gym Claim Result`) return zero rows over the last 365 days in
PostHog, and `Gym Page CTA Clicked` first fires 2026-08-19. The instrumentation from #4501/#4510 only
just shipped.

### What changed

- `canClaimByDomain` added to the shared `GYM_FIELDS` selection set and to `FIND_SIMILAR_GYMS`.
  `SEARCH_GYMS_DIRECTORY` is deliberately untouched — its cards don't claim.
- `ClaimGymDialog` (web) and `ClaimGymSheet` (mobile) take the flag instead of deriving it. Both drop
  the `isClaimableDomain` import; both keep `extractDomain` (display copy) and, on web,
  `emailDomainMatchesWebsite` (the localized client-side mismatch check, so es/fr/de users don't get
  the backend's English string for the common typo).
- Threaded through the three web call sites: `gym-detail.tsx`, `similar-gym-suggestions.tsx`, and
  `gym-claim-cta.tsx` — the last gains a `canClaimByDomain` prop fed by the server page. Mobile needed
  no call-site change; both hosts already pass the whole `Gym`.
- **Zero copy changes, so zero i18n work.** Both surfaces already render the admin-review branch
  whenever the flag is false — including hiding the "verify with a work email instead" switch, which
  previously offered a path that could only be refused.

The prop is **required, not defaulted**. A missing value has to be a compile error: a silent `false`
would hide the email path from gyms that can use it, which is the same class of bug in the other
direction. That's why the `Gym` literal fixtures in the tests below needed updating rather than the
type being loosened.

### Merge order — not optional

**This PR must not merge until #4559 has deployed.** The production mobile OTA auto-publishes on every
push to `main` and can reach devices *before* the backend deploys, and an unknown field fails
validation for the **whole** GraphQL document — not just the field. Landing this `GYM_FIELDS`
selection first would break every mobile gym view for the length of the deploy window. Same hazard
already documented at `packages/shared/graphql/src/operations/gyms.ts:108-123` for `myPendingClaim`.

- **PR 1** — #4559, base `main`. Schema + resolvers + tests. Merge and deploy first.
- **PR 2 (this one)** — base `fix/4018-claim-vouched-domain` (PR 1's branch). Rebases onto `main` once
  PR 1 merges.

### Follow-ups filed, not built

- #4568 — an owner still can't re-confirm a website an editor typed (`IS DISTINCT FROM` is false for
  the same string), and no manage UI shows the vouch state. Marco's widened scope from the issue
  comments. Split out because it changes a mutation **input** contract and so carries the same
  deploy-ordering hazard again, plus new copy in four locales.
- #4569 — a domain claim token minted while the website was vouched still redeems for up to 24h after
  the vouch drops. Low severity, and the naive fix would break the legitimate SYSTEM-catalog claim, so
  it needs its own design.

## Release Notes

- Claiming your gym now opens the right form the first time — if your website was added by someone
  other than the gym's owner, you go straight to a quick review instead of filling in a work email
  that gets turned down.

## Test plan

`vp test run --project web claim-gym-dialog gym-claim-cta similar-gym-suggestions --reporter=agent`
and `vp run test:mobile` — see the CI run on this PR for the full green.

New coverage, mirrored on both platforms
(`claim-gym-dialog.test.tsx`, `claim-gym-sheet.test.tsx`):

- `website='https://bonsist.bg'` with `canClaimByDomain={false}` mounts the admin-review branch — no
  work-email field, no "send verification email", and no switch offering the domain path;
- submitting from that state puts an input on the wire with **no** `claimEmail`;
- the same website with `canClaimByDomain={true}` renders the email form, so the fix can't degrade
  into "always admin review".

Web assertions read DOM properties / `queryBy*` null directly — this repo's web test setup ships no
jest-dom, so `toBeDisabled` / `toBeChecked` throw "Invalid Chai property".

Backend coverage for the field itself lives in #4559 (136 tests green there), including the pairing
that stops the flag drifting from the gate: every capability assertion fires the matching
`requestGymClaim` in the same test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016552Be7ctNKKH8QM9rkryN
