### PR TITLE
fix(mobile): retry and cap the playlist page drain so big smart playlists start

### DIFF
--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -121,10 +121,12 @@ export default function PlaylistDetail() {
       page,
       pageSize,
       board,
+      signal,
     }: {
       page: number;
       pageSize: number;
       board: { boardName: string; layoutId: number; sizeId: number; setIds: string; angle: number };
+      signal: AbortSignal;
     }) => {
       const input: GetPlaylistClimbsInput = {
         playlistId: playlistUuid,
@@ -136,9 +138,14 @@ export default function PlaylistDetail() {
         page,
         pageSize,
       };
+      // Object overload so the abort signal reaches fetch: leaving a playlist
+      // mid-drain must cancel the request in flight, not just stop the next one.
       const response = await getHttpClient().request<GetPlaylistClimbsQueryResponse, { input: GetPlaylistClimbsInput }>(
-        GET_PLAYLIST_CLIMBS,
-        { input },
+        {
+          document: GET_PLAYLIST_CLIMBS,
+          variables: { input },
+          signal,
+        },
       );
       return {
         climbs: toQueueClimbs(response.playlistClimbs.climbs),

--- a/packages/mobile/app/(tabs)/discover/smart/[type].tsx
+++ b/packages/mobile/app/(tabs)/discover/smart/[type].tsx
@@ -55,7 +55,17 @@ export default function SmartPlaylistDetail() {
   // Suggestion-refresh fetcher pages the smart playlist scoped to the active
   // board name so the play-drawer swipe walks the full computed list.
   const fetchPage = useCallback(
-    async ({ page, pageSize, board }: { page: number; pageSize: number; board: { boardName: string } }) => {
+    async ({
+      page,
+      pageSize,
+      board,
+      signal,
+    }: {
+      page: number;
+      pageSize: number;
+      board: { boardName: string };
+      signal: AbortSignal;
+    }) => {
       const input: GetSmartPlaylistInput = {
         type: smartType,
         userId,
@@ -63,10 +73,13 @@ export default function SmartPlaylistDetail() {
         page,
         pageSize,
       };
-      const response = await getHttpClient().request<GetSmartPlaylistQueryResponse, { input: GetSmartPlaylistInput }>(
-        GET_SMART_PLAYLIST,
-        { input },
-      );
+      // Object overload so the abort signal reaches fetch: leaving a playlist
+      // mid-drain must cancel the request in flight, not just stop the next one.
+      const response = await getHttpClient().request<GetSmartPlaylistQueryResponse, { input: GetSmartPlaylistInput }>({
+        document: GET_SMART_PLAYLIST,
+        variables: { input },
+        signal,
+      });
       return {
         climbs: toQueueClimbs(response.smartPlaylist.climbs),
         hasMore: response.smartPlaylist.hasMore,

--- a/packages/mobile/src/components/playlist/PlaylistQueueReplaceSheet.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistQueueReplaceSheet.tsx
@@ -18,8 +18,14 @@ type PlaylistQueueReplaceSheetProps = {
 // Confirmation before a playlist tap replaces the whole queue: replacing clears
 // the climbs queued after the current one, so warn first. Built on ModalSheet
 // (the shared @expo/ui native sheet wrapper) so it goes through the presentation
-// coordinator and never overlaps another native sheet. Pan-to-close is locked
-// while the replacement is in flight; the buttons drive the decision.
+// coordinator and never overlaps another native sheet.
+//
+// Cancel stays live while the replacement is in flight, and so does pan-to-close.
+// Confirming here genuinely starts the page drain, and a throttled first page can
+// now back off for the length of a server window (#4622) — locking the climber
+// into a modal for that long would read as a hung app. `onCancel` aborts the
+// in-flight drain and its sleep, so leaving is instant. Only Confirm is blocked
+// while replacing (it shows a spinner), so a double-tap can't start two drains.
 export function PlaylistQueueReplaceSheet({
   visible,
   futureQueueCount,
@@ -31,7 +37,7 @@ export function PlaylistQueueReplaceSheet({
   const { systemColors } = useTheme();
 
   return (
-    <ModalSheet visible={visible} enableDynamicSizing enablePanDownToClose={!isReplacing} onClose={onCancel}>
+    <ModalSheet visible={visible} enableDynamicSizing onClose={onCancel}>
       {/* The footerless ModalSheet wrapper composes insets.bottom onto the body
           (withSheetBottomInset), so this content only adds its own spacing. */}
       <View style={styles.content}>
@@ -51,7 +57,6 @@ export function PlaylistQueueReplaceSheet({
             variant="outlined"
             role="cancel"
             onPress={onCancel}
-            disabled={isReplacing}
             style={styles.button}
           />
           <Button

--- a/packages/mobile/src/components/playlist/__tests__/playlist-queue-replace-sheet.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-queue-replace-sheet.test.tsx
@@ -30,7 +30,9 @@ type ModalSheetMockProps = {
 // ModalSheet presents imperatively in the real app; here we render its children
 // only while `visible` and expose a synthetic close button to exercise onClose.
 vi.mock('../../ModalSheet', () => ({
-  ModalSheet: ({ children, visible, enableDynamicSizing, enablePanDownToClose, onClose }: ModalSheetMockProps) =>
+  // `enablePanDownToClose` defaults to true in the real ModalSheet, so the mock
+  // has to as well or "did this component lock the sheet?" reads backwards.
+  ModalSheet: ({ children, visible, enableDynamicSizing, enablePanDownToClose = true, onClose }: ModalSheetMockProps) =>
     visible
       ? createElement(
           'div',
@@ -141,14 +143,26 @@ describe('PlaylistQueueReplaceSheet', () => {
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
-  it('locks pan-to-close and shows loading while replacing', () => {
+  // #4622: confirming genuinely starts the page drain, and a throttled first
+  // page can now back off for the length of a server window. A locked sheet with
+  // a greyed-out Cancel for that long reads as a hung app, and `onCancel` aborts
+  // the drain and its sleep — so the way out must stay reachable.
+  it('keeps cancel and pan-to-close live while replacing', () => {
     const { container } = render(<PlaylistQueueReplaceSheet {...makeProps({ isReplacing: true })} />);
-    expect(container.querySelector('[data-sheet]')?.getAttribute('data-pan-close')).toBe('false');
-    expect(button(container, 'detail.queueReplace.cancel')?.disabled).toBe(true);
+    expect(container.querySelector('[data-sheet]')?.getAttribute('data-pan-close')).toBe('true');
+    expect(button(container, 'detail.queueReplace.cancel')?.disabled).toBeFalsy();
+    // Confirm still blocks a double-tap starting a second drain.
     expect(button(container, 'detail.queueReplace.confirm')?.getAttribute('data-loading')).toBe('true');
   });
 
-  it('allows pan-to-close only while idle', () => {
+  it('can be cancelled mid-replacement', () => {
+    const onCancel = vi.fn();
+    const { container } = render(<PlaylistQueueReplaceSheet {...makeProps({ isReplacing: true, onCancel })} />);
+    fireEvent.click(button(container, 'detail.queueReplace.cancel')!);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows pan-to-close while idle', () => {
     const { container } = render(<PlaylistQueueReplaceSheet {...makeProps()} />);
     expect(container.querySelector('[data-sheet]')?.getAttribute('data-pan-close')).toBe('true');
   });

--- a/packages/mobile/src/lib/playlists/__tests__/playlist-page-retry.test.ts
+++ b/packages/mobile/src/lib/playlists/__tests__/playlist-page-retry.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { PLAYLIST_DRAIN_MAX_TOTAL_WAIT_MS } from '@boardsesh/playlists-react';
 import {
-  shouldRetryPlaylistPage,
+  createPlaylistPageRetryPolicy,
   MAX_RATE_LIMIT_WAIT_MS,
   RATE_LIMIT_FALLBACK_WAIT_MS,
   RATE_LIMIT_JITTER_MS,
@@ -17,64 +18,96 @@ function makeClientError(message: string, extensions: Record<string, unknown>): 
   return clientError;
 }
 
+function makeRateLimited(retryAfterSeconds?: number): Error {
+  return makeClientError('Rate limit exceeded', {
+    code: 'RATE_LIMITED',
+    operation: 'smartPlaylist',
+    ...(retryAfterSeconds === undefined ? {} : { retryAfterSeconds }),
+  });
+}
+
 function makeAbortError(): Error {
   const abortError = new Error('Aborted');
   abortError.name = 'AbortError';
   return abortError;
 }
 
-describe('shouldRetryPlaylistPage', () => {
+describe('createPlaylistPageRetryPolicy', () => {
   it('honours retryAfterSeconds on a RATE_LIMITED page, then gives up', () => {
-    const rateLimited = makeClientError('Rate limit exceeded. Try again in 46 seconds.', {
-      code: 'RATE_LIMITED',
-      operation: 'smartPlaylist',
-      retryAfterSeconds: 46,
-    });
+    const policy = createPlaylistPageRetryPolicy();
+    const rateLimited = makeRateLimited(46);
 
-    const firstWaitMs = shouldRetryPlaylistPage(rateLimited, 0);
+    const firstWaitMs = policy(rateLimited, 0);
     expect(firstWaitMs).toBeGreaterThanOrEqual(46_000);
     expect(firstWaitMs).toBeLessThanOrEqual(46_000 + RATE_LIMIT_JITTER_MS);
     // One honest wait clears the whole fixed window; a second would just stall.
-    expect(shouldRetryPlaylistPage(rateLimited, 1)).toBeNull();
-  });
-
-  it('caps a rate-limit wait at the server window', () => {
-    const absurdHint = makeClientError('Rate limit exceeded. Try again in 900 seconds.', {
-      code: 'RATE_LIMITED',
-      retryAfterSeconds: 900,
-    });
-
-    const waitMs = shouldRetryPlaylistPage(absurdHint, 0);
-    expect(waitMs).toBeGreaterThanOrEqual(MAX_RATE_LIMIT_WAIT_MS);
-    expect(waitMs).toBeLessThanOrEqual(MAX_RATE_LIMIT_WAIT_MS + RATE_LIMIT_JITTER_MS);
+    expect(policy(rateLimited, 1)).toBeNull();
   });
 
   it('falls back to a short wait when the server sent no retryAfterSeconds', () => {
-    const hintless = makeClientError('Rate limit exceeded', { code: 'RATE_LIMITED' });
+    const waitMs = createPlaylistPageRetryPolicy()(makeRateLimited(), 0);
 
-    const waitMs = shouldRetryPlaylistPage(hintless, 0);
     expect(waitMs).toBeGreaterThanOrEqual(RATE_LIMIT_FALLBACK_WAIT_MS);
     expect(waitMs).toBeLessThanOrEqual(RATE_LIMIT_FALLBACK_WAIT_MS + RATE_LIMIT_JITTER_MS);
   });
 
   it('retries a transport drop twice with a short backoff', () => {
+    const policy = createPlaylistPageRetryPolicy();
     const droppedPage = new TypeError('Network request failed');
 
-    expect(shouldRetryPlaylistPage(droppedPage, 0)).toBe(400);
-    expect(shouldRetryPlaylistPage(droppedPage, 1)).toBe(1_200);
-    expect(shouldRetryPlaylistPage(droppedPage, 2)).toBeNull();
+    expect(policy(droppedPage, 0)).toBe(400);
+    expect(policy(droppedPage, 1)).toBe(1_200);
+    expect(policy(droppedPage, 2)).toBeNull();
   });
 
   it('never retries an abort', () => {
     // A cancelled activation must stop, not back off. Guards against
     // `isTransportNetworkError`'s deliberate AbortError exclusion drifting.
-    expect(shouldRetryPlaylistPage(makeAbortError(), 0)).toBeNull();
+    expect(createPlaylistPageRetryPolicy()(makeAbortError(), 0)).toBeNull();
   });
 
   it('never retries a plain GraphQL validation rejection', () => {
     // A real bug must fail fast instead of burning the climber's page budget.
     const badInput = makeClientError('Invalid playlist input', { code: 'BAD_USER_INPUT' });
 
-    expect(shouldRetryPlaylistPage(badInput, 0)).toBeNull();
+    expect(createPlaylistPageRetryPolicy()(badInput, 0)).toBeNull();
+  });
+
+  // The two classes fail for unrelated reasons. A single shared counter let one
+  // wifi blip spend the page's only rate-limit retry, so the throttle that
+  // followed gave up immediately and truncated the playlist.
+  it('keeps a separate budget per error class', () => {
+    const policy = createPlaylistPageRetryPolicy();
+
+    // A transport drop first. The `attempt` the drain passes keeps climbing,
+    // which is exactly what a shared counter would key its budget off.
+    expect(policy(new TypeError('Network request failed'), 0)).toBe(400);
+
+    // The re-send reaches the server and gets throttled. The rate-limit retry
+    // must still be available.
+    const rateLimitWaitMs = policy(makeRateLimited(46), 1);
+    expect(rateLimitWaitMs).toBeGreaterThanOrEqual(46_000);
+
+    // ...and the network budget is still where the drop left it, so the next
+    // drop gets the second network step rather than starting over or ending.
+    expect(policy(new TypeError('Network request failed'), 2)).toBe(1_200);
+    expect(policy(new TypeError('Network request failed'), 3)).toBeNull();
+    // The one rate-limit retry is genuinely spent, though.
+    expect(policy(makeRateLimited(46), 4)).toBeNull();
+  });
+
+  // A wait longer than the drain's budget is refused outright instead of being
+  // slept, so a wait that overshoots the cap silently costs the page its retry.
+  it('caps a rate-limit wait — jitter included — within the drain wait budget', () => {
+    expect(MAX_RATE_LIMIT_WAIT_MS).toBeLessThanOrEqual(PLAYLIST_DRAIN_MAX_TOTAL_WAIT_MS);
+
+    // The server emits a full-window hint whenever a throttled request lands in
+    // the first second of its aligned bucket, so this is routine traffic.
+    const fullWindowHint = createPlaylistPageRetryPolicy()(makeRateLimited(60), 0);
+    expect(fullWindowHint).toBeLessThanOrEqual(MAX_RATE_LIMIT_WAIT_MS);
+    expect(fullWindowHint).toBeGreaterThan(MAX_RATE_LIMIT_WAIT_MS - RATE_LIMIT_JITTER_MS - 1);
+
+    const absurdHint = createPlaylistPageRetryPolicy()(makeRateLimited(900), 0);
+    expect(absurdHint).toBeLessThanOrEqual(MAX_RATE_LIMIT_WAIT_MS);
   });
 });

--- a/packages/mobile/src/lib/playlists/__tests__/playlist-page-retry.test.ts
+++ b/packages/mobile/src/lib/playlists/__tests__/playlist-page-retry.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+  shouldRetryPlaylistPage,
+  MAX_RATE_LIMIT_WAIT_MS,
+  RATE_LIMIT_FALLBACK_WAIT_MS,
+  RATE_LIMIT_JITTER_MS,
+} from '../playlist-page-retry';
+
+/**
+ * graphql-request's `ClientError` shape — the drain runs over HTTP, so this is
+ * the literal object `parseRateLimitError` has to walk in production.
+ */
+function makeClientError(message: string, extensions: Record<string, unknown>): Error {
+  const clientError = new Error(message) as Error & { response: unknown };
+  clientError.name = 'ClientError';
+  clientError.response = { errors: [{ message, extensions }] };
+  return clientError;
+}
+
+function makeAbortError(): Error {
+  const abortError = new Error('Aborted');
+  abortError.name = 'AbortError';
+  return abortError;
+}
+
+describe('shouldRetryPlaylistPage', () => {
+  it('honours retryAfterSeconds on a RATE_LIMITED page, then gives up', () => {
+    const rateLimited = makeClientError('Rate limit exceeded. Try again in 46 seconds.', {
+      code: 'RATE_LIMITED',
+      operation: 'smartPlaylist',
+      retryAfterSeconds: 46,
+    });
+
+    const firstWaitMs = shouldRetryPlaylistPage(rateLimited, 0);
+    expect(firstWaitMs).toBeGreaterThanOrEqual(46_000);
+    expect(firstWaitMs).toBeLessThanOrEqual(46_000 + RATE_LIMIT_JITTER_MS);
+    // One honest wait clears the whole fixed window; a second would just stall.
+    expect(shouldRetryPlaylistPage(rateLimited, 1)).toBeNull();
+  });
+
+  it('caps a rate-limit wait at the server window', () => {
+    const absurdHint = makeClientError('Rate limit exceeded. Try again in 900 seconds.', {
+      code: 'RATE_LIMITED',
+      retryAfterSeconds: 900,
+    });
+
+    const waitMs = shouldRetryPlaylistPage(absurdHint, 0);
+    expect(waitMs).toBeGreaterThanOrEqual(MAX_RATE_LIMIT_WAIT_MS);
+    expect(waitMs).toBeLessThanOrEqual(MAX_RATE_LIMIT_WAIT_MS + RATE_LIMIT_JITTER_MS);
+  });
+
+  it('falls back to a short wait when the server sent no retryAfterSeconds', () => {
+    const hintless = makeClientError('Rate limit exceeded', { code: 'RATE_LIMITED' });
+
+    const waitMs = shouldRetryPlaylistPage(hintless, 0);
+    expect(waitMs).toBeGreaterThanOrEqual(RATE_LIMIT_FALLBACK_WAIT_MS);
+    expect(waitMs).toBeLessThanOrEqual(RATE_LIMIT_FALLBACK_WAIT_MS + RATE_LIMIT_JITTER_MS);
+  });
+
+  it('retries a transport drop twice with a short backoff', () => {
+    const droppedPage = new TypeError('Network request failed');
+
+    expect(shouldRetryPlaylistPage(droppedPage, 0)).toBe(400);
+    expect(shouldRetryPlaylistPage(droppedPage, 1)).toBe(1_200);
+    expect(shouldRetryPlaylistPage(droppedPage, 2)).toBeNull();
+  });
+
+  it('never retries an abort', () => {
+    // A cancelled activation must stop, not back off. Guards against
+    // `isTransportNetworkError`'s deliberate AbortError exclusion drifting.
+    expect(shouldRetryPlaylistPage(makeAbortError(), 0)).toBeNull();
+  });
+
+  it('never retries a plain GraphQL validation rejection', () => {
+    // A real bug must fail fast instead of burning the climber's page budget.
+    const badInput = makeClientError('Invalid playlist input', { code: 'BAD_USER_INPUT' });
+
+    expect(shouldRetryPlaylistPage(badInput, 0)).toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import type { Climb, ClimbQueueItem } from '@boardsesh/queue';
-import type { UsePlaylistClimbActivationOptions } from '@boardsesh/playlists-react';
+import type { DrainPlaylistPagesResult, UsePlaylistClimbActivationOptions } from '@boardsesh/playlists-react';
 import { usePlaylistActivation, _resetEmptyBoardFetchReportsForTests } from '../use-playlist-activation';
 
 // The shared `usePlaylistClimbActivation` is exercised by @boardsesh/playlists-react's
@@ -15,6 +15,17 @@ type ActiveBoard = { boardType: string; layoutId: number; sizeId: number; setIds
 type SuggestionSource = { playlistUuid: string; activatedClimbUuid: string; boardKey: string } | null;
 
 type QueueState = { queue: ClimbQueueItem[]; currentClimbQueueItem: ClimbQueueItem | null };
+
+type DrainArgs = {
+  fetchPage: (args: { page: number; pageSize: number; signal: AbortSignal }) => Promise<{
+    climbs: Climb[];
+    hasMore: boolean;
+  }>;
+  signal: AbortSignal;
+  pageSize: number;
+  maxPages?: number;
+  shouldRetryPage?: (error: unknown, attempt: number) => number | null;
+};
 
 const mocks = vi.hoisted(() => ({
   setCurrentClimb: vi.fn(),
@@ -32,7 +43,34 @@ const mocks = vi.hoisted(() => ({
   captured: undefined as UsePlaylistClimbActivationOptions | undefined,
   queueItemCounter: 0,
   reportHandledError: vi.fn(),
+  drain: vi.fn<(args: DrainArgs) => Promise<DrainPlaylistPagesResult>>(),
+  capturedDrainArgs: undefined as DrainArgs | undefined,
 }));
+
+/**
+ * Stand-in for the real bounded drain: pages the injected fetchPage until the
+ * server says there's no more, and reports it as a complete read. Keeps the
+ * wrapper's existing replacement cases exercising the real fetchPage plumbing;
+ * the drain's own stop reasons are covered in @boardsesh/playlists-react.
+ */
+async function drainToExhaustion(args: DrainArgs): Promise<DrainPlaylistPagesResult> {
+  const climbs: Climb[] = [];
+  let page = 0;
+  let hasMore = true;
+  while (hasMore && !args.signal.aborted) {
+    try {
+      const pageResult = await args.fetchPage({ page, pageSize: args.pageSize, signal: args.signal });
+      climbs.push(...pageResult.climbs);
+      hasMore = pageResult.hasMore;
+    } catch (error) {
+      // The real drain never throws for a page failure — it hands back what it
+      // has plus the reason, and the caller decides.
+      return { climbs, pagesFetched: page, complete: false, stoppedBy: 'error', error };
+    }
+    page += 1;
+  }
+  return { climbs, pagesFetched: page, complete: !hasMore, stoppedBy: hasMore ? 'aborted' : 'exhausted' };
+}
 
 const VIEW_ONLY_BOARD = { boardName: 'tension', layoutId: 9, sizeId: 5, setIds: '1,2', angle: 35 };
 
@@ -44,6 +82,11 @@ vi.mock('@boardsesh/playlists-react', () => ({
   fetchPlaylistSuggestionClimbs: (args: unknown) => mocks.fetchSuggestion(args),
   isAbortError: (error: unknown) => error instanceof Error && error.name === 'AbortError',
   PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE: 100,
+  PLAYLIST_QUEUE_REPLACE_MAX_PAGES: 30,
+  drainPlaylistPages: (args: DrainArgs) => {
+    mocks.capturedDrainArgs = args;
+    return mocks.drain(args);
+  },
 }));
 vi.mock('../../../providers/queue-provider', () => ({
   useQueueActions: () => ({
@@ -138,6 +181,8 @@ beforeEach(() => {
   mocks.suggestionSource = null;
   mocks.queueState = { queue: [], currentClimbQueueItem: null };
   mocks.captured = undefined;
+  mocks.capturedDrainArgs = undefined;
+  mocks.drain.mockImplementation(drainToExhaustion);
   mocks.activate.mockResolvedValue(undefined);
   mocks.queueItemCounter = 0;
   // Mirror real setQueue: it commits the new queue, so a later getQueueSnapshot
@@ -468,6 +513,11 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
     });
     expect(fetchPage).toHaveBeenCalled();
     expect(climbs.map((climb) => climb.uuid)).toEqual(['b']);
+    // The swipe-track refresh shares the queue-replacement drain's server
+    // bucket, so it gets the same bounded per-page backoff.
+    expect(mocks.fetchSuggestion).toHaveBeenCalledWith(
+      expect.objectContaining({ shouldRetryPage: expect.any(Function) }),
+    );
   });
 
   it('swallows rejections from the underlying activation (no unhandled void promise)', async () => {
@@ -799,16 +849,126 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
     it('keeps the queue unchanged and shows a toast when the full playlist fetch fails', async () => {
       const fetchPage = vi.fn().mockRejectedValue(new Error('network'));
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const tapped = makeClimb('b');
       const { result } = renderActivation(fetchPage, { replaceQueueOnActivate: true });
 
       await act(async () => {
-        await result.current.activate(makeClimb('b'));
+        await result.current.activate(tapped);
       });
 
       await waitFor(() => {
         expect(mocks.showToast).toHaveBeenCalledWith('detail.queueReplace.loadFailed', 'error');
       });
+      // Nothing landed at all, so this is still a hard failure: reported as
+      // `replace-queue`, not as a partial drain.
+      expect(mocks.reportHandledError).toHaveBeenCalledWith(expect.any(Error), {
+        tags: { source: 'playlist', op: 'replace-queue' },
+      });
+      // The seeded one-item queue is left alone — the drain never replaced it.
+      expect(mocks.setQueue).toHaveBeenCalledTimes(1);
+      expect(mocks.setQueue.mock.calls[0][0].map((item: ClimbQueueItem) => item.climb.uuid)).toEqual(['b']);
       errorSpy.mockRestore();
+    });
+
+    // #4622. The old drain was all-or-nothing: one throttled or dropped page
+    // threw away every page already fetched and the climber got an error toast
+    // instead of a queue. A partial read is a working circuit, so use it.
+    it('replaces the queue with a partial drain rather than failing the whole activation', async () => {
+      const tapped = makeClimb('b');
+      mocks.drain.mockResolvedValue({
+        climbs: [tapped, makeClimb('c')],
+        pagesFetched: 2,
+        complete: false,
+        stoppedBy: 'error',
+        error: new Error('Rate limit exceeded. Try again in 46 seconds.'),
+      });
+      const { result } = renderActivation(vi.fn(), { replaceQueueOnActivate: true });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+
+      await waitFor(() => {
+        const lastSetQueue = mocks.setQueue.mock.calls.at(-1);
+        expect(lastSetQueue?.[0].map((item: ClimbQueueItem) => item.climb.uuid)).toEqual(['b', 'c']);
+      });
+      expect(mocks.showToast).not.toHaveBeenCalled();
+      expect(mocks.reportHandledError).toHaveBeenCalledTimes(1);
+      expect(mocks.reportHandledError).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          level: 'warning',
+          tags: { source: 'playlist', op: 'replace-queue-partial' },
+          extra: expect.objectContaining({ stoppedBy: 'error', pagesFetched: 2, climbCount: 2 }),
+        }),
+      );
+    });
+
+    it('replaces the queue and reports the truncation when the drain hits its page cap', async () => {
+      const tapped = makeClimb('b');
+      mocks.drain.mockResolvedValue({
+        climbs: [tapped, makeClimb('c')],
+        pagesFetched: 30,
+        complete: false,
+        stoppedBy: 'page-cap',
+      });
+      const { result } = renderActivation(vi.fn(), { replaceQueueOnActivate: true });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+
+      await waitFor(() => {
+        const lastSetQueue = mocks.setQueue.mock.calls.at(-1);
+        expect(lastSetQueue?.[0].map((item: ClimbQueueItem) => item.climb.uuid)).toEqual(['b', 'c']);
+      });
+      expect(mocks.showToast).not.toHaveBeenCalled();
+      expect(mocks.reportHandledError).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          tags: { source: 'playlist', op: 'replace-queue-partial' },
+          extra: expect.objectContaining({ stoppedBy: 'page-cap', pagesFetched: 30 }),
+        }),
+      );
+    });
+
+    it('touches nothing and reports nothing when the drain is aborted mid-flight', async () => {
+      const tapped = makeClimb('b');
+      let cancelReplacement: () => void = () => {};
+      mocks.drain.mockImplementation(async () => {
+        // Leaving the screen (or tapping another row) aborts the replacement.
+        cancelReplacement();
+        return { climbs: [tapped, makeClimb('c')], pagesFetched: 1, complete: false, stoppedBy: 'aborted' };
+      });
+      const { result } = renderActivation(vi.fn(), { replaceQueueOnActivate: true });
+      cancelReplacement = () => result.current.queueReplaceSheet.onCancel();
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+
+      // Only the seed from the tap itself — the drained list never lands.
+      expect(mocks.setQueue).toHaveBeenCalledTimes(1);
+      expect(mocks.setQueue.mock.calls[0][0].map((item: ClimbQueueItem) => item.climb.uuid)).toEqual(['b']);
+      expect(mocks.showToast).not.toHaveBeenCalled();
+      expect(mocks.reportHandledError).not.toHaveBeenCalled();
+    });
+
+    it('drains with the shared page size, the page cap and a retry policy', async () => {
+      const tapped = makeClimb('b');
+      const fetchPage = vi.fn().mockResolvedValue({ climbs: [tapped], hasMore: false });
+      const { result } = renderActivation(fetchPage, { replaceQueueOnActivate: true });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+
+      await waitFor(() => expect(mocks.capturedDrainArgs).toBeDefined());
+      expect(mocks.capturedDrainArgs).toMatchObject({
+        pageSize: 100,
+        maxPages: 30,
+        shouldRetryPage: expect.any(Function),
+      });
     });
   });
 });

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -24,7 +24,7 @@ type DrainArgs = {
   signal: AbortSignal;
   pageSize: number;
   maxPages?: number;
-  shouldRetryPage?: (error: unknown, attempt: number) => number | null;
+  createPageRetryPolicy?: () => (error: unknown, attempt: number) => number | null;
 };
 
 const mocks = vi.hoisted(() => ({
@@ -516,7 +516,7 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
     // The swipe-track refresh shares the queue-replacement drain's server
     // bucket, so it gets the same bounded per-page backoff.
     expect(mocks.fetchSuggestion).toHaveBeenCalledWith(
-      expect.objectContaining({ shouldRetryPage: expect.any(Function) }),
+      expect.objectContaining({ createPageRetryPolicy: expect.any(Function) }),
     );
   });
 
@@ -954,6 +954,85 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
       expect(mocks.reportHandledError).not.toHaveBeenCalled();
     });
 
+    // #4622 regression. Only an `error` stop used to rethrow, so a drain that
+    // read NOTHING for any other reason fell through with `climbs = []` and
+    // committed a one-item queue — silently wiping the queue the climber had
+    // just confirmed the size of, with no toast anywhere.
+    it('leaves the queue alone and toasts when a confirmed replacement drains nothing', async () => {
+      const current = makeQueueItem('q-current', 'current');
+      const future = makeQueueItem('q-future', 'future');
+      mocks.queueState = { queue: [current, future], currentClimbQueueItem: current };
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const tapped = makeClimb('b');
+      // Page 0 came back throttled with a hint longer than the drain's whole
+      // wait budget, so not one page was ever read.
+      mocks.drain.mockResolvedValue({
+        climbs: [],
+        pagesFetched: 0,
+        complete: false,
+        stoppedBy: 'wait-budget',
+        error: new Error('Rate limit exceeded. Try again in 60 seconds.'),
+      });
+      const { result } = renderActivation(vi.fn(), {
+        replaceQueueOnActivate: true,
+        sourceId: 'playlist:wait-budget-1',
+        allClimbs: [tapped],
+      });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+      // The confirm-after-warning path is the one that never pre-seeds a queue.
+      expect(result.current.queueReplaceSheet.visible).toBe(true);
+      expect(mocks.setQueue).not.toHaveBeenCalled();
+
+      await act(async () => {
+        result.current.queueReplaceSheet.onConfirm();
+      });
+
+      await waitFor(() => {
+        expect(mocks.showToast).toHaveBeenCalledWith('detail.queueReplace.loadFailed', 'error');
+      });
+      // The climber's queue survives intact.
+      expect(mocks.setQueue).not.toHaveBeenCalled();
+      expect(mocks.reportHandledError).toHaveBeenCalledWith(expect.any(Error), {
+        tags: { source: 'playlist', op: 'replace-queue' },
+      });
+      // ...and the #3891 empty-fetch canary must not fire on a drain that never
+      // read a page — a false positive there permanently disarms the detector
+      // for this playlist for the rest of the session.
+      expect(mocks.reportHandledError).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ tags: { source: 'playlist', op: 'replace-queue-empty' } }),
+      );
+      errorSpy.mockRestore();
+    });
+
+    it('keeps the seeded queue when a tap-path drain lands zero pages on its wait budget', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const tapped = makeClimb('b');
+      mocks.drain.mockResolvedValue({
+        climbs: [],
+        pagesFetched: 0,
+        complete: false,
+        stoppedBy: 'wait-budget',
+        error: new Error('Rate limit exceeded. Try again in 60 seconds.'),
+      });
+      const { result } = renderActivation(vi.fn(), { replaceQueueOnActivate: true });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+
+      await waitFor(() => {
+        expect(mocks.showToast).toHaveBeenCalledWith('detail.queueReplace.loadFailed', 'error');
+      });
+      // Only the seed from the tap itself — never an empty replacement.
+      expect(mocks.setQueue).toHaveBeenCalledTimes(1);
+      expect(mocks.setQueue.mock.calls[0][0].map((item: ClimbQueueItem) => item.climb.uuid)).toEqual(['b']);
+      errorSpy.mockRestore();
+    });
+
     it('drains with the shared page size, the page cap and a retry policy', async () => {
       const tapped = makeClimb('b');
       const fetchPage = vi.fn().mockResolvedValue({ climbs: [tapped], hasMore: false });
@@ -967,7 +1046,7 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
       expect(mocks.capturedDrainArgs).toMatchObject({
         pageSize: 100,
         maxPages: 30,
-        shouldRetryPage: expect.any(Function),
+        createPageRetryPolicy: expect.any(Function),
       });
     });
   });

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -1008,6 +1008,26 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
       errorSpy.mockRestore();
     });
 
+    // The one zero-page stop that must NOT rethrow: `fetchAllClimbsForBoard`
+    // short-circuits to `{ pagesFetched: 0, stoppedBy: 'exhausted' }` when no
+    // board is active, and an "exhausted" read genuinely has nothing to add.
+    // Narrowing the guard to `pagesFetched === 0` would turn this into a toast.
+    it('falls through without a toast when a zero-page drain reports exhausted', async () => {
+      const tapped = makeClimb('b');
+      mocks.drain.mockResolvedValue({ climbs: [], pagesFetched: 0, complete: true, stoppedBy: 'exhausted' });
+      const { result } = renderActivation(vi.fn(), { replaceQueueOnActivate: true });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+
+      await waitFor(() => expect(mocks.setQueue).toHaveBeenCalledTimes(2));
+      // The seed, then the replacement built from the tapped climb alone.
+      expect(mocks.setQueue.mock.calls[1][0].map((item: ClimbQueueItem) => item.climb.uuid)).toEqual(['b']);
+      expect(mocks.showToast).not.toHaveBeenCalled();
+      expect(mocks.reportHandledError).not.toHaveBeenCalled();
+    });
+
     it('keeps the seeded queue when a tap-path drain lands zero pages on its wait budget', async () => {
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       const tapped = makeClimb('b');

--- a/packages/mobile/src/lib/playlists/playlist-page-retry.ts
+++ b/packages/mobile/src/lib/playlists/playlist-page-retry.ts
@@ -33,42 +33,73 @@ import type { ShouldRetryPage } from '@boardsesh/playlists-react';
  */
 export const MAX_RATE_LIMIT_RETRIES_PER_PAGE = 1;
 
+/** Spread a fleet of clients that all got the same hint off the same instant. */
+export const RATE_LIMIT_JITTER_MS = 250;
+
 /**
- * Ceiling on a single rate-limit wait. `RATE_LIMIT_WINDOW_MS` is 60s, so a
- * legitimate hint can never exceed it. Deliberately NOT the shared client's 30s
- * `RATE_LIMIT_MAX_WAIT_MS`: waking early on the 46s hints seen in production
- * would spend the one retry on a still-throttled bucket.
+ * Ceiling on a single rate-limit wait, JITTER INCLUDED. Must stay within the
+ * drain's total wait budget or the wait is refused before it is ever slept and
+ * the page loses its retry — the server emits a full-window hint whenever a
+ * throttled request lands in the first second of its aligned bucket, so that is
+ * a routine case, not a corner one. `RATE_LIMIT_WINDOW_MS` is 60s, so 60s minus
+ * the jitter head-room is still past every legitimate hint. Deliberately NOT
+ * the shared client's 30s `RATE_LIMIT_MAX_WAIT_MS`: waking early on the 46s
+ * hints seen in production would spend the one retry on a still-throttled
+ * bucket. `playlist-page-retry.test.ts` pins this at or under
+ * `PLAYLIST_DRAIN_MAX_TOTAL_WAIT_MS` so the two can't drift apart.
  */
 export const MAX_RATE_LIMIT_WAIT_MS = 60_000;
 
+/** The largest wait the policy may ask for before jitter is added on top. */
+const MAX_RATE_LIMIT_WAIT_BEFORE_JITTER_MS = MAX_RATE_LIMIT_WAIT_MS - RATE_LIMIT_JITTER_MS;
+
 /** Used when a pre-#2763 server sends a rate limit with no `retryAfterSeconds`. */
 export const RATE_LIMIT_FALLBACK_WAIT_MS = 2_000;
-
-/** Spread a fleet of clients that all got the same hint off the same instant. */
-export const RATE_LIMIT_JITTER_MS = 250;
 
 /** Two quick re-sends cover a gym-wifi to LTE handoff dropping one page. */
 export const MAX_NETWORK_RETRIES_PER_PAGE = 2;
 export const NETWORK_RETRY_WAIT_MS = [400, 1_200];
 
 /**
- * How long to wait before re-sending a failed playlist page, or `null` to give
- * up on it. `attempt` is 0 on the first failure.
+ * Builds the retry policy for ONE page: how long to wait before re-sending it,
+ * or `null` to give up on it.
+ *
+ * Each class of failure gets its OWN budget, which is why this is a factory
+ * over a closure rather than a pure function of an attempt count. The two
+ * classes fail for unrelated reasons and a shared counter lets one spend the
+ * other's retries: a wifi-to-LTE handoff dropping page 7 would otherwise
+ * consume the single rate-limit retry, so the throttle that follows gives up
+ * immediately and the climber gets a truncated playlist that one honest wait
+ * would have finished.
  */
-export const shouldRetryPlaylistPage: ShouldRetryPage = (error, attempt) => {
-  const rateLimit = parseRateLimitError(error);
-  if (rateLimit) {
-    if (attempt >= MAX_RATE_LIMIT_RETRIES_PER_PAGE) return null;
-    const hintedWaitMs = (rateLimit.retryAfterSeconds ?? 0) * 1_000;
-    const waitMs = Math.min(hintedWaitMs > 0 ? hintedWaitMs : RATE_LIMIT_FALLBACK_WAIT_MS, MAX_RATE_LIMIT_WAIT_MS);
-    return waitMs + Math.round(Math.random() * RATE_LIMIT_JITTER_MS);
-  }
-  // `isTransportNetworkError` excludes AbortError by design, so a cancelled
-  // activation is never mistaken for a flaky connection.
-  if (isTransportNetworkError(error)) {
-    if (attempt >= MAX_NETWORK_RETRIES_PER_PAGE) return null;
-    const lastWaitMs = NETWORK_RETRY_WAIT_MS[NETWORK_RETRY_WAIT_MS.length - 1] ?? 0;
-    return NETWORK_RETRY_WAIT_MS[attempt] ?? lastWaitMs;
-  }
-  return null;
-};
+export function createPlaylistPageRetryPolicy(): ShouldRetryPage {
+  let rateLimitAttempts = 0;
+  let networkAttempts = 0;
+
+  return (error) => {
+    const rateLimit = parseRateLimitError(error);
+    if (rateLimit) {
+      if (rateLimitAttempts >= MAX_RATE_LIMIT_RETRIES_PER_PAGE) return null;
+      rateLimitAttempts += 1;
+      const hintedWaitMs = (rateLimit.retryAfterSeconds ?? 0) * 1_000;
+      const waitMs = Math.min(
+        hintedWaitMs > 0 ? hintedWaitMs : RATE_LIMIT_FALLBACK_WAIT_MS,
+        MAX_RATE_LIMIT_WAIT_BEFORE_JITTER_MS,
+      );
+      // Jitter goes INSIDE the ceiling, not on top of it: a wait over the
+      // drain's budget is refused outright rather than slept, so overshooting
+      // the cap by a jitter would silently cost the page its retry.
+      return waitMs + Math.round(Math.random() * RATE_LIMIT_JITTER_MS);
+    }
+    // `isTransportNetworkError` excludes AbortError by design, so a cancelled
+    // activation is never mistaken for a flaky connection.
+    if (isTransportNetworkError(error)) {
+      if (networkAttempts >= MAX_NETWORK_RETRIES_PER_PAGE) return null;
+      const lastWaitMs = NETWORK_RETRY_WAIT_MS[NETWORK_RETRY_WAIT_MS.length - 1] ?? 0;
+      const waitMs = NETWORK_RETRY_WAIT_MS[networkAttempts] ?? lastWaitMs;
+      networkAttempts += 1;
+      return waitMs;
+    }
+    return null;
+  };
+}

--- a/packages/mobile/src/lib/playlists/playlist-page-retry.ts
+++ b/packages/mobile/src/lib/playlists/playlist-page-retry.ts
@@ -1,0 +1,74 @@
+// Retry policy for one page of a playlist drain (#4622).
+//
+// Lives on the mobile side rather than in @boardsesh/playlists-react because
+// this is where the transport error shapes are known: the shared drain injects
+// the policy so it needs no GraphQL client and no error-classification
+// dependency of its own.
+//
+// Deliberately narrow. Only two classes of rejection are worth re-sending:
+//
+//   - RATE_LIMITED, where the server is explicitly handing back a
+//     `retryAfterSeconds` and the resolver threw BEFORE doing any work
+//     (`applyRateLimit` is the first statement of the smartPlaylist resolver),
+//     so a re-send cannot double anything.
+//   - A transport drop, which never reached the server at all.
+//
+// Everything else — GraphQL validation errors, 4xx, programmer bugs — fails the
+// page immediately. Retrying those only burns the climber's per-minute budget
+// and delays the real failure.
+//
+// This is scoped to the drain on purpose. The app-wide policy is the opposite
+// (`query-provider.tsx`: never retry a RATE_LIMITED rejection), because retry is
+// only correct for requests the client itself is fanning out and can pace.
+
+import { parseRateLimitError } from '@boardsesh/graphql-client';
+import { isTransportNetworkError } from '@boardsesh/offline-sync/error-classification';
+import type { ShouldRetryPage } from '@boardsesh/playlists-react';
+
+/**
+ * One rate-limit retry per page. The backend window is a FIXED aligned 60s
+ * bucket, so its `retryAfterSeconds` hint always lands past the reset and one
+ * honest wait clears the whole budget. A second would only help if something
+ * else spent the budget while we slept.
+ */
+export const MAX_RATE_LIMIT_RETRIES_PER_PAGE = 1;
+
+/**
+ * Ceiling on a single rate-limit wait. `RATE_LIMIT_WINDOW_MS` is 60s, so a
+ * legitimate hint can never exceed it. Deliberately NOT the shared client's 30s
+ * `RATE_LIMIT_MAX_WAIT_MS`: waking early on the 46s hints seen in production
+ * would spend the one retry on a still-throttled bucket.
+ */
+export const MAX_RATE_LIMIT_WAIT_MS = 60_000;
+
+/** Used when a pre-#2763 server sends a rate limit with no `retryAfterSeconds`. */
+export const RATE_LIMIT_FALLBACK_WAIT_MS = 2_000;
+
+/** Spread a fleet of clients that all got the same hint off the same instant. */
+export const RATE_LIMIT_JITTER_MS = 250;
+
+/** Two quick re-sends cover a gym-wifi to LTE handoff dropping one page. */
+export const MAX_NETWORK_RETRIES_PER_PAGE = 2;
+export const NETWORK_RETRY_WAIT_MS = [400, 1_200];
+
+/**
+ * How long to wait before re-sending a failed playlist page, or `null` to give
+ * up on it. `attempt` is 0 on the first failure.
+ */
+export const shouldRetryPlaylistPage: ShouldRetryPage = (error, attempt) => {
+  const rateLimit = parseRateLimitError(error);
+  if (rateLimit) {
+    if (attempt >= MAX_RATE_LIMIT_RETRIES_PER_PAGE) return null;
+    const hintedWaitMs = (rateLimit.retryAfterSeconds ?? 0) * 1_000;
+    const waitMs = Math.min(hintedWaitMs > 0 ? hintedWaitMs : RATE_LIMIT_FALLBACK_WAIT_MS, MAX_RATE_LIMIT_WAIT_MS);
+    return waitMs + Math.round(Math.random() * RATE_LIMIT_JITTER_MS);
+  }
+  // `isTransportNetworkError` excludes AbortError by design, so a cancelled
+  // activation is never mistaken for a flaky connection.
+  if (isTransportNetworkError(error)) {
+    if (attempt >= MAX_NETWORK_RETRIES_PER_PAGE) return null;
+    const lastWaitMs = NETWORK_RETRY_WAIT_MS[NETWORK_RETRY_WAIT_MS.length - 1] ?? 0;
+    return NETWORK_RETRY_WAIT_MS[attempt] ?? lastWaitMs;
+  }
+  return null;
+};

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -37,7 +37,7 @@ import { climbToQueueItem } from '../climb-to-queue-item';
 import { reportHandledError } from '../error-reporting';
 import { toSchemaClimb } from '../climb-types';
 import { getPlaylistRenderBoardTarget } from './playlist-climb-render-board';
-import { shouldRetryPlaylistPage } from './playlist-page-retry';
+import { createPlaylistPageRetryPolicy } from './playlist-page-retry';
 import type { PlaylistRenderBoard } from './use-playlist-render-board';
 
 // Playlists whose board-scoped fetch has already been reported as empty this app
@@ -316,8 +316,9 @@ export function usePlaylistActivation({
         fetchPage: ({ page, pageSize, signal: pageSignal }) => fetchPage({ page, pageSize, board, signal: pageSignal }),
         // Same server bucket as the queue-replacement drain, so a throttled or
         // dropped page gets the same bounded backoff instead of killing the
-        // whole swipe-track refresh.
-        shouldRetryPage: shouldRetryPlaylistPage,
+        // whole swipe-track refresh — under the same total wait ceiling, so this
+        // fire-and-forget prefetch can't stay pending for minutes.
+        createPageRetryPolicy: createPlaylistPageRetryPolicy,
       });
     },
     [activeBoard, fetchPage],
@@ -341,7 +342,7 @@ export function usePlaylistActivation({
         signal,
         pageSize: PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
         maxPages: PLAYLIST_QUEUE_REPLACE_MAX_PAGES,
-        shouldRetryPage: shouldRetryPlaylistPage,
+        createPageRetryPolicy: createPlaylistPageRetryPolicy,
       });
     },
     [activeBoard, fetchPage],
@@ -382,12 +383,21 @@ export function usePlaylistActivation({
         let climbs = options.loadedClimbs;
         if (!climbs) {
           const drain = await fetchAllClimbsForBoard({ signal: abortController.signal });
-          // Nothing landed at all and the drain died on a rejection — that is the
-          // same failure as before, so rethrow and let the catch below toast and
-          // leave the seeded queue alone. Anything else is good enough to play.
-          if (drain.pagesFetched === 0 && drain.stoppedBy === 'error') throw drain.error;
+          // Cancelled: the climber left the playlist or tapped another climb.
+          // Write nothing, report nothing, toast nothing.
+          if (drain.stoppedBy === 'aborted') return;
+          // Nothing landed at all. Every non-`exhausted` stop reason here is a
+          // failure — a rejection, but also the wait ceiling and (in principle)
+          // a zero page cap — and committing `[]` would silently destroy the
+          // climber's whole queue down to the one tapped climb with no error
+          // anywhere. Rethrow so the catch below toasts and leaves the queue
+          // alone. `exhausted` at zero pages is the legitimate no-active-board
+          // case and must fall through.
+          if (drain.pagesFetched === 0 && drain.stoppedBy !== 'exhausted') {
+            throw drain.error ?? new Error(`Playlist queue replacement drained no pages (${drain.stoppedBy})`);
+          }
           climbs = drain.climbs;
-          if (!drain.complete && drain.stoppedBy !== 'aborted') {
+          if (!drain.complete) {
             // Silent for the climber (they got a working queue), but the page
             // cap, the rate-limit stops and the wait ceiling are all judgement
             // calls we want production numbers for before tuning them.

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -21,8 +21,11 @@ import { useTranslation } from 'react-i18next';
 import {
   usePlaylistClimbActivation,
   fetchPlaylistSuggestionClimbs,
+  drainPlaylistPages,
   isAbortError,
   PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
+  PLAYLIST_QUEUE_REPLACE_MAX_PAGES,
+  type DrainPlaylistPagesResult,
 } from '@boardsesh/playlists-react';
 import { createPlaylistSuggestionSource, getQueueBoardKey, type Climb, type ClimbQueueItem } from '@boardsesh/queue';
 import { canAddClimbToBoard } from '@boardsesh/board-config';
@@ -34,6 +37,7 @@ import { climbToQueueItem } from '../climb-to-queue-item';
 import { reportHandledError } from '../error-reporting';
 import { toSchemaClimb } from '../climb-types';
 import { getPlaylistRenderBoardTarget } from './playlist-climb-render-board';
+import { shouldRetryPlaylistPage } from './playlist-page-retry';
 import type { PlaylistRenderBoard } from './use-playlist-render-board';
 
 // Playlists whose board-scoped fetch has already been reported as empty this app
@@ -310,14 +314,21 @@ export function usePlaylistActivation({
         activatedClimbUuid,
         signal,
         fetchPage: ({ page, pageSize, signal: pageSignal }) => fetchPage({ page, pageSize, board, signal: pageSignal }),
+        // Same server bucket as the queue-replacement drain, so a throttled or
+        // dropped page gets the same bounded backoff instead of killing the
+        // whole swipe-track refresh.
+        shouldRetryPage: shouldRetryPlaylistPage,
       });
     },
     [activeBoard, fetchPage],
   );
 
+  // Reads the whole playlist for queue replacement. Bounded (30 pages), with a
+  // per-page backoff that RESUMES from the failed page and a partial result when
+  // it can't finish — see @boardsesh/playlists-react's drain for why (#4622).
   const fetchAllClimbsForBoard = useCallback(
-    async ({ signal }: { signal: AbortSignal }) => {
-      if (!activeBoard) return [];
+    async ({ signal }: { signal: AbortSignal }): Promise<DrainPlaylistPagesResult> => {
+      if (!activeBoard) return { climbs: [], pagesFetched: 0, complete: true, stoppedBy: 'exhausted' };
       const board = {
         boardName: activeBoard.boardType,
         layoutId: activeBoard.layoutId,
@@ -325,23 +336,13 @@ export function usePlaylistActivation({
         setIds: activeBoard.setIds,
         angle: activeBoard.angle,
       };
-      const climbs: Climb[] = [];
-      let page = 0;
-      let hasMore = true;
-
-      while (hasMore && !signal.aborted) {
-        const pageResult = await fetchPage({
-          page,
-          pageSize: PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
-          board,
-          signal,
-        });
-        climbs.push(...pageResult.climbs);
-        hasMore = pageResult.hasMore;
-        page += 1;
-      }
-
-      return climbs;
+      return drainPlaylistPages({
+        fetchPage: ({ page, pageSize, signal: pageSignal }) => fetchPage({ page, pageSize, board, signal: pageSignal }),
+        signal,
+        pageSize: PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
+        maxPages: PLAYLIST_QUEUE_REPLACE_MAX_PAGES,
+        shouldRetryPage: shouldRetryPlaylistPage,
+      });
     },
     [activeBoard, fetchPage],
   );
@@ -378,7 +379,30 @@ export function usePlaylistActivation({
       replacementAbortRef.current = abortController;
       setIsReplacingQueue(true);
       try {
-        const climbs = options.loadedClimbs ?? (await fetchAllClimbsForBoard({ signal: abortController.signal }));
+        let climbs = options.loadedClimbs;
+        if (!climbs) {
+          const drain = await fetchAllClimbsForBoard({ signal: abortController.signal });
+          // Nothing landed at all and the drain died on a rejection — that is the
+          // same failure as before, so rethrow and let the catch below toast and
+          // leave the seeded queue alone. Anything else is good enough to play.
+          if (drain.pagesFetched === 0 && drain.stoppedBy === 'error') throw drain.error;
+          climbs = drain.climbs;
+          if (!drain.complete && drain.stoppedBy !== 'aborted') {
+            // Silent for the climber (they got a working queue), but the page
+            // cap, the rate-limit stops and the wait ceiling are all judgement
+            // calls we want production numbers for before tuning them.
+            reportHandledError(drain.error ?? new Error('Playlist queue replacement drained partially'), {
+              level: 'warning',
+              tags: { source: 'playlist', op: 'replace-queue-partial' },
+              extra: {
+                sourceId,
+                stoppedBy: drain.stoppedBy,
+                pagesFetched: drain.pagesFetched,
+                climbCount: drain.climbs.length,
+              },
+            });
+          }
+        }
         if (abortController.signal.aborted) return;
         // Canary. A board-scoped fetch that comes back empty for a playlist the
         // detail list has already rendered climbable rows for degrades into a

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -401,16 +401,19 @@ export function usePlaylistActivation({
             // Silent for the climber (they got a working queue), but the page
             // cap, the rate-limit stops and the wait ceiling are all judgement
             // calls we want production numbers for before tuning them.
-            reportHandledError(drain.error ?? new Error('Playlist queue replacement drained partially'), {
-              level: 'warning',
-              tags: { source: 'playlist', op: 'replace-queue-partial' },
-              extra: {
-                sourceId,
-                stoppedBy: drain.stoppedBy,
-                pagesFetched: drain.pagesFetched,
-                climbCount: drain.climbs.length,
+            reportHandledError(
+              drain.error ?? new Error(`Playlist queue replacement drained partially (${drain.stoppedBy})`),
+              {
+                level: 'warning',
+                tags: { source: 'playlist', op: 'replace-queue-partial' },
+                extra: {
+                  sourceId,
+                  stoppedBy: drain.stoppedBy,
+                  pagesFetched: drain.pagesFetched,
+                  climbCount: drain.climbs.length,
+                },
               },
-            });
+            );
           }
         }
         if (abortController.signal.aborted) return;

--- a/packages/shared/playlists-react/src/__tests__/drain-playlist-pages.test.ts
+++ b/packages/shared/playlists-react/src/__tests__/drain-playlist-pages.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Climb } from '@boardsesh/queue';
+import {
+  abortableSleep,
+  drainPlaylistPages,
+  PLAYLIST_QUEUE_REPLACE_MAX_PAGES,
+  type DrainSleep,
+  type PlaylistPage,
+  type ShouldRetryPage,
+} from '../drain-playlist-pages';
+
+const PAGE_SIZE = 100;
+
+function makeClimb(uuid: string): Climb {
+  return {
+    uuid,
+    name: `Climb ${uuid}`,
+    frames: '',
+    setter_username: 'test',
+    angle: 40,
+    ascensionist_count: 0,
+    difficulty: '6a/V3',
+    quality_average: '3.0',
+    stars: 3,
+    difficulty_error: '0',
+    benchmark_difficulty: null,
+  } as unknown as Climb;
+}
+
+function makePage(pageIndex: number, count: number, hasMore: boolean): PlaylistPage {
+  return {
+    climbs: Array.from({ length: count }, (_unused, offset) => makeClimb(`p${pageIndex}-c${offset}`)),
+    hasMore,
+  };
+}
+
+/** Records every requested wait instead of burning wall-clock time. */
+function createSleepRecorder(): { sleep: DrainSleep; waits: number[] } {
+  const waits: number[] = [];
+  const sleep: DrainSleep = async (ms) => {
+    waits.push(ms);
+  };
+  return { sleep, waits };
+}
+
+function makeAbortError(): Error {
+  const abortError = new Error('aborted');
+  abortError.name = 'AbortError';
+  return abortError;
+}
+
+describe('drainPlaylistPages', () => {
+  it('drains every page and reports complete', async () => {
+    const fetchPage = vi
+      .fn<(args: { page: number }) => Promise<PlaylistPage>>()
+      .mockImplementation(async ({ page }) => makePage(page, 2, page < 2));
+
+    const result = await drainPlaylistPages({
+      fetchPage,
+      signal: new AbortController().signal,
+      pageSize: PAGE_SIZE,
+    });
+
+    expect(result.pagesFetched).toBe(3);
+    expect(result.complete).toBe(true);
+    expect(result.stoppedBy).toBe('exhausted');
+    expect(result.climbs.map((climb) => climb.uuid)).toEqual(['p0-c0', 'p0-c1', 'p1-c0', 'p1-c1', 'p2-c0', 'p2-c1']);
+  });
+
+  // Regression guard for the unbounded `while (hasMore)` loop (#4622): a
+  // playlist bigger than the server budget — or a resolver that never stops
+  // saying `hasMore` — must stop the client, not spin it.
+  it('stops at the page cap and reports it', async () => {
+    const fetchPage = vi
+      .fn<(args: { page: number }) => Promise<PlaylistPage>>()
+      .mockImplementation(async ({ page }) => makePage(page, PAGE_SIZE, true));
+
+    const result = await drainPlaylistPages({
+      fetchPage,
+      signal: new AbortController().signal,
+      pageSize: PAGE_SIZE,
+      maxPages: PLAYLIST_QUEUE_REPLACE_MAX_PAGES,
+    });
+
+    expect(fetchPage).toHaveBeenCalledTimes(30);
+    expect(result.pagesFetched).toBe(30);
+    expect(result.climbs).toHaveLength(3000);
+    expect(result.complete).toBe(false);
+    expect(result.stoppedBy).toBe('page-cap');
+  });
+
+  // THE CORE CASE. The old drain restarted at page 0 on any failure, throwing
+  // away everything already fetched and spending the server budget twice.
+  it('resumes from the failed page instead of restarting', async () => {
+    const requestedPages: number[] = [];
+    let page2Failures = 0;
+    const fetchPage = vi
+      .fn<(args: { page: number }) => Promise<PlaylistPage>>()
+      .mockImplementation(async ({ page }) => {
+        requestedPages.push(page);
+        if (page === 2 && page2Failures === 0) {
+          page2Failures += 1;
+          throw new Error('Rate limit exceeded. Try again in 5 seconds.');
+        }
+        return makePage(page, 1, page < 3);
+      });
+    const { sleep, waits } = createSleepRecorder();
+    const shouldRetryPage: ShouldRetryPage = (_error, attempt) => (attempt === 0 ? 5_000 : null);
+
+    const result = await drainPlaylistPages({
+      fetchPage,
+      signal: new AbortController().signal,
+      pageSize: PAGE_SIZE,
+      shouldRetryPage,
+      sleep,
+    });
+
+    expect(requestedPages).toEqual([0, 1, 2, 2, 3]);
+    expect(waits).toEqual([5_000]);
+    expect(result.stoppedBy).toBe('exhausted');
+    expect(result.complete).toBe(true);
+    expect(result.pagesFetched).toBe(4);
+    // Pages 0 and 1 survived the failure on page 2.
+    expect(result.climbs.map((climb) => climb.uuid)).toEqual(['p0-c0', 'p1-c0', 'p2-c0', 'p3-c0']);
+  });
+
+  it('gives up on a page after the injected policy says stop, and returns the partial', async () => {
+    const pageError = new Error('still broken');
+    const fetchPage = vi
+      .fn<(args: { page: number }) => Promise<PlaylistPage>>()
+      .mockImplementation(async ({ page }) => {
+        if (page === 2) throw pageError;
+        return makePage(page, PAGE_SIZE, true);
+      });
+    const { sleep } = createSleepRecorder();
+
+    const result = await drainPlaylistPages({
+      fetchPage,
+      signal: new AbortController().signal,
+      pageSize: PAGE_SIZE,
+      shouldRetryPage: () => null,
+      sleep,
+    });
+
+    expect(result.pagesFetched).toBe(2);
+    expect(result.climbs).toHaveLength(200);
+    expect(result.complete).toBe(false);
+    expect(result.stoppedBy).toBe('error');
+    expect(result.error).toBe(pageError);
+  });
+
+  // "Cannot hang forever": the whole drain shares one wall-clock sleep budget.
+  it('stops when the total wait budget is exhausted', async () => {
+    const pageError = new Error('Rate limit exceeded. Try again in 45 seconds.');
+    const fetchPage = vi
+      .fn<(args: { page: number }) => Promise<PlaylistPage>>()
+      .mockImplementation(async ({ page }) => {
+        if (page === 1) throw pageError;
+        return makePage(page, PAGE_SIZE, true);
+      });
+    const { sleep, waits } = createSleepRecorder();
+
+    const result = await drainPlaylistPages({
+      fetchPage,
+      signal: new AbortController().signal,
+      pageSize: PAGE_SIZE,
+      shouldRetryPage: () => 45_000,
+      sleep,
+      maxTotalWaitMs: 60_000,
+    });
+
+    // First retry fits (45s of 60s). The second asks for another 45s against a
+    // 15s remainder, so the drain stops instead of sleeping past its ceiling.
+    expect(waits).toEqual([45_000]);
+    expect(result.stoppedBy).toBe('wait-budget');
+    expect(result.complete).toBe(false);
+    expect(result.pagesFetched).toBe(1);
+    expect(result.climbs).toHaveLength(100);
+    expect(result.error).toBe(pageError);
+  });
+
+  it('returns the partial and stops issuing pages when the caller aborts mid-drain', async () => {
+    const controller = new AbortController();
+    const fetchPage = vi
+      .fn<(args: { page: number }) => Promise<PlaylistPage>>()
+      .mockImplementation(async ({ page }) => {
+        if (page === 1) controller.abort();
+        return makePage(page, 1, true);
+      });
+
+    const result = await drainPlaylistPages({
+      fetchPage,
+      signal: controller.signal,
+      pageSize: PAGE_SIZE,
+    });
+
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+    expect(result.stoppedBy).toBe('aborted');
+    expect(result.complete).toBe(false);
+    expect(result.climbs.map((climb) => climb.uuid)).toEqual(['p0-c0', 'p1-c0']);
+  });
+
+  it('never retries an AbortError from the page fetcher', async () => {
+    const shouldRetryPage = vi.fn<ShouldRetryPage>().mockReturnValue(1_000);
+    const fetchPage = vi.fn<(args: { page: number }) => Promise<PlaylistPage>>().mockRejectedValue(makeAbortError());
+    const { sleep, waits } = createSleepRecorder();
+
+    const result = await drainPlaylistPages({
+      fetchPage,
+      signal: new AbortController().signal,
+      pageSize: PAGE_SIZE,
+      shouldRetryPage,
+      sleep,
+    });
+
+    expect(shouldRetryPage).not.toHaveBeenCalled();
+    expect(waits).toEqual([]);
+    expect(result.stoppedBy).toBe('aborted');
+    expect(result.climbs).toEqual([]);
+  });
+
+  it("preserves today's fail-fast behaviour when no retry policy is injected", async () => {
+    const pageError = new Error('boom');
+    const fetchPage = vi.fn<(args: { page: number }) => Promise<PlaylistPage>>().mockRejectedValue(pageError);
+    const { sleep, waits } = createSleepRecorder();
+
+    const result = await drainPlaylistPages({
+      fetchPage,
+      signal: new AbortController().signal,
+      pageSize: PAGE_SIZE,
+      sleep,
+    });
+
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(waits).toEqual([]);
+    expect(result.stoppedBy).toBe('error');
+    expect(result.error).toBe(pageError);
+  });
+});
+
+describe('abortableSleep', () => {
+  it('settles immediately on abort instead of waiting the backoff out', async () => {
+    const controller = new AbortController();
+    const addEventListenerSpy = vi.spyOn(controller.signal, 'addEventListener');
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const startedAt = Date.now();
+
+    const pendingSleep = abortableSleep(5_000, controller.signal);
+    controller.abort();
+
+    await expect(pendingSleep).rejects.toMatchObject({ name: 'AbortError' });
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+    // `once` is what removes the listener when it fires; clearing the timer is
+    // what stops a cancelled activation leaving a 5s timeout behind.
+    expect(addEventListenerSpy).toHaveBeenCalledWith('abort', expect.any(Function), { once: true });
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+
+    addEventListenerSpy.mockRestore();
+    clearTimeoutSpy.mockRestore();
+  });
+
+  it('removes its abort listener when the wait completes normally', async () => {
+    const controller = new AbortController();
+    const removeEventListenerSpy = vi.spyOn(controller.signal, 'removeEventListener');
+
+    await abortableSleep(1, controller.signal);
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+    removeEventListenerSpy.mockRestore();
+  });
+
+  it('rejects straight away when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(abortableSleep(5_000, controller.signal)).rejects.toMatchObject({ name: 'AbortError' });
+  });
+});

--- a/packages/shared/playlists-react/src/__tests__/drain-playlist-pages.test.ts
+++ b/packages/shared/playlists-react/src/__tests__/drain-playlist-pages.test.ts
@@ -111,7 +111,7 @@ describe('drainPlaylistPages', () => {
       fetchPage,
       signal: new AbortController().signal,
       pageSize: PAGE_SIZE,
-      shouldRetryPage,
+      createPageRetryPolicy: () => shouldRetryPage,
       sleep,
     });
 
@@ -138,7 +138,7 @@ describe('drainPlaylistPages', () => {
       fetchPage,
       signal: new AbortController().signal,
       pageSize: PAGE_SIZE,
-      shouldRetryPage: () => null,
+      createPageRetryPolicy: () => () => null,
       sleep,
     });
 
@@ -164,7 +164,7 @@ describe('drainPlaylistPages', () => {
       fetchPage,
       signal: new AbortController().signal,
       pageSize: PAGE_SIZE,
-      shouldRetryPage: () => 45_000,
+      createPageRetryPolicy: () => () => 45_000,
       sleep,
       maxTotalWaitMs: 60_000,
     });
@@ -209,7 +209,7 @@ describe('drainPlaylistPages', () => {
       fetchPage,
       signal: new AbortController().signal,
       pageSize: PAGE_SIZE,
-      shouldRetryPage,
+      createPageRetryPolicy: () => shouldRetryPage,
       sleep,
     });
 
@@ -217,6 +217,48 @@ describe('drainPlaylistPages', () => {
     expect(waits).toEqual([]);
     expect(result.stoppedBy).toBe('aborted');
     expect(result.climbs).toEqual([]);
+  });
+
+  // Retry budgets are PER PAGE. A policy instance leaking across pages would let
+  // an early flaky page spend the budget of every page after it.
+  it('builds a fresh retry policy for every page', async () => {
+    const requestedPages: number[] = [];
+    const failedOnce = new Set<number>();
+    const fetchPage = vi
+      .fn<(args: { page: number }) => Promise<PlaylistPage>>()
+      .mockImplementation(async ({ page }) => {
+        requestedPages.push(page);
+        if (!failedOnce.has(page)) {
+          failedOnce.add(page);
+          throw new Error(`page ${page} dropped`);
+        }
+        return makePage(page, 1, page < 2);
+      });
+    const { sleep, waits } = createSleepRecorder();
+    // A single-use budget: `null` on the second failure the same instance sees.
+    const createPageRetryPolicy = () => {
+      let used = false;
+      const policy: ShouldRetryPage = () => {
+        if (used) return null;
+        used = true;
+        return 100;
+      };
+      return policy;
+    };
+
+    const result = await drainPlaylistPages({
+      fetchPage,
+      signal: new AbortController().signal,
+      pageSize: PAGE_SIZE,
+      createPageRetryPolicy,
+      sleep,
+    });
+
+    // Every page failed once and every page still got its own retry.
+    expect(requestedPages).toEqual([0, 0, 1, 1, 2, 2]);
+    expect(waits).toEqual([100, 100, 100]);
+    expect(result.stoppedBy).toBe('exhausted');
+    expect(result.pagesFetched).toBe(3);
   });
 
   it("preserves today's fail-fast behaviour when no retry policy is injected", async () => {

--- a/packages/shared/playlists-react/src/__tests__/fetch-playlist-suggestion-climbs.test.ts
+++ b/packages/shared/playlists-react/src/__tests__/fetch-playlist-suggestion-climbs.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Climb } from '@boardsesh/queue';
+import {
+  fetchPlaylistSuggestionClimbs,
+  PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
+} from '../fetch-playlist-suggestion-climbs';
+import type { DrainSleep, PlaylistPage, ShouldRetryPage } from '../drain-playlist-pages';
+
+function makeClimb(uuid: string): Climb {
+  return { uuid, name: `Climb ${uuid}`, angle: 40 } as unknown as Climb;
+}
+
+function makePage(pageIndex: number, count: number, hasMore: boolean): PlaylistPage {
+  return {
+    climbs: Array.from({ length: count }, (_unused, offset) => makeClimb(`p${pageIndex}-c${offset}`)),
+    hasMore,
+  };
+}
+
+function createSleepRecorder(): { sleep: DrainSleep; waits: number[] } {
+  const waits: number[] = [];
+  const sleep: DrainSleep = async (ms) => {
+    waits.push(ms);
+  };
+  return { sleep, waits };
+}
+
+describe('fetchPlaylistSuggestionClimbs', () => {
+  it('retries a dropped page and resumes on the same page', async () => {
+    const requestedPages: number[] = [];
+    let page1Failures = 0;
+    const fetchPage = vi.fn(async ({ page }: { page: number }) => {
+      requestedPages.push(page);
+      if (page === 1 && page1Failures === 0) {
+        page1Failures += 1;
+        throw new Error('dropped');
+      }
+      return makePage(page, 2, page < 2);
+    });
+    const { sleep, waits } = createSleepRecorder();
+
+    const climbs = await fetchPlaylistSuggestionClimbs({
+      activatedClimbUuid: 'p0-c0',
+      signal: new AbortController().signal,
+      fetchPage,
+      createPageRetryPolicy: () => (_error, attempt) => (attempt === 0 ? 400 : null),
+      sleep,
+    });
+
+    expect(requestedPages).toEqual([0, 1, 1, 2]);
+    expect(waits).toEqual([400]);
+    expect(climbs).toHaveLength(6);
+  });
+
+  // The refresh is fire-and-forget behind the play drawer. Without a shared
+  // ceiling, every one of its pages could sleep a full server window and leave
+  // the prefetch pending for minutes.
+  it('stops on its total wait budget and returns what it already has', async () => {
+    const fetchPage = vi.fn(async ({ page }: { page: number }) => {
+      if (page >= 1) throw new Error('Rate limit exceeded');
+      return makePage(page, 3, true);
+    });
+    const { sleep, waits } = createSleepRecorder();
+
+    const climbs = await fetchPlaylistSuggestionClimbs({
+      activatedClimbUuid: 'p0-c0',
+      signal: new AbortController().signal,
+      fetchPage,
+      // A policy that keeps asking for 45s. Bounded at three asks purely so a
+      // regression here FAILS instead of spinning the suite: with no budget the
+      // walk would sleep on every ask, then propagate page 1's rejection.
+      createPageRetryPolicy: () => {
+        let asks = 0;
+        return () => (asks++ < 3 ? 45_000 : null);
+      },
+      maxTotalWaitMs: 60_000,
+      sleep,
+    });
+
+    // 45s of the 60s budget is spent on page 1's first retry; the second ask
+    // does not fit, so the refresh ends with page 0's climbs instead of hanging.
+    expect(waits).toEqual([45_000]);
+    expect(climbs.map((climb) => climb.uuid)).toEqual(['p0-c0', 'p0-c1', 'p0-c2']);
+  });
+
+  it('still propagates a page rejection the policy gave up on', async () => {
+    const pageError = new Error('Invalid playlist input');
+    const fetchPage = vi.fn(async ({ page }: { page: number }) => {
+      if (page === 1) throw pageError;
+      return makePage(page, 1, true);
+    });
+    const giveUp: ShouldRetryPage = () => null;
+
+    await expect(
+      fetchPlaylistSuggestionClimbs({
+        activatedClimbUuid: 'p0-c0',
+        signal: new AbortController().signal,
+        fetchPage,
+        createPageRetryPolicy: () => giveUp,
+        sleep: async () => {},
+      }),
+    ).rejects.toBe(pageError);
+  });
+
+  it('requests the shared page size by default', async () => {
+    const fetchPage = vi.fn(async ({ page }: { page: number }) => makePage(page, 1, false));
+
+    await fetchPlaylistSuggestionClimbs({
+      activatedClimbUuid: 'p0-c0',
+      signal: new AbortController().signal,
+      fetchPage,
+    });
+
+    expect(fetchPage).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 0, pageSize: PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE }),
+    );
+  });
+});

--- a/packages/shared/playlists-react/src/drain-playlist-pages.ts
+++ b/packages/shared/playlists-react/src/drain-playlist-pages.ts
@@ -62,12 +62,13 @@ export type PlaylistPageFetcher = (args: {
 
 /**
  * Retry policy for a failed page. Returns how long to wait before re-sending
- * the SAME page, or `null` to give up on it. `attempt` is 0 on the first
- * failure, 1 on the second, and so on.
+ * the SAME page, or `null` to give up on it.
  *
- * A policy instance is scoped to ONE page, so it may keep state — which is how
- * a policy gives each class of failure its own budget instead of sharing one
- * counter (a transient network drop must not spend the page's rate-limit
+ * `attempt` counts EVERY retry of this page so far regardless of what failed —
+ * 0 on the first failure, 1 on the second, and so on. It is not a per-class
+ * count, so a policy with separate budgets per error class must keep its own
+ * counters and ignore this. A policy instance is scoped to ONE page precisely
+ * so it can (a transient network drop must not spend the page's rate-limit
  * retry).
  */
 export type ShouldRetryPage = (error: unknown, attempt: number) => number | null;

--- a/packages/shared/playlists-react/src/drain-playlist-pages.ts
+++ b/packages/shared/playlists-react/src/drain-playlist-pages.ts
@@ -1,0 +1,236 @@
+// Bounded, resumable, abortable page drain for "replace the queue with this
+// whole playlist".
+//
+// The old drain was a bare `while (hasMore)` loop with no cap, no pacing and no
+// per-page retry, and every page landed in ONE try/catch — so a single
+// rate-limited or dropped page threw away every page already fetched and the
+// user got "Couldn't start playlist" instead of a queue (#4622). Retrying
+// restarted at page 0 and spent the same server budget again.
+//
+// Three properties this module guarantees:
+//   1. Bounded fan-out. `maxPages` caps how many requests one activation can
+//      issue, so a huge playlist can never burn a whole per-minute server
+//      budget in one burst — and a `hasMore`-forever resolver bug can never spin
+//      the client forever.
+//   2. Resume, never restart. A retried page re-requests the SAME page number
+//      and keeps everything already accumulated.
+//   3. Partial beats nothing. The drain never throws for a page failure; it
+//      returns what it has plus why it stopped, so the caller can seed a working
+//      queue from a partial result instead of failing the whole activation.
+//
+// The retry POLICY (which errors are worth re-sending, and how long to wait) is
+// injected as `shouldRetryPage` rather than imported: this package stays free of
+// transport and error-shape dependencies, per CLAUDE.md's "inject every platform
+// I/O" rule for shared packages.
+
+import type { Climb } from '@boardsesh/queue';
+import { isAbortError } from './fetch-playlist-suggestion-climbs';
+
+/**
+ * Page cap for a queue-replacement drain: 30 pages x 100 climbs = 3000 climbs.
+ *
+ * The backend caps `smartPlaylist` at 60 requests per fixed 60s window keyed on
+ * the user (packages/backend/.../smart-playlists.ts), and the playlist detail
+ * list spends part of that budget itself while the climber scrolls. Half the
+ * budget leaves room for a second activation in the same window, and 3000
+ * climbs is far past a session's worth of climbing.
+ */
+export const PLAYLIST_QUEUE_REPLACE_MAX_PAGES = 30;
+
+/**
+ * Wall-clock ceiling on everything the drain is allowed to SLEEP across all of
+ * its retries. One full server window: a drain that would need to wait longer
+ * than that gives up and hands back what it has, so a pathological playlist can
+ * never hang a queue replacement indefinitely.
+ */
+export const PLAYLIST_DRAIN_MAX_TOTAL_WAIT_MS = 60_000;
+
+/** One page of a playlist fetch. */
+export type PlaylistPage = {
+  climbs: Climb[];
+  hasMore: boolean;
+};
+
+/** Fetches one page. The signal must be forwarded to the underlying request. */
+export type PlaylistPageFetcher = (args: {
+  page: number;
+  pageSize: number;
+  signal: AbortSignal;
+}) => Promise<PlaylistPage>;
+
+/**
+ * Retry policy for a failed page. Returns how long to wait before re-sending
+ * the SAME page, or `null` to give up on it. `attempt` is 0 on the first
+ * failure, 1 on the second, and so on.
+ */
+export type ShouldRetryPage = (error: unknown, attempt: number) => number | null;
+
+/** Injectable sleep so tests never wait on real timers. */
+export type DrainSleep = (ms: number, signal: AbortSignal) => Promise<void>;
+
+/** Why the drain stopped. Only `exhausted` means the whole playlist was read. */
+export type DrainStopReason = 'exhausted' | 'page-cap' | 'wait-budget' | 'aborted' | 'error';
+
+export type DrainPlaylistPagesResult = {
+  /** Everything that landed, in page order. Populated even on a partial stop. */
+  climbs: Climb[];
+  pagesFetched: number;
+  /** True only when the server said there was nothing more to read. */
+  complete: boolean;
+  stoppedBy: DrainStopReason;
+  /** The rejection that ended the drain, when one did. */
+  error?: unknown;
+};
+
+/** Mutable wait accounting shared across every page of one drain. */
+type DrainWaitBudget = { remainingMs: number };
+
+function createAbortError(): Error {
+  const abortError = new Error('Playlist page drain aborted');
+  abortError.name = 'AbortError';
+  return abortError;
+}
+
+/**
+ * Internal signal that a page asked for a backoff longer than the drain had
+ * left in its wait budget. Carries the underlying rejection so the caller still
+ * gets a real error to report.
+ */
+export class PlaylistDrainWaitBudgetError extends Error {
+  readonly pageError: unknown;
+
+  constructor(pageError: unknown) {
+    super('Playlist page drain exceeded its total wait budget');
+    this.name = 'PlaylistDrainWaitBudgetError';
+    this.pageError = pageError;
+  }
+}
+
+/**
+ * `setTimeout` that settles early when the signal aborts, so cancelling a
+ * playlist activation during a 46-second rate-limit backoff is instant instead
+ * of waiting the backoff out.
+ */
+export function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(createAbortError());
+      return;
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const onAbort = () => {
+      if (timer !== undefined) clearTimeout(timer);
+      reject(createAbortError());
+    };
+    timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/**
+ * Fetch one page, re-sending the SAME page while the injected policy asks for a
+ * retry and the shared wait budget can afford it.
+ *
+ * Aborts are never retried — a cancelled activation must stop, not back off.
+ * Without a `shouldRetryPage` this is exactly a bare `fetchPage` call: the first
+ * rejection propagates and nothing sleeps.
+ */
+export async function fetchPlaylistPageWithRetry({
+  fetchPage,
+  page,
+  pageSize,
+  signal,
+  shouldRetryPage,
+  sleep = abortableSleep,
+  waitBudget,
+}: {
+  fetchPage: PlaylistPageFetcher;
+  page: number;
+  pageSize: number;
+  signal: AbortSignal;
+  shouldRetryPage?: ShouldRetryPage;
+  sleep?: DrainSleep;
+  waitBudget?: DrainWaitBudget;
+}): Promise<PlaylistPage> {
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await fetchPage({ page, pageSize, signal });
+    } catch (error) {
+      if (isAbortError(error)) throw error;
+      if (!shouldRetryPage) throw error;
+      const waitMs = shouldRetryPage(error, attempt);
+      if (waitMs === null) throw error;
+      if (waitBudget) {
+        if (waitMs > waitBudget.remainingMs) throw new PlaylistDrainWaitBudgetError(error);
+        waitBudget.remainingMs -= waitMs;
+      }
+      await sleep(waitMs, signal);
+      attempt += 1;
+    }
+  }
+}
+
+/**
+ * Page through a playlist until the server runs out, the page cap is hit, the
+ * wait budget is spent, the caller aborts, or a page gives up.
+ *
+ * Never throws for a page failure — the partial climbs and the stop reason come
+ * back in the result so the caller can decide between "good enough" and
+ * "genuinely failed".
+ */
+export async function drainPlaylistPages({
+  fetchPage,
+  signal,
+  pageSize,
+  maxPages = PLAYLIST_QUEUE_REPLACE_MAX_PAGES,
+  shouldRetryPage,
+  sleep = abortableSleep,
+  maxTotalWaitMs = PLAYLIST_DRAIN_MAX_TOTAL_WAIT_MS,
+}: {
+  fetchPage: PlaylistPageFetcher;
+  signal: AbortSignal;
+  pageSize: number;
+  maxPages?: number;
+  shouldRetryPage?: ShouldRetryPage;
+  sleep?: DrainSleep;
+  maxTotalWaitMs?: number;
+}): Promise<DrainPlaylistPagesResult> {
+  const climbs: Climb[] = [];
+  const waitBudget: DrainWaitBudget = { remainingMs: maxTotalWaitMs };
+  let page = 0;
+  let hasMore = true;
+
+  while (hasMore && page < maxPages && !signal.aborted) {
+    let pageResult: PlaylistPage;
+    try {
+      pageResult = await fetchPlaylistPageWithRetry({
+        fetchPage,
+        page,
+        pageSize,
+        signal,
+        shouldRetryPage,
+        sleep,
+        waitBudget,
+      });
+    } catch (error) {
+      if (isAbortError(error)) {
+        return { climbs, pagesFetched: page, complete: false, stoppedBy: 'aborted' };
+      }
+      if (error instanceof PlaylistDrainWaitBudgetError) {
+        return { climbs, pagesFetched: page, complete: false, stoppedBy: 'wait-budget', error: error.pageError };
+      }
+      return { climbs, pagesFetched: page, complete: false, stoppedBy: 'error', error };
+    }
+    climbs.push(...pageResult.climbs);
+    hasMore = pageResult.hasMore;
+    page += 1;
+  }
+
+  if (!hasMore) return { climbs, pagesFetched: page, complete: true, stoppedBy: 'exhausted' };
+  if (signal.aborted) return { climbs, pagesFetched: page, complete: false, stoppedBy: 'aborted' };
+  return { climbs, pagesFetched: page, complete: false, stoppedBy: 'page-cap' };
+}

--- a/packages/shared/playlists-react/src/drain-playlist-pages.ts
+++ b/packages/shared/playlists-react/src/drain-playlist-pages.ts
@@ -19,9 +19,11 @@
 //      queue from a partial result instead of failing the whole activation.
 //
 // The retry POLICY (which errors are worth re-sending, and how long to wait) is
-// injected as `shouldRetryPage` rather than imported: this package stays free of
-// transport and error-shape dependencies, per CLAUDE.md's "inject every platform
-// I/O" rule for shared packages.
+// injected as `createPageRetryPolicy` rather than imported: this package stays
+// free of transport and error-shape dependencies, per CLAUDE.md's "inject every
+// platform I/O" rule for shared packages. It is a factory, not a function,
+// because a policy needs per-page state to keep separate budgets per error
+// class.
 
 import type { Climb } from '@boardsesh/queue';
 import { isAbortError } from './fetch-playlist-suggestion-climbs';
@@ -62,8 +64,19 @@ export type PlaylistPageFetcher = (args: {
  * Retry policy for a failed page. Returns how long to wait before re-sending
  * the SAME page, or `null` to give up on it. `attempt` is 0 on the first
  * failure, 1 on the second, and so on.
+ *
+ * A policy instance is scoped to ONE page, so it may keep state — which is how
+ * a policy gives each class of failure its own budget instead of sharing one
+ * counter (a transient network drop must not spend the page's rate-limit
+ * retry).
  */
 export type ShouldRetryPage = (error: unknown, attempt: number) => number | null;
+
+/**
+ * Builds a fresh, page-scoped retry policy. The drain calls this once per page
+ * so a stateful policy starts every page with full budgets.
+ */
+export type CreatePageRetryPolicy = () => ShouldRetryPage;
 
 /** Injectable sleep so tests never wait on real timers. */
 export type DrainSleep = (ms: number, signal: AbortSignal) => Promise<void>;
@@ -82,8 +95,12 @@ export type DrainPlaylistPagesResult = {
   error?: unknown;
 };
 
-/** Mutable wait accounting shared across every page of one drain. */
-type DrainWaitBudget = { remainingMs: number };
+/**
+ * Mutable wait accounting shared across every page of one page walk. Build one
+ * before the loop and hand the same object to every page, so the ceiling is on
+ * the whole walk rather than per page.
+ */
+export type DrainWaitBudget = { remainingMs: number };
 
 function createAbortError(): Error {
   const abortError = new Error('Playlist page drain aborted');
@@ -187,7 +204,7 @@ export async function drainPlaylistPages({
   signal,
   pageSize,
   maxPages = PLAYLIST_QUEUE_REPLACE_MAX_PAGES,
-  shouldRetryPage,
+  createPageRetryPolicy,
   sleep = abortableSleep,
   maxTotalWaitMs = PLAYLIST_DRAIN_MAX_TOTAL_WAIT_MS,
 }: {
@@ -195,7 +212,8 @@ export async function drainPlaylistPages({
   signal: AbortSignal;
   pageSize: number;
   maxPages?: number;
-  shouldRetryPage?: ShouldRetryPage;
+  /** Built once per page, so each page starts with fresh per-class budgets. */
+  createPageRetryPolicy?: CreatePageRetryPolicy;
   sleep?: DrainSleep;
   maxTotalWaitMs?: number;
 }): Promise<DrainPlaylistPagesResult> {
@@ -212,7 +230,7 @@ export async function drainPlaylistPages({
         page,
         pageSize,
         signal,
-        shouldRetryPage,
+        shouldRetryPage: createPageRetryPolicy?.(),
         sleep,
         waitBudget,
       });

--- a/packages/shared/playlists-react/src/fetch-playlist-suggestion-climbs.ts
+++ b/packages/shared/playlists-react/src/fetch-playlist-suggestion-climbs.ts
@@ -1,4 +1,5 @@
 import type { Climb } from '@boardsesh/queue';
+import { fetchPlaylistPageWithRetry, type DrainSleep, type ShouldRetryPage } from './drain-playlist-pages';
 
 export const PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE = 100;
 const MAX_PLAYLIST_SUGGESTION_REFRESH_PAGES = 10;
@@ -34,6 +35,8 @@ export async function fetchPlaylistSuggestionClimbs({
   pageSize = PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
   maxPages = MAX_PLAYLIST_SUGGESTION_REFRESH_PAGES,
   maxClimbsAfterActivated = MAX_PLAYLIST_SUGGESTION_REFRESH_CLIMBS_AFTER_ACTIVE,
+  shouldRetryPage,
+  sleep,
 }: {
   activatedClimbUuid: string;
   signal: AbortSignal;
@@ -41,6 +44,15 @@ export async function fetchPlaylistSuggestionClimbs({
   pageSize?: number;
   maxPages?: number;
   maxClimbsAfterActivated?: number;
+  /**
+   * Optional per-page retry policy. Omitted (the default) this helper behaves
+   * exactly as it always has: the first rejection propagates and nothing
+   * sleeps. Callers that share a rate-limited server bucket opt in so a single
+   * throttled or dropped page doesn't kill the whole refresh.
+   */
+  shouldRetryPage?: ShouldRetryPage;
+  /** Injectable sleep for tests; defaults to an abortable setTimeout. */
+  sleep?: DrainSleep;
 }): Promise<Climb[]> {
   const fetchedClimbs: Climb[] = [];
   let page = 0;
@@ -49,7 +61,14 @@ export async function fetchPlaylistSuggestionClimbs({
   let loadedClimbsAfterActivated = 0;
 
   while (hasMore && page < maxPages && loadedClimbsAfterActivated < maxClimbsAfterActivated && !signal.aborted) {
-    const pageResult = await fetchPage({ page, pageSize, signal });
+    const pageResult = await fetchPlaylistPageWithRetry({
+      fetchPage,
+      page,
+      pageSize,
+      signal,
+      shouldRetryPage,
+      sleep,
+    });
 
     for (const pageClimb of pageResult.climbs) {
       if (pageClimb.uuid === activatedClimbUuid) {

--- a/packages/shared/playlists-react/src/fetch-playlist-suggestion-climbs.ts
+++ b/packages/shared/playlists-react/src/fetch-playlist-suggestion-climbs.ts
@@ -1,5 +1,12 @@
 import type { Climb } from '@boardsesh/queue';
-import { fetchPlaylistPageWithRetry, type DrainSleep, type ShouldRetryPage } from './drain-playlist-pages';
+import {
+  fetchPlaylistPageWithRetry,
+  PlaylistDrainWaitBudgetError,
+  PLAYLIST_DRAIN_MAX_TOTAL_WAIT_MS,
+  type CreatePageRetryPolicy,
+  type DrainSleep,
+  type DrainWaitBudget,
+} from './drain-playlist-pages';
 
 export const PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE = 100;
 const MAX_PLAYLIST_SUGGESTION_REFRESH_PAGES = 10;
@@ -35,7 +42,8 @@ export async function fetchPlaylistSuggestionClimbs({
   pageSize = PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
   maxPages = MAX_PLAYLIST_SUGGESTION_REFRESH_PAGES,
   maxClimbsAfterActivated = MAX_PLAYLIST_SUGGESTION_REFRESH_CLIMBS_AFTER_ACTIVE,
-  shouldRetryPage,
+  createPageRetryPolicy,
+  maxTotalWaitMs = PLAYLIST_DRAIN_MAX_TOTAL_WAIT_MS,
   sleep,
 }: {
   activatedClimbUuid: string;
@@ -45,30 +53,49 @@ export async function fetchPlaylistSuggestionClimbs({
   maxPages?: number;
   maxClimbsAfterActivated?: number;
   /**
-   * Optional per-page retry policy. Omitted (the default) this helper behaves
-   * exactly as it always has: the first rejection propagates and nothing
-   * sleeps. Callers that share a rate-limited server bucket opt in so a single
-   * throttled or dropped page doesn't kill the whole refresh.
+   * Optional per-page retry policy factory. Omitted (the default) this helper
+   * behaves exactly as it always has: the first rejection propagates and
+   * nothing sleeps. Callers that share a rate-limited server bucket opt in so a
+   * single throttled or dropped page doesn't kill the whole refresh.
    */
-  shouldRetryPage?: ShouldRetryPage;
+  createPageRetryPolicy?: CreatePageRetryPolicy;
+  /**
+   * Wall-clock ceiling on everything this refresh may SLEEP across all of its
+   * pages. Without it a 10-page walk against a throttled bucket could stay
+   * pending for minutes on a fire-and-forget prefetch; with it the refresh
+   * stops early and returns the climbs it already has.
+   */
+  maxTotalWaitMs?: number;
   /** Injectable sleep for tests; defaults to an abortable setTimeout. */
   sleep?: DrainSleep;
 }): Promise<Climb[]> {
   const fetchedClimbs: Climb[] = [];
+  // One budget for the whole walk, not per page.
+  const waitBudget: DrainWaitBudget = { remainingMs: maxTotalWaitMs };
   let page = 0;
   let hasMore = true;
   let activatedClimbSeen = false;
   let loadedClimbsAfterActivated = 0;
 
   while (hasMore && page < maxPages && loadedClimbsAfterActivated < maxClimbsAfterActivated && !signal.aborted) {
-    const pageResult = await fetchPlaylistPageWithRetry({
-      fetchPage,
-      page,
-      pageSize,
-      signal,
-      shouldRetryPage,
-      sleep,
-    });
+    let pageResult: PlaylistSuggestionPage;
+    try {
+      pageResult = await fetchPlaylistPageWithRetry({
+        fetchPage,
+        page,
+        pageSize,
+        signal,
+        shouldRetryPage: createPageRetryPolicy?.(),
+        sleep,
+        waitBudget,
+      });
+    } catch (error) {
+      // Out of wait budget: the swipe track is a prefetch, so stop with what we
+      // have instead of failing the refresh on an internal signal. Every other
+      // rejection still propagates the way it always has.
+      if (error instanceof PlaylistDrainWaitBudgetError) break;
+      throw error;
+    }
 
     for (const pageClimb of pageResult.climbs) {
       if (pageClimb.uuid === activatedClimbUuid) {

--- a/packages/shared/playlists-react/src/index.ts
+++ b/packages/shared/playlists-react/src/index.ts
@@ -63,12 +63,15 @@ export {
   drainPlaylistPages,
   fetchPlaylistPageWithRetry,
   abortableSleep,
+  PlaylistDrainWaitBudgetError,
   PLAYLIST_QUEUE_REPLACE_MAX_PAGES,
   PLAYLIST_DRAIN_MAX_TOTAL_WAIT_MS,
 } from './drain-playlist-pages';
 export type {
   ShouldRetryPage,
+  CreatePageRetryPolicy,
   DrainSleep,
+  DrainWaitBudget,
   PlaylistPage,
   PlaylistPageFetcher,
   DrainPlaylistPagesResult,

--- a/packages/shared/playlists-react/src/index.ts
+++ b/packages/shared/playlists-react/src/index.ts
@@ -56,3 +56,21 @@ export {
   isAbortError,
   PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
 } from './fetch-playlist-suggestion-climbs';
+
+// Bounded/resumable page drain for queue replacement (#4622). The retry policy
+// is injected by the caller so this package stays transport-agnostic.
+export {
+  drainPlaylistPages,
+  fetchPlaylistPageWithRetry,
+  abortableSleep,
+  PLAYLIST_QUEUE_REPLACE_MAX_PAGES,
+  PLAYLIST_DRAIN_MAX_TOTAL_WAIT_MS,
+} from './drain-playlist-pages';
+export type {
+  ShouldRetryPage,
+  DrainSleep,
+  PlaylistPage,
+  PlaylistPageFetcher,
+  DrainPlaylistPagesResult,
+  DrainStopReason,
+} from './drain-playlist-pages';

--- a/packages/shared/playlists-react/src/index.ts
+++ b/packages/shared/playlists-react/src/index.ts
@@ -59,11 +59,13 @@ export {
 
 // Bounded/resumable page drain for queue replacement (#4622). The retry policy
 // is injected by the caller so this package stays transport-agnostic.
+// `PlaylistDrainWaitBudgetError` and `DrainWaitBudget` are deliberately NOT
+// re-exported: they are the internal signal and accounting shared between the
+// drain and the suggestion refresh, not something a consumer should bind to.
 export {
   drainPlaylistPages,
   fetchPlaylistPageWithRetry,
   abortableSleep,
-  PlaylistDrainWaitBudgetError,
   PLAYLIST_QUEUE_REPLACE_MAX_PAGES,
   PLAYLIST_DRAIN_MAX_TOTAL_WAIT_MS,
 } from './drain-playlist-pages';
@@ -71,7 +73,6 @@ export type {
   ShouldRetryPage,
   CreatePageRetryPolicy,
   DrainSleep,
-  DrainWaitBudget,
   PlaylistPage,
   PlaylistPageFetcher,
   DrainPlaylistPagesResult,


### PR DESCRIPTION
## Summary

Starting a playlist read **every** page of it in one unpaced burst, inside one
`try`/`catch`. One rate-limited or dropped page threw away every page already
fetched, the climber got "Couldn't start playlist. Try again.", and retrying
restarted at page 0 — spending the same 60-per-minute `smartPlaylist` budget
over again. A playlist past ~6000 climbs (60 pages of 100) could not be started
at all.

Sentry, `source:playlist op:replace-queue`, last 90 days: 47 events / 13 users.
23 of them are `Rate limit exceeded. Try again in N seconds.` with
`extensions.code: RATE_LIMITED` (hints from 2s to 46s); 21 are
`TypeError: Network request failed`, the half still firing.

The hand-rolled `while (hasMore)` loop is replaced with `drainPlaylistPages` in
`@boardsesh/playlists-react`:

- **Bounded** at 30 pages / 3000 climbs — half the server's per-minute budget, so
  two activations still fit in one window. Also closes the latent infinite loop
  on a `hasMore`-forever resolver.
- **Resumable.** A retried page re-requests the *same* page number and keeps
  everything already accumulated. It honours the server's
  `extensions.retryAfterSeconds`, under one 60s wall-clock sleep budget for the
  whole drain, so a replacement can never hang indefinitely.
- **Partial beats nothing.** If any page landed, the queue is replaced with what
  we have. A drain that read *no* page still toasts and leaves the queue exactly
  as it was — for every stop reason, not just a rejection.

The retry policy is injected (`createPlaylistPageRetryPolicy`) rather than
imported, so the shared package keeps no transport or error-shape dependency and
`package.json` / `bun.lock` are untouched. It re-sends only two classes:
`RATE_LIMITED` (the resolver calls `applyRateLimit` before doing any work, so a
re-send cannot double anything) and a transport drop that never reached the
server. GraphQL validation errors, 4xx and programmer bugs fail the page
immediately instead of burning the climber's budget. This stays scoped to the
drain on purpose — the app-wide policy is the opposite (`query-provider.tsx`:
never retry a `RATE_LIMITED` rejection), because retry is only correct for
requests the client itself is fanning out and can pace.

It is a *factory* built once per page, not a plain function, because each class
of failure needs its own budget. With one shared counter a wifi-to-LTE handoff
dropping page 7 spent the page's only rate-limit retry, so the throttle that
followed gave up immediately — an unrelated blip truncating a playlist that one
honest wait would have finished.

Three smaller fixes in the same path:

- Both playlist screens now forward their `AbortSignal` into
  `getHttpClient().request({ document, variables, signal })`. Leaving a playlist
  mid-drain used to stop the loop from *issuing* the next page but left the
  in-flight one running.
- The swipe-track refresh (`fetchPlaylistSuggestionClimbs`) gets the same
  per-page backoff *and the same total wait ceiling* — it shares the same server
  bucket, and a fire-and-forget prefetch that can sleep on all ten of its pages
  stays pending for minutes. Out of budget it stops with the climbs it has. Both
  parameters are optional and default to today's exact behaviour, so no other
  caller changes.
- Cancel and pan-to-close stay live on the queue-replace warning sheet while the
  replacement runs. Confirming now genuinely starts the drain, and a throttled
  first page can back off for the length of a server window — locking the
  climber into a modal for that long reads as a hung app. `onCancel` already
  aborted the drain *and* its sleep; only the greyed-out button made it
  unreachable. Confirm still shows a spinner, so a double-tap can't start two
  drains.

A truncated or partially drained replacement reports to Sentry as
`op: replace-queue-partial` with `stoppedBy` / `pagesFetched` / `climbCount`, so
the 30-page cap and the rate-limit stops are measurable before anyone tunes them.
Deliberately silent for the climber: a warning toast on an action that just
worked is noise, and 3000 climbs is far past a session.

**Native fingerprint: not moved.** TypeScript only — no new dependency, no Expo
plugin, no native module, no `app.config.ts` change. This ships over OTA.

Closes #4622

## Release Notes

- Big playlists start again — a slow or dropped page no longer kills the whole thing
- Tapping a climb in a huge circuit now fills your queue instead of erroring out
- Backing out of a playlist stops it loading straight away
- Cancel still works while a playlist is loading into your queue

## Test plan

New unit coverage:

- `packages/shared/playlists-react/src/__tests__/drain-playlist-pages.test.ts` —
  full drain, page cap (exactly 30 calls / 3000 climbs), **resume from the failed
  page** (asserts the request sequence is `[0, 1, 2, 2, 3]`, never a second `0`),
  give-up-with-partial, wait-budget exhaustion, abort mid-drain, aborts never
  retried, no-policy fail-fast, plus `abortableSleep` settling on abort instead of
  waiting the backoff out.
- `packages/mobile/src/lib/playlists/__tests__/playlist-page-retry.test.ts` — real
  graphql-request `ClientError` fixtures: honours `retryAfterSeconds: 46`, falls
  back when the server sent no hint, retries a transport drop twice, never
  retries an abort or a `BAD_USER_INPUT`; keeps a separate budget per error class
  when the classes alternate; and pins the rate-limit ceiling — jitter included —
  at or under the drain's total wait budget.
- `packages/shared/playlists-react/src/__tests__/fetch-playlist-suggestion-climbs.test.ts`
  — the swipe-track refresh resumes a dropped page, stops on its total wait
  budget with the climbs it already had, and still propagates a rejection the
  policy gave up on.
- `packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx` —
  partial drain still replaces the queue with no toast and one
  `replace-queue-partial` report; page-cap ditto; a zero-page stop toasts and
  leaves the queue alone on both the tap path and the confirm-after-warning path
  (which is the one that never pre-seeds a queue), without tripping the #3891
  empty-fetch canary; an aborted drain touches nothing; the drain is asked for
  the 30-page cap, the shared page size and a retry-policy factory.
- `packages/mobile/src/components/playlist/__tests__/playlist-queue-replace-sheet.test.tsx`
  — cancel and pan-to-close stay live while replacing, and cancel fires mid-flight.

Commands (all green):

- `vp test run --project playlists-react --reporter=agent` — 6 files / 39 tests passed
- `vp run test:mobile` — full suite green
- `vp run typecheck:mobile`, `vp run typecheck:shared`, `vp run typecheck:playlists-react`
- `vp check` — 0 errors
- `vp run check:mobile-bundle`

Device QA is still owed — `.boardsesh/qa-notes.md` (gitignored, in the worktree)
lists the flows: big smart playlist starts, back-out cancels the in-flight page,
rate-limited drain still fills the queue, airplane mode mid-drain, and the
regular playlist warning sheet. Note that `applyRateLimit` returns early when
`NODE_ENV === 'development'`, so reproducing the rate-limit path needs a build
pointed at a non-development backend.

