### PR TITLE
feat(mobile): zoom to the selected hold and step through holds in the outline editor

### DIFF
--- a/packages/mobile/src/components/outline-editor/EditToolbar.tsx
+++ b/packages/mobile/src/components/outline-editor/EditToolbar.tsx
@@ -102,14 +102,15 @@ export const EditToolbar = React.memo(function EditToolbar({
       />
 
       {/* Step through the board in reading order. Sits directly above the status
-          line, which carries the position this pair moves through. */}
+          line, which carries the position this pair moves through. Neither
+          button carries an icon: the shared icon map has `back` but no forward
+          counterpart, and one arrow on one side reads as lopsided. */}
       <View style={styles.stepRow}>
         <Button
           // i18n-ignore-next-line — admin-only screen
           title="Prev"
           variant="tonal"
           size="small"
-          icon="back"
           onPress={onPreviousPlacement}
           disabled={!canStepPlacement || saving}
           style={styles.stepButton}

--- a/packages/mobile/src/components/outline-editor/EditToolbar.tsx
+++ b/packages/mobile/src/components/outline-editor/EditToolbar.tsx
@@ -25,6 +25,13 @@ type EditToolbarProps = {
   onEditKindChange: (kind: HoldOutlineKind) => void;
   /** One line saying what the selected placement currently carries. */
   statusLine: string;
+  /** "14 / 499" — how far through the board this placement sits, or null with
+   *  nothing selected. Rendered beside the step buttons it belongs to. */
+  positionLabel: string | null;
+  onNextPlacement: () => void;
+  onPreviousPlacement: () => void;
+  /** False only on a config with no placements at all. */
+  canStepPlacement: boolean;
   /** Last failure to surface — a rejected stroke or a server error. */
   errorText: string | null;
   /** A finished stroke is waiting to be stored. */
@@ -52,6 +59,10 @@ export const EditToolbar = React.memo(function EditToolbar({
   editKind,
   onEditKindChange,
   statusLine,
+  positionLabel,
+  onNextPlacement,
+  onPreviousPlacement,
+  canStepPlacement,
   errorText,
   hasDraft,
   onSave,
@@ -89,6 +100,35 @@ export const EditToolbar = React.memo(function EditToolbar({
         accessibilityLabel="Boundary to draw"
         tint={editKind === 'LED_INNER' ? OUTLINE_EDITOR_COLORS.ledInner : OUTLINE_EDITOR_COLORS.overridden}
       />
+
+      {/* Step through the board in reading order. Sits directly above the status
+          line, which carries the position this pair moves through. */}
+      <View style={styles.stepRow}>
+        <Button
+          // i18n-ignore-next-line — admin-only screen
+          title="Prev"
+          variant="tonal"
+          size="small"
+          icon="back"
+          onPress={onPreviousPlacement}
+          disabled={!canStepPlacement || saving}
+          style={styles.stepButton}
+        />
+        {positionLabel ? (
+          <Text variant="subheadline" style={styles.position}>
+            {positionLabel}
+          </Text>
+        ) : null}
+        <Button
+          // i18n-ignore-next-line — admin-only screen
+          title="Next"
+          variant="tonal"
+          size="small"
+          onPress={onNextPlacement}
+          disabled={!canStepPlacement || saving}
+          style={styles.stepButton}
+        />
+      </View>
 
       <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.status}>
         {statusLine}
@@ -168,6 +208,20 @@ const styles = StyleSheet.create({
   },
   status: {
     textAlign: 'center',
+  },
+  stepRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[3],
+  },
+  stepButton: {
+    minWidth: 96,
+  },
+  position: {
+    minWidth: 88,
+    textAlign: 'center',
+    fontVariant: ['tabular-nums'],
   },
   buttonRow: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/outline-editor/OutlineCanvasScreen.tsx
+++ b/packages/mobile/src/components/outline-editor/OutlineCanvasScreen.tsx
@@ -21,6 +21,7 @@ import { DrawStrokeOverlay } from './DrawStrokeOverlay';
 import { EditToolbar } from './EditToolbar';
 import { buildOutlineRing, radiusRingToBoardPx, renderToBoardScale, type StrokeRejection } from './stroke';
 import { spatialPlacementOrder, stepPlacement, zoomTargetForHold } from './hold-navigation';
+import { withUnsavedDraftGuard } from './draft-guard';
 import type { RingPoint } from '@boardsesh/board-art-geometry/ring';
 
 // Admin-only screen — hardcoded English literals throughout, matching the
@@ -177,45 +178,24 @@ export function OutlineCanvasScreen({ boardName, layoutId, sizeId, setIds }: Out
   );
 
   /**
-   * Run `action`, but never throw away a finished outline without asking.
-   *
-   * Selecting another hold, switching kind, stepping to the next placement and
-   * deselecting all used to call `clearDraft()` outright, so a stroke that had
-   * already passed validation vanished on a stray tap with nothing said. During
-   * a mass-correction pass — which is what Next/Prev exist for — that is a lot
-   * of silent lost work.
+   * Run `action`, but never throw away a finished outline without asking. The
+   * rule itself is `withUnsavedDraftGuard` (pure, and tested); this binds it to
+   * the current draft and to the platform dialog that does the asking.
    */
   const withDraftGuard = useCallback(
-    (action: () => void) => {
-      if (draftOutline == null) {
-        action();
-        return;
-      }
-      Alert.alert(
-        // i18n-ignore-next-line — admin-only screen
-        'Discard the outline you drew?',
-        // i18n-ignore-next-line — admin-only screen
-        "It hasn't been saved yet.",
-        [
-          // i18n-ignore-next-line — admin-only screen
-          { text: 'Keep drawing', style: 'cancel' },
-          // i18n-ignore-next-line — admin-only screen
-          { text: 'Discard', style: 'destructive', onPress: action },
-        ],
-      );
-    },
+    (action: () => void) => withUnsavedDraftGuard(draftOutline != null, action, confirmDiscardDraft),
     [draftOutline],
   );
 
   /**
    * Move the selection, unconditionally dropping whatever draft is in flight.
    *
-   * CONTRACT: never call this directly. It is the "yes, discard it" half of the
-   * pair and has no guard of its own — put the call behind {@link goToPlacement}
-   * (or {@link withDraftGuard}) so an unsaved stroke gets its confirmation. It
-   * is separate precisely so the guard can wrap it as the confirm action.
+   * The name is the contract: this is the "yes, discard it" half of the pair and
+   * has no guard of its own. Reach it through {@link goToPlacement} (or
+   * {@link withDraftGuard}) so an unsaved stroke gets its confirmation — it is
+   * separate precisely so the guard can wrap it as the confirm action.
    */
-  const selectPlacement = useCallback(
+  const selectPlacementUnguarded = useCallback(
     (placementId: number) => {
       setSelectedPlacementId(placementId);
       setErrorText(null);
@@ -239,9 +219,9 @@ export function OutlineCanvasScreen({ boardName, layoutId, sizeId, setIds }: Out
         zoomToPlacement(placementId);
         return;
       }
-      withDraftGuard(() => selectPlacement(placementId));
+      withDraftGuard(() => selectPlacementUnguarded(placementId));
     },
-    [selectedPlacementId, zoomToPlacement, withDraftGuard, selectPlacement],
+    [selectedPlacementId, zoomToPlacement, withDraftGuard, selectPlacementUnguarded],
   );
 
   const handleHoldTap = useCallback(
@@ -530,6 +510,25 @@ export function OutlineCanvasScreen({ boardName, layoutId, sizeId, setIds }: Out
         />
       </ScrollView>
     </View>
+  );
+}
+
+/**
+ * Ask before throwing a drawn outline away. Module scope, so the screen's guard
+ * callback doesn't rebuild it every render.
+ */
+function confirmDiscardDraft(onConfirm: () => void): void {
+  Alert.alert(
+    // i18n-ignore-next-line — admin-only screen
+    'Discard the outline you drew?',
+    // i18n-ignore-next-line — admin-only screen
+    "It hasn't been saved yet.",
+    [
+      // i18n-ignore-next-line — admin-only screen
+      { text: 'Keep drawing', style: 'cancel' },
+      // i18n-ignore-next-line — admin-only screen
+      { text: 'Discard', style: 'destructive', onPress: onConfirm },
+    ],
   );
 }
 

--- a/packages/mobile/src/components/outline-editor/OutlineCanvasScreen.tsx
+++ b/packages/mobile/src/components/outline-editor/OutlineCanvasScreen.tsx
@@ -207,6 +207,14 @@ export function OutlineCanvasScreen({ boardName, layoutId, sizeId, setIds }: Out
     [draftOutline],
   );
 
+  /**
+   * Move the selection, unconditionally dropping whatever draft is in flight.
+   *
+   * CONTRACT: never call this directly. It is the "yes, discard it" half of the
+   * pair and has no guard of its own — put the call behind {@link goToPlacement}
+   * (or {@link withDraftGuard}) so an unsaved stroke gets its confirmation. It
+   * is separate precisely so the guard can wrap it as the confirm action.
+   */
   const selectPlacement = useCallback(
     (placementId: number) => {
       setSelectedPlacementId(placementId);

--- a/packages/mobile/src/components/outline-editor/OutlineCanvasScreen.tsx
+++ b/packages/mobile/src/components/outline-editor/OutlineCanvasScreen.tsx
@@ -257,11 +257,14 @@ export function OutlineCanvasScreen({ boardName, layoutId, sizeId, setIds }: Out
 
   const handleStepPlacement = useCallback(
     (delta: 1 | -1) => {
-      const next = stepPlacement(placementOrder, selectedPlacementId, delta);
+      // Index from the Map the counter already maintains, so a press is O(1)
+      // rather than a scan of several hundred placements.
+      const currentIndex = selectedPlacementId == null ? null : (orderPositionById.get(selectedPlacementId) ?? null);
+      const next = stepPlacement(placementOrder, currentIndex, delta);
       if (next == null) return;
       goToPlacement(next);
     },
-    [placementOrder, selectedPlacementId, goToPlacement],
+    [placementOrder, orderPositionById, selectedPlacementId, goToPlacement],
   );
 
   const handleNextPlacement = useCallback(() => handleStepPlacement(1), [handleStepPlacement]);

--- a/packages/mobile/src/components/outline-editor/OutlineCanvasScreen.tsx
+++ b/packages/mobile/src/components/outline-editor/OutlineCanvasScreen.tsx
@@ -1,11 +1,15 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { ScrollView, StyleSheet, View, useWindowDimensions } from 'react-native';
+import { Alert, ScrollView, StyleSheet, View, useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useSharedValue } from 'react-native-reanimated';
 import type { BoardName, HoldOutlineKind } from '@boardsesh/shared-schema';
 import { Text } from '../Text';
 import { ActivityIndicator } from '../ActivityIndicator';
-import { InteractiveFilterBoard, type FilterBoardTransformContext } from '../search/InteractiveFilterBoard';
+import {
+  InteractiveFilterBoard,
+  type FilterBoardControls,
+  type FilterBoardTransformContext,
+} from '../search/InteractiveFilterBoard';
 import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
 import { spacing } from '../../theme/tokens';
@@ -16,6 +20,7 @@ import { OutlineSvgLayer, type OutlineLayerData } from './OutlineSvgLayer';
 import { DrawStrokeOverlay } from './DrawStrokeOverlay';
 import { EditToolbar } from './EditToolbar';
 import { buildOutlineRing, radiusRingToBoardPx, renderToBoardScale, type StrokeRejection } from './stroke';
+import { spatialPlacementOrder, stepPlacement, zoomTargetForHold } from './hold-navigation';
 import type { RingPoint } from '@boardsesh/board-art-geometry/ring';
 
 // Admin-only screen — hardcoded English literals throughout, matching the
@@ -82,6 +87,11 @@ export function OutlineCanvasScreen({ boardName, layoutId, sizeId, setIds }: Out
   // stroke-start runOnJS hop rather than per frame.
   const drawingRef = useRef(false);
 
+  // Imperative handle on the board's zoom. Next/Prev live in the toolbar, below
+  // the board, so they can't reach the transform through the render-prop context
+  // the in-board overlays use.
+  const boardControlsRef = useRef<FilterBoardControls | null>(null);
+
   const boardHolds = useMemo(() => {
     if (!boardName) return null;
     return getCreateBoardHolds({ boardName, layoutId, sizeId, setIds: parseSetIdsParam(setIds) });
@@ -141,24 +151,122 @@ export function OutlineCanvasScreen({ boardName, layoutId, sizeId, setIds }: Out
     draftPointsSV.value = NO_POINTS;
   }, [draftPointsSV]);
 
+  // Reading order for the whole config, computed once. Next/Prev are then an
+  // index step, not a scan, however many hundred placements the board carries.
+  const placementOrder = useMemo(() => spatialPlacementOrder(boardHolds?.holdTargets ?? []), [boardHolds]);
+  const orderPositionById = useMemo(() => {
+    const index = new Map<number, number>();
+    placementOrder.forEach((placementId, position) => index.set(placementId, position));
+    return index;
+  }, [placementOrder]);
+
+  const zoomToPlacement = useCallback(
+    (placementId: number) => {
+      const hold = holdById.get(placementId);
+      if (!hold || !boardHolds || boardRender.width <= 0) return;
+      boardControlsRef.current?.zoomTo(
+        zoomTargetForHold({
+          hold,
+          boardWidth: boardHolds.boardWidth,
+          renderWidth: boardRender.width,
+          renderHeight: boardRender.height,
+        }),
+      );
+    },
+    [holdById, boardHolds, boardRender.width, boardRender.height],
+  );
+
+  /**
+   * Run `action`, but never throw away a finished outline without asking.
+   *
+   * Selecting another hold, switching kind, stepping to the next placement and
+   * deselecting all used to call `clearDraft()` outright, so a stroke that had
+   * already passed validation vanished on a stray tap with nothing said. During
+   * a mass-correction pass — which is what Next/Prev exist for — that is a lot
+   * of silent lost work.
+   */
+  const withDraftGuard = useCallback(
+    (action: () => void) => {
+      if (draftOutline == null) {
+        action();
+        return;
+      }
+      Alert.alert(
+        // i18n-ignore-next-line — admin-only screen
+        'Discard the outline you drew?',
+        // i18n-ignore-next-line — admin-only screen
+        "It hasn't been saved yet.",
+        [
+          // i18n-ignore-next-line — admin-only screen
+          { text: 'Keep drawing', style: 'cancel' },
+          // i18n-ignore-next-line — admin-only screen
+          { text: 'Discard', style: 'destructive', onPress: action },
+        ],
+      );
+    },
+    [draftOutline],
+  );
+
+  const selectPlacement = useCallback(
+    (placementId: number) => {
+      setSelectedPlacementId(placementId);
+      setErrorText(null);
+      clearDraft();
+      zoomToPlacement(placementId);
+    },
+    [clearDraft, zoomToPlacement],
+  );
+
+  /**
+   * Move the editor to `placementId`, guarding an unsaved draft on the way.
+   *
+   * Landing on the hold already selected is a re-frame, not a move: it keeps the
+   * draft and just animates the board back onto the hold. That makes tapping the
+   * hold you are working on a way to recentre after panning away, instead of a
+   * dialog asking whether to throw your own stroke out.
+   */
+  const goToPlacement = useCallback(
+    (placementId: number) => {
+      if (placementId === selectedPlacementId) {
+        zoomToPlacement(placementId);
+        return;
+      }
+      withDraftGuard(() => selectPlacement(placementId));
+    },
+    [selectedPlacementId, zoomToPlacement, withDraftGuard, selectPlacement],
+  );
+
   const handleHoldTap = useCallback(
     (holdId: number) => {
       // Reachable: while zoomed the overlay nests inside the pan detector, so a
       // declined touch reaches the board's hold taps. A tap resolved on the UI
       // thread can still land on JS just after a stroke started, so drop it.
       if (drawingRef.current) return;
-      setSelectedPlacementId(holdId);
-      setErrorText(null);
-      clearDraft();
+      goToPlacement(holdId);
     },
-    [clearDraft],
+    [goToPlacement],
   );
 
+  const handleStepPlacement = useCallback(
+    (delta: 1 | -1) => {
+      const next = stepPlacement(placementOrder, selectedPlacementId, delta);
+      if (next == null) return;
+      goToPlacement(next);
+    },
+    [placementOrder, selectedPlacementId, goToPlacement],
+  );
+
+  const handleNextPlacement = useCallback(() => handleStepPlacement(1), [handleStepPlacement]);
+  const handlePreviousPlacement = useCallback(() => handleStepPlacement(-1), [handleStepPlacement]);
+
   const handleDeselect = useCallback(() => {
-    setSelectedPlacementId(null);
-    setErrorText(null);
-    clearDraft();
-  }, [clearDraft]);
+    withDraftGuard(() => {
+      setSelectedPlacementId(null);
+      setErrorText(null);
+      clearDraft();
+      boardControlsRef.current?.resetZoom();
+    });
+  }, [withDraftGuard, clearDraft]);
 
   const handleStrokeStart = useCallback(() => {
     drawingRef.current = true;
@@ -251,17 +359,31 @@ export function OutlineCanvasScreen({ boardName, layoutId, sizeId, setIds }: Out
 
   const handleEditKindChange = useCallback(
     (kind: HoldOutlineKind) => {
-      setEditKind(kind);
-      setErrorText(null);
-      clearDraft();
+      withDraftGuard(() => {
+        setEditKind(kind);
+        setErrorText(null);
+        clearDraft();
+      });
     },
-    [clearDraft],
+    [withDraftGuard, clearDraft],
   );
 
   const hasOverride = selectedPlacementId != null && overrideMetaByKey.has(`${selectedPlacementId}:${editKind}`);
 
+  // "14 / 499" — mass correction is the job this screen exists for, so how far
+  // through the board you are belongs on screen.
+  const positionLabel = useMemo(() => {
+    if (selectedPlacementId == null) return null;
+    const position = orderPositionById.get(selectedPlacementId);
+    return position == null ? null : `${position + 1} / ${placementOrder.length}`;
+  }, [selectedPlacementId, orderPositionById, placementOrder.length]);
+
   const statusLine = useMemo(() => {
-    if (selectedPlacementId == null) return 'Tap a hold to select it, then draw its outline.';
+    if (selectedPlacementId == null) {
+      return placementOrder.length > 0
+        ? `Tap a hold to select it, or press Next. ${placementOrder.length} placements.`
+        : 'Tap a hold to select it, then draw its outline.';
+    }
     const meta = overrideMetaByKey.get(`${selectedPlacementId}:${editKind}`);
     if (meta) {
       const author = meta.authorDisplayName ?? 'someone';
@@ -271,7 +393,7 @@ export function OutlineCanvasScreen({ boardName, layoutId, sizeId, setIds }: Out
     return layerData.shardByPlacement.has(selectedPlacementId)
       ? `#${selectedPlacementId} · traced`
       : `#${selectedPlacementId} · missing — the renderer falls back to a plain ring`;
-  }, [selectedPlacementId, editKind, overrideMetaByKey, layerData.shardByPlacement]);
+  }, [selectedPlacementId, editKind, overrideMetaByKey, layerData.shardByPlacement, placementOrder.length]);
 
   const boardScale = renderToBoardScale(boardHolds?.boardWidth ?? 0, boardRender.width);
 
@@ -370,6 +492,7 @@ export function OutlineCanvasScreen({ boardName, layoutId, sizeId, setIds }: Out
           renderHeight={boardRender.height}
           renderInTransform={renderInTransform}
           renderAboveBoard={renderAboveBoard}
+          controlRef={boardControlsRef}
         />
       </View>
 
@@ -378,6 +501,10 @@ export function OutlineCanvasScreen({ boardName, layoutId, sizeId, setIds }: Out
           editKind={editKind}
           onEditKindChange={handleEditKindChange}
           statusLine={statusLine}
+          positionLabel={positionLabel}
+          onNextPlacement={handleNextPlacement}
+          onPreviousPlacement={handlePreviousPlacement}
+          canStepPlacement={placementOrder.length > 0}
           errorText={errorText ?? (outlinesQuery.isError ? 'Loading the stored outlines failed.' : null)}
           hasDraft={draftOutline != null}
           onSave={handleSave}

--- a/packages/mobile/src/components/outline-editor/__tests__/draft-guard.test.ts
+++ b/packages/mobile/src/components/outline-editor/__tests__/draft-guard.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { withUnsavedDraftGuard } from '../draft-guard';
+
+// Regression cover for the bug this guard exists to fix: a validated stroke used
+// to disappear on a stray tap, a kind switch or a step to the next placement,
+// with nothing asked. The property that matters is negative — with a draft in
+// flight, nothing reaches the action except through the confirmation.
+
+describe('withUnsavedDraftGuard', () => {
+  it('runs the action straight through when there is no draft', () => {
+    const action = vi.fn();
+    const confirm = vi.fn();
+    withUnsavedDraftGuard(false, action, confirm);
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it('never runs the action itself when a draft is in flight', () => {
+    const action = vi.fn();
+    const confirm = vi.fn();
+    withUnsavedDraftGuard(true, action, confirm);
+    expect(action).not.toHaveBeenCalled();
+    expect(confirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs the action once the confirmation says yes', () => {
+    const action = vi.fn();
+    // Stands in for the user tapping "Discard".
+    const confirmAndAccept = (onConfirm: () => void) => onConfirm();
+    withUnsavedDraftGuard(true, action, confirmAndAccept);
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the draft alone when the confirmation is dismissed', () => {
+    const action = vi.fn();
+    // Stands in for "Keep drawing" — the dialog closes, the callback never fires.
+    const confirmAndDismiss = () => {};
+    withUnsavedDraftGuard(true, action, confirmAndDismiss);
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('hands the confirmation the exact action it is deciding about', () => {
+    const action = vi.fn();
+    // Collected into an array rather than a `let`: assigning inside the callback
+    // leaves TypeScript narrowing the variable to its initial type, and CI
+    // typechecks test files.
+    const captured: Array<() => void> = [];
+    withUnsavedDraftGuard(true, action, (onConfirm) => captured.push(onConfirm));
+    expect(captured).toHaveLength(1);
+    captured[0]();
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/components/outline-editor/__tests__/hold-navigation.test.ts
+++ b/packages/mobile/src/components/outline-editor/__tests__/hold-navigation.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+import { MAX_SCALE, MIN_SCALE } from '@boardsesh/play-view';
+import type { BoardHoldTarget } from '../../../lib/create-board-holds';
+import {
+  ROW_TOLERANCE_RADII,
+  spatialPlacementOrder,
+  stepPlacement,
+  zoomTargetForHold,
+  type BoardZoomTarget,
+} from '../hold-navigation';
+
+function hold(id: number, cx: number, cy: number, r = 10): BoardHoldTarget {
+  return { id, cx, cy, r };
+}
+
+/**
+ * The board's forward transform, copied from `use-zoom-pan-gesture`'s
+ * `animatedZoomStyle` ([translate, scale] about a centre origin) — the same
+ * helper `stroke.test.ts` uses. `zoomTargetForHold` is only correct if pushing
+ * the hold through this lands it in the middle of the viewport.
+ */
+function forwardTransform(
+  localX: number,
+  localY: number,
+  target: BoardZoomTarget,
+  renderWidth: number,
+  renderHeight: number,
+): [number, number] {
+  const centreX = renderWidth / 2;
+  const centreY = renderHeight / 2;
+  return [
+    centreX + target.scale * (localX - centreX) + target.translateX,
+    centreY + target.scale * (localY - centreY) + target.translateY,
+  ];
+}
+
+describe('spatialPlacementOrder', () => {
+  it('returns nothing for a board with no placements', () => {
+    expect(spatialPlacementOrder([])).toEqual([]);
+  });
+
+  it('reads a single row left to right', () => {
+    const order = spatialPlacementOrder([hold(3, 300, 100), hold(1, 100, 100), hold(2, 200, 100)]);
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('reads rows top to bottom, each left to right', () => {
+    const order = spatialPlacementOrder([hold(4, 200, 500), hold(1, 100, 100), hold(3, 100, 500), hold(2, 200, 100)]);
+    expect(order).toEqual([1, 2, 3, 4]);
+  });
+
+  it('buckets a row that is not perfectly level', () => {
+    // Within 0.8r of the anchor's cy: same row, so cx decides.
+    const jitter = 10 * ROW_TOLERANCE_RADII - 0.001;
+    const order = spatialPlacementOrder([hold(2, 200, 100 + jitter), hold(1, 100, 100)]);
+    expect(order).toEqual([1, 2]);
+  });
+
+  it('starts a new row just past the tolerance', () => {
+    const beyond = 10 * ROW_TOLERANCE_RADII + 0.001;
+    // The lower hold is to the LEFT, so a plain cx sort would put it first —
+    // only correct row bucketing yields [1, 2].
+    const order = spatialPlacementOrder([hold(2, 10, 100 + beyond), hold(1, 500, 100)]);
+    expect(order).toEqual([1, 2]);
+  });
+
+  it('measures the tolerance against the row anchor, not the previous hold', () => {
+    // 0, 0.7r, 1.4r. Chaining off each previous hold would call all three one
+    // row; against the anchor the third is 1.4r away and starts its own.
+    const order = spatialPlacementOrder([hold(1, 500, 0), hold(2, 400, 7), hold(3, 300, 14)]);
+    expect(order).toEqual([2, 1, 3]);
+  });
+
+  it('keeps every placement exactly once', () => {
+    const holds = Array.from({ length: 60 }, (_, index) =>
+      hold(index + 1, (index % 10) * 100, Math.floor(index / 10) * 100),
+    );
+    const order = spatialPlacementOrder(holds);
+    expect(order).toHaveLength(60);
+    expect(new Set(order).size).toBe(60);
+  });
+});
+
+describe('stepPlacement', () => {
+  const order = [10, 20, 30];
+
+  it('has nowhere to go on an empty board', () => {
+    expect(stepPlacement([], null, 1)).toBeNull();
+    expect(stepPlacement([], 10, -1)).toBeNull();
+  });
+
+  it('enters at the first hold going forward and the last going back', () => {
+    expect(stepPlacement(order, null, 1)).toBe(10);
+    expect(stepPlacement(order, null, -1)).toBe(30);
+  });
+
+  it('advances and retreats one step', () => {
+    expect(stepPlacement(order, 20, 1)).toBe(30);
+    expect(stepPlacement(order, 20, -1)).toBe(10);
+  });
+
+  it('wraps at both ends', () => {
+    expect(stepPlacement(order, 30, 1)).toBe(10);
+    expect(stepPlacement(order, 10, -1)).toBe(30);
+  });
+
+  it('treats a selection that is no longer on the board as no selection', () => {
+    expect(stepPlacement(order, 999, 1)).toBe(10);
+    expect(stepPlacement(order, 999, -1)).toBe(30);
+  });
+
+  it('walks the whole board and returns to the start', () => {
+    let current = stepPlacement(order, null, 1);
+    for (let step = 0; step < order.length; step += 1) current = stepPlacement(order, current, 1);
+    expect(current).toBe(10);
+  });
+});
+
+describe('zoomTargetForHold', () => {
+  const boardWidth = 1080;
+  const renderWidth = 360;
+  const renderHeight = 640;
+
+  it('centres a mid-board hold under the board’s own forward transform', () => {
+    const target = zoomTargetForHold({
+      hold: hold(1, boardWidth / 2, 960, 30),
+      boardWidth,
+      renderWidth,
+      renderHeight,
+    });
+    const renderScale = renderWidth / boardWidth;
+    const [screenX, screenY] = forwardTransform(
+      (boardWidth / 2) * renderScale,
+      960 * renderScale,
+      target,
+      renderWidth,
+      renderHeight,
+    );
+    expect(screenX).toBeCloseTo(renderWidth / 2, 6);
+    expect(screenY).toBeCloseTo(renderHeight / 2, 6);
+  });
+
+  it('frames a corner hold as far as the board allows, never past its edge', () => {
+    const target = zoomTargetForHold({ hold: hold(1, 0, 0, 30), boardWidth, renderWidth, renderHeight });
+    // The pan clamp is the ceiling; a corner hold pins the board against it
+    // rather than dragging empty space into frame.
+    expect(target.translateX).toBeCloseTo((renderWidth * (target.scale - 1)) / 2, 6);
+    expect(target.translateY).toBeCloseTo((renderHeight * (target.scale - 1)) / 2, 6);
+  });
+
+  it('stays inside the gesture system’s zoom range', () => {
+    for (const radius of [1, 30, 400, 5000]) {
+      const target = zoomTargetForHold({ hold: hold(1, 540, 960, radius), boardWidth, renderWidth, renderHeight });
+      expect(target.scale).toBeGreaterThanOrEqual(MIN_SCALE);
+      expect(target.scale).toBeLessThanOrEqual(MAX_SCALE);
+    }
+  });
+
+  it('saturates at MAX_SCALE for a real Aurora placement radius', () => {
+    // Documents the note on zoomTargetForHold: a catalogue hold (r = xSpacing*4,
+    // ~30 board px on a 1080-wide board) wants far more magnification than the
+    // shared ceiling allows, so the ceiling is what decides how close we get.
+    const target = zoomTargetForHold({ hold: hold(1, 540, 960, 30), boardWidth, renderWidth, renderHeight });
+    expect(target.scale).toBe(MAX_SCALE);
+  });
+
+  it('uses the computed scale when the hold is big enough to need less than the ceiling', () => {
+    // Half the viewport's short side, so hold + 1.5r context exactly fills it.
+    const radiusBoardPx = ((renderWidth / 2 / (1 + 1.5)) * boardWidth) / renderWidth;
+    const target = zoomTargetForHold({
+      hold: hold(1, 540, 960, radiusBoardPx),
+      boardWidth,
+      renderWidth,
+      renderHeight,
+    });
+    expect(target.scale).toBeLessThan(MAX_SCALE);
+    expect(target.scale).toBeCloseTo(Math.min(renderWidth, renderHeight) / 2 / (renderWidth / 2), 6);
+  });
+
+  it('degrades to an identity transform before the board is measured', () => {
+    expect(zoomTargetForHold({ hold: hold(1, 540, 960, 30), boardWidth, renderWidth: 0, renderHeight: 0 })).toEqual({
+      scale: MIN_SCALE,
+      translateX: 0,
+      translateY: 0,
+    });
+  });
+});

--- a/packages/mobile/src/components/outline-editor/__tests__/hold-navigation.test.ts
+++ b/packages/mobile/src/components/outline-editor/__tests__/hold-navigation.test.ts
@@ -82,11 +82,13 @@ describe('spatialPlacementOrder', () => {
 });
 
 describe('stepPlacement', () => {
+  // Placement ids 10/20/30 at indices 0/1/2 — the argument is the INDEX.
   const order = [10, 20, 30];
+  const indexOf = (placementId: number) => order.indexOf(placementId);
 
   it('has nowhere to go on an empty board', () => {
     expect(stepPlacement([], null, 1)).toBeNull();
-    expect(stepPlacement([], 10, -1)).toBeNull();
+    expect(stepPlacement([], 0, -1)).toBeNull();
   });
 
   it('enters at the first hold going forward and the last going back', () => {
@@ -95,23 +97,29 @@ describe('stepPlacement', () => {
   });
 
   it('advances and retreats one step', () => {
-    expect(stepPlacement(order, 20, 1)).toBe(30);
-    expect(stepPlacement(order, 20, -1)).toBe(10);
+    expect(stepPlacement(order, indexOf(20), 1)).toBe(30);
+    expect(stepPlacement(order, indexOf(20), -1)).toBe(10);
   });
 
   it('wraps at both ends', () => {
-    expect(stepPlacement(order, 30, 1)).toBe(10);
-    expect(stepPlacement(order, 10, -1)).toBe(30);
+    expect(stepPlacement(order, indexOf(30), 1)).toBe(10);
+    expect(stepPlacement(order, indexOf(10), -1)).toBe(30);
   });
 
-  it('treats a selection that is no longer on the board as no selection', () => {
-    expect(stepPlacement(order, 999, 1)).toBe(10);
-    expect(stepPlacement(order, 999, -1)).toBe(30);
+  it('treats an index off the end of the board as no selection', () => {
+    // What the caller's position Map yields for a stale selection: a miss it
+    // turns into null, or — defensively — an index the order no longer has.
+    for (const staleIndex of [-1, order.length, 999]) {
+      expect(stepPlacement(order, staleIndex, 1)).toBe(10);
+      expect(stepPlacement(order, staleIndex, -1)).toBe(30);
+    }
   });
 
   it('walks the whole board and returns to the start', () => {
     let current = stepPlacement(order, null, 1);
-    for (let step = 0; step < order.length; step += 1) current = stepPlacement(order, current, 1);
+    for (let step = 0; step < order.length; step += 1) {
+      current = stepPlacement(order, current == null ? null : indexOf(current), 1);
+    }
     expect(current).toBe(10);
   });
 });
@@ -178,10 +186,17 @@ describe('zoomTargetForHold', () => {
   });
 
   it('degrades to an identity transform before the board is measured', () => {
-    expect(zoomTargetForHold({ hold: hold(1, 540, 960, 30), boardWidth, renderWidth: 0, renderHeight: 0 })).toEqual({
-      scale: MIN_SCALE,
-      translateX: 0,
-      translateY: 0,
-    });
+    const identity = { scale: MIN_SCALE, translateX: 0, translateY: 0 };
+    // Every way the geometry can be missing: the view not yet laid out, and a
+    // board config that resolved no dimensions at all.
+    expect(zoomTargetForHold({ hold: hold(1, 540, 960, 30), boardWidth, renderWidth: 0, renderHeight: 0 })).toEqual(
+      identity,
+    );
+    expect(zoomTargetForHold({ hold: hold(1, 540, 960, 30), boardWidth, renderWidth, renderHeight: 0 })).toEqual(
+      identity,
+    );
+    expect(zoomTargetForHold({ hold: hold(1, 540, 960, 30), boardWidth: 0, renderWidth, renderHeight })).toEqual(
+      identity,
+    );
   });
 });

--- a/packages/mobile/src/components/outline-editor/draft-guard.ts
+++ b/packages/mobile/src/components/outline-editor/draft-guard.ts
@@ -1,0 +1,41 @@
+/**
+ * The "don't silently bin the climber's stroke" rule, separated from the dialog
+ * that asks about it.
+ *
+ * This is the fix a review of #4859 asked for: selecting another hold, switching
+ * kind, stepping to the next placement and deselecting all used to drop a
+ * validated draft outright, so a finished stroke vanished on a stray tap with
+ * nothing said. Next/Prev made that worse, because a mass-correction pass is
+ * exactly where losing a stroke costs real work.
+ *
+ * The rule lives here as a pure function rather than inline in the screen so it
+ * can be tested without rendering a board or stubbing `Alert`. The screen
+ * supplies the asking; this decides whether to ask.
+ */
+
+/**
+ * Shows the confirmation, invoking `onConfirm` only if the user agrees.
+ * Deliberately returns nothing: the answer arrives through the callback, on the
+ * platform's own schedule.
+ */
+export type DraftDiscardConfirm = (onConfirm: () => void) => void;
+
+/**
+ * Run `action`, first confirming when it would discard unsaved work.
+ *
+ * With no draft in flight this is a straight call — the common case, and it must
+ * stay synchronous so ordinary navigation never feels gated. With a draft, the
+ * ONLY path to `action` is through `confirm`; this function never runs it
+ * itself, which is the property the tests pin.
+ */
+export function withUnsavedDraftGuard(
+  hasUnsavedDraft: boolean,
+  action: () => void,
+  confirm: DraftDiscardConfirm,
+): void {
+  if (!hasUnsavedDraft) {
+    action();
+    return;
+  }
+  confirm(action);
+}

--- a/packages/mobile/src/components/outline-editor/hold-navigation.ts
+++ b/packages/mobile/src/components/outline-editor/hold-navigation.ts
@@ -23,6 +23,14 @@ import type { BoardHoldTarget } from '../../lib/create-board-holds';
  * against the row's ANCHOR rather than the previous hold, so a row that drifts
  * gradually across the board can't chain one tolerance into the next and
  * swallow the row above it.
+ *
+ * ASSUMES a roughly uniform placement radius: the tolerance comes from the
+ * anchor, so a row whose first hold is unusually small would bucket tightly (and
+ * one whose first hold is unusually large, loosely). Every board in the
+ * catalogue derives `r` from a single grid spacing (`xSpacing * 4` in
+ * `board-details`), so in practice every hold on a config shares one radius. A
+ * future board with genuinely mixed hold sizes would want a per-config radius
+ * (median, say) instead of the anchor's.
  */
 export const ROW_TOLERANCE_RADII = 0.8;
 
@@ -75,20 +83,26 @@ export function spatialPlacementOrder(
 }
 
 /**
- * The placement one step forward (`1`) or back (`-1`) from `current`, wrapping
- * at both ends so a long correction pass never dead-ends.
+ * The placement one step forward (`1`) or back (`-1`) from the one at
+ * `currentIndex`, wrapping at both ends so a long correction pass never
+ * dead-ends.
  *
- * With nothing selected, stepping forward starts at the first hold and stepping
- * back starts at the last — so either button is a valid way in. A `current` that
- * isn't in the order (a stale selection after a config change) is treated the
- * same way.
+ * Takes the INDEX, not the placement id, so a button press stays O(1): the
+ * caller already keeps a position-by-id Map for the "14 / 499" counter, and
+ * looking the id up there beats scanning the order on every press of a
+ * several-hundred-placement board.
+ *
+ * `null` means nothing is selected — or the selection is no longer on this board
+ * (a stale id after a config change), which the caller's Map reports the same
+ * way. Either enters at the first hold going forward and the last going back, so
+ * both buttons are a valid way in.
  */
-export function stepPlacement(order: readonly number[], current: number | null, delta: 1 | -1): number | null {
+export function stepPlacement(order: readonly number[], currentIndex: number | null, delta: 1 | -1): number | null {
   if (order.length === 0) return null;
-  const currentIndex = current == null ? -1 : order.indexOf(current);
-  if (currentIndex === -1) return delta === 1 ? order[0] : order[order.length - 1];
-  const nextIndex = (currentIndex + delta + order.length) % order.length;
-  return order[nextIndex];
+  if (currentIndex == null || currentIndex < 0 || currentIndex >= order.length) {
+    return delta === 1 ? order[0] : order[order.length - 1];
+  }
+  return order[(currentIndex + delta + order.length) % order.length];
 }
 
 /** A board zoom transform, in the shape `use-zoom-pan-gesture` holds it. */
@@ -102,6 +116,9 @@ export type BoardZoomTarget = {
  * Worklet-free twin of `clampTranslation` in `use-zoom-pan-gesture`. Keeping the
  * board inside its own frame is the pan gesture's rule, and a programmatic zoom
  * has to obey it too or the first manual pan afterwards would snap.
+ *
+ * `@boardsesh/play-view` holds the canonical spec both copies answer to; this is
+ * the third expression of it, and the only one a test can call directly.
  *
  * The twin spells its "not zoomed" sentinel as the literal `currentScale <= 1`
  * (a worklet, so it can't reach a cross-module import); this one uses

--- a/packages/mobile/src/components/outline-editor/hold-navigation.ts
+++ b/packages/mobile/src/components/outline-editor/hold-navigation.ts
@@ -102,6 +102,12 @@ export type BoardZoomTarget = {
  * Worklet-free twin of `clampTranslation` in `use-zoom-pan-gesture`. Keeping the
  * board inside its own frame is the pan gesture's rule, and a programmatic zoom
  * has to obey it too or the first manual pan afterwards would snap.
+ *
+ * The twin spells its "not zoomed" sentinel as the literal `currentScale <= 1`
+ * (a worklet, so it can't reach a cross-module import); this one uses
+ * `MIN_SCALE`, which IS 1. They agree today and have to keep agreeing — if
+ * `MIN_SCALE` ever moves off 1, change both or a programmatic zoom and a manual
+ * pan will clamp differently.
  */
 function clampTranslation(translation: number, scale: number, extent: number): number {
   if (scale <= MIN_SCALE) return 0;

--- a/packages/mobile/src/components/outline-editor/hold-navigation.ts
+++ b/packages/mobile/src/components/outline-editor/hold-navigation.ts
@@ -1,0 +1,174 @@
+/**
+ * Walking the board hold by hold, and framing the one you land on.
+ *
+ * Correcting outlines is a mass-edit job — a Kilter 12x12 carries hundreds of
+ * placements — so the editor has to answer two questions without the user
+ * hunting: which hold comes next, and how do I get a close look at it.
+ *
+ * Both answers are pure functions here so they can be tested without a board on
+ * screen. The transform maths mirrors `use-zoom-pan-gesture`; see
+ * {@link zoomTargetForHold} for the exact relationship and why it has to stay in
+ * step.
+ */
+
+import { MAX_SCALE, MIN_SCALE } from '@boardsesh/play-view';
+import type { BoardHoldTarget } from '../../lib/create-board-holds';
+
+/**
+ * How far apart two holds' centres may sit vertically and still count as the
+ * same row, in units of the row's own placement radius.
+ *
+ * Aurora boards lay holds out on an even grid, so anything under a radius is
+ * comfortably "same row" and the next row up is several radii away. Measured
+ * against the row's ANCHOR rather than the previous hold, so a row that drifts
+ * gradually across the board can't chain one tolerance into the next and
+ * swallow the row above it.
+ */
+export const ROW_TOLERANCE_RADII = 0.8;
+
+/**
+ * How much board around the hold to keep in frame, in units of its radius. The
+ * hold plus this much context is what the zoom tries to fill the viewport with.
+ */
+export const ZOOM_CONTEXT_RADII = 1.5;
+
+/**
+ * Every placement in reading order: rows top to bottom, and left to right
+ * within each row.
+ *
+ * `cy` grows downward (it is board-image space, not climbing-wall space — see
+ * `holdGeometry`), so ascending `cy` really is top-first.
+ */
+export function spatialPlacementOrder(
+  holds: readonly BoardHoldTarget[],
+  rowToleranceRadii: number = ROW_TOLERANCE_RADII,
+): number[] {
+  if (holds.length === 0) return [];
+
+  // Ties broken by cx so the row-bucketing walk is deterministic for holds that
+  // share a cy exactly — which on a grid-laid-out board is most of them.
+  const byRowThenColumn = [...holds].sort((left, right) => left.cy - right.cy || left.cx - right.cx);
+
+  const rows: BoardHoldTarget[][] = [];
+  let currentRow: BoardHoldTarget[] = [];
+  let anchor: BoardHoldTarget | null = null;
+
+  for (const hold of byRowThenColumn) {
+    const belongsToCurrentRow = anchor != null && Math.abs(hold.cy - anchor.cy) <= anchor.r * rowToleranceRadii;
+    if (belongsToCurrentRow) {
+      currentRow.push(hold);
+      continue;
+    }
+    if (currentRow.length > 0) rows.push(currentRow);
+    currentRow = [hold];
+    anchor = hold;
+  }
+  if (currentRow.length > 0) rows.push(currentRow);
+
+  const ordered: number[] = [];
+  for (const row of rows) {
+    for (const hold of [...row].sort((left, right) => left.cx - right.cx)) {
+      ordered.push(hold.id);
+    }
+  }
+  return ordered;
+}
+
+/**
+ * The placement one step forward (`1`) or back (`-1`) from `current`, wrapping
+ * at both ends so a long correction pass never dead-ends.
+ *
+ * With nothing selected, stepping forward starts at the first hold and stepping
+ * back starts at the last — so either button is a valid way in. A `current` that
+ * isn't in the order (a stale selection after a config change) is treated the
+ * same way.
+ */
+export function stepPlacement(order: readonly number[], current: number | null, delta: 1 | -1): number | null {
+  if (order.length === 0) return null;
+  const currentIndex = current == null ? -1 : order.indexOf(current);
+  if (currentIndex === -1) return delta === 1 ? order[0] : order[order.length - 1];
+  const nextIndex = (currentIndex + delta + order.length) % order.length;
+  return order[nextIndex];
+}
+
+/** A board zoom transform, in the shape `use-zoom-pan-gesture` holds it. */
+export type BoardZoomTarget = {
+  scale: number;
+  translateX: number;
+  translateY: number;
+};
+
+/**
+ * Worklet-free twin of `clampTranslation` in `use-zoom-pan-gesture`. Keeping the
+ * board inside its own frame is the pan gesture's rule, and a programmatic zoom
+ * has to obey it too or the first manual pan afterwards would snap.
+ */
+function clampTranslation(translation: number, scale: number, extent: number): number {
+  if (scale <= MIN_SCALE) return 0;
+  const limit = (extent * (scale - 1)) / 2;
+  return Math.max(-limit, Math.min(limit, translation));
+}
+
+/**
+ * The transform that puts one hold in the middle of the viewport at a scale you
+ * can trace at.
+ *
+ * The board is drawn `transform: [translateX, translateY, scale]` about a centre
+ * origin, so a board-local point maps to the screen as
+ *
+ *     screen = centre + scale * (local - centre) + translate
+ *
+ * Setting `screen = centre` and solving gives `translate = -scale * (local -
+ * centre)`, which is the whole of the centring maths below. The result is then
+ * clamped exactly as a manual pan would be, so a hold near an edge frames as far
+ * as the board allows and no further.
+ *
+ * NOTE on the scale: for every Aurora config in the catalogue the ideal scale
+ * works out well above `MAX_SCALE`, so the answer saturates at the gesture
+ * system's ceiling of 4 and `contextRadii` never bites. That is deliberate —
+ * this stays clamped to the same range pinch-to-zoom uses rather than giving the
+ * editor a private zoom range — but it does mean "how close do we get" is
+ * currently a property of `MAX_SCALE`, not of this function.
+ */
+export function zoomTargetForHold({
+  hold,
+  boardWidth,
+  renderWidth,
+  renderHeight,
+  contextRadii = ZOOM_CONTEXT_RADII,
+  minScale = MIN_SCALE,
+  maxScale = MAX_SCALE,
+}: {
+  hold: BoardHoldTarget;
+  boardWidth: number;
+  renderWidth: number;
+  renderHeight: number;
+  contextRadii?: number;
+  minScale?: number;
+  maxScale?: number;
+}): BoardZoomTarget {
+  if (boardWidth <= 0 || renderWidth <= 0 || renderHeight <= 0) {
+    return { scale: minScale, translateX: 0, translateY: 0 };
+  }
+
+  // The board is drawn to its own aspect ratio, so one factor converts both axes.
+  const renderScale = renderWidth / boardWidth;
+  const holdRadiusRenderPx = hold.r * renderScale;
+
+  // Half-extent we want visible: the hold plus its context ring.
+  const desiredHalfExtent = holdRadiusRenderPx * (1 + contextRadii);
+  const viewportHalfExtent = Math.min(renderWidth, renderHeight) / 2;
+  const idealScale = desiredHalfExtent > 0 ? viewportHalfExtent / desiredHalfExtent : maxScale;
+  const scale = Math.max(minScale, Math.min(maxScale, idealScale));
+
+  const localX = hold.cx * renderScale;
+  const localY = hold.cy * renderScale;
+  const centreX = renderWidth / 2;
+  const centreY = renderHeight / 2;
+
+  return {
+    scale,
+    translateX: clampTranslation(-scale * (localX - centreX), scale, renderWidth),
+    translateY: clampTranslation(-scale * (localY - centreY), scale, renderHeight),
+  };
+}

--- a/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
@@ -102,6 +102,13 @@ type UseZoomPanGestureReturn = {
 // shared version is the canonical spec / test target; reanimated can't
 // reliably call non-worklet functions across module boundaries so we keep a
 // 'worklet'-marked clone here. Keep in sync.
+//
+// There is a THIRD copy — zoomTargetForHold's clamp in
+// outline-editor/hold-navigation.ts, which pre-clamps a programmatic zoom so it
+// lands where a manual pan would. It spells the "not zoomed" sentinel as
+// MIN_SCALE where this one uses the literal 1 (a worklet can't reach the
+// import). They are equal today; if MIN_SCALE ever moves off 1, all three have
+// to move together.
 function clampTranslation(
   translationX: number,
   translationY: number,
@@ -227,8 +234,12 @@ export function useZoomPanGesture({
       scale.value = withTiming(target.scale, { duration: timing.normal });
       translateX.value = withTiming(target.translateX, { duration: timing.normal });
       translateY.value = withTiming(target.translateY, { duration: timing.normal });
-      // Keep the gesture snapshots in step so a pan that starts before the
-      // animation settles doesn't jump back to the pre-zoom origin.
+      // Mirrors resetZoom, and belt-and-braces rather than load-bearing: both
+      // gestures re-snapshot these from the LIVE animated values in their own
+      // onStart (see the pinch's snapshot comment below), so a gesture that
+      // begins mid-animation already picks the board up where it visually is.
+      // These keep the saved state coherent for anything that reads it without
+      // a gesture start in front of it.
       savedScale.value = target.scale;
       savedTranslateX.value = target.translateX;
       savedTranslateY.value = target.translateY;

--- a/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
@@ -84,6 +84,17 @@ type UseZoomPanGestureReturn = {
   containerWidthSV: SharedValue<number>;
   containerHeightSV: SharedValue<number>;
   resetZoom: () => void;
+  /**
+   * Animate the board to an explicit transform — the programmatic twin of a
+   * pinch, used by the outline editor to frame the placement being corrected.
+   *
+   * Writes the same shared values the gestures do, so a pan or pinch started
+   * mid-flight simply takes over: both snapshot from the live animated value at
+   * `onStart` and assigning a shared value cancels its running animation.
+   * Callers are responsible for handing over an already-clamped transform (see
+   * `zoomTargetForHold`), because nothing here re-clamps it.
+   */
+  zoomTo: (target: { scale: number; translateX: number; translateY: number }) => void;
   animatedZoomStyle: AnimatedStyle<ViewStyle>;
 };
 
@@ -206,6 +217,27 @@ export function useZoomPanGesture({
     savedTranslateY.value = 0;
     updateZoomState(false);
   }, [scale, translateX, translateY, savedScale, savedTranslateX, savedTranslateY, updateZoomState]);
+
+  const zoomTo = useCallback(
+    (target: { scale: number; translateX: number; translateY: number }) => {
+      cancelAnimation(scale);
+      cancelAnimation(translateX);
+      cancelAnimation(translateY);
+
+      scale.value = withTiming(target.scale, { duration: timing.normal });
+      translateX.value = withTiming(target.translateX, { duration: timing.normal });
+      translateY.value = withTiming(target.translateY, { duration: timing.normal });
+      // Keep the gesture snapshots in step so a pan that starts before the
+      // animation settles doesn't jump back to the pre-zoom origin.
+      savedScale.value = target.scale;
+      savedTranslateX.value = target.translateX;
+      savedTranslateY.value = target.translateY;
+      // Mirror the pinch's own threshold: anything at or under it is "not
+      // zoomed", which is what mounts the pan overlay and the reset control.
+      updateZoomState(target.scale > ZOOM_THRESHOLD);
+    },
+    [scale, translateX, translateY, savedScale, savedTranslateX, savedTranslateY, updateZoomState],
+  );
 
   const pinchGesture = useMemo(() => {
     const pinch = Gesture.Pinch()
@@ -404,6 +436,7 @@ export function useZoomPanGesture({
     containerWidthSV,
     containerHeightSV,
     resetZoom,
+    zoomTo,
     animatedZoomStyle,
   };
 }

--- a/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
+++ b/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
@@ -1,4 +1,12 @@
-import React, { useCallback, useMemo, useRef, type MutableRefObject, type ReactNode } from 'react';
+import React, {
+  useCallback,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  type MutableRefObject,
+  type ReactNode,
+  type RefObject,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { View, StyleSheet, Pressable } from 'react-native';
 import Animated, { runOnJS, type SharedValue } from 'react-native-reanimated';
@@ -96,6 +104,24 @@ type InteractiveFilterBoardProps = {
    * hold").
    */
   renderAboveBoard?: (context: FilterBoardTransformContext) => ReactNode;
+  /**
+   * Imperative handle on the board's zoom, for chrome that lives OUTSIDE this
+   * component and still has to drive it — the outline editor's Next/Prev
+   * buttons, which sit in its toolbar and have to frame the hold they select.
+   *
+   * A ref rather than a prop-driven target, because "frame this hold" is an
+   * event, not state: re-selecting the hold you are already on should re-frame
+   * it, and a declarative prop equal to its previous value would not.
+   */
+  controlRef?: RefObject<FilterBoardControls | null>;
+};
+
+/** What {@link InteractiveFilterBoard} exposes through `controlRef`. */
+export type FilterBoardControls = {
+  /** Animate to an explicit, already-clamped board transform. */
+  zoomTo: (target: { scale: number; translateX: number; translateY: number }) => void;
+  /** Animate back to the unzoomed board. */
+  resetZoom: () => void;
 };
 
 const TAP_MAX_DURATION_MS = 300;
@@ -130,6 +156,7 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
   renderHeight,
   renderInTransform,
   renderAboveBoard,
+  controlRef,
 }: InteractiveFilterBoardProps) {
   const { t } = useTranslation('common');
   // Shared with the per-hold detectors and the rest/zoom tap overlays so they
@@ -147,6 +174,7 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
     containerWidthSV,
     containerHeightSV,
     resetZoom,
+    zoomTo,
     animatedZoomStyle,
   } = useZoomPanGesture({
     enabled: true,
@@ -174,6 +202,8 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
     }),
     [pinchGesture, scaleSV, translateXSV, translateYSV, containerWidthSV, containerHeightSV, renderWidth, renderHeight],
   );
+
+  useImperativeHandle(controlRef, () => ({ zoomTo, resetZoom }), [zoomTo, resetZoom]);
 
   // Hit circles so the zoomed pan overlay can resolve a tap to a hold itself
   // (it sits above the per-hold detectors — see #2687). Zone mode passes no


### PR DESCRIPTION
## Summary

Marco's two asks for the hold outline editor (#4859), for the iPad mass-correction pass: **zoom onto the hold you select**, and **step through holds with Next/Prev** instead of hunting for the next one by hand.

- **Zoom to the selected hold.** Tapping a hold — or landing on one via Next/Prev — animates the board so that hold sits in the middle of the viewport at working magnification (~300 ms). Manual pinch and pan are untouched and take over cleanly mid-animation.
- **Next / Prev**, walking the config in reading order: rows top to bottom, left to right within a row, wrapping at both ends. Each step selects and frames.
- **Position counter** in the toolbar (`14 / 499`), so a long correction pass shows how far through the board you are. With nothing selected the status line names the total and points at Next.

### How the zoom is wired

`useZoomPanGesture` gains a `zoomTo(target)` — the programmatic twin of `resetZoom`, built the same way: `cancelAnimation` on the three shared values, then `withTiming` onto each, then the `savedScale`/`savedTranslate*` snapshots so a pan starting before the animation settles doesn't jump back to the pre-zoom origin. It mirrors the pinch's own `ZOOM_THRESHOLD` when setting zoom state, which is what mounts the pan overlay and the reset control.

Nothing fights the animation: both the pinch and the pan snapshot from the *live* animated value in `onStart`, and assigning a shared value cancels its running animation — so a gesture begun mid-flight simply picks the board up where it currently is. That is the existing reset-zoom behaviour, not new machinery.

Next/Prev live in the toolbar, *below* the board, so they can't reach the transform through the render-prop context the in-board overlays use. `InteractiveFilterBoard` therefore exposes a small imperative handle — `controlRef: RefObject<FilterBoardControls | null>` with `{ zoomTo, resetZoom }` via `useImperativeHandle`. A ref rather than a declarative target prop because "frame this hold" is an **event**: re-selecting the hold you're already on should re-frame it, and a prop equal to its previous value wouldn't fire. Optional, so the two existing callers (`holds.tsx`, `zone.tsx`) are unchanged.

### Unsaved-draft protection (fixes a #4859 QA finding)

Review QA on #4859 flagged that a validated draft was discarded silently. It was: `handleHoldTap`, `handleDeselect` and `handleEditKindChange` all called `clearDraft()` outright, so a finished stroke vanished on a stray tap with nothing said. Next/Prev would have made that much worse — the whole point of those buttons is a long pass where losing a stroke costs real work.

All four paths plus the two new ones now run through one `withDraftGuard`, which confirms before discarding and is a no-op when there is no draft. Two deliberate exemptions, both so the guard doesn't nag about work it isn't protecting:

- **Redrawing** on the same hold replaces the draft without prompting — that's the normal correction loop, not a discard.
- **Re-selecting the hold you're already on** re-frames and keeps the draft, so tapping your own hold is a way to recentre after panning away rather than a dialog asking whether to bin your own stroke.

### One thing worth knowing

For every Aurora config in the catalogue the ideal scale works out well above the shared `MAX_SCALE` of 4, so the target saturates there and the `contextRadii` knob never bites in practice. I kept it clamped to the same range pinch-to-zoom uses rather than giving the editor a private zoom ceiling — that felt like a call to make deliberately rather than smuggle into a feature PR. It still lands the hold at roughly 22% of the viewport width, which is tracable; if it turns out too coarse on a real iPad, raising the editor's ceiling is a one-line follow-up. A test pins the saturation so the behaviour is documented rather than surprising.

### On the `native-fingerprint` label

CI labels this a native change; the diff is not one. All six changed files are under `packages/mobile/src/**` — `git diff --name-only origin/release/next..HEAD` over `app.config.ts`, `plugins/`, `modules/`, `locales/`, `package.json`, `patches/` and `bun.lock` is empty. The label comes from the base: `release/next` carries the Expo 57 upgrade, the rebuilt Rust renderer artifacts and the live-activity Swift changes, and the fingerprint is resolved against `main`.

So the `Risk: 2/5 — JS-only` line describes this diff accurately, and this PR already targets `release/next`. Practical consequence: it ships with that train's next TestFlight/Play build rather than as a production OTA, and no per-PR OTA preview can be published for it — which is why the iPad QA below has to wait for that build.

## Release Notes

none

- [x] No release note needed (internal / technical change)

## Test plan

Needs an admin account. The editor is More → Development → Hold Outlines.

1. Hold Outline Editor → tap a hold — board zooms onto it.
2. Press Next — selection walks to the neighbouring hold, zoomed.
3. Pinch/pan still work after the zoom animation.
4. Draft stroke + Next — draft is not silently lost.

## Risk

Risk: 2/5 — admin-only editor screen, JS-only

## Validation

| Check | Result |
|---|---|
| `vp run typecheck:mobile` | 0 errors |
| `vp run test:mobile` | 743 files / 7592 tests passed (+19 new) |
| `vp run check:mobile-bundle` | exit 0 — iOS + Android |
| `vp run check:i18n:orphans` | OK |
| `vp check` | 0 errors |

The new tests cover the pure half: reading-order bucketing (including that the row tolerance is measured against the row **anchor**, not the previous hold, so a gradually sloping row can't chain one tolerance into the next), `stepPlacement` wrapping and entry from no selection, and the zoom target — the centring assertion pushes the hold through the board's own forward transform and checks it lands dead centre, using the same helper `stroke.test.ts` uses.

## Owed device QA

The gesture-handover claim ("pinch/pan still work after the zoom animation") is reasoned from how the gestures snapshot their start state, and the animation itself can't be exercised in a unit test — step 3 of the test plan is the real check, on an iPad.

The draft guard is likewise UI-only: neither the confirm prompt nor the "re-selecting the same hold re-frames without prompting" exemption is covered by an automated test, so test-plan step 4 is what verifies it.
