### PR TITLE
feat(ci): allow a one-off zone-SSL apply from workflow_dispatch

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -26,6 +26,14 @@ on:
     # No paths filter — detect-changes decides per-side. Web deploys on
     # essentially any app change; backend only on backend-affecting paths.
   workflow_dispatch:
+    inputs:
+      cloudflare_allow_zone_ssl:
+        description: >-
+          One-off: let cf:apply set the ZONE-WIDE SSL/TLS mode. Off by default and
+          deliberately not wired to push, because the setting affects every hostname
+          on boardsesh.com (ws, app, www), not just the one being deployed.
+        type: boolean
+        default: false
 
 concurrency:
   group: production-deploy
@@ -575,7 +583,11 @@ jobs:
       - name: Apply Cloudflare config
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: vp run cf:apply -- --apply
+          # Only a manual dispatch can carry this; a push always resolves to ''.
+          # That is the point: an SSL drift should be a decision someone makes,
+          # not something a routine merge applies zone-wide on their behalf.
+          ALLOW_ZONE_SSL: ${{ inputs.cloudflare_allow_zone_ssl && '--allow-zone-ssl' || '' }}
+        run: vp run cf:apply -- --apply $ALLOW_ZONE_SSL
 
   # Manual deploy freeze for app.boardsesh.com, the Cloudflare Pages analogue of
   # check-rollback. deploy-web and deploy-production-backend both honour a pinned

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -1,5 +1,6 @@
 /// <reference types="node" />
 
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -442,5 +443,42 @@ describe('managed rule ordering and foreign-rule safety', () => {
     expect(changed).toBe(false);
     expect(rules).toBe(inSync);
     expect(diffManagedRules(inSync, desired.wafRules, 'waf-rule')).toEqual([]);
+  });
+});
+
+describe('deploy-cloudflare workflow wiring', () => {
+  const workflow = readFileSync('.github/workflows/production-deploy.yml', 'utf8');
+  const applyStep = workflow.slice(
+    workflow.indexOf('- name: Apply Cloudflare config'),
+    workflow.indexOf('deploy-app-web:'),
+  );
+
+  it('never hard-codes --allow-zone-ssl into the apply command', () => {
+    // The zone-wide SSL/TLS mode affects every hostname on boardsesh.com — ws,
+    // app and www. A routine merge must not be able to change it; only a
+    // deliberate manual dispatch can.
+    expect(applyStep).toContain('vp run cf:apply -- --apply $ALLOW_ZONE_SSL');
+    expect(applyStep).not.toMatch(/run:.*--apply\s+--allow-zone-ssl/);
+  });
+
+  it('gates the flag on a workflow_dispatch input, so a push resolves it to empty', () => {
+    // `inputs` is null on a push event, so the expression falls through to ''.
+    // If this were ever keyed on a repo variable or a secret instead, every
+    // merge would start applying zone-wide SSL changes silently.
+    expect(applyStep).toMatch(
+      /ALLOW_ZONE_SSL: \$\{\{ inputs\.cloudflare_allow_zone_ssl && '--allow-zone-ssl' \|\| '' \}\}/,
+    );
+  });
+
+  it('declares the input as a boolean defaulting to off', () => {
+    const dispatchBlock = workflow.slice(workflow.indexOf('workflow_dispatch:'), workflow.indexOf('concurrency:'));
+    expect(dispatchBlock).toContain('cloudflare_allow_zone_ssl:');
+    expect(dispatchBlock).toContain('type: boolean');
+    expect(dispatchBlock).toContain('default: false');
+  });
+
+  it('parses the exact argv the workflow produces, both with and without the flag', () => {
+    expect(parseArgs(['--apply'])).toEqual({ apply: true, allowZoneSsl: false, help: false });
+    expect(parseArgs(['--apply', '--allow-zone-ssl'])).toEqual({ apply: true, allowZoneSsl: true, help: false });
   });
 });


### PR DESCRIPTION
## Summary

`cf:apply` now converges the zone (verified in production — see below), but it exits **1** because one planned change is deliberately withheld:

```
[cf-apply] SKIPPED (blocked): Zone SSL mode "full" is weaker than required "strict"
[cf-apply] Done, but 1 change(s) were blocked and left unapplied
```

That guard is correct — the SSL/TLS mode is **zone-wide**, affecting `ws.boardsesh.com`, `app.boardsesh.com` and `www`, not just the host being deployed. But it also means `deploy-cloudflare` fails on *every* production run, and a permanently-red job is one that stops being read.

The fix is a `workflow_dispatch` boolean input, default off. `inputs` is null on a `push`, so the expression falls through to `''` and **a routine merge can never carry the flag** — only a deliberate manual dispatch can.

Hard-coding `--allow-zone-ssl` into the run line would have been one character of diff and would have handed every future merge the ability to change a zone-wide security setting on someone's behalf. That is the thing this PR exists to avoid.

## What already landed

The rules from #3837 are live and verified on production:

```
board-render:  cf-cache-status  DYNAMIC -> MISS -> HIT
AhrefsBot / SemrushBot / DataForSeoBot / Screaming Frog  -> 403, never reach Vercel
Brave-Search / Googlebot / Bingbot / Chrome              -> 200, reach Vercel
```

The allow-before-block ordering held on a real zone, which was the main thing worth proving.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project scripts` — 37 tests in `cloudflare-apply.test.ts` (was 33).
- The four new ones guard the **safety property**, not just the wiring: the flag is never hard-coded into the run line; it is gated on `inputs.` specifically (a repo variable or secret would silently re-arm every merge); the input is a boolean defaulting to `false`; and `parseArgs` handles both argv shapes the workflow can produce.
- **Mutation-tested:** hard-coding `--allow-zone-ssl` back into the run line fails two tests.
- YAML parses; the `ci-vp-toolchain` job guard still passes.

### After merge

Dispatch once with the box ticked, then confirm the zone came out at Full (strict) and that nothing on the apex broke:

```bash
gh workflow run production-deploy.yml -f cloudflare_allow_zone_ssl=true
# then
curl -sI https://ws.boardsesh.com/health | head -1
curl -sI https://www.boardsesh.com/ | head -1
curl -sI https://app.boardsesh.com/ | head -1
```

All three origins serve valid certificates (Vercel, Railway, CF Pages), so `strict` should be a no-op operationally — but it is zone-wide, so it is worth checking all three rather than assuming.

Subsequent pushes leave the input off and the SSL check becomes a no-op, so `deploy-cloudflare` goes green and stays meaningful.

Part of #4650 / epic #4648.