### PR TITLE
feat(mobile): bring back preview-first shared sessions, with the wall and the list fixed

### DIFF
--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -817,6 +817,20 @@ The session's `boardPath` is the route string the host first joined / created on
 
 ## Queue State Synchronization
 
+### The browse gate: browsing emits nothing
+
+Since #4281, a member of a session with **2+ distinct users** who is merely browsing
+climbs on mobile emits **no queue traffic at all** — no `CurrentClimbChanged`, no
+`QueueItemAdded`, no playback broadcasts. Browse-shaped gestures (swipes, climb-list
+taps, similar-climb taps, fresh drawer opens) pin a local view-only preview; only the
+explicit "Put on the wall" commit produces wire events, which then look exactly like
+any deliberate `setCurrentClimb`. This is a **sender-side** contract: receivers cannot
+distinguish an old client's browse noise from a real commit (slim payloads carry no
+intent flag — see the documented rejection in `sync-coordinator.ts`), so any future
+change to the message flow must preserve "browsing emits nothing" at the origin rather
+than trying to filter it downstream. The receiving side's auto-insert of every inbound
+current climb (issue #2217 behaviour) is only correct because of this contract.
+
 ### Event Types
 
 | Event                 | Description             | Fields                                                       |

--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -847,6 +847,12 @@ contains you. It splits peers by `connectionState`:
   reading as a crew. Release is immediate once the last peer is evicted (`UserLeft`)
   or the session ends.
 
+While browsing, the drawer keeps its own playlist suggestion source. A peer can
+commit a climb outside that playlist, which clears the provider's source for live
+queue navigation; the browsing drawer still walks its original list in both
+directions. The first crew swipe snapshots that source, and committing or returning
+to live clears the snapshot.
+
 ### Event Types
 
 | Event                 | Description             | Fields                                                       |

--- a/docs/websocket-implementation.md
+++ b/docs/websocket-implementation.md
@@ -831,6 +831,22 @@ change to the message flow must preserve "browsing emits nothing" at the origin 
 than trying to filter it downstream. The receiving side's auto-insert of every inbound
 current climb (issue #2217 behaviour) is only correct because of this contract.
 
+**Who counts as a crew** (`countSessionPeers` in `@boardsesh/queue-runtime`, read by
+mobile's `queue-provider.tsx`). The gate is behind the PostHog flag
+`shared-session-browse` (read `=== true`; off means every gesture drives the wall as
+it always did) and counts **peers**, never roster participants — the roster always
+contains you. It splits peers by `connectionState`:
+
+- **Arm** on `connected` peers only, after a 3s dwell (`SHARED_SESSION_DWELL_MS`), so a
+  one-frame roster blip never costs a lone climber their board.
+- **Hold** an armed gate while any peer is `connected` **or** `RECONNECTING`. A peer
+  inside the 60s grace window (see Grace Window above) is still crew; releasing the
+  instant their socket flapped made the climber's next swipe commit to the shared
+  queue, with the arming dwell then owed on top. A `RECONNECTING`-only roster never
+  arms anything, which is what keeps an authenticated client's own parked entry from
+  reading as a crew. Release is immediate once the last peer is evicted (`UserLeft`)
+  or the session ends.
+
 ### Event Types
 
 | Event                 | Description             | Fields                                                       |

--- a/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
@@ -5,6 +5,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Climb } from '@boardsesh/shared-schema';
 
 const mocks = vi.hoisted(() => ({
+  // The climb the drawer host reports as previewed, i.e. shown without being
+  // committed. Read at render so a test can drive the row highlight.
+  previewedClimbUuid: vi.fn<() => string | null>(() => null),
+  activeClimbUuid: vi.fn<() => string | null>(() => null),
   climb: {
     uuid: 'climb-1',
     name: 'Moonage',
@@ -28,7 +32,10 @@ const mocks = vi.hoisted(() => ({
   searchFailed: false,
   offlineCatalog: null as 'missing' | 'queued' | null,
   activateClimb: vi.fn(),
+  activationOptions: undefined as { previewOnly?: boolean } | undefined,
   openPlayDrawer: vi.fn(),
+  // Mutable per-test: whether another climber is in the session.
+  isSharedSession: false,
   setSetting: vi.fn(),
   // Deep-link params, mutable so the screenshot-mode auto-opens can be driven
   // without a second mock scaffold.
@@ -172,8 +179,23 @@ vi.mock('../../../../src/providers/climb-search-provider', () => ({
 }));
 
 vi.mock('../../../../src/components/ClimbListRow', () => ({
-  ClimbListRow: ({ climb: rowClimb, onPress }: { climb: Climb; onPress?: (pressedClimb: Climb) => void }) =>
-    createElement('button', { onClick: () => onPress?.(rowClimb) }, rowClimb.name),
+  // `selected` is surfaced, not swallowed: the row highlight is the only feedback
+  // a climber gets that a tap landed, and a mock that dropped it would let the
+  // highlight break with every case in this file still green.
+  ClimbListRow: ({
+    climb: rowClimb,
+    onPress,
+    selected,
+  }: {
+    climb: Climb;
+    onPress?: (pressedClimb: Climb) => void;
+    selected?: boolean;
+  }) =>
+    createElement(
+      'button',
+      { onClick: () => onPress?.(rowClimb), 'data-selected': selected ? 'true' : 'false' },
+      rowClimb.name,
+    ),
 }));
 
 vi.mock('../../../../src/components/ClimbListRowSkeleton', () => ({
@@ -221,6 +243,7 @@ vi.mock('../../../../src/providers/drawer-host-provider', () => ({
     openBoardSheet: vi.fn(),
     openPlayDrawer: mocks.openPlayDrawer,
   }),
+  usePreviewedClimbUuid: () => mocks.previewedClimbUuid(),
 }));
 
 vi.mock('../../../../src/providers/theme-provider', () => ({
@@ -242,7 +265,8 @@ vi.mock('../../../../src/theme/variants', () => ({
 }));
 
 vi.mock('../../../../src/providers/queue-provider', () => ({
-  useActiveClimbUuid: () => null,
+  useActiveClimbUuid: () => mocks.activeClimbUuid(),
+  useIsSharedSession: () => mocks.isSharedSession,
   useQueueActions: () => ({ addToQueue: vi.fn() }),
 }));
 
@@ -310,8 +334,14 @@ vi.mock('../../../../src/offline/use-offline-catalog-state', () => ({
 vi.mock('../../../../src/hooks/use-is-offline', () => ({ useIsOffline: () => mocks.isOffline }));
 
 vi.mock('../../../../src/lib/playlists/use-playlist-activation', () => ({
-  usePlaylistActivation: () => ({
-    activate: mocks.activateClimb,
+  // Options captured, not swallowed: `previewOnly` is how the screen tells the
+  // activation hook that a row tap must browse rather than take the crew's wall,
+  // and dropping it at this call site is invisible to the hook's own tests.
+  usePlaylistActivation: (options: { previewOnly?: boolean }) => ({
+    activate: (...args: unknown[]) => {
+      mocks.activationOptions = options;
+      return mocks.activateClimb(...args);
+    },
     queueReplaceSheet: {
       visible: false,
       futureQueueCount: 0,
@@ -378,6 +408,8 @@ vi.mock('../../../../src/theme/animations', () => ({ timing: { normal: 180 } }))
 import ClimbList from '../index';
 
 beforeEach(() => {
+  mocks.previewedClimbUuid.mockReturnValue(null);
+  mocks.activeClimbUuid.mockReturnValue(null);
   mocks.activateClimb.mockClear();
   mocks.openPlayDrawer.mockClear();
   mocks.setSetting.mockClear();
@@ -399,6 +431,8 @@ beforeEach(() => {
   mocks.searchFailed = false;
   mocks.offlineCatalog = null;
   mocks.searchParams = {};
+  mocks.isSharedSession = false;
+  mocks.activationOptions = undefined;
 });
 
 // The dead end this branch exists to remove, and the one it nearly reintroduced:
@@ -481,6 +515,61 @@ describe('ClimbList keyboard handling', () => {
   });
 });
 
+// Joining a crew changes what a row tap means: it browses instead of taking
+// everyone's wall. The screen decides that, and the drawer never sees the tap, so
+// nothing downstream can catch a regression here.
+describe('ClimbList shared-session row taps', () => {
+  it('routes a tap through the activation hook in browse mode', async () => {
+    mocks.isSharedSession = true;
+    const { findByText } = render(<ClimbList />);
+
+    fireEvent.click(await findByText('Moonage'));
+
+    // Through the hook — not the bare preview open — because only the hook can
+    // seed these results as the drawer's swipe track.
+    expect(mocks.activateClimb).toHaveBeenCalledWith({ uuid: 'climb-1' });
+    expect(mocks.openPlayDrawer).not.toHaveBeenCalled();
+    // The flag that makes that activation view-only. Without it the hook commits.
+    expect(mocks.activationOptions?.previewOnly).toBe(true);
+  });
+
+  it('browses in a crew even when the climber has tap-lighting ON', async () => {
+    mocks.isSharedSession = true;
+    mocks.lightOnClimbTap = true;
+    const { findByText } = render(<ClimbList />);
+
+    fireEvent.click(await findByText('Moonage'));
+
+    expect(mocks.activationOptions?.previewOnly).toBe(true);
+  });
+
+  // The setting is about the climber's own board; the crew rule is about
+  // everyone else's. With lighting off AND a crew, the tap must still take the
+  // seeded path rather than the bare preview open, or swiping on from it would
+  // walk the queue instead of the results.
+  it('prefers the seeded browse over the bare preview when both reasons apply', async () => {
+    mocks.isSharedSession = true;
+    mocks.lightOnClimbTap = false;
+    const { findByText } = render(<ClimbList />);
+
+    fireEvent.click(await findByText('Moonage'));
+
+    expect(mocks.openPlayDrawer).not.toHaveBeenCalled();
+    expect(mocks.activateClimb).toHaveBeenCalledWith({ uuid: 'climb-1' });
+    expect(mocks.activationOptions?.previewOnly).toBe(true);
+  });
+
+  it('leaves a solo tap committing', async () => {
+    mocks.isSharedSession = false;
+    const { findByText } = render(<ClimbList />);
+
+    fireEvent.click(await findByText('Moonage'));
+
+    expect(mocks.activateClimb).toHaveBeenCalledWith({ uuid: 'climb-1' });
+    expect(mocks.activationOptions?.previewOnly).toBe(false);
+  });
+});
+
 describe('ClimbList lightOnClimbTap setting', () => {
   it('opens the pressed climb as a view-only preview instead of activating it when the setting is off', async () => {
     mocks.lightOnClimbTap = false;
@@ -530,6 +619,9 @@ describe('ClimbList screenshot-mode wall-state deep links', () => {
       // view-only, so the capture puts the device in that state rather than
       // photographing a promise the app wouldn't keep.
       expect(mocks.setSetting).toHaveBeenCalledWith('lightOnSwipe', false);
+      // And the one-shot card that same setting triggers is spent up front: a
+      // store shot is the steady state, not a climber's first five seconds.
+      expect(mocks.setSetting).toHaveBeenCalledWith('browseNoticeSeen', true);
     });
   });
 
@@ -635,5 +727,33 @@ describe('ClimbList board-art pre-warm (#3191 regression guard)', () => {
     );
 
     expect(mocks.imagePrefetch).not.toHaveBeenCalled();
+  });
+});
+
+// The row highlight is the only feedback a climber gets that a tap landed. It
+// used to read the queue's current climb alone, which by construction only moves
+// when the queue does — so once a tap could open a view-only preview instead of
+// committing, tapping down a filtered list highlighted nothing at all and read as
+// a dead list.
+describe('ClimbList row highlight', () => {
+  it('follows the queue\u2019s current climb when nothing is being previewed', async () => {
+    mocks.activeClimbUuid.mockReturnValue(mocks.climb.uuid);
+    const { findByText } = render(<ClimbList />);
+
+    expect((await findByText('Moonage')).getAttribute('data-selected')).toBe('true');
+    expect((await findByText('Zenith')).getAttribute('data-selected')).toBe('false');
+  });
+
+  it('follows the previewed climb when a tap opened one instead of committing', async () => {
+    // The crew case: the queue never moved, so `activeClimbUuid` still names the
+    // climb that was up before the tap. The highlight has to follow the tap.
+    mocks.activeClimbUuid.mockReturnValue(mocks.climb.uuid);
+    mocks.previewedClimbUuid.mockReturnValue(mocks.secondClimb.uuid);
+    const { findByText } = render(<ClimbList />);
+
+    expect((await findByText('Zenith')).getAttribute('data-selected')).toBe('true');
+    // Exactly one row is selected — the previewed uuid clears itself on the next
+    // committing open, so the two can never both claim a row.
+    expect((await findByText('Moonage')).getAttribute('data-selected')).toBe('false');
   });
 });

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -46,10 +46,10 @@ import {
 import { FilterTokenRow } from '../../../src/components/search/FilterTokenRow';
 import { GradeRangeRail } from '../../../src/components/grade';
 import { applyPopularityBucket } from '../../../src/lib/filter-chip-menus';
-import { useDrawerHost } from '../../../src/providers/drawer-host-provider';
+import { useDrawerHost, usePreviewedClimbUuid } from '../../../src/providers/drawer-host-provider';
 import { useTheme, useAppColorScheme } from '../../../src/providers/theme-provider';
 import { selectByVariant } from '../../../src/theme/variants';
-import { useActiveClimbUuid, useQueueActions } from '../../../src/providers/queue-provider';
+import { useActiveClimbUuid, useIsSharedSession, useQueueActions } from '../../../src/providers/queue-provider';
 import { ClimbSearchProvider, useClimbSearch, type GradeBound } from '../../../src/providers/climb-search-provider';
 import { setSetting, useSetting } from '../../../src/settings';
 import { climbToQueueItem } from '../../../src/lib/climb-to-queue-item';
@@ -168,7 +168,16 @@ const ActiveAwareClimbListRow = memo(function ActiveAwareClimbListRow(
   props: Omit<ComponentProps<typeof ClimbListRow>, 'selected'>,
 ) {
   const activeClimbUuid = useActiveClimbUuid();
-  return <ClimbListRow {...props} selected={props.climb.uuid === activeClimbUuid} />;
+  // The highlight means "the climb you last had up", which is not always the
+  // queue's current climb. A row tap can open a view-only preview that never
+  // writes the queue, and `activeClimbUuid` by construction only moves when the
+  // queue does — so keying the highlight on it alone left a climber tapping down
+  // a filtered list with no feedback that anything had been selected at all.
+  // The previewed uuid clears itself on the next committing open, so exactly one
+  // row is ever selected.
+  const previewedClimbUuid = usePreviewedClimbUuid();
+  const selectedClimbUuid = previewedClimbUuid ?? activeClimbUuid;
+  return <ClimbListRow {...props} selected={props.climb.uuid === selectedClimbUuid} />;
 });
 
 function ClimbListInner() {
@@ -196,6 +205,11 @@ function ClimbListInner() {
   const { t: tCommon } = useTranslation('common');
   const { openClimbActions, openAddToPlaylist, openBoardSheet, openPlayDrawer, usesDetailPane } = useDrawerHost();
   const [lightOnClimbTap] = useSetting('lightOnClimbTap');
+  // Whether anyone else is in this session. Read off a dedicated selector context
+  // so this screen (which hosts a virtualized FlashList) doesn't re-render on the
+  // ≤1/2s session-stats push — the boolean flips only across the solo ↔ crew
+  // boundary.
+  const isSharedSession = useIsSharedSession();
   // One-time board-history reveal: armed when the user binds a board from the
   // onboarding hand-off and consumed on focus (see the useFocusEffect below).
   // Declared here so handleOpenBoardDetail can clear it — tapping the board
@@ -795,13 +809,17 @@ function ClimbListInner() {
     sourceId: 'climblist',
     allClimbs: allQueueClimbs,
     fetchPage: fetchSearchPage,
+    // In a crew, a row tap browses instead of taking everyone's wall: the drawer
+    // opens on the tapped climb with these results seeded as its swipe track, so
+    // the climber can walk the list and put up only the one they choose.
+    previewOnly: isSharedSession,
     refreshErrorMessage: 'Failed to refresh climb-list suggestions:',
   });
 
   const handleClimbPress = useCallback(
     (climb: Climb) => {
       blurSearchInputs();
-      if (!lightOnClimbTap) {
+      if (!lightOnClimbTap && !isSharedSession) {
         // Board lighting off for taps: open view-only (the Browsing pill + the
         // commit row) instead of committing — same landing as the explicit
         // "Preview" climb action, so the tap doesn't light the board or touch
@@ -809,9 +827,14 @@ function ClimbListInner() {
         openPlayDrawer(climb, { previewQueueItem: climbToQueueItem(climb) });
         return;
       }
+      // In a shared session this still routes through the activation hook, whose
+      // `previewOnly` branch opens the SAME view-only drawer — but seeded with the
+      // results list, which the bare preview above can't do. So the crew case gets
+      // browsing AND a swipe track, and a tap in a crew never commits regardless
+      // of the lighting setting.
       void activateClimbListClimb.activate(toQueueClimb(climb));
     },
-    [activateClimbListClimb, blurSearchInputs, lightOnClimbTap, openPlayDrawer],
+    [activateClimbListClimb, blurSearchInputs, isSharedSession, lightOnClimbTap, openPlayDrawer],
   );
 
   // Screenshot mode: when a specific board index is requested, switch the active
@@ -919,7 +942,14 @@ function ClimbListInner() {
     // capture device is a throwaway simulator, so writing the setting is the
     // honest way to reach the state — faking the chrome instead would ship a
     // store screenshot of a promise the app doesn't keep.
-    if (screenshotOpenPreview) setSetting('lightOnSwipe', false);
+    if (screenshotOpenPreview) {
+      setSetting('lightOnSwipe', false);
+      // That same setting is what triggers the one-shot "you're browsing" card.
+      // It is real product behaviour on a real first run, but a store screenshot
+      // is a portrait of the steady state, not of a climber's first five seconds
+      // — so the capture device starts already told.
+      setSetting('browseNoticeSeen', true);
+    }
     openPlayDrawer(firstClimb, {
       previewQueueItem: climbToQueueItem(firstClimb),
       previewIsWallClimb: Boolean(screenshotOpenWallPreview),

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -49,6 +49,7 @@ import { reportHandledError } from '../../../src/lib/error-reporting';
 import { toQueueClimbs } from '../../../src/lib/climb-types';
 import { hapticSelection } from '../../../src/lib/haptics';
 import { useAuth } from '../../../src/providers/auth-provider';
+import { useIsSharedSession } from '../../../src/providers/queue-provider';
 import { useToast } from '../../../src/providers/toast-provider';
 import { useTheme } from '../../../src/providers/theme-provider';
 import { iosSystemColors } from '../../../src/theme/ios-colors';
@@ -64,6 +65,10 @@ export default function PlaylistDetail() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const { isAuthenticated } = useAuth();
+  // Whether anyone else is in this session. Read off a dedicated selector context
+  // so the ≤1/2s session-stats push doesn't re-render this screen's list — the
+  // boolean flips only across the solo ↔ crew boundary.
+  const isSharedSession = useIsSharedSession();
   const { showToast } = useToast();
   const { systemColors, brandColors } = useTheme();
   const { updatePlaylist, deletePlaylist, pinPlaylist, unpinPlaylist, followPlaylist, unfollowPlaylist } =
@@ -172,6 +177,12 @@ export default function PlaylistDetail() {
     allClimbs,
     fetchPage,
     viewOnlyBoard: resolveViewOnlyBoard,
+    // In a crew a row tap browses: it opens the drawer on the tapped climb with
+    // the playlist seeded as the swipe track, and leaves the queue alone. The
+    // alternative here is the loudest write in the app — `replaceQueueOnActivate`
+    // swaps the whole crew's queue for the playlist order and takes the wall,
+    // which is not what tapping a row to look at it means.
+    previewOnly: isSharedSession,
     refreshErrorMessage: 'Failed to refresh playlist suggestions:',
     replaceQueueOnActivate: true,
   });

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -22,6 +22,7 @@ type TestBoardBanner = {
 
 type CapturedActivationOptions = {
   viewOnlyBoard?: TestRenderBoard | ((climb: Climb) => TestRenderBoard | null) | null;
+  previewOnly?: boolean;
 };
 
 // The metadata query goes through getHttpClient().request — mock it so we can
@@ -138,6 +139,10 @@ vi.mock('../../../../src/providers/theme-provider', () => ({
 }));
 const authMock = vi.hoisted(() => ({ isAuthenticated: true }));
 vi.mock('../../../../src/providers/auth-provider', () => ({ useAuth: () => authMock }));
+// Whether anyone else is in the session — what turns a row tap from "replace the
+// crew's queue and take the wall" into "show me this climb".
+const sessionMock = vi.hoisted(() => ({ isShared: false }));
+vi.mock('../../../../src/providers/queue-provider', () => ({ useIsSharedSession: () => sessionMock.isShared }));
 vi.mock('../../../../src/providers/toast-provider', () => ({ useToast: () => toast }));
 vi.mock('../../../../src/lib/playlists/use-playlist-activation', () => ({
   usePlaylistActivation: (options: CapturedActivationOptions) => {
@@ -301,6 +306,7 @@ beforeEach(() => {
   toast.showToast.mockClear();
   playlistMocks.allClimbs = [];
   playlistMocks.activationOptions = null;
+  sessionMock.isShared = false;
   playlistMocks.renderBoardResult = { renderBoard: null, banner: null };
   commentsMock.calls = [];
   commentsMock.totalCount = 0;
@@ -408,6 +414,28 @@ describe('PlaylistDetail metadata error handling', () => {
       layoutId: 9,
       angle: 35,
     });
+  });
+
+  // A row tap on this screen activates with `replaceQueueOnActivate` — the
+  // loudest write in the app, since it swaps everyone's queue for the playlist
+  // order and takes the wall. In a crew that cannot be what tapping a row to look
+  // at a climb means, so the tap browses instead.
+  it('browses a row tap in a crew instead of replacing everyone’s queue', async () => {
+    sessionMock.isShared = true;
+    requestMock.mockResolvedValue({ playlist: makePlaylist() });
+
+    renderDetail();
+
+    await waitFor(() => expect(playlistMocks.activationOptions?.previewOnly).toBe(true));
+  });
+
+  it('leaves a solo row tap activating the playlist as before', async () => {
+    requestMock.mockResolvedValue({ playlist: makePlaylist() });
+
+    renderDetail();
+
+    await waitFor(() => expect(playlistMocks.activationOptions).not.toBeNull());
+    expect(playlistMocks.activationOptions?.previewOnly).toBe(false);
   });
 });
 

--- a/packages/mobile/app/(tabs)/discover/smart/[type].tsx
+++ b/packages/mobile/app/(tabs)/discover/smart/[type].tsx
@@ -26,6 +26,7 @@ import { toQueueClimbs } from '../../../../src/lib/climb-types';
 import { smartPlaylistByType } from '../../../../src/lib/smart-playlists';
 import { useProfile } from '../../../../src/lib/graphql/hooks';
 import { useAuthToken } from '../../../../src/lib/graphql/use-auth-token';
+import { useIsSharedSession } from '../../../../src/providers/queue-provider';
 import { iosSystemColors } from '../../../../src/theme/ios-colors';
 
 type SmartParams = {
@@ -37,6 +38,9 @@ export default function SmartPlaylistDetail() {
   const { t } = useTranslation('playlists');
   const { data: profile } = useProfile();
   const { isLoading: tokenLoading } = useAuthToken();
+  // "Is anyone else here" — one boolean off a dedicated selector context, so the
+  // session-stats push doesn't re-render this screen's list.
+  const isSharedSession = useIsSharedSession();
 
   const userId = profile?.id ?? '';
   const preset = smartPlaylistByType(type);
@@ -89,6 +93,9 @@ export default function SmartPlaylistDetail() {
     sourceId: `smart:${smartType}:${userId}`,
     allClimbs,
     fetchPage,
+    // Same rule as the playlist screen above: with a crew present a row tap is a
+    // look, not a queue replacement plus a wall grab.
+    previewOnly: isSharedSession,
     refreshErrorMessage: 'Failed to refresh smart playlist suggestions:',
     replaceQueueOnActivate: true,
   });

--- a/packages/mobile/app/(tabs)/discover/smart/__tests__/[type].test.tsx
+++ b/packages/mobile/app/(tabs)/discover/smart/__tests__/[type].test.tsx
@@ -8,7 +8,7 @@ import type { Climb } from '@boardsesh/queue';
 // replacement (replaceQueueOnActivate) and thread the queue-replace sheet through,
 // exactly like the regular playlist detail screen. The hook + sheet themselves are
 // unit-tested elsewhere; here we only assert the wiring.
-type CapturedOptions = { sourceId: string; replaceQueueOnActivate?: boolean };
+type CapturedOptions = { sourceId: string; replaceQueueOnActivate?: boolean; previewOnly?: boolean };
 
 const smartMocks = vi.hoisted(() => ({
   activationOptions: null as CapturedOptions | null,
@@ -83,6 +83,12 @@ vi.mock('../../../../../src/lib/smart-playlists', () => ({
 vi.mock('../../../../../src/lib/graphql/hooks', () => ({ useProfile: () => ({ data: { id: 'u-1' } }) }));
 vi.mock('../../../../../src/lib/graphql/use-auth-token', () => ({ useAuthToken: () => ({ isLoading: false }) }));
 vi.mock('../../../../../src/theme/ios-colors', () => ({ iosSystemColors: { systemGray4: '#C7C7CC' } }));
+// Whether anyone else is in the session — what decides between replacing the
+// crew's queue and simply showing the tapped climb.
+const sessionMock = vi.hoisted(() => ({ isShared: false }));
+vi.mock('../../../../../src/providers/queue-provider', () => ({
+  useIsSharedSession: () => sessionMock.isShared,
+}));
 
 import SmartPlaylistDetail from '../[type]';
 
@@ -99,5 +105,22 @@ describe('SmartPlaylistDetail queue replacement wiring', () => {
 
     fireEvent.click(container.querySelector('[data-activate]')!);
     expect(smartMocks.activate).toHaveBeenCalledWith({ uuid: 'c-1' });
+  });
+
+  // Same rule as the playlist detail screen: with a crew present, a row tap is a
+  // look — not a replacement of everyone's queue plus a wall grab.
+  it('browses a row tap in a crew instead of replacing everyone’s queue', () => {
+    sessionMock.isShared = true;
+    render(<SmartPlaylistDetail />);
+
+    expect(smartMocks.activationOptions?.previewOnly).toBe(true);
+  });
+
+  it('leaves a solo row tap replacing the queue as before', () => {
+    sessionMock.isShared = false;
+    render(<SmartPlaylistDetail />);
+
+    expect(smartMocks.activationOptions?.previewOnly).toBe(false);
+    expect(smartMocks.activationOptions?.replaceQueueOnActivate).toBe(true);
   });
 });

--- a/packages/mobile/app/play.tsx
+++ b/packages/mobile/app/play.tsx
@@ -54,6 +54,7 @@ export default function PlayScreen() {
     onAngleChange,
     onSwitchBoard,
     onPlayDrawerClosed,
+    onPlayDrawerTargetConsumed,
     playTarget,
   } = usePlayDrawerRoute();
   const { boardConfig: storedBoardConfig, openPlayDrawer, openClimbActions, openLogAscent } = useDrawerHost();
@@ -94,6 +95,19 @@ export default function PlayScreen() {
   const onClosedRef = useRef(onPlayDrawerClosed);
   onClosedRef.current = onPlayDrawerClosed;
   useEffect(() => () => onClosedRef.current(), []);
+
+  // Tell the host which target this route has actually applied. The close above
+  // is only allowed to clear that one — a target written by a tap that landed
+  // during the dismiss window never reaches this effect (the route is already
+  // unmounting), so it survives and the next mount serves the tap instead of
+  // swallowing it. Runs in the same commit as PlayDrawer's own apply effect.
+  const onTargetConsumedRef = useRef(onPlayDrawerTargetConsumed);
+  onTargetConsumedRef.current = onPlayDrawerTargetConsumed;
+  const playTargetNonce = playTarget?.nonce;
+  useEffect(() => {
+    if (playTargetNonce == null) return;
+    onTargetConsumedRef.current(playTargetNonce);
+  }, [playTargetNonce]);
 
   // The queue renders climbs against the stored active board (thumbnails + tick),
   // same as the host's instance.

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -320,6 +320,8 @@ export function PlayDrawer({
   const [drawerPreviewSuggestionSource, setDrawerPreviewSuggestionSource] = useState<PlaylistSuggestionSource | null>(
     null,
   );
+  // Only crew-captured tracks expire with the latch; explicit previews stay private.
+  const crewCapturedSuggestionSourceRef = useRef(false);
   // True when the preview is the live wall climb (accessory bar) — the displayed
   // climb IS the one physically lit, which is what the "On the wall" pill states.
   const [drawerPreviewIsWallClimb, setDrawerPreviewIsWallClimb] = useState(false);
@@ -764,7 +766,13 @@ export function PlayDrawer({
   }, [isSharedSession, isPreview]);
   useEffect(() => {
     if (isSharedSession) return;
-    const timer = setTimeout(() => setSharedBrowseLatched(false), SHARED_BROWSE_LATCH_RELEASE_MS);
+    const timer = setTimeout(() => {
+      setSharedBrowseLatched(false);
+      if (crewCapturedSuggestionSourceRef.current) {
+        setDrawerPreviewSuggestionSource(null);
+        crewCapturedSuggestionSourceRef.current = false;
+      }
+    }, SHARED_BROWSE_LATCH_RELEASE_MS);
     return () => clearTimeout(timer);
   }, [isSharedSession]);
   // What the gestures and the chrome both read. Live crew OR a latch that armed
@@ -980,6 +988,7 @@ export function PlayDrawer({
     setSharedBrowseLatched(false);
     setDrawerPreviewItem(null);
     setDrawerPreviewSuggestionSource(null);
+    crewCapturedSuggestionSourceRef.current = false;
     setDrawerPreviewIsWallClimb(false);
     // Mirroring is drawer-local per displayed climb: every other navigation
     // resets it, and carrying a preview's mirror onto the committed head would
@@ -1034,6 +1043,7 @@ export function PlayDrawer({
     if (browseByDefaultRef.current) return;
     setDrawerPreviewItem(null);
     setDrawerPreviewSuggestionSource(null);
+    crewCapturedSuggestionSourceRef.current = false;
   }, [activeAngle]);
 
   // Re-anchor the pinned preview at the live angle. Only fetches while the
@@ -1129,6 +1139,7 @@ export function PlayDrawer({
       const pinnedItem = previewItem ?? (opensAsBrowse ? climbToQueueItem(selectedClimb) : null);
       setDrawerPreviewItem(pinnedItem);
       setDrawerPreviewSuggestionSource(pinnedItem ? playlistSuggestionSource : null);
+      crewCapturedSuggestionSourceRef.current = false;
       setDrawerPreviewIsWallClimb(pinnedItem ? (options?.previewIsWallClimb ?? false) : false);
       // Opening a COMMITTED climb is the third latch exit: the queue-sheet tap,
       // a playlist activation and the accessory-of-current open all deliberately
@@ -1174,6 +1185,11 @@ export function PlayDrawer({
     if (previewTarget.viewOnly) {
       if (!previewTarget.targetItem) return;
       setDrawerPreviewItem(previewTarget.targetItem);
+      // Keep this browse track if a peer moves the shared queue off the list.
+      if (browseByDefault && !drawerPreviewSuggestionSource && navigationSuggestionSource) {
+        setDrawerPreviewSuggestionSource(navigationSuggestionSource);
+        crewCapturedSuggestionSourceRef.current = true;
+      }
       // Swiping off the lit climb makes "this is the wall climb" false — the
       // flag means displayed-equals-wall, and the wall didn't move.
       setDrawerPreviewIsWallClimb(false);
@@ -1191,6 +1207,7 @@ export function PlayDrawer({
     drawerPreviewSuggestionSource,
     drawerPreviewItem,
     navigationState.prevItem,
+    navigationSuggestionSource,
     previousClimb,
     lightOnSwipe,
     browseByDefault,
@@ -1207,6 +1224,11 @@ export function PlayDrawer({
     if (previewTarget.viewOnly) {
       if (!previewTarget.targetItem) return;
       setDrawerPreviewItem(previewTarget.targetItem);
+      // Keep this browse track if a peer moves the shared queue off the list.
+      if (browseByDefault && !drawerPreviewSuggestionSource && navigationSuggestionSource) {
+        setDrawerPreviewSuggestionSource(navigationSuggestionSource);
+        crewCapturedSuggestionSourceRef.current = true;
+      }
       // See handlePrev: displayed-equals-wall stops being true the moment the
       // swipe lands somewhere else.
       setDrawerPreviewIsWallClimb(false);
@@ -1224,6 +1246,7 @@ export function PlayDrawer({
     drawerPreviewSuggestionSource,
     drawerPreviewItem,
     navigationState.nextItem,
+    navigationSuggestionSource,
     nextClimb,
     lightOnSwipe,
     browseByDefault,
@@ -1283,13 +1306,14 @@ export function PlayDrawer({
     setSharedBrowseLatched(false);
     setDrawerPreviewItem(null);
     setDrawerPreviewSuggestionSource(null);
+    crewCapturedSuggestionSourceRef.current = false;
     setDrawerPreviewIsWallClimb(false);
     // Mirroring is drawer-local per displayed climb and every other navigation
     // resets it (see `handleBackToLive`). The commit has to as well: the
     // auto-sender lights the committed item's own `climb.mirrored`, so a mirror
     // toggled while previewing would leave the drawer showing the climb flipped
     // and the wall showing it straight.
-    setIsMirrored(false);
+    clearMirror();
   }, [
     drawerPreviewItem,
     drawerPreviewSuggestionSource,
@@ -1522,6 +1546,7 @@ export function PlayDrawer({
       if (getSimilarClimbTapMode(viewer, { inSharedSession: browseByDefault }) === 'preview') {
         setDrawerPreviewItem(queueItem);
         setDrawerPreviewSuggestionSource(null);
+        crewCapturedSuggestionSourceRef.current = false;
         // A different climb is on screen now, so it is not the lit one.
         setDrawerPreviewIsWallClimb(false);
         clearMirror();
@@ -1537,6 +1562,7 @@ export function PlayDrawer({
       // clear any preview that was showing.
       setDrawerPreviewItem(null);
       setDrawerPreviewSuggestionSource(null);
+      crewCapturedSuggestionSourceRef.current = false;
       clearMirror();
       // The favorite override is cleared by the climb-change effect.
       setIsTickBarActive(false);

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -9,6 +9,7 @@ import {
   type RefObject,
 } from 'react';
 import {
+  AccessibilityInfo,
   Platform,
   View,
   Pressable,
@@ -24,6 +25,7 @@ import { router } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
+import { reanchorPlaylistSuggestionSource } from '@boardsesh/queue';
 import type { ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
 import { randomUUID } from 'expo-crypto';
 import {
@@ -31,7 +33,7 @@ import {
   findUpcomingQueueItemsWithSuggestions,
   boardSupportsMirroring,
 } from '@boardsesh/play-view';
-import { climbToQueueItem } from '../../lib/climb-to-queue-item';
+import { climbToQueueItem, resolveCommittableQueueItem } from '../../lib/climb-to-queue-item';
 import { formatRenderBoardLabel, resolveClimbRenderBoard, sameRenderBoard } from '../../lib/boards/climb-render-board';
 import type { ActiveSubDrawer } from '@boardsesh/play-view';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
@@ -46,8 +48,17 @@ import { PlayDrawerActionBar } from './PlayDrawerActionBar';
 import { WallStatePill } from './WallStatePill';
 import { WallStateCallout } from './WallStateCallout';
 import { BrowseFrameOverlay } from './BrowseFrameOverlay';
-import { resolveWallPillState, resolveCommitBarModel, shouldShowHolderBadge } from './wall-state';
+import {
+  resolveWallPillState,
+  resolveCommitBarModel,
+  shouldAdoptLateWallRead,
+  shouldArmBusyWallConfirm,
+  shouldShowHolderBadge,
+} from './wall-state';
 import { useWallStateAnnouncer } from './use-wall-state-announcer';
+import { useWallClimb } from './use-wall-climb';
+import { claimJoinedBrowseNotice, claimSoloBrowseNotice } from './joined-browse-notice';
+import { previewNeedsAngleReanchor, reanchorPreviewAtAngle } from './preview-angle-anchor';
 import { SwitchBoardOverlay } from './SwitchBoardOverlay';
 import { LogAscentSheet } from '../LogAscentSheet';
 import { DeferredSections } from './DeferredSections';
@@ -71,6 +82,7 @@ import {
   useQueueData,
   useQueueActions,
   useQueueSessionId,
+  useIsSharedSession,
 } from '../../providers/queue-provider';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { useSetting } from '../../settings';
@@ -78,7 +90,7 @@ import type { OpenClimbActionsOptions } from '../../providers/drawer-host-provid
 import { useAuth } from '../../providers/auth-provider';
 import { useClimbModerationEnabled } from '../../providers/feature-flags-provider';
 import { useToast } from '../../providers/toast-provider';
-import { useToggleFavorite, useFavoriteStatus } from '../../lib/graphql/hooks';
+import { useToggleFavorite, useFavoriteStatus, useClimb } from '../../lib/graphql/hooks';
 import { useDisplayGrade } from '../../hooks/use-display-grade';
 import { resolveTickDefaultGradeName } from '../../lib/boardsesh-grade-display';
 import { useShareClimb } from '../../hooks/use-share-climb';
@@ -238,6 +250,18 @@ const NO_PREFETCH_FRAMES: string[] = [];
 const DEFAULT_LOGBOOK_HEADER_HEIGHT = 52;
 
 /**
+ * How long the session must stay solo before an armed browse latch lets go.
+ *
+ * Longer than the provider's arming dwell, and deliberately so: arming late is a
+ * mild inconvenience, but releasing early re-arms wall control under a climber
+ * who is still mid-browse with a crew that is merely reconnecting. Ten seconds
+ * outlasts a wifi handover and a backgrounded peer's socket teardown, which are
+ * the flaps worth surviving, while still guaranteeing that a climber left alone
+ * gets their board back without having to find a button.
+ */
+export const SHARED_BROWSE_LATCH_RELEASE_MS = 10_000;
+
+/**
  * Full-screen "now playing" player (Spotify-style track view). Rendered as the
  * content of the `app/play.tsx` modal route (`presentation: 'transparentModal'`):
  * the native modal VC gives the slide-up present, button dismiss, and —
@@ -303,7 +327,12 @@ export function PlayDrawer({
   // hangs from. Owned here rather than inside the pill because the callout is an
   // absolute sibling of the swipeable header (so it doesn't ride the swipe
   // translate) — it can't be a child of the 32pt pill in the header's flank.
-  const [wallCalloutOpen, setWallCalloutOpen] = useState(false);
+  //
+  // Three states, not a boolean, because the same card serves two very different
+  // jobs: `'explainer'` is the tapped card (modal, focused, offers actions) and
+  // `'notice'` is the one-shot "you're browsing now" card that appears by itself
+  // when a shared session first latches the drawer (no modal, no focus steal).
+  const [wallCallout, setWallCallout] = useState<'none' | 'explainer' | 'notice'>('none');
   const [headerBottomY, setHeaderBottomY] = useState(0);
   // The mirror toggle, scoped to the climb it was made on. A bare boolean went
   // stale whenever the current climb changed by a route the drawer doesn't own
@@ -442,6 +471,10 @@ export function PlayDrawer({
   const { queue, currentClimbQueueItem } = useQueueData();
   const { setCurrentClimb, nextClimb, previousClimb, addToQueue, mirrorCurrentClimb } = useQueueActions();
   const { sessionId } = useQueueSessionId();
+  // "Is anyone else here." Read as one boolean off a dedicated selector context
+  // so the ≤1/2s session-stats push and every presence delta cost the drawer
+  // nothing — it flips only across the solo ↔ crew boundary.
+  const isSharedSession = useIsSharedSession();
   const playlistSuggestionSource = usePlaylistSuggestionSource();
   const bluetooth = useOptionalBluetoothContext();
   const [lightOnSwipe] = useSetting('lightOnSwipe');
@@ -668,17 +701,18 @@ export function PlayDrawer({
     boardName: boardName as BoardName,
     mirrored: isMirrored,
     isOpen: isSheetOpen,
-    // A preview animates on-screen only — its frames must never reach the wall
-    // (the Browsing chrome promises "the wall stays put", and even without the
-    // chrome a preview is not a commit). The live climb's writes resume when
-    // the preview clears.
-    //
+    // A pinned preview is not what the wall is showing, so scrubbing a route
+    // preview animates on screen and nowhere else: no BLE frame writes, no
+    // playback broadcast to the crew. The LIVE climb keeps its frames and
+    // resumes writing when the preview clears.
+    viewOnly: isPreview,
     // A climb from another board is suppressed for a harder reason: its hold ids
     // address a different wall, so writing them lights the WRONG holds on the
     // connected board. The scrim hides the play controls, but a party peer's
     // playback event starts the engine with no local tap, so the guard belongs
-    // here rather than on the button (#5099).
-    suppressWallWrites: isPreview || climbBoardMismatch,
+    // here rather than on the button (#5099). Frames only — the crew still
+    // hears the playback, it is this wall that cannot show it.
+    suppressWallWrites: climbBoardMismatch,
   });
 
   // Auto-close tick bar and drop the favorite override when climb changes, so the
@@ -698,31 +732,149 @@ export function PlayDrawer({
     pendingLogbookScrollRef.current = false;
   }, [displayedClimbUuid]);
 
+  // --- The shared-session browse latch ---------------------------------------
+  //
+  // In a crew, every browse-shaped gesture stays view-only: a swipe, a climb-list
+  // tap and a similar-climb tap all show you a climb without writing the shared
+  // queue or moving anyone's wall. Putting a climb up becomes the one explicit
+  // act, on the commit row.
+  //
+  // The latch has its own state rather than being read live off
+  // `isSharedSession` because mid-browse the roster can change under you — a peer
+  // drops off the wifi, someone leaves — and a live gate would turn the very next
+  // swipe back into a wall-driving commit while the climber's hand was already
+  // moving. So entering a browse in a crew ARMS it, and the climber's own exits
+  // disarm it (Back to live, a commit, or opening a committed climb). The arming
+  // effect is deliberately broader than "the first view-only gesture": a crew
+  // forming while a preview is already pinned latches too, so the climber who was
+  // mid-browse when a second phone joined gets the safe posture without
+  // re-entering the preview.
+  //
+  // It is NOT one-way, though it was, and that was a bug rather than a strict
+  // reading of the rule above. A latch that only the climber can clear assumes
+  // they know it is there; the climber who never opened the commit row just found
+  // that their swipes had quietly stopped lighting the board, with the crew that
+  // caused it long gone. So the latch survives a peer flapping and then releases:
+  // once the session has genuinely been solo for a dwell, ordinary wall control
+  // comes back on its own. The exits still fire instantly — this only covers the
+  // case where nobody ever took one.
+  const [sharedBrowseLatched, setSharedBrowseLatched] = useState(false);
+  useEffect(() => {
+    if (isSharedSession && isPreview) setSharedBrowseLatched(true);
+  }, [isSharedSession, isPreview]);
+  useEffect(() => {
+    if (isSharedSession) return;
+    const timer = setTimeout(() => setSharedBrowseLatched(false), SHARED_BROWSE_LATCH_RELEASE_MS);
+    return () => clearTimeout(timer);
+  }, [isSharedSession]);
+  // What the gestures and the chrome both read. Live crew OR a latch that armed
+  // while there was one.
+  const browseByDefault = isSharedSession || sharedBrowseLatched;
+
   // --- Wall state (header pill + commit row + viewfinder) --------------------
   //
-  // Everything keys on DISPLAYED-EQUALS-WALL, never on who holds Bluetooth. The
-  // wall climb we can state truthfully today is the accessory-bar preview, which
-  // IS the lit climb by construction; a wall uuid read from board presence in
-  // every state (so the pill can say "on the wall" after a plain swipe lands on
-  // it) is PR A2's, along with the shared-session latch and the busy-wall
-  // confirm. Nothing here changes WHEN a drawer state happens — the whole block
-  // restates the states the drawer already had in chrome that names them.
-  const wallClimbUuid = isPreview && drawerPreviewIsWallClimb ? (displayedClimbUuid ?? null) : null;
-  // Being in a preview is NOT enough to claim browsing. With `lightOnSwipe` on
-  // and no suggestion source (the explicit "Preview" climb action, a deep link,
-  // the workout builder) the next swipe falls straight through to
-  // `setCurrentClimb` — it writes the shared queue and re-arms the BLE
+  // Everything keys on DISPLAYED-EQUALS-WALL, never on who holds Bluetooth.
+  //
+  // The lit climb is read from board presence continuously, so the pill can say
+  // "On the wall" after a plain swipe lands back on it and the busy-wall confirm
+  // has something to compare against. `drawerPreviewIsWallClimb` stays as the
+  // fallback rather than being retired with it: the accessory-bar preview knows
+  // it is the lit climb by construction, and it is still right when this drawer
+  // renders outside the board-presence provider's subtree (where the read
+  // degrades to a dark wall instead of throwing).
+  const wallClimb = useWallClimb();
+  const wallClimbUuid = wallClimb.uuid ?? (isPreview && drawerPreviewIsWallClimb ? (displayedClimbUuid ?? null) : null);
+  // Being in a preview is NOT enough to claim browsing. With `lightOnSwipe` on,
+  // no suggestion source and nobody else in the session (the explicit "Preview"
+  // climb action, a deep link, the workout builder) the next swipe falls straight
+  // through to `setCurrentClimb` — it writes the shared queue and re-arms the BLE
   // auto-sender. So the latch is "a preview whose navigation genuinely stays
-  // view-only", read off the same predicate the swipe handlers use. Those
-  // previews get the truthful `live` presentation instead until PR A2's one-way
-  // latch makes the browse promise real for them too.
+  // view-only", read off the same predicate the swipe handlers use, which is what
+  // stops the chrome from ever promising more than the gesture keeps.
   const browseLatchActive =
     isPreview &&
     swipeStaysViewOnly({
       previewItem: drawerPreviewItem,
       previewSuggestionSource: drawerPreviewSuggestionSource,
       lightOnSwipe,
+      inSharedSession: browseByDefault,
     });
+  // Whether a swipe from a NON-preview state would drive the wall — the pill's
+  // `live` claim. Derived from the same predicate rather than restated, so a crew
+  // (where swipes browse) can't be told its next swipe goes up on the wall.
+  const navigationCommits = !swipeStaysViewOnly({
+    previewItem: null,
+    previewSuggestionSource: null,
+    lightOnSwipe,
+    inSharedSession: browseByDefault,
+  });
+  // --- Busy-wall confirm -----------------------------------------------------
+  //
+  // Someone else lit a climb while you were browsing. Taking the wall silently
+  // would blank a climb another climber may be mid-attempt on, so the first
+  // "Put on the wall" tap asks instead of committing.
+  //
+  // What it compares against is the wall AS IT WAS when browsing began, which is
+  // why the snapshot is taken on the latch's rising edge and read from a ref:
+  // depending on `wallClimbUuid` here would re-snapshot on every wall event and
+  // the question could never arise.
+  const wallClimbUuidRef = useRef(wallClimbUuid);
+  wallClimbUuidRef.current = wallClimbUuid;
+  const wallUuidAtLatchStartRef = useRef<string | null>(null);
+  const latchStartedAtRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!browseLatchActive) return;
+    wallUuidAtLatchStartRef.current = wallClimbUuidRef.current;
+    latchStartedAtRef.current = Date.now();
+  }, [browseLatchActive]);
+  // A wall read that lands AFTER the snapshot was taken. At a cold start the
+  // presence feed may still be connecting when browsing begins, so the snapshot
+  // reads `null` — which is what a dark wall reads like too. When the climb that
+  // then arrives was lit well before this browse started, it IS the snapshot, and
+  // recording it as such is what stops the first commit tap from announcing
+  // "Someone just lit X" about a climb nobody touched. Ambiguous reads change
+  // nothing and leave the confirm free to arm.
+  const wallClimbSentAt = wallClimb.sentAt;
+  useEffect(() => {
+    if (!browseLatchActive) return;
+    if (
+      shouldAdoptLateWallRead({
+        wallUuidAtLatchStart: wallUuidAtLatchStartRef.current,
+        wallClimbUuid,
+        wallClimbSentAt,
+        latchStartedAt: latchStartedAtRef.current,
+      })
+    ) {
+      wallUuidAtLatchStartRef.current = wallClimbUuid;
+    }
+  }, [browseLatchActive, wallClimbUuid, wallClimbSentAt]);
+  const [busyWallConfirmArmed, setBusyWallConfirmArmed] = useState(false);
+  // Browsing on is one of the three ways the confirm stands down: the question
+  // was "put THIS up instead of theirs", and this is no longer what's on screen.
+  // Keyed on the displayed climb rather than repeated in each of the prev /
+  // next / similar / list-tap handlers, so a navigation path added later can't
+  // forget it.
+  useEffect(() => {
+    setBusyWallConfirmArmed(false);
+  }, [displayedClimbUuid]);
+  // Amendment B: NO auto-timeout. A question about someone else's climb doesn't
+  // get to expire on a timer while the climber is looking at the wall to decide.
+  // It stands down on exactly three things: "Keep theirs" (below), any further
+  // browse navigation (the displayed-climb effect above — the question was about
+  // a climb that is no longer on screen), and the conflict resolving itself,
+  // which is this effect: the wall going dark, coming back to what it showed
+  // when browsing started, or landing on the very climb about to be committed
+  // all leave nothing to ask.
+  useEffect(() => {
+    if (!busyWallConfirmArmed) return;
+    const stillBusy = shouldArmBusyWallConfirm({
+      wallClimbUuid,
+      wallUuidAtLatchStart: wallUuidAtLatchStartRef.current,
+      displayedClimbUuid: displayedClimbUuid ?? null,
+    });
+    if (!stillBusy) setBusyWallConfirmArmed(false);
+  }, [busyWallConfirmArmed, wallClimbUuid, displayedClimbUuid]);
+
   // The resolvers take the RAW latch and do their own anonymous suppression, so
   // that rule stays where its table tests can see it rather than being pre-baked
   // out at this call site.
@@ -732,8 +884,9 @@ export function PlayDrawer({
     wallClimbUuid,
     browseLatchActive,
     // `lightOnSwipe` off is precisely "the next swipe does NOT drive the wall"
-    // (it's what `getSwipeNavigationTarget` turns into `forceViewOnly`).
-    navigationCommits: lightOnSwipe,
+    // (it's what `getSwipeNavigationTarget` turns into `forceViewOnly`); in a
+    // crew the same answer comes from the browse gate.
+    navigationCommits,
     // The lightbulb's own signal: this device's BLE link, or a session member's.
     // Merely being IN a session is not enough — the Start button opens one solo,
     // and a solo session with nothing connected moves no wall.
@@ -749,8 +902,7 @@ export function PlayDrawer({
     displayedClimbUuid: displayedClimbUuid ?? null,
     committedHeadUuid: currentClimbQueueItem?.climb.uuid ?? null,
     wallClimbUuid,
-    // The busy-wall confirm needs the wall-uuid-at-latch-start snapshot — PR A2.
-    confirmArmed: false,
+    confirmArmed: busyWallConfirmArmed,
     wallDriven: lightbulbActive,
   });
   // The latch as the board overlay sees it. It follows the latch itself, NOT the
@@ -764,29 +916,68 @@ export function PlayDrawer({
   // where returning to the committed head is still a real (and truthful) action.
   const canReturnToCommittedClimb = isPreview && !isAnonymous;
 
-  const { markLatchExit } = useWallStateAnnouncer({
+  const { markLatchExit, suppressBrowseAnnouncement } = useWallStateAnnouncer({
     pillState: wallPillState,
     climbName: displayedClimb?.name ?? null,
   });
 
-  const handleOpenWallCallout = useCallback(() => setWallCalloutOpen(true), []);
-  const handleCloseWallCallout = useCallback(() => setWallCalloutOpen(false), []);
+  const handleOpenWallCallout = useCallback(() => setWallCallout('explainer'), []);
+  const handleCloseWallCallout = useCallback(() => setWallCallout('none'), []);
   const handleHeaderLayout = useCallback((event: LayoutChangeEvent) => {
     const { y, height } = event.nativeEvent.layout;
     const measured = Math.round(y + height);
     setHeaderBottomY((previous) => (Math.abs(previous - measured) > 2 ? measured : previous));
   }, []);
   // An explainer about a state that just changed is stale, so the callout stands
-  // down whenever the state or the climb under it moves.
+  // down whenever the state or the climb under it moves. This also dismisses the
+  // one-shot notice on the climber's next navigation, which is the point at which
+  // they've clearly read it.
   useEffect(() => {
-    setWallCalloutOpen(false);
+    setWallCallout('none');
   }, [wallPillState, displayedClimbUuid]);
 
+  // Something silently changed what a swipe does, so say so — once. Fires the
+  // first time the latch actually engages: joining a crew, or (solo) the first
+  // navigation that stays view-only because board lighting is off for swipes and
+  // taps. Either way it is the moment the new rule becomes visible rather than
+  // merely true.
+  //
+  // The solo half is gated on a wall being reachable at all. With no board
+  // connected, no session and nothing lit, "the wall stays put" is a sentence
+  // about something the climber hasn't got — and the commit button reads "Set
+  // active" there for the same reason.
+  //
+  // Declared AFTER the dismiss effect above so the same commit can't close the
+  // card it just opened: the latch engaging usually moves the pill state and the
+  // climb at once, and effects run in declaration order.
+  const wallReachable = commitBarModel.commitLabel === 'putOnWall';
+  useEffect(() => {
+    if (isAnonymous || !browseLatchActive) return;
+    const claimed = isSharedSession ? claimJoinedBrowseNotice(sessionId) : wallReachable && claimSoloBrowseNotice();
+    if (!claimed) return;
+    setWallCallout('notice');
+    // The card is the visual half; this is the spoken one, and it is spoken on
+    // both platforms. A live region on a card that MOUNTS already holding its
+    // text is not a content change, so TalkBack can miss it — and the drawer can
+    // open straight into a browse (a crew climb-list tap), where there is no
+    // state transition for the wall-state announcer to narrate either. Its browse
+    // sentence stands down when this speaks, so one moment gets one sentence.
+    suppressBrowseAnnouncement();
+    AccessibilityInfo.announceForAccessibility(t('playView.wallState.joinedBrowseNotice'));
+  }, [isAnonymous, isSharedSession, browseLatchActive, sessionId, wallReachable, suppressBrowseAnnouncement, t]);
+
   // Leave the browse latch: drop the pinned preview (and the peek anchor + wall
-  // flag that ride it) so the drawer re-derives from the committed queue head.
-  // Identical to today's implicit clear — nothing is sent, nothing is written.
+  // flag that ride it) so the drawer re-derives from the committed queue head,
+  // and disarm the one-way shared-session latch — this is one of the two exits
+  // that are allowed to. Nothing is sent, nothing is written.
+  //
+  // This is also "Keep theirs": answering the busy-wall question by leaving the
+  // other climber's climb up IS going back to live, so the two share a handler
+  // rather than drifting into two subtly different exits.
   const handleBackToLive = useCallback(() => {
     markLatchExit('backToLive');
+    setBusyWallConfirmArmed(false);
+    setSharedBrowseLatched(false);
     setDrawerPreviewItem(null);
     setDrawerPreviewSuggestionSource(null);
     setDrawerPreviewIsWallClimb(false);
@@ -798,22 +989,70 @@ export function PlayDrawer({
     // above: previewing the committed climb itself changes neither
     // `wallPillState` nor `displayedClimbUuid` on exit, which would strand the
     // explainer (and its focus trap) open with its action already spent.
-    setWallCalloutOpen(false);
+    setWallCallout('none');
   }, [markLatchExit]);
 
-  // When the SELECTED board's angle changes, drop the locally-pinned climb so the drawer
-  // re-derives the displayed climb from currentClimbQueueItem — which the queue
-  // re-grade effect patches with the new angle's grade. Without this, the header
-  // would keep showing the stale grade baked into the locally-held climb. The
-  // preview suggestion source anchors peeks on that pinned climb, so it must
-  // drop with it — kept alone it would aim next-peeks at the wrong climb.
+  // The SELECTED board's angle moved (the angle pill / sheet — `activeAngle`, not
+  // the render board's, which follows the displayed climb).
+  //
+  // Under an ACTIVE browse latch the pinned preview stays: that is where the
+  // climber is living, and dropping it would throw away the climb they were
+  // looking at, the suggestion track they were walking, and the latch itself —
+  // for one tap on the angle pill. Its grade is re-resolved at the new angle
+  // just below, the way `useQueueRegrade` re-resolves the committed climb's.
+  //
+  // Everywhere else the preview is DROPPED, which is what this effect did before
+  // the latch existed, and restoring it fixes a real regression. Outside a crew a
+  // pinned preview is not somewhere the climber is living — it is the explicit
+  // Preview action, a deep link, the workout builder, a `lightOnClimbTap`-off
+  // tap. Keeping it across an angle change stranded solo climbers in a state
+  // where the drawer shows one climb and the wall shows another, and where a
+  // pinned suggestion source makes `getViewOnlyPreviewNavigationTarget` return
+  // view-only no matter what `lightOnSwipe` says — so every onward swipe stopped
+  // committing and the board stopped lighting, with no visible cause. This clear
+  // was the only implicit escape from that chain. On iPad it is the ONLY one:
+  // `IpadPlayPane` never unmounts, so nothing else resets drawer-local state.
+  //
+  // The wall flag drops either way: "displayed IS the lit climb" was true at the
+  // old angle, and an angle change is exactly what makes it false.
+  //
+  // Gated on `browseByDefault` — a crew is here, or a latch armed while one was —
+  // and NOT on `browseLatchActive`. The two are easy to confuse and only one is
+  // right: `browseLatchActive` means "swipes from this state stay view-only",
+  // which is equally true of a SOLO climber previewing a tracked climb. Keying on
+  // it would keep the preview pinned exactly where the regression bites, and the
+  // solo case is the one the field reports came from.
+  //
+  // Read through a ref so the effect keys on `[activeAngle]` alone. As a dependency it
+  // would clear the preview the moment the crew flag dropped — which is every
+  // commit, and every peer leaving — and those are cases where the preview is
+  // already being handled deliberately somewhere else.
+  const browseByDefaultRef = useRef(browseByDefault);
+  browseByDefaultRef.current = browseByDefault;
   useEffect(() => {
+    setDrawerPreviewIsWallClimb(false);
+    if (browseByDefaultRef.current) return;
     setDrawerPreviewItem(null);
     setDrawerPreviewSuggestionSource(null);
-    // The wall flag rides the pinned preview: with the preview gone there is no
-    // "displayed climb IS the lit one" claim left to make.
-    setDrawerPreviewIsWallClimb(false);
   }, [activeAngle]);
+
+  // Re-anchor the pinned preview at the live angle. Only fetches while the
+  // preview's baked-in grade actually belongs to a different angle, and the patch
+  // preserves the item's uuid — that uuid is the drawer's navigation anchor, so
+  // minting a fresh one would break prev/next and the remaining count.
+  const previewClimbUuid = drawerPreviewItem?.climb?.uuid ?? null;
+  const { data: previewClimbAtAngle } = useClimb(
+    previewClimbUuid && previewNeedsAngleReanchor(drawerPreviewItem, angle)
+      ? { boardName, layoutId, sizeId, setIds, angle, climbUuid: previewClimbUuid }
+      : null,
+  );
+  useEffect(() => {
+    if (!previewClimbAtAngle) return;
+    // `reanchorPreviewAtAngle` returns the same reference for a stale response
+    // (one that landed after the climber swiped on) or an item already at this
+    // angle, so this never churns the preview.
+    setDrawerPreviewItem((current) => reanchorPreviewAtAngle(current, angle, previewClimbAtAngle));
+  }, [previewClimbAtAngle, angle]);
 
   const { showToast } = useToast();
 
@@ -865,30 +1104,49 @@ export function PlayDrawer({
     (selectedClimb: Climb, options?: PlayDrawerOpenOptions) => {
       const previewItem = options?.previewQueueItem ?? null;
       const playlistSuggestionSource = options?.playlistSuggestionSource ?? null;
-      // A view-only preview is shown without committing; the badge keys off this.
-      // Commit paths (committedExternally) and fresh active opens leave it null so
-      // the drawer renders the real currentClimbQueueItem.
-      setDrawerPreviewItem(previewItem);
-      setDrawerPreviewSuggestionSource(previewItem ? playlistSuggestionSource : null);
-      setDrawerPreviewIsWallClimb(previewItem ? (options?.previewIsWallClimb ?? false) : false);
+      // Fresh active open (search / list / LogbookTab / a tick in the feed / a
+      // profile climb / the accessory bar's own current climb): the climb becomes
+      // current unless it already is, so re-opening the current climb doesn't
+      // re-append it. A fresh-uuid item on a genuinely new selection is
+      // intentional (re-tapping starts a fresh pass — see queue setCurrentClimb).
+      const isFreshActiveOpen = !previewItem && !options?.committedExternally;
+      const isAlreadyCurrent = currentClimbQueueItem?.climb.uuid === selectedClimb.uuid;
+      // ...except in a crew, where the same taps are a LOOK. Tapping a peer's
+      // tick in the session feed, or a row in your own logbook, must not move the
+      // shared queue and blank the climb someone is mid-attempt on — the deep-link
+      // opener already reasons this way and passes `preview: true`. Gated here
+      // rather than at each opener because the openers are many (feed, Logbook,
+      // Sessions, session detail, profile, notifications) and every one of them
+      // is the same gesture: show me this climb.
+      //
+      // Reads the LATCH, like every other gesture gate in this file, not the live
+      // roster: a peer's phone dropping off the wifi for a moment must not turn
+      // the tap the climber is already making into a queue write.
+      const opensAsBrowse = isFreshActiveOpen && !isAlreadyCurrent && browseByDefault;
+      // A view-only preview is shown without committing; the browse chrome keys
+      // off this. Commit paths (committedExternally) and solo fresh active opens
+      // leave it null so the drawer renders the real currentClimbQueueItem.
+      const pinnedItem = previewItem ?? (opensAsBrowse ? climbToQueueItem(selectedClimb) : null);
+      setDrawerPreviewItem(pinnedItem);
+      setDrawerPreviewSuggestionSource(pinnedItem ? playlistSuggestionSource : null);
+      setDrawerPreviewIsWallClimb(pinnedItem ? (options?.previewIsWallClimb ?? false) : false);
+      // Opening a COMMITTED climb is the third latch exit: the queue-sheet tap,
+      // a playlist activation and the accessory-of-current open all deliberately
+      // put a climb up, so they land the drawer live rather than mid-browse. A
+      // preview open leaves the latch alone — the arm effect picks it up if a
+      // crew is present.
+      if (!pinnedItem) setSharedBrowseLatched(false);
       clearMirror();
       // Drop any stale optimistic heart so the opened climb shows its real
       // (server) favorite status rather than a leftover from the last climb.
       setFavoriteOverride(null);
       setIsTickBarActive(false);
       setActiveSubDrawer('none');
-      if (!previewItem && !options?.committedExternally) {
-        // Fresh active open (search / list / LogbookTab / accessory-of-current):
-        // make it current unless it already is, so re-opening the current climb
-        // doesn't re-append it. A fresh-uuid item on a genuinely new selection is
-        // intentional (re-tapping starts a fresh pass — see queue setCurrentClimb).
-        const isAlreadyCurrent = currentClimbQueueItem?.climb.uuid === selectedClimb.uuid;
-        if (!isAlreadyCurrent) {
-          setCurrentClimb(climbToQueueItem(selectedClimb), { playlistSuggestionSource: null });
-        }
+      if (isFreshActiveOpen && !isAlreadyCurrent && !opensAsBrowse) {
+        setCurrentClimb(climbToQueueItem(selectedClimb), { playlistSuggestionSource: null });
       }
     },
-    [currentClimbQueueItem, setCurrentClimb],
+    [currentClimbQueueItem, setCurrentClimb, browseByDefault],
   );
 
   // Apply the host's open target. A new target is a fresh object with a bumped
@@ -911,6 +1169,7 @@ export function PlayDrawer({
       previewSuggestionSource: drawerPreviewSuggestionSource,
       targetItem: navigationState.prevItem,
       lightOnSwipe,
+      inSharedSession: browseByDefault,
     });
     if (previewTarget.viewOnly) {
       if (!previewTarget.targetItem) return;
@@ -928,7 +1187,14 @@ export function PlayDrawer({
     previousClimb();
     clearMirror();
     // The favorite override is cleared by the climb-change effect.
-  }, [drawerPreviewSuggestionSource, drawerPreviewItem, navigationState.prevItem, previousClimb, lightOnSwipe]);
+  }, [
+    drawerPreviewSuggestionSource,
+    drawerPreviewItem,
+    navigationState.prevItem,
+    previousClimb,
+    lightOnSwipe,
+    browseByDefault,
+  ]);
 
   const handleNext = useCallback(() => {
     const previewTarget = getSwipeNavigationTarget({
@@ -936,6 +1202,7 @@ export function PlayDrawer({
       previewSuggestionSource: drawerPreviewSuggestionSource,
       targetItem: navigationState.nextItem,
       lightOnSwipe,
+      inSharedSession: browseByDefault,
     });
     if (previewTarget.viewOnly) {
       if (!previewTarget.targetItem) return;
@@ -953,19 +1220,76 @@ export function PlayDrawer({
     nextClimb();
     clearMirror();
     // The favorite override is cleared by the climb-change effect.
-  }, [drawerPreviewSuggestionSource, drawerPreviewItem, navigationState.nextItem, nextClimb, lightOnSwipe]);
+  }, [
+    drawerPreviewSuggestionSource,
+    drawerPreviewItem,
+    navigationState.nextItem,
+    nextClimb,
+    lightOnSwipe,
+    browseByDefault,
+  ]);
 
   // Commit the browse latch: the previewed climb becomes the current queue item,
   // the latch drops, and the lightbulb (which acts on the current climb) now
   // drives this one. Wired to the commit row's "Put on the wall" / "Set active".
   const handleSetActive = useCallback(() => {
     if (!drawerPreviewItem) return;
+    // First tap on a wall someone else moved mid-browse: ask instead of taking
+    // it. Only under the browse latch — that is what makes
+    // `wallUuidAtLatchStartRef` mean "the wall as it was when you started
+    // looking around"; without one there is no before-and-after to compare.
+    if (
+      !busyWallConfirmArmed &&
+      browseLatchActive &&
+      shouldArmBusyWallConfirm({
+        wallClimbUuid,
+        wallUuidAtLatchStart: wallUuidAtLatchStartRef.current,
+        displayedClimbUuid: displayedClimbUuid ?? null,
+      })
+    ) {
+      setBusyWallConfirmArmed(true);
+      // The bubble is untouchable, so the words have to reach a screen reader
+      // some other way. Android hears the confirm row's polite live region;
+      // saying it here as well would read it twice, so this is the other half
+      // (amendment B).
+      if (Platform.OS !== 'android') {
+        AccessibilityInfo.announceForAccessibility(
+          t('playView.wallState.commitOverride.body', { name: wallClimb.name ?? '' }),
+        );
+      }
+      return;
+    }
     markLatchExit('commit');
-    setCurrentClimb(drawerPreviewItem, { playlistSuggestionSource: drawerPreviewSuggestionSource });
+    setBusyWallConfirmArmed(false);
+    // Launder the item first. Browsing a suggestion track walks onto transient
+    // `playlist-peek:<uuid>` items, and `toQueueItemWireInput` sends `item.uuid`
+    // verbatim — committing one straight would put a uuid on the wire that no
+    // peer can reconcile against their queue. Same helper `nextClimb()` uses.
+    const { item } = resolveCommittableQueueItem(drawerPreviewItem);
+    // Re-anchor the track on the climb actually going up. Browsing moves
+    // `drawerPreviewItem` swipe by swipe but never touches the source, so after a
+    // walk from A to Z the source still says the pass began at A — and committing
+    // that verbatim would aim next/previous and the remaining count at A's
+    // neighbours, several swipes behind where the climber is standing.
+    setCurrentClimb(item, {
+      playlistSuggestionSource: reanchorPlaylistSuggestionSource(drawerPreviewSuggestionSource, item.climb?.uuid),
+    });
+    setSharedBrowseLatched(false);
     setDrawerPreviewItem(null);
     setDrawerPreviewSuggestionSource(null);
     setDrawerPreviewIsWallClimb(false);
-  }, [drawerPreviewItem, drawerPreviewSuggestionSource, setCurrentClimb, markLatchExit]);
+  }, [
+    drawerPreviewItem,
+    drawerPreviewSuggestionSource,
+    setCurrentClimb,
+    markLatchExit,
+    busyWallConfirmArmed,
+    browseLatchActive,
+    wallClimbUuid,
+    wallClimb.name,
+    displayedClimbUuid,
+    t,
+  ]);
 
   // Solo and preview surfaces retain their existing local mirror semantics.
   useEffect(() => {
@@ -1177,7 +1501,12 @@ export function PlayDrawer({
       // which is what re-arms the BLE auto-sender. Similar Climbs is the only
       // affordance in the anonymous view that could otherwise still drive a
       // wall, so it takes the preview path the wrong-board drawer already uses.
-      if (getSimilarClimbTapMode(viewer) === 'preview') {
+      //
+      // A member in a crew takes the same path for a different reason: the member
+      // branch below writes TWICE (append to the shared queue, then take the
+      // wall), which is the loudest possible outcome for the idlest possible
+      // intent. Browsing is what the tap means there.
+      if (getSimilarClimbTapMode(viewer, { inSharedSession: browseByDefault }) === 'preview') {
         setDrawerPreviewItem(queueItem);
         setDrawerPreviewSuggestionSource(null);
         // A different climb is on screen now, so it is not the lit one.
@@ -1200,7 +1529,7 @@ export function PlayDrawer({
       setIsTickBarActive(false);
       setCurrentClimb(queueItem, { playlistSuggestionSource: null });
     },
-    [addToQueue, setCurrentClimb, viewer],
+    [addToQueue, setCurrentClimb, viewer, browseByDefault],
   );
 
   // The first screen is sized so the action bar stays visible and the Logbook
@@ -1299,11 +1628,13 @@ export function PlayDrawer({
                         callout can trap assistive tech the way a modal does: iOS
                         gets `accessibilityViewIsModal` on the callout itself,
                         Android has no such thing, so TalkBack would otherwise
-                        wander the drawer "behind" the open card. */}
+                        wander the drawer "behind" the open card. Only the TAPPED
+                        explainer traps: the one-shot notice appeared on its own,
+                        so it never takes the drawer away from a screen reader. */}
                     <View
                       style={styles.firstScreenContent}
-                      accessibilityElementsHidden={wallCalloutOpen}
-                      importantForAccessibility={wallCalloutOpen ? 'no-hide-descendants' : 'auto'}
+                      accessibilityElementsHidden={wallCallout === 'explainer'}
+                      importantForAccessibility={wallCallout === 'explainer' ? 'no-hide-descendants' : 'auto'}
                     >
                       <View style={styles.topRow}>
                         {/* The persistent pane has no dismiss, so it shows no grabber or
@@ -1471,6 +1802,12 @@ export function PlayDrawer({
                             secondaryMode={commitBarModel.mode}
                             showBackToLive={commitBarModel.showBackToLive}
                             showPutOnWall={commitBarModel.showPutOnWall}
+                            // Someone moved the wall mid-browse: the same two
+                            // controls become Keep theirs / Put mine up, so the
+                            // second tap on the filled button is the commit and
+                            // the text button is still the way out.
+                            showConfirm={commitBarModel.showConfirm}
+                            wallClimbName={wallClimb.name}
                             commitLabel={commitBarModel.commitLabel}
                             onBackToLive={handleBackToLive}
                             onCommit={handleSetActive}
@@ -1506,9 +1843,10 @@ export function PlayDrawer({
                         board art — zero layout cost, which is why it isn't a sheet.
                         `headerBottomY` is measured inside the wrapper, so the first
                         screen's own top padding is added back here. */}
-                    {wallCalloutOpen && wallPillState ? (
+                    {wallCallout !== 'none' && wallPillState ? (
                       <WallStateCallout
                         state={wallPillState}
+                        presentation={wallCallout}
                         top={firstScreenPaddingTop + headerBottomY + spacing[1]}
                         // Offered whenever a preview is pinned, NOT only under the
                         // browse latch: on the wrong board the commit row stands down
@@ -1517,9 +1855,11 @@ export function PlayDrawer({
                         // then the only way back to the committed climb short of
                         // dismissing the drawer.
                         //
-                        // "Browse from here" needs a latch that survives the next
-                        // navigation, which is PR A2's gating work — offering it now
-                        // would promise a browse the very next swipe would commit.
+                        // "Browse from here" is still withheld. A crew already
+                        // browses by default, so the action only means anything to a
+                        // SOLO climber — and there it needs a latch that isn't keyed
+                        // on the session. Offering it before that exists would
+                        // promise a browse the very next swipe would commit.
                         onBackToLive={canReturnToCommittedClimb ? handleBackToLive : undefined}
                         onDismiss={handleCloseWallCallout}
                       />
@@ -1536,9 +1876,9 @@ export function PlayDrawer({
                       a tap there must not scroll the logbook behind an open
                       modal. */}
                   <View
-                    accessibilityElementsHidden={wallCalloutOpen}
-                    importantForAccessibility={wallCalloutOpen ? 'no-hide-descendants' : 'auto'}
-                    pointerEvents={wallCalloutOpen ? 'none' : 'auto'}
+                    accessibilityElementsHidden={wallCallout === 'explainer'}
+                    importantForAccessibility={wallCallout === 'explainer' ? 'no-hide-descendants' : 'auto'}
+                    pointerEvents={wallCallout === 'explainer' ? 'none' : 'auto'}
                   >
                     <DeferredSections
                       climb={displayedClimb}

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -1237,10 +1237,16 @@ export function PlayDrawer({
     // First tap on a wall someone else moved mid-browse: ask instead of taking
     // it. Only under the browse latch — that is what makes
     // `wallUuidAtLatchStartRef` mean "the wall as it was when you started
-    // looking around"; without one there is no before-and-after to compare.
+    // looking around"; without one there is no before-and-after to compare. And
+    // only with a crew (`browseByDefault`: one is here, or was when the latch
+    // armed): "Someone just lit X" needs a someone. A solo climber with
+    // `lightOnSwipe` off is latched too, and the one way THEIR wall moves under
+    // a preview is their own lightbulb tap — asking them to confirm over their
+    // own climb would be the question asked of nobody.
     if (
       !busyWallConfirmArmed &&
       browseLatchActive &&
+      browseByDefault &&
       shouldArmBusyWallConfirm({
         wallClimbUuid,
         wallUuidAtLatchStart: wallUuidAtLatchStartRef.current,
@@ -1278,6 +1284,12 @@ export function PlayDrawer({
     setDrawerPreviewItem(null);
     setDrawerPreviewSuggestionSource(null);
     setDrawerPreviewIsWallClimb(false);
+    // Mirroring is drawer-local per displayed climb and every other navigation
+    // resets it (see `handleBackToLive`). The commit has to as well: the
+    // auto-sender lights the committed item's own `climb.mirrored`, so a mirror
+    // toggled while previewing would leave the drawer showing the climb flipped
+    // and the wall showing it straight.
+    setIsMirrored(false);
   }, [
     drawerPreviewItem,
     drawerPreviewSuggestionSource,
@@ -1285,6 +1297,7 @@ export function PlayDrawer({
     markLatchExit,
     busyWallConfirmArmed,
     browseLatchActive,
+    browseByDefault,
     wallClimbUuid,
     wallClimb.name,
     displayedClimbUuid,

--- a/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
@@ -66,6 +66,11 @@ type PlayDrawerActionBarProps = {
   showBackToLive?: boolean;
   /** Commit-mode only: hidden when the displayed climb is already the lit one. */
   showPutOnWall?: boolean;
+  /** Commit-mode only: someone moved the wall mid-browse, so the pair swaps to
+   *  Keep theirs / Put mine up and the question floats above the row. */
+  showConfirm?: boolean;
+  /** Commit-mode only: the lit climb's name, for the confirm's question. */
+  wallClimbName?: string | null;
   /** Commit-mode only: "Put on the wall" vs "Set active" where no wall is reachable. */
   commitLabel?: CommitButtonLabel;
   onBackToLive?: () => void;
@@ -125,6 +130,8 @@ export const PlayDrawerActionBar = memo(function PlayDrawerActionBar({
   secondaryMode = 'actions',
   showBackToLive = false,
   showPutOnWall = false,
+  showConfirm = false,
+  wallClimbName = null,
   commitLabel = 'putOnWall',
   onBackToLive,
   onCommit,
@@ -316,6 +323,8 @@ export const PlayDrawerActionBar = memo(function PlayDrawerActionBar({
           <PlayDrawerCommitBar
             showBackToLive={showBackToLive}
             showPutOnWall={showPutOnWall}
+            showConfirm={showConfirm}
+            wallClimbName={wallClimbName}
             commitLabel={commitLabel}
             onBackToLive={onBackToLive}
             onCommit={onCommit}

--- a/packages/mobile/src/components/play-drawer/PlayDrawerCommitBar.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerCommitBar.tsx
@@ -6,92 +6,174 @@
 // preview-first work is giving board art back, not spending it on chrome. The
 // utilities are gone for the duration on purpose: browsing is a transient
 // choosing state, and the primary row above still acts on the displayed climb.
+//
+// The busy-wall confirm re-uses the same two controls IN PLACE rather than
+// growing a dialog: the pair crossfades to "Keep theirs" / "Put mine up" and the
+// question floats above them as a bubble. Both actions are the ones the row
+// already had — the second tap on the filled button is the commit, and the text
+// button is still the exit — so nothing new can be tapped by accident, and the
+// row's geometry never moves under a thumb that is already on its way down.
 
 import { memo } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 import Animated, { FadeIn, useReducedMotion } from 'react-native-reanimated';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '../../providers/theme-provider';
-import { androidRipple, spacing } from '../../theme/tokens';
+import { androidRipple, spacing, borderRadius, shadows } from '../../theme/tokens';
+import { withAlpha } from '../../theme/colors';
+import { selectByVariant } from '../../theme/variants/select-by-variant';
 import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 import { glassSize } from '../../theme/layout';
 import { drawerActionBarStyles } from '../drawer-action-bar/DrawerActionBar';
 import { Text } from '../Text';
+import { Icon } from '../Icon';
 import type { CommitButtonLabel } from './wall-state';
+
+/** Matches the row's own control height, so the bubble clears the buttons. */
+const BUBBLE_LIFT = glassSize.inline + spacing[1];
+const BUBBLE_ICON_SIZE = 14;
+const SWAP_FADE_MS = 150;
+const BUBBLE_FADE_MS = 180;
 
 type PlayDrawerCommitBarProps = {
   showBackToLive: boolean;
   /** Hidden (never disabled-dead) when the displayed climb is already the lit one. */
   showPutOnWall: boolean;
   /**
+   * Someone else moved the wall while this climber was browsing. The pair swaps
+   * to Keep theirs / Put mine up and the question floats above it. Never true at
+   * the same time as the two flags above — `resolveCommitBarModel` owns that.
+   */
+  showConfirm: boolean;
+  /** The climb the wall is showing — named in the confirm's question. */
+  wallClimbName: string | null;
+  /**
    * "Put on the wall" where a wall is actually reachable, "Set active" where none
    * is — the button never promises a lighting it can't do.
    */
   commitLabel: CommitButtonLabel;
+  /** Leaves the latch. Doubles as "Keep theirs": both land the climber back on
+   *  the committed climb with the wall untouched, which is the same act. */
   onBackToLive: () => void;
+  /** Commits the displayed climb. The FIRST tap is what armed the confirm, so
+   *  the second one goes straight through — the host owns that ladder. */
   onCommit: () => void;
 };
 
 function PlayDrawerCommitBarImpl({
   showBackToLive,
   showPutOnWall,
+  showConfirm,
+  wallClimbName,
   commitLabel,
   onBackToLive,
   onCommit,
 }: PlayDrawerCommitBarProps) {
   const { t } = useTranslation('session');
-  const { brandColors, radii } = useTheme();
+  const { variant, brandColors, systemColors, m3SurfaceContainers, materialElevation, radii } = useTheme();
   const reduceMotion = useReducedMotion();
 
   const commitText = commitLabel === 'putOnWall' ? t('playView.wallState.putOnWall') : t('playView.setActive');
+  const exitText = showConfirm ? t('playView.wallState.commitOverride.cancel') : t('playView.wallState.backToLive');
+  const confirmText = showConfirm ? t('playView.wallState.commitOverride.confirm') : commitText;
+  // In confirm mode BOTH controls are the answer to the question, so neither
+  // flag applies — the pair is the decision.
+  const showExit = showConfirm || showBackToLive;
+  const showFilled = showConfirm || showPutOnWall;
+
+  const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
+  const bubbleSurface = isMaterial
+    ? [{ backgroundColor: m3SurfaceContainers.high }, materialElevation.level2]
+    : [
+        {
+          backgroundColor: systemColors.elevatedSurface,
+          borderWidth: StyleSheet.hairlineWidth,
+          // The connected-light semantic: this is a statement about the wall.
+          borderColor: withAlpha(brandColors.live, 0.35),
+        },
+        shadows.sm,
+      ];
 
   return (
-    <Animated.View entering={reduceMotion ? undefined : FadeIn.duration(150)} style={styles.row}>
-      {showBackToLive ? (
-        <Pressable
-          onPress={onBackToLive}
-          accessibilityRole="button"
-          accessibilityLabel={t('playView.wallState.backToLive')}
-          style={({ pressed }) => [styles.textButton, pressed && drawerActionBarStyles.actionButtonPressed]}
-        >
-          <Text
-            variant="subheadline"
-            color={brandColors.tint}
-            numberOfLines={1}
-            maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
-            style={styles.textButtonLabel}
-          >
-            {t('playView.wallState.backToLive')}
-          </Text>
-        </Pressable>
-      ) : null}
+    <View style={styles.row}>
+      {/* Zero layout shift: the question floats ABOVE the row rather than
+          pushing it. Untouchable on purpose — the two buttons below are the only
+          answers — but left readable, because TalkBack hears it from this polite
+          live region while VoiceOver hears the host's announcement.
 
-      <View style={drawerActionBarStyles.spacer} />
-
-      {showPutOnWall ? (
-        <Pressable
-          onPress={onCommit}
-          accessibilityRole="button"
-          accessibilityLabel={commitText}
-          android_ripple={androidRipple(brandColors.onPrimary)}
-          style={({ pressed }) => [
-            styles.filledButton,
-            { backgroundColor: brandColors.primaryFill, borderRadius: radii.button },
-            pressed && styles.filledButtonPressed,
-          ]}
-        >
-          <Text
-            variant="subheadline"
-            color={brandColors.onPrimary}
-            numberOfLines={1}
-            maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
-            style={styles.filledButtonLabel}
+          The region itself is mounted for the whole life of the row and sits
+          empty while browsing, so arming the confirm is a CONTENT CHANGE inside
+          it — which is the thing Android announces. A region that first appears
+          already holding its sentence is not a change, and TalkBack can pass over
+          it in silence. It has no surface of its own and is absolutely
+          positioned, so an empty one costs nothing. */}
+      <View accessibilityLiveRegion="polite" pointerEvents="none" style={styles.bubbleRegion}>
+        {showConfirm ? (
+          <Animated.View
+            entering={reduceMotion ? undefined : FadeIn.duration(BUBBLE_FADE_MS)}
+            style={[styles.bubble, ...bubbleSurface]}
           >
-            {commitText}
-          </Text>
-        </Pressable>
-      ) : null}
-    </Animated.View>
+            <Icon name="warning" size={BUBBLE_ICON_SIZE} color={brandColors.live} />
+            <Text variant="caption1" color={systemColors.label} numberOfLines={2} style={styles.bubbleText}>
+              {t('playView.wallState.commitOverride.body', { name: wallClimbName ?? '' })}
+            </Text>
+          </Animated.View>
+        ) : null}
+      </View>
+
+      {/* Keyed on the mode so the swap is a crossfade in place, not a relayout:
+          "Put mine up" lands exactly where "Put on the wall" was. */}
+      <Animated.View
+        key={showConfirm ? 'confirm' : 'browse'}
+        entering={reduceMotion ? undefined : FadeIn.duration(SWAP_FADE_MS)}
+        style={styles.controls}
+      >
+        {showExit ? (
+          <Pressable
+            onPress={onBackToLive}
+            accessibilityRole="button"
+            accessibilityLabel={exitText}
+            style={({ pressed }) => [styles.textButton, pressed && drawerActionBarStyles.actionButtonPressed]}
+          >
+            <Text
+              variant="subheadline"
+              color={brandColors.tint}
+              numberOfLines={1}
+              maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+              style={styles.textButtonLabel}
+            >
+              {exitText}
+            </Text>
+          </Pressable>
+        ) : null}
+
+        <View style={drawerActionBarStyles.spacer} />
+
+        {showFilled ? (
+          <Pressable
+            onPress={onCommit}
+            accessibilityRole="button"
+            accessibilityLabel={confirmText}
+            android_ripple={androidRipple(brandColors.onPrimary)}
+            style={({ pressed }) => [
+              styles.filledButton,
+              { backgroundColor: brandColors.primaryFill, borderRadius: radii.button },
+              pressed && styles.filledButtonPressed,
+            ]}
+          >
+            <Text
+              variant="subheadline"
+              color={brandColors.onPrimary}
+              numberOfLines={1}
+              maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+              style={styles.filledButtonLabel}
+            >
+              {confirmText}
+            </Text>
+          </Pressable>
+        ) : null}
+      </Animated.View>
+    </View>
   );
 }
 
@@ -102,8 +184,31 @@ const styles = StyleSheet.create({
   // controls + 8/12 padding) is untouched.
   row: {
     flex: 1,
+  },
+  controls: {
+    flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  // The live region's own box: no surface, no size of its own, so it costs
+  // nothing while it sits empty waiting for the question.
+  bubbleRegion: {
+    position: 'absolute',
+    bottom: BUBBLE_LIFT,
+    right: 0,
+    maxWidth: '85%',
+    alignItems: 'flex-end',
+  },
+  bubble: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[2],
+    paddingHorizontal: spacing[3],
+    paddingVertical: spacing[2],
+    borderRadius: borderRadius.md,
+  },
+  bubbleText: {
+    flexShrink: 1,
   },
   textButton: {
     height: glassSize.inline,

--- a/packages/mobile/src/components/play-drawer/WallStateCallout.tsx
+++ b/packages/mobile/src/components/play-drawer/WallStateCallout.tsx
@@ -42,15 +42,33 @@ const CALLOUT_FADE_MS = 150;
 const CALLOUT_SETTLE_PX = 4;
 /** An explainer, not a decision — it stands down on its own if left alone. */
 const CALLOUT_AUTO_DISMISS_MS = 8000;
+/**
+ * The one-shot joined-a-crew notice dwells shorter than a tapped explainer: the
+ * climber didn't ask for it, and it is one sentence over their board art.
+ */
+const NOTICE_AUTO_DISMISS_MS = 5000;
 
 type WallStateCalloutProps = {
   state: WallStatePillState;
   /** Y offset inside the drawer's first screen: the header's measured bottom edge. */
   top: number;
   /**
+   * `'explainer'` (default) is the tapped card: the climber asked for it, so it
+   * claims the modal, takes screen-reader focus, and offers the state's actions.
+   *
+   * `'notice'` is the one-shot "you're browsing now" card that appears on its own
+   * when the browse latch first engages. Nobody asked for it, so it claims
+   * nothing: no modal region, no focus steal, no scrim over the drawer (taps pass
+   * straight through to the board), no actions, and a shorter dwell. Assistive
+   * tech hears its sentence from the host, which announces it on both platforms
+   * when it claims the card.
+   */
+  presentation?: 'explainer' | 'notice';
+  /**
    * Start browsing from the displayed climb. Omitted when this viewer can't —
-   * which in PR A1 is everyone, because holding a latch across navigation is the
-   * A2 half of the feature (see PlayDrawer).
+   * a crew already browses by default, so it would only ever mean anything to a
+   * solo climber, and there it needs a latch that isn't keyed on the session
+   * (see PlayDrawer).
    */
   onBrowseFromHere?: () => void;
   /** Drop the pinned preview and go back to the committed climb. Omitted when
@@ -59,7 +77,15 @@ type WallStateCalloutProps = {
   onDismiss: () => void;
 };
 
-function WallStateCalloutImpl({ state, top, onBrowseFromHere, onBackToLive, onDismiss }: WallStateCalloutProps) {
+function WallStateCalloutImpl({
+  state,
+  top,
+  presentation = 'explainer',
+  onBrowseFromHere,
+  onBackToLive,
+  onDismiss,
+}: WallStateCalloutProps) {
+  const isNotice = presentation === 'notice';
   const { t } = useTranslation('session');
   const { variant, systemColors, brandColors, m3SurfaceContainers, materialElevation, motion } = useTheme();
   const reduceMotion = useReducedMotion();
@@ -68,27 +94,32 @@ function WallStateCalloutImpl({ state, top, onBrowseFromHere, onBackToLive, onDi
   const bodyRef = useRef<View>(null);
 
   useEffect(() => {
-    const handle = setTimeout(onDismiss, CALLOUT_AUTO_DISMISS_MS);
+    const handle = setTimeout(onDismiss, isNotice ? NOTICE_AUTO_DISMISS_MS : CALLOUT_AUTO_DISMISS_MS);
     return () => clearTimeout(handle);
-  }, [onDismiss]);
+  }, [onDismiss, isNotice]);
 
   // Land the screen reader on the sentence the climber just asked for, rather
-  // than wherever the focus happened to be when the card claimed the modal.
+  // than wherever the focus happened to be when the card claimed the modal. The
+  // notice asked for nothing, so it never yanks focus off whatever the climber
+  // was reading — it announces politely and gets out of the way.
   useEffect(() => {
+    if (isNotice) return;
     const nodeHandle = findNodeHandle(bodyRef.current);
     if (nodeHandle == null) return;
     AccessibilityInfo.setAccessibilityFocus(nodeHandle);
-  }, []);
+  }, [isNotice]);
 
   // Android hardware back closes the explainer instead of dismissing the whole
   // player — the same "innermost transient surface first" order a sheet gets.
+  // The notice claims no such priority: back belongs to the player under it.
   useEffect(() => {
+    if (isNotice) return;
     const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
       onDismiss();
       return true;
     });
     return () => subscription.remove();
-  }, [onDismiss]);
+  }, [onDismiss, isNotice]);
 
   const isMaterial = selectByVariant(variant, { material: true, liquidGlass: false });
   const cardSurface = isMaterial
@@ -118,8 +149,9 @@ function WallStateCalloutImpl({ state, top, onBrowseFromHere, onBackToLive, onDi
       .withInitialValues({ transform: [{ translateY: -CALLOUT_SETTLE_PX }] });
   }, [reduceMotion, isMaterial, motion.standard]);
 
-  const body =
-    state === 'onWall'
+  const body = isNotice
+    ? t('playView.wallState.joinedBrowseNotice')
+    : state === 'onWall'
       ? t('playView.wallState.onWallHint')
       : state === 'live'
         ? t('playView.wallState.liveHint')
@@ -135,25 +167,53 @@ function WallStateCalloutImpl({ state, top, onBrowseFromHere, onBackToLive, onDi
     // One modal region for the pair: on iOS `accessibilityViewIsModal` hides
     // everything OUTSIDE the view it sits on, so putting it on the card alone
     // would hide the dismiss scrim — the one element some states can offer.
-    <View accessibilityViewIsModal style={styles.modalRegion}>
-      {/* Outside tap dismisses. Labelled rather than decorative so assistive tech
-          has a way out that isn't the hardware back button. */}
-      <Pressable
-        onPress={onDismiss}
-        accessibilityRole="button"
-        accessibilityLabel={t('playView.closeAria')}
-        style={StyleSheet.absoluteFill}
-      />
-      <Animated.View entering={entering} style={[styles.card, { top }, ...cardSurface]}>
-        <View ref={bodyRef} accessible accessibilityRole="text">
-          <Text variant="footnote" color={systemColors.label} style={styles.body}>
-            {body}
-          </Text>
-        </View>
+    <View
+      accessibilityViewIsModal={!isNotice}
+      // The notice never scrims the drawer, so its container must not swallow
+      // taps meant for the board underneath it.
+      pointerEvents={isNotice ? 'box-none' : 'auto'}
+      style={styles.modalRegion}
+    >
+      {/* Outside tap dismisses the tapped explainer. Labelled rather than
+          decorative so assistive tech has a way out that isn't the hardware back
+          button. The notice owns no scrim at all — see `presentation`. */}
+      {isNotice ? null : (
+        <Pressable
+          onPress={onDismiss}
+          accessibilityRole="button"
+          accessibilityLabel={t('playView.closeAria')}
+          style={StyleSheet.absoluteFill}
+        />
+      )}
+      <Animated.View
+        entering={entering}
+        style={[styles.card, { top }, ...cardSurface]}
+        // No live region, on either presentation. The notice's sentence is spoken
+        // by the host the moment it claims the card (PlayDrawer), on both
+        // platforms: a region on a card that MOUNTS already holding its text is
+        // not a content change, so Android can miss it, and pairing it with the
+        // host's announcement would read the same moment out twice.
+        accessibilityLiveRegion="none"
+      >
+        {isNotice ? (
+          // A tap on the notice itself puts it away early — the only exit it
+          // offers, since it deliberately owns no scrim.
+          <Pressable onPress={onDismiss} accessibilityRole="button" accessibilityLabel={t('playView.closeAria')}>
+            <Text variant="footnote" color={systemColors.label} style={styles.body}>
+              {body}
+            </Text>
+          </Pressable>
+        ) : (
+          <View ref={bodyRef} accessible accessibilityRole="text">
+            <Text variant="footnote" color={systemColors.label} style={styles.body}>
+              {body}
+            </Text>
+          </View>
+        )}
 
         {/* Who lit it, and how long ago — the recency the 24pt pill avatar is too
             small to print, and the profile tap the pill deliberately gave up. */}
-        {state === 'onWall' ? (
+        {state === 'onWall' && !isNotice ? (
           <Pressable
             onPress={handleOpenDriverProfile}
             disabled={!driverUserId}
@@ -183,22 +243,27 @@ function WallStateCalloutImpl({ state, top, onBrowseFromHere, onBackToLive, onDi
           </Pressable>
         ) : null}
 
-        <View style={styles.actions}>
-          {onBrowseFromHere ? (
-            <Pressable onPress={onBrowseFromHere} accessibilityRole="button" style={styles.action}>
-              <Text variant="subheadline" color={brandColors.tint} style={styles.actionLabel}>
-                {t('playView.wallState.browseFromHere')}
-              </Text>
-            </Pressable>
-          ) : null}
-          {onBackToLive ? (
-            <Pressable onPress={onBackToLive} accessibilityRole="button" style={styles.action}>
-              <Text variant="subheadline" color={brandColors.tint} style={styles.actionLabel}>
-                {t('playView.wallState.backToLive')}
-              </Text>
-            </Pressable>
-          ) : null}
-        </View>
+        {/* The notice states a fact; it asks for nothing, so it offers nothing —
+            no live control under a thumb the climber never raised. The same
+            actions stay one pill tap away in the explainer. */}
+        {isNotice ? null : (
+          <View style={styles.actions}>
+            {onBrowseFromHere ? (
+              <Pressable onPress={onBrowseFromHere} accessibilityRole="button" style={styles.action}>
+                <Text variant="subheadline" color={brandColors.tint} style={styles.actionLabel}>
+                  {t('playView.wallState.browseFromHere')}
+                </Text>
+              </Pressable>
+            ) : null}
+            {onBackToLive ? (
+              <Pressable onPress={onBackToLive} accessibilityRole="button" style={styles.action}>
+                <Text variant="subheadline" color={brandColors.tint} style={styles.actionLabel}>
+                  {t('playView.wallState.backToLive')}
+                </Text>
+              </Pressable>
+            ) : null}
+          </View>
+        )}
       </Animated.View>
     </View>
   );

--- a/packages/mobile/src/components/play-drawer/__tests__/joined-browse-notice.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/joined-browse-notice.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach } from 'vitest';
 import {
   claimJoinedBrowseNotice,
   claimSoloBrowseNotice,
+  JOINED_BROWSE_NOTICE_LEDGER_CAP,
   _resetJoinedBrowseNoticeForTests,
 } from '../joined-browse-notice';
 import { resetAllSettings } from '../../../settings';
@@ -25,6 +26,24 @@ describe('claimJoinedBrowseNotice', () => {
     expect(claimJoinedBrowseNotice('session-1')).toBe(true);
     expect(claimJoinedBrowseNotice('session-2')).toBe(true);
     expect(claimJoinedBrowseNotice('session-2')).toBe(false);
+  });
+
+  // A client that keeps landing in fresh session ids must not grow the ledger
+  // for the life of the process. The oldest claim goes first, so the crews the
+  // climber is actually in stay remembered.
+  it('forgets the oldest crew once the ledger is full, and keeps the rest', () => {
+    for (let index = 0; index < JOINED_BROWSE_NOTICE_LEDGER_CAP; index += 1) {
+      expect(claimJoinedBrowseNotice(`session-${index}`)).toBe(true);
+    }
+    // Full: everything is still remembered.
+    expect(claimJoinedBrowseNotice('session-0')).toBe(false);
+    expect(claimJoinedBrowseNotice(`session-${JOINED_BROWSE_NOTICE_LEDGER_CAP - 1}`)).toBe(false);
+    // One over: the oldest is evicted, everyone else is still remembered.
+    expect(claimJoinedBrowseNotice('session-overflow')).toBe(true);
+    expect(claimJoinedBrowseNotice('session-1')).toBe(false);
+    expect(claimJoinedBrowseNotice('session-overflow')).toBe(false);
+    // The evicted crew explains itself again — one repeated card, not a leak.
+    expect(claimJoinedBrowseNotice('session-0')).toBe(true);
   });
 
   it('never claims solo — the solo rule has its own claim', () => {

--- a/packages/mobile/src/components/play-drawer/__tests__/joined-browse-notice.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/joined-browse-notice.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  claimJoinedBrowseNotice,
+  claimSoloBrowseNotice,
+  _resetJoinedBrowseNoticeForTests,
+} from '../joined-browse-notice';
+import { resetAllSettings } from '../../../settings';
+
+beforeEach(() => {
+  _resetJoinedBrowseNoticeForTests();
+  resetAllSettings();
+});
+
+describe('claimJoinedBrowseNotice', () => {
+  it('grants the notice exactly once per session', () => {
+    expect(claimJoinedBrowseNotice('session-1')).toBe(true);
+    expect(claimJoinedBrowseNotice('session-1')).toBe(false);
+    expect(claimJoinedBrowseNotice('session-1')).toBe(false);
+  });
+
+  // The claim lives in module state precisely so it survives the play drawer
+  // unmounting — it is a modal route, and a ref inside it would reset on every
+  // dismiss, re-showing the card each time the drawer opened.
+  it('explains a different crew again', () => {
+    expect(claimJoinedBrowseNotice('session-1')).toBe(true);
+    expect(claimJoinedBrowseNotice('session-2')).toBe(true);
+    expect(claimJoinedBrowseNotice('session-2')).toBe(false);
+  });
+
+  it('never claims solo — the solo rule has its own claim', () => {
+    expect(claimJoinedBrowseNotice(null)).toBe(false);
+    expect(claimJoinedBrowseNotice(null)).toBe(false);
+    // And a null claim must not consume a later real session's one shot.
+    expect(claimJoinedBrowseNotice('session-1')).toBe(true);
+  });
+});
+
+// The other half: a climber who turned board lighting off for swipes and taps
+// navigates view-only too, and nothing else says so.
+describe('claimSoloBrowseNotice', () => {
+  it('grants the notice exactly once', () => {
+    expect(claimSoloBrowseNotice()).toBe(true);
+    expect(claimSoloBrowseNotice()).toBe(false);
+  });
+
+  // Persisted, unlike the crew claim: the setting behind it survives app death,
+  // so an in-memory claim would re-explain it on every cold start.
+  it('stays claimed across a fresh module state', () => {
+    expect(claimSoloBrowseNotice()).toBe(true);
+    _resetJoinedBrowseNoticeForTests();
+    expect(claimSoloBrowseNotice()).toBe(false);
+  });
+
+  it('does not consume a crew session’s own one shot', () => {
+    expect(claimSoloBrowseNotice()).toBe(true);
+    expect(claimJoinedBrowseNotice('session-1')).toBe(true);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-anonymous.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-anonymous.test.tsx
@@ -25,6 +25,18 @@
 //      `requireAuthenticated`, so an armed one can only 401).
 //   5. The pane never paints its "Pick a climb" placeholder when the open target
 //      already carries the climb — not even on the first commit.
+//   6. The shared-session browse latch actually reaches the gestures: swipes and
+//      similar-climb taps go view-only in a crew, a queue-sheet tap stays live,
+//      the latch survives the session ending, and Back to live drops it. The
+//      rules themselves are pure and tested in `play-drawer-navigation.test.ts`;
+//      hardcoding `inSharedSession: false` at these call sites leaves all of
+//      those green while the wall gets taken on the next swipe.
+//   7. A playlist peek never reaches `setCurrentClimb` from the commit button.
+//   8. The busy-wall confirm: the FIRST commit tap on a wall someone else moved
+//      mid-browse asks instead of taking it, and stands down only on the three
+//      things amendment B allows (never a timer).
+//   9. The mirror toggle doesn't push a previewed climb's frames to a board that
+//      is lit with the LIVE climb.
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, act } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
@@ -35,6 +47,7 @@ type Props = Record<string, unknown>;
 const recorded = vi.hoisted(() => ({
   actionBar: [] as Props[],
   wallPill: [] as Props[],
+  wallCallout: [] as Props[],
   deferredSections: [] as Props[],
   favoriteStatus: [] as Props[],
   browseFrame: 0,
@@ -45,6 +58,33 @@ const queueActions = vi.hoisted(() => ({
   nextClimb: vi.fn(),
   previousClimb: vi.fn(),
   addToQueue: vi.fn(async () => 'added'),
+}));
+// Mutable session fixtures: whether another climber is in the session, and the
+// navigation state the drawer swipes through. Read at call time so a case can
+// change them between renders — which is how "the latch survives the session
+// ending" is exercised at all.
+const session = vi.hoisted(() => ({
+  isShared: false,
+  sessionId: null as string | null,
+  nextItem: null as { uuid: string; climb: unknown } | null,
+  // The committed queue head. Null in the preview-only cases (the drawer renders
+  // the pinned preview); set where a case needs a live climb to fall back to.
+  currentItem: null as { uuid: string; climb: unknown } | null,
+}));
+// What board presence says is physically lit. Mutated between renders so a case
+// can move the wall UNDER a browsing climber — which is the whole premise of the
+// busy-wall confirm.
+const wall = vi.hoisted(() => ({
+  uuid: null as string | null,
+  name: null as string | null,
+  // Server-stamped. Only the cold-start cases set it: it is how a read that
+  // merely ARRIVED late is told from a climb a peer lit mid-browse.
+  sentAt: null as string | null,
+}));
+// The BLE link. Null (no transport) unless a case needs to watch what does and
+// doesn't reach the board.
+const ble = vi.hoisted(() => ({
+  current: null as { isConnected: boolean; sendFramesToBoard: ReturnType<typeof vi.fn> } | null,
 }));
 
 // --- Host platform -----------------------------------------------------------
@@ -93,9 +133,9 @@ vi.mock('@boardsesh/play-view', () => ({
   // what is warmed ahead, so nothing is ahead.
   findUpcomingQueueItemsWithSuggestions: () => [],
   computeNavigationStateWithSuggestions: () => ({
-    nextItem: null,
+    nextItem: session.nextItem,
     prevItem: null,
-    canNext: false,
+    canNext: session.nextItem != null,
     canPrevious: false,
   }),
   boardSupportsMirroring: () => true,
@@ -123,7 +163,14 @@ vi.mock('../WallStatePill', () => ({
     return createElement('div', { 'data-testid': 'wall-state-pill' });
   },
 }));
-vi.mock('../WallStateCallout', () => ({ WallStateCallout: () => null }));
+// Recorded, not stubbed: the one-shot "you're browsing now" notice is rendered
+// through this same component, and only the host decides when.
+vi.mock('../WallStateCallout', () => ({
+  WallStateCallout: (props: Props) => {
+    recorded.wallCallout.push(props);
+    return null;
+  },
+}));
 vi.mock('../BrowseFrameOverlay', () => ({
   BrowseFrameOverlay: () => {
     recorded.browseFrame += 1;
@@ -164,12 +211,16 @@ vi.mock('../../Icon', () => ({ Icon: () => null }));
 
 // --- Hooks / providers -------------------------------------------------------
 vi.mock('../../../providers/queue-provider', () => ({
-  useQueueData: () => ({ queue: [], currentClimbQueueItem: null }),
+  useQueueData: () => ({ queue: [], currentClimbQueueItem: session.currentItem }),
   useQueueActions: () => queueActions,
-  useQueueSessionId: () => ({ sessionId: null }),
+  useQueueSessionId: () => ({ sessionId: session.sessionId }),
+  useIsSharedSession: () => session.isShared,
   usePlaylistSuggestionSource: () => null,
 }));
-vi.mock('../../../providers/bluetooth-provider', () => ({ useOptionalBluetoothContext: () => null }));
+vi.mock('../../../providers/bluetooth-provider', () => ({ useOptionalBluetoothContext: () => ble.current }));
+// Board presence, read continuously so the pill can say "On the wall" after any
+// navigation and the confirm has a before-and-after to compare.
+vi.mock('../use-wall-climb', () => ({ useWallClimb: () => wall }));
 vi.mock('../../../providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: false }) }));
 vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock('../../../lib/graphql/hooks', () => ({
@@ -178,6 +229,9 @@ vi.mock('../../../lib/graphql/hooks', () => ({
     recorded.favoriteStatus.push(options ?? {});
     return { data: undefined };
   },
+  // The angle re-anchor's fetch. Nothing here changes the angle, so it never
+  // resolves — the point is that its absence doesn't drop the pinned preview.
+  useClimb: () => ({ data: undefined }),
 }));
 vi.mock('../../../hooks/use-display-grade', () => ({ useDisplayGrade: () => ({ boardseshActive: false }) }));
 vi.mock('../../../hooks/use-share-climb', () => ({ useShareClimb: () => vi.fn() }));
@@ -203,8 +257,10 @@ vi.mock('../../../lib/board-details', () => ({
 // `boardsesh-grade-display` and `favorite-rollback` stay REAL — the wiring of
 // those helpers into the render is exactly what this file exists to measure.
 
-const { PlayDrawer } = await import('../PlayDrawer');
+const { AccessibilityInfo } = await import('react-native');
+const { PlayDrawer, SHARED_BROWSE_LATCH_RELEASE_MS } = await import('../PlayDrawer');
 const { setSetting, resetAllSettings } = await import('../../../settings');
+const { _resetJoinedBrowseNoticeForTests } = await import('../joined-browse-notice');
 
 const BOARD_CONFIG = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20', angle: 40 };
 const CLIMB = {
@@ -223,17 +279,40 @@ function openTargetFor(climb: Climb) {
   return { climb, options: { previewQueueItem: { uuid: 'queue-item-uuid', climb } }, nonce: 1 };
 }
 
+/** What a queue-sheet tap / playlist activation hands the drawer: already committed. */
+function committedTargetFor(climb: Climb) {
+  return { climb, options: { committedExternally: true }, nonce: 1 };
+}
+
+/**
+ * What a tick in the session feed, a Logbook row, a profile climb or a search hit
+ * hands the drawer: no preview, no commit — just "show me this climb", which solo
+ * means making it current.
+ */
+function freshTargetFor(climb: Climb) {
+  return { climb, options: {}, nonce: 1 };
+}
+
+function drawerElement(
+  viewer: 'member' | 'anonymous',
+  openTarget:
+    | ReturnType<typeof openTargetFor>
+    | ReturnType<typeof committedTargetFor>
+    | ReturnType<typeof freshTargetFor>,
+  onSignIn?: () => void,
+) {
+  return createElement(PlayDrawer, {
+    presentation: 'pane' as const,
+    viewer,
+    boardConfig: BOARD_CONFIG,
+    openTarget,
+    onOpenQueue: vi.fn(),
+    onSignIn,
+  });
+}
+
 function renderDrawer(viewer: 'member' | 'anonymous', onSignIn?: () => void) {
-  return render(
-    createElement(PlayDrawer, {
-      presentation: 'pane' as const,
-      viewer,
-      boardConfig: BOARD_CONFIG,
-      openTarget: openTargetFor(CLIMB),
-      onOpenQueue: vi.fn(),
-      onSignIn,
-    }),
-  );
+  return render(drawerElement(viewer, openTargetFor(CLIMB), onSignIn));
 }
 
 function lastActionBarProps(): Props {
@@ -248,16 +327,678 @@ function lastSimilarClimbHandler(): (climb: Climb) => Promise<void> {
   return props.onSimilarClimbPress as (climb: Climb) => Promise<void>;
 }
 
+/**
+ * The climb the drawer is currently showing, read back off the last
+ * DeferredSections render. Goes through the same never-rendered guard as
+ * `lastSimilarClimbHandler` so a drawer that failed to render fails the test by
+ * saying so, rather than by throwing a TypeError from a dereferenced `undefined`.
+ */
+function lastDisplayedClimbUuid(): string {
+  const props = recorded.deferredSections.at(-1);
+  if (!props) throw new Error('DeferredSections never rendered');
+  return (props.climb as Climb).uuid;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   recorded.actionBar = [];
   recorded.wallPill = [];
+  recorded.wallCallout = [];
   recorded.deferredSections = [];
   recorded.favoriteStatus = [];
   recorded.browseFrame = 0;
   recorded.panePlaceholder = 0;
   queueActions.addToQueue.mockResolvedValue('added');
+  session.isShared = false;
+  session.sessionId = null;
+  session.nextItem = null;
+  session.currentItem = null;
+  wall.uuid = null;
+  wall.name = null;
+  wall.sentAt = null;
+  ble.current = null;
   resetAllSettings();
+  _resetJoinedBrowseNoticeForTests();
+});
+
+// Joining a crew changes what every browse-shaped gesture means: a swipe, a
+// similar-climb tap and (elsewhere) a climb-list tap stop writing the queue
+// EVERYONE reads. The rules are pinned pure in `play-drawer-navigation.test.ts`;
+// what only a render can see is whether PlayDrawer feeds them the crew flag at
+// all — hardcoding `inSharedSession: false` at these call sites leaves every
+// pure test green while the wall gets taken on the next swipe.
+describe('PlayDrawer — the shared-session browse latch', () => {
+  const CREW = () => {
+    session.isShared = true;
+    session.sessionId = 'session-1';
+  };
+
+  it('browses a pinned preview in a crew even with lighting on', () => {
+    // Solo, this exact state commits on the next swipe (the case below it in
+    // this file). The crew flag is the only difference.
+    CREW();
+    renderDrawer('member');
+
+    expect(recorded.wallPill.at(-1)?.state).toBe('browsing');
+    expect(recorded.browseFrame).toBeGreaterThan(0);
+    expect(lastActionBarProps().secondaryMode).toBe('commit');
+  });
+
+  it('keeps a swipe view-only instead of moving the crew queue', () => {
+    CREW();
+    session.nextItem = { uuid: 'queue-item-next', climb: SIMILAR_CLIMB };
+    renderDrawer('member');
+
+    act(() => {
+      (lastActionBarProps().onNextClick as () => void)();
+    });
+
+    // `nextClimb()` is the shared-queue write and the BLE re-arm. The drawer
+    // still MOVES — a dead swipe would be its own regression — it just moves
+    // locally.
+    expect(queueActions.nextClimb).not.toHaveBeenCalled();
+    expect(lastDisplayedClimbUuid()).toBe(SIMILAR_CLIMB.uuid);
+  });
+
+  it('previews a similar climb instead of double-writing it', () => {
+    CREW();
+    renderDrawer('member');
+    const onSimilarClimbPress = lastSimilarClimbHandler();
+
+    return act(async () => {
+      await onSimilarClimbPress(SIMILAR_CLIMB);
+    }).then(() => {
+      // The member branch appends to the crew's queue AND takes the wall.
+      expect(queueActions.addToQueue).not.toHaveBeenCalled();
+      expect(queueActions.setCurrentClimb).not.toHaveBeenCalled();
+      expect(lastDisplayedClimbUuid()).toBe(SIMILAR_CLIMB.uuid);
+    });
+  });
+
+  // Every "show me this climb" opener that carries no preview — a tick in the
+  // session feed, a Logbook row, a profile climb, a search hit — lands in the
+  // drawer's fresh-active-open branch, which commits. In a crew that is the
+  // ordinary look-at-my-logbook gesture taking the wall from someone mid-attempt,
+  // so it browses instead. Gated at the opener rather than at each caller: they
+  // are many, and every one of them is the same gesture.
+  it('browses a tick-shaped open in a crew instead of taking the wall', () => {
+    CREW();
+    session.currentItem = { uuid: 'queue-item-current', climb: SIMILAR_CLIMB };
+    render(drawerElement('member', freshTargetFor(CLIMB)));
+
+    expect(queueActions.setCurrentClimb).not.toHaveBeenCalled();
+    expect(lastDisplayedClimbUuid()).toBe(CLIMB.uuid);
+    expect(lastActionBarProps().secondaryMode).toBe('commit');
+  });
+
+  it('still commits the same open when nobody else is here', () => {
+    session.currentItem = { uuid: 'queue-item-current', climb: SIMILAR_CLIMB };
+    render(drawerElement('member', freshTargetFor(CLIMB)));
+
+    expect(queueActions.setCurrentClimb).toHaveBeenCalledTimes(1);
+    expect(queueActions.setCurrentClimb.mock.calls[0][0].climb.uuid).toBe(CLIMB.uuid);
+  });
+
+  // Amendment A again, on the open path this time: the gate reads the LATCH, not
+  // the live roster, so a peer's phone dropping off the wifi for a moment can't
+  // turn the tap the climber is already making into a queue write.
+  it('keeps a fresh open browsing while the latch is up, session or no session', () => {
+    CREW();
+    session.currentItem = { uuid: 'queue-item-current', climb: SIMILAR_CLIMB };
+    const view = render(drawerElement('member', openTargetFor(SIMILAR_CLIMB)));
+
+    session.isShared = false;
+    session.sessionId = null;
+    view.rerender(drawerElement('member', freshTargetFor(CLIMB)));
+
+    expect(queueActions.setCurrentClimb).not.toHaveBeenCalled();
+    expect(lastDisplayedClimbUuid()).toBe(CLIMB.uuid);
+  });
+
+  // The accessory bar opens the climb that is ALREADY current. Nothing is
+  // written either way, so pinning it as a preview would only invent a browse the
+  // climber never started — and a commit row for a climb already up.
+  it('leaves an open of the current climb exactly as it was', () => {
+    CREW();
+    session.currentItem = { uuid: 'queue-item-current', climb: CLIMB };
+    render(drawerElement('member', freshTargetFor(CLIMB)));
+
+    expect(queueActions.setCurrentClimb).not.toHaveBeenCalled();
+    expect(lastActionBarProps().secondaryMode).toBe('actions');
+    expect(recorded.browseFrame).toBe(0);
+  });
+
+  // The one browse-shaped gesture that is deliberately NOT gated: tapping a row
+  // in the queue sheet is an explicit "play this now", and it arrives here
+  // already committed. Gating it would leave the crew with no way to drive the
+  // wall from the queue at all.
+  it('leaves a queue-sheet tap live — it arrives already committed', () => {
+    CREW();
+    session.currentItem = { uuid: 'queue-item-current', climb: CLIMB };
+    render(drawerElement('member', committedTargetFor(CLIMB)));
+
+    expect(recorded.wallPill.at(-1)?.state).not.toBe('browsing');
+    expect(recorded.browseFrame).toBe(0);
+    expect(lastActionBarProps().secondaryMode).toBe('actions');
+  });
+
+  // The latch outlasts the crew, but only for a dwell. Mid-browse the roster
+  // changes under you — a peer drops off the wifi, the session ends — and reading
+  // the gate live would turn the very next swipe into a wall-driving commit while
+  // the climber's hand was already moving. Holding it FOREVER was the other
+  // failure: a climber who never opened the commit row was left with swipes that
+  // no longer lit the board and a crew that was long gone.
+  it('holds the latch when the session ends mid-browse', () => {
+    CREW();
+    session.nextItem = { uuid: 'queue-item-next', climb: SIMILAR_CLIMB };
+    // One target object across both renders, so re-rendering doesn't re-run the
+    // drawer's open effect and confuse the state under test.
+    const target = openTargetFor(CLIMB);
+    const view = render(drawerElement('member', target));
+
+    // The crew evaporates.
+    session.isShared = false;
+    session.sessionId = null;
+    view.rerender(drawerElement('member', target));
+
+    expect(lastActionBarProps().secondaryMode).toBe('commit');
+    expect(recorded.wallPill.at(-1)?.state).toBe('browsing');
+
+    act(() => {
+      (lastActionBarProps().onNextClick as () => void)();
+    });
+    expect(queueActions.nextClimb).not.toHaveBeenCalled();
+  });
+
+  it('releases the latch on its own once the session has been solo for a dwell', () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    CREW();
+    session.currentItem = { uuid: 'queue-item-current', climb: SIMILAR_CLIMB };
+    session.nextItem = { uuid: 'queue-item-next', climb: SIMILAR_CLIMB };
+    const target = openTargetFor(CLIMB);
+    const view = render(drawerElement('member', target));
+
+    // Everyone leaves. The latch holds at first — that is the point of it.
+    session.isShared = false;
+    session.sessionId = null;
+    view.rerender(drawerElement('member', target));
+    act(() => {
+      (lastActionBarProps().onNextClick as () => void)();
+    });
+    expect(queueActions.nextClimb).not.toHaveBeenCalled();
+
+    // ...and then lets go, without the climber having to find a button.
+    act(() => {
+      vi.advanceTimersByTime(SHARED_BROWSE_LATCH_RELEASE_MS + 100);
+    });
+    view.rerender(drawerElement('member', target));
+    act(() => {
+      (lastActionBarProps().onNextClick as () => void)();
+    });
+    expect(queueActions.nextClimb).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it('takes the browsing notice down with the latch that raised it', () => {
+    // The card says navigation is view-only, so it must not outlive the latch —
+    // and now that the latch can release on its own, it can. It stands down
+    // because releasing moves the pill from `browsing` to `live` and the dismiss
+    // effect above keys on that; this pins the connection, which is otherwise
+    // two effects apart and easy to sever by making the pill latch-independent.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    CREW();
+    wall.uuid = 'some-other-climb';
+    const target = openTargetFor(CLIMB);
+    const view = render(drawerElement('member', target));
+    expect(recorded.wallCallout.at(-1)?.presentation).toBe('notice');
+
+    // The crew goes but the SESSION stays — the climber is alone in a session they
+    // started, which is the ordinary state. This render is what schedules the
+    // release timer, so it has to happen before the clock moves, and the latch is
+    // still up here, so the notice is still legitimately on screen.
+    session.isShared = false;
+    view.rerender(drawerElement('member', target));
+
+    act(() => {
+      vi.advanceTimersByTime(SHARED_BROWSE_LATCH_RELEASE_MS + 100);
+    });
+    view.rerender(drawerElement('member', target));
+
+    // Recorded from a clean slate AFTER the state settles, then rendered once
+    // more. A closed callout stops rendering entirely, so reading `.at(-1)` would
+    // hold a stale notice frame — and clearing any earlier would catch the
+    // transitional render that happens before the effects run.
+    recorded.wallCallout = [];
+    view.rerender(drawerElement('member', target));
+
+    expect(recorded.wallCallout.filter((props) => props.presentation === 'notice')).toHaveLength(0);
+    vi.useRealTimers();
+  });
+
+  it('drops the latch on Back to live, so the next swipe drives the wall again', () => {
+    CREW();
+    // A committed head to fall back to, on a different climb than the preview.
+    session.currentItem = { uuid: 'queue-item-current', climb: SIMILAR_CLIMB };
+    session.nextItem = { uuid: 'queue-item-next', climb: SIMILAR_CLIMB };
+    const target = openTargetFor(CLIMB);
+    const view = render(drawerElement('member', target));
+
+    act(() => {
+      (lastActionBarProps().onBackToLive as () => void)();
+    });
+    // Back to live is an exit, not a commit: nothing is sent on the way out.
+    expect(queueActions.setCurrentClimb).not.toHaveBeenCalled();
+
+    // Solo again — and with the latch disarmed, swipes commit as they did before.
+    session.isShared = false;
+    session.sessionId = null;
+    view.rerender(drawerElement('member', target));
+    act(() => {
+      (lastActionBarProps().onNextClick as () => void)();
+    });
+    expect(queueActions.nextClimb).toHaveBeenCalledTimes(1);
+  });
+
+  // Joining a crew silently changes what a swipe does, so the drawer says so —
+  // once. A card that reappears on every open is what people remember about a
+  // feature instead of the feature.
+  it('explains the new rule once, the first time the latch engages', () => {
+    CREW();
+    render(drawerElement('member', openTargetFor(CLIMB)));
+
+    const notices = recorded.wallCallout.filter((props) => props.presentation === 'notice');
+    expect(notices).toHaveLength(1);
+  });
+
+  it('does not explain it again on the next drawer open in the same session', () => {
+    CREW();
+    render(drawerElement('member', openTargetFor(CLIMB))).unmount();
+    recorded.wallCallout = [];
+
+    // The drawer is a modal route: it unmounts on every dismiss, which is why the
+    // claim can't live in component state.
+    render(drawerElement('member', openTargetFor(CLIMB)));
+
+    expect(recorded.wallCallout.filter((props) => props.presentation === 'notice')).toHaveLength(0);
+  });
+
+  it('never explains it to a climber with no wall to explain', () => {
+    // Board lighting off for swipes, but no board connected, no session and
+    // nothing lit: "the wall stays put" would be a sentence about something this
+    // climber hasn't got — the commit button reads "Set active" here for the same
+    // reason.
+    setSetting('lightOnSwipe', false);
+    renderDrawer('member');
+
+    expect(recorded.wallCallout.filter((props) => props.presentation === 'notice')).toHaveLength(0);
+  });
+
+  // The solo half of the same rule (#4640): turning board lighting off for swipes
+  // and taps quietly makes navigation view-only, and nothing else says so.
+  it('explains view-only navigation to a solo climber standing at a lit board', () => {
+    setSetting('lightOnSwipe', false);
+    wall.uuid = 'wall-climb-a';
+    wall.name = 'What Was Up';
+    render(drawerElement('member', openTargetFor(CLIMB))).unmount();
+
+    expect(recorded.wallCallout.filter((props) => props.presentation === 'notice')).toHaveLength(1);
+  });
+
+  it('tells that climber once, not once per drawer open', () => {
+    // Unlike the crew claim, this one is a decision about a device the climber
+    // keeps — so it is persisted, and a cold start does not re-explain it.
+    setSetting('lightOnSwipe', false);
+    wall.uuid = 'wall-climb-a';
+    render(drawerElement('member', openTargetFor(CLIMB))).unmount();
+    recorded.wallCallout = [];
+
+    render(drawerElement('member', openTargetFor(CLIMB)));
+
+    expect(recorded.wallCallout.filter((props) => props.presentation === 'notice')).toHaveLength(0);
+  });
+
+  // The card is the visual half. The spoken half has to come from here on BOTH
+  // platforms: a live region on a card that MOUNTS holding its text is not a
+  // content change (Android can miss it), and the drawer can open straight into a
+  // browse, where there is no transition for the wall-state announcer to narrate.
+  it('speaks the rule it just put on screen', () => {
+    CREW();
+    render(drawerElement('member', openTargetFor(CLIMB)));
+
+    expect(AccessibilityInfo.announceForAccessibility).toHaveBeenCalledWith('playView.wallState.joinedBrowseNotice');
+  });
+
+  it('does not read the shorter browse sentence over the notice', () => {
+    vi.useFakeTimers();
+    try {
+      // A crew forming mid-preview IS a pill transition, so the announcer would
+      // otherwise narrate it 600ms after the notice said the same thing at length.
+      const target = openTargetFor(CLIMB);
+      const view = render(drawerElement('member', target));
+      session.isShared = true;
+      session.sessionId = 'session-1';
+      view.rerender(drawerElement('member', target));
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+
+      expect(AccessibilityInfo.announceForAccessibility).toHaveBeenCalledTimes(1);
+      expect(AccessibilityInfo.announceForAccessibility).not.toHaveBeenCalledWith(
+        'playView.wallState.a11y.browseAnnounce',
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Browsing a suggestion track walks onto transient `playlist-peek:<uuid>`
+  // items, and `toQueueItemWireInput` puts `item.uuid` on the wire verbatim —
+  // so a peek reaching setCurrentClimb broadcasts a uuid no peer can reconcile
+  // against their queue. The commit button points at whatever is on screen.
+  it('launders a playlist peek before putting it on the wall', () => {
+    CREW();
+    render(
+      drawerElement('member', {
+        climb: CLIMB,
+        options: { previewQueueItem: { uuid: `playlist-peek:${CLIMB.uuid}`, climb: CLIMB } },
+        nonce: 1,
+      }),
+    );
+
+    act(() => {
+      (lastActionBarProps().onCommit as () => void)();
+    });
+
+    expect(queueActions.setCurrentClimb).toHaveBeenCalledTimes(1);
+    const [committed] = queueActions.setCurrentClimb.mock.calls[0];
+    expect(committed.uuid.startsWith('playlist-peek:')).toBe(false);
+    // Same climb, so the climber puts up what they were looking at.
+    expect(committed.climb.uuid).toBe(CLIMB.uuid);
+  });
+
+  // A session ending is not an exit (amendment A), so the commit row is still
+  // there afterwards — and it has to keep working. What changes is what it can
+  // honestly promise: with the crew gone, no BLE link and a dark wall, "Put on
+  // the wall" would be a lighting this phone cannot do.
+  it('still commits, as a local set-active, after the session ends mid-browse', () => {
+    CREW();
+    const target = openTargetFor(CLIMB);
+    const view = render(drawerElement('member', target));
+    expect(lastActionBarProps().commitLabel).toBe('putOnWall');
+
+    session.isShared = false;
+    session.sessionId = null;
+    view.rerender(drawerElement('member', target));
+
+    expect(lastActionBarProps().commitLabel).toBe('setActive');
+    act(() => {
+      (lastActionBarProps().onCommit as () => void)();
+    });
+    expect(queueActions.setCurrentClimb).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Someone else lit a climb while this climber was browsing. Taking the wall on
+// the next tap would blank a climb another climber may be mid-attempt on, so the
+// first tap asks. The predicate is table-tested in `wall-state.test.ts`; what
+// only a render can see is the bookkeeping around it — the wall-at-latch-start
+// snapshot, and the three (and only three) ways the question stands down.
+describe('PlayDrawer — the busy-wall confirm', () => {
+  const CREW = () => {
+    session.isShared = true;
+    session.sessionId = 'session-1';
+  };
+
+  /** Latch onto a preview against wall A, then let a peer move the wall to B. */
+  function browseThenLoseTheWall() {
+    CREW();
+    wall.uuid = 'wall-climb-a';
+    wall.name = 'What Was Up';
+    const target = openTargetFor(CLIMB);
+    const view = render(drawerElement('member', target));
+
+    wall.uuid = 'wall-climb-b';
+    wall.name = 'Their Project';
+    view.rerender(drawerElement('member', target));
+    return { view, target };
+  }
+
+  it('asks before taking a wall that moved under the climber', () => {
+    browseThenLoseTheWall();
+
+    act(() => {
+      (lastActionBarProps().onCommit as () => void)();
+    });
+
+    expect(lastActionBarProps().showConfirm).toBe(true);
+    expect(lastActionBarProps().wallClimbName).toBe('Their Project');
+    // The whole point: the first tap did NOT take the wall.
+    expect(queueActions.setCurrentClimb).not.toHaveBeenCalled();
+  });
+
+  it('speaks the question, since the bubble that carries it cannot be reached', () => {
+    browseThenLoseTheWall();
+
+    act(() => {
+      (lastActionBarProps().onCommit as () => void)();
+    });
+
+    expect(AccessibilityInfo.announceForAccessibility).toHaveBeenCalledWith('playView.wallState.commitOverride.body');
+  });
+
+  it('commits on the second tap', () => {
+    browseThenLoseTheWall();
+
+    act(() => {
+      (lastActionBarProps().onCommit as () => void)();
+    });
+    act(() => {
+      (lastActionBarProps().onCommit as () => void)();
+    });
+
+    expect(queueActions.setCurrentClimb).toHaveBeenCalledTimes(1);
+    expect(queueActions.setCurrentClimb.mock.calls[0][0].climb.uuid).toBe(CLIMB.uuid);
+  });
+
+  it('does not ask when the wall is still showing what it showed when browsing began', () => {
+    // Nothing happened while the climber was away — asking here would train
+    // people to tap through the question that matters.
+    CREW();
+    wall.uuid = 'wall-climb-a';
+    wall.name = 'What Was Up';
+    render(drawerElement('member', openTargetFor(CLIMB)));
+
+    act(() => {
+      (lastActionBarProps().onCommit as () => void)();
+    });
+
+    expect(lastActionBarProps().showConfirm).toBe(false);
+    expect(queueActions.setCurrentClimb).toHaveBeenCalledTimes(1);
+  });
+
+  // Amendment B: no auto-timeout. These next three are the ONLY ways out.
+  it('stands down on Keep theirs, sending nothing', () => {
+    // A committed head to land back on: "Keep theirs" drops the preview, and
+    // with nothing behind it the drawer would have no climb left to render.
+    session.currentItem = { uuid: 'queue-item-current', climb: SIMILAR_CLIMB };
+    browseThenLoseTheWall();
+    act(() => {
+      (lastActionBarProps().onCommit as () => void)();
+    });
+    expect(lastActionBarProps().showConfirm).toBe(true);
+
+    // "Keep theirs" IS the exit — the row hands it the same handler.
+    act(() => {
+      (lastActionBarProps().onBackToLive as () => void)();
+    });
+
+    expect(lastActionBarProps().showConfirm).toBe(false);
+    expect(queueActions.setCurrentClimb).not.toHaveBeenCalled();
+  });
+
+  it('stands down when the climber browses on', () => {
+    session.nextItem = { uuid: 'queue-item-next', climb: SIMILAR_CLIMB };
+    browseThenLoseTheWall();
+    act(() => {
+      (lastActionBarProps().onCommit as () => void)();
+    });
+    expect(lastActionBarProps().showConfirm).toBe(true);
+
+    // The question was "put THIS up instead of theirs" — and this isn't on
+    // screen any more.
+    act(() => {
+      (lastActionBarProps().onNextClick as () => void)();
+    });
+
+    expect(lastActionBarProps().showConfirm).toBe(false);
+    expect(queueActions.nextClimb).not.toHaveBeenCalled();
+  });
+
+  it('stands down when the conflict resolves itself', () => {
+    const { view, target } = browseThenLoseTheWall();
+    act(() => {
+      (lastActionBarProps().onCommit as () => void)();
+    });
+    expect(lastActionBarProps().showConfirm).toBe(true);
+
+    // The other climber put back what was up when this browse began. There is
+    // no longer anything to take.
+    act(() => {
+      wall.uuid = 'wall-climb-a';
+      wall.name = 'What Was Up';
+      view.rerender(drawerElement('member', target));
+    });
+
+    expect(lastActionBarProps().showConfirm).toBe(false);
+  });
+
+  // The snapshot is taken the moment browsing begins, and at a cold start the
+  // presence feed may not have delivered yet — so it reads null, which is what a
+  // dark wall reads like too. The lighting's own server timestamp is what tells
+  // the two apart.
+  it('does not accuse a peer when the wall read merely arrived late', () => {
+    CREW();
+    const target = openTargetFor(CLIMB);
+    const view = render(drawerElement('member', target));
+
+    // The catch-up lands, carrying the climb that had been lit the whole time.
+    wall.uuid = 'wall-climb-a';
+    wall.name = 'What Was Up';
+    wall.sentAt = new Date(Date.now() - 10 * 60_000).toISOString();
+    view.rerender(drawerElement('member', target));
+
+    act(() => {
+      (lastActionBarProps().onCommit as () => void)();
+    });
+
+    expect(lastActionBarProps().showConfirm).toBe(false);
+    expect(queueActions.setCurrentClimb).toHaveBeenCalledTimes(1);
+  });
+
+  it('still asks when the climb the feed delivers was lit during the browse', () => {
+    CREW();
+    const target = openTargetFor(CLIMB);
+    const view = render(drawerElement('member', target));
+
+    wall.uuid = 'wall-climb-b';
+    wall.name = 'Their Project';
+    wall.sentAt = new Date().toISOString();
+    view.rerender(drawerElement('member', target));
+
+    act(() => {
+      (lastActionBarProps().onCommit as () => void)();
+    });
+
+    expect(lastActionBarProps().showConfirm).toBe(true);
+    expect(queueActions.setCurrentClimb).not.toHaveBeenCalled();
+  });
+
+  it('never asks a solo climber with no latch', () => {
+    // With lighting on and nobody else here, a pinned preview's swipes commit —
+    // there is no browse to have a "before" for, so the commit goes straight
+    // through even though the wall is showing something else.
+    wall.uuid = 'wall-climb-b';
+    wall.name = 'Something Else';
+    render(drawerElement('member', openTargetFor(CLIMB)));
+
+    act(() => {
+      (lastActionBarProps().onCommit as () => void)();
+    });
+
+    expect(lastActionBarProps().showConfirm).toBe(false);
+    expect(queueActions.setCurrentClimb).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Until the drawer read board presence continuously it only knew the wall's
+// climb in one situation — the accessory-bar preview, which arrives already
+// knowing it is the lit one — so "On the wall" could never be said after any
+// other navigation landed on it.
+describe('PlayDrawer — reading the wall', () => {
+  it('says On the wall when presence reports the displayed climb as lit', () => {
+    session.currentItem = { uuid: 'queue-item-current', climb: CLIMB };
+    wall.uuid = CLIMB.uuid;
+    wall.name = CLIMB.name;
+    render(drawerElement('member', committedTargetFor(CLIMB)));
+
+    expect(recorded.wallPill.at(-1)?.state).toBe('onWall');
+    // The same face never twice: the pill owns the driver's avatar in this
+    // state, so the lightbulb's holder pip stands down.
+    expect(lastActionBarProps().showHolderBadge).toBe(false);
+  });
+
+  it('says nothing about a wall lit with a different climb', () => {
+    session.currentItem = { uuid: 'queue-item-current', climb: CLIMB };
+    wall.uuid = 'a-different-climb';
+    wall.name = 'Their Project';
+    render(drawerElement('member', committedTargetFor(CLIMB)));
+
+    expect(recorded.wallPill.at(-1)?.state).not.toBe('onWall');
+    expect(lastActionBarProps().showHolderBadge).toBe(true);
+  });
+});
+
+// The auto-sender is already browse-safe (it keys on the committed queue item),
+// but two paths in the drawer write frames directly off the DISPLAYED climb. Both
+// would put a climb nobody committed on a board that is lit with the live one.
+describe('PlayDrawer — the mirror toggle and the wall', () => {
+  const connectBle = () => {
+    ble.current = { isConnected: true, sendFramesToBoard: vi.fn(async () => true) };
+    return ble.current;
+  };
+
+  it('mirrors a preview on screen only', () => {
+    const bluetooth = connectBle();
+    session.isShared = true;
+    session.sessionId = 'session-1';
+    render(drawerElement('member', openTargetFor(CLIMB)));
+
+    act(() => {
+      (lastActionBarProps().onMirror as () => void)();
+    });
+
+    // The board is showing the LIVE climb; a re-push here would swap it for the
+    // one being browsed, which is the loudest possible reading of "flip the
+    // picture I'm looking at".
+    expect(bluetooth.sendFramesToBoard).not.toHaveBeenCalled();
+    // The drawer still mirrors — a dead toggle would be its own regression.
+    expect(lastActionBarProps().isMirrored).toBe(true);
+  });
+
+  it('still re-pushes the live climb when nothing is pinned', () => {
+    const bluetooth = connectBle();
+    session.currentItem = { uuid: 'queue-item-current', climb: CLIMB };
+    render(drawerElement('member', committedTargetFor(CLIMB)));
+
+    act(() => {
+      (lastActionBarProps().onMirror as () => void)();
+    });
+
+    // The auto-sender keys off the queue item's own `climb.mirrored`, so without
+    // this the LEDs would keep the old orientation.
+    expect(bluetooth.sendFramesToBoard).toHaveBeenCalledWith(CLIMB.frames, true);
+  });
 });
 
 describe('PlayDrawer — the anonymous joins', () => {
@@ -300,6 +1041,7 @@ describe('PlayDrawer — the anonymous joins', () => {
     // It still swaps what the drawer shows — Similar Climbs is the best reason
     // a visitor has to keep looking, so a dead tap would be its own regression.
     expect((recorded.deferredSections.at(-1)?.climb as Climb).uuid).toBe(SIMILAR_CLIMB.uuid);
+    expect(lastDisplayedClimbUuid()).toBe(SIMILAR_CLIMB.uuid);
   });
 
   it('still queues and activates a similar climb for a member', async () => {
@@ -397,5 +1139,87 @@ describe('PlayDrawer — the anonymous joins', () => {
     // shows the placeholder for one frame — a lie on a surface the visitor
     // reached by following a link to one specific climb.
     expect(recorded.panePlaceholder).toBe(0);
+  });
+});
+
+// A pinned preview silences the wall: it is what `useMobilePlayback`'s `viewOnly`
+// and the mirror re-push both gate on, and — with a suggestion source alongside
+// it — what makes every onward swipe view-only regardless of `lightOnSwipe`. So
+// how a preview ENDS is a wall-control question, and the angle change is the one
+// exit a climber can reach without knowing the browse chrome exists. #4683
+// removed it and solo climbers reported the board lighting only sometimes.
+describe('PlayDrawer — an angle change and the pinned preview', () => {
+  const SUGGESTION_SOURCE = {
+    playlistUuid: 'list-1',
+    activatedClimbUuid: CLIMB.uuid,
+    boardKey: 'kilter:1:10:1,20',
+    climbs: [CLIMB, SIMILAR_CLIMB],
+  } as unknown as Props;
+
+  /** A preview WITH a track — the shape whose swipes stay view-only on their own. */
+  function trackedTargetFor(climb: Climb) {
+    return {
+      climb,
+      options: {
+        previewQueueItem: { uuid: 'queue-item-uuid', climb },
+        playlistSuggestionSource: SUGGESTION_SOURCE,
+      },
+      nonce: 1,
+    } as unknown as ReturnType<typeof openTargetFor>;
+  }
+
+  function elementAtAngle(angle: number, openTarget: ReturnType<typeof trackedTargetFor>) {
+    return createElement(PlayDrawer, {
+      presentation: 'pane' as const,
+      viewer: 'member' as const,
+      boardConfig: { ...BOARD_CONFIG, angle },
+      openTarget,
+      onOpenQueue: vi.fn(),
+    });
+  }
+
+  it('drops a solo preview when the angle moves, so the next swipe drives the wall', () => {
+    // A committed head to fall back to once the preview goes.
+    session.currentItem = { uuid: 'queue-item-current', climb: SIMILAR_CLIMB };
+    // Same target object across both renders, so re-rendering doesn't re-run the
+    // open effect and re-pin the preview from underneath the case.
+    const target = trackedTargetFor(CLIMB);
+    const view = render(elementAtAngle(40, target));
+
+    // Preview + track: view-only, even though this climber never turned
+    // `lightOnSwipe` off. The board stays on the committed climb.
+    act(() => {
+      (lastActionBarProps().onNextClick as () => void)();
+    });
+    expect(queueActions.nextClimb).not.toHaveBeenCalled();
+
+    view.rerender(elementAtAngle(45, target));
+
+    // The angle moved and nobody is browsing with this climber, so the drawer is
+    // back on the live climb and ordinary wall control returns.
+    act(() => {
+      (lastActionBarProps().onNextClick as () => void)();
+    });
+    expect(queueActions.nextClimb).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a crew preview across an angle change', () => {
+    // The other half of the rule: in a crew the preview IS where the climber is
+    // living, and one tap on the angle pill must not throw away the climb they
+    // were looking at or the track they were walking.
+    session.isShared = true;
+    session.sessionId = 'session-1';
+    session.currentItem = { uuid: 'queue-item-current', climb: SIMILAR_CLIMB };
+    const target = trackedTargetFor(CLIMB);
+    const view = render(elementAtAngle(40, target));
+    expect(lastActionBarProps().secondaryMode).toBe('commit');
+
+    view.rerender(elementAtAngle(45, target));
+
+    expect(lastActionBarProps().secondaryMode).toBe('commit');
+    act(() => {
+      (lastActionBarProps().onNextClick as () => void)();
+    });
+    expect(queueActions.nextClimb).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-anonymous.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-anonymous.test.tsx
@@ -41,6 +41,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, act } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import type { Climb } from '@boardsesh/shared-schema';
+import type { PlaylistSuggestionSource } from '@boardsesh/queue';
 
 type Props = Record<string, unknown>;
 
@@ -65,6 +66,8 @@ const queueActions = vi.hoisted(() => ({
 // ending" is exercised at all.
 const session = vi.hoisted(() => ({
   isShared: false,
+  useRealNavigation: false,
+  suggestionSource: null as PlaylistSuggestionSource | null,
   sessionId: null as string | null,
   nextItem: null as { uuid: string; climb: unknown } | null,
   // The committed queue head. Null in the preview-only cases (the drawer renders
@@ -87,7 +90,13 @@ const wall = vi.hoisted(() => ({
 // The BLE link. Null (no transport) unless a case needs to watch what does and
 // doesn't reach the board.
 const ble = vi.hoisted(() => ({
-  current: null as { isConnected: boolean; sendFramesToBoard: ReturnType<typeof vi.fn> } | null,
+  current: null as {
+    isConnected: boolean;
+    sendFramesToBoard: ReturnType<typeof vi.fn>;
+    getMirrorIntent: ReturnType<typeof vi.fn>;
+    setMirrorIntent: ReturnType<typeof vi.fn>;
+    retainMirrorIntentFor: ReturnType<typeof vi.fn>;
+  } | null,
 }));
 
 // --- Host platform -----------------------------------------------------------
@@ -131,18 +140,26 @@ vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => k
 vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0, bottom: 0 }) }));
 
 // --- Shared packages ---------------------------------------------------------
-vi.mock('@boardsesh/play-view', () => ({
-  // The prefetch walk: these suites assert on the displayed board, not on
-  // what is warmed ahead, so nothing is ahead.
-  findUpcomingQueueItemsWithSuggestions: () => [],
-  computeNavigationStateWithSuggestions: () => ({
-    nextItem: session.nextItem,
-    prevItem: null,
-    canNext: session.nextItem != null,
-    canPrevious: false,
-  }),
-  boardSupportsMirroring: () => true,
-}));
+vi.mock('@boardsesh/play-view', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@boardsesh/play-view')>();
+  return {
+    // The prefetch walk: these suites assert on the displayed board, not on
+    // what is warmed ahead, so nothing is ahead.
+    findUpcomingQueueItemsWithSuggestions: () => [],
+    computeNavigationStateWithSuggestions: (
+      ...args: Parameters<typeof actual.computeNavigationStateWithSuggestions>
+    ) =>
+      session.useRealNavigation
+        ? actual.computeNavigationStateWithSuggestions(...args)
+        : {
+            nextItem: session.nextItem,
+            prevItem: null,
+            canNext: session.nextItem != null,
+            canPrevious: false,
+          },
+    boardSupportsMirroring: () => true,
+  };
+});
 vi.mock('@boardsesh/analytics', () => ({
   SHARED_EVENTS: {
     ClimbShared: 'Climb Shared',
@@ -218,7 +235,7 @@ vi.mock('../../../providers/queue-provider', () => ({
   useQueueActions: () => queueActions,
   useQueueSessionId: () => ({ sessionId: session.sessionId }),
   useIsSharedSession: () => session.isShared,
-  usePlaylistSuggestionSource: () => null,
+  usePlaylistSuggestionSource: () => session.suggestionSource,
 }));
 vi.mock('../../../providers/bluetooth-provider', () => ({ useOptionalBluetoothContext: () => ble.current }));
 // Board presence, read continuously so the pill can say "On the wall" after any
@@ -353,6 +370,8 @@ beforeEach(() => {
   recorded.panePlaceholder = 0;
   queueActions.addToQueue.mockResolvedValue('added');
   session.isShared = false;
+  session.useRealNavigation = false;
+  session.suggestionSource = null;
   session.sessionId = null;
   session.nextItem = null;
   session.currentItem = null;
@@ -403,6 +422,90 @@ describe('PlayDrawer — the shared-session browse latch', () => {
     expect(queueActions.nextClimb).not.toHaveBeenCalled();
     expect(lastDisplayedClimbUuid()).toBe(SIMILAR_CLIMB.uuid);
   });
+
+  it.each(['next', 'previous'] as const)(
+    'keeps the playlist after browsing %s and a peer leaves its track',
+    (direction) => {
+      CREW();
+      session.useRealNavigation = true;
+      const thirdClimb = { ...CLIMB, uuid: 'third-climb', name: 'Third climb' };
+      const climbs = direction === 'next' ? [CLIMB, SIMILAR_CLIMB, thirdClimb] : [thirdClimb, SIMILAR_CLIMB, CLIMB];
+      session.suggestionSource = {
+        playlistUuid: 'list-1',
+        activatedClimbUuid: CLIMB.uuid,
+        boardKey: 'kilter:1:10:1,20',
+        climbs,
+      } as unknown as PlaylistSuggestionSource;
+      session.currentItem = { uuid: 'queue-current', climb: CLIMB };
+      const target = committedTargetFor(CLIMB);
+      const view = render(drawerElement('member', target));
+      const swipe = () => {
+        const props = lastActionBarProps();
+        (props[direction === 'next' ? 'onNextClick' : 'onPrevClick'] as () => void)();
+      };
+      act(swipe);
+      expect(lastDisplayedClimbUuid()).toBe(SIMILAR_CLIMB.uuid);
+
+      // The provider clears its shared track when a peer commits outside it.
+      session.currentItem = { uuid: 'peer-current', climb: { ...CLIMB, uuid: 'outside-list' } };
+      session.suggestionSource = null;
+      view.rerender(drawerElement('member', target));
+      act(swipe);
+
+      expect(lastDisplayedClimbUuid()).toBe(thirdClimb.uuid);
+      expect(queueActions.nextClimb).not.toHaveBeenCalled();
+      expect(queueActions.previousClimb).not.toHaveBeenCalled();
+      expect(queueActions.setCurrentClimb).not.toHaveBeenCalled();
+      expect(queueActions.addToQueue).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([false, true])(
+    'releases only a crew-captured track after departure (explicit preview: %s)',
+    (explicitPreview) => {
+      vi.useFakeTimers();
+      try {
+        CREW();
+        session.useRealNavigation = true;
+        const thirdClimb = { ...CLIMB, uuid: 'third-climb' };
+        const source = {
+          playlistUuid: 'list-1',
+          activatedClimbUuid: CLIMB.uuid,
+          boardKey: 'kilter:1:10:1,20',
+          climbs: [CLIMB, SIMILAR_CLIMB, thirdClimb],
+        } as unknown as PlaylistSuggestionSource;
+        session.suggestionSource = source;
+        session.currentItem = { uuid: 'queue-current', climb: CLIMB };
+        const target = explicitPreview
+          ? { ...openTargetFor(CLIMB), options: { ...openTargetFor(CLIMB).options, playlistSuggestionSource: source } }
+          : committedTargetFor(CLIMB);
+        const view = render(drawerElement('member', target));
+        act(() => {
+          (lastActionBarProps().onNextClick as () => void)();
+        });
+        expect(lastDisplayedClimbUuid()).toBe(SIMILAR_CLIMB.uuid);
+
+        session.isShared = false;
+        session.sessionId = null;
+        view.rerender(drawerElement('member', target));
+        act(() => {
+          vi.advanceTimersByTime(SHARED_BROWSE_LATCH_RELEASE_MS);
+        });
+        act(() => {
+          (lastActionBarProps().onNextClick as () => void)();
+        });
+
+        if (explicitPreview) {
+          expect(lastDisplayedClimbUuid()).toBe(thirdClimb.uuid);
+          expect(queueActions.nextClimb).not.toHaveBeenCalled();
+        } else {
+          expect(queueActions.nextClimb).toHaveBeenCalledOnce();
+        }
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it('previews a similar climb instead of double-writing it', () => {
     CREW();
@@ -995,7 +1098,13 @@ describe('PlayDrawer — reading the wall', () => {
 // would put a climb nobody committed on a board that is lit with the live one.
 describe('PlayDrawer — the mirror toggle and the wall', () => {
   const connectBle = () => {
-    ble.current = { isConnected: true, sendFramesToBoard: vi.fn(async () => true) };
+    ble.current = {
+      isConnected: true,
+      sendFramesToBoard: vi.fn(async () => true),
+      getMirrorIntent: vi.fn(),
+      setMirrorIntent: vi.fn(),
+      retainMirrorIntentFor: vi.fn(),
+    };
     return ble.current;
   };
 
@@ -1043,7 +1152,7 @@ describe('PlayDrawer — the mirror toggle and the wall', () => {
     expect(lastActionBarProps().isMirrored).toBe(false);
   });
 
-  it('still re-pushes the live climb when nothing is pinned', () => {
+  it('still states the live mirror intent when nothing is pinned', () => {
     const bluetooth = connectBle();
     session.currentItem = { uuid: 'queue-item-current', climb: CLIMB };
     render(drawerElement('member', committedTargetFor(CLIMB)));
@@ -1052,9 +1161,8 @@ describe('PlayDrawer — the mirror toggle and the wall', () => {
       (lastActionBarProps().onMirror as () => void)();
     });
 
-    // The auto-sender keys off the queue item's own `climb.mirrored`, so without
-    // this the LEDs would keep the old orientation.
-    expect(bluetooth.sendFramesToBoard).toHaveBeenCalledWith(CLIMB.frames, true);
+    // The provider owns the write and reads the explicit solo mirror intent.
+    expect(bluetooth.setMirrorIntent).toHaveBeenCalledWith(CLIMB.uuid, true);
   });
 });
 

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-anonymous.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-anonymous.test.tsx
@@ -74,6 +74,9 @@ const session = vi.hoisted(() => ({
 // What board presence says is physically lit. Mutated between renders so a case
 // can move the wall UNDER a browsing climber — which is the whole premise of the
 // busy-wall confirm.
+// The lightbulb's own signal — this device's BLE link, or a session member's.
+// `resolveWallPillState` / `resolveCommitBarModel` read it as `wallDriven`.
+const lightbulb = vi.hoisted(() => ({ lit: false }));
 const wall = vi.hoisted(() => ({
   uuid: null as string | null,
   name: null as string | null,
@@ -245,7 +248,7 @@ vi.mock('../use-drawer-dismiss-gesture', () => ({
 }));
 vi.mock('../use-play-drawer-wake-lock', () => ({ usePlayDrawerWakeLock: () => undefined }));
 vi.mock('../../ble/use-lightbulb-control', () => ({
-  useLightbulbControl: () => ({ lit: false, localConnected: false, pending: false, onPress: vi.fn() }),
+  useLightbulbControl: () => ({ lit: lightbulb.lit, localConnected: false, pending: false, onPress: vi.fn() }),
 }));
 vi.mock('../copy-climb-name', () => ({ copyClimbName: vi.fn() }));
 vi.mock('../../../lib/haptics', () => ({ hapticSuccess: vi.fn() }));
@@ -354,6 +357,7 @@ beforeEach(() => {
   session.nextItem = null;
   session.currentItem = null;
   wall.uuid = null;
+  lightbulb.lit = false;
   wall.name = null;
   wall.sentAt = null;
   ble.current = null;
@@ -719,16 +723,20 @@ describe('PlayDrawer — the shared-session browse latch', () => {
 
   // A session ending is not an exit (amendment A), so the commit row is still
   // there afterwards — and it has to keep working. What changes is what it can
-  // honestly promise: with the crew gone, no BLE link and a dark wall, "Put on
-  // the wall" would be a lighting this phone cannot do.
+  // honestly promise: while a crew member drives a wall the button offers to put
+  // the climb on it; with the crew gone, no BLE link and a dark wall, "Put on
+  // the wall" would be a lighting this phone cannot do (#4872: the label follows
+  // `wallDriven`, never the bare fact of a session).
   it('still commits, as a local set-active, after the session ends mid-browse', () => {
     CREW();
+    lightbulb.lit = true;
     const target = openTargetFor(CLIMB);
     const view = render(drawerElement('member', target));
     expect(lastActionBarProps().commitLabel).toBe('putOnWall');
 
     session.isShared = false;
     session.sessionId = null;
+    lightbulb.lit = false;
     view.rerender(drawerElement('member', target));
 
     expect(lastActionBarProps().commitLabel).toBe('setActive');
@@ -775,6 +783,29 @@ describe('PlayDrawer — the busy-wall confirm', () => {
     expect(lastActionBarProps().wallClimbName).toBe('Their Project');
     // The whole point: the first tap did NOT take the wall.
     expect(queueActions.setCurrentClimb).not.toHaveBeenCalled();
+  });
+
+  // "Someone just lit X" needs a someone. A solo climber with `lightOnSwipe` off
+  // is latched too, and the one way their wall moves under a preview is their own
+  // lightbulb tap — so the question is never asked of them.
+  it('never asks a solo climber to confirm over their own lighting', () => {
+    setSetting('lightOnSwipe', false);
+    wall.uuid = null;
+    const target = openTargetFor(CLIMB);
+    const view = render(drawerElement('member', target));
+    expect(lastActionBarProps().showConfirm).toBe(false);
+
+    // Their own auto-sender lights the queue head mid-preview.
+    wall.uuid = 'wall-climb-head';
+    wall.name = 'My Own Climb';
+    view.rerender(drawerElement('member', target));
+
+    act(() => {
+      (lastActionBarProps().onCommit as () => void)();
+    });
+
+    expect(lastActionBarProps().showConfirm).toBe(false);
+    expect(queueActions.setCurrentClimb).toHaveBeenCalledTimes(1);
   });
 
   it('speaks the question, since the bubble that carries it cannot be reached', () => {
@@ -984,6 +1015,32 @@ describe('PlayDrawer — the mirror toggle and the wall', () => {
     expect(bluetooth.sendFramesToBoard).not.toHaveBeenCalled();
     // The drawer still mirrors — a dead toggle would be its own regression.
     expect(lastActionBarProps().isMirrored).toBe(true);
+  });
+
+  // The commit lights the queue item's own `climb.mirrored` (the auto-sender's
+  // key), never the drawer's toggle. Left set, the toggle would keep the drawer
+  // flipped while the wall came up straight — the one navigation that did not
+  // reset drawer-local mirroring.
+  it('drops a preview mirror on commit so the drawer matches the wall', () => {
+    connectBle();
+    session.isShared = true;
+    session.sessionId = 'session-1';
+    // The live climb the preview sits over; the drawer falls back to it once the
+    // preview clears, which is the render the assertion below reads.
+    session.currentItem = { uuid: 'queue-item-current', climb: SIMILAR_CLIMB };
+    render(drawerElement('member', openTargetFor(CLIMB)));
+
+    act(() => {
+      (lastActionBarProps().onMirror as () => void)();
+    });
+    expect(lastActionBarProps().isMirrored).toBe(true);
+
+    act(() => {
+      (lastActionBarProps().onCommit as () => void)();
+    });
+
+    expect(queueActions.setCurrentClimb).toHaveBeenCalledTimes(1);
+    expect(lastActionBarProps().isMirrored).toBe(false);
   });
 
   it('still re-pushes the live climb when nothing is pinned', () => {

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-commit-bar.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-commit-bar.test.tsx
@@ -2,6 +2,12 @@
 // The commit row's job is to never over-promise: the filled button says "Put on
 // the wall" only where a wall can actually be reached, and it disappears rather
 // than sitting there disabled when there is nothing to commit.
+//
+// The busy-wall confirm is the same row wearing different words. What the tests
+// below pin is that it stays the SAME TWO CONTROLS in the same two positions —
+// the filled button is still the commit, the text button is still the exit — so
+// a climber whose thumb is already moving toward "Put on the wall" cannot land
+// on a new action that appeared under it.
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
@@ -18,52 +24,92 @@ type PressMockProps = {
 const resolveStyle = (style: unknown) => (typeof style === 'function' ? style({ pressed: false }) : style);
 
 vi.mock('react-native', () => ({
-  View: ({ children }: ViewMockProps) => createElement('div', null, children),
+  // Forwards the live region: it lives on a plain View that outlives the
+  // question, which is what makes arming the confirm a content change Android
+  // will actually announce.
+  View: ({ children, accessibilityLiveRegion, pointerEvents }: ViewMockProps & AnimatedViewMockProps) =>
+    createElement(
+      'div',
+      { 'data-live-region': accessibilityLiveRegion, 'data-pointer-events': pointerEvents },
+      children,
+    ),
   Pressable: ({ children, onPress, accessibilityLabel, style }: PressMockProps) =>
     createElement(
       'button',
       { onClick: onPress, 'data-label': accessibilityLabel, 'data-style': JSON.stringify(resolveStyle(style) ?? null) },
       children,
     ),
-  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
 }));
 
 vi.mock('react-native-reanimated', () => ({
-  default: { View: ({ children }: ViewMockProps) => createElement('div', null, children) },
+  default: {
+    View: ({ children }: ViewMockProps) => createElement('div', { 'data-animated': 'true' }, children),
+  },
   FadeIn: { duration: (ms: number) => ({ fadeIn: ms }) },
   useReducedMotion: () => false,
 }));
 
-vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    // Renders the interpolation so the confirm's "Someone just lit {{name}}"
+    // can be asserted to actually carry the wall climb's name.
+    t: (key: string, params?: Record<string, string>) => (params?.name != null ? `${key}:${params.name}` : key),
+  }),
+}));
 
 vi.mock('../../Text', () => ({
   Text: ({ children, color }: { children?: ReactNode; color?: string }) =>
     createElement('span', { 'data-color': color }, children),
 }));
+vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }) }));
 vi.mock('../../drawer-action-bar/DrawerActionBar', () => ({
   drawerActionBarStyles: { spacer: { flex: 1 }, actionButtonPressed: { opacity: 0.6 } },
 }));
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
-    brandColors: { tint: '#6D28D9', primaryFill: '#6D28D9', onPrimary: '#FFFFFF' },
+    variant: 'liquidGlass',
+    brandColors: { tint: '#6D28D9', primaryFill: '#6D28D9', onPrimary: '#FFFFFF', live: '#FFB020' },
+    systemColors: { label: '#111111', elevatedSurface: '#FFFFFF' },
+    m3SurfaceContainers: { high: '#EEE8F6' },
+    materialElevation: { level2: { elevation: 2 } },
     radii: { button: 10 },
   }),
 }));
 vi.mock('../../../theme/tokens', () => ({
-  spacing: { 2: 8, 5: 20 },
+  spacing: { 1: 4, 2: 8, 3: 12, 5: 20 },
+  borderRadius: { md: 8 },
+  shadows: { sm: { shadowRadius: 2 } },
   androidRipple: (color: string) => ({ color, borderless: false }),
+}));
+vi.mock('../../../theme/colors', () => ({ withAlpha: (color: string, alpha: number) => `${color}/${alpha}` }));
+vi.mock('../../../theme/variants/select-by-variant', () => ({
+  selectByVariant: (variant: string, byVariant: Record<string, unknown>) => byVariant[variant],
 }));
 vi.mock('../../../theme/typography', () => ({ CHROME_LABEL_MAX_FONT_SCALE: 1.2 }));
 vi.mock('../../../theme/layout', () => ({ glassSize: { inline: 44 } }));
 
 import { PlayDrawerCommitBar } from '../PlayDrawerCommitBar';
 
+type AnimatedViewMockProps = { accessibilityLiveRegion?: string; pointerEvents?: string };
+
 const baseProps = {
   showBackToLive: true,
   showPutOnWall: true,
+  showConfirm: false,
+  wallClimbName: null,
   commitLabel: 'putOnWall' as const,
   onBackToLive: vi.fn(),
   onCommit: vi.fn(),
+};
+
+/** What the confirm swap hands the row: both browse flags off, the pair on. */
+const confirmProps = {
+  ...baseProps,
+  showBackToLive: false,
+  showPutOnWall: false,
+  showConfirm: true,
+  wallClimbName: 'Their Project',
 };
 
 const buttonLabels = (container: HTMLElement) =>
@@ -126,5 +172,74 @@ describe('PlayDrawerCommitBar', () => {
     const back = container.querySelector('[data-label="playView.wallState.backToLive"]') as HTMLElement;
     expect(back.getAttribute('data-style')).not.toContain('backgroundColor');
     expect(back.querySelector('span[data-color="#6D28D9"]')).toBeTruthy();
+  });
+});
+
+describe('PlayDrawerCommitBar — the busy-wall confirm', () => {
+  it('swaps the same two controls in place, keeping the commit trailing', () => {
+    // Position is the whole contract: a thumb already travelling toward "Put on
+    // the wall" must not land on "Keep theirs" because the pair reordered.
+    const { container } = render(createElement(PlayDrawerCommitBar, confirmProps));
+
+    expect(buttonLabels(container)).toEqual([
+      'playView.wallState.commitOverride.cancel',
+      'playView.wallState.commitOverride.confirm',
+    ]);
+  });
+
+  it('names the climb the wall is showing in the question', () => {
+    const { container } = render(createElement(PlayDrawerCommitBar, confirmProps));
+
+    expect(container.textContent).toContain('playView.wallState.commitOverride.body:Their Project');
+  });
+
+  it('floats the question untouchable, with a polite live region for TalkBack', () => {
+    // The bubble is the one piece of the confirm that isn't a control: it must
+    // not eat a tap meant for the buttons underneath, and — since it can't be
+    // reached by touch — the live region is how Android hears it at all.
+    const { container } = render(createElement(PlayDrawerCommitBar, confirmProps));
+    const region = container.querySelector('[data-live-region="polite"]') as HTMLElement;
+
+    expect(region).toBeTruthy();
+    expect(region.getAttribute('data-pointer-events')).toBe('none');
+    expect(region.querySelector('[data-icon="warning"]')).toBeTruthy();
+  });
+
+  it('routes the second tap to the same commit handler', () => {
+    // The first tap is what armed this, so "Put mine up" is not a new action —
+    // it is the commit going through. A separate handler here would be a second
+    // path to the wall that the arming ladder does not gate.
+    const onCommit = vi.fn();
+    const onBackToLive = vi.fn();
+    const { container } = render(createElement(PlayDrawerCommitBar, { ...confirmProps, onCommit, onBackToLive }));
+
+    (container.querySelector('[data-label="playView.wallState.commitOverride.confirm"]') as HTMLButtonElement).click();
+
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onBackToLive).not.toHaveBeenCalled();
+  });
+
+  it('routes Keep theirs to the exit — leaving their climb up IS going back to live', () => {
+    const onCommit = vi.fn();
+    const onBackToLive = vi.fn();
+    const { container } = render(createElement(PlayDrawerCommitBar, { ...confirmProps, onCommit, onBackToLive }));
+
+    (container.querySelector('[data-label="playView.wallState.commitOverride.cancel"]') as HTMLButtonElement).click();
+
+    expect(onBackToLive).toHaveBeenCalledTimes(1);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('shows no bubble while browsing — but keeps the live region waiting for it', () => {
+    // The region has to pre-exist the question: Android announces a CHANGE inside
+    // a live region, and a region that arrives already carrying its sentence is
+    // not a change. So the empty region stays mounted, and only the bubble comes
+    // and goes.
+    const { container } = render(createElement(PlayDrawerCommitBar, baseProps));
+    const region = container.querySelector('[data-live-region="polite"]') as HTMLElement;
+
+    expect(region).toBeTruthy();
+    expect(region.textContent).toBe('');
+    expect(container.querySelector('[data-icon="warning"]')).toBeNull();
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-cross-board.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-cross-board.test.tsx
@@ -176,12 +176,18 @@ vi.mock('../../../providers/queue-provider', () => ({
     addToQueue: vi.fn(async () => 'added'),
   }),
   useQueueSessionId: () => ({ sessionId: null }),
+  // Solo for every case here: the crew gate is off, so gestures commit as they
+  // always have and the board question stays the only variable.
+  useIsSharedSession: () => false,
   usePlaylistSuggestionSource: () => null,
 }));
 vi.mock('../../../providers/bluetooth-provider', () => ({ useOptionalBluetoothContext: () => null }));
 vi.mock('../../../providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
 vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
 vi.mock('../../../lib/graphql/hooks', () => ({
+  // The preview angle re-anchor asks for the climb at the live angle; nothing
+  // here pins a preview at another angle, so it never resolves.
+  useClimb: () => ({ data: undefined }),
   useToggleFavorite: () => ({ mutate: vi.fn() }),
   useFavoriteStatus: (boardName: string, uuid: string | null, angle: number) => {
     recorded.favoriteStatus.push({ boardName, uuid, angle });
@@ -204,6 +210,9 @@ vi.mock('../use-drawer-dismiss-gesture', () => ({
   useDrawerDismissGesture: () => ({ gesture: { enabled: () => ({}) }, translateY: { value: 0 } }),
 }));
 vi.mock('../use-play-drawer-wake-lock', () => ({ usePlayDrawerWakeLock: () => undefined }));
+// The lit-climb read reaches board presence → the ws client → secure storage;
+// none of that is under test here, and the wall is dark for every case.
+vi.mock('../use-wall-climb', () => ({ useWallClimb: () => ({ uuid: null, name: null, sentAt: null }) }));
 vi.mock('../../ble/use-lightbulb-control', () => ({
   useLightbulbControl: (options: { canRelay?: boolean; onRelayToHolder?: () => void }) => {
     recorded.lightbulb.push(options);

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-navigation.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-navigation.test.ts
@@ -162,6 +162,46 @@ describe('getSwipeNavigationTarget', () => {
       }),
     ).toEqual({ viewOnly: true, targetItem: nextItem });
   });
+
+  // The shared-session half. With a crew present a swipe writes the queue
+  // EVERYONE reads and moves the wall someone may be mid-attempt on, so browsing
+  // must not cost that — regardless of the climber's own lighting setting, which
+  // is about their board, not about the crew's.
+  it('goes view-only in a shared session even with lightOnSwipe on and no preview', () => {
+    const nextItem = makeItem('next');
+    expect(
+      getSwipeNavigationTarget({
+        previewItem: null,
+        previewSuggestionSource: null,
+        targetItem: nextItem,
+        lightOnSwipe: true,
+        inSharedSession: true,
+      }),
+    ).toEqual({ viewOnly: true, targetItem: nextItem });
+  });
+
+  it('leaves a solo swipe live when the shared-session flag is off', () => {
+    expect(
+      getSwipeNavigationTarget({
+        previewItem: null,
+        previewSuggestionSource: null,
+        targetItem: makeItem('next'),
+        lightOnSwipe: true,
+        inSharedSession: false,
+      }),
+    ).toEqual({ viewOnly: false });
+  });
+
+  it('defaults inSharedSession to false, so solo call sites read unchanged', () => {
+    expect(
+      getSwipeNavigationTarget({
+        previewItem: null,
+        previewSuggestionSource: null,
+        targetItem: makeItem('next'),
+        lightOnSwipe: true,
+      }),
+    ).toEqual({ viewOnly: false });
+  });
 });
 
 // What the wall-state chrome is allowed to claim. The pill ("Browsing"), the
@@ -197,20 +237,49 @@ describe('swipeStaysViewOnly', () => {
     ).toBe(true);
   });
 
+  it('is true in a shared session, whatever the lighting setting says', () => {
+    const currentItem = makeItem('current');
+
+    // The one combination that used to commit — a pinned preview, no suggestion
+    // source, lighting on — and the bare committed state before any preview
+    // exists. Both browse once there is an audience.
+    expect(
+      swipeStaysViewOnly({
+        previewItem: currentItem,
+        previewSuggestionSource: null,
+        lightOnSwipe: true,
+        inSharedSession: true,
+      }),
+    ).toBe(true);
+    expect(
+      swipeStaysViewOnly({
+        previewItem: null,
+        previewSuggestionSource: null,
+        lightOnSwipe: true,
+        inSharedSession: true,
+      }),
+    ).toBe(true);
+  });
+
   it('agrees with the swipe handlers it is derived from, whatever the target', () => {
     const currentItem = makeItem('current');
     const nextItem = makeItem('next');
 
     for (const lightOnSwipe of [true, false]) {
-      for (const previewSuggestionSource of [null, makePreviewSource(currentItem)]) {
-        expect(swipeStaysViewOnly({ previewItem: currentItem, previewSuggestionSource, lightOnSwipe })).toBe(
-          getSwipeNavigationTarget({
-            previewItem: currentItem,
-            previewSuggestionSource,
-            targetItem: nextItem,
-            lightOnSwipe,
-          }).viewOnly,
-        );
+      for (const inSharedSession of [true, false]) {
+        for (const previewSuggestionSource of [null, makePreviewSource(currentItem)]) {
+          expect(
+            swipeStaysViewOnly({ previewItem: currentItem, previewSuggestionSource, lightOnSwipe, inSharedSession }),
+          ).toBe(
+            getSwipeNavigationTarget({
+              previewItem: currentItem,
+              previewSuggestionSource,
+              targetItem: nextItem,
+              lightOnSwipe,
+              inSharedSession,
+            }).viewOnly,
+          );
+        }
       }
     }
   });
@@ -230,5 +299,22 @@ describe('getSimilarClimbTapMode', () => {
   // the back door into the same behaviour.
   it('only swaps the preview for a signed-out reader — no queue write, no BLE re-arm', () => {
     expect(getSimilarClimbTapMode('anonymous')).toBe('preview');
+  });
+
+  // The member branch writes TWICE — appends to the queue AND takes the wall —
+  // which in a crew is the loudest possible outcome for the idlest possible
+  // intent: glancing at a "you might also like" card.
+  it('previews instead of double-writing when a member is in a crew', () => {
+    expect(getSimilarClimbTapMode('member', { inSharedSession: true })).toBe('preview');
+  });
+
+  it('keeps the solo member on the queue path', () => {
+    expect(getSimilarClimbTapMode('member', { inSharedSession: false })).toBe('queue');
+    expect(getSimilarClimbTapMode('member', {})).toBe('queue');
+  });
+
+  it('leaves the signed-out reader on the preview path either way', () => {
+    expect(getSimilarClimbTapMode('anonymous', { inSharedSession: true })).toBe('preview');
+    expect(getSimilarClimbTapMode('anonymous', { inSharedSession: false })).toBe('preview');
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/preview-angle-anchor.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/preview-angle-anchor.test.ts
@@ -1,0 +1,115 @@
+// Reaching for the angle pill mid-browse used to cost the climber the climb they
+// were looking at: the drawer dropped its pinned preview and fell back to the
+// queue head. These pin the re-anchor that replaced that — same climb, same
+// item uuid (the drawer's navigation anchor), grade re-resolved at the new angle.
+import { describe, expect, it } from 'vitest';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { Climb } from '@boardsesh/shared-schema';
+import { previewNeedsAngleReanchor, reanchorPreviewAtAngle } from '../preview-angle-anchor';
+
+function makeItem(climbUuid: string, angle: number | null): ClimbQueueItem {
+  return {
+    uuid: 'queue-item-1',
+    suggested: true,
+    climb: {
+      uuid: climbUuid,
+      name: 'Crimpy Thing',
+      frames: 'p1145r15',
+      angle,
+      difficulty: 'V4',
+      quality_average: '3.0',
+      ascensionist_count: 12,
+      benchmark_difficulty: 'V5',
+      difficulty_error: '0.4',
+      boardseshDifficulty: 17,
+      boardseshConfidence: 'high',
+    },
+  } as unknown as ClimbQueueItem;
+}
+
+function makeClimbAtAngle(uuid: string, overrides: Partial<Climb> = {}): Climb {
+  return {
+    uuid,
+    name: 'Crimpy Thing',
+    frames: 'p1145r15',
+    angle: 50,
+    difficulty: 'V6',
+    quality_average: '3.6',
+    ascensionist_count: 40,
+    benchmark_difficulty: null,
+    difficulty_error: '0.2',
+    boardseshDifficulty: 21,
+    boardseshConfidence: 'medium',
+    ...overrides,
+  } as unknown as Climb;
+}
+
+describe('previewNeedsAngleReanchor', () => {
+  it('is true only when the pinned grade belongs to a different angle', () => {
+    expect(previewNeedsAngleReanchor(makeItem('climb-a', 40), 50)).toBe(true);
+    expect(previewNeedsAngleReanchor(makeItem('climb-a', 50), 50)).toBe(false);
+  });
+
+  it('leaves an angle-less climb alone rather than fetching on a guess', () => {
+    // A request per render is the failure mode this guard exists for.
+    expect(previewNeedsAngleReanchor(makeItem('climb-a', null), 50)).toBe(false);
+    expect(previewNeedsAngleReanchor(null, 50)).toBe(false);
+  });
+});
+
+describe('reanchorPreviewAtAngle', () => {
+  it('patches the angle-specific fields and keeps the item uuid', () => {
+    const item = makeItem('climb-a', 40);
+    const reanchored = reanchorPreviewAtAngle(item, 50, makeClimbAtAngle('climb-a'));
+
+    // The uuid is the drawer's navigation anchor — prev/next and the remaining
+    // count are computed against it, so minting a fresh one would break both.
+    expect(reanchored?.uuid).toBe('queue-item-1');
+    expect(reanchored?.suggested).toBe(true);
+    expect(reanchored?.climb.angle).toBe(50);
+    expect(reanchored?.climb.difficulty).toBe('V6');
+    expect(reanchored?.climb.quality_average).toBe('3.6');
+    expect(reanchored?.climb.ascensionist_count).toBe(40);
+    expect(reanchored?.climb.difficulty_error).toBe('0.2');
+    // Nothing angle-specific about the name or the holds; they ride through.
+    expect(reanchored?.climb.name).toBe('Crimpy Thing');
+    expect(reanchored?.climb.frames).toBe('p1145r15');
+  });
+
+  it('clears a benchmark and a Boardsesh grade the new angle does not have', () => {
+    // Explicit nulls, not omissions: carrying the previous angle's benchmark over
+    // would put a grade on screen that nobody ever climbed at this angle.
+    const reanchored = reanchorPreviewAtAngle(
+      makeItem('climb-a', 40),
+      50,
+      makeClimbAtAngle('climb-a', {
+        benchmark_difficulty: null,
+        boardseshDifficulty: null,
+        boardseshConfidence: null,
+      } as Partial<Climb>),
+    );
+
+    expect(reanchored?.climb.benchmark_difficulty).toBeNull();
+    expect(reanchored?.climb.boardseshDifficulty).toBeNull();
+    expect(reanchored?.climb.boardseshConfidence).toBeNull();
+  });
+
+  it('ignores a response for a climb the climber has already swiped off', () => {
+    const item = makeItem('climb-a', 40);
+    // Same reference back, so the state updater is a no-op and the preview
+    // doesn't flicker to a stranger's grade.
+    expect(reanchorPreviewAtAngle(item, 50, makeClimbAtAngle('climb-b'))).toBe(item);
+  });
+
+  it('is a no-op when the item is already at the live angle', () => {
+    const item = makeItem('climb-a', 50);
+    expect(reanchorPreviewAtAngle(item, 50, makeClimbAtAngle('climb-a'))).toBe(item);
+  });
+
+  it('is a no-op with nothing pinned or nothing fetched', () => {
+    const item = makeItem('climb-a', 40);
+    expect(reanchorPreviewAtAngle(null, 50, makeClimbAtAngle('climb-a'))).toBeNull();
+    expect(reanchorPreviewAtAngle(item, 50, null)).toBe(item);
+    expect(reanchorPreviewAtAngle(item, 50, undefined)).toBe(item);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/use-mobile-playback.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-mobile-playback.test.ts
@@ -145,19 +145,21 @@ beforeEach(() => {
   });
 });
 
-type PlaybackHarnessProps = { climb: Climb | null; suppressWallWrites?: boolean };
+type PlaybackGates = { viewOnly?: boolean; suppressWallWrites?: boolean };
+type PlaybackProps = { climb: Climb | null } & PlaybackGates;
 
-function renderPlayback(climb: Climb | null, options?: { suppressWallWrites?: boolean }) {
+function renderPlayback(climb: Climb | null, gates: PlaybackGates = {}) {
   return renderHook(
-    (props: PlaybackHarnessProps) =>
+    (props: PlaybackProps) =>
       useMobilePlayback({
         climb: props.climb,
         boardName: KILTER,
         mirrored: false,
         isOpen: true,
+        viewOnly: props.viewOnly ?? false,
         suppressWallWrites: props.suppressWallWrites ?? false,
       }),
-    { initialProps: { climb, suppressWallWrites: options?.suppressWallWrites } as PlaybackHarnessProps },
+    { initialProps: { climb, ...gates } },
   );
 }
 
@@ -180,37 +182,31 @@ function pushEngineFrame(frame: string, isAnimatable: boolean = frame !== '') {
 
 /** Push a new current frame and rerender so the BLE effect re-evaluates. */
 async function setFrame(
-  rerender: (props: { climb: Climb | null; suppressWallWrites?: boolean }) => void,
+  rerender: (props?: PlaybackProps) => void,
   climb: Climb | null,
   frame: string,
-  options?: { isAnimatable?: boolean },
+  options: PlaybackGates & { isAnimatable?: boolean } = {},
 ) {
   await act(async () => {
-    pushEngineFrame(frame, options?.isAnimatable);
-    rerender({ climb });
+    pushEngineFrame(frame, options.isAnimatable);
+    rerender({ climb, viewOnly: options.viewOnly, suppressWallWrites: options.suppressWallWrites });
   });
 }
 
 describe('useMobilePlayback — BLE drain', () => {
   // The Browsing chrome promises "the wall stays put": while the drawer shows a
   // preview, playback animates on-screen but not one frame may reach the board.
-  it('suppressWallWrites keeps every frame off the wall, then resumes when it lifts', async () => {
+  it('viewOnly keeps every frame off the wall, then resumes when it lifts', async () => {
     const climb = climbWith('c1');
-    const { rerender } = renderPlayback(climb, { suppressWallWrites: true });
+    const { rerender } = renderPlayback(climb, { viewOnly: true });
 
-    await act(async () => {
-      pushEngineFrame('F0');
-      rerender({ climb, suppressWallWrites: true });
-    });
-    await act(async () => {
-      pushEngineFrame('F1');
-      rerender({ climb, suppressWallWrites: true });
-    });
+    await setFrame(rerender, climb, 'F0', { viewOnly: true });
+    await setFrame(rerender, climb, 'F1', { viewOnly: true });
     expect(mocks.bluetooth.sendFramesToBoard).not.toHaveBeenCalled();
 
     // Preview cleared (Back to live / commit): writes resume with the current frame.
     await act(async () => {
-      rerender({ climb, suppressWallWrites: false });
+      rerender({ climb, viewOnly: false });
     });
     expect(mocks.bluetooth.sendFramesToBoard).toHaveBeenCalledTimes(1);
     expect(mocks.sendCalls[0].frame).toBe('F1');
@@ -332,6 +328,35 @@ describe('useMobilePlayback — BLE drain', () => {
     await setFrame(rerender, climb, 'F0');
     expect(mocks.bluetooth.sendFramesToBoard).not.toHaveBeenCalled();
   });
+
+  // The drawer can be BLE-connected, open, and animating a route while what's on
+  // screen is a preview — someone else's climb is lit, or the climber is looking
+  // ahead in a crew. Every other gate here is satisfied in that state, so this is
+  // the one that keeps a scrubbed preview off the wall.
+  it('writes nothing while the drawer is showing a preview', async () => {
+    const climb = climbWith('c1');
+    const { rerender } = renderPlayback(climb, { viewOnly: true });
+
+    await setFrame(rerender, climb, 'F0', { viewOnly: true });
+    expect(mocks.bluetooth.sendFramesToBoard).not.toHaveBeenCalled();
+  });
+
+  it('flushes the frame once the preview is committed', async () => {
+    // Leaving the preview must not leave the wall stuck on the last live frame:
+    // the gate suppresses writes, it doesn't poison the write trackers.
+    const climb = climbWith('c1');
+    const { rerender } = renderPlayback(climb, { viewOnly: true });
+
+    await setFrame(rerender, climb, 'F0', { viewOnly: true });
+    expect(mocks.bluetooth.sendFramesToBoard).not.toHaveBeenCalled();
+
+    await setFrame(rerender, climb, 'F0', { viewOnly: false });
+    expect(mocks.bluetooth.sendFramesToBoard).toHaveBeenCalledTimes(1);
+    expect(mocks.sendCalls[0].frame).toBe('F0');
+    await act(async () => {
+      mocks.sendCalls[0].resolve(true);
+    });
+  });
 });
 
 describe('useMobilePlayback — party-sync', () => {
@@ -361,7 +386,7 @@ describe('useMobilePlayback — party-sync', () => {
     expect(mocks.lastEngineInput.current?.externalState).not.toBeNull();
 
     act(() => {
-      rerender({ climb: climbWith('c2') });
+      rerender({ climb: climbWith('c2'), viewOnly: false });
     });
     expect(mocks.lastEngineInput.current?.externalState).toBeNull();
   });
@@ -417,10 +442,40 @@ describe('useMobilePlayback — party-sync', () => {
     // A publisher older than the field sends nothing; the engine must see null
     // rather than a stale count from the previous event.
     act(() => {
-      rerender({ climb: climbWith('c1') });
+      rerender({ climb: climbWith('c1'), viewOnly: false });
     });
     emitPlayback(playbackEvent({ climbUuid: 'c1', frameCount: undefined }));
     expect(mocks.lastEngineInput.current?.externalState?.frameCount).toBeNull();
+  });
+
+  // Browsing emits NOTHING on the wire. A published playback state is a write
+  // every peer on that climb follows — the wall one hop further out — so a
+  // preview being scrubbed must not reach the session at all.
+  it('publishes nothing while the drawer is showing a preview', () => {
+    renderPlayback(climbWith('c1'), { viewOnly: true });
+
+    act(() => {
+      mocks.lastEngineInput.current?.onLocalStateChange?.({
+        frameIndex: 1,
+        frameCount: 3,
+        isPlaying: true,
+        speed: 1,
+        paceMs: 500,
+        anchorTimestamp: 1700,
+        clientId: 'self',
+      });
+    });
+
+    expect(mocks.publishPlaybackState).not.toHaveBeenCalled();
+  });
+
+  // Watching what the crew is doing is exactly what browsing IS, so the inbound
+  // half stays armed — only the outbound half is gated.
+  it('still follows a peer while showing a preview', () => {
+    renderPlayback(climbWith('c1'), { viewOnly: true });
+
+    emitPlayback(playbackEvent({ climbUuid: 'c1', clientId: 'peer-1' }));
+    expect(mocks.lastEngineInput.current?.externalState?.clientId).toBe('peer-1');
   });
 
   it('reports a peer frame-count disagreement to analytics', () => {

--- a/packages/mobile/src/components/play-drawer/__tests__/use-mobile-playback.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-mobile-playback.test.ts
@@ -469,6 +469,28 @@ describe('useMobilePlayback — party-sync', () => {
     expect(mocks.publishPlaybackState).not.toHaveBeenCalled();
   });
 
+  // The two gates are not the same gate. A climb from another board is still
+  // the COMMITTED climb — peers on it with the right wall should follow the
+  // scrub, and their own `suppressWallWrites` protects their wall. Only this
+  // device's frames stay home (#5099); the crew still hears the playback.
+  it('still publishes while only wall writes are suppressed (board mismatch)', () => {
+    renderPlayback(climbWith('c1'), { suppressWallWrites: true });
+
+    act(() => {
+      mocks.lastEngineInput.current?.onLocalStateChange?.({
+        frameIndex: 1,
+        frameCount: 3,
+        isPlaying: true,
+        speed: 1,
+        paceMs: 500,
+        anchorTimestamp: 1700,
+        clientId: 'self',
+      });
+    });
+
+    expect(mocks.publishPlaybackState).toHaveBeenCalledTimes(1);
+  });
+
   // Watching what the crew is doing is exactly what browsing IS, so the inbound
   // half stays armed — only the outbound half is gated.
   it('still follows a peer while showing a preview', () => {

--- a/packages/mobile/src/components/play-drawer/__tests__/use-mobile-playback.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-mobile-playback.test.ts
@@ -245,6 +245,23 @@ describe('useMobilePlayback — BLE drain', () => {
     expect(mocks.bluetooth.sendFramesToBoard).not.toHaveBeenCalled();
   });
 
+  it('drops pending live frames when the drawer switches into preview', async () => {
+    const climb = climbWith('c1');
+    const { rerender } = renderPlayback(climb);
+    await setFrame(rerender, climb, 'F0');
+    await setFrame(rerender, climb, 'F1');
+    expect(mocks.sendCalls).toHaveLength(1);
+
+    await act(async () => {
+      rerender({ climb, viewOnly: true });
+    });
+    await act(async () => {
+      mocks.sendCalls[0].resolve(true);
+    });
+
+    expect(mocks.sendCalls.map(({ frame }) => frame)).toEqual(['F0']);
+  });
+
   it('collapses overlapping frame writes to the latest (GATT-safe)', async () => {
     const climb = climbWith('c1');
     const { rerender } = renderPlayback(climb);

--- a/packages/mobile/src/components/play-drawer/__tests__/use-wall-climb.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-wall-climb.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+// What the drawer is allowed to claim about the wall.
+//
+// Every piece of the wall-state chrome keys on DISPLAYED-EQUALS-WALL, so a read
+// that answers "something is lit" when nothing is bound would put an "On the
+// wall" pill over a dark board and arm a busy-wall confirm about a climb that
+// isn't there. The cases below are the ones where presence data exists but does
+// NOT mean the wall is lit for this climber.
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { createElement, type ContextType, type ReactNode } from 'react';
+
+const controls = vi.hoisted(() => ({ enabled: true, boardId: 7 as number | null }));
+
+// A real context created inside the factory, so the test injects through the
+// same instance the hook reads. The hook is deliberately NOT mocked here — the
+// non-throwing `useContext` read is half of what this file measures.
+vi.mock('@boardsesh/board-presence-react', async () => {
+  const React = await import('react');
+  return { BoardPresenceWallClimbContext: React.createContext<unknown>(undefined) };
+});
+vi.mock('../../../providers/board-presence-provider', () => ({
+  useBoardPresenceControls: () => controls,
+}));
+
+import { BoardPresenceWallClimbContext } from '@boardsesh/board-presence-react';
+import { useWallClimb } from '../use-wall-climb';
+
+const LIT = { climbUuid: 'climb-lit', name: 'Their Project', sentAt: '2026-08-21T10:00:00Z', seq: 4 };
+
+function renderWithWallClimb(value: unknown) {
+  return renderHook(() => useWallClimb(), {
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(
+        BoardPresenceWallClimbContext.Provider,
+        { value: value as ContextType<typeof BoardPresenceWallClimbContext> },
+        children,
+      ),
+  });
+}
+
+describe('useWallClimb', () => {
+  it('reports the lit climb and its name', () => {
+    controls.enabled = true;
+    controls.boardId = 7;
+    const { result } = renderWithWallClimb(LIT);
+
+    expect(result.current).toEqual({ uuid: 'climb-lit', name: 'Their Project', sentAt: '2026-08-21T10:00:00Z' });
+  });
+
+  it('reports a dark wall when nothing is lit', () => {
+    controls.enabled = true;
+    controls.boardId = 7;
+    const { result } = renderWithWallClimb(null);
+
+    expect(result.current).toEqual({ uuid: null, name: null, sentAt: null });
+  });
+
+  it('reports a dark wall when no board is bound, even with a climb in the feed', () => {
+    // A stale climb from a board this phone is no longer on is not "the wall" —
+    // committing against it would ask a question about someone else's gym.
+    controls.enabled = true;
+    controls.boardId = null;
+    const { result } = renderWithWallClimb(LIT);
+
+    expect(result.current.uuid).toBeNull();
+  });
+
+  it('reports a dark wall when presence is disabled', () => {
+    controls.enabled = false;
+    controls.boardId = 7;
+    const { result } = renderWithWallClimb(LIT);
+
+    expect(result.current.uuid).toBeNull();
+  });
+
+  it('degrades instead of throwing outside the presence provider', () => {
+    // The play drawer is a modal route and can render outside that subtree; the
+    // shared `useBoardPresenceWallClimb()` throws there, which would take the
+    // whole player down over a piece of chrome.
+    controls.enabled = true;
+    controls.boardId = 7;
+    const { result } = renderHook(() => useWallClimb());
+
+    expect(result.current).toEqual({ uuid: null, name: null, sentAt: null });
+  });
+
+  it('carries a nameless lit climb rather than dropping it', () => {
+    // The uuid is what the confirm's arming predicate needs; a missing name only
+    // costs the question its subject.
+    controls.enabled = true;
+    controls.boardId = 7;
+    const { result } = renderWithWallClimb({ ...LIT, name: undefined });
+
+    expect(result.current).toEqual({ uuid: 'climb-lit', name: null, sentAt: '2026-08-21T10:00:00Z' });
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/wall-state-callout.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/wall-state-callout.test.tsx
@@ -47,7 +47,13 @@ vi.mock('react-native-reanimated', () => {
     withInitialValues: (values: unknown) => ({ settle: values }),
   });
   return {
-    default: { View: ({ children }: ViewMockProps) => createElement('div', null, children) },
+    default: {
+      // Passes the live region through: the card must not carry one — the host
+      // speaks the notice's sentence itself (see PlayDrawer), and a region here
+      // would read the same moment out a second time.
+      View: ({ children, accessibilityLiveRegion }: ViewMockProps & { accessibilityLiveRegion?: string }) =>
+        createElement('div', { 'data-live-region': accessibilityLiveRegion ?? '' }, children),
+    },
     FadeIn: { duration: (ms: number) => ({ fadeIn: ms, easing: (curve: unknown) => ({ fadeIn: ms, easing: curve }) }) },
     FadeInUp: { springify: () => settleBuilder },
     useReducedMotion: () => false,
@@ -218,6 +224,78 @@ describe('WallStateCallout', () => {
       renderCallout({ onDismiss });
 
       vi.advanceTimersByTime(7999);
+      expect(onDismiss).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(1);
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// The same card, appearing on its own the first time a crew turns the drawer's
+// gestures into browsing. Nobody asked for it, so everything the tapped explainer
+// is allowed to claim — the modal region, the screen reader's focus, a scrim over
+// the board, the hardware back button — it must not.
+describe('WallStateCallout — the one-shot joined-a-crew notice', () => {
+  const renderNotice = (props: Partial<Parameters<typeof WallStateCallout>[0]> = {}) =>
+    renderCallout({ presentation: 'notice' as const, ...props });
+
+  it('states the browsing rule instead of the tapped state hint', () => {
+    const { container } = renderNotice({ state: 'browsing' });
+    expect(container.textContent).toContain('playView.wallState.joinedBrowseNotice');
+    expect(container.textContent).not.toContain('playView.wallState.browsingHint');
+  });
+
+  it('claims no modal region, so the drawer stays reachable behind it', () => {
+    const { container } = renderNotice();
+    expect(container.querySelector('[data-modal="true"]')).toBeNull();
+  });
+
+  it('offers no actions, even when the host has some to give', () => {
+    // A card the climber never opened must not put a live control under their
+    // thumb; the same actions stay one pill tap away in the explainer.
+    const { container } = renderNotice({ onBackToLive: vi.fn(), onBrowseFromHere: vi.fn() });
+    expect(labels(container)).not.toContain('playView.wallState.backToLive');
+    expect(container.textContent).not.toContain('playView.wallState.browseFromHere');
+  });
+
+  it('shows no driver row on the wall state', () => {
+    driverState.value = { driver: { userId: 'user-1', avatarUrl: null }, name: 'Ada', litAgo: '2m' };
+    const { container } = renderNotice({ state: 'onWall' });
+    expect(container.querySelector('[data-driver-avatar]')).toBeNull();
+  });
+
+  it('never yanks the screen reader off what it was reading, and never speaks twice', () => {
+    // The notice's sentence is announced by the host the moment it claims the
+    // card, on both platforms. A live region here would mean either a second
+    // reading of the same moment, or — since this card MOUNTS already holding its
+    // text, which is not a content change — nothing at all on Android.
+    const { container } = renderNotice();
+    expect(container.querySelector('[data-live-region="polite"]')).toBeNull();
+    expect(setAccessibilityFocus).not.toHaveBeenCalled();
+  });
+
+  it('leaves the hardware back button to the player underneath', () => {
+    renderNotice();
+    expect(backHandler.handler).toBeNull();
+  });
+
+  it('can be put away early by tapping it', () => {
+    const onDismiss = vi.fn();
+    const { container } = renderNotice({ onDismiss });
+    const [dismissButton] = [...container.querySelectorAll('button')];
+    dismissButton.click();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('dwells shorter than a card the climber asked for', () => {
+    vi.useFakeTimers();
+    try {
+      const onDismiss = vi.fn();
+      renderNotice({ onDismiss });
+
+      vi.advanceTimersByTime(4999);
       expect(onDismiss).not.toHaveBeenCalled();
       vi.advanceTimersByTime(1);
       expect(onDismiss).toHaveBeenCalledTimes(1);

--- a/packages/mobile/src/components/play-drawer/__tests__/wall-state.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/wall-state.test.ts
@@ -3,12 +3,15 @@ import {
   resolveCommitBarModel,
   resolveWallPillState,
   resolveWallStateAnnouncement,
+  shouldAdoptLateWallRead,
   shouldArmBusyWallConfirm,
   shouldShowHolderBadge,
+  WALL_READ_PRE_LATCH_TOLERANCE_MS,
   type CommitBarModel,
   type CommitBarModelInput,
   type WallPillState,
   type WallPillStateInput,
+  type LateWallReadInput,
   type WallStateAnnouncement,
   type WallStateAnnouncementInput,
 } from '../wall-state';
@@ -253,6 +256,62 @@ describe('shouldArmBusyWallConfirm', () => {
 
   it('arms when the latch started against a dark wall and someone has since lit one', () => {
     expect(shouldArmBusyWallConfirm({ ...armingCase, wallUuidAtLatchStart: null })).toBe(true);
+  });
+});
+
+// Telling "the feed hadn't delivered yet" from "the wall was dark". Both read as
+// a null snapshot, and the difference decides whether the first commit tap
+// accuses a peer of something they didn't do.
+describe('shouldAdoptLateWallRead', () => {
+  const LATCH_STARTED_AT = Date.parse('2026-08-21T10:00:00Z');
+  const lit = (offsetMs: number) => new Date(LATCH_STARTED_AT + offsetMs).toISOString();
+
+  /** The cold-start case: nothing known at latch start, then a long-lit climb lands. */
+  const lateReadCase: LateWallReadInput = {
+    wallUuidAtLatchStart: null,
+    wallClimbUuid: WALL_CLIMB,
+    wallClimbSentAt: lit(-10 * 60_000),
+    latchStartedAt: LATCH_STARTED_AT,
+  };
+
+  it('adopts a climb that was lit long before this browse began', () => {
+    expect(shouldAdoptLateWallRead(lateReadCase)).toBe(true);
+  });
+
+  // Each clause on its own — and every one of them fails SAFE, leaving the
+  // confirm free to arm.
+  it('leaves a snapshot that already read the wall alone', () => {
+    expect(shouldAdoptLateWallRead({ ...lateReadCase, wallUuidAtLatchStart: THEIR_CLIMB })).toBe(false);
+  });
+
+  it('has nothing to adopt while the wall is still dark', () => {
+    expect(shouldAdoptLateWallRead({ ...lateReadCase, wallClimbUuid: null })).toBe(false);
+  });
+
+  it('arms rather than guesses when the lighting carries no timestamp', () => {
+    expect(shouldAdoptLateWallRead({ ...lateReadCase, wallClimbSentAt: null })).toBe(false);
+    expect(shouldAdoptLateWallRead({ ...lateReadCase, wallClimbSentAt: 'not a date' })).toBe(false);
+  });
+
+  it('arms rather than guesses before any latch has started', () => {
+    expect(shouldAdoptLateWallRead({ ...lateReadCase, latchStartedAt: null })).toBe(false);
+  });
+
+  it('never adopts a climb lit DURING the browse — that is the peer this protects', () => {
+    expect(shouldAdoptLateWallRead({ ...lateReadCase, wallClimbSentAt: lit(1_000) })).toBe(false);
+  });
+
+  // The tolerance is the clock-skew allowance: the wall's timestamp comes from
+  // the server and the latch's from this phone, so "just before" is not evidence
+  // of anything.
+  it('treats a lighting inside the skew tolerance as too recent to adopt', () => {
+    const insideTolerance = lit(-(WALL_READ_PRE_LATCH_TOLERANCE_MS - 1_000));
+    expect(shouldAdoptLateWallRead({ ...lateReadCase, wallClimbSentAt: insideTolerance })).toBe(false);
+  });
+
+  it('adopts once the lighting is older than the tolerance', () => {
+    const outsideTolerance = lit(-(WALL_READ_PRE_LATCH_TOLERANCE_MS + 1_000));
+    expect(shouldAdoptLateWallRead({ ...lateReadCase, wallClimbSentAt: outsideTolerance })).toBe(true);
   });
 });
 

--- a/packages/mobile/src/components/play-drawer/joined-browse-notice.ts
+++ b/packages/mobile/src/components/play-drawer/joined-browse-notice.ts
@@ -1,0 +1,60 @@
+/**
+ * One-shot bookkeeping for the "you're browsing" notice.
+ *
+ * The notice explains a rule the climber never opted into: something silently
+ * changed what a swipe does — joining a crew, or turning board lighting off for
+ * swipes and taps. It has to be shown, and it has to be shown ONCE, because a
+ * card that reappears every time the drawer opens is the thing people remember
+ * about a feature instead of the feature.
+ *
+ * Two claims, because the two facts have different lifetimes:
+ *
+ *  - the crew rule lives as long as the crew does, so it is claimed per session
+ *    id in module state (not a ref inside PlayDrawer — the drawer is a modal
+ *    route and unmounts on every dismiss, which would re-fire the card on the
+ *    next open). Joining a DIFFERENT crew later explains itself again, and the
+ *    claim dying with the app only means a climber who force-quit mid-session
+ *    gets told once more;
+ *  - the lighting-setting rule is a decision the climber made on a device they
+ *    keep, so its claim is persisted.
+ */
+import { getSetting, setSetting } from '../../settings';
+
+const noticedSessionIds = new Set<string>();
+
+/**
+ * Claim the notice for this session: true exactly once per session id, false
+ * every time after. Solo (`null`) never claims — see
+ * {@link claimSoloBrowseNotice} for the other half.
+ */
+export function claimJoinedBrowseNotice(sessionId: string | null): boolean {
+  if (!sessionId || noticedSessionIds.has(sessionId)) return false;
+  noticedSessionIds.add(sessionId);
+  return true;
+}
+
+/**
+ * The solo half of the same explanation: a climber who turned board lighting off
+ * for swipes or taps (#4640) also navigates without driving their board, and
+ * nothing else tells them so.
+ *
+ * Persisted rather than held in memory, unlike the crew claim above, because the
+ * fact it records is permanent: a setting the climber changed once, on a device
+ * they keep. An in-memory claim would re-explain it on every cold start, which is
+ * exactly the card-everyone-remembers-instead-of-the-feature failure.
+ */
+export function claimSoloBrowseNotice(): boolean {
+  if (getSetting('browseNoticeSeen')) return false;
+  setSetting('browseNoticeSeen', true);
+  return true;
+}
+
+/**
+ * Clear the claim ledger. Test-only: the Set outlives an individual test, so
+ * without this a second case reusing a session id would see no notice and pass
+ * for the wrong reason. (The solo claim lives in settings, which the suites reset
+ * with `resetAllSettings`.)
+ */
+export function _resetJoinedBrowseNoticeForTests(): void {
+  noticedSessionIds.clear();
+}

--- a/packages/mobile/src/components/play-drawer/joined-browse-notice.ts
+++ b/packages/mobile/src/components/play-drawer/joined-browse-notice.ts
@@ -23,12 +23,27 @@ import { getSetting, setSetting } from '../../settings';
 const noticedSessionIds = new Set<string>();
 
 /**
+ * How many session ids the ledger remembers before it forgets the oldest. A
+ * climber joins a handful of crews a day at most; the cap only exists so a client
+ * that reconnects into a fresh session id over and over (a flapping kiosk, a
+ * test loop) cannot grow the Set for the life of the process. Forgetting an old
+ * id costs one repeated notice on a crew the climber rejoined much later, which
+ * is the cheap side of the trade.
+ */
+export const JOINED_BROWSE_NOTICE_LEDGER_CAP = 100;
+
+/**
  * Claim the notice for this session: true exactly once per session id, false
  * every time after. Solo (`null`) never claims — see
  * {@link claimSoloBrowseNotice} for the other half.
  */
 export function claimJoinedBrowseNotice(sessionId: string | null): boolean {
   if (!sessionId || noticedSessionIds.has(sessionId)) return false;
+  if (noticedSessionIds.size >= JOINED_BROWSE_NOTICE_LEDGER_CAP) {
+    // Sets iterate in insertion order, so the first key is the oldest claim.
+    const oldest = noticedSessionIds.values().next().value;
+    if (oldest !== undefined) noticedSessionIds.delete(oldest);
+  }
   noticedSessionIds.add(sessionId);
   return true;
 }

--- a/packages/mobile/src/components/play-drawer/play-drawer-navigation.ts
+++ b/packages/mobile/src/components/play-drawer/play-drawer-navigation.ts
@@ -32,29 +32,41 @@ export function getViewOnlyPreviewNavigationTarget({
 
 /**
  * The wiring `handlePrev`/`handleNext` actually call: turns the `lightOnSwipe`
- * setting into `forceViewOnly` and delegates to
- * {@link getViewOnlyPreviewNavigationTarget}. Split out as its own function
- * (rather than inlining `forceViewOnly: !lightOnSwipe` at each call site) so
- * the setting → forceViewOnly translation is directly unit-testable — the
- * component itself has no render test (PlayDrawer's dependency graph makes
- * one impractical; see IpadPlayPane.test.tsx, which mocks it out entirely).
+ * setting and the shared-session browse latch into `forceViewOnly` and delegates
+ * to {@link getViewOnlyPreviewNavigationTarget}. Split out as its own function
+ * (rather than inlining the translation at each call site) so it is directly
+ * unit-testable — the component itself has no render test (PlayDrawer's
+ * dependency graph makes one impractical; see IpadPlayPane.test.tsx, which mocks
+ * it out entirely).
+ *
+ * The two reasons to stay view-only are independent and either one is enough:
+ * the climber turned board lighting off for swipes, or someone else is in the
+ * session and a swipe would move THEIR wall and THEIR next-up.
  */
 export function getSwipeNavigationTarget({
   previewItem,
   previewSuggestionSource,
   targetItem,
   lightOnSwipe,
+  inSharedSession = false,
 }: {
   previewItem: ClimbQueueItem | null;
   previewSuggestionSource: PlaylistSuggestionSource | null;
   targetItem: ClimbQueueItem | null;
   lightOnSwipe: boolean;
+  /**
+   * A browse latch is up because there is an audience: a party session with at
+   * least one other climber in it, OR a latch that armed while there was one and
+   * has not been exited yet (the latch is one-way — see PlayDrawer). Defaults to
+   * false so the solo call sites read unchanged.
+   */
+  inSharedSession?: boolean;
 }): ViewOnlyPreviewNavigationTarget {
   return getViewOnlyPreviewNavigationTarget({
     previewItem,
     previewSuggestionSource,
     targetItem,
-    forceViewOnly: !lightOnSwipe,
+    forceViewOnly: !lightOnSwipe || inSharedSession,
   });
 }
 
@@ -79,12 +91,20 @@ export function swipeStaysViewOnly({
   previewItem,
   previewSuggestionSource,
   lightOnSwipe,
+  inSharedSession = false,
 }: {
   previewItem: ClimbQueueItem | null;
   previewSuggestionSource: PlaylistSuggestionSource | null;
   lightOnSwipe: boolean;
+  inSharedSession?: boolean;
 }): boolean {
-  return getSwipeNavigationTarget({ previewItem, previewSuggestionSource, targetItem: null, lightOnSwipe }).viewOnly;
+  return getSwipeNavigationTarget({
+    previewItem,
+    previewSuggestionSource,
+    targetItem: null,
+    lightOnSwipe,
+    inSharedSession,
+  }).viewOnly;
 }
 
 /**
@@ -108,7 +128,18 @@ export function swipeStaysViewOnly({
  *
  * The preview swap is the same mechanism `getViewOnlyPreviewNavigationTarget`
  * already uses above — show the climb, commit nothing.
+ *
+ * A member in a SHARED session takes the same preview path, for a third reason:
+ * the member branch double-writes (`addToQueue` AND `setCurrentClimb`), so a tap
+ * on a "you might also like" card would append to the crew's queue and take the
+ * wall in one gesture — the loudest possible outcome for the most idle possible
+ * intent. Browsing is what the tap means there; putting it up stays an explicit
+ * act on the commit row.
  */
-export function getSimilarClimbTapMode(viewer: 'member' | 'anonymous'): 'queue' | 'preview' {
-  return viewer === 'anonymous' ? 'preview' : 'queue';
+export function getSimilarClimbTapMode(
+  viewer: 'member' | 'anonymous',
+  { inSharedSession = false }: { inSharedSession?: boolean } = {},
+): 'queue' | 'preview' {
+  if (viewer === 'anonymous') return 'preview';
+  return inSharedSession ? 'preview' : 'queue';
 }

--- a/packages/mobile/src/components/play-drawer/play-drawer-navigation.ts
+++ b/packages/mobile/src/components/play-drawer/play-drawer-navigation.ts
@@ -35,9 +35,7 @@ export function getViewOnlyPreviewNavigationTarget({
  * setting and the shared-session browse latch into `forceViewOnly` and delegates
  * to {@link getViewOnlyPreviewNavigationTarget}. Split out as its own function
  * (rather than inlining the translation at each call site) so it is directly
- * unit-testable — the component itself has no render test (PlayDrawer's
- * dependency graph makes one impractical; see IpadPlayPane.test.tsx, which mocks
- * it out entirely).
+ * unit-testable alongside the PlayDrawer render tests.
  *
  * The two reasons to stay view-only are independent and either one is enough:
  * the climber turned board lighting off for swipes, or someone else is in the
@@ -57,7 +55,7 @@ export function getSwipeNavigationTarget({
   /**
    * A browse latch is up because there is an audience: a party session with at
    * least one other climber in it, OR a latch that armed while there was one and
-   * has not been exited yet (the latch is one-way — see PlayDrawer). Defaults to
+   * has not been exited or released after the solo dwell. Defaults to
    * false so the solo call sites read unchanged.
    */
   inSharedSession?: boolean;

--- a/packages/mobile/src/components/play-drawer/preview-angle-anchor.ts
+++ b/packages/mobile/src/components/play-drawer/preview-angle-anchor.ts
@@ -1,0 +1,75 @@
+/**
+ * Keeping a pinned browse preview alive across an angle change.
+ *
+ * A climb's grade, quality and send count are angle-specific, and a queue item
+ * carries them baked in for the angle it was fetched at. The COMMITTED climb has
+ * a self-healing path for that: `useQueueRegrade` notices `climb.angle !== angle`
+ * and patches the queue item in place from a fresh `GET_CLIMB`. A pinned drawer
+ * preview has no such path — it lives in component state, not in the queue — so
+ * the drawer used to drop it on every angle change and fall back to the queue
+ * head.
+ *
+ * That was fine when a preview was a momentary thing. Under the shared-session
+ * browse latch it is where the climber LIVES: reaching for the angle pill
+ * mid-browse would have thrown away the climb they were looking at, the
+ * suggestion track they were walking, and the latch itself. So the drawer now
+ * re-anchors instead — same climb, same latch, grade re-resolved at the new
+ * angle — using the same patch shape `useQueueRegrade` dispatches, so the two
+ * paths can't disagree about what "the grade at this angle" means.
+ */
+
+import type { ClimbQueueItem, ClimbRegradePatch } from '@boardsesh/queue';
+import type { Climb } from '@boardsesh/shared-schema';
+
+/**
+ * Whether the pinned preview is showing a grade from a different angle than the
+ * board is set to. An item with no angle on its climb is left alone: there is
+ * nothing to compare, and re-fetching on a guess would be a request per render.
+ */
+export function previewNeedsAngleReanchor(item: ClimbQueueItem | null, angle: number): boolean {
+  const climbAngle = item?.climb?.angle;
+  return climbAngle != null && climbAngle !== angle;
+}
+
+/**
+ * The angle-specific fields to copy off a climb fetched at the live angle —
+ * exactly `ClimbRegradePatch`, the shape `useQueueRegrade` builds for the
+ * committed path.
+ */
+function toRegradePatch(climb: Climb, angle: number): ClimbRegradePatch {
+  return {
+    angle,
+    difficulty: climb.difficulty,
+    quality_average: climb.quality_average,
+    ascensionist_count: climb.ascensionist_count,
+    benchmark_difficulty: climb.benchmark_difficulty ?? null,
+    difficulty_error: climb.difficulty_error,
+    // Explicit nulls so an angle with no boardsesh grade row clears the stale
+    // value from the climb's previous angle.
+    boardseshDifficulty: climb.boardseshDifficulty ?? null,
+    boardseshConfidence: climb.boardseshConfidence ?? null,
+  };
+}
+
+/**
+ * Re-anchor a pinned preview at `angle` from a freshly fetched climb.
+ *
+ * Returns the SAME item reference whenever there is nothing to do — no item, a
+ * fetch for a different climb (a stale response landing after the climber swiped
+ * on), or an item already at this angle. That identity guarantee is what lets
+ * the caller feed this straight into a `setState` updater without churning the
+ * preview on every render.
+ *
+ * The queue item's own uuid is preserved: it is the drawer's navigation anchor,
+ * and minting a fresh one would break prev/next and the remaining count.
+ */
+export function reanchorPreviewAtAngle(
+  item: ClimbQueueItem | null,
+  angle: number,
+  climbAtAngle: Climb | null | undefined,
+): ClimbQueueItem | null {
+  if (!item || !climbAtAngle) return item;
+  if (item.climb?.uuid !== climbAtAngle.uuid) return item;
+  if (!previewNeedsAngleReanchor(item, angle)) return item;
+  return { ...item, climb: { ...item.climb, ...toRegradePatch(climbAtAngle, angle) } };
+}

--- a/packages/mobile/src/components/play-drawer/use-mobile-playback.ts
+++ b/packages/mobile/src/components/play-drawer/use-mobile-playback.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import {
   useClimbFrames,
@@ -21,14 +21,24 @@ type UseMobilePlaybackInput = {
   /** Gates the BLE write loop only; the peer subscription stays armed regardless. */
   isOpen: boolean;
   /**
-   * True while the drawer shows a preview: playback keeps animating ON-SCREEN,
-   * but no frame reaches a connected wall. Without this, merely opening a
-   * preview of a multi-frame climb replaces the physical wall — the exact
-   * promise the Browsing chrome makes ("the wall stays put") broken by the
-   * writer below. The live climb's frames resume flowing when the preview
-   * clears (the climb-change reset re-arms the first-frame flush).
+   * The climb on screen is a PREVIEW — not what the wall or the shared queue is
+   * on. Playback then animates locally and reaches nothing outside the phone:
+   * no BLE frame writes (the wall keeps the live climb's frames; they resume
+   * when the preview clears — the climb-change reset re-arms the first-frame
+   * flush) and no playback broadcast (a peer following a route the crew never
+   * agreed to play would be the same intrusion one hop further out). Inbound
+   * peer state stays subscribed: watching what the crew is doing is exactly
+   * what browsing is. Required, not defaulted — every call site must decide.
    */
-  suppressWallWrites: boolean;
+  viewOnly: boolean;
+  /**
+   * The climb on screen belongs to a DIFFERENT board than the connected one, so
+   * its hold ids address the wrong wall and a frame write would light the wrong
+   * holds (#5099). Frames only: the playback state still reaches the crew — it is
+   * this wall that cannot show it, not the route that is private. Optional
+   * because most call sites have no board to disagree with.
+   */
+  suppressWallWrites?: boolean;
   /**
    * Fired once per user-initiated `play()` on a route. Analytics seam: mobile
    * has no analytics transport yet, so the play drawer leaves this undefined.
@@ -74,7 +84,8 @@ export function useMobilePlayback({
   boardName,
   mirrored,
   isOpen,
-  suppressWallWrites,
+  viewOnly,
+  suppressWallWrites = false,
   onRoutePlayed,
 }: UseMobilePlaybackInput): UseMobilePlaybackOutput {
   const { subscribeToPlaybackEvents, publishPlaybackState } = useQueueActions();
@@ -112,9 +123,17 @@ export function useMobilePlayback({
     return unsubscribe;
   }, [climbUuid, subscribeToPlaybackEvents]);
 
+  // Read through a ref so the engine keeps ONE `onLocalStateChange` identity for
+  // the drawer's lifetime — a preview being pinned must not look to the engine
+  // like a new listener.
+  const viewOnlyRef = useRef(viewOnly);
+  viewOnlyRef.current = viewOnly;
+
   const handleLocalStateChange = useCallback(
     (next: LocalPlaybackState) => {
       if (!climbUuid) return;
+      // Browsing broadcasts nothing (see `viewOnly`).
+      if (viewOnlyRef.current) return;
       void publishPlaybackState({
         climbUuid,
         frameIndex: next.frameIndex,
@@ -158,7 +177,7 @@ export function useMobilePlayback({
   // the wall through exactly the same latest-wins drain (#4634).
   const { currentFrameString, isAnimatable } = playback;
   const bluetoothConnected = bluetooth?.isConnected ?? false;
-  const wallFrame = !isOpen || suppressWallWrites || !isAnimatable || !bluetoothConnected ? null : currentFrameString;
+  const wallFrame = viewOnly || !isOpen || suppressWallWrites || !isAnimatable || !bluetoothConnected ? null : currentFrameString;
   useBleFrameWriter({
     frame: wallFrame,
     send: bluetooth?.sendFramesToBoard,

--- a/packages/mobile/src/components/play-drawer/use-mobile-playback.ts
+++ b/packages/mobile/src/components/play-drawer/use-mobile-playback.ts
@@ -177,7 +177,8 @@ export function useMobilePlayback({
   // the wall through exactly the same latest-wins drain (#4634).
   const { currentFrameString, isAnimatable } = playback;
   const bluetoothConnected = bluetooth?.isConnected ?? false;
-  const wallFrame = viewOnly || !isOpen || suppressWallWrites || !isAnimatable || !bluetoothConnected ? null : currentFrameString;
+  const wallFrame =
+    viewOnly || !isOpen || suppressWallWrites || !isAnimatable || !bluetoothConnected ? null : currentFrameString;
   useBleFrameWriter({
     frame: wallFrame,
     send: bluetooth?.sendFramesToBoard,

--- a/packages/mobile/src/components/play-drawer/use-wall-climb.ts
+++ b/packages/mobile/src/components/play-drawer/use-wall-climb.ts
@@ -1,0 +1,49 @@
+// What is physically lit on the board right now, in EVERY drawer state.
+//
+// Until this landed the drawer only knew the wall's climb in one situation — the
+// accessory-bar preview, which arrives already knowing it is the lit one — so
+// "On the wall" could never be said after a plain swipe landed back on it, and
+// the busy-wall confirm had nothing to compare against. Both need the wall read
+// continuously, which is what this is.
+//
+// It reads the NARROW board-presence selector, so the drawer re-renders when the
+// lit climb changes and not on holder / stats / undo-target churn (the same
+// reason `useWallClimbIfDistinct` uses it). And it reads it through `useContext`
+// rather than `useBoardPresenceWallClimb()`, which throws with no provider in
+// scope: the drawer can render outside that subtree, and a dark wall is the
+// honest answer there — never a crash. Same call the sibling `useBoardDriver`
+// makes, for the same reason.
+
+import { useContext, useMemo } from 'react';
+import { BoardPresenceWallClimbContext } from '@boardsesh/board-presence-react';
+import { useBoardPresenceControls } from '../../providers/board-presence-provider';
+
+export type WallClimb = {
+  /** The lit climb's uuid; `null` when the wall is dark, unbound, or unknown. */
+  uuid: string | null;
+  /** Its name — the busy-wall confirm says "Someone just lit {{name}}". */
+  name: string | null;
+  /**
+   * When the server recorded the lighting (ISO 8601, server-stamped). The
+   * busy-wall confirm reads it to tell "a peer just lit this" from "this was
+   * already up before the drawer even had a feed" — a distinction the uuid alone
+   * can't make, because a wall that is still connecting reads exactly like a dark
+   * one. `null` when nothing is lit.
+   */
+  sentAt: string | null;
+};
+
+/** No board bound, no feed, or nothing lit. A stable reference so the memo below
+ *  hands consumers the same object every render in the common (solo, unbound) case. */
+const DARK_WALL: WallClimb = { uuid: null, name: null, sentAt: null };
+
+export function useWallClimb(): WallClimb {
+  const { enabled, boardId } = useBoardPresenceControls();
+  // `undefined` means "outside the provider" here — degrade, don't throw.
+  const wallClimb = useContext(BoardPresenceWallClimbContext) ?? null;
+
+  return useMemo(() => {
+    if (!enabled || boardId === null || !wallClimb) return DARK_WALL;
+    return { uuid: wallClimb.climbUuid, name: wallClimb.name ?? null, sentAt: wallClimb.sentAt ?? null };
+  }, [enabled, boardId, wallClimb]);
+}

--- a/packages/mobile/src/components/play-drawer/use-wall-state-announcer.ts
+++ b/packages/mobile/src/components/play-drawer/use-wall-state-announcer.ts
@@ -34,13 +34,23 @@ export function useWallStateAnnouncer({
   pillState: WallPillState;
   /** The displayed climb's name — rides the commit / back-to-live sentences. */
   climbName: string | null;
-}): { markLatchExit: (exit: WallLatchExit) => void } {
+}): { markLatchExit: (exit: WallLatchExit) => void; suppressBrowseAnnouncement: () => void } {
   const { t } = useTranslation('session');
   const previousStateRef = useRef<WallPillState | undefined>(undefined);
   const exitRef = useRef<WallLatchExit | null>(null);
+  const suppressBrowseRef = useRef(false);
 
   const markLatchExit = useCallback((exit: WallLatchExit) => {
     exitRef.current = exit;
+  }, []);
+
+  // The one-shot joined-a-crew notice says the same thing as the browse sentence,
+  // in more words, at the same moment — so when the host shows it, it speaks and
+  // this stands down. Checked at fire time rather than at schedule time because
+  // the host claims the notice in a LATER effect of the same commit: by then this
+  // effect has already scheduled its announcement.
+  const suppressBrowseAnnouncement = useCallback(() => {
+    suppressBrowseRef.current = true;
   }, []);
 
   const sentences = useMemo(
@@ -62,14 +72,19 @@ export function useWallStateAnnouncer({
     previousStateRef.current = pillState;
     const exit = exitRef.current;
     exitRef.current = null;
+    // A new transition, so any suppression left over from the last one is spent.
+    suppressBrowseRef.current = false;
 
     const announcement = resolveWallStateAnnouncement({ previous, next: pillState, exit });
     if (announcement === null) return;
 
     const text = sentencesRef.current[announcement];
-    const handle = setTimeout(() => AccessibilityInfo.announceForAccessibility(text), ANNOUNCE_DEBOUNCE_MS);
+    const handle = setTimeout(() => {
+      if (announcement === 'browse' && suppressBrowseRef.current) return;
+      AccessibilityInfo.announceForAccessibility(text);
+    }, ANNOUNCE_DEBOUNCE_MS);
     return () => clearTimeout(handle);
   }, [pillState]);
 
-  return { markLatchExit };
+  return { markLatchExit, suppressBrowseAnnouncement };
 }

--- a/packages/mobile/src/components/play-drawer/wall-state.ts
+++ b/packages/mobile/src/components/play-drawer/wall-state.ts
@@ -245,8 +245,9 @@ export type BusyWallConfirmInput = {
  *  - a wall that already shows YOUR climb needs no confirm; the commit is a
  *    no-op against the LEDs.
  *
- * Consumed by the confirm swap in PR A2; the predicate lands now so the arming
- * rule is pinned before any UI depends on it.
+ * Once armed, only three things stand the question down (no timer among them):
+ * "Keep theirs", browsing on to another climb, or the conflict resolving itself
+ * — which is this predicate going false, so the same rule reads both ways.
  */
 export function shouldArmBusyWallConfirm({
   wallClimbUuid,
@@ -256,13 +257,61 @@ export function shouldArmBusyWallConfirm({
   return wallClimbUuid != null && wallClimbUuid !== wallUuidAtLatchStart && wallClimbUuid !== displayedClimbUuid;
 }
 
-// The rest of the wall-state copy is read by WallStatePill / WallStateCallout /
-// PlayDrawerCommitBar, so it needs no markers. These four have no reader until
-// PR A2 lands the busy-wall confirm and the joined-browse notice; delete each
-// marker as its `t()` call arrives, so the orphan gate stays honest about the
-// keys that really have nobody reading them.
-//
-// i18n-keep session:playView.wallState.commitOverride.body
-// i18n-keep session:playView.wallState.commitOverride.confirm
-// i18n-keep session:playView.wallState.commitOverride.cancel
-// i18n-keep session:playView.wallState.joinedBrowseNotice
+/**
+ * How much older than the latch's start a lighting must look before it counts as
+ * "this was already up". Generous on purpose: the two clocks being compared are
+ * different machines (the wall's timestamp is server-stamped, the latch's is this
+ * phone's), and the safe direction is asking a question nobody needed rather than
+ * taking a wall silently. A phone would have to run more than a minute FAST
+ * before a peer's fresh lighting could read as pre-existing.
+ */
+export const WALL_READ_PRE_LATCH_TOLERANCE_MS = 60_000;
+
+export type LateWallReadInput = {
+  /** The snapshot taken on the latch's rising edge — `null` when the wall was unknown. */
+  wallUuidAtLatchStart: string | null;
+  /** What the wall reads now. */
+  wallClimbUuid: string | null;
+  /** The lit climb's server-stamped timestamp (ISO 8601), if any. */
+  wallClimbSentAt: string | null;
+  /** When browsing began, by this device's clock. `null` before any latch. */
+  latchStartedAt: number | null;
+};
+
+/**
+ * Whether a wall read that arrived AFTER browsing began is really the wall as it
+ * was when browsing began.
+ *
+ * The snapshot is taken on the latch's rising edge, and at a cold start (or a
+ * presence reconnect) the feed may not have delivered yet — so the snapshot says
+ * `null`, which is indistinguishable from a dark wall. A second later the climb
+ * that had been lit the whole time arrives, and without this the first "Put on
+ * the wall" tap would announce "Someone just lit X" about a climb nobody touched.
+ *
+ * The discriminator is the lighting's own server timestamp: a climb lit well
+ * before this browse started was not lit during it. Everything ambiguous — no
+ * timestamp, an unparseable one, or one inside the skew tolerance — keeps the
+ * protective behaviour and lets the confirm arm.
+ */
+export function shouldAdoptLateWallRead({
+  wallUuidAtLatchStart,
+  wallClimbUuid,
+  wallClimbSentAt,
+  latchStartedAt,
+}: LateWallReadInput): boolean {
+  // Only the unknown-wall case is in doubt: a snapshot that read a real climb
+  // (or a real dark wall this device watched go dark) needs no help.
+  if (wallUuidAtLatchStart !== null) return false;
+  if (wallClimbUuid === null || wallClimbSentAt === null || latchStartedAt === null) return false;
+  const sentAtMs = Date.parse(wallClimbSentAt);
+  if (Number.isNaN(sentAtMs)) return false;
+  // Anything lit during this browse — including a lighting stamped later than the
+  // latch by a phone running slow — fails this and arms the confirm.
+  return sentAtMs < latchStartedAt - WALL_READ_PRE_LATCH_TOLERANCE_MS;
+}
+
+// Every wall-state key now has a real `t()` call behind it — the pill, the
+// callout, and the commit bar's browse and confirm modes — so this file no
+// longer reserves any. It ended PR A1 reserving three (the `commitOverride.*`
+// trio the confirm had no reader for yet) and each reservation came out with its
+// reader, so the orphan gate stays honest about the keys nobody is reading.

--- a/packages/mobile/src/lib/__tests__/committable-queue-item.test.ts
+++ b/packages/mobile/src/lib/__tests__/committable-queue-item.test.ts
@@ -1,0 +1,81 @@
+// The one rule standing between a browse and a broken party queue.
+//
+// `findNextQueueItemWithSuggestions` hands the drawer a synthetic
+// `playlist-peek:<climbUuid>` item for the next-up suggestion. It is a rendering
+// device — it is NOT in the queue — and `toQueueItemWireInput` puts `item.uuid`
+// on the wire verbatim. Committing one straight broadcasts a uuid no peer can
+// reconcile against their own queue.
+//
+// Until the shared-session browse latch, only `nextClimb()` could reach a peek,
+// and it laundered it inline. Browsing now walks a suggestion track item by item
+// with a "Put on the wall" button pointed at whatever is on screen, so the drawer
+// reaches one routinely. Hence one helper, one test.
+import { describe, it, expect, vi } from 'vitest';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+import { getPlaylistPeekQueueItemUuid } from '@boardsesh/queue';
+import type { Climb } from '@boardsesh/shared-schema';
+
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'minted-uuid' }));
+
+const { resolveCommittableQueueItem } = await import('../climb-to-queue-item');
+
+function makeClimb(uuid: string): Climb {
+  return {
+    uuid,
+    setter_username: 'setter',
+    name: 'Peeked Climb',
+    frames: 'p1145r15',
+    angle: 40,
+    ascensionist_count: 5,
+    difficulty: '21',
+    quality_average: '3.0',
+    stars: 3,
+    difficulty_error: '0.5',
+    benchmark_difficulty: null,
+    framesCount: 3,
+    framesPace: 900,
+  } as unknown as Climb;
+}
+
+function makeItem(uuid: string, climbUuid: string): ClimbQueueItem {
+  return { uuid, climb: makeClimb(climbUuid) } as unknown as ClimbQueueItem;
+}
+
+describe('resolveCommittableQueueItem', () => {
+  it('mints a real item for a playlist peek, so no synthetic uuid reaches the wire', () => {
+    const peekUuid = getPlaylistPeekQueueItemUuid('climb-a');
+    const { item, converted } = resolveCommittableQueueItem(makeItem(peekUuid, 'climb-a'));
+
+    expect(converted).toBe(true);
+    expect(item.uuid).toBe('minted-uuid');
+    expect(item.uuid.startsWith('playlist-peek:')).toBe(false);
+    // Same climb, so the climber commits what they were looking at.
+    expect(item.climb.uuid).toBe('climb-a');
+    // Suggestion-origin is preserved: pruning after the next navigation has to
+    // keep treating it as a suggestion, not as a climb the crew hand-queued.
+    expect(item.suggested).toBe(true);
+  });
+
+  it('carries the climb through intact, not a stub', () => {
+    const { item } = resolveCommittableQueueItem(makeItem(getPlaylistPeekQueueItemUuid('climb-a'), 'climb-a'));
+    // The pace metadata is the field a hand-rolled `{uuid, climb: {uuid, name}}`
+    // rebuild would quietly drop, sending route playback back to DEFAULT_PACE_MS.
+    expect(item.climb.framesCount).toBe(3);
+    expect(item.climb.framesPace).toBe(900);
+  });
+
+  it('leaves a real queue item exactly as it is — same reference, no new uuid', () => {
+    const real = makeItem('queue-item-1', 'climb-b');
+    const { item, converted } = resolveCommittableQueueItem(real);
+
+    expect(converted).toBe(false);
+    // Identity, not equality: the item is already IN the queue, and re-minting it
+    // would orphan the drawer's navigation anchor and duplicate the entry.
+    expect(item).toBe(real);
+  });
+
+  it('does not treat a uuid that merely contains the marker as a peek', () => {
+    const { converted } = resolveCommittableQueueItem(makeItem('real-playlist-peek:climb-c', 'climb-c'));
+    expect(converted).toBe(false);
+  });
+});

--- a/packages/mobile/src/lib/climb-to-queue-item.ts
+++ b/packages/mobile/src/lib/climb-to-queue-item.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'expo-crypto';
 import type { Climb, ClimbInput, ClimbQueueItemInput } from '@boardsesh/shared-schema';
-import type { ClimbQueueItem } from '@boardsesh/queue';
+import { isPlaylistPeekQueueItemUuid, type ClimbQueueItem } from '@boardsesh/queue';
 // Subpath import, not the barrel: nine queue-provider suites whole-module-mock
 // `@boardsesh/queue-react`, and this module sits in all of their graphs.
 import { toClimbQueueItemInput } from '@boardsesh/queue-react/queue-item-input';
@@ -151,5 +151,46 @@ export function climbToQueueItem(climb: Climb, options?: { suggested?: boolean; 
       // Woods' two boards apart (see toClimbInput above).
       compatibleSizeIds: climb.compatibleSizeIds,
     },
+  };
+}
+
+/** The outcome of {@link resolveCommittableQueueItem}. */
+export type CommittableQueueItem = {
+  /** The item that is safe to dispatch. */
+  item: ClimbQueueItem;
+  /**
+   * True when a transient peek was minted into a real item — the caller must
+   * ADD it to the queue, because the thing it replaced was never in it.
+   */
+  converted: boolean;
+};
+
+/**
+ * Make a queue item safe to commit.
+ *
+ * `findNextQueueItemWithSuggestions` hands back a synthetic
+ * `playlist-peek:<climbUuid>` item for the next-up playlist suggestion. That
+ * uuid is a local rendering device: it is not in the queue, and
+ * `toQueueItemWireInput` sends `item.uuid` verbatim, so dispatching one puts a
+ * uuid on the wire that no peer can reconcile against their queue. Every path
+ * that turns a DISPLAYED item into a COMMITTED one has to launder it first.
+ *
+ * There are two such paths — the queue provider's `nextClimb()` and the play
+ * drawer's "Put on the wall" — and until the drawer could pin a peek (which the
+ * shared-session browse latch makes routine, since browsing walks the suggestion
+ * track item by item) only the first one did. Extracted here so a third commit
+ * path can't be written without it, and so the rule has one test instead of two
+ * hand-agreeing copies.
+ *
+ * `suggested: true` is preserved on the minted item so suggestion pruning still
+ * treats it as suggestion-origin. The peek carries the queue package's wide
+ * `Climb`; `climbToQueueItem` reads only the `ClimbInput` subset, so the cast is
+ * runtime-safe.
+ */
+export function resolveCommittableQueueItem(item: ClimbQueueItem): CommittableQueueItem {
+  if (!isPlaylistPeekQueueItemUuid(item.uuid)) return { item, converted: false };
+  return {
+    item: climbToQueueItem(item.climb as unknown as Climb, { suggested: true }),
+    converted: true,
   };
 }

--- a/packages/mobile/src/lib/climb-to-queue-item.ts
+++ b/packages/mobile/src/lib/climb-to-queue-item.ts
@@ -175,12 +175,9 @@ export type CommittableQueueItem = {
  * uuid on the wire that no peer can reconcile against their queue. Every path
  * that turns a DISPLAYED item into a COMMITTED one has to launder it first.
  *
- * There are two such paths — the queue provider's `nextClimb()` and the play
- * drawer's "Put on the wall" — and until the drawer could pin a peek (which the
- * shared-session browse latch makes routine, since browsing walks the suggestion
- * track item by item) only the first one did. Extracted here so a third commit
- * path can't be written without it, and so the rule has one test instead of two
- * hand-agreeing copies.
+ * Used by both queue navigation directions and the drawer's "Put on the wall"
+ * action. Shared-session browsing can pin a peek before committing it, so all
+ * three paths use the same conversion.
  *
  * `suggested: true` is preserved on the minted item so suggestion pruning still
  * treats it as suggestion-origin. The peek carries the queue package's wide

--- a/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
+++ b/packages/mobile/src/lib/playlists/__tests__/use-playlist-activation.test.tsx
@@ -131,6 +131,7 @@ function renderActivation(
     allClimbs?: Climb[];
     sourceId?: string;
     viewOnlyBoard?: typeof VIEW_ONLY_BOARD | ((climb: Climb) => typeof VIEW_ONLY_BOARD | null) | null;
+    previewOnly?: boolean;
     replaceQueueOnActivate?: boolean;
   } = {},
 ) {
@@ -140,6 +141,7 @@ function renderActivation(
       allClimbs: options.allClimbs ?? [],
       fetchPage,
       viewOnlyBoard: options.viewOnlyBoard,
+      previewOnly: options.previewOnly,
       refreshErrorMessage: 'refresh failed:',
       replaceQueueOnActivate: options.replaceQueueOnActivate,
     }),
@@ -355,6 +357,124 @@ describe('usePlaylistActivation (mobile wrapper)', () => {
       }),
     });
     expect(mocks.activate).not.toHaveBeenCalled();
+  });
+
+  // `previewOnly` is how a shared session turns a climb-list row tap into
+  // browsing: same view-only landing as the wrong-board branch, but on the board
+  // the climber is standing at, and seeded with the list they tapped from so the
+  // drawer's swipes walk it.
+  describe('previewOnly (shared session)', () => {
+    it('opens the tapped climb view-only on the ACTIVE board, seeded with this list', async () => {
+      const climbA = makeClimb('a');
+      const climbB = makeClimb('b');
+      const fetchPage = vi.fn();
+      const { result } = renderActivation(fetchPage, {
+        allClimbs: [climbA, climbB],
+        sourceId: 'climblist',
+        previewOnly: true,
+      });
+
+      await result.current.activate(climbA);
+
+      expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climbA, {
+        previewQueueItem: expect.objectContaining({ climb: climbA }),
+        playlistSuggestionSource: expect.objectContaining({
+          playlistUuid: 'climblist',
+          activatedClimbUuid: 'a',
+          // The ACTIVE board's key — no board override, unlike the wrong-board
+          // branch. A source keyed to another board would never match.
+          boardKey: 'kilter:1:2:3',
+          climbs: [climbA, climbB],
+        }),
+      });
+      // The whole point: a row tap in a crew writes nothing.
+      expect(mocks.setCurrentClimb).not.toHaveBeenCalled();
+      expect(mocks.setQueue).not.toHaveBeenCalled();
+      expect(mocks.activate).not.toHaveBeenCalled();
+      expect(fetchPage).not.toHaveBeenCalled();
+    });
+
+    it('passes no board override, so the drawer stays on the board the climber is at', async () => {
+      const climb = makeClimb('a');
+      const { result } = renderActivation(vi.fn(), { allClimbs: [climb], previewOnly: true });
+
+      await result.current.activate(climb);
+
+      expect(mocks.openPlayDrawer.mock.calls[0][1]).not.toHaveProperty('boardConfig');
+    });
+
+    it('still previews when no active board has resolved yet', async () => {
+      // No board means no suggestion source to key — but a dead tap would be its
+      // own regression, so the climb still opens.
+      mocks.activeBoard = null;
+      const climb = makeClimb('a');
+      const { result } = renderActivation(vi.fn(), { allClimbs: [climb], previewOnly: true });
+
+      await result.current.activate(climb);
+
+      expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, {
+        previewQueueItem: expect.objectContaining({ climb }),
+        playlistSuggestionSource: null,
+      });
+      expect(mocks.setCurrentClimb).not.toHaveBeenCalled();
+    });
+
+    it('re-tapping the already-active climb previews it too, instead of reopening live', async () => {
+      // Solo this is a pure reopen (`committedExternally`). In a crew the tap has
+      // to leave the drawer browsing, or the climber's next swipe would drive the
+      // crew's wall from a state they thought was view-only.
+      mocks.activeClimbUuid = 'a';
+      mocks.suggestionSource = { playlistUuid: 'climblist', activatedClimbUuid: 'a', boardKey: 'kilter:1:2:3' };
+      const climb = makeClimb('a');
+      const { result } = renderActivation(vi.fn(), { allClimbs: [climb], sourceId: 'climblist', previewOnly: true });
+
+      await result.current.activate(climb);
+
+      expect(mocks.openPlayDrawer.mock.calls[0][1]).toEqual(
+        expect.objectContaining({ previewQueueItem: expect.objectContaining({ climb }) }),
+      );
+      expect(mocks.openPlayDrawer.mock.calls[0][1]).not.toHaveProperty('committedExternally');
+    });
+
+    it('beats replace-on-activate — a row tap never replaces a crew queue', async () => {
+      // Replacing the whole queue is the loudest write in the app. Ordering
+      // matters here, not just the flag: with the branches the other way round a
+      // playlist tap in a crew would wipe everyone's upcoming climbs.
+      const climb = makeClimb('a');
+      const { result } = renderActivation(vi.fn(), {
+        allClimbs: [climb],
+        previewOnly: true,
+        replaceQueueOnActivate: true,
+      });
+
+      await result.current.activate(climb);
+
+      expect(mocks.setQueue).not.toHaveBeenCalled();
+      expect(mocks.openPlayDrawer.mock.calls[0][1]).toHaveProperty('previewQueueItem');
+    });
+
+    it('yields to a wrong-board tap, which needs its own board override', async () => {
+      const climb = { ...makeClimb('a'), angle: 20 };
+      const { result } = renderActivation(vi.fn(), {
+        allClimbs: [climb],
+        previewOnly: true,
+        viewOnlyBoard: VIEW_ONLY_BOARD,
+      });
+
+      await result.current.activate(climb);
+
+      expect(mocks.openPlayDrawer.mock.calls[0][1]).toHaveProperty('boardConfig', { ...VIEW_ONLY_BOARD, angle: 20 });
+    });
+
+    it('leaves the solo tap committing, exactly as before', async () => {
+      const climb = makeClimb('a');
+      const { result } = renderActivation(vi.fn(), { allClimbs: [climb], previewOnly: false });
+
+      await result.current.activate(climb);
+
+      expect(mocks.activate).toHaveBeenCalledWith(climb);
+      expect(mocks.openPlayDrawer).toHaveBeenCalledWith(climb, { committedExternally: true });
+    });
   });
 
   it('fetchClimbsForBoard pages the playlist via the injected fetchPage', async () => {

--- a/packages/mobile/src/lib/playlists/use-playlist-activation.ts
+++ b/packages/mobile/src/lib/playlists/use-playlist-activation.ts
@@ -126,6 +126,17 @@ export type UsePlaylistActivationOptions = {
    * when that row should activate normally.
    */
   viewOnlyBoard?: PlaylistRenderBoard | ViewOnlyBoardResolver | null;
+  /**
+   * When true, a tap is view-only on the ACTIVE board: the drawer opens on the
+   * tapped climb with this list seeded as its swipe track, and the queue is not
+   * touched until the climber puts a climb up from the commit row.
+   *
+   * Same landing as `viewOnlyBoard`, different reason — that one is "this climb
+   * is on a board you're not on", this one is "there are other climbers in this
+   * session, so a row tap must not take their wall". Read live at tap time, so a
+   * crew forming or breaking up between render and tap is honoured.
+   */
+  previewOnly?: boolean;
   /** Logged when the async suggestion refresh fails (non-abort). */
   refreshErrorMessage: string;
   /** Replace the user's queue with the playlist order instead of suggestion-fallback navigation. */
@@ -206,6 +217,7 @@ export function usePlaylistActivation({
   allClimbs,
   fetchPage,
   viewOnlyBoard,
+  previewOnly = false,
   refreshErrorMessage,
   replaceQueueOnActivate = false,
 }: UsePlaylistActivationOptions): PlaylistActivationResult {
@@ -231,6 +243,13 @@ export function usePlaylistActivation({
   const playlistSuggestionSource = usePlaylistSuggestionSource();
   const playlistSuggestionSourceRef = useRef(playlistSuggestionSource);
   playlistSuggestionSourceRef.current = playlistSuggestionSource;
+
+  // Mirrored, not a dependency: `previewOnly` tracks whether anyone else is in
+  // the session, and threading it through the callback's deps would churn the
+  // identity of every climb row's onPress the moment a crew forms — for a value
+  // the callback only needs at tap time.
+  const previewOnlyRef = useRef(previewOnly);
+  previewOnlyRef.current = previewOnly;
 
   // The climbs the screen has loaded, mirrored into a ref so the empty-fetch
   // canary below can read them without putting `allClimbs` in
@@ -560,6 +579,36 @@ export function usePlaylistActivation({
           boardConfig: viewOnlyBoardConfig,
           previewQueueItem: item,
           playlistSuggestionSource: previewSuggestionSource,
+        });
+        return Promise.resolve();
+      }
+
+      // Browse-only tap on the ACTIVE board (a shared session). Same landing as
+      // the wrong-board branch above — drawer opens on the tapped climb, queue
+      // untouched — with two differences: no board override (this climb is on the
+      // board the climber is standing at), and the suggestion source is keyed to
+      // the ACTIVE board so the drawer's swipes walk this list instead of the
+      // queue. Ordered ahead of `replaceQueueOnActivate` deliberately: replacing a
+      // crew's whole queue is the loudest write in the app, and a row tap must
+      // never be it.
+      if (previewOnlyRef.current) {
+        const target = resolveTarget(climb);
+        openPlayDrawer(schemaClimb, {
+          previewQueueItem: climbToQueueItem(schemaClimb),
+          // A null target (no resolvable board) deliberately degrades to a
+          // trackless preview: the tapped climb still shows, swipes just walk
+          // the queue instead of this list — the same fallback the wrong-board
+          // branch above has always had. It should be unreachable here (the
+          // gate only fires in a shared session, where an active board
+          // resolved), so degrading beats blocking the tap on a broken invariant.
+          playlistSuggestionSource: target
+            ? createPlaylistSuggestionSource({
+                playlistUuid: sourceId,
+                activatedClimb: climb,
+                climbs: allClimbs,
+                boardKey: target.boardKey,
+              })
+            : null,
         });
         return Promise.resolve();
       }

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -831,6 +831,71 @@ describe('DrawerHostProvider play drawer open target', () => {
     await waitFor(() => expect(routes.at(-1)?.playTarget?.climb).toBe(climb));
     expect(routes.at(-1)?.playTarget?.options).toEqual({ committedExternally: true });
   });
+
+  // The close reset runs from the route's UNMOUNT cleanup — the end of the
+  // dismiss animation — and the list underneath is live and tappable for that
+  // whole window. A tap landing there writes a target the closing route never
+  // applies; clearing it unconditionally swallowed the tap and the drawer came
+  // back on the previous climb. So the reset may only clear a target the route
+  // actually CONSUMED.
+  it('keeps a target the closing route never applied', async () => {
+    const hosts: Array<HostValue> = [];
+    const routes: Array<RouteValue> = [];
+    renderHost(
+      (host) => hosts.push(host),
+      (route) => routes.push(route),
+    );
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    const firstClimb = makeQueueItem('queue-a', 'climb-a').climb as unknown as Climb;
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(firstClimb);
+    });
+    await waitFor(() => expect(routes.at(-1)?.playTarget?.climb).toBe(firstClimb));
+    // The route mounts and applies it.
+    act(() => {
+      routes.at(-1)?.onPlayDrawerTargetConsumed(routes.at(-1)!.playTarget!.nonce);
+    });
+
+    // The climber starts dismissing and taps the next row before unmount. The
+    // route is already going away, so it never applies this one.
+    const secondClimb = makeQueueItem('queue-b', 'climb-b').climb as unknown as Climb;
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(secondClimb);
+    });
+    act(() => {
+      routes.at(-1)?.onPlayDrawerClosed();
+    });
+
+    // The tap survives: the next mount serves it instead of swallowing it.
+    await waitFor(() => expect(routes.at(-1)?.playTarget?.climb).toBe(secondClimb));
+  });
+
+  it('still clears the target the route did apply', async () => {
+    // The other half — without this the reset would never fire and a stale climb
+    // could replay on a remount, which is what it exists to prevent.
+    const hosts: Array<HostValue> = [];
+    const routes: Array<RouteValue> = [];
+    renderHost(
+      (host) => hosts.push(host),
+      (route) => routes.push(route),
+    );
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    const climb = makeQueueItem('queue-c', 'climb-c').climb as unknown as Climb;
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(climb);
+    });
+    await waitFor(() => expect(routes.at(-1)?.playTarget?.climb).toBe(climb));
+    act(() => {
+      routes.at(-1)?.onPlayDrawerTargetConsumed(routes.at(-1)!.playTarget!.nonce);
+    });
+    act(() => {
+      routes.at(-1)?.onPlayDrawerClosed();
+    });
+
+    await waitFor(() => expect(routes.at(-1)?.playTarget).toBeNull());
+  });
 });
 
 describe('DrawerHostProvider play drawer board overrides', () => {

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -286,7 +286,13 @@ vi.mock('../../lib/climb-to-queue-item', () => ({
 }));
 
 import { router } from 'expo-router';
-import { DrawerHostProvider, useDrawerHost, usePlayDrawerRoute, type BoardConfig } from '../drawer-host-provider';
+import {
+  DrawerHostProvider,
+  useDrawerHost,
+  usePlayDrawerRoute,
+  usePreviewedClimbUuid,
+  type BoardConfig,
+} from '../drawer-host-provider';
 import type { BoardSheetClimbAction } from '../../components/board-presence/BoardSheet';
 
 const routerPush = router.push as unknown as ReturnType<typeof vi.fn>;
@@ -315,15 +321,21 @@ function makeQueueItem(uuid: string, climbUuid = uuid): ClimbQueueItem {
   };
 }
 
+const previewedClimbUuids: Array<string | null> = [];
+
 function Probe({ onHost, onRoute }: { onHost: (host: HostValue) => void; onRoute: (route: RouteValue) => void }) {
   const host = useDrawerHost();
   const route = usePlayDrawerRoute();
+  const previewedClimbUuid = usePreviewedClimbUuid();
   useEffect(() => {
     onHost(host);
   }, [host, onHost]);
   useEffect(() => {
     onRoute(route);
   }, [route, onRoute]);
+  useEffect(() => {
+    previewedClimbUuids.push(previewedClimbUuid);
+  }, [previewedClimbUuid]);
   return null;
 }
 
@@ -347,6 +359,7 @@ beforeEach(() => {
   presence.resetPresence.mockClear();
   queue.setCurrentClimb.mockClear();
   queue.activeClimbUuid = null;
+  previewedClimbUuids.length = 0;
   layoutCfg.widthClass = 'compact';
 });
 
@@ -871,6 +884,42 @@ describe('DrawerHostProvider play drawer open target', () => {
     await waitFor(() => expect(routes.at(-1)?.playTarget?.climb).toBe(secondClimb));
   });
 
+  // Same window, other half of the open: the board override is written by the
+  // same `openPlayDrawer` call as the target, and the next mount reads its board
+  // from it. Keeping the target while clearing the override replayed a climb
+  // from another board against the stored one.
+  it('keeps the board override alongside a target the closing route never applied', async () => {
+    const hosts: Array<HostValue> = [];
+    const routes: Array<RouteValue> = [];
+    renderHost(
+      (host) => hosts.push(host),
+      (route) => routes.push(route),
+    );
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    const firstClimb = makeQueueItem('queue-a', 'climb-a').climb as unknown as Climb;
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(firstClimb);
+    });
+    await waitFor(() => expect(routes.at(-1)?.playTarget?.climb).toBe(firstClimb));
+    act(() => {
+      routes.at(-1)?.onPlayDrawerTargetConsumed(routes.at(-1)!.playTarget!.nonce);
+    });
+
+    const otherBoard: BoardConfig = { boardName: 'tension', layoutId: 8, sizeId: 7, setIds: '5,6', angle: 35 };
+    const secondClimb = makeQueueItem('queue-b', 'climb-b').climb as unknown as Climb;
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(secondClimb, { boardConfig: otherBoard });
+    });
+    await waitFor(() => expect(routes.at(-1)?.activeBoardConfig).toMatchObject(otherBoard));
+    act(() => {
+      routes.at(-1)?.onPlayDrawerClosed();
+    });
+
+    await waitFor(() => expect(routes.at(-1)?.playTarget?.climb).toBe(secondClimb));
+    expect(routes.at(-1)?.activeBoardConfig).toMatchObject(otherBoard);
+  });
+
   it('still clears the target the route did apply', async () => {
     // The other half — without this the reset would never fire and a stale climb
     // could replay on a remount, which is what it exists to prevent.
@@ -895,6 +944,51 @@ describe('DrawerHostProvider play drawer open target', () => {
     });
 
     await waitFor(() => expect(routes.at(-1)?.playTarget).toBeNull());
+  });
+});
+
+describe('DrawerHostProvider previewed-climb highlight', () => {
+  // A preview outlives the drawer as "the climb you last had up" — until something
+  // is actually put up after it. Solo with `lightOnSwipe` on, an explicit Preview
+  // of A followed by a swipe commits B through the queue; the list must move to B.
+  it('yields to the next committed climb', async () => {
+    const hosts: Array<HostValue> = [];
+    const view = renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    const previewed = makeQueueItem('queue-a', 'climb-a');
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(previewed.climb as unknown as Climb, { previewQueueItem: previewed });
+    });
+    await waitFor(() => expect(previewedClimbUuids.at(-1)).toBe('climb-a'));
+
+    // The queue head moves on (a swipe committed B).
+    queue.activeClimbUuid = 'climb-b';
+    view.rerender(
+      createElement(DrawerHostProvider, null, createElement(Probe, { onHost: () => {}, onRoute: () => {} })),
+    );
+
+    await waitFor(() => expect(previewedClimbUuids.at(-1)).toBeNull());
+  });
+
+  it('keeps the highlight while the queue head is unchanged', async () => {
+    // The clear keys on the head CHANGING: the provider re-renders constantly
+    // (presence, stats) and none of that may cost the climber their highlight.
+    queue.activeClimbUuid = 'climb-head';
+    const hosts: Array<HostValue> = [];
+    const view = renderHost((host) => hosts.push(host));
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    const previewed = makeQueueItem('queue-a', 'climb-a');
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(previewed.climb as unknown as Climb, { previewQueueItem: previewed });
+    });
+    await waitFor(() => expect(previewedClimbUuids.at(-1)).toBe('climb-a'));
+
+    view.rerender(
+      createElement(DrawerHostProvider, null, createElement(Probe, { onHost: () => {}, onRoute: () => {} })),
+    );
+    expect(previewedClimbUuids.at(-1)).toBe('climb-a');
   });
 });
 

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -7,6 +7,15 @@ import { isPlaylistPeekQueueItemUuid } from '@boardsesh/queue';
 import type { ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
 import type { SessionStatus, SessionUser, UserBoard } from '@boardsesh/shared-schema';
 
+// The preview-first gate is flagged. Default it ON here so these tests exercise
+// the roster logic rather than the rollout switch; one test below flips it off
+// and asserts the switch itself, because a flag wired to nothing would leave the
+// whole feature inert with every other case in this file still green.
+const browseFlag = vi.hoisted(() => ({ enabled: true }));
+vi.mock('../feature-flags-provider', () => ({
+  useSharedSessionBrowseEnabled: () => browseFlag.enabled,
+}));
+
 const ws = vi.hoisted(() => {
   type WsEventName = 'connected' | 'closed';
   type WsEvent = { code: number; reason: string; wasClean: boolean };
@@ -226,11 +235,13 @@ vi.mock('../../lib/auth-transport-revision', async () => import('../../lib/auth-
 import {
   QueueProvider,
   useHasActiveClimb,
+  useIsSharedSession,
   usePlaylistSuggestionSource,
   useQueue,
   useQueueLiveStats,
   useQueueSessionControls,
   useQueueSessionId,
+  SHARED_SESSION_DWELL_MS,
 } from '../queue-provider';
 import { clearStoredSessionId } from '../../lib/session-store';
 import { track } from '../../lib/analytics';
@@ -275,6 +286,7 @@ type Snapshot = {
 type SelectorSnapshot = {
   sessionIdValue: ReturnType<typeof useQueueSessionId>;
   hasActiveClimb: boolean;
+  isSharedSession: boolean;
 };
 
 const user = (overrides: Partial<SessionUser> = {}): SessionUser => ({
@@ -400,9 +412,14 @@ function Probe({ onSnapshot }: { onSnapshot: (snapshot: Snapshot) => void }) {
 function SelectorProbe({ onSnapshot }: { onSnapshot: (snapshot: SelectorSnapshot) => void }) {
   const sessionIdValue = useQueueSessionId();
   const hasActiveClimb = useHasActiveClimb();
+  // The gate that turns swipes and list taps into browsing. Derived from the
+  // roster in the provider, so this is the only place the derivation can be
+  // observed — the pure rule's own tests can't see whether it is wired to
+  // anything.
+  const isSharedSession = useIsSharedSession();
   useEffect(() => {
-    onSnapshot({ sessionIdValue, hasActiveClimb });
-  }, [hasActiveClimb, onSnapshot, sessionIdValue]);
+    onSnapshot({ sessionIdValue, hasActiveClimb, isSharedSession });
+  }, [hasActiveClimb, isSharedSession, onSnapshot, sessionIdValue]);
   return null;
 }
 
@@ -448,6 +465,7 @@ function executeVariablesFor(marker: string): Record<string, unknown> | undefine
 
 describe('QueueProvider session update subscription', () => {
   beforeEach(() => {
+    browseFlag.enabled = true;
     ws.reset();
     ws.client.on.mockClear();
     ws.client.subscribe.mockClear();
@@ -998,6 +1016,245 @@ describe('QueueProvider session update subscription', () => {
       const latestSnapshot = snapshots.at(-1);
       expect(latestSnapshot?.users.map((entry) => entry.id)).toEqual(['participant-self', 'participant-2']);
     });
+  });
+
+  // The join between the pure rule (`shouldDefaultToBrowse`) and the live
+  // roster. The rule's own table tests can't see whether the provider calls it —
+  // hardcoding `false` here would leave the whole preview-first feature inert
+  // with every other suite green, and hardcoding `true` would take one-swipe wall
+  // control away from every solo climber who ever started a session.
+  it('turns gestures into browsing only once a second climber is on the roster', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const snapshots: Snapshot[] = [];
+    const selectorSnapshots: SelectorSnapshot[] = [];
+    renderProviderWithSelectors(
+      (snapshot) => snapshots.push(snapshot),
+      (selectorSnapshot) => selectorSnapshots.push(selectorSnapshot),
+    );
+
+    await waitFor(() => {
+      expect(ws.getSessionUpdatesSink()).not.toBeNull();
+      expect(selectorSnapshots.at(-1)).toBeDefined();
+    });
+    // A session of one is still solo: this is the ordinary state right after
+    // starting a session, and it must keep one-swipe wall control.
+    expect(selectorSnapshots.at(-1)?.isSharedSession).toBe(false);
+
+    const sessionUpdatesSink = ws.getSessionUpdatesSink();
+    if (!sessionUpdatesSink) throw new Error('session updates sink was not captured');
+
+    act(() => {
+      sessionUpdatesSink.next({
+        data: {
+          sessionUpdates: {
+            __typename: 'UserJoined',
+            user: user({ id: 'participant-2', username: 'Bo', userId: 'db-bo' }),
+          },
+        },
+      });
+    });
+
+    // The gate does NOT arm on arrival. A peer has to still be there after the
+    // dwell — see SHARED_SESSION_DWELL_MS — because the roster briefly doubles a
+    // lone climber on a reconnect, and arming on that took their board away.
+    expect(selectorSnapshots.at(-1)?.isSharedSession).toBe(false);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SHARED_SESSION_DWELL_MS + 100);
+    });
+
+    await waitFor(() => {
+      expect(selectorSnapshots.at(-1)?.isSharedSession).toBe(true);
+    });
+
+    // A third climber changes nothing, and must not churn the value: this
+    // boolean is read by the drawer (board art) and the climb list (a
+    // virtualized FlashList), which is why it lives in its own selector context.
+    const settledCount = selectorSnapshots.length;
+    act(() => {
+      sessionUpdatesSink.next({
+        data: {
+          sessionUpdates: {
+            __typename: 'UserJoined',
+            user: user({ id: 'participant-3', username: 'Cy', userId: 'db-cy' }),
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(snapshots.at(-1)?.users).toHaveLength(3);
+    });
+    expect(selectorSnapshots).toHaveLength(settledCount);
+    expect(selectorSnapshots.at(-1)?.isSharedSession).toBe(true);
+    vi.useRealTimers();
+  });
+
+  // The rollout switch. A flag wired to nothing is the failure mode this repo has
+  // already shipped twice (gym-kiosk, logbook-grouping-kill), and here it would
+  // be un-killable: the whole point of gating this feature is being able to turn
+  // it off from PostHog without another release.
+  it('leaves gestures alone entirely when the flag is off', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    browseFlag.enabled = false;
+    const selectorSnapshots: SelectorSnapshot[] = [];
+    renderProviderWithSelectors(
+      () => {},
+      (selectorSnapshot) => selectorSnapshots.push(selectorSnapshot),
+    );
+
+    await waitFor(() => {
+      expect(ws.getSessionUpdatesSink()).not.toBeNull();
+      expect(selectorSnapshots.at(-1)).toBeDefined();
+    });
+    const sessionUpdatesSink = ws.getSessionUpdatesSink();
+    if (!sessionUpdatesSink) throw new Error('session updates sink was not captured');
+
+    act(() => {
+      sessionUpdatesSink.next({
+        data: {
+          sessionUpdates: {
+            __typename: 'UserJoined',
+            user: user({ id: 'participant-2', username: 'Bo', userId: 'db-bo' }),
+          },
+        },
+      });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SHARED_SESSION_DWELL_MS + 100);
+    });
+
+    expect(selectorSnapshots.at(-1)?.isSharedSession).toBe(false);
+    vi.useRealTimers();
+  });
+
+  // The regression that took #4683 out of production. A reconnect that lands
+  // before the previous connection's `UserLeft` leaves a second roster entry for
+  // ONE human, keyed on the dead connection id with no userId — a different key
+  // from the live entry, so nothing merges them. Counting roster participants
+  // read that as a crew and stopped a lone climber's swipes from lighting their
+  // own board, with no visible cause and no way back.
+  it('does not read a climber\u2019s own stale reconnect entry as a crew', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const selectorSnapshots: SelectorSnapshot[] = [];
+    renderProviderWithSelectors(
+      () => {},
+      (selectorSnapshot) => selectorSnapshots.push(selectorSnapshot),
+    );
+
+    await waitFor(() => {
+      expect(ws.getSessionUpdatesSink()).not.toBeNull();
+      expect(selectorSnapshots.at(-1)).toBeDefined();
+    });
+    const sessionUpdatesSink = ws.getSessionUpdatesSink();
+    if (!sessionUpdatesSink) throw new Error('session updates sink was not captured');
+
+    act(() => {
+      sessionUpdatesSink.next({
+        data: {
+          sessionUpdates: {
+            __typename: 'UserJoined',
+            user: user({
+              id: 'dead-connection',
+              username: 'Self',
+              userId: null,
+              connectionState: 'RECONNECTING',
+            }),
+          },
+        },
+      });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SHARED_SESSION_DWELL_MS + 100);
+    });
+
+    expect(selectorSnapshots.at(-1)?.isSharedSession).toBe(false);
+    vi.useRealTimers();
+  });
+
+  // The dwell earning its keep: a peer who appears and is gone again before it
+  // elapses never arms the gate at all, so a roster that flaps cannot cost a
+  // climber their wall even for the one swipe they were mid-way through.
+  it('never arms for a peer who comes and goes inside the dwell', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const selectorSnapshots: SelectorSnapshot[] = [];
+    renderProviderWithSelectors(
+      () => {},
+      (selectorSnapshot) => selectorSnapshots.push(selectorSnapshot),
+    );
+
+    await waitFor(() => {
+      expect(ws.getSessionUpdatesSink()).not.toBeNull();
+      expect(selectorSnapshots.at(-1)).toBeDefined();
+    });
+    const sessionUpdatesSink = ws.getSessionUpdatesSink();
+    if (!sessionUpdatesSink) throw new Error('session updates sink was not captured');
+
+    act(() => {
+      sessionUpdatesSink.next({
+        data: {
+          sessionUpdates: {
+            __typename: 'UserJoined',
+            user: user({ id: 'participant-2', username: 'Bo', userId: 'db-bo' }),
+          },
+        },
+      });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SHARED_SESSION_DWELL_MS / 2);
+    });
+    act(() => {
+      sessionUpdatesSink.next({
+        data: { sessionUpdates: { __typename: 'UserLeft', userId: 'participant-2' } },
+      });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SHARED_SESSION_DWELL_MS * 2);
+    });
+
+    expect(selectorSnapshots.at(-1)?.isSharedSession).toBe(false);
+    vi.useRealTimers();
+  });
+
+  // Committing is now the ONE deliberate act that moves a shared wall — every
+  // browse-shaped gesture stopped firing this event — so it has to say which crew
+  // and how many people were in it. Without those two properties the question the
+  // whole preview-first change exists to answer ("did people stop stepping on
+  // each other") has no numerator.
+  it('stamps the crew and its size on the commit event', async () => {
+    const snapshots: Snapshot[] = [];
+    renderProvider((snapshot) => snapshots.push(snapshot));
+
+    await waitFor(() => expect(ws.getSessionUpdatesSink()).not.toBeNull());
+    const sessionUpdatesSink = ws.getSessionUpdatesSink();
+    if (!sessionUpdatesSink) throw new Error('session updates sink was not captured');
+
+    act(() => {
+      sessionUpdatesSink.next({
+        data: {
+          sessionUpdates: {
+            __typename: 'UserJoined',
+            user: user({ id: 'participant-2', username: 'Bo', userId: 'db-bo' }),
+          },
+        },
+      });
+    });
+    await waitFor(() => expect(snapshots.at(-1)?.users).toHaveLength(2));
+
+    vi.mocked(track).mockClear();
+    act(() => {
+      snapshots.at(-1)?.setCurrentClimb(makeQueueItem('commit-1', 'climb-commit-1'));
+    });
+
+    expect(vi.mocked(track)).toHaveBeenCalledWith(
+      SHARED_EVENTS.SetActiveClimb,
+      expect.objectContaining({
+        climbUuid: 'climb-commit-1',
+        sessionId: 'session-1',
+        // Distinct humans, the same count `partyMode` is derived from on Climb
+        // Added to Queue — not raw connection rows.
+        participantCount: 2,
+      }),
+    );
   });
 
   it('exposes the shared party wall actions through the mobile queue context', async () => {

--- a/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
+++ b/packages/mobile/src/providers/__tests__/queue-provider-session-updates.test.tsx
@@ -1215,6 +1215,136 @@ describe('QueueProvider session update subscription', () => {
     vi.useRealTimers();
   });
 
+  // A peer's socket blip is not a departure. Their seat is still on the roster
+  // (the server holds it for a minute), their wall stakes did not go anywhere,
+  // and dropping the gate the instant they flap made the climber's next swipe
+  // commit to the shared queue — with the arming dwell then owed on top when the
+  // peer came back. Held, the gate stands until the peer is actually gone.
+  it('holds an armed gate while a peer is reconnecting, and releases when they are evicted', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const selectorSnapshots: SelectorSnapshot[] = [];
+    renderProviderWithSelectors(
+      () => {},
+      (selectorSnapshot) => selectorSnapshots.push(selectorSnapshot),
+    );
+
+    await waitFor(() => {
+      expect(ws.getSessionUpdatesSink()).not.toBeNull();
+      expect(selectorSnapshots.at(-1)).toBeDefined();
+    });
+    const sessionUpdatesSink = ws.getSessionUpdatesSink();
+    if (!sessionUpdatesSink) throw new Error('session updates sink was not captured');
+
+    const bo = { id: 'participant-2', username: 'Bo', userId: 'db-bo' };
+    act(() => {
+      sessionUpdatesSink.next({
+        data: { sessionUpdates: { __typename: 'UserJoined', user: user(bo) } },
+      });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SHARED_SESSION_DWELL_MS + 100);
+    });
+    await waitFor(() => {
+      expect(selectorSnapshots.at(-1)?.isSharedSession).toBe(true);
+    });
+
+    // Bo's wifi drops. The server parks the seat and tells everyone.
+    act(() => {
+      sessionUpdatesSink.next({
+        data: {
+          sessionUpdates: {
+            __typename: 'UserPresenceChanged',
+            user: user({ ...bo, connectionState: 'RECONNECTING' }),
+          },
+        },
+      });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SHARED_SESSION_DWELL_MS * 2);
+    });
+    expect(selectorSnapshots.at(-1)?.isSharedSession).toBe(true);
+
+    // Bo is back: no dwell owed, the gate never dropped.
+    act(() => {
+      sessionUpdatesSink.next({
+        data: {
+          sessionUpdates: {
+            __typename: 'UserPresenceChanged',
+            user: user({ ...bo, connectionState: 'CONNECTED' }),
+          },
+        },
+      });
+    });
+    expect(selectorSnapshots.at(-1)?.isSharedSession).toBe(true);
+
+    // Bo drops again and this time the grace window runs out: the server evicts
+    // the seat, and THAT hands the wall back — immediately, no release dwell.
+    act(() => {
+      sessionUpdatesSink.next({
+        data: {
+          sessionUpdates: {
+            __typename: 'UserPresenceChanged',
+            user: user({ ...bo, connectionState: 'RECONNECTING' }),
+          },
+        },
+      });
+    });
+    act(() => {
+      sessionUpdatesSink.next({
+        data: { sessionUpdates: { __typename: 'UserLeft', userId: 'participant-2' } },
+      });
+    });
+    await waitFor(() => {
+      expect(selectorSnapshots.at(-1)?.isSharedSession).toBe(false);
+    });
+    vi.useRealTimers();
+  });
+
+  // The hold must never turn into an arm. A peer who joins, drops inside the
+  // dwell and sits in the grace window is exactly the shape of a lone climber's
+  // own stale connection — so it must not become a crew however long it lingers.
+  it('never arms for a peer who goes reconnecting before the dwell elapses', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const selectorSnapshots: SelectorSnapshot[] = [];
+    renderProviderWithSelectors(
+      () => {},
+      (selectorSnapshot) => selectorSnapshots.push(selectorSnapshot),
+    );
+
+    await waitFor(() => {
+      expect(ws.getSessionUpdatesSink()).not.toBeNull();
+      expect(selectorSnapshots.at(-1)).toBeDefined();
+    });
+    const sessionUpdatesSink = ws.getSessionUpdatesSink();
+    if (!sessionUpdatesSink) throw new Error('session updates sink was not captured');
+
+    const bo = { id: 'participant-2', username: 'Bo', userId: 'db-bo' };
+    act(() => {
+      sessionUpdatesSink.next({
+        data: { sessionUpdates: { __typename: 'UserJoined', user: user(bo) } },
+      });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SHARED_SESSION_DWELL_MS / 2);
+    });
+    act(() => {
+      sessionUpdatesSink.next({
+        data: {
+          sessionUpdates: {
+            __typename: 'UserPresenceChanged',
+            user: user({ ...bo, connectionState: 'RECONNECTING' }),
+          },
+        },
+      });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SHARED_SESSION_DWELL_MS * 3);
+    });
+
+    expect(selectorSnapshots.at(-1)?.isSharedSession).toBe(false);
+    vi.useRealTimers();
+  });
+
   // Committing is now the ONE deliberate act that moves a shared wall — every
   // browse-shaped gesture stopped firing this event — so it has to say which crew
   // and how many people were in it. Without those two properties the question the

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -40,7 +40,7 @@ import { boardLooselyMatches } from '../lib/boards/board-matches';
 import { useAuth } from './auth-provider';
 import { useReduceMotion } from '../hooks/use-reduce-motion';
 import { climbToQueueItem } from '../lib/climb-to-queue-item';
-import { useQueueActions, useQueueSessionControls } from './queue-provider';
+import { useActiveClimbUuid, useQueueActions, useQueueSessionControls } from './queue-provider';
 import { useDeviceLayout } from '../hooks/use-device-layout';
 import { resolveDetailPaneSurface } from '../theme/size-class';
 import { SIDEBAR_WIDTH } from '../theme/layout';
@@ -324,6 +324,22 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   // which is the bug this is here to fix. It reads as "the climb you last had
   // up", and outliving the drawer is what makes that sentence useful.
   const [previewedClimbUuid, setPreviewedClimbUuid] = useState<string | null>(null);
+  // ...but it IS cleared when the queue's committed climb moves on. A preview
+  // outlives the drawer as "the climb you last had up" only until something is
+  // actually put up after it: an explicit Preview of A followed by a swipe that
+  // commits B (solo, `lightOnSwipe` on) must highlight B, not keep pointing at
+  // A until the next list tap. Keys on the head CHANGING after mount — a
+  // re-render with the same head leaves the highlight alone — and a first
+  // commit from an empty queue counts as a change, since "tap a row, then swipe
+  // to commit" is the common shape and the head arriving under a pre-hydration
+  // preview is not.
+  const activeClimbUuid = useActiveClimbUuid();
+  const previousActiveClimbUuidRef = useRef(activeClimbUuid);
+  useEffect(() => {
+    if (previousActiveClimbUuidRef.current === activeClimbUuid) return;
+    previousActiveClimbUuidRef.current = activeClimbUuid;
+    setPreviewedClimbUuid(null);
+  }, [activeClimbUuid]);
   // The nonce of the last target the player route actually applied. See
   // `onPlayDrawerClosed` for why "consumed" and not "latest" is the right test.
   const consumedPlayTargetNonceRef = useRef(0);
@@ -526,7 +542,14 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   // snap back to the stored board, and clear the open target so a stray remount
   // can't replay a stale climb.
   const onPlayDrawerClosed = useCallback(() => {
-    setBoardConfigOverride(null);
+    // A target written since the last one the route applied belongs to a tap the
+    // route has not served yet (see below). Its board override was set in the
+    // same `openPlayDrawer` call and the next mount reads the board from
+    // `activeBoardConfig`, so the override has to survive with it — cleared here,
+    // a dismiss-window tap on a climb from another board would replay against
+    // the stored board with no way back to the one it was tapped on.
+    const targetPending = playTargetNonceRef.current !== consumedPlayTargetNonceRef.current;
+    if (!targetPending) setBoardConfigOverride(null);
     // Only drop the target this close was actually for. The reset runs from the
     // route's UNMOUNT cleanup — the end of the dismiss animation — and the list
     // underneath is live and tappable for that whole window (and for the pull-down

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -264,12 +264,43 @@ type PlayDrawerRouteValue = {
   /** Run from the route's unmount cleanup: clears the board override + open
    *  target so the next open starts clean. */
   onPlayDrawerClosed: () => void;
+  /** Report that the route has applied this target, so the close above knows
+   *  which one it is allowed to clear. */
+  onPlayDrawerTargetConsumed: (nonce: number) => void;
   /** The climb to show, with a bumped nonce per open so the route re-applies even
    *  when `router.navigate('/play')` is a no-op (re-tap while already open). */
   playTarget: PlayDrawerOpenTarget | null;
 };
 
 const PlayDrawerRouteContext = createContext<PlayDrawerRouteValue | null>(null);
+
+/**
+ * The climb a list should show as selected when it is NOT the queue's current
+ * climb — i.e. the drawer was opened as a view-only preview and never wrote the
+ * queue.
+ *
+ * Lists highlight their active row off `useActiveClimbUuid()`, which by
+ * construction only moves when the queue does. That was fine while every row tap
+ * committed; once a tap could open a preview instead, the highlight could never
+ * follow the tap, and a climber tapping down a filtered list got no feedback that
+ * anything had been selected at all.
+ *
+ * Its own context, memoized on the uuid, for the same reason
+ * `PlayDrawerRouteContext` is separate: the consumers are virtualized lists, and
+ * the wide `useDrawerHost()` value changes on every open.
+ */
+type PreviewedClimbValue = { previewedClimbUuid: string | null };
+
+const PreviewedClimbContext = createContext<PreviewedClimbValue>({ previewedClimbUuid: null });
+
+/**
+ * The previewed climb's uuid, or null when the queue's current climb is the
+ * honest answer. Resolve a row's selected state as
+ * `previewedClimbUuid ?? activeClimbUuid`.
+ */
+export function usePreviewedClimbUuid(): string | null {
+  return useContext(PreviewedClimbContext).previewedClimbUuid;
+}
 
 export function usePlayDrawerRoute(): PlayDrawerRouteValue {
   const context = useContext(PlayDrawerRouteContext);
@@ -283,6 +314,22 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   // route consumes this via usePlayDrawerRoute and runs PlayDrawer's openDrawer.
   const [playTarget, setPlayTarget] = useState<PlayDrawerOpenTarget | null>(null);
   const playTargetNonceRef = useRef(0);
+  // See PreviewedClimbContext. Set when an open is preview-shaped (the caller
+  // pinned a queue item the queue never receives), cleared when an open commits —
+  // from then on `activeClimbUuid` is accurate and tracks onward swipes too.
+  //
+  // Deliberately NOT cleared when the drawer closes. On a phone the player is a
+  // modal route, so the list is not on screen while it is open — clearing on
+  // dismiss would mean the highlight only ever existed where nobody could see it,
+  // which is the bug this is here to fix. It reads as "the climb you last had
+  // up", and outliving the drawer is what makes that sentence useful.
+  const [previewedClimbUuid, setPreviewedClimbUuid] = useState<string | null>(null);
+  // The nonce of the last target the player route actually applied. See
+  // `onPlayDrawerClosed` for why "consumed" and not "latest" is the right test.
+  const consumedPlayTargetNonceRef = useRef(0);
+  const onPlayDrawerTargetConsumed = useCallback((nonce: number) => {
+    consumedPlayTargetNonceRef.current = nonce;
+  }, []);
   // iPad regular width shows the PlayDrawer inline in the right-column pane
   // (IpadPlayPane) instead of the full-screen `/play` route. `paneTarget` is the
   // pane's equivalent of `playTarget`: the selected climb with a per-selection
@@ -451,6 +498,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     } else {
       setBoardConfigOverride(null);
     }
+    setPreviewedClimbUuid(openOptions.previewQueueItem ? climb.uuid : null);
     // iPad regular width hosts the drawer as a persistent right-column pane, so
     // drive it in place instead of navigating to `/play`. The pane reads
     // `paneTarget` via playDrawerPaneProps and re-applies on the bumped nonce (a
@@ -479,7 +527,22 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   // can't replay a stale climb.
   const onPlayDrawerClosed = useCallback(() => {
     setBoardConfigOverride(null);
-    setPlayTarget(null);
+    // Only drop the target this close was actually for. The reset runs from the
+    // route's UNMOUNT cleanup — the end of the dismiss animation — and the list
+    // underneath is live and tappable for that whole window (and for the pull-down
+    // that precedes it). A tap landing there sets a fresh target and finds
+    // `router.navigate('/play')` a no-op because the route is still in the stack,
+    // so an unguarded reset then nulls the target that tap just wrote and the
+    // drawer comes back on the previous climb. It reads as a dead tap.
+    //
+    // So the reset clears only a target the route actually CONSUMED. One that was
+    // written but never applied belongs to a tap that has not been served yet —
+    // replaying it on the next mount is the whole point, not a stale-climb bug.
+    // Previously the race was survivable by accident: every opener also wrote the
+    // queue, so the drawer still landed on the tapped climb even when the target
+    // was lost. Preview-shaped opens do not write the queue, which is what turned
+    // a latent race into a reproducible dead tap.
+    setPlayTarget((current) => (current && current.nonce === consumedPlayTargetNonceRef.current ? null : current));
   }, []);
 
   // Apply an angle change made from the play drawer's angle selector.
@@ -902,6 +965,8 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
     ],
   );
 
+  const previewedClimbValue = useMemo<PreviewedClimbValue>(() => ({ previewedClimbUuid }), [previewedClimbUuid]);
+
   // Volatile player state for the `app/play.tsx` route (separate context — see
   // PlayDrawerRouteValue — so the wide useDrawerHost consumers don't re-render
   // when this changes on every open).
@@ -914,6 +979,7 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       onAngleChange: handleAngleChange,
       onSwitchBoard: handleSwitchBoardFromDrawer,
       onPlayDrawerClosed,
+      onPlayDrawerTargetConsumed,
       playTarget,
     }),
     [
@@ -924,125 +990,128 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
       handleAngleChange,
       handleSwitchBoardFromDrawer,
       onPlayDrawerClosed,
+      onPlayDrawerTargetConsumed,
       playTarget,
     ],
   );
 
   return (
     <DrawerHostContext.Provider value={value}>
-      <PlayDrawerRouteContext.Provider value={routeValue}>
-        {children}
-        {logAscentData ? (
-          <LogAscentSheet
-            visible={logAscentVisible}
-            onClose={closeLogAscentSheet}
-            onFullyDismissed={clearLogAscentSheet}
-            climbUuid={logAscentData.climbUuid}
-            climbName={logAscentData.climbName}
-            boardName={logAscentData.boardName}
-            angle={logAscentData.angle}
-            isMirror={logAscentData.isMirror}
-            isBenchmark={logAscentData.isBenchmark}
-            baseAscensionistCount={logAscentData.baseAscensionistCount}
-            layoutId={logAscentData.layoutId}
-            sizeId={logAscentData.sizeId}
-            setIds={logAscentData.setIds}
-            sessionId={logAscentData.sessionId}
-            consensusGradeName={logAscentData.consensusGradeName}
+      <PreviewedClimbContext.Provider value={previewedClimbValue}>
+        <PlayDrawerRouteContext.Provider value={routeValue}>
+          {children}
+          {logAscentData ? (
+            <LogAscentSheet
+              visible={logAscentVisible}
+              onClose={closeLogAscentSheet}
+              onFullyDismissed={clearLogAscentSheet}
+              climbUuid={logAscentData.climbUuid}
+              climbName={logAscentData.climbName}
+              boardName={logAscentData.boardName}
+              angle={logAscentData.angle}
+              isMirror={logAscentData.isMirror}
+              isBenchmark={logAscentData.isBenchmark}
+              baseAscensionistCount={logAscentData.baseAscensionistCount}
+              layoutId={logAscentData.layoutId}
+              sizeId={logAscentData.sizeId}
+              setIds={logAscentData.setIds}
+              sessionId={logAscentData.sessionId}
+              consensusGradeName={logAscentData.consensusGradeName}
+            />
+          ) : null}
+          {betaVideoData ? (
+            <AddBetaVideoSheet
+              visible={betaVideoVisible}
+              climb={betaVideoData.climb}
+              boardName={betaVideoData.boardConfig.boardName as BoardName}
+              layoutId={betaVideoData.boardConfig.layoutId}
+              angle={betaVideoData.boardConfig.angle}
+              onClose={closeAddBetaVideo}
+              onFullyDismissed={clearBetaVideoSheet}
+            />
+          ) : null}
+          {reportClimbData ? (
+            <ReportClimbSheet
+              visible={reportClimbVisible}
+              climb={reportClimbData.climb}
+              boardName={reportClimbData.boardConfig.boardName as BoardName}
+              layoutId={reportClimbData.boardConfig.layoutId}
+              sizeId={reportClimbData.boardConfig.sizeId}
+              setIds={reportClimbData.boardConfig.setIds}
+              angle={reportClimbData.boardConfig.angle}
+              onClose={closeReportClimb}
+              onFullyDismissed={clearReportClimbSheet}
+            />
+          ) : null}
+          {playlistData ? (
+            <AddToPlaylistSheet
+              visible={playlistVisible}
+              climb={playlistData.climb}
+              boardName={playlistData.boardConfig.boardName as BoardName}
+              layoutId={playlistData.boardConfig.layoutId}
+              sizeId={playlistData.boardConfig.sizeId}
+              setIds={playlistData.boardConfig.setIds}
+              angle={playlistData.boardConfig.angle}
+              onClose={closeAddToPlaylist}
+              onFullyDismissed={clearPlaylistSheet}
+            />
+          ) : null}
+          {queueBoard ? (
+            <QueueSheet
+              ref={queueSheetRef}
+              board={queueBoard}
+              onClose={requestCloseQueueSheet}
+              onClimbPress={handleQueueClimbPress}
+              onOpenActions={handleQueueOpenActions}
+              onSuggestionPress={handleQueueSuggestionPress}
+              onTickHistory={handleQueueTickHistory}
+            />
+          ) : null}
+          <BoardSheet
+            ref={boardSheetRef}
+            boardLabel={boardSheetLabel}
+            boardConfig={storedActiveBoardConfig}
+            onClose={requestCloseBoardSheet}
+            onSwitchBoard={handleSwitchBoardFromSheet}
+            onClimbPress={handleBoardSheetClimbPress}
+            onAddToQueue={handleBoardSheetAddToQueue}
+            onOpenPlaylist={handleBoardSheetOpenPlaylist}
+            onOpenActions={handleBoardSheetModalOpenActions}
           />
-        ) : null}
-        {betaVideoData ? (
-          <AddBetaVideoSheet
-            visible={betaVideoVisible}
-            climb={betaVideoData.climb}
-            boardName={betaVideoData.boardConfig.boardName as BoardName}
-            layoutId={betaVideoData.boardConfig.layoutId}
-            angle={betaVideoData.boardConfig.angle}
-            onClose={closeAddBetaVideo}
-            onFullyDismissed={clearBetaVideoSheet}
-          />
-        ) : null}
-        {reportClimbData ? (
-          <ReportClimbSheet
-            visible={reportClimbVisible}
-            climb={reportClimbData.climb}
-            boardName={reportClimbData.boardConfig.boardName as BoardName}
-            layoutId={reportClimbData.boardConfig.layoutId}
-            sizeId={reportClimbData.boardConfig.sizeId}
-            setIds={reportClimbData.boardConfig.setIds}
-            angle={reportClimbData.boardConfig.angle}
-            onClose={closeReportClimb}
-            onFullyDismissed={clearReportClimbSheet}
-          />
-        ) : null}
-        {playlistData ? (
-          <AddToPlaylistSheet
-            visible={playlistVisible}
-            climb={playlistData.climb}
-            boardName={playlistData.boardConfig.boardName as BoardName}
-            layoutId={playlistData.boardConfig.layoutId}
-            sizeId={playlistData.boardConfig.sizeId}
-            setIds={playlistData.boardConfig.setIds}
-            angle={playlistData.boardConfig.angle}
-            onClose={closeAddToPlaylist}
-            onFullyDismissed={clearPlaylistSheet}
-          />
-        ) : null}
-        {queueBoard ? (
-          <QueueSheet
-            ref={queueSheetRef}
-            board={queueBoard}
-            onClose={requestCloseQueueSheet}
-            onClimbPress={handleQueueClimbPress}
-            onOpenActions={handleQueueOpenActions}
-            onSuggestionPress={handleQueueSuggestionPress}
-            onTickHistory={handleQueueTickHistory}
-          />
-        ) : null}
-        <BoardSheet
-          ref={boardSheetRef}
-          boardLabel={boardSheetLabel}
-          boardConfig={storedActiveBoardConfig}
-          onClose={requestCloseBoardSheet}
-          onSwitchBoard={handleSwitchBoardFromSheet}
-          onClimbPress={handleBoardSheetClimbPress}
-          onAddToQueue={handleBoardSheetAddToQueue}
-          onOpenPlaylist={handleBoardSheetOpenPlaylist}
-          onOpenActions={handleBoardSheetModalOpenActions}
-        />
-        {/* Rendered after the queue/board sheets so its iOS FullWindowOverlay mounts as a
+          {/* Rendered after the queue/board sheets so its iOS FullWindowOverlay mounts as a
           later sibling and floats above them when a row inside those sheets is
           long-pressed (RN-screens doesn't strictly guarantee cross-overlay z-order). */}
-        {climbActions ? (
-          <ClimbReactionMenu
-            key={climbActions.climb.uuid}
-            climb={climbActions.climb}
-            boardConfig={climbActions.boardConfig}
-            currentUserId={profile?.id ?? null}
-            isAuthenticated={isAuthenticated}
-            onEditEntry={climbActions.onEditEntry}
-            onAddBetaVideo={climbActions.onAddBetaVideo}
-            onTick={climbActions.onTick}
-            onReportClimb={climbActions.onReportClimb}
-            dismissSourceSheet={climbActions.dismissSourceSheet}
-            dismissPlayerAndWait={climbActions.dismissPlayerAndWait}
-            reduceMotion={reduceMotion}
-            onClose={closeClimbActions}
+          {climbActions ? (
+            <ClimbReactionMenu
+              key={climbActions.climb.uuid}
+              climb={climbActions.climb}
+              boardConfig={climbActions.boardConfig}
+              currentUserId={profile?.id ?? null}
+              isAuthenticated={isAuthenticated}
+              onEditEntry={climbActions.onEditEntry}
+              onAddBetaVideo={climbActions.onAddBetaVideo}
+              onTick={climbActions.onTick}
+              onReportClimb={climbActions.onReportClimb}
+              dismissSourceSheet={climbActions.dismissSourceSheet}
+              dismissPlayerAndWait={climbActions.dismissPlayerAndWait}
+              reduceMotion={reduceMotion}
+              onClose={closeClimbActions}
+            />
+          ) : null}
+          <QueueAddedSnackbar
+            visible={snackbarVisible}
+            nonce={snackbarNonce}
+            onDismiss={dismissSnackbar}
+            onOpen={handleSnackbarOpen}
           />
-        ) : null}
-        <QueueAddedSnackbar
-          visible={snackbarVisible}
-          nonce={snackbarNonce}
-          onDismiss={dismissSnackbar}
-          onOpen={handleSnackbarOpen}
-        />
-        <UndoWallChangeSnackbar
-          visible={undoWallChangeVisible}
-          nonce={undoWallChangeNonce}
-          onDismiss={dismissUndoWallChangeSnackbar}
-          onUndo={handleUndoWallChange}
-        />
-      </PlayDrawerRouteContext.Provider>
+          <UndoWallChangeSnackbar
+            visible={undoWallChangeVisible}
+            nonce={undoWallChangeNonce}
+            onDismiss={dismissUndoWallChangeSnackbar}
+            onUndo={handleUndoWallChange}
+          />
+        </PlayDrawerRouteContext.Provider>
+      </PreviewedClimbContext.Provider>
     </DrawerHostContext.Provider>
   );
 }

--- a/packages/mobile/src/providers/feature-flags-provider.tsx
+++ b/packages/mobile/src/providers/feature-flags-provider.tsx
@@ -94,6 +94,12 @@ export const FEATURE_FLAG_DEFINITIONS = [
     variants: ['1', '0.5', '0.25', '0.1', '0'],
   },
   {
+    key: 'shared-session-browse',
+    label: 'Preview-first shared sessions',
+    description:
+      'In a session with 2+ climbers, swipes and climb-list taps browse instead of writing the shared queue and lighting the wall; "Put on the wall" becomes the one commit. Off = every gesture drives the wall as it always did.',
+  },
+  {
     key: 'moonboard-wide-angles',
     label: 'MoonBoard wide angles',
     description:
@@ -261,6 +267,22 @@ export function useBackendOutageDetectionEnabled(): boolean {
  */
 export function useInteractiveRequestDeadlineEnabled(): boolean {
   return useFeatureFlag('interactive-request-deadline') !== false;
+}
+
+/**
+ * Gate for preview-first browsing in a shared session (#4281 / #4683).
+ *
+ * A POSITIVE rollout flag, not a `*-kill` one, and the direction is the whole
+ * point: unresolved must mean the behaviour this feature replaced. The off-state
+ * here is "your swipe lights the board", which is what the app has always done
+ * and what a climber standing at a wall expects — so the first frames of a cold
+ * open, a PostHog outage, and a missing key all land on the safe side. Reading
+ * it as a kill switch would do the opposite: it would default a whole fleet into
+ * a mode where gestures stop driving the wall, which is exactly the regression
+ * that took #4683 back out.
+ */
+export function useSharedSessionBrowseEnabled(): boolean {
+  return useFeatureFlag('shared-session-browse') === true;
 }
 
 function featureFlagsEqual(leftFlags: FeatureFlags, rightFlags: FeatureFlags): boolean {

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -48,7 +48,11 @@ import {
 } from '../lib/graphql/operations';
 import { getStoredActiveBoard } from '../lib/active-board-store';
 import { useActiveBoard, useSetActiveBoard } from '../lib/graphql/use-active-board';
-import { findPreviousQueueItemWithSuggestions, findNextQueueItemWithSuggestions, shouldDefaultToBrowse } from '@boardsesh/play-view';
+import {
+  findPreviousQueueItemWithSuggestions,
+  findNextQueueItemWithSuggestions,
+  shouldDefaultToBrowse,
+} from '@boardsesh/play-view';
 import { useSharedSessionBrowseEnabled } from './feature-flags-provider';
 import { toClimbQueueItem } from '../lib/queue-conversion';
 import { resolveCommittableQueueItem, toQueueItemWireInput, isClimbResolved } from '../lib/climb-to-queue-item';
@@ -1476,18 +1480,9 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       playlistSuggestionSourceRef.current,
     );
     if (!prevItem) return;
-    if (isPlaylistPeekQueueItemUuid(prevItem.uuid)) {
-      const realItem = climbToQueueItem(prevItem.climb as unknown as Parameters<typeof climbToQueueItem>[0], {
-        suggested: true,
-      });
-      // Insert after current, like the server does — see nextClimb. It's why
-      // swiping back then forward lands on the item we just committed
-      // (findNextQueueItemWithSuggestions dedupes against BOTH neighbours)
-      // instead of appending the same climb twice.
-      dispatchSetCurrent(realItem, true, undefined, true);
-    } else {
-      dispatchSetCurrent(prevItem, false);
-    }
+    const { item, converted } = resolveCommittableQueueItem(prevItem);
+    // Match nextClimb and the server: suggestions insert immediately after current.
+    dispatchSetCurrent(item, converted, undefined, converted);
   }, [dispatchSetCurrent]);
 
   // Optimistic dispatch for widget Next/Previous taps. The native widget intent

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -27,7 +27,7 @@ import type {
 } from '@boardsesh/queue';
 import {
   countDistinctSessionUsers,
-  countConnectedSessionPeers,
+  countSessionPeers,
   createJoinSessionTracker,
   type QueueSyncGate,
 } from '@boardsesh/queue-runtime';
@@ -1716,36 +1716,47 @@ export function QueueProvider({ children }: { children: ReactNode }) {
   // virtualized list twice a second for an answer that didn't change is exactly
   // the provider-value churn the perf checklist bans.
   //
-  // Counts connected PEERS (excluding this client's own entries), not roster
-  // participants — see `countConnectedSessionPeers` for why the participant
-  // count turned lone climbers into crews.
+  // Counts PEERS (excluding this client's own entries), not roster participants
+  // — see `countSessionPeers` for why the participant count turned lone climbers
+  // into crews, and why connected and reconnecting peers are kept apart.
   const sharedBrowseEnabled = useSharedSessionBrowseEnabled();
-  const crewPresentNow = shouldDefaultToBrowse({
-    sessionActive: sessionId != null,
-    connectedPeerCount: countConnectedSessionPeers(sessionUsers, {
-      // `participantId` IS the signed-in user's uuid for an authenticated
-      // client and the connection id for an anonymous one — either way it is
-      // the key this client's own roster entry carries, which is all the
-      // self-exclusion needs.
-      participantId: sessionRuntimeState.participantId,
-    }),
+  const sessionActive = sessionId != null;
+  const { connected: connectedPeerCount, reconnecting: reconnectingPeerCount } = countSessionPeers(sessionUsers, {
+    // `participantId` IS the signed-in user's uuid for an authenticated
+    // client and the connection id for an anonymous one — either way it is
+    // the key this client's own roster entry carries, which is all the
+    // self-exclusion needs.
+    participantId: sessionRuntimeState.participantId,
   });
+  // Arms the gate: someone else is here with a live socket.
+  const crewPresentNow = shouldDefaultToBrowse({ sessionActive, connectedPeerCount });
+  // Holds the gate: someone else is here, live or inside the server's reconnect
+  // grace window. A peer whose wifi flapped has not left — their seat and their
+  // wall stakes are still on the roster — so the gate must not hand the wall
+  // back for the seconds their socket is down. This never ARMS anything: a
+  // reconnecting-only roster (a lone climber's own dying connection) reads as no
+  // crew, which is what keeps the lone climber's board theirs.
+  const crewHoldingNow = sessionActive && connectedPeerCount + reconnectingPeerCount > 0;
   // Hold a newly-arrived crew for a dwell before acting on it, and drop it the
-  // instant it goes. The asymmetry is deliberate. Arming late costs a climber a
+  // instant it is gone. The asymmetry is deliberate. Arming late costs a climber a
   // couple of seconds of ordinary wall control while a peer settles; arming on a
   // one-frame roster blip costs them the wall until they find a button they have
   // no reason to look for. Releasing is immediate for the same reason — being
   // left alone must give the board straight back.
   const [crewDwellElapsed, setCrewDwellElapsed] = useState(false);
   useEffect(() => {
-    if (!crewPresentNow) {
+    if (!crewHoldingNow) {
       setCrewDwellElapsed(false);
       return;
     }
+    // Live peer: start (or restart) the arming dwell. Reconnecting-only: neither
+    // arm nor release — whatever the gate was, it stays, until the peer is back
+    // (this effect re-runs with a live peer) or evicted (`crewHoldingNow` drops).
+    if (!crewPresentNow) return;
     const timer = setTimeout(() => setCrewDwellElapsed(true), SHARED_SESSION_DWELL_MS);
     return () => clearTimeout(timer);
-  }, [crewPresentNow]);
-  const isSharedSession = sharedBrowseEnabled && crewPresentNow && crewDwellElapsed;
+  }, [crewPresentNow, crewHoldingNow]);
+  const isSharedSession = sharedBrowseEnabled && crewHoldingNow && crewDwellElapsed;
   const sharedSessionValue = useMemo<QueueSharedSessionContextValue>(() => ({ isSharedSession }), [isSharedSession]);
 
   const playlistSuggestionValue = useMemo<QueuePlaylistSuggestionContextValue>(

--- a/packages/mobile/src/providers/queue-provider.tsx
+++ b/packages/mobile/src/providers/queue-provider.tsx
@@ -15,7 +15,6 @@ import {
   initialState,
   createQueueSyncCoordinator,
   generateClientId,
-  isPlaylistPeekQueueItemUuid,
   playlistSuggestionSourceMatches,
   decideAdd,
   deriveAcceptedConfigs,
@@ -26,7 +25,12 @@ import type {
   PlaylistSuggestionSource,
   SetCurrentClimbOptions,
 } from '@boardsesh/queue';
-import { countDistinctSessionUsers, createJoinSessionTracker, type QueueSyncGate } from '@boardsesh/queue-runtime';
+import {
+  countDistinctSessionUsers,
+  countConnectedSessionPeers,
+  createJoinSessionTracker,
+  type QueueSyncGate,
+} from '@boardsesh/queue-runtime';
 import { useQueueMutations, type PublishPlaybackStateInput } from '@boardsesh/queue-react';
 import type { QueueItemAttribution } from '@boardsesh/queue-react/queue-item-input';
 import type { PlaybackStateChangedEvent, SessionUser } from '@boardsesh/shared-schema';
@@ -44,9 +48,10 @@ import {
 } from '../lib/graphql/operations';
 import { getStoredActiveBoard } from '../lib/active-board-store';
 import { useActiveBoard, useSetActiveBoard } from '../lib/graphql/use-active-board';
-import { findPreviousQueueItemWithSuggestions, findNextQueueItemWithSuggestions } from '@boardsesh/play-view';
+import { findPreviousQueueItemWithSuggestions, findNextQueueItemWithSuggestions, shouldDefaultToBrowse } from '@boardsesh/play-view';
+import { useSharedSessionBrowseEnabled } from './feature-flags-provider';
 import { toClimbQueueItem } from '../lib/queue-conversion';
-import { climbToQueueItem, toQueueItemWireInput, isClimbResolved } from '../lib/climb-to-queue-item';
+import { resolveCommittableQueueItem, toQueueItemWireInput, isClimbResolved } from '../lib/climb-to-queue-item';
 import { track, registerRenderSuperProperties } from '../lib/analytics';
 import {
   requestedBoardRenderMode,
@@ -68,6 +73,7 @@ import {
   QueueSessionControlContext,
   QueueSessionIdContext,
   QueueLiveStatsContext,
+  QueueSharedSessionContext,
   QueueActiveClimbContext,
   QueueHasActiveClimbContext,
   QueueDataContext,
@@ -77,6 +83,7 @@ import {
   type QueueSessionControlContextValue,
   type QueueSessionIdContextValue,
   type QueueLiveStatsContextValue,
+  type QueueSharedSessionContextValue,
   type QueueActiveClimbContextValue,
   type QueueHasActiveClimbContextValue,
   type QueueDataContextValue,
@@ -101,6 +108,7 @@ export {
   useQueueSessionControls,
   useQueueSessionId,
   useQueueLiveStats,
+  useIsSharedSession,
   useActiveClimbUuid,
   useHasActiveClimb,
   useQueueData,
@@ -139,6 +147,19 @@ const defaultSearchParams: QueueSearchParams = {};
 
 // Stable empty Set so the no-session case never publishes a fresh identity.
 const EMPTY_USER_ID_SET: ReadonlySet<string> = new Set<string>();
+
+/**
+ * How long a peer must stay on the roster before their presence turns the
+ * climber's gestures into browsing.
+ *
+ * Sized against what it is filtering, not against a feel target: the roster
+ * blips this exists to absorb are a reconnect landing before the previous
+ * connection's `UserLeft`, which resolves in well under a second once the
+ * server catches up. Three seconds clears that with room to spare and is still
+ * short enough that a climber who genuinely walks up with a friend never
+ * notices the gate arriving late.
+ */
+export const SHARED_SESSION_DWELL_MS = 3_000;
 
 export function QueueProvider({ children }: { children: ReactNode }) {
   const authTransportRevision = useAuthTransportRevision();
@@ -1401,6 +1422,15 @@ export function QueueProvider({ children }: { children: ReactNode }) {
         climbUuid: item.climb.uuid,
         layoutId: activeBoardRef.current?.layoutId,
         source: 'mobile',
+        // Which crew's wall just moved, and how many people were watching it.
+        // The preview-first work turns this event into the ONE deliberate act
+        // that drives a shared wall (every browse-shaped gesture stopped firing
+        // it), so without these two the "did people stop stepping on each
+        // other" question has no numerator. `sessionId` is a room id, not a
+        // person; the count is distinct humans, matching how `partyMode` is
+        // stamped on Climb Added to Queue rather than raw connection rows.
+        sessionId: sessionIdRef.current,
+        participantCount: countDistinctSessionUsers(sessionRuntimeStateRef.current?.users),
       });
       // Activating a climb slots it right after the current climb (issue #2217),
       // pushing the current climb into history — matching the local "set climb
@@ -1424,26 +1454,15 @@ export function QueueProvider({ children }: { children: ReactNode }) {
       playlistSuggestionSourceRef.current,
     );
     if (!nextItem) return;
-    if (isPlaylistPeekQueueItemUuid(nextItem.uuid)) {
-      // Mirror web: turn the transient peek into a real queue item with a fresh
-      // uuid so the synthetic `playlist-peek:<uuid>` never reaches the WS
-      // mutation (toQueueItemInput sends item.uuid verbatim). suggested:true so
-      // suggestion pruning still treats it as suggestion-origin. The peek climb
-      // is the queue package's wide Climb; climbToQueueItem only reads the
-      // ClimbInput subset, so the cast is runtime-safe.
-      const realItem = climbToQueueItem(nextItem.climb as unknown as Parameters<typeof climbToQueueItem>[0], {
-        suggested: true,
-      });
-      // insertAfterCurrent mirrors the server, which ALWAYS slots a
-      // shouldAddToQueue climb right after the current one
-      // (setCurrentClimbAndPublish, issue #2217). Since swipes went list-first
-      // (#4829) the current climb is no longer always the queue tail, where
-      // appending happened to agree — appending from mid-queue would diverge
-      // from the server's order and trip the ordered-hash watchdog.
-      dispatchSetCurrent(realItem, true, undefined, true);
-    } else {
-      dispatchSetCurrent(nextItem, false);
-    }
+    // Mirror web: a transient `playlist-peek:<uuid>` must never reach the WS
+    // mutation (toQueueItemInput sends item.uuid verbatim). The laundering lives
+    // in `resolveCommittableQueueItem` so the play drawer's commit button —
+    // which can now pin a peek while browsing a shared session — applies exactly
+    // the same rule. A converted peek was never in the queue, so it has to be
+    // added; a real item is already there.
+    const { item, converted } = resolveCommittableQueueItem(nextItem);
+    // New suggestions must match the server's insertion immediately after current.
+    dispatchSetCurrent(item, converted, undefined, converted);
   }, [dispatchSetCurrent]);
 
   const previousClimb = useCallback(() => {
@@ -1689,6 +1708,46 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     [liveStats, sessionUsers],
   );
 
+  // "Is anyone else here" — the gate that turns swipes and list taps into
+  // browsing instead of wall control. Derived here rather than in the drawer and
+  // the climb list so those two hot surfaces subscribe to a boolean that flips
+  // only across the solo ↔ crew boundary: the ≤1/2s stats push and every
+  // presence delta recreate `sessionUsers`, and re-rendering board art or a
+  // virtualized list twice a second for an answer that didn't change is exactly
+  // the provider-value churn the perf checklist bans.
+  //
+  // Counts connected PEERS (excluding this client's own entries), not roster
+  // participants — see `countConnectedSessionPeers` for why the participant
+  // count turned lone climbers into crews.
+  const sharedBrowseEnabled = useSharedSessionBrowseEnabled();
+  const crewPresentNow = shouldDefaultToBrowse({
+    sessionActive: sessionId != null,
+    connectedPeerCount: countConnectedSessionPeers(sessionUsers, {
+      // `participantId` IS the signed-in user's uuid for an authenticated
+      // client and the connection id for an anonymous one — either way it is
+      // the key this client's own roster entry carries, which is all the
+      // self-exclusion needs.
+      participantId: sessionRuntimeState.participantId,
+    }),
+  });
+  // Hold a newly-arrived crew for a dwell before acting on it, and drop it the
+  // instant it goes. The asymmetry is deliberate. Arming late costs a climber a
+  // couple of seconds of ordinary wall control while a peer settles; arming on a
+  // one-frame roster blip costs them the wall until they find a button they have
+  // no reason to look for. Releasing is immediate for the same reason — being
+  // left alone must give the board straight back.
+  const [crewDwellElapsed, setCrewDwellElapsed] = useState(false);
+  useEffect(() => {
+    if (!crewPresentNow) {
+      setCrewDwellElapsed(false);
+      return;
+    }
+    const timer = setTimeout(() => setCrewDwellElapsed(true), SHARED_SESSION_DWELL_MS);
+    return () => clearTimeout(timer);
+  }, [crewPresentNow]);
+  const isSharedSession = sharedBrowseEnabled && crewPresentNow && crewDwellElapsed;
+  const sharedSessionValue = useMemo<QueueSharedSessionContextValue>(() => ({ isSharedSession }), [isSharedSession]);
+
   const playlistSuggestionValue = useMemo<QueuePlaylistSuggestionContextValue>(
     () => ({ playlistSuggestionSource }),
     [playlistSuggestionSource],
@@ -1739,17 +1798,19 @@ export function QueueProvider({ children }: { children: ReactNode }) {
     <QueueSessionControlContext.Provider value={sessionControlValue}>
       <QueueSessionIdContext.Provider value={sessionIdValue}>
         <QueueLiveStatsContext.Provider value={liveStatsValue}>
-          <QueueActionsContext.Provider value={actionsValue}>
-            <QueuePlaylistSuggestionContext.Provider value={playlistSuggestionValue}>
-              <QueueActiveClimbContext.Provider value={activeClimbValue}>
-                <QueueHasActiveClimbContext.Provider value={hasActiveClimbValue}>
-                  <QueueDataContext.Provider value={queueDataValue}>
-                    <QueueContext.Provider value={contextValue}>{children}</QueueContext.Provider>
-                  </QueueDataContext.Provider>
-                </QueueHasActiveClimbContext.Provider>
-              </QueueActiveClimbContext.Provider>
-            </QueuePlaylistSuggestionContext.Provider>
-          </QueueActionsContext.Provider>
+          <QueueSharedSessionContext.Provider value={sharedSessionValue}>
+            <QueueActionsContext.Provider value={actionsValue}>
+              <QueuePlaylistSuggestionContext.Provider value={playlistSuggestionValue}>
+                <QueueActiveClimbContext.Provider value={activeClimbValue}>
+                  <QueueHasActiveClimbContext.Provider value={hasActiveClimbValue}>
+                    <QueueDataContext.Provider value={queueDataValue}>
+                      <QueueContext.Provider value={contextValue}>{children}</QueueContext.Provider>
+                    </QueueDataContext.Provider>
+                  </QueueHasActiveClimbContext.Provider>
+                </QueueActiveClimbContext.Provider>
+              </QueuePlaylistSuggestionContext.Provider>
+            </QueueActionsContext.Provider>
+          </QueueSharedSessionContext.Provider>
         </QueueLiveStatsContext.Provider>
       </QueueSessionIdContext.Provider>
     </QueueSessionControlContext.Provider>

--- a/packages/mobile/src/providers/queue/queue-contexts.ts
+++ b/packages/mobile/src/providers/queue/queue-contexts.ts
@@ -143,6 +143,7 @@ export const QueueContext = createContext<QueueContextValue | null>(null);
  * - useQueueSessionId(): rare session-id changes for structural chrome.
  * - useQueueSessionControls(): session id, serial/wall controls, and the member-userId set for party surfaces.
  * - useQueueLiveStats(): high-frequency live stats and roster updates.
+ * - useIsSharedSession(): "is anyone else here" — browse-by-default gating.
  * - useActiveClimbUuid(): row-level active-climb highlighting.
  * - useHasActiveClimb(): presence-only bottom chrome metrics.
  * - usePlaylistSuggestionSource(): playlist peek/suggestion navigation.
@@ -206,6 +207,25 @@ type QueueLiveStatsContextValue = {
 };
 
 export const QueueLiveStatsContext = createContext<QueueLiveStatsContextValue | null>(null);
+
+/**
+ * "Is anyone else in this session with me" — a single boolean whose identity
+ * flips ONLY across the solo ↔ crew boundary (`shouldDefaultToBrowse`).
+ *
+ * Its consumers are the surfaces that decide whether a gesture browses or takes
+ * the wall: the play drawer's swipes and the climb list's row taps. Both are
+ * hot — the climb list re-renders a virtualized FlashList, the drawer re-renders
+ * board art — so neither can subscribe to {@link QueueLiveStatsContext}, whose
+ * value is recreated by every ≤1/2s `SessionStatsUpdated` push and by every
+ * presence delta. Deriving the boolean HERE means a fifth climber joining, a
+ * peer's presence flapping, or a stats push costs those surfaces nothing: the
+ * value only changes when the answer does.
+ */
+type QueueSharedSessionContextValue = {
+  isSharedSession: boolean;
+};
+
+export const QueueSharedSessionContext = createContext<QueueSharedSessionContextValue | null>(null);
 
 /**
  * Active-climb selector context. Changes identity ONLY when the active climb's
@@ -295,6 +315,17 @@ export function useQueueLiveStats(): QueueLiveStatsContextValue {
   return context;
 }
 
+/**
+ * True when a party session is joined AND at least one other climber is on the
+ * roster — the condition under which browse-shaped gestures default to
+ * view-only. See {@link QueueSharedSessionContext}.
+ */
+export function useIsSharedSession(): boolean {
+  const context = useContext(QueueSharedSessionContext);
+  if (!context) throw new Error('useIsSharedSession must be used within QueueProvider');
+  return context.isSharedSession;
+}
+
 export function useActiveClimbUuid(): string | null {
   const context = useContext(QueueActiveClimbContext);
   if (!context) throw new Error('useActiveClimbUuid must be used within QueueProvider');
@@ -335,6 +366,7 @@ export type {
   QueueSessionControlContextValue,
   QueueSessionIdContextValue,
   QueueLiveStatsContextValue,
+  QueueSharedSessionContextValue,
   QueueActiveClimbContextValue,
   QueueHasActiveClimbContextValue,
   QueueDataContextValue,

--- a/packages/mobile/src/settings/defaults.ts
+++ b/packages/mobile/src/settings/defaults.ts
@@ -20,6 +20,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   notifySessionInvites: true,
   notifyClimbComments: true,
   kioskHintSeen: false,
+  browseNoticeSeen: false,
   bottomChromeDiagnostics: false,
   qaBriefSeenKey: null,
   qaVerdictSubmittedKey: null,

--- a/packages/mobile/src/settings/types.ts
+++ b/packages/mobile/src/settings/types.ts
@@ -67,6 +67,12 @@ export type AppSettings = {
   notifyClimbComments: boolean;
   /** One-shot: the "kiosk setup lives on the big screen" hint has been seen on My gyms. */
   kioskHintSeen: boolean;
+  /**
+   * One-shot: the play drawer has explained that navigation is view-only while
+   * board lighting is off for swipes/taps. Persisted because the setting behind
+   * it is — an in-memory claim would re-explain it on every cold start.
+   */
+  browseNoticeSeen: boolean;
   /** Show the live bottom-chrome geometry overlay (dev / preview / pr-channel only). */
   bottomChromeDiagnostics: boolean;
   /**

--- a/packages/shared/play-view/src/__tests__/browse-defaults.test.ts
+++ b/packages/shared/play-view/src/__tests__/browse-defaults.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { shouldDefaultToBrowse } from '../browse-defaults';
+
+describe('shouldDefaultToBrowse', () => {
+  const cases: { name: string; sessionActive: boolean; connectedPeerCount: number; expected: boolean }[] = [
+    { name: 'solo, no session at all', sessionActive: false, connectedPeerCount: 0, expected: false },
+    // The ordinary state right after starting a session: the climber is alone
+    // in it, so swipes keep driving their own wall.
+    { name: 'session of one — nobody has joined yet', sessionActive: true, connectedPeerCount: 0, expected: false },
+    { name: 'one peer — an audience exists', sessionActive: true, connectedPeerCount: 1, expected: true },
+    { name: 'a full crew', sessionActive: true, connectedPeerCount: 5, expected: true },
+    // A roster that outlived its session id is stale bookkeeping; it must not
+    // keep gestures view-only after the session ended.
+    { name: 'peers left over after the session ended', sessionActive: false, connectedPeerCount: 3, expected: false },
+    {
+      name: 'session id with an empty roster (pre-JOIN response)',
+      sessionActive: true,
+      connectedPeerCount: 0,
+      expected: false,
+    },
+  ];
+
+  it.each(cases)('$name', ({ sessionActive, connectedPeerCount, expected }) => {
+    expect(shouldDefaultToBrowse({ sessionActive, connectedPeerCount })).toBe(expected);
+  });
+
+  it('flips only across the 0 → 1 peer boundary', () => {
+    // The value is consumed as a context/prop by high-fanout surfaces, so the
+    // boundary is the whole point: a crew growing 1 → 2 → 3 must not churn it.
+    const counts = [0, 1, 2, 3, 11];
+    expect(
+      counts.map((connectedPeerCount) => shouldDefaultToBrowse({ sessionActive: true, connectedPeerCount })),
+    ).toEqual([false, true, true, true, true]);
+  });
+
+  // The regression that took #4683 back out. The gate used to be fed a count of
+  // roster PARTICIPANTS, which always includes the climber themselves — so the
+  // threshold had to be `> 1`, and any second entry for that same human (a
+  // reconnect landing before `UserLeft`, a socket that momentarily authenticated
+  // anonymously) read as an audience and stopped a lone climber's swipes from
+  // lighting their own board. Counting peers removes the self-entry from the
+  // arithmetic entirely, so a doubled solo roster can no longer reach the gate:
+  // `countConnectedSessionPeers` is what decides who counts, and it is tested
+  // against exactly those shapes in @boardsesh/queue-runtime.
+  it('takes peers, not participants — a lone climber can never reach the gate', () => {
+    expect(shouldDefaultToBrowse({ sessionActive: true, connectedPeerCount: 0 })).toBe(false);
+  });
+});

--- a/packages/shared/play-view/src/browse-defaults.ts
+++ b/packages/shared/play-view/src/browse-defaults.ts
@@ -1,0 +1,56 @@
+/**
+ * When a browse-shaped gesture should default to LOOKING rather than driving
+ * the wall.
+ *
+ * The rule is about audience, not permissions. Solo, a swipe through the play
+ * drawer is a private act: it lights your own board and nobody else notices.
+ * The moment a second climber is in the session, that same swipe writes the
+ * shared queue — it blanks a climb someone may be mid-attempt on and it moves
+ * everyone's next-up. Browsing must not cost that, so with an audience present
+ * every browse-shaped gesture lands view-only and the wall changes only when
+ * the climber explicitly puts a climb up.
+ *
+ * Kept pure and shared (rather than inlined in the drawer) because two very
+ * different surfaces have to agree on it — the play drawer's swipes and the
+ * climb list's row taps — and a disagreement between them is invisible: one
+ * would promise browsing while the other quietly took the wall.
+ */
+export type BrowseDefaultInput = {
+  /** A party session is joined (a session id exists). */
+  sessionActive: boolean;
+  /**
+   * Distinct OTHER humans currently connected, counted with
+   * `countConnectedSessionPeers` — peers, not participants, and not the raw
+   * roster length.
+   *
+   * Counting participants was the original shape and it was wrong in a way that
+   * only showed up in the field: the roster always contains you, and it can
+   * briefly contain you TWICE (a reconnect that lands before the previous
+   * connection's `UserLeft`, or a socket that momentarily authenticated
+   * anonymously — two different keys for one human, so dedupe cannot merge
+   * them). Either one reads as a crew, and a false crew stops a lone climber's
+   * swipes from lighting their own board. Counting connected peers removes both
+   * failure modes at the source.
+   */
+  connectedPeerCount: number;
+};
+
+/**
+ * True when browse-shaped gestures should stay view-only by default.
+ *
+ * Both clauses are load-bearing. A session of one is still solo — it is the
+ * ordinary state right after starting a session and before anyone joins, and
+ * making it browse-by-default would take away the one-swipe wall control the
+ * climber started the session with. And a roster with entries but no session id
+ * is stale bookkeeping from a session that has already ended, which must not
+ * keep gating gestures.
+ *
+ * This answers the question for an INSTANT. It deliberately says nothing about
+ * how long the crew has been there — callers hold the answer for a dwell before
+ * acting on it, so a one-frame roster blip cannot flip a climber into browsing
+ * (see `queue-provider`). Turning the gate back OFF is not dwelled: a climber
+ * left alone gets their board back immediately.
+ */
+export function shouldDefaultToBrowse({ sessionActive, connectedPeerCount }: BrowseDefaultInput): boolean {
+  return sessionActive && connectedPeerCount > 0;
+}

--- a/packages/shared/play-view/src/index.ts
+++ b/packages/shared/play-view/src/index.ts
@@ -7,6 +7,7 @@ export * from './tick-utils';
 export * from './quick-tick-state';
 export * from './board-utils';
 export * from './climb-rules';
+export * from './browse-defaults';
 export * from './swipe-carousel';
 export * from './wall-confirm-bus';
 export * from './wall-confirm-fallback';

--- a/packages/shared/queue-runtime/src/__tests__/session-roster.test.ts
+++ b/packages/shared/queue-runtime/src/__tests__/session-roster.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { countDistinctSessionUsers, dedupeSessionUsers } from '../session-roster';
+import { countConnectedSessionPeers, countDistinctSessionUsers, dedupeSessionUsers } from '../session-roster';
 
 type Roster = { id: string; userId?: string | null };
 
@@ -45,5 +45,80 @@ describe('session-roster dedupe', () => {
   it('handles the empty roster', () => {
     expect(countDistinctSessionUsers([])).toBe(0);
     expect(dedupeSessionUsers([])).toEqual([]);
+  });
+});
+
+// `countConnectedSessionPeers` exists because `countDistinctSessionUsers` was
+// the wrong question for a gate. These cases are the field shapes that made a
+// lone climber's swipes stop lighting their own board in #4683.
+describe('countConnectedSessionPeers', () => {
+  type Peer = { id: string; userId?: string | null; connectionState?: string | null };
+  const self = { participantId: 'me' };
+
+  it('does not count the climber themselves', () => {
+    const roster: Peer[] = [{ id: 'me', userId: 'user-me', connectionState: 'CONNECTED' }];
+    expect(countConnectedSessionPeers(roster, self)).toBe(0);
+  });
+
+  it('does not count the climber\u2019s own stale entry from a reconnect', () => {
+    // The reconnect landed before the previous connection’s `UserLeft`. The old
+    // entry is keyed on the dead connection id and carries no userId, so
+    // `userId ?? id` gives it a DIFFERENT key from the live one — dedupe cannot
+    // merge them, and the participant count read two humans where there was one.
+    const roster: Peer[] = [
+      { id: 'me', userId: 'user-me', connectionState: 'CONNECTED' },
+      { id: 'dead-conn', userId: null, connectionState: 'RECONNECTING' },
+    ];
+    expect(countDistinctSessionUsers(roster)).toBe(2);
+    expect(countConnectedSessionPeers(roster, self)).toBe(0);
+  });
+
+  it('excludes the climber by userId when their entry is connection-keyed', () => {
+    // The other half of the same race: the socket momentarily authenticated
+    // anonymously, so the live entry is keyed on the connection id while still
+    // carrying the userId.
+    const roster: Peer[] = [{ id: 'some-conn', userId: 'user-me', connectionState: 'CONNECTED' }];
+    expect(countConnectedSessionPeers(roster, { participantId: 'me', userId: 'user-me' })).toBe(0);
+  });
+
+  it('counts a genuine peer', () => {
+    const roster: Peer[] = [
+      { id: 'me', userId: 'user-me', connectionState: 'CONNECTED' },
+      { id: 'bo', userId: 'user-bo', connectionState: 'CONNECTED' },
+    ];
+    expect(countConnectedSessionPeers(roster, self)).toBe(1);
+  });
+
+  it('counts distinct anonymous peers separately', () => {
+    const roster: Peer[] = [
+      { id: 'me', connectionState: 'CONNECTED' },
+      { id: 'anon-1', connectionState: 'CONNECTED' },
+      { id: 'anon-2', connectionState: 'CONNECTED' },
+    ];
+    expect(countConnectedSessionPeers(roster, self)).toBe(2);
+  });
+
+  it('skips a peer the server says is not connected', () => {
+    const roster: Peer[] = [
+      { id: 'me', userId: 'user-me', connectionState: 'CONNECTED' },
+      { id: 'bo', userId: 'user-bo', connectionState: 'RECONNECTING' },
+    ];
+    expect(countConnectedSessionPeers(roster, self)).toBe(0);
+  });
+
+  it('treats an ABSENT connectionState as connected', () => {
+    // A backend that does not send the field must behave as it did before the
+    // filter existed. Reading a missing field as \u201cnot connected\u201d would report an
+    // empty crew for every session and silently disable the feature.
+    const roster: Peer[] = [
+      { id: 'me', userId: 'user-me' },
+      { id: 'bo', userId: 'user-bo' },
+    ];
+    expect(countConnectedSessionPeers(roster, self)).toBe(1);
+  });
+
+  it('returns 0 for a null or empty roster', () => {
+    expect(countConnectedSessionPeers(null, self)).toBe(0);
+    expect(countConnectedSessionPeers([], self)).toBe(0);
   });
 });

--- a/packages/shared/queue-runtime/src/__tests__/session-roster.test.ts
+++ b/packages/shared/queue-runtime/src/__tests__/session-roster.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { countConnectedSessionPeers, countDistinctSessionUsers, dedupeSessionUsers } from '../session-roster';
+import {
+  countConnectedSessionPeers,
+  countDistinctSessionUsers,
+  countSessionPeers,
+  dedupeSessionUsers,
+} from '../session-roster';
 
 type Roster = { id: string; userId?: string | null };
 
@@ -120,5 +125,63 @@ describe('countConnectedSessionPeers', () => {
   it('returns 0 for a null or empty roster', () => {
     expect(countConnectedSessionPeers(null, self)).toBe(0);
     expect(countConnectedSessionPeers([], self)).toBe(0);
+  });
+});
+
+// The gate arms on `connected` and is held by `connected + reconnecting`. The
+// split exists because the two shapes below look identical to a participant
+// count and must be read in opposite directions.
+describe('countSessionPeers', () => {
+  type Peer = { id: string; userId?: string | null; connectionState?: string | null };
+  const self = { participantId: 'me' };
+
+  it('files a peer inside the reconnect grace window under reconnecting, not connected', () => {
+    const roster: Peer[] = [
+      { id: 'me', userId: 'user-me', connectionState: 'CONNECTED' },
+      { id: 'bo', userId: 'user-bo', connectionState: 'RECONNECTING' },
+    ];
+    expect(countSessionPeers(roster, self)).toEqual({ connected: 0, reconnecting: 1 });
+  });
+
+  it('never files the climber\u2019s own dying connection anywhere', () => {
+    // The lone-climber shape from #4683: a reconnect landed, the old socket is
+    // in its grace window under a connection-id key. Neither bucket may count it
+    // — `reconnecting` HOLDS an armed gate, and there is nothing to hold for one
+    // human.
+    const roster: Peer[] = [
+      { id: 'me', userId: 'user-me', connectionState: 'CONNECTED' },
+      { id: 'dead-connection', userId: null, connectionState: 'RECONNECTING' },
+    ];
+    expect(countSessionPeers(roster, { participantId: 'me', userId: 'user-me' })).toEqual({
+      connected: 0,
+      reconnecting: 1,
+    });
+    // ...which is why the provider gates arming on `connected` alone; the
+    // anonymous ghost is indistinguishable from a real reconnecting stranger
+    // here, so this pins that it lands in the bucket that cannot arm.
+  });
+
+  it('counts one human with a live socket and a dying one as connected only', () => {
+    const roster: Peer[] = [
+      { id: 'me', userId: 'user-me', connectionState: 'CONNECTED' },
+      { id: 'bo-new', userId: 'user-bo', connectionState: 'CONNECTED' },
+      { id: 'bo-old', userId: 'user-bo', connectionState: 'RECONNECTING' },
+    ];
+    expect(countSessionPeers(roster, self)).toEqual({ connected: 1, reconnecting: 0 });
+  });
+
+  it('splits a mixed crew', () => {
+    const roster: Peer[] = [
+      { id: 'me', userId: 'user-me', connectionState: 'CONNECTED' },
+      { id: 'bo', userId: 'user-bo', connectionState: 'CONNECTED' },
+      { id: 'cy', userId: 'user-cy', connectionState: 'RECONNECTING' },
+      { id: 'anon', userId: null },
+    ];
+    expect(countSessionPeers(roster, self)).toEqual({ connected: 2, reconnecting: 1 });
+  });
+
+  it('returns zeros for a null or empty roster', () => {
+    expect(countSessionPeers(null, self)).toEqual({ connected: 0, reconnecting: 0 });
+    expect(countSessionPeers([], self)).toEqual({ connected: 0, reconnecting: 0 });
   });
 });

--- a/packages/shared/queue-runtime/src/index.ts
+++ b/packages/shared/queue-runtime/src/index.ts
@@ -35,7 +35,8 @@ export type {
   SessionConnectionTimerHandle,
 } from './session-connection';
 
-export { dedupeSessionUsers, countDistinctSessionUsers } from './session-roster';
+export { dedupeSessionUsers, countDistinctSessionUsers, countConnectedSessionPeers } from './session-roster';
+export type { SessionSelfIdentity } from './session-roster';
 
 export { applySessionRuntimeEvent, upsertRuntimeSessionUser } from './session-events';
 export type {

--- a/packages/shared/queue-runtime/src/index.ts
+++ b/packages/shared/queue-runtime/src/index.ts
@@ -35,8 +35,13 @@ export type {
   SessionConnectionTimerHandle,
 } from './session-connection';
 
-export { dedupeSessionUsers, countDistinctSessionUsers, countConnectedSessionPeers } from './session-roster';
-export type { SessionSelfIdentity } from './session-roster';
+export {
+  dedupeSessionUsers,
+  countDistinctSessionUsers,
+  countConnectedSessionPeers,
+  countSessionPeers,
+} from './session-roster';
+export type { SessionSelfIdentity, SessionPeerCounts } from './session-roster';
 
 export { applySessionRuntimeEvent, upsertRuntimeSessionUser } from './session-events';
 export type {

--- a/packages/shared/queue-runtime/src/session-roster.ts
+++ b/packages/shared/queue-runtime/src/session-roster.ts
@@ -40,3 +40,52 @@ export function countDistinctSessionUsers(users: readonly RosterIdentity[] | nul
   }
   return seen.size;
 }
+
+/** Who the local client is, for excluding its own roster entries. */
+export type SessionSelfIdentity = {
+  /** `RuntimeSessionState.participantId` — the key roster entries carry as `id`. */
+  participantId?: string | null;
+  /** The signed-in user's stable id, when there is one. */
+  userId?: string | null;
+};
+
+type ConnectedRosterIdentity = Pick<RuntimeSessionUser, 'id' | 'userId' | 'connectionState'>;
+
+/**
+ * Count distinct OTHER humans who are actually connected right now.
+ *
+ * {@link countDistinctSessionUsers} answers "how many people are in this
+ * session", which is the right question for an avatar row: a peer who is
+ * reconnecting is still one of the crew and should stay on screen. It is the
+ * wrong question for a gate that decides whether a gesture drives the wall,
+ * because it counts two things that are not an audience:
+ *
+ *  - **The climber themselves.** The roster always contains you.
+ *  - **Your own stale entry.** A reconnect that lands before the previous
+ *    connection's `UserLeft`, or a socket that momentarily authenticated
+ *    anonymously, leaves a second entry for one human keyed on the old
+ *    connection id — a different key from the authenticated one, so dedupe by
+ *    `userId ?? id` cannot merge them.
+ *
+ * Either one turns a lone climber into a false crew, and a gate that reads a
+ * false crew stops their swipes from lighting their own board. So this counts
+ * peers, not participants, and only ones the server says are live.
+ *
+ * `connectionState` is treated as connected when ABSENT, not when equal to
+ * `'CONNECTED'`: a backend that does not send the field must behave as it did
+ * before this filter existed rather than silently reporting an empty crew.
+ */
+export function countConnectedSessionPeers(
+  users: readonly ConnectedRosterIdentity[] | null | undefined,
+  self: SessionSelfIdentity,
+): number {
+  if (!users) return 0;
+  const seen = new Set<string>();
+  for (const user of users) {
+    if (user.connectionState != null && user.connectionState !== 'CONNECTED') continue;
+    if (self.participantId != null && user.id === self.participantId) continue;
+    if (self.userId != null && user.userId === self.userId) continue;
+    seen.add(user.userId ?? user.id);
+  }
+  return seen.size;
+}

--- a/packages/shared/queue-runtime/src/session-roster.ts
+++ b/packages/shared/queue-runtime/src/session-roster.ts
@@ -51,8 +51,21 @@ export type SessionSelfIdentity = {
 
 type ConnectedRosterIdentity = Pick<RuntimeSessionUser, 'id' | 'userId' | 'connectionState'>;
 
+/** Distinct OTHER humans on the roster, split by what the server says about their socket. */
+export type SessionPeerCounts = {
+  /** Peers the server reports live (or whose `connectionState` it does not report at all). */
+  connected: number;
+  /**
+   * Peers inside the server's reconnect grace window: their socket dropped and
+   * the roster is holding their seat until they come back or get evicted
+   * (`SESSION_GRACE_PERIOD_MS` on the backend — a minute). Still crew, not yet
+   * gone.
+   */
+  reconnecting: number;
+};
+
 /**
- * Count distinct OTHER humans who are actually connected right now.
+ * Count distinct OTHER humans on the roster, connected and reconnecting apart.
  *
  * {@link countDistinctSessionUsers} answers "how many people are in this
  * session", which is the right question for an avatar row: a peer who is
@@ -69,23 +82,49 @@ type ConnectedRosterIdentity = Pick<RuntimeSessionUser, 'id' | 'userId' | 'conne
  *
  * Either one turns a lone climber into a false crew, and a gate that reads a
  * false crew stops their swipes from lighting their own board. So this counts
- * peers, not participants, and only ones the server says are live.
+ * peers, not participants.
+ *
+ * The two buckets exist because the gate needs them for different things. Only
+ * a CONNECTED peer can ARM it: a stale self-entry is `RECONNECTING` from the
+ * moment the server notices the old socket is gone, and it stays that way for
+ * the whole grace window, so counting it as present would take a lone climber's
+ * board for a minute after every reconnect. But a peer who WAS connected and
+ * flaps to `RECONNECTING` is still an audience — their wall stakes did not leave
+ * with their wifi — so an armed gate is HELD by reconnecting peers and releases
+ * only when the last of them is evicted or leaves. Without that, a peer's
+ * socket blip made the next swipe commit to the shared queue, and re-arming
+ * then cost the arrival dwell on top.
  *
  * `connectionState` is treated as connected when ABSENT, not when equal to
  * `'CONNECTED'`: a backend that does not send the field must behave as it did
  * before this filter existed rather than silently reporting an empty crew.
  */
+export function countSessionPeers(
+  users: readonly ConnectedRosterIdentity[] | null | undefined,
+  self: SessionSelfIdentity,
+): SessionPeerCounts {
+  if (!users) return { connected: 0, reconnecting: 0 };
+  const connected = new Set<string>();
+  const reconnecting = new Set<string>();
+  for (const user of users) {
+    if (self.participantId != null && user.id === self.participantId) continue;
+    if (self.userId != null && user.userId === self.userId) continue;
+    const identity = user.userId ?? user.id;
+    if (user.connectionState == null || user.connectionState === 'CONNECTED') connected.add(identity);
+    else reconnecting.add(identity);
+  }
+  // One human with a live socket and a dying one is connected, not both.
+  for (const identity of connected) reconnecting.delete(identity);
+  return { connected: connected.size, reconnecting: reconnecting.size };
+}
+
+/**
+ * Distinct OTHER humans who are actually connected right now — the arming count
+ * for the browse gate. See {@link countSessionPeers} for the hold count.
+ */
 export function countConnectedSessionPeers(
   users: readonly ConnectedRosterIdentity[] | null | undefined,
   self: SessionSelfIdentity,
 ): number {
-  if (!users) return 0;
-  const seen = new Set<string>();
-  for (const user of users) {
-    if (user.connectionState != null && user.connectionState !== 'CONNECTED') continue;
-    if (self.participantId != null && user.id === self.participantId) continue;
-    if (self.userId != null && user.userId === self.userId) continue;
-    seen.add(user.userId ?? user.id);
-  }
-  return seen.size;
+  return countSessionPeers(users, self).connected;
 }

--- a/packages/shared/queue/src/__tests__/playlist-suggestions.test.ts
+++ b/packages/shared/queue/src/__tests__/playlist-suggestions.test.ts
@@ -3,6 +3,7 @@ import {
   mergeUniquePlaylistClimbs,
   playlistSuggestionSourceMatches,
   pruneSuggestedQueueItemsAfterCurrent,
+  reanchorPlaylistSuggestionSource,
 } from '../playlist-suggestions';
 import type { Climb, ClimbQueueItem, PlaylistSuggestionSource } from '../types';
 
@@ -103,5 +104,43 @@ describe('pruneSuggestedQueueItemsAfterCurrent', () => {
 
     const result = pruneSuggestedQueueItemsAfterCurrent(queue, notInQueue);
     expect(result).toBe(queue);
+  });
+});
+
+describe('reanchorPlaylistSuggestionSource', () => {
+  const source = (activatedClimbUuid: string, uuids: string[]): PlaylistSuggestionSource => ({
+    playlistUuid: 'list-1',
+    activatedClimbUuid,
+    boardKey: 'kilter:1:10:1,2',
+    climbs: uuids.map((uuid) => makeClimb(uuid)),
+  });
+
+  // The bug this exists for: a climber browses a track from `a` to `d` and puts
+  // `d` up. Committing with the source still anchored on `a` aims "next" at `b` —
+  // a climb they swiped past three gestures ago.
+  it('moves the anchor to the climb actually being committed', () => {
+    const reanchored = reanchorPlaylistSuggestionSource(source('a', ['a', 'b', 'c', 'd']), 'd');
+    expect(reanchored?.activatedClimbUuid).toBe('d');
+    expect(reanchored?.climbs.map((climb) => climb.uuid)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('returns the SAME reference when the anchor is already right', () => {
+    // Identity matters: this feeds a context value and a re-anchor that always
+    // allocated would churn every consumer on each commit.
+    const original = source('a', ['a', 'b']);
+    expect(reanchorPlaylistSuggestionSource(original, 'a')).toBe(original);
+  });
+
+  it('leaves a source alone when the climb is not in it', () => {
+    // Anchoring on a climb the source does not contain makes `activatedIndex`
+    // -1, which reads the whole list as exhausted — worse than a stale anchor.
+    const original = source('a', ['a', 'b']);
+    expect(reanchorPlaylistSuggestionSource(original, 'zz')).toBe(original);
+  });
+
+  it('handles a missing source or climb uuid', () => {
+    expect(reanchorPlaylistSuggestionSource(null, 'a')).toBeNull();
+    const original = source('a', ['a']);
+    expect(reanchorPlaylistSuggestionSource(original, undefined)).toBe(original);
   });
 });

--- a/packages/shared/queue/src/index.ts
+++ b/packages/shared/queue/src/index.ts
@@ -34,6 +34,7 @@ export {
   isPlaylistPeekQueueItemUuid,
   getQueueBoardKey,
   createPlaylistSuggestionSource,
+  reanchorPlaylistSuggestionSource,
 } from './playlist-suggestions';
 export type { QueueBoardKeyTarget } from './playlist-suggestions';
 

--- a/packages/shared/queue/src/playlist-suggestions.ts
+++ b/packages/shared/queue/src/playlist-suggestions.ts
@@ -105,6 +105,32 @@ export function insertQueueItemAfterCurrent(
 }
 
 /**
+ * Re-anchor a suggestion source on the climb that is actually being committed.
+ *
+ * A source records the climb its pass STARTED from (`activatedClimbUuid`), and
+ * everything downstream — `getPlaylistSuggestedClimbs`, the peek walk in
+ * `findNextQueueItemWithSuggestions`, the remaining count — measures from there.
+ * That is right while the pass is walking forward from the tapped climb, and
+ * wrong the moment a climber browses from A to Z and puts Z up: committing Z
+ * with a source still anchored on A aims "next" at whatever followed A, which is
+ * a climb the climber walked past several swipes ago.
+ *
+ * Returns the source unchanged when there is nothing to fix — no source, already
+ * anchored here, or a climb the source does not contain (a peek from some other
+ * track), since anchoring on a climb that is not in `climbs` would make the
+ * whole list read as exhausted.
+ */
+export function reanchorPlaylistSuggestionSource(
+  source: PlaylistSuggestionSource | null,
+  activatedClimbUuid: string | undefined,
+): PlaylistSuggestionSource | null {
+  if (!source || !activatedClimbUuid) return source;
+  if (source.activatedClimbUuid === activatedClimbUuid) return source;
+  if (!source.climbs.some((climb) => climb.uuid === activatedClimbUuid)) return source;
+  return { ...source, activatedClimbUuid };
+}
+
+/**
  * Generate a deterministic queue-item uuid for playlist peek items.
  */
 export function getPlaylistPeekQueueItemUuid(climbUuid: string): string {


### PR DESCRIPTION
## Summary

Restore preview-first shared sessions behind the positive `shared-session-browse` rollout flag. Missing, unresolved, or disabled flags preserve ordinary solo wall control. When enabled with a crew present, browsing stays private until the climber explicitly commits.

Fix the regressions that caused #4683 to be reverted in #4745: changing angle clears a solo preview, reconnecting peers hold an already-armed crew gate, and filtered-list selections keep their highlight and pending drawer target.

Rebased onto `origin/main` at `21bfbb8ba`. Conflict resolution preserves main's shared mirror mutations, solo mirror intent, latest-wins BLE frame writer, cross-board suppression, list-first navigation, insert-after-current ordering, report-climb sheets, and removal of obsolete telemetry.

The fresh review found and fixed a playlist integration bug: after starting a crew preview from a committed playlist climb, another phone selecting an unrelated climb could remove the preview's navigation track. The drawer now retains that track through peer navigation and releases crew-captured tracks after the ten-second solo dwell. Explicit preview tracks remain private.

Author-side verification:

- `vp run typecheck` and final `vp run typecheck:mobile` passed.
- Full mobile suite: 873 files, 9,585 tests passed. Final changed-scope regressions: 74 tests passed, including both playlist directions, crew departure, explicit-preview preservation, and entering preview with a BLE write pending. The new playlist/departure tests were confirmed failing before their respective fixes.
- Shared play-view, queue, queue-runtime, queue-react, and i18n suites: 737 tests passed.
- `vp check --fix`, translation checks, and iOS/Android Metro bundle checks passed. Pre-commit checks passed.
- Astra reviewed the final BLE/playback and browsing integration: no remaining actionable code blockers. No physical-board or two-device hardware testing was performed in this pass.

Rollout requirement: confirm `shared-session-browse` remains inactive at 0% before merge. Recheck solo board-lighting telemetry before enabling the crew rollout.

## Release Notes

- With crew browsing enabled, explore climbs without changing anyone's wall; put yours up when you're ready.
- Solo swipes light climbs again after an angle change or a crew session ends.
- Tapping through filtered results opens and highlights the climb you selected.

## Test plan

1. Solo, Bluetooth connected: swipe five climbs → the wall follows.
2. Preview a climb, change angle → solo swipes light climbs again.
3. Climbs tab: tap filtered rows → each selected climb opens.
4. Two phones, browse flag enabled: swipe → other phone’s wall stays.
5. Tap “Put on the wall” → both phones show your climb.

## Risk

Risk: 5/5 — changes when playback and shared queue commits reach the board; crew browsing remains gated.
