### PR TITLE
feat(mobile): cycle a hold's role on tap

### DIFF
--- a/docs/ui/08-create-climb.md
+++ b/docs/ui/08-create-climb.md
@@ -140,7 +140,7 @@
 **Mobile adaptation notes:**
 
 - `ZoomableBoard` maps to `react-native-gesture-handler` pinch/pan gestures + `react-native-reanimated` transforms
-- Hold type picker: bottom sheet instead of popover (finger occlusion on small screens)
+- Hold type picker: no popover. A brush toolbar (`CreateDrawerActionBar`) selects the paint role; tapping a hold cycles it through the board's roles starting at the selected brush, then OFF (`getNextBrushRole` in `brush-roles.ts`). Long-pressing a hold opens `HoldRoleSheet`, a bottom sheet to jump straight to a specific role.
 - File input for OCR: `expo-image-picker` or `expo-document-picker`
 - BLE via `react-native-ble-plx` -- direct connection, no browser API
 - Autosave to AsyncStorage instead of IndexedDB

--- a/packages/mobile/src/components/create-climb/__tests__/brush-roles.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/brush-roles.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { BoardName } from '@boardsesh/shared-schema';
-import { brushRoleColor, getPaintRoles } from '../brush-roles';
+import { brushRoleColor, getNextBrushRole, getPaintRoles } from '../brush-roles';
 
 describe('getPaintRoles', () => {
   it('excludes FOOT for MoonBoard saved-climb roles', () => {
@@ -20,5 +20,47 @@ describe('getPaintRoles', () => {
 
   it('uses configured role colour overrides when painting a role', () => {
     expect(brushRoleColor('kilter', 'HAND', { HAND: '#123456' })).toBe('#123456');
+  });
+});
+
+describe('getNextBrushRole', () => {
+  it('assigns the selected brush to a blank hold', () => {
+    expect(getNextBrushRole('kilter', 'OFF', 'HAND')).toBe('HAND');
+  });
+
+  it('cycles from the selected brush through the remaining roles, then OFF', () => {
+    // Kilter roles are STARTING, HAND, FINISH, FOOT; brush selected is HAND.
+    expect(getNextBrushRole('kilter', 'HAND', 'HAND')).toBe('FINISH');
+    expect(getNextBrushRole('kilter', 'FINISH', 'HAND')).toBe('FOOT');
+    expect(getNextBrushRole('kilter', 'FOOT', 'HAND')).toBe('STARTING');
+    expect(getNextBrushRole('kilter', 'STARTING', 'HAND')).toBe('OFF');
+  });
+
+  it('wraps from OFF back to the selected brush', () => {
+    expect(getNextBrushRole('kilter', 'OFF', 'FINISH')).toBe('FINISH');
+  });
+
+  it('skips FOOT for MoonBoard, matching its paint roles', () => {
+    expect(getNextBrushRole('moonboard', 'STARTING', 'STARTING')).toBe('HAND');
+    expect(getNextBrushRole('moonboard', 'FINISH', 'STARTING')).toBe('OFF');
+  });
+
+  it('starts the cycle at whichever role is currently the selected brush', () => {
+    // Selecting FINISH as the brush rotates the cycle to start there.
+    expect(getNextBrushRole('kilter', 'OFF', 'FINISH')).toBe('FINISH');
+    expect(getNextBrushRole('kilter', 'FINISH', 'FINISH')).toBe('FOOT');
+    expect(getNextBrushRole('kilter', 'FOOT', 'FINISH')).toBe('STARTING');
+    expect(getNextBrushRole('kilter', 'STARTING', 'FINISH')).toBe('HAND');
+    expect(getNextBrushRole('kilter', 'HAND', 'FINISH')).toBe('OFF');
+  });
+
+  it('always clears when the eraser brush is selected, regardless of current state', () => {
+    expect(getNextBrushRole('kilter', 'HAND', 'OFF')).toBe('OFF');
+    expect(getNextBrushRole('kilter', 'OFF', 'OFF')).toBe('OFF');
+  });
+
+  it('clears a hold in an unrecognised state instead of throwing', () => {
+    expect(() => getNextBrushRole('not-a-board' as BoardName, 'OFF', 'HAND')).not.toThrow();
+    expect(getNextBrushRole('not-a-board' as BoardName, 'OFF', 'HAND')).toBe('OFF');
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-paint.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-paint.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Drives handlePaint through the real getNextBrushRole/getPaintRoles (brush-roles
+// is intentionally left unmocked here) to pin the tap-to-cycle contract end to
+// end: a tap on a hold advances it through the board's paint roles starting at
+// the selected brush, while the eraser brush always clears.
+
+const board = vi.hoisted(() => ({
+  isAuthenticated: true,
+  saveClimb: vi.fn(),
+  updateClimb: vi.fn(),
+}));
+const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
+const queue = vi.hoisted(() => ({ setCurrentClimb: vi.fn() }));
+const router = vi.hoisted(() => ({ push: vi.fn() }));
+
+const createClimb = vi.hoisted(() => ({
+  litUpHoldsMap: { 1: { state: 'STARTING' }, 2: { state: 'HAND' }, 3: { state: 'FINISH' } },
+  frames: [{ 1: { state: 'STARTING' }, 2: { state: 'HAND' }, 3: { state: 'FINISH' } }],
+  frameCount: 1,
+  currentFrameIndex: 0,
+  setHoldState: vi.fn(),
+  generateFramesString: vi.fn(() => 'p1r12p2r13p3r14'),
+  currentFrameBleString: vi.fn(() => 'p1r12p2r13p3r14'),
+  startingCount: 1,
+  finishCount: 1,
+  isValid: true,
+  resetHolds: vi.fn(),
+  loadHolds: vi.fn(),
+  loadFrames: vi.fn(),
+  duplicateFrame: vi.fn(),
+  deleteFrame: vi.fn(),
+  goToFrame: vi.fn(),
+  nextFrame: vi.fn(),
+  prevFrame: vi.fn(),
+  undo: vi.fn(),
+  redo: vi.fn(),
+  canUndo: false,
+  canRedo: false,
+}));
+
+// The controller only touches `AppState` from react-native (autosave flush);
+// stub it so the test transformer doesn't load the real RN.
+vi.mock('react-native', () => ({
+  AppState: { addEventListener: () => ({ remove: () => {} }) },
+}));
+vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'preview-uuid' }));
+vi.mock('expo-router', () => ({ useRouter: () => router }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock('@boardsesh/shared-schema', () => ({
+  isNoMatchClimb: () => false,
+  withNoMatch: (description: string | null | undefined) => description ?? '',
+}));
+
+vi.mock('@boardsesh/create-climb-react', () => ({
+  useCreateClimb: () => createClimb,
+  computeCanUpdate: (savedClimb: unknown) => savedClimb != null,
+  computeEditLocked: () => false,
+  buildInitialFrames: () => [{}],
+}));
+
+vi.mock('@boardsesh/board-react', () => ({
+  useBoardActions: () => ({
+    isAuthenticated: board.isAuthenticated,
+    saveClimb: board.saveClimb,
+    updateClimb: board.updateClimb,
+  }),
+  isDuplicateClimbError: () => false,
+}));
+
+vi.mock('@boardsesh/graphql-client', () => ({
+  GraphQLOperationError: class GraphQLOperationError extends Error {},
+}));
+
+vi.mock('../../../providers/auth-provider', () => ({
+  useAuth: () => ({ refreshAuthState: vi.fn() }),
+}));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useProfile: () => ({ data: { displayName: 'Tester' } }),
+  useClimb: () => ({ data: undefined }),
+}));
+vi.mock('../../../providers/queue-provider', () => ({
+  useQueueActions: () => ({ setCurrentClimb: queue.setCurrentClimb }),
+}));
+vi.mock('../../../providers/bluetooth-provider', () => ({
+  useOptionalBluetoothContext: () => null,
+}));
+vi.mock('../../../providers/toast-provider', () => ({
+  useToast: () => ({ showToast: toast.showToast }),
+}));
+vi.mock('../../../lib/climb-to-queue-item', () => ({ climbToQueueItem: () => ({}) }));
+vi.mock('../../../lib/create-climb-draft-store', () => ({
+  loadDraft: vi.fn(async () => null),
+  saveDraft: vi.fn(async () => {}),
+  clearDraft: vi.fn(async () => {}),
+  createClimbDraftKey: () => 'draft-key',
+}));
+
+import { useCreateClimbScreen } from '../use-create-climb-screen';
+
+const BOARD = {
+  boardName: 'kilter' as const,
+  layoutId: 1,
+  sizeId: 10,
+  setIds: '1,2',
+  angle: 40,
+};
+
+beforeEach(() => {
+  createClimb.setHoldState.mockClear();
+});
+
+describe('useCreateClimbScreen handlePaint (tap-to-cycle)', () => {
+  it('assigns the selected brush to a blank hold', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+
+    act(() => result.current.handlePaint(4));
+
+    expect(createClimb.setHoldState).toHaveBeenCalledWith(4, 'HAND');
+  });
+
+  it('cycles a painted hold to the next role after the selected brush', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+
+    // Hold 1 is fixture-seeded as STARTING; the default brush is HAND, so the
+    // cycle order is HAND -> FINISH -> FOOT -> STARTING -> OFF.
+    act(() => result.current.handlePaint(1));
+
+    expect(createClimb.setHoldState).toHaveBeenCalledWith(1, 'OFF');
+  });
+
+  it('restarts the cycle at the newly selected brush', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+
+    act(() => result.current.setSelectedBrush('FINISH'));
+    // Hold 3 is fixture-seeded as FINISH, which is now the cycle's start, so
+    // the next tap advances past it to FOOT.
+    act(() => result.current.handlePaint(3));
+
+    expect(createClimb.setHoldState).toHaveBeenCalledWith(3, 'FOOT');
+  });
+
+  it('always erases when the eraser brush is selected', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+
+    act(() => result.current.setSelectedBrush('OFF'));
+    // Hold 2 is fixture-seeded as HAND; the eraser brush never cycles.
+    act(() => result.current.handlePaint(2));
+
+    expect(createClimb.setHoldState).toHaveBeenCalledWith(2, 'OFF');
+  });
+});

--- a/packages/mobile/src/components/create-climb/brush-roles.ts
+++ b/packages/mobile/src/components/create-climb/brush-roles.ts
@@ -20,6 +20,28 @@ export function getPaintRoles(boardName: BoardName): ReadonlyArray<Exclude<Brush
 }
 
 /**
+ * The role a tap should advance a hold to. Cycles through the board's paint
+ * roles starting at the selected brush, then OFF, then back to the selected
+ * brush — so tapping a hold repeatedly walks every role without needing the
+ * long-press sheet. The eraser brush ('OFF' selected) skips the cycle and
+ * always clears, matching its role as a dedicated erase tool rather than a
+ * cycle anchor.
+ */
+export function getNextBrushRole(
+  boardName: BoardName,
+  currentState: HoldState | 'OFF',
+  selectedBrush: BrushRole,
+): BrushRole {
+  if (selectedBrush === 'OFF') return 'OFF';
+  const supportedRoles = getPaintRoles(boardName);
+  if (supportedRoles.length === 0) return 'OFF';
+  const startIndex = Math.max(supportedRoles.indexOf(selectedBrush), 0);
+  const cycle: BrushRole[] = [...supportedRoles.slice(startIndex), ...supportedRoles.slice(0, startIndex), 'OFF'];
+  const currentIndex = cycle.findIndex((role) => role === currentState);
+  return cycle[(currentIndex + 1) % cycle.length];
+}
+
+/**
  * The swatch colour for a role on a given board, taken from the board's
  * canonical role code (the same code the frame string and BLE encoder use).
  * Falls back to a neutral grey when a board doesn't define the role (e.g. a

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -31,7 +31,7 @@ import {
   createClimbDraftKey,
   type CreateClimbDraft,
 } from '../../lib/create-climb-draft-store';
-import { getPaintRoles, type BrushRole } from './brush-roles';
+import { getNextBrushRole, getPaintRoles, type BrushRole } from './brush-roles';
 
 // The save button's visual state, derived from auth + the saved-climb snapshot +
 // in-flight state. Lives here (the controller computes it) so the UI imports it.
@@ -361,11 +361,15 @@ export function useCreateClimbScreen({
   }, [holdsJson, bleConnected, currentFrameBleString]);
 
   // ---- Painting + role assignment. ----
+  // A tap cycles the tapped hold through the board's paint roles, starting
+  // from the currently selected brush, rather than always overwriting it with
+  // that brush — so fixing a mis-painted hold no longer requires a long press.
   const handlePaint = useCallback(
     (holdId: number) => {
-      setHoldState(holdId, selectedBrush);
+      const currentState = litUpHoldsMap[holdId]?.state ?? 'OFF';
+      setHoldState(holdId, getNextBrushRole(board.boardName, currentState, selectedBrush));
     },
-    [setHoldState, selectedBrush],
+    [setHoldState, selectedBrush, litUpHoldsMap, board.boardName],
   );
 
   const handleAssignRole = useCallback(


### PR DESCRIPTION
## Summary

This PR cycles a holds role when you tap on it in the editor. Makes it a bit easier editing/creating climbs.

## Release Notes

- Tap a hold in the climb editor to cycle through its role (hand, start, finish, foot) instead of needing a long press to change it once it's set.

## Test plan

- [x] `vp run typecheck:mobile`
- [x] `vp test run --project mobile` — full suite passes except 2 pre-existing, unrelated failures on `main` (`logbook-tab-grouped.test.tsx`, `feed-time-buckets.test.ts`) not touched by this change
- [x] New tests: `brush-roles.test.ts` (pure `getNextBrushRole` cycle math per board) and `use-create-climb-screen-paint.test.tsx` (wiring: tap cycles from selected brush, eraser always clears)
- [x] `vp check` — 0 errors
- [x] `vp run check:mobile-bundle`