### PR TITLE
fix(ci): publish app.boardsesh.com with the account-scoped PAGES_TOKEN

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -685,14 +685,18 @@ jobs:
           # publish with `--cwd "$RUNNER_TEMP"` so wrangler finds it there.
           cp -R deploy/app-subdomain/functions "$RUNNER_TEMP/functions"
 
-      # Needs Account.Cloudflare Pages Edit on the shared Production-environment
-      # token. It is the same secret deploy-cloudflare uses for the zone, so a
-      # rotation that grants only the zone scopes lands here as
-      # `Authentication error [code: 10000]` while `wrangler whoami` still works.
-      # See the token section of docs/cloudflare.md.
+      # PAGES_TOKEN, not CLOUDFLARE_API_TOKEN. Cloudflare Pages is an ACCOUNT-level
+      # permission, and CLOUDFLARE_API_TOKEN is zone-scoped for deploy-cloudflare —
+      # its policies map `…account.<id>: {…account.zone.*: "*"}` (all zones), never
+      # `…account.<id>: "*"` (the account), which is the only shape a Pages grant
+      # attaches to. Editing one token to serve both kept dropping the other's
+      # scope, so they are split. Symptom of getting it wrong:
+      # `Authentication error [code: 10000]` on /pages/projects/… while
+      # `wrangler whoami` still succeeds and names the account, which reads as a
+      # bad credential rather than a missing scope. See docs/cloudflare.md.
       - name: Publish to Cloudflare Pages
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.PAGES_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           bunx wrangler@4 pages deploy "$RUNNER_TEMP/app-standalone" \

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -122,14 +122,13 @@ Create ONE token covering today's zone tooling, the Pages deploy of
 `app.boardsesh.com`, and the upcoming OpenNext deploy, so this setup never has to
 be repeated.
 
-> **One token, three consumers.** `CLOUDFLARE_API_TOKEN` in the GitHub Production
-> environment is read by `deploy-cloudflare` (zone config), `deploy-app-web`
-> (`wrangler pages deploy`), and later the OpenNext web deploy. **Rotating or
-> re-scoping it for one of them silently breaks the others** — a token carrying
-> only the zone scopes below authenticates fine against the zone and returns
-> `Authentication error [code: 10000]` on `/pages/projects/boardsesh-app`. That
-> exact regression took `app.boardsesh.com` off the deploy train on 2026-08-25.
-> Grant every section below, not just the one you came here for.
+> **Two tokens, split by scope level.** `CLOUDFLARE_API_TOKEN` (zone-scoped) is
+> read by `deploy-cloudflare`; `PAGES_TOKEN` (account-scoped) is read by
+> `deploy-app-web`. Both live in the GitHub **Production** environment. They are
+> separate on purpose: Cloudflare Pages is an **account**-level permission and the
+> zone tooling needs none, so serving both from one token means every re-scope
+> risks dropping the other's grant — which is exactly what took
+> `app.boardsesh.com` off the deploy train on 2026-08-25. Keep them apart.
 
 **Needed now (zone tooling, `vp run cf:apply`):**
 
@@ -145,32 +144,43 @@ Create a token at <https://dash.cloudflare.com/profile/api-tokens> scoped to the
 - **Zone.Zone Settings Read** — read the SSL/TLS mode
 - **Zone.Zone Settings Edit** — only if you'll run `--allow-zone-ssl`
 
-**Needed now (Pages deploy of app.boardsesh.com, `deploy-app-web`):**
+**`PAGES_TOKEN` — a SEPARATE token for `deploy-app-web`:**
 
 - **Account.Cloudflare Pages Edit** — `wrangler pages deploy` against the
-  `boardsesh-app` project. Account-scoped, so the token cannot be zone-only.
-  Without it the publish step fails with `Authentication error [code: 10000]`
-  while `wrangler whoami` still succeeds — it reads as a bad token, but it is a
-  missing scope.
+  `boardsesh-app` project. This is the token's only required scope.
 
-  In the token editor this is the **left-hand dropdown set to Account**, not
-  Zone, plus the account named under **Account Resources**. Ticking every
-  permission the zone offers cannot supply it — that is exactly how the token
-  ended up without it in 2026-08. Quickest check on an existing token: open its
-  summary, and if every row sits under `boardsesh.com` with no Account resource
-  section, Pages is missing no matter how long the list is.
+  In the token editor it is the **left-hand dropdown set to Account**, not Zone,
+  plus the account named under **Account Resources**. Ticking every permission
+  the zone offers cannot supply it, because the two live in different resource
+  namespaces. Read the token back from
+  `GET /user/tokens/{id}` and compare the `resources` shape — that is the only
+  unambiguous check, since the dashboard renders all three forms similarly:
 
-**Add now for the OpenNext migration (wrangler deploy of packages/web):**
+  ```jsonc
+  { "com.cloudflare.api.account.<id>": "*" }                              // account — Pages attaches here
+  { "com.cloudflare.api.account.<id>": { "com.cloudflare.api.account.zone.*": "*" } } // all zones — it does NOT
+  { "com.cloudflare.api.account.zone.<id>": "*" }                          // one zone — it does NOT
+  ```
+
+  A permission added to either of the lower two forms silently does nothing for
+  Pages. Beware `Custom Pages` (branded error pages, zone-level) and `Page Shield`
+  / `Page Rules` — none is Cloudflare Pages, and searching the picker for "Pages"
+  surfaces them first.
+
+**For the OpenNext migration (wrangler deploy of packages/web)** — these are
+account-level too, so they belong on `PAGES_TOKEN` (or a third token); the
+zone-scoped `CLOUDFLARE_API_TOKEN` cannot carry them:
 
 - **Account.Workers Scripts Edit** — deploy the Worker
 - **Account.Workers KV Storage Edit** — OpenNext incremental cache (if KV-backed)
 - **Account.Workers R2 Storage Edit** — only if the OpenNext cache uses R2
 - **Zone.Workers Routes Edit** — attach the Worker to www/apex routes
 
-Then store both values in the GitHub Production environment:
+Then store the values in the GitHub Production environment:
 
 ```
-gh secret set CLOUDFLARE_API_TOKEN --env Production
+gh secret set CLOUDFLARE_API_TOKEN --env Production   # zone-scoped, deploy-cloudflare
+gh secret set PAGES_TOKEN          --env Production   # account-scoped, deploy-app-web
 gh secret set CLOUDFLARE_ACCOUNT_ID --env Production
 ```
 

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -24,7 +24,7 @@ import {
   upsertCacheRule,
 } from '../infra/cloudflare/plan';
 import type { LiveDnsRecord, LiveState, RulesetRule } from '../infra/cloudflare/plan';
-import { parseArgs } from './cloudflare-apply';
+import { RELATED_TOKENS, TOKEN_SCOPES, parseArgs } from './cloudflare-apply';
 
 const desired = desiredCloudflareState;
 /** The og cache rule — the one the pre-existing cases in this file were written against. */
@@ -480,5 +480,52 @@ describe('deploy-cloudflare workflow wiring', () => {
   it('parses the exact argv the workflow produces, both with and without the flag', () => {
     expect(parseArgs(['--apply'])).toEqual({ apply: true, allowZoneSsl: false, help: false });
     expect(parseArgs(['--apply', '--allow-zone-ssl'])).toEqual({ apply: true, allowZoneSsl: true, help: false });
+  });
+});
+
+describe('token scope guidance', () => {
+  // printTokenScopes() is the only place a maintainer sees this list, so it has
+  // to keep pace with the requests the tool makes — and has to steer a Pages
+  // failure toward the right secret instead of toward re-scoping this one.
+  it('names every zone permission the tool calls', () => {
+    // One entry per request, reads included: a token missing a read scope fails
+    // just as hard as one missing a write. Zone.WAF Edit went missing from this
+    // list once while the crawler rules depended on it, so a partially-converged
+    // zone was the failure mode rather than a clean error.
+    const printed = TOKEN_SCOPES.join('\n');
+    expect(printed).toContain('Zone.Zone Read'); // GET /zones?name= (resolve the zone id)
+    expect(printed).toContain('Zone.DNS Edit'); // PATCH the ws record's proxied flag
+    expect(printed).toContain('Zone.Cache Rules Edit'); // PUT the cache-settings phase
+    expect(printed).toContain('Zone.WAF Edit'); // PUT the firewall-custom phase
+    expect(printed).toContain('Zone.Zone Settings Read'); // GET /settings/ssl
+    expect(printed).toContain('Zone.Zone Settings Edit'); // PATCH /settings/ssl
+  });
+
+  it('claims no account-level scope for the zone token', () => {
+    // The inverse guard, and the one that matches the incident: answering a Pages
+    // 10000 by adding an account policy to THIS token is what dropped the zone
+    // grants on 2026-08-25. Account permissions live in a different resource
+    // namespace and cannot ride along here, so nothing account-level belongs in
+    // this list — Pages is deploy-app-web's PAGES_TOKEN.
+    for (const scope of TOKEN_SCOPES) expect(scope).toMatch(/^Zone\./);
+  });
+
+  it('points a Pages failure at the separate secret by name', () => {
+    // Without the secret's name the printout sends a maintainer back to the same
+    // wrong token, since the symptom (Authentication error [code: 10000] while
+    // `wrangler whoami` succeeds) reads as a bad credential, not a missing scope.
+    const printed = RELATED_TOKENS.join('\n');
+    expect(printed).toContain('PAGES_TOKEN');
+    expect(printed).toContain('Cloudflare Pages Edit');
+  });
+
+  it('holds scopes, not prose, so the printed columns stay aligned', () => {
+    // Guards shape rather than wording: an explanation parked in either array
+    // prints ragged against the indent, and a blank spacer entry prints as
+    // trailing whitespace. Reasons belong in comments above the list.
+    for (const entry of [...TOKEN_SCOPES, ...RELATED_TOKENS]) {
+      expect(entry).toMatch(/^(Zone\.|Account\.|[A-Z_]+ )\S/);
+      expect(entry).toContain('—');
+    }
   });
 });

--- a/scripts/cloudflare-apply.ts
+++ b/scripts/cloudflare-apply.ts
@@ -54,13 +54,16 @@ const TOKEN_SCOPES = [
   'Zone.Zone Settings Edit  — ONLY needed with --allow-zone-ssl (to set the zone SSL mode)',
 ];
 
-// Scopes another consumer of the SAME Production-environment CLOUDFLARE_API_TOKEN
-// needs. Printed alongside the list above because a token built from that list
-// ALONE authenticates here and fails with `Authentication error [code: 10000]`
-// there — which reads as a bad credential, not a missing scope, since
-// `wrangler whoami` still succeeds. That regression took app.boardsesh.com off
-// the deploy train on 2026-08-25. See the token section of docs/cloudflare.md.
-const SHARED_TOKEN_SCOPES = ['Account.Cloudflare Pages Edit — wrangler pages deploy (deploy-app-web)'];
+// Named here so nobody answers a Pages `Authentication error [code: 10000]` by
+// bolting an account policy onto the zone token this tool reads. Cloudflare keeps
+// account and zone permissions in different resource namespaces, so one grant
+// cannot serve both: an account-level scope attaches only to
+// `{"com.cloudflare.api.account.<id>": "*"}`, never to the all-zones form
+// `{"com.cloudflare.api.account.<id>": {"com.cloudflare.api.account.zone.*": "*"}}`
+// that the dashboard renders almost identically. Re-scoping one token to cover
+// both dropped the other's grant twice over on 2026-08-25, which is why they are
+// split. See the token section of docs/cloudflare.md.
+const RELATED_TOKENS = ['PAGES_TOKEN — Account.Cloudflare Pages Edit, read by deploy-app-web (not this tool)'];
 
 export interface CliOptions {
   apply: boolean;
@@ -241,8 +244,8 @@ function printPlan(changes: PlannedChange[]): void {
 function printTokenScopes(): void {
   console.error('[cf-apply] CLOUDFLARE_API_TOKEN is required. Create a token with these scopes on the zone:');
   for (const scope of TOKEN_SCOPES) console.error(`             ${scope}`);
-  console.error('           The same token is shared with other jobs. Keep their scopes on it too:');
-  for (const scope of SHARED_TOKEN_SCOPES) console.error(`             ${scope}`);
+  console.error('           Zone scopes only — Cloudflare Pages lives on a separate secret:');
+  for (const related of RELATED_TOKENS) console.error(`             ${related}`);
   console.error('           https://dash.cloudflare.com/profile/api-tokens');
 }
 
@@ -345,7 +348,7 @@ async function main(): Promise<number> {
 }
 
 // Exported for docs/tests: the module can be imported without running the CLI.
-export { CF_API_BASE, SHARED_TOKEN_SCOPES, TOKEN_SCOPES, ZONE_NAME };
+export { CF_API_BASE, RELATED_TOKENS, TOKEN_SCOPES, ZONE_NAME };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main()


### PR DESCRIPTION
## Summary

Unblocks the production deploy. `deploy-app-web` has failed on every run since 2026-08-25 with `Authentication error [code: 10000]` on `/pages/projects/boardsesh-app`; it now reads the new account-scoped `PAGES_TOKEN` instead of the zone-scoped `CLOUDFLARE_API_TOKEN`.

**Why one token could not serve both.** Cloudflare keeps account and zone permissions in separate resource namespaces. A Cloudflare Pages grant attaches only to the account form, and never to the all-zones form the dashboard renders almost identically:

```jsonc
{ "com.cloudflare.api.account.<id>": "*" }                                             // account — Pages attaches here
{ "com.cloudflare.api.account.<id>": { "com.cloudflare.api.account.zone.*": "*" } }    // all zones — it does NOT
{ "com.cloudflare.api.account.zone.<id>": "*" }                                        // one zone — it does NOT
```

Three separate attempts to add Pages to the existing token all landed in a zone policy, where it does nothing. And because editing a token rewrites its policy set, each re-scope dropped whichever grant the *other* job depended on — that is how the zone tooling gaining its scopes on 2026-08-25 silently cost `app.boardsesh.com` its Pages scope in the first place. Splitting them removes the failure mode rather than documenting around it.

So: `deploy-cloudflare` keeps `CLOUDFLARE_API_TOKEN` (zone-scoped), `deploy-app-web` gets `PAGES_TOKEN` (account-scoped, Pages Edit only). Both live in the Production environment. As a side benefit each token is now least-privilege for its job, rather than one credential holding ~90 permissions for two unrelated deploys.

The runbook is rewritten around the split, with the three resource shapes side by side — reading the token back from `GET /user/tokens/{id}` is the only unambiguous check, since the dashboard shows all three similarly. It also flags the near-miss names, because searching the permission picker for "Pages" surfaces all of them before the right one: `Custom Pages` is zone-level branded error pages, `Page Shield` and `Page Rules` are neither.

**Supersedes #4805**, whose premise ("one shared token, keep every consumer's scopes on it") this change invalidates. Its scope test is folded in here, adjusted, and I've closed it — landing both would have left the suite asserting the old model.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run scripts/cloudflare-apply.test.ts` — 41 passed. Four cases: every zone permission the tool calls (reads included); **nothing account-level in the zone token's list** — the inverse guard, and the one that matches the incident, since answering a Pages `10000` by adding an account policy to *that* token is what broke the zone grants; the printout naming `PAGES_TOKEN`; and the shape guard from #4805.
- `vp test run scripts/mobile-ci-env-parity.test.ts` — 34 passed.
- Workflow YAML parsed and asserted: the publish step's env resolves to `CLOUDFLARE_API_TOKEN: ${{ secrets.PAGES_TOKEN }}`.
- `vp run cf:apply` with no token — printout still aligned, and now ends with `Zone scopes only — Cloudflare Pages lives on a separate secret: PAGES_TOKEN …`.

Confirmed present: `PAGES_TOKEN` in the Production environment (`gh secret list --env Production`), added 2026-08-26T04:28:06Z.

## Verification after merge

I can't exercise this from a branch — the Production environment is main-only, so the secret is unreadable until this lands. Merging triggers a deploy that tests it directly; I'm watching and will confirm `app.boardsesh.com` publishes, or read the next error if `PAGES_TOKEN` needs another pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1KXk18eSA4gtKU5BoPMfo
