### PR TITLE
feat(mobile): admin hold outline editor with Apple Pencil support

### DIFF
--- a/docs/board-art-geometry.md
+++ b/docs/board-art-geometry.md
@@ -183,6 +183,35 @@ under a concave underside) miss their own centre by up to 0.03 radii, and a stri
 would make exactly those holds un-correctable. The failure it exists to catch is a ring
 drawn around the NEIGHBOURING hold, which sits ~2 radii away.
 
+### The editor that writes them
+
+The rows are drawn by hand in the Expo app, on two admin-only routes under the profile
+stack: `app/(tabs)/profile/outline-editor.tsx` picks a board, layout and size, and
+`outline-canvas.tsx` opens the board with every placement's outline drawn over it —
+traced, overridden, missing, and a ghost of the shard outline still sitting under a
+differing override. The entry point is More → Development → Hold Outlines, gated
+`__DEV__ || isAdmin`; both routes re-check that themselves, because a deep link reaches
+them directly. The implementation lives in `packages/mobile/src/components/outline-editor/`.
+
+Drawing is Apple-Pencil-first. The stroke surface only claims a touch when the pointer is a
+stylus — or when the finger-draw toggle is on — so a finger still pans and pinches the
+zoomed board mid-edit. v1 is freehand redraw plus revert; there is no vertex dragging, on
+the grounds that a whole silhouette is quicker to re-trace with a pencil than to nudge point
+by point, and the tracer's decimation runs over the result either way.
+
+Its coordinate chain is pure and tested (`outline-editor/stroke.ts`): invert the board's
+zoom transform, scale render px to board px, decimate with `simplifyRing` at
+`SIMPLIFY_EPSILON_BOARD_PX` **while still in board pixels**, and only then divide through by
+the placement radius. Two details are parity, not preference, and will silently diverge if
+either side changes alone: the ring is rounded BEFORE it is implicitly closed
+(`closeRing(roundRing(...))`, the resolver's order — rounding can newly equate a head and
+tail), and the centre gate is the same softened `pointInRing` OR `CENTRE_TOLERANCE_RADII`
+test, so the editor never rejects a ring the backend would have taken.
+
+A revert deletes the row immediately, but the deployed shard keeps its old traced outline
+until the next export, so what a corrected hold renders as in the meantime is the shard's
+version. The toolbar says so.
+
 ## Regenerating
 
 ```bash

--- a/packages/mobile/app/(tabs)/profile/_layout.tsx
+++ b/packages/mobile/app/(tabs)/profile/_layout.tsx
@@ -42,6 +42,10 @@ export default function ProfileLayout() {
         <Stack.Screen name="dev-offline-writes" options={{ title: 'Offline Writes' }} />
         {/* i18n-ignore-next-line — tester-only screen */}
         <Stack.Screen name="sentry-diagnostics" options={{ title: 'Sentry Diagnostics' }} />
+        {/* i18n-ignore-next-line — admin-only screen */}
+        <Stack.Screen name="outline-editor" options={{ title: 'Hold Outlines' }} />
+        {/* i18n-ignore-next-line — admin-only screen */}
+        <Stack.Screen name="outline-canvas" options={{ title: 'Outline Editor' }} />
         <Stack.Screen name="delete-account" options={{ title: tSettings('deleteAccount.title') }} />
       </Stack>
     </BoardArtVisibilityProvider>

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -822,7 +822,9 @@ export default function MoreScreen() {
         label: 'Hold Outlines',
         // i18n-ignore-next-line
         subtitle: 'Redraw a traced hold silhouette, or annotate its LED ring',
-        icon: 'featureFlags',
+        // Board-look, not featureFlags: this row edits how the board is DRAWN,
+        // and the two dev rows above it already carry the flag icon.
+        icon: 'boardLook',
         onPress: navAction(() => router.push('/(tabs)/profile/outline-editor')),
       });
     }

--- a/packages/mobile/app/(tabs)/profile/more.tsx
+++ b/packages/mobile/app/(tabs)/profile/more.tsx
@@ -11,7 +11,7 @@ import { useLocalePreference } from '../../../src/providers/i18n-provider';
 import { resolveLanguage, type LocaleOverride } from '../../../src/lib/i18n/locale-preference';
 import { openExternalUrl } from '../../../src/lib/open-url';
 import { useConfirmSignOut } from '../../../src/hooks/use-confirm-sign-out';
-import { useProfile, useMyBoards } from '../../../src/lib/graphql/hooks';
+import { useProfile, useMyBoards, useIsAdmin } from '../../../src/lib/graphql/hooks';
 import { useBoardDownloads } from '../../../src/offline/use-board-downloads';
 import { isOfflineEngineEnabled } from '../../../src/lib/offline-engine';
 import { useOfflineSchemaReady } from '../../../src/db/use-offline-schema-ready';
@@ -81,6 +81,9 @@ export default function MoreScreen() {
   const { t: tNotifications } = useTranslation('notifications');
   const confirmSignOut = useConfirmSignOut();
   const { data: profile } = useProfile();
+  // Its own query, deliberately not a field on the profile document — see
+  // useIsAdmin. Fails closed, so an older backend just hides the admin rows.
+  const { isAdmin } = useIsAdmin();
   const { gradeFormat, setGradeFormat } = useGradeFormat();
   const { localePreference, setLocalePreference } = useLocalePreference();
   const { enabled: sessionRecordingEnabled, setEnabled: setSessionRecordingPreference } =
@@ -234,11 +237,18 @@ export default function MoreScreen() {
   // shapes, inspect the outbox). Same audience as the flag overrides.
   const showOfflineWrites = __DEV__ || Boolean(profile?.isTester);
 
+  // The hold-outline editor rewrites the silhouettes every climber's board
+  // renders, so it's admin-only rather than tester-only. `isAdmin` rides its own
+  // small query (useIsAdmin) which fails closed, so a backend that predates the
+  // field simply doesn't show the row.
+  const showOutlineEditor = __DEV__ || isAdmin;
+
   // Don't render an empty "Development" section header when no tool applies.
   // Store-build previews now use xprem's everyone-facing blue edge marker, so
   // the retired OTA channel switcher is no longer listed here.
   const showDevSection =
-    (__DEV__ || Boolean(profile?.isTester)) && (showDevServerSwitcher || showFeatureFlags || showOfflineWrites);
+    (__DEV__ || Boolean(profile?.isTester) || isAdmin) &&
+    (showDevServerSwitcher || showFeatureFlags || showOfflineWrites || showOutlineEditor);
 
   // 'System' follows the device language; the rest are the supported locales,
   // labelled in their own script (English / Español / Français) from
@@ -802,6 +812,18 @@ export default function MoreScreen() {
         subtitle: 'Open the tester PR picker; surfing itself only works in a store build',
         icon: 'otaChannel',
         onPress: navAction(() => router.push('/qa/pick?prNumbers=1')),
+      });
+    }
+    if (showOutlineEditor) {
+      devRows.push({
+        kind: 'nav',
+        key: 'outlineEditor',
+        // i18n-ignore-next-line — admin-only dev tooling
+        label: 'Hold Outlines',
+        // i18n-ignore-next-line
+        subtitle: 'Redraw a traced hold silhouette, or annotate its LED ring',
+        icon: 'featureFlags',
+        onPress: navAction(() => router.push('/(tabs)/profile/outline-editor')),
       });
     }
     if (profile?.isTester) {

--- a/packages/mobile/app/(tabs)/profile/outline-canvas.tsx
+++ b/packages/mobile/app/(tabs)/profile/outline-canvas.tsx
@@ -1,0 +1,42 @@
+import { useLocalSearchParams } from 'expo-router';
+import { SUPPORTED_BOARDS, type BoardName } from '@boardsesh/shared-schema';
+import { OutlineCanvasScreen } from '../../../src/components/outline-editor/OutlineCanvasScreen';
+import { OutlineEditorGate } from '../../../src/components/outline-editor/OutlineEditorGate';
+import { OutlineEditorMessage } from '../../../src/components/outline-editor/OutlineEditorMessage';
+
+type Params = {
+  boardName?: string;
+  layoutId?: string;
+  sizeId?: string;
+  setIds?: string;
+};
+
+function isBoardName(value: string | undefined): value is BoardName {
+  return value != null && (SUPPORTED_BOARDS as readonly string[]).includes(value);
+}
+
+export default function OutlineCanvasRoute() {
+  const params = useLocalSearchParams<Params>();
+  const layoutId = Number(params.layoutId ?? NaN);
+  const sizeId = Number(params.sizeId ?? NaN);
+
+  // A hand-built deep link can land here with anything in the query string, so
+  // validate before handing the config to the geometry lookup.
+  const paramsAreValid = isBoardName(params.boardName) && Number.isFinite(layoutId) && Number.isFinite(sizeId);
+
+  return (
+    <OutlineEditorGate>
+      {paramsAreValid && isBoardName(params.boardName) ? (
+        <OutlineCanvasScreen
+          boardName={params.boardName}
+          layoutId={layoutId}
+          sizeId={sizeId}
+          setIds={params.setIds ?? ''}
+        />
+      ) : (
+        // i18n-ignore-next-line — admin-only screen
+        <OutlineEditorMessage message="That link doesn't name a board configuration. Pick one from the editor list." />
+      )}
+    </OutlineEditorGate>
+  );
+}

--- a/packages/mobile/app/(tabs)/profile/outline-editor.tsx
+++ b/packages/mobile/app/(tabs)/profile/outline-editor.tsx
@@ -1,0 +1,10 @@
+import { OutlineEditorPickerScreen } from '../../../src/components/outline-editor/OutlineEditorPickerScreen';
+import { OutlineEditorGate } from '../../../src/components/outline-editor/OutlineEditorGate';
+
+export default function OutlineEditorRoute() {
+  return (
+    <OutlineEditorGate>
+      <OutlineEditorPickerScreen />
+    </OutlineEditorGate>
+  );
+}

--- a/packages/mobile/src/components/outline-editor/DrawStrokeOverlay.tsx
+++ b/packages/mobile/src/components/outline-editor/DrawStrokeOverlay.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, type MutableRefObject } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Gesture, GestureDetector, PointerType, type GestureType } from 'react-native-gesture-handler';
 import { runOnJS, useSharedValue, type SharedValue } from 'react-native-reanimated';
@@ -44,8 +44,14 @@ type DrawStrokeOverlayProps = {
   containerHeightSV: SharedValue<number>;
   /** Board px per render px (`boardWidth / renderWidth`). */
   boardScale: number;
-  /** The board's pinch, composed Simultaneous so 2-finger zoom survives a draw. */
-  pinchGesture: GestureType;
+  /**
+   * Ref handle on the board's pinch. Declared as a RELATION
+   * (`simultaneousWithExternalGesture`), never composed into this detector: a
+   * Gesture instance carries one RNGH handler tag, and mounting the board's
+   * pinch in a second `GestureDetector` throws "Handler with tag N already
+   * exists" and drops the handler the board still owns when this unmounts.
+   */
+  pinchRef: MutableRefObject<GestureType | undefined>;
   /** Fired once when a stroke actually starts — the screen uses it to stop hold taps. */
   onStrokeStart: () => void;
   /** Fired once at stroke end with the whole stroke in board px. */
@@ -63,6 +69,18 @@ type DrawStrokeOverlayProps = {
  * would swallow every drag and the zoomed board could no longer be repositioned
  * mid-edit; with it, a finger drag on an iPad still pans the zoomed board and a
  * two-finger pinch still zooms, while the pencil draws.
+ *
+ * The fall-through only works because this overlay is mounted INSIDE the pan
+ * overlay's view (see `renderAboveBoard` in InteractiveFilterBoard): RNGH offers
+ * a declined touch to ancestors, never to siblings drawn underneath.
+ *
+ * There is deliberately no `maxPointers(1)`. A palm resting on the glass is
+ * normal Apple Pencil posture, and capping the pointer count would cancel the
+ * stroke the moment it landed. Once a stroke is live, later touches are ignored
+ * outright rather than allowed to start or fail one. The cost is that Pan
+ * reports the CENTROID of all active pointers, so a palm iPadOS fails to reject
+ * can drag the sampled point — a real-device QA item, not something a simulator
+ * can show.
  *
  * Samples are converted to board px on the UI thread — the worklet twin of
  * `screenToBoardPoint` in `stroke.ts`, inlined because reanimated can't reliably
@@ -82,7 +100,7 @@ export const DrawStrokeOverlay = React.memo(function DrawStrokeOverlay({
   containerWidthSV,
   containerHeightSV,
   boardScale,
-  pinchGesture,
+  pinchRef,
   onStrokeStart,
   onStrokeEnd,
   onStrokeCancel,
@@ -91,6 +109,9 @@ export const DrawStrokeOverlay = React.memo(function DrawStrokeOverlay({
   // have to be a gesture dependency, and rebuilding a live RNGH gesture
   // mid-session has wedged iOS before (see use-zoom-pan-gesture).
   const boardScaleSV = useSharedValue(boardScale);
+  // True between activation and finalize. Lives on the UI thread because the
+  // activation worklet has to read it on the very next touch-down.
+  const isDrawingSV = useSharedValue(false);
   useEffect(() => {
     boardScaleSV.value = boardScale;
   }, [boardScale, boardScaleSV]);
@@ -105,11 +126,14 @@ export const DrawStrokeOverlay = React.memo(function DrawStrokeOverlay({
   const gesture = useMemo(() => {
     const pan = Gesture.Pan()
       .minPointers(1)
-      .maxPointers(1)
       .manualActivation(true)
       .onTouchesDown((event, manager) => {
         'worklet';
+        // A stroke is already live: a second touch (typically the palm) must
+        // neither restart nor fail it.
+        if (isDrawingSV.value) return;
         if (event.pointerType === STYLUS_POINTER_TYPE || fingerDrawSV.value) {
+          isDrawingSV.value = true;
           manager.activate();
           return;
         }
@@ -151,13 +175,16 @@ export const DrawStrokeOverlay = React.memo(function DrawStrokeOverlay({
       })
       .onFinalize((_event, success) => {
         'worklet';
+        isDrawingSV.value = false;
         if (success) return;
         runOnJS(handleCancel)();
       });
 
-    // Simultaneous with the board's pinch (the ZoneOverlay pattern) so a
-    // two-finger zoom still recognises while a finger sits on this overlay.
-    return Gesture.Simultaneous(pan, pinchGesture);
+    // A RELATION on the board's pinch, not a composition of it — so a two-finger
+    // zoom still recognises while a finger or pencil sits on this overlay,
+    // without this detector claiming the pinch's handler tag.
+    pan.simultaneousWithExternalGesture(pinchRef);
+    return pan;
     // handleStart/handleEnd/handleCancel are intentionally not deps — they're
     // captured once and read render-scoped values through callbacksRef.
   }, [
@@ -169,7 +196,8 @@ export const DrawStrokeOverlay = React.memo(function DrawStrokeOverlay({
     containerWidthSV,
     containerHeightSV,
     boardScaleSV,
-    pinchGesture,
+    isDrawingSV,
+    pinchRef,
   ]);
 
   return (

--- a/packages/mobile/src/components/outline-editor/DrawStrokeOverlay.tsx
+++ b/packages/mobile/src/components/outline-editor/DrawStrokeOverlay.tsx
@@ -1,0 +1,180 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Gesture, GestureDetector, PointerType, type GestureType } from 'react-native-gesture-handler';
+import { runOnJS, useSharedValue, type SharedValue } from 'react-native-reanimated';
+import { STROKE_MIN_SAMPLE_BOARD_PX } from './stroke';
+
+/**
+ * Pointer types that draw. Read into a module-level number so the activation
+ * worklet captures a primitive rather than the whole `PointerType` enum object.
+ */
+const STYLUS_POINTER_TYPE: number = PointerType.STYLUS;
+
+/** Squared form of the sampling gate, so the worklet needs no `Math.hypot`. */
+const MIN_SAMPLE_DISTANCE_SQUARED = STROKE_MIN_SAMPLE_BOARD_PX * STROKE_MIN_SAMPLE_BOARD_PX;
+
+/**
+ * Hard cap on one stroke's sample count (in numbers, so half this many points).
+ * A stroke is decimated to at most 150 points on commit anyway; the cap only
+ * stops a stylus left resting under a slow drift from growing the shared value
+ * without bound.
+ */
+const MAX_STROKE_NUMBERS = 4000;
+
+type DrawStrokeOverlayProps = {
+  /**
+   * The live stroke, in BOARD px, flat `[x0, y0, x1, y1, ...]`. Owned by the
+   * screen because the preview is drawn by the SVG layer INSIDE the zoom
+   * transform (so it tracks the board for free) while this overlay sits above
+   * it. Replaced wholesale on each kept sample — reanimated only reacts to a new
+   * value, not an in-place push.
+   */
+  pointsSV: SharedValue<number[]>;
+  /**
+   * True when the finger-draw toggle is on. Off (the default) only an Apple
+   * Pencil / stylus draws, and every finger touch falls through to the board's
+   * own pan and pinch.
+   */
+  fingerDrawSV: SharedValue<boolean>;
+  /** The board's live zoom transform, from `FilterBoardTransformContext`. */
+  scaleSV: SharedValue<number>;
+  translateXSV: SharedValue<number>;
+  translateYSV: SharedValue<number>;
+  containerWidthSV: SharedValue<number>;
+  containerHeightSV: SharedValue<number>;
+  /** Board px per render px (`boardWidth / renderWidth`). */
+  boardScale: number;
+  /** The board's pinch, composed Simultaneous so 2-finger zoom survives a draw. */
+  pinchGesture: GestureType;
+  /** Fired once when a stroke actually starts — the screen uses it to stop hold taps. */
+  onStrokeStart: () => void;
+  /** Fired once at stroke end with the whole stroke in board px. */
+  onStrokeEnd: (boardPoints: number[]) => void;
+  /** Fired once when a stroke is cancelled without committing. */
+  onStrokeCancel: () => void;
+};
+
+/**
+ * The Apple-Pencil draw surface: a full-bleed pan that only claims the touch
+ * when the pointer is a stylus (or the finger-draw toggle is on), and otherwise
+ * fails so the touch reaches the board underneath.
+ *
+ * That split is the whole point of `manualActivation(true)`. Without it the pan
+ * would swallow every drag and the zoomed board could no longer be repositioned
+ * mid-edit; with it, a finger drag on an iPad still pans the zoomed board and a
+ * two-finger pinch still zooms, while the pencil draws.
+ *
+ * Samples are converted to board px on the UI thread — the worklet twin of
+ * `screenToBoardPoint` in `stroke.ts`, inlined because reanimated can't reliably
+ * call a cross-module worklet (same split as `use-zoomed-hold-tap-gesture`).
+ * Absolute event coordinates, never `translationX/Y`: a delta would accumulate
+ * the zoom scale twice.
+ *
+ * `runOnJS` fires at most three times per stroke (start, end, cancel) — never
+ * per frame.
+ */
+export const DrawStrokeOverlay = React.memo(function DrawStrokeOverlay({
+  pointsSV,
+  fingerDrawSV,
+  scaleSV,
+  translateXSV,
+  translateYSV,
+  containerWidthSV,
+  containerHeightSV,
+  boardScale,
+  pinchGesture,
+  onStrokeStart,
+  onStrokeEnd,
+  onStrokeCancel,
+}: DrawStrokeOverlayProps) {
+  // Mirrored into a shared value rather than captured: a captured number would
+  // have to be a gesture dependency, and rebuilding a live RNGH gesture
+  // mid-session has wedged iOS before (see use-zoom-pan-gesture).
+  const boardScaleSV = useSharedValue(boardScale);
+  useEffect(() => {
+    boardScaleSV.value = boardScale;
+  }, [boardScale, boardScaleSV]);
+
+  const callbacksRef = useRef({ onStrokeStart, onStrokeEnd, onStrokeCancel });
+  callbacksRef.current = { onStrokeStart, onStrokeEnd, onStrokeCancel };
+  // Captured once by the gesture memo — only closes over the stable ref.
+  const handleStart = () => callbacksRef.current.onStrokeStart();
+  const handleEnd = (boardPoints: number[]) => callbacksRef.current.onStrokeEnd(boardPoints);
+  const handleCancel = () => callbacksRef.current.onStrokeCancel();
+
+  const gesture = useMemo(() => {
+    const pan = Gesture.Pan()
+      .minPointers(1)
+      .maxPointers(1)
+      .manualActivation(true)
+      .onTouchesDown((event, manager) => {
+        'worklet';
+        if (event.pointerType === STYLUS_POINTER_TYPE || fingerDrawSV.value) {
+          manager.activate();
+          return;
+        }
+        // Not a drawing pointer: hand the touch back so the board's own
+        // zoomed-pan / pinch / hold-tap gestures can have it.
+        manager.fail();
+      })
+      .onStart((event) => {
+        'worklet';
+        const centreX = containerWidthSV.value / 2;
+        const centreY = containerHeightSV.value / 2;
+        const renderX = (event.x - translateXSV.value - centreX) / scaleSV.value + centreX;
+        const renderY = (event.y - translateYSV.value - centreY) / scaleSV.value + centreY;
+        pointsSV.value = [renderX * boardScaleSV.value, renderY * boardScaleSV.value];
+        runOnJS(handleStart)();
+      })
+      .onUpdate((event) => {
+        'worklet';
+        const current = pointsSV.value;
+        const count = current.length;
+        if (count === 0 || count >= MAX_STROKE_NUMBERS) return;
+        const centreX = containerWidthSV.value / 2;
+        const centreY = containerHeightSV.value / 2;
+        const renderX = (event.x - translateXSV.value - centreX) / scaleSV.value + centreX;
+        const renderY = (event.y - translateYSV.value - centreY) / scaleSV.value + centreY;
+        const boardX = renderX * boardScaleSV.value;
+        const boardY = renderY * boardScaleSV.value;
+        const deltaX = boardX - current[count - 2];
+        const deltaY = boardY - current[count - 1];
+        // Gate the append on real movement so a resting stylus doesn't push a
+        // point (and reallocate the shared value) every frame.
+        if (deltaX * deltaX + deltaY * deltaY < MIN_SAMPLE_DISTANCE_SQUARED) return;
+        pointsSV.value = [...current, boardX, boardY];
+      })
+      .onEnd((_event, success) => {
+        'worklet';
+        if (!success) return;
+        runOnJS(handleEnd)(pointsSV.value);
+      })
+      .onFinalize((_event, success) => {
+        'worklet';
+        if (success) return;
+        runOnJS(handleCancel)();
+      });
+
+    // Simultaneous with the board's pinch (the ZoneOverlay pattern) so a
+    // two-finger zoom still recognises while a finger sits on this overlay.
+    return Gesture.Simultaneous(pan, pinchGesture);
+    // handleStart/handleEnd/handleCancel are intentionally not deps — they're
+    // captured once and read render-scoped values through callbacksRef.
+  }, [
+    pointsSV,
+    fingerDrawSV,
+    scaleSV,
+    translateXSV,
+    translateYSV,
+    containerWidthSV,
+    containerHeightSV,
+    boardScaleSV,
+    pinchGesture,
+  ]);
+
+  return (
+    <GestureDetector gesture={gesture}>
+      <View collapsable={false} style={StyleSheet.absoluteFill} />
+    </GestureDetector>
+  );
+});

--- a/packages/mobile/src/components/outline-editor/EditToolbar.tsx
+++ b/packages/mobile/src/components/outline-editor/EditToolbar.tsx
@@ -1,0 +1,182 @@
+import React, { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import type { HoldOutlineKind } from '@boardsesh/shared-schema';
+import { Text } from '../Text';
+import { Button } from '../Button';
+import { SegmentedControl } from '../SegmentedControl';
+import { SwitchRow } from '../SwitchRow';
+import { useTheme } from '../../providers/theme-provider';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { spacing } from '../../theme/tokens';
+import { OUTLINE_EDITOR_COLORS } from './OutlineSvgLayer';
+
+// Admin-only screen: every string below is a hardcoded English literal, the same
+// convention the tester-only Feature Flags / Offline Writes screens follow. No
+// catalog keys, so `check:i18n:orphans` has nothing to chase.
+
+// i18n-ignore-next-line — admin-only screen
+const KIND_OPTIONS: { key: HoldOutlineKind; label: string }[] = [
+  { key: 'SILHOUETTE', label: 'Silhouette' },
+  { key: 'LED_INNER', label: 'LED ring' },
+];
+
+type EditToolbarProps = {
+  editKind: HoldOutlineKind;
+  onEditKindChange: (kind: HoldOutlineKind) => void;
+  /** One line saying what the selected placement currently carries. */
+  statusLine: string;
+  /** Last failure to surface — a rejected stroke or a server error. */
+  errorText: string | null;
+  /** A finished stroke is waiting to be stored. */
+  hasDraft: boolean;
+  onSave: () => void;
+  onDiscardDraft: () => void;
+  /** A stored override of the current kind exists for the selected placement. */
+  hasOverride: boolean;
+  onRevert: () => void;
+  /** True while a placement is selected — while it is, the pencil draws instead
+   *  of selecting, so the toolbar has to offer a way back to picking. */
+  hasSelection: boolean;
+  onDeselect: () => void;
+  saving: boolean;
+  fingerDraw: boolean;
+  onFingerDrawChange: (next: boolean) => void;
+};
+
+/**
+ * The editor's whole control surface: which boundary is being drawn, what the
+ * selected placement carries today, and the three writes (store this stroke,
+ * throw it away, drop the stored override).
+ */
+export const EditToolbar = React.memo(function EditToolbar({
+  editKind,
+  onEditKindChange,
+  statusLine,
+  errorText,
+  hasDraft,
+  onSave,
+  onDiscardDraft,
+  hasOverride,
+  onRevert,
+  hasSelection,
+  onDeselect,
+  saving,
+  fingerDraw,
+  onFingerDrawChange,
+}: EditToolbarProps) {
+  const { systemColors } = useTheme();
+
+  // Reverting a LED_INNER row removes an annotation; there is no traced version
+  // to fall back to, so the label has to say something different.
+  const revertLabel = editKind === 'LED_INNER' ? 'Remove ring annotation' : 'Revert to traced';
+
+  const revertNote = useMemo(() => {
+    if (!hasOverride) return null;
+    return editKind === 'LED_INNER'
+      ? // i18n-ignore-next-line — admin-only screen
+        'Removing the annotation deletes the row immediately. Nothing else renders it yet.'
+      : // i18n-ignore-next-line — admin-only screen
+        'Reverting deletes the row immediately. The deployed shard keeps the old traced outline until the next export.';
+  }, [editKind, hasOverride]);
+
+  return (
+    <View style={[styles.root, { backgroundColor: systemColors.groupedBackground }]}>
+      <SegmentedControl
+        options={KIND_OPTIONS}
+        selectedKey={editKind}
+        onSelect={onEditKindChange}
+        // i18n-ignore-next-line — admin-only screen
+        accessibilityLabel="Boundary to draw"
+        tint={editKind === 'LED_INNER' ? OUTLINE_EDITOR_COLORS.ledInner : OUTLINE_EDITOR_COLORS.overridden}
+      />
+
+      <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.status}>
+        {statusLine}
+      </Text>
+
+      {errorText ? (
+        <Text variant="footnote" color={iosSystemColors.systemRed} style={styles.status}>
+          {errorText}
+        </Text>
+      ) : null}
+
+      <View style={styles.buttonRow}>
+        <Button
+          // i18n-ignore-next-line — admin-only screen
+          title="Save"
+          variant="filled"
+          size="small"
+          onPress={onSave}
+          disabled={!hasDraft || saving}
+          loading={saving}
+          style={styles.button}
+        />
+        <Button
+          // i18n-ignore-next-line — admin-only screen
+          title="Discard"
+          variant="text"
+          size="small"
+          role="cancel"
+          onPress={onDiscardDraft}
+          disabled={!hasDraft || saving}
+          style={styles.button}
+        />
+        <Button
+          // i18n-ignore-next-line — admin-only screen
+          title="Pick another hold"
+          variant="text"
+          size="small"
+          onPress={onDeselect}
+          disabled={!hasSelection || saving}
+          style={styles.button}
+        />
+        <Button
+          title={revertLabel}
+          variant="outlined"
+          size="small"
+          role="destructive"
+          onPress={onRevert}
+          disabled={!hasOverride || saving}
+          style={styles.button}
+        />
+      </View>
+
+      {revertNote ? (
+        <Text variant="caption1" color={systemColors.tertiaryLabel} style={styles.status}>
+          {revertNote}
+        </Text>
+      ) : null}
+
+      <SwitchRow
+        // i18n-ignore-next-line — admin-only screen
+        label="Draw with a finger"
+        // i18n-ignore-next-line — admin-only screen
+        description="Off: only an Apple Pencil draws, so a finger still pans and zooms."
+        value={fingerDraw}
+        onValueChange={onFingerDrawChange}
+      />
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  root: {
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[3],
+    paddingBottom: spacing[2],
+    gap: spacing[2],
+  },
+  status: {
+    textAlign: 'center',
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[2],
+  },
+  button: {
+    flexShrink: 1,
+  },
+});

--- a/packages/mobile/src/components/outline-editor/OutlineCanvasScreen.tsx
+++ b/packages/mobile/src/components/outline-editor/OutlineCanvasScreen.tsx
@@ -15,7 +15,7 @@ import { getCreateBoardHolds, parseSetIdsParam, type BoardHoldTarget } from '../
 import { OutlineSvgLayer, type OutlineLayerData } from './OutlineSvgLayer';
 import { DrawStrokeOverlay } from './DrawStrokeOverlay';
 import { EditToolbar } from './EditToolbar';
-import { buildOutlineRing, radiusRingToBoardPx, renderToBoardScale } from './stroke';
+import { buildOutlineRing, radiusRingToBoardPx, renderToBoardScale, type StrokeRejection } from './stroke';
 import type { RingPoint } from '@boardsesh/board-art-geometry/ring';
 
 // Admin-only screen — hardcoded English literals throughout, matching the
@@ -280,6 +280,7 @@ export function OutlineCanvasScreen({ boardName, layoutId, sizeId, setIds }: Out
       boardHolds ? (
         <OutlineSvgLayer
           holdTargets={boardHolds.holdTargets}
+          holdById={holdById}
           data={layerData}
           selectedPlacementId={selectedPlacementId}
           editKind={editKind}
@@ -290,7 +291,16 @@ export function OutlineCanvasScreen({ boardName, layoutId, sizeId, setIds }: Out
           renderHeight={boardRender.height}
         />
       ) : null,
-    [boardHolds, layerData, selectedPlacementId, editKind, draftPointsSV, boardRender.width, boardRender.height],
+    [
+      boardHolds,
+      holdById,
+      layerData,
+      selectedPlacementId,
+      editKind,
+      draftPointsSV,
+      boardRender.width,
+      boardRender.height,
+    ],
   );
 
   // Mounted only while a placement is selected. Before that the pencil has to be
@@ -385,9 +395,10 @@ export function OutlineCanvasScreen({ boardName, layoutId, sizeId, setIds }: Out
   );
 }
 
-function rejectionMessage(reason: 'too-few-points' | 'centre-outside' | 'out-of-bounds'): string {
+function rejectionMessage(reason: StrokeRejection): string {
   if (reason === 'centre-outside') return "That ring doesn't cover the hold's centre. Draw around the hold you picked.";
   if (reason === 'out-of-bounds') return 'That ring is far bigger than a hold. Zoom in and trace the hold itself.';
+  if (reason === 'too-complex') return "That stroke has too much detail to store. Trace the hold's edge in one pass.";
   return 'That stroke is too short to be an outline. Draw a full loop around the hold.';
 }
 

--- a/packages/mobile/src/components/outline-editor/OutlineCanvasScreen.tsx
+++ b/packages/mobile/src/components/outline-editor/OutlineCanvasScreen.tsx
@@ -143,6 +143,9 @@ export function OutlineCanvasScreen({ boardName, layoutId, sizeId, setIds }: Out
 
   const handleHoldTap = useCallback(
     (holdId: number) => {
+      // Reachable: while zoomed the overlay nests inside the pan detector, so a
+      // declined touch reaches the board's hold taps. A tap resolved on the UI
+      // thread can still land on JS just after a stroke started, so drop it.
       if (drawingRef.current) return;
       setSelectedPlacementId(holdId);
       setErrorText(null);
@@ -163,6 +166,12 @@ export function OutlineCanvasScreen({ boardName, layoutId, sizeId, setIds }: Out
   }, []);
 
   const handleStrokeCancel = useCallback(() => {
+    // Only a stroke that actually STARTED may clear the preview. The overlay
+    // finalizes on every touch it declines too (a finger while only the stylus
+    // draws), and without this guard one of those would wipe the preview of an
+    // already-validated draft while Save stayed armed — you'd store a ring you
+    // could no longer see.
+    if (!drawingRef.current) return;
     drawingRef.current = false;
     draftPointsSV.value = NO_POINTS;
   }, [draftPointsSV]);
@@ -300,7 +309,7 @@ export function OutlineCanvasScreen({ boardName, layoutId, sizeId, setIds }: Out
           containerWidthSV={context.containerWidthSV}
           containerHeightSV={context.containerHeightSV}
           boardScale={boardScale}
-          pinchGesture={context.pinchGesture}
+          pinchRef={context.pinchRef}
           onStrokeStart={handleStrokeStart}
           onStrokeEnd={handleStrokeEnd}
           onStrokeCancel={handleStrokeCancel}

--- a/packages/mobile/src/components/outline-editor/OutlineCanvasScreen.tsx
+++ b/packages/mobile/src/components/outline-editor/OutlineCanvasScreen.tsx
@@ -1,0 +1,403 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { ScrollView, StyleSheet, View, useWindowDimensions } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useSharedValue } from 'react-native-reanimated';
+import type { BoardName, HoldOutlineKind } from '@boardsesh/shared-schema';
+import { Text } from '../Text';
+import { ActivityIndicator } from '../ActivityIndicator';
+import { InteractiveFilterBoard, type FilterBoardTransformContext } from '../search/InteractiveFilterBoard';
+import { useTheme } from '../../providers/theme-provider';
+import { useToast } from '../../providers/toast-provider';
+import { spacing } from '../../theme/tokens';
+import { useDeleteHoldOutlineOverride, useHoldOutlines, useUpsertHoldOutlineOverride } from '../../lib/graphql/hooks';
+import { extractGraphqlMessage } from '../../lib/graphql/extract-error-message';
+import { getCreateBoardHolds, parseSetIdsParam, type BoardHoldTarget } from '../../lib/create-board-holds';
+import { OutlineSvgLayer, type OutlineLayerData } from './OutlineSvgLayer';
+import { DrawStrokeOverlay } from './DrawStrokeOverlay';
+import { EditToolbar } from './EditToolbar';
+import { buildOutlineRing, radiusRingToBoardPx, renderToBoardScale } from './stroke';
+import type { RingPoint } from '@boardsesh/board-art-geometry/ring';
+
+// Admin-only screen — hardcoded English literals throughout, matching the
+// tester-only development screens.
+
+/**
+ * Vertical space (px) the chrome around the board needs: the native header plus
+ * the edit toolbar (segmented control, status lines, button row, finger-draw
+ * switch). A rough constant is enough — the available height is clamped below.
+ */
+const CHROME_BUDGET = 360;
+
+const NO_POINTS: number[] = [];
+
+type OutlineCanvasScreenProps = {
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  setIds: string;
+};
+
+/** Flat `[x0, y0, ...]` board px → the `[x, y]` pairs `buildOutlineRing` wants. */
+function toRingPoints(flat: number[]): RingPoint[] {
+  const points: RingPoint[] = [];
+  for (let index = 0; index + 1 < flat.length; index += 2) {
+    points.push([flat[index], flat[index + 1]]);
+  }
+  return points;
+}
+
+function formatUpdatedAt(iso: string): string {
+  const parsed = new Date(iso);
+  return Number.isNaN(parsed.getTime()) ? iso : parsed.toLocaleDateString();
+}
+
+/**
+ * The hold-outline correction canvas: the board at any zoom, every placement's
+ * outline drawn over it by role, and an Apple-Pencil surface for redrawing the
+ * one that's wrong.
+ *
+ * v1 is freehand redraw plus revert. There is no vertex dragging — a whole
+ * silhouette is quicker to re-trace with a pencil than to nudge point by point,
+ * and the tracer's own decimation runs over the result either way.
+ */
+export function OutlineCanvasScreen({ boardName, layoutId, sizeId, setIds }: OutlineCanvasScreenProps) {
+  const { systemColors } = useTheme();
+  const { showToast } = useToast();
+  const insets = useSafeAreaInsets();
+  const { width: windowWidth, height: windowHeight } = useWindowDimensions();
+
+  const [selectedPlacementId, setSelectedPlacementId] = useState<number | null>(null);
+  const [editKind, setEditKind] = useState<HoldOutlineKind>('SILHOUETTE');
+  const [fingerDraw, setFingerDraw] = useState(false);
+  const [draftOutline, setDraftOutline] = useState<number[] | null>(null);
+  const [errorText, setErrorText] = useState<string | null>(null);
+
+  // The live stroke in board px. A shared value, not state: it is written on the
+  // UI thread once per kept sample and read by the preview path's
+  // useAnimatedProps, so no React render is involved until the stroke ends.
+  const draftPointsSV = useSharedValue<number[]>(NO_POINTS);
+  const fingerDrawSV = useSharedValue(false);
+
+  // A stroke in progress must not also select a hold. Set from the one
+  // stroke-start runOnJS hop rather than per frame.
+  const drawingRef = useRef(false);
+
+  const boardHolds = useMemo(() => {
+    if (!boardName) return null;
+    return getCreateBoardHolds({ boardName, layoutId, sizeId, setIds: parseSetIdsParam(setIds) });
+  }, [boardName, layoutId, sizeId, setIds]);
+
+  const outlinesQuery = useHoldOutlines(boardName ? { boardName, layoutId, sizeId } : null);
+  const upsertOverride = useUpsertHoldOutlineOverride();
+  const deleteOverride = useDeleteHoldOutlineOverride();
+
+  const layerData = useMemo<OutlineLayerData>(() => {
+    const shardByPlacement = new Map<number, number[]>();
+    const silhouetteByPlacement = new Map<number, number[]>();
+    const ledInnerByPlacement = new Map<number, number[]>();
+    const outlines = outlinesQuery.data;
+    if (outlines) {
+      for (const shard of outlines.shardOutlines) shardByPlacement.set(shard.placementId, shard.outline);
+      for (const override of outlines.overrides) {
+        const target = override.kind === 'LED_INNER' ? ledInnerByPlacement : silhouetteByPlacement;
+        target.set(override.placementId, override.outline);
+      }
+    }
+    return { shardByPlacement, silhouetteByPlacement, ledInnerByPlacement };
+  }, [outlinesQuery.data]);
+
+  // Per-placement override metadata, indexed once so the status line is an O(1)
+  // lookup rather than a scan of the override list on every render.
+  const overrideMetaByKey = useMemo(() => {
+    const index = new Map<string, { authorDisplayName: string | null; updatedAt: string }>();
+    for (const override of outlinesQuery.data?.overrides ?? []) {
+      index.set(`${override.placementId}:${override.kind}`, {
+        authorDisplayName: override.authorDisplayName,
+        updatedAt: override.updatedAt,
+      });
+    }
+    return index;
+  }, [outlinesQuery.data]);
+
+  const holdById = useMemo(() => {
+    const index = new Map<number, BoardHoldTarget>();
+    for (const hold of boardHolds?.holdTargets ?? []) index.set(hold.id, hold);
+    return index;
+  }, [boardHolds]);
+
+  const boardRender = useMemo(() => {
+    if (!boardHolds) return { width: 0, height: 0 };
+    const boardAspect = boardHolds.boardWidth / boardHolds.boardHeight;
+    const availableWidth = windowWidth - spacing[4] * 2;
+    const availableHeight = Math.max(200, windowHeight - insets.top - insets.bottom - CHROME_BUDGET);
+    if (availableWidth / availableHeight > boardAspect) {
+      return { width: availableHeight * boardAspect, height: availableHeight };
+    }
+    return { width: availableWidth, height: availableWidth / boardAspect };
+  }, [boardHolds, windowWidth, windowHeight, insets.top, insets.bottom]);
+
+  const clearDraft = useCallback(() => {
+    setDraftOutline(null);
+    draftPointsSV.value = NO_POINTS;
+  }, [draftPointsSV]);
+
+  const handleHoldTap = useCallback(
+    (holdId: number) => {
+      if (drawingRef.current) return;
+      setSelectedPlacementId(holdId);
+      setErrorText(null);
+      clearDraft();
+    },
+    [clearDraft],
+  );
+
+  const handleDeselect = useCallback(() => {
+    setSelectedPlacementId(null);
+    setErrorText(null);
+    clearDraft();
+  }, [clearDraft]);
+
+  const handleStrokeStart = useCallback(() => {
+    drawingRef.current = true;
+    setErrorText(null);
+  }, []);
+
+  const handleStrokeCancel = useCallback(() => {
+    drawingRef.current = false;
+    draftPointsSV.value = NO_POINTS;
+  }, [draftPointsSV]);
+
+  const handleStrokeEnd = useCallback(
+    (strokeBoardPoints: number[]) => {
+      drawingRef.current = false;
+      const hold = selectedPlacementId == null ? null : holdById.get(selectedPlacementId);
+      if (!hold) {
+        draftPointsSV.value = NO_POINTS;
+        setErrorText('Tap a hold first, then draw its outline.');
+        return;
+      }
+      const result = buildOutlineRing(toRingPoints(strokeBoardPoints), hold);
+      if (!result.ok) {
+        // Keep the board and the selection as they are — the fix is to draw
+        // again, not to start over.
+        draftPointsSV.value = NO_POINTS;
+        setErrorText(rejectionMessage(result.reason));
+        showToast(rejectionMessage(result.reason), 'error');
+        return;
+      }
+      // Show back exactly what would be stored — the decimated, closed ring —
+      // rather than the raw stylus trail, so the preview and the write agree.
+      const previewBoardRing = radiusRingToBoardPx(result.outline, hold);
+      draftPointsSV.value = [...previewBoardRing, previewBoardRing[0], previewBoardRing[1]];
+      setDraftOutline(result.outline);
+    },
+    [selectedPlacementId, holdById, draftPointsSV, showToast],
+  );
+
+  const handleSave = useCallback(() => {
+    if (!draftOutline || selectedPlacementId == null) return;
+    setErrorText(null);
+    upsertOverride.mutate(
+      { boardName, layoutId, sizeId, placementId: selectedPlacementId, kind: editKind, outline: draftOutline },
+      {
+        onSuccess: () => {
+          clearDraft();
+          showToast('Outline saved', 'success');
+        },
+        onError: (error: unknown) => {
+          const message = extractGraphqlMessage(error) ?? 'Saving the outline failed.';
+          setErrorText(message);
+          showToast(message, 'error');
+        },
+      },
+    );
+  }, [draftOutline, selectedPlacementId, upsertOverride, boardName, layoutId, sizeId, editKind, clearDraft, showToast]);
+
+  const handleRevert = useCallback(() => {
+    if (selectedPlacementId == null) return;
+    setErrorText(null);
+    deleteOverride.mutate(
+      { boardName, layoutId, sizeId, placementId: selectedPlacementId, kind: editKind },
+      {
+        onSuccess: () => {
+          clearDraft();
+          showToast(editKind === 'LED_INNER' ? 'Annotation removed' : 'Reverted to the traced outline', 'success');
+        },
+        onError: (error: unknown) => {
+          const message = extractGraphqlMessage(error) ?? 'Removing the override failed.';
+          setErrorText(message);
+          showToast(message, 'error');
+        },
+      },
+    );
+  }, [selectedPlacementId, deleteOverride, boardName, layoutId, sizeId, editKind, clearDraft, showToast]);
+
+  const handleFingerDrawChange = useCallback(
+    (next: boolean) => {
+      setFingerDraw(next);
+      fingerDrawSV.value = next;
+    },
+    [fingerDrawSV],
+  );
+
+  const handleEditKindChange = useCallback(
+    (kind: HoldOutlineKind) => {
+      setEditKind(kind);
+      setErrorText(null);
+      clearDraft();
+    },
+    [clearDraft],
+  );
+
+  const hasOverride = selectedPlacementId != null && overrideMetaByKey.has(`${selectedPlacementId}:${editKind}`);
+
+  const statusLine = useMemo(() => {
+    if (selectedPlacementId == null) return 'Tap a hold to select it, then draw its outline.';
+    const meta = overrideMetaByKey.get(`${selectedPlacementId}:${editKind}`);
+    if (meta) {
+      const author = meta.authorDisplayName ?? 'someone';
+      return `#${selectedPlacementId} · overridden by ${author} on ${formatUpdatedAt(meta.updatedAt)}`;
+    }
+    if (editKind === 'LED_INNER') return `#${selectedPlacementId} · no LED ring annotation yet`;
+    return layerData.shardByPlacement.has(selectedPlacementId)
+      ? `#${selectedPlacementId} · traced`
+      : `#${selectedPlacementId} · missing — the renderer falls back to a plain ring`;
+  }, [selectedPlacementId, editKind, overrideMetaByKey, layerData.shardByPlacement]);
+
+  const boardScale = renderToBoardScale(boardHolds?.boardWidth ?? 0, boardRender.width);
+
+  const renderInTransform = useCallback(
+    () =>
+      boardHolds ? (
+        <OutlineSvgLayer
+          holdTargets={boardHolds.holdTargets}
+          data={layerData}
+          selectedPlacementId={selectedPlacementId}
+          editKind={editKind}
+          draftPointsSV={draftPointsSV}
+          boardWidth={boardHolds.boardWidth}
+          boardHeight={boardHolds.boardHeight}
+          renderWidth={boardRender.width}
+          renderHeight={boardRender.height}
+        />
+      ) : null,
+    [boardHolds, layerData, selectedPlacementId, editKind, draftPointsSV, boardRender.width, boardRender.height],
+  );
+
+  // Mounted only while a placement is selected. Before that the pencil has to be
+  // able to TAP a hold, and this overlay would swallow the tap and answer "pick a
+  // hold first" — so the board keeps its own gestures until there is something to
+  // draw on. "Pick another hold" in the toolbar unmounts it again.
+  const renderAboveBoard = useCallback(
+    (context: FilterBoardTransformContext) =>
+      selectedPlacementId == null ? null : (
+        <DrawStrokeOverlay
+          pointsSV={draftPointsSV}
+          fingerDrawSV={fingerDrawSV}
+          scaleSV={context.scaleSV}
+          translateXSV={context.translateXSV}
+          translateYSV={context.translateYSV}
+          containerWidthSV={context.containerWidthSV}
+          containerHeightSV={context.containerHeightSV}
+          boardScale={boardScale}
+          pinchGesture={context.pinchGesture}
+          onStrokeStart={handleStrokeStart}
+          onStrokeEnd={handleStrokeEnd}
+          onStrokeCancel={handleStrokeCancel}
+        />
+      ),
+    [
+      selectedPlacementId,
+      draftPointsSV,
+      fingerDrawSV,
+      boardScale,
+      handleStrokeStart,
+      handleStrokeEnd,
+      handleStrokeCancel,
+    ],
+  );
+
+  if (!boardHolds || !boardName) {
+    return (
+      <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
+        <Text variant="headline">This board configuration has no hold geometry.</Text>
+      </View>
+    );
+  }
+
+  if (outlinesQuery.isLoading) {
+    return (
+      <View style={[styles.centered, { backgroundColor: systemColors.background }]}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: systemColors.background }]}>
+      <View style={styles.boardSection}>
+        <InteractiveFilterBoard
+          boardName={boardName}
+          layoutId={layoutId}
+          sizeId={sizeId}
+          setIds={setIds}
+          boardWidth={boardHolds.boardWidth}
+          boardHeight={boardHolds.boardHeight}
+          holdTargets={boardHolds.holdTargets}
+          activeHoldId={selectedPlacementId}
+          onHoldTap={handleHoldTap}
+          showHoldMarkers={false}
+          renderWidth={boardRender.width}
+          renderHeight={boardRender.height}
+          renderInTransform={renderInTransform}
+          renderAboveBoard={renderAboveBoard}
+        />
+      </View>
+
+      <ScrollView keyboardShouldPersistTaps="handled" style={styles.toolbarScroll}>
+        <EditToolbar
+          editKind={editKind}
+          onEditKindChange={handleEditKindChange}
+          statusLine={statusLine}
+          errorText={errorText ?? (outlinesQuery.isError ? 'Loading the stored outlines failed.' : null)}
+          hasDraft={draftOutline != null}
+          onSave={handleSave}
+          onDiscardDraft={clearDraft}
+          hasOverride={hasOverride}
+          onRevert={handleRevert}
+          hasSelection={selectedPlacementId != null}
+          onDeselect={handleDeselect}
+          saving={upsertOverride.isPending || deleteOverride.isPending}
+          fingerDraw={fingerDraw}
+          onFingerDrawChange={handleFingerDrawChange}
+        />
+      </ScrollView>
+    </View>
+  );
+}
+
+function rejectionMessage(reason: 'too-few-points' | 'centre-outside' | 'out-of-bounds'): string {
+  if (reason === 'centre-outside') return "That ring doesn't cover the hold's centre. Draw around the hold you picked.";
+  if (reason === 'out-of-bounds') return 'That ring is far bigger than a hold. Zoom in and trace the hold itself.';
+  return 'That stroke is too short to be an outline. Draw a full loop around the hold.';
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing[4],
+  },
+  boardSection: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  toolbarScroll: {
+    flexGrow: 0,
+  },
+});

--- a/packages/mobile/src/components/outline-editor/OutlineEditorGate.tsx
+++ b/packages/mobile/src/components/outline-editor/OutlineEditorGate.tsx
@@ -45,9 +45,16 @@ export function OutlineEditorGate({ children }: { children: ReactNode }) {
       <View style={[styles.centered, { backgroundColor: systemColors.groupedBackground }]}>
         <Icon name="lock" size={40} color={iosSystemColors.systemGray} />
         <Text variant="headline" style={styles.title}>
+          {/* i18n-ignore-next-line — admin-only screen */}
           The outline editor is admin-only.
         </Text>
-        <Button title="Back" variant="outlined" onPress={() => router.back()} style={styles.button} />
+        <Button
+          // i18n-ignore-next-line — admin-only screen
+          title="Back"
+          variant="outlined"
+          onPress={() => router.back()}
+          style={styles.button}
+        />
       </View>
     );
   }

--- a/packages/mobile/src/components/outline-editor/OutlineEditorGate.tsx
+++ b/packages/mobile/src/components/outline-editor/OutlineEditorGate.tsx
@@ -1,0 +1,72 @@
+import React, { type ReactNode } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { Button } from '../Button';
+import { ActivityIndicator } from '../ActivityIndicator';
+import { useIsAdmin } from '../../lib/graphql/hooks';
+import { useTheme } from '../../providers/theme-provider';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { spacing } from '../../theme/tokens';
+
+// Admin-only screen — hardcoded English literals, the tester-screen convention.
+
+/**
+ * Route guard for the outline editor.
+ *
+ * Hiding the More-tab row is not a guard: a deep link reaches either editor
+ * route directly, and the mutations behind them rewrite what every climber's
+ * board renders. `__DEV__` always passes (the profile query often doesn't
+ * resolve against a local backend); otherwise the flag has to come back true.
+ * `useIsAdmin` fails closed, so a backend that doesn't yet serve the field —
+ * or a request that errors — lands here rather than in the editor.
+ *
+ * A no-access state rather than a redirect, so a deep link that misses says why
+ * (the `app/boards/edit.tsx` precedent).
+ */
+export function OutlineEditorGate({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const { systemColors } = useTheme();
+  const { isAdmin, isLoading } = useIsAdmin({ enabled: !__DEV__ });
+
+  if (__DEV__) return <>{children}</>;
+
+  if (isLoading) {
+    return (
+      <View style={[styles.centered, { backgroundColor: systemColors.groupedBackground }]}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <View style={[styles.centered, { backgroundColor: systemColors.groupedBackground }]}>
+        <Icon name="lock" size={40} color={iosSystemColors.systemGray} />
+        <Text variant="headline" style={styles.title}>
+          The outline editor is admin-only.
+        </Text>
+        <Button title="Back" variant="outlined" onPress={() => router.back()} style={styles.button} />
+      </View>
+    );
+  }
+
+  return <>{children}</>;
+}
+
+const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing[6],
+  },
+  title: {
+    marginTop: spacing[3],
+    textAlign: 'center',
+  },
+  button: {
+    marginTop: spacing[4],
+  },
+});

--- a/packages/mobile/src/components/outline-editor/OutlineEditorMessage.tsx
+++ b/packages/mobile/src/components/outline-editor/OutlineEditorMessage.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { Text } from '../Text';
+import { Button } from '../Button';
+import { useTheme } from '../../providers/theme-provider';
+import { spacing } from '../../theme/tokens';
+
+// Admin-only screen — hardcoded English literals, the tester-screen convention.
+
+/** A dead-end state for the editor routes, with a way back. */
+export function OutlineEditorMessage({ message }: { message: string }) {
+  const router = useRouter();
+  const { systemColors } = useTheme();
+
+  return (
+    <View style={[styles.centered, { backgroundColor: systemColors.groupedBackground }]}>
+      <Text variant="headline" style={styles.title}>
+        {message}
+      </Text>
+      <Button
+        // i18n-ignore-next-line — admin-only screen
+        title="Back"
+        variant="outlined"
+        onPress={() => router.back()}
+        style={styles.button}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing[6],
+  },
+  title: {
+    textAlign: 'center',
+  },
+  button: {
+    marginTop: spacing[4],
+  },
+});

--- a/packages/mobile/src/components/outline-editor/OutlineEditorPickerScreen.tsx
+++ b/packages/mobile/src/components/outline-editor/OutlineEditorPickerScreen.tsx
@@ -17,6 +17,12 @@ type PickerRow = { key: string; id: number; label: string; detail?: string };
 /**
  * Board → layout → size, then into the canvas.
  *
+ * Plain `.map()` inside a `ScrollView`, deliberately unvirtualized: the three
+ * lists are 8 boards, at most ~14 layouts and at most ~10 sizes, all resolved
+ * synchronously from bundled constants. A FlashList here would cost more than it
+ * saves — see the list rule in docs/react-native-performance.md, which is about
+ * unbounded/remote lists.
+ *
  * Everything the backend's `holdOutlines` query can answer for is listed,
  * including the boards that ship no traced shard at all (Woods): a config with
  * no shard is exactly the one worth hand-drawing, and the editor draws its

--- a/packages/mobile/src/components/outline-editor/OutlineEditorPickerScreen.tsx
+++ b/packages/mobile/src/components/outline-editor/OutlineEditorPickerScreen.tsx
@@ -1,0 +1,202 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { BOARD_DISPLAY_ORDER, type BoardName } from '@boardsesh/shared-schema';
+import { boardTypeLabel } from '@boardsesh/board-constants';
+import { outlineEditorLayouts, outlineEditorSetIds, outlineEditorSizes } from './board-configs';
+import { Text } from '../Text';
+import { Button } from '../Button';
+import { useTheme } from '../../providers/theme-provider';
+import { hapticSelection } from '../../lib/haptics';
+import { spacing, borderRadius } from '../../theme/tokens';
+
+// Admin-only screen — hardcoded English literals, the tester-screen convention.
+
+type PickerRow = { key: string; id: number; label: string; detail?: string };
+
+/**
+ * Board → layout → size, then into the canvas.
+ *
+ * Everything the backend's `holdOutlines` query can answer for is listed,
+ * including the boards that ship no traced shard at all (Woods): a config with
+ * no shard is exactly the one worth hand-drawing, and the editor draws its
+ * placements as "missing" rings rather than hiding them.
+ */
+export function OutlineEditorPickerScreen() {
+  const router = useRouter();
+  const { systemColors, brandColors } = useTheme();
+
+  const [boardName, setBoardName] = useState<BoardName | null>(null);
+  const [layoutId, setLayoutId] = useState<number | null>(null);
+  const [sizeId, setSizeId] = useState<number | null>(null);
+
+  const boardRows = useMemo<PickerRow[]>(
+    () =>
+      BOARD_DISPLAY_ORDER.map((name) => ({
+        key: name,
+        id: 0,
+        label: boardTypeLabel(name),
+        detail: name,
+      })),
+    [],
+  );
+
+  const layoutRows = useMemo<PickerRow[]>(() => {
+    if (!boardName) return [];
+    return outlineEditorLayouts(boardName).map((layout) => ({
+      key: `${boardName}-${layout.id}`,
+      id: layout.id,
+      label: layout.name,
+      detail: `Layout ${layout.id}`,
+    }));
+  }, [boardName]);
+
+  const sizeRows = useMemo<PickerRow[]>(() => {
+    if (!boardName || layoutId == null) return [];
+    return outlineEditorSizes(boardName, layoutId).map((size) => ({
+      key: `${boardName}-${layoutId}-${size.id}`,
+      id: size.id,
+      label: size.name,
+      detail: size.description || `Size ${size.id}`,
+    }));
+  }, [boardName, layoutId]);
+
+  const handleSelectBoard = useCallback((name: BoardName) => {
+    hapticSelection();
+    setBoardName(name);
+    setLayoutId(null);
+    setSizeId(null);
+  }, []);
+
+  const handleSelectLayout = useCallback((nextLayoutId: number) => {
+    hapticSelection();
+    setLayoutId(nextLayoutId);
+    setSizeId(null);
+  }, []);
+
+  const handleSelectSize = useCallback((nextSizeId: number) => {
+    hapticSelection();
+    setSizeId(nextSizeId);
+  }, []);
+
+  const handleOpen = useCallback(() => {
+    if (!boardName || layoutId == null || sizeId == null) return;
+    // Every set of the layout and size, which is how a geometry shard is traced
+    // — the board art an override is drawn against has all of them mounted.
+    const setIds = outlineEditorSetIds(boardName, layoutId, sizeId);
+    router.push({
+      pathname: '/(tabs)/profile/outline-canvas',
+      params: { boardName, layoutId: String(layoutId), sizeId: String(sizeId), setIds },
+    });
+  }, [router, boardName, layoutId, sizeId]);
+
+  const renderRows = (rows: PickerRow[], selectedId: number | null, onSelect: (id: number) => void) =>
+    rows.map((row) => {
+      const isSelected = selectedId === row.id;
+      return (
+        <Pressable
+          key={row.key}
+          onPress={() => onSelect(row.id)}
+          accessibilityRole="button"
+          accessibilityState={{ selected: isSelected }}
+          style={[
+            styles.row,
+            {
+              backgroundColor: systemColors.secondaryBackground,
+              borderColor: isSelected ? brandColors.primary : 'transparent',
+            },
+          ]}
+        >
+          <Text variant="body">{row.label}</Text>
+          {row.detail ? (
+            <Text variant="caption1" color={systemColors.secondaryLabel}>
+              {row.detail}
+            </Text>
+          ) : null}
+        </Pressable>
+      );
+    });
+
+  return (
+    <ScrollView style={{ backgroundColor: systemColors.groupedBackground }} contentContainerStyle={styles.content}>
+      <Text variant="footnote" color={systemColors.secondaryLabel}>
+        Best with Apple Pencil on iPad.
+      </Text>
+
+      <Text variant="headline" style={styles.heading}>
+        Board
+      </Text>
+      <View style={styles.rowGroup}>
+        {boardRows.map((row) => {
+          const isSelected = boardName === row.detail;
+          return (
+            <Pressable
+              key={row.key}
+              onPress={() => handleSelectBoard(row.key as BoardName)}
+              accessibilityRole="button"
+              accessibilityState={{ selected: isSelected }}
+              style={[
+                styles.row,
+                {
+                  backgroundColor: systemColors.secondaryBackground,
+                  borderColor: isSelected ? brandColors.primary : 'transparent',
+                },
+              ]}
+            >
+              <Text variant="body">{row.label}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {boardName ? (
+        <>
+          <Text variant="headline" style={styles.heading}>
+            Layout
+          </Text>
+          <View style={styles.rowGroup}>{renderRows(layoutRows, layoutId, handleSelectLayout)}</View>
+        </>
+      ) : null}
+
+      {boardName && layoutId != null ? (
+        <>
+          <Text variant="headline" style={styles.heading}>
+            Size
+          </Text>
+          <View style={styles.rowGroup}>{renderRows(sizeRows, sizeId, handleSelectSize)}</View>
+        </>
+      ) : null}
+
+      <Button
+        title="Open the editor"
+        variant="filled"
+        onPress={handleOpen}
+        disabled={!boardName || layoutId == null || sizeId == null}
+        style={styles.openButton}
+      />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    padding: spacing[4],
+    gap: spacing[2],
+    paddingBottom: spacing[12],
+  },
+  heading: {
+    marginTop: spacing[3],
+  },
+  rowGroup: {
+    gap: spacing[2],
+  },
+  row: {
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[3],
+    borderRadius: borderRadius.md,
+    borderWidth: 2,
+  },
+  openButton: {
+    marginTop: spacing[5],
+  },
+});

--- a/packages/mobile/src/components/outline-editor/OutlineSvgLayer.tsx
+++ b/packages/mobile/src/components/outline-editor/OutlineSvgLayer.tsx
@@ -70,8 +70,9 @@ const STROKE_WIDTH = {
  * Concatenated by ROLE, not by placement: a board config carries up to a few
  * thousand placements, and one `<Path>` element each would be thousands of
  * native views to mount and diff. Each role instead gets a single `d` built by
- * joining `M…Z` subpaths, so the layer is six nodes regardless of board size and
- * each one rebuilds only when its own bucket changes.
+ * joining `M…Z` subpaths, so the layer is seven nodes regardless of board size
+ * — five role buckets, the selection, and the live draft — and each rebuilds only
+ * when its own bucket changes.
  *
  * Coordinates are BOARD px throughout, mapped to the rendered box by the
  * `viewBox` — the same frame the stored rings convert into, so nothing here

--- a/packages/mobile/src/components/outline-editor/OutlineSvgLayer.tsx
+++ b/packages/mobile/src/components/outline-editor/OutlineSvgLayer.tsx
@@ -42,6 +42,10 @@ export type OutlineLayerData = {
 
 type OutlineSvgLayerProps = {
   holdTargets: BoardHoldTarget[];
+  /** The same holds keyed by placement id. Passed in rather than rebuilt (or
+   *  scanned with `.find`) so resolving the selection stays O(1) — the screen
+   *  already maintains this index. */
+  holdById: Map<number, BoardHoldTarget>;
   data: OutlineLayerData;
   selectedPlacementId: number | null;
   editKind: HoldOutlineKind;
@@ -82,6 +86,7 @@ const STROKE_WIDTH = {
  */
 export const OutlineSvgLayer = React.memo(function OutlineSvgLayer({
   holdTargets,
+  holdById,
   data,
   selectedPlacementId,
   editKind,
@@ -135,7 +140,7 @@ export const OutlineSvgLayer = React.memo(function OutlineSvgLayer({
   // kind currently being edited, so switching mode moves the highlight.
   const selectedPath = useMemo(() => {
     if (selectedPlacementId == null) return '';
-    const hold = holdTargets.find((candidate) => candidate.id === selectedPlacementId);
+    const hold = holdById.get(selectedPlacementId);
     if (!hold) return '';
     if (editKind === 'LED_INNER') {
       const ledInnerOverride = ledInnerByPlacement.get(hold.id);
@@ -143,7 +148,7 @@ export const OutlineSvgLayer = React.memo(function OutlineSvgLayer({
     }
     const outline = silhouetteByPlacement.get(hold.id) ?? shardByPlacement.get(hold.id);
     return outline ? ringToPathData(radiusRingToBoardPx(outline, hold)) : placementRingPathData(hold);
-  }, [selectedPlacementId, editKind, holdTargets, silhouetteByPlacement, shardByPlacement, ledInnerByPlacement]);
+  }, [selectedPlacementId, editKind, holdById, silhouetteByPlacement, shardByPlacement, ledInnerByPlacement]);
 
   // Dash length scaled off the board's own size so it reads the same on a
   // 4000px-wide Kilter and a small Tension.

--- a/packages/mobile/src/components/outline-editor/OutlineSvgLayer.tsx
+++ b/packages/mobile/src/components/outline-editor/OutlineSvgLayer.tsx
@@ -1,0 +1,230 @@
+import React, { useMemo } from 'react';
+import { StyleSheet } from 'react-native';
+import Animated, { useAnimatedProps, type SharedValue } from 'react-native-reanimated';
+import Svg, { Path } from 'react-native-svg';
+import type { HoldOutlineKind } from '@boardsesh/shared-schema';
+import type { BoardHoldTarget } from '../../lib/create-board-holds';
+import { placementRingPathData, radiusRingToBoardPx, ringToPathData } from './stroke';
+
+const AnimatedPath = Animated.createAnimatedComponent(Path);
+
+/**
+ * Editor role colours. Deliberately fixed rather than theme-derived: this is an
+ * admin tool whose whole job is telling four states apart at a glance over
+ * arbitrary board art, so the hues are chosen against the board photo, not
+ * against the app's light/dark surfaces.
+ */
+export const OUTLINE_EDITOR_COLORS = {
+  /** What the tracer produced and nobody has touched. */
+  traced: '#9CA3AF',
+  /** A stored SILHOUETTE override. */
+  overridden: '#34D399',
+  /** The shard outline still sitting under a differing override. */
+  ghost: '#6B7280',
+  /** No shard outline and no override — the renderer falls back to a plain ring. */
+  missing: '#F59E0B',
+  /** A stored LED_INNER annotation: the inner edge of the LED base plate. */
+  ledInner: '#60A5FA',
+  /** The placement currently being edited. */
+  selected: '#FFFFFF',
+  /** The stroke under the pencil right now. */
+  draft: '#FDE047',
+} as const;
+
+export type OutlineLayerData = {
+  /** Traced silhouettes from the deployed shard, by placement id. */
+  shardByPlacement: Map<number, number[]>;
+  /** Stored SILHOUETTE overrides, by placement id. */
+  silhouetteByPlacement: Map<number, number[]>;
+  /** Stored LED_INNER annotations, by placement id. */
+  ledInnerByPlacement: Map<number, number[]>;
+};
+
+type OutlineSvgLayerProps = {
+  holdTargets: BoardHoldTarget[];
+  data: OutlineLayerData;
+  selectedPlacementId: number | null;
+  editKind: HoldOutlineKind;
+  /** The live stroke in board px, written by `DrawStrokeOverlay`. */
+  draftPointsSV: SharedValue<number[]>;
+  boardWidth: number;
+  boardHeight: number;
+  renderWidth: number;
+  renderHeight: number;
+};
+
+/** Stroke widths in device px — see the `vectorEffect` note on the component. */
+const STROKE_WIDTH = {
+  traced: 1,
+  overridden: 1.6,
+  ghost: 1,
+  missing: 1,
+  ledInner: 1.4,
+  selected: 2.6,
+  draft: 2.4,
+} as const;
+
+/**
+ * Every placement's outline, in one SVG.
+ *
+ * Concatenated by ROLE, not by placement: a board config carries up to a few
+ * thousand placements, and one `<Path>` element each would be thousands of
+ * native views to mount and diff. Each role instead gets a single `d` built by
+ * joining `M…Z` subpaths, so the layer is six nodes regardless of board size and
+ * each one rebuilds only when its own bucket changes.
+ *
+ * Coordinates are BOARD px throughout, mapped to the rendered box by the
+ * `viewBox` — the same frame the stored rings convert into, so nothing here
+ * needs to know the zoom. `vectorEffect="non-scaling-stroke"` keeps line weight
+ * readable at any board size; dash lengths stay in user units, which is why they
+ * are quoted relative to a hold radius rather than in device px.
+ */
+export const OutlineSvgLayer = React.memo(function OutlineSvgLayer({
+  holdTargets,
+  data,
+  selectedPlacementId,
+  editKind,
+  draftPointsSV,
+  boardWidth,
+  boardHeight,
+  renderWidth,
+  renderHeight,
+}: OutlineSvgLayerProps) {
+  const { shardByPlacement, silhouetteByPlacement, ledInnerByPlacement } = data;
+
+  const buckets = useMemo(() => {
+    const traced: string[] = [];
+    const overridden: string[] = [];
+    const ghost: string[] = [];
+    const missing: string[] = [];
+    const ledInner: string[] = [];
+
+    for (const hold of holdTargets) {
+      const shardOutline = shardByPlacement.get(hold.id);
+      const silhouetteOverride = silhouetteByPlacement.get(hold.id);
+      const ledInnerOverride = ledInnerByPlacement.get(hold.id);
+
+      if (silhouetteOverride) {
+        overridden.push(ringToPathData(radiusRingToBoardPx(silhouetteOverride, hold)));
+        // Keep the tracer's version visible underneath so the correction can be
+        // judged against what it replaced.
+        if (shardOutline) ghost.push(ringToPathData(radiusRingToBoardPx(shardOutline, hold)));
+      } else if (shardOutline) {
+        traced.push(ringToPathData(radiusRingToBoardPx(shardOutline, hold)));
+      } else {
+        missing.push(placementRingPathData(hold));
+      }
+
+      if (ledInnerOverride) {
+        ledInner.push(ringToPathData(radiusRingToBoardPx(ledInnerOverride, hold)));
+      }
+    }
+
+    return {
+      traced: traced.join(''),
+      overridden: overridden.join(''),
+      ghost: ghost.join(''),
+      missing: missing.join(''),
+      ledInner: ledInner.join(''),
+    };
+  }, [holdTargets, shardByPlacement, silhouetteByPlacement, ledInnerByPlacement]);
+
+  // The placement being edited, drawn again on top in white so it reads over
+  // whichever role colour it already carries. The ring shown is the one for the
+  // kind currently being edited, so switching mode moves the highlight.
+  const selectedPath = useMemo(() => {
+    if (selectedPlacementId == null) return '';
+    const hold = holdTargets.find((candidate) => candidate.id === selectedPlacementId);
+    if (!hold) return '';
+    if (editKind === 'LED_INNER') {
+      const ledInnerOverride = ledInnerByPlacement.get(hold.id);
+      return ledInnerOverride ? ringToPathData(radiusRingToBoardPx(ledInnerOverride, hold)) : '';
+    }
+    const outline = silhouetteByPlacement.get(hold.id) ?? shardByPlacement.get(hold.id);
+    return outline ? ringToPathData(radiusRingToBoardPx(outline, hold)) : placementRingPathData(hold);
+  }, [selectedPlacementId, editKind, holdTargets, silhouetteByPlacement, shardByPlacement, ledInnerByPlacement]);
+
+  // Dash length scaled off the board's own size so it reads the same on a
+  // 4000px-wide Kilter and a small Tension.
+  const dashLength = Math.max(2, boardWidth / 300);
+
+  const draftProps = useAnimatedProps(() => {
+    'worklet';
+    const points = draftPointsSV.value;
+    if (points.length < 4) return { d: '' };
+    let path = `M${points[0]} ${points[1]}`;
+    for (let index = 2; index < points.length; index += 2) {
+      path += `L${points[index]} ${points[index + 1]}`;
+    }
+    return { d: path };
+  });
+
+  if (renderWidth <= 0 || renderHeight <= 0) return null;
+
+  return (
+    <Svg
+      pointerEvents="none"
+      style={StyleSheet.absoluteFill}
+      width={renderWidth}
+      height={renderHeight}
+      viewBox={`0 0 ${boardWidth} ${boardHeight}`}
+    >
+      <Path
+        d={buckets.ghost}
+        fill="none"
+        stroke={OUTLINE_EDITOR_COLORS.ghost}
+        strokeWidth={STROKE_WIDTH.ghost}
+        strokeOpacity={0.5}
+        strokeDasharray={[dashLength, dashLength]}
+        vectorEffect="non-scaling-stroke"
+      />
+      <Path
+        d={buckets.missing}
+        fill="none"
+        stroke={OUTLINE_EDITOR_COLORS.missing}
+        strokeWidth={STROKE_WIDTH.missing}
+        strokeOpacity={0.8}
+        strokeDasharray={[dashLength, dashLength]}
+        vectorEffect="non-scaling-stroke"
+      />
+      <Path
+        d={buckets.traced}
+        fill="none"
+        stroke={OUTLINE_EDITOR_COLORS.traced}
+        strokeWidth={STROKE_WIDTH.traced}
+        strokeOpacity={0.85}
+        vectorEffect="non-scaling-stroke"
+      />
+      <Path
+        d={buckets.overridden}
+        fill="none"
+        stroke={OUTLINE_EDITOR_COLORS.overridden}
+        strokeWidth={STROKE_WIDTH.overridden}
+        vectorEffect="non-scaling-stroke"
+      />
+      <Path
+        d={buckets.ledInner}
+        fill="none"
+        stroke={OUTLINE_EDITOR_COLORS.ledInner}
+        strokeWidth={STROKE_WIDTH.ledInner}
+        vectorEffect="non-scaling-stroke"
+      />
+      <Path
+        d={selectedPath}
+        fill="none"
+        stroke={OUTLINE_EDITOR_COLORS.selected}
+        strokeWidth={STROKE_WIDTH.selected}
+        vectorEffect="non-scaling-stroke"
+      />
+      <AnimatedPath
+        animatedProps={draftProps}
+        fill="none"
+        stroke={OUTLINE_EDITOR_COLORS.draft}
+        strokeWidth={STROKE_WIDTH.draft}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        vectorEffect="non-scaling-stroke"
+      />
+    </Svg>
+  );
+});

--- a/packages/mobile/src/components/outline-editor/__tests__/board-configs.test.ts
+++ b/packages/mobile/src/components/outline-editor/__tests__/board-configs.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { BOARD_DISPLAY_ORDER } from '@boardsesh/shared-schema';
+import { outlineEditorLayouts, outlineEditorSetIds, outlineEditorSizes } from '../board-configs';
+
+describe('outlineEditorLayouts', () => {
+  it('lists at least one layout for every supported board', () => {
+    for (const boardName of BOARD_DISPLAY_ORDER) {
+      expect(outlineEditorLayouts(boardName).length, boardName).toBeGreaterThan(0);
+    }
+  });
+
+  it('covers MoonBoard and Woods, which carry no Aurora product-size rows', () => {
+    expect(outlineEditorLayouts('moonboard').map((layout) => layout.name)).toContain('MoonBoard 2024');
+    expect(outlineEditorLayouts('woods')).toEqual([{ id: 1, name: 'Original' }]);
+  });
+});
+
+describe('outlineEditorSizes', () => {
+  it('lists at least one size for every board’s first layout', () => {
+    for (const boardName of BOARD_DISPLAY_ORDER) {
+      const firstLayout = outlineEditorLayouts(boardName)[0];
+      expect(outlineEditorSizes(boardName, firstLayout.id).length, boardName).toBeGreaterThan(0);
+    }
+  });
+
+  it('keeps the two Woods boards apart — their hold ids mean different things', () => {
+    expect(outlineEditorSizes('woods', 1).map((size) => size.id)).toEqual([1, 2]);
+  });
+});
+
+describe('outlineEditorSetIds', () => {
+  it('returns every set of the layout and size, comma separated', () => {
+    // MoonBoard 2016 ships three sets; a shard is traced with all of them.
+    expect(outlineEditorSetIds('moonboard', 2, 1)).toBe('2,3,4');
+  });
+
+  it('returns the synthetic Woods set', () => {
+    expect(outlineEditorSetIds('woods', 1, 2)).toBe('1');
+  });
+
+  it('returns the Aurora sets of a real Kilter config', () => {
+    expect(outlineEditorSetIds('kilter', 1, 28).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/mobile/src/components/outline-editor/__tests__/stroke.test.ts
+++ b/packages/mobile/src/components/outline-editor/__tests__/stroke.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { CENTRE_TOLERANCE_RADII, MAX_RING_NUMBERS } from '@boardsesh/board-art-geometry/ring';
+import { CENTRE_TOLERANCE_RADII, MAX_RING_NUMBERS, closeRing, roundRing } from '@boardsesh/board-art-geometry/ring';
 import type { BoardHoldTarget } from '../../../lib/create-board-holds';
 import {
+  OUTLINE_DECIMALS,
   boardRingToRadiusUnits,
   buildOutlineRing,
   closeStrokeLoop,
@@ -273,5 +274,33 @@ describe('ringToPathData', () => {
 describe('placementRingPathData', () => {
   it('draws a circle at the placement radius', () => {
     expect(placementRingPathData(HOLD)).toBe('M380 300a20 20 0 1 0 40 0a20 20 0 1 0 -40 0Z');
+  });
+});
+
+describe('buildOutlineRing normalisation order', () => {
+  it('matches the server: rounding can equate a head and tail that closing alone would keep', () => {
+    // Property of the two primitives, asserted directly. `roundRing` collapses a
+    // 5th-decimal difference; `closeRing` only drops an EXACT duplicate. So the
+    // two orders genuinely disagree, and the backend's upsert resolver commits to
+    // closeRing(roundRing(...)) — which is why buildOutlineRing does the same.
+    const ring = [0, 0, 1, 0, 1, 1, 0.00001, 0.00001];
+    const roundThenClose = closeRing(roundRing(ring, OUTLINE_DECIMALS));
+    const closeThenRound = roundRing(closeRing(ring), OUTLINE_DECIMALS);
+    expect(roundThenClose).toHaveLength(6);
+    expect(closeThenRound).toHaveLength(8);
+    expect(closeThenRound.slice(0, 6)).toEqual(roundThenClose);
+  });
+
+  it('emits a ring the server normalisation leaves untouched', () => {
+    // The guarantee that actually matters: whatever the editor previews is
+    // byte-for-byte what the resolver stores, so re-running its
+    // closeRing(roundRing(...)) is a no-op. A close-before-round client would
+    // fail this whenever the two orders diverged.
+    for (const pointCount of [12, 48, 200]) {
+      const result = buildOutlineRing(circleBoardPoints(HOLD.cx, HOLD.cy, HOLD.r, pointCount), HOLD);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(closeRing(roundRing(result.outline, OUTLINE_DECIMALS))).toEqual(result.outline);
+    }
   });
 });

--- a/packages/mobile/src/components/outline-editor/__tests__/stroke.test.ts
+++ b/packages/mobile/src/components/outline-editor/__tests__/stroke.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from 'vitest';
+import { CENTRE_TOLERANCE_RADII, MAX_RING_NUMBERS } from '@boardsesh/board-art-geometry/ring';
+import type { BoardHoldTarget } from '../../../lib/create-board-holds';
+import {
+  boardRingToRadiusUnits,
+  buildOutlineRing,
+  closeStrokeLoop,
+  dedupeStrokePoints,
+  placementRingPathData,
+  radiusRingToBoardPx,
+  renderToBoardScale,
+  ringCoversCentre,
+  ringToPathData,
+  screenToBoardPoint,
+  screenToRenderPoint,
+  type BoardZoomTransform,
+} from '../stroke';
+
+const HOLD: BoardHoldTarget = { id: 42, cx: 400, cy: 300, r: 20 };
+
+const AT_REST: BoardZoomTransform = {
+  scale: 1,
+  translateX: 0,
+  translateY: 0,
+  containerWidth: 360,
+  containerHeight: 480,
+};
+
+// A real zoomed-in-and-panned state: 2.5x with the board pushed left and up, the
+// shape `useZoomPanGesture` produces after a pinch plus a drag.
+const ZOOMED: BoardZoomTransform = {
+  scale: 2.5,
+  translateX: -140,
+  translateY: 96,
+  containerWidth: 360,
+  containerHeight: 480,
+};
+
+/** The forward map the board's `animatedZoomStyle` applies (centre origin). */
+function forwardTransform(localX: number, localY: number, transform: BoardZoomTransform): [number, number] {
+  const centreX = transform.containerWidth / 2;
+  const centreY = transform.containerHeight / 2;
+  return [
+    centreX + transform.scale * (localX - centreX) + transform.translateX,
+    centreY + transform.scale * (localY - centreY) + transform.translateY,
+  ];
+}
+
+/** A regular n-gon in board px around a centre — the shape a clean trace makes. */
+function circleBoardPoints(centreX: number, centreY: number, radius: number, count: number): [number, number][] {
+  const points: [number, number][] = [];
+  for (let index = 0; index < count; index += 1) {
+    const angle = (index / count) * Math.PI * 2;
+    points.push([centreX + Math.cos(angle) * radius, centreY + Math.sin(angle) * radius]);
+  }
+  return points;
+}
+
+describe('screenToRenderPoint', () => {
+  it('is the exact inverse of the board transform at rest', () => {
+    const [screenX, screenY] = forwardTransform(120, 200, AT_REST);
+    const [renderX, renderY] = screenToRenderPoint(screenX, screenY, AT_REST);
+    expect(renderX).toBeCloseTo(120, 10);
+    expect(renderY).toBeCloseTo(200, 10);
+  });
+
+  it('is the exact inverse of a zoomed, panned board transform', () => {
+    for (const [localX, localY] of [
+      [0, 0],
+      [120, 200],
+      [359, 479],
+    ] as const) {
+      const [screenX, screenY] = forwardTransform(localX, localY, ZOOMED);
+      const [renderX, renderY] = screenToRenderPoint(screenX, screenY, ZOOMED);
+      expect(renderX).toBeCloseTo(localX, 10);
+      expect(renderY).toBeCloseTo(localY, 10);
+    }
+  });
+});
+
+describe('renderToBoardScale', () => {
+  it('scales render px up to board px', () => {
+    expect(renderToBoardScale(1080, 360)).toBe(3);
+  });
+
+  it('is zero rather than Infinity before the board is measured', () => {
+    expect(renderToBoardScale(1080, 0)).toBe(0);
+  });
+});
+
+describe('screenToBoardPoint', () => {
+  it('round-trips a board point through the zoomed transform and back', () => {
+    const boardWidth = 1080;
+    const renderWidth = 360;
+    const boardScale = renderToBoardScale(boardWidth, renderWidth);
+    // Start from a known board point, project it to render px, forward-transform
+    // it to a screen touch, then run the editor's chain over that touch.
+    const boardPoint: [number, number] = [612, 441];
+    const renderPoint: [number, number] = [boardPoint[0] / boardScale, boardPoint[1] / boardScale];
+    const [screenX, screenY] = forwardTransform(renderPoint[0], renderPoint[1], ZOOMED);
+
+    const [recoveredX, recoveredY] = screenToBoardPoint(screenX, screenY, ZOOMED, boardWidth, renderWidth);
+    expect(recoveredX).toBeCloseTo(boardPoint[0], 8);
+    expect(recoveredY).toBeCloseTo(boardPoint[1], 8);
+  });
+});
+
+describe('dedupeStrokePoints', () => {
+  it('drops samples closer than the minimum distance', () => {
+    const points: [number, number][] = [
+      [0, 0],
+      [0.1, 0],
+      [5, 0],
+      [5.1, 0.1],
+      [10, 0],
+    ];
+    expect(dedupeStrokePoints(points, 1)).toEqual([
+      [0, 0],
+      [5, 0],
+      [10, 0],
+    ]);
+  });
+});
+
+describe('closeStrokeLoop', () => {
+  it('drops a tail that has come back onto the head', () => {
+    const points: [number, number][] = [
+      [0, 0],
+      [10, 0],
+      [10, 10],
+      [0, 10],
+      [1, 1],
+      [0.5, 0.5],
+    ];
+    expect(closeStrokeLoop(points, 3)).toEqual([
+      [0, 0],
+      [10, 0],
+      [10, 10],
+      [0, 10],
+    ]);
+  });
+
+  it('never eats the whole stroke', () => {
+    const points: [number, number][] = [
+      [0, 0],
+      [0.1, 0],
+      [0.2, 0],
+    ];
+    expect(closeStrokeLoop(points, 10)).toHaveLength(2);
+  });
+});
+
+describe('boardRingToRadiusUnits / radiusRingToBoardPx', () => {
+  it('round-trips board px through radius units', () => {
+    const boardRing = [420, 300, 400, 320, 380, 300, 400, 280];
+    const radiusRing = boardRingToRadiusUnits(boardRing, HOLD);
+    expect(radiusRing).toEqual([1, 0, 0, 1, -1, 0, 0, -1]);
+    expect(radiusRingToBoardPx(radiusRing, HOLD)).toEqual(boardRing);
+  });
+});
+
+describe('ringCoversCentre', () => {
+  it('accepts a ring around the origin', () => {
+    const ring = [1, 0, 0, 1, -1, 0, 0, -1];
+    expect(ringCoversCentre(ring)).toBe(true);
+  });
+
+  it('accepts a ring that misses the centre by less than the tolerance', () => {
+    const missBy = CENTRE_TOLERANCE_RADII / 2;
+    const ring = [missBy, -1, 1, 0, missBy, 1];
+    expect(ringCoversCentre(ring)).toBe(true);
+  });
+
+  it('rejects a ring drawn around the neighbouring hold', () => {
+    const ring = [1, 0, 3, 0, 3, 2, 1, 2];
+    expect(ringCoversCentre(ring)).toBe(false);
+  });
+});
+
+describe('buildOutlineRing', () => {
+  it('turns a traced circle into a stored ring in radius units', () => {
+    const stroke = circleBoardPoints(HOLD.cx, HOLD.cy, HOLD.r, 48);
+    const result = buildOutlineRing(stroke, HOLD);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Every coordinate lands near the unit circle, because the stroke was drawn
+    // at exactly the placement radius.
+    for (let index = 0; index < result.outline.length; index += 2) {
+      const distance = Math.hypot(result.outline[index], result.outline[index + 1]);
+      expect(distance).toBeGreaterThan(0.9);
+      expect(distance).toBeLessThan(1.1);
+    }
+    expect(result.outline.length).toBeGreaterThanOrEqual(6);
+    expect(result.outline.length).toBeLessThanOrEqual(MAX_RING_NUMBERS);
+  });
+
+  it('rounds stored coordinates to 4 decimals', () => {
+    const stroke = circleBoardPoints(HOLD.cx, HOLD.cy, HOLD.r * 1.13137, 40);
+    const result = buildOutlineRing(stroke, HOLD);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    for (const value of result.outline) {
+      expect(value).toBe(Math.round(value * 10000) / 10000);
+    }
+  });
+
+  it('survives the full screen → stored-ring chain on a zoomed board', () => {
+    const boardWidth = 1080;
+    const renderWidth = 360;
+    const boardScale = renderToBoardScale(boardWidth, renderWidth);
+    const hold: BoardHoldTarget = { id: 7, cx: 540, cy: 720, r: 24 };
+
+    // Synthesize the touches a pencil would produce tracing this hold while the
+    // board is zoomed 2.5x and panned.
+    const screenStroke = circleBoardPoints(hold.cx, hold.cy, hold.r, 60).map(([boardX, boardY]) =>
+      forwardTransform(boardX / boardScale, boardY / boardScale, ZOOMED),
+    );
+    const boardStroke = screenStroke.map(([screenX, screenY]) =>
+      screenToBoardPoint(screenX, screenY, ZOOMED, boardWidth, renderWidth),
+    );
+
+    const result = buildOutlineRing(boardStroke, hold);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(ringCoversCentre(result.outline)).toBe(true);
+    for (let index = 0; index < result.outline.length; index += 2) {
+      expect(Math.hypot(result.outline[index], result.outline[index + 1])).toBeCloseTo(1, 1);
+    }
+  });
+
+  it('rejects a stroke too short to be an outline', () => {
+    const result = buildOutlineRing(
+      [
+        [400, 300],
+        [401, 300],
+      ],
+      HOLD,
+    );
+    expect(result).toEqual({ ok: false, reason: 'too-few-points' });
+  });
+
+  it('rejects a ring drawn around the neighbouring hold', () => {
+    const stroke = circleBoardPoints(HOLD.cx + HOLD.r * 2.2, HOLD.cy, HOLD.r, 40);
+    const result = buildOutlineRing(stroke, HOLD);
+    expect(result).toEqual({ ok: false, reason: 'centre-outside' });
+  });
+
+  it('rejects a ring far larger than any hold', () => {
+    const stroke = circleBoardPoints(HOLD.cx, HOLD.cy, HOLD.r * 6, 40);
+    const result = buildOutlineRing(stroke, HOLD);
+    expect(result).toEqual({ ok: false, reason: 'out-of-bounds' });
+  });
+
+  it('decimates a dense scribble down to a storable ring', () => {
+    const stroke = circleBoardPoints(HOLD.cx, HOLD.cy, HOLD.r, 2000);
+    const result = buildOutlineRing(stroke, HOLD);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.outline.length).toBeLessThanOrEqual(MAX_RING_NUMBERS);
+  });
+});
+
+describe('ringToPathData', () => {
+  it('emits a closed subpath', () => {
+    expect(ringToPathData([0, 0, 10, 0, 10, 10])).toBe('M0 0L10 0L10 10Z');
+  });
+
+  it('emits nothing for a ring too short to draw', () => {
+    expect(ringToPathData([0, 0, 10, 0])).toBe('');
+  });
+});
+
+describe('placementRingPathData', () => {
+  it('draws a circle at the placement radius', () => {
+    expect(placementRingPathData(HOLD)).toBe('M380 300a20 20 0 1 0 40 0a20 20 0 1 0 -40 0Z');
+  });
+});

--- a/packages/mobile/src/components/outline-editor/board-configs.ts
+++ b/packages/mobile/src/components/outline-editor/board-configs.ts
@@ -1,0 +1,77 @@
+/**
+ * Every board configuration the outline editor can open, enumerated from the
+ * bundled catalogue.
+ *
+ * Three families answer "what layouts / sizes / sets exist?" from different
+ * places, and the picker has to list all of them: the backend's `holdOutlines`
+ * query serves any config, and a config with no traced shard at all (Woods) is
+ * exactly the one worth hand-drawing. Aurora boards read the generated
+ * product-size tables; MoonBoard and Woods carry no rows there and keep their
+ * layouts, sizes and sets in `@boardsesh/board-config` instead.
+ */
+
+import {
+  MOONBOARD_LAYOUTS,
+  MOONBOARD_SETS,
+  MOONBOARD_SIZE,
+  WOODS_LAYOUTS,
+  WOODS_SETS,
+  WOODS_SIZES,
+  type MoonBoardLayoutKey,
+} from '@boardsesh/board-config';
+import { getAllLayouts, getSetsForLayoutAndSize, getSizesForLayoutId } from '@boardsesh/board-constants/product-sizes';
+import type { BoardName } from '@boardsesh/shared-schema';
+
+export type OutlineEditorLayout = { id: number; name: string };
+export type OutlineEditorSize = { id: number; name: string; description: string };
+
+function moonBoardLayoutKeyFor(layoutId: number): MoonBoardLayoutKey | undefined {
+  return (Object.keys(MOONBOARD_LAYOUTS) as MoonBoardLayoutKey[]).find((key) => MOONBOARD_LAYOUTS[key].id === layoutId);
+}
+
+/** The layouts of one board, newest catalogue order. */
+export function outlineEditorLayouts(boardName: BoardName): OutlineEditorLayout[] {
+  if (boardName === 'moonboard') {
+    return Object.values(MOONBOARD_LAYOUTS).map((layout) => ({ id: layout.id, name: layout.name }));
+  }
+  if (boardName === 'woods') {
+    return [{ id: WOODS_LAYOUTS.woods.id, name: WOODS_LAYOUTS.woods.name }];
+  }
+  return getAllLayouts(boardName).map((layout) => ({ id: layout.id, name: layout.name }));
+}
+
+/** The sizes one layout ships in. */
+export function outlineEditorSizes(boardName: BoardName, layoutId: number): OutlineEditorSize[] {
+  if (boardName === 'moonboard') {
+    return [{ id: MOONBOARD_SIZE.id, name: MOONBOARD_SIZE.name, description: MOONBOARD_SIZE.description }];
+  }
+  if (boardName === 'woods') {
+    // The two Woods boards number their holds from their own origins, so they
+    // are genuinely different configs — both are listed.
+    return Object.values(WOODS_SIZES).map((size) => ({ id: size.id, name: size.name, description: '' }));
+  }
+  return getSizesForLayoutId(boardName, layoutId).map((size) => ({
+    id: size.id,
+    name: size.name,
+    description: size.description,
+  }));
+}
+
+/**
+ * Every set of a layout and size, as the comma-separated string the board routes
+ * take. That's how a geometry shard is traced — with all of them mounted — so an
+ * override is always drawn against the same art.
+ */
+export function outlineEditorSetIds(boardName: BoardName, layoutId: number, sizeId: number): string {
+  if (boardName === 'moonboard') {
+    const layoutKey = moonBoardLayoutKeyFor(layoutId);
+    const sets = layoutKey ? (MOONBOARD_SETS[layoutKey] ?? []) : [];
+    return sets.map((set) => set.id).join(',');
+  }
+  if (boardName === 'woods') {
+    return WOODS_SETS.map((set) => set.id).join(',');
+  }
+  return getSetsForLayoutAndSize(boardName, layoutId, sizeId)
+    .map((set) => set.id)
+    .join(',');
+}

--- a/packages/mobile/src/components/outline-editor/stroke.ts
+++ b/packages/mobile/src/components/outline-editor/stroke.ts
@@ -74,7 +74,7 @@ export const STROKE_CLOSE_TOLERANCE_BOARD_PX = 3;
 export const OUTLINE_DECIMALS = 4;
 
 /** Why a drawn stroke can't be stored. The editor keeps drawing on any of these. */
-export type StrokeRejection = 'too-few-points' | 'centre-outside' | 'out-of-bounds';
+export type StrokeRejection = 'too-few-points' | 'too-complex' | 'centre-outside' | 'out-of-bounds';
 
 export type StrokeResult = { ok: true; outline: number[] } | { ok: false; reason: StrokeRejection };
 
@@ -225,7 +225,10 @@ export function buildOutlineRing(strokeBoardPoints: RingPoint[], hold: BoardHold
     epsilon *= 2;
     simplified = simplifyRing(looped, epsilon);
   }
-  if (simplified.length * 2 > MAX_RING_NUMBERS) return { ok: false, reason: 'too-few-points' };
+  // Still too many points after six doublings (epsilon 102 board px, far coarser
+  // than any hold). Its own reason: the failure is the opposite of a short
+  // stroke, and reporting "too short" here would send the editor the wrong way.
+  if (simplified.length * 2 > MAX_RING_NUMBERS) return { ok: false, reason: 'too-complex' };
 
   // Round, THEN close — the server's order (see the note above).
   const radiusRing = closeRing(roundRing(boardRingToRadiusUnits(flattenRing(simplified), hold), OUTLINE_DECIMALS));

--- a/packages/mobile/src/components/outline-editor/stroke.ts
+++ b/packages/mobile/src/components/outline-editor/stroke.ts
@@ -66,6 +66,13 @@ export const STROKE_MIN_SAMPLE_BOARD_PX = 0.8;
  */
 export const STROKE_CLOSE_TOLERANCE_BOARD_PX = 3;
 
+/**
+ * Decimal places a stored ring is rounded to. Matches `OUTLINE_DECIMALS` in the
+ * backend's upsert resolver — the two have to agree or the editor previews a
+ * ring the server rewrites.
+ */
+export const OUTLINE_DECIMALS = 4;
+
 /** Why a drawn stroke can't be stored. The editor keeps drawing on any of these. */
 export type StrokeRejection = 'too-few-points' | 'centre-outside' | 'out-of-bounds';
 
@@ -158,10 +165,9 @@ export function flattenRing(points: RingPoint[]): number[] {
 /** Board px → units of a placement's radius, relative to its centre. */
 export function boardRingToRadiusUnits(ring: number[], hold: BoardHoldTarget): number[] {
   const radius = hold.r;
-  const converted: number[] = new Array(ring.length);
+  const converted: number[] = [];
   for (let index = 0; index < ring.length; index += 2) {
-    converted[index] = (ring[index] - hold.cx) / radius;
-    converted[index + 1] = (ring[index + 1] - hold.cy) / radius;
+    converted.push((ring[index] - hold.cx) / radius, (ring[index + 1] - hold.cy) / radius);
   }
   return converted;
 }
@@ -169,10 +175,9 @@ export function boardRingToRadiusUnits(ring: number[], hold: BoardHoldTarget): n
 /** The inverse of {@link boardRingToRadiusUnits} — what the SVG layer draws. */
 export function radiusRingToBoardPx(ring: number[], hold: BoardHoldTarget): number[] {
   const radius = hold.r;
-  const converted: number[] = new Array(ring.length);
+  const converted: number[] = [];
   for (let index = 0; index < ring.length; index += 2) {
-    converted[index] = hold.cx + ring[index] * radius;
-    converted[index + 1] = hold.cy + ring[index + 1] * radius;
+    converted.push(hold.cx + ring[index] * radius, hold.cy + ring[index + 1] * radius);
   }
   return converted;
 }
@@ -193,10 +198,17 @@ export function ringCoversCentre(radiusRing: number[]): boolean {
  * Turn a freehand stroke, already in board px, into a storable ring in radius
  * units — or say why it can't be one.
  *
- * Order is load-bearing: dedupe, close the loop, simplify at the tracer's own
- * BOARD-pixel tolerance, and only then divide through by the placement radius.
- * Simplifying after the divide would apply a 1.6-radii epsilon and collapse
- * every hold to a triangle.
+ * Order is load-bearing twice over.
+ *
+ * Simplification runs in BOARD px, before the divide-through by the placement
+ * radius: the tracer's 1.6 epsilon is quoted in board pixels, and applying it to
+ * a radius-unit ring would collapse every hold to a triangle.
+ *
+ * Rounding runs BEFORE the implicit close, mirroring
+ * `closeRing(roundRing(...))` in the backend's upsert resolver. Rounding to 4
+ * decimals can newly equate a head and tail that differed in the 5th, so closing
+ * first would leave a duplicate point the server then drops — and the editor
+ * would preview a ring one point longer than the one actually stored.
  */
 export function buildOutlineRing(strokeBoardPoints: RingPoint[], hold: BoardHoldTarget): StrokeResult {
   const deduped = dedupeStrokePoints(strokeBoardPoints, STROKE_MIN_SAMPLE_BOARD_PX);
@@ -215,10 +227,9 @@ export function buildOutlineRing(strokeBoardPoints: RingPoint[], hold: BoardHold
   }
   if (simplified.length * 2 > MAX_RING_NUMBERS) return { ok: false, reason: 'too-few-points' };
 
-  const boardRing = closeRing(flattenRing(simplified));
-  if (boardRing.length < MIN_RING_NUMBERS) return { ok: false, reason: 'too-few-points' };
-
-  const radiusRing = roundRing(boardRingToRadiusUnits(boardRing, hold), 4);
+  // Round, THEN close — the server's order (see the note above).
+  const radiusRing = closeRing(roundRing(boardRingToRadiusUnits(flattenRing(simplified), hold), OUTLINE_DECIMALS));
+  if (radiusRing.length < MIN_RING_NUMBERS) return { ok: false, reason: 'too-few-points' };
   if (radiusRing.some((value) => !Number.isFinite(value) || Math.abs(value) > MAX_RING_COORDINATE)) {
     return { ok: false, reason: 'out-of-bounds' };
   }

--- a/packages/mobile/src/components/outline-editor/stroke.ts
+++ b/packages/mobile/src/components/outline-editor/stroke.ts
@@ -1,0 +1,250 @@
+/**
+ * The outline editor's coordinate chain, as pure functions.
+ *
+ * A stylus sample arrives in screen px relative to the board container and has
+ * to end up as a stored ring in units of the placement radius. Four frames are
+ * involved and mixing them silently produces a plausible-looking ring in the
+ * wrong place, so each hop lives here as its own named function with a test:
+ *
+ *   1. screen px  → board-local RENDER px   `screenToRenderPoint` (invert zoom)
+ *   2. render px  → BOARD px                `renderToBoardScale`
+ *   3. board px   → a simplified ring       `buildOutlineRing`
+ *   4. board px   → RADIUS units            (inside `buildOutlineRing`)
+ *
+ * Step 1 has a worklet twin in `DrawStrokeOverlay` (reanimated can't reliably
+ * call a cross-module worklet — the same split `use-zoomed-hold-tap-gesture`
+ * makes against `inverseTransformPoint`). Keep the two in sync; the round-trip
+ * test in `__tests__/stroke.test.ts` pins the algebra either way.
+ *
+ * MIND THE UNITS. `SIMPLIFY_EPSILON_BOARD_PX` is quoted in BOARD pixels, which
+ * is why simplification happens BEFORE the divide-through by the placement
+ * radius, not after — see the constant's own note in
+ * `@boardsesh/board-art-geometry/ring`.
+ */
+
+import {
+  CENTRE_TOLERANCE_RADII,
+  MAX_RING_COORDINATE,
+  MAX_RING_NUMBERS,
+  MIN_RING_NUMBERS,
+  SIMPLIFY_EPSILON_BOARD_PX,
+  closeRing,
+  distanceToRing,
+  pointInRing,
+  roundRing,
+  simplifyRing,
+  type RingPoint,
+} from '@boardsesh/board-art-geometry/ring';
+import { inverseTransformPoint } from '../create-climb/holdLayout';
+import type { BoardHoldTarget } from '../../lib/create-board-holds';
+
+/** The board's live zoom transform, as the overlay's shared values read it. */
+export type BoardZoomTransform = {
+  scale: number;
+  translateX: number;
+  translateY: number;
+  containerWidth: number;
+  containerHeight: number;
+};
+
+/**
+ * Minimum movement (in BOARD px) before a stroke keeps another sample.
+ *
+ * Gates the worklet's shared-value append so a resting stylus doesn't push a
+ * point per frame. Comfortably finer than the 1.6 board-px simplification
+ * tolerance the ring is decimated at, so nothing a human draws is lost to it.
+ */
+export const STROKE_MIN_SAMPLE_BOARD_PX = 0.8;
+
+/**
+ * How close a stroke's last sample has to land to its first before we treat the
+ * loop as closed and drop the tail, in BOARD px.
+ *
+ * Rings are stored implicitly closed. A freehand loop almost never ends on the
+ * exact pixel it started from, so `closeRing`'s equality test alone would leave
+ * a duplicate head point and a near-zero-length final edge.
+ */
+export const STROKE_CLOSE_TOLERANCE_BOARD_PX = 3;
+
+/** Why a drawn stroke can't be stored. The editor keeps drawing on any of these. */
+export type StrokeRejection = 'too-few-points' | 'centre-outside' | 'out-of-bounds';
+
+export type StrokeResult = { ok: true; outline: number[] } | { ok: false; reason: StrokeRejection };
+
+/**
+ * Invert the board's zoom transform: a point in container/screen px becomes a
+ * point in board-local, untransformed RENDER px.
+ *
+ * Thin wrapper over the create-board's `inverseTransformPoint` so the editor
+ * reads as one chain — and so a change to the board's transform origin can only
+ * be made in one place.
+ */
+export function screenToRenderPoint(screenX: number, screenY: number, transform: BoardZoomTransform): RingPoint {
+  const { x, y } = inverseTransformPoint(
+    screenX,
+    screenY,
+    transform.scale,
+    transform.translateX,
+    transform.translateY,
+    transform.containerWidth,
+    transform.containerHeight,
+  );
+  return [x, y];
+}
+
+/**
+ * Render px → board px. The board is drawn to its own aspect ratio, so one
+ * uniform factor covers both axes.
+ */
+export function renderToBoardScale(boardWidth: number, renderWidth: number): number {
+  return renderWidth > 0 ? boardWidth / renderWidth : 0;
+}
+
+/** The full step-1+2 hop, for the test's round-trip and for any JS-side caller. */
+export function screenToBoardPoint(
+  screenX: number,
+  screenY: number,
+  transform: BoardZoomTransform,
+  boardWidth: number,
+  renderWidth: number,
+): RingPoint {
+  const [renderX, renderY] = screenToRenderPoint(screenX, screenY, transform);
+  const scale = renderToBoardScale(boardWidth, renderWidth);
+  return [renderX * scale, renderY * scale];
+}
+
+/** Drop consecutive samples closer together than `minDistance`. */
+export function dedupeStrokePoints(points: RingPoint[], minDistance: number): RingPoint[] {
+  const kept: RingPoint[] = [];
+  const minDistanceSquared = minDistance * minDistance;
+  for (const point of points) {
+    const previous = kept[kept.length - 1];
+    if (previous) {
+      const deltaX = point[0] - previous[0];
+      const deltaY = point[1] - previous[1];
+      if (deltaX * deltaX + deltaY * deltaY < minDistanceSquared) continue;
+    }
+    kept.push(point);
+  }
+  return kept;
+}
+
+/**
+ * Drop the tail of a freehand loop that has come back around onto its own head,
+ * so the ring closes implicitly instead of storing a stub edge. Never eats the
+ * whole stroke — the first two points always survive.
+ */
+export function closeStrokeLoop(points: RingPoint[], tolerance: number): RingPoint[] {
+  if (points.length < 3) return points;
+  const [headX, headY] = points[0];
+  let end = points.length;
+  while (end > 2) {
+    const [tailX, tailY] = points[end - 1];
+    if (Math.hypot(tailX - headX, tailY - headY) > tolerance) break;
+    end -= 1;
+  }
+  return end === points.length ? points : points.slice(0, end);
+}
+
+/** Flatten `[[x, y], ...]` to the stored `[x0, y0, x1, y1, ...]` shape. */
+export function flattenRing(points: RingPoint[]): number[] {
+  const flat: number[] = [];
+  for (const [x, y] of points) {
+    flat.push(x, y);
+  }
+  return flat;
+}
+
+/** Board px → units of a placement's radius, relative to its centre. */
+export function boardRingToRadiusUnits(ring: number[], hold: BoardHoldTarget): number[] {
+  const radius = hold.r;
+  const converted: number[] = new Array(ring.length);
+  for (let index = 0; index < ring.length; index += 2) {
+    converted[index] = (ring[index] - hold.cx) / radius;
+    converted[index + 1] = (ring[index + 1] - hold.cy) / radius;
+  }
+  return converted;
+}
+
+/** The inverse of {@link boardRingToRadiusUnits} — what the SVG layer draws. */
+export function radiusRingToBoardPx(ring: number[], hold: BoardHoldTarget): number[] {
+  const radius = hold.r;
+  const converted: number[] = new Array(ring.length);
+  for (let index = 0; index < ring.length; index += 2) {
+    converted[index] = hold.cx + ring[index] * radius;
+    converted[index + 1] = hold.cy + ring[index + 1] * radius;
+  }
+  return converted;
+}
+
+/**
+ * Does this ring enclose the placement it was drawn for?
+ *
+ * Mirrors the backend's softened gate exactly (`pointInRing` OR within
+ * {@link CENTRE_TOLERANCE_RADII}) so the client never rejects a ring the server
+ * would have accepted — a hold whose bolt sits under a concave underside
+ * genuinely traces without containing its own centre.
+ */
+export function ringCoversCentre(radiusRing: number[]): boolean {
+  return pointInRing(radiusRing, 0, 0) || distanceToRing(radiusRing, 0, 0) <= CENTRE_TOLERANCE_RADII;
+}
+
+/**
+ * Turn a freehand stroke, already in board px, into a storable ring in radius
+ * units — or say why it can't be one.
+ *
+ * Order is load-bearing: dedupe, close the loop, simplify at the tracer's own
+ * BOARD-pixel tolerance, and only then divide through by the placement radius.
+ * Simplifying after the divide would apply a 1.6-radii epsilon and collapse
+ * every hold to a triangle.
+ */
+export function buildOutlineRing(strokeBoardPoints: RingPoint[], hold: BoardHoldTarget): StrokeResult {
+  const deduped = dedupeStrokePoints(strokeBoardPoints, STROKE_MIN_SAMPLE_BOARD_PX);
+  const looped = closeStrokeLoop(deduped, STROKE_CLOSE_TOLERANCE_BOARD_PX);
+  if (looped.length < 3) return { ok: false, reason: 'too-few-points' };
+
+  // Decimate at the tracer's tolerance, then keep doubling it if the result is
+  // still longer than a stored ring may be. A hand-drawn hold lands far under
+  // the cap on the first pass; the loop only exists so a pathological scribble
+  // degrades into a coarser ring rather than a dead end.
+  let simplified = simplifyRing(looped, SIMPLIFY_EPSILON_BOARD_PX);
+  let epsilon = SIMPLIFY_EPSILON_BOARD_PX;
+  while (simplified.length * 2 > MAX_RING_NUMBERS && epsilon < SIMPLIFY_EPSILON_BOARD_PX * 64) {
+    epsilon *= 2;
+    simplified = simplifyRing(looped, epsilon);
+  }
+  if (simplified.length * 2 > MAX_RING_NUMBERS) return { ok: false, reason: 'too-few-points' };
+
+  const boardRing = closeRing(flattenRing(simplified));
+  if (boardRing.length < MIN_RING_NUMBERS) return { ok: false, reason: 'too-few-points' };
+
+  const radiusRing = roundRing(boardRingToRadiusUnits(boardRing, hold), 4);
+  if (radiusRing.some((value) => !Number.isFinite(value) || Math.abs(value) > MAX_RING_COORDINATE)) {
+    return { ok: false, reason: 'out-of-bounds' };
+  }
+  if (!ringCoversCentre(radiusRing)) return { ok: false, reason: 'centre-outside' };
+
+  return { ok: true, outline: radiusRing };
+}
+
+/**
+ * An SVG `d` for one implicitly-closed flat ring, in whatever units the ring is
+ * in. Empty string for a ring too short to draw, so a caller can concatenate
+ * without guarding.
+ */
+export function ringToPathData(ring: number[]): string {
+  if (ring.length < MIN_RING_NUMBERS) return '';
+  let path = `M${ring[0]} ${ring[1]}`;
+  for (let index = 2; index < ring.length; index += 2) {
+    path += `L${ring[index]} ${ring[index + 1]}`;
+  }
+  return `${path}Z`;
+}
+
+/** A circle at the placement radius, as an SVG `d` in board px. The renderer's
+ *  fallback for a placement with no art of its own — and what the editor draws
+ *  dashed to say "nothing traced here yet". */
+export function placementRingPathData(hold: BoardHoldTarget): string {
+  const { cx, cy, r } = hold;
+  return `M${cx - r} ${cy}a${r} ${r} 0 1 0 ${r * 2} 0a${r} ${r} 0 1 0 ${-r * 2} 0Z`;
+}

--- a/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
+++ b/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, type ReactNode } from 'react';
+import React, { useCallback, useMemo, useRef, type MutableRefObject, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View, StyleSheet, Pressable } from 'react-native';
 import Animated, { runOnJS, type SharedValue } from 'react-native-reanimated';
@@ -16,8 +16,24 @@ import { SearchHoldFilterRings } from './SearchHoldFilterRings';
 
 /** Context handed to an overlay rendered inside the board's zoom transform. */
 export type FilterBoardTransformContext = {
-  /** The board's pinch gesture, to compose overlay pans Simultaneous with it. */
+  /**
+   * The board's pinch gesture.
+   *
+   * NOTE for new overlays: do NOT compose this instance into your own
+   * `GestureDetector`. RNGH assigns one handler tag per Gesture object and
+   * `createGestureHandler` throws "Handler with tag N already exists" the moment
+   * a second detector mounts it (RNGestureHandlerModule.kt /
+   * RNGestureHandlerManager.mm). Declare the relation instead:
+   * `yourGesture.simultaneousWithExternalGesture(pinchRef)`.
+   */
   pinchGesture: GestureType;
+  /**
+   * Ref handle on that same pinch, for
+   * `simultaneousWithExternalGesture(pinchRef)` — the safe way to let a
+   * two-finger zoom recognise while a finger sits on your overlay. See the
+   * warning on `pinchGesture`.
+   */
+  pinchRef: MutableRefObject<GestureType | undefined>;
   /** Live zoom scale, so an overlay can convert screen-pixel deltas to board px. */
   scaleSV: SharedValue<number>;
   /**
@@ -62,10 +78,22 @@ type InteractiveFilterBoardProps = {
    */
   renderInTransform?: (context: FilterBoardTransformContext) => ReactNode;
   /**
-   * Overlay rendered ABOVE the zoom transform (and above the zoomed pan layer),
-   * in plain container coordinates — used by the outline editor for the stylus
-   * draw surface, which has to see raw screen points and invert the transform
-   * itself. Rendered before the reset-zoom button so that button stays tappable.
+   * Overlay rendered ABOVE the zoom transform, in plain container coordinates —
+   * used by the outline editor for the stylus draw surface, which has to see raw
+   * screen points and invert the transform itself.
+   *
+   * While zoomed it is rendered as a CHILD of the pan overlay's view, not as a
+   * sibling above it. That nesting is what makes a gesture the overlay declines
+   * (`manager.fail()` on a finger when only a stylus draws) fall through to the
+   * board's own pan and hold taps: RNGH offers a touch to the handlers on the
+   * touched view and its ANCESTORS, so a sibling that merely sits underneath
+   * would never see it and one-finger panning would be dead.
+   *
+   * At rest there is no pan overlay to nest inside, so it renders as a sibling —
+   * and an at-rest tap the overlay declines reaches the ancestor pinch but not
+   * the hold-tap layer inside the transform. Callers that need tap-to-select at
+   * rest must offer their own affordance (the outline editor's "Pick another
+   * hold").
    */
   renderAboveBoard?: (context: FilterBoardTransformContext) => ReactNode;
 };
@@ -135,6 +163,7 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
   const transformContext = useMemo<FilterBoardTransformContext>(
     () => ({
       pinchGesture,
+      pinchRef,
       scaleSV,
       translateXSV,
       translateYSV,
@@ -295,7 +324,12 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
               `overlayGesture` is the bare pan (no onHoldTap). */}
           {isZoomed ? (
             <GestureDetector gesture={overlayGesture}>
-              <View style={StyleSheet.absoluteFill} />
+              <View style={StyleSheet.absoluteFill}>
+                {/* renderAboveBoard nests HERE, inside the pan's own view, so
+                    this gesture is its ancestor and a declined touch falls
+                    through to the pan / zoomed hold taps. See the prop's doc. */}
+                {renderAboveBoard ? renderAboveBoard(transformContext) : null}
+              </View>
             </GestureDetector>
           ) : null}
 
@@ -309,10 +343,10 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
             </Animated.View>
           ) : null}
 
-          {/* Overlay ABOVE the transform, in container coordinates. Sits over
-              the zoomed pan layer so it gets first refusal on a touch, and
-              before the reset-zoom button so that button still wins its own. */}
-          {renderAboveBoard ? renderAboveBoard(transformContext) : null}
+          {/* At rest there is no pan overlay to nest inside, so the above-board
+              overlay renders as a sibling here — before the reset-zoom button so
+              that button still wins its own touches. */}
+          {!isZoomed && renderAboveBoard ? renderAboveBoard(transformContext) : null}
 
           {isZoomed ? (
             <Pressable style={styles.resetButton} onPress={resetZoom} hitSlop={8} accessibilityRole="button">

--- a/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
+++ b/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
@@ -20,6 +20,18 @@ export type FilterBoardTransformContext = {
   pinchGesture: GestureType;
   /** Live zoom scale, so an overlay can convert screen-pixel deltas to board px. */
   scaleSV: SharedValue<number>;
+  /**
+   * The rest of the live zoom transform. Together with `scaleSV` and the
+   * container size these are everything needed to invert the board's transform
+   * on the UI thread — what an overlay drawn ABOVE the transform (see
+   * `renderAboveBoard`) needs to map a screen point back to board-local px.
+   * Produced by `useZoomPanGesture` all along; forwarded here so an overlay
+   * doesn't have to re-derive them.
+   */
+  translateXSV: SharedValue<number>;
+  translateYSV: SharedValue<number>;
+  containerWidthSV: SharedValue<number>;
+  containerHeightSV: SharedValue<number>;
   renderWidth: number;
   renderHeight: number;
 };
@@ -49,6 +61,13 @@ type InteractiveFilterBoardProps = {
    * rectangle. Receives the board pinch + live scale so its pans compose cleanly.
    */
   renderInTransform?: (context: FilterBoardTransformContext) => ReactNode;
+  /**
+   * Overlay rendered ABOVE the zoom transform (and above the zoomed pan layer),
+   * in plain container coordinates — used by the outline editor for the stylus
+   * draw surface, which has to see raw screen points and invert the transform
+   * itself. Rendered before the reset-zoom button so that button stays tappable.
+   */
+  renderAboveBoard?: (context: FilterBoardTransformContext) => ReactNode;
 };
 
 const TAP_MAX_DURATION_MS = 300;
@@ -82,6 +101,7 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
   renderWidth,
   renderHeight,
   renderInTransform,
+  renderAboveBoard,
 }: InteractiveFilterBoardProps) {
   const { t } = useTranslation('common');
   // Shared with the per-hold detectors and the rest/zoom tap overlays so they
@@ -113,8 +133,17 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
   // handler (HoldTargetLayer requires both).
 
   const transformContext = useMemo<FilterBoardTransformContext>(
-    () => ({ pinchGesture, scaleSV, renderWidth, renderHeight }),
-    [pinchGesture, scaleSV, renderWidth, renderHeight],
+    () => ({
+      pinchGesture,
+      scaleSV,
+      translateXSV,
+      translateYSV,
+      containerWidthSV,
+      containerHeightSV,
+      renderWidth,
+      renderHeight,
+    }),
+    [pinchGesture, scaleSV, translateXSV, translateYSV, containerWidthSV, containerHeightSV, renderWidth, renderHeight],
   );
 
   // Hit circles so the zoomed pan overlay can resolve a tap to a hold itself
@@ -279,6 +308,11 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
               {renderInTransform(transformContext)}
             </Animated.View>
           ) : null}
+
+          {/* Overlay ABOVE the transform, in container coordinates. Sits over
+              the zoomed pan layer so it gets first refusal on a touch, and
+              before the reset-zoom button so that button still wins its own. */}
+          {renderAboveBoard ? renderAboveBoard(transformContext) : null}
 
           {isZoomed ? (
             <Pressable style={styles.resetButton} onPress={resetZoom} hitSlop={8} accessibilityRole="button">

--- a/packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx
@@ -53,7 +53,12 @@ vi.mock('react-native-gesture-handler', () => {
       LongPress: createGesture,
       Exclusive: (...gestures: unknown[]) => ({ gestures }),
     },
-    GestureDetector: ({ children }: ChildrenProps) => createElement('div', { 'data-gesture': 'true' }, children),
+    GestureDetector: ({ children, gesture }: ChildrenProps & { gesture?: { zoomedPanOverlay?: boolean } }) =>
+      createElement(
+        'div',
+        { 'data-gesture': 'true', 'data-zoom-pan': gesture?.zoomedPanOverlay ? 'true' : undefined },
+        children,
+      ),
   };
 });
 
@@ -78,7 +83,7 @@ vi.mock('../../play-drawer/use-zoom-pan-gesture', () => ({
 // The composed overlay gesture is exercised by holdLayout unit tests + device
 // QA; here we only assert the zoomed chrome, so return a placeholder gesture.
 vi.mock('../../create-climb/use-zoomed-hold-tap-gesture', () => ({
-  useZoomedHoldTapGesture: () => ({}),
+  useZoomedHoldTapGesture: () => ({ zoomedPanOverlay: true }),
   PAN_ACTIVATION_OFFSET: 8,
 }));
 
@@ -250,5 +255,54 @@ describe('InteractiveFilterBoard', () => {
     expect(context.translateYSV).toBe(zoomState.translateYSV);
     expect(context.containerWidthSV).toBe(zoomState.containerWidthSV);
     expect(context.containerHeightSV).toBe(zoomState.containerHeightSV);
+  });
+  it('nests renderAboveBoard inside the pan detector while zoomed, so declined touches fall through', () => {
+    // RNGH offers a declined touch to ANCESTORS, never to siblings drawn
+    // underneath. If the overlay were a sibling of the pan layer, a finger the
+    // outline editor's draw surface fails would reach nothing and one-finger
+    // panning would be dead while a hold is selected.
+    zoomState.isZoomed = true;
+    const { container } = render(
+      <InteractiveFilterBoard
+        boardName="kilter"
+        layoutId={1}
+        sizeId={10}
+        setIds="1,2"
+        boardWidth={1000}
+        boardHeight={1000}
+        holdTargets={holdTargets}
+        renderWidth={400}
+        renderHeight={500}
+        renderAboveBoard={() => <div data-above-board="true" />}
+      />,
+    );
+    const panDetector = container.querySelector('[data-zoom-pan="true"]');
+    expect(panDetector).not.toBeNull();
+    expect(panDetector?.querySelector('[data-above-board="true"]')).not.toBeNull();
+  });
+
+  it('hands renderAboveBoard a pinchRef so overlays relate to the pinch instead of mounting it', () => {
+    // Composing the board's pinch INSTANCE into a second GestureDetector throws
+    // "Handler with tag N already exists" in RNGH 2.32 — the ref is the safe
+    // handle for simultaneousWithExternalGesture.
+    const seen: Record<string, unknown>[] = [];
+    render(
+      <InteractiveFilterBoard
+        boardName="kilter"
+        layoutId={1}
+        sizeId={10}
+        setIds="1,2"
+        boardWidth={1000}
+        boardHeight={1000}
+        holdTargets={holdTargets}
+        renderWidth={400}
+        renderHeight={500}
+        renderAboveBoard={(context) => {
+          seen.push(context as unknown as Record<string, unknown>);
+          return null;
+        }}
+      />,
+    );
+    expect(seen[0].pinchRef).toBeDefined();
   });
 });

--- a/packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx
@@ -7,7 +7,15 @@ import type { BoardHoldTarget } from '../../../lib/create-board-holds';
 
 // Controls the mocked zoom hook so each test can assert the zoomed-only chrome
 // (pan overlay + reset button) without driving real gestures.
-const zoomState = vi.hoisted(() => ({ isZoomed: false, resetZoom: vi.fn() }));
+const zoomState = vi.hoisted(() => ({
+  isZoomed: false,
+  resetZoom: vi.fn(),
+  scaleSV: { value: 1 },
+  translateXSV: { value: 0 },
+  translateYSV: { value: 0 },
+  containerWidthSV: { value: 400 },
+  containerHeightSV: { value: 500 },
+}));
 
 type ChildrenProps = { children?: ReactNode };
 type StyleProps = ChildrenProps & { style?: unknown };
@@ -56,6 +64,14 @@ vi.mock('../../play-drawer/use-zoom-pan-gesture', () => ({
     isZoomed: zoomState.isZoomed,
     resetZoom: zoomState.resetZoom,
     animatedZoomStyle: {},
+    // The transform shared values the board forwards through
+    // FilterBoardTransformContext. Stand-ins, not real shared values — the
+    // renderAboveBoard tests only assert they reach the overlay.
+    scaleSV: zoomState.scaleSV,
+    translateXSV: zoomState.translateXSV,
+    translateYSV: zoomState.translateYSV,
+    containerWidthSV: zoomState.containerWidthSV,
+    containerHeightSV: zoomState.containerHeightSV,
   }),
 }));
 
@@ -202,5 +218,37 @@ describe('InteractiveFilterBoard', () => {
 
     const unknown = renderBoard({ activeHoldId: 999 });
     expect(unknown.container.querySelector('[data-hold-layer="true"]')).not.toBeNull();
+  });
+  it('does not render an above-board overlay unless one is asked for', () => {
+    const { container } = renderBoard();
+    expect(container.querySelector('[data-above-board="true"]')).toBeNull();
+  });
+
+  it('renders renderAboveBoard and hands it the full zoom transform', () => {
+    const seen: Record<string, unknown>[] = [];
+    const { container } = render(
+      <InteractiveFilterBoard
+        boardName="kilter"
+        layoutId={1}
+        sizeId={10}
+        setIds="1,2"
+        boardWidth={1000}
+        boardHeight={1000}
+        holdTargets={holdTargets}
+        renderWidth={400}
+        renderHeight={500}
+        renderAboveBoard={(context) => {
+          seen.push(context as unknown as Record<string, unknown>);
+          return <div data-above-board="true" />;
+        }}
+      />,
+    );
+    expect(container.querySelector('[data-above-board="true"]')).not.toBeNull();
+    const context = seen[0];
+    expect(context.scaleSV).toBe(zoomState.scaleSV);
+    expect(context.translateXSV).toBe(zoomState.translateXSV);
+    expect(context.translateYSV).toBe(zoomState.translateYSV);
+    expect(context.containerWidthSV).toBe(zoomState.containerWidthSV);
+    expect(context.containerHeightSV).toBe(zoomState.containerHeightSV);
   });
 });

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/hold-outline-cache.test.ts
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/hold-outline-cache.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { withHoldOutlineOverride, withoutHoldOutlineOverride } from '../hold-outline-cache';
+import type { HoldOutlinesQueryResponse, HoldOutlineOverrideRow } from '../../operations';
+
+// The outline editor's mutations write the React Query cache directly instead of
+// invalidating — a refetch would re-download the config's whole traced shard set
+// on every single save. That makes these two splices the only thing keeping the
+// board on screen honest, so they get their own tests.
+
+function overrideRow(overrides: Partial<HoldOutlineOverrideRow> = {}): HoldOutlineOverrideRow {
+  return {
+    placementId: 1448,
+    kind: 'SILHOUETTE',
+    outline: [1, 0, 0, 1, -1, 0],
+    note: null,
+    authorId: 'user-1',
+    authorDisplayName: 'Marco',
+    updatedAt: '2026-08-30T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function cache(overrides: HoldOutlineOverrideRow[]): HoldOutlinesQueryResponse {
+  return {
+    holdOutlines: {
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 28,
+      shardOutlines: [{ placementId: 1448, outline: [0.9, 0, 0, 0.9, -0.9, 0] }],
+      overrides,
+    },
+  };
+}
+
+describe('withHoldOutlineOverride', () => {
+  it('adds a row for a placement that had none', () => {
+    const next = withHoldOutlineOverride(cache([]), overrideRow());
+    expect(next.holdOutlines.overrides).toHaveLength(1);
+    expect(next.holdOutlines.overrides[0].placementId).toBe(1448);
+  });
+
+  it('replaces the row for the same placement AND kind, rather than duplicating it', () => {
+    const previous = cache([overrideRow({ outline: [2, 0, 0, 2, -2, 0] })]);
+    const next = withHoldOutlineOverride(previous, overrideRow({ outline: [1, 0, 0, 1, -1, 0] }));
+    expect(next.holdOutlines.overrides).toHaveLength(1);
+    expect(next.holdOutlines.overrides[0].outline).toEqual([1, 0, 0, 1, -1, 0]);
+  });
+
+  it('leaves the other kind on the same placement standing', () => {
+    // A silhouette correction and an LED-ring annotation describe different
+    // boundaries of one hold and coexist; saving one must not drop the other.
+    const previous = cache([overrideRow({ kind: 'LED_INNER' })]);
+    const next = withHoldOutlineOverride(previous, overrideRow({ kind: 'SILHOUETTE' }));
+    expect(next.holdOutlines.overrides.map((row) => row.kind).sort((a, b) => a.localeCompare(b))).toEqual([
+      'LED_INNER',
+      'SILHOUETTE',
+    ]);
+  });
+
+  it('leaves other placements and the shard outlines untouched', () => {
+    const previous = cache([overrideRow({ placementId: 4800 })]);
+    const next = withHoldOutlineOverride(previous, overrideRow({ placementId: 1448 }));
+    expect(next.holdOutlines.overrides.map((row) => row.placementId).sort((a, b) => a - b)).toEqual([1448, 4800]);
+    expect(next.holdOutlines.shardOutlines).toEqual(previous.holdOutlines.shardOutlines);
+  });
+});
+
+describe('withoutHoldOutlineOverride', () => {
+  it('drops the named placement and kind', () => {
+    const previous = cache([overrideRow()]);
+    expect(withoutHoldOutlineOverride(previous, 1448, 'SILHOUETTE').holdOutlines.overrides).toEqual([]);
+  });
+
+  it('defaults an absent kind to SILHOUETTE, the way the resolver does', () => {
+    // `kind` is optional on DeleteHoldOutlineOverrideInput. If the client didn't
+    // normalise it the same way the server does, a bare revert would delete the
+    // row on the backend and leave it on screen.
+    const previous = cache([overrideRow()]);
+    expect(withoutHoldOutlineOverride(previous, 1448, undefined).holdOutlines.overrides).toEqual([]);
+  });
+
+  it('does not touch the other kind on the same placement', () => {
+    const previous = cache([overrideRow({ kind: 'SILHOUETTE' }), overrideRow({ kind: 'LED_INNER' })]);
+    const next = withoutHoldOutlineOverride(previous, 1448, 'LED_INNER');
+    expect(next.holdOutlines.overrides.map((row) => row.kind)).toEqual(['SILHOUETTE']);
+  });
+
+  it('is a no-op when nothing matches', () => {
+    const previous = cache([overrideRow({ placementId: 4800 })]);
+    expect(withoutHoldOutlineOverride(previous, 1448, 'SILHOUETTE').holdOutlines.overrides).toHaveLength(1);
+  });
+});

--- a/packages/mobile/src/lib/graphql/hooks/hold-outline-cache.ts
+++ b/packages/mobile/src/lib/graphql/hooks/hold-outline-cache.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure cache splices for the hold-outline editor's mutations.
+ *
+ * Their own module, not part of `hooks/index`, for the same reason
+ * `use-notifications` is kept out of that barrel: it reaches native modules, so
+ * importing it from a test that mocks only the GraphQL client sends Rolldown's
+ * scan into react-native's Flow source and fails the whole file. These are
+ * plain data transforms and their tests should not have to mock a thing.
+ *
+ * Why splice at all: the editor's mutations write the React Query cache directly
+ * instead of invalidating. The server answers an upsert with the stored row, so
+ * the cache can be made exact without a round trip — and a refetch would
+ * re-download the config's entire traced shard set on every single save, which
+ * on a large Kilter layout is thousands of polygons for a one-placement edit.
+ */
+
+import type { HoldOutlineKind } from '@boardsesh/shared-schema';
+import type { HoldOutlineOverrideRow, HoldOutlinesQueryResponse } from '../operations';
+
+/**
+ * Replace (or add) one override row, keyed by placement AND kind.
+ *
+ * Both parts of the key matter: a silhouette correction and an LED-ring
+ * annotation describe different boundaries of the same hold and coexist, so
+ * saving one must not evict the other.
+ */
+export function withHoldOutlineOverride(
+  previous: HoldOutlinesQueryResponse,
+  row: HoldOutlineOverrideRow,
+): HoldOutlinesQueryResponse {
+  const others = previous.holdOutlines.overrides.filter(
+    (override) => !(override.placementId === row.placementId && override.kind === row.kind),
+  );
+  return { holdOutlines: { ...previous.holdOutlines, overrides: [...others, row] } };
+}
+
+/**
+ * Drop one override row. `kind` is optional on the mutation input and defaults
+ * to SILHOUETTE server-side, so it is normalised the same way here — without
+ * that, a bare revert would delete the row on the backend and leave it on
+ * screen.
+ */
+export function withoutHoldOutlineOverride(
+  previous: HoldOutlinesQueryResponse,
+  placementId: number,
+  kind: HoldOutlineKind | undefined,
+): HoldOutlinesQueryResponse {
+  const resolvedKind: HoldOutlineKind = kind ?? 'SILHOUETTE';
+  return {
+    holdOutlines: {
+      ...previous.holdOutlines,
+      overrides: previous.holdOutlines.overrides.filter(
+        (override) => !(override.placementId === placementId && override.kind === resolvedKind),
+      ),
+    },
+  };
+}

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -19,6 +19,7 @@ import type {
   RequestGymClaimInput,
   UpsertHoldOutlineOverrideInput,
   DeleteHoldOutlineOverrideInput,
+  HoldOutlineKind,
 } from '@boardsesh/shared-schema';
 import {
   SIMILAR_CLIMBS_QUERY,
@@ -134,6 +135,7 @@ import {
   DELETE_HOLD_OUTLINE_OVERRIDE,
   type GetProfileAdminFlagQueryResponse,
   type HoldOutlinesQueryResponse,
+  type HoldOutlineOverrideRow,
   type UpsertHoldOutlineOverrideMutationResponse,
   type DeleteHoldOutlineOverrideMutationResponse,
 } from '../operations';
@@ -1473,16 +1475,29 @@ export function useUpsertHoldOutlineOverride() {
       );
       return response.upsertHoldOutlineOverride;
     },
-    onSuccess: (_row, input) => {
-      void queryClient.invalidateQueries({
-        queryKey: holdOutlinesQueryKey({
-          boardName: input.boardName,
-          layoutId: input.layoutId,
-          sizeId: input.sizeId,
-        }),
-      });
+    // Splice the returned row into the cache rather than invalidating. The
+    // mutation answers with the stored row, so the cache can be made exact
+    // without a round trip — and a refetch would re-download the config's whole
+    // traced shard set on every single save, which on a big Kilter layout is
+    // thousands of polygons for a one-placement edit.
+    onSuccess: (row, input) => {
+      queryClient.setQueryData<HoldOutlinesQueryResponse>(
+        holdOutlinesQueryKey({ boardName: input.boardName, layoutId: input.layoutId, sizeId: input.sizeId }),
+        (previous) => (previous ? withHoldOutlineOverride(previous, row) : previous),
+      );
     },
   });
+}
+
+/** Replace (or add) one override row, keyed by placement AND kind. */
+function withHoldOutlineOverride(
+  previous: HoldOutlinesQueryResponse,
+  row: HoldOutlineOverrideRow,
+): HoldOutlinesQueryResponse {
+  const others = previous.holdOutlines.overrides.filter(
+    (override) => !(override.placementId === row.placementId && override.kind === row.kind),
+  );
+  return { holdOutlines: { ...previous.holdOutlines, overrides: [...others, row] } };
 }
 
 /**
@@ -1500,14 +1515,26 @@ export function useDeleteHoldOutlineOverride() {
       );
       return response.deleteHoldOutlineOverride;
     },
+    // Drop the row from the cache directly, for the same reason the upsert
+    // splices: a revert must not re-download the whole shard set. `kind` is
+    // optional on the input and defaults to SILHOUETTE server-side, so normalise
+    // before matching or a bare revert would drop nothing.
     onSuccess: (_deleted, input) => {
-      void queryClient.invalidateQueries({
-        queryKey: holdOutlinesQueryKey({
-          boardName: input.boardName,
-          layoutId: input.layoutId,
-          sizeId: input.sizeId,
-        }),
-      });
+      const kind: HoldOutlineKind = input.kind ?? 'SILHOUETTE';
+      queryClient.setQueryData<HoldOutlinesQueryResponse>(
+        holdOutlinesQueryKey({ boardName: input.boardName, layoutId: input.layoutId, sizeId: input.sizeId }),
+        (previous) =>
+          previous
+            ? {
+                holdOutlines: {
+                  ...previous.holdOutlines,
+                  overrides: previous.holdOutlines.overrides.filter(
+                    (override) => !(override.placementId === input.placementId && override.kind === kind),
+                  ),
+                },
+              }
+            : previous,
+      );
     },
   });
 }

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -19,7 +19,6 @@ import type {
   RequestGymClaimInput,
   UpsertHoldOutlineOverrideInput,
   DeleteHoldOutlineOverrideInput,
-  HoldOutlineKind,
 } from '@boardsesh/shared-schema';
 import {
   SIMILAR_CLIMBS_QUERY,
@@ -87,6 +86,7 @@ import {
   type GetBoardBySlugQueryResponse,
 } from '@boardsesh/graphql/operations/boards';
 import { getHttpClient } from '../client';
+import { withHoldOutlineOverride, withoutHoldOutlineOverride } from './hold-outline-cache';
 import {
   GET_PROFILE,
   UPDATE_PROFILE,
@@ -135,7 +135,6 @@ import {
   DELETE_HOLD_OUTLINE_OVERRIDE,
   type GetProfileAdminFlagQueryResponse,
   type HoldOutlinesQueryResponse,
-  type HoldOutlineOverrideRow,
   type UpsertHoldOutlineOverrideMutationResponse,
   type DeleteHoldOutlineOverrideMutationResponse,
 } from '../operations';
@@ -1489,17 +1488,6 @@ export function useUpsertHoldOutlineOverride() {
   });
 }
 
-/** Replace (or add) one override row, keyed by placement AND kind. */
-function withHoldOutlineOverride(
-  previous: HoldOutlinesQueryResponse,
-  row: HoldOutlineOverrideRow,
-): HoldOutlinesQueryResponse {
-  const others = previous.holdOutlines.overrides.filter(
-    (override) => !(override.placementId === row.placementId && override.kind === row.kind),
-  );
-  return { holdOutlines: { ...previous.holdOutlines, overrides: [...others, row] } };
-}
-
 /**
  * Drop one placement's override of one kind, reverting the renderer to whatever
  * the shard traced. Dropping a silhouette leaves any LED_INNER annotation
@@ -1520,20 +1508,10 @@ export function useDeleteHoldOutlineOverride() {
     // optional on the input and defaults to SILHOUETTE server-side, so normalise
     // before matching or a bare revert would drop nothing.
     onSuccess: (_deleted, input) => {
-      const kind: HoldOutlineKind = input.kind ?? 'SILHOUETTE';
       queryClient.setQueryData<HoldOutlinesQueryResponse>(
         holdOutlinesQueryKey({ boardName: input.boardName, layoutId: input.layoutId, sizeId: input.sizeId }),
         (previous) =>
-          previous
-            ? {
-                holdOutlines: {
-                  ...previous.holdOutlines,
-                  overrides: previous.holdOutlines.overrides.filter(
-                    (override) => !(override.placementId === input.placementId && override.kind === kind),
-                  ),
-                },
-              }
-            : previous,
+          previous ? withoutHoldOutlineOverride(previous, input.placementId, input.kind ?? undefined) : previous,
       );
     },
   });

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -17,6 +17,8 @@ import type {
   GrantGymWriteAccessInput,
   RevokeGymWriteAccessInput,
   RequestGymClaimInput,
+  UpsertHoldOutlineOverrideInput,
+  DeleteHoldOutlineOverrideInput,
 } from '@boardsesh/shared-schema';
 import {
   SIMILAR_CLIMBS_QUERY,
@@ -126,6 +128,14 @@ import {
   type EndSessionMutationResponse,
   type ToggleFavoriteMutationVariables,
   type ToggleFavoriteMutationResponse,
+  GET_PROFILE_ADMIN_FLAG,
+  GET_HOLD_OUTLINES,
+  UPSERT_HOLD_OUTLINE_OVERRIDE,
+  DELETE_HOLD_OUTLINE_OVERRIDE,
+  type GetProfileAdminFlagQueryResponse,
+  type HoldOutlinesQueryResponse,
+  type UpsertHoldOutlineOverrideMutationResponse,
+  type DeleteHoldOutlineOverrideMutationResponse,
 } from '../operations';
 
 type ToggleFavoriteVariables = ToggleFavoriteMutationVariables & {
@@ -1395,3 +1405,109 @@ export {
   useSetIntegrationAutoSync,
   useSyncSessionToIntegration,
 } from './use-integrations';
+
+// ============================================
+// Hold Outline Overrides (admin outline editor)
+// ============================================
+
+/**
+ * Is the viewer an admin? Its own query document, not a field on `useProfile`.
+ *
+ * `UserProfile.isAdmin` reaches production in a backend deploy that lands after
+ * this JS does, so asking for it inside `GET_PROFILE` would fail that whole
+ * query — and blank the You tab — for every user until the two lined up. Here a
+ * miss is contained: the query errors, `data` stays undefined, and the flag
+ * reads false. Fail-closed is the right default for an admin gate anyway.
+ */
+export function useIsAdmin(options?: { enabled?: boolean }): { isAdmin: boolean; isLoading: boolean } {
+  const query = useQuery({
+    queryKey: ['profileAdminFlag'],
+    queryFn: () => getHttpClient().request<GetProfileAdminFlagQueryResponse>(GET_PROFILE_ADMIN_FLAG),
+    select: (data) => data.profile?.isAdmin ?? false,
+    enabled: options?.enabled ?? true,
+    // One retry only: an old backend rejects this document every time, and the
+    // gate should settle to "no" quickly rather than spin.
+    retry: 1,
+  });
+  return { isAdmin: query.data ?? false, isLoading: query.isLoading };
+}
+
+export type HoldOutlineConfigKey = { boardName: string; layoutId: number; sizeId: number };
+
+/** Query key both the outline query and its mutations invalidate against. */
+function holdOutlinesQueryKey(config: HoldOutlineConfigKey) {
+  return ['holdOutlines', config.boardName, config.layoutId, config.sizeId] as const;
+}
+
+/**
+ * The traced silhouettes the deployed shard ships for one board config, plus
+ * every live override of every kind. The editor draws both — the shard as what
+ * the tracer produced, the overrides as what a human corrected — so they arrive
+ * side by side rather than merged.
+ */
+export function useHoldOutlines(config: HoldOutlineConfigKey | null, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: config ? holdOutlinesQueryKey(config) : ['holdOutlines', null],
+    queryFn: () =>
+      getHttpClient().request<HoldOutlinesQueryResponse>(GET_HOLD_OUTLINES, {
+        input: { boardName: config?.boardName, layoutId: config?.layoutId, sizeId: config?.sizeId },
+      }),
+    select: (data) => data.holdOutlines,
+    enabled: (options?.enabled ?? true) && config != null,
+  });
+}
+
+/**
+ * Store a hand-drawn ring for one placement and kind. The server re-validates
+ * the ring (shape, bounds, and that it covers the placement centre) and rejects
+ * anything it doesn't like, so the caller has to surface the failure rather than
+ * assume the write landed.
+ */
+export function useUpsertHoldOutlineOverride() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: UpsertHoldOutlineOverrideInput) => {
+      const response = await getHttpClient().request<UpsertHoldOutlineOverrideMutationResponse>(
+        UPSERT_HOLD_OUTLINE_OVERRIDE,
+        { input },
+      );
+      return response.upsertHoldOutlineOverride;
+    },
+    onSuccess: (_row, input) => {
+      void queryClient.invalidateQueries({
+        queryKey: holdOutlinesQueryKey({
+          boardName: input.boardName,
+          layoutId: input.layoutId,
+          sizeId: input.sizeId,
+        }),
+      });
+    },
+  });
+}
+
+/**
+ * Drop one placement's override of one kind, reverting the renderer to whatever
+ * the shard traced. Dropping a silhouette leaves any LED_INNER annotation
+ * standing, and vice versa — the server keys on both.
+ */
+export function useDeleteHoldOutlineOverride() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: DeleteHoldOutlineOverrideInput) => {
+      const response = await getHttpClient().request<DeleteHoldOutlineOverrideMutationResponse>(
+        DELETE_HOLD_OUTLINE_OVERRIDE,
+        { input },
+      );
+      return response.deleteHoldOutlineOverride;
+    },
+    onSuccess: (_deleted, input) => {
+      void queryClient.invalidateQueries({
+        queryKey: holdOutlinesQueryKey({
+          boardName: input.boardName,
+          layoutId: input.layoutId,
+          sizeId: input.sizeId,
+        }),
+      });
+    },
+  });
+}

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -25,6 +25,11 @@ import type {
   SessionGradeDistributionItem,
   SessionHealthExport,
   UserSearchConnection,
+  HoldOutlineConfigInput,
+  HoldOutlineKind,
+  PlacementOutline,
+  UpsertHoldOutlineOverrideInput,
+  DeleteHoldOutlineOverrideInput,
 } from '@boardsesh/shared-schema';
 import type { SubscriptionQueueItem } from '../queue-conversion';
 
@@ -1714,4 +1719,121 @@ export type RemoveFavoriteMutationVariables = {
 
 export type RemoveFavoriteMutationResponse = {
   removeFavorite: boolean;
+};
+
+// ============================================
+// Hold Outline Overrides (admin outline editor)
+// ============================================
+
+/**
+ * The viewer's admin flag, asked for on its own rather than added to
+ * `GET_PROFILE`.
+ *
+ * `UserProfile.isAdmin` ships in a backend deploy that lands AFTER this JS does
+ * (mobile updates over the air, the backend on its own cadence). Folded into the
+ * profile document, an unknown field would fail the whole query and blank the
+ * You tab for everyone until the backend caught up. On its own it fails alone,
+ * and the hook reading it falls closed to "not an admin".
+ */
+export const GET_PROFILE_ADMIN_FLAG = gql`
+  query ProfileAdminFlag {
+    profile {
+      id
+      isAdmin
+    }
+  }
+`;
+
+export type GetProfileAdminFlagQueryResponse = {
+  profile: { id: string; isAdmin: boolean } | null;
+};
+
+export const GET_HOLD_OUTLINES = gql`
+  query HoldOutlines($input: HoldOutlineConfigInput!) {
+    holdOutlines(input: $input) {
+      boardName
+      layoutId
+      sizeId
+      shardOutlines {
+        placementId
+        outline
+      }
+      overrides {
+        placementId
+        kind
+        outline
+        note
+        authorId
+        authorDisplayName
+        updatedAt
+      }
+    }
+  }
+`;
+
+export type HoldOutlinesQueryVariables = {
+  input: HoldOutlineConfigInput;
+};
+
+/**
+ * Hand-written response type: `packages/mobile` is deliberately outside the
+ * codegen globs, so every operation in this file declares the exact selection it
+ * asks for. Narrower than the schema's `BoardHoldOutlines` — the config echo is
+ * dropped from the override rows because the query already knows it.
+ */
+export type HoldOutlinesQueryResponse = {
+  holdOutlines: {
+    boardName: string;
+    layoutId: number;
+    sizeId: number;
+    shardOutlines: PlacementOutline[];
+    overrides: HoldOutlineOverrideRow[];
+  };
+};
+
+/** One override as this document selects it. */
+export type HoldOutlineOverrideRow = {
+  placementId: number;
+  kind: HoldOutlineKind;
+  outline: number[];
+  note: string | null;
+  authorId: string | null;
+  authorDisplayName: string | null;
+  updatedAt: string;
+};
+
+export const UPSERT_HOLD_OUTLINE_OVERRIDE = gql`
+  mutation UpsertHoldOutlineOverride($input: UpsertHoldOutlineOverrideInput!) {
+    upsertHoldOutlineOverride(input: $input) {
+      placementId
+      kind
+      outline
+      note
+      authorId
+      authorDisplayName
+      updatedAt
+    }
+  }
+`;
+
+export type UpsertHoldOutlineOverrideMutationVariables = {
+  input: UpsertHoldOutlineOverrideInput;
+};
+
+export type UpsertHoldOutlineOverrideMutationResponse = {
+  upsertHoldOutlineOverride: HoldOutlineOverrideRow;
+};
+
+export const DELETE_HOLD_OUTLINE_OVERRIDE = gql`
+  mutation DeleteHoldOutlineOverride($input: DeleteHoldOutlineOverrideInput!) {
+    deleteHoldOutlineOverride(input: $input)
+  }
+`;
+
+export type DeleteHoldOutlineOverrideMutationVariables = {
+  input: DeleteHoldOutlineOverrideInput;
+};
+
+export type DeleteHoldOutlineOverrideMutationResponse = {
+  deleteHoldOutlineOverride: boolean;
 };


### PR DESCRIPTION
## Summary

An admin-only pair of routes in the Expo app for correcting the traced hold silhouettes the board renderer lights, plus a second annotation mode that captures the LED base-plate ring.

The tracer (`@boardsesh/board-art-geometry`) gets most holds right and some badly wrong, and there has been no way to fix one short of re-running the whole capture pipeline. This adds the human-in-the-loop half: a board/layout/size picker, then a canvas that draws every placement's outline over the real board art and lets an Apple Pencil re-trace the one that's wrong. Saving writes a `HoldOutlineOverride` row through the API added in #4856; reverting deletes it.

**What it does**

- **Picker** — board → layout → size, everything the `holdOutlines` query can serve. MoonBoard and Woods carry no rows in the Aurora product-size tables, so their layouts/sizes/sets come from `@boardsesh/board-config` instead; a config with no traced shard at all is exactly the one worth hand-drawing, so nothing is excluded.
- **Canvas** — one SVG over the zoomable board. Every placement is drawn in the colour of its state: traced, overridden, missing (a dashed placement-radius ring, what the renderer falls back to), plus a faint ghost of the shard outline still sitting under a differing override.
- **Draw** — tap a hold, trace around it, Save. The stroke is decimated by the tracer's own Douglas-Peucker at the tracer's own tolerance, so a corrected ring is the same kind of object as the ones beside it.
- **LED ring mode** (`kind: LED_INNER`) — stores the INNER boundary of a hold's LED base plate; the lit ring is the silhouette minus that polygon. These are hand annotations that become ground truth for a later auto-extractor, so the mode toggle is explicit and its strokes get their own colour. Reverting here is labelled "Remove ring annotation" — there is no traced version to fall back to.
- **Finger-draw toggle** — off by default, so on an iPad the Pencil draws while a finger still pans and pinches. On, for anyone without a stylus.

**Gating.** `__DEV__ || isAdmin`, on both the More-tab row and each route itself (a deep link reaches these directly, and the mutations rewrite what every climber's board renders). `isAdmin` rides its own small query rather than joining `GET_PROFILE`: the backend field deploys after this JS does, and an unknown field inside the profile document would fail that whole query and blank the You tab until the two lined up. On its own it fails alone and reads false — fail-closed, which is the right default for an admin gate anyway.

Copy is hardcoded English literals with `i18n-ignore`, the convention the tester-only Feature Flags / Offline Writes screens already follow.

### Stacked on #4856 — and on the native release train

Based on `feat/hold-outline-overrides-backend`, and targeted at it. **Merge #4856 first**; this retargets to `release/next` once that lands.

**This does not ship as a production OTA**, despite being a JS-only diff. My four commits touch zero fingerprint inputs — no `app.config.ts`, no `plugins/`, no `modules/`, no `package.json`, no `patches/` (`git diff --name-only 192b845f7..HEAD` over those globs is empty), and gesture-handler, svg and reanimated are all already in the shipped binary. But the stack is based on `release/next`, whose ancestry carries the Expo 57 upgrade, the rebuilt Rust renderer `.so`/`.a` artifacts and the live-activity Swift changes. That is what the bot's "Native change detected" verdict is reporting — it resolves the fingerprint against `main`. So this rides the next TestFlight/Play build with the rest of that train, and nothing here moves the production fingerprint on its own.

### Notable review fixes

Adversarial review caught two gesture-layer blockers, both fixed here:

1. **Duplicate gesture instance.** The draw overlay composed the board's pinch via `Gesture.Simultaneous(pan, pinchGesture)` — the same instance `InteractiveFilterBoard` already mounts in its own detector. RNGH assigns one handler tag per `Gesture` object and `createGestureHandler` throws `"Handler with tag N already exists"` on both platforms (`RNGestureHandlerModule.kt:35-39`, `RNGestureHandlerManager.mm:98-104`), and the overlay unmounting would drop a handler the board still owns. Now declares the relation instead — `pan.simultaneousWithExternalGesture(pinchRef)` — which is what the file already does for its own tap overlays.
2. **`fail()` had nothing to fall through to.** The overlay sat as a *sibling above* the pan layer, and RNGH offers a declined touch to ancestors, never to siblings underneath — so with a hold selected, one-finger panning was dead, contradicting the toolbar copy. `renderAboveBoard` now nests the overlay *inside* the pan detector's view while zoomed, so a declined finger reaches the pan and the zoomed hold taps.

Also: mutations splice their result into the React Query cache instead of invalidating (a refetch re-downloaded the config's entire traced shard set on every save); client ring normalisation now mirrors the resolver's `closeRing(roundRing(...))` order exactly; `maxPointers(1)` is gone so a resting palm can't cancel a stroke; and a touch the overlay declines can no longer wipe the preview of an already-validated draft while Save stayed armed.

### Related

Found en route, filed not fixed: #4858 — `ZoneOverlay` has the same duplicate-instance shape as blocker 1, and worse: `app/(tabs)/climbs/zone.tsx:270` forwards the board's pinch into `ZoneOverlay`, which mounts that one instance in five more detectors (`ZoneOverlay.tsx:248` body + `:502` × four corner handles). Left alone here so the zone editor gets its own device QA; the fix is mechanical now that `pinchRef` is on the context.


### Second review round

An automated review raised five more, all applied in `6fc65f9`: a stroke too dense to decimate reported itself as *too short* (own reason code now); the SVG layer resolved the selection with a linear scan instead of the Map the screen already keeps; the cache splices had no tests (they moved into their own module to get them — the hooks barrel reaches native modules, so a test importing it sends Rolldown into react-native's Flow source); `docs/board-art-geometry.md` didn't mention the editor its "Hand-corrected outlines" section already anticipated; and the More row had borrowed the feature-flags icon from the row directly above it.

## Release Notes

none

- [x] No release note needed (internal / technical change)

## Test plan

Needs an admin account. An iPad with an Apple Pencil is the real target, but step 3's toggle makes it testable on any device.

1. You tab → More → Development → Hold Outlines.
2. Pick Kilter → any layout → any size, open the editor.
3. Tap a hold, turn on "Draw with a finger", trace around it.
4. Save — that hold's outline turns green.
5. Revert to traced — the green clears, grey returns.

## Risk

Risk: 3/5 — new admin-only screens, OTA JS-only

## Owed device QA

A simulator can't prove any of these; all three need an iPad + Pencil:

- **Pencil `pointerType`** — that RNGH reports `PointerType.STYLUS` for Apple Pencil, so the stroke activates without the finger-draw toggle.
- **Gesture fall-through** — that a one-finger drag pans the zoomed board, and two fingers still pinch, while a hold is selected and finger-draw is OFF. The nesting fix is unit-tested structurally (the overlay really is rendered inside the pan detector), but only a device proves RNGH routes the declined touch.
- **Palm rejection** — `maxPointers(1)` was dropped so a resting palm can't cancel a stroke, but Pan reports the *centroid* of active pointers, so a palm iPadOS fails to reject would drag the sampled point. Unknown which way this lands in practice.

Also unverified on-device: at rest (not zoomed) a tap the draw overlay declines reaches the ancestor pinch but not the hold-tap layer inside the transform, so tap-to-select-another-hold at rest goes through the toolbar's "Pick another hold" button. Documented on the prop.

## Validation

| Check | Result |
|---|---|
| `vp run typecheck:mobile` | 0 errors |
| `vp run test:mobile` | 733 files / 7432 tests passed (+21 new) |
| `vp run check:mobile-bundle` | iOS + Android OK |
| `vp run check:i18n:orphans` | OK |
| `vp run check:i18n` | OK |
| `vp check` | 0 errors, 329 warnings (all pre-existing; 2 fewer than before) |
| `docs/board-art-geometry.md` | gains "The editor that writes them" |

No bundle growth from geometry: `@boardsesh/board-art-geometry` was already a mobile dependency and its ~3 MB shard set already ships via `use-native-climb-render`. The editor imports only the `/ring` subpath, which has zero imports of its own.
