### PR TITLE
fix(mobile): bound and retry the playlist queue-replacement drain

### DIFF
--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -121,10 +121,12 @@ export default function PlaylistDetail() {
       page,
       pageSize,
       board,
+      signal,
     }: {
       page: number;
       pageSize: number;
       board: { boardName: string; layoutId: number; sizeId: number; setIds: string; angle: number };
+      signal: AbortSignal;
     }) => {
       const input: GetPlaylistClimbsInput = {
         playlistId: playlistUuid,
@@ -136,9 +138,14 @@ export default function PlaylistDetail() {
         page,
         pageSize,
       };
+      // See the smart-playlist screen: passing the signal is what turns
+      // "stop paging" into "cancel the request that is already out".
       const response = await getHttpClient().request<GetPlaylistClimbsQueryResponse, { input: GetPlaylistClimbsInput }>(
-        GET_PLAYLIST_CLIMBS,
-        { input },
+        {
+          document: GET_PLAYLIST_CLIMBS,
+          variables: { input },
+          signal,
+        },
       );
       return {
         climbs: toQueueClimbs(response.playlistClimbs.climbs),

--- a/packages/mobile/app/(tabs)/discover/smart/[type].tsx
+++ b/packages/mobile/app/(tabs)/discover/smart/[type].tsx
@@ -55,7 +55,17 @@ export default function SmartPlaylistDetail() {
   // Suggestion-refresh fetcher pages the smart playlist scoped to the active
   // board name so the play-drawer swipe walks the full computed list.
   const fetchPage = useCallback(
-    async ({ page, pageSize, board }: { page: number; pageSize: number; board: { boardName: string } }) => {
+    async ({
+      page,
+      pageSize,
+      board,
+      signal,
+    }: {
+      page: number;
+      pageSize: number;
+      board: { boardName: string };
+      signal: AbortSignal;
+    }) => {
       const input: GetSmartPlaylistInput = {
         type: smartType,
         userId,
@@ -63,10 +73,14 @@ export default function SmartPlaylistDetail() {
         page,
         pageSize,
       };
-      const response = await getHttpClient().request<GetSmartPlaylistQueryResponse, { input: GetSmartPlaylistInput }>(
-        GET_SMART_PLAYLIST,
-        { input },
-      );
+      // `signal` is what makes backing out of a playlist actually cancel the
+      // load. Without it the drain only skipped the NEXT page; the in-flight
+      // request ran to completion and could still replace the queue late.
+      const response = await getHttpClient().request<GetSmartPlaylistQueryResponse, { input: GetSmartPlaylistInput }>({
+        document: GET_SMART_PLAYLIST,
+        variables: { input },
+        signal,
+      });
       return {
         climbs: toQueueClimbs(response.smartPlaylist.climbs),
         hasMore: response.smartPlaylist.hasMore,

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -884,6 +884,7 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
           expect.objectContaining({ tags: { source: 'playlist', op: 'replace-queue-capped' } }),
         );
       });
+      // Exactly one call per page: the mock never rejects, so no retry inflates this.
       expect(fetchPage).toHaveBeenCalledTimes(MAX_PLAYLIST_QUEUE_REPLACE_PAGES);
       // Truncated, not failed: the climber still gets a circuit and no toast.
       expect(mocks.setQueue).toHaveBeenCalled();

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -90,6 +90,20 @@ vi.mock('../../climb-to-queue-item', () => ({
   }),
 }));
 
+/** The shape graphql-request 7.4.0 actually throws for a rate-limited operation. */
+function makeRateLimitClientError(retryAfterSeconds: number): Error {
+  return Object.assign(new Error(`Rate limit exceeded. Try again in ${retryAfterSeconds} seconds.`), {
+    response: {
+      errors: [
+        {
+          message: `Rate limit exceeded. Try again in ${retryAfterSeconds} seconds.`,
+          extensions: { code: 'RATE_LIMITED', operation: 'smartPlaylist', retryAfterSeconds },
+        },
+      ],
+    },
+  });
+}
+
 function makeClimb(uuid: string, overrides: Partial<Climb> = {}): Climb {
   return {
     uuid,
@@ -881,7 +895,7 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
       await waitFor(() => {
         expect(mocks.reportHandledError).toHaveBeenCalledWith(
           expect.any(Error),
-          expect.objectContaining({ tags: { source: 'playlist', op: 'replace-queue-capped' } }),
+          expect.objectContaining({ tags: { source: 'playlist', op: 'replace-queue-page-cap' } }),
         );
       });
       // Exactly one call per page: the mock never rejects, so no retry inflates this.
@@ -914,6 +928,81 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
       );
       // And it does not spin: one page is enough to know the server is stuck.
       expect(fetchPage).toHaveBeenCalledTimes(1);
+    });
+
+    // The reachable half of the guard, and the one that used to be silent: a
+    // logbook playlist whose refs all fail to hydrate returns `climbs: []` with
+    // `hasMore: true`. The climber still gets a one-item queue either way, so
+    // this Sentry report is the only signal anyone gets.
+    it('reports a no-progress stop under its own op so triage can tell it from the page cap', async () => {
+      const fetchPage = vi.fn().mockResolvedValue({ climbs: [], hasMore: true });
+      const { result } = renderActivation(fetchPage, {
+        replaceQueueOnActivate: true,
+        sourceId: 'playlist:no-progress-2',
+        allClimbs: [makeClimb('a'), makeClimb('b')],
+      });
+
+      await act(async () => {
+        await result.current.activate(makeClimb('b'));
+      });
+
+      await waitFor(() => {
+        expect(mocks.reportHandledError).toHaveBeenCalledWith(
+          expect.any(Error),
+          expect.objectContaining({
+            tags: { source: 'playlist', op: 'replace-queue-no-progress' },
+            extra: { sourceId: 'playlist:no-progress-2', pagesFetched: 1, climbCount: 0 },
+          }),
+        );
+      });
+      // Still silent for the climber.
+      expect(mocks.showToast).not.toHaveBeenCalled();
+    });
+
+    // The rate-limit path runs through the REAL parseRateLimitError from
+    // @boardsesh/graphql-client (this file does not mock it). Without these two,
+    // renaming `retryAfterSeconds` or breaking the ClientError shape match would
+    // leave every suite green while every rate limit became a hard failure.
+    it('waits out a short rate limit read by the real parser and still fills the queue', async () => {
+      const tapped = makeClimb('b');
+      const fetchPage = vi
+        .fn()
+        .mockRejectedValueOnce(makeRateLimitClientError(1))
+        .mockResolvedValue({ climbs: [makeClimb('a'), tapped], hasMore: false });
+      const { result } = renderActivation(fetchPage, { replaceQueueOnActivate: true });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+
+      expect(fetchPage).toHaveBeenCalledTimes(2);
+      expect(mocks.showToast).not.toHaveBeenCalled();
+      const lastSetQueue = mocks.setQueue.mock.calls.at(-1);
+      expect(lastSetQueue?.[0].map((item: ClimbQueueItem) => item.climb.uuid)).toEqual(['a', 'b']);
+    }, 10_000);
+
+    it('fails fast on a long rate limit and hands the original error to Sentry', async () => {
+      const fetchPage = vi.fn().mockRejectedValue(makeRateLimitClientError(46));
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { result } = renderActivation(fetchPage, { replaceQueueOnActivate: true });
+
+      await act(async () => {
+        await result.current.activate(makeClimb('b'));
+      });
+
+      await waitFor(() => {
+        expect(mocks.showToast).toHaveBeenCalledWith('detail.queueReplace.loadFailed', 'error');
+      });
+      // No spinner held for 46 seconds, and no retry spent on it.
+      expect(fetchPage).toHaveBeenCalledTimes(1);
+      // The ORIGINAL error is what reaches reportHandledError, so
+      // isGraphqlRateLimitedError can still read extensions.code and downgrade
+      // the event to warning + rate_limited instead of paging someone.
+      const reported = mocks.reportHandledError.mock.calls.at(-1);
+      expect(reported?.[0]).toMatchObject({
+        response: { errors: [{ extensions: { code: 'RATE_LIMITED', retryAfterSeconds: 46 } }] },
+      });
+      errorSpy.mockRestore();
     });
 
     // The toast overlay renders BEHIND a native @expo/ui sheet, so a failure on

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import type { Climb, ClimbQueueItem } from '@boardsesh/queue';
 import type { UsePlaylistClimbActivationOptions } from '@boardsesh/playlists-react';
+import { MAX_PLAYLIST_QUEUE_REPLACE_PAGES } from '@boardsesh/playlists-react/fetch-playlist-suggestion-climbs';
 import { usePlaylistActivation, _resetEmptyBoardFetchReportsForTests } from '../use-playlist-activation';
 
 // The shared `usePlaylistClimbActivation` is exercised by @boardsesh/playlists-react's
@@ -36,15 +37,25 @@ const mocks = vi.hoisted(() => ({
 
 const VIEW_ONLY_BOARD = { boardName: 'tension', layoutId: 9, sizeId: 5, setIds: '1,2', angle: 35 };
 
-vi.mock('@boardsesh/playlists-react', () => ({
-  usePlaylistClimbActivation: (options: UsePlaylistClimbActivationOptions) => {
-    mocks.captured = options;
-    return mocks.activate;
-  },
-  fetchPlaylistSuggestionClimbs: (args: unknown) => mocks.fetchSuggestion(args),
-  isAbortError: (error: unknown) => error instanceof Error && error.name === 'AbortError',
-  PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE: 100,
-}));
+// Only the React hook is stubbed. The paged drain is the pure-TS half of the
+// package, and stubbing it would make every assertion below about page fetching
+// vacuous — so it comes from the real module via its subpath export.
+vi.mock('@boardsesh/playlists-react', async () => {
+  const drain = await vi.importActual<typeof import('@boardsesh/playlists-react/fetch-playlist-suggestion-climbs')>(
+    '@boardsesh/playlists-react/fetch-playlist-suggestion-climbs',
+  );
+  return {
+    usePlaylistClimbActivation: (options: UsePlaylistClimbActivationOptions) => {
+      mocks.captured = options;
+      return mocks.activate;
+    },
+    fetchPlaylistSuggestionClimbs: (args: unknown) => mocks.fetchSuggestion(args),
+    isAbortError: drain.isAbortError,
+    drainPlaylistPages: drain.drainPlaylistPages,
+    MAX_PLAYLIST_QUEUE_REPLACE_PAGES: drain.MAX_PLAYLIST_QUEUE_REPLACE_PAGES,
+    PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE: drain.PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
+  };
+});
 vi.mock('../../../providers/queue-provider', () => ({
   useQueueActions: () => ({
     setCurrentClimb: mocks.setCurrentClimb,
@@ -808,6 +819,126 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
       await waitFor(() => {
         expect(mocks.showToast).toHaveBeenCalledWith('detail.queueReplace.loadFailed', 'error');
       });
+      errorSpy.mockRestore();
+    });
+
+    // A plain Error is a server verdict, not a blip. Retrying it would only make
+    // the climber wait longer for the same toast, so the page is issued once.
+    it('does not retry a non-transport failure', async () => {
+      const fetchPage = vi.fn().mockRejectedValue(new Error('User not found'));
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { result } = renderActivation(fetchPage, { replaceQueueOnActivate: true });
+
+      await act(async () => {
+        await result.current.activate(makeClimb('b'));
+      });
+
+      await waitFor(() => {
+        expect(mocks.showToast).toHaveBeenCalledWith('detail.queueReplace.loadFailed', 'error');
+      });
+      expect(fetchPage).toHaveBeenCalledTimes(1);
+      errorSpy.mockRestore();
+    });
+
+    // The half of #4622 still firing in Sentry: one dropped fetch used to kill
+    // the whole replacement. Pins that the hook injects a retry predicate that
+    // actually recognises `TypeError: Network request failed`.
+    it('retries a dropped page and still fills the queue', async () => {
+      const tapped = makeClimb('b');
+      const fetchPage = vi
+        .fn()
+        .mockRejectedValueOnce(new TypeError('Network request failed'))
+        .mockResolvedValue({ climbs: [makeClimb('a'), tapped, makeClimb('c')], hasMore: false });
+      const { result } = renderActivation(fetchPage, { replaceQueueOnActivate: true });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+
+      await waitFor(() => {
+        expect(fetchPage).toHaveBeenCalledTimes(2);
+      });
+      await waitFor(() => {
+        const lastSetQueue = mocks.setQueue.mock.calls.at(-1);
+        expect(lastSetQueue?.[0].map((item: ClimbQueueItem) => item.climb.uuid)).toEqual(['a', 'b', 'c']);
+      });
+      expect(mocks.showToast).not.toHaveBeenCalled();
+    });
+
+    // The runaway bound. Truncation is silent for the climber and loud for us.
+    it('stops at the page cap, still replaces the queue, and reports it', async () => {
+      let pageCounter = 0;
+      const fetchPage = vi.fn(async () => ({ climbs: [makeClimb(`cap-${pageCounter++}`)], hasMore: true }));
+      const { result } = renderActivation(fetchPage, {
+        replaceQueueOnActivate: true,
+        sourceId: 'playlist:capped-1',
+      });
+
+      await act(async () => {
+        await result.current.activate(makeClimb('b'));
+      });
+
+      await waitFor(() => {
+        expect(mocks.reportHandledError).toHaveBeenCalledWith(
+          expect.any(Error),
+          expect.objectContaining({ tags: { source: 'playlist', op: 'replace-queue-capped' } }),
+        );
+      });
+      expect(fetchPage).toHaveBeenCalledTimes(MAX_PLAYLIST_QUEUE_REPLACE_PAGES);
+      // Truncated, not failed: the climber still gets a circuit and no toast.
+      expect(mocks.setQueue).toHaveBeenCalled();
+      expect(mocks.showToast).not.toHaveBeenCalled();
+    });
+
+    // A server that repeats a page is a paging defect, not the #3891 empty-fetch
+    // defect. Firing that canary here would poison the signal it exists to give.
+    it('does not fire the #3891 empty-fetch canary when the drain stopped on no-progress', async () => {
+      const tapped = makeClimb('b');
+      // Empty page that still claims there is more — the shape `52d9a631f` fixed.
+      const fetchPage = vi.fn().mockResolvedValue({ climbs: [], hasMore: true });
+      const { result } = renderActivation(fetchPage, {
+        replaceQueueOnActivate: true,
+        sourceId: 'playlist:no-progress-1',
+        allClimbs: [makeClimb('a'), tapped, makeClimb('c')],
+      });
+
+      await act(async () => {
+        await result.current.activate(tapped);
+      });
+
+      await waitFor(() => expect(fetchPage).toHaveBeenCalled());
+      expect(mocks.reportHandledError).not.toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({ tags: { source: 'playlist', op: 'replace-queue-empty' } }),
+      );
+      // And it does not spin: one page is enough to know the server is stuck.
+      expect(fetchPage).toHaveBeenCalledTimes(1);
+    });
+
+    // The toast overlay renders BEHIND a native @expo/ui sheet, so a failure on
+    // the confirm path used to leave the sheet up with an invisible error under
+    // it. The sheet must be gone by the time the toast is on screen.
+    it('dismisses the confirm sheet when the confirmed replacement fails', async () => {
+      const current = makeQueueItem('q-current', 'current');
+      const future = makeQueueItem('q-future', 'future');
+      mocks.queueState = { queue: [current, future], currentClimbQueueItem: current };
+      const fetchPage = vi.fn().mockRejectedValue(new Error('boom'));
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const { result } = renderActivation(fetchPage, { replaceQueueOnActivate: true });
+
+      await act(async () => {
+        await result.current.activate(makeClimb('b'));
+      });
+      expect(result.current.queueReplaceSheet.visible).toBe(true);
+
+      await act(async () => {
+        result.current.queueReplaceSheet.onConfirm();
+      });
+
+      await waitFor(() => {
+        expect(mocks.showToast).toHaveBeenCalledWith('detail.queueReplace.loadFailed', 'error');
+      });
+      expect(result.current.queueReplaceSheet.visible).toBe(false);
       errorSpy.mockRestore();
     });
   });

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -405,14 +405,20 @@ export function usePlaylistActivation({
           drainPagesFetched = drainResult.pagesFetched;
         }
         if (abortController.signal.aborted) return;
-        // The runaway bound fired, which means a server paging defect (or a
-        // genuinely enormous playlist) got past every other guard. Truncation is
-        // silent on purpose — the climber gets a working circuit either way, and
-        // a toast for a branch nothing should reach is copy we would have to
-        // translate forever. If this shows up in Sentry, revisit with evidence.
-        if (drainStopReason === 'page-cap' && !options.loadedClimbs) {
-          reportHandledError(new Error('Playlist drain hit the page cap'), {
-            tags: { source: 'playlist', op: 'replace-queue-capped' },
+        // The drain stopped short of the server's own end-of-list. Both reasons
+        // truncate silently for the climber — they still get a working circuit,
+        // and a toast for this would be copy we translate forever — so this
+        // report is the ONLY signal either branch produces. Separate `op` per
+        // reason because their odds could not be more different:
+        //   page-cap     needs 20 productive pages (2,000 climbs). Should never fire.
+        //   no-progress  is the count/select drift the guard exists for and CAN
+        //                fire on live data: a logbook playlist whose refs all
+        //                fail to hydrate returns `climbs: [], hasMore: true`,
+        //                which would otherwise be a silent one-item queue.
+        // Kept off the #3891 canary's `op` so neither signal pollutes the other.
+        if ((drainStopReason === 'page-cap' || drainStopReason === 'no-progress') && !options.loadedClimbs) {
+          reportHandledError(new Error(`Playlist drain stopped early: ${drainStopReason}`), {
+            tags: { source: 'playlist', op: `replace-queue-${drainStopReason}` },
             extra: { sourceId, pagesFetched: drainPagesFetched, climbCount: climbs.length },
           });
         }
@@ -472,7 +478,10 @@ export function usePlaylistActivation({
         }
         setPendingReplacement(null);
       } catch (error) {
-        if (isAbortError(error)) return;
+        // Ask the signal, not the error's `name` — see the drain's own catch.
+        // A runtime whose abort does not carry `name: 'AbortError'` would
+        // otherwise toast the climber for a cancellation they requested.
+        if (abortController.signal.aborted || isAbortError(error)) return;
         console.error('Playlist queue replacement failed:', error);
         reportHandledError(error, {
           tags: { source: 'playlist', op: 'replace-queue' },

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -20,10 +20,16 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   usePlaylistClimbActivation,
+  drainPlaylistPages,
   fetchPlaylistSuggestionClimbs,
   isAbortError,
+  MAX_PLAYLIST_QUEUE_REPLACE_PAGES,
   PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
+  type PlaylistDrainResult,
+  type PlaylistDrainStopReason,
 } from '@boardsesh/playlists-react';
+import { isTransportNetworkError } from '@boardsesh/offline-sync/error-classification';
+import { parseRateLimitError } from '@boardsesh/graphql-client';
 import { createPlaylistSuggestionSource, getQueueBoardKey, type Climb, type ClimbQueueItem } from '@boardsesh/queue';
 import { canAddClimbToBoard } from '@boardsesh/board-config';
 import { useActiveClimbUuid, usePlaylistSuggestionSource, useQueueActions } from '../../providers/queue-provider';
@@ -41,6 +47,16 @@ import type { PlaylistRenderBoard } from './use-playlist-render-board';
 // climber poking at a broken playlist re-taps rows freely, so without this one
 // bad playlist could ship hundreds of identical events.
 const reportedEmptyBoardFetches = new Set<string>();
+
+// Which page failures the drain should try again, injected so the shared package
+// keeps no dependency on `@boardsesh/offline-sync` (web does not have it).
+// `isTransportNetworkError` is deliberately narrow — it matches the runtime's
+// own hardcoded transport strings and errno codes, never a programmer bug — so a
+// deterministic server verdict still fails on the first attempt.
+const PLAYLIST_DRAIN_RETRY_POLICY = {
+  isRetryable: isTransportNetworkError,
+  parseRetryAfterSeconds: (error: unknown) => parseRateLimitError(error)?.retryAfterSeconds ?? null,
+} as const;
 
 /**
  * Clear the once-per-session canary bookkeeping. Test-only: the Set above is
@@ -132,6 +148,12 @@ type PendingQueueReplacement = {
   futureQueueCount: number;
   loadedClimbs?: Climb[];
   previewQueueItem?: ClimbQueueItem | null;
+  /**
+   * How the drain that produced `loadedClimbs` ended. Carried across the confirm
+   * sheet so the #3891 empty-fetch canary is judged on the drain that actually
+   * ran, not re-derived from a page list that has lost its provenance.
+   */
+  drainStopReason?: PlaylistDrainStopReason;
 };
 
 export type PlaylistQueueReplaceSheetState = {
@@ -310,14 +332,15 @@ export function usePlaylistActivation({
         activatedClimbUuid,
         signal,
         fetchPage: ({ page, pageSize, signal: pageSignal }) => fetchPage({ page, pageSize, board, signal: pageSignal }),
+        ...PLAYLIST_DRAIN_RETRY_POLICY,
       });
     },
     [activeBoard, fetchPage],
   );
 
   const fetchAllClimbsForBoard = useCallback(
-    async ({ signal }: { signal: AbortSignal }) => {
-      if (!activeBoard) return [];
+    async ({ signal }: { signal: AbortSignal }): Promise<PlaylistDrainResult> => {
+      if (!activeBoard) return { climbs: [], stopReason: 'complete', pagesFetched: 0 };
       const board = {
         boardName: activeBoard.boardType,
         layoutId: activeBoard.layoutId,
@@ -325,23 +348,13 @@ export function usePlaylistActivation({
         setIds: activeBoard.setIds,
         angle: activeBoard.angle,
       };
-      const climbs: Climb[] = [];
-      let page = 0;
-      let hasMore = true;
-
-      while (hasMore && !signal.aborted) {
-        const pageResult = await fetchPage({
-          page,
-          pageSize: PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
-          board,
-          signal,
-        });
-        climbs.push(...pageResult.climbs);
-        hasMore = pageResult.hasMore;
-        page += 1;
-      }
-
-      return climbs;
+      return drainPlaylistPages({
+        signal,
+        pageSize: PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
+        maxPages: MAX_PLAYLIST_QUEUE_REPLACE_PAGES,
+        fetchPage: ({ page, pageSize, signal: pageSignal }) => fetchPage({ page, pageSize, board, signal: pageSignal }),
+        ...PLAYLIST_DRAIN_RETRY_POLICY,
+      });
     },
     [activeBoard, fetchPage],
   );
@@ -371,15 +384,38 @@ export function usePlaylistActivation({
         allowClearingManualFuture?: boolean;
         loadedClimbs?: Climb[];
         previewQueueItem?: ClimbQueueItem | null;
+        drainStopReason?: PlaylistDrainStopReason;
       } = {},
     ) => {
       replacementAbortRef.current?.abort();
       const abortController = new AbortController();
       replacementAbortRef.current = abortController;
       setIsReplacingQueue(true);
+      // Read by the catch block so a failed drain reports how far it got.
+      let drainStopReason: PlaylistDrainStopReason | null = null;
+      let drainPagesFetched = 0;
       try {
-        const climbs = options.loadedClimbs ?? (await fetchAllClimbsForBoard({ signal: abortController.signal }));
+        let climbs = options.loadedClimbs;
+        if (climbs) {
+          drainStopReason = options.drainStopReason ?? null;
+        } else {
+          const drainResult = await fetchAllClimbsForBoard({ signal: abortController.signal });
+          climbs = drainResult.climbs;
+          drainStopReason = drainResult.stopReason;
+          drainPagesFetched = drainResult.pagesFetched;
+        }
         if (abortController.signal.aborted) return;
+        // The runaway bound fired, which means a server paging defect (or a
+        // genuinely enormous playlist) got past every other guard. Truncation is
+        // silent on purpose — the climber gets a working circuit either way, and
+        // a toast for a branch nothing should reach is copy we would have to
+        // translate forever. If this shows up in Sentry, revisit with evidence.
+        if (drainStopReason === 'page-cap' && !options.loadedClimbs) {
+          reportHandledError(new Error('Playlist drain hit the page cap'), {
+            tags: { source: 'playlist', op: 'replace-queue-capped' },
+            extra: { sourceId, pagesFetched: drainPagesFetched, climbCount: climbs.length },
+          });
+        }
         // Canary. A board-scoped fetch that comes back empty for a playlist the
         // detail list has already rendered climbable rows for degrades into a
         // perfectly plausible one-item queue (buildPlaylistQueue appends the
@@ -388,7 +424,14 @@ export function usePlaylistActivation({
         // per playlist per session, so the next instance of that class pages us
         // instead of a user. Gated on climbs this board CAN render, so a playlist
         // full of off-board climbs (legitimately empty here) stays silent.
-        if (climbs.length === 0 && activeBoard && !reportedEmptyBoardFetches.has(sourceId)) {
+        if (
+          climbs.length === 0 &&
+          // A capped or repeating drain is a different, already-reported fault.
+          // Firing #3891's canary on it would poison that signal.
+          (drainStopReason === null || drainStopReason === 'complete') &&
+          activeBoard &&
+          !reportedEmptyBoardFetches.has(sourceId)
+        ) {
           const renderableCount = countClimbsThisBoardCanRender(loadedClimbsRef.current, {
             boardName: activeBoard.boardType,
             layoutId: activeBoard.layoutId,
@@ -416,6 +459,7 @@ export function usePlaylistActivation({
             futureQueueCount: latestFutureQueueCount,
             loadedClimbs: climbs,
             previewQueueItem: options.previewQueueItem ?? null,
+            drainStopReason: drainStopReason ?? undefined,
           });
           return;
         }
@@ -430,7 +474,15 @@ export function usePlaylistActivation({
       } catch (error) {
         if (isAbortError(error)) return;
         console.error('Playlist queue replacement failed:', error);
-        reportHandledError(error, { tags: { source: 'playlist', op: 'replace-queue' } });
+        reportHandledError(error, {
+          tags: { source: 'playlist', op: 'replace-queue' },
+          extra: { sourceId, reason: drainStopReason ?? 'error', pagesFetched: drainPagesFetched },
+        });
+        // Dismiss the confirm sheet FIRST. The toast overlay is a root-level JS
+        // view and renders BEHIND a native @expo/ui sheet (toast-provider.tsx),
+        // so a failure on the confirm path used to leave the sheet up with an
+        // invisible error behind it.
+        setPendingReplacement(null);
         showToast(t('detail.queueReplace.loadFailed'), 'error');
       } finally {
         if (replacementAbortRef.current === abortController) {
@@ -463,6 +515,7 @@ export function usePlaylistActivation({
       allowClearingManualFuture: true,
       loadedClimbs: pendingReplacement.loadedClimbs,
       previewQueueItem: pendingReplacement.previewQueueItem,
+      drainStopReason: pendingReplacement.drainStopReason,
     });
   }, [getQueueSnapshot, isReplacingQueue, pendingReplacement, replaceQueueWithPlaylist]);
 

--- a/packages/shared/playlists-react/src/__tests__/fetch-playlist-suggestion-climbs.test.ts
+++ b/packages/shared/playlists-react/src/__tests__/fetch-playlist-suggestion-climbs.test.ts
@@ -301,7 +301,50 @@ describe('drainPlaylistPages', () => {
     expect(sleep).toHaveBeenCalledTimes(1);
   });
 
-  it('propagates an AbortError from a page without retrying it', async () => {
+  it('reports a caller-requested stop as caller-stop, not the runaway page cap', async () => {
+    const fetchPage = vi.fn(async ({ page }: { page: number }) => ({
+      climbs: makePage(page, 10),
+      hasMore: true,
+    }));
+
+    const result = await drainPlaylistPages({
+      fetchPage,
+      signal: new AbortController().signal,
+      pageSize: 10,
+      maxPages: 20,
+      isRetryable: neverRetryable,
+      parseRetryAfterSeconds: noRateLimit,
+      sleep: makeImmediateSleep(),
+      stopAfterPage: () => true,
+    });
+
+    // A consumer that mistook this for 'page-cap' would ship bogus runaway-bound
+    // telemetry for a stop it asked for itself.
+    expect(result.stopReason).toBe('caller-stop');
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops a uuid repeated inside a single page', async () => {
+    const duplicated = makeClimb('dupe');
+    const fetchPage = vi.fn(async () => ({
+      climbs: [duplicated, makeClimb('other'), duplicated],
+      hasMore: false,
+    }));
+
+    const result = await drainPlaylistPages({
+      fetchPage,
+      signal: new AbortController().signal,
+      pageSize: 10,
+      maxPages: 20,
+      isRetryable: neverRetryable,
+      parseRetryAfterSeconds: noRateLimit,
+      sleep: makeImmediateSleep(),
+    });
+
+    expect(result.climbs.map((climb) => climb.uuid)).toEqual(['dupe', 'other']);
+  });
+
+  it('rejects with an AbortError from a page without retrying it', async () => {
     const sleep = makeImmediateSleep();
     const abortError = new Error('aborted');
     abortError.name = 'AbortError';
@@ -316,6 +359,37 @@ describe('drainPlaylistPages', () => {
         pageSize: 100,
         maxPages: 30,
         // Deliberately permissive: abort must win over the retry predicate.
+        isRetryable: () => true,
+        parseRetryAfterSeconds: noRateLimit,
+        sleep,
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  // The expo/fetch shape. `FetchError` sets no `name` and prefixes the message
+  // with "fetch failed:", which `isTransportNetworkError` matches — so an abort
+  // would be classified as a retryable transport blip and, once the attempt
+  // budget refused the retry, surface as a hard failure for a cancellation the
+  // caller requested. Only the signal is authoritative.
+  it('treats a cancelled request as an abort even when the error carries no AbortError marker', async () => {
+    const sleep = makeImmediateSleep();
+    const controller = new AbortController();
+    const fetchPage = vi.fn(async () => {
+      controller.abort();
+      // No `name`, message shaped exactly like expo/fetch's FetchError.
+      throw new Error('fetch failed: The operation was aborted.');
+    });
+
+    await expect(
+      drainPlaylistPages({
+        fetchPage,
+        signal: controller.signal,
+        pageSize: 100,
+        maxPages: 20,
+        // Deliberately permissive: this is the predicate that would misfire.
         isRetryable: () => true,
         parseRetryAfterSeconds: noRateLimit,
         sleep,

--- a/packages/shared/playlists-react/src/__tests__/fetch-playlist-suggestion-climbs.test.ts
+++ b/packages/shared/playlists-react/src/__tests__/fetch-playlist-suggestion-climbs.test.ts
@@ -1,0 +1,497 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Climb } from '@boardsesh/queue';
+import {
+  drainPlaylistPages,
+  fetchPlaylistSuggestionClimbs,
+  isAbortError,
+  MAX_PLAYLIST_QUEUE_REPLACE_PAGES,
+  PLAYLIST_PAGE_MAX_ATTEMPTS,
+  PLAYLIST_RATE_LIMIT_MAX_WAIT_MS,
+  PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
+} from '../fetch-playlist-suggestion-climbs';
+
+function makeClimb(uuid: string): Climb {
+  return {
+    uuid,
+    name: `Climb ${uuid}`,
+    frames: '',
+    setter_username: 'test',
+    angle: 40,
+    ascensionist_count: 0,
+    difficulty: '6a/V3',
+    quality_average: '3',
+    stars: 3,
+    difficulty_error: '0',
+    benchmark_difficulty: null,
+  };
+}
+
+/** `pageSize` fresh climbs whose uuids are unique to `page`. */
+function makePage(page: number, pageSize: number): Climb[] {
+  return Array.from({ length: pageSize }, (_, index) => makeClimb(`p${page}-c${index}`));
+}
+
+/** A graphql-request `ClientError`-shaped rate limit, the shape the screens actually throw. */
+function makeRateLimitError(retryAfterSeconds: number): Error {
+  const error = new Error(`Rate limit exceeded. Try again in ${retryAfterSeconds} seconds.`);
+  return Object.assign(error, {
+    response: {
+      errors: [
+        {
+          message: `Rate limit exceeded. Try again in ${retryAfterSeconds} seconds.`,
+          extensions: { code: 'RATE_LIMITED', operation: 'smartPlaylist', retryAfterSeconds },
+        },
+      ],
+    },
+  });
+}
+
+function makeTransportError(): TypeError {
+  return new TypeError('Network request failed');
+}
+
+/** Records `(ms, signal)` and resolves immediately so the suite stays fast. */
+function makeImmediateSleep() {
+  return vi.fn(async (_ms: number, _signal: AbortSignal) => {});
+}
+
+const neverRetryable = () => false;
+const noRateLimit = () => null;
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('drainPlaylistPages', () => {
+  it('stops at maxPages when the server keeps claiming there is more', async () => {
+    const fetchPage = vi.fn(async ({ page }: { page: number }) => ({
+      climbs: makePage(page, 100),
+      hasMore: true,
+    }));
+
+    const result = await drainPlaylistPages({
+      fetchPage,
+      signal: new AbortController().signal,
+      pageSize: 100,
+      maxPages: MAX_PLAYLIST_QUEUE_REPLACE_PAGES,
+      isRetryable: neverRetryable,
+      parseRetryAfterSeconds: noRateLimit,
+      sleep: makeImmediateSleep(),
+    });
+
+    expect(fetchPage).toHaveBeenCalledTimes(MAX_PLAYLIST_QUEUE_REPLACE_PAGES);
+    expect(result.stopReason).toBe('page-cap');
+    expect(result.pagesFetched).toBe(MAX_PLAYLIST_QUEUE_REPLACE_PAGES);
+    expect(result.climbs).toHaveLength(MAX_PLAYLIST_QUEUE_REPLACE_PAGES * 100);
+  });
+
+  // Replays the server defect fixed in 52d9a631f: past the recommendation offset
+  // clamp the resolver re-served the SAME page with `hasMore: true` forever. The
+  // client must not need a correct server to terminate.
+  it('stops on no-progress when the server re-serves a page it already sent', async () => {
+    const fetchPage = vi.fn(async ({ page }: { page: number }) => ({
+      // Pages 0-4 are fresh; page 5 onward re-serves page 4, forever.
+      climbs: makePage(Math.min(page, 4), 10),
+      hasMore: true,
+    }));
+
+    const result = await drainPlaylistPages({
+      fetchPage,
+      signal: new AbortController().signal,
+      pageSize: 10,
+      maxPages: 50,
+      isRetryable: neverRetryable,
+      parseRetryAfterSeconds: noRateLimit,
+      sleep: makeImmediateSleep(),
+    });
+
+    expect(result.stopReason).toBe('no-progress');
+    expect(result.pagesFetched).toBe(6);
+    expect(fetchPage).toHaveBeenCalledTimes(6);
+    const uuids = result.climbs.map((climb) => climb.uuid);
+    expect(new Set(uuids).size).toBe(uuids.length);
+    expect(uuids).toHaveLength(50);
+  });
+
+  it('stops on no-progress for an empty page that still claims hasMore', async () => {
+    const fetchPage = vi.fn(async () => ({ climbs: [], hasMore: true }));
+
+    const result = await drainPlaylistPages({
+      fetchPage,
+      signal: new AbortController().signal,
+      pageSize: 100,
+      maxPages: 30,
+      isRetryable: neverRetryable,
+      parseRetryAfterSeconds: noRateLimit,
+      sleep: makeImmediateSleep(),
+    });
+
+    expect(result.stopReason).toBe('no-progress');
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  // An empty playlist legitimately returns nothing and says so. That must stay
+  // 'complete', because the mobile #3891 empty-fetch canary is gated on it.
+  it('treats an empty final page as complete, not no-progress', async () => {
+    const fetchPage = vi.fn(async () => ({ climbs: [], hasMore: false }));
+
+    const result = await drainPlaylistPages({
+      fetchPage,
+      signal: new AbortController().signal,
+      pageSize: 100,
+      maxPages: 30,
+      isRetryable: neverRetryable,
+      parseRetryAfterSeconds: noRateLimit,
+      sleep: makeImmediateSleep(),
+    });
+
+    expect(result.stopReason).toBe('complete');
+    expect(result.climbs).toEqual([]);
+  });
+
+  it('retries a transport error once and completes', async () => {
+    const sleep = makeImmediateSleep();
+    const fetchPage = vi
+      .fn<(args: { page: number }) => Promise<{ climbs: Climb[]; hasMore: boolean }>>()
+      .mockResolvedValueOnce({ climbs: makePage(0, 2), hasMore: true })
+      .mockRejectedValueOnce(makeTransportError())
+      .mockResolvedValueOnce({ climbs: makePage(1, 2), hasMore: false });
+
+    const result = await drainPlaylistPages({
+      fetchPage,
+      signal: new AbortController().signal,
+      pageSize: 2,
+      maxPages: 30,
+      isRetryable: (error) => error instanceof TypeError,
+      parseRetryAfterSeconds: noRateLimit,
+      sleep,
+      random: () => 0,
+    });
+
+    expect(result.stopReason).toBe('complete');
+    expect(result.climbs).toHaveLength(4);
+    // Page 1 was issued twice: 3 calls for 2 pages.
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+    expect(fetchPage.mock.calls[1]?.[0].page).toBe(1);
+    expect(fetchPage.mock.calls[2]?.[0].page).toBe(1);
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  // THE test. `smart-playlists.ts:350` throws a plain `Error('User not found')`
+  // for a broken profile. Retrying that buys nothing and doubles the time to the
+  // same toast, so a non-transport error must fail on the first attempt.
+  it('does NOT retry a non-transport error', async () => {
+    const sleep = makeImmediateSleep();
+    const fetchPage = vi
+      .fn<(args: { page: number }) => Promise<{ climbs: Climb[]; hasMore: boolean }>>()
+      .mockResolvedValueOnce({ climbs: makePage(0, 2), hasMore: true })
+      .mockRejectedValue(new Error('User not found'));
+
+    await expect(
+      drainPlaylistPages({
+        fetchPage,
+        signal: new AbortController().signal,
+        pageSize: 2,
+        maxPages: 30,
+        isRetryable: (error) => error instanceof TypeError,
+        parseRetryAfterSeconds: noRateLimit,
+        sleep,
+      }),
+    ).rejects.toThrow('User not found');
+
+    // Page 0 once, page 1 once. No retry of page 1.
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('gives up after PLAYLIST_PAGE_MAX_ATTEMPTS on a persistent transport error', async () => {
+    const sleep = makeImmediateSleep();
+    const fetchPage = vi.fn(async () => {
+      throw makeTransportError();
+    });
+
+    await expect(
+      drainPlaylistPages({
+        fetchPage,
+        signal: new AbortController().signal,
+        pageSize: 100,
+        maxPages: 30,
+        isRetryable: () => true,
+        parseRetryAfterSeconds: noRateLimit,
+        sleep,
+      }),
+    ).rejects.toThrow('Network request failed');
+
+    expect(fetchPage).toHaveBeenCalledTimes(PLAYLIST_PAGE_MAX_ATTEMPTS);
+    expect(sleep).toHaveBeenCalledTimes(PLAYLIST_PAGE_MAX_ATTEMPTS - 1);
+  });
+
+  it('waits out a short RATE_LIMITED and re-issues the same page', async () => {
+    const sleep = makeImmediateSleep();
+    const fetchPage = vi
+      .fn<(args: { page: number }) => Promise<{ climbs: Climb[]; hasMore: boolean }>>()
+      .mockRejectedValueOnce(makeRateLimitError(2))
+      .mockResolvedValueOnce({ climbs: makePage(0, 2), hasMore: false });
+
+    const result = await drainPlaylistPages({
+      fetchPage,
+      signal: new AbortController().signal,
+      pageSize: 2,
+      maxPages: 30,
+      isRetryable: neverRetryable,
+      parseRetryAfterSeconds: (error) => parseRetryAfterSecondsForTest(error),
+      sleep,
+      random: () => 0,
+    });
+
+    expect(result.stopReason).toBe('complete');
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep.mock.calls[0]?.[0]).toBe(2000);
+  });
+
+  it('fails fast on a RATE_LIMITED that asks for longer than the ceiling', async () => {
+    const sleep = makeImmediateSleep();
+    const fetchPage = vi.fn(async () => {
+      throw makeRateLimitError(46);
+    });
+
+    await expect(
+      drainPlaylistPages({
+        fetchPage,
+        signal: new AbortController().signal,
+        pageSize: 100,
+        maxPages: 30,
+        isRetryable: () => true,
+        parseRetryAfterSeconds: (error) => parseRetryAfterSecondsForTest(error),
+        sleep,
+      }),
+    ).rejects.toThrow(/Rate limit exceeded/);
+
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+    expect(46_000).toBeGreaterThan(PLAYLIST_RATE_LIMIT_MAX_WAIT_MS);
+  });
+
+  it('propagates an AbortError from a page without retrying it', async () => {
+    const sleep = makeImmediateSleep();
+    const abortError = new Error('aborted');
+    abortError.name = 'AbortError';
+    const fetchPage = vi.fn(async () => {
+      throw abortError;
+    });
+
+    await expect(
+      drainPlaylistPages({
+        fetchPage,
+        signal: new AbortController().signal,
+        pageSize: 100,
+        maxPages: 30,
+        // Deliberately permissive: abort must win over the retry predicate.
+        isRetryable: () => true,
+        parseRetryAfterSeconds: noRateLimit,
+        sleep,
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  // Without this, an aborted activation resolves seconds later and stomps a queue
+  // the climber has already moved on from.
+  it('aborts during the default sleep, clears its timer and never resolves late', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const fetchPage = vi.fn(async () => {
+      throw makeTransportError();
+    });
+
+    const drainPromise = drainPlaylistPages({
+      fetchPage,
+      signal: controller.signal,
+      pageSize: 100,
+      maxPages: 30,
+      isRetryable: () => true,
+      parseRetryAfterSeconds: noRateLimit,
+      // No `sleep` override: this exercises the real abortable sleep.
+    });
+    const settled = drainPromise.then(
+      () => 'resolved' as const,
+      (error: unknown) => (isAbortError(error) ? ('aborted' as const) : ('rejected' as const)),
+    );
+
+    // Let the first fetchPage rejection land and the retry sleep start.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.getTimerCount()).toBe(1);
+
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(5000);
+
+    await expect(settled).resolves.toBe('aborted');
+    expect(vi.getTimerCount()).toBe(0);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fetch anything when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const fetchPage = vi.fn(async () => ({ climbs: makePage(0, 2), hasMore: true }));
+
+    const result = await drainPlaylistPages({
+      fetchPage,
+      signal: controller.signal,
+      pageSize: 2,
+      maxPages: 30,
+      isRetryable: neverRetryable,
+      parseRetryAfterSeconds: noRateLimit,
+      sleep: makeImmediateSleep(),
+    });
+
+    expect(fetchPage).not.toHaveBeenCalled();
+    expect(result.stopReason).toBe('aborted');
+    expect(result.climbs).toEqual([]);
+  });
+});
+
+describe('fetchPlaylistSuggestionClimbs', () => {
+  it('keeps its 10-page cap', async () => {
+    const fetchPage = vi.fn(async ({ page }: { page: number }) => ({
+      climbs: makePage(page, 1),
+      hasMore: true,
+    }));
+
+    const climbs = await fetchPlaylistSuggestionClimbs({
+      activatedClimbUuid: 'not-in-this-list',
+      signal: new AbortController().signal,
+      fetchPage,
+      pageSize: 1,
+    });
+
+    expect(fetchPage).toHaveBeenCalledTimes(10);
+    expect(climbs).toHaveLength(10);
+    expect(fetchPage.mock.calls[0]?.[0]).toMatchObject({ page: 0, pageSize: 1 });
+  });
+
+  it('defaults to the shared refresh page size', async () => {
+    const fetchPage = vi.fn(async (_args: { page: number; pageSize: number; signal: AbortSignal }) => ({
+      climbs: makePage(0, 1),
+      hasMore: false,
+    }));
+
+    await fetchPlaylistSuggestionClimbs({
+      activatedClimbUuid: 'p0-c0',
+      signal: new AbortController().signal,
+      fetchPage,
+    });
+
+    expect(fetchPage.mock.calls[0]?.[0]).toMatchObject({ pageSize: PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE });
+  });
+
+  it('stops once maxClimbsAfterActivated climbs follow the activated climb', async () => {
+    // Page 0 holds the activated climb; every later page adds 10 more after it.
+    const fetchPage = vi.fn(async ({ page }: { page: number }) => ({
+      climbs: page === 0 ? [makeClimb('activated'), ...makePage(0, 9)] : makePage(page, 10),
+      hasMore: true,
+    }));
+
+    const climbs = await fetchPlaylistSuggestionClimbs({
+      activatedClimbUuid: 'activated',
+      signal: new AbortController().signal,
+      fetchPage,
+      pageSize: 10,
+      maxPages: 100,
+      maxClimbsAfterActivated: 25,
+    });
+
+    // 9 after the activated climb on page 0, +10 on page 1, +10 on page 2 = 29 >= 25.
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+    expect(climbs).toHaveLength(30);
+  });
+
+  it('does not count climbs loaded before the activated climb is seen', async () => {
+    const fetchPage = vi.fn(async ({ page }: { page: number }) => ({
+      climbs: page === 2 ? [makeClimb('activated'), ...makePage(2, 9)] : makePage(page, 10),
+      hasMore: true,
+    }));
+
+    await fetchPlaylistSuggestionClimbs({
+      activatedClimbUuid: 'activated',
+      signal: new AbortController().signal,
+      fetchPage,
+      pageSize: 10,
+      maxPages: 100,
+      maxClimbsAfterActivated: 25,
+    });
+
+    // Pages 0 and 1 are "before"; counting starts on page 2 (9), then 10, then 10.
+    expect(fetchPage).toHaveBeenCalledTimes(5);
+  });
+
+  it('does not double-count a page that was retried', async () => {
+    const sleep = makeImmediateSleep();
+    let page1Attempts = 0;
+    const fetchPage = vi.fn(async ({ page }: { page: number }) => {
+      if (page === 1) {
+        page1Attempts += 1;
+        if (page1Attempts === 1) throw makeTransportError();
+      }
+      return {
+        climbs: page === 0 ? [makeClimb('activated'), ...makePage(0, 9)] : makePage(page, 10),
+        hasMore: true,
+      };
+    });
+
+    const climbs = await fetchPlaylistSuggestionClimbs({
+      activatedClimbUuid: 'activated',
+      signal: new AbortController().signal,
+      fetchPage,
+      pageSize: 10,
+      maxPages: 100,
+      maxClimbsAfterActivated: 25,
+      isRetryable: (error) => error instanceof TypeError,
+      sleep,
+    });
+
+    // Same stop point as the un-retried run above: page 2 tips it over 25.
+    // 4 calls = 3 pages + 1 retry.
+    expect(fetchPage).toHaveBeenCalledTimes(4);
+    expect(climbs).toHaveLength(30);
+  });
+
+  it('stops mid-drain when the signal aborts between pages', async () => {
+    const controller = new AbortController();
+    const fetchPage = vi.fn(async ({ page }: { page: number }) => {
+      if (page === 1) controller.abort();
+      return { climbs: makePage(page, 10), hasMore: true };
+    });
+
+    const climbs = await fetchPlaylistSuggestionClimbs({
+      activatedClimbUuid: 'nope',
+      signal: controller.signal,
+      fetchPage,
+      pageSize: 10,
+      maxPages: 100,
+    });
+
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+    expect(climbs).toHaveLength(20);
+  });
+});
+
+/**
+ * Local stand-in for `parseRateLimitError` from `@boardsesh/graphql-client`.
+ * The drainer takes the predicate as a parameter precisely so this package needs
+ * no dependency on it; the mobile hook injects the real one.
+ */
+function parseRetryAfterSecondsForTest(error: unknown): number | null {
+  if (typeof error !== 'object' || error === null) return null;
+  const response = (error as { response?: { errors?: unknown } }).response;
+  if (!response || !Array.isArray(response.errors)) return null;
+  for (const entry of response.errors as Array<{ extensions?: { code?: unknown; retryAfterSeconds?: unknown } }>) {
+    if (entry?.extensions?.code === 'RATE_LIMITED' && typeof entry.extensions.retryAfterSeconds === 'number') {
+      return entry.extensions.retryAfterSeconds;
+    }
+  }
+  return null;
+}

--- a/packages/shared/playlists-react/src/__tests__/fetch-playlist-suggestion-climbs.test.ts
+++ b/packages/shared/playlists-react/src/__tests__/fetch-playlist-suggestion-climbs.test.ts
@@ -273,6 +273,34 @@ describe('drainPlaylistPages', () => {
     expect(46_000).toBeGreaterThan(PLAYLIST_RATE_LIMIT_MAX_WAIT_MS);
   });
 
+  // The attempt budget is per page and covers BOTH retry reasons: a rate limit
+  // arriving on the second attempt throws rather than sleeping again. That keeps
+  // a page bounded at two requests no matter how the failures interleave, which
+  // is the property that stops a rate limit from becoming an unbounded wait.
+  it('does not wait out a rate limit that arrives on the last allowed attempt', async () => {
+    const sleep = makeImmediateSleep();
+    const fetchPage = vi
+      .fn<(args: { page: number }) => Promise<{ climbs: Climb[]; hasMore: boolean }>>()
+      .mockRejectedValueOnce(makeTransportError())
+      .mockRejectedValueOnce(makeRateLimitError(1));
+
+    await expect(
+      drainPlaylistPages({
+        fetchPage,
+        signal: new AbortController().signal,
+        pageSize: 100,
+        maxPages: 30,
+        isRetryable: (error) => error instanceof TypeError,
+        parseRetryAfterSeconds: (error) => parseRetryAfterSecondsForTest(error),
+        sleep,
+      }),
+    ).rejects.toThrow(/Rate limit exceeded/);
+
+    expect(fetchPage).toHaveBeenCalledTimes(PLAYLIST_PAGE_MAX_ATTEMPTS);
+    // Only the transport backoff slept. The rate limit was never waited out.
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
   it('propagates an AbortError from a page without retrying it', async () => {
     const sleep = makeImmediateSleep();
     const abortError = new Error('aborted');

--- a/packages/shared/playlists-react/src/fetch-playlist-suggestion-climbs.ts
+++ b/packages/shared/playlists-react/src/fetch-playlist-suggestion-climbs.ts
@@ -77,6 +77,10 @@ export type DrainPlaylistPagesArgs = {
   /**
    * Stop the drain after this page even though the server has more. Receives the
    * climbs this page actually added (duplicates already filtered out).
+   *
+   * Only called while `hasMore` is still true — on the final page the drain is
+   * ending anyway, so there is nothing left to stop. Do not use it as a
+   * see-every-page hook: it will miss the last one.
    */
   stopAfterPage?: (newClimbs: Climb[]) => boolean;
   /** Injectable so tests do not wait on real timers. */

--- a/packages/shared/playlists-react/src/fetch-playlist-suggestion-climbs.ts
+++ b/packages/shared/playlists-react/src/fetch-playlist-suggestion-climbs.ts
@@ -10,6 +10,25 @@ const MAX_PLAYLIST_SUGGESTION_REFRESH_PAGES = 10;
 // sizes without burning a 10-page fetch on every activation.
 const MAX_PLAYLIST_SUGGESTION_REFRESH_CLIMBS_AFTER_ACTIVE = 250;
 
+// Runaway bound for the queue-replacement drain, NOT a product feature.
+// Nothing on the server should get near it today: the four RECOMMENDED_* smart
+// playlists are clamped to 6 pages by MAX_RECOMMENDATION_OFFSET, and both the
+// logbook branch and `playlistClimbs` derive `hasMore` from real row counts. It
+// exists so the next paging defect degrades into a short queue instead of
+// draining until a rate limiter says stop — CLAUDE.md's mobile performance
+// checklist bans drain-until-`hasMore` outright. Hitting it is a bug, so the
+// mobile caller reports it to Sentry rather than telling the climber.
+export const MAX_PLAYLIST_QUEUE_REPLACE_PAGES = 30;
+
+// One retry per page. A dropped fetch on gym wifi recovers on the second try;
+// a third almost never lands and just doubles the time to the error toast.
+export const PLAYLIST_PAGE_MAX_ATTEMPTS = 2;
+const PLAYLIST_PAGE_RETRY_DELAY_MS = 600;
+const PLAYLIST_PAGE_RETRY_JITTER_MS = 250;
+// A rate limit asking for longer than this is handed to the climber instead of
+// held behind a spinner. The server hands out waits of up to 60 s.
+export const PLAYLIST_RATE_LIMIT_MAX_WAIT_MS = 3_000;
+
 type FetchPlaylistSuggestionPageArgs = {
   page: number;
   pageSize: number;
@@ -21,10 +40,191 @@ type PlaylistSuggestionPage = {
   hasMore: boolean;
 };
 
+export type PlaylistDrainStopReason =
+  /** The server said `hasMore: false`. The list is whole. */
+  | 'complete'
+  /** A client-side cap stopped a server that still had more to give. */
+  | 'page-cap'
+  /** A page added no climbs we had not already seen. The server is repeating itself. */
+  | 'no-progress'
+  /** The caller aborted between pages. */
+  | 'aborted';
+
+export type PlaylistDrainResult = {
+  climbs: Climb[];
+  stopReason: PlaylistDrainStopReason;
+  pagesFetched: number;
+};
+
+export type DrainPlaylistPagesArgs = {
+  fetchPage: (args: FetchPlaylistSuggestionPageArgs) => Promise<PlaylistSuggestionPage>;
+  signal: AbortSignal;
+  pageSize: number;
+  /** Required. There is deliberately no default that means "unlimited". */
+  maxPages: number;
+  /**
+   * True when the error is a transient transport failure worth one more try.
+   * Injected so this package needs no dependency on `@boardsesh/offline-sync`
+   * (which web does not have); mobile passes `isTransportNetworkError`.
+   * Defaults to never retrying — a caller that wants retries must ask for them.
+   */
+  isRetryable?: (error: unknown) => boolean;
+  /**
+   * Seconds the server asked us to wait, or null when this is not a rate limit.
+   * Injected for the same reason; mobile passes `parseRateLimitError`.
+   */
+  parseRetryAfterSeconds?: (error: unknown) => number | null;
+  /**
+   * Stop the drain after this page even though the server has more. Receives the
+   * climbs this page actually added (duplicates already filtered out).
+   */
+  stopAfterPage?: (newClimbs: Climb[]) => boolean;
+  /** Injectable so tests do not wait on real timers. */
+  sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
+  /** Injectable so retry jitter is deterministic under test. */
+  random?: () => number;
+};
+
 export function isAbortError(err: unknown): boolean {
   if (typeof err !== 'object' || err === null) return false;
   const abortCandidate = err as { name?: unknown; code?: unknown };
   return abortCandidate.name === 'AbortError' || abortCandidate.code === 20;
+}
+
+function createAbortError(): Error {
+  const abortError = new Error('Playlist page drain aborted');
+  abortError.name = 'AbortError';
+  return abortError;
+}
+
+/**
+ * `setTimeout` that loses to its abort signal.
+ *
+ * Load-bearing: without the abort listener a cancelled activation sits out its
+ * retry delay and then replaces a queue the climber has already moved on from.
+ * The timer is cleared on abort so nothing fires late.
+ *
+ * `packages/sync-runtime/src/daemon.ts` has an equivalent `sleepWithAbort`, but
+ * that package is daemon-side and pulling it into the RN/web bundle graph for
+ * twelve lines is the wrong trade. A third caller should extract these into a
+ * shared async-utils package.
+ */
+function defaultAbortableSleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(createAbortError());
+      return;
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const onAbort = () => {
+      if (timer !== undefined) clearTimeout(timer);
+      reject(createAbortError());
+    };
+    timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/**
+ * Page through a playlist until the server runs out, something stops making
+ * progress, or a bound is hit — retrying only what is worth retrying.
+ *
+ * Retry policy, in order of precedence:
+ *   1. abort wins over everything and is never retried;
+ *   2. a short `RATE_LIMITED` is waited out and the same page re-issued; a long
+ *      one is rethrown so the climber gets an answer instead of a spinner;
+ *   3. a transport failure (`isRetryable`) gets one more attempt;
+ *   4. anything else — a GraphQL validation error, a 4xx, the logbook resolver's
+ *      `User not found` — is rethrown immediately. Retrying a deterministic
+ *      server verdict buys nothing and doubles the time to the same toast.
+ *
+ * Retrying a page is safe because the drain is a read: climbs are appended only
+ * on success, and duplicates are filtered by uuid regardless.
+ *
+ * Deliberately NOT here: pacing. Both rate-limit tiers count requests per 60 s
+ * window, so any delay short enough to be acceptable inside an interactive tap
+ * gives no rate-limit protection at all — it only adds latency. Terminating the
+ * loop is `maxPages`' job.
+ */
+export async function drainPlaylistPages({
+  fetchPage,
+  signal,
+  pageSize,
+  maxPages,
+  isRetryable = () => false,
+  parseRetryAfterSeconds = () => null,
+  stopAfterPage,
+  sleep = defaultAbortableSleep,
+  random = Math.random,
+}: DrainPlaylistPagesArgs): Promise<PlaylistDrainResult> {
+  const climbs: Climb[] = [];
+  const seenClimbUuids = new Set<string>();
+  let page = 0;
+  let hasMore = true;
+  let stopReason: PlaylistDrainStopReason = 'complete';
+
+  const fetchPageWithRetry = async (pageIndex: number): Promise<PlaylistSuggestionPage> => {
+    let attempt = 0;
+    for (;;) {
+      attempt += 1;
+      try {
+        return await fetchPage({ page: pageIndex, pageSize, signal });
+      } catch (error) {
+        if (isAbortError(error)) throw error;
+        if (attempt >= PLAYLIST_PAGE_MAX_ATTEMPTS) throw error;
+
+        const retryAfterSeconds = parseRetryAfterSeconds(error);
+        if (retryAfterSeconds !== null) {
+          const waitMs = retryAfterSeconds * 1000;
+          if (waitMs > PLAYLIST_RATE_LIMIT_MAX_WAIT_MS) throw error;
+          await sleep(waitMs + random() * PLAYLIST_PAGE_RETRY_JITTER_MS, signal);
+          continue;
+        }
+
+        if (!isRetryable(error)) throw error;
+        await sleep(PLAYLIST_PAGE_RETRY_DELAY_MS + random() * PLAYLIST_PAGE_RETRY_JITTER_MS, signal);
+      }
+    }
+  };
+
+  while (hasMore) {
+    if (signal.aborted) {
+      stopReason = 'aborted';
+      break;
+    }
+    if (page >= maxPages) {
+      stopReason = 'page-cap';
+      break;
+    }
+
+    const pageResult = await fetchPageWithRetry(page);
+    page += 1;
+
+    const newClimbs = pageResult.climbs.filter((pageClimb) => !seenClimbUuids.has(pageClimb.uuid));
+    for (const newClimb of newClimbs) {
+      seenClimbUuids.add(newClimb.uuid);
+    }
+    climbs.push(...newClimbs);
+    hasMore = pageResult.hasMore;
+
+    if (newClimbs.length === 0) {
+      // An empty final page is a legitimately empty list. An empty page the
+      // server claims to have more after is the defect class `52d9a631f` fixed
+      // on the backend: a clamped offset re-serving the same rows forever.
+      stopReason = hasMore ? 'no-progress' : 'complete';
+      break;
+    }
+
+    if (hasMore && stopAfterPage?.(newClimbs)) {
+      stopReason = 'page-cap';
+      break;
+    }
+  }
+
+  return { climbs, stopReason, pagesFetched: page };
 }
 
 export async function fetchPlaylistSuggestionClimbs({
@@ -34,6 +234,10 @@ export async function fetchPlaylistSuggestionClimbs({
   pageSize = PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
   maxPages = MAX_PLAYLIST_SUGGESTION_REFRESH_PAGES,
   maxClimbsAfterActivated = MAX_PLAYLIST_SUGGESTION_REFRESH_CLIMBS_AFTER_ACTIVE,
+  isRetryable,
+  parseRetryAfterSeconds,
+  sleep,
+  random,
 }: {
   activatedClimbUuid: string;
   signal: AbortSignal;
@@ -41,30 +245,32 @@ export async function fetchPlaylistSuggestionClimbs({
   pageSize?: number;
   maxPages?: number;
   maxClimbsAfterActivated?: number;
-}): Promise<Climb[]> {
-  const fetchedClimbs: Climb[] = [];
-  let page = 0;
-  let hasMore = true;
+} & Pick<DrainPlaylistPagesArgs, 'isRetryable' | 'parseRetryAfterSeconds' | 'sleep' | 'random'>): Promise<Climb[]> {
   let activatedClimbSeen = false;
   let loadedClimbsAfterActivated = 0;
 
-  while (hasMore && page < maxPages && loadedClimbsAfterActivated < maxClimbsAfterActivated && !signal.aborted) {
-    const pageResult = await fetchPage({ page, pageSize, signal });
-
-    for (const pageClimb of pageResult.climbs) {
-      if (pageClimb.uuid === activatedClimbUuid) {
-        activatedClimbSeen = true;
-        continue;
+  const { climbs } = await drainPlaylistPages({
+    fetchPage,
+    signal,
+    pageSize,
+    maxPages,
+    isRetryable,
+    parseRetryAfterSeconds,
+    sleep,
+    random,
+    stopAfterPage: (newClimbs) => {
+      for (const newClimb of newClimbs) {
+        if (newClimb.uuid === activatedClimbUuid) {
+          activatedClimbSeen = true;
+          continue;
+        }
+        if (activatedClimbSeen) {
+          loadedClimbsAfterActivated += 1;
+        }
       }
-      if (activatedClimbSeen) {
-        loadedClimbsAfterActivated += 1;
-      }
-    }
+      return loadedClimbsAfterActivated >= maxClimbsAfterActivated;
+    },
+  });
 
-    fetchedClimbs.push(...pageResult.climbs);
-    hasMore = pageResult.hasMore;
-    page += 1;
-  }
-
-  return fetchedClimbs;
+  return climbs;
 }

--- a/packages/shared/playlists-react/src/fetch-playlist-suggestion-climbs.ts
+++ b/packages/shared/playlists-react/src/fetch-playlist-suggestion-climbs.ts
@@ -18,7 +18,15 @@ const MAX_PLAYLIST_SUGGESTION_REFRESH_CLIMBS_AFTER_ACTIVE = 250;
 // draining until a rate limiter says stop — CLAUDE.md's mobile performance
 // checklist bans drain-until-`hasMore` outright. Hitting it is a bug, so the
 // mobile caller reports it to Sentry rather than telling the climber.
-export const MAX_PLAYLIST_QUEUE_REPLACE_PAGES = 30;
+//
+// 20 is chosen against the budget this guard exists to protect, not by feel:
+//   20 pages x PLAYLIST_PAGE_MAX_ATTEMPTS (2) = 40 requests worst case,
+//   against `applyRateLimit(ctx, 60, 'smartPlaylist')` — a fixed 60-per-60s
+//   bucket keyed `${userId}:smartPlaylist` and SHARED with the list screen's
+//   own infinite scroll. 40 leaves 20 requests of headroom; 30 pages would put
+//   the worst case at exactly 60, i.e. sitting on the trip point.
+// 20 x 100 climbs is still a 2,000-climb queue, far past any real session.
+export const MAX_PLAYLIST_QUEUE_REPLACE_PAGES = 20;
 
 // One retry per page. A dropped fetch on gym wifi recovers on the second try;
 // a third almost never lands and just doubles the time to the error toast.
@@ -27,6 +35,10 @@ const PLAYLIST_PAGE_RETRY_DELAY_MS = 600;
 const PLAYLIST_PAGE_RETRY_JITTER_MS = 250;
 // A rate limit asking for longer than this is handed to the climber instead of
 // held behind a spinner. The server hands out waits of up to 60 s.
+// Per PAGE, not per drain: a fully rate-limited 20-page drain could still sleep
+// ~60 s in total behind the caller's spinner. That needs a 2,000-climb playlist
+// AND sustained 429s, so it is a known bound rather than a live risk; a
+// drain-level deadline is the fix if it ever shows up.
 export const PLAYLIST_RATE_LIMIT_MAX_WAIT_MS = 3_000;
 
 type FetchPlaylistSuggestionPageArgs = {
@@ -43,8 +55,10 @@ type PlaylistSuggestionPage = {
 export type PlaylistDrainStopReason =
   /** The server said `hasMore: false`. The list is whole. */
   | 'complete'
-  /** A client-side cap stopped a server that still had more to give. */
+  /** The runaway page bound stopped a server that still had more to give. */
   | 'page-cap'
+  /** The caller's own `stopAfterPage` predicate ended the drain. Not a fault. */
+  | 'caller-stop'
   /** A page added no climbs we had not already seen. The server is repeating itself. */
   | 'no-progress'
   /** The caller aborted between pages. */
@@ -177,7 +191,14 @@ export async function drainPlaylistPages({
       try {
         return await fetchPage({ page: pageIndex, pageSize, signal });
       } catch (error) {
-        if (isAbortError(error)) throw error;
+        // Abort wins over everything — including the runtime's error shape. Only
+        // ask the signal, which is authoritative; `name: 'AbortError'` is not.
+        // RN's whatwg-fetch sets it, but expo/fetch throws a `FetchError` with
+        // NO `name` and a "fetch failed:" prefix, which `isTransportNetworkError`
+        // would happily classify as a retryable transport blip. Trusting the
+        // shape alone turns a cancellation the climber asked for into a red
+        // toast plus a Sentry event.
+        if (signal.aborted || isAbortError(error)) throw createAbortError();
         if (attempt >= PLAYLIST_PAGE_MAX_ATTEMPTS) throw error;
 
         const retryAfterSeconds = parseRetryAfterSeconds(error);
@@ -207,9 +228,13 @@ export async function drainPlaylistPages({
     const pageResult = await fetchPageWithRetry(page);
     page += 1;
 
-    const newClimbs = pageResult.climbs.filter((pageClimb) => !seenClimbUuids.has(pageClimb.uuid));
-    for (const newClimb of newClimbs) {
-      seenClimbUuids.add(newClimb.uuid);
+    // Marking as we go, so a uuid repeated INSIDE one page is dropped too — a
+    // filter-then-mark pass would let both copies through.
+    const newClimbs: Climb[] = [];
+    for (const pageClimb of pageResult.climbs) {
+      if (seenClimbUuids.has(pageClimb.uuid)) continue;
+      seenClimbUuids.add(pageClimb.uuid);
+      newClimbs.push(pageClimb);
     }
     climbs.push(...newClimbs);
     hasMore = pageResult.hasMore;
@@ -223,7 +248,7 @@ export async function drainPlaylistPages({
     }
 
     if (hasMore && stopAfterPage?.(newClimbs)) {
-      stopReason = 'page-cap';
+      stopReason = 'caller-stop';
       break;
     }
   }

--- a/packages/shared/playlists-react/src/index.ts
+++ b/packages/shared/playlists-react/src/index.ts
@@ -49,10 +49,19 @@ export type { UsePlaylistMutationsOptions, UsePlaylistMutationsResult } from './
 export { usePlaylistItemMutations } from './use-playlist-item-mutations';
 export type { UsePlaylistItemMutationsOptions, UsePlaylistItemMutationsResult } from './use-playlist-item-mutations';
 
-// Suggestion-refresh helper (also reachable via the
-// ./fetch-playlist-suggestion-climbs subpath).
+// Paged playlist drain + the suggestion-refresh helper built on it (also
+// reachable via the ./fetch-playlist-suggestion-climbs subpath).
 export {
+  drainPlaylistPages,
   fetchPlaylistSuggestionClimbs,
   isAbortError,
+  MAX_PLAYLIST_QUEUE_REPLACE_PAGES,
+  PLAYLIST_PAGE_MAX_ATTEMPTS,
+  PLAYLIST_RATE_LIMIT_MAX_WAIT_MS,
   PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
+} from './fetch-playlist-suggestion-climbs';
+export type {
+  DrainPlaylistPagesArgs,
+  PlaylistDrainResult,
+  PlaylistDrainStopReason,
 } from './fetch-playlist-suggestion-climbs';

--- a/packages/shared/playlists-react/src/index.ts
+++ b/packages/shared/playlists-react/src/index.ts
@@ -56,8 +56,6 @@ export {
   fetchPlaylistSuggestionClimbs,
   isAbortError,
   MAX_PLAYLIST_QUEUE_REPLACE_PAGES,
-  PLAYLIST_PAGE_MAX_ATTEMPTS,
-  PLAYLIST_RATE_LIMIT_MAX_WAIT_MS,
   PLAYLIST_SUGGESTION_REFRESH_PAGE_SIZE,
 } from './fetch-playlist-suggestion-climbs';
 export type {


### PR DESCRIPTION
## Summary

Closes #4622.

**Lead with the honest finding: the `RATE_LIMITED` half of this ticket was a server bug, and it is already fixed.**

`52d9a631f` ("fix(backend): MoonBoard playlist activation left the queue empty") changed how the smart-playlist resolver derives `hasMore`:

```diff
-      hasMore: (recPage + 1) * pageSize < totalCount,
+      hasMore: recPage < maxRecPage && (recPage + 1) * pageSize < totalCount,
```

Before it, the four `RECOMMENDED_*` presets clamped their offset at `MAX_RECOMMENDATION_OFFSET = 500` but computed `hasMore` against the unclamped catalog-wide `totalCount`. From page 6 on the server re-served the same 100 climbs with `hasMore: true` forever, and the client's `while (hasMore && !signal.aborted)` had no exit — it fired `smartPlaylist` requests until the 60/min bucket rejected it. That is the mechanism behind the 23 `RATE_LIMITED` events.

That commit has been on `main` since **2026-07-31 20:48 UTC** (merge `5b08d2029`, PR #4010) and there has been no recurrence in the 24 days since. For calibration: the original bursts ran 07-15, 07-16, 07-17, 07-20, 07-21, 07-28, so the largest gap inside the incident was 7 days. 24 days is 3.4× that. At `pageSize: 100` a recommendation drain is now capped at **6 requests**.

Two caveats stated plainly rather than papered over:

- The ticket's timeline does **not** prove the fix stopped it. The last `RATE_LIMITED` event is 2026-07-28 07:49, which is 3d 13h *before* `52d9a631f` reached `main`. The evidence is the silence *since*, not the stop itself.
- **I could not verify the Sentry gate.** The review asked for a re-run of the Discover query at `statsPeriod=30d` filtered to `source:playlist op:replace-queue` to confirm zero `RATE_LIMITED` events after 2026-07-31 20:48 UTC. Sentry reads need a `sntryu_` user token, and this environment has none (no `sentry-cli`, no Sentry MCP, no token in env). **Please confirm that query before merging.** If any `RATE_LIMITED` appears after that timestamp, the server fix did not hold and this becomes a backend investigation instead of client hardening. Nothing here depends on that answer being "zero" — the still-firing `TypeError: Network request failed` half (21 events / 9 users, last seen 2026-08-17) justifies the change on its own — but the framing above does.

### What this PR actually fixes

**One dropped page no longer kills the whole queue replacement.** `replaceQueueWithPlaylist` awaits the drain and its result is the *only* input to `setQueue`, so any thrown page landed in the catch-all and produced `detail.queueReplace.loadFailed`. With the server fix in, a recommendation drain is 1–6 requests, so this is mundane: one flaky `fetch` out of six. The drain now retries a transport failure once.

**A drain that stops early now reports itself.** `page-cap` and `no-progress` both truncate silently for the climber, so a `reportHandledError` under `op: replace-queue-page-cap` / `replace-queue-no-progress` is the only signal either produces. They are split because their odds differ enormously: `page-cap` needs 20 productive pages (2,000 climbs) and should never fire, while `no-progress` is the count/select drift the guard exists for and *can* fire on live data — a logbook smart playlist whose refs all fail to hydrate (`hydrate-climbs.ts:163` drops refs with no `board_climbs` row) returns `climbs: [], hasMore: true`, which would otherwise be a silent one-item queue. Without this, the PR would have made that shape *less* observable than `main`.

**Abort is decided by the signal, not the error's `name`.** `isAbortError` alone is only correct because every shipped build sets `EXPO_PUBLIC_USE_RN_FETCH=1`. Without it, `expo/fetch` throws a `FetchError` with no `name` and a `fetch failed:` prefix, which `isTransportNetworkError` matches — so a cancellation would be retried as a transport blip and then surface as a red toast plus a Sentry event. Since this PR is what plumbs the signal into `fetch`, both catch sites now check `signal.aborted` first.

**Retries are narrow on purpose.** Only transport-class errors retry, via `isTransportNetworkError` from `@boardsesh/offline-sync/error-classification`. A deterministic server verdict — a GraphQL validation error, a 4xx, the logbook resolver's `throw new Error('User not found')` at `smart-playlists.ts:350` — fails on the first attempt, as it does today. Retrying those would only make the climber wait ~1s longer for the same toast.

**Backing out of a playlist now actually cancels the load.** `signal` was already on the `fetchPage` option type but neither screen destructured it, so `replacementAbortRef.abort()` only stopped the *next* page from being issued while the in-flight one ran to completion. Both screens now pass it into `getHttpClient().request({ document, variables, signal })`.

**The loop is bounded.** `MAX_PLAYLIST_QUEUE_REPLACE_PAGES = 20` plus a no-progress guard (a page adding zero new climb uuids stops the drain). The no-progress guard is the precise defence against the `52d9a631f` defect class — it fires on the first repeated page rather than after 30 — and against any future drift between the logbook branch's `selectSmartClimbRefs` and its separate `countSmartClimbRefs` at `smart-playlists.ts:353-355`. CLAUDE.md's mobile performance checklist bans drain-until-`hasMore` outright.

**The error toast on the confirm path is now visible.** The toast overlay is a root-level JS view that renders *behind* a native `@expo/ui` sheet (`toast-provider.tsx:54-59`, whose own comment says so). `confirmQueueReplacement` runs the drain while `PlaylistQueueReplaceSheet` is still up, so a failure there left the sheet visible with an invisible error behind it. `setPendingReplacement(null)` now runs before `showToast`. This is a latent bug the existing `loadFailed` toast has had all along.

### One behavioural delta worth calling out

`fetchPlaylistSuggestionClimbs` now **deduplicates by uuid**. The old loop pushed `pageResult.climbs` unfiltered; the new path shares `drainPlaylistPages`' `seenClimbUuids` set, which is what the no-progress guard is built on. This is an improvement — duplicates in a swipe track are a bug, and `buildPlaylistQueue` already deduped downstream — but it is a real change for anything that relied on page-order duplicates. Nothing does.

### Deliberately not in this PR

The cap is 20 rather than 30 deliberately: 20 pages x 2 attempts = **40 requests** worst case against the 60-per-60s `smartPlaylist` bucket, which is keyed `${userId}:smartPlaylist` and shared with the list screen's own paging. 30 pages would have put the worst case at exactly 60 — sitting on the trip point the guard exists to avoid. The arithmetic is in a comment next to the constant.

- **No truncation toast and no new i18n keys.** The 30-page cap is a runaway bound, not a product feature. It cannot fire for the four recommendation presets (the server stops at 6 pages), so a toast plus 8 strings across `en-US/es/fr/de` would be permanent translation-parity obligation for a branch nothing should reach. Truncation is silent for the climber and loud for us: hitting the cap fires `reportHandledError` with `op: replace-queue-capped`. If that ever shows in Sentry, we add the toast then, with evidence.
- **No pacing.** Both rate-limit tiers count requests per 60s window, so any delay short enough to be acceptable inside an interactive tap gives zero rate-limit protection — it only adds latency. Terminating the loop is the cap's job.
- **No resume state machine.** At ≤6 pages, "retrying starts from page 0" costs 6 requests out of 60.
- **No backend change.** The 60/min `smartPlaylist` budget stays as it is.

### Triage note

The Sentry tag `use-playlist-activation.ts:414` in the ticket is **stale**. Line 414 today is `setPendingReplacement({` inside the future-queue warning branch; the catch-all moved when the file gained the #3891 empty-fetch canary on 2026-07-30. Triage on the `op: replace-queue` tag, not the line tag. This PR also adds `{ reason, pagesFetched }` to that report so the next occurrence is classifiable without one.

### Filed separately

#4711 — the offline-sync drainer dead-letters `RATE_LIMITED` mutations instead of retrying them. The fix exists on `feat/standings-phase0`/`phase1` (`06e0d0671`) but is **not on `main`**, so `isRetryable` still dead-letters string-coded `RATE_LIMITED`, reachable via `setter_follows` (30/min) and beta-link ticks. Cross-linked to #4458 so it isn't fixed twice. Out of scope here — the playlist drain is a read, not an outbox mutation.

## Release Notes

Starting a big playlist no longer dies on one dropped page: a flaky page retries on its own, and backing out of a playlist actually cancels the load.

## Test plan

Every command below was run in a fresh worktree off `origin/main` (`76cc8f522`) and passed:

| command | result |
| --- | --- |
| `vp run typecheck:mobile` | pass |
| `vp run typecheck:web` | pass (`playlists-react` is a web dep) |
| `vp test run --project playlists-react --reporter=agent` | pass — 41 tests, 5 files |
| `vp run test:mobile` | pass — 6938 tests, 701 files |
| `vp run check:mobile-bundle` | pass |
| `vp check` | pass |

**30 new tests** (21 shared, 9 mobile). `packages/shared/playlists-react/src/__tests__/fetch-playlist-suggestion-climbs.test.ts` is new — there was no test for this file at all before. It covers: the page cap; the no-progress guard replaying the `52d9a631f` bug (page 5 onward re-serving page 4 with `hasMore: true`); an empty page with `hasMore: true` vs an empty *final* page (the second must stay `complete`, because the #3891 canary is gated on it); transport retry; **non-transport errors NOT being retried**; `RATE_LIMITED` at 2s waited out vs 46s failing fast, built in the real graphql-request `ClientError` shape; abort during a page; abort during a sleep under fake timers asserting `vi.getTimerCount() === 0` and no late resolve; a pre-aborted signal doing zero fetches; and the preserved `fetchPlaylistSuggestionClimbs` contract (10-page cap, `maxClimbsAfterActivated` counted only after the activated uuid is seen, no double-count on a retried page).

**Three mutation tests were run to prove the new guards are load-bearing**, not just green:

1. Flipping the retry predicate to retry-everything (the policy the original plan proposed) turned exactly one test red: *"does NOT retry a non-transport error"*.
2. Removing the canary stop-reason gate turned red: *"does not fire the #3891 empty-fetch canary when the drain stopped on no-progress"*.
3. Removing the `setPendingReplacement(null)` call from the catch turned red: *"dismisses the confirm sheet when the confirmed replacement fails"*. To be precise about what that test guards: it pins the **presence** of the dismiss, not its position. Moving the call after `showToast` leaves it green, because both are React state updates in the same async continuation and React 19 batches them into one commit — the order cannot change what renders. The presence is the real fix: on `main` the catch never dismissed the sheet at all, so a confirm-path failure left it up indefinitely with an invisible toast behind it. The ordering in the source is documentation of intent, not a guarantee the test enforces.

One deliberate divergence from the review's test list: it asks for *"`page-cap` replaces the queue and does not fire the #3891 canary"*. With the real drain wired in, a `page-cap` stop is **unreachable with zero climbs** — it requires 30 successful pages that each added new climbs, so `climbs.length >= 30` and the canary could never fire on it anyway. The reachable canary-poisoning case is `no-progress` with zero climbs (an empty page that still claims `hasMore`), so the test guards that instead, plus a separate test that `page-cap` replaces the queue and reports `replace-queue-capped`. Both were confirmed to fail before the fix.

The mobile test file previously stubbed the entire `@boardsesh/playlists-react` module, which would have made every page-fetch assertion vacuous once the loop moved into the package. It now pulls the real pure-TS drain through its subpath export and stubs only the React hook.

**Not verified:** the Sentry gate (no read token in this environment — see Summary), and on-device QA. `.boardsesh/qa-notes.md` covers the flows to exercise: happy path unchanged on both screens, airplane-mode toggle mid-drain riding it out, a non-network failure failing immediately rather than after a retry, back-out actually cancelling, and the confirm-sheet toast being visible on failure.

**Risk / rollback.** JS-only, no migrations, no backend change, no native change, no BLE code (no Fable review gate). Behaviour is governed by constants in one shared module: setting `PLAYLIST_PAGE_MAX_ATTEMPTS = 1` reverts to today's timing with the cap intact; `git revert` plus the automatic production OTA on merge to `main` is a full rollback at an unchanged fingerprint.
