### PR TITLE
fix(ci): preserve release sync merge history

### DIFF
--- a/.github/workflows/release-next-sync.yml
+++ b/.github/workflows/release-next-sync.yml
@@ -1,7 +1,10 @@
 name: Sync release/next with main
 
-# release/next is an ephemeral native release train. Keep its open PR rebased on
-# the exact current main while never overwriting a maintainer's concurrent push.
+# release/next is an ephemeral native release train. Keep its open PR current
+# with the exact main tip while never overwriting a maintainer's concurrent push.
+# Linear trains are rebased; once the train owns merge history, preserve it by
+# merging main. Claude resolves conflicts locally, but only the repository App
+# can push the independently verified result.
 
 on:
   push:
@@ -19,11 +22,12 @@ permissions:
 jobs:
   rebase:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 60
     outputs:
       attempted: ${{ steps.target.outputs.attempted }}
       pr_number: ${{ steps.target.outputs.pr_number }}
       release_sha: ${{ steps.target.outputs.release_sha }}
+      main_sha: ${{ steps.target.outputs.main_sha }}
     steps:
       - name: Find the open release PR
         id: target
@@ -34,9 +38,10 @@ jobs:
           release_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/release%2Fnext" --jq '.object.sha' 2>/dev/null || true)"
           if [ -z "$release_sha" ]; then
             echo "attempted=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::release/next does not exist; nothing to rebase."
+            echo "::notice::release/next does not exist; nothing to sync."
             exit 0
           fi
+          main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
 
           owner="${GITHUB_REPOSITORY%%/*}"
           pr="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls" \
@@ -45,11 +50,12 @@ jobs:
           pr_number="$(jq -r '.number // empty' <<<"$pr")"
           if [ -z "$pr_number" ]; then
             echo "attempted=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::release/next has no open PR to main; nothing to rebase."
+            echo "::notice::release/next has no open PR to main; nothing to sync."
             exit 0
           fi
           [ "$(jq -r '.base.ref' <<<"$pr")" = main ] && \
             [ "$(jq -r '.head.ref' <<<"$pr")" = release/next ] && \
+            [ "$(jq -r '.base.sha' <<<"$pr")" = "$main_sha" ] && \
             [ "$(jq -r '.head.sha' <<<"$pr")" = "$release_sha" ] && \
             [ "$(jq -r '.base.repo.full_name' <<<"$pr")" = "$GITHUB_REPOSITORY" ] && \
             [ "$(jq -r '.head.repo.full_name' <<<"$pr")" = "$GITHUB_REPOSITORY" ] || {
@@ -60,18 +66,7 @@ jobs:
           echo "attempted=true" >> "$GITHUB_OUTPUT"
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
           echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
-
-      - name: Mint repository App token
-        id: push_token
-        if: steps.target.outputs.attempted == 'true'
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
-        with:
-          app-id: ${{ vars.OTA_PUSH_APP_ID }}
-          private-key: ${{ secrets.OTA_PUSH_APP_PRIVATE_KEY }}
-          permission-contents: write
-          # Required when the rebased train contains .github/workflows changes.
-          # The App installation must grant this before sync can be enabled.
-          permission-workflows: write
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
 
       - name: Checkout release/next
         if: steps.target.outputs.attempted == 'true'
@@ -81,10 +76,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Rebase release/next onto current main
-        id: rebase
+      - name: Update release/next to current main
+        id: update
         if: steps.target.outputs.attempted == 'true'
         env:
+          EXPECTED_MAIN_SHA: ${{ steps.target.outputs.main_sha }}
           EXPECTED_RELEASE_SHA: ${{ steps.target.outputs.release_sha }}
         run: |
           set -euo pipefail
@@ -95,33 +91,299 @@ jobs:
             '+refs/heads/release/next:refs/remotes/origin/release/next'
 
           current_release_sha="$(git rev-parse origin/release/next)"
+          current_main_sha="$(git rev-parse origin/main)"
           if [ "$current_release_sha" != "$EXPECTED_RELEASE_SHA" ]; then
-            printf 'release/next moved before rebase: expected %s, found %s\n' \
+            printf 'release/next moved before sync: expected %s, found %s\n' \
               "$EXPECTED_RELEASE_SHA" "$current_release_sha" > "$RUNNER_TEMP/release-next-sync-error.txt"
-            echo "::error::release/next moved before rebase; refusing to overwrite it."
+            echo "::error::release/next moved before sync; refusing to overwrite it."
+            exit 1
+          fi
+          if [ "$current_main_sha" != "$EXPECTED_MAIN_SHA" ]; then
+            printf 'main moved before sync: expected %s, found %s\n' \
+              "$EXPECTED_MAIN_SHA" "$current_main_sha" > "$RUNNER_TEMP/release-next-sync-error.txt"
+            echo "::error::main moved before sync; the queued run will use the newer tip."
             exit 1
           fi
 
           git reset --hard "$EXPECTED_RELEASE_SHA"
-          set +e
-          git rebase --rebase-merges origin/main
-          rebase_status=$?
-          set -e
-          if [ "$rebase_status" -ne 0 ]; then
-            {
-              echo 'Rebase conflicts:'
-              git diff --name-only --diff-filter=U | head -n 20
-            } > "$RUNNER_TEMP/release-next-sync-error.txt"
-            git rebase --abort
-            echo "::error::release/next could not be rebased onto main."
-            exit "$rebase_status"
+          if [ -n "$(git rev-list --merges --max-count=1 "$EXPECTED_MAIN_SHA..$EXPECTED_RELEASE_SHA")" ]; then
+            strategy=merge
+          else
+            strategy=rebase
           fi
-          echo "rebased_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "strategy=$strategy" >> "$GITHUB_OUTPUT"
+          echo "::notice::Updating release/next with strategy: $strategy"
+
+          set +e
+          if [ "$strategy" = merge ]; then
+            git merge --no-edit --no-ff "$EXPECTED_MAIN_SHA"
+          else
+            git rebase "$EXPECTED_MAIN_SHA"
+          fi
+          update_status=$?
+          set -e
+
+          has_conflicts=false
+          if [ -n "$(git ls-files -u)" ]; then
+            has_conflicts=true
+          fi
+          if [ "$update_status" -ne 0 ] && [ "$strategy" = rebase ] && [ "$has_conflicts" = true ]; then
+            echo "::warning::Linear rebase conflicted; retrying as one merge for bounded conflict resolution."
+            git rebase --abort
+            strategy=merge
+            echo "strategy=$strategy" >> "$GITHUB_OUTPUT"
+            set +e
+            git merge --no-edit --no-ff "$EXPECTED_MAIN_SHA"
+            update_status=$?
+            set -e
+            has_conflicts=false
+            if [ -n "$(git ls-files -u)" ]; then
+              has_conflicts=true
+            fi
+          fi
+
+          if [ "$update_status" -ne 0 ]; then
+            if [ "$has_conflicts" = false ]; then
+              printf '%s update failed without unmerged paths.\n' "$strategy" \
+                > "$RUNNER_TEMP/release-next-sync-error.txt"
+              echo "::error::release/next $strategy failed without conflicts Claude can resolve."
+              exit "$update_status"
+            fi
+            git diff --name-only -z --diff-filter=U > "$RUNNER_TEMP/release-next-conflicts.txt"
+            git ls-files --stage -z | sha256sum | awk '{print $1}' \
+              > "$RUNNER_TEMP/release-next-index.sha256"
+            {
+              printf '%s conflicts:\n' "$strategy"
+              conflict_count=0
+              while IFS= read -r -d '' conflict_path && [ "$conflict_count" -lt 20 ]; do
+                printf '%q\n' "$conflict_path"
+                conflict_count=$((conflict_count + 1))
+              done < "$RUNNER_TEMP/release-next-conflicts.txt"
+            } > "$RUNNER_TEMP/release-next-sync-error.txt"
+            echo "conflicted=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::release/next merge stopped on conflicts; handing the working files to Claude Opus."
+            exit 0
+          fi
+          echo "conflicted=false" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve update conflicts with Claude Opus
+        id: claude_conflicts
+        if: steps.target.outputs.attempted == 'true' && steps.update.outputs.conflicted == 'true'
+        uses: anthropics/claude-code-action/base-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Resolve the merge conflicts already in progress in this checkout.
+
+            Repository: ${{ github.repository }}
+            Branch: release/next
+            Original release tip: ${{ steps.target.outputs.release_sha }}
+            Main tip: ${{ steps.target.outputs.main_sha }}
+
+            Inspect both sides of every path listed by
+            `git diff --name-only --diff-filter=U`. Preserve the intent of the
+            release train and main. Edit only those already-conflicted paths.
+            Follow the existing code's conventions; do not load repository-owned
+            agent instructions, skills, hooks, plugins, or MCP servers. You may
+            remove one of those paths only when deletion is the correct merge
+            resolution. Do not change adjacent or unrelated files.
+
+            Do not stage, commit, continue, abort, or restart the merge. Do not
+            rebase, reset, switch branches, create files, or push. Stop after the
+            working files contain the complete conflict resolution. Trusted shell
+            steps will reject out-of-scope paths, stage the recorded conflict set,
+            commit, verify both tips, and push with an explicit lease.
+          claude_args: |
+            --model claude-opus-5
+            --effort high
+            --restricted
+            --safe-mode
+            --no-session-persistence
+            --permission-mode dontAsk
+            --max-turns 24
+            --max-budget-usd 20
+            --tools "Read,Edit,Grep,Glob,Bash"
+            --disallowed-tools "mcp__*"
+            --allowed-tools "Read,Edit,Grep,Glob,Bash(git status),Bash(git status *),Bash(git diff),Bash(git diff *),Bash(git log *),Bash(git show *),Bash(git ls-files *),Bash(git checkout --ours *),Bash(git checkout --theirs *),Bash(rm *)"
+
+      - name: Stage and commit Claude's conflict resolution
+        if: steps.target.outputs.attempted == 'true' && steps.update.outputs.conflicted == 'true'
+        run: |
+          set -euo pipefail
+          conflict_file="$RUNNER_TEMP/release-next-conflicts.txt"
+          test -s "$conflict_file" || {
+            echo 'The recorded conflict path list is missing.' > "$RUNNER_TEMP/release-next-sync-error.txt"
+            exit 1
+          }
+          expected_index_hash="$(cat "$RUNNER_TEMP/release-next-index.sha256")"
+          current_index_hash="$(git ls-files --stage -z | sha256sum | awk '{print $1}')"
+          if [ "$current_index_hash" != "$expected_index_hash" ]; then
+            echo 'Claude changed the Git index; only trusted shell may stage resolutions.' \
+              > "$RUNNER_TEMP/release-next-sync-error.txt"
+            echo '::error::Claude changed the Git index.'
+            exit 1
+          fi
+
+          sort -z -u "$conflict_file" > "$RUNNER_TEMP/release-next-conflicts.sorted.txt"
+          git diff --name-only -z | sort -z -u > "$RUNNER_TEMP/release-next-working-paths.txt"
+          comm -z -23 \
+            "$RUNNER_TEMP/release-next-working-paths.txt" \
+            "$RUNNER_TEMP/release-next-conflicts.sorted.txt" \
+            > "$RUNNER_TEMP/release-next-out-of-scope.txt"
+          if [ -s "$RUNNER_TEMP/release-next-out-of-scope.txt" ]; then
+            {
+              echo 'Claude changed paths outside the recorded conflict set:'
+              path_count=0
+              while IFS= read -r -d '' changed_path && [ "$path_count" -lt 20 ]; do
+                printf '%q\n' "$changed_path"
+                path_count=$((path_count + 1))
+              done < "$RUNNER_TEMP/release-next-out-of-scope.txt"
+            } > "$RUNNER_TEMP/release-next-sync-error.txt"
+            echo '::error::Claude changed paths outside the recorded conflict set.'
+            exit 1
+          fi
+
+          git ls-files --others --exclude-standard -z > "$RUNNER_TEMP/release-next-untracked.txt"
+          if [ -s "$RUNNER_TEMP/release-next-untracked.txt" ]; then
+            {
+              echo 'Claude created untracked paths:'
+              path_count=0
+              while IFS= read -r -d '' untracked_path && [ "$path_count" -lt 20 ]; do
+                printf '%q\n' "$untracked_path"
+                path_count=$((path_count + 1))
+              done < "$RUNNER_TEMP/release-next-untracked.txt"
+            } > "$RUNNER_TEMP/release-next-sync-error.txt"
+            echo '::error::Claude created files outside the merge resolution.'
+            exit 1
+          fi
+          git diff --check || {
+            echo 'Claude left conflict markers or whitespace errors.' > "$RUNNER_TEMP/release-next-sync-error.txt"
+            exit 1
+          }
+
+          while IFS= read -r -d '' conflict_path; do
+            git add -A -- "$conflict_path"
+          done < "$conflict_file"
+          if [ -n "$(git ls-files -u)" ]; then
+            {
+              echo 'Claude left unmerged paths:'
+              git diff --name-only --diff-filter=U
+            } > "$RUNNER_TEMP/release-next-sync-error.txt"
+            exit 1
+          fi
+          git diff --quiet || {
+            git diff --name-only > "$RUNNER_TEMP/release-next-sync-error.txt"
+            echo '::error::Claude left unstaged changes after the conflict set was staged.'
+            exit 1
+          }
+          git commit --no-edit
+
+      - name: Set up Vite+ for AI resolution validation
+        if: steps.target.outputs.attempted == 'true' && steps.update.outputs.conflicted == 'true'
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: 'lts'
+          cache: true
+
+      - name: Install dependencies for AI resolution validation
+        if: steps.target.outputs.attempted == 'true' && steps.update.outputs.conflicted == 'true'
+        run: vp install
+
+      - name: Validate the AI conflict resolution
+        if: steps.target.outputs.attempted == 'true' && steps.update.outputs.conflicted == 'true'
+        run: |
+          set -euo pipefail
+          set +e
+          vp check > "$RUNNER_TEMP/release-next-vp-check.log" 2>&1
+          check_status=$?
+          set -e
+          cat "$RUNNER_TEMP/release-next-vp-check.log" || true
+          if [ "$check_status" -ne 0 ]; then
+            echo 'Claude conflict resolution failed vp check.' > "$RUNNER_TEMP/release-next-sync-error.txt"
+            exit "$check_status"
+          fi
+          vp run typecheck || {
+            echo 'Claude conflict resolution failed the full typecheck.' \
+              > "$RUNNER_TEMP/release-next-sync-error.txt"
+            exit 1
+          }
+          vp test run --reporter=agent || {
+            echo 'Claude conflict resolution failed the full test suite.' \
+              > "$RUNNER_TEMP/release-next-sync-error.txt"
+            exit 1
+          }
+
+      - name: Verify the completed update
+        id: verify
+        if: steps.target.outputs.attempted == 'true'
+        env:
+          EXPECTED_MAIN_SHA: ${{ steps.target.outputs.main_sha }}
+          EXPECTED_RELEASE_SHA: ${{ steps.target.outputs.release_sha }}
+          UPDATE_STRATEGY: ${{ steps.update.outputs.strategy }}
+        run: |
+          set -euo pipefail
+          if [ -n "$(git ls-files -u)" ]; then
+            {
+              echo 'Claude left unmerged paths:'
+              git diff --name-only --diff-filter=U
+            } > "$RUNNER_TEMP/release-next-sync-error.txt"
+            echo '::error::Claude did not resolve every update conflict.'
+            exit 1
+          fi
+          if git rev-parse -q --verify MERGE_HEAD >/dev/null || \
+            [ -d "$(git rev-parse --git-path rebase-merge)" ] || \
+            [ -d "$(git rev-parse --git-path rebase-apply)" ]; then
+            echo 'The Git update operation is still in progress.' > "$RUNNER_TEMP/release-next-sync-error.txt"
+            echo '::error::Claude did not finish the update operation.'
+            exit 1
+          fi
+          if [ -n "$(git status --porcelain)" ]; then
+            git status --short > "$RUNNER_TEMP/release-next-sync-error.txt"
+            echo '::error::The completed update left unstaged or uncommitted changes.'
+            exit 1
+          fi
+          git diff --check "$EXPECTED_RELEASE_SHA..HEAD" || {
+            echo 'The completed update introduced whitespace errors.' > "$RUNNER_TEMP/release-next-sync-error.txt"
+            exit 1
+          }
+          git merge-base --is-ancestor "$EXPECTED_MAIN_SHA" HEAD || {
+            echo 'The updated branch does not contain current main.' > "$RUNNER_TEMP/release-next-sync-error.txt"
+            exit 1
+          }
+          if [ "$UPDATE_STRATEGY" = merge ]; then
+            git merge-base --is-ancestor "$EXPECTED_RELEASE_SHA" HEAD || {
+              echo 'The merge update lost the original release tip.' > "$RUNNER_TEMP/release-next-sync-error.txt"
+              exit 1
+            }
+            if ! git merge-base --is-ancestor "$EXPECTED_MAIN_SHA" "$EXPECTED_RELEASE_SHA"; then
+              test "$(git rev-parse HEAD^1)" = "$EXPECTED_RELEASE_SHA" && \
+                test "$(git rev-parse HEAD^2)" = "$EXPECTED_MAIN_SHA" || {
+                  echo 'The merge commit does not have the exact release/main parents.' \
+                    > "$RUNNER_TEMP/release-next-sync-error.txt"
+                  exit 1
+                }
+            fi
+          fi
+          echo "updated_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Mint repository App token
+        id: push_token
+        if: steps.target.outputs.attempted == 'true'
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ vars.OTA_PUSH_APP_ID }}
+          private-key: ${{ secrets.OTA_PUSH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          # Required when the updated train contains .github/workflows changes.
+          # The App installation must grant this before sync can be enabled.
+          permission-workflows: write
 
       - name: Recheck the PR and push with an explicit lease
         if: steps.target.outputs.attempted == 'true'
         env:
+          EXPECTED_MAIN_SHA: ${{ steps.target.outputs.main_sha }}
           EXPECTED_RELEASE_SHA: ${{ steps.target.outputs.release_sha }}
+          UPDATED_RELEASE_SHA: ${{ steps.verify.outputs.updated_sha }}
           GH_APP_TOKEN: ${{ steps.push_token.outputs.token }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.target.outputs.pr_number }}
@@ -129,17 +391,31 @@ jobs:
           set -euo pipefail
           current_pr="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
           test "$(jq -r '.state' <<<"$current_pr")" = open || {
-            echo 'The release PR closed during rebase.' > "$RUNNER_TEMP/release-next-sync-error.txt"
+            echo 'The release PR closed during sync.' > "$RUNNER_TEMP/release-next-sync-error.txt"
             exit 1
           }
           test "$(jq -r '.head.sha' <<<"$current_pr")" = "$EXPECTED_RELEASE_SHA" || {
-            echo 'release/next moved during rebase; the lease-protected push was skipped.' > "$RUNNER_TEMP/release-next-sync-error.txt"
+            echo 'release/next moved during sync; the lease-protected push was skipped.' > "$RUNNER_TEMP/release-next-sync-error.txt"
+            exit 1
+          }
+          test "$(jq -r '.base.sha' <<<"$current_pr")" = "$EXPECTED_MAIN_SHA" || {
+            echo 'main moved during sync; the queued run will use the newer tip.' > "$RUNNER_TEMP/release-next-sync-error.txt"
             exit 1
           }
           test "$(jq -r '.base.ref' <<<"$current_pr")" = main
           test "$(jq -r '.head.ref' <<<"$current_pr")" = release/next
           test "$(jq -r '.base.repo.full_name' <<<"$current_pr")" = "$GITHUB_REPOSITORY"
           test "$(jq -r '.head.repo.full_name' <<<"$current_pr")" = "$GITHUB_REPOSITORY"
+          current_release_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/release%2Fnext" --jq '.object.sha')"
+          current_main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
+          test "$current_release_sha" = "$EXPECTED_RELEASE_SHA" || {
+            echo 'release/next moved immediately before push.' > "$RUNNER_TEMP/release-next-sync-error.txt"
+            exit 1
+          }
+          test "$current_main_sha" = "$EXPECTED_MAIN_SHA" || {
+            echo 'main moved immediately before push.' > "$RUNNER_TEMP/release-next-sync-error.txt"
+            exit 1
+          }
 
           git_auth="$(printf 'x-access-token:%s' "$GH_APP_TOKEN" | base64 | tr -d '\n')"
           clear_git_auth() {
@@ -148,9 +424,12 @@ jobs:
           trap clear_git_auth EXIT
           git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $git_auth"
           set +e
-          git push --force-with-lease="release/next:$EXPECTED_RELEASE_SHA" \
+          git push --atomic \
+            --force-with-lease="refs/heads/release/next:$EXPECTED_RELEASE_SHA" \
+            --force-with-lease="refs/heads/main:$EXPECTED_MAIN_SHA" \
             "https://github.com/${GITHUB_REPOSITORY}.git" \
-            'HEAD:refs/heads/release/next'
+            'HEAD:refs/heads/release/next' \
+            "$EXPECTED_MAIN_SHA:refs/heads/main"
           push_status=$?
           set -e
           clear_git_auth
@@ -160,13 +439,27 @@ jobs:
             echo '::error::Repository App could not update release/next; check Contents/Workflows write permissions and branch bypass.'
             exit "$push_status"
           fi
+          pushed_release_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/release%2Fnext" --jq '.object.sha')"
+          test "$pushed_release_sha" = "$UPDATED_RELEASE_SHA" || {
+            echo 'The pushed release/next ref does not match the verified update.' \
+              > "$RUNNER_TEMP/release-next-sync-error.txt"
+            exit 1
+          }
+          pushed_main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
+          test "$pushed_main_sha" = "$EXPECTED_MAIN_SHA" || {
+            echo 'main moved during the release push; the queued sync must update release/next again.' \
+              > "$RUNNER_TEMP/release-next-sync-error.txt"
+            exit 1
+          }
 
       - name: Preserve sync failure details
         if: failure() && steps.target.outputs.attempted == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: release-next-sync-failure-${{ github.run_id }}
-          path: ${{ runner.temp }}/release-next-sync-error.txt
+          path: |
+            ${{ runner.temp }}/release-next-sync-error.txt
+            ${{ steps.claude_conflicts.outputs.execution_file }}
           if-no-files-found: ignore
           retention-days: 1
 
@@ -200,7 +493,7 @@ jobs:
           # Leave room below Discord's 2,000-character content limit for the
           # heading, PR/ref fields, and run URL even when conflict paths are long.
           details="${details:0:1200}"
-          content="$(printf '🚨 **release/next rebase failed**\n• PR: #%s\n• release: `%s`\n• main: `%s`\n• error: %s\n<%s>' \
+          content="$(printf '🚨 **release/next sync failed**\n• PR: #%s\n• release: `%s`\n• main: `%s`\n• error: %s\n<%s>' \
             "$PR_NUMBER" "${RELEASE_SHA:0:12}" "${MAIN_SHA:0:12}" "$details" "$RUN_URL")"
           jq -n --arg content "$content" '{content: $content, allowed_mentions: {parse: []}}' \
             | curl -sS --fail-with-body -X POST -H 'Content-Type: application/json' -d @- "$DISCORD_DEPLOY_WEBHOOK" || \

--- a/docs/mobile-store-release.md
+++ b/docs/mobile-store-release.md
@@ -31,15 +31,17 @@ the repository secret and the environment is not a credential boundary. Keep
 workflows also use it.
 
 The repository App used by `OTA_PUSH_APP_ID` needs Contents, Workflows and Pull
-requests write access. Workflows is required to rebase commits that
-touch `.github/workflows`; Pull requests is required for the acceptance monitor
-to merge with the App token so the resulting `main` push triggers production
-OTA.
+requests write access. Workflows is required to sync commits that touch
+`.github/workflows`; Pull requests is required for the acceptance monitor to
+merge with the App token so the resulting `main` push triggers production OTA.
+Keep `CLAUDE_CODE_OAUTH_TOKEN` as a repository secret for conflict resolution.
+Claude receives only the read-only workflow token; the repository App token is
+minted after Claude exits and the result passes deterministic checks.
 
 Protect `release/next` with the same pull-request approval rules as `main`, but
 give only that repository App a ruleset bypass so it can perform the
-lease-protected rebase force-push. Allow branch deletion: the train is ephemeral
-and is removed after its release PR merges.
+lease-protected sync push. Allow branch deletion: the train is ephemeral and is
+removed after its release PR merges.
 
 Add an active tag ruleset for `build-*`, `fingerprint-*`, and `release/*` that
 blocks creation, updates and deletion except through the same repository App.
@@ -56,9 +58,20 @@ them would make automatic merge unsafe.
   Keep the server compatible with the current store app until the replacement
   release has been adopted.
 
-`release/next` is rebased automatically after every `main` push. A conflict
-leaves the branch untouched and posts the failed rebase to `#deployments` for
-manual resolution.
+`release/next` is synchronized automatically after every `main` push. A linear
+train is rebased. Once the release-only range contains a merge commit, the
+workflow preserves that history by merging the exact `main` tip instead. If a
+linear rebase conflicts, it also falls back to one merge so conflict resolution
+stays bounded to a single set of files.
+
+Merge conflicts are handed to a restricted Claude Opus agent. It can edit only
+the recorded conflict paths and cannot stage, commit or push. Trusted workflow
+steps reject extra paths, stage and commit the resolution, then run `vp check`,
+the full typecheck and the full test suite. Only after those pass does the
+workflow recheck the exact `main` and `release/next` tips and push atomically
+with explicit leases on both refs. A failed agent, failed verification, or
+concurrent branch update leaves the remote branch untouched and posts details
+to `#deployments` for manual resolution.
 
 ## 2. Automatic candidate builds from `release/next`
 
@@ -74,7 +87,7 @@ A push that resolves to a new native fingerprint triggers:
   Release is created.
 
 Both workflows record the exact store build number, commit and fingerprint in a
-`build-<platform>-v<version>-<number>-<shortfp>` tag. A JS-only rebase keeps the
+`build-<platform>-v<version>-<number>-<shortfp>` tag. A JS-only sync keeps the
 fingerprint and skips a duplicate store build; its JavaScript ships by OTA after
 the accepted release merges.
 

--- a/scripts/native-release-workflows.test.ts
+++ b/scripts/native-release-workflows.test.ts
@@ -76,18 +76,68 @@ describe('native release train workflow contracts', () => {
     expect(android.indexOf('Require Play upload credentials')).toBeLessThan(android.indexOf('Expo prebuild'));
   });
 
-  it('rebases with the repository App, an explicit lease, and Discord failure reporting', () => {
+  it('preserves merge history and confines Opus conflict resolution before the leased push', () => {
     expect(sync).toContain('branches: [main]');
     expect(sync).toContain('actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547');
-    expect(sync).toContain('git rebase --rebase-merges origin/main');
-    expect(sync).toContain('--force-with-lease="release/next:$EXPECTED_RELEASE_SHA"');
-    expect(sync).toContain('DISCORD_DEPLOY_WEBHOOK');
+    expect(sync).toContain('git rev-list --merges --max-count=1 "$EXPECTED_MAIN_SHA..$EXPECTED_RELEASE_SHA"');
+    expect(sync).toContain('git rebase "$EXPECTED_MAIN_SHA"');
+    expect(sync).toContain('git merge --no-edit --no-ff "$EXPECTED_MAIN_SHA"');
+    expect(sync).not.toContain('git rebase --rebase-merges');
     expect(sync).toContain('git rebase --abort');
+    expect(sync).toContain(
+      'anthropics/claude-code-action/base-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210',
+    );
+    expect(sync).toContain('--model claude-opus-5');
+    expect(sync).toContain('--restricted');
+    expect(sync).toContain('--safe-mode');
+    expect(sync).toContain('--no-session-persistence');
+    expect(sync).toContain('--permission-mode dontAsk');
+    expect(sync).toContain('--tools "Read,Edit,Grep,Glob,Bash"');
+    expect(sync).toContain('--disallowed-tools "mcp__*"');
+    expect(sync).not.toContain('github_token: ${{ github.token }}');
+    expect(sync).not.toContain('id-token: write');
+    expect(sync).toContain('git ls-files --stage -z | sha256sum');
+    expect(sync).toContain('git diff --name-only -z');
+    expect(sync).toContain('comm -z -23');
+    expect(sync).toContain('release-next-out-of-scope.txt');
+    expect(sync).toContain('git ls-files --others --exclude-standard -z');
+    expect(sync).toContain("while IFS= read -r -d '' conflict_path");
+    expect(sync).toContain('git commit --no-edit');
+    expect(sync).toContain('vp check > "$RUNNER_TEMP/release-next-vp-check.log"');
+    expect(sync).toContain('vp run typecheck');
+    expect(sync).toContain('vp test run --reporter=agent');
+    expect(sync).toContain('test "$(git rev-parse HEAD^1)" = "$EXPECTED_RELEASE_SHA"');
+    expect(sync).toContain('test "$(git rev-parse HEAD^2)" = "$EXPECTED_MAIN_SHA"');
+    expect(sync).toContain('git push --atomic');
+    expect(sync).toContain('--force-with-lease="refs/heads/release/next:$EXPECTED_RELEASE_SHA"');
+    expect(sync).toContain('--force-with-lease="refs/heads/main:$EXPECTED_MAIN_SHA"');
+    expect(sync).toContain('"$EXPECTED_MAIN_SHA:refs/heads/main"');
+    expect(sync).toContain('DISCORD_DEPLOY_WEBHOOK');
     expect(sync).toContain("'.head.repo.full_name'");
     expect(sync).toContain('permission-workflows: write');
     expect(sync).not.toContain('https://x-access-token:${GH_APP_TOKEN}@github.com');
     expect(sync).toContain('trap clear_git_auth EXIT');
     expect(sync).toContain('check Contents/Workflows write permissions and branch bypass');
+    expect(sync).toContain('main moved immediately before push.');
+    expect(sync).toContain('release/next moved immediately before push.');
+    expect(sync).toContain('The pushed release/next ref does not match the verified update.');
+    expect(sync).toContain('main moved during the release push; the queued sync must update release/next again.');
+    expect(sync.indexOf('Resolve update conflicts with Claude Opus')).toBeLessThan(
+      sync.indexOf('Mint repository App token'),
+    );
+    const claudeStep = sync.slice(
+      sync.indexOf('Resolve update conflicts with Claude Opus'),
+      sync.indexOf("Stage and commit Claude's conflict resolution"),
+    );
+    expect(claudeStep).not.toContain('GH_APP_TOKEN');
+    expect(claudeStep).not.toContain('OTA_PUSH_APP_PRIVATE_KEY');
+    expect(claudeStep).not.toContain('AGENTS.md');
+    expect(claudeStep).not.toContain('Bash(git push');
+    expect(claudeStep).not.toContain('Bash(git add');
+    expect(claudeStep).not.toContain('Bash(git commit');
+    expect(claudeStep).not.toContain('Bash(git merge --continue');
+    expect(claudeStep).not.toContain('Bash(git rebase --continue');
+    expect(sync.indexOf('Validate the AI conflict resolution')).toBeLessThan(sync.indexOf('Mint repository App token'));
     const rebaseJob = sync.slice(sync.indexOf('  rebase:'), sync.indexOf('  notify-failure:'));
     expect(rebaseJob).not.toContain('environment: Native Release');
     expect(sync).toContain('notify-failure:');

--- a/scripts/release-next-sync-workflow.test.ts
+++ b/scripts/release-next-sync-workflow.test.ts
@@ -1,0 +1,325 @@
+/// <reference types="node" />
+
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, onTestFinished } from 'vitest';
+import { parse } from 'yaml';
+
+type WorkflowStep = { name?: string; run?: string };
+type FixtureKind =
+  | 'linear'
+  | 'merge-history'
+  | 'main-merge-history'
+  | 'conflict'
+  | 'conflict-special-path'
+  | 'conflict-delete';
+type Fixture = {
+  conflictPath: string;
+  mainSha: string;
+  originRepository: string;
+  releaseSha: string;
+  runnerTemp: string;
+  worktree: string;
+};
+type EnvironmentOverrides = Record<string, string | undefined>;
+
+const workflowSource = readFileSync('.github/workflows/release-next-sync.yml', 'utf8');
+const workflow = parse(workflowSource) as { jobs: { rebase: { steps: WorkflowStep[] } } };
+
+function scriptFor(stepName: string): string {
+  const script = workflow.jobs.rebase.steps.find((step) => step.name === stepName)?.run;
+  if (!script) throw new Error(`Workflow step has no shell script: ${stepName}`);
+  return script;
+}
+
+const updateScript = scriptFor('Update release/next to current main');
+const finalizeScript = scriptFor("Stage and commit Claude's conflict resolution");
+const verifyScript = scriptFor('Verify the completed update');
+
+function run(
+  command: string,
+  args: string[],
+  cwd: string,
+  environmentOverrides: EnvironmentOverrides = {},
+): SpawnSyncReturns<string> {
+  return spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_CONFIG_NOSYSTEM: '1',
+      ...environmentOverrides,
+    },
+  });
+}
+
+function runGit(args: string[], cwd: string): string {
+  const result = run('git', args, cwd);
+  if (result.status !== 0) throw new Error(`git ${args.join(' ')} failed:\n${result.stderr}`);
+  return result.stdout.trim();
+}
+
+function commitAll(worktree: string, message: string): void {
+  runGit(['add', '.'], worktree);
+  runGit(['-c', 'core.hooksPath=/dev/null', 'commit', '-m', message], worktree);
+}
+
+function createFixture(kind: FixtureKind): Fixture {
+  const rootDirectory = mkdtempSync(join(tmpdir(), 'release-next-sync-'));
+  onTestFinished(() => rmSync(rootDirectory, { force: true, recursive: true }));
+  const originRepository = join(rootDirectory, 'origin.git');
+  const worktree = join(rootDirectory, 'worktree');
+  const runnerTemp = join(rootDirectory, 'runner-temp');
+  mkdirSync(runnerTemp);
+
+  expect(run('git', ['init', '--bare', originRepository], rootDirectory).status).toBe(0);
+  expect(run('git', ['clone', originRepository, worktree], rootDirectory).status).toBe(0);
+  runGit(['config', 'user.name', 'Release Sync Test'], worktree);
+  runGit(['config', 'user.email', 'release-sync@example.com'], worktree);
+  runGit(['config', 'core.hooksPath', '/dev/null'], worktree);
+  runGit(['checkout', '-b', 'main'], worktree);
+  const conflictPath = kind === 'conflict-special-path' ? 'conflict\nfile\tname.txt' : 'conflict.txt';
+  writeFileSync(join(worktree, conflictPath), 'base\n', 'utf8');
+  writeFileSync(join(worktree, 'stable.txt'), 'stable\n', 'utf8');
+  commitAll(worktree, 'chore: seed fixture');
+  runGit(['push', '-u', 'origin', 'main'], worktree);
+
+  runGit(['checkout', '-b', 'release/next'], worktree);
+  if (kind.startsWith('conflict')) {
+    writeFileSync(join(worktree, conflictPath), 'release\n', 'utf8');
+    commitAll(worktree, 'feat: change release value');
+  } else if (kind === 'merge-history') {
+    runGit(['checkout', '-b', 'release-feature'], worktree);
+    writeFileSync(join(worktree, 'release-feature.txt'), 'release merge\n', 'utf8');
+    commitAll(worktree, 'feat: add merged release work');
+    runGit(['checkout', 'release/next'], worktree);
+    runGit(['merge', '--no-ff', '-m', 'merge: release feature', 'release-feature'], worktree);
+  } else {
+    writeFileSync(join(worktree, 'release-linear.txt'), 'release linear\n', 'utf8');
+    commitAll(worktree, 'feat: add linear release work');
+  }
+  const releaseSha = runGit(['rev-parse', 'HEAD'], worktree);
+  runGit(['push', '-u', 'origin', 'release/next'], worktree);
+
+  runGit(['checkout', 'main'], worktree);
+  if (kind === 'conflict-delete') {
+    unlinkSync(join(worktree, conflictPath));
+  } else if (kind.startsWith('conflict')) {
+    writeFileSync(join(worktree, conflictPath), 'main\n', 'utf8');
+  } else if (kind === 'main-merge-history') {
+    runGit(['checkout', '-b', 'main-feature'], worktree);
+    writeFileSync(join(worktree, 'main-merge.txt'), 'main merge\n', 'utf8');
+    commitAll(worktree, 'feat: add merged main work');
+    runGit(['checkout', 'main'], worktree);
+    runGit(['merge', '--no-ff', '-m', 'merge: main feature', 'main-feature'], worktree);
+  } else {
+    writeFileSync(join(worktree, 'main-change.txt'), 'main change\n', 'utf8');
+  }
+  if (kind !== 'main-merge-history') commitAll(worktree, 'feat: advance main');
+  const mainSha = runGit(['rev-parse', 'HEAD'], worktree);
+  runGit(['push', 'origin', 'main'], worktree);
+  runGit(['checkout', 'release/next'], worktree);
+  return { conflictPath, mainSha, originRepository, releaseSha, runnerTemp, worktree };
+}
+
+function atomicPush(fixture: Fixture): SpawnSyncReturns<string> {
+  return run(
+    'git',
+    [
+      'push',
+      '--atomic',
+      `--force-with-lease=refs/heads/release/next:${fixture.releaseSha}`,
+      `--force-with-lease=refs/heads/main:${fixture.mainSha}`,
+      'origin',
+      'HEAD:refs/heads/release/next',
+      `${fixture.mainSha}:refs/heads/main`,
+    ],
+    fixture.worktree,
+  );
+}
+
+function remoteSha(fixture: Fixture, ref: string): string {
+  return runGit(['ls-remote', 'origin', ref], fixture.worktree).split('\t')[0];
+}
+
+function runWorkflowScript(
+  script: string,
+  fixture: Fixture,
+  outputName: string,
+  environmentOverrides: EnvironmentOverrides = {},
+): SpawnSyncReturns<string> {
+  return run('bash', ['-c', script], fixture.worktree, {
+    EXPECTED_MAIN_SHA: fixture.mainSha,
+    EXPECTED_RELEASE_SHA: fixture.releaseSha,
+    GITHUB_OUTPUT: join(fixture.runnerTemp, outputName),
+    RUNNER_TEMP: fixture.runnerTemp,
+    ...environmentOverrides,
+  });
+}
+
+function outputValues(fixture: Fixture, outputName: string, key: string): string[] {
+  return readFileSync(join(fixture.runnerTemp, outputName), 'utf8')
+    .split('\n')
+    .filter((line) => line.startsWith(`${key}=`))
+    .map((line) => line.slice(key.length + 1));
+}
+
+describe('release/next sync workflow shell behavior', () => {
+  it('rebases a linear release range', () => {
+    const fixture = createFixture('linear');
+    const result = runWorkflowScript(updateScript, fixture, 'update-output.txt');
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(outputValues(fixture, 'update-output.txt', 'strategy')).toEqual(['rebase']);
+    expect(outputValues(fixture, 'update-output.txt', 'conflicted')).toEqual(['false']);
+    expect(run('git', ['merge-base', '--is-ancestor', fixture.mainSha, 'HEAD'], fixture.worktree).status).toBe(0);
+    expect(run('git', ['merge-base', '--is-ancestor', fixture.releaseSha, 'HEAD'], fixture.worktree).status).toBe(1);
+  });
+
+  it('creates a merge commit when the release-only range owns merge history', () => {
+    const fixture = createFixture('merge-history');
+    const result = runWorkflowScript(updateScript, fixture, 'update-output.txt');
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(outputValues(fixture, 'update-output.txt', 'strategy')).toEqual(['merge']);
+    expect(outputValues(fixture, 'update-output.txt', 'conflicted')).toEqual(['false']);
+    expect(runGit(['rev-parse', 'HEAD^1'], fixture.worktree)).toBe(fixture.releaseSha);
+    expect(runGit(['rev-parse', 'HEAD^2'], fixture.worktree)).toBe(fixture.mainSha);
+  });
+
+  it('still rebases when only main owns merge history', () => {
+    const fixture = createFixture('main-merge-history');
+    const result = runWorkflowScript(updateScript, fixture, 'update-output.txt');
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(outputValues(fixture, 'update-output.txt', 'strategy')).toEqual(['rebase']);
+    expect(outputValues(fixture, 'update-output.txt', 'conflicted')).toEqual(['false']);
+    expect(run('git', ['merge-base', '--is-ancestor', fixture.mainSha, 'HEAD'], fixture.worktree).status).toBe(0);
+    expect(run('git', ['merge-base', '--is-ancestor', fixture.releaseSha, 'HEAD'], fixture.worktree).status).toBe(1);
+  });
+
+  it('atomically pushes the update while both leases still match', () => {
+    const fixture = createFixture('linear');
+    const updateResult = runWorkflowScript(updateScript, fixture, 'update-output.txt');
+    expect(updateResult.status, updateResult.stderr).toBe(0);
+    const updatedReleaseSha = runGit(['rev-parse', 'HEAD'], fixture.worktree);
+
+    const pushResult = atomicPush(fixture);
+
+    expect(pushResult.status, pushResult.stderr).toBe(0);
+    expect(remoteSha(fixture, 'refs/heads/release/next')).toBe(updatedReleaseSha);
+    expect(remoteSha(fixture, 'refs/heads/main')).toBe(fixture.mainSha);
+  });
+
+  it('leaves release/next untouched when main moves during the update', () => {
+    const fixture = createFixture('linear');
+    const updateResult = runWorkflowScript(updateScript, fixture, 'update-output.txt');
+    expect(updateResult.status, updateResult.stderr).toBe(0);
+    const raceWorktree = join(fixture.runnerTemp, 'main-race-worktree');
+    expect(run('git', ['clone', fixture.originRepository, raceWorktree], fixture.runnerTemp).status).toBe(0);
+    runGit(['config', 'user.name', 'Release Sync Race Test'], raceWorktree);
+    runGit(['config', 'user.email', 'release-sync-race@example.com'], raceWorktree);
+    runGit(['config', 'core.hooksPath', '/dev/null'], raceWorktree);
+    runGit(['checkout', 'main'], raceWorktree);
+    writeFileSync(join(raceWorktree, 'racing-main-change.txt'), 'new main tip\n', 'utf8');
+    commitAll(raceWorktree, 'feat: race the release sync');
+    const racedMainSha = runGit(['rev-parse', 'HEAD'], raceWorktree);
+    runGit(['push', 'origin', 'main'], raceWorktree);
+
+    const pushResult = atomicPush(fixture);
+
+    expect(pushResult.status).not.toBe(0);
+    expect(remoteSha(fixture, 'refs/heads/release/next')).toBe(fixture.releaseSha);
+    expect(remoteSha(fixture, 'refs/heads/main')).toBe(racedMainSha);
+  });
+
+  it('falls back from a conflicting rebase and commits a scoped merge resolution', () => {
+    const fixture = createFixture('conflict');
+    const updateResult = runWorkflowScript(updateScript, fixture, 'update-output.txt');
+
+    expect(updateResult.status, updateResult.stderr).toBe(0);
+    expect(outputValues(fixture, 'update-output.txt', 'strategy')).toEqual(['rebase', 'merge']);
+    expect(outputValues(fixture, 'update-output.txt', 'conflicted')).toEqual(['true']);
+    expect(runGit(['rev-parse', 'MERGE_HEAD'], fixture.worktree)).toBe(fixture.mainSha);
+    expect(readFileSync(join(fixture.runnerTemp, 'release-next-conflicts.txt'))).toEqual(
+      Buffer.from(`${fixture.conflictPath}\0`),
+    );
+
+    writeFileSync(join(fixture.worktree, fixture.conflictPath), 'main\nrelease\n', 'utf8');
+    const finalizeResult = runWorkflowScript(finalizeScript, fixture, 'finalize-output.txt');
+    expect(finalizeResult.status, finalizeResult.stderr).toBe(0);
+    expect(runGit(['rev-parse', 'HEAD^1'], fixture.worktree)).toBe(fixture.releaseSha);
+    expect(runGit(['rev-parse', 'HEAD^2'], fixture.worktree)).toBe(fixture.mainSha);
+
+    const verifyResult = runWorkflowScript(verifyScript, fixture, 'verify-output.txt', {
+      UPDATE_STRATEGY: 'merge',
+    });
+    expect(verifyResult.status, verifyResult.stderr).toBe(0);
+    expect(outputValues(fixture, 'verify-output.txt', 'updated_sha')).toEqual([
+      runGit(['rev-parse', 'HEAD'], fixture.worktree),
+    ]);
+  });
+
+  it('rejects a conflict agent that edits a non-conflict path', () => {
+    const fixture = createFixture('conflict');
+    const updateResult = runWorkflowScript(updateScript, fixture, 'update-output.txt');
+    expect(updateResult.status, updateResult.stderr).toBe(0);
+
+    writeFileSync(join(fixture.worktree, fixture.conflictPath), 'main\nrelease\n', 'utf8');
+    writeFileSync(join(fixture.worktree, 'stable.txt'), 'changed outside conflict\n', 'utf8');
+    const finalizeResult = runWorkflowScript(finalizeScript, fixture, 'finalize-output.txt');
+
+    expect(finalizeResult.status).toBe(1);
+    expect(readFileSync(join(fixture.runnerTemp, 'release-next-sync-error.txt'), 'utf8')).toContain('stable.txt');
+    expect(runGit(['rev-parse', 'HEAD'], fixture.worktree)).toBe(fixture.releaseSha);
+  });
+
+  it('rejects a conflict agent that stages a non-conflict path', () => {
+    const fixture = createFixture('conflict');
+    const updateResult = runWorkflowScript(updateScript, fixture, 'update-output.txt');
+    expect(updateResult.status, updateResult.stderr).toBe(0);
+
+    writeFileSync(join(fixture.worktree, fixture.conflictPath), 'main\nrelease\n', 'utf8');
+    writeFileSync(join(fixture.worktree, 'stable.txt'), 'staged outside conflict\n', 'utf8');
+    runGit(['add', 'stable.txt'], fixture.worktree);
+    const finalizeResult = runWorkflowScript(finalizeScript, fixture, 'finalize-output.txt');
+
+    expect(finalizeResult.status).toBe(1);
+    expect(readFileSync(join(fixture.runnerTemp, 'release-next-sync-error.txt'), 'utf8')).toContain(
+      'changed the Git index',
+    );
+    expect(runGit(['rev-parse', 'HEAD'], fixture.worktree)).toBe(fixture.releaseSha);
+  });
+
+  it('handles a conflicted pathname containing tabs and newlines', () => {
+    const fixture = createFixture('conflict-special-path');
+    const updateResult = runWorkflowScript(updateScript, fixture, 'update-output.txt');
+    expect(updateResult.status, updateResult.stderr).toBe(0);
+
+    expect(readFileSync(join(fixture.runnerTemp, 'release-next-conflicts.txt'))).toEqual(
+      Buffer.from(`${fixture.conflictPath}\0`),
+    );
+    writeFileSync(join(fixture.worktree, fixture.conflictPath), 'main\nrelease\n', 'utf8');
+    const finalizeResult = runWorkflowScript(finalizeScript, fixture, 'finalize-output.txt');
+
+    expect(finalizeResult.status, finalizeResult.stderr).toBe(0);
+    expect(runGit(['rev-parse', 'HEAD^1'], fixture.worktree)).toBe(fixture.releaseSha);
+    expect(runGit(['rev-parse', 'HEAD^2'], fixture.worktree)).toBe(fixture.mainSha);
+  });
+
+  it('can accept deletion as the conflict resolution', () => {
+    const fixture = createFixture('conflict-delete');
+    const updateResult = runWorkflowScript(updateScript, fixture, 'update-output.txt');
+    expect(updateResult.status, updateResult.stderr).toBe(0);
+
+    rmSync(join(fixture.worktree, fixture.conflictPath));
+    const finalizeResult = runWorkflowScript(finalizeScript, fixture, 'finalize-output.txt');
+
+    expect(finalizeResult.status, finalizeResult.stderr).toBe(0);
+    expect(runGit(['rev-parse', 'HEAD^1'], fixture.worktree)).toBe(fixture.releaseSha);
+    expect(runGit(['rev-parse', 'HEAD^2'], fixture.worktree)).toBe(fixture.mainSha);
+  });
+});


### PR DESCRIPTION
## Summary

- Rebase linear release trains, then preserve release-owned merge history with merge commits.
- Let a restricted Claude Opus agent resolve only recorded conflict paths.
- Validate AI resolutions before an atomic, dual-ref lease-protected push.
- Add shell-level coverage for conflicts, unusual paths, deletions, and ref races.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 4/5 — changes the automated native release branch update path.
