### PR TITLE
revert(ci): put app.boardsesh.com back on the shared Cloudflare token

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -685,18 +685,14 @@ jobs:
           # publish with `--cwd "$RUNNER_TEMP"` so wrangler finds it there.
           cp -R deploy/app-subdomain/functions "$RUNNER_TEMP/functions"
 
-      # PAGES_TOKEN, not CLOUDFLARE_API_TOKEN. Cloudflare Pages is an ACCOUNT-level
-      # permission, and CLOUDFLARE_API_TOKEN is zone-scoped for deploy-cloudflare —
-      # its policies map `…account.<id>: {…account.zone.*: "*"}` (all zones), never
-      # `…account.<id>: "*"` (the account), which is the only shape a Pages grant
-      # attaches to. Editing one token to serve both kept dropping the other's
-      # scope, so they are split. Symptom of getting it wrong:
-      # `Authentication error [code: 10000]` on /pages/projects/… while
-      # `wrangler whoami` still succeeds and names the account, which reads as a
-      # bad credential rather than a missing scope. See docs/cloudflare.md.
+      # Needs Account.Cloudflare Pages Edit on the shared Production-environment
+      # token. It is the same secret deploy-cloudflare uses for the zone, so a
+      # rotation that grants only the zone scopes lands here as
+      # `Authentication error [code: 10000]` while `wrangler whoami` still works.
+      # See the token section of docs/cloudflare.md.
       - name: Publish to Cloudflare Pages
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.PAGES_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           bunx wrangler@4 pages deploy "$RUNNER_TEMP/app-standalone" \

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -122,13 +122,14 @@ Create ONE token covering today's zone tooling, the Pages deploy of
 `app.boardsesh.com`, and the upcoming OpenNext deploy, so this setup never has to
 be repeated.
 
-> **Two tokens, split by scope level.** `CLOUDFLARE_API_TOKEN` (zone-scoped) is
-> read by `deploy-cloudflare`; `PAGES_TOKEN` (account-scoped) is read by
-> `deploy-app-web`. Both live in the GitHub **Production** environment. They are
-> separate on purpose: Cloudflare Pages is an **account**-level permission and the
-> zone tooling needs none, so serving both from one token means every re-scope
-> risks dropping the other's grant — which is exactly what took
-> `app.boardsesh.com` off the deploy train on 2026-08-25. Keep them apart.
+> **One token, three consumers.** `CLOUDFLARE_API_TOKEN` in the GitHub Production
+> environment is read by `deploy-cloudflare` (zone config), `deploy-app-web`
+> (`wrangler pages deploy`), and later the OpenNext web deploy. **Rotating or
+> re-scoping it for one of them silently breaks the others** — a token carrying
+> only the zone scopes below authenticates fine against the zone and returns
+> `Authentication error [code: 10000]` on `/pages/projects/boardsesh-app`. That
+> exact regression took `app.boardsesh.com` off the deploy train on 2026-08-25.
+> Grant every section below, not just the one you came here for.
 
 **Needed now (zone tooling, `vp run cf:apply`):**
 
@@ -144,43 +145,48 @@ Create a token at <https://dash.cloudflare.com/profile/api-tokens> scoped to the
 - **Zone.Zone Settings Read** — read the SSL/TLS mode
 - **Zone.Zone Settings Edit** — only if you'll run `--allow-zone-ssl`
 
-**`PAGES_TOKEN` — a SEPARATE token for `deploy-app-web`:**
+**Needed now (Pages deploy of app.boardsesh.com, `deploy-app-web`):**
 
 - **Account.Cloudflare Pages Edit** — `wrangler pages deploy` against the
-  `boardsesh-app` project. This is the token's only required scope.
+  `boardsesh-app` project. Account-scoped, so the token cannot be zone-only.
+  Without it the publish step fails with `Authentication error [code: 10000]`
+  while `wrangler whoami` still succeeds — it reads as a bad token, but it is a
+  missing scope.
 
-  In the token editor it is the **left-hand dropdown set to Account**, not Zone,
-  plus the account named under **Account Resources**. Ticking every permission
-  the zone offers cannot supply it, because the two live in different resource
-  namespaces. Read the token back from
-  `GET /user/tokens/{id}` and compare the `resources` shape — that is the only
-  unambiguous check, since the dashboard renders all three forms similarly:
+  **The permission picker is grouped by resource type, and Cloudflare Pages
+  exists only in the Account group** — never in the Zone/domain group where every
+  other scope on this token lives. Browsing the domain section for it is a dead
+  end: what surfaces there is `Custom Pages` (branded error pages), `Page Shield`
+  and `Page Rules`, none of which is Cloudflare Pages. That is what cost four
+  attempts in 2026-08. Set the row's left-hand dropdown to **Account** first,
+  then pick it, and name the account under **Account Resources**.
+
+  Verify by reading the token back rather than by eye — the dashboard renders all
+  three resource forms similarly, and only the first grants Pages:
 
   ```jsonc
-  { "com.cloudflare.api.account.<id>": "*" }                              // account — Pages attaches here
-  { "com.cloudflare.api.account.<id>": { "com.cloudflare.api.account.zone.*": "*" } } // all zones — it does NOT
-  { "com.cloudflare.api.account.zone.<id>": "*" }                          // one zone — it does NOT
+  { "com.cloudflare.api.account.<id>": "*" }                                           // account — Pages attaches here
+  { "com.cloudflare.api.account.<id>": { "com.cloudflare.api.account.zone.*": "*" } }  // all zones — it does NOT
+  { "com.cloudflare.api.account.zone.<id>": "*" }                                      // one zone — it does NOT
   ```
 
-  A permission added to either of the lower two forms silently does nothing for
-  Pages. Beware `Custom Pages` (branded error pages, zone-level) and `Page Shield`
-  / `Page Rules` — none is Cloudflare Pages, and searching the picker for "Pages"
-  surfaces them first.
+  Read it from `GET /accounts/{account_id}/tokens/{id}` for an account-owned
+  token (dashboard → account → API tokens) or `GET /user/tokens/{id}` for a user
+  token (`/profile/api-tokens`). Those are two separate token systems with
+  separate lists; ours is account-owned, which `wrangler whoami` confirms by
+  printing `You are logged in with an Account API Token`.
 
-**For the OpenNext migration (wrangler deploy of packages/web)** — these are
-account-level too, so they belong on `PAGES_TOKEN` (or a third token); the
-zone-scoped `CLOUDFLARE_API_TOKEN` cannot carry them:
+**Add now for the OpenNext migration (wrangler deploy of packages/web):**
 
 - **Account.Workers Scripts Edit** — deploy the Worker
 - **Account.Workers KV Storage Edit** — OpenNext incremental cache (if KV-backed)
 - **Account.Workers R2 Storage Edit** — only if the OpenNext cache uses R2
 - **Zone.Workers Routes Edit** — attach the Worker to www/apex routes
 
-Then store the values in the GitHub Production environment:
+Then store both values in the GitHub Production environment:
 
 ```
-gh secret set CLOUDFLARE_API_TOKEN --env Production   # zone-scoped, deploy-cloudflare
-gh secret set PAGES_TOKEN          --env Production   # account-scoped, deploy-app-web
+gh secret set CLOUDFLARE_API_TOKEN --env Production
 gh secret set CLOUDFLARE_ACCOUNT_ID --env Production
 ```
 

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -24,7 +24,7 @@ import {
   upsertCacheRule,
 } from '../infra/cloudflare/plan';
 import type { LiveDnsRecord, LiveState, RulesetRule } from '../infra/cloudflare/plan';
-import { RELATED_TOKENS, TOKEN_SCOPES, parseArgs } from './cloudflare-apply';
+import { SHARED_TOKEN_SCOPES, TOKEN_SCOPES, parseArgs } from './cloudflare-apply';
 
 const desired = desiredCloudflareState;
 /** The og cache rule — the one the pre-existing cases in this file were written against. */
@@ -484,9 +484,9 @@ describe('deploy-cloudflare workflow wiring', () => {
 });
 
 describe('token scope guidance', () => {
-  // printTokenScopes() is the only place a maintainer sees this list, so it has
-  // to keep pace with the requests the tool makes — and has to steer a Pages
-  // failure toward the right secret instead of toward re-scoping this one.
+  // printTokenScopes() is the only place a maintainer sees these lists, so they
+  // have to keep pace with the requests the tool makes — and with the other job
+  // reading the same Production-environment CLOUDFLARE_API_TOKEN.
   it('names every zone permission the tool calls', () => {
     // One entry per request, reads included: a token missing a read scope fails
     // just as hard as one missing a write. Zone.WAF Edit went missing from this
@@ -501,31 +501,24 @@ describe('token scope guidance', () => {
     expect(printed).toContain('Zone.Zone Settings Edit'); // PATCH /settings/ssl
   });
 
-  it('claims no account-level scope for the zone token', () => {
-    // The inverse guard, and the one that matches the incident: answering a Pages
-    // 10000 by adding an account policy to THIS token is what dropped the zone
-    // grants on 2026-08-25. Account permissions live in a different resource
-    // namespace and cannot ride along here, so nothing account-level belongs in
-    // this list — Pages is deploy-app-web's PAGES_TOKEN.
-    for (const scope of TOKEN_SCOPES) expect(scope).toMatch(/^Zone\./);
-  });
-
-  it('points a Pages failure at the separate secret by name', () => {
-    // Without the secret's name the printout sends a maintainer back to the same
-    // wrong token, since the symptom (Authentication error [code: 10000] while
-    // `wrangler whoami` succeeds) reads as a bad credential, not a missing scope.
-    const printed = RELATED_TOKENS.join('\n');
-    expect(printed).toContain('PAGES_TOKEN');
-    expect(printed).toContain('Cloudflare Pages Edit');
+  it('keeps the Pages scope deploy-app-web needs, and marks it Account-level', () => {
+    // The `Account.` prefix is the load-bearing part, not decoration. Cloudflare's
+    // permission picker is grouped by resource type, and Cloudflare Pages appears
+    // ONLY under Account — never under the zone/domain group where the rest of
+    // this token's scopes live. Searching the domain section for it turns up
+    // Custom Pages, Page Shield and Page Rules, none of which is Pages, and the
+    // resulting token fails `wrangler pages deploy` with
+    // Authentication error [code: 10000] while `wrangler whoami` still succeeds.
+    expect(SHARED_TOKEN_SCOPES.join('\n')).toContain('Account.Cloudflare Pages Edit');
   });
 
   it('holds scopes, not prose, so the printed columns stay aligned', () => {
     // Guards shape rather than wording: an explanation parked in either array
     // prints ragged against the indent, and a blank spacer entry prints as
     // trailing whitespace. Reasons belong in comments above the list.
-    for (const entry of [...TOKEN_SCOPES, ...RELATED_TOKENS]) {
-      expect(entry).toMatch(/^(Zone\.|Account\.|[A-Z_]+ )\S/);
-      expect(entry).toContain('—');
+    for (const scope of [...TOKEN_SCOPES, ...SHARED_TOKEN_SCOPES]) {
+      expect(scope).toMatch(/^(Zone|Account)\.\S/);
+      expect(scope).toContain('—');
     }
   });
 });

--- a/scripts/cloudflare-apply.ts
+++ b/scripts/cloudflare-apply.ts
@@ -54,16 +54,13 @@ const TOKEN_SCOPES = [
   'Zone.Zone Settings Edit  — ONLY needed with --allow-zone-ssl (to set the zone SSL mode)',
 ];
 
-// Named here so nobody answers a Pages `Authentication error [code: 10000]` by
-// bolting an account policy onto the zone token this tool reads. Cloudflare keeps
-// account and zone permissions in different resource namespaces, so one grant
-// cannot serve both: an account-level scope attaches only to
-// `{"com.cloudflare.api.account.<id>": "*"}`, never to the all-zones form
-// `{"com.cloudflare.api.account.<id>": {"com.cloudflare.api.account.zone.*": "*"}}`
-// that the dashboard renders almost identically. Re-scoping one token to cover
-// both dropped the other's grant twice over on 2026-08-25, which is why they are
-// split. See the token section of docs/cloudflare.md.
-const RELATED_TOKENS = ['PAGES_TOKEN — Account.Cloudflare Pages Edit, read by deploy-app-web (not this tool)'];
+// Scopes another consumer of the SAME Production-environment CLOUDFLARE_API_TOKEN
+// needs. Printed alongside the list above because a token built from that list
+// ALONE authenticates here and fails with `Authentication error [code: 10000]`
+// there — which reads as a bad credential, not a missing scope, since
+// `wrangler whoami` still succeeds. That regression took app.boardsesh.com off
+// the deploy train on 2026-08-25. See the token section of docs/cloudflare.md.
+const SHARED_TOKEN_SCOPES = ['Account.Cloudflare Pages Edit — wrangler pages deploy (deploy-app-web)'];
 
 export interface CliOptions {
   apply: boolean;
@@ -244,8 +241,8 @@ function printPlan(changes: PlannedChange[]): void {
 function printTokenScopes(): void {
   console.error('[cf-apply] CLOUDFLARE_API_TOKEN is required. Create a token with these scopes on the zone:');
   for (const scope of TOKEN_SCOPES) console.error(`             ${scope}`);
-  console.error('           Zone scopes only — Cloudflare Pages lives on a separate secret:');
-  for (const related of RELATED_TOKENS) console.error(`             ${related}`);
+  console.error('           The same token is shared with other jobs. Keep their scopes on it too:');
+  for (const scope of SHARED_TOKEN_SCOPES) console.error(`             ${scope}`);
   console.error('           https://dash.cloudflare.com/profile/api-tokens');
 }
 
@@ -348,7 +345,7 @@ async function main(): Promise<number> {
 }
 
 // Exported for docs/tests: the module can be imported without running the CLI.
-export { CF_API_BASE, RELATED_TOKENS, TOKEN_SCOPES, ZONE_NAME };
+export { CF_API_BASE, SHARED_TOKEN_SCOPES, TOKEN_SCOPES, ZONE_NAME };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main()


### PR DESCRIPTION
## Summary

Reverts #4808. `deploy-app-web` goes back to `CLOUDFLARE_API_TOKEN`.

The token split was a workaround for not being able to get a Pages grant onto the shared token — and that turned out to be a UI problem, not a structural one. Cloudflare's permission picker is **grouped by resource type**, and Cloudflare Pages appears only in the **Account** group, never in the Zone/domain group where the rest of this token's scopes live. Four attempts searched the domain section, which is exactly where the near-miss names are: `Custom Pages` (branded error pages), `Page Shield`, `Page Rules`. None is Cloudflare Pages.

GH ACTIONS now carries the account-level policy alongside its existing zone one:

```json
"resources": { "com.cloudflare.api.account.7e9cab94…": "*" }
```

So one token serves both jobs again and `PAGES_TOKEN` is redundant.

**Keeps what the detour taught us.** The runbook now says where Pages hides in the picker and why the domain section is a dead end, shows the three resource forms side by side, and notes that account-owned and user tokens are separate systems with separate read-back endpoints (`GET /accounts/{account_id}/tokens/{id}` vs `GET /user/tokens/{id}`) — ours is account-owned, which `wrangler whoami` confirms by printing `You are logged in with an Account API Token`.

Reading the token back is the only unambiguous check, because the dashboard renders all three forms almost identically and only the first grants Pages:

```jsonc
{ "com.cloudflare.api.account.<id>": "*" }                                           // account — Pages attaches here
{ "com.cloudflare.api.account.<id>": { "com.cloudflare.api.account.zone.*": "*" } }  // all zones — it does NOT
{ "com.cloudflare.api.account.zone.<id>": "*" }                                      // one zone — it does NOT
```

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run scripts/cloudflare-apply.test.ts` — 40 passed. The scope tests existed only on the reverted commit, so they're restored here; the Pages case now asserts the `Account.` prefix specifically, since that prefix is the load-bearing part rather than decoration.
- Workflow YAML parsed and asserted: the publish step resolves to `CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}`.
- Confirmed from the token JSON that the zone policy still carries everything `cf:apply` calls (Zone Read, DNS Write, Cache Settings Write, Zone WAF Write, Zone Settings Read/Write), so `deploy-cloudflare` is unaffected by the revert.

Merging is the test — the Production environment is main-only, so the secret can't be exercised from a branch. I'm watching and will confirm `app.boardsesh.com` publishes.

## Follow-up

`PAGES_TOKEN` is now unused. I've left the secret and the Cloudflare token in place rather than deleting either — your call whether to clean them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1KXk18eSA4gtKU5BoPMfo
