### PR TITLE
fix(web): Re-gen the static assets

### DIFF
--- a/packages/shared/static-assets/src/generated/catalog.json
+++ b/packages/shared/static-assets/src/generated/catalog.json
@@ -360,8 +360,12 @@
   "/images/touchstone/product_sizes_layouts_sets/1-v4.webp": "static/v1/f250480ca9c4fbf65b30db4b6582fe6f5559053a139a10562900d3ce8677d955.webp",
   "/images/touchstone/product_sizes_layouts_sets/thumbs/1-v2.webp": "static/v1/58cc2bc142bbef8b38b90fc2a3ee5439eaeec753a8527644a744a634ddf17c7d.webp",
   "/images/touchstone/product_sizes_layouts_sets/thumbs/1-v4.webp": "static/v1/17c6e943f8dee997d965f87ba8ef7d813d1d9a6c896a2d0c107bd871b3d21b74.webp",
+  "/images/woods/thumbs/woods-12x12-bg.dark.webp": "static/v1/c01234ccad41f61797b4abfe6bc117d86c047c62109cfff6f9374f88d897ac60.webp",
   "/images/woods/thumbs/woods-12x12-bg.webp": "static/v1/a474ff17b439f149ed15980457e9632600c01600f9e7548d85f33f805fdf2874.webp",
+  "/images/woods/thumbs/woods-8x10-bg.dark.webp": "static/v1/6d6d8e2d947ab956eb6b150f618c518af5ef8935e2f9d374b2aec0e737774063.webp",
   "/images/woods/thumbs/woods-8x10-bg.webp": "static/v1/cac8d3925ca088a3104f9ef55469679ac633f6066b563f3721f5963f384e07d7.webp",
+  "/images/woods/woods-12x12-bg.dark.webp": "static/v1/e00266ef364832ea34532a24cbbfba90f6e48e792d2e6c40b9fe649e4d43cb44.webp",
   "/images/woods/woods-12x12-bg.webp": "static/v1/597007618f0619866086afa4e4051e08a86b359210e49681056da7533295f8ce.webp",
+  "/images/woods/woods-8x10-bg.dark.webp": "static/v1/3eaa0449ed84bf901e0db5dbf58e155e8b7a183da1f6ae768d6cb4275dd6b0b3.webp",
   "/images/woods/woods-8x10-bg.webp": "static/v1/877e1d816f096bd1c759b3cfea5239b4a6a74bc37ad20c5b029d9bb2dc8366de.webp"
 }


### PR DESCRIPTION
## Summary

<!-- What this change does and why. Link the issue it closes (Closes #123). -->

## Release Notes

<!--
The line(s) below ship to users in the mobile "What's New" screen.

Write in climber voice. Describe what the user gets, not what the feature does:
  - "Resume a session right where you left off"  (good)
  - "Added session-resume state to the queue reducer"  (too internal)

One short line per user-facing change. The first line is the headline; any extra
lines fill in the detail. Keep it to what someone would actually notice.

Nothing user-facing (refactor, CI, deps, tests)? Tick the checkbox below instead
(or add the `skip-changelog` label). Leaving this section blank fails CI.
-->

- [ ] No release note needed (internal / technical change)

## Test plan

<!--
A tester reads this on their phone, in 5 minutes, with ADHD. Testers pick this PR
in the Boardsesh app and see these steps word for word.
  - 1 to 5 numbered steps. One action, then what they should see. 12 words or fewer.
  - Name the screen: "You tab → Log a tick → note field grows to 8 lines".
  - Needs a board, Bluetooth, or a signed-in account? Say so in step 1.
  - Internal-only change (CI, deps, refactor)? "1. CI green." is a valid plan.
Leaving this empty fails CI (`pr-test-plan`). Maintainers can add `skip-qa-gate`.
-->

1.

## Risk

<!--
One line: `Risk: N/5 — why`. Testers see the score next to the PR.
  1  docs, CI, deps, copy
  2  isolated UI or logic with tests
  3  new screen, shared package, backend resolver
  4  data writes, offline sync, auth-adjacent, publish pipeline
  5  BLE, OTA/native config, migrations with backfill (BLE also needs a Fable review)
-->

Risk: /5 —
