### PR TITLE
fix(mobile): tap-cycle a hold only when continuing or capped, skip full roles

### DIFF
--- a/packages/mobile/src/components/create-climb/__tests__/brush-roles.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/brush-roles.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { BoardName } from '@boardsesh/shared-schema';
-import { brushRoleColor, getNextBrushRole, getPaintRoles } from '../brush-roles';
+import type { BoardName, LitUpHoldsMap } from '@boardsesh/shared-schema';
+import { brushRoleColor, computeRoleCapacity, getNextBrushRole, getPaintRoles } from '../brush-roles';
 
 describe('getPaintRoles', () => {
   it('excludes FOOT for MoonBoard saved-climb roles', () => {
@@ -62,5 +62,40 @@ describe('getNextBrushRole', () => {
   it('clears a hold in an unrecognised state instead of throwing', () => {
     expect(() => getNextBrushRole('not-a-board' as BoardName, 'OFF', 'HAND')).not.toThrow();
     expect(getNextBrushRole('not-a-board' as BoardName, 'OFF', 'HAND')).toBe('OFF');
+  });
+
+  it('skips a full role and lands on the next open one', () => {
+    // STARTING full, cycle from FOOT would normally land on STARTING next.
+    expect(getNextBrushRole('kilter', 'FOOT', 'HAND', { STARTING: true })).toBe('OFF');
+  });
+
+  it('skips every full role in a row, not just the first', () => {
+    // Starts and finishes both full, campus (no feet) active: from HAND the
+    // only open destination left is OFF.
+    expect(getNextBrushRole('kilter', 'HAND', 'HAND', { STARTING: true, FINISH: true, FOOT: true })).toBe('OFF');
+    // ...and tapping again from OFF comes back around to HAND, the one role
+    // that's never full — oscillating between hand hold and no hold.
+    expect(getNextBrushRole('kilter', 'OFF', 'HAND', { STARTING: true, FINISH: true, FOOT: true })).toBe('HAND');
+  });
+});
+
+describe('computeRoleCapacity', () => {
+  it('flags STARTING/FINISH full at two, excluding the tapped hold itself', () => {
+    const map: LitUpHoldsMap = {
+      1: { state: 'STARTING', color: '', displayColor: '' },
+      2: { state: 'STARTING', color: '', displayColor: '' },
+      3: { state: 'FINISH', color: '', displayColor: '' },
+    };
+    // Hold 1 is one of the two starts, but excluded from its own count — with
+    // only hold 2 left counting, STARTING has room for hold 1 to stay there.
+    expect(computeRoleCapacity(map, 1, false)).toEqual({ STARTING: false, FINISH: false, FOOT: false });
+    // A different, uninvolved hold sees both existing starts and is capped.
+    expect(computeRoleCapacity(map, 4, false)).toEqual({ STARTING: true, FINISH: false, FOOT: false });
+  });
+
+  it('caps FOOT at zero exactly when campus is on', () => {
+    const map: LitUpHoldsMap = {};
+    expect(computeRoleCapacity(map, 1, true)).toMatchObject({ FOOT: true });
+    expect(computeRoleCapacity(map, 1, false)).toMatchObject({ FOOT: false });
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-paint.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-paint.test.tsx
@@ -2,10 +2,11 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Drives handlePaint through the real getNextBrushRole/getPaintRoles (brush-roles
-// is intentionally left unmocked here) to pin the tap-to-cycle contract end to
-// end: a tap on a hold advances it through the board's paint roles starting at
-// the selected brush, while the eraser brush always clears.
+// Drives handlePaint through the real getNextBrushRole/getPaintRoles/computeRoleCapacity
+// (brush-roles is intentionally left unmocked here) to pin the tap-to-cycle
+// contract end to end: a first tap sets a hold straight to the selected brush;
+// only a repeat tap on the same hold under the same brush — or a brush whose
+// role has no room left — cycles it onward, and the eraser brush always clears.
 
 const board = vi.hoisted(() => ({
   isAuthenticated: true,
@@ -15,6 +16,8 @@ const board = vi.hoisted(() => ({
 const toast = vi.hoisted(() => ({ showToast: vi.fn() }));
 const queue = vi.hoisted(() => ({ setCurrentClimb: vi.fn() }));
 const router = vi.hoisted(() => ({ push: vi.fn() }));
+
+const DEFAULT_HOLDS = { 1: { state: 'STARTING' }, 2: { state: 'HAND' }, 3: { state: 'FINISH' } };
 
 const createClimb = vi.hoisted(() => ({
   litUpHoldsMap: { 1: { state: 'STARTING' }, 2: { state: 'HAND' }, 3: { state: 'FINISH' } },
@@ -118,6 +121,7 @@ const BOARD = {
 
 beforeEach(() => {
   createClimb.setHoldState.mockClear();
+  createClimb.litUpHoldsMap = DEFAULT_HOLDS;
 });
 
 describe('useCreateClimbScreen handlePaint (tap-to-cycle)', () => {
@@ -129,25 +133,64 @@ describe('useCreateClimbScreen handlePaint (tap-to-cycle)', () => {
     expect(createClimb.setHoldState).toHaveBeenCalledWith(4, 'HAND');
   });
 
-  it('cycles a painted hold to the next role after the selected brush', () => {
+  it('sets a pre-painted hold straight to a newly selected brush, without cycling', () => {
     const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
 
-    // Hold 1 is fixture-seeded as STARTING; the default brush is HAND, so the
-    // cycle order is HAND -> FINISH -> FOOT -> STARTING -> OFF.
+    // Hold 1 is fixture-seeded as STARTING; the default brush is HAND. The
+    // very first tap under this brush just reassigns the hold — it isn't the
+    // "last tapped hold under this brush" yet, and HAND is never full.
     act(() => result.current.handlePaint(1));
 
-    expect(createClimb.setHoldState).toHaveBeenCalledWith(1, 'OFF');
+    expect(createClimb.setHoldState).toHaveBeenLastCalledWith(1, 'HAND');
   });
 
-  it('restarts the cycle at the newly selected brush', () => {
+  it('cycles onward on a repeat tap of the same hold under the same brush', () => {
     const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
 
-    act(() => result.current.setSelectedBrush('FINISH'));
-    // Hold 3 is fixture-seeded as FINISH, which is now the cycle's start, so
-    // the next tap advances past it to FOOT.
+    act(() => result.current.handlePaint(1));
+    act(() => result.current.handlePaint(1));
+
+    // The mock setHoldState never mutates the fixture, so hold 1 still reads
+    // back as STARTING; a second tap under the same (still-selected) HAND
+    // brush recognises the repeat and cycles from there instead of
+    // re-confirming HAND — HAND -> FINISH -> FOOT -> STARTING -> OFF.
+    expect(createClimb.setHoldState).toHaveBeenLastCalledWith(1, 'OFF');
+  });
+
+  it('sets directly again after switching brushes, even on a hold mid-cycle', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+
+    act(() => result.current.handlePaint(1));
+    act(() => result.current.setSelectedBrush('FOOT'));
+    // Switching brushes breaks the "last tapped under this brush" chain, so
+    // this tap reassigns hold 1 straight to FOOT instead of resuming a cycle.
+    act(() => result.current.handlePaint(1));
+
+    expect(createClimb.setHoldState).toHaveBeenLastCalledWith(1, 'FOOT');
+  });
+
+  it('cycles on the very first tap when the selected brush is already at capacity', () => {
+    createClimb.litUpHoldsMap = { 1: { state: 'STARTING' }, 2: { state: 'STARTING' }, 3: { state: 'HAND' } };
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+
+    act(() => result.current.setSelectedBrush('STARTING'));
+    // Two starts are already placed, so setting hold 3 to a third start would
+    // silently no-op — cycle it onward instead.
     act(() => result.current.handlePaint(3));
 
-    expect(createClimb.setHoldState).toHaveBeenCalledWith(3, 'FOOT');
+    expect(createClimb.setHoldState).toHaveBeenLastCalledWith(3, 'FINISH');
+  });
+
+  it('skips FOOT while campus is enabled, landing on the next open role', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+
+    act(() => result.current.setCampus(true));
+    act(() => result.current.setSelectedBrush('FOOT'));
+    // Hold 4 is blank; a campus climb allows no feet, so the forced cycle
+    // skips FOOT and lands on the next role in rotation, STARTING.
+    act(() => result.current.handlePaint(4));
+
+    expect(createClimb.setHoldState).toHaveBeenLastCalledWith(4, 'STARTING');
   });
 
   it('always erases when the eraser brush is selected', () => {
@@ -157,6 +200,6 @@ describe('useCreateClimbScreen handlePaint (tap-to-cycle)', () => {
     // Hold 2 is fixture-seeded as HAND; the eraser brush never cycles.
     act(() => result.current.handlePaint(2));
 
-    expect(createClimb.setHoldState).toHaveBeenCalledWith(2, 'OFF');
+    expect(createClimb.setHoldState).toHaveBeenLastCalledWith(2, 'OFF');
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-paint.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-paint.test.tsx
@@ -122,6 +122,8 @@ const BOARD = {
 beforeEach(() => {
   createClimb.setHoldState.mockClear();
   createClimb.litUpHoldsMap = DEFAULT_HOLDS;
+  createClimb.currentFrameIndex = 0;
+  createClimb.frameCount = 1;
 });
 
 describe('useCreateClimbScreen handlePaint (tap-to-cycle)', () => {
@@ -201,5 +203,52 @@ describe('useCreateClimbScreen handlePaint (tap-to-cycle)', () => {
     act(() => result.current.handlePaint(2));
 
     expect(createClimb.setHoldState).toHaveBeenLastCalledWith(2, 'OFF');
+  });
+
+  it('a same-role first tap is a visible no-op, but the very next tap still cycles', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+
+    // Hold 2 is already HAND, and the default brush is HAND too — the first
+    // tap re-confirms the same role (a no-op paint), but it still counts as
+    // "the last tapped hold under this brush" for the tap that follows.
+    act(() => result.current.handlePaint(2));
+    expect(createClimb.setHoldState).toHaveBeenLastCalledWith(2, 'HAND');
+
+    act(() => result.current.handlePaint(2));
+    expect(createClimb.setHoldState).toHaveBeenLastCalledWith(2, 'FINISH');
+  });
+
+  it('handleAssignRole resets the cycle, so a follow-up tap sets directly', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+
+    act(() => result.current.handlePaint(1));
+    // The long-press role sheet is a direct assignment, not a tap.
+    act(() => result.current.handleAssignRole(1, 'FINISH'));
+    // Without the reset this would resume the HAND cycle instead of setting
+    // hold 1 straight to HAND again.
+    act(() => result.current.handlePaint(1));
+
+    expect(createClimb.setHoldState).toHaveBeenLastCalledWith(1, 'HAND');
+  });
+
+  it('handleClearHolds resets the cycle, so a follow-up tap sets directly', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+
+    act(() => result.current.handlePaint(1));
+    act(() => result.current.handleClearHolds());
+    act(() => result.current.handlePaint(1));
+
+    expect(createClimb.setHoldState).toHaveBeenLastCalledWith(1, 'HAND');
+  });
+
+  it('resets the cycle when the active frame changes', () => {
+    const { result, rerender } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+
+    act(() => result.current.handlePaint(1));
+    createClimb.currentFrameIndex = 1;
+    rerender();
+    act(() => result.current.handlePaint(1));
+
+    expect(createClimb.setHoldState).toHaveBeenLastCalledWith(1, 'HAND');
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-paint.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-paint.test.tsx
@@ -172,6 +172,20 @@ describe('useCreateClimbScreen handlePaint (tap-to-cycle)', () => {
     expect(createClimb.setHoldState).toHaveBeenLastCalledWith(1, 'FOOT');
   });
 
+  it('resumes the cycle on a hold if the brush round-trips back to it, untapped in between', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));
+
+    act(() => result.current.handlePaint(1)); // last-tapped: hold 1 under HAND
+    act(() => result.current.setSelectedBrush('FOOT')); // no tap under FOOT
+    act(() => result.current.setSelectedBrush('HAND')); // back to HAND, untapped
+    // Hold 1 is still "the last hold tapped under HAND" — the round trip
+    // through FOOT never tapped anything, so this resumes the cycle rather
+    // than re-confirming HAND.
+    act(() => result.current.handlePaint(1));
+
+    expect(createClimb.setHoldState).toHaveBeenLastCalledWith(1, 'OFF');
+  });
+
   it('cycles on the very first tap when the selected brush is already at capacity', () => {
     createClimb.litUpHoldsMap = { 1: { state: 'STARTING' }, 2: { state: 'STARTING' }, 3: { state: 'HAND' } };
     const { result } = renderHook(() => useCreateClimbScreen({ board: BOARD }));

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-paint.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-paint.test.tsx
@@ -153,9 +153,10 @@ describe('useCreateClimbScreen handlePaint (tap-to-cycle)', () => {
     act(() => result.current.handlePaint(1));
 
     // The mock setHoldState never mutates the fixture, so hold 1 still reads
-    // back as STARTING; a second tap under the same (still-selected) HAND
-    // brush recognises the repeat and cycles from there instead of
-    // re-confirming HAND — HAND -> FINISH -> FOOT -> STARTING -> OFF.
+    // back as its seeded STARTING on the second tap. Under the HAND brush the
+    // cycle order is HAND, FINISH, FOOT, STARTING, OFF — the repeat tap
+    // recognises hold 1 as "last tapped under this brush" and advances one
+    // step past STARTING, landing on OFF, instead of re-confirming HAND.
     expect(createClimb.setHoldState).toHaveBeenLastCalledWith(1, 'OFF');
   });
 

--- a/packages/mobile/src/components/create-climb/brush-roles.ts
+++ b/packages/mobile/src/components/create-climb/brush-roles.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { HOLD_STATE_MAP, STATE_TO_PRIMARY_CODE } from '@boardsesh/board-constants/hold-states';
-import type { BoardName, HoldState } from '@boardsesh/shared-schema';
+import type { BoardName, HoldState, LitUpHoldsMap } from '@boardsesh/shared-schema';
 import { getEffectiveHoldRoleColor, type HoldColorOverrides } from '../../lib/hold-color-overrides';
 
 // The four paintable roles plus the eraser. `'OFF'` clears a hold; the four
@@ -19,6 +19,30 @@ export function getPaintRoles(boardName: BoardName): ReadonlyArray<Exclude<Brush
   return PAINT_ROLES.filter((role) => supportedRoles?.[role] !== undefined);
 }
 
+/** Which paint roles currently have no room left, keyed by role (missing/false = open). */
+export type RoleCapacity = Partial<Record<Exclude<BrushRole, 'OFF'>, boolean>>;
+
+/**
+ * Capacity for the tapped hold's own board, excluding the tapped hold itself
+ * (it's about to be reassigned, so its current slot doesn't count against the
+ * role it's leaving). STARTING and FINISH cap at 2; FOOT caps at 0 — no feet
+ * allowed — while a "campus" climb is toggled on; HAND has no cap.
+ */
+export function computeRoleCapacity(litUpHoldsMap: LitUpHoldsMap, holdId: number, campus: boolean): RoleCapacity {
+  let startingCount = 0;
+  let finishCount = 0;
+  for (const [id, hold] of Object.entries(litUpHoldsMap)) {
+    if (Number(id) === holdId) continue;
+    if (hold.state === 'STARTING') startingCount += 1;
+    if (hold.state === 'FINISH') finishCount += 1;
+  }
+  return {
+    STARTING: startingCount >= 2,
+    FINISH: finishCount >= 2,
+    FOOT: campus,
+  };
+}
+
 /**
  * The role a tap should advance a hold to. Cycles through the board's paint
  * roles starting at the selected brush, then OFF, then back to the selected
@@ -26,19 +50,31 @@ export function getPaintRoles(boardName: BoardName): ReadonlyArray<Exclude<Brush
  * long-press sheet. The eraser brush ('OFF' selected) skips the cycle and
  * always clears, matching its role as a dedicated erase tool rather than a
  * cycle anchor.
+ *
+ * `atCapacity` (from {@link computeRoleCapacity}) makes the cycle skip a role
+ * that's already full — e.g. it never proposes a third start piece, and never
+ * proposes a foot piece on a "campus" climb — landing on the next open role
+ * instead. 'OFF' (no hold) never counts as full, so the loop always resolves
+ * by the time it gets there; the trailing return only satisfies the compiler.
  */
 export function getNextBrushRole(
   boardName: BoardName,
   currentState: HoldState | 'OFF',
   selectedBrush: BrushRole,
+  atCapacity: RoleCapacity = {},
 ): BrushRole {
   if (selectedBrush === 'OFF') return 'OFF';
   const supportedRoles = getPaintRoles(boardName);
   if (supportedRoles.length === 0) return 'OFF';
   const startIndex = Math.max(supportedRoles.indexOf(selectedBrush), 0);
   const cycle: BrushRole[] = [...supportedRoles.slice(startIndex), ...supportedRoles.slice(0, startIndex), 'OFF'];
-  const currentIndex = cycle.findIndex((role) => role === currentState);
-  return cycle[(currentIndex + 1) % cycle.length];
+  const anchor = cycle.findIndex((role) => role === currentState);
+  for (let step = 1; step <= cycle.length; step += 1) {
+    const candidate = cycle[(anchor + step) % cycle.length];
+    if (candidate === 'OFF' || !atCapacity[candidate]) return candidate;
+  }
+  // Unreachable: 'OFF' is always in `cycle` and never counts as full.
+  return anchor === -1 ? cycle[0] : cycle[anchor];
 }
 
 /**

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -40,7 +40,7 @@ import {
   isDraftStorageAvailable,
   type CreateClimbDraft,
 } from '../../lib/create-climb-draft-store';
-import { getNextBrushRole, getPaintRoles, type BrushRole } from './brush-roles';
+import { computeRoleCapacity, getNextBrushRole, getPaintRoles, type BrushRole } from './brush-roles';
 import { useCreateClimbAutosave } from './use-create-climb-autosave';
 import { deriveDraftStatusView, type DraftStatusView } from './draft-status-view';
 
@@ -651,16 +651,38 @@ export function useCreateClimbScreen({
   }, [holdsJson, bleConnected, currentFrameBleString]);
 
   // ---- Painting + role assignment. ----
-  // A tap cycles the tapped hold through the board's paint roles, starting
-  // from the currently selected brush, rather than always overwriting it with
-  // that brush — so fixing a mis-painted hold no longer requires a long press.
+  // A tap sets the tapped hold straight to the selected brush — cycling only
+  // kicks in when the tap can't just do that: re-tapping the same hold with
+  // the same brush still selected (so repeated taps walk the role list
+  // instead of re-confirming the first one over and over), or the brush's
+  // role has no room left (2 starts/finishes already placed, or a foot piece
+  // on a "campus" climb), where setting directly would silently no-op. Reset
+  // on any other tap — a different hold, or the same hold after switching
+  // brushes — so switching to Foot and tapping a start hold sets it to Foot
+  // outright rather than resuming wherever the last cycle left off.
+  const lastPaintRef = useRef<{ holdId: number; brush: BrushRole } | null>(null);
   const handlePaint = useCallback(
     (holdId: number) => {
       const currentState = litUpHoldsMap[holdId]?.state ?? 'OFF';
-      setHoldState(holdId, getNextBrushRole(board.boardName, currentState, selectedBrush));
+      const isContinuingCycle =
+        lastPaintRef.current?.holdId === holdId && lastPaintRef.current?.brush === selectedBrush;
+      const atCapacity = computeRoleCapacity(litUpHoldsMap, holdId, campus);
+      const brushAtCapacity = selectedBrush !== 'OFF' && !!atCapacity[selectedBrush];
+      const nextState =
+        isContinuingCycle || brushAtCapacity
+          ? getNextBrushRole(board.boardName, currentState, selectedBrush, atCapacity)
+          : selectedBrush;
+      setHoldState(holdId, nextState);
+      lastPaintRef.current = { holdId, brush: selectedBrush };
     },
-    [setHoldState, selectedBrush, litUpHoldsMap, board.boardName],
+    [setHoldState, selectedBrush, litUpHoldsMap, board.boardName, campus],
   );
+
+  // A hold-role cycle only makes sense while staying on the same frame —
+  // switching frames (nav, duplicate, delete) starts a fresh tapping context.
+  useEffect(() => {
+    lastPaintRef.current = null;
+  }, [currentFrameIndex, frameCount]);
 
   const handleAssignRole = useCallback(
     (holdId: number, role: BrushRole) => {
@@ -677,6 +699,7 @@ export function useCreateClimbScreen({
   /** Empty this frame's holds. Undoable through the reducer; touches nothing else. */
   const handleClearHolds = useCallback(() => {
     resetHolds();
+    lastPaintRef.current = null;
   }, [resetHolds]);
 
   const resetToBlankClimb = useCallback(async () => {
@@ -691,6 +714,7 @@ export function useCreateClimbScreen({
       if (!mountedRef.current) return;
       setPendingNewClimb(false);
       resetHolds();
+      lastPaintRef.current = null;
       setName('');
       setDescription('');
       setNoMatch(false);

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -664,6 +664,12 @@ export function useCreateClimbScreen({
   const handlePaint = useCallback(
     (holdId: number) => {
       const currentState = litUpHoldsMap[holdId]?.state ?? 'OFF';
+      // `lastPaintRef` itself is never cleared on a brush switch — only this
+      // equality check gates it — so tapping X under brush A, switching to
+      // brush B (without tapping), then switching back to A and tapping X
+      // again still counts as "last tapped under A" and resumes that cycle.
+      // Deliberate: it's still true that X is the last hold tapped while A was
+      // the active role.
       const isContinuingCycle =
         lastPaintRef.current?.holdId === holdId && lastPaintRef.current?.brush === selectedBrush;
       const atCapacity = computeRoleCapacity(litUpHoldsMap, holdId, campus);

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -687,6 +687,10 @@ export function useCreateClimbScreen({
   const handleAssignRole = useCallback(
     (holdId: number, role: BrushRole) => {
       setHoldState(holdId, role);
+      // The long-press role sheet is a direct assignment, not a tap — clear
+      // any in-progress cycle so a follow-up tap on this hold starts fresh
+      // instead of resuming wherever the sheet left it.
+      lastPaintRef.current = null;
     },
     [setHoldState],
   );


### PR DESCRIPTION
## Summary

- A tap on a hold in the climb editor used to always cycle its role, even on the very first tap under a newly-selected brush — so switching to a different brush and tapping an already-painted hold walked through every role before landing on the one you wanted, instead of just painting it.
- Cycling could also propose a role that was already full (a third start piece, or a foot piece on a "campus" climb) — `setHoldState`'s capacity guard would silently no-op that tap and the hold wouldn't visibly change.
- A tap now sets the hold straight to the selected brush. Cycling only kicks in on a **repeat** tap of the same hold under the same brush (so tapping again keeps walking the roles), or when the brush's role has **no room left** (so the tap does *something* instead of nothing). The cycle itself now skips any role that's already full and lands on the next open one.

## Release Notes

- Tapping a hold in the climb editor now paints it directly with your selected role. Tap the same hold again to cycle through the other roles, and the cycle skips roles that are already full (two starts, two finishes, or feet on a campus climb).

## Test plan

1. Climb editor → tap a blank hold → hold paints in the selected brush role.
2. Tap that same hold again → role cycles to the next option.
3. With 2 starts already set, tap a hand hold on Start → it skips ahead instead of no-op.

## Risk

Risk: 2/5 — isolated tap-handling logic in the mobile create-climb editor, covered by unit + hook tests, no BLE/data/migration changes.

Fixes #4882.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNR3KAmAb4YkTjPEDQSGJE
