### PR TITLE
fix(backend): accept negative board angles on similarClimbs and climb reads

### DIFF
--- a/packages/backend/src/__tests__/board-presence.test.ts
+++ b/packages/backend/src/__tests__/board-presence.test.ts
@@ -1137,6 +1137,62 @@ describe('board-presence resolvers', () => {
       ).rejects.toThrow('Unknown climb');
     });
 
+    it('accepts a negative board angle (Aurora boards support negative tilt) and publishes it verbatim', async () => {
+      // reportBoardClimb fires on EVERY climb-light event from a connected/kiosk
+      // board, so a negative-tilt board (e.g. -5°) must not error here. There's
+      // no board_climb_stats row at -5° for TEST_CLIMB_UUID, so the grade join
+      // simply misses (grade: null) rather than rejecting the report.
+      const boardId = await makeBoard();
+      const received: BoardPresenceEvent[] = [];
+      const unsubscribe = await pubsub.subscribeBoardPresence(String(boardId), (event) => received.push(event));
+
+      const ok = await boardPresenceMutations.reportBoardClimb(
+        undefined,
+        { boardId, climb: makeQueueItemInput(), angle: -5 },
+        authCtx(),
+      );
+      expect(ok).toBe(true);
+
+      const climbSet = received.find((event): event is BoardClimbSet => event.__typename === 'BoardClimbSet');
+      expect(climbSet).toBeDefined();
+      expect(climbSet!.climb.angle).toBe(-5);
+      expect(climbSet!.climb.grade).toBeNull();
+      unsubscribe();
+    });
+
+    it('rejects angle -91 (outside the -90..90 board-tilt range) before touching the board', async () => {
+      const boardId = await makeBoard();
+      await expect(
+        boardPresenceMutations.reportBoardClimb(
+          undefined,
+          { boardId, climb: makeQueueItemInput(), angle: -91 },
+          authCtx(),
+        ),
+      ).rejects.toThrow();
+    });
+
+    it('accepts a negative climb.angle (ClimbInputSchema) as the fallback when no top-level angle is sent', async () => {
+      // ReportBoardClimbInputSchema.climb extends ClimbInputSchema — this proves
+      // ITS angle bound (not just BoardPresenceAngleSchema's) accepts negative
+      // tilt: the top-level `angle` arg is omitted, so effectiveAngle falls back
+      // to validatedClimb.climb.angle.
+      const boardId = await makeBoard();
+      const received: BoardPresenceEvent[] = [];
+      const unsubscribe = await pubsub.subscribeBoardPresence(String(boardId), (event) => received.push(event));
+
+      const ok = await boardPresenceMutations.reportBoardClimb(
+        undefined,
+        { boardId, climb: makeQueueItemInput({ angle: -5 }) },
+        authCtx(),
+      );
+      expect(ok).toBe(true);
+
+      const climbSet = received.find((event): event is BoardClimbSet => event.__typename === 'BoardClimbSet');
+      expect(climbSet).toBeDefined();
+      expect(climbSet!.climb.angle).toBe(-5);
+      unsubscribe();
+    });
+
     it('rejects a report from a user who never connected to the board (proof-of-presence)', async () => {
       // makeBoard() resolves as TEST_USER_ID, stamping that user's membership.
       // A different authenticated user who never connected must not be able to

--- a/packages/backend/src/__tests__/climb-similar-resolver.test.ts
+++ b/packages/backend/src/__tests__/climb-similar-resolver.test.ts
@@ -93,6 +93,34 @@ describe('climbQueries.similarClimbs', () => {
     expect(findSimilarClimbsMock).not.toHaveBeenCalled();
   });
 
+  it('accepts angle -5 and forwards it to the similarity helper as statsAngle: -5', async () => {
+    // Aurora boards support negative tilt (e.g. grasshopper at -5°). angle is
+    // only an optional stats-join key, so a negative value must pass
+    // validation and flow straight through to findSimilarClimbs.
+    mockDb.select.mockReturnValueOnce(mockSelectChain([{ holdId: 1, holdState: 'STARTING' }]));
+
+    await climbQueries.similarClimbs(
+      {},
+      { input: { boardType: 'kilter', layoutId: 8, climbUuid: 'target-uuid', angle: -5 } },
+      makeCtx(),
+    );
+
+    expect(findSimilarClimbsMock).toHaveBeenCalledTimes(1);
+    const args = findSimilarClimbsMock.mock.calls[0][0];
+    expect(args).toMatchObject({ statsAngle: -5 });
+  });
+
+  it('rejects angle -95 before reaching the helper', async () => {
+    await expect(
+      climbQueries.similarClimbs(
+        {},
+        { input: { boardType: 'kilter', layoutId: 8, climbUuid: 'target-uuid', angle: -95 } },
+        makeCtx(),
+      ),
+    ).rejects.toThrow();
+    expect(findSimilarClimbsMock).not.toHaveBeenCalled();
+  });
+
   it('climbUuid path reads the target climbs holds and passes them through with excludeUuid set to the target', async () => {
     mockDb.select.mockReturnValueOnce(
       mockSelectChain([

--- a/packages/backend/src/__tests__/discover-playlists.test.ts
+++ b/packages/backend/src/__tests__/discover-playlists.test.ts
@@ -232,6 +232,34 @@ describe('discoverPlaylists resolver', () => {
     expect(resultsCalls.where.length).toBe(1);
   });
 
+  it('accepts a negative angle (Aurora boards support negative tilt) filter', async () => {
+    const ctx = makeCtx();
+
+    const { chain: countChain } = createMockChain([{ count: 0 }]);
+    mockDb.select.mockReturnValueOnce(countChain);
+
+    const { chain: resultsChain } = createMockChain([]);
+    mockDb.select.mockReturnValueOnce(resultsChain);
+
+    const result = await playlistQueries.discoverPlaylists(
+      null,
+      { input: { boardType: 'kilter', layoutId: 8, sizeId: 25, angle: -5 } },
+      ctx,
+    );
+
+    expect(result.totalCount).toBe(0);
+    expect(result.playlists).toEqual([]);
+  });
+
+  it('rejects angle -91 (outside the -90..90 board-tilt range)', async () => {
+    const ctx = makeCtx();
+
+    await expect(
+      playlistQueries.discoverPlaylists(null, { input: { boardType: 'kilter', layoutId: 8, angle: -91 } }, ctx),
+    ).rejects.toThrow();
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
   it('should paginate correctly with hasMore', async () => {
     const ctx = makeCtx();
 

--- a/packages/backend/src/__tests__/graphql-resolvers.test.ts
+++ b/packages/backend/src/__tests__/graphql-resolvers.test.ts
@@ -200,6 +200,87 @@ describe('GraphQL Resolver Input Validation', () => {
       );
     });
 
+    it('should reject invalid angle (< -90)', async () => {
+      const query = `
+        query TestClimb(
+          $boardName: String!
+          $layoutId: Int!
+          $sizeId: Int!
+          $setIds: String!
+          $angle: Int!
+          $climbUuid: ID!
+        ) {
+          climb(
+            boardName: $boardName
+            layoutId: $layoutId
+            sizeId: $sizeId
+            setIds: $setIds
+            angle: $angle
+            climbUuid: $climbUuid
+          ) {
+            uuid
+          }
+        }
+      `;
+
+      await expectError(
+        client,
+        {
+          query,
+          variables: {
+            boardName: 'kilter',
+            layoutId: 1,
+            sizeId: 1,
+            setIds: '1',
+            angle: -95,
+            climbUuid: 'test-uuid',
+          },
+        },
+        'Invalid angle',
+      );
+    });
+
+    it('should accept negative angle -5 (Aurora boards support negative tilt) without an angle error', async () => {
+      const query = `
+        query TestClimb(
+          $boardName: String!
+          $layoutId: Int!
+          $sizeId: Int!
+          $setIds: String!
+          $angle: Int!
+          $climbUuid: ID!
+        ) {
+          climb(
+            boardName: $boardName
+            layoutId: $layoutId
+            sizeId: $sizeId
+            setIds: $setIds
+            angle: $angle
+            climbUuid: $climbUuid
+          ) {
+            uuid
+          }
+        }
+      `;
+
+      // 'test-uuid' doesn't exist, so the resolver simply returns a null
+      // climb — the point of this test is that it gets past angle
+      // validation instead of throwing 'Invalid angle'.
+      const result = await execute<{ climb: { uuid: string } | null }>(client, {
+        query,
+        variables: {
+          boardName: 'kilter',
+          layoutId: 1,
+          sizeId: 1,
+          setIds: '1',
+          angle: -5,
+          climbUuid: 'test-uuid',
+        },
+      });
+
+      expect(result.climb).toBeNull();
+    });
+
     it('should reject invalid board name', async () => {
       const query = `
         query TestClimb(

--- a/packages/backend/src/__tests__/playlist-climbs-active-angle.test.ts
+++ b/packages/backend/src/__tests__/playlist-climbs-active-angle.test.ts
@@ -137,6 +137,31 @@ describe('playlistClimbs — active-angle override (real DB)', () => {
     expect(byUuid['climb-c'].difficulty).toBeTruthy();
   });
 
+  it('accepts a negative activeAngle (Aurora boards support negative tilt) and falls back like any other unmatched angle', async () => {
+    // No board_climb_stats row at -5° for any on-board climb, so the EXISTS
+    // guard drops the override and each on-board climb falls back to its
+    // most-ascended angle — same behaviour as a positive angle with no stats.
+    const result = await playlistQueries.playlistClimbs(
+      null,
+      { input: { playlistId: PLAYLIST_UUID, activeBoardName: 'kilter', activeAngle: -5 } },
+      makeCtx(),
+    );
+
+    const byUuid = Object.fromEntries(result.climbs.map((climb) => [climb.uuid, climb]));
+    expect(byUuid['climb-a'].angle).toBe(50);
+    expect(byUuid['climb-b'].angle).toBe(50);
+  });
+
+  it('rejects activeAngle -91 (outside the -90..90 board-tilt range)', async () => {
+    await expect(
+      playlistQueries.playlistClimbs(
+        null,
+        { input: { playlistId: PLAYLIST_UUID, activeBoardName: 'kilter', activeAngle: -91 } },
+        makeCtx(),
+      ),
+    ).rejects.toThrow();
+  });
+
   it('without an active board, on-board climbs still default to the most-ascents angle (unchanged behaviour)', async () => {
     const result = await playlistQueries.playlistClimbs(null, { input: { playlistId: PLAYLIST_UUID } }, makeCtx());
 

--- a/packages/backend/src/__tests__/setter-stats-moonboard.test.ts
+++ b/packages/backend/src/__tests__/setter-stats-moonboard.test.ts
@@ -108,6 +108,29 @@ describe('setterStats — size filter skips MoonBoard, still applies to Aurora b
     expect(result).toEqual([{ setterUsername: 'kilter-sized-setter', climbCount: 1 }]);
   });
 
+  it('accepts a negative angle (Aurora boards support negative tilt) and returns an empty result for the unmatched stats join', async () => {
+    // Mobile's setter filter sends the live board angle. There's no
+    // board_climb_stats row at -5° for any seeded climb here, so the inner
+    // join simply yields no rows — the request must not be rejected outright.
+    const result = await climbQueries.setterStats(
+      null,
+      { input: { boardName: 'moonboard', layoutId: 1, sizeId: 1, setIds: '1', angle: -5 } },
+      makeCtx(),
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('rejects angle -91 (outside the -90..90 board-tilt range)', async () => {
+    await expect(
+      climbQueries.setterStats(
+        null,
+        { input: { boardName: 'moonboard', layoutId: 1, sizeId: 1, setIds: '1', angle: -91 } },
+        makeCtx(),
+      ),
+    ).rejects.toThrow();
+  });
+
   it('filters MoonBoard setters by a search substring', async () => {
     const result = await climbQueries.setterStats(
       null,

--- a/packages/backend/src/__tests__/smart-playlists.test.ts
+++ b/packages/backend/src/__tests__/smart-playlists.test.ts
@@ -423,6 +423,36 @@ describe('smartPlaylist resolver', () => {
     expect(resolveTargetMock).not.toHaveBeenCalled();
   });
 
+  it('accepts a negative angle (Aurora boards support negative tilt) instead of rejecting the input', async () => {
+    // Non-owner short-circuit keeps this cheap (no DB/board-resolution mocks
+    // needed) while still proving angle: -5 clears GetSmartPlaylistInputSchema
+    // validation rather than throwing.
+    const ctx = makeCtx({ userId: 'someone-else' });
+
+    const result = await playlistQueries.smartPlaylist(
+      null,
+      { input: { type: 'RECOMMENDED_CROWD_FAVORITES', userId: 'user-123', angle: -5 } },
+      ctx,
+    );
+
+    expect(result.climbs).toEqual([]);
+    expect(result.totalCount).toBe(0);
+  });
+
+  it('rejects angle -91 (outside the -90..90 board-tilt range) before any DB or board-resolution work', async () => {
+    const ctx = makeCtx({ userId: 'someone-else' });
+
+    await expect(
+      playlistQueries.smartPlaylist(
+        null,
+        { input: { type: 'RECOMMENDED_CROWD_FAVORITES', userId: 'user-123', angle: -91 } },
+        ctx,
+      ),
+    ).rejects.toThrow();
+    expect(mockDb.select).not.toHaveBeenCalled();
+    expect(resolveTargetMock).not.toHaveBeenCalled();
+  });
+
   it('RECOMMENDED_* returns an empty result (not a throw) when no board resolves', async () => {
     const ctx = makeCtx();
     resolveTargetMock.mockResolvedValueOnce(null);

--- a/packages/backend/src/graphql/resolvers/climbs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/queries.ts
@@ -286,7 +286,8 @@ export const climbQueries = {
     // Validate all parameters
     if (layoutId <= 0) throw new Error('Invalid layoutId: must be positive');
     if (sizeId <= 0) throw new Error('Invalid sizeId: must be positive');
-    if (angle < 0 || angle > 90) throw new Error('Invalid angle: must be between 0 and 90');
+    // Aurora boards support negative tilt (e.g. -5°); mobile sends the live board angle here.
+    if (angle < -90 || angle > 90) throw new Error('Invalid angle: must be between -90 and 90');
     validateInput(ExternalUUIDSchema, climbUuid, 'climbUuid');
 
     if (DEBUG) logger.info('[climb] Fetching:', { boardName, layoutId, sizeId, setIds, angle, climbUuid });

--- a/packages/backend/src/validation/schemas/board-presence.ts
+++ b/packages/backend/src/validation/schemas/board-presence.ts
@@ -9,7 +9,8 @@ export const BoardPresenceConfigInputSchema = z.object({
   setIds: NumericCsvSchema,
 });
 
-export const BoardPresenceAngleSchema = z.number().int().min(0).max(90).nullable().optional();
+// Live board angle; Aurora supports negative tilt.
+export const BoardPresenceAngleSchema = z.number().int().min(-90).max(90).nullable().optional();
 
 export const ReportBoardClimbInputSchema = z.object({
   uuid: z.string().min(1, 'Queue item UUID cannot be empty').max(100, 'Queue item UUID too long'),

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -45,7 +45,12 @@ export const ClimbInputSchema = z.object({
     .max(10000)
     .nullish()
     .transform((v) => v ?? ''),
-  angle: z.number().min(0).max(90),
+  // Live board angle; Aurora supports negative tilt. ClimbInputSchema is only
+  // consumed by the presence/queue climb payload (ClimbQueueItemSchema,
+  // ReportBoardClimbInputSchema) — catalogue-write schemas (SaveClimbInputSchema,
+  // UpdateClimbInputSchema, SaveMoonBoardClimbInputSchema) define their own
+  // angle bound independently and stay strict.
+  angle: z.number().min(-90).max(90),
   ascensionist_count: z
     .number()
     .min(0)
@@ -305,7 +310,9 @@ export const SetterStatsInputSchema = z.object({
   layoutId: z.number().int().positive('Layout ID must be positive'),
   sizeId: z.number().int().positive('Size ID must be positive'),
   setIds: z.string().min(1, 'Set IDs cannot be empty'),
-  angle: z.number().int().min(0).max(90),
+  // Live board angle; Aurora supports negative tilt. Mobile's setter filter
+  // sends the live angle here.
+  angle: z.number().int().min(-90).max(90),
   search: z.string().max(200).optional(),
 });
 

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -319,7 +319,9 @@ export const SimilarClimbsInputSchema = z
     // (favorites, playlists, etc.) and length-bounds them so a malformed
     // string can't reach the underlying SQL.
     excludeClimbUuid: ExternalUUIDSchema.optional(),
-    angle: z.number().int().min(0).max(90).optional(),
+    // Aurora boards support negative tilt (e.g. -5°); angle is only an optional
+    // stats-join key here, so a non-matching value nulls the join rather than erroring.
+    angle: z.number().int().min(-90).max(90).optional(),
     climbUuid: ExternalUUIDSchema.optional(),
     frames: z.string().min(1).max(10000).optional(),
   })

--- a/packages/backend/src/validation/schemas/playlists.ts
+++ b/packages/backend/src/validation/schemas/playlists.ts
@@ -100,7 +100,8 @@ export const GetPlaylistClimbsInputSchema = z
     // selected angle instead of the added-at / most-ascents fallback. Both are
     // required together — one without the other would silently no-op.
     activeBoardName: BoardNameSchema.optional(),
-    activeAngle: z.number().int().min(0).max(90).optional(),
+    // Live board angle; Aurora supports negative tilt.
+    activeAngle: z.number().int().min(-90).max(90).optional(),
     page: z.number().int().min(0).optional(),
     pageSize: z.number().int().min(1).max(100).optional(),
   })
@@ -113,7 +114,8 @@ export const DiscoverPlaylistsInputSchema = z.object({
   boardType: BoardNameSchema.optional(),
   layoutId: z.number().int().positive().optional(),
   sizeId: z.number().int().positive().nullable().optional(),
-  angle: z.number().int().min(0).max(90).nullable().optional(),
+  // Live board angle; Aurora supports negative tilt.
+  angle: z.number().int().min(-90).max(90).nullable().optional(),
   name: z.string().max(100).optional(),
   creatorIds: z.array(z.string().min(1)).optional(),
   generatedRecommendation: z.boolean().nullable().optional(),
@@ -152,7 +154,8 @@ export const GetSmartPlaylistInputSchema = z.object({
   boardName: BoardNameSchema.optional(),
   boardUuid: z.string().min(1).optional(),
   sizeId: z.number().int().positive().optional(),
-  angle: z.number().int().min(0).max(90).optional(),
+  // Live board angle; Aurora supports negative tilt.
+  angle: z.number().int().min(-90).max(90).optional(),
   page: z.number().int().min(0).optional(),
   pageSize: z.number().int().min(1).max(100).optional(),
 });


### PR DESCRIPTION
## Summary

Fixes #4650 — the web climb view for boards at negative tilt (e.g. grasshopper at -5°) triggers 159 backend validation errors/day. Web deliberately supports negative angles in URLs ("Aurora supports negative tilt readings"), and mobile sends the live board angle in several places. This PR widens every backend input that carries that **live board angle** from `.min(0)` to `.min(-90)` (Aurora's practical tilt floor), leaving `.max(90)` untouched.

### Widened paths

1. **`SimilarClimbsInputSchema.angle`** (`validation/schemas/climbs.ts`) — feeds `resolvers/climbs/queries.ts` → `statsAngle` → an equality filter in `climb-similarity.ts`. An unmatched negative angle just nulls the stats join rather than being invalid.
2. **The `climb` query's hand-rolled guard** (`resolvers/climbs/queries.ts`, `if (angle < 0 || angle > 90) throw ...`) — widened to `angle < -90 || angle > 90`. Mobile's `GET_CLIMB` sends the live board angle here; this guard rejected it outright.
3. **`BoardPresenceAngleSchema`** (`validation/schemas/board-presence.ts`) — gates `reportBoardClimb`, which a connected/kiosk board fires on **every** climb-light event in a live session. A negative-tilt board was erroring continuously.
4. **`ClimbInputSchema.angle`** (`validation/schemas/climbs.ts`) — verified its only consumers before widening: `ClimbQueueItemSchema` (queue mutations, session `initialQueue`) and `ReportBoardClimbInputSchema.climb` (board presence). No catalogue-write schema (`SaveClimbInputSchema`, `UpdateClimbInputSchema`, `SaveMoonBoardClimbInputSchema`) references it — they each define their own independent `angle` bound — so it was safe to widen directly.
5. **`GetPlaylistClimbsInputSchema.activeAngle`** (`validation/schemas/playlists.ts`) — all-boards playlist view rendered at the viewer's live angle.
6. **`DiscoverPlaylistsInputSchema.angle`** (`validation/schemas/playlists.ts`) — playlist discovery filtered by the viewer's live angle.
7. **`GetSmartPlaylistInputSchema.angle`** (`validation/schemas/playlists.ts`) — smart playlists (recommendations, etc.) hydrated at the viewer's live angle.
8. **`SetterStatsInputSchema.angle`** (`validation/schemas/climbs.ts`) — mobile's setter-filter autocomplete sends the live angle.

### Catalogue-write schemas stay strict by design (unchanged)

`SaveClimbInputSchema`, `UpdateClimbInputSchema`, `SaveMoonBoardClimbInputSchema`, `CheckMoonBoardClimbDuplicatesInputSchema`, `AddClimbToPlaylistInputSchema`, tick schemas, and proposal schemas all keep their original `.min(0).max(90)` bound — these persist a canonical angle for a climb/tick/proposal, not a read filtered by whatever angle a live board happens to be tilted at, so `.min(0)` stays correct there.

## Release Notes

- Similar climbs, climb details, board-presence live sends, playlists, and the setter filter now all work on boards set to a negative tilt

## Test plan

- [x] `vp run typecheck` — clean (both commits)
- [x] `vp test run --project backend --reporter=agent` (full project, first commit) — 268/270 files, 3733/3734 tests passed. The 1 failure (`websocket-sync.test.ts`, a `board_session_queues` foreign-key violation) is a pre-existing sandbox/test-infra flake unrelated to angle validation.
- [x] `vp test run --project backend --reporter=agent` scoped to every changed/added test file (both commits together) — 7 files, 162/162 tests passed:
  - `climb-similar-resolver.test.ts`, `graphql-resolvers.test.ts` (commit 1: `similarClimbs` + `climb` query)
  - `board-presence.test.ts` (`reportBoardClimb` accepts angle -5 and publishes it verbatim, including via `climb.angle` fallback with no top-level angle; rejects -91)
  - `playlist-climbs-active-angle.test.ts` (`activeAngle: -5` falls back like any unmatched angle; rejects -91)
  - `discover-playlists.test.ts` (`angle: -5` accepted; rejects -91 with zero DB calls)
  - `smart-playlists.test.ts` (`angle: -5` accepted; rejects -91 before any DB/board-resolution work)
  - `setter-stats-moonboard.test.ts` (`angle: -5` returns an empty result for the unmatched stats join, not an error; rejects -91)
- [x] `vp check` — 0 errors, 260 pre-existing warnings, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aZ1zjpqkXScoo4jyzL49X