### PR TITLE
fix(backend): tighten hold outline override auth order and read-time guards

### DIFF
--- a/packages/backend/src/__tests__/hold-outline-overrides.test.ts
+++ b/packages/backend/src/__tests__/hold-outline-overrides.test.ts
@@ -76,19 +76,30 @@ beforeEach(async () => {
   `);
 });
 
-/** Every operation, so an authorization test can sweep all three at once. */
+/**
+ * Every operation, so an authorization test can sweep all three at once.
+ *
+ * Sequential on purpose. The upsert and the delete touch the same row, so racing
+ * them under `Promise.all` leaves it undefined which one lands last — the delete
+ * could resolve `false` on a row the upsert has not written yet. Awaiting in
+ * order makes the sweep deterministic; it is checking who may call these, not
+ * how they interleave.
+ */
 type BoardConfig = { boardName: string; layoutId: number; sizeId: number };
 
 async function callAll(config: BoardConfig, placementId: number, ctx: ConnectionContext): Promise<unknown[]> {
-  return Promise.all([
-    holdOutlineQueries.holdOutlines(null, { input: { ...config } }, ctx),
-    holdOutlineMutations.upsertHoldOutlineOverride(
-      null,
-      { input: { ...config, placementId, outline: SQUARE_RING } },
-      ctx,
-    ),
-    holdOutlineMutations.deleteHoldOutlineOverride(null, { input: { ...config, placementId } }, ctx),
-  ]);
+  const read = await holdOutlineQueries.holdOutlines(null, { input: { ...config } }, ctx);
+  const written = await holdOutlineMutations.upsertHoldOutlineOverride(
+    null,
+    { input: { ...config, placementId, outline: SQUARE_RING } },
+    ctx,
+  );
+  const deleted = await holdOutlineMutations.deleteHoldOutlineOverride(
+    null,
+    { input: { ...config, placementId } },
+    ctx,
+  );
+  return [read, written, deleted];
 }
 
 describe('hold outline override authorization', () => {
@@ -228,7 +239,9 @@ describe('upsertHoldOutlineOverride validation', () => {
     expect(await storedOverrides()).toHaveLength(0);
   });
 
-  it('rejects an unknown board name before it reaches the role check', async () => {
+  it('rejects an unknown board name once the caller is past the role check', async () => {
+    // A global admin holds a null-scoped row, so requireAdmin admits them for
+    // any board name and the schema is what turns this one away.
     await expect(
       holdOutlineMutations.upsertHoldOutlineOverride(
         null,
@@ -236,6 +249,35 @@ describe('upsertHoldOutlineOverride validation', () => {
         authCtx(GLOBAL_ADMIN),
       ),
     ).rejects.toThrow(/Invalid input/);
+  });
+
+  it('answers an unauthenticated caller with auth, never with the board-name enum', async () => {
+    // Authorization runs before validation precisely so a signed-out prober
+    // cannot read the list of valid board names out of a Zod error.
+    for (const badInput of [
+      { boardName: 'notaboard', layoutId: 1, sizeId: 10, placementId: 1, outline: SQUARE_RING },
+      { boardName: 'kilter', layoutId: 'nope', sizeId: 10, placementId: 1, outline: SQUARE_RING },
+      {},
+    ]) {
+      const failure = await holdOutlineMutations.upsertHoldOutlineOverride(null, { input: badInput }, anonCtx()).then(
+        () => new Error('expected a rejection'),
+        (error: unknown) => error as Error,
+      );
+      expect(failure.message).toMatch(/authentication required/i);
+      expect(failure.message).not.toMatch(/Invalid input/);
+    }
+  });
+
+  it('turns a board-scoped admin away from another board before validating', async () => {
+    // The Kilter admin is signed in but has no Tension row, so the scope check
+    // is what stops them — not the malformed layoutId sitting behind it.
+    await expect(
+      holdOutlineMutations.upsertHoldOutlineOverride(
+        null,
+        { input: { ...TENSION_CONFIG, layoutId: 'nope', placementId: 1, outline: SQUARE_RING } },
+        authCtx(KILTER_ADMIN),
+      ),
+    ).rejects.toThrow(/admin role required/i);
   });
 });
 
@@ -444,6 +486,36 @@ describe('hold outline override round trip', () => {
 
     expect(created.note).toBeNull();
     expect((await storedOverrides())[0].note).toBeNull();
+  });
+
+  it('drops a stored row whose outline is not a ring instead of serving it', async () => {
+    // Writes cannot produce these, so they are forced in directly — the shapes a
+    // hand-run UPDATE or an older column shape could leave behind. A renderer
+    // fed one of these draws garbage and cannot tell that it did.
+    const corrupt = [
+      { placementId: KILTER_PLACEMENT, outline: sql`'[-1,-1,1,-1,1]'::jsonb` },
+      { placementId: KILTER_PLACEMENT + 1, outline: sql`'[-1,-1,1,-1,"x",1]'::jsonb` },
+      { placementId: KILTER_PLACEMENT + 2, outline: sql`'[-1,-1]'::jsonb` },
+      { placementId: KILTER_PLACEMENT + 3, outline: sql`'{"not":"a ring"}'::jsonb` },
+    ];
+    for (const { placementId, outline } of corrupt) {
+      await db.execute(sql`
+        INSERT INTO hold_outline_overrides
+          (board_name, layout_id, size_id, placement_id, kind, outline, author_id, created_at, updated_at)
+        VALUES ('kilter', 1, 10, ${placementId}, 'silhouette', ${outline}, ${GLOBAL_ADMIN}, now(), now())
+      `);
+    }
+    // One good row alongside them, so this proves a filter rather than a crash.
+    await holdOutlineMutations.upsertHoldOutlineOverride(
+      null,
+      { input: { ...KILTER_CONFIG, placementId: KILTER_PLACEMENT + 4, outline: SQUARE_RING } },
+      authCtx(GLOBAL_ADMIN),
+    );
+
+    const read = await holdOutlineQueries.holdOutlines(null, { input: { ...KILTER_CONFIG } }, authCtx(GLOBAL_ADMIN));
+
+    expect(await storedOverrides()).toHaveLength(5);
+    expect(read.overrides.map((entry) => entry.placementId)).toEqual([KILTER_PLACEMENT + 4]);
   });
 
   it("keeps one board config's overrides out of another config's read", async () => {

--- a/packages/backend/src/graphql/resolvers/board/hold-outline-overrides.ts
+++ b/packages/backend/src/graphql/resolvers/board/hold-outline-overrides.ts
@@ -21,6 +21,7 @@ import { getSetsForLayoutAndSize } from '@boardsesh/board-constants/product-size
 import { getBoardDetailsForBoard } from '@boardsesh/board-render';
 import * as dbSchema from '@boardsesh/db/schema';
 import { db } from '../../../db/client';
+import { logger } from '../../../utils/logger';
 import { applyRateLimit, validateInput } from '../shared/helpers';
 import { requireAdmin } from '../social/roles';
 import {
@@ -113,6 +114,46 @@ function placementIdsFor({ boardName, layoutId, sizeId }: HoldOutlineConfig): Se
   }
 }
 
+/**
+ * The board name as the caller sent it, unvalidated, for the authorization
+ * check that has to run BEFORE validation.
+ *
+ * `requireAdmin` is board-scoped, so it needs a board name — but running the
+ * Zod schema first to get one means an unauthenticated caller learns which board
+ * names exist from the enum error. Reading the raw field is safe: it only ever
+ * reaches `hasAdmin`, where it is compared against the caller's own role rows.
+ * An unknown string matches no board-scoped row, so it cannot grant anything;
+ * a global admin (`board_type IS NULL`) passes either way and is then held to
+ * the schema like everyone else.
+ */
+function rawBoardName(input: unknown): string | undefined {
+  if (typeof input !== 'object' || input === null) return undefined;
+  const { boardName } = input as { boardName?: unknown };
+  return typeof boardName === 'string' ? boardName : undefined;
+}
+
+/**
+ * Is a stored ring structurally sound enough to hand to a client?
+ *
+ * Writes already enforce the full contract, so this only fires on a row that
+ * reached the column another way — a hand-run UPDATE, a restore from an older
+ * shape, a bad migration. jsonb will hold any of those happily, and a renderer
+ * fed an odd-length or NaN-bearing ring draws garbage rather than failing, so
+ * the read path drops the row instead of passing it on.
+ *
+ * Deliberately looser than the write gate: structure only, no coordinate bound
+ * and no length ceiling. Those are policy and can be retuned; a row stored under
+ * an older policy is stale, not corrupt, and should still render.
+ */
+function isRenderableStoredRing(outline: unknown): outline is number[] {
+  return (
+    Array.isArray(outline) &&
+    outline.length >= MIN_RING_NUMBERS &&
+    outline.length % 2 === 0 &&
+    outline.every((value) => typeof value === 'number' && Number.isFinite(value))
+  );
+}
+
 /** The DB row shape the two write paths and the read path all return to GraphQL. */
 type OverrideRow = {
   boardName: string;
@@ -163,9 +204,11 @@ export const holdOutlineQueries = {
     { input }: { input: unknown },
     ctx: ConnectionContext,
   ): Promise<BoardHoldOutlines> => {
-    const config = validateInput(HoldOutlineConfigInputSchema, input, 'input');
-    await requireAdmin(ctx, config.boardName);
+    // Authorization first, validation second: an unauthenticated caller must not
+    // be able to read the board-name enum out of a validation error.
+    await requireAdmin(ctx, rawBoardName(input));
     await applyRateLimit(ctx, HOLD_OUTLINES_QUERY_LIMIT, 'holdOutlines');
+    const config = validateInput(HoldOutlineConfigInputSchema, input, 'input');
 
     // Null is the normal answer for a config the tracer never covered (Woods
     // ships no shard at all): the editor draws against the ring fallback the
@@ -205,12 +248,28 @@ export const holdOutlineQueries = {
       )
       .orderBy(dbSchema.holdOutlineOverrides.placementId, dbSchema.holdOutlineOverrides.kind);
 
+    // A row that is not structurally a ring is dropped rather than handed on:
+    // the editor would draw garbage from it and could not tell that it had. Not
+    // reachable through this API — writes enforce the full contract — so a hit
+    // means the column was written some other way, which is worth a log line.
+    const renderable = rows.filter((row) => {
+      if (isRenderableStoredRing(row.outline)) return true;
+      logger.warn('[holdOutlines] dropping a stored override whose outline is not a ring', {
+        boardName: row.boardName,
+        layoutId: row.layoutId,
+        sizeId: row.sizeId,
+        placementId: row.placementId,
+        kind: row.kind,
+      });
+      return false;
+    });
+
     return {
       boardName: config.boardName,
       layoutId: config.layoutId,
       sizeId: config.sizeId,
       shardOutlines,
-      overrides: rows.map((row) => toGraphQLOverride(row, row.authorDisplayName ?? row.authorName ?? null)),
+      overrides: renderable.map((row) => toGraphQLOverride(row, row.authorDisplayName ?? row.authorName ?? null)),
     };
   },
 };
@@ -221,13 +280,13 @@ export const holdOutlineMutations = {
     { input }: { input: unknown },
     ctx: ConnectionContext,
   ): Promise<HoldOutlineOverride> => {
-    const validated = validateInput(UpsertHoldOutlineOverrideInputSchema, input, 'input');
-    await requireAdmin(ctx, validated.boardName);
+    // Authorization first, validation second — see the query above.
+    await requireAdmin(ctx, rawBoardName(input));
     await applyRateLimit(ctx, HOLD_OUTLINE_MUTATION_LIMIT, 'upsertHoldOutlineOverride');
-    const authorId = ctx.userId;
-    if (!authorId) {
-      throw new Error('Authentication required to perform this operation');
-    }
+    const validated = validateInput(UpsertHoldOutlineOverrideInputSchema, input, 'input');
+    // `requireAdmin` runs `requireAuthenticated` first, so reaching here means
+    // `ctx.userId` is set; the non-null assertion is the guarantee, not a guess.
+    const authorId = ctx.userId!;
 
     if (!placementIdsFor(validated).has(validated.placementId)) {
       throw new GraphQLError(`Placement ${validated.placementId} is not on this board config.`, {
@@ -266,8 +325,9 @@ export const holdOutlineMutations = {
     }
 
     // An editor that clears the field sends '', which is not a reason — store the
-    // absence rather than an empty string nothing can render.
-    const note = validated.note?.trim() || null;
+    // absence rather than an empty string nothing can render. The schema has
+    // already trimmed it, so `||` is doing the whole job here.
+    const note = validated.note || null;
 
     const [row] = await db
       .insert(dbSchema.holdOutlineOverrides)
@@ -316,9 +376,10 @@ export const holdOutlineMutations = {
     { input }: { input: unknown },
     ctx: ConnectionContext,
   ): Promise<boolean> => {
-    const validated = validateInput(DeleteHoldOutlineOverrideInputSchema, input, 'input');
-    await requireAdmin(ctx, validated.boardName);
+    // Authorization first, validation second — see the query above.
+    await requireAdmin(ctx, rawBoardName(input));
     await applyRateLimit(ctx, HOLD_OUTLINE_MUTATION_LIMIT, 'deleteHoldOutlineOverride');
+    const validated = validateInput(DeleteHoldOutlineOverrideInputSchema, input, 'input');
 
     const removed = await db
       .delete(dbSchema.holdOutlineOverrides)


### PR DESCRIPTION
## Summary

Review follow-up to #4868, which merged before these could be pushed to its branch. Five of the six `claude-review` items, all in the hold-outline-override resolvers and their tests. No schema change, no new API surface.

**1 — Auth before validation (the one with teeth).** All three resolvers ran `validateInput` before `requireAdmin`, so a signed-out caller got a Zod `Invalid input` error for a bad board name and a GraphQL auth error for a good one — enough to read the board-name enum back out. `requireAdmin` now runs first.

The scope check needs a board name *before* the schema has produced one, so it reads the raw field. That is safe: the value only ever reaches `hasAdmin`, where it is compared against the caller's own role rows, so an unknown string matches no board-scoped row and cannot grant anything. A global admin (`board_type IS NULL`) passes either way and is then held to the schema like everyone else.

**2 — Dead auth check.** `requireAdmin` calls `requireAuthenticated` internally, so the `if (!authorId) throw` behind it was unreachable.

**3 — Read-time ring guard.** `holdOutlines` now drops any stored row whose `outline` is not structurally a ring (array, even length, at least 3 points, all finite) and logs it. Drizzle's `$type<number[]>()` is compile-time only; jsonb will hold anything, and a renderer fed an odd-length or NaN-bearing ring draws garbage rather than failing.

Deliberately **looser** than the write gate — no coordinate bound, no length ceiling. Those are policy and can be retuned; a row stored under an older policy is stale, not corrupt, and should still render. Unreachable through this API since writes enforce the full contract, so a hit means the column was written some other way — hence the log line rather than a silent skip.

**4 — Redundant `.trim()`.** The Zod schema already trims the note.

**5 — Raced test helper.** `callAll` ran query/upsert/delete under `Promise.all`. The upsert and delete touch the same row, so it was undefined which landed last. Sequential now.

Three tests added: a signed-out caller never sees `Invalid input`; a board-scoped admin is turned away from another board before validation runs; four force-inserted malformed rows are filtered out of a read while a good row beside them survives.

## Not fixed here — filed as #4874

The sixth item, the Douglas-Peucker duplication between `packages/shared/board-art-geometry/src/ring.ts` and `scripts/generate-board-art-geometry.ts`, is real but out of scope: touching the generator re-opens the shard drift gate on a change that has nothing to do with tracing.

Worth recording because I checked rather than assumed — I had expected the per-image tracer stack (#4857 → #4863) to have already collapsed the two copies on `release/next`. **It has not.** Both `origin/main` and `origin/release/next` still carry the generator's private `simplify` and `SIMPLIFY_EPSILON`, and no open PR resolves it, so this was untracked until now. #4874 also notes the two branches' copies of that file have diverged, which affects which line it should land on first.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.
2. Backend tests cover the auth ordering and the read-time filter.
3. Nothing user-facing ships — admin-only API with no client yet.

## Risk

Risk: 2/5 — resolver auth ordering + a read-side filter, both covered by tests
