### PR TITLE
fix(ci): document the Pages scope the shared Cloudflare token needs

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -685,6 +685,11 @@ jobs:
           # publish with `--cwd "$RUNNER_TEMP"` so wrangler finds it there.
           cp -R deploy/app-subdomain/functions "$RUNNER_TEMP/functions"
 
+      # Needs Account.Cloudflare Pages Edit on the shared Production-environment
+      # token. It is the same secret deploy-cloudflare uses for the zone, so a
+      # rotation that grants only the zone scopes lands here as
+      # `Authentication error [code: 10000]` while `wrangler whoami` still works.
+      # See the token section of docs/cloudflare.md.
       - name: Publish to Cloudflare Pages
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -256,6 +256,10 @@ openssl s_client -connect cname.vercel-dns.com:443 \
   openssl x509 -noout -subject -issuer -dates
 ```
 
+`updates.boardsesh.com` is Railway too, so it takes the first form with its own
+`-servername`. `app.boardsesh.com` is Pages — the origin is Cloudflare itself, so
+there is nothing to check.
+
 Measured 2026-08-25: `www` (Vercel), `ws` and `updates` (Railway) are the only
 proxied origins and each serves a Let's Encrypt cert for its exact hostname, so
 `strict` is safe. The apex and `ota.boardsesh.com` are DNS-only and unaffected;

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -118,8 +118,18 @@ needs an edge rate-limit rule, which is not managed here yet.
 
 ### One-time: create the API token
 
-Create ONE token covering both today's zone tooling and the upcoming OpenNext
-deploy, so this setup never has to be repeated:
+Create ONE token covering today's zone tooling, the Pages deploy of
+`app.boardsesh.com`, and the upcoming OpenNext deploy, so this setup never has to
+be repeated.
+
+> **One token, three consumers.** `CLOUDFLARE_API_TOKEN` in the GitHub Production
+> environment is read by `deploy-cloudflare` (zone config), `deploy-app-web`
+> (`wrangler pages deploy`), and later the OpenNext web deploy. **Rotating or
+> re-scoping it for one of them silently breaks the others** — a token carrying
+> only the zone scopes below authenticates fine against the zone and returns
+> `Authentication error [code: 10000]` on `/pages/projects/boardsesh-app`. That
+> exact regression took `app.boardsesh.com` off the deploy train on 2026-08-25.
+> Grant every section below, not just the one you came here for.
 
 **Needed now (zone tooling, `vp run cf:apply`):**
 
@@ -134,6 +144,14 @@ Create a token at <https://dash.cloudflare.com/profile/api-tokens> scoped to the
   so a partially-converged zone is the failure mode, not a silent skip.
 - **Zone.Zone Settings Read** — read the SSL/TLS mode
 - **Zone.Zone Settings Edit** — only if you'll run `--allow-zone-ssl`
+
+**Needed now (Pages deploy of app.boardsesh.com, `deploy-app-web`):**
+
+- **Account.Cloudflare Pages Edit** — `wrangler pages deploy` against the
+  `boardsesh-app` project. Account-scoped, so the token cannot be zone-only.
+  Without it the publish step fails with `Authentication error [code: 10000]`
+  while `wrangler whoami` still succeeds — it reads as a bad token, but it is a
+  missing scope.
 
 **Add now for the OpenNext migration (wrangler deploy of packages/web):**
 
@@ -208,8 +226,34 @@ get_runtime_logs since=6h group_by=route source=["serverless"] environment=produ
 that touch `infra/cloudflare/` or the apply script (and on manual dispatch),
 reading `CLOUDFLARE_API_TOKEN` from the GitHub **Production** environment
 secrets: `gh secret set CLOUDFLARE_API_TOKEN --env Production`. A failing job
-means unapplied drift (often a blocked zone-SSL change) — run the dry-run
-locally to see the plan.
+means unapplied drift — run the dry-run locally to see the plan.
+
+A **blocked** zone-SSL change is the one failure a merge cannot clear: pushes
+deliberately resolve `--allow-zone-ssl` to empty, so `cf:apply` re-plans the same
+change, skips it, and exits non-zero on every subsequent push. Clear it once, by
+hand — either `Actions → Production Deploy → Run workflow` with
+**cloudflare_allow_zone_ssl** ticked, or by setting the mode in the dashboard.
+Before flipping the zone, check that every **proxied** hostname's origin serves a
+publicly-trusted cert for its exact name, since the mode is zone-wide:
+
+```bash
+# Proxied hosts resolve to Cloudflare IPs (104.21.x / 172.67.x); DNS-only hosts
+# resolve straight to the origin and the zone SSL mode does not govern them.
+for H in www ws updates app; do
+  echo "$H: $(getent ahostsv4 "$H.boardsesh.com" | awk '{print $1}' | sort -u | tr '\n' ' ')"
+done
+
+# For each proxied host, ask its origin for the cert it would show Cloudflare.
+openssl s_client -connect backend-production.up.railway.app:443 \
+  -servername ws.boardsesh.com </dev/null 2>/dev/null |
+  openssl x509 -noout -subject -issuer -dates
+```
+
+Measured 2026-08-25: `www` (Vercel), `ws` and `updates` (Railway) are the only
+proxied origins and each serves a Let's Encrypt cert for its exact hostname, so
+`strict` is safe. The apex and `ota.boardsesh.com` are DNS-only and unaffected;
+`*.preview.boardsesh.com` rides a Cloudflare Tunnel, which does not use the
+zone's origin-encryption mode.
 
 ### Rollback
 

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -240,12 +240,19 @@ publicly-trusted cert for its exact name, since the mode is zone-wide:
 # Proxied hosts resolve to Cloudflare IPs (104.21.x / 172.67.x); DNS-only hosts
 # resolve straight to the origin and the zone SSL mode does not govern them.
 for H in www ws updates app; do
-  echo "$H: $(getent ahostsv4 "$H.boardsesh.com" | awk '{print $1}' | sort -u | tr '\n' ' ')"
+  echo "$H: $(dig +short "$H.boardsesh.com" A | tr '\n' ' ')"
 done
 
 # For each proxied host, ask its origin for the cert it would show Cloudflare.
+# Railway's edge selects the cert by SNI, so any Railway hostname reaches the
+# right one — the app name below is not load-bearing, `-servername` is.
 openssl s_client -connect backend-production.up.railway.app:443 \
   -servername ws.boardsesh.com </dev/null 2>/dev/null |
+  openssl x509 -noout -subject -issuer -dates
+
+# Vercel-backed hosts answer on their CNAME target the same way.
+openssl s_client -connect cname.vercel-dns.com:443 \
+  -servername www.boardsesh.com </dev/null 2>/dev/null |
   openssl x509 -noout -subject -issuer -dates
 ```
 

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -153,6 +153,13 @@ Create a token at <https://dash.cloudflare.com/profile/api-tokens> scoped to the
   while `wrangler whoami` still succeeds — it reads as a bad token, but it is a
   missing scope.
 
+  In the token editor this is the **left-hand dropdown set to Account**, not
+  Zone, plus the account named under **Account Resources**. Ticking every
+  permission the zone offers cannot supply it — that is exactly how the token
+  ended up without it in 2026-08. Quickest check on an existing token: open its
+  summary, and if every row sits under `boardsesh.com` with no Account resource
+  section, Pages is missing no matter how long the list is.
+
 **Add now for the OpenNext migration (wrangler deploy of packages/web):**
 
 - **Account.Workers Scripts Edit** — deploy the Worker

--- a/scripts/cloudflare-apply.ts
+++ b/scripts/cloudflare-apply.ts
@@ -49,8 +49,14 @@ const TOKEN_SCOPES = [
   'Zone.Zone Read           — resolve the zone id by name + read zone list',
   'Zone.DNS Edit            — patch the ws.boardsesh.com record proxied flag',
   'Zone.Cache Rules Edit    — create/update the /og/ cache rule',
+  'Zone.WAF Edit            — create/update the two crawler rules',
   'Zone.Zone Settings Read  — read the SSL/TLS mode',
   'Zone.Zone Settings Edit  — ONLY needed with --allow-zone-ssl (to set the zone SSL mode)',
+  '',
+  'The SAME Production-environment CLOUDFLARE_API_TOKEN also publishes app.boardsesh.com',
+  'from the deploy-app-web job, so a token built from the zone list above ALONE will',
+  'authenticate here and 10000 there. Keep this scope on it too:',
+  'Account.Cloudflare Pages Edit — wrangler pages deploy (deploy-app-web); unused by this tool',
 ];
 
 export interface CliOptions {

--- a/scripts/cloudflare-apply.ts
+++ b/scripts/cloudflare-apply.ts
@@ -52,12 +52,15 @@ const TOKEN_SCOPES = [
   'Zone.WAF Edit            — create/update the two crawler rules',
   'Zone.Zone Settings Read  — read the SSL/TLS mode',
   'Zone.Zone Settings Edit  — ONLY needed with --allow-zone-ssl (to set the zone SSL mode)',
-  '',
-  'The SAME Production-environment CLOUDFLARE_API_TOKEN also publishes app.boardsesh.com',
-  'from the deploy-app-web job, so a token built from the zone list above ALONE will',
-  'authenticate here and 10000 there. Keep this scope on it too:',
-  'Account.Cloudflare Pages Edit — wrangler pages deploy (deploy-app-web); unused by this tool',
 ];
+
+// Scopes another consumer of the SAME Production-environment CLOUDFLARE_API_TOKEN
+// needs. Printed alongside the list above because a token built from that list
+// ALONE authenticates here and fails with `Authentication error [code: 10000]`
+// there — which reads as a bad credential, not a missing scope, since
+// `wrangler whoami` still succeeds. That regression took app.boardsesh.com off
+// the deploy train on 2026-08-25. See the token section of docs/cloudflare.md.
+const SHARED_TOKEN_SCOPES = ['Account.Cloudflare Pages Edit — wrangler pages deploy (deploy-app-web)'];
 
 export interface CliOptions {
   apply: boolean;
@@ -238,6 +241,8 @@ function printPlan(changes: PlannedChange[]): void {
 function printTokenScopes(): void {
   console.error('[cf-apply] CLOUDFLARE_API_TOKEN is required. Create a token with these scopes on the zone:');
   for (const scope of TOKEN_SCOPES) console.error(`             ${scope}`);
+  console.error('           The same token is shared with other jobs. Keep their scopes on it too:');
+  for (const scope of SHARED_TOKEN_SCOPES) console.error(`             ${scope}`);
   console.error('           https://dash.cloudflare.com/profile/api-tokens');
 }
 
@@ -340,7 +345,7 @@ async function main(): Promise<number> {
 }
 
 // Exported for docs/tests: the module can be imported without running the CLI.
-export { CF_API_BASE, TOKEN_SCOPES, ZONE_NAME };
+export { CF_API_BASE, SHARED_TOKEN_SCOPES, TOKEN_SCOPES, ZONE_NAME };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main()


### PR DESCRIPTION
## Summary

Main had failed seven deploys in a row. Two independent causes, neither of which a merge could clear.

**1. `deploy-app-web` — `Authentication error [code: 10000]` on the Pages publish.**

`CLOUDFLARE_API_TOKEN` in the Production environment has three consumers: `deploy-cloudflare` (zone config), `deploy-app-web` (`wrangler pages deploy`), and later the OpenNext web deploy. The token section of `docs/cloudflare.md` listed only the zone scopes, so when the token was re-scoped on 2026-08-25 for the new zone tooling it lost **Account.Cloudflare Pages Edit**. The timeline shows it cleanly: at 13:42 `cf:apply` reported `Zone "boardsesh.com" not found among 0 zone(s) visible to this token` while the Pages publish still succeeded; by 13:59 `cf:apply` could read the zone and created four rules, and the Pages publish has failed on every run since.

It reads as a bad credential rather than a missing scope, because `wrangler whoami` still succeeds and prints the account. This PR documents the Pages scope alongside the zone ones, warns at the top of the token section that re-scoping for one consumer breaks the others, and repeats the symptom in the two places someone debugging would actually look: the workflow step and the `TOKEN_SCOPES` list the script prints when the token is missing.

**2. `deploy-cloudflare` — a blocked zone-SSL change that re-failed on every push.**

The zone was on SSL mode `full`; `infra/cloudflare/config.ts` requires `strict`. Pushes deliberately resolve `--allow-zone-ssl` to empty, so `cf:apply` re-planned the same change, skipped it, and exited non-zero — forever. Cleared out of band via the `cloudflare_allow_zone_ssl` dispatch added in #4774 ([run 32922167237](https://github.com/boardsesh/boardsesh/actions/runs/32922167237)): `[cf-apply] applied: Zone SSL mode "full" is weaker than required "strict"` → `Done — zone converged to desired state`. No code change was needed for it, but the runbook did not describe the trap, so this PR writes it down along with how to check the proxied origins before flipping a zone-wide setting.

While in `TOKEN_SCOPES` I also added **Zone.WAF Edit**, which was genuinely missing from it. `docs/cloudflare.md` has listed that scope since #3837 — the two crawler rules need it — but the printout the script emits when the token is absent did not, so anyone building a token from that printout alone would drop it and half-converge the zone. Same class of bug as the Pages one, one layer down.

Only the docs, one comment block, and the `TOKEN_SCOPES` printout change here. No behaviour change.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` — my three files are clean. Two pre-existing `no-floating-promises` errors remain in `packages/db/scripts/dedupe-gym-locations-args.test.ts` (last touched by #3699), untouched by this PR.
- `vp test run scripts/cloudflare-apply.test.ts` — 37 passed.
- `vp test run scripts/mobile-ci-env-parity.test.ts` — 34 passed (production-deploy.yml edit is a step-level comment, so workflow-level `env:` extraction is unaffected).

Verified against production after the SSL flip, since the mode is zone-wide:

| host | proxied | result |
| --- | --- | --- |
| `www.boardsesh.com` | yes (Vercel origin) | 200 |
| `ws.boardsesh.com` | yes (Railway origin) | `POST /graphql` 200 |
| `updates.boardsesh.com` | yes (Railway origin) | `/manifest` 400 — reaches origin, missing headers |
| `app.boardsesh.com` | yes (Pages) | 200 |
| `boardsesh.com` | no — DNS-only to Vercel | 308, unaffected by the mode |

No 526s. Each proxied origin was checked beforehand with `openssl s_client -servername <host>` and serves a Let's Encrypt cert for its exact hostname (expiring Oct–Nov 2026).

## Still needed (not fixable in this repo)

`deploy-app-web` stays red until **Account → Cloudflare Pages → Edit** is added back to the token at <https://dash.cloudflare.com/profile/api-tokens>. Editing the existing token is enough — no `gh secret set` needed, since the value does not change. `app.boardsesh.com` is serving its 2026-08-25 13:40 build until then; it is stale, not down.

Two unrelated things surfaced while tracing the zone and are left alone here:

- `ota.boardsesh.com` (the frozen V2 OTA server) is DNS-only to `69.46.46.21` and presents a `CN=*.up.railway.app` cert, so it fails TLS for its own hostname — any fleet still pointed at it cannot fetch updates at all. Zone SSL mode does not govern it.
- `detect-changes` baselines against the last **successful** run, so a persistently red pipeline keeps re-marking every target as changed. Self-correcting once main is green, but it does mean a single stuck job re-deploys everything on each push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1KXk18eSA4gtKU5BoPMfo

