### PR TITLE
fix(mobile): resolve the session-join board from the full board list

### DIFF
--- a/packages/mobile/app/join/[sessionId].tsx
+++ b/packages/mobile/app/join/[sessionId].tsx
@@ -16,13 +16,15 @@ import { useTheme } from '../../src/providers/theme-provider';
 import { useAuth } from '../../src/providers/auth-provider';
 import { useQueueSessionId, useQueueActions } from '../../src/providers/queue-provider';
 import { useToast } from '../../src/providers/toast-provider';
+import { isNetworkError } from '@boardsesh/offline-sync/error-classification';
 import {
   useSessionPreview,
-  useMyBoards,
   useCreateBoard,
   useBoardBySlug,
+  fetchAllMyBoards,
   fetchBoardBySlug,
 } from '../../src/lib/graphql/hooks';
+import { createBoardOrAdoptDuplicate } from '../../src/lib/graphql/create-board-or-adopt-duplicate';
 import { resolveBoardForSession } from '../../src/lib/board-path-to-user-board';
 import { spacing, borderRadius } from '../../src/theme/tokens';
 
@@ -47,7 +49,6 @@ export default function JoinSessionScreen() {
   const { joinSession, clearSession } = useQueueActions();
 
   const preview = useSessionPreview(sessionId);
-  const myBoards = useMyBoards(undefined, { enabled: isAuthenticated });
   const createBoard = useCreateBoard();
 
   const [isJoining, setIsJoining] = useState(false);
@@ -77,19 +78,20 @@ export default function JoinSessionScreen() {
     if (!session) return;
     setIsJoining(true);
     try {
-      // Make sure the user's boards have loaded before resolving. On a cold
-      // deep-link open the preview can resolve before myBoards; an empty list
-      // makes resolveBoardForSession create a board the user already owns, which
-      // the backend rejects ("You already have a board with this configuration")
-      // and surfaces as a generic join error. Awaiting the boards lets the
-      // owned-board reuse path run instead.
-      let ownedBoards = myBoards.data?.boards;
-      if (!ownedBoards) {
-        ownedBoards = (await myBoards.refetch()).data?.boards ?? [];
-      }
       const userBoard = await resolveBoardForSession(session.boardPath, {
-        ownedBoards,
-        createBoard: (input) => createBoard.mutateAsync(input),
+        // The whole owned rack, walked imperatively. `useMyBoards` hands back one
+        // page — 20 boards by default — so a joiner whose matching board sorts
+        // past it reads as owning no such board and the join mints a duplicate
+        // the backend then rejects. The walk also REJECTS when it can't reach the
+        // server, where an awaited `refetch()` would pause forever under
+        // `networkMode: 'offlineFirst'` and a `?? []` fallback would mint that
+        // same duplicate.
+        loadOwnedBoards: fetchAllMyBoards,
+        // Absorbs the narrow race the walk can't: a board with this config
+        // created on another device since the walk comes back as
+        // BOARD_DUPLICATE_CONFIG naming the board to join on instead.
+        createBoard: (input) =>
+          createBoardOrAdoptDuplicate(input, (createInput) => createBoard.mutateAsync(createInput)),
         fetchBoardBySlug,
       });
       await joinSession(session.id, { boardPath: session.boardPath, userBoard });
@@ -109,10 +111,14 @@ export default function JoinSessionScreen() {
       router.replace('/(tabs)/record');
     } catch (error) {
       if (__DEV__) console.warn('[join] failed to join session', error);
-      showToast(t('mobileJoin.joinError'), 'error');
+      // Resolving the session's board needs the network, so a join attempted with
+      // no signal fails on the transport rather than on anything the climber did.
+      // Saying so is the difference between "move to where you have bars" and a
+      // generic failure they can only retry blindly.
+      showToast(isNetworkError(error) ? t('mobileJoin.offlineError') : t('mobileJoin.joinError'), 'error');
       setIsJoining(false);
     }
-  }, [session, myBoards, createBoard, joinSession, router, showToast, t]);
+  }, [session, createBoard, joinSession, router, showToast, t]);
 
   const handleJoinPress = useCallback(() => {
     if (!session) return;

--- a/packages/mobile/app/join/__tests__/join-session-analytics.test.tsx
+++ b/packages/mobile/app/join/__tests__/join-session-analytics.test.tsx
@@ -92,10 +92,11 @@ vi.mock('../../../src/providers/queue-provider', () => ({
 vi.mock('../../../src/providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock('../../../src/lib/graphql/hooks', () => ({
   useSessionPreview: () => preview,
-  useMyBoards: () => ({ data: { boards: [] }, refetch: vi.fn(async () => ({ data: { boards: [] } })) }),
   useCreateBoard: () => ({ mutateAsync: vi.fn(async () => ({})) }),
   useBoardBySlug: () => slugBoardQuery,
+  fetchAllMyBoards: vi.fn(async () => []),
   fetchBoardBySlug: vi.fn(async () => null),
+  fetchBoardByUuid: vi.fn(async () => null),
 }));
 vi.mock('../../../src/lib/board-path-to-user-board', () => ({
   resolveBoardForSession: boardResolver.resolveBoardForSession,

--- a/packages/mobile/app/join/__tests__/join-session-board-resolution.test.tsx
+++ b/packages/mobile/app/join/__tests__/join-session-board-resolution.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+//
+// The join screen's board resolution, end to end from the Join tap: the real
+// `resolveBoardForSession` + `createBoardOrAdoptDuplicate` wired to mocked
+// GraphQL. What's pinned here is the three ways the old one-page/`?? []`
+// resolution went wrong (#4409):
+//   1. a matching board past the first `myBoards` page is REUSED, not duplicated;
+//   2. a BOARD_DUPLICATE_CONFIG rejection is adopted into the board it names;
+//   3. an offline walk surfaces an offline message instead of hanging.
+import { act, render, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+const queue = vi.hoisted(() => ({
+  joinSession: vi.fn(async () => {}),
+  clearSession: vi.fn(async () => {}),
+}));
+const router = vi.hoisted(() => ({ replace: vi.fn(), back: vi.fn() }));
+const showToast = vi.hoisted(() => vi.fn());
+const fetchAllMyBoards = vi.hoisted(() => vi.fn());
+const fetchBoardBySlug = vi.hoisted(() => vi.fn());
+const fetchBoardByUuid = vi.hoisted(() => vi.fn());
+const createBoardMutateAsync = vi.hoisted(() => vi.fn());
+
+const SESSION_BOARD_PATH = 'kilter/8/17/27,28/40';
+
+const preview = vi.hoisted(() => ({
+  data: {
+    id: 'session-42',
+    boardPath: 'kilter/8/17/27,28/40',
+    endedAt: null as string | null,
+    users: [{ id: 'u1', username: 'host', avatarUrl: null, isLeader: true }],
+  },
+  isLoading: false,
+  isError: false,
+  refetch: vi.fn(),
+}));
+
+// Captures the confirmation card's Join button (the first one rendered).
+const buttons = vi.hoisted(() => ({ joinPress: null as (() => void) | null }));
+
+vi.mock('../../../src/lib/analytics', () => ({ track: vi.fn() }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+  Alert: { alert: vi.fn() },
+}));
+
+vi.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ sessionId: 'session-42' }),
+  useRouter: () => router,
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0 }) }));
+
+vi.mock('../../../src/components/Button', () => ({
+  Button: ({ onPress }: { onPress?: () => void }) => {
+    if (buttons.joinPress === null && onPress) buttons.joinPress = onPress;
+    return createElement('button');
+  },
+}));
+vi.mock('../../../src/components/Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../../src/components/Card', () => ({
+  Card: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('../../../src/components/Avatar', () => ({ Avatar: () => null }));
+vi.mock('../../../src/components/ActivityIndicator', () => ({ ActivityIndicator: () => null }));
+vi.mock('../../../src/components/Icon', () => ({ Icon: () => null }));
+vi.mock('../../../src/providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: {}, brandColors: {} }),
+}));
+vi.mock('../../../src/providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
+vi.mock('../../../src/providers/queue-provider', () => ({
+  useQueueSessionId: () => ({ sessionId: null }),
+  useQueueActions: () => ({ joinSession: queue.joinSession, clearSession: queue.clearSession }),
+}));
+vi.mock('../../../src/providers/toast-provider', () => ({ useToast: () => ({ showToast }) }));
+// The only GraphQL boundary. `createBoardOrAdoptDuplicate` imports this same
+// module (as `./hooks`), so its `fetchBoardByUuid` is the mock below too.
+vi.mock('../../../src/lib/graphql/hooks', () => ({
+  useSessionPreview: () => preview,
+  useCreateBoard: () => ({ mutateAsync: createBoardMutateAsync }),
+  useBoardBySlug: () => ({ data: null }),
+  fetchAllMyBoards,
+  fetchBoardBySlug,
+  fetchBoardByUuid,
+}));
+vi.mock('../../../src/theme/tokens', () => ({ spacing: {}, borderRadius: {} }));
+
+import JoinSessionScreen from '../[sessionId]';
+
+function board(overrides: Partial<UserBoard> = {}): UserBoard {
+  return {
+    uuid: 'board-uuid',
+    boardType: 'kilter',
+    layoutId: 8,
+    sizeId: 17,
+    setIds: '27,28',
+    name: 'Kilter',
+    angle: 20,
+    isOwned: true,
+    isAngleAdjustable: true,
+    ...overrides,
+  } as unknown as UserBoard;
+}
+
+/** The BOARD_DUPLICATE_CONFIG shape graphql-request throws, as the backend sends it. */
+function duplicateRejection(existingBoardUuid: string) {
+  return {
+    response: {
+      errors: [
+        { message: 'You already have this board', extensions: { code: 'BOARD_DUPLICATE_CONFIG', existingBoardUuid } },
+      ],
+    },
+  };
+}
+
+async function pressJoin() {
+  render(createElement(JoinSessionScreen));
+  expect(buttons.joinPress).not.toBeNull();
+  await act(async () => {
+    buttons.joinPress?.();
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  buttons.joinPress = null;
+  preview.data.boardPath = SESSION_BOARD_PATH;
+  fetchAllMyBoards.mockResolvedValue([]);
+  fetchBoardBySlug.mockResolvedValue(null);
+  fetchBoardByUuid.mockResolvedValue(null);
+  createBoardMutateAsync.mockResolvedValue(board({ uuid: 'minted-uuid', isOwned: false, angle: 40 }));
+});
+
+describe('JoinSessionScreen board resolution', () => {
+  // The headline bug: `useMyBoards` served 20 boards and the join treated that
+  // page as the whole rack, so a joiner whose board sorted onto page two minted a
+  // duplicate. The full walk is what makes the match findable.
+  it('reuses a matching board from past the first myBoards page', async () => {
+    const matching = board({ uuid: 'page-two-uuid' });
+    const firstPage = Array.from({ length: 20 }, (_, index) => board({ uuid: `other-${index}`, sizeId: 99 }));
+    fetchAllMyBoards.mockResolvedValue([...firstPage, matching]);
+
+    await pressJoin();
+
+    await waitFor(() => expect(queue.joinSession).toHaveBeenCalledTimes(1));
+    expect(createBoardMutateAsync).not.toHaveBeenCalled();
+    expect(queue.joinSession).toHaveBeenCalledWith('session-42', {
+      boardPath: SESSION_BOARD_PATH,
+      // Adopted at the session's angle, not the board's stored 20.
+      userBoard: { ...matching, angle: 40 },
+    });
+    expect(router.replace).toHaveBeenCalledWith('/(tabs)/record');
+  });
+
+  // The walk closes the common case but not the race: a board created on another
+  // device since the walk still rejects, and the rejection names the board to use.
+  it('adopts the board a duplicate rejection names instead of failing the join', async () => {
+    const existing = board({ uuid: 'existing-uuid', angle: 20 });
+    createBoardMutateAsync.mockRejectedValue(duplicateRejection('existing-uuid'));
+    fetchBoardByUuid.mockResolvedValue(existing);
+
+    await pressJoin();
+
+    await waitFor(() => expect(queue.joinSession).toHaveBeenCalledTimes(1));
+    expect(fetchBoardByUuid).toHaveBeenCalledWith('existing-uuid');
+    expect(queue.joinSession).toHaveBeenCalledWith('session-42', {
+      boardPath: SESSION_BOARD_PATH,
+      userBoard: { ...existing, angle: 40 },
+    });
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  // Previously: an awaited `refetch()` paused forever under `offlineFirst`, and a
+  // failed one degraded to `[]` and minted a duplicate. Now the walk rejects, and
+  // the rejection is a transport failure the climber is told about by name.
+  it('surfaces an offline message when the owned-board walk cannot reach the server', async () => {
+    fetchAllMyBoards.mockRejectedValue(new TypeError('Network request failed'));
+
+    await pressJoin();
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith('mobileJoin.offlineError', 'error'));
+    expect(createBoardMutateAsync).not.toHaveBeenCalled();
+    expect(queue.joinSession).not.toHaveBeenCalled();
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  // A server verdict is not a connectivity problem — telling a climber with full
+  // bars that they're offline sends them chasing the wrong fix.
+  it('keeps the generic join error for a server-side failure', async () => {
+    createBoardMutateAsync.mockRejectedValue({
+      response: { errors: [{ message: 'Board limit reached', extensions: { code: 'BOARD_LIMIT', status: 400 } }] },
+    });
+
+    await pressJoin();
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith('mobileJoin.joinError', 'error'));
+    expect(queue.joinSession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/board-path-to-user-board.test.ts
+++ b/packages/mobile/src/lib/__tests__/board-path-to-user-board.test.ts
@@ -106,7 +106,7 @@ describe('resolveBoardForSession', () => {
     const owned = makeBoard({ angle: 40 });
     const createBoard = vi.fn();
     const result = await resolveBoardForSession('kilter/8/17/27,28/30', {
-      ownedBoards: [owned],
+      loadOwnedBoards: async () => [owned],
       createBoard,
       fetchBoardBySlug: vi.fn(),
     });
@@ -118,7 +118,7 @@ describe('resolveBoardForSession', () => {
     const created = makeBoard({ uuid: 'fresh-uuid', isOwned: false, angle: 30 });
     const createBoard = vi.fn().mockResolvedValue(created);
     const result = await resolveBoardForSession('kilter/8/17/27,28/30', {
-      ownedBoards: [],
+      loadOwnedBoards: async () => [],
       createBoard,
       fetchBoardBySlug: vi.fn(),
     });
@@ -136,8 +136,58 @@ describe('resolveBoardForSession', () => {
 
   it('throws on an unparseable board path', async () => {
     await expect(
-      resolveBoardForSession('garbage', { ownedBoards: [], createBoard: vi.fn(), fetchBoardBySlug: vi.fn() }),
+      resolveBoardForSession('garbage', {
+        loadOwnedBoards: async () => [],
+        createBoard: vi.fn(),
+        fetchBoardBySlug: vi.fn(),
+      }),
     ).rejects.toThrow(/Cannot resolve a board/);
+  });
+
+  // The bug this contract exists for: a joiner's matching board sorts past the
+  // first `myBoards` page. The resolver never slices the list it is handed, so a
+  // match at the end of a full walk reuses that board instead of minting one.
+  it('reuses a matching board from deep in the owned list rather than creating one', async () => {
+    const matching = makeBoard({ uuid: 'page-two-uuid', angle: 40 });
+    const nonMatching = Array.from({ length: 60 }, (_, index) => makeBoard({ uuid: `other-${index}`, sizeId: 99 }));
+    const createBoard = vi.fn();
+    const result = await resolveBoardForSession('kilter/8/17/27,28/30', {
+      loadOwnedBoards: async () => [...nonMatching, matching],
+      createBoard,
+      fetchBoardBySlug: vi.fn(),
+    });
+    expect(result).toMatchObject({ uuid: 'page-two-uuid', angle: 30 });
+    expect(createBoard).not.toHaveBeenCalled();
+  });
+
+  // "You own no boards" and "we couldn't find out which boards you own" are the
+  // same input to the reuse step and mint the same duplicate, so a failed load
+  // has to fail the resolve.
+  it('propagates a failed owned-board load instead of creating a board', async () => {
+    const createBoard = vi.fn();
+    await expect(
+      resolveBoardForSession('kilter/8/17/27,28/30', {
+        loadOwnedBoards: async () => {
+          throw new Error('Network request failed');
+        },
+        createBoard,
+        fetchBoardBySlug: vi.fn(),
+      }),
+    ).rejects.toThrow(/Network request failed/);
+    expect(createBoard).not.toHaveBeenCalled();
+  });
+
+  // A named board resolves by slug, so the owned-list walk (a round trip, and a
+  // rejection while offline) must never run for it.
+  it('never loads the owned list for a named-board path', async () => {
+    const loadOwnedBoards = vi.fn(async () => []);
+    const namedBoard = makeBoard({ uuid: 'named-uuid', slug: 'my-gym-moonboard', angle: 25 });
+    await resolveBoardForSession('/b/my-gym-moonboard/40', {
+      loadOwnedBoards,
+      createBoard: vi.fn(),
+      fetchBoardBySlug: vi.fn().mockResolvedValue(namedBoard),
+    });
+    expect(loadOwnedBoards).not.toHaveBeenCalled();
   });
 
   describe('named-board (/b/{slug}) paths', () => {
@@ -146,7 +196,7 @@ describe('resolveBoardForSession', () => {
       const fetchBoardBySlug = vi.fn().mockResolvedValue(namedBoard);
       const createBoard = vi.fn();
       const result = await resolveBoardForSession('/b/my-gym-moonboard/40/list', {
-        ownedBoards: [],
+        loadOwnedBoards: async () => [],
         createBoard,
         fetchBoardBySlug,
       });
@@ -160,7 +210,7 @@ describe('resolveBoardForSession', () => {
       const namedBoard = makeBoard({ uuid: 'named-uuid', slug: 'my-gym-moonboard', angle: 25 });
       const fetchBoardBySlug = vi.fn().mockResolvedValue(namedBoard);
       const result = await resolveBoardForSession('/b/my-gym-moonboard', {
-        ownedBoards: [],
+        loadOwnedBoards: async () => [],
         createBoard: vi.fn(),
         fetchBoardBySlug,
       });
@@ -172,7 +222,7 @@ describe('resolveBoardForSession', () => {
       const fetchBoardBySlug = vi.fn().mockResolvedValue(null);
       await expect(
         resolveBoardForSession('/b/deleted-board/40', {
-          ownedBoards: [],
+          loadOwnedBoards: async () => [],
           createBoard: vi.fn(),
           fetchBoardBySlug,
         }),

--- a/packages/mobile/src/lib/board-path-to-user-board.ts
+++ b/packages/mobile/src/lib/board-path-to-user-board.ts
@@ -9,8 +9,9 @@
 // a full UserBoard (uuid/slug/isAngleAdjustable).
 //
 // The pure logic (parse + owned-reuse + the create-input it would build) is
-// factored out so it can be unit-tested without React/GraphQL. The join screen
-// wires the real `useMyBoards` data + `useCreateBoard` mutation into `deps`.
+// factored out so it can be unit-tested without React/GraphQL. Callers wire the
+// real owned-board walk (`fetchAllMyBoards`) + `useCreateBoard` mutation into
+// `deps`.
 
 import type { CreateBoardInput, UserBoard } from '@boardsesh/shared-schema';
 import { parseBoardPath, parseNamedBoardPath, formatBoardDisplayName } from '@boardsesh/board-config';
@@ -27,8 +28,25 @@ export type ResolvedBoardConfig = {
 };
 
 export type ResolveBoardDeps = {
-  /** The boards the signed-in user already owns (from `useMyBoards`). */
-  ownedBoards: UserBoard[];
+  /**
+   * Every board the signed-in user already owns, loaded on demand.
+   *
+   * A loader rather than a pre-populated array, because the two ways of getting
+   * that array wrong both mint a duplicate of gear the user already has and the
+   * resolver cannot tell them apart from an honestly empty rack. A single
+   * `myBoards` page (20 rows by default, 50 at the cap) hides a board that sorts
+   * onto page two; and an awaited React Query `refetch()` under
+   * `networkMode: 'offlineFirst'` pauses its retryer while offline and never
+   * settles, so callers that guarded it with a `?? []` fallback handed over an
+   * empty list on exactly the failure that matters. Owning the call here makes
+   * the guard part of the contract instead of something every caller reimplements:
+   * pass an imperative walk that REJECTS (`fetchAllMyBoards`), and a failed load
+   * fails the resolve rather than creating a board.
+   *
+   * Called lazily, and only for the tuple form — a named board (`/b/{slug}`)
+   * resolves by slug and never reads the owned list.
+   */
+  loadOwnedBoards: () => Promise<UserBoard[]>;
   /** Persists a new board server-side and returns the full UserBoard. */
   createBoard: (input: CreateBoardInput) => Promise<UserBoard>;
   /** Resolve a named board (`/b/{slug}`) to its full entity, or null when the
@@ -99,6 +117,10 @@ export function buildCreateBoardInput(config: ResolvedBoardConfig): CreateBoardI
  *   1. Parse the path → config (throws on an unparseable / angle-less path).
  *   2. Reuse a matching owned board (angle overridden from the path), or
  *   3. Create a new board via `deps.createBoard`.
+ *
+ * A rejected `deps.loadOwnedBoards()` propagates: "you own no boards" and "we
+ * couldn't find out which boards you own" are the same input to step 2 and mint
+ * the same duplicate, so the resolver refuses to guess.
  */
 export async function resolveBoardForSession(boardPath: string, deps: ResolveBoardDeps): Promise<UserBoard> {
   const named = parseNamedBoardPath(boardPath);
@@ -116,7 +138,7 @@ export async function resolveBoardForSession(boardPath: string, deps: ResolveBoa
     throw new Error(`Cannot resolve a board from session boardPath: ${boardPath}`);
   }
 
-  const owned = findOwnedBoardForSession(deps.ownedBoards, config);
+  const owned = findOwnedBoardForSession(await deps.loadOwnedBoards(), config);
   if (owned) return owned;
 
   return deps.createBoard(buildCreateBoardInput(config));

--- a/packages/mobile/src/lib/graphql/__tests__/create-board-or-adopt-duplicate.test.ts
+++ b/packages/mobile/src/lib/graphql/__tests__/create-board-or-adopt-duplicate.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CreateBoardInput, UserBoard } from '@boardsesh/shared-schema';
+
+const fetchBoardByUuid = vi.hoisted(() => vi.fn());
+
+vi.mock('../hooks', () => ({ fetchBoardByUuid }));
+
+import { createBoardOrAdoptDuplicate } from '../create-board-or-adopt-duplicate';
+
+function makeBoard(overrides: Partial<UserBoard> = {}): UserBoard {
+  return {
+    uuid: 'board-uuid',
+    boardType: 'kilter',
+    layoutId: 8,
+    sizeId: 17,
+    setIds: '27,28',
+    name: 'Kilter',
+    angle: 40,
+    isOwned: false,
+    isAngleAdjustable: true,
+    ...overrides,
+  } as unknown as UserBoard;
+}
+
+const CREATE_INPUT: CreateBoardInput = {
+  boardType: 'kilter',
+  layoutId: 8,
+  sizeId: 17,
+  setIds: '27,28',
+  angle: 30,
+  isOwned: false,
+  name: 'Kilter',
+};
+
+/** The BOARD_DUPLICATE_CONFIG shape graphql-request throws, as the backend sends it. */
+function duplicateRejection(existingBoardUuid: string) {
+  return {
+    response: {
+      errors: [
+        { message: 'You already have this board', extensions: { code: 'BOARD_DUPLICATE_CONFIG', existingBoardUuid } },
+      ],
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchBoardByUuid.mockResolvedValue(null);
+});
+
+describe('createBoardOrAdoptDuplicate', () => {
+  it('returns the created board when the server accepts the create', async () => {
+    const created = makeBoard({ uuid: 'fresh-uuid', angle: 30 });
+    const createBoard = vi.fn().mockResolvedValue(created);
+
+    await expect(createBoardOrAdoptDuplicate(CREATE_INPUT, createBoard)).resolves.toBe(created);
+    expect(createBoard).toHaveBeenCalledWith(CREATE_INPUT);
+    expect(fetchBoardByUuid).not.toHaveBeenCalled();
+  });
+
+  it('adopts the board a duplicate rejection names, at the input angle', async () => {
+    const existing = makeBoard({ uuid: 'existing-uuid', angle: 40 });
+    fetchBoardByUuid.mockResolvedValue(existing);
+    const createBoard = vi.fn().mockRejectedValue(duplicateRejection('existing-uuid'));
+
+    const result = await createBoardOrAdoptDuplicate(CREATE_INPUT, createBoard);
+
+    expect(fetchBoardByUuid).toHaveBeenCalledWith('existing-uuid');
+    expect(result).toEqual({ ...existing, angle: 30 });
+    // The cached board must not be mutated in place.
+    expect(existing.angle).toBe(40);
+  });
+
+  it('returns the same reference when the existing board is already at the input angle', async () => {
+    const existing = makeBoard({ uuid: 'existing-uuid', angle: 30 });
+    fetchBoardByUuid.mockResolvedValue(existing);
+    const createBoard = vi.fn().mockRejectedValue(duplicateRejection('existing-uuid'));
+
+    await expect(createBoardOrAdoptDuplicate(CREATE_INPUT, createBoard)).resolves.toBe(existing);
+  });
+
+  it("falls back to the existing board's own angle when the input carries none", async () => {
+    const existing = makeBoard({ uuid: 'existing-uuid', angle: 45 });
+    fetchBoardByUuid.mockResolvedValue(existing);
+    const createBoard = vi.fn().mockRejectedValue(duplicateRejection('existing-uuid'));
+
+    const result = await createBoardOrAdoptDuplicate({ ...CREATE_INPUT, angle: undefined }, createBoard);
+
+    expect(result).toBe(existing);
+  });
+
+  it('rethrows a rejection that is not a duplicate', async () => {
+    const createBoard = vi.fn().mockRejectedValue(new Error('Network request failed'));
+
+    await expect(createBoardOrAdoptDuplicate(CREATE_INPUT, createBoard)).rejects.toThrow(/Network request failed/);
+    expect(fetchBoardByUuid).not.toHaveBeenCalled();
+  });
+
+  it('rethrows the create rejection when the named board cannot be read', async () => {
+    fetchBoardByUuid.mockResolvedValue(null);
+    const rejection = duplicateRejection('existing-uuid');
+    const createBoard = vi.fn().mockRejectedValue(rejection);
+
+    await expect(createBoardOrAdoptDuplicate(CREATE_INPUT, createBoard)).rejects.toBe(rejection);
+  });
+
+  it('rethrows the create rejection when the lookup itself fails', async () => {
+    fetchBoardByUuid.mockRejectedValue(new Error('lookup exploded'));
+    const rejection = duplicateRejection('existing-uuid');
+    const createBoard = vi.fn().mockRejectedValue(rejection);
+
+    // The create rejection is the failure that describes what happened, so the
+    // lookup's own rejection is swallowed rather than replacing it.
+    await expect(createBoardOrAdoptDuplicate(CREATE_INPUT, createBoard)).rejects.toBe(rejection);
+  });
+});

--- a/packages/mobile/src/lib/graphql/create-board-or-adopt-duplicate.ts
+++ b/packages/mobile/src/lib/graphql/create-board-or-adopt-duplicate.ts
@@ -1,0 +1,46 @@
+// `createBoard`, with the server's duplicate rejection recovered into the board
+// it names.
+//
+// Shared by every caller that resolves a board config into a real `UserBoard`:
+// the canonical-URL deep links (`use-board-route-target`) and the party-session
+// join screen (`app/join/[sessionId]`). Both walk the owned list first and both
+// hit the same race afterwards, so the recovery lives here rather than in either.
+
+import type { CreateBoardInput, UserBoard } from '@boardsesh/shared-schema';
+import { readDuplicateBoardError } from './extract-error-message';
+import { fetchBoardByUuid } from './hooks';
+
+/**
+ * Create the board `input` describes, adopting the existing board when the
+ * server rejects the create as a duplicate.
+ *
+ * Walking the owned list first closes the common case but not the race: a board
+ * with this config created on another device between that walk and this create
+ * still comes back as BOARD_DUPLICATE_CONFIG. The rejection carries the existing
+ * board's uuid precisely so a client needn't search a paginated list for it — so
+ * a join or deep link that would otherwise dead-end adopts the board the user
+ * already has. The angle comes off the create input, which is the URL's / the
+ * session's.
+ */
+export async function createBoardOrAdoptDuplicate(
+  input: CreateBoardInput,
+  createBoard: (input: CreateBoardInput) => Promise<UserBoard>,
+): Promise<UserBoard> {
+  try {
+    return await createBoard(input);
+  } catch (createError) {
+    const duplicate = readDuplicateBoardError(createError);
+    if (!duplicate) throw createError;
+    // A duplicate naming a board we then can't read is a dead end, not a
+    // fallback — and the create rejection is the failure that describes what
+    // happened, so the lookup's own rejection is swallowed rather than replacing
+    // it. Hence `.catch(() => null)`: a rejected lookup and a null board are the
+    // same outcome here.
+    const existing = await fetchBoardByUuid(duplicate.boardUuid).catch(() => null);
+    if (!existing) throw createError;
+    // `CreateBoardInput.angle` is optional on the wire; `buildCreateBoardInput`
+    // always fills it from the path, and the board's own angle is the fallback.
+    const angle = input.angle ?? existing.angle;
+    return existing.angle === angle ? existing : { ...existing, angle };
+  }
+}

--- a/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
+++ b/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
@@ -377,10 +377,11 @@ describe('useBoardRouteTarget', () => {
     rerender(createElement(Harness, { target: { kind: 'list', board: KILTER_BOARD } as BoardRouteTarget }));
 
     await waitFor(() => expect(resolveBoardForSession).toHaveBeenCalledTimes(1));
-    expect(resolveBoardForSession).toHaveBeenCalledWith(
-      'kilter/1/10/1,20/40',
-      expect.objectContaining({ ownedBoards: [RESOLVED_BOARD] }),
-    );
+    expect(resolveBoardForSession).toHaveBeenCalledWith('kilter/1/10/1,20/40', expect.anything());
+    // The list is handed over through the loader the resolver now owns, already
+    // walked here so it isn't fetched twice.
+    const [, deps] = resolveBoardForSession.mock.calls[0] as [string, { loadOwnedBoards: () => Promise<unknown> }];
+    await expect(deps.loadOwnedBoards()).resolves.toEqual([RESOLVED_BOARD]);
     await waitFor(() => expect(router.replace).toHaveBeenCalledWith('/(tabs)/climbs'));
   });
 

--- a/packages/mobile/src/lib/routing/use-board-route-target.ts
+++ b/packages/mobile/src/lib/routing/use-board-route-target.ts
@@ -30,15 +30,15 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'expo-router';
 import { onlineManager } from '@tanstack/react-query';
 import { isNetworkError } from '@boardsesh/offline-sync/error-classification';
-import type { Climb, CreateBoardInput, UserBoard } from '@boardsesh/shared-schema';
+import type { Climb, UserBoard } from '@boardsesh/shared-schema';
 import { toBoardPath, type BoardRouteTarget } from './board-route-target';
 // The platform switch is this constant, not `Platform.OS` — the hook then needs
 // no `react-native` import, whose RN 0.86 Flow entry the vitest node env cannot
 // parse (see the config's `hooks-dual-write` exclusion note).
 import { RELAXES_ANONYMOUS_ROUTES } from './anonymous-auth-gate';
 import { useClimb } from '../graphql/hooks';
-import { fetchAllMyBoards, fetchBoardBySlug, fetchBoardByUuid, useCreateBoard } from '../graphql/hooks';
-import { readDuplicateBoardError } from '../graphql/extract-error-message';
+import { fetchAllMyBoards, fetchBoardBySlug, useCreateBoard } from '../graphql/hooks';
+import { createBoardOrAdoptDuplicate } from '../graphql/create-board-or-adopt-duplicate';
 import { useSetActiveBoard } from '../graphql/use-active-board';
 import { getStoredActiveBoard } from '../active-board-store';
 import { getOfflineBoards } from '../../settings/offline-boards';
@@ -173,40 +173,6 @@ async function resolveBoardSlugLocalFirst(slug: string): Promise<UserBoard | nul
     const downloadedBoard = await findLocalBoardForSlug(slug, true);
     if (!downloadedBoard) throw slugError;
     return downloadedBoard;
-  }
-}
-
-/**
- * `createBoard`, with the server's duplicate rejection recovered into the board
- * it names.
- *
- * Walking the owned list first closes the common case but not the race: a board
- * with this config created on another device between that walk and this create
- * still comes back as BOARD_DUPLICATE_CONFIG. The rejection carries the existing
- * board's uuid precisely so a client needn't search a paginated list for it — so
- * a URL that would otherwise dead-end as not-found adopts the board the user
- * already has. The angle comes off the create input, which is the URL's.
- */
-async function createBoardOrAdoptDuplicate(
-  input: CreateBoardInput,
-  createBoard: (input: CreateBoardInput) => Promise<UserBoard>,
-): Promise<UserBoard> {
-  try {
-    return await createBoard(input);
-  } catch (createError) {
-    const duplicate = readDuplicateBoardError(createError);
-    if (!duplicate) throw createError;
-    // A duplicate naming a board we then can't read is a dead end, not a
-    // fallback — and the create rejection is the failure that describes what
-    // happened, so the lookup's own rejection is swallowed rather than replacing
-    // it. Hence `.catch(() => null)`: a rejected lookup and a null board are the
-    // same outcome here.
-    const existing = await fetchBoardByUuid(duplicate.boardUuid).catch(() => null);
-    if (!existing) throw createError;
-    // `CreateBoardInput.angle` is optional on the wire; `buildCreateBoardInput`
-    // always fills it from the URL, and the board's own angle is the fallback.
-    const angle = input.angle ?? existing.angle;
-    return existing.angle === angle ? existing : { ...existing, angle };
   }
 }
 
@@ -362,7 +328,10 @@ function useAdoptedBoard(
         const resolved =
           localBoard ??
           (await resolveBoardForSession(boardPath, {
-            ownedBoards,
+            // Already walked above (or deliberately left empty for a signed-out
+            // visitor), so the loader hands the list straight back rather than
+            // fetching it twice.
+            loadOwnedBoards: async () => ownedBoards,
             createBoard: (input) =>
               createBoardOrAdoptDuplicate(input, (createInput) => createBoardMutation.mutateAsync(createInput)),
             // Local first here too, so a named board already on the device opens

--- a/packages/shared/i18n/locales/de/session.json
+++ b/packages/shared/i18n/locales/de/session.json
@@ -551,6 +551,7 @@
     "switchBody": "Du verlässt deine aktive Session, um dieser beizutreten.",
     "signInToJoin": "Zum Beitreten anmelden",
     "joinError": "Der Session konnte nicht beigetreten werden",
+    "offlineError": "Offline — verbinde dich neu, um dieser Session beizutreten",
     "hostFallback": "jemandem aus der Crew"
   }
 }

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -551,6 +551,7 @@
     "switchBody": "You'll leave your active session to join this one.",
     "signInToJoin": "Sign in to join",
     "joinError": "Couldn't join the session",
+    "offlineError": "You're offline — reconnect to join this session",
     "hostFallback": "a climber"
   }
 }

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -551,6 +551,7 @@
     "switchBody": "Saldrás de tu sesión activa para unirte a esta.",
     "signInToJoin": "Inicia sesión para unirte",
     "joinError": "No se pudo unir a la sesión",
+    "offlineError": "Sin conexión: vuelve a conectarte para unirte a esta sesión",
     "hostFallback": "un escalador"
   }
 }

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -551,6 +551,7 @@
     "switchBody": "Vous quitterez votre session active pour rejoindre celle-ci.",
     "signInToJoin": "Connectez-vous pour rejoindre",
     "joinError": "Impossible de rejoindre la session",
+    "offlineError": "Hors ligne — reconnectez-vous pour rejoindre cette session",
     "hostFallback": "un grimpeur"
   }
 }


### PR DESCRIPTION
## Summary

Joining a session via a shared link only checked the user's first 20 boards, so a matching board sitting on a later page looked like "no board owned," and the app created a duplicate (or the backend rejected it and the join failed with a generic error). It also hung forever if the join happened offline. The fix moves board-ownership resolution to a full paginated fetch that fails loudly instead of degrading to an empty list, reuses a shared duplicate-adoption helper between the join screen and the existing deep-link flow, and adds a distinct offline error message instead of an infinite spinner.

---

Closes #4409

## The bug

`app/join/[sessionId].tsx` resolved the session's board from `useMyBoards(undefined)` — the server's **20-board default page**, handed to `resolveBoardForSession` as if it were the user's whole rack. Three ways that goes wrong:

- **A board past the first page reads as no board at all.** The joiner's matching board sorts onto page two, the resolver sees no match, and `CREATE_BOARD` mints a duplicate of gear they already own — or the backend rejects it as `BOARD_DUPLICATE_CONFIG` and the join dies on a generic error.
- **Offline, the join hung.** The pre-fetch awaited `myBoards.refetch()`, and under React Query's `networkMode: 'offlineFirst'` a paused retryer never settles. The spinner spun forever.
- **A failed fetch degraded to `[]`** — the same input as "you own nothing", minting the same duplicate.

The deep-link hook (#3823) already had the pieces; the join screen never got them.

## The fix

1. **`createBoardOrAdoptDuplicate` lifted** out of `use-board-route-target.ts` into `src/lib/graphql/create-board-or-adopt-duplicate.ts`. Both callers hit the same cross-device race after their owned-list walk, so the recovery lives in one place instead of one of them.
2. **`ResolveBoardDeps.ownedBoards: UserBoard[]` becomes `loadOwnedBoards: () => Promise<UserBoard[]>`.** The guard belongs in the resolver's contract, not copied by every caller: "you own no boards" and "we couldn't find out which boards you own" are the same input to the reuse step and mint the same duplicate, so a rejected load now fails the resolve instead of guessing. It is also lazy — a named board (`/b/{slug}`) resolves by slug and never pays for the walk.
3. **The join screen passes `fetchAllMyBoards`** — the imperative pagination walk that rejects instead of pausing — and wraps its create in `createBoardOrAdoptDuplicate`.
4. **Offline gets its own message.** A join that failed on the transport says so (`mobileJoin.offlineError`, branched on `isNetworkError`) rather than showing the generic join error, which a climber can only retry blindly. Added to all four locales.

`use-board-route-target` keeps its own richer offline handling (downloaded-board fallback, `onlineManager` short-circuit) and hands its already-walked list straight to the loader, so nothing is fetched twice.

## Tests

New `app/join/__tests__/join-session-board-resolution.test.tsx` drives the real resolver and adopt helper from a Join tap against a mocked GraphQL boundary:

- a matching board past the first `myBoards` page is reused, at the session's angle, with no create;
- a `BOARD_DUPLICATE_CONFIG` rejection is adopted into the board it names, and the join completes;
- an unreachable server surfaces the offline message, mints nothing, and joins nothing;
- a server verdict (`status: 400`) keeps the generic join error, so a climber with full bars is not told they are offline.

Plus unit coverage for the lifted `createBoardOrAdoptDuplicate` and the new `loadOwnedBoards` contract (deep match reused, failed load propagated, never called for a named-board path).

## Release Notes

Joining a session from a link now finds the board you already own instead of quietly adding a second copy of it, even if you own a lot of boards. If the link opens with no signal, the join tells you you're offline and stops instead of spinning forever.
