### PR TITLE
fix(web): record why the boards sitemap shard carries no lastmod

### DIFF
--- a/packages/web/app/lib/seo/sitemap/__tests__/board-entries.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/board-entries.test.ts
@@ -3,6 +3,8 @@ import { ANGLES } from '@boardsesh/board-config';
 import type { PopularBoardConfig } from '@boardsesh/shared-schema';
 import { popularConfigListUrl } from '@/app/lib/url-utils';
 import { boardConfigsToItems } from '../board-entries';
+import { expandAllLocales, latestLastModified } from '../entries';
+import { renderUrlset } from '../sitemap-xml';
 
 const kilterConfig: PopularBoardConfig = {
   boardType: 'kilter',
@@ -82,10 +84,22 @@ describe('boardConfigsToItems', () => {
     }
   });
 
-  it('carries no lastModified — there is no real per-config timestamp to report', () => {
-    for (const item of boardConfigsToItems([kilterConfig])) {
+  // The config does carry timestamps; none of them describes page 1 of this
+  // list, which is the top 50 by ascents and has not gained a climb in years.
+  // The measured numbers are in `board-entries.ts`. Asserted through the real
+  // renderer, not only on the items: wiring a config-wide timestamp back in
+  // would reach both the shard XML and the shard's own index entry, and an
+  // item-level assertion alone would not say so.
+  it('emits no <lastmod> at all — no per-config timestamp describes page 1 of the list', () => {
+    const items = boardConfigsToItems([kilterConfig, moonboardConfig]);
+    expect(items.length).toBeGreaterThan(0);
+
+    for (const item of items) {
       expect(item.lastModified).toBeUndefined();
     }
+
+    expect(renderUrlset(expandAllLocales(items))).not.toContain('<lastmod>');
+    expect(latestLastModified(items)).toBeNull();
   });
 
   it('skips configs with no listed climbs and unknown board types', () => {

--- a/packages/web/app/lib/seo/sitemap/__tests__/board-entries.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/board-entries.test.ts
@@ -3,7 +3,7 @@ import { ANGLES } from '@boardsesh/board-config';
 import type { PopularBoardConfig } from '@boardsesh/shared-schema';
 import { popularConfigListUrl } from '@/app/lib/url-utils';
 import { boardConfigsToItems } from '../board-entries';
-import { expandAllLocales, latestLastModified } from '../entries';
+import { expandDefaultLocaleOnly, latestLastModified } from '../entries';
 import { renderUrlset } from '../sitemap-xml';
 
 const kilterConfig: PopularBoardConfig = {
@@ -87,9 +87,10 @@ describe('boardConfigsToItems', () => {
   // The config does carry timestamps; none of them describes page 1 of this
   // list, which is the top 50 by ascents and has not gained a climb in years.
   // The measured numbers are in `board-entries.ts`. Asserted through the real
-  // renderer, not only on the items: wiring a config-wide timestamp back in
-  // would reach both the shard XML and the shard's own index entry, and an
-  // item-level assertion alone would not say so.
+  // renderer and the shard's own `expansion: 'default-locale-only'`, not only
+  // on the items: wiring a config-wide timestamp back in would reach both the
+  // shard XML and the shard's index entry, and an item-level assertion alone
+  // would not say so.
   it('emits no <lastmod> at all — no per-config timestamp describes page 1 of the list', () => {
     const items = boardConfigsToItems([kilterConfig, moonboardConfig]);
     expect(items.length).toBeGreaterThan(0);
@@ -98,7 +99,7 @@ describe('boardConfigsToItems', () => {
       expect(item.lastModified).toBeUndefined();
     }
 
-    expect(renderUrlset(expandAllLocales(items))).not.toContain('<lastmod>');
+    expect(renderUrlset(expandDefaultLocaleOnly(items))).not.toContain('<lastmod>');
     expect(latestLastModified(items)).toBeNull();
   });
 

--- a/packages/web/app/lib/seo/sitemap/board-entries.ts
+++ b/packages/web/app/lib/seo/sitemap/board-entries.ts
@@ -13,10 +13,39 @@ import type { SitemapItem } from './entries';
  * set, for 668 items / 2,672 URLs. Either way it sits far inside the
  * 11,250-item shard budget. Production is not reconciled against these.
  *
- * Deliberately no `<lastmod>`: there is no per-config content timestamp in the
- * data today, and `new Date()` would be a lie. `<lastmod>` is optional in the
- * sitemap protocol; crawlers fall back to other freshness signals. Follow-up to
- * add `lastClimbAt` to `popularBoardConfigs` is filed.
+ * Deliberately no `<lastmod>`, and the reason is not "the data carries no
+ * timestamp" — it does. The reason is that no timestamp the *config* carries
+ * describes *this page*. #4466 proposed a per-config
+ * `MAX(board_climbs.created_at)`; measured against the dev database that value
+ * is fabricated freshness, so it is not wired up here:
+ *
+ * - The URL below is page 1 only, at the default sort: the top
+ *   `FRONT_DOOR_PAGE_SIZE` (50) climbs by ascents (`fetchFrontDoorListPage`).
+ *   For `/kilter/…/40/list` (layout 1, size 10, sets 1+20) the rank-50 cutoff is
+ *   21,407 ascents and the newest climb on that page was created 2021-02-11.
+ *   The best-ascended climb created into that config in the snapshot's last 90
+ *   days has 86 ascents — 0.4% of the cutoff — so a newly set climb cannot reach
+ *   page 1 at all.
+ * - Meanwhile 6,148 climbs were created into that one config in the snapshot's
+ *   last 30 days (~205/day), so a config-wide `MAX(created_at)` advances every
+ *   single day. It would stamp that URL 2026-01-31 for a page whose newest
+ *   content is from 2021 — five years of freshness the page never had, refreshed
+ *   daily. That is exactly what `SitemapItem.lastModified` warns about in
+ *   `entries.ts`: not literally `new Date()`, but indistinguishable from it.
+ * - It is also not angle-aware, and the page is — the list query INNER JOINs
+ *   `board_climb_stats` at the URL's angle. One config-wide value stamped onto
+ *   all 15 angle URLs is wrong per angle: for tension layout 11 / size 9 the
+ *   honest page-1 timestamps run 2024-12-26 (65°) to 2026-01-26 (55°), and 70°
+ *   has no page-1 content at all.
+ *
+ * The honest version is `MAX(created_at)` over the page-1 window *per angle*.
+ * On the dev database that query costs 207 s against the 78 s the existing
+ * `popularBoardConfigs` statement already spends, and the warm path holds a
+ * 120 s Redis lock — so it does not fit where it would have to live. `<lastmod>`
+ * is optional in the sitemap protocol and crawlers fall back to other freshness
+ * signals, so omitting it stays the right call until that window is affordable.
+ * Per-climb freshness already ships truthfully on the climbs shards, where
+ * `climb-query.ts` uses `board_climbs.updated_at` per climb.
  */
 export function boardConfigsToItems(configs: readonly PopularBoardConfig[]): SitemapItem[] {
   const items: SitemapItem[] = [];

--- a/packages/web/app/lib/seo/sitemap/board-entries.ts
+++ b/packages/web/app/lib/seo/sitemap/board-entries.ts
@@ -16,7 +16,8 @@ import type { SitemapItem } from './entries';
  * Deliberately no `<lastmod>`, and the reason is not "the data carries no
  * timestamp" — it does. The reason is that no timestamp the *config* carries
  * describes *this page*. #4466 proposed a per-config
- * `MAX(board_climbs.created_at)`; measured against the dev database that value
+ * `MAX(board_climbs.created_at)`; measured against the dev database (the
+ * 2026-01-31 catalog snapshot — every date below is relative to it) that value
  * is fabricated freshness, so it is not wired up here:
  *
  * - The URL below is page 1 only, at the default sort: the top

--- a/packages/web/app/lib/seo/sitemap/board-entries.ts
+++ b/packages/web/app/lib/seo/sitemap/board-entries.ts
@@ -7,11 +7,13 @@ import type { SitemapItem } from './entries';
  * One entry per (board config × angle). Angles are genuinely different content —
  * grades shift with the wall angle and each angle page is self-canonical — so all
  * of them ship. Measured against the dev image on 2026-08-19: 45 listed configs
- * give 660 items (2,640 locale-expanded URLs) — 45 × 15 is the pre-filter upper
- * bound and the zero-climb skip below brings it down — and the four MoonBoard
- * configs `board-config-source.ts` synthesises add 8 more at their own 2-angle
- * set, for 668 items / 2,672 URLs. Either way it sits far inside the
- * 11,250-item shard budget. Production is not reconciled against these.
+ * give 660 items — 45 × 15 is the pre-filter upper bound and the zero-climb skip
+ * below brings it down — and the four MoonBoard configs
+ * `board-config-source.ts` synthesises add 8 more at their own 2-angle set, for
+ * 668. One URL each: the shard is `expansion: 'default-locale-only'` because
+ * these pages cross-canonicalise to the default locale. Either way it sits far
+ * inside the 11,250-item shard budget. Production is not reconciled against
+ * these.
  *
  * Deliberately no `<lastmod>`, and the reason is not "the data carries no
  * timestamp" — it does. The reason is that no timestamp the *config* carries


### PR DESCRIPTION
## Summary

**This PR is the opposite of what it originally was.** It started as the web
half of the #4466 stack — add `lastClimbAt` to `GET_POPULAR_BOARD_CONFIGS` and
stamp it as `<lastmod>` on `/sitemaps/boards.xml`. Measuring that value against
the page it would stamp showed it is fabricated freshness, so the PR now records
the measurement in the code instead, and pins the omission with a test that
fails if anyone re-wires it.

It is no longer stacked on #4598 — base is `main`, and it selects nothing new
from the backend, so there is no deploy-order hazard left.

### What the URL in this shard actually is

`boardConfigsToItems` emits page 1 only, at the default sort:
`fetchFrontDoorListPage` fetches exactly `FRONT_DOOR_PAGE_SIZE = 50` climbs at
`DEFAULT_SEARCH_PARAMS.sortBy = 'ascents'`. `StaticListFrontDoor` renders those
50 rows plus a static heading and pagination — no total count, no dates. So the
page changes when its top-50 membership changes, not when a climb is set.

### The numbers (dev database, the 2026-01-31 catalog snapshot)

`/kilter/…/40/list`, layout 1 / size 10 / sets 1+20 — the config-tuple URL this
shard submits:

| | |
|---|---|
| ascents at rank 50 (the page-1 cutoff) | **21,407** |
| newest `created_at` among those 50 climbs | **2021-02-11** |
| best ascents among climbs created into the config in the last 90 days | **86** (0.4% of the cutoff) |
| climbs created into the config in the last 30 days | **6,148** (~205/day) |
| what a config-wide `MAX(created_at)` would have stamped | **2026-01-31** |

A newly set climb cannot reach page 1, but the config-wide max moves every day.
The emitted `<lastmod>` would have claimed daily change on a page whose newest
content is five years old — not literally `new Date()`, but observationally
indistinguishable from it, which is the exact failure `SitemapItem.lastModified`
warns about in `entries.ts`.

It is also not angle-aware while the page is — the list query INNER JOINs
`board_climb_stats` at the URL's angle. One config-wide value stamped onto all
15 angle URLs is wrong per angle. Tension layout 11 / size 9, honest per-angle
page-1 maxima:

```
65°  2024-12-26     55°  2026-01-26     40°/45°  2025-03-06
60°  2025-04-24     50°  2025-09-05     70°      no page-1 content at all
```

against a single 2026-01-31 config-wide stamp for every one of them.

### Why not just compute the honest value

The honest version is `MAX(created_at)` over the page-1 window **per angle**,
mirroring the page's own predicates (`compatible_size_ids @> [size]`,
`required_set_ids <@ set_ids`, INNER JOIN at the angle, `ORDER BY
ascensionist_count DESC LIMIT 50`). Timed on the dev database:

- existing `popularBoardConfigs` statement: **78 s**
- per-(config, angle) page-1 window, all 765 pairs: **207 s**

That lands on top of the 78 s, inside a warm path that holds a **120 s** Redis
lock (`REDIS_LOCK_TTL_SECONDS`), so it does not fit where it would have to live
without redesigning the locking. Omitting `<lastmod>` is optional in the sitemap
protocol and is what the pre-change code already chose. Per-climb freshness
already ships truthfully on the climbs shards, which use
`board_climbs.updated_at` per climb.

### What changed

- `board-entries.ts` — the omission comment said "there is no per-config content
  timestamp in the data today". That was stale (`board_climbs.created_at` is
  right there) and it is what generated #4466. It now carries the measured
  reason and the cost of the honest alternative, so the next reader does not
  re-file it.
- `__tests__/board-entries.test.ts` — the `lastModified is undefined` case now
  asserts through the real renderer and through `latestLastModified(items)`,
  on both a Kilter and a MoonBoard config.
- Rebased onto `main`, which made the boards shard
  `expansion: 'default-locale-only'` after this branch was cut. The renderer
  assertion now goes through `expandDefaultLocaleOnly`, so it checks the XML
  the shard actually serves, and the header no longer counts locale twins the
  shard stopped emitting.

Mutation-tested: adding `lastModified: new Date('2026-01-31T01:07:53.189Z')` to
the pushed item turns the test red, and it stays red on the renderer assertion
alone with the item-level loop removed — so the XML and index-entry oracles are
independently load-bearing, not decoration. Both mutations reverted.

### Follow-up spotted while measuring, not fixed here

The shard skips a config with `climbCount <= 0`, but `climbCount` is
config-wide while the page is angle-filtered. Tension layout 11 / size 9 at 70°
and MoonBoard layouts 1/6/7 at 25° have no climbs at that angle at all, yet
still get a submitted URL that renders the empty state. Worth its own issue
alongside #4473's soft-404 work.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 1/5 — a comment and a test under `packages/web/app/lib/seo/sitemap/`. No
runtime behaviour changes: the shard emitted no `<lastmod>` before this PR and
emits none after, which is the whole point.

## Author verification

- `vp check --fix` via the pre-commit hook, plus `check:i18n` and
  `check:i18n:orphans` — clean.
- `vp run typecheck` — clean (`next build` + `tsc --noEmit`).
- `vp run test:web --reporter=agent` — 3957 tests. Two runs each surfaced a
  different flake under load (`gym-form`, `location-sync-freezes-panel`); both
  pass in isolation and neither touches this diff.
- Post-rebase: `board-entries.test.ts` 8/8 green against `main`.

## Production targets

**`www.boardsesh.com` only**, and with no behaviour change — the diff is a
comment and a test, both under `packages/web/app/lib/seo/sitemap/`. Nothing in
`packages/shared/**` or `packages/mobile/**` is touched, so no OTA reaches
`app.boardsesh.com` or the native store fleet, and the backend is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5Jti1UCBFtwGaJswYKY5Z
