### PR TITLE
fix(ci): repair sitemap smoke and asset catalog

### DIFF
--- a/packages/shared/static-assets/src/generated/catalog.json
+++ b/packages/shared/static-assets/src/generated/catalog.json
@@ -360,8 +360,12 @@
   "/images/touchstone/product_sizes_layouts_sets/1-v4.webp": "static/v1/f250480ca9c4fbf65b30db4b6582fe6f5559053a139a10562900d3ce8677d955.webp",
   "/images/touchstone/product_sizes_layouts_sets/thumbs/1-v2.webp": "static/v1/58cc2bc142bbef8b38b90fc2a3ee5439eaeec753a8527644a744a634ddf17c7d.webp",
   "/images/touchstone/product_sizes_layouts_sets/thumbs/1-v4.webp": "static/v1/17c6e943f8dee997d965f87ba8ef7d813d1d9a6c896a2d0c107bd871b3d21b74.webp",
+  "/images/woods/thumbs/woods-12x12-bg.dark.webp": "static/v1/c01234ccad41f61797b4abfe6bc117d86c047c62109cfff6f9374f88d897ac60.webp",
   "/images/woods/thumbs/woods-12x12-bg.webp": "static/v1/a474ff17b439f149ed15980457e9632600c01600f9e7548d85f33f805fdf2874.webp",
+  "/images/woods/thumbs/woods-8x10-bg.dark.webp": "static/v1/6d6d8e2d947ab956eb6b150f618c518af5ef8935e2f9d374b2aec0e737774063.webp",
   "/images/woods/thumbs/woods-8x10-bg.webp": "static/v1/cac8d3925ca088a3104f9ef55469679ac633f6066b563f3721f5963f384e07d7.webp",
+  "/images/woods/woods-12x12-bg.dark.webp": "static/v1/e00266ef364832ea34532a24cbbfba90f6e48e792d2e6c40b9fe649e4d43cb44.webp",
   "/images/woods/woods-12x12-bg.webp": "static/v1/597007618f0619866086afa4e4051e08a86b359210e49681056da7533295f8ce.webp",
+  "/images/woods/woods-8x10-bg.dark.webp": "static/v1/3eaa0449ed84bf901e0db5dbf58e155e8b7a183da1f6ae768d6cb4275dd6b0b3.webp",
   "/images/woods/woods-8x10-bg.webp": "static/v1/877e1d816f096bd1c759b3cfea5239b4a6a74bc37ad20c5b029d9bb2dc8366de.webp"
 }

--- a/packages/web/app/lib/seo/sitemap/__tests__/shard-route-handler.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/shard-route-handler.test.ts
@@ -147,6 +147,7 @@ afterEach(() => {
   Object.assign(playlistRows, { count: 1, shouldThrow: false, hang: false, delayMs: 0 });
   Object.assign(climbSummary, { itemCount: 25_000, shouldThrow: false, hang: false, delayMs: 0 });
   Object.assign(pureBuilders, { shouldThrow: false, hang: false, delayMs: 0 });
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
 

--- a/scripts/production-smoke.test.ts
+++ b/scripts/production-smoke.test.ts
@@ -274,8 +274,8 @@ describe('www production smoke checks', () => {
     const healthy = response({
       status: 410,
       contentType: 'text/plain; charset=utf-8',
-      body: 'climb sitemaps are disabled',
-      headers: { 'cache-control': 'public, s-maxage=3600, must-revalidate' },
+      body: 'climbs sitemaps are disabled',
+      headers: { 'cache-control': 'public, must-revalidate' },
     });
     expect(check.assert(healthy)).toBeNull();
     expect(check.assert({ ...healthy, status: 200 })).toMatch(/410/);

--- a/scripts/production-smoke.ts
+++ b/scripts/production-smoke.ts
@@ -156,7 +156,12 @@ const SITEMAP_DEGRADED_HEADER = 'x-sitemap-degraded';
  */
 const SITEMAP_CLIMBS_SOURCE_HEADER = 'x-sitemap-climbs-source';
 const CLIMB_SITEMAP_PATH_PREFIX = '/sitemaps/climbs/';
-const DISABLED_CLIMB_CACHE_CONTROL = 'public, s-maxage=3600, must-revalidate';
+/**
+ * Vercel consumes `s-maxage=3600` as its private CDN instruction and removes it
+ * from the downstream header. The route-level test pins the full header before
+ * that transformation; production smoke pins what browsers and crawlers see.
+ */
+const DISABLED_CLIMB_CLIENT_CACHE_CONTROL = 'public, must-revalidate';
 
 /**
  * Shards the index must always list.
@@ -317,9 +322,9 @@ export const WWW_CHECKS: SmokeCheck[] = [
       firstFailure(
         expectStatus(response, 410),
         expectContentType(response, 'text/plain'),
-        response.headers['cache-control'] === DISABLED_CLIMB_CACHE_CONTROL
+        response.headers['cache-control'] === DISABLED_CLIMB_CLIENT_CACHE_CONTROL
           ? null
-          : `expected cache-control "${DISABLED_CLIMB_CACHE_CONTROL}", got "${response.headers['cache-control'] ?? ''}"`,
+          : `expected cache-control "${DISABLED_CLIMB_CLIENT_CACHE_CONTROL}", got "${response.headers['cache-control'] ?? ''}"`,
       ),
   },
   {


### PR DESCRIPTION
## Summary

- Match production smoke to Vercel's client-visible cache header.
- Align the disabled response fixture and clean environment stubs.
- Verify the paused sitemap behavior against production.
- Register Woods dark board art omitted from the generated asset catalog.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. Run production smoke → all sitemap checks pass.
2. Check static assets → generated catalog is current.

## Risk

Risk: 1/5 — smoke and generated-catalog corrections only.
