### PR TITLE
fix(mobile): size the Android tick sheet to its form, not the screen

### DIFF
--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -146,16 +146,30 @@ and which index is requested — it has a fixed ~50% "partial" state and a conte
 "expanded" state, nothing in between (see `androidSafeSnapPoints` in
 `src/components/sheet-snap-points.ts`). A sheet whose detents are tuned against iOS's real first
 fraction (e.g. `65%`/`80%`, sized so a pinned footer fits under the form) can be TALLER than
-Android's ~50% partial state, stranding that footer below the fold (#4723). For a multi-detent
-sheet with a pinned footer, pass `androidOpensExpanded` to `Sheet` / `ModalSheet` — `LogAscentSheet`
-and `LogbookEditSheet` opt in. It collapses the sheet to its single LAST detent on Android (via
-`androidSafeSnapPoints`) rather than requesting the last index of a multi-detent config: a single
-detent makes the native sheet set `skipPartiallyExpanded`, which removes "partial" as a landable
-state entirely, so it can only rest at Expanded (or Hidden) — no imperative re-snap in the mix.
-Requesting an index into a multi-detent config instead depends on `@expo/ui`'s Android layer
-calling `sheetState.expand()` in a `LaunchedEffect` it wraps in a swallowed `catch` ("Expanded
-anchor may be unreachable; never crash the view") — a real, silent-failure race that can leave
-the sheet resting at partial with the footer off-screen even when the right index was requested.
+Android's ~50% partial state, stranding that footer below the fold (#4723). But its "expanded"
+state only actually fits content when `@expo/ui`'s content-fitting path is on — `enableDynamicSizing`
+with **no** snap points, so the shim sets `fitToContents` and hosts the RN tree in an
+`RNHostView matchContents` that forces the Compose node to the RN child's measured height. A
+single near-full detent (`['92%']`) does NOT take that path — the sheet fills the screen and a
+short form floats in ~310 dp of void above the footer (#4720).
+
+For a multi-detent form with a pinned footer, pass `androidContentSized` to `Sheet` / `ModalSheet`
+(`LogAscentSheet` and `LogbookEditSheet` opt in). On Android it drops the `%` detents and takes
+the content-fitting path; iOS / web keep the exact detents and the `useSheetColumnStyle` bound.
+Two things make it safe for a scroll body — the case `androidSafeSnapPoints`'s old comment warned
+content-fitting would collapse:
+
+- The single flex child (the `KeyboardAvoidingView`) takes a **`maxHeight`** of
+  `window − topInset − chrome`, not `flex: 1` — under a `matchContents` host a `flex: 1` child
+  resolves to zero. At rest it measures to the form; a keyboard-up long note pushes it into the
+  ceiling.
+- The scroll body takes **`flexShrink: 1`**, not `flex: 1` — content height at rest (this is what
+  closes the void), and it shrinks-and-scrolls once the column hits its ceiling so the footer
+  stays pinned above the keyboard instead of the note clipping.
+
+`skipPartiallyExpanded` still comes for free (the shim sets it whenever `fitToContents` or a
+single detent), so the ~50% partial trap of #4723 stays closed — the sheet can only rest at its
+one content-fitted state or Hidden, no imperative re-snap in the mix.
 
 The bound isn't optional the moment a surface gains a scroll body: without it the scroll view
 never gains an overflow, so nothing scrolls **and** the footer is off-screen. `LogAscentSheet`

--- a/packages/mobile/src/components/LogAscentSheet.tsx
+++ b/packages/mobile/src/components/LogAscentSheet.tsx
@@ -143,10 +143,11 @@ export function LogAscentSheet({
       scrollable
       surface="solid"
       footerSurface="flush"
-      // Android's ~50% partial state can't fit this form under a pinned
-      // footer (see `androidOpensExpanded` on `ModalSheet`, #4723) — open
-      // expanded there so the Send button never lands off the fold.
-      androidOpensExpanded
+      // Android's ~50% partial state can't fit this form under a pinned footer
+      // (#4723), and a near-full single detent leaves ~310 dp of void below it
+      // (#4720). Size the sheet to the form on Android instead — see
+      // `androidContentSized` on `ModalSheet`.
+      androidContentSized
       header={
         <TickSheetHeader
           title={climbName ?? t('mobile.tick.fallbackTitle')}

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -69,11 +69,16 @@ type ModalSheetProps = {
   /** Optional fixed header, rendered above the body and outside its scroll — so a
    * title and close affordance stay put while the body scrolls. */
   header?: ReactNode;
-  /** Collapses to a single, expanded-only detent on Android instead of the usual
-   * multi-detent config, so a pinned footer never strands below Android's ~50%
-   * partial state (#4723). See `androidSafeSnapPoints` for the full rationale;
-   * no effect on iOS/web, or on a single detent already at/above 75%. */
-  androidOpensExpanded?: boolean;
+  /** Size the sheet to its content on Android via `@expo/ui`'s content-fitting
+   * path (`enableDynamicSizing` + no snap points) instead of the `%` detents.
+   * For a multi-detent form whose pinned footer only fits at the last detent
+   * (the tick sheets): a near-full single detent there strands the footer under
+   * ~310 dp of empty sheet (#4720), and Android's ~50% partial state can't fit
+   * the form under the footer at all (#4723). Content-fitting closes both. The
+   * column takes a `maxHeight` ceiling (see `useSheetColumnStyle`) so a
+   * keyboard-up long note still scrolls under the footer rather than clipping.
+   * No effect on iOS / web — they keep the exact `%` detents. */
+  androidContentSized?: boolean;
 };
 
 export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(function ModalSheet(
@@ -93,7 +98,7 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
     surface = 'glass',
     footerSurface = 'plate',
     header,
-    androidOpensExpanded = false,
+    androidContentSized = false,
   },
   ref,
 ) {
@@ -103,13 +108,13 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
   // Plain string, never a PlatformColor — see the `surface` prop doc.
   const solidBackground = useMemo(() => ({ backgroundColor: sheetSurface }), [sheetSurface]);
 
-  // Single-detent sheets jump to full screen on @expo/ui's Android sheet — give
-  // them a partial state instead. An `androidOpensExpanded` sheet instead
-  // collapses to its single LAST detent on Android (see androidSafeSnapPoints).
-  const effectiveSnapPoints = useMemo(
-    () => androidSafeSnapPoints(snapPoints, androidOpensExpanded),
-    [snapPoints, androidOpensExpanded],
-  );
+  // On Android, `androidContentSized` swaps the `%` detents for `@expo/ui`'s
+  // content-fitting path — no snap points reach the native sheet, so this only
+  // pads a SMALL single detent to give Android a partial state (see
+  // androidSafeSnapPoints), and passes iOS / web through untouched.
+  const contentSizedOnAndroid = androidContentSized && Platform.OS === 'android';
+  const useContentFitting = enableDynamicSizing || contentSizedOnAndroid;
+  const effectiveSnapPoints = useMemo(() => androidSafeSnapPoints(snapPoints), [snapPoints]);
 
   const sheetRef = useRef<BottomSheetMethods>(null);
   const managed = useManagedSheet({
@@ -126,7 +131,7 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
 
   // Track the resting detent so the iOS column bound follows drags between detents.
   const [activeIndex, setActiveIndex] = useState(0);
-  const columnStyle = useSheetColumnStyle(snapPoints, { enableDynamicSizing, activeIndex });
+  const columnStyle = useSheetColumnStyle(snapPoints, { enableDynamicSizing, activeIndex, contentSizedOnAndroid });
   // Dev-only observers for #3922 — they feed a log line, never layout.
   const { probeProps, sentinelProps, onColumnLayout } = useSheetDetentProbe(columnStyle, 'ModalSheet');
 
@@ -158,7 +163,12 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
   // itself is the child, so it carries the bound directly — otherwise an iOS
   // scrollable sheet sizes to its content and anything past the detent is
   // clipped and unreachable instead of scrolling.
-  const bodyStyle = hasChrome ? styles.content : columnStyle;
+  //
+  // On Android's content-fitting path the KAV takes a `maxHeight`, not `flex: 1`,
+  // so the body can't `flex: 1` into it — it takes its content height at rest
+  // (this is what closes the void) and `flexShrink: 1` so it shrinks and scrolls
+  // once a keyboard-up long note pushes the column into that ceiling.
+  const bodyStyle = hasChrome ? (contentSizedOnAndroid ? styles.contentShrink : styles.content) : columnStyle;
   // Without a pinned footer the body sits against the bottom edge, so it has to
   // clear the Android edge-to-edge navigation bar itself — the native sheet does
   // not pad content for it. With a footer the body scrolls above the footer, which
@@ -183,7 +193,7 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
     >
       {children}
     </BottomSheetScrollView>
-  ) : enableDynamicSizing && !hasChrome && Platform.OS === 'web' ? (
+  ) : useContentFitting && !hasChrome && Platform.OS === 'web' ? (
     // Web + dynamic sizing only, where the column is never bounded and the
     // #3922 probe stays idle — so there is nothing to measure here.
     <BottomSheetView style={[bodyStyle, bodyContentContainerStyle]}>{children}</BottomSheetView>
@@ -217,12 +227,12 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
       // forgiving: it reads `index` both to mount (`GorhomBottomSheetModal
       // index={...}`) and inside its own `.present()`/`requestOpen` fallback, so
       // `-1` here left the web sheet unable to ever open (#4684 review). Keep it
-      // at the real first-detent index; an `androidOpensExpanded` sheet is
-      // already collapsed to its single expanded detent on Android, so index 0
-      // IS expanded there too.
+      // at the real first-detent index; an `androidContentSized` sheet has no
+      // snap points on Android and only its one content-fitted state, so index 0
+      // is that state.
       index={0}
-      snapPoints={enableDynamicSizing ? undefined : effectiveSnapPoints}
-      enableDynamicSizing={enableDynamicSizing}
+      snapPoints={useContentFitting ? undefined : effectiveSnapPoints}
+      enableDynamicSizing={useContentFitting}
       enablePanDownToClose={enablePanDownToClose}
       handleIndicatorStyle={sheet.handleStyle}
       backgroundStyle={surface === 'solid' ? solidBackground : undefined}
@@ -239,9 +249,10 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
       {hasChrome ? (
         // The single flex child of the native sheet: bound to the detent height on
         // iOS (see useSheetColumnStyle) so the pinned footer can't fall off-screen
-        // (#3330); flex:1 on Android / fitToContents. `padding` on both platforms:
-        // the Android Compose dialog window does not resize for the keyboard, so
-        // without it the keyboard covers the footer's input (emulator-verified).
+        // (#3330); flex:1 on Android's detent path; a `maxHeight` ceiling on its
+        // content-fitting path (#4720). `padding` on both platforms: the Android
+        // Compose dialog window does not resize for the keyboard, so without it
+        // the keyboard covers the footer's input (emulator-verified).
         <KeyboardAvoidingView style={columnStyle} behavior="padding" onLayout={onColumnLayout}>
           {header}
           {body}
@@ -270,6 +281,11 @@ const styles = StyleSheet.create({
   },
   content: {
     flex: 1,
+  },
+  // Android content-fitting path: content height at rest (closes the void),
+  // shrinks to scroll when a keyboard-up long note fills the column's ceiling.
+  contentShrink: {
+    flexShrink: 1,
   },
   footer: {
     paddingHorizontal: spacing[4],

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -77,7 +77,11 @@ type ModalSheetProps = {
    * the form under the footer at all (#4723). Content-fitting closes both. The
    * column takes a `maxHeight` ceiling (see `useSheetColumnStyle`) so a
    * keyboard-up long note still scrolls under the footer rather than clipping.
-   * No effect on iOS / web — they keep the exact `%` detents. */
+   * No effect on iOS / web — they keep the exact `%` detents.
+   *
+   * Designed for a sheet with a `header` / `footer` (the `maxHeight` lands on the
+   * KeyboardAvoidingView). A chrome-less sheet has no reason to reach for it —
+   * pass `enableDynamicSizing` instead. */
   androidContentSized?: boolean;
 };
 
@@ -109,11 +113,12 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
   const solidBackground = useMemo(() => ({ backgroundColor: sheetSurface }), [sheetSurface]);
 
   // On Android, `androidContentSized` swaps the `%` detents for `@expo/ui`'s
-  // content-fitting path — no snap points reach the native sheet, so this only
-  // pads a SMALL single detent to give Android a partial state (see
-  // androidSafeSnapPoints), and passes iOS / web through untouched.
+  // content-fitting path (no snap points at all reach the native sheet).
   const contentSizedOnAndroid = androidContentSized && Platform.OS === 'android';
   const useContentFitting = enableDynamicSizing || contentSizedOnAndroid;
+  // Consumed only on the detent path below (`useContentFitting` false): pads a
+  // SMALL single detent to give Android a partial state, passes iOS / web
+  // through untouched. See androidSafeSnapPoints.
   const effectiveSnapPoints = useMemo(() => androidSafeSnapPoints(snapPoints), [snapPoints]);
 
   const sheetRef = useRef<BottomSheetMethods>(null);

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -77,7 +77,11 @@ type SheetProps = {
    * the form under the footer at all (#4723). Content-fitting closes both. The
    * column takes a `maxHeight` ceiling (see `useSheetColumnStyle`) so a
    * keyboard-up long note still scrolls under the footer rather than clipping.
-   * No effect on iOS / web — they keep the exact `%` detents. */
+   * No effect on iOS / web — they keep the exact `%` detents.
+   *
+   * Designed for a sheet with a `header` / `footer` (the `maxHeight` lands on the
+   * KeyboardAvoidingView). A chrome-less sheet has no reason to reach for it —
+   * pass `enableDynamicSizing` instead. */
   androidContentSized?: boolean;
 };
 
@@ -109,11 +113,12 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
   const solidBackground = useMemo(() => ({ backgroundColor: sheetSurface }), [sheetSurface]);
 
   // On Android, `androidContentSized` swaps the `%` detents for `@expo/ui`'s
-  // content-fitting path — no snap points reach the native sheet, so this only
-  // pads a SMALL single detent to give Android a partial state (see
-  // androidSafeSnapPoints), and passes iOS / web through untouched.
+  // content-fitting path (no snap points at all reach the native sheet).
   const contentSizedOnAndroid = androidContentSized && Platform.OS === 'android';
   const useContentFitting = enableDynamicSizing || contentSizedOnAndroid;
+  // Consumed only on the detent path below (`useContentFitting` false): pads a
+  // SMALL single detent to give Android a partial state, passes iOS / web
+  // through untouched. See androidSafeSnapPoints.
   const effectiveSnapPoints = useMemo(() => androidSafeSnapPoints(snapPoints), [snapPoints]);
 
   const sheetRef = useRef<BottomSheetMethods>(null);

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -69,11 +69,16 @@ type SheetProps = {
   /** Optional fixed header, rendered above the body and outside its scroll — so a
    * title and close affordance stay put while the body scrolls. */
   header?: ReactNode;
-  /** Collapses to a single, expanded-only detent on Android instead of the usual
-   * multi-detent config, so a pinned footer never strands below Android's ~50%
-   * partial state (#4723). See `androidSafeSnapPoints` for the full rationale;
-   * no effect on iOS/web, or on a single detent already at/above 75%. */
-  androidOpensExpanded?: boolean;
+  /** Size the sheet to its content on Android via `@expo/ui`'s content-fitting
+   * path (`enableDynamicSizing` + no snap points) instead of the `%` detents.
+   * For a multi-detent form whose pinned footer only fits at the last detent
+   * (the tick sheets): a near-full single detent there strands the footer under
+   * ~310 dp of empty sheet (#4720), and Android's ~50% partial state can't fit
+   * the form under the footer at all (#4723). Content-fitting closes both. The
+   * column takes a `maxHeight` ceiling (see `useSheetColumnStyle`) so a
+   * keyboard-up long note still scrolls under the footer rather than clipping.
+   * No effect on iOS / web — they keep the exact `%` detents. */
+  androidContentSized?: boolean;
 };
 
 export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
@@ -93,7 +98,7 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
     surface = 'glass',
     footerSurface = 'plate',
     header,
-    androidOpensExpanded = false,
+    androidContentSized = false,
   },
   ref,
 ) {
@@ -102,12 +107,14 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
   const snapPoints = useMemo(() => customSnapPoints ?? ['50%', '90%'], [customSnapPoints]);
   // Plain string, never a PlatformColor — see the `surface` prop doc.
   const solidBackground = useMemo(() => ({ backgroundColor: sheetSurface }), [sheetSurface]);
-  // See `androidOpensExpanded` above: collapses to the single LAST detent on
-  // Android instead of picking an index into a multi-detent config.
-  const effectiveSnapPoints = useMemo(
-    () => androidSafeSnapPoints(snapPoints, androidOpensExpanded),
-    [snapPoints, androidOpensExpanded],
-  );
+
+  // On Android, `androidContentSized` swaps the `%` detents for `@expo/ui`'s
+  // content-fitting path — no snap points reach the native sheet, so this only
+  // pads a SMALL single detent to give Android a partial state (see
+  // androidSafeSnapPoints), and passes iOS / web through untouched.
+  const contentSizedOnAndroid = androidContentSized && Platform.OS === 'android';
+  const useContentFitting = enableDynamicSizing || contentSizedOnAndroid;
+  const effectiveSnapPoints = useMemo(() => androidSafeSnapPoints(snapPoints), [snapPoints]);
 
   const sheetRef = useRef<BottomSheetMethods>(null);
   const managed = useManagedSheet({
@@ -124,7 +131,7 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
 
   // Track the resting detent so the iOS column bound follows drags between detents.
   const [activeIndex, setActiveIndex] = useState(0);
-  const columnStyle = useSheetColumnStyle(snapPoints, { enableDynamicSizing, activeIndex });
+  const columnStyle = useSheetColumnStyle(snapPoints, { enableDynamicSizing, activeIndex, contentSizedOnAndroid });
   // Dev-only observers for #3922 — they feed a log line, never layout.
   const { probeProps, sentinelProps, onColumnLayout } = useSheetDetentProbe(columnStyle, 'Sheet');
 
@@ -156,7 +163,12 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
   // itself is the child, so it carries the bound directly — otherwise an iOS
   // scrollable sheet sizes to its content and anything past the detent is
   // clipped and unreachable instead of scrolling.
-  const bodyStyle = hasChrome ? styles.content : columnStyle;
+  //
+  // On Android's content-fitting path the KAV takes a `maxHeight`, not `flex: 1`,
+  // so the body can't `flex: 1` into it — it takes its content height at rest
+  // (this is what closes the void) and `flexShrink: 1` so it shrinks and scrolls
+  // once a keyboard-up long note pushes the column into that ceiling.
+  const bodyStyle = hasChrome ? (contentSizedOnAndroid ? styles.contentShrink : styles.content) : columnStyle;
   // Without a pinned footer the body sits against the bottom edge, so it has to
   // clear the Android edge-to-edge navigation bar itself — the native sheet does
   // not pad content for it. With a footer the body scrolls above the footer, which
@@ -181,7 +193,7 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
     >
       {children}
     </BottomSheetScrollView>
-  ) : enableDynamicSizing && !hasChrome && Platform.OS === 'web' ? (
+  ) : useContentFitting && !hasChrome && Platform.OS === 'web' ? (
     // Web + dynamic sizing only, where the column is never bounded and the
     // #3922 probe stays idle — so there is nothing to measure here.
     <BottomSheetView style={[bodyStyle, bodyContentContainerStyle]}>{children}</BottomSheetView>
@@ -210,8 +222,8 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
     <BottomSheet
       ref={sheetRef}
       index={-1}
-      snapPoints={enableDynamicSizing ? undefined : effectiveSnapPoints}
-      enableDynamicSizing={enableDynamicSizing}
+      snapPoints={useContentFitting ? undefined : effectiveSnapPoints}
+      enableDynamicSizing={useContentFitting}
       enablePanDownToClose={enablePanDownToClose}
       onChange={handleChange}
       onFullyDismissed={managed.onFullyDismissed}
@@ -228,9 +240,10 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
       {hasChrome ? (
         // The single flex child of the native sheet: bound to the detent height on
         // iOS (see useSheetColumnStyle) so the pinned footer can't fall off-screen
-        // (#3330); flex:1 on Android / fitToContents. `padding` on both platforms:
-        // the Android Compose dialog window does not resize for the keyboard, so
-        // without it the keyboard covers the footer's input (emulator-verified).
+        // (#3330); flex:1 on Android's detent path; a `maxHeight` ceiling on its
+        // content-fitting path (#4720). `padding` on both platforms: the Android
+        // Compose dialog window does not resize for the keyboard, so without it
+        // the keyboard covers the footer's input (emulator-verified).
         <KeyboardAvoidingView style={columnStyle} behavior="padding" onLayout={onColumnLayout}>
           {header}
           {body}
@@ -259,6 +272,11 @@ const styles = StyleSheet.create({
   },
   content: {
     flex: 1,
+  },
+  // Android content-fitting path: content height at rest (closes the void),
+  // shrinks to scroll when a keyboard-up long note fills the column's ceiling.
+  contentShrink: {
+    flexShrink: 1,
   },
   footer: {
     paddingHorizontal: spacing[4],

--- a/packages/mobile/src/components/__tests__/log-ascent-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/log-ascent-sheet.test.tsx
@@ -427,11 +427,16 @@ describe('LogAscentSheet detent bound', () => {
     expect(columnStyle(container)).toEqual({ height: 484 });
   });
 
-  it('leaves the column flexing on Android, where the Material sheet bounds it natively', () => {
+  it('caps the column at window − topInset − chrome on Android (content-fitting path, #4720)', () => {
+    // `androidContentSized` drops the `%` detents on Android and hosts the form
+    // in a `matchContents` RNHostView. A `flex: 1` column resolves to zero there,
+    // so the column takes a `maxHeight` ceiling instead — the form measures
+    // itself under it, and a keyboard-up long note shrink-scrolls into it.
+    // round(844 − 44 − 20) = 780.
     platformMock.OS = 'android';
     const { container } = renderSheet();
 
-    expect(columnStyle(container)).toEqual({ flex: 1 });
+    expect(columnStyle(container)).toEqual({ maxHeight: 780 });
   });
 
   it('renders the fields inside the sheet body, above the pinned action bar', () => {

--- a/packages/mobile/src/components/__tests__/modal-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/modal-sheet.test.tsx
@@ -6,17 +6,32 @@ import { createElement, forwardRef, type ReactNode, type Ref } from 'react';
 const captures = vi.hoisted(() => ({
   bottomSheetViewUsed: false,
   scrollUsed: false,
+  snapPoints: undefined as unknown,
+  enableDynamicSizing: undefined as unknown,
+  scrollStyle: undefined as unknown,
 }));
 const platform = vi.hoisted(() => ({ os: 'ios' }));
 
 type ViewMockProps = { children?: ReactNode };
 
 vi.mock('@expo/ui/community/bottom-sheet', () => ({
-  BottomSheetModal: forwardRef(({ children }: ViewMockProps, ref: Ref<unknown>) =>
-    createElement('div', { 'data-sheet': 'true', ref }, children),
+  BottomSheetModal: forwardRef(
+    (
+      {
+        children,
+        snapPoints,
+        enableDynamicSizing,
+      }: ViewMockProps & { snapPoints?: unknown; enableDynamicSizing?: unknown },
+      ref: Ref<unknown>,
+    ) => {
+      captures.snapPoints = snapPoints;
+      captures.enableDynamicSizing = enableDynamicSizing;
+      return createElement('div', { 'data-sheet': 'true', ref }, children);
+    },
   ),
-  BottomSheetScrollView: ({ children }: ViewMockProps) => {
+  BottomSheetScrollView: ({ children, style }: ViewMockProps & { style?: unknown }) => {
     captures.scrollUsed = true;
+    captures.scrollStyle = style;
     return createElement('div', { 'data-scroll': 'true' }, children);
   },
   BottomSheetView: ({ children }: ViewMockProps) => {
@@ -95,6 +110,9 @@ import { ModalSheet } from '../ModalSheet';
 beforeEach(() => {
   captures.bottomSheetViewUsed = false;
   captures.scrollUsed = false;
+  captures.snapPoints = undefined;
+  captures.enableDynamicSizing = undefined;
+  captures.scrollStyle = undefined;
   platform.os = 'ios';
 });
 
@@ -137,5 +155,29 @@ describe('ModalSheet', () => {
       </ModalSheet>,
     );
     expect(captures.bottomSheetViewUsed).toBe(false);
+  });
+
+  describe('androidContentSized (#4720)', () => {
+    it('drops the snap points for the content-fitting path on Android', () => {
+      platform.os = 'android';
+      render(
+        <ModalSheet androidContentSized snapPoints={['65%', '92%']} scrollable footer={<div>save</div>}>
+          <div>body</div>
+        </ModalSheet>,
+      );
+      expect(captures.snapPoints).toBeUndefined();
+      expect(captures.enableDynamicSizing).toBe(true);
+      expect(captures.scrollStyle).toEqual({ flexShrink: 1 });
+    });
+
+    it('keeps the exact detents on iOS regardless of the flag', () => {
+      render(
+        <ModalSheet androidContentSized snapPoints={['65%', '92%']} scrollable footer={<div>save</div>}>
+          <div>body</div>
+        </ModalSheet>,
+      );
+      expect(captures.snapPoints).toEqual(['65%', '92%']);
+      expect(captures.enableDynamicSizing).toBe(false);
+    });
   });
 });

--- a/packages/mobile/src/components/__tests__/sheet-snap-points.test.ts
+++ b/packages/mobile/src/components/__tests__/sheet-snap-points.test.ts
@@ -50,41 +50,18 @@ describe('androidSafeSnapPoints (iOS passthrough)', () => {
   });
 });
 
-describe('androidSafeSnapPoints (androidOpensExpanded, Android)', () => {
+// `androidContentSized` sheets (the tick sheets) never reach here on Android —
+// `Sheet` / `ModalSheet` route them into `@expo/ui`'s content-fitting path with
+// NO snap points. `androidSafeSnapPoints` is only asked to pad a small single
+// detent; a multi-detent tick config that did reach it is passed through
+// untouched (it is never used on that path).
+describe('androidSafeSnapPoints (content-fitting sheets are handled upstream)', () => {
   beforeEach(() => {
     platform.OS = 'android';
   });
 
-  it('collapses a multi-detent sheet to its single last detent when opted in', () => {
-    expect(androidSafeSnapPoints(['50%', '90%'], true)).toEqual(['90%']);
-    expect(androidSafeSnapPoints(['20%', '50%', '90%'], true)).toEqual(['90%']);
-  });
-
-  it('leaves a multi-detent sheet unchanged when not opted in', () => {
-    expect(androidSafeSnapPoints(['50%', '90%'], false)).toEqual(['50%', '90%']);
-  });
-
-  it('leaves an already single-detent sheet unchanged when opted in', () => {
-    expect(androidSafeSnapPoints(['90%'], true)).toEqual(['90%']);
-  });
-
-  it('does not fall through to the small-single-detent padding branch when opted in', () => {
-    expect(androidSafeSnapPoints(['65%'], true)).toEqual(['65%']);
-  });
-
-  it('collapses a multi-detent sheet with numeric (px) detents to the last one', () => {
-    expect(androidSafeSnapPoints([300, 600], true)).toEqual([600]);
-  });
-});
-
-describe('androidSafeSnapPoints (androidOpensExpanded, iOS/web passthrough)', () => {
-  it('leaves a multi-detent sheet unchanged on iOS, regardless of the opt-in', () => {
-    platform.OS = 'ios';
-    expect(androidSafeSnapPoints(['50%', '90%'], true)).toEqual(['50%', '90%']);
-  });
-
-  it('leaves a multi-detent sheet unchanged on web, regardless of the opt-in', () => {
-    platform.OS = 'web';
-    expect(androidSafeSnapPoints(['50%', '90%'], true)).toEqual(['50%', '90%']);
+  it('passes a multi-detent tick config through untouched', () => {
+    expect(androidSafeSnapPoints(['65%', '92%'])).toEqual(['65%', '92%']);
+    expect(androidSafeSnapPoints(['80%', '92%'])).toEqual(['80%', '92%']);
   });
 });

--- a/packages/mobile/src/components/__tests__/sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/sheet.test.tsx
@@ -11,6 +11,7 @@ import { createElement, forwardRef, type ReactNode, type Ref } from 'react';
 const captures = vi.hoisted(() => ({
   onChange: null as null | ((index: number) => void),
   snapPoints: undefined as unknown,
+  enableDynamicSizing: undefined as unknown,
   scrollUsed: false,
   bottomSheetViewUsed: false,
   scrollStyle: undefined as unknown,
@@ -32,14 +33,16 @@ type SheetMockProps = {
   children?: ReactNode;
   onChange?: (index: number) => void;
   snapPoints?: unknown;
+  enableDynamicSizing?: unknown;
 };
 type ViewMockProps = { children?: ReactNode };
 
 // The native Expo drop-in: a passthrough that captures the props Sheet sets.
 vi.mock('@expo/ui/community/bottom-sheet', () => ({
-  default: forwardRef(({ children, onChange, snapPoints }: SheetMockProps, ref: Ref<unknown>) => {
+  default: forwardRef(({ children, onChange, snapPoints, enableDynamicSizing }: SheetMockProps, ref: Ref<unknown>) => {
     captures.onChange = onChange ?? null;
     captures.snapPoints = snapPoints;
+    captures.enableDynamicSizing = enableDynamicSizing;
     return createElement('div', { 'data-sheet': 'true', ref }, children);
   }),
   BottomSheetScrollView: ({
@@ -144,6 +147,7 @@ import { Sheet } from '../Sheet';
 beforeEach(() => {
   captures.onChange = null;
   captures.snapPoints = undefined;
+  captures.enableDynamicSizing = undefined;
   captures.scrollUsed = false;
   captures.bottomSheetViewUsed = false;
   captures.scrollStyle = undefined;
@@ -276,6 +280,39 @@ describe('Sheet', () => {
       </Sheet>,
     );
     expect(flattenStyle(captures.viewStyle).paddingBottom).toBe(42);
+  });
+
+  describe('androidContentSized', () => {
+    it('drops the snap points for the content-fitting path on Android (#4720)', () => {
+      platform.os = 'android';
+      render(
+        <Sheet androidContentSized snapPoints={['80%', '92%']} scrollable footer={<div>save</div>}>
+          <div>body</div>
+        </Sheet>,
+      );
+      expect(captures.snapPoints).toBeUndefined();
+      expect(captures.enableDynamicSizing).toBe(true);
+    });
+
+    it('lets the scroll body shrink-to-scroll instead of flex-filling on that path', () => {
+      platform.os = 'android';
+      render(
+        <Sheet androidContentSized snapPoints={['80%', '92%']} scrollable footer={<div>save</div>}>
+          <div>body</div>
+        </Sheet>,
+      );
+      expect(flattenStyle(captures.scrollStyle)).toEqual({ flexShrink: 1 });
+    });
+
+    it('keeps the exact detents on iOS regardless of the flag', () => {
+      render(
+        <Sheet androidContentSized snapPoints={['80%', '92%']} scrollable footer={<div>save</div>}>
+          <div>body</div>
+        </Sheet>,
+      );
+      expect(captures.snapPoints).toEqual(['80%', '92%']);
+      expect(captures.enableDynamicSizing).toBe(false);
+    });
   });
 
   it('fires a haptic and onChange only when the sheet opens (index >= 0)', () => {

--- a/packages/mobile/src/components/__tests__/use-sheet-column-style.test.tsx
+++ b/packages/mobile/src/components/__tests__/use-sheet-column-style.test.tsx
@@ -83,4 +83,20 @@ describe('useSheetColumnStyle', () => {
     const { result } = renderHook(() => useSheetColumnStyle(['90%']));
     expect(result.current).toEqual(FILL);
   });
+
+  it('caps the Android column at window − topInset − chrome on the content-fitting path (#4720)', () => {
+    // A `flex: 1` column resolves to zero inside a `matchContents` RNHostView, so
+    // the content-fitting path takes a `maxHeight` ceiling instead — the form
+    // measures under it, a keyboard-up long note shrink-scrolls into it.
+    // round(844 − 44 − 20) = 780.
+    platformMock.OS = 'android';
+    const { result } = renderHook(() => useSheetColumnStyle(['65%', '92%'], { contentSizedOnAndroid: true }));
+    expect(result.current).toEqual({ maxHeight: 780 });
+  });
+
+  it('ignores contentSizedOnAndroid on iOS (detents still win there)', () => {
+    const { result } = renderHook(() => useSheetColumnStyle(['90%'], { contentSizedOnAndroid: true }));
+    // round(776 × 0.9) − 20 = 678, exactly as without the flag.
+    expect(result.current).toEqual({ height: 678 });
+  });
 });

--- a/packages/mobile/src/components/sheet-snap-points.ts
+++ b/packages/mobile/src/components/sheet-snap-points.ts
@@ -21,29 +21,18 @@ const ANDROID_NEAR_FULL_DETENT_PERCENT = 75;
  * expanded state is the right match, so it's left unchanged. Multi-detent sheets
  * already have a partial state, and non-% (px) detents are left as-is.
  *
- * `androidOpensExpanded` (a multi-detent sheet whose pinned footer only fits at
- * its LAST detent, e.g. the tick sheets, #4723) collapses to that single last
- * detent on Android — not "keep both detents and pick the last index at
- * present-time", which depends on an `@expo/ui` Android `expand()` call the
- * library's own `ModalBottomSheetView.kt` can silently no-op ("Expanded anchor
- * may be unreachable"). A single detent removes "partial" as a resting state
- * entirely, so the sheet can only land on Expanded. This check runs BEFORE the
- * small-single-detent padding below: without that ordering, an opted-in sheet
- * with one detent under 75% would fall into the padding branch and come back
- * out with a "partial" resting state again — exactly what the opt-in exists to
- * remove.
+ * A sheet whose form only fits under a pinned footer at its LAST detent (the tick
+ * sheets, #4723) does NOT come through here at all on Android — `Sheet` /
+ * `ModalSheet` route it into `@expo/ui`'s content-fitting path instead (see
+ * `androidContentSized`), which sizes the sheet to the form and closes the
+ * ~310 dp void a single near-full detent left below it (#4720).
  *
- * The added/removed values are ignored on Android (only partial/expanded exist),
- * and this keeps the body's flex layout intact (unlike switching to fit-to-content,
- * which can collapse a scrollable body). iOS / web honour the exact detents via
+ * The added values are ignored on Android (only partial/expanded exist), and this
+ * keeps the body's flex layout intact. iOS / web honour the exact detents via
  * SwiftUI / CSS, so they're returned unchanged.
  */
-export function androidSafeSnapPoints(
-  snapPoints: (string | number)[],
-  androidOpensExpanded = false,
-): (string | number)[] {
+export function androidSafeSnapPoints(snapPoints: (string | number)[]): (string | number)[] {
   if (Platform.OS !== 'android') return snapPoints;
-  if (androidOpensExpanded) return [snapPoints[snapPoints.length - 1]];
   if (snapPoints.length !== 1) return snapPoints;
   const only = snapPoints[0];
   const percent = typeof only === 'string' && only.trim().endsWith('%') ? parseFloat(only) : null;

--- a/packages/mobile/src/components/tick/tick-sheet-metrics.ts
+++ b/packages/mobile/src/components/tick/tick-sheet-metrics.ts
@@ -61,7 +61,9 @@ export const TICK_STACK_FONT_SCALE = 1.3;
 export const TICK_COUNT_RAIL_MIN_CHIPS = 15;
 
 /**
- * Create sheet detents.
+ * Create sheet detents. iOS / web only — Android takes `@expo/ui`'s
+ * content-fitting path (`androidContentSized` on `ModalSheet`, #4720) and never
+ * reads these values.
  *
  * Column: header 56 + rows (date 56 + grade 60 + stars 56 + tries 60 + note 68
  * = 300) + footer (paddingTop 12 + error slot 18 + gap 8 + button 56 +
@@ -80,7 +82,8 @@ export const TICK_COUNT_RAIL_MIN_CHIPS = 15;
 export const CREATE_TICK_SNAP_POINTS = ['65%', '92%'];
 
 /**
- * Edit sheet detents.
+ * Edit sheet detents. iOS / web only — Android takes the content-fitting path
+ * (`androidContentSized`, #4720).
  *
  * Column: header 56 + rows (status 56 + date 56 + grade 60 + angle 64 + stars
  * 56 + tries 60 + note 68 = 420) + delete group (spacing[8] 32 + 56 = 88) +

--- a/packages/mobile/src/components/use-sheet-column-style.ts
+++ b/packages/mobile/src/components/use-sheet-column-style.ts
@@ -32,6 +32,12 @@ type SheetColumnStyleOptions = {
   /** The detent the sheet is currently resting at (from the native `onChange`
    * index). Drives the height when a sheet has multiple `%` detents. */
   activeIndex?: number;
+  /** The sheet is on `@expo/ui`'s Android content-fitting path (see
+   * `androidContentSized` on `Sheet` / `ModalSheet`). The column then carries a
+   * `maxHeight` — not `flex: 1`, which collapses to nothing under a `matchContents`
+   * host — so the sheet sizes to the form yet a keyboard-up long note still
+   * scrolls under the pinned footer instead of clipping (#4720). */
+  contentSizedOnAndroid?: boolean;
 };
 
 /**
@@ -47,16 +53,25 @@ type SheetColumnStyleOptions = {
  * the literal sheet height. The `SHEET_TOP_CHROME_PT` margin covers the
  * drag-indicator chrome, erring short.
  *
- * Android's Material sheet bounds the column natively, and fitToContents sheets
- * are measured natively too, so both keep `flex: 1`.
+ * Android's Material sheet bounds the column natively, so it keeps `flex: 1` —
+ * EXCEPT on the content-fitting path (`contentSizedOnAndroid`), where the native
+ * `RNHostView` forces the Compose node to the RN child's measured height: a
+ * `flex: 1` child there resolves to zero, so the column instead takes a
+ * `maxHeight` of `window − topInset − chrome` and lets its body shrink-and-scroll
+ * into that ceiling.
  */
 export function useSheetColumnStyle(
   snapPoints: (string | number)[] | undefined,
-  { enableDynamicSizing = false, activeIndex = 0 }: SheetColumnStyleOptions = {},
+  { enableDynamicSizing = false, activeIndex = 0, contentSizedOnAndroid = false }: SheetColumnStyleOptions = {},
 ): ViewStyle {
   const { height: windowHeight } = useWindowDimensions();
   const insets = useSafeAreaInsets();
   return useMemo<ViewStyle>(() => {
+    if (Platform.OS === 'android') {
+      return contentSizedOnAndroid
+        ? { maxHeight: Math.round(windowHeight - insets.top - SHEET_TOP_CHROME_PT) }
+        : fillStyle;
+    }
     if (Platform.OS !== 'ios' || enableDynamicSizing || !snapPoints || snapPoints.length === 0) {
       return fillStyle;
     }
@@ -66,7 +81,7 @@ export function useSheetColumnStyle(
     const topGapPt = parseInt(String(Platform.Version), 10) >= 26 ? SHEET_TOP_GAP_PT : 0;
     const height = detentColumnHeight(snapPoints[index], windowHeight, insets.top, topGapPt);
     return height == null ? fillStyle : { height };
-  }, [snapPoints, enableDynamicSizing, activeIndex, windowHeight, insets.top]);
+  }, [snapPoints, enableDynamicSizing, activeIndex, windowHeight, insets.top, contentSizedOnAndroid]);
 }
 
 function detentColumnHeight(

--- a/packages/mobile/src/components/you/LogbookEditSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookEditSheet.tsx
@@ -229,9 +229,9 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
       surface="solid"
       footerSurface="flush"
       // See the identical fix on the create-tick sheet (`LogAscentSheet`,
-      // #4723): the edit sheet has the same pinned-footer-under-Android's-
-      // partial-state shape, so it gets the same opt-in.
-      androidOpensExpanded
+      // #4723 / #4720): the edit sheet has the same pinned-footer-over-a-tall-
+      // form shape, so it gets the same Android content-fitting opt-in.
+      androidContentSized
       onClose={onClose}
       header={
         <TickSheetHeader

--- a/packages/mobile/src/components/you/LogbookTab.tsx
+++ b/packages/mobile/src/components/you/LogbookTab.tsx
@@ -360,9 +360,8 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true }: Logbo
     setEditAscent(ascent);
     // Pin to the first detent explicitly rather than `present()`, which reopens
     // at whatever detent the sheet last rested at (sticky across opens on iOS).
-    // Android's Expanded state is deterministic either way — `androidOpensExpanded`
-    // collapses EDIT_TICK_SNAP_POINTS to a single detent there, so index 0 IS
-    // that detent.
+    // Android is deterministic either way — `androidContentSized` gives the edit
+    // sheet one content-fitted state there, so index 0 IS that state.
     editSheetRef.current?.snapToIndex(0);
   }, []);
 

--- a/packages/mobile/src/components/you/__tests__/logbook-edit-sheet.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/logbook-edit-sheet.test.tsx
@@ -19,6 +19,12 @@ const nativePlatform = vi.hoisted(() => ({
   OS: 'ios' as 'ios' | 'android',
 }));
 
+// What the edit sheet hands its `Sheet` chrome — asserted so the Android
+// content-fitting opt-in (#4720) can't be dropped silently.
+const sheetProps = vi.hoisted(() => ({
+  androidContentSized: undefined as boolean | undefined,
+}));
+
 const toast = vi.hoisted(() => ({
   showToast: vi.fn(),
 }));
@@ -99,8 +105,20 @@ vi.mock('../../../providers/dialog-provider', () => ({
   useConfirm: () => () => Promise.resolve(true),
 }));
 vi.mock('../../Sheet', () => ({
-  Sheet: ({ children, header, footer }: { children?: ReactNode; header?: ReactNode; footer?: ReactNode }) =>
-    createElement('div', null, header, children, footer),
+  Sheet: ({
+    children,
+    header,
+    footer,
+    androidContentSized,
+  }: {
+    children?: ReactNode;
+    header?: ReactNode;
+    footer?: ReactNode;
+    androidContentSized?: boolean;
+  }) => {
+    sheetProps.androidContentSized = androidContentSized;
+    return createElement('div', null, header, children, footer);
+  },
 }));
 vi.mock('../../Button', () => ({
   Button: ({ title, onPress, disabled }: { title: string; onPress: () => void; disabled?: boolean }) =>
@@ -277,6 +295,7 @@ function expectClimbedAtIso(isoTimestamp: string | undefined, expectedDate: Date
 
 beforeEach(() => {
   nativePlatform.OS = 'ios';
+  sheetProps.androidContentSized = undefined;
   pickerSelections.date = new Date(2026, 0, 9, 0, 0, 0, 0);
   pickerSelections.time = new Date(2026, 0, 9, 20, 15, 0, 0);
   dateTimePickerAndroid.open.mockClear();
@@ -290,6 +309,11 @@ afterEach(() => {
 });
 
 describe('LogbookEditSheet', () => {
+  it('opts the sheet into Android content-fitting so the form is not lost in a full-screen sheet (#4720)', () => {
+    renderSheet();
+    expect(sheetProps.androidContentSized).toBe(true);
+  });
+
   it('saves the selected local date and time as an ISO timestamp', () => {
     renderSheet();
 


### PR DESCRIPTION
## Summary

On Android the create-tick sheet (`LogAscentSheet`) and edit-tick sheet (`LogbookEditSheet`)
opened ~310 dp taller than their content — a short form floating in a slab of empty violet
above the pinned Attempt/Send bar, so the two footer buttons read as orphaned rather than
pinned.

Cause: `androidOpensExpanded` collapsed those sheets to a single `['92%']` detent on Android.
`@expo/ui`'s Material `ModalBottomSheet` never reads the `%` value for a single detent — it
just fills the screen — and the content-fitting host (`RNHostView matchContents`) only turns on
with `enableDynamicSizing` **and** no snap points, which that path never had.

This routes the two sheets into that content-fitting path on Android instead, so the sheet
sizes to the form. iOS and web are untouched — they keep the exact `65%`/`92%` and `80%`/`92%`
detents and the `useSheetColumnStyle` bound.

Two guards keep a scroll body safe under `matchContents` — the failure the old
`androidSafeSnapPoints` comment warned content-fitting would cause:

- The sheet's single flex child takes a `maxHeight` of `window − topInset − chrome`, not
  `flex: 1` (which resolves to zero when the native side forces the Compose node to the RN
  child's measured height). At rest it measures to the form; a keyboard-up long note pushes it
  into that ceiling.
- The scroll body takes `flexShrink: 1`, not `flex: 1` — content height at rest (this is what
  closes the void), then shrinks-and-scrolls once the column hits its ceiling, so the footer
  stays pinned above the keyboard rather than the note clipping.

`skipPartiallyExpanded` still comes for free on this path, so the ~50% partial-state footer
trap of #4723 stays closed. Prop renamed `androidOpensExpanded` → `androidContentSized`.

Closes #4720.

### Verification

- `vp run typecheck:mobile`, `vp run test:mobile` (7091 pass), `vp check`,
  `vp run check:mobile-bundle` — all green.
- Unit coverage added/updated: `sheet.test.tsx`, `modal-sheet.test.tsx`,
  `use-sheet-column-style.test.tsx`, `log-ascent-sheet.test.tsx`, `sheet-snap-points.test.ts`.
- **Android emulator QA is still pending** — this dev box is Apple Silicon with no x86_64
  Android emulator, and the fix can't be seen on iOS (unchanged there by design). The layout
  is reasoned from the vendored `@expo/ui` Kotlin/TS source, but the `matchContents`
  measurement is a genuine device gate (#3330 is the iOS-side precedent). Test plan below is
  the emulator checklist.

## Release Notes

- On Android, the tick sheet now opens at the height of the form instead of a near-full sheet with a slab of empty space under the buttons.

## Test plan

1. Android. Open a climb, tap the tick button.
2. Sheet rests at the form height — no big gap above Attempt/Send.
3. Tap the note field. Form scrolls, Attempt/Send stays above the keyboard.
4. Type ~10 lines. Note grows, then the body scrolls; nothing below the footer clips.
5. You tab → Logbook → swipe a tick → edit sheet: same, delete row reachable, Save pinned.

## Risk

Risk: 3/5 — shared sheet primitives (`Sheet` / `ModalSheet` / `useSheetColumnStyle`) used by every bottom sheet; change is Android-only and behind an opt-in prop, iOS/web paths byte-identical, but the `@expo/ui` content-fitting measurement needs on-device confirmation.
