### PR TITLE
chore(repo): stop formatting markdown — it corrupts identifiers in prose

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -19,3 +19,14 @@ docs/embedded-architecture.md
 # scripts/__tests__/mobile-screenshots.test.ts (exact quote style included) —
 # a formatting pass that rewrites quotes breaks those tests.
 packages/mobile/.maestro/
+
+# Markdown is not formatted. The formatter's emphasis pairing does not follow
+# CommonMark's intraword-underscore rule: on docs/websocket-implementation.md it
+# paired the `_` inside the bare identifier NOT_FOUND with a later `_signed-in_`
+# and emitted NOT*FOUND + \_signed-in*, corrupting an identifier in prose on
+# every run. Prose gains little from auto-formatting and has content the
+# formatter can get wrong. Mirrored in vite.config.ts fmt.ignore.
+# The CHANGELOG.md and docs/embedded-architecture.md entries above are now
+# subsumed by this, but stay: they document why those two must never be
+# formatted even if markdown formatting is ever reinstated.
+*.md

--- a/scripts/__tests__/ci-lint-scope.test.ts
+++ b/scripts/__tests__/ci-lint-scope.test.ts
@@ -109,3 +109,35 @@ describe('lint ignore scope', () => {
     }
   });
 });
+
+describe('markdown is out of formatting scope', () => {
+  /**
+   * The formatter's emphasis pairing does not follow CommonMark's
+   * intraword-underscore rule. On `docs/websocket-implementation.md` it paired
+   * the `_` inside the bare identifier `NOT_FOUND` with a later `_signed-in_`
+   * and emitted `NOT*FOUND` + `\_signed-in*` — corrupting an identifier in
+   * prose, reproducibly, on every `vp check --fix`.
+   *
+   * Prose gains little from auto-formatting and carries content the formatter
+   * can get wrong, so `.md` is excluded. It has to be excluded in BOTH places:
+   * `vp check` reads the `fmt.ignore` block, but a full-repo run only honours
+   * `.prettierignore` for some path forms (see the note above that list).
+   */
+  const MARKDOWN_GLOB = '**/*.md';
+  const PRETTIERIGNORE_PATH = '.prettierignore';
+
+  it('excludes markdown in vite.config.ts fmt.ignore', () => {
+    const fmtIgnores = stringArrayLiteral(readFileSync(VITE_CONFIG_PATH, 'utf8'), 'ignore');
+    expect(fmtIgnores).toContain(MARKDOWN_GLOB);
+  });
+
+  it('excludes markdown in .prettierignore too', () => {
+    // Belt and braces on purpose: dropping either one silently reinstates
+    // formatting for the path forms the other does not cover.
+    const patterns = readFileSync(PRETTIERIGNORE_PATH, 'utf8')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith('#'));
+    expect(patterns).toContain('*.md');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,17 @@ export default defineConfig({
     // packages/mobile/src/data/changelog.generated.json) or by nested dir
     // (drizzle/meta/) live in .prettierignore — this `ignore` glob list does not
     // reliably match those forms in `vp check`, but .prettierignore does.
-    ignore: ['design/**', '**/generated/**', '**/board-controller/**', 'CHANGELOG.md'],
+    //
+    // Markdown is not formatted at all. The formatter rewrites emphasis spans,
+    // and its pairing does not follow CommonMark's intraword-underscore rule:
+    // on docs/websocket-implementation.md it paired the `_` inside the bare
+    // identifier `NOT_FOUND` with a later `_signed-in_` and emitted
+    // `NOT*FOUND` + `\_signed-in*`, silently corrupting an identifier in prose.
+    // Reproducible on every run. Prose gains little from auto-formatting and
+    // has content the formatter can get wrong, so `.md` is out of scope —
+    // mirrored in .prettierignore because a full-repo `vp check` only honours
+    // that file for some path forms.
+    ignore: ['design/**', '**/generated/**', '**/board-controller/**', 'CHANGELOG.md', '**/*.md'],
   },
   lint: {
     // Keep this list in lock-step with `ignorePatterns` in .oxlintrc.json.


### PR DESCRIPTION
## Summary

`vp check --fix` rewrites markdown emphasis spans, and its pairing does not follow CommonMark's intraword-underscore rule. On `docs/websocket-implementation.md` it produces:

```diff
-…an anonymous read masks as NOT_FOUND. … A _signed-in_ viewer additionally holds…
+…an anonymous read masks as NOT*FOUND. … A \_signed-in* viewer additionally holds…
```

`NOT_FOUND` is a bare identifier in prose. CommonMark is explicit that an underscore flanked by alphanumerics can neither open nor close emphasis, so it should be literal — the formatter paired it with the later `_signed-in_` anyway and rewrote the span across both. Reproducible on every run.

A formatter that can change what a doc *means* is worth less than the consistency it buys on prose, so markdown comes out of scope.

**Scope, since the finding sounds worse than it is:** the pre-commit hook only runs `vp check --fix` on `*.{ts,tsx,js,mjs,cjs}` (`staged` block in `vite.config.ts`), so this never fired on commit. It takes a full-repo `vp check --fix` to hit — which is how it was found, while validating an unrelated PR.

**Blast radius today is one file.** Every other markdown file in the repo already round-trips unchanged, so this removes a hazard rather than papering over widespread drift.

## Why both ignore lists

`vp check` reads `fmt.ignore` in `vite.config.ts`, but a full-repo run only honours `.prettierignore` for some path forms — there is already a note to exactly that effect above that list. Dropping either one silently reinstates formatting for the paths the other misses, so both are set and the guard pins both.

The existing `CHANGELOG.md` and `docs/embedded-architecture.md` entries are now subsumed by `*.md` but stay put: they document *why* those two must never be formatted, which still matters if markdown formatting is ever reinstated.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- New `markdown is out of formatting scope` block in `scripts/__tests__/ci-lint-scope.test.ts` — its natural home, which already pins the fmt/lint scope contracts.
- **Mutation-tested both halves**: removing `'**/*.md'` from `fmt.ignore` fails one assertion; removing `*.md` from `.prettierignore` fails the other.
- Verified behaviourally: `vp check --fix docs/websocket-implementation.md` now leaves the file untouched, where before it corrupted it every run.
- `vp check` clean — "All 4834 files are correctly formatted".

## Alternative considered

Backticking `NOT_FOUND` in that one doc would fix today's symptom and leave the trap armed for the next person who writes an identifier with an underscore in prose. Worth doing on its own merits, but not instead of this.