### PR TITLE
fix(backend): refuse a gym claim approval that ownership has moved past

### DIFF
--- a/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
@@ -15,11 +15,14 @@ import {
   hashClaimToken,
   MAX_PENDING_CLAIMS_PER_USER,
   GYM_CLAIM_LIMIT_CODE,
+  GYM_CLAIM_SUPERSEDED_CODE,
 } from '../graphql/resolvers/social/gym-claims';
+import { socialGymOwnerReassignMutations } from '../graphql/resolvers/social/gym-owner-reassign';
 import {
   socialCommunitySettingsMutations,
   socialCommunitySettingsQueries,
 } from '../graphql/resolvers/social/community-settings';
+import { resetAllRateLimits } from '../utils/rate-limiter';
 
 /**
  * Real-DB coverage for the gym write-access (editor) role + grant/revoke
@@ -290,7 +293,8 @@ beforeEach(async () => {
   await db.execute(sql`
     TRUNCATE TABLE
       "community_roles", "community_settings", "gym_members", "gym_follows", "gym_claims",
-      "board_follows", "boardsesh_ticks", "user_boards", "gyms", "notifications"
+      "gym_owner_reassignments", "board_follows", "boardsesh_ticks", "user_boards", "gyms",
+      "notifications"
     RESTART IDENTITY CASCADE
   `);
 
@@ -1317,12 +1321,15 @@ describe('applyGymClaim / verifyGymClaimByToken — ownership transfer', () => {
 
     const applied = await applyGymClaim(claimRow);
     expect(applied).toEqual({
-      gymName: 'Real Gym',
-      gymUuid: claimGym.uuid,
-      gymSlug: claimGym.uuid, // insertGym seeds slug = uuid
-      claimantUserId: CLAIMANT,
-      claimEmail: 'boss@realgym.com',
-      priorOwnerId: PRIOR_OWNER,
+      outcome: 'applied',
+      applied: {
+        gymName: 'Real Gym',
+        gymUuid: claimGym.uuid,
+        gymSlug: claimGym.uuid, // insertGym seeds slug = uuid
+        claimantUserId: CLAIMANT,
+        claimEmail: 'boss@realgym.com',
+        priorOwnerId: PRIOR_OWNER,
+      },
     });
 
     expect(await gymOwnerId(claimGym.uuid)).toBe(CLAIMANT);
@@ -1972,11 +1979,16 @@ describe('requestGymClaim — auto-approval', () => {
       ),
     ]);
 
+    // Two curated messages are possible and which one the loser gets is pure
+    // timing: it either loses the guarded UPDATE (already-resolved wording), or
+    // reads the winner's approved row first and is refused as superseded. Both
+    // are written for the reviewer; neither is the internal race message.
     for (const outcome of outcomes) {
       if (outcome.status === 'rejected') {
-        expect(String(outcome.reason?.message)).toBe(
+        expect([
           'Could not approve this claim — the gym may have been removed or it was already resolved',
-        );
+          'This gym changed hands after the claim was filed.',
+        ]).toContain(String(outcome.reason?.message));
       }
     }
 
@@ -2082,7 +2094,9 @@ describe('approving a claim lands the same way whichever path approves it', () =
     const directGym = await insertGym({ ownerId: SYSTEM_OWNER, name: 'Parity Direct' });
     const directClaimId = await insertClaim({ gymId: directGym.id, claimantUserId: CLAIMANT, method: 'admin' });
     const [directClaim] = await db.select().from(dbSchema.gymClaims).where(eq(dbSchema.gymClaims.id, directClaimId));
-    expect(await applyGymClaim(directClaim, { requireCurrentOwnerId: SYSTEM_OWNER })).not.toBeNull();
+    expect(await applyGymClaim(directClaim, { requireCurrentOwnerId: SYSTEM_OWNER })).toMatchObject({
+      outcome: 'applied',
+    });
 
     // Identical end state...
     expect(await gymOwnerId(autoGym.uuid)).toBe(CLAIMANT);
@@ -2431,5 +2445,193 @@ describe('gym community settings — admin-only', () => {
       authCtx(GLOBAL_ADMIN),
     );
     expect(asAdmin.map((setting) => setting.key).sort()).toEqual(['approval_threshold', 'gym_claim_auto_approve']);
+  });
+});
+
+// ============================================================================
+// #4525 — a claim the gym's ownership has already moved past
+// ============================================================================
+
+/**
+ * `applyGymClaim` used to decide purely from the claim row and the gym's CURRENT
+ * state, so a claim that had been sitting in the queue could still be approved
+ * long after someone settled the question a different way. Approving it moved
+ * `owner_id` back to the claimant, demoted the admin's chosen owner to a gym
+ * admin membership row, mailed that person "someone verified they manage this
+ * gym" (which is false for a handover), and re-stamped `syncFrozenAt` — the one
+ * write `reassignGymOwner` deliberately leaves out (#4520).
+ *
+ * These pin the refusal end to end: nothing at all is written, and the claim is
+ * left `pending` so the claimant still gets a real outcome from Deny.
+ */
+describe('a claim ownership has moved past cannot be approved (#4525)', () => {
+  // A gym reassigned in one test would otherwise still count as "moved" in the
+  // next: gym_owner_reassignments has no FK to gyms, so the CASCADE that clears
+  // the rest of the fixture leaves it alone (it's in the TRUNCATE list above for
+  // exactly that reason). The reassign mutation is also capped at 10 per user,
+  // and the tier-1 bucket does not reset by itself between tests.
+  beforeEach(() => {
+    resetAllRateLimits();
+  });
+
+  const REASSIGN_REASON = 'The wall was sold and the buyer runs it now.';
+
+  const reassignTo = (gymUuid: string, currentOwnerId: string, newOwnerId: string) =>
+    socialGymOwnerReassignMutations.reassignGymOwner(
+      null,
+      {
+        input: {
+          gymUuid,
+          expectedCurrentOwnerId: currentOwnerId,
+          newOwnerId,
+          reason: REASSIGN_REASON,
+        },
+      },
+      authCtx(GLOBAL_ADMIN),
+    );
+
+  const approveAsAdmin = (claimId: number) =>
+    socialGymClaimMutations.reviewGymClaim(null, { input: { claimId, decision: 'approve' } }, authCtx(GLOBAL_ADMIN));
+
+  const allMembers = async (gymId: number): Promise<Array<{ user_id: string; role: string }>> => {
+    const result = await db.execute(sql`
+      SELECT user_id, role FROM gym_members WHERE gym_id = ${gymId} ORDER BY user_id
+    `);
+    return Array.from(result as Iterable<{ user_id: string; role: string }>);
+  };
+
+  it('refuses the approval after a handover, and writes nothing at all', async () => {
+    // The gym is deliberately UNFROZEN: a re-stamp here would stop location sync
+    // maintaining a listing an admin had just decided sync may keep maintaining.
+    const claimGym = await insertGym({ ownerId: PRIOR_OWNER, name: 'Superseded Wall' });
+    const claimId = await insertClaim({ gymId: claimGym.id, claimantUserId: CLAIMANT, method: 'admin' });
+
+    await reassignTo(claimGym.uuid, PRIOR_OWNER, SECOND_TARGET);
+    expect(await gymOwnerId(claimGym.uuid)).toBe(SECOND_TARGET);
+    expect(await gymSyncFrozenAt(claimGym.uuid)).toBeNull();
+    const membersAfterHandover = await allMembers(claimGym.id);
+    vi.clearAllMocks();
+
+    const rejection = await approveAsAdmin(claimId).catch((error: unknown) => error);
+    expect((rejection as GraphQLError).extensions).toMatchObject({ code: GYM_CLAIM_SUPERSEDED_CODE });
+
+    // Ownership stays where the admin put it, and the freeze marker is untouched.
+    expect(await gymOwnerId(claimGym.uuid)).toBe(SECOND_TARGET);
+    expect(await gymSyncFrozenAt(claimGym.uuid)).toBeNull();
+
+    // The admin's chosen owner is NOT demoted to a membership row, and the
+    // claimant's own rows are left exactly as they were.
+    expect(await allMembers(claimGym.id)).toEqual(membersAfterHandover);
+
+    // Still pending: Deny is how the claimant gets an outcome, and a denial
+    // email that says so beats being closed out with nothing.
+    expect(await claimStatus(claimId)).toBe('pending');
+
+    // Nobody is told anything — least of all the "someone verified they manage
+    // this gym" note to an owner who is still the owner.
+    expect(await claimApprovedNotifications(CLAIMANT)).toEqual([]);
+    expect(sendGymClaimApprovedEmail).not.toHaveBeenCalled();
+    expect(sendGymClaimOwnershipLostEmail).not.toHaveBeenCalled();
+  });
+
+  it('leaves a frozen listing frozen at the exact same timestamp', async () => {
+    // The unfrozen case above goes red on "set it anyway"; this one goes red on
+    // a re-stamp that merely keeps the column non-null. Same split as #4520's
+    // freeze-preservation pair.
+    const claimGym = await insertGym({ ownerId: PRIOR_OWNER, name: 'Frozen Wall' });
+    const frozenAt = '2026-08-01T01:02:03.000Z';
+    await db.execute(sql`UPDATE gyms SET sync_frozen_at = ${frozenAt} WHERE id = ${claimGym.id}`);
+    const claimId = await insertClaim({ gymId: claimGym.id, claimantUserId: CLAIMANT, method: 'admin' });
+
+    await reassignTo(claimGym.uuid, PRIOR_OWNER, SECOND_TARGET);
+
+    const rejection = await approveAsAdmin(claimId).catch((error: unknown) => error);
+    expect((rejection as GraphQLError).extensions).toMatchObject({ code: GYM_CLAIM_SUPERSEDED_CODE });
+
+    const stillFrozenAt = await gymSyncFrozenAt(claimGym.uuid);
+    expect(new Date(stillFrozenAt!).toISOString()).toBe(frozenAt);
+    expect(await gymOwnerId(claimGym.uuid)).toBe(SECOND_TARGET);
+  });
+
+  it('refuses the second of two queued claims on one gym, with no handover involved', async () => {
+    // The two-admin case the issue calls out: nothing but the claim queue is in
+    // play, and the second approval would take the gym straight back off the
+    // person the first one just gave it to.
+    const claimGym = await insertGym({ ownerId: PRIOR_OWNER, name: 'Two Reviewers' });
+    const firstClaim = await insertClaim({ gymId: claimGym.id, claimantUserId: CLAIMANT, method: 'admin' });
+    const secondClaim = await insertClaim({ gymId: claimGym.id, claimantUserId: PLAIN_USER, method: 'admin' });
+
+    await expect(approveAsAdmin(firstClaim)).resolves.toBe(true);
+    expect(await gymOwnerId(claimGym.uuid)).toBe(CLAIMANT);
+
+    const rejection = await approveAsAdmin(secondClaim).catch((error: unknown) => error);
+    expect((rejection as GraphQLError).extensions).toMatchObject({ code: GYM_CLAIM_SUPERSEDED_CODE });
+
+    expect(await gymOwnerId(claimGym.uuid)).toBe(CLAIMANT);
+    expect(await claimStatus(secondClaim)).toBe('pending');
+  });
+
+  it('still approves a claim filed AFTER the handover', async () => {
+    // The control. Without it the guard could refuse every approval and every
+    // assertion above would still pass.
+    const claimGym = await insertGym({ ownerId: PRIOR_OWNER, name: 'Claimed After Handover' });
+
+    await reassignTo(claimGym.uuid, PRIOR_OWNER, SECOND_TARGET);
+    const claimId = await insertClaim({ gymId: claimGym.id, claimantUserId: CLAIMANT, method: 'admin' });
+
+    await expect(approveAsAdmin(claimId)).resolves.toBe(true);
+    expect(await gymOwnerId(claimGym.uuid)).toBe(CLAIMANT);
+    expect(await gymSyncFrozenAt(claimGym.uuid)).not.toBeNull();
+    expect(await claimStatus(claimId)).toBe('approved');
+    // The handover's owner is displaced by a decision made after it, which is
+    // the normal claim path — so he keeps gym-admin access, as always.
+    expect(await gymMemberRole(claimGym.id, SECOND_TARGET)).toBe('admin');
+  });
+
+  it('still approves when the handover gave the gym to the claimant themselves', async () => {
+    // An admin who resolves a claim with the handover panel instead of the queue
+    // leaves the row behind. Approving it moves nothing and freezes nothing —
+    // it just closes the queue entry for the person who did get the gym. Refuse
+    // that and Deny (with its "sorry, no" email) is their only way out.
+    const claimGym = await insertGym({ ownerId: PRIOR_OWNER, name: 'Handed To The Claimant' });
+    const claimId = await insertClaim({ gymId: claimGym.id, claimantUserId: CLAIMANT, method: 'admin' });
+
+    await reassignTo(claimGym.uuid, PRIOR_OWNER, CLAIMANT);
+    expect(await gymSyncFrozenAt(claimGym.uuid)).toBeNull();
+
+    await expect(approveAsAdmin(claimId)).resolves.toBe(true);
+    expect(await claimStatus(claimId)).toBe('approved');
+    expect(await gymOwnerId(claimGym.uuid)).toBe(CLAIMANT);
+    // No transfer ran, so the freeze marker stays as the handover left it.
+    expect(await gymSyncFrozenAt(claimGym.uuid)).toBeNull();
+  });
+
+  it('refuses the domain verification link too, and keeps the claim usable', async () => {
+    // The emailed link is a second, unattended way into the same transfer. It
+    // reports `superseded` rather than `used` — the link was never spent.
+    const claimGym = await insertGym({
+      ownerId: PRIOR_OWNER,
+      name: 'Domain Superseded',
+      website: 'https://www.domain-superseded.com',
+    });
+    const claimId = await insertClaim({
+      gymId: claimGym.id,
+      claimantUserId: CLAIMANT,
+      method: 'domain',
+      claimEmail: 'boss@domain-superseded.com',
+      tokenHash: hashClaimToken('superseded-token'),
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    await reassignTo(claimGym.uuid, PRIOR_OWNER, SECOND_TARGET);
+    vi.clearAllMocks();
+
+    expect(await verifyGymClaimByToken('superseded-token')).toEqual({ ok: false, reason: 'superseded' });
+
+    expect(await gymOwnerId(claimGym.uuid)).toBe(SECOND_TARGET);
+    expect(await gymSyncFrozenAt(claimGym.uuid)).toBeNull();
+    expect(await claimStatus(claimId)).toBe('pending');
+    expect(sendGymClaimApprovedEmail).not.toHaveBeenCalled();
+    expect(sendGymClaimOwnershipLostEmail).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/graphql/resolvers/social/gym-claims.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-claims.ts
@@ -41,6 +41,13 @@ export const MAX_PENDING_CLAIMS_PER_USER = 10;
 export const GYM_CLAIM_LIMIT_CODE = 'GYM_CLAIM_LIMIT_REACHED';
 
 /**
+ * `extensions.code` when the claim is older than the gym's current ownership —
+ * someone already decided who owns this gym after the claim was filed, so
+ * applying it now would silently reverse that decision.
+ */
+export const GYM_CLAIM_SUPERSEDED_CODE = 'GYM_CLAIM_SUPERSEDED';
+
+/**
  * A claim that is genuinely still live: `pending` AND not past its expiry.
  *
  * The status column alone is not enough. A domain claim's token dies after 24h,
@@ -74,12 +81,78 @@ type ClaimApplied = {
 };
 
 /**
+ * Why an apply did not happen. `superseded` is its own outcome rather than a
+ * flavour of "not applied" because the two need opposite handling: a not-applied
+ * claim is already resolved or the gym is gone (nothing left to do), while a
+ * superseded one is still `pending` and needs a human to deny it or move
+ * ownership deliberately.
+ */
+export type ApplyGymClaimResult =
+  | { outcome: 'applied'; applied: ClaimApplied }
+  | { outcome: 'superseded' }
+  | { outcome: 'not_applied' };
+
+/**
+ * Has anyone decided who owns this gym since `claim` was filed?
+ *
+ * Exactly two code paths move `gyms.owner_id` — this function's own transfer and
+ * `reassignGymOwner` — and both leave a dated record: an admin handover writes a
+ * `gym_owner_reassignments` row, and a claim-driven transfer is dated by the
+ * approved claim row itself (an approved claim's `updated_at` IS its approval
+ * time). Reading both is therefore an exhaustive answer, with no new bookkeeping
+ * and no lock held across the decision.
+ *
+ * Anything newer than the claim means applying it now would reverse a decision
+ * somebody made with more information than the claim carries.
+ */
+async function ownershipMovedSinceClaim(
+  tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
+  gymUuid: string,
+  claim: typeof dbSchema.gymClaims.$inferSelect,
+): Promise<boolean> {
+  const [reassignment] = await tx
+    .select({ id: dbSchema.gymOwnerReassignments.id })
+    .from(dbSchema.gymOwnerReassignments)
+    .where(
+      and(
+        eq(dbSchema.gymOwnerReassignments.gymUuid, gymUuid),
+        gt(dbSchema.gymOwnerReassignments.createdAt, claim.createdAt),
+      ),
+    )
+    .limit(1);
+  if (reassignment) return true;
+
+  const [approvedSince] = await tx
+    .select({ id: dbSchema.gymClaims.id })
+    .from(dbSchema.gymClaims)
+    .where(
+      and(
+        eq(dbSchema.gymClaims.gymId, claim.gymId),
+        ne(dbSchema.gymClaims.id, claim.id),
+        eq(dbSchema.gymClaims.status, 'approved'),
+        gt(dbSchema.gymClaims.updatedAt, claim.createdAt),
+      ),
+    )
+    .limit(1);
+  return approvedSince !== undefined;
+}
+
+/**
  * Apply a claim: transfer gym ownership to the claimant. The pending row is
  * flipped to `approved` atomically first — if another transaction already
  * resolved it (double-clicked verify link, concurrent admin approval), this
- * returns null and does nothing, so the transfer + emails happen exactly once.
- * A real prior owner (not the system/import user) is kept on as a gym admin and
- * reported back so they can be notified. Returns null if the gym vanished.
+ * returns `not_applied` and does nothing, so the transfer + emails happen
+ * exactly once. A real prior owner (not the system/import user) is kept on as a
+ * gym admin and reported back so they can be notified. Also `not_applied` if
+ * the gym vanished.
+ *
+ * A claim older than the gym's current ownership returns `superseded` having
+ * written NOTHING — not even the status flip. Approving it would move ownership
+ * back to the claimant, demote whoever an admin chose to a membership row, mail
+ * them "someone verified they manage this gym" (false for a handover), and
+ * re-stamp `syncFrozenAt`, which `reassignGymOwner` goes out of its way to leave
+ * alone. The row stays `pending` so the claimant still gets a real outcome from
+ * the existing Deny path instead of being closed out silently.
  *
  * `requireCurrentOwnerId` narrows the apply to a gym still owned by that user —
  * the auto-approval path passes the system import user so it can only ever hand
@@ -90,7 +163,7 @@ type ClaimApplied = {
 export async function applyGymClaim(
   claim: typeof dbSchema.gymClaims.$inferSelect,
   opts: { reviewerId?: string; requireCurrentOwnerId?: string } = {},
-): Promise<ClaimApplied | null> {
+): Promise<ApplyGymClaimResult> {
   const { reviewerId, requireCurrentOwnerId } = opts;
   return db.transaction(async (tx) => {
     const [gym] = await tx
@@ -98,8 +171,24 @@ export async function applyGymClaim(
       .from(dbSchema.gyms)
       .where(and(eq(dbSchema.gyms.id, claim.gymId), isNull(dbSchema.gyms.deletedAt)))
       .limit(1);
-    if (!gym) return null;
-    if (requireCurrentOwnerId !== undefined && gym.ownerId !== requireCurrentOwnerId) return null;
+    if (!gym) return { outcome: 'not_applied' };
+    if (requireCurrentOwnerId !== undefined && gym.ownerId !== requireCurrentOwnerId) {
+      return { outcome: 'not_applied' };
+    }
+
+    // Only a claim that would actually move the gym can undo someone's decision.
+    // When the claimant already owns it — an admin who handed the gym straight
+    // to them rather than working the queue — the transfer block below is a
+    // no-op, so approving is how that claim finally gets an outcome. Refusing it
+    // would strand the row with Deny (and its "sorry, no" email) as the only way
+    // out, for the person who was in fact given the gym.
+    //
+    // No `FOR UPDATE`: a handover committing between this read and the transfer
+    // makes the owner-guarded UPDATE below match 0 rows and roll the whole
+    // transaction back, which is the behaviour the concurrency tests pin.
+    if (gym.ownerId !== claim.claimantUserId && (await ownershipMovedSinceClaim(tx, gym.uuid, claim))) {
+      return { outcome: 'superseded' };
+    }
 
     // Claim the pending row atomically; 0 rows means someone else already resolved it.
     const flipped = await tx
@@ -107,7 +196,7 @@ export async function applyGymClaim(
       .set({ status: 'approved', reviewedBy: reviewerId ?? null, updatedAt: new Date() })
       .where(and(eq(dbSchema.gymClaims.id, claim.id), eq(dbSchema.gymClaims.status, 'pending')))
       .returning({ id: dbSchema.gymClaims.id });
-    if (flipped.length === 0) return null;
+    if (flipped.length === 0) return { outcome: 'not_applied' };
 
     const priorOwnerId = gym.ownerId;
     const claimantId = claim.claimantUserId;
@@ -149,12 +238,15 @@ export async function applyGymClaim(
     }
 
     return {
-      gymName: gym.name,
-      gymUuid: gym.uuid,
-      gymSlug: gym.slug,
-      claimantUserId: claimantId,
-      claimEmail: claim.claimEmail,
-      priorOwnerId: notifyPriorOwnerId,
+      outcome: 'applied',
+      applied: {
+        gymName: gym.name,
+        gymUuid: gym.uuid,
+        gymSlug: gym.slug,
+        claimantUserId: claimantId,
+        claimEmail: claim.claimEmail,
+        priorOwnerId: notifyPriorOwnerId,
+      },
     };
   });
 }
@@ -215,7 +307,7 @@ export async function verifyGymClaimByToken(
   token: string,
 ): Promise<
   | { ok: true; gymName: string; gymSlug: string | null; gymUuid: string }
-  | { ok: false; reason: 'invalid' | 'expired' | 'used' }
+  | { ok: false; reason: 'invalid' | 'expired' | 'used' | 'superseded' }
 > {
   if (!token) return { ok: false, reason: 'invalid' };
   const tokenHash = hashClaimToken(token);
@@ -237,9 +329,16 @@ export async function verifyGymClaimByToken(
   }
 
   const result = await applyGymClaim(claim);
-  if (!result) return { ok: false, reason: 'used' };
-  await notifyClaimApplied(result);
-  return { ok: true, gymName: result.gymName, gymSlug: result.gymSlug, gymUuid: result.gymUuid };
+  // Not 'used': the link still works, the gym just isn't this claimant's to take
+  // any more. The claim stays pending so an admin can resolve it deliberately.
+  if (result.outcome === 'superseded') {
+    logger.warn(`[GymClaim] Domain claim ${claim.id} on gym ${claim.gymId} was superseded; leaving it pending`);
+    return { ok: false, reason: 'superseded' };
+  }
+  if (result.outcome !== 'applied') return { ok: false, reason: 'used' };
+  const { applied } = result;
+  await notifyClaimApplied(applied);
+  return { ok: true, gymName: applied.gymName, gymSlug: applied.gymSlug, gymUuid: applied.gymUuid };
 }
 
 /**
@@ -286,12 +385,15 @@ async function tryAutoApproveAdminClaim(
     await applyRateLimit(ctx, 3, 'gymClaimAutoApprove');
 
     const result = await applyGymClaim(claim, { requireCurrentOwnerId: SYSTEM_BOARD_OWNER_ID });
-    if (result) {
-      logger.info(
-        `[GymClaim] Auto-approved claim ${claim.id} on gym ${gym.uuid} for user ${claim.claimantUserId} (unclaimed listing)`,
-      );
+    if (result.outcome === 'superseded') {
+      logger.warn(`[GymClaim] Claim ${claim.id} on gym ${gym.uuid} was superseded; leaving it queued`);
+      return null;
     }
-    return result;
+    if (result.outcome !== 'applied') return null;
+    logger.info(
+      `[GymClaim] Auto-approved claim ${claim.id} on gym ${gym.uuid} for user ${claim.claimantUserId} (unclaimed listing)`,
+    );
+    return result.applied;
   } catch (error) {
     // Pass the Error itself, not `.message` — winston serializes the stack.
     logger.warn(`[GymClaim] Auto-approval of claim ${claim.id} on gym ${gym.uuid} failed; leaving it queued:`, error);
@@ -717,25 +819,40 @@ export const socialGymClaimMutations = {
       return true;
     }
 
-    // Both ways this can fail mean the same thing to the reviewer — the claim
-    // wasn't applied — so fold them into one message. `applyGymClaim` returns
-    // null when the gym is gone or the claim was already resolved, and throws
-    // when a concurrent transfer beat us to the guarded UPDATE; letting that
-    // throw escape would hand the admin an internal message instead.
-    let result: ClaimApplied | null;
+    // Two of the ways this can fail mean the same thing to the reviewer — the
+    // claim wasn't applied — so fold them into one message. `applyGymClaim`
+    // returns `not_applied` when the gym is gone or the claim was already
+    // resolved, and throws when a concurrent transfer beat us to the guarded
+    // UPDATE; letting that throw escape would hand the admin an internal
+    // message instead. `superseded` is deliberately NOT folded in — see below.
+    let result: ApplyGymClaimResult;
     try {
       result = await applyGymClaim(claim, { reviewerId: adminUserId });
     } catch (error) {
       logger.warn(`[GymClaim] Manual approval of claim ${claim.id} lost an ownership race:`, error);
-      result = null;
+      result = { outcome: 'not_applied' };
     }
 
-    if (!result) {
+    // Raised outside the catch above on purpose: this one is not "the claim
+    // wasn't applied, try again", it is a decision the reviewer has to make.
+    // Somebody already settled who owns this gym after the claim was filed, so
+    // approving would hand it back and undo them. Deny it, or move ownership on
+    // purpose with the handover panel next to the queue.
+    if (result.outcome === 'superseded') {
+      logger.warn(
+        `[GymClaim] Refused approval of claim ${claim.id} on gym ${claim.gymId}: ownership moved after it was filed`,
+      );
+      throw new GraphQLError('This gym changed hands after the claim was filed.', {
+        extensions: { code: GYM_CLAIM_SUPERSEDED_CODE },
+      });
+    }
+
+    if (result.outcome !== 'applied') {
       // The gym was removed, or the claim was resolved concurrently — don't
       // report a success the admin panel would show as "approved".
       throw new Error('Could not approve this claim — the gym may have been removed or it was already resolved');
     }
-    await notifyClaimApplied(result);
+    await notifyClaimApplied(result.applied);
     return true;
   },
 };

--- a/packages/shared/i18n/locales/de/admin.json
+++ b/packages/shared/i18n/locales/de/admin.json
@@ -250,7 +250,8 @@
     "snackbar": {
       "approved": "Anspruch angenommen — Besitz übertragen",
       "denied": "Anspruch abgelehnt",
-      "failed": "Der Anspruch ließ sich nicht ändern"
+      "failed": "Der Anspruch ließ sich nicht ändern",
+      "superseded": "Diese Halle hat nach dem Anspruch den Besitzer gewechselt. Lehn ihn ab oder nutz unten Hallen-Besitz übertragen."
     },
     "table": {
       "claimant": "Anspruchsteller*in",

--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -656,6 +656,7 @@
         "invalid": "Dieser Link ist ungültig. Starte den Anspruch nochmal von der Halle aus.",
         "expired": "Dieser Link ist abgelaufen. Starte den Anspruch nochmal und hol dir einen frischen.",
         "used": "Dieser Link wurde schon benutzt.",
+        "superseded": "Diese Halle hat jetzt einen anderen Besitzer, dieser Link kann sie also nicht übertragen. Starte den Anspruch nochmal von der Halle aus, dann schaut sich das ein Admin an.",
         "serverError": "Bei uns ging etwas schief. Versuch es gleich nochmal."
       }
     }

--- a/packages/shared/i18n/locales/en-US/admin.json
+++ b/packages/shared/i18n/locales/en-US/admin.json
@@ -250,7 +250,8 @@
     "snackbar": {
       "approved": "Claim approved — ownership transferred",
       "denied": "Claim denied",
-      "failed": "Couldn't update the claim"
+      "failed": "Couldn't update the claim",
+      "superseded": "This gym changed hands after the claim was filed. Deny it, or use Move gym ownership below."
     },
     "table": {
       "claimant": "Claimant",

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -656,6 +656,7 @@
         "invalid": "This claim link isn't valid. Start the claim again from the gym.",
         "expired": "This link expired. Start the claim again to get a fresh one.",
         "used": "This link was already used.",
+        "superseded": "This gym has a different owner now, so this link can't hand it over. Start the claim again from the gym and an admin will take a look.",
         "serverError": "Something went wrong on our end. Try again in a bit."
       }
     }

--- a/packages/shared/i18n/locales/es/admin.json
+++ b/packages/shared/i18n/locales/es/admin.json
@@ -250,7 +250,8 @@
     "snackbar": {
       "approved": "Reclamación aprobada: propiedad transferida",
       "denied": "Reclamación rechazada",
-      "failed": "No se pudo actualizar la reclamación"
+      "failed": "No se pudo actualizar la reclamación",
+      "superseded": "Este rocódromo cambió de manos después de presentarse la reclamación. Recházala o usa Cambiar la propiedad de un rocódromo más abajo."
     },
     "table": {
       "claimant": "Solicitante",

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -656,6 +656,7 @@
         "invalid": "Este enlace de reclamación no es válido. Vuelve a iniciar la reclamación desde el rocódromo.",
         "expired": "Este enlace ha caducado. Vuelve a iniciar la reclamación para obtener uno nuevo.",
         "used": "Este enlace ya se ha usado.",
+        "superseded": "Este rocódromo ya tiene otro propietario, así que este enlace no puede traspasarlo. Vuelve a iniciar la reclamación desde el rocódromo y un administrador la revisará.",
         "serverError": "Algo salió mal por nuestra parte. Inténtalo de nuevo en un momento."
       }
     }

--- a/packages/shared/i18n/locales/fr/admin.json
+++ b/packages/shared/i18n/locales/fr/admin.json
@@ -250,7 +250,8 @@
     "snackbar": {
       "approved": "Revendication approuvée — propriété transférée",
       "denied": "Revendication refusée",
-      "failed": "Impossible de mettre à jour la revendication"
+      "failed": "Impossible de mettre à jour la revendication",
+      "superseded": "Cette salle a changé de mains après le dépôt de la revendication. Refusez-la, ou utilisez Changer le propriétaire d’une salle plus bas."
     },
     "table": {
       "claimant": "Demandeur",

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -656,6 +656,7 @@
         "invalid": "Ce lien de revendication n’est pas valide. Relancez la revendication depuis la salle.",
         "expired": "Ce lien a expiré. Relancez la revendication pour en obtenir un nouveau.",
         "used": "Ce lien a déjà été utilisé.",
+        "superseded": "Cette salle a désormais un autre propriétaire, ce lien ne peut donc pas la transférer. Relancez la revendication depuis la salle et un administrateur l’examinera.",
         "serverError": "Une erreur est survenue de notre côté. Réessayez dans un instant."
       }
     }

--- a/packages/web/app/components/admin/__tests__/gym-claims-panel.test.tsx
+++ b/packages/web/app/components/admin/__tests__/gym-claims-panel.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { GymClaim } from '@boardsesh/shared-schema';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import GymClaimsPanel from '../gym-claims-panel';
+
+const mockRequest = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (namespace?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(namespace, key, options),
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'admin-token' }),
+}));
+
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+vi.mock('@boardsesh/graphql/operations', () => ({
+  PENDING_GYM_CLAIMS: 'PENDING_GYM_CLAIMS',
+  REVIEW_GYM_CLAIM: 'REVIEW_GYM_CLAIM',
+}));
+
+const claim: GymClaim = {
+  id: '17',
+  gymUuid: '6b1c1dd3-6e63-4f1e-9d0b-3e2ce4a0f5aa',
+  gymName: 'Committee Wall',
+  claimantUserId: 'stale-claimant',
+  claimantDisplayName: 'Ada Claimant',
+  claimantAvatarUrl: null,
+  method: 'admin',
+  status: 'pending',
+  claimEmail: null,
+  message: 'I run this place.',
+  createdAt: '2026-07-01T09:00:00.000Z',
+};
+
+function queueResponse() {
+  return { pendingGymClaims: { claims: [claim], totalCount: 1, hasMore: false } };
+}
+
+async function renderQueue(): Promise<void> {
+  render(<GymClaimsPanel />);
+  await screen.findByText('Committee Wall');
+}
+
+describe('GymClaimsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('names the superseded rejection and keeps the claim in the queue for a Deny', async () => {
+    const superseded = Object.assign(new Error('superseded'), {
+      response: { errors: [{ extensions: { code: 'GYM_CLAIM_SUPERSEDED' } }] },
+    });
+    mockRequest.mockResolvedValueOnce(queueResponse()).mockRejectedValueOnce(superseded);
+
+    await renderQueue();
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+
+    // The code-specific line, not the generic "couldn't update": approving is
+    // never going to work on this row, and the reviewer needs to know why.
+    expect(
+      await screen.findByText(
+        'This gym changed hands after the claim was filed. Deny it, or use Move gym ownership below.',
+      ),
+    ).toBeTruthy();
+
+    // The claim is still pending server-side, and Deny is the next action — so
+    // it must not disappear from the table the way a successful review does.
+    expect(screen.getByText('Committee Wall')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Deny' }).hasAttribute('disabled')).toBe(false);
+  });
+
+  it('falls back to the generic failure line when a rejection carries no code', async () => {
+    mockRequest.mockResolvedValueOnce(queueResponse()).mockRejectedValueOnce(new Error('network down'));
+
+    await renderQueue();
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+
+    expect(await screen.findByText("Couldn't update the claim")).toBeTruthy();
+    expect(screen.getByText('Committee Wall')).toBeTruthy();
+  });
+
+  it('drops the row from the queue when the review lands', async () => {
+    mockRequest.mockResolvedValueOnce(queueResponse()).mockResolvedValueOnce({ reviewGymClaim: true });
+
+    await renderQueue();
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+
+    expect(await screen.findByText('Claim approved — ownership transferred')).toBeTruthy();
+    await waitFor(() => expect(screen.queryByText('Committee Wall')).toBeNull());
+  });
+});

--- a/packages/web/app/components/admin/gym-claims-panel.tsx
+++ b/packages/web/app/components/admin/gym-claims-panel.tsx
@@ -30,6 +30,25 @@ import {
 } from '@boardsesh/graphql/operations';
 import type { GymClaim } from '@boardsesh/shared-schema';
 
+type GraphqlErrorLike = { extensions?: { code?: unknown } | null };
+
+/**
+ * The `extensions.code` the backend tags a rejected review with, read the same
+ * way the handover panel next door reads its own codes. Only one code needs its
+ * own line today: a claim the gym's ownership has already moved past, where the
+ * fix is to deny it or run a deliberate handover — not to retry.
+ */
+function failureCode(error: unknown): string | null {
+  if (!error || typeof error !== 'object') return null;
+  const response = (error as { response?: { errors?: GraphqlErrorLike[] } }).response;
+  const graphqlErrors = Array.isArray(response?.errors) ? response.errors : [];
+  for (const graphqlError of graphqlErrors) {
+    const code = graphqlError.extensions?.code;
+    if (typeof code === 'string') return code;
+  }
+  return null;
+}
+
 export default function GymClaimsPanel() {
   const { t } = useTranslation('admin');
   const { token } = useWsAuthToken();
@@ -81,10 +100,16 @@ export default function GymClaimsPanel() {
         await client.request<ReviewGymClaimMutationResponse, ReviewGymClaimMutationVariables>(REVIEW_GYM_CLAIM, {
           input: { claimId, decision },
         });
-        setClaims((prev) => prev.filter((c) => c.id !== claimId));
+        setClaims((prev) => prev.filter((claim) => claim.id !== claimId));
         setSnackbar(decision === 'approve' ? t('gymClaims.snackbar.approved') : t('gymClaims.snackbar.denied'));
-      } catch {
-        setSnackbar(t('gymClaims.snackbar.failed'));
+      } catch (err) {
+        // A superseded claim is still pending and Deny is the next action, so
+        // the row deliberately stays in the table.
+        setSnackbar(
+          failureCode(err) === 'GYM_CLAIM_SUPERSEDED'
+            ? t('gymClaims.snackbar.superseded')
+            : t('gymClaims.snackbar.failed'),
+        );
       } finally {
         setPendingId(null);
       }
@@ -207,7 +232,9 @@ export default function GymClaimsPanel() {
         </Box>
       )}
 
-      <Snackbar open={!!snackbar} autoHideDuration={3000} onClose={() => setSnackbar('')} message={snackbar} />
+      {/* 4s to match the two sibling admin panels — the rejection lines here are
+          a sentence of instruction, not a one-word confirmation. */}
+      <Snackbar open={!!snackbar} autoHideDuration={4000} onClose={() => setSnackbar('')} message={snackbar} />
     </Box>
   );
 }

--- a/packages/web/app/gym-claim/error/page.tsx
+++ b/packages/web/app/gym-claim/error/page.tsx
@@ -19,6 +19,8 @@ function reasonMessage(t: (key: string) => string, reason: string | undefined): 
       return t('claimLanding.error.reasons.expired');
     case 'used':
       return t('claimLanding.error.reasons.used');
+    case 'superseded':
+      return t('claimLanding.error.reasons.superseded');
     case 'server_error':
       return t('claimLanding.error.reasons.serverError');
     default:


### PR DESCRIPTION
## Summary

Closes #4525.

The title of the issue undersells this. Approving a stale claim does not just re-stamp a timestamp — it hands the gym back:

1. A gym has a pending claim from A sitting in the review queue.
2. An admin decides the gym belongs to B and moves it there with the handover panel (`reassignGymOwner`), which deliberately leaves `syncFrozenAt` exactly as it was.
3. Nobody resolves A's claim. Weeks later an admin approves it from the queue.
4. `applyGymClaim` runs its normal transfer: `gyms.owner_id` goes back to **A**, **B is demoted to a gym-admin membership row**, A's membership row is deleted, and B gets `sendGymClaimOwnershipLostEmail` — *"someone verified they manage this gym"*, which is simply untrue for an admin handover. On top of that the UPDATE stamps `syncFrozenAt: new Date()`, the one write #4520 goes out of its way to omit, so a listing an admin had left unfrozen stops being maintained by location sync.

Meanwhile the `gym_owner_reassignments` audit row still records the correct before/after pair from when the handover ran, so the trail reads clean. Nothing surfaces any of it.

`applyGymClaim` decided all of that from the claim row and the gym's *current* state alone. It never asked whether ownership had already moved since the claim was filed, and `reviewGymClaim` passed no `requireCurrentOwnerId` guard either.

### The fix

A staleness check inside `applyGymClaim`'s transaction, before the pending→approved flip. Exactly two code paths move `gyms.owner_id` (`grep` for `update(dbSchema.gyms)` / `SET owner_id` — `createGym` only INSERTs), and both leave a dated record:

- an admin handover writes a `gym_owner_reassignments` row (hits the existing `gym_owner_reassignments_gym_history_idx`);
- a claim-driven transfer is dated by the approved claim row itself — an approved claim's `updated_at` **is** its approval time.

Reading both is an exhaustive answer with no new bookkeeping. Anything newer than `claim.created_at` and the apply writes **nothing at all** — not even the status flip — and returns `superseded`. Reading the claim table also closes the two-admin case the issue calls the useful follow-on: two pending claims on one gym, both approved, the second one refused.

No `FOR UPDATE`. A handover committing between the staleness read and the transfer still makes the owner-guarded UPDATE match 0 rows and roll the whole transaction back — the behaviour the existing concurrency tests pin.

### What the reviewer sees, and what the claimant gets

The claim is left **`pending`**, deliberately. There is no `superseded` value in `gym_claim_status` and adding one would cost an enum migration plus codegen, and — worse — would silently close a claim with no outcome ever reaching the claimant, which is the exact complaint #4515 fixed for denials. Deny stays the human outcome, and it still sends the denial email.

`reviewGymClaim` throws a `GraphQLError` tagged `GYM_CLAIM_SUPERSEDED`, raised *outside* the try/catch that folds the concurrent-transfer race into the generic failure, so it isn't swallowed. `GymClaimsPanel` reads the code the same way `GymOwnerReassignPanel` reads its own and names the reason instead of "Couldn't update the claim" — and keeps the row in the table, because Deny is the admin's next action. The domain verify link reports `superseded` rather than `used` (the link was never spent), and the landing page tells the claimant to file again, which genuinely works: a fresh claim is newer than the handover.

One deliberate carve-out: if the claimant **already owns the gym** — an admin who resolved the claim with the handover panel instead of the queue — the transfer block is a no-op, so approving moves nothing and freezes nothing. Refusing it would strand the row with Deny, and its "sorry, no" email, as the only way out for the person who did get the gym. Covered by a test.

### Exposure

Preventive, not a live incident. PostHog (project 412845, last 365 days) shows **zero** `Gym Claim Submitted` / `Gym Claim Result` / `Gym Claim CTA Clicked` events — the instrumented claim queue has had no production traffic, and the directory only just opened to everyone. Caveat: claims filed before #4515 added that instrumentation wouldn't appear, so that bounds recent behaviour rather than all history. This lands before the funnel gets traffic.

Not in scope, per the issue's Option A: `pendingClaimCount` on `GymOwnershipSummary` so the handover dialog warns about queued claims. With the approval now refused that's a nicety rather than the fix — worth a separate small PR.

## Release Notes

- Approving an old gym claim can't quietly take a gym back off the person an admin handed it to — if ownership already moved, the review says so instead of reversing it.

## Test plan

Six new backend cases in `gym-write-access-and-claims.test.ts`, all against the real DB. The load-bearing one is the issue's full sequence: reassign to B, approve A's older claim, and assert ownership **stays** with B, `syncFrozenAt` is untouched, the membership rows are byte-identical to what the handover left, the claim is still `pending`, and no approval or ownership-lost email fired.

- **Unfrozen gym** (the issue's sequence) — refused with `GYM_CLAIM_SUPERSEDED`, `sync_frozen_at` still NULL, `gym_members` unchanged, no notification, no emails.
- **Frozen gym** — the exact seeded timestamp survives. Same two-mistake split as #4520's freeze pair: the NULL case goes red on "set it for consistency", this one goes red on a re-stamp that merely keeps the column non-null.
- **Two admins, no handover** — two queued claims on one gym; the first approval lands, the second is refused and stays `pending`.
- **Control** — claim filed *after* the handover approves normally, ownership moves, `syncFrozenAt` is stamped. Without this the guard could refuse everything and every assertion above would still pass.
- **Carve-out** — handover gave the gym to the claimant; approving still closes the row, and moves/freezes nothing.
- **Domain path** — `verifyGymClaimByToken` returns `{ ok: false, reason: 'superseded' }`, no transfer, claim left pending.

Proof the guard is load-bearing: with the check short-circuited to `false`, exactly those four refusal cases fail and the two controls pass.

Also updated: the two direct `applyGymClaim` call sites for the new discriminated-union return; `gym_owner_reassignments` added to the file's `TRUNCATE` list (it has no FK to `gyms`, so the CASCADE that clears the rest of the fixture leaves it behind); and the "never leaks the internal race message" test now accepts either curated message, since the loser of that race can now legitimately be refused as superseded rather than as already-resolved.

Ran locally:

- `vp test run --project backend gym-write-access-and-claims --reporter=agent` — **108 passed**.
- `vp run typecheck:backend` — clean (test-inclusive).
- `vp run check:i18n`, `vp run check:i18n:orphans` — clean.
- `vp test run --project i18n --reporter=agent` — 101 passed (catalog parity for the two new keys across en-US/es/fr/de).
- Pre-commit hook (`vp check --fix` + both i18n checks) passed.

New web test `gym-claims-panel.test.tsx` (superseded copy renders, row stays in the queue, generic fallback, success drops the row) — **not** verified locally. This box is at load average ~100 on 8 cores with ~25 worktrees running, and the *pre-existing, untouched* `gym-owner-reassign-panel.test.tsx` fails 5/5 with jsdom render timeouts under that load. Component behaviour was confirmed directly (the panel renders the superseded line and keeps the row); leaving the timing to CI rather than chasing it here.
