### PR TITLE
fix(mobile): let the advertised board type veto a foreign serial match

### DIFF
--- a/packages/mobile/src/components/board-discovery/BluetoothQuickstartSheet.tsx
+++ b/packages/mobile/src/components/board-discovery/BluetoothQuickstartSheet.tsx
@@ -31,8 +31,11 @@ export const BluetoothQuickstartSheet = forwardRef<BottomSheet, BluetoothQuickst
   function BluetoothQuickstartSheet({ active, onClose, onSelect }, ref) {
     const { systemColors } = useTheme();
     const { t } = useTranslation(['boards', 'settings']);
-    const { status, serials, start, reset } = useBoardScan();
-    const { data: boards = [], isLoading: isResolving } = useBoardsBySerialNumbers(serials);
+    const { status, serials, advertisedTypes, start, reset } = useBoardScan();
+    // Scoped to what each controller announced. Aurora reuses a serial across
+    // board apps, so unscoped this sheet would offer a stranger's Kilter board
+    // for an in-range Tension controller and let the user make it active.
+    const { data: boards = [], isLoading: isResolving } = useBoardsBySerialNumbers(serials, advertisedTypes);
 
     // `!isResolving` matters: the scan reports 'done' the moment the radio work
     // finishes, while `boards` stays empty until GraphQL has turned the serials

--- a/packages/mobile/src/components/board-discovery/__tests__/bluetooth-quickstart-sheet.test.tsx
+++ b/packages/mobile/src/components/board-discovery/__tests__/bluetooth-quickstart-sheet.test.tsx
@@ -302,7 +302,12 @@ describe('BluetoothQuickstartSheet board rows', () => {
 
     render(createElement(BluetoothQuickstartSheet, { active: true, onClose: () => {}, onSelect: () => {} }));
 
-    expect(resolveCalls.at(-1)).toMatchObject({ serialNumbers: ['12345'] });
-    expect([...(resolveCalls.at(-1)?.advertisedTypes ?? [])]).toEqual([['12345', 'tension']]);
+    const lastCall = resolveCalls.at(-1);
+    expect({ serialNumbers: lastCall?.serialNumbers, advertisedTypes: [...(lastCall?.advertisedTypes ?? [])] }).toEqual(
+      {
+        serialNumbers: ['12345'],
+        advertisedTypes: [['12345', 'tension']],
+      },
+    );
   });
 });

--- a/packages/mobile/src/components/board-discovery/__tests__/bluetooth-quickstart-sheet.test.tsx
+++ b/packages/mobile/src/components/board-discovery/__tests__/bluetooth-quickstart-sheet.test.tsx
@@ -6,11 +6,16 @@ import { createElement, forwardRef, type ReactNode, type Ref } from 'react';
 const scan = vi.hoisted(() => ({
   status: 'done' as 'idle' | 'scanning' | 'done' | 'unavailable',
   serials: [] as string[],
+  advertisedTypes: new Map<string, string>(),
   start: vi.fn(async () => {}),
   reset: vi.fn(),
 }));
 
 const boards = vi.hoisted(() => ({ data: [] as unknown[], isLoading: false }));
+
+const { resolveCalls } = vi.hoisted(() => ({
+  resolveCalls: [] as Array<{ serialNumbers: string[]; advertisedTypes?: ReadonlyMap<string, string> }>,
+}));
 
 const locationHint = vi.hoisted(() => ({
   shouldOfferLocationGrant: false,
@@ -47,7 +52,13 @@ vi.mock('../../../lib/ble/use-android-scan-location-hint', () => ({
 }));
 
 vi.mock('../../../lib/graphql/hooks', () => ({
-  useBoardsBySerialNumbers: () => boards,
+  useBoardsBySerialNumbers: (serialNumbers: string[], advertisedTypes?: ReadonlyMap<string, string>) => {
+    // Recorded so the sheet is pinned to passing the scan's advertised types
+    // through. Without them the hook resolves a serial to whichever board type
+    // carries it, and this sheet makes that board active.
+    resolveCalls.push({ serialNumbers, advertisedTypes });
+    return boards;
+  },
 }));
 
 vi.mock('../../../providers/theme-provider', () => ({
@@ -90,6 +101,8 @@ describe('BluetoothQuickstartSheet', () => {
   beforeEach(() => {
     scan.status = 'done';
     scan.serials = [];
+    scan.advertisedTypes = new Map();
+    resolveCalls.length = 0;
     scan.start.mockClear();
     scan.reset.mockReset();
     boards.data = [];
@@ -278,5 +291,18 @@ describe('BluetoothQuickstartSheet board rows', () => {
     const { container } = renderSheet();
 
     expect(hasText(container, 'Original 12×14')).toBe(true);
+  });
+
+  it('resolves scanned serials scoped to the type each controller advertised', () => {
+    // The Benchmark bug on this surface: Aurora reuses a serial across board
+    // apps, so an unscoped lookup can offer a stranger's Kilter board for an
+    // in-range Tension controller — and this sheet makes the pick active.
+    scan.serials = ['12345'];
+    scan.advertisedTypes = new Map([['12345', 'tension']]);
+
+    render(createElement(BluetoothQuickstartSheet, { active: true, onClose: () => {}, onSelect: () => {} }));
+
+    expect(resolveCalls.at(-1)).toMatchObject({ serialNumbers: ['12345'] });
+    expect([...(resolveCalls.at(-1)?.advertisedTypes ?? [])]).toEqual([['12345', 'tension']]);
   });
 });

--- a/packages/mobile/src/lib/ble/__tests__/advertised-board-type.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/advertised-board-type.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import {
+  advertisedBoardTypesBySerial,
+  matchesAdvertisedType,
+  sharedAdvertisedBoardType,
+} from '../advertised-board-type';
+
+/**
+ * The single source of the "a serial identifies a controller only within a board
+ * type" rule. Aurora numbers each board app separately, so a Kilter `#12345` and
+ * a Tension `#12345` are different hardware — reported from Benchmark Climbing,
+ * where a Tension controller resolved onto a stranger's Kilter board.
+ *
+ * Both surfaces that turn scan results into boards read this module (the
+ * connect-time picker via resolve-serials.ts, the quickstart sheet via
+ * useBoardsBySerialNumbers), so it is where the rule gets pinned.
+ */
+describe('advertisedBoardTypesBySerial', () => {
+  it('keys each device name by its serial and board type', () => {
+    const advertisedTypes = advertisedBoardTypesBySerial([
+      { name: 'Tension Board#12345@3' },
+      { name: 'Kilter Board#99@3' },
+    ]);
+
+    expect([...advertisedTypes]).toEqual([
+      ['12345', 'tension'],
+      ['99', 'kilter'],
+    ]);
+  });
+
+  it('omits a name with no recognisable board type', () => {
+    expect(advertisedBoardTypesBySerial([{ name: 'Mystery Box#12345@3' }, {}]).size).toBe(0);
+  });
+
+  it('keeps the first sighting when a serial is advertised twice', () => {
+    // Two boxes in range genuinely claiming one serial is a supplier fault we
+    // can't adjudicate here; take the first and stay deterministic.
+    const advertisedTypes = advertisedBoardTypesBySerial([
+      { name: 'Tension Board#12345@3' },
+      { name: 'Kilter Board#12345@3' },
+    ]);
+
+    expect(advertisedTypes.get('12345')).toBe('tension');
+  });
+});
+
+describe('sharedAdvertisedBoardType', () => {
+  it('returns the type when the whole scan agrees', () => {
+    expect(sharedAdvertisedBoardType(new Map([['1', 'tension']]))).toBe('tension');
+    expect(
+      sharedAdvertisedBoardType(
+        new Map([
+          ['1', 'tension'],
+          ['2', 'tension'],
+        ]),
+      ),
+    ).toBe('tension');
+  });
+
+  it('returns undefined for a mixed scan so the request goes out unscoped', () => {
+    // One argument can't describe two types; the per-serial filter takes over.
+    expect(
+      sharedAdvertisedBoardType(
+        new Map([
+          ['1', 'tension'],
+          ['2', 'kilter'],
+        ]),
+      ),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when nothing advertised a type', () => {
+    expect(sharedAdvertisedBoardType(new Map())).toBeUndefined();
+  });
+});
+
+describe('matchesAdvertisedType', () => {
+  const advertisedTypes = new Map([['12345', 'tension']]);
+
+  it('rejects a board of a different type', () => {
+    expect(matchesAdvertisedType('12345', 'kilter', advertisedTypes)).toBe(false);
+  });
+
+  it('accepts a board of the advertised type', () => {
+    expect(matchesAdvertisedType('12345', 'tension', advertisedTypes)).toBe(true);
+  });
+
+  it('accepts when either side is unknown', () => {
+    // Permissive on purpose: an unknown type is not evidence of a mismatch, and
+    // dropping the match would lose a board the picker could otherwise name.
+    expect(matchesAdvertisedType('99', 'kilter', advertisedTypes)).toBe(true);
+    expect(matchesAdvertisedType('12345', undefined, advertisedTypes)).toBe(true);
+    expect(matchesAdvertisedType('12345', null, advertisedTypes)).toBe(true);
+  });
+});

--- a/packages/mobile/src/lib/ble/__tests__/resolve-serials-hook.test.tsx
+++ b/packages/mobile/src/lib/ble/__tests__/resolve-serials-hook.test.tsx
@@ -99,7 +99,48 @@ describe('useResolvedBleDeviceBoards', () => {
     // Only the public saved-boards query fires; the auth-gated recorded-configs
     // query is skipped because authToken is null (falsy) inside resolveBleSerialNumbers.
     expect(harness.request).toHaveBeenCalledTimes(1);
-    expect(harness.request).toHaveBeenCalledWith(GET_BOARDS_BY_SERIAL_NUMBERS, { serialNumbers: ['SN-A'] });
+    // Scoped to the type the device names advertise (`Kilter Board#SN-A@3`),
+    // so a Tension controller sharing this serial can't come back.
+    expect(harness.request).toHaveBeenCalledWith(GET_BOARDS_BY_SERIAL_NUMBERS, {
+      serialNumbers: ['SN-A'],
+      boardType: 'kilter',
+    });
+  });
+
+  it('refetches when a device name arrives late and reveals the board type', async () => {
+    // A scan result can land without a name and get one moments later. The
+    // advertised type decides which board may claim the serial, so it has to be
+    // part of the query key — otherwise the first, type-less result stays cached
+    // and the board stays mis-identified for the rest of the scan.
+    vi.mocked(useAuthToken).mockReturnValue({ data: null } as ReturnType<typeof useAuthToken>);
+    harness.request.mockImplementation((operation: unknown) => {
+      if (operation === GET_BOARDS_BY_SERIAL_NUMBERS) {
+        return Promise.resolve({ boardsBySerialNumbers: [] });
+      }
+      return Promise.reject(new Error('Unexpected operation'));
+    });
+
+    const namelessDevices = [{ deviceId: 'device-0', name: 'Board#SN-A@3', rssi: -50 }];
+    const { rerender } = renderHook(({ devices }) => useResolvedBleDeviceBoards(devices), {
+      wrapper: QueryWrapper,
+      initialProps: { devices: namelessDevices as ReturnType<typeof makeDevices> },
+    });
+
+    await waitFor(() =>
+      expect(harness.request).toHaveBeenCalledWith(GET_BOARDS_BY_SERIAL_NUMBERS, {
+        serialNumbers: ['SN-A'],
+        boardType: undefined,
+      }),
+    );
+
+    rerender({ devices: makeDevices(['SN-A']) });
+
+    await waitFor(() =>
+      expect(harness.request).toHaveBeenCalledWith(GET_BOARDS_BY_SERIAL_NUMBERS, {
+        serialNumbers: ['SN-A'],
+        boardType: 'kilter',
+      }),
+    );
   });
 
   it('does not fire any query while authToken is still loading (authToken === undefined)', async () => {

--- a/packages/mobile/src/lib/ble/__tests__/resolve-serials.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/resolve-serials.test.ts
@@ -23,7 +23,11 @@ vi.mock('../../graphql/use-auth-token', () => ({
   useAuthToken: vi.fn(() => ({ data: null })),
 }));
 
-import { resolveBleSerialNumbers, serialsFromDiscoveredDevices } from '../resolve-serials';
+import {
+  advertisedBoardTypesBySerial,
+  resolveBleSerialNumbers,
+  serialsFromDiscoveredDevices,
+} from '../resolve-serials';
 
 function makeBoard(serialNumber: string, overrides: Partial<UserBoard> = {}): UserBoard {
   return {
@@ -126,7 +130,10 @@ describe('resolveBleSerialNumbers', () => {
 
     expect(resolvedBoards.size).toBe(0);
     expect(harness.request).toHaveBeenCalledTimes(1);
-    expect(harness.request).toHaveBeenCalledWith(GET_BOARDS_BY_SERIAL_NUMBERS, { serialNumbers: ['SN-1'] });
+    expect(harness.request).toHaveBeenCalledWith(GET_BOARDS_BY_SERIAL_NUMBERS, {
+      serialNumbers: ['SN-1'],
+      boardType: undefined,
+    });
   });
 
   it('uses the provided auth token instead of reading storage', async () => {
@@ -144,5 +151,124 @@ describe('resolveBleSerialNumbers', () => {
 
     expect(resolvedBoards.get('SN-1')).toEqual({ kind: 'recorded', config: makeConfig('SN-1') });
     expect(harness.request).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * Aurora numbers each board app separately, so a serial identifies a controller
+ * only WITHIN a board type: a Kilter `#12345` and a Tension `#12345` are
+ * different hardware. Reported from Benchmark Climbing, where connecting the
+ * gym's Tension board resolved onto a stranger's Kilter board that shared the
+ * serial, so every connect announced it as a Kilter board.
+ */
+describe('advertisedBoardTypesBySerial', () => {
+  it('reads the board type out of each device name', () => {
+    const advertisedTypes = advertisedBoardTypesBySerial([
+      { deviceId: 'a', name: 'Tension Board#12345@3', rssi: -40 },
+      { deviceId: 'b', name: 'Kilter Board#99@3', rssi: -50 },
+    ]);
+
+    expect(advertisedTypes.get('12345')).toBe('tension');
+    expect(advertisedTypes.get('99')).toBe('kilter');
+  });
+
+  it('omits serials whose name carries no recognisable board type', () => {
+    // Absent, not null: an unknown type must not be treated as a mismatch, or a
+    // real board would be filtered out of the picker.
+    const advertisedTypes = advertisedBoardTypesBySerial([
+      { deviceId: 'a', name: 'Mystery Box#12345@3', rssi: -40 },
+      { deviceId: 'b', rssi: -50 },
+    ]);
+
+    expect(advertisedTypes.size).toBe(0);
+  });
+});
+
+describe('resolveBleSerialNumbers — advertised board type', () => {
+  const tensionDevices = [{ deviceId: 'a', name: 'Tension Board#SN-1@3', rssi: -40 }];
+
+  function mockLookup(boards: UserBoard[], configs: BoardSerialConfig[] = []) {
+    harness.request.mockImplementation((operation: unknown) => {
+      if (operation === GET_BOARDS_BY_SERIAL_NUMBERS) return Promise.resolve({ boardsBySerialNumbers: boards });
+      if (operation === GET_MY_BOARD_SERIAL_CONFIGS) return Promise.resolve({ myBoardSerialConfigs: configs });
+      return Promise.reject(new Error('Unexpected operation'));
+    });
+  }
+
+  it('drops a saved board whose type is not what the controller advertised', async () => {
+    // The Benchmark case: the backend still returns the Kilter board (an older
+    // deployment ignores the boardType argument), so the client has to refuse it.
+    mockLookup([makeBoard('SN-1', { boardType: 'kilter', name: 'Someone else Kilter' })]);
+
+    const resolvedBoards = await resolveBleSerialNumbers(['SN-1'], null, advertisedBoardTypesBySerial(tensionDevices));
+
+    expect(resolvedBoards.size).toBe(0);
+  });
+
+  it('keeps a saved board of the advertised type', async () => {
+    const tensionBoard = makeBoard('SN-1', { boardType: 'tension', name: 'Benchmark Tension' });
+    mockLookup([tensionBoard]);
+
+    const resolvedBoards = await resolveBleSerialNumbers(['SN-1'], null, advertisedBoardTypesBySerial(tensionDevices));
+
+    expect(resolvedBoards.get('SN-1')).toEqual({ kind: 'saved', board: tensionBoard });
+  });
+
+  it('drops a recorded config of the wrong type and does not fall back to it', async () => {
+    // The recorded fallback must not become a second way in for the same board
+    // the saved-board filter just refused.
+    harness.authToken = 'token-1';
+    mockLookup([makeBoard('SN-1', { boardType: 'kilter' })], [makeConfig('SN-1', { boardName: 'kilter' })]);
+
+    const resolvedBoards = await resolveBleSerialNumbers(
+      ['SN-1'],
+      'token-1',
+      advertisedBoardTypesBySerial(tensionDevices),
+    );
+
+    expect(resolvedBoards.size).toBe(0);
+  });
+
+  it('keeps a match when the device name advertised no type', async () => {
+    const kilterBoard = makeBoard('SN-1', { boardType: 'kilter' });
+    mockLookup([kilterBoard]);
+
+    const resolvedBoards = await resolveBleSerialNumbers(['SN-1'], null, new Map());
+
+    expect(resolvedBoards.get('SN-1')).toEqual({ kind: 'saved', board: kilterBoard });
+  });
+
+  it('scopes the query when the whole scan advertises one type', async () => {
+    mockLookup([]);
+
+    await resolveBleSerialNumbers(['SN-1'], null, advertisedBoardTypesBySerial(tensionDevices));
+
+    expect(harness.request).toHaveBeenCalledWith(GET_BOARDS_BY_SERIAL_NUMBERS, {
+      serialNumbers: ['SN-1'],
+      boardType: 'tension',
+    });
+  });
+
+  it('sends no board type for a mixed scan, and still filters per serial', async () => {
+    // One argument can't describe two types, so the request goes out wide and
+    // each serial is checked against its own advertisement.
+    const mixedDevices = [
+      { deviceId: 'a', name: 'Tension Board#SN-1@3', rssi: -40 },
+      { deviceId: 'b', name: 'Kilter Board#SN-2@3', rssi: -50 },
+    ];
+    mockLookup([makeBoard('SN-1', { boardType: 'kilter' }), makeBoard('SN-2', { boardType: 'kilter' })]);
+
+    const resolvedBoards = await resolveBleSerialNumbers(
+      ['SN-1', 'SN-2'],
+      null,
+      advertisedBoardTypesBySerial(mixedDevices),
+    );
+
+    expect(harness.request).toHaveBeenCalledWith(GET_BOARDS_BY_SERIAL_NUMBERS, {
+      serialNumbers: ['SN-1', 'SN-2'],
+      boardType: undefined,
+    });
+    expect(resolvedBoards.has('SN-1')).toBe(false);
+    expect(resolvedBoards.get('SN-2')?.kind).toBe('saved');
   });
 });

--- a/packages/mobile/src/lib/ble/__tests__/use-board-scan.test.ts
+++ b/packages/mobile/src/lib/ble/__tests__/use-board-scan.test.ts
@@ -45,6 +45,13 @@ vi.mock('@boardsesh/ble-protocol', () => ({
   UART_SERVICE_UUID: 'uart-uuid',
   REDBEARLAB_SERVICE_UUID: 'redbearlab-uuid',
   parseSerialNumber: (name?: string) => name?.match(/#([^@]+)/)?.[1],
+  // The scan now records the board type each device advertises, so the
+  // quickstart sheet can't offer a board of the wrong type for a reused serial.
+  // Mirrors the real prefix match over the Aurora board names.
+  parseBoardTypeFromDeviceName: (name?: string) =>
+    ['kilter', 'tension', 'decoy', 'touchstone', 'grasshopper', 'soill'].find((board) =>
+      name?.toLowerCase().replace(/[\s-]/g, '').startsWith(board),
+    ),
 }));
 
 import { useBoardScan } from '../use-board-scan';

--- a/packages/mobile/src/lib/ble/advertised-board-type.ts
+++ b/packages/mobile/src/lib/ble/advertised-board-type.ts
@@ -1,0 +1,66 @@
+import { parseBoardTypeFromDeviceName, parseSerialNumber } from '@boardsesh/ble-protocol';
+
+/**
+ * Only the advertised name matters here, so this takes the narrowest shape that
+ * carries it — both the connect-time picker's `DiscoveredDevice` and the
+ * quickstart scan's lighter records satisfy it. The other scan-result fields
+ * are declared optional purely so a caller can hand over a full record without
+ * TypeScript's excess-property check rejecting the literal; nothing reads them.
+ */
+export type NamedDevice = { name?: string; deviceId?: string; rssi?: number };
+
+/**
+ * The board type a controller announces in its BLE device name
+ * (`Tension Board#12345@3`), keyed by the serial in that same name.
+ *
+ * Aurora numbers each board app separately, so a serial identifies a controller
+ * only WITHIN a type: a Kilter `#12345` and a Tension `#12345` are different
+ * hardware. The advertised name is the only trustworthy signal about the box in
+ * front of the climber, so it decides which resolved board may claim a serial.
+ *
+ * This module is the single source of that rule. Both surfaces that turn scan
+ * results into boards — the connect-time device picker (`resolve-serials.ts`)
+ * and the Bluetooth quickstart sheet — go through it, so they can't drift into
+ * disagreeing about which board a serial means.
+ *
+ * A serial whose name carries no recognisable type is simply absent from the
+ * map, and is left unfiltered downstream: an unknown type is not evidence of a
+ * mismatch, and dropping the match would lose a board we could otherwise name.
+ */
+export type AdvertisedBoardTypes = ReadonlyMap<string, string>;
+
+export function advertisedBoardTypesBySerial(devices: ReadonlyArray<NamedDevice>): Map<string, string> {
+  const advertisedTypes = new Map<string, string>();
+  for (const device of devices) {
+    const serial = parseSerialNumber(device.name);
+    if (!serial || advertisedTypes.has(serial)) continue;
+    const boardType = parseBoardTypeFromDeviceName(device.name);
+    if (boardType) advertisedTypes.set(serial, boardType);
+  }
+  return advertisedTypes;
+}
+
+/**
+ * The single board type a request can be scoped to, or undefined when the scan
+ * is mixed (or nothing advertised a type). One argument can't describe two
+ * types, so a mixed scan goes out unscoped and `matchesAdvertisedType` filters
+ * the response per serial.
+ */
+export function sharedAdvertisedBoardType(advertisedTypes: AdvertisedBoardTypes): string | undefined {
+  const distinctTypes = new Set(advertisedTypes.values());
+  return distinctTypes.size === 1 ? [...distinctTypes][0] : undefined;
+}
+
+/**
+ * Whether a board of `boardType` may claim `serialNumber`. Unknown on either
+ * side means "can't tell" — keep it, per the permissive rule above.
+ */
+export function matchesAdvertisedType(
+  serialNumber: string,
+  boardType: string | null | undefined,
+  advertisedTypes: AdvertisedBoardTypes,
+): boolean {
+  const advertisedType = advertisedTypes.get(serialNumber);
+  if (!advertisedType || !boardType) return true;
+  return boardType === advertisedType;
+}

--- a/packages/mobile/src/lib/ble/picker-resolution-stats.ts
+++ b/packages/mobile/src/lib/ble/picker-resolution-stats.ts
@@ -8,6 +8,12 @@ import { configFromResolvedEntry, type BleBoardConfig } from './board-config-mat
  * The board type a picker row effectively represents, mirroring DeviceCard: a
  * resolved (saved/recorded) board's real type, else the type parsed from the
  * advertised name. `undefined` when neither can identify it.
+ *
+ * The resolved board winning is safe because `resolveBleSerialNumbers` already
+ * refuses any entry whose type contradicts the advertisement, so the two can no
+ * longer disagree — the resolved type is the advertised one, just more specific.
+ * If that filter is ever relaxed, this precedence has to flip: it is what let a
+ * Tension controller render as a stranger's Kilter board.
  */
 export function effectiveBoardType(
   device: DiscoveredDevice,

--- a/packages/mobile/src/lib/ble/resolve-serials.ts
+++ b/packages/mobile/src/lib/ble/resolve-serials.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { parseSerialNumber } from '@boardsesh/ble-protocol';
+import { parseBoardTypeFromDeviceName, parseSerialNumber } from '@boardsesh/ble-protocol';
 import {
   GET_BOARDS_BY_SERIAL_NUMBERS,
   GET_MY_BOARD_SERIAL_CONFIGS,
@@ -29,9 +29,61 @@ export function serialsFromDiscoveredDevices(devices: ReadonlyArray<DiscoveredDe
   return [...serials];
 }
 
+/**
+ * The board type each discovered serial advertises, read straight from the BLE
+ * device name (`Tension Board#12345@3`).
+ *
+ * Aurora numbers each board app separately, so a serial identifies a controller
+ * only WITHIN a type: a Kilter `#12345` and a Tension `#12345` are different
+ * hardware. The advertised name is the only trustworthy signal about the box in
+ * front of the climber, so it decides which resolved board may claim a serial.
+ *
+ * Serials whose name carries no recognisable type are absent from the map, and
+ * are left unfiltered — an unknown type must not throw away a real match.
+ */
+export function advertisedBoardTypesBySerial(devices: ReadonlyArray<DiscoveredDevice>): Map<string, string> {
+  const advertisedTypes = new Map<string, string>();
+  for (const device of devices) {
+    const serial = parseSerialNumber(device.name);
+    if (!serial || advertisedTypes.has(serial)) continue;
+    const boardType = parseBoardTypeFromDeviceName(device.name);
+    if (boardType) advertisedTypes.set(serial, boardType);
+  }
+  return advertisedTypes;
+}
+
+/**
+ * The single board type to scope the request to, or undefined when the scan is
+ * mixed (or nothing advertised a type). A mixed scan can't be narrowed with one
+ * argument, so it goes out unscoped and `matchesAdvertisedType` filters the
+ * response per serial.
+ */
+function sharedAdvertisedBoardType(advertisedTypes: ReadonlyMap<string, string>): string | undefined {
+  const distinctTypes = new Set(advertisedTypes.values());
+  return distinctTypes.size === 1 ? [...distinctTypes][0] : undefined;
+}
+
+/**
+ * Whether a resolved entry describes hardware of the type this serial
+ * advertised. Unknown on either side means "can't tell" — keep the entry, since
+ * dropping it would lose a board the picker could otherwise name.
+ */
+function matchesAdvertisedType(
+  serialNumber: string,
+  entry: ResolvedBoardEntry,
+  advertisedTypes: ReadonlyMap<string, string>,
+): boolean {
+  const advertisedType = advertisedTypes.get(serialNumber);
+  if (!advertisedType) return true;
+  const entryBoardType = entry.kind === 'saved' ? entry.board.boardType : entry.config.boardName;
+  if (!entryBoardType) return true;
+  return entryBoardType === advertisedType;
+}
+
 export async function resolveBleSerialNumbers(
   serialNumbers: string[],
   providedAuthToken?: string | null,
+  advertisedTypes: ReadonlyMap<string, string> = new Map(),
 ): Promise<Map<string, ResolvedBoardEntry>> {
   const uniqueSerialNumbers = [
     ...new Set(serialNumbers.filter((serialNumber) => serialNumber.trim().length > 0)),
@@ -52,6 +104,11 @@ export async function resolveBleSerialNumbers(
     client
       .request<GetBoardsBySerialNumbersQueryResponse>(GET_BOARDS_BY_SERIAL_NUMBERS, {
         serialNumbers: uniqueSerialNumbers,
+        // Narrows the query when the whole scan advertises one type, which is
+        // the usual case. It only reduces what comes back — the per-serial
+        // filter below is what actually enforces the rule, so a mixed scan (or
+        // an older backend that ignores the argument) is still correct.
+        boardType: sharedAdvertisedBoardType(advertisedTypes),
       })
       .catch(() => ({ boardsBySerialNumbers: [] as UserBoard[] })),
     recordedRequest,
@@ -59,14 +116,19 @@ export async function resolveBleSerialNumbers(
 
   const resolvedBoards = new Map<string, ResolvedBoardEntry>();
   for (const board of savedResult.boardsBySerialNumbers) {
-    if (board.serialNumber) {
-      resolvedBoards.set(board.serialNumber, { kind: 'saved', board });
-    }
+    if (!board.serialNumber) continue;
+    const entry: ResolvedBoardEntry = { kind: 'saved', board };
+    // A board of another type shares nothing but the number with the controller
+    // that just advertised. Letting it in is what made a Tension box at
+    // Benchmark Climbing render — and behave — as a stranger's Kilter board.
+    if (!matchesAdvertisedType(board.serialNumber, entry, advertisedTypes)) continue;
+    resolvedBoards.set(board.serialNumber, entry);
   }
   for (const config of recordedResult.myBoardSerialConfigs) {
-    if (!resolvedBoards.has(config.serialNumber)) {
-      resolvedBoards.set(config.serialNumber, { kind: 'recorded', config });
-    }
+    if (resolvedBoards.has(config.serialNumber)) continue;
+    const entry: ResolvedBoardEntry = { kind: 'recorded', config };
+    if (!matchesAdvertisedType(config.serialNumber, entry, advertisedTypes)) continue;
+    resolvedBoards.set(config.serialNumber, entry);
   }
   return resolvedBoards;
 }
@@ -84,11 +146,22 @@ export function useResolvedBleDeviceBoards(devices: ReadonlyArray<DiscoveredDevi
     () => (serialNumbersKey.length > 0 ? serialNumbersKey.split('@') : []),
     [serialNumbersKey],
   );
+  // Rebuilt whenever `devices` changes identity, which is cheap and keeps the
+  // map in step with late-arriving device names. Only the sorted entries below
+  // reach the query key, so this churn never refetches on its own.
+  const advertisedTypes = useMemo(() => advertisedBoardTypesBySerial(devices), [devices]);
+  // A serial's advertised type can arrive after the serial itself (the name
+  // lands late), and it changes which board may claim that serial — so it has
+  // to key the cache, not just the request. Sorted for a stable hash.
+  const advertisedTypeEntries = useMemo(
+    () => [...advertisedTypes].sort(([first], [second]) => first.localeCompare(second)),
+    [advertisedTypes],
+  );
   const authTokenQuery = useAuthToken();
   const authToken = authTokenQuery.data;
   const { data } = useQuery({
-    queryKey: ['bleDeviceSerials', authToken ?? null, serialNumbers],
-    queryFn: () => resolveBleSerialNumbers(serialNumbers, authToken ?? null),
+    queryKey: ['bleDeviceSerials', authToken ?? null, serialNumbers, advertisedTypeEntries],
+    queryFn: () => resolveBleSerialNumbers(serialNumbers, authToken ?? null, advertisedTypes),
     enabled: serialNumbers.length > 0 && authToken !== undefined,
     staleTime: 30_000,
   });

--- a/packages/mobile/src/lib/ble/resolve-serials.ts
+++ b/packages/mobile/src/lib/ble/resolve-serials.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { parseBoardTypeFromDeviceName, parseSerialNumber } from '@boardsesh/ble-protocol';
+import { parseSerialNumber } from '@boardsesh/ble-protocol';
 import {
   GET_BOARDS_BY_SERIAL_NUMBERS,
   GET_MY_BOARD_SERIAL_CONFIGS,
@@ -13,6 +13,14 @@ import { getAuthToken } from '../auth-store';
 import { getHttpClient } from '../graphql/client';
 import { useAuthToken } from '../graphql/use-auth-token';
 import type { DiscoveredDevice } from './types';
+import {
+  advertisedBoardTypesBySerial,
+  matchesAdvertisedType,
+  sharedAdvertisedBoardType,
+  type AdvertisedBoardTypes,
+} from './advertised-board-type';
+
+export { advertisedBoardTypesBySerial } from './advertised-board-type';
 
 export type ResolvedBoardEntry = { kind: 'saved'; board: UserBoard } | { kind: 'recorded'; config: BoardSerialConfig };
 
@@ -29,61 +37,10 @@ export function serialsFromDiscoveredDevices(devices: ReadonlyArray<DiscoveredDe
   return [...serials];
 }
 
-/**
- * The board type each discovered serial advertises, read straight from the BLE
- * device name (`Tension Board#12345@3`).
- *
- * Aurora numbers each board app separately, so a serial identifies a controller
- * only WITHIN a type: a Kilter `#12345` and a Tension `#12345` are different
- * hardware. The advertised name is the only trustworthy signal about the box in
- * front of the climber, so it decides which resolved board may claim a serial.
- *
- * Serials whose name carries no recognisable type are absent from the map, and
- * are left unfiltered — an unknown type must not throw away a real match.
- */
-export function advertisedBoardTypesBySerial(devices: ReadonlyArray<DiscoveredDevice>): Map<string, string> {
-  const advertisedTypes = new Map<string, string>();
-  for (const device of devices) {
-    const serial = parseSerialNumber(device.name);
-    if (!serial || advertisedTypes.has(serial)) continue;
-    const boardType = parseBoardTypeFromDeviceName(device.name);
-    if (boardType) advertisedTypes.set(serial, boardType);
-  }
-  return advertisedTypes;
-}
-
-/**
- * The single board type to scope the request to, or undefined when the scan is
- * mixed (or nothing advertised a type). A mixed scan can't be narrowed with one
- * argument, so it goes out unscoped and `matchesAdvertisedType` filters the
- * response per serial.
- */
-function sharedAdvertisedBoardType(advertisedTypes: ReadonlyMap<string, string>): string | undefined {
-  const distinctTypes = new Set(advertisedTypes.values());
-  return distinctTypes.size === 1 ? [...distinctTypes][0] : undefined;
-}
-
-/**
- * Whether a resolved entry describes hardware of the type this serial
- * advertised. Unknown on either side means "can't tell" — keep the entry, since
- * dropping it would lose a board the picker could otherwise name.
- */
-function matchesAdvertisedType(
-  serialNumber: string,
-  entry: ResolvedBoardEntry,
-  advertisedTypes: ReadonlyMap<string, string>,
-): boolean {
-  const advertisedType = advertisedTypes.get(serialNumber);
-  if (!advertisedType) return true;
-  const entryBoardType = entry.kind === 'saved' ? entry.board.boardType : entry.config.boardName;
-  if (!entryBoardType) return true;
-  return entryBoardType === advertisedType;
-}
-
 export async function resolveBleSerialNumbers(
   serialNumbers: string[],
   providedAuthToken?: string | null,
-  advertisedTypes: ReadonlyMap<string, string> = new Map(),
+  advertisedTypes: AdvertisedBoardTypes = new Map(),
 ): Promise<Map<string, ResolvedBoardEntry>> {
   const uniqueSerialNumbers = [
     ...new Set(serialNumbers.filter((serialNumber) => serialNumber.trim().length > 0)),
@@ -117,18 +74,16 @@ export async function resolveBleSerialNumbers(
   const resolvedBoards = new Map<string, ResolvedBoardEntry>();
   for (const board of savedResult.boardsBySerialNumbers) {
     if (!board.serialNumber) continue;
-    const entry: ResolvedBoardEntry = { kind: 'saved', board };
     // A board of another type shares nothing but the number with the controller
     // that just advertised. Letting it in is what made a Tension box at
     // Benchmark Climbing render — and behave — as a stranger's Kilter board.
-    if (!matchesAdvertisedType(board.serialNumber, entry, advertisedTypes)) continue;
-    resolvedBoards.set(board.serialNumber, entry);
+    if (!matchesAdvertisedType(board.serialNumber, board.boardType, advertisedTypes)) continue;
+    resolvedBoards.set(board.serialNumber, { kind: 'saved', board });
   }
   for (const config of recordedResult.myBoardSerialConfigs) {
     if (resolvedBoards.has(config.serialNumber)) continue;
-    const entry: ResolvedBoardEntry = { kind: 'recorded', config };
-    if (!matchesAdvertisedType(config.serialNumber, entry, advertisedTypes)) continue;
-    resolvedBoards.set(config.serialNumber, entry);
+    if (!matchesAdvertisedType(config.serialNumber, config.boardName, advertisedTypes)) continue;
+    resolvedBoards.set(config.serialNumber, { kind: 'recorded', config });
   }
   return resolvedBoards;
 }

--- a/packages/mobile/src/lib/ble/use-board-bluetooth.ts
+++ b/packages/mobile/src/lib/ble/use-board-bluetooth.ts
@@ -381,6 +381,16 @@ export type BleConnectionHandle = {
    * must use this for asynchronous connection work instead of rendered refs. */
   config: BleConnectionConfigSnapshot;
   /**
+   * The board type this controller advertised in its BLE device name
+   * (`Tension Board#12345@3`), captured at connect alongside the generation.
+   *
+   * Distinct from `config.boardName`, which is the route the climber is on.
+   * Aurora numbers each board app separately, so a serial identifies hardware
+   * only within a type — this is the field that keeps a serial lookup on the
+   * box actually connected. `undefined` when the name identifies no board type.
+   */
+  advertisedBoardType?: string;
+  /**
    * Attach the board-presence ID resolved for this exact connection. Returns
    * false when the generation/config is stale or a different ID already won.
    */
@@ -623,10 +633,12 @@ export function useBoardBluetooth({
       generation: number,
       configIdentity: string,
       config: BleConnectionConfigSnapshot,
+      advertisedBoardType: string | undefined,
     ): BleConnectionHandle => ({
       generation,
       configIdentity,
       config,
+      advertisedBoardType,
       setAnalyticsBoardId: (boardId: number): boolean => {
         const lifetime = activeConnectionLifetimeRef.current;
         if (
@@ -1279,6 +1291,7 @@ export function useBoardBluetooth({
           connectionGeneration,
           connectionIdentity,
           connectionConfig,
+          parseAnyBoardTypeFromDeviceName(connection.deviceName),
         );
 
         // Push board configuration into the native BoardBleManager so the
@@ -1708,6 +1721,7 @@ export function useBoardBluetooth({
         connectionGeneration,
         currentConnectionIdentity,
         currentConnectionConfig,
+        parseAnyBoardTypeFromDeviceName(deviceName),
       );
       void adapter
         .configureBoard({

--- a/packages/mobile/src/lib/ble/use-board-scan.ts
+++ b/packages/mobile/src/lib/ble/use-board-scan.ts
@@ -4,9 +4,16 @@
 // numbers — the picker then resolves serials to boards via
 // GET_BOARDS_BY_SERIAL_NUMBERS and sets the chosen one active. No connection is
 // opened here; connecting happens later when the user enters play mode.
+//
+// The board type each device advertises is collected alongside its serial.
+// Aurora reuses a serial across board apps, so without it this sheet would
+// happily offer a stranger's Kilter board for an in-range Tension controller
+// and let the user make it active — the Benchmark Climbing bug, one surface
+// over from the connect-time picker.
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { parseSerialNumber } from '@boardsesh/ble-protocol';
+import { advertisedBoardTypesBySerial, type AdvertisedBoardTypes } from './advertised-board-type';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../analytics';
 import { bleManager } from './ble-manager';
@@ -18,12 +25,18 @@ import { describeBlePermissionDenial } from './android-location-permission';
 
 const SCAN_TIMEOUT_MS = 15_000;
 
+// Stable empty identity so a reset doesn't hand consumers a fresh Map every
+// render (and churn the query key built from it).
+const EMPTY_ADVERTISED_TYPES: AdvertisedBoardTypes = new Map();
+
 export type BoardScanStatus = 'idle' | 'scanning' | 'done' | 'unavailable';
 
 export type BoardScan = {
   status: BoardScanStatus;
   /** Distinct serial numbers parsed from in-range device names. */
   serials: string[];
+  /** Board type advertised for each of those serials, where the name carried one. */
+  advertisedTypes: AdvertisedBoardTypes;
   start: () => Promise<void>;
   /** Stop any in-flight scan and return to idle (e.g. when the sheet closes). */
   reset: () => void;
@@ -32,6 +45,7 @@ export type BoardScan = {
 export function useBoardScan(): BoardScan {
   const [status, setStatus] = useState<BoardScanStatus>('idle');
   const [serials, setSerials] = useState<string[]>([]);
+  const [advertisedTypes, setAdvertisedTypes] = useState<AdvertisedBoardTypes>(EMPTY_ADVERTISED_TYPES);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scanningRef = useRef(false);
   const scanAttemptRef = useRef(0);
@@ -78,8 +92,9 @@ export function useBoardScan(): BoardScan {
       return;
     }
 
-    const found = new Set<string>();
+    const found = new Map<string, { deviceId: string; name?: string }>();
     setSerials([]);
+    setAdvertisedTypes(EMPTY_ADVERTISED_TYPES);
     setStatus('scanning');
     scanningRef.current = true;
 
@@ -108,8 +123,11 @@ export function useBoardScan(): BoardScan {
       }
       const serial = parseSerialNumber(deviceName);
       if (serial && !found.has(serial)) {
-        found.add(serial);
-        setSerials([...found]);
+        // Keep the whole name, not just the serial: the advertised board type
+        // lives in the same string and decides which board may claim it.
+        found.set(serial, { deviceId: device.id, name: deviceName });
+        setSerials([...found.keys()]);
+        setAdvertisedTypes(advertisedBoardTypesBySerial([...found.values()]));
       }
     });
 
@@ -124,6 +142,7 @@ export function useBoardScan(): BoardScan {
     scanAttemptRef.current += 1;
     stop();
     setSerials([]);
+    setAdvertisedTypes(EMPTY_ADVERTISED_TYPES);
     setStatus('idle');
   }, [stop]);
 
@@ -137,5 +156,5 @@ export function useBoardScan(): BoardScan {
     };
   }, [stop]);
 
-  return { status, serials, start, reset };
+  return { status, serials, advertisedTypes, start, reset };
 }

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -372,10 +372,17 @@ export function useBoardsBySerialNumbers(serialNumbers: string[], advertisedType
         serialNumbers,
         boardType,
       }),
-    select: (data) =>
-      data.boardsBySerialNumbers.filter((board) =>
-        board.serialNumber ? matchesAdvertisedType(board.serialNumber, board.boardType, advertisedTypes) : true,
-      ),
+    // Memoized on `advertisedTypes` so the dependency is explicit: `select`
+    // re-runs when its own reference changes, so an unmemoized closure would
+    // re-filter the cached response whenever a caller handed over a new Map with
+    // the same contents.
+    select: useCallback(
+      (data: GetBoardsBySerialNumbersQueryResponse) =>
+        data.boardsBySerialNumbers.filter((board) =>
+          board.serialNumber ? matchesAdvertisedType(board.serialNumber, board.boardType, advertisedTypes) : true,
+        ),
+      [advertisedTypes],
+    ),
     enabled: serialNumbers.length > 0,
   });
 }

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -85,6 +85,11 @@ import {
 } from '@boardsesh/graphql/operations/boards';
 import { getHttpClient } from '../client';
 import {
+  matchesAdvertisedType,
+  sharedAdvertisedBoardType,
+  type AdvertisedBoardTypes,
+} from '../../ble/advertised-board-type';
+import {
   GET_PROFILE,
   UPDATE_PROFILE,
   GET_MY_BOARDS,
@@ -336,12 +341,35 @@ export function fetchBoardsBySerialNumbers(serialNumbers: string[]): Promise<Use
     .then((data) => data.boardsBySerialNumbers);
 }
 
-export function useBoardsBySerialNumbers(serialNumbers: string[]) {
+/**
+ * Resolve scanned controller serials to boards, scoped to the board type each
+ * one advertised.
+ *
+ * Aurora numbers each board app separately, so a serial identifies a controller
+ * only within a type. Without `advertisedTypes` this returns whichever board
+ * carries the number — which is how an in-range Tension controller could be
+ * offered as a stranger's Kilter board, and made active.
+ *
+ * The `boardType` argument only narrows the request (and a mixed scan can't use
+ * it at all); the per-serial `matchesAdvertisedType` filter below is what
+ * actually enforces the rule.
+ */
+export function useBoardsBySerialNumbers(serialNumbers: string[], advertisedTypes: AdvertisedBoardTypes = new Map()) {
+  // Sorted entries, not the map, so the key hashes stably across renders while
+  // still changing when a late-arriving device name reveals a type.
+  const advertisedTypeEntries = [...advertisedTypes].sort(([first], [second]) => first.localeCompare(second));
+  const boardType = sharedAdvertisedBoardType(advertisedTypes);
   return useQuery({
-    queryKey: ['boardsBySerialNumbers', serialNumbers],
+    queryKey: ['boardsBySerialNumbers', serialNumbers, advertisedTypeEntries],
     queryFn: () =>
-      getHttpClient().request<GetBoardsBySerialNumbersQueryResponse>(GET_BOARDS_BY_SERIAL_NUMBERS, { serialNumbers }),
-    select: (data) => data.boardsBySerialNumbers,
+      getHttpClient().request<GetBoardsBySerialNumbersQueryResponse>(GET_BOARDS_BY_SERIAL_NUMBERS, {
+        serialNumbers,
+        boardType,
+      }),
+    select: (data) =>
+      data.boardsBySerialNumbers.filter((board) =>
+        board.serialNumber ? matchesAdvertisedType(board.serialNumber, board.boardType, advertisedTypes) : true,
+      ),
     enabled: serialNumbers.length > 0,
   });
 }

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -356,9 +356,15 @@ export function fetchBoardsBySerialNumbers(serialNumbers: string[]): Promise<Use
  */
 export function useBoardsBySerialNumbers(serialNumbers: string[], advertisedTypes: AdvertisedBoardTypes = new Map()) {
   // Sorted entries, not the map, so the key hashes stably across renders while
-  // still changing when a late-arriving device name reveals a type.
-  const advertisedTypeEntries = [...advertisedTypes].sort(([first], [second]) => first.localeCompare(second));
-  const boardType = sharedAdvertisedBoardType(advertisedTypes);
+  // still changing when a late-arriving device name reveals a type. Memoized to
+  // match useResolvedBleDeviceBoards: React Query's structural hashing already
+  // prevents a spurious refetch, so this is about not re-sorting on every render
+  // during a live scan (mobile performance checklist).
+  const advertisedTypeEntries = useMemo(
+    () => [...advertisedTypes].sort(([first], [second]) => first.localeCompare(second)),
+    [advertisedTypes],
+  );
+  const boardType = useMemo(() => sharedAdvertisedBoardType(advertisedTypes), [advertisedTypes]);
   return useQuery({
     queryKey: ['boardsBySerialNumbers', serialNumbers, advertisedTypeEntries],
     queryFn: () =>
@@ -1065,7 +1071,7 @@ export function useFavoriteStatus(
 // Beta Videos (Instagram + TikTok per climb)
 // ============================================
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   GET_BETA_LINKS,
   GET_RECENT_BETA_LINKS,

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -311,8 +311,8 @@ export type SearchBoardsQueryResponse = {
 };
 
 export const GET_BOARDS_BY_SERIAL_NUMBERS = gql`
-  query GetBoardsBySerialNumbers($serialNumbers: [String!]!) {
-    boardsBySerialNumbers(serialNumbers: $serialNumbers) {
+  query GetBoardsBySerialNumbers($serialNumbers: [String!]!, $boardType: String) {
+    boardsBySerialNumbers(serialNumbers: $serialNumbers, boardType: $boardType) {
       ${BOARD_FIELDS}
     }
   }
@@ -320,6 +320,10 @@ export const GET_BOARDS_BY_SERIAL_NUMBERS = gql`
 
 export type GetBoardsBySerialNumbersQueryVariables = {
   serialNumbers: string[];
+  // The board type advertised in the BLE device name. Sent only when every
+  // serial in the request advertises the same type; a mixed scan omits it and
+  // the caller filters per serial instead. See lib/ble/advertised-board-type.ts.
+  boardType?: string;
 };
 
 export type GetBoardsBySerialNumbersQueryResponse = {

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -797,6 +797,11 @@ export function BluetoothProvider({
       // older physical link.
       const { boardName: boardType, layoutId, sizeId, setIds: connectionSetIds } = connection.config;
       const setIds = connectionSetIds ?? '';
+      // The type the controller announced, from the same immutable snapshot as
+      // the config above. Aurora reuses a serial across board apps, so without
+      // it the resolver can bind this connection to a board of another type
+      // that happens to share the number.
+      const { advertisedBoardType } = connection;
 
       // Resolve+bind the shared board so the wall feed subscribes. Aurora uses
       // its controller serial; serial-less boards use the per-config fallback
@@ -809,7 +814,7 @@ export function BluetoothProvider({
         pendingPresenceResolveConnectionRef.current = connection;
         const resolvePromise =
           serial && serial.length > 0
-            ? resolveAndBindBoard({ serial, boardType, layoutId, sizeId, setIds })
+            ? resolveAndBindBoard({ serial, boardType, layoutId, sizeId, setIds, advertisedBoardType })
             : resolveAndBindBoardByConfig({ boardType, layoutId, sizeId, setIds });
         void resolvePromise
           .then((resolved) => {

--- a/packages/mobile/src/providers/board-presence-provider.tsx
+++ b/packages/mobile/src/providers/board-presence-provider.tsx
@@ -48,9 +48,17 @@ export type ResolveBoardArgs = {
   layoutId: number;
   sizeId: number;
   setIds: string;
+  /**
+   * The board type the connected controller advertised over BLE, from the
+   * connection snapshot. Distinct from `boardType`, which is the route the
+   * climber is on: Aurora numbers each board app separately, so this is what
+   * keeps the serial lookup on the hardware in front of them.
+   */
+  advertisedBoardType?: string;
 };
 
-export type ResolveBoardConfigArgs = Omit<ResolveBoardArgs, 'serial'>;
+// No serial means no advertisement to read a type from.
+export type ResolveBoardConfigArgs = Omit<ResolveBoardArgs, 'serial' | 'advertisedBoardType'>;
 
 export type ResolveBoardUuidArgs = {
   boardUuid: string;
@@ -97,7 +105,10 @@ function boardConfigResolveKey({ boardType, layoutId, sizeId, setIds }: ResolveB
 }
 
 function boardSerialResolveKey(args: ResolveBoardArgs): string {
-  return `serial:${args.serial}:${args.boardType}:${args.layoutId}:${args.sizeId}:${args.setIds}`;
+  // `advertisedBoardType` is part of the key because it changes which board the
+  // serial resolves to. Left out, a cached binding from a connect that reported
+  // no type would be reused for one that does.
+  return `serial:${args.serial}:${args.boardType}:${args.layoutId}:${args.sizeId}:${args.setIds}:${args.advertisedBoardType ?? ''}`;
 }
 
 function boardUuidResolveKey({ boardUuid }: ResolveBoardUuidArgs): string {

--- a/packages/shared/board-presence-react/src/create-board-presence-client.ts
+++ b/packages/shared/board-presence-react/src/create-board-presence-client.ts
@@ -62,6 +62,14 @@ export type SerialResolveArgs = {
   layoutId: number;
   sizeId: number;
   setIds: string;
+  /**
+   * The board type the connected controller advertises in its BLE device name
+   * (`Tension Board#12345@3`). Aurora numbers each board app separately, so the
+   * same serial exists on controllers of different types; this scopes the
+   * server's lookup to the hardware actually connected. Optional — `boardType`
+   * above is the route the climber is on, which is not the same fact.
+   */
+  advertisedBoardType?: string;
 };
 
 /** A GraphQL operation: the query/mutation/subscription string plus variables. */

--- a/packages/shared/graphql/src/operations/board-presence.ts
+++ b/packages/shared/graphql/src/operations/board-presence.ts
@@ -104,6 +104,7 @@ export const RESOLVE_BOARD_FOR_SERIAL = `
     $layoutId: Int!
     $sizeId: Int!
     $setIds: String!
+    $advertisedBoardType: String
   ) {
     resolveBoardForSerial(
       serial: $serial
@@ -111,6 +112,7 @@ export const RESOLVE_BOARD_FOR_SERIAL = `
       layoutId: $layoutId
       sizeId: $sizeId
       setIds: $setIds
+      advertisedBoardType: $advertisedBoardType
     ) {
       boardId
       boardName
@@ -133,6 +135,7 @@ export const RESOLVE_BOARD_CANDIDATES_FOR_SERIAL = `
     $layoutId: Int!
     $sizeId: Int!
     $setIds: String!
+    $advertisedBoardType: String
   ) {
     resolveBoardCandidatesForSerial(
       serial: $serial
@@ -140,6 +143,7 @@ export const RESOLVE_BOARD_CANDIDATES_FOR_SERIAL = `
       layoutId: $layoutId
       sizeId: $sizeId
       setIds: $setIds
+      advertisedBoardType: $advertisedBoardType
     ) {
       board {
         boardId

--- a/packages/shared/graphql/src/operations/boards.ts
+++ b/packages/shared/graphql/src/operations/boards.ts
@@ -151,8 +151,8 @@ export const GET_POPULAR_BOARD_CONFIGS = gql`
 `;
 
 export const GET_BOARDS_BY_SERIAL_NUMBERS = gql`
-  query GetBoardsBySerialNumbers($serialNumbers: [String!]!) {
-    boardsBySerialNumbers(serialNumbers: $serialNumbers) {
+  query GetBoardsBySerialNumbers($serialNumbers: [String!]!, $boardType: String) {
+    boardsBySerialNumbers(serialNumbers: $serialNumbers, boardType: $boardType) {
       ${BOARD_FIELDS}
     }
   }
@@ -326,6 +326,10 @@ export type GetPopularBoardConfigsQueryResponse = {
 
 export type GetBoardsBySerialNumbersQueryVariables = {
   serialNumbers: string[];
+  // The board type advertised in the BLE device name. Sent only when every
+  // serial in the request advertises the same type; a mixed scan omits it and
+  // the caller filters per serial instead.
+  boardType?: string;
 };
 
 export type GetBoardsBySerialNumbersQueryResponse = {


### PR DESCRIPTION
## Summary

Client half of the Benchmark Climbing report: connecting to the gym's Tension board announced it as a Kilter board, on every attempt. Backend half is #4864, now merged.

**Aurora numbers each board app separately**, so a serial identifies a controller only *within* a board type — a Kilter `#12345` and a Tension `#12345` are different hardware. The BLE advertisement has always carried the type (`Tension Board#12345@3`); nothing on the resolution path read it.

### What the prod data actually shows

Worth stating plainly, because the first version of this description guessed wrong. The failure is **not** two boards fighting over a shared serial — only one serial in prod (`752041`) is carried by boards of two different types, and it isn't Benchmark's.

The real mechanism is a **sticky remembered pointer**:

- **459 of 476** gym Tension boards carry no serial at all (17 do). So a Tension connect resolves nothing.
- Resolution then falls through to bind-or-create, which builds from the **route** config — minting or binding a *Kilter* board when the climber is on a Kilter route.
- That choice is remembered in `user_board_serials`, and `findChosenBoardForSerial` short-circuits everything else — so every later connect returns the Kilter board. Hence "every time".

Exactly one such row exists today: serial `751766`, reported type `tension`, pointing at board 1115 *"Vital Brooklyn - Kilter Board Homewall"*. #4864's type check rejects that pointer and re-resolves, and its zero-candidate guard stops the cross-type mint that writes rows like it. This PR stops the client feeding the wrong board in.

### The enforcement point

`lib/ble/advertised-board-type.ts` now owns the rule, and both surfaces that turn scan results into boards read it:

- **Connect-time picker** — `resolveBleSerialNumbers` drops any resolved board or recorded config whose type contradicts the advertisement. Filtering there rather than at each consumer means the picker, `DeviceCard`, `effectiveBoardType` and the config-mismatch alert all read a map that can no longer hold a foreign board.
- **Bluetooth quickstart sheet** — found by the Fable review, and the reason the rule got hoisted into its own module. That sheet resolves serials through a *second, mobile-local copy* of `GET_BOARDS_BY_SERIAL_NUMBERS` and never touches `resolve-serials.ts`, while `use-board-scan` discarded device names entirely. So the same bug survived on the surface that makes a board active. `useBoardScan` now keeps each name and exposes `advertisedTypes`; `useBoardsBySerialNumbers` scopes and filters with them.

Deliberately permissive in one direction: a serial whose name carries no recognisable type is left unfiltered. An unknown type is not evidence of a mismatch, and dropping the match would lose a board the picker could otherwise name.

### Everything else

- The query is scoped server-side when the whole scan advertises one type. A mixed scan can't be narrowed by one argument, so it goes out wide and the per-serial filter does the work — which is also why an older backend that ignores the argument stays correct.
- The advertised type is part of the React Query key. A scan result can arrive without a name and get one moments later; without this the first type-less result stays cached and the board stays mis-identified for the rest of the scan. Regression test covers it.
- Board presence carries it too: captured on `BleConnectionHandle` beside the generation (immutable, same rule as the config snapshot), threaded into `resolveBoardCandidatesForSerial`, and folded into `boardSerialResolveKey` so a cached binding can't outlive the fact that produced it.
- `effectiveBoardType` still lets a resolved board's type win, which is safe now the two can't disagree. The comment records the invariant and says to flip it if the filter is ever relaxed.

### Fable review

Required by CLAUDE.md for `packages/mobile/src/lib/ble/`. Verdict was changes-requested on the quickstart gap above — fixed in 50a2321. Its other checks came back clean: MoonBoard/Woods can't be dropped by the Aurora-only parser (their names carry no `#`, so they never enter serial resolution), both `createConnectionHandle` sites capture from the correct per-generation locals, query-key churn is safe under TanStack's structural hashing, and reconnect/auto-disconnect are untouched.

## Release Notes

- The board picker names the board you are actually connecting to, instead of someone else's board that happens to share a serial number

## Test plan

1. Open the app near your board, tap Connect.
2. Picker lists your board with the right name.
3. Tap it — no "different board" warning appears.
4. Light a climb; it shows on your board's feed.

## Risk

Risk: 4/5 — BLE device resolution and the presence binding that routes ticks and wall history.

JS-only, so the Expo fingerprint is unchanged and this rides OTA on `main`. `vp run typecheck:mobile` clean; `vp run test:mobile` 6981 passed (704 files); `vp run check:mobile-bundle` OK; `vp check` 0 errors.

Device QA is owed — the failure needs a real controller on a gym board whose serial doesn't resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbsEp4fAbm7mrUiXEbSwPC
