### PR TITLE
fix(mobile): real Wall Finder layout/size chips for Woods and MoonBoard

### DIFF
--- a/packages/mobile/src/components/gym-directory/__tests__/wall-finder-filter-chips.test.tsx
+++ b/packages/mobile/src/components/gym-directory/__tests__/wall-finder-filter-chips.test.tsx
@@ -9,7 +9,7 @@ type PressProps = { children?: ReactNode; onPress?: () => void; accessibilityLab
 const hapticSelection = vi.fn();
 
 vi.mock('@boardsesh/board-config', () => ({
-  SUPPORTED_BOARDS: ['kilter', 'tension', 'moonboard'],
+  SUPPORTED_BOARDS: ['kilter', 'tension', 'moonboard', 'woods'],
   formatBoardDisplayName: (boardType: string) => boardType.charAt(0).toUpperCase() + boardType.slice(1),
 }));
 
@@ -67,6 +67,38 @@ describe('WallFinderFilterChips', () => {
     expect(getByText('Kilter')).toBeTruthy();
     expect(getByText('Tension')).toBeTruthy();
     expect(getByText('Moonboard')).toBeTruthy();
+  });
+
+  // Woods rides the same generic chip row, but it's the board whose layout/size
+  // tiers used to come up empty (#4751) — so pin the whole cascade end to end.
+  it('renders the Woods chip and its layout + size chips', () => {
+    const onToggle = vi.fn();
+    const onToggleLayout = vi.fn();
+    const onToggleSize = vi.fn();
+    const { getByText, getByLabelText } = render(
+      <WallFinderFilterChips
+        {...baseProps({
+          selected: ['woods'],
+          onToggle,
+          onToggleLayout,
+          onToggleSize,
+          layoutOptions: [{ id: 1, label: 'Original' }],
+          sizeOptions: [
+            { label: '8 x 10', sizeIds: [1] },
+            { label: '12 x 12', sizeIds: [2] },
+          ],
+        })}
+      />,
+    );
+
+    fireEvent.click(getByLabelText('Woods'));
+    expect(onToggle).toHaveBeenCalledWith('woods');
+
+    fireEvent.click(getByText('Original'));
+    expect(onToggleLayout).toHaveBeenCalledWith(1);
+
+    fireEvent.click(getByText('12 x 12'));
+    expect(onToggleSize).toHaveBeenCalledWith([2]);
   });
 
   it('toggles a board type (with a haptic) when its chip is tapped', () => {

--- a/packages/mobile/src/lib/__tests__/wall-finder-filter.test.ts
+++ b/packages/mobile/src/lib/__tests__/wall-finder-filter.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { MOONBOARD_LAYOUTS, SUPPORTED_BOARDS, WOODS_LAYOUTS } from '@boardsesh/board-config';
+import {
+  MOONBOARD_LAYOUTS,
+  MOONBOARD_SIZE,
+  SUPPORTED_BOARDS,
+  WOODS_LAYOUTS,
+  WOODS_SIZES,
+} from '@boardsesh/board-config';
 import {
   DEFAULT_WALL_FINDER_FILTER,
   hasActiveWallFinderFilter,
@@ -174,18 +180,21 @@ describe('buildSizeOptions', () => {
   });
 
   // Both Woods sizes, as separate chips — an 8x10 climb can't be queued onto a
-  // 12x12 board, so the two must never collapse into one label.
+  // 12x12 board, so the two must never collapse into one label. Ids come from
+  // the catalogue (a renumber there is not this builder's business); the labels
+  // stay literal because grouping BY label is the behaviour under test, and
+  // deriving both sides would make the assertion tautological.
   it('offers both Woods sizes under the Woods layout', () => {
     expect(buildSizeOptions({ boardTypes: ['woods'], layoutIds: [WOODS_LAYOUTS.woods.id] })).toEqual([
-      { label: '8 x 10', sizeIds: [1] },
-      { label: '12 x 12', sizeIds: [2] },
+      { label: '8 x 10', sizeIds: [WOODS_SIZES['8x10'].id] },
+      { label: '12 x 12', sizeIds: [WOODS_SIZES['12x12'].id] },
     ]);
   });
 
   it("offers MoonBoard's single size under a MoonBoard layout", () => {
     expect(
       buildSizeOptions({ boardTypes: ['moonboard'], layoutIds: [MOONBOARD_LAYOUTS['moonboard-2024'].id] }),
-    ).toEqual([{ label: 'Standard', sizeIds: [1] }]);
+    ).toEqual([{ label: 'Standard', sizeIds: [MOONBOARD_SIZE.id] }]);
   });
 
   it('stays empty for a layout the selected board type does not have', () => {

--- a/packages/mobile/src/lib/__tests__/wall-finder-filter.test.ts
+++ b/packages/mobile/src/lib/__tests__/wall-finder-filter.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { MOONBOARD_LAYOUTS, SUPPORTED_BOARDS, WOODS_LAYOUTS } from '@boardsesh/board-config';
 import {
   DEFAULT_WALL_FINDER_FILTER,
   hasActiveWallFinderFilter,
@@ -130,6 +131,28 @@ describe('buildLayoutOptions', () => {
       expect(option.label.length).toBeGreaterThan(0);
     }
   });
+
+  // Woods and MoonBoard are code-driven: they have no rows in the generated
+  // LAYOUTS table, so the Aurora-only accessor these builders used to call
+  // returned nothing and their chip rows came up empty (#4751).
+  it('lists the single Woods layout', () => {
+    expect(buildLayoutOptions({ boardTypes: ['woods'] })).toEqual([{ id: WOODS_LAYOUTS.woods.id, label: 'Original' }]);
+  });
+
+  it('lists every MoonBoard layout', () => {
+    expect(buildLayoutOptions({ boardTypes: ['moonboard'] })).toEqual(
+      Object.values(MOONBOARD_LAYOUTS).map((layout) => ({ id: layout.id, label: layout.name })),
+    );
+  });
+
+  // The regression guard the two cases above exist to generalise: a board added
+  // to SUPPORTED_BOARDS without a layout source silently ships an empty chip row,
+  // which reads as a broken filter rather than an absent one.
+  it('offers at least one layout for every supported board type', () => {
+    for (const boardType of SUPPORTED_BOARDS) {
+      expect(buildLayoutOptions({ boardTypes: [boardType] }).length).toBeGreaterThan(0);
+    }
+  });
 });
 
 describe('buildSizeOptions', () => {
@@ -148,5 +171,25 @@ describe('buildSizeOptions', () => {
       expect(typeof option.label).toBe('string');
       expect(option.sizeIds.length).toBeGreaterThan(0);
     }
+  });
+
+  // Both Woods sizes, as separate chips — an 8x10 climb can't be queued onto a
+  // 12x12 board, so the two must never collapse into one label.
+  it('offers both Woods sizes under the Woods layout', () => {
+    expect(buildSizeOptions({ boardTypes: ['woods'], layoutIds: [WOODS_LAYOUTS.woods.id] })).toEqual([
+      { label: '8 x 10', sizeIds: [1] },
+      { label: '12 x 12', sizeIds: [2] },
+    ]);
+  });
+
+  it("offers MoonBoard's single size under a MoonBoard layout", () => {
+    expect(
+      buildSizeOptions({ boardTypes: ['moonboard'], layoutIds: [MOONBOARD_LAYOUTS['moonboard-2024'].id] }),
+    ).toEqual([{ label: 'Standard', sizeIds: [1] }]);
+  });
+
+  it('stays empty for a layout the selected board type does not have', () => {
+    expect(buildSizeOptions({ boardTypes: ['woods'], layoutIds: [999] })).toEqual([]);
+    expect(buildSizeOptions({ boardTypes: ['moonboard'], layoutIds: [999] })).toEqual([]);
   });
 });

--- a/packages/mobile/src/lib/wall-finder-filter.ts
+++ b/packages/mobile/src/lib/wall-finder-filter.ts
@@ -1,5 +1,5 @@
 import type { BoardName } from '@boardsesh/shared-schema';
-import { getAllLayouts, getSizesForLayoutId } from '@boardsesh/board-constants';
+import { getBoardLayouts, getBoardSizesForLayoutId } from './custom-board-options';
 
 /**
  * The applied filter for the Find Gym ("Wall Finder") screen.
@@ -14,7 +14,7 @@ import { getAllLayouts, getSizesForLayoutId } from '@boardsesh/board-constants';
  *   not literally named after it).
  * - `place` — the label of a geocoded place search ("Showing <place>"); the
  *   camera move itself is viewport state, not stored here.
- * - `boardTypes` — selected board types (Kilter / Tension / MoonBoard),
+ * - `boardTypes` — selected board types (every board in `SUPPORTED_BOARDS`),
  *   multi-select OR. ANDs with `name` and the current viewport.
  * - `layoutIds` — selected layout ids, multi-select OR. Only meaningful when a
  *   single board type is selected (layouts are board-type-scoped), so the toggle
@@ -105,27 +105,34 @@ export function clearWallFinderChipFilters(filter: WallFinderFilter): WallFinder
 
 /**
  * Layout chips for the current filter — empty unless exactly one board type is
- * selected (layouts are board-type-scoped). Sourced from board-constants so the
- * chips are deterministic and don't vanish as the user narrows.
+ * selected (layouts are board-type-scoped). Sourced from the same board-aware
+ * cascade the board builder uses, so the chips are deterministic, don't vanish
+ * as the user narrows, and carry the exact ids the builder wrote to
+ * `user_boards.layout_id`. Going through `getBoardLayouts` rather than
+ * board-constants' `getAllLayouts` is what makes the code-driven boards work:
+ * MoonBoard and Woods have no generated `LAYOUTS` rows, so the Aurora-only
+ * helper returns nothing for them and their chips came up empty.
  */
 export function buildLayoutOptions(filter: WallFinderFilter): WallFinderLayoutOption[] {
   const types = filter.boardTypes ?? [];
   if (types.length !== 1) return [];
-  return getAllLayouts(types[0]).map((layout) => ({ id: layout.id, label: layout.name }));
+  return getBoardLayouts(types[0]).map((layout) => ({ id: layout.id, label: layout.name }));
 }
 
 /**
  * Size chips for the current filter — empty unless exactly one board type AND one
  * layout are selected (sizes are layout-scoped). Grouped by display name so one
  * chip can carry several Aurora size ids that share a label (e.g. a Full Ride /
- * Mainline pair under the same dimensions).
+ * Mainline pair under the same dimensions). Same board-aware cascade as
+ * `buildLayoutOptions` — Woods' two sizes and MoonBoard's single one live in
+ * code, not in the generated tables.
  */
 export function buildSizeOptions(filter: WallFinderFilter): WallFinderSizeOption[] {
   const types = filter.boardTypes ?? [];
   const layouts = filter.layoutIds ?? [];
   if (types.length !== 1 || layouts.length !== 1) return [];
   const byName = new Map<string, number[]>();
-  for (const size of getSizesForLayoutId(types[0], layouts[0])) {
+  for (const size of getBoardSizesForLayoutId(types[0], layouts[0])) {
     const existing = byName.get(size.name);
     if (existing) existing.push(size.id);
     else byName.set(size.name, [size.id]);


### PR DESCRIPTION
Closes #4751.

## Summary

Selecting the **Woods** or **MoonBoard** chip on Find Gym produced zero layout chips and zero size chips, so the filter read as broken rather than absent. MoonBoard has had this gap since it shipped; Woods inherited it in #3306.

`buildLayoutOptions` / `buildSizeOptions` called board-constants' `getAllLayouts` / `getSizesForLayoutId`, which read the generated `LAYOUTS` map. `LAYOUTS.woods` and `LAYOUTS.moonboard` are deliberately `{}` — both boards are code-driven rather than sourced from Aurora's tables — so the Aurora-only accessors returned nothing.

**The fix is reuse, not new branches.** `packages/mobile/src/lib/custom-board-options.ts` already *is* the Aurora-vs-code-driven cascade the issue proposed writing: it covers both boards, is unit-tested, and returns the same `LayoutData` / `ProductSizeData` shapes the chip builders consume. It's also what the board **builder** uses (`use-board-builder.ts:105-107`) — and the builder is what writes `user_boards.layout_id` / `size_id`. Pointing the chip builders at the same helpers therefore guarantees the chips emit exactly the ids the backend filters on, with no drift possible between the two. `wall-finder-filter.ts` was the last caller still on the Aurora-only accessors.

| Board | Layout chips | Size chips |
|---|---|---|
| Woods | Original | 8 x 10, 12 x 12 |
| MoonBoard | its seven layouts | Standard |
| Kilter / Tension | unchanged | unchanged |

No backend change — `gyms.ts:845-861` already filters with a board-agnostic `ub.layout_id IN (…) AND ub.size_id IN (…)`. No i18n change — chip labels come from board data.

The lone MoonBoard "Standard" size chip is a no-op filter (every MoonBoard board is `size_id` 1). Kept deliberately: it's consistent with single-size Aurora layouts, and suppressing it would mean adding back the per-board special case this change removes.

## The other half of #4751: dropped, not deferred

The issue also asked to widen the Bluetooth quickstart scan to detect Woods/MoonBoard controllers. I investigated and **dropped it**, with the reasoning written up [on the issue](https://github.com/boardsesh/boardsesh/issues/4751#issuecomment-5411894202) so it isn't rediscovered later. Short version:

1. **No identity on the wire** — Woods advertises exactly `"Woods Board"` / `"Woods Board v2"`. The name doesn't even carry board **size**, and size is the one Woods field that matters (8×10 and 12×12 hold ids overlap numerically but are different holds).
2. **Every branch dead-ends at a button already on the same screen** — the quickstart sheet sits beside "Create board" and "Find nearby" on `/boards`. Own one Woods board? It's already in "Your boards". Own both sizes? We can't tell which is in front of you.
3. **Location is already the better join key** — resolving *someone else's* gym board is what `useNearbyBoards` behind "Find nearby" does.
4. **The literal proposal would regress the scan** — `scanFamily: 'moonboard'` matches the *generic Nordic UART service UUID*, not just the name (`board-device-filter.ts:70`), so a gym full of UART peripherals would surface as "boards near you".

Worth revisiting only if Woods firmware ever advertises a serial. **No BLE files are touched by this PR**, so it's outside the Fable BLE-review gate.

## Test plan

- `vp run typecheck:mobile` — green
- `vp run test:mobile` — 700 files / 6917 tests green
- `vp check` — 2 errors + 261 warnings, byte-identical to a clean `main` tree (verified by stashing); nothing new
- `vp run check:mobile-bundle` — OK
- New coverage: `wall-finder-filter.test.ts` pins the actual chip data (exact Woods and MoonBoard layout/size output, plus a guard that **every** board in `SUPPORTED_BOARDS` yields ≥1 layout chip, so the next code-driven board can't silently ship an empty row). `wall-finder-filter-chips.test.tsx` gets the Woods case the issue asked for.
- Not done: a simulator pass. Port 8081 was held by another worktree's Metro, and pointing a dev client at the wrong bundle would have produced a false green — flagging rather than claiming it.

## Release Notes

- Filter the gym map by Woods and MoonBoard boards for real — picking Woods now offers Original plus the 8×10 and 12×12 sizes instead of an empty row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AByiA51rJL4ojKw5pBn7Rh
