### PR TITLE
docs(store): rewrite the 2.4 What's New around the Boardsesh board look

### DIFF
--- a/docs/board-render-analytics.md
+++ b/docs/board-render-analytics.md
@@ -269,10 +269,16 @@ Nothing has been created in PostHog by this PR. When ready:
 
 1. **Two multivariate feature flags**, both matching the mobile catalog
    exactly (`packages/mobile/src/providers/feature-flags-provider.tsx`):
-   - `board-render-mode-default` — variants `classic` / `boardsesh`. Ship at
-     **0% `boardsesh`** initially (mobile's own shipped default already reads
-     `classic` when the flag is unresolved, so 0% is a no-op rollout, not a
-     silent behaviour change).
+   - `board-render-mode-default` — variants `classic` / `boardsesh`.
+     **For the 2.4 store release this ships at 100% `boardsesh`** — the
+     Boardsesh drawing is the default a climber gets, and Classic stays one tap
+     away under More > Board look > Render. Create the flag at **0%
+     `boardsesh`** first and ramp it only once the 2.4 binary is live in both
+     stores: mobile's shipped default reads `classic` when the flag is
+     unresolved, so 0% is a no-op rollout rather than a silent behaviour
+     change, and a climber on an older binary that cannot draw the mode is
+     pinned to Classic by the capability probe regardless of the flag. A
+     climber's own Settings choice always beats the flag in both directions.
    - `board-glow-falloff` — variants `soft` / `plateau`.
 2. **An Experiment on `board-glow-falloff`**, 50/50 `soft` / `plateau`, with
    **`Climb View Opened` as a CUSTOM EXPOSURE EVENT**, filtered to

--- a/fastlane/metadata/android/de-DE/changelogs/default.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/default.txt
@@ -1,6 +1,5 @@
 Neu in 2.4:
-- Dein Board, neu gezeichnet: beleuchtete Griffe leuchten in ihrer eigenen Silhouette statt als farbiger Kreis, und die Wand tritt zurück. Auch Woods-Boards haben echte Silhouetten.
-- Lieber Kreise? Profil > Mehr > Board-Look > Klassisch.
-- Vorgaben, Leucht- und Schleierregler, Farbsehschwäche-Paletten, die auch dein Board beleuchten.
-- MoonBoard: „Griff darüber beleuchten“ ergänzt eine gedimmte LED über jedem Start- und Handgriff.
+- Ein neuer Look für dein Board: beleuchtete Griffe leuchten in ihrer eigenen Silhouette, die Wand tritt zurück. Neuer Standard auf jedem Board, Woods inklusive.
+- Stell ihn dir ein unter Profil > Mehr > Board-Look: Vorgaben, Leuchten, Schleier, Markierungen, Farbsehschwäche-Paletten. Lieber Kreise? Darstellung auf Klassisch.
+- MoonBoard: mit dem quelloffenen Arduino-LED-Controller „Griff darüber beleuchten“ aktivieren.
 - Panels schließen zuverlässig.

--- a/fastlane/metadata/android/de-DE/changelogs/default.txt
+++ b/fastlane/metadata/android/de-DE/changelogs/default.txt
@@ -1,4 +1,6 @@
 Neu in 2.4:
-- MoonBoard: Aktiviere „Griff darüber beleuchten“ für eine zweite, gedimmte LED über jedem beleuchteten Start- oder Handgriff auf unterstützten Controllern.
-- Panels schließen nach dem Wechsel in den Hintergrund oder zwischen Screens zuverlässig.
-- Geteilte Dateien bleiben im Boardsesh-Cache, auch wenn eine andere App einen ungewöhnlichen Namen liefert.
+- Dein Board, neu gezeichnet: beleuchtete Griffe leuchten in ihrer eigenen Silhouette statt als farbiger Kreis, und die Wand tritt zurück. Auch Woods-Boards haben echte Silhouetten.
+- Lieber Kreise? Profil > Mehr > Board-Look > Klassisch.
+- Vorgaben, Leucht- und Schleierregler, Farbsehschwäche-Paletten, die auch dein Board beleuchten.
+- MoonBoard: „Griff darüber beleuchten“ ergänzt eine gedimmte LED über jedem Start- und Handgriff.
+- Panels schließen zuverlässig.

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,6 +1,5 @@
 New in 2.4:
-- Your board, redrawn: lit holds glow in their own shape instead of a coloured circle, and the wall dims back so the climb reads from across the room. Woods boards get real outlines too.
-- Prefer circles? Profile > More > Board look > Classic.
-- Presets, glow and veil controls, and colour-blind palettes that light your wall too.
-- MoonBoard: "Light the hold above" adds a dimmer LED above each lit start and hand hold.
+- A new look for your board: lit holds glow in their own shape and the wall dims back, so the climb reads from across the room. It's the new default on every board, Woods included.
+- Make it yours under Profile > More > Board look: presets, glow, veil, marks, colour-vision palettes. Want the old circles? Set Render to Classic.
+- MoonBoard: running the open-source Arduino LED controller? Turn on "Light the hold above".
 - Sheets close reliably after backgrounding.

--- a/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,4 +1,6 @@
 New in 2.4:
-- MoonBoard: turn on “Light the hold above” for a dimmer LED above each lit start and hand hold on supported controllers.
-- Sheets close reliably after backgrounding or moving between screens.
-- Files shared into Boardsesh stay safely inside its cache, even when another app sends an unusual filename.
+- Your board, redrawn: lit holds glow in their own shape instead of a coloured circle, and the wall dims back so the climb reads from across the room. Woods boards get real outlines too.
+- Prefer circles? Profile > More > Board look > Classic.
+- Presets, glow and veil controls, and colour-blind palettes that light your wall too.
+- MoonBoard: "Light the hold above" adds a dimmer LED above each lit start and hand hold.
+- Sheets close reliably after backgrounding.

--- a/fastlane/metadata/android/es-ES/changelogs/default.txt
+++ b/fastlane/metadata/android/es-ES/changelogs/default.txt
@@ -1,4 +1,6 @@
 Novedades de 2.4:
-- MoonBoard: activa «Iluminar la presa de arriba» para añadir un LED tenue sobre cada presa de inicio o de mano iluminada en controladores compatibles.
-- Los paneles se cierran bien después de dejar la app en segundo plano o cambiar de pantalla.
-- Los archivos compartidos con Boardsesh se quedan dentro de su caché aunque otra app envíe un nombre poco habitual.
+- Tu plafón, redibujado: las presas encendidas brillan con su propia silueta en vez de un círculo de color, y el muro se atenúa. Los Woods también tienen siluetas reales.
+- ¿Prefieres círculos? Perfil > Más > Aspecto del plafón > Clásico.
+- Preajustes, controles de resplandor y velo, y paletas para daltonismo que también encienden tu plafón.
+- MoonBoard: «Iluminar la presa de arriba» añade un LED tenue sobre cada presa de inicio o de mano.
+- Los paneles se cierran bien.

--- a/fastlane/metadata/android/es-ES/changelogs/default.txt
+++ b/fastlane/metadata/android/es-ES/changelogs/default.txt
@@ -1,6 +1,5 @@
 Novedades de 2.4:
-- Tu plafón, redibujado: las presas encendidas brillan con su propia silueta en vez de un círculo de color, y el muro se atenúa. Los Woods también tienen siluetas reales.
-- ¿Prefieres círculos? Perfil > Más > Aspecto del plafón > Clásico.
-- Preajustes, controles de resplandor y velo, y paletas para daltonismo que también encienden tu plafón.
-- MoonBoard: «Iluminar la presa de arriba» añade un LED tenue sobre cada presa de inicio o de mano.
+- Un nuevo aspecto para tu plafón: las presas encendidas brillan con su propia silueta y el muro se atenúa. Es el nuevo aspecto por defecto en todos los plafones, Woods incluido.
+- Hazlo tuyo en Perfil > Más > Aspecto del plafón: preajustes, resplandor, velo, marcas, paletas para daltonismo. ¿Prefieres círculos? Pon Renderizado en Clásico.
+- MoonBoard: con el controlador LED de código abierto con Arduino, activa «Iluminar la presa de arriba».
 - Los paneles se cierran bien.

--- a/fastlane/metadata/android/fr-FR/changelogs/default.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/default.txt
@@ -1,4 +1,6 @@
 Nouveautés de la version 2.4 :
-- MoonBoard : active « Allumer la prise du dessus » pour ajouter une LED plus tamisée au-dessus de chaque prise de départ ou de main allumée sur les contrôleurs compatibles.
-- Les panneaux se ferment correctement après un passage en arrière-plan ou un changement d’écran.
-- Les fichiers partagés avec Boardsesh restent dans son cache même si une autre app fournit un nom inhabituel.
+- Ta board, redessinée : les prises allumées brillent dans leur vraie silhouette au lieu d'un cercle, et le mur s'assombrit. Les Woods aussi.
+- Tu préfères les cercles ? Profil > Plus > Look de la board > Classique.
+- Préréglages, réglages de lueur et de voile, palettes daltonisme qui allument aussi ta board.
+- MoonBoard : « Allumer la prise du dessus » ajoute une LED tamisée au-dessus de chaque prise de départ ou de main.
+- Les panneaux se ferment bien.

--- a/fastlane/metadata/android/fr-FR/changelogs/default.txt
+++ b/fastlane/metadata/android/fr-FR/changelogs/default.txt
@@ -1,6 +1,5 @@
 Nouveautés de la version 2.4 :
-- Ta board, redessinée : les prises allumées brillent dans leur vraie silhouette au lieu d'un cercle, et le mur s'assombrit. Les Woods aussi.
-- Tu préfères les cercles ? Profil > Plus > Look de la board > Classique.
-- Préréglages, réglages de lueur et de voile, palettes daltonisme qui allument aussi ta board.
-- MoonBoard : « Allumer la prise du dessus » ajoute une LED tamisée au-dessus de chaque prise de départ ou de main.
+- Un nouveau look pour ta board : les prises allumées brillent dans leur propre silhouette et le mur s'assombrit. C'est le look par défaut sur toutes les boards, Woods compris.
+- À régler dans Profil > Plus > Look de la board : préréglages, lueur, voile, marques, palettes daltonisme. Tu préfères les cercles ? Mets Rendu sur Classique.
+- MoonBoard : avec le contrôleur LED open source Arduino, active « Allumer la prise du dessus ».
 - Les panneaux se ferment bien.

--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -1,4 +1,27 @@
 Neu in 2.4:
 
-- MoonBoard: Aktiviere „Griff darüber beleuchten“, damit unterstützte Controller eine zweite, gedimmte LED über jedem beleuchteten Start- oder Handgriff einschalten.
-- Boardfotos und Griff-Overlays laden auf iOS ohne zusätzliche Pause.
+DEIN BOARD, NEU GEZEICHNET
+
+- Beleuchtete Griffe leuchten jetzt in ihrer eigenen Silhouette, direkt vom Board-Bild abgepaust, statt als farbiger Kreis über dem Foto. Jeder Griff leuchtet in seiner echten Form, und der Rest der Wand tritt zurück — so liest du den Boulder quer durch die Halle.
+- Am Kilter Homewall kommt das Licht von der LED-Platte rund um jeden Griff, genau wie bei einer eingeschalteten Wand.
+- Auch Woods-Boards haben jetzt echte Griff-Silhouetten.
+- Lieber Kreise? Profil > Mehr > Board-Look > Darstellung > Klassisch. Es geht dir nichts verloren.
+
+BOARD-LOOK
+
+- Starte mit einer Vorgabe: Boardsesh, Kräftig, Dezent oder Maximaler Kontrast. Und stell alles selbst ein, wenn du magst: Leuchtverlauf und -reichweite, Board-Schleier, Markierungsstil und Füllstärke, Listen-Vorschau.
+- Farbsehschwäche-Paletten (Protanopie, Deuteranopie, Tritanopie und Monochrom) für alle vier Griff-Rollen auf einmal. Sie beleuchten auch dein Board in diesen Farben, nicht nur den Bildschirm. Nur MoonBoards behalten ihre eigenen LEDs.
+- Rollen-Glyphen setzen einen Ring, einen Balken oder ein X in jeden beleuchteten Griff, damit die Rollen auch ohne Farbe klar bleiben.
+- Deine Barrierefreiheits-Einstellungen wohnen jetzt hier. Markierungsform, Strichstärke und Größe gelten weiterhin für die klassische Darstellung.
+
+MOONBOARD
+
+- Aktiviere „Griff darüber beleuchten“, damit unterstützte Controller eine zweite, gedimmte LED über jedem beleuchteten Start- oder Handgriff einschalten.
+
+BEHOBEN
+
+- Das Verbinden mit einem Board löscht es nicht mehr: Was an der Wand leuchtet, bleibt an, bis du einen Boulder auswählst.
+- Boardfotos und Griff-Overlays laden ohne zusätzliche Pause.
+- Ein Woods-Boulder, den die App nicht exakt beleuchten kann, sagt das jetzt, statt die falschen Griffe zu beleuchten.
+
+Kostenlos, werbefrei, Open Source.

--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -1,22 +1,14 @@
 Neu in 2.4:
 
-DEIN BOARD, NEU GEZEICHNET
+EIN NEUER LOOK FÜR DEIN BOARD
 
-- Beleuchtete Griffe leuchten jetzt in ihrer eigenen Silhouette, direkt vom Board-Bild abgepaust, statt als farbiger Kreis über dem Foto. Jeder Griff leuchtet in seiner echten Form, und der Rest der Wand tritt zurück — so liest du den Boulder quer durch die Halle.
-- Am Kilter Homewall kommt das Licht von der LED-Platte rund um jeden Griff, genau wie bei einer eingeschalteten Wand.
-- Auch Woods-Boards haben jetzt echte Griff-Silhouetten.
-- Lieber Kreise? Profil > Mehr > Board-Look > Darstellung > Klassisch. Es geht dir nichts verloren.
+Beleuchtete Griffe leuchten jetzt in ihrer eigenen Silhouette, direkt vom Board-Bild abgepaust, während der Rest der Wand zurücktritt. Schluss mit farbigen Kreisen über dem Foto: Du liest den Boulder quer durch die Halle. Das ist der neue Standard auf jedem Board, Woods inklusive, und am Kilter Homewall kommt das Licht von der LED-Platte rund um jeden Griff.
 
-BOARD-LOOK
-
-- Starte mit einer Vorgabe: Boardsesh, Kräftig, Dezent oder Maximaler Kontrast. Und stell alles selbst ein, wenn du magst: Leuchtverlauf und -reichweite, Board-Schleier, Markierungsstil und Füllstärke, Listen-Vorschau.
-- Farbsehschwäche-Paletten (Protanopie, Deuteranopie, Tritanopie und Monochrom) für alle vier Griff-Rollen auf einmal. Sie beleuchten auch dein Board in diesen Farben, nicht nur den Bildschirm. Nur MoonBoards behalten ihre eigenen LEDs.
-- Rollen-Glyphen setzen einen Ring, einen Balken oder ein X in jeden beleuchteten Griff, damit die Rollen auch ohne Farbe klar bleiben.
-- Deine Barrierefreiheits-Einstellungen wohnen jetzt hier. Markierungsform, Strichstärke und Größe gelten weiterhin für die klassische Darstellung.
+Stell ihn dir ein unter Profil > Mehr > Board-Look. Starte mit einer Vorgabe oder nimm alles selbst in die Hand: Leuchten, Schleier, Markierungen, Listen-Vorschau, Rollen-Glyphen und Farbsehschwäche-Paletten, die auch dein Board in diesen Farben beleuchten, nicht nur den Bildschirm. Lieber die alten Kreise? Stell Darstellung auf Klassisch.
 
 MOONBOARD
 
-- Aktiviere „Griff darüber beleuchten“, damit unterstützte Controller eine zweite, gedimmte LED über jedem beleuchteten Start- oder Handgriff einschalten.
+- Du nutzt den quelloffenen Arduino-LED-Controller fürs MoonBoard? Aktiviere „Griff darüber beleuchten“ für eine zweite, gedimmte LED über jedem beleuchteten Start- und Handgriff.
 
 BEHOBEN
 

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,22 +1,14 @@
 New in 2.4:
 
-YOUR BOARD, REDRAWN
+A NEW LOOK FOR YOUR BOARD
 
-- Lit holds now glow in their own shape, traced off the board art itself. No more coloured circles floating over the photo: every hold lights up as the shape it actually is, and the rest of the wall dims back so the climb reads from across the room.
-- On Kilter home walls the light comes off the LED plate around each hold, the way it looks when the wall is on.
-- Woods boards get real hold outlines too.
-- Still want the circles? Profile > More > Board look > Render > Classic. Nothing you had is gone.
+Lit holds now glow in their own shape, traced off the board art itself, while the rest of the wall dims back. No more coloured circles floating over the photo: the climb reads from across the room. It's the new default on every board, Woods included, and on Kilter home walls the light comes off the LED plate around each hold.
 
-BOARD LOOK
-
-- Start from a preset: Boardsesh, Bold, Subtle or Max contrast. Open the knobs when you want them: glow falloff and reach, board veil, mark style and fill strength, list thumbnails.
-- Colour-vision palettes for protanopia, deuteranopia, tritanopia and monochrome, applied to all four hold roles at once. They light your wall in those colours too, not just your screen. MoonBoards keep their own LEDs.
-- Role glyphs drop a ring, bar or X inside each lit hold, so the roles stay easy to tell apart without colour.
-- Your accessibility settings live here now. Marker shape, brush and size still apply to the Classic render.
+Make it yours under Profile > More > Board look. Start from a preset, or take over every part of it: glow, veil, marks, list thumbnails, role glyphs, and colour-vision palettes that light your wall in those colours too, not just your screen. Want the old circles back? Set Render to Classic.
 
 MOONBOARD
 
-- Turn on "Light the hold above" to add a dimmer LED above each lit start and hand hold on supported controllers.
+- Running the open-source Arduino MoonBoard LED controller? Turn on "Light the hold above" for a dimmer LED above each lit start and hand hold.
 
 FIXED
 

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,4 +1,27 @@
 New in 2.4:
 
-- MoonBoard: turn on “Light the hold above” to add a dimmer LED above each lit start and hand hold on supported controllers.
-- Board photos and hold overlays load without the extra pause on iOS.
+YOUR BOARD, REDRAWN
+
+- Lit holds now glow in their own shape, traced off the board art itself. No more coloured circles floating over the photo: every hold lights up as the shape it actually is, and the rest of the wall dims back so the climb reads from across the room.
+- On Kilter home walls the light comes off the LED plate around each hold, the way it looks when the wall is on.
+- Woods boards get real hold outlines too.
+- Still want the circles? Profile > More > Board look > Render > Classic. Nothing you had is gone.
+
+BOARD LOOK
+
+- Start from a preset: Boardsesh, Bold, Subtle or Max contrast. Open the knobs when you want them: glow falloff and reach, board veil, mark style and fill strength, list thumbnails.
+- Colour-vision palettes for protanopia, deuteranopia, tritanopia and monochrome, applied to all four hold roles at once. They light your wall in those colours too, not just your screen. MoonBoards keep their own LEDs.
+- Role glyphs drop a ring, bar or X inside each lit hold, so the roles stay easy to tell apart without colour.
+- Your accessibility settings live here now. Marker shape, brush and size still apply to the Classic render.
+
+MOONBOARD
+
+- Turn on "Light the hold above" to add a dimmer LED above each lit start and hand hold on supported controllers.
+
+FIXED
+
+- Connecting to a board no longer wipes it. What's lit on the wall stays lit until you pick a climb.
+- Board photos and hold overlays load without the extra pause.
+- A Woods climb the app can't light exactly now says so, instead of lighting the wrong holds.
+
+Free, no ads, open source.

--- a/fastlane/metadata/es-ES/release_notes.txt
+++ b/fastlane/metadata/es-ES/release_notes.txt
@@ -1,22 +1,14 @@
 Novedades de 2.4:
 
-TU PLAFÓN, REDIBUJADO
+UN NUEVO ASPECTO PARA TU PLAFÓN
 
-- Las presas encendidas brillan ahora con su propia silueta, calcada del dibujo del plafón, en vez de con un círculo de color sobre la foto. Cada presa se ilumina con la forma que tiene de verdad y el resto del muro se atenúa, así que el bloque se lee desde el otro lado de la sala.
-- En los Kilter Homewall la luz sale de la placa LED que rodea cada presa, igual que cuando el muro está encendido.
-- Los plafones Woods también tienen siluetas de presa reales.
-- ¿Prefieres los círculos? Perfil > Más > Aspecto del plafón > Renderizado > Clásico. No has perdido nada.
+Las presas encendidas brillan ahora con su propia silueta, calcada del dibujo del plafón, mientras el resto del muro se atenúa. Se acabaron los círculos de color sobre la foto: el bloque se lee desde el otro lado de la sala. Es el nuevo aspecto por defecto en todos los plafones, Woods incluido, y en los Kilter Homewall la luz sale de la placa LED que rodea cada presa.
 
-ASPECTO DEL PLAFÓN
-
-- Empieza por un preajuste: Boardsesh, Intenso, Sutil o Máximo contraste. Y abre los ajustes cuando quieras: caída y alcance del resplandor, velo del plafón, estilo e intensidad de las marcas, miniaturas de las listas.
-- Paletas para daltonismo (protanopía, deuteranopía, tritanopía y monocromo) aplicadas a los cuatro roles de presa a la vez. También encienden tu plafón con esos colores, no solo la pantalla. Los MoonBoard mantienen sus propios LED.
-- Los glifos de rol añaden un anillo, una barra o una X dentro de cada presa encendida, para que los roles se distingan sin depender del color.
-- Tus ajustes de accesibilidad ahora viven aquí. La forma, el grosor y el tamaño del marcador se siguen aplicando al renderizado Clásico.
+Hazlo tuyo en Perfil > Más > Aspecto del plafón. Empieza por un preajuste o toma el control de cada detalle: resplandor, velo, marcas, miniaturas de listas, glifos de rol y paletas para daltonismo que también encienden tu plafón con esos colores, no solo la pantalla. ¿Prefieres los círculos de antes? Pon Renderizado en Clásico.
 
 MOONBOARD
 
-- Activa «Iluminar la presa de arriba» para añadir un LED más tenue sobre cada presa de inicio o de mano iluminada en controladores compatibles.
+- ¿Usas el controlador LED de código abierto con Arduino para MoonBoard? Activa «Iluminar la presa de arriba» para añadir un LED más tenue sobre cada presa de inicio o de mano iluminada.
 
 CORREGIDO
 

--- a/fastlane/metadata/es-ES/release_notes.txt
+++ b/fastlane/metadata/es-ES/release_notes.txt
@@ -1,4 +1,27 @@
 Novedades de 2.4:
 
-- MoonBoard: activa «Iluminar la presa de arriba» para añadir un LED más tenue sobre cada presa de inicio o de mano iluminada en controladores compatibles.
-- En iOS, las fotos del plafón y las superposiciones de presas cargan sin la pausa extra.
+TU PLAFÓN, REDIBUJADO
+
+- Las presas encendidas brillan ahora con su propia silueta, calcada del dibujo del plafón, en vez de con un círculo de color sobre la foto. Cada presa se ilumina con la forma que tiene de verdad y el resto del muro se atenúa, así que el bloque se lee desde el otro lado de la sala.
+- En los Kilter Homewall la luz sale de la placa LED que rodea cada presa, igual que cuando el muro está encendido.
+- Los plafones Woods también tienen siluetas de presa reales.
+- ¿Prefieres los círculos? Perfil > Más > Aspecto del plafón > Renderizado > Clásico. No has perdido nada.
+
+ASPECTO DEL PLAFÓN
+
+- Empieza por un preajuste: Boardsesh, Intenso, Sutil o Máximo contraste. Y abre los ajustes cuando quieras: caída y alcance del resplandor, velo del plafón, estilo e intensidad de las marcas, miniaturas de las listas.
+- Paletas para daltonismo (protanopía, deuteranopía, tritanopía y monocromo) aplicadas a los cuatro roles de presa a la vez. También encienden tu plafón con esos colores, no solo la pantalla. Los MoonBoard mantienen sus propios LED.
+- Los glifos de rol añaden un anillo, una barra o una X dentro de cada presa encendida, para que los roles se distingan sin depender del color.
+- Tus ajustes de accesibilidad ahora viven aquí. La forma, el grosor y el tamaño del marcador se siguen aplicando al renderizado Clásico.
+
+MOONBOARD
+
+- Activa «Iluminar la presa de arriba» para añadir un LED más tenue sobre cada presa de inicio o de mano iluminada en controladores compatibles.
+
+CORREGIDO
+
+- Conectarte a un plafón ya no lo apaga: lo que esté iluminado en el muro sigue así hasta que elijas un bloque.
+- Las fotos del plafón y las superposiciones de presas cargan sin la pausa extra.
+- Un bloque de Woods que la app no puede iluminar con exactitud ahora lo dice, en vez de encender las presas equivocadas.
+
+Gratis, sin anuncios, código abierto.

--- a/fastlane/metadata/es-MX/release_notes.txt
+++ b/fastlane/metadata/es-MX/release_notes.txt
@@ -1,22 +1,14 @@
 Novedades de 2.4:
 
-TU PLAFÓN, REDIBUJADO
+UN NUEVO ASPECTO PARA TU PLAFÓN
 
-- Las presas encendidas brillan ahora con su propia silueta, calcada del dibujo del plafón, en vez de con un círculo de color sobre la foto. Cada presa se ilumina con la forma que tiene de verdad y el resto del muro se atenúa, así que el bloque se lee desde el otro lado de la sala.
-- En los Kilter Homewall la luz sale de la placa LED que rodea cada presa, igual que cuando el muro está encendido.
-- Los plafones Woods también tienen siluetas de presa reales.
-- ¿Prefieres los círculos? Perfil > Más > Aspecto del plafón > Renderizado > Clásico. No has perdido nada.
+Las presas encendidas brillan ahora con su propia silueta, calcada del dibujo del plafón, mientras el resto del muro se atenúa. Se acabaron los círculos de color sobre la foto: el bloque se lee desde el otro lado de la sala. Es el nuevo aspecto por defecto en todos los plafones, Woods incluido, y en los Kilter Homewall la luz sale de la placa LED que rodea cada presa.
 
-ASPECTO DEL PLAFÓN
-
-- Empieza por un preajuste: Boardsesh, Intenso, Sutil o Máximo contraste. Y abre los ajustes cuando quieras: caída y alcance del resplandor, velo del plafón, estilo e intensidad de las marcas, miniaturas de las listas.
-- Paletas para daltonismo (protanopía, deuteranopía, tritanopía y monocromo) aplicadas a los cuatro roles de presa a la vez. También encienden tu plafón con esos colores, no solo la pantalla. Los MoonBoard mantienen sus propios LED.
-- Los glifos de rol añaden un anillo, una barra o una X dentro de cada presa encendida, para que los roles se distingan sin depender del color.
-- Tus ajustes de accesibilidad ahora viven aquí. La forma, el grosor y el tamaño del marcador se siguen aplicando al renderizado Clásico.
+Hazlo tuyo en Perfil > Más > Aspecto del plafón. Empieza por un preajuste o toma el control de cada detalle: resplandor, velo, marcas, miniaturas de listas, glifos de rol y paletas para daltonismo que también encienden tu plafón con esos colores, no solo la pantalla. ¿Prefieres los círculos de antes? Pon Renderizado en Clásico.
 
 MOONBOARD
 
-- Activa «Iluminar la presa de arriba» para añadir un LED más tenue sobre cada presa de inicio o de mano iluminada en controladores compatibles.
+- ¿Usas el controlador LED de código abierto con Arduino para MoonBoard? Activa «Iluminar la presa de arriba» para añadir un LED más tenue sobre cada presa de inicio o de mano iluminada.
 
 CORREGIDO
 

--- a/fastlane/metadata/es-MX/release_notes.txt
+++ b/fastlane/metadata/es-MX/release_notes.txt
@@ -1,4 +1,27 @@
 Novedades de 2.4:
 
-- MoonBoard: activa «Iluminar la presa de arriba» para añadir un LED más tenue sobre cada presa de inicio o de mano iluminada en controladores compatibles.
-- En iOS, las fotos del plafón y las superposiciones de presas cargan sin la pausa extra.
+TU PLAFÓN, REDIBUJADO
+
+- Las presas encendidas brillan ahora con su propia silueta, calcada del dibujo del plafón, en vez de con un círculo de color sobre la foto. Cada presa se ilumina con la forma que tiene de verdad y el resto del muro se atenúa, así que el bloque se lee desde el otro lado de la sala.
+- En los Kilter Homewall la luz sale de la placa LED que rodea cada presa, igual que cuando el muro está encendido.
+- Los plafones Woods también tienen siluetas de presa reales.
+- ¿Prefieres los círculos? Perfil > Más > Aspecto del plafón > Renderizado > Clásico. No has perdido nada.
+
+ASPECTO DEL PLAFÓN
+
+- Empieza por un preajuste: Boardsesh, Intenso, Sutil o Máximo contraste. Y abre los ajustes cuando quieras: caída y alcance del resplandor, velo del plafón, estilo e intensidad de las marcas, miniaturas de las listas.
+- Paletas para daltonismo (protanopía, deuteranopía, tritanopía y monocromo) aplicadas a los cuatro roles de presa a la vez. También encienden tu plafón con esos colores, no solo la pantalla. Los MoonBoard mantienen sus propios LED.
+- Los glifos de rol añaden un anillo, una barra o una X dentro de cada presa encendida, para que los roles se distingan sin depender del color.
+- Tus ajustes de accesibilidad ahora viven aquí. La forma, el grosor y el tamaño del marcador se siguen aplicando al renderizado Clásico.
+
+MOONBOARD
+
+- Activa «Iluminar la presa de arriba» para añadir un LED más tenue sobre cada presa de inicio o de mano iluminada en controladores compatibles.
+
+CORREGIDO
+
+- Conectarte a un plafón ya no lo apaga: lo que esté iluminado en el muro sigue así hasta que elijas un bloque.
+- Las fotos del plafón y las superposiciones de presas cargan sin la pausa extra.
+- Un bloque de Woods que la app no puede iluminar con exactitud ahora lo dice, en vez de encender las presas equivocadas.
+
+Gratis, sin anuncios, código abierto.

--- a/fastlane/metadata/fr-FR/release_notes.txt
+++ b/fastlane/metadata/fr-FR/release_notes.txt
@@ -1,4 +1,27 @@
 Nouveautés de la version 2.4 :
 
-- MoonBoard : active « Allumer la prise du dessus » pour ajouter une LED plus tamisée au-dessus de chaque prise de départ ou de main allumée sur les contrôleurs compatibles.
-- Sur iOS, les photos de board et les superpositions de prises s’affichent sans pause supplémentaire.
+TA BOARD, REDESSINÉE
+
+- Les prises allumées brillent maintenant avec leur propre silhouette, décalquée sur le visuel de la board, au lieu d'un cercle de couleur posé sur la photo. Chaque prise s'allume dans sa vraie forme et le reste du mur s'assombrit, donc le bloc se lit depuis l'autre bout de la salle.
+- Sur les Kilter Homewall, la lumière sort de la plaque LED qui entoure chaque prise, comme quand le mur est allumé.
+- Les boards Woods ont aussi de vraies silhouettes de prise.
+- Tu préfères les cercles ? Profil > Plus > Look de la board > Rendu > Classique. Tu ne perds rien.
+
+LOOK DE LA BOARD
+
+- Pars d'un préréglage : Boardsesh, Intense, Discret ou Contraste max. Et ouvre les réglages quand tu veux : dégradé et portée de la lueur, voile de la board, style et intensité des marques, vignettes des listes.
+- Palettes daltonisme (protanopie, deutéranopie, tritanopie et monochrome) appliquées aux quatre rôles de prise d'un coup. Elles allument aussi ta board dans ces couleurs, pas seulement l'écran. Les MoonBoard gardent leurs propres LED.
+- Les glyphes de rôle ajoutent un anneau, une barre ou un repère en X dans chaque prise allumée, pour que les rôles restent faciles à distinguer sans les couleurs.
+- Tes réglages d'accessibilité vivent ici maintenant. La forme, l'épaisseur et la taille du marqueur s'appliquent toujours au rendu Classique.
+
+MOONBOARD
+
+- Active « Allumer la prise du dessus » pour ajouter une LED plus tamisée au-dessus de chaque prise de départ ou de main allumée sur les contrôleurs compatibles.
+
+CORRIGÉ
+
+- Se connecter à une board ne l'éteint plus : ce qui est allumé sur le mur le reste jusqu'à ce que tu choisisses un bloc.
+- Les photos de board et les superpositions de prises s'affichent sans pause supplémentaire.
+- Un bloc Woods que l'app ne peut pas allumer exactement le dit maintenant, au lieu d'allumer les mauvaises prises.
+
+Gratuit, sans pub, open source.

--- a/fastlane/metadata/fr-FR/release_notes.txt
+++ b/fastlane/metadata/fr-FR/release_notes.txt
@@ -1,22 +1,14 @@
 Nouveautés de la version 2.4 :
 
-TA BOARD, REDESSINÉE
+UN NOUVEAU LOOK POUR TA BOARD
 
-- Les prises allumées brillent maintenant avec leur propre silhouette, décalquée sur le visuel de la board, au lieu d'un cercle de couleur posé sur la photo. Chaque prise s'allume dans sa vraie forme et le reste du mur s'assombrit, donc le bloc se lit depuis l'autre bout de la salle.
-- Sur les Kilter Homewall, la lumière sort de la plaque LED qui entoure chaque prise, comme quand le mur est allumé.
-- Les boards Woods ont aussi de vraies silhouettes de prise.
-- Tu préfères les cercles ? Profil > Plus > Look de la board > Rendu > Classique. Tu ne perds rien.
+Les prises allumées brillent maintenant dans leur propre silhouette, décalquée sur le visuel de la board, pendant que le reste du mur s'assombrit. Fini les cercles de couleur posés sur la photo : le bloc se lit depuis l'autre bout de la salle. C'est le nouveau look par défaut sur toutes les boards, Woods compris, et sur les Kilter Homewall la lumière sort de la plaque LED qui entoure chaque prise.
 
-LOOK DE LA BOARD
-
-- Pars d'un préréglage : Boardsesh, Intense, Discret ou Contraste max. Et ouvre les réglages quand tu veux : dégradé et portée de la lueur, voile de la board, style et intensité des marques, vignettes des listes.
-- Palettes daltonisme (protanopie, deutéranopie, tritanopie et monochrome) appliquées aux quatre rôles de prise d'un coup. Elles allument aussi ta board dans ces couleurs, pas seulement l'écran. Les MoonBoard gardent leurs propres LED.
-- Les glyphes de rôle ajoutent un anneau, une barre ou un repère en X dans chaque prise allumée, pour que les rôles restent faciles à distinguer sans les couleurs.
-- Tes réglages d'accessibilité vivent ici maintenant. La forme, l'épaisseur et la taille du marqueur s'appliquent toujours au rendu Classique.
+À toi de le régler dans Profil > Plus > Look de la board. Pars d'un préréglage ou reprends la main sur tout : lueur, voile, marques, vignettes de liste, glyphes de rôle et palettes daltonisme, qui allument aussi ta board dans ces couleurs, pas seulement l'écran. Tu préfères les cercles d'avant ? Mets Rendu sur Classique.
 
 MOONBOARD
 
-- Active « Allumer la prise du dessus » pour ajouter une LED plus tamisée au-dessus de chaque prise de départ ou de main allumée sur les contrôleurs compatibles.
+- Tu utilises le contrôleur LED open source à base d'Arduino pour MoonBoard ? Active « Allumer la prise du dessus » pour ajouter une LED plus tamisée au-dessus de chaque prise de départ ou de main allumée.
 
 CORRIGÉ
 


### PR DESCRIPTION
## Summary

Rewrites the 2.4 store "What's New" across all nine fastlane files. The committed copy was written at `cfcdef9d8` ("prepare 2.4.0 store release"), at the top of the release train — it only covers the MoonBoard adjacent-hold LED and the iOS image-load stall. The 173 commits that landed since then include the whole #2202 board-render campaign, which is the actual headline of this release.

**Apple** (`fastlane/metadata/{en-US,es-ES,es-MX,fr-FR,de-DE}/release_notes.txt`, ≤4000 chars) opens with two short paragraphs: the new default look and what it does, then where to customise it and how to get the circles back. Then MoonBoard, then iOS-only fixes.

**Play** (`fastlane/metadata/android/{en-US,de-DE,es-ES,fr-FR}/changelogs/default.txt`, ≤500 chars) carries the same headline cut to length, with the Android sheet fix in place of the iOS ones.

What's covered, and where it came from:

| Copy | Source |
| --- | --- |
| Lit holds glow in their own traced silhouette; the wall dims back | #4833 / #4834 / #4835 / #4857 |
| Kilter home walls light from the LED plate around each hold | #4869 / #4871 |
| Woods boards get real hold outlines | #4865 (the old "art is 100% opaque" skip is gone) |
| Board look: presets, glow/veil controls, marks, thumbnails | #4836 |
| Colour-vision palettes that light the wall too; role glyphs | #4836 |
| MoonBoard "Light the hold above", scoped to the open-source Arduino LED controller | #4420, review feedback |
| Connecting no longer wipes the wall (iOS) | #4710 (closes #4544) |
| Board photos load without the pause (iOS) | #4301 (fixes #3928) |
| Sheets close reliably (Android) | #4120 (closes #4108) |
| A Woods climb the app can't light exactly says so | `1573497ad` |

Three things I deliberately kept out: the iPad hold-outline editor (#4859 is `isAdmin`-gated, untranslated, and ships zero corrected outlines), the tester preview/verdict flow (#4792 / #4825, tester-gated), and the SDK 57 patch stack (#4477 / #4848, no user-visible delta).

The story the copy tells is deliberately short: we shipped a better default, and you can take it apart if you want to. Classic is named in every locale with the exact path to it (`Profile > More > Board look`, set Render to Classic, and the translated equivalents), so the default flip never reads as something being taken away. Terminology follows `docs/i18n-{spanish,french,german}-glossary.md` and reuses the shipped in-app labels — a climber who reads "Aspecto del plafón" / "Look de la board" / "Board-Look" finds that screen by that name.

### Also in here

`docs/board-render-analytics.md` still said to ship `board-render-mode-default` at **0% `boardsesh`**. That is now the create-then-ramp instruction, with the 2.4 decision recorded: ramp to **100% `boardsesh`** once the binary is live in both stores. Until that flag is created and ramped in PostHog (project 412845), the notes describe a mode climbers must pick themselves — `packages/mobile/src/providers/feature-flags-provider.tsx:91-97`, unresolved reads as `classic`.

### Two preconditions before the build

1. **`board-render-mode-default` must exist and be ramped in PostHog.** This repo has shipped a flag that was wired in code but never created (`gym-kiosk`). Verify it exists.
2. **`release/next` is 14 commits behind `main`.** Merging `main` in adds two more user-facing fixes — #4881 (Android tick sheet sized to its form) and #4728 (logging a send during a board download no longer waits on it). They are not in this copy. If you merge, these two lines slot into the Play changelog's last bullet and the Apple FIXED block.

## Release Notes

- [x] No release note needed (internal / technical change)

Store listing copy, not an app change — the in-app What's New screen is not affected.

## Test plan

1. CI green (`store-metadata-limits` passes 29/29).

## Risk

Risk: 1/5 — store listing text plus one doc paragraph. No code, no schema, no native config. A wrong value is reversible by editing the `.txt` and re-running the metadata lane.

