### PR TITLE
feat(mobile): show who queued each climb in a shared session

### DIFF
--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -418,12 +418,15 @@ function QueueItemRowComponent({
   const showSentAtAngle =
     isHistoryItem && !isEditMode && typeof climbedAtAngle === 'number' && climbedAtAngle !== board.angle;
 
-  // Edit mode strips secondary chrome (same rule as the sent-at-angle chip) and
-  // is the row's widest state — the checkbox slot plus the delete affordance.
   const addedBy = resolveQueueRowAttribution(item.addedByUser, {
-    showAddedBy: showAddedBy && !isEditMode,
+    showAddedBy,
     viewerUserId,
   });
+  // Edit mode strips secondary chrome (same rule as the sent-at-angle chip) and
+  // is the row's widest state — the checkbox slot plus the delete affordance.
+  // Only the glyph goes: the accessibility label has no width budget, and a
+  // VoiceOver user needs to know whose climb they are about to bulk-delete.
+  const showAddedByAvatar = addedBy != null && !isEditMode;
 
   // A plain const, deliberately NOT a useMemo: `rowAccessibilityActions` above is
   // memoized because a test asserts its identity across re-renders, but a string
@@ -489,7 +492,7 @@ function QueueItemRowComponent({
         )}
 
         {/* Who queued it — decorative; the row's own label carries the name. */}
-        {addedBy && (
+        {showAddedByAvatar && addedBy && (
           <View
             pointerEvents="none"
             accessibilityElementsHidden

--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -15,6 +15,8 @@ import { Text } from './Text';
 import { Icon } from './Icon';
 import { ClimbListItemContent } from './ClimbListItemContent';
 import { THUMBNAIL_WIDTH } from './ClimbListThumbnail';
+import { BoardDriverAvatar } from './board-presence/BoardDriverAvatar';
+import { resolveQueueRowAttribution } from '../lib/queue-attribution';
 import { iosSystemColors } from '../theme/ios-colors';
 import { spacing } from '../theme/tokens';
 import { springs } from '../theme/animations';
@@ -69,6 +71,10 @@ type QueueItemRowProps = {
   queueIndex?: number;
   /** Whether this row may be dragged (future rows, not in edit mode). */
   isDraggable?: boolean;
+  /** Show who queued this climb. True only while a party session is active. */
+  showAddedBy?: boolean;
+  /** The viewer's own party-profile id; their own adds render no avatar. */
+  viewerUserId?: string | null;
 };
 
 function PositionIndicator({
@@ -121,6 +127,8 @@ function QueueItemRowComponent({
   rowIndex,
   queueIndex,
   isDraggable = false,
+  showAddedBy = false,
+  viewerUserId = null,
 }: QueueItemRowProps) {
   const { systemColors, brandColors } = useTheme();
   const { t } = useTranslation('session');
@@ -410,6 +418,21 @@ function QueueItemRowComponent({
   const showSentAtAngle =
     isHistoryItem && !isEditMode && typeof climbedAtAngle === 'number' && climbedAtAngle !== board.angle;
 
+  // Edit mode strips secondary chrome (same rule as the sent-at-angle chip) and
+  // is the row's widest state — the checkbox slot plus the delete affordance.
+  const addedBy = resolveQueueRowAttribution(item.addedByUser, {
+    showAddedBy: showAddedBy && !isEditMode,
+    viewerUserId,
+  });
+
+  // A plain const, deliberately NOT a useMemo: `rowAccessibilityActions` above is
+  // memoized because a test asserts its identity across re-renders, but a string
+  // has no such contract and memoizing it would only add a deps array to keep true.
+  const positionLabel = t('mobile.queue.positionLabel', { position });
+  const rowAccessibilityLabel = addedBy
+    ? `${climbName}, ${positionLabel}, ${t('mobile.queue.addedByAria', { name: addedBy.name })}`
+    : `${climbName}, ${positionLabel}`;
+
   const rowContent = (
     // touchAction="pan-y" (web only): RNGH otherwise defaults the row's DOM node
     // to `touch-action: none`, which blocks native touch-scrolling for any drag
@@ -420,7 +443,7 @@ function QueueItemRowComponent({
       <Animated.View
         accessible
         accessibilityRole="button"
-        accessibilityLabel={`${climbName}, ${t('mobile.queue.positionLabel', { position })}`}
+        accessibilityLabel={rowAccessibilityLabel}
         accessibilityState={{ selected: isEditMode ? isSelected : isCurrentClimb }}
         onAccessibilityTap={handlePress}
         accessibilityActions={rowAccessibilityActions}
@@ -463,6 +486,18 @@ function QueueItemRowComponent({
           >
             {t('mobile.queue.sentAtAngle', { angle: climbedAtAngle })}
           </Text>
+        )}
+
+        {/* Who queued it — decorative; the row's own label carries the name. */}
+        {addedBy && (
+          <View
+            pointerEvents="none"
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+            style={styles.addedByAvatar}
+          >
+            <BoardDriverAvatar uri={addedBy.avatarUrl} name={addedBy.name} size={20} status="none" />
+          </View>
         )}
 
         {/* Trailing action: tick (history) or drag handle (upcoming) */}
@@ -581,6 +616,9 @@ const styles = StyleSheet.create({
   sentAtAngle: {
     flexShrink: 0,
     fontVariant: ['tabular-nums'],
+  },
+  addedByAvatar: {
+    flexShrink: 0,
   },
   deleteAction: {
     position: 'absolute',

--- a/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
+++ b/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
@@ -50,6 +50,7 @@ type AccessibilityCapture = {
   onAccessibilityTap?: () => void;
   accessibilityActions?: { name: string; label?: string }[];
   onAccessibilityAction?: (event: { nativeEvent: { actionName: string } }) => void;
+  accessibilityLabel?: string;
 };
 const a11y = vi.hoisted(() => ({
   row: null as null | AccessibilityCapture,
@@ -112,6 +113,7 @@ vi.mock('react-native-reanimated', () => {
         onAccessibilityTap: rest.onAccessibilityTap,
         accessibilityActions: rest.accessibilityActions,
         onAccessibilityAction: rest.onAccessibilityAction,
+        accessibilityLabel: rest.accessibilityLabel,
       };
     }
     return createElement('div', null, children);
@@ -230,6 +232,14 @@ vi.mock('../ClimbListItemContent', () => ({
 
 vi.mock('../ClimbListThumbnail', () => ({ THUMBNAIL_WIDTH: 96 }));
 
+// Without this mock the new import drags PressableAvatar → expo-router's
+// useRouter and Avatar → Image/PixelRatio into a graph whose `react-native` mock
+// above exports only Platform, PlatformColor, View, Pressable and StyleSheet —
+// which would break every test in this file, not just the attribution ones.
+vi.mock('../board-presence/BoardDriverAvatar', () => ({
+  BoardDriverAvatar: ({ name }: { name?: string | null }) => createElement('span', { 'data-added-by': name ?? '' }),
+}));
+
 vi.mock('../../theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 3: 12 } }));
 
 vi.mock('../../theme/animations', () => ({ springs: { interactive: {} } }));
@@ -246,12 +256,13 @@ const board: QueueItemRowBoard = {
   angle: 40,
 };
 
-function makeItem(uuid: string, name: string): ClimbQueueItem {
+function makeItem(uuid: string, name: string, addedByUser?: ClimbQueueItem['addedByUser']): ClimbQueueItem {
   return {
     uuid,
     climb: { uuid: `climb-${uuid}`, name } as ClimbQueueItem['climb'],
     addedBy: null,
     source: null,
+    addedByUser,
   } as ClimbQueueItem;
 }
 
@@ -820,6 +831,89 @@ describe('QueueItemRow React.memo', () => {
     // Single negative number = leftward-only activation; NOT a symmetric [-10, 10]
     // array (which would also activate on rightward / right-diagonal drags).
     expect(activeOffsetX?.args).toEqual([-10]);
+  });
+});
+
+describe('QueueItemRow added-by attribution', () => {
+  const peer = { id: 'peer-1', username: 'Mina', avatarUrl: null };
+  const baseProps = {
+    position: 1,
+    board,
+    isCurrentClimb: false,
+    onPress,
+    onRemove,
+    onToggleSelect,
+  };
+
+  beforeEach(() => {
+    renderCounter.count = 0;
+    a11y.row = null;
+    a11y.tick = null;
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing outside a session', () => {
+    const { container } = render(
+      <QueueItemRow item={makeItem('a', 'Crimp Master', peer)} {...baseProps} showAddedBy={false} viewerUserId="me" />,
+    );
+    expect(container.querySelector('[data-added-by]')).toBeNull();
+    expect(a11y.row?.accessibilityLabel).not.toContain('mobile.queue.addedByAria');
+  });
+
+  it('renders no empty slot for an item that predates attribution', () => {
+    const { container } = render(
+      <QueueItemRow item={makeItem('a', 'Crimp Master')} {...baseProps} showAddedBy viewerUserId="me" />,
+    );
+    expect(container.querySelector('[data-added-by]')).toBeNull();
+    expect(a11y.row?.accessibilityLabel).not.toContain('mobile.queue.addedByAria');
+  });
+
+  it('renders nothing for the viewers own add', () => {
+    const own = { id: 'me', username: 'Marco', avatarUrl: null };
+    const { container } = render(
+      <QueueItemRow item={makeItem('a', 'Crimp Master', own)} {...baseProps} showAddedBy viewerUserId="me" />,
+    );
+    expect(container.querySelector('[data-added-by]')).toBeNull();
+    expect(a11y.row?.accessibilityLabel).not.toContain('mobile.queue.addedByAria');
+  });
+
+  it('renders the peers face and names them in the row label', () => {
+    const { container } = render(
+      <QueueItemRow item={makeItem('a', 'Crimp Master', peer)} {...baseProps} showAddedBy viewerUserId="me" />,
+    );
+    expect(container.querySelector('[data-added-by]')?.getAttribute('data-added-by')).toBe('Mina');
+    expect(a11y.row?.accessibilityLabel).toContain('mobile.queue.addedByAria');
+  });
+
+  it('suppresses the face in edit mode', () => {
+    const { container } = render(
+      <QueueItemRow
+        item={makeItem('a', 'Crimp Master', peer)}
+        {...baseProps}
+        showAddedBy
+        viewerUserId="me"
+        isEditMode
+      />,
+    );
+    expect(container.querySelector('[data-added-by]')).toBeNull();
+  });
+
+  it('still skips a re-render with attribution props set', () => {
+    const element = (
+      <QueueItemRow item={makeItem('a', 'Crimp Master', peer)} {...baseProps} showAddedBy viewerUserId="me" />
+    );
+    const { rerender } = render(element);
+    expect(renderCounter.count).toBe(1);
+    rerender(element);
+    expect(renderCounter.count).toBe(1);
+  });
+
+  it('re-renders exactly once when a session starts', () => {
+    const item = makeItem('a', 'Crimp Master', peer);
+    const { rerender } = render(<QueueItemRow item={item} {...baseProps} showAddedBy={false} viewerUserId="me" />);
+    expect(renderCounter.count).toBe(1);
+    rerender(<QueueItemRow item={item} {...baseProps} showAddedBy viewerUserId="me" />);
+    expect(renderCounter.count).toBe(2);
   });
 });
 

--- a/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
+++ b/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
@@ -203,7 +203,13 @@ vi.mock('react-native-gesture-handler', () => {
 });
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  // Raw key passthrough (what the rest of this file asserts on), EXCEPT for the
+  // added-by label, which resolves its `{{name}}` placeholder. Asserting on a raw
+  // key there would pass even if the name argument never reached the catalog.
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) =>
+      key === 'mobile.queue.addedByAria' ? `Added by ${String(options?.name)}` : key,
+  }),
 }));
 
 vi.mock('../../providers/theme-provider', () => ({
@@ -857,7 +863,7 @@ describe('QueueItemRow added-by attribution', () => {
       <QueueItemRow item={makeItem('a', 'Crimp Master', peer)} {...baseProps} showAddedBy={false} viewerUserId="me" />,
     );
     expect(container.querySelector('[data-added-by]')).toBeNull();
-    expect(a11y.row?.accessibilityLabel).not.toContain('mobile.queue.addedByAria');
+    expect(a11y.row?.accessibilityLabel).not.toContain('Added by');
   });
 
   it('renders no empty slot for an item that predates attribution', () => {
@@ -865,7 +871,7 @@ describe('QueueItemRow added-by attribution', () => {
       <QueueItemRow item={makeItem('a', 'Crimp Master')} {...baseProps} showAddedBy viewerUserId="me" />,
     );
     expect(container.querySelector('[data-added-by]')).toBeNull();
-    expect(a11y.row?.accessibilityLabel).not.toContain('mobile.queue.addedByAria');
+    expect(a11y.row?.accessibilityLabel).not.toContain('Added by');
   });
 
   it('renders nothing for the viewers own add', () => {
@@ -874,7 +880,7 @@ describe('QueueItemRow added-by attribution', () => {
       <QueueItemRow item={makeItem('a', 'Crimp Master', own)} {...baseProps} showAddedBy viewerUserId="me" />,
     );
     expect(container.querySelector('[data-added-by]')).toBeNull();
-    expect(a11y.row?.accessibilityLabel).not.toContain('mobile.queue.addedByAria');
+    expect(a11y.row?.accessibilityLabel).not.toContain('Added by');
   });
 
   it('renders the peers face and names them in the row label', () => {
@@ -882,7 +888,7 @@ describe('QueueItemRow added-by attribution', () => {
       <QueueItemRow item={makeItem('a', 'Crimp Master', peer)} {...baseProps} showAddedBy viewerUserId="me" />,
     );
     expect(container.querySelector('[data-added-by]')?.getAttribute('data-added-by')).toBe('Mina');
-    expect(a11y.row?.accessibilityLabel).toContain('mobile.queue.addedByAria');
+    expect(a11y.row?.accessibilityLabel).toContain('Added by Mina');
   });
 
   it('suppresses the face in edit mode', () => {

--- a/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
+++ b/packages/mobile/src/components/__tests__/queue-item-row-memo.test.tsx
@@ -891,7 +891,10 @@ describe('QueueItemRow added-by attribution', () => {
     expect(a11y.row?.accessibilityLabel).toContain('Added by Mina');
   });
 
-  it('suppresses the face in edit mode', () => {
+  it('suppresses the face in edit mode but keeps the name in the row label', () => {
+    // Edit mode is the row's widest state, so the 20dp glyph goes. The
+    // accessibility label has no width budget though, and a VoiceOver user
+    // bulk-selecting rows to delete still needs to know whose climb each one is.
     const { container } = render(
       <QueueItemRow
         item={makeItem('a', 'Crimp Master', peer)}
@@ -902,6 +905,7 @@ describe('QueueItemRow added-by attribution', () => {
       />,
     );
     expect(container.querySelector('[data-added-by]')).toBeNull();
+    expect(a11y.row?.accessibilityLabel).toContain('Added by Mina');
   });
 
   it('still skips a re-render with attribution props set', () => {

--- a/packages/mobile/src/components/play-drawer/QueueList.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueList.tsx
@@ -13,6 +13,8 @@ import { Text } from '../Text';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
+import { useQueueSessionId } from '../../providers/queue-provider';
+import { usePartyProfile } from '../../providers/party-profile-provider';
 import { hapticSelection } from '../../lib/haptics';
 import { useSearchClimbs } from '../../lib/graphql/hooks';
 import { toClimbSearchInput, DEFAULT_CLIMB_FILTER_STATE } from '@boardsesh/climb-filters';
@@ -88,6 +90,20 @@ function QueueListComponent({
   const { systemColors, brandColors } = useTheme();
   const insets = useSafeAreaInsets();
   const flatListRef = useRef<FlatList<QueueListRow> | null>(null);
+
+  // Attribution is a session artifact: faces appear while a party session is
+  // joined and stay put when a peer leaves. Deliberately NOT useIsSharedSession()
+  // — that resolves to `sessionActive && distinctUserCount > 1`, so the last peer
+  // leaving (or presence flapping) would wipe every face off a queue still full
+  // of the crew's climbs. And deliberately paired with viewerUserId: the queue
+  // provider stamps SOLO adds too, so without the self-exclusion a one-person
+  // session would show the viewer's own face on every row. Neither value is read
+  // from the live `sessionUsers` roster, which is recreated by every session
+  // stats push.
+  const { sessionId } = useQueueSessionId();
+  const { profile } = usePartyProfile();
+  const showAddedBy = sessionId != null;
+  const viewerUserId = profile?.id ?? null;
 
   // Clear the queue toolbar (styles.listContent's spacing[10]) AND the Android
   // edge-to-edge navigation bar, so the last row never sits under the 3-button nav
@@ -271,6 +287,8 @@ function QueueListComponent({
               onRemove={onRemove}
               onToggleSelect={onToggleSelect}
               onTickHistory={onTickHistory}
+              showAddedBy={showAddedBy}
+              viewerUserId={viewerUserId}
             />
           );
 
@@ -287,6 +305,8 @@ function QueueListComponent({
               onOpenActions={onOpenActions}
               onRemove={onRemove}
               onToggleSelect={onToggleSelect}
+              showAddedBy={showAddedBy}
+              viewerUserId={viewerUserId}
             />
           );
 
@@ -307,6 +327,8 @@ function QueueListComponent({
               rowIndex={index}
               queueIndex={row.queueIndex}
               isDraggable={!isEditMode}
+              showAddedBy={showAddedBy}
+              viewerUserId={viewerUserId}
             />
           );
 
@@ -349,6 +371,8 @@ function QueueListComponent({
       onTickHistory,
       onShowFullHistory,
       handleSuggestionPress,
+      showAddedBy,
+      viewerUserId,
       systemColors.separator,
       systemColors.secondaryBackground,
       brandColors.primary,

--- a/packages/mobile/src/components/play-drawer/QueueList.tsx
+++ b/packages/mobile/src/components/play-drawer/QueueList.tsx
@@ -100,9 +100,13 @@ function QueueListComponent({
   // session would show the viewer's own face on every row. Neither value is read
   // from the live `sessionUsers` roster, which is recreated by every session
   // stats push.
+  // Gated on isLoading as well: `profile` and `sessionId` hydrate on racing async
+  // paths, so a cold launch into a restored session can resolve the session first
+  // and leave viewerUserId null for a frame — long enough to flash the viewer's
+  // own face on their own rows before self-exclusion can suppress it.
   const { sessionId } = useQueueSessionId();
-  const { profile } = usePartyProfile();
-  const showAddedBy = sessionId != null;
+  const { profile, isLoading: isPartyProfileLoading } = usePartyProfile();
+  const showAddedBy = sessionId != null && !isPartyProfileLoading;
   const viewerUserId = profile?.id ?? null;
 
   // Clear the queue toolbar (styles.listContent's spacing[10]) AND the Android

--- a/packages/mobile/src/components/play-drawer/__tests__/queue-list-added-by.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/queue-list-added-by.test.tsx
@@ -17,7 +17,7 @@ import type { ClimbQueueItem } from '@boardsesh/queue';
 // starts mid-queue" test would prove nothing. A store notification re-renders
 // QueueList through the memo, exactly the way a real context change does.
 const session = vi.hoisted(() => {
-  type Snapshot = { sessionId: string | null; profile: { id: string } | null };
+  type Snapshot = { sessionId: string | null; profile: { id: string } | null; isLoading?: boolean };
   const listeners = new Set<() => void>();
   let snapshot: Snapshot = { sessionId: null, profile: null };
   return {
@@ -119,9 +119,10 @@ vi.mock('../../../providers/queue-provider', async () => {
 vi.mock('../../../providers/party-profile-provider', async () => {
   const React = await vi.importActual<typeof import('react')>('react');
   return {
-    usePartyProfile: () => ({
-      profile: React.useSyncExternalStore(session.subscribe, session.getSnapshot, session.getSnapshot).profile,
-    }),
+    usePartyProfile: () => {
+      const snapshot = React.useSyncExternalStore(session.subscribe, session.getSnapshot, session.getSnapshot);
+      return { profile: snapshot.profile, isLoading: snapshot.isLoading ?? false };
+    },
   };
 });
 
@@ -221,6 +222,30 @@ describe('QueueList added-by wiring', () => {
     for (const props of capturedRows.props) {
       expect(props.showAddedBy).toBe(true);
       expect(props.viewerUserId).toBeNull();
+    }
+  });
+
+  it('holds every face back until the party profile has resolved', () => {
+    // A cold launch into a restored session resolves sessionId before the party
+    // profile, so viewerUserId is null for a frame. Without this gate the
+    // viewer's OWN face flashes on their own rows, because the queue provider
+    // stamps solo adds with this device's identity too.
+    session.set({ sessionId: 'session-1', profile: null, isLoading: true });
+    renderList();
+
+    expect(capturedRows.props).toHaveLength(3);
+    for (const props of capturedRows.props) {
+      expect(props.showAddedBy).toBe(false);
+    }
+
+    // ...and they arrive once it lands, without a remount.
+    capturedRows.props.length = 0;
+    act(() => session.set({ sessionId: 'session-1', profile: { id: 'me' }, isLoading: false }));
+
+    expect(capturedRows.props).toHaveLength(3);
+    for (const props of capturedRows.props) {
+      expect(props.showAddedBy).toBe(true);
+      expect(props.viewerUserId).toBe('me');
     }
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/queue-list-added-by.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/queue-list-added-by.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ClimbQueueItem } from '@boardsesh/queue';
@@ -11,10 +11,27 @@ import type { ClimbQueueItem } from '@boardsesh/queue';
 // visibly broken feature. This file renders the real QueueList over all three row
 // kinds and asserts every captured row got the props.
 
-const session = vi.hoisted(() => ({
-  sessionId: null as string | null,
-  profile: null as { id: string } | null,
-}));
+// A tiny external store behind the mocked session/profile hooks, subscribed to
+// with useSyncExternalStore. QueueList is React.memo'd, so reading these off a
+// plain mutable would let an identical-props re-render bail out and a "session
+// starts mid-queue" test would prove nothing. A store notification re-renders
+// QueueList through the memo, exactly the way a real context change does.
+const session = vi.hoisted(() => {
+  type Snapshot = { sessionId: string | null; profile: { id: string } | null };
+  const listeners = new Set<() => void>();
+  let snapshot: Snapshot = { sessionId: null, profile: null };
+  return {
+    getSnapshot: (): Snapshot => snapshot,
+    set: (next: Snapshot) => {
+      snapshot = next;
+      for (const listener of listeners) listener();
+    },
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+});
 
 const capturedRows = vi.hoisted(() => ({
   props: [] as Record<string, unknown>[],
@@ -90,13 +107,23 @@ vi.mock('../../QueueItemRow', () => ({
   },
 }));
 
-vi.mock('../../../providers/queue-provider', () => ({
-  useQueueSessionId: () => ({ sessionId: session.sessionId }),
-}));
+vi.mock('../../../providers/queue-provider', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  return {
+    useQueueSessionId: () => ({
+      sessionId: React.useSyncExternalStore(session.subscribe, session.getSnapshot, session.getSnapshot).sessionId,
+    }),
+  };
+});
 
-vi.mock('../../../providers/party-profile-provider', () => ({
-  usePartyProfile: () => ({ profile: session.profile }),
-}));
+vi.mock('../../../providers/party-profile-provider', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  return {
+    usePartyProfile: () => ({
+      profile: React.useSyncExternalStore(session.subscribe, session.getSnapshot, session.getSnapshot).profile,
+    }),
+  };
+});
 
 import { QueueList } from '../QueueList';
 
@@ -138,13 +165,11 @@ function renderList() {
 describe('QueueList added-by wiring', () => {
   beforeEach(() => {
     capturedRows.props = [];
-    session.sessionId = null;
-    session.profile = null;
+    session.set({ sessionId: null, profile: null });
   });
 
   it('passes attribution to all three row kinds during a session', () => {
-    session.sessionId = 'session-1';
-    session.profile = { id: 'me' };
+    session.set({ sessionId: 'session-1', profile: { id: 'me' } });
     renderList();
 
     // History (a), current (b) and future (c) — assert the row kinds too, so a
@@ -161,8 +186,7 @@ describe('QueueList added-by wiring', () => {
   });
 
   it('switches attribution off outside a session', () => {
-    session.sessionId = null;
-    session.profile = { id: 'me' };
+    session.set({ sessionId: null, profile: { id: 'me' } });
     renderList();
 
     expect(capturedRows.props).toHaveLength(3);
@@ -171,9 +195,26 @@ describe('QueueList added-by wiring', () => {
     }
   });
 
+  it('turns attribution on for a queue that was already full when the session started', () => {
+    session.set({ sessionId: null, profile: { id: 'me' } });
+    renderList();
+    expect(capturedRows.props.every((props) => props.showAddedBy === false)).toBe(true);
+
+    // No prop changes — only the session store moves, the way joining a session
+    // moves the real context. QueueList is memo'd, so this also proves the memo
+    // does not strand the rows on stale attribution.
+    capturedRows.props = [];
+    act(() => session.set({ sessionId: 'session-1', profile: { id: 'me' } }));
+
+    expect(capturedRows.props).toHaveLength(3);
+    for (const props of capturedRows.props) {
+      expect(props.showAddedBy).toBe(true);
+      expect(props.viewerUserId).toBe('me');
+    }
+  });
+
   it('still shows peers faces to a viewer with no party profile', () => {
-    session.sessionId = 'session-1';
-    session.profile = null;
+    session.set({ sessionId: 'session-1', profile: null });
     renderList();
 
     expect(capturedRows.props).toHaveLength(3);

--- a/packages/mobile/src/components/play-drawer/__tests__/queue-list-added-by.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/queue-list-added-by.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+
+// Wiring guard for #4672. `QueueItemRow` renders in THREE places inside
+// QueueList — history, current and future — and nothing else in the repo renders
+// QueueList unmounted (QueueSheet's freeze test mocks it wholesale), so passing
+// the attribution props to only two of the three would ship a green suite and a
+// visibly broken feature. This file renders the real QueueList over all three row
+// kinds and asserts every captured row got the props.
+
+const session = vi.hoisted(() => ({
+  sessionId: null as string | null,
+  profile: null as { id: string } | null,
+}));
+
+const capturedRows = vi.hoisted(() => ({
+  props: [] as Record<string, unknown>[],
+}));
+
+type ViewProps = { children?: ReactNode; testID?: string; style?: unknown };
+
+vi.mock('react-native', () => ({
+  View: ({ children }: ViewProps) => createElement('div', null, children),
+  Pressable: ({ children }: ViewProps) => createElement('div', null, children),
+  Platform: { OS: 'ios', select: (options: Record<string, unknown>) => options.ios ?? options.default },
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('@expo/ui/community/bottom-sheet', () => ({
+  BottomSheetFlatList: ({
+    data,
+    renderItem,
+    keyExtractor,
+  }: {
+    data: unknown[];
+    renderItem: (info: { item: unknown; index: number }) => ReactNode;
+    keyExtractor: (item: unknown, index: number) => string;
+  }) =>
+    createElement(
+      'div',
+      null,
+      data.map((item, index) => createElement('div', { key: keyExtractor(item, index) }, renderItem({ item, index }))),
+    ),
+}));
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { separator: '#ccc', secondaryBackground: '#fff' },
+    brandColors: { primary: '#6D28D9' },
+  }),
+}));
+
+vi.mock('../../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 10: 40, 16: 64 },
+}));
+vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#888' } }));
+vi.mock('../../../lib/graphql/hooks', () => ({ useSearchClimbs: () => ({ data: undefined }) }));
+vi.mock('../../sheet-content-inset', () => ({ withSheetBottomInset: (style: unknown) => style }));
+vi.mock('../use-queue-drag', () => ({
+  useQueueDrag: () => ({
+    isDragging: false,
+    controls: {
+      shared: {},
+      onRowHeight: vi.fn(),
+      makeHandleGesture: vi.fn(),
+    },
+  }),
+}));
+vi.mock('../../Text', () => ({ Text: ({ children }: ViewProps) => createElement('span', null, children) }));
+vi.mock('../../ClimbListItemContent', () => ({ ClimbListItemContent: () => createElement('span', null) }));
+
+// Capture every QueueItemRow render's props. Also re-exports the two layout
+// constants QueueList imports from the same module for its styles.
+vi.mock('../../QueueItemRow', () => ({
+  POSITION_SLOT_WIDTH: 28,
+  SEPARATOR_INSET: 200,
+  QueueItemRow: (props: Record<string, unknown>) => {
+    capturedRows.props.push(props);
+    return createElement('div');
+  },
+}));
+
+vi.mock('../../../providers/queue-provider', () => ({
+  useQueueSessionId: () => ({ sessionId: session.sessionId }),
+}));
+
+vi.mock('../../../providers/party-profile-provider', () => ({
+  usePartyProfile: () => ({ profile: session.profile }),
+}));
+
+import { QueueList } from '../QueueList';
+
+const board = { boardName: 'kilter' as const, layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 };
+
+function makeItem(uuid: string): ClimbQueueItem {
+  return {
+    uuid,
+    climb: { uuid: `climb-${uuid}`, name: `Climb ${uuid}` },
+    addedByUser: { id: 'peer-1', username: 'Mina', avatarUrl: null },
+  } as ClimbQueueItem;
+}
+
+const queue = [makeItem('a'), makeItem('b'), makeItem('c')];
+
+function renderList() {
+  return render(
+    <QueueList
+      queue={queue}
+      currentItemUuid="b"
+      board={board}
+      isEditMode={false}
+      showHistory
+      showFullHistory
+      selectedItems={new Set<string>()}
+      playlistSuggestionSource={null}
+      active
+      onToggleSelect={vi.fn()}
+      onClimbPress={vi.fn()}
+      onRemove={vi.fn()}
+      onShowFullHistory={vi.fn()}
+      onTickHistory={vi.fn()}
+      onSuggestionPress={vi.fn()}
+      reorderQueue={vi.fn()}
+    />,
+  );
+}
+
+describe('QueueList added-by wiring', () => {
+  beforeEach(() => {
+    capturedRows.props = [];
+    session.sessionId = null;
+    session.profile = null;
+  });
+
+  it('passes attribution to all three row kinds during a session', () => {
+    session.sessionId = 'session-1';
+    session.profile = { id: 'me' };
+    renderList();
+
+    // History (a), current (b) and future (c) — assert the row kinds too, so a
+    // future row-order change can't quietly make this assertion vacuous.
+    expect(capturedRows.props).toHaveLength(3);
+    expect(capturedRows.props[0].isHistoryItem).toBe(true);
+    expect(capturedRows.props[1].isCurrentClimb).toBe(true);
+    expect(capturedRows.props[2].isDraggable).toBe(true);
+
+    for (const props of capturedRows.props) {
+      expect(props.showAddedBy).toBe(true);
+      expect(props.viewerUserId).toBe('me');
+    }
+  });
+
+  it('switches attribution off outside a session', () => {
+    session.sessionId = null;
+    session.profile = { id: 'me' };
+    renderList();
+
+    expect(capturedRows.props).toHaveLength(3);
+    for (const props of capturedRows.props) {
+      expect(props.showAddedBy).toBe(false);
+    }
+  });
+
+  it('still shows peers faces to a viewer with no party profile', () => {
+    session.sessionId = 'session-1';
+    session.profile = null;
+    renderList();
+
+    expect(capturedRows.props).toHaveLength(3);
+    for (const props of capturedRows.props) {
+      expect(props.showAddedBy).toBe(true);
+      expect(props.viewerUserId).toBeNull();
+    }
+  });
+});

--- a/packages/mobile/src/lib/__tests__/queue-attribution.test.ts
+++ b/packages/mobile/src/lib/__tests__/queue-attribution.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import type { QueueItemUser } from '@boardsesh/queue';
+import { resolveQueueRowAttribution } from '../queue-attribution';
+
+const peer: QueueItemUser = { id: 'peer-1', username: 'Mina', avatarUrl: 'https://cdn/mina.png' };
+const viewer = { showAddedBy: true, viewerUserId: 'me' };
+
+describe('resolveQueueRowAttribution', () => {
+  it('renders nothing when attribution is switched off (no session)', () => {
+    expect(resolveQueueRowAttribution(peer, { showAddedBy: false, viewerUserId: 'me' })).toBeNull();
+  });
+
+  it('renders nothing for a legacy item with no addedByUser', () => {
+    expect(resolveQueueRowAttribution(undefined, viewer)).toBeNull();
+  });
+
+  it('renders nothing when the server sent an explicit null', () => {
+    expect(resolveQueueRowAttribution(null, viewer)).toBeNull();
+  });
+
+  it('renders nothing for an empty username even with an avatar', () => {
+    expect(
+      resolveQueueRowAttribution({ id: 'peer-1', username: '', avatarUrl: 'https://cdn/x.png' }, viewer),
+    ).toBeNull();
+  });
+
+  it('renders nothing for a whitespace-only username', () => {
+    expect(resolveQueueRowAttribution({ id: 'peer-1', username: '   ', avatarUrl: null }, viewer)).toBeNull();
+  });
+
+  it('renders nothing for the viewers own add', () => {
+    expect(resolveQueueRowAttribution({ id: 'me', username: 'Marco', avatarUrl: null }, viewer)).toBeNull();
+  });
+
+  it('still renders when the viewer id is unknown', () => {
+    expect(
+      resolveQueueRowAttribution(
+        { id: 'me', username: 'Marco', avatarUrl: null },
+        {
+          showAddedBy: true,
+          viewerUserId: null,
+        },
+      ),
+    ).toEqual({ name: 'Marco', avatarUrl: null });
+  });
+
+  it('renders a peer with no avatar as initials-only attribution', () => {
+    expect(resolveQueueRowAttribution({ id: 'peer-1', username: 'Mina', avatarUrl: null }, viewer)).toEqual({
+      name: 'Mina',
+      avatarUrl: null,
+    });
+  });
+
+  it('normalises an absent avatarUrl to null', () => {
+    expect(resolveQueueRowAttribution({ id: 'peer-1', username: 'Mina' }, viewer)).toEqual({
+      name: 'Mina',
+      avatarUrl: null,
+    });
+  });
+
+  it('returns the peers name and avatar', () => {
+    expect(resolveQueueRowAttribution(peer, viewer)).toEqual({ name: 'Mina', avatarUrl: 'https://cdn/mina.png' });
+  });
+
+  it('does not leak the user id into the render payload', () => {
+    const resolved = resolveQueueRowAttribution(peer, viewer);
+    expect(resolved && Object.keys(resolved).sort()).toEqual(['avatarUrl', 'name']);
+  });
+});

--- a/packages/mobile/src/lib/queue-attribution.ts
+++ b/packages/mobile/src/lib/queue-attribution.ts
@@ -1,0 +1,49 @@
+import type { QueueItemUser } from '@boardsesh/queue';
+
+/** What a queue row needs to draw the "who queued this" face. */
+export type QueueRowAttribution = {
+  name: string;
+  avatarUrl: string | null;
+};
+
+export type QueueRowAttributionOptions = {
+  /** False outside a party session — no faces at all. */
+  showAddedBy: boolean;
+  /** The viewer's own party-profile id; their own adds render nothing. */
+  viewerUserId: string | null;
+};
+
+/**
+ * Decide whether a queue row shows who put the climb up, and with what.
+ *
+ * `null` means render NO element at all — not an empty slot. An `Avatar` with
+ * neither a uri nor a name draws a `?` glyph on a primary-coloured disc
+ * (`components/Avatar.tsx`), which is exactly the broken-looking placeholder
+ * this feature is meant to avoid.
+ *
+ * The result deliberately DROPS `addedByUser.id`. A queue row is a live
+ * gesture arena (row tap, swipe-to-delete, drag handle, tick button), so a
+ * nested navigating Pressable would need the same explicit
+ * `blocksExternalGesture` wiring the tick button carries. v1 is decorative and
+ * non-interactive; profile navigation is a follow-up.
+ *
+ * `avatarUrl` is normalised from `string | null | undefined` down to
+ * `string | null` because `QueueItemUser.avatarUrl` is both optional and
+ * nullable.
+ */
+export function resolveQueueRowAttribution(
+  addedByUser: QueueItemUser | null | undefined,
+  { showAddedBy, viewerUserId }: QueueRowAttributionOptions,
+): QueueRowAttribution | null {
+  if (!showAddedBy) return null;
+  if (!addedByUser) return null;
+  // Self-exclusion: the queue provider stamps SOLO adds with this device's own
+  // identity too, so without this a one-person session would put the viewer's
+  // own face on every row they queued.
+  if (viewerUserId != null && addedByUser.id === viewerUserId) return null;
+  // Defensive `typeof`, not a bare `.trim()`: the type says `string`, but the
+  // value arrives straight off an unvalidated subscription payload.
+  const name = typeof addedByUser.username === 'string' ? addedByUser.username.trim() : '';
+  if (name === '') return null;
+  return { name, avatarUrl: addedByUser.avatarUrl ?? null };
+}

--- a/packages/shared/i18n/locales/de/session.json
+++ b/packages/shared/i18n/locales/de/session.json
@@ -271,6 +271,7 @@
       "unknownClimb": "Unbekannter Boulder",
       "removeClimb": "Boulder entfernen",
       "positionLabel": "Position {{position}}",
+      "addedByAria": "Hinzugefügt von {{name}}",
       "syncError": "Sync-Fehler in der Warteschlange",
       "outOfSyncRefreshed": "Die Warteschlange war nicht synchron. Von deiner Crew neu geladen.",
       "sessionCreateError": "Session konnte nicht erstellt werden",

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -271,6 +271,7 @@
       "unknownClimb": "Unknown climb",
       "removeClimb": "Remove climb",
       "positionLabel": "position {{position}}",
+      "addedByAria": "Added by {{name}}",
       "syncError": "Queue sync error",
       "outOfSyncRefreshed": "Queue was out of sync. Refreshed from your crew.",
       "sessionCreateError": "Couldn't create session",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -271,6 +271,7 @@
       "unknownClimb": "Bloque desconocido",
       "removeClimb": "Eliminar bloque",
       "positionLabel": "posición {{position}}",
+      "addedByAria": "Añadido por {{name}}",
       "syncError": "Error de sincronización de cola",
       "outOfSyncRefreshed": "La cola estaba desincronizada. Se actualizó con tu grupo.",
       "sessionCreateError": "No se pudo crear la sesión",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -271,6 +271,7 @@
       "unknownClimb": "Bloc inconnu",
       "removeClimb": "Supprimer le bloc",
       "positionLabel": "position {{position}}",
+      "addedByAria": "Ajouté par {{name}}",
       "syncError": "Erreur de synchronisation de la file",
       "outOfSyncRefreshed": "La file était désynchronisée. Actualisée depuis ton groupe.",
       "sessionCreateError": "Impossible de créer la session",


### PR DESCRIPTION
Closes #4672

## What

Queue rows already carry `addedByUser` end to end — the provider stamps it on every local add, it survives the wire in both directions, and it round-trips through the offline snapshot. Nothing ever drew it. This renders it.

During a party session, each queue row shows a small (20dp) avatar of the climber who put that climb up. It appears on all three row kinds — history, current, and upcoming — because `QueueList` renders `QueueItemRow` from three separate call sites and the ticket calls out history rows explicitly.

## How it's gated

Two conditions, both deliberate:

1. **`sessionId != null`**, not `useIsSharedSession()`. That hook resolves to `sessionActive && distinctUserCount > 1`, so the moment a peer left — or presence flapped — every face would vanish off a queue still full of the crew's climbs.
2. **Per-row self-exclusion.** `attributeNewItem` stamps *solo* adds with this device's identity too, so without excluding `addedByUser.id === viewerUserId` a one-person session would put your own face on every row you queued.

A face therefore means exactly "someone else queued this".

Absent, self, or nameless attribution renders **no element at all** — not an empty slot. `Avatar` with neither a uri nor a name draws a `?` glyph on a primary-coloured disc, which is the broken-looking placeholder the ticket warns about. The avatar is also suppressed in edit mode, following the same rule the sent-at-angle chip already uses (edit mode is the row's widest state).

The avatar is decorative and non-interactive: it carries `pointerEvents="none"` and is hidden from screen readers, because the row's own accessibility label now ends with "Added by {name}". No `userId` is passed to `BoardDriverAvatar`, which keeps it on the non-interactive branch rather than nesting a Pressable inside the row's gesture arena.

## Notes

- Per-row cost is O(1) off the row's own item — no roster read, no Map lookup, no new array. `renderRow`'s deps gain two primitives.
- `resolveQueueRowAttribution` is a pure function in `packages/mobile/src/lib/queue-attribution.ts` so the decision table is unit-testable with no mocks.
- JS/TS/JSON only — no `app.config.ts`, `plugins/**`, `modules/**`, `patches/**` or dependency change, so the runtime fingerprint is unchanged and this ships OTA.

## Tests

- `queue-attribution.test.ts` — 11 cases over the decision table, including the `avatarUrl: undefined` normalisation and an assertion that the render payload never leaks a user id.
- `queue-item-row-memo.test.tsx` — attribution rendering, edit-mode suppression, the accessibility label, and proof the row still bails out of a same-props re-render with the new props set. Also widens the file's `AccessibilityCapture` to record `accessibilityLabel`, which nothing was capturing before.
- `queue-list-added-by.test.tsx` (new) — asserts **all three** `QueueItemRow` call sites receive the props. Verified by mutation: deleting them from just the current-item call site turns this file red. Nothing else in the repo renders `QueueList` unmocked, so without this file a two-of-three wiring would have shipped green.

Validated: `vp check`, `vp run typecheck:mobile`, `vp run test:mobile`, `vp test run --project i18n`, `vp run check:i18n:orphans`, `vp run check:mobile-bundle`.

## Release Notes

- The queue now shows who put each climb up while you're in a session with your crew.
- A small face sits on every row someone else added — upcoming, current, and the ones you've already worked through. Your own adds stay clean.
