### PR TITLE
fix(backend): bound board render set ids

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -155,7 +155,9 @@ jobs:
             NEXTAUTH_SECRET="branch-deploy-secret-${PR_NUM}"
             BACKEND_INTERNAL_URL="ws://backend-pr-${PR_NUM}:8080/graphql"
 
-            # Start per-PR backend (priority 100 overrides staging backend at priority 1)
+            # Start per-PR backend (priority 100 overrides staging backend at priority 1).
+            # The 768 MB limit leaves headroom for the Rust/WASM renderer, sharp
+            # working buffers, and render LRUs beyond the old 256 MB allocation.
             docker run -d \
               --name backend-pr-${PR_NUM} \
               --network ${NETWORK} \

--- a/packages/backend/src/__tests__/board-render.test.ts
+++ b/packages/backend/src/__tests__/board-render.test.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RateLimitError } from '../utils/rate-limiter';
+import { MAX_SET_IDS_LENGTH } from '@boardsesh/board-render';
 
 vi.mock('../services/board-render', () => ({
   InvalidBoardRenderConfigError: class InvalidBoardRenderConfigError extends Error {
@@ -175,6 +176,7 @@ describe('handleBoardRender', () => {
       { ...validParams, set_ids: '1,,20' },
       { ...validParams, set_ids: '1,a' },
       { ...validParams, set_ids: '999999999999999999999999' },
+      { ...validParams, set_ids: '1'.repeat(MAX_SET_IDS_LENGTH + 1) },
       { ...validParams, set_ids: '1,2,3,4,5,6,7,8,9,10,11' },
     ];
 

--- a/packages/backend/src/__tests__/og-climb.test.ts
+++ b/packages/backend/src/__tests__/og-climb.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import sharp from 'sharp';
+import { MAX_SET_IDS_LENGTH } from '@boardsesh/board-render';
 import { RateLimitError } from '../utils/rate-limiter';
 
 // The handler under test talks to the board-render service and the Redis rate
@@ -109,6 +110,18 @@ describe('handleOgClimb', () => {
       const res = await run({ ...validParams, set_ids: '1,a' });
       expect(res.statusCode).toBe(400);
       expect(renderOgClimb).not.toHaveBeenCalled();
+    });
+
+    it('rejects oversized set_ids before schema and render work', async () => {
+      const res = await run({ ...validParams, set_ids: '1'.repeat(MAX_SET_IDS_LENGTH + 1) });
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(String(res.body))).toEqual({
+        error: 'Invalid parameters',
+        details: ['set_ids is too large'],
+      });
+      expect(renderOgClimb).not.toHaveBeenCalled();
+      expect(ensureBoardRendererAvailable).not.toHaveBeenCalled();
+      expect(checkRateLimitRedis).not.toHaveBeenCalled();
     });
 
     it('rejects missing or empty frames with 400 — a blank board must not get immutable 200 headers', async () => {

--- a/packages/backend/src/handlers/board-render.ts
+++ b/packages/backend/src/handlers/board-render.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import {
   MAX_FRAMES_LENGTH,
   MAX_SET_IDS,
+  MAX_SET_IDS_LENGTH,
   VALID_BOARD_NAMES,
   boardseshRenderQuerySchema,
   createOgImageHeaders,
@@ -98,6 +99,10 @@ export async function handleBoardRender(req: IncomingMessage, res: ServerRespons
   const parsedSizeId = parseNonnegativeInteger(sizeId);
   if (parsedSizeId === null) {
     sendJson(req, res, 400, { error: 'size_id must be a nonnegative integer' });
+    return;
+  }
+  if (setIds.length > MAX_SET_IDS_LENGTH) {
+    sendJson(req, res, 400, { error: 'set_ids is too large' });
     return;
   }
   const parsedSetIds = setIds.split(',');

--- a/packages/backend/src/handlers/og-climb.ts
+++ b/packages/backend/src/handlers/og-climb.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import {
+  MAX_SET_IDS_LENGTH,
   createOgImageHeaders,
   normalizeOutputFormat,
   ogClimbQuerySchema,
@@ -34,13 +35,19 @@ function sendJson(res: ServerResponse, status: number, body: unknown): void {
 export async function handleOgClimb(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
   if (!applyCorsHeaders(req, res)) return;
 
+  const rawSetIds = url.searchParams.get('set_ids');
+  if (rawSetIds !== null && rawSetIds.length > MAX_SET_IDS_LENGTH) {
+    sendJson(res, 400, { error: 'Invalid parameters', details: ['set_ids is too large'] });
+    return;
+  }
+
   // Validate BEFORE any render work — a bad request is cheap to reject and can't
   // push this public CPU-heavy endpoint into wasted WASM/sharp renders.
   const parsed = ogClimbQuerySchema.safeParse({
     board_name: url.searchParams.get('board_name'),
     layout_id: url.searchParams.get('layout_id'),
     size_id: url.searchParams.get('size_id'),
-    set_ids: url.searchParams.get('set_ids'),
+    set_ids: rawSetIds,
     frames: url.searchParams.get('frames') ?? '',
     format: url.searchParams.get('format') ?? undefined,
     // boardsesh-mode render options (issue #2202) — see docs/og-climb.md.

--- a/packages/shared/board-render/src/__tests__/validation.test.ts
+++ b/packages/shared/board-render/src/__tests__/validation.test.ts
@@ -13,6 +13,7 @@ import {
   renderModeSchema,
   VALID_BOARD_NAMES,
   MAX_FRAMES_LENGTH,
+  MAX_SET_IDS_LENGTH,
 } from '../validation';
 
 describe('normalizeOutputFormat', () => {
@@ -153,6 +154,13 @@ describe('ogClimbQuerySchema', () => {
   it('rejects more set_ids than MAX_SET_IDS', () => {
     const tooManySetIds = Array.from({ length: 11 }, (_, index) => index + 1).join(',');
     expect(ogClimbQuerySchema.safeParse({ ...valid, set_ids: tooManySetIds }).success).toBe(false);
+  });
+
+  it('rejects an oversized set_ids string before syntax validation', () => {
+    const oversizedSetIds = '1'.repeat(MAX_SET_IDS_LENGTH + 1);
+    const result = ogClimbQuerySchema.safeParse({ ...valid, set_ids: oversizedSetIds });
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.issues[0]?.message).toBe('set_ids is too large');
   });
 
   it('rejects malformed frames', () => {

--- a/packages/shared/board-render/src/validation.ts
+++ b/packages/shared/board-render/src/validation.ts
@@ -19,6 +19,13 @@ export const MAX_FRAMES_LENGTH = 16_384;
 export const MAX_SET_IDS = 10;
 
 /**
+ * Ten comma-separated safe integers. Apply this byte-sized bound before regex
+ * or split work so hostile query strings cannot make validation scale with an
+ * arbitrary input length.
+ */
+export const MAX_SET_IDS_LENGTH = MAX_SET_IDS * String(Number.MAX_SAFE_INTEGER).length + (MAX_SET_IDS - 1);
+
+/**
  * Hard ceiling on the rendered pixel count. Every in-flight plane costs 4 bytes
  * a pixel, so this is what stops a hand-crafted request from sizing a render
  * past what the process can hold. The largest real board is Kilter's 1080×2498
@@ -126,6 +133,7 @@ export const ogClimbQuerySchema = z
     size_id: z.coerce.number().int().nonnegative(),
     set_ids: z
       .string()
+      .max(MAX_SET_IDS_LENGTH, 'set_ids is too large')
       .regex(/^\d+(,\d+)*$/, 'set_ids must be a comma-separated list of integers')
       .refine((setIdsCsv) => setIdsCsv.split(',').length <= MAX_SET_IDS, `set_ids accepts at most ${MAX_SET_IDS} ids`)
       // Canonicalise (sort + dedupe) so equivalent queries render and cache identically.


### PR DESCRIPTION
## Summary

- Bound comma-separated board render set IDs before regex and split validation.
- Apply the same cap to the canonical render endpoint and OG climb schema.
- Document why preview render backends need a 768 MB memory limit.
- Follow-up to #4821 after its final automated review arrived during merge.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 2/5 — isolated public-input validation with focused regression tests.