### PR TITLE
fix(web): gate the sticky-locale 307 on a crawler list that names live scrapers

### DIFF
--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -655,12 +655,27 @@ describe('middleware cache headers on climb view pages', () => {
 // A crawler that persists cookies (observed in production logs) acquires
 // boardsesh-locale by crawling one /de|/es|/fr page, then bounces every
 // subsequent unprefixed URL through a locale twin — ~15k of these 307s/day,
-// plus the render MISS on the twin it lands on. Bots must never be sent
+// plus the render MISS on the twin it lands on. Crawlers must never be sent
 // through the sticky-locale redirect, and must never acquire the cookie.
+//
+// #4667 gated this on Next's `userAgent(request).isBot`, whose list names no
+// scraper newer than ~2023. Probed against production on 2026-08-24, Googlebot
+// correctly got a 200 while AhrefsBot, SemrushBot, DataForSeoBot and MJ12bot
+// were all still taking the 307 to the /es twin. The cases below cover both
+// halves of the repo-owned list in `app/lib/is-crawler.ts`.
 describe('middleware bot-gates the sticky locale redirect and cookie', () => {
   const GOOGLEBOT_UA = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
   const CHROME_UA =
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36';
+  const CRAWLER_UAS: [string, string][] = [
+    ['Googlebot (named by Next)', GOOGLEBOT_UA],
+    ['AhrefsBot', 'Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)'],
+    ['SemrushBot', 'Mozilla/5.0 (compatible; SemrushBot/7~bl; +http://www.semrush.com/bot.html)'],
+    ['DataForSeoBot', 'Mozilla/5.0 (compatible; DataForSeoBot/1.0; +https://dataforseo.com/dataforseo-bot)'],
+    ['MJ12bot', 'Mozilla/5.0 (compatible; MJ12bot/v1.4.8; http://mj12bot.com/)'],
+    ['DotBot', 'Mozilla/5.0 (compatible; DotBot/1.2; +https://opensiteexplorer.org/dotbot; help@moz.com)'],
+    ['archive.org_bot', 'Mozilla/5.0 (compatible; archive.org_bot +http://www.archive.org/details/archive.org_bot)'],
+  ];
 
   function makeRequestWithUserAgent(url: string, ua: string): NextRequest {
     return new NextRequest(new URL(url, 'http://localhost:3000'), {
@@ -668,16 +683,19 @@ describe('middleware bot-gates the sticky locale redirect and cookie', () => {
     });
   }
 
-  it('does not 307 a bot carrying a stale non-default locale cookie — it gets a default-locale 200 for the requested URL', () => {
-    const request = makeRequestWithUserAgent('/some/page', GOOGLEBOT_UA);
-    request.cookies.set(LOCALE_COOKIE, 'de');
+  it.each(CRAWLER_UAS)(
+    'does not 307 %s carrying a stale non-default locale cookie — it gets a default-locale 200 for the requested URL',
+    (_label, crawlerUa) => {
+      const request = makeRequestWithUserAgent('/some/page', crawlerUa);
+      request.cookies.set(LOCALE_COOKIE, 'de');
 
-    const response = middleware(request);
+      const response = middleware(request);
 
-    expect(response.status).not.toBe(307);
-    expect(response.headers.has('location')).toBe(false);
-    expect(response.headers.get(`x-middleware-request-${LOCALE_HEADER}`)).toBe(DEFAULT_LOCALE);
-  });
+      expect(response.status).not.toBe(307);
+      expect(response.headers.has('location')).toBe(false);
+      expect(response.headers.get(`x-middleware-request-${LOCALE_HEADER}`)).toBe(DEFAULT_LOCALE);
+    },
+  );
 
   it('still 307s a human (non-bot UA) carrying the same stale locale cookie', () => {
     const request = makeRequestWithUserAgent('/some/page', CHROME_UA);
@@ -689,11 +707,14 @@ describe('middleware bot-gates the sticky locale redirect and cookie', () => {
     expect(response.headers.get('location')).toBe('http://localhost:3000/de/some/page');
   });
 
-  it('never sets the boardsesh-locale cookie for a bot visiting a locale-prefixed URL', () => {
-    const response = middleware(makeRequestWithUserAgent('/es/some/page', GOOGLEBOT_UA));
+  it.each(CRAWLER_UAS)(
+    'never sets the boardsesh-locale cookie for %s visiting a locale-prefixed URL',
+    (_label, crawlerUa) => {
+      const response = middleware(makeRequestWithUserAgent('/es/some/page', crawlerUa));
 
-    expect(response.headers.has('set-cookie')).toBe(false);
-  });
+      expect(response.headers.has('set-cookie')).toBe(false);
+    },
+  );
 
   it('sets the boardsesh-locale cookie for a human (non-bot UA) visiting a locale-prefixed URL', () => {
     const response = middleware(makeRequestWithUserAgent('/es/some/page', CHROME_UA));
@@ -701,6 +722,21 @@ describe('middleware bot-gates the sticky locale redirect and cookie', () => {
     const setCookie = response.headers.get('set-cookie');
     expect(setCookie).toContain(LOCALE_COOKIE);
     expect(setCookie).toContain('es');
+  });
+
+  // The /api/v1 and /api/auth matcher entries reach the classifier call site,
+  // so the isApi short-circuit must leave their behaviour untouched.
+  it('leaves an /api/v1 request unchanged whether or not it carries a crawler UA', () => {
+    const crawlerResponse = middleware(
+      makeRequestWithUserAgent('/api/v1/kilter/climbs', 'Mozilla/5.0 (compatible; AhrefsBot/7.0)'),
+    );
+    const humanResponse = middleware(makeRequestWithUserAgent('/api/v1/kilter/climbs', CHROME_UA));
+
+    expect(crawlerResponse.status).toBe(humanResponse.status);
+    expect(crawlerResponse.headers.has('set-cookie')).toBe(false);
+    expect(humanResponse.headers.has('set-cookie')).toBe(false);
+    expect(crawlerResponse.headers.get(`x-middleware-request-${LOCALE_HEADER}`)).toBe(DEFAULT_LOCALE);
+    expect(humanResponse.headers.get(`x-middleware-request-${LOCALE_HEADER}`)).toBe(DEFAULT_LOCALE);
   });
 });
 

--- a/packages/web/app/lib/__tests__/is-crawler.test.ts
+++ b/packages/web/app/lib/__tests__/is-crawler.test.ts
@@ -27,11 +27,23 @@ const nextBotTokens = extractNextBotTokens();
 const uaContaining = (token: string) => `Mozilla/5.0 (compatible; ${token}/2.1; +http://example.invalid/bot.html)`;
 
 describe('isCrawlerUserAgent is a superset of the installed Next bot list', () => {
-  it('found the isBot regex in the installed Next, with a plausible token count', () => {
+  it('extracted a plausible token list from the installed Next, not regex debris', () => {
     // Guards the extraction itself: if Next ever ships a differently-shaped
-    // isBot, this fails loudly instead of leaving the it.each below vacuous.
+    // isBot, this must fail loudly rather than leave the it.each below vacuous
+    // or, worse, iterating over fragments that happen to number 30+. A count
+    // alone would not catch that, so anchor on tokens Next has shipped since
+    // 2019 and reject anything that does not look like a UA token.
     expect(nextBotTokens.length).toBeGreaterThanOrEqual(30);
-    expect(nextBotTokens).toContain('Googlebot');
+    expect(nextBotTokens.length).toBeLessThan(200);
+    for (const anchorToken of ['Googlebot', 'Bingbot', 'facebookexternalhit', 'Twitterbot', 'GPTBot']) {
+      expect(nextBotTokens).toContain(anchorToken);
+    }
+    for (const token of nextBotTokens) {
+      expect(token.length).toBeGreaterThan(2);
+      expect(token.length).toBeLessThan(40);
+      // UA tokens, not regex fragments: no leftover grouping or quantifiers.
+      expect(/^[\w .+-]+$/.test(token)).toBe(true);
+    }
   });
 
   it.each(nextBotTokens)('still classifies Next token %s as a crawler', (token) => {

--- a/packages/web/app/lib/__tests__/is-crawler.test.ts
+++ b/packages/web/app/lib/__tests__/is-crawler.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vite-plus/test';
+// Deep import into Next internals, used ONLY here: `next/server` re-exports
+// `userAgent` but not `isBot`, and this suite needs the live regex to prove we
+// are still a superset of it. Production code never takes this path — see the
+// header of `is-crawler.ts`.
+import { isBot } from 'next/dist/server/web/spec-extension/user-agent';
+import { CRAWLER_USER_AGENT_PATTERN, isCrawlerUserAgent } from '@/app/lib/is-crawler';
+
+/**
+ * Pull the alternatives out of the installed Next's `isBot` source rather than
+ * hand-copying them, so a future Next widening fails this suite instead of
+ * silently leaving our pattern narrower than the one we replaced.
+ */
+function extractNextBotTokens(): string[] {
+  const isBotSource = String(isBot);
+  const regexLiteral = /\/((?:\\.|\[[^\]]*\]|[^/\\])+)\/i\.test\(/.exec(isBotSource);
+  if (!regexLiteral) {
+    throw new Error(`Could not find the isBot regex literal in the installed Next. Source was:\n${isBotSource}`);
+  }
+  return regexLiteral[1].split('|');
+}
+
+const nextBotTokens = extractNextBotTokens();
+
+// Realistic-shaped UA that embeds one token, so each case exercises a substring
+// match in context rather than the bare token on its own.
+const uaContaining = (token: string) => `Mozilla/5.0 (compatible; ${token}/2.1; +http://example.invalid/bot.html)`;
+
+describe('isCrawlerUserAgent is a superset of the installed Next bot list', () => {
+  it('found the isBot regex in the installed Next, with a plausible token count', () => {
+    // Guards the extraction itself: if Next ever ships a differently-shaped
+    // isBot, this fails loudly instead of leaving the it.each below vacuous.
+    expect(nextBotTokens.length).toBeGreaterThanOrEqual(30);
+    expect(nextBotTokens).toContain('Googlebot');
+  });
+
+  it.each(nextBotTokens)('still classifies Next token %s as a crawler', (token) => {
+    const userAgentHeader = uaContaining(token);
+    // Sanity: the fixture really does embed the token Next matches on.
+    expect(isBot(userAgentHeader)).toBe(true);
+    expect(isCrawlerUserAgent(userAgentHeader)).toBe(true);
+  });
+});
+
+describe('isCrawlerUserAgent covers the scrapers Next omits', () => {
+  // Every UA here was sent at production on 2026-08-24 and reached the origin
+  // (HTTP 200 on the /es twin, HTTP 307 to the twin on the unprefixed URL).
+  const SCRAPER_UAS: [string, string][] = [
+    ['AhrefsBot', 'Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)'],
+    ['AhrefsSiteAudit', 'Mozilla/5.0 (compatible; AhrefsSiteAudit/6.1; +http://ahrefs.com/robot/)'],
+    ['SemrushBot', 'Mozilla/5.0 (compatible; SemrushBot/7~bl; +http://www.semrush.com/bot.html)'],
+    ['DataForSeoBot', 'Mozilla/5.0 (compatible; DataForSeoBot/1.0; +https://dataforseo.com/dataforseo-bot)'],
+    ['MJ12bot', 'Mozilla/5.0 (compatible; MJ12bot/v1.4.8; http://mj12bot.com/)'],
+    ['DotBot', 'Mozilla/5.0 (compatible; DotBot/1.2; +https://opensiteexplorer.org/dotbot; help@moz.com)'],
+    ['BLEXBot', 'Mozilla/5.0 (compatible; BLEXBot/1.0; +http://webmeup-crawler.com/)'],
+    ['Barkrowler', 'Mozilla/5.0 (compatible; Barkrowler/0.9; +https://babbar.tech/crawler)'],
+    ['serpstatbot', 'Mozilla/5.0 (compatible; serpstatbot/2.1; +http://serpstatbot.com/)'],
+    ['SeznamBot', 'Mozilla/5.0 (compatible; SeznamBot/4.0; +http://napoveda.seznam.cz/seznambot-intro/)'],
+    ['ZoominfoBot', 'Mozilla/5.0 (compatible; ZoominfoBot; zoominfobot at zoominfo dot com)'],
+    ['Screaming Frog', 'Screaming Frog SEO Spider/21.4'],
+    ['archive.org_bot', 'Mozilla/5.0 (compatible; archive.org_bot +http://www.archive.org/details/archive.org_bot)'],
+  ];
+
+  it.each(SCRAPER_UAS)('classifies %s as a crawler', (_token, userAgentHeader) => {
+    expect(isCrawlerUserAgent(userAgentHeader)).toBe(true);
+  });
+
+  it.each(SCRAPER_UAS)('%s is not already covered by Next', (_token, userAgentHeader) => {
+    // If Next ever adds one of these, drop it from SEO_SCRAPER_TOKENS rather
+    // than carrying the same token in both halves.
+    expect(isBot(userAgentHeader)).toBe(false);
+  });
+
+  it('escapes the dot in archive.org_bot instead of letting it match any character', () => {
+    expect(isCrawlerUserAgent('Mozilla/5.0 (compatible; archiveXorg_bot)')).toBe(false);
+  });
+});
+
+describe('isCrawlerUserAgent leaves real browsers alone', () => {
+  // A false positive costs a real visitor their sticky locale, so these are the
+  // cases that must never regress.
+  const BROWSER_UAS: [string, string][] = [
+    [
+      'Chrome on Windows',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
+    ],
+    ['Firefox on Linux', 'Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0'],
+    [
+      'Safari on iOS',
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Mobile/15E148 Safari/604.1',
+    ],
+    [
+      'Edge on Windows',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 Edg/128.0.2739.42',
+    ],
+    [
+      'Samsung Internet',
+      'Mozilla/5.0 (Linux; Android 14; SAMSUNG SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/25.0 Chrome/121.0.0.0 Mobile Safari/537.36',
+    ],
+    [
+      'Yandex Browser desktop',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 YaBrowser/23.9.1.962 Yowser/2.5 Safari/537.36',
+    ],
+    [
+      'Yandex Browser Android',
+      'Mozilla/5.0 (Linux; arm_64; Android 13; SM-A536B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 YaBrowser/22.11.3.104.00 SA/3 Mobile Safari/537.36',
+    ],
+  ];
+
+  it.each(BROWSER_UAS)('does not classify %s as a crawler', (_label, userAgentHeader) => {
+    expect(isCrawlerUserAgent(userAgentHeader)).toBe(false);
+  });
+
+  it('inherits one Yandex false positive from Next, and it fails gracefully', () => {
+    // The Yandex Search in-app browser spells `YandexSearch`, which contains the
+    // `yandex` substring Next matches on. We keep the token rather than diverge
+    // from Next: the cost is that this visitor gets a default-locale 200 for the
+    // URL they asked for instead of a sticky-locale redirect — the same
+    // behaviour the bot branch was designed to give, not an error.
+    const yandexSearchInAppUa =
+      'Mozilla/5.0 (Linux; Android 13; SM-A536B) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/106.0.0.0 Mobile Safari/537.36 YandexSearch/1.0';
+    expect(isBot(yandexSearchInAppUa)).toBe(true);
+    expect(isCrawlerUserAgent(yandexSearchInAppUa)).toBe(true);
+  });
+});
+
+describe('isCrawlerUserAgent handles a missing header', () => {
+  it('returns false for null', () => {
+    expect(isCrawlerUserAgent(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isCrawlerUserAgent(undefined)).toBe(false);
+  });
+
+  it('returns false for an empty string', () => {
+    expect(isCrawlerUserAgent('')).toBe(false);
+  });
+});
+
+describe('CRAWLER_USER_AGENT_PATTERN is stateless', () => {
+  it('carries no g flag, so repeated .test() calls do not alternate', () => {
+    expect(CRAWLER_USER_AGENT_PATTERN.flags).toBe('i');
+
+    const ahrefsUa = 'Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)';
+    expect(CRAWLER_USER_AGENT_PATTERN.test(ahrefsUa)).toBe(true);
+    expect(CRAWLER_USER_AGENT_PATTERN.test(ahrefsUa)).toBe(true);
+    expect(CRAWLER_USER_AGENT_PATTERN.test(ahrefsUa)).toBe(true);
+  });
+});

--- a/packages/web/app/lib/is-crawler.ts
+++ b/packages/web/app/lib/is-crawler.ts
@@ -1,0 +1,126 @@
+/**
+ * Crawler classification for the two sticky-locale gates in `middleware.ts`.
+ *
+ * `next/server` exposes `userAgent(request).isBot`, and #4667 used it. Two
+ * problems with that:
+ *
+ * 1. `userAgent()` is `{ ...uaparser(input), isBot: isBot(input) }` — the full
+ *    ua-parser-js parse runs on every matched request just to read one boolean.
+ *    `isBot` itself is not re-exported from `next/server` (see
+ *    `next/server.d.ts`, which exports only `userAgent` and
+ *    `userAgentFromString`), so there is no cheap way to reach it. Importing
+ *    `next/dist/server/web/spec-extension/user-agent` directly does resolve
+ *    today, but that is a deep import into Next internals with no stability
+ *    guarantee, so the tokens are inlined below instead and a test pins the
+ *    superset property against the installed copy.
+ * 2. Next's list names no scraper newer than ~2023, so the crawlers that
+ *    actually still loop through our locale twins walk straight past it.
+ *
+ * Probed against production on 2026-08-24 with
+ * `curl -sSI -A '<ua>' -H 'Cookie: boardsesh-locale=es' https://www.boardsesh.com/<climb-view-url>`:
+ * AhrefsBot, AhrefsSiteAudit, SemrushBot, DataForSeoBot, MJ12bot, DotBot,
+ * BLEXBot, Barkrowler, serpstatbot, SeznamBot, ZoominfoBot, Screaming Frog and
+ * archive.org_bot all reached the origin and all got the 307 to the /es twin,
+ * while Googlebot (named by Next) correctly got a 200. Those thirteen are the
+ * extension list.
+ *
+ * Deliberately NOT listed: the AI crawlers (ClaudeBot, Claude-User,
+ * PerplexityBot, GPTBot, OAI-SearchBot, ChatGPT-User, Bytespider, Amazonbot,
+ * CCBot, PetalBot, meta-externalagent). The same probe returned `HTTP/2 403`
+ * from `server: cloudflare` with no `x-vercel-cache` header for every one of
+ * them — Cloudflare's AI-bot block stops them before Vercel, so a middleware UA
+ * regex can never see them and adding them would be dead code. Re-run the probe
+ * and revisit this list if that Cloudflare rule is ever relaxed, and as part of
+ * the Railway cutover (#4652), which moves the edge.
+ *
+ * `Google-Extended` is also absent on purpose: it is a robots.txt-only opt-out
+ * control token and never appears in a User-Agent header.
+ *
+ * Two things this cannot do, both fine:
+ * - A false positive is graceful. The visitor gets a default-locale 200 for the
+ *   URL they actually asked for, which is already the deliberate behaviour of
+ *   the bot branch, not an error page. Every token below is crawler-only — no
+ *   bare `bot`, `spider` or `crawler` alternative — so a device-model string
+ *   cannot trip it.
+ * - It cannot catch a UA-rotating headless farm. One walked ~2,500 climb-view
+ *   URLs on 2026-08-22 presenting ordinary Chrome/Firefox/Edge UAs (PostHog:
+ *   2,031 distinct persons, one pageview each, `$referring_domain` null on
+ *   every event). That population needs an edge rate-limit, not a UA list —
+ *   see `docs/vercel-compute-baseline.md`.
+ */
+
+/**
+ * Next 16.2.12's own bot tokens, copied token-for-token from the `isBot` regex
+ * in `next/dist/server/web/spec-extension/user-agent.js`. Kept as a separate
+ * half so `is-crawler.test.ts` can assert we are still a superset of whatever
+ * the installed Next ships.
+ */
+const NEXT_BOT_TOKENS = [
+  'Googlebot',
+  'Mediapartners-Google',
+  'AdsBot-Google',
+  'googleweblight',
+  'Storebot-Google',
+  'Google-PageRenderer',
+  'Google-InspectionTool',
+  'Bingbot',
+  'BingPreview',
+  'Slurp',
+  'DuckDuckBot',
+  'baiduspider',
+  'yandex',
+  'sogou',
+  'LinkedInBot',
+  'bitlybot',
+  'tumblr',
+  'vkShare',
+  'quora link preview',
+  'facebookexternalhit',
+  'facebookcatalog',
+  'Twitterbot',
+  'applebot',
+  'redditbot',
+  'Slackbot',
+  'Discordbot',
+  'WhatsApp',
+  'SkypeUriPreview',
+  'ia_archiver',
+  'GPTBot',
+] as const;
+
+/**
+ * SEO/backlink scrapers and archivers that Next omits and that were verified to
+ * reach our origin — see the probe in the file header. These are the agents
+ * still bouncing through the locale twins today.
+ */
+const SEO_SCRAPER_TOKENS = [
+  'AhrefsBot',
+  'AhrefsSiteAudit',
+  'SemrushBot',
+  'DataForSeoBot',
+  'MJ12bot',
+  'DotBot',
+  'BLEXBot',
+  'Barkrowler',
+  'serpstatbot',
+  'SeznamBot',
+  'ZoominfoBot',
+  'Screaming Frog SEO Spider',
+  'archive.org_bot',
+] as const;
+
+const escapeRegExpLiteral = (token: string): string => token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Case-insensitive alternation over every token above. No `g` flag on purpose:
+ * a module-level `g`-flagged regex carries `lastIndex` between `.test()` calls
+ * and would alternate true/false on repeated identical input.
+ */
+export const CRAWLER_USER_AGENT_PATTERN = new RegExp(
+  [...NEXT_BOT_TOKENS, ...SEO_SCRAPER_TOKENS].map(escapeRegExpLiteral).join('|'),
+  'i',
+);
+
+export function isCrawlerUserAgent(userAgentHeader: string | null | undefined): boolean {
+  return userAgentHeader ? CRAWLER_USER_AGENT_PATTERN.test(userAgentHeader) : false;
+}

--- a/packages/web/app/lib/is-crawler.ts
+++ b/packages/web/app/lib/is-crawler.ts
@@ -46,7 +46,8 @@
  *   URLs on 2026-08-22 presenting ordinary Chrome/Firefox/Edge UAs (PostHog:
  *   2,031 distinct persons, one pageview each, `$referring_domain` null on
  *   every event). That population needs an edge rate-limit, not a UA list —
- *   see `docs/vercel-compute-baseline.md`.
+ *   see the burn-hunt write-up on #4650 (`docs/vercel-compute-baseline.md`,
+ *   added by the companion PR #4717).
  */
 
 /**

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -1,7 +1,8 @@
 // middleware.ts
-import { NextResponse, userAgent, type NextRequest } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { SUPPORTED_BOARDS } from './app/lib/board-data';
 import { getClimbViewPageCacheTTL, getListPageCacheTTL } from './app/lib/list-page-cache';
+import { isCrawlerUserAgent } from './app/lib/is-crawler';
 import { CLIMB_SESSION_COOKIE } from './app/lib/climb-session-cookie';
 import { PATHNAME_HEADER } from './app/lib/request-pathname-header';
 import { isSecureCookieContext } from './app/lib/auth/secure-cookies';
@@ -185,18 +186,27 @@ export function middleware(request: NextRequest) {
     ? { locale: DEFAULT_LOCALE, strippedPath: pathname, needsRewrite: false }
     : detectLocale(pathname);
 
-  const requestUserAgent = userAgent(request);
+  // Classify once for the two sticky-locale gates below. Skipped outright for
+  // /api/*: the `/api/v1/:path*` and `/api/auth/:path*` matcher entries do
+  // reach this line, but `isApi` above pins their locale to DEFAULT_LOCALE, so
+  // neither gate can fire for them and classifying would be pure cost.
+  const isCrawler = isApi ? false : isCrawlerUserAgent(request.headers.get('user-agent'));
 
   // Cookie-driven sticky locale: when a page request arrives without a locale
   // prefix and the visitor previously chose a non-default locale, send them
   // to the prefixed URL so subsequent navigation stays in their language.
   //
-  // Bots are excluded: crawlers that persist cookies (observed in production
+  // Crawlers are excluded: ones that persist cookies (observed in production
   // logs) acquire the boardsesh-locale cookie by crawling a /de|/es|/fr page
   // once, then bounce every subsequent unprefixed URL through a locale twin —
   // ~15k of these 307s/day, plus the render MISS on the twin they land on.
-  // Bots get a default-locale 200 for the URL they actually requested instead.
-  if (!isApi && locale === DEFAULT_LOCALE && !requestUserAgent.isBot) {
+  // Crawlers get a default-locale 200 for the URL they requested instead.
+  //
+  // The classifier is ours, not Next's `userAgent(request).isBot`: Next's list
+  // names no scraper newer than ~2023, and AhrefsBot, SemrushBot, DataForSeoBot
+  // and MJ12bot were all still taking this 307 in production on 2026-08-24. See
+  // `app/lib/is-crawler.ts` for the token list and the probe behind it.
+  if (!isApi && locale === DEFAULT_LOCALE && !isCrawler) {
     const cookieLocale = request.cookies.get(LOCALE_COOKIE)?.value;
     if (isSupportedLocale(cookieLocale) && cookieLocale !== DEFAULT_LOCALE) {
       const target = new URL(`/${cookieLocale}${pathname}`, request.url);
@@ -232,9 +242,9 @@ export function middleware(request: NextRequest) {
 
   // Sticky cookie: any visit on a non-default locale URL writes the cookie so
   // a shared /es/... link from a friend persists for the recipient too.
-  // Bots never acquire it — see the sticky-locale redirect bot-gate above for
+  // Crawlers never acquire it — see the sticky-locale redirect gate above for
   // why a cookie-persisting crawler must never be handed this cookie.
-  if (locale !== DEFAULT_LOCALE && !requestUserAgent.isBot) {
+  if (locale !== DEFAULT_LOCALE && !isCrawler) {
     response.cookies.set(LOCALE_COOKIE, locale, {
       path: '/',
       sameSite: 'lax',


### PR DESCRIPTION
## Summary

Part of #4650. Finishes the crawler gate #4667 opened. Does **not** close #4650 — the `vercel metrics` pull is still blocked on a token, and #4648's Phase 0 checklist gates the Speed Insights cancellation and the Observability-tier downgrade on that pull.

#4667 gated the sticky-locale 307 and the `boardsesh-locale` cookie write on `userAgent(request).isBot` from `next/server`. That regex names 30 tokens and nothing newer than about 2023, so a good chunk of what is actually crawling us walks straight past it. This replaces it with a repo-owned list in `packages/web/app/lib/is-crawler.ts` and drops the per-request `uaparser()` parse.

Paired with **#4717**, which publishes `docs/vercel-compute-baseline.md`. Split on purpose: this one is a middleware regression-risk review, that one is a cost write-up for #4648 Phase 2, and #4717 can land regardless of any argument about the token list below. #4715 was filed from the same write-up (board-render → Railway).

### What the probe actually showed

Every UA below was sent at production on 2026-08-24:

```bash
CLIMB='/decoy/dungeon-trainer/12x12/schist-…flat-edge/20/view/small-cheese-002A7AE12E264BA8B0CF67E4404AECBA'
# does it reach Vercel at all?
curl -sSI -A "$UA" "https://www.boardsesh.com/es${CLIMB}"
# does it still take the sticky-locale 307?
curl -sSI -A "$UA" -H 'Cookie: boardsesh-locale=es' "https://www.boardsesh.com${CLIMB}"
```

**Reaches the origin and still loops today** — these are the extension list:

| User agent | `/es` twin | unprefixed + stale cookie |
|---|---|---|
| AhrefsBot | 200 (`x-vercel-cache: HIT`) | **307 → `/es/…`** |
| AhrefsSiteAudit | 200 | **307** |
| SemrushBot | 200 (HIT) | **307** |
| DataForSeoBot | 200 (HIT) | **307** |
| MJ12bot | 200 (HIT) | **307** |
| DotBot | 200 | **307** |
| BLEXBot | 200 | **307** |
| Barkrowler | 200 | **307** |
| serpstatbot | 200 | **307** |
| SeznamBot | 200 | **307** |
| ZoominfoBot | 200 | **307** |
| Screaming Frog SEO Spider | 200 | **307** |
| archive.org_bot | 200 | **307** |
| Googlebot (control, named by Next) | 200 (HIT) | 200 — already gated |
| Chrome 126 (control, human) | 200 (HIT) | 307 — correct, unchanged |

**Never reaches Vercel** — Cloudflare 403s them at the edge (`server: cloudflare`, no `x-vercel-cache` header at all), so a middleware UA regex can never see them:

`ClaudeBot`, `Claude-User`, `PerplexityBot`, `GPTBot`, `OAI-SearchBot`, `ChatGPT-User`, `Bytespider`, `Amazonbot`, `CCBot`, `PetalBot`, `meta-externalagent` — all `HTTP/2 403`.

Adding those tokens would be dead code, so they are deliberately absent. `is-crawler.ts` records the probe and names the trigger to revisit it: if that Cloudflare rule is ever relaxed, and at the Railway cutover (#4652), which moves the edge. `Google-Extended` is absent for a different reason — it is a robots.txt-only opt-out control token and never appears in a User-Agent header.

### What this is worth

No CPU number is claimed, and this PR should not be read as one. Googlebot — the population #4667's own body names as the pinned cause ("Cookie-persisting crawlers (Googlebot et al.) … pinned in prod logs") — has been gated since 2026-08-22. So the residual here is the un-named-crawler share of the ~15k 307s/day, against ~600k function invocations/day and ~42 CPU-h/day, and each of those 307s returns from middleware before any render. It closes a coverage gap in a fix merged for this issue; the `uaparser()` removal is a free strict improvement on top. The metrics pull is what will size the actual win.

Worth saying plainly: a UA list cannot catch a UA-rotating headless farm. One walked ~2,500 climb-view URLs on 2026-08-22 presenting ordinary Chrome/Firefox/Edge UAs (PostHog: 2,031 distinct persons, exactly one pageview each, `$referring_domain` null on every event). That population needs an edge rate-limit. It is written up in the docs PR, not fixed here.

### The change

- **New** `packages/web/app/lib/is-crawler.ts` — `CRAWLER_USER_AGENT_PATTERN` (one case-insensitive `RegExp`, deliberately no `g` flag: a module-level `g`-flagged regex carries `lastIndex` between `.test()` calls and would alternate true/false on identical input) plus `isCrawlerUserAgent()`. Two commented halves: Next 16.2.12's 30 tokens, and the 13 probed scrapers.
- **`packages/web/middleware.ts`** — both gate sites now read one `isCrawler` const. Classification is skipped outright for `/api/*`: the `/api/v1/:path*` and `/api/auth/:path*` matcher entries do reach that line, but `isApi` pins their locale to the default, so neither gate can fire and classifying them was pure cost. `userAgent` is no longer imported from `next/server`, so the full ua-parser-js parse is gone from the hot path (it was building the whole parsed object to read one boolean, because `isBot` is not re-exported from `next/server`).

### Failure mode, deliberately

A false positive means the visitor gets a default-locale 200 for the URL they asked for — already the documented behaviour of the bot branch, not an error page. Every token is crawler-only; there is no bare `bot`/`spider`/`crawler` alternative that a device-model string could trip.

One inherited false positive is now documented rather than discovered later: `YandexSearch/1.0`, the Yandex Search in-app browser, contains the `yandex` substring Next matches on, so it is classified as a crawler. Kept rather than diverging from Next, with the graceful failure mode pinned in a test. Yandex *Browser* (`YaBrowser/… Yowser/…`, both desktop and Android) contains no `yandex` substring and matches neither list — also pinned.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project web --reporter=agent packages/web/app/lib/__tests__/is-crawler.test.ts packages/web/app/__tests__/middleware.test.ts` — 243/243 passing.
- `vp run test:web` — 4235 passing. 3 pre-existing failures in `controllers-section`, `gym-settings-panel` and `location-sync-freezes-panel` (testing-library timeouts); reproduced identically on a clean `origin/main` worktree at 76cc8f522 with no local changes, so they are not from this diff.
- `vp check` — clean for every file in this diff (the pre-commit hook runs `vp check --fix` on exactly these four, plus `check:i18n` and `check:i18n:orphans`, and all passed). The only repo-wide lint errors are two `Cannot find module '@gorhom/bottom-sheet'` in `packages/mobile/src/web-shims/bottom-sheet.tsx`, which is the nested `packages/mobile/web-runtime` install not being present locally — CI runs `mobile:web-runtime:install` as a dependency.
- `vp run typecheck:web` — exit 0 (full `build:web` + `tsc`). CI's `typecheck` job is also green.
- New `is-crawler.test.ts`: the superset test **derives** Next's token list at test time from the installed `isBot` source rather than hand-copying it, with a guard assertion on the extraction, so a future Next widening fails this suite instead of silently leaving us narrower than the list we replaced. Plus all 13 scraper UAs (and an assertion that Next does *not* already cover them, so the two halves cannot drift into duplicates), 7 real browser UAs as negatives, the `archive.org_bot` dot-escaping case, null/undefined/empty, and a no-`g`-flag statefulness check.
- `middleware.test.ts`: the two bot cases became `it.each` over 7 crawler UAs for both the 307 gate and the cookie-set gate. The two human `CHROME_UA` cases are untouched — they are the false-positive regression guard. One new case pins that an `/api/v1` request behaves identically with and without a crawler UA, covering the `isApi` short-circuit.

**Expo native fingerprint:** unchanged. Nothing under `packages/mobile`, no native config, no dependency change — `packages/web` only.
