### PR TITLE
fix(ci): assert the real daily cache header in the backend smoke check

### DIFF
--- a/scripts/production-backend-smoke.mjs
+++ b/scripts/production-backend-smoke.mjs
@@ -7,6 +7,11 @@ const DEFAULT_BASE_URL = 'https://ws.boardsesh.com';
 const DEFAULT_ATTEMPTS = 12;
 const DEFAULT_RETRY_DELAY_MS = 5_000;
 const DEFAULT_TIMEOUT_MS = 10_000;
+// Mirrors DAILY_TTL_SECONDS / DAILY_STALE_TTL_SECONDS in
+// packages/shared/board-render/src/headers.ts, which is what the backend serves
+// for an unversioned render. Kept honest by a test that reads those constants.
+const DAILY_CACHE_TTL_SECONDS = 86_400;
+const DAILY_CACHE_STALE_TTL_SECONDS = 604_800;
 const REQUIRED_GROUPED_NOTIFICATION_FIELDS = Object.freeze(['climbLayoutId', 'climbAngle']);
 const INTROSPECTION_QUERY = `
   query ProductionBackendSchemaSmoke {
@@ -104,6 +109,18 @@ function boardRenderEndpoint(baseUrl, cacheBuster = Date.now(), renderVersion = 
   return parsedUrl.toString();
 }
 
+function parseCacheControl(headerValue) {
+  const directives = new Map();
+  for (const rawDirective of headerValue.split(',')) {
+    const directive = rawDirective.trim().toLowerCase();
+    if (!directive) continue;
+    const separatorIndex = directive.indexOf('=');
+    if (separatorIndex === -1) directives.set(directive, '');
+    else directives.set(directive.slice(0, separatorIndex), directive.slice(separatorIndex + 1));
+  }
+  return directives;
+}
+
 function delay(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
@@ -181,14 +198,21 @@ async function checkBoardRenderOnce({
       throw new Error(`board render returned unexpected Content-Type: ${contentType || '(missing)'}`);
     }
     const cacheControl = response.headers.get('cache-control') ?? '';
-    if (!cacheControl.includes('public')) {
+    const cacheDirectives = parseCacheControl(cacheControl);
+    if (!cacheDirectives.has('public')) {
       throw new Error(`board render returned unexpected Cache-Control: ${cacheControl || '(missing)'}`);
     }
     if (renderVersion === null) {
-      if (cacheControl.includes('immutable') || !cacheControl.includes('max-age=86400')) {
+      // The daily tier keeps browsers honest (`max-age=0`) and lets the CDN hold
+      // the bytes for a day, so assert the shared-cache directives, not max-age.
+      if (
+        cacheDirectives.has('immutable') ||
+        cacheDirectives.get('s-maxage') !== String(DAILY_CACHE_TTL_SECONDS) ||
+        cacheDirectives.get('stale-while-revalidate') !== String(DAILY_CACHE_STALE_TTL_SECONDS)
+      ) {
         throw new Error(`unversioned board render returned unexpected Cache-Control: ${cacheControl || '(missing)'}`);
       }
-    } else if (!cacheControl.includes('immutable')) {
+    } else if (!cacheDirectives.has('immutable')) {
       throw new Error(`versioned board render returned unexpected Cache-Control: ${cacheControl || '(missing)'}`);
     }
     if (!response.headers.get('x-railway-request-id')) {
@@ -306,6 +330,8 @@ if (process.argv[1] === scriptPath) {
 
 export {
   BOARD_RENDER_VERSION,
+  DAILY_CACHE_STALE_TTL_SECONDS,
+  DAILY_CACHE_TTL_SECONDS,
   DEFAULT_ATTEMPTS,
   DEFAULT_BASE_URL,
   DEFAULT_RETRY_DELAY_MS,
@@ -317,6 +343,7 @@ export {
   checkBoardRenderOnce,
   checkBackendSchemaOnce,
   graphqlEndpoint,
+  parseCacheControl,
   parseCliArguments,
   parseGraphqlResponse,
   runBackendSmoke,

--- a/scripts/production-backend-smoke.test.mjs
+++ b/scripts/production-backend-smoke.test.mjs
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
+import { readFileSync } from 'node:fs';
 import {
   BOARD_RENDER_VERSION,
+  DAILY_CACHE_STALE_TTL_SECONDS,
+  DAILY_CACHE_TTL_SECONDS,
   assertGroupedNotificationSchema,
   boardRenderEndpoint,
   checkBoardRenderOnce,
@@ -9,6 +12,10 @@ import {
   parseGraphqlResponse,
   runBackendSmoke,
 } from './production-backend-smoke.mjs';
+
+// The exact header the backend serves for an unversioned render — browsers
+// revalidate every time (`max-age=0`), the CDN holds the bytes for a day.
+const DAILY_CACHE_CONTROL = 'public, max-age=0, s-maxage=86400, stale-while-revalidate=604800';
 
 function schemaPayload(fieldNames = ['id', 'climbLayoutId', 'climbAngle']) {
   return {
@@ -138,7 +145,7 @@ void test('checks the unversioned daily-cache board render path', async () => {
       return boardRenderResponse({
         headers: {
           'Content-Type': 'image/webp',
-          'Cache-Control': 'public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800',
+          'Cache-Control': DAILY_CACHE_CONTROL,
           'X-Railway-Request-Id': 'request-123',
         },
       });
@@ -148,7 +155,45 @@ void test('checks the unversioned daily-cache board render path', async () => {
 
   assert.equal(requestUrl.searchParams.has('v'), false);
   assert.doesNotMatch(renderResult.cacheControl, /immutable/);
-  assert.match(renderResult.cacheControl, /max-age=86400/);
+  assert.match(renderResult.cacheControl, /s-maxage=86400/);
+});
+
+void test('rejects an unversioned render served on the short redirect-grade tier', async () => {
+  await assert.rejects(
+    checkBoardRenderOnce({
+      baseUrl: 'https://example.com',
+      renderVersion: null,
+      fetchImpl: async () =>
+        boardRenderResponse({
+          headers: {
+            'Content-Type': 'image/webp',
+            'Cache-Control': 'public, max-age=0, s-maxage=300, stale-while-revalidate=86400',
+            'X-Railway-Request-Id': 'request-123',
+          },
+        }),
+      timeoutMs: 100,
+    }),
+    /unversioned board render returned unexpected Cache-Control/,
+  );
+});
+
+// The smoke check asserts a header the backend builds elsewhere. A fixture that
+// drifts from `createOgImageHeaders` is how the daily-tier check shipped asserting
+// a `max-age=86400` production never sent, so read the real constants here.
+void test('mirrors the daily cache tier defined by the shared board-render headers', () => {
+  const headersModule = readFileSync(
+    new URL('../packages/shared/board-render/src/headers.ts', import.meta.url),
+    'utf8',
+  );
+  const dailyTtl = headersModule.match(/const DAILY_TTL_SECONDS = ([\d_]+);/);
+  const dailyStaleTtl = headersModule.match(/const DAILY_STALE_TTL_SECONDS = ([\d_]+);/);
+  assert.ok(dailyTtl && dailyStaleTtl, 'could not read the daily cache constants from headers.ts');
+  assert.equal(Number(dailyTtl[1].replaceAll('_', '')), DAILY_CACHE_TTL_SECONDS);
+  assert.equal(Number(dailyStaleTtl[1].replaceAll('_', '')), DAILY_CACHE_STALE_TTL_SECONDS);
+  assert.equal(
+    DAILY_CACHE_CONTROL,
+    `public, max-age=0, s-maxage=${DAILY_CACHE_TTL_SECONDS}, stale-while-revalidate=${DAILY_CACHE_STALE_TTL_SECONDS}`,
+  );
 });
 
 void test('rejects cached proxy responses and malformed image bytes', async () => {
@@ -225,7 +270,7 @@ void test('retries transient failures and succeeds within the bounded attempt co
         return boardRenderResponse({
           headers: {
             'Content-Type': 'image/webp',
-            'Cache-Control': 'public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800',
+            'Cache-Control': DAILY_CACHE_CONTROL,
             'X-Railway-Request-Id': 'request-123',
           },
         });


### PR DESCRIPTION
## What

The main deploy has been failing at `node scripts/production-backend-smoke.mjs` — 12/12 attempts rejecting the unversioned board render:

```
unversioned board render returned unexpected Cache-Control:
public, max-age=0, s-maxage=86400, stale-while-revalidate=604800
```

The header is correct. The check was wrong. `createOgImageHeaders` serves the daily tier as `max-age=0, s-maxage=86400, stale-while-revalidate=604800` (browsers revalidate, the CDN holds the bytes for a day), but the smoke check asserted `max-age=86400`, which production has never sent. Note `s-maxage=86400` does not contain the substring `max-age=86400`, so the `includes()` check could not pass at all.

The unit test that was supposed to cover this used a fixture header (`public, max-age=86400, s-maxage=86400, ...`) that no code path produces — which is how a check that could never pass shipped green.

## How

1. Parse Cache-Control into directives instead of substring-matching.
2. Daily tier now asserts the pair that actually matters: `s-maxage=86400` + `stale-while-revalidate=604800`, and no `immutable`. Versioned tier is unchanged.
3. Test fixtures use the real production header; added a rejection case for the short (300s) tier.
4. New test reads `DAILY_TTL_SECONDS` / `DAILY_STALE_TTL_SECONDS` out of `packages/shared/board-render/src/headers.ts` so the smoke check and the header builder can't drift apart again.

Verified against live production: `node scripts/production-backend-smoke.mjs` passes on attempt 1 (versioned + daily render, 24702 bytes each).

## Test plan

1. CI green.
2. Main deploy reaches "Production backend smoke passed".

## Risk

Risk: 1/5 — CI-only script; no runtime, schema or app code touched.

## Release Notes

none
