### PR TITLE
fix(db): bound production connection pressure

### DIFF
--- a/.github/workflows/pgbouncer-image.yml
+++ b/.github/workflows/pgbouncer-image.yml
@@ -1,0 +1,107 @@
+name: Build and Publish PgBouncer Image
+
+on:
+  push:
+    branches: [main]
+    paths: &pgbouncer_paths
+      - 'deploy/pgbouncer/**'
+      - '.github/workflows/pgbouncer-image.yml'
+      - 'scripts/__tests__/pgbouncer-config.test.ts'
+  pull_request:
+    paths: *pgbouncer_paths
+
+concurrency:
+  group: pgbouncer-image-${{ github.event_name == 'push' && 'production' || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  IMAGE: ghcr.io/boardsesh/boardsesh-pgbouncer
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Build pull-request image without publishing
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: deploy/pgbouncer
+          file: deploy/pgbouncer/Dockerfile
+          platforms: linux/amd64
+          load: true
+          push: false
+          provenance: false
+          tags: boardsesh-pgbouncer:pr-smoke
+          cache-from: type=gha,scope=pgbouncer
+
+      - name: Smoke-test image and runtime rendering
+        run: sh deploy/pgbouncer/smoke-test.sh boardsesh-pgbouncer:pr-smoke
+
+  build-and-push:
+    if: github.event_name == 'push'
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Enable multi-architecture emulation
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: metadata
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=production
+            type=sha,prefix=sha-,format=long
+
+      - name: Build and publish image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: deploy/pgbouncer
+          file: deploy/pgbouncer/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          pull: true
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha,scope=pgbouncer
+          cache-to: type=gha,mode=max,scope=pgbouncer
+          provenance: mode=max
+
+      - name: Attest published image provenance
+        uses: actions/attest-build-provenance@8beda2b7ed98355c0e97c0a63bec38ae472e66c4 # v4
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -585,9 +585,25 @@ jobs:
       - name: Install dependencies
         run: vp install --frozen-lockfile
 
+      - name: Require direct database connection
+        env:
+          DATABASE_DIRECT_URL: ${{ secrets.DATABASE_DIRECT_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          if [ -z "$DATABASE_DIRECT_URL" ]; then
+            echo "::error::DATABASE_DIRECT_URL is required; migrations must bypass PgBouncer transaction pooling."
+            exit 1
+          fi
+          if [ "$DATABASE_DIRECT_URL" = "$DATABASE_URL" ]; then
+            echo "::error::DATABASE_DIRECT_URL must differ from the pooled DATABASE_URL; migrations must connect directly."
+            exit 1
+          fi
+
       - name: Run database migrations
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          # Migrations use session features that transaction pooling cannot
+          # preserve. Never fall back to the pooled runtime connection.
+          DATABASE_URL: ${{ secrets.DATABASE_DIRECT_URL }}
           VERIFY_MIGRATION_JOURNAL: '1'
         run: vp exec pnpm --filter @boardsesh/db run db:migrate
 

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -585,19 +585,11 @@ jobs:
       - name: Install dependencies
         run: vp install --frozen-lockfile
 
-      - name: Require direct database connection
+      - name: Verify direct database connection
         env:
+          DATABASE_DIRECT_ENDPOINT: ${{ vars.DATABASE_DIRECT_ENDPOINT }}
           DATABASE_DIRECT_URL: ${{ secrets.DATABASE_DIRECT_URL }}
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-        run: |
-          if [ -z "$DATABASE_DIRECT_URL" ]; then
-            echo "::error::DATABASE_DIRECT_URL is required; migrations must bypass PgBouncer transaction pooling."
-            exit 1
-          fi
-          if [ "$DATABASE_DIRECT_URL" = "$DATABASE_URL" ]; then
-            echo "::error::DATABASE_DIRECT_URL must differ from the pooled DATABASE_URL; migrations must connect directly."
-            exit 1
-          fi
+        run: vp exec tsx packages/db/scripts/verify-direct-database.ts
 
       - name: Run database migrations
         env:

--- a/deploy/pgbouncer/Dockerfile
+++ b/deploy/pgbouncer/Dockerfile
@@ -1,0 +1,63 @@
+FROM debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171 AS builder
+
+ARG PGBOUNCER_VERSION=1.25.2
+ARG PGBOUNCER_SHA256=924ad35113fd0a71c8e2dbe85b5d03445532e2b7b37a9f8a48983beea238b332
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      curl \
+      libc-ares-dev \
+      libevent-dev \
+      libssl-dev \
+      pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+RUN curl --fail --location --proto '=https' --tlsv1.2 \
+      "https://www.pgbouncer.org/downloads/files/${PGBOUNCER_VERSION}/pgbouncer-${PGBOUNCER_VERSION}.tar.gz" \
+      --output pgbouncer.tar.gz \
+    && printf '%s  %s\n' "${PGBOUNCER_SHA256}" pgbouncer.tar.gz | sha256sum --check --strict \
+    && tar --extract --gzip --file pgbouncer.tar.gz --strip-components=1 \
+    && ./configure --prefix=/usr/local --with-cares \
+    && make -j"$(nproc)" pgbouncer \
+    && install --directory /staging/usr/local/bin \
+    && install --mode=0755 pgbouncer /staging/usr/local/bin/pgbouncer \
+    && pgbouncer_version_output="$(/staging/usr/local/bin/pgbouncer --version)" \
+    && printf '%s\n' "$pgbouncer_version_output" | grep --line-regexp --fixed-strings "PgBouncer ${PGBOUNCER_VERSION}" \
+    && printf '%s\n' "$pgbouncer_version_output" | grep --fixed-strings 'adns: c-ares' \
+    && printf '%s\n' "$pgbouncer_version_output" | grep --fixed-strings 'tls: OpenSSL'
+
+FROM debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171 AS runtime
+
+LABEL org.opencontainers.image.source="https://github.com/boardsesh/boardsesh" \
+      org.opencontainers.image.title="Boardsesh PgBouncer" \
+      org.opencontainers.image.version="1.25.2" \
+      org.opencontainers.image.licenses="ISC"
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+      ca-certificates \
+      libc-ares2 \
+      libevent-2.1-7 \
+      libssl3 \
+      openssl \
+      postgresql-client \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 10001 pgbouncer \
+    && useradd --uid 10001 --gid pgbouncer --no-create-home --home-dir /nonexistent --shell /usr/sbin/nologin pgbouncer \
+    && install --directory --owner=pgbouncer --group=pgbouncer --mode=0700 /run/pgbouncer
+
+COPY --from=builder /staging/usr/local/bin/pgbouncer /usr/local/bin/pgbouncer
+COPY --chmod=0755 docker-entrypoint.sh healthcheck.sh /usr/local/bin/
+
+USER 10001:10001
+
+EXPOSE 6432
+STOPSIGNAL SIGTERM
+
+HEALTHCHECK --interval=10s --timeout=5s --start-period=10s --retries=3 CMD ["/usr/local/bin/healthcheck.sh"]
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/deploy/pgbouncer/README.md
+++ b/deploy/pgbouncer/README.md
@@ -79,7 +79,10 @@ gh attestation verify \
   --repo boardsesh/boardsesh
 ```
 
-Database migrations require a direct PostgreSQL URL that is distinct from the
-pooled `DATABASE_URL`. Production fails before migrations when
-`DATABASE_DIRECT_URL` is absent or exactly equals `DATABASE_URL`; it never falls
-back to PgBouncer or retains the pooled URL as a durable migration fallback.
+Database migrations require a direct PostgreSQL URL. Production compares the
+URL's non-credential `host:port/database` identity with the protected
+`DATABASE_DIRECT_ENDPOINT` environment variable, then runs a TLS `SELECT 1`.
+The PgBouncer endpoint must not match that pinned identity. Before cutover
+`DATABASE_DIRECT_URL` may equal the still-direct runtime `DATABASE_URL`. After
+cutover the URLs naturally differ because only runtime traffic uses the pooler.
+Migrations never fall back to the runtime connection.

--- a/deploy/pgbouncer/README.md
+++ b/deploy/pgbouncer/README.md
@@ -1,0 +1,85 @@
+# Boardsesh PgBouncer image
+
+This image runs PgBouncer 1.25.2 in transaction-pooling mode. Deploy exactly
+one replica: its 45-connection database and upstream-user limits are per
+PgBouncer process, so replicas would multiply the PostgreSQL connection budget.
+Client connections are disconnected when a query waits more than 5 seconds for
+an upstream connection. Clients must reconnect and retry transient failures with
+bounded backoff; this deliberately fails fast during pool saturation or
+PostgreSQL outages.
+
+The container listens on port `6432`, requires TLS from clients, and verifies
+the upstream PostgreSQL certificate and hostname. Configure these secret
+environment variables:
+
+- `PGBOUNCER_UPSTREAM_HOST` and optional `PGBOUNCER_UPSTREAM_PORT` (default `5432`)
+- `PGBOUNCER_DATABASE_NAME`, `PGBOUNCER_UPSTREAM_USER`, `PGBOUNCER_UPSTREAM_PASSWORD`
+- `PGBOUNCER_CLIENT_USER`, `PGBOUNCER_CLIENT_PASSWORD`
+- `PGBOUNCER_ADMIN_USER`, `PGBOUNCER_ADMIN_PASSWORD`
+- `PGBOUNCER_SERVER_TLS_CA`
+
+The admin username must be distinct from both application and upstream users,
+and the upstream username must differ from the application username. The HBA
+rules allow application identities to reach only the configured application
+database and the admin identity to reach only PgBouncer's admin console.
+
+Restrict network ingress to the Boardsesh application workloads that use the
+pool, plus an explicit operator source when remote admin-console access is
+needed. TLS and HBA authentication do not replace a service-level firewall or
+private-network allowlist.
+
+The IPv4-only `listen_addr = 0.0.0.0` and HBA rules are intentional for the
+current private network. Review both the HBA rules and network allowlist before
+enabling IPv6 listeners.
+
+Set both `PGBOUNCER_SERVER_TLS_CERT` and `PGBOUNCER_SERVER_TLS_KEY` when the
+upstream requires a client certificate. `PGBOUNCER_LISTEN_PORT` defaults to
+`6432`. Set both `PGBOUNCER_CLIENT_TLS_CERT` and `PGBOUNCER_CLIENT_TLS_KEY` to
+inject a stable client-facing identity. When omitted, the container generates a
+one-year self-signed certificate at boot; clients should use `sslmode=require`
+unless the generated certificate is distributed as a trust anchor. Supply PEM
+contents directly; the entrypoint writes all generated files with owner-only
+permissions and does not print their contents.
+
+Secret environment variables remain visible to operators with container or
+platform inspection access. The client username and password must remain in the
+container configuration because Docker starts health checks independently of
+the PgBouncer process. Restrict deployment-secret and container-inspection
+permissions to trusted operators.
+
+`PGBOUNCER_RUNTIME_DIR` is an internal deployment/test-only override. Production
+should leave it unset and use `/run/pgbouncer`. If a controlled test or
+deployment must set it, use only a trusted absolute path made from letters,
+digits, `_`, `.`, `/`, and `-`, without `..` path segments. Never derive it from
+request or application input.
+
+Rotate client credentials with two PgBouncer deployments:
+
+1. Set `PGBOUNCER_CLIENT_USER_NEXT` and `PGBOUNCER_CLIENT_PASSWORD_NEXT`; deploy.
+2. Move every client to the next credentials and confirm old traffic reaches zero.
+3. Promote the next credentials to the primary variables, remove `_NEXT`; deploy.
+
+The two PgBouncer deployments keep both application identities valid during
+the client rollout. The next username must differ from every active identity.
+Do not use this overlap for upstream or admin credentials. Rotate the upstream
+database role in a controlled database/PgBouncer change, and rotate the admin
+identity separately from application traffic; health must pass after each.
+
+Set the container's open-file limit to at least `2048`. The configured ceiling
+alone can use 500 client sockets plus 45 upstream sockets, before PgBouncer's
+listening sockets, DNS activity, health checks, and runtime overhead.
+
+Production deployments should resolve the full-commit tag to its immutable OCI
+digest and deploy `ghcr.io/boardsesh/boardsesh-pgbouncer@sha256:...`, never the
+mutable `:production` tag directly. Verify its GitHub provenance first:
+
+```sh
+gh attestation verify \
+  oci://ghcr.io/boardsesh/boardsesh-pgbouncer@sha256:DIGEST \
+  --repo boardsesh/boardsesh
+```
+
+Database migrations require a direct PostgreSQL URL that is distinct from the
+pooled `DATABASE_URL`. Production fails before migrations when
+`DATABASE_DIRECT_URL` is absent or exactly equals `DATABASE_URL`; it never falls
+back to PgBouncer or retains the pooled URL as a durable migration fallback.

--- a/deploy/pgbouncer/docker-entrypoint.sh
+++ b/deploy/pgbouncer/docker-entrypoint.sh
@@ -1,0 +1,267 @@
+#!/bin/sh
+set +x
+set -eu
+
+fail() {
+  printf 'PgBouncer configuration error: %s\n' "$1" >&2
+  exit 1
+}
+
+require_variable() {
+  variable_name=$1
+  eval "variable_value=\${${variable_name}:-}"
+  [ -n "$variable_value" ] || fail "$variable_name is required"
+}
+
+validate_identifier() {
+  variable_name=$1
+  variable_value=$2
+  case "$variable_value" in
+    *[!A-Za-z0-9_.@-]*) fail "$variable_name contains unsupported characters" ;;
+  esac
+}
+
+validate_host() {
+  case "$PGBOUNCER_UPSTREAM_HOST" in
+    *[!A-Za-z0-9_.:-]*) fail 'PGBOUNCER_UPSTREAM_HOST contains unsupported characters' ;;
+  esac
+}
+
+validate_port() {
+  variable_name=$1
+  variable_value=$2
+  case "$variable_value" in
+    ''|*[!0-9]*) fail "$variable_name must be an integer from 1 through 65535" ;;
+  esac
+  [ "$variable_value" -ge 1 ] && [ "$variable_value" -le 65535 ] ||
+    fail "$variable_name must be an integer from 1 through 65535"
+}
+
+validate_runtime_directory() {
+  variable_value=$1
+  case "$variable_value" in
+    /*) ;;
+    *) fail 'PGBOUNCER_RUNTIME_DIR must be an absolute path' ;;
+  esac
+  case "$variable_value" in
+    *[!A-Za-z0-9_./-]*) fail 'PGBOUNCER_RUNTIME_DIR contains unsupported characters' ;;
+  esac
+  case "$variable_value" in
+    */../*|*/..) fail "PGBOUNCER_RUNTIME_DIR must not contain '..' path segments" ;;
+  esac
+}
+
+validate_password() {
+  variable_name=$1
+  variable_value=$2
+  carriage_return=$(printf '\r')
+  case "$variable_value" in
+    *"$carriage_return"*|*'
+'*) fail "$variable_name must not contain line breaks" ;;
+  esac
+}
+
+escape_auth_field() {
+  # PgBouncer's auth-file format escapes a double quote by doubling it.
+  printf '%s' "$1" | sed 's/"/""/g'
+}
+
+append_credential() {
+  credential_user=$1
+  credential_password=$2
+  escaped_user=$(escape_auth_field "$credential_user")
+  escaped_password=$(escape_auth_field "$credential_password")
+  printf '"%s" "%s"\n' "$escaped_user" "$escaped_password" >>"$userlist_temporary"
+}
+
+for required_variable in \
+  PGBOUNCER_UPSTREAM_HOST \
+  PGBOUNCER_DATABASE_NAME \
+  PGBOUNCER_UPSTREAM_USER \
+  PGBOUNCER_UPSTREAM_PASSWORD \
+  PGBOUNCER_CLIENT_USER \
+  PGBOUNCER_CLIENT_PASSWORD \
+  PGBOUNCER_ADMIN_USER \
+  PGBOUNCER_ADMIN_PASSWORD \
+  PGBOUNCER_SERVER_TLS_CA; do
+  require_variable "$required_variable"
+done
+
+PGBOUNCER_UPSTREAM_PORT=${PGBOUNCER_UPSTREAM_PORT:-5432}
+PGBOUNCER_LISTEN_PORT=${PGBOUNCER_LISTEN_PORT:-6432}
+PGBOUNCER_RUNTIME_DIR=${PGBOUNCER_RUNTIME_DIR:-/run/pgbouncer}
+
+validate_host
+validate_identifier PGBOUNCER_DATABASE_NAME "$PGBOUNCER_DATABASE_NAME"
+validate_identifier PGBOUNCER_UPSTREAM_USER "$PGBOUNCER_UPSTREAM_USER"
+validate_identifier PGBOUNCER_CLIENT_USER "$PGBOUNCER_CLIENT_USER"
+validate_identifier PGBOUNCER_ADMIN_USER "$PGBOUNCER_ADMIN_USER"
+validate_port PGBOUNCER_UPSTREAM_PORT "$PGBOUNCER_UPSTREAM_PORT"
+validate_port PGBOUNCER_LISTEN_PORT "$PGBOUNCER_LISTEN_PORT"
+validate_runtime_directory "$PGBOUNCER_RUNTIME_DIR"
+validate_password PGBOUNCER_UPSTREAM_PASSWORD "$PGBOUNCER_UPSTREAM_PASSWORD"
+validate_password PGBOUNCER_CLIENT_PASSWORD "$PGBOUNCER_CLIENT_PASSWORD"
+validate_password PGBOUNCER_ADMIN_PASSWORD "$PGBOUNCER_ADMIN_PASSWORD"
+
+if [ "$PGBOUNCER_CLIENT_USER" = "$PGBOUNCER_UPSTREAM_USER" ] ||
+  [ "$PGBOUNCER_CLIENT_USER" = "$PGBOUNCER_ADMIN_USER" ] ||
+  [ "$PGBOUNCER_UPSTREAM_USER" = "$PGBOUNCER_ADMIN_USER" ]; then
+  fail 'client, upstream, and admin users must be pairwise distinct'
+fi
+
+if [ -n "${PGBOUNCER_CLIENT_USER_NEXT:-}" ] || [ -n "${PGBOUNCER_CLIENT_PASSWORD_NEXT:-}" ]; then
+  [ -n "${PGBOUNCER_CLIENT_USER_NEXT:-}" ] && [ -n "${PGBOUNCER_CLIENT_PASSWORD_NEXT:-}" ] ||
+    fail 'PGBOUNCER_CLIENT_USER_NEXT and PGBOUNCER_CLIENT_PASSWORD_NEXT must be set together'
+  validate_identifier PGBOUNCER_CLIENT_USER_NEXT "$PGBOUNCER_CLIENT_USER_NEXT"
+  validate_password PGBOUNCER_CLIENT_PASSWORD_NEXT "$PGBOUNCER_CLIENT_PASSWORD_NEXT"
+  if [ "$PGBOUNCER_CLIENT_USER_NEXT" = "$PGBOUNCER_CLIENT_USER" ] ||
+    [ "$PGBOUNCER_CLIENT_USER_NEXT" = "$PGBOUNCER_UPSTREAM_USER" ] ||
+    [ "$PGBOUNCER_CLIENT_USER_NEXT" = "$PGBOUNCER_ADMIN_USER" ]; then
+    fail 'PGBOUNCER_CLIENT_USER_NEXT must be distinct from all active users'
+  fi
+fi
+
+if [ -n "${PGBOUNCER_SERVER_TLS_CERT:-}" ] || [ -n "${PGBOUNCER_SERVER_TLS_KEY:-}" ]; then
+  [ -n "${PGBOUNCER_SERVER_TLS_CERT:-}" ] && [ -n "${PGBOUNCER_SERVER_TLS_KEY:-}" ] ||
+    fail 'PGBOUNCER_SERVER_TLS_CERT and PGBOUNCER_SERVER_TLS_KEY must be set together'
+fi
+
+if [ -n "${PGBOUNCER_CLIENT_TLS_CERT:-}" ] || [ -n "${PGBOUNCER_CLIENT_TLS_KEY:-}" ]; then
+  [ -n "${PGBOUNCER_CLIENT_TLS_CERT:-}" ] && [ -n "${PGBOUNCER_CLIENT_TLS_KEY:-}" ] ||
+    fail 'PGBOUNCER_CLIENT_TLS_CERT and PGBOUNCER_CLIENT_TLS_KEY must be set together'
+fi
+
+umask 077
+mkdir -p "$PGBOUNCER_RUNTIME_DIR"
+[ -d "$PGBOUNCER_RUNTIME_DIR" ] || fail 'PGBOUNCER_RUNTIME_DIR is not a directory'
+
+config_file="$PGBOUNCER_RUNTIME_DIR/pgbouncer.ini"
+userlist_file="$PGBOUNCER_RUNTIME_DIR/userlist.txt"
+auth_hba_file="$PGBOUNCER_RUNTIME_DIR/auth_hba.conf"
+client_certificate_file="$PGBOUNCER_RUNTIME_DIR/client.crt"
+client_key_file="$PGBOUNCER_RUNTIME_DIR/client.key"
+server_ca_file="$PGBOUNCER_RUNTIME_DIR/server-ca.crt"
+server_certificate_file="$PGBOUNCER_RUNTIME_DIR/server.crt"
+server_key_file="$PGBOUNCER_RUNTIME_DIR/server.key"
+userlist_temporary="$PGBOUNCER_RUNTIME_DIR/.userlist.txt.$$"
+auth_hba_temporary="$PGBOUNCER_RUNTIME_DIR/.auth_hba.conf.$$"
+config_temporary="$PGBOUNCER_RUNTIME_DIR/.pgbouncer.ini.$$"
+
+trap 'rm -f "$userlist_temporary" "$auth_hba_temporary" "$config_temporary"' EXIT HUP INT TERM
+
+: >"$userlist_temporary"
+append_credential "$PGBOUNCER_CLIENT_USER" "$PGBOUNCER_CLIENT_PASSWORD"
+
+append_credential "$PGBOUNCER_UPSTREAM_USER" "$PGBOUNCER_UPSTREAM_PASSWORD"
+append_credential "$PGBOUNCER_ADMIN_USER" "$PGBOUNCER_ADMIN_PASSWORD"
+if [ -n "${PGBOUNCER_CLIENT_USER_NEXT:-}" ]; then
+  append_credential "$PGBOUNCER_CLIENT_USER_NEXT" "$PGBOUNCER_CLIENT_PASSWORD_NEXT"
+fi
+
+mv "$userlist_temporary" "$userlist_file"
+
+cat >"$auth_hba_temporary" <<EOF
+local all all reject
+hostnossl all all 0.0.0.0/0 reject
+hostssl $PGBOUNCER_DATABASE_NAME $PGBOUNCER_CLIENT_USER 0.0.0.0/0 scram-sha-256
+EOF
+if [ -n "${PGBOUNCER_CLIENT_USER_NEXT:-}" ]; then
+  printf 'hostssl %s %s 0.0.0.0/0 scram-sha-256\n' \
+    "$PGBOUNCER_DATABASE_NAME" "$PGBOUNCER_CLIENT_USER_NEXT" >>"$auth_hba_temporary"
+fi
+cat >>"$auth_hba_temporary" <<EOF
+hostssl pgbouncer $PGBOUNCER_ADMIN_USER 0.0.0.0/0 scram-sha-256
+hostssl all all 0.0.0.0/0 reject
+EOF
+mv "$auth_hba_temporary" "$auth_hba_file"
+
+if [ -n "${PGBOUNCER_CLIENT_TLS_CERT:-}" ]; then
+  printf '%s\n' "$PGBOUNCER_CLIENT_TLS_CERT" >"$client_certificate_file"
+  printf '%s\n' "$PGBOUNCER_CLIENT_TLS_KEY" >"$client_key_file"
+else
+  openssl req \
+    -x509 \
+    -newkey rsa:2048 \
+    -sha256 \
+    -nodes \
+    -days 365 \
+    -subj '/CN=pgbouncer' \
+    -addext 'subjectAltName=DNS:pgbouncer' \
+    -keyout "$client_key_file" \
+    -out "$client_certificate_file" \
+    >/dev/null 2>&1 || fail 'could not generate the client-facing TLS certificate'
+fi
+printf '%s\n' "$PGBOUNCER_SERVER_TLS_CA" >"$server_ca_file"
+
+server_identity_config=''
+if [ -n "${PGBOUNCER_SERVER_TLS_CERT:-}" ]; then
+  printf '%s\n' "$PGBOUNCER_SERVER_TLS_CERT" >"$server_certificate_file"
+  printf '%s\n' "$PGBOUNCER_SERVER_TLS_KEY" >"$server_key_file"
+  server_identity_config="server_tls_cert_file = $server_certificate_file
+server_tls_key_file = $server_key_file"
+fi
+
+cat >"$config_temporary" <<EOF
+[databases]
+$PGBOUNCER_DATABASE_NAME = host=$PGBOUNCER_UPSTREAM_HOST port=$PGBOUNCER_UPSTREAM_PORT dbname=$PGBOUNCER_DATABASE_NAME user=$PGBOUNCER_UPSTREAM_USER
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = $PGBOUNCER_LISTEN_PORT
+unix_socket_dir = $PGBOUNCER_RUNTIME_DIR
+pidfile = $PGBOUNCER_RUNTIME_DIR/pgbouncer.pid
+
+auth_type = hba
+auth_file = $userlist_file
+auth_hba_file = $auth_hba_file
+admin_users = $PGBOUNCER_ADMIN_USER
+stats_users = $PGBOUNCER_ADMIN_USER
+
+pool_mode = transaction
+default_pool_size = 40
+min_pool_size = 0
+reserve_pool_size = 5
+reserve_pool_timeout = 3
+max_db_connections = 45
+max_user_connections = 45
+max_client_conn = 500
+max_prepared_statements = 0
+query_wait_timeout = 5
+client_login_timeout = 5
+server_connect_timeout = 5
+server_login_retry = 3
+server_idle_timeout = 300
+idle_transaction_timeout = 60
+
+client_tls_sslmode = require
+client_tls_cert_file = $client_certificate_file
+client_tls_key_file = $client_key_file
+client_tls_protocols = secure
+
+server_tls_sslmode = verify-full
+server_tls_ca_file = $server_ca_file
+server_tls_protocols = secure
+$server_identity_config
+EOF
+
+mv "$config_temporary" "$config_file"
+trap - EXIT HUP INT TERM
+
+# Do not leave secret values in PgBouncer's process environment. Docker health
+# checks receive the container's configured environment independently.
+unset \
+  PGBOUNCER_UPSTREAM_PASSWORD \
+  PGBOUNCER_CLIENT_PASSWORD \
+  PGBOUNCER_CLIENT_PASSWORD_NEXT \
+  PGBOUNCER_ADMIN_PASSWORD \
+  PGBOUNCER_CLIENT_TLS_CERT \
+  PGBOUNCER_CLIENT_TLS_KEY \
+  PGBOUNCER_SERVER_TLS_CA \
+  PGBOUNCER_SERVER_TLS_CERT \
+  PGBOUNCER_SERVER_TLS_KEY
+
+if [ "$#" -gt 0 ]; then
+  exec "$@"
+fi
+
+exec pgbouncer "$config_file"

--- a/deploy/pgbouncer/healthcheck.sh
+++ b/deploy/pgbouncer/healthcheck.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -eu
+
+[ -n "${PGBOUNCER_CLIENT_USER:-}" ] || exit 1
+[ -n "${PGBOUNCER_CLIENT_PASSWORD:-}" ] || exit 1
+[ -n "${PGBOUNCER_DATABASE_NAME:-}" ] || exit 1
+
+PGPASSWORD=$PGBOUNCER_CLIENT_PASSWORD \
+PGSSLMODE=require \
+  psql \
+    --no-password \
+    --no-psqlrc \
+    --quiet \
+    --host=127.0.0.1 \
+    --port="${PGBOUNCER_LISTEN_PORT:-6432}" \
+    --username="$PGBOUNCER_CLIENT_USER" \
+    --dbname="$PGBOUNCER_DATABASE_NAME" \
+    --command='SELECT 1' \
+    >/dev/null 2>&1

--- a/deploy/pgbouncer/smoke-test.sh
+++ b/deploy/pgbouncer/smoke-test.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+set -eu
+
+pgbouncer_image=${1:-boardsesh-pgbouncer:validation}
+postgres_image='docker.io/library/postgres:17-bookworm@sha256:051f7b7b3abdd564d5d1bd1e8c4b9c1b6e77087d1dd22020ede611c096a272e0'
+resource_suffix="${GITHUB_RUN_ID:-local}-$$"
+network_name="pgbouncer-smoke-$resource_suffix"
+tls_volume_name="pgbouncer-smoke-tls-$resource_suffix"
+postgres_container="pgbouncer-smoke-postgres-$resource_suffix"
+pgbouncer_container="pgbouncer-smoke-pool-$resource_suffix"
+
+cleanup() {
+  docker rm --force "$pgbouncer_container" "$postgres_container" >/dev/null 2>&1 || true
+  docker network rm "$network_name" >/dev/null 2>&1 || true
+  docker volume rm "$tls_volume_name" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT HUP INT TERM
+
+docker network create "$network_name" >/dev/null
+docker volume create "$tls_volume_name" >/dev/null
+
+docker run --rm \
+  --user 0:0 \
+  --volume "$tls_volume_name:/tls" \
+  --entrypoint sh \
+  "$pgbouncer_image" \
+  -c 'chown 999:999 /tls'
+
+docker run --rm \
+  --user 999:999 \
+  --volume "$tls_volume_name:/tls" \
+  --entrypoint sh \
+  "$pgbouncer_image" \
+  -c "openssl req -x509 -newkey rsa:2048 -sha256 -nodes -days 1 -subj '/CN=smoke-ca' -keyout /tls/ca.key -out /tls/ca.crt >/dev/null 2>&1 &&
+    openssl req -newkey rsa:2048 -sha256 -nodes -subj '/CN=postgres-smoke' -keyout /tls/server.key -out /tls/server.csr >/dev/null 2>&1 &&
+    printf 'subjectAltName=DNS:postgres-smoke\n' >/tls/server.ext &&
+    openssl x509 -req -sha256 -days 1 -in /tls/server.csr -CA /tls/ca.crt -CAkey /tls/ca.key -CAcreateserial -extfile /tls/server.ext -out /tls/server.crt >/dev/null 2>&1 &&
+    chmod 0600 /tls/server.key"
+
+docker run --detach \
+  --name "$postgres_container" \
+  --network "$network_name" \
+  --network-alias postgres-smoke \
+  --env POSTGRES_DB=boardsesh \
+  --env POSTGRES_USER=server_user \
+  --env POSTGRES_PASSWORD=server_password \
+  --env POSTGRES_INITDB_ARGS=--auth-host=scram-sha-256 \
+  --volume "$tls_volume_name:/tls:ro" \
+  "$postgres_image" \
+  -c ssl=on \
+  -c ssl_cert_file=/tls/server.crt \
+  -c ssl_key_file=/tls/server.key \
+  -c password_encryption=scram-sha-256 \
+  >/dev/null
+
+postgres_ready=false
+for readiness_attempt in $(seq 1 30); do
+  if docker exec "$postgres_container" pg_isready --quiet --username=server_user --dbname=boardsesh; then
+    postgres_ready=true
+    break
+  fi
+  sleep 1
+done
+[ "$postgres_ready" = true ] || {
+  docker logs "$postgres_container" >&2
+  exit 1
+}
+
+server_ca="$(docker run --rm --volume "$tls_volume_name:/tls:ro" --entrypoint cat "$pgbouncer_image" /tls/ca.crt)"
+export server_ca
+
+docker run --detach \
+  --name "$pgbouncer_container" \
+  --network "$network_name" \
+  --env PGBOUNCER_UPSTREAM_HOST=postgres-smoke \
+  --env PGBOUNCER_DATABASE_NAME=boardsesh \
+  --env PGBOUNCER_UPSTREAM_USER=server_user \
+  --env PGBOUNCER_UPSTREAM_PASSWORD=server_password \
+  --env PGBOUNCER_CLIENT_USER=client_user \
+  --env PGBOUNCER_CLIENT_PASSWORD=client_password \
+  --env PGBOUNCER_CLIENT_USER_NEXT=next_client_user \
+  --env PGBOUNCER_CLIENT_PASSWORD_NEXT=next_client_password \
+  --env PGBOUNCER_ADMIN_USER=admin_user \
+  --env PGBOUNCER_ADMIN_PASSWORD=admin_password \
+  --env PGBOUNCER_SERVER_TLS_CA="$server_ca" \
+  "$pgbouncer_image" \
+  >/dev/null
+
+pgbouncer_healthy=false
+for health_attempt in $(seq 1 30); do
+  health_status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}' "$pgbouncer_container")"
+  if [ "$health_status" = healthy ]; then
+    pgbouncer_healthy=true
+    break
+  fi
+  [ "$health_status" != unhealthy ] || break
+  sleep 1
+done
+[ "$pgbouncer_healthy" = true ] || {
+  docker logs "$pgbouncer_container" >&2
+  exit 1
+}
+
+PGPASSWORD=next_client_password docker exec \
+  --env PGPASSWORD \
+  --env PGSSLMODE=require \
+  "$pgbouncer_container" \
+  psql --no-password --no-psqlrc --quiet --host=127.0.0.1 --port=6432 --username=next_client_user --dbname=boardsesh --command='SELECT 1' \
+  >/dev/null
+
+if PGPASSWORD=admin_password docker exec \
+  --env PGPASSWORD \
+  --env PGSSLMODE=require \
+  "$pgbouncer_container" \
+  psql --no-password --no-psqlrc --quiet --host=127.0.0.1 --port=6432 --username=admin_user --dbname=boardsesh --command='SELECT 1' \
+  >/dev/null 2>&1; then
+  printf 'admin identity unexpectedly reached the application database\n' >&2
+  exit 1
+fi
+
+if PGPASSWORD=client_password docker exec \
+  --env PGPASSWORD \
+  --env PGSSLMODE=require \
+  "$pgbouncer_container" \
+  psql --no-password --no-psqlrc --quiet --host=127.0.0.1 --port=6432 --username=client_user --dbname=pgbouncer --command='SHOW VERSION' \
+  >/dev/null 2>&1; then
+  printf 'application identity unexpectedly reached the admin console\n' >&2
+  exit 1
+fi
+
+printf 'PgBouncer TLS application-path smoke test passed\n'

--- a/docs/db-connectivity.md
+++ b/docs/db-connectivity.md
@@ -248,8 +248,11 @@ raising `max` never helps.
 The production app/runtime `DATABASE_URL` points at the TLS listener on the
 single-replica PgBouncer service. Privileged workflows use
 `DATABASE_DIRECT_URL` to reach PostgreSQL without transaction pooling; the
-production migration job fails closed when that direct secret is absent. Do not
-put the direct URL in Vercel runtime settings.
+production migration job pins its non-credential `host:port/database` identity
+in the protected `DATABASE_DIRECT_ENDPOINT` environment variable and runs a TLS
+`SELECT 1` before migration. Before cutover the secret may equal the still-direct
+runtime URL; after cutover the two naturally differ. Do not put the direct URL
+in Vercel runtime settings.
 
 The image is published as `ghcr.io/boardsesh/boardsesh-pgbouncer`, built from
 `deploy/pgbouncer/` by `.github/workflows/pgbouncer-image.yml`. Deploy the
@@ -341,8 +344,10 @@ paths, chosen by what the URL actually points at:
   `ALTER ROLE <app_role> SET statement_timeout = '8s'`, which passes through a
   pooler transparently.
 
-`psql "$DATABASE_URL" -c 'show pool_mode;'` tells you which you have: a direct
-Postgres errors, PgBouncer answers.
+Do not use `SHOW pool_mode` on the application database to identify the
+endpoint. PgBouncer accepts its `SHOW` commands only on the dedicated admin
+database; on an application database it forwards the query to PostgreSQL. Pin
+the expected direct `host:port/database` as described above instead.
 
 ### There is no web health probe
 

--- a/docs/db-connectivity.md
+++ b/docs/db-connectivity.md
@@ -145,13 +145,13 @@ rather than an error.
 
 `packages/web/app/lib/db/read-deadline.ts` bounds one read client-side. It races
 the pending query against a timer and rejects with `DbReadTimeoutError`
-(`code: 'DB_READ_TIMEOUT'`) when the timer wins. It is wired at four
-front-door reads — the two statements behind `getClimb`, the all-angles
+(`code: 'DB_READ_TIMEOUT'`) when the timer wins. It is wired at three
+front-door reads — the alias-resolving `getClimb` statement, the all-angles
 stats select, and the shared climb search — and deliberately **not** inside
 `withConnectRetry` or `packages/db`, where it would change behaviour for the
 backend, the sync runners and every script.
 
-**Cancellation covers three of the four.** On a timeout the helper calls
+**Cancellation covers two of the three.** On a timeout the helper calls
 `query.cancel()` the way the health probe does, so a timed-out statement does not
 fire later against a recovered pool. That only works for raw postgres.js
 queries. The list front door's search is drizzle-issued and exposes no
@@ -167,8 +167,8 @@ internally (`Query.cancel()` returns `null`), so a failure to open it surfaces a
 an unhandled rejection the runtime logs. Accepted: a zombie statement firing
 against a recovered pool is worse than a log line.
 
-**One budget per request, not per statement.** The climb page issues three reads
-in sequence, so three independent 6 s deadlines would be an ~18 s request
+**One budget per request, not per statement.** The climb page issues two reads
+in sequence, so two independent 6 s deadlines would be a ~12 s request
 ceiling — the opposite of shedding load. `app/lib/db/request-read-budget.ts`
 puts one deadline timestamp in React's per-render `cache` scope and hands each
 read whatever the earlier ones left, floored at 500 ms. Outside a render scope
@@ -231,7 +231,8 @@ holds because the budget is per request — see the shared-budget note above.
 
 The pool knobs default to the values that used to be hard-coded — except on
 Vercel, where an unset knob now falls back to the serverless pair (`max` 3,
-idle 5 s; `process.env.VERCEL` selects it, an explicit env var still wins).
+idle 5 s; `VERCEL=1` or `VERCEL_ENV=production|preview` selects it, and an
+explicit env var still wins).
 The split exists because peak server-side connections scale with
 **instance count × connections held idle**, not with per-instance `max` — a
 fleet of serverless instances each sitting on a few idle connections for 30 s
@@ -241,6 +242,91 @@ bursts on climb-view SSR held ~10 idle connections per lambda) and starved the
 backend's `POST /graphql` alongside (BOARDSESH-A1). Lowering `DB_POOL_MAX` and
 `DB_POOL_IDLE_TIMEOUT_S` on a serverless deployment shrinks that footprint;
 raising `max` never helps.
+
+## Production PgBouncer topology (#4842)
+
+The production app/runtime `DATABASE_URL` points at the TLS listener on the
+single-replica PgBouncer service. Privileged workflows use
+`DATABASE_DIRECT_URL` to reach PostgreSQL without transaction pooling; the
+production migration job fails closed when that direct secret is absent. Do not
+put the direct URL in Vercel runtime settings.
+
+The image is published as `ghcr.io/boardsesh/boardsesh-pgbouncer`, built from
+`deploy/pgbouncer/` by `.github/workflows/pgbouncer-image.yml`. Deploy the
+attested digest behind the full-commit `sha-...` tag, never the mutable
+`:production` tag. Its fixed budget is 40 ordinary server connections plus 5
+reserve connections, capped at 45 for the database. It accepts up to 500
+clients and rejects a queued or incomplete-login client after 5 seconds. Run
+exactly one replica: two replicas double the database budget and can recreate
+the incident this service prevents.
+
+Production PostgreSQL exposes 197 application slots (`max_connections=200`
+minus 3 reserved slots). PgBouncer therefore consumes at most 45 and leaves 152
+for migrations, replication, administrator access, and services not yet cut
+over. Recheck that remainder before adding any direct client or pooler replica.
+
+### Deploy and cut over
+
+1. Provision `DATABASE_DIRECT_URL`, the three distinct identities, TLS material,
+   and `PGBOUNCER_CUTOVER_SMOKE_TOKEN` before changing any runtime URL.
+2. Verify the full-SHA image's GitHub attestation, resolve its OCI digest, and
+   deploy that digest with the environment in `deploy/pgbouncer/README.md`.
+3. Allow PgBouncer ingress only from approved Vercel egress and operator
+   sources; do not leave its TCP endpoint open to the public internet.
+4. Point a Vercel staging deployment at the pooled URL, then run the smoke below.
+5. Promote the pooled URL through two clean Vercel production deployments.
+
+Load `PGBOUNCER_CUTOVER_SMOKE_TOKEN` from the same secret store used by the
+target deployment, then run:
+
+```sh
+vp run smoke:pgbouncer-cutover -- --origin https://TARGET
+```
+
+The command requires zero failures from both 100 climb renders and 100 uncached
+database probes at concurrency 32. Keep `prepare: false` in every app client.
+Use a dedicated high-entropy token, never a database credential. Remove it from
+Vercel after the cutover so the probe returns 401, and provision a fresh token
+for a future cutover.
+
+Old Vercel deployments retain their old environment snapshot. The second
+deployment is mandatory: after the first clean pooled deployment, create an
+identical one before declaring the direct-connection fleet drained. Route the
+backend and sync daemons through PgBouncer separately after the crawl test and
+watch each change as its own connection-budget event.
+
+### Observe, alert, and roll back
+
+Connect to the PgBouncer admin database with its admin credentials, then run:
+
+```sql
+SHOW POOLS;
+SHOW STATS;
+SHOW CLIENTS;
+SHOW SERVERS;
+```
+
+`sv_active + sv_idle + sv_used + sv_tested + sv_login` must stay at or below 45
+for the application database. Success is zero load-test 500s, zero PostgreSQL
+`53300` events, and no more than 45 PgBouncer server connections.
+
+Server Sentry events carry `postgres.error_code`; `53300` also carries
+`postgres.resource_exhaustion:true`. Configure the production metric alert for
+at least one matching event in 5 minutes and require 30 clean minutes for
+recovery. Alert configuration remains manual because CI's Sentry access is
+read-only.
+
+Rollback by restoring the direct PostgreSQL `DATABASE_URL` and redeploying. Keep
+the safer Vercel 3/5 pool defaults during rollback. Do not stop PgBouncer until
+all deployments using its URL are drained.
+
+Rotate client credentials without an authentication gap: add a distinct
+`PGBOUNCER_CLIENT_USER_NEXT` and password, deploy PgBouncer with both client
+identities, update Vercel, complete two Vercel deployments, wait for old-client
+traffic to reach zero, then promote the next identity and remove the old one.
+Rotate upstream and admin credentials separately in controlled PgBouncer
+deployments and run health checks after each. Never reuse the PostgreSQL
+superuser as the client or admin login.
 
 ### The `statement_timeout` hazard
 

--- a/docs/db-connectivity.md
+++ b/docs/db-connectivity.md
@@ -245,14 +245,16 @@ raising `max` never helps.
 
 ## Production PgBouncer topology (#4842)
 
-The production app/runtime `DATABASE_URL` points at the TLS listener on the
-single-replica PgBouncer service. Privileged workflows use
+Until the separate cutover, the production app/runtime `DATABASE_URL` still
+points directly at PostgreSQL. After cutover, the Railway web service's runtime
+URL points at the TLS listener on the single-replica PgBouncer service.
+Privileged workflows use
 `DATABASE_DIRECT_URL` to reach PostgreSQL without transaction pooling; the
 production migration job pins its non-credential `host:port/database` identity
 in the protected `DATABASE_DIRECT_ENDPOINT` environment variable and runs a TLS
 `SELECT 1` before migration. Before cutover the secret may equal the still-direct
 runtime URL; after cutover the two naturally differ. Do not put the direct URL
-in Vercel runtime settings.
+in any pooled application runtime setting.
 
 The image is published as `ghcr.io/boardsesh/boardsesh-pgbouncer`, built from
 `deploy/pgbouncer/` by `.github/workflows/pgbouncer-image.yml`. Deploy the
@@ -274,10 +276,14 @@ over. Recheck that remainder before adding any direct client or pooler replica.
    and `PGBOUNCER_CUTOVER_SMOKE_TOKEN` before changing any runtime URL.
 2. Verify the full-SHA image's GitHub attestation, resolve its OCI digest, and
    deploy that digest with the environment in `deploy/pgbouncer/README.md`.
-3. Allow PgBouncer ingress only from approved Vercel egress and operator
-   sources; do not leave its TCP endpoint open to the public internet.
-4. Point a Vercel staging deployment at the pooled URL, then run the smoke below.
-5. Promote the pooled URL through two clean Vercel production deployments.
+3. Keep PgBouncer on Railway's private network. Allow only approved application
+   workloads and an explicit operator source; do not expose its listener to the
+   public internet.
+4. With the Railway web service still direct, run the smoke below against its
+   direct `RAILWAY_WEB_ORIGIN` to record a healthy baseline.
+5. Change only the Railway web service's `DATABASE_URL` to the pooled private
+   URL, redeploy the current image, then repeat the smoke against both
+   `RAILWAY_WEB_ORIGIN` and `https://www.boardsesh.com`.
 
 Load `PGBOUNCER_CUTOVER_SMOKE_TOKEN` from the same secret store used by the
 target deployment, then run:
@@ -289,14 +295,13 @@ vp run smoke:pgbouncer-cutover -- --origin https://TARGET
 The command requires zero failures from both 100 climb renders and 100 uncached
 database probes at concurrency 32. Keep `prepare: false` in every app client.
 Use a dedicated high-entropy token, never a database credential. Remove it from
-Vercel after the cutover so the probe returns 401, and provision a fresh token
-for a future cutover.
+the Railway web service after the cutover so the probe returns 401, and
+provision a fresh token for a future cutover.
 
-Old Vercel deployments retain their old environment snapshot. The second
-deployment is mandatory: after the first clean pooled deployment, create an
-identical one before declaring the direct-connection fleet drained. Route the
-backend and sync daemons through PgBouncer separately after the crawl test and
-watch each change as its own connection-budget event.
+The Vercel deployment is only the seven-day warm rollback origin after the DNS
+flip; do not treat it as the cutover target or overwrite its direct database
+snapshot. Route the backend and sync daemons through PgBouncer separately after
+the crawl test and watch each change as its own connection-budget event.
 
 ### Observe, alert, and roll back
 
@@ -319,13 +324,14 @@ at least one matching event in 5 minutes and require 30 clean minutes for
 recovery. Alert configuration remains manual because CI's Sentry access is
 read-only.
 
-Rollback by restoring the direct PostgreSQL `DATABASE_URL` and redeploying. Keep
-the safer Vercel 3/5 pool defaults during rollback. Do not stop PgBouncer until
-all deployments using its URL are drained.
+Rollback by restoring the Railway web service's direct PostgreSQL
+`DATABASE_URL` and redeploying. Do not raise its pool knobs during rollback;
+the warm Vercel rollback deployment retains the safer 3/5 defaults. Do not stop
+PgBouncer until all deployments using its URL are drained.
 
 Rotate client credentials without an authentication gap: add a distinct
 `PGBOUNCER_CLIENT_USER_NEXT` and password, deploy PgBouncer with both client
-identities, update Vercel, complete two Vercel deployments, wait for old-client
+identities, update and redeploy the Railway web service, wait for old-client
 traffic to reach zero, then promote the next identity and remove the old one.
 Rotate upstream and admin credentials separately in controlled PgBouncer
 deployments and run health checks after each. Never reuse the PostgreSQL

--- a/docs/production-deploy.md
+++ b/docs/production-deploy.md
@@ -391,6 +391,7 @@ Production environment, not a personal or team API token. The rollback helper
 derives and checks its project/environment scope on every use. Rotate it in
 Railway first, replace the GitHub Production-environment secret, then revoke the
 old token after a green deploy.
+
 ## Why only one run moves at a time
 
 ```yaml

--- a/docs/production-deploy.md
+++ b/docs/production-deploy.md
@@ -6,9 +6,15 @@ backend in parallel, gates on both builds passing, migrates, then deploys.
 
 The protected Production environment must define `DATABASE_DIRECT_URL` for the
 migration job. Runtime `DATABASE_URL` may point at PgBouncer, but migrations
-must bypass transaction pooling. The workflow fails before migration when the
-direct secret is absent or exactly equals the pooled `DATABASE_URL`; it never
-falls back to the pooled runtime connection.
+must bypass transaction pooling. The workflow connects to the direct secret and
+requires its non-credential `host:port/database` identity to equal the protected
+`DATABASE_DIRECT_ENDPOINT` environment variable, then runs a TLS `SELECT 1`.
+A pooler endpoint, missing configuration, authentication failure, or network
+failure stops the deploy. Before cutover the direct and runtime secrets may be
+the same PostgreSQL URL. After cutover they naturally differ because only the
+runtime URL points at PgBouncer. The workflow never falls back to the runtime
+connection. Update the endpoint variable deliberately if Railway replaces the
+database TCP proxy; password-only rotations do not change it.
 
 ## Architecture during the cut-over
 

--- a/docs/production-deploy.md
+++ b/docs/production-deploy.md
@@ -4,6 +4,12 @@
 auto-deploy is off). Every push to `main` starts a run; the run builds web and
 backend in parallel, gates on both builds passing, migrates, then deploys.
 
+The protected Production environment must define `DATABASE_DIRECT_URL` for the
+migration job. Runtime `DATABASE_URL` may point at PgBouncer, but migrations
+must bypass transaction pooling. The workflow fails before migration when the
+direct secret is absent or exactly equals the pooled `DATABASE_URL`; it never
+falls back to the pooled runtime connection.
+
 ## Architecture during the cut-over
 
 www (`packages/web`) is moving off Vercel onto a Railway container (epic
@@ -379,7 +385,6 @@ Production environment, not a personal or team API token. The rollback helper
 derives and checks its project/environment scope on every use. Rotate it in
 Railway first, replace the GitHub Production-environment secret, then revoke the
 old token after a green deploy.
-
 ## Why only one run moves at a time
 
 ```yaml

--- a/packages/db/scripts/db-connection.test.ts
+++ b/packages/db/scripts/db-connection.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { isLocalDatabaseUrl, describeDatabaseHost } from './db-connection.js';
+import postgres from 'postgres';
+import { describeDatabaseHost, isLocalDatabaseUrl, scriptDatabaseConnectionOptions } from './db-connection.js';
 
 // Real automation paths this must recognize as local, verified against the
 // repo (see db-connection.ts's doc comment for the file:line evidence):
@@ -67,6 +68,45 @@ void test('fails closed on malformed or empty URLs', () => {
   assert.equal(isLocalDatabaseUrl('not a url at all'), false);
   assert.equal(isLocalDatabaseUrl(''), false);
   assert.equal(isLocalDatabaseUrl('postgresql://'), false);
+});
+
+void test('forces TLS for remote scripts even when the URL requests plaintext', async () => {
+  const plaintextUrl = 'postgresql://user:pass@direct.example:5432/db?sslmode=disable';
+  const options = scriptDatabaseConnectionOptions(plaintextUrl);
+  const client = postgres(plaintextUrl, options);
+  assert.deepEqual(options, {
+    max: 1,
+    ssl: 'require',
+  });
+  assert.equal(client.options.ssl, 'require');
+  await client.end();
+  assert.deepEqual(scriptDatabaseConnectionOptions('postgresql://postgres@localhost:5432/main'), { max: 1 });
+});
+
+void test('preserves remote certificate verification instead of downgrading it', async () => {
+  const verifiedUrl = 'postgresql://user:pass@direct.example:5432/db?sslmode=verify-full';
+  const options = scriptDatabaseConnectionOptions(verifiedUrl);
+  const client = postgres(verifiedUrl, options);
+  assert.deepEqual(options, { max: 1 });
+  assert.equal(client.options.ssl, 'verify-full');
+  await client.end();
+});
+
+void test('matches postgres-js last-value and case-sensitive TLS parsing', async () => {
+  const duplicateModeUrl = 'postgresql://user:pass@direct.example:5432/db?sslmode=verify-full&sslmode=disable';
+  const duplicateModeClient = postgres(duplicateModeUrl, scriptDatabaseConnectionOptions(duplicateModeUrl));
+  assert.equal(duplicateModeClient.options.ssl, 'require');
+  await duplicateModeClient.end();
+
+  const uppercaseRootUrl = 'postgresql://user:pass@direct.example:5432/db?sslmode=disable&sslrootcert=SYSTEM';
+  const uppercaseRootClient = postgres(uppercaseRootUrl, scriptDatabaseConnectionOptions(uppercaseRootUrl));
+  assert.equal(uppercaseRootClient.options.ssl, 'require');
+  await uppercaseRootClient.end();
+
+  const systemRootUrl = 'postgresql://user:pass@direct.example:5432/db?sslmode=disable&sslrootcert=system';
+  const systemRootClient = postgres(systemRootUrl, scriptDatabaseConnectionOptions(systemRootUrl));
+  assert.equal(systemRootClient.options.ssl, 'verify-full');
+  await systemRootClient.end();
 });
 
 void test('describeDatabaseHost reports host:port for a normal connection string', () => {

--- a/packages/db/scripts/db-connection.ts
+++ b/packages/db/scripts/db-connection.ts
@@ -160,13 +160,38 @@ export function isLocalDatabaseUrl(databaseUrl: string): boolean {
   );
 }
 
+/**
+ * One-shot database scripts may use plaintext only for the repo's known local
+ * development hosts. Force TLS for remote URLs that omit it or permit
+ * plaintext, while preserving URL modes that also verify certificates.
+ */
+export function scriptDatabaseConnectionOptions(databaseUrl: string) {
+  const options = { max: 1 };
+  if (isLocalDatabaseUrl(databaseUrl)) return options;
+
+  try {
+    const parsedDatabaseUrl = new URL(databaseUrl);
+    const sslMode = parsedDatabaseUrl.searchParams.getAll('sslmode').at(-1);
+    const sslRootCertificate = parsedDatabaseUrl.searchParams.getAll('sslrootcert').at(-1);
+    const driverRequiresTls =
+      sslRootCertificate === 'system' ||
+      (sslMode !== undefined && !['', 'disable', 'false', 'allow', 'prefer'].includes(sslMode));
+    if (driverRequiresTls) return options;
+  } catch {
+    // postgres-js will reject the URL. Keep the fail-safe TLS option so a
+    // parse mismatch can never make a remote script choose plaintext.
+  }
+
+  return { ...options, ssl: 'require' as const };
+}
+
 type ScriptDb = ReturnType<typeof drizzle>;
 
 export function createScriptDb(url?: string): { db: ScriptDb; close: () => Promise<void> } {
   const databaseUrl = url ?? getScriptDatabaseUrl();
   // Scripts are short-lived one-shots and target the direct (non-pooled) URL,
   // so a single connection is sufficient and avoids opening 10 by default.
-  const client = postgres(databaseUrl, { max: 1 });
+  const client = postgres(databaseUrl, scriptDatabaseConnectionOptions(databaseUrl));
   const db = drizzle(client);
   return {
     db,

--- a/packages/db/scripts/direct-database-guard.ts
+++ b/packages/db/scripts/direct-database-guard.ts
@@ -39,11 +39,24 @@ export function assertExpectedDirectEndpoint(connectionString: string, expectedE
     throw new Error('DATABASE_DIRECT_ENDPOINT is required to identify the trusted PostgreSQL endpoint');
   }
 
-  if (databaseEndpointIdentity(connectionString) !== expectedEndpoint) {
+  let normalizedExpectedEndpoint: string;
+  try {
+    const expectedUrl = new URL(`postgresql://${expectedEndpoint}`);
+    if (expectedUrl.username || expectedUrl.password || expectedUrl.search || expectedUrl.hash) throw new Error();
+    normalizedExpectedEndpoint = databaseEndpointIdentity(expectedUrl.href);
+  } catch {
+    throw new Error('DATABASE_DIRECT_ENDPOINT must be a valid host:port/database identity');
+  }
+
+  if (databaseEndpointIdentity(connectionString) !== normalizedExpectedEndpoint) {
     throw new Error('DATABASE_DIRECT_URL does not match the trusted PostgreSQL endpoint');
   }
 }
 
 export async function verifyDirectConnectivity(client: QueryClient): Promise<void> {
-  await client.unsafe('SELECT 1');
+  try {
+    await client.unsafe('SELECT 1');
+  } catch {
+    throw new Error('DATABASE_DIRECT_URL failed TLS connectivity or SELECT 1 verification');
+  }
 }

--- a/packages/db/scripts/direct-database-guard.ts
+++ b/packages/db/scripts/direct-database-guard.ts
@@ -1,0 +1,49 @@
+type QueryClient = {
+  unsafe: (query: string) => Promise<unknown>;
+};
+
+export function databaseEndpointIdentity(connectionString: string): string {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(connectionString);
+  } catch {
+    // ERR_INVALID_URL may retain its input, which can include credentials. Do
+    // not propagate it into CI logs.
+    throw new Error('DATABASE_DIRECT_URL is not a valid PostgreSQL URL');
+  }
+  if (parsedUrl.protocol !== 'postgres:' && parsedUrl.protocol !== 'postgresql:') {
+    throw new Error('DATABASE_DIRECT_URL must use the postgres or postgresql protocol');
+  }
+
+  let databaseName: string;
+  try {
+    databaseName = decodeURIComponent(parsedUrl.pathname.replace(/^\//, ''));
+  } catch {
+    throw new Error('DATABASE_DIRECT_URL contains an invalid database name');
+  }
+  if (!parsedUrl.hostname || !databaseName) {
+    throw new Error('DATABASE_DIRECT_URL must include a hostname and database name');
+  }
+
+  return `${parsedUrl.hostname.toLowerCase()}:${parsedUrl.port || '5432'}/${databaseName}`;
+}
+
+/**
+ * Compare only the non-credential endpoint identity. The protected environment
+ * pins the known Railway PostgreSQL TCP endpoint; PgBouncer has a different
+ * hostname or port. Password rotation therefore needs no workflow change, while
+ * moving the direct endpoint remains an explicit fail-closed operation.
+ */
+export function assertExpectedDirectEndpoint(connectionString: string, expectedEndpoint: string): void {
+  if (!expectedEndpoint) {
+    throw new Error('DATABASE_DIRECT_ENDPOINT is required to identify the trusted PostgreSQL endpoint');
+  }
+
+  if (databaseEndpointIdentity(connectionString) !== expectedEndpoint) {
+    throw new Error('DATABASE_DIRECT_URL does not match the trusted PostgreSQL endpoint');
+  }
+}
+
+export async function verifyDirectConnectivity(client: QueryClient): Promise<void> {
+  await client.unsafe('SELECT 1');
+}

--- a/packages/db/scripts/migrate.ts
+++ b/packages/db/scripts/migrate.ts
@@ -13,6 +13,7 @@ import {
 } from './migration-journal.js';
 import { migrationExecutionContractFromEnvironment, reserveMigrationOwnerSession } from './migration-owner-role.js';
 import { runMigrationWithRuntimeAclContract } from './migration-runtime-acl.js';
+import { scriptDatabaseConnectionOptions } from './db-connection.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -61,7 +62,7 @@ async function runMigrations() {
   }
   console.info(`🔄 Running migrations on: ${dbHost}`);
 
-  const connectionPool = postgres(databaseUrl, { max: 1 });
+  const connectionPool = postgres(databaseUrl, scriptDatabaseConnectionOptions(databaseUrl));
   let closeMigrationSession: (() => Promise<void>) | undefined;
   try {
     // SET ROLE is session state. Reserve one physical connection so no pool

--- a/packages/db/scripts/verify-direct-database.ts
+++ b/packages/db/scripts/verify-direct-database.ts
@@ -1,0 +1,27 @@
+import postgres from 'postgres';
+import { assertExpectedDirectEndpoint, verifyDirectConnectivity } from './direct-database-guard';
+
+async function verifyDirectDatabase(): Promise<void> {
+  const connectionString = process.env.DATABASE_DIRECT_URL;
+  if (!connectionString) {
+    throw new Error('DATABASE_DIRECT_URL is required; migrations must bypass PgBouncer transaction pooling');
+  }
+  assertExpectedDirectEndpoint(connectionString, process.env.DATABASE_DIRECT_ENDPOINT ?? '');
+
+  const client = postgres(connectionString, {
+    connect_timeout: 15,
+    max: 1,
+    onnotice: () => {},
+    prepare: false,
+    ssl: 'require',
+  });
+
+  try {
+    await verifyDirectConnectivity(client);
+    console.info('Verified DATABASE_DIRECT_URL reaches PostgreSQL directly');
+  } finally {
+    await client.end({ timeout: 5 });
+  }
+}
+
+void verifyDirectDatabase();

--- a/packages/db/src/client/__tests__/postgres.test.ts
+++ b/packages/db/src/client/__tests__/postgres.test.ts
@@ -68,32 +68,69 @@ void describe('postgres client', () => {
       }
     }
 
-    void it('defaults to the values that were hard-coded before the knobs existed', async () => {
+    void it('keeps the previous defaults outside Vercel', async () => {
       const options = await poolOptionsWith({
         DB_POOL_MAX: undefined,
         DB_POOL_IDLE_TIMEOUT_S: undefined,
         VERCEL: undefined,
+        VERCEL_ENV: undefined,
       });
       assert.equal(options.max, 10);
       assert.equal(options.idle_timeout, 30);
     });
 
-    void it('shrinks the defaults on Vercel, where instance count is the term that grows', async () => {
-      // A crawl burst scales lambda count; instances × held-idle connections
-      // can exhaust the shared max_connections. See docs/db-connectivity.md.
+    void it('does not treat empty Vercel markers as a Vercel runtime', async () => {
+      const options = await poolOptionsWith({
+        DB_POOL_MAX: undefined,
+        DB_POOL_IDLE_TIMEOUT_S: undefined,
+        VERCEL: '',
+        VERCEL_ENV: '',
+      });
+      assert.equal(options.max, 10);
+      assert.equal(options.idle_timeout, 30);
+    });
+
+    void it('uses smaller defaults on Vercel', async () => {
       const options = await poolOptionsWith({
         DB_POOL_MAX: undefined,
         DB_POOL_IDLE_TIMEOUT_S: undefined,
         VERCEL: '1',
+        VERCEL_ENV: 'production',
       });
       assert.equal(options.max, 3);
       assert.equal(options.idle_timeout, 5);
     });
 
-    void it('lets explicit knobs override the serverless defaults', async () => {
-      const options = await poolOptionsWith({ DB_POOL_MAX: '6', DB_POOL_IDLE_TIMEOUT_S: '20', VERCEL: '1' });
+    void it('uses smaller defaults when VERCEL_ENV is the only runtime marker', async () => {
+      const options = await poolOptionsWith({
+        DB_POOL_MAX: undefined,
+        DB_POOL_IDLE_TIMEOUT_S: undefined,
+        VERCEL: undefined,
+        VERCEL_ENV: 'preview',
+      });
+      assert.equal(options.max, 3);
+      assert.equal(options.idle_timeout, 5);
+    });
+
+    void it('keeps non-Vercel defaults for local VERCEL_ENV=development', async () => {
+      const options = await poolOptionsWith({
+        DB_POOL_MAX: undefined,
+        DB_POOL_IDLE_TIMEOUT_S: undefined,
+        VERCEL: undefined,
+        VERCEL_ENV: 'development',
+      });
+      assert.equal(options.max, 10);
+      assert.equal(options.idle_timeout, 30);
+    });
+
+    void it('lets explicit pool knobs override the Vercel defaults', async () => {
+      const options = await poolOptionsWith({
+        DB_POOL_MAX: '6',
+        DB_POOL_IDLE_TIMEOUT_S: '15',
+        VERCEL: '1',
+      });
       assert.equal(options.max, 6);
-      assert.equal(options.idle_timeout, 20);
+      assert.equal(options.idle_timeout, 15);
     });
 
     void it('honours DB_POOL_MAX and DB_POOL_IDLE_TIMEOUT_S', async () => {
@@ -103,8 +140,7 @@ void describe('postgres client', () => {
     });
 
     void it('clamps DB_POOL_MAX to the two-connection floor', async () => {
-      // getClimb issues two sequential statements; a pool of one serialises
-      // every front-door render behind a single connection.
+      // A pool of one serialises every front-door render behind one connection.
       const options = await poolOptionsWith({ DB_POOL_MAX: '1' });
       assert.equal(options.max, 2);
     });
@@ -137,6 +173,11 @@ void describe('postgres client', () => {
       // direct. See docs/db-connectivity.md.
       const options = await poolOptionsWith({ DB_STATEMENT_TIMEOUT_MS: undefined });
       assert.equal(options.connection.statement_timeout, undefined);
+    });
+
+    void it('disables prepared statements for PgBouncer transaction pooling', async () => {
+      const options = await poolOptionsWith({});
+      assert.equal(options.prepare, false);
     });
 
     void it('emits statement_timeout when DB_STATEMENT_TIMEOUT_MS is set', async () => {

--- a/packages/db/src/client/postgres.ts
+++ b/packages/db/src/client/postgres.ts
@@ -20,17 +20,18 @@ const sqlLogger = process.env.DEBUG_SQL === 'true' ? new QueryLogger() : undefin
 
 const fullSchema = { ...schema, ...relations };
 
-/** Pool size when `DB_POOL_MAX` is unset — unchanged from before the knob existed. */
+/** Pool size when `DB_POOL_MAX` is unset outside Vercel. */
 export const DEFAULT_POOL_MAX = 10;
-/** Seconds an idle connection is held when `DB_POOL_IDLE_TIMEOUT_S` is unset. */
+/** Seconds an idle connection is held when `DB_POOL_IDLE_TIMEOUT_S` is unset outside Vercel. */
 export const DEFAULT_POOL_IDLE_TIMEOUT_S = 30;
 /** Serverless (Vercel) pool defaults — smaller per-lambda footprint; see docs/db-connectivity.md § pool sizing. */
 export const SERVERLESS_DEFAULT_POOL_MAX = 3;
 export const SERVERLESS_DEFAULT_POOL_IDLE_TIMEOUT_S = 5;
 /**
- * `getClimb` issues two sequential statements and drizzle's connect-retry can
- * hold a slot while it re-dials, so a pool of one serialises everything behind
- * a single connection. Clamp rather than trust a typo in a dashboard.
+ * A climb page issues its climb and all-angle reads sequentially, and drizzle's
+ * connect-retry can hold a slot while it re-dials. A pool of one serialises
+ * every request behind a single connection. Clamp rather than trust a typo in
+ * a dashboard.
  */
 export const MIN_POOL_MAX = 2;
 /**
@@ -56,12 +57,16 @@ function readPoolInt(name: string, fallback: number, minimum: number): number {
   return Math.max(minimum, parsed);
 }
 
+function isVercelRuntime(): boolean {
+  const vercelEnvironment = process.env.VERCEL_ENV;
+  return process.env.VERCEL === '1' || vercelEnvironment === 'production' || vercelEnvironment === 'preview';
+}
+
 /**
- * Per-deployment pool knobs. On Vercel the defaults are the serverless pair
- * above; everywhere else (backend, sync jobs, scripts) they stay the values
- * that were hard-coded here before, so nothing changes unless the env var is
- * set. The split exists because peak server-side connections scale with
- * *instance count* × held-idle connections, not with per-instance `max`.
+ * Per-deployment pool knobs. Vercel defaults to 3 connections held for 5
+ * seconds; backend, sync jobs and scripts keep the previous 10/30 defaults.
+ * Explicit env vars win in every runtime. Peak server-side connections scale
+ * with *instance count* × held-idle connections, not with per-instance `max`.
  *
  * `prepare: false` is required when the target is PgBouncer in transaction
  * pooling mode (Railway's pooled URL): backends are reused across transactions
@@ -105,12 +110,12 @@ export function resetReportedPostgresNotices(): void {
 }
 
 function basePoolOptions() {
-  const isServerless = Boolean(process.env.VERCEL);
+  const vercelRuntime = isVercelRuntime();
   return {
-    max: readPoolInt('DB_POOL_MAX', isServerless ? SERVERLESS_DEFAULT_POOL_MAX : DEFAULT_POOL_MAX, MIN_POOL_MAX),
+    max: readPoolInt('DB_POOL_MAX', vercelRuntime ? SERVERLESS_DEFAULT_POOL_MAX : DEFAULT_POOL_MAX, MIN_POOL_MAX),
     idle_timeout: readPoolInt(
       'DB_POOL_IDLE_TIMEOUT_S',
-      isServerless ? SERVERLESS_DEFAULT_POOL_IDLE_TIMEOUT_S : DEFAULT_POOL_IDLE_TIMEOUT_S,
+      vercelRuntime ? SERVERLESS_DEFAULT_POOL_IDLE_TIMEOUT_S : DEFAULT_POOL_IDLE_TIMEOUT_S,
       MIN_POOL_IDLE_TIMEOUT_S,
     ),
     connect_timeout: 30,

--- a/packages/web/app/__tests__/rest-surface-inventory.test.ts
+++ b/packages/web/app/__tests__/rest-surface-inventory.test.ts
@@ -1,5 +1,5 @@
 /**
- * The standing inventory oracle for issue #1889 (REST surface audit: 39
+ * The standing inventory oracle for issue #1889 (REST surface audit: 40
  * routes classified after the board renderer moved to Railway in #4715 and
  * the Railway healthcheck route landed in #3798).
  *
@@ -61,7 +61,7 @@ const VERDICTS: Record<string, Verdict> = {
   // so a transient blip can't fail a deploy or start a restart loop. ---
   'app/api/health/route.ts': 'keep-external',
 
-  // --- /api/internal/* (15) ---
+  // --- /api/internal/* (16) ---
   // Party-session / kiosk auth bridge — never delete.
   'app/api/internal/ws-auth/route.ts': 'keep-external',
   // No web consumer, but no production surface either (404s outside
@@ -80,6 +80,9 @@ const VERDICTS: Record<string, Verdict> = {
   // Retained for a manual initial refresh when Railway takes over scheduling.
   // It must remain absent from Vercel's scheduler while climb sitemaps are paused.
   'app/api/internal/refresh-sitemap-climbs/route.ts': 'keep-external',
+  // Operator-only target for the PgBouncer cutover smoke CLI. Production app
+  // code never calls it; the dedicated bearer token keeps it off public paths.
+  'app/api/internal/pgbouncer-cutover-readiness/route.ts': 'keep-external',
   'app/api/internal/beta-link-thumbnail/route.ts': 'keep-caller',
   'app/api/internal/revalidate-climb/route.ts': 'keep-caller',
   'app/api/internal/climb-search-cache/revalidate/route.ts': 'keep-caller',
@@ -236,6 +239,6 @@ describe('REST surface inventory (issue #1889)', () => {
   it('counts exactly the audited surface', () => {
     // Guards the headline number in issue #1889 itself — a change here means
     // the issue body needs a fresh audit pass, not a quiet reclassification.
-    expect(derived.size).toBe(39);
+    expect(derived.size).toBe(40);
   });
 });

--- a/packages/web/app/api/internal/pgbouncer-cutover-readiness/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/pgbouncer-cutover-readiness/__tests__/route.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
+
+const database = vi.hoisted(() => ({ execute: vi.fn(), deadlines: [] as number[] }));
+
+vi.mock('@/app/lib/db/db', () => ({
+  getDb: () => database,
+  rowsFromResult: (queryResult: unknown) => queryResult,
+}));
+vi.mock('@/app/lib/db/read-deadline', () => ({
+  withReadDeadline: async (_label: string, pending: PromiseLike<unknown>, timeoutMs: number) => {
+    database.deadlines.push(timeoutMs);
+    return await pending;
+  },
+}));
+
+const routeModule = await import('../route');
+const NO_STORE = 'private, no-store, max-age=0';
+
+function request(authorization?: string): Request {
+  return new Request('https://www.boardsesh.com/api/internal/pgbouncer-cutover-readiness', {
+    headers: authorization ? { authorization } : undefined,
+  });
+}
+
+beforeEach(() => {
+  vi.stubEnv('PGBOUNCER_CUTOVER_SMOKE_TOKEN', 'test-probe-secret');
+  database.execute.mockReset();
+  database.deadlines = [];
+  database.execute.mockResolvedValue([{ ready: 1 }]);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('GET /api/internal/pgbouncer-cutover-readiness', () => {
+  it('rejects missing, wrong, same-length wrong, and unconfigured credentials before DB work', async () => {
+    const rejected = [
+      await routeModule.GET(request()),
+      await routeModule.GET(request('Bearer wrong')),
+      await routeModule.GET(request('Bearer test-probe-secrex')),
+      await routeModule.GET(request('Bearer ')),
+    ];
+    vi.stubEnv('PGBOUNCER_CUTOVER_SMOKE_TOKEN', '');
+    rejected.push(await routeModule.GET(request('Bearer test-probe-secret')));
+    rejected.push(await routeModule.GET(request('Bearer ')));
+
+    expect(rejected.map((response) => response.status)).toEqual([401, 401, 401, 401, 401, 401]);
+    expect(rejected.every((response) => response.headers.get('cache-control') === NO_STORE)).toBe(true);
+    expect(rejected.every((response) => response.headers.get('vary') === 'Authorization')).toBe(true);
+    expect(database.execute).not.toHaveBeenCalled();
+  });
+
+  it('runs one primary query and returns an uncached success', async () => {
+    const response = await routeModule.GET(request('Bearer test-probe-secret'));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(database.execute).toHaveBeenCalledTimes(1);
+    expect(database.deadlines).toEqual([5_000]);
+    expect(response.headers.get('cache-control')).toBe(NO_STORE);
+    expect(response.headers.get('cdn-cache-control')).toBe('no-store');
+    expect(response.headers.get('vercel-cdn-cache-control')).toBe('no-store');
+    expect(response.headers.get('vary')).toBe('Authorization');
+  });
+
+  it('returns an uncached 503 without driver details on failure or a wrong result', async () => {
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    database.execute.mockRejectedValueOnce(new Error('password and host must stay private'));
+
+    const failed = await routeModule.GET(request('Bearer test-probe-secret'));
+    database.execute.mockResolvedValueOnce([{ ready: 0 }]);
+    const wrongResult = await routeModule.GET(request('Bearer test-probe-secret'));
+
+    expect(failed.status).toBe(503);
+    expect(wrongResult.status).toBe(503);
+    expect(await failed.json()).toEqual({ ok: false });
+    for (const response of [failed, wrongResult]) {
+      expect(response.headers.get('cache-control')).toBe(NO_STORE);
+      expect(response.headers.get('cdn-cache-control')).toBe('no-store');
+      expect(response.headers.get('vercel-cdn-cache-control')).toBe('no-store');
+      expect(response.headers.get('vary')).toBe('Authorization');
+    }
+    expect(errorLog).toHaveBeenCalledWith('[pgbouncer-cutover-readiness] database probe failed');
+    expect(JSON.stringify(errorLog.mock.calls)).not.toContain('password');
+  });
+});

--- a/packages/web/app/api/internal/pgbouncer-cutover-readiness/route.ts
+++ b/packages/web/app/api/internal/pgbouncer-cutover-readiness/route.ts
@@ -1,0 +1,54 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { sql } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+import { getDb, rowsFromResult } from '@/app/lib/db/db';
+import { withReadDeadline } from '@/app/lib/db/read-deadline';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const revalidate = 0;
+
+const TOKEN_ENV = 'PGBOUNCER_CUTOVER_SMOKE_TOKEN';
+const PROBE_DB_TIMEOUT_MS = 5_000;
+const NO_STORE_HEADERS = {
+  'Cache-Control': 'private, no-store, max-age=0',
+  'CDN-Cache-Control': 'no-store',
+  'Vercel-CDN-Cache-Control': 'no-store',
+  Vary: 'Authorization',
+};
+
+function isAuthorized(request: Request): boolean {
+  const configuredToken = process.env[TOKEN_ENV] ?? '';
+  const expectedDigest = createHash('sha256').update(`Bearer ${configuredToken}`).digest();
+  const presentedDigest = createHash('sha256')
+    .update(request.headers.get('authorization') ?? '')
+    .digest();
+  const digestsMatch = timingSafeEqual(expectedDigest, presentedDigest);
+
+  // Always do the same fixed-length comparison, including when the token is
+  // unset. An empty configured token can never authorize `Bearer `.
+  return configuredToken.length > 0 && digestsMatch;
+}
+
+/** An authenticated, uncached round trip through the web runtime's primary database pool. */
+export async function GET(request: Request) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ ok: false }, { status: 401, headers: NO_STORE_HEADERS });
+  }
+
+  try {
+    const database = getDb();
+    const queryResult = await withReadDeadline(
+      'pgbouncer-cutover-readiness',
+      database.execute(sql`select 1 as ready`),
+      PROBE_DB_TIMEOUT_MS,
+    );
+    const [row] = rowsFromResult<{ ready: number }>(queryResult);
+    if (Number(row?.ready) !== 1) throw new Error('unexpected readiness result');
+    return NextResponse.json({ ok: true }, { headers: NO_STORE_HEADERS });
+  } catch {
+    // Never log the driver error object: it can carry host/user connection data.
+    console.error('[pgbouncer-cutover-readiness] database probe failed');
+    return NextResponse.json({ ok: false }, { status: 503, headers: NO_STORE_HEADERS });
+  }
+}

--- a/packages/web/app/lib/data/__tests__/climb-missing-not-cached.test.ts
+++ b/packages/web/app/lib/data/__tests__/climb-missing-not-cached.test.ts
@@ -50,7 +50,6 @@ const params = {
 };
 
 function queueReads(): void {
-  mockSqlTag.mockResolvedValueOnce([]); // alias lookup: no alias
   mockSqlTag.mockResolvedValueOnce(rows.climbRow ? [rows.climbRow] : []);
 }
 
@@ -68,8 +67,8 @@ describe('missing climbs are not negatively cached', () => {
     queueReads();
     await expect(getClimb(params)).resolves.toBeNull();
 
-    // Four statements: two reads, neither of them cached.
-    expect(mockSqlTag).toHaveBeenCalledTimes(4);
+    // Two statements: two reads, neither of them cached.
+    expect(mockSqlTag).toHaveBeenCalledTimes(2);
   });
 
   it('recovers as soon as the row lands', async () => {
@@ -89,6 +88,6 @@ describe('missing climbs are not negatively cached', () => {
     await getClimb(params);
     await getClimb(params);
 
-    expect(mockSqlTag).toHaveBeenCalledTimes(2);
+    expect(mockSqlTag).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/app/lib/data/__tests__/climb-request-dedupe.test.ts
+++ b/packages/web/app/lib/data/__tests__/climb-request-dedupe.test.ts
@@ -4,9 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 /**
  * `generateMetadata` and the page body both read the climb, and Next renders
  * them concurrently. `unstable_cache` has no in-flight single-flight, so on a
- * cold key both used to miss and both used to run the alias lookup and the climb
- * select — four statements where two would do, on the six-figure crawl surface
- * W-23 submits.
+ * cold key both used to miss and duplicate the climb select on the six-figure
+ * crawl surface W-23 submits.
  *
  * React's `cache` is a per-render memo in a Server Component but a plain
  * passthrough in the client build vitest resolves, so this file substitutes a
@@ -97,42 +96,42 @@ describe('climb front door per-request dedupe', () => {
     // the memo keys on primitives rather than on the params object.
     await Promise.all([getClimb(params), getClimb(equivalentParams)]);
 
-    expect(mockSqlTag).toHaveBeenCalledTimes(2);
+    expect(mockSqlTag).toHaveBeenCalledTimes(1);
   });
 
-  it('a full climb-page data pass costs exactly three statements', async () => {
+  it('a full climb-page data pass costs exactly two statements', async () => {
     // Models the route: metadata's read, the body's read, then the angle table.
     await getClimb(params);
     await getClimb(equivalentParams);
     await getClimbStatsForAllAngles(params);
 
-    expect(mockSqlTag).toHaveBeenCalledTimes(3);
+    expect(mockSqlTag).toHaveBeenCalledTimes(2);
   });
 
   it('still reads a different climb separately', async () => {
     await getClimb(params);
     await getClimb({ ...params, climb_uuid: 'another-climb' });
 
-    expect(mockSqlTag).toHaveBeenCalledTimes(4);
+    expect(mockSqlTag).toHaveBeenCalledTimes(2);
   });
 
   it('shares one read budget across the request instead of restarting it per statement', async () => {
     await getClimb(params);
     await getClimbStatsForAllAngles(params);
 
-    // Three reads, one budget: the alias lookup gets the full 6 s and each later
-    // read gets what the earlier ones left. A per-statement deadline hands all
-    // three the same 6000, which makes the request's real ceiling ~18 s.
-    expect(deadlineBudgets).toEqual([6000, 5000, 4000]);
+    // Two reads, one budget: the climb gets the full 6 s and the angle table
+    // gets what remains. Independent deadlines would make the request ceiling
+    // roughly 12 s.
+    expect(deadlineBudgets).toEqual([6000, 5000]);
   });
 
   it('starts a fresh budget on the next request', async () => {
     await getClimb(params);
-    expect(deadlineBudgets).toEqual([6000, 5000]);
+    expect(deadlineBudgets).toEqual([6000]);
 
     startNewRequest();
 
     await getClimb(params);
-    expect(deadlineBudgets).toEqual([6000, 5000]);
+    expect(deadlineBudgets).toEqual([6000]);
   });
 });

--- a/packages/web/app/lib/data/__tests__/front-door-fanout.test.ts
+++ b/packages/web/app/lib/data/__tests__/front-door-fanout.test.ts
@@ -6,9 +6,8 @@ import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
  *
  * The crawl surface W-23 submits is six figures of climb URLs, so the number of
  * Postgres round trips one cold render costs is a load-bearing number, not an
- * implementation detail. This counts them and asserts the alias lookup and the
- * climb select stay strictly sequential (one connection at a time), so nobody
- * re-inflates the fan-out without the budget going red.
+ * implementation detail. Alias resolution is part of the climb-select CTE, so
+ * one cold climb read must stay one statement and one connection.
  */
 const { mockSqlTag, rowsFromResultMock, inFlight } = vi.hoisted(() => {
   const inFlight = { current: 0, max: 0 };
@@ -61,16 +60,13 @@ describe('climb front door statement budget', () => {
     inFlight.max = 0;
   });
 
-  it('getClimb costs exactly two statements', async () => {
+  it('getClimb resolves aliases and selects the climb in one statement', async () => {
     await getClimb(params);
-    expect(mockSqlTag).toHaveBeenCalledTimes(2);
+    expect(mockSqlTag).toHaveBeenCalledTimes(1);
   });
 
-  it('getClimb runs its alias lookup and climb select sequentially', async () => {
+  it('getClimb holds at most one connection', async () => {
     await getClimb(params);
-    // The climb select needs the alias result, so max concurrency is 1. If this
-    // ever becomes 2 the two statements were fired together against different
-    // uuids — the alias resolution would be silently dropped.
     expect(inFlight.max).toBe(1);
   });
 
@@ -80,7 +76,7 @@ describe('climb front door statement budget', () => {
   });
 
   // The whole-page budget lives in `climb-request-dedupe.test.ts`, where React's
-  // `cache` is a real memo. Asserting 3 here would be arithmetic on the two
-  // cases above (2 + 1) and would pin the number while being unable to tell the
+  // `cache` is a real memo. Asserting 2 here would be arithmetic on the two
+  // cases above (1 + 1) and would pin the number while being unable to tell the
   // deduped page pass from the un-deduped one — the regression that matters.
 });

--- a/packages/web/app/lib/data/__tests__/queries.test.ts
+++ b/packages/web/app/lib/data/__tests__/queries.test.ts
@@ -38,7 +38,6 @@ describe('getClimb', () => {
   });
 
   it('maps layoutId, boardType, and derives difficulty/is_no_match from characteristics', async () => {
-    mockSqlTag.mockResolvedValueOnce([]); // alias lookup: no alias, uuid unchanged
     mockSqlTag.mockResolvedValueOnce([
       {
         uuid: 'climb-uuid-1',
@@ -75,7 +74,7 @@ describe('getClimb', () => {
       }),
     );
 
-    expect(mockSqlTag).toHaveBeenCalledTimes(2);
+    expect(mockSqlTag).toHaveBeenCalledTimes(1);
     expect(climb.uuid).toBe('climb-uuid-1');
     expect(climb.layoutId).toBe(8);
     expect(climb.boardType).toBe('kilter');
@@ -85,7 +84,6 @@ describe('getClimb', () => {
   });
 
   it('derives is_no_match from the description prefix when characteristics is null', async () => {
-    mockSqlTag.mockResolvedValueOnce([]); // alias lookup: no alias, uuid unchanged
     mockSqlTag.mockResolvedValueOnce([
       {
         uuid: 'climb-uuid-2',
@@ -129,7 +127,6 @@ describe('getClimb', () => {
   });
 
   it('is_no_match is false when characteristics has no no_match token and the description does not start with "no match"', async () => {
-    mockSqlTag.mockResolvedValueOnce([]); // alias lookup: no alias, uuid unchanged
     mockSqlTag.mockResolvedValueOnce([
       {
         uuid: 'climb-uuid-3',
@@ -172,7 +169,6 @@ describe('getClimb', () => {
   });
 
   it('resolves an old/merged climb link through board_climb_aliases to the canonical uuid', async () => {
-    mockSqlTag.mockResolvedValueOnce([{ canonical_uuid: 'canonical-uuid-9' }]); // alias hit
     mockSqlTag.mockResolvedValueOnce([
       {
         uuid: 'canonical-uuid-9',
@@ -209,20 +205,20 @@ describe('getClimb', () => {
       }),
     );
 
-    expect(mockSqlTag).toHaveBeenCalledTimes(2);
-    // The climb query (2nd call) must have queried by the RESOLVED canonical
-    // uuid, not the alias — otherwise this renders an empty husk instead of
-    // the merged climb's real data. Call args are [strings, ...interpolated
-    // values]; check the interpolated values only.
-    const [, ...climbQueryValues] = mockSqlTag.mock.calls[1];
-    expect(climbQueryValues).toContain('canonical-uuid-9');
-    expect(climbQueryValues).not.toContain('old-alias-uuid-9');
+    expect(mockSqlTag).toHaveBeenCalledTimes(1);
+    // The single statement resolves the requested alias inside a CTE before it
+    // joins board_climbs. The canonical UUID is returned by Postgres rather
+    // than interpolated from JavaScript.
+    const [queryStrings, ...climbQueryValues] = mockSqlTag.mock.calls[0];
+    const climbQueryText = Array.from(queryStrings as TemplateStringsArray).join(' ');
+    expect(climbQueryText).toContain('resolved_climb AS NOT MATERIALIZED');
+    expect(climbQueryText).toContain('board_climb_aliases');
+    expect(climbQueryValues).toContain('old-alias-uuid-9');
     expect(climb.uuid).toBe('canonical-uuid-9');
   });
 
   it('resolves null when no row matches, instead of throwing on an undefined row', async () => {
-    mockSqlTag.mockResolvedValueOnce([]); // alias lookup: no alias
-    mockSqlTag.mockResolvedValueOnce([]); // climb select: no such climb
+    mockSqlTag.mockResolvedValueOnce([]); // no resolved climb row
 
     const climb = await getClimb({
       board_name: 'kilter',

--- a/packages/web/app/lib/data/queries.ts
+++ b/packages/web/app/lib/data/queries.ts
@@ -30,35 +30,13 @@ class ClimbRowMissingError extends Error {
   }
 }
 
-// Resolves an old/bookmarked/shared climb link through board_climb_aliases:
-// a climb that's since been merged into another (e.g. the MoonBoard
-// angle-dedup migration 0193_moonboard_angle_dedup_backfill) must still
-// resolve to where its stats/ticks/favorites actually live now, not render an
-// empty husk. A miss returns the input uuid unchanged, mirroring
-// resolveCanonicalClimbUuid in
-// packages/db/src/queries/aliases.ts (not reused directly — that helper
-// takes a drizzle db handle and this file's queries are raw postgres-js sql).
-async function resolveCanonicalClimbUuidWeb(boardName: BoardName, climbUuid: string): Promise<string> {
-  const result = rowsFromResult<{ canonical_uuid: string }>(
-    await withReadDeadline(
-      'climb-alias',
-      sql`
-      SELECT canonical_uuid FROM board_climb_aliases
-      WHERE board_type = ${boardName} AND alias_uuid = ${climbUuid}
-      LIMIT 1
-    `,
-      remainingReadBudgetMs(),
-    ),
-  );
-  return result[0]?.canonical_uuid ?? climbUuid;
-}
-
 /**
  * Throws `ClimbRowMissingError` when no row matches — a genuinely missing climb,
  * which the caller turns back into `null`. Anything else (a saturated pool, a
  * read deadline, a dead database) throws its own error, so the page can tell
- * "this climb does not exist" from "we could not answer right now". The two used
- * to be indistinguishable, and both rendered a 404 on an indexed URL.
+ * "this climb does not exist" from "we could not answer right now". Alias
+ * resolution lives in the same statement as the climb select so one cold page
+ * holds one server connection for one round trip rather than two.
  */
 async function fetchClimbFromDb(
   boardName: BoardName,
@@ -66,8 +44,6 @@ async function fetchClimbFromDb(
   angle: number,
   requestedClimbUuid: string,
 ): Promise<Climb> {
-  const climbUuid = await resolveCanonicalClimbUuidWeb(boardName, requestedClimbUuid);
-
   // Direct-by-UUID lookups intentionally do NOT filter `frames_count = 1`.
   // Search/dedupe still skip multi-frame climbs (see queries/climbs/*),
   // but the player needs to be able to render them when a URL points at one.
@@ -75,6 +51,18 @@ async function fetchClimbFromDb(
     await withReadDeadline(
       'climb-select',
       sql`
+        WITH resolved_climb AS NOT MATERIALIZED (
+          SELECT COALESCE(
+            (
+              SELECT aliases.canonical_uuid
+              FROM board_climb_aliases aliases
+              WHERE aliases.board_type = ${boardName}
+                AND aliases.alias_uuid = ${requestedClimbUuid}
+              LIMIT 1
+            ),
+            ${requestedClimbUuid}
+          ) AS uuid
+        )
         SELECT climbs.uuid, climbs.setter_username, climbs.user_id as "userId", climbs.name, climbs.description,
         climbs.layout_id as "layoutId", climbs.board_type as "boardType",
         climbs.frames, climbs.frames_count as "framesCount", climbs.frames_pace as "framesPace",
@@ -86,21 +74,21 @@ async function fetchClimbFromDb(
         CASE WHEN climb_stats.benchmark_difficulty > 0 THEN climb_stats.benchmark_difficulty::text ELSE NULL END as benchmark_difficulty,
         climbs.is_draft, climbs.created_at, climbs.published_at, climbs.characteristics,
         climbs.compatible_size_ids as "compatibleSizeIds"
-        FROM board_climbs climbs
+        FROM resolved_climb
+        INNER JOIN board_climbs climbs ON climbs.uuid = resolved_climb.uuid
         LEFT JOIN board_climb_stats climb_stats
           ON climb_stats.climb_uuid = climbs.uuid
           AND climb_stats.angle = ${angle}
           AND climb_stats.board_type = ${boardName}
         WHERE climbs.board_type = ${boardName}
         AND climbs.layout_id = ${layoutId}
-        AND climbs.uuid = ${climbUuid}
         limit 1
       `,
       remainingReadBudgetMs(),
     ),
   );
   const row = result[0];
-  if (!row) throw new ClimbRowMissingError(climbUuid);
+  if (!row) throw new ClimbRowMissingError(requestedClimbUuid);
   return {
     ...row,
     difficulty: getGradeLabel(row.difficulty_id),
@@ -143,8 +131,7 @@ async function cachedClimbFetch(
  * React-`cache`d on primitives, so `generateMetadata` and the page body share
  * one read per request. `unstable_cache` has no in-flight single-flight and
  * Next renders the two concurrently, so on a cold key both used to miss and
- * both used to run the alias lookup and the climb select — four statements
- * where two would do.
+ * duplicate the climb select.
  * Keying on primitives (rather than the params object) makes the dedupe work in
  * the `/b/{slug}` tree too, where the two entry points build their own objects.
  *

--- a/packages/web/app/lib/db/__tests__/read-deadline-wiring.test.ts
+++ b/packages/web/app/lib/db/__tests__/read-deadline-wiring.test.ts
@@ -8,7 +8,7 @@ import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
  * `db-pool-exhaustion.test.ts` proves it against a live Postgres — but both
  * would stay green if a refactor (or a merge that resolved a conflict by keeping
  * the old `await sql\`…\`` form) dropped the wrapper from the front-door reads.
- * This pins the four call sites by name.
+ * This pins the three call sites by name.
  */
 const { recordedReads, mockSqlTag } = vi.hoisted(() => ({
   recordedReads: [] as { label: string; ms: number | undefined }[],
@@ -68,10 +68,10 @@ describe('front-door reads run under a deadline', () => {
     mockSqlTag.mockClear();
   });
 
-  it('bounds the alias lookup and the climb select', async () => {
+  it('bounds the climb select that resolves aliases in its CTE', async () => {
     await getClimb(params);
 
-    expect(labels()).toEqual(['climb-alias', 'climb-select']);
+    expect(labels()).toEqual(['climb-select']);
   });
 
   it('bounds the all-angles stats read', async () => {

--- a/packages/web/app/lib/observability/__tests__/postgres-error-tags.test.ts
+++ b/packages/web/app/lib/observability/__tests__/postgres-error-tags.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vite-plus/test';
+import type { Event, EventHint } from '@sentry/nextjs';
+import { findPostgresErrorCode, tagPostgresError } from '../postgres-error-tags';
+
+describe('Postgres Sentry tags', () => {
+  it('finds a postgres.js SQLSTATE through Drizzle cause wrappers', () => {
+    const postgresError = Object.assign(new Error('remaining connection slots are reserved'), { code: '53300' });
+    const drizzleError = Object.assign(new Error('Failed query'), { cause: postgresError });
+
+    expect(findPostgresErrorCode(drizzleError)).toBe('53300');
+  });
+
+  it('ignores non-Postgres codes and cycle-safe cause chains', () => {
+    const cyclicError = Object.assign(new Error('cycle'), { code: 'ECONNRESET', cause: undefined as unknown });
+    cyclicError.cause = cyclicError;
+
+    expect(findPostgresErrorCode(cyclicError)).toBeNull();
+  });
+
+  it('leaves events unchanged when originalException is null or undefined', () => {
+    const event: Event = { tags: { route: 'climb-view' } };
+
+    expect(tagPostgresError(event, { originalException: null })).toBe(event);
+    expect(tagPostgresError(event, { originalException: undefined })).toBe(event);
+  });
+
+  it('tags 53300 events while preserving existing tags', () => {
+    const event: Event = { tags: { route: 'climb-view' } };
+    const hint: EventHint = {
+      originalException: Object.assign(new Error('too many clients'), { code: '53300' }),
+    };
+
+    expect(tagPostgresError(event, hint).tags).toEqual({
+      route: 'climb-view',
+      'postgres.error_code': '53300',
+      'postgres.resource_exhaustion': 'true',
+    });
+  });
+
+  it('tags other PostgreSQL errors without calling them resource exhaustion', () => {
+    const event = tagPostgresError({}, { originalException: { code: '42P01' } });
+
+    expect(event.tags).toEqual({ 'postgres.error_code': '42P01' });
+  });
+
+  it('tags the PostgreSQL raise-exception SQLSTATE P0001 without resource exhaustion', () => {
+    const event = tagPostgresError({}, { originalException: { code: 'P0001' } });
+
+    expect(event.tags).toEqual({ 'postgres.error_code': 'P0001' });
+  });
+});

--- a/packages/web/app/lib/observability/__tests__/postgres-error-tags.test.ts
+++ b/packages/web/app/lib/observability/__tests__/postgres-error-tags.test.ts
@@ -15,6 +15,7 @@ describe('Postgres Sentry tags', () => {
     cyclicError.cause = cyclicError;
 
     expect(findPostgresErrorCode(cyclicError)).toBeNull();
+    expect(findPostgresErrorCode(Object.assign(new Error('not permitted'), { code: 'EPERM' }))).toBeNull();
   });
 
   it('leaves events unchanged when originalException is null or undefined', () => {

--- a/packages/web/app/lib/observability/postgres-error-tags.ts
+++ b/packages/web/app/lib/observability/postgres-error-tags.ts
@@ -3,6 +3,51 @@ import type { ErrorEvent, Event, EventHint } from '@sentry/nextjs';
 export const POSTGRES_TOO_MANY_CONNECTIONS_CODE = '53300';
 
 const MAX_CAUSE_DEPTH = 8;
+const POSTGRES_SQLSTATE_CLASSES = new Set([
+  '00',
+  '01',
+  '02',
+  '03',
+  '08',
+  '09',
+  '0A',
+  '0B',
+  '0F',
+  '0L',
+  '0P',
+  '0Z',
+  '20',
+  '21',
+  '22',
+  '23',
+  '24',
+  '25',
+  '26',
+  '27',
+  '28',
+  '2B',
+  '2D',
+  '2F',
+  '34',
+  '38',
+  '39',
+  '3B',
+  '3D',
+  '3F',
+  '40',
+  '42',
+  '44',
+  '53',
+  '54',
+  '55',
+  '57',
+  '58',
+  '72',
+  'F0',
+  'HV',
+  'P0',
+  'XX',
+]);
 
 type ErrorWithCause = {
   cause?: unknown;
@@ -27,7 +72,13 @@ export function findPostgresErrorCode(error: unknown): string | null {
     if (visited.has(candidate)) return null;
     visited.add(candidate);
 
-    if (typeof candidate.code === 'string' && /^[0-9A-Z]{5}$/.test(candidate.code)) return candidate.code;
+    if (
+      typeof candidate.code === 'string' &&
+      /^[0-9A-Z]{5}$/.test(candidate.code) &&
+      POSTGRES_SQLSTATE_CLASSES.has(candidate.code.slice(0, 2))
+    ) {
+      return candidate.code;
+    }
     candidate = asErrorWithCause(candidate.cause);
   }
 

--- a/packages/web/app/lib/observability/postgres-error-tags.ts
+++ b/packages/web/app/lib/observability/postgres-error-tags.ts
@@ -1,0 +1,52 @@
+import type { ErrorEvent, Event, EventHint } from '@sentry/nextjs';
+
+export const POSTGRES_TOO_MANY_CONNECTIONS_CODE = '53300';
+
+const MAX_CAUSE_DEPTH = 8;
+
+type ErrorWithCause = {
+  cause?: unknown;
+  code?: unknown;
+};
+
+function asErrorWithCause(candidate: unknown): ErrorWithCause | null {
+  if ((typeof candidate !== 'object' && typeof candidate !== 'function') || candidate === null) return null;
+  return candidate as ErrorWithCause;
+}
+
+/**
+ * Finds a PostgreSQL SQLSTATE without assuming the driver error is the value
+ * Sentry received. Drizzle wraps postgres.js failures in `cause`, and other
+ * request layers can add more wrappers, so walk a short cycle-safe chain.
+ */
+export function findPostgresErrorCode(error: unknown): string | null {
+  const visited = new Set<ErrorWithCause>();
+  let candidate = asErrorWithCause(error);
+
+  for (let depth = 0; candidate && depth < MAX_CAUSE_DEPTH; depth += 1) {
+    if (visited.has(candidate)) return null;
+    visited.add(candidate);
+
+    if (typeof candidate.code === 'string' && /^[0-9A-Z]{5}$/.test(candidate.code)) return candidate.code;
+    candidate = asErrorWithCause(candidate.cause);
+  }
+
+  return null;
+}
+
+/** Adds stable Sentry tags used by the production connection-exhaustion alert. */
+export function tagPostgresError(event: ErrorEvent, hint: EventHint): ErrorEvent;
+export function tagPostgresError(event: Event, hint: EventHint): Event;
+export function tagPostgresError(event: Event, hint: EventHint): Event {
+  const postgresErrorCode = findPostgresErrorCode(hint.originalException);
+  if (!postgresErrorCode) return event;
+
+  return {
+    ...event,
+    tags: {
+      ...event.tags,
+      'postgres.error_code': postgresErrorCode,
+      ...(postgresErrorCode === POSTGRES_TOO_MANY_CONNECTIONS_CODE ? { 'postgres.resource_exhaustion': 'true' } : {}),
+    },
+  };
+}

--- a/packages/web/sentry.server.config.ts
+++ b/packages/web/sentry.server.config.ts
@@ -4,6 +4,7 @@
 
 import * as Sentry from '@sentry/nextjs';
 import { isProductionSentryEnvironment, resolveSentryEnvironment } from '@boardsesh/db/client/config';
+import { tagPostgresError } from '@/app/lib/observability/postgres-error-tags';
 
 Sentry.init({
   dsn: 'https://f55e6626faf787ae5291ad75b010ea14@o4510644927660032.ingest.us.sentry.io/4510644930150400',
@@ -18,6 +19,11 @@ Sentry.init({
   enabled: isProductionSentryEnvironment(),
 
   environment: resolveSentryEnvironment(),
+
+  // Normalise postgres.js and Drizzle wrapper shapes into queryable SQLSTATE
+  // tags. Production alerts can now match `postgres.error_code:53300` without
+  // relying on an English message or one particular error wrapper.
+  beforeSend: tagPostgresError,
 
   // Enable logs to be sent to Sentry
   enableLogs: true,

--- a/scripts/__tests__/direct-database-guard.test.ts
+++ b/scripts/__tests__/direct-database-guard.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vite-plus/test';
+import {
+  assertExpectedDirectEndpoint,
+  databaseEndpointIdentity,
+  verifyDirectConnectivity,
+} from '../../packages/db/scripts/direct-database-guard';
+
+describe('direct database guard', () => {
+  it('normalizes the default PostgreSQL port without retaining credentials', () => {
+    expect(databaseEndpointIdentity('postgresql://migrator:secret@DIRECT.EXAMPLE/boardsesh?sslmode=require')).toBe(
+      'direct.example:5432/boardsesh',
+    );
+  });
+
+  it('accepts the pinned direct host, port, and database', () => {
+    expect(() =>
+      assertExpectedDirectEndpoint(
+        'postgres://migrator:secret@direct.example:15432/boardsesh',
+        'direct.example:15432/boardsesh',
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects a PgBouncer endpoint even when credentials and database match', () => {
+    expect(() =>
+      assertExpectedDirectEndpoint(
+        'postgres://migrator:secret@pooler.example:6432/boardsesh',
+        'direct.example:15432/boardsesh',
+      ),
+    ).toThrow(/does not match the trusted PostgreSQL endpoint/);
+  });
+
+  it('requires the protected endpoint identity', () => {
+    expect(() => assertExpectedDirectEndpoint('postgres://migrator:secret@direct.example/boardsesh', '')).toThrow(
+      /DATABASE_DIRECT_ENDPOINT is required/,
+    );
+  });
+
+  it('redacts malformed connection strings from parse errors', () => {
+    const sentinelPassword = 'never-print-this-password';
+    let thrownError: unknown;
+
+    try {
+      databaseEndpointIdentity(`postgresql://migrator:${sentinelPassword}@[invalid/boardsesh`);
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toBeInstanceOf(Error);
+    const serializedError = JSON.stringify(thrownError, Object.getOwnPropertyNames(thrownError as object));
+    expect(String(thrownError)).not.toContain(sentinelPassword);
+    expect(serializedError).not.toContain(sentinelPassword);
+    expect(String(thrownError)).toContain('DATABASE_DIRECT_URL is not a valid PostgreSQL URL');
+  });
+
+  it('runs a read-only connectivity probe and propagates failures', async () => {
+    const unsafe = vi.fn<(query: string) => Promise<unknown>>().mockResolvedValue([{ '?column?': 1 }]);
+    await verifyDirectConnectivity({ unsafe });
+    expect(unsafe).toHaveBeenCalledExactlyOnceWith('SELECT 1');
+
+    const connectionError = Object.assign(new Error('connection failed'), { code: 'ECONNREFUSED' });
+    await expect(
+      verifyDirectConnectivity({
+        unsafe: () => Promise.reject(connectionError),
+      }),
+    ).rejects.toBe(connectionError);
+  });
+});

--- a/scripts/__tests__/direct-database-guard.test.ts
+++ b/scripts/__tests__/direct-database-guard.test.ts
@@ -19,6 +19,12 @@ describe('direct database guard', () => {
         'direct.example:15432/boardsesh',
       ),
     ).not.toThrow();
+    expect(() =>
+      assertExpectedDirectEndpoint(
+        'postgres://migrator:secret@direct.example:15432/boardsesh',
+        'DIRECT.EXAMPLE:15432/boardsesh',
+      ),
+    ).not.toThrow();
   });
 
   it('rejects a PgBouncer endpoint even when credentials and database match', () => {
@@ -34,6 +40,9 @@ describe('direct database guard', () => {
     expect(() => assertExpectedDirectEndpoint('postgres://migrator:secret@direct.example/boardsesh', '')).toThrow(
       /DATABASE_DIRECT_ENDPOINT is required/,
     );
+    expect(() =>
+      assertExpectedDirectEndpoint('postgres://migrator:secret@direct.example/boardsesh', 'user@direct.example/db'),
+    ).toThrow(/DATABASE_DIRECT_ENDPOINT must be a valid/);
   });
 
   it('redacts malformed connection strings from parse errors', () => {
@@ -53,16 +62,15 @@ describe('direct database guard', () => {
     expect(String(thrownError)).toContain('DATABASE_DIRECT_URL is not a valid PostgreSQL URL');
   });
 
-  it('runs a read-only connectivity probe and propagates failures', async () => {
+  it('runs a read-only connectivity probe and redacts failures', async () => {
     const unsafe = vi.fn<(query: string) => Promise<unknown>>().mockResolvedValue([{ '?column?': 1 }]);
     await verifyDirectConnectivity({ unsafe });
     expect(unsafe).toHaveBeenCalledExactlyOnceWith('SELECT 1');
 
-    const connectionError = Object.assign(new Error('connection failed'), { code: 'ECONNREFUSED' });
     await expect(
       verifyDirectConnectivity({
-        unsafe: () => Promise.reject(connectionError),
+        unsafe: () => Promise.reject(new Error('postgresql://migrator:secret@direct.example/boardsesh')),
       }),
-    ).rejects.toBe(connectionError);
+    ).rejects.toThrow('DATABASE_DIRECT_URL failed TLS connectivity or SELECT 1 verification');
   });
 });

--- a/scripts/__tests__/pgbouncer-config.test.ts
+++ b/scripts/__tests__/pgbouncer-config.test.ts
@@ -4,7 +4,7 @@ import { spawnSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
 
 const ENTRYPOINT_PATH = 'deploy/pgbouncer/docker-entrypoint.sh';
 const DOCKERFILE_PATH = 'deploy/pgbouncer/Dockerfile';

--- a/scripts/__tests__/pgbouncer-config.test.ts
+++ b/scripts/__tests__/pgbouncer-config.test.ts
@@ -1,0 +1,308 @@
+/// <reference types="node" />
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const ENTRYPOINT_PATH = 'deploy/pgbouncer/docker-entrypoint.sh';
+const DOCKERFILE_PATH = 'deploy/pgbouncer/Dockerfile';
+const HEALTHCHECK_PATH = 'deploy/pgbouncer/healthcheck.sh';
+const SMOKE_TEST_PATH = 'deploy/pgbouncer/smoke-test.sh';
+const WORKFLOW_PATH = '.github/workflows/pgbouncer-image.yml';
+const PRODUCTION_WORKFLOW_PATH = '.github/workflows/production-deploy.yml';
+const temporaryDirectories: string[] = [];
+
+const baseEnvironment = {
+  PGBOUNCER_UPSTREAM_HOST: 'postgres.internal',
+  PGBOUNCER_UPSTREAM_PORT: '5432',
+  PGBOUNCER_DATABASE_NAME: 'boardsesh',
+  PGBOUNCER_UPSTREAM_USER: 'boardsesh_server',
+  PGBOUNCER_UPSTREAM_PASSWORD: 'upstream "secret" \\ value',
+  PGBOUNCER_CLIENT_USER: 'boardsesh_client',
+  PGBOUNCER_CLIENT_PASSWORD: 'client "secret" \\ value',
+  PGBOUNCER_ADMIN_USER: 'pgbouncer_admin',
+  PGBOUNCER_ADMIN_PASSWORD: 'admin "secret" \\ value',
+  PGBOUNCER_CLIENT_TLS_CERT: '-----BEGIN CERTIFICATE-----\nclient certificate\n-----END CERTIFICATE-----',
+  PGBOUNCER_CLIENT_TLS_KEY: '-----BEGIN PRIVATE KEY-----\nclient key\n-----END PRIVATE KEY-----',
+  PGBOUNCER_SERVER_TLS_CA: '-----BEGIN CERTIFICATE-----\nserver ca\n-----END CERTIFICATE-----',
+};
+
+afterEach(() => {
+  for (const temporaryDirectory of temporaryDirectories.splice(0)) {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+function render(overrides: Record<string, string | undefined> = {}, trace = false) {
+  const runtimeDirectory = mkdtempSync(join(tmpdir(), 'boardsesh-pgbouncer-'));
+  temporaryDirectories.push(runtimeDirectory);
+
+  const environment: NodeJS.ProcessEnv = {
+    NODE_ENV: 'test',
+    PATH: process.env.PATH,
+    ...baseEnvironment,
+    PGBOUNCER_RUNTIME_DIR: runtimeDirectory,
+  };
+  for (const [variableName, variableValue] of Object.entries(overrides)) {
+    if (variableValue === undefined) delete environment[variableName];
+    else environment[variableName] = variableValue;
+  }
+
+  const result = spawnSync('sh', [...(trace ? ['-x'] : []), ENTRYPOINT_PATH, 'true'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: environment,
+  });
+
+  return { result, runtimeDirectory };
+}
+
+describe('PgBouncer runtime configuration', () => {
+  it('renders the bounded transaction pool and required TLS modes', () => {
+    const { result, runtimeDirectory } = render();
+    expect(result.status, result.stderr).toBe(0);
+
+    const configuration = readFileSync(join(runtimeDirectory, 'pgbouncer.ini'), 'utf8');
+    expect(configuration).toContain(
+      'boardsesh = host=postgres.internal port=5432 dbname=boardsesh user=boardsesh_server',
+    );
+    expect(configuration).toMatch(/pool_mode = transaction/);
+    expect(configuration).toMatch(/default_pool_size = 40/);
+    expect(configuration).toMatch(/min_pool_size = 0/);
+    expect(configuration).toMatch(/reserve_pool_size = 5/);
+    expect(configuration).toMatch(/reserve_pool_timeout = 3/);
+    expect(configuration).toMatch(/max_db_connections = 45/);
+    expect(configuration).toMatch(/max_user_connections = 45/);
+    expect(configuration).toMatch(/max_client_conn = 500/);
+    expect(configuration).toMatch(/max_prepared_statements = 0/);
+    expect(configuration).toMatch(/query_wait_timeout = 5/);
+    expect(configuration).toMatch(/client_login_timeout = 5/);
+    expect(configuration).toMatch(/server_connect_timeout = 5/);
+    expect(configuration).toMatch(/server_login_retry = 3/);
+    expect(configuration).toMatch(/server_idle_timeout = 300/);
+    expect(configuration).toMatch(/idle_transaction_timeout = 60/);
+    expect(configuration).toMatch(/client_tls_sslmode = require/);
+    expect(configuration).toMatch(/server_tls_sslmode = verify-full/);
+
+    for (const secret of [
+      baseEnvironment.PGBOUNCER_UPSTREAM_PASSWORD,
+      baseEnvironment.PGBOUNCER_CLIENT_PASSWORD,
+      baseEnvironment.PGBOUNCER_ADMIN_PASSWORD,
+    ]) {
+      expect(configuration).not.toContain(secret);
+      expect(result.stdout).not.toContain(secret);
+      expect(result.stderr).not.toContain(secret);
+    }
+  });
+
+  it('escapes auth-file quotes and protects every generated file', () => {
+    const { result, runtimeDirectory } = render();
+    expect(result.status, result.stderr).toBe(0);
+
+    expect(readFileSync(join(runtimeDirectory, 'userlist.txt'), 'utf8')).toBe(
+      '"boardsesh_client" "client ""secret"" \\ value"\n' +
+        '"boardsesh_server" "upstream ""secret"" \\ value"\n' +
+        '"pgbouncer_admin" "admin ""secret"" \\ value"\n',
+    );
+
+    for (const fileName of [
+      'pgbouncer.ini',
+      'userlist.txt',
+      'auth_hba.conf',
+      'client.crt',
+      'client.key',
+      'server-ca.crt',
+    ]) {
+      expect(statSync(join(runtimeDirectory, fileName)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it('rejects configuration injection without echoing the supplied value', () => {
+    const injectedHost = 'postgres.internal\npassword=do-not-print';
+    const { result } = render({ PGBOUNCER_UPSTREAM_HOST: injectedHost });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('PGBOUNCER_UPSTREAM_HOST contains unsupported characters');
+    expect(result.stderr).not.toContain(injectedHost);
+  });
+
+  it('rejects unsafe runtime directories without echoing injected configuration', () => {
+    const injectedRuntimeDirectory = '/tmp/pgbouncer\nauth_type = trust';
+    const injectedResult = render({ PGBOUNCER_RUNTIME_DIR: injectedRuntimeDirectory }).result;
+    expect(injectedResult.status).not.toBe(0);
+    expect(injectedResult.stderr).toContain('PGBOUNCER_RUNTIME_DIR contains unsupported characters');
+    expect(injectedResult.stderr).not.toContain(injectedRuntimeDirectory);
+    expect(injectedResult.stderr).not.toContain('auth_type = trust');
+
+    const relativeResult = render({ PGBOUNCER_RUNTIME_DIR: 'relative/runtime' }).result;
+    expect(relativeResult.status).not.toBe(0);
+    expect(relativeResult.stderr).toContain('PGBOUNCER_RUNTIME_DIR must be an absolute path');
+
+    const parentSegmentResult = render({ PGBOUNCER_RUNTIME_DIR: '/tmp/../run/pgbouncer' }).result;
+    expect(parentSegmentResult.status).not.toBe(0);
+    expect(parentSegmentResult.stderr).toContain("PGBOUNCER_RUNTIME_DIR must not contain '..' path segments");
+  });
+
+  it('disables shell tracing before it handles credentials', () => {
+    const { result } = render({}, true);
+    expect(result.status, result.stderr).toBe(0);
+    for (const secret of [
+      baseEnvironment.PGBOUNCER_UPSTREAM_PASSWORD,
+      baseEnvironment.PGBOUNCER_CLIENT_PASSWORD,
+      baseEnvironment.PGBOUNCER_ADMIN_PASSWORD,
+    ]) {
+      expect(result.stderr).not.toContain(secret);
+    }
+  });
+
+  it('requires both optional upstream client-certificate values', () => {
+    const { result } = render({ PGBOUNCER_SERVER_TLS_CERT: 'certificate only' });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('PGBOUNCER_SERVER_TLS_CERT and PGBOUNCER_SERVER_TLS_KEY must be set together');
+  });
+
+  it('requires the primary identities to be pairwise distinct', () => {
+    const { result } = render({ PGBOUNCER_UPSTREAM_USER: baseEnvironment.PGBOUNCER_CLIENT_USER });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('client, upstream, and admin users must be pairwise distinct');
+  });
+
+  it('overlaps a distinct next client identity without widening HBA access', () => {
+    const { result, runtimeDirectory } = render({
+      PGBOUNCER_CLIENT_USER_NEXT: 'boardsesh_client_next',
+      PGBOUNCER_CLIENT_PASSWORD_NEXT: 'next client secret',
+    });
+    expect(result.status, result.stderr).toBe(0);
+
+    const hba = readFileSync(join(runtimeDirectory, 'auth_hba.conf'), 'utf8');
+    expect(hba).toBe(
+      'local all all reject\n' +
+        'hostnossl all all 0.0.0.0/0 reject\n' +
+        'hostssl boardsesh boardsesh_client 0.0.0.0/0 scram-sha-256\n' +
+        'hostssl boardsesh boardsesh_client_next 0.0.0.0/0 scram-sha-256\n' +
+        'hostssl pgbouncer pgbouncer_admin 0.0.0.0/0 scram-sha-256\n' +
+        'hostssl all all 0.0.0.0/0 reject\n',
+    );
+    expect(readFileSync(join(runtimeDirectory, 'userlist.txt'), 'utf8')).toContain(
+      '"boardsesh_client_next" "next client secret"',
+    );
+  });
+
+  it('requires both next-client credential values and a unique next identity', () => {
+    const missingPassword = render({ PGBOUNCER_CLIENT_USER_NEXT: 'boardsesh_client_next' }).result;
+    expect(missingPassword.status).not.toBe(0);
+    expect(missingPassword.stderr).toContain(
+      'PGBOUNCER_CLIENT_USER_NEXT and PGBOUNCER_CLIENT_PASSWORD_NEXT must be set together',
+    );
+
+    const reusedIdentity = render({
+      PGBOUNCER_CLIENT_USER_NEXT: baseEnvironment.PGBOUNCER_ADMIN_USER,
+      PGBOUNCER_CLIENT_PASSWORD_NEXT: 'next secret',
+    }).result;
+    expect(reusedIdentity.status).not.toBe(0);
+    expect(reusedIdentity.stderr).toContain('PGBOUNCER_CLIENT_USER_NEXT must be distinct from all active users');
+  });
+
+  it('generates a self-signed client-facing identity when none is injected', () => {
+    const { result, runtimeDirectory } = render({
+      PGBOUNCER_CLIENT_TLS_CERT: undefined,
+      PGBOUNCER_CLIENT_TLS_KEY: undefined,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(readFileSync(join(runtimeDirectory, 'client.crt'), 'utf8')).toContain('-----BEGIN CERTIFICATE-----');
+    expect(readFileSync(join(runtimeDirectory, 'client.key'), 'utf8')).toContain('-----BEGIN PRIVATE KEY-----');
+  });
+
+  it('health-checks the client application path over TLS', () => {
+    const healthcheck = readFileSync(HEALTHCHECK_PATH, 'utf8');
+    expect(healthcheck).toContain('PGPASSWORD=$PGBOUNCER_CLIENT_PASSWORD');
+    expect(healthcheck).toContain('PGSSLMODE=require');
+    expect(healthcheck).toContain('--username="$PGBOUNCER_CLIENT_USER"');
+    expect(healthcheck).toContain('--dbname="$PGBOUNCER_DATABASE_NAME"');
+    expect(healthcheck).toContain("--command='SELECT 1'");
+  });
+});
+
+describe('PgBouncer image publication contract', () => {
+  it('builds the verified official release in a non-root multi-stage image', () => {
+    const dockerfile = readFileSync(DOCKERFILE_PATH, 'utf8');
+    expect(dockerfile.match(/^FROM /gm)).toHaveLength(2);
+    expect(
+      dockerfile.match(
+        /^FROM debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171/gm,
+      ),
+    ).toHaveLength(2);
+    expect(dockerfile).toContain('PGBOUNCER_VERSION=1.25.2');
+    expect(dockerfile).toContain('924ad35113fd0a71c8e2dbe85b5d03445532e2b7b37a9f8a48983beea238b332');
+    expect(dockerfile).toContain('https://www.pgbouncer.org/downloads/files/${PGBOUNCER_VERSION}/');
+    expect(dockerfile).toContain('sha256sum --check --strict');
+    expect(dockerfile).toContain('--with-cares');
+    expect(dockerfile).toContain('grep --line-regexp --fixed-strings "PgBouncer ${PGBOUNCER_VERSION}"');
+    expect(dockerfile).toContain("grep --fixed-strings 'adns: c-ares'");
+    expect(dockerfile).toContain("grep --fixed-strings 'tls: OpenSSL'");
+    expect(dockerfile).toContain('USER 10001:10001');
+    expect(dockerfile).toContain('HEALTHCHECK');
+  });
+
+  it('publishes the production multi-architecture image from main with provenance', () => {
+    const workflow = readFileSync(WORKFLOW_PATH, 'utf8');
+    expect(workflow).toContain('branches: [main]');
+    expect(workflow).toContain('pull_request:');
+    expect(workflow).toContain(
+      "group: pgbouncer-image-${{ github.event_name == 'push' && 'production' || github.ref }}",
+    );
+    expect(workflow).toContain("cancel-in-progress: ${{ github.event_name == 'pull_request' }}");
+    expect(workflow).toContain("- 'deploy/pgbouncer/**'");
+    expect(workflow).toContain('IMAGE: ghcr.io/boardsesh/boardsesh-pgbouncer');
+    expect(workflow).toContain('type=raw,value=production');
+    expect(workflow).toContain('platforms: linux/amd64,linux/arm64');
+    expect(workflow).toContain('provenance: mode=max');
+    expect(workflow).toContain('push: false');
+    expect(workflow).toContain('boardsesh-pgbouncer:pr-smoke');
+    expect(workflow).toContain('run: sh deploy/pgbouncer/smoke-test.sh boardsesh-pgbouncer:pr-smoke');
+    expect(workflow).toContain('needs: validate');
+    expect(workflow).toContain('type=sha,prefix=sha-,format=long');
+    expect(workflow).toContain('persist-credentials: false');
+    expect(workflow).toContain('actions/attest-build-provenance@8beda2b7ed98355c0e97c0a63bec38ae472e66c4');
+    expect(workflow).toContain('attestations: write');
+    expect(workflow).toContain('id-token: write');
+  });
+
+  it('boots pinned PostgreSQL and tests health plus both HBA denial paths', () => {
+    const smokeTest = readFileSync(SMOKE_TEST_PATH, 'utf8');
+    expect(smokeTest).toContain(
+      'postgres:17-bookworm@sha256:051f7b7b3abdd564d5d1bd1e8c4b9c1b6e77087d1dd22020ede611c096a272e0',
+    );
+    expect(smokeTest).toContain('.State.Health.Status');
+    expect(smokeTest).toContain('--port=6432 --username=next_client_user --dbname=boardsesh');
+    expect(smokeTest).toContain('admin identity unexpectedly reached the application database');
+    expect(smokeTest).toContain('application identity unexpectedly reached the admin console');
+  });
+
+  it('keeps production migrations on a required direct database URL', () => {
+    const productionWorkflow = readFileSync(PRODUCTION_WORKFLOW_PATH, 'utf8');
+    const migrateJobStart = productionWorkflow.indexOf('\n  migrate:\n');
+    const deployWebJobStart = productionWorkflow.indexOf('\n  deploy-web:\n', migrateJobStart);
+    expect(migrateJobStart).toBeGreaterThan(-1);
+    expect(deployWebJobStart).toBeGreaterThan(migrateJobStart);
+
+    const migrateJob = productionWorkflow.slice(migrateJobStart, deployWebJobStart);
+    const guardStepStart = migrateJob.indexOf('      - name: Require direct database connection\n');
+    const migrationStepStart = migrateJob.indexOf('      - name: Run database migrations\n', guardStepStart);
+    expect(guardStepStart).toBeGreaterThan(-1);
+    expect(migrationStepStart).toBeGreaterThan(guardStepStart);
+
+    const guardStep = migrateJob.slice(guardStepStart, migrationStepStart);
+    expect(guardStep).toContain('DATABASE_DIRECT_URL: ${{ secrets.DATABASE_DIRECT_URL }}');
+    expect(guardStep).toContain('DATABASE_URL: ${{ secrets.DATABASE_URL }}');
+    expect(guardStep).toMatch(/if \[ -z "\$DATABASE_DIRECT_URL" \]; then[\s\S]*?exit 1\s+fi/);
+    expect(guardStep).toMatch(/if \[ "\$DATABASE_DIRECT_URL" = "\$DATABASE_URL" \]; then[\s\S]*?exit 1\s+fi/);
+    expect(guardStep).toContain('DATABASE_DIRECT_URL must differ from the pooled DATABASE_URL');
+    expect(guardStep).not.toMatch(/DATABASE_DIRECT_URL\s*\|\|/);
+
+    const migrationStep = migrateJob.slice(migrationStepStart);
+    expect(migrationStep).toContain('DATABASE_URL: ${{ secrets.DATABASE_DIRECT_URL }}');
+    expect(migrationStep).not.toContain('DATABASE_URL: ${{ secrets.DATABASE_URL }}');
+  });
+});

--- a/scripts/__tests__/pgbouncer-config.test.ts
+++ b/scripts/__tests__/pgbouncer-config.test.ts
@@ -288,17 +288,16 @@ describe('PgBouncer image publication contract', () => {
     expect(deployWebJobStart).toBeGreaterThan(migrateJobStart);
 
     const migrateJob = productionWorkflow.slice(migrateJobStart, deployWebJobStart);
-    const guardStepStart = migrateJob.indexOf('      - name: Require direct database connection\n');
+    const guardStepStart = migrateJob.indexOf('      - name: Verify direct database connection\n');
     const migrationStepStart = migrateJob.indexOf('      - name: Run database migrations\n', guardStepStart);
     expect(guardStepStart).toBeGreaterThan(-1);
     expect(migrationStepStart).toBeGreaterThan(guardStepStart);
 
     const guardStep = migrateJob.slice(guardStepStart, migrationStepStart);
+    expect(guardStep).toContain('DATABASE_DIRECT_ENDPOINT: ${{ vars.DATABASE_DIRECT_ENDPOINT }}');
     expect(guardStep).toContain('DATABASE_DIRECT_URL: ${{ secrets.DATABASE_DIRECT_URL }}');
-    expect(guardStep).toContain('DATABASE_URL: ${{ secrets.DATABASE_URL }}');
-    expect(guardStep).toMatch(/if \[ -z "\$DATABASE_DIRECT_URL" \]; then[\s\S]*?exit 1\s+fi/);
-    expect(guardStep).toMatch(/if \[ "\$DATABASE_DIRECT_URL" = "\$DATABASE_URL" \]; then[\s\S]*?exit 1\s+fi/);
-    expect(guardStep).toContain('DATABASE_DIRECT_URL must differ from the pooled DATABASE_URL');
+    expect(guardStep).not.toContain('DATABASE_URL: ${{ secrets.DATABASE_URL }}');
+    expect(guardStep).toContain('run: vp exec tsx packages/db/scripts/verify-direct-database.ts');
     expect(guardStep).not.toMatch(/DATABASE_DIRECT_URL\s*\|\|/);
 
     const migrationStep = migrateJob.slice(migrationStepStart);

--- a/scripts/lib/postgres-image-publisher-contract.ts
+++ b/scripts/lib/postgres-image-publisher-contract.ts
@@ -251,7 +251,7 @@ const CONTRACT_STEPS: ExpectedStep[] = [
   { name: 'Verify publisher authority and artifact contracts' },
 ];
 
-const CONTRACT_WORKFLOW_METADATA_SHA256 = '9f53ade79a7ae06ae71c8938bb4476c2ad6905667ef34f8150c16caed55374af';
+const CONTRACT_WORKFLOW_METADATA_SHA256 = '598a7028d9332760676c83e3481238a5fbd4ca9ac2a4fb0cdecb4df1b66ecf16';
 const CONTRACT_JOB_METADATA_SHA256 = '9e0f951e6bceb41814be7e67f5cfe5cf5d808315af99a39bc312cbce1c7f0cfb';
 const CONTRACT_STEP_SHA256: Record<string, string> = {
   'Checkout repository without persisted credentials':
@@ -960,7 +960,7 @@ function validatePublisherDocument(failures: string[], publisher: UnknownRecord,
 }
 
 function validateContractDocument(failures: string[], contract: UnknownRecord, contractWorkflow: string): void {
-  if (!keysEqual(contract, ['name', 'on', 'permissions', 'jobs'])) {
+  if (!keysEqual(contract, ['name', 'on', 'permissions', 'concurrency', 'jobs'])) {
     failures.push('contract workflow top-level keys must match the exact read-only allowlist with no defaults');
   }
   if (contract.name !== 'PostgreSQL Image Publisher Contract') {
@@ -983,6 +983,14 @@ function validateContractDocument(failures: string[], contract: UnknownRecord, c
   }
   if (!recordsEqual(recordAt(contract, 'permissions'), { contents: 'read' })) {
     failures.push('contract workflow must be globally contents-read-only');
+  }
+  if (
+    !recordsEqual(recordAt(contract, 'concurrency'), {
+      group: 'postgres-image-contract-${{ github.event.pull_request.number || github.ref }}',
+      'cancel-in-progress': "${{ github.event_name == 'pull_request' }}",
+    })
+  ) {
+    failures.push('contract workflow concurrency must match the exact reviewed pull-request cancellation policy');
   }
   const jobs = recordAt(contract, 'jobs');
   if (!jobs || JSON.stringify(Object.keys(jobs)) !== JSON.stringify(['verify-trust-boundary'])) {

--- a/scripts/lib/postgres-image-publisher-contract.ts
+++ b/scripts/lib/postgres-image-publisher-contract.ts
@@ -251,7 +251,7 @@ const CONTRACT_STEPS: ExpectedStep[] = [
   { name: 'Verify publisher authority and artifact contracts' },
 ];
 
-const CONTRACT_WORKFLOW_METADATA_SHA256 = '598a7028d9332760676c83e3481238a5fbd4ca9ac2a4fb0cdecb4df1b66ecf16';
+const CONTRACT_WORKFLOW_METADATA_SHA256 = '9f53ade79a7ae06ae71c8938bb4476c2ad6905667ef34f8150c16caed55374af';
 const CONTRACT_JOB_METADATA_SHA256 = '9e0f951e6bceb41814be7e67f5cfe5cf5d808315af99a39bc312cbce1c7f0cfb';
 const CONTRACT_STEP_SHA256: Record<string, string> = {
   'Checkout repository without persisted credentials':
@@ -960,7 +960,7 @@ function validatePublisherDocument(failures: string[], publisher: UnknownRecord,
 }
 
 function validateContractDocument(failures: string[], contract: UnknownRecord, contractWorkflow: string): void {
-  if (!keysEqual(contract, ['name', 'on', 'permissions', 'concurrency', 'jobs'])) {
+  if (!keysEqual(contract, ['name', 'on', 'permissions', 'jobs'])) {
     failures.push('contract workflow top-level keys must match the exact read-only allowlist with no defaults');
   }
   if (contract.name !== 'PostgreSQL Image Publisher Contract') {
@@ -983,14 +983,6 @@ function validateContractDocument(failures: string[], contract: UnknownRecord, c
   }
   if (!recordsEqual(recordAt(contract, 'permissions'), { contents: 'read' })) {
     failures.push('contract workflow must be globally contents-read-only');
-  }
-  if (
-    !recordsEqual(recordAt(contract, 'concurrency'), {
-      group: 'postgres-image-contract-${{ github.event.pull_request.number || github.ref }}',
-      'cancel-in-progress': "${{ github.event_name == 'pull_request' }}",
-    })
-  ) {
-    failures.push('contract workflow concurrency must match the exact reviewed pull-request cancellation policy');
   }
   const jobs = recordAt(contract, 'jobs');
   if (!jobs || JSON.stringify(Object.keys(jobs)) !== JSON.stringify(['verify-trust-boundary'])) {

--- a/scripts/pgbouncer-cutover-smoke.test.ts
+++ b/scripts/pgbouncer-cutover-smoke.test.ts
@@ -2,12 +2,13 @@
 
 import { describe, expect, it, vi } from 'vite-plus/test';
 import {
-  CLIMB_SITEMAP_PATH,
+  BOARD_SITEMAP_PATH,
   CUTOVER_TOKEN_ENV,
   DEFAULT_CONCURRENCY,
   DEFAULT_REQUESTS,
   DEFAULT_TIMEOUT_MS,
   READINESS_PATH,
+  extractClimbUrlsFromListing,
   formatSummary,
   parseArguments,
   parseOrigin,
@@ -15,6 +16,7 @@ import {
   runCutoverSmoke,
   runProbeRequests,
   runRequests,
+  selectBoardListUrls,
   selectClimbUrls,
   summarizeOutcomes,
   validateClimbResponse,
@@ -26,6 +28,10 @@ const TEST_ENV = { [CUTOVER_TOKEN_ENV]: 'probe-secret' };
 
 function sitemap(urls: readonly string[]): string {
   return `<?xml version="1.0"?><urlset>${urls.map((url) => `<url><loc>${url}</loc></url>`).join('')}</urlset>`;
+}
+
+function listing(urls: readonly string[]): string {
+  return `<!doctype html><html><body>${urls.map((url) => `<a href="${url}">Climb</a>`).join('')}</body></html>`;
 }
 
 function climbResponse(status = 200): Response {
@@ -91,33 +97,44 @@ describe('parseArguments', () => {
   });
 });
 
-describe('sitemap URL selection', () => {
-  it('decodes, deduplicates, and samples exactly across the full population', () => {
+describe('board-listing climb discovery', () => {
+  it('keeps canonical listing URLs from the always-on board sitemap', () => {
+    expect(
+      selectBoardListUrls(
+        sitemap([
+          'https://www.boardsesh.com/kilter/layout/size/set/40/list',
+          'https://www.boardsesh.com/es/kilter/layout/size/set/40/list',
+          'https://www.boardsesh.com/gyms',
+        ]),
+      ),
+    ).toEqual(['https://www.boardsesh.com/kilter/layout/size/set/40/list']);
+    expect(() => selectBoardListUrls('<html></html>')).toThrow('<urlset>');
+    expect(() => selectBoardListUrls(sitemap(['not a URL']))).toThrow('invalid <loc>');
+    expect(() => selectBoardListUrls(sitemap(['https://user:secret@example.com/list']))).toThrow('unsafe <loc>');
+    expect(() => selectBoardListUrls(sitemap(['https://www.boardsesh.com/settings']))).toThrow(
+      'no canonical board listing',
+    );
+  });
+
+  it('extracts same-origin climb links and samples across the discovered population', () => {
     const urls = Array.from(
       { length: 10 },
       (_, index) => `https://www.boardsesh.com/kilter/config/40/view/climb-${index}`,
     );
-    const xml = sitemap([
-      `${urls[0]}?angle=40&amp;mirror=false`,
-      `${urls[0]}?angle=40&amp;mirror=false`,
-      ...urls.slice(1),
-    ]);
-    expect(selectClimbUrls(xml, 4)).toEqual([`${urls[0]}?angle=40&mirror=false`, urls[3], urls[6], urls[9]]);
-    expect(selectClimbUrls(sitemap(urls), 1)).toEqual([urls[0]]);
-  });
-
-  it('fails closed on short, malformed, unsafe, and non-climb sitemaps', () => {
-    expect(() => selectClimbUrls(sitemap(['https://www.boardsesh.com/kilter/layout/size/set/40/view/one']), 2)).toThrow(
-      '1 unique URLs; 2 required',
+    const extracted = extractClimbUrlsFromListing(
+      listing([
+        `${urls[0]}?angle=40&amp;mirror=false`,
+        `${urls[0]}?angle=40&amp;mirror=false`,
+        ...urls.slice(1),
+        'https://attacker.example/kilter/config/40/view/foreign',
+        '/settings',
+      ]),
+      'https://www.boardsesh.com/kilter/config/40/list',
     );
-    expect(() => selectClimbUrls('<html></html>', 1)).toThrow('<urlset>');
-    expect(() => selectClimbUrls(sitemap(['not a URL']), 1)).toThrow('invalid <loc>');
-    expect(() => selectClimbUrls(sitemap(['https://user:secret@example.com/view/climb']), 1)).toThrow('unsafe <loc>');
-    expect(() => selectClimbUrls(sitemap(['https://www.boardsesh.com/settings']), 1)).toThrow('non-climb <loc>');
-    expect(() => selectClimbUrls(sitemap(['https://www.boardsesh.com/view/']), 1)).toThrow('non-climb <loc>');
-    expect(() => selectClimbUrls(sitemap(['https://www.boardsesh.com/account/view/settings']), 1)).toThrow(
-      'non-climb <loc>',
-    );
+    expect(selectClimbUrls(extracted, 4)).toEqual([`${urls[0]}?angle=40&mirror=false`, urls[3], urls[6], urls[9]]);
+    expect(selectClimbUrls(extracted, 1)).toEqual([`${urls[0]}?angle=40&mirror=false`]);
+    expect(() => extractClimbUrlsFromListing('<main></main>', 'https://www.boardsesh.com/list')).toThrow('<html>');
+    expect(() => selectClimbUrls(extracted, 11)).toThrow('10 unique climb URLs; 11 required');
   });
 
   it('rewrites only the origin while preserving path and query', () => {
@@ -235,15 +252,14 @@ describe('runCutoverSmoke', () => {
     const fetchMock: FetchLike = vi.fn(async (input, init) => {
       const url = String(input);
       requestedUrls.push(url);
-      if (url === `https://cutover.example.com${CLIMB_SITEMAP_PATH}`) {
+      if (url === `https://cutover.example.com${BOARD_SITEMAP_PATH}`) {
+        expect(init?.headers).not.toHaveProperty('Authorization');
+        return new Response(sitemap(['https://www.boardsesh.com/kilter/layout/size/set/40/list']));
+      }
+      if (url === 'https://cutover.example.com/kilter/layout/size/set/40/list') {
         expect(init?.headers).not.toHaveProperty('Authorization');
         return new Response(
-          sitemap(
-            Array.from(
-              { length: 4 },
-              (_, index) => `https://www.boardsesh.com/kilter/layout/size/set/40/view/climb-${index}`,
-            ),
-          ),
+          listing(Array.from({ length: 4 }, (_, index) => `/kilter/layout/size/set/40/view/climb-${index}`)),
         );
       }
       if (url.includes(READINESS_PATH)) {
@@ -259,7 +275,8 @@ describe('runCutoverSmoke', () => {
     expect(report.database).toMatchObject({ total: 3, successful: 3, failed: 0 });
     expect(report.climbs).toMatchObject({ total: 3, successful: 3, failed: 0 });
     expect(requestedUrls).toEqual([
-      'https://cutover.example.com/sitemaps/climbs/1.xml',
+      'https://cutover.example.com/sitemaps/boards.xml',
+      'https://cutover.example.com/kilter/layout/size/set/40/list',
       'https://cutover.example.com/api/internal/pgbouncer-cutover-readiness?request=1',
       'https://cutover.example.com/api/internal/pgbouncer-cutover-readiness?request=2',
       'https://cutover.example.com/api/internal/pgbouncer-cutover-readiness?request=3',
@@ -269,11 +286,15 @@ describe('runCutoverSmoke', () => {
     ]);
   });
 
-  it('does not start either batch when the sitemap has fewer URLs than required', async () => {
-    const fetchMock: FetchLike = vi.fn(
-      async () => new Response(sitemap(['https://www.boardsesh.com/kilter/layout/size/set/40/view/only-one'])),
+  it('does not start either batch when the listings expose fewer URLs than required', async () => {
+    const fetchMock: FetchLike = vi.fn(async (input) =>
+      String(input).endsWith(BOARD_SITEMAP_PATH)
+        ? new Response(sitemap(['https://www.boardsesh.com/kilter/layout/size/set/40/list']))
+        : new Response(listing(['/kilter/layout/size/set/40/view/only-one'])),
     );
-    await expect(runCutoverSmoke(options({ requests: 2 }), fetchMock)).rejects.toThrow('1 unique URLs; 2 required');
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await expect(runCutoverSmoke(options({ requests: 2 }), fetchMock)).rejects.toThrow(
+      '1 unique climb URLs; 2 required',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/scripts/pgbouncer-cutover-smoke.test.ts
+++ b/scripts/pgbouncer-cutover-smoke.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vite-plus/test';
 import {
   CLIMB_SITEMAP_PATH,
   CUTOVER_TOKEN_ENV,

--- a/scripts/pgbouncer-cutover-smoke.test.ts
+++ b/scripts/pgbouncer-cutover-smoke.test.ts
@@ -1,0 +1,270 @@
+/// <reference types="node" />
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CLIMB_SITEMAP_PATH,
+  CUTOVER_TOKEN_ENV,
+  DEFAULT_CONCURRENCY,
+  DEFAULT_REQUESTS,
+  DEFAULT_TIMEOUT_MS,
+  READINESS_PATH,
+  formatSummary,
+  parseArguments,
+  parseOrigin,
+  rewriteUrlsToOrigin,
+  runCutoverSmoke,
+  runProbeRequests,
+  runRequests,
+  selectClimbUrls,
+  summarizeOutcomes,
+  validateClimbResponse,
+  type FetchLike,
+  type RequestOutcome,
+} from './pgbouncer-cutover-smoke';
+
+const TEST_ENV = { [CUTOVER_TOKEN_ENV]: 'probe-secret' };
+
+function sitemap(urls: readonly string[]): string {
+  return `<?xml version="1.0"?><urlset>${urls.map((url) => `<url><loc>${url}</loc></url>`).join('')}</urlset>`;
+}
+
+function climbResponse(status = 200): Response {
+  const body =
+    '<!doctype html><html><body><main><h1>Climb name</h1>' +
+    '<script type="application/ld+json">{"@type":"CreativeWork"}</script>' +
+    `${'x'.repeat(4_000)}</main></body></html>`;
+  return new Response(body, { status, headers: { 'content-type': 'text/html; charset=utf-8' } });
+}
+
+function probeResponse(status = 200, ok = true, noStore = true): Response {
+  return Response.json(
+    { ok },
+    { status, headers: noStore ? { 'cache-control': 'private, no-store, max-age=0' } : undefined },
+  );
+}
+
+function options(overrides: Partial<ReturnType<typeof parseArguments>> = {}) {
+  return {
+    origin: 'https://cutover.example.com',
+    requests: 3,
+    concurrency: 2,
+    timeoutMs: 100,
+    probeToken: 'probe-secret',
+    ...overrides,
+  };
+}
+
+describe('parseArguments', () => {
+  it('requires a safe explicit origin and a dedicated environment token', () => {
+    expect(parseArguments(['--origin', 'https://cutover.boardsesh.com/'], TEST_ENV)).toEqual({
+      origin: 'https://cutover.boardsesh.com',
+      requests: DEFAULT_REQUESTS,
+      concurrency: DEFAULT_CONCURRENCY,
+      timeoutMs: DEFAULT_TIMEOUT_MS,
+      probeToken: 'probe-secret',
+    });
+    expect(() => parseArguments([], TEST_ENV)).toThrow('--origin is required');
+    expect(() => parseArguments(['--origin', 'https://example.com'], {})).toThrow(CUTOVER_TOKEN_ENV);
+    expect(() => parseOrigin('postgres://db.example.com')).toThrow('http:// or https://');
+    expect(() => parseOrigin('http://cutover.boardsesh.com')).toThrow('https:// outside localhost');
+    expect(() => parseOrigin('https://user:secret@cutover.boardsesh.com')).toThrow('credentials');
+    expect(() => parseOrigin('https://cutover.boardsesh.com/path')).toThrow('path, query, or fragment');
+  });
+
+  it('accepts the vp separator and exact positive overrides', () => {
+    expect(
+      parseArguments(
+        ['--', '--origin', 'http://localhost:3000', '--requests', '7', '--concurrency', '3', '--timeout-ms', '1250'],
+        TEST_ENV,
+      ),
+    ).toEqual({
+      origin: 'http://localhost:3000',
+      requests: 7,
+      concurrency: 3,
+      timeoutMs: 1250,
+      probeToken: 'probe-secret',
+    });
+    expect(() => parseArguments(['--origin', 'https://example.com', '--requests', '0'], TEST_ENV)).toThrow(
+      'positive integer',
+    );
+    expect(() => parseArguments(['--origin', 'https://example.com', '--wat', '1'], TEST_ENV)).toThrow('unknown option');
+  });
+});
+
+describe('sitemap URL selection', () => {
+  it('decodes, deduplicates, and samples exactly across the full population', () => {
+    const urls = Array.from(
+      { length: 10 },
+      (_, index) => `https://www.boardsesh.com/kilter/config/40/view/climb-${index}`,
+    );
+    const xml = sitemap([
+      `${urls[0]}?angle=40&amp;mirror=false`,
+      `${urls[0]}?angle=40&amp;mirror=false`,
+      ...urls.slice(1),
+    ]);
+    expect(selectClimbUrls(xml, 4)).toEqual([`${urls[0]}?angle=40&mirror=false`, urls[3], urls[6], urls[9]]);
+    expect(selectClimbUrls(sitemap(urls), 1)).toEqual([urls[0]]);
+  });
+
+  it('fails closed on short, malformed, unsafe, and non-climb sitemaps', () => {
+    expect(() => selectClimbUrls(sitemap(['https://www.boardsesh.com/view/one']), 2)).toThrow(
+      '1 unique URLs; 2 required',
+    );
+    expect(() => selectClimbUrls('<html></html>', 1)).toThrow('<urlset>');
+    expect(() => selectClimbUrls(sitemap(['not a URL']), 1)).toThrow('invalid <loc>');
+    expect(() => selectClimbUrls(sitemap(['https://user:secret@example.com/view/climb']), 1)).toThrow('unsafe <loc>');
+    expect(() => selectClimbUrls(sitemap(['https://www.boardsesh.com/settings']), 1)).toThrow('non-climb <loc>');
+  });
+
+  it('rewrites only the origin while preserving path and query', () => {
+    expect(
+      rewriteUrlsToOrigin(
+        ['https://www.boardsesh.com/kilter/layout/40/view/example?mirror=false'],
+        'https://cutover.boardsesh.com:8443',
+      ),
+    ).toEqual(['https://cutover.boardsesh.com:8443/kilter/layout/40/view/example?mirror=false']);
+  });
+});
+
+describe('climb response validation', () => {
+  it('requires direct 2xx complete climb-specific SSR HTML', async () => {
+    const healthy = climbResponse();
+    expect(validateClimbResponse(200, 'text/html', await healthy.text())).toBeNull();
+    expect(validateClimbResponse(302, 'text/html', 'x'.repeat(5_000))).toBe('http');
+    expect(validateClimbResponse(200, 'text/html', '<main><h1>Error</h1></main>')).toBe('short-html');
+    expect(validateClimbResponse(200, 'text/html', `<main><h1>Error</h1>${'x'.repeat(5_000)}</main>`)).toBe(
+      'missing-jsonld',
+    );
+    expect(validateClimbResponse(200, 'application/json', 'x'.repeat(5_000))).toBe('non-html');
+  });
+
+  it('keeps the timeout active while consuming a streamed body', async () => {
+    const fetchMock: FetchLike = vi.fn(async (_input, init) => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('<html><main>'));
+          init?.signal?.addEventListener('abort', () => controller.error(new Error('aborted')), { once: true });
+        },
+      });
+      return new Response(stream, { headers: { 'content-type': 'text/html' } });
+    });
+    const [outcome] = await runRequests(['https://target.example.com/view/climb'], 1, 5, fetchMock);
+    expect(outcome.error).toBe('timeout');
+  });
+});
+
+describe('bounded runners', () => {
+  it('completes exactly 100 climb GETs without exceeding concurrency 32, even after failures', async () => {
+    let active = 0;
+    let peak = 0;
+    const seen = new Map<string, number>();
+    const fetchMock: FetchLike = vi.fn(async (input, init) => {
+      active += 1;
+      peak = Math.max(peak, active);
+      const url = String(input);
+      seen.set(url, (seen.get(url) ?? 0) + 1);
+      expect(init?.redirect).toBe('manual');
+      expect(init?.headers).not.toHaveProperty('Authorization');
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      active -= 1;
+      return url.endsWith('/0') ? new Response(null, { status: 302 }) : climbResponse();
+    });
+    const urls = Array.from({ length: 100 }, (_, index) => `https://cutover.example.com/view/${index}`);
+
+    const outcomes = await runRequests(urls, 32, 100, fetchMock);
+
+    expect(outcomes).toHaveLength(100);
+    expect(peak).toBe(32);
+    expect([...seen.values()]).toEqual(Array.from({ length: 100 }, () => 1));
+    expect(outcomes[0].error).toBe('http');
+  });
+
+  it('runs one authenticated no-store database probe per request under the same bound', async () => {
+    let active = 0;
+    let peak = 0;
+    const fetchMock: FetchLike = vi.fn(async (input, init) => {
+      active += 1;
+      peak = Math.max(peak, active);
+      expect(String(input)).toMatch(`${READINESS_PATH}?request=`);
+      expect(init?.headers).toMatchObject({ Authorization: 'Bearer probe-secret' });
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      active -= 1;
+      return probeResponse();
+    });
+
+    const outcomes = await runProbeRequests(options({ requests: 100, concurrency: 32 }), fetchMock);
+
+    expect(outcomes).toHaveLength(100);
+    expect(peak).toBe(32);
+    expect(outcomes.every((outcome) => outcome.error === null)).toBe(true);
+  });
+
+  it('rejects redirects, bad payloads, and cacheable probe responses', async () => {
+    const responses = [new Response(null, { status: 302 }), probeResponse(200, false), probeResponse(200, true, false)];
+    const fetchMock: FetchLike = vi.fn(async () => responses.shift() ?? probeResponse());
+    const outcomes = await runProbeRequests(options(), fetchMock);
+    expect(outcomes.map((outcome) => outcome.error)).toEqual(['invalid-probe', 'invalid-probe', 'cacheable-probe']);
+  });
+});
+
+describe('summary', () => {
+  it('prints fixed status, failure-reason, and latency counts without request details', () => {
+    const outcomes: RequestOutcome[] = [
+      { status: 200, latencyMs: 10, error: null },
+      { status: 204, latencyMs: 20, error: null },
+      { status: 302, latencyMs: 30, error: 'http' },
+      { status: 500, latencyMs: 40, error: 'http' },
+      { status: null, latencyMs: 50, error: 'network' },
+    ];
+    const formatted = formatSummary(summarizeOutcomes(outcomes));
+    expect(formatted).toBe(
+      'requests=5 ok=2 failed=3 status=200:1,204:1,302:1,500:1 timeouts=0 network=1 invalid=2 errors=http:2,network:1 latency_ms=p50:30,p95:50,max:50',
+    );
+    expect(formatted).not.toContain('http://');
+    expect(formatted).not.toContain('secret');
+  });
+});
+
+describe('runCutoverSmoke', () => {
+  it('runs exact database and climb batches while keeping the token off public requests', async () => {
+    const requestedUrls: string[] = [];
+    const fetchMock: FetchLike = vi.fn(async (input, init) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      if (url === `https://cutover.example.com${CLIMB_SITEMAP_PATH}`) {
+        expect(init?.headers).not.toHaveProperty('Authorization');
+        return new Response(
+          sitemap(Array.from({ length: 4 }, (_, index) => `https://www.boardsesh.com/kilter/view/climb-${index}`)),
+        );
+      }
+      if (url.includes(READINESS_PATH)) {
+        expect(init?.headers).toMatchObject({ Authorization: 'Bearer probe-secret' });
+        return probeResponse();
+      }
+      expect(init?.headers).not.toHaveProperty('Authorization');
+      return climbResponse();
+    });
+
+    const report = await runCutoverSmoke(options(), fetchMock);
+
+    expect(report.database).toMatchObject({ total: 3, successful: 3, failed: 0 });
+    expect(report.climbs).toMatchObject({ total: 3, successful: 3, failed: 0 });
+    expect(requestedUrls).toEqual([
+      'https://cutover.example.com/sitemaps/climbs/1.xml',
+      'https://cutover.example.com/api/internal/pgbouncer-cutover-readiness?request=1',
+      'https://cutover.example.com/api/internal/pgbouncer-cutover-readiness?request=2',
+      'https://cutover.example.com/api/internal/pgbouncer-cutover-readiness?request=3',
+      'https://cutover.example.com/kilter/view/climb-0',
+      'https://cutover.example.com/kilter/view/climb-2',
+      'https://cutover.example.com/kilter/view/climb-3',
+    ]);
+  });
+
+  it('does not start either batch when the sitemap has fewer URLs than required', async () => {
+    const fetchMock: FetchLike = vi.fn(
+      async () => new Response(sitemap(['https://www.boardsesh.com/kilter/view/only-one'])),
+    );
+    await expect(runCutoverSmoke(options({ requests: 2 }), fetchMock)).rejects.toThrow('1 unique URLs; 2 required');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/scripts/pgbouncer-cutover-smoke.test.ts
+++ b/scripts/pgbouncer-cutover-smoke.test.ts
@@ -107,13 +107,17 @@ describe('sitemap URL selection', () => {
   });
 
   it('fails closed on short, malformed, unsafe, and non-climb sitemaps', () => {
-    expect(() => selectClimbUrls(sitemap(['https://www.boardsesh.com/view/one']), 2)).toThrow(
+    expect(() => selectClimbUrls(sitemap(['https://www.boardsesh.com/kilter/layout/size/set/40/view/one']), 2)).toThrow(
       '1 unique URLs; 2 required',
     );
     expect(() => selectClimbUrls('<html></html>', 1)).toThrow('<urlset>');
     expect(() => selectClimbUrls(sitemap(['not a URL']), 1)).toThrow('invalid <loc>');
     expect(() => selectClimbUrls(sitemap(['https://user:secret@example.com/view/climb']), 1)).toThrow('unsafe <loc>');
     expect(() => selectClimbUrls(sitemap(['https://www.boardsesh.com/settings']), 1)).toThrow('non-climb <loc>');
+    expect(() => selectClimbUrls(sitemap(['https://www.boardsesh.com/view/']), 1)).toThrow('non-climb <loc>');
+    expect(() => selectClimbUrls(sitemap(['https://www.boardsesh.com/account/view/settings']), 1)).toThrow(
+      'non-climb <loc>',
+    );
   });
 
   it('rewrites only the origin while preserving path and query', () => {
@@ -234,7 +238,12 @@ describe('runCutoverSmoke', () => {
       if (url === `https://cutover.example.com${CLIMB_SITEMAP_PATH}`) {
         expect(init?.headers).not.toHaveProperty('Authorization');
         return new Response(
-          sitemap(Array.from({ length: 4 }, (_, index) => `https://www.boardsesh.com/kilter/view/climb-${index}`)),
+          sitemap(
+            Array.from(
+              { length: 4 },
+              (_, index) => `https://www.boardsesh.com/kilter/layout/size/set/40/view/climb-${index}`,
+            ),
+          ),
         );
       }
       if (url.includes(READINESS_PATH)) {
@@ -254,15 +263,15 @@ describe('runCutoverSmoke', () => {
       'https://cutover.example.com/api/internal/pgbouncer-cutover-readiness?request=1',
       'https://cutover.example.com/api/internal/pgbouncer-cutover-readiness?request=2',
       'https://cutover.example.com/api/internal/pgbouncer-cutover-readiness?request=3',
-      'https://cutover.example.com/kilter/view/climb-0',
-      'https://cutover.example.com/kilter/view/climb-2',
-      'https://cutover.example.com/kilter/view/climb-3',
+      'https://cutover.example.com/kilter/layout/size/set/40/view/climb-0',
+      'https://cutover.example.com/kilter/layout/size/set/40/view/climb-2',
+      'https://cutover.example.com/kilter/layout/size/set/40/view/climb-3',
     ]);
   });
 
   it('does not start either batch when the sitemap has fewer URLs than required', async () => {
     const fetchMock: FetchLike = vi.fn(
-      async () => new Response(sitemap(['https://www.boardsesh.com/kilter/view/only-one'])),
+      async () => new Response(sitemap(['https://www.boardsesh.com/kilter/layout/size/set/40/view/only-one'])),
     );
     await expect(runCutoverSmoke(options({ requests: 2 }), fetchMock)).rejects.toThrow('1 unique URLs; 2 required');
     expect(fetchMock).toHaveBeenCalledTimes(1);

--- a/scripts/pgbouncer-cutover-smoke.ts
+++ b/scripts/pgbouncer-cutover-smoke.ts
@@ -1,0 +1,489 @@
+#!/usr/bin/env tsx
+/// <reference types="node" />
+
+import { performance } from 'node:perf_hooks';
+import { pathToFileURL } from 'node:url';
+
+export const DEFAULT_REQUESTS = 100;
+export const DEFAULT_CONCURRENCY = 32;
+export const DEFAULT_TIMEOUT_MS = 10_000;
+// One complete deterministic shard is enough to spread probes across many
+// climbs without multiplying sitemap downloads during the cutover window.
+export const CLIMB_SITEMAP_PATH = '/sitemaps/climbs/1.xml';
+export const READINESS_PATH = '/api/internal/pgbouncer-cutover-readiness';
+export const CUTOVER_TOKEN_ENV = 'PGBOUNCER_CUTOVER_SMOKE_TOKEN';
+
+const MIN_CLIMB_HTML_CHARS = 4_000;
+const MAX_CLIMB_HTML_BYTES = 2_000_000;
+const MAX_SITEMAP_BYTES = 8_000_000;
+const MAX_PROBE_BYTES = 1_024;
+
+export type FailureCode =
+  | 'timeout'
+  | 'network'
+  | 'http'
+  | 'non-html'
+  | 'short-html'
+  | 'missing-main'
+  | 'missing-h1'
+  | 'missing-jsonld'
+  | 'body-too-large'
+  | 'invalid-probe'
+  | 'cacheable-probe';
+
+export type CutoverOptions = {
+  origin: string;
+  requests: number;
+  concurrency: number;
+  timeoutMs: number;
+  probeToken: string;
+};
+
+export type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+export type RequestOutcome = {
+  status: number | null;
+  latencyMs: number;
+  error: FailureCode | null;
+};
+
+export type CutoverSummary = {
+  total: number;
+  successful: number;
+  failed: number;
+  timedOut: number;
+  networkErrors: number;
+  invalidResponses: number;
+  errorCounts: ReadonlyMap<FailureCode, number>;
+  statusCounts: ReadonlyMap<number, number>;
+  p50Ms: number;
+  p95Ms: number;
+  maxMs: number;
+};
+
+export type CutoverReport = {
+  database: CutoverSummary;
+  climbs: CutoverSummary;
+};
+
+function parsePositiveInteger(flag: string, raw: string | undefined): number {
+  if (raw === undefined) throw new Error(`${flag} needs a value`);
+  if (!/^\d+$/.test(raw)) throw new Error(`${flag} must be a positive integer`);
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) throw new Error(`${flag} must be a positive integer`);
+  return parsed;
+}
+
+/** Accepts an HTTP(S) origin, not a URL carrying a path, credentials, query, or fragment. */
+export function parseOrigin(raw: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error('--origin must be a valid HTTP(S) origin');
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error('--origin must use http:// or https://');
+  }
+  if (parsed.protocol === 'http:' && !['localhost', '127.0.0.1', '[::1]'].includes(parsed.hostname)) {
+    throw new Error('--origin must use https:// outside localhost');
+  }
+  if (parsed.username || parsed.password) throw new Error('--origin must not contain credentials');
+  if (parsed.pathname !== '/' || parsed.search || parsed.hash) {
+    throw new Error('--origin must not contain a path, query, or fragment');
+  }
+  return parsed.origin;
+}
+
+/** Parses public options from argv and the probe credential from one dedicated environment variable. */
+export function parseArguments(
+  argv: readonly string[],
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): CutoverOptions {
+  const parsed: Partial<CutoverOptions> = {};
+  const seen = new Set<string>();
+  const forwardedArguments = argv[0] === '--' ? argv.slice(1) : argv;
+
+  for (let index = 0; index < forwardedArguments.length; index += 2) {
+    const flag = forwardedArguments[index];
+    const raw = forwardedArguments[index + 1];
+    if (!flag?.startsWith('--')) throw new Error(`unexpected argument: ${flag ?? ''}`);
+    if (seen.has(flag)) throw new Error(`${flag} may only be provided once`);
+    seen.add(flag);
+
+    switch (flag) {
+      case '--origin':
+        if (raw === undefined) throw new Error('--origin needs a value');
+        parsed.origin = parseOrigin(raw);
+        break;
+      case '--requests':
+        parsed.requests = parsePositiveInteger(flag, raw);
+        break;
+      case '--concurrency':
+        parsed.concurrency = parsePositiveInteger(flag, raw);
+        break;
+      case '--timeout-ms':
+        parsed.timeoutMs = parsePositiveInteger(flag, raw);
+        break;
+      default:
+        throw new Error(`unknown option: ${flag}`);
+    }
+  }
+
+  if (!parsed.origin) throw new Error('--origin is required');
+  const probeToken = env[CUTOVER_TOKEN_ENV];
+  if (!probeToken) throw new Error(`${CUTOVER_TOKEN_ENV} is required`);
+  return {
+    origin: parsed.origin,
+    requests: parsed.requests ?? DEFAULT_REQUESTS,
+    concurrency: parsed.concurrency ?? DEFAULT_CONCURRENCY,
+    timeoutMs: parsed.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    probeToken,
+  };
+}
+
+function decodeXmlText(encoded: string): string {
+  return encoded.replace(/&(?:#(\d+)|#x([\da-f]+)|amp|apos|gt|lt|quot);/gi, (entity, decimal, hexadecimal) => {
+    if (decimal) return String.fromCodePoint(Number(decimal));
+    if (hexadecimal) return String.fromCodePoint(Number.parseInt(hexadecimal, 16));
+    const namedEntities: Record<string, string> = {
+      '&amp;': '&',
+      '&apos;': "'",
+      '&gt;': '>',
+      '&lt;': '<',
+      '&quot;': '"',
+    };
+    return namedEntities[entity.toLowerCase()] ?? entity;
+  });
+}
+
+/** Extracts unique HTTP(S) URLs, then samples evenly across the complete sitemap. */
+export function selectClimbUrls(xml: string, count: number): string[] {
+  if (!Number.isSafeInteger(count) || count < 1) throw new Error('request count must be a positive integer');
+  if (!/<urlset\b/i.test(xml)) throw new Error('climb sitemap has no <urlset> root');
+
+  const uniqueUrls: string[] = [];
+  const seen = new Set<string>();
+  const locationPattern = /<loc\b[^>]*>([\s\S]*?)<\/loc\s*>/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = locationPattern.exec(xml)) !== null) {
+    const location = decodeXmlText(match[1].trim());
+    let parsed: URL;
+    try {
+      parsed = new URL(location);
+    } catch {
+      throw new Error('climb sitemap contains an invalid <loc> URL');
+    }
+    if ((parsed.protocol !== 'http:' && parsed.protocol !== 'https:') || parsed.username || parsed.password) {
+      throw new Error('climb sitemap contains an unsafe <loc> URL');
+    }
+    if (parsed.hash) throw new Error('climb sitemap contains a fragmented <loc> URL');
+    if (!parsed.pathname.includes('/view/')) throw new Error('climb sitemap contains a non-climb <loc> URL');
+    if (!seen.has(parsed.href)) {
+      seen.add(parsed.href);
+      uniqueUrls.push(parsed.href);
+    }
+  }
+
+  if (uniqueUrls.length < count) {
+    throw new Error(`climb sitemap has ${uniqueUrls.length} unique URLs; ${count} required`);
+  }
+
+  // Include both ends and evenly cover everything between them. This makes a
+  // cutover hit long-tail/cold pages without adding randomness to incident QA.
+  if (count === 1) return [uniqueUrls[0]];
+  return Array.from({ length: count }, (_, index) => {
+    const sourceIndex = Math.round((index * (uniqueUrls.length - 1)) / (count - 1));
+    return uniqueUrls[sourceIndex];
+  });
+}
+
+/** Keeps each climb path/query but guarantees every request starts on the target origin. */
+export function rewriteUrlsToOrigin(urls: readonly string[], origin: string): string[] {
+  const targetOrigin = parseOrigin(origin);
+  return urls.map((source) => {
+    const parsed = new URL(source);
+    return new URL(`${parsed.pathname}${parsed.search}`, targetOrigin).href;
+  });
+}
+
+/** Rejects status-only and streamed error shells that can otherwise look like healthy climb responses. */
+export function validateClimbResponse(status: number, contentType: string, body: string): FailureCode | null {
+  if (status < 200 || status >= 300) return 'http';
+  if (!contentType.toLowerCase().includes('text/html')) return 'non-html';
+  if (body.length < MIN_CLIMB_HTML_CHARS) return 'short-html';
+  if (!/<main[\s>]/i.test(body)) return 'missing-main';
+  if (!/<h1[\s>]/i.test(body)) return 'missing-h1';
+  if (!/type=["']application\/ld\+json["']/i.test(body) || !/["']@type["']\s*:\s*["']CreativeWork["']/i.test(body)) {
+    return 'missing-jsonld';
+  }
+  return null;
+}
+
+class BodyTooLargeError extends Error {
+  constructor() {
+    super('response body exceeded safety limit');
+  }
+}
+
+/** Reads a complete response without allowing 32 concurrent bodies to grow without limit. */
+async function readBody(response: Response, maximumBytes: number): Promise<string> {
+  if (!response.body) return '';
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let body = '';
+  let bytesRead = 0;
+
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) return body + decoder.decode();
+    bytesRead += chunk.value.byteLength;
+    if (bytesRead > maximumBytes) {
+      await reader.cancel().catch(() => undefined);
+      throw new BodyTooLargeError();
+    }
+    body += decoder.decode(chunk.value, { stream: true });
+  }
+}
+
+async function requestOnce(url: string, timeoutMs: number, fetchImpl: FetchLike): Promise<RequestOutcome> {
+  const controller = new AbortController();
+  const startedAt = performance.now();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      method: 'GET',
+      redirect: 'manual',
+      signal: controller.signal,
+      headers: { 'User-Agent': 'boardsesh-pgbouncer-cutover-smoke/1.0', 'Cache-Control': 'no-cache' },
+    });
+    // Await the complete body under the same abort signal. A streamed 200 shell
+    // is not a pass until its meaningful climb markup actually arrives.
+    const body = await readBody(response, MAX_CLIMB_HTML_BYTES);
+    const validationFailure = validateClimbResponse(response.status, response.headers.get('content-type') ?? '', body);
+    return {
+      status: response.status,
+      latencyMs: performance.now() - startedAt,
+      error: validationFailure,
+    };
+  } catch (error) {
+    return {
+      status: null,
+      latencyMs: performance.now() - startedAt,
+      error: controller.signal.aborted ? 'timeout' : error instanceof BodyTooLargeError ? 'body-too-large' : 'network',
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/** Runs every URL once with a worker pool; `concurrency` is a hard upper bound. */
+export async function runRequests(
+  urls: readonly string[],
+  concurrency: number,
+  timeoutMs: number,
+  fetchImpl: FetchLike = fetch,
+): Promise<RequestOutcome[]> {
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1) throw new Error('timeout must be a positive integer');
+  return runWorkerPool(urls.length, concurrency, (requestIndex) =>
+    requestOnce(urls[requestIndex], timeoutMs, fetchImpl),
+  );
+}
+
+async function runWorkerPool(
+  itemCount: number,
+  concurrency: number,
+  perform: (itemIndex: number) => Promise<RequestOutcome>,
+): Promise<RequestOutcome[]> {
+  if (!Number.isSafeInteger(concurrency) || concurrency < 1) throw new Error('concurrency must be a positive integer');
+
+  const outcomes: RequestOutcome[] = [];
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, itemCount);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < itemCount) {
+        const requestIndex = nextIndex;
+        nextIndex += 1;
+        outcomes[requestIndex] = await perform(requestIndex);
+      }
+    }),
+  );
+  return outcomes;
+}
+
+function percentile(sortedLatencies: readonly number[], percentileValue: number): number {
+  if (sortedLatencies.length === 0) return 0;
+  return sortedLatencies[Math.ceil(sortedLatencies.length * percentileValue) - 1];
+}
+
+export function summarizeOutcomes(outcomes: readonly RequestOutcome[]): CutoverSummary {
+  const statusCounts = new Map<number, number>();
+  const errorCounts = new Map<FailureCode, number>();
+  let successful = 0;
+  let timedOut = 0;
+  let networkErrors = 0;
+  let invalidResponses = 0;
+
+  for (const outcome of outcomes) {
+    if (outcome.error) errorCounts.set(outcome.error, (errorCounts.get(outcome.error) ?? 0) + 1);
+    if (outcome.status !== null) {
+      statusCounts.set(outcome.status, (statusCounts.get(outcome.status) ?? 0) + 1);
+      if (outcome.error === null) successful += 1;
+    } else if (outcome.error === 'timeout') {
+      timedOut += 1;
+    } else {
+      networkErrors += 1;
+    }
+    if (outcome.error && outcome.error !== 'timeout' && outcome.error !== 'network') invalidResponses += 1;
+  }
+
+  const latencies = outcomes.map((outcome) => outcome.latencyMs).sort((left, right) => left - right);
+  return {
+    total: outcomes.length,
+    successful,
+    failed: outcomes.length - successful,
+    timedOut,
+    networkErrors,
+    invalidResponses,
+    errorCounts,
+    statusCounts,
+    p50Ms: percentile(latencies, 0.5),
+    p95Ms: percentile(latencies, 0.95),
+    maxMs: latencies.at(-1) ?? 0,
+  };
+}
+
+export function formatSummary(summary: CutoverSummary): string {
+  const statuses = [...summary.statusCounts.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([status, count]) => `${status}:${count}`)
+    .join(',');
+  const errors = [...summary.errorCounts.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([error, count]) => `${error}:${count}`)
+    .join(',');
+  return [
+    `requests=${summary.total}`,
+    `ok=${summary.successful}`,
+    `failed=${summary.failed}`,
+    `status=${statuses || 'none'}`,
+    `timeouts=${summary.timedOut}`,
+    `network=${summary.networkErrors}`,
+    `invalid=${summary.invalidResponses}`,
+    `errors=${errors || 'none'}`,
+    `latency_ms=p50:${Math.round(summary.p50Ms)},p95:${Math.round(summary.p95Ms)},max:${Math.round(summary.maxMs)}`,
+  ].join(' ');
+}
+
+async function fetchSitemapXml(origin: string, timeoutMs: number, fetchImpl: FetchLike): Promise<string> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(new URL(CLIMB_SITEMAP_PATH, origin), {
+      method: 'GET',
+      redirect: 'manual',
+      signal: controller.signal,
+      headers: { 'User-Agent': 'boardsesh-pgbouncer-cutover-smoke/1.0', 'Cache-Control': 'no-cache' },
+    });
+    if (response.status < 200 || response.status >= 300) {
+      throw new Error(`climb sitemap returned HTTP ${response.status}`);
+    }
+    return await readBody(response, MAX_SITEMAP_BYTES);
+  } catch (error) {
+    if (controller.signal.aborted) throw new Error(`climb sitemap timed out after ${timeoutMs}ms`);
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function probeDatabaseOnce(
+  options: CutoverOptions,
+  requestIndex: number,
+  fetchImpl: FetchLike,
+): Promise<RequestOutcome> {
+  const controller = new AbortController();
+  const startedAt = performance.now();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs);
+  try {
+    const probeUrl = new URL(READINESS_PATH, options.origin);
+    probeUrl.searchParams.set('request', String(requestIndex + 1));
+    const response = await fetchImpl(probeUrl, {
+      method: 'GET',
+      redirect: 'manual',
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${options.probeToken}`,
+        'User-Agent': 'boardsesh-pgbouncer-cutover-smoke/1.0',
+        'Cache-Control': 'no-cache',
+      },
+    });
+    const bodyText = await readBody(response, MAX_PROBE_BYTES);
+    let body: unknown;
+    try {
+      body = JSON.parse(bodyText);
+    } catch {
+      body = null;
+    }
+    const validPayload =
+      response.status === 200 && typeof body === 'object' && body !== null && 'ok' in body && body.ok === true;
+    const noStore = (response.headers.get('cache-control') ?? '').toLowerCase().includes('no-store');
+    return {
+      status: response.status,
+      latencyMs: performance.now() - startedAt,
+      error: !validPayload ? 'invalid-probe' : !noStore ? 'cacheable-probe' : null,
+    };
+  } catch (error) {
+    return {
+      status: null,
+      latencyMs: performance.now() - startedAt,
+      error: controller.signal.aborted ? 'timeout' : error instanceof BodyTooLargeError ? 'body-too-large' : 'network',
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function runProbeRequests(
+  options: CutoverOptions,
+  fetchImpl: FetchLike = fetch,
+): Promise<RequestOutcome[]> {
+  if (!Number.isSafeInteger(options.timeoutMs) || options.timeoutMs < 1) {
+    throw new Error('timeout must be a positive integer');
+  }
+  return runWorkerPool(options.requests, options.concurrency, (requestIndex) =>
+    probeDatabaseOnce(options, requestIndex, fetchImpl),
+  );
+}
+
+export async function runCutoverSmoke(options: CutoverOptions, fetchImpl: FetchLike = fetch): Promise<CutoverReport> {
+  const sitemapXml = await fetchSitemapXml(options.origin, options.timeoutMs, fetchImpl);
+  const sourceUrls = selectClimbUrls(sitemapXml, options.requests);
+  const targetUrls = rewriteUrlsToOrigin(sourceUrls, options.origin);
+  const databaseOutcomes = await runProbeRequests(options, fetchImpl);
+  const climbOutcomes = await runRequests(targetUrls, options.concurrency, options.timeoutMs, fetchImpl);
+  return { database: summarizeOutcomes(databaseOutcomes), climbs: summarizeOutcomes(climbOutcomes) };
+}
+
+async function main(): Promise<void> {
+  const options = parseArguments(process.argv.slice(2));
+  console.log(
+    `PgBouncer cutover smoke origin=${options.origin} requests=${options.requests} concurrency=${options.concurrency} timeout_ms=${options.timeoutMs}`,
+  );
+  const report = await runCutoverSmoke(options);
+  console.log(`database ${formatSummary(report.database)}`);
+  console.log(`climbs   ${formatSummary(report.climbs)}`);
+  const failures = report.database.failed + report.climbs.failed;
+  if (failures > 0) throw new Error(`${failures} request(s) failed`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`PgBouncer cutover smoke failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/pgbouncer-cutover-smoke.ts
+++ b/scripts/pgbouncer-cutover-smoke.ts
@@ -180,7 +180,10 @@ export function selectClimbUrls(xml: string, count: number): string[] {
       throw new Error('climb sitemap contains an unsafe <loc> URL');
     }
     if (parsed.hash) throw new Error('climb sitemap contains a fragmented <loc> URL');
-    if (!parsed.pathname.includes('/view/')) throw new Error('climb sitemap contains a non-climb <loc> URL');
+    const isClimbViewPath = /^\/(?:b\/[^/]+\/[^/]+|(?:kilter|moonboard|tension)(?:\/[^/]+)+)\/view\/[^/]+\/?$/.test(
+      parsed.pathname,
+    );
+    if (!isClimbViewPath) throw new Error('climb sitemap contains a non-climb <loc> URL');
     if (!seen.has(parsed.href)) {
       seen.add(parsed.href);
       uniqueUrls.push(parsed.href);

--- a/scripts/pgbouncer-cutover-smoke.ts
+++ b/scripts/pgbouncer-cutover-smoke.ts
@@ -7,15 +7,18 @@ import { pathToFileURL } from 'node:url';
 export const DEFAULT_REQUESTS = 100;
 export const DEFAULT_CONCURRENCY = 32;
 export const DEFAULT_TIMEOUT_MS = 10_000;
-// One complete deterministic shard is enough to spread probes across many
-// climbs without multiplying sitemap downloads during the cutover window.
-export const CLIMB_SITEMAP_PATH = '/sitemaps/climbs/1.xml';
+// Climb sitemaps are intentionally paused in production. The fixed board
+// sitemap stays published and leads to SSR listing pages that expose canonical
+// climb links without adding a cutover-only database endpoint.
+export const BOARD_SITEMAP_PATH = '/sitemaps/boards.xml';
 export const READINESS_PATH = '/api/internal/pgbouncer-cutover-readiness';
 export const CUTOVER_TOKEN_ENV = 'PGBOUNCER_CUTOVER_SMOKE_TOKEN';
 
 const MIN_CLIMB_HTML_CHARS = 4_000;
 const MAX_CLIMB_HTML_BYTES = 2_000_000;
 const MAX_SITEMAP_BYTES = 8_000_000;
+const MAX_LISTING_HTML_BYTES = 2_000_000;
+const MIN_SOURCE_LISTINGS = 8;
 const MAX_PROBE_BYTES = 1_024;
 
 export type FailureCode =
@@ -158,12 +161,9 @@ function decodeXmlText(encoded: string): string {
   });
 }
 
-/** Extracts unique HTTP(S) URLs, then samples evenly across the complete sitemap. */
-export function selectClimbUrls(xml: string, count: number): string[] {
-  if (!Number.isSafeInteger(count) || count < 1) throw new Error('request count must be a positive integer');
-  if (!/<urlset\b/i.test(xml)) throw new Error('climb sitemap has no <urlset> root');
-
-  const uniqueUrls: string[] = [];
+function sitemapLocations(xml: string, label: string): string[] {
+  if (!/<urlset\b/i.test(xml)) throw new Error(`${label} sitemap has no <urlset> root`);
+  const locations: string[] = [];
   const seen = new Set<string>();
   const locationPattern = /<loc\b[^>]*>([\s\S]*?)<\/loc\s*>/gi;
   let match: RegExpExecArray | null;
@@ -174,32 +174,79 @@ export function selectClimbUrls(xml: string, count: number): string[] {
     try {
       parsed = new URL(location);
     } catch {
-      throw new Error('climb sitemap contains an invalid <loc> URL');
+      throw new Error(`${label} sitemap contains an invalid <loc> URL`);
     }
     if ((parsed.protocol !== 'http:' && parsed.protocol !== 'https:') || parsed.username || parsed.password) {
-      throw new Error('climb sitemap contains an unsafe <loc> URL');
+      throw new Error(`${label} sitemap contains an unsafe <loc> URL`);
     }
-    if (parsed.hash) throw new Error('climb sitemap contains a fragmented <loc> URL');
-    const isClimbViewPath = /^\/(?:b\/[^/]+\/[^/]+|(?:kilter|moonboard|tension)(?:\/[^/]+)+)\/view\/[^/]+\/?$/.test(
-      parsed.pathname,
-    );
-    if (!isClimbViewPath) throw new Error('climb sitemap contains a non-climb <loc> URL');
+    if (parsed.hash) throw new Error(`${label} sitemap contains a fragmented <loc> URL`);
+    if (!seen.has(parsed.href)) {
+      seen.add(parsed.href);
+      locations.push(parsed.href);
+    }
+  }
+  return locations;
+}
+
+/** Keeps canonical, non-localized board listing URLs from the always-on fixed shard. */
+export function selectBoardListUrls(xml: string): string[] {
+  const locations = sitemapLocations(xml, 'board');
+  const boardListPath = /^\/(?:kilter|moonboard|tension)(?:\/[^/]+)+\/list\/?$/;
+  const listings = locations.filter((location) => boardListPath.test(new URL(location).pathname));
+  if (listings.length === 0) throw new Error('board sitemap has no canonical board listing URLs');
+  return listings;
+}
+
+function isClimbViewPath(pathname: string): boolean {
+  return /^\/(?:b\/[^/]+\/[^/]+|(?:kilter|moonboard|tension)(?:\/[^/]+)+)\/view\/[^/]+\/?$/.test(pathname);
+}
+
+/** Extracts same-origin canonical climb links from one server-rendered board listing. */
+export function extractClimbUrlsFromListing(html: string, listingUrl: string): string[] {
+  if (!/<html[\s>]/i.test(html)) throw new Error('board listing response has no <html> root');
+  const source = new URL(listingUrl);
+  const uniqueUrls: string[] = [];
+  const seen = new Set<string>();
+  const hrefPattern = /<a\b[^>]*\bhref\s*=\s*(["'])(.*?)\1/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = hrefPattern.exec(html)) !== null) {
+    const href = decodeXmlText(match[2].trim());
+    let parsed: URL;
+    try {
+      parsed = new URL(href, source);
+    } catch {
+      continue;
+    }
+    if (
+      parsed.origin !== source.origin ||
+      parsed.username ||
+      parsed.password ||
+      parsed.hash ||
+      !isClimbViewPath(parsed.pathname)
+    ) {
+      continue;
+    }
     if (!seen.has(parsed.href)) {
       seen.add(parsed.href);
       uniqueUrls.push(parsed.href);
     }
   }
+  return uniqueUrls;
+}
 
-  if (uniqueUrls.length < count) {
-    throw new Error(`climb sitemap has ${uniqueUrls.length} unique URLs; ${count} required`);
+/** Selects exactly `count` URLs while evenly covering the discovered population. */
+export function selectClimbUrls(urls: readonly string[], count: number): string[] {
+  if (!Number.isSafeInteger(count) || count < 1) throw new Error('request count must be a positive integer');
+
+  if (urls.length < count) {
+    throw new Error(`board listings exposed ${urls.length} unique climb URLs; ${count} required`);
   }
 
-  // Include both ends and evenly cover everything between them. This makes a
-  // cutover hit long-tail/cold pages without adding randomness to incident QA.
-  if (count === 1) return [uniqueUrls[0]];
+  if (count === 1) return [urls[0]];
   return Array.from({ length: count }, (_, index) => {
-    const sourceIndex = Math.round((index * (uniqueUrls.length - 1)) / (count - 1));
-    return uniqueUrls[sourceIndex];
+    const sourceIndex = Math.round((index * (urls.length - 1)) / (count - 1));
+    return urls[sourceIndex];
   });
 }
 
@@ -382,26 +429,77 @@ export function formatSummary(summary: CutoverSummary): string {
   ].join(' ');
 }
 
-async function fetchSitemapXml(origin: string, timeoutMs: number, fetchImpl: FetchLike): Promise<string> {
+async function fetchPublicText(
+  url: string | URL,
+  label: string,
+  timeoutMs: number,
+  maximumBytes: number,
+  fetchImpl: FetchLike,
+): Promise<string> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const response = await fetchImpl(new URL(CLIMB_SITEMAP_PATH, origin), {
+    const response = await fetchImpl(url, {
       method: 'GET',
       redirect: 'manual',
       signal: controller.signal,
       headers: { 'User-Agent': 'boardsesh-pgbouncer-cutover-smoke/1.0', 'Cache-Control': 'no-cache' },
     });
     if (response.status < 200 || response.status >= 300) {
-      throw new Error(`climb sitemap returned HTTP ${response.status}`);
+      throw new Error(`${label} returned HTTP ${response.status}`);
     }
-    return await readBody(response, MAX_SITEMAP_BYTES);
+    return await readBody(response, maximumBytes);
   } catch (error) {
-    if (controller.signal.aborted) throw new Error(`climb sitemap timed out after ${timeoutMs}ms`);
+    if (controller.signal.aborted) throw new Error(`${label} timed out after ${timeoutMs}ms`);
     throw error;
   } finally {
     clearTimeout(timeout);
   }
+}
+
+function sampleEvenly<T>(items: readonly T[], count: number): T[] {
+  if (count >= items.length) return [...items];
+  if (count === 1) return [items[0]];
+  return Array.from({ length: count }, (_, index) => {
+    const sourceIndex = Math.round((index * (items.length - 1)) / (count - 1));
+    return items[sourceIndex];
+  });
+}
+
+export async function discoverClimbUrls(
+  origin: string,
+  count: number,
+  timeoutMs: number,
+  fetchImpl: FetchLike,
+): Promise<string[]> {
+  const boardSitemapXml = await fetchPublicText(
+    new URL(BOARD_SITEMAP_PATH, origin),
+    'board sitemap',
+    timeoutMs,
+    MAX_SITEMAP_BYTES,
+    fetchImpl,
+  );
+  const boardListingUrls = rewriteUrlsToOrigin(selectBoardListUrls(boardSitemapXml), origin);
+  // Production listings currently expose 50 SSR climb links. Sample at least
+  // eight configurations across the whole board shard and keep going when a
+  // sparse configuration exposes fewer, without fetching the complete shard.
+  const sourceListingCount = Math.min(boardListingUrls.length, Math.max(MIN_SOURCE_LISTINGS, Math.ceil(count / 25)));
+  const sourceListings = sampleEvenly(boardListingUrls, sourceListingCount);
+  const uniqueClimbUrls: string[] = [];
+  const seen = new Set<string>();
+
+  for (const listingUrl of sourceListings) {
+    const html = await fetchPublicText(listingUrl, 'board listing', timeoutMs, MAX_LISTING_HTML_BYTES, fetchImpl);
+    for (const climbUrl of extractClimbUrlsFromListing(html, listingUrl)) {
+      if (!seen.has(climbUrl)) {
+        seen.add(climbUrl);
+        uniqueClimbUrls.push(climbUrl);
+      }
+    }
+    if (uniqueClimbUrls.length >= count) break;
+  }
+
+  return selectClimbUrls(uniqueClimbUrls, count);
 }
 
 async function probeDatabaseOnce(
@@ -464,9 +562,7 @@ export async function runProbeRequests(
 }
 
 export async function runCutoverSmoke(options: CutoverOptions, fetchImpl: FetchLike = fetch): Promise<CutoverReport> {
-  const sitemapXml = await fetchSitemapXml(options.origin, options.timeoutMs, fetchImpl);
-  const sourceUrls = selectClimbUrls(sitemapXml, options.requests);
-  const targetUrls = rewriteUrlsToOrigin(sourceUrls, options.origin);
+  const targetUrls = await discoverClimbUrls(options.origin, options.requests, options.timeoutMs, fetchImpl);
   const databaseOutcomes = await runProbeRequests(options, fetchImpl);
   const climbOutcomes = await runRequests(targetUrls, options.concurrency, options.timeoutMs, fetchImpl);
   return { database: summarizeOutcomes(databaseOutcomes), climbs: summarizeOutcomes(climbOutcomes) };

--- a/scripts/postgres-image-publisher-contract.test.ts
+++ b/scripts/postgres-image-publisher-contract.test.ts
@@ -609,22 +609,6 @@ describe('trusted PostgreSQL image publisher contract', () => {
   });
 
   it.each([
-    [
-      'group',
-      '  group: postgres-image-contract-${{ github.event.pull_request.number || github.ref }}',
-      '  group: postgres-image-contract-${{ github.ref }}',
-    ],
-    [
-      'cancellation policy',
-      "  cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
-      '  cancel-in-progress: true',
-    ],
-  ])('rejects an altered contract concurrency %s', (_label, expected, replacement) => {
-    const weakened = replaceRequired(contractWorkflow, expected, replacement);
-    expect(failuresFor(publisherWorkflow, weakened)).toMatch(/exact reviewed pull-request cancellation policy/);
-  });
-
-  it.each([
     ['ref', 'main'],
     ['repository', 'attacker/example'],
     ['path', 'source'],

--- a/scripts/postgres-image-publisher-contract.test.ts
+++ b/scripts/postgres-image-publisher-contract.test.ts
@@ -609,6 +609,22 @@ describe('trusted PostgreSQL image publisher contract', () => {
   });
 
   it.each([
+    [
+      'group',
+      '  group: postgres-image-contract-${{ github.event.pull_request.number || github.ref }}',
+      '  group: postgres-image-contract-${{ github.ref }}',
+    ],
+    [
+      'cancellation policy',
+      "  cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+      '  cancel-in-progress: true',
+    ],
+  ])('rejects an altered contract concurrency %s', (_label, expected, replacement) => {
+    const weakened = replaceRequired(contractWorkflow, expected, replacement);
+    expect(failuresFor(publisherWorkflow, weakened)).toMatch(/exact reviewed pull-request cancellation policy/);
+  });
+
+  it.each([
     ['ref', 'main'],
     ['repository', 'attacker/example'],
     ['path', 'source'],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1134,6 +1134,10 @@ export default defineConfig({
         command: 'tsx scripts/production-smoke.ts',
         cache: false,
       },
+      'smoke:pgbouncer-cutover': {
+        command: 'tsx scripts/pgbouncer-cutover-smoke.ts',
+        cache: false,
+      },
       // Browser boot check for app.boardsesh.com — proves the bundle evaluates
       // and React mounts, which the curl smoke in production-deploy.yml cannot
       // see. Uses its own Playwright config (no globalSetup, no webServer) so


### PR DESCRIPTION
## Summary

- Cap Vercel Postgres clients at 3 with 5-second idle expiry.
- Resolve climb aliases and fetch climbs in one database statement.
- Publish a hardened, attested PgBouncer image with a real TLS smoke test.
- Keep migrations on a pinned direct PostgreSQL endpoint.
- Add SQLSTATE tags and protected readiness and cutover-smoke tooling.

Closes #4842.

Production `DATABASE_DIRECT_URL` and its endpoint identity are provisioned. The pooled Vercel URL and cutover token remain later rollout steps documented in `docs/db-connectivity.md`.

## Release Notes

Climb pages keep loading when traffic spikes.

## Test plan

1. Open a Kilter climb list → climbs render without server errors.
2. Open a climb → name, grade, stats, and board appear.
3. Open a missing climb → a 404 page appears.
4. Check readiness → database and endpoint checks pass.
5. Run CI → PgBouncer and deployment contract checks pass.

## Risk

Risk: 4/5 — changes production database routing, pooling, and image publication.