### PR TITLE
feat(mobile): draw the Boardsesh render mode natively, behind a probe and a settings model

### DIFF
--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-boardsesh.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-boardsesh.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
-import { getWallLightness } from '@boardsesh/board-art-geometry';
+import { getWallLightness, loadBoardArtGeometry } from '@boardsesh/board-art-geometry';
 
 // Issue #2202: the Boardsesh drawing — a wash of the play field over the unlit
 // wall, a glow clipped to each lit hold's traced silhouette, and a HAND blue
@@ -433,6 +433,126 @@ describe('per-hold geometry', () => {
   });
 });
 
+describe('per-hold geometry, joined against the real shard data', () => {
+  // Every case above proves withLitHoldGeometry's `geometry.outlines[hold.id]`
+  // lookup against hand-picked mock holds, mocked through `getBoardRenderData`.
+  // Both the mock ids and the shard's ids come from fixtures written for this
+  // file, so a mismatch between the two REAL catalogues — the placement ids
+  // `@boardsesh/board-constants` hands out and the ids
+  // `@boardsesh/board-art-geometry` traced outlines against — would still
+  // pass. This proves the same lookup with the real `getBoardRenderData` and
+  // the real shards.
+  //
+  // Tension Board 2 Mirror 12x12 (tension, layout 10, size 6 — the same
+  // `TB2_MIRROR` fixture the veil tests below use) is fully traced today
+  // (498/498, per the generated `outline-counts` table), so any two of its
+  // real placement ids are traced ones. Kilter's `1-10` (12x12 with
+  // kickboard) is fully traced too (476/476) — the real board with untraced
+  // placements today is Kilter's `1-7` (12 x 14, Commercial: 476/527, 51
+  // untraced), so that shard stands in for the "lit but untraced" case.
+  // `TB2_MIRROR.setIds` ('20') is only ever fed to the MOCKED
+  // `getBoardRenderData` elsewhere in this file, so it was never checked
+  // against a real set for this layout+size — set 12 is ('10-6-12' in the
+  // generated product-sizes table).
+  const TB2_MIRROR_REAL_SET_IDS = '12';
+  const KILTER_UNTRACED = { boardName: 'kilter' as const, layoutId: 1, sizeId: 7, setIds: '1,20' };
+
+  // The board-details module is mocked at the top of this file, so
+  // `_getBoardConfigForTests` never reaches the real `getBoardRenderData`
+  // unless the mock is told to hand it back. `vi.importActual` gets the real
+  // implementation past that mock for these two cases only; loading it once
+  // up front and pinning it with `mockReturnValue` (rather than delegating
+  // through `mockImplementation`, whose declared type here is the zero-arg
+  // canned-fixture shape every other case in this file uses) sidesteps that
+  // mismatch entirely, since a fixed return value never needs a matching
+  // parameter list.
+  async function loadRealRenderData(query: {
+    boardName: 'tension' | 'kilter';
+    layoutId: number;
+    sizeId: number;
+    setIds: number[];
+  }): Promise<{ holdsData: { id: number }[] }> {
+    const actual = await vi.importActual<typeof import('../../lib/board-details')>('../../lib/board-details');
+    const renderData = actual.getBoardRenderData(query);
+    if (renderData === null) throw new Error(`no real render data for ${JSON.stringify(query)}`);
+    getBoardRenderDataMock.mockReturnValue(renderData);
+    return renderData;
+  }
+
+  function expectRealOutline(litHold: Record<string, unknown>): void {
+    expect(Array.isArray(litHold.outline)).toBe(true);
+    const outline = litHold.outline as number[];
+    expect(outline.length % 2).toBe(0);
+    expect(outline.length).toBeGreaterThanOrEqual(6);
+    expect(outline.every((coordinate) => Number.isFinite(coordinate))).toBe(true);
+  }
+
+  it('attaches the real traced outline on Tension Board 2 Mirror 12x12, and nothing on an unlit hold', async () => {
+    const geometry = loadBoardArtGeometry(TB2_MIRROR);
+    expect(geometry).not.toBeNull();
+
+    const { holdsData } = await loadRealRenderData({
+      boardName: TB2_MIRROR.boardName,
+      layoutId: TB2_MIRROR.layoutId,
+      sizeId: TB2_MIRROR.sizeId,
+      setIds: [Number(TB2_MIRROR_REAL_SET_IDS)],
+    });
+    expect(holdsData.length).toBeGreaterThan(2);
+
+    // Fully traced (498/498): any two real ids are traced ones.
+    const [litA, litB, unlit] = holdsData;
+    expect(geometry?.outlines[litA.id]).toBeDefined();
+    expect(geometry?.outlines[litB.id]).toBeDefined();
+
+    const configBase = buildConfig(
+      { ...TB2_MIRROR, setIds: TB2_MIRROR_REAL_SET_IDS },
+      {
+        frames: `p${litA.id}r2p${litB.id}r2`,
+        boardsesh: boardseshInputs(),
+        renderSignature: 'real-shard-tb2-mirror',
+      },
+    );
+
+    expectRealOutline(holdById(configBase, litA.id));
+    expectRealOutline(holdById(configBase, litB.id));
+    // A real placement this climb does not light gets no outline at all.
+    expect('outline' in holdById(configBase, unlit.id)).toBe(false);
+  });
+
+  it('leaves a real untraced Kilter placement without an outline, even when it is lit', async () => {
+    const geometry = loadBoardArtGeometry(KILTER_UNTRACED);
+    expect(geometry).not.toBeNull();
+
+    const { holdsData } = await loadRealRenderData({
+      boardName: KILTER_UNTRACED.boardName,
+      layoutId: KILTER_UNTRACED.layoutId,
+      sizeId: KILTER_UNTRACED.sizeId,
+      setIds: [1, 20],
+    });
+
+    const traced = holdsData.filter((hold) => geometry?.outlines[hold.id] !== undefined);
+    const untracedHold = holdsData.find((hold) => geometry?.outlines[hold.id] === undefined);
+    expect(traced.length).toBeGreaterThanOrEqual(2);
+    // The 51 untraced placements gate-4 pins for this shard (527 - 476): at
+    // least one real id the tracer skipped.
+    expect(untracedHold).toBeDefined();
+    const untracedId = (untracedHold as { id: number }).id;
+
+    const [tracedA, tracedB] = traced;
+    const configBase = buildConfig(KILTER_UNTRACED, {
+      frames: `p${tracedA.id}r43p${tracedB.id}r43p${untracedId}r43`,
+      boardsesh: boardseshInputs(),
+      renderSignature: 'real-shard-kilter-untraced',
+    });
+
+    expectRealOutline(holdById(configBase, tracedA.id));
+    expectRealOutline(holdById(configBase, tracedB.id));
+    // Lit, but no traced art: the renderer's own ring fallback, not a
+    // fabricated outline.
+    expect('outline' in holdById(configBase, untracedId)).toBe(false);
+  });
+});
+
 describe('the veil, measured against the real shards', () => {
   it.each([
     ['Tension Board 2 Mirror 12x12', TB2_MIRROR],
@@ -453,14 +573,14 @@ describe('the veil, measured against the real shards', () => {
 describe('the cache key', () => {
   const CLIMB = { boardName: 'grasshopper', layoutId: 1, sizeId: 5, setIds: '1' };
 
-  function keyFor(boardSignature: string): string {
+  function keyFor(boardSignature: string, frames: string = GRASSHOPPER_FRAMES): string {
     const composed = ['default', boardSignature].filter(Boolean).join('.');
     return buildCacheKey(
       CLIMB.boardName,
       CLIMB.layoutId,
       CLIMB.sizeId,
       CLIMB.setIds,
-      GRASSHOPPER_FRAMES,
+      frames,
       false,
       undefined,
       composed,
@@ -495,25 +615,80 @@ describe('the cache key', () => {
     expect(keyFor(signatureFor({}))).not.toBe(keyFor(''));
   });
 
-  it.each([
-    ['glowFalloff', { glowFalloff: 'plateau' as const }],
-    ['glowReach', { glowReach: 1.5 }],
-    ['plateauShare', { plateauShare: 0.55 }],
-    ['markStyle', { markStyle: 'fill' as const }],
-    ['fillOpacity', { fillOpacity: 0.8 }],
-    ['softDisc', { softDisc: true }],
-    ['smallHoldBoost', { smallHoldBoost: false }],
-    ['ledDots', { ledDots: false }],
-    ['roleGlyphs', { roleGlyphs: true }],
-    ['thumbnailStyle', { thumbnailStyle: 'glow' as const }],
-  ])('changes when %s changes', (_field, overrides) => {
-    expect(keyFor(signatureFor(overrides))).not.toBe(keyFor(signatureFor({})));
-  });
+  /**
+   * One non-default value per `BoardseshRenderSettings` field, keyed by the
+   * type itself — a 13th field is a compile error here until it is listed, so
+   * the it.each below (driven off `DEFAULT_BOARDSESH_RENDER_SETTINGS`'s own
+   * keys) can never silently skip a token that should split the cache.
+   */
+  const MOVED_OFF_DEFAULT: { [K in keyof BoardseshRenderSettings]: BoardseshRenderSettings[K] } = {
+    glowFalloff: 'plateau',
+    glowReach: 1.2,
+    plateauShare: 0.55,
+    veil: 'strong',
+    veilOpacity: 0.5,
+    markStyle: 'glow-fill',
+    fillOpacity: 0.8,
+    softDisc: true,
+    smallHoldBoost: false,
+    ledDots: false,
+    roleGlyphs: true,
+    thumbnailStyle: 'glow',
+  };
+
+  /**
+   * `veilOpacity` only reaches `resolveVeilOpacity` when `veil` is `'custom'`
+   * — paired here so moving this field alone actually changes the resolved
+   * opacity, rather than silently doing nothing under the still-`'auto'`
+   * default the raw override would otherwise leave in place.
+   */
+  function overrideFor(field: keyof BoardseshRenderSettings): Partial<BoardseshRenderSettings> {
+    if (field === 'veilOpacity') return { veil: 'custom', veilOpacity: MOVED_OFF_DEFAULT.veilOpacity };
+    return { [field]: MOVED_OFF_DEFAULT[field] } as Partial<BoardseshRenderSettings>;
+  }
+
+  // Gap to the dark field lands in the soft bucket (0.175-0.34), so `auto`
+  // resolves to 0.3 here — different from both `strong` (always 0.6) and a
+  // `custom` 0.5, which is what lets `veil` and `veilOpacity` prove they move
+  // the key too, resolved the way the hook resolves them rather than as a raw,
+  // unresolved override.
+  const WALL_ROW = { mean: 0.45, coverage: 1 };
+
+  function resolvedSignatureFor(overrides: Partial<BoardseshRenderSettings>): string {
+    const boardsesh = { ...DEFAULT_BOARDSESH_RENDER_SETTINGS, ...overrides };
+    const effective = resolveEffectiveRenderSettings({ mode: 'boardsesh', boardsesh }, undefined, true);
+    const veilOpacity = resolveVeilOpacity(boardsesh, WALL_ROW, DARK_FIELD);
+    return buildBoardRenderSignature(effective, DARK_FIELD, veilOpacity);
+  }
+
+  it.each(Object.keys(DEFAULT_BOARDSESH_RENDER_SETTINGS) as (keyof BoardseshRenderSettings)[])(
+    'changes when %s changes',
+    (field) => {
+      expect(keyFor(resolvedSignatureFor(overrideFor(field)))).not.toBe(keyFor(resolvedSignatureFor({})));
+    },
+  );
 
   it('changes when the theme flips the play field under the veil', () => {
     // Both halves of the flip move: the field colour the veil washes toward,
     // and the strength the measurement gives it on that field.
     expect(keyFor(signatureFor({}, LIGHT_FIELD, 0))).not.toBe(keyFor(signatureFor({}, DARK_FIELD, 0.6)));
+  });
+
+  it('keeps the Boardsesh half of the key alive across an empty-frames render', () => {
+    // No frames means nothing to colour- or shape-override, but a Boardsesh
+    // render with zero frames still paints the veil and the field wash — the
+    // key must still tell the two themes apart, not collapse to one classic
+    // key the way it used to.
+    const lightKey = keyFor(signatureFor({}, LIGHT_FIELD, 0), '');
+    const darkKey = keyFor(signatureFor({}, DARK_FIELD, 0.6), '');
+    expect(lightKey).not.toBe(darkKey);
+  });
+
+  it('still collapses a classic render with empty frames to the default key', () => {
+    // Unchanged from before the fix: with no frames, there is nothing lit for
+    // a marker override to apply to, so a classic signature (no
+    // `mode-boardsesh` token at all) still ignores it.
+    expect(keyFor('hand-123456', '')).toBe(keyFor('', ''));
   });
 });
 

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -808,6 +808,19 @@ function canonicalizeSetIds(setIds: string): string {
     .join(',');
 }
 
+/**
+ * The board-render half of a composed `[overrideHalf, boardHalf].join('.')`
+ * signature (see the `effectiveRenderSignature` memo further down), or `''`
+ * for a classic render. The override half is never empty — it is `'default'`
+ * at minimum — so the board half, when present, always starts at the
+ * `mode-boardsesh` token `buildBoardRenderSignature` always leads with, right
+ * after that separating dot.
+ */
+function boardRenderSignatureHalf(renderSignature: string): string {
+  const markerIndex = renderSignature.indexOf('.mode-boardsesh');
+  return markerIndex === -1 ? '' : renderSignature.slice(markerIndex + 1);
+}
+
 export function buildCacheKey(
   boardName: string,
   layoutId: number,
@@ -818,7 +831,17 @@ export function buildCacheKey(
   renderWidth?: number,
   renderSignature = DEFAULT_HOLD_COLOR_SIGNATURE,
 ): string {
-  const effectiveRenderSignature = frames.length === 0 ? DEFAULT_HOLD_COLOR_SIGNATURE : renderSignature;
+  // With no frames there are no lit holds to colour- or shape-override, so
+  // that half of the signature is meaningless and collapses to the default —
+  // but a Boardsesh render with no frames still paints the veil and the field
+  // wash, so THAT half must survive rather than being thrown away with it.
+  const boardHalf = boardRenderSignatureHalf(renderSignature);
+  const effectiveRenderSignature =
+    frames.length === 0
+      ? boardHalf
+        ? `${DEFAULT_HOLD_COLOR_SIGNATURE}.${boardHalf}`
+        : DEFAULT_HOLD_COLOR_SIGNATURE
+      : renderSignature;
   const framesHash =
     effectiveRenderSignature === DEFAULT_HOLD_COLOR_SIGNATURE
       ? fnv1aHex(frames)
@@ -1016,6 +1039,9 @@ function buildBoardseshFields(
     ...(veilOpacity > 0 ? { veil: { color: fieldColor, opacity: veilOpacity } } : {}),
     // A bare glow reads faint once a thumbnail is scaled to ~76px, so the small
     // surface takes the fill under it unless the climber asked for the glow.
+    // `'fill'` maps to `'glow-fill'`, not a bare fill, on purpose: the spike
+    // measured the filled thumbnail WITH its own small glow (the "veil + tint"
+    // arm) as the winner, not the fill alone.
     mark_style: filledStyle ? (settings.thumbnailStyle === 'glow' ? 'glow' : 'glow-fill') : settings.markStyle,
     glow_falloff: glowFalloff,
     glow: {

--- a/packages/mobile/src/lib/__tests__/board-render-settings.test.ts
+++ b/packages/mobile/src/lib/__tests__/board-render-settings.test.ts
@@ -301,25 +301,81 @@ describe('buildBoardRenderSignature', () => {
     expect(boardseshSignature(chosen)).toBe(boardseshSignature(chosen));
   });
 
-  it.each([
-    ['glowFalloff', { glowFalloff: 'plateau' as const }, 'glow-plateau'],
-    ['glowReach', { glowReach: 1.2 }, 'reach-1.2'],
-    ['plateauShare', { plateauShare: 0.55 }, 'plateau-0.55'],
-    ['markStyle', { markStyle: 'glow-fill' as const }, 'marks-glow-fill'],
-    ['fillOpacity', { fillOpacity: 0.8 }, 'fill-0.8'],
-    ['softDisc', { softDisc: true }, 'disc'],
-    ['smallHoldBoost', { smallHoldBoost: false }, 'noboost'],
-    ['ledDots', { ledDots: false }, 'noleds'],
-    ['roleGlyphs', { roleGlyphs: true }, 'glyphs'],
-    ['thumbnailStyle', { thumbnailStyle: 'glow' as const }, 'thumb-glow'],
-  ])('changes the signature when %s moves off its default', (_field, override, token) => {
-    const moved = boardseshSignature(override);
-    expect(moved).not.toBe(boardseshSignature({}));
-    // Substring, not a split on '.': a numeric token carries its own decimal
-    // point. The signature is an opaque cache-key fragment and is never parsed
-    // back apart, so that costs nothing.
-    expect(moved).toContain(token);
-  });
+  /**
+   * One non-default value per `BoardseshRenderSettings` field, keyed by the
+   * type itself — a 13th field is a compile error here until it is listed, so
+   * the it.each below (driven off `DEFAULT_BOARDSESH_RENDER_SETTINGS`'s own
+   * keys) can never silently skip a token the renderer reads.
+   */
+  const MOVED_OFF_DEFAULT: { [K in keyof BoardseshRenderSettings]: BoardseshRenderSettings[K] } = {
+    glowFalloff: 'plateau',
+    glowReach: 1.2,
+    plateauShare: 0.55,
+    veil: 'strong',
+    veilOpacity: 0.5,
+    markStyle: 'glow-fill',
+    fillOpacity: 0.8,
+    softDisc: true,
+    smallHoldBoost: false,
+    ledDots: false,
+    roleGlyphs: true,
+    thumbnailStyle: 'glow',
+  };
+
+  /** The substring `buildBoardRenderSignature` mints for each field above. */
+  const EXPECTED_TOKEN: { [K in keyof BoardseshRenderSettings]: string } = {
+    glowFalloff: 'glow-plateau',
+    glowReach: 'reach-1.2',
+    plateauShare: 'plateau-0.55',
+    // `strong` always resolves to 0.6, against `auto`'s 0.3 under WALL_ROW.
+    veil: 'veil-181225-60',
+    // Paired with `veil: 'custom'` below — 0.5 only reaches the resolver then.
+    veilOpacity: 'veil-181225-50',
+    markStyle: 'marks-glow-fill',
+    fillOpacity: 'fill-0.8',
+    softDisc: 'disc',
+    smallHoldBoost: 'noboost',
+    ledDots: 'noleds',
+    roleGlyphs: 'glyphs',
+    thumbnailStyle: 'thumb-glow',
+  };
+
+  /**
+   * `veilOpacity` only reaches `resolveVeilOpacity` when `veil` is `'custom'`
+   * — paired here so moving this field alone actually changes the resolved
+   * opacity, rather than silently doing nothing under the still-`'auto'`
+   * default a raw override would otherwise leave in place.
+   */
+  function overrideFor(field: keyof BoardseshRenderSettings): Partial<BoardseshRenderSettings> {
+    if (field === 'veilOpacity') return { veil: 'custom', veilOpacity: MOVED_OFF_DEFAULT.veilOpacity };
+    return { [field]: MOVED_OFF_DEFAULT[field] } as Partial<BoardseshRenderSettings>;
+  }
+
+  // Gap to the dark field lands in the soft bucket (0.175-0.34), so `auto`
+  // resolves to 0.3 here — different from both `strong` (always 0.6) and a
+  // `custom` 0.5, which is what lets `veil` and `veilOpacity` prove they move
+  // the signature too, resolved through `resolveVeilOpacity` the way a real
+  // render resolves them rather than as a raw, unresolved override.
+  const WALL_ROW = { mean: 0.45, coverage: 1 };
+
+  function resolvedBoardseshSignature(overrides: Partial<BoardseshRenderSettings>): string {
+    const settings = sanitizeBoardRenderSettings(settingsWith(overrides));
+    const effective = resolveEffectiveRenderSettings(settings, undefined, true);
+    const veilOpacity = resolveVeilOpacity(effective.boardsesh, WALL_ROW, DARK_FIELD);
+    return buildBoardRenderSignature(effective, DARK_FIELD, veilOpacity);
+  }
+
+  it.each(Object.keys(DEFAULT_BOARDSESH_RENDER_SETTINGS) as (keyof BoardseshRenderSettings)[])(
+    'changes the signature when %s moves off its default',
+    (field) => {
+      const moved = resolvedBoardseshSignature(overrideFor(field));
+      expect(moved).not.toBe(resolvedBoardseshSignature({}));
+      // Substring, not a split on '.': a numeric token carries its own decimal
+      // point. The signature is an opaque cache-key fragment and is never
+      // parsed back apart, so that costs nothing.
+      expect(moved).toContain(EXPECTED_TOKEN[field]);
+    },
+  );
 
   it('spells the veil out as field colour and percent', () => {
     expect(boardseshSignature({}, 0.3)).toContain('veil-181225-30');

--- a/packages/mobile/src/lib/board-render-settings.ts
+++ b/packages/mobile/src/lib/board-render-settings.ts
@@ -33,7 +33,13 @@ export type GlowFalloffSetting = 'default' | 'soft' | 'plateau';
 export type VeilSetting = 'auto' | 'off' | 'soft' | 'strong' | 'custom';
 /** What the Boardsesh drawing puts on a lit hold at full size. */
 export type MarkStyleSetting = 'glow' | 'glow-fill' | 'fill';
-/** The same choice for a list thumbnail, where a bare glow reads faint at ~76px. */
+/**
+ * The same choice for a list thumbnail, where a bare glow reads faint at
+ * ~76px. `fill` renders as `glow-fill`, not a bare fill — the spike's
+ * winning thumbnail arm was the filled mark WITH its own small glow
+ * ("veil + tint"), so that pairing is what this maps to (see
+ * `buildBoardseshFields` in `use-native-climb-render.ts`).
+ */
 export type ThumbnailStyleSetting = 'fill' | 'glow';
 
 export type BoardseshRenderSettings = {


### PR DESCRIPTION
## Summary

Part of #2202 — the third of five PRs porting the dark-field rendering spike (PR #4783) into the product. Stacked on #4833 (silhouette data) and #4834 (Rust renderer); the diff shrinks to the mobile half once those merge.

- **The app can now draw the Boardsesh mode.** `use-native-climb-render.ts` loads the board's silhouette shard, computes the veil from the wall-vs-field lightness gap (0.60 / 0.30 / 0, 0 on the light theme), and sends a `render_mode: "boardsesh"` config — outlines on the lit holds, LED covers on every bright-LED placement, roles for the glyphs, the `#6980FF` HAND — through the existing native bridge. Every knob of the mode is a field in a new persisted settings model (`board-render-settings.ts`: mode, falloff, reach, plateau share, veil, mark style, fill, disc, boost, LED dots, glyphs, thumbnail style) with an `EffectiveBoardRenderSettings` resolver that a later PR feeds the rollout flags into. Nothing is user-visible yet: the default is Classic until the settings screen and the flags land.
- **A stale library can't fake it.** Rather than a new native method name, the shim probes the binary once per run (the same 8×8 config in classic and Boardsesh; different bytes = capable) and refuses Boardsesh configs otherwise, so an iOS build whose xcframework was not rebuilt falls back to Classic instead of silently drawing it.
- **Cache contract v7.** The render signature carries the mode, falloff, every tunable, the field colour and the veil opacity, and `RENDERER_VERSION` moves 6 → 7, so a bucket flip or a theme flip never reuses the other bucket's overlay.
- Classic renders emit byte-identical configs (pinned).
- Android renderer libraries rebuilt from the reviewed Rust (NDK 27.1, 16 KB page alignment verified). `build-native-renderer.sh` takes `ios | android | all`.

**This is a native change** — it ships on the next store build, not OTA. Before it can be marked ready:

- [ ] Rebuild the iOS xcframework on macOS: `bash scripts/build-native-renderer.sh ios`, commit `packages/mobile/modules/board-renderer/ios/BoardRendererNative.xcframework`. Until then the probe reads Boardsesh as unavailable on iOS.
- [x] Android emulator captures in both modes (see the evidence comment) — probe SUPPORTED, veil + glow drawn on Kilter and Tension, Woods falls back.
- [ ] On-device profile of one native-width Boardsesh render on a mid-tier Android phone (host release timing is 24 ms at 1206 px with 17 lit holds; the loaded emulator measured 5–7× Classic, which is not a phone number).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck:mobile`, `vp run test:mobile` (full suite), `vp run check:mobile-bundle`
- `vp test run --project board-constants`, `--project board-config` (display-colour helper, drift test)
- Probe gate mutation-tested (`if (false && …)` → red); veil figures in the tests come from the real shards (TB2 Mirror / Tension Original 0.60 dark, 0 light; Grasshopper 0.30; Woods no shard → 0)
- Android `.so`: every LOAD segment `p_align = 0x4000`, `board_renderer_render` exported, Boardsesh field names present
- Android emulator captures of a real climb in both modes: see the evidence comment

