### PR TITLE
fix(ci): install the vp toolchain in deploy-cloudflare, and pin the pairing

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -559,6 +559,16 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
+      # `vp` does not come from `bun install` — it is a separate toolchain the
+      # action puts on PATH. Without this step the apply step dies on
+      # `vp: command not found` AFTER the Production environment has already
+      # handed it the Cloudflare token, which reads as a credentials problem
+      # and is not. Every other `vp run` step in this workflow pairs with it.
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: 'lts'
+          cache: true
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/scripts/__tests__/ci-vp-toolchain.test.ts
+++ b/scripts/__tests__/ci-vp-toolchain.test.ts
@@ -1,0 +1,121 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `vp` is not installed by `bun install` — it is a separate toolchain that
+ * `voidzero-dev/setup-vp` puts on PATH. A job that runs `vp` without that step
+ * dies on `vp: command not found`.
+ *
+ * That failure is nastier than it looks in the two jobs that carry production
+ * credentials: `deploy-cloudflare` had already been handed the Cloudflare token
+ * by the Production environment before the step died, so the run reads as a
+ * credentials or permissions problem when it is a missing binary. It shipped
+ * that way in #3837 and failed on the first real deploy (run 32852243129).
+ *
+ * The pairing is invisible at review time — the `uses:` step and the `run:` line
+ * can be forty lines apart — so it is pinned here instead.
+ */
+
+const WORKFLOW_PATHS = ['.github/workflows/production-deploy.yml', '.github/workflows/ci.yml'] as const;
+
+const SETUP_VP_ACTION = 'voidzero-dev/setup-vp';
+
+/**
+ * `vp` invoked as a command, not the two-letter sequence appearing inside a
+ * word, a path, or a URL. Anchored on the subcommands the repo actually uses so
+ * a stray "vp" in prose can't trip it.
+ */
+const VP_INVOCATION = /(^|[\s;&|(])vp\s+(run|test|check|fmt|lint|exec)\b/;
+
+/** Strip full-line comments so a `# ... vp run ...` note isn't read as an invocation. */
+function withoutCommentLines(source: string): string[] {
+  return source.split('\n').filter((line) => !line.trimStart().startsWith('#'));
+}
+
+/**
+ * Split a workflow into its top-level jobs. Jobs sit at indentation 2 under a
+ * column-0 `jobs:` key; a job's block runs until the next line at indentation
+ * <= 2 that isn't blank.
+ */
+function jobBlocks(source: string): Map<string, string[]> {
+  const lines = withoutCommentLines(source);
+  const jobsIndex = lines.findIndex((line) => line === 'jobs:');
+  if (jobsIndex < 0) throw new Error('workflow has no top-level `jobs:` key');
+
+  const blocks = new Map<string, string[]>();
+  let currentName: string | null = null;
+  let currentLines: string[] = [];
+
+  for (const line of lines.slice(jobsIndex + 1)) {
+    const jobHeader = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
+    if (jobHeader) {
+      if (currentName) blocks.set(currentName, currentLines);
+      currentName = jobHeader[1];
+      currentLines = [];
+      continue;
+    }
+    // A non-blank line back at column 0 ends the jobs mapping entirely.
+    if (line.trim() && !line.startsWith(' ')) break;
+    if (currentName) currentLines.push(line);
+  }
+  if (currentName) blocks.set(currentName, currentLines);
+
+  return blocks;
+}
+
+describe.each(WORKFLOW_PATHS)('%s', (workflowPath) => {
+  const source = readFileSync(workflowPath, 'utf8');
+  const jobs = jobBlocks(source);
+
+  it('parses into jobs at all', () => {
+    // Guard the guard: a parser that silently found nothing would make every
+    // assertion below vacuously true — exactly the failure mode that let a
+    // previous YAML-regex guard sit green while inert.
+    expect(jobs.size).toBeGreaterThan(3);
+  });
+
+  it('installs the vp toolchain in every job that runs vp', () => {
+    const missing: string[] = [];
+
+    for (const [jobName, jobLines] of jobs) {
+      const runsVp = jobLines.some((line) => VP_INVOCATION.test(line));
+      if (!runsVp) continue;
+      const installsVp = jobLines.some((line) => line.includes(SETUP_VP_ACTION));
+      if (!installsVp) missing.push(jobName);
+    }
+
+    expect(missing, `jobs run \`vp\` without \`${SETUP_VP_ACTION}\`: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('finds at least one job that actually runs vp', () => {
+    // Otherwise the assertion above passes by never entering its loop.
+    const vpJobs = [...jobs].filter(([, jobLines]) => jobLines.some((line) => VP_INVOCATION.test(line)));
+    expect(vpJobs.length).toBeGreaterThan(0);
+  });
+});
+
+describe('VP_INVOCATION', () => {
+  it('matches the ways this repo invokes vp', () => {
+    for (const line of [
+      '        run: vp run cf:apply -- --apply',
+      '        run: vp test run --project scripts',
+      '          vp check --fix',
+      '        run: bun install && vp run typecheck',
+    ]) {
+      expect(VP_INVOCATION.test(line), line).toBe(true);
+    }
+  });
+
+  it('does not match vp inside a word, path, or URL', () => {
+    for (const line of [
+      '        run: node scripts/vp-helper.mjs',
+      '      - uses: voidzero-dev/setup-vp@v1',
+      '        run: echo "https://viteplus.dev/vp run"',
+      '        run: ./bin/myvp run something',
+    ]) {
+      expect(VP_INVOCATION.test(line), line).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`deploy-cloudflare` (added in #3837) ran `vp run cf:apply` with only `oven-sh/setup-bun`, so it died on **`vp: command not found`** on the first real production deploy — [run 32852243129](https://github.com/boardsesh/boardsesh/actions/runs/32852243129). `vp` does not come from `bun install`; it is a separate toolchain that `voidzero-dev/setup-vp` puts on PATH, and every other `vp run` step in this workflow pairs with that action.

My mistake in #3837: I checked that other jobs in the same workflow run `vp` after `setup-bun` and concluded it was available, without noticing the `setup-vp` step sitting between them.

The failure mode is worse than a missing binary usually is. The `Production` environment had already handed the job the Cloudflare token before the step died, so the run reads as a credentials or permissions problem when it is nothing of the sort — exactly the wrong place to send whoever debugs it next.

**Nothing else was affected.** `deploy-cloudflare` has `needs: [detect-changes]` and nothing depends on it, which is how it was scoped on purpose: `build-web`, `build-backend`, `deploy-app-web` and `migrate` all succeeded in the same run. The zone is simply unconverged, not half-converged — the job failed before making any API call.

## The guard

The fix is one `uses:` block. The interesting part is `scripts/__tests__/ci-vp-toolchain.test.ts`, which walks every job in `production-deploy.yml` and `ci.yml` and asserts that any job invoking `vp` also installs it.

This pairing is invisible at review time — the `uses:` step and the `run:` line can be forty lines apart — which is precisely why it shipped green through a full CI matrix.

**The guard guards itself.** Two extra assertions exist because this repo has already been bitten by a workflow guard that matched nothing and sat green while inert:

- `parses into jobs at all` — a parser that silently found zero jobs would make the main assertion vacuously true.
- `finds at least one job that actually runs vp` — otherwise the main loop never executes.

`VP_INVOCATION` is anchored on the subcommands the repo actually uses and has its own positive/negative cases, so `setup-vp@v1`, `scripts/vp-helper.mjs`, and a `vp run` inside a URL don't trip it.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project scripts scripts/__tests__/ci-vp-toolchain.test.ts` — 8 tests pass.
- **Mutation-tested.** Removing the `setup-vp` step again — the exact bug that just failed production — fails with `jobs run \`vp\` without \`voidzero-dev/setup-vp\`: deploy-cloudflare`. It names the job.
- The guard passes against `main` as it stands, so no other job is currently missing the pairing.

### After merge

`deploy-cloudflare` re-runs on the next push touching `infra/cloudflare/**` or the apply tooling — this PR touches neither, so it will **not** re-trigger on its own merge. Either dispatch the workflow manually, or run the apply locally:

```bash
CLOUDFLARE_API_TOKEN=… vp run cf:apply          # dry-run, read the plan first
CLOUDFLARE_API_TOKEN=… vp run cf:apply -- --apply
```

The og-rule caveat from #3837 still stands: the existing `/og/` rule was created by hand so it does not carry the tool's description marker, and applying would create a second one rather than adopting it.

Part of #4650 / epic #4648.