### PR TITLE
fix(db): let teardown drop a disabled subscription

### DIFF
--- a/docs/neon-migration.md
+++ b/docs/neon-migration.md
@@ -429,8 +429,10 @@ table-synchronization slot draw from the same 60 seconds, so a teardown that
 meets a dozen held sync slots still returns in about a minute rather than a
 dozen. A dead replication socket can hold one open until Neon's
 `wal_sender_timeout` expires; raise the budget past that rather than looping the
-command. The subscription is already dropped by this point, so the re-run picks
-up at the slot and the publication — expect it to say so, and treat the run as
+command, and write the new value without a leading zero: bash reads `090` as
+octal, so teardown refuses it outright rather than waiting a number nobody asked
+for. The subscription is already dropped by this point, so the re-run picks up
+at the slot and the publication — expect it to say so, and treat the run as
 unfinished until it exits clean. That re-run has no subscription left to match
 sync slots against, so instead of dropping them it lists them under `cannot
 attribute to any subscription`. Check that no other subscriber on that database

--- a/docs/neon-migration.md
+++ b/docs/neon-migration.md
@@ -421,16 +421,20 @@ never finished, so teardown sweeps the table-synchronization slots
 dropped. Those slots retain WAL exactly like the main one, and after a detached
 drop nothing else would ever remove them.
 
-If a walsender on Neon has not disconnected yet, teardown waits up to
-`SOURCE_SLOT_RELEASE_SECONDS` (default 60) for it and then stops with `source
-slot ... is still held by an active walsender`. A dead replication socket can
-hold one open until Neon's `wal_sender_timeout` expires; raise the budget past
-that rather than looping the command. The subscription is already dropped by
-this point, so the re-run picks up at the slot and the publication — expect it
-to say so, and treat the run as unfinished until it exits clean. That re-run has
-no subscription left to match sync slots against, so instead of dropping them it
-lists them under `cannot attribute to any subscription`. Check that no other
-subscriber on that database owns them and drop each one by hand:
+If a walsender on Neon has not disconnected yet, teardown waits for it and then
+stops with `source slot ... is still held by an active walsender`.
+`SOURCE_SLOT_RELEASE_SECONDS` (default 60) is the budget for that waiting across
+the whole run, not per slot: the migration slot and every stranded
+table-synchronization slot draw from the same 60 seconds, so a teardown that
+meets a dozen held sync slots still returns in about a minute rather than a
+dozen. A dead replication socket can hold one open until Neon's
+`wal_sender_timeout` expires; raise the budget past that rather than looping the
+command. The subscription is already dropped by this point, so the re-run picks
+up at the slot and the publication — expect it to say so, and treat the run as
+unfinished until it exits clean. That re-run has no subscription left to match
+sync slots against, so instead of dropping them it lists them under `cannot
+attribute to any subscription`. Check that no other subscriber on that database
+owns them and drop each one by hand:
 
 ```sql
 SELECT pg_drop_replication_slot('pg_<oid>_sync_<relid>_<sysid>');

--- a/docs/neon-migration.md
+++ b/docs/neon-migration.md
@@ -402,6 +402,40 @@ Feed those two values back into the block above. Do not reach for a hand-written
 `DROP SUBSCRIPTION` instead — the helper's owner comparison is the only check
 standing between this teardown and someone else's same-name object.
 
+A plain `DROP SUBSCRIPTION` also has to reach Neon to drop the slot at the other
+end, which is exactly what an operator running this section usually cannot do.
+The helper disables the subscription, detaches it with
+`ALTER SUBSCRIPTION ... SET (slot_name = NONE)`, and only then drops it, so the
+drop is local to Railway; the slot is removed separately over the Neon admin
+connection. Because those three statements autocommit one at a time, teardown
+accepts the two half-finished shapes a failed run leaves behind — a disabled
+subscription, or a disabled one whose `subslotname` is already NULL — and
+finishes the job. Identity is unchanged: the subscription's name, owner,
+publication list, connection digest and digest comment still all have to match
+before anything is dropped, so a same-name subscription belonging to somebody
+else is refused whether it is enabled or not.
+
+Detaching also means the drop no longer cleans up after an initial copy that
+never finished, so teardown sweeps the table-synchronization slots
+(`pg_<oid>_sync_...`) itself, matching on the OID of the subscription it just
+dropped. Those slots retain WAL exactly like the main one, and after a detached
+drop nothing else would ever remove them.
+
+If a walsender on Neon has not disconnected yet, teardown waits up to
+`SOURCE_SLOT_RELEASE_SECONDS` (default 60) for it and then stops with `source
+slot ... is still held by an active walsender`. A dead replication socket can
+hold one open until Neon's `wal_sender_timeout` expires; raise the budget past
+that rather than looping the command. The subscription is already dropped by
+this point, so the re-run picks up at the slot and the publication — expect it
+to say so, and treat the run as unfinished until it exits clean. That re-run has
+no subscription left to match sync slots against, so instead of dropping them it
+lists them under `cannot attribute to any subscription`. Check that no other
+subscriber on that database owns them and drop each one by hand:
+
+```sql
+SELECT pg_drop_replication_slot('pg_<oid>_sync_<relid>_<sysid>');
+```
+
 ## 7. Homelab Read Replica Setup
 
 ### 7.1 PostgreSQL Installation

--- a/docs/neon-migration.md
+++ b/docs/neon-migration.md
@@ -435,8 +435,9 @@ for. The subscription is already dropped by this point, so the re-run picks up
 at the slot and the publication — expect it to say so, and treat the run as
 unfinished until it exits clean. That re-run has no subscription left to match
 sync slots against, so instead of dropping them it lists them under `cannot
-attribute to any subscription`. Check that no other subscriber on that database
-owns them and drop each one by hand:
+attribute to any subscription`, finishes the safe publication cleanup, and
+returns non-zero without removing the temporary subscriber role. Check that no
+other subscriber on that database owns them and drop each one by hand:
 
 ```sql
 SELECT pg_drop_replication_slot('pg_<oid>_sync_<relid>_<sysid>');

--- a/scripts/postgres-logical-replication.sh
+++ b/scripts/postgres-logical-replication.sh
@@ -2249,7 +2249,7 @@ SQL
       return 0
       ;;
     *)
-      fail "source slot $slot_name is still held by an active walsender and this teardown run's ${SOURCE_SLOT_RELEASE_SECONDS}s SOURCE_SLOT_RELEASE_SECONDS budget for all slots is spent; re-run teardown once it has disconnected, or raise SOURCE_SLOT_RELEASE_SECONDS past the source wal_sender_timeout"
+      fail "source slot $slot_name is still held by an active walsender and this teardown run's shared SOURCE_SLOT_RELEASE_SECONDS budget for all slots is spent (configured ${SOURCE_SLOT_RELEASE_SECONDS}s; 0s remain for this and later slots); re-run teardown once it has disconnected, or raise SOURCE_SLOT_RELEASE_SECONDS past the source wal_sender_timeout"
       ;;
   esac
   # Re-prove identity and idleness inside the deleting statement itself. The

--- a/scripts/postgres-logical-replication.sh
+++ b/scripts/postgres-logical-replication.sh
@@ -21,6 +21,7 @@ TARGET_RUNTIME_SCHEMAS="${TARGET_RUNTIME_SCHEMAS:-}"
 TARGET_MIGRATOR_ROLE="${TARGET_MIGRATOR_ROLE:-}"
 SOURCE_DATABASE_NAME="${SOURCE_DATABASE_NAME:-railway}"
 TARGET_DATABASE_NAME="${TARGET_DATABASE_NAME:-railway}"
+SOURCE_SLOT_RELEASE_SECONDS="${SOURCE_SLOT_RELEASE_SECONDS:-60}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/postgres-credentials.sh
 source "$SCRIPT_DIR/lib/postgres-credentials.sh"
@@ -97,6 +98,11 @@ Environment:
                                     sync-sequences will proceed.
   TEARDOWN_CONFIRMED               Must be true for teardown. Set only after the 72-hour
                                     acceptance window and successful PG18 restore drill.
+  SOURCE_SLOT_RELEASE_SECONDS       Optional teardown budget in seconds, default 60. How
+                                    long to wait for the publisher to release a slot after
+                                    the subscription that held it is dropped. Raise it past
+                                    the source's wal_sender_timeout when a dead replication
+                                    socket keeps the walsender attached for longer.
 
 Commands:
   setup
@@ -768,6 +774,14 @@ SELECT subscriber.rolcanlogin::text || '|' ||
         (SELECT rolsuper FROM pg_roles WHERE rolname = current_user) OR
         pg_has_role(current_user, subscriber.oid, 'SET'))::text || '|' ||
        (
+         -- subenabled stays asserted here even though teardown now tolerates a
+         -- disabled subscription. Teardown only reaches this through
+         -- drop_target_subscriber_role, which runs after an unfiltered re-count
+         -- of pg_subscription has already proven the subscription is gone, so
+         -- the count is 0 whichever way this predicate reads. Relaxing it for
+         -- symmetry would be dead weakening: the 'absent' case below would then
+         -- read a disabled leftover as absent and clear the way for the role to
+         -- be dropped out from under a subscription that still exists.
          SELECT count(*) FROM pg_subscription AS subscription
          WHERE subscription.subname = '${SUBSCRIPTION_NAME}'
            AND subscription.subowner = subscriber.oid
@@ -1446,20 +1460,49 @@ ORDER BY extension.extname;")"
 assert_subscription_contract() {
   # Validate the role boundary independently first. The exact catalog query
   # below is the single authority for whether the expected subscription is
-  # present, enabled, and owned by that role.
+  # present, owned by that role, and -- unless the caller says otherwise --
+  # still able to replicate.
   #
   # Teardown passes skip-subscriber-role-shape. Dropping a subscription, slot
   # and publication never touches the role, so the role's ACL shape cannot make
   # that unsafe -- and gating on it would strand the WAL-emergency path exactly
-  # when the slot is filling the source disk. Identity is still proven, by the
-  # subowner/name/slot/publication equality in the query below. The full role
-  # contract is still enforced where it decides a DROP ROLE, in
-  # drop_target_subscriber_role.
+  # when the slot is filling the source disk. The full role contract is still
+  # enforced where it decides a DROP ROLE, in drop_target_subscriber_role.
   local subscriber_role_check="${1:-validate-subscriber-role}"
   [[ "$subscriber_role_check" =~ ^(validate-subscriber-role|skip-subscriber-role-shape)$ ]] ||
     fail "internal subscriber role check must be validate-subscriber-role or skip-subscriber-role-shape"
   if [[ "$subscriber_role_check" == 'validate-subscriber-role' ]]; then
     validate_target_subscriber_role optional
+  fi
+
+  # Teardown also passes allow-disabled-detached, for the same reason and with
+  # the same care. subenabled and subslotname say whether the subscription can
+  # still replicate, not whose it is, and teardown is the one caller whose job
+  # is to remove one that cannot. DROP SUBSCRIPTION has to reach the publisher
+  # to drop the remote slot, so the outage that sends an operator to teardown
+  # commits the DISABLE and then fails the DROP; teardown answers that by
+  # detaching the slot with SET (slot_name = NONE) first, which nulls
+  # subslotname. Both half-finished shapes have to be resumable, or the slot
+  # keeps filling the source disk with nothing left that will remove it.
+  #
+  # Identity is carried by the five predicates no caller may relax: subname,
+  # subowner = TARGET_SUBSCRIBER_ROLE, subpublications, the md5 of subconninfo,
+  # and the conninfo-digest comment setup wrote on the subscription. Only this
+  # migration's setup produces all five together, so a same-named subscription
+  # belonging to somebody else is still refused, disabled or not. The option
+  # predicates -- binary, origin, run_as_owner, password_required, failover --
+  # stay asserted on every path; nothing teardown does can change them, so
+  # there is no half-finished shape they could wrongly refuse. The table
+  # coverage comparison at the end of this function is the one assertion that
+  # is neither identity nor teardown-proof; see the note there.
+  local replication_state_check="${2:-require-enabled-attached}"
+  [[ "$replication_state_check" =~ ^(require-enabled-attached|allow-disabled-detached)$ ]] ||
+    fail "internal replication state check must be require-enabled-attached or allow-disabled-detached"
+  local enabled_predicate='AND subscription.subenabled'
+  local slot_predicate="AND subscription.subslotname = '${SLOT_NAME}'"
+  if [[ "$replication_state_check" == 'allow-disabled-detached' ]]; then
+    enabled_predicate=''
+    slot_predicate="AND (subscription.subslotname = '${SLOT_NAME}' OR subscription.subslotname IS NULL)"
   fi
 
   [[ "$PUBLISHER_CONNINFO_DIGEST" =~ ^[0-9a-f]{32}$ &&
@@ -1472,13 +1515,13 @@ SELECT count(*) = 1
 FROM pg_subscription AS subscription
 WHERE subscription.subname = '${SUBSCRIPTION_NAME}'
   AND pg_get_userbyid(subscription.subowner) = '${TARGET_SUBSCRIBER_ROLE}'
-  AND subscription.subenabled
+  ${enabled_predicate}
   AND NOT subscription.subbinary
   AND subscription.suborigin = 'none'
   AND NOT subscription.subrunasowner
   AND subscription.subpasswordrequired
   AND NOT subscription.subfailover
-  AND subscription.subslotname = '${SLOT_NAME}'
+  ${slot_predicate}
   AND subscription.subpublications = ARRAY['${PUBLICATION_NAME}']::text[]
   AND md5(subscription.subconninfo) = '${PUBLISHER_CONNINFO_DIGEST}'
   AND obj_description(subscription.oid, 'pg_subscription') =
@@ -1497,6 +1540,15 @@ JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace
 WHERE subscription.subname = '${SUBSCRIPTION_NAME}'
 ORDER BY 1;")"
 
+  # Health, not identity: the comparison below holds the source's included
+  # tables against what the subscription synchronizes, which drifts whenever a
+  # table is created or dropped in an included schema. It is asserted on the
+  # teardown path too, deliberately left alone by the #4513 relaxation: that
+  # fix widened exactly the two predicates a half-finished teardown of our own
+  # making turns false, and schema drift is neither of them. It is a real
+  # second way to strand teardown, tracked separately -- it needs the same
+  # treatment on assert_publication_contract's manifest, which gates teardown
+  # just as hard.
   if [[ "$source_manifest" != "$target_manifest" ]]; then
     diff -u \
       <(printf '%s\n' "$source_manifest") \
@@ -2119,12 +2171,80 @@ SELECT count(*) FROM pg_roles AS subscriber WHERE subscriber.rolname = '${TARGET
   echo "Temporary subscriber role '$TARGET_SUBSCRIBER_ROLE' removed. Drop MIGRATION_SUBSCRIBER_ROLE and MIGRATION_SUBSCRIPTION_NAME from the deploy environment now."
 }
 
+# Every table-synchronization slot the initial copy of one subscription created
+# on the source. PostgreSQL builds these names as
+# pg_<subscription oid>_sync_<relation oid>_<subscriber system identifier>; the
+# trailing group only appeared in 15, so the pattern tolerates its absence
+# rather than walking past a WAL-retaining slot from an older subscriber. The
+# subscription OID is the discriminator: it is read out of the target catalogue
+# before the subscription is dropped, so no other subscription's sync slots can
+# match. The logical/pgoutput/current-database shape is asserted for the same
+# reason the main slot asserts it.
+source_tablesync_slots() {
+  psql_neon -X -Atq -v subscription_oid="$1" <<'SQL'
+SELECT slot.slot_name
+FROM pg_replication_slots AS slot
+WHERE slot.slot_name ~ ('^pg_' || :'subscription_oid' || '_sync_[0-9]+(_[0-9]+)?$')
+  AND slot.slot_type = 'logical'
+  AND slot.plugin = 'pgoutput'
+  AND slot.database = current_database()
+ORDER BY slot.slot_name;
+SQL
+}
+
+# Wait out the publisher's walsender, then drop a slot this run has already
+# proven belongs to the subscription it just removed. DROP SUBSCRIPTION stops
+# the subscriber's workers before it returns, but the publisher only releases
+# the slot once its walsender notices the closed connection -- which, when the
+# socket died rather than closed, takes until wal_sender_timeout. That gap used
+# to be invisible, because an attached DROP removed the remote slots itself;
+# detaching first makes this the code that has to sit through it. Polling beats
+# failing a teardown that is one socket close away from finishing, and anything
+# else still holding the slot fails the budget out with the catalogue untouched.
+release_and_drop_source_slot() {
+  local slot_name="$1"
+  local release_attempt=0
+  local slot_state
+  while true; do
+    # Three-valued deliberately. 'gone' means a second operator dropped the slot
+    # while this run was waiting, which is the outcome the caller wanted anyway;
+    # folding it into a plain "not released" boolean would spend the whole
+    # budget on an absent slot and then blame a walsender that is not there.
+    slot_state="$(psql_neon -X -Atq -v slot_name="$slot_name" <<'SQL'
+SELECT coalesce(
+         (SELECT CASE WHEN slot.active THEN 'held' ELSE 'released' END
+          FROM pg_replication_slots AS slot
+          WHERE slot.slot_name = :'slot_name'),
+         'gone');
+SQL
+)"
+    [[ "$slot_state" == 'held' && "$release_attempt" -lt "$SOURCE_SLOT_RELEASE_SECONDS" ]] || break
+    release_attempt=$((release_attempt + 1))
+    sleep 1
+  done
+  case "$slot_state" in
+    released) ;;
+    gone)
+      echo "Source slot '$slot_name' was already gone when teardown reached it."
+      return 0
+      ;;
+    *)
+      fail "source slot $slot_name is still held by an active walsender after ${SOURCE_SLOT_RELEASE_SECONDS}s; re-run teardown once it has disconnected, or raise SOURCE_SLOT_RELEASE_SECONDS past the source wal_sender_timeout"
+      ;;
+  esac
+  psql_neon -X -v slot_name="$slot_name" >/dev/null <<'SQL'
+SELECT pg_drop_replication_slot(:'slot_name');
+SQL
+}
+
 teardown_replication() {
   [[ "${TEARDOWN_CONFIRMED:-false}" == "true" ]] ||
     fail "teardown requires TEARDOWN_CONFIRMED=true after the 72-hour acceptance window and a successful PG18 restore drill"
   check_common_requirements
   require_env NEON_REPLICATION_DATABASE_URL SOURCE_REPLICATION_DATABASE_URL
   prepare_publisher_connection
+  [[ "$SOURCE_SLOT_RELEASE_SECONDS" =~ ^[0-9]+$ ]] ||
+    fail "SOURCE_SLOT_RELEASE_SECONDS must be a whole number of seconds"
   # TARGET_OWNER_ROLE and TARGET_SUBSCRIBER_ROLE are deliberately not required
   # here. Dropping the subscription needs them (its owner is half the proof the
   # subscription is ours) and so does the role cleanup, and both demand them at
@@ -2142,6 +2262,7 @@ teardown_replication() {
   # stale or unrelated publication/subscription/slot must never be deleted by
   # a teardown invocation that happens to reuse these names.
   local subscription_exists publication_exists source_slot_exists source_slot_contract
+  local subscription_identity='' subscription_oid='' subscription_slot_name=''
   subscription_exists="$(psql_railway -Atq -c "SELECT 1 FROM pg_subscription WHERE subname = '$SUBSCRIPTION_NAME';")"
   publication_exists="$(psql_neon -Atq -c "SELECT 1 FROM pg_publication WHERE pubname = '$PUBLICATION_NAME';")"
   source_slot_exists="$(psql_neon -X -Atq -v slot_name="$SLOT_NAME" <<'SQL'
@@ -2157,22 +2278,58 @@ SQL
     fail "source has duplicate slots named $SLOT_NAME"
 
   if [[ "$subscription_exists" == "1" ]]; then
+    # Read the OID and the slot association before any guard consults them, and
+    # before the drop takes both away. The slot association is what tells a
+    # subscription this teardown already detached (subslotname NULL, the shape a
+    # run interrupted after SET (slot_name = NONE) leaves) apart from one that
+    # never named this migration's slot at all. The OID is the only thing that
+    # will identify the table-synchronization slots afterwards.
+    subscription_identity="$(psql_railway -X -Atq -c "
+SELECT format('%s|%s', subscription.oid, coalesce(subscription.subslotname, ''))
+FROM pg_subscription AS subscription
+WHERE subscription.subname = '${SUBSCRIPTION_NAME}';")"
+    subscription_oid="${subscription_identity%%|*}"
+    subscription_slot_name="${subscription_identity#*|}"
+    [[ "$subscription_oid" =~ ^[0-9]+$ ]] ||
+      fail "could not read the OID of subscription $SUBSCRIPTION_NAME; refusing teardown"
+    # Not relaxed alongside subenabled/subslotname, and not an oversight.
+    # Teardown drops subscription, then slot, then publication, so no partial run
+    # of its own can produce a subscription without a publication; and a
+    # publication retains no WAL, so no emergency hand-fix produces that shape
+    # either. It only happens when these names describe two different migrations.
     [[ "$publication_exists" == '1' ]] ||
       fail "subscription $SUBSCRIPTION_NAME exists without the exact source publication; refusing teardown"
-    [[ "$source_slot_exists" == '1' ]] ||
+    # A subscription that still names its slot must have that slot on the source;
+    # anything else means these names do not describe one migration. A detached
+    # subscription is the legitimate exception: the slot it used to own may
+    # already be gone, dropped by the block below on an earlier run or by hand
+    # during the WAL emergency. Gate the exception on the detachment rather than
+    # dropping the guard, so the ordinary case still fails closed.
+    [[ "$source_slot_exists" == '1' || -z "$subscription_slot_name" ]] ||
       fail "subscription $SUBSCRIPTION_NAME exists without source slot $SLOT_NAME; refusing teardown"
     [[ -n "${TARGET_OWNER_ROLE:-}" && -n "${TARGET_SUBSCRIBER_ROLE:-}" ]] ||
       fail "subscription $SUBSCRIPTION_NAME still exists; proving it belongs to this migration needs TARGET_SUBSCRIBER_ROLE, and finishing the run needs TARGET_OWNER_ROLE for the role cleanup. Export both. Slot- and publication-only cleanup needs neither"
-    assert_subscription_contract skip-subscriber-role-shape
+    assert_subscription_contract skip-subscriber-role-shape allow-disabled-detached
   fi
   if [[ "$publication_exists" == '1' ]]; then
     assert_publication_contract
   fi
   if [[ "$source_slot_exists" == '1' ]]; then
+    # An active slot is only tolerable when the walsender holding it announces
+    # itself as this migration's subscription, which is what setup put in the
+    # subscription's conninfo application_name. That attribution used to be
+    # gated on the subscription still existing, and detaching-before-dropping
+    # broke the assumption behind the gate: the walsender outlives the drop by
+    # up to wal_sender_timeout, so a run that exhausts the release budget below
+    # leaves precisely a live walsender with no subscription. Gating on the
+    # subscription would have met that re-run with an identity-shaped refusal --
+    # "this slot is not yours" -- when the truthful answer is "wait". The gate
+    # never carried identity anyway; the application_name comparison does, and
+    # it is unchanged. Nothing is dropped on the strength of this check either:
+    # release_and_drop_source_slot re-proves the slot is idle first.
     source_slot_contract="$(psql_neon -X -Atq \
       -v slot_name="$SLOT_NAME" \
-      -v subscription_name="$SUBSCRIPTION_NAME" \
-      -v subscription_exists="${subscription_exists:+true}" <<'SQL'
+      -v subscription_name="$SUBSCRIPTION_NAME" <<'SQL'
 SELECT count(*) = 1
 FROM pg_replication_slots AS slot
 WHERE slot.slot_name = :'slot_name'
@@ -2181,14 +2338,11 @@ WHERE slot.slot_name = :'slot_name'
   AND slot.database = current_database()
   AND (
     NOT slot.active
-    OR (
-      :'subscription_exists' = 'true'
-      AND EXISTS (
-        SELECT 1
-        FROM pg_stat_replication AS replication
-        WHERE replication.pid = slot.active_pid
-          AND replication.application_name = :'subscription_name'
-      )
+    OR EXISTS (
+      SELECT 1
+      FROM pg_stat_replication AS replication
+      WHERE replication.pid = slot.active_pid
+        AND replication.application_name = :'subscription_name'
     )
   );
 SQL
@@ -2199,17 +2353,37 @@ SQL
 
   echo "Dropping Railway subscription if present..."
   if [[ "$subscription_exists" == "1" ]]; then
+    # Detach the slot before dropping. DROP SUBSCRIPTION opens a replication
+    # connection to the publisher to drop the remote slot, and an unreachable
+    # publisher is the usual reason teardown is being run at all: without the
+    # detach the DISABLE commits, the DROP fails, and the source goes on
+    # retaining WAL behind a slot nothing will remove. The order is
+    # load-bearing, because PostgreSQL only accepts slot_name = NONE on a
+    # disabled subscription. Every statement is autocommitted and idempotent,
+    # so a re-run repeats whichever of the three did not land. The slot itself
+    # is then removed on the source, over the admin connection, by the block
+    # below.
     psql_railway <<SQL
 ALTER SUBSCRIPTION $SUBSCRIPTION_NAME DISABLE;
+ALTER SUBSCRIPTION $SUBSCRIPTION_NAME SET (slot_name = NONE);
 DROP SUBSCRIPTION $SUBSCRIPTION_NAME;
 SQL
   else
     echo "Railway subscription '$SUBSCRIPTION_NAME' does not exist."
   fi
 
-  # DROP SUBSCRIPTION normally removes its remote slot. A failed/partial prior
-  # teardown can leave the exact migration slot orphaned, so verify and remove
-  # it independently. Never touch any other slot.
+  # Detaching the slot above makes this the normal path rather than the
+  # exceptional one: the drop no longer removes the remote slot, so the source
+  # slot is still here on every teardown that had a subscription, not just after
+  # a failed or partial prior one. What that does not change is how weak a
+  # slot's own identity is -- slots carry no owner and no comment, so all this
+  # can prove is the exact name plus the logical/pgoutput/current-database
+  # shape. The subscription contract above is what ties that name to this
+  # migration; on the orphan path, where there is no subscription left to ask,
+  # the name is the whole of it. A second rehearsal that reuses SLOT_NAME
+  # against the same source database is the one thing that could fool it.
+  # Verify the exact migration slot and remove only that one. Never touch any
+  # other slot.
   source_slot_exists="$(psql_neon -X -Atq -v slot_name="$SLOT_NAME" <<'SQL'
 SELECT count(*) FROM pg_replication_slots WHERE slot_name = :'slot_name';
 SQL
@@ -2221,15 +2395,12 @@ FROM pg_replication_slots
 WHERE slot_name = :'slot_name'
   AND slot_type = 'logical'
   AND plugin = 'pgoutput'
-  AND database = current_database()
-  AND NOT active;
+  AND database = current_database();
 SQL
 )"
     [[ "$source_slot_contract" == 't' ]] ||
-      fail "source slot $SLOT_NAME exists but is active or does not match the exact logical pgoutput/current-database contract"
-    psql_neon -X -v slot_name="$SLOT_NAME" >/dev/null <<'SQL'
-SELECT pg_drop_replication_slot(:'slot_name');
-SQL
+      fail "source slot $SLOT_NAME does not match the exact logical pgoutput/current-database contract"
+    release_and_drop_source_slot "$SLOT_NAME"
   elif [[ "$source_slot_exists" != '0' ]]; then
     fail "source has duplicate slots named $SLOT_NAME"
   fi
@@ -2239,6 +2410,57 @@ SELECT count(*) FROM pg_replication_slots WHERE slot_name = :'slot_name';
 SQL
 )"
   [[ "$source_slot_exists" == '0' ]] || fail "source slot $SLOT_NAME still exists after teardown"
+
+  # An attached DROP SUBSCRIPTION also removes the table-synchronization slots
+  # an unfinished initial copy left on the publisher; a detached one, by design,
+  # contacts the publisher for nothing at all. So a teardown that interrupts a
+  # copy -- the likeliest shape of the disk-filling emergency, since retention
+  # peaks there -- strands one sync slot per unsynchronized table, each holding
+  # WAL exactly like the main slot, and nothing else will ever remove them: the
+  # subscription that named them is gone. Sweep them over the same admin
+  # connection that just dropped the main slot, and verify, or the fix for
+  # #4513 would have traded a loud wedge for a silent all-clear over a source
+  # that is still filling up.
+  local stranded_tablesync_slots unattributed_tablesync_slots tablesync_slot
+  if [[ -n "$subscription_oid" ]]; then
+    stranded_tablesync_slots="$(source_tablesync_slots "$subscription_oid")"
+    if [[ -n "$stranded_tablesync_slots" ]]; then
+      echo "Dropping table-synchronization slots stranded by the initial copy..."
+      while IFS= read -r tablesync_slot; do
+        [[ -n "$tablesync_slot" ]] || continue
+        echo "  $tablesync_slot"
+        release_and_drop_source_slot "$tablesync_slot"
+      done <<<"$stranded_tablesync_slots"
+      [[ -z "$(source_tablesync_slots "$subscription_oid")" ]] ||
+        fail "source table-synchronization slots for subscription $SUBSCRIPTION_NAME still exist after teardown and keep retaining WAL"
+    fi
+  else
+    # No subscription left to read an OID from, so nothing here can prove which
+    # subscription a sync slot belongs to -- another subscriber replicating this
+    # same database produces indistinguishable names, and teardown does not drop
+    # what it cannot attribute. Report instead. A run that exhausted the release
+    # budget above dies after the subscription is already gone, so its re-run
+    # arrives exactly here with its own sync slots still holding WAL, and
+    # exiting clean over them is the one outcome worse than refusing.
+    unattributed_tablesync_slots="$(psql_neon -X -Atq <<'SQL'
+SELECT slot.slot_name
+FROM pg_replication_slots AS slot
+WHERE slot.slot_name ~ '^pg_[0-9]+_sync_[0-9]+(_[0-9]+)?$'
+  AND slot.slot_type = 'logical'
+  AND slot.plugin = 'pgoutput'
+  AND slot.database = current_database()
+ORDER BY slot.slot_name;
+SQL
+)"
+    if [[ -n "$unattributed_tablesync_slots" ]]; then
+      echo "warning: the source still holds table-synchronization slots that teardown cannot attribute to any subscription, and they retain WAL:"
+      while IFS= read -r tablesync_slot; do
+        [[ -n "$tablesync_slot" ]] || continue
+        echo "  $tablesync_slot"
+      done <<<"$unattributed_tablesync_slots"
+      echo "warning: confirm no other subscriber owns them, then drop each with SELECT pg_drop_replication_slot('<name>') on the source."
+    fi
+  fi
 
   echo "Dropping Neon publication if present..."
   if [[ "$publication_exists" == '1' ]]; then

--- a/scripts/postgres-logical-replication.sh
+++ b/scripts/postgres-logical-replication.sh
@@ -2284,8 +2284,14 @@ teardown_replication() {
   check_common_requirements
   require_env NEON_REPLICATION_DATABASE_URL SOURCE_REPLICATION_DATABASE_URL
   prepare_publisher_connection
-  [[ "$SOURCE_SLOT_RELEASE_SECONDS" =~ ^[0-9]+$ ]] ||
-    fail "SOURCE_SLOT_RELEASE_SECONDS must be a whole number of seconds"
+  # Leading zeros are rejected, not tolerated: bash reads a 0-prefixed literal as
+  # octal, so a plausible-looking SOURCE_SLOT_RELEASE_SECONDS=060 would quietly
+  # become 48 seconds and 08 would blow up mid-poll as "value too great for
+  # base", which the loop's `|| break` turns into an instant "budget spent". The
+  # failure message below names the total the operator asked for, so the total
+  # has to be the total they get.
+  [[ "$SOURCE_SLOT_RELEASE_SECONDS" =~ ^(0|[1-9][0-9]*)$ ]] ||
+    fail "SOURCE_SLOT_RELEASE_SECONDS must be a whole number of seconds with no leading zeros"
   # One allowance for the run, handed to every release_and_drop_source_slot call
   # from here on. Set it only after the format check, so a typo fails as a typo
   # rather than as arithmetic inside the poll loop.

--- a/scripts/postgres-logical-replication.sh
+++ b/scripts/postgres-logical-replication.sh
@@ -22,6 +22,11 @@ TARGET_MIGRATOR_ROLE="${TARGET_MIGRATOR_ROLE:-}"
 SOURCE_DATABASE_NAME="${SOURCE_DATABASE_NAME:-railway}"
 TARGET_DATABASE_NAME="${TARGET_DATABASE_NAME:-railway}"
 SOURCE_SLOT_RELEASE_SECONDS="${SOURCE_SLOT_RELEASE_SECONDS:-60}"
+# Seconds of walsender waiting left for the whole teardown run, shared by every
+# release_and_drop_source_slot call. Teardown initialises it from
+# SOURCE_SLOT_RELEASE_SECONDS once its format has been validated; see the note on
+# that function for why the budget is one allowance rather than one per slot.
+SOURCE_SLOT_RELEASE_BUDGET_REMAINING=0
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/postgres-credentials.sh
 source "$SCRIPT_DIR/lib/postgres-credentials.sh"
@@ -100,9 +105,14 @@ Environment:
                                     acceptance window and successful PG18 restore drill.
   SOURCE_SLOT_RELEASE_SECONDS       Optional teardown budget in seconds, default 60. How
                                     long to wait for the publisher to release a slot after
-                                    the subscription that held it is dropped. Raise it past
-                                    the source's wal_sender_timeout when a dead replication
-                                    socket keeps the walsender attached for longer.
+                                    the subscription that held it is dropped. One budget
+                                    for the whole run, shared by the migration slot and
+                                    every stranded table-synchronization slot -- not a
+                                    fresh 60s each, which an interrupted copy of many
+                                    tables would turn into an hour of waiting. Raise it
+                                    past the source's wal_sender_timeout when a dead
+                                    replication socket keeps the walsender attached for
+                                    longer.
 
 Commands:
   setup
@@ -2201,9 +2211,16 @@ SQL
 # detaching first makes this the code that has to sit through it. Polling beats
 # failing a teardown that is one socket close away from finishing, and anything
 # else still holding the slot fails the budget out with the catalogue untouched.
+#
+# The budget is one allowance for the run, not one per slot. Teardown calls this
+# once for the migration slot and once per table-synchronization slot the
+# interrupted copy stranded, and a fresh allowance each time would multiply the
+# default 60s by the number of unsynchronized tables -- 50 tables is close to an
+# hour of a teardown doing nothing while the source it was called to unblock
+# goes on filling. One walsender wait tells the operator everything the
+# fifty-first would; the answer is to wait and re-run, not to keep the terminal.
 release_and_drop_source_slot() {
   local slot_name="$1"
-  local release_attempt=0
   local slot_state
   while true; do
     # Three-valued deliberately. 'gone' means a second operator dropped the slot
@@ -2218,8 +2235,11 @@ SELECT coalesce(
          'gone');
 SQL
 )"
-    [[ "$slot_state" == 'held' && "$release_attempt" -lt "$SOURCE_SLOT_RELEASE_SECONDS" ]] || break
-    release_attempt=$((release_attempt + 1))
+    # Seconds remaining, not attempts made: every iteration that continues
+    # sleeps exactly one second and spends exactly one second of the run's
+    # budget, so a budget of 0 means "probe once and do not wait at all".
+    [[ "$slot_state" == 'held' && "$SOURCE_SLOT_RELEASE_BUDGET_REMAINING" -gt 0 ]] || break
+    SOURCE_SLOT_RELEASE_BUDGET_REMAINING=$((SOURCE_SLOT_RELEASE_BUDGET_REMAINING - 1))
     sleep 1
   done
   case "$slot_state" in
@@ -2229,12 +2249,33 @@ SQL
       return 0
       ;;
     *)
-      fail "source slot $slot_name is still held by an active walsender after ${SOURCE_SLOT_RELEASE_SECONDS}s; re-run teardown once it has disconnected, or raise SOURCE_SLOT_RELEASE_SECONDS past the source wal_sender_timeout"
+      fail "source slot $slot_name is still held by an active walsender and this teardown run's ${SOURCE_SLOT_RELEASE_SECONDS}s SOURCE_SLOT_RELEASE_SECONDS budget for all slots is spent; re-run teardown once it has disconnected, or raise SOURCE_SLOT_RELEASE_SECONDS past the source wal_sender_timeout"
       ;;
   esac
+  # Re-prove identity and idleness inside the deleting statement itself. The
+  # poll above and the contract check before it both read the catalogue in
+  # earlier transactions, and a walsender can reattach in the gap; a bare
+  # pg_drop_replication_slot(:'slot_name') would then act on a decision that had
+  # already gone stale. Matching nothing is the safe outcome here, so the drop
+  # cannot report it -- the verification below is what turns a WHERE that
+  # matched no row into a refusal instead of a silent all-clear over a slot that
+  # is still retaining WAL.
   psql_neon -X -v slot_name="$slot_name" >/dev/null <<'SQL'
-SELECT pg_drop_replication_slot(:'slot_name');
+SELECT pg_drop_replication_slot(slot.slot_name)
+FROM pg_replication_slots AS slot
+WHERE slot.slot_name = :'slot_name'
+  AND slot.slot_type = 'logical'
+  AND slot.plugin = 'pgoutput'
+  AND slot.database = current_database()
+  AND NOT slot.active;
 SQL
+  local slot_remains
+  slot_remains="$(psql_neon -X -Atq -v slot_name="$slot_name" <<'SQL'
+SELECT count(*) FROM pg_replication_slots WHERE slot_name = :'slot_name';
+SQL
+)"
+  [[ "$slot_remains" == '0' ]] ||
+    fail "source slot $slot_name survived its guarded drop, so it changed shape or was re-acquired between the release poll and the drop and is still retaining WAL; re-check it on the source and re-run teardown"
 }
 
 teardown_replication() {
@@ -2245,6 +2286,10 @@ teardown_replication() {
   prepare_publisher_connection
   [[ "$SOURCE_SLOT_RELEASE_SECONDS" =~ ^[0-9]+$ ]] ||
     fail "SOURCE_SLOT_RELEASE_SECONDS must be a whole number of seconds"
+  # One allowance for the run, handed to every release_and_drop_source_slot call
+  # from here on. Set it only after the format check, so a typo fails as a typo
+  # rather than as arithmetic inside the poll loop.
+  SOURCE_SLOT_RELEASE_BUDGET_REMAINING="$SOURCE_SLOT_RELEASE_SECONDS"
   # TARGET_OWNER_ROLE and TARGET_SUBSCRIBER_ROLE are deliberately not required
   # here. Dropping the subscription needs them (its owner is half the proof the
   # subscription is ours) and so does the role cleanup, and both demand them at
@@ -2363,6 +2408,14 @@ SQL
     # so a re-run repeats whichever of the three did not land. The slot itself
     # is then removed on the source, over the admin connection, by the block
     # below.
+    #
+    # Idempotent includes the middle statement, which is the one a re-run is
+    # most likely to repeat: verified on PostgreSQL 18.4, a second
+    # SET (slot_name = NONE) against an already-detached subscription returns
+    # ALTER SUBSCRIPTION cleanly rather than erroring on the NULL subslotname,
+    # and the DROP that follows it succeeds. Measured, not assumed -- the
+    # alternative would be reading subslotname first and branching, which buys
+    # nothing and adds a state to get wrong.
     psql_railway <<SQL
 ALTER SUBSCRIPTION $SUBSCRIPTION_NAME DISABLE;
 ALTER SUBSCRIPTION $SUBSCRIPTION_NAME SET (slot_name = NONE);

--- a/scripts/postgres-logical-replication.sh
+++ b/scripts/postgres-logical-replication.sh
@@ -2481,6 +2481,7 @@ SQL
   # #4513 would have traded a loud wedge for a silent all-clear over a source
   # that is still filling up.
   local stranded_tablesync_slots unattributed_tablesync_slots tablesync_slot
+  unattributed_tablesync_slots=''
   if [[ -n "$subscription_oid" ]]; then
     stranded_tablesync_slots="$(source_tablesync_slots "$subscription_oid")"
     if [[ -n "$stranded_tablesync_slots" ]]; then
@@ -2545,6 +2546,10 @@ SQL
     fail "publication $PUBLICATION_NAME still exists; refusing to remove the temporary subscriber role"
   [[ "$remaining_slots" == '0' ]] ||
     fail "source slot $SLOT_NAME still exists; refusing to remove the temporary subscriber role"
+
+  if [[ -n "$unattributed_tablesync_slots" ]]; then
+    fail "source table-synchronization slots remain unattributed; refusing to report teardown complete or remove the temporary subscriber role. Resolve the listed slots, then re-run teardown"
+  fi
 
   drop_target_subscriber_role
 }

--- a/scripts/postgres-logical-replication.test.sh
+++ b/scripts/postgres-logical-replication.test.sh
@@ -1214,13 +1214,14 @@ done
 # makes identical-looking names -- but exiting clean without mentioning them
 # would hide exactly the WAL retention this whole change is about.
 reset_replication_object_state
-FAKE_SUBSCRIPTION_EXISTS=0 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=0 \
+rm -f "$SUBSCRIBER_DROPPED_MARKER"
+if FAKE_SUBSCRIPTION_EXISTS=0 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=0 \
   FAKE_UNATTRIBUTED_TABLESYNC_SLOTS='pg_31337_sync_16400_74921' \
-  run_teardown >"$ERROR_LOG" 2>&1 || {
-  cat "$ERROR_LOG" >&2
-  printf 'Expected teardown to finish over sync slots it cannot attribute.\n' >&2
+  FAKE_SUBSCRIBER_ROLE_COUNT=1 FAKE_SUBSCRIBER_CONTRACT="$GOOD_SUBSCRIBER_CONTRACT" \
+  run_teardown >"$ERROR_LOG" 2>&1; then
+  printf 'Expected teardown to refuse an all-clear over sync slots it cannot attribute.\n' >&2
   exit 1
-}
+fi
 grep -Fq 'cannot attribute to any subscription' "$ERROR_LOG" || {
   cat "$ERROR_LOG" >&2
   printf 'Teardown said nothing about the unattributable sync slots it left retaining WAL.\n' >&2
@@ -1231,9 +1232,24 @@ grep -Fq 'pg_31337_sync_16400_74921' "$ERROR_LOG" || {
   printf 'Teardown did not name the sync slots it left behind.\n' >&2
   exit 1
 }
+grep -Fq 'refusing to report teardown complete or remove the temporary subscriber role' "$ERROR_LOG" || {
+  cat "$ERROR_LOG" >&2
+  printf 'Teardown did not report the unattributable slots as unfinished cleanup.\n' >&2
+  exit 1
+}
+grep -Fq 'DROP PUBLICATION boardsesh_pg18_migration' "$REPLICATION_OBJECT_LOG" || {
+  cat "$ERROR_LOG" "$REPLICATION_OBJECT_LOG" >&2
+  printf 'Teardown did not finish the safe publication cleanup before refusing.\n' >&2
+  exit 1
+}
 if [[ -s "$SLOT_DROP_NAME_LOG" ]]; then
   cat "$SLOT_DROP_NAME_LOG" >&2
   printf 'Teardown dropped a slot it could not attribute to this migration.\n' >&2
+  exit 1
+fi
+if [[ -s "$ROLE_STATEMENT_LOG" ]]; then
+  cat "$ROLE_STATEMENT_LOG" >&2
+  printf 'Teardown removed the temporary subscriber role before every slot was resolved.\n' >&2
   exit 1
 fi
 

--- a/scripts/postgres-logical-replication.test.sh
+++ b/scripts/postgres-logical-replication.test.sh
@@ -1136,6 +1136,16 @@ grep -Fq 'is still held by an active walsender' "$ERROR_LOG" || {
   printf 'Teardown failed for the wrong reason while the slot was held.\n' >&2
   exit 1
 }
+grep -Fq 'configured 0s; 0s remain for this and later slots' "$ERROR_LOG" || {
+  cat "$ERROR_LOG" >&2
+  printf 'The zero-budget error did not distinguish configured and remaining time.\n' >&2
+  exit 1
+}
+if [[ -s "$SLEEP_LOG" ]]; then
+  cat "$SLEEP_LOG" >&2
+  printf 'A zero-second release budget slept instead of probing exactly once.\n' >&2
+  exit 1
+fi
 if [[ -s "$SLOT_DROP_NAME_LOG" ]]; then
   cat "$SLOT_DROP_NAME_LOG" >&2
   printf 'Teardown dropped a slot that was still held by a walsender.\n' >&2

--- a/scripts/postgres-logical-replication.test.sh
+++ b/scripts/postgres-logical-replication.test.sh
@@ -34,12 +34,21 @@ readonly SUBSCRIPTION_DROPPED_MARKER="$TEST_ROOT/subscription-dropped"
 # the migration slot and any stranded table-synchronization slot through the same
 # statement, so only the -v slot_name it passed tells them apart.
 readonly SLOT_DROP_NAME_LOG="$TEST_ROOT/slot-drop-names.log"
+# The release poll's wait is simulated, never slept: a fake sleep on PATH records
+# each second the helper would have spent so a case can assert how much of the
+# budget went where, and keeps the suite at seconds rather than minutes.
+readonly SLEEP_LOG="$TEST_ROOT/sleep.log"
+# One counter file per slot name, so a case can hold a slot for its first N
+# release probes and let it go afterwards. That is the shape that tells an
+# aggregate budget apart from a per-slot one.
+readonly SLOT_POLL_COUNT_DIR="$TEST_ROOT/slot-poll-counts"
 export ARGUMENT_LOG CLEANUP_PATH_LOG SUBSCRIPTION_FILE_CHECK HYPOPG_CREATE_MARKER \
   ROLE_STATEMENT_LOG SUBSCRIBER_DROPPED_MARKER REPLICATION_OBJECT_LOG \
   PUBLICATION_DROPPED_MARKER SLOT_DROPPED_MARKER SUBSCRIPTION_DROPPED_MARKER \
-  SLOT_DROP_NAME_LOG
-mkdir -p "$FAKE_BIN"
+  SLOT_DROP_NAME_LOG SLEEP_LOG SLOT_POLL_COUNT_DIR
+mkdir -p "$FAKE_BIN" "$SLOT_POLL_COUNT_DIR"
 : >"$SLOT_DROP_NAME_LOG"
+: >"$SLEEP_LOG"
 
 assert_absent() {
   local needle="$1"
@@ -161,12 +170,31 @@ if [[ "$sql" == *'DROP PUBLICATION'* ]]; then
   : >"$PUBLICATION_DROPPED_MARKER"
 fi
 if [[ "$sql" == *'pg_drop_replication_slot'* ]]; then
+  # The drop re-proves identity and idleness in the statement that deletes, since
+  # the poll that decided the slot was droppable committed earlier and a
+  # walsender can reattach in between. Simulating a drop that lost those
+  # predicates would let them be deleted with the suite still green, so refuse to
+  # answer one at all.
+  for required_drop_predicate in \
+    "slot.slot_name = :'slot_name'" \
+    "slot.slot_type = 'logical'" \
+    "slot.plugin = 'pgoutput'" \
+    'slot.database = current_database()' \
+    'NOT slot.active'; do
+    [[ "$sql" == *"$required_drop_predicate"* ]] || exit 81
+  done
   printf '%s\n' "$sql" >>"$REPLICATION_OBJECT_LOG"
-  printf '%s\n' "$psql_variable_slot_name" >>"$SLOT_DROP_NAME_LOG"
-  # Only the migration slot drives the simulated existence probes. Sync slots
-  # come and go by name through SLOT_DROP_NAME_LOG.
-  if [[ "$psql_variable_slot_name" == 'boardsesh_pg18_migration' ]]; then
-    : >"$SLOT_DROPPED_MARKER"
+  # FAKE_SLOT_DROP_MATCHES_NOTHING is that reattachment: the WHERE matches no
+  # row, so nothing is deleted and nothing is reported. Leave both the name log
+  # and the existence marker alone, so only the helper's own post-drop check can
+  # notice.
+  if [[ "${FAKE_SLOT_DROP_MATCHES_NOTHING:-0}" != '1' ]]; then
+    printf '%s\n' "$psql_variable_slot_name" >>"$SLOT_DROP_NAME_LOG"
+    # Only the migration slot drives the simulated existence probes. Sync slots
+    # come and go by name through SLOT_DROP_NAME_LOG.
+    if [[ "$psql_variable_slot_name" == 'boardsesh_pg18_migration' ]]; then
+      : >"$SLOT_DROPPED_MARKER"
+    fi
   fi
 fi
 if [[ "$sql" == *'DROP SUBSCRIPTION'* ]]; then
@@ -235,6 +263,21 @@ case "$sql" in
     [[ "$sql" == *"md5(subscription.subconninfo) = '"* ]] || contract_verdict=f
     [[ "$sql" == *"obj_description(subscription.oid, 'pg_subscription') ="* &&
       "$sql" == *"'boardsesh-pg18-conninfo-v1:"* ]] || contract_verdict=f
+    # The five option predicates need the same presence check, for the same
+    # reason and one more: no simulated knob varies them, and #4513 relaxed the
+    # two predicates next to them, so a slip that deleted one of these instead
+    # would leave every arm here matching and the whole suite green. They are
+    # asserted on every path, teardown included -- nothing teardown does can
+    # change a subscription's options, so there is no half-finished shape they
+    # could wrongly refuse and no reason for any caller to relax one.
+    for required_option_predicate in \
+      'AND NOT subscription.subbinary' \
+      "AND subscription.suborigin = 'none'" \
+      'AND NOT subscription.subrunasowner' \
+      'AND subscription.subpasswordrequired' \
+      'AND NOT subscription.subfailover'; do
+      [[ "$sql" == *"$required_option_predicate"* ]] || contract_verdict=f
+    done
     [[ "${FAKE_SUBSCRIPTION_CONNINFO_MATCHES:-t}" == 't' ]] || contract_verdict=f
     printf '%s\n' "$contract_verdict"
     ;;
@@ -279,10 +322,28 @@ case "$sql" in
     # The release poll. 'gone' simulates a second operator dropping the slot
     # mid-wait, so mark it dropped too: the verification afterwards has to see it
     # absent rather than blame a walsender that is no longer there.
-    if [[ "${FAKE_SLOT_RELEASE_STATE:-released}" == 'gone' ]]; then
+    slot_release_state="${FAKE_SLOT_RELEASE_STATE:-released}"
+    # Per-slot hold, layered over that: a slot named in FAKE_HELD_SLOT_NAMES
+    # answers 'held' for its first FAKE_HELD_SLOT_POLLS probes and 'released'
+    # after. Two slots each holding for one probe is what separates a budget
+    # shared by the run from one handed out fresh per slot.
+    if [[ -n "$psql_variable_slot_name" &&
+      " ${FAKE_HELD_SLOT_NAMES:-} " == *" $psql_variable_slot_name "* ]]; then
+      slot_poll_counter="$SLOT_POLL_COUNT_DIR/$psql_variable_slot_name"
+      slot_poll_count=0
+      [[ ! -f "$slot_poll_counter" ]] || slot_poll_count="$(<"$slot_poll_counter")"
+      slot_poll_count=$((slot_poll_count + 1))
+      printf '%s\n' "$slot_poll_count" >"$slot_poll_counter"
+      if [[ "$slot_poll_count" -le "${FAKE_HELD_SLOT_POLLS:-1}" ]]; then
+        slot_release_state=held
+      else
+        slot_release_state=released
+      fi
+    fi
+    if [[ "$slot_release_state" == 'gone' ]]; then
       : >"$SLOT_DROPPED_MARKER"
     fi
-    printf '%s\n' "${FAKE_SLOT_RELEASE_STATE:-released}"
+    printf '%s\n' "$slot_release_state"
     ;;
   *"~ '^pg_[0-9]+_sync_"*)
     # The orphan-path probe: sync slots that survive with no subscription left to
@@ -355,7 +416,17 @@ printf '\n' >>"$ARGUMENT_LOG"
 [[ " $* " != *'postgresql://'* && " $* " != *'postgres://'* ]]
 FAKE_PG_RESTORE
 
-chmod +x "$FAKE_BIN/psql" "$FAKE_BIN/pg_dump" "$FAKE_BIN/pg_restore"
+# The helper's release poll sleeps a second per iteration of the walsender wait.
+# Record the seconds instead of spending them: the budget arithmetic is what the
+# cases are about, and a real wait would put minutes on a suite that runs in
+# seconds. Deterministic too -- no wall clock decides how many probes happen.
+cat >"$FAKE_BIN/sleep" <<'FAKE_SLEEP'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+printf '%s\n' "$1" >>"$SLEEP_LOG"
+FAKE_SLEEP
+
+chmod +x "$FAKE_BIN/psql" "$FAKE_BIN/pg_dump" "$FAKE_BIN/pg_restore" "$FAKE_BIN/sleep"
 
 PATH="$FAKE_BIN:$PATH" \
 PGHOST='poison-host' \
@@ -771,9 +842,11 @@ assert_absent 'publisher-secret' "$ARGUMENT_LOG" "$ERROR_LOG"
 # row. Reset the drop markers so each run meets that state again.
 reset_replication_object_state() {
   rm -f "$SUBSCRIPTION_DROPPED_MARKER" "$PUBLICATION_DROPPED_MARKER" "$SLOT_DROPPED_MARKER"
+  rm -f "$SLOT_POLL_COUNT_DIR"/*
   : >"$REPLICATION_OBJECT_LOG"
   : >"$ROLE_STATEMENT_LOG"
   : >"$SLOT_DROP_NAME_LOG"
+  : >"$SLEEP_LOG"
 }
 
 # Every refusal is asserted twice: teardown has to exit non-zero *and* say why.
@@ -933,10 +1006,19 @@ run_status >"$ERROR_LOG" 2>&1 || {
   exit 1
 }
 
-for rejected_subscription_state in disabled detached; do
+# Three simulated rows, each pinning a different piece of what the strict
+# contract still demands. The middle one is the state teardown actually
+# produces: DISABLE and SET (slot_name = NONE) autocommit in that order, so
+# subslotname only ever goes NULL on a subscription that is already disabled.
+# Enabled-with-a-NULL-slot is not a shape this script can leave behind, and
+# pinning status against a state nothing produces would prove nothing about the
+# real half-finished run -- so the third case carries the slot predicate on its
+# own instead, with a subscription that names somebody else's slot.
+for rejected_subscription_state in disabled disabled-and-detached pointed-elsewhere; do
   case "$rejected_subscription_state" in
     disabled) simulated_enabled_state=f simulated_slot_state=boardsesh_pg18_migration ;;
-    detached) simulated_enabled_state=t simulated_slot_state='' ;;
+    disabled-and-detached) simulated_enabled_state=f simulated_slot_state='' ;;
+    pointed-elsewhere) simulated_enabled_state=t simulated_slot_state=somebody_elses_slot ;;
   esac
   if FAKE_SUBSCRIPTION_ENABLED="$simulated_enabled_state" \
     FAKE_SUBSCRIPTION_SLOT_NAME="$simulated_slot_state" \
@@ -1124,6 +1206,73 @@ if grep -Fq 'cannot attribute to any subscription' "$ERROR_LOG"; then
   exit 1
 fi
 
+# 20. SOURCE_SLOT_RELEASE_SECONDS is the budget for the run, not for each slot.
+# An interrupted initial copy leaves one sync slot per unsynchronized table, so a
+# per-slot allowance would multiply the default 60s by that count -- tens of
+# minutes of teardown waiting while the source it was called to unblock keeps
+# filling. Two slots that each hold for exactly one probe, against a one-second
+# budget: the first spends it, and the second must meet an empty budget rather
+# than a fresh one.
+reset_replication_object_state
+if FAKE_SUBSCRIPTION_EXISTS=1 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=1 \
+  FAKE_SUBSCRIPTION_OID=24680 \
+  FAKE_TABLESYNC_SLOTS='pg_24680_sync_16400_74921 pg_24680_sync_16401_74921' \
+  FAKE_HELD_SLOT_NAMES='pg_24680_sync_16400_74921 pg_24680_sync_16401_74921' \
+  FAKE_HELD_SLOT_POLLS=1 SOURCE_SLOT_RELEASE_SECONDS=1 \
+  run_teardown >"$ERROR_LOG" 2>&1; then
+  printf 'Expected the second held slot to meet a budget the first had already spent.\n' >&2
+  exit 1
+fi
+grep -Fq 'budget for all slots is spent' "$ERROR_LOG" || {
+  cat "$ERROR_LOG" >&2
+  printf 'Teardown did not report the shared release budget as spent.\n' >&2
+  exit 1
+}
+grep -Fxq 'pg_24680_sync_16400_74921' "$SLOT_DROP_NAME_LOG" || {
+  cat "$ERROR_LOG" "$SLOT_DROP_NAME_LOG" >&2
+  printf 'The first held slot was not dropped after it released.\n' >&2
+  exit 1
+}
+if grep -Fxq 'pg_24680_sync_16401_74921' "$SLOT_DROP_NAME_LOG"; then
+  cat "$SLOT_DROP_NAME_LOG" >&2
+  printf 'The second held slot got a fresh release budget of its own.\n' >&2
+  exit 1
+fi
+# One second of budget, one second of waiting, across the whole run. A per-slot
+# budget would have slept once more before failing, or not failed at all.
+[[ "$(wc -l <"$SLEEP_LOG")" -eq 1 ]] || {
+  cat "$SLEEP_LOG" >&2
+  printf 'Teardown spent something other than the one second of budget it had.\n' >&2
+  exit 1
+}
+
+# 21. The drop re-checks identity and idleness in the deleting statement, so a
+# walsender that reattached since the release poll makes the WHERE match nothing.
+# Nothing deleted and nothing reported is the safe half; teardown still has to
+# say so, or #4513's loud wedge is traded for a silent all-clear over a slot that
+# is still retaining WAL.
+reset_replication_object_state
+if FAKE_SUBSCRIPTION_EXISTS=0 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=1 \
+  FAKE_SLOT_DROP_MATCHES_NOTHING=1 \
+  run_teardown >"$ERROR_LOG" 2>&1; then
+  printf 'Expected teardown to fail over a slot its guarded drop did not remove.\n' >&2
+  exit 1
+fi
+grep -Fq 'survived its guarded drop' "$ERROR_LOG" || {
+  cat "$ERROR_LOG" >&2
+  printf 'Teardown failed for the wrong reason over a drop that matched nothing.\n' >&2
+  exit 1
+}
+grep -Fq 'pg_drop_replication_slot' "$REPLICATION_OBJECT_LOG" || {
+  cat "$ERROR_LOG" "$REPLICATION_OBJECT_LOG" >&2
+  printf 'Teardown never issued the guarded drop it then failed to verify.\n' >&2
+  exit 1
+}
+if [[ -e "$PUBLICATION_DROPPED_MARKER" ]]; then
+  printf 'Teardown carried on to the publication over a slot it had not removed.\n' >&2
+  exit 1
+fi
+
 assert_absent 'source:sec\ret' "$ARGUMENT_LOG" "$ERROR_LOG"
 assert_absent 'target-secret' "$ARGUMENT_LOG" "$ERROR_LOG"
 assert_absent 'publisher-secret' "$ARGUMENT_LOG" "$ERROR_LOG"
@@ -1133,3 +1282,4 @@ printf 'Teardown drops only an exact temporary subscriber role, idempotently.\n'
 printf 'Teardown clears an orphan slot and publication without the role variables.\n'
 printf 'Teardown drops a disabled or slot-detached subscription without weakening its identity contract.\n'
 printf 'Teardown clears the sync slots a detached drop leaves behind, and waits out the publisher walsender.\n'
+printf 'The walsender wait is one budget for the run, and every slot drop re-proves the slot before deleting it.\n'

--- a/scripts/postgres-logical-replication.test.sh
+++ b/scripts/postgres-logical-replication.test.sh
@@ -30,10 +30,16 @@ readonly REPLICATION_OBJECT_LOG="$TEST_ROOT/replication-objects.log"
 readonly PUBLICATION_DROPPED_MARKER="$TEST_ROOT/publication-dropped"
 readonly SLOT_DROPPED_MARKER="$TEST_ROOT/slot-dropped"
 readonly SUBSCRIPTION_DROPPED_MARKER="$TEST_ROOT/subscription-dropped"
+# Slot drops are recorded by name as well as by statement text: the helper drops
+# the migration slot and any stranded table-synchronization slot through the same
+# statement, so only the -v slot_name it passed tells them apart.
+readonly SLOT_DROP_NAME_LOG="$TEST_ROOT/slot-drop-names.log"
 export ARGUMENT_LOG CLEANUP_PATH_LOG SUBSCRIPTION_FILE_CHECK HYPOPG_CREATE_MARKER \
   ROLE_STATEMENT_LOG SUBSCRIBER_DROPPED_MARKER REPLICATION_OBJECT_LOG \
-  PUBLICATION_DROPPED_MARKER SLOT_DROPPED_MARKER SUBSCRIPTION_DROPPED_MARKER
+  PUBLICATION_DROPPED_MARKER SLOT_DROPPED_MARKER SUBSCRIPTION_DROPPED_MARKER \
+  SLOT_DROP_NAME_LOG
 mkdir -p "$FAKE_BIN"
+: >"$SLOT_DROP_NAME_LOG"
 
 assert_absent() {
   local needle="$1"
@@ -105,12 +111,22 @@ esac
 sql=''
 previous_argument=''
 expect_sql=false
+# Real psql substitutes :'name' server-side, so the captured statement text never
+# carries the value. Keep the two the helper varies per call.
+psql_variable_slot_name=''
+psql_variable_subscription_oid=''
 for argument in "$@"; do
   if [[ "$expect_sql" == true ]]; then
     sql="$argument"
     expect_sql=false
   elif [[ "$argument" == '-c' || "$argument" == '--command' || "$argument" =~ ^-[A-Za-z]*c[A-Za-z]*$ ]]; then
     expect_sql=true
+  fi
+  if [[ "$previous_argument" == '-v' || "$previous_argument" == '--set' ]]; then
+    case "$argument" in
+      slot_name=*) psql_variable_slot_name="${argument#slot_name=}" ;;
+      subscription_oid=*) psql_variable_subscription_oid="${argument#subscription_oid=}" ;;
+    esac
   fi
   if [[ "$previous_argument" == '--file' || "$previous_argument" == '-f' ]]; then
     [[ -f "$argument" ]]
@@ -146,7 +162,12 @@ if [[ "$sql" == *'DROP PUBLICATION'* ]]; then
 fi
 if [[ "$sql" == *'pg_drop_replication_slot'* ]]; then
   printf '%s\n' "$sql" >>"$REPLICATION_OBJECT_LOG"
-  : >"$SLOT_DROPPED_MARKER"
+  printf '%s\n' "$psql_variable_slot_name" >>"$SLOT_DROP_NAME_LOG"
+  # Only the migration slot drives the simulated existence probes. Sync slots
+  # come and go by name through SLOT_DROP_NAME_LOG.
+  if [[ "$psql_variable_slot_name" == 'boardsesh_pg18_migration' ]]; then
+    : >"$SLOT_DROPPED_MARKER"
+  fi
 fi
 if [[ "$sql" == *'DROP SUBSCRIPTION'* ]]; then
   printf '%s\n' "$sql" >>"$REPLICATION_OBJECT_LOG"
@@ -179,7 +200,44 @@ case "$sql" in
   *'WITH owner_role AS ('*'aclexplode(database.datacl)'*) printf 't\n' ;;
   *"rolcanlogin::text"*"WHERE rolname = current_user"*) printf '%s\n' "${FAKE_PUBLISHER_CONTRACT:-true|false|false|false|true|true|false|true|true|true|true|true}" ;;
   *"has_database_privilege(oid, current_database(), 'CREATE')"*) printf 't\n' ;;
-  *'FROM pg_subscription AS subscription'*) printf 't\n' ;;
+  *"format('%s|%s', subscription.oid"*)
+    # Teardown's pre-drop identity probe. FAKE_SUBSCRIPTION_SLOT_NAME expands
+    # with ${VAR-default}, not ${VAR:-default}, on purpose: set-but-empty is the
+    # detached subscription (subslotname NULL) a run interrupted after
+    # SET (slot_name = NONE) leaves behind, and :- would erase that case.
+    printf '%s|%s\n' "${FAKE_SUBSCRIPTION_OID:-16452}" \
+      "${FAKE_SUBSCRIPTION_SLOT_NAME-boardsesh_pg18_migration}"
+    ;;
+  *'FROM pg_subscription AS subscription'*)
+    # Evaluate the emitted subscription contract against a simulated catalog row
+    # rather than answering 't' unconditionally. Teardown's relaxation is a
+    # change to this query's predicates, so reading the SQL the helper actually
+    # sent is the only way a test can prove which call site relaxed what.
+    simulated_slot_name="${FAKE_SUBSCRIPTION_SLOT_NAME-boardsesh_pg18_migration}"
+    contract_verdict=t
+    if [[ "$sql" == *'AND subscription.subenabled'* && "${FAKE_SUBSCRIPTION_ENABLED:-t}" != 't' ]]; then
+      contract_verdict=f
+    fi
+    if [[ -n "$simulated_slot_name" ]]; then
+      [[ "$sql" == *"subscription.subslotname = '${simulated_slot_name}'"* ]] || contract_verdict=f
+    else
+      [[ "$sql" == *'subscription.subslotname IS NULL'* ]] || contract_verdict=f
+    fi
+    [[ "$sql" == *"pg_get_userbyid(subscription.subowner) = '${FAKE_SUBSCRIPTION_OWNER:-boardsesh_pg18_subscriber}'"* ]] ||
+      contract_verdict=f
+    [[ "$sql" == *"subscription.subpublications = ARRAY['${FAKE_SUBSCRIPTION_PUBLICATION:-boardsesh_pg18_migration}']::text[]"* ]] ||
+      contract_verdict=f
+    # The two connection predicates are checked for presence as well as
+    # simulated, unlike the knobs above. They are the half of the identity proof
+    # no other test exercises -- the live-PostgreSQL decoy in
+    # scripts/postgres18-image-smoke.sh also differs in owner and origin -- so
+    # without this, deleting them from the helper would pass the whole suite.
+    [[ "$sql" == *"md5(subscription.subconninfo) = '"* ]] || contract_verdict=f
+    [[ "$sql" == *"obj_description(subscription.oid, 'pg_subscription') ="* &&
+      "$sql" == *"'boardsesh-pg18-conninfo-v1:"* ]] || contract_verdict=f
+    [[ "${FAKE_SUBSCRIPTION_CONNINFO_MATCHES:-t}" == 't' ]] || contract_verdict=f
+    printf '%s\n' "$contract_verdict"
+    ;;
   *'FROM pg_publication AS publication'*) printf 't\n' ;;
   *'FROM pg_subscription_rel AS subscription_relation'*) printf 'public.example\n' ;;
   *'SELECT string_agg('*|*"SELECT format('%I.%I', n.nspname, c.relname)"*) printf 'public.example\n' ;;
@@ -199,9 +257,59 @@ case "$sql" in
       printf '0\n'
     fi
     ;;
+  *'FROM pg_stat_replication AS replication'*)
+    # Teardown's pre-mutation slot contract, evaluated against a simulated slot
+    # the same way the subscription contract arm is: by reading the predicates
+    # the helper actually emitted. FAKE_SLOT_ACTIVE=1 is our own walsender still
+    # attached, which is what a run that exhausted the release budget leaves
+    # behind once the subscription is gone; 'foreign' is somebody else holding a
+    # same-named slot, which must never be tolerated.
+    slot_contract_verdict=t
+    if [[ "${FAKE_SLOT_ACTIVE:-0}" != '0' ]]; then
+      slot_contract_verdict=f
+      if [[ "${FAKE_SLOT_ACTIVE}" == '1' &&
+        "$sql" == *"replication.application_name = :'subscription_name'"* &&
+        "$sql" != *"subscription_exists' = 'true'"* ]]; then
+        slot_contract_verdict=t
+      fi
+    fi
+    printf '%s\n' "$slot_contract_verdict"
+    ;;
+  *"CASE WHEN slot.active THEN 'held'"*)
+    # The release poll. 'gone' simulates a second operator dropping the slot
+    # mid-wait, so mark it dropped too: the verification afterwards has to see it
+    # absent rather than blame a walsender that is no longer there.
+    if [[ "${FAKE_SLOT_RELEASE_STATE:-released}" == 'gone' ]]; then
+      : >"$SLOT_DROPPED_MARKER"
+    fi
+    printf '%s\n' "${FAKE_SLOT_RELEASE_STATE:-released}"
+    ;;
+  *"~ '^pg_[0-9]+_sync_"*)
+    # The orphan-path probe: sync slots that survive with no subscription left to
+    # attribute them to. Must be answered above the OID-scoped arm below, whose
+    # pattern its own text would otherwise match.
+    printf '%s\n' ${FAKE_UNATTRIBUTED_TABLESYNC_SLOTS:-}
+    ;;
+  *'_sync_[0-9]+'*)
+    # Stranded table-synchronization slots on the source. Answered only when the
+    # helper passed the subscription OID it read from the target catalogue *and*
+    # built the name pattern out of it, so neither a sweep aimed at the wrong
+    # subscription nor one widened to every subscription's sync slots can pass.
+    if [[ "$psql_variable_subscription_oid" == "${FAKE_SUBSCRIPTION_OID:-16452}" &&
+      "$sql" == *":'subscription_oid'"* ]]; then
+      for simulated_tablesync_slot in ${FAKE_TABLESYNC_SLOTS:-}; do
+        if [[ "${FAKE_TABLESYNC_SLOTS_PERSIST:-0}" == '1' ]] ||
+          ! grep -Fxq "$simulated_tablesync_slot" "$SLOT_DROP_NAME_LOG"; then
+          printf '%s\n' "$simulated_tablesync_slot"
+        fi
+      done
+    fi
+    ;;
   *'FROM pg_replication_slots'*)
-    # The contract probes only run once the slot is known to exist, so they
-    # always answer "matches"; the count probes track the simulated drop.
+    # Keep this arm last of the four: it matches every slot query, and the three
+    # above are the specific ones. The contract probes only run once the slot is
+    # known to exist, so they always answer "matches"; the count probes track the
+    # simulated drop.
     if [[ "$sql" == *'count(*) = 1'* ]]; then
       printf 't\n'
     elif [[ "${FAKE_SLOT_EXISTS:-0}" == '1' && ! -f "$SLOT_DROPPED_MARKER" ]]; then
@@ -658,6 +766,370 @@ assert_absent 'source:sec\ret' "$ARGUMENT_LOG" "$ERROR_LOG"
 assert_absent 'target-secret' "$ARGUMENT_LOG" "$ERROR_LOG"
 assert_absent 'publisher-secret' "$ARGUMENT_LOG" "$ERROR_LOG"
 
+# The remaining teardown cases all start from the same object state -- subscription,
+# publication and slot all present -- and vary only the simulated pg_subscription
+# row. Reset the drop markers so each run meets that state again.
+reset_replication_object_state() {
+  rm -f "$SUBSCRIPTION_DROPPED_MARKER" "$PUBLICATION_DROPPED_MARKER" "$SLOT_DROPPED_MARKER"
+  : >"$REPLICATION_OBJECT_LOG"
+  : >"$ROLE_STATEMENT_LOG"
+  : >"$SLOT_DROP_NAME_LOG"
+}
+
+# Every refusal is asserted twice: teardown has to exit non-zero *and* say why.
+# A bare "expected this to fail" would also pass if the helper were missing and
+# bash exited 127 without ever reading the catalog.
+assert_teardown_refuses() {
+  local expected_message="$1"
+  reset_replication_object_state
+  if run_teardown >"$ERROR_LOG" 2>&1; then
+    printf 'Expected teardown to refuse this subscription: %s\n' "$expected_message" >&2
+    exit 1
+  fi
+  grep -Fq "$expected_message" "$ERROR_LOG" || {
+    cat "$ERROR_LOG" >&2
+    printf 'Teardown refused for the wrong reason; expected: %s\n' "$expected_message" >&2
+    exit 1
+  }
+  if [[ -s "$REPLICATION_OBJECT_LOG" ]]; then
+    cat "$REPLICATION_OBJECT_LOG" >&2
+    printf 'Teardown dropped a replication object before refusing.\n' >&2
+    exit 1
+  fi
+}
+
+assert_teardown_cleared_every_replication_object() {
+  local failure_note="$1"
+  local expected_statement
+  for expected_statement in 'DROP SUBSCRIPTION boardsesh_pg18_sub;' 'pg_drop_replication_slot' \
+    'DROP PUBLICATION boardsesh_pg18_migration'; do
+    grep -Fq "$expected_statement" "$REPLICATION_OBJECT_LOG" || {
+      cat "$ERROR_LOG" "$REPLICATION_OBJECT_LOG" >&2
+      printf '%s: %s was never issued.\n' "$failure_note" "$expected_statement" >&2
+      exit 1
+    }
+  done
+}
+
+# 8. Issue #4513. DROP SUBSCRIPTION has to reach the publisher to drop the remote
+# slot, so the publisher outage that sent the operator to teardown commits the
+# DISABLE and fails the DROP. The next run meets a disabled subscription and has
+# to finish the job rather than refuse on subenabled while the source fills.
+reset_replication_object_state
+FAKE_SUBSCRIPTION_EXISTS=1 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=1 \
+  FAKE_SUBSCRIPTION_ENABLED=f \
+  run_teardown >"$ERROR_LOG" 2>&1 || {
+  cat "$ERROR_LOG" >&2
+  printf 'Expected teardown to drop a disabled subscription.\n' >&2
+  exit 1
+}
+assert_teardown_cleared_every_replication_object 'Teardown of a disabled subscription'
+
+# The drop disables, then detaches, then drops, in that order: a detached
+# DROP SUBSCRIPTION never contacts the unreachable publisher, and PostgreSQL
+# only accepts slot_name = NONE while the subscription is disabled.
+teardown_subscription_statements="$(tr '\n' ' ' <"$REPLICATION_OBJECT_LOG" | tr -s ' ')"
+[[ "$teardown_subscription_statements" == *'ALTER SUBSCRIPTION boardsesh_pg18_sub DISABLE; ALTER SUBSCRIPTION boardsesh_pg18_sub SET (slot_name = NONE); DROP SUBSCRIPTION boardsesh_pg18_sub;'* ]] || {
+  cat "$REPLICATION_OBJECT_LOG" >&2
+  printf 'Teardown did not disable, detach, then drop the subscription in that order.\n' >&2
+  exit 1
+}
+
+# 9. The same run interrupted one statement later: SET (slot_name = NONE)
+# committed, the DROP did not, so subslotname is NULL. The slot is still on the
+# source, still retaining WAL, and teardown owns removing it.
+reset_replication_object_state
+FAKE_SUBSCRIPTION_EXISTS=1 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=1 \
+  FAKE_SUBSCRIPTION_ENABLED=f FAKE_SUBSCRIPTION_SLOT_NAME='' \
+  run_teardown >"$ERROR_LOG" 2>&1 || {
+  cat "$ERROR_LOG" >&2
+  printf 'Expected teardown to drop a subscription whose slot is already detached.\n' >&2
+  exit 1
+}
+assert_teardown_cleared_every_replication_object 'Teardown of a detached subscription'
+
+# 10. Detached, and the orphan slot already dropped by hand during the emergency.
+# The subscription and publication still have to go.
+reset_replication_object_state
+FAKE_SUBSCRIPTION_EXISTS=1 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=0 \
+  FAKE_SUBSCRIPTION_ENABLED=f FAKE_SUBSCRIPTION_SLOT_NAME='' \
+  run_teardown >"$ERROR_LOG" 2>&1 || {
+  cat "$ERROR_LOG" >&2
+  printf 'Expected teardown to finish once the detached subscription lost its slot.\n' >&2
+  exit 1
+}
+grep -Fq 'DROP SUBSCRIPTION boardsesh_pg18_sub;' "$REPLICATION_OBJECT_LOG" || {
+  cat "$ERROR_LOG" "$REPLICATION_OBJECT_LOG" >&2
+  printf 'Teardown left a detached subscription in place.\n' >&2
+  exit 1
+}
+grep -Fq 'DROP PUBLICATION boardsesh_pg18_migration' "$REPLICATION_OBJECT_LOG" || {
+  cat "$ERROR_LOG" "$REPLICATION_OBJECT_LOG" >&2
+  printf 'Teardown left the source publication in place.\n' >&2
+  exit 1
+}
+
+# 11. The same missing slot with the subscription still attached to it is not the
+# resumable case; it means these names do not describe one migration. The
+# detached exception above must not have weakened that.
+FAKE_SUBSCRIPTION_EXISTS=1 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=0 \
+  assert_teardown_refuses 'exists without source slot boardsesh_pg18_migration; refusing teardown'
+
+# 12. Identity still has to be proven. Relaxing subenabled and subslotname leaves
+# subname, subowner, subpublications, the conninfo digest and the digest comment
+# carrying it, so a same-named subscription that fails any of them is refused --
+# and refused whether it is enabled, disabled, or already detached.
+readonly SUBSCRIPTION_CONTRACT_REFUSAL='does not match the exact owner/options/publication/slot/canonical connection contract'
+for simulated_slot_state in boardsesh_pg18_migration ''; do
+  for simulated_enabled_state in t f; do
+    FAKE_SUBSCRIPTION_EXISTS=1 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=1 \
+      FAKE_SUBSCRIPTION_SLOT_NAME="$simulated_slot_state" \
+      FAKE_SUBSCRIPTION_ENABLED="$simulated_enabled_state" \
+      FAKE_SUBSCRIPTION_OWNER=somebody_elses_role \
+      assert_teardown_refuses "$SUBSCRIPTION_CONTRACT_REFUSAL"
+    FAKE_SUBSCRIPTION_EXISTS=1 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=1 \
+      FAKE_SUBSCRIPTION_SLOT_NAME="$simulated_slot_state" \
+      FAKE_SUBSCRIPTION_ENABLED="$simulated_enabled_state" \
+      FAKE_SUBSCRIPTION_PUBLICATION=somebody_elses_publication \
+      assert_teardown_refuses "$SUBSCRIPTION_CONTRACT_REFUSAL"
+    FAKE_SUBSCRIPTION_EXISTS=1 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=1 \
+      FAKE_SUBSCRIPTION_SLOT_NAME="$simulated_slot_state" \
+      FAKE_SUBSCRIPTION_ENABLED="$simulated_enabled_state" \
+      FAKE_SUBSCRIPTION_CONNINFO_MATCHES=f \
+      assert_teardown_refuses "$SUBSCRIPTION_CONTRACT_REFUSAL"
+  done
+done
+
+# A subscription pointing at some other slot is not detached, and the OR that
+# admits NULL must not have turned into "any slot name will do".
+FAKE_SUBSCRIPTION_EXISTS=1 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=1 \
+  FAKE_SUBSCRIPTION_SLOT_NAME=somebody_elses_slot \
+  assert_teardown_refuses "$SUBSCRIPTION_CONTRACT_REFUSAL"
+
+# 13. Only teardown asked for the relaxation. status, setup and sync-sequences
+# read a subscription they expect to be replicating, and a disabled or detached
+# one means the migration is not in the state they are about to report on.
+run_status() {
+  PATH="$FAKE_BIN:$PATH" \
+    NEON_DATABASE_URL='postgresql://source%3Auser:source%3Asec%5Cret@[2001:db8::1]/main%3Adb?sslmode=verify-full&application_name=argv-test' \
+    RAILWAY_DATABASE_URL='postgresql://target:target-secret@target.example:5432/main?sslmode=verify-full&application_name=argv-test' \
+    NEON_REPLICATION_DATABASE_URL='postgresql://publisher:publisher-secret@source.example:5432/main?sslmode=verify-full&application_name=boardsesh_pg18_sub' \
+    TARGET_OWNER_ROLE=boardsesh_owner \
+    TARGET_MIGRATOR_ROLE=boardsesh_migrator \
+    TARGET_SUBSCRIBER_ROLE=boardsesh_pg18_subscriber \
+    TARGET_RUNTIME_ROLE=boardsesh_runtime \
+    TARGET_RUNTIME_SCHEMAS=public \
+    SOURCE_DATABASE_NAME=main \
+    TARGET_DATABASE_NAME=main \
+    CHECK_TABLES=example \
+    bash "$PWD/scripts/postgres-logical-replication.sh" status
+}
+
+# The control run proves the case below fails on the simulated row rather than on
+# a status command that was already broken.
+run_status >"$ERROR_LOG" 2>&1 || {
+  cat "$ERROR_LOG" >&2
+  printf 'Expected status to accept an enabled subscription with its slot attached.\n' >&2
+  exit 1
+}
+
+for rejected_subscription_state in disabled detached; do
+  case "$rejected_subscription_state" in
+    disabled) simulated_enabled_state=f simulated_slot_state=boardsesh_pg18_migration ;;
+    detached) simulated_enabled_state=t simulated_slot_state='' ;;
+  esac
+  if FAKE_SUBSCRIPTION_ENABLED="$simulated_enabled_state" \
+    FAKE_SUBSCRIPTION_SLOT_NAME="$simulated_slot_state" \
+    run_status >"$ERROR_LOG" 2>&1; then
+    printf 'Expected status to reject a %s subscription.\n' "$rejected_subscription_state" >&2
+    exit 1
+  fi
+  grep -Fq "$SUBSCRIPTION_CONTRACT_REFUSAL" "$ERROR_LOG" || {
+    cat "$ERROR_LOG" >&2
+    printf 'status rejected the %s subscription for the wrong reason.\n' "$rejected_subscription_state" >&2
+    exit 1
+  }
+done
+
+# 14. Detaching the slot means DROP SUBSCRIPTION never contacts the publisher, so
+# it no longer cleans up after an unfinished initial copy either. One
+# table-synchronization slot per unsynchronized table is left holding WAL with
+# nothing but this sweep to remove it. The fake answers only when the helper
+# passes the subscription OID it read before the drop, so this also pins that the
+# sweep is aimed at this migration's subscription rather than at a wildcard.
+reset_replication_object_state
+FAKE_SUBSCRIPTION_EXISTS=1 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=1 \
+  FAKE_SUBSCRIPTION_OID=24680 \
+  FAKE_TABLESYNC_SLOTS='pg_24680_sync_16400_74921 pg_24680_sync_16401_74921' \
+  run_teardown >"$ERROR_LOG" 2>&1 || {
+  cat "$ERROR_LOG" >&2
+  printf 'Expected teardown to sweep the stranded table-synchronization slots.\n' >&2
+  exit 1
+}
+assert_teardown_cleared_every_replication_object 'Teardown with stranded sync slots'
+for expected_dropped_slot in boardsesh_pg18_migration pg_24680_sync_16400_74921 pg_24680_sync_16401_74921; do
+  grep -Fxq "$expected_dropped_slot" "$SLOT_DROP_NAME_LOG" || {
+    cat "$ERROR_LOG" "$SLOT_DROP_NAME_LOG" >&2
+    printf 'Teardown left %s retaining WAL on the source.\n' "$expected_dropped_slot" >&2
+    exit 1
+  }
+done
+
+# 15. A sync slot that survives the sweep means the source is still filling, so
+# teardown has to say so instead of exiting clean. A silent all-clear over a
+# retained slot is the failure #4513 is about.
+reset_replication_object_state
+if FAKE_SUBSCRIPTION_EXISTS=1 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=1 \
+  FAKE_SUBSCRIPTION_OID=24680 \
+  FAKE_TABLESYNC_SLOTS='pg_24680_sync_16400_74921' FAKE_TABLESYNC_SLOTS_PERSIST=1 \
+  run_teardown >"$ERROR_LOG" 2>&1; then
+  printf 'Expected teardown to fail on a table-synchronization slot it could not remove.\n' >&2
+  exit 1
+fi
+grep -Fq 'still exist after teardown and keep retaining WAL' "$ERROR_LOG" || {
+  cat "$ERROR_LOG" >&2
+  printf 'Teardown failed for the wrong reason on an unremovable sync slot.\n' >&2
+  exit 1
+}
+
+# 16. The publisher releases a slot only once its walsender notices the closed
+# connection, so teardown waits. Budget exhausted, it must stop with the catalog
+# untouched -- and name the walsender, because the operator's next move is to
+# wait, not to go hunting for a contract mismatch.
+reset_replication_object_state
+if FAKE_SUBSCRIPTION_EXISTS=1 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=1 \
+  FAKE_SLOT_RELEASE_STATE=held SOURCE_SLOT_RELEASE_SECONDS=0 \
+  run_teardown >"$ERROR_LOG" 2>&1; then
+  printf 'Expected teardown to stop while a walsender still held the source slot.\n' >&2
+  exit 1
+fi
+grep -Fq 'is still held by an active walsender' "$ERROR_LOG" || {
+  cat "$ERROR_LOG" >&2
+  printf 'Teardown failed for the wrong reason while the slot was held.\n' >&2
+  exit 1
+}
+if [[ -s "$SLOT_DROP_NAME_LOG" ]]; then
+  cat "$SLOT_DROP_NAME_LOG" >&2
+  printf 'Teardown dropped a slot that was still held by a walsender.\n' >&2
+  exit 1
+fi
+
+# 17. The same poll must not confuse "already gone" with "still held". A second
+# operator dropping the slot mid-wait is the outcome teardown wanted; spending
+# the whole budget and then blaming a walsender that is not there sends the next
+# responder after the wrong thing.
+reset_replication_object_state
+FAKE_SUBSCRIPTION_EXISTS=1 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=1 \
+  FAKE_SLOT_RELEASE_STATE=gone SOURCE_SLOT_RELEASE_SECONDS=0 \
+  run_teardown >"$ERROR_LOG" 2>&1 || {
+  cat "$ERROR_LOG" >&2
+  printf 'Expected teardown to finish when the source slot vanished mid-wait.\n' >&2
+  exit 1
+}
+grep -Fq "Source slot 'boardsesh_pg18_migration' was already gone" "$ERROR_LOG" || {
+  cat "$ERROR_LOG" >&2
+  printf 'Teardown did not report the slot as already gone.\n' >&2
+  exit 1
+}
+grep -Fq 'DROP SUBSCRIPTION boardsesh_pg18_sub;' "$REPLICATION_OBJECT_LOG"
+grep -Fq 'DROP PUBLICATION boardsesh_pg18_migration' "$REPLICATION_OBJECT_LOG"
+if [[ -s "$SLOT_DROP_NAME_LOG" ]]; then
+  cat "$SLOT_DROP_NAME_LOG" >&2
+  printf 'Teardown dropped a slot that was already gone.\n' >&2
+  exit 1
+fi
+
+# 18. The state a budget-exhausted run leaves for its own re-run: subscription
+# already dropped, our walsender still attached to the slot for as long as the
+# source's wal_sender_timeout. The pre-mutation slot contract has to read that as
+# "wait", not as "this slot is not yours".
+reset_replication_object_state
+FAKE_SUBSCRIPTION_EXISTS=0 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=1 \
+  FAKE_SLOT_ACTIVE=1 \
+  run_teardown >"$ERROR_LOG" 2>&1 || {
+  cat "$ERROR_LOG" >&2
+  printf 'Expected the re-run after an exhausted release budget to finish the slot.\n' >&2
+  exit 1
+}
+grep -Fxq 'boardsesh_pg18_migration' "$SLOT_DROP_NAME_LOG" || {
+  cat "$ERROR_LOG" "$SLOT_DROP_NAME_LOG" >&2
+  printf 'The re-run left the WAL-retaining slot in place.\n' >&2
+  exit 1
+}
+
+# ...and that tolerance is still attribution-gated. An active slot held by
+# anything that does not announce itself as this subscription is refused, with or
+# without a subscription left to compare it against.
+for simulated_subscription_presence in 0 1; do
+  reset_replication_object_state
+  if FAKE_SUBSCRIPTION_EXISTS="$simulated_subscription_presence" FAKE_PUBLICATION_EXISTS=1 \
+    FAKE_SLOT_EXISTS=1 FAKE_SLOT_ACTIVE=foreign \
+    run_teardown >"$ERROR_LOG" 2>&1; then
+    printf 'Expected teardown to refuse a source slot held by a foreign walsender.\n' >&2
+    exit 1
+  fi
+  grep -Fq 'does not match the exact logical pgoutput/current-database/subscription contract' "$ERROR_LOG" || {
+    cat "$ERROR_LOG" >&2
+    printf 'Teardown refused the foreign-walsender slot for the wrong reason.\n' >&2
+    exit 1
+  }
+  if [[ -s "$REPLICATION_OBJECT_LOG" ]]; then
+    cat "$REPLICATION_OBJECT_LOG" >&2
+    printf 'Teardown dropped a replication object before refusing a foreign walsender.\n' >&2
+    exit 1
+  fi
+done
+
+# 19. A run that dies on the walsender wait has already dropped the subscription,
+# so its re-run has no OID left to attribute sync slots with. Teardown will not
+# drop what it cannot attribute -- another subscriber on this source database
+# makes identical-looking names -- but exiting clean without mentioning them
+# would hide exactly the WAL retention this whole change is about.
+reset_replication_object_state
+FAKE_SUBSCRIPTION_EXISTS=0 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=0 \
+  FAKE_UNATTRIBUTED_TABLESYNC_SLOTS='pg_31337_sync_16400_74921' \
+  run_teardown >"$ERROR_LOG" 2>&1 || {
+  cat "$ERROR_LOG" >&2
+  printf 'Expected teardown to finish over sync slots it cannot attribute.\n' >&2
+  exit 1
+}
+grep -Fq 'cannot attribute to any subscription' "$ERROR_LOG" || {
+  cat "$ERROR_LOG" >&2
+  printf 'Teardown said nothing about the unattributable sync slots it left retaining WAL.\n' >&2
+  exit 1
+}
+grep -Fq 'pg_31337_sync_16400_74921' "$ERROR_LOG" || {
+  cat "$ERROR_LOG" >&2
+  printf 'Teardown did not name the sync slots it left behind.\n' >&2
+  exit 1
+}
+if [[ -s "$SLOT_DROP_NAME_LOG" ]]; then
+  cat "$SLOT_DROP_NAME_LOG" >&2
+  printf 'Teardown dropped a slot it could not attribute to this migration.\n' >&2
+  exit 1
+fi
+
+# The same run with nothing stranded must stay quiet, or the warning is noise
+# every operator learns to scroll past.
+reset_replication_object_state
+FAKE_SUBSCRIPTION_EXISTS=0 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=0 \
+  run_teardown >"$ERROR_LOG" 2>&1 || {
+  cat "$ERROR_LOG" >&2
+  printf 'Expected a teardown with nothing stranded to succeed.\n' >&2
+  exit 1
+}
+if grep -Fq 'cannot attribute to any subscription' "$ERROR_LOG"; then
+  cat "$ERROR_LOG" >&2
+  printf 'Teardown warned about sync slots that do not exist.\n' >&2
+  exit 1
+fi
+
+assert_absent 'source:sec\ret' "$ARGUMENT_LOG" "$ERROR_LOG"
+assert_absent 'target-secret' "$ARGUMENT_LOG" "$ERROR_LOG"
+assert_absent 'publisher-secret' "$ARGUMENT_LOG" "$ERROR_LOG"
+
 printf 'Replication helper keeps database passwords out of child argv and inherited xtrace.\n'
 printf 'Teardown drops only an exact temporary subscriber role, idempotently.\n'
 printf 'Teardown clears an orphan slot and publication without the role variables.\n'
+printf 'Teardown drops a disabled or slot-detached subscription without weakening its identity contract.\n'
+printf 'Teardown clears the sync slots a detached drop leaves behind, and waits out the publisher walsender.\n'

--- a/scripts/postgres-logical-replication.test.sh
+++ b/scripts/postgres-logical-replication.test.sh
@@ -19,6 +19,9 @@ trap cleanup_test_root EXIT
 
 readonly FAKE_BIN="$TEST_ROOT/bin"
 readonly ARGUMENT_LOG="$TEST_ROOT/arguments.log"
+# The slice of ARGUMENT_LOG one run appended, so a case can assert on the SQL
+# that run emitted without truncating the log the password-leak checks read.
+readonly STATUS_ARGUMENT_LOG="$TEST_ROOT/status-arguments.log"
 readonly CLEANUP_PATH_LOG="$TEST_ROOT/cleanup-path.log"
 readonly SUBSCRIPTION_FILE_CHECK="$TEST_ROOT/subscription-file-checked"
 readonly HYPOPG_CREATE_MARKER="$TEST_ROOT/hypopg-created"
@@ -120,6 +123,12 @@ esac
 sql=''
 previous_argument=''
 expect_sql=false
+# Set once a --file argument is seen. The helper's only stdin-less, -c-less psql
+# calls are the --file ones, and for those the SQL is on disk, not on stdin;
+# reading stdin anyway blocks until EOF, so a caller that leaves an open pipe
+# there (a CI wrapper, an agent harness) wedges this whole suite on its first
+# --file call instead of running it.
+saw_file_argument=false
 # Real psql substitutes :'name' server-side, so the captured statement text never
 # carries the value. Keep the two the helper varies per call.
 psql_variable_slot_name=''
@@ -138,6 +147,7 @@ for argument in "$@"; do
     esac
   fi
   if [[ "$previous_argument" == '--file' || "$previous_argument" == '-f' ]]; then
+    saw_file_argument=true
     [[ -f "$argument" ]]
     [[ "$(stat -c '%a' "$argument" 2>/dev/null || stat -f '%Lp' "$argument")" == '600' ]]
     if grep -Fq 'CREATE SUBSCRIPTION' "$argument"; then
@@ -149,7 +159,9 @@ for argument in "$@"; do
   fi
   previous_argument="$argument"
 done
-if [[ -z "$sql" && ! -t 0 ]]; then
+# Heredoc SQL arrives on stdin, so it still has to be read -- but only when this
+# call had no other source for it. See saw_file_argument above.
+if [[ -z "$sql" && "$saw_file_argument" == false && ! -t 0 ]]; then
   sql="$(</dev/stdin)"
 fi
 if [[ "$sql" == *'CREATE EXTENSION IF NOT EXISTS hypopg'* ]]; then
@@ -251,6 +263,14 @@ case "$sql" in
     else
       [[ "$sql" == *'subscription.subslotname IS NULL'* ]] || contract_verdict=f
     fi
+    # subname is simulated by nothing at all -- every arm here answers for the
+    # one subscription this suite knows about -- so `WHERE subscription.subname
+    # = '...'` could become `WHERE true` and each remaining predicate would go on
+    # matching the same simulated row. It is the first of the five predicates no
+    # caller may relax, and the one that keeps the contract about this
+    # migration's subscription rather than about whatever single subscription
+    # happens to be on the target.
+    [[ "$sql" == *"subscription.subname = 'boardsesh_pg18_sub'"* ]] || contract_verdict=f
     [[ "$sql" == *"pg_get_userbyid(subscription.subowner) = '${FAKE_SUBSCRIPTION_OWNER:-boardsesh_pg18_subscriber}'"* ]] ||
       contract_verdict=f
     [[ "$sql" == *"subscription.subpublications = ARRAY['${FAKE_SUBSCRIPTION_PUBLICATION:-boardsesh_pg18_migration}']::text[]"* ]] ||
@@ -999,12 +1019,37 @@ run_status() {
 }
 
 # The control run proves the case below fails on the simulated row rather than on
-# a status command that was already broken.
+# a status command that was already broken. Note where the argv log had reached
+# first: the assertions after it must read only what this one run emitted, and
+# truncating instead would drop the teardown runs above out of the password-leak
+# check at the end of the file.
+status_argv_offset="$(wc -c <"$ARGUMENT_LOG")"
 run_status >"$ERROR_LOG" 2>&1 || {
   cat "$ERROR_LOG" >&2
   printf 'Expected status to accept an enabled subscription with its slot attached.\n' >&2
   exit 1
 }
+tail -c "+$((status_argv_offset + 1))" "$ARGUMENT_LOG" >"$STATUS_ARGUMENT_LOG"
+
+# Read the strict contract's slot predicate out of the SQL that run actually
+# emitted, instead of only inferring it from simulated rows. No simulated row can
+# see this axis on its own: real PostgreSQL refuses ALTER SUBSCRIPTION ... ENABLE
+# on a subscription with no slot name ("cannot enable subscription that does not
+# have a slot name"), so enabled-with-a-NULL-slot is unreachable and there is no
+# catalog shape the strict slot predicate is the only thing to reject. Without
+# these two lines, widening the strict `local slot_predicate=` to teardown's
+# `OR ... IS NULL` form -- every caller quietly helping itself to the relaxation
+# #4513 gave teardown alone -- leaves this whole suite green.
+grep -Fq "AND subscription.subslotname = 'boardsesh_pg18_migration'" "$STATUS_ARGUMENT_LOG" || {
+  cat "$STATUS_ARGUMENT_LOG" >&2
+  printf 'status stopped demanding the migration slot by name.\n' >&2
+  exit 1
+}
+if grep -Fq 'subslotname IS NULL' "$STATUS_ARGUMENT_LOG"; then
+  cat "$STATUS_ARGUMENT_LOG" >&2
+  printf 'status adopted the detached-subscription relaxation meant for teardown.\n' >&2
+  exit 1
+fi
 
 # Three simulated rows, each pinning a different piece of what the strict
 # contract still demands. The middle one is the state teardown actually
@@ -1013,7 +1058,8 @@ run_status >"$ERROR_LOG" 2>&1 || {
 # Enabled-with-a-NULL-slot is not a shape this script can leave behind, and
 # pinning status against a state nothing produces would prove nothing about the
 # real half-finished run -- so the third case carries the slot predicate on its
-# own instead, with a subscription that names somebody else's slot.
+# own instead, with a subscription that names somebody else's slot, and the NULL
+# half is held by the text check above.
 for rejected_subscription_state in disabled disabled-and-detached pointed-elsewhere; do
   case "$rejected_subscription_state" in
     disabled) simulated_enabled_state=f simulated_slot_state=boardsesh_pg18_migration ;;
@@ -1273,6 +1319,36 @@ if [[ -e "$PUBLICATION_DROPPED_MARKER" ]]; then
   exit 1
 fi
 
+# 22. The budget is read as a bash integer, and bash reads a leading zero as
+# octal. SOURCE_SLOT_RELEASE_SECONDS=060 is exactly what an operator types when
+# they mean a minute; unchecked it is 48 seconds, and 08 is an arithmetic error
+# the poll's `|| break` launders into an immediate "budget spent". Neither may
+# reach the catalog: the run has to stop at the argument, before it touches
+# anything, because the exhaustion message names the total that was asked for.
+# An empty value is not in this list: SOURCE_SLOT_RELEASE_SECONDS is read with
+# ${...:-60}, so unset and empty both mean the documented default.
+for malformed_release_budget in 060 08 1.5 sixty -1 ' 60'; do
+  reset_replication_object_state
+  if FAKE_SUBSCRIPTION_EXISTS=1 FAKE_PUBLICATION_EXISTS=1 FAKE_SLOT_EXISTS=1 \
+    SOURCE_SLOT_RELEASE_SECONDS="$malformed_release_budget" \
+    run_teardown >"$ERROR_LOG" 2>&1; then
+    printf 'Teardown accepted SOURCE_SLOT_RELEASE_SECONDS=%s.\n' "$malformed_release_budget" >&2
+    exit 1
+  fi
+  grep -Fq 'SOURCE_SLOT_RELEASE_SECONDS must be a whole number of seconds' "$ERROR_LOG" || {
+    cat "$ERROR_LOG" >&2
+    printf 'Teardown rejected SOURCE_SLOT_RELEASE_SECONDS=%s for the wrong reason.\n' "$malformed_release_budget" >&2
+    exit 1
+  }
+  # Refused at the argument, so nothing was dropped on the way to finding out.
+  if [[ -e "$SUBSCRIPTION_DROPPED_MARKER" || -e "$SLOT_DROPPED_MARKER" ||
+    -e "$PUBLICATION_DROPPED_MARKER" ]]; then
+    printf 'Teardown started work before rejecting SOURCE_SLOT_RELEASE_SECONDS=%s.\n' \
+      "$malformed_release_budget" >&2
+    exit 1
+  fi
+done
+
 assert_absent 'source:sec\ret' "$ARGUMENT_LOG" "$ERROR_LOG"
 assert_absent 'target-secret' "$ARGUMENT_LOG" "$ERROR_LOG"
 assert_absent 'publisher-secret' "$ARGUMENT_LOG" "$ERROR_LOG"
@@ -1283,3 +1359,4 @@ printf 'Teardown clears an orphan slot and publication without the role variable
 printf 'Teardown drops a disabled or slot-detached subscription without weakening its identity contract.\n'
 printf 'Teardown clears the sync slots a detached drop leaves behind, and waits out the publisher walsender.\n'
 printf 'The walsender wait is one budget for the run, and every slot drop re-proves the slot before deleting it.\n'
+printf 'The walsender budget is refused unless it reads as the number of seconds it looks like.\n'


### PR DESCRIPTION
## Summary

Fixes the logical-replication teardown path used during the PostgreSQL 18 cutover:

- drops a disabled or slot-detached subscription after proving its identity;
- clears detached sync slots without broadening the deletion target;
- spends one bounded walsender wait budget across the teardown;
- refuses an all-clear when a sync slot cannot be attributed, while still finishing safe publication cleanup;
- keeps the strict subscription contract pinned by text and mutation tests.

Closes #4513.

## Stack

This is the root of the PostgreSQL 18.6 stack and targets `main` at `e852e07ad67b29893823838f3b6b38e53684826a`.

Current head: `aeb567ccf2fec238d02ee7df1e0aa3167ef90b3c`.

Merge order: **#4702 → #4703 → #4994**. #4703 adds the generated trigger-function migration; #4994 builds the PostgreSQL 18.6/PostGIS 3.6.4 producer images from both fixes.

No production service, database, Railway setting, or consumer image digest is changed by this PR.

## PostgreSQL 18.6 / PostGIS 3.6.4 evidence

Image-rehearsal downstream head `25b77248e16e2be38c2960fc8a21a2fa6c4c7749` passed; current #4994 head `2ada5e56ca589556d34f64bea022ada0bc6381ec` preserves the image inputs and adds audit-only safety corrections:

- PostgreSQL 18.6 image audit and two-host logical-migration smoke;
- seeded image with all 211 migrations, including generated migration 0210;
- seeded PostgreSQL 18.6/PostGIS 3.6.4 fresh-volume and restart smoke;
- 21/21 spatial checks from PostgreSQL 16.14/PostGIS 3.7.0dev to PostgreSQL 18.6/PostGIS 3.6.4.

`vp run test:postgres18-contract` passes directly at current #4994 head `2ada5e56ca589556d34f64bea022ada0bc6381ec`, including the reviewer follow-ups for unattributed sync slots, the zero-second shared budget, both sequence ACL discriminator guards, and all 70 fail-closed trigger-function parser cases.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 4/5 — changes emergency logical-replication teardown safeguards.
