### PR TITLE
feat: change min route playback speed to 0.1x

### DIFF
--- a/packages/backend/src/__tests__/playback-state-validation.test.ts
+++ b/packages/backend/src/__tests__/playback-state-validation.test.ts
@@ -44,7 +44,7 @@ describe('PlaybackStateInputSchema', () => {
     ['fractional frame count', { frameCount: 4.5 }],
     ['frame count above GraphQL Int maximum', { frameCount: GRAPHQL_INT_MAX + 1 }],
     ['frame index above GraphQL Int maximum', { frameIndex: GRAPHQL_INT_MAX + 1 }],
-    ['speed below the control minimum', { speed: 0.49 }],
+    ['speed below the control minimum', { speed: 0.09 }],
     ['speed above the control maximum', { speed: 10.01 }],
     ['pace below the engine floor', { paceMs: 199 }],
     ['fractional pace', { paceMs: 200.5 }],

--- a/packages/backend/src/validation/schemas/playback.ts
+++ b/packages/backend/src/validation/schemas/playback.ts
@@ -35,7 +35,7 @@ export const PlaybackStateInputSchema = z.object({
   speed: z
     .number()
     .finite('Playback speed must be finite')
-    .min(0.5, 'Playback speed must be at least 0.5×')
+    .min(0.1, 'Playback speed must be at least 0.1×')
     .max(10, 'Playback speed cannot exceed 10×'),
   paceMs: z
     .number()

--- a/packages/mobile/src/components/play-drawer/PlaybackControls.tsx
+++ b/packages/mobile/src/components/play-drawer/PlaybackControls.tsx
@@ -29,7 +29,7 @@ import { roundedReportSpeed, shouldReportSpeed } from './playback-speed-report';
 
 // Continuous range; mirrors web's effective span. 1× is the natural default and
 // gets a gentle release-magnet (see commit()).
-const MIN_SPEED = 0.5;
+const MIN_SPEED = 0.1;
 const MAX_SPEED = 10;
 const THUMB_SIZE = 20;
 const TRACK_HEIGHT = 6;

--- a/packages/mobile/src/components/play-drawer/__tests__/playback-speed-report.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/playback-speed-report.test.ts
@@ -25,16 +25,16 @@ function reportsForDrag(pixels: number[]): number[] {
 
 describe('shouldReportSpeed gate', () => {
   it('matches the displayed 0.1x-rounded speed', () => {
-    // 0.5x..10x over 300px ≈ 0.0317x/px. Endpoints are exact.
-    expect(roundedReportSpeed(0, USABLE)).toBe(0.5);
+    // 0.1x..10x over 300px = 0.033x/px. Endpoints are exact.
+    expect(roundedReportSpeed(0, USABLE)).toBe(0.1);
     expect(roundedReportSpeed(USABLE, USABLE)).toBe(10);
-    // Mid-track lands at (0.5 + 0.5 * 9.5) = 5.25; Math.round(52.5) = 53 → 5.3.
-    expect(roundedReportSpeed(USABLE / 2, USABLE)).toBe(5.3);
+    // Mid-track lands at (0.1 + 0.5 * 9.9) = 5.05; Math.round(50.5) = 51 → 5.1.
+    expect(roundedReportSpeed(USABLE / 2, USABLE)).toBe(5.1);
   });
 
   it('reports far fewer times than the frame count over a sub-pixel-per-frame drag', () => {
-    // 60 frames of 1px each = 60px of travel ≈ 1.9x. One report per 0.1x step,
-    // so ~19 reports vs 60 frames — never one per frame.
+    // 60 frames of 1px each = 60px of travel ≈ 2.0x. One report per 0.1x step,
+    // so ~20 reports vs 60 frames — never one per frame.
     const pixels = Array.from({ length: 60 }, (_, index) => index + 1);
     const reported = reportsForDrag(pixels);
 
@@ -47,7 +47,7 @@ describe('shouldReportSpeed gate', () => {
   });
 
   it('does not report when several frames stay within the same 0.1x bucket', () => {
-    // ~0.0317x/px, so a 1px nudge near the same spot can stay in one bucket.
+    // 0.033x/px, so a 1px nudge near the same spot can stay in one bucket.
     // Frames at the same px never re-report; the first reports, the rest skip.
     let lastReported = roundedReportSpeed(100, USABLE);
     const decisions = [101, 100, 100, 101].map((px) => {

--- a/packages/mobile/src/components/play-drawer/playback-speed-report.ts
+++ b/packages/mobile/src/components/play-drawer/playback-speed-report.ts
@@ -9,7 +9,7 @@
 // the rule-5 anti-pattern. The displayed label only shows 0.1× precision, so we
 // gate the hop on the 0.1-rounded speed actually changing, not on the raw frame.
 
-const MIN_SPEED = 0.5;
+const MIN_SPEED = 0.1;
 const MAX_SPEED = 10;
 
 /**


### PR DESCRIPTION
## Summary

A minimal fix to allow climb routes to be played back slower. There are better solutions long-term (per #4633), but this should at least make the playback feature usable in the meantime.

## Release Notes

<!--
The line(s) below ship to users in the mobile "What's New" screen.

Write in climber voice. Describe what the user gets, not what the feature does:
  - "Resume a session right where you left off"  (good)
  - "Added session-resume state to the queue reducer"  (too internal)

One short line per user-facing change. The first line is the headline; any extra
lines fill in the detail. Keep it to what someone would actually notice.

Nothing user-facing (refactor, CI, deps, tests)? Tick the checkbox below instead
(or add the `skip-changelog` label). Leaving this section blank fails CI.
-->

- Play back routes up to 5x slower (down to 0.1x)

## Test plan

<!-- How you verified this. Commands run, flows exercised, platforms checked. -->

- Confirmed working in the OTA preview