### PR TITLE
feat(mobile): add no-kickboard and campus climb characteristics

### DIFF
--- a/docs/i18n-french-glossary.md
+++ b/docs/i18n-french-glossary.md
@@ -48,6 +48,8 @@ Use instead:
 | project (unsent climb)  | projet (verb: travailler)             |
 | redpoint                | après travail                         |
 | climber                 | grimpeur / grimpeuse                  |
+| kickboard (climb rule)  | kickboard (anglicism — see below)     |
+| campus (no feet)        | campus (anglicism — see below)        |
 
 « Tentative » is not a go on a climb — keep it for non-climbing attempts (login attempts, retries, rate limits). A go on a climb is « un essai ».
 
@@ -55,6 +57,7 @@ Use instead:
 
 - **Brand product names:** `Kilter Board`, `Tension Board`, `MoonBoard`, `Kilter Homewall`, `Boardsesh` (trademarks — see `LEGAL.md` and the `/legal` page).
 - **beta**, **flash**, **crew**, **playlist** — anglicisms French climbers use as-is.
+- **kickboard**, **campus** — climb-rule characteristics (« Sans kickboard », « Campus (sans pieds) »). No established French climbing-gym translation; do **not** render "kickboard" as « planche » or « planche du bas » — that reintroduces the « planche »/board-device ambiguity this glossary bans above.
 - **JSON keys** (`send`, `sends`, `statSent`, …) and **ICU placeholders** (`{{board}}`, `{{sends}}`). Only translate values.
 
 ## The board device is « la board » (feminine)

--- a/docs/i18n-german-glossary.md
+++ b/docs/i18n-german-glossary.md
@@ -62,6 +62,8 @@ Every string names the board device **Board**, neuter in grammar: _das Board, ei
 | playlist                | Playlist                                    |
 | Party Mode              | Party-Modus                                 |
 | Boardsesh grade         | Boardsesh-Grad                              |
+| kickboard (climb rule)  | Fußleiste (abbreviated "FL" in badges)       |
+| campus (no feet)        | Campus (kept in English)                    |
 
 « Tentative »-style false friends: a go on a climb is **Versuch**, not a login/retry "attempt" calqued oddly. Login/rate-limit attempts can still use Versuch where natural German already does.
 

--- a/docs/i18n-spanish-glossary.md
+++ b/docs/i18n-spanish-glossary.md
@@ -64,6 +64,8 @@ These are already used consistently in the catalogs — keep using them so we do
 | queue                   | cola                   |
 | climber                 | escalador / escaladora |
 | Party Mode              | Modo Fiesta            |
+| kickboard (climb rule)  | repisa (inferior)      |
+| campus (no feet)        | Campus (kept in English) |
 
 Kept in English by convention (technical board-config terms): **layout**, **set / sets**, **logbook**, **setter**, **beta**.
 

--- a/packages/backend/src/__tests__/climb-mutations.test.ts
+++ b/packages/backend/src/__tests__/climb-mutations.test.ts
@@ -346,6 +346,48 @@ describe('climb mutations', () => {
     ).rejects.toThrow(/duplicate/i);
   });
 
+  it('rejects an unknown characteristic token', async () => {
+    await expect(
+      climbMutations.saveClimb(
+        {},
+        {
+          input: {
+            boardType: 'kilter',
+            layoutId: 1,
+            name: 'Unknown Token Climb',
+            description: '',
+            isDraft: false,
+            frames: 'p1r43',
+            angle: 40,
+            characteristics: ['some_unknown_token'],
+          },
+        },
+        makeCtx(),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it('rejects no_match sent through the characteristics field (it must ride the description instead)', async () => {
+    await expect(
+      climbMutations.saveClimb(
+        {},
+        {
+          input: {
+            boardType: 'kilter',
+            layoutId: 1,
+            name: 'No Match Via Wrong Field',
+            description: '',
+            isDraft: false,
+            frames: 'p1r43',
+            angle: 40,
+            characteristics: ['no_match'],
+          },
+        },
+        makeCtx(),
+      ),
+    ).rejects.toThrow();
+  });
+
   it('derives no_match from the description and merges it with a client-supplied toggle on creation', async () => {
     // Regression: saveClimb used to store ONLY the client-supplied toggleable
     // tokens, so a climb created with no_match (via the description prefix) AND

--- a/packages/backend/src/__tests__/climb-mutations.test.ts
+++ b/packages/backend/src/__tests__/climb-mutations.test.ts
@@ -325,6 +325,27 @@ describe('climb mutations', () => {
     expect(insertCalls[0].values).toMatchObject({ characteristics: null });
   });
 
+  it('rejects a characteristics array with a duplicate token', async () => {
+    await expect(
+      climbMutations.saveClimb(
+        {},
+        {
+          input: {
+            boardType: 'kilter',
+            layoutId: 1,
+            name: 'Duplicate Token Climb',
+            description: '',
+            isDraft: false,
+            frames: 'p1r43',
+            angle: 40,
+            characteristics: ['no_kickboard', 'no_kickboard'],
+          },
+        },
+        makeCtx(),
+      ),
+    ).rejects.toThrow(/duplicate/i);
+  });
+
   it('stores non-draft MoonBoard climbs as listed', async () => {
     mockDb.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
     mockDb.select

--- a/packages/backend/src/__tests__/climb-mutations.test.ts
+++ b/packages/backend/src/__tests__/climb-mutations.test.ts
@@ -237,6 +237,94 @@ describe('climb mutations', () => {
     ]);
   });
 
+  it('stores client-supplied toggleable characteristics on a new Aurora climb', async () => {
+    mockDb.execute.mockResolvedValueOnce([]);
+    mockDb.select.mockReturnValueOnce(
+      createMockChain([{ name: 'Alice', displayName: 'Alice Setter', image: null, avatarUrl: null }]),
+    );
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await climbMutations.saveClimb(
+      {},
+      {
+        input: {
+          boardType: 'kilter',
+          layoutId: 1,
+          name: 'No Kickboard Climb',
+          description: '',
+          isDraft: false,
+          frames: 'p1r43',
+          angle: 40,
+          characteristics: ['no_kickboard'],
+        },
+      },
+      makeCtx(),
+    );
+
+    expect(insertCalls[0].values).toMatchObject({ characteristics: ['no_kickboard'] });
+  });
+
+  it('stores null characteristics on a new Aurora climb when the field is omitted', async () => {
+    mockDb.execute.mockResolvedValueOnce([]);
+    mockDb.select.mockReturnValueOnce(
+      createMockChain([{ name: 'Alice', displayName: 'Alice Setter', image: null, avatarUrl: null }]),
+    );
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await climbMutations.saveClimb(
+      {},
+      {
+        input: {
+          boardType: 'kilter',
+          layoutId: 1,
+          name: 'Plain Climb',
+          description: '',
+          isDraft: false,
+          frames: 'p1r43',
+          angle: 40,
+        },
+      },
+      makeCtx(),
+    );
+
+    expect(insertCalls[0].values).toMatchObject({ characteristics: null });
+  });
+
+  it('accepts an explicit null characteristics field on saveClimb (mobile always sends the field, not omission)', async () => {
+    mockDb.execute.mockResolvedValueOnce([]);
+    mockDb.select.mockReturnValueOnce(
+      createMockChain([{ name: 'Alice', displayName: 'Alice Setter', image: null, avatarUrl: null }]),
+    );
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await expect(
+      climbMutations.saveClimb(
+        {},
+        {
+          input: {
+            boardType: 'kilter',
+            layoutId: 1,
+            name: 'Plain Climb',
+            description: '',
+            isDraft: false,
+            frames: 'p1r43',
+            angle: 40,
+            characteristics: null,
+          },
+        },
+        makeCtx(),
+      ),
+    ).resolves.toBeDefined();
+
+    expect(insertCalls[0].values).toMatchObject({ characteristics: null });
+  });
+
   it('stores non-draft MoonBoard climbs as listed', async () => {
     mockDb.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
     mockDb.select
@@ -743,6 +831,191 @@ describe('climb mutations', () => {
     // in the update set, so the stored method_footless token is untouched.
     expect(updateSet).toBeDefined();
     expect(updateSet).not.toHaveProperty('characteristics');
+  });
+
+  // MoonBoard problems have no updateClimb-based edit path today: there is no
+  // saveMoonBoardClimb caller in web/mobile UI that later calls updateClimb on
+  // the same row, and the MoonBoard "method" field is only ever set once, at
+  // creation, via SaveMoonBoardClimbInput. So a
+  // `boardType: 'moonboard'` + `characteristics: [...]` updateClimb call isn't
+  // a real flow to test today — the toggleable-tokens loop below doesn't gate
+  // on boardType (unlike the no_match-from-description derivation), so if a
+  // MoonBoard row *were* ever routed through updateClimb with a `characteristics`
+  // field, the requested no_kickboard/campus tokens would still merge in
+  // (leaving any method_* token untouched, since the loop only ever touches the
+  // two TOGGLEABLE_CLIMB_CHARACTERISTICS tokens).
+
+  it('updateClimb merges a client-supplied characteristic onto an existing no_match row', async () => {
+    let updateSet: Record<string, unknown> | undefined;
+    mockDb.select.mockReturnValueOnce(
+      createMockChain([
+        {
+          uuid: 'climb-3',
+          userId: 'user-123',
+          isDraft: true,
+          publishedAt: null,
+          createdAt: '2026-05-14T20:00:00.000Z',
+          angle: 35,
+          layoutId: 8,
+          frames: 'p1r1',
+          framesCount: 1,
+          setterUsername: 'Alice Setter',
+          characteristics: ['no_match'],
+        },
+      ]),
+    );
+    const updateChain: Record<string, unknown> = {
+      set: vi.fn((values: Record<string, unknown>) => {
+        updateSet = values;
+        return updateChain;
+      }),
+      where: vi.fn(() => updateChain),
+    };
+    mockDb.update = vi.fn().mockReturnValue(updateChain);
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await climbMutations.updateClimb(
+      {},
+      { input: { boardType: 'kilter', uuid: 'climb-3', characteristics: ['campus'] } },
+      makeCtx(),
+    );
+
+    expect(updateSet?.characteristics).toEqual(expect.arrayContaining(['no_match', 'campus']));
+    expect((updateSet?.characteristics as string[]).sort()).toEqual(['campus', 'no_match']);
+  });
+
+  it('updateClimb composes a description-driven no_match flip with a client-supplied characteristic in the same call', async () => {
+    let updateSet: Record<string, unknown> | undefined;
+    mockDb.select.mockReturnValueOnce(
+      createMockChain([
+        {
+          uuid: 'climb-4',
+          userId: 'user-123',
+          isDraft: true,
+          publishedAt: null,
+          createdAt: '2026-05-14T20:00:00.000Z',
+          angle: 35,
+          layoutId: 8,
+          frames: 'p1r1',
+          framesCount: 1,
+          setterUsername: 'Alice Setter',
+          characteristics: null,
+        },
+      ]),
+    );
+    const updateChain: Record<string, unknown> = {
+      set: vi.fn((values: Record<string, unknown>) => {
+        updateSet = values;
+        return updateChain;
+      }),
+      where: vi.fn(() => updateChain),
+    };
+    mockDb.update = vi.fn().mockReturnValue(updateChain);
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await climbMutations.updateClimb(
+      {},
+      {
+        input: {
+          boardType: 'kilter',
+          uuid: 'climb-4',
+          description: 'No match\nbeta',
+          characteristics: ['no_kickboard'],
+        },
+      },
+      makeCtx(),
+    );
+
+    // This is the exact "one clobbering the other" case: without the
+    // restructure, only the last-applied branch's characteristics write would
+    // have survived.
+    expect((updateSet?.characteristics as string[]).sort()).toEqual(['no_kickboard', 'no_match']);
+  });
+
+  it('updateClimb sending an empty characteristics array turns off previously-set toggleable tokens, leaving no_match/method alone', async () => {
+    let updateSet: Record<string, unknown> | undefined;
+    mockDb.select.mockReturnValueOnce(
+      createMockChain([
+        {
+          uuid: 'climb-5',
+          userId: 'user-123',
+          isDraft: true,
+          publishedAt: null,
+          createdAt: '2026-05-14T20:00:00.000Z',
+          angle: 35,
+          layoutId: 8,
+          frames: 'p1r1',
+          framesCount: 1,
+          setterUsername: 'Alice Setter',
+          characteristics: ['no_match', 'no_kickboard', 'campus'],
+        },
+      ]),
+    );
+    const updateChain: Record<string, unknown> = {
+      set: vi.fn((values: Record<string, unknown>) => {
+        updateSet = values;
+        return updateChain;
+      }),
+      where: vi.fn(() => updateChain),
+    };
+    mockDb.update = vi.fn().mockReturnValue(updateChain);
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await climbMutations.updateClimb(
+      {},
+      { input: { boardType: 'kilter', uuid: 'climb-5', characteristics: [] } },
+      makeCtx(),
+    );
+
+    expect(updateSet?.characteristics).toEqual(['no_match']);
+  });
+
+  it('updateClimb sending an explicit null characteristics field behaves like an empty array (mobile sends null, not [])', async () => {
+    let updateSet: Record<string, unknown> | undefined;
+    mockDb.select.mockReturnValueOnce(
+      createMockChain([
+        {
+          uuid: 'climb-6',
+          userId: 'user-123',
+          isDraft: true,
+          publishedAt: null,
+          createdAt: '2026-05-14T20:00:00.000Z',
+          angle: 35,
+          layoutId: 8,
+          frames: 'p1r1',
+          framesCount: 1,
+          setterUsername: 'Alice Setter',
+          characteristics: ['no_match', 'no_kickboard', 'campus'],
+        },
+      ]),
+    );
+    const updateChain: Record<string, unknown> = {
+      set: vi.fn((values: Record<string, unknown>) => {
+        updateSet = values;
+        return updateChain;
+      }),
+      where: vi.fn(() => updateChain),
+    };
+    mockDb.update = vi.fn().mockReturnValue(updateChain);
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await expect(
+      climbMutations.updateClimb(
+        {},
+        { input: { boardType: 'kilter', uuid: 'climb-6', characteristics: null } },
+        makeCtx(),
+      ),
+    ).resolves.toBeDefined();
+
+    expect(updateSet?.characteristics).toEqual(['no_match']);
   });
 
   it('throws when publishing a draft without an angle', async () => {

--- a/packages/backend/src/__tests__/climb-mutations.test.ts
+++ b/packages/backend/src/__tests__/climb-mutations.test.ts
@@ -346,6 +346,44 @@ describe('climb mutations', () => {
     ).rejects.toThrow(/duplicate/i);
   });
 
+  it('derives no_match from the description and merges it with a client-supplied toggle on creation', async () => {
+    // Regression: saveClimb used to store ONLY the client-supplied toggleable
+    // tokens, so a climb created with no_match (via the description prefix) AND
+    // a toggle stored characteristics=['no_kickboard'] — non-null, so readers
+    // that prefer the array over the description fallback silently dropped the
+    // no-match badge until the next edit.
+    mockDb.execute.mockResolvedValueOnce([]);
+    mockDb.select.mockReturnValueOnce(
+      createMockChain([{ name: 'Alice', displayName: 'Alice Setter', image: null, avatarUrl: null }]),
+    );
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await climbMutations.saveClimb(
+      {},
+      {
+        input: {
+          boardType: 'kilter',
+          layoutId: 1,
+          name: 'No Match No Kickboard',
+          description: 'No match\nbeta',
+          isDraft: false,
+          frames: 'p1r43',
+          angle: 40,
+          characteristics: ['no_kickboard'],
+        },
+      },
+      makeCtx(),
+    );
+
+    const stored = insertCalls[0].values as { characteristics: string[]; description: string };
+    expect(stored.characteristics.sort()).toEqual(['no_kickboard', 'no_match']);
+    // The prefix is stripped from the stored description — characteristics is
+    // the sole source of truth going forward, matching updateClimb's behavior.
+    expect(stored.description).toBe('beta');
+  });
+
   it('stores non-draft MoonBoard climbs as listed', async () => {
     mockDb.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
     mockDb.select

--- a/packages/backend/src/graphql/resolvers/climbs/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/mutations.ts
@@ -7,6 +7,7 @@ import {
   type UpdateClimbResult,
   SUPPORTED_BOARDS,
   CLIMB_CHARACTERISTICS,
+  TOGGLEABLE_CLIMB_CHARACTERISTICS,
   isNoMatchClimb,
   withCharacteristic,
   withNoMatch,
@@ -174,6 +175,8 @@ export const climbMutations = {
         publishedAt,
         synced: false,
         syncError: null,
+        characteristics:
+          validated.characteristics && validated.characteristics.length > 0 ? validated.characteristics : null,
       });
 
       // Aurora's sync-back round-trip eventually populates board_climb_holds for
@@ -570,24 +573,46 @@ export const climbMutations = {
         publishedAt: nextPublishedAt,
       };
       if (validated.name !== undefined) updateSet.name = validated.name;
+      // Build the characteristics array once so a no_match-from-description
+      // derivation and an explicit characteristics update (no_kickboard/campus)
+      // in the same call compose instead of one clobbering the other. Starts
+      // from the existing row so any other token (MoonBoard method) survives
+      // untouched unless explicitly touched below.
+      let nextCharacteristics = existing.characteristics ? [...existing.characteristics] : [];
+      let characteristicsChanged = false;
+
       if (validated.description !== undefined) {
         // Derive no_match from the raw incoming description (may still carry the
         // Aurora "No match\n" prefix), then strip the prefix from the stored value
         // so characteristics is the sole source of truth going forward.
         const isNoMatchFromDesc = isNoMatchClimb(validated.description);
         updateSet.description = withNoMatch(validated.description, false);
-        // Keep the no_match characteristic in sync, preserving any other tokens
-        // (e.g. a MoonBoard method). no_match is an Aurora-family concept — never
-        // derive it for MoonBoard, where a description starting with "no match" is
-        // just user prose and would otherwise clobber the climb's method token.
+        // no_match is an Aurora-family concept — never derive it for MoonBoard,
+        // where a description starting with "no match" is just user prose and
+        // would otherwise clobber the climb's method token.
         if (validated.boardType !== 'moonboard') {
-          const nextCharacteristics = withCharacteristic(
-            existing.characteristics,
+          nextCharacteristics = withCharacteristic(
+            nextCharacteristics,
             CLIMB_CHARACTERISTICS.NO_MATCH,
             isNoMatchFromDesc,
           );
-          updateSet.characteristics = nextCharacteristics.length > 0 ? nextCharacteristics : null;
+          characteristicsChanged = true;
         }
+      }
+      if (validated.characteristics !== undefined) {
+        // Client sends the full desired boolean state of each freely-toggleable
+        // token; anything else already on the row (no_match, MoonBoard method)
+        // is left alone. `null` (both toggles off) is equivalent to `[]` here —
+        // the field is nullable because clients send explicit null, not omission,
+        // when nothing is toggled on.
+        const desiredCharacteristics = validated.characteristics ?? [];
+        for (const token of TOGGLEABLE_CLIMB_CHARACTERISTICS) {
+          nextCharacteristics = withCharacteristic(nextCharacteristics, token, desiredCharacteristics.includes(token));
+        }
+        characteristicsChanged = true;
+      }
+      if (characteristicsChanged) {
+        updateSet.characteristics = nextCharacteristics.length > 0 ? nextCharacteristics : null;
       }
       if (validated.frames !== undefined) updateSet.frames = validated.frames;
       if (validated.angle !== undefined) updateSet.angle = validated.angle;

--- a/packages/backend/src/graphql/resolvers/climbs/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/mutations.ts
@@ -156,6 +156,23 @@ export const climbMutations = {
         }
       }
 
+      // Derive no_match from the raw incoming description (may carry the Aurora
+      // "No match\n" prefix) the same way updateClimb does, and merge it with any
+      // client-supplied toggleable tokens (no_kickboard/campus). Without this, a
+      // climb created with no_match AND a toggle stored characteristics=['no_kickboard']
+      // — non-null, so readers that prefer the array over the description fallback
+      // (ClimbAttributeIcons, the is_no_match resolver) silently dropped the
+      // no-match badge until the next edit. no_match is Aurora-family only — this
+      // resolver never serves MoonBoard (that's saveMoonBoardClimb), but the guard
+      // mirrors updateClimb's for the same reason: a "no match" description prefix
+      // on MoonBoard would just be user prose.
+      const isNoMatchFromDesc = validated.boardType !== 'moonboard' && isNoMatchClimb(validated.description);
+      const nextCharacteristics = withCharacteristic(
+        validated.characteristics ?? [],
+        CLIMB_CHARACTERISTICS.NO_MATCH,
+        isNoMatchFromDesc,
+      );
+
       await tx.insert(UNIFIED_TABLES.climbs).values({
         boardType: validated.boardType,
         uuid,
@@ -164,7 +181,7 @@ export const climbMutations = {
         setterId: null,
         setterUsername: preferredSetter,
         name: validated.name,
-        description: validated.description ?? '',
+        description: withNoMatch(validated.description ?? '', false),
         angle: validated.angle,
         framesCount,
         framesPace: validated.framesPace ?? 0,
@@ -175,8 +192,7 @@ export const climbMutations = {
         publishedAt,
         synced: false,
         syncError: null,
-        characteristics:
-          validated.characteristics && validated.characteristics.length > 0 ? validated.characteristics : null,
+        characteristics: nextCharacteristics.length > 0 ? nextCharacteristics : null,
       });
 
       // Aurora's sync-back round-trip eventually populates board_climb_holds for

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { CONFIDENCE, MAX_SEARCH_PAGE } from '@boardsesh/db/queries';
-import { CLIMB_CHARACTERISTICS } from '@boardsesh/shared-schema';
+import { CLIMB_CHARACTERISTICS, TOGGLEABLE_CLIMB_CHARACTERISTICS } from '@boardsesh/shared-schema';
 import { ExternalUUIDSchema, BoardNameSchema } from './primitives';
 
 // Cap holdsFilter entries: each ANY entry becomes a LIKE scan over board_climbs.frames
@@ -253,6 +253,18 @@ export const SaveClimbInputSchema = z.object({
   framesCount: z.number().int().min(1).optional(),
   framesPace: z.number().int().min(0).optional(),
   angle: z.number().int().min(0).max(90),
+  // Only the freely-toggleable characteristics (no_kickboard, campus) are settable
+  // through this field — no_match is derived from `description` (see the resolver),
+  // and MoonBoard method tokens are creation-time-only via SaveMoonBoardClimbInput.
+  // .nullable(): the GraphQL field is a nullable list, and clients (mobile's
+  // buildToggleableCharacteristics) send explicit `null` when both toggles are
+  // off — `.optional()` alone rejects that literal null and 400s every ordinary
+  // save/update, not just ones touching these two characteristics.
+  characteristics: z
+    .array(z.enum([...TOGGLEABLE_CLIMB_CHARACTERISTICS]))
+    .max(TOGGLEABLE_CLIMB_CHARACTERISTICS.length)
+    .optional()
+    .nullable(),
 });
 
 export const UpdateClimbInputSchema = z.object({
@@ -265,6 +277,15 @@ export const UpdateClimbInputSchema = z.object({
   isDraft: z.boolean().optional(),
   framesCount: z.number().int().min(1).optional(),
   framesPace: z.number().int().min(0).optional(),
+  // Only the freely-toggleable characteristics (no_kickboard, campus) are settable
+  // through this field — no_match is derived from `description` (see the resolver),
+  // and MoonBoard method tokens are creation-time-only via SaveMoonBoardClimbInput.
+  // .nullable(): see SaveClimbInputSchema above — clients send explicit null.
+  characteristics: z
+    .array(z.enum([...TOGGLEABLE_CLIMB_CHARACTERISTICS]))
+    .max(TOGGLEABLE_CLIMB_CHARACTERISTICS.length)
+    .optional()
+    .nullable(),
 });
 
 export const MoonBoardHoldsInputSchema = z.object({

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -243,6 +243,26 @@ export const ClimbSearchInputSchema = z.object({
   zoneMode: z.enum(['allHolds', 'anyHold']).optional(),
 });
 
+// Only the freely-toggleable characteristics (no_kickboard, campus) are settable
+// through the SaveClimbInput/UpdateClimbInput `characteristics` field — no_match
+// is derived from `description` (see the resolver), and MoonBoard method tokens
+// are creation-time-only via SaveMoonBoardClimbInput.
+// .nullable(): the GraphQL field is a nullable list, and clients (mobile's
+// buildToggleableCharacteristics) send explicit `null` when both toggles are off —
+// `.optional()` alone rejects that literal null and 400s every ordinary
+// save/update, not just ones touching these two characteristics.
+// .refine: a client can only mean one thing by repeating a token twice, and
+// `withCharacteristic` is idempotent either way, but rejecting the duplicate
+// up front is cheaper to reason about than silently tolerating malformed input.
+const ToggleableCharacteristicsSchema = z
+  .array(z.enum([...TOGGLEABLE_CLIMB_CHARACTERISTICS]))
+  .max(TOGGLEABLE_CLIMB_CHARACTERISTICS.length)
+  .refine((tokens) => new Set(tokens).size === tokens.length, {
+    message: 'characteristics must not contain duplicate tokens',
+  })
+  .optional()
+  .nullable();
+
 export const SaveClimbInputSchema = z.object({
   boardType: BoardNameSchema,
   layoutId: z.number().int().positive('Layout ID must be positive'),
@@ -253,18 +273,7 @@ export const SaveClimbInputSchema = z.object({
   framesCount: z.number().int().min(1).optional(),
   framesPace: z.number().int().min(0).optional(),
   angle: z.number().int().min(0).max(90),
-  // Only the freely-toggleable characteristics (no_kickboard, campus) are settable
-  // through this field — no_match is derived from `description` (see the resolver),
-  // and MoonBoard method tokens are creation-time-only via SaveMoonBoardClimbInput.
-  // .nullable(): the GraphQL field is a nullable list, and clients (mobile's
-  // buildToggleableCharacteristics) send explicit `null` when both toggles are
-  // off — `.optional()` alone rejects that literal null and 400s every ordinary
-  // save/update, not just ones touching these two characteristics.
-  characteristics: z
-    .array(z.enum([...TOGGLEABLE_CLIMB_CHARACTERISTICS]))
-    .max(TOGGLEABLE_CLIMB_CHARACTERISTICS.length)
-    .optional()
-    .nullable(),
+  characteristics: ToggleableCharacteristicsSchema,
 });
 
 export const UpdateClimbInputSchema = z.object({
@@ -277,15 +286,7 @@ export const UpdateClimbInputSchema = z.object({
   isDraft: z.boolean().optional(),
   framesCount: z.number().int().min(1).optional(),
   framesPace: z.number().int().min(0).optional(),
-  // Only the freely-toggleable characteristics (no_kickboard, campus) are settable
-  // through this field — no_match is derived from `description` (see the resolver),
-  // and MoonBoard method tokens are creation-time-only via SaveMoonBoardClimbInput.
-  // .nullable(): see SaveClimbInputSchema above — clients send explicit null.
-  characteristics: z
-    .array(z.enum([...TOGGLEABLE_CLIMB_CHARACTERISTICS]))
-    .max(TOGGLEABLE_CLIMB_CHARACTERISTICS.length)
-    .optional()
-    .nullable(),
+  characteristics: ToggleableCharacteristicsSchema,
 });
 
 export const MoonBoardHoldsInputSchema = z.object({

--- a/packages/mobile/src/components/ClimbAttributeIcons.tsx
+++ b/packages/mobile/src/components/ClimbAttributeIcons.tsx
@@ -2,7 +2,13 @@ import { memo } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
-import { CLIMB_CHARACTERISTICS, getMoonBoardMethod, hasCharacteristic, isNoMatch } from '@boardsesh/shared-schema';
+import {
+  CLIMB_CHARACTERISTICS,
+  getMoonBoardMethod,
+  isCampus,
+  isNoKickboard,
+  isNoMatch,
+} from '@boardsesh/shared-schema';
 import { Icon } from './Icon';
 import { useTheme } from '../providers/theme-provider';
 
@@ -45,9 +51,8 @@ function methodLabel(characteristics: string[] | null | undefined, t: TFunction<
  */
 function extraCharacteristicLabels(characteristics: string[] | null | undefined, t: TFunction<'climbs'>): string[] {
   const labels: string[] = [];
-  if (hasCharacteristic(characteristics, CLIMB_CHARACTERISTICS.CAMPUS)) labels.push(t('mobile.climbRow.campus'));
-  if (hasCharacteristic(characteristics, CLIMB_CHARACTERISTICS.NO_KICKBOARD))
-    labels.push(t('mobile.climbRow.noKickboard'));
+  if (isCampus(characteristics)) labels.push(t('mobile.climbRow.campus'));
+  if (isNoKickboard(characteristics)) labels.push(t('mobile.climbRow.noKickboard'));
   return labels;
 }
 

--- a/packages/mobile/src/components/ClimbAttributeIcons.tsx
+++ b/packages/mobile/src/components/ClimbAttributeIcons.tsx
@@ -2,7 +2,7 @@ import { memo } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
-import { CLIMB_CHARACTERISTICS, getMoonBoardMethod, isNoMatch } from '@boardsesh/shared-schema';
+import { CLIMB_CHARACTERISTICS, getMoonBoardMethod, hasCharacteristic, isNoMatch } from '@boardsesh/shared-schema';
 import { Icon } from './Icon';
 import { useTheme } from '../providers/theme-provider';
 
@@ -39,6 +39,19 @@ function methodLabel(characteristics: string[] | null | undefined, t: TFunction<
 }
 
 /**
+ * Text badges for the freely-toggleable no-kickboard / campus characteristics —
+ * same reasoning as `methodLabel` above: no clean SF-Symbol exists for either
+ * rule, so they render as text rather than joining the icon-map.
+ */
+function extraCharacteristicLabels(characteristics: string[] | null | undefined, t: TFunction<'climbs'>): string[] {
+  const labels: string[] = [];
+  if (hasCharacteristic(characteristics, CLIMB_CHARACTERISTICS.CAMPUS)) labels.push(t('mobile.climbRow.campus'));
+  if (hasCharacteristic(characteristics, CLIMB_CHARACTERISTICS.NO_KICKBOARD))
+    labels.push(t('mobile.climbRow.noKickboard'));
+  return labels;
+}
+
+/**
  * Grey glyph cluster for a climb's intrinsic attributes, rendered inline after a
  * climb name (web parity: `packages/web/.../climb-card/climb-icons.tsx`).
  * Order matches web — © benchmark/classic, then ⊘ no-match. Monochrome so it
@@ -60,8 +73,9 @@ export const ClimbAttributeIcons = memo(function ClimbAttributeIcons({
   // tick-sourced rows that carry the flag but not the full characteristics array.
   const isNoMatchClimb = characteristics != null ? isNoMatch(characteristics) : (isNoMatchFallback ?? false);
   const method = methodLabel(characteristics, t);
+  const extraLabels = extraCharacteristicLabels(characteristics, t);
 
-  if (!isBenchmark && !isNoMatchClimb && !method) return null;
+  if (!isBenchmark && !isNoMatchClimb && !method && extraLabels.length === 0) return null;
 
   return (
     <>
@@ -77,6 +91,11 @@ export const ClimbAttributeIcons = memo(function ClimbAttributeIcons({
       ) : null}
       {method ? (
         <Text style={[styles.method, { fontSize: size - 2, color: theme.systemColors.secondaryLabel }]}>{method}</Text>
+      ) : null}
+      {extraLabels.length > 0 ? (
+        <Text style={[styles.method, { fontSize: size - 2, color: theme.systemColors.secondaryLabel }]}>
+          {extraLabels.join(' · ')}
+        </Text>
       ) : null}
     </>
   );

--- a/packages/mobile/src/components/__tests__/ClimbAttributeIcons.test.tsx
+++ b/packages/mobile/src/components/__tests__/ClimbAttributeIcons.test.tsx
@@ -3,11 +3,13 @@ import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
-// react-native View → a div that surfaces the a11y label; StyleSheet passthrough.
+// react-native View → a div that surfaces the a11y label; Text → a plain span
+// (the method / extra-characteristic text badges); StyleSheet passthrough.
 vi.mock('react-native', () => ({
   StyleSheet: { create: (styles: unknown) => styles },
   View: ({ children, accessibilityLabel }: { children?: ReactNode; accessibilityLabel?: string }) =>
     createElement('div', { 'data-a11y': accessibilityLabel }, children),
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
 
 // Icon → a span exposing the glyph name + size + colour so we can assert which
@@ -95,5 +97,33 @@ describe('ClimbAttributeIcons', () => {
     // characteristics=[] (no no_match token) takes precedence over isNoMatch=true
     const { container } = render(<ClimbAttributeIcons characteristics={[]} isNoMatch />);
     expect(icons(container)).toEqual([]);
+  });
+
+  const badgeTexts = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('span:not([data-icon])'))
+      .map((node) => node.textContent)
+      .filter((text): text is string => !!text);
+
+  it('renders a "Campus" text badge when characteristics includes campus', () => {
+    const { container } = render(<ClimbAttributeIcons characteristics={['campus']} />);
+    expect(badgeTexts(container)).toEqual(['mobile.climbRow.campus']);
+  });
+
+  it('renders a "No KB" text badge when characteristics includes no_kickboard', () => {
+    const { container } = render(<ClimbAttributeIcons characteristics={['no_kickboard']} />);
+    expect(badgeTexts(container)).toEqual(['mobile.climbRow.noKickboard']);
+  });
+
+  it('joins both badges with " · " when both characteristics are present', () => {
+    const { container } = render(<ClimbAttributeIcons characteristics={['no_kickboard', 'campus']} />);
+    expect(badgeTexts(container)).toEqual(['mobile.climbRow.campus · mobile.climbRow.noKickboard']);
+  });
+
+  it('coexists with no-match and benchmark when all three apply at once', () => {
+    const { container } = render(
+      <ClimbAttributeIcons characteristics={['no_match', 'no_kickboard', 'campus']} benchmarkDifficulty="5" />,
+    );
+    expect(icons(container)).toEqual(['benchmark', 'no.match']);
+    expect(badgeTexts(container)).toEqual(['mobile.climbRow.campus · mobile.climbRow.noKickboard']);
   });
 });

--- a/packages/mobile/src/components/create-climb/CreateDrawer.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawer.tsx
@@ -225,6 +225,10 @@ export function CreateDrawer({
             onChangeDescription={controller.setDescription}
             noMatch={controller.noMatch}
             onChangeNoMatch={controller.setNoMatch}
+            noKickboard={controller.noKickboard}
+            onChangeNoKickboard={controller.setNoKickboard}
+            campus={controller.campus}
+            onChangeCampus={controller.setCampus}
             isDraft={controller.isDraft}
             onChangeIsDraft={controller.setIsDraft}
             showAllHolds={controller.showAllHolds}

--- a/packages/mobile/src/components/create-climb/CreateDrawerForm.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawerForm.tsx
@@ -14,6 +14,10 @@ type CreateDrawerFormProps = {
   onChangeDescription: (next: string) => void;
   noMatch: boolean;
   onChangeNoMatch: (next: boolean) => void;
+  noKickboard: boolean;
+  onChangeNoKickboard: (next: boolean) => void;
+  campus: boolean;
+  onChangeCampus: (next: boolean) => void;
   isDraft: boolean;
   onChangeIsDraft: (next: boolean) => void;
   showAllHolds: boolean;
@@ -31,6 +35,10 @@ export function CreateDrawerForm({
   onChangeDescription,
   noMatch,
   onChangeNoMatch,
+  noKickboard,
+  onChangeNoKickboard,
+  campus,
+  onChangeCampus,
   isDraft,
   onChangeIsDraft,
   showAllHolds,
@@ -72,6 +80,18 @@ export function CreateDrawerForm({
           description={t('mobile.create.settings.noMatchDescription')}
           value={noMatch}
           onValueChange={onChangeNoMatch}
+        />
+        <SwitchRow
+          label={t('mobile.create.settings.noKickboardLabel')}
+          description={t('mobile.create.settings.noKickboardDescription')}
+          value={noKickboard}
+          onValueChange={onChangeNoKickboard}
+        />
+        <SwitchRow
+          label={t('mobile.create.settings.campusLabel')}
+          description={t('mobile.create.settings.campusDescription')}
+          value={campus}
+          onValueChange={onChangeCampus}
         />
         <SwitchRow
           label={t('mobile.create.settings.draftLabel')}

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
@@ -75,6 +75,9 @@ vi.mock('@boardsesh/shared-schema', () => ({
   CLIMB_CHARACTERISTICS: { NO_KICKBOARD: 'no_kickboard', CAMPUS: 'campus', NO_MATCH: 'no_match' },
   hasCharacteristic: (characteristics: string[] | null | undefined, token: string) =>
     !!characteristics && characteristics.includes(token),
+  isNoKickboard: (characteristics: string[] | null | undefined) =>
+    !!characteristics && characteristics.includes('no_kickboard'),
+  isCampus: (characteristics: string[] | null | undefined) => !!characteristics && characteristics.includes('campus'),
   withCharacteristic: (characteristics: string[] | null | undefined, token: string, enabled: boolean) => {
     const current = characteristics ? [...characteristics] : [];
     if (!enabled) return current.filter((existing) => existing !== token);
@@ -200,6 +203,25 @@ describe('useCreateClimbScreen analytics', () => {
     expect(reactQuery.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['searchClimbs'] });
     expect(reactQuery.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['infiniteSearchClimbs'] });
     expect(reactQuery.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['searchClimbsCount'] });
+  });
+
+  it("seeds noKickboard/campus from an existing climb's characteristics in edit mode", async () => {
+    editClimb.data = {
+      uuid: 'existing-toggled-climb',
+      name: 'Existing Toggled',
+      description: '',
+      frames: 'p1r12',
+      is_draft: false,
+      created_at: '2026-01-01T00:00:00.000Z',
+      published_at: '2026-01-02T00:00:00.000Z',
+      characteristics: ['no_kickboard', 'campus'],
+    };
+
+    const { result } = renderScreen('existing-toggled-climb');
+    await waitFor(() => expect(result.current.saveState).toBe('ready'));
+
+    expect(result.current.noKickboard).toBe(true);
+    expect(result.current.campus).toBe(true);
   });
 
   it('fires "Climb Updated" when saving an existing climb in edit mode', async () => {

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
@@ -72,6 +72,14 @@ vi.mock('@tanstack/react-query', () => ({
 vi.mock('@boardsesh/shared-schema', () => ({
   isNoMatchClimb: () => false,
   withNoMatch: (description: string) => description,
+  CLIMB_CHARACTERISTICS: { NO_KICKBOARD: 'no_kickboard', CAMPUS: 'campus', NO_MATCH: 'no_match' },
+  hasCharacteristic: (characteristics: string[] | null | undefined, token: string) =>
+    !!characteristics && characteristics.includes(token),
+  withCharacteristic: (characteristics: string[] | null | undefined, token: string, enabled: boolean) => {
+    const current = characteristics ? [...characteristics] : [];
+    if (!enabled) return current.filter((existing) => existing !== token);
+    return current.includes(token) ? current : [...current, token];
+  },
 }));
 
 vi.mock('@boardsesh/create-climb-react', () => ({

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-angle.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-angle.test.tsx
@@ -68,6 +68,9 @@ vi.mock('@boardsesh/shared-schema', () => ({
   CLIMB_CHARACTERISTICS: { NO_KICKBOARD: 'no_kickboard', CAMPUS: 'campus', NO_MATCH: 'no_match' },
   hasCharacteristic: (characteristics: string[] | null | undefined, token: string) =>
     !!characteristics && characteristics.includes(token),
+  isNoKickboard: (characteristics: string[] | null | undefined) =>
+    !!characteristics && characteristics.includes('no_kickboard'),
+  isCampus: (characteristics: string[] | null | undefined) => !!characteristics && characteristics.includes('campus'),
   withCharacteristic: (characteristics: string[] | null | undefined, token: string, enabled: boolean) => {
     const current = characteristics ? [...characteristics] : [];
     if (!enabled) return current.filter((existing) => existing !== token);

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-angle.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-angle.test.tsx
@@ -65,6 +65,14 @@ vi.mock('@tanstack/react-query', () => ({
 vi.mock('@boardsesh/shared-schema', () => ({
   isNoMatchClimb: () => false,
   withNoMatch: (description: string) => description,
+  CLIMB_CHARACTERISTICS: { NO_KICKBOARD: 'no_kickboard', CAMPUS: 'campus', NO_MATCH: 'no_match' },
+  hasCharacteristic: (characteristics: string[] | null | undefined, token: string) =>
+    !!characteristics && characteristics.includes(token),
+  withCharacteristic: (characteristics: string[] | null | undefined, token: string, enabled: boolean) => {
+    const current = characteristics ? [...characteristics] : [];
+    if (!enabled) return current.filter((existing) => existing !== token);
+    return current.includes(token) ? current : [...current, token];
+  },
 }));
 vi.mock('@boardsesh/create-climb-react', () => ({
   useCreateClimb: () => createClimb,

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
@@ -68,6 +68,9 @@ vi.mock('@boardsesh/shared-schema', () => ({
   CLIMB_CHARACTERISTICS: { NO_KICKBOARD: 'no_kickboard', CAMPUS: 'campus', NO_MATCH: 'no_match' },
   hasCharacteristic: (characteristics: string[] | null | undefined, token: string) =>
     !!characteristics && characteristics.includes(token),
+  isNoKickboard: (characteristics: string[] | null | undefined) =>
+    !!characteristics && characteristics.includes('no_kickboard'),
+  isCampus: (characteristics: string[] | null | undefined) => !!characteristics && characteristics.includes('campus'),
   withCharacteristic: (characteristics: string[] | null | undefined, token: string, enabled: boolean) => {
     const current = characteristics ? [...characteristics] : [];
     if (!enabled) return current.filter((existing) => existing !== token);

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
@@ -65,6 +65,14 @@ vi.mock('react-native', () => ({
 vi.mock('@boardsesh/shared-schema', () => ({
   isNoMatchClimb: () => false,
   withNoMatch: (description: string) => description,
+  CLIMB_CHARACTERISTICS: { NO_KICKBOARD: 'no_kickboard', CAMPUS: 'campus', NO_MATCH: 'no_match' },
+  hasCharacteristic: (characteristics: string[] | null | undefined, token: string) =>
+    !!characteristics && characteristics.includes(token),
+  withCharacteristic: (characteristics: string[] | null | undefined, token: string, enabled: boolean) => {
+    const current = characteristics ? [...characteristics] : [];
+    if (!enabled) return current.filter((existing) => existing !== token);
+    return current.includes(token) ? current : [...current, token];
+  },
 }));
 vi.mock('@boardsesh/create-climb-react', () => ({
   useCreateClimb: () => createClimb,

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
@@ -64,6 +64,14 @@ vi.mock('@boardsesh/shared-schema', () => ({
     if (enabled) return /^no match/i.test(current) ? current : `${NO_MATCH_PREFIX}${current}`;
     return current.replace(/^no match(?:\r?\n|$)/i, '');
   },
+  CLIMB_CHARACTERISTICS: { NO_KICKBOARD: 'no_kickboard', CAMPUS: 'campus', NO_MATCH: 'no_match' },
+  hasCharacteristic: (characteristics: string[] | null | undefined, token: string) =>
+    !!characteristics && characteristics.includes(token),
+  withCharacteristic: (characteristics: string[] | null | undefined, token: string, enabled: boolean) => {
+    const current = characteristics ? [...characteristics] : [];
+    if (!enabled) return current.filter((existing) => existing !== token);
+    return current.includes(token) ? current : [...current, token];
+  },
 }));
 
 vi.mock('@boardsesh/create-climb-react', () => ({
@@ -155,5 +163,31 @@ describe('useCreateClimbScreen handleClear', () => {
     expect(board.saveClimb).toHaveBeenCalledTimes(1);
     const savedDescription = board.saveClimb.mock.calls[0]?.[0]?.description ?? '';
     expect(savedDescription.startsWith('No match')).toBe(false);
+  });
+
+  it('resets the no-kickboard / campus toggles so a brand-new climb starts without either', async () => {
+    board.saveClimb.mockResolvedValue({ uuid: 'fresh-2', createdAt: null, publishedAt: null, isDraft: true });
+
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+
+    act(() => {
+      result.current.setNoKickboard(true);
+      result.current.setCampus(true);
+    });
+    await waitFor(() => expect(result.current.noKickboard).toBe(true));
+    expect(result.current.campus).toBe(true);
+
+    act(() => result.current.handleClear());
+
+    expect(result.current.noKickboard).toBe(false);
+    expect(result.current.campus).toBe(false);
+
+    act(() => result.current.setName('Fresh Problem 2'));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(board.saveClimb).toHaveBeenCalledTimes(1);
+    expect(board.saveClimb.mock.calls[0]?.[0]?.characteristics).toBeNull();
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
@@ -67,6 +67,9 @@ vi.mock('@boardsesh/shared-schema', () => ({
   CLIMB_CHARACTERISTICS: { NO_KICKBOARD: 'no_kickboard', CAMPUS: 'campus', NO_MATCH: 'no_match' },
   hasCharacteristic: (characteristics: string[] | null | undefined, token: string) =>
     !!characteristics && characteristics.includes(token),
+  isNoKickboard: (characteristics: string[] | null | undefined) =>
+    !!characteristics && characteristics.includes('no_kickboard'),
+  isCampus: (characteristics: string[] | null | undefined) => !!characteristics && characteristics.includes('campus'),
   withCharacteristic: (characteristics: string[] | null | undefined, token: string, enabled: boolean) => {
     const current = characteristics ? [...characteristics] : [];
     if (!enabled) return current.filter((existing) => existing !== token);

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
@@ -239,6 +239,25 @@ describe('create-climb queue hand-off carries board identity', () => {
     expect(climb.characteristics).toContain('campus');
   });
 
+  it('keeps the no-match badge alongside campus/no-kickboard in the provisional queue row', () => {
+    // Regression: ClimbAttributeIcons prefers `characteristics` over `is_no_match`
+    // the moment the array is non-null, so a provisional climb that only put
+    // campus/no_kickboard into that array (and left no_match to the separate
+    // is_no_match bool) would silently drop the no-match badge from the queue.
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    act(() => result.current.setName('No Match Campus'));
+    act(() => {
+      result.current.setNoMatch(true);
+      result.current.setCampus(true);
+    });
+    act(() => result.current.handleSetActive());
+
+    const { climb } = lastQueuedItem();
+    expect(climb.is_no_match).toBe(true);
+    expect(climb.characteristics).toEqual(expect.arrayContaining(['no_match', 'campus']));
+  });
+
   it('marks the provisional climb single-frame so playback does not wait on a pace', () => {
     const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
 

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
@@ -210,9 +210,9 @@ describe('create-climb queue hand-off carries board identity', () => {
       await result.current.handleSave();
     });
 
-    expect(board.saveClimb).toHaveBeenCalledWith(
-      expect.objectContaining({ characteristics: ['no_kickboard', 'campus'] }),
-    );
+    const sentCharacteristics = board.saveClimb.mock.calls[0]?.[0]?.characteristics as string[];
+    expect(sentCharacteristics).toHaveLength(2);
+    expect(sentCharacteristics).toEqual(expect.arrayContaining(['no_kickboard', 'campus']));
 
     board.saveClimb.mockClear();
     act(() => {

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
@@ -66,6 +66,14 @@ vi.mock('@tanstack/react-query', () => ({
 vi.mock('@boardsesh/shared-schema', () => ({
   isNoMatchClimb: () => false,
   withNoMatch: (description: string) => description,
+  CLIMB_CHARACTERISTICS: { NO_KICKBOARD: 'no_kickboard', CAMPUS: 'campus', NO_MATCH: 'no_match' },
+  hasCharacteristic: (characteristics: string[] | null | undefined, token: string) =>
+    !!characteristics && characteristics.includes(token),
+  withCharacteristic: (characteristics: string[] | null | undefined, token: string, enabled: boolean) => {
+    const current = characteristics ? [...characteristics] : [];
+    if (!enabled) return current.filter((existing) => existing !== token);
+    return current.includes(token) ? current : [...current, token];
+  },
 }));
 vi.mock('@boardsesh/create-climb-react', () => ({
   useCreateClimb: () => createClimb,
@@ -187,6 +195,48 @@ describe('create-climb queue hand-off carries board identity', () => {
     expect(climb.uuid).toBe('saved-1');
     expect(climb.boardType).toBe('kilter');
     expect(climb.layoutId).toBe(8);
+  });
+
+  it('sends both toggled characteristics to saveClimb, and null when neither is set', async () => {
+    board.saveClimb.mockResolvedValue({ uuid: 'saved-2', createdAt: null, publishedAt: null, isDraft: true });
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    act(() => result.current.setName('Both Toggles'));
+    act(() => {
+      result.current.setNoKickboard(true);
+      result.current.setCampus(true);
+    });
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(board.saveClimb).toHaveBeenCalledWith(
+      expect.objectContaining({ characteristics: ['no_kickboard', 'campus'] }),
+    );
+
+    board.saveClimb.mockClear();
+    act(() => {
+      result.current.setNoKickboard(false);
+      result.current.setCampus(false);
+    });
+    // Re-save as a fresh (unsaved) climb is not exercised here — this hook instance
+    // already has a savedClimb row, so the next save goes through updateClimb.
+    board.updateClimb.mockResolvedValue({ uuid: 'saved-2', createdAt: null, publishedAt: null, isDraft: true });
+    await act(async () => {
+      await result.current.handleSave();
+    });
+    expect(board.updateClimb).toHaveBeenCalledWith(expect.objectContaining({ characteristics: null }));
+  });
+
+  it('carries the campus characteristic through the real boundary', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: kilterBoard }));
+
+    act(() => result.current.setName('Campus Only'));
+    act(() => result.current.setCampus(true));
+    act(() => result.current.handleSetActive());
+
+    const { climb } = lastQueuedItem();
+    expect(climb.characteristics).toContain('campus');
   });
 
   it('marks the provisional climb single-frame so playback does not wait on a pace', () => {

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
@@ -69,6 +69,9 @@ vi.mock('@boardsesh/shared-schema', () => ({
   CLIMB_CHARACTERISTICS: { NO_KICKBOARD: 'no_kickboard', CAMPUS: 'campus', NO_MATCH: 'no_match' },
   hasCharacteristic: (characteristics: string[] | null | undefined, token: string) =>
     !!characteristics && characteristics.includes(token),
+  isNoKickboard: (characteristics: string[] | null | undefined) =>
+    !!characteristics && characteristics.includes('no_kickboard'),
+  isCampus: (characteristics: string[] | null | undefined) => !!characteristics && characteristics.includes('campus'),
   withCharacteristic: (characteristics: string[] | null | undefined, token: string, enabled: boolean) => {
     const current = characteristics ? [...characteristics] : [];
     if (!enabled) return current.filter((existing) => existing !== token);

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -9,7 +9,8 @@ import {
   isNoMatchClimb,
   withNoMatch,
   CLIMB_CHARACTERISTICS,
-  hasCharacteristic,
+  isNoKickboard,
+  isCampus,
   withCharacteristic,
 } from '@boardsesh/shared-schema';
 import {
@@ -273,8 +274,8 @@ export function useCreateClimbScreen({
     setName(editClimb.name);
     setDescription(withNoMatch(editClimb.description ?? '', false));
     setNoMatch(isNoMatchClimb(editClimb.description));
-    setNoKickboard(hasCharacteristic(editClimb.characteristics, CLIMB_CHARACTERISTICS.NO_KICKBOARD));
-    setCampus(hasCharacteristic(editClimb.characteristics, CLIMB_CHARACTERISTICS.CAMPUS));
+    setNoKickboard(isNoKickboard(editClimb.characteristics));
+    setCampus(isCampus(editClimb.characteristics));
     setIsDraft(editClimb.is_draft ?? false);
     setSavedClimb({
       uuid: editClimb.uuid,

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -99,6 +99,22 @@ function buildToggleableCharacteristics(noKickboard: boolean, campus: boolean): 
 }
 
 /**
+ * Same as {@link buildToggleableCharacteristics}, but also folds in no_match —
+ * used only for the LOCAL provisional queue-item display (buildProvisionalClimb),
+ * never for the save/update payload. `ClimbAttributeIcons` prefers the
+ * `characteristics` array over the legacy `is_no_match` bool the moment the array
+ * is non-null, so a provisional row with, say, campus=true and noMatch=true would
+ * otherwise show the campus badge but silently drop the no-match one. The real
+ * saved row doesn't have this problem: the server derives no_match from
+ * `description` independently of the client-supplied `characteristics` field.
+ */
+function buildProvisionalCharacteristics(noMatch: boolean, noKickboard: boolean, campus: boolean): string[] | null {
+  const toggleable = buildToggleableCharacteristics(noKickboard, campus) ?? [];
+  const withNoMatchToken = withCharacteristic(toggleable, CLIMB_CHARACTERISTICS.NO_MATCH, noMatch);
+  return withNoMatchToken.length > 0 ? withNoMatchToken : null;
+}
+
+/**
  * The create-climb screen controller. Composes the shared hold-state machine
  * with auth, the board provider's save/update mutations, the per-board local
  * autosave, BLE preview, and the queue, and exposes a save state machine the
@@ -473,7 +489,7 @@ export function useCreateClimbScreen({
       difficulty_error: '0',
       benchmark_difficulty: null,
       is_no_match: noMatch,
-      characteristics: buildToggleableCharacteristics(noKickboard, campus),
+      characteristics: buildProvisionalCharacteristics(noMatch, noKickboard, campus),
       // Not-yet-saved climbs are drafts by definition; once saved, mirror the
       // tracked row so a published climb doesn't queue as a draft.
       is_draft: savedClimb?.isDraft ?? true,

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -189,6 +189,7 @@ export function useCreateClimbScreen({
   // param exists, unlike forkFrames/forkName/forkDescription) — a pre-existing,
   // acceptable gap consistent with how forking already works for everything except
   // no_match, which rides in the description text. Both default false on a fork.
+  // Tracked in https://github.com/boardsesh/boardsesh/issues/4832.
   const [noKickboard, setNoKickboard] = useState(false);
   const [campus, setCampus] = useState(false);
   const [isDraft, setIsDraft] = useState(true);

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -5,7 +5,13 @@ import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
-import { isNoMatchClimb, withNoMatch } from '@boardsesh/shared-schema';
+import {
+  isNoMatchClimb,
+  withNoMatch,
+  CLIMB_CHARACTERISTICS,
+  hasCharacteristic,
+  withCharacteristic,
+} from '@boardsesh/shared-schema';
 import {
   useCreateClimb,
   computeCanUpdate,
@@ -80,6 +86,19 @@ function readDuplicateExtensions(err: unknown): PublishDuplicateError {
 }
 
 /**
+ * Compute the full desired boolean state of the freely-toggleable climb
+ * characteristics (no_kickboard / campus) from the editor's two switches. The
+ * server merges this array onto whatever else is already on the row (no_match,
+ * MoonBoard method tokens), so only these two tokens are ever represented here.
+ */
+function buildToggleableCharacteristics(noKickboard: boolean, campus: boolean): string[] | null {
+  let characteristics: string[] = [];
+  characteristics = withCharacteristic(characteristics, CLIMB_CHARACTERISTICS.NO_KICKBOARD, noKickboard);
+  characteristics = withCharacteristic(characteristics, CLIMB_CHARACTERISTICS.CAMPUS, campus);
+  return characteristics.length > 0 ? characteristics : null;
+}
+
+/**
  * The create-climb screen controller. Composes the shared hold-state machine
  * with auth, the board provider's save/update mutations, the per-board local
  * autosave, BLE preview, and the queue, and exposes a save state machine the
@@ -149,6 +168,12 @@ export function useCreateClimbScreen({
   // save time, so the editable description field stays clean and the toggle never
   // gets stuck on a fuzzy match. A follow-up migrates this to a real column.
   const [noMatch, setNoMatch] = useState(isForking && forkDescription ? isNoMatchClimb(forkDescription) : false);
+  // Forking doesn't currently carry characteristics through (no forkCharacteristics
+  // param exists, unlike forkFrames/forkName/forkDescription) — a pre-existing,
+  // acceptable gap consistent with how forking already works for everything except
+  // no_match, which rides in the description text. Both default false on a fork.
+  const [noKickboard, setNoKickboard] = useState(false);
+  const [campus, setCampus] = useState(false);
   const [isDraft, setIsDraft] = useState(true);
   const [showAllHolds, setShowAllHolds] = useState(false);
 
@@ -232,6 +257,8 @@ export function useCreateClimbScreen({
     setName(editClimb.name);
     setDescription(withNoMatch(editClimb.description ?? '', false));
     setNoMatch(isNoMatchClimb(editClimb.description));
+    setNoKickboard(hasCharacteristic(editClimb.characteristics, CLIMB_CHARACTERISTICS.NO_KICKBOARD));
+    setCampus(hasCharacteristic(editClimb.characteristics, CLIMB_CHARACTERISTICS.CAMPUS));
     setIsDraft(editClimb.is_draft ?? false);
     setSavedClimb({
       uuid: editClimb.uuid,
@@ -265,6 +292,8 @@ export function useCreateClimbScreen({
       setName(draft.name);
       setDescription(withNoMatch(draft.description, false));
       setNoMatch(isNoMatchClimb(draft.description));
+      setNoKickboard(draft.noKickboard ?? false);
+      setCampus(draft.campus ?? false);
       setIsDraft(draft.isDraft);
       restoredRef.current = true;
     });
@@ -307,6 +336,8 @@ export function useCreateClimbScreen({
       name,
       description: withNoMatch(description, noMatch),
       isDraft,
+      noKickboard,
+      campus,
     };
     // Mirror the latest payload so a flush (unmount/background) can persist the
     // pending edit even before the debounce fires.
@@ -321,7 +352,19 @@ export function useCreateClimbScreen({
       pendingDraftRef.current.dirty = false;
     }, AUTOSAVE_DEBOUNCE_MS);
     return () => clearTimeout(handle);
-  }, [holdsJson, framesJson, frameCount, name, description, noMatch, isDraft, draftKey, autosaveDisabled]);
+  }, [
+    holdsJson,
+    framesJson,
+    frameCount,
+    name,
+    description,
+    noMatch,
+    noKickboard,
+    campus,
+    isDraft,
+    draftKey,
+    autosaveDisabled,
+  ]);
 
   // ---- Flush the pending draft on unmount / background. ----
   // JS timers are suspended when the app is backgrounded and the cleanup's
@@ -382,6 +425,8 @@ export function useCreateClimbScreen({
     setName('');
     setDescription('');
     setNoMatch(false);
+    setNoKickboard(false);
+    setCampus(false);
     setIsDraft(true);
     setSavedClimb(null);
     setPublishDuplicateError(null);
@@ -428,6 +473,7 @@ export function useCreateClimbScreen({
       difficulty_error: '0',
       benchmark_difficulty: null,
       is_no_match: noMatch,
+      characteristics: buildToggleableCharacteristics(noKickboard, campus),
       // Not-yet-saved climbs are drafts by definition; once saved, mirror the
       // tracked row so a published climb doesn't queue as a draft.
       is_draft: savedClimb?.isDraft ?? true,
@@ -439,7 +485,20 @@ export function useCreateClimbScreen({
       // DEFAULT_PACE_MS whenever framesPace isn't a positive number.
       framesPace: null,
     }),
-    [name, description, noMatch, profile, savedClimb, board.angle, board.boardName, board.layoutId, t, frameCount],
+    [
+      name,
+      description,
+      noMatch,
+      noKickboard,
+      campus,
+      profile,
+      savedClimb,
+      board.angle,
+      board.boardName,
+      board.layoutId,
+      t,
+      frameCount,
+    ],
   );
 
   // Push the freshly saved climb into the queue as the current climb so the
@@ -516,6 +575,7 @@ export function useCreateClimbScreen({
     // to the same name via the shared board-constants table. PostHog groups by
     // exact value, so the string must match web for these create-climb events.
     const boardLayout = getLayoutName(board.boardName, board.layoutId);
+    const characteristics = buildToggleableCharacteristics(noKickboard, campus);
     try {
       if (canUpdate && savedClimb) {
         const result = await updateClimb({
@@ -528,6 +588,7 @@ export function useCreateClimbScreen({
           framesCount: frameCount,
           framesPace: 0,
           isDraft,
+          characteristics,
         });
         setSavedClimb({
           uuid: result.uuid,
@@ -555,6 +616,7 @@ export function useCreateClimbScreen({
           frames_count: frameCount,
           frames_pace: 0,
           angle: board.angle,
+          characteristics,
         });
         setSavedClimb({
           uuid: result.uuid,
@@ -618,6 +680,8 @@ export function useCreateClimbScreen({
     board,
     description,
     noMatch,
+    noKickboard,
+    campus,
     isDraft,
     draftKey,
     requestFocusName,
@@ -666,6 +730,10 @@ export function useCreateClimbScreen({
     setIsDraft,
     noMatch,
     setNoMatch,
+    noKickboard,
+    setNoKickboard,
+    campus,
+    setCampus,
     // save
     saveState,
     handleSave,

--- a/packages/mobile/src/lib/create-climb-draft-store.ts
+++ b/packages/mobile/src/lib/create-climb-draft-store.ts
@@ -22,6 +22,11 @@ export type CreateClimbDraft = {
   name: string;
   description: string;
   isDraft: boolean;
+  /** "No kickboard" toggle — feet allowed, kickboard off-limits. Optional so old
+   *  persisted drafts without it still pass the type guard and default to false. */
+  noKickboard?: boolean;
+  /** "Campus" toggle — no feet at all. Optional for the same back-compat reason. */
+  campus?: boolean;
 };
 
 const KEY_PREFIX = 'boardsesh_create_climb_draft:';

--- a/packages/shared-schema/src/__tests__/characteristics.test.ts
+++ b/packages/shared-schema/src/__tests__/characteristics.test.ts
@@ -3,6 +3,8 @@ import {
   CLIMB_CHARACTERISTICS,
   hasCharacteristic,
   isNoMatch,
+  isNoKickboard,
+  isCampus,
   getMoonBoardMethod,
   withCharacteristic,
   isMethodCharacteristic,
@@ -23,6 +25,24 @@ describe('hasCharacteristic / isNoMatch', () => {
   });
 });
 
+describe('isNoKickboard / isCampus', () => {
+  it('detects the new independent toggle tokens', () => {
+    expect(isNoKickboard(['no_kickboard'])).toBe(true);
+    expect(isNoKickboard(['campus'])).toBe(false);
+    expect(isCampus(['campus'])).toBe(true);
+    expect(isCampus(['no_kickboard'])).toBe(false);
+  });
+
+  it('handles null/undefined/empty', () => {
+    expect(isNoKickboard(null)).toBe(false);
+    expect(isNoKickboard(undefined)).toBe(false);
+    expect(isNoKickboard([])).toBe(false);
+    expect(isCampus(null)).toBe(false);
+    expect(isCampus(undefined)).toBe(false);
+    expect(isCampus([])).toBe(false);
+  });
+});
+
 describe('getMoonBoardMethod', () => {
   it('returns the single method token, or null for the default', () => {
     expect(getMoonBoardMethod(['method_footless'])).toBe('method_footless');
@@ -38,6 +58,11 @@ describe('isMethodCharacteristic', () => {
     expect(isMethodCharacteristic('method_footless')).toBe(true);
     expect(isMethodCharacteristic('method_no_kickboard')).toBe(true);
     expect(isMethodCharacteristic('no_match')).toBe(false);
+  });
+
+  it('the new independent toggle tokens are not methods', () => {
+    expect(isMethodCharacteristic('no_kickboard')).toBe(false);
+    expect(isMethodCharacteristic('campus')).toBe(false);
   });
 });
 
@@ -66,6 +91,26 @@ describe('withCharacteristic', () => {
   it('handles null/undefined input', () => {
     expect(withCharacteristic(null, CLIMB_CHARACTERISTICS.NO_MATCH, true)).toEqual(['no_match']);
     expect(withCharacteristic(undefined, CLIMB_CHARACTERISTICS.METHOD_FOOTLESS, true)).toEqual(['method_footless']);
+  });
+
+  it('no_kickboard/campus survive enabling a method_* token (not in the mutual-exclusivity set)', () => {
+    expect(withCharacteristic(['no_kickboard', 'campus'], CLIMB_CHARACTERISTICS.METHOD_FOOTLESS, true)).toEqual([
+      'no_kickboard',
+      'campus',
+      'method_footless',
+    ]);
+  });
+
+  it('enabling no_kickboard and campus together keeps both (no mutual exclusion between them)', () => {
+    let characteristics = withCharacteristic([], CLIMB_CHARACTERISTICS.NO_KICKBOARD, true);
+    characteristics = withCharacteristic(characteristics, CLIMB_CHARACTERISTICS.CAMPUS, true);
+    expect(characteristics).toEqual(['no_kickboard', 'campus']);
+  });
+
+  it('toggles no_kickboard/campus off independently of each other and of method tokens', () => {
+    const start = ['method_footless', 'no_kickboard', 'campus'];
+    expect(withCharacteristic(start, CLIMB_CHARACTERISTICS.NO_KICKBOARD, false)).toEqual(['method_footless', 'campus']);
+    expect(withCharacteristic(start, CLIMB_CHARACTERISTICS.CAMPUS, false)).toEqual(['method_footless', 'no_kickboard']);
   });
 });
 

--- a/packages/shared-schema/src/characteristics.ts
+++ b/packages/shared-schema/src/characteristics.ts
@@ -14,6 +14,10 @@
 export const CLIMB_CHARACTERISTICS = {
   /** Matching (both hands on the same hold) is disallowed. Aurora convention. */
   NO_MATCH: 'no_match',
+  /** Feet may be used, but not the kickboard. Independent toggle — any board type. */
+  NO_KICKBOARD: 'no_kickboard',
+  /** No feet allowed at all (hands only). Independent toggle — any board type. */
+  CAMPUS: 'campus',
   /** MoonBoard "Footless": no foot holds, kickboard not used. */
   METHOD_FOOTLESS: 'method_footless',
   /** MoonBoard "Footless + kickboard": no foot holds, the kickboard may be used. */
@@ -51,6 +55,27 @@ export function hasCharacteristic(
 export function isNoMatch(characteristics: readonly string[] | null | undefined): boolean {
   return hasCharacteristic(characteristics, CLIMB_CHARACTERISTICS.NO_MATCH);
 }
+
+/** Whether this climb disallows the kickboard as a foot hold. */
+export function isNoKickboard(characteristics: readonly string[] | null | undefined): boolean {
+  return hasCharacteristic(characteristics, CLIMB_CHARACTERISTICS.NO_KICKBOARD);
+}
+
+/** Whether this climb is campus-only (no feet at all). */
+export function isCampus(characteristics: readonly string[] | null | undefined): boolean {
+  return hasCharacteristic(characteristics, CLIMB_CHARACTERISTICS.CAMPUS);
+}
+
+/**
+ * Tokens that are freely toggleable and independent of each other (unlike the
+ * mutually-exclusive METHOD_* group). A client sends the full desired boolean
+ * state of each of these; the server merges them in without touching any other
+ * characteristic (no_match, MoonBoard method) already on the row.
+ */
+export const TOGGLEABLE_CLIMB_CHARACTERISTICS = [
+  CLIMB_CHARACTERISTICS.NO_KICKBOARD,
+  CLIMB_CHARACTERISTICS.CAMPUS,
+] as const;
 
 /** The MoonBoard method token on a climb, or null for the "feet follow hands" default. */
 export function getMoonBoardMethod(characteristics: readonly string[] | null | undefined): ClimbCharacteristic | null {

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -4670,6 +4670,8 @@ input SaveClimbInput {
   framesCount: Int
   framesPace: Int
   angle: Int!
+  "Freely-toggleable characteristics to set at creation. Only CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS are accepted here — no_match is server-derived from description, and MoonBoard method is creation-time-only via SaveMoonBoardClimbInput."
+  characteristics: [String!]
 }
 
 """
@@ -4726,6 +4728,8 @@ input UpdateClimbInput {
   isDraft: Boolean
   framesCount: Int
   framesPace: Int
+  "Freely-toggleable characteristics: the full desired boolean state of CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS. Any other characteristic already on the row (no_match, MoonBoard method) is left untouched."
+  characteristics: [String!]
 }
 
 type UpdateClimbResult {

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -6368,6 +6368,8 @@ export type SaveAuroraCredentialInput = {
 export type SaveClimbInput = {
   angle: Scalars['Int']['input'];
   boardType: Scalars['String']['input'];
+  /** Freely-toggleable characteristics to set at creation. Only CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS are accepted here — no_match is server-derived from description, and MoonBoard method is creation-time-only via SaveMoonBoardClimbInput. */
+  characteristics?: InputMaybe<Array<Scalars['String']['input']>>;
   description?: InputMaybe<Scalars['String']['input']>;
   frames: Scalars['String']['input'];
   framesCount?: InputMaybe<Scalars['Int']['input']>;
@@ -7757,6 +7759,8 @@ export type UpdateBoardInput = {
 export type UpdateClimbInput = {
   angle?: InputMaybe<Scalars['Int']['input']>;
   boardType: Scalars['String']['input'];
+  /** Freely-toggleable characteristics: the full desired boolean state of CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS. Any other characteristic already on the row (no_match, MoonBoard method) is left untouched. */
+  characteristics?: InputMaybe<Array<Scalars['String']['input']>>;
   description?: InputMaybe<Scalars['String']['input']>;
   frames?: InputMaybe<Scalars['String']['input']>;
   framesCount?: InputMaybe<Scalars['Int']['input']>;

--- a/packages/shared-schema/src/schema/new-climb-feed.ts
+++ b/packages/shared-schema/src/schema/new-climb-feed.ts
@@ -81,6 +81,8 @@ export const newClimbFeedTypeDefs = /* GraphQL */ `
     framesCount: Int
     framesPace: Int
     angle: Int!
+    "Freely-toggleable characteristics to set at creation. Only CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS are accepted here — no_match is server-derived from description, and MoonBoard method is creation-time-only via SaveMoonBoardClimbInput."
+    characteristics: [String!]
   }
 
   """
@@ -137,6 +139,8 @@ export const newClimbFeedTypeDefs = /* GraphQL */ `
     isDraft: Boolean
     framesCount: Int
     framesPace: Int
+    "Freely-toggleable characteristics: the full desired boolean state of CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS. Any other characteristic already on the row (no_match, MoonBoard method) is left untouched."
+    characteristics: [String!]
   }
 
   type UpdateClimbResult {

--- a/packages/shared-schema/src/types/climb.ts
+++ b/packages/shared-schema/src/types/climb.ts
@@ -247,6 +247,11 @@ export type SaveClimbInput = {
   framesCount?: number | null;
   framesPace?: number | null;
   angle: number;
+  // Freely-toggleable characteristics to set at creation. Only
+  // CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS are accepted here — no_match is
+  // server-derived from description, and MoonBoard method is creation-time-only
+  // via SaveMoonBoardClimbInput.
+  characteristics?: string[] | null;
 };
 
 export type SaveMoonBoardClimbInput = {
@@ -293,6 +298,10 @@ export type UpdateClimbInput = {
   isDraft?: boolean | null;
   framesCount?: number | null;
   framesPace?: number | null;
+  // Freely-toggleable characteristics: the full desired boolean state of
+  // CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS. Any other characteristic
+  // already on the row (no_match, MoonBoard method) is left untouched.
+  characteristics?: string[] | null;
 };
 
 export type UpdateClimbResult = {

--- a/packages/shared/board-react/src/__tests__/climb-helpers.test.ts
+++ b/packages/shared/board-react/src/__tests__/climb-helpers.test.ts
@@ -25,12 +25,18 @@ describe('toSaveClimbInput', () => {
       framesCount: 1,
       framesPace: 0,
       angle: 40,
+      characteristics: null,
     });
   });
 
   it('defaults a missing description to an empty string', () => {
     const result = toSaveClimbInput('tension', { ...options, description: '' });
     expect(result.description).toBe('');
+  });
+
+  it('passes through explicit characteristics', () => {
+    const result = toSaveClimbInput('kilter', { ...options, characteristics: ['no_kickboard', 'campus'] });
+    expect(result.characteristics).toEqual(['no_kickboard', 'campus']);
   });
 });
 

--- a/packages/shared/board-react/src/climb-helpers.ts
+++ b/packages/shared/board-react/src/climb-helpers.ts
@@ -13,6 +13,8 @@ export type SaveClimbOptions = {
   frames_count?: number;
   frames_pace?: number;
   angle: number;
+  // Freely-toggleable characteristics to set at creation (no_kickboard / campus).
+  characteristics?: string[] | null;
 };
 
 export type SaveClimbResponse = {
@@ -40,6 +42,7 @@ export function toSaveClimbInput(boardName: BoardName, options: SaveClimbOptions
     framesCount: options.frames_count,
     framesPace: options.frames_pace,
     angle: options.angle,
+    characteristics: options.characteristics ?? null,
   };
 }
 

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -6365,6 +6365,8 @@ export type SaveAuroraCredentialInput = {
 export type SaveClimbInput = {
   angle: Scalars['Int']['input'];
   boardType: Scalars['String']['input'];
+  /** Freely-toggleable characteristics to set at creation. Only CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS are accepted here — no_match is server-derived from description, and MoonBoard method is creation-time-only via SaveMoonBoardClimbInput. */
+  characteristics?: InputMaybe<Array<Scalars['String']['input']>>;
   description?: InputMaybe<Scalars['String']['input']>;
   frames: Scalars['String']['input'];
   framesCount?: InputMaybe<Scalars['Int']['input']>;
@@ -7754,6 +7756,8 @@ export type UpdateBoardInput = {
 export type UpdateClimbInput = {
   angle?: InputMaybe<Scalars['Int']['input']>;
   boardType: Scalars['String']['input'];
+  /** Freely-toggleable characteristics: the full desired boolean state of CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS. Any other characteristic already on the row (no_match, MoonBoard method) is left untouched. */
+  characteristics?: InputMaybe<Array<Scalars['String']['input']>>;
   description?: InputMaybe<Scalars['String']['input']>;
   frames?: InputMaybe<Scalars['String']['input']>;
   framesCount?: InputMaybe<Scalars['Int']['input']>;

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -465,6 +465,8 @@
         "attempt": "Versucht"
       },
       "noMatch": "Kein Matchen",
+      "campus": "Campus",
+      "noKickboard": "Ohne FL",
       "benchmark": "Benchmark",
       "method": {
         "footless": "Ohne Füße",
@@ -522,7 +524,11 @@
         "showAllHoldsLabel": "Alle Griffe zeigen",
         "showAllHoldsDescription": "Hebt jeden antippbaren Griff auf dem Board hervor.",
         "noMatchLabel": "Kein Matchen",
-        "noMatchDescription": "Hände dürfen nicht am selben Griff matchen"
+        "noMatchDescription": "Hände dürfen nicht am selben Griff matchen",
+        "noKickboardLabel": "Ohne Fußleiste",
+        "noKickboardDescription": "Füße dürfen die Fußleiste nicht benutzen",
+        "campusLabel": "Campus (ohne Füße)",
+        "campusDescription": "Nur Hände, keine Füße"
       },
       "drafts": {
         "holds_one": "{{count}} Griff",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -465,6 +465,8 @@
         "attempt": "Tried"
       },
       "noMatch": "No matching",
+      "campus": "Campus",
+      "noKickboard": "No KB",
       "benchmark": "Benchmark",
       "method": {
         "footless": "Footless",
@@ -522,7 +524,11 @@
         "showAllHoldsLabel": "Show all holds",
         "showAllHoldsDescription": "Highlight every tappable hold on the board.",
         "noMatchLabel": "No matching",
-        "noMatchDescription": "Hands can't match on the same hold"
+        "noMatchDescription": "Hands can't match on the same hold",
+        "noKickboardLabel": "No kickboard",
+        "noKickboardDescription": "Feet can't use the kickboard",
+        "campusLabel": "Campus (no feet)",
+        "campusDescription": "Hands only — no feet allowed"
       },
       "drafts": {
         "holds_one": "{{count}} hold",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -465,6 +465,8 @@
         "attempt": "Intentado"
       },
       "noMatch": "Sin igualar",
+      "campus": "Campus",
+      "noKickboard": "Sin repisa",
       "benchmark": "Benchmark",
       "method": {
         "footless": "Sin pies",
@@ -522,7 +524,11 @@
         "showAllHoldsLabel": "Mostrar todas las presas",
         "showAllHoldsDescription": "Resalta todas las presas pulsables del panel.",
         "noMatchLabel": "Sin igualar",
-        "noMatchDescription": "No se pueden igualar las manos en la misma presa"
+        "noMatchDescription": "No se pueden igualar las manos en la misma presa",
+        "noKickboardLabel": "Sin repisa inferior",
+        "noKickboardDescription": "Los pies no pueden apoyarse en la repisa inferior",
+        "campusLabel": "Campus (sin pies)",
+        "campusDescription": "Solo manos, sin apoyar los pies"
       },
       "drafts": {
         "holds_one": "{{count}} presa",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -525,8 +525,8 @@
         "showAllHoldsDescription": "Met en évidence chaque prise cliquable de la board.",
         "noMatchLabel": "Une main par prise",
         "noMatchDescription": "Les mains ne peuvent pas se rejoindre sur la même prise",
-        "noKickboardLabel": "Sans planche du bas",
-        "noKickboardDescription": "Les pieds ne peuvent pas utiliser la planche du bas",
+        "noKickboardLabel": "Sans kickboard",
+        "noKickboardDescription": "Les pieds ne peuvent pas utiliser le kickboard",
         "campusLabel": "Campus (sans pieds)",
         "campusDescription": "Mains seulement, sans les pieds"
       },

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -466,7 +466,7 @@
       },
       "noMatch": "Une main par prise",
       "campus": "Campus",
-      "noKickboard": "Sans planche",
+      "noKickboard": "Sans KB",
       "benchmark": "Benchmark",
       "method": {
         "footless": "Sans pieds",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -465,6 +465,8 @@
         "attempt": "Essayé"
       },
       "noMatch": "Une main par prise",
+      "campus": "Campus",
+      "noKickboard": "Sans planche",
       "benchmark": "Benchmark",
       "method": {
         "footless": "Sans pieds",
@@ -522,7 +524,11 @@
         "showAllHoldsLabel": "Afficher toutes les prises",
         "showAllHoldsDescription": "Met en évidence chaque prise cliquable de la board.",
         "noMatchLabel": "Une main par prise",
-        "noMatchDescription": "Les mains ne peuvent pas se rejoindre sur la même prise"
+        "noMatchDescription": "Les mains ne peuvent pas se rejoindre sur la même prise",
+        "noKickboardLabel": "Sans planche du bas",
+        "noKickboardDescription": "Les pieds ne peuvent pas utiliser la planche du bas",
+        "campusLabel": "Campus (sans pieds)",
+        "campusDescription": "Mains seulement, sans les pieds"
       },
       "drafts": {
         "holds_one": "{{count}} prise",

--- a/packages/web/app/hooks/__tests__/use-save-climb.test.ts
+++ b/packages/web/app/hooks/__tests__/use-save-climb.test.ts
@@ -183,6 +183,7 @@ describe('useSaveClimb', () => {
           framesCount: 1,
           framesPace: 0,
           angle: 40,
+          characteristics: null,
         },
       },
     });


### PR DESCRIPTION
## Summary

Adds two new climb rule toggles alongside the existing "no matching" one when creating or editing a climb on mobile: **no kickboard** and **campus** (no feet at all). Both are freely toggleable and editable any time you edit the climb, the same way no-matching already works.

Under the hood, these ride the existing `board_climbs.characteristics` array (`no_kickboard` / `campus` tokens), independent of each other and of MoonBoard's existing `method` field (footless/no-kickboard/footless+kickboard), which already covers the same concepts for MoonBoard problems and is untouched by this PR.

Scope for this PR: Kilter/Tension, mobile only. Web doesn't have a no-matching toggle in the create-climb form either today, so parity there is a separate follow-up.

## Release Notes

- Tag climbs as "no kickboard" or "campus" (no feet) right in the climb editor, alongside no-matching.

## Test plan

- `vp run typecheck:backend`, `vp run typecheck:shared`, `vp run typecheck:mobile` — clean
- `vp test run --project backend --reporter=agent` — green (new saveClimb/updateClimb coverage: creating with the new tokens, merging a toggle onto an existing no_match row, composing a description-driven no_match flip with a client-supplied toggle in the same call, clearing toggles via an empty/`null` array)
- `vp test run --project mobile --reporter=agent` — green (toggle state through edit-mode seeding, local-draft autosave/restore, Clear, the queue hand-off, and the read-only badge display)
- `vp test run --project web --reporter=agent`, `vp run check:i18n` — green
- `vp check` — clean (all remaining lint items are pre-existing, unrelated to this diff)
- Manually traced: an explicit `characteristics: null` (what the client always sends when both toggles are off) round-trips through validation and the resolver correctly — caught and fixed a bug in review where the zod schema's `.optional()` alone rejected that literal `null`, which would have 400'd every ordinary climb save/update, not just ones touching these two toggles.