### PR TITLE
fix(web): Disable post deploy smoke test

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -458,25 +458,25 @@ jobs:
           echo "Deployment URL: $URL"
           echo "url=$URL" >> "$GITHUB_OUTPUT"
 
-      - name: Post-deploy smoke against www.boardsesh.com
-        # Skipped when a rollback is pinned: `--skip-domain` means this deploy
-        # is uploaded but NOT serving, so www is still the rolled-back build.
-        # Smoking it would report on a deployment this job did not promote.
-        #
-        # This runs AFTER the deploy, so it is a detector, not a gate — it can
-        # turn the job red (and fire notify-failure) but can never block a
-        # deploy from going out. That asymmetry is deliberate: a fail-closed
-        # deploy gate stopped production deploys for two days once already.
-        if: needs.check-rollback.outputs.active != 'true'
-        env:
-          SMOKE_KIOSK_GYM_SLUG: ${{ vars.SMOKE_KIOSK_GYM_SLUG }}
-          SMOKE_EMBED_BOARD_UUID: ${{ vars.SMOKE_EMBED_BOARD_UUID }}
-        # Bun executes the TypeScript directly — no `bunx`, no `tsx`, nothing
-        # fetched at deploy time. `vp run smoke:production` is the same script
-        # and is how to run it by hand, but no deploy job has vp, and
-        # curl-installing the toolchain here would put a network dependency on
-        # the production deploy path that could red a deploy that shipped fine.
-        run: bun scripts/production-smoke.ts
+      # - name: Post-deploy smoke against www.boardsesh.com
+      #   # Skipped when a rollback is pinned: `--skip-domain` means this deploy
+      #   # is uploaded but NOT serving, so www is still the rolled-back build.
+      #   # Smoking it would report on a deployment this job did not promote.
+      #   #
+      #   # This runs AFTER the deploy, so it is a detector, not a gate — it can
+      #   # turn the job red (and fire notify-failure) but can never block a
+      #   # deploy from going out. That asymmetry is deliberate: a fail-closed
+      #   # deploy gate stopped production deploys for two days once already.
+      #   if: needs.check-rollback.outputs.active != 'true'
+      #   env:
+      #     SMOKE_KIOSK_GYM_SLUG: ${{ vars.SMOKE_KIOSK_GYM_SLUG }}
+      #     SMOKE_EMBED_BOARD_UUID: ${{ vars.SMOKE_EMBED_BOARD_UUID }}
+      #   # Bun executes the TypeScript directly — no `bunx`, no `tsx`, nothing
+      #   # fetched at deploy time. `vp run smoke:production` is the same script
+      #   # and is how to run it by hand, but no deploy job has vp, and
+      #   # curl-installing the toolchain here would put a network dependency on
+      #   # the production deploy path that could red a deploy that shipped fine.
+      #   run: bun scripts/production-smoke.ts
 
   deploy-production-backend:
     needs: [detect-changes, check-rollback, build-backend, migrate]


### PR DESCRIPTION
## Summary

<!-- What this change does and why. Link the issue it closes (Closes #123). -->

## Release Notes

<!--
The line(s) below ship to users in the mobile "What's New" screen.

Write in climber voice. Describe what the user gets, not what the feature does:
  - "Resume a session right where you left off"  (good)
  - "Added session-resume state to the queue reducer"  (too internal)

One short line per user-facing change. The first line is the headline; any extra
lines fill in the detail. Keep it to what someone would actually notice.

Nothing user-facing (refactor, CI, deps, tests)? Tick the checkbox below instead
(or add the `skip-changelog` label). Leaving this section blank fails CI.
-->

- [ ] No release note needed (internal / technical change)

## Test plan

<!--
A tester reads this on their phone, in 5 minutes, with ADHD. Testers pick this PR
in the Boardsesh app and see these steps word for word.
  - 1 to 5 numbered steps. One action, then what they should see. 12 words or fewer.
  - Name the screen: "You tab → Log a tick → note field grows to 8 lines".
  - Needs a board, Bluetooth, or a signed-in account? Say so in step 1.
  - Internal-only change (CI, deps, refactor)? "1. CI green." is a valid plan.
Leaving this empty fails CI (`pr-test-plan`). Maintainers can add `skip-qa-gate`.
-->

1.

## Risk

<!--
One line: `Risk: N/5 — why`. Testers see the score next to the PR.
  1  docs, CI, deps, copy
  2  isolated UI or logic with tests
  3  new screen, shared package, backend resolver
  4  data writes, offline sync, auth-adjacent, publish pipeline
  5  BLE, OTA/native config, migrations with backfill (BLE also needs a Fable review)
-->

Risk: /5 —
