### PR TITLE
fix(mobile): [native-train] stop the implicit relight clearing the wall with no queue state

### DIFF
--- a/packages/mobile/ios-tests/BoardBleImplicitRelightStateTests.swift
+++ b/packages/mobile/ios-tests/BoardBleImplicitRelightStateTests.swift
@@ -126,6 +126,20 @@ final class BoardBleImplicitRelightStateTests: XCTestCase {
         )
     }
 
+    /// Distinct from the absent-state case above: here JS did publish, and what
+    /// it published is an empty queue. `SharedQueueState.currentItem` returns
+    /// nil for both, and neither is a licence to clear — an explicit clear
+    /// comes through `write(hex:)` with empty frames, not through this loader.
+    func testImplicitRelightWithAnExplicitlyEmptySharedQueueLeavesTheWallAlone() {
+        let peripheral = FakeWritablePeripheral()
+        installConnection(peripheral)
+
+        SharedQueueState.save(items: [], currentIndex: 0, to: defaults)
+        manager.testHooks.displaySharedCurrentItem(defaults: defaults)
+
+        XCTAssertTrue(peripheral.writtenChunks.isEmpty)
+    }
+
     func testImplicitRelightWithAnOutOfRangeSharedIndexLeavesTheWallAlone() {
         let peripheral = FakeWritablePeripheral()
         installConnection(peripheral)

--- a/packages/mobile/ios-tests/BoardBleImplicitRelightStateTests.swift
+++ b/packages/mobile/ios-tests/BoardBleImplicitRelightStateTests.swift
@@ -152,7 +152,10 @@ final class BoardBleImplicitRelightStateTests: XCTestCase {
         SharedQueueState.save(items: [queueItem()], currentIndex: 5, to: defaults)
         manager.testHooks.displaySharedCurrentItem(defaults: defaults)
 
-        XCTAssertTrue(peripheral.writtenChunks.isEmpty)
+        XCTAssertTrue(
+            peripheral.writtenChunks.isEmpty,
+            "a stale out-of-range index must not clear the wall (#4544)"
+        )
     }
 
     func testImplicitRelightWithAValidSharedCurrentClimbStillLights() {

--- a/packages/mobile/ios-tests/BoardBleImplicitRelightStateTests.swift
+++ b/packages/mobile/ios-tests/BoardBleImplicitRelightStateTests.swift
@@ -137,7 +137,10 @@ final class BoardBleImplicitRelightStateTests: XCTestCase {
         SharedQueueState.save(items: [], currentIndex: 0, to: defaults)
         manager.testHooks.displaySharedCurrentItem(defaults: defaults)
 
-        XCTAssertTrue(peripheral.writtenChunks.isEmpty)
+        XCTAssertTrue(
+            peripheral.writtenChunks.isEmpty,
+            "a published-but-empty queue must not clear the wall either (#4544)"
+        )
     }
 
     func testImplicitRelightWithAnOutOfRangeSharedIndexLeavesTheWallAlone() {

--- a/packages/mobile/ios-tests/BoardBleImplicitRelightStateTests.swift
+++ b/packages/mobile/ios-tests/BoardBleImplicitRelightStateTests.swift
@@ -1,0 +1,177 @@
+import CoreBluetooth
+import XCTest
+
+/// Coverage for the implicit re-light's reading of the App-Group queue copy
+/// (#4544): when that copy holds no current climb, the wall must be left alone
+/// rather than cleared. The explicit-arguments path — the one
+/// SessionWebSocketManager repaints from live session state — must keep
+/// clearing, because there an empty queue is authoritative rather than absent.
+///
+/// Everything runs against an ISOLATED `UserDefaults` suite through
+/// `testHooks.displaySharedCurrentItem(defaults:)`, mirroring
+/// `LiveActivityWidgetTests`, so a developer machine's real app-group defaults
+/// are never read or written. The seam sits below whatever authorisation gate
+/// wraps the connect-path callers, so these assertions hold regardless of how
+/// a connect is gated.
+@available(iOS 17.0, *)
+final class BoardBleImplicitRelightStateTests: XCTestCase {
+    private var scheduler: FakeBleTimerScheduler!
+    private var manager: BoardBleManager!
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var cancelledPeripheralIds: [UUID] = []
+    private let uartWriteCharacteristicUuid = CBUUID(string: "6E400002-B5A3-F393-E0A9-E50E24DCCA9E")
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "com.boardsesh.rn.implicit-relight-tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+
+        cancelledPeripheralIds = []
+        scheduler = FakeBleTimerScheduler()
+        manager = BoardBleManager(timerScheduler: scheduler, createCentralManagerEagerly: false)
+        let hooks = manager.testHooks
+        hooks.sync {
+            // A dev machine's app-group defaults could leak a persisted config.
+            hooks.setConfiguration(nil)
+            hooks.setCancelPeripheralConnectionOverride { [weak self] peripheral in
+                self?.cancelledPeripheralIds.append(peripheral.identifier)
+            }
+        }
+    }
+
+    override func tearDown() {
+        manager.testHooks.sync {
+            manager.testHooks.setCancelPeripheralConnectionOverride(nil)
+        }
+        manager = nil
+        scheduler = nil
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+    //
+    // `FakeWritablePeripheral` and `FakeBleTimerScheduler` are top-level and
+    // shared, but BoardBleWriteFlowTests' own construction helpers are private
+    // members of that suite, so they are copied rather than reused.
+
+    private func makeCharacteristic(
+        uuid: CBUUID? = nil,
+        properties: CBCharacteristicProperties = .writeWithoutResponse
+    ) -> CBMutableCharacteristic {
+        CBMutableCharacteristic(
+            type: uuid ?? uartWriteCharacteristicUuid,
+            properties: properties,
+            value: nil,
+            permissions: [.writeable]
+        )
+    }
+
+    /// MoonBoard specifically: `makeMoonboardPacket(frames: "")` returns the
+    /// 3-byte `l##` clear-all, so an unwanted clear writes real bytes a test can
+    /// catch instead of being an invisible no-op.
+    private func moonboardConfiguration() -> BoardBleConfiguration {
+        BoardBleConfiguration(
+            boardName: "moonboard",
+            layoutId: 0,
+            sizeId: 0,
+            apiLevel: nil,
+            deviceName: nil,
+            colorOverrides: [:],
+            numRows: nil
+        )
+    }
+
+    private func queueItem(frames: String = "p1r42", mirrored: Bool = false) -> SharedQueueItem {
+        SharedQueueItem(
+            uuid: "queue-item",
+            climbUuid: "climb-item",
+            climbName: "Test climb",
+            difficulty: "6c+/V5",
+            angle: 40,
+            frames: frames,
+            setterUsername: "tester",
+            mirrored: mirrored
+        )
+    }
+
+    /// Seed BOTH the configuration and the connection. `clearBoardOnBleQueue`
+    /// bails at its own guards when either is missing, so a test that seeded
+    /// only one would pass even with the bug present.
+    private func installConnection(_ peripheral: FakeWritablePeripheral) {
+        let hooks = manager.testHooks
+        hooks.sync {
+            hooks.setConfiguration(moonboardConfiguration())
+            hooks.setConnection(peripheral: peripheral, characteristic: makeCharacteristic())
+        }
+    }
+
+    // MARK: - The implicit, shared-state re-light
+
+    func testImplicitRelightWithNoSharedQueueStateLeavesTheWallAlone() {
+        let peripheral = FakeWritablePeripheral()
+        installConnection(peripheral)
+
+        // The isolated suite has never been written to — the state of every
+        // install whose climber has not published a queue yet.
+        manager.testHooks.displaySharedCurrentItem(defaults: defaults)
+
+        XCTAssertTrue(
+            peripheral.writtenChunks.isEmpty,
+            "an absent App-Group queue copy must not clear the wall (#4544)"
+        )
+    }
+
+    func testImplicitRelightWithAnOutOfRangeSharedIndexLeavesTheWallAlone() {
+        let peripheral = FakeWritablePeripheral()
+        installConnection(peripheral)
+
+        // Stale index rather than absent state: a queue was published, then the
+        // index ran past its end.
+        SharedQueueState.save(items: [queueItem()], currentIndex: 5, to: defaults)
+        manager.testHooks.displaySharedCurrentItem(defaults: defaults)
+
+        XCTAssertTrue(peripheral.writtenChunks.isEmpty)
+    }
+
+    func testImplicitRelightWithAValidSharedCurrentClimbStillLights() {
+        let peripheral = FakeWritablePeripheral()
+        installConnection(peripheral)
+
+        SharedQueueState.save(items: [queueItem()], currentIndex: 0, to: defaults)
+        manager.testHooks.displaySharedCurrentItem(defaults: defaults)
+
+        // Only the first chunk goes out synchronously; the rest pace on
+        // chunkDelay timers this test deliberately does not fire.
+        XCTAssertGreaterThanOrEqual(
+            peripheral.writtenChunks.count,
+            1,
+            "a real current climb must still re-light the wall"
+        )
+    }
+
+    // MARK: - The explicit, caller-supplied path
+
+    /// The live-session repaint (SessionWebSocketManager) hands in items and an
+    /// index directly; an out-of-range index there means "no current climb" and
+    /// must still dark the wall. No connect flow, and no reset of
+    /// `writtenChunks` (it is `private(set)`) — the assertion is on the delta.
+    func testExplicitDisplayCurrentItemWithNoCurrentClimbStillClears() {
+        let peripheral = FakeWritablePeripheral()
+        let writtenBefore = peripheral.writtenChunks.count
+
+        let hooks = manager.testHooks
+        hooks.sync {
+            hooks.setConfiguration(moonboardConfiguration())
+            hooks.setConnection(peripheral: peripheral, characteristic: makeCharacteristic())
+            manager.displayCurrentItem(items: [], currentIndex: 0)
+        }
+
+        XCTAssertEqual(peripheral.writtenChunks.count, writtenBefore + 1)
+        XCTAssertEqual(peripheral.writtenChunks.last?.data, Data("l##".utf8))
+    }
+}

--- a/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
+++ b/packages/mobile/ios-tests/LiveActivityWidgetTests.swift
@@ -354,8 +354,9 @@ final class LiveActivityWidgetTests: XCTestCase {
         XCTAssertEqual(state.currentIndex, 0)
 
         // Emptying the queue leaves index 0 into an empty array — every
-        // consumer bounds-checks (SharedQueueState.currentItem returns nil,
-        // displayCurrentItemOnBleQueue clears the board), so this must stay a
+        // consumer bounds-checks: SharedQueueState.currentItem returns nil, and
+        // the implicit re-light then leaves the wall alone (#4544) while the
+        // explicit displayCurrentItem path still clears. So this must stay a
         // representable, non-crashing state.
         state = QueueStateReducer.apply(.itemRemoved(uuid: "A", sequence: 3), to: state)
         XCTAssertTrue(state.items.isEmpty)

--- a/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
+++ b/packages/mobile/modules/live-activity/ios/BoardBleManager.swift
@@ -1047,10 +1047,31 @@ final class BoardBleManager: NSObject, CBCentralManagerDelegate, CBPeripheralDel
         processWriteQueue()
     }
 
-    private func displaySharedCurrentItemOnBleQueue() {
-        guard let defaults = SharedConstants.sharedDefaults else { return }
-        let (items, currentIndex) = SharedQueueState.load(from: defaults)
-        displayCurrentItemOnBleQueue(items: items, currentIndex: currentIndex)
+    /// Re-light the wall from the App-Group queue copy. Absence of that copy is
+    /// NOT an instruction to clear (#4544): it is only ever written once JS has
+    /// published a queue, so a climber who has never opened a queue on this
+    /// install had every connect issue a clear-all. It looked harmless only
+    /// because the JS auto-sender usually repainted a moment later.
+    ///
+    /// A deliberate clear stays a deliberate clear. JS `clearBoard()` writes
+    /// empty frames through `write(hex:)`, and the live-session repaint
+    /// (`displayCurrentItem(items:currentIndex:)`, called by
+    /// SessionWebSocketManager) still clears on an out-of-range index — there
+    /// the empty state is authoritative rather than merely absent.
+    ///
+    /// `defaults` is a default argument, re-evaluated at every call, so all
+    /// production call sites keep reading the real App Group. The parameter
+    /// exists only so the Swift suite can drive this against an isolated
+    /// suite instead of a developer machine's app-group defaults.
+    private func displaySharedCurrentItemOnBleQueue(
+        defaults: UserDefaults? = SharedConstants.sharedDefaults
+    ) {
+        guard let defaults else { return }
+        guard let item = SharedQueueState.currentItem(from: defaults) else {
+            logger.info("Skipping implicit BLE re-light: no current climb in the App Group queue copy (#4544)")
+            return
+        }
+        displayItemOnBleQueue(item)
     }
 
     private func displayCurrentItemOnBleQueue(
@@ -2861,6 +2882,16 @@ extension BoardBleManager {
                     peripheral: peripheral,
                     characteristic: characteristic
                 )
+            }
+        }
+
+        /// Drive the implicit shared-state re-light directly, against an
+        /// isolated defaults suite. Deliberately below whatever gate wraps the
+        /// connect-path callers, so the #4544 contract (absent state is not a
+        /// clear) is pinned independently of how a connect is authorised.
+        func displaySharedCurrentItem(defaults: UserDefaults) {
+            manager.runOnBleQueueSync {
+                manager.displaySharedCurrentItemOnBleQueue(defaults: defaults)
             }
         }
 

--- a/scripts/prepare-rn-ios-tests.mjs
+++ b/scripts/prepare-rn-ios-tests.mjs
@@ -26,6 +26,10 @@ const TEST_SOURCE_FILES = [
     projectPath: 'BoardseshTests/BoardBleWriteFlowTests.swift',
   },
   {
+    sourcePath: '../ios-tests/BoardBleImplicitRelightStateTests.swift',
+    projectPath: 'BoardseshTests/BoardBleImplicitRelightStateTests.swift',
+  },
+  {
     sourcePath: '../ios-tests/BoardBleDisconnectTests.swift',
     projectPath: 'BoardseshTests/BoardBleDisconnectTests.swift',
   },


### PR DESCRIPTION
## Summary

Closes #4544.

`displaySharedCurrentItemOnBleQueue()` read the App-Group queue copy and handed the
result straight to `displayCurrentItemOnBleQueue(items:currentIndex:)`, whose first
statement is:

```swift
guard currentIndex >= 0, currentIndex < items.count else { clearBoardOnBleQueue(...); return }
```

`SharedQueueState.load(from:)` returns `(items: [], currentIndex: 0)` when the keys are
simply missing, so **"no shared state was ever written" was indistinguishable from
"the queue is empty"** — and both routed to a real clear-all. On MoonBoard that is the
3-byte `l##` packet, so it writes real bytes rather than being a silent no-op.

Four ordinary connect paths reach it (`finishConnectionSetupOnBleQueue`, `configure(_:)`,
and the two already-connected early returns), and App-Group queue state is only written
once a Live Activity has run. Per the issue's PostHog numbers, 84% of iOS Bluetooth
climbers have never had that state, so every connect they made issued a clear. It went
unnoticed because the JS auto-sender usually repainted a moment later.

### The change

The fix lands in the loader, not in `displayCurrentItemOnBleQueue`. That is the boundary
between "state was read from the App Group and might be absent" and "a caller explicitly
handed me items and an index":

- `displaySharedCurrentItemOnBleQueue` now uses `SharedQueueState.currentItem(from:)`
  (same bounds check) and returns without writing when it yields `nil`.
- `displayCurrentItemOnBleQueue`, `clearBoardOnBleQueue` and all four call sites are
  byte-identical. The explicit-arguments path still clears on an out-of-range index,
  because its callers are authoritative: `SessionWebSocketManager.persistAndNotify`
  repaints from live session state, and `displayCurrentItemAwaitingReady` comes from
  `LiveActivityBleBridge.writeBoardForIntent`.
- JS `bluetooth.clearBoard()` sends empty frames through the write path and never enters
  this code, so a deliberate clear still darks the wall.

One production signature detail worth a reviewer's eye: the loader gained a
`defaults: UserDefaults? = SharedConstants.sharedDefaults` default argument. Swift
re-evaluates default expressions at every call site and all four call sites are
untouched, so this is behaviour-preserving; it exists purely so the Swift suite can
drive the unit against an isolated `UserDefaults` suite instead of a developer machine's
real app-group defaults.

### Relationship to the other relight PRs

- **#4413** is the user-visible report this came out of.
- **#4549** is open and unmerged, JS-only, and mirrors App-Group state so most users get a
  real relight. This PR fixes the residual "never had a queue on this install" case that
  #4549's own tests document as belonging to #4544. They compose; neither duplicates the
  other.
- **#4551** is open, also targets `release/next-ota`, and restructures all four callers
  behind an authorization gate — but it leaves the body of
  `displaySharedCurrentItemOnBleQueue` alone, so the Swift hunks merge cleanly in either
  order. Crucially **#4551 does not already fix this**: a fresh, legitimate `.userConnect`
  passes its gate and still reaches the clear. Registration in
  `scripts/prepare-rn-ios-tests.mjs` is inserted after the `BoardBleWriteFlowTests.swift`
  entry specifically to avoid a textual conflict with #4551's insertion point.

One semantic wrinkle for whoever merges second: once #4551 lands, its
`implicitRelightAttempts` counter increments immediately before this loader runs, so an
"attempt" can now produce no write at all. Nothing breaks, but the counter's meaning
drifts from "writes attempted" to "gate passed". Worth a follow-up, not a blocker here.

### Native train

**This must never be merged to `main`.** It changes Swift under
`packages/mobile/modules/live-activity/ios/`, so it moves the Expo native fingerprint and
can never ship OTA. Base branch is `release/next-ota`, same as #4551.

## Release Notes

- Connecting to a board no longer blanks it when you have not lined up a climb yet — the wall keeps whatever is lit until you pick something.

## Test plan

New XCTest suite `packages/mobile/ios-tests/BoardBleImplicitRelightStateTests.swift`, run
against an isolated `UserDefaults` suite through a new
`TestHooks.displaySharedCurrentItem(defaults:)` seam (the `LiveActivityWidgetTests`
pattern), so it never reads or writes the real app group. The seam sits below whatever
gate wraps the connect-path callers, so it holds in either merge order with #4551:

1. `testImplicitRelightWithNoSharedQueueStateLeavesTheWallAlone` — empty suite, MoonBoard
   config **and** a fake connection seeded (both are required; `clearBoardOnBleQueue`
   bails at its own guards otherwise and the test would pass on unfixed code) → zero
   writes.
2. `testImplicitRelightWithAnOutOfRangeSharedIndexLeavesTheWallAlone` — one item at index
   5 → zero writes.
3. `testImplicitRelightWithAValidSharedCurrentClimbStillLights` — one item at index 0 →
   at least one chunk. Pins that the fix did not just disable relight.
4. `testExplicitDisplayCurrentItemWithNoCurrentClimbStillClears` — no connect flow;
   `displayCurrentItem(items: [], currentIndex: 0)` → exactly one more chunk than the
   baseline, equal to `Data("l##".utf8)`. Pins that SessionWebSocketManager's
   authoritative repaint path is unchanged. (`writtenChunks` is `private(set)`, so this
   asserts on a delta rather than resetting the fake.)

Also fixed a comment in `LiveActivityWidgetTests` that asserted the old
"empty state clears the board" contract; its assertions pass either way, which is exactly
why it would have rotted silently.

**Ran locally (Linux):**

- `vp check` — pass
- `vp run typecheck:mobile` — pass
- `vp test run --project scripts --reporter=agent` — 865 pass. Confirmed
  `prepare-rn-ios-tests.test.ts` goes **red** without the `.mjs` registration and green
  with it, so the new Swift file provably reaches the generated Xcode test target.
- `vp run test:mobile` — 6525/6526 twice, with a **different** 5s-timeout failure each
  run (`use-board-route-target.test.tsx > re-resolves when the network comes back after
  an offline failure`, then `uses the bundled screenshot locale in screenshot mode`).
  Each passes when its file is run alone, so this is local timeout flake under parallel
  load, not a regression — and this PR changes no TypeScript at all. CI's `test-default`
  shards are green.
- `vp run check:mobile-bundle` — pass (iOS and Android)

**Could not run locally:** the Swift tests. There is no XCTest runner on Linux; they only
execute in `ios-rn-ci.yml`'s macOS `build-and-test` job — so CI was the first proof of
both. That job has since gone **green**, so the suite compiles and its assertions hold.

**Device QA still owed before the train ships:**

1. Fresh install, never started a session, connect to a board another climber left lit —
   the wall must keep showing something rather than going dark, and must light your
   climb once you pick one.
2. Connect with a queue and a live session — the wall still re-lights on connect.
3. Start a session, empty the queue, disconnect and reconnect — the wall re-lights the
   last published climb rather than clearing. (This is the intended trade: a stale climb
   beats a black wall, and these boards are last-connection-wins. #4549 asserts the same
   behaviour on the JS side.)
4. Explicit clear from the BLE control sheet still darks the wall.

Bluetooth change, so this needs a Fable review before merge. Keeping it a draft until CI
is green and that review has landed; the merge itself goes out with the native train.
