### PR TITLE
fix(mobile): only say "Live" when a wall is driven, and stop the play header jumping

### DIFF
--- a/packages/mobile/src/components/DrawerHeader.tsx
+++ b/packages/mobile/src/components/DrawerHeader.tsx
@@ -21,6 +21,14 @@ type DrawerHeaderProps = {
    *  stays centered regardless of the trailing element's width. */
   trailing?: ReactNode;
   trailingMinWidth?: number;
+  /**
+   * Floor for the flanked row's height. Pass it when the leading slot can come
+   * and go (the play drawer's wall-state pill) so the header keeps ONE height
+   * whether the slot is filled or empty: without it the row is as tall as its
+   * tallest child, so a 44pt pill beside a ~40pt centre column grows the whole
+   * header — and, in a fixed-height parent, shrinks whatever sits below it.
+   */
+  minRowHeight?: number;
 };
 
 /**
@@ -36,6 +44,7 @@ export const DrawerHeader = memo(function DrawerHeader({
   leading,
   trailing,
   trailingMinWidth = DEFAULT_TRAILING_MIN_WIDTH,
+  minRowHeight,
 }: DrawerHeaderProps) {
   const [trailingWidth, setTrailingWidth] = useState(trailingMinWidth);
   const [leadingWidth, setLeadingWidth] = useState(0);
@@ -60,7 +69,7 @@ export const DrawerHeader = memo(function DrawerHeader({
 
   return (
     <View style={styles.container}>
-      <View style={styles.headerRow}>
+      <View style={[styles.headerRow, minRowHeight != null && { minHeight: minRowHeight }]}>
         {hasLeading ? (
           <View style={[styles.side, { width: sideWidth }]}>
             <View style={styles.sideMeasure} onLayout={handleLeadingLayout}>

--- a/packages/mobile/src/components/__tests__/drawer-header.test.tsx
+++ b/packages/mobile/src/components/__tests__/drawer-header.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+// The play drawer swipes TWO of these past each other: the current climb's
+// header (which may carry the wall-state pill in its leading slot) and the peek
+// header sliding in behind it. If the two disagree about their geometry, the
+// climb name and its attribute glyphs step as they cross — which is exactly what
+// `minRowHeight` and the peek's reserved leading slot exist to prevent. So the
+// assertions here are about the row keeping ONE height and ONE flank model,
+// whichever branch it takes.
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+type ViewMockProps = { children?: ReactNode; style?: unknown; onLayout?: unknown };
+const styleAttr = (style: unknown) => JSON.stringify(style ?? null);
+
+vi.mock('react-native', () => ({
+  View: ({ children, style }: ViewMockProps) => createElement('div', { 'data-style': styleAttr(style) }, children),
+  StyleSheet: { create: (sheet: Record<string, unknown>) => sheet },
+}));
+vi.mock('../../theme/tokens', () => ({ spacing: { 3: 12, 4: 16, 12: 48 } }));
+
+import { DrawerHeader } from '../DrawerHeader';
+
+const ROW_HEIGHT = 44;
+
+/** Flattened styles of every view, innermost detail included. */
+const styles = (container: HTMLElement) =>
+  [...container.querySelectorAll('div[data-style]')].map((node) => node.getAttribute('data-style') ?? '');
+
+const renderHeader = (leading?: ReactNode) =>
+  render(
+    createElement(DrawerHeader, {
+      center: createElement('span', null, 'Climb name'),
+      trailing: createElement('span', null, 'V5'),
+      leading,
+      minRowHeight: ROW_HEIGHT,
+    }),
+  );
+
+/** The row is the one view carrying both the row direction and the height floor. */
+const rowStyle = (container: HTMLElement) =>
+  styles(container).find((style) => style.includes('"flexDirection":"row"')) ?? '';
+
+describe('DrawerHeader', () => {
+  it('holds the same row height with and without a leading element', () => {
+    const withPill = renderHeader(createElement('span', null, 'Live'));
+    const withoutPill = renderHeader();
+
+    expect(rowStyle(withPill.container)).toContain(`"minHeight":${ROW_HEIGHT}`);
+    expect(rowStyle(withoutPill.container)).toContain(`"minHeight":${ROW_HEIGHT}`);
+  });
+
+  // Without the floor the row is only as tall as its tallest child, so a 44pt
+  // pill beside a ~40pt centre column grew the whole header — and, inside the
+  // drawer's fixed-height first screen, shrank the board art below it.
+  it('leaves the row unconstrained when no floor is asked for', () => {
+    const { container } = render(
+      createElement(DrawerHeader, {
+        center: createElement('span', null, 'Climb name'),
+        trailing: createElement('span', null, 'V5'),
+      }),
+    );
+
+    expect(rowStyle(container)).not.toContain('minHeight');
+  });
+
+  it('mirrors the flanks so the centred name cannot drift toward the grade', () => {
+    const { container } = renderHeader(createElement('span', null, 'Live'));
+    // Both flanks are rendered at the same measured width (the trailing floor
+    // until onLayout reports, which jsdom never does).
+    const flanks = styles(container).filter((style) => style.includes('"width":48'));
+
+    expect(flanks).toHaveLength(2);
+  });
+});

--- a/packages/mobile/src/components/__tests__/drawer-header.test.tsx
+++ b/packages/mobile/src/components/__tests__/drawer-header.test.tsx
@@ -7,14 +7,25 @@
 // assertions here are about the row keeping ONE height and ONE flank model,
 // whichever branch it takes.
 import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
-type ViewMockProps = { children?: ReactNode; style?: unknown; onLayout?: unknown };
+type LayoutEvent = { nativeEvent: { layout: { width: number } } };
+type ViewMockProps = { children?: ReactNode; style?: unknown; onLayout?: (event: LayoutEvent) => void };
 const styleAttr = (style: unknown) => JSON.stringify(style ?? null);
 
+// jsdom never lays anything out, so the measured flanks would sit at 0 forever
+// and every assertion would really be reading the trailing floor. Capture the
+// handlers instead and feed them widths by hand — that is the only way to reach
+// the re-balancing this chassis exists for. Filled in render order, so [0] is
+// the leading measure view and [1] the trailing one.
+const layoutHandlers: Array<(event: LayoutEvent) => void> = [];
+
 vi.mock('react-native', () => ({
-  View: ({ children, style }: ViewMockProps) => createElement('div', { 'data-style': styleAttr(style) }, children),
+  View: ({ children, style, onLayout }: ViewMockProps) => {
+    if (onLayout) layoutHandlers.push(onLayout);
+    return createElement('div', { 'data-style': styleAttr(style) }, children);
+  },
   StyleSheet: { create: (sheet: Record<string, unknown>) => sheet },
 }));
 vi.mock('../../theme/tokens', () => ({ spacing: { 3: 12, 4: 16, 12: 48 } }));
@@ -27,8 +38,10 @@ const ROW_HEIGHT = 44;
 const styles = (container: HTMLElement) =>
   [...container.querySelectorAll('div[data-style]')].map((node) => node.getAttribute('data-style') ?? '');
 
-const renderHeader = (leading?: ReactNode) =>
-  render(
+/** Clears the handler list first, so `layoutHandlers` always belongs to THIS render. */
+const renderHeader = (leading?: ReactNode) => {
+  layoutHandlers.length = 0;
+  return render(
     createElement(DrawerHeader, {
       center: createElement('span', null, 'Climb name'),
       trailing: createElement('span', null, 'V5'),
@@ -36,6 +49,15 @@ const renderHeader = (leading?: ReactNode) =>
       minRowHeight: ROW_HEIGHT,
     }),
   );
+};
+
+/** Report a measured width for the leading flank, the way a real layout pass would. */
+const measureLeading = (width: number) => {
+  // Fail loudly rather than silently measuring the wrong slot if the chassis
+  // ever renders its flanks in the other order.
+  expect(layoutHandlers).toHaveLength(2);
+  act(() => layoutHandlers[0]({ nativeEvent: { layout: { width } } }));
+};
 
 /** The row is the one view carrying both the row direction and the height floor. */
 const rowStyle = (container: HTMLElement) =>
@@ -64,12 +86,31 @@ describe('DrawerHeader', () => {
     expect(rowStyle(container)).not.toContain('minHeight');
   });
 
-  it('mirrors the flanks so the centred name cannot drift toward the grade', () => {
+  // The contract this chassis exists for: both flanks take the WIDER of the two
+  // so the centred name cannot drift toward the narrower (grade) side. Driving a
+  // real measurement is the only way to reach it — asserting the un-measured
+  // state would just be reading the trailing floor back.
+  it('widens both flanks to a leading element wider than the floor', () => {
     const { container } = renderHeader(createElement('span', null, 'Live'));
-    // Both flanks are rendered at the same measured width (the trailing floor
-    // until onLayout reports, which jsdom never does).
-    const flanks = styles(container).filter((style) => style.includes('"width":48'));
+    measureLeading(62);
 
-    expect(flanks).toHaveLength(2);
+    expect(styles(container).filter((style) => style.includes('"width":62'))).toHaveLength(2);
+  });
+
+  it('keeps the floor when the leading element is narrower than it', () => {
+    const { container } = renderHeader(createElement('span', null, 'Live'));
+    measureLeading(20);
+
+    expect(styles(container).filter((style) => style.includes('"width":48'))).toHaveLength(2);
+  });
+
+  // Rounded up, never down. A flank that landed on a fraction would let the swipe
+  // peek and the current header disagree by a subpixel — the exact drift the
+  // reserved slot is there to prevent.
+  it('rounds a fractional measurement up', () => {
+    const { container } = renderHeader(createElement('span', null, 'Live'));
+    measureLeading(61.4);
+
+    expect(styles(container).filter((style) => style.includes('"width":62'))).toHaveLength(2);
   });
 });

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -510,7 +510,6 @@ export function PlayDrawer({
   // confirm. Nothing here changes WHEN a drawer state happens — the whole block
   // restates the states the drawer already had in chrome that names them.
   const wallClimbUuid = isPreview && drawerPreviewIsWallClimb ? (displayedClimbUuid ?? null) : null;
-  const inSharedSession = sessionId != null;
   // Being in a preview is NOT enough to claim browsing. With `lightOnSwipe` on
   // and no suggestion source (the explicit "Preview" climb action, a deep link,
   // the workout builder) the next swipe falls straight through to
@@ -537,8 +536,10 @@ export function PlayDrawer({
     // `lightOnSwipe` off is precisely "the next swipe does NOT drive the wall"
     // (it's what `getSwipeNavigationTarget` turns into `forceViewOnly`).
     navigationCommits: lightOnSwipe,
-    inSharedSession,
-    bleConnected: bluetoothConnected,
+    // The lightbulb's own signal: this device's BLE link, or a session member's.
+    // Merely being IN a session is not enough — the Start button opens one solo,
+    // and a solo session with nothing connected moves no wall.
+    wallDriven: lightbulbActive,
   });
   const commitBarModel = resolveCommitBarModel({
     // Wider than the latch on purpose: a `lightOnSwipe`-on preview with no
@@ -552,8 +553,7 @@ export function PlayDrawer({
     wallClimbUuid,
     // The busy-wall confirm needs the wall-uuid-at-latch-start snapshot — PR A2.
     confirmArmed: false,
-    inSharedSession,
-    bleConnected: bluetoothConnected,
+    wallDriven: lightbulbActive,
   });
   // The latch as the board overlay sees it. It follows the latch itself, NOT the
   // commit row: on the wrong board the row stands down (its controls would be
@@ -1136,6 +1136,14 @@ export function PlayDrawer({
                                 boardName={boardName as BoardName}
                                 layoutId={layoutId}
                                 angle={angle}
+                                // The incoming header reserves the same flank the
+                                // current one spends on the pill, so the name and
+                                // its attribute glyphs slide across at a fixed
+                                // position instead of stepping mid-swipe. Invisible
+                                // and a11y-hidden: it holds space, it claims nothing.
+                                leading={
+                                  wallPillState ? <WallStatePill state={wallPillState} reserveOnly /> : undefined
+                                }
                               />
                             ) : null
                           }

--- a/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
@@ -10,6 +10,7 @@ import { MarqueeText } from '../MarqueeText';
 import { DrawerHeader } from '../DrawerHeader';
 import { ClimbAttributeIcons } from '../ClimbAttributeIcons';
 import { iosSystemColors } from '../../theme/ios-colors';
+import { WALL_STATE_PILL_TOUCH_HEIGHT } from '../../theme/layout';
 import { useDisplayGrade } from '../../hooks/use-display-grade';
 
 type PlayDrawerHeaderProps = {
@@ -32,7 +33,8 @@ type PlayDrawerHeaderProps = {
   /** Climb characteristics; no-match and MoonBoard method_* tokens render as glyphs/labels. */
   characteristics?: string[] | null;
   /** Left-aligned element on the name's row (e.g. the on-wall status). The header
-   *  balances both flanks so the name stays centered. */
+   *  balances both flanks so the name stays centered. The swipe peek passes a
+   *  reserve-only copy so the incoming header matches this one exactly. */
   leading?: ReactNode;
   /** Long-press handler on the name (copies it to the clipboard). When omitted the
    *  name is a plain, non-interactive label — used for the swipe "peek" header. */
@@ -67,6 +69,12 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
   return (
     <DrawerHeader
       leading={leading}
+      // Reserve the wall-state pill's 44pt touch box unconditionally. The pill
+      // comes and goes with the wall (and the swipe peek carries only an
+      // invisible copy), so without a floor the header would breathe 64↔68pt on
+      // every change — visibly stepping the name and its attribute glyphs, and
+      // resizing the board art below inside the fixed-height first screen.
+      minRowHeight={WALL_STATE_PILL_TOUCH_HEIGHT}
       center={
         <>
           <View style={styles.nameRow}>

--- a/packages/mobile/src/components/play-drawer/WallStatePill.tsx
+++ b/packages/mobile/src/components/play-drawer/WallStatePill.tsx
@@ -27,7 +27,7 @@ import { spacing, borderRadius, androidRipple } from '../../theme/tokens';
 import { withAlpha } from '../../theme/colors';
 import { selectByVariant } from '../../theme/variants/select-by-variant';
 import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
-import { glassSize, WALL_LIVE_DOT_SIZE } from '../../theme/layout';
+import { glassSize, WALL_LIVE_DOT_SIZE, WALL_STATE_PILL_TOUCH_HEIGHT } from '../../theme/layout';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { BoardDriverAvatar } from '../board-presence/BoardDriverAvatar';
@@ -38,15 +38,6 @@ import type { WallPillState } from './wall-state';
 export type WallStatePillState = Exclude<WallPillState, null>;
 
 const PILL_HEIGHT = glassSize.mini;
-/**
- * The pressable is the 44pt floor; the capsule inside stays 32pt. `hitSlop` can't
- * do this job here — the touch area never extends past the parent's bounds, and
- * every ancestor of this pill (the header's measured leading flank) sizes to its
- * content, so slop on a 32pt chip is inert on both platforms. Costs the header at
- * most 4pt against its ~40pt centre column, only in the states where a banner
- * used to cost 32pt or more.
- */
-const PILL_TOUCH_HEIGHT = glassSize.inline;
 /** 24pt reads as a face at the pill's 32pt height with 4pt of breathing room. */
 const AVATAR_SIZE = 24;
 const BROWSING_GLYPH_SIZE = 14;
@@ -54,10 +45,22 @@ const BROWSING_GLYPH_SIZE = 14;
 type WallStatePillProps = {
   state: WallStatePillState;
   /** Opens the explainer callout. The pill itself changes nothing. */
-  onPress: () => void;
+  onPress?: () => void;
+  /**
+   * Render the pill purely to hold its space: invisible, untappable, and hidden
+   * from assistive tech. The swipe peek header uses this so it measures the same
+   * flank width as the header it slides in behind — the climb name and its
+   * attribute glyphs then hold their exact position through a swipe instead of
+   * stepping when the two headers disagree about whether a pill exists.
+   *
+   * It renders the REAL pill rather than a fixed-width spacer because the width
+   * is the translated label's ("Live" / "En vivo" / "En direct" all differ) and
+   * an avatar chip is narrower again — only the real thing measures right.
+   */
+  reserveOnly?: boolean;
 };
 
-function WallStatePillImpl({ state, onPress }: WallStatePillProps) {
+function WallStatePillImpl({ state, onPress, reserveOnly = false }: WallStatePillProps) {
   const { t } = useTranslation('session');
   const { variant, systemColors, brandColors, m3, m3SurfaceContainers } = useTheme();
   const reduceMotion = useReducedMotion();
@@ -117,21 +120,28 @@ function WallStatePillImpl({ state, onPress }: WallStatePillProps) {
 
   return (
     <Pressable
-      onPress={onPress}
-      accessibilityRole="button"
-      accessibilityLabel={accessibilityLabel}
-      accessibilityHint={accessibilityHint}
-      android_ripple={androidRipple(rippleColor, true)}
+      onPress={reserveOnly ? undefined : onPress}
+      accessibilityRole={reserveOnly ? undefined : 'button'}
+      accessibilityLabel={reserveOnly ? undefined : accessibilityLabel}
+      accessibilityHint={reserveOnly ? undefined : accessibilityHint}
+      accessibilityElementsHidden={reserveOnly}
+      importantForAccessibility={reserveOnly ? 'no-hide-descendants' : 'auto'}
+      pointerEvents={reserveOnly ? 'none' : 'auto'}
+      android_ripple={reserveOnly ? undefined : androidRipple(rippleColor, true)}
       // Material answers a press with the ripple above; Liquid Glass has no state
       // layer, so it takes the drawer action bar's opacity + scale idiom.
-      style={({ pressed }) => [styles.touchTarget, pressed && !isMaterial && styles.touchTargetPressed]}
+      style={({ pressed }) => [
+        styles.touchTarget,
+        reserveOnly && styles.touchTargetReserved,
+        pressed && !reserveOnly && !isMaterial && styles.touchTargetPressed,
+      ]}
     >
       <Animated.View
         // Keyed so a state change re-enters rather than cross-mutating styles.
         // Removal is an instant cut: the host unmounts the slot in the same commit,
         // which Reanimated can't reliably intercept with an `exiting`.
         key={state}
-        entering={reduceMotion ? undefined : FadeIn.duration(180)}
+        entering={reduceMotion || reserveOnly ? undefined : FadeIn.duration(180)}
         style={[styles.pill, state === 'onWall' ? styles.pillAvatar : styles.pillLabelled, containerStyle]}
       >
         {state === 'onWall' ? (
@@ -186,9 +196,14 @@ function WallStatePillImpl({ state, onPress }: WallStatePillProps) {
 export const WallStatePill = memo(WallStatePillImpl);
 
 const styles = StyleSheet.create({
+  // The pressable carries the 44pt touch floor — the same value DrawerHeader
+  // reserves for the slot — while the capsule inside stays 32pt. `hitSlop` can't
+  // do this job here: the touch area never extends past the parent's bounds, and
+  // every ancestor of this pill (the header's measured leading flank) sizes to
+  // its content, so slop on a 32pt chip is inert on both platforms.
   touchTarget: {
     flexShrink: 1,
-    height: PILL_TOUCH_HEIGHT,
+    height: WALL_STATE_PILL_TOUCH_HEIGHT,
     justifyContent: 'center',
     // The capsule hugs its content; without this it would stretch to whatever
     // width the header's flank hands the (taller) touch box.
@@ -197,6 +212,10 @@ const styles = StyleSheet.create({
   touchTargetPressed: {
     opacity: 0.6,
     transform: [{ scale: 0.92 }],
+  },
+  // Holds the slot's width and height without painting anything.
+  touchTargetReserved: {
+    opacity: 0,
   },
   pill: {
     flexShrink: 1,

--- a/packages/mobile/src/components/play-drawer/WallStatePill.tsx
+++ b/packages/mobile/src/components/play-drawer/WallStatePill.tsx
@@ -42,23 +42,26 @@ const PILL_HEIGHT = glassSize.mini;
 const AVATAR_SIZE = 24;
 const BROWSING_GLYPH_SIZE = 14;
 
-type WallStatePillProps = {
-  state: WallStatePillState;
-  /** Opens the explainer callout. The pill itself changes nothing. */
-  onPress?: () => void;
-  /**
-   * Render the pill purely to hold its space: invisible, untappable, and hidden
-   * from assistive tech. The swipe peek header uses this so it measures the same
-   * flank width as the header it slides in behind — the climb name and its
-   * attribute glyphs then hold their exact position through a swipe instead of
-   * stepping when the two headers disagree about whether a pill exists.
-   *
-   * It renders the REAL pill rather than a fixed-width spacer because the width
-   * is the translated label's ("Live" / "En vivo" / "En direct" all differ) and
-   * an avatar chip is narrower again — only the real thing measures right.
-   */
-  reserveOnly?: boolean;
-};
+/**
+ * Two shapes that never mix, so the wrong pill can't be built.
+ *
+ * The INDICATOR the climber taps to open the explainer, which must carry an
+ * `onPress` — without one it renders a dead 44pt target that looks tappable.
+ *
+ * Or a RESERVE-ONLY copy: invisible, untappable, hidden from assistive tech,
+ * there purely to hold the slot's space. The swipe peek header uses it so its
+ * header measures the same flank width as the one it slides in behind — the
+ * climb name and its attribute glyphs then hold their exact position through a
+ * swipe instead of stepping when the two headers disagree about whether a pill
+ * exists. It renders the REAL pill rather than a fixed-width spacer because the
+ * width is the translated label's ("Live" / "En vivo" / "En direct" all differ)
+ * and an avatar chip is narrower again — only the real thing measures right.
+ * An `onPress` on this shape would promise a tap nothing answers, so the union
+ * forbids it.
+ */
+type WallStatePillProps =
+  | { state: WallStatePillState; onPress: () => void; reserveOnly?: false }
+  | { state: WallStatePillState; onPress?: never; reserveOnly: true };
 
 function WallStatePillImpl({ state, onPress, reserveOnly = false }: WallStatePillProps) {
   const { t } = useTranslation('session');
@@ -126,7 +129,6 @@ function WallStatePillImpl({ state, onPress, reserveOnly = false }: WallStatePil
       accessibilityHint={reserveOnly ? undefined : accessibilityHint}
       accessibilityElementsHidden={reserveOnly}
       importantForAccessibility={reserveOnly ? 'no-hide-descendants' : 'auto'}
-      pointerEvents={reserveOnly ? 'none' : 'auto'}
       android_ripple={reserveOnly ? undefined : androidRipple(rippleColor, true)}
       // Material answers a press with the ripple above; Liquid Glass has no state
       // layer, so it takes the drawer action bar's opacity + scale idiom.
@@ -213,9 +215,13 @@ const styles = StyleSheet.create({
     opacity: 0.6,
     transform: [{ scale: 0.92 }],
   },
-  // Holds the slot's width and height without painting anything.
+  // Holds the slot's width and height without painting anything and without
+  // answering a touch — one style is the whole of "inert". `pointerEvents` rides
+  // the style rather than the Pressable prop, which React Native deprecated in
+  // 0.64.
   touchTargetReserved: {
     opacity: 0,
+    pointerEvents: 'none',
   },
   pill: {
     flexShrink: 1,

--- a/packages/mobile/src/components/play-drawer/__tests__/wall-state-pill.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/wall-state-pill.test.tsx
@@ -13,8 +13,11 @@ type ViewMockProps = { children?: ReactNode; style?: unknown };
 type PressMockProps = {
   children?: ReactNode;
   onPress?: () => void;
+  accessibilityRole?: string;
   accessibilityLabel?: string;
   accessibilityHint?: string;
+  accessibilityElementsHidden?: boolean;
+  pointerEvents?: string;
   android_ripple?: { color: string; borderless: boolean };
   style?: unknown | ((state: { pressed: boolean }) => unknown);
 };
@@ -22,13 +25,26 @@ const styleAttr = (style: unknown) => JSON.stringify(style ?? null);
 
 vi.mock('react-native', () => ({
   View: ({ children, style }: ViewMockProps) => createElement('div', { 'data-style': styleAttr(style) }, children),
-  Pressable: ({ children, onPress, accessibilityLabel, accessibilityHint, android_ripple, style }: PressMockProps) =>
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityRole,
+    accessibilityLabel,
+    accessibilityHint,
+    accessibilityElementsHidden,
+    pointerEvents,
+    android_ripple,
+    style,
+  }: PressMockProps) =>
     createElement(
       'button',
       {
         onClick: onPress,
+        'data-role': accessibilityRole ?? '',
         'data-label': accessibilityLabel,
         'data-hint': accessibilityHint,
+        'data-a11y-hidden': accessibilityElementsHidden ? 'true' : '',
+        'data-pointer-events': pointerEvents ?? '',
         'data-ripple': android_ripple ? JSON.stringify(android_ripple) : '',
         'data-style': styleAttr(typeof style === 'function' ? style({ pressed: false }) : style),
         'data-style-pressed': styleAttr(typeof style === 'function' ? style({ pressed: true }) : style),
@@ -98,12 +114,22 @@ vi.mock('../../../theme/tokens', () => ({
   androidRipple: (color: string, borderless: boolean) => ({ color, borderless }),
 }));
 vi.mock('../../../theme/typography', () => ({ CHROME_LABEL_MAX_FONT_SCALE: 1.2 }));
-vi.mock('../../../theme/layout', () => ({ glassSize: { mini: 32, inline: 44 }, WALL_LIVE_DOT_SIZE: 10 }));
+vi.mock('../../../theme/layout', () => ({
+  glassSize: { mini: 32, inline: 44 },
+  WALL_LIVE_DOT_SIZE: 10,
+  WALL_STATE_PILL_TOUCH_HEIGHT: 44,
+}));
 
 import { WallStatePill } from '../WallStatePill';
 
-const renderPill = (props: Partial<{ state: 'onWall' | 'live' | 'browsing' }> = {}) =>
-  render(createElement(WallStatePill, { state: props.state ?? 'browsing', onPress: vi.fn() }));
+const renderPill = (props: Partial<{ state: 'onWall' | 'live' | 'browsing'; reserveOnly: boolean }> = {}) =>
+  render(
+    createElement(WallStatePill, {
+      state: props.state ?? 'browsing',
+      onPress: vi.fn(),
+      reserveOnly: props.reserveOnly,
+    }),
+  );
 
 const pill = (container: HTMLElement) => container.querySelector('button') as HTMLElement;
 /** Serialised styles of every view, for the handful of assertions about colour/size. */
@@ -203,5 +229,38 @@ describe('WallStatePill', () => {
     expect(button.getAttribute('data-ripple')).toContain('#16111F');
     expect(button.getAttribute('data-style-pressed')).toContain('"opacity":0.6');
     expect(button.getAttribute('data-style')).not.toContain('"opacity":0.6');
+  });
+
+  // The swipe peek renders this copy so its header measures the same leading
+  // flank as the header sliding out behind it — that parity is what stops the
+  // climb name and its attribute glyphs stepping mid-swipe. It must hold the
+  // space and nothing else: no tap, no words, nothing for a screen reader.
+  describe('reserveOnly', () => {
+    it("keeps the real pill's footprint so the reserved flank measures true", () => {
+      const visible = renderPill({ state: 'live' });
+      const reserved = renderPill({ state: 'live', reserveOnly: true });
+
+      // Same tree, same intrinsic size — a fixed-width spacer could not track a
+      // translated label ('Live' / 'En vivo' / 'En direct' all differ).
+      expect(reserved.container.textContent).toBe(visible.container.textContent);
+      expect(pill(reserved.container).getAttribute('data-style')).toContain('"height":44');
+      expect(pill(reserved.container).getAttribute('data-style')).toContain('"opacity":0');
+    });
+
+    it('claims nothing: untappable, unlabelled, hidden from assistive tech', () => {
+      const onPress = vi.fn();
+      const { container } = render(
+        createElement(WallStatePill, { state: 'live' as const, onPress, reserveOnly: true }),
+      );
+      const button = pill(container);
+
+      button.click();
+      expect(onPress).not.toHaveBeenCalled();
+      expect(button.getAttribute('data-role')).toBe('');
+      expect(button.getAttribute('data-label')).toBeNull();
+      expect(button.getAttribute('data-a11y-hidden')).toBe('true');
+      expect(button.getAttribute('data-pointer-events')).toBe('none');
+      expect(button.getAttribute('data-ripple')).toBe('');
+    });
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/wall-state-pill.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/wall-state-pill.test.tsx
@@ -7,7 +7,7 @@
 // use-wall-state-announcer.test.ts.
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
-import { createElement, type ReactNode } from 'react';
+import { createElement, type ComponentProps, type ReactNode } from 'react';
 
 type ViewMockProps = { children?: ReactNode; style?: unknown };
 type PressMockProps = {
@@ -17,7 +17,6 @@ type PressMockProps = {
   accessibilityLabel?: string;
   accessibilityHint?: string;
   accessibilityElementsHidden?: boolean;
-  pointerEvents?: string;
   android_ripple?: { color: string; borderless: boolean };
   style?: unknown | ((state: { pressed: boolean }) => unknown);
 };
@@ -32,7 +31,6 @@ vi.mock('react-native', () => ({
     accessibilityLabel,
     accessibilityHint,
     accessibilityElementsHidden,
-    pointerEvents,
     android_ripple,
     style,
   }: PressMockProps) =>
@@ -44,7 +42,6 @@ vi.mock('react-native', () => ({
         'data-label': accessibilityLabel,
         'data-hint': accessibilityHint,
         'data-a11y-hidden': accessibilityElementsHidden ? 'true' : '',
-        'data-pointer-events': pointerEvents ?? '',
         'data-ripple': android_ripple ? JSON.stringify(android_ripple) : '',
         'data-style': styleAttr(typeof style === 'function' ? style({ pressed: false }) : style),
         'data-style-pressed': styleAttr(typeof style === 'function' ? style({ pressed: true }) : style),
@@ -122,14 +119,16 @@ vi.mock('../../../theme/layout', () => ({
 
 import { WallStatePill } from '../WallStatePill';
 
-const renderPill = (props: Partial<{ state: 'onWall' | 'live' | 'browsing'; reserveOnly: boolean }> = {}) =>
-  render(
-    createElement(WallStatePill, {
-      state: props.state ?? 'browsing',
-      onPress: vi.fn(),
-      reserveOnly: props.reserveOnly,
-    }),
+type WallStatePillProps = ComponentProps<typeof WallStatePill>;
+
+const renderPill = (props: Partial<{ state: 'onWall' | 'live' | 'browsing'; reserveOnly: boolean }> = {}) => {
+  const state = props.state ?? 'browsing';
+  return render(
+    props.reserveOnly
+      ? createElement(WallStatePill, { state, reserveOnly: true })
+      : createElement(WallStatePill, { state, onPress: vi.fn() }),
   );
+};
 
 const pill = (container: HTMLElement) => container.querySelector('button') as HTMLElement;
 /** Serialised styles of every view, for the handful of assertions about colour/size. */
@@ -249,8 +248,11 @@ describe('WallStatePill', () => {
 
     it('claims nothing: untappable, unlabelled, hidden from assistive tech', () => {
       const onPress = vi.fn();
+      // The props union already makes this call impossible to write — that is the
+      // compile-time half. The cast reaches past it to the runtime guard sitting
+      // behind it, which is what still protects a JavaScript caller.
       const { container } = render(
-        createElement(WallStatePill, { state: 'live' as const, onPress, reserveOnly: true }),
+        createElement(WallStatePill, { state: 'live', onPress, reserveOnly: true } as unknown as WallStatePillProps),
       );
       const button = pill(container);
 
@@ -259,8 +261,9 @@ describe('WallStatePill', () => {
       expect(button.getAttribute('data-role')).toBe('');
       expect(button.getAttribute('data-label')).toBeNull();
       expect(button.getAttribute('data-a11y-hidden')).toBe('true');
-      expect(button.getAttribute('data-pointer-events')).toBe('none');
       expect(button.getAttribute('data-ripple')).toBe('');
+      // Inertness rides the style now, not the deprecated Pressable prop.
+      expect(button.getAttribute('data-style')).toContain('"pointerEvents":"none"');
     });
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/wall-state.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/wall-state.test.ts
@@ -24,8 +24,7 @@ const pillBase: WallPillStateInput = {
   wallClimbUuid: null,
   browseLatchActive: false,
   navigationCommits: false,
-  inSharedSession: false,
-  bleConnected: false,
+  wallDriven: false,
 };
 
 /** Signed-in climber on their own head, no preview pinned, nothing armed. */
@@ -37,8 +36,7 @@ const commitBase: CommitBarModelInput = {
   committedHeadUuid: MY_CLIMB,
   wallClimbUuid: null,
   confirmArmed: false,
-  inSharedSession: false,
-  bleConnected: false,
+  wallDriven: false,
 };
 
 describe('resolveWallPillState', () => {
@@ -65,12 +63,11 @@ describe('resolveWallPillState', () => {
     ['browse latch up with no wall known', { browseLatchActive: true }, 'browsing'],
     [
       'browse latch outranks a committing navigation',
-      { browseLatchActive: true, navigationCommits: true, bleConnected: true },
+      { browseLatchActive: true, navigationCommits: true, wallDriven: true },
       'browsing',
     ],
-    // Rung 4 — live needs stakes, and any one of the three is enough.
-    ['committing navigation over our own BLE link', { navigationCommits: true, bleConnected: true }, 'live'],
-    ['committing navigation in a shared session', { navigationCommits: true, inSharedSession: true }, 'live'],
+    // Rung 4 — live needs stakes, and either one is enough.
+    ['committing navigation over a wall someone is driving', { navigationCommits: true, wallDriven: true }, 'live'],
     [
       'committing navigation with a known lit climb but no link of our own',
       { navigationCommits: true, wallClimbUuid: THEIR_CLIMB },
@@ -78,8 +75,11 @@ describe('resolveWallPillState', () => {
     ],
     // Rung 5 — no stakes, so the leading slot stays empty exactly as today.
     ['plain solo: nothing lit, no session, no link', {}, null],
-    ['connected but not committing (lightOnSwipe off, still on the head)', { bleConnected: true }, null],
+    ['connected but not committing (lightOnSwipe off, still on the head)', { wallDriven: true }, null],
     ['committing with nothing at stake', { navigationCommits: true }, null],
+    // The regression: the Start button opens a session solo, so "a session
+    // exists" used to light the pill on a phone with nothing connected at all.
+    ['a started session nobody is driving a wall from', { navigationCommits: true, wallDriven: false }, null],
   ];
 
   it.each(cases)('%s → %j', (_scenario, overrides, expected) => {
@@ -96,7 +96,7 @@ describe('resolveWallPillState', () => {
     const wouldLightThePill: Array<Partial<WallPillStateInput>> = [
       { displayedClimbUuid: WALL_CLIMB, wallClimbUuid: WALL_CLIMB },
       { browseLatchActive: true },
-      { navigationCommits: true, bleConnected: true },
+      { navigationCommits: true, wallDriven: true },
     ];
     for (const overrides of wouldLightThePill) {
       expect(resolveWallPillState({ ...pillBase, ...overrides })).not.toBe(null);
@@ -210,8 +210,7 @@ describe('resolveCommitBarModel', () => {
   describe('commit label', () => {
     // The button must never promise a lighting it can't do.
     it.each([
-      ['this device drives the board', { bleConnected: true }, 'putOnWall'],
-      ['a shared session is listening', { inSharedSession: true }, 'putOnWall'],
+      ['a wall is being driven (this device, or a session peer)', { wallDriven: true }, 'putOnWall'],
       ['a lit climb is known', { wallClimbUuid: THEIR_CLIMB }, 'putOnWall'],
       ['no wall is reachable at all', {}, 'setActive'],
     ] as Array<[string, Partial<CommitBarModelInput>, string]>)('%s → %s', (_scenario, overrides, expected) => {

--- a/packages/mobile/src/components/play-drawer/wall-state.ts
+++ b/packages/mobile/src/components/play-drawer/wall-state.ts
@@ -8,9 +8,11 @@
  * render test impractical, which is exactly why the drawer's other decisions
  * (`play-drawer-navigation.ts`) live in pure modules too.
  *
- * The whole feature keys on DISPLAYED-EQUALS-WALL, never on who holds the
- * Bluetooth link: what the climber sees on screen versus what is physically lit
- * is the only thing the chrome is allowed to claim.
+ * Which climb the chrome names keys on DISPLAYED-EQUALS-WALL, never on who holds
+ * the Bluetooth link: what the climber sees on screen versus what is physically
+ * lit is the only thing the chrome is allowed to claim. Whether a wall is
+ * REACHABLE at all is the separate `wallDriven` question — a promise about the
+ * next swipe, and the one thing the link is allowed to answer.
  */
 
 /**
@@ -40,10 +42,16 @@ export type WallPillStateInput = {
   browseLatchActive: boolean;
   /** The next swipe writes the shared queue / lights the wall. */
   navigationCommits: boolean;
-  /** In a shared (party) session, so navigation has an audience even with no BLE link. */
-  inSharedSession: boolean;
-  /** This device holds the Bluetooth link to the board. */
-  bleConnected: boolean;
+  /**
+   * A wall is genuinely being driven: this device holds the Bluetooth link, or a
+   * member of this session does. Fed from `useLightbulbControl().lit`, so the
+   * pill and the lightbulb can never disagree about whether a wall is reachable.
+   *
+   * Deliberately NOT "a session exists". The Start button creates a session solo
+   * (`use-session-commands.ts`), so keying on `sessionId != null` promised "your
+   * next climb goes up on the wall" to a climber with nothing connected at all.
+   */
+  wallDriven: boolean;
 };
 
 /**
@@ -54,10 +62,10 @@ export type WallPillStateInput = {
  * carrying the latch. The pill is a statement about the wall, not about how you
  * got here.
  *
- * `live` needs stakes — a known lit climb, a shared session, or this device's
- * own BLE link. Plain solo with none of those returns `null`: there is nothing
- * to promise, so the slot stays empty rather than shipping a badge that means
- * nothing. The moment stakes exist the pill appears and stays for the session.
+ * `live` needs stakes — a known lit climb, or a wall someone is actually driving
+ * (this device's own BLE link, or a session member's). Plain solo with neither
+ * returns `null`: there is nothing to promise, so the slot stays empty rather
+ * than shipping a badge that means nothing.
  */
 export function resolveWallPillState({
   isAnonymous,
@@ -65,13 +73,12 @@ export function resolveWallPillState({
   wallClimbUuid,
   browseLatchActive,
   navigationCommits,
-  inSharedSession,
-  bleConnected,
+  wallDriven,
 }: WallPillStateInput): WallPillState {
   if (isAnonymous) return null;
   if (wallClimbUuid != null && displayedClimbUuid === wallClimbUuid) return 'onWall';
   if (browseLatchActive) return 'browsing';
-  if (navigationCommits && (wallClimbUuid != null || inSharedSession || bleConnected)) return 'live';
+  if (navigationCommits && (wallClimbUuid != null || wallDriven)) return 'live';
   return null;
 }
 
@@ -90,7 +97,7 @@ export type CommitBarMode = 'actions' | 'commit';
 
 /**
  * Which label the filled commit button wears. With no wall reachable at all —
- * no BLE link, no session, no known lit climb (the plain #4640 / logbook
+ * nobody driving a wall and no known lit climb (the plain #4640 / logbook
  * preview) — it falls back to "Set active" so the button never promises a
  * lighting it cannot do.
  */
@@ -122,8 +129,8 @@ export type CommitBarModelInput = {
   wallClimbUuid: string | null;
   /** A busy-wall confirm has been armed by a first commit tap (PR A2). */
   confirmArmed: boolean;
-  inSharedSession: boolean;
-  bleConnected: boolean;
+  /** A wall is genuinely being driven — see {@link WallPillStateInput.wallDriven}. */
+  wallDriven: boolean;
 };
 
 /**
@@ -154,11 +161,9 @@ export function resolveCommitBarModel({
   committedHeadUuid,
   wallClimbUuid,
   confirmArmed,
-  inSharedSession,
-  bleConnected,
+  wallDriven,
 }: CommitBarModelInput): CommitBarModel {
-  const commitLabel: CommitButtonLabel =
-    wallClimbUuid != null || inSharedSession || bleConnected ? 'putOnWall' : 'setActive';
+  const commitLabel: CommitButtonLabel = wallClimbUuid != null || wallDriven ? 'putOnWall' : 'setActive';
   const displayedIsCommittedHead = displayedClimbUuid != null && displayedClimbUuid === committedHeadUuid;
   const inCommitMode = previewPinned && !isAnonymous && !boardMismatch && !displayedIsCommittedHead;
   if (!inCommitMode) {

--- a/packages/mobile/src/theme/layout.ts
+++ b/packages/mobile/src/theme/layout.ts
@@ -136,3 +136,15 @@ export const SIDEBAR_NAV_ICON_SIZE = 26;
 /** Diameter of the "live"/now-on-the-wall status dot in the rail cell and wall
  *  strip — one value so every board-presence surface uses the same dot. */
 export const WALL_LIVE_DOT_SIZE = 10;
+
+/**
+ * Touch height of the play drawer's wall-state pill, and the height the drawer
+ * header reserves for its leading slot whether or not a pill is in it.
+ *
+ * One value because the two must agree: the pill comes and goes with the wall
+ * (and a swipe puts a pill-less peek header on screen beside a pill-bearing
+ * one), so a header sized to its tallest child would breathe 64↔68pt on every
+ * change — stepping the climb name and its attribute glyphs, and resizing the
+ * board art below it inside the fixed-height first screen.
+ */
+export const WALL_STATE_PILL_TOUCH_HEIGHT = glassSize.inline;


### PR DESCRIPTION
## Summary

Two fixes to the play drawer's wall-state pill.

**1. "Live" was showing with nothing connected.** `resolveWallPillState` granted the `live` state on `inSharedSession`, which `PlayDrawer` defined as `sessionId != null`. But the **Start** button creates a session solo (`use-session-commands.ts`: "Explicit session creation — the Start button (PreSessionView) and nothing else"), so starting any session showed a `Live` pill — whose explainer reads "Your next climb goes up on the wall" — with no board connected and nobody else present. `resolveCommitBarModel` had the same flaw and labelled its button "Put on the wall" when it could only set the queue head.

Both resolvers now take a single `wallDriven` input, fed from the lightbulb's own `deriveBoardConnection` signal (`useLightbulbControl().lit`): this device holds the BLE link, or a member of this session does. The pill and the lightbulb can no longer disagree about whether a wall is reachable, and a solo session with nothing connected gets no pill and a "Set active" button.

**2. The header stepped on every swipe.** Three things compounded:

- The pill's 44pt touch box sits beside a ~40pt centre column (`body` 22 + `marginTop` 2 + `caption1` 16), and `DrawerHeader`'s row is `alignItems: 'center'` — so the header grew 64 → 68pt only in the states that show a pill. `firstScreen` is a fixed height with `boardSection: {flex: 1}`, so the board art resized with it.
- The swipe **peek** header rendered no `leading` at all, so it took `DrawerHeader`'s other branch — different row height *and* a different centre-column x from the header it slides in behind. That mismatch is what the eye caught on every swipe: the climb name and its benchmark ("classic") glyph stepping vertically.
- `DrawerHeader` measures its flanks via `onLayout` into state, so any change re-centres the title a commit late.

`DrawerHeader` gains an optional `minRowHeight`; `PlayDrawerHeader` always reserves the pill's touch height (`WALL_STATE_PILL_TOUCH_HEIGHT`, moved into `theme/layout.ts` beside `WALL_LIVE_DOT_SIZE`), so the header keeps one height whether a pill is in the slot or not. The peek carries a `reserveOnly` copy of the pill — invisible, untappable, `accessibilityElementsHidden` — so both headers measure the same flank. It renders the *real* pill rather than a fixed-width spacer because the width is the translated label's ("Live" / "En vivo" / "En direct" all differ) and the `onWall` avatar chip is narrower again.

Known residual, unchanged by this PR: the pill still rides `swipeTranslateX`, so it slides off with the outgoing header and the reserved slot is empty until the fling resets. Hoisting it into a non-animating layer is the follow-up if that gap reads badly on device. `isSessionWallLit` also remains best-effort (it can stick `true` if a `WallDisconnected` is missed) — the pill now inherits exactly the lightbulb's staleness rather than a worse one.

## Release Notes

- The Live badge in the play drawer now only shows when a board is actually connected — yours or a session mate's
- Climb name and grade hold still while you swipe between climbs instead of nudging up and down

## Test plan

1. Start a solo session, no board connected. Open a climb.
2. Play drawer top row shows **no** Live badge.
3. Connect a board over Bluetooth. Live badge appears.
4. Swipe left and right through the queue. Name and grade hold still.
5. Disconnect. Badge goes, header and board art stay put.

## Risk

Risk: 2/5 — mobile UI only, no BLE protocol or native changes; the wall-state resolvers are pure and table-tested, and the layout change is one reserved row height plus a peek-side spacer.

## Validation

- `vp run typecheck:mobile` — pass
- `vp run test:mobile` — 704 files, 6966 tests pass
- `vp check` — 0 errors
- `vp run check:mobile-bundle` — android bundle OK (15.4 MB)

JS-only, so the Expo fingerprint is unchanged and this targets `main` for OTA.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXe8EcdxUv63c7oFWytdPo)_