### PR TITLE
fix(web): pause climb sitemap publication on Vercel

### DIFF
--- a/docs/sitemap.md
+++ b/docs/sitemap.md
@@ -16,7 +16,7 @@ Two kinds of shard:
 
 |                   | fixed (`SHARD_REGISTRY`)                           | paged (`PAGED_SHARD_REGISTRY`)                   |
 | ----------------- | -------------------------------------------------- | ------------------------------------------------ |
-| members           | `static`, `boards`, `gyms`, `setters`, `playlists` | `climbs`                                         |
+| members           | `static`, `boards`, `gyms`, `setters`, `playlists` | `climbs` when enabled                            |
 | file              | one `/sitemaps/<id>.xml`                           | `/sitemaps/climbs/1.xml … N.xml`                 |
 | index asks it for | the whole item list                                | `summary()` only — count + newest timestamp      |
 | N comes from      | —                                                  | `ceil(itemCount / urlsPerShard)` at request time |
@@ -24,6 +24,29 @@ Two kinds of shard:
 `N` is derived from the summary on every request, never from the filesystem: Next has
 no partial dynamic segments, so a `climbs-1.xml` shape would hardcode today's page
 count into the directory tree.
+
+## The climb sitemap switch
+
+Climb sitemap publication is paused by default. It is enabled only when the
+server-side environment variable `CLIMB_SITEMAPS_ENABLED` is exactly `true`.
+Unset values and variants such as `1` or `TRUE` stay disabled.
+
+Disabled mode has one contract across every entry point:
+
+- `/sitemap.xml` omits every `/sitemaps/climbs/N.xml` entry intentionally. It does
+  not read the climb store, name `climbs` in `X-Sitemap-Degraded`, or shorten the
+  index cache window.
+- Direct `/sitemaps/climbs/*.xml` requests return `410 Gone` with
+  `Cache-Control: public, s-maxage=3600, must-revalidate`. The one-hour expiry lets
+  a later re-enable become visible without leaving crawler retries uncached.
+- `/sitemap.xml` does not schedule the climb-store `after()` refresh.
+- An authenticated `/api/internal/refresh-sitemap-climbs` request returns
+  `{ "shard": "climbs", "skipped": "disabled" }` without scanning the database.
+  Authentication still runs first, so an unauthenticated request remains `401`.
+
+The tables, refresh code, and enabled read behavior remain in place. Set
+`CLIMB_SITEMAPS_ENABLED=true` to restore publication; all other sitemap shards are
+unaffected by the switch.
 
 ## Degrade at the index, fail closed at the shard
 
@@ -82,8 +105,9 @@ stats update no longer makes all six pages look changed. It is strictly
 best-effort — an empty store or a failed aggregate falls back to the shard-wide
 value and never degrades the shard.
 
-Both tables are a **cache, not a source of truth**. Truncate them and nothing is
-lost: the read paths fall back to the live scan they replaced, and the next refresh
+Both tables are a **cache, not a source of truth**, and are retained while climb
+sitemaps are paused. When the switch is enabled, truncating them loses no source
+data: the read paths fall back to the live scan they replaced, and the next refresh
 repopulates them.
 
 ### Read behaviour
@@ -126,11 +150,11 @@ So a fallback names itself, on two channels:
   `page-empty`, `page-read-failed`). The page-path event fires _before_ the 51 s
   fallback build, so a Vercel timeout cannot swallow it.
 
-`scripts/production-smoke.ts` reads the header off the index response it already
-fetches — no extra request — and reports `live` as a **warning**, not a failure:
-the index it just validated is complete either way, so this is "the fast path is not
-the one running", not "the sitemap is broken". A missing header is not a finding; a
-deploy that predates it and a summary that never settled both leave it absent.
+While publication is paused, `scripts/production-smoke.ts` requires this header to
+be absent. It also requires the index to omit climb shard URLs and requires a direct
+climb shard request to return the cacheable 410. Re-enabling the surface therefore
+requires an intentional smoke-test update; changing only an environment variable
+cannot silently restore the crawler load.
 
 One honest limit, shared with `X-Sitemap-Degraded`: the header rides a CDN-cached
 response. A healthy index is `s-maxage=3600` and the shard pages are
@@ -139,44 +163,70 @@ request header, so the value read can be up to that old in either direction. It 
 signal that a wedged store gets noticed within the hour, not a live probe. The Sentry
 event has no such lag.
 
-### Who refreshes it
+### Who refreshes it when enabled
 
-1. **The cron** — `/api/internal/refresh-sitemap-climbs`, six-hourly, in
-   `packages/web/vercel.json`. Six hours matches the shard's own `s-maxage=21600`, so
-   no layer is staler than any other. Auth is `requireCronAuth`, which reads
-   `CRON_SECRET`; Vercel injects the matching bearer automatically.
-2. **The `after()` self-heal** on `/sitemap.xml` itself. After the response has
+The former six-hour Vercel cron has been removed while publication is paused.
+There are two refresh paths when `CLIMB_SITEMAPS_ENABLED=true`:
+
+1. **The `after()` self-heal** on `/sitemap.xml` itself. After the response has
    flushed — so it cannot touch the 3 s deadline or the latency a crawler sees — the
    index kicks a refresh if the summary row is missing or past 48 h, **or if
    `sitemap_climb_urls` is empty**. That last probe matters on the deploy that adds
-   the URL table: the summary row is fresh (the cron kept writing it), so a
-   summary-only check would wait out the six-hourly cron while every page request
-   took the 51 s fallback. Single-flighted per instance behind a 15-minute floor.
-   This is what keeps the fix from depending on a scheduler: a lapsed cron degrades
-   to "healed by the next crawl", not to a broken sitemap.
-3. **By hand**, after a deploy that leaves the store empty:
+   the URL table: an older summary row can still be fresh while the new table is
+   empty, so a summary-only check would wait for the age threshold while every page
+   request took the 51 s fallback. Single-flighted per instance behind a 15-minute floor.
+   This keeps the enabled surface scheduler-independent: a missing or old store
+   degrades to "healed by the next crawl", not to a permanently broken sitemap.
+2. **By hand**, after enabling the switch or a deploy that leaves the store empty:
 
    ```
-   curl -sS -H "Authorization: Bearer $CRON_SECRET" \
+   curl --fail-with-body --silent --show-error \
+     -H "Authorization: Bearer $CRON_SECRET" \
      https://www.boardsesh.com/api/internal/refresh-sitemap-climbs
    ```
 
-   Worth being precise about what this buys, because it is easy to over- or
-   under-sell. It is not required — the `after()` hook fires on the first
-   `/sitemap.xml` request and closes the window for every request after it. What the
-   curl does is close it _now_ rather than one crawl later, and it is the only one of
-   the three that reports back: a 409 tells you the refresh was refused and why,
-   where the self-heal only writes that to the log. So: reach for it on a deploy that
-   empties the store, and any time you want an answer rather than a hope.
+   The `after()` hook fires on the first enabled `/sitemap.xml` request, so the curl
+   is not required. It closes the window immediately and reports refusals directly:
+   a 409 prints why the refresh was declined and exits non-zero, while the self-heal
+   only writes that to the log. While the switch is disabled, the same authenticated
+   curl returns `skipped: "disabled"` and performs no scan.
+
+### Railway re-enable runbook
+
+1. In the cutover change, update the production smoke contract from paused/410 to
+   enabled/store so that the same deployment verifies the intended state.
+2. Set `CLIMB_SITEMAPS_ENABLED=true` and `CRON_SECRET` on the Railway web service,
+   then deploy the cutover before starting a scheduler.
+3. Run the Node validator command in step 4 once from a shell with both variables
+   set. Continue only after it exits zero; it rejects non-200 responses, disabled or
+   concurrent skips, invalid JSON, empty results, and timeouts.
+4. Create a separate one-shot Railway cron service from this repository. Give it
+   `BOARDSESH_WEB_ORIGIN` and a reference to the web service's `CRON_SECRET`, set
+   its UTC schedule to `0 */6 * * *`, and use this exact start command:
+
+   ```sh
+   node -e 'const origin=process.env.BOARDSESH_WEB_ORIGIN;const secret=process.env.CRON_SECRET;if(!origin||!secret)throw new Error("missing BOARDSESH_WEB_ORIGIN or CRON_SECRET");fetch(new URL("/api/internal/refresh-sitemap-climbs",origin),{headers:{Authorization:`Bearer ${secret}`},signal:AbortSignal.timeout(330000)}).then(async response=>{const body=await response.text();console.log(body);const payload=JSON.parse(body);if(!response.ok||payload.shard!=="climbs"||payload.skipped!==null||!Number.isInteger(payload.itemCount)||payload.itemCount<1)throw new Error(`refresh rejected: HTTP ${response.status}`)}).catch(error=>{console.error(error);process.exitCode=1})'
+   ```
+
+   The command exits zero only after a stored, non-empty refresh. It exits non-zero
+   on HTTP errors, refusal bodies, missing configuration, invalid JSON, or timeout.
+   It must terminate after each run; Railway skips later schedules while an earlier
+   cron process remains active. Do not attach this schedule to the web service and
+   do not restore the Vercel cron.
+5. Verify `/sitemap.xml` includes `/sitemaps/climbs/1.xml` with
+   `X-Sitemap-Climbs-Source: store`, then verify that direct shard returns HTTP 200
+   XML with the same source header. Confirm the scheduler's next run succeeds before
+   removing migration monitoring.
 
 ### Refusals, and how to get out of one
 
-The refresher declines to write in four cases. Two are benign concurrency and answer
-200; two mean the store is frozen and answer **409**, so a wedge fails the cron run
-that found it rather than hiding in the logs.
+The endpoint can skip before or during a refresh. Disabled mode answers 200 before
+the refresher runs. Of the four refresher-level cases, two are benign concurrency and
+answer 200; two mean the store is frozen and answer **409**.
 
 | `skipped`    | status | meaning                                                                                                                       |
 | ------------ | ------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| `disabled`   | 200    | the switch is off; no database scan runs                                                                                      |
 | `locked`     | 200    | another instance holds the write lock                                                                                         |
 | `superseded` | 200    | another instance wrote a newer answer while this one was scanning                                                             |
 | `empty`      | 409    | the scan computed 0 climbs. Never stored — a stored zero makes the index drop the shard, which is the bug this table prevents |
@@ -289,11 +339,12 @@ and fails every connection (`packages/db/src/client/postgres.ts`, `docs/db-conne
 
 ## What is still slow
 
-`/sitemaps/climbs/N.xml` is fixed (#4552) — a stored page reads in milliseconds. What
-remains slow is the **fallback**: an empty `sitemap_climb_urls` (the deploy that adds
-it, a truncation, local dev) still takes the 51 s live build until the first refresh
-runs. The self-heal's empty-table probe bounds that window to one crawl of
-`/sitemap.xml`; the manual curl closes it immediately.
+When enabled, `/sitemaps/climbs/N.xml` is fixed (#4552) — a stored page reads in
+milliseconds. What remains slow is the **fallback**: an empty
+`sitemap_climb_urls` (a truncation or local dev) still takes the 51 s live build until
+the first refresh runs. The self-heal's empty-table probe bounds that window to one
+crawl of `/sitemap.xml`; the manual curl closes it immediately. Disabled requests do
+not reach either path; they return the cacheable 410.
 
 Fixed shards have **no byte budget**. `shardRouteHandler` checks `MAX_URLS_PER_SHARD`
 on the fixed path but never `MAX_SHARD_BYTES` — that guard exists only on the paged
@@ -303,14 +354,11 @@ while `MAX_ITEMS_PER_SHARD` lets it reach 11,250. Tracked separately.
 
 ## Operational gotchas
 
-- **A deploy that changes climb URL shape needs a manual refresh to take effect
-  before the next cron.** `sitemap_climb_urls.path` is RENDERED at refresh time, so
-  new URL logic keeps serving the old shape for up to six hours unless someone runs
-  the curl above. The old URLs still resolve (the pages self-canonicalise), so this
-  is a staleness window, not an outage.
-- **The cron is one of eight** in `packages/web/vercel.json`. The Railway cutover
-  (#3795/#3798) has to re-point all of them. The `after()` self-heal is the backstop if
-  one is missed.
-- **`scripts/production-smoke.ts` requires `climbs` in the index (degradable — WARN
-  when `X-Sitemap-Degraded` names it, FAIL when it vanishes silently).** The
-  degradable escape covers the empty-store window right after the migration deploys.
+- **After enabling, a deploy that changes climb URL shape needs a manual refresh.**
+  `sitemap_climb_urls.path` is rendered at refresh time, so new URL logic keeps
+  serving the old shape until the store is stale enough for the self-heal or someone
+  runs the curl above. The old URLs still resolve (the pages self-canonicalise), so
+  this is a staleness window, not an outage.
+- **`scripts/production-smoke.ts` pins the paused state.** It fails if climb URLs
+  or source headers return, and it requires the direct shard's cacheable 410. The
+  Railway cutover must update that contract alongside the environment switch.

--- a/packages/web/app/__tests__/rest-surface-inventory.test.ts
+++ b/packages/web/app/__tests__/rest-surface-inventory.test.ts
@@ -70,6 +70,8 @@ const VERDICTS: Record<string, Verdict> = {
   'app/api/internal/cleanup/route.ts': 'keep-external',
   'app/api/internal/prewarm-heatmap/[board_name]/route.ts': 'keep-external',
   'app/api/internal/profile-percentiles/route.ts': 'keep-external',
+  // Retained for a manual initial refresh when Railway takes over scheduling.
+  // It must remain absent from Vercel's scheduler while climb sitemaps are paused.
   'app/api/internal/refresh-sitemap-climbs/route.ts': 'keep-external',
   'app/api/internal/beta-link-thumbnail/route.ts': 'keep-caller',
   'app/api/internal/revalidate-climb/route.ts': 'keep-caller',
@@ -190,6 +192,10 @@ describe('REST surface inventory (issue #1889)', () => {
     });
 
     expect(classified).toEqual(cronPaths.map((cronPath) => ({ cronPath, verdict: 'keep-external' })));
+  });
+
+  it('keeps the paused climb sitemap refresh out of Vercel cron', () => {
+    expect(readCronPaths()).not.toContain('/api/internal/refresh-sitemap-climbs');
   });
 
   it('counts exactly the audited surface', () => {

--- a/packages/web/app/api/internal/refresh-sitemap-climbs/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/refresh-sitemap-climbs/__tests__/route.test.ts
@@ -42,6 +42,7 @@ beforeEach(() => {
     scanDurationMs: 41_000,
   };
   vi.stubEnv('CRON_SECRET', 'test-secret');
+  vi.stubEnv('CLIMB_SITEMAPS_ENABLED', 'true');
 });
 
 afterEach(() => {
@@ -60,6 +61,25 @@ describe('GET /api/internal/refresh-sitemap-climbs', () => {
 
   it('401s a wrong bearer token', async () => {
     const response = await routeModule.GET(request('', { authorization: 'Bearer wrong-secret' }));
+
+    expect(response.status).toBe(401);
+    expect(refresh.calls).toHaveLength(0);
+  });
+
+  it('reports an authenticated disabled skip without running the scan', async () => {
+    vi.stubEnv('CLIMB_SITEMAPS_ENABLED', 'false');
+
+    const response = await routeModule.GET(request('', AUTHORIZED));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ shard: 'climbs', skipped: 'disabled' });
+    expect(refresh.calls).toHaveLength(0);
+  });
+
+  it('still authenticates before reporting a disabled skip', async () => {
+    vi.stubEnv('CLIMB_SITEMAPS_ENABLED', 'false');
+
+    const response = await routeModule.GET(request());
 
     expect(response.status).toBe(401);
     expect(refresh.calls).toHaveLength(0);

--- a/packages/web/app/api/internal/refresh-sitemap-climbs/route.ts
+++ b/packages/web/app/api/internal/refresh-sitemap-climbs/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { requireCronAuth } from '@/app/lib/auth/cron-auth';
+import { climbSitemapsEnabled } from '@/app/lib/seo/sitemap/climb-sitemaps-enabled';
 import { refreshClimbSitemapStore } from '@/app/lib/seo/sitemap/climb-store';
 
 /**
@@ -9,9 +10,9 @@ import { refreshClimbSitemapStore } from '@/app/lib/seo/sitemap/climb-store';
  * `/sitemaps/climbs/N.xml` serves as an ordinal range read instead of a 51 s
  * full rebuild per cold page (#4552).
  *
- * Scheduled six-hourly in `packages/web/vercel.json`, matching the shard's own
- * `s-maxage=21600` so no layer is staler than any other. Vercel injects
- * `Authorization: Bearer $CRON_SECRET`; `requireCronAuth` is what checks it.
+ * The Vercel schedule is paused with climb sitemap publication. This route stays
+ * available for authenticated manual refreshes when the switch is enabled;
+ * `requireCronAuth` checks `Authorization: Bearer $CRON_SECRET`.
  *
  * `?force=1` bypasses the >50%-shrink guard. It exists so the guard cannot wedge
  * the store permanently: if the catalogue genuinely shrank, every scheduled run
@@ -24,6 +25,10 @@ export async function GET(request: Request) {
   const authError = requireCronAuth(request);
   if (authError) {
     return authError;
+  }
+
+  if (!climbSitemapsEnabled()) {
+    return NextResponse.json({ shard: 'climbs', skipped: 'disabled' });
   }
 
   const force = new URL(request.url).searchParams.get('force') === '1';
@@ -43,7 +48,7 @@ export async function GET(request: Request) {
     // A refusal to write is NOT a success. `empty` and `shrank` mean the store is
     // frozen at whatever it held while the read path keeps serving it, and a 200
     // would leave that visible only to whoever greps the logs. 409 makes a wedged
-    // store fail the cron run that discovered it.
+    // store visible to the operator who requested the refresh.
     if (result.skipped === 'empty' || result.skipped === 'shrank') {
       return NextResponse.json(
         {

--- a/packages/web/app/lib/seo/sitemap/__tests__/climb-shards.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/climb-shards.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import type { PopularBoardConfig } from '@boardsesh/shared-schema';
 import { CLIMB_URLS_PER_SHARD, MAX_SHARD_BYTES } from '../sitemap-xml';
 import type { SitemapItem } from '../entries';
@@ -38,6 +38,7 @@ const climbs = vi.hoisted(() => ({
   buildThrows: false,
   buildsEmpty: false,
   pathLength: 0,
+  summaryCalls: 0,
   buildCalls: 0,
   /** What the per-page lastmod aggregate answers; empty means "store empty, use the uniform value". */
   pageLastmods: [] as (Date | null)[],
@@ -56,6 +57,7 @@ const climbs = vi.hoisted(() => ({
 // real fallback does, so the handler's slice/epoch checks stay exercised.
 vi.mock('../climb-store', () => ({
   fetchClimbShardSummary: async () => {
+    climbs.summaryCalls += 1;
     if (climbs.summaryThrows) throw new Error('climbs summary unavailable');
     // A summary that never settles: the failure a try/catch cannot see.
     if (climbs.summaryHangs) return new Promise<never>(() => {});
@@ -89,11 +91,13 @@ const {
   CLIMB_SOURCE_HEADER,
   PAGED_SHARD_REGISTRY,
   buildSitemapIndexXml,
+  pagedSitemapShardEnabled,
   pagedShardRouteHandler,
   sitemapIndexRouteHandler,
 } = await import('../shard-registry');
 
 beforeEach(() => {
+  vi.stubEnv('CLIMB_SITEMAPS_ENABLED', 'true');
   climbs.itemCount = 3;
   climbs.builtCount = null;
   climbs.summaryThrows = false;
@@ -101,6 +105,7 @@ beforeEach(() => {
   climbs.buildThrows = false;
   climbs.buildsEmpty = false;
   climbs.pathLength = 0;
+  climbs.summaryCalls = 0;
   climbs.buildCalls = 0;
   climbs.pageLastmods = [];
   climbs.pageLastmodsThrow = false;
@@ -108,7 +113,15 @@ beforeEach(() => {
   climbs.pageSource = 'store';
 });
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 describe('the paged climbs shard', () => {
+  it('leaves future paged shards enabled unless they opt into a gate', () => {
+    expect(pagedSitemapShardEnabled({})).toBe(true);
+  });
+
   it('registers one paged shard, default-locale-only, on its own cache window', () => {
     expect(PAGED_SHARD_REGISTRY).toHaveLength(1);
     const [shard] = PAGED_SHARD_REGISTRY;
@@ -118,6 +131,18 @@ describe('the paged climbs shard', () => {
     expect(shard.urlsPerShard).toBe(CLIMB_URLS_PER_SHARD);
     expect(shard.expectsUrls).toBe(true);
     expect(shard.pagePath(2)).toBe('/sitemaps/climbs/2.xml');
+  });
+
+  it('returns a cacheable 410 without reading the store when the switch is not exactly true', async () => {
+    vi.stubEnv('CLIMB_SITEMAPS_ENABLED', 'TRUE');
+
+    const response = await pagedShardRouteHandler('climbs', '1.xml');
+
+    expect(response.status).toBe(410);
+    expect(response.headers.get('content-type')).toBe('text/plain; charset=utf-8');
+    expect(response.headers.get('cache-control')).toBe('public, s-maxage=3600, must-revalidate');
+    expect(climbs.summaryCalls).toBe(0);
+    expect(climbs.buildCalls).toBe(0);
   });
 
   it('serves a page as application/xml on the long climb cache window', async () => {
@@ -216,6 +241,21 @@ describe('the paged climbs shard', () => {
 });
 
 describe('the index and the climbs shard', () => {
+  it('omits disabled climbs intentionally without a store read or degradation', async () => {
+    vi.stubEnv('CLIMB_SITEMAPS_ENABLED', '');
+
+    const response = await sitemapIndexRouteHandler();
+    const xml = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(xml).not.toContain('/sitemaps/climbs/');
+    expect(response.headers.get('x-sitemap-degraded')).toBeNull();
+    expect(response.headers.get(CLIMB_SOURCE_HEADER)).toBeNull();
+    expect(response.headers.get('cache-control')).toBe('public, s-maxage=3600, stale-while-revalidate=86400');
+    expect(climbs.summaryCalls).toBe(0);
+    expect(climbs.buildCalls).toBe(0);
+  });
+
   it('lists one <sitemap> per derived page and stamps the summary timestamp', async () => {
     climbs.itemCount = CLIMB_URLS_PER_SHARD + 1;
 

--- a/packages/web/app/lib/seo/sitemap/__tests__/climb-sitemaps-enabled.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/climb-sitemaps-enabled.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
+
+const { climbSitemapsEnabled } = await import('../climb-sitemaps-enabled');
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('climbSitemapsEnabled', () => {
+  it('enables publication only for the exact lowercase true value', () => {
+    for (const disabledValue of ['', '1', 'TRUE', 'false']) {
+      vi.stubEnv('CLIMB_SITEMAPS_ENABLED', disabledValue);
+      expect(climbSitemapsEnabled()).toBe(false);
+    }
+
+    vi.stubEnv('CLIMB_SITEMAPS_ENABLED', 'true');
+    expect(climbSitemapsEnabled()).toBe(true);
+  });
+
+  it('defaults to disabled when the variable is absent', () => {
+    vi.stubEnv('CLIMB_SITEMAPS_ENABLED', undefined);
+    expect(climbSitemapsEnabled()).toBe(false);
+  });
+});

--- a/packages/web/app/lib/seo/sitemap/__tests__/shard-route-handler.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/shard-route-handler.test.ts
@@ -123,6 +123,7 @@ let errors: string[] = [];
 let warnings: string[] = [];
 
 beforeEach(() => {
+  vi.stubEnv('CLIMB_SITEMAPS_ENABLED', 'true');
   errors = [];
   warnings = [];
   vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {

--- a/packages/web/app/lib/seo/sitemap/climb-sitemaps-enabled.ts
+++ b/packages/web/app/lib/seo/sitemap/climb-sitemaps-enabled.ts
@@ -1,0 +1,11 @@
+import 'server-only';
+
+/**
+ * Climb sitemaps are paused by default because publishing roughly 53,000 climb
+ * URLs created the crawler-driven render and transfer spike. Keep the check
+ * strict so values such as `1`, `TRUE`, or an unset variable cannot enable the
+ * surface accidentally.
+ */
+export function climbSitemapsEnabled(): boolean {
+  return process.env.CLIMB_SITEMAPS_ENABLED === 'true';
+}

--- a/packages/web/app/lib/seo/sitemap/climb-store.ts
+++ b/packages/web/app/lib/seo/sitemap/climb-store.ts
@@ -34,9 +34,8 @@ export const CLIMBS_SHARD_ID = 'climbs';
 
 /**
  * How old a stored answer may get before the read path starts shouting and the
- * self-heal fires. Deliberately far longer than the 6-hour cron interval: this is
- * "nobody has refreshed this in two days, the scheduler is gone", not "this is
- * slightly behind".
+ * self-heal fires. Forty-eight hours avoids treating ordinary catalogue drift as
+ * an outage while still bounding how long an enabled store can go untouched.
  */
 export const SITEMAP_CLIMB_STORE_MAX_AGE_MS = 48 * 60 * 60 * 1000;
 
@@ -239,9 +238,9 @@ let refreshInFlight: { force: boolean; run: Promise<ClimbStoreRefreshResult> } |
  * **What the lock does and does not buy.** It serialises the WRITE. It does not
  * stop two instances computing concurrently, because taking it before the compute
  * would mean holding a transaction open across it. That residual is acceptable and
- * bounded: the cron is the normal trigger and runs on one instance, the `after()`
- * self-heal is single-flighted per instance behind a 15-minute floor, and the
- * compute itself is a read-only sequential scan. The `superseded` check inside the
+ * bounded: the `after()` self-heal is single-flighted per instance behind a
+ * 15-minute floor, the manual endpoint shares the in-flight work, and the compute
+ * itself is a read-only sequential scan. The `superseded` check inside the
  * transaction means the second finisher writes nothing rather than clobbering a
  * newer answer.
  *
@@ -251,7 +250,7 @@ let refreshInFlight: { force: boolean; run: Promise<ClimbStoreRefreshResult> } |
  * bug this table exists to prevent.
  *
  * The single-flight below shares a scan only between callers that want the SAME
- * thing. A `?force=1` that piggybacked on a cron's in-flight refresh would silently
+ * thing. A `?force=1` that piggybacked on a non-force in-flight refresh would silently
  * keep the shrink guard and hand the operator back a 409 telling them to do the
  * thing they just did — which would make the escape hatch look broken exactly when
  * it is needed. So a caller whose `force` disagrees waits for the in-flight scan to
@@ -333,8 +332,8 @@ async function runRefresh(force: boolean): Promise<ClimbStoreRefreshResult> {
     // Fail closed on a collapse. A refresh that suddenly reports a third of the
     // catalogue is a regressed predicate far more often than it is a real
     // deletion, and storing it would quietly shrink the index. `?force=1` on the
-    // cron route is the way out when the shrink IS real, so the guard cannot wedge
-    // the store permanently.
+    // authenticated refresh route is the way out when the shrink IS real, so the
+    // guard cannot wedge the store permanently.
     if (!force && previousItemCount !== null && itemCount * 2 < previousItemCount) {
       console.error(
         `[sitemap] the climbs summary refresh computed ${itemCount} items, down from ${previousItemCount} — refusing to store a >50% shrink. Re-run with ?force=1 if the shrink is real.`,
@@ -514,11 +513,10 @@ let lastSelfHealAt = 0;
  * The self-heal, called from `after()` on `/sitemap.xml` once the response has
  * flushed.
  *
- * It is what keeps this fix from depending on a scheduler. A lapsed cron (the
- * Railway cutover, #3795/#3798, has to re-point all eight of them) degrades to
- * "the store is refreshed by a crawler fetch" rather than to a broken sitemap.
- * It also populates the store on the very first `/sitemap.xml` after deploy,
- * without anyone running the manual curl.
+ * It keeps the enabled surface independent of a scheduler: a missing or stale
+ * store degrades to "the store is refreshed by a crawler fetch" rather than to a
+ * permanently broken sitemap. It also populates the store on the first enabled
+ * `/sitemap.xml` request after deploy, without anyone running the manual curl.
  *
  * Never awaited by a request, never allowed to throw into one: `after()` runs
  * post-flush, so the only thing a failure here can cost is the refresh itself.
@@ -533,10 +531,10 @@ export async function refreshClimbStoreIfStale(): Promise<void> {
   try {
     const stored = await fetchStoredClimbRefresh();
     // The URL-table check is not redundant with the summary row: on the deploy
-    // that ADDS `sitemap_climb_urls`, the summary row is fresh (#4523's cron has
-    // been writing it) while the URL table sits empty — and without this check
-    // the self-heal would wait out the cron while every page request took the
-    // 51 s fallback. One `LIMIT 1` probe closes that window on the first crawl.
+    // that ADDS `sitemap_climb_urls`, an older summary row can still be fresh while
+    // the new URL table sits empty — and without this check the self-heal would
+    // wait for the age threshold while every page request took the 51 s fallback.
+    // One `LIMIT 1` probe closes that window on the first crawl.
     const staleReason = !stored
       ? 'empty'
       : now - stored.computedAt.getTime() >= SITEMAP_CLIMB_STORE_MAX_AGE_MS

--- a/packages/web/app/lib/seo/sitemap/shard-registry.ts
+++ b/packages/web/app/lib/seo/sitemap/shard-registry.ts
@@ -2,6 +2,7 @@ import 'server-only';
 import { getAllBoardConfigsOrThrow } from '@/app/lib/server-popular-configs';
 import { absoluteUrl } from '@/app/lib/seo/base-url';
 import { boardConfigsToItems } from './board-entries';
+import { climbSitemapsEnabled } from './climb-sitemaps-enabled';
 import { buildClimbShardPage, fetchClimbShardSummary, fetchStoredClimbPageLastmods } from './climb-store';
 import {
   allLocalesUrlCount,
@@ -110,6 +111,7 @@ export const CLIMB_SOURCE_HEADER = 'X-Sitemap-Climbs-Source';
  * reaches a ten-connection pool.
  */
 const CLIMB_CACHE_CONTROL = 'public, s-maxage=21600, stale-while-revalidate=604800';
+const DISABLED_CLIMB_CACHE_CONTROL = 'public, s-maxage=3600, must-revalidate';
 
 function xmlResponse(
   body: string,
@@ -137,6 +139,21 @@ function notFoundResponse(): Response {
     headers: {
       'Content-Type': 'text/plain; charset=utf-8',
       'Cache-Control': 'no-store',
+    },
+  });
+}
+
+/**
+ * A disabled climb sitemap is intentionally withdrawn, not temporarily broken.
+ * Cache the 410 for one hour so crawlers stop retrying without making a later
+ * `CLIMB_SITEMAPS_ENABLED=true` rollout wait on a long-lived edge response.
+ */
+function disabledClimbSitemapResponse(): Response {
+  return new Response('climb sitemaps are disabled', {
+    status: 410,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': DISABLED_CLIMB_CACHE_CONTROL,
     },
   });
 }
@@ -280,6 +297,8 @@ export type PagedShardSource = 'store' | 'live';
  */
 export type PagedSitemapShard = {
   id: PagedShardId;
+  /** Optional publication gate. Paged shards without one stay enabled. */
+  enabled?: () => boolean;
   /** Directory under `app/sitemaps/`, pinned against the on-disk walk. */
   routeDirectory: string;
   pagePath: (page: number) => string;
@@ -311,6 +330,7 @@ export type PagedSitemapShard = {
 export const PAGED_SHARD_REGISTRY: readonly PagedSitemapShard[] = [
   {
     id: 'climbs',
+    enabled: climbSitemapsEnabled,
     routeDirectory: 'climbs',
     pagePath: (page: number) => `/sitemaps/climbs/${page}.xml`,
     expansion: 'default-locale-only',
@@ -329,6 +349,11 @@ export const PAGED_SHARD_REGISTRY: readonly PagedSitemapShard[] = [
   },
 ];
 
+/** A future paged shard is published unless it explicitly opts into a gate. */
+export function pagedSitemapShardEnabled(shard: Pick<PagedSitemapShard, 'enabled'>): boolean {
+  return shard.enabled?.() ?? true;
+}
+
 function expandForShard(items: readonly SitemapItem[], expansion: ShardExpansion): SitemapUrlEntry[] {
   return expansion === 'all-locales' ? expandAllLocales(items) : expandDefaultLocaleOnly(items);
 }
@@ -341,6 +366,9 @@ export async function pagedShardRouteHandler(id: PagedShardId, rawPage: string):
   const shard = PAGED_SHARD_REGISTRY.find((candidate) => candidate.id === id);
   if (!shard) {
     return unavailableResponse();
+  }
+  if (!pagedSitemapShardEnabled(shard)) {
+    return disabledClimbSitemapResponse();
   }
 
   // `[1-9]\d*` and not `\d+`: `Number('007')` is 7, so a permissive parser gives
@@ -447,8 +475,8 @@ function sourceHeaders(shard: PagedSitemapShard, source: PagedShardSource | unde
  * `force-dynamic` and every CDN miss otherwise re-ran it live: the uncached boards
  * fetch took ~10 s cold and deterministically lost its shard on the first request
  * after a deploy (#4519). The climbs summary is no longer cached-expensive but
- * PRECOMPUTED: one row of `sitemap_shard_refreshes`, written by a cron and an
- * `after()` self-heal, because caching an expensive question only moves when you
+ * PRECOMPUTED: one row of `sitemap_shard_refreshes`, written by the authenticated
+ * refresh endpoint or an `after()` self-heal, because caching an expensive question only moves when you
  * pay for it — a cold miss on sixteen sequential `DISTINCT ON` scans could never
  * meet 3 s at any cache temperature (#4523). `fetchPlaylistSitemapRows` is cached
  * like boards rather than precomputed like climbs, because its answer is small
@@ -625,9 +653,13 @@ export type SitemapIndexResult = {
  * exact harm the fail-closed rule exists to avoid.
  */
 export async function buildSitemapIndexXml(): Promise<SitemapIndexResult> {
+  // Disabled is an intentional publication choice, not a failed builder. Keep
+  // climbs out of the settled walk entirely so the index performs no store read,
+  // carries no degradation header, and keeps its normal cache window.
+  const activePagedShards = PAGED_SHARD_REGISTRY.filter(pagedSitemapShardEnabled);
   const [fixedSettled, pagedSettled] = await Promise.all([
     Promise.allSettled(SHARD_REGISTRY.map((shard) => buildIndexEntry(shard))),
-    Promise.allSettled(PAGED_SHARD_REGISTRY.map((shard) => buildPagedIndexEntries(shard))),
+    Promise.allSettled(activePagedShards.map((shard) => buildPagedIndexEntries(shard))),
   ]);
 
   const entries: SitemapIndexEntry[] = [];
@@ -653,7 +685,7 @@ export async function buildSitemapIndexXml(): Promise<SitemapIndexResult> {
   });
 
   pagedSettled.forEach((outcome, index) => {
-    const shard = PAGED_SHARD_REGISTRY[index];
+    const shard = activePagedShards[index];
     if (outcome.status === 'rejected') {
       degradedShards.push(shard.id);
       // No source header on this branch, deliberately: a rejected or timed-out
@@ -681,7 +713,7 @@ export async function buildSitemapIndexXml(): Promise<SitemapIndexResult> {
   }
 
   if (entries.length === 0) {
-    const builderCount = SHARD_REGISTRY.length + PAGED_SHARD_REGISTRY.length;
+    const builderCount = SHARD_REGISTRY.length + activePagedShards.length;
     throw new Error(
       `[sitemap] index has no shards to publish (${degradedShards.length} of ${builderCount} builders failed) — refusing to publish an empty index`,
     );

--- a/packages/web/app/lib/seo/sitemap/shard-registry.ts
+++ b/packages/web/app/lib/seo/sitemap/shard-registry.ts
@@ -111,7 +111,7 @@ export const CLIMB_SOURCE_HEADER = 'X-Sitemap-Climbs-Source';
  * reaches a ten-connection pool.
  */
 const CLIMB_CACHE_CONTROL = 'public, s-maxage=21600, stale-while-revalidate=604800';
-const DISABLED_CLIMB_CACHE_CONTROL = 'public, s-maxage=3600, must-revalidate';
+const DISABLED_PAGED_SITEMAP_CACHE_CONTROL = 'public, s-maxage=3600, must-revalidate';
 
 function xmlResponse(
   body: string,
@@ -144,16 +144,16 @@ function notFoundResponse(): Response {
 }
 
 /**
- * A disabled climb sitemap is intentionally withdrawn, not temporarily broken.
+ * A disabled paged sitemap is intentionally withdrawn, not temporarily broken.
  * Cache the 410 for one hour so crawlers stop retrying without making a later
- * `CLIMB_SITEMAPS_ENABLED=true` rollout wait on a long-lived edge response.
+ * re-enable wait on a long-lived edge response.
  */
-function disabledClimbSitemapResponse(): Response {
-  return new Response('climb sitemaps are disabled', {
+function disabledPagedSitemapResponse(id: PagedShardId): Response {
+  return new Response(`${id} sitemaps are disabled`, {
     status: 410,
     headers: {
       'Content-Type': 'text/plain; charset=utf-8',
-      'Cache-Control': DISABLED_CLIMB_CACHE_CONTROL,
+      'Cache-Control': DISABLED_PAGED_SITEMAP_CACHE_CONTROL,
     },
   });
 }
@@ -368,7 +368,7 @@ export async function pagedShardRouteHandler(id: PagedShardId, rawPage: string):
     return unavailableResponse();
   }
   if (!pagedSitemapShardEnabled(shard)) {
-    return disabledClimbSitemapResponse();
+    return disabledPagedSitemapResponse(shard.id);
   }
 
   // `[1-9]\d*` and not `\d+`: `Number('007')` is 7, so a permissive parser gives

--- a/packages/web/app/sitemap.xml/__tests__/route.test.ts
+++ b/packages/web/app/sitemap.xml/__tests__/route.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
+
+const deferred = vi.hoisted(() => ({
+  callbacks: [] as Array<() => void | Promise<void>>,
+  climbRefreshCalls: 0,
+  playlistWarmCalls: 0,
+}));
+
+vi.mock('next/server', () => ({
+  after: (callback: () => void | Promise<void>) => {
+    deferred.callbacks.push(callback);
+  },
+}));
+
+vi.mock('@/app/lib/seo/sitemap/climb-store', () => ({
+  refreshClimbStoreIfStale: async () => {
+    deferred.climbRefreshCalls += 1;
+  },
+}));
+
+vi.mock('@/app/lib/seo/sitemap/playlist-query', () => ({
+  warmPlaylistSitemapCache: async () => {
+    deferred.playlistWarmCalls += 1;
+  },
+}));
+
+vi.mock('@/app/lib/seo/sitemap/shard-registry', () => ({
+  sitemapIndexRouteHandler: async () => new Response('<sitemapindex/>', { status: 200 }),
+}));
+
+const routeModule = await import('../route');
+
+beforeEach(() => {
+  deferred.callbacks = [];
+  deferred.climbRefreshCalls = 0;
+  deferred.playlistWarmCalls = 0;
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('GET /sitemap.xml deferred refreshes', () => {
+  it('does not schedule the climb refresh when climb sitemaps are disabled', async () => {
+    vi.stubEnv('CLIMB_SITEMAPS_ENABLED', 'false');
+
+    const response = await routeModule.GET();
+
+    expect(response.status).toBe(200);
+    expect(deferred.callbacks).toHaveLength(1);
+    await deferred.callbacks[0]();
+    expect(deferred.climbRefreshCalls).toBe(0);
+    expect(deferred.playlistWarmCalls).toBe(1);
+  });
+
+  it('keeps both deferred refreshes when the switch is exactly true', async () => {
+    vi.stubEnv('CLIMB_SITEMAPS_ENABLED', 'true');
+
+    await routeModule.GET();
+
+    expect(deferred.callbacks).toHaveLength(2);
+    await Promise.all(deferred.callbacks.map((callback) => Promise.resolve(callback())));
+    expect(deferred.climbRefreshCalls).toBe(1);
+    expect(deferred.playlistWarmCalls).toBe(1);
+  });
+});

--- a/packages/web/app/sitemap.xml/route.ts
+++ b/packages/web/app/sitemap.xml/route.ts
@@ -1,4 +1,5 @@
 import { after } from 'next/server';
+import { climbSitemapsEnabled } from '@/app/lib/seo/sitemap/climb-sitemaps-enabled';
 import { refreshClimbStoreIfStale } from '@/app/lib/seo/sitemap/climb-store';
 import { warmPlaylistSitemapCache } from '@/app/lib/seo/sitemap/playlist-query';
 import { sitemapIndexRouteHandler } from '@/app/lib/seo/sitemap/shard-registry';
@@ -36,14 +37,16 @@ export async function GET(): Promise<Response> {
   // `refreshClimbStoreIfStale` no-ops cheaply on a fresh store and is
   // single-flighted behind a 15-minute floor per instance.
   //
-  // It is what makes the fix scheduler-independent: a cron the Railway cutover
-  // (#3795/#3798) forgets to re-point degrades to "healed by the next crawl"
-  // rather than to a sitemap that quietly goes back to dropping the shard.
+  // It keeps the enabled surface scheduler-independent: a missing or stale store
+  // degrades to "healed by the next crawl" rather than to a sitemap that quietly
+  // goes back to dropping the shard.
   //
   // `after` from 'next/server', never `waitUntil` from '@vercel/functions' — Next
   // 16.2 supplies a real awaiter on self-hosted Node too, and the Vercel-only
   // import would not survive the move off Vercel.
-  after(refreshClimbStoreIfStale);
+  if (climbSitemapsEnabled()) {
+    after(refreshClimbStoreIfStale);
+  }
 
   // Same slot, same reason, different shard. The playlists rows are cached rather
   // than stored (#4524), and a first-population `unstable_cache` miss registers

--- a/packages/web/vercel.json
+++ b/packages/web/vercel.json
@@ -38,10 +38,6 @@
     {
       "path": "/api/internal/cleanup",
       "schedule": "0 5 * * *"
-    },
-    {
-      "path": "/api/internal/refresh-sitemap-climbs",
-      "schedule": "0 */6 * * *"
     }
   ]
 }

--- a/scripts/production-smoke.test.ts
+++ b/scripts/production-smoke.test.ts
@@ -41,6 +41,7 @@ describe('www production smoke checks', () => {
         '/',
         '/robots.txt',
         '/sitemap.xml',
+        '/sitemaps/climbs/1.xml',
         // Both `expectsUrls` shard routes get a check of their own. `boards.xml`
         // in particular is the only hard signal left on the boards surface once
         // the index check can excuse a declared degradation.
@@ -90,7 +91,6 @@ describe('www production smoke checks', () => {
       '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
       '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
       '<sitemap><loc>https://www.boardsesh.com/sitemaps/playlists.xml</loc></sitemap>' +
-      '<sitemap><loc>https://www.boardsesh.com/sitemaps/climbs/1.xml</loc></sitemap>' +
       '</sitemapindex>';
     expect(check.assert(response({ contentType: 'application/xml', body: healthyIndex }))).toBeNull();
 
@@ -102,21 +102,8 @@ describe('www production smoke checks', () => {
       '<sitemapindex>' +
       '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
       '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
-      '<sitemap><loc>https://www.boardsesh.com/sitemaps/climbs/1.xml</loc></sitemap>' +
       '</sitemapindex>';
     expect(check.assert(response({ contentType: 'application/xml', body: withoutPlaylists }))).toMatch(/playlists/);
-
-    // #4552: `climbs` is required too — ~52,000 URLs across six pages, the
-    // largest surface on the site, and the shard this check was blind to while
-    // its summary could not meet the deadline. Silently missing page 1 is a
-    // failure now.
-    const withoutClimbs =
-      '<sitemapindex>' +
-      '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
-      '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
-      '<sitemap><loc>https://www.boardsesh.com/sitemaps/playlists.xml</loc></sitemap>' +
-      '</sitemapindex>';
-    expect(check.assert(response({ contentType: 'application/xml', body: withoutClimbs }))).toMatch(/climbs/);
 
     // The regression this check has to keep catching after #4476. The index now
     // degrades rather than 503ing, so a cold-start failure of the boards builder
@@ -154,7 +141,7 @@ describe('www production smoke checks', () => {
     const withoutBoards = response({
       contentType: 'application/xml',
       body: '<sitemapindex><sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap></sitemapindex>',
-      headers: { 'x-sitemap-degraded': 'boards,playlists,climbs' },
+      headers: { 'x-sitemap-degraded': 'boards,playlists' },
     });
     expect(check.assert(withoutBoards)).toBeNull();
     // Names the shards, so the annotation is actionable without opening the site.
@@ -182,15 +169,14 @@ describe('www production smoke checks', () => {
         '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
         '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
         '</sitemapindex>',
-      headers: { 'x-sitemap-degraded': 'playlists,climbs' },
+      headers: { 'x-sitemap-degraded': 'playlists' },
     });
     expect(check.assert(declaredDegradable)).toBeNull();
-    expect(check.degradation?.(declaredDegradable)).toMatch(/playlists, climbs/);
+    expect(check.degradation?.(declaredDegradable)).toMatch(/playlists/);
     expect(check.degradation?.(declaredDegradable)).toMatch(/required playlists/);
 
     // A shard this list does not require at all is worth a warning but is not a
-    // missing mandatory, so nothing is flagged as required. (`climbs` moved to
-    // the required list in #4552; `gyms` is the remaining genuinely optional one.)
+    // missing mandatory, so nothing is flagged as required.
     const optionalOnly = response({
       contentType: 'application/xml',
       body:
@@ -198,7 +184,6 @@ describe('www production smoke checks', () => {
         '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
         '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
         '<sitemap><loc>https://www.boardsesh.com/sitemaps/playlists.xml</loc></sitemap>' +
-        '<sitemap><loc>https://www.boardsesh.com/sitemaps/climbs/1.xml</loc></sitemap>' +
         '</sitemapindex>',
       headers: { 'x-sitemap-degraded': 'gyms' },
     });
@@ -208,7 +193,7 @@ describe('www production smoke checks', () => {
 
     // The header can never rescue a genuinely broken index: a non-200, a body
     // that is not a `<sitemapindex>`, or one that resolved nothing at all.
-    const degradedHeader = { 'x-sitemap-degraded': 'boards,playlists,climbs' };
+    const degradedHeader = { 'x-sitemap-degraded': 'boards,playlists' };
     expect(
       check.assert(response({ status: 503, contentType: 'application/xml', body: '', headers: degradedHeader })),
     ).toMatch(/503/);
@@ -240,68 +225,61 @@ describe('www production smoke checks', () => {
         '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
         '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
         '<sitemap><loc>https://www.boardsesh.com/sitemaps/playlists.xml</loc></sitemap>' +
-        '<sitemap><loc>https://www.boardsesh.com/sitemaps/climbs/1.xml</loc></sitemap>' +
         '</sitemapindex>',
     });
     expect(check.degradation?.(healthy) ?? null).toBeNull();
   });
 
-  it('warns when the climbs shard is served from the live scan rather than the store', () => {
-    // The gap `x-sitemap-degraded` structurally cannot see (#4583). An empty or
-    // unreadable store still produces a complete, correct index, so the body has
-    // every `<loc>` and no shard is declared dropped — while each
-    // `/sitemaps/climbs/N.xml` behind it rebuilds the whole ordered list. That is
-    // the shape the climbs shard sat in from W-23 until #4661.
+  it('fails if production exposes any climb sitemap publication signal', () => {
     const check = checkNamed('sitemap index');
-    const completeIndex =
+    const pausedIndex =
       '<sitemapindex>' +
       '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
       '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
       '<sitemap><loc>https://www.boardsesh.com/sitemaps/playlists.xml</loc></sitemap>' +
-      '<sitemap><loc>https://www.boardsesh.com/sitemaps/climbs/1.xml</loc></sitemap>' +
       '</sitemapindex>';
-
-    const liveSource = response({
-      contentType: 'application/xml',
-      body: completeIndex,
-      headers: { 'x-sitemap-climbs-source': 'live' },
-    });
-    // A WARN, never a FAIL: the index it just validated is complete either way.
-    expect(check.assert(liveSource)).toBeNull();
-    expect(check.degradation?.(liveSource)).toMatch(/live scan/);
-    expect(check.degradation?.(liveSource)).toMatch(/refresh-sitemap-climbs/);
-
-    // The fast path says nothing.
     expect(
-      check.degradation?.(
+      check.assert(
         response({
           contentType: 'application/xml',
-          body: completeIndex,
+          body: pausedIndex.replace(
+            '</sitemapindex>',
+            '<sitemap><loc>https://www.boardsesh.com/sitemaps/climbs/1.xml</loc></sitemap></sitemapindex>',
+          ),
+        }),
+      ),
+    ).toMatch(/still publishes/);
+    expect(
+      check.assert(
+        response({
+          contentType: 'application/xml',
+          body: pausedIndex,
           headers: { 'x-sitemap-climbs-source': 'store' },
         }),
-      ) ?? null,
-    ).toBeNull();
+      ),
+    ).toMatch(/source/);
+    expect(
+      check.assert(
+        response({
+          contentType: 'application/xml',
+          body: pausedIndex,
+          headers: { 'x-sitemap-degraded': 'climbs' },
+        }),
+      ),
+    ).toMatch(/intentional/);
+  });
 
-    // Neither does an absent header — a deploy that predates it, or a summary
-    // that lost the 3 s race and never reported a path. The `x-sitemap-degraded`
-    // branch already covers the second one, and inventing a finding from silence
-    // would make every older deployment warn.
-    expect(check.degradation?.(response({ contentType: 'application/xml', body: completeIndex })) ?? null).toBeNull();
-
-    // Both signals at once read as both reasons, not one swallowing the other.
-    const bothWrong = response({
-      contentType: 'application/xml',
-      body:
-        '<sitemapindex>' +
-        '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
-        '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
-        '<sitemap><loc>https://www.boardsesh.com/sitemaps/climbs/1.xml</loc></sitemap>' +
-        '</sitemapindex>',
-      headers: { 'x-sitemap-degraded': 'playlists', 'x-sitemap-climbs-source': 'live' },
+  it('requires a cacheable 410 from the paused climb shard', () => {
+    const check = checkNamed('paused climb sitemap shard');
+    const healthy = response({
+      status: 410,
+      contentType: 'text/plain; charset=utf-8',
+      body: 'climb sitemaps are disabled',
+      headers: { 'cache-control': 'public, s-maxage=3600, must-revalidate' },
     });
-    expect(check.assert(bothWrong)).toBeNull();
-    expect(check.degradation?.(bothWrong)).toMatch(/playlists/);
-    expect(check.degradation?.(bothWrong)).toMatch(/live scan/);
+    expect(check.assert(healthy)).toBeNull();
+    expect(check.assert({ ...healthy, status: 200 })).toMatch(/410/);
+    expect(check.assert({ ...healthy, headers: { 'cache-control': 'no-store' } })).toMatch(/cache-control/);
   });
 
   it('rejects an empty static sitemap shard', () => {

--- a/scripts/production-smoke.ts
+++ b/scripts/production-smoke.ts
@@ -150,18 +150,13 @@ const MIN_RENDERED_PAGE_CHARS = 4_000;
 const SITEMAP_DEGRADED_HEADER = 'x-sitemap-degraded';
 
 /**
- * The header `sitemapIndexRouteHandler` sets naming which path served the climbs
- * shard: `store` (the materialised `sitemap_climb_urls` / `sitemap_shard_refreshes`
- * read) or `live` (the scan they replaced).
- *
- * `X-Sitemap-Degraded` cannot see this. A store that is empty or unreadable still
- * produces a complete, correct index — the live scan is the documented fallback —
- * so the shard keeps its `<loc>` and nothing here goes red, while every
- * `/sitemaps/climbs/N.xml` behind it rebuilds the whole ordered list at 51 s a
- * page. That is the shape #4583 sat in from W-23 until #4661, unnoticed, so it
- * gets its own signal.
+ * This header must be absent while climb sitemap publication is paused. Checking
+ * it alongside the body catches a partial re-enable where the paged shard still
+ * runs but its `<loc>` is missing from the index.
  */
 const SITEMAP_CLIMBS_SOURCE_HEADER = 'x-sitemap-climbs-source';
+const CLIMB_SITEMAP_PATH_PREFIX = '/sitemaps/climbs/';
+const DISABLED_CLIMB_CACHE_CONTROL = 'public, s-maxage=3600, must-revalidate';
 
 /**
  * Shards the index must always list.
@@ -177,16 +172,9 @@ const SITEMAP_CLIMBS_SOURCE_HEADER = 'x-sitemap-climbs-source';
  * entry can still lose the 3 s deadline once and self-heal on the `after()` warm —
  * a WARN. The shard vanishing without the header saying so is still a FAIL.
  *
- * `climbs` is required as of #4552 — before it, this list had no view of the
- * largest surface on the site. It could not be asserted earlier: its summary
- * could not meet `SHARD_DEADLINE_MS` at any cache temperature, so production
- * served the index degraded on most requests and the entry would have been a
- * permanently red check rather than a detector. #4523 made the summary a single
- * row of `sitemap_shard_refreshes`; `degradable: true` covers the residue — a
- * store empty right after the migration deploys falls back to the scan that
- * loses the deadline once, self-heals via `after()`, and names itself in the
- * header. The `<loc>` asserted is page 1, which exists whenever the shard has
- * any URLs at all.
+ * `climbs` is deliberately not required because this smoke pins the production
+ * pause: its index entries and source signals must be absent, and its direct
+ * route must return the cacheable 410 checked below.
  *
  * `degradable` is what `X-Sitemap-Degraded` may excuse. `boards` is genuinely
  * transient — a cold cache, a slow backend — and self-heals under the 60s window.
@@ -204,7 +192,6 @@ const REQUIRED_SITEMAP_SHARDS = [
   { id: 'static', loc: 'https://www.boardsesh.com/sitemaps/static.xml', degradable: false },
   { id: 'boards', loc: 'https://www.boardsesh.com/sitemaps/boards.xml', degradable: true },
   { id: 'playlists', loc: 'https://www.boardsesh.com/sitemaps/playlists.xml', degradable: true },
-  { id: 'climbs', loc: 'https://www.boardsesh.com/sitemaps/climbs/1.xml', degradable: true },
 ] as const;
 
 type RequiredSitemapShard = (typeof REQUIRED_SITEMAP_SHARDS)[number];
@@ -288,6 +275,19 @@ export const WWW_CHECKS: SmokeCheck[] = [
       if (structural) return structural;
 
       const declared = declaredDegradedShards(response);
+      const pauseFailure = firstFailure(
+        response.body.includes(CLIMB_SITEMAP_PATH_PREFIX)
+          ? `response still publishes the paused ${CLIMB_SITEMAP_PATH_PREFIX} surface`
+          : null,
+        declared.includes('climbs')
+          ? `the ${SITEMAP_DEGRADED_HEADER} header names climbs instead of treating the pause as intentional`
+          : null,
+        response.headers[SITEMAP_CLIMBS_SOURCE_HEADER]
+          ? `the paused surface emitted ${SITEMAP_CLIMBS_SOURCE_HEADER}: ${response.headers[SITEMAP_CLIMBS_SOURCE_HEADER]}`
+          : null,
+      );
+      if (pauseFailure) return pauseFailure;
+
       const unexcused = missingRequiredShards(response).filter(
         (shard) => !shard.degradable || !declared.includes(shard.id),
       );
@@ -307,21 +307,20 @@ export const WWW_CHECKS: SmokeCheck[] = [
         );
       }
 
-      // A WARN and not an `assert`, on the same reasoning the header comment
-      // gives: the served index is complete and correct either way, so this is
-      // "the fast path is not the one running", not "the sitemap is broken".
-      // A missing header is not a finding — a deploy that predates the header,
-      // or a summary that lost the 3 s race and never reported a path, both
-      // leave it absent, and the `x-sitemap-degraded` branch above already
-      // covers the second one.
-      if (response.headers[SITEMAP_CLIMBS_SOURCE_HEADER] === 'live') {
-        reasons.push(
-          `the climbs shard is being served from the live scan, not the materialised store (${SITEMAP_CLIMBS_SOURCE_HEADER}: live) — every /sitemaps/climbs/N.xml is rebuilding the whole ordered list. Run /api/internal/refresh-sitemap-climbs`,
-        );
-      }
-
       return reasons.length === 0 ? null : reasons.join('; ');
     },
+  },
+  {
+    name: 'the paused climb sitemap shard returns a cacheable Gone response',
+    path: '/sitemaps/climbs/1.xml',
+    assert: (response) =>
+      firstFailure(
+        expectStatus(response, 410),
+        expectContentType(response, 'text/plain'),
+        response.headers['cache-control'] === DISABLED_CLIMB_CACHE_CONTROL
+          ? null
+          : `expected cache-control "${DISABLED_CLIMB_CACHE_CONTROL}", got "${response.headers['cache-control'] ?? ''}"`,
+      ),
   },
   {
     name: 'the static sitemap shard serves URLs',


### PR DESCRIPTION
## Summary

- Pause climb sitemap publication by default behind strict server-only `CLIMB_SITEMAPS_ENABLED=true` opt-in. The public climb pages and their metadata remain unchanged.
- Omit climb shards from `/sitemap.xml` without store reads, return a one-hour cacheable 410 from direct shard URLs, and skip authenticated/deferred refresh work while disabled.
- Remove the Vercel refresh cron, pin the paused state in production smoke tests, and document the Railway re-enable sequence. This shuts down the crawler surface introduced in #4483 that is transferring about 12 GB daily.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. Open `/sitemap.xml` → climb shard links stay absent.
2. Open `/sitemaps/climbs/1.xml` → 410 Gone appears.
3. Open a climb page → climb content still renders.

## Risk

Risk: 2/5 — isolated SEO publication switch with focused coverage.
