### PR TITLE
feat(repo): rate-limit the climb-view path at Cloudflare, in observe-only mode

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -185,8 +185,37 @@ installs cleanly and matches nothing. A test pins that too.
 **What this does not catch.** UA blocking only stops crawlers that identify
 themselves honestly. A UA-rotating farm walked ~2,500 climb-view URLs on
 2026-08-22 behind ordinary Chrome/Firefox UAs (PostHog: 2,031 distinct persons,
-one pageview each, `$referring_domain` null on every event). That population
-needs an edge rate-limit rule, which is not managed here yet.
+one pageview each, `$referring_domain` null on every event). That population is
+what the rate-limit rule below is for.
+
+### Rate limiting the climb-view path
+
+`http_ratelimit` is the third managed phase. One rule,
+`boardsesh:climb-view-rate-limit`, counts requests per client IP against the
+`/view/` path on www — the segment every climb-view URL shape shares, across the
+config-tuple tree, the `/b/{slug}` tree and the `/de`, `/es` and `/fr` locale
+prefixes. Matching the segment rather than enumerating the trees means the rule
+cannot silently miss whichever tree is added next.
+
+**It ships in `log` mode and mitigates nothing.** The threshold (60 requests per
+60s, per IP per colo) is a starting guess, not a measurement: a reader opens a
+handful of climbs a minute and a crawler walks hundreds, but the gap between
+them has never been measured here. Read a few days of Cloudflare analytics at
+this setting, size the number against real traffic, then change `action`.
+
+Two things to know before flipping it:
+
+- `log` is **Enterprise-only**. On a lower plan the softest available mitigation
+  is `managed_challenge` (a real browser passes transparently; a headless farm
+  mostly does not), then `block`. If the zone rejects the rule on apply, that is
+  the reason — switch the action rather than the threshold.
+- `cf.colo.id` is a required characteristic outside Enterprise, so the counter is
+  per-datacentre rather than global and the effective allowance is higher than
+  `requests_per_period` alone suggests.
+
+Guessing low and blocking on day one throttles a gym full of climbers behind one
+NAT, which is why observe-first is the default. Rollback is the usual one: set
+`enabled: false` on the rule and re-run `vp run cf:apply -- --apply`.
 
 ### One-time: create the API token
 
@@ -215,6 +244,9 @@ Create a token at <https://dash.cloudflare.com/profile/api-tokens> scoped to the
 - **Zone.WAF Edit** — create/update the two crawler rules (see below). Without
   this scope `cf:apply` fails on the WAF phase while the cache rules still apply,
   so a partially-converged zone is the failure mode, not a silent skip.
+- **Zone.Rate Limit Edit** — create/update the climb-view rate-limit rule in the
+  `http_ratelimit` phase. Same partial-convergence failure mode as WAF Edit: the
+  earlier phases apply, this one 403s.
 - **Zone.Zone Settings Read** — read the SSL/TLS mode
 - **Zone.Zone Settings Edit** — only if you'll run `--allow-zone-ssl`
 

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -77,11 +77,24 @@ export const CRAWLER_ALLOW_RULE_DESCRIPTION =
   'boardsesh:allow-search-crawlers (managed by scripts/cloudflare-apply.ts)';
 export const CRAWLER_BLOCK_RULE_DESCRIPTION = 'boardsesh:block-seo-scrapers (managed by scripts/cloudflare-apply.ts)';
 
+/** Marker for the climb-view rate-limit rule. Same never-rename contract as above. */
+export const CLIMB_VIEW_RATE_LIMIT_RULE_DESCRIPTION =
+  'boardsesh:climb-view-rate-limit (managed by scripts/cloudflare-apply.ts)';
+
 /** The rulesets phase that holds cache-eligibility rules. */
 export const CACHE_RULE_PHASE = 'http_request_cache_settings';
 
 /** The rulesets phase that holds WAF custom rules. */
 export const WAF_RULE_PHASE = 'http_request_firewall_custom';
+
+/**
+ * The rulesets phase that holds rate-limiting rules.
+ *
+ * Unlike the cache and WAF phases, a zone that has never carried a rate-limit
+ * rule has no entrypoint ruleset here at all. `fetchPhaseRules` already reads a
+ * 404 as an empty phase, so the first apply creates it rather than failing.
+ */
+export const RATE_LIMIT_RULE_PHASE = 'http_ratelimit';
 
 /** Cloudflare SSL/TLS modes ordered weakest → strongest, for the "is the live mode weaker?" check. */
 export const SSL_MODE_STRENGTH = ['off', 'flexible', 'full', 'strict'] as const;
@@ -157,6 +170,38 @@ export interface WafRuleDesired {
   enabled: boolean;
 }
 
+/**
+ * A Cloudflare rate-limiting rule (the `http_ratelimit` phase).
+ *
+ * `action` is deliberately a union rather than a constant because the softest
+ * option is plan-gated: `log` observes without mitigating anything, which is
+ * what you want while sizing a threshold against real traffic, but Cloudflare
+ * restricts it to Enterprise. On lower plans the gentlest available action is
+ * `managed_challenge` — a real browser passes it transparently, a headless
+ * farm mostly does not — and `block` is the blunt instrument. Changing the
+ * mitigation is a one-word edit to the declared rule below.
+ *
+ * `characteristics` is what the counter is keyed on. `cf.colo.id` is required
+ * by Cloudflare on non-Enterprise plans and makes the budget per-datacentre
+ * rather than global, so the effective allowance is somewhat higher than
+ * `requests_per_period` suggests.
+ */
+export interface RateLimitRuleDesired {
+  description: string;
+  expression: string;
+  action: 'log' | 'managed_challenge' | 'block';
+  ratelimit: {
+    characteristics: string[];
+    /** Counting window in seconds. */
+    period: number;
+    /** Requests allowed per key per `period` before the action fires. */
+    requests_per_period: number;
+    /** How long the action keeps firing for a key that went over, in seconds. */
+    mitigation_timeout: number;
+  };
+  enabled: boolean;
+}
+
 export interface CloudflareDesiredState {
   zoneName: string;
   dnsRecords: DnsRecordDesired[];
@@ -168,6 +213,11 @@ export interface CloudflareDesiredState {
    * search engine. See upsertManagedRules in ./plan.
    */
   wafRules: WafRuleDesired[];
+  /**
+   * Order is not significant: each rate-limit rule counts independently, and
+   * Cloudflare evaluates every matching rule rather than stopping at the first.
+   */
+  rateLimitRules: RateLimitRuleDesired[];
   ssl: SslDesired;
 }
 
@@ -254,6 +304,19 @@ export function buildUserAgentExpression(tokens: readonly string[]): string {
 export const CRAWLER_ALLOW_EXPRESSION = buildUserAgentExpression(CRAWLER_ALLOW_TOKENS);
 export const CRAWLER_BLOCK_EXPRESSION = buildUserAgentExpression(CRAWLER_BLOCK_TOKENS);
 
+/**
+ * Climb-view pages on www, across every URL shape that renders one.
+ *
+ * Deliberately a `/view/` path match rather than an enumeration of the route
+ * trees: the config-tuple tree, the `/b/{slug}` short tree and the `/de`,
+ * `/es` and `/fr` locale prefixes all render the same expensive SSR, and a
+ * pattern per tree would silently miss whichever one is added next. Nothing
+ * else on www uses a `/view/` segment.
+ *
+ * Host-scoped so a future origin on another hostname cannot inherit it.
+ */
+export const CLIMB_VIEW_RATE_LIMIT_EXPRESSION = `(http.host eq "${WWW_HOSTNAME}" and http.request.uri.path contains "/view/")`;
+
 export const desiredCloudflareState: CloudflareDesiredState = {
   zoneName: ZONE_NAME,
   dnsRecords: [
@@ -328,6 +391,27 @@ export const desiredCloudflareState: CloudflareDesiredState = {
       description: CRAWLER_BLOCK_RULE_DESCRIPTION,
       expression: CRAWLER_BLOCK_EXPRESSION,
       action: 'block',
+      enabled: true,
+    },
+  ],
+  rateLimitRules: [
+    {
+      description: CLIMB_VIEW_RATE_LIMIT_RULE_DESCRIPTION,
+      expression: CLIMB_VIEW_RATE_LIMIT_EXPRESSION,
+      // Starts in observe-only mode on purpose. The threshold below is a
+      // starting guess, not a measurement: a real reader opens a handful of
+      // climbs a minute, a crawler walks hundreds, but the gap between them is
+      // exactly what we have never measured. Read a few days of Cloudflare
+      // analytics at this setting, size the number against what real traffic
+      // does, and only then swap the action. Guessing low and blocking on day
+      // one throttles a gym full of climbers sharing one NAT.
+      action: 'log',
+      ratelimit: {
+        characteristics: ['ip.src', 'cf.colo.id'],
+        period: 60,
+        requests_per_period: 60,
+        mitigation_timeout: 600,
+      },
       enabled: true,
     },
   ],

--- a/infra/cloudflare/plan.ts
+++ b/infra/cloudflare/plan.ts
@@ -6,11 +6,18 @@
 // scripts/cloudflare-apply.test.ts. The I/O (fetching live state, applying changes)
 // lives in scripts/cloudflare-apply.ts.
 
-import { SSL_MODE_STRENGTH, ZONE_NAME } from './config';
-import type { CacheRuleDesired, DnsRecordDesired, SslDesired, SslMode, WafRuleDesired } from './config';
+import { CACHE_RULE_PHASE, RATE_LIMIT_RULE_PHASE, SSL_MODE_STRENGTH, WAF_RULE_PHASE, ZONE_NAME } from './config';
+import type {
+  CacheRuleDesired,
+  DnsRecordDesired,
+  RateLimitRuleDesired,
+  SslDesired,
+  SslMode,
+  WafRuleDesired,
+} from './config';
 
 /** Anything this tool owns inside a ruleset phase. Identity is the description marker. */
-export type ManagedRuleDesired = CacheRuleDesired | WafRuleDesired;
+export type ManagedRuleDesired = CacheRuleDesired | WafRuleDesired | RateLimitRuleDesired;
 
 /** A DNS record as Cloudflare returns it. Which fields are owned depends on the desired record's management mode. */
 export interface LiveDnsRecord {
@@ -39,6 +46,9 @@ export interface RulesetRule {
   // read, and it keeps our strongly-typed desired rule assignable here. Compared
   // structurally via jsonEqual, never accessed by shape.
   action_parameters?: unknown;
+  // Rate-limit rules carry their counter config here rather than in
+  // action_parameters. Same treatment: compared structurally, never by shape.
+  ratelimit?: unknown;
   enabled?: boolean;
   version?: string;
   last_updated?: string;
@@ -52,9 +62,85 @@ export interface LiveState {
   cacheRules: RulesetRule[];
   /** Rules live in the WAF custom phase. Empty when the phase has no entrypoint ruleset yet. */
   wafRules: RulesetRule[];
+  /** Rate-limit phase. Commonly absent entirely on a zone that never had one; reads as empty. */
+  rateLimitRules: RulesetRule[];
   sslMode: string;
   /** Zone-wide flattening overrides per-record settings and breaks Tigris CNAME verification. */
   flattenAllCnames: boolean;
+}
+
+/** One planned-change kind per managed ruleset phase. */
+export type ManagedRuleResource = 'cache-rule' | 'waf-rule' | 'rate-limit-rule';
+
+/**
+ * Every ruleset phase this tool owns, in one place.
+ *
+ * This exists because the read, the diff and the apply each used to name the
+ * phases independently — two `fetchPhaseRules` calls, two `diffManagedRules`
+ * calls, and an `if/else if` chain with no `else`. Adding a third phase to two
+ * of those three and forgetting the third produced a dry-run that reported
+ * drift and an apply that silently wrote nothing. Driving all three from this
+ * array means a new phase is one entry, and `resolveRulePhase` throws rather
+ * than falling through if anything ever gets out of step.
+ */
+export interface ManagedRulePhase {
+  readonly resource: ManagedRuleResource;
+  /** Cloudflare rulesets phase name, used for both the GET and the PUT. */
+  readonly phase: string;
+  /** How the phase is named in dry-run output. */
+  readonly label: string;
+  readonly selectLive: (live: LiveState) => RulesetRule[];
+  readonly selectDesired: (desired: DesiredRuleSets) => readonly ManagedRuleDesired[];
+}
+
+/** The subset of the desired state that the phase registry selects from. */
+export interface DesiredRuleSets {
+  cacheRules: CacheRuleDesired[];
+  wafRules: WafRuleDesired[];
+  rateLimitRules: RateLimitRuleDesired[];
+}
+
+export const MANAGED_RULE_PHASES: readonly ManagedRulePhase[] = [
+  {
+    resource: 'cache-rule',
+    phase: CACHE_RULE_PHASE,
+    label: 'Cache rule',
+    selectLive: (live) => live.cacheRules,
+    selectDesired: (desired) => desired.cacheRules,
+  },
+  {
+    resource: 'waf-rule',
+    phase: WAF_RULE_PHASE,
+    label: 'WAF rule',
+    selectLive: (live) => live.wafRules,
+    selectDesired: (desired) => desired.wafRules,
+  },
+  {
+    resource: 'rate-limit-rule',
+    phase: RATE_LIMIT_RULE_PHASE,
+    label: 'Rate-limit rule',
+    selectLive: (live) => live.rateLimitRules,
+    selectDesired: (desired) => desired.rateLimitRules,
+  },
+];
+
+/**
+ * The registry entry for a planned change, or a loud failure.
+ *
+ * The apply loop routes through this instead of a ternary so that an
+ * unregistered resource stops the run rather than skipping the write — the
+ * difference between "the deploy failed" and "the deploy said applied and the
+ * zone never changed".
+ */
+export function resolveRulePhase(resource: ManagedRuleResource): ManagedRulePhase {
+  const entry = MANAGED_RULE_PHASES.find((candidate) => candidate.resource === resource);
+  if (!entry) {
+    throw new Error(
+      `No managed ruleset phase registered for resource "${resource}". ` +
+        `Add it to MANAGED_RULE_PHASES in infra/cloudflare/plan.ts.`,
+    );
+  }
+  return entry;
 }
 
 export interface PlanOptions {
@@ -63,7 +149,7 @@ export interface PlanOptions {
 }
 
 export interface PlannedChange {
-  resource: 'dns' | 'cache-rule' | 'waf-rule' | 'ssl';
+  resource: 'dns' | ManagedRuleResource | 'ssl';
   /** One-line human-readable summary of what would change. */
   summary: string;
   /** Optional extra context printed under the summary. */
@@ -109,7 +195,18 @@ export function cacheRuleMatches(liveRule: RulesetRule, desiredRule: ManagedRule
     liveRule.expression === desiredRule.expression &&
     liveRule.action === desiredRule.action &&
     (liveRule.enabled ?? true) === desiredRule.enabled &&
-    jsonEqual(liveRule.action_parameters, desiredRule.action_parameters)
+    // Both payload fields are per-variant: cache and WAF rules carry
+    // action_parameters, rate-limit rules carry ratelimit instead. Compare each
+    // only where it exists, and treat absent as undefined so a rule that should
+    // have neither cannot match one that has one.
+    jsonEqual(
+      liveRule.action_parameters,
+      'action_parameters' in desiredRule ? desiredRule.action_parameters : undefined,
+    ) &&
+    // Without this a rate-limit rule is write-once: its threshold, window and
+    // characteristics all live under `ratelimit`, so re-tuning the number
+    // would diff clean and never reach the zone.
+    jsonEqual(liveRule.ratelimit, 'ratelimit' in desiredRule ? desiredRule.ratelimit : undefined)
   );
 }
 
@@ -122,7 +219,8 @@ function sameRule(liveRule: RulesetRule | undefined, nextRule: RulesetRule): boo
     liveRule.expression === nextRule.expression &&
     liveRule.action === nextRule.action &&
     (liveRule.enabled ?? true) === (nextRule.enabled ?? true) &&
-    jsonEqual(liveRule.action_parameters, nextRule.action_parameters)
+    jsonEqual(liveRule.action_parameters, nextRule.action_parameters) &&
+    jsonEqual(liveRule.ratelimit, nextRule.ratelimit)
   );
 }
 
@@ -254,17 +352,17 @@ export function diffDnsRecord(desired: DnsRecordDesired, liveRecord: LiveDnsReco
  */
 export function diffManagedRules(
   existingRules: RulesetRule[],
-  desiredRules: ManagedRuleDesired[],
-  resource: 'cache-rule' | 'waf-rule',
+  desiredRules: readonly ManagedRuleDesired[],
+  resource: ManagedRuleResource,
 ): PlannedChange[] {
-  const { changed } = upsertCacheRule(existingRules, desiredRules);
+  const { changed } = upsertCacheRule(existingRules, [...desiredRules]);
   if (!changed) return [];
 
   const managedDescriptions = new Set(desiredRules.map((rule) => rule.description));
   const foreignCount = existingRules.filter(
     (rule) => rule.description === undefined || !managedDescriptions.has(rule.description),
   ).length;
-  const label = resource === 'waf-rule' ? 'WAF rule' : 'Cache rule';
+  const { label } = resolveRulePhase(resource);
 
   const changes: PlannedChange[] = [];
   for (const desiredRule of desiredRules) {
@@ -338,10 +436,8 @@ export function diffSslMode(desiredMode: SslMode, liveMode: string, allowZoneSsl
 
 /** Full desired-vs-live diff: the ordered list of changes --apply would attempt. Empty = in sync. */
 export function buildPlan(
-  desired: {
+  desired: DesiredRuleSets & {
     dnsRecords: DnsRecordDesired[];
-    cacheRules: CacheRuleDesired[];
-    wafRules: WafRuleDesired[];
     ssl: SslDesired;
   },
   live: LiveState,
@@ -369,16 +465,18 @@ export function buildPlan(
     return change ? [change] : [];
   });
 
-  const cacheChanges = diffManagedRules(live.cacheRules, desired.cacheRules, 'cache-rule');
-  const wafChanges = diffManagedRules(live.wafRules, desired.wafRules, 'waf-rule');
+  // Driven by MANAGED_RULE_PHASES so the plan can never cover fewer phases than
+  // the apply writes, or vice versa.
+  const ruleChanges = MANAGED_RULE_PHASES.flatMap((phase) =>
+    diffManagedRules(phase.selectLive(live), phase.selectDesired(desired), phase.resource),
+  );
 
   const sslChange = diffSslMode(desired.ssl.mode, live.sslMode, options.allowZoneSsl);
   // Order matters on cutover: SSL and the cache rule must be live BEFORE the
   // proxied flip, or traffic transits Cloudflare without them (Flexible-SSL
   // redirect loops would take the WebSocket host down).
   if (sslChange) changes.push(sslChange);
-  changes.push(...cacheChanges);
-  changes.push(...wafChanges);
+  changes.push(...ruleChanges);
   for (const dnsChange of dnsChanges) {
     const desiredRecord = desired.dnsRecords.find((record) => record.name === dnsChange.dnsName);
     if (!desiredRecord) throw new Error(`No desired DNS record found for planned change "${dnsChange.dnsName}"`);

--- a/infra/cloudflare/plan.ts
+++ b/infra/cloudflare/plan.ts
@@ -59,11 +59,18 @@ export interface RulesetRule {
 export interface LiveState {
   /** One entry per desired hostname. Fully managed records may be null when they need creation. */
   dnsRecords: Record<string, LiveDnsRecord | null>;
-  cacheRules: RulesetRule[];
-  /** Rules live in the WAF custom phase. Empty when the phase has no entrypoint ruleset yet. */
-  wafRules: RulesetRule[];
-  /** Rate-limit phase. Commonly absent entirely on a zone that never had one; reads as empty. */
-  rateLimitRules: RulesetRule[];
+  /**
+   * Live rules per managed phase, keyed by resource.
+   *
+   * A keyed record rather than one named field per phase, so adding a phase is
+   * a one-place change: the read fills this by iterating MANAGED_RULE_PHASES
+   * rather than naming fields, and ALL_PHASES_REGISTERED below fails the build
+   * if a resource is declared without a registry entry to fetch it.
+   *
+   * A phase with no entrypoint ruleset yet reads as an empty array — common on
+   * the rate-limit phase for a zone that has never had one.
+   */
+  rules: Record<ManagedRuleResource, RulesetRule[]>;
   sslMode: string;
   /** Zone-wide flattening overrides per-record settings and breaks Tigris CNAME verification. */
   flattenAllCnames: boolean;
@@ -100,29 +107,42 @@ export interface DesiredRuleSets {
   rateLimitRules: RateLimitRuleDesired[];
 }
 
-export const MANAGED_RULE_PHASES: readonly ManagedRulePhase[] = [
+export const MANAGED_RULE_PHASES = [
   {
     resource: 'cache-rule',
     phase: CACHE_RULE_PHASE,
     label: 'Cache rule',
-    selectLive: (live) => live.cacheRules,
+    selectLive: (live) => live.rules['cache-rule'],
     selectDesired: (desired) => desired.cacheRules,
   },
   {
     resource: 'waf-rule',
     phase: WAF_RULE_PHASE,
     label: 'WAF rule',
-    selectLive: (live) => live.wafRules,
+    selectLive: (live) => live.rules['waf-rule'],
     selectDesired: (desired) => desired.wafRules,
   },
   {
     resource: 'rate-limit-rule',
     phase: RATE_LIMIT_RULE_PHASE,
     label: 'Rate-limit rule',
-    selectLive: (live) => live.rateLimitRules,
+    selectLive: (live) => live.rules['rate-limit-rule'],
     selectDesired: (desired) => desired.rateLimitRules,
   },
-];
+] as const satisfies readonly ManagedRulePhase[];
+
+/**
+ * Build-time proof that every declared resource has a registry entry.
+ *
+ * Without this the `as` cast in `fetchLiveState` would be a lie: a resource
+ * added to ManagedRuleResource but not to MANAGED_RULE_PHASES would never be
+ * fetched, and its key would simply be missing from the record at runtime
+ * while the cast asserted otherwise. Adding the resource alone stops compiling
+ * here, which is the whole point of the registry.
+ */
+type UnregisteredResource = Exclude<ManagedRuleResource, (typeof MANAGED_RULE_PHASES)[number]['resource']>;
+const ALL_PHASES_REGISTERED: UnregisteredResource extends never ? true : never = true;
+void ALL_PHASES_REGISTERED;
 
 /**
  * The registry entry for a planned change, or a loud failure.

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -13,12 +13,15 @@ import {
   CRAWLER_ALLOW_TOKENS,
   CRAWLER_BLOCK_RULE_DESCRIPTION,
   CRAWLER_BLOCK_TOKENS,
+  CLIMB_VIEW_RATE_LIMIT_RULE_DESCRIPTION,
+  RATE_LIMIT_RULE_PHASE,
   WWW_HOSTNAME,
   WS_HOSTNAME,
   desiredCloudflareState,
 } from '../infra/cloudflare/config';
 import type { DnsRecordDesired, FullyManagedDnsRecordDesired } from '../infra/cloudflare/config';
 import {
+  MANAGED_RULE_PHASES,
   buildPlan,
   cacheRuleMatches,
   diffCacheRule,
@@ -26,6 +29,7 @@ import {
   diffDnsRecord,
   diffSslMode,
   jsonEqual,
+  resolveRulePhase,
   upsertCacheRule,
 } from '../infra/cloudflare/plan';
 import type { LiveDnsRecord, LiveState, RulesetRule } from '../infra/cloudflare/plan';
@@ -111,7 +115,15 @@ function foreignRule(id: string): RulesetRule {
 
 /** Live copies of every managed rule, matching desired (plus Cloudflare's read-only fields). */
 function matchingLiveRules(
-  desiredRules: readonly { description: string; expression: string; action: string; action_parameters?: unknown }[],
+  desiredRules: readonly {
+    description: string;
+    expression: string;
+    action: string;
+    action_parameters?: unknown;
+    // Carried through so a rate-limit rule can be "in sync" in a fixture at all:
+    // its threshold lives here, and cacheRuleMatches compares it.
+    ratelimit?: unknown;
+  }[],
 ): RulesetRule[] {
   return desiredRules.map((rule, index) => ({
     id: `our-rule-id-${index}`,
@@ -122,8 +134,17 @@ function matchingLiveRules(
     expression: rule.expression,
     action: rule.action,
     action_parameters: rule.action_parameters,
+    ratelimit: rule.ratelimit,
     enabled: true,
   }));
+}
+
+/** LiveState field holding the live rules for a managed resource. */
+function phaseStateKey(resource: string): 'cacheRules' | 'wafRules' | 'rateLimitRules' {
+  if (resource === 'cache-rule') return 'cacheRules';
+  if (resource === 'waf-rule') return 'wafRules';
+  if (resource === 'rate-limit-rule') return 'rateLimitRules';
+  throw new Error(`Unmapped managed rule resource "${resource}" — add it here and to MANAGED_RULE_PHASES.`);
 }
 
 function inSyncLiveState(): LiveState {
@@ -134,6 +155,7 @@ function inSyncLiveState(): LiveState {
     },
     cacheRules: matchingLiveRules(desired.cacheRules),
     wafRules: matchingLiveRules(desired.wafRules),
+    rateLimitRules: matchingLiveRules(desired.rateLimitRules),
     sslMode: 'strict',
     flattenAllCnames: false,
   };
@@ -335,6 +357,7 @@ describe('buildPlan', () => {
       },
       cacheRules: [foreignRule('foreign-a')],
       wafRules: matchingLiveRules(desired.wafRules),
+      rateLimitRules: matchingLiveRules(desired.rateLimitRules),
       sslMode: 'full',
       flattenAllCnames: false,
     };
@@ -360,6 +383,7 @@ describe('buildPlan', () => {
       },
       cacheRules: [],
       wafRules: [],
+      rateLimitRules: [],
       sslMode: 'strict',
       flattenAllCnames: false,
     };
@@ -376,6 +400,7 @@ describe('buildPlan', () => {
       },
       cacheRules: matchingLiveRules(desired.cacheRules),
       wafRules: matchingLiveRules(desired.wafRules),
+      rateLimitRules: matchingLiveRules(desired.rateLimitRules),
       sslMode: 'full',
       flattenAllCnames: false,
     };
@@ -698,6 +723,7 @@ describe('token scope guidance', () => {
     expect(printed).toContain('Zone.DNS Edit'); // PATCH ws; create/update the assets CNAME
     expect(printed).toContain('Zone.Cache Rules Edit'); // PUT the cache-settings phase
     expect(printed).toContain('Zone.WAF Edit'); // PUT the firewall-custom phase
+    expect(printed).toContain('Zone.Rate Limit Edit'); // PUT the http_ratelimit phase
     expect(printed).toContain('Zone.Zone Settings Read'); // GET /settings/ssl
     expect(printed).toContain('Zone.Zone Settings Edit'); // PATCH /settings/ssl
   });
@@ -721,5 +747,98 @@ describe('token scope guidance', () => {
       expect(scope).toMatch(/^(Zone|Account)\.\S/);
       expect(scope).toContain('—');
     }
+  });
+});
+
+describe('managed ruleset phases', () => {
+  // The bug this registry exists to prevent: the read, the diff and the apply
+  // each named the phases independently, and the apply's if/else chain had no
+  // else. A third phase wired into two of the three produced a dry-run that
+  // reported drift and an apply that wrote nothing while logging "applied".
+
+  it('registers a distinct phase and resource for every managed rule kind', () => {
+    const resources = MANAGED_RULE_PHASES.map((phase) => phase.resource);
+    const phases = MANAGED_RULE_PHASES.map((phase) => phase.phase);
+    expect(new Set(resources).size).toBe(MANAGED_RULE_PHASES.length);
+    expect(new Set(phases).size).toBe(MANAGED_RULE_PHASES.length);
+    expect(phases).toContain(RATE_LIMIT_RULE_PHASE);
+  });
+
+  it('resolves every registered resource, and throws rather than skipping an unknown one', () => {
+    for (const phase of MANAGED_RULE_PHASES) {
+      expect(resolveRulePhase(phase.resource)).toBe(phase);
+    }
+    // The mutant this kills: returning undefined (or falling through) here is
+    // what made the old apply loop silently skip a whole phase.
+    expect(() => resolveRulePhase('nope' as (typeof MANAGED_RULE_PHASES)[number]['resource'])).toThrowError(
+      /No managed ruleset phase registered/,
+    );
+  });
+
+  it('plans a change for drift in EVERY registered phase, not just the first two', () => {
+    // Walks the registry rather than naming phases, so a phase added later is
+    // covered by this test the day it is added.
+    for (const phase of MANAGED_RULE_PHASES) {
+      const live = inSyncLiveState();
+      // Empty this one phase; every other phase stays in sync.
+      const drifted: LiveState = { ...live, [phaseStateKey(phase.resource)]: [] } as LiveState;
+      const changes = buildPlan(desired, drifted, { allowZoneSsl: false });
+      expect(
+        changes.some((change) => change.resource === phase.resource),
+        `${phase.resource} drift produced no planned change`,
+      ).toBe(true);
+    }
+  });
+
+  it('preserves foreign rules in every phase, including a foreign rate-limit rule', () => {
+    // The PUT replaces the whole phase, so anything not merged through is deleted.
+    for (const phase of MANAGED_RULE_PHASES) {
+      const foreign = foreignRule(`foreign-${phase.resource}`);
+      const { rules } = upsertCacheRule([foreign], [...phase.selectDesired(desired)]);
+      expect(rules).toContain(foreign);
+      expect(rules).toHaveLength(1 + phase.selectDesired(desired).length);
+    }
+  });
+});
+
+describe('climb-view rate-limit rule', () => {
+  const rateLimitRule = desired.rateLimitRules.find(
+    (rule) => rule.description === CLIMB_VIEW_RATE_LIMIT_RULE_DESCRIPTION,
+  );
+
+  it('is declared, and starts in observe-only mode', () => {
+    // Shipping this straight to `block` on a guessed threshold would throttle a
+    // gym full of climbers behind one NAT. Flip it only after reading analytics.
+    expect(rateLimitRule).toBeDefined();
+    expect(rateLimitRule?.action).toBe('log');
+    expect(rateLimitRule?.enabled).toBe(true);
+  });
+
+  it('keys the counter on the client IP and the required colo characteristic', () => {
+    // Cloudflare rejects a non-Enterprise rate-limit rule that omits cf.colo.id.
+    expect(rateLimitRule?.ratelimit.characteristics).toEqual(['ip.src', 'cf.colo.id']);
+  });
+
+  it('covers every climb-view URL shape on www, including the locale prefixes', () => {
+    // A pattern per route tree would miss whichever tree is added next, so the
+    // rule matches the /view/ segment that all of them share.
+    const expression = rateLimitRule?.expression ?? '';
+    expect(expression).toContain(`http.host eq "${WWW_HOSTNAME}"`);
+    expect(expression).toContain('"/view/"');
+    // Host-scoped: a future origin on ws must not inherit it.
+    expect(expression).not.toContain(WS_HOSTNAME);
+  });
+
+  it('treats a threshold change as drift', () => {
+    // Without ratelimit in the comparison the rule is write-once: re-tuning
+    // requests_per_period would diff clean and never reach the zone.
+    const live = matchingLiveRules(desired.rateLimitRules)[0];
+    expect(cacheRuleMatches(live, desired.rateLimitRules[0])).toBe(true);
+
+    const retuned = {
+      ...desired.rateLimitRules[0],
+      ratelimit: { ...desired.rateLimitRules[0].ratelimit, requests_per_period: 30 },
+    };
+    expect(cacheRuleMatches(live, retuned)).toBe(false);
   });
 });

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -139,23 +139,17 @@ function matchingLiveRules(
   }));
 }
 
-/** LiveState field holding the live rules for a managed resource. */
-function phaseStateKey(resource: string): 'cacheRules' | 'wafRules' | 'rateLimitRules' {
-  if (resource === 'cache-rule') return 'cacheRules';
-  if (resource === 'waf-rule') return 'wafRules';
-  if (resource === 'rate-limit-rule') return 'rateLimitRules';
-  throw new Error(`Unmapped managed rule resource "${resource}" — add it here and to MANAGED_RULE_PHASES.`);
-}
-
 function inSyncLiveState(): LiveState {
   return {
     dnsRecords: {
       [wsDnsRecord.name]: liveDnsRecord(),
       [assetsDnsRecord.name]: liveAssetsDnsRecord(),
     },
-    cacheRules: matchingLiveRules(desired.cacheRules),
-    wafRules: matchingLiveRules(desired.wafRules),
-    rateLimitRules: matchingLiveRules(desired.rateLimitRules),
+    rules: {
+      'cache-rule': matchingLiveRules(desired.cacheRules),
+      'waf-rule': matchingLiveRules(desired.wafRules),
+      'rate-limit-rule': matchingLiveRules(desired.rateLimitRules),
+    },
     sslMode: 'strict',
     flattenAllCnames: false,
   };
@@ -355,9 +349,11 @@ describe('buildPlan', () => {
         [wsDnsRecord.name]: liveDnsRecord({ proxied: false }),
         [assetsDnsRecord.name]: liveAssetsDnsRecord(),
       },
-      cacheRules: [foreignRule('foreign-a')],
-      wafRules: matchingLiveRules(desired.wafRules),
-      rateLimitRules: matchingLiveRules(desired.rateLimitRules),
+      rules: {
+        'cache-rule': [foreignRule('foreign-a')],
+        'waf-rule': matchingLiveRules(desired.wafRules),
+        'rate-limit-rule': matchingLiveRules(desired.rateLimitRules),
+      },
       sslMode: 'full',
       flattenAllCnames: false,
     };
@@ -381,9 +377,7 @@ describe('buildPlan', () => {
         [wsDnsRecord.name]: liveDnsRecord({ proxied: false }),
         [assetsDnsRecord.name]: liveAssetsDnsRecord(),
       },
-      cacheRules: [],
-      wafRules: [],
-      rateLimitRules: [],
+      rules: { 'cache-rule': [], 'waf-rule': [], 'rate-limit-rule': [] },
       sslMode: 'strict',
       flattenAllCnames: false,
     };
@@ -398,9 +392,11 @@ describe('buildPlan', () => {
         [wsDnsRecord.name]: liveDnsRecord({ proxied: false }),
         [assetsDnsRecord.name]: null,
       },
-      cacheRules: matchingLiveRules(desired.cacheRules),
-      wafRules: matchingLiveRules(desired.wafRules),
-      rateLimitRules: matchingLiveRules(desired.rateLimitRules),
+      rules: {
+        'cache-rule': matchingLiveRules(desired.cacheRules),
+        'waf-rule': matchingLiveRules(desired.wafRules),
+        'rate-limit-rule': matchingLiveRules(desired.rateLimitRules),
+      },
       sslMode: 'full',
       flattenAllCnames: false,
     };
@@ -781,7 +777,7 @@ describe('managed ruleset phases', () => {
     for (const phase of MANAGED_RULE_PHASES) {
       const live = inSyncLiveState();
       // Empty this one phase; every other phase stays in sync.
-      const drifted: LiveState = { ...live, [phaseStateKey(phase.resource)]: [] } as LiveState;
+      const drifted: LiveState = { ...live, rules: { ...live.rules, [phase.resource]: [] } };
       const changes = buildPlan(desired, drifted, { allowZoneSsl: false });
       expect(
         changes.some((change) => change.resource === phase.resource),

--- a/scripts/cloudflare-apply.ts
+++ b/scripts/cloudflare-apply.ts
@@ -40,9 +40,9 @@
  */
 
 import { pathToFileURL } from 'node:url';
-import { CACHE_RULE_PHASE, WAF_RULE_PHASE, ZONE_NAME, desiredCloudflareState } from '../infra/cloudflare/config';
+import { ZONE_NAME, desiredCloudflareState } from '../infra/cloudflare/config';
 import type { DnsRecordDesired, FullyManagedDnsRecordDesired, SslMode } from '../infra/cloudflare/config';
-import { buildPlan, upsertCacheRule } from '../infra/cloudflare/plan';
+import { MANAGED_RULE_PHASES, buildPlan, resolveRulePhase, upsertCacheRule } from '../infra/cloudflare/plan';
 import type { LiveDnsRecord, LiveState, PlannedChange, RulesetRule } from '../infra/cloudflare/plan';
 
 const CF_API_BASE = 'https://api.cloudflare.com/client/v4';
@@ -54,6 +54,7 @@ const TOKEN_SCOPES = [
   'Zone.DNS Edit            — manage DNS records + read zone CNAME-flattening settings',
   'Zone.Cache Rules Edit    — create/update the /og/ cache rule',
   'Zone.WAF Edit            — create/update the two crawler rules',
+  'Zone.Rate Limit Edit     — create/update the climb-view rate-limit rule (http_ratelimit phase)',
   'Zone.Zone Settings Read  — read the SSL/TLS mode',
   'Zone.Zone Settings Edit  — ONLY needed with --allow-zone-ssl (to set the zone SSL mode)',
 ];
@@ -217,17 +218,23 @@ async function fetchLiveState(
   zoneId: string,
   desiredDnsRecords: DnsRecordDesired[],
 ): Promise<LiveState> {
-  const [fetchedDnsRecords, cacheRules, wafRules, sslMode, flattenAllCnames] = await Promise.all([
+  const [fetchedDnsRecords, phaseRules, sslMode, flattenAllCnames] = await Promise.all([
     Promise.all(
       desiredDnsRecords.map(
         async (desiredRecord) => [desiredRecord, await fetchDnsRecord(token, zoneId, desiredRecord.name)] as const,
       ),
     ),
-    fetchPhaseRules(token, zoneId, CACHE_RULE_PHASE),
-    fetchPhaseRules(token, zoneId, WAF_RULE_PHASE),
+    // One read per registered phase: adding a phase to the registry cannot leave
+    // the diff comparing against an empty array it never fetched.
+    Promise.all(
+      MANAGED_RULE_PHASES.map(
+        async (phase) => [phase.resource, await fetchPhaseRules(token, zoneId, phase.phase)] as const,
+      ),
+    ),
     fetchSslMode(token, zoneId),
     fetchFlattenAllCnames(token, zoneId),
   ]);
+  const rulesByResource = new Map(phaseRules);
   const dnsRecords: Record<string, LiveDnsRecord | null> = {};
   for (const [desiredRecord, liveRecord] of fetchedDnsRecords) {
     if (!liveRecord && desiredRecord.management === 'proxied-only') {
@@ -238,7 +245,14 @@ async function fetchLiveState(
     }
     dnsRecords[desiredRecord.name] = liveRecord;
   }
-  return { dnsRecords, cacheRules, wafRules, sslMode, flattenAllCnames };
+  return {
+    dnsRecords,
+    cacheRules: rulesByResource.get('cache-rule') ?? [],
+    wafRules: rulesByResource.get('waf-rule') ?? [],
+    rateLimitRules: rulesByResource.get('rate-limit-rule') ?? [],
+    sslMode,
+    flattenAllCnames,
+  };
 }
 
 export function fullyManagedDnsBody(desired: FullyManagedDnsRecordDesired): Record<string, unknown> {
@@ -369,21 +383,23 @@ async function main(): Promise<number> {
       if (!desiredRecord) throw new Error(`No desired DNS record found for planned change "${change.dnsName}"`);
       await applyDnsRecord(token, zoneId, desiredRecord, live.dnsRecords[desiredRecord.name] ?? null);
       console.log(`[cf-apply] applied: ${change.summary}`);
-    } else if (change.resource === 'cache-rule' || change.resource === 'waf-rule') {
+    } else if (change.resource === 'ssl') {
+      await applySslMode(token, zoneId, desired.ssl.mode);
+      console.log(`[cf-apply] applied: ${change.summary}`);
+    } else {
       // One PUT per phase, not per planned change. The plan reports each drifted
       // rule separately so a dry-run names them, but the rulesets API only offers
       // a whole-phase write and the merged array already contains every rule.
-      const phase = change.resource === 'waf-rule' ? WAF_RULE_PHASE : CACHE_RULE_PHASE;
-      if (!appliedPhases.has(phase)) {
-        const existingRules = change.resource === 'waf-rule' ? live.wafRules : live.cacheRules;
-        const desiredRules = change.resource === 'waf-rule' ? desired.wafRules : desired.cacheRules;
-        const { rules } = upsertCacheRule(existingRules, desiredRules);
-        await applyPhaseRules(token, zoneId, phase, rules);
-        appliedPhases.add(phase);
+      //
+      // Resolved through the registry rather than a ternary: an unregistered
+      // resource throws here instead of falling out of the chain and reporting
+      // "applied" for a write that never happened.
+      const phase = resolveRulePhase(change.resource);
+      if (!appliedPhases.has(phase.phase)) {
+        const { rules } = upsertCacheRule(phase.selectLive(live), [...phase.selectDesired(desired)]);
+        await applyPhaseRules(token, zoneId, phase.phase, rules);
+        appliedPhases.add(phase.phase);
       }
-      console.log(`[cf-apply] applied: ${change.summary}`);
-    } else if (change.resource === 'ssl') {
-      await applySslMode(token, zoneId, desired.ssl.mode);
       console.log(`[cf-apply] applied: ${change.summary}`);
     }
   }

--- a/scripts/cloudflare-apply.ts
+++ b/scripts/cloudflare-apply.ts
@@ -234,7 +234,10 @@ async function fetchLiveState(
     fetchSslMode(token, zoneId),
     fetchFlattenAllCnames(token, zoneId),
   ]);
-  const rulesByResource = new Map(phaseRules);
+  // Built straight from the registry: no second place that has to learn about a
+  // new phase. The cast is sound because ALL_PHASES_REGISTERED in plan.ts fails
+  // the build if a resource has no registry entry, so every key is present.
+  const rules = Object.fromEntries(phaseRules) as LiveState['rules'];
   const dnsRecords: Record<string, LiveDnsRecord | null> = {};
   for (const [desiredRecord, liveRecord] of fetchedDnsRecords) {
     if (!liveRecord && desiredRecord.management === 'proxied-only') {
@@ -245,14 +248,7 @@ async function fetchLiveState(
     }
     dnsRecords[desiredRecord.name] = liveRecord;
   }
-  return {
-    dnsRecords,
-    cacheRules: rulesByResource.get('cache-rule') ?? [],
-    wafRules: rulesByResource.get('waf-rule') ?? [],
-    rateLimitRules: rulesByResource.get('rate-limit-rule') ?? [],
-    sslMode,
-    flattenAllCnames,
-  };
+  return { dnsRecords, rules, sslMode, flattenAllCnames };
 }
 
 export function fullyManagedDnsBody(desired: FullyManagedDnsRecordDesired): Record<string, unknown> {


### PR DESCRIPTION
## Summary

Adds `http_ratelimit` as a third managed Cloudflare phase, with one rule counting climb-view requests per client IP on www. It ships in **`log` mode and mitigates nothing** — the threshold is a starting guess, and blocking on a guess throttles a gym full of climbers behind one NAT.

The expression matches the `/view/` segment rather than enumerating route trees, so it covers the config-tuple tree, `/b/{slug}`, and the `/de` `/es` `/fr` locale prefixes — and cannot silently miss whichever tree is added next.

**The phase could not simply be added.** The read, the diff and the apply each named the phases independently — two `fetchPhaseRules` calls, two `diffManagedRules` calls, and an `if/else if` chain with **no `else`**. Wiring a third phase into two of those three would have produced a dry-run reporting drift and an apply that logged `applied` and wrote nothing. All three now iterate `MANAGED_RULE_PHASES`, and `resolveRulePhase` throws instead of falling through.

**Bug found on the way** (would have bitten the first re-tune): `cacheRuleMatches` and `sameRule` compared `action_parameters` but not `ratelimit`, where a rate-limit rule's threshold, window and characteristics live. The rule would have been write-once — every later threshold change would diff clean and never reach the zone.

Refs #4802

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. Run `vp run cf:apply` with no token; it lists the new scope.
2. Run `vp test run --project scripts`; 1214 pass.
3. Unregister the rate-limit phase; the registration test fails.
4. Drop the `ratelimit` comparison; the threshold-drift test fails.
5. After merge, `vp run cf:apply` dry-run names the new rule.

## Risk

Risk: 4/5 — touches the tool that writes production Cloudflare config, and each phase PUT replaces the whole phase, so a merge error could drop foreign rules. Mitigated by foreign-rule preservation tests across every registered phase, and by the rule shipping in observe-only mode. Nothing applies until a maintainer runs the apply on `main`.

## ⚠️ Do not merge until the API token has `Zone.Rate Limit Edit`

`deploy-cloudflare` runs `cf:apply --apply` on every push to `main` that touches this config. Without the scope it will apply the cache and WAF phases and then 403 on `http_ratelimit` — a **partially converged zone**, which is the documented failure mode rather than a clean abort.

The token is shared by three consumers and is account- plus zone-scoped; re-scoping it for one consumer took `app.boardsesh.com` off the deploy train on 2026-08-25, so keep `Account.Cloudflare Pages Edit` on it. `vp run cf:apply` with no token prints the full required list.

## One open question for the maintainer

`log` is an **Enterprise-only** rate-limit action. If the zone is on a lower plan, the apply will reject the rule and the fix is to change `action` to `managed_challenge` (a real browser passes transparently; a headless farm mostly does not) — a one-word edit to the declared rule, documented in `docs/cloudflare.md`. I could not check the plan tier from here: it is recorded nowhere in the repo and needs the dashboard or the token.

## Not covered

The apply loop itself has no HTTP-level test in this suite — `fetchLiveState`, `applyPhaseRules` and `main` are never exercised, which predates this PR. The registry plus `resolveRulePhase` throwing is the structural guard; a source-grep assertion that the loop still routes through it would be a proxy test, so I left it out deliberately.

