### PR TITLE
feat(ci): manage static asset CDN DNS

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -185,7 +185,6 @@ jobs:
     if: >-
       always()
       && needs.detect-changes.outputs.static_assets_changed == 'true'
-      && (needs.deploy-cloudflare.result == 'success' || needs.deploy-cloudflare.result == 'skipped')
     runs-on: ubuntu-latest
     # A stuck S3/CDN socket must release the serialized production-deploy
     # concurrency group. A healthy full-catalog validation takes about three
@@ -193,6 +192,22 @@ jobs:
     timeout-minutes: 10
     environment: Production
     steps:
+      # Run this job even when its Cloudflare dependency failed, then fail it
+      # explicitly. Otherwise GitHub reports the dependency-blocked job as
+      # "skipped", which downstream build gates legitimately accept when no
+      # static assets changed.
+      - name: Require successful Cloudflare prerequisite
+        env:
+          CLOUDFLARE_DEPLOY_RESULT: ${{ needs.deploy-cloudflare.result }}
+        run: |
+          case "$CLOUDFLARE_DEPLOY_RESULT" in
+            success|skipped) ;;
+            *)
+              echo "::error::Cloudflare prerequisite finished with result: $CLOUDFLARE_DEPLOY_RESULT"
+              exit 1
+              ;;
+          esac
+
       - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -181,8 +181,11 @@ jobs:
   # URLs. The uploader lists the dedicated bucket and PUTs only missing hashes;
   # it never deletes or overwrites objects needed by an older deployment.
   sync-static-assets:
-    needs: [detect-changes]
-    if: needs.detect-changes.outputs.static_assets_changed == 'true'
+    needs: [detect-changes, deploy-cloudflare]
+    if: >-
+      always()
+      && needs.detect-changes.outputs.static_assets_changed == 'true'
+      && (needs.deploy-cloudflare.result == 'success' || needs.deploy-cloudflare.result == 'skipped')
     runs-on: ubuntu-latest
     # A stuck S3/CDN socket must release the serialized production-deploy
     # concurrency group. A healthy full-catalog validation takes about three
@@ -592,9 +595,10 @@ jobs:
   # is too heavy here (this file has no such gate for web/backend either); the
   # expo-web-smoke suite stays the dispatch-only gate in e2e-tests.yml.
   # Converges the Cloudflare zone config (infra/cloudflare) on main. Runs only
-  # when the desired state or apply tooling changes (or on manual dispatch);
-  # nothing else depends on it, so a Cloudflare API hiccup never blocks the
-  # web/backend deploys. A non-zero exit = unapplied drift (e.g. a blocked
+  # when the desired state or apply tooling changes (or on manual dispatch).
+  # Static-asset publication waits for this job when both targets change, so it
+  # cannot validate the public hostname before its DNS record is converged. A
+  # non-zero exit = unapplied drift (e.g. a blocked
   # zone-SSL change) and should be investigated, not retried blindly.
   # The planned OpenNext (Cloudflare Workers) deploy of packages/web will be a
   # sibling job reusing the same Production-environment CLOUDFLARE_API_TOKEN

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -15,6 +15,40 @@ that migration too, so the deploy job can reuse them:
   the token (`gh secret set CLOUDFLARE_ACCOUNT_ID --env Production`); wrangler
   needs it and it never changes.
 
+## assets.boardsesh.com DNS-only Tigris domain
+
+The public static-assets hostname is repo-managed DNS. `vp run cf:apply` creates
+and maintains this complete record (not just its proxy flag):
+
+```text
+assets.boardsesh.com CNAME boardsesh-static-assets.t3.tigrisbucket.io
+TTL: automatic (Cloudflare API value 1)
+Proxy status: DNS only
+CNAME flattening: disabled
+```
+
+Keep it DNS-only. Tigris terminates TLS and serves the public objects globally;
+putting Cloudflare's proxy in front would add a second CDN/TLS layer and obscure
+the CNAME Tigris uses to verify the custom domain. There is deliberately no
+Cloudflare cache rule for `assets.boardsesh.com`.
+
+The apply also disables per-record CNAME flattening. It reads the zone DNS
+settings and fails closed if **Flatten all CNAMEs** is enabled, because that
+zone-wide option overrides the record and prevents Tigris from seeing the
+literal verification target. Turn that option off in Cloudflare DNS settings;
+do not bypass this guard.
+
+One-time setup order:
+
+1. In Tigris, create/configure the dedicated `boardsesh-static-assets` bucket,
+   public reads, CORS, CI access key, and deletion protection as documented in
+   [static-assets.md](./static-assets.md).
+2. Register `assets.boardsesh.com` as that bucket's custom domain in Tigris.
+3. Merge/apply the repo Cloudflare state. The apply creates the DNS-only CNAME
+   if absent and corrects its target, type, TTL, or proxy status if they drift.
+4. Wait for Tigris to report the custom domain and certificate active, then run
+   the verification commands below before publishing the first catalog.
+
 ## ws.boardsesh.com edge caching (og images)
 
 `ws.boardsesh.com` is a single-region Railway origin; distant clients (and the
@@ -30,8 +64,13 @@ second run is a no-op).
 
 What it manages (and nothing else on the zone):
 
-- **DNS** — the `ws` record's proxied flag → orange cloud. The record's
-  target/type/content are not managed; the record must already exist.
+- **DNS** — two records with different ownership boundaries:
+  - `ws`: only its proxied flag → orange cloud. Its target/type/content are not
+    managed and the record must already exist.
+  - `assets`: the full DNS-only CNAME shape shown above. It is created when
+    missing and its owned fields (including disabled CNAME flattening) are
+    corrected when drifted. The tool refuses to apply while zone-wide CNAME
+    flattening would override that record.
 - **Cache** — one rule in the `http_request_cache_settings` phase, expression
   `(http.host eq "ws.boardsesh.com" and starts_with(http.request.uri.path, "/og/"))`
   → eligible for cache, edge TTL "use cache-control if present, bypass if not"
@@ -155,7 +194,8 @@ Create a token at <https://dash.cloudflare.com/profile/api-tokens> scoped to the
 `boardsesh.com` zone with:
 
 - **Zone.Zone Read** — resolve the zone id by name + read the zone list
-- **Zone.DNS Edit** — patch the `ws` record proxied flag
+- **Zone.DNS Edit** — patch the `ws` proxy flag, create/update the `assets` CNAME,
+  and read the zone's CNAME-flattening settings
 - **Zone.Cache Rules Edit** — create/update the `/og/` and board-render cache rules
 - **Zone.WAF Edit** — create/update the two crawler rules (see below). Without
   this scope `cf:apply` fails on the WAF phase while the cache rules still apply,
@@ -221,6 +261,10 @@ CLOUDFLARE_API_TOKEN=... vp run cf:apply -- --apply
 CLOUDFLARE_API_TOKEN=... vp run cf:apply -- --apply --allow-zone-ssl
 ```
 
+That one apply covers both DNS records plus the cache/WAF phases. A missing
+`ws` record remains a hard error because this repo does not know its origin
+target; a missing `assets` record is an ordinary planned create.
+
 `CLOUDFLARE_ZONE_ID` is optional — when unset, the zone id is resolved by name.
 
 Confirm WebSockets are enabled for the zone (Network tab; on by default on
@@ -261,6 +305,25 @@ done
 Expect Ahrefs and Semrush at `403 reached-vercel:0`; Brave, Google and Bing at
 `200 reached-vercel:1`.
 
+For the static-assets custom domain, confirm the public DNS answer remains the
+Tigris target (not Cloudflare anycast), TLS is valid, listing is unavailable,
+and a catalog object supports both `HEAD` and cross-origin `GET`:
+
+```bash
+dig +short assets.boardsesh.com CNAME
+curl -sS -o /dev/null -w '%{http_code}\n' https://assets.boardsesh.com/
+curl -sSI -H 'Origin: https://www.boardsesh.com' \
+  https://assets.boardsesh.com/static/v1/<catalog-object>
+curl -sS -H 'Origin: https://www.boardsesh.com' -o /dev/null -D - \
+  https://assets.boardsesh.com/static/v1/<catalog-object>
+```
+
+The CNAME must be `boardsesh-static-assets.t3.tigrisbucket.io.` and the bucket
+root should return `403` rather than an object listing. The object
+responses must include the image's correct content type,
+`cache-control: public, max-age=31536000, immutable`, and a permissive CORS
+header.
+
 Then confirm the compute actually fell — the point of the exercise. Rerun the
 route breakdown a day later and compare against the table above:
 
@@ -275,6 +338,8 @@ that touch `infra/cloudflare/` or the apply script (and on manual dispatch),
 reading `CLOUDFLARE_API_TOKEN` from the GitHub **Production** environment
 secrets: `gh secret set CLOUDFLARE_API_TOKEN --env Production`. A failing job
 means unapplied drift — run the dry-run locally to see the plan.
+The assets DNS record is included in the same job; no dashboard DNS step is
+needed after the Tigris-side custom domain registration.
 
 A **blocked** zone-SSL change is the one failure a merge cannot clear: pushes
 deliberately resolve `--allow-zone-ssl` to empty, so `cf:apply` re-plans the same

--- a/docs/static-assets.md
+++ b/docs/static-assets.md
@@ -95,8 +95,10 @@ SHA-256, MIME type, immutable caching, and CORS). Each public CDN attempt has a 
 failures (404, 429, 5xx, network errors, timeouts, or stale headers/body) retry up to six times with bounded
 exponential jitter; permanent 4xx responses fail immediately. The complete `sync-static-assets` job has a 10-minute
 timeout so a stalled storage or CDN connection cannot hold the serialized production deployment indefinitely.
-When Cloudflare desired state changes in the same deployment, `sync-static-assets` waits for `deploy-cloudflare` to
-succeed (or skip when there is no Cloudflare change), preventing public validation from racing DNS convergence.
+When Cloudflare desired state changes in the same deployment, `sync-static-assets` waits for `deploy-cloudflare`,
+preventing public validation from racing DNS convergence. A successful or legitimately skipped Cloudflare job allows
+publication; a failed or cancelled prerequisite explicitly fails `sync-static-assets` so downstream builds cannot
+mistake a dependency skip for permission to deploy unvalidated catalog URLs.
 
 After every object passes, it writes `static/v1/manifest.json` as a short-cached audit record. Seeing a new audit
 manifest therefore means all assets it names passed publication QA. A failed upload blocks web/Expo-web artifacts

--- a/docs/static-assets.md
+++ b/docs/static-assets.md
@@ -50,8 +50,23 @@ buckets. Configure it with:
 - a CI key allowed to list the bucket and put/head objects under `static/v1/`, without delete permission;
 - deletion protection or an equivalent operator guard. The publisher never deletes an object.
 
-Map the custom domain only after its TLS certificate and public reads work. Tigris's S3 API endpoint is for signed
-publishing; browsers must use `assets.boardsesh.com`.
+Register `assets.boardsesh.com` as the bucket's custom domain in Tigris, then let the repo-managed Cloudflare apply
+create its verification/delivery record:
+
+```text
+assets.boardsesh.com CNAME boardsesh-static-assets.t3.tigrisbucket.io
+TTL: automatic
+Proxy status: DNS only
+CNAME flattening: disabled
+```
+
+The desired DNS state lives in `infra/cloudflare/config.ts` and is converged by `vp run cf:apply -- --apply`. It
+creates the record when missing and repairs its type, target, TTL, or proxy flag when drifted. Keep the record
+DNS-only: Tigris owns TLS and global object delivery, and there is intentionally no Cloudflare cache rule for this
+hostname. It also disables per-record CNAME flattening and fails closed if Cloudflare's zone-wide **Flatten all
+CNAMEs** setting would override that record. Wait for Tigris to report the custom-domain certificate active and
+verify public reads before the first catalog publication. Tigris's S3 API endpoint is for signed publishing;
+browsers must use `assets.boardsesh.com`.
 
 Set these secrets on GitHub's protected `Production` environment:
 
@@ -80,6 +95,8 @@ SHA-256, MIME type, immutable caching, and CORS). Each public CDN attempt has a 
 failures (404, 429, 5xx, network errors, timeouts, or stale headers/body) retry up to six times with bounded
 exponential jitter; permanent 4xx responses fail immediately. The complete `sync-static-assets` job has a 10-minute
 timeout so a stalled storage or CDN connection cannot hold the serialized production deployment indefinitely.
+When Cloudflare desired state changes in the same deployment, `sync-static-assets` waits for `deploy-cloudflare` to
+succeed (or skip when there is no Cloudflare change), preventing public validation from racing DNS convergence.
 
 After every object passes, it writes `static/v1/manifest.json` as a short-cached audit record. Seeing a new audit
 manifest therefore means all assets it names passed publication QA. A failed upload blocks web/Expo-web artifacts
@@ -97,8 +114,10 @@ bucket credentials.
 
 ### First deployment
 
-Provision the empty bucket, public-read policy, CORS, custom domain, and Production secrets before merging the first
-catalog change. The first main deployment uploads and validates the complete catalog before either web build starts.
+Provision the empty bucket, public-read policy, CORS, Tigris custom-domain registration, repo-managed DNS, and
+Production secrets before merging the first catalog change. Confirm the Tigris custom-domain certificate is active
+before rerunning the deployment. The first main deployment uploads and validates the complete catalog before either
+web build starts.
 Until that job succeeds, previews continue using their committed same-origin files and production remains on the
 previous deployment. Later runs upload only new content hashes but still validate the complete published catalog.
 

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -5,7 +5,7 @@
 // reads it, diffs it against the live zone, and (only with --apply) converges the
 // delta.
 //
-// Why this exists, in two halves:
+// Why this exists, in three parts:
 //
 // 1. ws.boardsesh.com (a single-region Railway origin) sits behind the Cloudflare
 //    proxy so the immutable /og/* share-card images edge-cache globally. Everything
@@ -17,12 +17,22 @@
 //    ~442,600 Vercel function invocations/day, of which /api/internal/board-render
 //    was ~215,600 and the climb-view page ~203,900, against a published sitemap of
 //    only ~60k URLs and ~2,000 homepage hits. See docs/cloudflare.md.
+//
+// 3. assets.boardsesh.com is the public, DNS-only custom domain for the Tigris
+//    static-assets bucket. Unlike ws, this tool owns the record's complete shape
+//    and creates it when it is absent.
 
 /** The Cloudflare zone this config manages. Resolved to a zone id by name when CLOUDFLARE_ZONE_ID is unset. */
 export const ZONE_NAME = 'boardsesh.com';
 
 /** The Railway-backed host we put behind the Cloudflare proxy. */
 export const WS_HOSTNAME = 'ws.boardsesh.com';
+
+/** Public custom domain for the content-addressed static-assets bucket. */
+export const ASSETS_HOSTNAME = 'assets.boardsesh.com';
+
+/** Tigris custom-domain DNS target for the dedicated Boardsesh static-assets bucket. */
+export const ASSETS_CNAME_TARGET = 'boardsesh-static-assets.t3.tigrisbucket.io';
 
 /** Path prefix whose responses are immutable (`Cache-Control: … immutable`, 1y) and safe to edge-cache. */
 export const OG_PATH_PREFIX = '/og/';
@@ -72,12 +82,30 @@ export type SslMode = (typeof SSL_MODE_STRENGTH)[number];
 /** SSL/TLS mode we require for the zone. `strict` = Full (strict); Flexible causes redirect loops with Railway. */
 export const REQUIRED_SSL_MODE: SslMode = 'strict';
 
-export interface DnsRecordDesired {
-  /** DNS record name (host). We assert only the proxied flag on the existing record; content/type are not managed. */
+interface DnsRecordDesiredBase {
   name: string;
-  /** Orange-cloud the record so requests transit the Cloudflare edge. */
   proxied: boolean;
 }
+
+/** A pre-existing record for which this tool owns only Cloudflare's proxy flag. */
+export interface ProxyOnlyDnsRecordDesired extends DnsRecordDesiredBase {
+  management: 'proxied-only';
+}
+
+/** A record whose complete writable DNS shape is owned by this repo. */
+export interface FullyManagedDnsRecordDesired extends DnsRecordDesiredBase {
+  management: 'full';
+  type: 'CNAME';
+  content: string;
+  /** Cloudflare API value 1 means automatic TTL. */
+  ttl: number;
+  /** Keep the literal CNAME visible so the third-party provider can verify it. */
+  settings: {
+    flatten_cname: false;
+  };
+}
+
+export type DnsRecordDesired = ProxyOnlyDnsRecordDesired | FullyManagedDnsRecordDesired;
 
 export interface CacheRuleActionParameters {
   /** true = eligible for cache. */
@@ -123,7 +151,7 @@ export interface WafRuleDesired {
 
 export interface CloudflareDesiredState {
   zoneName: string;
-  dns: DnsRecordDesired;
+  dnsRecords: DnsRecordDesired[];
   /** Order is not significant: cache rules are matched by expression, not precedence. */
   cacheRules: CacheRuleDesired[];
   /**
@@ -217,10 +245,24 @@ export const CRAWLER_BLOCK_EXPRESSION = buildUserAgentExpression(CRAWLER_BLOCK_T
 
 export const desiredCloudflareState: CloudflareDesiredState = {
   zoneName: ZONE_NAME,
-  dns: {
-    name: WS_HOSTNAME,
-    proxied: true,
-  },
+  dnsRecords: [
+    {
+      management: 'proxied-only',
+      name: WS_HOSTNAME,
+      proxied: true,
+    },
+    {
+      management: 'full',
+      name: ASSETS_HOSTNAME,
+      type: 'CNAME',
+      content: ASSETS_CNAME_TARGET,
+      ttl: 1,
+      proxied: false,
+      settings: {
+        flatten_cname: false,
+      },
+    },
+  ],
   cacheRules: [
     {
       description: CACHE_RULE_DESCRIPTION,

--- a/infra/cloudflare/plan.ts
+++ b/infra/cloudflare/plan.ts
@@ -186,6 +186,11 @@ export function upsertCacheRule(
   return { rules: changed ? rules : existingRules, changed };
 }
 
+/** Render Cloudflare's special automatic-TTL value without mislabelling future explicit TTLs. */
+function describeDnsTtl(ttl: number): string {
+  return ttl === 1 ? 'automatic' : String(ttl);
+}
+
 /** Plan creation or owned-field convergence for one DNS record. */
 export function diffDnsRecord(desired: DnsRecordDesired, liveRecord: LiveDnsRecord | null): PlannedChange | null {
   if (!liveRecord) {
@@ -199,7 +204,8 @@ export function diffDnsRecord(desired: DnsRecordDesired, liveRecord: LiveDnsReco
       dnsName: desired.name,
       summary: `DNS ${desired.name}: missing — will create`,
       detail:
-        `${desired.type} ${desired.name} → ${desired.content}, ttl automatic, proxied ${desired.proxied}, ` +
+        `${desired.type} ${desired.name} → ${desired.content}, ttl ${describeDnsTtl(desired.ttl)}, ` +
+        `proxied ${desired.proxied}, ` +
         `CNAME flattening disabled`,
     };
   }
@@ -217,7 +223,9 @@ export function diffDnsRecord(desired: DnsRecordDesired, liveRecord: LiveDnsReco
   const driftedFields: string[] = [];
   if (liveRecord.type !== desired.type) driftedFields.push(`type ${liveRecord.type} → ${desired.type}`);
   if (liveRecord.content !== desired.content) driftedFields.push(`content ${liveRecord.content} → ${desired.content}`);
-  if (liveRecord.ttl !== desired.ttl) driftedFields.push(`ttl ${liveRecord.ttl} → automatic`);
+  if (liveRecord.ttl !== desired.ttl) {
+    driftedFields.push(`ttl ${describeDnsTtl(liveRecord.ttl)} → ${describeDnsTtl(desired.ttl)}`);
+  }
   if (liveRecord.proxied !== desired.proxied) {
     driftedFields.push(`proxied ${liveRecord.proxied} → ${desired.proxied}`);
   }

--- a/infra/cloudflare/plan.ts
+++ b/infra/cloudflare/plan.ts
@@ -12,13 +12,17 @@ import type { CacheRuleDesired, DnsRecordDesired, SslDesired, SslMode, WafRuleDe
 /** Anything this tool owns inside a ruleset phase. Identity is the description marker. */
 export type ManagedRuleDesired = CacheRuleDesired | WafRuleDesired;
 
-/** A DNS record as Cloudflare returns it. We only manage `proxied`; the rest is context. */
+/** A DNS record as Cloudflare returns it. Which fields are owned depends on the desired record's management mode. */
 export interface LiveDnsRecord {
   id: string;
   name: string;
   type: string;
   content: string;
+  ttl: number;
   proxied: boolean;
+  settings?: {
+    flatten_cname?: boolean;
+  };
 }
 
 /**
@@ -43,11 +47,14 @@ export interface RulesetRule {
 
 /** Live zone state the plan diffs against, gathered by the apply script's read phase. */
 export interface LiveState {
-  dnsRecord: LiveDnsRecord;
+  /** One entry per desired hostname. Fully managed records may be null when they need creation. */
+  dnsRecords: Record<string, LiveDnsRecord | null>;
   cacheRules: RulesetRule[];
   /** Rules live in the WAF custom phase. Empty when the phase has no entrypoint ruleset yet. */
   wafRules: RulesetRule[];
   sslMode: string;
+  /** Zone-wide flattening overrides per-record settings and breaks Tigris CNAME verification. */
+  flattenAllCnames: boolean;
 }
 
 export interface PlanOptions {
@@ -61,6 +68,8 @@ export interface PlannedChange {
   summary: string;
   /** Optional extra context printed under the summary. */
   detail?: string;
+  /** Present for DNS changes so the apply layer can select the right desired/live record. */
+  dnsName?: string;
   /**
    * true = a change that is NOT auto-applied: the zone-wide SSL mutation
    * requires an explicit opt-in flag (it affects every host on the zone), and
@@ -177,13 +186,53 @@ export function upsertCacheRule(
   return { rules: changed ? rules : existingRules, changed };
 }
 
-/** Plan the DNS proxied-flag change, or null when already at the desired value. */
-export function diffDnsRecord(desired: DnsRecordDesired, liveRecord: LiveDnsRecord): PlannedChange | null {
-  if (liveRecord.proxied === desired.proxied) return null;
+/** Plan creation or owned-field convergence for one DNS record. */
+export function diffDnsRecord(desired: DnsRecordDesired, liveRecord: LiveDnsRecord | null): PlannedChange | null {
+  if (!liveRecord) {
+    if (desired.management === 'proxied-only') {
+      throw new Error(
+        `DNS record "${desired.name}" is missing. It is proxy-only managed and must be created outside this tool.`,
+      );
+    }
+    return {
+      resource: 'dns',
+      dnsName: desired.name,
+      summary: `DNS ${desired.name}: missing — will create`,
+      detail:
+        `${desired.type} ${desired.name} → ${desired.content}, ttl automatic, proxied ${desired.proxied}, ` +
+        `CNAME flattening disabled`,
+    };
+  }
+
+  if (desired.management === 'proxied-only') {
+    if (liveRecord.proxied === desired.proxied) return null;
+    return {
+      resource: 'dns',
+      dnsName: desired.name,
+      summary: `DNS ${desired.name}: set proxied ${liveRecord.proxied} → ${desired.proxied}`,
+      detail: `record ${liveRecord.type} ${liveRecord.name} → ${liveRecord.content} (target unchanged; only the proxied flag is managed)`,
+    };
+  }
+
+  const driftedFields: string[] = [];
+  if (liveRecord.type !== desired.type) driftedFields.push(`type ${liveRecord.type} → ${desired.type}`);
+  if (liveRecord.content !== desired.content) driftedFields.push(`content ${liveRecord.content} → ${desired.content}`);
+  if (liveRecord.ttl !== desired.ttl) driftedFields.push(`ttl ${liveRecord.ttl} → automatic`);
+  if (liveRecord.proxied !== desired.proxied) {
+    driftedFields.push(`proxied ${liveRecord.proxied} → ${desired.proxied}`);
+  }
+  if ((liveRecord.settings?.flatten_cname ?? false) !== desired.settings.flatten_cname) {
+    driftedFields.push(
+      `flatten_cname ${liveRecord.settings?.flatten_cname ?? false} → ${desired.settings.flatten_cname}`,
+    );
+  }
+  if (driftedFields.length === 0) return null;
+
   return {
     resource: 'dns',
-    summary: `DNS ${desired.name}: set proxied ${liveRecord.proxied} → ${desired.proxied}`,
-    detail: `record ${liveRecord.type} ${liveRecord.name} → ${liveRecord.content} (target unchanged; only the proxied flag is managed)`,
+    dnsName: desired.name,
+    summary: `DNS ${desired.name}: managed fields differ — will update`,
+    detail: driftedFields.join(', '),
   };
 }
 
@@ -282,7 +331,7 @@ export function diffSslMode(desiredMode: SslMode, liveMode: string, allowZoneSsl
 /** Full desired-vs-live diff: the ordered list of changes --apply would attempt. Empty = in sync. */
 export function buildPlan(
   desired: {
-    dns: DnsRecordDesired;
+    dnsRecords: DnsRecordDesired[];
     cacheRules: CacheRuleDesired[];
     wafRules: WafRuleDesired[];
     ssl: SslDesired;
@@ -290,9 +339,27 @@ export function buildPlan(
   live: LiveState,
   options: PlanOptions,
 ): PlannedChange[] {
+  const requiresLiteralCname = desired.dnsRecords.some(
+    (record) =>
+      record.management === 'full' &&
+      record.type === 'CNAME' &&
+      !record.proxied &&
+      record.settings.flatten_cname === false,
+  );
+  if (requiresLiteralCname && live.flattenAllCnames) {
+    throw new Error(
+      `Cloudflare zone-wide CNAME flattening is enabled for ${ZONE_NAME}. ` +
+        `Disable "Flatten all CNAMEs" before applying: it overrides the per-record setting and hides the literal ` +
+        `CNAME required for Tigris custom-domain verification.`,
+    );
+  }
+
   const changes: PlannedChange[] = [];
 
-  const dnsChange = diffDnsRecord(desired.dns, live.dnsRecord);
+  const dnsChanges = desired.dnsRecords.flatMap((desiredRecord) => {
+    const change = diffDnsRecord(desiredRecord, live.dnsRecords[desiredRecord.name] ?? null);
+    return change ? [change] : [];
+  });
 
   const cacheChanges = diffManagedRules(live.cacheRules, desired.cacheRules, 'cache-rule');
   const wafChanges = diffManagedRules(live.wafRules, desired.wafRules, 'waf-rule');
@@ -304,8 +371,10 @@ export function buildPlan(
   if (sslChange) changes.push(sslChange);
   changes.push(...cacheChanges);
   changes.push(...wafChanges);
-  if (dnsChange) {
-    if (desired.dns.proxied && sslChange?.blocked) {
+  for (const dnsChange of dnsChanges) {
+    const desiredRecord = desired.dnsRecords.find((record) => record.name === dnsChange.dnsName);
+    if (!desiredRecord) throw new Error(`No desired DNS record found for planned change "${dnsChange.dnsName}"`);
+    if (desiredRecord.proxied && sslChange?.blocked) {
       // Never turn the proxy on while the required SSL mode can't be applied:
       // Flexible SSL against the origin causes redirect loops on every host.
       changes.push({

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -4,6 +4,8 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 import {
+  ASSETS_CNAME_TARGET,
+  ASSETS_HOSTNAME,
   BOARD_RENDER_CACHE_RULE_DESCRIPTION,
   CACHE_RULE_DESCRIPTION,
   CRAWLER_ALLOW_RULE_DESCRIPTION,
@@ -11,8 +13,10 @@ import {
   CRAWLER_BLOCK_RULE_DESCRIPTION,
   CRAWLER_BLOCK_TOKENS,
   WWW_HOSTNAME,
+  WS_HOSTNAME,
   desiredCloudflareState,
 } from '../infra/cloudflare/config';
+import type { DnsRecordDesired, FullyManagedDnsRecordDesired } from '../infra/cloudflare/config';
 import {
   buildPlan,
   cacheRuleMatches,
@@ -24,19 +28,48 @@ import {
   upsertCacheRule,
 } from '../infra/cloudflare/plan';
 import type { LiveDnsRecord, LiveState, RulesetRule } from '../infra/cloudflare/plan';
-import { SHARED_TOKEN_SCOPES, TOKEN_SCOPES, parseArgs } from './cloudflare-apply';
+import { SHARED_TOKEN_SCOPES, TOKEN_SCOPES, fullyManagedDnsBody, parseArgs } from './cloudflare-apply';
 
 const desired = desiredCloudflareState;
+
+function requiredDnsRecord(name: string): DnsRecordDesired {
+  const record = desired.dnsRecords.find((candidate) => candidate.name === name);
+  if (!record) throw new Error(`Expected ${name} in desired Cloudflare DNS state`);
+  return record;
+}
+
+function requiredFullyManagedDnsRecord(name: string): FullyManagedDnsRecordDesired {
+  const record = requiredDnsRecord(name);
+  if (record.management !== 'full') throw new Error(`Expected ${name} to be fully managed`);
+  return record;
+}
+
+const wsDnsRecord = requiredDnsRecord(WS_HOSTNAME);
+const assetsDnsRecord = requiredFullyManagedDnsRecord(ASSETS_HOSTNAME);
 /** The og cache rule — the one the pre-existing cases in this file were written against. */
 const ogCacheRule = desired.cacheRules[0];
 
 function liveDnsRecord(overrides: Partial<LiveDnsRecord> = {}): LiveDnsRecord {
   return {
     id: 'dns-record-id',
-    name: desired.dns.name,
+    name: wsDnsRecord.name,
     type: 'CNAME',
     content: 'boardsesh-backend.up.railway.app',
+    ttl: 1,
     proxied: true,
+    ...overrides,
+  };
+}
+
+function liveAssetsDnsRecord(overrides: Partial<LiveDnsRecord> = {}): LiveDnsRecord {
+  return {
+    id: 'assets-dns-record-id',
+    name: assetsDnsRecord.name,
+    type: assetsDnsRecord.type,
+    content: assetsDnsRecord.content,
+    ttl: assetsDnsRecord.ttl,
+    proxied: assetsDnsRecord.proxied,
+    settings: assetsDnsRecord.settings,
     ...overrides,
   };
 }
@@ -94,10 +127,14 @@ function matchingLiveRules(
 
 function inSyncLiveState(): LiveState {
   return {
-    dnsRecord: liveDnsRecord(),
+    dnsRecords: {
+      [wsDnsRecord.name]: liveDnsRecord(),
+      [assetsDnsRecord.name]: liveAssetsDnsRecord(),
+    },
     cacheRules: matchingLiveRules(desired.cacheRules),
     wafRules: matchingLiveRules(desired.wafRules),
     sslMode: 'strict',
+    flattenAllCnames: false,
   };
 }
 
@@ -123,14 +160,56 @@ describe('parseArgs', () => {
 
 describe('diffDnsRecord', () => {
   it('is a no-op when the record is already proxied', () => {
-    expect(diffDnsRecord(desired.dns, liveDnsRecord({ proxied: true }))).toBeNull();
+    expect(diffDnsRecord(wsDnsRecord, liveDnsRecord({ proxied: true }))).toBeNull();
   });
 
   it('plans a proxied flip when the record is grey-clouded', () => {
-    const change = diffDnsRecord(desired.dns, liveDnsRecord({ proxied: false }));
+    const change = diffDnsRecord(wsDnsRecord, liveDnsRecord({ proxied: false }));
     expect(change).not.toBeNull();
     expect(change?.resource).toBe('dns');
+    expect(change?.dnsName).toBe(WS_HOSTNAME);
     expect(change?.summary).toContain('proxied false → true');
+  });
+
+  it('does not take ownership of the existing ws record target, type, or TTL', () => {
+    expect(
+      diffDnsRecord(wsDnsRecord, liveDnsRecord({ type: 'A', content: '203.0.113.10', ttl: 300, proxied: true })),
+    ).toBeNull();
+  });
+
+  it('plans creation of the fully managed assets record when it is missing', () => {
+    const change = diffDnsRecord(assetsDnsRecord, null);
+    expect(change).toMatchObject({
+      resource: 'dns',
+      dnsName: ASSETS_HOSTNAME,
+      summary: expect.stringContaining('missing — will create'),
+    });
+    expect(change?.detail).toContain(ASSETS_CNAME_TARGET);
+    expect(change?.detail).toContain('ttl automatic');
+    expect(change?.detail).toContain('proxied false');
+    expect(change?.detail).toContain('CNAME flattening disabled');
+  });
+
+  it('is a no-op when every owned assets field matches', () => {
+    expect(diffDnsRecord(assetsDnsRecord, liveAssetsDnsRecord())).toBeNull();
+  });
+
+  it('plans correction of every owned assets field when it drifts', () => {
+    const change = diffDnsRecord(
+      assetsDnsRecord,
+      liveAssetsDnsRecord({ type: 'A', content: 'old.example.com', ttl: 300, proxied: true }),
+    );
+    expect(change?.summary).toContain('managed fields differ — will update');
+    expect(change?.detail).toContain('type A → CNAME');
+    expect(change?.detail).toContain(`content old.example.com → ${ASSETS_CNAME_TARGET}`);
+    expect(change?.detail).toContain('ttl 300 → automatic');
+    expect(change?.detail).toContain('proxied true → false');
+  });
+
+  it('plans disabling per-record CNAME flattening when it drifts', () => {
+    const change = diffDnsRecord(assetsDnsRecord, liveAssetsDnsRecord({ settings: { flatten_cname: true } }));
+
+    expect(change?.detail).toContain('flatten_cname true → false');
   });
 });
 
@@ -238,10 +317,14 @@ describe('buildPlan', () => {
 
   it('collects every drift (dns + cache + ssl) into one plan', () => {
     const drifted: LiveState = {
-      dnsRecord: liveDnsRecord({ proxied: false }),
+      dnsRecords: {
+        [wsDnsRecord.name]: liveDnsRecord({ proxied: false }),
+        [assetsDnsRecord.name]: liveAssetsDnsRecord(),
+      },
       cacheRules: [foreignRule('foreign-a')],
       wafRules: matchingLiveRules(desired.wafRules),
       sslMode: 'full',
+      flattenAllCnames: false,
     };
     const changes = buildPlan(desired, drifted, { allowZoneSsl: false });
     // Cutover-safe order: the proxied flip is planned last, after SSL + the rules.
@@ -259,14 +342,77 @@ describe('buildPlan', () => {
 
   it('does not hold back the proxied flip when SSL is already compliant', () => {
     const drifted: LiveState = {
-      dnsRecord: liveDnsRecord({ proxied: false }),
+      dnsRecords: {
+        [wsDnsRecord.name]: liveDnsRecord({ proxied: false }),
+        [assetsDnsRecord.name]: liveAssetsDnsRecord(),
+      },
       cacheRules: [],
       wafRules: [],
       sslMode: 'strict',
+      flattenAllCnames: false,
     };
     const changes = buildPlan(desired, drifted, { allowZoneSsl: false });
     const dnsChange = changes.find((change) => change.resource === 'dns');
     expect(dnsChange?.blocked).toBeUndefined();
+  });
+
+  it('plans multiple DNS records independently and does not SSL-block a DNS-only create', () => {
+    const drifted: LiveState = {
+      dnsRecords: {
+        [wsDnsRecord.name]: liveDnsRecord({ proxied: false }),
+        [assetsDnsRecord.name]: null,
+      },
+      cacheRules: matchingLiveRules(desired.cacheRules),
+      wafRules: matchingLiveRules(desired.wafRules),
+      sslMode: 'full',
+      flattenAllCnames: false,
+    };
+    const changes = buildPlan(desired, drifted, { allowZoneSsl: false });
+    const dnsChanges = changes.filter((change) => change.resource === 'dns');
+
+    expect(dnsChanges.map((change) => change.dnsName)).toEqual([WS_HOSTNAME, ASSETS_HOSTNAME]);
+    expect(dnsChanges.find((change) => change.dnsName === WS_HOSTNAME)?.blocked).toBe(true);
+    expect(dnsChanges.find((change) => change.dnsName === ASSETS_HOSTNAME)?.blocked).toBeUndefined();
+  });
+
+  it('fails closed when zone-wide flattening would hide the Tigris verification CNAME', () => {
+    const flattenedZone: LiveState = { ...inSyncLiveState(), flattenAllCnames: true };
+
+    expect(() => buildPlan(desired, flattenedZone, { allowZoneSsl: false })).toThrow('Disable "Flatten all CNAMEs"');
+  });
+});
+
+describe('assets.boardsesh.com desired state', () => {
+  it('declares the exact DNS-only Tigris CNAME with automatic TTL', () => {
+    expect(assetsDnsRecord).toEqual({
+      management: 'full',
+      name: 'assets.boardsesh.com',
+      type: 'CNAME',
+      content: 'boardsesh-static-assets.t3.tigrisbucket.io',
+      ttl: 1,
+      proxied: false,
+      settings: {
+        flatten_cname: false,
+      },
+    });
+  });
+
+  it('writes the complete Cloudflare create/update body including the anti-flattening guard', () => {
+    expect(fullyManagedDnsBody(assetsDnsRecord)).toEqual({
+      type: 'CNAME',
+      name: 'assets.boardsesh.com',
+      content: 'boardsesh-static-assets.t3.tigrisbucket.io',
+      ttl: 1,
+      proxied: false,
+      settings: {
+        flatten_cname: false,
+      },
+    });
+  });
+
+  it('keeps DNS record identities unique and adds no assets cache rule', () => {
+    expect(new Set(desired.dnsRecords.map((record) => record.name)).size).toBe(desired.dnsRecords.length);
+    expect(desired.cacheRules.every((rule) => !rule.expression.includes(ASSETS_HOSTNAME))).toBe(true);
   });
 });
 
@@ -481,6 +627,15 @@ describe('deploy-cloudflare workflow wiring', () => {
     expect(parseArgs(['--apply'])).toEqual({ apply: true, allowZoneSsl: false, help: false });
     expect(parseArgs(['--apply', '--allow-zone-ssl'])).toEqual({ apply: true, allowZoneSsl: true, help: false });
   });
+
+  it('converges Cloudflare before publishing assets when both targets change', () => {
+    const syncJob = workflow.slice(workflow.indexOf('  sync-static-assets:'), workflow.indexOf('  build-web:'));
+
+    expect(syncJob).toContain('needs: [detect-changes, deploy-cloudflare]');
+    expect(syncJob).toContain('always()');
+    expect(syncJob).toContain("needs.deploy-cloudflare.result == 'success'");
+    expect(syncJob).toContain("needs.deploy-cloudflare.result == 'skipped'");
+  });
 });
 
 describe('token scope guidance', () => {
@@ -494,7 +649,7 @@ describe('token scope guidance', () => {
     // zone was the failure mode rather than a clean error.
     const printed = TOKEN_SCOPES.join('\n');
     expect(printed).toContain('Zone.Zone Read'); // GET /zones?name= (resolve the zone id)
-    expect(printed).toContain('Zone.DNS Edit'); // PATCH the ws record's proxied flag
+    expect(printed).toContain('Zone.DNS Edit'); // PATCH ws; create/update the assets CNAME
     expect(printed).toContain('Zone.Cache Rules Edit'); // PUT the cache-settings phase
     expect(printed).toContain('Zone.WAF Edit'); // PUT the firewall-custom phase
     expect(printed).toContain('Zone.Zone Settings Read'); // GET /settings/ssl

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -211,6 +211,13 @@ describe('diffDnsRecord', () => {
 
     expect(change?.detail).toContain('flatten_cname true → false');
   });
+
+  it('reports explicit desired TTLs without calling them automatic', () => {
+    const explicitTtl = { ...assetsDnsRecord, ttl: 300 };
+    const change = diffDnsRecord(explicitTtl, liveAssetsDnsRecord({ ttl: 1 }));
+
+    expect(change?.detail).toContain('ttl automatic → 300');
+  });
 });
 
 describe('diffSslMode (SSL weaker warning)', () => {

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -648,8 +648,15 @@ describe('deploy-cloudflare workflow wiring', () => {
 
     expect(syncJob).toContain('needs: [detect-changes, deploy-cloudflare]');
     expect(syncJob).toContain('always()');
-    expect(syncJob).toContain("needs.deploy-cloudflare.result == 'success'");
-    expect(syncJob).toContain("needs.deploy-cloudflare.result == 'skipped'");
+    const syncJobCondition = syncJob.slice(0, syncJob.indexOf('    runs-on:'));
+    expect(syncJobCondition).not.toContain('needs.deploy-cloudflare.result');
+    const prerequisiteStep = syncJob.slice(
+      syncJob.indexOf('      - name: Require successful Cloudflare prerequisite'),
+      syncJob.indexOf('      - uses: actions/checkout@v6'),
+    );
+    expect(prerequisiteStep).toContain('CLOUDFLARE_DEPLOY_RESULT: ${{ needs.deploy-cloudflare.result }}');
+    expect(prerequisiteStep).toContain('success|skipped)');
+    expect(prerequisiteStep).toContain('exit 1');
   });
 });
 

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -177,6 +177,10 @@ describe('diffDnsRecord', () => {
     ).toBeNull();
   });
 
+  it('fails closed when the proxy-only ws record is missing', () => {
+    expect(() => diffDnsRecord(wsDnsRecord, null)).toThrow('proxy-only managed');
+  });
+
   it('plans creation of the fully managed assets record when it is missing', () => {
     const change = diffDnsRecord(assetsDnsRecord, null);
     expect(change).toMatchObject({
@@ -636,7 +640,11 @@ describe('deploy-cloudflare workflow wiring', () => {
   });
 
   it('converges Cloudflare before publishing assets when both targets change', () => {
-    const syncJob = workflow.slice(workflow.indexOf('  sync-static-assets:'), workflow.indexOf('  build-web:'));
+    const syncJobStart = workflow.indexOf('  sync-static-assets:');
+    const buildWebStart = workflow.indexOf('  build-web:');
+    expect(syncJobStart).toBeGreaterThan(-1);
+    expect(buildWebStart).toBeGreaterThan(syncJobStart);
+    const syncJob = workflow.slice(syncJobStart, buildWebStart);
 
     expect(syncJob).toContain('needs: [detect-changes, deploy-cloudflare]');
     expect(syncJob).toContain('always()');

--- a/scripts/cloudflare-apply.ts
+++ b/scripts/cloudflare-apply.ts
@@ -9,6 +9,10 @@
  * What it manages (and nothing else on the zone):
  *   - DNS: the `ws.boardsesh.com` record's proxied flag → true (orange cloud). The
  *     record's target/type/content are NOT managed — the record already exists.
+ *     The `assets.boardsesh.com` record is fully managed and created when absent:
+ *     CNAME → the Tigris bucket target, automatic TTL, DNS-only, with per-record
+ *     CNAME flattening disabled. Zone-wide CNAME flattening fails closed because
+ *     it would hide the literal answer Tigris verifies.
  *   - Cache: one rule in the http_request_cache_settings phase that makes
  *     ws.boardsesh.com/og/* eligible for cache and respects the origin TTL. Any OTHER
  *     rule already in that phase is preserved verbatim.
@@ -37,7 +41,7 @@
 
 import { pathToFileURL } from 'node:url';
 import { CACHE_RULE_PHASE, WAF_RULE_PHASE, ZONE_NAME, desiredCloudflareState } from '../infra/cloudflare/config';
-import type { SslMode } from '../infra/cloudflare/config';
+import type { DnsRecordDesired, FullyManagedDnsRecordDesired, SslMode } from '../infra/cloudflare/config';
 import { buildPlan, upsertCacheRule } from '../infra/cloudflare/plan';
 import type { LiveDnsRecord, LiveState, PlannedChange, RulesetRule } from '../infra/cloudflare/plan';
 
@@ -47,7 +51,7 @@ const CF_API_BASE = 'https://api.cloudflare.com/client/v4';
 // missing so a maintainer can create one with the right (minimal) permissions.
 const TOKEN_SCOPES = [
   'Zone.Zone Read           — resolve the zone id by name + read zone list',
-  'Zone.DNS Edit            — patch the ws.boardsesh.com record proxied flag',
+  'Zone.DNS Edit            — manage DNS records + read zone CNAME-flattening settings',
   'Zone.Cache Rules Edit    — create/update the /og/ cache rule',
   'Zone.WAF Edit            — create/update the two crawler rules',
   'Zone.Zone Settings Read  — read the SSL/TLS mode',
@@ -164,20 +168,17 @@ async function resolveZoneId(token: string, zoneName: string): Promise<string> {
   return zone.id;
 }
 
-async function fetchDnsRecord(token: string, zoneId: string, name: string): Promise<LiveDnsRecord> {
+async function fetchDnsRecord(token: string, zoneId: string, name: string): Promise<LiveDnsRecord | null> {
   const records = await cfRequest<LiveDnsRecord[]>(
     token,
     'GET',
     `/zones/${zoneId}/dns_records?name=${encodeURIComponent(name)}`,
   );
-  const record = records.find((candidate) => candidate.name === name);
-  if (!record) {
-    throw new Error(
-      `DNS record "${name}" not found in zone ${zoneId}. This tool only patches the existing ` +
-        `record's proxied flag — create the record first (in the dashboard or your DNS pipeline).`,
-    );
+  const exactRecords = records.filter((candidate) => candidate.name === name);
+  if (exactRecords.length > 1) {
+    throw new Error(`DNS name "${name}" is ambiguous: Cloudflare returned ${exactRecords.length} exact records`);
   }
-  return record;
+  return exactRecords[0] ?? null;
 }
 
 /** A phase's entrypoint ruleset. Returns an empty rule set when the phase has no ruleset yet (404). */
@@ -201,18 +202,72 @@ async function fetchSslMode(token: string, zoneId: string): Promise<string> {
   return setting.value;
 }
 
-async function fetchLiveState(token: string, zoneId: string, dnsName: string): Promise<LiveState> {
-  const [dnsRecord, cacheRules, wafRules, sslMode] = await Promise.all([
-    fetchDnsRecord(token, zoneId, dnsName),
+async function fetchFlattenAllCnames(token: string, zoneId: string): Promise<boolean> {
+  const settings = await cfRequest<{ flatten_all_cnames: boolean }>(token, 'GET', `/zones/${zoneId}/dns_settings`);
+  if (typeof settings.flatten_all_cnames !== 'boolean') {
+    throw new Error(
+      `Cloudflare API returned an invalid flatten_all_cnames value for zone ${zoneId}; refusing to apply DNS changes`,
+    );
+  }
+  return settings.flatten_all_cnames;
+}
+
+async function fetchLiveState(
+  token: string,
+  zoneId: string,
+  desiredDnsRecords: DnsRecordDesired[],
+): Promise<LiveState> {
+  const [fetchedDnsRecords, cacheRules, wafRules, sslMode, flattenAllCnames] = await Promise.all([
+    Promise.all(
+      desiredDnsRecords.map(
+        async (desiredRecord) => [desiredRecord, await fetchDnsRecord(token, zoneId, desiredRecord.name)] as const,
+      ),
+    ),
     fetchPhaseRules(token, zoneId, CACHE_RULE_PHASE),
     fetchPhaseRules(token, zoneId, WAF_RULE_PHASE),
     fetchSslMode(token, zoneId),
+    fetchFlattenAllCnames(token, zoneId),
   ]);
-  return { dnsRecord, cacheRules, wafRules, sslMode };
+  const dnsRecords: Record<string, LiveDnsRecord | null> = {};
+  for (const [desiredRecord, liveRecord] of fetchedDnsRecords) {
+    if (!liveRecord && desiredRecord.management === 'proxied-only') {
+      throw new Error(
+        `DNS record "${desiredRecord.name}" not found in zone ${zoneId}. This tool manages only its proxied flag; ` +
+          `create the record first in the system that owns its target.`,
+      );
+    }
+    dnsRecords[desiredRecord.name] = liveRecord;
+  }
+  return { dnsRecords, cacheRules, wafRules, sslMode, flattenAllCnames };
 }
 
-async function applyDnsProxied(token: string, zoneId: string, recordId: string, proxied: boolean): Promise<void> {
-  await cfRequest(token, 'PATCH', `/zones/${zoneId}/dns_records/${recordId}`, { proxied });
+export function fullyManagedDnsBody(desired: FullyManagedDnsRecordDesired): Record<string, unknown> {
+  return {
+    type: desired.type,
+    name: desired.name,
+    content: desired.content,
+    ttl: desired.ttl,
+    proxied: desired.proxied,
+    settings: desired.settings,
+  };
+}
+
+async function applyDnsRecord(
+  token: string,
+  zoneId: string,
+  desired: DnsRecordDesired,
+  liveRecord: LiveDnsRecord | null,
+): Promise<void> {
+  if (!liveRecord) {
+    if (desired.management === 'proxied-only') {
+      throw new Error(`Cannot create proxy-only DNS record "${desired.name}"; its target is intentionally unmanaged`);
+    }
+    await cfRequest(token, 'POST', `/zones/${zoneId}/dns_records`, fullyManagedDnsBody(desired));
+    return;
+  }
+
+  const body = desired.management === 'proxied-only' ? { proxied: desired.proxied } : fullyManagedDnsBody(desired);
+  await cfRequest(token, 'PATCH', `/zones/${zoneId}/dns_records/${liveRecord.id}`, body);
 }
 
 async function applyPhaseRules(token: string, zoneId: string, phase: string, rules: RulesetRule[]): Promise<void> {
@@ -277,7 +332,7 @@ async function main(): Promise<number> {
   console.log('');
 
   const zoneId = await resolveZoneId(token, desired.zoneName);
-  const live = await fetchLiveState(token, zoneId, desired.dns.name);
+  const live = await fetchLiveState(token, zoneId, desired.dnsRecords);
   const changes = buildPlan(desired, live, { allowZoneSsl: options.allowZoneSsl });
 
   if (changes.length === 0) {
@@ -310,7 +365,9 @@ async function main(): Promise<number> {
     }
 
     if (change.resource === 'dns') {
-      await applyDnsProxied(token, zoneId, live.dnsRecord.id, desired.dns.proxied);
+      const desiredRecord = desired.dnsRecords.find((record) => record.name === change.dnsName);
+      if (!desiredRecord) throw new Error(`No desired DNS record found for planned change "${change.dnsName}"`);
+      await applyDnsRecord(token, zoneId, desiredRecord, live.dnsRecords[desiredRecord.name] ?? null);
       console.log(`[cf-apply] applied: ${change.summary}`);
     } else if (change.resource === 'cache-rule' || change.resource === 'waf-rule') {
       // One PUT per phase, not per planned change. The plan reports each drifted


### PR DESCRIPTION
## Summary

- Manage assets.boardsesh.com as a repo-owned DNS-only CNAME to boardsesh-static-assets.t3.tigrisbucket.io.
- Disable per-record CNAME flattening and fail closed when zone-wide flattening would hide the literal Tigris verification record.
- Run deploy-cloudflare before sync-static-assets when both targets change, preventing public validation from racing DNS convergence.
- Document Tigris custom-domain, CORS, TLS, and post-apply verification steps.

The five STATIC_ASSETS Production environment secrets have been provisioned separately. Do not rerun the failed Production deployment until Tigris CORS and custom-domain TLS are active.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- vp test run scripts/cloudflare-apply.test.ts --reporter=agent (53 passed)
- node --test scripts/check-service-deploy-inputs.test.mjs scripts/production-deploy-changes.test.mjs (30 passed)
- vp check on all seven changed files
- vp run typecheck, including the Next production build
- git diff --check
- Independent implementation QA and post-fix QA review: no remaining blockers