### PR TITLE
fix(ci): derive the deploy-changes summary from its outputs so targets can't drift

### DIFF
--- a/scripts/production-deploy-changes.mjs
+++ b/scripts/production-deploy-changes.mjs
@@ -266,6 +266,14 @@ function formatGitHubOutputs(result) {
   ].join('\n');
 }
 
+/** Human-readable target summary, derived from the emitted outputs so the two can't drift. */
+function summariseTargets(result) {
+  return formatGitHubOutputs(result)
+    .split('\n')
+    .filter((line) => !line.startsWith('deployment_base_sha='))
+    .join('; ');
+}
+
 function runCli(argv) {
   const options = parseCliArguments(argv);
   const result = determineProductionDeployChanges({
@@ -282,7 +290,12 @@ function runCli(argv) {
 
   console.error(
     `production-deploy-changes: ${result.reason}; base=${result.deploymentBaseSha || 'none'}; ` +
-      `web=${result.web}; backend=${result.backend}; app=${result.app}`,
+      // Derived from formatGitHubOutputs, not hand-listed: the two drifted apart
+      // when `cloudflare` was added (#3837) and the deploy log then could not
+      // say whether the Cloudflare apply had been targeted — precisely the
+      // question you ask when that job misbehaves. Deriving it means a new
+      // target shows up here for free.
+      summariseTargets(result),
   );
   if (result.changedFiles.length > 0) {
     console.error(`Changed files since deployment baseline:\n${result.changedFiles.join('\n')}`);
@@ -301,6 +314,7 @@ if (process.argv[1] === scriptPath) {
 
 export {
   classifyChangedFiles,
+  summariseTargets,
   createCliGit,
   determineProductionDeployChanges,
   formatGitHubOutputs,

--- a/scripts/production-deploy-changes.test.mjs
+++ b/scripts/production-deploy-changes.test.mjs
@@ -5,6 +5,7 @@ import {
   determineProductionDeployChanges,
   formatGitHubOutputs,
   selectLatestSuccessfulPriorRun,
+  summariseTargets,
 } from './production-deploy-changes.mjs';
 
 const BASE_SHA = '1111111111111111111111111111111111111111';
@@ -359,4 +360,24 @@ void test('a git comparison error falls back to a full build', () => {
 
   assert.equal(result.fullBuild, true);
   assert.deepEqual([result.web, result.backend, result.app], [true, true, true]);
+});
+
+void test('the human-readable summary names every target the outputs do', () => {
+  // These drifted once already: `cloudflare` was added to the GITHUB_OUTPUT
+  // block but not to the log line, so the deploy log could not say whether the
+  // Cloudflare apply had been targeted. Deriving one from the other makes that
+  // impossible, and this pins it.
+  const result = determineProductionDeployChanges({
+    eventName: 'workflow_dispatch',
+    headSha: '',
+    runsPayload: null,
+    git: null,
+  });
+
+  const summary = summariseTargets(result);
+  for (const target of ['web', 'backend', 'app', 'cloudflare']) {
+    assert.ok(summary.includes(`${target}=`), `summary must name ${target}: ${summary}`);
+  }
+  // And it must not leak the base sha, which the caller prints separately.
+  assert.ok(!summary.includes('deployment_base_sha'), summary);
 });


### PR DESCRIPTION
## Summary

`detect-changes` emits its targets twice: once as `GITHUB_OUTPUT` lines the jobs gate on, and once as a human-readable line in the log. #3837 added `cloudflare` to the first and not the second, so the deploy log printed:

```
production-deploy-changes: cumulative-diff; base=723620b7…; web=true; backend=true; app=true
```

No mention of Cloudflare — which is exactly the question you ask when `deploy-cloudflare` misbehaves, and it did twice today (runs [32852243129](https://github.com/boardsesh/boardsesh/actions/runs/32852243129) and [32853285644](https://github.com/boardsesh/boardsesh/actions/runs/32853285644)). I hit this while debugging those runs: the job was plainly running, and the log said nothing about why.

Rather than hand-adding `cloudflare` to the second list and leaving the identical trap for the next target, the summary is now **derived** from `formatGitHubOutputs` — the single source of truth — with `deployment_base_sha` filtered out because the caller prints it separately. A new deploy target now shows up in the log for free.

Mutation-tested: filtering `cloudflare=` back out of the derived summary fails with `summary must name cloudflare: web=true; backend=true; app=true`.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `node --test scripts/production-deploy-changes.test.mjs` — 22 tests (was 21).
- The new test asserts the summary names every target the outputs do, and that it does not leak the base sha.
- Mutation-tested as above.

Part of #4650 / epic #4648.