### PR TITLE
feat(backend): publish the board catalogue as a nightly snapshot artifact

### DIFF
--- a/.github/workflows/export-board-snapshots.yml
+++ b/.github/workflows/export-board-snapshots.yml
@@ -2,7 +2,8 @@ name: Export Board Snapshots
 
 # Nightly: build every per-(board, layout) SQLite snapshot of board_climbs +
 # board_climb_stats, plus one whole-catalogue artifact of the board hardware
-# tables (board-snapshots/v1-catalog, read only by the seeded dev-db image). Every 15 minutes: cheaply probe the live gzip manifest's
+# tables (board-snapshots/v1-catalog, read only by the seeded dev-db image).
+# Every 15 minutes: cheaply probe the live gzip manifest's
 # watermarks and rebuild only layouts once they have >=500 stable delta rows,
 # keeping prolonged bulk gaps out of fresh downloads. Idempotent — each
 # refresh mints new content-addressed artifacts and rewrites the manifest last.
@@ -169,7 +170,8 @@ jobs:
         if: >-
           ${{
             (github.event_name == 'schedule' && github.event.schedule == '15 7 * * *') ||
-            (github.event_name == 'workflow_dispatch' && inputs.refresh_threshold == '' && inputs.board == '')
+            (github.event_name == 'workflow_dispatch' && inputs.refresh_threshold == '' &&
+             inputs.board == '' && inputs.layout == '')
           }}
         working-directory: packages/backend
         env:

--- a/.github/workflows/export-board-snapshots.yml
+++ b/.github/workflows/export-board-snapshots.yml
@@ -1,7 +1,8 @@
 name: Export Board Snapshots
 
 # Nightly: build every per-(board, layout) SQLite snapshot of board_climbs +
-# board_climb_stats. Every 15 minutes: cheaply probe the live gzip manifest's
+# board_climb_stats, plus one whole-catalogue artifact of the board hardware
+# tables (board-snapshots/v1-catalog, read only by the seeded dev-db image). Every 15 minutes: cheaply probe the live gzip manifest's
 # watermarks and rebuild only layouts once they have >=500 stable delta rows,
 # keeping prolonged bulk gaps out of fresh downloads. Idempotent — each
 # refresh mints new content-addressed artifacts and rewrites the manifest last.
@@ -151,3 +152,31 @@ jobs:
           if [ -n "$LAYOUT" ]; then args+=("--layout=$LAYOUT"); fi
           if [ -n "$REFRESH_THRESHOLD" ]; then args+=("--refresh-threshold=$REFRESH_THRESHOLD"); fi
           node --import tsx src/scripts/export-board-snapshots.ts "${args[@]}"
+
+      # Catalogue pass → board-snapshots/v1-catalog. The hardware geometry and
+      # reference tables the per-layout artifacts deliberately do not carry
+      # (holes, placements, LEDs, sets, sizes, layouts, grade scales, aliases,
+      # beta links). Its consumer is the seeded developer database image, which
+      # used to scrape six Aurora APKs for exactly this data (issue #4508); the
+      # mobile fleet never reads this prefix.
+      #
+      # Nightly only, and never on the 15-minute scan or a --board/--layout
+      # dispatch: it is one whole-catalogue artifact, ~30k geometry rows that
+      # change a handful of times a year, so a frequent rebuild would only churn
+      # S3. A failure here must not fail the fleet-facing passes above, which is
+      # why it runs last.
+      - name: Export board catalogue (gzip → board-snapshots/v1-catalog)
+        if: >-
+          ${{
+            (github.event_name == 'schedule' && github.event.schedule == '15 7 * * *') ||
+            (github.event_name == 'workflow_dispatch' && inputs.refresh_threshold == '' && inputs.board == '')
+          }}
+        working-directory: packages/backend
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL_S3 || secrets.AWS_ENDPOINT_URL }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION || secrets.AWS_DEFAULT_REGION }}
+        run: node --import tsx src/scripts/export-board-catalog.ts

--- a/docs/board-snapshots-dataset.md
+++ b/docs/board-snapshots-dataset.md
@@ -10,8 +10,13 @@ analysis, backup, or tooling can use them directly.
 The one stable URL is the manifest:
 
 ```
-https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1/manifest.json
+https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1-gzip/manifest.json
 ```
+
+Artifacts under this prefix are stored gzipped and served with `Content-Encoding: gzip`. Anything
+that honours that header (curl, browsers, most HTTP clients) hands you a plain SQLite file; a
+straight-to-disk downloader may write the raw gzip stream instead, so check the first two bytes for
+`1f 8b` and gunzip if they are there rather than trusting `contentEncoding`.
 
 Everything else is discovered from it. **Never hardcode artifact URLs** — every nightly run mints
 new timestamped artifacts, and superseded ones are pruned after a 14-day grace window. A cron job
@@ -19,14 +24,16 @@ that stores an artifact URL will 404 within two weeks; a job that reads the mani
 keep working.
 
 ```sh
+manifest=https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1-gzip/manifest.json
+
 # List what's available
-curl -s https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1/manifest.json |
+curl -s "$manifest" |
   jq -r '.entries[] | "\(.boardType):\(.layoutId)\t\(.bytes / 1e6 | floor)MB\t\(.tables.board_climbs.rowCount) climbs"'
 
-# Download one board's catalog (e.g. Tension board 2)
-url=$(curl -s https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1/manifest.json |
+# Download one board's catalog (e.g. Tension board 2). --compressed decodes it.
+url=$(curl -s "$manifest" |
   jq -r '.entries[] | select(.boardType == "tension" and .layoutId == 9) | .url')
-curl -o tension-9.db "$url"
+curl --compressed -o tension-9.db "$url"
 
 # Query it
 sqlite3 tension-9.db "SELECT name, setter_username FROM board_climbs LIMIT 5"
@@ -40,45 +47,60 @@ only care about one size.
 
 `formatVersion: 1`. Each entry:
 
-| Field                                                   | Meaning                                                                       |
-| ------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `boardType`, `layoutId`                                 | Which catalog this artifact holds                                             |
-| `url`                                                   | Public download URL (valid until pruned — always re-resolve via the manifest) |
-| `key`                                                   | Object key under `board-snapshots/v1/`                                        |
-| `bytes`                                                 | Stored size                                                                   |
-| `contentEncoding`                                       | `identity` (a plain SQLite file) or `gzip` (gunzip before opening)            |
-| `builtAt`                                               | When the export built this artifact                                           |
-| `schemaVersion`                                         | SQLite schema revision of the tables inside                                   |
-| `tables.<name>.rowCount`                                | Row counts, for sanity-checking a download                                    |
-| `tables.<name>.watermarkUpdatedAt` / `watermarkSyncSeq` | Sync cursors (app-internal; irrelevant for dataset use)                       |
+| Field                                                   | Meaning                                                                                         |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `boardType`, `layoutId`                                 | Which catalog this artifact holds                                                               |
+| `url`                                                   | Public download URL (valid until pruned — always re-resolve via the manifest)                   |
+| `key`                                                   | Object key under `board-snapshots/v1/`                                                          |
+| `bytes`                                                 | Stored size                                                                                     |
+| `contentEncoding`                                       | `identity` (a plain SQLite file) or `gzip` (gunzip before opening)                              |
+| `builtAt`                                               | When the export built this artifact                                                             |
+| `schemaVersion`                                         | SQLite schema revision of the tables inside                                                     |
+| `tables.<name>.rowCount`                                | Row counts, for sanity-checking a download                                                      |
+| `tables.<name>.watermarkUpdatedAt` / `watermarkSyncSeq` | Sync cursors (app-internal; irrelevant for dataset use)                                         |
+| `grades`                                                | Present when the layout has Boardsesh grades: a sibling artifact with its own `url` and `bytes` |
 
-Artifacts are currently all `identity`-encoded. Treat `schemaVersion` as informational: columns may
-be added over time (additive), and a breaking layout change would ship under a new
-`board-snapshots/v2/` prefix rather than mutating `v1`.
+Treat `schemaVersion` as informational: columns may be added over time (additive), and a breaking
+layout change would ship under a new `board-snapshots/v2*` prefix rather than mutating `v1-gzip`.
+A `board-snapshots/v1` prefix still carries identity-encoded copies of the same artifacts; it is
+kept only as a rollback target and will be deleted, so don't build against it.
 
 ## What's inside
 
-Each artifact is a standard SQLite database with three tables. The authoritative DDL lives in
-`packages/shared/offline-sync/src/db/schema.ts`.
+Each per-layout artifact is a standard SQLite database with three tables. The authoritative DDL
+lives in `packages/shared/offline-sync/src/db/schema.ts`.
 
-**`board_climbs`** — one row per climb: `uuid` (primary key), `board_type`, `layout_id`, `name`,
-`description`, `setter_username`, `angle` (the setter's intended angle, where the board type has
-one), `frames` (the hold sequence as the board's native frame string), `edge_left/right/bottom/top`
-(placement bounding box), `is_listed`/`is_draft` flags, `created_at`, `compatible_size_ids` /
-`required_set_ids` (JSON arrays), and sync bookkeeping (`updated_at`, `sync_seq`).
+**`board_climbs`** — one row per climb, all 27 columns: `uuid` (primary key), `board_type`,
+`layout_id`, `setter_id`, `setter_username`, `name`, `description`, `hsm`,
+`edge_left/right/bottom/top` (placement bounding box), `angle` (the setter's intended angle, where
+the board type has one), `frames_count`, `frames_pace`, `frames` (the hold sequence as the board's
+native frame string), `is_draft`, `is_listed`, `created_at`, `published_at`, `user_id`,
+`required_set_ids` / `compatible_size_ids` / `characteristics` (JSON arrays), `hold_fingerprint`,
+and sync bookkeeping (`updated_at`, `sync_seq`).
+
+Drafts and unlisted climbs **are** included — filter on `is_listed` / `is_draft` yourself if you
+only want the public catalog. There is no size filter either: a layout's artifact spans every wall
+size, so filter with `compatible_size_ids`.
 
 **`board_climb_stats`** — community stats per `(climb, angle)`: `ascensionist_count`,
 `difficulty_average` and `display_difficulty` (in the board's native difficulty scale),
-`benchmark_difficulty` where the community designates benchmarks, `quality_average` (0–3 star
+`benchmark_difficulty` where the community designates benchmarks, `quality_average` (0–5 star
 scale), and first-ascent attribution (`fa_username`, `fa_at`).
 
 **`snapshot_meta`** — export bookkeeping (row counts, watermarks, schema/format versions). Useful
 for verifying integrity: `row_count` should match `SELECT COUNT(*)` on each table.
 
-Not included: Boardsesh-computed universal grades (`board_climb_grades` — see
-`boardsesh-grade.md`), user accounts, ticks/logbooks, or any personal data beyond the public
-setter username and first-ascent username attached to climbs and ascents by the climbers who
-published them.
+**Grades** ride in a sibling file, not in this one. Where a layout has Boardsesh-computed universal
+grades (see `boardsesh-grade.md`), its manifest entry carries a `grades` object with its own `url`;
+that file holds one `board_climb_grades` table. MoonBoard layouts have none by design.
+
+**Board hardware** — holes, placements, LED positions, hold sets, product sizes, layouts, grade
+scales — is a third artifact, one file for every board, discovered from its own manifest at
+`board-snapshots/v1-catalog/manifest.json`. That is what turns a climb's `frames` string and
+`layout_id` into coordinates on a wall. Same conventions: read the manifest, never hardcode a URL.
+
+Not included: user accounts, ticks/logbooks, or any personal data beyond the public setter username
+and first-ascent username attached to climbs and ascents by the climbers who published them.
 
 ## Freshness and cadence
 
@@ -91,8 +113,8 @@ published them.
 ## Being a good consumer
 
 - Re-resolve through the manifest; download an artifact at most once per day (they only change
-  nightly). The full set is ~600 MB, dominated by one 270 MB artifact — please don't re-fetch it
-  hourly.
+  nightly). The full set is ~224 MB on the wire (~600 MB decoded), dominated by one 100 MB Kilter
+  artifact — please don't re-fetch it hourly.
 - Verify downloads: check `bytes` against what you received and run `PRAGMA quick_check` before
   trusting a file.
 

--- a/docs/board-snapshots-dataset.md
+++ b/docs/board-snapshots-dataset.md
@@ -51,7 +51,7 @@ only care about one size.
 | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `boardType`, `layoutId`                                 | Which catalog this artifact holds                                                               |
 | `url`                                                   | Public download URL (valid until pruned — always re-resolve via the manifest)                   |
-| `key`                                                   | Object key under `board-snapshots/v1/`                                                          |
+| `key`                                                   | Object key under `board-snapshots/v1-gzip/`                                                     |
 | `bytes`                                                 | Stored size                                                                                     |
 | `contentEncoding`                                       | `identity` (a plain SQLite file) or `gzip` (gunzip before opening)                              |
 | `builtAt`                                               | When the export built this artifact                                                             |

--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -1148,6 +1148,65 @@ snapshot path stays healthy this is rarely hot, but any sustained drop in the `m
 (see the failure-rate check above) puts more traffic through the correlated `EXISTS` on every fallback
 page — that's the trigger to prioritize the fix.
 
+## Catalogue artifact (`board-snapshots/v1-catalog`)
+
+A third prefix, published by the same nightly run and read by nobody in the mobile fleet.
+
+The per-layout artifacts carry the climb catalogue. They deliberately do not carry the **hardware
+catalogue** — the t-nut holes, placements, LED positions, hold sets, product sizes, layouts, grade
+scales and attempt enums that every board render and every grade lookup needs. That data is small
+(~30k rows across the six Aurora boards; MoonBoard and Woods geometry lives in
+`@boardsesh/board-constants`, not Postgres), it changes a handful of times a year, and it is
+board-scoped rather than layout-scoped, so it does not fit the per-layout shape at all.
+
+The seeded developer database image needs it, though. That image used to scrape six Aurora APKs and
+run pgloader at build time to get it (issue #4508). Publishing the same rows as one more artifact
+lets the image be built entirely from public, production-derived, nightly-verified files.
+
+|          |                                                                                             |
+| -------- | ------------------------------------------------------------------------------------------- |
+| Script   | `packages/backend/src/scripts/export-board-catalog.ts`                                      |
+| Prefix   | `board-snapshots/v1-catalog` — one gzip artifact + its own `manifest.json`                  |
+| Cadence  | The 07:15 UTC nightly only. Never the 15-minute scan; never a `--board`/`--layout` dispatch |
+| Size     | ~12 MB gzipped (~63 MB on disk), dominated by `board_climb_aliases`                         |
+| Consumer | The seeded developer database image (`packages/db/docker/Dockerfile.dev-db`) — issue #4508  |
+
+Tables, in the order a consumer must load them (foreign keys point backwards):
+
+`board_products`, `board_layouts`, `board_product_sizes`, `board_sets`, `board_placement_roles`,
+`board_holes`, `board_placements`, `board_leds`, `board_product_sizes_layouts_sets`, `board_kits`,
+`board_difficulty_grades`, `board_attempts`, then — after every layout artifact has loaded, because
+their rows reference `board_climbs` — `board_climb_aliases` and `board_beta_links`.
+
+`board_beta_links` drops `created_by_user_id`, `tick_uuid` and `board_id` at export: they are
+per-user links to production rows that mean nothing in another database.
+
+**This prefix has its own manifest on purpose.** It is not an entry in the fleet-facing manifest and
+it does not widen `SNAPSHOT_TABLES`. A shipped binary verifies a downloaded artifact against a
+two-table `snapshot_meta` and counts an unexpected table as an import _failure_; two of those and the
+scope falls back to the paged crawl. Keeping the catalogue in its own prefix means no shipped client
+can ever see it.
+
+```json
+{
+  "formatVersion": 1,
+  "generatedAt": "2026-08-26T07:16:04.221Z",
+  "artifact": {
+    "key": "board-snapshots/v1-catalog/2026-08-26T07-15-58-102Z.db",
+    "url": "https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1-catalog/...",
+    "bytes": 12685503,
+    "uncompressedBytes": 63229952,
+    "contentEncoding": "gzip",
+    "builtAt": "2026-08-26T07:15:58.102Z",
+    "schemaVersion": 1,
+    "tables": { "board_holes": { "rowCount": 6405 }, "...": {} }
+  }
+}
+```
+
+Same 14-day prune grace as the other prefixes, and the manifest is written last, so a reader never
+sees a key that is not on S3 yet.
+
 ## Rollout plan
 
 1. **Build configuration**: confirm `EXPO_PUBLIC_SNAPSHOT_BASE_URL` is set to the real Tigris bucket URL

--- a/packages/backend/src/__tests__/catalog-export.test.ts
+++ b/packages/backend/src/__tests__/catalog-export.test.ts
@@ -27,8 +27,9 @@ import {
   catalogSnapshotBaseTables,
   catalogSnapshotDeferredTables,
 } from '@boardsesh/db/catalog-snapshot';
+import { uploadToS3, deleteFromS3, listS3Objects } from '../storage/s3';
 import { db } from '../db/client';
-import { buildCatalogArtifact, catalogColumnsFor, parseArgs } from '../scripts/export-board-catalog';
+import { buildCatalogArtifact, catalogColumnsFor, parseArgs, runCatalogExport } from '../scripts/export-board-catalog';
 
 const BUILT_AT = '2026-08-26T07:15:58.102Z';
 
@@ -177,5 +178,67 @@ describe('board catalogue export', () => {
   it('defers exactly the tables whose rows reference board_climbs', () => {
     expect(catalogSnapshotDeferredTables()).toEqual(['board_climb_aliases', 'board_beta_links']);
     expect(catalogSnapshotBaseTables()).not.toContain('board_climb_aliases');
+  });
+});
+
+describe('runCatalogExport', () => {
+  const CATALOG_PREFIX = 'board-snapshots/v1-catalog';
+  const MANIFEST_KEY = `${CATALOG_PREFIX}/manifest.json`;
+  const THIRTY_DAYS_AGO = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const ONE_DAY_AGO = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await resetCatalogTables();
+    await seedMinimalCatalog();
+  });
+
+  // A reader must never see a manifest naming a key that is not on S3 yet, so
+  // the artifact has to be uploaded before the manifest that references it.
+  it('uploads the artifact before the manifest that names it', async () => {
+    vi.mocked(listS3Objects).mockResolvedValue([]);
+    await runCatalogExport([]);
+
+    const keys = vi.mocked(uploadToS3).mock.calls.map(([, key]) => key);
+    expect(keys).toHaveLength(2);
+    expect(keys[0]).toMatch(new RegExp(`^${CATALOG_PREFIX}/.*\\.db$`));
+    expect(keys[1]).toBe(MANIFEST_KEY);
+
+    const manifest = JSON.parse(vi.mocked(uploadToS3).mock.calls[1][0].toString('utf8'));
+    expect(manifest.formatVersion).toBe(1);
+    expect(manifest.artifact.key).toBe(keys[0]);
+    expect(manifest.artifact.contentEncoding).toBe('gzip');
+    expect(Object.keys(manifest.artifact.tables).sort()).toEqual(
+      CATALOG_SNAPSHOT_TABLES.map((table) => table.name).sort(),
+    );
+  });
+
+  it('prunes superseded artifacts past the grace window, and nothing else', async () => {
+    vi.mocked(listS3Objects).mockImplementation(async () => [
+      { key: `${CATALOG_PREFIX}/ancient.db`, size: 10, lastModified: THIRTY_DAYS_AGO },
+      // Superseded but inside the 14-day grace: a client may still be holding
+      // the manifest that names it.
+      { key: `${CATALOG_PREFIX}/yesterday.db`, size: 10, lastModified: ONE_DAY_AGO },
+      { key: MANIFEST_KEY, size: 10, lastModified: THIRTY_DAYS_AGO },
+    ]);
+
+    await runCatalogExport([]);
+
+    const deleted = vi.mocked(deleteFromS3).mock.calls.map(([key]) => key);
+    expect(deleted).toEqual([`${CATALOG_PREFIX}/ancient.db`]);
+  });
+
+  // Storage costs are worth less than a published artifact, so a failing prune
+  // is logged and swallowed rather than failing the run.
+  it('does not fail the run when pruning throws', async () => {
+    vi.mocked(listS3Objects).mockRejectedValue(new Error('S3 list exploded'));
+    await expect(runCatalogExport([])).resolves.toBeUndefined();
+    expect(vi.mocked(uploadToS3).mock.calls.map(([, key]) => key)).toContain(MANIFEST_KEY);
+  });
+
+  it('builds without uploading anything on a dry run', async () => {
+    await runCatalogExport(['--dry-run']);
+    expect(uploadToS3).not.toHaveBeenCalled();
+    expect(deleteFromS3).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/__tests__/catalog-export.test.ts
+++ b/packages/backend/src/__tests__/catalog-export.test.ts
@@ -15,7 +15,7 @@ vi.mock('../storage/s3', () => ({
   listS3Objects: vi.fn(async () => []),
 }));
 
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
@@ -24,6 +24,8 @@ import { createPool } from '@boardsesh/db/client';
 import {
   CATALOG_SNAPSHOT_TABLES,
   CATALOG_SNAPSHOT_EXCLUDED_COLUMNS,
+  CATALOG_SNAPSHOT_REDACTED_COLUMNS,
+  CATALOG_SNAPSHOT_REDACTED_VALUE,
   catalogSnapshotBaseTables,
   catalogSnapshotDeferredTables,
 } from '@boardsesh/db/catalog-snapshot';
@@ -32,6 +34,8 @@ import { db } from '../db/client';
 import { buildCatalogArtifact, catalogColumnsFor, parseArgs, runCatalogExport } from '../scripts/export-board-catalog';
 
 const BUILT_AT = '2026-08-26T07:15:58.102Z';
+// A value that must never appear in a published artifact.
+const GATED_LAYOUT_PASSWORD = 'super-secret-aurora-password';
 
 async function resetCatalogTables(): Promise<void> {
   for (const table of [...catalogSnapshotDeferredTables()].reverse()) {
@@ -45,12 +49,17 @@ async function resetCatalogTables(): Promise<void> {
 
 async function seedMinimalCatalog(): Promise<void> {
   await db.execute(sql`
-    INSERT INTO board_products (board_type, id, name, is_listed, min_count_in_frame, max_count_in_frame)
-    VALUES ('kilter', 1, 'Kilter Board', true, 1, 1)
+    INSERT INTO board_products (board_type, id, name, is_listed, min_count_in_frame, max_count_in_frame, password)
+    VALUES ('kilter', 1, 'Kilter Board', true, 1, 1, NULL)
   `);
   await db.execute(sql`
-    INSERT INTO board_layouts (board_type, id, product_id, name, is_mirrored, is_listed)
-    VALUES ('kilter', 1, 1, 'Original', false, true)
+    INSERT INTO board_layouts (board_type, id, product_id, name, is_mirrored, is_listed, password)
+    VALUES ('kilter', 1, 1, 'Original', false, true, NULL)
+  `);
+  // A password-gated layout, so the redaction below has a real secret to hide.
+  await db.execute(sql`
+    INSERT INTO board_layouts (board_type, id, product_id, name, is_mirrored, is_listed, password)
+    VALUES ('kilter', 2, 1, 'Gated', false, false, ${GATED_LAYOUT_PASSWORD})
   `);
   await db.execute(sql`
     INSERT INTO board_kits (board_type, serial_number, name, is_autoconnect, is_listed, created_at, updated_at)
@@ -145,6 +154,21 @@ describe('board catalogue export', () => {
         expect(betaLinkColumns).not.toContain('created_by_user_id');
         expect(betaLinkColumns).not.toContain('tick_uuid');
         expect(betaLinkColumns).not.toContain('board_id');
+
+        // The artifact is world-readable. `slug-utils.ts` only ever asks whether
+        // a layout has a password (`isNull`), so nullness must survive the export
+        // while the value must not.
+        const layoutPasswords = artifact.prepare('SELECT id, password FROM board_layouts ORDER BY id').all() as {
+          id: number;
+          password: string | null;
+        }[];
+        expect(layoutPasswords).toEqual([
+          { id: 1, password: null },
+          { id: 2, password: CATALOG_SNAPSHOT_REDACTED_VALUE },
+        ]);
+        // Belt and braces: the secret must not appear anywhere in the bytes,
+        // including any index or free page the column list would not reveal.
+        expect(readFileSync(filePath, 'latin1')).not.toContain(GATED_LAYOUT_PASSWORD);
       } finally {
         artifact.close();
       }
@@ -240,5 +264,23 @@ describe('runCatalogExport', () => {
     await runCatalogExport(['--dry-run']);
     expect(uploadToS3).not.toHaveBeenCalled();
     expect(deleteFromS3).not.toHaveBeenCalled();
+  });
+});
+
+describe('catalogue redaction contract', () => {
+  it('redacts every password column the schema exposes', () => {
+    // A new password-bearing catalogue column must be added to the contract, not
+    // silently published. These are the only two the schema has today.
+    expect(CATALOG_SNAPSHOT_REDACTED_COLUMNS).toEqual({
+      board_products: ['password'],
+      board_layouts: ['password'],
+    });
+  });
+
+  it('marks redacted columns on the resolved column list', async () => {
+    const columns = await catalogColumnsFor(createPool(), 'board_layouts');
+    const password = columns.find((column) => column.name === 'password');
+    expect(password?.redacted).toBe(true);
+    expect(columns.find((column) => column.name === 'name')?.redacted).toBe(false);
   });
 });

--- a/packages/backend/src/__tests__/catalog-export.test.ts
+++ b/packages/backend/src/__tests__/catalog-export.test.ts
@@ -1,0 +1,181 @@
+// The nightly board-catalogue export: what lands in the artifact, what is
+// deliberately left out of it, and the ordering contract the seeded developer
+// database image loads it by.
+//
+// S3 is mocked at the storage/s3 boundary (same as snapshot-export-run.test.ts);
+// Postgres is the real worker test DB.
+
+import { describe, it, expect, beforeEach, vi } from 'vite-plus/test';
+
+vi.mock('../storage/s3', () => ({
+  isS3Configured: vi.fn(() => true),
+  getPublicUrl: vi.fn((key: string) => `https://cdn.example/${key}`),
+  uploadToS3: vi.fn(async (_buffer: Buffer, key: string) => ({ url: `https://cdn.example/${key}`, key })),
+  deleteFromS3: vi.fn(async () => {}),
+  listS3Objects: vi.fn(async () => []),
+}));
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { sql } from 'drizzle-orm';
+import { createPool } from '@boardsesh/db/client';
+import {
+  CATALOG_SNAPSHOT_TABLES,
+  CATALOG_SNAPSHOT_EXCLUDED_COLUMNS,
+  catalogSnapshotBaseTables,
+  catalogSnapshotDeferredTables,
+} from '@boardsesh/db/catalog-snapshot';
+import { db } from '../db/client';
+import { buildCatalogArtifact, catalogColumnsFor, parseArgs } from '../scripts/export-board-catalog';
+
+const BUILT_AT = '2026-08-26T07:15:58.102Z';
+
+async function resetCatalogTables(): Promise<void> {
+  for (const table of [...catalogSnapshotDeferredTables()].reverse()) {
+    await db.execute(sql.raw(`DELETE FROM ${table}`));
+  }
+  await db.execute(sql.raw('DELETE FROM board_climbs'));
+  for (const table of [...catalogSnapshotBaseTables()].reverse()) {
+    await db.execute(sql.raw(`DELETE FROM ${table}`));
+  }
+}
+
+async function seedMinimalCatalog(): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO board_products (board_type, id, name, is_listed, min_count_in_frame, max_count_in_frame)
+    VALUES ('kilter', 1, 'Kilter Board', true, 1, 1)
+  `);
+  await db.execute(sql`
+    INSERT INTO board_layouts (board_type, id, product_id, name, is_mirrored, is_listed)
+    VALUES ('kilter', 1, 1, 'Original', false, true)
+  `);
+  await db.execute(sql`
+    INSERT INTO board_kits (board_type, serial_number, name, is_autoconnect, is_listed, created_at, updated_at)
+    VALUES ('kilter', 'SN-1', 'A kit', true, true, '2026-01-01', '2026-01-02')
+  `);
+  await db.execute(sql`
+    INSERT INTO board_climbs (uuid, board_type, layout_id, name, frames, is_draft, is_listed)
+    VALUES ('climb-1', 'kilter', 1, 'A climb', 'p1r12', false, true)
+  `);
+  await db.execute(sql`
+    INSERT INTO board_climb_aliases (board_type, alias_uuid, canonical_uuid, source)
+    VALUES ('kilter', 'climb-1', 'climb-1', 'backfill')
+  `);
+  await db.execute(sql`
+    INSERT INTO board_beta_links (board_type, climb_uuid, link, foreign_username, angle, is_listed, created_by_user_id)
+    VALUES ('kilter', 'climb-1', 'https://instagram.test/p/abc', 'someone', 40, true, NULL)
+  `);
+}
+
+describe('board catalogue export', () => {
+  beforeEach(async () => {
+    await resetCatalogTables();
+  });
+
+  it('parses its flags and rejects an unsafe key prefix', () => {
+    expect(parseArgs([])).toEqual({ dryRun: false, keyPrefix: 'board-snapshots/v1-catalog' });
+    expect(parseArgs(['--dry-run', '--key-prefix', 'board-snapshots/staging'])).toEqual({
+      dryRun: true,
+      keyPrefix: 'board-snapshots/staging',
+    });
+    expect(() => parseArgs(['--key-prefix', '../escape'])).toThrow(/--key-prefix/);
+    expect(() => parseArgs(['--nope'])).toThrow(/Unknown argument/);
+  });
+
+  // These are per-user links to production rows. The artifact is public and the
+  // ids resolve in exactly one database, so they must never be exported.
+  it('drops the account-linking columns of board_beta_links', async () => {
+    const sqlClient = createPool();
+    const columns = await catalogColumnsFor(sqlClient, 'board_beta_links');
+    const names = columns.map((column) => column.name);
+
+    expect(names).toContain('climb_uuid');
+    expect(names).toContain('foreign_username');
+    for (const excluded of CATALOG_SNAPSHOT_EXCLUDED_COLUMNS.board_beta_links ?? []) {
+      expect(names).not.toContain(excluded);
+    }
+  });
+
+  it('builds an artifact carrying every contract table plus snapshot_meta', async () => {
+    await seedMinimalCatalog();
+
+    const workDir = mkdtempSync(join(tmpdir(), 'catalog-export-test-'));
+    const filePath = join(workDir, 'catalog.db');
+    try {
+      const tables = await buildCatalogArtifact({ sqlClient: createPool(), filePath, builtAt: BUILT_AT });
+
+      expect(Object.keys(tables).sort()).toEqual(CATALOG_SNAPSHOT_TABLES.map((table) => table.name).sort());
+      expect(tables.board_products.rowCount).toBe(1);
+      expect(tables.board_kits.rowCount).toBe(1);
+      expect(tables.board_climb_aliases.rowCount).toBe(1);
+
+      const artifact = new DatabaseSync(filePath, { readOnly: true });
+      try {
+        // Every row count the loader verifies must match the file it verifies.
+        const meta = artifact
+          .prepare('SELECT table_name, row_count, built_at, format_version FROM snapshot_meta')
+          .all() as {
+          table_name: string;
+          row_count: number;
+          built_at: string;
+          format_version: number;
+        }[];
+        expect(meta).toHaveLength(CATALOG_SNAPSHOT_TABLES.length);
+        for (const row of meta) {
+          const actual = artifact.prepare(`SELECT count(*) AS n FROM ${row.table_name}`).get() as { n: number };
+          expect(actual.n).toBe(row.row_count);
+          expect(row.built_at).toBe(BUILT_AT);
+          expect(row.format_version).toBe(1);
+        }
+
+        // SQLite has no boolean: the loader reads 0/1 back through booleanToPg.
+        const kit = artifact.prepare('SELECT is_autoconnect, name FROM board_kits').get() as {
+          is_autoconnect: number;
+          name: string;
+        };
+        expect(kit.is_autoconnect).toBe(1);
+        expect(kit.name).toBe('A kit');
+
+        const betaLinkColumns = (
+          artifact.prepare('PRAGMA table_info(board_beta_links)').all() as { name: string }[]
+        ).map((column) => column.name);
+        expect(betaLinkColumns).not.toContain('created_by_user_id');
+        expect(betaLinkColumns).not.toContain('tick_uuid');
+        expect(betaLinkColumns).not.toContain('board_id');
+      } finally {
+        artifact.close();
+      }
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  // The artifact is written in load order, and the loader replays it in that
+  // order. A table appearing before one its foreign keys point at would fail the
+  // image build, not the export.
+  it('orders the contract so no table precedes one it references', () => {
+    const order: string[] = CATALOG_SNAPSHOT_TABLES.map((table) => table.name);
+    const dependencies: Record<string, readonly string[]> = {
+      board_layouts: ['board_products'],
+      board_product_sizes: ['board_products'],
+      board_placement_roles: ['board_products'],
+      board_holes: ['board_products'],
+      board_placements: ['board_holes', 'board_layouts', 'board_sets', 'board_placement_roles'],
+      board_leds: ['board_holes', 'board_product_sizes'],
+      board_product_sizes_layouts_sets: ['board_layouts', 'board_product_sizes', 'board_sets'],
+    };
+
+    for (const [table, needs] of Object.entries(dependencies)) {
+      for (const need of needs) {
+        expect(order.indexOf(need)).toBeLessThan(order.indexOf(table));
+      }
+    }
+  });
+
+  it('defers exactly the tables whose rows reference board_climbs', () => {
+    expect(catalogSnapshotDeferredTables()).toEqual(['board_climb_aliases', 'board_beta_links']);
+    expect(catalogSnapshotBaseTables()).not.toContain('board_climb_aliases');
+  });
+});

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -135,6 +135,7 @@ export const schemaSQL = `
 
   DROP TABLE IF EXISTS "board_climb_ratings" CASCADE;
   DROP TABLE IF EXISTS "board_climb_aliases" CASCADE;
+  DROP TABLE IF EXISTS "board_kits" CASCADE;
   DROP TABLE IF EXISTS "board_climb_stats" CASCADE;
   DROP TABLE IF EXISTS "board_climbs" CASCADE;
   DROP TABLE IF EXISTS "board_difficulty_grades" CASCADE;
@@ -407,6 +408,17 @@ export const schemaSQL = `
     "position" integer,
     "name" text,
     PRIMARY KEY ("board_type", "id")
+  );
+
+  CREATE TABLE IF NOT EXISTS "board_kits" (
+    "board_type" text NOT NULL,
+    "serial_number" text NOT NULL,
+    "name" text,
+    "is_autoconnect" boolean NOT NULL,
+    "is_listed" boolean NOT NULL,
+    "created_at" text NOT NULL,
+    "updated_at" text NOT NULL,
+    PRIMARY KEY ("board_type", "serial_number")
   );
 
   CREATE TABLE IF NOT EXISTS "board_products" (

--- a/packages/backend/src/scripts/export-board-catalog.ts
+++ b/packages/backend/src/scripts/export-board-catalog.ts
@@ -33,7 +33,7 @@ import { gzipSync } from 'node:zlib';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { Sql } from 'postgres';
+import type { Sql, TransactionSql } from 'postgres';
 import { createPool, closePool } from '@boardsesh/db/client';
 import { normalizeRow, type RawRow } from '../graphql/resolvers/sync/row-normalize';
 import { uploadToS3, isS3Configured, deleteFromS3, listS3Objects } from '../storage/s3';
@@ -41,6 +41,8 @@ import { logger } from '../utils/logger';
 import {
   CATALOG_SNAPSHOT_TABLES,
   CATALOG_SNAPSHOT_EXCLUDED_COLUMNS,
+  CATALOG_SNAPSHOT_REDACTED_COLUMNS,
+  CATALOG_SNAPSHOT_REDACTED_VALUE,
   type CatalogSnapshotTableName,
 } from '@boardsesh/db/catalog-snapshot';
 import { publicUrlForKey, snapshotPublicBaseUrl } from './export-board-snapshots';
@@ -97,9 +99,14 @@ function sqliteTypeFor(dataType: string): string {
   }
 }
 
-export type CatalogColumn = { name: string; dataType: string };
+export type CatalogColumn = {
+  name: string;
+  dataType: string;
+  /** Export a presence marker rather than the value. See CATALOG_SNAPSHOT_REDACTED_COLUMNS. */
+  redacted: boolean;
+};
 
-export async function catalogColumnsFor(sqlClient: Sql, tableName: string): Promise<CatalogColumn[]> {
+export async function catalogColumnsFor(sqlClient: Sql | TransactionSql, tableName: string): Promise<CatalogColumn[]> {
   const rows = await sqlClient<{ column_name: string; data_type: string }[]>`
     SELECT column_name, data_type
     FROM information_schema.columns
@@ -110,9 +117,10 @@ export async function catalogColumnsFor(sqlClient: Sql, tableName: string): Prom
     throw new Error(`catalog table ${tableName} has no columns — is the schema migrated?`);
   }
   const excluded = new Set(CATALOG_SNAPSHOT_EXCLUDED_COLUMNS[tableName as CatalogSnapshotTableName] ?? []);
+  const redacted = new Set(CATALOG_SNAPSHOT_REDACTED_COLUMNS[tableName as CatalogSnapshotTableName] ?? []);
   const columns = rows
     .filter((row) => !excluded.has(row.column_name))
-    .map((row) => ({ name: row.column_name, dataType: row.data_type }));
+    .map((row) => ({ name: row.column_name, dataType: row.data_type, redacted: redacted.has(row.column_name) }));
   for (const column of columns) {
     if (!SAFE_IDENTIFIER.test(column.name)) {
       throw new Error(`Refusing to build catalog SELECT with unsafe column identifier: ${column.name}`);
@@ -141,7 +149,7 @@ function toSqliteValue(value: unknown): string | number | null {
 }
 
 async function streamTableIntoSqlite(
-  sqlClient: Sql,
+  tx: TransactionSql,
   db: DatabaseSync,
   tableName: string,
   columns: readonly CatalogColumn[],
@@ -161,8 +169,17 @@ async function streamTableIntoSqlite(
   );
 
   let rowCount = 0;
-  const selectSql = `SELECT ${columnNames.join(', ')} FROM ${tableName}`;
-  for await (const batch of sqlClient.unsafe(selectSql).cursor(2000)) {
+  // A redacted column is read as a presence marker, never as its value — the
+  // CASE runs in Postgres so the secret is never even fetched over the wire.
+  const selectList = columns
+    .map((column) =>
+      column.redacted
+        ? `CASE WHEN ${column.name} IS NULL THEN NULL ELSE '${CATALOG_SNAPSHOT_REDACTED_VALUE}' END AS ${column.name}`
+        : column.name,
+    )
+    .join(', ');
+  const selectSql = `SELECT ${selectList} FROM ${tableName}`;
+  for await (const batch of tx.unsafe(selectSql).cursor(2000)) {
     for (const row of batch as RawRow[]) {
       const normalized = normalizeRow(row);
       insert.run(...columnNames.map((column) => toSqliteValue(normalized[column])));
@@ -185,11 +202,21 @@ export async function buildCatalogArtifact(params: {
   try {
     db.exec(SNAPSHOT_META_DDL);
     db.exec('BEGIN');
-    for (const table of CATALOG_SNAPSHOT_TABLES) {
-      const columns = await catalogColumnsFor(sqlClient, table.name);
-      const rowCount = await streamTableIntoSqlite(sqlClient, db, table.name, columns);
-      tables[table.name] = { rowCount };
-    }
+    // ONE Postgres snapshot for every table. The catalogue's foreign keys point
+    // between the tables being exported, so reading each under its own snapshot
+    // lets an Aurora import that commits mid-export land a child here whose
+    // parent is not — an artifact that only fails much later, when the seeded
+    // image loads it under real constraints. READ ONLY makes the intent explicit
+    // and lets Postgres skip assigning a transaction id. Same rule the
+    // per-layout exporter follows.
+    await sqlClient.begin(async (tx) => {
+      await tx.unsafe('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY');
+      for (const table of CATALOG_SNAPSHOT_TABLES) {
+        const columns = await catalogColumnsFor(tx, table.name);
+        const rowCount = await streamTableIntoSqlite(tx, db, table.name, columns);
+        tables[table.name] = { rowCount };
+      }
+    });
 
     const insertMeta = db.prepare(
       'INSERT OR REPLACE INTO snapshot_meta (table_name, row_count, built_at, schema_version, format_version) VALUES (?, ?, ?, ?, ?)',

--- a/packages/backend/src/scripts/export-board-catalog.ts
+++ b/packages/backend/src/scripts/export-board-catalog.ts
@@ -1,0 +1,344 @@
+/**
+ * Export the board catalogue — the hardware geometry and reference tables that
+ * the per-layout climb snapshots deliberately do not carry — as ONE gzip SQLite
+ * artifact plus its own manifest, under `board-snapshots/v1-catalog`.
+ *
+ * Why a separate prefix and manifest rather than a new table in the whole-layout
+ * artifact: every shipped mobile binary verifies a downloaded artifact against a
+ * two-table `snapshot_meta` and treats an unexpected table as a COUNTED import
+ * failure (see snapshot-manifest.ts). Widening SNAPSHOT_TABLES would make an
+ * updated client reject every artifact still inside the 14-day prune grace. This
+ * artifact is invisible to the fleet: nothing in the client reads this prefix.
+ *
+ * Its consumer is the seeded developer database image
+ * (packages/db/docker/Dockerfile.dev-db), which used to scrape six Aurora APKs
+ * at build time to get exactly this data. Geometry is also useful to anyone
+ * using the public dataset (docs/board-snapshots-dataset.md) — the climb
+ * artifacts reference layout/size/set ids that only mean something with it.
+ *
+ * Everything here is public, non-personal catalogue data: t-nut coordinates,
+ * LED positions, hold sets, product sizes, grade scales. The two columns that
+ * link a beta link back to a Boardsesh account (`created_by_user_id`,
+ * `tick_uuid`) and to a registered wall (`board_id`) are dropped — they are
+ * per-user state, they would not resolve against any other database's ids, and
+ * they must not be republished.
+ *
+ * Usage:
+ *   node --import tsx src/scripts/export-board-catalog.ts [--dry-run] [--key-prefix <p>]
+ */
+
+import { pathToFileURL } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+import { gzipSync } from 'node:zlib';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Sql } from 'postgres';
+import { createPool, closePool } from '@boardsesh/db/client';
+import { normalizeRow, type RawRow } from '../graphql/resolvers/sync/row-normalize';
+import { uploadToS3, isS3Configured, deleteFromS3, listS3Objects } from '../storage/s3';
+import { logger } from '../utils/logger';
+import {
+  CATALOG_SNAPSHOT_TABLES,
+  CATALOG_SNAPSHOT_EXCLUDED_COLUMNS,
+  type CatalogSnapshotTableName,
+} from '@boardsesh/db/catalog-snapshot';
+import { publicUrlForKey, snapshotPublicBaseUrl } from './export-board-snapshots';
+
+const DEFAULT_CATALOG_KEY_PREFIX = 'board-snapshots/v1-catalog';
+const SAFE_KEY_PREFIX = /^[a-z0-9]+(?:[/-][a-z0-9]+)*$/;
+const ARTIFACT_CONTENT_TYPE = 'application/x-sqlite3';
+const MANIFEST_CACHE_CONTROL = 'public, max-age=300';
+const PRUNE_GRACE_MS = 14 * 24 * 60 * 60 * 1000;
+
+export const CATALOG_MANIFEST_FORMAT_VERSION = 1 as const;
+export const CATALOG_SCHEMA_VERSION = 1 as const;
+
+// Only snake_case identifiers may be spliced into a SELECT column list. Column
+// names come from information_schema, not from user input, but the query is
+// built by string concatenation so the guard stays.
+const SAFE_IDENTIFIER = /^[a-z_][a-z0-9_]*$/;
+
+export type CatalogTableStats = { rowCount: number };
+
+export type CatalogManifest = {
+  formatVersion: typeof CATALOG_MANIFEST_FORMAT_VERSION;
+  generatedAt: string;
+  artifact: {
+    key: string;
+    url: string;
+    bytes: number;
+    uncompressedBytes: number;
+    contentEncoding: 'gzip' | 'identity';
+    builtAt: string;
+    schemaVersion: number;
+    tables: Record<string, CatalogTableStats>;
+  };
+};
+
+/**
+ * Postgres type → SQLite storage class. Arrays and booleans arrive as their
+ * `toSqliteValue` shape (JSON text and 0/1), which is what the climb artifacts
+ * already do, so a consumer decodes both files the same way.
+ */
+function sqliteTypeFor(dataType: string): string {
+  switch (dataType) {
+    case 'integer':
+    case 'smallint':
+    case 'bigint':
+    case 'boolean':
+      return 'INTEGER';
+    case 'double precision':
+    case 'real':
+    case 'numeric':
+      return 'REAL';
+    default:
+      return 'TEXT';
+  }
+}
+
+export type CatalogColumn = { name: string; dataType: string };
+
+export async function catalogColumnsFor(sqlClient: Sql, tableName: string): Promise<CatalogColumn[]> {
+  const rows = await sqlClient<{ column_name: string; data_type: string }[]>`
+    SELECT column_name, data_type
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = ${tableName}
+    ORDER BY ordinal_position
+  `;
+  if (rows.length === 0) {
+    throw new Error(`catalog table ${tableName} has no columns — is the schema migrated?`);
+  }
+  const excluded = new Set(CATALOG_SNAPSHOT_EXCLUDED_COLUMNS[tableName as CatalogSnapshotTableName] ?? []);
+  const columns = rows
+    .filter((row) => !excluded.has(row.column_name))
+    .map((row) => ({ name: row.column_name, dataType: row.data_type }));
+  for (const column of columns) {
+    if (!SAFE_IDENTIFIER.test(column.name)) {
+      throw new Error(`Refusing to build catalog SELECT with unsafe column identifier: ${column.name}`);
+    }
+  }
+  return columns;
+}
+
+const SNAPSHOT_META_DDL = `
+CREATE TABLE IF NOT EXISTS snapshot_meta (
+  table_name TEXT PRIMARY KEY,
+  row_count INTEGER,
+  built_at TEXT,
+  schema_version INTEGER,
+  format_version INTEGER
+);
+`;
+
+function toSqliteValue(value: unknown): string | number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'boolean') return value ? 1 : 0;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'object') return JSON.stringify(value);
+  if (typeof value === 'bigint') return value.toString();
+  return value as string | number;
+}
+
+async function streamTableIntoSqlite(
+  sqlClient: Sql,
+  db: DatabaseSync,
+  tableName: string,
+  columns: readonly CatalogColumn[],
+): Promise<number> {
+  const columnNames = columns.map((column) => column.name);
+  db.exec(
+    `CREATE TABLE IF NOT EXISTS ${tableName} (\n${columns
+      .map((column) => `  ${column.name} ${sqliteTypeFor(column.dataType)}`)
+      .join(',\n')}\n);`,
+  );
+
+  const insert = db.prepare(
+    `INSERT INTO ${tableName} (${columnNames.join(', ')}) VALUES (${columnNames.map(() => '?').join(', ')})`,
+  );
+
+  let rowCount = 0;
+  const selectSql = `SELECT ${columnNames.join(', ')} FROM ${tableName}`;
+  for await (const batch of sqlClient.unsafe(selectSql).cursor(2000)) {
+    for (const row of batch as RawRow[]) {
+      const normalized = normalizeRow(row);
+      insert.run(...columnNames.map((column) => toSqliteValue(normalized[column])));
+      rowCount += 1;
+    }
+  }
+
+  return rowCount;
+}
+
+export async function buildCatalogArtifact(params: {
+  sqlClient: Sql;
+  filePath: string;
+  builtAt: string;
+}): Promise<Record<string, CatalogTableStats>> {
+  const { sqlClient, filePath, builtAt } = params;
+  const db = new DatabaseSync(filePath);
+  const tables: Record<string, CatalogTableStats> = {};
+
+  try {
+    db.exec(SNAPSHOT_META_DDL);
+    db.exec('BEGIN');
+    for (const table of CATALOG_SNAPSHOT_TABLES) {
+      const columns = await catalogColumnsFor(sqlClient, table.name);
+      const rowCount = await streamTableIntoSqlite(sqlClient, db, table.name, columns);
+      tables[table.name] = { rowCount };
+    }
+
+    const insertMeta = db.prepare(
+      'INSERT OR REPLACE INTO snapshot_meta (table_name, row_count, built_at, schema_version, format_version) VALUES (?, ?, ?, ?, ?)',
+    );
+    for (const [tableName, stats] of Object.entries(tables)) {
+      insertMeta.run(tableName, stats.rowCount, builtAt, CATALOG_SCHEMA_VERSION, CATALOG_MANIFEST_FORMAT_VERSION);
+    }
+    db.exec('COMMIT');
+  } catch (error) {
+    try {
+      db.exec('ROLLBACK');
+    } catch {
+      // The transaction may never have opened; the artifact is discarded anyway.
+    }
+    throw error;
+  } finally {
+    db.close();
+  }
+
+  return tables;
+}
+
+type ExportOptions = { dryRun: boolean; keyPrefix: string };
+
+export function parseArgs(argv: string[]): ExportOptions {
+  const options: ExportOptions = { dryRun: false, keyPrefix: DEFAULT_CATALOG_KEY_PREFIX };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--dry-run') {
+      options.dryRun = true;
+    } else if (arg === '--key-prefix') {
+      index += 1;
+      const raw = argv[index];
+      if (!raw || !SAFE_KEY_PREFIX.test(raw)) {
+        throw new Error(`--key-prefix must be a slash-separated lowercase path, got: ${raw ?? '(missing)'}`);
+      }
+      options.keyPrefix = raw;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+/**
+ * Delete artifacts under our own prefix that the new manifest no longer points
+ * at and that are past the grace window. Never fatal: a failed prune costs
+ * storage, a failed export costs correctness.
+ */
+async function pruneStaleArtifacts(manifest: CatalogManifest, nowMs: number, keyPrefix: string): Promise<void> {
+  try {
+    const referencedKeys = new Set([manifest.artifact.key, `${keyPrefix}/manifest.json`]);
+    const cutoffMs = nowMs - PRUNE_GRACE_MS;
+    const objects = await listS3Objects(`${keyPrefix}/`);
+    let prunedCount = 0;
+    for (const object of objects) {
+      if (referencedKeys.has(object.key)) continue;
+      if (!object.lastModified || object.lastModified.getTime() >= cutoffMs) continue;
+      try {
+        await deleteFromS3(object.key);
+        prunedCount += 1;
+      } catch (error) {
+        logger.warn('[export-catalog] failed to prune stale artifact — continuing', {
+          key: object.key,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    logger.info('[export-catalog] prune complete', { scanned: objects.length, pruned: prunedCount });
+  } catch (error) {
+    logger.warn('[export-catalog] artifact prune failed — continuing (prune is never fatal)', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function runCatalogExport(argv: string[]): Promise<void> {
+  const options = parseArgs(argv);
+  if (!options.dryRun && !isS3Configured()) {
+    throw new Error('S3 is not configured — set the AWS_* env vars or pass --dry-run');
+  }
+
+  const startedAt = Date.now();
+  const builtAt = new Date(startedAt).toISOString();
+  const workDir = mkdtempSync(join(tmpdir(), 'board-catalog-'));
+  const filePath = join(workDir, 'catalog.db');
+  const sqlClient = createPool();
+
+  try {
+    const tables = await buildCatalogArtifact({ sqlClient, filePath, builtAt });
+
+    const rawBuffer = readFileSync(filePath);
+    const uploadBody = gzipSync(rawBuffer);
+    const keyStamp = builtAt.replace(/[:.]/g, '-');
+    const key = `${options.keyPrefix}/${keyStamp}.db`;
+    const canBuildPublicUrl = isS3Configured() || snapshotPublicBaseUrl() !== '';
+
+    const manifest: CatalogManifest = {
+      formatVersion: CATALOG_MANIFEST_FORMAT_VERSION,
+      generatedAt: new Date().toISOString(),
+      artifact: {
+        key,
+        url: canBuildPublicUrl ? publicUrlForKey(key) : `dry-run:${key}`,
+        bytes: uploadBody.length,
+        uncompressedBytes: rawBuffer.length,
+        contentEncoding: 'gzip',
+        builtAt,
+        schemaVersion: CATALOG_SCHEMA_VERSION,
+        tables,
+      },
+    };
+
+    const rowTotal = Object.values(tables).reduce((sum, stats) => sum + stats.rowCount, 0);
+
+    if (options.dryRun) {
+      logger.info('[export-catalog] built (dry-run, not uploaded)', {
+        filePath,
+        rows: rowTotal,
+        rawBytes: rawBuffer.length,
+        uploadBytes: uploadBody.length,
+        tables,
+        durationMs: Date.now() - startedAt,
+      });
+      // Leave the artifact on disk so a dry run can be inspected with sqlite3.
+      logger.info('[export-catalog] dry-run artifact retained', { filePath });
+      return;
+    }
+
+    // Artifact first, manifest last: a reader must never see a key that is not
+    // on S3 yet.
+    await uploadToS3(uploadBody, key, ARTIFACT_CONTENT_TYPE, { contentEncoding: 'gzip' });
+    await uploadToS3(Buffer.from(JSON.stringify(manifest)), `${options.keyPrefix}/manifest.json`, 'application/json', {
+      cacheControl: MANIFEST_CACHE_CONTROL,
+    });
+    logger.info('[export-catalog] published', {
+      key,
+      rows: rowTotal,
+      uploadBytes: uploadBody.length,
+      durationMs: Date.now() - startedAt,
+    });
+
+    await pruneStaleArtifacts(manifest, Date.now(), options.keyPrefix);
+  } finally {
+    await closePool();
+    if (!options.dryRun) rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(process.argv[1]).href : '';
+if (invokedPath === import.meta.url) {
+  runCatalogExport(process.argv.slice(2)).catch((error) => {
+    logger.error('[export-catalog] failed', { error: error instanceof Error ? error.message : String(error) });
+    process.exitCode = 1;
+  });
+}

--- a/packages/backend/src/scripts/export-board-catalog.ts
+++ b/packages/backend/src/scripts/export-board-catalog.ts
@@ -146,6 +146,9 @@ async function streamTableIntoSqlite(
   tableName: string,
   columns: readonly CatalogColumn[],
 ): Promise<number> {
+  if (!SAFE_IDENTIFIER.test(tableName)) {
+    throw new Error(`Refusing to build catalog SQL with unsafe table identifier: ${tableName}`);
+  }
   const columnNames = columns.map((column) => column.name);
   db.exec(
     `CREATE TABLE IF NOT EXISTS ${tableName} (\n${columns
@@ -273,6 +276,10 @@ export async function runCatalogExport(argv: string[]): Promise<void> {
   const builtAt = new Date(startedAt).toISOString();
   const workDir = mkdtempSync(join(tmpdir(), 'board-catalog-'));
   const filePath = join(workDir, 'catalog.db');
+  // Closed by the CLI entry below, not here — tests share the cached pool, and
+  // `db` in packages/backend/src/db/client.ts holds a reference to the drizzle
+  // wrapper built over it, so ending it here would break every later caller in
+  // the process. Same contract as export-board-snapshots.ts.
   const sqlClient = createPool();
 
   try {
@@ -330,15 +337,18 @@ export async function runCatalogExport(argv: string[]): Promise<void> {
 
     await pruneStaleArtifacts(manifest, Date.now(), options.keyPrefix);
   } finally {
-    await closePool();
     if (!options.dryRun) rmSync(workDir, { recursive: true, force: true });
   }
 }
 
 const invokedPath = process.argv[1] ? pathToFileURL(process.argv[1]).href : '';
 if (invokedPath === import.meta.url) {
-  runCatalogExport(process.argv.slice(2)).catch((error) => {
-    logger.error('[export-catalog] failed', { error: error instanceof Error ? error.message : String(error) });
-    process.exitCode = 1;
-  });
+  runCatalogExport(process.argv.slice(2))
+    .catch((error) => {
+      logger.error('[export-catalog] failed', { error: error instanceof Error ? error.message : String(error) });
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      await closePool();
+    });
 }

--- a/packages/backend/src/scripts/export-board-snapshots.ts
+++ b/packages/backend/src/scripts/export-board-snapshots.ts
@@ -78,11 +78,11 @@ const ARTIFACT_CONTENT_TYPE = 'application/x-sqlite3';
 // needed), entry URLs become `${base}/${key}`; unset falls back to getPublicUrl
 // for S3-compatible stores whose endpoint serves public reads directly. Read
 // lazily (not at module load) so tests can set it per-run.
-function snapshotPublicBaseUrl(): string {
+export function snapshotPublicBaseUrl(): string {
   return (process.env.SNAPSHOT_PUBLIC_BASE_URL ?? '').trim().replace(/\/+$/, '');
 }
 
-function publicUrlForKey(key: string): string {
+export function publicUrlForKey(key: string): string {
   const publicBase = snapshotPublicBaseUrl();
   return publicBase ? `${publicBase}/${key}` : getPublicUrl(key);
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -46,6 +46,11 @@
       "import": "./src/client/config.ts",
       "default": "./src/client/config.ts"
     },
+    "./catalog-snapshot": {
+      "types": "./src/catalog-snapshot.ts",
+      "import": "./src/catalog-snapshot.ts",
+      "default": "./src/catalog-snapshot.ts"
+    },
     "./queries": {
       "types": "./src/queries/index.ts",
       "import": "./src/queries/index.ts",

--- a/packages/db/src/catalog-snapshot.ts
+++ b/packages/db/src/catalog-snapshot.ts
@@ -1,0 +1,72 @@
+/**
+ * The board-catalogue snapshot contract: which tables the nightly catalogue
+ * artifact carries, in the order a consumer must load them.
+ *
+ * Two packages read this. `packages/backend/src/scripts/export-board-catalog.ts`
+ * builds the artifact from it; `packages/db/scripts/load-board-snapshots.ts`
+ * loads the artifact into the seeded developer database from it. Keeping one
+ * list means a table added to the export can never be silently skipped by the
+ * loader — the drift would otherwise only surface as an empty table in an image
+ * nobody rebuilds for weeks.
+ *
+ * See docs/board-snapshots.md → "Catalogue artifact".
+ */
+
+/**
+ * Export and load order, which is foreign-key order: every table comes after
+ * the tables its foreign keys point at. `board_placements` needs holes,
+ * layouts, sets and roles; `board_leds` needs holes and product sizes;
+ * `board_product_sizes_layouts_sets` needs layouts, sizes and sets.
+ *
+ * `deferred` marks the tables whose rows reference `board_climbs`, which lives
+ * in the per-layout artifacts: they can only load after every layout has.
+ */
+export const CATALOG_SNAPSHOT_TABLES = [
+  { name: 'board_products', deferred: false },
+  { name: 'board_layouts', deferred: false },
+  { name: 'board_product_sizes', deferred: false },
+  { name: 'board_sets', deferred: false },
+  { name: 'board_placement_roles', deferred: false },
+  { name: 'board_holes', deferred: false },
+  { name: 'board_placements', deferred: false },
+  { name: 'board_leds', deferred: false },
+  { name: 'board_product_sizes_layouts_sets', deferred: false },
+  { name: 'board_kits', deferred: false },
+  { name: 'board_difficulty_grades', deferred: false },
+  { name: 'board_attempts', deferred: false },
+  { name: 'board_climb_aliases', deferred: true },
+  { name: 'board_beta_links', deferred: true },
+] as const;
+
+export type CatalogSnapshotTableName = (typeof CATALOG_SNAPSHOT_TABLES)[number]['name'];
+
+/**
+ * Columns dropped at export. `board_beta_links` links a video back to the
+ * Boardsesh account that attached it, the tick it was attached to, and the
+ * registered wall it was climbed on. Those ids resolve in exactly one database,
+ * and the artifact is public — so they never leave production.
+ */
+export const CATALOG_SNAPSHOT_EXCLUDED_COLUMNS: Partial<Record<CatalogSnapshotTableName, readonly string[]>> = {
+  board_beta_links: ['created_by_user_id', 'tick_uuid', 'board_id'],
+};
+
+/**
+ * For a deferred table, the column carrying a `board_climbs.uuid` that a
+ * foreign key enforces. The loader filters on it: a climb updated inside the
+ * export's stability window is absent from its layout artifact, and an alias
+ * pointing at it would violate `board_climb_aliases_canonical_fk`.
+ *
+ * `board_beta_links.climb_uuid` has no such constraint, so it is not listed —
+ * a beta link whose climb has not landed yet is stored, not dropped.
+ */
+export const CATALOG_SNAPSHOT_CLIMB_REFERENCE_COLUMNS: Partial<Record<CatalogSnapshotTableName, string>> = {
+  board_climb_aliases: 'canonical_uuid',
+};
+
+/** Tables loaded before the per-layout climb artifacts, in order. */
+export const catalogSnapshotBaseTables = (): CatalogSnapshotTableName[] =>
+  CATALOG_SNAPSHOT_TABLES.filter((table) => !table.deferred).map((table) => table.name);
+
+/** Tables loaded after every per-layout climb artifact, in order. */
+export const catalogSnapshotDeferredTables = (): CatalogSnapshotTableName[] =>
+  CATALOG_SNAPSHOT_TABLES.filter((table) => table.deferred).map((table) => table.name);

--- a/packages/db/src/catalog-snapshot.ts
+++ b/packages/db/src/catalog-snapshot.ts
@@ -51,6 +51,25 @@ export const CATALOG_SNAPSHOT_EXCLUDED_COLUMNS: Partial<Record<CatalogSnapshotTa
 };
 
 /**
+ * Columns exported as a presence marker instead of their value.
+ *
+ * Aurora gates some products and layouts behind a password, and the only thing
+ * Boardsesh ever asks about that column is whether it is set —
+ * `packages/web/app/lib/slug-utils.ts` filters public slugs with
+ * `isNull(layouts.password)` and nothing anywhere reads the value. The artifact
+ * is world-readable, so it carries a fixed sentinel where production has a
+ * password and NULL where it does not: `IS NULL` behaves identically in a
+ * database seeded from it, and the credential never leaves production.
+ */
+export const CATALOG_SNAPSHOT_REDACTED_COLUMNS: Partial<Record<CatalogSnapshotTableName, readonly string[]>> = {
+  board_products: ['password'],
+  board_layouts: ['password'],
+};
+
+/** What a redacted column holds when production has a value there. */
+export const CATALOG_SNAPSHOT_REDACTED_VALUE = 'redacted';
+
+/**
  * For a deferred table, the column carrying a `board_climbs.uuid` that a
  * foreign key enforces. The loader filters on it: a climb updated inside the
  * export's stability window is absent from its layout artifact, and an alias


### PR DESCRIPTION
First half of #4508. On its own this only adds a nightly artifact; the dev-db image switch that consumes it is stacked behind it in a follow-up PR, because that build cannot go green until this artifact exists.

## What and why

The per-layout board snapshots carry the climb catalogue. They deliberately do **not** carry the hardware catalogue — t-nut holes, placements, LED positions, hold sets, product sizes, layouts, grade scales, attempt enums. Nothing renders a board or resolves a grade without those, and `@boardsesh/board-constants/src/generated/*` is itself generated from them.

That data is ~30k rows across the six Aurora boards (MoonBoard and Woods geometry lives in `@boardsesh/board-constants`, not Postgres), it changes a handful of times a year, and it is board-scoped rather than layout-scoped — so it never fitted the per-layout artifact shape.

This publishes it as one gzip SQLite artifact under `board-snapshots/v1-catalog` with its own manifest, written by the same nightly export run. Measured against production data: **425,616 rows, 63 MB on disk, 12 MB gzipped, built in 3.8s.**

## Why its own prefix

Not a new table in the whole-layout artifact, and not a new entry in the fleet-facing manifest. Every shipped mobile binary verifies a downloaded artifact against a two-table `snapshot_meta` and counts an unexpected table as a *counted* import failure — two of those and the scope falls back to the paged crawl. Nothing in the client reads `v1-catalog`, so nothing in the fleet can trip over it.

## Tables

Exported in load order (foreign keys point backwards):

`board_products`, `board_layouts`, `board_product_sizes`, `board_sets`, `board_placement_roles`, `board_holes`, `board_placements`, `board_leds`, `board_product_sizes_layouts_sets`, `board_kits`, `board_difficulty_grades`, `board_attempts` — then, deferred until after every layout's climbs have loaded because their rows reference `board_climbs`: `board_climb_aliases`, `board_beta_links`.

`board_beta_links` drops `created_by_user_id`, `tick_uuid` and `board_id` at export. They are per-user links to production rows, they resolve in exactly one database, and this artifact is public.

The table list and its ordering live in `@boardsesh/db/catalog-snapshot` rather than in the export script, so the export job and its consumer read one contract instead of two lists that drift.

## Cadence

Nightly 07:15 UTC pass only. Never the 15-minute refresh scan, never a `--board`/`--layout` dispatch — it is one whole-catalogue artifact of rows that change a few times a year, so a frequent rebuild would only churn S3. It runs last so a failure there cannot fail the two fleet-facing passes.

Same 14-day prune grace and manifest-written-last ordering as the other prefixes.

## Docs

Two drifts the audit turned up in `docs/board-snapshots-dataset.md`, fixed here:

- It still handed outside users the identity `board-snapshots/v1` manifest URL. That prefix is a rollback target now; the live one is `v1-gzip`.
- Its `board_climbs` column list omitted `setter_id`, `hsm`, `frames_count`, `frames_pace`, `published_at`, `user_id`, `hold_fingerprint` and `characteristics`, and didn't mention that drafts and unlisted climbs are included or that `quality_average` is a 0–5 scale (it said 0–3).

## Testing

- `vp check` — 0 errors.
- `vp run typecheck` — clean.
- `packages/backend/src/__tests__/catalog-export.test.ts` — 5 tests: flag parsing, the beta-link column exclusions, a real artifact built against the worker Postgres (every contract table present, `snapshot_meta.row_count` matching actual counts, booleans stored as 0/1, excluded columns absent), the foreign-key ordering contract, and the deferred set.
- Dry-run against a dev database with production-shaped catalogue data: 425,616 rows across all 14 tables, 12 MB gzipped.

## Release Notes

- [x] No release note needed (internal / technical change)
