### PR TITLE
test(web): decouple the error-boundary retry test from wall-clock time

### DIFF
--- a/packages/web/app/components/__tests__/error-boundary.test.tsx
+++ b/packages/web/app/components/__tests__/error-boundary.test.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
-import { render, screen, act, waitFor } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vite-plus/test';
 import ErrorBoundary from '../error-boundary';
 
 // Suppress React error boundary console noise in tests
 beforeEach(() => {
   vi.spyOn(console, 'error').mockImplementation(() => {});
-  vi.useFakeTimers({ shouldAdvanceTime: true });
+  // The clock is frozen on purpose. `shouldAdvanceTime: true` ticks the fake
+  // clock from real wall time, and Vitest fakes requestAnimationFrame, so the
+  // boundary's pending recovery frame fires between statements and silently
+  // spends one of its three retries. On a loaded CI shard that left the budget
+  // exhausted while the child was still throwing, the boundary gave up, and
+  // the test could never see "recovered". See #4470.
+  vi.useFakeTimers();
 });
 afterEach(() => {
   vi.useRealTimers();
@@ -15,6 +21,18 @@ afterEach(() => {
 
 const AlwaysThrow = () => {
   throw new Error('persistent error');
+};
+
+const Conditional = ({ throwNow }: { throwNow: boolean }) => {
+  if (throwNow) throw new Error('transient');
+  return <div>recovered</div>;
+};
+
+/** Fire exactly one pending recovery frame, and nothing else. */
+const nextFrame = async () => {
+  await act(async () => {
+    vi.advanceTimersByTime(16);
+  });
 };
 
 describe('ErrorBoundary', () => {
@@ -46,30 +64,30 @@ describe('ErrorBoundary', () => {
   });
 
   describe('recoverable mode', () => {
+    /** A recoverable boundary whose child throws only while `throwNow` is set. */
+    const recoverableTree = (throwNow: boolean) => (
+      <ErrorBoundary recoverable fallback={<div>gave up</div>}>
+        <Conditional throwNow={throwNow} />
+      </ErrorBoundary>
+    );
+
     it('auto-resets after a transient error', async () => {
-      let shouldThrow = true;
-
-      const Conditional = () => {
-        if (shouldThrow) throw new Error('transient');
-        return <div>recovered</div>;
-      };
-
-      render(
+      const { rerender } = render(
         <ErrorBoundary recoverable>
-          <Conditional />
+          <Conditional throwNow />
         </ErrorBoundary>,
       );
 
       // Error caught, fallback rendered (null)
       expect(screen.queryByText('recovered')).toBeNull();
 
-      // Fix the error before the rAF fires
-      shouldThrow = false;
-
-      // Flush the requestAnimationFrame that triggers recovery
-      await act(async () => {
-        vi.advanceTimersByTime(16);
-      });
+      // Fix the error, then flush the recovery frame the boundary scheduled.
+      rerender(
+        <ErrorBoundary recoverable>
+          <Conditional throwNow={false} />
+        </ErrorBoundary>,
+      );
+      await nextFrame();
 
       expect(screen.getByText('recovered')).toBeTruthy();
     });
@@ -83,59 +101,54 @@ describe('ErrorBoundary', () => {
 
       // Flush multiple rAF cycles (more than the 3 retry limit)
       for (let i = 0; i < 5; i++) {
-        await act(async () => {
-          vi.advanceTimersByTime(16);
-        });
+        await nextFrame();
       }
 
       // Should have given up and show the fallback permanently
       expect(screen.getByText('gave up')).toBeTruthy();
     });
 
-    it('resets retry budget after quiet period', async () => {
-      let shouldThrow = true;
+    it('exhausts the budget after three recoveries', async () => {
+      const { rerender } = render(recoverableTree(true));
 
-      const Conditional = () => {
-        if (shouldThrow) throw new Error('transient');
-        return <div>recovered</div>;
-      };
-
-      render(
-        <ErrorBoundary recoverable>
-          <Conditional />
-        </ErrorBoundary>,
-      );
-
-      // Burn through 2 retries (still throwing)
-      for (let i = 0; i < 2; i++) {
-        await act(async () => {
-          vi.advanceTimersByTime(16);
-        });
+      // Three successful recoveries spend the whole budget.
+      for (let round = 0; round < 3; round++) {
+        rerender(recoverableTree(false));
+        await nextFrame();
+        expect(screen.getByText('recovered')).toBeTruthy();
+        rerender(recoverableTree(true));
       }
 
-      // Fix the error and let the 3rd retry succeed. `waitFor` gives React's
-      // commit phase room to flush even when the rAF advance lands on a tick
-      // that doesn't drain microtasks in one pass — locally this resolves
-      // immediately; CI occasionally needs a second pass before the
-      // child re-renders.
-      shouldThrow = false;
-      await act(async () => {
-        vi.advanceTimersByTime(16);
-      });
-      await waitFor(() => expect(screen.getByText('recovered')).toBeTruthy());
+      // Fourth error, budget spent, no quiet period: stuck on the fallback.
+      rerender(recoverableTree(false));
+      await nextFrame();
+      expect(screen.queryByText('recovered')).toBeNull();
+      expect(screen.getByText('gave up')).toBeTruthy();
+    });
 
-      // Wait for the 30 s reset timer to fire
+    it('resets retry budget after quiet period', async () => {
+      const { rerender } = render(recoverableTree(true));
+
+      // Spend the full budget on three recoveries, ending error-free.
+      for (let round = 0; round < 3; round++) {
+        rerender(recoverableTree(false));
+        await nextFrame();
+        expect(screen.getByText('recovered')).toBeTruthy();
+        if (round < 2) rerender(recoverableTree(true));
+      }
+
+      // 30 s error-free puts the budget back to zero.
       await act(async () => {
         vi.advanceTimersByTime(30_000);
       });
 
-      // Trigger a new error — should recover again (budget was reset)
-      shouldThrow = true;
-      // Force a re-render that throws
-      await act(async () => {
-        // Unmount and remount to trigger a fresh error
-        screen.getByText('recovered').textContent = '';
-      });
+      // A brand new error still recovers. Without the reset this would stay on
+      // the fallback, as 'exhausts the budget after three recoveries' shows.
+      rerender(recoverableTree(true));
+      expect(screen.getByText('gave up')).toBeTruthy();
+      rerender(recoverableTree(false));
+      await nextFrame();
+      expect(screen.getByText('recovered')).toBeTruthy();
     });
 
     it('does not auto-reset when recoverable is false', async () => {
@@ -148,9 +161,7 @@ describe('ErrorBoundary', () => {
       expect(screen.getByText('stuck')).toBeTruthy();
 
       // Flush rAF
-      await act(async () => {
-        vi.advanceTimersByTime(16);
-      });
+      await nextFrame();
 
       // Still stuck on fallback
       expect(screen.getByText('stuck')).toBeTruthy();

--- a/packages/web/app/components/error-boundary.tsx
+++ b/packages/web/app/components/error-boundary.tsx
@@ -14,7 +14,10 @@ type ErrorBoundaryProps = {
    * instead of permanently showing the fallback. Useful for transient DOM
    * errors caused by browser extensions or auto-translate modifying the DOM.
    * Retries up to 3 times in quick succession before falling back permanently.
-   * The retry budget resets after 30 s of error-free operation.
+   * The retry budget resets after 30 s of error-free operation. That reset only
+   * helps a boundary that is currently rendering fine: once the budget is spent
+   * the boundary stays on the fallback, because zeroing the counter never
+   * clears `hasError` and unmounted children cannot throw again.
    */
   recoverable?: boolean;
 };


### PR DESCRIPTION
## Summary

`ErrorBoundary > recoverable mode > resets retry budget after quiet period` reds in CI for reasons
unrelated to the diff. The cause is in the test file, not in sharding and not in cross-file state.

`error-boundary.test.tsx` opened with `vi.useFakeTimers({ shouldAdvanceTime: true })`. That option
starts a **real** 20 ms interval which calls `clock.tick(20)` on the fake clock, and Vitest fakes
`requestAnimationFrame` by default (its `toFake` list is every sinon timer except `nextTick` and
`queueMicrotask`). `ErrorBoundary.componentDidCatch` schedules its recovery through
`requestAnimationFrame`, so every one of those wall-clock ticks fired a pending recovery frame and
permanently spent one of the boundary's three retries — with no `advanceTimersByTime` call anywhere
near it.

The failing case sits exactly on that boundary: it deliberately burned 2 retries and then needed the
3rd. On a loaded runner one extra auto-tick landed between the `await act()` steps, `retryCount` hit
the cap of 3 while the child was still throwing, `componentDidCatch` stopped scheduling frames, and
the boundary could never render `recovered` again. The 30 s reset timer cannot rescue it either: a
boundary that has given up no longer mounts children, so nothing can throw and nothing clears
`hasError`.

The fix removes the coupling rather than papering over it:

- Freeze the clock (`vi.useFakeTimers()`), with a comment naming this issue.
- Drive every error/recovery transition with an explicit `rerender` plus one 16 ms frame advance, so
  each step has exactly one intended effect.
- Drop `waitFor` — it only ever made progress *because* of the auto-advance (RTL's fake-timer branch
  needs a `jest` global, which Vitest does not define, so it took its real-timer path against faked
  timers).
- Add `exhausts the budget after three recoveries` as the negative control the reset case leans on.
  The old reset test finished by assigning to `textContent`, asserted nothing, and never re-triggered
  an error, so the budget reset was not actually covered.

One doc-only line on `error-boundary.tsx` records the wart found while proving the mechanism: the
30 s reset only helps a boundary that is currently rendering fine. No behaviour change — the
component is correct as written.

### Failure rates (this is the acceptance test)

Reproduced with the file running **completely alone**, on an 8-core box, with 48 CPU burners
(`for i in $(seq 1 48); do (while :; do :; done) & done`, load average ~100):

| | result |
|---|---|
| before (`shouldAdvanceTime: true`, unmodified file) | **9 failed / 1 passed** of 10 |
| after (frozen clock) | **0 failed / 10 passed** of 10 |

Failure message on every red run: `Unable to find an element with the text: recovered`, the exact CI
error. At 14 burners (load ~27) the old file passed 10/10 — the flake needs the machine genuinely
starved, which is what a 2-shard runner is.

### The shard asymmetry is not the bug

The issue notes that push runs shard 3 ways and PR runs shard 2 ways, and suggests equalising them.
Leaving `ci.yml` alone on purpose: the test fails **standing alone** under load, with no other file
in the run, so shard count is not what breaks it. Fewer shards only make each runner busier, which
raises the odds of an auto-tick landing in the wrong place. Equalising would have made this rarer,
never fixed, and would have hidden the real defect.

Closes #4470

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project web packages/web/app/components/__tests__/error-boundary.test.tsx --reporter=verbose` — 8 passed (was 7; one new negative-control case).
- Load-stress gate, 10 runs each under 48 CPU burners — numbers in the table above.
- Negative control checked by hand: raising `MAX_RECOVERY_ATTEMPTS` makes
  `exhausts the budget after three recoveries` fail, so the new pair really pins the 3-attempt
  budget instead of passing vacuously.
- `vp run typecheck:web`, `vp check`.
- Three other test files carry the same `shouldAdvanceTime` coupling. None is a known flake, so they
  are out of scope here and tracked separately in #4602.
