### PR TITLE
fix(mobile): give the Android tick note room for a real beta note

### DIFF
--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -146,7 +146,7 @@ and which index is requested — it has a fixed ~50% "partial" state and a conte
 "expanded" state, nothing in between (see `androidSafeSnapPoints` in
 `src/components/sheet-snap-points.ts`). A sheet whose detents are tuned against iOS's real first
 fraction (e.g. `65%`/`80%`, sized so a pinned footer fits under the form) can be TALLER than
-Android's ~50% partial state, stranding that footer below the fold (#4642). For a multi-detent
+Android's ~50% partial state, stranding that footer below the fold (#4723). For a multi-detent
 sheet with a pinned footer, pass `androidOpensExpanded` to `Sheet` / `ModalSheet` — `LogAscentSheet`
 and `LogbookEditSheet` opt in. It collapses the sheet to its single LAST detent on Android (via
 `androidSafeSnapPoints`) rather than requesting the last index of a multi-detent config: a single

--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -146,7 +146,7 @@ and which index is requested — it has a fixed ~50% "partial" state and a conte
 "expanded" state, nothing in between (see `androidSafeSnapPoints` in
 `src/components/sheet-snap-points.ts`). A sheet whose detents are tuned against iOS's real first
 fraction (e.g. `65%`/`80%`, sized so a pinned footer fits under the form) can be TALLER than
-Android's ~50% partial state, stranding that footer below the fold (#4231). For a multi-detent
+Android's ~50% partial state, stranding that footer below the fold (#4642). For a multi-detent
 sheet with a pinned footer, pass `androidOpensExpanded` to `Sheet` / `ModalSheet` — `LogAscentSheet`
 and `LogbookEditSheet` opt in. It collapses the sheet to its single LAST detent on Android (via
 `androidSafeSnapPoints`) rather than requesting the last index of a multi-detent config: a single

--- a/packages/mobile/src/components/LogAscentSheet.tsx
+++ b/packages/mobile/src/components/LogAscentSheet.tsx
@@ -144,7 +144,7 @@ export function LogAscentSheet({
       surface="solid"
       footerSurface="flush"
       // Android's ~50% partial state can't fit this form under a pinned
-      // footer (see `androidOpensExpanded` on `ModalSheet`, #4231) — open
+      // footer (see `androidOpensExpanded` on `ModalSheet`, #4642) — open
       // expanded there so the Send button never lands off the fold.
       androidOpensExpanded
       header={

--- a/packages/mobile/src/components/LogAscentSheet.tsx
+++ b/packages/mobile/src/components/LogAscentSheet.tsx
@@ -144,7 +144,7 @@ export function LogAscentSheet({
       surface="solid"
       footerSurface="flush"
       // Android's ~50% partial state can't fit this form under a pinned
-      // footer (see `androidOpensExpanded` on `ModalSheet`, #4642) — open
+      // footer (see `androidOpensExpanded` on `ModalSheet`, #4723) — open
       // expanded there so the Send button never lands off the fold.
       androidOpensExpanded
       header={

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -71,7 +71,7 @@ type ModalSheetProps = {
   header?: ReactNode;
   /** Collapses to a single, expanded-only detent on Android instead of the usual
    * multi-detent config, so a pinned footer never strands below Android's ~50%
-   * partial state (#4642). See `androidSafeSnapPoints` for the full rationale;
+   * partial state (#4723). See `androidSafeSnapPoints` for the full rationale;
    * no effect on iOS/web, or on a single detent already at/above 75%. */
   androidOpensExpanded?: boolean;
 };

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -71,7 +71,7 @@ type ModalSheetProps = {
   header?: ReactNode;
   /** Collapses to a single, expanded-only detent on Android instead of the usual
    * multi-detent config, so a pinned footer never strands below Android's ~50%
-   * partial state (#4231). See `androidSafeSnapPoints` for the full rationale;
+   * partial state (#4642). See `androidSafeSnapPoints` for the full rationale;
    * no effect on iOS/web, or on a single detent already at/above 75%. */
   androidOpensExpanded?: boolean;
 };

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -71,7 +71,7 @@ type SheetProps = {
   header?: ReactNode;
   /** Collapses to a single, expanded-only detent on Android instead of the usual
    * multi-detent config, so a pinned footer never strands below Android's ~50%
-   * partial state (#4231). See `androidSafeSnapPoints` for the full rationale;
+   * partial state (#4642). See `androidSafeSnapPoints` for the full rationale;
    * no effect on iOS/web, or on a single detent already at/above 75%. */
   androidOpensExpanded?: boolean;
 };

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -71,7 +71,7 @@ type SheetProps = {
   header?: ReactNode;
   /** Collapses to a single, expanded-only detent on Android instead of the usual
    * multi-detent config, so a pinned footer never strands below Android's ~50%
-   * partial state (#4642). See `androidSafeSnapPoints` for the full rationale;
+   * partial state (#4723). See `androidSafeSnapPoints` for the full rationale;
    * no effect on iOS/web, or on a single detent already at/above 75%. */
   androidOpensExpanded?: boolean;
 };

--- a/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
+++ b/packages/mobile/src/components/play-drawer/QuickTickBar.tsx
@@ -121,7 +121,10 @@ export const QuickTickBar = React.memo(function QuickTickBar({ form }: QuickTick
         />
       </TickFormRow>
 
-      <TickFormRow label={tClimbs('mobile.tick.noteLabel')} showSeparator={false} testID="tick-row-note">
+      {/* `alignTop`: the note is the one control that grows well past the 56pt
+          row beat, and a centred label floats ~31pt below the first line of
+          the climber's own text (#4642). */}
+      <TickFormRow label={tClimbs('mobile.tick.noteLabel')} alignTop showSeparator={false} testID="tick-row-note">
         <TickNoteField
           value={comment}
           onChangeText={onCommentChange}

--- a/packages/mobile/src/components/sheet-snap-points.ts
+++ b/packages/mobile/src/components/sheet-snap-points.ts
@@ -22,7 +22,7 @@ const ANDROID_NEAR_FULL_DETENT_PERCENT = 75;
  * already have a partial state, and non-% (px) detents are left as-is.
  *
  * `androidOpensExpanded` (a multi-detent sheet whose pinned footer only fits at
- * its LAST detent, e.g. the tick sheets, #4231) collapses to that single last
+ * its LAST detent, e.g. the tick sheets, #4642) collapses to that single last
  * detent on Android — not "keep both detents and pick the last index at
  * present-time", which depends on an `@expo/ui` Android `expand()` call the
  * library's own `ModalBottomSheetView.kt` can silently no-op ("Expanded anchor

--- a/packages/mobile/src/components/sheet-snap-points.ts
+++ b/packages/mobile/src/components/sheet-snap-points.ts
@@ -22,7 +22,7 @@ const ANDROID_NEAR_FULL_DETENT_PERCENT = 75;
  * already have a partial state, and non-% (px) detents are left as-is.
  *
  * `androidOpensExpanded` (a multi-detent sheet whose pinned footer only fits at
- * its LAST detent, e.g. the tick sheets, #4642) collapses to that single last
+ * its LAST detent, e.g. the tick sheets, #4723) collapses to that single last
  * detent on Android — not "keep both detents and pick the last index at
  * present-time", which depends on an `@expo/ui` Android `expand()` call the
  * library's own `ModalBottomSheetView.kt` can silently no-op ("Expanded anchor

--- a/packages/mobile/src/components/tick/TickFormRow.tsx
+++ b/packages/mobile/src/components/tick/TickFormRow.tsx
@@ -29,7 +29,7 @@ type TickFormRowProps = {
    *  row's trailing gutter so the rail reads as scrollable rather than clipped. */
   bleed?: boolean;
   /** Top-align the label against a control that is much taller than the 56pt
-   *  beat — the note field, which grows to 180pt. Centred, its label floats
+   *  beat — the note field, which grows to 160pt. Centred, its label floats
    *  ~31pt below the first line of the climber's own text and reads as broken.
    *  Opt-in, so every other row keeps the centred beat. NOT `stacked`: that
    *  flips the row to a column and is a different layout. */

--- a/packages/mobile/src/components/tick/TickFormRow.tsx
+++ b/packages/mobile/src/components/tick/TickFormRow.tsx
@@ -28,6 +28,12 @@ type TickFormRowProps = {
   /** Let the control run to the screen edge (a horizontal rail), dropping the
    *  row's trailing gutter so the rail reads as scrollable rather than clipped. */
   bleed?: boolean;
+  /** Top-align the label against a control that is much taller than the 56pt
+   *  beat — the note field, which grows to 180pt. Centred, its label floats
+   *  ~31pt below the first line of the climber's own text and reads as broken.
+   *  Opt-in, so every other row keeps the centred beat. NOT `stacked`: that
+   *  flips the row to a column and is a different layout. */
+  alignTop?: boolean;
   /** Dim + inert, without unmounting: the edit sheet's Tries row when the tick
    *  is a flash. Keeping the row mounted preserves the form's vertical rhythm
    *  and the control's state. */
@@ -43,6 +49,7 @@ export const TickFormRow = React.memo(function TickFormRow({
   children,
   height,
   bleed = false,
+  alignTop = false,
   disabled = false,
   showSeparator = true,
   testID,
@@ -54,6 +61,9 @@ export const TickFormRow = React.memo(function TickFormRow({
   const stacked = fontScale > TICK_STACK_FONT_SCALE;
 
   const dimmed = disabled ? { opacity: opacity.disabled } : undefined;
+  // Stacked already puts the label on its own line above the control, so
+  // top-alignment is moot there and its insets would just double the gap.
+  const topAligned = alignTop && !stacked;
 
   return (
     <View testID={testID}>
@@ -64,11 +74,18 @@ export const TickFormRow = React.memo(function TickFormRow({
             paddingRight: bleed ? 0 : TICK_GUTTER,
             minHeight: height ?? TICK_ROW_HEIGHT,
             gap: stacked ? spacing[2] : TICK_LABEL_GAP,
+            paddingTop: topAligned ? spacing[1] : 0,
           },
+          topAligned ? styles.rowAlignTop : null,
           stacked ? styles.rowStacked : null,
         ]}
       >
-        <Text variant="body" color={systemColors.secondaryLabel} numberOfLines={2} style={[styles.label, dimmed]}>
+        <Text
+          variant="body"
+          color={systemColors.secondaryLabel}
+          numberOfLines={2}
+          style={[styles.label, { paddingTop: topAligned ? spacing[2] : 0 }, dimmed]}
+        >
           {label}
         </Text>
         <View
@@ -101,6 +118,11 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     paddingLeft: TICK_GUTTER,
+  },
+  rowAlignTop: {
+    // Paired with the row's `paddingTop` and the label's, this sits the label's
+    // cap-height on the field's first line of text rather than on its border.
+    alignItems: 'flex-start',
   },
   rowStacked: {
     flexDirection: 'column',

--- a/packages/mobile/src/components/tick/TickNoteField.tsx
+++ b/packages/mobile/src/components/tick/TickNoteField.tsx
@@ -75,8 +75,8 @@ const styles = StyleSheet.create({
     // TextInput draws no scrollbar — so whatever is above the ceiling is gone
     // with nothing on screen to say so. At the old 96pt (4 lines) that bit
     // early: on a 405x900pt Pixel emulator a six-line note opened mid-sentence
-    // ("out. Felt hard for the grade today...") while ~300pt of the sheet sat
-    // empty between this row and the Attempt/Send bar (#4642). 180pt is eight
+    // ("before the dyn beta is solid now and I wan...") while ~300pt of the
+    // sheet sat empty below this row (#4642). 180pt is eight
     // lines (8 x 20 + 16 padding + 2 border), and it still fits whole inside
     // the ~293pt that sheet body keeps above the keyboard, so a long note stays
     // one glance rather than a blind scroll. Anything longer scrolls the sheet

--- a/packages/mobile/src/components/tick/TickNoteField.tsx
+++ b/packages/mobile/src/components/tick/TickNoteField.tsx
@@ -1,15 +1,20 @@
 // One note field for both tick sheets. A single styled `TextInput`, never a
 // bordered wrapper `View` around a `flex: 1` input.
 //
-// The vertical padding below is load-bearing on Android — do not remove it. On
-// Fabric a TextInput that declares no vertical padding has the theme's default
-// EditText padding (~10pt top + ~10pt bottom) written into its Yoga style by
-// `AndroidTextInputComponentDescriptor`, so declaring padding here replaces that
-// default rather than adding to it. In the old two-layer shape the outer box's
-// `justifyContent: 'center'` pinned the `flex: 1` input to a 26pt content box,
-// the inherited ~20pt of theme padding ate almost all of it, and the note
-// rendered as a ~5pt sliver of glyph bottoms and a stub caret (#4642, fixed in
-// #4684). `EndSessionSheet` uses the same flat shape.
+// The vertical padding below is load-bearing on Android — do not remove it.
+// What is established: on 2.3.1 the note rendered as a ~5pt band of glyph
+// bottoms and a stub caret inside its 44pt box, the first ink sat ~9.7pt below
+// the input's top edge despite `textAlignVertical: 'top'`, and declaring
+// padding on the input (#4684) fixed it. The leading explanation is Fabric's:
+// `AndroidTextInputComponentDescriptor` writes the theme's default EditText
+// padding (~10pt top + ~10pt bottom) into the Yoga style of any TextInput that
+// declares none, and declaring padding here sets `hasPaddingVertical` and
+// replaces it. Treat that as the best hypothesis rather than proven — the
+// competing "the flex child collapsed to zero height" story does NOT hold
+// (vendored Yoga clamps `availableInnerMainDim` to the min constraint before
+// `resolveFlexibleLength`, so the old child resolved to ~26pt, and a 20pt line
+// fits in 26pt). Either way the padding is what changed the rendering, so the
+// test next door pins it (#4642).
 import React, { useCallback, useState } from 'react';
 import { StyleSheet } from 'react-native';
 import { BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
@@ -56,9 +61,13 @@ export const TickNoteField = React.memo(function TickNoteField({
           paddingHorizontal: spacing[3],
           paddingVertical: spacing[2],
           backgroundColor: systemColors.fill,
-          // Transparent at rest rather than absent, so gaining focus does not
-          // resize the field by a point.
-          borderColor: focused ? brandColors.primary : 'transparent',
+          // A real edge at rest, not `transparent` — an unfocused field with no
+          // visible boundary reads as decoration rather than somewhere to
+          // type. `borderWidth` is unchanged either way, so focus recolours the
+          // edge instead of resizing the box. `separator` is the only border
+          // role the design system has here and it clears only ~1.9:1 on
+          // Android dark, under WCAG 1.4.11's 3:1 — tracked in #4722.
+          borderColor: focused ? brandColors.primary : systemColors.separator,
           color: systemColors.label,
         },
       ]}
@@ -70,7 +79,11 @@ const styles = StyleSheet.create({
   input: {
     flex: 1,
     borderWidth: 1,
-    minHeight: 44,
+    // Two lines at rest, matching `EndSessionSheet`'s recap box: 2 x 20pt
+    // subheadline + 16pt padding + 2pt border = 58, on the 4pt grid. One line
+    // was half the complaint in #4642 still shipping — a beta note opens with
+    // room for a sentence, not a word.
+    minHeight: 64,
     // Past this the note scrolls INSIDE the field, and an Android multiline
     // TextInput draws no scrollbar — so whatever is above the ceiling is gone
     // with nothing on screen to say so. At the old 96pt (4 lines) that bit
@@ -79,10 +92,14 @@ const styles = StyleSheet.create({
     // sheet sat empty below this row (#4642). 180pt is eight
     // lines (8 x 20 + 16 padding + 2 border), and it still fits whole inside
     // the ~293pt that sheet body keeps above the keyboard, so a long note stays
-    // one glance rather than a blind scroll. Anything longer scrolls the sheet
-    // body, which at least moves visibly. Detents are unchanged: the body is
-    // scrollable under a pinned footer, so the extra height costs the
-    // Attempt/Send bar nothing.
+    // one glance rather than a blind scroll. iOS is the tighter of the two and
+    // the real bound on this number: its keyboard-up visible body is ~196-200pt
+    // (derived from the detents, not measured here), which 180 clears with
+    // ~16pt spare. A field taller than the visible body can never scroll fully
+    // into view, so anyone raising this ceiling has to re-check iOS first.
+    // Anything longer scrolls the sheet body, which at least moves visibly.
+    // Detents are unchanged: the body is scrollable under a pinned footer, so
+    // the extra height costs the Attempt/Send bar nothing.
     maxHeight: 180,
     textAlignVertical: 'top',
   },

--- a/packages/mobile/src/components/tick/TickNoteField.tsx
+++ b/packages/mobile/src/components/tick/TickNoteField.tsx
@@ -1,7 +1,15 @@
-// One note field for both tick sheets. A single styled `TextInput`, not a
-// bordered wrapper `View` around a `flex: 1` input — that two-layer shape
-// clipped multiline text on Android (#4231); matches `EndSessionSheet`'s flat
-// shape instead.
+// One note field for both tick sheets. A single styled `TextInput`, never a
+// bordered wrapper `View` around a `flex: 1` input.
+//
+// The vertical padding below is load-bearing on Android — do not remove it. On
+// Fabric a TextInput that declares no vertical padding has the theme's default
+// EditText padding (~10pt top + ~10pt bottom) written into its Yoga style by
+// `AndroidTextInputComponentDescriptor`, so declaring padding here replaces that
+// default rather than adding to it. In the old two-layer shape the outer box's
+// `justifyContent: 'center'` pinned the `flex: 1` input to a 26pt content box,
+// the inherited ~20pt of theme padding ate almost all of it, and the note
+// rendered as a ~5pt sliver of glyph bottoms and a stub caret (#4642, fixed in
+// #4684). `EndSessionSheet` uses the same flat shape.
 import React, { useCallback, useState } from 'react';
 import { StyleSheet } from 'react-native';
 import { BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
@@ -63,9 +71,19 @@ const styles = StyleSheet.create({
     flex: 1,
     borderWidth: 1,
     minHeight: 44,
-    // Grows with the note up to three-ish lines, then scrolls — the sheet's
-    // detent is sized for the resting height, not the longest possible note.
-    maxHeight: 96,
+    // Past this the note scrolls INSIDE the field, and an Android multiline
+    // TextInput draws no scrollbar — so whatever is above the ceiling is gone
+    // with nothing on screen to say so. At the old 96pt (4 lines) that bit
+    // early: on a 405x900pt Pixel emulator a six-line note opened mid-sentence
+    // ("out. Felt hard for the grade today...") while ~300pt of the sheet sat
+    // empty between this row and the Attempt/Send bar (#4642). 180pt is eight
+    // lines (8 x 20 + 16 padding + 2 border), and it still fits whole inside
+    // the ~293pt that sheet body keeps above the keyboard, so a long note stays
+    // one glance rather than a blind scroll. Anything longer scrolls the sheet
+    // body, which at least moves visibly. Detents are unchanged: the body is
+    // scrollable under a pinned footer, so the extra height costs the
+    // Attempt/Send bar nothing.
+    maxHeight: 180,
     textAlignVertical: 'top',
   },
 });

--- a/packages/mobile/src/components/tick/TickNoteField.tsx
+++ b/packages/mobile/src/components/tick/TickNoteField.tsx
@@ -65,8 +65,9 @@ export const TickNoteField = React.memo(function TickNoteField({
           // visible boundary reads as decoration rather than somewhere to
           // type. `borderWidth` is unchanged either way, so focus recolours the
           // edge instead of resizing the box. `separator` is the only border
-          // role the design system has here and it clears only ~1.9:1 on
-          // Android dark, under WCAG 1.4.11's 3:1 — tracked in #4722.
+          // role the design system has here, and it clears WCAG 1.4.11's 3:1 in
+          // neither scheme: ~1.9:1 in dark, ~1.6:1 in light, so dark is the
+          // BETTER of the two rather than the worst case — tracked in #4722.
           borderColor: focused ? brandColors.primary : systemColors.separator,
           color: systemColors.label,
         },
@@ -89,18 +90,30 @@ const styles = StyleSheet.create({
     // with nothing on screen to say so. At the old 96pt (4 lines) that bit
     // early: on a 405x900pt Pixel emulator a six-line note opened mid-sentence
     // ("before the dyn beta is solid now and I wan...") while ~300pt of the
-    // sheet sat empty below this row (#4642). 180pt is eight
-    // lines (8 x 20 + 16 padding + 2 border), and it still fits whole inside
-    // the ~293pt that sheet body keeps above the keyboard, so a long note stays
-    // one glance rather than a blind scroll. iOS is the tighter of the two and
-    // the real bound on this number: its keyboard-up visible body is ~196-200pt
-    // (derived from the detents, not measured here), which 180 clears with
-    // ~16pt spare. A field taller than the visible body can never scroll fully
-    // into view, so anyone raising this ceiling has to re-check iOS first.
+    // sheet sat empty below this row (#4642). 160pt is seven lines
+    // (7 x 20 + 16 padding + 2 border = 158, 2pt spare) — +67% on the old
+    // ceiling, so a long note stays one glance rather than a blind scroll.
+    //
+    // iOS is the tighter of the two and the real bound on this number: its
+    // keyboard-up visible body is 162pt. Derived, not measured, on the
+    // reference device the detent test pins (`log-ascent-sheet.test.tsx`:
+    // window 844 - top inset 44 - iOS-26 card gap 24 = base 776). The '92%'
+    // keyboard detent gives a 694pt column; KAV `behavior="padding"` takes 336
+    // for the keyboard, leaving 358; less the 56pt header and the 140pt
+    // footer = 162. The footer is 140 and NOT 106 because
+    // `useWindowBottomInset()` keeps returning the published 34pt window inset
+    // while the keyboard is up — nothing in the app zeroes it on keyboard show
+    // (`hooks/use-window-bottom-inset.ts`). An earlier draft assumed that inset
+    // collapsed, read the body as ~196pt, and set 180 — which overflows the
+    // real body by 18pt. A field taller than the visible body can never scroll
+    // fully into view, so anyone raising this ceiling has to re-check that
+    // inset first, not just the detent.
+    //
     // Anything longer scrolls the sheet body, which at least moves visibly.
-    // Detents are unchanged: the body is scrollable under a pinned footer, so
-    // the extra height costs the Attempt/Send bar nothing.
-    maxHeight: 180,
+    // Detent VALUES are unchanged: the body is scrollable under a pinned
+    // footer, so the extra height costs the Attempt/Send bar nothing (the
+    // derivations in `tick-sheet-metrics.ts` do carry the taller note row).
+    maxHeight: 160,
     textAlignVertical: 'top',
   },
 });

--- a/packages/mobile/src/components/tick/__tests__/tick-form-row-align-top.test.tsx
+++ b/packages/mobile/src/components/tick/__tests__/tick-form-row-align-top.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+//
+// `alignTop` exists for exactly one row. The note field grows to 180pt while
+// every other tick control sits on the 56pt beat, and the row's default
+// `alignItems: 'center'` puts the label's baseline against the middle of that
+// tall box — roughly 31pt below the first line of the climber's own text, which
+// reads as a broken row (#4642). These tests pin that it is opt-in: the note
+// row takes it, a plain row must not, and it stays out of the way of the
+// large-text `stacked` layout, which already puts the label on its own line.
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { flattenStyle } from '../../../../test/flatten-style';
+
+const windowMock = vi.hoisted(() => ({ fontScale: 1 }));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'android', select: (options: Record<string, unknown>) => options.android ?? options.default },
+  PlatformColor: (name: string) => name,
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  View: ({ children, style, testID }: { children?: ReactNode; style?: unknown; testID?: string }) =>
+    createElement('div', { 'data-style': JSON.stringify(style ?? null), 'data-testid': testID }, children),
+  useWindowDimensions: () => ({ width: 405, height: 900, fontScale: windowMock.fontScale }),
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children, style }: { children?: ReactNode; style?: unknown }) =>
+    createElement('span', { 'data-style': JSON.stringify(style ?? null) }, children),
+}));
+
+vi.mock('../../../providers/theme-provider', async () => {
+  const { makeThemeMock } = await import('../../../test/theme-mock');
+  const theme = makeThemeMock({ variant: 'material', colorScheme: 'dark' });
+  return { useTheme: () => theme };
+});
+
+import { TickFormRow } from '../TickFormRow';
+import { spacing } from '../../../theme/tokens';
+
+function renderRow(props: { alignTop?: boolean } = {}) {
+  const { container } = render(
+    createElement(TickFormRow, {
+      label: 'Note',
+      testID: 'row',
+      children: createElement('input', { readOnly: true }),
+      ...props,
+    }),
+  );
+  // The row's own box is the first child of the testID'd wrapper; the label is
+  // the only span.
+  const row = container.querySelector('[data-testid="row"] > div');
+  const label = container.querySelector('span');
+  return {
+    row: flattenStyle(JSON.parse(row?.getAttribute('data-style') ?? 'null')),
+    label: flattenStyle(JSON.parse(label?.getAttribute('data-style') ?? 'null')),
+  };
+}
+
+describe('TickFormRow alignTop', () => {
+  it('keeps the centred 56pt beat by default', () => {
+    windowMock.fontScale = 1;
+    const { row, label } = renderRow();
+
+    expect(row.alignItems).toBe('center');
+    expect(row.paddingTop).toBe(0);
+    expect(label.paddingTop).toBe(0);
+  });
+
+  it('top-aligns the label when a row opts in', () => {
+    windowMock.fontScale = 1;
+    const { row, label } = renderRow({ alignTop: true });
+
+    expect(row.alignItems).toBe('flex-start');
+    expect(row.paddingTop).toBe(spacing[1]);
+    expect(label.paddingTop).toBe(spacing[2]);
+  });
+
+  it('defers to the stacked layout at large text sizes', () => {
+    // Stacked is a column with the label already above the control, so the
+    // top-alignment insets would only double the gap.
+    windowMock.fontScale = 1.5;
+    const { row, label } = renderRow({ alignTop: true });
+
+    expect(row.flexDirection).toBe('column');
+    expect(row.paddingTop).toBe(0);
+    expect(label.paddingTop).toBe(0);
+  });
+});

--- a/packages/mobile/src/components/tick/__tests__/tick-form-row-align-top.test.tsx
+++ b/packages/mobile/src/components/tick/__tests__/tick-form-row-align-top.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 //
-// `alignTop` exists for exactly one row. The note field grows to 180pt while
+// `alignTop` exists for exactly one row. The note field grows to 160pt while
 // every other tick control sits on the 56pt beat, and the row's default
 // `alignItems: 'center'` puts the label's baseline against the middle of that
 // tall box — roughly 31pt below the first line of the climber's own text, which

--- a/packages/mobile/src/components/tick/__tests__/tick-note-field.test.tsx
+++ b/packages/mobile/src/components/tick/__tests__/tick-note-field.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+//
+// The guard on the shape that shipped #4642: an Android tick note rendered as a
+// ~5pt sliver of glyph bottoms. Nothing in JS can observe the native padding
+// injection that caused it, so this file pins the two JS-observable
+// preconditions the fix rests on — the flat single-input shape, and the
+// input declaring its own vertical padding — plus the arithmetic that one line
+// of `subheadline` actually fits between them.
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { flattenStyle } from '../../../../test/flatten-style';
+
+type TextInputMockProps = {
+  style?: unknown;
+  multiline?: boolean;
+  placeholder?: string;
+  accessibilityLabel?: string;
+  value?: string;
+};
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'android', select: (options: Record<string, unknown>) => options.android ?? options.default },
+  PlatformColor: (name: string) => name,
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  View: ({ children, style }: { children?: ReactNode; style?: unknown }) =>
+    createElement('div', { 'data-style': JSON.stringify(style ?? null) }, children),
+}));
+
+vi.mock('@expo/ui/community/bottom-sheet', () => ({
+  BottomSheetTextInput: ({ style, multiline, placeholder, accessibilityLabel, value }: TextInputMockProps) =>
+    createElement('textarea', {
+      'data-style': JSON.stringify(style ?? null),
+      'data-multiline': multiline ? 'true' : 'false',
+      'data-placeholder': placeholder,
+      'data-a11y-label': accessibilityLabel,
+      'data-value': value,
+    }),
+}));
+
+vi.mock('../../../providers/theme-provider', async () => {
+  const { makeThemeMock } = await import('../../../test/theme-mock');
+  const theme = makeThemeMock({ variant: 'material', colorScheme: 'dark' });
+  return { useTheme: () => theme };
+});
+
+import { TickNoteField } from '../TickNoteField';
+import { materialTextStyles } from '../../../theme/typography';
+
+function renderField() {
+  return render(
+    createElement(TickNoteField, {
+      value: '',
+      onChangeText: vi.fn(),
+      placeholder: 'How did it go?',
+      accessibilityLabel: 'Note',
+    }),
+  );
+}
+
+/** The input's own flattened style — the array it is handed, resolved. */
+function inputStyle(container: HTMLElement): Record<string, unknown> {
+  const input = container.querySelector('textarea');
+  expect(input).not.toBeNull();
+  return flattenStyle(JSON.parse(input?.getAttribute('data-style') ?? 'null'));
+}
+
+describe('TickNoteField', () => {
+  it('renders the input as its own root, with no wrapper element around it', () => {
+    // The 2.3.1 shape was a bordered `View` wrapping a `flex: 1` input, and the
+    // outer box's `justifyContent: 'center'` is what pinned the input to a
+    // 26pt content box it could not grow out of. Re-adding a wrapper here
+    // rebuilds that trap, so the root element IS the input.
+    const { container } = renderField();
+
+    expect(container.firstElementChild?.tagName).toBe('TEXTAREA');
+    expect(container.querySelectorAll('div')).toHaveLength(0);
+    expect(container.querySelectorAll('textarea')).toHaveLength(1);
+  });
+
+  it('declares its own vertical padding, which Android needs', () => {
+    // Load-bearing, not decoration. `AndroidTextInputComponentDescriptor.h:98-102`
+    // writes the theme's default EditText padding (~10pt top + ~10pt bottom)
+    // into the Yoga style of any TextInput that declares none:
+    //
+    //   if (!props.hasPadding && !props.hasPaddingTop && !props.hasPaddingVertical) {
+    //     style.setPadding(yoga::Edge::Top, points(theme.top));
+    //   }
+    //
+    // Declaring padding here sets `hasPaddingVertical` and suppresses that
+    // default. Drop it and the ~5pt sliver of #4642 comes back. Do not "tidy"
+    // this away because iOS looks fine without it.
+    const { container } = renderField();
+    const style = inputStyle(container);
+
+    const paddingVertical = verticalPaddingOf(style);
+    expect(paddingVertical).toBeGreaterThan(0);
+  });
+
+  it('leaves room for a full line of subheadline inside its resting height', () => {
+    // The property the fix actually established: content box =
+    // minHeight - 2*paddingVertical - 2*borderWidth must clear one rendered
+    // line. Green today at 44 - 16 - 2 = 26 against a 20pt line box; red the
+    // moment someone shaves the minimum or fattens the padding.
+    const { container } = renderField();
+    const style = inputStyle(container);
+
+    const minHeight = Number(style.minHeight);
+    const borderWidth = Number(style.borderWidth ?? 0);
+    const contentHeight = minHeight - 2 * verticalPaddingOf(style) - 2 * borderWidth;
+
+    expect(contentHeight).toBeGreaterThanOrEqual(materialTextStyles.subheadline.lineHeight);
+  });
+
+  it('grows past its resting height before it starts hiding text', () => {
+    // #4642's second half: past `maxHeight` the note scrolls inside the field,
+    // and an Android multiline TextInput draws no scrollbar — so the start of
+    // the note disappears with nothing on screen to say so. Four lines was too
+    // few to be rare. Keep the ceiling at eight lines or better.
+    const { container } = renderField();
+    const style = inputStyle(container);
+
+    const maxHeight = Number(style.maxHeight);
+    const borderWidth = Number(style.borderWidth ?? 0);
+    const visibleLines = Math.floor(
+      (maxHeight - 2 * verticalPaddingOf(style) - 2 * borderWidth) / materialTextStyles.subheadline.lineHeight,
+    );
+
+    expect(maxHeight).toBeGreaterThan(Number(style.minHeight));
+    expect(visibleLines).toBeGreaterThanOrEqual(8);
+    expect(style.textAlignVertical).toBe('top');
+    expect(container.querySelector('textarea')?.getAttribute('data-multiline')).toBe('true');
+  });
+});
+
+/** Vertical padding however it was spelled: `paddingVertical`, `padding`, or a
+ *  matching `paddingTop`/`paddingBottom` pair. Any of the three sets Fabric's
+ *  `hasPadding*` flags and suppresses the injected theme default. */
+function verticalPaddingOf(style: Record<string, unknown>): number {
+  if (style.paddingVertical != null) return Number(style.paddingVertical);
+  if (style.paddingTop != null && style.paddingBottom != null) {
+    expect(style.paddingTop).toBe(style.paddingBottom);
+    return Number(style.paddingTop);
+  }
+  if (style.padding != null) return Number(style.padding);
+  return 0;
+}

--- a/packages/mobile/src/components/tick/__tests__/tick-note-field.test.tsx
+++ b/packages/mobile/src/components/tick/__tests__/tick-note-field.test.tsx
@@ -93,8 +93,7 @@ describe('TickNoteField', () => {
     const { container } = renderField();
     const style = inputStyle(container);
 
-    const paddingVertical = verticalPaddingOf(style);
-    expect(paddingVertical).toBeGreaterThan(0);
+    expect(totalVerticalPaddingOf(style)).toBeGreaterThan(0);
   });
 
   it('leaves room for a full line of subheadline inside its resting height', () => {
@@ -107,7 +106,7 @@ describe('TickNoteField', () => {
 
     const minHeight = Number(style.minHeight);
     const borderWidth = Number(style.borderWidth ?? 0);
-    const contentHeight = minHeight - 2 * verticalPaddingOf(style) - 2 * borderWidth;
+    const contentHeight = minHeight - totalVerticalPaddingOf(style) - 2 * borderWidth;
 
     expect(contentHeight).toBeGreaterThanOrEqual(materialTextStyles.subheadline.lineHeight);
   });
@@ -123,7 +122,7 @@ describe('TickNoteField', () => {
     const maxHeight = Number(style.maxHeight);
     const borderWidth = Number(style.borderWidth ?? 0);
     const visibleLines = Math.floor(
-      (maxHeight - 2 * verticalPaddingOf(style) - 2 * borderWidth) / materialTextStyles.subheadline.lineHeight,
+      (maxHeight - totalVerticalPaddingOf(style) - 2 * borderWidth) / materialTextStyles.subheadline.lineHeight,
     );
 
     expect(maxHeight).toBeGreaterThan(Number(style.minHeight));
@@ -133,15 +132,16 @@ describe('TickNoteField', () => {
   });
 });
 
-/** Vertical padding however it was spelled: `paddingVertical`, `padding`, or a
- *  matching `paddingTop`/`paddingBottom` pair. Any of the three sets Fabric's
- *  `hasPadding*` flags and suppresses the injected theme default. */
-function verticalPaddingOf(style: Record<string, unknown>): number {
-  if (style.paddingVertical != null) return Number(style.paddingVertical);
-  if (style.paddingTop != null && style.paddingBottom != null) {
-    expect(style.paddingTop).toBe(style.paddingBottom);
-    return Number(style.paddingTop);
+/** Top + bottom padding, however it was spelled: `paddingVertical`, `padding`,
+ *  or a `paddingTop`/`paddingBottom` pair. Any of the three sets Fabric's
+ *  `hasPadding*` flags and suppresses the injected theme default. Returns the
+ *  sum rather than one edge, so the arithmetic below holds even if the two
+ *  edges ever differ — and so this helper never asserts on the caller's behalf. */
+function totalVerticalPaddingOf(style: Record<string, unknown>): number {
+  if (style.paddingVertical != null) return 2 * Number(style.paddingVertical);
+  if (style.paddingTop != null || style.paddingBottom != null) {
+    return Number(style.paddingTop ?? 0) + Number(style.paddingBottom ?? 0);
   }
-  if (style.padding != null) return Number(style.padding);
+  if (style.padding != null) return 2 * Number(style.padding);
   return 0;
 }

--- a/packages/mobile/src/components/tick/__tests__/tick-note-field.test.tsx
+++ b/packages/mobile/src/components/tick/__tests__/tick-note-field.test.tsx
@@ -96,19 +96,39 @@ describe('TickNoteField', () => {
     expect(totalVerticalPaddingOf(style)).toBeGreaterThan(0);
   });
 
-  it('leaves room for a full line of subheadline inside its resting height', () => {
-    // The property the fix actually established: content box =
-    // minHeight - 2*paddingVertical - 2*borderWidth must clear one rendered
-    // line. Green today at 44 - 16 - 2 = 26 against a 20pt line box; red the
-    // moment someone shaves the minimum or fattens the padding.
+  it('opens with room for two lines of subheadline, never fewer than one', () => {
+    // Two invariants in one, and they are not the same invariant.
+    //
+    // The floor — content box clears ONE rendered line — is the property
+    // #4684's fix established, and the one that failed in 2.3.1. It must hold
+    // whatever the resting height becomes.
+    //
+    // The target — it clears TWO — is #4642's other half: a beta note that
+    // opens one line tall gives the climber a word's worth of room to start a
+    // sentence in. Green today at 64 - 16 - 2 = 46 against a 20pt line box.
     const { container } = renderField();
     const style = inputStyle(container);
 
     const minHeight = Number(style.minHeight);
     const borderWidth = Number(style.borderWidth ?? 0);
     const contentHeight = minHeight - totalVerticalPaddingOf(style) - 2 * borderWidth;
+    const { lineHeight } = materialTextStyles.subheadline;
 
-    expect(contentHeight).toBeGreaterThanOrEqual(materialTextStyles.subheadline.lineHeight);
+    expect(contentHeight).toBeGreaterThanOrEqual(lineHeight);
+    expect(contentHeight).toBeGreaterThanOrEqual(2 * lineHeight);
+  });
+
+  it('draws a visible edge before it is focused', () => {
+    // `transparent` at rest left the field with no boundary at all, so it read
+    // as decoration rather than somewhere to type. The contrast that border
+    // reaches is a separate, tracked problem (#4722); that it EXISTS is this
+    // one. `borderWidth` stays put either way so focus never resizes the box.
+    const { container } = renderField();
+    const style = inputStyle(container);
+
+    expect(style.borderColor).not.toBe('transparent');
+    expect(style.borderColor).toBeTruthy();
+    expect(Number(style.borderWidth)).toBeGreaterThan(0);
   });
 
   it('grows past its resting height before it starts hiding text', () => {

--- a/packages/mobile/src/components/tick/__tests__/tick-note-field.test.tsx
+++ b/packages/mobile/src/components/tick/__tests__/tick-note-field.test.tsx
@@ -109,6 +109,11 @@ describe('TickNoteField', () => {
     const { container } = renderField();
     const style = inputStyle(container);
 
+    // Ahead of the arithmetic, because `minHeight` living on a wrapper instead
+    // of the input (the 2.3.1 shape) makes every number below `NaN`, and
+    // "expected NaN to be >= 40" names the symptom rather than the cause.
+    expect(style.minHeight).toBeTypeOf('number');
+
     const minHeight = Number(style.minHeight);
     const borderWidth = Number(style.borderWidth ?? 0);
     const contentHeight = minHeight - totalVerticalPaddingOf(style) - 2 * borderWidth;
@@ -135,9 +140,15 @@ describe('TickNoteField', () => {
     // #4642's second half: past `maxHeight` the note scrolls inside the field,
     // and an Android multiline TextInput draws no scrollbar — so the start of
     // the note disappears with nothing on screen to say so. Four lines was too
-    // few to be rare. Keep the ceiling at eight lines or better.
+    // few to be rare. Seven is the ceiling, and it is bounded from above too:
+    // iOS keeps only 162pt of sheet body above the keyboard, and a field taller
+    // than that can never scroll fully into view (see `TickNoteField`).
     const { container } = renderField();
     const style = inputStyle(container);
+
+    // Same reason as the resting-height test: without this the regression
+    // reports `NaN`, not "the ceiling moved off the input".
+    expect(style.maxHeight).toBeTypeOf('number');
 
     const maxHeight = Number(style.maxHeight);
     const borderWidth = Number(style.borderWidth ?? 0);
@@ -146,7 +157,7 @@ describe('TickNoteField', () => {
     );
 
     expect(maxHeight).toBeGreaterThan(Number(style.minHeight));
-    expect(visibleLines).toBeGreaterThanOrEqual(8);
+    expect(visibleLines).toBeGreaterThanOrEqual(7);
     expect(style.textAlignVertical).toBe('top');
     expect(container.querySelector('textarea')?.getAttribute('data-multiline')).toBe('true');
   });

--- a/packages/mobile/src/components/tick/tick-sheet-metrics.ts
+++ b/packages/mobile/src/components/tick/tick-sheet-metrics.ts
@@ -63,12 +63,19 @@ export const TICK_COUNT_RAIL_MIN_CHIPS = 15;
 /**
  * Create sheet detents.
  *
- * Column: header 56 + rows (date 56 + grade 60 + stars 56 + tries 60 + note 56
- * = 288) + footer (paddingTop 12 + error slot 18 + gap 8 + button 56 +
- * paddingBottom 12 + window inset ~34 = 140) = 484; plus SHEET_TOP_CHROME_PT 20
- * = 504. On an iPhone 16 Pro the fraction base is 852 - 59 top inset - 24 top
- * gap = 769, so 504/769 = 65.5% -> '65%'. The second detent is the keyboard
- * detent.
+ * Column: header 56 + rows (date 56 + grade 60 + stars 56 + tries 60 + note 68
+ * = 300) + footer (paddingTop 12 + error slot 18 + gap 8 + button 56 +
+ * paddingBottom 12 + window inset ~34 = 140) = 496; plus SHEET_TOP_CHROME_PT 20
+ * = 516. On an iPhone 16 Pro the fraction base is 852 - 59 top inset - 24 top
+ * gap = 769, so 516/769 = 67.1%. The detent stays '65%' anyway — that is a
+ * 480pt column, ~16pt short of the content, so the bottom edge of the note row
+ * opens just under the fold. Deliberate: the body scrolls under a pinned
+ * footer, and erring SHORT is the safe direction (use-sheet-column-style.ts:5-8
+ * — a few spare points beat a clipped footer, #3330). The second detent is the
+ * keyboard detent.
+ *
+ * The note row is 68, not the 56pt beat: the field's own minHeight 64 plus the
+ * row's 4pt `alignTop` inset (#4642). Change either and this derivation moves.
  */
 export const CREATE_TICK_SNAP_POINTS = ['65%', '92%'];
 
@@ -76,10 +83,10 @@ export const CREATE_TICK_SNAP_POINTS = ['65%', '92%'];
  * Edit sheet detents.
  *
  * Column: header 56 + rows (status 56 + date 56 + grade 60 + angle 64 + stars
- * 56 + tries 60 + note 56 = 408) + delete group (spacing[8] 32 + 56 = 88) +
- * footer 122 = 674; plus 20 = 694/769 = 90%. That is higher than we want a
- * sheet to open, so the first detent is deliberately '80%' and the body scrolls
- * the last ~90pt — safe because Save is pinned in the footer, not chased down
- * the scroll. The second detent is the keyboard detent.
+ * 56 + tries 60 + note 68 = 420) + delete group (spacing[8] 32 + 56 = 88) +
+ * footer 122 = 686; plus 20 = 706/769 = 91.8%. That is higher than we want a
+ * sheet to open, so the first detent is deliberately '80%' (a 595pt column) and
+ * the body scrolls the last ~91pt — safe because Save is pinned in the footer,
+ * not chased down the scroll. The second detent is the keyboard detent.
  */
 export const EDIT_TICK_SNAP_POINTS = ['80%', '92%'];

--- a/packages/mobile/src/components/you/LogbookEditSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookEditSheet.tsx
@@ -229,7 +229,7 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
       surface="solid"
       footerSurface="flush"
       // See the identical fix on the create-tick sheet (`LogAscentSheet`,
-      // #4642): the edit sheet has the same pinned-footer-under-Android's-
+      // #4723): the edit sheet has the same pinned-footer-under-Android's-
       // partial-state shape, so it gets the same opt-in.
       androidOpensExpanded
       onClose={onClose}
@@ -316,7 +316,8 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
         />
       </TickFormRow>
 
-      <TickFormRow label={tTick('mobile.tick.noteLabel')} showSeparator={false}>
+      {/* `alignTop` for the same reason as the create sheet's note row (#4642). */}
+      <TickFormRow label={tTick('mobile.tick.noteLabel')} alignTop showSeparator={false} testID="tick-row-note">
         <TickNoteField
           value={comment}
           onChangeText={setComment}

--- a/packages/mobile/src/components/you/LogbookEditSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookEditSheet.tsx
@@ -229,7 +229,7 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
       surface="solid"
       footerSurface="flush"
       // See the identical fix on the create-tick sheet (`LogAscentSheet`,
-      // #4231): the edit sheet has the same pinned-footer-under-Android's-
+      // #4642): the edit sheet has the same pinned-footer-under-Android's-
       // partial-state shape, so it gets the same opt-in.
       androidOpensExpanded
       onClose={onClose}


### PR DESCRIPTION
## Summary

Fixes #4642.

The reporter filed one complaint with two halves, and they resolve differently.

**Half 1 — "i cant see the text. it is there".** Already fixed. The note rendered as a ~5pt band of glyph bottoms and a stub caret; that landed on `main` in #4684 / `245f9ca1b` on 2026-08-22 and shipped on the `production` OTA channel on 2026-08-23, two days after this issue was filed against 2.3.1. #4684 was merged without the emulator pass its own test plan asked for, and it linked #4231 (an unrelated gym-claim ticket, closed 2026-08-11) rather than this issue — which is why #4642 is still open. This PR closes that loop: it verifies half 1 on a device, states the mechanism honestly, and guards it.

**Half 2 — "the text window is to small".** Still live, and this PR fixes it.

### What the emulator showed

Android emulator, Pixel AVD at 810x1800 px / density 320 (= 405x900pt, close to the reporter's 411x914pt device), dark, current `main`. Measurements are `uiautomator` node bounds on the `Tick note` node.

| | Measured on `main` |
| --- | --- |
| Note field at rest | 44pt — one line |
| Note field with a long note | **95.5pt** — pinned at the 96pt `maxHeight`, four lines |
| Empty sheet between the Note row and the Attempt/Send bar, keyboard down | **~302pt** |
| Sheet body height above the keyboard | ~293pt |

Past four lines the note scrolls **inside** the field. An Android multiline `TextInput` has no scrollbar prop at all in RN 0.86, so there is nothing on screen to say text exists above the fold — a six-line note opened mid-sentence on *"before the dyn beta is solid now and I wan…"*, with the first lines silently gone. That is exactly "the text window is to small", and the sheet had ~300pt of empty space it was not using.

### The change

| | before | after |
| --- | --- | --- |
| `minHeight` | 44 — one line | **64** — two lines |
| `maxHeight` | 96 — four lines | **160** — seven lines |
| label alignment on the note row | centred against the box | **top-aligned** to the first line of text |
| border at rest | `transparent` | `systemColors.separator` |

**`maxHeight` 96 → 160.** Seven lines (7 × 20pt `subheadline` line-height + 16pt padding + 2pt border = 158, 2pt spare), +67% on the old ceiling. A maxed note spends 116 of the ~302pt of measured dead space.

The binding constraint is not Android but **iOS**, and this ceiling was 180 until review re-derived that bound. On the reference device the detent test pins (window 844 − 44 top inset − 24 iOS-26 card gap = base 776): the `'92%'` keyboard detent gives a 694pt column, `KeyboardAvoidingView behavior="padding"` takes 336 for the keyboard → 358, less the 56pt header and the footer. The footer is where the two readings split. The 180 figure assumed the window bottom inset collapses to 0 while the keyboard is up (footer 106 → body 196pt); it does not — `useWindowBottomInset()` keeps returning the published 34pt inset and nothing in the app zeroes it on keyboard show (`hooks/use-window-bottom-inset.ts:20-24`), so the footer is 140 and the **visible body is 162pt**. 180 overflowed it by 18pt, and a field taller than the visible body can never scroll fully into view — the exact rule the old comment stated and its own value broke.

160 is safe under both readings. The derivation, including which assumption killed 180, is now in the constant's comment, so nobody re-raises the ceiling on the old argument.

**`minHeight` 44 → 64.** Two lines of `subheadline` plus the field's own padding and border, matching `EndSessionSheet`'s recap box. A one-line box to start a beta note in was half the complaint still shipping.

**`alignTop` on `TickFormRow`.** `TickFormRow` centres its label against the control, which is correct for every row on the 56pt beat and wrong for the one control that now grows to 160pt — the label ended up level with the middle of the note rather than its first line. New opt-in prop (row `alignItems: 'flex-start'` + `paddingTop: spacing[1]`, label `paddingTop: spacing[2]`), passed **only** from `QuickTickBar` and `LogbookEditSheet`, so every other row is untouched. It defers to `stacked`, which already puts the label on its own line. Verified on the emulator at a 178pt field (the tallest the pre-review 180pt ceiling allowed): label top and field top land on the same pixel, was ~31pt below the first text line. The alignment is independent of the ceiling, so lowering it to 160 does not change that geometry.

One caveat for the next adopter, deliberately left as-is: the inset is **top-only** (`paddingTop: spacing[1]`, no matching `paddingBottom`). Invisible on the two rows that opt in today — both pass `showSeparator={false}` and are last in their sheet — but the first row that takes `alignTop` *with* a separator gets its hairline flush against the control's bottom edge with 4pt above it, which reads as a rendering bug rather than a missing prop. Mirror the inset, or keep pairing `alignTop` with `showSeparator={false}`.

**Visible edge at rest.** `borderColor: 'transparent'` meant the unfocused field had no boundary at all. Now `systemColors.separator`, with `borderWidth` unchanged so focus recolours rather than resizes. Being straight about it: it clears WCAG 1.4.11's 3:1 in **neither** scheme — **~1.9:1 in dark, ~1.6:1 in light**, so dark is the better of the two rather than the worst case. The design system has no border role that clears 3:1 on both platforms. Tracked in **#4722**, not solved here.

**Deliberately not touched — and two independent emulator passes reached this same conclusion:**

- **The detents.** `CREATE_TICK_SNAP_POINTS[0]` is discarded before it reaches the sheet on Android (`sheet-snap-points.ts:45`, under `androidOpensExpanded`), and `@expo/ui`'s Android sheet never reads a `%` for sizing — so a detent edit changes zero pixels on the reported platform while forcing `log-ascent-sheet.test.tsx` to be re-baselined. The body is scrollable under a pinned footer, so the taller field costs the action bar nothing.
- **`TickFormRow`'s `height` prop.** Applied as `minHeight` (`TickFormRow.tsx:65`), so the row already sizes to a taller child. Inert.
- **Parking the caret at the start on blur.** An overflowing note stays scrolled wherever the caret left it, so blurring can leave you looking at the middle of your own note. The taller box makes that far rarer but does not remove it. Fixing it means `setNativeProps({ selection })` during blur, which touches Android IME composition and needs a device matrix rather than one emulator. Filed as **#4730**.

### On the mechanism, honestly

#4684's commit message credits *"nested-flex vertical centering"* for the sliver. That does not survive the arithmetic: the old outer box was 44 − 16 padding − 2 border = 26pt inner, and a 20pt line fits in 26pt. Nor does the stronger version of that story — this repo's vendored Yoga clamps `availableInnerMainDim` to the min constraint *before* `resolveFlexibleLength` (`CalculateLayout.cpp`), so the old child resolved to ~26pt, not 0.

What **is** established: the ink band measured ~5pt, the first ink sat ~9.7pt below the input's top edge despite `textAlignVertical: 'top'`, and declaring padding on the input fixed it. The **leading hypothesis** for the ~9.7pt is Fabric's — `AndroidTextInputComponentDescriptor.h:98-102` writes the theme's default `EditText` padding into the Yoga style of any `TextInput` that declares none, and declaring padding sets `hasPaddingVertical` and suppresses it. The header comment now says exactly that much and no more. Either way the padding is what changed the rendering, so `tick-note-field.test.tsx` guards it — and a future "simplify" pass that keeps the flat shape but drops the padding now fails a test instead of re-opening the bug.

### Review follow-ups (applied in `f6135165c`)

- **The ceiling: 180 → 160.** Re-derived above. The old number rested on an unstated assumption about the window bottom inset that the code does not honour.
- **Detent derivations un-drifted.** `tick-sheet-metrics.ts` still derived both sheets from a 56pt note row while this PR made the row **68** (field `minHeight` 64 + the 4pt `alignTop` inset). So the create column is 496, not 484 (+20 chrome → 516/769 = 67.1%), and the edit column 686, not 674 (706/769 = 91.8%). **Detent values are unchanged** — `['65%', '92%']` / `['80%', '92%']` still ship, and `log-ascent-sheet.test.tsx` needs no re-baseline. What changed is that the comments now say the truth: at `'65%'` the 480pt column opens ~16pt short of the content, deliberately, because the body scrolls under a pinned footer and erring short beats a clipped footer (#3330). That module exists to stop the field size and the detent arithmetic drifting apart, so it does not get to drift itself.
- **WCAG figures corrected** — both schemes stated, above.
- **Two assertions no longer fail via `NaN`.** `minHeight` / `maxHeight` living on a wrapper instead of the input made every number downstream `NaN`; the tests went red (no false green) but reported *"expected NaN to be >= 40"*. They now check the property is on the input first, and the regression reads *"expected undefined to be type of 'number'"* — mutation-checked by moving both off the input.

### Cross-reference cleanup

Six comments cited `#4231` for the Android tick-sheet work: `sheet-snap-points.ts`, `Sheet.tsx`, `ModalSheet.tsx`, `LogAscentSheet.tsx`, `you/LogbookEditSheet.tsx`, `docs/mobile-sheets-vs-routes.md`. Every one of them describes the **pinned-footer / Send-button-below-the-fold** bug — `androidOpensExpanded`, Android's ~50% partial state stranding the footer — **not** the note field. So they point at **#4723**, the issue filed for that, not at this one. (An earlier revision of this PR pointed them at #4642; that was wrong for the same reason #4231 was, and is corrected in `f38f4ec1`.)

## Release Notes

- Room for real beta when you log a send: the note box opens two lines tall and grows to hold a full paragraph, so what you're writing stays on screen instead of scrolling out of sight.

## Test plan

Emulator: Android, Pixel AVD 810x1800 @ density 320, dark, dev-client against Metro from this branch. Climbs → a climb → log a send → Note.

- [x] **Short note** (`gogogo`) on current `main`: full-height glyphs, full-height caret, light violet on the dark violet fill. Half 1 confirmed fixed by #4684 — the check #4684 never ran.
- [x] **Long note** on current `main`: field pinned at 95.5pt / four lines, note rendering from mid-sentence, ~302pt of empty sheet below it. Half 2 reproduced.
- [x] **This branch, at rest**: field 64pt / two lines, label level with the placeholder's first line, visible border before focus.
- [x] **This branch, long note**: field grows 98 → 118 → 158 → 178pt reading from its first word, clamps at exactly 180pt, label top and field top on the same pixel, Attempt/Send on screen above the keyboard, body scrolls the rows above. Captured at the 180pt revision; **not re-captured at 160**, which caps the same field one 20pt line earlier (158pt rendered) and changes nothing else on screen.
- [x] `vp check` — my files clean (scoped run: 16 files, no warnings or errors); the full-repo run reports 8 errors + 259 warnings, all pre-existing in `packages/backend` and `packages/db` and untouched here
- [x] `vp test run --project mobile tick-note-field tick-form-row log-ascent` — 4 files, 31 tests, all pass
- [x] `vp run typecheck:mobile` — clean
- [x] `vp run test:mobile` — 703 files, 6940 tests, all pass
- [x] `vp run check:mobile-bundle` — android bundle OK

Every guard added here was **mutation-tested** — each fails on its own regression and stays green for the others:

| Mutation | Fails |
| --- | --- |
| drop `paddingVertical` | padding guard only |
| `maxHeight` back to 96 | ceiling guard only |
| `minHeight` back to 44 | two-line guard only |
| `borderColor` back to `transparent` | visible-edge guard only |
| wrap the input in a `View` | flat-shape guard only |
| `alignTop` ignored | opt-in guard only |
| `alignTop` applied unconditionally | default-beat guard only |
| `minHeight` / `maxHeight` moved off the input | both height guards, now naming the moved property instead of `NaN` |

JS-only, so this rides the production OTA — no native rebuild, no fingerprint change.

Two independent emulator passes (this one and a parallel session) reproduced the same 4-line cap and independently rejected the detent bump and the `height` prop.

The reporter's screenshot is on #4642. GitHub image upload is not reachable from this environment, so the numbers above are node bounds rather than pixel-peeping, and the captures are laid out side by side here: **https://claude.ai/code/artifact/1fa50a2c-1e7c-4174-961a-11644245bed4** (Boardsesh team only). The PNGs are at `.boardsesh/shots/` in the working tree — happy to have them dragged into this body by anyone with a browser session.

