### PR TITLE
fix(web): stop crawler page renders firing a 3 GB board-render each

### DIFF
--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -655,12 +655,27 @@ describe('middleware cache headers on climb view pages', () => {
 // A crawler that persists cookies (observed in production logs) acquires
 // boardsesh-locale by crawling one /de|/es|/fr page, then bounces every
 // subsequent unprefixed URL through a locale twin — ~15k of these 307s/day,
-// plus the render MISS on the twin it lands on. Bots must never be sent
+// plus the render MISS on the twin it lands on. Crawlers must never be sent
 // through the sticky-locale redirect, and must never acquire the cookie.
+//
+// #4667 gated this on Next's `userAgent(request).isBot`, whose list names no
+// scraper newer than ~2023. Probed against production on 2026-08-24, Googlebot
+// correctly got a 200 while AhrefsBot, SemrushBot, DataForSeoBot and MJ12bot
+// were all still taking the 307 to the /es twin. The cases below cover both
+// halves of the repo-owned list in `app/lib/is-crawler.ts`.
 describe('middleware bot-gates the sticky locale redirect and cookie', () => {
   const GOOGLEBOT_UA = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
   const CHROME_UA =
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36';
+  const CRAWLER_UAS: [string, string][] = [
+    ['Googlebot (named by Next)', GOOGLEBOT_UA],
+    ['AhrefsBot', 'Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)'],
+    ['SemrushBot', 'Mozilla/5.0 (compatible; SemrushBot/7~bl; +http://www.semrush.com/bot.html)'],
+    ['DataForSeoBot', 'Mozilla/5.0 (compatible; DataForSeoBot/1.0; +https://dataforseo.com/dataforseo-bot)'],
+    ['MJ12bot', 'Mozilla/5.0 (compatible; MJ12bot/v1.4.8; http://mj12bot.com/)'],
+    ['DotBot', 'Mozilla/5.0 (compatible; DotBot/1.2; +https://opensiteexplorer.org/dotbot; help@moz.com)'],
+    ['archive.org_bot', 'Mozilla/5.0 (compatible; archive.org_bot +http://www.archive.org/details/archive.org_bot)'],
+  ];
 
   function makeRequestWithUserAgent(url: string, ua: string): NextRequest {
     return new NextRequest(new URL(url, 'http://localhost:3000'), {
@@ -668,16 +683,19 @@ describe('middleware bot-gates the sticky locale redirect and cookie', () => {
     });
   }
 
-  it('does not 307 a bot carrying a stale non-default locale cookie — it gets a default-locale 200 for the requested URL', () => {
-    const request = makeRequestWithUserAgent('/some/page', GOOGLEBOT_UA);
-    request.cookies.set(LOCALE_COOKIE, 'de');
+  it.each(CRAWLER_UAS)(
+    'does not 307 %s carrying a stale non-default locale cookie — it gets a default-locale 200 for the requested URL',
+    (_label, crawlerUa) => {
+      const request = makeRequestWithUserAgent('/some/page', crawlerUa);
+      request.cookies.set(LOCALE_COOKIE, 'de');
 
-    const response = middleware(request);
+      const response = middleware(request);
 
-    expect(response.status).not.toBe(307);
-    expect(response.headers.has('location')).toBe(false);
-    expect(response.headers.get(`x-middleware-request-${LOCALE_HEADER}`)).toBe(DEFAULT_LOCALE);
-  });
+      expect(response.status).not.toBe(307);
+      expect(response.headers.has('location')).toBe(false);
+      expect(response.headers.get(`x-middleware-request-${LOCALE_HEADER}`)).toBe(DEFAULT_LOCALE);
+    },
+  );
 
   it('still 307s a human (non-bot UA) carrying the same stale locale cookie', () => {
     const request = makeRequestWithUserAgent('/some/page', CHROME_UA);
@@ -689,11 +707,14 @@ describe('middleware bot-gates the sticky locale redirect and cookie', () => {
     expect(response.headers.get('location')).toBe('http://localhost:3000/de/some/page');
   });
 
-  it('never sets the boardsesh-locale cookie for a bot visiting a locale-prefixed URL', () => {
-    const response = middleware(makeRequestWithUserAgent('/es/some/page', GOOGLEBOT_UA));
+  it.each(CRAWLER_UAS)(
+    'never sets the boardsesh-locale cookie for %s visiting a locale-prefixed URL',
+    (_label, crawlerUa) => {
+      const response = middleware(makeRequestWithUserAgent('/es/some/page', crawlerUa));
 
-    expect(response.headers.has('set-cookie')).toBe(false);
-  });
+      expect(response.headers.has('set-cookie')).toBe(false);
+    },
+  );
 
   it('sets the boardsesh-locale cookie for a human (non-bot UA) visiting a locale-prefixed URL', () => {
     const response = middleware(makeRequestWithUserAgent('/es/some/page', CHROME_UA));
@@ -701,6 +722,21 @@ describe('middleware bot-gates the sticky locale redirect and cookie', () => {
     const setCookie = response.headers.get('set-cookie');
     expect(setCookie).toContain(LOCALE_COOKIE);
     expect(setCookie).toContain('es');
+  });
+
+  // The /api/v1 and /api/auth matcher entries reach the classifier call site,
+  // so the isApi short-circuit must leave their behaviour untouched.
+  it('leaves an /api/v1 request unchanged whether or not it carries a crawler UA', () => {
+    const crawlerResponse = middleware(
+      makeRequestWithUserAgent('/api/v1/kilter/climbs', 'Mozilla/5.0 (compatible; AhrefsBot/7.0)'),
+    );
+    const humanResponse = middleware(makeRequestWithUserAgent('/api/v1/kilter/climbs', CHROME_UA));
+
+    expect(crawlerResponse.status).toBe(humanResponse.status);
+    expect(crawlerResponse.headers.has('set-cookie')).toBe(false);
+    expect(humanResponse.headers.has('set-cookie')).toBe(false);
+    expect(crawlerResponse.headers.get(`x-middleware-request-${LOCALE_HEADER}`)).toBe(DEFAULT_LOCALE);
+    expect(humanResponse.headers.get(`x-middleware-request-${LOCALE_HEADER}`)).toBe(DEFAULT_LOCALE);
   });
 });
 

--- a/packages/web/app/lib/__tests__/is-crawler.test.ts
+++ b/packages/web/app/lib/__tests__/is-crawler.test.ts
@@ -27,11 +27,23 @@ const nextBotTokens = extractNextBotTokens();
 const uaContaining = (token: string) => `Mozilla/5.0 (compatible; ${token}/2.1; +http://example.invalid/bot.html)`;
 
 describe('isCrawlerUserAgent is a superset of the installed Next bot list', () => {
-  it('found the isBot regex in the installed Next, with a plausible token count', () => {
+  it('extracted a plausible token list from the installed Next, not regex debris', () => {
     // Guards the extraction itself: if Next ever ships a differently-shaped
-    // isBot, this fails loudly instead of leaving the it.each below vacuous.
+    // isBot, this must fail loudly rather than leave the it.each below vacuous
+    // or, worse, iterating over fragments that happen to number 30+. A count
+    // alone would not catch that, so anchor on tokens Next has shipped since
+    // 2019 and reject anything that does not look like a UA token.
     expect(nextBotTokens.length).toBeGreaterThanOrEqual(30);
-    expect(nextBotTokens).toContain('Googlebot');
+    expect(nextBotTokens.length).toBeLessThan(200);
+    for (const anchorToken of ['Googlebot', 'Bingbot', 'facebookexternalhit', 'Twitterbot', 'GPTBot']) {
+      expect(nextBotTokens).toContain(anchorToken);
+    }
+    for (const token of nextBotTokens) {
+      expect(token.length).toBeGreaterThan(2);
+      expect(token.length).toBeLessThan(40);
+      // UA tokens, not regex fragments: no leftover grouping or quantifiers.
+      expect(/^[\w .+-]+$/.test(token)).toBe(true);
+    }
   });
 
   it.each(nextBotTokens)('still classifies Next token %s as a crawler', (token) => {

--- a/packages/web/app/lib/__tests__/is-crawler.test.ts
+++ b/packages/web/app/lib/__tests__/is-crawler.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vite-plus/test';
+// Deep import into Next internals, used ONLY here: `next/server` re-exports
+// `userAgent` but not `isBot`, and this suite needs the live regex to prove we
+// are still a superset of it. Production code never takes this path — see the
+// header of `is-crawler.ts`.
+import { isBot } from 'next/dist/server/web/spec-extension/user-agent';
+import { CRAWLER_USER_AGENT_PATTERN, isCrawlerUserAgent } from '@/app/lib/is-crawler';
+
+/**
+ * Pull the alternatives out of the installed Next's `isBot` source rather than
+ * hand-copying them, so a future Next widening fails this suite instead of
+ * silently leaving our pattern narrower than the one we replaced.
+ */
+function extractNextBotTokens(): string[] {
+  const isBotSource = String(isBot);
+  const regexLiteral = /\/((?:\\.|\[[^\]]*\]|[^/\\])+)\/i\.test\(/.exec(isBotSource);
+  if (!regexLiteral) {
+    throw new Error(`Could not find the isBot regex literal in the installed Next. Source was:\n${isBotSource}`);
+  }
+  return regexLiteral[1].split('|');
+}
+
+const nextBotTokens = extractNextBotTokens();
+
+// Realistic-shaped UA that embeds one token, so each case exercises a substring
+// match in context rather than the bare token on its own.
+const uaContaining = (token: string) => `Mozilla/5.0 (compatible; ${token}/2.1; +http://example.invalid/bot.html)`;
+
+describe('isCrawlerUserAgent is a superset of the installed Next bot list', () => {
+  it('found the isBot regex in the installed Next, with a plausible token count', () => {
+    // Guards the extraction itself: if Next ever ships a differently-shaped
+    // isBot, this fails loudly instead of leaving the it.each below vacuous.
+    expect(nextBotTokens.length).toBeGreaterThanOrEqual(30);
+    expect(nextBotTokens).toContain('Googlebot');
+  });
+
+  it.each(nextBotTokens)('still classifies Next token %s as a crawler', (token) => {
+    const userAgentHeader = uaContaining(token);
+    // Sanity: the fixture really does embed the token Next matches on.
+    expect(isBot(userAgentHeader)).toBe(true);
+    expect(isCrawlerUserAgent(userAgentHeader)).toBe(true);
+  });
+});
+
+describe('isCrawlerUserAgent covers the scrapers Next omits', () => {
+  // Every UA here was sent at production on 2026-08-24 and reached the origin
+  // (HTTP 200 on the /es twin, HTTP 307 to the twin on the unprefixed URL).
+  const SCRAPER_UAS: [string, string][] = [
+    ['AhrefsBot', 'Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)'],
+    ['AhrefsSiteAudit', 'Mozilla/5.0 (compatible; AhrefsSiteAudit/6.1; +http://ahrefs.com/robot/)'],
+    ['SemrushBot', 'Mozilla/5.0 (compatible; SemrushBot/7~bl; +http://www.semrush.com/bot.html)'],
+    ['DataForSeoBot', 'Mozilla/5.0 (compatible; DataForSeoBot/1.0; +https://dataforseo.com/dataforseo-bot)'],
+    ['MJ12bot', 'Mozilla/5.0 (compatible; MJ12bot/v1.4.8; http://mj12bot.com/)'],
+    ['DotBot', 'Mozilla/5.0 (compatible; DotBot/1.2; +https://opensiteexplorer.org/dotbot; help@moz.com)'],
+    ['BLEXBot', 'Mozilla/5.0 (compatible; BLEXBot/1.0; +http://webmeup-crawler.com/)'],
+    ['Barkrowler', 'Mozilla/5.0 (compatible; Barkrowler/0.9; +https://babbar.tech/crawler)'],
+    ['serpstatbot', 'Mozilla/5.0 (compatible; serpstatbot/2.1; +http://serpstatbot.com/)'],
+    ['SeznamBot', 'Mozilla/5.0 (compatible; SeznamBot/4.0; +http://napoveda.seznam.cz/seznambot-intro/)'],
+    ['ZoominfoBot', 'Mozilla/5.0 (compatible; ZoominfoBot; zoominfobot at zoominfo dot com)'],
+    ['Screaming Frog', 'Screaming Frog SEO Spider/21.4'],
+    ['archive.org_bot', 'Mozilla/5.0 (compatible; archive.org_bot +http://www.archive.org/details/archive.org_bot)'],
+  ];
+
+  it.each(SCRAPER_UAS)('classifies %s as a crawler', (_token, userAgentHeader) => {
+    expect(isCrawlerUserAgent(userAgentHeader)).toBe(true);
+  });
+
+  it.each(SCRAPER_UAS)('%s is not already covered by Next', (_token, userAgentHeader) => {
+    // If Next ever adds one of these, drop it from SEO_SCRAPER_TOKENS rather
+    // than carrying the same token in both halves.
+    expect(isBot(userAgentHeader)).toBe(false);
+  });
+
+  it('escapes the dot in archive.org_bot instead of letting it match any character', () => {
+    expect(isCrawlerUserAgent('Mozilla/5.0 (compatible; archiveXorg_bot)')).toBe(false);
+  });
+});
+
+describe('isCrawlerUserAgent leaves real browsers alone', () => {
+  // A false positive costs a real visitor their sticky locale, so these are the
+  // cases that must never regress.
+  const BROWSER_UAS: [string, string][] = [
+    [
+      'Chrome on Windows',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
+    ],
+    ['Firefox on Linux', 'Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0'],
+    [
+      'Safari on iOS',
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Mobile/15E148 Safari/604.1',
+    ],
+    [
+      'Edge on Windows',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 Edg/128.0.2739.42',
+    ],
+    [
+      'Samsung Internet',
+      'Mozilla/5.0 (Linux; Android 14; SAMSUNG SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/25.0 Chrome/121.0.0.0 Mobile Safari/537.36',
+    ],
+    [
+      'Yandex Browser desktop',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 YaBrowser/23.9.1.962 Yowser/2.5 Safari/537.36',
+    ],
+    [
+      'Yandex Browser Android',
+      'Mozilla/5.0 (Linux; arm_64; Android 13; SM-A536B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 YaBrowser/22.11.3.104.00 SA/3 Mobile Safari/537.36',
+    ],
+  ];
+
+  it.each(BROWSER_UAS)('does not classify %s as a crawler', (_label, userAgentHeader) => {
+    expect(isCrawlerUserAgent(userAgentHeader)).toBe(false);
+  });
+
+  it('inherits one Yandex false positive from Next, and it fails gracefully', () => {
+    // The Yandex Search in-app browser spells `YandexSearch`, which contains the
+    // `yandex` substring Next matches on. We keep the token rather than diverge
+    // from Next: the cost is that this visitor gets a default-locale 200 for the
+    // URL they asked for instead of a sticky-locale redirect — the same
+    // behaviour the bot branch was designed to give, not an error.
+    const yandexSearchInAppUa =
+      'Mozilla/5.0 (Linux; Android 13; SM-A536B) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/106.0.0.0 Mobile Safari/537.36 YandexSearch/1.0';
+    expect(isBot(yandexSearchInAppUa)).toBe(true);
+    expect(isCrawlerUserAgent(yandexSearchInAppUa)).toBe(true);
+  });
+});
+
+describe('isCrawlerUserAgent handles a missing header', () => {
+  it('returns false for null', () => {
+    expect(isCrawlerUserAgent(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isCrawlerUserAgent(undefined)).toBe(false);
+  });
+
+  it('returns false for an empty string', () => {
+    expect(isCrawlerUserAgent('')).toBe(false);
+  });
+});
+
+describe('CRAWLER_USER_AGENT_PATTERN is stateless', () => {
+  it('carries no g flag, so repeated .test() calls do not alternate', () => {
+    expect(CRAWLER_USER_AGENT_PATTERN.flags).toBe('i');
+
+    const ahrefsUa = 'Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)';
+    expect(CRAWLER_USER_AGENT_PATTERN.test(ahrefsUa)).toBe(true);
+    expect(CRAWLER_USER_AGENT_PATTERN.test(ahrefsUa)).toBe(true);
+    expect(CRAWLER_USER_AGENT_PATTERN.test(ahrefsUa)).toBe(true);
+  });
+});

--- a/packages/web/app/lib/__tests__/warm-overlay-cache.test.ts
+++ b/packages/web/app/lib/__tests__/warm-overlay-cache.test.ts
@@ -7,7 +7,10 @@ vi.mock('@/app/components/board-renderer/util', () => ({
   buildOgBoardRenderUrl: vi.fn(() => 'https://ws.boardsesh.com/og/climb?og'),
 }));
 
-import { FRONT_DOOR_WARM_LIMIT, warmOverlays } from '../warm-overlay-cache';
+const headersMock = vi.hoisted(() => vi.fn());
+vi.mock('next/headers', () => ({ headers: headersMock }));
+
+import { FRONT_DOOR_WARM_LIMIT, scheduleOverlayWarming, warmOverlays } from '../warm-overlay-cache';
 import { buildOgBoardRenderUrl } from '@/app/components/board-renderer/util';
 
 type WarmOverlaysArg = Parameters<typeof warmOverlays>[0];
@@ -80,5 +83,79 @@ describe('warmOverlays', () => {
     // pool connections it is holding — alive past the response it rode in on.
     const [, requestInit] = vi.mocked(fetch).mock.calls[0];
     expect(requestInit?.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe('scheduleOverlayWarming', () => {
+  /** Let the fire-and-forget chain inside `scheduleOverlayWarming` settle. */
+  const flushWarming = () => new Promise((resolve) => setImmediate(resolve));
+
+  const withUserAgent = (userAgentHeader: string | null) =>
+    headersMock.mockReturnValue(Promise.resolve({ get: () => userAgentHeader }));
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(buildOgBoardRenderUrl).mockReturnValue('https://ws.boardsesh.com/og/climb?og');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ body: null }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('warms for a human visitor', async () => {
+    withUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/126.0.0.0 Safari/537.36');
+
+    scheduleOverlayWarming({ boardDetails, climbs, variant: 'full' });
+    await flushWarming();
+
+    expect(fetch).toHaveBeenCalled();
+  });
+
+  // The whole point of the gate: a crawler renders the page and never fetches
+  // the image, so every warm it triggers is a wasted 3 GB WASM+sharp render.
+  it.each([
+    ['Googlebot', 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'],
+    ['AhrefsBot', 'Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)'],
+    ['SemrushBot', 'Mozilla/5.0 (compatible; SemrushBot/7~bl; +http://www.semrush.com/bot.html)'],
+  ])('skips warming for %s', async (_name, userAgentHeader) => {
+    withUserAgent(userAgentHeader);
+
+    scheduleOverlayWarming({ boardDetails, climbs, variant: 'full' });
+    await flushWarming();
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  // Fails closed — see the doc comment on `warmUnlessCrawler`. A false skip
+  // costs one on-demand LCP render; a false warm costs the invocation the gate
+  // exists to remove.
+  it('skips warming when there is no request scope', async () => {
+    headersMock.mockImplementation(() => {
+      throw new Error('`headers` was called outside a request scope');
+    });
+
+    scheduleOverlayWarming({ boardDetails, climbs, variant: 'full' });
+    await flushWarming();
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('skips warming when the header read rejects', async () => {
+    headersMock.mockReturnValue(Promise.reject(new Error('dynamic API not available')));
+
+    scheduleOverlayWarming({ boardDetails, climbs, variant: 'full' });
+    await flushWarming();
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('warms when the request carries no user-agent at all', async () => {
+    withUserAgent(null);
+
+    scheduleOverlayWarming({ boardDetails, climbs, variant: 'full' });
+    await flushWarming();
+
+    expect(fetch).toHaveBeenCalled();
   });
 });

--- a/packages/web/app/lib/is-crawler.ts
+++ b/packages/web/app/lib/is-crawler.ts
@@ -1,0 +1,126 @@
+/**
+ * Crawler classification for the two sticky-locale gates in `middleware.ts`.
+ *
+ * `next/server` exposes `userAgent(request).isBot`, and #4667 used it. Two
+ * problems with that:
+ *
+ * 1. `userAgent()` is `{ ...uaparser(input), isBot: isBot(input) }` — the full
+ *    ua-parser-js parse runs on every matched request just to read one boolean.
+ *    `isBot` itself is not re-exported from `next/server` (see
+ *    `next/server.d.ts`, which exports only `userAgent` and
+ *    `userAgentFromString`), so there is no cheap way to reach it. Importing
+ *    `next/dist/server/web/spec-extension/user-agent` directly does resolve
+ *    today, but that is a deep import into Next internals with no stability
+ *    guarantee, so the tokens are inlined below instead and a test pins the
+ *    superset property against the installed copy.
+ * 2. Next's list names no scraper newer than ~2023, so the crawlers that
+ *    actually still loop through our locale twins walk straight past it.
+ *
+ * Probed against production on 2026-08-24 with
+ * `curl -sSI -A '<ua>' -H 'Cookie: boardsesh-locale=es' https://www.boardsesh.com/<climb-view-url>`:
+ * AhrefsBot, AhrefsSiteAudit, SemrushBot, DataForSeoBot, MJ12bot, DotBot,
+ * BLEXBot, Barkrowler, serpstatbot, SeznamBot, ZoominfoBot, Screaming Frog and
+ * archive.org_bot all reached the origin and all got the 307 to the /es twin,
+ * while Googlebot (named by Next) correctly got a 200. Those thirteen are the
+ * extension list.
+ *
+ * Deliberately NOT listed: the AI crawlers (ClaudeBot, Claude-User,
+ * PerplexityBot, GPTBot, OAI-SearchBot, ChatGPT-User, Bytespider, Amazonbot,
+ * CCBot, PetalBot, meta-externalagent). The same probe returned `HTTP/2 403`
+ * from `server: cloudflare` with no `x-vercel-cache` header for every one of
+ * them — Cloudflare's AI-bot block stops them before Vercel, so a middleware UA
+ * regex can never see them and adding them would be dead code. Re-run the probe
+ * and revisit this list if that Cloudflare rule is ever relaxed, and as part of
+ * the Railway cutover (#4652), which moves the edge.
+ *
+ * `Google-Extended` is also absent on purpose: it is a robots.txt-only opt-out
+ * control token and never appears in a User-Agent header.
+ *
+ * Two things this cannot do, both fine:
+ * - A false positive is graceful. The visitor gets a default-locale 200 for the
+ *   URL they actually asked for, which is already the deliberate behaviour of
+ *   the bot branch, not an error page. Every token below is crawler-only — no
+ *   bare `bot`, `spider` or `crawler` alternative — so a device-model string
+ *   cannot trip it.
+ * - It cannot catch a UA-rotating headless farm. One walked ~2,500 climb-view
+ *   URLs on 2026-08-22 presenting ordinary Chrome/Firefox/Edge UAs (PostHog:
+ *   2,031 distinct persons, one pageview each, `$referring_domain` null on
+ *   every event). That population needs an edge rate-limit, not a UA list —
+ *   see `docs/vercel-compute-baseline.md`.
+ */
+
+/**
+ * Next 16.2.12's own bot tokens, copied token-for-token from the `isBot` regex
+ * in `next/dist/server/web/spec-extension/user-agent.js`. Kept as a separate
+ * half so `is-crawler.test.ts` can assert we are still a superset of whatever
+ * the installed Next ships.
+ */
+const NEXT_BOT_TOKENS = [
+  'Googlebot',
+  'Mediapartners-Google',
+  'AdsBot-Google',
+  'googleweblight',
+  'Storebot-Google',
+  'Google-PageRenderer',
+  'Google-InspectionTool',
+  'Bingbot',
+  'BingPreview',
+  'Slurp',
+  'DuckDuckBot',
+  'baiduspider',
+  'yandex',
+  'sogou',
+  'LinkedInBot',
+  'bitlybot',
+  'tumblr',
+  'vkShare',
+  'quora link preview',
+  'facebookexternalhit',
+  'facebookcatalog',
+  'Twitterbot',
+  'applebot',
+  'redditbot',
+  'Slackbot',
+  'Discordbot',
+  'WhatsApp',
+  'SkypeUriPreview',
+  'ia_archiver',
+  'GPTBot',
+] as const;
+
+/**
+ * SEO/backlink scrapers and archivers that Next omits and that were verified to
+ * reach our origin — see the probe in the file header. These are the agents
+ * still bouncing through the locale twins today.
+ */
+const SEO_SCRAPER_TOKENS = [
+  'AhrefsBot',
+  'AhrefsSiteAudit',
+  'SemrushBot',
+  'DataForSeoBot',
+  'MJ12bot',
+  'DotBot',
+  'BLEXBot',
+  'Barkrowler',
+  'serpstatbot',
+  'SeznamBot',
+  'ZoominfoBot',
+  'Screaming Frog SEO Spider',
+  'archive.org_bot',
+] as const;
+
+const escapeRegExpLiteral = (token: string): string => token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Case-insensitive alternation over every token above. No `g` flag on purpose:
+ * a module-level `g`-flagged regex carries `lastIndex` between `.test()` calls
+ * and would alternate true/false on repeated identical input.
+ */
+export const CRAWLER_USER_AGENT_PATTERN = new RegExp(
+  [...NEXT_BOT_TOKENS, ...SEO_SCRAPER_TOKENS].map(escapeRegExpLiteral).join('|'),
+  'i',
+);
+
+export function isCrawlerUserAgent(userAgentHeader: string | null | undefined): boolean {
+  return userAgentHeader ? CRAWLER_USER_AGENT_PATTERN.test(userAgentHeader) : false;
+}

--- a/packages/web/app/lib/is-crawler.ts
+++ b/packages/web/app/lib/is-crawler.ts
@@ -46,7 +46,8 @@
  *   URLs on 2026-08-22 presenting ordinary Chrome/Firefox/Edge UAs (PostHog:
  *   2,031 distinct persons, one pageview each, `$referring_domain` null on
  *   every event). That population needs an edge rate-limit, not a UA list —
- *   see `docs/vercel-compute-baseline.md`.
+ *   see the burn-hunt write-up on #4650 (`docs/vercel-compute-baseline.md`,
+ *   added by the companion PR #4717).
  */
 
 /**

--- a/packages/web/app/lib/warm-overlay-cache.ts
+++ b/packages/web/app/lib/warm-overlay-cache.ts
@@ -1,4 +1,6 @@
+import { headers } from 'next/headers';
 import { buildOgBoardRenderUrl, buildOverlayUrl } from '@/app/components/board-renderer/util';
+import { isCrawlerUserAgent } from '@/app/lib/is-crawler';
 import { SITE_URL } from '@/app/lib/seo/base-url';
 import type { BoardDetails, Climb } from '@/app/lib/types';
 
@@ -35,10 +37,58 @@ type WarmOverlaysOptions = {
  * shares the climb — the first crawler fetch is then a warm hit.
  */
 export function scheduleOverlayWarming(options: WarmOverlaysOptions): void {
+  const pendingHeaders = requestHeadersOrNull();
+  // No request scope (a static prerender) — there is no visitor whose LCP this
+  // would be racing, so there is nothing to warm for.
+  if (!pendingHeaders) return;
+
   // Fire-and-forget — don't await. The serverless function stays alive
   // while the SSR response is still streaming, giving these fetches
   // time to complete and populate the CDN cache.
-  void warmOverlays(options);
+  void warmUnlessCrawler(pendingHeaders, options);
+}
+
+/**
+ * `headers()` has to be CALLED synchronously inside the request scope to bind
+ * to Next's async store — awaiting the promise later, inside the
+ * fire-and-forget chain, is fine. Returns null instead of throwing so the
+ * caller can treat "no request" as "nothing to warm".
+ */
+function requestHeadersOrNull(): ReturnType<typeof headers> | null {
+  try {
+    return headers();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Warming for a crawler is pure waste: it renders the page and then never
+ * fetches the image the warm just rendered. That is what made
+ * `/api/internal/board-render` a shadow of the crawl rather than independent
+ * traffic — measured 2026-08-25, board-render invocations tracked climb-view
+ * invocations at 1.06:1, roughly one 3 GB WASM+sharp render per crawled climb
+ * page (#4650).
+ *
+ * Googlebot-Image is unaffected: it still gets the image, rendered on demand
+ * when it actually asks, which `app/robots.ts` explicitly allows. The rendered
+ * HTML does not change either way — the warm is a pure side effect — so this
+ * cannot fork the CDN entry between crawlers and humans.
+ *
+ * Fails CLOSED. A header read that throws skips the warm, because the cost of
+ * a false skip is one un-warmed LCP image that renders on demand, while the
+ * cost of a false warm is exactly the invocation this exists to remove.
+ */
+async function warmUnlessCrawler(
+  pendingHeaders: ReturnType<typeof headers>,
+  options: WarmOverlaysOptions,
+): Promise<void> {
+  try {
+    if (isCrawlerUserAgent((await pendingHeaders).get('user-agent'))) return;
+  } catch {
+    return;
+  }
+  await warmOverlays(options);
 }
 
 // Exported for tests; `scheduleOverlayWarming` is the production entry point.

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -1,7 +1,8 @@
 // middleware.ts
-import { NextResponse, userAgent, type NextRequest } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { SUPPORTED_BOARDS } from './app/lib/board-data';
 import { getClimbViewPageCacheTTL, getListPageCacheTTL } from './app/lib/list-page-cache';
+import { isCrawlerUserAgent } from './app/lib/is-crawler';
 import { CLIMB_SESSION_COOKIE } from './app/lib/climb-session-cookie';
 import { PATHNAME_HEADER } from './app/lib/request-pathname-header';
 import { isSecureCookieContext } from './app/lib/auth/secure-cookies';
@@ -185,18 +186,27 @@ export function middleware(request: NextRequest) {
     ? { locale: DEFAULT_LOCALE, strippedPath: pathname, needsRewrite: false }
     : detectLocale(pathname);
 
-  const requestUserAgent = userAgent(request);
+  // Classify once for the two sticky-locale gates below. Skipped outright for
+  // /api/*: the `/api/v1/:path*` and `/api/auth/:path*` matcher entries do
+  // reach this line, but `isApi` above pins their locale to DEFAULT_LOCALE, so
+  // neither gate can fire for them and classifying would be pure cost.
+  const isCrawler = isApi ? false : isCrawlerUserAgent(request.headers.get('user-agent'));
 
   // Cookie-driven sticky locale: when a page request arrives without a locale
   // prefix and the visitor previously chose a non-default locale, send them
   // to the prefixed URL so subsequent navigation stays in their language.
   //
-  // Bots are excluded: crawlers that persist cookies (observed in production
+  // Crawlers are excluded: ones that persist cookies (observed in production
   // logs) acquire the boardsesh-locale cookie by crawling a /de|/es|/fr page
   // once, then bounce every subsequent unprefixed URL through a locale twin —
   // ~15k of these 307s/day, plus the render MISS on the twin they land on.
-  // Bots get a default-locale 200 for the URL they actually requested instead.
-  if (!isApi && locale === DEFAULT_LOCALE && !requestUserAgent.isBot) {
+  // Crawlers get a default-locale 200 for the URL they requested instead.
+  //
+  // The classifier is ours, not Next's `userAgent(request).isBot`: Next's list
+  // names no scraper newer than ~2023, and AhrefsBot, SemrushBot, DataForSeoBot
+  // and MJ12bot were all still taking this 307 in production on 2026-08-24. See
+  // `app/lib/is-crawler.ts` for the token list and the probe behind it.
+  if (!isApi && locale === DEFAULT_LOCALE && !isCrawler) {
     const cookieLocale = request.cookies.get(LOCALE_COOKIE)?.value;
     if (isSupportedLocale(cookieLocale) && cookieLocale !== DEFAULT_LOCALE) {
       const target = new URL(`/${cookieLocale}${pathname}`, request.url);
@@ -232,9 +242,9 @@ export function middleware(request: NextRequest) {
 
   // Sticky cookie: any visit on a non-default locale URL writes the cookie so
   // a shared /es/... link from a friend persists for the recipient too.
-  // Bots never acquire it — see the sticky-locale redirect bot-gate above for
+  // Crawlers never acquire it — see the sticky-locale redirect gate above for
   // why a cookie-persisting crawler must never be handed this cookie.
-  if (locale !== DEFAULT_LOCALE && !requestUserAgent.isBot) {
+  if (locale !== DEFAULT_LOCALE && !isCrawler) {
     response.cookies.set(LOCALE_COOKIE, locale, {
       path: '/',
       sameSite: 'lax',


### PR DESCRIPTION
## Summary

Part of #4650. **Stacked on #4716** — it needs that PR's `app/lib/is-crawler.ts`, so review/merge #4716 first and this rebases onto `main` cleanly afterwards.

`scheduleOverlayWarming` fired on every render from all three call sites, crawlers included. Each one is a same-origin fetch to `/api/internal/board-render` — the only route in `packages/web/vercel.json` with a `memory` override (**3009 MB**) — so every crawled climb page paid for a full WASM + sharp render of an image the crawler then never fetched. This gates the warm on the crawler check.

### What the numbers showed

Re-measured against production on 2026-08-25 via the Vercel MCP, which #4717 could not do (that agent had no credentials and left its post-wave column empty on purpose).

| | per day |
|---|---|
| Function invocations | ~442,600 |
| — `/api/internal/board-render` | ~215,600 (48.7%) |
| — climb view `…/view/[climb_uuid]` | ~203,900 (46.1%) |
| — `/setter/[setter_username]` | ~15,900 (3.6%) |
| — the other 48 routes combined | ~7,100 (1.6%) |
| Homepage `/` | ~2,000 |

board-render tracks climb-view at **1.06:1**. That is the tell: it is not independent traffic, it is a shadow of the crawl — roughly one 3 GB render per crawled climb page, and this line is what creates it.

Measured cost of one render: `server-timing: wasm;dur=6.3, sharp;dur=393.7` — ~400 ms of real CPU for a 250 KB WebP, at 3009 MB.

> ⚠️ **`get_runtime_logs` with `since: 24h` is silently truncated.** It reports 249,960 where the 6 h window × 4 gives 442,564 and the 30 min window × 48 gives 535,632; the two short windows agree with each other and the 24 h one does not. Derive daily rates from a 6 h or 30 min window and scale, or you will under-report by ~2× and conclude the #4675 wave worked better than it did.

### What this does not change

- **Googlebot-Image still gets its image.** It is rendered on demand when actually requested, which `app/robots.ts` already allows, instead of speculatively on every page render.
- **Humans are untouched.** The warm still fires for them, so the LCP board image is still primed before the browser asks.
- **No CDN cache fork.** The rendered HTML is identical either way — the warm is a pure side effect — so crawlers and humans keep sharing one cache entry.
- **No new dynamic-rendering constraint.** Both climb-view trees and both list trees already read `headers()` transitively through `getLocale`.

### Fails closed, on purpose

A header read that throws skips the warm rather than falling back to warming. A false skip costs one un-warmed LCP image that renders on demand; a false warm costs exactly the invocation this exists to remove. Both branches are covered by tests, and both were mutation-tested — neutering either one turns the suite red (4 tests for the crawler check, 1 for the no-request-scope path).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project web` — full suite green; 7 new tests in `app/lib/__tests__/warm-overlay-cache.test.ts`.
- `vp run typecheck:web` — clean.
- `vp check` — the two changed files are clean (the repo-wide run flags only pre-existing issues in `aurora-sync`/`backend`/`mobile`, none touched here).
- **Mutation-tested both guards.** `if (false && isCrawlerUserAgent(...))` → 4 failures; making `requestHeadersOrNull` swallow its throw and return an empty header bag → 1 failure. Neither guard is inert.

### After deploy

Confirm the 1.06:1 ratio breaks — board-render should fall well below climb-view rather than tracking it:

```
get_runtime_logs since=30m group_by=route source=["serverless"] environment=production
```

And confirm the human path is intact: load a climb page in a normal browser and check the board image still paints from cache.
