### PR TITLE
feat(backend): expose lastClimbAt on popularBoardConfigs

### DIFF
--- a/packages/backend/src/__tests__/operations-schema-validation.test.ts
+++ b/packages/backend/src/__tests__/operations-schema-validation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vite-plus/test';
 import { readFileSync } from 'fs';
-import { buildSchema, parse, validate, visit, type DocumentNode, type GraphQLSchema } from 'graphql';
+import { buildSchema, parse, validate, visit, GraphQLObjectType, type DocumentNode, type GraphQLSchema } from 'graphql';
 import { typeDefs } from '@boardsesh/shared-schema';
 import * as publicOperations from '@boardsesh/graphql/operations';
 import * as accountOperations from '@boardsesh/graphql/operations/account';
@@ -471,4 +471,29 @@ describe('previous-release driver operations: reduced-B7 validation split', () =
       expect(unknownMutationErrors.length).toBeGreaterThan(0);
     });
   }
+});
+
+// Issue #4466: `PopularBoardConfig.lastClimbAt` MUST stay nullable (`String`,
+// not `String!`). The Redis cache is keyed with a 1-year TTL and warmed only
+// by the node that wins a deploy-time lock — a node that loses the lock, or
+// an old-version node restarting after a deploy, can serve a legacy cached
+// row that has no `lastClimbAt` key at all. A non-null field over that
+// missing key would null the whole `PopularBoardConfig`, which sits inside
+// `configs: [PopularBoardConfig!]!` — erroring the entire query and taking
+// down the boards sitemap shard, the paged climbs shard's config groups, and
+// the homepage rail all at once. Every other test in this campaign runs
+// against a freshly-built cache, so only an explicit SDL assertion catches
+// this regression.
+describe('PopularBoardConfig.lastClimbAt stays nullable', () => {
+  it('is declared as `String`, not `String!`, on the executable schema', () => {
+    const popularBoardConfigType = schema.getType('PopularBoardConfig');
+    if (!(popularBoardConfigType instanceof GraphQLObjectType)) {
+      throw new Error('PopularBoardConfig type not found (or not an object type) on the built schema');
+    }
+    const lastClimbAtField = popularBoardConfigType.getFields().lastClimbAt;
+    if (!lastClimbAtField) {
+      throw new Error('PopularBoardConfig.lastClimbAt field not found on the built schema');
+    }
+    expect(String(lastClimbAtField.type)).toBe('String');
+  });
 });

--- a/packages/backend/src/__tests__/popular-board-configs-last-climb-at.test.ts
+++ b/packages/backend/src/__tests__/popular-board-configs-last-climb-at.test.ts
@@ -154,8 +154,18 @@ describe('popularBoardConfigs.lastClimbAt (SQL aggregate, real DB)', () => {
 describe('normalizeCatalogTimestamp', () => {
   it.each([
     ['2024-03-11 09:00:00.123456', '2024-03-11T09:00:00.123Z'],
+    // The commonest Aurora shape: space separator, no fraction at all. Covered
+    // only through the SQL test otherwise, which cannot distinguish "the
+    // normaliser handled it" from "the aggregate picked a different row".
+    ['2024-03-11 09:00:00', '2024-03-11T09:00:00.000Z'],
     ['2023-11-23T18:00:15.227', '2023-11-23T18:00:15.227Z'],
     ['2024-03-11T09:00:00Z', '2024-03-11T09:00:00.000Z'],
+    // The SQL `LIKE '____-__-__%'` mask is deliberately loose enough to pass a
+    // zone-carrying row through, so the JS side has to convert one rather than
+    // stamp `Z` over it. +05:30 is 03:30 UTC, and the colon-less spelling is
+    // the same instant.
+    ['2024-03-11T09:00:00+05:30', '2024-03-11T03:30:00.000Z'],
+    ['2024-03-11T09:00:00-0800', '2024-03-11T17:00:00.000Z'],
     // Sub-millisecond fraction, explicitly right-padded (0.5s = 500ms, not 5ms).
     ['2024-03-11T09:00:00.5', '2024-03-11T09:00:00.500Z'],
     [null, null],

--- a/packages/backend/src/__tests__/popular-board-configs-last-climb-at.test.ts
+++ b/packages/backend/src/__tests__/popular-board-configs-last-climb-at.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vite-plus/test';
 import { and, eq, sql } from 'drizzle-orm';
 import * as dbSchema from '@boardsesh/db/schema';
 import { db } from '../db/client';

--- a/packages/backend/src/__tests__/popular-board-configs-last-climb-at.test.ts
+++ b/packages/backend/src/__tests__/popular-board-configs-last-climb-at.test.ts
@@ -1,0 +1,217 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { and, eq, sql } from 'drizzle-orm';
+import * as dbSchema from '@boardsesh/db/schema';
+import { db } from '../db/client';
+import { redisClientManager, type RedisClients } from '../redis/client';
+import {
+  getPopularConfigs,
+  normalizeCatalogTimestamp,
+  type CachedPopularConfig,
+} from '../graphql/resolvers/social/boards';
+import { seedAuroraCatalogFixtures } from './helpers/board-catalog-fixture';
+
+// Issue #4466: `popularBoardConfigs` gains `lastClimbAt`, the newest listed
+// climb's `created_at` in that config, normalised to a proper ISO-8601 UTC
+// string. `board_climbs.created_at` is TEXT, not timestamptz, and carries two
+// naive-UTC (zone-less) separator styles depending on the importer — Aurora
+// writes a space (`'2024-03-11 09:00:00'`), MoonBoard writes ISO-T
+// (`'2023-11-23T18:00:15.227'`). A raw text MAX across a mix of both is wrong
+// on a shared calendar day: 'T' (0x54) sorts after ' ' (0x20), so the SQL
+// aggregate must canonicalise the separator before taking the max.
+const BOARD_TYPE = 'lastclimbat-test';
+const PRODUCT_ID = 941001;
+const LAYOUT_ID = 941001;
+const SIZE_ID = 941001;
+const SET_ID = 941001;
+
+// Config edges: a climb counts only if edge_left > bps.edge_left,
+// edge_right < bps.edge_right, edge_bottom > bps.edge_bottom, edge_top <
+// bps.edge_top (strict containment). In-bounds climbs use 10..90; the size
+// itself is 0..100.
+const SIZE_EDGES = { edgeLeft: 0, edgeRight: 100, edgeBottom: 0, edgeTop: 100 };
+const IN_BOUNDS_EDGES = { edgeLeft: 10, edgeRight: 90, edgeBottom: 10, edgeTop: 90 };
+
+async function insertClimb(params: {
+  uuid: string;
+  edges: { edgeLeft: number; edgeRight: number; edgeBottom: number; edgeTop: number };
+  createdAt: string | null;
+  isListed: boolean;
+  isDraft: boolean;
+}) {
+  const { uuid, edges, createdAt, isListed, isDraft } = params;
+  await db.execute(sql`
+    INSERT INTO board_climbs
+      (uuid, board_type, layout_id, name, edge_left, edge_right, edge_bottom, edge_top, is_listed, is_draft, created_at)
+    VALUES
+      (${uuid}, ${BOARD_TYPE}, ${LAYOUT_ID}, ${uuid}, ${edges.edgeLeft}, ${edges.edgeRight}, ${edges.edgeBottom}, ${edges.edgeTop}, ${isListed}, ${isDraft}, ${createdAt})
+  `);
+}
+
+async function cleanupClimbs() {
+  await db.execute(sql`DELETE FROM board_climb_stats WHERE board_type = ${BOARD_TYPE}`);
+  await db.execute(sql`DELETE FROM board_climbs WHERE board_type = ${BOARD_TYPE}`);
+}
+
+describe('popularBoardConfigs.lastClimbAt (SQL aggregate, real DB)', () => {
+  let teardownFixture: (() => Promise<void>) | undefined;
+
+  beforeAll(async () => {
+    await cleanupClimbs();
+    teardownFixture = await seedAuroraCatalogFixtures([
+      {
+        boardType: BOARD_TYPE,
+        productId: PRODUCT_ID,
+        layoutId: LAYOUT_ID,
+        sizeId: SIZE_ID,
+        setIds: [SET_ID],
+        associationIdBase: 941001,
+        isListed: true,
+      },
+    ]);
+    // The fixture helper doesn't set edges (not every consumer needs them) —
+    // stamp them here so the LATERAL's containment predicate has something
+    // real to compare against.
+    await db
+      .update(dbSchema.boardProductSizes)
+      .set(SIZE_EDGES)
+      .where(and(eq(dbSchema.boardProductSizes.boardType, BOARD_TYPE), eq(dbSchema.boardProductSizes.id, SIZE_ID)));
+  });
+
+  afterAll(async () => {
+    await cleanupClimbs();
+    if (teardownFixture) await teardownFixture();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function findConfig(): Promise<CachedPopularConfig | undefined> {
+    vi.spyOn(redisClientManager, 'isRedisConnected').mockReturnValue(false);
+    const configs = await getPopularConfigs();
+    return configs.find((config) => config.boardType === BOARD_TYPE && config.layoutId === LAYOUT_ID);
+  }
+
+  it('takes the chronological max across mixed space/T separators, ignoring NULL and out-of-config rows', async () => {
+    await cleanupClimbs();
+    await insertClimb({
+      uuid: `${BOARD_TYPE}-A`,
+      edges: IN_BOUNDS_EDGES,
+      createdAt: '2024-01-01 10:00:00.123456',
+      isListed: true,
+      isDraft: false,
+    });
+    await insertClimb({
+      // Space-separated, no fractional seconds — the real chronological max.
+      uuid: `${BOARD_TYPE}-B`,
+      edges: IN_BOUNDS_EDGES,
+      createdAt: '2024-03-11 09:00:00',
+      isListed: true,
+      isDraft: false,
+    });
+    await insertClimb({
+      // Same calendar date as B, ISO-T separated, earlier time. A raw text
+      // MAX (no separator normalisation) would wrongly prefer this row over
+      // B, since 'T' (0x54) sorts after ' ' (0x20).
+      uuid: `${BOARD_TYPE}-F`,
+      edges: IN_BOUNDS_EDGES,
+      createdAt: '2024-03-11T08:00:00.000',
+      isListed: true,
+      isDraft: false,
+    });
+    await insertClimb({
+      uuid: `${BOARD_TYPE}-E`,
+      edges: IN_BOUNDS_EDGES,
+      createdAt: null,
+      isListed: true,
+      isDraft: false,
+    });
+    await insertClimb({
+      // Decoy: same layout but edges outside the config's size — must not
+      // count even though its created_at is far in the future.
+      uuid: `${BOARD_TYPE}-C`,
+      edges: { edgeLeft: 0, edgeRight: 90, edgeBottom: 10, edgeTop: 90 },
+      createdAt: '2030-01-01 00:00:00',
+      isListed: true,
+      isDraft: false,
+    });
+    await insertClimb({
+      // Decoy: in-bounds but unlisted — must not count even though its
+      // created_at is far in the future.
+      uuid: `${BOARD_TYPE}-D`,
+      edges: IN_BOUNDS_EDGES,
+      createdAt: '2029-01-01 00:00:00',
+      isListed: false,
+      isDraft: false,
+    });
+
+    const config = await findConfig();
+    expect(config).toBeDefined();
+    expect(config?.lastClimbAt).toBe('2024-03-11T09:00:00.000Z');
+  });
+});
+
+describe('normalizeCatalogTimestamp', () => {
+  it.each([
+    ['2024-03-11 09:00:00.123456', '2024-03-11T09:00:00.123Z'],
+    ['2023-11-23T18:00:15.227', '2023-11-23T18:00:15.227Z'],
+    ['2024-03-11T09:00:00Z', '2024-03-11T09:00:00.000Z'],
+    [null, null],
+    ['', null],
+    ['unknown', null],
+    ['2024-13-45T00:00:00', null],
+  ])('normalizeCatalogTimestamp(%p) -> %p', (input, expected) => {
+    expect(normalizeCatalogTimestamp(input)).toBe(expected);
+  });
+
+  it('rejects a value in the future rather than leaking a fabricated <lastmod>', () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-19T00:00:00Z'));
+    try {
+      expect(normalizeCatalogTimestamp('2030-01-01 00:00:00')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('popularBoardConfigs cache: legacy row without lastClimbAt', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resolves without throwing and leaves lastClimbAt absent, never a synthesised value', async () => {
+    const legacyConfig: Omit<CachedPopularConfig, 'lastClimbAt'> = {
+      boardType: 'legacy-cache-test',
+      layoutId: 1,
+      layoutName: 'Legacy Layout',
+      sizeId: 1,
+      sizeName: 'Legacy Size',
+      sizeDescription: null,
+      setIds: [1],
+      setNames: ['Legacy Set'],
+      climbCount: 5,
+      totalAscents: 10,
+      boardCount: 2,
+      displayName: 'Legacy Layout Legacy Size',
+    };
+
+    const mockPublisher = {
+      get: vi.fn().mockResolvedValue(JSON.stringify([legacyConfig])),
+      set: vi.fn(),
+    } as unknown as RedisClients['publisher'];
+
+    vi.spyOn(redisClientManager, 'isRedisConnected').mockReturnValue(true);
+    vi.spyOn(redisClientManager, 'getClients').mockReturnValue({
+      publisher: mockPublisher,
+      subscriber: {} as RedisClients['subscriber'],
+      streamConsumer: {} as RedisClients['streamConsumer'],
+    });
+
+    const configs = await getPopularConfigs();
+
+    expect(configs).toHaveLength(1);
+    expect(configs[0].boardType).toBe('legacy-cache-test');
+    expect(configs[0].lastClimbAt).toBeUndefined();
+  });
+});

--- a/packages/backend/src/__tests__/popular-board-configs-last-climb-at.test.ts
+++ b/packages/backend/src/__tests__/popular-board-configs-last-climb-at.test.ts
@@ -156,6 +156,8 @@ describe('normalizeCatalogTimestamp', () => {
     ['2024-03-11 09:00:00.123456', '2024-03-11T09:00:00.123Z'],
     ['2023-11-23T18:00:15.227', '2023-11-23T18:00:15.227Z'],
     ['2024-03-11T09:00:00Z', '2024-03-11T09:00:00.000Z'],
+    // Sub-millisecond fraction, explicitly right-padded (0.5s = 500ms, not 5ms).
+    ['2024-03-11T09:00:00.5', '2024-03-11T09:00:00.500Z'],
     [null, null],
     ['', null],
     ['unknown', null],

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -806,8 +806,8 @@ const REDIS_CACHE_KEY = 'boardsesh:popular-board-configs:v2';
 // old, which is the safe direction for a `<lastmod>`, but say it out loud rather
 // than let a reader assume the field follows the data.
 //
-// Do not "fix" that by bounding the TTL to hours. The statement below takes 78 s
-// on the dev database (~750 ms per config LATERAL × 45 configs); every expiry
+// Do not "fix" that by bounding the TTL to hours. The statement below was timed
+// at 78 s end to end over the dev database's 45 listed configs; every expiry
 // would put that on a live request, behind the web side's 10 s
 // `SITEMAP_FETCH_TIMEOUT_MS` and the boards shard's 3 s `SHARD_DEADLINE_MS` —
 // trading a stale value for a periodic 503 shard and an empty homepage rail.

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -799,6 +799,19 @@ function formatDisplayName(
 // old key is simply orphaned and expires under its own TTL. Do NOT bump this
 // per deploy, only per payload-shape change.
 const REDIS_CACHE_KEY = 'boardsesh:popular-board-configs:v2';
+// A year, and the only thing that clears it is `warmPopularConfigsCache` at
+// boot. So every value in this payload — `climbCount`, `totalAscents`, and now
+// `lastClimbAt` — tracks DEPLOY CADENCE, not the catalogue: a climb set an hour
+// after a deploy does not move `lastClimbAt` until the next one. Staleness errs
+// old, which is the safe direction for a `<lastmod>`, but say it out loud rather
+// than let a reader assume the field follows the data.
+//
+// Do not "fix" that by bounding the TTL to hours. The statement below takes 78 s
+// on the dev database (~750 ms per config LATERAL × 45 configs); every expiry
+// would put that on a live request, behind the web side's 10 s
+// `SITEMAP_FETCH_TIMEOUT_MS` and the boards shard's 3 s `SHARD_DEADLINE_MS` —
+// trading a stale value for a periodic 503 shard and an empty homepage rail.
+// Boot-warm plus a long TTL is the design, not an oversight.
 const REDIS_CACHE_TTL_SECONDS = 365 * 24 * 60 * 60; // 1 year
 const REDIS_LOCK_KEY = 'boardsesh:popular-board-configs:lock';
 const REDIS_LOCK_TTL_SECONDS = 120; // 2 min lock to prevent duplicate queries across nodes

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -683,7 +683,11 @@ export type CachedPopularConfig = {
   totalAscents: number;
   boardCount: number;
   displayName: string;
-  lastClimbAt: string | null;
+  // Optional, not just nullable: a legacy Redis row cached before this field
+  // existed has no key for it at all, and JSON.parse of that row produces
+  // `undefined` here, not `null` — the cache-legacy-row test pins that. A
+  // non-optional type would be a lie about what call sites actually see.
+  lastClimbAt?: string | null;
 };
 
 /**
@@ -701,6 +705,13 @@ export type CachedPopularConfig = {
  *
  * Returns `null` for anything unparseable, and for a timestamp in the future
  * (a corrupt row must never leak a fabricated future `<lastmod>`).
+ *
+ * The fractional-seconds group is explicitly truncated to exactly 3 digits
+ * (padded on the right when shorter) before hitting `Date.parse`. ECMA-262
+ * only specifies millisecond precision (`.sss`) for the extended ISO format;
+ * Aurora's microsecond-precision `created_at` (6 digits) parsing correctly is
+ * a V8 leniency, not a spec guarantee — truncate explicitly rather than lean
+ * on that.
  */
 export function normalizeCatalogTimestamp(raw: unknown): string | null {
   if (typeof raw !== 'string' || raw.length === 0) {
@@ -713,7 +724,11 @@ export function normalizeCatalogTimestamp(raw: unknown): string | null {
   }
 
   const [, datePart, timePart, fractionPart, zonePart] = match;
-  const rebuilt = `${datePart}T${timePart}${fractionPart ?? ''}${zonePart ?? 'Z'}`;
+  // fractionPart includes its leading dot (e.g. ".123456" or ".5"). Keep up to
+  // 3 digits after the dot and right-pad shorter fractions with zeros — ".5"
+  // means 0.5s = 500ms, so the pad is on the right, not the left.
+  const millis = fractionPart ? `.${fractionPart.slice(1, 4).padEnd(3, '0')}` : '';
+  const rebuilt = `${datePart}T${timePart}${millis}${zonePart ?? 'Z'}`;
   const parsedMs = Date.parse(rebuilt);
   if (!Number.isFinite(parsedMs)) {
     return null;

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -683,7 +683,47 @@ export type CachedPopularConfig = {
   totalAscents: number;
   boardCount: number;
   displayName: string;
+  lastClimbAt: string | null;
 };
+
+/**
+ * Normalise a `board_climbs.created_at` value into a proper ISO-8601 UTC
+ * timestamp string.
+ *
+ * The column is `text`, not `timestamptz`, and carries at least two naive
+ * (zone-less) formats depending on the importer: Aurora/PowerSync writes a
+ * space-separated form (`'2024-03-11 09:00:00.123456'`) and MoonBoard writes
+ * ISO-T (`'2023-11-23T18:00:15.227'`). Neither carries a timezone offset, so
+ * a plain `new Date(raw)` would read both as *local* time — timezone-dependent
+ * and wrong. This is a pure string transform (not a `Date` round-trip) so the
+ * behaviour is identical in every runner timezone: parse the pieces, rebuild
+ * with an explicit `Z`, then validate.
+ *
+ * Returns `null` for anything unparseable, and for a timestamp in the future
+ * (a corrupt row must never leak a fabricated future `<lastmod>`).
+ */
+export function normalizeCatalogTimestamp(raw: unknown): string | null {
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return null;
+  }
+
+  const match = /^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2})(\.\d+)?(Z|[+-]\d{2}:?\d{2})?$/.exec(raw);
+  if (!match) {
+    return null;
+  }
+
+  const [, datePart, timePart, fractionPart, zonePart] = match;
+  const rebuilt = `${datePart}T${timePart}${fractionPart ?? ''}${zonePart ?? 'Z'}`;
+  const parsedMs = Date.parse(rebuilt);
+  if (!Number.isFinite(parsedMs)) {
+    return null;
+  }
+  if (parsedMs > Date.now()) {
+    return null;
+  }
+
+  return new Date(parsedMs).toISOString();
+}
 
 const BOARD_TYPE_LABELS: Record<string, string> = {
   kilter: 'Kilter',
@@ -739,7 +779,11 @@ function formatDisplayName(
   return `${shortLayout} ${shortSize}${setLabel}`.trim();
 }
 
-const REDIS_CACHE_KEY = 'boardsesh:popular-board-configs';
+// v2: added `lastClimbAt`. Bump this suffix whenever the cached payload shape
+// changes so new code can never read a pre-shape row back out of Redis — the
+// old key is simply orphaned and expires under its own TTL. Do NOT bump this
+// per deploy, only per payload-shape change.
+const REDIS_CACHE_KEY = 'boardsesh:popular-board-configs:v2';
 const REDIS_CACHE_TTL_SECONDS = 365 * 24 * 60 * 60; // 1 year
 const REDIS_LOCK_KEY = 'boardsesh:popular-board-configs:lock';
 const REDIS_LOCK_TTL_SECONDS = 120; // 2 min lock to prevent duplicate queries across nodes
@@ -784,7 +828,7 @@ export function dropPopularConfigsFallback(): void {
   fallbackGeneration += 1;
 }
 
-async function getPopularConfigs(): Promise<CachedPopularConfig[]> {
+export async function getPopularConfigs(): Promise<CachedPopularConfig[]> {
   // Try Redis cache first
   if (redisClientManager.isRedisConnected()) {
     try {
@@ -837,7 +881,8 @@ async function runPopularConfigsQuery(): Promise<CachedPopularConfig[]> {
       configs.set_names,
       COALESCE(cc.climb_count, 0) AS climb_count,
       COALESCE(cc.total_ascents, 0) AS total_ascents,
-      COALESCE(ub_counts.board_count, 0) AS board_count
+      COALESCE(ub_counts.board_count, 0) AS board_count,
+      cc.last_climb_at
     FROM (
       SELECT
         psls.board_type,
@@ -868,7 +913,17 @@ async function runPopularConfigsQuery(): Promise<CachedPopularConfig[]> {
     LEFT JOIN LATERAL (
       SELECT
         COUNT(DISTINCT bc.uuid)::int AS climb_count,
-        COALESCE(SUM(bcs.ascensionist_count), 0)::int AS total_ascents
+        COALESCE(SUM(bcs.ascensionist_count), 0)::int AS total_ascents,
+        -- created_at is text, not timestamptz, and carries two naive-UTC
+        -- separator styles (Aurora writes a space, MoonBoard writes 'T').
+        -- REPLACE canonicalises the separator before the text MAX so the
+        -- comparison is chronological rather than lexicographic (raw 'T'
+        -- (0x54) sorts after ' ' (0x20), which would silently pick the wrong
+        -- row on a shared calendar day). The LIKE mask drops anything that
+        -- doesn't start with a YYYY-MM-DD date -- Postgres has no try_cast,
+        -- so this must stay a text filter, never a ::timestamp cast, or one
+        -- unparseable legacy row would 500 the whole query.
+        MAX(REPLACE(bc.created_at, ' ', 'T')) FILTER (WHERE bc.created_at LIKE '____-__-__%') AS last_climb_at
       FROM board_climbs bc
       LEFT JOIN board_climb_stats bcs
         ON bcs.board_type = bc.board_type AND bcs.climb_uuid = bc.uuid
@@ -918,6 +973,7 @@ async function runPopularConfigsQuery(): Promise<CachedPopularConfig[]> {
       totalAscents: Number(row.total_ascents),
       boardCount: Number(row.board_count),
       displayName: formatDisplayName(boardType, layoutName, sizeName, setNames),
+      lastClimbAt: normalizeCatalogTimestamp(row.last_climb_at),
     };
   });
 

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2706,6 +2706,15 @@ type PopularBoardConfig {
   to null rather than error the whole config (which sits inside
   [PopularBoardConfig!]! — a non-null field here would null the entire row
   and error the whole query for every caller reading a stale cache entry).
+
+  NOT a sitemap <lastmod>. It describes the whole config, not any one page:
+  it is neither angle-filtered nor restricted to the top-50-by-ascents window
+  that /{board}/{layout}/{size}/{sets}/{angle}/list actually renders, and it
+  advances daily while that page's newest climb is years old. The measured
+  numbers are in packages/web/app/lib/seo/sitemap/board-entries.ts.
+
+  It is also only as fresh as the last backend deploy — see the Redis TTL
+  comment in the resolver.
   """
   lastClimbAt: String
 }

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2699,6 +2699,15 @@ type PopularBoardConfig {
   boardCount: Int!
   "Pre-formatted display name for UI (e.g. 'OG 12x12 Full Ride')"
   displayName: String!
+  """
+  ISO-8601 UTC timestamp of the newest listed climb in this config, or null.
+  Nullable by design, not merely absent data: a legacy cached row written
+  before this field existed has no value for it, and this field must resolve
+  to null rather than error the whole config (which sits inside
+  [PopularBoardConfig!]! — a non-null field here would null the entire row
+  and error the whole query for every caller reading a stale cache entry).
+  """
+  lastClimbAt: String
 }
 
 """

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -4780,6 +4780,15 @@ export type PopularBoardConfig = {
    * to null rather than error the whole config (which sits inside
    * [PopularBoardConfig!]! — a non-null field here would null the entire row
    * and error the whole query for every caller reading a stale cache entry).
+   *
+   * NOT a sitemap <lastmod>. It describes the whole config, not any one page:
+   * it is neither angle-filtered nor restricted to the top-50-by-ascents window
+   * that /{board}/{layout}/{size}/{sets}/{angle}/list actually renders, and it
+   * advances daily while that page's newest climb is years old. The measured
+   * numbers are in packages/web/app/lib/seo/sitemap/board-entries.ts.
+   *
+   * It is also only as fresh as the last backend deploy — see the Redis TTL
+   * comment in the resolver.
    */
   lastClimbAt?: Maybe<Scalars['String']['output']>;
   /** Layout ID */

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -4773,6 +4773,15 @@ export type PopularBoardConfig = {
   climbCount: Scalars['Int']['output'];
   /** Pre-formatted display name for UI (e.g. 'OG 12x12 Full Ride') */
   displayName: Scalars['String']['output'];
+  /**
+   * ISO-8601 UTC timestamp of the newest listed climb in this config, or null.
+   * Nullable by design, not merely absent data: a legacy cached row written
+   * before this field existed has no value for it, and this field must resolve
+   * to null rather than error the whole config (which sits inside
+   * [PopularBoardConfig!]! — a non-null field here would null the entire row
+   * and error the whole query for every caller reading a stale cache entry).
+   */
+  lastClimbAt?: Maybe<Scalars['String']['output']>;
   /** Layout ID */
   layoutId: Scalars['Int']['output'];
   /** Human-readable layout name */
@@ -11821,6 +11830,7 @@ export type PopularBoardConfigResolvers<
   boardType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   climbCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   displayName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  lastClimbAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   layoutId?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   layoutName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   setIds?: Resolver<Array<ResolversTypes['Int']>, ParentType, ContextType>;

--- a/packages/shared-schema/src/schema/board-entities.ts
+++ b/packages/shared-schema/src/schema/board-entities.ts
@@ -381,6 +381,15 @@ export const boardEntitiesTypeDefs = /* GraphQL */ `
     to null rather than error the whole config (which sits inside
     [PopularBoardConfig!]! — a non-null field here would null the entire row
     and error the whole query for every caller reading a stale cache entry).
+
+    NOT a sitemap <lastmod>. It describes the whole config, not any one page:
+    it is neither angle-filtered nor restricted to the top-50-by-ascents window
+    that /{board}/{layout}/{size}/{sets}/{angle}/list actually renders, and it
+    advances daily while that page's newest climb is years old. The measured
+    numbers are in packages/web/app/lib/seo/sitemap/board-entries.ts.
+
+    It is also only as fresh as the last backend deploy — see the Redis TTL
+    comment in the resolver.
     """
     lastClimbAt: String
   }

--- a/packages/shared-schema/src/schema/board-entities.ts
+++ b/packages/shared-schema/src/schema/board-entities.ts
@@ -374,6 +374,15 @@ export const boardEntitiesTypeDefs = /* GraphQL */ `
     boardCount: Int!
     "Pre-formatted display name for UI (e.g. 'OG 12x12 Full Ride')"
     displayName: String!
+    """
+    ISO-8601 UTC timestamp of the newest listed climb in this config, or null.
+    Nullable by design, not merely absent data: a legacy cached row written
+    before this field existed has no value for it, and this field must resolve
+    to null rather than error the whole config (which sits inside
+    [PopularBoardConfig!]! — a non-null field here would null the entire row
+    and error the whole query for every caller reading a stale cache entry).
+    """
+    lastClimbAt: String
   }
 
   """

--- a/packages/shared-schema/src/types/board-entities.ts
+++ b/packages/shared-schema/src/types/board-entities.ts
@@ -169,6 +169,7 @@ export type PopularBoardConfig = {
   totalAscents: number;
   boardCount: number;
   displayName: string;
+  lastClimbAt?: string | null;
 };
 
 export type PopularBoardConfigConnection = {

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -4770,6 +4770,15 @@ export type PopularBoardConfig = {
   climbCount: Scalars['Int']['output'];
   /** Pre-formatted display name for UI (e.g. 'OG 12x12 Full Ride') */
   displayName: Scalars['String']['output'];
+  /**
+   * ISO-8601 UTC timestamp of the newest listed climb in this config, or null.
+   * Nullable by design, not merely absent data: a legacy cached row written
+   * before this field existed has no value for it, and this field must resolve
+   * to null rather than error the whole config (which sits inside
+   * [PopularBoardConfig!]! — a non-null field here would null the entire row
+   * and error the whole query for every caller reading a stale cache entry).
+   */
+  lastClimbAt?: Maybe<Scalars['String']['output']>;
   /** Layout ID */
   layoutId: Scalars['Int']['output'];
   /** Human-readable layout name */

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -4777,6 +4777,15 @@ export type PopularBoardConfig = {
    * to null rather than error the whole config (which sits inside
    * [PopularBoardConfig!]! — a non-null field here would null the entire row
    * and error the whole query for every caller reading a stale cache entry).
+   *
+   * NOT a sitemap <lastmod>. It describes the whole config, not any one page:
+   * it is neither angle-filtered nor restricted to the top-50-by-ascents window
+   * that /{board}/{layout}/{size}/{sets}/{angle}/list actually renders, and it
+   * advances daily while that page's newest climb is years old. The measured
+   * numbers are in packages/web/app/lib/seo/sitemap/board-entries.ts.
+   *
+   * It is also only as fresh as the last backend deploy — see the Redis TTL
+   * comment in the resolver.
    */
   lastClimbAt?: Maybe<Scalars['String']['output']>;
   /** Layout ID */


### PR DESCRIPTION
## Summary

Adds a `lastClimbAt` field to the backend's `popularBoardConfigs` GraphQL query, computing the newest listed climb's creation time per board config (normalising two different upstream timestamp formats into ISO-8601 UTC). It was built as the backend half of a stack feeding a `<lastmod>` value into the boards sitemap, but the web PR that would have consumed it (#4599) no longer does so, because a config-wide max timestamp turned out to be inaccurate for that purpose (a new climb can't reach the sitemapped page-1 URL, so the value doesn't reflect real freshness). The PR is currently in draft with no consumer selecting the field, and is now a decision point: close it as dead code, or rebuild it as a per-angle map to match the honest sitemap use case (which would need the caching/warm-path redesigned for cost reasons).

---

> ## ⚠️ Read this before merging: the consumer this PR was built for is gone
>
> This shipped as the backend half of a stack whose web half (#4599) would stamp
> `lastClimbAt` as `<lastmod>` on `/sitemaps/boards.xml`. **#4599 no longer does
> that** — measured against the page it would stamp, a config-wide
> `MAX(created_at)` is fabricated freshness, so #4599 now records the measurement
> and pins the omission instead. It is unstacked, based on `main`, and selects
> nothing new from the backend.
>
> **That leaves this PR with no consumer.** It is in draft and needs a call:
>
> - **Close it** — nothing selects `lastClimbAt`, and a GraphQL field nothing
>   selects is dead code.
> - **Or commission the honest version** — `MAX(created_at)` over the page-1
>   window *per angle*, returned as a per-(config, angle) map rather than one
>   scalar per config. That is a different field shape, and it needs the warm
>   path redesigned: measured on the dev database the per-angle query costs
>   **207 s** on top of the **78 s** this statement already spends, against a
>   **120 s** `REDIS_LOCK_TTL_SECONDS`. The normaliser, the `:v2` key and the
>   nullable-SDL decision below all survive into that version.
>
> ### Why the scalar is wrong for a `<lastmod>`
>
> The sitemapped URL is page 1 only, at the default sort — the top
> `FRONT_DOOR_PAGE_SIZE` (50) climbs by ascents. Dev database, 2026-01-31
> snapshot, `/kilter/…/40/list` (layout 1 / size 10 / sets 1+20):
>
> | | |
> |---|---|
> | ascents at rank 50 (the page-1 cutoff) | 21,407 |
> | newest `created_at` among those 50 | 2021-02-11 |
> | best ascents among climbs created into the config in the last 90 days | 86 (0.4% of the cutoff) |
> | climbs created into the config in the last 30 days | 6,148 (~205/day) |
> | what this field would have stamped | 2026-01-31 |
>
> A new climb cannot reach page 1, but the value moves daily. It is also not
> angle-aware while the page is (the list query INNER JOINs `board_climb_stats`
> at the URL's angle): tension layout 11 / size 9 honest page-1 maxima run
> 2024-12-26 (65°) to 2026-01-26 (55°), and 70° has no page-1 content at all,
> against one 2026-01-31 stamp for all 15 angle URLs.
>
> Full numbers and method: #4599 and
> `packages/web/app/lib/seo/sitemap/board-entries.ts`.
>
> ### Also added since review
>
> A doc-only commit recording two properties a reader would otherwise have to
> infer: the whole cached payload only refreshes at boot, so it tracks deploy
> cadence rather than the catalogue; and bounding the Redis TTL to hours is not
> the fix, because the 78 s statement would then land on a live request behind
> the web side's 10 s `SITEMAP_FETCH_TIMEOUT_MS` and the boards shard's 3 s
> `SHARD_DEADLINE_MS`.

---

## Summary

Adds `lastClimbAt` to `popularBoardConfigs` — the newest listed climb's
upstream creation time for each board config, normalised to a proper
ISO-8601 UTC string. This is the **backend half of a two-PR stack** for
#4466; the web half (which turns this into `<lastmod>` on
`/sitemaps/boards.xml`) is #4599 and depends on this PR being live in
production first.

**This PR ships inert.** No client selects the new field yet, so merging
and deploying it changes nothing observable.

### Why `created_at`, and why it needed normalising

`board_climbs.created_at` is `text`, not `timestamptz`, and carries two
naive-UTC (zone-less) separator styles depending on the importer: Aurora
writes a space (`'2024-03-11 09:00:00'`), MoonBoard writes ISO-T
(`'2023-11-23T18:00:15.227'`). A raw text `MAX()` across a mix of both
picks the wrong row on a shared calendar day — `'T'` (0x54) sorts after
`' '` (0x20) — so the SQL aggregate canonicalises the separator
(`REPLACE(bc.created_at, ' ', 'T')`) before taking the max, filtered by a
`LIKE` mask (never a `::timestamp` cast — Postgres has no `try_cast`, so
one legacy garbage row would 500 the whole query). The JS-side
`normalizeCatalogTimestamp` is a pure string transform, not a `Date`
round-trip, so an explicit `Z` gets stamped identically in every runner
timezone; it also rejects anything unparseable and anything in the future.

### Was `created_at` a real upstream clock, or a sync-job artefact?

Ran the read-only production probe the plan called for (Marco
pre-authorized read-only prod access for this work) before writing any
code:

```
board_type    total    with_created  iso_t   space_sep  min_created                    max_created
decoy         8485     8485          0       8485       2021-05-09 19:30:46.884686      2026-08-19 00:15:15.468256
grasshopper   21923    21923         0       21923      2020-09-07 15:14:46.224079      2026-08-19 03:49:29.118979
kilter        317801   317801        52870   264931     2018-05-14 06:08:06.348046      2026-08-19T21:01:25.740558Z
moonboard     271780   239947        239947  0          2010-09-29T12:35:11             2026-08-14T10:08:12.552Z
soill         2035     2035          0       2035       2023-10-13 16:38:52.187900      2026-08-19 01:27:59.299356
tension       144442   144442        2       144440     2021-02-13 01:52:52.000000      2026-08-19 20:58:00.700593
touchstone    1353     1353          0       1353       2022-02-16 03:57:24.791820      2026-01-30 01:54:04.615780
```

(filtered to `is_listed = true AND is_draft = false` — the same rows the
LATERAL scans.)

To settle whether `created_at` is a real per-climb clock or just "when the
sync job last ran," pulled the top 10 kilter rows by `created_at DESC`:
they have **distinct** `created_at` values staggered minutes apart with
distinct climb names, while `updated_at` is identical across all of them
(`2026-08-19T21:03:00.443Z` — the sync job's completion time). That's the
signature of a genuine upstream per-climb timestamp, not a sync-run
artefact — confirming the issue's original choice of `created_at` over
`updated_at`.

`moonboard`'s NULL rate on `created_at` (~12%) is real but not
NULL-dominated — the config still gets a `<lastmod>` from its other 88%.

### What changed

- `boards.ts`: the existing `LEFT JOIN LATERAL` gains one aggregate
  (`MAX(REPLACE(bc.created_at, ' ', 'T')) FILTER (WHERE bc.created_at LIKE
  '____-__-__%')`) riding rows the LATERAL already scans — no new join,
  no new index.
- New exported `normalizeCatalogTimestamp(raw: unknown): string | null` —
  pure-string ISO normaliser, timezone-independent by construction.
- `CachedPopularConfig.lastClimbAt: string | null`.
- SDL: `PopularBoardConfig.lastClimbAt: String` — **deliberately
  nullable** (not `String!`). The Redis cache carries a 1-year TTL and is
  only refreshed by the node that wins a deploy-time lock; a node that
  loses the lock, or an old-version node restarting after a deploy, can
  serve a legacy cached row with no `lastClimbAt` key at all. A non-null
  field over that missing key would null the entire `PopularBoardConfig`,
  which sits inside `configs: [PopularBoardConfig!]!` — erroring the
  whole query and taking down the boards sitemap shard, the paged climbs
  shard's config groups, and the homepage rail together. A new backend
  test pins the SDL type as `String`.
- Redis cache key bumped `boardsesh:popular-board-configs` → `...:v2`.
  The nullable-field path is the safety net, not the plan — the version
  bump means new code structurally cannot read a pre-shape cached row,
  rather than relying on "probably refreshed."
- `vp run codegen` output regenerated (`shared-schema` generated
  schema/types, `shared/graphql` generated client types).

### Tests

New `popular-board-configs-last-climb-at.test.ts` (real DB):
- Seeds one config with climbs at `'2024-01-01 10:00:00.123456'`
  (space), `'2024-03-11 09:00:00'` (space, the true max),
  `'2024-03-11T08:00:00.000'` (same date, T-separated, earlier — the row
  a naive text `MAX` would wrongly prefer), and a NULL `created_at`; two
  decoys (out-of-bounds edges, unlisted) with far-future timestamps that
  must not leak through. Asserts the resolved `lastClimbAt` is exactly
  `'2024-03-11T09:00:00.000Z'`.
- `normalizeCatalogTimestamp` table test covering both separator styles,
  an explicit zone, and the null/malformed/future rejections.
- Cache-legacy-row test: a Redis hit missing the `lastClimbAt` key
  resolves without throwing and leaves the field `undefined` — never a
  synthesised `new Date()`.
- `operations-schema-validation.test.ts`: asserts
  `PopularBoardConfig.lastClimbAt` is exactly `String`, not `String!`.

Every oracle was mutation-tested (mutation applied, watched red, reverted):
dropping the `REPLACE` separator normalisation, tightening the SDL field
to `String!`, and adding a `?? new Date()` fallback in the cache-read
path all turned the corresponding test red.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check --fix` — 0 errors (324 pre-existing warnings, unrelated to
  this change).
- `vp run typecheck` — clean.
- `vp test run --project backend --reporter=agent` (isolated run, per the
  repo's backend-tests-no-concurrency rule) — 244/244 passing across
  `popular-board-configs-last-climb-at.test.ts` and
  `operations-schema-validation.test.ts`.

## Production targets

**Corrected — this is not backend-only.** The earlier claim ("Backend only …
No web, mobile, or native change") was wrong. This PR edits
`packages/shared-schema/src/schema/board-entities.ts` and its generated output,
and `.github/workflows/mobile-ota-production.yml` fires on
`packages/shared-schema/**` pushed to `main`. So merging this **auto-publishes a
production OTA to the entire native store fleet** (JS-only diff, so the
fingerprint is unchanged and every installed binary picks it up), alongside the
Railway backend deploy. Mobile keeps its own copy of the document and never
selects `lastClimbAt`, so there is no behaviour change — but the fleet does get
a new bundle.

There is no deploy-order constraint left: #4599 is unstacked, based on `main`,
and selects nothing new from the backend.
</content>
</invoke>
