### PR TITLE
fix(ci): add static-assets to the dockerWeb paths filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,7 @@ jobs:
               - 'packages/shared/queue/**'
               - 'packages/shared/queue-react/**'
               - 'packages/shared/queue-runtime/**'
+              - 'packages/shared/static-assets/**'
               - 'packages/shared/velvet-tokens/**'
               - 'packages/shared/watch-pairing/**'
               - 'packages/sync-runtime/**'


### PR DESCRIPTION
## Summary

This PR fixes a CI test that's been failing on every push to `main` and every PR based on it. `packages/shared/static-assets/**` was included in the static-assets job's own path filter but missing from the `dockerWeb` filter, so the test verifying that every workspace package feeding the web Docker image is covered kept failing. The fix adds that one missing path, in alphabetical order, to `dockerWeb` in `ci.yml`.

---

## What

Adds `packages/shared/static-assets/**` to the `dockerWeb` paths filter in `ci.yml`. The package is listed in the static-assets job's own filter (line ~372) but was never added to `dockerWeb`, so `scripts/__tests__/ci-docker-web-workflow.test.ts` ("covers every workspace package the web image is built from") fails a `test-default` shard on every push to `main` right now (e.g. run 33288140069) and on every PR based on it.

One line, alphabetical position between `queue-runtime` and `velvet-tokens`.

## Test plan

1. CI green.
2. `vp test run scripts/__tests__/ci-docker-web-workflow.test.ts` — 12/12 pass (was 1 failing).

## Risk

Risk: 1/5 — CI paths filter only; adds a trigger path, removes nothing.

## Release Notes

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3jRkK5KxMfH6PUmhGFNwE