### PR TITLE
fix(db): serverless-sized pool defaults on Vercel

### DIFF
--- a/docs/db-connectivity.md
+++ b/docs/db-connectivity.md
@@ -217,25 +217,30 @@ rest of the hour-long entry.
 
 ### Budgets
 
-| knob                      | default | meaning                                                                                  |
-| ------------------------- | ------- | ---------------------------------------------------------------------------------------- |
-| `DB_READ_DEADLINE_MS`     | 6000    | web front door: wall clock for one _request's_ reads (queue wait + connect + execute)    |
-| `DB_POOL_MAX`             | 10      | postgres.js `max`, clamped to a floor of 2                                               |
-| `DB_POOL_IDLE_TIMEOUT_S`  | 30      | seconds an idle connection is held open; `0` means "never close one" and is not clamped  |
-| `DB_STATEMENT_TIMEOUT_MS` | unset   | emits a `statement_timeout` startup parameter — **off by default**, see the hazard below |
+| knob                      | default        | meaning                                                                                  |
+| ------------------------- | -------------- | ---------------------------------------------------------------------------------------- |
+| `DB_READ_DEADLINE_MS`     | 6000           | web front door: wall clock for one _request's_ reads (queue wait + connect + execute)    |
+| `DB_POOL_MAX`             | 10 (Vercel: 3) | postgres.js `max`, clamped to a floor of 2                                               |
+| `DB_POOL_IDLE_TIMEOUT_S`  | 30 (Vercel: 5) | seconds an idle connection is held open; `0` means "never close one" and is not clamped  |
+| `DB_STATEMENT_TIMEOUT_MS` | unset          | emits a `statement_timeout` startup parameter — **off by default**, see the hazard below |
 
 6000 sits deliberately below `DB_CONNECT_RETRY_BUDGET_MS` (10000): during a
 brownout the front door should shed load rather than spend a second and third
 connect attempt holding a pool slot while a crawler waits. That comparison only
 holds because the budget is per request — see the shared-budget note above.
 
-The pool knobs default to the values that used to be hard-coded, so nothing
-changes for a deployment that does not set them. They exist because peak
-server-side connections scale with **instance count × connections held idle**,
-not with per-instance `max` — a fleet of serverless instances each sitting on a
-few idle connections for 30 s is the term that grows during a crawl burst.
-Lowering `DB_POOL_MAX` and `DB_POOL_IDLE_TIMEOUT_S` on a serverless deployment
-shrinks that footprint; raising `max` never helps.
+The pool knobs default to the values that used to be hard-coded — except on
+Vercel, where an unset knob now falls back to the serverless pair (`max` 3,
+idle 5 s; `process.env.VERCEL` selects it, an explicit env var still wins).
+The split exists because peak server-side connections scale with
+**instance count × connections held idle**, not with per-instance `max` — a
+fleet of serverless instances each sitting on a few idle connections for 30 s
+is the term that grows during a crawl burst. On 2026-08-29 exactly that
+exhausted the shared `max_connections = 200` (Sentry BOARDSESH-FS: crawler
+bursts on climb-view SSR held ~10 idle connections per lambda) and starved the
+backend's `POST /graphql` alongside (BOARDSESH-A1). Lowering `DB_POOL_MAX` and
+`DB_POOL_IDLE_TIMEOUT_S` on a serverless deployment shrinks that footprint;
+raising `max` never helps.
 
 ### The `statement_timeout` hazard
 

--- a/packages/db/src/client/__tests__/postgres.test.ts
+++ b/packages/db/src/client/__tests__/postgres.test.ts
@@ -119,6 +119,11 @@ void describe('postgres client', () => {
       assert.equal(options.max, 3);
     });
 
+    void it('falls back to the serverless default when DB_POOL_IDLE_TIMEOUT_S is not a number on Vercel', async () => {
+      const options = await poolOptionsWith({ DB_POOL_IDLE_TIMEOUT_S: 'abc', VERCEL: '1' });
+      assert.equal(options.idle_timeout, 5);
+    });
+
     void it('keeps DB_POOL_IDLE_TIMEOUT_S=0 as "never close an idle connection"', async () => {
       // postgres.js treats a falsy idle_timeout as disabled, so 0 is meaningful
       // and must not be clamped up the way DB_POOL_MAX is.

--- a/packages/db/src/client/__tests__/postgres.test.ts
+++ b/packages/db/src/client/__tests__/postgres.test.ts
@@ -110,7 +110,7 @@ void describe('postgres client', () => {
     });
 
     void it('falls back to the default when DB_POOL_MAX is not a number', async () => {
-      const options = await poolOptionsWith({ DB_POOL_MAX: 'abc' });
+      const options = await poolOptionsWith({ DB_POOL_MAX: 'abc', VERCEL: undefined });
       assert.equal(options.max, 10);
     });
 

--- a/packages/db/src/client/__tests__/postgres.test.ts
+++ b/packages/db/src/client/__tests__/postgres.test.ts
@@ -114,6 +114,11 @@ void describe('postgres client', () => {
       assert.equal(options.max, 10);
     });
 
+    void it('falls back to the serverless default when DB_POOL_MAX is not a number on Vercel', async () => {
+      const options = await poolOptionsWith({ DB_POOL_MAX: 'abc', VERCEL: '1' });
+      assert.equal(options.max, 3);
+    });
+
     void it('keeps DB_POOL_IDLE_TIMEOUT_S=0 as "never close an idle connection"', async () => {
       // postgres.js treats a falsy idle_timeout as disabled, so 0 is meaningful
       // and must not be clamped up the way DB_POOL_MAX is.

--- a/packages/db/src/client/__tests__/postgres.test.ts
+++ b/packages/db/src/client/__tests__/postgres.test.ts
@@ -69,9 +69,31 @@ void describe('postgres client', () => {
     }
 
     void it('defaults to the values that were hard-coded before the knobs existed', async () => {
-      const options = await poolOptionsWith({ DB_POOL_MAX: undefined, DB_POOL_IDLE_TIMEOUT_S: undefined });
+      const options = await poolOptionsWith({
+        DB_POOL_MAX: undefined,
+        DB_POOL_IDLE_TIMEOUT_S: undefined,
+        VERCEL: undefined,
+      });
       assert.equal(options.max, 10);
       assert.equal(options.idle_timeout, 30);
+    });
+
+    void it('shrinks the defaults on Vercel, where instance count is the term that grows', async () => {
+      // A crawl burst scales lambda count; instances × held-idle connections
+      // exhausted the shared max_connections on 2026-08-29 (BOARDSESH-FS).
+      const options = await poolOptionsWith({
+        DB_POOL_MAX: undefined,
+        DB_POOL_IDLE_TIMEOUT_S: undefined,
+        VERCEL: '1',
+      });
+      assert.equal(options.max, 3);
+      assert.equal(options.idle_timeout, 5);
+    });
+
+    void it('lets explicit knobs override the serverless defaults', async () => {
+      const options = await poolOptionsWith({ DB_POOL_MAX: '6', DB_POOL_IDLE_TIMEOUT_S: '20', VERCEL: '1' });
+      assert.equal(options.max, 6);
+      assert.equal(options.idle_timeout, 20);
     });
 
     void it('honours DB_POOL_MAX and DB_POOL_IDLE_TIMEOUT_S', async () => {

--- a/packages/db/src/client/__tests__/postgres.test.ts
+++ b/packages/db/src/client/__tests__/postgres.test.ts
@@ -80,7 +80,7 @@ void describe('postgres client', () => {
 
     void it('shrinks the defaults on Vercel, where instance count is the term that grows', async () => {
       // A crawl burst scales lambda count; instances × held-idle connections
-      // exhausted the shared max_connections on 2026-08-29 (BOARDSESH-FS).
+      // can exhaust the shared max_connections. See docs/db-connectivity.md.
       const options = await poolOptionsWith({
         DB_POOL_MAX: undefined,
         DB_POOL_IDLE_TIMEOUT_S: undefined,

--- a/packages/db/src/client/postgres.ts
+++ b/packages/db/src/client/postgres.ts
@@ -25,6 +25,19 @@ export const DEFAULT_POOL_MAX = 10;
 /** Seconds an idle connection is held when `DB_POOL_IDLE_TIMEOUT_S` is unset. */
 export const DEFAULT_POOL_IDLE_TIMEOUT_S = 30;
 /**
+ * Defaults when running on Vercel (`VERCEL` is set in every build and function
+ * runtime there). Peak server-side connections scale with instance count ×
+ * connections held idle, and a crawl burst scales the instance count — on
+ * 2026-08-29 a fleet of lambdas each sitting on 10 idle connections for 30 s
+ * exhausted the shared Postgres `max_connections` (Sentry BOARDSESH-FS) and
+ * starved the backend with it. Three, not the floor of two, because Fluid-style
+ * instances serve concurrent requests that would serialise on a pair. Explicit
+ * `DB_POOL_MAX` / `DB_POOL_IDLE_TIMEOUT_S` still win. See
+ * docs/db-connectivity.md § pool sizing.
+ */
+export const SERVERLESS_DEFAULT_POOL_MAX = 3;
+export const SERVERLESS_DEFAULT_POOL_IDLE_TIMEOUT_S = 5;
+/**
  * `getClimb` issues two sequential statements and drizzle's connect-retry can
  * hold a slot while it re-dials, so a pool of one serialises everything behind
  * a single connection. Clamp rather than trust a typo in a dashboard.
@@ -54,11 +67,11 @@ function readPoolInt(name: string, fallback: number, minimum: number): number {
 }
 
 /**
- * Per-deployment pool knobs. Both default to the values that were hard-coded
- * here before, so backend, sync jobs and scripts are unchanged unless the env
- * var is set — today only the Vercel project is expected to set them, because
- * peak server-side connections scale with *instance count* × held-idle
- * connections, not with per-instance `max`.
+ * Per-deployment pool knobs. On Vercel the defaults are the serverless pair
+ * above; everywhere else (backend, sync jobs, scripts) they stay the values
+ * that were hard-coded here before, so nothing changes unless the env var is
+ * set. The split exists because peak server-side connections scale with
+ * *instance count* × held-idle connections, not with per-instance `max`.
  *
  * `prepare: false` is required when the target is PgBouncer in transaction
  * pooling mode (Railway's pooled URL): backends are reused across transactions
@@ -69,9 +82,14 @@ function readPoolInt(name: string, fallback: number, minimum: number): number {
  * rebuilds its pool (tests, HMR) picks up the current environment.
  */
 function basePoolOptions() {
+  const isServerless = Boolean(process.env.VERCEL);
   return {
-    max: readPoolInt('DB_POOL_MAX', DEFAULT_POOL_MAX, MIN_POOL_MAX),
-    idle_timeout: readPoolInt('DB_POOL_IDLE_TIMEOUT_S', DEFAULT_POOL_IDLE_TIMEOUT_S, MIN_POOL_IDLE_TIMEOUT_S),
+    max: readPoolInt('DB_POOL_MAX', isServerless ? SERVERLESS_DEFAULT_POOL_MAX : DEFAULT_POOL_MAX, MIN_POOL_MAX),
+    idle_timeout: readPoolInt(
+      'DB_POOL_IDLE_TIMEOUT_S',
+      isServerless ? SERVERLESS_DEFAULT_POOL_IDLE_TIMEOUT_S : DEFAULT_POOL_IDLE_TIMEOUT_S,
+      MIN_POOL_IDLE_TIMEOUT_S,
+    ),
     connect_timeout: 30,
     prepare: false,
     ...statementTimeoutOption(),

--- a/packages/db/src/client/postgres.ts
+++ b/packages/db/src/client/postgres.ts
@@ -24,17 +24,7 @@ const fullSchema = { ...schema, ...relations };
 export const DEFAULT_POOL_MAX = 10;
 /** Seconds an idle connection is held when `DB_POOL_IDLE_TIMEOUT_S` is unset. */
 export const DEFAULT_POOL_IDLE_TIMEOUT_S = 30;
-/**
- * Defaults when running on Vercel (`VERCEL` is set in every build and function
- * runtime there). Peak server-side connections scale with instance count ×
- * connections held idle, and a crawl burst scales the instance count — on
- * 2026-08-29 a fleet of lambdas each sitting on 10 idle connections for 30 s
- * exhausted the shared Postgres `max_connections` (Sentry BOARDSESH-FS) and
- * starved the backend with it. Three, not the floor of two, because Fluid-style
- * instances serve concurrent requests that would serialise on a pair. Explicit
- * `DB_POOL_MAX` / `DB_POOL_IDLE_TIMEOUT_S` still win. See
- * docs/db-connectivity.md § pool sizing.
- */
+/** Serverless (Vercel) pool defaults — smaller per-lambda footprint; see docs/db-connectivity.md § pool sizing. */
 export const SERVERLESS_DEFAULT_POOL_MAX = 3;
 export const SERVERLESS_DEFAULT_POOL_IDLE_TIMEOUT_S = 5;
 /**


### PR DESCRIPTION
## Summary

During the 2026-08-29 incident behind #4850, the shared Railway Postgres (`max_connections = 200`) was exhausted by `sorry, too many clients already` errors — 940/hour at peak, 552+ users in 24h (Sentry BOARDSESH-FS/FW/FX on web, BOARDSESH-A1 on the backend's `POST /graphql`, so mobile users were hit too). Mechanism, confirmed in `pg_stat_activity`: each Vercel lambda holds up to 10 idle postgres.js connections for 30 s (the `DB_POOL_MAX` / `DB_POOL_IDLE_TIMEOUT_S` defaults), and a crawler burst on climb-view SSR scales the lambda count — instances × 10 blows past 200 and starves the backend alongside.

`docs/db-connectivity.md` already documents the fix direction ("Lowering `DB_POOL_MAX` and `DB_POOL_IDLE_TIMEOUT_S` on a serverless deployment shrinks that footprint") but relied on the Vercel project setting the env vars, which it doesn't. This PR makes the safe values the default there: when `process.env.VERCEL` is set and the knobs are unset, the pool defaults to `max: 3`, `idle_timeout: 5` instead of 10/30. Explicit env vars still win, and every non-Vercel consumer (backend, sync jobs, scripts) keeps 10/30.

Three, not the floor of two, because Fluid-style instances serve concurrent requests that would serialise on a pair.

The env vars can (and should) still be set on the Vercel project for immediate relief before this deploys; this change just removes the dependence on dashboard state.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 2/5 — one guarded default change in `packages/db`, only takes effect where `VERCEL` is set (web prod/preview), covered by new unit tests; worst case is slower cold SSR reads from smaller pools.
