### PR TITLE
feat(web): put MoonBoard in the sitemaps

### DIFF
--- a/docs/sitemap.md
+++ b/docs/sitemap.md
@@ -82,8 +82,10 @@ layout that has listed, non-draft climbs, and appends them to the listed configs
 backend deploy to a sitemap change and move the board picker underneath it.
 
 The synthetic configs carry `boardCount: 0` and `totalAscents: 0`, which is
-honest (there is no `user_boards` row shape behind them) and also keeps them last
-under `isBetterConfig`'s ordering, so the source is strictly additive. The
+honest (there is no `user_boards` row shape behind them) and nothing more. It
+does not hold them last in any ordering: `isBetterConfig` only ranks candidates
+within one `boardType:layoutId` group, so the source is additive in **content**
+and not in **ordinal** — see "Adding a board also moves `ordinal`" below. The
 `climbCount` is a plain grouped count over `board_climbs`, **not** the tier-2
 `DISTINCT ON` scan: both shards read that number only as a `> 0` gate, so making
 the boards shard pay the climbs shard's cost budget for a boolean would be the
@@ -129,9 +131,14 @@ emits nothing new — a change that looks complete in review and ships a no-op.
 half-done edit.
 
 Adding a board also moves `ordinal`, because `resolveClimbSitemapGroups` orders
-by board type rather than appending. That is a catalogue change, which is what
-`ordinal` is allowed to move for; each page stays self-contained and its
-`<lastmod>` is recomputed from the rows it actually holds.
+by board type rather than appending — the sort is a plain lexicographic compare
+on `boardType`, so `moonboard` landed between `kilter` and `soill` rather than on
+the end. On the dev image that pushed 15,032 Soill/Tension/Touchstone URLs from
+pages 3–5 onto pages 8–9. That is a catalogue change, which is what `ordinal` is
+allowed to move for; each page stays self-contained and its `<lastmod>` is
+recomputed from the rows it actually holds. A board type that must NOT move the
+existing ordinals needs an explicit rank in that sort — `boardCount` and
+`isBetterConfig` cannot deliver it, since neither is consulted across groups.
 
 ## Degrade at the index, fail closed at the shard
 
@@ -205,9 +212,16 @@ live scan they replaced, and the next refresh repopulates them.
 
 The page read (`buildClimbShardPage`) follows the same doctrine: an empty
 `sitemap_climb_urls` or a read that throws falls back to the live grouped build —
-the 51 s path, correct and never worse than before the store existed. There is no
-staleness bound on pages; the summary row's 48 h shout covers the store as a whole,
-since both tables share one refresh.
+the 51 s path, correct and never worse than before the store existed. It is
+TTL-cached per instance, so only the first request into an empty store pays it
+(measured on the dev image with MoonBoard in: 22.7 s for the first hit against a
+warm database, dev route compile included, then 0.40 s and 0.48 s; the same scan
+costs 64.9 s cold — see "What the refresh costs" below, it is the same builder).
+That is why the route exports `maxDuration = 300` — the `after()`
+self-heal only fires on `/sitemap.xml`, so a crawler that lands on a page URL
+first has to be allowed to finish the slow build rather than be cut off. There is
+no staleness bound on pages; the summary row's 48 h shout covers the store as a
+whole, since both tables share one refresh.
 
 ### Saying which path served (#4583)
 
@@ -347,6 +361,26 @@ commented out in `production-deploy.yml`.
 a second cron service: the refresh runs on the Railway scheduler
 (`refresh-sitemap-climbs`), and `registry.test.ts` reds if a path is scheduled
 on both sides.
+
+### What the refresh costs
+
+Worth stating as a range, because the spread between a warm and a cold Postgres
+is wide enough to mislead if only one end is quoted. All measured on the full
+dev image (648k climbs, 85,347 tier-2 URLs across 13 groups, MoonBoard included),
+through the real cron route:
+
+| database state                          | `scanDurationMs` | measured                       |
+| --------------------------------------- | ---------------- | ------------------------------ |
+| cold — container restarted, empty store | **64.9 s**       | #4578 review, reproduced twice |
+| warm, repeat runs on a loaded box       | 20.0 – 28.4 s    | #4578 review, three runs       |
+| warm, quiet box                         | 8.9 – 12.2 s     | #4578 authoring, two runs      |
+
+Budget against the **cold** number. `maxDuration` on the cron route is 300 s;
+scaling 64.9 s by production's projected 126,642 rows over the dev image's 85,347
+gives roughly **96 s**, so the margin is about 3x — not the 24x the warm figure
+suggests. The same scan is what `buildClimbShardPage` falls back to when the
+store is empty, which is why `/sitemaps/climbs/[page]` carries a `maxDuration`
+of its own.
 
 ### Refusals, and how to get out of one
 

--- a/docs/sitemap.md
+++ b/docs/sitemap.md
@@ -58,6 +58,81 @@ and all other sitemap shards are unaffected by the switch. Turning it off and ba
 on costs nothing but a redeploy: the store is a cache, and the `after()` self-heal
 below repopulates it on the first crawl.
 
+## Where board configurations come from
+
+Two shards need the list of board configurations to build URLs from, and they do
+**not** ask the same question. `board-config-source.ts` is the seam.
+
+`getAllBoardConfigsOrThrow` (`server-popular-configs.ts`) answers _which board
+pages are worth building_. It reads `popularBoardConfigs` from the backend, which
+builds its universe with a `GROUP BY` over `board_product_sizes_layouts_sets` —
+the Aurora sync tables. That is the right universe for the home rail and the
+mobile board picker, and it is why MoonBoard was in no sitemap for so long:
+nothing writes a psls row for MoonBoard. The only writers are the Aurora
+importers and no migration seeds one, so MoonBoard was never ranked out — it was
+never a candidate.
+
+The sitemap's question is _which climbs are worth indexing_, and MoonBoard is the
+largest board in the addressable set. Its configuration is not in the database at
+all; it is the static `MOONBOARD_LAYOUTS` / `MOONBOARD_SETS` tables that
+`getDefaultRenderBoard` already resolves for every renderer we ship. So
+`board-config-source.ts` synthesises one `PopularBoardConfig` per MoonBoard
+layout that has listed, non-draft climbs, and appends them to the listed configs
+— rather than changing what `popularBoardConfigs` returns, which would couple a
+backend deploy to a sitemap change and move the board picker underneath it.
+
+The synthetic configs carry `boardCount: 0` and `totalAscents: 0`, which is
+honest (there is no `user_boards` row shape behind them) and also keeps them last
+under `isBetterConfig`'s ordering, so the source is strictly additive. The
+`climbCount` is a plain grouped count over `board_climbs`, **not** the tier-2
+`DISTINCT ON` scan: both shards read that number only as a `> 0` gate, so making
+the boards shard pay the climbs shard's cost budget for a boolean would be the
+wrong trade.
+
+### Two callers, two fail policies
+
+|                                   | caller                 | on a MoonBoard count failure    |
+| --------------------------------- | ---------------------- | ------------------------------- |
+| `getSitemapClimbConfigsOrThrow()` | the climb shards       | **throws**                      |
+| `getBoardsShardConfigsOrThrow()`  | `/sitemaps/boards.xml` | logs, serves the listed configs |
+
+The strict one has to be strict. The climbs shard resolves its groups twice per
+crawl — once for the summary the index sizes pages from, once for the item build
+— and `pagedShardRouteHandler` throws "cache epochs disagree" the moment those two
+see different group sets. A tolerated failure there is worse than a 503.
+
+The tolerant one has no second builder to disagree with, and the arithmetic is
+lopsided: MoonBoard contributes 8 of `boards.xml`'s 668 items on the dev image
+against the listed configs' 660. Before this module existed no database failure
+could reach that shard at all — it was a GraphQL fetch behind a backend Redis
+cache with a one-year TTL — so 503ing 660 working Kilter/Tension/Decoy URLs
+because a grouped count timed out would be a regression bought with nothing. A
+failed **listed** fetch still throws on both paths: that is the leg whose loss
+would tell Google the boards were deleted.
+
+The count query carries a 10 s budget applied _inside_ the shared single-flight
+promise, so a give-up is not memoised and the next caller retries instead of
+joining a stall that already gave up. Nothing else bounds it: the pool sets
+`connect_timeout: 30` and `statement_timeout` is off by default (PgBouncer
+rejects it as a startup parameter — see `docs/db-connectivity.md`).
+
+### The refresher is the only door
+
+Since the climb store landed, adding a board to the sitemap means adding it to
+`buildAllTier2UrlRows()`, and nowhere else is sufficient. The shard pages do not
+build anything: they read `sitemap_climb_urls`, and that table is written by one
+refresher whose only selection entry point is that function. A config that
+reaches `/sitemaps/boards.xml` and the live summary fallback but not the
+refresher produces a store that has never heard of the board and a shard that
+emits nothing new — a change that looks complete in review and ships a no-op.
+`__tests__/moonboard-reaches-the-store.test.ts` exists to red exactly that
+half-done edit.
+
+Adding a board also moves `ordinal`, because `resolveClimbSitemapGroups` orders
+by board type rather than appending. That is a catalogue change, which is what
+`ordinal` is allowed to move for; each page stays self-contained and its
+`<lastmod>` is recomputed from the rows it actually holds.
+
 ## Degrade at the index, fail closed at the shard
 
 The doctrine splits by layer, and the split is deliberate.
@@ -404,6 +479,18 @@ milliseconds. What remains slow is the **fallback**: an empty
 the first refresh runs. The self-heal's empty-table probe bounds that window to one
 crawl of `/sitemap.xml`; the manual curl closes it immediately. Disabled requests do
 not reach either path; they return the cacheable 410.
+
+That one crawl really does degrade, and it is worth knowing what it looks like so
+nobody mistakes it for a regression. Measured on the dev image with the store
+truncated, over the thirteen groups the code resolved when this branch was
+cut — the shape is what matters here, and the counts are owed a re-measure
+since `main` widened the tier-2 angle predicate to the routable set: `/sitemap.xml`
+answers 200 in 4.3 s with `X-Sitemap-Degraded: climbs` and no climbs pages
+listed, then the `after()` self-heal writes 85,347 rows and every request after
+it is healthy at ~0.1 s. Do not reach for concurrency here — a fan-out over the
+group list was tried and dropped, because a cold thirteen-group scan does not fit
+in `SHARD_DEADLINE_MS` at any lane count and the pool is ten connections wide
+(#4461). The answer to a slow fallback is a refreshed store.
 
 Both shard paths now check bytes, and they check different numbers on purpose
 (#4618, closed by #4648).

--- a/docs/sitemap.md
+++ b/docs/sitemap.md
@@ -217,11 +217,13 @@ TTL-cached per instance, so only the first request into an empty store pays it
 (measured on the dev image with MoonBoard in: 22.7 s for the first hit against a
 warm database, dev route compile included, then 0.40 s and 0.48 s; the same scan
 costs 64.9 s cold — see "What the refresh costs" below, it is the same builder).
-That is why the route exports `maxDuration = 300` — the `after()`
-self-heal only fires on `/sitemap.xml`, so a crawler that lands on a page URL
-first has to be allowed to finish the slow build rather than be cut off. There is
-no staleness bound on pages; the summary row's 48 h shout covers the store as a
-whole, since both tables share one refresh.
+The `after()` self-heal only fires on `/sitemap.xml`, so a crawler that lands on
+a page URL first has to be allowed to finish that slow build rather than be cut
+off. On the Railway container it is, with nothing to configure: the route carries
+no `maxDuration`, for the same reason `/sitemap.xml` dropped its own (#4648) —
+there is no per-invocation ceiling to raise. There is no staleness bound on
+pages; the summary row's 48 h shout covers the store as a whole, since both
+tables share one refresh.
 
 ### Saying which path served (#4583)
 
@@ -375,12 +377,13 @@ through the real cron route:
 | warm, repeat runs on a loaded box       | 20.0 – 28.4 s    | #4578 review, three runs       |
 | warm, quiet box                         | 8.9 – 12.2 s     | #4578 authoring, two runs      |
 
-Budget against the **cold** number. `maxDuration` on the cron route is 300 s;
-scaling 64.9 s by production's projected 126,642 rows over the dev image's 85,347
-gives roughly **96 s**, so the margin is about 3x — not the 24x the warm figure
-suggests. The same scan is what `buildClimbShardPage` falls back to when the
-store is empty, which is why `/sitemaps/climbs/[page]` carries a `maxDuration`
-of its own.
+Budget against the **cold** number. `maxDuration` on the refresh route is still
+300 s — vestigial on the container, load-bearing only on the frozen Vercel
+rollback deployment; scaling 64.9 s by production's projected 126,642 rows over
+the dev image's 85,347 gives roughly **96 s**, so that margin is about 3x, not
+the 24x the warm figure suggests. The same scan is what `buildClimbShardPage`
+falls back to when the store is empty, and on the container that fallback has no
+ceiling to run into.
 
 ### Refusals, and how to get out of one
 

--- a/docs/web-reposition.md
+++ b/docs/web-reposition.md
@@ -501,22 +501,23 @@ Tier 2 — listed, non-draft climbs with at least ten ascents — now ships as p
 sitemap shards, and the five JSON-LD types the front doors were missing are
 emitted from one escaping helper.
 
-**The climb shards submit the default locale only.** This is a deliberate
-inconsistency with the boards shard, which does fan out to all four locales, and
-the difference is volume: boards is 690 items → 2,760 URLs; production emits
-52,842 climb items, which would fan out to 211,368 locale URLs, each carrying a
-five-entry `xhtml:link` block. Even one 10,000-item climb page would expand to
-40,000 URL entries and exceed Vercel's 4.5 MB serverless response ceiling.
+**The climb shards submit the default locale only** — and since #4648 so does
+the boards shard, so this is no longer an inconsistency to explain. The volume
+argument that motivated it stands on its own: production emits 52,842 climb
+items, which fanned out would be 211,368 locale URLs each carrying a five-entry
+`xhtml:link` block. One 10,000-item page would expand to 40,000 URL entries and
+take a page from ~2.5 MB to 8.7 MB, past `pagedShardByteBudget`'s 5 MB. Do not
+"fix" it by fanning climbs out.
 
 (Measured against production with the branch's exact angle, size, set, listing,
 ascent and alias predicates: 127,131 tier-2 climbs exist, while 52,842 resolve
-through a selected public board configuration → 6 pages. All 73,412 MoonBoard
-climbs are absent because there is no MoonBoard configuration, 69 Kilter layout-5
-climbs have no selected layout, and the chosen size/set predicates exclude 808
-more. An earlier 53,650 estimate stopped at the layout intersection and therefore
-overstated the emitted set by those 808. Nothing in the code depends on the
-snapshot count; the page count comes from the summary at request time.) Do not
-"fix" the inconsistency by fanning climbs out.
+through a selected public board configuration → 6 pages. 73,412 of the absent
+climbs were MoonBoard's, because no MoonBoard configuration existed to resolve
+through — lifted by #4493; 69 Kilter layout-5 climbs have no selected layout, and
+the chosen size/set predicates exclude 808 more. An earlier 53,650 estimate
+stopped at the layout intersection and therefore overstated the emitted set by
+those 808. Nothing in the code depends on the snapshot count; the page count
+comes from the summary at request time.)
 Nothing is noindexed — the locked decision on `/es`, `/fr` and `/de` climbing
 pages is untouched. They stay indexable, they stay link-discovered, and they
 carry reciprocal HTML hreflang from `createPageMetadata`'s `alternates.languages`,
@@ -628,19 +629,24 @@ production, the broken predicate matches **106,550 of 127,131** tier-2 climbs
 carries `alias_uuid <> canonical_uuid`; without it most of the sitemap vanishes
 silently while the remaining boards keep the shard non-empty.
 
-**MoonBoard configurations are held out of the shard.** `generateSetSlug` joins
-set-name slugs with `_`, while the MoonBoard page's parser
-(`getMoonBoardSetsBySlug`) splits the slug on `-` and substring-matches the parts
-— so the set slug the shard emits does not round-trip, and the page's own
-canonical comes back with a different set-id list. 212 of 227 layout×set
-combinations mismatch, the full set lists on masters-2017 and masters-2019
-included. `tryConstructSlugViewUrl` returns a URL for all 227, so the
-resolvability probe cannot see it; the hold-out is a separate, named exclusion.
-Costs nothing today (`getPopularConfigs()` emits no MoonBoard rows, excluding all
-73,412 production tier-2 MoonBoard climbs before this guard runs) and stops the
-shard going wrong the moment a `board_product_sizes_layouts_sets` seed lands.
-Lifting it means making `getMoonBoardSetsBySlug` an exact `generateSetNameSlug`
-match on `_`-split parts — a routing-parser change, not a sitemap one.
+**MoonBoard configurations were held out of the shard, and are not any more.**
+The hold-out existed because `generateSetSlug` joins set-name slugs with `_`
+while the MoonBoard page's parser (`getMoonBoardSetsBySlug`) split on `-` and
+substring-matched the parts, so the set slug the shard emitted did not round-trip
+and the page's own canonical came back with a different set-id list — 212 of 227
+layout×set combinations, the full set lists on masters-2017 and masters-2019
+included. `tryConstructSlugViewUrl` returned a URL for all 227, so the
+resolvability probe could not see it, which is why it had to be a separate named
+exclusion rather than a filter.
+
+#4576 made that parser an exact `generateSetNameSlug` match on `_`-split parts,
+pinned by a 291-tuple round-trip and a byte-identity suite over these groups, so
+the reason is gone and the exclusion went with it (#4493). MoonBoard reaches the
+shards through `board-config-source.ts`, which synthesises a `PopularBoardConfig`
+per layout with listed climbs — the configurations are static tables, not
+`board_product_sizes_layouts_sets` rows, which is why `popularBoardConfigs` never
+had them. See "Where board configurations come from" in
+[sitemap.md](./sitemap.md).
 
 **`<lastmod>` is the later of the climb-content and chosen-angle stats clocks.**
 Ascents and grades advance `board_climb_stats.updated_at`; name, description and

--- a/packages/web/app/lib/seo/sitemap/__tests__/board-config-source.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/board-config-source.test.ts
@@ -37,7 +37,11 @@ vi.mock('@/app/lib/server-popular-configs', () => ({
 }));
 
 /** Stands in for the grouped count query — one row per MoonBoard layout id. */
-const climbCounts = vi.hoisted(() => ({ rows: [] as { layoutId: number | null; climbCount: number }[], calls: 0 }));
+const climbCounts = vi.hoisted(() => ({
+  rows: [] as { layoutId: number | null; climbCount: number }[],
+  calls: 0,
+  throws: false,
+}));
 vi.mock('@/app/lib/db/db', () => ({
   dbzRead: {
     select: () => ({
@@ -45,6 +49,7 @@ vi.mock('@/app/lib/db/db', () => ({
         where: () => ({
           groupBy: async () => {
             climbCounts.calls += 1;
+            if (climbCounts.throws) throw new Error('read pool exhausted');
             return climbCounts.rows;
           },
         }),
@@ -66,6 +71,7 @@ beforeEach(() => {
   listed.throws = false;
   climbCounts.rows = ALL_LAYOUTS;
   climbCounts.calls = 0;
+  climbCounts.throws = false;
 });
 
 describe('getSitemapBoardConfigsOrThrow', () => {
@@ -149,6 +155,36 @@ describe('getSitemapBoardConfigsOrThrow', () => {
     expect(climbCounts.calls).toBe(1);
 
     resetSitemapBoardConfigCacheForTests();
+    await getSitemapBoardConfigsOrThrow();
+    expect(climbCounts.calls).toBe(2);
+  });
+
+  it('does not memoise a failed count, so a transient DB error is not an hour of missing MoonBoard', async () => {
+    // The in-process layer stores nothing on a rejection: `cachedCounts` is only
+    // assigned inside the `.then`. Without that, one unlucky read would pin an
+    // empty MoonBoard catalogue for the whole TTL and the sitemap would quietly
+    // lose 44k URLs while answering 200.
+    climbCounts.throws = true;
+    await expect(getSitemapBoardConfigsOrThrow()).rejects.toThrow('read pool exhausted');
+    expect(climbCounts.calls).toBe(1);
+
+    climbCounts.throws = false;
+    const moonboard = (await getSitemapBoardConfigsOrThrow()).filter((config) => config.boardType === 'moonboard');
+    expect(moonboard).toHaveLength(7);
+    expect(climbCounts.calls).toBe(2);
+  });
+
+  it('shares one rejection across concurrent callers, then lets the next one retry', async () => {
+    climbCounts.throws = true;
+    const inFlight = [
+      getSitemapBoardConfigsOrThrow(),
+      getSitemapBoardConfigsOrThrow(),
+      getSitemapBoardConfigsOrThrow(),
+    ];
+    await Promise.all(inFlight.map((pending) => expect(pending).rejects.toThrow('read pool exhausted')));
+    expect(climbCounts.calls).toBe(1);
+
+    climbCounts.throws = false;
     await getSitemapBoardConfigsOrThrow();
     expect(climbCounts.calls).toBe(2);
   });

--- a/packages/web/app/lib/seo/sitemap/__tests__/board-config-source.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/board-config-source.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vite-plus/test';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import type { PopularBoardConfig } from '@boardsesh/shared-schema';
+import { MOONBOARD_LAYOUTS } from '@/app/lib/moonboard-config';
 
 vi.mock('server-only', () => ({}));
 
@@ -41,6 +42,8 @@ const climbCounts = vi.hoisted(() => ({
   rows: [] as { layoutId: number | null; climbCount: number }[],
   calls: 0,
   throws: false,
+  /** A read that never comes back — the mode the pool's 30 s connect timeout and the absent statement_timeout leave unbounded. */
+  stalls: false,
 }));
 vi.mock('@/app/lib/db/db', () => ({
   dbzRead: {
@@ -50,6 +53,7 @@ vi.mock('@/app/lib/db/db', () => ({
           groupBy: async () => {
             climbCounts.calls += 1;
             if (climbCounts.throws) throw new Error('read pool exhausted');
+            if (climbCounts.stalls) return new Promise(() => {});
             return climbCounts.rows;
           },
         }),
@@ -58,11 +62,27 @@ vi.mock('@/app/lib/db/db', () => ({
   },
 }));
 
-const { buildMoonBoardClimbCountQuery, getSitemapBoardConfigsOrThrow, resetSitemapBoardConfigCacheForTests } =
-  await import('../board-config-source');
+const {
+  buildMoonBoardClimbCountQuery,
+  getBoardsShardConfigsOrThrow,
+  getSitemapClimbConfigsOrThrow,
+  resetSitemapBoardConfigCacheForTests,
+} = await import('../board-config-source');
 
-/** Every MoonBoard layout id carrying a climb count, so all seven are synthesised. */
-const ALL_LAYOUTS = [1, 2, 3, 4, 5, 6, 7].map((layoutId) => ({ layoutId, climbCount: 1_000 + layoutId }));
+/**
+ * Every MoonBoard layout id carrying a climb count, so all seven are synthesised.
+ *
+ * Derived from the catalogue, not a hardcoded `[1..7]`: with a literal list a new
+ * `MOONBOARD_LAYOUTS` entry gets no count row, `climbCount` resolves to 0, and
+ * `buildMoonBoardConfigs` drops it before `toHaveLength(7)` or the literal tuple
+ * list below can see it — so this file stayed green on a half-done catalogue edit
+ * that the source comment claims it catches. The EXPECTATIONS stay literal; only
+ * the input is derived.
+ */
+const ALL_LAYOUTS = Object.values(MOONBOARD_LAYOUTS).map(({ id }) => ({
+  layoutId: id,
+  climbCount: 1_000 + id,
+}));
 
 beforeEach(() => {
   resetSitemapBoardConfigCacheForTests();
@@ -72,11 +92,12 @@ beforeEach(() => {
   climbCounts.rows = ALL_LAYOUTS;
   climbCounts.calls = 0;
   climbCounts.throws = false;
+  climbCounts.stalls = false;
 });
 
-describe('getSitemapBoardConfigsOrThrow', () => {
+describe('getSitemapClimbConfigsOrThrow', () => {
   it('adds one MoonBoard config per layout, on top of the listed configs', async () => {
-    const configs = await getSitemapBoardConfigsOrThrow();
+    const configs = await getSitemapClimbConfigsOrThrow();
 
     // The listed configs pass through untouched and stay first — a synthetic
     // source that reordered or displaced them would be a different, riskier
@@ -102,7 +123,7 @@ describe('getSitemapBoardConfigsOrThrow', () => {
   });
 
   it('carries the measured climb count, and the names both shards fall back to', async () => {
-    const masters2017 = (await getSitemapBoardConfigsOrThrow()).find(
+    const masters2017 = (await getSitemapClimbConfigsOrThrow()).find(
       (config) => config.boardType === 'moonboard' && config.layoutId === 4,
     );
 
@@ -129,14 +150,14 @@ describe('getSitemapBoardConfigsOrThrow', () => {
       { layoutId: 4, climbCount: 0 },
     ];
 
-    const moonboard = (await getSitemapBoardConfigsOrThrow()).filter((config) => config.boardType === 'moonboard');
+    const moonboard = (await getSitemapClimbConfigsOrThrow()).filter((config) => config.boardType === 'moonboard');
     expect(moonboard.map((config) => config.layoutId)).toEqual([2]);
   });
 
   it('ignores a count row with no layout id', async () => {
     climbCounts.rows = [{ layoutId: null, climbCount: 12_345 }];
 
-    const moonboard = (await getSitemapBoardConfigsOrThrow()).filter((config) => config.boardType === 'moonboard');
+    const moonboard = (await getSitemapClimbConfigsOrThrow()).filter((config) => config.boardType === 'moonboard');
     expect(moonboard).toEqual([]);
   });
 
@@ -145,17 +166,25 @@ describe('getSitemapBoardConfigsOrThrow', () => {
     // summary at the same moment. `unstable_cache` does not deduplicate
     // concurrent misses, which is why the in-process single-flight is here.
     await Promise.all([
-      getSitemapBoardConfigsOrThrow(),
-      getSitemapBoardConfigsOrThrow(),
-      getSitemapBoardConfigsOrThrow(),
+      getSitemapClimbConfigsOrThrow(),
+      getSitemapClimbConfigsOrThrow(),
+      getSitemapClimbConfigsOrThrow(),
     ]);
     expect(climbCounts.calls).toBe(1);
+    // Exactly one listed-config call per request — the `Promise.all` leg — with
+    // deduplication delegated to `getAllBoardConfigsOrThrow`'s own in-process
+    // single-flight (which the mock deliberately does not reimplement, or this
+    // would be asserting the mock). Three requests, three legs: replacing the
+    // `Promise.all` with two sequential `getAllBoardConfigsOrThrow()` calls
+    // doubles this to six. Left unasserted, the counter implied coverage the
+    // file did not have.
+    expect(listed.calls).toBe(3);
 
-    await getSitemapBoardConfigsOrThrow();
+    await getSitemapClimbConfigsOrThrow();
     expect(climbCounts.calls).toBe(1);
 
     resetSitemapBoardConfigCacheForTests();
-    await getSitemapBoardConfigsOrThrow();
+    await getSitemapClimbConfigsOrThrow();
     expect(climbCounts.calls).toBe(2);
   });
 
@@ -165,11 +194,11 @@ describe('getSitemapBoardConfigsOrThrow', () => {
     // empty MoonBoard catalogue for the whole TTL and the sitemap would quietly
     // lose 44k URLs while answering 200.
     climbCounts.throws = true;
-    await expect(getSitemapBoardConfigsOrThrow()).rejects.toThrow('read pool exhausted');
+    await expect(getSitemapClimbConfigsOrThrow()).rejects.toThrow('read pool exhausted');
     expect(climbCounts.calls).toBe(1);
 
     climbCounts.throws = false;
-    const moonboard = (await getSitemapBoardConfigsOrThrow()).filter((config) => config.boardType === 'moonboard');
+    const moonboard = (await getSitemapClimbConfigsOrThrow()).filter((config) => config.boardType === 'moonboard');
     expect(moonboard).toHaveLength(7);
     expect(climbCounts.calls).toBe(2);
   });
@@ -177,15 +206,15 @@ describe('getSitemapBoardConfigsOrThrow', () => {
   it('shares one rejection across concurrent callers, then lets the next one retry', async () => {
     climbCounts.throws = true;
     const inFlight = [
-      getSitemapBoardConfigsOrThrow(),
-      getSitemapBoardConfigsOrThrow(),
-      getSitemapBoardConfigsOrThrow(),
+      getSitemapClimbConfigsOrThrow(),
+      getSitemapClimbConfigsOrThrow(),
+      getSitemapClimbConfigsOrThrow(),
     ];
     await Promise.all(inFlight.map((pending) => expect(pending).rejects.toThrow('read pool exhausted')));
     expect(climbCounts.calls).toBe(1);
 
     climbCounts.throws = false;
-    await getSitemapBoardConfigsOrThrow();
+    await getSitemapClimbConfigsOrThrow();
     expect(climbCounts.calls).toBe(2);
   });
 
@@ -194,7 +223,72 @@ describe('getSitemapBoardConfigsOrThrow', () => {
     // deleted. The shard route turns this throw into a 503.
     listed.throws = true;
 
-    await expect(getSitemapBoardConfigsOrThrow()).rejects.toThrow('backend unreachable');
+    await expect(getSitemapClimbConfigsOrThrow()).rejects.toThrow('backend unreachable');
+  });
+});
+
+describe('the count query is bounded', () => {
+  it('gives up on a stalled read instead of holding the shard open', async () => {
+    // Nothing else bounds this. `dbzRead`'s pool sets `connect_timeout: 30` and
+    // leaves `statement_timeout` off by default, so before this the only limit
+    // was the platform's — and the single-flight made every later caller join
+    // the stall rather than retry.
+    climbCounts.stalls = true;
+    vi.useFakeTimers();
+    try {
+      const pending = getSitemapClimbConfigsOrThrow();
+      const asserted = expect(pending).rejects.toThrow('exceeded its 10000ms budget');
+      await vi.advanceTimersByTimeAsync(10_000);
+      await asserted;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('lets the boards shard through on a stalled read', async () => {
+    climbCounts.stalls = true;
+    vi.useFakeTimers();
+    try {
+      const pending = getBoardsShardConfigsOrThrow();
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(await pending).toEqual([KILTER_CONFIG]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('getBoardsShardConfigsOrThrow', () => {
+  it('serves the listed configs when the MoonBoard count fails, rather than 503ing the whole shard', async () => {
+    // The lopsided trade this exists for: on the dev image MoonBoard contributes
+    // 8 of `/sitemaps/boards.xml`'s 668 items and the listed configs contribute
+    // 660. Before this module, no database failure could reach that shard at all.
+    climbCounts.throws = true;
+
+    const configs = await getBoardsShardConfigsOrThrow();
+
+    expect(configs).toEqual([KILTER_CONFIG]);
+  });
+
+  it('still throws when the listed configs fail', async () => {
+    listed.throws = true;
+
+    await expect(getBoardsShardConfigsOrThrow()).rejects.toThrow('backend unreachable');
+  });
+
+  it('carries the MoonBoard configs when the count succeeds', async () => {
+    const moonboard = (await getBoardsShardConfigsOrThrow()).filter((config) => config.boardType === 'moonboard');
+
+    expect(moonboard).toHaveLength(7);
+  });
+
+  it('does not swallow a MoonBoard failure for the climbs shard', async () => {
+    // Same module, opposite policy — the climbs shard resolves its groups twice
+    // per crawl and `pagedShardRouteHandler` throws "cache epochs disagree" if
+    // those two disagree, so a tolerated failure there is worse than a 503.
+    climbCounts.throws = true;
+
+    await expect(getSitemapClimbConfigsOrThrow()).rejects.toThrow('read pool exhausted');
   });
 });
 
@@ -211,12 +305,17 @@ describe('the MoonBoard climb-count query', () => {
   const normalised = sql.toLowerCase().replace(/\s+/g, ' ');
 
   it('counts only listed, non-draft MoonBoard climbs, grouped by layout', () => {
-    expect(normalised).toMatch(/"board_climbs"\."board_type" = \$\d+/);
-    expect(params).toContain('moonboard');
-    expect(normalised).toMatch(/"board_climbs"\."is_listed" = \$\d+/);
-    expect(normalised).toMatch(/"board_climbs"\."is_draft" = \$\d+/);
-    expect(params).toContain(true);
-    expect(params).toContain(false);
+    expect(normalised).toMatch(/"board_climbs"\."board_type" = \$\d+ and "board_climbs"\."is_listed" = \$\d+/);
+    expect(normalised).toMatch(/"board_climbs"\."is_listed" = \$\d+ and "board_climbs"\."is_draft" = \$\d+/);
+    // POSITIONAL, not `toContain` three times. Drizzle renders the predicate as
+    // `board_type = $1 and is_listed = $2 and is_draft = $3`, so swapping the two
+    // booleans leaves the SQL text identical and a position-blind assertion still
+    // green — while the query counts drafted, unlisted MoonBoard climbs, of which
+    // the dev image has zero. `fetchMoonBoardClimbCounts` would return an empty
+    // Map, all seven layouts would be dropped, and both shards would ship exactly
+    // what they ship today with `expectsUrls` never firing, because Kilter and
+    // Tension keep them non-empty.
+    expect(params).toEqual(['moonboard', true, false]);
     expect(normalised).toContain('group by "board_climbs"."layout_id"');
   });
 

--- a/packages/web/app/lib/seo/sitemap/__tests__/board-config-source.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/board-config-source.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi, beforeEach } from 'vite-plus/test';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import type { PopularBoardConfig } from '@boardsesh/shared-schema';
+
+vi.mock('server-only', () => ({}));
+
+/** The Data Cache is a pass-through here; the layer under test is the merge. */
+vi.mock('next/cache', () => ({ unstable_cache: (fn: (...args: never[]) => unknown) => fn }));
+
+const KILTER_CONFIG: PopularBoardConfig = {
+  boardType: 'kilter',
+  layoutId: 1,
+  layoutName: 'Kilter Board Original',
+  sizeId: 10,
+  sizeName: '12 x 12 with kickboard',
+  sizeDescription: '12 x 12 Square',
+  setIds: [1, 20],
+  setNames: ['Bolt Ons', 'Screw Ons'],
+  climbCount: 4200,
+  totalAscents: 99,
+  boardCount: 7,
+  displayName: 'Kilter OG 12x12',
+};
+
+/**
+ * Production's shape: `popularBoardConfigs` is driven by
+ * `board_product_sizes_layouts_sets`, which carries no MoonBoard row, so the
+ * listed configs never contain one. That is the premise this module exists for.
+ */
+const listed = vi.hoisted(() => ({ configs: [] as PopularBoardConfig[], calls: 0, throws: false }));
+vi.mock('@/app/lib/server-popular-configs', () => ({
+  getAllBoardConfigsOrThrow: async () => {
+    listed.calls += 1;
+    if (listed.throws) throw new Error('backend unreachable');
+    return listed.configs;
+  },
+}));
+
+/** Stands in for the grouped count query — one row per MoonBoard layout id. */
+const climbCounts = vi.hoisted(() => ({ rows: [] as { layoutId: number | null; climbCount: number }[], calls: 0 }));
+vi.mock('@/app/lib/db/db', () => ({
+  dbzRead: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          groupBy: async () => {
+            climbCounts.calls += 1;
+            return climbCounts.rows;
+          },
+        }),
+      }),
+    }),
+  },
+}));
+
+const { buildMoonBoardClimbCountQuery, getSitemapBoardConfigsOrThrow, resetSitemapBoardConfigCacheForTests } =
+  await import('../board-config-source');
+
+/** Every MoonBoard layout id carrying a climb count, so all seven are synthesised. */
+const ALL_LAYOUTS = [1, 2, 3, 4, 5, 6, 7].map((layoutId) => ({ layoutId, climbCount: 1_000 + layoutId }));
+
+beforeEach(() => {
+  resetSitemapBoardConfigCacheForTests();
+  listed.configs = [KILTER_CONFIG];
+  listed.calls = 0;
+  listed.throws = false;
+  climbCounts.rows = ALL_LAYOUTS;
+  climbCounts.calls = 0;
+});
+
+describe('getSitemapBoardConfigsOrThrow', () => {
+  it('adds one MoonBoard config per layout, on top of the listed configs', async () => {
+    const configs = await getSitemapBoardConfigsOrThrow();
+
+    // The listed configs pass through untouched and stay first — a synthetic
+    // source that reordered or displaced them would be a different, riskier
+    // change than the additive one this is meant to be.
+    expect(configs[0]).toEqual(KILTER_CONFIG);
+    expect(configs.filter((config) => config.boardType === 'kilter')).toEqual([KILTER_CONFIG]);
+
+    const moonboard = configs.filter((config) => config.boardType === 'moonboard');
+    expect(moonboard).toHaveLength(7);
+
+    // LITERAL tuples, not values re-derived by calling `getDefaultRenderBoard`
+    // in the test — that would assert `f(x) === f(x)` and stay green if the
+    // source started emitting a partial set list or the wrong size id.
+    expect(moonboard.map(({ layoutId, sizeId, setIds }) => ({ layoutId, sizeId, setIds }))).toEqual([
+      { layoutId: 1, sizeId: 1, setIds: [1] },
+      { layoutId: 2, sizeId: 1, setIds: [2, 3, 4] },
+      { layoutId: 3, sizeId: 1, setIds: [5, 6, 7, 8, 9, 10] },
+      { layoutId: 4, sizeId: 1, setIds: [11, 12, 13, 14, 15, 16] },
+      { layoutId: 5, sizeId: 1, setIds: [17, 18, 19, 20, 21, 22, 23] },
+      { layoutId: 6, sizeId: 1, setIds: [24, 25, 26, 27] },
+      { layoutId: 7, sizeId: 1, setIds: [28, 29, 30, 31] },
+    ]);
+  });
+
+  it('carries the measured climb count, and the names both shards fall back to', async () => {
+    const masters2017 = (await getSitemapBoardConfigsOrThrow()).find(
+      (config) => config.boardType === 'moonboard' && config.layoutId === 4,
+    );
+
+    expect(masters2017?.climbCount).toBe(1_004);
+    expect(masters2017?.layoutName).toBe('MoonBoard Masters 2017');
+    expect(masters2017?.sizeName).toBe('Standard');
+    expect(masters2017?.sizeDescription).toBe('11x18 Grid');
+    expect(masters2017?.setNames).toEqual([
+      'Hold Set A',
+      'Hold Set B',
+      'Hold Set C',
+      'Original School Holds',
+      'Screw-on Feet',
+      'Wooden Holds',
+    ]);
+    // Zero physical boards is the truth, and it also keeps every synthetic
+    // config last under `isBetterConfig`, so no Aurora group can be displaced.
+    expect(masters2017?.boardCount).toBe(0);
+  });
+
+  it('drops a layout with no listed climbs rather than shipping a thin /list page', async () => {
+    climbCounts.rows = [
+      { layoutId: 2, climbCount: 59_019 },
+      { layoutId: 4, climbCount: 0 },
+    ];
+
+    const moonboard = (await getSitemapBoardConfigsOrThrow()).filter((config) => config.boardType === 'moonboard');
+    expect(moonboard.map((config) => config.layoutId)).toEqual([2]);
+  });
+
+  it('ignores a count row with no layout id', async () => {
+    climbCounts.rows = [{ layoutId: null, climbCount: 12_345 }];
+
+    const moonboard = (await getSitemapBoardConfigsOrThrow()).filter((config) => config.boardType === 'moonboard');
+    expect(moonboard).toEqual([]);
+  });
+
+  it('runs the count query once across concurrent callers, then serves it from the TTL', async () => {
+    // One cold `/sitemap.xml` reaches this from the boards shard and the climbs
+    // summary at the same moment. `unstable_cache` does not deduplicate
+    // concurrent misses, which is why the in-process single-flight is here.
+    await Promise.all([
+      getSitemapBoardConfigsOrThrow(),
+      getSitemapBoardConfigsOrThrow(),
+      getSitemapBoardConfigsOrThrow(),
+    ]);
+    expect(climbCounts.calls).toBe(1);
+
+    await getSitemapBoardConfigsOrThrow();
+    expect(climbCounts.calls).toBe(1);
+
+    resetSitemapBoardConfigCacheForTests();
+    await getSitemapBoardConfigsOrThrow();
+    expect(climbCounts.calls).toBe(2);
+  });
+
+  it('propagates a listed-config failure instead of publishing a MoonBoard-only sitemap', async () => {
+    // A sitemap that quietly loses its Aurora URLs tells Google those pages were
+    // deleted. The shard route turns this throw into a 503.
+    listed.throws = true;
+
+    await expect(getSitemapBoardConfigsOrThrow()).rejects.toThrow('backend unreachable');
+  });
+});
+
+/**
+ * The stub above returns fixed rows, so it cannot say anything about the
+ * predicate. This renders the SQL drizzle actually produces instead of
+ * restating the WHERE clause the test hopes is there — a rebuilt predicate in a
+ * stub is a tautology.
+ */
+describe('the MoonBoard climb-count query', () => {
+  // A drizzle instance with no client behind it: building and rendering a query
+  // never touches a connection.
+  const { sql, params } = buildMoonBoardClimbCountQuery(drizzle({} as never) as never).toSQL();
+  const normalised = sql.toLowerCase().replace(/\s+/g, ' ');
+
+  it('counts only listed, non-draft MoonBoard climbs, grouped by layout', () => {
+    expect(normalised).toMatch(/"board_climbs"\."board_type" = \$\d+/);
+    expect(params).toContain('moonboard');
+    expect(normalised).toMatch(/"board_climbs"\."is_listed" = \$\d+/);
+    expect(normalised).toMatch(/"board_climbs"\."is_draft" = \$\d+/);
+    expect(params).toContain(true);
+    expect(params).toContain(false);
+    expect(normalised).toContain('group by "board_climbs"."layout_id"');
+  });
+
+  it('is the cheap grouped count, not the tier-2 DISTINCT ON scan', () => {
+    // The whole reason this query exists separately: both shards read the number
+    // only as a `> 0` gate, so it must not carry the climbs shard's cost.
+    expect(normalised).not.toContain('distinct on');
+    expect(normalised).not.toContain('board_climb_stats');
+    expect(normalised).toContain('count(*)');
+  });
+});

--- a/packages/web/app/lib/seo/sitemap/__tests__/board-config-source.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/board-config-source.test.ts
@@ -99,9 +99,12 @@ describe('getSitemapClimbConfigsOrThrow', () => {
   it('adds one MoonBoard config per layout, on top of the listed configs', async () => {
     const configs = await getSitemapClimbConfigsOrThrow();
 
-    // The listed configs pass through untouched and stay first — a synthetic
-    // source that reordered or displaced them would be a different, riskier
-    // change than the additive one this is meant to be.
+    // The listed configs pass through untouched and are still at the front of
+    // THIS array: the synthetics are appended, never spliced in or substituted.
+    // Array position is not shard position — `resolveClimbSitemapGroups` sorts
+    // by board type downstream and does interleave MoonBoard (see
+    // `moonboard-reaches-the-store.test.ts`) — so what this pins is that no
+    // listed config was rewritten or dropped on the way through.
     expect(configs[0]).toEqual(KILTER_CONFIG);
     expect(configs.filter((config) => config.boardType === 'kilter')).toEqual([KILTER_CONFIG]);
 
@@ -139,8 +142,11 @@ describe('getSitemapClimbConfigsOrThrow', () => {
       'Screw-on Feet',
       'Wooden Holds',
     ]);
-    // Zero physical boards is the truth, and it also keeps every synthetic
-    // config last under `isBetterConfig`, so no Aurora group can be displaced.
+    // Zero physical boards is the truth, and that is all it is. It does NOT
+    // hold the synthetic configs last: `isBetterConfig` only ranks candidates
+    // within one `boardType:layoutId` group, and `resolveClimbSitemapGroups`
+    // orders groups lexicographically by board type, so `moonboard` sorts
+    // between `kilter` and `soill` and moves every later group's `ordinal`.
     expect(masters2017?.boardCount).toBe(0);
   });
 

--- a/packages/web/app/lib/seo/sitemap/__tests__/climb-entries.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/climb-entries.test.ts
@@ -191,8 +191,8 @@ describe('isResolvableGroup', () => {
   });
 });
 
-describe('the MoonBoard hold-out', () => {
-  /** masters-2017 (layout 4), the FULL static set list — the best case, and it still fails. */
+describe('MoonBoard, once its set slugs round-trip', () => {
+  /** masters-2017 (layout 4), the FULL static set list — the case that used to fail. */
   const MOONBOARD_GROUP: ClimbConfigGroup = {
     boardType: 'moonboard',
     layoutId: 4,
@@ -200,23 +200,29 @@ describe('the MoonBoard hold-out', () => {
     setIds: [11, 12, 13, 14, 15, 16],
   };
 
-  it('builds a readable URL for a MoonBoard configuration — the probe alone is not enough', () => {
-    // The trap this test exists to document: `tryConstructSlugViewUrl` happily
-    // returns a URL, so a resolvability-only filter would ship all 227 MoonBoard
-    // configurations.
+  const MOONBOARD_SET_NAMES = [
+    'Wooden Holds',
+    'Screw-on Feet',
+    'Original School Holds',
+    'Hold Set C',
+    'Hold Set B',
+    'Hold Set A',
+  ];
+
+  it('builds a readable URL for a MoonBoard configuration', () => {
+    // The slug is unchanged — the emitter never had the bug. What changed is
+    // that `getMoonBoardSetsBySlug` now parses `…_screw_…` back to set 15
+    // instead of dropping it, so this URL is self-canonical. Byte-identity for
+    // all seven layouts is pinned in `moonboard-canonical-identity.test.ts`.
     const path = climbRowsToItems([row()], MOONBOARD_GROUP).items[0]?.path;
 
-    // `Screw-on Feet` (id 15) is in the slug this emits and NOT in what the page
-    // parses back: `getMoonBoardSetsBySlug` splits on `-`, so no part of
-    // `…_screw_…` ever matches `screw-on-feet`, and the canonical comes back
-    // without it. Byte-identity fails on 212 of 227 MoonBoard configurations.
     expect(path).toBe(
       '/moonboard/masters-2017/standard-11x18-grid/wooden-holds_screw_original-school-holds_hold-set-c_hold-set-b_hold-set-a/40/view/test-climb-abcdef1234567890abcdef1234567890',
     );
   });
 
-  it('holds MoonBoard out of the shard until the set slug round-trips', () => {
-    expect(isResolvableGroup(MOONBOARD_GROUP)).toBe(false);
+  it('ships every MoonBoard layout the config source names', () => {
+    expect(isResolvableGroup(MOONBOARD_GROUP)).toBe(true);
     expect(
       resolveClimbSitemapGroups([
         config({
@@ -224,20 +230,33 @@ describe('the MoonBoard hold-out', () => {
           layoutId: 4,
           sizeId: 1,
           setIds: [11, 12, 13, 14, 15, 16],
-          setNames: [
-            'Wooden Holds',
-            'Screw-on Feet',
-            'Original School Holds',
-            'Hold Set C',
-            'Hold Set B',
-            'Hold Set A',
-          ],
+          setNames: MOONBOARD_SET_NAMES,
         }),
+        config({
+          boardType: 'moonboard',
+          layoutId: 2,
+          sizeId: 1,
+          setIds: [2, 3, 4],
+          setNames: ['Hold Set A', 'Hold Set B', 'Original School Holds'],
+        }),
+      ]).map((group) => `${group.boardType}/${group.layoutId}`),
+    ).toEqual(['moonboard/2', 'moonboard/4']);
+  });
+
+  it('still drops a MoonBoard configuration with no readable URL', () => {
+    // The probe has to stay ANDed in. Replacing the deleted hold-out with a
+    // blanket `return true` would ship this: layout 999 is not in
+    // `MOONBOARD_LAYOUTS`, so `getMoonBoardDetails` throws and there is no URL
+    // to emit at any tuple.
+    expect(isResolvableGroup({ boardType: 'moonboard', layoutId: 999, sizeId: 1, setIds: [11] })).toBe(false);
+    expect(
+      resolveClimbSitemapGroups([
+        config({ boardType: 'moonboard', layoutId: 999, sizeId: 1, setIds: [11], setNames: ['Hold Set A'] }),
       ]),
     ).toEqual([]);
   });
 
-  it('still ships the Aurora boards, so the hold-out is scoped and not a blanket', () => {
+  it('still ships the Aurora boards, so nothing about them moved', () => {
     expect(resolveClimbSitemapGroups([config({})])).toHaveLength(1);
     expect(
       resolveClimbSitemapGroups([config({ boardType: 'tension', layoutId: 9, sizeId: 1, setIds: [8, 9, 10, 11] })]),

--- a/packages/web/app/lib/seo/sitemap/__tests__/climb-item-cache.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/climb-item-cache.test.ts
@@ -32,7 +32,7 @@ const TENSION_CONFIG: PopularBoardConfig = {
 // Three groups, so "sequential" is observable at all: with one group a
 // Promise.all rewrite and a for-loop are indistinguishable.
 vi.mock('../board-config-source', () => ({
-  getSitemapBoardConfigsOrThrow: async () => [
+  getSitemapClimbConfigsOrThrow: async () => [
     KILTER_CONFIG,
     { ...KILTER_CONFIG, layoutId: 8, sizeId: 25, setIds: [26, 27] },
     TENSION_CONFIG,

--- a/packages/web/app/lib/seo/sitemap/__tests__/climb-item-cache.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/climb-item-cache.test.ts
@@ -31,8 +31,8 @@ const TENSION_CONFIG: PopularBoardConfig = {
 
 // Three groups, so "sequential" is observable at all: with one group a
 // Promise.all rewrite and a for-loop are indistinguishable.
-vi.mock('@/app/lib/server-popular-configs', () => ({
-  getAllBoardConfigsOrThrow: async () => [
+vi.mock('../board-config-source', () => ({
+  getSitemapBoardConfigsOrThrow: async () => [
     KILTER_CONFIG,
     { ...KILTER_CONFIG, layoutId: 8, sizeId: 25, setIds: [26, 27] },
     TENSION_CONFIG,

--- a/packages/web/app/lib/seo/sitemap/__tests__/climb-query.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/climb-query.test.ts
@@ -6,7 +6,7 @@ vi.mock('server-only', () => ({}));
 // A drizzle instance with no client behind it: building and rendering a query
 // never touches the connection, and the test must not need a database.
 vi.mock('@/app/lib/db/db', () => ({ dbzRead: drizzle({} as never) }));
-vi.mock('../board-config-source', () => ({ getSitemapBoardConfigsOrThrow: async () => [] }));
+vi.mock('../board-config-source', () => ({ getSitemapClimbConfigsOrThrow: async () => [] }));
 
 const { buildTier2ClimbQuery, buildTier2ClimbSummaryQuery, TIER_2_MIN_ASCENTS } = await import('../climb-query');
 

--- a/packages/web/app/lib/seo/sitemap/__tests__/climb-query.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/climb-query.test.ts
@@ -6,7 +6,7 @@ vi.mock('server-only', () => ({}));
 // A drizzle instance with no client behind it: building and rendering a query
 // never touches the connection, and the test must not need a database.
 vi.mock('@/app/lib/db/db', () => ({ dbzRead: drizzle({} as never) }));
-vi.mock('@/app/lib/server-popular-configs', () => ({ getAllBoardConfigsOrThrow: async () => [] }));
+vi.mock('../board-config-source', () => ({ getSitemapBoardConfigsOrThrow: async () => [] }));
 
 const { buildTier2ClimbQuery, buildTier2ClimbSummaryQuery, TIER_2_MIN_ASCENTS } = await import('../climb-query');
 

--- a/packages/web/app/lib/seo/sitemap/__tests__/climb-shards.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/climb-shards.test.ts
@@ -21,7 +21,8 @@ const KILTER_CONFIG: PopularBoardConfig = {
 };
 
 vi.mock('../board-config-source', () => ({
-  getSitemapBoardConfigsOrThrow: async () => [KILTER_CONFIG],
+  getSitemapClimbConfigsOrThrow: async () => [KILTER_CONFIG],
+  getBoardsShardConfigsOrThrow: async () => [KILTER_CONFIG],
 }));
 vi.mock('../playlist-query', () => ({
   fetchPlaylistSitemapRows: async () => [{ uuid: 'abc-123', updatedAt: new Date('2026-04-30T00:00:00.000Z') }],

--- a/packages/web/app/lib/seo/sitemap/__tests__/climb-shards.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/climb-shards.test.ts
@@ -20,8 +20,8 @@ const KILTER_CONFIG: PopularBoardConfig = {
   displayName: 'Kilter Original 12x12',
 };
 
-vi.mock('@/app/lib/server-popular-configs', () => ({
-  getAllBoardConfigsOrThrow: async () => [KILTER_CONFIG],
+vi.mock('../board-config-source', () => ({
+  getSitemapBoardConfigsOrThrow: async () => [KILTER_CONFIG],
 }));
 vi.mock('../playlist-query', () => ({
   fetchPlaylistSitemapRows: async () => [{ uuid: 'abc-123', updatedAt: new Date('2026-04-30T00:00:00.000Z') }],

--- a/packages/web/app/lib/seo/sitemap/__tests__/climb-shards.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/climb-shards.test.ts
@@ -220,8 +220,11 @@ describe('the paged climbs shard', () => {
     const budget = pagedShardByteBudget(CLIMB_URLS_PER_SHARD);
     expect(budget).toBeLessThan(MAX_SHARD_BYTES);
     expect(budget).toBeLessThan(CLIMB_URLS_PER_SHARD * 866);
-    // ...and still comfortably above the ~250 bytes/URL the pages actually cost.
-    expect(budget).toBeGreaterThan(CLIMB_URLS_PER_SHARD * 250);
+    // ...and still above the worst page the shard actually renders: MoonBoard
+    // Masters 2019's 92-character set slug costs 297 B/URL, measured through the
+    // real builders in `moonboard-canonical-identity.test.ts`. This was written
+    // against 250 while the shard was Kilter and Tension only.
+    expect(budget).toBeGreaterThan(CLIMB_URLS_PER_SHARD * 297);
   });
 
   it('503s when the builder throws', async () => {

--- a/packages/web/app/lib/seo/sitemap/__tests__/moonboard-canonical-identity.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/moonboard-canonical-identity.test.ts
@@ -30,6 +30,8 @@ import { resolveClimbDisplayName } from '@/app/lib/string-utils';
 import { buildCanonicalClimbListUrl, buildCanonicalClimbViewUrl, popularConfigListUrl } from '@/app/lib/url-utils';
 import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
 import { climbRowsToItems, type ClimbConfigGroup } from '../climb-entries';
+import { expandDefaultLocaleOnly } from '../entries';
+import { CLIMB_URLS_PER_SHARD, pagedShardByteBudget, renderUrlset } from '../sitemap-xml';
 
 /**
  * The property the whole MoonBoard sitemap turns on: a URL the shard submits is
@@ -215,5 +217,61 @@ describe('MoonBoard sitemap URLs are self-canonical', () => {
         };
       }),
     ).toEqual(literalTuples);
+  });
+});
+
+/**
+ * The set slug is what makes one climb URL cost more than another, and MoonBoard
+ * spends the most of it — `masters-2019`'s full set is 92 characters. That is
+ * the number `sitemap-xml.ts` quotes when it says 500 B/URL is 1.68x the worst
+ * page rather than 2x, and a number in a comment is a comment. This measures it.
+ *
+ * Per-URL cost is read as a DELTA between two page sizes, so the urlset preamble
+ * and closing tag cancel out instead of being amortised into the answer, and the
+ * projection to a full page is exact rather than approximate.
+ */
+describe('the MoonBoard page fits the paged byte budget', () => {
+  function bytesFor(layoutKey: MoonBoardLayoutKey, urlCount: number): number {
+    const group = fullSetGroup(layoutKey);
+    const rows = Array.from({ length: urlCount }, (_, index) => ({
+      // 32 hex characters, the real uuid width, and a 15-character name — the
+      // fixture `sitemap-xml.ts` documents its per-URL figures against.
+      uuid: index.toString(16).padStart(32, '0'),
+      name: 'Fifteen Chars!!',
+      angle: 40,
+      updatedAt: new Date('2026-01-31T00:00:00.000Z'),
+    }));
+
+    const { items, dropped } = climbRowsToItems(rows, group);
+    expect(dropped, `${layoutKey} dropped rows the shard would have submitted`).toBe(0);
+    return Buffer.byteLength(renderUrlset(expandDefaultLocaleOnly(items)), 'utf8');
+  }
+
+  it('moonboard-masters-2019, the widest set slug we ship, stays under the budget', () => {
+    const perUrl = (bytesFor('moonboard-masters-2019', 2_000) - bytesFor('moonboard-masters-2019', 1_000)) / 1_000;
+    const fullPage = perUrl * CLIMB_URLS_PER_SHARD;
+    const budget = pagedShardByteBudget(CLIMB_URLS_PER_SHARD);
+
+    // The documented figure, with enough slack for a uuid or name of a different
+    // width and none for a set slug that grew.
+    expect(perUrl).toBeGreaterThan(290);
+    expect(perUrl).toBeLessThan(315);
+    expect(fullPage).toBeLessThan(budget);
+
+    // Stated as the margin, because that is the thing a new board spends: one
+    // extra character anywhere in the path costs CLIMB_URLS_PER_SHARD bytes.
+    const headroomChars = (budget - fullPage) / CLIMB_URLS_PER_SHARD;
+    expect(headroomChars).toBeGreaterThan(150);
+    expect(headroomChars).toBeLessThan(260);
+  });
+
+  it('every other MoonBoard layout costs less than masters-2019', () => {
+    const worst = (bytesFor('moonboard-masters-2019', 2_000) - bytesFor('moonboard-masters-2019', 1_000)) / 1_000;
+
+    for (const layoutKey of MOONBOARD_LAYOUT_KEYS) {
+      if (layoutKey === 'moonboard-masters-2019') continue;
+      const perUrl = (bytesFor(layoutKey, 2_000) - bytesFor(layoutKey, 1_000)) / 1_000;
+      expect(perUrl, `${layoutKey} is wider than masters-2019`).toBeLessThanOrEqual(worst);
+    }
   });
 });

--- a/packages/web/app/lib/seo/sitemap/__tests__/moonboard-canonical-identity.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/moonboard-canonical-identity.test.ts
@@ -22,7 +22,7 @@ vi.mock('next/navigation', () => ({
   },
 }));
 
-import { ANGLES } from '@boardsesh/board-config';
+import { ANGLES, getDefaultRenderBoard } from '@boardsesh/board-config';
 import type { PopularBoardConfig } from '@boardsesh/shared-schema';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { MOONBOARD_LAYOUTS, MOONBOARD_SETS, MOONBOARD_SIZE, type MoonBoardLayoutKey } from '@/app/lib/moonboard-config';
@@ -182,9 +182,12 @@ describe('MoonBoard sitemap URLs are self-canonical', () => {
   });
 
   it('the full-set tuples are the ones the shared render-board resolver already names', () => {
-    // Literal, not re-derived: an expectation computed by calling the same
-    // function the source calls would assert `f(x) === f(x)`.
-    expect(MOONBOARD_LAYOUT_KEYS.map((layoutKey) => fullSetGroup(layoutKey))).toEqual([
+    // Two claims, and the second is the one the title is about.
+    //
+    // 1. The fixtures this whole file canonicalises are the literal tuples
+    //    below — written out, not re-derived, so a table that started emitting
+    //    a partial set list has something to disagree with.
+    const literalTuples = [
       { boardType: 'moonboard', layoutId: 1, sizeId: 1, setIds: [1] },
       { boardType: 'moonboard', layoutId: 2, sizeId: 1, setIds: [2, 3, 4] },
       { boardType: 'moonboard', layoutId: 3, sizeId: 1, setIds: [5, 6, 7, 8, 9, 10] },
@@ -192,6 +195,25 @@ describe('MoonBoard sitemap URLs are self-canonical', () => {
       { boardType: 'moonboard', layoutId: 5, sizeId: 1, setIds: [17, 18, 19, 20, 21, 22, 23] },
       { boardType: 'moonboard', layoutId: 6, sizeId: 1, setIds: [24, 25, 26, 27] },
       { boardType: 'moonboard', layoutId: 7, sizeId: 1, setIds: [28, 29, 30, 31] },
-    ]);
+    ];
+    expect(MOONBOARD_LAYOUT_KEYS.map((layoutKey) => fullSetGroup(layoutKey))).toEqual(literalTuples);
+
+    // 2. `getDefaultRenderBoard` — the function `board-config-source.ts`
+    //    actually derives the shipped configs from — names those same tuples.
+    //    Without this leg the whole suite would keep canonicalising tuples the
+    //    shard had stopped emitting: `fullSetGroup` reads `MOONBOARD_SETS`
+    //    directly, so a resolver that began returning a subset for MoonBoard
+    //    would drift away silently and every case here would stay green.
+    expect(
+      literalTuples.map(({ layoutId }) => {
+        const renderBoard = getDefaultRenderBoard('moonboard', layoutId);
+        return {
+          boardType: 'moonboard',
+          layoutId: renderBoard?.layoutId,
+          sizeId: renderBoard?.sizeId,
+          setIds: renderBoard?.setIds,
+        };
+      }),
+    ).toEqual(literalTuples);
   });
 });

--- a/packages/web/app/lib/seo/sitemap/__tests__/moonboard-reaches-the-store.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/moonboard-reaches-the-store.test.ts
@@ -60,6 +60,29 @@ const MOONBOARD_MASTERS_2017: PopularBoardConfig = {
   displayName: 'MoonBoard Masters 2017',
 };
 
+/**
+ * A second Aurora board, here only so the ordering assertion below has
+ * something to be wrong about. Tension's Original Layout on the full wall with
+ * all four sets is a resolvable group (`climb-entries.test.ts:262` pins that),
+ * and `tension` sorts AFTER `moonboard`, so this is the row MoonBoard displaces.
+ * Names and set list are the real catalogue ones, so nothing here reads as a
+ * tuple the app could not serve.
+ */
+const TENSION_CONFIG: PopularBoardConfig = {
+  boardType: 'tension',
+  layoutId: 9,
+  layoutName: 'Original Layout',
+  sizeId: 1,
+  sizeName: 'Full Wall',
+  sizeDescription: 'Rows: KB1, KB2, 1-18 Columns: A-K',
+  setIds: [8, 9, 10, 11],
+  setNames: ['Set A', 'Set B', 'Set C', 'Foot Set'],
+  climbCount: 3100,
+  totalAscents: 42,
+  boardCount: 7,
+  displayName: 'Tension Original Full Wall',
+};
+
 const source = vi.hoisted(() => ({ configs: [] as unknown[] }));
 vi.mock('../board-config-source', () => ({
   getSitemapClimbConfigsOrThrow: async () => source.configs,
@@ -107,7 +130,7 @@ afterEach(() => {
 
 describe('the refresher that fills sitemap_climb_urls', () => {
   it('emits MoonBoard URLs, so the stored rows carry them', async () => {
-    source.configs = [KILTER_CONFIG, MOONBOARD_MASTERS_2017];
+    source.configs = [KILTER_CONFIG, MOONBOARD_MASTERS_2017, TENSION_CONFIG];
 
     const urlRows = await buildAllTier2UrlRows();
     const moonboardRows = urlRows.filter((row) => row.boardType === 'moonboard');
@@ -125,11 +148,27 @@ describe('the refresher that fills sitemap_climb_urls', () => {
       `/moonboard/masters-2017/standard-11x18-grid/${FULL_SET_SLUG}/40/view/to-dokids-yuito-${KILTER_UUID}`,
     ]);
 
-    // Kilter is untouched and still first: the config source is additive, and a
-    // MoonBoard row displacing an Aurora one would move every page boundary in
-    // the store.
+    // Kilter's rows are untouched — same count, and still the first thing the
+    // store sees.
     expect(urlRows[0]?.boardType).toBe('kilter');
     expect(urlRows.filter((row) => row.boardType === 'kilter')).toHaveLength(2);
+
+    // The WHOLE emission order, not just row 0, because MoonBoard is NOT
+    // appended. `resolveClimbSitemapGroups` sorts groups by a lexicographic
+    // compare on board type, so `moonboard` lands between `kilter` and
+    // `tension` and every Tension ordinal moves by the MoonBoard row count.
+    // Asserting only `urlRows[0] === 'kilter'` cannot see that: `kilter` sorts
+    // first either way. This sequence is the contract the store's page
+    // boundaries actually follow, and `docs/sitemap.md` explains why moving
+    // them is allowed.
+    expect(urlRows.map((row) => row.boardType)).toEqual([
+      'kilter',
+      'kilter',
+      'moonboard',
+      'moonboard',
+      'tension',
+      'tension',
+    ]);
   });
 
   it('carries no MoonBoard rows when the config source has none — the state before this change', async () => {

--- a/packages/web/app/lib/seo/sitemap/__tests__/moonboard-reaches-the-store.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/moonboard-reaches-the-store.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import type { PopularBoardConfig } from '@boardsesh/shared-schema';
+
+/**
+ * The seam that decides whether MoonBoard is in the sitemap at all, tested as a
+ * composition rather than as three separate mocks agreeing with each other.
+ *
+ * Since #4552 the shard pages do not build anything: they read
+ * `sitemap_climb_urls`, and that table is written by one refresher whose only
+ * selection entry point is `buildAllTier2UrlRows()`. So a synthetic MoonBoard
+ * config that reaches `/sitemaps/boards.xml` but not THIS function produces a
+ * store that has never heard of MoonBoard and a shard that emits nothing new —
+ * a change that looks complete in review, passes the boards-shard tests, and
+ * ships a no-op.
+ *
+ * `climb-store.test.ts` pins the other half: the rows this returns are the rows
+ * written and the rows a page serves. Together they are the end-to-end claim.
+ */
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/app/lib/db/db', () => ({ dbzRead: {} }));
+vi.mock('next/cache', () => ({ unstable_cache: (fn: (...args: never[]) => unknown) => fn }));
+
+const KILTER_CONFIG: PopularBoardConfig = {
+  boardType: 'kilter',
+  layoutId: 1,
+  layoutName: 'Kilter Board Original',
+  sizeId: 10,
+  sizeName: '12 x 12 with kickboard',
+  sizeDescription: '12 x 12 Square',
+  setIds: [1, 20],
+  setNames: ['Bolt Ons', 'Screw Ons'],
+  climbCount: 4200,
+  totalAscents: 99,
+  boardCount: 12,
+  displayName: 'Kilter Original 12x12',
+};
+
+/**
+ * MoonBoard Masters 2017, every hold set — the tuple `board-config-source.ts`
+ * synthesises for layout 4, written out as literals rather than re-derived by
+ * calling `getDefaultRenderBoard` here, which would assert `f(x) === f(x)`.
+ *
+ * Masters 2017 on purpose: `Screw-on Feet` slugs to `screw`, which is the set
+ * the old `-`-splitting parser silently dropped, so the URL this emits is also
+ * the one #4576's round-trip fix is about.
+ */
+const MOONBOARD_MASTERS_2017: PopularBoardConfig = {
+  boardType: 'moonboard',
+  layoutId: 4,
+  layoutName: 'MoonBoard Masters 2017',
+  sizeId: 1,
+  sizeName: 'MoonBoard',
+  sizeDescription: '11 x 18',
+  setIds: [11, 12, 13, 14, 15, 16],
+  setNames: ['Hold Set A', 'Hold Set B', 'Hold Set C', 'Original School Holds', 'Screw-on Feet', 'Wooden Holds'],
+  climbCount: 54_678,
+  totalAscents: 0,
+  boardCount: 0,
+  displayName: 'MoonBoard Masters 2017',
+};
+
+const source = vi.hoisted(() => ({ configs: [] as unknown[] }));
+vi.mock('../board-config-source', () => ({
+  getSitemapClimbConfigsOrThrow: async () => source.configs,
+}));
+
+/**
+ * One climb per group. The MoonBoard uuid is the dashed RFC-4122 form every
+ * MoonBoard row in `board_climbs` actually carries, not a 32-hex stand-in — the
+ * shape #4576's extractor had to learn, and the shape whose URL has to survive
+ * being stored as text and read back.
+ */
+const MOONBOARD_UUID = '9fe54099-6fdd-5adb-b82f-2d7bcb10d4ad';
+/**
+ * The full masters-2017 set slug as `generateSetSlug` emits it — descending by
+ * set-name slug, `_`-joined, with `screw` (Screw-on Feet) present. Written out
+ * rather than computed from the config's `setNames`, so a builder that started
+ * emitting a partial or differently-ordered list has something to disagree with.
+ */
+const FULL_SET_SLUG = 'wooden-holds_screw_original-school-holds_hold-set-c_hold-set-b_hold-set-a';
+const KILTER_UUID = 'abcdef1234567890abcdef1234567890';
+
+const scans = vi.hoisted(() => ({ count: 0 }));
+vi.mock('@boardsesh/db/queries', () => ({
+  withSerialPlan: async () => {
+    scans.count += 1;
+    // Both uuids on every group; `climbRowsToItems` renders whatever the group
+    // it was handed says, so the MoonBoard path can only appear if a MoonBoard
+    // GROUP reached the loop.
+    return [MOONBOARD_UUID, KILTER_UUID].map((uuid) => ({
+      uuid,
+      name: 'To Dokids Yuito',
+      angle: 40,
+      statsUpdatedAt: new Date('2026-05-04T11:22:33.000Z'),
+      climbUpdatedAt: new Date('2026-05-05T00:00:00.000Z'),
+    }));
+  },
+}));
+
+const { buildAllTier2UrlRows } = await import('../climb-query');
+
+afterEach(() => {
+  scans.count = 0;
+  source.configs = [];
+});
+
+describe('the refresher that fills sitemap_climb_urls', () => {
+  it('emits MoonBoard URLs, so the stored rows carry them', async () => {
+    source.configs = [KILTER_CONFIG, MOONBOARD_MASTERS_2017];
+
+    const urlRows = await buildAllTier2UrlRows();
+    const moonboardRows = urlRows.filter((row) => row.boardType === 'moonboard');
+
+    // Two climbs on the MoonBoard group, and the annotation the store writes
+    // into `board_type` / `layout_id` names the group they came from.
+    expect(moonboardRows).toHaveLength(2);
+    expect(new Set(moonboardRows.map((row) => row.layoutId))).toEqual(new Set([4]));
+
+    // The full set slug, `_`-joined, INCLUDING `screw` — the part the old parser
+    // could not produce and the reason masters-2017 canonicalised onto a URL
+    // nobody asked for.
+    expect(moonboardRows.map((row) => row.path)).toEqual([
+      `/moonboard/masters-2017/standard-11x18-grid/${FULL_SET_SLUG}/40/view/to-dokids-yuito-${MOONBOARD_UUID}`,
+      `/moonboard/masters-2017/standard-11x18-grid/${FULL_SET_SLUG}/40/view/to-dokids-yuito-${KILTER_UUID}`,
+    ]);
+
+    // Kilter is untouched and still first: the config source is additive, and a
+    // MoonBoard row displacing an Aurora one would move every page boundary in
+    // the store.
+    expect(urlRows[0]?.boardType).toBe('kilter');
+    expect(urlRows.filter((row) => row.boardType === 'kilter')).toHaveLength(2);
+  });
+
+  it('carries no MoonBoard rows when the config source has none — the state before this change', async () => {
+    source.configs = [KILTER_CONFIG];
+
+    const urlRows = await buildAllTier2UrlRows();
+
+    // The negative arm is what makes the positive one mean something: it pins
+    // that the MoonBoard paths above came from the CONFIG SOURCE and not from
+    // some unconditional MoonBoard branch inside the builder.
+    expect(urlRows.filter((row) => row.boardType === 'moonboard')).toHaveLength(0);
+    expect(scans.count).toBe(1);
+  });
+});

--- a/packages/web/app/lib/seo/sitemap/__tests__/shard-registry.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/shard-registry.test.ts
@@ -38,7 +38,7 @@ const MOONBOARD_CONFIG: PopularBoardConfig = {
   displayName: 'MoonBoard Masters 2017',
 };
 vi.mock('../board-config-source', () => ({
-  getSitemapBoardConfigsOrThrow: async () => [KILTER_CONFIG, MOONBOARD_CONFIG],
+  getBoardsShardConfigsOrThrow: async () => [KILTER_CONFIG, MOONBOARD_CONFIG],
 }));
 vi.mock('../playlist-query', () => ({
   fetchPlaylistSitemapRows: async () => [],

--- a/packages/web/app/lib/seo/sitemap/__tests__/shard-registry.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/shard-registry.test.ts
@@ -1,12 +1,44 @@
 import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vite-plus/test';
+import type { PopularBoardConfig } from '@boardsesh/shared-schema';
 import { buildGymEntries } from '../gym-entries';
 import { buildSetterEntries } from '../setter-entries';
 
 vi.mock('server-only', () => ({}));
-vi.mock('@/app/lib/server-popular-configs', () => ({
-  getAllBoardConfigsOrThrow: async () => [],
+
+const KILTER_CONFIG: PopularBoardConfig = {
+  boardType: 'kilter',
+  layoutId: 1,
+  layoutName: 'Kilter Board Original',
+  sizeId: 10,
+  sizeName: '12 x 12 with kickboard',
+  sizeDescription: '12 x 12 Square',
+  setIds: [1, 20],
+  setNames: ['Bolt Ons', 'Screw Ons'],
+  climbCount: 4200,
+  totalAscents: 99,
+  boardCount: 7,
+  displayName: 'Kilter OG 12x12',
+};
+
+/** The shape `board-config-source` synthesises: Masters 2017, every hold set. */
+const MOONBOARD_CONFIG: PopularBoardConfig = {
+  boardType: 'moonboard',
+  layoutId: 4,
+  layoutName: 'MoonBoard Masters 2017',
+  sizeId: 1,
+  sizeName: 'Standard',
+  sizeDescription: '11x18 Grid',
+  setIds: [11, 12, 13, 14, 15, 16],
+  setNames: ['Hold Set A', 'Hold Set B', 'Hold Set C', 'Original School Holds', 'Screw-on Feet', 'Wooden Holds'],
+  climbCount: 54678,
+  totalAscents: 0,
+  boardCount: 0,
+  displayName: 'MoonBoard Masters 2017',
+};
+vi.mock('../board-config-source', () => ({
+  getSitemapBoardConfigsOrThrow: async () => [KILTER_CONFIG, MOONBOARD_CONFIG],
 }));
 vi.mock('../playlist-query', () => ({
   fetchPlaylistSitemapRows: async () => [],
@@ -81,6 +113,29 @@ describe('SHARD_REGISTRY', () => {
     expect(Object.fromEntries(PAGED_SHARD_REGISTRY.map((shard) => [shard.id, shard.expectsUrls]))).toEqual({
       climbs: true,
     });
+  });
+
+  it('builds MoonBoard URLs into the boards shard, not just into the climb shards', async () => {
+    // The half-migration this catches: wiring only the climb shards to the
+    // sitemap config source and leaving the boards shard on the listed-config
+    // fetch. The climb shards would then emit tens of thousands of MoonBoard
+    // URLs while `/sitemaps/boards.xml` carried none, and nothing else here
+    // would go red.
+    const boards = SHARD_REGISTRY.find((shard) => shard.id === 'boards');
+    expect(boards).toBeDefined();
+
+    const items = await boards!.build();
+    const moonBoardPaths = items.map((item) => item.path).filter((path) => path.startsWith('/moonboard/'));
+
+    // Both MoonBoard angles, and nothing else on the board.
+    expect(moonBoardPaths).toHaveLength(2);
+    for (const path of moonBoardPaths) {
+      // `//` is the empty-path-segment shape `popularConfigListUrl` emits when
+      // it falls into its name branch with no set names — a 404 handed to Google.
+      expect(path).not.toContain('//');
+      expect(path).not.toContain('?');
+    }
+    expect(items.some((item) => item.path.startsWith('/kilter/'))).toBe(true);
   });
 
   it('keeps paged and fixed shard ids in one namespace', () => {

--- a/packages/web/app/lib/seo/sitemap/__tests__/shard-route-handler.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/shard-route-handler.test.ts
@@ -37,7 +37,7 @@ const forever = <T>(): Promise<T> => new Promise<T>(() => {});
 const after = (ms: number): Promise<void> => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 vi.mock('../board-config-source', () => ({
-  getSitemapBoardConfigsOrThrow: async () => {
+  getBoardsShardConfigsOrThrow: async () => {
     if (boardConfigs.hang) {
       return forever<PopularBoardConfig[]>();
     }

--- a/packages/web/app/lib/seo/sitemap/__tests__/shard-route-handler.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/shard-route-handler.test.ts
@@ -36,8 +36,8 @@ const forever = <T>(): Promise<T> => new Promise<T>(() => {});
 /** Settles late: the failure mode a *total* budget turns into a starved shard. */
 const after = (ms: number): Promise<void> => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-vi.mock('@/app/lib/server-popular-configs', () => ({
-  getAllBoardConfigsOrThrow: async () => {
+vi.mock('../board-config-source', () => ({
+  getSitemapBoardConfigsOrThrow: async () => {
     if (boardConfigs.hang) {
       return forever<PopularBoardConfig[]>();
     }

--- a/packages/web/app/lib/seo/sitemap/board-config-source.ts
+++ b/packages/web/app/lib/seo/sitemap/board-config-source.ts
@@ -1,0 +1,172 @@
+import 'server-only';
+import { unstable_cache } from 'next/cache';
+import { and, count, eq } from 'drizzle-orm';
+import { getDefaultRenderBoard } from '@boardsesh/board-config';
+import type { PopularBoardConfig } from '@boardsesh/shared-schema';
+import { dbzRead } from '@/app/lib/db/db';
+import { boardClimbs } from '@/app/lib/db/schema';
+import { MOONBOARD_LAYOUTS, MOONBOARD_SETS, MOONBOARD_SIZE, type MoonBoardLayoutKey } from '@/app/lib/moonboard-config';
+import { getAllBoardConfigsOrThrow } from '@/app/lib/server-popular-configs';
+
+/**
+ * The board configurations the SITEMAP builds URLs from — deliberately a
+ * different question from the one `popularBoardConfigs` answers.
+ *
+ * `getAllBoardConfigsOrThrow` asks "which board pages are worth building", and
+ * its answer comes from `board_product_sizes_layouts_sets`: the Aurora sync
+ * tables. That is the right universe for the home rail and the mobile board
+ * picker, and it is why MoonBoard has never appeared in a sitemap — nothing
+ * writes a psls row for it. The only writers are the Aurora importers, and no
+ * migration seeds one. MoonBoard was not ranked out; it was never a candidate.
+ *
+ * The sitemap's question is "which climbs are worth indexing", and MoonBoard is
+ * the largest board in the addressable set. Its configuration is not in the
+ * database at all — it is the static `MOONBOARD_LAYOUTS` / `MOONBOARD_SETS`
+ * tables that `getDefaultRenderBoard` already resolves for every renderer we
+ * ship — so this module answers the sitemap's question by adding those seven
+ * layouts to the listed configs rather than by changing what
+ * `popularBoardConfigs` returns.
+ *
+ * Kept in the web sitemap layer on purpose: no backend deploy coupling, and no
+ * change to the resolver the mobile board picker and the www home rail read.
+ */
+
+/** In-process TTL and Data Cache window, matching `getAllBoardConfigsOrThrow`. */
+const MOONBOARD_REVALIDATE_SECONDS = 3_600;
+const MOONBOARD_TTL_MS = MOONBOARD_REVALIDATE_SECONDS * 1_000;
+const MOONBOARD_CACHE_TAG = 'sitemap-moonboard-climb-counts';
+
+const MOONBOARD_LAYOUT_KEYS = Object.keys(MOONBOARD_LAYOUTS) as MoonBoardLayoutKey[];
+
+/**
+ * Listed, non-draft MoonBoard climbs per layout.
+ *
+ * A plain grouped count, NOT the tier-2 `DISTINCT ON` scan the climbs shard
+ * runs. Both shards use this number only as a `> 0` gate — `board-entries.ts`
+ * skips a config with no listed climbs as a thin page, `climb-entries.ts` skips
+ * the group entirely — and making the boards shard pay the climbs shard's cost
+ * budget for a boolean is the wrong trade. The tier-2 count that decides how
+ * many URLs actually ship is computed downstream, where it is already paid for.
+ */
+export function buildMoonBoardClimbCountQuery(db: typeof dbzRead) {
+  return db
+    .select({ layoutId: boardClimbs.layoutId, climbCount: count() })
+    .from(boardClimbs)
+    .where(and(eq(boardClimbs.boardType, 'moonboard'), eq(boardClimbs.isListed, true), eq(boardClimbs.isDraft, false)))
+    .groupBy(boardClimbs.layoutId);
+}
+
+async function fetchMoonBoardClimbCounts(): Promise<Map<number, number>> {
+  const rows = await buildMoonBoardClimbCountQuery(dbzRead);
+
+  const countsByLayout = new Map<number, number>();
+  for (const row of rows) {
+    if (row.layoutId == null) continue;
+    countsByLayout.set(row.layoutId, Number(row.climbCount));
+  }
+  return countsByLayout;
+}
+
+/** Data Cache stores plain JSON, so the Map is rebuilt on the way out. */
+const cachedMoonBoardClimbCounts = unstable_cache(
+  async (): Promise<[number, number][]> => [...(await fetchMoonBoardClimbCounts()).entries()],
+  ['sitemap-moonboard-climb-counts'],
+  { revalidate: MOONBOARD_REVALIDATE_SECONDS, tags: [MOONBOARD_CACHE_TAG] },
+);
+
+let cachedCounts: { builtAt: number; countsByLayout: Map<number, number> } | null = null;
+let countsInFlight: Promise<Map<number, number>> | null = null;
+
+/**
+ * Same two-layer shape as `getAllBoardConfigsOrThrow`: the Data Cache for
+ * cross-instance freshness, an in-process TTL and single-flight in front of it
+ * because `unstable_cache` does not deduplicate concurrent misses and one cold
+ * `/sitemap.xml` reaches this from the boards shard and the climbs summary at
+ * the same moment.
+ */
+async function getMoonBoardClimbCounts(): Promise<Map<number, number>> {
+  if (cachedCounts && Date.now() - cachedCounts.builtAt < MOONBOARD_TTL_MS) {
+    return cachedCounts.countsByLayout;
+  }
+  if (countsInFlight) {
+    return countsInFlight;
+  }
+
+  const build = cachedMoonBoardClimbCounts().then((entries) => {
+    const countsByLayout = new Map(entries);
+    cachedCounts = { builtAt: Date.now(), countsByLayout };
+    return countsByLayout;
+  });
+  countsInFlight = build;
+
+  try {
+    return await build;
+  } finally {
+    countsInFlight = null;
+  }
+}
+
+/**
+ * One config per MoonBoard layout: the layout's single size with every hold set
+ * installed, which is what `getDefaultRenderBoard` already returns for MoonBoard
+ * and what every MoonBoard board render in the app uses.
+ *
+ * `boardCount: 0` is honest — there is no `user_boards` row shape behind these —
+ * and it also keeps them last under `isBetterConfig`'s ordering, so adding them
+ * cannot reorder or displace any Aurora group.
+ *
+ * A layout with no listed climbs is dropped rather than shipped with a zero
+ * count: both shards would skip it anyway, and leaving it in means a future
+ * caller has to know that.
+ */
+function buildMoonBoardConfigs(countsByLayout: Map<number, number>): PopularBoardConfig[] {
+  const configs: PopularBoardConfig[] = [];
+
+  for (const layoutKey of MOONBOARD_LAYOUT_KEYS) {
+    const layout = MOONBOARD_LAYOUTS[layoutKey];
+    const climbCount = countsByLayout.get(layout.id) ?? 0;
+    if (climbCount <= 0) continue;
+
+    const renderBoard = getDefaultRenderBoard('moonboard', layout.id);
+    if (!renderBoard) continue;
+
+    configs.push({
+      boardType: 'moonboard',
+      layoutId: renderBoard.layoutId,
+      layoutName: layout.name,
+      sizeId: renderBoard.sizeId,
+      sizeName: MOONBOARD_SIZE.name,
+      sizeDescription: MOONBOARD_SIZE.description,
+      setIds: renderBoard.setIds,
+      setNames: MOONBOARD_SETS[layoutKey].filter((set) => renderBoard.setIds.includes(set.id)).map((set) => set.name),
+      climbCount,
+      // Not measured here, and not read by either shard. A number invented to
+      // fill the field would show up in `isBetterConfig`'s ranking as if it
+      // meant something.
+      totalAscents: 0,
+      boardCount: 0,
+      displayName: layout.name,
+    });
+  }
+
+  return configs;
+}
+
+/**
+ * Every board configuration the sitemap shards build URLs from.
+ *
+ * Throws for the same reason `getAllBoardConfigsOrThrow` does: a sitemap that
+ * quietly loses its URLs tells Google those pages were deleted, so the route
+ * turns a throw into a 503 and the crawler keeps its last good copy.
+ */
+export async function getSitemapBoardConfigsOrThrow(): Promise<PopularBoardConfig[]> {
+  const [listedConfigs, moonBoardCounts] = await Promise.all([getAllBoardConfigsOrThrow(), getMoonBoardClimbCounts()]);
+
+  return [...listedConfigs, ...buildMoonBoardConfigs(moonBoardCounts)];
+}
+
+/** Test seam: drops the in-process TTL cache and any in-flight fetch. */
+export function resetSitemapBoardConfigCacheForTests(): void {
+  cachedCounts = null;
+  countsInFlight = null;
+}

--- a/packages/web/app/lib/seo/sitemap/board-config-source.ts
+++ b/packages/web/app/lib/seo/sitemap/board-config-source.ts
@@ -160,9 +160,15 @@ async function getMoonBoardClimbCounts(): Promise<Map<number, number>> {
  * installed, which is what `getDefaultRenderBoard` already returns for MoonBoard
  * and what every MoonBoard board render in the app uses.
  *
- * `boardCount: 0` is honest — there is no `user_boards` row shape behind these —
- * and it also keeps them last under `isBetterConfig`'s ordering, so adding them
- * cannot reorder or displace any Aurora group.
+ * `boardCount: 0` is honest — there is no `user_boards` row shape behind these.
+ * It buys nothing in ordering, and the source is **additive in content, not in
+ * ordinal**: `isBetterConfig` only ranks candidates WITHIN one
+ * `boardType:layoutId` group, and cross-group order comes from the lexicographic
+ * `boardType` sort at the end of `resolveClimbSitemapGroups`, where `moonboard`
+ * lands between `kilter` and `soill`. So every Tension/Soill/Touchstone URL
+ * shifts by the MoonBoard row count and changes page in `sitemap_climb_urls`.
+ * That is a catalogue change, which is what `ordinal` is allowed to move for —
+ * see the "Adding a board also moves `ordinal`" note in `docs/sitemap.md`.
  *
  * A layout with no listed climbs is dropped rather than shipped with a zero
  * count: both shards would skip it anyway, and leaving it in means a future

--- a/packages/web/app/lib/seo/sitemap/board-config-source.ts
+++ b/packages/web/app/lib/seo/sitemap/board-config-source.ts
@@ -36,6 +36,15 @@ const MOONBOARD_REVALIDATE_SECONDS = 3_600;
 const MOONBOARD_TTL_MS = MOONBOARD_REVALIDATE_SECONDS * 1_000;
 const MOONBOARD_CACHE_TAG = 'sitemap-moonboard-climb-counts';
 
+/**
+ * MoonBoard's catalogue is code, not data: adding a layout or a hold set means
+ * editing `MOONBOARD_LAYOUTS` / `MOONBOARD_SETS` in
+ * `@boardsesh/board-config`, and until that lands the new layout has no sitemap
+ * entry and no board art. Two test files pin the tuples as literals so the edit
+ * cannot be half-done — `__tests__/board-config-source.test.ts` and
+ * `__tests__/moonboard-canonical-identity.test.ts`. Both go red on a new layout
+ * and both want updating in the same change.
+ */
 const MOONBOARD_LAYOUT_KEYS = Object.keys(MOONBOARD_LAYOUTS) as MoonBoardLayoutKey[];
 
 /**

--- a/packages/web/app/lib/seo/sitemap/board-config-source.ts
+++ b/packages/web/app/lib/seo/sitemap/board-config-source.ts
@@ -33,6 +33,26 @@ import { getAllBoardConfigsOrThrow } from '@/app/lib/server-popular-configs';
 
 /** In-process TTL and Data Cache window, matching `getAllBoardConfigsOrThrow`. */
 const MOONBOARD_REVALIDATE_SECONDS = 3_600;
+
+/**
+ * Wall-clock bound on the count query, matching the `SITEMAP_FETCH_TIMEOUT_MS`
+ * the listed-config fetch gives its own `AbortController`.
+ *
+ * `shardRouteHandler` is documented "deliberately unbounded" on the grounds that
+ * `getAllBoardConfigsOrThrow` budgets itself 10 s. This leg runs in parallel with
+ * it and had no bound at any layer: `dbzRead`'s pool sets `connect_timeout: 30`
+ * and `statement_timeout` is off by default (PgBouncer rejects it as a startup
+ * parameter — see docs/db-connectivity.md), so a stalled read would have held the
+ * boards shard for the whole platform timeout, and the single-flight would have
+ * made every later caller join the stall. Measured cost of the query itself on
+ * the dev image: 36 ms warm, 151 ms first touch, so 10 s is a tail bound and not
+ * a budget anything is expected to spend.
+ *
+ * Like `withDeadline` in `shard-registry.ts`, this stops waiting rather than
+ * cancelling: the abandoned query keeps running and will populate the caches for
+ * whoever asks next.
+ */
+const MOONBOARD_COUNT_TIMEOUT_MS = 10_000;
 const MOONBOARD_TTL_MS = MOONBOARD_REVALIDATE_SECONDS * 1_000;
 const MOONBOARD_CACHE_TAG = 'sitemap-moonboard-climb-counts';
 
@@ -76,6 +96,18 @@ async function fetchMoonBoardClimbCounts(): Promise<Map<number, number>> {
   return countsByLayout;
 }
 
+function withTimeout<T>(work: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return Promise.race([
+    work.finally(() => {
+      if (timer) clearTimeout(timer);
+    }),
+    new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => reject(new Error(`${label} exceeded its ${ms}ms budget`)), ms);
+    }),
+  ]);
+}
+
 /** Data Cache stores plain JSON, so the Map is rebuilt on the way out. */
 const cachedMoonBoardClimbCounts = unstable_cache(
   async (): Promise<[number, number][]> => [...(await fetchMoonBoardClimbCounts()).entries()],
@@ -101,7 +133,15 @@ async function getMoonBoardClimbCounts(): Promise<Map<number, number>> {
     return countsInFlight;
   }
 
-  const build = cachedMoonBoardClimbCounts().then((entries) => {
+  // The timeout is INSIDE the shared promise on purpose: a rejection then flows
+  // through the same path a query error does, so it is not memoised, every
+  // concurrent caller sees it, and the next caller retries instead of joining a
+  // stall that already gave up.
+  const build = withTimeout(
+    cachedMoonBoardClimbCounts(),
+    MOONBOARD_COUNT_TIMEOUT_MS,
+    '[sitemap] MoonBoard climb-count query',
+  ).then((entries) => {
     const countsByLayout = new Map(entries);
     cachedCounts = { builtAt: Date.now(), countsByLayout };
     return countsByLayout;
@@ -162,14 +202,50 @@ function buildMoonBoardConfigs(countsByLayout: Map<number, number>): PopularBoar
 }
 
 /**
- * Every board configuration the sitemap shards build URLs from.
+ * Every board configuration the CLIMB shards build URLs from.
  *
- * Throws for the same reason `getAllBoardConfigsOrThrow` does: a sitemap that
- * quietly loses its URLs tells Google those pages were deleted, so the route
- * turns a throw into a 503 and the crawler keeps its last good copy.
+ * Strict on both legs, and it has to be. The climbs shard resolves its groups
+ * twice per crawl — once for the summary the index sizes pages from, once for
+ * the item build — and `pagedShardRouteHandler` throws "cache epochs disagree"
+ * the moment those two see different group sets. A MoonBoard count that failed
+ * for one and succeeded for the other is exactly that disagreement, so a failure
+ * has to fail the whole thing: the route turns the throw into a 503 and the
+ * crawler keeps its last good copy, which is what `getAllBoardConfigsOrThrow`
+ * already does for the same reason.
  */
-export async function getSitemapBoardConfigsOrThrow(): Promise<PopularBoardConfig[]> {
+export async function getSitemapClimbConfigsOrThrow(): Promise<PopularBoardConfig[]> {
   const [listedConfigs, moonBoardCounts] = await Promise.all([getAllBoardConfigsOrThrow(), getMoonBoardClimbCounts()]);
+
+  return [...listedConfigs, ...buildMoonBoardConfigs(moonBoardCounts)];
+}
+
+/**
+ * The same configurations for `/sitemaps/boards.xml`, with the MoonBoard leg
+ * allowed to fail.
+ *
+ * Different question, different fail policy. The boards shard has no second
+ * builder to disagree with, and the arithmetic is lopsided: MoonBoard
+ * contributes 8 of its 668 items on the dev image, while the listed configs
+ * contribute 660. Before this module existed no database failure could reach
+ * that shard at all — it was a GraphQL fetch behind a backend Redis cache with a
+ * one-year TTL — so making 660 working Kilter/Tension/Decoy URLs 503 for an hour
+ * because a grouped count timed out would be a strict regression bought with
+ * nothing.
+ *
+ * A failed listed fetch still throws. That is the leg whose loss would tell
+ * Google the boards were deleted.
+ */
+export async function getBoardsShardConfigsOrThrow(): Promise<PopularBoardConfig[]> {
+  const [listedConfigs, moonBoardCounts] = await Promise.all([
+    getAllBoardConfigsOrThrow(),
+    getMoonBoardClimbCounts().catch((err: unknown) => {
+      console.error(
+        '[sitemap] boards shard: MoonBoard climb counts unavailable, serving the listed configs without them:',
+        err instanceof Error ? err.message : err,
+      );
+      return new Map<number, number>();
+    }),
+  ]);
 
   return [...listedConfigs, ...buildMoonBoardConfigs(moonBoardCounts)];
 }

--- a/packages/web/app/lib/seo/sitemap/board-entries.ts
+++ b/packages/web/app/lib/seo/sitemap/board-entries.ts
@@ -6,10 +6,12 @@ import type { SitemapItem } from './entries';
 /**
  * One entry per (board config × angle). Angles are genuinely different content —
  * grades shift with the wall angle and each angle page is self-canonical — so all
- * of them ship. Measured against the dev database, 51 listed configs give 660
- * items (2,640 locale-expanded URLs): 51 × 15 is the pre-filter upper bound, and
- * the MoonBoard 2-angle set plus the zero-climb skip below bring it to 660.
- * Either way it sits far inside the 11,250-item shard budget.
+ * of them ship. Measured against the dev image on 2026-08-19: 45 listed configs
+ * give 660 items (2,640 locale-expanded URLs) — 45 × 15 is the pre-filter upper
+ * bound and the zero-climb skip below brings it down — and the four MoonBoard
+ * configs `board-config-source.ts` synthesises add 8 more at their own 2-angle
+ * set, for 668 items / 2,672 URLs. Either way it sits far inside the
+ * 11,250-item shard budget. Production is not reconciled against these.
  *
  * Deliberately no `<lastmod>`: there is no per-config content timestamp in the
  * data today, and `new Date()` would be a lie. `<lastmod>` is optional in the

--- a/packages/web/app/lib/seo/sitemap/climb-entries.ts
+++ b/packages/web/app/lib/seo/sitemap/climb-entries.ts
@@ -147,8 +147,11 @@ export function isResolvableGroup(group: ClimbConfigGroup): boolean {
  *     one is the own-goal this shard exists to avoid.
  *
  * Deliberately no `<changefreq>`/`<priority>`: Google ignores both, and they
- * cost ~55 bytes per URL — 7 MB across tier 2, against a 4 MB per-shard ceiling.
- * The byte budget is a contract here, not a preference.
+ * cost ~55 bytes per URL — ~550 KB on a full 10,000-URL page, on top of the
+ * 203-297 B/URL the paths themselves spend. Against `pagedShardByteBudget`'s
+ * 5 MB that is 11% of the page bought for nothing, and the worst page
+ * (MoonBoard Masters 2019) is already at 59%. The byte budget is a contract
+ * here, not a preference.
  */
 export function climbRowsToItems(
   rows: readonly ClimbSitemapRow[],

--- a/packages/web/app/lib/seo/sitemap/climb-entries.ts
+++ b/packages/web/app/lib/seo/sitemap/climb-entries.ts
@@ -108,40 +108,25 @@ export function resolveClimbSitemapGroups(configs: readonly PopularBoardConfig[]
 const PROBE_UUID = '00000000000000000000000000000000';
 
 /**
- * MoonBoard configurations are held out of the shard, and `isResolvableGroup`
- * cannot see why.
+ * The one filter: does this configuration have a readable URL at all?
  *
- * The set slug this builder emits does not round-trip through the parser the
- * MoonBoard page uses. `generateSetSlug` joins set-name slugs with `_`
- * (`readable-url-utils.ts`), while `getMoonBoardSetsBySlug`
- * (`url-utils.server.ts`) splits the slug on `-` and substring-matches the
- * parts — so `…/wooden-holds_screw_original-school-holds_…` parses back to a
- * DIFFERENT set-id list, and `generateMetadata` then emits a `<link
- * rel="canonical">` that is not the URL we submitted. Measured over the static
- * MoonBoard tables: 212 of 227 layout×set combinations mismatch, including the
- * full set list on masters-2017 and masters-2019. Every such URL is one Google
- * drops as "alternate page with proper canonical".
+ * A named MoonBoard exclusion used to sit alongside the probe, because the set
+ * slug this builder emits did not round-trip through the parser the MoonBoard
+ * page runs — `generateSetSlug` joins on `_` while `getMoonBoardSetsBySlug`
+ * split on `-`, so a submitted URL rendered a canonical pointing elsewhere and
+ * Google dropped it as "alternate page with proper canonical". That parser is
+ * now an exact match (`url-utils.server.ts`), pinned by a 291-tuple round-trip
+ * and by a byte-identity suite over these very groups, so the exclusion is gone
+ * with the reason for it.
  *
- * `tryConstructSlugViewUrl` returns a URL for all 227, so the resolvability
- * probe is green on every one of them — which is precisely why this is a
- * separate, named exclusion rather than a tweak to the probe.
- *
- * Not live today (`getPopularConfigs()` emits no MoonBoard rows — there is no
- * `board_product_sizes_layouts_sets` seed for it, and `/sitemaps/boards.xml`
- * carries zero `/moonboard/` URLs), so this costs nothing now and stops the
- * shard from going wrong the moment a seed lands. Lifting it means making
- * `getMoonBoardSetsBySlug` an exact `generateSetNameSlug` match on `_`-split
- * parts — a routing-parser change, not a sitemap one.
+ * The probe stays, and it is what still drops Kilter layout 5 ("Kilter Spire"):
+ * an orphaned layout with no size associations, so it has no readable URL at any
+ * tuple. 69 tier-2 climbs, documented rather than fixed.
  */
-function hasRoundTrippableSetSlug(group: ClimbConfigGroup): boolean {
-  return toBoardName(group.boardType) !== 'moonboard';
-}
-
 export function isResolvableGroup(group: ClimbConfigGroup): boolean {
   return (
-    hasRoundTrippableSetSlug(group) &&
     tryConstructSlugViewUrl(group.boardType, group.layoutId, group.sizeId, group.setIds, 0, PROBE_UUID, 'probe') !==
-      null
+    null
   );
 }
 

--- a/packages/web/app/lib/seo/sitemap/climb-query.ts
+++ b/packages/web/app/lib/seo/sitemap/climb-query.ts
@@ -5,7 +5,7 @@ import { getRoutableBoardAngles, toBoardName } from '@boardsesh/board-config';
 import { withSerialPlan, type SerialPlanDb } from '@boardsesh/db/queries';
 import { dbzRead } from '@/app/lib/db/db';
 import { boardClimbAliases, boardClimbStats, boardClimbs } from '@/app/lib/db/schema';
-import { getAllBoardConfigsOrThrow } from '@/app/lib/server-popular-configs';
+import { getSitemapBoardConfigsOrThrow } from './board-config-source';
 import {
   climbRowsToItems,
   resolveClimbSitemapGroups,
@@ -215,7 +215,7 @@ export async function fetchTier2ClimbRows(group: ClimbConfigGroup): Promise<Clim
  * fallback below only when the store is empty).
  */
 async function computeTier2Summary(): Promise<{ itemCount: number; lastModifiedIso: string | null }> {
-  const groups = resolveClimbSitemapGroups(await getAllBoardConfigsOrThrow());
+  const groups = resolveClimbSitemapGroups(await getSitemapBoardConfigsOrThrow());
 
   let itemCount = 0;
   let lastModified: Date | null = null;
@@ -321,7 +321,7 @@ export type Tier2UrlRow = {
  * of the shard; a drifting duplicate is exactly how that recurs.
  */
 export async function buildAllTier2UrlRows(): Promise<Tier2UrlRow[]> {
-  const groups = resolveClimbSitemapGroups(await getAllBoardConfigsOrThrow());
+  const groups = resolveClimbSitemapGroups(await getSitemapBoardConfigsOrThrow());
   const urlRows: Tier2UrlRow[] = [];
   let dropped = 0;
 

--- a/packages/web/app/lib/seo/sitemap/climb-query.ts
+++ b/packages/web/app/lib/seo/sitemap/climb-query.ts
@@ -5,7 +5,7 @@ import { getRoutableBoardAngles, toBoardName } from '@boardsesh/board-config';
 import { withSerialPlan, type SerialPlanDb } from '@boardsesh/db/queries';
 import { dbzRead } from '@/app/lib/db/db';
 import { boardClimbAliases, boardClimbStats, boardClimbs } from '@/app/lib/db/schema';
-import { getSitemapBoardConfigsOrThrow } from './board-config-source';
+import { getSitemapClimbConfigsOrThrow } from './board-config-source';
 import {
   climbRowsToItems,
   resolveClimbSitemapGroups,
@@ -206,16 +206,24 @@ export async function fetchTier2ClimbRows(group: ClimbConfigGroup): Promise<Clim
  * The RESULT is two numbers. The COST is not: it is the same `DISTINCT ON` scan
  * as the item build, once per `(board_type, layout_id)` group — measured on the
  * full-board dev image at 16.7 s cold, 0.95 s fully warm, for the largest of
- * sixteen groups. Read that as "small answer, expensive question".
+ * them. Read that as "small answer, expensive question".
  *
  * One caller: the cached `fetchTier2Summary` fallback below. The refresher used
  * to be the second (#4523), but it now derives the summary from the URL rows it
- * builds anyway (`buildAllTier2UrlRows`), so it runs sixteen scans instead of
- * thirty-two. Request paths want `fetchClimbShardSummary()` (store first, the
- * fallback below only when the store is empty).
+ * builds anyway (`buildAllTier2UrlRows`), so it runs one set of scans instead of
+ * two. Request paths want `fetchClimbShardSummary()` (store first, the fallback
+ * below only when the store is empty).
+ *
+ * Still sequential, and adding MoonBoard's groups is not a reason to change
+ * that. An earlier draft of this change fanned the loop out three lanes wide to
+ * bring the LIVE summary back inside `SHARD_DEADLINE_MS`; #4552 then took the
+ * index off this path entirely, so the deadline this raced is no longer on the
+ * far side of it. What is left is the pre-first-refresh fallback, where the
+ * answer is to refresh the store, not to spend three of a ten-connection pool on
+ * a path that should run once per deploy.
  */
 async function computeTier2Summary(): Promise<{ itemCount: number; lastModifiedIso: string | null }> {
-  const groups = resolveClimbSitemapGroups(await getSitemapBoardConfigsOrThrow());
+  const groups = resolveClimbSitemapGroups(await getSitemapClimbConfigsOrThrow());
 
   let itemCount = 0;
   let lastModified: Date | null = null;
@@ -319,9 +327,17 @@ export type Tier2UrlRow = {
  * `buildChosenSubquery` comments above record two separate measured incidents
  * where a plausible-looking second copy of this selection silently dropped most
  * of the shard; a drifting duplicate is exactly how that recurs.
+ *
+ * `getSitemapClimbConfigsOrThrow`, not `getAllBoardConfigsOrThrow`, and that one
+ * word is the whole of what puts MoonBoard in the sitemap. #4552 moved the pages
+ * onto `sitemap_climb_urls`, so a board that is missing from the config source
+ * the REFRESHER reads is missing from the stored rows, and every downstream read
+ * — the shard pages, the index's item count, the per-page `<lastmod>` — is
+ * missing it too, however many synthetic configs exist elsewhere. There is no
+ * second place to add it: the refresher's only entry point is this function.
  */
 export async function buildAllTier2UrlRows(): Promise<Tier2UrlRow[]> {
-  const groups = resolveClimbSitemapGroups(await getSitemapBoardConfigsOrThrow());
+  const groups = resolveClimbSitemapGroups(await getSitemapClimbConfigsOrThrow());
   const urlRows: Tier2UrlRow[] = [];
   let dropped = 0;
 

--- a/packages/web/app/lib/seo/sitemap/shard-registry.ts
+++ b/packages/web/app/lib/seo/sitemap/shard-registry.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 import { absoluteUrl } from '@/app/lib/seo/base-url';
-import { getSitemapBoardConfigsOrThrow } from './board-config-source';
+import { getBoardsShardConfigsOrThrow } from './board-config-source';
 import { boardConfigsToItems } from './board-entries';
 import { climbSitemapsEnabled } from './climb-sitemaps-enabled';
 import { buildClimbShardPage, fetchClimbShardSummary, fetchStoredClimbPageLastmods } from './climb-store';
@@ -76,7 +76,7 @@ export const SHARD_REGISTRY: readonly SitemapShard[] = [
     // must not be listed. This shard was 2,780 URLs of which 2,085 were locale
     // twins; it is ~695 now, plus MoonBoard's below.
     expansion: 'default-locale-only',
-    build: async () => boardConfigsToItems(await getSitemapBoardConfigsOrThrow()),
+    build: async () => boardConfigsToItems(await getBoardsShardConfigsOrThrow()),
   },
   { id: 'gyms', path: '/sitemaps/gyms.xml', expectsUrls: false, build: async () => buildGymEntries() },
   {
@@ -535,14 +535,13 @@ function sourceHeaders(shard: PagedSitemapShard, source: PagedShardSource | unde
  * its paged summary, so fixed and paged work intentionally share one constant.
  *
  * The data-backed builders no longer share one shape, and the difference is the
- * point. `getBoardsShardConfigsOrThrow` is cached at two levels — a Next Data
- * Cache entry plus an in-process TTL and single-flight, on both its legs: the
- * listed configs through `getAllBoardConfigsOrThrow`'s own pair, and the
- * MoonBoard climb-count query through the pair in `board-config-source.ts` —
- * because `/sitemap.xml` is
- * `force-dynamic` and every CDN miss otherwise re-ran it live: the uncached boards
- * fetch took ~10 s cold and deterministically lost its shard on the first request
- * after a deploy (#4519). The climbs summary is no longer cached-expensive but
+ * point. `getBoardsShardConfigsOrThrow` is cached at two levels on both its legs
+ * — a Next Data Cache entry plus an in-process TTL and single-flight, from
+ * `getAllBoardConfigsOrThrow` for the listed configs and from
+ * `board-config-source.ts` for the MoonBoard climb counts — because
+ * `/sitemap.xml` is `force-dynamic` and every CDN miss otherwise re-ran it live:
+ * the uncached boards fetch took ~10 s cold and deterministically lost its shard
+ * on the first request after a deploy (#4519). The climbs summary is no longer cached-expensive but
  * PRECOMPUTED: one row of `sitemap_shard_refreshes`, written by the authenticated
  * refresh endpoint or an `after()` self-heal, because caching an expensive question only moves when you
  * pay for it — a cold miss on sixteen sequential `DISTINCT ON` scans could never

--- a/packages/web/app/lib/seo/sitemap/shard-registry.ts
+++ b/packages/web/app/lib/seo/sitemap/shard-registry.ts
@@ -544,7 +544,7 @@ function sourceHeaders(shard: PagedSitemapShard, source: PagedShardSource | unde
  * on the first request after a deploy (#4519). The climbs summary is no longer cached-expensive but
  * PRECOMPUTED: one row of `sitemap_shard_refreshes`, written by the authenticated
  * refresh endpoint or an `after()` self-heal, because caching an expensive question only moves when you
- * pay for it — a cold miss on sixteen sequential `DISTINCT ON` scans could never
+ * pay for it — a cold miss on one sequential `DISTINCT ON` scan per config group could never
  * meet 3 s at any cache temperature (#4523). `fetchPlaylistSitemapRows` is cached
  * like boards rather than precomputed like climbs, because its answer is small
  * enough to hold — ~200 KB of rows today, ~840 KB at the item cap (#4524). That

--- a/packages/web/app/lib/seo/sitemap/shard-registry.ts
+++ b/packages/web/app/lib/seo/sitemap/shard-registry.ts
@@ -1,6 +1,6 @@
 import 'server-only';
-import { getAllBoardConfigsOrThrow } from '@/app/lib/server-popular-configs';
 import { absoluteUrl } from '@/app/lib/seo/base-url';
+import { getSitemapBoardConfigsOrThrow } from './board-config-source';
 import { boardConfigsToItems } from './board-entries';
 import { climbSitemapsEnabled } from './climb-sitemaps-enabled';
 import { buildClimbShardPage, fetchClimbShardSummary, fetchStoredClimbPageLastmods } from './climb-store';
@@ -74,9 +74,9 @@ export const SHARD_REGISTRY: readonly SitemapShard[] = [
     expectsUrls: true,
     // Board list pages cross-canonicalise to the default locale, so the twins
     // must not be listed. This shard was 2,780 URLs of which 2,085 were locale
-    // twins; it is ~695 now.
+    // twins; it is ~695 now, plus MoonBoard's below.
     expansion: 'default-locale-only',
-    build: async () => boardConfigsToItems(await getAllBoardConfigsOrThrow()),
+    build: async () => boardConfigsToItems(await getSitemapBoardConfigsOrThrow()),
   },
   { id: 'gyms', path: '/sitemaps/gyms.xml', expectsUrls: false, build: async () => buildGymEntries() },
   {
@@ -535,8 +535,11 @@ function sourceHeaders(shard: PagedSitemapShard, source: PagedShardSource | unde
  * its paged summary, so fixed and paged work intentionally share one constant.
  *
  * The data-backed builders no longer share one shape, and the difference is the
- * point. `getAllBoardConfigsOrThrow` is cached at two levels — a Next Data Cache
- * entry plus an in-process TTL and single-flight — because `/sitemap.xml` is
+ * point. `getBoardsShardConfigsOrThrow` is cached at two levels — a Next Data
+ * Cache entry plus an in-process TTL and single-flight, on both its legs: the
+ * listed configs through `getAllBoardConfigsOrThrow`'s own pair, and the
+ * MoonBoard climb-count query through the pair in `board-config-source.ts` —
+ * because `/sitemap.xml` is
  * `force-dynamic` and every CDN miss otherwise re-ran it live: the uncached boards
  * fetch took ~10 s cold and deterministically lost its shard on the first request
  * after a deploy (#4519). The climbs summary is no longer cached-expensive but

--- a/packages/web/app/lib/seo/sitemap/sitemap-xml.ts
+++ b/packages/web/app/lib/seo/sitemap/sitemap-xml.ts
@@ -38,16 +38,19 @@ export const MAX_ITEMS_PER_SHARD = Math.floor(MAX_URLS_PER_SHARD / SUPPORTED_LOC
  * one, not a Kilter one. Measured through `climbRowsToItems` + `renderUrlset`
  * with a 15-character climb name, 10,000 URLs, `default-locale-only`:
  *
- * - Kilter original 12x12 (`screw_bolt`, 10 chars) — 203 B/URL, 2.03 MB, 41% of
- *   this page's `pagedShardByteBudget`.
+ * - Kilter original 12x12 (`screw_bolt`, 10 chars) — ~203 B/URL, ~2.0 MB.
  * - MoonBoard Masters 2019 (`wooden-holds-c_wooden-holds-b_wooden-holds_screw_
- *   original-school-holds_hold-set-b_hold-set-a`, 92 chars) — 303 B/URL,
- *   **3.03 MB, 61%**. Every other MoonBoard layout sits between 246 and 284
- *   B/URL.
+ *   original-school-holds_hold-set-b_hold-set-a`, 92 chars) — **297 B/URL,
+ *   2.97 MB, 59%** of this page's `pagedShardByteBudget`. Every other MoonBoard
+ *   layout costs less.
+ *
+ * Those are not comment numbers: `moonboard-canonical-identity.test.ts` renders
+ * the page through `climbRowsToItems` + `renderUrlset` and reads the per-URL
+ * cost as a delta between two page sizes, so the preamble cancels out.
  *
  * The arithmetic is linear and worth keeping: on a full page one extra
- * character anywhere in the path costs 10,000 bytes, so Masters 2019 is ~197
- * characters of set slug (or climb name) short of the budget. Lower this
+ * character anywhere in the path costs 10,000 bytes, so Masters 2019 is **203
+ * characters** of set slug (or climb name) short of the budget. Lower this
  * constant before adding a board that spends them. The failure mode is not
  * transient — the budget is enforced on the rendered body, so an over-budget
  * page 503s on every request until someone re-shards.
@@ -88,7 +91,7 @@ export const MAX_SHARD_BYTES = 45_000_000;
  * Bytes per URL a PAGED shard page may average before its own guard fires.
  *
  * `MAX_SHARD_BYTES` cannot do this job: it is sized to the protocol, and the only
- * paged shard configured today renders 10,000 URLs at 203-303 bytes each — 2.0
+ * paged shard configured today renders 10,000 URLs at 203-297 bytes each — 2.0
  * to 3.0 MB, fifteen times under it. A ceiling that far above the page it guards
  * cannot see the regression that matters, which is a per-URL cost that
  * multiplied. Fanning the climbs pages out to locales would do exactly that: it
@@ -98,7 +101,7 @@ export const MAX_SHARD_BYTES = 45_000_000;
  * 500 sits above the worst page and well under the fanned-out one, so a page
  * that grew legitimately long paths still serves and that regression still 503s.
  * The margin is thinner than it reads: the spread is the SET SLUG, and MoonBoard
- * Masters 2019 spends 92 characters of it at 303 B/URL — 1.65x, not the 2x this
+ * Masters 2019 spends 92 characters of it at 297 B/URL — 1.68x, not the 2x this
  * comment claimed while the shard was Kilter and Tension only. A board with a
  * longer slug than that needs this constant revisited, not just added.
  */

--- a/packages/web/app/lib/seo/sitemap/sitemap-xml.ts
+++ b/packages/web/app/lib/seo/sitemap/sitemap-xml.ts
@@ -31,8 +31,26 @@ export const MAX_ITEMS_PER_SHARD = Math.floor(MAX_URLS_PER_SHARD / SUPPORTED_LOC
  *   refresh, which is exactly the re-crawl volume #4842/#4861 are open about.
  * - **Bounded work per request.** A page is one ordinal-range read plus one
  *   rendered string held whole in memory. At 10,000 rows that is ~21 ms and
- *   ~2.5 MB on a container whose RSS the deploy runbook watches; at 45,000 it
- *   is four and a half times both.
+ *   2.0-3.0 MB on a container whose RSS the deploy runbook watches; at 45,000
+ *   it is four and a half times both.
+ *
+ * The **set slug** is what spreads that range, so the worst page is a MoonBoard
+ * one, not a Kilter one. Measured through `climbRowsToItems` + `renderUrlset`
+ * with a 15-character climb name, 10,000 URLs, `default-locale-only`:
+ *
+ * - Kilter original 12x12 (`screw_bolt`, 10 chars) — 203 B/URL, 2.03 MB, 41% of
+ *   this page's `pagedShardByteBudget`.
+ * - MoonBoard Masters 2019 (`wooden-holds-c_wooden-holds-b_wooden-holds_screw_
+ *   original-school-holds_hold-set-b_hold-set-a`, 92 chars) — 303 B/URL,
+ *   **3.03 MB, 61%**. Every other MoonBoard layout sits between 246 and 284
+ *   B/URL.
+ *
+ * The arithmetic is linear and worth keeping: on a full page one extra
+ * character anywhere in the path costs 10,000 bytes, so Masters 2019 is ~197
+ * characters of set slug (or climb name) short of the budget. Lower this
+ * constant before adding a board that spends them. The failure mode is not
+ * transient — the budget is enforced on the rendered body, so an over-budget
+ * page 503s on every request until someone re-shards.
  *
  * Raising it is a deliberate change with a crawl-shape argument behind it, not
  * a leftover to clean up.
@@ -70,15 +88,19 @@ export const MAX_SHARD_BYTES = 45_000_000;
  * Bytes per URL a PAGED shard page may average before its own guard fires.
  *
  * `MAX_SHARD_BYTES` cannot do this job: it is sized to the protocol, and the only
- * paged shard configured today renders 10,000 URLs at ~250 bytes each — ~2.5 MB,
- * eighteen times under it. A ceiling that far above the page it guards cannot see
- * the regression that matters, which is a per-URL cost that multiplied. Fanning
- * the climbs pages out to locales would do exactly that: it adds the hreflang
- * alternates block `entries.ts` warns against, taking each URL from ~250 B to the
- * 866 B measured on `/sitemaps/playlists.xml` and a page from 2.5 MB to 8.7 MB.
+ * paged shard configured today renders 10,000 URLs at 203-303 bytes each — 2.0
+ * to 3.0 MB, fifteen times under it. A ceiling that far above the page it guards
+ * cannot see the regression that matters, which is a per-URL cost that
+ * multiplied. Fanning the climbs pages out to locales would do exactly that: it
+ * adds the hreflang alternates block `entries.ts` warns against, taking each URL
+ * to the 866 B measured on `/sitemaps/playlists.xml` and a page to 8.7 MB.
  *
- * 500 is double the measured cost and well under the fanned-out one, so a page
+ * 500 sits above the worst page and well under the fanned-out one, so a page
  * that grew legitimately long paths still serves and that regression still 503s.
+ * The margin is thinner than it reads: the spread is the SET SLUG, and MoonBoard
+ * Masters 2019 spends 92 characters of it at 303 B/URL — 1.65x, not the 2x this
+ * comment claimed while the shard was Kilter and Tension only. A board with a
+ * longer slug than that needs this constant revisited, not just added.
  */
 const PAGED_SHARD_BYTES_PER_URL = 500;
 

--- a/packages/web/app/sitemaps/climbs/[page]/route.ts
+++ b/packages/web/app/sitemaps/climbs/[page]/route.ts
@@ -13,6 +13,28 @@ import { pagedShardRouteHandler } from '@/app/lib/seo/sitemap/shard-registry';
  */
 export const dynamic = 'force-dynamic';
 
+/**
+ * The only shard route carrying one, because it is the only one whose fallback
+ * is a minute-long scan. Steady state this is an ordinal range read of
+ * `sitemap_climb_urls` answering in ~0.1 s. Before the first refresh — the
+ * deploy that adds a board, a truncation, local dev — `buildClimbShardPage`
+ * falls back to the live grouped build, the 51 s path `docs/sitemap.md`
+ * documents, which is the same scan the refresher runs: 64.9 s cold and
+ * 20-28 s warm on the dev image with MoonBoard's groups in. Only the first
+ * request pays it, because the fallback build is TTL-cached per instance (a
+ * measured first hit answered in 22.7 s, dev route compile included; the next
+ * two in 0.40 s and 0.48 s).
+ *
+ * Without this export the platform default cuts that first request off as a
+ * 504. With it the crawler gets the slow-but-correct 200 the fallback is
+ * designed to be. The `after()` self-heal fires on `/sitemap.xml` only, so a
+ * crawler that reaches a page URL first does not get the window closed for it.
+ *
+ * Same value and the same Vercel-only caveat as `/sitemap.xml` and the cron
+ * refresher: inert on self-hosted Node, where there is no per-invocation ceiling.
+ */
+export const maxDuration = 300;
+
 export async function GET(_request: Request, context: { params: Promise<{ page: string }> }): Promise<Response> {
   const { page } = await context.params;
   return pagedShardRouteHandler('climbs', page);

--- a/packages/web/app/sitemaps/climbs/[page]/route.ts
+++ b/packages/web/app/sitemaps/climbs/[page]/route.ts
@@ -13,27 +13,19 @@ import { pagedShardRouteHandler } from '@/app/lib/seo/sitemap/shard-registry';
  */
 export const dynamic = 'force-dynamic';
 
-/**
- * The only shard route carrying one, because it is the only one whose fallback
- * is a minute-long scan. Steady state this is an ordinal range read of
- * `sitemap_climb_urls` answering in ~0.1 s. Before the first refresh — the
- * deploy that adds a board, a truncation, local dev — `buildClimbShardPage`
- * falls back to the live grouped build, the 51 s path `docs/sitemap.md`
- * documents, which is the same scan the refresher runs: 64.9 s cold and
- * 20-28 s warm on the dev image with MoonBoard's groups in. Only the first
- * request pays it, because the fallback build is TTL-cached per instance (a
- * measured first hit answered in 22.7 s, dev route compile included; the next
- * two in 0.40 s and 0.48 s).
- *
- * Without this export the platform default cuts that first request off as a
- * 504. With it the crawler gets the slow-but-correct 200 the fallback is
- * designed to be. The `after()` self-heal fires on `/sitemap.xml` only, so a
- * crawler that reaches a page URL first does not get the window closed for it.
- *
- * Same value and the same Vercel-only caveat as `/sitemap.xml` and the cron
- * refresher: inert on self-hosted Node, where there is no per-invocation ceiling.
- */
-export const maxDuration = 300;
+// There is deliberately no `maxDuration` export here, for the same reason
+// `/sitemap.xml` dropped its own (#4648). 300 was Vercel's Pro ceiling, bought
+// for the one request that pays the fallback: before the first refresh — the
+// deploy that adds a board, a truncation, local dev — `buildClimbShardPage`
+// falls back to the live grouped build, the 51 s path `docs/sitemap.md`
+// documents (64.9 s cold and 20-28 s warm on the dev image with MoonBoard's
+// groups in; only the first request pays it, because the fallback is TTL-cached
+// per instance). www serves from a Railway container now, where there is no
+// per-invocation ceiling to raise, so the export would describe a platform this
+// route no longer runs on. The Vercel deployment kept for the rollback window
+// is not a reason to keep it: `/sitemap.xml` dropped its own under exactly that
+// condition, and that deployment already serves the withdrawn climb contract
+// (410 from these pages) until `CLIMB_SITEMAPS_ENABLED` is set there.
 
 export async function GET(_request: Request, context: { params: Promise<{ page: string }> }): Promise<Response> {
   const { page } = await context.params;


### PR DESCRIPTION
## Summary

Closes #4493. **#4576 merged as `c283806` while this was in review, so the stack is resolved and this now targets `main` directly.** That ordering was load-bearing: dropping the sitemap's MoonBoard hold-out ahead of the parser and uuid fixes would have submitted tens of thousands of URLs that 404 or canonicalise elsewhere. It is no longer a risk — the parser fix is live.

**The issue's diagnosis is wrong.** MoonBoard is not ranked out of `popularBoardConfigs`. That resolver builds its universe with a `GROUP BY` over `board_product_sizes_layouts_sets`; `user_boards` only supplies `board_count` for the `ORDER BY`, and nothing is dropped for being unpopular. There is **no psls row for MoonBoard at all** — the only writers are the Aurora importers (`import-aurora-board-unified.ts`, `packages/aurora-sync`) and no migration seeds one. So the issue's recommended option 2, "rank by climbCount instead of boardCount", has nothing to rank.

The fix is option 1, and it is far cheaper than the issue estimates: `getDefaultRenderBoard('moonboard', layoutId)` already returns exactly the `{ layoutId, sizeId, setIds }` tuple, pure and synchronous, and web already imports it.

## Rebased onto the materialised store

This branch was written against the old shard, where every page built the whole ordered list live. **#4661 landed underneath it** and moved the ground: the climbs shard now reads `sitemap_climb_urls`, written by one refresher, and `/sitemap.xml` reads one row of `sitemap_shard_refreshes`. Two consequences, both acted on rather than carried:

- **The refresher is now the only door into the sitemap.** A synthetic config that reaches `/sitemaps/boards.xml` and the live summary but not `buildAllTier2UrlRows()` produces a store that has never heard of MoonBoard and a shard that emits nothing new — a change that looks complete in review and ships a no-op. `buildAllTier2UrlRows` resolves its groups from `getSitemapClimbConfigsOrThrow` now. That one call is the substantive edit in this PR, and there is no second place to make it: the cron, the `after()` self-heal and the live fallback all funnel through that function, deliberately (#4661 kept one selection path so a drifting duplicate could not recur).
- **`SUMMARY_CONCURRENCY = 3` is gone.** It existed to bring the LIVE summary back inside `SHARD_DEADLINE_MS`. `/sitemap.xml` is not on that path any more, so the deadline it raced is no longer on the far side of it. What is left is the pre-first-refresh fallback, where the answer is to refresh the store — not to spend three of a ten-connection pool on a path that should run once per deploy. The group loop is sequential again and `climb-item-cache.test.ts` pins `maxInFlight === 1`, matching main. Measured cost of that decision is in "The empty-store window" below; it is one degraded request, self-healed.

**What else changed**

- New `packages/web/app/lib/seo/sitemap/board-config-source.ts`: the listed configs, plus one synthetic `PopularBoardConfig` per MoonBoard layout. The two questions get separate entry points instead of one query with a fallback bolted on — "which board pages are worth building" stays a user-boards popularity question in the backend, "which climbs are worth indexing" becomes a catalogue-coverage question in the sitemap layer.
- An honest `climbCount` from one grouped Drizzle count over `board_climbs` (listed, non-draft) per layout, behind the same Data Cache + in-process TTL + single-flight shape `getAllBoardConfigsOrThrow` uses, and behind a 10 s budget. Deliberately **not** `buildTier2ClimbSummaryQuery`: both shards read this number only as a `> 0` gate. A layout with no listed climbs is dropped rather than shipped as a thin `/list` page.
- `hasRoundTrippableSetSlug` and its call are deleted. It existed because web's parser disagreed with the emitter — #4576 makes them agree. The `tryConstructSlugViewUrl` probe stays and is still what drops **Kilter layout 5 ("Kilter Spire")**: an orphaned layout with no size associations, so `resolveReadableBoardSegments` returns null at every tuple. 69 tier-2 climbs in production, documented not fixed.
- **The boards shard no longer 503s when the MoonBoard count fails.** The strict and tolerant sources are separate functions.
- Both shards repointed, and the `vi.mock` sites moved to the module the code now reads.

**Production target:** `www.boardsesh.com` only. Now that #4576 has merged and this is rebased onto `main`, the diff is 14 files and every one of them is under `packages/web/app/lib/seo/sitemap/` or `docs/` — nothing in `packages/mobile`, `packages/shared` or `packages/backend`, so no OTA and no store fleet. (The `pr-4578` OTA preview channel published earlier in this PR's life, while the branch still carried #4576's `packages/shared/play-view` commit; it does not any more.) No migration, no new redirect (so no `es`/`fr`/`de` sibling work), no user-facing strings.

---

## Numbers

### Production, measured today (read-only `SELECT`, aggregates only)

Live right now, before this PR:

| surface | value |
|---|---|
| `/sitemap.xml` | 9 `<sitemap>` entries, **no `x-sitemap-degraded`**, 0.21 s |
| climbs shard | **6 pages, 53,230 URLs**, zero `/moonboard/` |
| `climbs/1.xml` | 200 in **0.11 s** (2,247,529 B) |
| `climbs/6.xml` | 200 in 4.63 s cold, 3,230 URLs |
| `boards.xml` | 2,760 URLs (690 items × 4 locales), zero `/moonboard/` |

MoonBoard tier-2 in production, counted with the shard's own predicate — `DISTINCT ON (climb_uuid)`, `ascensionist_count >= 10`, `angle IN (25, 40)`, the NULL-tolerant set containment, the genuine-alias anti-join:

| layout | tier-2 | listed non-draft |
|---|---|---|
| 1 · MoonBoard 2010 | 7 | 124 |
| 2 · MoonBoard 2016 | 21,973 | 92,677 |
| 3 · MoonBoard 2024 | 6,419 | 36,135 |
| 4 · Masters 2017 | 25,551 | 73,244 |
| 5 · Masters 2019 | 13,990 | 56,864 |
| 6 · Mini 2020 | 3,779 | 7,867 |
| 7 · Mini 2025 | 1,693 | 4,870 |
| **total** | **73,412** | **271,781** |

All seven layouts clear the `> 0` gate in production, so all seven synthetic configs ship — unlike the dev image, where only four do.

Projected:

| | items | pages | boards.xml |
|---|---|---|---|
| before | 53,230 | **6** | 690 items / 2,760 URLs |
| after | **126,642** | **13** | 704 items / 2,816 URLs |

Total tier-2 across all 17 groups is 127,555 today; the 913 between that and 126,642 is Kilter layout 5 (69) plus the angle and size/set predicates the shard applies and a raw group count does not.

### Dev image, measured end to end through the real code path

`vp run dev` against the full dev image (648k climbs), store truncated first, then refreshed through `/api/internal/refresh-sitemap-climbs?force=1`.

| | items | groups | pages |
|---|---|---|---|
| before | 41,336 | 9 | **5** |
| after | **85,347** | 13 | **9** |

The before row is derived from the after run itself — the store carries `board_type`, so the non-MoonBoard rows are exactly 41,336 — and it matches the 41,336 #4661 measured independently on the same image.

Per MoonBoard group, straight out of `sitemap_climb_urls`:

| board | layout | URLs | ordinals |
|---|---|---|---|
| moonboard | 2 (2016) | 15,907 | 26,304–42,210 |
| moonboard | 4 (Masters 2017) | 19,338 | 42,211–61,548 |
| moonboard | 5 (Masters 2019) | 6,825 | 61,549–68,373 |
| moonboard | 6 (Mini 2020) | 1,941 | 68,374–70,314 |

Layouts 1, 3 and 7 have zero listed climbs on this image and are dropped by the gate. Production has all seven.

**Shard read time, from the store:**

| | |
|---|---|
| `/sitemap.xml` | 0.086 / 0.098 / 0.105 s, **no `x-sitemap-degraded`**, 9 climbs pages, 6 distinct per-page `<lastmod>` |
| `climbs/1.xml` (10,000 URLs, 2,329,686 B) | 0.073 s warm, 1.10 s on the first hit after a route compile |
| `climbs/5.xml` (10,000 URLs, all MoonBoard) | 0.10–0.16 s |
| `climbs/9.xml` (5,347 URLs) | 0.084 s |
| `climbs/0.xml`, `climbs/10.xml` | 404, not 503 |

**Refresh cost**, for 13 groups, all through the real cron route on the same image. Stated as a range, because quoting only the warm end makes the budget look far safer than it is:

| database state | `scanDurationMs` |
|---|---|
| **cold** — Postgres container restarted, store truncated | **64,937 ms** |
| warm, repeat runs on a loaded box | 19,998 – 28,421 ms |
| warm, quiet box | 8,921 – 12,217 ms |
| `after()` self-heal on a partly-cold image | 27,870 ms |

Budget against the cold number. The route's `maxDuration` is 300 s; scaling 64.9 s by production's projected 126,642 rows over the dev image's 85,347 gives roughly **96 s**, so the real margin is about **3x**, not the 24x the warm figure implies. Production also adds three more MoonBoard groups (20 total). It is a background cron, not a request path — but the same builder is the shard page's empty-store fallback, which is a request path, so `/sitemaps/climbs/[page]` now exports `maxDuration = 300` like its two siblings. Without it a crawler that reaches a page URL before the first refresh takes a platform 504 instead of the slow 200 the fallback is designed to be (measured: 22.7 s for that first hit against a warm DB, dev route compile included, then 0.40 s and 0.48 s — the fallback build is TTL-cached per instance).

**Largest served page is 2,935,185 B**, 73% of `MAX_SHARD_BYTES`. The worst *possible* page is a bit past that, and it is a MoonBoard one: MoonBoard set slugs are much longer than Kilter's, so a full 10,000-URL page of Masters 2019 (`wooden-holds-c_wooden-holds-b_wooden-holds_screw_original-school-holds_hold-set-b_hold-set-a`, 92 characters) renders **303 B/URL, 3.03 MB, 76%** against Kilter original's 203 B/URL and 2.03 MB — measured through `climbRowsToItems` + `renderUrlset` with a 15-character climb name. Headroom is real but it is one long set list wide: on a full page each extra path character costs 10,000 bytes, so Masters 2019 sits ~97 characters short of the 4 MB stop. `CLIMB_URLS_PER_SHARD`'s comment said "around 2.5 MB" from Kilter lengths; it now carries the MoonBoard figures.

Adding MoonBoard also moves page boundaries for existing URLs, because `resolveClimbSitemapGroups` orders by board type and MoonBoard sorts into the middle rather than onto the end. Measured on the refreshed dev store — moonboard holds ordinals 26,304–70,314, so **15,032 Soill/Tension/Touchstone URLs moved from pages 3–5 onto pages 8–9**. That is a catalogue change, which is exactly what `ordinal` is allowed to move for; each page is self-contained and its `<lastmod>` is recomputed from the rows it actually holds.

An earlier revision of this branch claimed the opposite in three places — that `boardCount: 0` "keeps them last under `isBetterConfig`'s ordering, so adding them cannot reorder or displace any Aurora group". That is false on both clauses: `isBetterConfig` is only called inside the per-group `best` map in `resolveClimbSitemapGroups` and never compares across board types, and the cross-group order is a plain lexicographic `boardType` compare where `moonboard` lands between `kilter` and `soill`. Corrected in `board-config-source.ts`, `board-config-source.test.ts` and `docs/sitemap.md` (which was contradicting itself between two sections). Nothing about the shipped ordering changed — only the description of it.

### The empty-store window, stated rather than papered over

This is the one place dropping `SUMMARY_CONCURRENCY` costs something. With the store truncated, the very first `/sitemap.xml` takes the live fallback:

```
/sitemap.xml  200 in 4.30 s   x-sitemap-degraded: climbs   (0 climbs pages listed)
```

Then the `after()` self-heal #4661 built fires post-flush, and every request after it is healthy:

```
[sitemap] self-healed the climb sitemap store (empty): 85347 items in 27870ms, skipped=no
/sitemap.xml  200 in 0.105 s   healthy   9 climbs pages
/sitemap.xml  200 in 0.098 s   healthy
/sitemap.xml  200 in 0.086 s   healthy
```

So the window is **one request per empty store**, under a 60-second degraded cache header, and it closes without anyone running a curl. Three lanes of fan-out would have made that one request ~2 s instead of ~4.3 s and still degraded, because thirteen groups cold do not fit in 3 s at any lane count — which is precisely why #4661 moved the index off this path instead of tuning it. Adding MoonBoard widens a window that already existed and already self-closes; it does not open a new one.

### The composition, proved end to end

A URL pulled out of `/sitemaps/climbs/5.xml` — that is, out of the materialised store — fetched in the browser:

```
/moonboard/2016/standard-11x18-grid/original-school-holds_hold-set-b_hold-set-a/40/view/can-you-do-it-dcb417f0-225f-59a6-8758-60d123532dc5
  200 · <h1>Can you do it? — 7c+/V10</h1>
  <link rel="canonical"> byte-identical to the submitted path
```

And the two layouts #4576 exists for, both from the shard, both with the `screw` part the old parser could never produce:

```
/moonboard/masters-2017/standard-11x18-grid/wooden-holds_screw_original-school-holds_hold-set-c_hold-set-b_hold-set-a/40/view/for-finn-663d3df8-…
  200 · canonical byte-identical
/moonboard/masters-2019/standard-11x18-grid/wooden-holds-c_wooden-holds-b_wooden-holds_screw_original-school-holds_hold-set-b_hold-set-a/40/view/ganan-las-negras-00087864-…
  200 · canonical byte-identical
```

`boards.xml` on the same run: 668 items / 2,672 URLs, 8 MoonBoard `/list` URLs (four layouts × two angles), all 660 Kilter/Tension/Decoy items still present, zero `//` and zero `?`.

## Release Notes

- MoonBoard climbs can now be found on Google. Every MoonBoard layout with problems on it goes into the sitemap, so a search for a problem by name can land on it directly instead of only ever reaching Kilter and Tension.

## Test plan

1. Search Google for a MoonBoard problem by name.
2. Open a MoonBoard climb link → the right board loads.
3. Copy that page's URL, open it fresh → same board, same angle.
4. Open a Kilter climb link → still works as before.

## Risk

Risk: 3/5 — this submits tens of thousands of new URLs to Google, and a URL that
does not round-trip to its own page's canonical is worse than no URL: Google
records it as "alternate page with proper canonical" and the whole batch stops
earning anything. That is the failure the hold-out existed to prevent, and it is
now covered by `moonboard-canonical-identity.test.ts`, which composes the real
emitter, the real route parser and the real canonical builder over all seven
layouts. Reversible in one deploy — the shard is derived, nothing is written
that a revert would not undo, and `CLIMB_SITEMAPS_ENABLED` withdraws the whole
climb surface without a code change.

## Rebased onto main, 2026-09-05

The branch was ~795 commits behind, and the sitemap infrastructure moved under
it. Three files conflicted; the more important half is that **every number this
branch argued from was measured against a guard that no longer exists.**

- **`shard-registry.ts`** — main's `boards` entry gained
  `expansion: 'default-locale-only'` (#4648) with a comment. Kept both and took
  only this branch's `build:` source. Taking the branch's side wholesale would
  have dropped that line and reddened
  `app/__tests__/board-content-metadata-guard.test.ts`, which reads
  `shard-registry.ts` **as text** and greps the `id: 'boards'` block for it — no
  type error to warn you first.
- **`sitemap-xml.ts`** — main rewrote the same block from scratch. Took main's
  argument whole and grafted on the one thing this branch adds: the per-URL cost
  is not one number, the **set slug** spreads it, and MoonBoard sits at the top.
- **`docs/sitemap.md`** — kept main's climb-sitemap-switch section, added the
  config-source section after it, and let main's byte-budget rewrite win
  outright. This branch's version still said "fixed shards have no byte budget",
  which stopped being true at #4648.

**Byte figures re-measured, and now checked rather than asserted.** The branch
sized MoonBoard's pages against a 4 MB Vercel response ceiling. That ceiling is
gone: `MAX_SHARD_BYTES` is a 45 MB protocol backstop and the working guard is
`pagedShardByteBudget()` at 500 B/URL, so a climbs page is checked against 5 MB.
Rather than restate the arithmetic, `moonboard-canonical-identity.test.ts` now
renders a full Masters 2019 page through `climbRowsToItems` + `renderUrlset` and
reads per-URL cost as a **delta between two page sizes**, so the urlset preamble
cancels out instead of being amortised into the answer.

| | measured |
|---|---|
| MoonBoard Masters 2019 (92-char set slug) | **297 B/URL** |
| a full 10,000-URL page | **2.97 MB** |
| `pagedShardByteBudget(10_000)` | 5.00 MB — **59% used** |
| headroom | **203 characters** of set slug or climb name |

That corrects two claims on `main` too. `PAGED_SHARD_BYTES_PER_URL`'s 500 was
documented as "double the measured cost"; with MoonBoard in the shard it is
**1.68x**. And `climb-shards.test.ts` asserted the budget clears "~250 bytes/URL
the pages actually cost" — true while the shard was Kilter and Tension only, and
it would have gone on passing while proving less than it says. Now 297.

**Docs that had gone false.** `docs/web-reposition.md` still carried the hold-out
rationale as live ("212 of 227 layout×set combinations mismatch") although #4576
fixed the parser it described, and still explained the climb shards'
default-locale-only expansion as an inconsistency with a boards shard that has
since moved to the same expansion. Both rewritten.

**Owed, and flagged rather than guessed:** the refresh-cost and empty-store
figures in `docs/sitemap.md` ("thirteen groups", "85,347 rows") were measured
before `main` widened the tier-2 angle predicate from the picker set to the
routable set, so the counts need a re-measure on a dev image. The shape of the
degrade is unchanged and the text now says which numbers are pre-rebase. No
in-repo dev database was available on the box this rebase ran on.

## Author verification

Every oracle was mutation-tested: mutation applied, test watched go red, reverted, `git status --porcelain` verified clean afterwards.

**`__tests__/moonboard-reaches-the-store.test.ts`** (new, 2 tests) — the seam this rebase is about, as a composition rather than three mocks agreeing: real `resolveClimbSitemapGroups`, real `climbRowsToItems`, a masters-2017 config with **literal** tuples, and a dashed RFC-4122 uuid, asserting the emitted path byte for byte including `screw`. A negative arm pins that the MoonBoard URLs came from the config source and not from an unconditional MoonBoard branch inside the builder.

- Mutation — both call sites back to `getAllBoardConfigsOrThrow`: **11 red across 2 files**.
- Mutation — **only** `buildAllTier2UrlRows` back, leaving the summary and the boards shard on the new source. This is the half-done edit that looks complete in review, keeps `/sitemaps/boards.xml` full of MoonBoard `/list` URLs, and ships a store with no MoonBoard in it: **7 red**, including both new oracles.

**`__tests__/board-config-source.test.ts`** (16 tests) — the listed configs are mocked to production's MoonBoard-free shape and the count query is stubbed per layout. Set tuples asserted as **literals** (`{ layoutId: 4, sizeId: 1, setIds: [11,12,13,14,15,16] }`), never re-derived by calling `getDefaultRenderBoard`, which would assert `f(x) === f(x)`.
  - The **input** layout list is derived from `MOONBOARD_LAYOUTS` rather than a hardcoded `[1..7]`. With the literal list, a new catalogue layout got no count row, resolved to `climbCount: 0`, and was dropped before `toHaveLength(7)` could see it — so this file stayed green on exactly the half-done edit the source comment claims it catches. Mutation: add a `moonboard-2027` layout + set entry → **red**.
  - The rendered-SQL oracle asserted `toContain(true)` / `toContain(false)`, which is position-blind: swapping `isListed`/`isDraft` renders byte-identical SQL and a params array that still contains both, so the query would have matched **zero** listed MoonBoard climbs and shipped a no-op — with `expectsUrls` never firing because Kilter and Tension keep both shards non-empty. Now `toEqual(['moonboard', true, false])`. Mutation: swap the booleans → **red**.
  - The boards shard serves the listed configs when the count fails; still throws when the **listed** fetch fails; the climbs shard still throws on a count failure. Mutation: make the boards leg rethrow → **2 red** (and the route probe goes 503).
  - A stalled read is given up on at 10 s, on both paths. Mutation: remove the timeout wrapper → **2 red**, each hanging 5 s first.
  - A rejected count is not memoised. Mutations: memoise the rejection, and drop the single-flight → **red** each.
  - `listed.calls` pins one listed-config call per request. Mutation: split the `Promise.all` into two sequential calls → **red**.

**`__tests__/climb-entries.test.ts`** — the `MoonBoard hold-out` block asserts the opposite now: `isResolvableGroup` is true for the Masters 2017 full-set group, `resolveClimbSitemapGroups` returns both MoonBoard layouts it is given, the Aurora assertions are unchanged, **and** a bogus MoonBoard group (`layoutId: 999`) is still dropped. Mutation: replace the deleted hold-out with a blanket `return true` → **3 red**.

**`__tests__/shard-registry.test.ts`** — builds the `boards` shard with a Kilter and a MoonBoard config, asserts exactly two `/moonboard/` paths, no `//`, no `?`, Kilter still present. Mutation: leave the boards shard on the old source and wire only the climb shards → **10 red across 3 files**.

**`__tests__/climb-item-cache.test.ts`** — back to main's three-group fixture and `maxInFlight === 1` for both the item build and the summary, since the fan-out is gone.

Gates, post-rebase on this box:

- `packages/web/app/lib/seo` + `app/sitemaps` + `app/sitemap.xml` +
  `board-content-metadata-guard` — **26 files, 290 tests green**, including the
  two new byte oracles and the text-scanning expansion guard.
- Pre-rebase, on the original base: `vp run typecheck` pass; `--project web`
  364 files / 4,089 tests (one unrelated `waitFor` flake in
  `gym-owner-reassign-panel.test.tsx` under full-suite load, green on its own);
  `--project i18n` 101 pass; `check:i18n` + `:orphans` OK; `vp check` 0 errors.
- Pre-commit hook pass, no `--no-verify`.

Manual QA plan is in `.boardsesh/qa-notes.md` and was exercised against `vp run dev` for the MoonBoard climb pages, the canonical, both shards and the empty-store self-heal.

**Not verified:** the in-process RSS of the 126,642-row refresh, and the canonical `<link>` in the `es`/`fr`/`de` locales (checked in `en-US` only).

---

## Review round: three false claims and a missing guard

Everything below was reproduced before it was changed.

- **The ordinal invariant was false.** Detailed above. Three comment/doc sites corrected; no behaviour change. If ordinal stability for existing boards is ever wanted, it needs an explicit rank in that sort — `boardCount` cannot deliver it — and `docs/sitemap.md` now says so.
- **`moonboard-reaches-the-store.test.ts` could not see the displacement it claimed to guard.** Its fixture was kilter + moonboard only, so `expect(urlRows[0]?.boardType).toBe('kilter')` passes under any insertion point (`kilter` sorts first either way). It now carries a real Tension config (Original Layout / Full Wall / all four sets, catalogue-accurate) and pins the whole emitted sequence `['kilter','kilter','moonboard','moonboard','tension','tension']`. Mutation — rank `moonboard` last in the group sort → the new assertion **reds** and the old one stays **green**, which is the finding in one run.
- **`moonboard-canonical-identity.test.ts`'s last case never called the resolver it is named after.** Both sides of `the full-set tuples are the ones the shared render-board resolver already names` came from `MOONBOARD_SETS`; `getDefaultRenderBoard` — the function the config source actually derives from — was not in it. It now pins the resolver's tuples against the same literals. Mutation — make `getDefaultRenderBoard` return a one-set subset for MoonBoard → **1 red, 14 green**, i.e. the entire canonical suite would have gone on canonicalising tuples the shard had stopped emitting.
- **`/sitemaps/climbs/[page]` had no `maxDuration`.** Added at the time, matching `/sitemap.xml` and the cron refresher. **Reverted in the rebase** — #4648 removed `/sitemap.xml`'s own, because the Railway container has no per-invocation ceiling to raise, so the export would have described a platform this route no longer runs on. The comment in its place says so.
- **The refresh-cost and shard-byte figures were the optimistic ends of their ranges.** Both re-measured and restated above and in `docs/sitemap.md`.




🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5Jti1UCBFtwGaJswYKY5Z
