### PR TITLE
fix(web): give the container a canonical origin, and refuse to boot without one

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -104,6 +104,12 @@ ENV BOARDSESH_WEB=$BOARDSESH_WEB
 # Prefer supplying NEXTAUTH_URL and BASE_URL at `docker run` / in the Railway
 # service variables; this build arg is only a baked default for an image built
 # for one known origin, which is how branch-deploy.yml builds preview images.
+#
+# NOTE: with no `--build-arg BASE_URL`, this bakes the EMPTY STRING — BASE_URL is
+# then PRESENT and empty rather than absent. Everything that reads it must treat
+# empty as unset; the transactional-email routes use `?.trim() ||`, never `??`,
+# for exactly this reason.
+#
 # Pinned by scripts/__tests__/dockerfile-web-auth-origin.test.ts, because
 # nothing in CI builds this file.
 ARG BASE_URL

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -90,6 +90,25 @@ ENV NODE_ENV=production
 ARG BOARDSESH_WEB=1
 ENV BOARDSESH_WEB=$BOARDSESH_WEB
 
+# The canonical origin this deployment serves. One of NEXTAUTH_URL / BASE_URL is
+# REQUIRED at runtime: with neither, the server cannot know its own origin,
+# next-auth falls back to http://localhost:3000, every session cookie loses its
+# `__Secure-` name and its `Domain=.boardsesh.com` scope, and the whole signed-in
+# fleet is logged out (issue #4651). instrumentation.ts now refuses to boot in
+# that state rather than serve it.
+#
+# The builder stage's ARG/ENV BASE_URL does NOT reach this stage, and neither
+# does `packages/web/.env.local` — Next's standalone writer copies only `.env`
+# and `.env.production`. So the runner has to declare it itself.
+#
+# Prefer supplying NEXTAUTH_URL and BASE_URL at `docker run` / in the Railway
+# service variables; this build arg is only a baked default for an image built
+# for one known origin, which is how branch-deploy.yml builds preview images.
+# Pinned by scripts/__tests__/dockerfile-web-auth-origin.test.ts, because
+# nothing in CI builds this file.
+ARG BASE_URL
+ENV BASE_URL=$BASE_URL
+
 # Create non-root user
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
@@ -110,7 +129,12 @@ EXPOSE 3000
 ENV HOSTNAME=0.0.0.0
 ENV PORT=3000
 
+# An HTTP probe, not a TCP connect. Next keeps listening after a failed server
+# prepare and answers every request with a 500, so a socket that accepts proves
+# nothing — measured: the pre-#4651 container reported `healthy` while 100% of
+# requests 500'd. /robots.txt is prerendered static and touches no database, so
+# a non-5xx here means the app really did prepare.
 HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
-  CMD node -e "const s=require('net').connect(3000,'127.0.0.1',()=>{s.end();process.exit(0)});s.on('error',()=>process.exit(1))"
+  CMD node -e "require('http').get({host:'127.0.0.1',port:3000,path:'/robots.txt'},(r)=>{r.resume();process.exit(r.statusCode<500?0:1)}).on('error',()=>process.exit(1))"
 
 CMD ["node", "packages/web/server.js"]

--- a/docs/web-canonical-origin.md
+++ b/docs/web-canonical-origin.md
@@ -66,6 +66,17 @@ both variables at run time anyway (Railway service variables, `docker run -e`);
 the build arg is only a baked default for an image built for one known origin,
 which is how `.github/workflows/branch-deploy.yml` builds preview images.
 
+Two consequences worth knowing:
+
+- With no `--build-arg BASE_URL`, that `ENV` bakes the **empty string**, so
+  `BASE_URL` is present-and-empty rather than absent. Anything reading it must
+  treat empty as unset — `?.trim() ||`, never `??`. The transactional-email
+  routes (`register`, `forgot-password`, `resend-verification`) do.
+- Running the standalone server straight out of a local `vp run build`
+  (`node packages/web/.next/standalone/packages/web/server.js`) now exits `1`:
+  that tree has no `.env` files at all, for the same reason the container didn't.
+  Pass `NEXTAUTH_URL=http://localhost:3000` on the command line.
+
 ## Verifying a deployment
 
 ```sh

--- a/docs/web-canonical-origin.md
+++ b/docs/web-canonical-origin.md
@@ -1,0 +1,88 @@
+# The web app's canonical origin (and why a missing one logs everyone out)
+
+Every hosted deployment of `packages/web` **must** be told which origin it serves.
+This is the one environment variable you cannot forget.
+
+## What to set
+
+| Variable       | Required         | What it does                                                                                                                                        |
+| -------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NEXTAUTH_URL` | Yes, on any host | The canonical origin. next-auth builds every auth URL (including the OAuth `redirect_uri`) from it, and `sessionCookieDomain()` reads its hostname. |
+| `BASE_URL`     | Yes, same value  | Fallback for the above, and the base for links in verification / password-reset email.                                                              |
+
+Both should be the exact public https origin, no trailing slash: `https://www.boardsesh.com`.
+
+`AUTH_COOKIE_DOMAIN` overrides the derived cookie domain for a non-standard deployment.
+You almost never want it.
+
+## What happens without one
+
+`packages/web/app/lib/auth/secure-cookies.ts` picks the session cookie name from
+whether this is a secure context, and the cookie's `Domain` from the serving
+hostname. With no canonical origin:
+
+- the session cookie is written as `next-auth.session-token`, not `__Secure-next-auth.session-token`;
+- it loses `Domain=.boardsesh.com`, so it stops being shared with `app.boardsesh.com`;
+- a cookie of the same name at a different domain scope is a **different browser
+  entry**, so even holding the name fixed this is its own logout;
+- next-auth falls back to `http://localhost:3000` and Google/Apple sign-in sends
+  people to a dead localhost page (this actually shipped once — issue #4227).
+
+Cookie name and domain are how a browser finds an existing session. Change either
+and every signed-in user is logged out at once.
+
+## The boot guard
+
+`diagnoseCanonicalOrigin()` (`packages/web/app/lib/auth/canonical-auth-url.ts`)
+runs from `instrumentation.ts` on every server boot:
+
+| Runtime                                                      | Result                                        |
+| ------------------------------------------------------------ | --------------------------------------------- |
+| `NODE_ENV=production`, neither `NEXTAUTH_URL` nor `BASE_URL` | **fatal** — logs the reason and exits `1`     |
+| `NODE_ENV=production`, only a loopback origin named          | warning — correct for `next start` and CI e2e |
+| anything else (dev, vitest, a build)                         | silent                                        |
+
+It exits rather than throws. Throwing out of `register()` leaves Next listening
+and answering every request with a 500 while a TCP healthcheck still reports
+`healthy` — measured on this image. Exiting is the signal a deploy fails on.
+
+`AUTH_ALLOW_MISSING_CANONICAL_ORIGIN=1` downgrades the fatal to a warning and lets
+the server boot. **It does not fix anything** — it boots straight into the
+logged-out state above. Emergency use only, when a degraded site genuinely beats
+no site.
+
+## Why this bit us
+
+`Dockerfile.web` declared `ARG BASE_URL` / `ENV BASE_URL` in the **builder** stage
+only. Next's standalone writer copies just `.env` and `.env.production` into the
+output — never the tracked `packages/web/.env.local` that supplies these values on
+a laptop and on Vercel. So the runtime container had no canonical origin at all,
+and the old backstop in `applyCanonicalAuthUrl()` needed a _parseable loopback_
+`NEXTAUTH_URL` before it would say anything, so an absent one produced no warning
+whatsoever. Issue #4651.
+
+The runner stage now declares `ARG`/`ENV BASE_URL` of its own. Prefer supplying
+both variables at run time anyway (Railway service variables, `docker run -e`);
+the build arg is only a baked default for an image built for one known origin,
+which is how `.github/workflows/branch-deploy.yml` builds preview images.
+
+## Verifying a deployment
+
+```sh
+curl -sS -D- -o /dev/null https://<host>/api/auth/csrf | grep -i '^set-cookie'
+```
+
+On the production www host you want, exactly:
+
+```
+set-cookie: __Host-next-auth.csrf-token=…; Path=/; HttpOnly; Secure; SameSite=Lax
+set-cookie: __Secure-next-auth.callback-url=…; Domain=.boardsesh.com; Path=/; HttpOnly; Secure; SameSite=None
+```
+
+Both prefixes and the `Domain` come from the same `cookies` block that names the
+session cookie (`packages/web/app/lib/auth/auth-options.ts`), so this one request
+is a sufficient check — no login required.
+
+A preview host (`{N}.preview.boardsesh.com`, `*.vercel.app`) should show the
+`__Secure-` prefix but **no** `Domain`: a preview must never be able to write or
+delete the production cookie identity.

--- a/packages/web/app/api/auth/[...nextauth]/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/[...nextauth]/__tests__/route.test.ts
@@ -159,6 +159,86 @@ describe('POST /api/auth/[...nextauth]', () => {
     expect(getTokenMock).not.toHaveBeenCalled();
   });
 
+  it('resolves the sign-out identity from a session stored under the other cookie name', async () => {
+    // Without the fallback read, a session living under the name the predicate
+    // did NOT pick fails the identity comparison and every sign-out 409s.
+    getTokenMock.mockResolvedValueOnce(null).mockResolvedValueOnce({ sub: 'user-1', authSessionId: 'login-1' });
+    const signOutRequest = request('/api/auth/signout', {
+      csrfToken: 'csrf-token',
+      expectedUserId: 'user-1',
+      expectedAuthSessionId: 'login-1',
+    });
+
+    await expect(POST(signOutRequest, context)).resolves.toMatchObject({ status: 200 });
+
+    expect(getTokenMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ cookieName: '__Secure-next-auth.session-token' }),
+    );
+    expect(getTokenMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ cookieName: 'next-auth.session-token' }));
+  });
+
+  it('clears BOTH session cookie names on sign-out, in both scopes', async () => {
+    // The read paths accept either name (sessionCookieNameCandidates), so a
+    // sign-out that cleared only one would leave a cookie that still
+    // authenticates — a logout bypass. Delete a name from
+    // appendSignOutSessionCookieClears and this goes red.
+    getTokenMock.mockResolvedValue({ sub: 'user-1', authSessionId: 'login-1' });
+    nextAuthHandlerMock.mockResolvedValue(
+      new Response(null, {
+        status: 200,
+        headers: {
+          'Set-Cookie':
+            '__Secure-next-auth.session-token=; Path=/; Domain=.boardsesh.com; Max-Age=0; HttpOnly; SameSite=Lax; Secure',
+        },
+      }),
+    );
+    const signOutRequest = request('/api/auth/signout', {
+      csrfToken: 'csrf-token',
+      expectedUserId: 'user-1',
+      expectedAuthSessionId: 'login-1',
+    });
+
+    const response = await POST(signOutRequest, context);
+
+    const setCookies = response.headers.getSetCookie();
+    for (const name of ['__Secure-next-auth.session-token', 'next-auth.session-token']) {
+      const deletions = setCookies.filter((setCookie) => setCookie.startsWith(`${name}=;`));
+      expect(
+        deletions.some((setCookie) => /;\s*Domain=\.boardsesh\.com/i.test(setCookie)),
+        name,
+      ).toBe(true);
+      expect(
+        deletions.some((setCookie) => !/;\s*Domain=/i.test(setCookie)),
+        name,
+      ).toBe(true);
+      for (const deletion of deletions) expect(deletion, name).toMatch(/Max-Age=0/i);
+    }
+  });
+
+  it('clears both names on sign-out even where no cookie domain applies', async () => {
+    // A homelab preview / a mis-enved container is host-only. The legacy clear
+    // skips those on purpose (it would delete a freshly written login cookie);
+    // the sign-out clear must not inherit that, or the bypass reopens exactly
+    // where the fallback read is most likely to be doing the resolving.
+    vi.stubEnv('VERCEL_ENV', '');
+    vi.stubEnv('VERCEL_URL', '');
+    vi.stubEnv('NEXTAUTH_URL', 'https://42.preview.boardsesh.com');
+    getTokenMock.mockResolvedValue({ sub: 'user-1', authSessionId: 'login-1' });
+    nextAuthHandlerMock.mockResolvedValue(new Response(null, { status: 200 }));
+    const signOutRequest = request('/api/auth/signout', {
+      csrfToken: 'csrf-token',
+      expectedUserId: 'user-1',
+      expectedAuthSessionId: 'login-1',
+    });
+
+    const response = await POST(signOutRequest, context);
+
+    const clearedNames = response.headers.getSetCookie().map((setCookie) => setCookie.split('=', 1)[0]);
+    expect(clearedNames).toContain('__Secure-next-auth.session-token');
+    expect(clearedNames).toContain('next-auth.session-token');
+  });
+
   it('clears the legacy host-only cookie when signing out', async () => {
     getTokenMock.mockResolvedValue({ sub: 'user-1', authSessionId: 'login-1' });
     nextAuthHandlerMock.mockResolvedValue(

--- a/packages/web/app/api/auth/[...nextauth]/route.ts
+++ b/packages/web/app/api/auth/[...nextauth]/route.ts
@@ -4,9 +4,10 @@ import { type NextRequest, NextResponse } from 'next/server';
 import { authOptions } from '@/app/lib/auth/auth-options';
 import {
   appendLegacyHostOnlySessionCookieClear,
+  appendSignOutSessionCookieClears,
   isSecureCookieContext,
   responseSetsSessionCookie,
-  sessionCookieName,
+  sessionCookieNameCandidates,
 } from '@/app/lib/auth/secure-cookies';
 import {
   bindExpoReturnToState,
@@ -162,14 +163,16 @@ export async function POST(request: NextRequest, context: NextAuthRouteContext):
   if (expectedIdentity === null) return guardedSignOutResponse(400, 'signout_identity_required');
   if (expectedIdentity === 'invalid') return guardedSignOutResponse(400, 'invalid_signout_identity');
 
+  // Both cookie names, preferred first — the same read the WebSocket handshake
+  // does. If the identity guard only looked at the name isSecureCookieContext()
+  // currently picks, a session living under the other name would fail the
+  // comparison and turn every sign-out into a 409 the user cannot get past.
+  const [preferredCookieName, fallbackCookieName] = sessionCookieNameCandidates();
+  const tokenOptions = { req: request, secret: process.env.NEXTAUTH_SECRET, secureCookie: isSecureCookieContext() };
   let token: Awaited<ReturnType<typeof getToken>>;
   try {
-    token = await getToken({
-      req: request,
-      secret: process.env.NEXTAUTH_SECRET,
-      secureCookie: isSecureCookieContext(),
-      cookieName: sessionCookieName(),
-    });
+    token = await getToken({ ...tokenOptions, cookieName: preferredCookieName });
+    token ??= await getToken({ ...tokenOptions, cookieName: fallbackCookieName });
   } catch {
     return guardedSignOutResponse(503, 'signout_identity_unavailable');
   }
@@ -177,10 +180,11 @@ export async function POST(request: NextRequest, context: NextAuthRouteContext):
   if (token?.sub !== expectedIdentity.userId || token.authSessionId !== expectedIdentity.authSessionId) {
     return guardedSignOutResponse(409, 'signout_identity_changed');
   }
-  // NextAuth's sign-out clears only the Domain-scoped cookie; also clear the
-  // legacy host-only cookie so a pre-migration session can't survive logout.
+  // NextAuth's sign-out clears only the Domain-scoped cookie under the one name
+  // it picked. Clear both names in both scopes, so the read fallback above can't
+  // resurrect a session the user just signed out of.
   const response = await handler(request, context);
-  appendLegacyHostOnlySessionCookieClear(response);
+  appendSignOutSessionCookieClears(response);
   return response;
 }
 

--- a/packages/web/app/api/auth/[...nextauth]/route.ts
+++ b/packages/web/app/api/auth/[...nextauth]/route.ts
@@ -184,7 +184,10 @@ export async function POST(request: NextRequest, context: NextAuthRouteContext):
   // it picked. Clear both names in both scopes, so the read fallback above can't
   // resurrect a session the user just signed out of.
   const response = await handler(request, context);
-  appendSignOutSessionCookieClears(response);
+  appendSignOutSessionCookieClears(
+    response,
+    request.cookies.getAll().map((requestCookie) => requestCookie.name),
+  );
   return response;
 }
 

--- a/packages/web/app/api/auth/forgot-password/route.ts
+++ b/packages/web/app/api/auth/forgot-password/route.ts
@@ -87,7 +87,11 @@ export async function POST(request: NextRequest) {
       });
     });
 
-    const baseUrl = process.env.BASE_URL ?? request.nextUrl.origin;
+    // `?.trim() ||`, not `??`: Dockerfile.web's runner stage declares
+    // `ENV BASE_URL=$BASE_URL`, which is the EMPTY STRING in an image built
+    // without the build arg. `??` keeps an empty string and every link in this
+    // email would lose its origin; falling back to the request origin is right.
+    const baseUrl = process.env.BASE_URL?.trim() || request.nextUrl.origin;
     // Email is sent outside the transaction intentionally (nodemailer is not transactional).
     // If this throws, the token remains in the DB but unreachable to the user — the
     // delete-before-insert at the start of the next attempt cleans it up automatically.

--- a/packages/web/app/api/auth/register/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/register/__tests__/route.test.ts
@@ -93,4 +93,21 @@ describe('POST /api/auth/register', () => {
       if (savedBaseUrl !== undefined) process.env.BASE_URL = savedBaseUrl;
     }
   });
+
+  it('falls back to the request origin when BASE_URL is present but empty', async () => {
+    // Dockerfile.web's runner stage declares `ENV BASE_URL=$BASE_URL`, which is
+    // the empty string in an image built without the build arg — present, not
+    // absent. With `??` that empty string wins and every link in the email
+    // loses its origin.
+    const savedBaseUrl = process.env.BASE_URL;
+    process.env.BASE_URL = '';
+    try {
+      await POST(createRequest({ email: 'test@example.com', password: 'password123' }, 'https://www.boardsesh.com'));
+      const [, , baseUrl] = mockSendVerificationEmail.mock.calls[0] as [string, string, string];
+      expect(baseUrl).toBe('https://www.boardsesh.com');
+    } finally {
+      if (savedBaseUrl === undefined) delete process.env.BASE_URL;
+      else process.env.BASE_URL = savedBaseUrl;
+    }
+  });
 });

--- a/packages/web/app/api/auth/register/route.ts
+++ b/packages/web/app/api/auth/register/route.ts
@@ -111,7 +111,11 @@ export async function POST(request: NextRequest) {
 
     // Send verification email if enabled
     if (emailVerificationEnabled && verificationToken) {
-      const baseUrl = process.env.BASE_URL ?? request.nextUrl.origin;
+      // `?.trim() ||`, not `??`: Dockerfile.web's runner stage declares
+      // `ENV BASE_URL=$BASE_URL`, which is the EMPTY STRING in an image built
+      // without the build arg. `??` keeps an empty string and every link in this
+      // email would lose its origin; falling back to the request origin is right.
+      const baseUrl = process.env.BASE_URL?.trim() || request.nextUrl.origin;
       let emailSent = false;
       try {
         await sendVerificationEmail(email, verificationToken, baseUrl);

--- a/packages/web/app/api/auth/resend-verification/route.ts
+++ b/packages/web/app/api/auth/resend-verification/route.ts
@@ -83,7 +83,11 @@ export async function POST(request: NextRequest) {
       });
     });
 
-    const baseUrl = process.env.BASE_URL ?? request.nextUrl.origin;
+    // `?.trim() ||`, not `??`: Dockerfile.web's runner stage declares
+    // `ENV BASE_URL=$BASE_URL`, which is the EMPTY STRING in an image built
+    // without the build arg. `??` keeps an empty string and every link in this
+    // email would lose its origin; falling back to the request origin is right.
+    const baseUrl = process.env.BASE_URL?.trim() || request.nextUrl.origin;
     await sendVerificationEmail(email, token, baseUrl);
 
     await consistentDelay(startTime);

--- a/packages/web/app/api/internal/ws-auth/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/ws-auth/__tests__/route.test.ts
@@ -8,9 +8,11 @@ vi.mock('next-auth/jwt', () => ({
   decode: (...args: unknown[]) => decodeMock(...args),
 }));
 
+// Real names, stubbed predicate: the route's job here is to try BOTH, and a
+// stub that invented names would not prove that.
 vi.mock('@/app/lib/auth/secure-cookies', () => ({
   isSecureCookieContext: () => true,
-  sessionCookieName: () => '__Secure-next-auth.session-token',
+  sessionCookieNameCandidates: () => ['__Secure-next-auth.session-token', 'next-auth.session-token'],
 }));
 
 import { GET } from '../route';
@@ -54,15 +56,49 @@ describe('GET /api/internal/ws-auth', () => {
     expect(decodeMock).toHaveBeenCalledWith(expect.objectContaining({ token: 'encrypted-session-token' }));
   });
 
-  it('returns a no-store anonymous result when the cookie is absent', async () => {
+  it('returns a no-store anonymous result when neither cookie name is present', async () => {
     getTokenMock.mockResolvedValue(null);
 
     const response = await GET(request());
 
     await expect(response.json()).resolves.toEqual({ token: null, authenticated: false });
     expect(response.headers.get('Cache-Control')).toBe('private, no-store');
-    expect(getTokenMock).toHaveBeenCalledTimes(1);
+    // Both names tried, and no decrypt on either — next-auth returns before
+    // `decode` when the cookie is absent, so the fallback is free.
+    expect(getTokenMock).toHaveBeenCalledTimes(2);
     expect(decodeMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves a session stored under the other cookie name', async () => {
+    // The #4651 safety net: a host change that flips isSecureCookieContext()
+    // must not make a live session unreadable. Here the secure name misses and
+    // the plain one hits.
+    getTokenMock.mockResolvedValueOnce(null).mockResolvedValueOnce('plain-named-session-token');
+    decodeMock.mockResolvedValue({ sub: 'user-1', authSessionId: 'login-1' });
+
+    const response = await GET(request());
+
+    await expect(response.json()).resolves.toEqual({
+      token: 'plain-named-session-token',
+      authenticated: true,
+      userId: 'user-1',
+      authSessionId: 'login-1',
+    });
+    expect(getTokenMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ cookieName: '__Secure-next-auth.session-token' }),
+    );
+    expect(getTokenMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ cookieName: 'next-auth.session-token' }));
+    expect(decodeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not read the second name when the preferred one resolves', async () => {
+    getTokenMock.mockResolvedValue('encrypted-session-token');
+    decodeMock.mockResolvedValue({ sub: 'user-1' });
+
+    await GET(request());
+
+    expect(getTokenMock).toHaveBeenCalledTimes(1);
   });
 
   it('does not expose a raw cookie whose decoded token has no subject', async () => {

--- a/packages/web/app/api/internal/ws-auth/route.ts
+++ b/packages/web/app/api/internal/ws-auth/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { decode, getToken, type JWT } from 'next-auth/jwt';
-import { isSecureCookieContext, sessionCookieName } from '@/app/lib/auth/secure-cookies';
+import { isSecureCookieContext, sessionCookieNameCandidates } from '@/app/lib/auth/secure-cookies';
 
 const PRIVATE_NO_STORE_HEADERS = { 'Cache-Control': 'private, no-store' } as const;
 
@@ -10,22 +10,35 @@ const PRIVATE_NO_STORE_HEADERS = { 'Cache-Control': 'private, no-store' } as con
  */
 export async function GET(request: NextRequest) {
   try {
-    const secureCookie = isSecureCookieContext();
     // Pass cookieName + secureCookie explicitly: next-auth's internal derivation
     // breaks if NEXTAUTH_URL is set to an http:// value (the `??` only falls back
-    // when NEXTAUTH_URL is unset, not when it's wrong).
+    // when NEXTAUTH_URL is unset, not when it's wrong). `secureCookie` only
+    // steers next-auth's DEFAULT cookie name, which the explicit `cookieName`
+    // always overrides — it stays here to document the context, not to select.
     const tokenOptions = {
       req: request,
       secret: process.env.NEXTAUTH_SECRET,
-      secureCookie,
-      cookieName: sessionCookieName(),
-    };
+      secureCookie: isSecureCookieContext(),
+      raw: true,
+    } as const;
 
-    // Read the raw cookie bytes once (`raw: true` does not decrypt), then run a
+    // Read the raw cookie bytes (`raw: true` does not decrypt), then run a
     // single decrypt/decode to validate it. This is the same work `raw: false`
     // does internally, so decoding here directly avoids the second cookie read
     // and keeps the JWE decrypted exactly once per handshake.
-    const token = await getToken({ ...tokenOptions, raw: true });
+    //
+    // Try both cookie names, preferred first: this module never loads
+    // auth-options, so it depends entirely on the instrumentation hook having
+    // patched NEXTAUTH_URL. Accepting either name means a session written under
+    // the other one still authenticates the WebSocket handshake even if that
+    // patch, or isSecureCookieContext() itself, is wrong (issue #4651). The
+    // fallback costs nothing on the hit path and no extra decrypt on the miss
+    // path — next-auth returns before `decode` when the cookie is absent.
+    const [preferredCookieName, fallbackCookieName] = sessionCookieNameCandidates();
+    let token = await getToken({ ...tokenOptions, cookieName: preferredCookieName });
+    if (typeof token !== 'string' || !token.trim()) {
+      token = await getToken({ ...tokenOptions, cookieName: fallbackCookieName });
+    }
     if (typeof token !== 'string' || !token.trim()) {
       // User is not authenticated - this is OK, just return null
       return NextResponse.json({ token: null, authenticated: false }, { headers: PRIVATE_NO_STORE_HEADERS });

--- a/packages/web/app/lib/auth/__tests__/canonical-auth-url.test.ts
+++ b/packages/web/app/lib/auth/__tests__/canonical-auth-url.test.ts
@@ -303,6 +303,16 @@ describe('diagnoseCanonicalOrigin', () => {
     expect(diagnoseCanonicalOrigin({ ...PRODUCTION_SERVER, VITEST: 'true' })).toEqual({ level: 'ok' });
   });
 
+  it('never fails a build', () => {
+    // `next build` runs with NODE_ENV=production. Measured on Next 16.2.12 it
+    // does not call the instrumentation hook at all, so this is belt-and-braces
+    // — but a build serves no requests and writes no cookies, so it must never
+    // be the thing this guard stops.
+    expect(diagnoseCanonicalOrigin({ ...PRODUCTION_SERVER, NEXT_PHASE: 'phase-production-build' })).toEqual({
+      level: 'ok',
+    });
+  });
+
   it('downgrades the fatal to a warning when the operator sets the bypass', () => {
     for (const bypassValue of ['1', 'true', 'TRUE']) {
       const diagnosis = diagnoseCanonicalOrigin({

--- a/packages/web/app/lib/auth/__tests__/canonical-auth-url.test.ts
+++ b/packages/web/app/lib/auth/__tests__/canonical-auth-url.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, afterEach } from 'vite-plus/test';
-import { resolveCanonicalAuthUrl, applyCanonicalAuthUrl, type AuthEnv } from '../canonical-auth-url';
+import {
+  ALLOW_MISSING_CANONICAL_ORIGIN_ENV_VAR,
+  applyCanonicalAuthUrl,
+  type AuthEnv,
+  diagnoseCanonicalOrigin,
+  resolveCanonicalAuthUrl,
+} from '../canonical-auth-url';
 
 // Every case drives an explicit env object, so nothing here depends on the
 // ambient process env.
@@ -213,5 +219,114 @@ describe('applyCanonicalAuthUrl', () => {
       applyCanonicalAuthUrl(env);
       if (env.NEXTAUTH_URL) expectNotLoopback(env.NEXTAUTH_URL, hostedEnv);
     }
+  });
+
+  it('says nothing at all when a hosted deployment names no origin and NEXTAUTH_URL is simply absent', () => {
+    // The gap diagnoseCanonicalOrigin exists to close: the backstop needs a
+    // PARSEABLE loopback value before it warns, so an absent NEXTAUTH_URL is
+    // total silence — which is precisely the state Dockerfile.web's runner
+    // stage shipped before #4651.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const env: AuthEnv = { NODE_ENV: 'production' };
+
+    expect(applyCanonicalAuthUrl(env)).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('diagnoseCanonicalOrigin', () => {
+  const PRODUCTION_SERVER: AuthEnv = { NODE_ENV: 'production' };
+
+  it('is fatal on a production server that names no origin at all (the Railway container bug)', () => {
+    const diagnosis = diagnoseCanonicalOrigin({ ...PRODUCTION_SERVER, DATABASE_URL: 'postgres://db/main' });
+
+    expect(diagnosis.level).toBe('fatal');
+    // The message has to name what to set; an operator reading a crashed boot
+    // log gets one shot at understanding it.
+    expect(diagnosis.level === 'fatal' && diagnosis.message).toContain('NEXTAUTH_URL');
+    expect(diagnosis.level === 'fatal' && diagnosis.message).toContain('BASE_URL');
+  });
+
+  it('is ok on Railway production once the canonical origin is set', () => {
+    expect(diagnoseCanonicalOrigin({ ...PRODUCTION_SERVER, NEXTAUTH_URL: PROD_ORIGIN })).toEqual({ level: 'ok' });
+    expect(diagnoseCanonicalOrigin({ ...PRODUCTION_SERVER, BASE_URL: PROD_ORIGIN })).toEqual({ level: 'ok' });
+  });
+
+  it('is ok on Vercel production, where the loopback env file is overridden by the resolver', () => {
+    // Measured production state: .env.local supplies loopback values and
+    // VERCEL_ENV resolves the canonical origin over the top of them. Booting
+    // must not become conditional on Vercel project env being fixed first.
+    expect(
+      diagnoseCanonicalOrigin({
+        ...PRODUCTION_SERVER,
+        VERCEL: '1',
+        VERCEL_ENV: 'production',
+        VERCEL_URL: 'boardsesh-abc.vercel.app',
+        NEXTAUTH_URL: 'http://localhost:3000',
+        BASE_URL: 'http://localhost:3000',
+      }),
+    ).toEqual({ level: 'ok' });
+  });
+
+  it('is ok on a Vercel preview', () => {
+    expect(
+      diagnoseCanonicalOrigin({
+        ...PRODUCTION_SERVER,
+        VERCEL_ENV: 'preview',
+        VERCEL_URL: 'boardsesh-abc.vercel.app',
+      }),
+    ).toEqual({ level: 'ok' });
+  });
+
+  it('is ok on the homelab branch-deploy container', () => {
+    expect(diagnoseCanonicalOrigin({ ...PRODUCTION_SERVER, NEXTAUTH_URL: 'https://42.preview.boardsesh.com' })).toEqual(
+      { level: 'ok' },
+    );
+  });
+
+  it('only warns when a production server names a loopback origin', () => {
+    // `next start` on a laptop and the CI e2e server (which sets
+    // NEXTAUTH_URL=http://localhost:3000) are indistinguishable at boot from a
+    // host handed a copy of .env.local. Failing those closed would brick both.
+    const diagnosis = diagnoseCanonicalOrigin({ ...PRODUCTION_SERVER, ...LOCAL_DEV_ENV });
+
+    expect(diagnosis.level).toBe('warn');
+    expect(diagnosis.level === 'warn' && diagnosis.message).toContain('http://localhost:3000');
+  });
+
+  it('is silent on a developer machine and in a test runner', () => {
+    expect(diagnoseCanonicalOrigin({})).toEqual({ level: 'ok' });
+    expect(diagnoseCanonicalOrigin(LOCAL_DEV_ENV)).toEqual({ level: 'ok' });
+    expect(diagnoseCanonicalOrigin({ NODE_ENV: 'development' })).toEqual({ level: 'ok' });
+    expect(diagnoseCanonicalOrigin({ NODE_ENV: 'test' })).toEqual({ level: 'ok' });
+    // A fixture that forces NODE_ENV=production inside vitest is still a test.
+    expect(diagnoseCanonicalOrigin({ ...PRODUCTION_SERVER, VITEST: 'true' })).toEqual({ level: 'ok' });
+  });
+
+  it('downgrades the fatal to a warning when the operator sets the bypass', () => {
+    for (const bypassValue of ['1', 'true', 'TRUE']) {
+      const diagnosis = diagnoseCanonicalOrigin({
+        ...PRODUCTION_SERVER,
+        [ALLOW_MISSING_CANONICAL_ORIGIN_ENV_VAR]: bypassValue,
+      });
+      expect(diagnosis.level, bypassValue).toBe('warn');
+    }
+    // Anything else is not a bypass — a stray empty value must not disarm it.
+    expect(diagnoseCanonicalOrigin({ ...PRODUCTION_SERVER, [ALLOW_MISSING_CANONICAL_ORIGIN_ENV_VAR]: '' }).level).toBe(
+      'fatal',
+    );
+  });
+
+  it('does not fire for an empty-string origin variable', () => {
+    // Dockerfile.web's runner declares `ENV BASE_URL=$BASE_URL`, which is the
+    // empty string when the image is built without the build arg. An empty
+    // value names nothing, so it must still be fatal rather than pass the check.
+    expect(diagnoseCanonicalOrigin({ ...PRODUCTION_SERVER, BASE_URL: '', NEXTAUTH_URL: '' }).level).toBe('fatal');
+  });
+
+  it('mutates nothing', () => {
+    const env: AuthEnv = { ...PRODUCTION_SERVER };
+    diagnoseCanonicalOrigin(env);
+    expect(env).toEqual({ NODE_ENV: 'production' });
   });
 });

--- a/packages/web/app/lib/auth/__tests__/secure-cookies.test.ts
+++ b/packages/web/app/lib/auth/__tests__/secure-cookies.test.ts
@@ -361,6 +361,26 @@ describe('appendSignOutSessionCookieClears', () => {
     );
   });
 
+  it('clears the chunks of an oversized session cookie, not just the base name', () => {
+    // next-auth splits a >4KB session into `<name>.0`, `<name>.1`, … and its
+    // SessionStore reassembles anything whose name startsWith the base. Clear
+    // only the base and a chunked session survives sign-out — and the fallback
+    // read keeps honouring it. Drop the chunk loop and this goes red.
+    stubAuthEnv({ NEXTAUTH_URL: 'https://www.boardsesh.com' });
+    const response = new Response(null);
+    appendSignOutSessionCookieClears(response, [
+      `${PLAIN_SESSION_COOKIE_NAME}.0`,
+      `${PLAIN_SESSION_COOKIE_NAME}.1`,
+      'unrelated-cookie',
+    ]);
+
+    const clearedNames = response.headers.getSetCookie().map((setCookie) => setCookie.split('=', 1)[0]);
+    expect(clearedNames).toContain(`${PLAIN_SESSION_COOKIE_NAME}.0`);
+    expect(clearedNames).toContain(`${PLAIN_SESSION_COOKIE_NAME}.1`);
+    // Never touch a cookie that isn't a session token.
+    expect(clearedNames).not.toContain('unrelated-cookie');
+  });
+
   it('clears every name the read path would accept, in every environment', () => {
     // Mutation guard: drop a name from appendSignOutSessionCookieClears and this
     // goes red. Without it, sign-out leaves a cookie the dual read still honours.

--- a/packages/web/app/lib/auth/__tests__/secure-cookies.test.ts
+++ b/packages/web/app/lib/auth/__tests__/secure-cookies.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   appendLegacyHostOnlySessionCookieClear,
+  appendSignOutSessionCookieClears,
   isSecureCookieContext,
+  PLAIN_SESSION_COOKIE_NAME,
   responseSetsSessionCookie,
+  SECURE_SESSION_COOKIE_NAME,
   sessionCookieDomain,
   sessionCookieName,
+  sessionCookieNameCandidates,
 } from '../secure-cookies';
 
 // Pin every env the helpers read so values leaking in from the shell can't
@@ -17,6 +21,87 @@ function stubAuthEnv(
   vi.stubEnv('VERCEL_ENV', overrides.VERCEL_ENV ?? '');
   vi.stubEnv('VERCEL_URL', overrides.VERCEL_URL ?? '');
 }
+
+// One row per environment this code has to survive, including the two the
+// Railway cutover introduces. The point of the table is that a future edit
+// which flips ANY of these rows fails here rather than in production, where
+// flipping the cookie NAME logs out every signed-in user at once (#4651).
+type CookieEnvCase = {
+  label: string;
+  env: Partial<Record<'AUTH_COOKIE_DOMAIN' | 'NEXTAUTH_URL' | 'VERCEL_ENV' | 'VERCEL_URL', string>>;
+  secure: boolean;
+  name: string;
+  domain: string | undefined;
+};
+
+const COOKIE_ENV_CASES: CookieEnvCase[] = [
+  {
+    // As measured in production today: the tracked packages/web/.env.local ships
+    // a loopback NEXTAUTH_URL, and the instrumentation hook rewrites it to the
+    // canonical origin before any request is served.
+    label: 'Vercel production, NEXTAUTH_URL already patched to the canonical origin',
+    env: {
+      VERCEL_ENV: 'production',
+      VERCEL_URL: 'boardsesh-abc.vercel.app',
+      NEXTAUTH_URL: 'https://www.boardsesh.com',
+    },
+    secure: true,
+    name: SECURE_SESSION_COOKIE_NAME,
+    domain: '.boardsesh.com',
+  },
+  {
+    label: 'Vercel preview',
+    env: { VERCEL_ENV: 'preview', VERCEL_URL: 'boardsesh-abc.vercel.app' },
+    secure: true,
+    name: SECURE_SESSION_COOKIE_NAME,
+    // A Domain=.boardsesh.com on a *.vercel.app response fails the browser's
+    // domain-match check; preview login must stay host-only.
+    domain: undefined,
+  },
+  {
+    label: 'Railway production with the canonical https origin set, no VERCEL_* at all',
+    env: { NEXTAUTH_URL: 'https://www.boardsesh.com' },
+    secure: true,
+    name: SECURE_SESSION_COOKIE_NAME,
+    domain: '.boardsesh.com',
+  },
+  {
+    // The bug #4651 is actually about: Dockerfile.web's runner stage carried no
+    // canonical origin, so the container silently served plain-named, Domain-less
+    // cookies. instrumentation.ts now refuses to boot here — this row pins what
+    // the cookies WOULD be if it ever booted anyway.
+    label: 'Railway production with no origin variable at all (pre-#4651 container)',
+    env: {},
+    secure: false,
+    name: PLAIN_SESSION_COOKIE_NAME,
+    domain: undefined,
+  },
+  {
+    label: 'local dev over http',
+    env: { VERCEL_ENV: 'development', NEXTAUTH_URL: 'http://localhost:3000' },
+    secure: false,
+    name: PLAIN_SESSION_COOKIE_NAME,
+    domain: undefined,
+  },
+  {
+    label: 'homelab preview host',
+    env: { NEXTAUTH_URL: 'https://42.preview.boardsesh.com' },
+    secure: true,
+    name: SECURE_SESSION_COOKIE_NAME,
+    domain: undefined,
+  },
+];
+
+describe('session cookie shape across every host we run on', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it.each(COOKIE_ENV_CASES)('$label', ({ env, secure, name, domain }) => {
+    stubAuthEnv(env);
+    expect(isSecureCookieContext()).toBe(secure);
+    expect(sessionCookieName()).toBe(name);
+    expect(sessionCookieDomain()).toBe(domain);
+  });
+});
 
 describe('isSecureCookieContext', () => {
   afterEach(() => vi.unstubAllEnvs());
@@ -185,5 +270,108 @@ describe('appendLegacyHostOnlySessionCookieClear', () => {
     const response = new Response(null);
     appendLegacyHostOnlySessionCookieClear(response);
     expect(response.headers.getSetCookie()).toEqual([]);
+  });
+});
+
+describe('sessionCookieNameCandidates', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('puts the secure name first in a secure context, and still offers the plain one', () => {
+    stubAuthEnv({ NEXTAUTH_URL: 'https://www.boardsesh.com' });
+    expect(sessionCookieNameCandidates()).toEqual([SECURE_SESSION_COOKIE_NAME, PLAIN_SESSION_COOKIE_NAME]);
+  });
+
+  it('puts the plain name first in a non-secure context, and still offers the secure one', () => {
+    stubAuthEnv({ NEXTAUTH_URL: 'http://localhost:3000' });
+    expect(sessionCookieNameCandidates()).toEqual([PLAIN_SESSION_COOKIE_NAME, SECURE_SESSION_COOKIE_NAME]);
+  });
+
+  it('offers both names in every environment, so a wrong predicate cannot hide a live session', () => {
+    // The whole point of the dual read: whatever the predicate decides, a reader
+    // is handed both names. Narrow this to one and the #4651 failure mode — a
+    // host change flips the name, every session becomes unreadable — comes back.
+    for (const { env } of COOKIE_ENV_CASES) {
+      stubAuthEnv(env);
+      expect(new Set(sessionCookieNameCandidates())).toEqual(
+        new Set([SECURE_SESSION_COOKIE_NAME, PLAIN_SESSION_COOKIE_NAME]),
+      );
+    }
+  });
+});
+
+describe('appendSignOutSessionCookieClears', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('clears both names in both scopes on the production www host', () => {
+    stubAuthEnv({ NEXTAUTH_URL: 'https://www.boardsesh.com', VERCEL_ENV: 'production' });
+    const response = new Response(null);
+    appendSignOutSessionCookieClears(response);
+
+    const cleared = response.headers.getSetCookie();
+    expect(cleared).toHaveLength(4);
+    for (const name of [SECURE_SESSION_COOKIE_NAME, PLAIN_SESSION_COOKIE_NAME]) {
+      const clearsForName = cleared.filter((setCookie) => setCookie.startsWith(`${name}=;`));
+      expect(clearsForName, name).toHaveLength(2);
+      expect(
+        clearsForName.some((setCookie) => /;\s*Domain=\.boardsesh\.com/i.test(setCookie)),
+        name,
+      ).toBe(true);
+      expect(
+        clearsForName.some((setCookie) => !/;\s*Domain=/i.test(setCookie)),
+        name,
+      ).toBe(true);
+      for (const setCookie of clearsForName) expect(setCookie, name).toMatch(/Max-Age=0/i);
+    }
+  });
+
+  it('still clears both names where there is no cookie domain — the guard it must NOT inherit', () => {
+    // appendLegacyHostOnlySessionCookieClear returns early when
+    // sessionCookieDomain() is undefined, because on a LOGIN it would delete the
+    // cookie NextAuth just wrote. A sign-out writes nothing, so inheriting that
+    // early return would emit no clears at all on local dev, previews and a
+    // mis-enved container — exactly where the dual read is most likely to be
+    // resolving the other name, i.e. exactly where the logout bypass would bite.
+    stubAuthEnv({ NEXTAUTH_URL: 'https://42.preview.boardsesh.com' });
+    expect(sessionCookieDomain()).toBeUndefined();
+
+    const response = new Response(null);
+    appendSignOutSessionCookieClears(response);
+
+    const cleared = response.headers.getSetCookie();
+    expect(cleared).toHaveLength(2);
+    expect(cleared.some((setCookie) => setCookie.startsWith(`${SECURE_SESSION_COOKIE_NAME}=;`))).toBe(true);
+    expect(cleared.some((setCookie) => setCookie.startsWith(`${PLAIN_SESSION_COOKIE_NAME}=;`))).toBe(true);
+    for (const setCookie of cleared) expect(setCookie).not.toMatch(/;\s*Domain=/i);
+  });
+
+  it('always marks the __Secure- clear Secure, and follows the context for the plain one', () => {
+    // A `__Secure-` cookie is only accepted with the Secure attribute
+    // (RFC 6265bis §4.1.3.1), so its deletion carries one even over http — where
+    // the browser drops it, correctly, since no such cookie can exist there. A
+    // Secure deletion of the PLAIN name over http would be dropped too, and that
+    // one has a real cookie to delete.
+    stubAuthEnv({ NEXTAUTH_URL: 'http://localhost:3000' });
+    const response = new Response(null);
+    appendSignOutSessionCookieClears(response);
+
+    const cleared = response.headers.getSetCookie();
+    expect(cleared.find((setCookie) => setCookie.startsWith(`${SECURE_SESSION_COOKIE_NAME}=;`))).toMatch(/;\s*Secure/);
+    expect(cleared.find((setCookie) => setCookie.startsWith(`${PLAIN_SESSION_COOKIE_NAME}=;`))).not.toMatch(
+      /;\s*Secure/,
+    );
+  });
+
+  it('clears every name the read path would accept, in every environment', () => {
+    // Mutation guard: drop a name from appendSignOutSessionCookieClears and this
+    // goes red. Without it, sign-out leaves a cookie the dual read still honours.
+    for (const { env } of COOKIE_ENV_CASES) {
+      stubAuthEnv(env);
+      const response = new Response(null);
+      appendSignOutSessionCookieClears(response);
+      const clearedNames = new Set(response.headers.getSetCookie().map((setCookie) => setCookie.split('=', 1)[0]));
+      for (const candidate of sessionCookieNameCandidates()) {
+        expect([...clearedNames], JSON.stringify(env)).toContain(candidate);
+      }
+    }
   });
 });

--- a/packages/web/app/lib/auth/canonical-auth-url.ts
+++ b/packages/web/app/lib/auth/canonical-auth-url.ts
@@ -136,7 +136,12 @@ export const ALLOW_MISSING_CANONICAL_ORIGIN_ENV_VAR = 'AUTH_ALLOW_MISSING_CANONI
 function isProductionServerRuntime(env: AuthEnv): boolean {
   if (env.NODE_ENV !== 'production') return false;
   // A vitest worker handed NODE_ENV=production by a fixture is still a test run.
-  return env.VITEST !== 'true';
+  if (env.VITEST === 'true') return false;
+  // `next build` sets NODE_ENV=production too. Measured on Next 16.2.12: it does
+  // not invoke the instrumentation hook, so this branch is belt-and-braces — but
+  // a build has no visitors and no cookies, so if that ever changes it must not
+  // become a build failure.
+  return !env.NEXT_PHASE?.startsWith('phase-production-build');
 }
 
 function namesAnyOrigin(env: AuthEnv): boolean {

--- a/packages/web/app/lib/auth/canonical-auth-url.ts
+++ b/packages/web/app/lib/auth/canonical-auth-url.ts
@@ -113,6 +113,112 @@ export function resolveCanonicalAuthUrl(env: AuthEnv = process.env): string | un
   return undefined;
 }
 
+// The env vars an operator can set to name this deployment's canonical origin,
+// in the order resolveCanonicalAuthUrl consults them. Exported so the boot
+// guard's message, its tests and the deployment docs cannot drift from what the
+// resolver actually reads.
+export const CANONICAL_ORIGIN_ENV_VARS = ['NEXTAUTH_URL', 'BASE_URL'] as const;
+
+// Emergency bypass for the fatal branch of diagnoseCanonicalOrigin(). Booting
+// past a missing canonical origin means shipping the mass logout the guard
+// exists to stop, so this only ever downgrades the failure to a warning — it is
+// for an operator who has decided that a degraded site beats no site.
+export const ALLOW_MISSING_CANONICAL_ORIGIN_ENV_VAR = 'AUTH_ALLOW_MISSING_CANONICAL_ORIGIN';
+
+// True when this process is a built production server — `next start`, or the
+// standalone server Dockerfile.web's runner stage launches — rather than
+// `vp run dev`, a vitest worker, or a build step.
+//
+// Deliberately NOT keyed on a hosting vendor: VERCEL_ENV / VERCEL_URL are absent
+// on Railway and on every other host, which is the whole reason issue #4651
+// exists. `NODE_ENV === 'production'` is the host-agnostic form of the same
+// question, and it is exactly what the runner stage bakes in (ENV NODE_ENV=production).
+function isProductionServerRuntime(env: AuthEnv): boolean {
+  if (env.NODE_ENV !== 'production') return false;
+  // A vitest worker handed NODE_ENV=production by a fixture is still a test run.
+  return env.VITEST !== 'true';
+}
+
+function namesAnyOrigin(env: AuthEnv): boolean {
+  return CANONICAL_ORIGIN_ENV_VARS.some((variableName) => parseAbsoluteHttpUrl(env[variableName]) !== undefined);
+}
+
+function isBypassEnabled(env: AuthEnv): boolean {
+  const bypass = env[ALLOW_MISSING_CANONICAL_ORIGIN_ENV_VAR]?.trim().toLowerCase();
+  return bypass === '1' || bypass === 'true';
+}
+
+/**
+ * What to tell the operator about this deployment's canonical origin at boot.
+ *
+ * `fatal` is reserved for the one state that is unambiguously broken and cannot
+ * occur on a developer machine: a production server on which NEITHER
+ * NEXTAUTH_URL NOR BASE_URL names any http(s) origin at all. Every local and CI
+ * path names one — the tracked `packages/web/.env.local` supplies both, and
+ * `.github/workflows/e2e-tests.yml` sets NEXTAUTH_URL explicitly — while
+ * Dockerfile.web's runner stage carried neither before #4651, because Next's
+ * standalone writer copies only `.env` / `.env.production`, never `.env.local`.
+ *
+ * That state used to be SILENT: applyCanonicalAuthUrl's backstop below needs a
+ * *parseable loopback* NEXTAUTH_URL before it says anything, so an absent one
+ * produced no warning while the deployment quietly served plain-named,
+ * Domain-less session cookies and localhost OAuth redirects.
+ *
+ * A loopback origin on a production server only ever warns: `next start` on a
+ * laptop and the CI e2e server are indistinguishable at boot from a host that
+ * was handed a copy of `.env.local`, and failing those closed would be worse
+ * than the warning.
+ *
+ * Pure: reads only the passed env, mutates nothing. Call it BEFORE
+ * applyCanonicalAuthUrl(), which can delete a loopback NEXTAUTH_URL and so turn
+ * a warn into a spurious fatal.
+ *
+ * Full rationale and the deployment checklist: docs/web-canonical-origin.md.
+ */
+export type CanonicalOriginDiagnosis =
+  | { level: 'ok' }
+  | { level: 'warn'; message: string }
+  | { level: 'fatal'; message: string };
+
+export function diagnoseCanonicalOrigin(env: AuthEnv = process.env): CanonicalOriginDiagnosis {
+  if (!isProductionServerRuntime(env)) return { level: 'ok' };
+  if (resolveCanonicalAuthUrl(env)) return { level: 'ok' };
+
+  if (namesAnyOrigin(env)) {
+    const named = CANONICAL_ORIGIN_ENV_VARS.filter((variableName) => env[variableName]?.trim())
+      .map((variableName) => `${variableName}="${env[variableName]}"`)
+      .join(', ');
+    return {
+      level: 'warn',
+      message:
+        `[auth] NODE_ENV=production but the only origin this deployment names is a loopback one (${named}). ` +
+        'That is correct for `next start` on a laptop and for the CI e2e server. On a real deployment it means ' +
+        'session cookies lose the `__Secure-` prefix and the `.boardsesh.com` domain scope, and OAuth redirects ' +
+        "to localhost — set NEXTAUTH_URL to this deployment's canonical https origin.",
+    };
+  }
+
+  const message =
+    '[auth] No canonical origin is configured. This process is running as a production server ' +
+    `(NODE_ENV=production) and neither ${CANONICAL_ORIGIN_ENV_VARS.join(' nor ')} names an http(s) origin, so ` +
+    'next-auth falls back to http://localhost:3000: every session cookie loses its `__Secure-` name and its ' +
+    '`Domain=.boardsesh.com` scope — which logs out every signed-in user — and OAuth sends people to a dead ' +
+    "localhost page. Set NEXTAUTH_URL to this deployment's canonical https origin (and BASE_URL to the same " +
+    'value; it also builds the links in verification and password-reset email), e.g. ' +
+    'NEXTAUTH_URL=https://www.boardsesh.com.';
+
+  if (isBypassEnabled(env)) {
+    return {
+      level: 'warn',
+      message: `${message} Booting anyway because ${ALLOW_MISSING_CANONICAL_ORIGIN_ENV_VAR} is set.`,
+    };
+  }
+  return {
+    level: 'fatal',
+    message: `${message} To boot anyway and accept that logout, set ${ALLOW_MISSING_CANONICAL_ORIGIN_ENV_VAR}=1.`,
+  };
+}
+
 /**
  * Writes the canonical origin into `env.NEXTAUTH_URL` when it differs from what
  * is already there, so next-auth (and our cookie-domain helpers) read a correct
@@ -128,6 +234,11 @@ export function applyCanonicalAuthUrl(env: AuthEnv = process.env): string | unde
     // from the (platform-set) forwarded host when VERCEL is present, instead of
     // hard-coding a loopback redirect URI. This is a backstop for a
     // misconfigured deployment, not a supported configuration.
+    //
+    // It needs a PARSEABLE loopback value to say anything, so a deployment with
+    // NEXTAUTH_URL simply absent falls straight through in silence. That gap is
+    // covered by diagnoseCanonicalOrigin() above, which instrumentation.ts runs
+    // at boot.
     const loopback = parseAbsoluteHttpUrl(env.NEXTAUTH_URL);
     if (loopback && isLoopbackHostname(loopback.hostname) && isHostedDeployment(env)) {
       console.warn(

--- a/packages/web/app/lib/auth/secure-cookies.ts
+++ b/packages/web/app/lib/auth/secure-cookies.ts
@@ -130,9 +130,21 @@ function sessionCookieClear(name: string, domain: string | undefined): string {
  * nothing at all on exactly the host-only deployments (local, previews, a
  * mis-enved container) where the other name is most likely to be the live one.
  */
-export function appendSignOutSessionCookieClears(response: Response): void {
+export function appendSignOutSessionCookieClears(response: Response, requestCookieNames: readonly string[] = []): void {
   const domain = sessionCookieDomain();
-  for (const name of [SECURE_SESSION_COOKIE_NAME, PLAIN_SESSION_COOKIE_NAME]) {
+  const namesToClear = new Set([SECURE_SESSION_COOKIE_NAME, PLAIN_SESSION_COOKIE_NAME]);
+  // next-auth splits an oversized session cookie into `<name>.0`, `<name>.1`, …
+  // and its SessionStore reassembles anything whose name startsWith the base
+  // (next-auth/core/lib/cookie.js). Clearing only the base names would leave a
+  // chunked session intact — and the fallback read would go on honouring it.
+  // Pass the names the request actually carried so the chunk count never has to
+  // be guessed.
+  for (const cookieName of requestCookieNames) {
+    for (const baseName of [SECURE_SESSION_COOKIE_NAME, PLAIN_SESSION_COOKIE_NAME]) {
+      if (cookieName.startsWith(`${baseName}.`)) namesToClear.add(cookieName);
+    }
+  }
+  for (const name of namesToClear) {
     response.headers.append('Set-Cookie', sessionCookieClear(name, undefined));
     if (domain) response.headers.append('Set-Cookie', sessionCookieClear(name, domain));
   }

--- a/packages/web/app/lib/auth/secure-cookies.ts
+++ b/packages/web/app/lib/auth/secure-cookies.ts
@@ -13,8 +13,33 @@ export function isSecureCookieContext(): boolean {
   );
 }
 
+export const SECURE_SESSION_COOKIE_NAME = '__Secure-next-auth.session-token';
+export const PLAIN_SESSION_COOKIE_NAME = 'next-auth.session-token';
+
 export function sessionCookieName(): string {
-  return isSecureCookieContext() ? '__Secure-next-auth.session-token' : 'next-auth.session-token';
+  return isSecureCookieContext() ? SECURE_SESSION_COOKIE_NAME : PLAIN_SESSION_COOKIE_NAME;
+}
+
+// Both session cookie names, the one this context would WRITE first. Read paths
+// try them in order so that resolving an existing session never depends on
+// isSecureCookieContext() being right: the failure this whole module guards
+// against is a host change flipping the predicate and making every live cookie
+// unreadable, and a reader that accepts either name simply cannot have it.
+//
+// `server-auth.ts` has read both names in production since it was written; this
+// is the same posture, expressed once. The write path stays single-named —
+// next-auth writes one cookie, and `__Secure-` may only be set over https
+// (RFC 6265bis §4.1.3.1), so there is no dual write to be had.
+//
+// The cost is that a plain-named cookie minted during a misconfiguration window
+// is honoured again. www is HSTS'd and the value is still a JWE validated
+// against NEXTAUTH_SECRET, so the exposure is small — but it is why sign-out
+// clears BOTH names (appendSignOutSessionCookieClears below). Revisit with the
+// rest of the Vercel teardown, #4656.
+export function sessionCookieNameCandidates(): readonly [string, string] {
+  return isSecureCookieContext()
+    ? [SECURE_SESSION_COOKIE_NAME, PLAIN_SESSION_COOKIE_NAME]
+    : [PLAIN_SESSION_COOKIE_NAME, SECURE_SESSION_COOKIE_NAME];
 }
 
 // Domain attribute for the session cookie (and the OAuth-flow cookies), shared
@@ -73,6 +98,44 @@ export function appendLegacyHostOnlySessionCookieClear(response: Response): void
   const secure = isSecureCookieContext();
   const clearedCookie = `${sessionCookieName()}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax${secure ? '; Secure' : ''}`;
   response.headers.append('Set-Cookie', clearedCookie);
+}
+
+function sessionCookieClear(name: string, domain: string | undefined): string {
+  // A `__Secure-` cookie is only accepted with the Secure attribute, whatever
+  // isSecureCookieContext() says, so its deletion always carries one. Over http
+  // the browser drops that Set-Cookie — correctly: no `__Secure-` cookie can
+  // exist there to delete. The plain name follows the context instead, because
+  // a Secure deletion sent over http would be dropped and dev sign-out would
+  // stop clearing anything.
+  const secure = name.startsWith('__Secure-') || isSecureCookieContext();
+  return `${name}=; Path=/${domain ? `; Domain=${domain}` : ''}; Max-Age=0; HttpOnly; SameSite=Lax${secure ? '; Secure' : ''}`;
+}
+
+/**
+ * Sign-out only. Deletes BOTH session cookie names, in every scope this
+ * deployment could have written them in (Domain-scoped where a cookie domain
+ * applies, plus host-only).
+ *
+ * Why both names: the read paths accept either (sessionCookieNameCandidates),
+ * so clearing only the name the predicate currently picks would leave a cookie
+ * behind that still authenticates — a logout bypass, and a worse one than the
+ * legacy host-only cookie `appendLegacyHostOnlySessionCookieClear` was written
+ * to close, because it survives indefinitely.
+ *
+ * Why this does NOT reuse that function: it returns early when
+ * `sessionCookieDomain()` is undefined. That early return is correct there —
+ * on a LOGIN response with no cookie domain in play, the "legacy" clear would
+ * target the very cookie NextAuth just wrote. A sign-out writes no fresh
+ * cookie, so there is nothing to protect, and inheriting the guard would emit
+ * nothing at all on exactly the host-only deployments (local, previews, a
+ * mis-enved container) where the other name is most likely to be the live one.
+ */
+export function appendSignOutSessionCookieClears(response: Response): void {
+  const domain = sessionCookieDomain();
+  for (const name of [SECURE_SESSION_COOKIE_NAME, PLAIN_SESSION_COOKIE_NAME]) {
+    response.headers.append('Set-Cookie', sessionCookieClear(name, undefined));
+    if (domain) response.headers.append('Set-Cookie', sessionCookieClear(name, domain));
+  }
 }
 
 // True when the response installs a fresh (non-empty) value for the session

--- a/packages/web/instrumentation.ts
+++ b/packages/web/instrumentation.ts
@@ -1,13 +1,42 @@
 import * as Sentry from '@sentry/nextjs';
-import { applyCanonicalAuthUrl } from './app/lib/auth/canonical-auth-url';
+import { applyCanonicalAuthUrl, diagnoseCanonicalOrigin } from './app/lib/auth/canonical-auth-url';
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
+    // Read the diagnosis off the PRISTINE env, before applyCanonicalAuthUrl can
+    // delete a loopback NEXTAUTH_URL — a deleted one would look like "no origin
+    // named at all" and turn a warning into a spurious boot failure.
+    const canonicalOriginDiagnosis = diagnoseCanonicalOrigin();
+
     // Once per server boot, so routes that read NEXTAUTH_URL without importing
     // auth-options (e.g. /api/internal/ws-auth via secure-cookies) also see the
     // canonical origin instead of next-auth's localhost fallback (issue #4227).
     applyCanonicalAuthUrl();
+
+    // Sentry first, so the throw below is reported rather than only printed.
     await import('./sentry.server.config');
+
+    if (canonicalOriginDiagnosis.level === 'warn') {
+      console.warn(canonicalOriginDiagnosis.message);
+    } else if (canonicalOriginDiagnosis.level === 'fatal') {
+      // Refusing to boot beats serving a fleet-wide logout: an unconfigured
+      // origin flips every session cookie's name and drops its domain scope, so
+      // a container that starts "fine" quietly signs out the entire user base
+      // (issue #4651).
+      console.error(canonicalOriginDiagnosis.message);
+      Sentry.captureException(new Error(canonicalOriginDiagnosis.message));
+      await Sentry.flush(2000).catch(() => {});
+      // Exit rather than throw. Measured on the Dockerfile.web runner: throwing
+      // out of register() leaves Next answering EVERY request with a 500 while
+      // the process stays alive — and the container's healthcheck still reports
+      // healthy, so an orchestrator happily promotes it. Exiting is the signal
+      // a deploy actually fails on. It cannot fire on a developer machine or in
+      // CI: diagnoseCanonicalOrigin only returns 'fatal' when NODE_ENV is
+      // production AND neither NEXTAUTH_URL nor BASE_URL names any origin, and
+      // every local, test and build path names one (the tracked
+      // packages/web/.env.local, or e2e-tests.yml's explicit NEXTAUTH_URL).
+      process.exit(1);
+    }
   }
 
   if (process.env.NEXT_RUNTIME === 'edge') {

--- a/scripts/__tests__/dockerfile-web-auth-origin.test.ts
+++ b/scripts/__tests__/dockerfile-web-auth-origin.test.ts
@@ -32,9 +32,20 @@ describe('Dockerfile.web canonical auth origin', () => {
   });
 
   it('declares BASE_URL in the runner stage, not only in the builder', () => {
-    expect(builderStage).toContain('ENV BASE_URL=$BASE_URL');
-    expect(runnerStage).toContain('ARG BASE_URL');
-    expect(runnerStage).toContain('ENV BASE_URL=$BASE_URL');
+    // Whole-line matches: `toContain('ARG BASE_URL')` is happily satisfied by
+    // `ARG BASE_URL_SOMETHING_ELSE`, and text pinning is this file's only job.
+    expect(builderStage).toMatch(/^ENV BASE_URL=\$BASE_URL$/m);
+    expect(runnerStage).toMatch(/^ARG BASE_URL$/m);
+    expect(runnerStage).toMatch(/^ENV BASE_URL=\$BASE_URL$/m);
+  });
+
+  it('documents that the runner ENV is an empty string without the build arg', () => {
+    // `ENV BASE_URL=$BASE_URL` with no `--build-arg` bakes BASE_URL="" — the
+    // variable is PRESENT and empty, not absent. Three transactional-email
+    // routes read it, and `??` would have kept that empty string and stripped
+    // the origin off every verification and password-reset link. They use
+    // `?.trim() ||`; this pins the reason next to the cause.
+    expect(runnerStage).toMatch(/empty string/i);
   });
 
   it('does not bake a NEXTAUTH_URL into the image', () => {

--- a/scripts/__tests__/dockerfile-web-auth-origin.test.ts
+++ b/scripts/__tests__/dockerfile-web-auth-origin.test.ts
@@ -1,0 +1,66 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Nothing in CI builds Dockerfile.web (branch-deploy.yml is workflow_dispatch
+// only, and railway.toml's [deploy] block covers the backend image), so a text
+// pin is the only oracle this file has. Same reasoning as
+// dockerfile-web-no-expo-export.test.ts.
+//
+// What is being pinned: the runner stage must carry a canonical-origin variable
+// of its own. It used to carry none — `ARG BASE_URL` / `ENV BASE_URL` sat in the
+// BUILDER stage, and Next's standalone writer copies only `.env` and
+// `.env.production`, never the tracked `packages/web/.env.local` that supplies
+// NEXTAUTH_URL/BASE_URL on a laptop and on Vercel. The resulting container had
+// no idea what origin it served: plain-named, Domain-less session cookies and
+// localhost OAuth redirects, silently (issue #4651).
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const dockerfile = readFileSync(join(repositoryRoot, 'Dockerfile.web'), 'utf8');
+const runnerStage = dockerfile.slice(dockerfile.indexOf('AS runner'));
+const builderStage = dockerfile.slice(dockerfile.indexOf('AS builder'), dockerfile.indexOf('AS runner'));
+
+describe('Dockerfile.web canonical auth origin', () => {
+  it('splits into a builder and a runner stage', () => {
+    // Every assertion below slices on these markers; if the stage names change,
+    // the slices silently become the whole file and the pins stop meaning anything.
+    expect(dockerfile).toContain('AS builder');
+    expect(dockerfile).toContain('AS runner');
+    expect(dockerfile.indexOf('AS builder')).toBeLessThan(dockerfile.indexOf('AS runner'));
+  });
+
+  it('declares BASE_URL in the runner stage, not only in the builder', () => {
+    expect(builderStage).toContain('ENV BASE_URL=$BASE_URL');
+    expect(runnerStage).toContain('ARG BASE_URL');
+    expect(runnerStage).toContain('ENV BASE_URL=$BASE_URL');
+  });
+
+  it('does not bake a NEXTAUTH_URL into the image', () => {
+    // NEXTAUTH_URL is the direct authority for the cookie name, the cookie
+    // domain and the OAuth redirect_uri. Baking one into a reusable image is how
+    // a preview container ends up claiming the production origin — and writing
+    // Domain=.boardsesh.com from a preview host, which a browser accepts and a
+    // preview sign-out then uses to delete the production cookie. It is supplied
+    // at run time (branch-deploy.yml `-e NEXTAUTH_URL=…`, Railway service vars).
+    expect(dockerfile).not.toContain('ENV NEXTAUTH_URL');
+  });
+
+  it('healthchecks over HTTP, not a bare TCP connect', () => {
+    // A socket that accepts proves nothing: Next keeps listening after a failed
+    // server prepare and 500s every request. The pre-#4651 container reported
+    // `healthy` while answering nothing — measured, not assumed.
+    expect(runnerStage).toContain('HEALTHCHECK');
+    expect(runnerStage).not.toContain("require('net')");
+    expect(runnerStage).toContain("require('http')");
+    expect(runnerStage).toContain('statusCode<500');
+  });
+
+  it('keeps the runner on NODE_ENV=production, which is what the boot guard keys on', () => {
+    // diagnoseCanonicalOrigin() treats NODE_ENV=production as "this is a built
+    // production server" — the host-agnostic replacement for VERCEL_ENV. Drop
+    // this and the container that has no origin boots quietly again.
+    expect(runnerStage).toContain('ENV NODE_ENV=production');
+  });
+});


### PR DESCRIPTION
## Summary

Part of #4648 (Phase 1). Closes #4651.

### The issue's prescribed fix is a no-op — don't ship it

The issue says to "re-key the decision off the canonical base URL's https-ness
(`BASE_URL`/`NEXTAUTH_URL`), not the hosting vendor", quoting the predicate as
`VERCEL_ENV === 'production' || !!VERCEL_URL`.

That quote is stale. `isSecureCookieContext()` already has three terms, and one of
them already is `process.env.NEXTAUTH_URL?.startsWith('https://')`. And
`applyCanonicalAuthUrl()` runs from `instrumentation.ts:9` on every nodejs boot
(#4227), so by the time any module reads it, `NEXTAUTH_URL` is the canonical https
origin — including in `/api/internal/ws-auth`, which never imports `auth-options`.
Adding a `BASE_URL` https term buys exactly one new true-case, in a configuration
where the resolver has already copied `BASE_URL` into `NEXTAUTH_URL` and the
existing term therefore already fires.

Going the other way — *deleting* the Vercel terms, as the issue also asks — is
worse than a no-op. `packages/web/.env.local` is tracked and ships a loopback
`NEXTAUTH_URL` into the Vercel runtime; strip `VERCEL_ENV`/`VERCEL_URL` from
`isHostedDeployment()` and `resolveCanonicalAuthUrl()` returns `undefined` in
production today, which flips the cookie name and logs out the fleet on Vercel,
before Railway is even involved. So `secure-cookies.ts`'s predicate and
`sessionCookieDomain()` are **unchanged** here. `sessionCookieDomain()` keeps its
preview guard for free.

### The real bug: the runner stage had no canonical origin at all

`Dockerfile.web` declared `ARG BASE_URL` / `ENV BASE_URL` inside the **builder**
stage (line 57). The **runner** stage set only `NODE_ENV`, `BOARDSESH_WEB`,
`HOSTNAME` and `PORT`. Next's standalone writer copies only `.env` and
`.env.production` out of the build — never `.env.local`. So a Railway container
would have started with no origin variable whatsoever:

- `resolveCanonicalAuthUrl()` → `undefined`
- session cookie written as `next-auth.session-token`, not `__Secure-next-auth.session-token`
- `Domain=.boardsesh.com` dropped, so the cookie stops being shared with `app.boardsesh.com`
  (and a same-named cookie at a different domain scope is a *different* browser
  entry — a second, independent logout)
- next-auth falls back to `http://localhost:3000` for the OAuth `redirect_uri` (#4227 again)

...and **no diagnostic at all**, because the backstop at `canonical-auth-url.ts:131`
needs a *parseable loopback* `NEXTAUTH_URL` before it will warn. An absent one
falls straight through in silence. Measured, not assumed: `grep BASE_URL` on the
built image's runner env came back empty, and a container run with only
`NEXTAUTH_SECRET` + `DATABASE_URL` served plain-named, `Domain`-less cookies.

### What this PR does

1. **Runner-stage env plumbing.** `Dockerfile.web`'s runner declares its own
   `ARG`/`ENV BASE_URL`. Pinned by a new text test
   (`scripts/__tests__/dockerfile-web-auth-origin.test.ts`) because nothing in CI
   builds this file. Required variables documented in `docs/web-canonical-origin.md`.

2. **Fail loudly, not silently.** `diagnoseCanonicalOrigin()` runs at boot from
   `instrumentation.ts`, on the *pristine* env (before `applyCanonicalAuthUrl()`
   can delete a loopback value and make a warning look like a fatal):

   | Runtime | Result |
   | --- | --- |
   | `NODE_ENV=production`, neither `NEXTAUTH_URL` nor `BASE_URL` names an origin | **fatal** — logs, reports to Sentry, exits `1` |
   | `NODE_ENV=production`, only a loopback origin named | warning |
   | anything else (dev, vitest, a build) | silent |

   `NODE_ENV=production` is the host-agnostic form of "this is a built production
   server" and is exactly what the runner stage bakes in. It **cannot** brick a
   local, CI or build run: the fatal branch needs *no origin variable at all*, and
   every one of those paths names one — the tracked `.env.local` on a laptop and in
   the Docker builder, `e2e-tests.yml`'s explicit `NEXTAUTH_URL` in CI.
   `AUTH_ALLOW_MISSING_CANONICAL_ORIGIN=1` downgrades the fatal to a warning for an
   operator who decides a degraded site beats no site.

   It **exits** rather than throws, and that is a measured decision. With a throw,
   Next kept the process alive, answered every request with a 500, and the
   container's TCP healthcheck still reported `healthy` — an orchestrator would
   have promoted it. Which is also why:

3. **The Docker HEALTHCHECK is now an HTTP probe** of `/robots.txt` (prerendered,
   no database) that fails on 5xx, instead of a bare `net.connect`.

4. **Dual read at both `getToken` sites** (`ws-auth/route.ts`,
   `[...nextauth]/route.ts`). **Scope, stated precisely:** this covers those two
   endpoints only. `auth-options.ts:168` still configures NextAuth with one
   `sessionToken.name`, so `getServerSession`, `/api/auth/session`, `useSession`
   and `middleware.ts` remain single-named — if `isSecureCookieContext()` ever
   flipped, the fleet would still be logged out. What the dual read actually buys
   is that the WebSocket handshake keeps working and sign-out stops returning 409.
   Do **not** read it as "the logout risk is covered"; the guard in (2) is what
   covers that. `cookieName` is a real next-auth option and there is no doubled
   decrypt — `getToken` returns before `decode` when the cookie is absent.
   `secureCookie` stays a single shared value (it only steers next-auth's
   *default* name, which the explicit `cookieName` always overrides); passing it
   per candidate would have been cargo cult. `server-auth.ts` has read both names
   in production since it was written — this is the same posture.

   **The trade-off, named.** On `www` a plain `next-auth.session-token` now
   authenticates at `/api/internal/ws-auth` and passes the sign-out identity guard
   where only `__Secure-` did before. The plain name has neither the `Secure`
   attribute nor prefix protection, so the realistic exposure is session
   *fixation* — an active attacker on a plaintext sibling host pinning a victim's
   WebSocket identity to an attacker-owned account — and only for a victim with no
   existing `__Secure-` cookie, since the preferred name is tried first. Mitigated
   by HSTS `includeSubDomains` (`next.config.mjs:387`, `:412`). Marked for revisit
   with the rest of the Vercel teardown (#4656).

5. **Sign-out clears both names, in both scopes** — and every chunk of them.
   The dual read would otherwise be a logout bypass, and
   `appendLegacyHostOnlySessionCookieClear`'s `sessionCookieDomain() === undefined`
   early return must **not** be inherited: it exists so a *login* response doesn't
   delete the cookie it just wrote, and a sign-out writes nothing. Inheriting it
   would emit nothing at all on exactly the host-only deployments where the other
   name is most likely to be the live one. next-auth also splits an oversized
   session into `<name>.0`, `<name>.1`, … and reassembles anything whose name
   `startsWith` the base, so the clear takes the request's cookie names and deletes
   the chunks too rather than guessing how many there are.

6. **`?.trim() ||`, not `??`, on the three transactional-email routes.** The new
   runner-stage `ENV BASE_URL=$BASE_URL` bakes the **empty string** when the image
   is built without the build arg — the variable becomes present-and-empty rather
   than absent, and `??` would have kept it, stripping the origin off every
   verification, password-reset and registration link. Caught in review; it would
   have been a regression this PR introduced.

## `Set-Cookie` diff: production vs container

Values redacted; names and attributes are the payload.

`GET /api/auth/csrf` — **byte-identical**:

```
--- production  https://www.boardsesh.com (Vercel)
+++ container   this branch, docker run -e NEXTAUTH_URL=https://www.boardsesh.com -e BASE_URL=https://www.boardsesh.com
 set-cookie: __Host-next-auth.csrf-token=<redacted>; Path=/; HttpOnly; Secure; SameSite=Lax
 set-cookie: __Secure-next-auth.callback-url=<redacted>; Domain=.boardsesh.com; Path=/; HttpOnly; Secure; SameSite=None
```

(no diff — `diff` output is empty)

A real credentials login against the container, against the dev DB:

```
set-cookie: __Secure-next-auth.callback-url=<redacted>; Domain=.boardsesh.com; Path=/; HttpOnly; Secure; SameSite=None
set-cookie: __Secure-next-auth.session-token=<redacted>; Domain=.boardsesh.com; Path=/; Expires=…; HttpOnly; Secure; SameSite=Lax
set-cookie: __Secure-next-auth.session-token=<redacted>; Path=/; Max-Age=0; HttpOnly; SameSite=Lax; Secure
```

— the `__Secure-` prefix, the shared `.boardsesh.com` domain, and the unchanged
legacy host-only clear. `__Host-next-auth.csrf-token` is next-auth's own name, not
ours, and it also comes out right, which is the independent check that
`NEXTAUTH_URL` really did reach next-auth.

Same image, `NEXTAUTH_URL=http://localhost:3000` (negative control — proves the
predicate is not stuck true):

```
set-cookie: next-auth.session-token=<redacted>; Path=/; Expires=…; HttpOnly; SameSite=Lax
```

Same image, **no origin variable at all** (the pre-this-PR Railway state):

```
[auth] No canonical origin is configured. … Set NEXTAUTH_URL to this deployment's canonical https origin …
container exited with code 1
```

## Test plan

- `vp run typecheck` — green
- `vp check` — 0 errors
- `vp test run --project web` — 370 files, 4293 tests, green
- `vp test run --project scripts` — 68 files, 1033 tests, green
- New unit coverage for the predicate + origin resolution over Vercel prod, Vercel
  preview, Railway-with-https-origin, **Railway with no origin var at all**, local
  dev http, homelab preview, and env-missing; plus the bypass, the empty-string
  `ENV BASE_URL=` case, and purity.
- Mutation-tested (each of these makes a test go red):
  - drop `PLAIN_SESSION_COOKIE_NAME` from `appendSignOutSessionCookieClears` → 6 red
  - neuter `diagnoseCanonicalOrigin`'s production-server check → 4 red
  - delete the fallback `getToken` in `ws-auth` → 2 red
  - drop the chunk loop from `appendSignOutSessionCookieClears` → 1 red
- Built `Dockerfile.web` and exercised the container end to end against the dev DB:
  login, `/api/internal/ws-auth` with the JWE under **each** cookie name (both
  authenticate), and a sign-out while the session was held under the *plain* name.
  That sign-out returned 200 (it would have 409'd without the fallback read) and
  emitted all four clears:

  ```
  __Secure-next-auth.session-token=; Path=/; Max-Age=0; …; Secure
  __Secure-next-auth.session-token=; Path=/; Domain=.boardsesh.com; Max-Age=0; …; Secure
  next-auth.session-token=; Path=/; Max-Age=0; …; Secure
  next-auth.session-token=; Path=/; Domain=.boardsesh.com; Max-Age=0; …; Secure
  ```

  Worth noting what NextAuth itself emitted on that request: **nothing**. Its
  `SessionStore` only deletes cookies it can see, and it was configured with the
  `__Secure-` name. Without this PR's clear, that sign-out returns 200 and leaves a
  cookie behind that still authenticates.

## What is deliberately NOT deleted

- **`packages/backend/src/handlers/cors.ts`'s `*.vercel.app` allowlist.** The issue
  calls it dead. It isn't: the production deployment's own URL
  (`boardsesh-<hash>-marcodejonghs-projects.vercel.app`) matches the regex, and
  that is the shape Instant Rollback verification produces. Left in place for
  #4656.
- **`.github/workflows/branch-deploy.yml`'s `-e VERCEL_ENV=preview`.** Traceably
  inert (the preview container sets an https `NEXTAUTH_URL`, which short-circuits
  every consumer ahead of it), but branch-deploy is `workflow_dispatch`-only so
  this PR cannot produce a live proof. Not worth the risk for zero gain. #4656.
- **`isSecureCookieContext()` / `sessionCookieDomain()`.** See the top of this
  description.

The remaining host-agnostic cleanups the issue lists — `og/setter/route.tsx`,
`warm-overlay-cache.ts` (which the issue misses, and which is on a hot SSR path),
`drizzle.config.ts`, `crypto/src/env.ts`, and the Sentry gate that goes dark on
Railway — ship separately, so a mass-logout-capable change and six cosmetics don't
share one revert lever.

## Release Notes

- [x] No release note needed (internal / technical change)
