### PR TITLE
fix: accept legacy mixed-case mobile logins

### DIFF
--- a/packages/backend/src/__tests__/native-auth-credentials-integration.test.ts
+++ b/packages/backend/src/__tests__/native-auth-credentials-integration.test.ts
@@ -5,7 +5,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { Socket } from 'node:net';
 import { afterAll, beforeEach, describe, expect, it } from 'vite-plus/test';
 import { hash } from 'bcryptjs';
-import { eq } from 'drizzle-orm';
+import { inArray } from 'drizzle-orm';
 import { users, userCredentials } from '@boardsesh/db/schema/auth';
 import { db } from '../db/client';
 
@@ -72,6 +72,8 @@ function parseJwtSubject(response: MockResponse): unknown {
 }
 
 const testUserId = crypto.randomUUID();
+const oversizedUserIds = Array.from({ length: 9 }, () => crypto.randomUUID());
+const allTestUserIds = [testUserId, ...oversizedUserIds];
 
 describe('native credentials auth against Postgres', () => {
   beforeEach(() => {
@@ -79,7 +81,7 @@ describe('native credentials auth against Postgres', () => {
   });
 
   afterAll(async () => {
-    await db.delete(users).where(eq(users.id, testUserId));
+    await db.delete(users).where(inArray(users.id, allTestUserIds));
   });
 
   it('authenticates a lower-case submission against a legacy mixed-case email row', async () => {
@@ -103,5 +105,33 @@ describe('native credentials auth against Postgres', () => {
 
     expect(response.statusCode).toBe(200);
     expect(parseJwtSubject(response)).toBe(testUserId);
+  });
+
+  it('rejects a case-insensitive group above the credential candidate limit', async () => {
+    const passwordHash = await hash('oversized-group-password', 10);
+    await db.insert(users).values(
+      oversizedUserIds.map((id, index) => ({
+        id,
+        email: 'Oversized.Native.Group@example.com',
+        name: `Oversized Native Login ${index}`,
+      })),
+    );
+    await db.insert(userCredentials).values(
+      oversizedUserIds.map((userId) => ({
+        userId,
+        passwordHash,
+      })),
+    );
+
+    const request = makeRequest({
+      email: 'oversized.native.group@example.com',
+      password: 'oversized-group-password',
+    });
+    const response = makeResponse();
+
+    await handleNativeAuthCredentials(request as unknown as IncomingMessage, response as unknown as ServerResponse);
+
+    expect(response.statusCode).toBe(401);
+    expect(JSON.parse(response.body)).toEqual({ error: 'Invalid email or password' });
   });
 });

--- a/packages/backend/src/__tests__/native-auth-credentials-integration.test.ts
+++ b/packages/backend/src/__tests__/native-auth-credentials-integration.test.ts
@@ -74,6 +74,8 @@ function parseJwtSubject(response: MockResponse): unknown {
 const testUserId = crypto.randomUUID();
 const oversizedUserIds = Array.from({ length: 9 }, () => crypto.randomUUID());
 const allTestUserIds = [testUserId, ...oversizedUserIds];
+const legacyTestEmail = `Legacy.Native.Login.${testUserId}@example.com`;
+const oversizedTestEmail = `Oversized.Native.Group.${oversizedUserIds[0]}@example.com`;
 
 describe('native credentials auth against Postgres', () => {
   beforeEach(() => {
@@ -87,7 +89,7 @@ describe('native credentials auth against Postgres', () => {
   it('authenticates a lower-case submission against a legacy mixed-case email row', async () => {
     await db.insert(users).values({
       id: testUserId,
-      email: 'Legacy.Native.Login@example.com',
+      email: legacyTestEmail,
       name: 'Legacy Native Login',
     });
     await db.insert(userCredentials).values({
@@ -96,7 +98,7 @@ describe('native credentials auth against Postgres', () => {
     });
 
     const request = makeRequest({
-      email: 'legacy.native.login@example.com',
+      email: legacyTestEmail.toLowerCase(),
       password: 'mixed-case-password',
     });
     const response = makeResponse();
@@ -112,7 +114,7 @@ describe('native credentials auth against Postgres', () => {
     await db.insert(users).values(
       oversizedUserIds.map((id, index) => ({
         id,
-        email: 'Oversized.Native.Group@example.com',
+        email: oversizedTestEmail,
         name: `Oversized Native Login ${index}`,
       })),
     );
@@ -124,7 +126,7 @@ describe('native credentials auth against Postgres', () => {
     );
 
     const request = makeRequest({
-      email: 'oversized.native.group@example.com',
+      email: oversizedTestEmail.toLowerCase(),
       password: 'oversized-group-password',
     });
     const response = makeResponse();

--- a/packages/backend/src/__tests__/native-auth-credentials-integration.test.ts
+++ b/packages/backend/src/__tests__/native-auth-credentials-integration.test.ts
@@ -1,0 +1,107 @@
+// @ts-nocheck — __tests__ is excluded from tsconfig.json; Vitest checks this file.
+import crypto from 'node:crypto';
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { Socket } from 'node:net';
+import { afterAll, beforeEach, describe, expect, it } from 'vite-plus/test';
+import { hash } from 'bcryptjs';
+import { eq } from 'drizzle-orm';
+import { users, userCredentials } from '@boardsesh/db/schema/auth';
+import { db } from '../db/client';
+
+process.env.NEXTAUTH_SECRET = 'test-secret-for-native-auth-credentials-integration';
+
+const { handleNativeAuthCredentials, __resetNativeAuthStateForTests } = await import('../handlers/native-auth');
+
+interface MockRequest extends EventEmitter {
+  method?: string;
+  url?: string;
+  headers: Record<string, string | string[]>;
+  socket: Partial<Socket>;
+  destroy: () => void;
+}
+
+interface MockResponse {
+  statusCode: number;
+  body: string;
+  headers: Record<string, unknown>;
+  writeHead: (status: number, headers?: Record<string, unknown>) => void;
+  end: (body?: string) => void;
+  setHeader: (name: string, value: unknown) => void;
+}
+
+function makeRequest(body: unknown): MockRequest {
+  const request = new EventEmitter() as MockRequest;
+  request.method = 'POST';
+  request.url = '/auth/native/credentials';
+  request.headers = {};
+  request.socket = { remoteAddress: '127.0.0.1' };
+  request.destroy = () => undefined;
+  setImmediate(() => {
+    request.emit('data', Buffer.from(JSON.stringify(body), 'utf8'));
+    request.emit('end');
+  });
+  return request;
+}
+
+function makeResponse(): MockResponse {
+  return {
+    statusCode: 0,
+    body: '',
+    headers: {},
+    writeHead(status, headers) {
+      this.statusCode = status;
+      if (headers) Object.assign(this.headers, headers);
+    },
+    end(body) {
+      if (body !== undefined) this.body = body;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+  };
+}
+
+function parseJwtSubject(response: MockResponse): unknown {
+  const parsed = JSON.parse(response.body) as { jwt?: unknown };
+  if (typeof parsed.jwt !== 'string') throw new Error('Expected JWT response');
+  const encodedPayload = parsed.jwt.split('.')[1];
+  if (!encodedPayload) throw new Error('Expected JWT payload');
+  const payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')) as { sub?: unknown };
+  return payload.sub;
+}
+
+const testUserId = crypto.randomUUID();
+
+describe('native credentials auth against Postgres', () => {
+  beforeEach(() => {
+    __resetNativeAuthStateForTests();
+  });
+
+  afterAll(async () => {
+    await db.delete(users).where(eq(users.id, testUserId));
+  });
+
+  it('authenticates a lower-case submission against a legacy mixed-case email row', async () => {
+    await db.insert(users).values({
+      id: testUserId,
+      email: 'Legacy.Native.Login@example.com',
+      name: 'Legacy Native Login',
+    });
+    await db.insert(userCredentials).values({
+      userId: testUserId,
+      passwordHash: await hash('mixed-case-password', 10),
+    });
+
+    const request = makeRequest({
+      email: 'legacy.native.login@example.com',
+      password: 'mixed-case-password',
+    });
+    const response = makeResponse();
+
+    await handleNativeAuthCredentials(request as unknown as IncomingMessage, response as unknown as ServerResponse);
+
+    expect(response.statusCode).toBe(200);
+    expect(parseJwtSubject(response)).toBe(testUserId);
+  });
+});

--- a/packages/backend/src/__tests__/native-auth-credentials.test.ts
+++ b/packages/backend/src/__tests__/native-auth-credentials.test.ts
@@ -5,7 +5,12 @@ import { EventEmitter } from 'node:events';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { Socket } from 'node:net';
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
-import { hash } from 'bcryptjs';
+import { compare, hash } from 'bcryptjs';
+
+vi.mock('bcryptjs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('bcryptjs')>();
+  return { ...actual, compare: vi.fn(actual.compare) };
+});
 
 // ---------------------------------------------------------------------------
 // Test secret — must match what generateTokenPair reads from env
@@ -325,6 +330,7 @@ describe('handleNativeAuthCredentials', () => {
 
     expect(res.statusCode).toBe(401);
     expect(parseBody(res).error).toBe('Invalid email or password');
+    expect(vi.mocked(compare)).toHaveBeenCalledTimes(8);
     expect(mockDbInsertValues).not.toHaveBeenCalled();
   });
 

--- a/packages/backend/src/__tests__/native-auth-credentials.test.ts
+++ b/packages/backend/src/__tests__/native-auth-credentials.test.ts
@@ -18,9 +18,8 @@ process.env.NEXTAUTH_SECRET = TEST_SECRET;
 // Mocks (must be hoisted before importing the handler)
 // ---------------------------------------------------------------------------
 
-// db.select() returns rows queued via mockDbSelectQueue. Every chained call
-// (.from / .where / .limit) is a no-op that returns the same chain object;
-// only the trailing await resolves to the queued result.
+// db.select() returns rows queued via mockDbSelectQueue. Every chained call is
+// a no-op that returns the same chain object; .limit() resolves the queued row.
 const mockDbSelectQueue: unknown[][] = [];
 const mockDbInsertValues = vi.fn(async () => []);
 
@@ -30,12 +29,14 @@ vi.mock('../db/client', () => {
       from() {
         return chain;
       },
+      innerJoin() {
+        return chain;
+      },
       where() {
         return chain;
       },
       limit() {
-        const rows = mockDbSelectQueue.shift() ?? [];
-        return Promise.resolve(rows);
+        return Promise.resolve(mockDbSelectQueue.shift() ?? []);
       },
     };
     return chain;
@@ -135,6 +136,15 @@ function parseBody(res: MockRes): Record<string, unknown> {
   return JSON.parse(res.body) as Record<string, unknown>;
 }
 
+function parseJwtSubject(res: MockRes): unknown {
+  const jwt = parseBody(res).jwt;
+  if (typeof jwt !== 'string') throw new Error('Expected JWT response');
+  const encodedPayload = jwt.split('.')[1];
+  if (!encodedPayload) throw new Error('Expected JWT payload');
+  const payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')) as { sub?: unknown };
+  return payload.sub;
+}
+
 function queueSelect(rows: unknown[]): void {
   mockDbSelectQueue.push(rows);
 }
@@ -153,7 +163,6 @@ describe('handleNativeAuthCredentials', () => {
 
   it('returns JWT + refresh token for valid email + password', async () => {
     const passwordHash = await hash('correct-horse', 10);
-    queueSelect([{ id: 'user-1', email: 'test@example.com' }]);
     queueSelect([{ userId: 'user-1', passwordHash }]);
 
     const req = makeRequest({
@@ -175,7 +184,6 @@ describe('handleNativeAuthCredentials', () => {
 
   it('lower-cases and trims the submitted email before lookup', async () => {
     const passwordHash = await hash('correct-horse', 10);
-    queueSelect([{ id: 'user-1', email: 'test@example.com' }]);
     queueSelect([{ userId: 'user-1', passwordHash }]);
 
     const req = makeRequest({
@@ -187,6 +195,43 @@ describe('handleNativeAuthCredentials', () => {
     await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
 
     expect(res.statusCode).toBe(200);
+  });
+
+  it('authenticates a legacy account whose stored email uses mixed casing', async () => {
+    const passwordHash = await hash('legacy-password', 10);
+    queueSelect([{ userId: 'legacy-user', passwordHash }]);
+
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'legacy.user@example.com', password: 'legacy-password' },
+    });
+    const res = makeResponse();
+
+    await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+
+    expect(res.statusCode).toBe(200);
+    expect(mockDbInsertValues).toHaveBeenCalledWith(expect.objectContaining({ userId: 'legacy-user' }));
+  });
+
+  it('authenticates a later password match among duplicate-by-case accounts', async () => {
+    const firstPasswordHash = await hash('first-password', 10);
+    const secondPasswordHash = await hash('second-password', 10);
+    queueSelect([
+      { userId: 'first-user', passwordHash: firstPasswordHash },
+      { userId: 'second-user', passwordHash: secondPasswordHash },
+    ]);
+
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'DUPLICATE@example.com', password: 'second-password' },
+    });
+    const res = makeResponse();
+
+    await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+
+    expect(res.statusCode).toBe(200);
+    expect(mockDbInsertValues).toHaveBeenCalledWith(expect.objectContaining({ userId: 'second-user' }));
+    expect(parseJwtSubject(res)).toBe('second-user');
   });
 
   it('returns 401 for an unknown email', async () => {
@@ -206,7 +251,6 @@ describe('handleNativeAuthCredentials', () => {
 
   it('returns 401 for a wrong password', async () => {
     const passwordHash = await hash('correct-horse', 10);
-    queueSelect([{ id: 'user-1', email: 'test@example.com' }]);
     queueSelect([{ userId: 'user-1', passwordHash }]);
 
     const req = makeRequest({
@@ -221,9 +265,71 @@ describe('handleNativeAuthCredentials', () => {
     expect(parseBody(res).error).toBe('Invalid email or password');
   });
 
+  it('returns the generic 401 when every duplicate-by-case password is wrong', async () => {
+    const firstPasswordHash = await hash('first-password', 10);
+    const secondPasswordHash = await hash('second-password', 10);
+    queueSelect([
+      { userId: 'first-user', passwordHash: firstPasswordHash },
+      { userId: 'second-user', passwordHash: secondPasswordHash },
+    ]);
+
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'duplicate@example.com', password: 'wrong-password' },
+    });
+    const res = makeResponse();
+
+    await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+
+    expect(res.statusCode).toBe(401);
+    expect(parseBody(res).error).toBe('Invalid email or password');
+    expect(mockDbInsertValues).not.toHaveBeenCalled();
+  });
+
+  it('returns the generic 401 when duplicate-by-case accounts share the submitted password', async () => {
+    const sharedPasswordHash = await hash('shared-password', 10);
+    queueSelect([
+      { userId: 'first-user', passwordHash: sharedPasswordHash },
+      { userId: 'second-user', passwordHash: sharedPasswordHash },
+    ]);
+
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'duplicate@example.com', password: 'shared-password' },
+    });
+    const res = makeResponse();
+
+    await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+
+    expect(res.statusCode).toBe(401);
+    expect(parseBody(res).error).toBe('Invalid email or password');
+    expect(mockDbInsertValues).not.toHaveBeenCalled();
+  });
+
+  it('bounds bcrypt work for an oversized duplicate-by-case account group', async () => {
+    const passwordHash = await hash('candidate-password', 10);
+    queueSelect(
+      Array.from({ length: 9 }, (_, index) => ({
+        userId: `candidate-${index}`,
+        passwordHash,
+      })),
+    );
+
+    const req = makeRequest({
+      method: 'POST',
+      body: { email: 'duplicate@example.com', password: 'candidate-password' },
+    });
+    const res = makeResponse();
+
+    await handleNativeAuthCredentials(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+
+    expect(res.statusCode).toBe(401);
+    expect(parseBody(res).error).toBe('Invalid email or password');
+    expect(mockDbInsertValues).not.toHaveBeenCalled();
+  });
+
   it('returns 401 for an OAuth-only user (no userCredentials row)', async () => {
-    queueSelect([{ id: 'user-oauth', email: 'oauth@example.com' }]);
-    queueSelect([]); // no credentials row
+    queueSelect([]); // inner join excludes the user with no credentials row
 
     const req = makeRequest({
       method: 'POST',
@@ -287,7 +393,6 @@ describe('handleNativeAuthCredentials', () => {
 
     // Make 10 successful requests to fill the bucket (limit is 10/min/IP).
     for (let i = 0; i < 10; i++) {
-      queueSelect([{ id: 'user-1', email: 'test@example.com' }]);
       queueSelect([{ userId: 'user-1', passwordHash }]);
       const req = makeRequest({
         method: 'POST',

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -9,6 +9,7 @@ export const schemaSQL = `
   DROP TABLE IF EXISTS "board_session_participants" CASCADE;
   DROP TABLE IF EXISTS "board_sessions" CASCADE;
   DROP TABLE IF EXISTS "user_climb_percentiles" CASCADE;
+  DROP TABLE IF EXISTS "user_credentials" CASCADE;
   DROP TABLE IF EXISTS "users" CASCADE;
 
   CREATE TABLE IF NOT EXISTS "users" (
@@ -17,6 +18,13 @@ export const schemaSQL = `
     "email" text NOT NULL,
     "emailVerified" timestamp,
     "image" text,
+    "created_at" timestamp DEFAULT now() NOT NULL,
+    "updated_at" timestamp DEFAULT now() NOT NULL
+  );
+
+  CREATE TABLE IF NOT EXISTS "user_credentials" (
+    "user_id" text PRIMARY KEY NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "password_hash" text NOT NULL,
     "created_at" timestamp DEFAULT now() NOT NULL,
     "updated_at" timestamp DEFAULT now() NOT NULL
   );

--- a/packages/backend/src/handlers/native-auth.ts
+++ b/packages/backend/src/handlers/native-auth.ts
@@ -549,10 +549,23 @@ export async function handleNativeAuthCredentials(req: IncomingMessage, res: Ser
       .where(sql`LOWER(${users.email}) = ${normalizedEmail}`)
       .limit(MAX_CREDENTIAL_CANDIDATES + 1);
 
-    if (credentialCandidates.length === 0 || credentialCandidates.length > MAX_CREDENTIAL_CANDIDATES) {
-      // Unknown emails, OAuth-only accounts, and oversized ambiguous groups all
-      // take one dummy comparison and return the same generic response.
+    if (credentialCandidates.length === 0) {
+      // Unknown emails and OAuth-only accounts take one dummy comparison and
+      // return the same generic response.
       await compare(password, DUMMY_PASSWORD_HASH);
+      sendJson(res, 401, { error: INVALID_CREDENTIALS_ERROR });
+      return;
+    }
+
+    if (credentialCandidates.length > MAX_CREDENTIAL_CANDIDATES) {
+      // Keep oversized groups bounded while matching the work performed for
+      // the largest supported group, so the limit sentinel is not observable
+      // through a sudden drop to one bcrypt comparison.
+      await Promise.all(
+        credentialCandidates
+          .slice(0, MAX_CREDENTIAL_CANDIDATES)
+          .map((candidate) => compare(password, candidate.passwordHash)),
+      );
       sendJson(res, 401, { error: INVALID_CREDENTIALS_ERROR });
       return;
     }

--- a/packages/backend/src/handlers/native-auth.ts
+++ b/packages/backend/src/handlers/native-auth.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'http';
 import crypto from 'crypto';
 import { SignJWT, createRemoteJWKSet, jwtVerify } from 'jose';
 import { compare, hash } from 'bcryptjs';
-import { eq, and, isNull, lt, or, isNotNull } from 'drizzle-orm';
+import { eq, and, isNull, lt, or, isNotNull, sql } from 'drizzle-orm';
 import { mobileRefreshTokens, users, userCredentials, accounts, userProfiles } from '@boardsesh/db/schema/auth';
 import { db } from '../db/client';
 import { redisClientManager } from '../redis/client';
@@ -20,6 +20,14 @@ const DUMMY_PASSWORD_HASH = '$2b$10$CwTycUXWue0Thq9StjUM0uJ8/oQbk1Ec7T0p/7K8nXfR
 
 /** Generic error returned for all credential validation failures. */
 const INVALID_CREDENTIALS_ERROR = 'Invalid email or password';
+
+/**
+ * Bound duplicate-by-case password checks so malformed legacy account groups
+ * cannot turn one rate-limited login attempt into unbounded bcrypt work. The
+ * current production maximum is six; leave headroom while account cleanup and
+ * a case-insensitive unique index remain separate work.
+ */
+const MAX_CREDENTIAL_CANDIDATES = 8;
 
 /**
  * Registration field bounds — mirror the web register route's Zod schema
@@ -526,35 +534,50 @@ export async function handleNativeAuthCredentials(req: IncomingMessage, res: Ser
   const normalizedEmail = email.trim().toLowerCase();
 
   try {
-    const userRows = await db.select().from(users).where(eq(users.email, normalizedEmail)).limit(1);
-    const user = userRows[0];
+    // Legacy web accounts may retain mixed-case emails, and users.email is not
+    // currently unique case-insensitively. Load every exact case-insensitive
+    // match so duplicate-by-case accounts can each authenticate with their own
+    // password. Using LOWER rather than ILIKE avoids treating valid email
+    // characters such as `_` as pattern wildcards.
+    const credentialCandidates = await db
+      .select({
+        userId: users.id,
+        passwordHash: userCredentials.passwordHash,
+      })
+      .from(users)
+      .innerJoin(userCredentials, eq(userCredentials.userId, users.id))
+      .where(sql`LOWER(${users.email}) = ${normalizedEmail}`)
+      .limit(MAX_CREDENTIAL_CANDIDATES + 1);
 
-    if (!user) {
-      // Dummy compare against a fixed hash to mask the user-lookup miss in
-      // response time. Result is intentionally discarded.
+    if (credentialCandidates.length === 0 || credentialCandidates.length > MAX_CREDENTIAL_CANDIDATES) {
+      // Unknown emails, OAuth-only accounts, and oversized ambiguous groups all
+      // take one dummy comparison and return the same generic response.
       await compare(password, DUMMY_PASSWORD_HASH);
       sendJson(res, 401, { error: INVALID_CREDENTIALS_ERROR });
       return;
     }
 
-    const credentialRows = await db.select().from(userCredentials).where(eq(userCredentials.userId, user.id)).limit(1);
-    const credentials = credentialRows[0];
+    // Check every available hash. Aside from supporting duplicate-by-case
+    // accounts, avoiding an early exit keeps success timing independent of a
+    // matching candidate's position in the result set.
+    const passwordMatchResults = await Promise.all(
+      credentialCandidates.map((candidate) => compare(password, candidate.passwordHash)),
+    );
+    const matchingCredentialIndexes = passwordMatchResults.reduce<number[]>((indexes, passwordMatches, index) => {
+      if (passwordMatches) indexes.push(index);
+      return indexes;
+    }, []);
 
-    if (!credentials) {
-      // OAuth-only user with no password. Same dummy compare for timing parity.
-      await compare(password, DUMMY_PASSWORD_HASH);
+    // Duplicate-by-case accounts can share a password. Without an unambiguous
+    // match there is no safe account to issue the session for.
+    if (matchingCredentialIndexes.length !== 1) {
       sendJson(res, 401, { error: INVALID_CREDENTIALS_ERROR });
       return;
     }
 
-    const passwordMatches = await compare(password, credentials.passwordHash);
-    if (!passwordMatches) {
-      sendJson(res, 401, { error: INVALID_CREDENTIALS_ERROR });
-      return;
-    }
-
-    const tokenPair = await generateTokenPair(user.id);
-    logger.info(`[NativeAuth] Credentials sign-in successful for user ${user.id}`);
+    const authenticatedUserId = credentialCandidates[matchingCredentialIndexes[0]].userId;
+    const tokenPair = await generateTokenPair(authenticatedUserId);
+    logger.info(`[NativeAuth] Credentials sign-in successful for user ${authenticatedUserId}`);
     sendJson(res, 200, tokenPair);
   } catch (error) {
     logger.error('[NativeAuth] Credentials sign-in failed:', error);

--- a/packages/mobile/app/auth/__tests__/login-register-link.test.tsx
+++ b/packages/mobile/app/auth/__tests__/login-register-link.test.tsx
@@ -26,7 +26,8 @@ vi.mock('react-native', () => ({
   },
   KeyboardAvoidingView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
-  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  View: ({ children, accessibilityRole }: { children?: ReactNode; accessibilityRole?: string }) =>
+    createElement('div', { role: accessibilityRole }, children),
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
   Pressable: ({ onPress, children }: { onPress?: () => void; children?: ReactNode }) =>
     createElement('button', { onClick: onPress }, children),
@@ -91,6 +92,7 @@ describe('LoginScreen', () => {
 
     const { container } = render(<LoginScreen />);
 
+    expect(container.querySelector('[role="alert"]')).toBeNull();
     expect(container.textContent).not.toContain('login.splitScreenNotice');
   });
 

--- a/packages/mobile/app/auth/__tests__/login-register-link.test.tsx
+++ b/packages/mobile/app/auth/__tests__/login-register-link.test.tsx
@@ -13,9 +13,17 @@ import { createElement, type ReactNode } from 'react';
 
 const router = vi.hoisted(() => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }));
 const returnHrefState = vi.hoisted(() => ({ current: null as string | null }));
+const platformState = vi.hoisted(() => ({ os: 'web', version: undefined as number | undefined }));
 
 vi.mock('react-native', () => ({
-  Platform: { OS: 'web', Version: undefined },
+  Platform: {
+    get OS() {
+      return platformState.os;
+    },
+    get Version() {
+      return platformState.version;
+    },
+  },
   KeyboardAvoidingView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
@@ -45,7 +53,6 @@ vi.mock('../../../src/hooks/use-native-oauth-sign-in', () => ({
 }));
 vi.mock('../../../src/components/AuthFieldset', () => ({ AuthFieldset: () => null }));
 vi.mock('../../../src/components/Button', () => ({ Button: () => null }));
-vi.mock('../../../src/components/Icon', () => ({ Icon: () => null }));
 vi.mock('../../../src/components/auth/OAuthProviderButtons', () => ({
   OAuthProviderButtons: () => null,
   useOAuthProviders: () => ({ loading: false, error: null, apple: false, google: false }),
@@ -71,11 +78,22 @@ function linkByKey(container: HTMLElement, key: string): HTMLElement {
 beforeEach(() => {
   vi.clearAllMocks();
   returnHrefState.current = null;
+  platformState.os = 'web';
+  platformState.version = undefined;
 });
 
 const RETURN_PATH = '/b/the-gym/40/view/crimpy-thing-0A1B2C3D4E5F60718293A4B5C6D7E8F9';
 
-describe('LoginScreen sign-up link', () => {
+describe('LoginScreen', () => {
+  it('does not show the retired split-screen warning on Android 15+', () => {
+    platformState.os = 'android';
+    platformState.version = 35;
+
+    const { container } = render(<LoginScreen />);
+
+    expect(container.textContent).not.toContain('login.splitScreenNotice');
+  });
+
   it('forwards a read-only return path to the register screen', () => {
     returnHrefState.current = RETURN_PATH;
 

--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -11,7 +11,6 @@ import { useTheme } from '../../src/providers/theme-provider';
 import { useNativeOAuthSignIn } from '../../src/hooks/use-native-oauth-sign-in';
 import { AuthFieldset } from '../../src/components/AuthFieldset';
 import { Button } from '../../src/components/Button';
-import { Icon } from '../../src/components/Icon';
 import { track } from '../../src/lib/analytics';
 import { reportError } from '../../src/lib/error-reporting';
 import { hapticLight } from '../../src/lib/haptics';
@@ -97,13 +96,6 @@ export default function LoginScreen() {
     }
   }
 
-  // Newer Android (15+/edge-to-edge) can leave the login form touch-dead in full
-  // screen while split-screen restores touch — under investigation. Surface the
-  // split-screen workaround so a stuck user can still sign in. iOS/older Android
-  // are unaffected, so the notice is gated to the device class that hits it.
-  const showAndroidFreezeNotice =
-    Platform.OS === 'android' && typeof Platform.Version === 'number' && Platform.Version >= 35;
-
   const oauthProviders = useOAuthProviders();
   const showSocialSignIn =
     oauthProviders.loading || oauthProviders.error || oauthProviders.apple || oauthProviders.google;
@@ -115,25 +107,6 @@ export default function LoginScreen() {
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="interactive"
       >
-        {showAndroidFreezeNotice ? (
-          <View
-            style={[
-              styles.freezeNotice,
-              { backgroundColor: theme.systemColors.secondaryBackground, borderColor: theme.systemColors.separator },
-            ]}
-            accessibilityRole="alert"
-          >
-            <Icon name="warning" size={22} color={theme.brandColors.warning} />
-            <View style={styles.freezeNoticeText}>
-              <Text style={[styles.freezeNoticeTitle, { color: theme.systemColors.label }]}>
-                {t('login.splitScreenNotice.title')}
-              </Text>
-              <Text style={[styles.freezeNoticeBody, { color: theme.systemColors.secondaryLabel }]}>
-                {t('login.splitScreenNotice.body')}
-              </Text>
-            </View>
-          </View>
-        ) : null}
         <View style={styles.header}>
           <Image
             source={require('../../assets/splash-icon.png')}
@@ -279,27 +252,6 @@ export default function LoginScreen() {
 
 const styles = StyleSheet.create({
   container: { flexGrow: 1, justifyContent: 'center', padding: 24 },
-  freezeNotice: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    gap: 12,
-    padding: 14,
-    borderRadius: 12,
-    borderWidth: StyleSheet.hairlineWidth,
-    marginBottom: 24,
-  },
-  freezeNoticeText: {
-    flex: 1,
-    gap: 4,
-  },
-  freezeNoticeTitle: {
-    fontSize: 15,
-    fontWeight: '700',
-  },
-  freezeNoticeBody: {
-    fontSize: 14,
-    lineHeight: 19,
-  },
   header: { alignItems: 'center', marginBottom: 32 },
   logo: { width: 96, height: 96, marginBottom: 16 },
   title: { fontSize: 34, fontWeight: '700', marginBottom: 8 },

--- a/packages/shared/i18n/locales/de/auth.json
+++ b/packages/shared/i18n/locales/de/auth.json
@@ -64,10 +64,6 @@
       "discord": "Discord beitreten",
       "forgotPassword": "Passwort vergessen?"
     },
-    "splitScreenNotice": {
-      "title": "Anmeldung reagiert nicht?",
-      "body": "Auf manchen neueren Android-Handys friert der Anmeldebildschirm ein. Nutz solange den Splitscreen zum Anmelden, während wir das reparieren."
-    },
     "a11y": {
       "showPassword": "Passwort anzeigen",
       "hidePassword": "Passwort verbergen",

--- a/packages/shared/i18n/locales/en-US/auth.json
+++ b/packages/shared/i18n/locales/en-US/auth.json
@@ -64,10 +64,6 @@
       "discord": "Join Discord",
       "forgotPassword": "Forgot password?"
     },
-    "splitScreenNotice": {
-      "title": "Sign-in not responding?",
-      "body": "On some newer Android phones the login screen can freeze. Open split-screen view to sign in while we fix it."
-    },
     "a11y": {
       "showPassword": "Show password",
       "hidePassword": "Hide password",

--- a/packages/shared/i18n/locales/es/auth.json
+++ b/packages/shared/i18n/locales/es/auth.json
@@ -64,10 +64,6 @@
       "discord": "Únete a Discord",
       "forgotPassword": "¿Olvidaste tu contraseña?"
     },
-    "splitScreenNotice": {
-      "title": "¿El inicio de sesión no responde?",
-      "body": "En algunos teléfonos Android recientes la pantalla de inicio de sesión puede congelarse. Abre la vista de pantalla dividida para iniciar sesión mientras lo solucionamos."
-    },
     "a11y": {
       "showPassword": "Mostrar contraseña",
       "hidePassword": "Ocultar contraseña",

--- a/packages/shared/i18n/locales/fr/auth.json
+++ b/packages/shared/i18n/locales/fr/auth.json
@@ -64,10 +64,6 @@
       "discord": "Rejoindre Discord",
       "forgotPassword": "Mot de passe oublié ?"
     },
-    "splitScreenNotice": {
-      "title": "La connexion ne répond pas ?",
-      "body": "Sur certains téléphones Android récents, l'écran de connexion peut se figer. Ouvrez le mode écran partagé pour vous connecter le temps que nous corrigions le problème."
-    },
     "a11y": {
       "showPassword": "Afficher le mot de passe",
       "hidePassword": "Masquer le mot de passe",


### PR DESCRIPTION
## Summary

- Match native email/password logins case-insensitively for legacy accounts.
- Select only an unambiguous password match across duplicate-case accounts.
- Bound bcrypt work and remove the obsolete Android split-screen warning.

## Release Notes

Email sign-in now works when your account email contains uppercase letters.
The old Android split-screen sign-in warning is gone.

- [ ] No release note needed (internal / technical change)

## Test plan

1. Open Android login → old split-screen warning is gone.
2. Enter mixed-case account credentials → app opens signed in.
3. Enter wrong password → invalid-credentials message appears.

## Risk

Risk: 4/5 — changes native credential selection without changing stored accounts.
