### PR TITLE
fix(db): answer the Woods board-region and hold search filters

### DIFF
--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -5,8 +5,8 @@ import { ExternalUUIDSchema, BoardNameSchema } from './primitives';
 
 // Cap holdsFilter entries: each ANY entry becomes a LIKE scan over board_climbs.frames
 // (no trigram index there), so an unbounded record is a cheap amplification vector on
-// an anonymous endpoint. 300 is far above any board layout's usable hold count, so it
-// never rejects a real per-hold selection.
+// an anonymous endpoint. 300 is far above the number of holds anyone taps by hand —
+// though no longer above every board's hold count, since a Woods 12x12 has 894.
 const MAX_HOLD_FILTER_ENTRIES = 300;
 
 /** One transport batch for primary-backed live climb-stat reconciliation. */

--- a/packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts
+++ b/packages/db/src/queries/climbs/__tests__/create-climb-filters.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import type { SQL } from 'drizzle-orm';
+import { woodsHoldIdsInZone } from '@boardsesh/board-config';
 import { createClimbFilters } from '../create-climb-filters';
 import type { BoardRouteParams, ClimbSearchParams } from '../types';
 
@@ -191,7 +192,10 @@ void describe('createClimbFilters: zone modes', () => {
     assert.match(rendered, /zone_bp\.hole_id\s*=\s*zone_ch\.hold_id/);
     assert.match(rendered, /MOD\(\(zone_bp\.hole_id - 1\), 11\)/);
     assert.match(rendered, /1\.1 \+/);
-    assert.match(rendered, /16\.92 -/);
+    // Loose on the trailing digits: the vertical origin is computed in floating
+    // point (18 * 0.94 renders as 16.919999999999998), so pinning it exactly
+    // asserts the formatter rather than the calibration.
+    assert.match(rendered, /16\.9\d* -/);
     assert.doesNotMatch(rendered, /zone_bh\.x\s*>?=/);
     assert.doesNotMatch(rendered, /zone_bh\.y\s*>?=/);
     assert.doesNotMatch(rendered, /zone_bp\.set_id IN/);
@@ -205,7 +209,7 @@ void describe('createClimbFilters: zone modes', () => {
 
     const rendered = sqlToString(filters.zoneConditions[0]);
     assert.match(rendered, /1\.1517 \+/);
-    assert.match(rendered, /11\.0484 -/);
+    assert.match(rendered, /11\.04\d* -/);
     assert.match(rendered, /12 - \(FLOOR/);
   });
 
@@ -255,6 +259,113 @@ void describe('createClimbFilters: zone modes', () => {
   });
 });
 
+// Woods has no `board_placements` / `board_holes` rows and no denormalized
+// `edge_*` on its climbs, so neither of the paths above can answer a region box
+// for it (boardsesh/boardsesh#4748). Its holds are resolved against the box in
+// TypeScript and the query filters on hold ids instead.
+void describe('createClimbFilters: Woods zone modes', () => {
+  // 8x10 = size id 1, a 21-column x 25-row edge box. The lower-left quarter.
+  const woodsParams = { board_name: 'woods' as const, layout_id: 1, size_id: 1, set_ids: [1], angle: 40 };
+  const zoneBox = { edgeLeft: 0, edgeRight: 10, edgeBottom: 0, edgeTop: 12 };
+
+  void it('matches allHolds by rejecting any hold outside the box', () => {
+    const filters = createClimbFilters(woodsParams, { zoneBox });
+
+    assert.equal(filters.zoneConditions.length, 2);
+    const rendered = filters.zoneConditions.map(sqlToString).join(' && ');
+    // A climb must have holds, and none of them may fall outside the box.
+    assert.match(rendered, /EXISTS/);
+    assert.match(rendered, /NOT EXISTS/);
+    assert.match(rendered, /AND NOT \(zone_ch\.hold_id = ANY\(ARRAY\[/);
+    // No placement bridge, and no reliance on the NULL edge columns.
+    assert.doesNotMatch(rendered, /board_placements/);
+    assert.doesNotMatch(rendered, /board_holes/);
+    assert.doesNotMatch(rendered, /edge_left/);
+  });
+
+  void it('filters on exactly the hold ids the shared geometry puts inside the box', () => {
+    const filters = createClimbFilters(woodsParams, { zoneBox, zoneMode: 'anyHold' });
+    const rendered = sqlToString(filters.zoneConditions[0]);
+    const holdIds = woodsHoldIdsInZone(woodsParams.size_id, zoneBox)!;
+
+    // Read the ids back off the rendered ARRAY[...] literal rather than restating
+    // the geometry here — the point is that the query and the picker agree.
+    const renderedIds = rendered
+      .slice(rendered.indexOf('ARRAY[') + 'ARRAY['.length, rendered.indexOf(']::int[]'))
+      .split(',')
+      .map((value) => Number(value.trim()));
+    assert.ok(holdIds.length > 0);
+    assert.deepEqual(renderedIds, holdIds);
+  });
+
+  void it('matches anyHold with a single EXISTS over the holds inside the box', () => {
+    const filters = createClimbFilters(woodsParams, { zoneBox, zoneMode: 'anyHold' });
+
+    assert.equal(filters.zoneConditions.length, 1);
+    const rendered = sqlToString(filters.zoneConditions[0]);
+    assert.match(rendered, /EXISTS/);
+    assert.doesNotMatch(rendered, /NOT EXISTS/);
+    assert.match(rendered, /zone_ch\.hold_id = ANY\(ARRAY\[/);
+    assert.doesNotMatch(rendered, /board_placements/);
+  });
+
+  void it('selects different holds for the two board sizes', () => {
+    const smallBoard = createClimbFilters(woodsParams, { zoneBox, zoneMode: 'anyHold' });
+    const largeBoard = createClimbFilters({ ...woodsParams, size_id: 2 }, { zoneBox, zoneMode: 'anyHold' });
+
+    assert.notEqual(sqlToString(smallBoard.zoneConditions[0]), sqlToString(largeBoard.zoneConditions[0]));
+  });
+
+  void it('fails closed on a box that covers no hold', () => {
+    const filters = createClimbFilters(woodsParams, {
+      zoneBox: { edgeLeft: 0, edgeRight: 1, edgeBottom: 0, edgeTop: 1 },
+      zoneMode: 'anyHold',
+    });
+
+    assert.equal(filters.zoneConditions.length, 1);
+    assert.match(sqlToString(filters.zoneConditions[0]), /false/i);
+  });
+
+  void it('fails closed on a size id that is not a Woods board', () => {
+    const filters = createClimbFilters({ ...woodsParams, size_id: 99 }, { zoneBox });
+
+    assert.equal(filters.zoneConditions.length, 1);
+    assert.match(sqlToString(filters.zoneConditions[0]), /false/i);
+  });
+});
+
+// `baseHoldLocation` is 0-based on Woods, so the hold-key parser can't reject
+// non-positive ids the way it did — hold 0 is the first hold of every Woods board.
+void describe('createClimbFilters: hold keys', () => {
+  void it('keeps hold id 0', () => {
+    const filters = createClimbFilters(params, { holdsFilter: { '0': { ANY: 'include' } } });
+
+    assert.deepEqual(filters.anyHolds, [0]);
+    assert.match(sqlToString(filters.holdConditions[0]), /frames like %p0r%/i);
+  });
+
+  void it('keeps hold id 0 behind the hold_ prefix, and in a state filter', () => {
+    const filters = createClimbFilters(params, { holdsFilter: { hold_0: { HAND: 'include' } } });
+
+    assert.deepEqual(filters.holdStateFilters, [{ holdId: 0, state: 'HAND', mode: 'include' }]);
+  });
+
+  void it('still drops keys that are not a hold number', () => {
+    const filters = createClimbFilters(params, {
+      holdsFilter: {
+        hold_: { ANY: 'include' },
+        'hold_-1': { ANY: 'include' },
+        'hold_1.5': { ANY: 'include' },
+        hold_red: { ANY: 'include' },
+        '': { ANY: 'include' },
+      },
+    });
+
+    assert.deepEqual(filters.anyHolds, []);
+    assert.equal(filters.holdConditions.length, 0);
+  });
+});
+
 void describe('createClimbFilters: MoonBoard hold search', () => {
   const moonBoardParams: BoardRouteParams = {
     board_name: 'moonboard',
@@ -270,7 +381,7 @@ void describe('createClimbFilters: MoonBoard hold search', () => {
     });
 
     assert.equal(filters.holdConditions.length, 1);
-    assert.match(sqlToString(filters.holdConditions[0]), /frames LIKE %p56r%/);
+    assert.match(sqlToString(filters.holdConditions[0]), /frames like %p56r%/i);
   });
 
   void it('matches role-specific filters against MoonBoard climb-hold cell ids', () => {

--- a/packages/db/src/queries/climbs/create-climb-filters.ts
+++ b/packages/db/src/queries/climbs/create-climb-filters.ts
@@ -291,6 +291,10 @@ export const createClimbFilters = (params: BoardRouteParams, searchParams: Climb
       // The two Woods sizes reuse the same hold ids for different physical holds,
       // so the id set is per-size; the `compatible_size_ids` filter above is what
       // keeps the other size's climbs out of the results.
+      //
+      // The id list needs no cap the way `holdsFilter` does: it isn't user input,
+      // it's a subset of one board size's hold table, so it tops out at the 894
+      // holds of a 12x12 no matter what box arrives.
       const zoneHoldIds = woodsHoldIdsInZone(params.size_id, validZoneBox);
       if (!zoneHoldIds || zoneHoldIds.length === 0) {
         // An unknown size id, or a box drawn over bare board. No climb can match

--- a/packages/db/src/queries/climbs/create-climb-filters.ts
+++ b/packages/db/src/queries/climbs/create-climb-filters.ts
@@ -1,5 +1,5 @@
 import { type SQL, eq, gt, gte, sql, like, notLike, inArray, isNull, or, and } from 'drizzle-orm';
-import { getMoonBoardGeometryByLayoutId } from '@boardsesh/board-config';
+import { getMoonBoardGeometryByLayoutId, woodsHoldIdsInZone } from '@boardsesh/board-config';
 import { getTallWideScope } from '@boardsesh/board-constants/product-sizes';
 import {
   boardClimbs,
@@ -21,11 +21,14 @@ function escapeLikePattern(input: string): string {
   return input.replace(/[\\%_]/g, (char) => `\\${char}`);
 }
 
-// A Postgres `ARRAY[...]::int[]` literal from a size-id list, for the tall/wide
-// `compatible_size_ids &&` overlap predicates.
-function sizeIdArrayLiteral(sizeIds: readonly number[]): SQL {
+// A Postgres `ARRAY[...]::int[]` literal from a number list, for the tall/wide
+// `compatible_size_ids &&` overlap predicates and the Woods zone `= ANY(...)`
+// probes. Built explicitly because drizzle's `sql` template expands a bare JS
+// array into a parenthesised parameter list — a ROW literal Postgres won't cast
+// to `int[]`.
+function intArrayLiteral(values: readonly number[]): SQL {
   return sql`ARRAY[${sql.join(
-    sizeIds.map((sizeId) => sql`${sizeId}`),
+    values.map((value) => sql`${value}`),
     sql`, `,
   )}]::int[]`;
 }
@@ -64,8 +67,14 @@ export const createClimbFilters = (params: BoardRouteParams, searchParams: Climb
   const holdStateFilters: Array<{ holdId: number; state: string; mode: 'include' | 'exclude' }> = [];
 
   for (const [keyRaw, entry] of Object.entries(searchParams.holdsFilter || {})) {
-    const holdId = Number(keyRaw.replace('hold_', ''));
-    if (!Number.isInteger(holdId) || holdId <= 0 || !entry || typeof entry !== 'object') continue;
+    // Hold ids are 0-based on Woods, so the guard can't reject non-positive ids the
+    // way it used to — the first hold of every Woods board would be unfilterable.
+    // `Number('')` is 0 too, so check the key really is digits instead of leaning
+    // on the parsed number alone. The offline mirror of this parser lives in
+    // packages/mobile/src/db/queries/search-climbs-local.ts and must agree.
+    const holdKey = keyRaw.replace('hold_', '');
+    const holdId = Number(holdKey);
+    if (!/^\d+$/.test(holdKey) || !Number.isSafeInteger(holdId) || !entry || typeof entry !== 'object') continue;
     for (const [type, mode] of Object.entries(entry as Record<string, unknown>)) {
       if (mode !== 'include' && mode !== 'exclude') continue;
       if (type === 'ANY') {
@@ -254,7 +263,9 @@ export const createClimbFilters = (params: BoardRouteParams, searchParams: Climb
   // Zone filter — restrict climbs by the user-defined box in board grid
   // coordinates. Aurora boards keep the denormalized `allHolds` path.
   // MoonBoard uses calibrated layout placements for both modes because its
-  // climbs intentionally do not carry denormalized edge columns.
+  // climbs intentionally do not carry denormalized edge columns. Woods has
+  // neither placements nor edge columns and resolves the box against its hold
+  // geometry in TypeScript (see the branch below).
   // Direct db-layer callers bypass GraphQL validation, so re-check the box.
   const zoneBox = searchParams.zoneBox;
   const hasZoneBox = !!zoneBox;
@@ -267,7 +278,61 @@ export const createClimbFilters = (params: BoardRouteParams, searchParams: Climb
     // closed like the tall/wide filters below rather than returning every climb.
     zoneConditions.push(sql`false`);
   } else if (validZoneBox) {
-    if (zoneMode === 'anyHold') {
+    if (params.board_name === 'woods') {
+      // Woods is code-driven: there are no `board_placements` / `board_holes`
+      // rows to read a hold's coordinates from, and its climbs carry no
+      // denormalized `edge_*`, so both paths below match nothing at all
+      // (boardsesh/boardsesh#4748). Resolve the box in TypeScript instead —
+      // `woodsHoldIdsInZone` walks the same detected hold centres the picker drew
+      // the box over — and filter on hold ids, which `board_climb_holds` stores
+      // directly. Its primary key is (board_type, climb_uuid, hold_id), so each
+      // probe below is an index lookup.
+      //
+      // The two Woods sizes reuse the same hold ids for different physical holds,
+      // so the id set is per-size; the `compatible_size_ids` filter above is what
+      // keeps the other size's climbs out of the results.
+      const zoneHoldIds = woodsHoldIdsInZone(params.size_id, validZoneBox);
+      if (!zoneHoldIds || zoneHoldIds.length === 0) {
+        // An unknown size id, or a box drawn over bare board. No climb can match
+        // either way, and returning everything would be worse than nothing — so
+        // fail closed like the degenerate-box case above.
+        zoneConditions.push(sql`false`);
+      } else if (zoneMode === 'anyHold') {
+        zoneConditions.push(sql`EXISTS (
+          SELECT 1
+          FROM ${boardClimbHolds} zone_ch
+          WHERE zone_ch.board_type = ${params.board_name}
+            AND zone_ch.climb_uuid = ${boardClimbs.uuid}
+            AND zone_ch.hold_id = ANY(${intArrayLiteral(zoneHoldIds)})
+        )`);
+      } else {
+        // allHolds: every hold of the climb must fit inside the box — i.e. the
+        // climb has holds, and none of them is outside it. Same shape as the
+        // MoonBoard containment branch, where the leading EXISTS is what stops a
+        // climb with no hold rows at all from matching vacuously.
+        //
+        // "Outside" is phrased as the complement of the in-box ids rather than as
+        // its own list, so a hold id the geometry doesn't know — a corrupt row, or
+        // one from a catalog newer than these constants — counts as outside rather
+        // than being silently waved through. It also binds the smaller array for
+        // the boxes people actually draw.
+        zoneConditions.push(
+          sql`EXISTS (
+            SELECT 1
+            FROM ${boardClimbHolds} zone_ch
+            WHERE zone_ch.board_type = ${params.board_name}
+              AND zone_ch.climb_uuid = ${boardClimbs.uuid}
+          )`,
+          sql`NOT EXISTS (
+            SELECT 1
+            FROM ${boardClimbHolds} zone_ch
+            WHERE zone_ch.board_type = ${params.board_name}
+              AND zone_ch.climb_uuid = ${boardClimbs.uuid}
+              AND NOT (zone_ch.hold_id = ANY(${intArrayLiteral(zoneHoldIds)}))
+          )`,
+        );
+      }
+    } else if (zoneMode === 'anyHold') {
       const zonePlacementMatch = climbHoldPlacementMatchSql({
         boardType: sql.raw('zone_ch.board_type'),
         climbHoldId: sql.raw('zone_ch.hold_id'),
@@ -375,7 +440,7 @@ export const createClimbFilters = (params: BoardRouteParams, searchParams: Climb
   if (searchParams.onlyTallClimbs) {
     tallClimbsConditions.push(
       hasShorter
-        ? sql`${boardClimbs.compatibleSizeIds} IS NOT NULL AND NOT (${boardClimbs.compatibleSizeIds} && ${sizeIdArrayLiteral(shorterSizeIds)})`
+        ? sql`${boardClimbs.compatibleSizeIds} IS NOT NULL AND NOT (${boardClimbs.compatibleSizeIds} && ${intArrayLiteral(shorterSizeIds)})`
         : sql`false`,
     );
   }
@@ -384,7 +449,7 @@ export const createClimbFilters = (params: BoardRouteParams, searchParams: Climb
   if (searchParams.onlyWideClimbs) {
     wideClimbsConditions.push(
       hasNarrower
-        ? sql`${boardClimbs.compatibleSizeIds} IS NOT NULL AND NOT (${boardClimbs.compatibleSizeIds} && ${sizeIdArrayLiteral(narrowerSizeIds)})`
+        ? sql`${boardClimbs.compatibleSizeIds} IS NOT NULL AND NOT (${boardClimbs.compatibleSizeIds} && ${intArrayLiteral(narrowerSizeIds)})`
         : sql`false`,
     );
   }

--- a/packages/mobile/app/(tabs)/climbs/__tests__/holds.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/holds.test.tsx
@@ -193,16 +193,15 @@ describe('HoldFilterScreen', () => {
     expect(emitMock).toHaveBeenCalledWith({ [String(TAPPED_HOLD_ID)]: { STARTING: 'include' } });
   });
 
-  // The filter sheet hides the Holds row for Woods, so only a hand-built link
-  // gets here — and painting holds would search against placement rows that
-  // don't exist for that board.
-  it('leaves the route for a board that has no hold placements to search', () => {
+  // Woods hold ids match `board_climb_holds.hold_id` and the `p<id>r` frames token
+  // directly — no placement bridge — so this route paints for it like any other
+  // board (boardsesh/boardsesh#4748).
+  it('paints the board for a code-driven board instead of leaving the route', () => {
     routeParams.current = { boardName: 'woods', layoutId: '1', sizeId: '1', setIds: '1' };
 
-    const { container, queryByText } = render(<HoldFilterScreen />);
+    const { container } = render(<HoldFilterScreen />);
 
-    expect(routerMock.replace).toHaveBeenCalledWith('/(tabs)/climbs');
-    expect(queryByText('board')).toBeNull();
-    expect(container.querySelector('[data-spinner]')).not.toBeNull();
+    expect(routerMock.replace).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-spinner]')).toBeNull();
   });
 });

--- a/packages/mobile/app/(tabs)/climbs/__tests__/zone-screen.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/zone-screen.test.tsx
@@ -323,18 +323,17 @@ describe('ZoneFilterScreen', () => {
     });
   });
 
-  // The filter sheet hides the Zone row for Woods, so only a hand-built link
-  // gets here — and its hold centres are board-art pixels, not the placement
-  // grid the box is expressed in, so a dragged region would filter nothing.
-  describe('a board whose holds are not in placement-grid space', () => {
-    it('leaves the route instead of offering a region to drag', () => {
+  // Woods reaches this route like any other board now: its zone box is projected
+  // from its own hold geometry rather than a placement grid
+  // (boardsesh/boardsesh#4748).
+  describe('a code-driven board', () => {
+    it('offers a region to drag instead of leaving the route', () => {
       routeParams.current = baseParams({ boardName: 'woods', sizeId: '1' });
 
       const { container } = render(<ZoneFilterScreen />);
 
-      expect(routerMock.replace).toHaveBeenCalledWith('/(tabs)/climbs');
-      expect(container.querySelector('[data-button="mobile.zoneFilter.enable"]')).toBeNull();
-      expect(container.querySelector('[data-spinner]')).not.toBeNull();
+      expect(routerMock.replace).not.toHaveBeenCalled();
+      expect(container.querySelector('[data-button="mobile.zoneFilter.enable"]')).not.toBeNull();
     });
   });
 });

--- a/packages/mobile/app/(tabs)/climbs/holds.tsx
+++ b/packages/mobile/app/(tabs)/climbs/holds.tsx
@@ -6,7 +6,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { getLayout } from '@boardsesh/board-constants/product-sizes';
 import { countFilteredHolds, parseHoldsFilter, toggleHoldFilterType } from '@boardsesh/climb-filters';
-import { getBoardCapabilities } from '@boardsesh/board-config';
 import type { BoardName, HoldFilterEntry, HoldFilterMode, HoldFilterType, HoldsFilter } from '@boardsesh/shared-schema';
 import { Text } from '../../../src/components/Text';
 import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
@@ -15,7 +14,6 @@ import { HoldFilterPicker } from '../../../src/components/search/HoldFilterPicke
 import { useTheme } from '../../../src/providers/theme-provider';
 import { getCreateBoardHolds, parseSetIdsParam } from '../../../src/lib/create-board-holds';
 import { emitHoldsFilterSelection } from '../../../src/lib/hold-filter-handoff';
-import { useUnsupportedBoardExit } from '../../../src/lib/routing/use-unsupported-board-exit';
 import { track } from '../../../src/lib/analytics';
 import { spacing } from '../../../src/theme/tokens';
 
@@ -61,14 +59,6 @@ export default function HoldFilterScreen() {
   // `boardDetails.layout_name`), not the numeric id, so the hold-filter events
   // join cleanly with web across platforms. Falls back to '' for unknown ids.
   const boardLayout = getLayout(boardName, layoutId)?.name ?? '';
-
-  // The filter sheet hides the Holds row on a board that can't answer a hold
-  // search (Woods), so only a hand-built link reaches this route for one. Leave
-  // rather than paint a board whose taps would search against no placement rows:
-  // online hold search resolves the picked hold ids against `board_placements`,
-  // which has no Woods rows yet (#4748).
-  const boardCannotSearchHolds = params.boardName != null && !getBoardCapabilities(params.boardName).holdFilters;
-  useUnsupportedBoardExit(boardCannotSearchHolds);
 
   const [holdsFilter, setHoldsFilter] = useState<HoldsFilter>(() => parseHoldsFilter(params.holdsFilter));
   // Mirror of the latest holdsFilter so the focus-effect cleanup hands back the
@@ -160,7 +150,7 @@ export default function HoldFilterScreen() {
     });
   }, [navigation, filteredCount, handleClearAll, brandColors.primary, t]);
 
-  if (!boardHolds || !boardName || boardCannotSearchHolds) {
+  if (!boardHolds || !boardName) {
     return (
       <View style={[styles.loading, { backgroundColor: systemColors.background }]}>
         <ActivityIndicator size="large" />

--- a/packages/mobile/app/(tabs)/climbs/zone.tsx
+++ b/packages/mobile/app/(tabs)/climbs/zone.tsx
@@ -12,7 +12,6 @@ import {
   type HoldPositionLookup,
 } from '@boardsesh/climb-filters';
 import { getLayout } from '@boardsesh/board-constants';
-import { getBoardCapabilities } from '@boardsesh/board-config';
 import type { BoardName, HoldsFilter, ZoneBoxInput, ZoneMatchMode } from '@boardsesh/shared-schema';
 import { Text } from '../../../src/components/Text';
 import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
@@ -27,7 +26,6 @@ import { ZoneOverlay, type ZoneCornerLabels } from '../../../src/components/sear
 import { useTheme } from '../../../src/providers/theme-provider';
 import { getCreateBoardHolds } from '../../../src/lib/create-board-holds';
 import { emitZoneFilterSelection } from '../../../src/lib/zone-filter-handoff';
-import { useUnsupportedBoardExit } from '../../../src/lib/routing/use-unsupported-board-exit';
 import { track } from '../../../src/lib/analytics';
 import { hapticSelection } from '../../../src/lib/haptics';
 import { overlays, spacing } from '../../../src/theme/tokens';
@@ -111,13 +109,6 @@ export default function ZoneFilterScreen() {
   // carried the board family (e.g. "kilter"), so resolve the real name from the
   // board config instead of trusting the param.
   const layoutName = getLayout(boardName, layoutId)?.name ?? '';
-
-  // The filter sheet hides the Zone row on a board whose hold centres aren't in
-  // placement-grid space (Woods), so only a hand-built link reaches this route
-  // for one. Leave rather than let a box be dragged in coordinates the search
-  // can't read back (#4748).
-  const boardCannotSearchZone = params.boardName != null && !getBoardCapabilities(params.boardName).holdFilters;
-  useUnsupportedBoardExit(boardCannotSearchZone);
 
   const [zoneBox, setZoneBox] = useState<ZoneBoxInput | null>(() => parseZoneBox(params.zoneBox));
   const [zoneMode, setZoneMode] = useState<ZoneMatchMode>(() => parseZoneMode(params.zoneMode));
@@ -299,7 +290,7 @@ export default function ZoneFilterScreen() {
     });
   }, [navigation, zoneActive, handleClear, brandColors.primary, t]);
 
-  if (!boardHolds || !boardName || !dims || boardCannotSearchZone) {
+  if (!boardHolds || !boardName || !dims) {
     return (
       <View style={[styles.loading, { backgroundColor: systemColors.background }]}>
         <ActivityIndicator size="large" />

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -37,7 +37,6 @@ import {
   type BoardSearchConfig,
   type ProgressFilter,
 } from '@boardsesh/climb-filters';
-import { getBoardCapabilities } from '@boardsesh/board-config';
 import { Text } from './Text';
 import { Button } from './Button';
 import { SegmentedControl } from './SegmentedControl';
@@ -547,10 +546,8 @@ export function ClimbFilterSheet({
   // a board config — the sheet only mounts while it's open, so mount == visible.
   // Prewarming is an idempotent cache warm, so a re-run on boardConfig churn is
   // harmless. (Replaces the old expand-triggered PREWARM_..._AFTER_REFINE path.)
-  // Skipped on a board whose Holds row is hidden (Woods): the warm cache has no
-  // reader left, so it would only burn the geometry pass on sheet open.
   useEffect(() => {
-    if (!boardConfig || !getBoardCapabilities(boardConfig.boardName).holdFilters) return;
+    if (!boardConfig) return;
     prewarmCreateBoardHolds({
       boardName: boardConfig.boardName as BoardName,
       layoutId: boardConfig.layoutId,
@@ -705,12 +702,6 @@ export function ClimbFilterSheet({
 
   const holdFilterCount = countFilteredHolds(localBoardFilters.holdsFilter);
   const zoneActive = localBoardFilters.zoneBox != null;
-  // Woods has no `board_placements` rows to search hold ids against, and its
-  // zone box would be dragged in board-art pixels rather than the placement-grid
-  // space the query filters on — both rows would return silent zero results, so
-  // hide them entirely (#4748). See the holdFilters row of the board-capability
-  // table in @boardsesh/board-config.
-  const holdFiltersAvailable = getBoardCapabilities(boardConfig?.boardName).holdFilters;
 
   const trackColor = systemColors.fill;
   const accuracyValue: GradeAccuracyValue | 'off' = localFilters.gradeAccuracy ?? 'off';
@@ -1047,55 +1038,51 @@ export function ClimbFilterSheet({
                 </View>
               </Pressable>
 
-              {holdFiltersAvailable ? (
-                <>
-                  <View style={styles.subsectionGap} />
-                  <Pressable
-                    onPress={openHoldFilter}
-                    disabled={!boardConfig}
-                    accessibilityRole="button"
-                    accessibilityLabel={t('mobile.holdFilter.title')}
-                    style={({ pressed }) => [
-                      styles.tappableRow,
-                      { backgroundColor: systemColors.tertiaryBackground },
-                      pressed && styles.tappableRowPressed,
-                      !boardConfig && styles.tappableRowDisabled,
-                    ]}
-                  >
-                    <Text variant="body">{t('mobile.holdFilter.title')}</Text>
-                    <View style={styles.tappableRowTrailing}>
-                      <Text variant="footnote" style={styles.tappableRowValue}>
-                        {holdFilterCount > 0
-                          ? t('mobile.holdFilter.summaryCount', { count: holdFilterCount })
-                          : t('mobile.filter.none')}
-                      </Text>
-                      <Icon name="chevron.right" size={14} color={systemColors.tertiaryLabel} />
-                    </View>
-                  </Pressable>
+              <View style={styles.subsectionGap} />
+              <Pressable
+                onPress={openHoldFilter}
+                disabled={!boardConfig}
+                accessibilityRole="button"
+                accessibilityLabel={t('mobile.holdFilter.title')}
+                style={({ pressed }) => [
+                  styles.tappableRow,
+                  { backgroundColor: systemColors.tertiaryBackground },
+                  pressed && styles.tappableRowPressed,
+                  !boardConfig && styles.tappableRowDisabled,
+                ]}
+              >
+                <Text variant="body">{t('mobile.holdFilter.title')}</Text>
+                <View style={styles.tappableRowTrailing}>
+                  <Text variant="footnote" style={styles.tappableRowValue}>
+                    {holdFilterCount > 0
+                      ? t('mobile.holdFilter.summaryCount', { count: holdFilterCount })
+                      : t('mobile.filter.none')}
+                  </Text>
+                  <Icon name="chevron.right" size={14} color={systemColors.tertiaryLabel} />
+                </View>
+              </Pressable>
 
-                  <View style={styles.subsectionGap} />
-                  <Pressable
-                    onPress={openZoneFilter}
-                    disabled={!boardConfig}
-                    accessibilityRole="button"
-                    accessibilityLabel={t('mobile.zoneFilter.title')}
-                    style={({ pressed }) => [
-                      styles.tappableRow,
-                      { backgroundColor: systemColors.tertiaryBackground },
-                      pressed && styles.tappableRowPressed,
-                      !boardConfig && styles.tappableRowDisabled,
-                    ]}
-                  >
-                    <Text variant="body">{t('mobile.zoneFilter.title')}</Text>
-                    <View style={styles.tappableRowTrailing}>
-                      <Text variant="footnote" style={styles.tappableRowValue}>
-                        {zoneActive ? t('mobile.zoneFilter.summaryActive') : t('mobile.filter.none')}
-                      </Text>
-                      <Icon name="chevron.right" size={14} color={systemColors.tertiaryLabel} />
-                    </View>
-                  </Pressable>
-                </>
-              ) : null}
+              <View style={styles.subsectionGap} />
+              <Pressable
+                onPress={openZoneFilter}
+                disabled={!boardConfig}
+                accessibilityRole="button"
+                accessibilityLabel={t('mobile.zoneFilter.title')}
+                style={({ pressed }) => [
+                  styles.tappableRow,
+                  { backgroundColor: systemColors.tertiaryBackground },
+                  pressed && styles.tappableRowPressed,
+                  !boardConfig && styles.tappableRowDisabled,
+                ]}
+              >
+                <Text variant="body">{t('mobile.zoneFilter.title')}</Text>
+                <View style={styles.tappableRowTrailing}>
+                  <Text variant="footnote" style={styles.tappableRowValue}>
+                    {zoneActive ? t('mobile.zoneFilter.summaryActive') : t('mobile.filter.none')}
+                  </Text>
+                  <Icon name="chevron.right" size={14} color={systemColors.tertiaryLabel} />
+                </View>
+              </Pressable>
 
               {/* Beta videos — a content property of the climb, not a quality signal.
                   A group header carries the pin; the switch uses the descriptive line

--- a/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
@@ -694,10 +694,10 @@ describe('ClimbFilterSheet rows without a board config', () => {
   });
 });
 
-// Woods has no `board_placements` rows to resolve a hold search against, and its
-// hold centres are board-art pixels rather than placement-grid coordinates — so
-// both pickers would return silent zero results. The rows go away entirely
-// rather than sit there doing nothing.
+// Woods used to hide both pickers: it has no `board_placements` rows to resolve a
+// hold search against, and its zone box is projected from its own hold geometry
+// rather than a placement grid. The search answers both off that geometry now, so
+// the rows are offered on every board — boardsesh/boardsesh#4748.
 describe('ClimbFilterSheet hold + zone rows by board', () => {
   const woodsBoardConfig = { ...boardConfig, boardName: 'woods' };
 
@@ -708,23 +708,19 @@ describe('ClimbFilterSheet hold + zone rows by board', () => {
     expect(queryByLabelText('mobile.zoneFilter.title')).not.toBeNull();
   });
 
-  it('hides both rows for Woods', () => {
+  it('shows both rows on Woods too', () => {
     const { queryByLabelText } = renderFilterSheet({ boardConfig: woodsBoardConfig });
 
-    expect(queryByLabelText('mobile.holdFilter.title')).toBeNull();
-    expect(queryByLabelText('mobile.zoneFilter.title')).toBeNull();
+    expect(queryByLabelText('mobile.holdFilter.title')).not.toBeNull();
+    expect(queryByLabelText('mobile.zoneFilter.title')).not.toBeNull();
   });
 
-  it('keeps the Setters row on Woods — only the placement-backed filters go', () => {
-    const { queryByLabelText } = renderFilterSheet({ boardConfig: woodsBoardConfig });
-
-    expect(queryByLabelText('mobile.filter.setters')).not.toBeNull();
-  });
-
-  it('skips the hold-geometry prewarm when the Holds row is hidden', () => {
+  it('warms the hold geometry on Woods, the same as any other board', () => {
     renderFilterSheet({ boardConfig: woodsBoardConfig });
 
-    expect(createBoardHoldsMocks.prewarmCreateBoardHolds).not.toHaveBeenCalled();
+    expect(createBoardHoldsMocks.prewarmCreateBoardHolds).toHaveBeenCalledWith(
+      expect.objectContaining({ boardName: 'woods' }),
+    );
   });
 });
 

--- a/packages/mobile/src/db/queries/__tests__/search-climbs-local.test.ts
+++ b/packages/mobile/src/db/queries/__tests__/search-climbs-local.test.ts
@@ -298,6 +298,19 @@ describe('searchClimbsLocal', () => {
     ]);
   });
 
+  // Woods numbers its holds from 0, so hold 0 is a real hold. It used to be
+  // dropped by the key parser here and online both — boardsesh/boardsesh#4748.
+  it('filters on hold id 0 without matching p10r/p20r', async () => {
+    await insertClimb(db, { uuid: 'ground-up', name: 'Ground Up', frames: 'p0r4p18r2' });
+    await insertClimb(db, { uuid: 'high-start', name: 'High Start', frames: 'p10r4p203r2' });
+    await insertStat(db, { climbUuid: 'ground-up', ascensionistCount: 5 });
+    await insertStat(db, { climbUuid: 'high-start', ascensionistCount: 5 });
+
+    expect(uuids(await searchClimbsLocal(db, makeInput({ holdsFilter: { hold_0: { ANY: 'include' } } })))).toEqual([
+      'ground-up',
+    ]);
+  });
+
   it('applies personal-progress filters against local ticks and surfaces user counts', async () => {
     await insertClimb(db, { uuid: 'sent' });
     await insertClimb(db, { uuid: 'tried' });

--- a/packages/mobile/src/db/queries/search-climbs-local.ts
+++ b/packages/mobile/src/db/queries/search-climbs-local.ts
@@ -104,8 +104,13 @@ function parseHoldsFilter(holdsFilter: unknown): HoldFilters {
   let hasHoldState = false;
   if (holdsFilter && typeof holdsFilter === 'object') {
     for (const [keyRaw, entry] of Object.entries(holdsFilter as Record<string, unknown>)) {
-      const holdId = Number(String(keyRaw).replace('hold_', ''));
-      if (!Number.isInteger(holdId) || holdId <= 0 || !entry || typeof entry !== 'object') continue;
+      // Same shape as the online parser in
+      // packages/db/src/queries/climbs/create-climb-filters.ts — hold id 0 is a
+      // real hold on Woods, and the two must agree or an offline search answers a
+      // filter the online one drops.
+      const holdKey = String(keyRaw).replace('hold_', '');
+      const holdId = Number(holdKey);
+      if (!/^\d+$/.test(holdKey) || !Number.isSafeInteger(holdId) || !entry || typeof entry !== 'object') continue;
       for (const [type, mode] of Object.entries(entry as Record<string, unknown>)) {
         if (mode !== 'include' && mode !== 'exclude') continue;
         if (type === 'ANY') {

--- a/packages/shared/board-config/src/__tests__/board-capabilities.test.ts
+++ b/packages/shared/board-config/src/__tests__/board-capabilities.test.ts
@@ -5,34 +5,30 @@ import { getBoardCapabilities, type BoardCapabilities } from '../board-capabilit
 // The whole table in one place: change a row here and the reviewer sees exactly
 // which surface turns on or off.
 const EXPECTED: Record<string, BoardCapabilities> = {
-  kilter: { crowdGrade: true, holdFilters: true, climbCreation: true, nativeBoardControl: true, auroraAppLink: true },
-  tension: { crowdGrade: true, holdFilters: true, climbCreation: true, nativeBoardControl: true, auroraAppLink: true },
-  decoy: { crowdGrade: true, holdFilters: true, climbCreation: true, nativeBoardControl: true, auroraAppLink: true },
+  kilter: { crowdGrade: true, climbCreation: true, nativeBoardControl: true, auroraAppLink: true },
+  tension: { crowdGrade: true, climbCreation: true, nativeBoardControl: true, auroraAppLink: true },
+  decoy: { crowdGrade: true, climbCreation: true, nativeBoardControl: true, auroraAppLink: true },
   touchstone: {
     crowdGrade: true,
-    holdFilters: true,
     climbCreation: true,
     nativeBoardControl: true,
     auroraAppLink: true,
   },
   grasshopper: {
     crowdGrade: true,
-    holdFilters: true,
     climbCreation: true,
     nativeBoardControl: true,
     auroraAppLink: true,
   },
-  soill: { crowdGrade: true, holdFilters: true, climbCreation: true, nativeBoardControl: true, auroraAppLink: true },
+  soill: { crowdGrade: true, climbCreation: true, nativeBoardControl: true, auroraAppLink: true },
   moonboard: {
     crowdGrade: false,
-    holdFilters: true,
     climbCreation: true,
     nativeBoardControl: true,
     auroraAppLink: false,
   },
   woods: {
     crowdGrade: false,
-    holdFilters: false,
     climbCreation: false,
     nativeBoardControl: false,
     auroraAppLink: false,
@@ -54,7 +50,6 @@ describe('getBoardCapabilities', () => {
     for (const auroraBoard of AURORA_BOARDS) {
       expect(getBoardCapabilities(auroraBoard)).toEqual({
         crowdGrade: true,
-        holdFilters: true,
         climbCreation: true,
         nativeBoardControl: true,
         auroraAppLink: true,
@@ -75,7 +70,6 @@ describe('getBoardCapabilities', () => {
     // missing board guard on it separately.
     const auroraDefaults = {
       crowdGrade: true,
-      holdFilters: true,
       climbCreation: true,
       nativeBoardControl: true,
       auroraAppLink: true,

--- a/packages/shared/board-config/src/__tests__/woods-config.test.ts
+++ b/packages/shared/board-config/src/__tests__/woods-config.test.ts
@@ -13,6 +13,8 @@ import {
   getWoodsHoldPosition,
   getWoodsHoldGridPosition,
   getWoodsHoldImagePosition,
+  getWoodsHoldZonePosition,
+  woodsHoldIdsInZone,
   getWoodsMirroredHoldLocation,
   getWoodsBoardDetails,
   encodeWoodsHoldsToFrames,
@@ -238,5 +240,183 @@ describe('getGradesForBoard(woods)', () => {
   it('leaves the other boards on the full ladder', () => {
     expect(getGradesForBoard('kilter')).toEqual(BOULDER_GRADES);
     expect(getGradesForBoard('woods').length).toBeLessThan(BOULDER_GRADES.length);
+  });
+});
+
+// The board-region ("zone") search box is dragged over the board art and sent to
+// the server in the grid space `getWoodsBoardDetails` reports its edges in. The
+// client derives a hold's place in that space with `svgToGrid`
+// (packages/shared/climb-filters/src/climb-zone-math.ts); the server derives it
+// with `getWoodsHoldZonePosition`. These tests pin the two to the same answer —
+// see boardsesh/boardsesh#4748.
+//
+// `svgToGrid` is re-stated here rather than imported so board-config keeps no
+// dependency on climb-filters. Its own copy of the formula is pinned against
+// Woods-shaped dims in climb-zone-math.test.ts, so a change on either side breaks
+// a test.
+function svgToGridReference(
+  svgX: number,
+  svgY: number,
+  dims: {
+    boardWidth: number;
+    boardHeight: number;
+    edgeLeft: number;
+    edgeRight: number;
+    edgeBottom: number;
+    edgeTop: number;
+  },
+): { x: number; y: number } {
+  const xSpacing = dims.boardWidth / (dims.edgeRight - dims.edgeLeft);
+  const ySpacing = dims.boardHeight / (dims.edgeTop - dims.edgeBottom);
+  return {
+    x: svgX / xSpacing + dims.edgeLeft,
+    y: dims.edgeBottom + (dims.boardHeight - svgY) / ySpacing,
+  };
+}
+
+describe('getWoodsHoldZonePosition', () => {
+  it('scales the detected position onto the board edges, flipping y', () => {
+    const geometry = WOODS_GEOMETRY['12x12'];
+    const detected = getWoodsHoldGridPosition(0, '12x12')!;
+    const zone = getWoodsHoldZonePosition(0, '12x12')!;
+
+    expect(zone.x).toBeCloseTo(detected.x * geometry.maxColumns, 5);
+    expect(zone.y).toBeCloseTo((1 - detected.y) * geometry.numRows, 5);
+  });
+
+  it('puts the top row high and the bottom row low — the y flip is the easy thing to get wrong', () => {
+    const topRowHold = getWoodsHoldZonePosition(0, '8x10')!;
+    const bottomRowHold = getWoodsHoldZonePosition(totalHolds('8x10') - 1, '8x10')!;
+
+    expect(topRowHold.y).toBeGreaterThan(bottomRowHold.y);
+    expect(topRowHold.y).toBeGreaterThan(WOODS_GEOMETRY['8x10'].numRows * 0.9);
+    expect(bottomRowHold.y).toBeLessThan(WOODS_GEOMETRY['8x10'].numRows * 0.15);
+  });
+
+  it('agrees with the client grid math over every hold on both sizes', () => {
+    for (const size of WOODS_BOARD_SIZES) {
+      const details = getWoodsBoardDetails({ size_id: WOODS_SIZES[size].id });
+      const dims = {
+        boardWidth: details.boardWidth,
+        boardHeight: details.boardHeight,
+        edgeLeft: details.edge_left,
+        edgeRight: details.edge_right,
+        edgeBottom: details.edge_bottom,
+        edgeTop: details.edge_top,
+      };
+
+      for (const hold of details.holdsData) {
+        const expected = svgToGridReference(hold.cx, hold.cy, dims);
+        const actual = getWoodsHoldZonePosition(hold.id, size)!;
+        expect(actual.x).toBeCloseTo(expected.x, 6);
+        expect(actual.y).toBeCloseTo(expected.y, 6);
+      }
+    }
+  });
+
+  it('returns undefined for a location past the board', () => {
+    expect(getWoodsHoldZonePosition(485, '8x10')).toBeUndefined();
+  });
+});
+
+describe('woodsHoldIdsInZone', () => {
+  const fullBoard = (size: '8x10' | '12x12') => ({
+    edgeLeft: 0,
+    edgeRight: WOODS_GEOMETRY[size].maxColumns,
+    edgeBottom: 0,
+    edgeTop: WOODS_GEOMETRY[size].numRows,
+  });
+
+  it('returns a subset of the board, ascending and without duplicates', () => {
+    for (const size of WOODS_BOARD_SIZES) {
+      const box = { ...fullBoard(size), edgeRight: WOODS_GEOMETRY[size].maxColumns / 2 };
+      const inside = woodsHoldIdsInZone(WOODS_SIZES[size].id, box)!;
+
+      expect(inside.length).toBeGreaterThan(0);
+      expect(inside.length).toBeLessThan(totalHolds(size));
+      expect(new Set(inside).size).toBe(inside.length);
+      expect([...inside].sort((left, right) => left - right)).toEqual(inside);
+    }
+  });
+
+  it('returns every hold for a box covering the whole board', () => {
+    for (const size of WOODS_BOARD_SIZES) {
+      expect(woodsHoldIdsInZone(WOODS_SIZES[size].id, fullBoard(size))).toHaveLength(totalHolds(size));
+    }
+  });
+
+  it('selects the top strip of the board, not the bottom', () => {
+    const size = '8x10';
+    const { numRows, maxColumns } = WOODS_GEOMETRY[size];
+    const inside = woodsHoldIdsInZone(WOODS_SIZES[size].id, {
+      edgeLeft: 0,
+      edgeRight: maxColumns,
+      edgeBottom: numRows - 2,
+      edgeTop: numRows,
+    })!;
+
+    // Hold 0 is the leftmost hold of the top row; the last hold is on the floor row.
+    expect(inside).toContain(0);
+    expect(inside).not.toContain(totalHolds(size) - 1);
+    for (const holdId of inside) {
+      expect(getWoodsHoldGridPosition(holdId, size)!.y).toBeLessThan(0.15);
+    }
+  });
+
+  it('keeps a hold sitting exactly on an edge inside the box', () => {
+    const size = '12x12';
+    const onTheEdge = getWoodsHoldZonePosition(0, size)!;
+    const inside = woodsHoldIdsInZone(WOODS_SIZES[size].id, {
+      edgeLeft: onTheEdge.x,
+      edgeRight: WOODS_GEOMETRY[size].maxColumns,
+      edgeBottom: 0,
+      edgeTop: onTheEdge.y,
+    })!;
+
+    expect(inside).toContain(0);
+  });
+
+  it('returns no holds for a box over a bare corner', () => {
+    expect(
+      woodsHoldIdsInZone(WOODS_SIZES['8x10'].id, { edgeLeft: 0, edgeRight: 0.5, edgeBottom: 0, edgeTop: 0.5 }),
+    ).toHaveLength(0);
+  });
+
+  it('answers the two sizes independently — the same hold id is a different hold', () => {
+    const box = { edgeLeft: 0, edgeRight: 6, edgeBottom: 0, edgeTop: 6 };
+
+    expect(woodsHoldIdsInZone(WOODS_SIZES['8x10'].id, box)).not.toEqual(
+      woodsHoldIdsInZone(WOODS_SIZES['12x12'].id, box),
+    );
+  });
+
+  it('picks the same holds the picker would highlight', () => {
+    // The drift guard: run the board details the picker renders through the
+    // client's own containment test and expect the same ids back.
+    const box = { edgeLeft: 4, edgeRight: 17, edgeBottom: 6, edgeTop: 20 };
+    for (const size of WOODS_BOARD_SIZES) {
+      const details = getWoodsBoardDetails({ size_id: WOODS_SIZES[size].id });
+      const dims = {
+        boardWidth: details.boardWidth,
+        boardHeight: details.boardHeight,
+        edgeLeft: details.edge_left,
+        edgeRight: details.edge_right,
+        edgeBottom: details.edge_bottom,
+        edgeTop: details.edge_top,
+      };
+      const fromDetails = details.holdsData
+        .filter((hold) => {
+          const grid = svgToGridReference(hold.cx, hold.cy, dims);
+          return grid.x >= box.edgeLeft && grid.x <= box.edgeRight && grid.y >= box.edgeBottom && grid.y <= box.edgeTop;
+        })
+        .map((hold) => hold.id);
+
+      expect(woodsHoldIdsInZone(WOODS_SIZES[size].id, box)).toEqual(fromDetails);
+      expect(fromDetails.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns null for a size id that is not a Woods board, so the caller fails closed', () => {
+    expect(woodsHoldIdsInZone(3, { edgeLeft: 0, edgeRight: 10, edgeBottom: 0, edgeTop: 10 })).toBeNull();
   });
 });

--- a/packages/shared/board-config/src/board-capabilities.ts
+++ b/packages/shared/board-config/src/board-capabilities.ts
@@ -10,6 +10,10 @@
 // `boardName !== 'woods'` in the tree. They are one table now: read a capability
 // here, and a new board is one row.
 //
+// A capability leaves the table once every board answers yes to it — `holdFilters`
+// did, when Woods learned to answer a hold/zone search off its own geometry
+// (boardsesh/boardsesh#4748). A future board that can't reintroduces the row.
+//
 // Deliberately NOT in here:
 //  - `isSizeScopedBoard` — mirrored into offline-sync by design, so it stays
 //    where the sync engine can duplicate it without importing this package.
@@ -29,27 +33,6 @@ export type BoardCapabilities = {
    * entirely for those and explains the gap instead of showing an empty section.
    */
   crowdGrade: boolean;
-  /**
-   * The board can answer a hold-type or board-region (zone) search.
-   *
-   * False on Woods for two independent reasons:
-   *
-   * 1. Online hold search resolves the picked hold ids against
-   *    `board_placements`, and Woods has no rows there — it is code-driven
-   *    geometry, imported without hardware. Every Woods hold search would come
-   *    back empty with nothing on screen to explain why.
-   * 2. The zone box is expressed in placement-grid space (`edge_left`/`edge_top`
-   *    and friends). Woods hold centres are CV-detected board-art PIXELS, so a
-   *    box dragged over the art doesn't map to the coordinates the query filters
-   *    on.
-   *
-   * So the Holds and Zone rows are HIDDEN rather than left to return silent zero
-   * results, and the two full-screen picker routes bail out if a hand-built link
-   * reaches them anyway. Both light up for Woods the moment `board_placements`
-   * is seeded (the way `backfill-moonboard-hardware.ts` seeds MoonBoard) and the
-   * zone box gets a Woods-native pixel-space mapping — boardsesh/boardsesh#4748.
-   */
-  holdFilters: boolean;
   /**
    * New climbs can be set on the board from inside Boardsesh (create / fork /
    * edit).
@@ -103,7 +86,6 @@ export type BoardCapabilities = {
  */
 const AURORA_CAPABILITIES: BoardCapabilities = {
   crowdGrade: true,
-  holdFilters: true,
   climbCreation: true,
   nativeBoardControl: true,
   auroraAppLink: true,
@@ -117,20 +99,18 @@ const AURORA_CAPABILITIES: BoardCapabilities = {
  */
 const MOONBOARD_CAPABILITIES: BoardCapabilities = {
   crowdGrade: false,
-  holdFilters: true,
   climbCreation: true,
   nativeBoardControl: true,
   auroraAppLink: false,
 };
 
 /**
- * Woods: a static catalog import — browse, light up and tick all work, and
- * nothing else does yet. Each `false` has its own follow-up: #4748 (hold/zone
- * filters), #4750 (create), #3314 (the Swift encoder).
+ * Woods: a static catalog import — browse, search, light up and tick all work.
+ * Each remaining `false` has its own follow-up: #4750 (create), #3314 (the Swift
+ * encoder).
  */
 const WOODS_CAPABILITIES: BoardCapabilities = {
   crowdGrade: false,
-  holdFilters: false,
   climbCreation: false,
   nativeBoardControl: false,
   auroraAppLink: false,

--- a/packages/shared/board-config/src/woods-config.ts
+++ b/packages/shared/board-config/src/woods-config.ts
@@ -66,7 +66,6 @@ const WOODS_HOLD_TYPE_TO_CODE: Record<WoodsHoldType, number> = {
 export function encodeWoodsHoldsToFrames(holds: Array<{ type: string; baseHoldLocation: number }>): string {
   return holds
     .filter((hold): hold is { type: WoodsHoldType; baseHoldLocation: number } => hold.type in WOODS_HOLD_TYPE_TO_CODE)
-    .slice()
     .sort((a, b) => a.baseHoldLocation - b.baseHoldLocation)
     .map((hold) => `p${hold.baseHoldLocation}r${WOODS_HOLD_TYPE_TO_CODE[hold.type]}`)
     .join('');

--- a/packages/shared/board-config/src/woods-config.ts
+++ b/packages/shared/board-config/src/woods-config.ts
@@ -195,6 +195,80 @@ export function getWoodsHoldImagePosition(
 }
 
 /**
+ * A hold's position in Woods ZONE-GRID space — the coordinates the "Board region"
+ * search box is expressed in.
+ *
+ * The box is dragged over the board art, and `svgToGrid` in
+ * `@boardsesh/climb-filters` converts a render position back to grid units using
+ * only the `boardWidth`/`boardHeight` and `edge_*` that
+ * {@link getWoodsBoardDetails} reports. For Woods that is board-art pixels over a
+ * `0..maxColumns` × `0..numRows` box, so the conversion collapses to scaling the
+ * normalised hold centre — with y flipped, because grid y counts up from the floor
+ * while the art's y counts down from the top.
+ *
+ * This is deliberately NOT the hold's real (row, column): rows have different
+ * lengths and an uneven pitch, so the hold in column 3 is not at x = 3. It doesn't
+ * need to be. The zone filter only needs the client and the server to put a hold in
+ * the same place, and both derive it from the same normalised centre.
+ */
+export function getWoodsHoldZonePosition(
+  baseHoldLocation: number,
+  size: WoodsBoardSize,
+): { x: number; y: number } | undefined {
+  const position = getWoodsHoldGridPosition(baseHoldLocation, size);
+  if (!position) return undefined;
+  const geometry = WOODS_GEOMETRY[size];
+  return { x: position.x * geometry.maxColumns, y: (1 - position.y) * geometry.numRows };
+}
+
+/** The four edges of a board-region search box, in Woods zone-grid space. */
+export type WoodsZoneBox = {
+  edgeLeft: number;
+  edgeRight: number;
+  edgeBottom: number;
+  edgeTop: number;
+};
+
+/**
+ * Every hold of a board size that sits inside a region box, so the climb search
+ * can answer a zone query with no `board_placements` / `board_holes` rows behind
+ * it — Woods is code-driven and has none (boardsesh/boardsesh#4748).
+ *
+ * Inclusive on all four edges, matching `isHoldInsideZone` on the client: the
+ * `allHolds` filter keeps a climb whose every hold fits inside the box, so a hold
+ * sitting exactly on an edge must not disqualify it. Positions are compared
+ * unrounded for the same reason — the client prunes its own hold filters with the
+ * raw float, and a rounded server would disagree on the boundary.
+ *
+ * The two Woods sizes number their holds differently, so the caller passes the
+ * size being browsed. A size id that isn't a Woods board returns null rather than
+ * a plausible-looking list, so a stale or crafted size fails the search closed.
+ *
+ * Ids come back ascending: the keys of `WOODS_HOLD_POSITIONS` are array indices,
+ * which `Object.keys` enumerates in numeric order.
+ */
+export function woodsHoldIdsInZone(sizeId: number, box: WoodsZoneBox): number[] | null {
+  const dimension = woodsSizeIdToDimension(sizeId);
+  if (!dimension) return null;
+
+  const inside: number[] = [];
+  for (const holdKey of Object.keys(WOODS_HOLD_POSITIONS[dimension])) {
+    const baseHoldLocation = Number(holdKey);
+    const position = getWoodsHoldZonePosition(baseHoldLocation, dimension);
+    if (!position) continue;
+    if (
+      position.x >= box.edgeLeft &&
+      position.x <= box.edgeRight &&
+      position.y >= box.edgeBottom &&
+      position.y <= box.edgeTop
+    ) {
+      inside.push(baseHoldLocation);
+    }
+  }
+  return inside;
+}
+
+/**
  * The horizontally-mirrored hold for a `baseHoldLocation` — the same row, with the
  * column reflected across the row's width (column → rowLength - 1 - column). Returns
  * the input location for the centre hold of an odd-width row (it mirrors to itself)

--- a/packages/shared/climb-filters/src/__tests__/climb-zone-math.test.ts
+++ b/packages/shared/climb-filters/src/__tests__/climb-zone-math.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import type { HoldsFilter } from '@boardsesh/shared-schema';
 import {
   gridToSvg,
+  svgToGrid,
   pruneHoldsToZone,
   type BoardDimensions,
   type BoardEdges,
@@ -67,5 +68,38 @@ describe('pruneHoldsToZone', () => {
   it('returns an empty object when every hold is outside the zone', () => {
     const holdsFilter: HoldsFilter = { 2: { FOOT: 'include' }, 3: { STARTING: 'exclude' } };
     expect(pruneHoldsToZone(holdsFilter, ZONE, HOLDS_BY_ID, DIMS)).toEqual({});
+  });
+});
+
+// Woods is code-driven: it has no `board_placements` rows, so its server-side zone
+// search re-derives a hold's grid position from the normalised centres in
+// `@boardsesh/board-config` (`getWoodsHoldZonePosition`) instead of reading
+// `board_holes.x/y`. That only lines up with what the picker sends while this
+// conversion stays as it is, so pin it against Woods-shaped dims — the 8x10 board
+// art (720×1000 px) over a 21-column × 25-row edge box. The other half of the
+// contract lives in board-config's woods-config.test.ts.
+// See boardsesh/boardsesh#4748.
+describe('svgToGrid on a code-driven board (Woods 8x10)', () => {
+  const WOODS_8X10_DIMS: BoardDimensions = {
+    boardWidth: 720,
+    boardHeight: 1000,
+    edgeLeft: 0,
+    edgeRight: 21,
+    edgeBottom: 0,
+    edgeTop: 25,
+  };
+
+  it('scales x by the column count and flips y off the board height', () => {
+    // A hold detected at (0.05904, 0.03434) of the art — near the top-left.
+    const hold = { cx: 0.05904 * 720, cy: 0.03434 * 1000 };
+    const grid = svgToGrid(hold.cx, hold.cy, WOODS_8X10_DIMS);
+
+    expect(grid.x).toBeCloseTo(0.05904 * 21, 6);
+    expect(grid.y).toBeCloseTo((1 - 0.03434) * 25, 6);
+  });
+
+  it('maps the art corners onto the edge box', () => {
+    expect(svgToGrid(0, 1000, WOODS_8X10_DIMS)).toEqual({ x: 0, y: 0 });
+    expect(svgToGrid(720, 0, WOODS_8X10_DIMS)).toEqual({ x: 21, y: 25 });
   });
 });

--- a/packages/web/app/lib/__tests__/url-utils.test.ts
+++ b/packages/web/app/lib/__tests__/url-utils.test.ts
@@ -577,12 +577,25 @@ describe('urlParamsToSearchParams', () => {
   it('should drop hold params with non-numeric IDs', () => {
     const urlParams = new URLSearchParams({
       hold_red: 'ANY:include',
+      'hold_-1': 'ANY:include',
+      'hold_1.5': 'ANY:include',
+      hold_: 'ANY:include',
       hold_142: 'ANY:include',
     });
 
     const result = urlParamsToSearchParams(urlParams);
 
     expect(result.holdsFilter).toEqual({ 142: { ANY: 'include' } });
+  });
+
+  // Woods numbers its holds from 0, so hold 0 is a real hold and has to survive
+  // the parse — boardsesh/boardsesh#4748.
+  it('should keep hold id 0', () => {
+    const urlParams = new URLSearchParams({ hold_0: 'ANY:include' });
+
+    const result = urlParamsToSearchParams(urlParams);
+
+    expect(result.holdsFilter).toEqual({ 0: { ANY: 'include' } });
   });
 
   it('should use defaults for missing parameters', () => {

--- a/packages/web/app/lib/url-utils.ts
+++ b/packages/web/app/lib/url-utils.ts
@@ -314,11 +314,14 @@ function parseHoldsFilterFromUrl(urlParams: URLSearchParams): HoldsFilter {
   const result: HoldsFilter = {};
   for (const [key, value] of urlParams.entries()) {
     if (!key.startsWith('hold_')) continue;
-    // Hold IDs in board_climb_holds are positive integers, so reject 0,
-    // negatives, NaN, and floats. Floats like `hold_1.5` would silently
-    // miss every climb in the SQL `LIKE '%1.5r%'` lookup.
-    const holdId = Number(key.slice('hold_'.length));
-    if (!Number.isInteger(holdId) || holdId <= 0) continue;
+    // Hold ids in board_climb_holds are non-negative integers — 0 included, since
+    // Woods numbers its holds from 0 — so reject only negatives, NaN and floats.
+    // Floats like `hold_1.5` would silently miss every climb in the SQL
+    // `LIKE '%p1.5r%'` lookup. Digits-only rather than a bare `>= 0` test, because
+    // `Number('')` is 0 and would let a lone `hold_` through as hold 0.
+    const holdKey = key.slice('hold_'.length);
+    const holdId = Number(holdKey);
+    if (!/^\d+$/.test(holdKey) || !Number.isSafeInteger(holdId)) continue;
     const entry = parseSingleEntry(value);
     if (Object.keys(entry).length > 0) {
       result[holdId] = entry;


### PR DESCRIPTION
## Summary

Closes #4748.

The **Board region** filter never matched a Woods climb, on either mode:

- `allHolds` compares `board_climbs.edge_left/right/bottom/top`, which the Woods importer writes as `NULL` — `NULL >= x` is never true, so every Woods climb was excluded.
- `anyHold` joins `board_climb_holds → board_placements → board_holes`, and Woods has zero rows in either hardware table.

Woods is a code-driven board on purpose (#3306): an 8×10 is not a crop of a 12×12 and the two sizes reuse the same numeric hold ids for different physical holds, so seeding Aurora-style placements for it would be wrong. Both rows were hidden behind `holdFilters: false` rather than left to return silent zero results.

**It doesn't need the hardware.** The box is dragged over the board art, and the client already projects a hold into box coordinates with `svgToGrid` over the edges `getWoodsBoardDetails` reports. For Woods that collapses to:

```
x = normX * maxColumns        // 21 (8×10) / 33 (12×12)
y = (1 - normY) * numRows      // 25 (8×10) / 31 (12×12)
```

So the server resolves the box against `WOODS_HOLD_POSITIONS` directly and filters on hold ids, which `board_climb_holds` already stores. No hardware rows, no `edge_*` backfill, no data migration, no importer change.

- `woodsHoldIdsInZone(sizeId, box)` in `@boardsesh/board-config` returns the in-box hold ids (null for a size that isn't a Woods board).
- `create-climb-filters` gains a Woods branch: one `EXISTS` for `anyHold`; for `allHolds`, "has holds" + "no hold outside the box", phrased as the complement of the in-box ids so an id the geometry doesn't know counts as outside. It fails closed on an unknown size id or a box drawn over bare board.
- The two sizes stay apart through the `compatible_size_ids` filter that was already there.

**Hold search already worked for Woods** — it matches `board_climb_holds.hold_id` and the `p<id>r` frames token with no placement bridge — **except for hold 0**. Woods numbers holds from 0 and all three filter parsers (online, offline SQLite, web URL) dropped ids `<= 0`, so the first hold of every Woods board was unfilterable. They now accept any digits-only key, which still rejects `hold_`, `hold_-1`, `hold_1.5` and `hold_red`.

With that, no board has `holdFilters: false` any more, so the capability, the filter sheet's conditional and the two picker route guards are removed. `useUnsupportedBoardExit` stays — `create.tsx` still uses it for `climbCreation`.

The web hold-heatmap (`/api/v1/.../heatmap`) reuses `createClimbFilters`, so it inherits the fix; a `zoneBox=` on a Woods heatmap used to return `[]`.

## Release Notes

- Filter Woods climbs by board region — draw a box on the wall and keep only the climbs that stay inside it, or the ones that reach into it
- Search Woods climbs by hold, including the bottom row that used to be ignored

## Test plan

**Automated**

- `vp check`, `vp run typecheck` (46 tasks)
- `vp run test:db` — 491 pass. New: Woods `allHolds`/`anyHold` SQL shape, the emitted ids matching `woodsHoldIdsInZone`, per-size divergence, fail-closed on unknown size / empty box, and hold-key parsing (0 kept, malformed keys still dropped). Also un-rotted three assertions in that file that had been failing since they were written (`18 * 0.94` renders as `16.919999999999998`; drizzle renders `like` lower-case) — `test:db` isn't a CI gate, so nobody saw them.
- `vp run test:mobile` — 6,918 pass. Woods filter rows now asserted present, the geometry prewarm asserted to run, both picker routes asserted to render for Woods, and an offline hold-0 case (`p0r` must not match `p10r`).
- `vp test run --project board-config --project climb-filters --project web` — 4,628 pass. `woodsHoldIdsInZone` partition/edge-inclusivity/y-flip/per-size cases, a drift guard asserting it picks the same holds the picker would highlight, and `svgToGrid` pinned against Woods-shaped dims on the other side of the contract.

**Against the real catalog** (imported into the dev DB: 4,968 climbs on 12×12, 424 on 8×10)

| check | 12×12 | 8×10 |
| --- | --- | --- |
| no filter | 4,968 | 424 |
| default inner-60% box, `allHolds` | 32 | 10 |
| default inner-60% box, `anyHold` | 4,937 | 413 |
| box over bare board | 0 | 0 |
| unknown size id | 0 | 0 |
| hold-0 filter | 186 | 55 |
| first page | 113 ms | 43 ms |

Invariants held on every result set: no `allHolds` result has a hold outside the box, every `anyHold` result touches one, `allHolds` is a subset of `anyHold`, every `anyHold`-only result really does have a hold outside, and neither size returns the other's climbs.

Also exercised through GraphQL end to end (Zod → resolver → SQL), which matched the direct-DB numbers exactly and still rejects an inverted box.

**Regression** — Kilter is unchanged: 220,412 unfiltered, 3,348 `allHolds`, 219,947 `anyHold` for the same box before and after. MoonBoard's calibrated placement path is untouched.

**Visual** — rendered the drawn box and the selected holds over the real 12×12 board art. The highlighted holds fill the rectangle exactly, and an asymmetric top-left box lands top-left (a wrong y-flip would put it bottom-left).

## Notes for reviewers

- Woods hold search is size-scoped only through `compatible_size_ids`; that predicate is load-bearing here, since the same hold id means a different hold on the other board.
- A freshly-imported Woods catalog needs `ANALYZE` before the planner picks a sane plan — on stale stats the `allHolds` query took 7.4 s, and 38 ms after. Worth knowing for the production import (#4768); autovacuum gets there on its own.
- `MAX_HOLD_FILTER_ENTRIES` is 300, and its comment claimed that was above every board's hold count. A Woods 12×12 has 894. The cap is still far above what anyone taps by hand; the comment is corrected.
- The Woods holds picker has 894 tap targets and the CV hold table has ~17 near-duplicate pairs on 12×12, so it's pinch-to-zoom-first and tapping a twinned hold is a coin flip. That's the existing hold-position table, not this change — re-extracting it is the follow-up already noted in `woods-config.ts`.
- Offline zone search still falls back to the network on every board, so a downloaded Woods board with no connection shows the existing "filter unavailable offline" state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENg7SsGanfzWXM6TfyWY7d
