### PR TITLE
test(ci): pin the token scopes cf:apply prints

### DIFF
--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -24,7 +24,7 @@ import {
   upsertCacheRule,
 } from '../infra/cloudflare/plan';
 import type { LiveDnsRecord, LiveState, RulesetRule } from '../infra/cloudflare/plan';
-import { parseArgs } from './cloudflare-apply';
+import { SHARED_TOKEN_SCOPES, TOKEN_SCOPES, parseArgs } from './cloudflare-apply';
 
 const desired = desiredCloudflareState;
 /** The og cache rule — the one the pre-existing cases in this file were written against. */
@@ -480,5 +480,37 @@ describe('deploy-cloudflare workflow wiring', () => {
   it('parses the exact argv the workflow produces, both with and without the flag', () => {
     expect(parseArgs(['--apply'])).toEqual({ apply: true, allowZoneSsl: false, help: false });
     expect(parseArgs(['--apply', '--allow-zone-ssl'])).toEqual({ apply: true, allowZoneSsl: true, help: false });
+  });
+});
+
+describe('token scope guidance', () => {
+  // printTokenScopes() is the only place a maintainer sees these lists, so they
+  // have to keep pace with the API calls the tool actually makes — and with the
+  // OTHER jobs reading the same Production-environment CLOUDFLARE_API_TOKEN.
+  it('names every zone permission the tool calls', () => {
+    const printed = TOKEN_SCOPES.join('\n');
+    // Zone.WAF Edit went missing from this list once while the crawler rules
+    // depended on it, so a partially-converged zone was the failure mode.
+    expect(printed).toContain('Zone.WAF Edit');
+    expect(printed).toContain('Zone.Cache Rules Edit');
+    expect(printed).toContain('Zone.DNS Edit');
+    expect(printed).toContain('Zone.Zone Settings Edit');
+  });
+
+  it('keeps the Pages scope deploy-app-web needs from the shared token', () => {
+    // A token built from TOKEN_SCOPES alone converges this zone perfectly and
+    // then fails `wrangler pages deploy` with Authentication error [code: 10000]
+    // — which is what took app.boardsesh.com off the deploy train on 2026-08-25.
+    expect(SHARED_TOKEN_SCOPES.join('\n')).toContain('Cloudflare Pages Edit');
+  });
+
+  it('holds scopes, not prose, so the printed columns stay aligned', () => {
+    // Guards the shape rather than the wording: an explanation parked in either
+    // array prints as a ragged line against the indent, and a blank spacer entry
+    // prints as trailing whitespace. Reasons belong in comments above the list.
+    for (const scope of [...TOKEN_SCOPES, ...SHARED_TOKEN_SCOPES]) {
+      expect(scope).toMatch(/^(Zone|Account)\.\S/);
+      expect(scope).toContain('—');
+    }
   });
 });

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -488,13 +488,18 @@ describe('token scope guidance', () => {
   // have to keep pace with the API calls the tool actually makes — and with the
   // OTHER jobs reading the same Production-environment CLOUDFLARE_API_TOKEN.
   it('names every zone permission the tool calls', () => {
-    const printed = TOKEN_SCOPES.join('\n');
+    // One entry per request the tool makes, reads included — a token missing a
+    // read scope fails just as hard as one missing a write, and listing all six
+    // keeps the set obviously complete instead of an unexplained subset.
     // Zone.WAF Edit went missing from this list once while the crawler rules
     // depended on it, so a partially-converged zone was the failure mode.
-    expect(printed).toContain('Zone.WAF Edit');
-    expect(printed).toContain('Zone.Cache Rules Edit');
-    expect(printed).toContain('Zone.DNS Edit');
-    expect(printed).toContain('Zone.Zone Settings Edit');
+    const printed = TOKEN_SCOPES.join('\n');
+    expect(printed).toContain('Zone.Zone Read'); // GET /zones?name= (resolve the zone id)
+    expect(printed).toContain('Zone.DNS Edit'); // PATCH the ws record's proxied flag
+    expect(printed).toContain('Zone.Cache Rules Edit'); // PUT the cache-settings phase
+    expect(printed).toContain('Zone.WAF Edit'); // PUT the firewall-custom phase
+    expect(printed).toContain('Zone.Zone Settings Read'); // GET /settings/ssl
+    expect(printed).toContain('Zone.Zone Settings Edit'); // PATCH /settings/ssl
   });
 
   it('keeps the Pages scope deploy-app-web needs from the shared token', () => {


### PR DESCRIPTION
## Summary

Follow-up to #4804, which merged before I finished the last review note on it.

`SHARED_TOKEN_SCOPES` is newly exported and printed at the exact moment a maintainer is building a Cloudflare token, and nothing stopped the Pages scope from disappearing again the way it did on 2026-08-25. Three cases close that:

- **Zone permissions the tool actually calls.** `Zone.WAF Edit` went missing from this list once already while the two crawler rules depended on it, so a half-converged zone was the failure mode rather than a clean error.
- **The Pages scope the shared token needs for `deploy-app-web`.** A token built from `TOKEN_SCOPES` alone converges the zone perfectly and then fails `wrangler pages deploy` with `Authentication error [code: 10000]`.
- **Shape, not wording.** Every entry has to read as a permission (`Zone.…` / `Account.…` with an em-dash separator). That fails both a blank spacer — which prints as a trailing-whitespace line — and an explanation parked in the array, which prints ragged against the 13-space indent instead of lining up with the other entries. Reasons belong in comments above the list, which is where #4804 put them after review.

Deliberately no assertion on the descriptive text after the em-dash, so rewording a scope's explanation doesn't fail the suite.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run scripts/cloudflare-apply.test.ts` — 40 passed (37 before).
- Verified the third case actually bites: it rejects both shapes #4804's review flagged — a `''` entry and a prose line such as `The SAME Production-environment CLOUDFLARE_API_TOKEN also publishes…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1KXk18eSA4gtKU5BoPMfo
