### PR TITLE
docs(repo): credit xprem for our OTA updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -332,3 +332,5 @@ Official self-hosting support is planned but still involved to set up. For now t
 ## Thanks
 
 This app started as a fork of [Climbdex](https://github.com/lemeryfertitta/Climbdex), and we use [BoardLib](https://github.com/lemeryfertitta/BoardLib) to build the database. Thanks to @lemeryfertitta for making this project possible.
+
+Thanks also to [Mercure Technologies](https://github.com/mercuretechnologies) for granting Boardsesh an enterprise license for [xprem](https://github.com/mercuretechnologies/xprem). It's the OTA server behind our releases, and the reason a reviewer can try your pull request from a store build via the channel switcher described above.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ If you find Boardsesh useful and can spare it, sponsorship helps us keep the lig
 
 [![Sponsor Boardsesh](https://img.shields.io/badge/Sponsor-Boardsesh-ea4aaa?logo=github-sponsors&style=for-the-badge)](https://github.com/sponsors/boardsesh)
 
+## Thanks
+
+Most Boardsesh updates reach your phone without an app store release, and that's down to [xprem](https://github.com/mercuretechnologies/xprem) — the self-hosted Expo OTA update server built by [Mercure Technologies](https://github.com/mercuretechnologies), who gave Boardsesh an enterprise license for it.
+
+Between mid-June and late August 2026 we shipped 552 user-facing changes to the mobile app, and only 64 of them needed a new App Store or Play build. xprem also runs our per-PR preview channels, so anyone on a store build can switch to a pull request's bundle from What's New and tell us whether it works before it merges.
+
 ## Join the Community
 
 We're always looking to collaborate with climbers, developers, and anyone passionate about improving the board climbing experience. Whether you want to contribute code, suggest features, or just say hello—we'd love to hear from you.

--- a/packages/mobile/app/__tests__/acknowledgements.test.tsx
+++ b/packages/mobile/app/__tests__/acknowledgements.test.tsx
@@ -46,6 +46,7 @@ vi.mock('../../src/lib/acknowledgements', () => ({
   friends: ['Gabby', 'Caz', 'Joz'],
   dogName: 'Scout',
   SPONSORS_URL: 'https://github.com/sponsors/boardsesh',
+  XPREM_URL: 'https://github.com/mercuretechnologies/xprem',
 }));
 vi.mock('../../src/lib/open-url', () => openUrl);
 vi.mock('../../src/lib/discord', () => discord);
@@ -139,6 +140,17 @@ describe('AcknowledgementsScreen', () => {
     expect(routerMock.push).toHaveBeenCalledWith('/licenses');
   });
 
+  it('opens the xprem repo from the powered-by card', () => {
+    render(<AcknowledgementsScreen />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'xprem' }));
+
+    expect(openUrl.openExternalUrl).toHaveBeenCalledWith(
+      'https://github.com/mercuretechnologies/xprem',
+      'acknowledgements-xprem',
+    );
+  });
+
   it('opens the Scout easter-egg page from the dog card', () => {
     render(<AcknowledgementsScreen />);
 
@@ -158,6 +170,7 @@ describe('AcknowledgementsScreen', () => {
       friends: ['Gabby'],
       dogName: 'Scout',
       SPONSORS_URL: 'https://github.com/sponsors/boardsesh',
+      XPREM_URL: 'https://github.com/mercuretechnologies/xprem',
     }));
     const { default: EmptySponsorsScreen } = await import('../acknowledgements');
 

--- a/packages/mobile/app/acknowledgements.tsx
+++ b/packages/mobile/app/acknowledgements.tsx
@@ -16,6 +16,7 @@ import {
   friends,
   dogName,
   SPONSORS_URL,
+  XPREM_URL,
 } from '../src/lib/acknowledgements';
 import { openDiscordInvite } from '../src/lib/discord';
 import { openExternalUrl } from '../src/lib/open-url';
@@ -102,6 +103,9 @@ export default function AcknowledgementsScreen() {
   }, []);
   const handleJoinDiscord = useCallback(() => {
     void openDiscordInvite('acknowledgements');
+  }, []);
+  const handleOpenXprem = useCallback(() => {
+    void openExternalUrl(XPREM_URL, 'acknowledgements-xprem');
   }, []);
   const handleOpenScout = useCallback(() => {
     router.push('/scout');
@@ -192,6 +196,18 @@ export default function AcknowledgementsScreen() {
               />
             </View>
           )}
+        </View>
+
+        <View style={styles.section}>
+          <SectionHeader title={t('mobile.acknowledgements.poweredByTitle')} />
+          <View style={styles.cardStack}>
+            <ThanksCard
+              icon="server"
+              title="xprem"
+              body={t('mobile.acknowledgements.xpremBody')}
+              onPress={handleOpenXprem}
+            />
+          </View>
         </View>
 
         <View style={styles.section}>

--- a/packages/mobile/src/lib/acknowledgements.ts
+++ b/packages/mobile/src/lib/acknowledgements.ts
@@ -35,6 +35,12 @@ export const privateSponsorCount: number = data.privateSponsorCount;
 /** Where the "Become a sponsor" empty-state CTA points. */
 export const SPONSORS_URL = 'https://github.com/sponsors/boardsesh';
 
+/**
+ * The self-hosted OTA server behind our over-the-air releases and per-PR previews.
+ * Mercure Technologies gave us an enterprise license for it — see the "Powered by" card.
+ */
+export const XPREM_URL = 'https://github.com/mercuretechnologies/xprem';
+
 // Personal thanks — kept as data so the screen renders the names directly.
 // Gabby leads the crew; Scout gets her own easter-egg page.
 export const friends = ['Gabby', 'Caz', 'Josh', 'Pete', 'Nic', 'Jess', 'Roxy'] as const;

--- a/packages/mobile/src/lib/acknowledgements.ts
+++ b/packages/mobile/src/lib/acknowledgements.ts
@@ -35,10 +35,7 @@ export const privateSponsorCount: number = data.privateSponsorCount;
 /** Where the "Become a sponsor" empty-state CTA points. */
 export const SPONSORS_URL = 'https://github.com/sponsors/boardsesh';
 
-/**
- * The self-hosted OTA server behind our over-the-air releases and per-PR previews.
- * Mercure Technologies gave us an enterprise license for it — see the "Powered by" card.
- */
+/** The OTA server behind our releases — Mercure Technologies gave us an enterprise license. */
 export const XPREM_URL = 'https://github.com/mercuretechnologies/xprem';
 
 // Personal thanks — kept as data so the screen renders the names directly.

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -229,6 +229,8 @@
       "sponsorsEmpty": "Noch keine Sponsoren — willst du den Anfang machen?",
       "privateSponsorsThanks": "und {{count}} weitere, die privat sponsern — auch euch danke",
       "becomeSponsor": "Sponsor werden",
+      "poweredByTitle": "Läuft mit",
+      "xpremBody": "Mercure Technologies hat Boardsesh eine Enterprise-Lizenz für xprem geschenkt, den Server hinter unseren Over-the-Air-Updates. Deshalb landen Fixes auf deinem Handy, ohne auf eine Store-Prüfung zu warten, und deshalb kannst du unter Neuigkeiten eine Vorschau ausprobieren.",
       "personalTitle": "Persönlicher Dank",
       "discordTitle": "Alle in unserem Discord",
       "discordBody": "Danke für die Beta, die Motivation und die Bug-Reports. Tippen zum Beitreten.",

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -229,6 +229,8 @@
       "sponsorsEmpty": "No sponsors yet — want to be the first?",
       "privateSponsorsThanks": "and {{count}} more sponsoring privately — thank you too",
       "becomeSponsor": "Become a sponsor",
+      "poweredByTitle": "Powered by",
+      "xpremBody": "Mercure Technologies gave Boardsesh an enterprise license for xprem, the server behind our over-the-air updates. It's why fixes reach your phone without waiting on an app store review, and why you can try a preview build from What's New.",
       "personalTitle": "Personal thanks",
       "discordTitle": "Everyone on our Discord",
       "discordBody": "Thanks for the beta, the psyche, and the bug reports. Tap to join.",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -408,6 +408,8 @@
       "sponsorsEmpty": "Aún no hay patrocinadores, ¿quieres ser el primero?",
       "privateSponsorsThanks": "y {{count}} más patrocinando en privado — gracias también",
       "becomeSponsor": "Hazte patrocinador",
+      "poweredByTitle": "Con tecnología de",
+      "xpremBody": "Mercure Technologies le dio a Boardsesh una licencia enterprise de xprem, el servidor detrás de nuestras actualizaciones over-the-air. Por eso las correcciones llegan a tu móvil sin esperar la revisión de la tienda de apps, y por eso puedes probar una versión preliminar desde Novedades.",
       "personalTitle": "Agradecimientos personales",
       "discordTitle": "Toda la gente de nuestro Discord",
       "discordBody": "Gracias por la beta, la motivación y los reportes de fallos. Toca para unirte.",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -229,6 +229,8 @@
       "sponsorsEmpty": "Pas encore de sponsor — envie d'être le premier ?",
       "privateSponsorsThanks": "et {{count}} de plus en privé — merci à vous aussi",
       "becomeSponsor": "Devenir sponsor",
+      "poweredByTitle": "Propulsé par",
+      "xpremBody": "Mercure Technologies a offert à Boardsesh une licence entreprise pour xprem, le serveur derrière nos mises à jour over-the-air. C'est grâce à lui que les correctifs arrivent sur votre téléphone sans attendre la validation du store, et que vous pouvez essayer une préversion depuis Nouveautés.",
       "personalTitle": "Remerciements personnels",
       "discordTitle": "Tout le monde sur notre Discord",
       "discordBody": "Merci pour la beta, la motivation et les rapports de bugs. Touchez pour rejoindre.",


### PR DESCRIPTION
## Summary

[Mercure Technologies](https://github.com/mercuretechnologies) granted Boardsesh an **enterprise license** for [xprem](https://github.com/mercuretechnologies/xprem) (renamed from `expo-open-ota` at v3.1.0) — the self-hosted Expo OTA control plane we run at `updates.boardsesh.com`. It ships our production JS updates and the per-PR preview channels users reach from What's New → "Try a preview".

Until now xprem was named only in internal places: `docs/mobile-ota-updates.md`, `scripts/lib/eoas.ts`, CI workflows, `CLAUDE.md`/`AGENTS.md`. Nothing user-facing credited them. It also can't appear on the generated `/licenses` list, because `eoas` is a `bunx`-invoked CI tool rather than a bundled npm dependency — so the credit has to be written by hand.

Three surfaces:

- **`README.md`** — a new `## Thanks` section between `## Support Boardsesh` and `## Join the Community`, naming the enterprise license.
- **`CONTRIBUTING.md`** — one paragraph appended to the existing `## Thanks` section, which already credits Climbdex / BoardLib by name.
- **Mobile Acknowledgements** — a new **"Powered by"** section between Sponsors and Personal thanks, holding a tappable card that opens the xprem repo. Reuses the file's existing `ThanksCard` primitive and `openExternalUrl` handler convention; no new components or styles.

### Numbers in the README copy

Stated as dated history so they don't go stale, and verified against this tree:

| Claim | Source |
| --- | --- |
| 552 user-facing changes shipped 2026-06-19 → 2026-08-25 | `packages/mobile/src/data/changelog.generated.json` → `entries` |
| only 64 needed a new App Store / Play build | same file → `nativeReleases` |

Deliberately **no version number** in public copy: the CLI is pinned to `eoas@3.1.2` while Railway still runs the `v3.0.5` image (hand-off tracked in #4613).

### i18n

`poweredByTitle` + `xpremBody` added to all four catalogs (`en-US`, `es`, `fr`, `de`) — `catalog-completeness.test.ts` enforces key-set parity, so a partial edit fails CI. No placeholders. Formality matched to each catalog's existing acknowledgements copy: French **vouvoiement** (`discordBody` is "Touchez pour rejoindre"), Spanish **tú**, German informal **du**. Screen name references match each catalog's `mobile.changelog.title` — Novedades / Nouveautés / Neuigkeiten.

## Release Notes

- Say thanks to xprem, the update server that gets fixes to your phone without an app store wait

## Test plan

- `vp run typecheck:mobile` — clean
- `vp run test:mobile` — 702 files, 6919 tests pass. The acknowledgements suite goes 8 → 9 tests; the new one asserts the card calls `openExternalUrl` with the repo URL and the `acknowledgements-xprem` source tag. `XPREM_URL` added to **both** the `vi.mock` and the `vi.doMock` factories, since the suite fully mocks the data module.
- `vp test run --project i18n` — 101 tests pass, proving all four catalogs match.
- `vp check` — clean on the touched files. The 2 pre-existing lint errors (`packages/aurora-sync/…/apply-user-logbook.ts`, `packages/mobile/src/lib/__tests__/sweep-caches.test.ts`) reproduce on a stashed tree and are not from this branch.

No simulator pass: this worktree has no cached `.app`, and the card reuses the existing `ThanksCard` plus the same `styles.section` / `styles.cardStack` as its four siblings, so there's no new layout code. The `server` icon resolves on both platforms (`server.rack` / `server-network`, `icon-map.ts:44`). Pixel layout in light/dark is therefore unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YncFmU3KfYj1mrGayc32w

