### PR TITLE
feat(mobile): keep every climb-creator session on the phone, and say so

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/create.tsx
+++ b/packages/mobile/app/(tabs)/climbs/create.tsx
@@ -129,7 +129,7 @@ export default function CreateClimbRoute() {
     // holds that don't exist on the new layout/size. Angle is excluded so a
     // session-sync angle change doesn't wipe an in-progress paint.
     <CreateClimbScreen
-      key={createClimbScreenKey(params.editClimbUuid, board)}
+      key={createClimbScreenKey(params.editClimbUuid, board, params.forkFrames)}
       board={board}
       forkFrames={params.forkFrames}
       forkName={params.forkName}

--- a/packages/mobile/src/components/Button.android.tsx
+++ b/packages/mobile/src/components/Button.android.tsx
@@ -23,7 +23,7 @@ import {
   Text,
   TextButton,
 } from '@expo/ui/jetpack-compose';
-import { fillMaxWidth, padding, size } from '@expo/ui/jetpack-compose/modifiers';
+import { defaultMinSize, fillMaxWidth, padding, size } from '@expo/ui/jetpack-compose/modifiers';
 import type { ImageSourcePropType } from 'react-native';
 import { useTheme } from '../providers/theme-provider';
 import { brandAccentColor } from '../theme/expo-ui-modifiers';
@@ -65,6 +65,7 @@ export function Button({
   loading = false,
   haptic = true,
   tintColor,
+  minHeight,
   role = 'default',
   testID,
   style,
@@ -133,6 +134,16 @@ export function Button({
   const isFullWidth = isFullWidthStyle(style);
   const iconSource = icon ? BUTTON_ICON_SOURCE[icon] : undefined;
 
+  // Compose has no discrete height buckets: a button is exactly its content plus
+  // `contentPadding`, so `small` lands at 40dp — under the 44 touch floor. Callers
+  // that sit in a row of 44dp controls pass `minHeight`; `defaultMinSize` is the
+  // Compose idiom for exactly that (a floor, not a fixed height, so a long label
+  // or large Dynamic Type still grows the button).
+  const composeModifiers = [
+    ...(isFullWidth ? [fillMaxWidth()] : []),
+    ...(minHeight != null ? [defaultMinSize({ minHeight })] : []),
+  ];
+
   return (
     <Host
       matchContents={isFullWidth ? { vertical: true } : true}
@@ -150,7 +161,7 @@ export function Button({
           end: config.paddingHorizontal,
           bottom: config.paddingVertical,
         }}
-        modifiers={isFullWidth ? [fillMaxWidth()] : []}
+        modifiers={composeModifiers}
       >
         <Row verticalAlignment="center">
           {loading ? (

--- a/packages/mobile/src/components/Button.ios.tsx
+++ b/packages/mobile/src/components/Button.ios.tsx
@@ -68,6 +68,7 @@ export function Button({
   loading = false,
   haptic = true,
   tintColor,
+  minHeight = 44,
   over,
   role = 'default',
   testID,
@@ -125,7 +126,7 @@ export function Button({
     buttonBorderShape('roundedRectangle', radii.button),
     controlSize(CONTROL_SIZE[size]),
     font({ textStyle: TEXT_STYLE[size], weight: 'semibold' }),
-    frame({ minHeight: 44, ...(isFullWidth ? { maxWidth: Infinity } : {}) }),
+    frame({ minHeight, ...(isFullWidth ? { maxWidth: Infinity } : {}) }),
     disabledModifier(disabled || loading),
     accessibilityLabelModifier(accessibilityLabel ?? title),
   ];

--- a/packages/mobile/src/components/Button.types.ts
+++ b/packages/mobile/src/components/Button.types.ts
@@ -40,6 +40,13 @@ export type ButtonProps = {
   loading?: boolean;
   haptic?: boolean;
   tintColor?: string;
+  /**
+   * Floor for the button's height, in dp. iOS already floors every button at the
+   * 44pt target; Compose derives its height from `contentPadding` alone, so a
+   * `small` filled button lands at 40 there. Pass this where the button sits in a
+   * row of 44dp controls and must not be the one under the touch floor.
+   */
+  minHeight?: number;
   /** See {@link ButtonSurface}. Per-button override of the surrounding provider. */
   over?: ButtonSurface;
   /** See {@link ButtonRole}. */

--- a/packages/mobile/src/components/Button.web.tsx
+++ b/packages/mobile/src/components/Button.web.tsx
@@ -40,6 +40,7 @@ export function Button({
   loading = false,
   haptic = true,
   tintColor,
+  minHeight,
   role = 'default',
   testID,
   style,
@@ -89,7 +90,14 @@ export function Button({
       // A full-width button stretches to its row; an inline one hugs its content
       // (Paper's default). `alignSelf` mirrors the Compose `fillMaxWidth()` intent.
       style={[isFullWidth ? styles.fullWidth : styles.inline, style]}
-      contentStyle={{ paddingHorizontal: config.paddingHorizontal, paddingVertical: config.paddingVertical }}
+      // Paper sizes the button from its content row, so the touch-floor override
+      // belongs here (same role as the Compose `defaultMinSize`), not on the outer
+      // container — see `minHeight` in Button.types.ts.
+      contentStyle={{
+        paddingHorizontal: config.paddingHorizontal,
+        paddingVertical: config.paddingVertical,
+        ...(minHeight != null ? { minHeight } : {}),
+      }}
       labelStyle={{ fontSize: config.fontSize }}
     >
       {title}

--- a/packages/mobile/src/components/create-climb/CreateClimbScreen.tsx
+++ b/packages/mobile/src/components/create-climb/CreateClimbScreen.tsx
@@ -65,6 +65,20 @@ export function CreateClimbScreen({
     [board.boardName, board.layoutId, board.sizeId, board.setIds],
   );
 
+  // Every dismiss path — chevron, pan-down, backdrop, hardware back — lands here.
+  // No confirm on any of them: the autosave flush on unmount already keeps the
+  // work, and a modal on the pan-down (the most-used gesture on this surface)
+  // would be hostile. Just say it once, and only when the climber could
+  // reasonably think it's gone — the controller decides that.
+  //
+  // Toast AFTER the pop, not before: the toast overlay is a root-level JS View
+  // that renders behind any native sheet (see toast-provider), so firing it while
+  // the drawer is still up shows nothing.
+  const handleClose = useCallback(() => {
+    router.back();
+    controller.notifyDraftKeptOnDismiss();
+  }, [router, controller]);
+
   const handleLongPress = useCallback((holdId: number) => setLongPressHoldId(holdId), []);
   const closeHoldRole = useCallback(() => setLongPressHoldId(null), []);
 
@@ -136,7 +150,7 @@ export function CreateClimbScreen({
         onLongPressHold={handleLongPress}
         subSheetOpen={longPressHoldId !== null}
         onLoadDraft={handleLoadDraft}
-        onClose={() => router.back()}
+        onClose={handleClose}
         onViewDuplicate={handleViewDuplicate}
       />
 

--- a/packages/mobile/src/components/create-climb/CreateClimbScreen.tsx
+++ b/packages/mobile/src/components/create-climb/CreateClimbScreen.tsx
@@ -43,6 +43,19 @@ export function CreateClimbScreen({
   const router = useRouter();
   const { openPlayDrawer } = useDrawerHost();
 
+  const handleStartedNewClimb = useCallback(() => {
+    router.replace({
+      pathname: '/(tabs)/climbs/create',
+      params: {
+        boardName: board.boardName,
+        layoutId: String(board.layoutId),
+        sizeId: String(board.sizeId),
+        setIds: board.setIds,
+        angle: String(board.angle),
+      },
+    });
+  }, [router, board]);
+
   const controller = useCreateClimbScreen({
     board,
     forkFrames,
@@ -50,6 +63,7 @@ export function CreateClimbScreen({
     forkDescription,
     editClimbUuid,
     onPublished: () => router.back(),
+    onStartedNewClimb: handleStartedNewClimb,
   });
 
   const [longPressHoldId, setLongPressHoldId] = useState<number | null>(null);

--- a/packages/mobile/src/components/create-climb/CreateClimbScreen.tsx
+++ b/packages/mobile/src/components/create-climb/CreateClimbScreen.tsx
@@ -74,10 +74,11 @@ export function CreateClimbScreen({
   // Toast AFTER the pop, not before: the toast overlay is a root-level JS View
   // that renders behind any native sheet (see toast-provider), so firing it while
   // the drawer is still up shows nothing.
+  const { notifyDraftKeptOnDismiss } = controller;
   const handleClose = useCallback(() => {
     router.back();
-    controller.notifyDraftKeptOnDismiss();
-  }, [router, controller]);
+    notifyDraftKeptOnDismiss();
+  }, [router, notifyDraftKeptOnDismiss]);
 
   const handleLongPress = useCallback((holdId: number) => setLongPressHoldId(holdId), []);
   const closeHoldRole = useCallback(() => setLongPressHoldId(null), []);

--- a/packages/mobile/src/components/create-climb/CreateDraftStatusRow.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDraftStatusRow.tsx
@@ -6,10 +6,14 @@ import { spacing } from '../../theme/tokens';
 import type { DraftStatusView } from './draft-status-view';
 
 type CreateDraftStatusRowProps = {
-  status: DraftStatusView;
+  /** The line to show, or null when the editor is empty and has nothing to say. */
+  status: DraftStatusView | null;
   /** The action bar's shared, rate-limited voice. See useRateLimitedAnnouncer. */
   announce: (text: string) => void;
 };
+
+/** caption1 line box, used as the row's floor when there is no text. */
+const RESERVED_LINE_HEIGHT = 16;
 
 /**
  * The persistent one-line answer to "is my work safe?", sitting directly under
@@ -18,6 +22,14 @@ type CreateDraftStatusRowProps = {
  * Left-aligned on purpose: a caption right-aligned under the pill is under your
  * thumb at exactly the moment you want to read it, and the left rule is shared
  * with the brush chips and the description label.
+ *
+ * The row ALWAYS occupies its line box, even with nothing to say. It is not free
+ * to collapse: the drawer sizes the board against the chrome and derives the peek
+ * snap-point from the measured above-fold height, so a row that appeared when the
+ * first hold landed changed `peekHeight` mid-session and re-snapped an expanded
+ * sheet back down to peek — a one-shot jolt at exactly the moment someone starts
+ * working. Reserving the height keeps the chrome constant, which also stops the
+ * content below shifting as the line comes and goes.
  */
 export const CreateDraftStatusRow = memo(function CreateDraftStatusRow({
   status,
@@ -26,37 +38,41 @@ export const CreateDraftStatusRow = memo(function CreateDraftStatusRow({
   const { systemColors, brandColors } = useTheme();
 
   const color =
-    status.tone === 'error'
+    status?.tone === 'error'
       ? brandColors.error
-      : status.tone === 'warning'
+      : status?.tone === 'warning'
         ? brandColors.warning
         : systemColors.secondaryLabel;
 
   // Speak only on a TRANSITION into an announce-worthy state, and never on first
   // paint (opening an already-saved draft should not narrate itself).
   const lastTextRef = useRef<string | null>(null);
+  const statusText = status?.text ?? null;
+  const shouldAnnounce = status?.announce ?? false;
   useEffect(() => {
     const previousText = lastTextRef.current;
-    lastTextRef.current = status.text;
-    if (previousText === null || previousText === status.text) return;
-    if (!status.announce) return;
-    announce(status.text);
-  }, [status.text, status.announce, announce]);
+    lastTextRef.current = statusText;
+    if (statusText === null || previousText === null || previousText === statusText) return;
+    if (!shouldAnnounce) return;
+    announce(statusText);
+  }, [statusText, shouldAnnounce, announce]);
 
   return (
-    <View style={styles.row}>
-      <Text
-        variant="caption1"
-        color={color}
-        numberOfLines={1}
-        ellipsizeMode="tail"
-        // Explicitly NOT a live region: the state behind this line flips on a
-        // 500ms autosave debounce, so `polite` would re-announce on every
-        // keystroke and every hold tap. The effect above narrates transitions.
-        accessibilityLiveRegion="none"
-      >
-        {status.text}
-      </Text>
+    <View style={styles.row} testID="create-draft-status-row">
+      {statusText === null ? null : (
+        <Text
+          variant="caption1"
+          color={color}
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          // Explicitly NOT a live region: the state behind this line flips on a
+          // 500ms autosave debounce, so `polite` would re-announce on every
+          // keystroke and every hold tap. The effect above narrates transitions.
+          accessibilityLiveRegion="none"
+        >
+          {statusText}
+        </Text>
+      )}
     </View>
   );
 });
@@ -67,5 +83,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[4],
     paddingTop: spacing[1],
     paddingBottom: spacing[3],
+    // Floor, not a fixed height: larger Dynamic Type still grows the line.
+    minHeight: RESERVED_LINE_HEIGHT,
   },
 });

--- a/packages/mobile/src/components/create-climb/CreateDraftStatusRow.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDraftStatusRow.tsx
@@ -1,0 +1,71 @@
+import { memo, useEffect, useRef } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Text } from '../Text';
+import { useTheme } from '../../providers/theme-provider';
+import { spacing } from '../../theme/tokens';
+import type { DraftStatusView } from './draft-status-view';
+
+type CreateDraftStatusRowProps = {
+  status: DraftStatusView;
+  /** The action bar's shared, rate-limited voice. See useRateLimitedAnnouncer. */
+  announce: (text: string) => void;
+};
+
+/**
+ * The persistent one-line answer to "is my work safe?", sitting directly under
+ * the Save row so the answer and the button that changes it are in one glance.
+ *
+ * Left-aligned on purpose: a caption right-aligned under the pill is under your
+ * thumb at exactly the moment you want to read it, and the left rule is shared
+ * with the brush chips and the description label.
+ */
+export const CreateDraftStatusRow = memo(function CreateDraftStatusRow({
+  status,
+  announce,
+}: CreateDraftStatusRowProps) {
+  const { systemColors, brandColors } = useTheme();
+
+  const color =
+    status.tone === 'error'
+      ? brandColors.error
+      : status.tone === 'warning'
+        ? brandColors.warning
+        : systemColors.secondaryLabel;
+
+  // Speak only on a TRANSITION into an announce-worthy state, and never on first
+  // paint (opening an already-saved draft should not narrate itself).
+  const lastTextRef = useRef<string | null>(null);
+  useEffect(() => {
+    const previousText = lastTextRef.current;
+    lastTextRef.current = status.text;
+    if (previousText === null || previousText === status.text) return;
+    if (!status.announce) return;
+    announce(status.text);
+  }, [status.text, status.announce, announce]);
+
+  return (
+    <View style={styles.row}>
+      <Text
+        variant="caption1"
+        color={color}
+        numberOfLines={1}
+        ellipsizeMode="tail"
+        // Explicitly NOT a live region: the state behind this line flips on a
+        // 500ms autosave debounce, so `polite` would re-announce on every
+        // keystroke and every hold tap. The effect above narrates transitions.
+        accessibilityLiveRegion="none"
+      >
+        {status.text}
+      </Text>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  row: {
+    // Left edge lines up with the brush chips and the "Description" label.
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[1],
+    paddingBottom: spacing[3],
+  },
+});

--- a/packages/mobile/src/components/create-climb/CreateDraftStatusRow.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDraftStatusRow.tsx
@@ -52,8 +52,13 @@ export const CreateDraftStatusRow = memo(function CreateDraftStatusRow({
   useEffect(() => {
     const previousText = lastTextRef.current;
     lastTextRef.current = statusText;
-    if (statusText === null || previousText === null || previousText === statusText) return;
-    if (!shouldAnnounce) return;
+    if (statusText === null || !shouldAnnounce) {
+      // An announce-worthy warning may be waiting at the rate limiter's trailing
+      // edge. Moving to a quiet/empty state makes that warning stale.
+      announce('');
+      return;
+    }
+    if (previousText === null || previousText === statusText) return;
     announce(statusText);
   }, [statusText, shouldAnnounce, announce]);
 

--- a/packages/mobile/src/components/create-climb/CreateDrawer.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawer.tsx
@@ -41,10 +41,13 @@ type CreateDrawerProps = {
   onViewDuplicate: (uuid: string) => void;
 };
 
-// Space the header + two-row action bar + handle + safe areas need, so the
-// board is sized to leave them on-screen at the peek (a rough reserve — the
-// peek snap itself is measured from the real above-fold height).
-const ABOVE_FOLD_CHROME = 300;
+// Space the header + action bar + draft-status line + handle + safe areas need,
+// so the board is sized to leave them on-screen at the peek (a rough reserve —
+// the peek snap itself is measured from the real above-fold height, so erring
+// high only costs a few dp of board). Raised from 300 when the status line
+// landed under the Save row: it adds a 16dp caption plus its padding, minus the
+// 8dp the action row gives back.
+const ABOVE_FOLD_CHROME = 320;
 
 // The native sheet's drag grabber sits in the sheet chrome above the content;
 // reserve a small fixed amount for it in the peek snap-point (replaces the old
@@ -205,7 +208,8 @@ export function CreateDrawer({
             canRedo={controller.canRedo}
             onUndo={controller.undo}
             onRedo={controller.redo}
-            onClear={controller.handleClear}
+            onClearHolds={controller.handleClearHolds}
+            onNewClimb={() => void controller.handleNewClimb()}
             frameCount={controller.frameCount}
             currentFrameIndex={controller.currentFrameIndex}
             onDuplicateFrame={controller.duplicateFrame}
@@ -216,6 +220,8 @@ export function CreateDrawer({
             onSetActive={controller.handleSetActive}
             saveState={controller.saveState}
             onSave={() => void controller.handleSave()}
+            publishBlocked={controller.publishBlocked}
+            draftStatus={controller.draftStatus}
           />
         </View>
 

--- a/packages/mobile/src/components/create-climb/CreateDrawer.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawer.tsx
@@ -16,6 +16,8 @@ import { CreateDrawerActionBar } from './CreateDrawerActionBar';
 import { CreateDrawerForm } from './CreateDrawerForm';
 import { OpenDraftsSection } from './OpenDraftsSection';
 import { DuplicateBanner } from './DuplicateBanner';
+import { InlineConfirmBanner } from './InlineConfirmBanner';
+import { useTranslation } from 'react-i18next';
 import { useCreateClimbScreen, type CreateClimbBoard } from './use-create-climb-screen';
 
 type Controller = ReturnType<typeof useCreateClimbScreen>;
@@ -44,10 +46,16 @@ type CreateDrawerProps = {
 // Space the header + action bar + draft-status line + handle + safe areas need,
 // so the board is sized to leave them on-screen at the peek (a rough reserve —
 // the peek snap itself is measured from the real above-fold height, so erring
-// high only costs a few dp of board). Raised from 300 when the status line
-// landed under the Save row: it adds a 16dp caption plus its padding, minus the
-// 8dp the action row gives back.
-const ABOVE_FOLD_CHROME = 320;
+// high only costs a few dp of board).
+//
+// Raised from 300 by exactly what the status line costs the action bar: +32 for
+// its line box and padding, −8 from the action row's bottom padding, so +24. The
+// board shrinks by the same 24, which makes the peek height IDENTICAL to what it
+// was before the line existed — the status line is free at the peek, in every
+// state (the row reserves its height even when empty, so this doesn't drift as
+// you paint). Deliberately not rounded: a round number here would silently make
+// the peek taller and eat into an already-tight budget on a tall board.
+const ABOVE_FOLD_CHROME = 324;
 
 // The native sheet's drag grabber sits in the sheet chrome above the content;
 // reserve a small fixed amount for it in the peek snap-point (replaces the old
@@ -71,6 +79,7 @@ export function CreateDrawer({
   onViewDuplicate,
 }: CreateDrawerProps) {
   const { systemColors } = useTheme();
+  const { t } = useTranslation('climbs');
   const insets = useSafeAreaInsets();
   // Bottom terms use the WINDOW inset: this drawer is a route inside the climbs
   // tab, whose per-tab provider folds iOS 26 tab chrome the sheet covers into
@@ -167,6 +176,17 @@ export function CreateDrawer({
             onToggleBle={controller.handleToggleBle}
           />
 
+          {controller.pendingNewClimb ? (
+            <InlineConfirmBanner
+              title={t('mobile.create.newClimb.confirm.title')}
+              message={t('mobile.create.newClimb.confirm.message')}
+              confirmLabel={t('mobile.create.newClimb.confirm.action')}
+              cancelLabel={t('createClimbForm.dismiss')}
+              onConfirm={controller.confirmNewClimb}
+              onCancel={controller.cancelNewClimb}
+            />
+          ) : null}
+
           {controller.publishDuplicateError ? (
             <DuplicateBanner
               name={controller.publishDuplicateError.existingClimbName}
@@ -209,7 +229,7 @@ export function CreateDrawer({
             onUndo={controller.undo}
             onRedo={controller.redo}
             onClearHolds={controller.handleClearHolds}
-            onNewClimb={() => void controller.handleNewClimb()}
+            onNewClimb={controller.handleNewClimb}
             frameCount={controller.frameCount}
             currentFrameIndex={controller.currentFrameIndex}
             onDuplicateFrame={controller.duplicateFrame}

--- a/packages/mobile/src/components/create-climb/CreateDrawer.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawer.tsx
@@ -90,7 +90,11 @@ export function CreateDrawer({
 
   // Measured above-fold height drives the peek snap-point (the native grabber is
   // a fixed reserve now, not a measured custom handle).
-  const [aboveFoldHeight, setAboveFoldHeight] = useState(0);
+  // Measured in two pieces, with the transient banners sitting BETWEEN them and
+  // measured by neither — see the note on the JSX below.
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const [boardBlockHeight, setBoardBlockHeight] = useState(0);
+  const aboveFoldHeight = headerHeight > 0 && boardBlockHeight > 0 ? headerHeight + boardBlockHeight : 0;
   // Live snap index, kept current via onChange so the re-snap below targets the
   // index the user is actually at (not a one-shot reset that breaks on rotation).
   const indexRef = useRef(0);
@@ -113,8 +117,11 @@ export function CreateDrawer({
   const setHeightIfChanged = (setter: (updater: (prev: number) => number) => void, measured: number) => {
     setter((prev) => (Math.abs(prev - measured) > 2 ? Math.round(measured) : prev));
   };
-  const handleAboveFoldLayout = useCallback((event: LayoutChangeEvent) => {
-    setHeightIfChanged(setAboveFoldHeight, event.nativeEvent.layout.height);
+  const handleHeaderLayout = useCallback((event: LayoutChangeEvent) => {
+    setHeightIfChanged(setHeaderHeight, event.nativeEvent.layout.height);
+  }, []);
+  const handleBoardBlockLayout = useCallback((event: LayoutChangeEvent) => {
+    setHeightIfChanged(setBoardBlockHeight, event.nativeEvent.layout.height);
   }, []);
 
   // native grabber reserve + content paddingTop + above-fold (header + board +
@@ -163,7 +170,7 @@ export function CreateDrawer({
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="on-drag"
       >
-        <View onLayout={handleAboveFoldLayout}>
+        <View onLayout={handleHeaderLayout} testID="create-drawer-measured-header">
           <CreateDrawerHeader
             name={controller.name}
             onChangeName={controller.setName}
@@ -175,33 +182,47 @@ export function CreateDrawer({
             bleConnecting={controller.bleConnecting}
             onToggleBle={controller.handleToggleBle}
           />
+        </View>
 
-          {controller.pendingNewClimb ? (
-            <InlineConfirmBanner
-              title={t('mobile.create.newClimb.confirm.title')}
-              message={t('mobile.create.newClimb.confirm.message')}
-              confirmLabel={t('mobile.create.newClimb.confirm.action')}
-              cancelLabel={t('createClimbForm.dismiss')}
-              onConfirm={controller.confirmNewClimb}
-              onCancel={controller.cancelNewClimb}
-            />
-          ) : null}
+        {/* Transient, and deliberately measured by NEITHER block above or below.
+            The peek snap-point is derived from the measured above-fold height, so
+            anything that mounts inside a measured region moves `peekHeight` and
+            re-snaps the sheet — which collapsed an expanded drawer the instant a
+            banner appeared, hiding the very climb the banner is asking about. The
+            status row solved the same problem by reserving a constant line box;
+            these can't, because reserving ~100dp permanently for something rarely
+            on screen would cost more above-fold budget than the board can spare.
+            So they push content instead of resizing the sheet: the drawer stays
+            exactly where the climber put it. Pinned by "keeps the transient
+            banners out of the measured above-fold region" in
+            create-drawer-measured-region.test.tsx. */}
+        {controller.pendingNewClimb ? (
+          <InlineConfirmBanner
+            title={t('mobile.create.newClimb.confirm.title')}
+            message={t('mobile.create.newClimb.confirm.message')}
+            confirmLabel={t('mobile.create.newClimb.confirm.action')}
+            cancelLabel={t('createClimbForm.dismiss')}
+            onConfirm={controller.confirmNewClimb}
+            onCancel={controller.cancelNewClimb}
+          />
+        ) : null}
 
-          {controller.publishDuplicateError ? (
-            <DuplicateBanner
-              name={controller.publishDuplicateError.existingClimbName}
-              onView={
-                controller.publishDuplicateError.existingClimbUuid
-                  ? () => {
-                      const uuid = controller.publishDuplicateError?.existingClimbUuid;
-                      if (uuid) onViewDuplicate(uuid);
-                    }
-                  : undefined
-              }
-              onDismiss={controller.dismissDuplicateError}
-            />
-          ) : null}
+        {controller.publishDuplicateError ? (
+          <DuplicateBanner
+            name={controller.publishDuplicateError.existingClimbName}
+            onView={
+              controller.publishDuplicateError.existingClimbUuid
+                ? () => {
+                    const uuid = controller.publishDuplicateError?.existingClimbUuid;
+                    if (uuid) onViewDuplicate(uuid);
+                  }
+                : undefined
+            }
+            onDismiss={controller.dismissDuplicateError}
+          />
+        ) : null}
 
+        <View onLayout={handleBoardBlockLayout} testID="create-drawer-measured-board-block">
           <View style={styles.boardSection}>
             <InteractiveCreateBoard
               boardName={board.boardName as BoardName}

--- a/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
@@ -174,7 +174,7 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
         </Pressable>
       </View>
 
-      <View style={[drawerActionBarStyles.rowSecondary, draftStatus ? styles.rowSecondaryWithStatus : null]}>
+      <View style={[drawerActionBarStyles.rowSecondary, styles.rowSecondaryWithStatus]}>
         {/* Pinned outside the scroller: undo has to stay reachable on a
             multi-frame climb, where the editing cluster is wider than the row. */}
         <ActionButton
@@ -267,7 +267,8 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
         <SaveButton saveState={saveState} onSave={onSave} publishBlocked={publishBlocked} />
       </View>
 
-      {draftStatus ? <CreateDraftStatusRow status={draftStatus} announce={announce} /> : null}
+      {/* Always rendered, even with nothing to say — see CreateDraftStatusRow. */}
+      <CreateDraftStatusRow status={draftStatus} announce={announce} />
     </View>
   );
 });
@@ -339,8 +340,8 @@ const styles = StyleSheet.create({
     minWidth: 44,
     textAlign: 'center',
   },
-  // The status row carries the bar's bottom padding when it's showing, so the
-  // line sits 4dp under the Save pill rather than a full gap below it.
+  // The status row carries the bar's bottom padding, so the line sits 4dp under
+  // the Save pill rather than a full gap below it.
   rowSecondaryWithStatus: {
     paddingBottom: spacing[1],
   },

--- a/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { View, Pressable, ScrollView, StyleSheet } from 'react-native';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { useTranslation } from 'react-i18next';
@@ -11,9 +11,13 @@ import { useTheme } from '../../providers/theme-provider';
 import { hapticSelection } from '../../lib/haptics';
 import { useHoldColorOverrides } from '../../lib/hold-color-overrides';
 import { brandColors } from '../../theme/colors';
+import { glassSize } from '../../theme/layout';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { brushRoleColor, getPaintRoles, useBrushRoleLabels, type BrushRole } from './brush-roles';
 import { deriveSaveButtonView } from './save-button-view';
+import { CreateDraftStatusRow } from './CreateDraftStatusRow';
+import { useRateLimitedAnnouncer } from './use-rate-limited-announcer';
+import type { DraftStatusView } from './draft-status-view';
 import type { SaveButtonState } from './use-create-climb-screen';
 
 // Looked up dynamically by role below; mark each resolvable key (one per line,
@@ -31,7 +35,10 @@ type CreateDrawerActionBarProps = {
   canRedo: boolean;
   onUndo: () => void;
   onRedo: () => void;
-  onClear: () => void;
+  /** Empty this frame's holds. Undoable; leaves name/description/storage alone. */
+  onClearHolds: () => void;
+  /** Park this climb and start a blank one (confirms when nothing is saved yet). */
+  onNewClimb: () => void;
   frameCount: number;
   currentFrameIndex: number;
   onDuplicateFrame: () => void;
@@ -42,14 +49,24 @@ type CreateDrawerActionBarProps = {
   onSetActive: () => void;
   saveState: SaveButtonState;
   onSave: () => void;
+  /** True while publishing is selected but the climb has no start or finish hold. */
+  publishBlocked: boolean;
+  /** The persistent "is my work safe?" line, or null for an empty editor. */
+  draftStatus: DraftStatusView | null;
 };
 
 /**
- * The create-drawer two-row action bar, built on the shared drawer-action-bar
- * grammar. Row 1 (where the Play Drawer's play controls sit) is the five brush
- * chips; Row 2 is the other actions: undo / redo / clear, then set-active and
- * the save state-machine button. Row 2's editing actions scroll horizontally so
- * set-active and save stay pinned no matter how wide that cluster grows.
+ * The create-drawer action bar, built on the shared drawer-action-bar grammar.
+ * Row 1 (where the Play Drawer's play controls sit) is the brush chips; row 2 is
+ * the editing actions, then set-active and the save state-machine button; under
+ * both sits the persistent draft-status line.
+ *
+ * Undo is pinned OUTSIDE the horizontal scroller on the leading edge, the mirror
+ * of the trailing pinned pair. Nine 44dp controls need ~460dp and the scroller
+ * has ~261dp, so on any multi-frame climb undo used to scroll off the left edge —
+ * putting the only recovery from a mis-tap out of reach exactly when the row got
+ * crowded. Pinning it is cheaper than a confirm and fixes the case a confirm
+ * wouldn't. Redo stays in the scroller.
  */
 export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
   boardName,
@@ -59,7 +76,8 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
   canRedo,
   onUndo,
   onRedo,
-  onClear,
+  onClearHolds,
+  onNewClimb,
   frameCount,
   currentFrameIndex,
   onDuplicateFrame,
@@ -70,11 +88,32 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
   onSetActive,
   saveState,
   onSave,
+  publishBlocked,
+  draftStatus,
 }: CreateDrawerActionBarProps) {
   const { t } = useTranslation('climbs');
   const { systemColors } = useTheme();
   const roleLabels = useBrushRoleLabels();
   const { overrides: holdColorOverrides } = useHoldColorOverrides();
+  // One voice for this whole surface, so a status transition and a frame
+  // announcement can't talk over each other.
+  const announce = useRateLimitedAnnouncer();
+
+  // Duplicating a frame is undoable, so it needs feedback rather than a confirm:
+  // today the only sign a frame appeared is the "2/2" counter mid-row. Haptic on
+  // press (matching the brush chips), and the new count spoken once — on the
+  // transition only, so frame NAVIGATION stays silent.
+  const announceFrameCountRef = useRef(false);
+  const handleDuplicateFrame = useCallback(() => {
+    hapticSelection();
+    announceFrameCountRef.current = true;
+    onDuplicateFrame();
+  }, [onDuplicateFrame]);
+  useEffect(() => {
+    if (!announceFrameCountRef.current) return;
+    announceFrameCountRef.current = false;
+    announce(t('mobile.create.frames.counter', { index: currentFrameIndex + 1, total: frameCount }));
+  }, [frameCount, currentFrameIndex, announce, t]);
 
   const paintRoles = useMemo(() => getPaintRoles(boardName), [boardName]);
   const roleChips = useMemo(
@@ -135,7 +174,17 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
         </Pressable>
       </View>
 
-      <View style={drawerActionBarStyles.rowSecondary}>
+      <View style={[drawerActionBarStyles.rowSecondary, draftStatus ? styles.rowSecondaryWithStatus : null]}>
+        {/* Pinned outside the scroller: undo has to stay reachable on a
+            multi-frame climb, where the editing cluster is wider than the row. */}
+        <ActionButton
+          size="sm"
+          iconName="undo"
+          onPress={onUndo}
+          disabled={!canUndo}
+          accessibilityLabel={t('mobile.create.actions.undo')}
+        />
+
         {/* The editing cluster grows by four controls once a climb has a second
             frame, and RN views don't shrink — with no wrap and no scroll it used
             to push Save clean off the right edge. The scroller takes the row's
@@ -150,28 +199,24 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
         >
           <ActionButton
             size="sm"
-            iconName="undo"
-            onPress={onUndo}
-            disabled={!canUndo}
-            accessibilityLabel={t('mobile.create.actions.undo')}
-          />
-          <ActionButton
-            size="sm"
             iconName="redo"
             onPress={onRedo}
             disabled={!canRedo}
             accessibilityLabel={t('mobile.create.actions.redo')}
           />
+          {/* Keeps the trash can: now that it empties holds and nothing else, the
+              glyph is honest. An eraser would collide with the Erase BRUSH chip
+              59dp above — one glyph meaning both a mode and a command. */}
           <ActionButton
             size="sm"
             iconName="delete"
-            onPress={onClear}
+            onPress={onClearHolds}
             accessibilityLabel={t('mobile.create.actions.clear')}
           />
           <ActionButton
             size="sm"
             iconName="copy"
-            onPress={onDuplicateFrame}
+            onPress={handleDuplicateFrame}
             accessibilityLabel={t('mobile.create.frames.duplicate')}
           />
           {frameCount > 1 && (
@@ -201,6 +246,15 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
               />
             </>
           )}
+          {/* Last in the scroller: the least-used control in the row, and the one
+              it's fine to scroll for. `plus`, not `refresh` — that's already the
+              playback-restart glyph. */}
+          <ActionButton
+            size="sm"
+            iconName="plus"
+            onPress={onNewClimb}
+            accessibilityLabel={t('mobile.create.actions.newClimb')}
+          />
         </ScrollView>
 
         <ActionButton
@@ -210,13 +264,23 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
           disabled={!canSetActive}
           accessibilityLabel={t('mobile.create.actions.setActive')}
         />
-        <SaveButton saveState={saveState} onSave={onSave} />
+        <SaveButton saveState={saveState} onSave={onSave} publishBlocked={publishBlocked} />
       </View>
+
+      {draftStatus ? <CreateDraftStatusRow status={draftStatus} announce={announce} /> : null}
     </View>
   );
 });
 
-function SaveButton({ saveState, onSave }: { saveState: SaveButtonState; onSave: () => void }) {
+function SaveButton({
+  saveState,
+  onSave,
+  publishBlocked,
+}: {
+  saveState: SaveButtonState;
+  onSave: () => void;
+  publishBlocked: boolean;
+}) {
   const { t } = useTranslation('climbs');
   const view = deriveSaveButtonView(saveState, t);
 
@@ -227,12 +291,17 @@ function SaveButton({ saveState, onSave }: { saveState: SaveButtonState; onSave:
         icon={view.icon ?? undefined}
         variant="filled"
         size="small"
+        // The only sub-44 control on this surface (Compose sizes a small filled
+        // button at 40), shoulder to shoulder with 44dp icon buttons. Floor it.
+        minHeight={glassSize.inline}
         // Success keeps the static green fill (white-legible in both schemes; the
         // lifted dark success tint would fail white-on-fill). For the default tint
         // we pass nothing so the filled Button uses its own scheme-aware
         // `primaryFill` (lifts to #7C3AED in dark), matching every other CTA.
         tintColor={view.tint === 'success' ? brandColors.success : undefined}
-        disabled={view.disabled}
+        // A blocked publish disables the button; the status line directly below
+        // names the missing requirement, so it is never mute.
+        disabled={view.disabled || publishBlocked}
         onPress={onSave}
       />
     </ButtonSurfaceProvider>
@@ -269,6 +338,11 @@ const styles = StyleSheet.create({
   frameCounter: {
     minWidth: 44,
     textAlign: 'center',
+  },
+  // The status row carries the bar's bottom padding when it's showing, so the
+  // line sits 4dp under the Save pill rather than a full gap below it.
+  rowSecondaryWithStatus: {
+    paddingBottom: spacing[1],
   },
   actionScroll: {
     // Claims the row's leftover width so the trailing Set Active + Save pair is

--- a/packages/mobile/src/components/create-climb/CreateDrawerHeader.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawerHeader.tsx
@@ -56,10 +56,16 @@ export const CreateDrawerHeader = memo(function CreateDrawerHeader({
 
   return (
     <View style={styles.row}>
+      {/* NOT `createClimbForm.dismiss` — that key is a DIALOG cancel label, and
+          its translations say discard ("Descartar" / "Ignorer" / "Ausblenden").
+          On a close button, for a feature whose whole point is "does closing lose
+          my work?", the screen-reader user was getting a stronger wrong signal
+          than the sighted one. The work is kept; the hint says where. */}
       <Pressable
         onPress={onClose}
         accessibilityRole="button"
-        accessibilityLabel={t('createClimbForm.dismiss')}
+        accessibilityLabel={t('mobile.create.actions.close')}
+        accessibilityHint={t('mobile.create.actions.closeHint')}
         hitSlop={8}
         style={[styles.iconButton, { backgroundColor: systemColors.fill }]}
       >

--- a/packages/mobile/src/components/create-climb/DraftRow.tsx
+++ b/packages/mobile/src/components/create-climb/DraftRow.tsx
@@ -28,7 +28,16 @@ export function DraftRow({ climb, onPress, onDelete }: DraftRowProps) {
 
   const holdCount = countHolds(climb.frames);
   const relative = formatRelativeTime(climb.created_at);
-  const subtitleParts = [t('mobile.create.drafts.holds', { count: holdCount }), relative].filter(Boolean);
+  const framesCount = climb.framesCount ?? 1;
+  // Untitled drafts all render as "Draft", so the subtitle is what tells them
+  // apart. Frame count joins it once a climb is a route — never a localized
+  // fallback written into `board_climbs.name`, which would freeze one locale
+  // into the row forever.
+  const subtitleParts = [
+    t('mobile.create.drafts.holds', { count: holdCount }),
+    framesCount > 1 ? t('mobile.create.drafts.frames', { count: framesCount }) : null,
+    relative,
+  ].filter(Boolean);
 
   const handlePress = useCallback(() => {
     hapticLight();

--- a/packages/mobile/src/components/create-climb/DuplicateBanner.tsx
+++ b/packages/mobile/src/components/create-climb/DuplicateBanner.tsx
@@ -35,7 +35,9 @@ export function DuplicateBanner({ name, onView, onDismiss }: DuplicateBannerProp
           </Pressable>
         ) : null}
       </View>
-      <Pressable onPress={onDismiss} accessibilityRole="button" hitSlop={8}>
+      {/* 16dp glyph + hitSlop 8 was a 32dp effective target, under the 44 floor.
+          14 lands it at 44 without moving anything visually. */}
+      <Pressable onPress={onDismiss} accessibilityRole="button" hitSlop={14}>
         <Icon name="close" size={16} color={systemColors.secondaryLabel} />
       </Pressable>
     </View>

--- a/packages/mobile/src/components/create-climb/InlineConfirmBanner.tsx
+++ b/packages/mobile/src/components/create-climb/InlineConfirmBanner.tsx
@@ -1,6 +1,7 @@
 import { View, Pressable, StyleSheet } from 'react-native';
 import { Text } from '../Text';
 import { useTheme } from '../../providers/theme-provider';
+import { glassSize } from '../../theme/layout';
 import { spacing, borderRadius } from '../../theme/tokens';
 
 type InlineConfirmBannerProps = {
@@ -82,9 +83,14 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
     gap: spacing[4],
   },
-  // 44dp effective target via hitSlop on a compact text action.
+  // The NODE has to clear the 44dp touch floor, not just the effective area:
+  // `hitSlop` is invisible to an accessibility scanner and to anyone aiming at
+  // the glyph, and the measured node is what an audit reports. Padding alone
+  // lands at ~42 (footnote line box + 2x12), so the floor is explicit.
   action: {
-    paddingVertical: spacing[2],
-    paddingHorizontal: spacing[1],
+    minHeight: glassSize.inline,
+    justifyContent: 'center',
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[2],
   },
 });

--- a/packages/mobile/src/components/create-climb/InlineConfirmBanner.tsx
+++ b/packages/mobile/src/components/create-climb/InlineConfirmBanner.tsx
@@ -1,0 +1,90 @@
+import { View, Pressable, StyleSheet } from 'react-native';
+import { Text } from '../Text';
+import { useTheme } from '../../providers/theme-provider';
+import { spacing, borderRadius } from '../../theme/tokens';
+
+type InlineConfirmBannerProps = {
+  title: string;
+  message: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+/**
+ * A confirm rendered as sheet CONTENT rather than as a dialog.
+ *
+ * `useConfirm` cannot be used from inside this drawer on Android: the Material
+ * path renders a Paper `Dialog` inside a `Portal`, which is a JS view mounted at
+ * the app root, while the create drawer is a NATIVE @expo/ui bottom sheet
+ * composited above that root. The dialog paints behind the sheet and is never
+ * seen — the promise just never resolves to `true`, so the action silently does
+ * nothing. (iOS is fine: the same provider uses a native `Alert` there, which is
+ * its own window.) The toast overlay has the identical problem, which is why
+ * `toast-provider` carries a warning about it.
+ *
+ * Inline content cannot be occluded by the sheet it lives in, which is why
+ * `DuplicateBanner` — the other thing in this drawer that must not be missed —
+ * is built the same way.
+ */
+export function InlineConfirmBanner({
+  title,
+  message,
+  confirmLabel,
+  cancelLabel,
+  onConfirm,
+  onCancel,
+}: InlineConfirmBannerProps) {
+  const { systemColors, brandColors } = useTheme();
+  return (
+    <View style={[styles.banner, { backgroundColor: systemColors.fill }]} accessibilityRole="alert">
+      <View style={styles.text}>
+        <Text variant="footnote" style={styles.title}>
+          {title}
+        </Text>
+        <Text variant="footnote" color={systemColors.secondaryLabel}>
+          {message}
+        </Text>
+      </View>
+      <View style={styles.actions}>
+        <Pressable onPress={onCancel} accessibilityRole="button" hitSlop={8} style={styles.action}>
+          <Text variant="footnote" color={systemColors.secondaryLabel}>
+            {cancelLabel}
+          </Text>
+        </Pressable>
+        <Pressable onPress={onConfirm} accessibilityRole="button" hitSlop={8} style={styles.action}>
+          <Text variant="footnote" color={brandColors.error}>
+            {confirmLabel}
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    marginHorizontal: spacing[4],
+    marginTop: spacing[2],
+    padding: spacing[3],
+    borderRadius: borderRadius.md,
+    gap: spacing[2],
+  },
+  text: {
+    gap: spacing[1],
+  },
+  title: {
+    fontWeight: '600',
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: spacing[4],
+  },
+  // 44dp effective target via hitSlop on a compact text action.
+  action: {
+    paddingVertical: spacing[2],
+    paddingHorizontal: spacing[1],
+  },
+});

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-action-bar.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-action-bar.test.tsx
@@ -9,7 +9,8 @@ import { createElement, type ReactNode } from 'react';
 type PressMockProps = { children?: ReactNode; onPress?: () => void; accessibilityLabel?: string };
 const announceSpy = vi.hoisted(() => vi.fn());
 vi.mock('react-native', () => ({
-  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  View: ({ children, testID }: { children?: ReactNode; testID?: string }) =>
+    createElement('div', { 'data-testid': testID }, children),
   Pressable: ({ children, onPress, accessibilityLabel }: PressMockProps) =>
     createElement('button', { onClick: onPress, 'data-label': accessibilityLabel }, children),
   ScrollView: ({ children, horizontal }: { children?: ReactNode; horizontal?: boolean }) =>
@@ -90,6 +91,7 @@ function renderBar(frameCount: number, overrides: Partial<typeof baseProps> = {}
   const { container } = render(createElement(CreateDrawerActionBar, { ...baseProps, frameCount, ...overrides }));
   return {
     container,
+    statusRow: container.querySelector('[data-testid="create-draft-status-row"]') as HTMLElement,
     scroller: container.querySelector('[data-scroll="true"]') as HTMLElement,
     undo: container.querySelector('[data-action="undo"]') as HTMLElement,
     setActive: container.querySelector('[data-action="play.circle"]') as HTMLElement,
@@ -158,9 +160,29 @@ describe('CreateDrawerActionBar', () => {
     expect(container.textContent).toContain('mobile.create.publish.blocked');
   });
 
-  it('renders no status line for an empty editor', () => {
-    const { container } = renderBar(1);
+  it('renders no status TEXT for an empty editor, but still holds the row', () => {
+    // The words are absent by design — an empty editor has nothing to report.
+    // The ROW is not, and that distinction is load-bearing: the drawer sizes the
+    // board against the chrome and derives its peek snap-point from the measured
+    // above-fold height. When this row appeared only once content existed,
+    // painting the FIRST hold grew the chrome, moved `peekHeight`, and re-snapped
+    // an expanded sheet back down to peek — a one-shot jolt at exactly the moment
+    // someone starts working. Make this row conditional again and that returns.
+    const { container, statusRow } = renderBar(1);
     expect(container.textContent).not.toContain('mobile.create.autosave');
+    expect(statusRow).toBeTruthy();
+  });
+
+  it('holds the same status row whether or not there is anything to say', () => {
+    // The chrome height must not depend on content — see above.
+    const empty = renderBar(1);
+    const withStatus = renderBar(1, {
+      draftStatus: { text: 'mobile.create.autosave.onDevice', tone: 'muted', announce: false },
+    });
+
+    expect(empty.statusRow).toBeTruthy();
+    expect(withStatus.statusRow).toBeTruthy();
+    expect(withStatus.statusRow.textContent).toContain('mobile.create.autosave.onDevice');
   });
 
   it('puts the multi-frame stepper in the scroller rather than pushing Save off the row', () => {

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-action-bar.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-action-bar.test.tsx
@@ -7,6 +7,7 @@ import { createElement, type ReactNode } from 'react';
 // tests can assert which controls ride the scroller and which stay pinned
 // outside it — the whole point of the row's layout.
 type PressMockProps = { children?: ReactNode; onPress?: () => void; accessibilityLabel?: string };
+const announceSpy = vi.hoisted(() => vi.fn());
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   Pressable: ({ children, onPress, accessibilityLabel }: PressMockProps) =>
@@ -14,6 +15,7 @@ vi.mock('react-native', () => ({
   ScrollView: ({ children, horizontal }: { children?: ReactNode; horizontal?: boolean }) =>
     createElement('div', { 'data-scroll': 'true', 'data-horizontal': horizontal ? 'true' : 'false' }, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  AccessibilityInfo: { announceForAccessibility: announceSpy },
 }));
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
@@ -25,8 +27,13 @@ vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
 vi.mock('../../Button', () => ({
-  Button: ({ title, disabled }: { title?: string; disabled?: boolean }) =>
-    createElement('button', { 'data-save-button': 'true', 'data-title': title, disabled }),
+  Button: ({ title, disabled, minHeight }: { title?: string; disabled?: boolean; minHeight?: number }) =>
+    createElement('button', {
+      'data-save-button': 'true',
+      'data-title': title,
+      'data-min-height': minHeight,
+      disabled,
+    }),
 }));
 vi.mock('../../Button.surface', () => ({
   ButtonSurfaceProvider: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
@@ -44,12 +51,16 @@ vi.mock('../brush-roles', () => ({
 vi.mock('../../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
 vi.mock('../../../lib/hold-color-overrides', () => ({ useHoldColorOverrides: () => ({ overrides: {} }) }));
 vi.mock('../../../providers/theme-provider', () => ({
-  useTheme: () => ({ systemColors: { fill: '#EFEFF0', label: '#000000' } }),
+  useTheme: () => ({
+    systemColors: { fill: '#EFEFF0', label: '#000000', secondaryLabel: '#5B5563' },
+    brandColors: { warning: '#B45309', error: '#C81E1E' },
+  }),
 }));
 vi.mock('../../../theme/colors', () => ({ brandColors: { primary: '#6D28D9', success: '#047857' } }));
 vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 3: 12, 4: 16 }, borderRadius: { md: 8 } }));
 
 import { CreateDrawerActionBar } from '../CreateDrawerActionBar';
+import type { DraftStatusView } from '../draft-status-view';
 
 const baseProps = {
   boardName: 'kilter' as const,
@@ -59,7 +70,8 @@ const baseProps = {
   canRedo: true,
   onUndo: vi.fn(),
   onRedo: vi.fn(),
-  onClear: vi.fn(),
+  onClearHolds: vi.fn(),
+  onNewClimb: vi.fn(),
   frameCount: 1,
   currentFrameIndex: 0,
   onDuplicateFrame: vi.fn(),
@@ -70,12 +82,16 @@ const baseProps = {
   onSetActive: vi.fn(),
   saveState: 'ready' as const,
   onSave: vi.fn(),
+  publishBlocked: false,
+  draftStatus: null as DraftStatusView | null,
 };
 
-function renderBar(frameCount: number) {
-  const { container } = render(createElement(CreateDrawerActionBar, { ...baseProps, frameCount }));
+function renderBar(frameCount: number, overrides: Partial<typeof baseProps> = {}) {
+  const { container } = render(createElement(CreateDrawerActionBar, { ...baseProps, frameCount, ...overrides }));
   return {
+    container,
     scroller: container.querySelector('[data-scroll="true"]') as HTMLElement,
+    undo: container.querySelector('[data-action="undo"]') as HTMLElement,
     setActive: container.querySelector('[data-action="play.circle"]') as HTMLElement,
     save: container.querySelector('[data-save-button="true"]') as HTMLElement,
   };
@@ -91,8 +107,60 @@ describe('CreateDrawerActionBar', () => {
     expect(scroller.contains(setActive)).toBe(false);
     expect(scroller.contains(save)).toBe(false);
     // The editing actions are the part allowed to scroll.
-    expect(scroller.querySelector('[data-action="undo"]')).toBeTruthy();
+    expect(scroller.querySelector('[data-action="redo"]')).toBeTruthy();
     expect(scroller.querySelector('[data-action="copy"]')).toBeTruthy();
+  });
+
+  it('pins undo outside the scroller so recovery survives a crowded row', () => {
+    // Nine 44dp controls need ~460dp and the scroller has ~261dp, so undo used to
+    // scroll off the left edge the moment a climb had a second frame — putting the
+    // only recovery from a mis-tap out of reach exactly when the row got crowded.
+    const { scroller, undo } = renderBar(3);
+
+    expect(undo).toBeTruthy();
+    expect(scroller.contains(undo)).toBe(false);
+    // Redo is the one that may scroll.
+    expect(scroller.querySelector('[data-action="redo"]')).toBeTruthy();
+  });
+
+  it('keeps the trash glyph for Clear holds and adds a separate Start-a-new-climb', () => {
+    // Two buttons, two jobs. `eraser` is not available for Clear holds — it is
+    // already the Erase BRUSH chip in the row above, and one glyph can't mean both
+    // a mode you enter and a destructive command you fire.
+    const { container, scroller } = renderBar(1);
+
+    const clear = container.querySelector('[data-action="delete"]') as HTMLElement;
+    const newClimb = container.querySelector('[data-action="plus"]') as HTMLElement;
+    expect(clear).toBeTruthy();
+    expect(clear.getAttribute('data-label')).toBe('mobile.create.actions.clear');
+    expect(newClimb).toBeTruthy();
+    expect(newClimb.getAttribute('data-label')).toBe('mobile.create.actions.newClimb');
+    expect(container.querySelector('[data-action="eraser"]')).toBeNull();
+    // "Start a new climb" is the least-used control, so it's the one that scrolls.
+    expect(scroller.contains(newClimb)).toBe(true);
+  });
+
+  it('floors the Save pill at the 44dp touch target', () => {
+    // Compose sizes a small filled button at 40 — the only sub-floor control on
+    // this surface, shoulder to shoulder with 44dp icon buttons.
+    const { save } = renderBar(1);
+    expect(save.getAttribute('data-min-height')).toBe('44');
+  });
+
+  it('disables Save while a publish is blocked, and renders the reason under it', () => {
+    const { save, container } = renderBar(1, {
+      publishBlocked: true,
+      draftStatus: { text: 'mobile.create.publish.blocked', tone: 'warning', announce: true },
+    });
+
+    expect((save as HTMLButtonElement).disabled).toBe(true);
+    // A disabled button must never be mute.
+    expect(container.textContent).toContain('mobile.create.publish.blocked');
+  });
+
+  it('renders no status line for an empty editor', () => {
+    const { container } = renderBar(1);
+    expect(container.textContent).not.toContain('mobile.create.autosave');
   });
 
   it('puts the multi-frame stepper in the scroller rather than pushing Save off the row', () => {

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-measured-region.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-measured-region.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// The drawer derives its peek snap-point from the MEASURED above-fold height, so
+// anything that mounts inside a measured region moves `peekHeight` and re-snaps
+// the sheet. That collapsed an expanded drawer the instant a banner appeared —
+// hiding the very climb the banner was asking the climber to discard.
+//
+// The status row solved the same problem by reserving a constant line box. The
+// banners can't: reserving ~100dp permanently for something rarely on screen
+// costs more above-fold budget than the board can spare. So they live BETWEEN the
+// two measured blocks and are measured by neither.
+
+type ViewMockProps = { children?: ReactNode; onLayout?: unknown; testID?: string };
+vi.mock('react-native', () => ({
+  View: ({ children, onLayout, testID }: ViewMockProps) =>
+    createElement('div', { 'data-measured': onLayout ? 'true' : undefined, 'data-testid': testID }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  useWindowDimensions: () => ({ width: 405, height: 900 }),
+}));
+vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 24, bottom: 0 }) }));
+vi.mock('../../../hooks/use-window-bottom-inset', () => ({ useWindowBottomInset: () => 48 }));
+vi.mock('@expo/ui/community/bottom-sheet', () => ({
+  default: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  BottomSheetScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { secondaryBackground: '#221A33' } }),
+}));
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 6: 24 },
+  sheetStyles: { background: {} },
+}));
+vi.mock('../InteractiveCreateBoard', () => ({
+  InteractiveCreateBoard: () => createElement('div', { 'data-node': 'board' }),
+}));
+vi.mock('../CreateDrawerHeader', () => ({
+  CreateDrawerHeader: () => createElement('div', { 'data-node': 'header' }),
+}));
+vi.mock('../CreateDrawerActionBar', () => ({
+  CreateDrawerActionBar: () => createElement('div', { 'data-node': 'action-bar' }),
+}));
+vi.mock('../CreateDrawerForm', () => ({ CreateDrawerForm: () => createElement('div', { 'data-node': 'form' }) }));
+vi.mock('../OpenDraftsSection', () => ({ OpenDraftsSection: () => createElement('div', { 'data-node': 'drafts' }) }));
+vi.mock('../InlineConfirmBanner', () => ({
+  InlineConfirmBanner: () => createElement('div', { 'data-node': 'confirm-banner' }),
+}));
+vi.mock('../DuplicateBanner', () => ({
+  DuplicateBanner: () => createElement('div', { 'data-node': 'duplicate-banner' }),
+}));
+
+import { CreateDrawer } from '../CreateDrawer';
+
+const board = { boardName: 'kilter' as const, layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 };
+const boardHolds = { holdTargets: [], boardWidth: 650, boardHeight: 1000 };
+
+type Controller = Parameters<typeof CreateDrawer>[0]['controller'];
+
+function makeController(overrides: Record<string, unknown>): Controller {
+  return {
+    name: '',
+    setName: vi.fn(),
+    startingCount: 0,
+    finishCount: 0,
+    focusNameSignal: 0,
+    bleConnected: false,
+    bleConnecting: false,
+    handleToggleBle: vi.fn(),
+    litUpHoldsMap: {},
+    handlePaint: vi.fn(),
+    showAllHolds: false,
+    selectedBrush: 'HAND',
+    setSelectedBrush: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+    undo: vi.fn(),
+    redo: vi.fn(),
+    handleClearHolds: vi.fn(),
+    handleNewClimb: vi.fn(),
+    frameCount: 1,
+    currentFrameIndex: 0,
+    duplicateFrame: vi.fn(),
+    deleteFrame: vi.fn(),
+    prevFrame: vi.fn(),
+    nextFrame: vi.fn(),
+    canSetActive: false,
+    handleSetActive: vi.fn(),
+    saveState: 'ready',
+    handleSave: vi.fn(),
+    publishBlocked: false,
+    draftStatus: null,
+    pendingNewClimb: false,
+    confirmNewClimb: vi.fn(),
+    cancelNewClimb: vi.fn(),
+    publishDuplicateError: null,
+    dismissDuplicateError: vi.fn(),
+    description: '',
+    setDescription: vi.fn(),
+    noMatch: false,
+    setNoMatch: vi.fn(),
+    isDraft: true,
+    setIsDraft: vi.fn(),
+    setShowAllHolds: vi.fn(),
+    ...overrides,
+  } as unknown as Controller;
+}
+
+function renderDrawer(overrides: Record<string, unknown>) {
+  const { container } = render(
+    createElement(CreateDrawer, {
+      board,
+      controller: makeController(overrides),
+      boardHolds,
+      onLongPressHold: vi.fn(),
+      subSheetOpen: false,
+      onLoadDraft: vi.fn(),
+      onClose: vi.fn(),
+      onViewDuplicate: vi.fn(),
+    }),
+  );
+  return {
+    container,
+    measured: Array.from(container.querySelectorAll('[data-measured="true"]')),
+    node: (name: string) => container.querySelector(`[data-node="${name}"]`),
+  };
+}
+
+describe('CreateDrawer measured above-fold region', () => {
+  it('measures the header and the board block, which is what sizes the peek', () => {
+    const { measured, node } = renderDrawer({});
+    expect(measured.length).toBe(2);
+    expect(measured.some((block) => block.contains(node('header')))).toBe(true);
+    expect(measured.some((block) => block.contains(node('board')))).toBe(true);
+    expect(measured.some((block) => block.contains(node('action-bar')))).toBe(true);
+  });
+
+  it('keeps the transient banners out of the measured above-fold region', () => {
+    // Put either banner back inside a measured block and its mount changes
+    // `peekHeight`, which re-snaps the sheet out from under the climber.
+    const confirm = renderDrawer({ pendingNewClimb: true });
+    expect(confirm.node('confirm-banner')).toBeTruthy();
+    expect(confirm.measured.some((block) => block.contains(confirm.node('confirm-banner')))).toBe(false);
+
+    const duplicate = renderDrawer({
+      publishDuplicateError: { existingClimbUuid: 'x', existingClimbName: 'Other climb' },
+    });
+    expect(duplicate.node('duplicate-banner')).toBeTruthy();
+    expect(duplicate.measured.some((block) => block.contains(duplicate.node('duplicate-banner')))).toBe(false);
+  });
+
+  it('measures the same nodes whether or not a banner is showing', () => {
+    // The real invariant: the measured set is banner-independent, so the peek
+    // height cannot move when one appears.
+    const without = renderDrawer({});
+    const withBanner = renderDrawer({ pendingNewClimb: true });
+
+    const measuredNodeNames = (r: ReturnType<typeof renderDrawer>) =>
+      r.measured
+        .flatMap((block) => Array.from(block.querySelectorAll('[data-node]')))
+        .map((el) => el.getAttribute('data-node'))
+        .sort();
+
+    expect(measuredNodeNames(withBanner)).toEqual(measuredNodeNames(without));
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/draft-status-view.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/draft-status-view.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { deriveDraftStatusView, type DraftStatusState } from '../draft-status-view';
+
+// The line answers "is my work safe, and where is it?" — the question the create
+// drawer had no answer to at all. One case per branch, plus the two orderings
+// that decide which truth wins when several apply at once.
+
+const identity = (key: string) => key;
+
+const base: DraftStatusState = {
+  hasContent: true,
+  localPersistenceAvailable: true,
+  hasSavedClimb: false,
+  hasUnsavedEdits: false,
+  saveFailed: false,
+  publishBlocked: false,
+};
+
+describe('deriveDraftStatusView', () => {
+  it('says nothing about an empty editor', () => {
+    expect(deriveDraftStatusView({ ...base, hasContent: false }, identity)).toBeNull();
+  });
+
+  it('reports the on-device copy for a never-saved climb', () => {
+    expect(deriveDraftStatusView(base, identity)).toEqual({
+      text: 'mobile.create.autosave.onDevice',
+      tone: 'muted',
+      announce: false,
+    });
+  });
+
+  it('reports the account copy once a row exists', () => {
+    expect(deriveDraftStatusView({ ...base, hasSavedClimb: true }, identity)).toEqual({
+      text: 'mobile.create.autosave.inAccount',
+      tone: 'muted',
+      announce: true,
+    });
+  });
+
+  it('says the newest edits are local-only after a save', () => {
+    expect(deriveDraftStatusView({ ...base, hasSavedClimb: true, hasUnsavedEdits: true }, identity)).toEqual({
+      text: 'mobile.create.autosave.unsyncedEdits',
+      tone: 'muted',
+      announce: false,
+    });
+  });
+
+  it('warns when nothing can be stored at all', () => {
+    // Signed-out expo-web: every write is dropped, so no other branch may claim
+    // the work is kept anywhere.
+    expect(deriveDraftStatusView({ ...base, localPersistenceAvailable: false, hasSavedClimb: true }, identity)).toEqual(
+      {
+        text: 'mobile.create.autosave.notStored',
+        tone: 'warning',
+        announce: true,
+      },
+    );
+  });
+
+  it('surfaces a failed save in the error tone, outranking the happy states', () => {
+    // Without this branch the line reads "Saved on this phone" — true, and silent
+    // about the account copy never happening once the 3s toast is gone.
+    expect(deriveDraftStatusView({ ...base, saveFailed: true }, identity)).toEqual({
+      text: 'mobile.create.autosave.saveFailed',
+      tone: 'error',
+      announce: true,
+    });
+    expect(deriveDraftStatusView({ ...base, hasSavedClimb: true, saveFailed: true }, identity)?.tone).toBe('error');
+  });
+
+  it('names the missing requirement while a publish is blocked', () => {
+    expect(deriveDraftStatusView({ ...base, publishBlocked: true }, identity)).toEqual({
+      text: 'mobile.create.publish.blocked',
+      tone: 'warning',
+      announce: true,
+    });
+  });
+
+  it('has no "saving" state — the button already says that', () => {
+    // Two "Saving…" strings 20dp apart is noise. Nothing in the input can produce
+    // a line other than the six above, so a save in flight leaves the line put.
+    const everyText = [
+      base,
+      { ...base, hasSavedClimb: true },
+      { ...base, hasSavedClimb: true, hasUnsavedEdits: true },
+      { ...base, localPersistenceAvailable: false },
+      { ...base, saveFailed: true },
+      { ...base, publishBlocked: true },
+    ].map((state) => deriveDraftStatusView(state, identity)?.text);
+    expect(everyText).not.toContain('mobile.create.save.saving');
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/inline-confirm-banner.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/inline-confirm-banner.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, within } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// This banner exists because `useConfirm` cannot be seen from inside the create
+// drawer on Android: the Material path renders a Paper Dialog in a JS Portal at
+// the app root, and the drawer is a native @expo/ui sheet composited above it, so
+// the dialog paints behind and its promise never resolves. Sheet content cannot be
+// occluded by the sheet it lives in, which is the whole point of this component.
+
+type PressMockProps = { children?: ReactNode; onPress?: () => void; accessibilityRole?: string };
+vi.mock('react-native', () => ({
+  View: ({ children, accessibilityRole }: { children?: ReactNode; accessibilityRole?: string }) =>
+    createElement('div', { role: accessibilityRole }, children),
+  Pressable: ({ children, onPress, accessibilityRole }: PressMockProps) =>
+    createElement('button', { onClick: onPress, 'data-role': accessibilityRole }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { fill: '#EFEFF0', secondaryLabel: '#5B5563' },
+    brandColors: { error: '#C81E1E' },
+  }),
+}));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 3: 12, 4: 16 }, borderRadius: { md: 8 } }));
+
+import { InlineConfirmBanner } from '../InlineConfirmBanner';
+
+const props = {
+  title: 'Start over?',
+  message: "This one isn't in your drafts yet.",
+  confirmLabel: 'Start over',
+  cancelLabel: 'Dismiss',
+};
+
+function renderBanner() {
+  const onConfirm = vi.fn();
+  const onCancel = vi.fn();
+  const { container, getByText } = render(createElement(InlineConfirmBanner, { ...props, onConfirm, onCancel }));
+  return { container, getByText, onConfirm, onCancel };
+}
+
+describe('InlineConfirmBanner', () => {
+  it('states what is being asked and offers both ways out', () => {
+    const { getByText } = renderBanner();
+    expect(getByText('Start over?')).toBeTruthy();
+    expect(getByText("This one isn't in your drafts yet.")).toBeTruthy();
+    expect(getByText('Start over')).toBeTruthy();
+    expect(getByText('Dismiss')).toBeTruthy();
+  });
+
+  it('announces itself as an alert, since it replaces a dialog', () => {
+    const { container } = renderBanner();
+    expect(container.querySelector('[role="alert"]')).toBeTruthy();
+  });
+
+  it('reports the choice the climber actually made', () => {
+    // Each render gets its own container: both banners share one document, so an
+    // unscoped query would match the other one's buttons too.
+    const confirming = renderBanner();
+    fireEvent.click(within(confirming.container).getByText('Start over'));
+    expect(confirming.onConfirm).toHaveBeenCalledTimes(1);
+    expect(confirming.onCancel).not.toHaveBeenCalled();
+
+    const cancelling = renderBanner();
+    fireEvent.click(within(cancelling.container).getByText('Dismiss'));
+    expect(cancelling.onCancel).toHaveBeenCalledTimes(1);
+    expect(cancelling.onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-autosave.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-autosave.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+import { useRef } from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const draftStore = vi.hoisted(() => ({
+  saveDraft: vi.fn(async (_key: string, _draft: Record<string, unknown>) => {}),
+  clearDraft: vi.fn(async (_key: string) => {}),
+}));
+
+const appState = vi.hoisted(() => ({
+  listeners: [] as Array<(state: string) => void>,
+  addEventListener: vi.fn((_event: string, listener: (state: string) => void) => {
+    appState.listeners.push(listener);
+    return { remove: vi.fn() };
+  }),
+  emit(state: string) {
+    appState.listeners.forEach((listener) => listener(state));
+  },
+}));
+
+vi.mock('react-native', () => ({
+  AppState: { addEventListener: appState.addEventListener },
+}));
+
+vi.mock('../../../lib/create-climb-draft-store', () => ({
+  saveDraft: draftStore.saveDraft,
+  clearDraft: draftStore.clearDraft,
+}));
+
+import { AUTOSAVE_DEBOUNCE_MS, useCreateClimbAutosave } from '../use-create-climb-autosave';
+
+const BASE_DRAFT = {
+  holdsJson: '{}',
+  framesJson: '[{}]',
+  name: '',
+  description: '',
+  isDraft: true,
+};
+
+function useAutosaveHarness({ hasContent, signature }: { hasContent: boolean; signature: string }) {
+  const restoredRef = useRef(true);
+  return useCreateClimbAutosave({
+    slotKey: 'draft-key',
+    draft: { ...BASE_DRAFT, name: signature },
+    draftSignature: signature,
+    hasContent,
+    restoredRef,
+    restoreEpoch: 0,
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  draftStore.saveDraft.mockReset();
+  draftStore.saveDraft.mockResolvedValue(undefined);
+  draftStore.clearDraft.mockReset();
+  draftStore.clearDraft.mockResolvedValue(undefined);
+  appState.listeners = [];
+  appState.addEventListener.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useCreateClimbAutosave', () => {
+  it('flushes a pending empty-form clear on unmount', () => {
+    const { unmount } = renderHook(() => useAutosaveHarness({ hasContent: false, signature: 'empty' }));
+
+    unmount();
+
+    expect(draftStore.clearDraft).toHaveBeenCalledExactlyOnceWith('draft-key');
+    expect(draftStore.saveDraft).not.toHaveBeenCalled();
+  });
+
+  it('flushes a pending empty-form clear when the app backgrounds', () => {
+    renderHook(() => useAutosaveHarness({ hasContent: false, signature: 'empty' }));
+
+    act(() => appState.emit('background'));
+
+    expect(draftStore.clearDraft).toHaveBeenCalledExactlyOnceWith('draft-key');
+    expect(draftStore.saveDraft).not.toHaveBeenCalled();
+  });
+
+  it('debounces a non-empty draft save', () => {
+    renderHook(() => useAutosaveHarness({ hasContent: true, signature: 'work in progress' }));
+
+    act(() => {
+      vi.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS - 1);
+    });
+    expect(draftStore.saveDraft).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(draftStore.saveDraft).toHaveBeenCalledExactlyOnceWith(
+      'draft-key',
+      expect.objectContaining({ name: 'work in progress' }),
+    );
+  });
+
+  it('discards immediately and prevents unmount from recreating the slot', async () => {
+    const { result, unmount } = renderHook(() =>
+      useAutosaveHarness({ hasContent: true, signature: 'deliberately discarded' }),
+    );
+
+    await act(async () => {
+      await result.current.discard();
+    });
+    unmount();
+
+    expect(draftStore.clearDraft).toHaveBeenCalledExactlyOnceWith('draft-key');
+    expect(draftStore.saveDraft).not.toHaveBeenCalled();
+  });
+
+  it('orders an explicit linked write after an autosave already in flight', async () => {
+    let finishAutosave: (() => void) | undefined;
+    draftStore.saveDraft.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishAutosave = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useAutosaveHarness({ hasContent: true, signature: 'older autosave' }));
+
+    act(() => {
+      vi.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS);
+    });
+    expect(draftStore.saveDraft).toHaveBeenCalledTimes(1);
+
+    const linkedDraft = {
+      ...BASE_DRAFT,
+      name: 'linked save',
+      savedClimbJson: '{"uuid":"row-1"}',
+      savedPayloadSignature: 'baseline',
+    };
+    let pendingLinkedWrite: Promise<void> | undefined;
+    act(() => {
+      pendingLinkedWrite = result.current.persist(linkedDraft);
+    });
+    expect(draftStore.saveDraft).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      finishAutosave?.();
+      await pendingLinkedWrite;
+    });
+
+    expect(draftStore.saveDraft).toHaveBeenCalledTimes(2);
+    expect(draftStore.saveDraft).toHaveBeenLastCalledWith('draft-key', linkedDraft);
+  });
+
+  it('re-persists the latest draft when a deliberate clear fails', async () => {
+    draftStore.clearDraft.mockRejectedValueOnce(new Error('storage unavailable'));
+    const { result, unmount } = renderHook(() =>
+      useAutosaveHarness({ hasContent: true, signature: 'latest working copy' }),
+    );
+
+    await act(async () => {
+      await expect(result.current.discard()).rejects.toThrow('storage unavailable');
+    });
+    unmount();
+
+    expect(draftStore.saveDraft).toHaveBeenCalledWith(
+      'draft-key',
+      expect.objectContaining({ name: 'latest working copy' }),
+    );
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
@@ -40,6 +40,8 @@ const createClimb = vi.hoisted(() => ({
   startingCount: 1,
   finishCount: 1,
   isValid: true,
+  canSave: true,
+  canPublish: true,
   resetHolds: vi.fn(),
   loadHolds: vi.fn(),
   loadFrames: vi.fn(),
@@ -131,6 +133,14 @@ vi.mock('../../../lib/create-climb-draft-store', () => ({
   saveDraft: vi.fn(async () => {}),
   clearDraft: vi.fn(async () => {}),
   createClimbDraftKey: () => 'draft-key',
+  createClimbEditDraftKey: (boardType: string, uuid: string) => `edit:${boardType}:${uuid}`,
+  createClimbForkDraftKey: (boardKey: string) => `fork:${boardKey}`,
+  isDraftStorageAvailable: () => true,
+}));
+// The controller awaits `confirm` from here for "start a new climb"; the real
+// provider pulls in react-native's Alert/Platform, which this file doesn't stub.
+vi.mock('../../../providers/dialog-provider', () => ({
+  useConfirm: () => vi.fn(async () => true),
 }));
 vi.mock('../brush-roles', () => ({
   getPaintRoles: () => ['HAND', 'STARTING', 'FINISH'],

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-angle.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-angle.test.tsx
@@ -38,6 +38,8 @@ const createClimb = vi.hoisted(() => ({
   startingCount: 1,
   finishCount: 1,
   isValid: true,
+  canSave: true,
+  canPublish: true,
   resetHolds: vi.fn(),
   loadHolds: vi.fn(),
   loadFrames: vi.fn(),
@@ -120,6 +122,14 @@ vi.mock('../../../lib/create-climb-draft-store', () => ({
   saveDraft: vi.fn(async () => {}),
   clearDraft: vi.fn(async () => {}),
   createClimbDraftKey: () => 'draft-key',
+  createClimbEditDraftKey: (boardType: string, uuid: string) => `edit:${boardType}:${uuid}`,
+  createClimbForkDraftKey: (boardKey: string) => `fork:${boardKey}`,
+  isDraftStorageAvailable: () => true,
+}));
+// The controller awaits `confirm` from here for "start a new climb"; the real
+// provider pulls in react-native's Alert/Platform, which this file doesn't stub.
+vi.mock('../../../providers/dialog-provider', () => ({
+  useConfirm: () => vi.fn(async () => true),
 }));
 vi.mock('../brush-roles', () => ({
   getPaintRoles: () => ['HAND', 'STARTING', 'FINISH'],

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
@@ -626,4 +626,29 @@ describe('useCreateClimbScreen autosave flush', () => {
     expect(draftStore.clearDraft).toHaveBeenCalledWith('fork:draft-key');
     expect(draftStore.clearDraft).not.toHaveBeenCalledWith('draft-key');
   });
+
+  it('cannot show a stale save failure once the draft toggle moves', async () => {
+    // Review raised the case where `saveFailed` and `publishBlocked` are both
+    // true and the failure hides the publish reason. It is unreachable, and this
+    // pins WHY: `isDraft` is part of the payload signature, so flipping the
+    // toggle moves the signature and retires the recorded failure with it.
+    // Drop `isDraft` from the signature and this goes red.
+    boardActions.saveClimb.mockRejectedValue(new Error('network down'));
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    await waitFor(() => expect(draftStore.loadDraft).toHaveBeenCalled());
+
+    act(() => result.current.setName('Will fail'));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+    expect(result.current.draftStatus).toEqual({
+      text: 'mobile.create.autosave.saveFailed',
+      tone: 'error',
+      announce: true,
+    });
+
+    // Switching to publish is a payload change, so the failure does not linger.
+    act(() => result.current.setIsDraft(false));
+    expect(result.current.draftStatus?.text).not.toBe('mobile.create.autosave.saveFailed');
+  });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
@@ -40,6 +40,8 @@ const boardActions = vi.hoisted(() => ({
   updateClimb: vi.fn(),
 }));
 
+const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
+
 const createClimb = vi.hoisted(() => ({
   litUpHoldsMap: {} as Record<number, { state: string }>,
   frames: [{} as Record<number, { state: string }>],
@@ -125,7 +127,7 @@ vi.mock('../../../providers/bluetooth-provider', () => ({
   useOptionalBluetoothContext: () => null,
 }));
 vi.mock('../../../providers/toast-provider', () => ({
-  useToast: () => ({ showToast: vi.fn() }),
+  useToast: () => ({ showToast: toast.showToast }),
 }));
 vi.mock('../../../providers/dialog-provider', () => ({
   useConfirm: () => vi.fn(async () => true),
@@ -176,6 +178,8 @@ beforeEach(() => {
   createClimb.frames = [{}];
   appState.listeners = [];
   appState.addEventListener.mockClear();
+  toast.showToast.mockClear();
+  draftStore.isDraftStorageAvailable.mockReturnValue(true);
 });
 
 afterEach(() => {
@@ -511,5 +515,79 @@ describe('useCreateClimbScreen autosave flush', () => {
     // (the detach effect nulls savedClimb, so the payload can't carry it).
     expect(savedKeys()).toEqual(['kilter:1:10:1,2:25']);
     expect(draftStore.saveDraft.mock.calls[0]?.[1]?.savedClimbJson).toBeUndefined();
+  });
+
+  it('tells you the draft was kept only when it is nowhere else to be found', async () => {
+    // The one conditional toast on dismiss. Silent when the work is already a row
+    // in Open drafts (the status line said so), and silent for an empty editor —
+    // a notice on every close is noise, and noise on the most-used gesture on
+    // this surface is how confirms get trained away.
+    boardActions.saveClimb.mockResolvedValue({ uuid: 'row-1', createdAt: null, publishedAt: null, isDraft: true });
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    await waitFor(() => expect(draftStore.loadDraft).toHaveBeenCalled());
+
+    // Empty editor: nothing to lose, nothing to say.
+    act(() => result.current.notifyDraftKeptOnDismiss());
+    expect(toast.showToast).not.toHaveBeenCalled();
+
+    // Painted but never saved: this is the case a climber could think is gone.
+    act(() => result.current.setName('Unsaved WIP'));
+    act(() => result.current.notifyDraftKeptOnDismiss());
+    expect(toast.showToast).toHaveBeenCalledTimes(1);
+    expect(toast.showToast.mock.calls[0]?.[0]).toBe('mobile.create.autosave.keptToast');
+
+    // Saved to the account: it is in Open drafts, so stay quiet. (Clear after the
+    // save, whose own "Draft saved" toast is a separate, wanted one.)
+    await act(async () => {
+      await result.current.handleSave();
+    });
+    toast.showToast.mockClear();
+    act(() => result.current.notifyDraftKeptOnDismiss());
+    expect(toast.showToast).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet on dismiss when nothing could be stored in the first place', async () => {
+    // Signed-out expo-web writes nothing at all, so promising a kept draft would
+    // be a lie. The status line already says "Sign in to keep this draft".
+    draftStore.isDraftStorageAvailable.mockReturnValue(false);
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    await waitFor(() => expect(draftStore.loadDraft).toHaveBeenCalled());
+
+    act(() => result.current.setName('Anonymous WIP'));
+    act(() => result.current.notifyDraftKeptOnDismiss());
+
+    expect(toast.showToast).not.toHaveBeenCalled();
+    expect(result.current.draftStatus).toEqual({
+      text: 'mobile.create.autosave.notStored',
+      tone: 'warning',
+      announce: true,
+    });
+  });
+
+  it('blocks publishing a climb with no start or finish, and says why', async () => {
+    // `isValid` is `totalHolds > 0` and SaveClimbInputSchema checks neither end,
+    // so without this a one-hold blob is one tap from being a public climb.
+    createClimb.canPublish = false;
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    await waitFor(() => expect(draftStore.loadDraft).toHaveBeenCalled());
+    act(() => result.current.setName('One blob'));
+
+    // A DRAFT save is unaffected — drafts stay cheap.
+    expect(result.current.publishBlocked).toBe(false);
+
+    act(() => result.current.setIsDraft(false));
+    expect(result.current.publishBlocked).toBe(true);
+    expect(result.current.draftStatus).toEqual({
+      text: 'mobile.create.publish.blocked',
+      tone: 'warning',
+      announce: true,
+    });
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+    expect(boardActions.saveClimb).not.toHaveBeenCalled();
+
+    createClimb.canPublish = true;
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
@@ -619,9 +619,9 @@ describe('useCreateClimbScreen autosave flush', () => {
     await waitFor(() => expect(result.current.name).toBe('Original remix'));
     draftStore.clearDraft.mockClear();
 
-    await act(async () => {
-      await result.current.handleNewClimb();
-    });
+    // A fork carries content and no saved row, so this asks inline first.
+    act(() => result.current.handleNewClimb());
+    act(() => result.current.confirmNewClimb());
 
     expect(draftStore.clearDraft).toHaveBeenCalledWith('fork:draft-key');
     expect(draftStore.clearDraft).not.toHaveBeenCalledWith('draft-key');

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
@@ -33,6 +33,7 @@ const appState = vi.hoisted(() => ({
 // to drive it. Parameterised the way use-create-climb-screen-angle.test.tsx does.
 const graphql = vi.hoisted(() => ({
   climb: undefined as undefined | Record<string, unknown>,
+  climbFailed: false,
 }));
 
 const boardActions = vi.hoisted(() => ({
@@ -118,7 +119,7 @@ vi.mock('../../../providers/auth-provider', () => ({
 }));
 vi.mock('../../../lib/graphql/hooks', () => ({
   useProfile: () => ({ data: { displayName: 'Tester' } }),
-  useClimb: () => ({ data: graphql.climb }),
+  useClimb: () => ({ data: graphql.climb, isError: graphql.climbFailed }),
 }));
 vi.mock('../../../providers/queue-provider', () => ({
   useQueueActions: () => ({ setCurrentClimb: vi.fn() }),
@@ -173,6 +174,7 @@ beforeEach(() => {
   boardActions.saveClimb.mockReset();
   boardActions.updateClimb.mockReset();
   graphql.climb = undefined;
+  graphql.climbFailed = false;
   createClimb.frameCount = 1;
   createClimb.litUpHoldsMap = {};
   createClimb.frames = [{}];
@@ -589,5 +591,39 @@ describe('useCreateClimbScreen autosave flush', () => {
     expect(boardActions.saveClimb).not.toHaveBeenCalled();
 
     createClimb.canPublish = true;
+  });
+
+  it('keeps autosaving in edit mode even when the climb never loads', async () => {
+    // If the query fails permanently — offline, or the row is gone — the seed
+    // effect never runs. Gate autosave on it and the whole edit session silently
+    // stops saving: paint, kill the app, lose everything. That is the exact
+    // failure this change exists to remove, so the gate opens on the failure too.
+    graphql.climb = undefined;
+    graphql.climbFailed = true;
+
+    const { result, unmount } = renderHook(() => useCreateClimbScreen({ board: BOARD, editClimbUuid: 'climb-9' }));
+    act(() => result.current.setName('Painted while offline'));
+    unmount();
+
+    expect(savedKeys()).toEqual(['edit:kilter:climb-9']);
+    expect(draftStore.saveDraft.mock.calls[0]?.[1]?.name).toBe('Painted while offline');
+  });
+
+  it('drops the slot this session owns when starting a new climb, not always the new-climb one', async () => {
+    // Clearing only the board-config key left an abandoned fork slot behind, and
+    // the plain creator's fork fallback would then resurrect it as a ghost draft
+    // on the next open.
+    const { result } = renderHook(() =>
+      useCreateClimbScreen({ board: BOARD, forkFrames: 'p1r12', forkName: 'Original' }),
+    );
+    await waitFor(() => expect(result.current.name).toBe('Original remix'));
+    draftStore.clearDraft.mockClear();
+
+    await act(async () => {
+      await result.current.handleNewClimb();
+    });
+
+    expect(draftStore.clearDraft).toHaveBeenCalledWith('fork:draft-key');
+    expect(draftStore.clearDraft).not.toHaveBeenCalledWith('draft-key');
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
@@ -165,8 +165,10 @@ function savedKeys(): string[] {
 }
 
 beforeEach(() => {
-  draftStore.saveDraft.mockClear();
-  draftStore.clearDraft.mockClear();
+  draftStore.saveDraft.mockReset();
+  draftStore.saveDraft.mockResolvedValue(undefined);
+  draftStore.clearDraft.mockReset();
+  draftStore.clearDraft.mockResolvedValue(undefined);
   draftStore.loadDraft.mockReset();
   draftStore.loadDraft.mockResolvedValue(null);
   draftStore.createClimbDraftKey.mockReset();
@@ -244,11 +246,16 @@ describe('useCreateClimbScreen autosave flush', () => {
     unmount();
 
     expect(savedKeys()).toEqual(['draft-key']);
-    const payload = draftStore.saveDraft.mock.calls[0]?.[1] as { description?: string; savedClimbJson?: string };
+    const payload = draftStore.saveDraft.mock.calls[0]?.[1] as {
+      description?: string;
+      savedClimbJson?: string;
+      savedPayloadSignature?: string;
+    };
     expect(payload.description).toBe('more beta after the save');
     // The link back to the server row, so a relaunch UPDATES it rather than
     // creating a second copy in Open drafts.
     expect(JSON.parse(payload.savedClimbJson ?? '{}')).toMatchObject({ uuid: 'row-1' });
+    expect(payload.savedPayloadSignature).toBeTypeOf('string');
   });
 
   it('never clears the on-device copy on a draft-Save', async () => {
@@ -264,6 +271,49 @@ describe('useCreateClimbScreen autosave flush', () => {
     expect(draftStore.clearDraft).not.toHaveBeenCalled();
     // It is REWRITTEN instead, so the slot stays the working copy.
     expect(savedKeys()).toContain('draft-key');
+  });
+
+  it('cancels an older debounced write before linking the slot to a saved row', async () => {
+    vi.useFakeTimers();
+    boardActions.saveClimb.mockResolvedValue({ uuid: 'row-1', createdAt: null, publishedAt: null, isDraft: true });
+    let finishLinkedWrite: (() => void) | undefined;
+    draftStore.saveDraft.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishLinkedWrite = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => result.current.setName('Link this working copy'));
+    let pendingSave: Promise<void> | undefined;
+    act(() => {
+      pendingSave = result.current.handleSave();
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(draftStore.saveDraft).toHaveBeenCalledTimes(1);
+    expect(draftStore.saveDraft.mock.calls[0]?.[1]).toMatchObject({
+      name: 'Link this working copy',
+      savedClimbJson: expect.stringContaining('row-1'),
+      savedPayloadSignature: expect.any(String),
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(draftStore.saveDraft).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      finishLinkedWrite?.();
+      await pendingSave;
+    });
   });
 
   it('does not clear the slot on a publish when the payload moved mid-flight', async () => {
@@ -349,6 +399,11 @@ describe('useCreateClimbScreen autosave flush', () => {
     await waitFor(() => expect(result.current.name).toBe('Rescued remix'));
     expect(draftStore.loadDraft).toHaveBeenCalledWith('draft-key');
     expect(draftStore.loadDraft).toHaveBeenCalledWith('fork:draft-key');
+    expect(draftStore.saveDraft).toHaveBeenCalledWith('draft-key', expect.objectContaining({ name: 'Rescued remix' }));
+    expect(draftStore.clearDraft).toHaveBeenCalledWith('fork:draft-key');
+    expect(draftStore.saveDraft.mock.invocationCallOrder[0]).toBeLessThan(
+      draftStore.clearDraft.mock.invocationCallOrder[0],
+    );
   });
 
   it('re-attaches the saved row from the restored slot so the next save updates it', async () => {
@@ -379,6 +434,10 @@ describe('useCreateClimbScreen autosave flush', () => {
 
     const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
     await waitFor(() => expect(result.current.name).toBe('Restored'));
+
+    // Legacy linked payloads predate savedPayloadSignature. They must be treated
+    // conservatively as phone-only until the next successful explicit save.
+    expect(result.current.draftStatus?.text).toBe('mobile.create.autosave.unsyncedEdits');
 
     await act(async () => {
       await result.current.handleSave();
@@ -429,8 +488,11 @@ describe('useCreateClimbScreen autosave flush', () => {
     await waitFor(() => expect(result.current.name).toBe('Server name'));
     await waitFor(() => expect(draftStore.loadDraft).toHaveBeenCalledWith('edit:kilter:climb-9'));
 
+    expect(result.current.draftStatus?.text).toBe('mobile.create.autosave.inAccount');
+
     draftStore.saveDraft.mockClear();
     act(() => result.current.setName('Edited name'));
+    expect(result.current.draftStatus?.text).toBe('mobile.create.autosave.unsyncedEdits');
     unmount();
 
     // Editing a draft had NO autosave at all before — and the edit path is the
@@ -593,20 +655,239 @@ describe('useCreateClimbScreen autosave flush', () => {
     createClimb.canPublish = true;
   });
 
-  it('keeps autosaving in edit mode even when the climb never loads', async () => {
+  it('restores the edit slot before autosaving when the climb never loads', async () => {
     // If the query fails permanently — offline, or the row is gone — the seed
     // effect never runs. Gate autosave on it and the whole edit session silently
     // stops saving: paint, kill the app, lose everything. That is the exact
     // failure this change exists to remove, so the gate opens on the failure too.
     graphql.climb = undefined;
     graphql.climbFailed = true;
+    draftStore.loadDraft.mockResolvedValue({
+      holdsJson: '{}',
+      framesJson: '[{}]',
+      name: 'Recovered offline edit',
+      description: 'phone beta',
+      isDraft: true,
+    });
 
     const { result, unmount } = renderHook(() => useCreateClimbScreen({ board: BOARD, editClimbUuid: 'climb-9' }));
+    await waitFor(() => expect(result.current.name).toBe('Recovered offline edit'));
+    expect(draftStore.saveDraft).not.toHaveBeenCalled();
     act(() => result.current.setName('Painted while offline'));
     unmount();
 
     expect(savedKeys()).toEqual(['edit:kilter:climb-9']);
     expect(draftStore.saveDraft.mock.calls[0]?.[1]?.name).toBe('Painted while offline');
+  });
+
+  it('does not overwrite a failure-restored edit when the server retry later succeeds', async () => {
+    graphql.climbFailed = true;
+    draftStore.loadDraft.mockResolvedValue({
+      holdsJson: '{}',
+      framesJson: '[{}]',
+      name: 'Recovered offline edit',
+      description: 'phone beta',
+      isDraft: true,
+    });
+
+    const { result, rerender } = renderHook(() => useCreateClimbScreen({ board: BOARD, editClimbUuid: 'climb-9' }));
+    await waitFor(() => expect(result.current.name).toBe('Recovered offline edit'));
+
+    graphql.climbFailed = false;
+    graphql.climb = {
+      uuid: 'climb-9',
+      name: 'Older server name',
+      description: 'server beta',
+      frames: 'p1r12',
+      is_draft: true,
+      created_at: null,
+      published_at: null,
+    };
+    rerender();
+
+    await waitFor(() => expect(result.current.draftStatus?.text).toBe('mobile.create.autosave.unsyncedEdits'));
+    expect(result.current.name).toBe('Recovered offline edit');
+  });
+
+  it('keeps current-session edits when a found failure restore finishes late', async () => {
+    graphql.climbFailed = true;
+    let finishRestore: ((draft: Record<string, unknown> | null) => void) | undefined;
+    draftStore.loadDraft.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishRestore = resolve;
+        }),
+    );
+
+    const { result, rerender } = renderHook(() => useCreateClimbScreen({ board: BOARD, editClimbUuid: 'climb-9' }));
+    await waitFor(() => expect(finishRestore).toBeDefined());
+    act(() => result.current.setName('Typed while storage was loading'));
+
+    graphql.climbFailed = false;
+    graphql.climb = {
+      uuid: 'climb-9',
+      name: 'Server retry',
+      description: 'server beta',
+      frames: 'p1r12',
+      is_draft: true,
+      created_at: null,
+      published_at: null,
+    };
+    rerender();
+
+    await act(async () => {
+      finishRestore?.({
+        holdsJson: '{}',
+        framesJson: '[{}]',
+        name: 'Phone copy still loading',
+        description: 'phone beta',
+        isDraft: true,
+      });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.name).toBe('Typed while storage was loading'));
+    expect(result.current.draftStatus?.text).toBe('mobile.create.autosave.unsyncedEdits');
+  });
+
+  it('keeps current-session edits when an empty failure restore finishes late', async () => {
+    graphql.climbFailed = true;
+    let finishRestore: ((draft: null) => void) | undefined;
+    draftStore.loadDraft.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishRestore = resolve;
+        }),
+    );
+    const { result, rerender } = renderHook(() => useCreateClimbScreen({ board: BOARD, editClimbUuid: 'climb-9' }));
+    await waitFor(() => expect(finishRestore).toBeDefined());
+    act(() => result.current.setName('Typed before empty result'));
+
+    await act(async () => {
+      finishRestore?.(null);
+      await Promise.resolve();
+    });
+    graphql.climbFailed = false;
+    graphql.climb = {
+      uuid: 'climb-9',
+      name: 'Older server name',
+      description: 'server beta',
+      frames: 'p1r12',
+      is_draft: true,
+      created_at: null,
+      published_at: null,
+    };
+    rerender();
+
+    await waitFor(() => expect(result.current.draftStatus?.text).toBe('mobile.create.autosave.unsyncedEdits'));
+    expect(result.current.name).toBe('Typed before empty result');
+  });
+
+  it('arms autosave for an edit made while the failure restore was pending', async () => {
+    graphql.climbFailed = true;
+    let finishRestore: ((draft: null) => void) | undefined;
+    draftStore.loadDraft.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishRestore = resolve;
+        }),
+    );
+    const { result, unmount } = renderHook(() => useCreateClimbScreen({ board: BOARD, editClimbUuid: 'climb-9' }));
+    await waitFor(() => expect(finishRestore).toBeDefined());
+    act(() => result.current.setName('Typed before restore opened'));
+
+    await act(async () => {
+      finishRestore?.(null);
+      await Promise.resolve();
+    });
+    draftStore.saveDraft.mockClear();
+    unmount();
+
+    expect(draftStore.saveDraft).toHaveBeenCalledWith(
+      'edit:kilter:climb-9',
+      expect.objectContaining({ name: 'Typed before restore opened' }),
+    );
+  });
+
+  it('keeps edits made after an empty offline restore when the server retry succeeds', async () => {
+    graphql.climbFailed = true;
+    draftStore.loadDraft.mockResolvedValue(null);
+    const { result, rerender } = renderHook(() => useCreateClimbScreen({ board: BOARD, editClimbUuid: 'climb-9' }));
+    await waitFor(() => expect(draftStore.loadDraft).toHaveBeenCalledWith('edit:kilter:climb-9'));
+
+    act(() => result.current.setName('Typed while offline'));
+    graphql.climbFailed = false;
+    graphql.climb = {
+      uuid: 'climb-9',
+      name: 'Older server name',
+      description: 'server beta',
+      frames: 'p1r12',
+      is_draft: true,
+      created_at: null,
+      published_at: null,
+    };
+    rerender();
+
+    await waitFor(() => expect(result.current.draftStatus?.text).toBe('mobile.create.autosave.unsyncedEdits'));
+    expect(result.current.name).toBe('Typed while offline');
+  });
+
+  it('leaves edit identity before starting a fresh climb', async () => {
+    graphql.climbFailed = true;
+    draftStore.loadDraft.mockResolvedValue({
+      holdsJson: '{}',
+      framesJson: '[{}]',
+      name: 'Offline edit',
+      description: '',
+      isDraft: true,
+    });
+    const onStartedNewClimb = vi.fn();
+    const { result } = renderHook(() =>
+      useCreateClimbScreen({ board: BOARD, editClimbUuid: 'climb-9', onStartedNewClimb }),
+    );
+    await waitFor(() => expect(result.current.name).toBe('Offline edit'));
+
+    act(() => result.current.handleNewClimb());
+    await act(async () => {
+      result.current.confirmNewClimb();
+      await Promise.resolve();
+    });
+
+    expect(draftStore.clearDraft).toHaveBeenCalledWith('edit:kilter:climb-9');
+    expect(onStartedNewClimb).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not navigate after a pending Start new clear outlives the screen', async () => {
+    graphql.climbFailed = true;
+    draftStore.loadDraft.mockResolvedValue({
+      holdsJson: '{}',
+      framesJson: '[{}]',
+      name: 'Offline edit',
+      description: '',
+      isDraft: true,
+    });
+    let finishClear: (() => void) | undefined;
+    draftStore.clearDraft.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishClear = resolve;
+        }),
+    );
+    const onStartedNewClimb = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useCreateClimbScreen({ board: BOARD, editClimbUuid: 'climb-9', onStartedNewClimb }),
+    );
+    await waitFor(() => expect(result.current.name).toBe('Offline edit'));
+
+    act(() => result.current.handleNewClimb());
+    act(() => result.current.confirmNewClimb());
+    unmount();
+    await act(async () => {
+      finishClear?.();
+      await Promise.resolve();
+    });
+
+    expect(onStartedNewClimb).not.toHaveBeenCalled();
   });
 
   it('drops the slot this session owns when starting a new climb, not always the new-climb one', async () => {
@@ -621,7 +902,10 @@ describe('useCreateClimbScreen autosave flush', () => {
 
     // A fork carries content and no saved row, so this asks inline first.
     act(() => result.current.handleNewClimb());
-    act(() => result.current.confirmNewClimb());
+    await act(async () => {
+      result.current.confirmNewClimb();
+      await Promise.resolve();
+    });
 
     expect(draftStore.clearDraft).toHaveBeenCalledWith('fork:draft-key');
     expect(draftStore.clearDraft).not.toHaveBeenCalledWith('draft-key');

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
@@ -2,18 +2,20 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Exercises the local-autosave effect's persistence guarantees:
-//  1. Flush-on-unmount: a pending debounced edit must be written immediately
-//     when the screen unmounts (drawer close / navigation), instead of being
-//     dropped by the cleanup's clearTimeout.
-//  2. Fork isolation: opening a fork must never overwrite the shared per-board
-//     new-climb autosave slot.
+// The local-autosave durability contract. Autosave used to be switched OFF in
+// three states — editing an existing draft, remixing, and everything after the
+// first Save — and a draft-Save deleted the on-device slot outright, so "Save,
+// then kill the app" lost the lot. Each `it` below pins one half of the fix:
+// which slot a mode writes, and what a save is allowed to do to that slot.
 
 const draftStore = vi.hoisted(() => ({
-  loadDraft: vi.fn(async () => null),
-  saveDraft: vi.fn(async (_key: string, _draft: { name: string }) => {}),
-  clearDraft: vi.fn(async () => {}),
-  createClimbDraftKey: vi.fn(() => 'draft-key'),
+  loadDraft: vi.fn(async (_key: string) => null as null | Record<string, unknown>),
+  saveDraft: vi.fn(async (_key: string, _draft: Record<string, unknown>) => {}),
+  clearDraft: vi.fn(async (_key: string) => {}),
+  createClimbDraftKey: vi.fn((_config: { angle: number }) => 'draft-key'),
+  createClimbEditDraftKey: vi.fn((boardType: string, uuid: string) => `edit:${boardType}:${uuid}`),
+  createClimbForkDraftKey: vi.fn((boardKey: string) => `fork:${boardKey}`),
+  isDraftStorageAvailable: vi.fn(() => true),
 }));
 
 const appState = vi.hoisted(() => ({
@@ -27,17 +29,30 @@ const appState = vi.hoisted(() => ({
   },
 }));
 
+// `useClimb` is what edit mode seeds from, so tests that mount in edit mode have
+// to drive it. Parameterised the way use-create-climb-screen-angle.test.tsx does.
+const graphql = vi.hoisted(() => ({
+  climb: undefined as undefined | Record<string, unknown>,
+}));
+
+const boardActions = vi.hoisted(() => ({
+  saveClimb: vi.fn(),
+  updateClimb: vi.fn(),
+}));
+
 const createClimb = vi.hoisted(() => ({
   litUpHoldsMap: {} as Record<number, { state: string }>,
   frames: [{} as Record<number, { state: string }>],
   frameCount: 1,
   currentFrameIndex: 0,
   setHoldState: vi.fn(),
-  generateFramesString: vi.fn(() => ''),
+  generateFramesString: vi.fn(() => 'p1r12'),
   currentFrameBleString: vi.fn(() => ''),
-  startingCount: 0,
-  finishCount: 0,
-  isValid: false,
+  startingCount: 1,
+  finishCount: 1,
+  isValid: true,
+  canSave: true,
+  canPublish: true,
   resetHolds: vi.fn(),
   loadHolds: vi.fn(),
   loadFrames: vi.fn(),
@@ -59,6 +74,8 @@ vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => k
 vi.mock('@tanstack/react-query', () => ({
   useQueryClient: () => ({ invalidateQueries: vi.fn() }),
 }));
+// The controller reaches for nothing else from react-native — the autosave hook
+// owns the only AppState use, and the announcer lives in the action bar.
 vi.mock('react-native', () => ({
   AppState: { addEventListener: appState.addEventListener },
 }));
@@ -86,8 +103,8 @@ vi.mock('@boardsesh/create-climb-react', () => ({
 vi.mock('@boardsesh/board-react', () => ({
   useBoardActions: () => ({
     isAuthenticated: true,
-    saveClimb: vi.fn(),
-    updateClimb: vi.fn(),
+    saveClimb: boardActions.saveClimb,
+    updateClimb: boardActions.updateClimb,
   }),
   isDuplicateClimbError: () => false,
 }));
@@ -99,7 +116,7 @@ vi.mock('../../../providers/auth-provider', () => ({
 }));
 vi.mock('../../../lib/graphql/hooks', () => ({
   useProfile: () => ({ data: { displayName: 'Tester' } }),
-  useClimb: () => ({ data: undefined }),
+  useClimb: () => ({ data: graphql.climb }),
 }));
 vi.mock('../../../providers/queue-provider', () => ({
   useQueueActions: () => ({ setCurrentClimb: vi.fn() }),
@@ -110,12 +127,20 @@ vi.mock('../../../providers/bluetooth-provider', () => ({
 vi.mock('../../../providers/toast-provider', () => ({
   useToast: () => ({ showToast: vi.fn() }),
 }));
+vi.mock('../../../providers/dialog-provider', () => ({
+  useConfirm: () => vi.fn(async () => true),
+}));
 vi.mock('../../../lib/climb-to-queue-item', () => ({ climbToQueueItem: () => ({}) }));
+// Importing a name this factory doesn't list is an ESM error, not `undefined` —
+// every export the controller pulls from the store has to appear here.
 vi.mock('../../../lib/create-climb-draft-store', () => ({
   loadDraft: draftStore.loadDraft,
   saveDraft: draftStore.saveDraft,
   clearDraft: draftStore.clearDraft,
   createClimbDraftKey: draftStore.createClimbDraftKey,
+  createClimbEditDraftKey: draftStore.createClimbEditDraftKey,
+  createClimbForkDraftKey: draftStore.createClimbForkDraftKey,
+  isDraftStorageAvailable: draftStore.isDraftStorageAvailable,
 }));
 vi.mock('../brush-roles', () => ({
   getPaintRoles: () => ['HAND', 'STARTING', 'FINISH'],
@@ -131,11 +156,24 @@ const BOARD = {
   angle: 40,
 };
 
+/** Keys `saveDraft` was called with, in order. */
+function savedKeys(): string[] {
+  return draftStore.saveDraft.mock.calls.map((call) => call[0] as string);
+}
+
 beforeEach(() => {
   draftStore.saveDraft.mockClear();
   draftStore.clearDraft.mockClear();
-  draftStore.loadDraft.mockClear();
+  draftStore.loadDraft.mockReset();
+  draftStore.loadDraft.mockResolvedValue(null);
+  draftStore.createClimbDraftKey.mockReset();
   draftStore.createClimbDraftKey.mockReturnValue('draft-key');
+  boardActions.saveClimb.mockReset();
+  boardActions.updateClimb.mockReset();
+  graphql.climb = undefined;
+  createClimb.frameCount = 1;
+  createClimb.litUpHoldsMap = {};
+  createClimb.frames = [{}];
   appState.listeners = [];
   appState.addEventListener.mockClear();
 });
@@ -182,24 +220,296 @@ describe('useCreateClimbScreen autosave flush', () => {
     expect(draftStore.saveDraft.mock.calls[0]?.[1]?.name).toBe('Background WIP');
   });
 
-  it('does not write the shared new-climb slot when forking (debounced or flush)', async () => {
+  it('keeps autosaving after the first Save, carrying the saved-climb link', async () => {
+    // The reported bug: Save a draft, keep painting, kill the app — everything
+    // after the Save was gone, AND the Save had deleted the on-device copy too.
+    boardActions.saveClimb.mockResolvedValue({ uuid: 'row-1', createdAt: null, publishedAt: null, isDraft: true });
+    const { result, unmount } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    await waitFor(() => expect(draftStore.loadDraft).toHaveBeenCalled());
+
+    act(() => result.current.setName('QA autosave'));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+    expect(boardActions.saveClimb).toHaveBeenCalledTimes(1);
+
+    draftStore.saveDraft.mockClear();
+    act(() => result.current.setDescription('more beta after the save'));
+    unmount();
+
+    expect(savedKeys()).toEqual(['draft-key']);
+    const payload = draftStore.saveDraft.mock.calls[0]?.[1] as { description?: string; savedClimbJson?: string };
+    expect(payload.description).toBe('more beta after the save');
+    // The link back to the server row, so a relaunch UPDATES it rather than
+    // creating a second copy in Open drafts.
+    expect(JSON.parse(payload.savedClimbJson ?? '{}')).toMatchObject({ uuid: 'row-1' });
+  });
+
+  it('never clears the on-device copy on a draft-Save', async () => {
+    boardActions.saveClimb.mockResolvedValue({ uuid: 'row-1', createdAt: null, publishedAt: null, isDraft: true });
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    await waitFor(() => expect(draftStore.loadDraft).toHaveBeenCalled());
+
+    act(() => result.current.setName('Draft save'));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(draftStore.clearDraft).not.toHaveBeenCalled();
+    // It is REWRITTEN instead, so the slot stays the working copy.
+    expect(savedKeys()).toContain('draft-key');
+  });
+
+  it('does not clear the slot on a publish when the payload moved mid-flight', async () => {
+    // Compare-and-clear: the local write and the server round trip are
+    // independent, so anything typed while the mutation was in flight would
+    // otherwise be deleted by its success.
+    let resolvePublish: ((value: unknown) => void) | undefined;
+    boardActions.saveClimb.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePublish = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    await waitFor(() => expect(draftStore.loadDraft).toHaveBeenCalled());
+
+    act(() => {
+      result.current.setName('Publish me');
+      result.current.setIsDraft(false);
+    });
+
+    let pending: Promise<void> | undefined;
+    act(() => {
+      pending = result.current.handleSave();
+    });
+    // ...and the climber keeps typing while the publish is in the air.
+    act(() => result.current.setDescription('typed during the round trip'));
+    await act(async () => {
+      resolvePublish?.({ uuid: 'row-1', createdAt: null, publishedAt: null, isDraft: false });
+      await pending;
+    });
+
+    expect(draftStore.clearDraft).not.toHaveBeenCalled();
+  });
+
+  it('clears the slot on a publish when nothing changed mid-flight', async () => {
+    boardActions.saveClimb.mockResolvedValue({ uuid: 'row-1', createdAt: null, publishedAt: null, isDraft: false });
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    await waitFor(() => expect(draftStore.loadDraft).toHaveBeenCalled());
+
+    act(() => {
+      result.current.setName('Publish me');
+      result.current.setIsDraft(false);
+    });
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(draftStore.clearDraft).toHaveBeenCalledWith('draft-key');
+  });
+
+  it('writes a fork to its own slot and never to the shared new-climb key', async () => {
     const { result, unmount } = renderHook(() =>
       useCreateClimbScreen({ board: BOARD, forkFrames: 'p1r12', forkName: 'Original' }),
     );
-    // A fork seeds its own holds/name; let any restore settle.
     await waitFor(() => expect(result.current.name).toBe('Original remix'));
 
     vi.useFakeTimers();
     act(() => result.current.setDescription('forked beta'));
-    // Run past the debounce window — a non-fork WIP would persist here.
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1000);
     });
-    // And exercise the unmount-flush path too.
     unmount();
 
-    // Forks seed from their source and skip restore, so they must never persist
-    // into the per-board new-climb autosave key (it would clobber a real WIP).
+    // A fork used to be locked out of autosave entirely, because writing the
+    // board-config key would clobber a real new-climb WIP. Identity is in the key
+    // now, so it saves — into `fork:`, never `draft-key`.
+    expect(savedKeys()).toContain('fork:draft-key');
+    expect(savedKeys().every((key) => key === 'fork:draft-key')).toBe(true);
+  });
+
+  it('restores a fork session from the plain creator when the new-climb slot is empty', async () => {
+    // A killed remix can only be reached from a plain creator mount — the modal
+    // route that carried `forkFrames` is gone by then.
+    draftStore.loadDraft.mockImplementation(async (key: string) =>
+      key === 'fork:draft-key'
+        ? { holdsJson: '{}', framesJson: '[{}]', name: 'Rescued remix', description: '', isDraft: true }
+        : null,
+    );
+
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+
+    await waitFor(() => expect(result.current.name).toBe('Rescued remix'));
+    expect(draftStore.loadDraft).toHaveBeenCalledWith('draft-key');
+    expect(draftStore.loadDraft).toHaveBeenCalledWith('fork:draft-key');
+  });
+
+  it('re-attaches the saved row from the restored slot so the next save updates it', async () => {
+    draftStore.loadDraft.mockImplementation(async (key: string) =>
+      key === 'draft-key'
+        ? {
+            holdsJson: '{}',
+            framesJson: '[{}]',
+            name: 'Restored',
+            description: '',
+            isDraft: true,
+            savedClimbJson: JSON.stringify({
+              uuid: 'row-1',
+              boardType: 'kilter',
+              createdAt: null,
+              publishedAt: null,
+              isDraft: true,
+            }),
+          }
+        : null,
+    );
+    boardActions.updateClimb.mockResolvedValue({
+      uuid: 'row-1',
+      createdAt: null,
+      publishedAt: null,
+      isDraft: true,
+    });
+
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    await waitFor(() => expect(result.current.name).toBe('Restored'));
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    // Without the re-attach this would take the create branch and leave a
+    // duplicate row in Open drafts.
+    expect(boardActions.updateClimb).toHaveBeenCalledTimes(1);
+    expect(boardActions.saveClimb).not.toHaveBeenCalled();
+  });
+
+  it('ignores a corrupt saved-climb link but still restores the paint', async () => {
+    draftStore.loadDraft.mockImplementation(async (key: string) =>
+      key === 'draft-key'
+        ? {
+            holdsJson: '{}',
+            framesJson: '[{}]',
+            name: 'Corrupt link',
+            description: '',
+            isDraft: true,
+            savedClimbJson: '{not json',
+          }
+        : null,
+    );
+    boardActions.saveClimb.mockResolvedValue({ uuid: 'new', createdAt: null, publishedAt: null, isDraft: true });
+
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    await waitFor(() => expect(result.current.name).toBe('Corrupt link'));
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+    expect(boardActions.saveClimb).toHaveBeenCalledTimes(1);
+  });
+
+  it('autosaves an edit session into its own identity-keyed slot', async () => {
+    graphql.climb = {
+      uuid: 'climb-9',
+      name: 'Server name',
+      description: '',
+      frames: 'p1r12',
+      is_draft: true,
+      created_at: null,
+      published_at: null,
+    };
+
+    const { result, unmount } = renderHook(() => useCreateClimbScreen({ board: BOARD, editClimbUuid: 'climb-9' }));
+    await waitFor(() => expect(result.current.name).toBe('Server name'));
+    await waitFor(() => expect(draftStore.loadDraft).toHaveBeenCalledWith('edit:kilter:climb-9'));
+
+    draftStore.saveDraft.mockClear();
+    act(() => result.current.setName('Edited name'));
+    unmount();
+
+    // Editing a draft had NO autosave at all before — and the edit path is the
+    // common one, since tapping a row in Open drafts lands here.
+    expect(savedKeys()).toEqual(['edit:kilter:climb-9']);
+    expect(draftStore.saveDraft.mock.calls[0]?.[1]?.name).toBe('Edited name');
+  });
+
+  it('applies the stored edit slot over the server copy, and writes nothing before it lands', async () => {
+    // THE ordering hazard. `restoredRef` must open only after the `edit:` slot has
+    // been applied: any earlier and the next debounce tick writes the freshly
+    // fetched SERVER copy into the slot, destroying the unflushed edits this
+    // restore exists to recover — silently. Reverse the ordering in
+    // use-create-climb-screen.ts and both assertions below fail.
+    graphql.climb = {
+      uuid: 'climb-9',
+      name: 'Server name',
+      description: 'server beta',
+      frames: 'p1r12',
+      is_draft: true,
+      created_at: null,
+      published_at: null,
+    };
+    let releaseSlot: ((value: Record<string, unknown> | null) => void) | undefined;
+    draftStore.loadDraft.mockImplementation(
+      (key: string) =>
+        new Promise((resolve) => {
+          if (key !== 'edit:kilter:climb-9') {
+            resolve(null);
+            return;
+          }
+          releaseSlot = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD, editClimbUuid: 'climb-9' }));
+    await waitFor(() => expect(result.current.name).toBe('Server name'));
+    await waitFor(() => expect(releaseSlot).toBeDefined());
+
+    // While the slot is still in flight nothing may be persisted — the only
+    // payload available right now is the server copy.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+    });
     expect(draftStore.saveDraft).not.toHaveBeenCalled();
+
+    await act(async () => {
+      releaseSlot?.({
+        holdsJson: '{}',
+        framesJson: '[{}]',
+        name: 'Unflushed local name',
+        description: 'local beta',
+        isDraft: true,
+      });
+      await Promise.resolve();
+    });
+
+    // The local slot wins over the server copy...
+    await waitFor(() => expect(result.current.name).toBe('Unflushed local name'));
+    // ...and no write ever carried the server copy into the slot.
+    expect(draftStore.saveDraft.mock.calls.every((call) => call[1]?.name !== 'Server name')).toBe(true);
+  });
+
+  it('moves to the new angle slot without the saved-row link, leaving the old angle alone', async () => {
+    boardActions.saveClimb.mockResolvedValue({ uuid: 'row-1', createdAt: null, publishedAt: null, isDraft: true });
+    draftStore.createClimbDraftKey.mockImplementation((config: { angle: number }) => `kilter:1:10:1,2:${config.angle}`);
+
+    const { result, rerender, unmount } = renderHook(
+      (props: { angle: number }) => useCreateClimbScreen({ board: { ...BOARD, angle: props.angle } }),
+      { initialProps: { angle: 40 } },
+    );
+    await waitFor(() => expect(draftStore.loadDraft).toHaveBeenCalled());
+    act(() => result.current.setName('Angled'));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    draftStore.saveDraft.mockClear();
+    rerender({ angle: 25 });
+    act(() => result.current.setDescription('at the new angle'));
+    unmount();
+
+    // Each angle owns its own slot, and the row link is dropped with the angle
+    // (the detach effect nulls savedClimb, so the payload can't carry it).
+    expect(savedKeys()).toEqual(['kilter:1:10:1,2:25']);
+    expect(draftStore.saveDraft.mock.calls[0]?.[1]?.savedClimbJson).toBeUndefined();
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
@@ -168,7 +168,10 @@ describe('useCreateClimbScreen handleNewClimb', () => {
     // Start fresh. Holds are painted and nothing is saved, so this raises the
     // inline confirm first; accept it.
     act(() => result.current.handleNewClimb());
-    act(() => result.current.confirmNewClimb());
+    await act(async () => {
+      result.current.confirmNewClimb();
+      await Promise.resolve();
+    });
 
     // A brand-new climb must start without any rule markers.
     expect(result.current.noMatch).toBe(false);
@@ -245,13 +248,47 @@ describe('useCreateClimbScreen handleNewClimb', () => {
     });
     draftStore.clearDraft.mockClear();
 
-    act(() => result.current.handleNewClimb());
+    await act(async () => {
+      result.current.handleNewClimb();
+      await Promise.resolve();
+    });
 
     // Nothing is at risk: the row is in Open drafts. Only the new-climb slot goes,
     // never an `edit:` slot.
     expect(result.current.pendingNewClimb).toBe(false);
     expect(draftStore.clearDraft).toHaveBeenCalledWith('draft-key');
     expect(result.current.name).toBe('');
+  });
+
+  it('asks before dropping edits made after the last draft save', async () => {
+    board.saveClimb.mockResolvedValue({ uuid: 'row-1', createdAt: null, publishedAt: null, isDraft: true });
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    act(() => result.current.setName('Saved first'));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    act(() => result.current.setDescription('phone-only beta'));
+    act(() => result.current.handleNewClimb());
+
+    expect(result.current.pendingNewClimb).toBe(true);
+    expect(result.current.name).toBe('Saved first');
+    expect(result.current.description).toBe('phone-only beta');
+  });
+
+  it('dismisses a pending Start new confirmation after the climb is saved', async () => {
+    board.saveClimb.mockResolvedValue({ uuid: 'row-1', createdAt: null, publishedAt: null, isDraft: true });
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    act(() => result.current.setName('Save while asking'));
+    act(() => result.current.handleNewClimb());
+    expect(result.current.pendingNewClimb).toBe(true);
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(result.current.pendingNewClimb).toBe(false);
+    expect(result.current.name).toBe('Save while asking');
   });
 
   it('asks inline before dropping unsaved work, and cancelling changes nothing', async () => {
@@ -283,11 +320,71 @@ describe('useCreateClimbScreen handleNewClimb', () => {
     createClimb.resetHolds.mockClear();
 
     act(() => result.current.handleNewClimb());
-    act(() => result.current.confirmNewClimb());
+    await act(async () => {
+      result.current.confirmNewClimb();
+      await Promise.resolve();
+    });
 
     expect(result.current.pendingNewClimb).toBe(false);
     expect(result.current.name).toBe('');
     expect(createClimb.resetHolds).toHaveBeenCalledTimes(1);
     expect(draftStore.clearDraft).toHaveBeenCalledWith('draft-key');
+  });
+
+  it('waits for the slot to be retired before resetting the editor', async () => {
+    let finishClear: (() => void) | undefined;
+    draftStore.clearDraft.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishClear = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    act(() => result.current.setName('Keep until durable clear'));
+
+    act(() => result.current.handleNewClimb());
+    act(() => result.current.confirmNewClimb());
+
+    expect(result.current.name).toBe('Keep until durable clear');
+    expect(createClimb.resetHolds).not.toHaveBeenCalled();
+
+    await act(async () => {
+      finishClear?.();
+      await Promise.resolve();
+    });
+
+    expect(result.current.name).toBe('');
+    expect(createClimb.resetHolds).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores Start new confirmation while Save is in flight', async () => {
+    let finishSave: ((saved: { uuid: string; createdAt: null; publishedAt: null; isDraft: true }) => void) | undefined;
+    board.saveClimb.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishSave = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    act(() => result.current.setName('Saving now'));
+    act(() => result.current.handleNewClimb());
+    expect(result.current.pendingNewClimb).toBe(true);
+
+    let pendingSave: Promise<void> | undefined;
+    act(() => {
+      pendingSave = result.current.handleSave();
+    });
+    act(() => result.current.confirmNewClimb());
+
+    expect(draftStore.clearDraft).not.toHaveBeenCalled();
+    expect(result.current.name).toBe('Saving now');
+
+    await act(async () => {
+      finishSave?.({ uuid: 'row-1', createdAt: null, publishedAt: null, isDraft: true });
+      await pendingSave;
+    });
+
+    expect(result.current.pendingNewClimb).toBe(false);
+    expect(result.current.name).toBe('Saving now');
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
@@ -199,8 +199,10 @@ describe('useCreateClimbScreen handleNewClimb', () => {
     await waitFor(() => expect(result.current.noKickboard).toBe(true));
     expect(result.current.campus).toBe(true);
 
+    act(() => result.current.handleNewClimb());
     await act(async () => {
-      await result.current.handleNewClimb();
+      result.current.confirmNewClimb();
+      await Promise.resolve();
     });
 
     expect(result.current.noKickboard).toBe(false);

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
@@ -15,6 +15,12 @@ const board = vi.hoisted(() => ({
 const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
 const queue = vi.hoisted(() => ({ setCurrentClimb: vi.fn() }));
 const router = vi.hoisted(() => ({ push: vi.fn() }));
+const dialog = vi.hoisted(() => ({ confirm: vi.fn(async () => true) }));
+const draftStore = vi.hoisted(() => ({
+  loadDraft: vi.fn(async () => null),
+  saveDraft: vi.fn(async (_key: string, _draft: Record<string, unknown>) => {}),
+  clearDraft: vi.fn(async (_key: string) => {}),
+}));
 
 const createClimb = vi.hoisted(() => ({
   litUpHoldsMap: { 1: { state: 'STARTING' }, 2: { state: 'HAND' }, 3: { state: 'FINISH' } },
@@ -27,6 +33,8 @@ const createClimb = vi.hoisted(() => ({
   startingCount: 1,
   finishCount: 1,
   isValid: true,
+  canSave: true,
+  canPublish: true,
   resetHolds: vi.fn(),
   loadHolds: vi.fn(),
   loadFrames: vi.fn(),
@@ -115,10 +123,16 @@ vi.mock('../../../providers/toast-provider', () => ({
 }));
 vi.mock('../../../lib/climb-to-queue-item', () => ({ climbToQueueItem: () => ({}) }));
 vi.mock('../../../lib/create-climb-draft-store', () => ({
-  loadDraft: vi.fn(async () => null),
-  saveDraft: vi.fn(async () => {}),
-  clearDraft: vi.fn(async () => {}),
+  loadDraft: draftStore.loadDraft,
+  saveDraft: draftStore.saveDraft,
+  clearDraft: draftStore.clearDraft,
   createClimbDraftKey: () => 'draft-key',
+  createClimbEditDraftKey: (boardType: string, uuid: string) => `edit:${boardType}:${uuid}`,
+  createClimbForkDraftKey: (boardKey: string) => `fork:${boardKey}`,
+  isDraftStorageAvailable: () => true,
+}));
+vi.mock('../../../providers/dialog-provider', () => ({
+  useConfirm: () => dialog.confirm,
 }));
 vi.mock('../brush-roles', () => ({
   getPaintRoles: () => ['HAND', 'STARTING', 'FINISH'],
@@ -139,9 +153,14 @@ beforeEach(() => {
   board.updateClimb.mockReset();
   toast.showToast.mockClear();
   queue.setCurrentClimb.mockClear();
+  dialog.confirm.mockReset();
+  dialog.confirm.mockResolvedValue(true);
+  draftStore.clearDraft.mockClear();
+  draftStore.saveDraft.mockClear();
+  createClimb.resetHolds.mockClear();
 });
 
-describe('useCreateClimbScreen handleClear', () => {
+describe('useCreateClimbScreen handleNewClimb', () => {
   it('resets the No-match toggle so a brand-new climb is not silently tagged no-match', async () => {
     board.saveClimb.mockResolvedValue({ uuid: 'fresh', createdAt: null, publishedAt: null, isDraft: true });
 
@@ -152,7 +171,9 @@ describe('useCreateClimbScreen handleClear', () => {
     await waitFor(() => expect(result.current.noMatch).toBe(true));
 
     // Start fresh.
-    act(() => result.current.handleClear());
+    await act(async () => {
+      await result.current.handleNewClimb();
+    });
 
     // A brand-new climb must start without any rule markers.
     expect(result.current.noMatch).toBe(false);
@@ -180,7 +201,9 @@ describe('useCreateClimbScreen handleClear', () => {
     await waitFor(() => expect(result.current.noKickboard).toBe(true));
     expect(result.current.campus).toBe(true);
 
-    act(() => result.current.handleClear());
+    await act(async () => {
+      await result.current.handleNewClimb();
+    });
 
     expect(result.current.noKickboard).toBe(false);
     expect(result.current.campus).toBe(false);
@@ -192,5 +215,66 @@ describe('useCreateClimbScreen handleClear', () => {
 
     expect(board.saveClimb).toHaveBeenCalledTimes(1);
     expect(board.saveClimb.mock.calls[0]?.[0]?.characteristics).toBeNull();
+  });
+
+  it('clears only the holds when Clear holds is tapped', async () => {
+    // The trash button used to also wipe the name, the description, the saved-row
+    // link and the on-device slot — none of which undo brings back — behind a
+    // label that said "Clear holds". Now the label is the whole behaviour.
+    board.saveClimb.mockResolvedValue({ uuid: 'row-1', createdAt: null, publishedAt: null, isDraft: true });
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+
+    act(() => {
+      result.current.setName('Keep my name');
+      result.current.setDescription('keep my beta');
+    });
+    await act(async () => {
+      await result.current.handleSave();
+    });
+    draftStore.clearDraft.mockClear();
+
+    act(() => result.current.handleClearHolds());
+
+    expect(createClimb.resetHolds).toHaveBeenCalledTimes(1);
+    expect(result.current.name).toBe('Keep my name');
+    expect(result.current.description).toBe('keep my beta');
+    expect(draftStore.clearDraft).not.toHaveBeenCalled();
+  });
+
+  it('starts a new climb without prompting once the work is in your drafts', async () => {
+    board.saveClimb.mockResolvedValue({ uuid: 'row-1', createdAt: null, publishedAt: null, isDraft: true });
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    act(() => result.current.setName('Already saved'));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+    draftStore.clearDraft.mockClear();
+
+    await act(async () => {
+      await result.current.handleNewClimb();
+    });
+
+    // Nothing is at risk: the row is in Open drafts. Only the new-climb slot goes,
+    // never an `edit:` slot.
+    expect(dialog.confirm).not.toHaveBeenCalled();
+    expect(draftStore.clearDraft).toHaveBeenCalledWith('draft-key');
+    expect(result.current.name).toBe('');
+  });
+
+  it('prompts before dropping unsaved work, and a declined prompt changes nothing', async () => {
+    dialog.confirm.mockResolvedValue(false);
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    act(() => result.current.setName('Never saved'));
+    draftStore.clearDraft.mockClear();
+    createClimb.resetHolds.mockClear();
+
+    await act(async () => {
+      await result.current.handleNewClimb();
+    });
+
+    expect(dialog.confirm).toHaveBeenCalledTimes(1);
+    expect(result.current.name).toBe('Never saved');
+    expect(createClimb.resetHolds).not.toHaveBeenCalled();
+    expect(draftStore.clearDraft).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
@@ -15,7 +15,6 @@ const board = vi.hoisted(() => ({
 const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
 const queue = vi.hoisted(() => ({ setCurrentClimb: vi.fn() }));
 const router = vi.hoisted(() => ({ push: vi.fn() }));
-const dialog = vi.hoisted(() => ({ confirm: vi.fn(async () => true) }));
 const draftStore = vi.hoisted(() => ({
   loadDraft: vi.fn(async () => null),
   saveDraft: vi.fn(async (_key: string, _draft: Record<string, unknown>) => {}),
@@ -131,9 +130,7 @@ vi.mock('../../../lib/create-climb-draft-store', () => ({
   createClimbForkDraftKey: (boardKey: string) => `fork:${boardKey}`,
   isDraftStorageAvailable: () => true,
 }));
-vi.mock('../../../providers/dialog-provider', () => ({
-  useConfirm: () => dialog.confirm,
-}));
+
 vi.mock('../brush-roles', () => ({
   getPaintRoles: () => ['HAND', 'STARTING', 'FINISH'],
 }));
@@ -153,8 +150,6 @@ beforeEach(() => {
   board.updateClimb.mockReset();
   toast.showToast.mockClear();
   queue.setCurrentClimb.mockClear();
-  dialog.confirm.mockReset();
-  dialog.confirm.mockResolvedValue(true);
   draftStore.clearDraft.mockClear();
   draftStore.saveDraft.mockClear();
   createClimb.resetHolds.mockClear();
@@ -170,10 +165,10 @@ describe('useCreateClimbScreen handleNewClimb', () => {
     act(() => result.current.setNoMatch(true));
     await waitFor(() => expect(result.current.noMatch).toBe(true));
 
-    // Start fresh.
-    await act(async () => {
-      await result.current.handleNewClimb();
-    });
+    // Start fresh. Holds are painted and nothing is saved, so this raises the
+    // inline confirm first; accept it.
+    act(() => result.current.handleNewClimb());
+    act(() => result.current.confirmNewClimb());
 
     // A brand-new climb must start without any rule markers.
     expect(result.current.noMatch).toBe(false);
@@ -250,31 +245,49 @@ describe('useCreateClimbScreen handleNewClimb', () => {
     });
     draftStore.clearDraft.mockClear();
 
-    await act(async () => {
-      await result.current.handleNewClimb();
-    });
+    act(() => result.current.handleNewClimb());
 
     // Nothing is at risk: the row is in Open drafts. Only the new-climb slot goes,
     // never an `edit:` slot.
-    expect(dialog.confirm).not.toHaveBeenCalled();
+    expect(result.current.pendingNewClimb).toBe(false);
     expect(draftStore.clearDraft).toHaveBeenCalledWith('draft-key');
     expect(result.current.name).toBe('');
   });
 
-  it('prompts before dropping unsaved work, and a declined prompt changes nothing', async () => {
-    dialog.confirm.mockResolvedValue(false);
+  it('asks inline before dropping unsaved work, and cancelling changes nothing', async () => {
+    // The ask is sheet CONTENT, not a dialog. `useConfirm` renders a Paper Dialog
+    // in a JS Portal on Android, which paints behind this native sheet — its
+    // promise never resolves, so this button did nothing at all.
     const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
     act(() => result.current.setName('Never saved'));
     draftStore.clearDraft.mockClear();
     createClimb.resetHolds.mockClear();
 
-    await act(async () => {
-      await result.current.handleNewClimb();
-    });
+    act(() => result.current.handleNewClimb());
 
-    expect(dialog.confirm).toHaveBeenCalledTimes(1);
+    expect(result.current.pendingNewClimb).toBe(true);
+    expect(result.current.name).toBe('Never saved');
+    expect(createClimb.resetHolds).not.toHaveBeenCalled();
+
+    act(() => result.current.cancelNewClimb());
+    expect(result.current.pendingNewClimb).toBe(false);
     expect(result.current.name).toBe('Never saved');
     expect(createClimb.resetHolds).not.toHaveBeenCalled();
     expect(draftStore.clearDraft).not.toHaveBeenCalled();
+  });
+
+  it('resets once the inline confirm is accepted', async () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+    act(() => result.current.setName('Never saved'));
+    draftStore.clearDraft.mockClear();
+    createClimb.resetHolds.mockClear();
+
+    act(() => result.current.handleNewClimb());
+    act(() => result.current.confirmNewClimb());
+
+    expect(result.current.pendingNewClimb).toBe(false);
+    expect(result.current.name).toBe('');
+    expect(createClimb.resetHolds).toHaveBeenCalledTimes(1);
+    expect(draftStore.clearDraft).toHaveBeenCalledWith('draft-key');
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-paint.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-paint.test.tsx
@@ -101,6 +101,9 @@ vi.mock('../../../lib/create-climb-draft-store', () => ({
   saveDraft: vi.fn(async () => {}),
   clearDraft: vi.fn(async () => {}),
   createClimbDraftKey: () => 'draft-key',
+  createClimbEditDraftKey: (boardType: string, uuid: string) => `edit:${boardType}:${uuid}`,
+  createClimbForkDraftKey: (boardKey: string) => `fork:${boardKey}`,
+  isDraftStorageAvailable: () => true,
 }));
 
 import { useCreateClimbScreen } from '../use-create-climb-screen';

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
@@ -39,6 +39,8 @@ const createClimb = vi.hoisted(() => ({
   startingCount: 1,
   finishCount: 1,
   isValid: true,
+  canSave: true,
+  canPublish: true,
   resetHolds: vi.fn(),
   loadHolds: vi.fn(),
   loadFrames: vi.fn(),
@@ -117,6 +119,14 @@ vi.mock('../../../lib/create-climb-draft-store', () => ({
   saveDraft: vi.fn(async () => {}),
   clearDraft: vi.fn(async () => {}),
   createClimbDraftKey: () => 'draft-key',
+  createClimbEditDraftKey: (boardType: string, uuid: string) => `edit:${boardType}:${uuid}`,
+  createClimbForkDraftKey: (boardKey: string) => `fork:${boardKey}`,
+  isDraftStorageAvailable: () => true,
+}));
+// The controller awaits `confirm` from here for "start a new climb"; the real
+// provider pulls in react-native's Alert/Platform, which this file doesn't stub.
+vi.mock('../../../providers/dialog-provider', () => ({
+  useConfirm: () => vi.fn(async () => true),
 }));
 vi.mock('../brush-roles', () => ({
   getPaintRoles: () => ['HAND', 'STARTING', 'FINISH'],

--- a/packages/mobile/src/components/create-climb/__tests__/use-rate-limited-announcer.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-rate-limited-announcer.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The rate limit is load-bearing, not a nicety. The state behind the draft status
+// line flips on a 500ms autosave debounce, so an unthrottled voice would talk over
+// every keystroke and every hold tap — which is why the line's live region is
+// explicitly `none` and this is the only thing allowed to speak.
+
+const announceSpy = vi.hoisted(() => vi.fn());
+vi.mock('react-native', () => ({
+  AccessibilityInfo: { announceForAccessibility: announceSpy },
+}));
+
+import { useRateLimitedAnnouncer, ANNOUNCE_MIN_INTERVAL_MS } from '../use-rate-limited-announcer';
+
+beforeEach(() => {
+  announceSpy.mockClear();
+  vi.useFakeTimers();
+  // Start well past the epoch so the first call isn't accidentally inside the window.
+  vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useRateLimitedAnnouncer', () => {
+  it('speaks the first transition immediately', () => {
+    const { result } = renderHook(() => useRateLimitedAnnouncer());
+    act(() => result.current('Draft saved to your account'));
+    expect(announceSpy).toHaveBeenCalledExactlyOnceWith('Draft saved to your account');
+  });
+
+  it('swallows a different message inside the window', () => {
+    const { result } = renderHook(() => useRateLimitedAnnouncer());
+    act(() => result.current('first'));
+    act(() => vi.advanceTimersByTime(ANNOUNCE_MIN_INTERVAL_MS - 1));
+    act(() => result.current('second'));
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('speaks again once the window has passed', () => {
+    const { result } = renderHook(() => useRateLimitedAnnouncer());
+    act(() => result.current('first'));
+    act(() => vi.advanceTimersByTime(ANNOUNCE_MIN_INTERVAL_MS));
+    act(() => result.current('second'));
+    expect(announceSpy).toHaveBeenCalledTimes(2);
+    expect(announceSpy).toHaveBeenLastCalledWith('second');
+  });
+
+  it('never repeats the sentence it last spoke, however long you wait', () => {
+    // A status line can return to a state it already announced; hearing the same
+    // words again carries no new information.
+    const { result } = renderHook(() => useRateLimitedAnnouncer());
+    act(() => result.current('same words'));
+    act(() => vi.advanceTimersByTime(ANNOUNCE_MIN_INTERVAL_MS * 5));
+    act(() => result.current('same words'));
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores an empty message', () => {
+    const { result } = renderHook(() => useRateLimitedAnnouncer());
+    act(() => result.current(''));
+    expect(announceSpy).not.toHaveBeenCalled();
+  });
+
+  it('hands back a stable callback so a memoized consumer does not re-render', () => {
+    const { result, rerender } = renderHook(() => useRateLimitedAnnouncer());
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/use-rate-limited-announcer.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-rate-limited-announcer.test.tsx
@@ -32,18 +32,41 @@ describe('useRateLimitedAnnouncer', () => {
     expect(announceSpy).toHaveBeenCalledExactlyOnceWith('Draft saved to your account');
   });
 
-  it('swallows a different message inside the window', () => {
+  it('delivers a suppressed message at the trailing edge of the window', () => {
     const { result } = renderHook(() => useRateLimitedAnnouncer());
     act(() => result.current('first'));
-    act(() => vi.advanceTimersByTime(ANNOUNCE_MIN_INTERVAL_MS - 1));
+    act(() => {
+      vi.advanceTimersByTime(ANNOUNCE_MIN_INTERVAL_MS - 1);
+    });
     act(() => result.current('second'));
     expect(announceSpy).toHaveBeenCalledTimes(1);
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(announceSpy).toHaveBeenCalledTimes(2);
+    expect(announceSpy).toHaveBeenLastCalledWith('second');
+  });
+
+  it('keeps only the latest distinct message during the window', () => {
+    const { result } = renderHook(() => useRateLimitedAnnouncer());
+    act(() => result.current('first'));
+    act(() => result.current('superseded'));
+    act(() => result.current('latest'));
+
+    act(() => {
+      vi.advanceTimersByTime(ANNOUNCE_MIN_INTERVAL_MS);
+    });
+
+    expect(announceSpy).toHaveBeenCalledTimes(2);
+    expect(announceSpy).toHaveBeenLastCalledWith('latest');
   });
 
   it('speaks again once the window has passed', () => {
     const { result } = renderHook(() => useRateLimitedAnnouncer());
     act(() => result.current('first'));
-    act(() => vi.advanceTimersByTime(ANNOUNCE_MIN_INTERVAL_MS));
+    act(() => {
+      vi.advanceTimersByTime(ANNOUNCE_MIN_INTERVAL_MS);
+    });
     act(() => result.current('second'));
     expect(announceSpy).toHaveBeenCalledTimes(2);
     expect(announceSpy).toHaveBeenLastCalledWith('second');
@@ -54,15 +77,48 @@ describe('useRateLimitedAnnouncer', () => {
     // words again carries no new information.
     const { result } = renderHook(() => useRateLimitedAnnouncer());
     act(() => result.current('same words'));
-    act(() => vi.advanceTimersByTime(ANNOUNCE_MIN_INTERVAL_MS * 5));
+    act(() => {
+      vi.advanceTimersByTime(ANNOUNCE_MIN_INTERVAL_MS * 5);
+    });
     act(() => result.current('same words'));
     expect(announceSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('ignores an empty message', () => {
+  it('cancels a queued status when the latest status matches the last announcement', () => {
     const { result } = renderHook(() => useRateLimitedAnnouncer());
+    act(() => result.current('saved'));
+    act(() => result.current('saving'));
+    act(() => result.current('saved'));
+
+    act(() => {
+      vi.advanceTimersByTime(ANNOUNCE_MIN_INTERVAL_MS);
+    });
+
+    expect(announceSpy).toHaveBeenCalledExactlyOnceWith('saved');
+  });
+
+  it('cancels its trailing announcement on unmount', () => {
+    const { result, unmount } = renderHook(() => useRateLimitedAnnouncer());
+    act(() => result.current('first'));
+    act(() => result.current('queued'));
+
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(ANNOUNCE_MIN_INTERVAL_MS);
+    });
+
+    expect(announceSpy).toHaveBeenCalledExactlyOnceWith('first');
+  });
+
+  it('uses an empty message to cancel a queued stale status', () => {
+    const { result } = renderHook(() => useRateLimitedAnnouncer());
+    act(() => result.current('first'));
+    act(() => result.current('queued warning'));
     act(() => result.current(''));
-    expect(announceSpy).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(ANNOUNCE_MIN_INTERVAL_MS);
+    });
+    expect(announceSpy).toHaveBeenCalledExactlyOnceWith('first');
   });
 
   it('hands back a stable callback so a memoized consumer does not re-render', () => {

--- a/packages/mobile/src/components/create-climb/draft-status-view.ts
+++ b/packages/mobile/src/components/create-climb/draft-status-view.ts
@@ -1,0 +1,76 @@
+/** Minimal translate signature so this stays a pure, renderer-free util. */
+export type TranslateDraftStatus = (key: string) => string;
+
+/**
+ * How loudly the line reads. `muted` is every ordinary state — a successful save
+ * gets no green and no tick, because the Save button's own 3s `justSaved` state
+ * already carries the momentary confirmation and a PERSISTENT semantic colour
+ * reads as an alert that never clears.
+ */
+export type DraftStatusTone = 'muted' | 'warning' | 'error';
+
+export type DraftStatusView = {
+  text: string;
+  tone: DraftStatusTone;
+  /**
+   * Whether entering this state is worth speaking to assistive tech. True only
+   * for the states that change the ANSWER to "is my work safe?" — never for the
+   * on-device autosave tick, which fires on every keystroke and every hold tap.
+   * The row's live region is `none`; this drives a rate-limited announcement.
+   */
+  announce: boolean;
+};
+
+export type DraftStatusState = {
+  /** Anything painted or typed. Nothing to say about an empty editor. */
+  hasContent: boolean;
+  /** False on signed-out expo-web, where nothing is written at all. */
+  localPersistenceAvailable: boolean;
+  hasSavedClimb: boolean;
+  /** Edited since the last successful explicit save. */
+  hasUnsavedEdits: boolean;
+  /** The last explicit save was rejected for a non-duplicate reason. */
+  saveFailed: boolean;
+  /** Publishing is selected but the climb has no start or no finish hold. */
+  publishBlocked: boolean;
+};
+
+/**
+ * The persistent one-line answer to "is my work safe, and where is it?", rendered
+ * under the Save row. Pure so every branch is table-testable without a renderer;
+ * keys are static literals so the i18n orphan checker still sees them.
+ *
+ * There is deliberately NO "saving…" branch. The Save button already says that
+ * while a save is in flight, and two "Saving…" strings 20dp apart is noise — the
+ * line simply keeps whatever it said before the press, which stays true.
+ */
+export function deriveDraftStatusView(state: DraftStatusState, t: TranslateDraftStatus): DraftStatusView | null {
+  if (!state.hasContent) return null;
+
+  // Storage truth first: on signed-out expo-web every write is dropped, so no
+  // other branch is allowed to claim the work is kept anywhere.
+  if (!state.localPersistenceAvailable) {
+    return { text: t('mobile.create.autosave.notStored'), tone: 'warning', announce: true };
+  }
+
+  // A failed save is the one moment the answer is only PARTLY yes: the work is on
+  // the phone, and the account copy silently did not happen. Sticky until the next
+  // successful save or a payload change — never on a timer.
+  if (state.saveFailed) {
+    return { text: t('mobile.create.autosave.saveFailed'), tone: 'error', announce: true };
+  }
+
+  // A disabled button must never be mute: while Save is blocked from publishing,
+  // this line is what names the missing requirement.
+  if (state.publishBlocked) {
+    return { text: t('mobile.create.publish.blocked'), tone: 'warning', announce: true };
+  }
+
+  if (state.hasSavedClimb) {
+    return state.hasUnsavedEdits
+      ? { text: t('mobile.create.autosave.unsyncedEdits'), tone: 'muted', announce: false }
+      : { text: t('mobile.create.autosave.inAccount'), tone: 'muted', announce: true };
+  }
+
+  return { text: t('mobile.create.autosave.onDevice'), tone: 'muted', announce: false };
+}

--- a/packages/mobile/src/components/create-climb/use-create-climb-autosave.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-autosave.ts
@@ -1,0 +1,105 @@
+// The create-climb editor's on-device autosave: a debounced write of the current
+// working copy into one slot, plus the two flushes that keep the "a backgrounded
+// app doesn't lose work-in-progress" promise honest.
+//
+// Extracted from the screen controller so the controller keeps the parts that
+// need its other state (which slot, what the payload is, when a server save
+// re-attaches a row) and this file owns only the timing. It has no GraphQL
+// knowledge and never decides WHICH slot to write — the caller passes the key.
+//
+// `holdsJson` / `framesJson` deliberately stay in the controller: the BLE preview
+// effect closes over `holdsJson` and lists it in its deps, and that effect must
+// stay byte-identical (moving it would put this change in Bluetooth review
+// scope). The caller passes the finished payload in.
+
+import { useCallback, useEffect, useRef, type RefObject } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+import { clearDraft, saveDraft, type CreateClimbDraft } from '../../lib/create-climb-draft-store';
+
+export const AUTOSAVE_DEBOUNCE_MS = 500;
+
+type UseCreateClimbAutosaveArgs = {
+  /** Which storage slot this authoring session owns. */
+  slotKey: string;
+  /** The payload to persist. A fresh object each render; see `draftSignature`. */
+  draft: CreateClimbDraft;
+  /**
+   * Cheap value-identity for `draft`. The effect keys on this rather than the
+   * object, so an unrelated re-render can't restart the debounce (and so we
+   * don't re-serialize the whole payload every render just to compare it).
+   */
+  draftSignature: string;
+  /** False when the editor is empty — the slot is dropped instead of written. */
+  hasContent: boolean;
+  /**
+   * Gate: stays false until the mount-time restore has been applied. Writing
+   * before that persists the empty/server copy OVER the stored one and destroys
+   * exactly the work the restore exists to recover.
+   */
+  restoredRef: RefObject<boolean>;
+};
+
+/**
+ * Persists the working copy into `slotKey`, debounced, and flushes immediately on
+ * unmount and on backgrounding.
+ */
+export function useCreateClimbAutosave({
+  slotKey,
+  draft,
+  draftSignature,
+  hasContent,
+  restoredRef,
+}: UseCreateClimbAutosaveArgs): { flush: () => void } {
+  // The most recent payload, kept current by the debounced effect so a flush can
+  // persist it synchronously without waiting for the (suspended-when-backgrounded)
+  // debounce timer. `dirty` gates whether there is anything worth flushing.
+  const pendingDraftRef = useRef<{ key: string; draft: CreateClimbDraft; dirty: boolean }>({
+    key: slotKey,
+    draft,
+    dirty: false,
+  });
+  // Read through refs so the effect can key on the SIGNATURE alone.
+  const draftRef = useRef(draft);
+  draftRef.current = draft;
+
+  useEffect(() => {
+    if (!restoredRef.current) return;
+    pendingDraftRef.current = { key: slotKey, draft: draftRef.current, dirty: hasContent };
+    const handle = setTimeout(() => {
+      const pending = pendingDraftRef.current;
+      pending.dirty = false;
+      if (!hasContent) {
+        void clearDraft(slotKey);
+        return;
+      }
+      void saveDraft(slotKey, pending.draft);
+    }, AUTOSAVE_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+    // `draftSignature` stands in for the payload contents; `draftRef` carries the
+    // object itself. `restoredRef` is a ref and never re-triggers.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slotKey, draftSignature, hasContent]);
+
+  // JS timers are suspended when the app is backgrounded, and the effect
+  // cleanup's clearTimeout drops the pending edit when the drawer closes inside
+  // the debounce window — so persist the latest payload immediately on both.
+  // `restoredRef` is a ref object, stable for the hook's lifetime.
+  const flush = useCallback(() => {
+    const pending = pendingDraftRef.current;
+    if (!restoredRef.current || !pending.dirty) return;
+    pending.dirty = false;
+    void saveDraft(pending.key, pending.draft);
+  }, [restoredRef]);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (state: AppStateStatus) => {
+      if (state === 'background' || state === 'inactive') flush();
+    });
+    return () => {
+      subscription.remove();
+      flush();
+    };
+  }, [flush]);
+
+  return { flush };
+}

--- a/packages/mobile/src/components/create-climb/use-create-climb-autosave.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-autosave.ts
@@ -66,13 +66,17 @@ export function useCreateClimbAutosave({
     if (!restoredRef.current) return;
     pendingDraftRef.current = { key: slotKey, draft: draftRef.current, dirty: hasContent };
     const handle = setTimeout(() => {
+      // Key off the mirrored payload, exactly as `flush` does. A slot change
+      // re-runs this effect and its cleanup cancels the pending timer, so the two
+      // can't actually diverge — but reading one source makes that plain instead
+      // of leaving a reader to prove it.
       const pending = pendingDraftRef.current;
       pending.dirty = false;
       if (!hasContent) {
-        void clearDraft(slotKey);
+        void clearDraft(pending.key);
         return;
       }
-      void saveDraft(slotKey, pending.draft);
+      void saveDraft(pending.key, pending.draft);
     }, AUTOSAVE_DEBOUNCE_MS);
     return () => clearTimeout(handle);
     // `draftSignature` stands in for the payload contents; `draftRef` carries the

--- a/packages/mobile/src/components/create-climb/use-create-climb-autosave.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-autosave.ts
@@ -18,6 +18,8 @@ import { clearDraft, saveDraft, type CreateClimbDraft } from '../../lib/create-c
 
 export const AUTOSAVE_DEBOUNCE_MS = 500;
 
+type PendingAutosaveOperation = { type: 'none' } | { type: 'save'; key: string } | { type: 'clear'; key: string };
+
 type UseCreateClimbAutosaveArgs = {
   /** Which storage slot this authoring session owns. */
   slotKey: string;
@@ -37,6 +39,8 @@ type UseCreateClimbAutosaveArgs = {
    * exactly the work the restore exists to recover.
    */
   restoredRef: RefObject<boolean>;
+  /** Changes when mount-time restore finishes so pre-restore edits can arm. */
+  restoreEpoch: number;
 };
 
 /**
@@ -49,51 +53,112 @@ export function useCreateClimbAutosave({
   draftSignature,
   hasContent,
   restoredRef,
-}: UseCreateClimbAutosaveArgs): { flush: () => void } {
+  restoreEpoch,
+}: UseCreateClimbAutosaveArgs): {
+  flush: () => void;
+  discard: () => Promise<void>;
+  persist: (draft: CreateClimbDraft) => Promise<void>;
+} {
   // The most recent payload, kept current by the debounced effect so a flush can
   // persist it synchronously without waiting for the (suspended-when-backgrounded)
-  // debounce timer. `dirty` gates whether there is anything worth flushing.
-  const pendingDraftRef = useRef<{ key: string; draft: CreateClimbDraft; dirty: boolean }>({
-    key: slotKey,
-    draft,
-    dirty: false,
-  });
+  // debounce timer. Empty editors carry an explicit `clear` operation: treating
+  // them as merely "not dirty" made an unmount/background flush drop the clear
+  // and leave the previous working copy behind.
+  const pendingOperationRef = useRef<PendingAutosaveOperation>({ type: 'none' });
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const storageOperationRef = useRef<Promise<void> | null>(null);
   // Read through refs so the effect can key on the SIGNATURE alone.
   const draftRef = useRef(draft);
   draftRef.current = draft;
 
+  const enqueueStorageOperation = useCallback((operation: () => Promise<void>): Promise<void> => {
+    const previousOperation = storageOperationRef.current;
+    const nextOperation = previousOperation ? previousOperation.catch(() => undefined).then(operation) : operation();
+    storageOperationRef.current = nextOperation;
+    void nextOperation.then(
+      () => {
+        if (storageOperationRef.current === nextOperation) storageOperationRef.current = null;
+      },
+      () => {
+        if (storageOperationRef.current === nextOperation) storageOperationRef.current = null;
+      },
+    );
+    return nextOperation;
+  }, []);
+
+  const executePendingOperation = useCallback(() => {
+    const pendingOperation = pendingOperationRef.current;
+    pendingOperationRef.current = { type: 'none' };
+    if (pendingOperation.type === 'save') {
+      const pendingDraft = draftRef.current;
+      void enqueueStorageOperation(() => saveDraft(pendingOperation.key, pendingDraft));
+    } else if (pendingOperation.type === 'clear') {
+      void enqueueStorageOperation(() => clearDraft(pendingOperation.key));
+    }
+  }, [enqueueStorageOperation]);
+
   useEffect(() => {
     if (!restoredRef.current) return;
-    pendingDraftRef.current = { key: slotKey, draft: draftRef.current, dirty: hasContent };
-    const handle = setTimeout(() => {
-      // Key off the mirrored payload, exactly as `flush` does. A slot change
-      // re-runs this effect and its cleanup cancels the pending timer, so the two
-      // can't actually diverge — but reading one source makes that plain instead
-      // of leaving a reader to prove it.
-      const pending = pendingDraftRef.current;
-      pending.dirty = false;
-      if (!hasContent) {
-        void clearDraft(pending.key);
-        return;
-      }
-      void saveDraft(pending.key, pending.draft);
+    pendingOperationRef.current = hasContent ? { type: 'save', key: slotKey } : { type: 'clear', key: slotKey };
+    debounceTimerRef.current = setTimeout(() => {
+      debounceTimerRef.current = null;
+      executePendingOperation();
     }, AUTOSAVE_DEBOUNCE_MS);
-    return () => clearTimeout(handle);
+    return () => {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    };
     // `draftSignature` stands in for the payload contents; `draftRef` carries the
-    // object itself. `restoredRef` is a ref and never re-triggers.
+    // object itself. `restoreEpoch` re-runs this once when the ref gate opens,
+    // preserving edits made while an asynchronous restore was still pending.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [slotKey, draftSignature, hasContent]);
+  }, [slotKey, draftSignature, hasContent, restoreEpoch, executePendingOperation]);
 
   // JS timers are suspended when the app is backgrounded, and the effect
   // cleanup's clearTimeout drops the pending edit when the drawer closes inside
   // the debounce window — so persist the latest payload immediately on both.
   // `restoredRef` is a ref object, stable for the hook's lifetime.
   const flush = useCallback(() => {
-    const pending = pendingDraftRef.current;
-    if (!restoredRef.current || !pending.dirty) return;
-    pending.dirty = false;
-    void saveDraft(pending.key, pending.draft);
-  }, [restoredRef]);
+    if (!restoredRef.current) return;
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    debounceTimerRef.current = null;
+    executePendingOperation();
+  }, [restoredRef, executePendingOperation]);
+
+  const cancelPending = useCallback(() => {
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    debounceTimerRef.current = null;
+    pendingOperationRef.current = { type: 'none' };
+  }, []);
+
+  // Deliberate abandonment is different from the form naturally becoming
+  // empty. Clear immediately and retire the pending operation before the caller
+  // navigates/unmounts, so the cleanup flush cannot recreate the slot from the
+  // last non-empty render.
+  const discard = useCallback(() => {
+    cancelPending();
+    const clearOperation = enqueueStorageOperation(() => clearDraft(slotKey));
+    return clearOperation.catch(async (error: unknown) => {
+      // A failed deliberate clear must not turn off the durability guarantee.
+      // Re-persist the latest working copy before reporting failure so cancelling
+      // the confirmation and then dismissing cannot lose a never-written edit.
+      if (hasContent) {
+        await enqueueStorageOperation(() => saveDraft(slotKey, draftRef.current));
+      }
+      throw error;
+    });
+  }, [cancelPending, enqueueStorageOperation, hasContent, slotKey]);
+
+  // Explicit Save must be ordered after any autosave already writing, then win
+  // with the server-row link and saved payload baseline. Cancelling a timer alone
+  // cannot stop a storage write that has already started.
+  const persist = useCallback(
+    (nextDraft: CreateClimbDraft) => {
+      cancelPending();
+      return enqueueStorageOperation(() => saveDraft(slotKey, nextDraft));
+    },
+    [cancelPending, enqueueStorageOperation, slotKey],
+  );
 
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (state: AppStateStatus) => {
@@ -105,5 +170,5 @@ export function useCreateClimbAutosave({
     };
   }, [flush]);
 
-  return { flush };
+  return { flush, discard, persist };
 }

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { AppState, type AppStateStatus } from 'react-native';
 import { randomUUID } from 'expo-crypto';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -30,15 +29,21 @@ import { useProfile, useClimb } from '../../lib/graphql/hooks';
 import { useQueueActions } from '../../providers/queue-provider';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { useToast } from '../../providers/toast-provider';
+import { useConfirm } from '../../providers/dialog-provider';
 import { climbToQueueItem } from '../../lib/climb-to-queue-item';
 import {
   loadDraft,
   saveDraft,
   clearDraft,
   createClimbDraftKey,
+  createClimbEditDraftKey,
+  createClimbForkDraftKey,
+  isDraftStorageAvailable,
   type CreateClimbDraft,
 } from '../../lib/create-climb-draft-store';
 import { getNextBrushRole, getPaintRoles, type BrushRole } from './brush-roles';
+import { useCreateClimbAutosave } from './use-create-climb-autosave';
+import { deriveDraftStatusView, type DraftStatusView } from './draft-status-view';
 
 // The save button's visual state, derived from auth + the saved-climb snapshot +
 // in-flight state. Lives here (the controller computes it) so the UI imports it.
@@ -65,9 +70,30 @@ type UseCreateClimbScreenArgs = {
   onPublished?: () => void;
 };
 
-const AUTOSAVE_DEBOUNCE_MS = 500;
 const BLE_PREVIEW_DEBOUNCE_MS = 250;
 const JUST_SAVED_MS = 3000;
+
+/** Field separator for the payload signature — cannot occur in JSON or user text. */
+const SIGNATURE_SEPARATOR = '\u0000';
+
+function parseSavedClimbSnapshot(serialized: string | undefined): SavedClimbSnapshot | null {
+  if (!serialized) return null;
+  try {
+    const parsed = JSON.parse(serialized) as Partial<SavedClimbSnapshot>;
+    if (typeof parsed?.uuid !== 'string' || typeof parsed?.boardType !== 'string') return null;
+    return {
+      uuid: parsed.uuid,
+      boardType: parsed.boardType,
+      createdAt: parsed.createdAt ?? null,
+      publishedAt: parsed.publishedAt ?? null,
+      isDraft: parsed.isDraft ?? true,
+    };
+  } catch {
+    // Corrupt snapshot — restore the paint, drop the row link. The next Save
+    // creates a fresh climb rather than updating an unknown uuid.
+    return null;
+  }
+}
 
 /** Duplicate-publish detail surfaced inline so the user can view the match. */
 export type PublishDuplicateError = {
@@ -137,6 +163,7 @@ export function useCreateClimbScreen({
   const { setCurrentClimb } = useQueueActions();
   const bluetooth = useOptionalBluetoothContext();
   const { showToast } = useToast();
+  const confirm = useConfirm();
   const queryClient = useQueryClient();
 
   const isForking = !!forkFrames;
@@ -163,6 +190,8 @@ export function useCreateClimbScreen({
     startingCount,
     finishCount,
     isValid,
+    canSave,
+    canPublish,
     resetHolds,
     loadFrames,
     duplicateFrame,
@@ -199,6 +228,11 @@ export function useCreateClimbScreen({
   const [isSaving, setIsSaving] = useState(false);
   const [justSaved, setJustSaved] = useState(false);
   const [publishDuplicateError, setPublishDuplicateError] = useState<PublishDuplicateError | null>(null);
+  // Payload signature at the last SUCCESSFUL explicit save, and at the last
+  // FAILED one. Both are compared against the live signature below, which is how
+  // "edited since you saved" and "that save failed" stay true without a timer.
+  const [savedSignature, setSavedSignature] = useState<string | null>(null);
+  const [failedSignature, setFailedSignature] = useState<string | null>(null);
 
   useEffect(() => {
     setSelectedBrush((currentBrush) => {
@@ -209,9 +243,28 @@ export function useCreateClimbScreen({
   }, [board.boardName]);
 
   const draftKey = useMemo(() => createClimbDraftKey(board), [board]);
-  // Skip the local-autosave restore when forking or editing (those seed from
-  // their own source); also skip until the initial restore lands.
-  const skipRestoreRef = useRef(isForking || isEditing);
+
+  // ---- One deterministic autosave slot per authoring mode. ----
+  // Identity now lives in the KEY, which is why autosave no longer has to be
+  // switched off outside the plain-new case. It used to be, because the slot key
+  // carried board config only: a fork or an edit writing it would clobber a real
+  // new-climb WIP and resurface as a phantom. The cost of that boolean was that
+  // editing a draft, remixing a climb, and everything after the first Save had no
+  // autosave at all — the three states where losing work hurts most.
+  //   new  → `<board>:<layout>:<size>:<sets>:<angle>`  (string UNCHANGED, so
+  //          drafts already on devices keep restoring — no migration)
+  //   edit → `edit:<boardType>:<uuid>`   (reopening that climb finds it)
+  //   fork → `fork:<boardKey>`           (a plain-new mount falls back to it)
+  const autosaveSlotKey = useMemo(() => {
+    if (isEditing && editClimbUuid) return createClimbEditDraftKey(board.boardName, editClimbUuid);
+    if (isForking) return createClimbForkDraftKey(draftKey);
+    return draftKey;
+  }, [isEditing, editClimbUuid, isForking, board.boardName, draftKey]);
+
+  // Forks seed from another climb's frames, so there is nothing to restore.
+  // Edit mode DOES restore, but inside the seed effect below — after the server
+  // copy lands, never before it.
+  const skipRestoreRef = useRef(isForking);
   const restoredRef = useRef(false);
   // Stable provisional queue-item uuid for an unsaved WIP, so re-tapping "Set as
   // active" updates the same queue slot instead of appending a new item each tap.
@@ -267,6 +320,28 @@ export function useCreateClimbScreen({
     [isEditing, editClimbUuid, board],
   );
   const { data: editClimb } = useClimb(editVariables);
+
+  // Apply a stored working copy over whatever the editor currently holds.
+  const applyStoredDraft = useCallback(
+    (draft: CreateClimbDraft) => {
+      try {
+        const restoredFrames = draft.framesJson
+          ? (JSON.parse(draft.framesJson) as Parameters<typeof loadFrames>[0])
+          : [JSON.parse(draft.holdsJson) as Parameters<typeof loadFrames>[0][number]];
+        loadFrames(restoredFrames);
+      } catch {
+        // Corrupt holds payload — keep whatever is already loaded.
+      }
+      setName(draft.name);
+      setDescription(withNoMatch(draft.description, false));
+      setNoMatch(isNoMatchClimb(draft.description));
+      setNoKickboard(draft.noKickboard ?? false);
+      setCampus(draft.campus ?? false);
+      setIsDraft(draft.isDraft);
+    },
+    [loadFrames],
+  );
+
   const editSeededRef = useRef(false);
   useEffect(() => {
     if (!editClimb || editSeededRef.current) return;
@@ -285,36 +360,53 @@ export function useCreateClimbScreen({
       publishedAt: editClimb.published_at ?? null,
       isDraft: editClimb.is_draft ?? false,
     });
-  }, [editClimb, board.boardName, loadFrames]);
 
-  // ---- Local autosave restore on mount. ----
+    // ORDERING IS LOAD-BEARING. The `edit:` slot is applied OVER the server copy,
+    // and `restoredRef` opens only once that has resolved. Set it any earlier and
+    // the next debounce tick writes the freshly fetched SERVER copy into the slot,
+    // destroying exactly the unflushed edits this restore exists to recover —
+    // silently, while the status line still reads "Draft saved to your account".
+    // Pinned by "applies the stored edit slot over the server copy" in
+    // use-create-climb-screen-autosave.test.tsx. No cancellation on purpose:
+    // `editSeededRef` already makes this run once per mount, and a cancelled
+    // restore would leave the gate shut and autosave dead for the whole session.
+    void loadDraft(createClimbEditDraftKey(board.boardName, editClimb.uuid))
+      .then((storedDraft) => {
+        if (storedDraft) applyStoredDraft(storedDraft);
+      })
+      .catch(() => {
+        // Unreadable slot — the server copy stands.
+      })
+      .finally(() => {
+        restoredRef.current = true;
+      });
+  }, [editClimb, board.boardName, loadFrames, applyStoredDraft]);
+
+  // ---- Local autosave restore on mount (plain new climb). ----
   useEffect(() => {
-    if (skipRestoreRef.current) {
-      restoredRef.current = true;
+    // Edit mode restores inside the seed effect above; forks seed from source.
+    if (isEditing || skipRestoreRef.current) {
+      if (!isEditing) restoredRef.current = true;
       return;
     }
     let cancelled = false;
-    void loadDraft(draftKey).then((draft) => {
+    void (async () => {
+      let draft = await loadDraft(draftKey);
+      // A killed remix session lives in the fork slot, and a cold relaunch can
+      // only land on the plain creator (the modal route with `forkFrames` is
+      // gone), so this is the only door back to it.
+      if (!draft) draft = await loadDraft(createClimbForkDraftKey(draftKey));
       if (cancelled || !draft) {
         restoredRef.current = true;
         return;
       }
-      try {
-        const frames = draft.framesJson
-          ? (JSON.parse(draft.framesJson) as Parameters<typeof loadFrames>[0])
-          : [JSON.parse(draft.holdsJson) as Parameters<typeof loadFrames>[0][number]];
-        loadFrames(frames);
-      } catch {
-        // Corrupt holds payload — ignore and start clean.
-      }
-      setName(draft.name);
-      setDescription(withNoMatch(draft.description, false));
-      setNoMatch(isNoMatchClimb(draft.description));
-      setNoKickboard(draft.noKickboard ?? false);
-      setCampus(draft.campus ?? false);
-      setIsDraft(draft.isDraft);
+      applyStoredDraft(draft);
+      // Re-attach the server row this working copy belongs to, so the next Save
+      // UPDATES that climb instead of creating a duplicate in Open drafts.
+      const restoredSavedClimb = parseSavedClimbSnapshot(draft.savedClimbJson);
+      if (restoredSavedClimb) setSavedClimb(restoredSavedClimb);
       restoredRef.current = true;
-    });
+    })();
     return () => {
       cancelled = true;
     };
@@ -325,30 +417,30 @@ export function useCreateClimbScreen({
   // ---- Local autosave (debounced). ----
   const holdsJson = useMemo(() => JSON.stringify(litUpHoldsMap), [litUpHoldsMap]);
   const framesJson = useMemo(() => JSON.stringify(frames), [frames]);
-  // The most recent autosave payload, kept current by the debounced effect so a
-  // flush-on-unmount / background can persist it synchronously without waiting
-  // for the (suspended-when-backgrounded) debounce timer. `dirty` gates whether
-  // there is anything worth flushing for the current per-board new-draft slot.
-  const pendingDraftRef = useRef<{ key: string; draft: CreateClimbDraft; dirty: boolean }>({
-    key: draftKey,
-    draft: { holdsJson, framesJson, name, description, isDraft },
-    dirty: false,
-  });
-  // Forks seed from another climb's frames and skip restore, so — like edit
-  // mode — they must never write the shared per-board new-draft autosave slot,
-  // or merely opening a fork would clobber a real new-climb WIP under the same
-  // (board-config-only) key and resurface as a phantom on the next "new climb".
-  const autosaveDisabled = isEditing || isForking || !!savedClimb;
-  useEffect(() => {
-    if (!restoredRef.current) return;
-    // Edit mode / forks operate on a seeded climb, and a just-saved WIP is owned
-    // by the server row — none of them belong in the new-draft autosave slot.
-    if (autosaveDisabled) {
-      pendingDraftRef.current.dirty = false;
-      return;
-    }
-    const hasContent = holdsJson !== '{}' || frameCount > 1 || name.trim() !== '' || description.trim() !== '';
-    const draft: CreateClimbDraft = {
+  const hasContent = holdsJson !== '{}' || frameCount > 1 || name.trim() !== '' || description.trim() !== '';
+
+  // Content identity of the working copy. One value serves three jobs: it tells
+  // the status line whether there are edits since the last save, it clears a
+  // stale save-failure the moment the payload moves, and `handleSave` compares it
+  // before and after the round trip so a publish never clears work typed while
+  // the mutation was in flight.
+  const payloadSignature = [
+    holdsJson,
+    framesJson,
+    name,
+    description,
+    noMatch ? '1' : '0',
+    noKickboard ? '1' : '0',
+    campus ? '1' : '0',
+    isDraft ? '1' : '0',
+  ].join(SIGNATURE_SEPARATOR);
+  const payloadSignatureRef = useRef(payloadSignature);
+  payloadSignatureRef.current = payloadSignature;
+
+  const savedClimbJson = useMemo(() => (savedClimb ? JSON.stringify(savedClimb) : undefined), [savedClimb]);
+
+  const autosaveDraft = useMemo<CreateClimbDraft>(
+    () => ({
       holdsJson,
       framesJson,
       name,
@@ -356,55 +448,34 @@ export function useCreateClimbScreen({
       isDraft,
       noKickboard,
       campus,
-    };
-    // Mirror the latest payload so a flush (unmount/background) can persist the
-    // pending edit even before the debounce fires.
-    pendingDraftRef.current = { key: draftKey, draft, dirty: hasContent };
-    const handle = setTimeout(() => {
-      if (!hasContent) {
-        void clearDraft(draftKey);
-        pendingDraftRef.current.dirty = false;
-        return;
-      }
-      void saveDraft(draftKey, draft);
-      pendingDraftRef.current.dirty = false;
-    }, AUTOSAVE_DEBOUNCE_MS);
-    return () => clearTimeout(handle);
-  }, [
-    holdsJson,
-    framesJson,
-    frameCount,
-    name,
-    description,
-    noMatch,
-    noKickboard,
-    campus,
-    isDraft,
-    draftKey,
-    autosaveDisabled,
-  ]);
+      savedClimbJson,
+      origin: isEditing ? 'edit' : isForking ? 'fork' : 'new',
+      updatedAtMs: Date.now(),
+    }),
+    [
+      holdsJson,
+      framesJson,
+      name,
+      description,
+      noMatch,
+      noKickboard,
+      campus,
+      isDraft,
+      savedClimbJson,
+      isEditing,
+      isForking,
+    ],
+  );
+  const autosaveDraftRef = useRef(autosaveDraft);
+  autosaveDraftRef.current = autosaveDraft;
 
-  // ---- Flush the pending draft on unmount / background. ----
-  // JS timers are suspended when the app is backgrounded and the cleanup's
-  // clearTimeout drops the pending edit when the drawer closes within the
-  // debounce window, so persist the latest payload immediately on both
-  // transitions. Keeps the draft-store's "a backgrounded app doesn't lose
-  // work-in-progress" promise.
-  const flushPendingDraft = useCallback(() => {
-    const pending = pendingDraftRef.current;
-    if (!restoredRef.current || !pending.dirty) return;
-    pending.dirty = false;
-    void saveDraft(pending.key, pending.draft);
-  }, []);
-  useEffect(() => {
-    const subscription = AppState.addEventListener('change', (state: AppStateStatus) => {
-      if (state === 'background' || state === 'inactive') flushPendingDraft();
-    });
-    return () => {
-      subscription.remove();
-      flushPendingDraft();
-    };
-  }, [flushPendingDraft]);
+  useCreateClimbAutosave({
+    slotKey: autosaveSlotKey,
+    draft: autosaveDraft,
+    draftSignature: `${payloadSignature}${SIGNATURE_SEPARATOR}${savedClimbJson ?? ''}`,
+    hasContent,
+    restoredRef,
+  });
 
   // ---- BLE preview (debounced) while connected. ----
   const sendFramesRef = useRef(bluetooth?.sendFramesToBoard);
@@ -440,10 +511,33 @@ export function useCreateClimbScreen({
     [setHoldState],
   );
 
-  const handleClear = useCallback(() => {
+  // ---- Clear holds vs. start a new climb. ----
+  // These were one button doing both jobs behind a trash can labelled "Clear
+  // holds": it also wiped the name, the description and the on-device slot, none
+  // of which undo restores. Split so the label, the glyph and the behaviour agree.
+
+  /** Empty this frame's holds. Undoable through the reducer; touches nothing else. */
+  const handleClearHolds = useCallback(() => {
     resetHolds();
-    // Treat Clear as a brand-new climb: wipe name/description/draft flag too, or
-    // a Save straight after Clear reuses the old name and skips the name prompt.
+  }, [resetHolds]);
+
+  /**
+   * Park this climb and start a blank one. A saved climb keeps its row in Open
+   * drafts (only the new-climb slot is dropped, never an `edit:` slot). An unsaved
+   * one genuinely is not recoverable, so that case — and only that case — confirms.
+   */
+  const handleNewClimb = useCallback(async () => {
+    if (savedClimb == null && hasContent) {
+      const confirmed = await confirm({
+        title: t('mobile.create.newClimb.confirm.title'),
+        message: t('mobile.create.newClimb.confirm.message'),
+        confirmLabel: t('mobile.create.newClimb.confirm.action'),
+        cancelLabel: t('createClimbForm.dismiss'),
+        destructive: true,
+      });
+      if (!confirmed) return;
+    }
+    resetHolds();
     setName('');
     setDescription('');
     setNoMatch(false);
@@ -452,10 +546,12 @@ export function useCreateClimbScreen({
     setIsDraft(true);
     setSavedClimb(null);
     setPublishDuplicateError(null);
+    setSavedSignature(null);
+    setFailedSignature(null);
     // Fresh climb identity for the next WIP so its queue item is independent.
     previewUuidRef.current = randomUUID();
     void clearDraft(draftKey);
-  }, [resetHolds, draftKey]);
+  }, [resetHolds, draftKey, savedClimb, hasContent, confirm, t]);
 
   // Build a minimal Climb the queue can hold for a not-yet-saved or just-saved
   // climb. The mutation input (`ClimbInput`) is a strict subset of Climb, so
@@ -567,6 +663,34 @@ export function useCreateClimbScreen({
     return 'ready';
   }, [isAuthenticated, isSaving, justSaved, editLocked]);
 
+  // ---- Is my work safe, and where is it? ----
+  // Only the PUBLIC transition is gated. Nothing else checks starts and finishes
+  // — not the editor, not SaveClimbInputSchema — so without this a one-hold blob
+  // is one tap from being a public climb. The draft threshold stays where it is:
+  // tightening it would regress every draft that saves today, and a disabled Save
+  // with nothing to say is worse than a silent no-op. While this is true, the
+  // status line names the missing requirement directly under the button.
+  const publishBlocked = !isDraft && hasContent && !canPublish;
+  const localPersistenceAvailable = isDraftStorageAvailable();
+  const hasUnsavedEdits = savedClimb != null && savedSignature !== null && savedSignature !== payloadSignature;
+  const saveFailed = failedSignature !== null && failedSignature === payloadSignature;
+
+  const draftStatus: DraftStatusView | null = useMemo(
+    () =>
+      deriveDraftStatusView(
+        {
+          hasContent,
+          localPersistenceAvailable,
+          hasSavedClimb: savedClimb != null,
+          hasUnsavedEdits,
+          saveFailed,
+          publishBlocked,
+        },
+        t,
+      ),
+    [hasContent, localPersistenceAvailable, savedClimb, hasUnsavedEdits, saveFailed, publishBlocked, t],
+  );
+
   // Signal the screen should focus the header name field (e.g. on a save with
   // no name yet). The name input lives in the drawer header, not a settings sheet.
   const [focusNameSignal, setFocusNameSignal] = useState(0);
@@ -578,7 +702,8 @@ export function useCreateClimbScreen({
       return;
     }
     if (editLocked) return;
-    if (!isValid) return;
+    // Drafts stay cheap; publishing needs a start and a finish.
+    if (isDraft ? !canSave : !canPublish) return;
     if (name.trim() === '') {
       requestFocusName();
       return;
@@ -586,6 +711,10 @@ export function useCreateClimbScreen({
 
     setIsSaving(true);
     setPublishDuplicateError(null);
+    // Captured BEFORE the mutation fires. Anything typed during the round trip
+    // moves the live signature, and both the slot clear and the "saved" status
+    // below check that before acting on a stale result.
+    const signatureAtSave = payloadSignatureRef.current;
     const frames = generateFramesString();
     // Encode the no-match marker into the description only at save time.
     const fullDescription = withNoMatch(description, noMatch);
@@ -598,6 +727,7 @@ export function useCreateClimbScreen({
     // exact value, so the string must match web for these create-climb events.
     const boardLayout = getLayoutName(board.boardName, board.layoutId);
     const characteristics = buildToggleableCharacteristics(noKickboard, campus);
+    let nextSavedClimb: SavedClimbSnapshot | null = null;
     try {
       if (canUpdate && savedClimb) {
         const result = await updateClimb({
@@ -612,13 +742,14 @@ export function useCreateClimbScreen({
           isDraft,
           characteristics,
         });
-        setSavedClimb({
+        nextSavedClimb = {
           uuid: result.uuid,
           boardType: board.boardName,
           createdAt: result.createdAt ?? savedClimb.createdAt,
           publishedAt: result.publishedAt ?? savedClimb.publishedAt,
           isDraft: result.isDraft,
-        });
+        };
+        setSavedClimb(nextSavedClimb);
         // Match web's schema exactly (create-climb-form.tsx) so PostHog funnels
         // that group by these props line up across platforms. `boardLayout` is the
         // resolved layout NAME (same value web sends), not the numeric id.
@@ -640,13 +771,14 @@ export function useCreateClimbScreen({
           angle: board.angle,
           characteristics,
         });
-        setSavedClimb({
+        nextSavedClimb = {
           uuid: result.uuid,
           boardType: board.boardName,
           createdAt: result.createdAt ?? null,
           publishedAt: result.publishedAt ?? null,
           isDraft,
-        });
+        };
+        setSavedClimb(nextSavedClimb);
         // Match web's schema exactly (create-climb-form.tsx). See ClimbUpdated above.
         track(SHARED_EVENTS.ClimbCreated, {
           boardLayout,
@@ -655,7 +787,22 @@ export function useCreateClimbScreen({
         });
         syncSavedToQueue(result.uuid, frames);
       }
-      await clearDraft(draftKey);
+      // ---- What happens to the on-device working copy. ----
+      // A draft-Save used to delete it unconditionally, which is what made "Save,
+      // then kill the app" lose everything: autosave was off once a row existed,
+      // so nothing ever wrote it back. Now the slot IS the working copy, and only
+      // a PUBLISH retires it — under a compare-and-clear, so anything typed during
+      // the round trip survives.
+      if (isDraft) {
+        await saveDraft(autosaveSlotKey, {
+          ...autosaveDraftRef.current,
+          savedClimbJson: nextSavedClimb ? JSON.stringify(nextSavedClimb) : undefined,
+        });
+      } else if (payloadSignatureRef.current === signatureAtSave) {
+        await clearDraft(autosaveSlotKey);
+      }
+      setFailedSignature(null);
+      setSavedSignature(signatureAtSave);
       // Refresh the inline Open Drafts table AND the Climbs tab's infinite list
       // so the just-saved climb appears / updates (mirrors useDeleteDraftClimb's
       // key set in lib/graphql/hooks/index.ts — create, edit, and publish-draft
@@ -679,8 +826,14 @@ export function useCreateClimbScreen({
         error_reason: isDuplicateClimbError(err) ? 'duplicate' : 'exception',
       });
       if (isDuplicateClimbError(err)) {
+        // The inline DuplicateBanner already explains this one and offers the
+        // match — the status line would just repeat it.
         setPublishDuplicateError(readDuplicateExtensions(err));
       } else {
+        // The toast is gone in 3s. Without a persistent line the editor would go
+        // on reading "Saved on this phone" — true, and silent about the account
+        // copy never happening. Sticky until the next successful save or an edit.
+        setFailedSignature(signatureAtSave);
         showToast(t('createClimbForm.alerts.saveFailedFallback'), 'error');
       }
     } finally {
@@ -690,7 +843,8 @@ export function useCreateClimbScreen({
     isAuthenticated,
     router,
     editLocked,
-    isValid,
+    canSave,
+    canPublish,
     name,
     canUpdate,
     savedClimb,
@@ -705,7 +859,7 @@ export function useCreateClimbScreen({
     noKickboard,
     campus,
     isDraft,
-    draftKey,
+    autosaveSlotKey,
     requestFocusName,
     syncSavedToQueue,
     showToast,
@@ -718,17 +872,35 @@ export function useCreateClimbScreen({
 
   const canSetActive = isValid;
 
+  // ---- Dismissing the sheet. ----
+  // No confirm on any of the four dismiss paths (chevron, pan-down, backdrop,
+  // hardware back): pan-down is the most-used gesture on this surface and a modal
+  // on it is hostile. The autosave flush on unmount already keeps the work, so the
+  // only thing missing was saying so — once, and only when the climber could
+  // reasonably think it is gone: content exists and there is no row in Open
+  // drafts to find it in.
+  const dismissNoticeRef = useRef({ hasContent, hasSavedClimb: savedClimb != null, localPersistenceAvailable });
+  dismissNoticeRef.current = { hasContent, hasSavedClimb: savedClimb != null, localPersistenceAvailable };
+  const notifyDraftKeptOnDismiss = useCallback(() => {
+    const notice = dismissNoticeRef.current;
+    if (!notice.hasContent || notice.hasSavedClimb || !notice.localPersistenceAvailable) return;
+    showToast(t('mobile.create.autosave.keptToast'), 'info');
+  }, [showToast, t]);
+
   return {
     // editor state
     litUpHoldsMap,
     startingCount,
     finishCount,
     isValid,
+    canSave,
+    canPublish,
     selectedBrush,
     setSelectedBrush,
     handlePaint,
     handleAssignRole,
-    handleClear,
+    handleClearHolds,
+    handleNewClimb,
     showAllHolds,
     setShowAllHolds,
     // frames (route/circuit editing)
@@ -759,11 +931,15 @@ export function useCreateClimbScreen({
     // save
     saveState,
     handleSave,
+    publishBlocked,
     canSetActive,
     handleSetActive,
     publishDuplicateError,
     dismissDuplicateError,
     focusNameSignal,
+    // persistence
+    draftStatus,
+    notifyDraftKeptOnDismiss,
     // ble
     bleAvailable: !!bluetooth,
     bleConnected,

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -319,7 +319,7 @@ export function useCreateClimbScreen({
         : null,
     [isEditing, editClimbUuid, board],
   );
-  const { data: editClimb } = useClimb(editVariables);
+  const { data: editClimb, isError: editClimbFailed } = useClimb(editVariables);
 
   // Apply a stored working copy over whatever the editor currently holds.
   const applyStoredDraft = useCallback(
@@ -381,6 +381,17 @@ export function useCreateClimbScreen({
         restoredRef.current = true;
       });
   }, [editClimb, board.boardName, loadFrames, applyStoredDraft]);
+
+  // If the climb never loads — offline, or the row is gone — the seed effect
+  // above never runs, so the gate it opens would stay shut for the whole session
+  // and autosave would be silently off in exactly the mode this change exists to
+  // fix. Open it on a settled failure so the paint is still kept on the phone.
+  // (A later retry that succeeds still seeds, and its `edit:` slot load then
+  // reapplies whatever was painted in the meantime.)
+  useEffect(() => {
+    if (!isEditing || !editClimbFailed || editSeededRef.current) return;
+    restoredRef.current = true;
+  }, [isEditing, editClimbFailed]);
 
   // ---- Local autosave restore on mount (plain new climb). ----
   useEffect(() => {
@@ -550,8 +561,14 @@ export function useCreateClimbScreen({
     setFailedSignature(null);
     // Fresh climb identity for the next WIP so its queue item is independent.
     previewUuidRef.current = randomUUID();
-    void clearDraft(draftKey);
-  }, [resetHolds, draftKey, savedClimb, hasContent, confirm, t]);
+    // Drop the working copy THIS session owns — in fork/edit mode that is the
+    // `fork:`/`edit:` slot, not the shared new-climb one. Clearing only
+    // `draftKey` left an abandoned fork slot behind, which the plain creator's
+    // fork fallback would then resurrect as a ghost draft on the next open. A
+    // server draft is untouched either way: it lives in board_climbs, not here,
+    // so an edit session still leaves its row in Open drafts.
+    void clearDraft(autosaveSlotKey);
+  }, [resetHolds, autosaveSlotKey, savedClimb, hasContent, confirm, t]);
 
   // Build a minimal Climb the queue can hold for a not-yet-saved or just-saved
   // climb. The mutation input (`ClimbInput`) is a strict subset of Climb, so

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -67,6 +67,8 @@ type UseCreateClimbScreenArgs = {
   /** Called after a successful publish (non-draft save) so the screen can
    *  dismiss the drawer and let the success toast show over the list. */
   onPublished?: () => void;
+  /** Replaces edit/fork route identity with a plain creator after Start new. */
+  onStartedNewClimb?: () => void;
 };
 
 const BLE_PREVIEW_DEBOUNCE_MS = 250;
@@ -74,6 +76,30 @@ const JUST_SAVED_MS = 3000;
 
 /** Field separator for the payload signature — cannot occur in JSON or user text. */
 const SIGNATURE_SEPARATOR = '\u0000';
+
+type PayloadSignatureFields = {
+  holdsJson: string;
+  framesJson: string;
+  name: string;
+  description: string;
+  noMatch: boolean;
+  noKickboard: boolean;
+  campus: boolean;
+  isDraft: boolean;
+};
+
+function createPayloadSignature(fields: PayloadSignatureFields): string {
+  return [
+    fields.holdsJson,
+    fields.framesJson,
+    fields.name,
+    fields.description,
+    fields.noMatch ? '1' : '0',
+    fields.noKickboard ? '1' : '0',
+    fields.campus ? '1' : '0',
+    fields.isDraft ? '1' : '0',
+  ].join(SIGNATURE_SEPARATOR);
+}
 
 function parseSavedClimbSnapshot(serialized: string | undefined): SavedClimbSnapshot | null {
   if (!serialized) return null;
@@ -153,6 +179,7 @@ export function useCreateClimbScreen({
   forkDescription,
   editClimbUuid,
   onPublished,
+  onStartedNewClimb,
 }: UseCreateClimbScreenArgs) {
   const router = useRouter();
   const { t } = useTranslation('climbs');
@@ -232,7 +259,12 @@ export function useCreateClimbScreen({
   // Inline "Start over?" confirm, rendered as sheet content — see handleNewClimb.
   const [pendingNewClimb, setPendingNewClimb] = useState(false);
   const [savedSignature, setSavedSignature] = useState<string | null>(null);
+  const [savedSignatureUnknown, setSavedSignatureUnknown] = useState(false);
   const [failedSignature, setFailedSignature] = useState<string | null>(null);
+  // State updates do not become visible until React renders again. These refs
+  // close the same-tick race between Save and Start new (or two quick taps).
+  const saveInFlightRef = useRef(false);
+  const startNewInFlightRef = useRef(false);
 
   useEffect(() => {
     setSelectedBrush((currentBrush) => {
@@ -266,14 +298,21 @@ export function useCreateClimbScreen({
   // copy lands, never before it.
   const skipRestoreRef = useRef(isForking);
   const restoredRef = useRef(false);
+  const [restoreEpoch, setRestoreEpoch] = useState(0);
   // Stable provisional queue-item uuid for an unsaved WIP, so re-tapping "Set as
   // active" updates the same queue slot instead of appending a new item each tap.
   const previewUuidRef = useRef<string | null>(null);
   if (!previewUuidRef.current) previewUuidRef.current = randomUUID();
   // Tracked so the just-saved confirmation timer is cleared on unmount.
   const justSavedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
+  const markRestored = useCallback(() => {
+    restoredRef.current = true;
+    if (mountedRef.current) setRestoreEpoch((epoch) => epoch + 1);
+  }, []);
   useEffect(
     () => () => {
+      mountedRef.current = false;
       if (justSavedTimerRef.current) clearTimeout(justSavedTimerRef.current);
     },
     [],
@@ -300,6 +339,8 @@ export function useCreateClimbScreen({
     // next Save creates a new climb, clear any stale duplicate banner, and mint
     // a new preview uuid so Set Active pushes an independent queue item.
     setSavedClimb(null);
+    setSavedSignature(null);
+    setSavedSignatureUnknown(false);
     setPublishDuplicateError(null);
     previewUuidRef.current = randomUUID();
   }, [board.angle, isEditing]);
@@ -342,24 +383,110 @@ export function useCreateClimbScreen({
     [loadFrames],
   );
 
+  type EditFailureRestoreState = 'idle' | 'loading' | 'found' | 'empty';
+  const editFailureRestoreStateRef = useRef<EditFailureRestoreState>('idle');
+  const emptyFailureBaselineSignatureRef = useRef<string | null>(null);
+  const [editFailureRestoreState, setEditFailureRestoreState] = useState<EditFailureRestoreState>('idle');
   const editSeededRef = useRef(false);
+
+  // A failed edit query must restore the existing edit slot BEFORE opening the
+  // autosave gate. Otherwise the blank editor's first change overwrites the
+  // only durable copy. Keep the result as state so a later successful retry can
+  // attach the server row without racing or replacing the restored editor.
   useEffect(() => {
-    if (!editClimb || editSeededRef.current) return;
+    if (
+      !isEditing ||
+      !editClimbUuid ||
+      !editClimbFailed ||
+      editSeededRef.current ||
+      editFailureRestoreStateRef.current !== 'idle'
+    ) {
+      return;
+    }
+    editFailureRestoreStateRef.current = 'loading';
+    setEditFailureRestoreState('loading');
+    const signatureBeforeRestore = payloadSignatureRef.current;
+    void loadDraft(createClimbEditDraftKey(board.boardName, editClimbUuid))
+      .then((storedDraft) => {
+        if (!storedDraft) {
+          emptyFailureBaselineSignatureRef.current = signatureBeforeRestore;
+          editFailureRestoreStateRef.current = 'empty';
+          setEditFailureRestoreState('empty');
+          return;
+        }
+        if (payloadSignatureRef.current === signatureBeforeRestore) applyStoredDraft(storedDraft);
+        const restoredSavedClimb = parseSavedClimbSnapshot(storedDraft.savedClimbJson) ?? {
+          uuid: editClimbUuid,
+          boardType: board.boardName,
+          createdAt: null,
+          publishedAt: null,
+          isDraft: storedDraft.isDraft,
+        };
+        setSavedClimb(restoredSavedClimb);
+        setSavedSignature(storedDraft.savedPayloadSignature ?? null);
+        setSavedSignatureUnknown(storedDraft.savedPayloadSignature === undefined);
+        editFailureRestoreStateRef.current = 'found';
+        setEditFailureRestoreState('found');
+      })
+      .catch(() => {
+        emptyFailureBaselineSignatureRef.current = signatureBeforeRestore;
+        editFailureRestoreStateRef.current = 'empty';
+        setEditFailureRestoreState('empty');
+      })
+      .finally(() => {
+        markRestored();
+      });
+  }, [isEditing, editClimbUuid, editClimbFailed, board.boardName, applyStoredDraft, markRestored]);
+
+  useEffect(() => {
+    if (!editClimb || editSeededRef.current || editFailureRestoreState === 'loading') return;
     editSeededRef.current = true;
-    loadFrames(buildInitialFrames(editClimb.frames, board.boardName));
-    setName(editClimb.name);
-    setDescription(withNoMatch(editClimb.description ?? '', false));
-    setNoMatch(isNoMatchClimb(editClimb.description));
-    setNoKickboard(isNoKickboard(editClimb.characteristics));
-    setCampus(isCampus(editClimb.characteristics));
-    setIsDraft(editClimb.is_draft ?? false);
-    setSavedClimb({
+    const serverFrames = buildInitialFrames(editClimb.frames, board.boardName);
+    const serverDescription = withNoMatch(editClimb.description ?? '', false);
+    const serverNoMatch = isNoMatchClimb(editClimb.description);
+    const serverNoKickboard = isNoKickboard(editClimb.characteristics);
+    const serverCampus = isCampus(editClimb.characteristics);
+    const serverIsDraft = editClimb.is_draft ?? false;
+    const serverSignature = createPayloadSignature({
+      holdsJson: JSON.stringify(serverFrames[0] ?? {}),
+      framesJson: JSON.stringify(serverFrames),
+      name: editClimb.name,
+      description: serverDescription,
+      noMatch: serverNoMatch,
+      noKickboard: serverNoKickboard,
+      campus: serverCampus,
+      isDraft: serverIsDraft,
+    });
+    const serverSnapshot: SavedClimbSnapshot = {
       uuid: editClimb.uuid,
       boardType: board.boardName,
       createdAt: editClimb.created_at ?? null,
       publishedAt: editClimb.published_at ?? null,
-      isDraft: editClimb.is_draft ?? false,
-    });
+      isDraft: serverIsDraft,
+    };
+    setSavedClimb(serverSnapshot);
+    setSavedSignature(serverSignature);
+    setSavedSignatureUnknown(false);
+
+    // The failure path already restored the phone copy. A retry may attach the
+    // authoritative server identity and baseline, but must never reseed the
+    // editor and wipe edits made while offline.
+    const editedAfterEmptyFailure =
+      editFailureRestoreState === 'empty' &&
+      emptyFailureBaselineSignatureRef.current !== null &&
+      payloadSignatureRef.current !== emptyFailureBaselineSignatureRef.current;
+    if (editFailureRestoreState === 'found' || editedAfterEmptyFailure) {
+      markRestored();
+      return;
+    }
+
+    loadFrames(serverFrames);
+    setName(editClimb.name);
+    setDescription(serverDescription);
+    setNoMatch(serverNoMatch);
+    setNoKickboard(serverNoKickboard);
+    setCampus(serverCampus);
+    setIsDraft(serverIsDraft);
 
     // ORDERING IS LOAD-BEARING. The `edit:` slot is applied OVER the server copy,
     // and `restoredRef` opens only once that has resolved. Set it any earlier and
@@ -372,51 +499,64 @@ export function useCreateClimbScreen({
     // restore would leave the gate shut and autosave dead for the whole session.
     void loadDraft(createClimbEditDraftKey(board.boardName, editClimb.uuid))
       .then((storedDraft) => {
-        if (storedDraft) applyStoredDraft(storedDraft);
+        if (storedDraft) {
+          applyStoredDraft(storedDraft);
+          setSavedSignature(serverSignature);
+        }
       })
       .catch(() => {
         // Unreadable slot — the server copy stands.
       })
       .finally(() => {
-        restoredRef.current = true;
+        markRestored();
       });
-  }, [editClimb, board.boardName, loadFrames, applyStoredDraft]);
-
-  // If the climb never loads — offline, or the row is gone — the seed effect
-  // above never runs, so the gate it opens would stay shut for the whole session
-  // and autosave would be silently off in exactly the mode this change exists to
-  // fix. Open it on a settled failure so the paint is still kept on the phone.
-  // (A later retry that succeeds still seeds, and its `edit:` slot load then
-  // reapplies whatever was painted in the meantime.)
-  useEffect(() => {
-    if (!isEditing || !editClimbFailed || editSeededRef.current) return;
-    restoredRef.current = true;
-  }, [isEditing, editClimbFailed]);
+  }, [editClimb, editFailureRestoreState, board.boardName, loadFrames, applyStoredDraft, markRestored]);
 
   // ---- Local autosave restore on mount (plain new climb). ----
   useEffect(() => {
     // Edit mode restores inside the seed effect above; forks seed from source.
     if (isEditing || skipRestoreRef.current) {
-      if (!isEditing) restoredRef.current = true;
+      if (!isEditing) markRestored();
       return;
     }
     let cancelled = false;
     void (async () => {
-      let draft = await loadDraft(draftKey);
-      // A killed remix session lives in the fork slot, and a cold relaunch can
-      // only land on the plain creator (the modal route with `forkFrames` is
-      // gone), so this is the only door back to it.
-      if (!draft) draft = await loadDraft(createClimbForkDraftKey(draftKey));
-      if (cancelled || !draft) {
-        restoredRef.current = true;
-        return;
+      try {
+        let draft = await loadDraft(draftKey);
+        // A killed remix session lives in the fork slot, and a cold relaunch can
+        // only land on the plain creator (the modal route with `forkFrames` is
+        // gone), so this is the only door back to it. Adopt it with a write-first
+        // migration: a crash can leave two copies, never zero copies.
+        if (!draft) {
+          const forkSlotKey = createClimbForkDraftKey(draftKey);
+          const forkDraft = await loadDraft(forkSlotKey);
+          if (forkDraft) {
+            await saveDraft(draftKey, forkDraft);
+            draft = forkDraft;
+            try {
+              await clearDraft(forkSlotKey);
+            } catch {
+              // The destination is durable and wins on the next mount. Leave it
+              // intact even if retiring the source needs another attempt.
+            }
+          }
+        }
+        if (cancelled || !draft) return;
+        applyStoredDraft(draft);
+        // Re-attach the server row this working copy belongs to, so the next Save
+        // UPDATES that climb instead of creating a duplicate in Open drafts.
+        const restoredSavedClimb = parseSavedClimbSnapshot(draft.savedClimbJson);
+        if (restoredSavedClimb) {
+          setSavedClimb(restoredSavedClimb);
+          setSavedSignature(draft.savedPayloadSignature ?? null);
+          setSavedSignatureUnknown(draft.savedPayloadSignature === undefined);
+        }
+      } catch {
+        // Storage failure leaves the editor empty but must not disable autosave
+        // for the rest of the session.
+      } finally {
+        if (!cancelled) markRestored();
       }
-      applyStoredDraft(draft);
-      // Re-attach the server row this working copy belongs to, so the next Save
-      // UPDATES that climb instead of creating a duplicate in Open drafts.
-      const restoredSavedClimb = parseSavedClimbSnapshot(draft.savedClimbJson);
-      if (restoredSavedClimb) setSavedClimb(restoredSavedClimb);
-      restoredRef.current = true;
     })();
     return () => {
       cancelled = true;
@@ -435,18 +575,20 @@ export function useCreateClimbScreen({
   // stale save-failure the moment the payload moves, and `handleSave` compares it
   // before and after the round trip so a publish never clears work typed while
   // the mutation was in flight.
-  const payloadSignature = [
+  const payloadSignature = createPayloadSignature({
     holdsJson,
     framesJson,
     name,
     description,
-    noMatch ? '1' : '0',
-    noKickboard ? '1' : '0',
-    campus ? '1' : '0',
-    isDraft ? '1' : '0',
-  ].join(SIGNATURE_SEPARATOR);
+    noMatch,
+    noKickboard,
+    campus,
+    isDraft,
+  });
   const payloadSignatureRef = useRef(payloadSignature);
   payloadSignatureRef.current = payloadSignature;
+  const hasUnsavedEdits =
+    savedClimb != null && (savedSignatureUnknown || (savedSignature !== null && savedSignature !== payloadSignature));
 
   const savedClimbJson = useMemo(() => (savedClimb ? JSON.stringify(savedClimb) : undefined), [savedClimb]);
 
@@ -460,6 +602,7 @@ export function useCreateClimbScreen({
       noKickboard,
       campus,
       savedClimbJson,
+      savedPayloadSignature: savedSignature ?? undefined,
       origin: isEditing ? 'edit' : isForking ? 'fork' : 'new',
       updatedAtMs: Date.now(),
     }),
@@ -473,6 +616,7 @@ export function useCreateClimbScreen({
       campus,
       isDraft,
       savedClimbJson,
+      savedSignature,
       isEditing,
       isForking,
     ],
@@ -480,12 +624,15 @@ export function useCreateClimbScreen({
   const autosaveDraftRef = useRef(autosaveDraft);
   autosaveDraftRef.current = autosaveDraft;
 
-  useCreateClimbAutosave({
+  const { discard: discardAutosaveSlot, persist: persistAutosaveSlot } = useCreateClimbAutosave({
     slotKey: autosaveSlotKey,
     draft: autosaveDraft,
-    draftSignature: `${payloadSignature}${SIGNATURE_SEPARATOR}${savedClimbJson ?? ''}`,
+    // Server-link metadata is written explicitly on Save. Only content changes
+    // re-arm the debounce, avoiding a redundant second write after Save.
+    draftSignature: payloadSignature,
     hasContent,
     restoredRef,
+    restoreEpoch,
   });
 
   // ---- BLE preview (debounced) while connected. ----
@@ -532,29 +679,47 @@ export function useCreateClimbScreen({
     resetHolds();
   }, [resetHolds]);
 
-  const resetToBlankClimb = useCallback(() => {
-    setPendingNewClimb(false);
-    resetHolds();
-    setName('');
-    setDescription('');
-    setNoMatch(false);
-    setNoKickboard(false);
-    setCampus(false);
-    setIsDraft(true);
-    setSavedClimb(null);
-    setPublishDuplicateError(null);
-    setSavedSignature(null);
-    setFailedSignature(null);
-    // Fresh climb identity for the next WIP so its queue item is independent.
-    previewUuidRef.current = randomUUID();
+  const resetToBlankClimb = useCallback(async () => {
     // Drop the working copy THIS session owns — in fork/edit mode that is the
     // `fork:`/`edit:` slot, not the shared new-climb one. Clearing only
     // `draftKey` left an abandoned fork slot behind, which the plain creator's
     // fork fallback would then resurrect as a ghost draft on the next open. A
     // server draft is untouched either way: it lives in board_climbs, not here,
     // so an edit session still leaves its row in Open drafts.
-    void clearDraft(autosaveSlotKey);
-  }, [resetHolds, autosaveSlotKey]);
+    try {
+      await discardAutosaveSlot();
+      if (!mountedRef.current) return;
+      setPendingNewClimb(false);
+      resetHolds();
+      setName('');
+      setDescription('');
+      setNoMatch(false);
+      setNoKickboard(false);
+      setCampus(false);
+      setIsDraft(true);
+      setSavedClimb(null);
+      setPublishDuplicateError(null);
+      setSavedSignature(null);
+      setSavedSignatureUnknown(false);
+      setFailedSignature(null);
+      // Fresh climb identity for the next WIP so its queue item is independent.
+      previewUuidRef.current = randomUUID();
+      if (isEditing || isForking) onStartedNewClimb?.();
+    } catch {
+      // Keep the editor and confirmation intact when storage cannot retire the
+      // slot. Resetting anyway would let that supposedly abandoned work restore
+      // as a ghost draft on the next mount; clearing the in-flight ref below
+      // leaves the action retryable.
+    } finally {
+      startNewInFlightRef.current = false;
+    }
+  }, [resetHolds, discardAutosaveSlot, isEditing, isForking, onStartedNewClimb]);
+
+  const confirmNewClimb = useCallback(() => {
+    if (saveInFlightRef.current || startNewInFlightRef.current) return;
+    startNewInFlightRef.current = true;
+    void resetToBlankClimb();
+  }, [resetToBlankClimb]);
 
   /**
    * Park this climb and start a blank one. A saved climb keeps its row in Open
@@ -565,12 +730,14 @@ export function useCreateClimbScreen({
    * button doing nothing at all. See InlineConfirmBanner.
    */
   const handleNewClimb = useCallback(() => {
-    if (savedClimb == null && hasContent) {
+    if (saveInFlightRef.current || startNewInFlightRef.current) return;
+    if (hasContent && (savedClimb == null || hasUnsavedEdits)) {
       setPendingNewClimb(true);
       return;
     }
-    resetToBlankClimb();
-  }, [savedClimb, hasContent, resetToBlankClimb]);
+    startNewInFlightRef.current = true;
+    void resetToBlankClimb();
+  }, [savedClimb, hasContent, hasUnsavedEdits, resetToBlankClimb]);
 
   const cancelNewClimb = useCallback(() => setPendingNewClimb(false), []);
 
@@ -693,7 +860,6 @@ export function useCreateClimbScreen({
   // status line names the missing requirement directly under the button.
   const publishBlocked = !isDraft && hasContent && !canPublish;
   const localPersistenceAvailable = isDraftStorageAvailable();
-  const hasUnsavedEdits = savedClimb != null && savedSignature !== null && savedSignature !== payloadSignature;
   const saveFailed = failedSignature !== null && failedSignature === payloadSignature;
 
   const draftStatus: DraftStatusView | null = useMemo(
@@ -718,6 +884,7 @@ export function useCreateClimbScreen({
   const requestFocusName = useCallback(() => setFocusNameSignal((value) => value + 1), []);
 
   const handleSave = useCallback(async () => {
+    if (saveInFlightRef.current || startNewInFlightRef.current) return;
     if (!isAuthenticated) {
       router.push('/auth/login');
       return;
@@ -730,6 +897,7 @@ export function useCreateClimbScreen({
       return;
     }
 
+    saveInFlightRef.current = true;
     setIsSaving(true);
     setPublishDuplicateError(null);
     // Captured BEFORE the mutation fires. Anything typed during the round trip
@@ -814,16 +982,23 @@ export function useCreateClimbScreen({
       // so nothing ever wrote it back. Now the slot IS the working copy, and only
       // a PUBLISH retires it — under a compare-and-clear, so anything typed during
       // the round trip survives.
-      if (isDraft) {
-        await saveDraft(autosaveSlotKey, {
+      const payloadChangedDuringSave = payloadSignatureRef.current !== signatureAtSave;
+      if (isDraft || payloadChangedDuringSave) {
+        // The explicit linked write is authoritative. Retire any older debounce
+        // first so it cannot finish later and overwrite the server-row link or
+        // the payload baseline this save just established.
+        await persistAutosaveSlot({
           ...autosaveDraftRef.current,
           savedClimbJson: nextSavedClimb ? JSON.stringify(nextSavedClimb) : undefined,
+          savedPayloadSignature: signatureAtSave,
         });
-      } else if (payloadSignatureRef.current === signatureAtSave) {
-        await clearDraft(autosaveSlotKey);
+      } else {
+        await discardAutosaveSlot();
       }
+      setPendingNewClimb(false);
       setFailedSignature(null);
       setSavedSignature(signatureAtSave);
+      setSavedSignatureUnknown(false);
       // Refresh the inline Open Drafts table AND the Climbs tab's infinite list
       // so the just-saved climb appears / updates (mirrors useDeleteDraftClimb's
       // key set in lib/graphql/hooks/index.ts — create, edit, and publish-draft
@@ -858,6 +1033,7 @@ export function useCreateClimbScreen({
         showToast(t('createClimbForm.alerts.saveFailedFallback'), 'error');
       }
     } finally {
+      saveInFlightRef.current = false;
       setIsSaving(false);
     }
   }, [
@@ -881,6 +1057,8 @@ export function useCreateClimbScreen({
     campus,
     isDraft,
     autosaveSlotKey,
+    discardAutosaveSlot,
+    persistAutosaveSlot,
     requestFocusName,
     syncSavedToQueue,
     showToast,
@@ -923,7 +1101,7 @@ export function useCreateClimbScreen({
     handleClearHolds,
     handleNewClimb,
     pendingNewClimb,
-    confirmNewClimb: resetToBlankClimb,
+    confirmNewClimb,
     cancelNewClimb,
     showAllHolds,
     setShowAllHolds,

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -29,7 +29,6 @@ import { useProfile, useClimb } from '../../lib/graphql/hooks';
 import { useQueueActions } from '../../providers/queue-provider';
 import { useOptionalBluetoothContext } from '../../providers/bluetooth-provider';
 import { useToast } from '../../providers/toast-provider';
-import { useConfirm } from '../../providers/dialog-provider';
 import { climbToQueueItem } from '../../lib/climb-to-queue-item';
 import {
   loadDraft,
@@ -163,7 +162,6 @@ export function useCreateClimbScreen({
   const { setCurrentClimb } = useQueueActions();
   const bluetooth = useOptionalBluetoothContext();
   const { showToast } = useToast();
-  const confirm = useConfirm();
   const queryClient = useQueryClient();
 
   const isForking = !!forkFrames;
@@ -231,6 +229,8 @@ export function useCreateClimbScreen({
   // Payload signature at the last SUCCESSFUL explicit save, and at the last
   // FAILED one. Both are compared against the live signature below, which is how
   // "edited since you saved" and "that save failed" stay true without a timer.
+  // Inline "Start over?" confirm, rendered as sheet content — see handleNewClimb.
+  const [pendingNewClimb, setPendingNewClimb] = useState(false);
   const [savedSignature, setSavedSignature] = useState<string | null>(null);
   const [failedSignature, setFailedSignature] = useState<string | null>(null);
 
@@ -532,22 +532,8 @@ export function useCreateClimbScreen({
     resetHolds();
   }, [resetHolds]);
 
-  /**
-   * Park this climb and start a blank one. A saved climb keeps its row in Open
-   * drafts (only the new-climb slot is dropped, never an `edit:` slot). An unsaved
-   * one genuinely is not recoverable, so that case — and only that case — confirms.
-   */
-  const handleNewClimb = useCallback(async () => {
-    if (savedClimb == null && hasContent) {
-      const confirmed = await confirm({
-        title: t('mobile.create.newClimb.confirm.title'),
-        message: t('mobile.create.newClimb.confirm.message'),
-        confirmLabel: t('mobile.create.newClimb.confirm.action'),
-        cancelLabel: t('createClimbForm.dismiss'),
-        destructive: true,
-      });
-      if (!confirmed) return;
-    }
+  const resetToBlankClimb = useCallback(() => {
+    setPendingNewClimb(false);
     resetHolds();
     setName('');
     setDescription('');
@@ -568,7 +554,25 @@ export function useCreateClimbScreen({
     // server draft is untouched either way: it lives in board_climbs, not here,
     // so an edit session still leaves its row in Open drafts.
     void clearDraft(autosaveSlotKey);
-  }, [resetHolds, autosaveSlotKey, savedClimb, hasContent, confirm, t]);
+  }, [resetHolds, autosaveSlotKey]);
+
+  /**
+   * Park this climb and start a blank one. A saved climb keeps its row in Open
+   * drafts (only the working slot is dropped), so that case goes straight
+   * through. An unsaved one genuinely is not recoverable, so it asks first —
+   * INLINE, not through `useConfirm`: a dialog raised from inside this native
+   * sheet is invisible on Android and its promise never resolves, which left this
+   * button doing nothing at all. See InlineConfirmBanner.
+   */
+  const handleNewClimb = useCallback(() => {
+    if (savedClimb == null && hasContent) {
+      setPendingNewClimb(true);
+      return;
+    }
+    resetToBlankClimb();
+  }, [savedClimb, hasContent, resetToBlankClimb]);
+
+  const cancelNewClimb = useCallback(() => setPendingNewClimb(false), []);
 
   // Build a minimal Climb the queue can hold for a not-yet-saved or just-saved
   // climb. The mutation input (`ClimbInput`) is a strict subset of Climb, so
@@ -918,6 +922,9 @@ export function useCreateClimbScreen({
     handleAssignRole,
     handleClearHolds,
     handleNewClimb,
+    pendingNewClimb,
+    confirmNewClimb: resetToBlankClimb,
+    cancelNewClimb,
     showAllHolds,
     setShowAllHolds,
     // frames (route/circuit editing)

--- a/packages/mobile/src/components/create-climb/use-rate-limited-announcer.ts
+++ b/packages/mobile/src/components/create-climb/use-rate-limited-announcer.ts
@@ -1,0 +1,38 @@
+// One rate-limited voice for the create drawer.
+//
+// The alternative — an `accessibilityLiveRegion="polite"` on the status line —
+// is a trap here: the autosave is debounced at 500ms and its state flips while
+// you paint and while you type, so a polite region re-announces on every
+// keystroke and every hold tap. That makes the sheet unusable with TalkBack /
+// VoiceOver on, which is a worse bug than the one being fixed.
+//
+// So the line's live region is explicitly `none` and transitions that change the
+// answer are spoken through here instead, at most one every 10 seconds, never
+// twice in a row with the same words.
+
+import { useCallback, useRef } from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+export const ANNOUNCE_MIN_INTERVAL_MS = 10_000;
+
+/**
+ * Returns a stable `announce(text)` that speaks at most once per
+ * `minIntervalMs`, dropping repeats of the sentence it last spoke.
+ */
+export function useRateLimitedAnnouncer(minIntervalMs: number = ANNOUNCE_MIN_INTERVAL_MS): (text: string) => void {
+  const lastAnnouncedAtRef = useRef(0);
+  const lastTextRef = useRef<string | null>(null);
+
+  return useCallback(
+    (text: string) => {
+      if (!text) return;
+      if (text === lastTextRef.current) return;
+      const now = Date.now();
+      if (now - lastAnnouncedAtRef.current < minIntervalMs) return;
+      lastAnnouncedAtRef.current = now;
+      lastTextRef.current = text;
+      AccessibilityInfo.announceForAccessibility(text);
+    },
+    [minIntervalMs],
+  );
+}

--- a/packages/mobile/src/components/create-climb/use-rate-limited-announcer.ts
+++ b/packages/mobile/src/components/create-climb/use-rate-limited-announcer.ts
@@ -10,29 +10,65 @@
 // answer are spoken through here instead, at most one every 10 seconds, never
 // twice in a row with the same words.
 
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { AccessibilityInfo } from 'react-native';
 
 export const ANNOUNCE_MIN_INTERVAL_MS = 10_000;
 
 /**
- * Returns a stable `announce(text)` that speaks at most once per
- * `minIntervalMs`, dropping repeats of the sentence it last spoke.
+ * Returns an `announce(text)` that speaks at most once per `minIntervalMs`.
+ * During the cooldown it keeps only the latest distinct sentence and speaks it
+ * at the trailing edge, so a meaningful final state is delayed rather than lost.
  */
 export function useRateLimitedAnnouncer(minIntervalMs: number = ANNOUNCE_MIN_INTERVAL_MS): (text: string) => void {
   const lastAnnouncedAtRef = useRef(0);
   const lastTextRef = useRef<string | null>(null);
+  const pendingTextRef = useRef<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearPending = useCallback(() => {
+    pendingTextRef.current = null;
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }, []);
+
+  useEffect(() => clearPending, [clearPending]);
 
   return useCallback(
     (text: string) => {
-      if (!text) return;
-      if (text === lastTextRef.current) return;
+      if (!text) {
+        clearPending();
+        return;
+      }
+      if (text === lastTextRef.current) {
+        // The status returned to what was already announced. Any different
+        // queued status is now stale and must not be spoken later.
+        clearPending();
+        return;
+      }
+      if (text === pendingTextRef.current) return;
       const now = Date.now();
-      if (now - lastAnnouncedAtRef.current < minIntervalMs) return;
-      lastAnnouncedAtRef.current = now;
-      lastTextRef.current = text;
-      AccessibilityInfo.announceForAccessibility(text);
+      const elapsedMs = now - lastAnnouncedAtRef.current;
+      if (elapsedMs >= minIntervalMs) {
+        clearPending();
+        lastAnnouncedAtRef.current = now;
+        lastTextRef.current = text;
+        AccessibilityInfo.announceForAccessibility(text);
+        return;
+      }
+
+      pendingTextRef.current = text;
+      if (timerRef.current) return;
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        const pendingText = pendingTextRef.current;
+        pendingTextRef.current = null;
+        if (!pendingText || pendingText === lastTextRef.current) return;
+        lastAnnouncedAtRef.current = Date.now();
+        lastTextRef.current = pendingText;
+        AccessibilityInfo.announceForAccessibility(pendingText);
+      }, minIntervalMs - elapsedMs);
     },
-    [minIntervalMs],
+    [clearPending, minIntervalMs],
   );
 }

--- a/packages/mobile/src/lib/__tests__/create-climb-draft-store.test.ts
+++ b/packages/mobile/src/lib/__tests__/create-climb-draft-store.test.ts
@@ -67,4 +67,66 @@ describe('createClimbDraftKey', () => {
     await expect(loadDraft('first-board')).resolves.toBeNull();
     await expect(loadDraft('second-board')).resolves.toBeNull();
   });
+
+  it('round-trips the edit and fork slots alongside the new-climb one', async () => {
+    const { saveDraft, loadDraft, createClimbEditDraftKey, createClimbForkDraftKey } =
+      await import('../create-climb-draft-store');
+    const newClimbKey = createClimbDraftKey(base);
+    const editKey = createClimbEditDraftKey('kilter', 'climb-9');
+    const forkKey = createClimbForkDraftKey(newClimbKey);
+
+    // Identity lives in the key, which is what lets all three autosave at once
+    // without any of them clobbering another.
+    expect(editKey).toBe('edit:kilter:climb-9');
+    expect(forkKey).toBe(`fork:${newClimbKey}`);
+    expect(new Set([newClimbKey, editKey, forkKey]).size).toBe(3);
+
+    await saveDraft(newClimbKey, { holdsJson: '{}', name: 'New', description: '', isDraft: true });
+    await saveDraft(editKey, { holdsJson: '{}', name: 'Edit', description: '', isDraft: true });
+    await saveDraft(forkKey, { holdsJson: '{}', name: 'Fork', description: '', isDraft: true });
+
+    await expect(loadDraft(newClimbKey)).resolves.toMatchObject({ name: 'New' });
+    await expect(loadDraft(editKey)).resolves.toMatchObject({ name: 'Edit' });
+    await expect(loadDraft(forkKey)).resolves.toMatchObject({ name: 'Fork' });
+  });
+
+  it('sweeps all three key shapes on account cleanup', async () => {
+    const { saveDraft, loadDraft, clearAllCreateClimbDrafts, createClimbEditDraftKey, createClimbForkDraftKey } =
+      await import('../create-climb-draft-store');
+    const keys = [
+      createClimbDraftKey(base),
+      createClimbEditDraftKey('kilter', 'climb-9'),
+      createClimbForkDraftKey('k'),
+    ];
+    for (const key of keys) {
+      await saveDraft(key, { holdsJson: '{}', name: key, description: '', isDraft: true });
+    }
+
+    await clearAllCreateClimbDrafts();
+
+    for (const key of keys) {
+      await expect(loadDraft(key)).resolves.toBeNull();
+    }
+  });
+
+  it('still loads a payload stored in the original four-field shape', async () => {
+    // The no-migration guarantee: every field added since is optional, and the
+    // new-climb key string never changed, so drafts already on devices restore.
+    const { saveDraft, loadDraft } = await import('../create-climb-draft-store');
+    const key = createClimbDraftKey(base);
+    await saveDraft(key, { holdsJson: '{"1":{"state":"HAND"}}', name: 'Legacy', description: '', isDraft: true });
+
+    await expect(loadDraft(key)).resolves.toEqual({
+      holdsJson: '{"1":{"state":"HAND"}}',
+      name: 'Legacy',
+      description: '',
+      isDraft: true,
+    });
+  });
+
+  it('always reports storage as available on native', async () => {
+    const { isDraftStorageAvailable } = await import('../create-climb-draft-store');
+    expect(isDraftStorageAvailable()).toBe(true);
+    expect(isDraftStorageAvailable(null)).toBe(true);
+  });
 });

--- a/packages/mobile/src/lib/__tests__/create-climb-screen-key.test.ts
+++ b/packages/mobile/src/lib/__tests__/create-climb-screen-key.test.ts
@@ -31,4 +31,9 @@ describe('createClimbScreenKey', () => {
     expect(createClimbScreenKey('uuid-a', kilter)).not.toBe(createClimbScreenKey('uuid-b', kilter));
     expect(createClimbScreenKey(undefined, kilter)).toBe(createClimbScreenKey('new', kilter));
   });
+
+  it('remounts when leaving a fork for a plain new climb', () => {
+    expect(createClimbScreenKey(undefined, kilter, 'p1r12')).not.toBe(createClimbScreenKey(undefined, kilter));
+    expect(createClimbScreenKey(undefined, kilter, 'p1r12')).toBe(createClimbScreenKey(undefined, kilter, 'p1r12'));
+  });
 });

--- a/packages/mobile/src/lib/__tests__/user-scoped-draft-stores.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/user-scoped-draft-stores.web.test.ts
@@ -73,6 +73,24 @@ describe('browser user-scoped draft stores', () => {
     await expect(loadDraft(boardKey)).resolves.toEqual(draft);
   });
 
+  it('reports storage as unavailable with no signed-in owner, and writes nothing', async () => {
+    // Every browser write is account-scoped, so a signed-out visitor stores
+    // nothing at all. The status line reads this so it can say "Sign in to keep
+    // this draft" instead of promising a draft that was never written.
+    const { isDraftStorageAvailable, saveDraft, loadDraft } = await import('../create-climb-draft-store.web');
+    const { setCurrentUserStorageOwner } = await import('../user-storage-owner.web');
+
+    setCurrentUserStorageOwner(null);
+    expect(isDraftStorageAvailable()).toBe(false);
+    await saveDraft('kilter:1:2:10:40', { holdsJson: '{}', name: 'Anonymous', description: '', isDraft: true });
+    await expect(loadDraft('kilter:1:2:10:40')).resolves.toBeNull();
+
+    setCurrentUserStorageOwner(userASessionOne);
+    expect(isDraftStorageAvailable()).toBe(true);
+    // ...and the signed-out attempt left nothing behind for the account either.
+    await expect(loadDraft('kilter:1:2:10:40')).resolves.toBeNull();
+  });
+
   it('does not expose user A recap draft to user B for the same session', async () => {
     const { setDraftComment, getDraftComment } = await import('../session-comment-draft-store.web');
     const { setCurrentUserStorageOwner } = await import('../user-storage-owner.web');

--- a/packages/mobile/src/lib/__tests__/user-scoped-draft-stores.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/user-scoped-draft-stores.web.test.ts
@@ -33,6 +33,23 @@ async function resetStorage(): Promise<void> {
   storage.__reset();
 }
 
+// The two platform forks declare `CreateClimbDraft` independently, so tsc sees no
+// relationship between them and silent drift is possible — it has already
+// happened once (the web fork was missing `framesJson` while round-tripping it at
+// runtime). This is a compile-time equality check, not a runtime assertion: add a
+// field to one fork and `vp run typecheck:mobile` fails here.
+type NativeCreateClimbDraft = import('../create-climb-draft-store').CreateClimbDraft;
+type WebCreateClimbDraft = import('../create-climb-draft-store.web').CreateClimbDraft;
+// Compare the KEY SETS, not just assignability: every field here is optional
+// except the original four, and an optional field present on one side only is
+// still mutually assignable — which is precisely the drift that happened.
+type SameKeys<A, B> = [keyof A] extends [keyof B] ? ([keyof B] extends [keyof A] ? true : false) : false;
+type MutuallyAssignable<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+const createClimbDraftKeysMatch: SameKeys<NativeCreateClimbDraft, WebCreateClimbDraft> = true;
+const createClimbDraftTypesMatch: MutuallyAssignable<NativeCreateClimbDraft, WebCreateClimbDraft> = true;
+void createClimbDraftKeysMatch;
+void createClimbDraftTypesMatch;
+
 describe('browser user-scoped draft stores', () => {
   beforeEach(async () => {
     vi.resetModules();

--- a/packages/mobile/src/lib/create-climb-draft-store.ts
+++ b/packages/mobile/src/lib/create-climb-draft-store.ts
@@ -10,6 +10,9 @@
 import { getPreference, setPreference, removePreference, removePreferencesMatching } from './preference-store';
 import type { UserStorageOwner } from './user-storage-owner';
 
+/** Which authoring mode wrote this slot. Diagnostic only — the key decides. */
+export type CreateClimbDraftOrigin = 'new' | 'edit' | 'fork';
+
 export type CreateClimbDraft = {
   /**
    * JSON.stringify of the editor's active-frame LitUpHoldsMap. Kept for
@@ -27,6 +30,17 @@ export type CreateClimbDraft = {
   noKickboard?: boolean;
   /** "Campus" toggle — no feet at all. Optional for the same back-compat reason. */
   campus?: boolean;
+  /**
+   * JSON.stringify of the `SavedClimbSnapshot` this working copy is attached to,
+   * once it has been saved to the server at least once. Restoring it re-links a
+   * cold-started session to its row, so the next Save UPDATES that climb instead
+   * of creating a duplicate. Absent for a never-saved WIP.
+   */
+  savedClimbJson?: string;
+  /** Which authoring mode wrote this payload. Diagnostic; not read on restore. */
+  origin?: CreateClimbDraftOrigin;
+  /** Wall-clock of the last content change. Diagnostic; not rendered (no `updated_at` on Climb to be honest against). */
+  updatedAtMs?: number;
 };
 
 const KEY_PREFIX = 'boardsesh_create_climb_draft:';
@@ -49,10 +63,42 @@ export function createClimbDraftKey(config: {
   return `${config.boardName}:${config.layoutId}:${config.sizeId}:${config.setIds}:${config.angle}`;
 }
 
+/**
+ * Slot for editing one existing climb. Identity is in the KEY, so an edit
+ * session can autosave without ever colliding with the board-config-keyed
+ * new-climb slot — which is what forced autosave off in edit mode before.
+ * Deterministic, so reopening the same climb finds it with no stored pointer.
+ */
+export function createClimbEditDraftKey(boardType: string, uuid: string): string {
+  return `edit:${boardType}:${uuid}`;
+}
+
+/**
+ * Slot for a remix/fork session, one per board config. Separate from the
+ * new-climb slot so opening a fork can't clobber a real new-climb WIP, and
+ * restorable from a plain creator mount after the app is killed.
+ */
+export function createClimbForkDraftKey(boardKey: string): string {
+  return `fork:${boardKey}`;
+}
+
+/**
+ * Whether this platform can actually persist a draft right now. Always true on
+ * native; the browser fork returns false for a signed-out visitor, whose writes
+ * are silently dropped. The status line reads this so it never claims a draft is
+ * "saved on this phone" when nothing was written.
+ */
+export function isDraftStorageAvailable(_owner?: UserStorageOwner | null): boolean {
+  return true;
+}
+
 function storageKey(boardKey: string): string {
   return `${KEY_PREFIX}${boardKey}`;
 }
 
+// Requires only the four fields the ORIGINAL payload shape carried, so every
+// draft already sitting on a device keeps validating and restoring. Every field
+// added since is optional — do not tighten this without a migration.
 function isCreateClimbDraft(value: unknown): value is CreateClimbDraft {
   if (value == null || typeof value !== 'object') return false;
   const candidate = value as Partial<CreateClimbDraft>;

--- a/packages/mobile/src/lib/create-climb-draft-store.ts
+++ b/packages/mobile/src/lib/create-climb-draft-store.ts
@@ -37,6 +37,11 @@ export type CreateClimbDraft = {
    * of creating a duplicate. Absent for a never-saved WIP.
    */
   savedClimbJson?: string;
+  /**
+   * Payload signature at the last successful server save. Restoring it lets the
+   * editor distinguish the account copy from newer phone-only edits.
+   */
+  savedPayloadSignature?: string;
   /** Which authoring mode wrote this payload. Diagnostic; not read on restore. */
   origin?: CreateClimbDraftOrigin;
   /** Wall-clock of the last content change. Diagnostic; not rendered (no `updated_at` on Climb to be honest against). */

--- a/packages/mobile/src/lib/create-climb-draft-store.web.ts
+++ b/packages/mobile/src/lib/create-climb-draft-store.web.ts
@@ -15,6 +15,10 @@ export type CreateClimbDraft = {
   name: string;
   description: string;
   isDraft: boolean;
+  /** "No kickboard" toggle. Optional for drafts created before this field. */
+  noKickboard?: boolean;
+  /** "Campus" toggle. Optional for drafts created before this field. */
+  campus?: boolean;
   /** JSON.stringify of the attached `SavedClimbSnapshot`. See the native fork. */
   savedClimbJson?: string;
   /** Payload signature at the last successful server save. See the native fork. */

--- a/packages/mobile/src/lib/create-climb-draft-store.web.ts
+++ b/packages/mobile/src/lib/create-climb-draft-store.web.ts
@@ -2,12 +2,23 @@ import { getPreference, removePreference, removePreferencesMatching, setPreferen
 import type { UserStorageOwner } from './user-storage-owner';
 import { userScopedStorageKey } from './user-storage-owner.web';
 
+/** Which authoring mode wrote this slot. Diagnostic only — the key decides. */
+export type CreateClimbDraftOrigin = 'new' | 'edit' | 'fork';
+
+// Mirrors the native shape field for field. `framesJson` round-tripped here all
+// along (the validator ignores unknown keys) but was missing from the type.
 export type CreateClimbDraft = {
-  /** JSON.stringify of the editor's LitUpHoldsMap. */
+  /** JSON.stringify of the editor's active-frame LitUpHoldsMap. */
   holdsJson: string;
+  /** JSON.stringify(LitUpHoldsMap[]) — the full frame sequence. */
+  framesJson?: string;
   name: string;
   description: string;
   isDraft: boolean;
+  /** JSON.stringify of the attached `SavedClimbSnapshot`. See the native fork. */
+  savedClimbJson?: string;
+  origin?: CreateClimbDraftOrigin;
+  updatedAtMs?: number;
 };
 
 const KEY_PREFIX = 'boardsesh_create_climb_draft:';
@@ -20,6 +31,24 @@ export function createClimbDraftKey(config: {
   angle: number;
 }): string {
   return `${config.boardName}:${config.layoutId}:${config.sizeId}:${config.setIds}:${config.angle}`;
+}
+
+/** See the native fork — one deterministic slot per authoring mode. */
+export function createClimbEditDraftKey(boardType: string, uuid: string): string {
+  return `edit:${boardType}:${uuid}`;
+}
+
+export function createClimbForkDraftKey(boardKey: string): string {
+  return `fork:${boardKey}`;
+}
+
+/**
+ * False for a signed-out browser visitor: every write here is account-scoped and
+ * `userScopedStorageKey` returns null with no owner, so nothing is stored at all.
+ * The status line reads this instead of promising a draft that was never written.
+ */
+export function isDraftStorageAvailable(owner?: UserStorageOwner | null): boolean {
+  return userScopedStorageKey('', owner) !== null;
 }
 
 function storageKey(boardKey: string): string {

--- a/packages/mobile/src/lib/create-climb-draft-store.web.ts
+++ b/packages/mobile/src/lib/create-climb-draft-store.web.ts
@@ -17,6 +17,8 @@ export type CreateClimbDraft = {
   isDraft: boolean;
   /** JSON.stringify of the attached `SavedClimbSnapshot`. See the native fork. */
   savedClimbJson?: string;
+  /** Payload signature at the last successful server save. See the native fork. */
+  savedPayloadSignature?: string;
   origin?: CreateClimbDraftOrigin;
   updatedAtMs?: number;
 };

--- a/packages/mobile/src/lib/create-climb-screen-key.ts
+++ b/packages/mobile/src/lib/create-climb-screen-key.ts
@@ -10,9 +10,9 @@ type CreateClimbKeyBoard = {
 /**
  * React `key` for the mounted CreateClimbScreen.
  *
- * Keyed on the edited climb (so switching drafts remounts with a fresh undo
- * history) AND on the board's hold-identity tuple (boardName/layoutId/sizeId/
- * setIds). The hook seeds its holds reducer once at mount and never re-sanitizes
+ * Keyed on the authoring mode (so edit/fork/new transitions remount with a fresh
+ * undo history) AND on the board's hold-identity tuple (boardName/layoutId/
+ * sizeId/setIds). The hook seeds its holds reducer once at mount and never re-sanitizes
  * the painted holds when the board changes, so a board switch under a bare-open
  * create screen (active-board fallback) must remount to drop holds that don't
  * exist on the new layout/size and to re-run the per-board draft restore.
@@ -21,6 +21,12 @@ type CreateClimbKeyBoard = {
  * board's angle, and an angle-only remount would wipe an in-progress paint.
  * Angle does not affect which holds are valid.
  */
-export function createClimbScreenKey(editClimbUuid: string | undefined, board: CreateClimbKeyBoard): string {
-  return `${editClimbUuid ?? 'new'}:${board.boardName}:${board.layoutId}:${board.sizeId}:${board.setIds}`;
+export function createClimbScreenKey(
+  editClimbUuid: string | undefined,
+  board: CreateClimbKeyBoard,
+  forkFrames?: string,
+): string {
+  const authoringIdentity =
+    editClimbUuid && editClimbUuid !== 'new' ? `edit:${editClimbUuid}` : forkFrames ? 'fork' : 'new';
+  return `${authoringIdentity}:${board.boardName}:${board.layoutId}:${board.sizeId}:${board.setIds}`;
 }

--- a/packages/shared/create-climb-react/src/__tests__/use-create-climb.test.ts
+++ b/packages/shared/create-climb-react/src/__tests__/use-create-climb.test.ts
@@ -399,6 +399,21 @@ describe('useCreateClimb', () => {
       expect(result.current.totalHolds).toBe(2);
       expect(result.current.isValid).toBe(true);
     });
+
+    it('allows publishing when the same hold has start and finish roles in different frames', () => {
+      const initialFrames: LitUpHoldsMap[] = [
+        { 100: { state: 'STARTING', color: '#00FF00', displayColor: '#00FF00' } },
+        { 100: { state: 'FINISH', color: '#FF00FF', displayColor: '#FF00FF' } },
+      ];
+
+      const { result } = renderHook(() => useCreateClimb('kilter', { initialFrames }));
+
+      // The flattened union contains only the later FINISH state. Publish
+      // validity must inspect every frame or it loses the earlier STARTING role.
+      expect(result.current.startingCount).toBe(0);
+      expect(result.current.finishCount).toBe(1);
+      expect(result.current.canPublish).toBe(true);
+    });
   });
 
   describe('initialFrames', () => {

--- a/packages/shared/create-climb-react/src/use-create-climb.ts
+++ b/packages/shared/create-climb-react/src/use-create-climb.ts
@@ -223,7 +223,18 @@ export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOpt
 
   const totalHolds = useMemo(() => Object.values(unionHolds).filter((h) => h.state !== 'OFF').length, [unionHolds]);
 
-  const isValid = totalHolds > 0;
+  // Two thresholds, deliberately different, because the destinations carry
+  // different risk:
+  //  - `canSave` keeps a private draft cheap. Any painted hold is worth keeping,
+  //    and tightening it would regress every draft that saves today.
+  //  - `canPublish` gates the PUBLIC transition. Nothing else checks starts and
+  //    finishes — SaveClimbInputSchema wants only a name and one non-empty frame
+  //    — so without this a one-hold blob is one tap from being a public climb.
+  const canSave = totalHolds > 0;
+  const canPublish = startingCount >= 1 && finishCount >= 1;
+
+  /** Alias of `canSave`, kept for existing callers. Prefer `canSave` / `canPublish`. */
+  const isValid = canSave;
 
   const setHoldState = useCallback(
     (holdId: number, nextState: HoldState | 'OFF') => {
@@ -337,6 +348,8 @@ export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOpt
     finishCount,
     totalHolds,
     isValid,
+    canSave,
+    canPublish,
     resetHolds,
     loadHolds,
     loadFrames,

--- a/packages/shared/create-climb-react/src/use-create-climb.ts
+++ b/packages/shared/create-climb-react/src/use-create-climb.ts
@@ -230,8 +230,22 @@ export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOpt
   //  - `canPublish` gates the PUBLIC transition. Nothing else checks starts and
   //    finishes — SaveClimbInputSchema wants only a name and one non-empty frame
   //    — so without this a one-hold blob is one tap from being a public climb.
+  // Scan the frames themselves rather than the flattened union. A hold can
+  // legitimately change from STARTING in one frame to FINISH in a later frame;
+  // the union keeps only its last state and would incorrectly reject that route.
   const canSave = totalHolds > 0;
-  const canPublish = startingCount >= 1 && finishCount >= 1;
+  const canPublish = useMemo(() => {
+    let hasStartingHold = false;
+    let hasFinishHold = false;
+    for (const frame of history.present) {
+      for (const hold of Object.values(frame)) {
+        if (hold.state === 'STARTING') hasStartingHold = true;
+        if (hold.state === 'FINISH') hasFinishHold = true;
+        if (hasStartingHold && hasFinishHold) return true;
+      }
+    }
+    return false;
+  }, [history.present]);
 
   /** Alias of `canSave`, kept for existing callers. Prefer `canSave` / `canPublish`. */
   const isValid = canSave;

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -505,7 +505,10 @@
         "clear": "Griffe entfernen",
         "setActive": "Als aktiven Boulder setzen",
         "undo": "Rückgängig",
-        "redo": "Wiederholen"
+        "redo": "Wiederholen",
+        "newClimb": "Neuen Boulder erstellen",
+        "close": "Schließen",
+        "closeHint": "Dein Entwurf bleibt auf diesem Handy."
       },
       "frames": {
         "duplicate": "Bild duplizieren",
@@ -533,7 +536,9 @@
       "drafts": {
         "holds_one": "{{count}} Griff",
         "holds_other": "{{count}} Griffe",
-        "sectionTitle": "Entwürfe öffnen"
+        "sectionTitle": "Offene Entwürfe",
+        "frames_one": "{{count}} Frame",
+        "frames_other": "{{count}} Frames"
       },
       "unavailable": {
         "title": "Hier lässt sich noch nichts bauen",
@@ -552,6 +557,24 @@
         "done": "Gespeichert",
         "draftToast": "Entwurf gespeichert",
         "publishedToast": "Boulder veröffentlicht"
+      },
+      "autosave": {
+        "onDevice": "Auf diesem Handy gespeichert",
+        "inAccount": "Entwurf in deinem Konto gespeichert",
+        "unsyncedEdits": "Die neuesten Änderungen sind nur auf diesem Handy",
+        "notStored": "Melde dich an, um diesen Entwurf zu behalten",
+        "saveFailed": "Speichern in deinem Konto fehlgeschlagen. Tippe auf Speichern, um es nochmal zu versuchen.",
+        "keptToast": "Entwurf auf diesem Handy behalten. Öffne den Editor wieder, um ihn fertig zu machen."
+      },
+      "newClimb": {
+        "confirm": {
+          "title": "Neu anfangen?",
+          "message": "Der hier ist noch nicht in deinen Entwürfen. Wenn du neu anfängst, ist er weg.",
+          "action": "Neu anfangen"
+        }
+      },
+      "publish": {
+        "blocked": "Füge einen Start- und einen Zielgriff hinzu, um zu veröffentlichen"
       }
     },
     "holdFilter": {

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -574,7 +574,7 @@
         }
       },
       "publish": {
-        "blocked": "Füge einen Start- und einen Zielgriff hinzu, um zu veröffentlichen"
+        "blocked": "Füge einen Startgriff und einen Topgriff hinzu, um zu veröffentlichen"
       }
     },
     "holdFilter": {

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -537,8 +537,8 @@
         "holds_one": "{{count}} Griff",
         "holds_other": "{{count}} Griffe",
         "sectionTitle": "Offene Entwürfe",
-        "frames_one": "{{count}} Frame",
-        "frames_other": "{{count}} Frames"
+        "frames_one": "{{count}} Bild",
+        "frames_other": "{{count}} Bilder"
       },
       "unavailable": {
         "title": "Hier lässt sich noch nichts bauen",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -505,7 +505,10 @@
         "clear": "Clear holds",
         "setActive": "Set as active climb",
         "undo": "Undo",
-        "redo": "Redo"
+        "redo": "Redo",
+        "newClimb": "Start a new climb",
+        "close": "Close",
+        "closeHint": "Your draft stays on this phone."
       },
       "frames": {
         "duplicate": "Duplicate frame",
@@ -533,7 +536,9 @@
       "drafts": {
         "holds_one": "{{count}} hold",
         "holds_other": "{{count}} holds",
-        "sectionTitle": "Open drafts"
+        "sectionTitle": "Open drafts",
+        "frames_one": "{{count}} frame",
+        "frames_other": "{{count}} frames"
       },
       "unavailable": {
         "title": "Can't build here yet",
@@ -552,6 +557,24 @@
         "done": "Saved",
         "draftToast": "Draft saved",
         "publishedToast": "Climb published"
+      },
+      "autosave": {
+        "onDevice": "Saved on this phone",
+        "inAccount": "Draft saved to your account",
+        "unsyncedEdits": "Latest edits are on this phone only",
+        "notStored": "Sign in to keep this draft",
+        "saveFailed": "Couldn't save to your account. Tap Save to retry.",
+        "keptToast": "Draft kept on this phone. Reopen the creator to finish it."
+      },
+      "newClimb": {
+        "confirm": {
+          "title": "Start over?",
+          "message": "This one isn't in your drafts yet. Starting a new climb drops it.",
+          "action": "Start over"
+        }
+      },
+      "publish": {
+        "blocked": "Add a start and a finish hold to publish"
       }
     },
     "holdFilter": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -574,7 +574,7 @@
         }
       },
       "publish": {
-        "blocked": "Añade una presa de inicio y una de final para publicar"
+        "blocked": "Añade una presa de salida y una de final para publicar"
       }
     },
     "holdFilter": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -505,7 +505,10 @@
         "clear": "Borrar presas",
         "setActive": "Fijar como vía activa",
         "undo": "Deshacer",
-        "redo": "Rehacer"
+        "redo": "Rehacer",
+        "newClimb": "Empezar una vía nueva",
+        "close": "Cerrar",
+        "closeHint": "Tu borrador se queda en este teléfono."
       },
       "frames": {
         "duplicate": "Duplicar cuadro",
@@ -522,7 +525,7 @@
         "draftLabel": "Guardar como borrador",
         "draftDescription": "Los borradores quedan privados hasta que los publiques.",
         "showAllHoldsLabel": "Mostrar todas las presas",
-        "showAllHoldsDescription": "Resalta todas las presas pulsables del panel.",
+        "showAllHoldsDescription": "Resalta todas las presas pulsables del plafón.",
         "noMatchLabel": "Sin igualar",
         "noMatchDescription": "No se pueden igualar las manos en la misma presa",
         "noKickboardLabel": "Sin repisa inferior",
@@ -533,11 +536,13 @@
       "drafts": {
         "holds_one": "{{count}} presa",
         "holds_other": "{{count}} presas",
-        "sectionTitle": "Borradores abiertos"
+        "sectionTitle": "Borradores abiertos",
+        "frames_one": "{{count}} fotograma",
+        "frames_other": "{{count}} fotogramas"
       },
       "unavailable": {
         "title": "Aún no se puede crear aquí",
-        "subtitle": "Esta configuración de panel no admite la creación de vías."
+        "subtitle": "Esta configuración de plafón no admite la creación de vías."
       },
       "fab": {
         "ariaLabel": "Crear una vía"
@@ -552,6 +557,24 @@
         "done": "Guardado",
         "draftToast": "Borrador guardado",
         "publishedToast": "Vía publicada"
+      },
+      "autosave": {
+        "onDevice": "Guardado en este teléfono",
+        "inAccount": "Borrador guardado en tu cuenta",
+        "unsyncedEdits": "Los últimos cambios están solo en este teléfono",
+        "notStored": "Inicia sesión para guardar este borrador",
+        "saveFailed": "No se pudo guardar en tu cuenta. Toca Guardar para reintentar.",
+        "keptToast": "Borrador guardado en este teléfono. Vuelve a abrir el editor para terminarla."
+      },
+      "newClimb": {
+        "confirm": {
+          "title": "¿Empezar de cero?",
+          "message": "Esta todavía no está en tus borradores. Si empiezas otra, se pierde.",
+          "action": "Empezar de cero"
+        }
+      },
+      "publish": {
+        "blocked": "Añade una presa de inicio y una de final para publicar"
       }
     },
     "holdFilter": {

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -537,8 +537,8 @@
         "holds_one": "{{count}} presa",
         "holds_other": "{{count}} presas",
         "sectionTitle": "Borradores abiertos",
-        "frames_one": "{{count}} fotograma",
-        "frames_other": "{{count}} fotogramas"
+        "frames_one": "{{count}} cuadro",
+        "frames_other": "{{count}} cuadros"
       },
       "unavailable": {
         "title": "Aún no se puede crear aquí",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -574,7 +574,7 @@
         }
       },
       "publish": {
-        "blocked": "Ajoutez une prise de départ et une prise finale pour publier"
+        "blocked": "Ajoutez une prise de départ et une prise d'arrivée pour publier"
       }
     },
     "holdFilter": {

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -505,7 +505,10 @@
         "clear": "Effacer les prises",
         "setActive": "Définir comme voie active",
         "undo": "Annuler",
-        "redo": "Rétablir"
+        "redo": "Rétablir",
+        "newClimb": "Commencer une nouvelle voie",
+        "close": "Fermer",
+        "closeHint": "Votre brouillon reste sur ce téléphone."
       },
       "frames": {
         "duplicate": "Dupliquer l'image",
@@ -533,7 +536,9 @@
       "drafts": {
         "holds_one": "{{count}} prise",
         "holds_other": "{{count}} prises",
-        "sectionTitle": "Brouillons en cours"
+        "sectionTitle": "Brouillons en cours",
+        "frames_one": "{{count}} image",
+        "frames_other": "{{count}} images"
       },
       "unavailable": {
         "title": "Création indisponible ici",
@@ -552,6 +557,24 @@
         "done": "Enregistré",
         "draftToast": "Brouillon enregistré",
         "publishedToast": "Voie publiée"
+      },
+      "autosave": {
+        "onDevice": "Enregistré sur ce téléphone",
+        "inAccount": "Brouillon enregistré sur votre compte",
+        "unsyncedEdits": "Les dernières modifications sont uniquement sur ce téléphone",
+        "notStored": "Connectez-vous pour garder ce brouillon",
+        "saveFailed": "Impossible d'enregistrer sur votre compte. Touchez Enregistrer pour réessayer.",
+        "keptToast": "Brouillon gardé sur ce téléphone. Rouvrez l'éditeur pour la terminer."
+      },
+      "newClimb": {
+        "confirm": {
+          "title": "Repartir de zéro ?",
+          "message": "Celle-ci n'est pas encore dans vos brouillons. En commencer une autre l'efface.",
+          "action": "Repartir de zéro"
+        }
+      },
+      "publish": {
+        "blocked": "Ajoutez une prise de départ et une prise finale pour publier"
       }
     },
     "holdFilter": {


### PR DESCRIPTION
## Summary

The climb creator lost work in three states, and never told you where anything was.

Autosave was switched **off** whenever `isEditing || isForking || !!savedClimb`. That boolean existed for a real reason — the slot key carried board config only (`<board>:<layout>:<size>:<sets>:<angle>`), so a fork or an edit writing it would clobber a genuine new-climb WIP and resurface as a phantom. The cost was that editing a draft, remixing a climb, and everything after the first Save had no autosave at all. On top of that, `handleSave` deleted the on-device slot on **every** success, so a draft-Save was the moment your backup vanished and was never rewritten: paint, Save, paint more, kill the app, reopen — blank, and "Open drafts" still read "No drafts yet".

Identity moves into the **key** instead of being papered over with a boolean. One deterministic slot per authoring mode:

| Mode | Slot | Reachable from |
| --- | --- | --- |
| New climb (and after its first Save) | `<board>:<layout>:<size>:<sets>:<angle>` — **string unchanged**, so drafts already on devices keep restoring | a plain creator mount |
| Editing an existing climb | `edit:<boardType>:<uuid>` | reopening that climb |
| Remix / fork | `fork:<boardKey>` | a plain creator mount, falling back when the new-climb slot is empty |

With identity in the key, autosave runs in every mode. The slot is now the *working copy*: a draft-Save rewrites it (carrying the `SavedClimbSnapshot` so a cold relaunch **updates** its row instead of leaving a duplicate in Open drafts) and never clears it. Only a publish retires it, under a compare-and-clear on the payload signature, so anything typed while the mutation is in flight survives.

**The sharpest edge is the edit-mode restore ordering.** The `edit:` slot is applied over the freshly fetched server copy, and `restoredRef` opens only once that resolves. Set it any earlier and the next debounce tick writes the *server* copy into the slot, destroying exactly the unflushed edits the feature exists to protect — silently, while the status line still reads "Draft saved to your account". That ordering is pinned by a test that was **mutation-tested**: moving `restoredRef.current = true` above the `loadDraft` makes it fail on both assertions.

Alongside the durability work:

- **A persistent status line** under the Save row (left-aligned, `caption1`): "Saved on this phone" / "Draft saved to your account" / "Latest edits are on this phone only" / "Sign in to keep this draft" / "Couldn't save to your account." Muted for every ordinary state — the Save button's existing 3 s green already carries the momentary confirmation, and a persistent semantic colour reads as an alert that never clears. Warning and error tones only for the two states where the answer is *no* or *partly*.
- **The close chevron stopped lying.** It reused `createClimbForm.dismiss`, a *dialog cancel* label whose Spanish value is literally "Descartar" — discard. On a bug report about "does closing lose my work", the Spanish build's close button said it discards it. New `mobile.create.actions.close` + a hint that says the draft stays on the phone.
- **Dismissal keeps the work silently** — no confirm on any of the four dismiss paths, since pan-down is the most-used gesture here — plus one toast, fired *after* `router.back()` and only when there is content and no row in Open drafts to find it in.
- **Clear holds does exactly that.** It used to also wipe the name, the description, the saved-row link and the on-device slot behind a trash can labelled "Clear holds"; undo brought back only the holds. Split into Clear holds (undoable, touches nothing else) and a separate **Start a new climb** that confirms only when the work isn't saved anywhere yet.
- **Undo is pinned outside the horizontal scroller.** Nine 44 dp controls need ~460 dp and the scroller has ~261 dp, so the moment a climb had a second frame the only recovery from a mis-tap scrolled off the left edge. Cheaper than a confirm, and it fixes the multi-frame case a confirm wouldn't.
- **Publishing needs a start and a finish hold.** `isValid` was `totalHolds > 0` and `SaveClimbInputSchema` checks neither, so a one-hold blob was one tap from public. `canSave` is unchanged (drafts stay cheap); the new `canPublish` gates only the public transition, and the status line names the missing requirement while Save is disabled.
- **The Save pill meets the 44 dp touch floor.** It measured 57.9 × 40.0 — the only sub-floor control on a surface of 44 dp icon buttons (Compose sizes a `small` filled button from `contentPadding` alone). New `minHeight` prop on `Button`, wired through all three platform implementations.
- **Frame duplication gets feedback** (haptic + a one-shot announcement) rather than a confirm, since it is already undoable.
- **The screen-reader trap is closed.** A 500 ms-debounced autosave under `accessibilityLiveRegion="polite"` would re-announce on every keystroke and every hold tap. The line sets `="none"` explicitly and only transitions that change the answer are spoken, rate-limited to one per 10 s and de-duplicated.

Two pre-existing i18n defects in strings this PR already edits, fixed as drive-bys: `es` used **"panel"** where the glossary mandates **plafón** (`showAllHoldsDescription`, `unavailable.subtitle`), and `de` `drafts.sectionTitle` read "Entwürfe öffnen" — an imperative "open the drafts", where `es` and `fr` both correctly read it as the noun phrase. Now „Offene Entwürfe".

Refs #4628. This is **Part A**: durable local autosave, honest status, safe trash. The literal "only press to submit" ask — server-side draft autosave, removing the "Save as draft" toggle, renaming Save → Publish — is Part B and deliberately not here. Renaming Save to Publish before server autosave exists would strand "put this in my account" with no affordance at all, since Part A's local slot never surfaces in Open drafts. Part B's four blockers (per-call toast suppression in `@boardsesh/board-react`, invalidation cadence against the non-virtualized 50-row drafts list, `updateClimb` cost per write, and the empty-name reject loop) are written up in the plan.

## Risk

Risk: 4/5 — mobile draft persistence changes touch data-loss and route-identity paths.

## Release Notes

- Your work in the climb creator is kept on your phone now, in every mode — editing a draft, remixing a climb, or picking up after you've already saved once. Kill the app mid-build and it's all still there when you come back.
- A line under the Save button always tells you where your climb is: on this phone, in your account, or waiting on edits you haven't saved yet.
- The trash button clears holds and nothing else. Starting a fresh climb is its own button, and it asks first if the one you're on isn't saved anywhere.
- Undo stays put on the row instead of sliding off once a climb has more than one frame.
- Publishing now asks for a start and a finish hold. Drafts save with whatever you've got.

## Test plan

1. Paint, dismiss, reopen → holds and frames return.
2. Save, edit, restart → latest local edits return.
3. Start new after editing → confirmation protects unsaved work.
4. Publish across frames → start and finish roles pass.

### Automated validation

All run from the worktree on this branch. Emulator not booted — a shared single-instance resource is held by another session; **this change wants one visual pass** (see Deviations).

| Command | Result |
| --- | --- |
| `vp run typecheck:mobile` | pass |
| `vp run typecheck` (full monorepo) | pass |
| `vp run test:mobile` | **711 files, 7090 tests, all pass** (rebased onto latest `main`) |
| `vp test run --project i18n` | 2 files, 101 tests, pass (the parity gate for the four locales) |
| `vp test run --reporter=agent use-create-climb.test` | 47 pass (shared hook, `canSave` / `canPublish`) |
| `vp test run --project web use-save-climb moonboard` | 8 files, 69 tests, pass |
| `vp check` | **0 errors**, 260 warnings — all pre-existing, none in any file this PR touches |
| `vp run check:mobile-bundle` | iOS and Android bundles OK |
| `vp run check:i18n` | OK — 325 files, no hardcoded strings |
| `vp run check:i18n:orphans` | OK — every catalog key referenced, every reference resolves |

**Mutation test on the load-bearing ordering.** Moved `restoredRef.current = true` above the `edit:` slot load and re-ran: `applies the stored edit slot over the server copy, and writes nothing before it lands` failed (1 failed / 12 passed). Reverted; 13/13 green again. The test is not vacuous.

New coverage: 18 cases in `use-create-climb-screen-autosave.test.tsx` (slot-per-mode, no-clear-on-draft-save, compare-and-clear on publish both ways, fork isolation + fork restore from the plain creator, `savedClimbJson` re-attach + corrupt-payload tolerance, edit-slot autosave, the ordering pin, angle migration, the conditional dismissal toast, the publish start/finish gate, and the two review fixes below), 8 in `draft-status-view.test.ts`, 7 in `create-drawer-action-bar.test.tsx` (pinned undo, glyph split, 44 dp floor, blocked-publish reason), 3 in the clear/new-climb split, 4 in the draft-store (three key shapes round-trip, sweep, and the no-migration guarantee that an original four-field payload still loads), 1 in the web store (signed-out storage is genuinely unavailable and writes nothing).

## Review follow-ups

`claude-review` found two real bugs. Both were cases where the durability this PR promises quietly didn't happen — worse than the bug being replaced — and both are now fixed and pinned by tests that were mutation-tested against the old code.

1. **"Start a new climb" dropped the wrong slot.** It always cleared the board-config key, even from a fork or edit session whose working copy lives under a different one. The abandoned `fork:` slot survived, and the plain creator's fork fallback then resurrected it as a ghost draft on the next open. Now it drops the slot the session actually owns. A server draft is untouched either way — that row lives in `board_climbs`, not in the slot — so an edit session still leaves its row in Open drafts, which is what the design asked for.

2. **A failing climb query left autosave gated off for the whole edit session.** The gate opened inside the seed effect, which only runs once `useClimb` resolves. Offline, or against a deleted row, `editClimb` stays undefined, the effect never runs, and the session saves nothing — paint, kill the app, lose everything, in exactly the mode this PR exists to fix. The gate now also opens on a settled failure. A later retry that succeeds still seeds, and its `edit:` slot load reapplies whatever was painted in the meantime.

Also taken from the review: the debounce path now reads its slot key off the mirrored payload, as `flush` already did. That is a no-op today — a slot change re-runs the effect and its cleanup cancels the pending timer, so the two can't diverge — but reading one source makes the invariant plain instead of leaving a reader to prove it.

**A guard for the duplicated platform type.** The review flagged `CreateClimbDraft` being declared independently in the native and `.web` forks, where tsc sees no relationship. That drift has already happened once — the web fork was missing `framesJson` while round-tripping it at runtime — so rather than restructure a pattern used by every `*.web.ts` fork in the repo, there is now a compile-time check that the two key sets match. Worth recording: the obvious version of that check is **vacuous**. A mutual-assignability check passes happily when one side has an extra *optional* field, which is precisely the drift that occurred; comparing `keyof` catches it. Verified by mutating both directions, including reproducing the original `framesJson` drift.

Three review points not acted on, with reasons:

- **Toast on the same tick as `router.back()`.** The toast overlay is a root-level JS view, so it is occluded for the ~300 ms dismiss animation and then visible for the remaining ~2.7 s of its 3 s life. The shipped publish path does the same thing in the opposite order (toast, *then* `router.back()`) and reads fine. Adding a timer tuned to an animation duration would be a worse trade than the 300 ms of occlusion.
- **`Date.now()` inside a `useMemo`.** The memo's deps are every content field, so the value is the time of the last content change — which is what the field means. It is diagnostic and never rendered; no timestamp is shown anywhere in this feature, deliberately, because `Climb` exposes only `created_at` and "3 days ago" on a draft touched 90 seconds ago would be a lie.
- **A residual `fork:` slot surviving a plain-new publish.** That slot holds genuine unfinished remix work, and restoring it is the feature, not a leak — it is what the fork-fallback test pins. With fix 1 in place, the deliberately abandoned case is cleared explicitly; what remains is the rescue path working as designed.

## Where Part A stops, explicitly

**An autosaved climb does not appear in "Open drafts", and that is intended.** `OpenDraftsSection` is a single React Query result over the **server** (`useSearchClimbs({ onlyDrafts: true })`, which the backend requires auth for). The local slot is client-side plumbing; it never becomes a row.

So the promise this PR makes is precise: **reopen the creator and your work is there** — not "your work shows up in the drafts list". Those are different guarantees and it is worth not blurring them. Getting a row without pressing Save requires a server write on every change, which is Part B and carries the four blockers recorded in the plan (per-call toast suppression in `@boardsesh/board-react`, invalidation cadence against a non-virtualized 50-row list, `updateClimb` cost per write, and the empty-name reject loop).

Deliberately not bridged here — merging a device-only source into that list means a synthetic `Climb`, a two-source delete path, and a "why is this draft only on my phone?" support question, for a row the climber can already get back by reopening the creator.

## Emulator QA

Run against `f7de353ec` on Android (810 × 1800 @ density 320). The core fix verified end to end: paint → dismiss → reopen restored all five holds, the frame count, and the status line, and it survived a full app backgrounding. Three fixes came out of it, all in this PR:

- **The status line moved the peek.** It rendered only once there was something to say, so painting the *first* hold grew the chrome, changed `peekHeight`, and re-snapped an expanded sheet back down to peek. A jolt at exactly the moment someone starts working, and new in this branch. The row now always holds its line box (the text is still absent when empty), and the reserve is set to what the line actually costs, so the board shrinks by what the bar grew.
- **The peek is now identical to `main` in every state.** Measured at 405 × 900 dp: 831 dp before this branch, 835 dp as first pushed, 831 dp now. That also settles the separate complaint that a tall board's peek hides the action bar — real, but **pre-existing**: this branch no longer moves that number at all, so it neither caused nor worsens it. Filed separately rather than fixed blind, since sizing the board off measured chrome needs device iteration.
- **"Start a new climb" did nothing on Android** when there was unsaved work. `useConfirm` renders a Paper `Dialog` inside a JS `Portal` on the Material path, and this drawer is a native `@expo/ui` sheet composited above the RN root — the dialog painted behind it and the promise never resolved. The ask is now sheet *content*, which cannot be occluded by the sheet it lives in (the same reason `DuplicateBanner` is built that way). iOS was never affected: the same provider uses a native `Alert` there.

Confirmed good and unchanged: the status line is left-aligned on the 16 dp rule with no truncation even on the longest string, the Save pill is 58 × 44 dp against 44 × 44 dp icon buttons, and undo stays pinned across every scroll offset at `frameCount = 2`.

A second device pass on the inline confirm found the same peek-resize problem in a second place, now fixed. The banner mounts into the measured above-fold region, so a single `+` tap moved `peekHeight` and re-snapped the drawer — the handle dropped ~400 dp, collapsing an expanded sheet to peek and putting the board and the whole action row off-screen. The climber was being asked "start over?" about a climb they could no longer see, on a PR whose subject is not losing work. The measured region is now split in two — header and board-block — with the transient banners between them and measured by neither: they push content instead of resizing the sheet, so the drawer stays where the climber put it. Reserving a constant height (the status-row fix) is wrong here — ~100 dp permanently for something rarely on screen is budget a tall board cannot spare.

That change necessarily covers **`DuplicateBanner`** as well, which mounts into the same slot and had the identical pre-existing defect. There is no way to exclude one without the other short of leaving the older one broken, so it is fixed here rather than filed. The banner's two text actions are also floored at 44 dp: they measured 32 at the node, and while `hitSlop` brought the effective area to 48, hitSlop is invisible to an accessibility scanner and to anyone aiming at the glyph. Padding alone lands at 40–42 depending on the type scale, so the floor is explicit.

Three findings were **not** fixed here and are filed instead — the first two are shared infrastructure, the third restyles every toast in the app:

- #4811 — `useConfirm` from inside a native sheet is invisible on Android. Root cause of the third bullet above; also implicates the pre-existing draft-delete confirm in this same drawer.
- #4812 — the Save button still says "Save" when it is about to publish publicly. Pre-existing; this PR's status line is what makes the mismatch legible.
- #4813 — the `info` toast is violet-on-violet, measured at **4.02:1 in dark mode** against a 4.5:1 AA threshold (light passes at 5.21:1).

One unrelated commit rides along: `main` at `668d30c30` landed a markdown emphasis marker the repo formatter disagrees with, so `vp check` fails on **any** PR that rebases onto it — CI lints the merge result, so it shows up on the PR rather than on main. One character, exactly what `vp check --fix` emits, committed on its own so the diff explains itself. Worth someone knowing: it will red every PR until it lands somewhere.

## Deviations

Three, all deliberate, none silent.

1. **No `accessibilityHint` on the Save button** (design A-4 asked for one on a disabled Publish). `@expo/ui`'s Compose `semantics` modifier exposes only `contentType` — no hint, no contentDescription — which is why `Button.android.tsx` already carries a dev warning that `accessibilityLabel` can't be applied there. Adding the prop would make it work on iOS and silently do nothing on Android, which is the platform this bug was reported on. Instead the blocked reason is on-screen text directly under the button (`publish.blocked`, warning tone) and is announced on the transition, so the disabled button is never mute on either platform. `accessibilityState={{ disabled }}` is already carried natively by both implementations.

2. **Save pill floored at 44 dp, not the 48 dp `glassSize.inlinePrimary`** the design preferred. The action row is 44 dp tall; a 48 dp pill grows it by 4 more than the +20 dp the `ABOVE_FOLD_CHROME` bump (300 → 320) budgets for. 44 keeps the row height unchanged and still clears the touch floor.

3. **The status row's literal padding (`spacing[3]` bottom) costs +24 dp, not the +20 dp the design states**, with `rowSecondary`'s bottom padding dropping 12 → 4. The design gives both a literal spec and a net-cost figure that differ by 4 dp; I followed the literal spec and kept the specified 320 reserve. `ABOVE_FOLD_CHROME` is a *reserve* used only to size the board — the peek snap-point is measured from real layout — so erring 4 dp low costs a few dp of board height and nothing else.

Also worth flagging as a **visible behaviour change**: a draft-Save no longer wipes the on-device copy. Anyone who relied on "Save, then reopen gives me a blank creator" now gets their tracked draft back instead. That is the fix, but it is a change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5EgwpjzbCqfLGbj6qESeA
