### PR TITLE
fix(web): stop keying runtime behaviour on the hosting vendor

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -184,7 +184,13 @@ jobs:
             BACKEND_INTERNAL_URL="ws://staging-backend:8080/graphql"
           fi
 
-          # Pull and start web
+          # Pull and start web.
+          #
+          # TODO(#4656): the `-e VERCEL_ENV=preview` below goes with the Vercel
+          # project. Traced inert already — the https NEXTAUTH_URL short-circuits
+          # every consumer ahead of it — but this workflow is
+          # workflow_dispatch-only, so no PR can produce the live proof, and
+          # #4651 chose not to remove it on a desk-check alone.
           docker pull ghcr.io/boardsesh/boardsesh-web:pr-${PR_NUM}
 
           docker run -d \

--- a/packages/backend/src/handlers/cors.ts
+++ b/packages/backend/src/handlers/cors.ts
@@ -8,6 +8,12 @@ import { logger } from '../utils/logger';
 // via VERCEL_PREVIEW_ORIGIN_SUFFIX so a fork/other deployment can allow its own
 // preview origins without patching this file. Recomputed in initCors so the env
 // is read at startup (and in tests).
+// TODO(#4656): delete with the Vercel project, not before. Issue #4651 called
+// this dead code; it is not. The production deployment's own URL has the shape
+// `boardsesh-<hash>-marcodejonghs-projects.vercel.app`, which matches the regex
+// built below — and that is exactly the URL Instant Rollback verification hands
+// a human to browse. The env OVERRIDE is unused (grepped: nothing outside
+// cors.test.ts sets VERCEL_PREVIEW_ORIGIN_SUFFIX); the default suffix is not.
 const DEFAULT_VERCEL_PREVIEW_ORIGIN_SUFFIX = 'marcodejonghs-projects.vercel.app';
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/packages/crypto/src/env.ts
+++ b/packages/crypto/src/env.ts
@@ -6,9 +6,14 @@ export const ENV_VAR_NAME = 'AURORA_CREDENTIALS_SECRET';
 const DEFAULT_DEV_KEY = 'changeme-development-key';
 
 /**
- * Get the encryption secret, with optional development fallback
- * Supports both Vercel (VERCEL_ENV) and Node.js (NODE_ENV) environments
- * @throws Error if secret is not set and not in development mode
+ * Get the encryption secret, with a development fallback.
+ *
+ * Keyed on NODE_ENV alone — the host-agnostic signal. `VERCEL_ENV === 'development'`
+ * used to be OR'd in, but it is only ever set by the tracked
+ * `packages/web/.env.local`, where NODE_ENV already says `development`, so it
+ * added no case any host reaches (#4651).
+ *
+ * @throws Error if the secret is not set and this is not a dev/test run
  */
 export function getEncryptionSecret(): string {
   const secret = process.env[ENV_VAR_NAME];
@@ -17,12 +22,8 @@ export function getEncryptionSecret(): string {
     return secret;
   }
 
-  // Check if we're in development mode
-  const isVercelDev = process.env.VERCEL_ENV === 'development';
-  const isNodeDev = process.env.NODE_ENV === 'development';
-  const isDevelopment = isVercelDev || isNodeDev;
-
-  if (isDevelopment) {
+  const nodeEnv = process.env.NODE_ENV;
+  if (nodeEnv === 'development' || nodeEnv === 'test') {
     return DEFAULT_DEV_KEY;
   }
 

--- a/packages/crypto/src/env.ts
+++ b/packages/crypto/src/env.ts
@@ -13,7 +13,7 @@ const DEFAULT_DEV_KEY = 'changeme-development-key';
  * `packages/web/.env.local`, where NODE_ENV already says `development`, so it
  * added no case any host reaches (#4651).
  *
- * @throws Error if the secret is not set and this is not a dev/test run
+ * @throws Error if the secret is not set and this is not a dev run
  */
 export function getEncryptionSecret(): string {
   const secret = process.env[ENV_VAR_NAME];
@@ -22,8 +22,7 @@ export function getEncryptionSecret(): string {
     return secret;
   }
 
-  const nodeEnv = process.env.NODE_ENV;
-  if (nodeEnv === 'development' || nodeEnv === 'test') {
+  if (process.env.NODE_ENV === 'development') {
     return DEFAULT_DEV_KEY;
   }
 

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,16 +1,16 @@
 import { config } from 'dotenv';
 import { defineConfig } from 'drizzle-kit';
 import path from 'path';
+// One definition of "this host can only be a developer machine", shared with the
+// runtime Sentry gate rather than re-listed here. That module is deliberately
+// import-free, so pulling it in costs nothing.
+import { isPrivateHostname } from './src/client/config';
 
 // Load environment from root or web package
 config({ path: path.resolve(process.cwd(), '../../.boardsesh/dev-db.env') });
 config({ path: path.resolve(process.cwd(), '../../.env.local') });
 config({ path: path.resolve(process.cwd(), '../web/.env.local') });
 config({ path: path.resolve(process.cwd(), '../web/.env.development.local') });
-
-// Hostnames that can only be a developer machine or a compose service, so TLS
-// would be pointless there. Anything else is a real database and gets TLS.
-const LOCAL_POSTGRES_HOSTS = new Set(['', 'localhost', '127.0.0.1', '0.0.0.0', '::1', 'postgres', 'postgres-test']);
 
 // Support both DATABASE_URL (Neon) and individual POSTGRES_* variables (local Docker)
 const getDatabaseConfig = () => {
@@ -32,7 +32,7 @@ const getDatabaseConfig = () => {
     // silently ran without TLS (#4651). This branch only runs when DATABASE_URL
     // is unset (the early return above), i.e. the local POSTGRES_* path.
     ssl:
-      !LOCAL_POSTGRES_HOSTS.has((process.env.POSTGRES_HOST ?? '').trim().toLowerCase()) ||
+      !isPrivateHostname((process.env.POSTGRES_HOST ?? '').trim().toLowerCase()) ||
       process.env.IS_CI === 'true' ||
       // TODO(#4656): retire with the Vercel project.
       process.env.VERCEL_ENV === 'production',

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -8,6 +8,10 @@ config({ path: path.resolve(process.cwd(), '../../.env.local') });
 config({ path: path.resolve(process.cwd(), '../web/.env.local') });
 config({ path: path.resolve(process.cwd(), '../web/.env.development.local') });
 
+// Hostnames that can only be a developer machine or a compose service, so TLS
+// would be pointless there. Anything else is a real database and gets TLS.
+const LOCAL_POSTGRES_HOSTS = new Set(['', 'localhost', '127.0.0.1', '0.0.0.0', '::1', 'postgres', 'postgres-test']);
+
 // Support both DATABASE_URL (Neon) and individual POSTGRES_* variables (local Docker)
 const getDatabaseConfig = () => {
   if (process.env.DATABASE_URL) {
@@ -21,7 +25,17 @@ const getDatabaseConfig = () => {
     user: process.env.POSTGRES_USER!,
     password: process.env.POSTGRES_PASSWORD!,
     database: process.env.POSTGRES_DATABASE!,
-    ssl: process.env.VERCEL_ENV === 'production' || process.env.IS_CI === 'true',
+    // Strictly additive: every case that used to get TLS still does, plus any
+    // host that is demonstrably not a developer machine. VERCEL_ENV was the only
+    // "this is a real database" signal before, which meant drizzle-kit against a
+    // remote database from anywhere that is not Vercel — a laptop included —
+    // silently ran without TLS (#4651). This branch only runs when DATABASE_URL
+    // is unset (the early return above), i.e. the local POSTGRES_* path.
+    ssl:
+      !LOCAL_POSTGRES_HOSTS.has((process.env.POSTGRES_HOST ?? '').trim().toLowerCase()) ||
+      process.env.IS_CI === 'true' ||
+      // TODO(#4656): retire with the Vercel project.
+      process.env.VERCEL_ENV === 'production',
   };
 };
 

--- a/packages/db/scripts/db-connection.ts
+++ b/packages/db/scripts/db-connection.ts
@@ -22,6 +22,11 @@ export function getScriptDatabaseUrl(): string {
   const isLocalUrl =
     databaseUrl.includes('localhost') || databaseUrl.includes('localtest.me') || databaseUrl.includes('127.0.0.1');
 
+  // TODO(#4656): make this host-agnostic when the Vercel project goes away.
+  // Widening it to "any automated build" is NOT the fix — .github/workflows/ci.yml
+  // and db-migration-renumber.yml both run these scripts in GitHub Actions
+  // against a localhost service container on purpose, so a CI term here would
+  // exit(1) on every one of those jobs.
   if (process.env.VERCEL && isLocalUrl) {
     console.error('Refusing to run with local DATABASE_URL in Vercel build');
     process.exit(1);

--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -41,6 +41,8 @@ async function runMigrations() {
   const isLocalUrl =
     databaseUrl.includes('localhost') || databaseUrl.includes('localtest.me') || databaseUrl.includes('127.0.0.1');
 
+  // TODO(#4656): host-agnostic form — see db-connection.ts for why a CI term
+  // here would break the workflows that migrate a localhost service container.
   if (process.env.VERCEL && isLocalUrl) {
     console.error('❌ Refusing to run migrations with local DATABASE_URL in Vercel build');
     console.error('   Set DATABASE_URL in Vercel project environment variables');

--- a/packages/db/src/client/__tests__/sentry-environment.test.ts
+++ b/packages/db/src/client/__tests__/sentry-environment.test.ts
@@ -119,4 +119,23 @@ void describe('resolveSentryEnvironment', () => {
     assert.equal(isPrivateDatabaseTarget(), false);
     assert.equal(isProductionSentryEnvironment(), true);
   });
+
+  // packages/web's sentry.{server,edge}.config.ts moved off
+  // `VERCEL_ENV === 'production'` onto these helpers (#4651). The two cases below
+  // are the ones that swap could have got wrong.
+  void it('still reports from a Vercel production deployment', () => {
+    setEnv({ VERCEL_ENV: 'production', NODE_ENV: 'production', DATABASE_URL: PRODUCTION_DATABASE_URL });
+    assert.equal(resolveSentryEnvironment(), 'production');
+    assert.equal(isProductionSentryEnvironment(), true);
+  });
+
+  void it('fails OPEN in an edge runtime that never sees DATABASE_URL', () => {
+    // The edge sandbox may not carry DATABASE_URL, so isPrivateDatabaseTarget()
+    // has no signal there. That resolves to 'production' and reports, which is
+    // the safe direction — but it means edge Sentry can be enabled where server
+    // Sentry is not. Asserted so the asymmetry is deliberate, not a surprise.
+    setEnv({ NODE_ENV: 'production' });
+    assert.equal(isPrivateDatabaseTarget(), false);
+    assert.equal(isProductionSentryEnvironment(), true);
+  });
 });

--- a/packages/db/src/client/__tests__/sentry-environment.test.ts
+++ b/packages/db/src/client/__tests__/sentry-environment.test.ts
@@ -129,6 +129,18 @@ void describe('resolveSentryEnvironment', () => {
     assert.equal(isProductionSentryEnvironment(), true);
   });
 
+  void it('is silenced by a VERCEL_ENV=development leaking out of packages/web/.env.local', () => {
+    // The load-bearing half of the case above. The tracked packages/web/.env.local
+    // sets VERCEL_ENV=development, and its NEXTAUTH_URL demonstrably DOES leak
+    // into the Vercel production runtime. If VERCEL_ENV leaked the same way, the
+    // swap off `VERCEL_ENV === 'production'` onto isLocalDevelopment() would turn
+    // production Sentry off. It does not leak — Vercel sets VERCEL_ENV as a real
+    // system variable, which wins over any .env file — but this pins what would
+    // happen if that ever changed, so the failure is a red test and not silence.
+    setEnv({ VERCEL_ENV: 'development', NODE_ENV: 'production', DATABASE_URL: PRODUCTION_DATABASE_URL });
+    assert.equal(isProductionSentryEnvironment(), false);
+  });
+
   void it('fails OPEN in an edge runtime that never sees DATABASE_URL', () => {
     // The edge sandbox may not carry DATABASE_URL, so isPrivateDatabaseTarget()
     // has no signal there. That resolves to 'production' and reports, which is

--- a/packages/db/src/client/config.ts
+++ b/packages/db/src/client/config.ts
@@ -47,7 +47,7 @@ function getDatabaseHostname(): string | undefined {
  * the exact failure #3603 was filed for. A dev database reached by literal IPv6
  * address stays unrecognised instead, which fails the safe way: it reports.
  */
-function isPrivateHostname(hostname: string): boolean {
+export function isPrivateHostname(hostname: string): boolean {
   if (hostname === 'localhost' || hostname.endsWith('.localhost')) return true;
   if (hostname.endsWith('.local') || hostname.endsWith('.ts.net')) return true;
   // A single-label hostname — `db` (packages/backend/docker-compose.yml),

--- a/packages/web/app/api/og/setter/route.tsx
+++ b/packages/web/app/api/og/setter/route.tsx
@@ -61,7 +61,13 @@ export async function GET(request: NextRequest) {
     const gradeRows = gradeResult;
 
     const displayName = summary.displayName;
-    const origin = process.env.VERCEL_URL ? 'https://www.boardsesh.com' : 'http://localhost:3000';
+    // Absolute base for a relative avatar path. Host-agnostic: the request's own
+    // origin is correct on every deployment AND on localhost, and a configured
+    // https BASE_URL wins so the avatar fetch goes out through the CDN rather
+    // than looping back into this instance. Keying this on VERCEL_URL silently
+    // rewrote every avatar to localhost off Vercel (#4651).
+    const configuredOrigin = process.env.BASE_URL?.trim();
+    const origin = configuredOrigin?.startsWith('https://') ? configuredOrigin : new URL(request.url).origin;
     const rawAvatarUrl = summary.avatarUrl || null;
     const avatarUrl = rawAvatarUrl && !rawAvatarUrl.startsWith('http') ? `${origin}${rawAvatarUrl}` : rawAvatarUrl;
 

--- a/packages/web/app/lib/__tests__/warm-overlay-cache.test.ts
+++ b/packages/web/app/lib/__tests__/warm-overlay-cache.test.ts
@@ -198,13 +198,15 @@ describe('the origin warm fetches are aimed at', () => {
     expectOriginIs(warmedOverlayUrl(), 'https://www.boardsesh.com');
   });
 
-  it('does NOT aim at localhost just because VERCEL_URL is unset', async () => {
-    // The bug: `VERCEL_URL ? SITE_URL : 'http://localhost:3000'` sent every warm
-    // fetch on a non-Vercel host to a loopback port nothing is listening on —
-    // on the hot SSR path of every list and climb-view render (#4651).
-    stubOriginEnv({ NEXTAUTH_URL: 'https://www.boardsesh.com' });
+  it('ignores a loopback origin variable rather than warming localhost from a real host', async () => {
+    // The bug shape: `VERCEL_URL ? SITE_URL : 'http://localhost:3000'` sent every
+    // warm fetch on a non-Vercel host to a loopback port nothing is listening on,
+    // on the hot SSR path of every list and climb-view render (#4651). The
+    // tracked packages/web/.env.local supplies exactly this loopback BASE_URL, so
+    // an https NEXTAUTH_URL has to win over it.
+    stubOriginEnv({ BASE_URL: 'http://localhost:3000', NEXTAUTH_URL: 'https://www.boardsesh.com' });
     await warmOverlays({ boardDetails, climbs, variant: 'thumbnail' });
-    expect(warmedOverlayUrl()).not.toContain('localhost');
+    expectOriginIs(warmedOverlayUrl(), 'https://www.boardsesh.com');
   });
 
   it('still uses the site URL on Vercel, and localhost in local dev', async () => {

--- a/packages/web/app/lib/__tests__/warm-overlay-cache.test.ts
+++ b/packages/web/app/lib/__tests__/warm-overlay-cache.test.ts
@@ -159,3 +159,62 @@ describe('scheduleOverlayWarming', () => {
     expect(fetch).toHaveBeenCalled();
   });
 });
+
+describe('the origin warm fetches are aimed at', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ body: null }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  function warmedOverlayUrl(): string {
+    const overlayCall = vi.mocked(fetch).mock.calls.find(([url]) => String(url).includes('/api/internal/board-render'));
+    return String(overlayCall?.[0]);
+  }
+
+  function expectOriginIs(warmedUrl: string, expectedOrigin: string): void {
+    expect(new URL(warmedUrl).origin).toBe(expectedOrigin);
+  }
+
+  function stubOriginEnv(overrides: Partial<Record<'BASE_URL' | 'NEXTAUTH_URL' | 'VERCEL_URL', string>>) {
+    vi.stubEnv('BASE_URL', overrides.BASE_URL ?? '');
+    vi.stubEnv('NEXTAUTH_URL', overrides.NEXTAUTH_URL ?? '');
+    vi.stubEnv('VERCEL_URL', overrides.VERCEL_URL ?? '');
+  }
+
+  it('uses a configured https BASE_URL, on any host', async () => {
+    stubOriginEnv({ BASE_URL: 'https://www.boardsesh.com' });
+    await warmOverlays({ boardDetails, climbs, variant: 'thumbnail' });
+    expectOriginIs(warmedOverlayUrl(), 'https://www.boardsesh.com');
+  });
+
+  it('falls back to the canonical NEXTAUTH_URL when BASE_URL names nothing', async () => {
+    stubOriginEnv({ NEXTAUTH_URL: 'https://www.boardsesh.com' });
+    await warmOverlays({ boardDetails, climbs, variant: 'thumbnail' });
+    expectOriginIs(warmedOverlayUrl(), 'https://www.boardsesh.com');
+  });
+
+  it('does NOT aim at localhost just because VERCEL_URL is unset', async () => {
+    // The bug: `VERCEL_URL ? SITE_URL : 'http://localhost:3000'` sent every warm
+    // fetch on a non-Vercel host to a loopback port nothing is listening on —
+    // on the hot SSR path of every list and climb-view render (#4651).
+    stubOriginEnv({ NEXTAUTH_URL: 'https://www.boardsesh.com' });
+    await warmOverlays({ boardDetails, climbs, variant: 'thumbnail' });
+    expect(warmedOverlayUrl()).not.toContain('localhost');
+  });
+
+  it('still uses the site URL on Vercel, and localhost in local dev', async () => {
+    stubOriginEnv({ VERCEL_URL: 'boardsesh-abc.vercel.app' });
+    await warmOverlays({ boardDetails, climbs, variant: 'thumbnail' });
+    expectOriginIs(warmedOverlayUrl(), 'https://www.boardsesh.com');
+
+    vi.mocked(fetch).mockClear();
+    stubOriginEnv({ NEXTAUTH_URL: 'http://localhost:3000' });
+    await warmOverlays({ boardDetails, climbs, variant: 'thumbnail' });
+    expectOriginIs(warmedOverlayUrl(), 'http://localhost:3000');
+  });
+});

--- a/packages/web/app/lib/api-docs/generate-openapi.ts
+++ b/packages/web/app/lib/api-docs/generate-openapi.ts
@@ -87,9 +87,13 @@ Layout, size, and set IDs can be either numeric IDs or human-readable slugs.
     },
     servers: [
       {
-        url: process.env.VERCEL_URL
-          ? `https://${process.env.VERCEL_URL}`
-          : process.env.NEXTAUTH_URL || 'http://localhost:3000',
+        // The deployment's canonical origin first — VERCEL_URL is the
+        // per-deployment hostname, which is neither stable nor present off
+        // Vercel (#4651). TODO(#4656): drop the VERCEL_URL term with the project.
+        url:
+          process.env.BASE_URL?.trim() ||
+          process.env.NEXTAUTH_URL?.trim() ||
+          (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000'),
         description: 'Current server',
       },
     ],

--- a/packages/web/app/lib/api-docs/generate-openapi.ts
+++ b/packages/web/app/lib/api-docs/generate-openapi.ts
@@ -16,6 +16,12 @@ import { registry } from './openapi-registry';
 // Import routes to register them with the registry
 import './openapi-routes';
 
+/** The value when it names an https origin, otherwise undefined. */
+function httpsOrigin(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed?.startsWith('https://') ? trimmed : undefined;
+}
+
 // Register security scheme
 registry.registerComponent('securitySchemes', 'session', {
   type: 'apiKey',
@@ -89,10 +95,15 @@ Layout, size, and set IDs can be either numeric IDs or human-readable slugs.
       {
         // The deployment's canonical origin first — VERCEL_URL is the
         // per-deployment hostname, which is neither stable nor present off
-        // Vercel (#4651). TODO(#4656): drop the VERCEL_URL term with the project.
+        // Vercel (#4651). The https gate matters: this file runs under
+        // `bun run generate:openapi` at BUILD time, which loads the tracked
+        // packages/web/.env.local, and that file supplies a loopback BASE_URL and
+        // NEXTAUTH_URL. Without the gate a production build would bake
+        // `http://localhost:3000` into the public /docs schema.
+        // TODO(#4656): drop the VERCEL_URL term with the project.
         url:
-          process.env.BASE_URL?.trim() ||
-          process.env.NEXTAUTH_URL?.trim() ||
+          httpsOrigin(process.env.BASE_URL) ??
+          httpsOrigin(process.env.NEXTAUTH_URL) ??
           (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000'),
         description: 'Current server',
       },

--- a/packages/web/app/lib/warm-overlay-cache.ts
+++ b/packages/web/app/lib/warm-overlay-cache.ts
@@ -4,7 +4,26 @@ import { isCrawlerUserAgent } from '@/app/lib/is-crawler';
 import { SITE_URL } from '@/app/lib/seo/base-url';
 import type { BoardDetails, Climb } from '@/app/lib/types';
 
-const BASE_URL = process.env.VERCEL_URL ? SITE_URL : 'http://localhost:3000';
+// Absolute base for the same-origin warm fetches below. Read per call rather
+// than pinned at module scope: this used to be `VERCEL_URL ? SITE_URL :
+// 'http://localhost:3000'`, which points every warm fetch at localhost on any
+// host that isn't Vercel — on a hot SSR path, so the whole warm silently becomes
+// a fan-out of connection refusals (#4651).
+//
+// A configured https BASE_URL wins (that is the deployment's canonical origin);
+// otherwise the loopback default, which is what local dev wants and is the only
+// thing a warm can reach when nothing names an origin.
+function warmOrigin(): string {
+  const configuredOrigin = process.env.BASE_URL?.trim();
+  if (configuredOrigin?.startsWith('https://')) return configuredOrigin;
+  const nextAuthOrigin = process.env.NEXTAUTH_URL?.trim();
+  if (nextAuthOrigin?.startsWith('https://')) return nextAuthOrigin;
+  // TODO(#4656): retire with the Vercel project. Unreachable in the nodejs
+  // runtime today — instrumentation.ts patches NEXTAUTH_URL to the canonical
+  // origin before any request is served — but kept so this stays a strict
+  // superset of the behaviour it replaces.
+  return process.env.VERCEL_URL ? SITE_URL : 'http://localhost:3000';
+}
 
 /**
  * How many list rows the `/list` front door warms per SSR render.
@@ -98,9 +117,10 @@ export async function warmOverlays(options: WarmOverlaysOptions): Promise<void> 
     const isThumbnail = variant === 'thumbnail';
     const toWarm = climbs.slice(0, maxImages);
 
+    const origin = warmOrigin();
     const warmTargets: string[] = [];
     for (const climb of toWarm) {
-      warmTargets.push(`${BASE_URL}${buildOverlayUrl(boardDetails, climb.frames, isThumbnail)}`);
+      warmTargets.push(`${origin}${buildOverlayUrl(boardDetails, climb.frames, isThumbnail)}`);
 
       // Only the full climb-view pages warm the og card. A thumbnail list would
       // fan out one backend og render per row for images no crawler fetches.

--- a/packages/web/sentry.edge.config.ts
+++ b/packages/web/sentry.edge.config.ts
@@ -4,19 +4,21 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
-
-// Only enable Sentry on production deployments to avoid polluting error tracking
-const isProductionDomain = process.env.VERCEL_ENV === 'production';
+import { isProductionSentryEnvironment, resolveSentryEnvironment } from '@boardsesh/db/client/config';
 
 Sentry.init({
   dsn: 'https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400',
 
-  // Only send errors when running on boardsesh.com
-  enabled: isProductionDomain,
+  // Report only from a real production deployment. This used to be
+  // `VERCEL_ENV === 'production'`, which is unset on Railway and on every other
+  // host — the swap would have taken web Sentry dark at exactly the moment the
+  // telemetry mattered most (#4651). resolveSentryEnvironment() is the same
+  // helper the backend's instrument.ts uses, and it already covers a Railway
+  // deployment (NODE_ENV and SENTRY_ENVIRONMENT both unset, non-private
+  // DATABASE_URL) as well as branch deploys (SENTRY_ENVIRONMENT=preview).
+  enabled: isProductionSentryEnvironment(),
 
-  // Only initializes on VERCEL_ENV === 'production' (see the gate above), so tag
-  // events accordingly for the environment:production filter.
-  environment: 'production',
+  environment: resolveSentryEnvironment(),
 
   // Enable logs to be sent to Sentry
   enableLogs: true,

--- a/packages/web/sentry.server.config.ts
+++ b/packages/web/sentry.server.config.ts
@@ -3,19 +3,21 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
-
-// Only enable Sentry on production deployments to avoid polluting error tracking
-const isProductionDomain = process.env.VERCEL_ENV === 'production';
+import { isProductionSentryEnvironment, resolveSentryEnvironment } from '@boardsesh/db/client/config';
 
 Sentry.init({
   dsn: 'https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400',
 
-  // Only send errors when running on boardsesh.com
-  enabled: isProductionDomain,
+  // Report only from a real production deployment. This used to be
+  // `VERCEL_ENV === 'production'`, which is unset on Railway and on every other
+  // host — the swap would have taken web Sentry dark at exactly the moment the
+  // telemetry mattered most (#4651). resolveSentryEnvironment() is the same
+  // helper the backend's instrument.ts uses, and it already covers a Railway
+  // deployment (NODE_ENV and SENTRY_ENVIRONMENT both unset, non-private
+  // DATABASE_URL) as well as branch deploys (SENTRY_ENVIRONMENT=preview).
+  enabled: isProductionSentryEnvironment(),
 
-  // Only initializes on VERCEL_ENV === 'production' (see the gate above), so tag
-  // events accordingly for the environment:production filter.
-  environment: 'production',
+  environment: resolveSentryEnvironment(),
 
   // Enable logs to be sent to Sentry
   enableLogs: true,


### PR DESCRIPTION
## Summary

The cosmetic half of #4651. Part of #4648 (Phase 1). The auth-critical half is
#4790 — deliberately a separate revert lever, so rolling back a one-line origin
tweak cannot also turn production Sentry back off.

Nothing in this PR can move a session cookie.

### The one that isn't cosmetic

`sentry.server.config.ts` and `sentry.edge.config.ts` gated `enabled` on
`process.env.VERCEL_ENV === 'production'`. (To be precise: `Sentry.init` is called
unconditionally — only `enabled` and `environment` were gated. Don't go looking
for an `if`.) `VERCEL_ENV` is unset on Railway, so web Sentry would have gone
silent at exactly the moment the cutover most needed it.

Both now use `isProductionSentryEnvironment()` / `resolveSentryEnvironment()` from
`@boardsesh/db/client/config` — the same helpers `packages/backend/src/instrument.ts`
already uses, which is also where the #3603 "Railway leaves NODE_ENV unset"
handling lives. Behaviour by environment, all asserted in
`packages/db/src/client/__tests__/sentry-environment.test.ts`:

| Environment | Before | After |
| --- | --- | --- |
| Vercel production | enabled, `production` | enabled, `production` |
| Railway production | **disabled** | enabled, `production` |
| branch deploy (`SENTRY_ENVIRONMENT=preview`) | disabled | disabled, `preview` |
| local dev / vitest / GitHub Actions | disabled | disabled |

One asymmetry worth knowing about, now pinned by a test: the edge sandbox may not
carry `DATABASE_URL`, so `isPrivateDatabaseTarget()` has no signal there and edge
Sentry can resolve `production` where the server would not. That fails open
(reports), which is the safe direction.

### The one the issue misses

`packages/web/app/lib/warm-overlay-cache.ts:7` was
`process.env.VERCEL_URL ? SITE_URL : 'http://localhost:3000'` — the same shape as
the `og/setter` line the issue *does* list, but on a hot path: it is imported by
both climb-view page components, so on any non-Vercel host every SSR render would
have fanned out warm fetches to a loopback port nothing is listening on. Now
resolved from the deployment's canonical origin, with the `VERCEL_URL` term kept
as a `TODO(#4656)` fallback so this is a strict superset of what it replaced.

### The rest

- **`app/api/og/setter/route.tsx`** — the same `VERCEL_URL` ternary rewrote every
  relative avatar URL to `http://localhost:3000` off Vercel. Now a configured
  https `BASE_URL`, else the request's own origin, which is byte-identical in both
  current environments (`https://www.boardsesh.com` on Vercel prod,
  `http://localhost:3000` locally).
- **`packages/db/drizzle.config.ts`** — TLS was gated on `VERCEL_ENV === 'production'`,
  so drizzle-kit pointed at a remote database from a laptop silently ran without
  it. Now also true for any non-local `POSTGRES_HOST`; strictly additive, both old
  terms kept, so `ssl` can only go false→true. "Non-local" reuses
  `isPrivateHostname()` from `packages/db/src/client/config.ts` rather than a
  second, shorter list that would have disagreed with it (the `db` compose
  service, `host.docker.internal`, Tailscale). Worth knowing: this branch is
  unreachable whenever `DATABASE_URL` is set (`:13-17` returns first), so today it
  only ever runs on the local `POSTGRES_*` path.
- **`packages/crypto/src/env.ts`** — dropped `VERCEL_ENV === 'development'`. It was
  OR'd with `NODE_ENV === 'development'` and only ever set by the tracked
  `packages/web/.env.local`, which sets both, so it added no case any host reaches.
  Verified there is no script or workflow that runs with `VERCEL_ENV=development`
  and *without* `NODE_ENV=development` and calls `getEncryptionSecret()`: the
  backend loads its own env and never web's `.env.local`, and `packages/web` has
  zero source imports of `@boardsesh/crypto`.
- **`app/lib/api-docs/generate-openapi.ts`** — the OpenAPI `servers[0].url` came
  from `VERCEL_URL`, the per-deployment hostname. Canonical origin first now,
  gated on `https://` like its siblings: this file runs at build time under a
  process that loads the tracked `packages/web/.env.local`, so an ungated read
  would have baked `http://localhost:3000` into the public `/docs` schema.

## Verify before deleting — what stays, and why

The issue asks for three deletions. All three are refused, annotated
`TODO(#4656)` in place:

- **`packages/backend/src/handlers/cors.ts`'s `*.vercel.app` allowlist.** Called
  dead code by the issue. It isn't. The production deployment's own URL has the
  shape `boardsesh-<hash>-marcodejonghs-projects.vercel.app`, which matches the
  regex — and that is exactly the URL Instant Rollback verification produces for a
  human to browse. Only the env *override* (`VERCEL_PREVIEW_ORIGIN_SUFFIX`) is
  genuinely unused; nothing outside `cors.test.ts` sets it.
- **`.github/workflows/branch-deploy.yml`'s `-e VERCEL_ENV=preview`.** Traced
  inert — the container's https `NEXTAUTH_URL` short-circuits every consumer ahead
  of it — but branch-deploy is `workflow_dispatch`-only, so no PR can produce the
  live proof. Not removed on a desk-check.
- **`packages/db/scripts/{db-connection,migrate}.ts`'s `process.env.VERCEL` guard.**
  I tried widening this to "any automated build" and caught myself: `ci.yml:929`
  and `db-migration-renumber.yml:145` both run `db:migrate` inside GitHub Actions
  against `postgresql://…@localhost:5432/main` on purpose. A CI term here would
  `exit(1)` on every one of those jobs. The narrow `VERCEL` check stays until
  there is a real "this is a deployment" signal to key on.

## Test plan

- `vp run typecheck` — green
- `vp check` — 0 errors
- `vp test run --project web` — 370 files, 4268 tests, green
- `vp test run --project crypto` — 23 tests, green
- `vp test run --project backend packages/backend/src/__tests__/cors.test.ts` — 57 tests, green
- `vp run test:db` — 490 pass / 3 fail; the 3 are pre-existing MoonBoard
  climb-filter reds on `main`, untouched by this diff
- New coverage: four cases pinning which origin the warm fetches are aimed at
  (configured `BASE_URL`, canonical `NEXTAUTH_URL`, "not localhost just because
  `VERCEL_URL` is unset", and the unchanged Vercel/local behaviour), plus the two
  Sentry cases above.

## Release Notes

- [x] No release note needed (internal / technical change)
