### PR TITLE
fix(db): stop logging a Postgres NOTICE on every new connection

### DIFF
--- a/packages/db/src/client/__tests__/postgres-notice.test.ts
+++ b/packages/db/src/client/__tests__/postgres-notice.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { handlePostgresNotice, resetReportedPostgresNotices } from '../postgres';
+
+void describe('postgres notice handling', () => {
+  beforeEach(() => resetReportedPostgresNotices());
+
+  void it('reports a notice once and drops the repeats', () => {
+    // The whole point: CheckMyDatabase fires the collation notice on every new
+    // backend connection, which on short-lived serverless instances is roughly
+    // one log line per request.
+    const logged: string[] = [];
+    const collation = { code: '01000', message: 'database "railway" has a collation version mismatch' };
+
+    handlePostgresNotice(collation, (message) => logged.push(message));
+    handlePostgresNotice(collation, (message) => logged.push(message));
+    handlePostgresNotice(collation, (message) => logged.push(message));
+
+    assert.equal(logged.length, 1);
+    assert.match(logged[0], /collation version mismatch/);
+    assert.match(logged[0], /01000/);
+  });
+
+  void it('still reports a notice it has not seen before', () => {
+    // Deduping must not become swallowing: a new condition has to surface.
+    const logged: string[] = [];
+
+    handlePostgresNotice({ code: '01000', message: 'collation' }, (message) => logged.push(message));
+    handlePostgresNotice({ code: '42P07', message: 'relation already exists' }, (message) => logged.push(message));
+
+    assert.equal(logged.length, 2);
+    assert.match(logged[1], /relation already exists/);
+  });
+
+  void it('falls back to the message when a notice carries no code', () => {
+    const logged: string[] = [];
+
+    handlePostgresNotice({ message: 'no code here' }, (message) => logged.push(message));
+    handlePostgresNotice({ message: 'no code here' }, (message) => logged.push(message));
+    handlePostgresNotice({ message: 'a different one' }, (message) => logged.push(message));
+
+    assert.equal(logged.length, 2);
+    assert.match(logged[0], /\(no code\)/);
+  });
+});

--- a/packages/db/src/client/postgres.ts
+++ b/packages/db/src/client/postgres.ts
@@ -71,6 +71,39 @@ function readPoolInt(name: string, fallback: number, minimum: number): number {
  * Read at pool-construction time rather than module load so a process that
  * rebuilds its pool (tests, HMR) picks up the current environment.
  */
+/**
+ * Postgres NOTICE frames, deduplicated per process.
+ *
+ * postgres.js `console.log`s every notice when `onnotice` is unset, and
+ * `CheckMyDatabase` emits one on EVERY new backend connection. On Vercel,
+ * where instances are short-lived and the pool idles out in seconds, that
+ * approximates one log line per request: production carries a standing
+ * `collation version mismatch` notice that accounted for roughly a quarter of
+ * all function invocations' log output.
+ *
+ * Swallowing notices outright would hide a genuinely new one, so keep the
+ * first of each kind and drop the repeats. Per process is the right lifetime —
+ * a fresh instance reports once, and a condition that clears stops being
+ * reported when instances cycle.
+ */
+const reportedNoticeKeys = new Set<string>();
+
+/** Exported for tests: the dedupe is the whole behaviour, so it needs to be observable. */
+export function handlePostgresNotice(
+  notice: { code?: string; message?: string },
+  log: (message: string) => void = console.warn,
+): void {
+  const key = notice.code ?? notice.message ?? 'unknown';
+  if (reportedNoticeKeys.has(key)) return;
+  reportedNoticeKeys.add(key);
+  log(`[db] postgres notice ${notice.code ?? '(no code)'}: ${notice.message ?? '(no message)'}`);
+}
+
+/** Test seam: the dedupe set is process-global, so a test that asserts on it must reset it. */
+export function resetReportedPostgresNotices(): void {
+  reportedNoticeKeys.clear();
+}
+
 function basePoolOptions() {
   const isServerless = Boolean(process.env.VERCEL);
   return {
@@ -82,6 +115,7 @@ function basePoolOptions() {
     ),
     connect_timeout: 30,
     prepare: false,
+    onnotice: handlePostgresNotice,
     ...statementTimeoutOption(),
   };
 }


### PR DESCRIPTION
## Summary

`postgres.js` `console.log`s every Postgres NOTICE frame when `onnotice` is unset, and `CheckMyDatabase` emits one on **every new backend connection**. On Vercel — short-lived instances, pool idling out in seconds — that is roughly one log line per request.

Production carries a standing `database "railway" has a collation version mismatch` notice, measured on **26% of function invocations** (1,806 of 6,874 in a 30-minute window).

Dedupes per process instead of swallowing: the first notice of each kind is reported, repeats are dropped. A notice nobody has seen before still surfaces, and a condition that clears stops being reported as instances cycle. Every test harness in the repo already passed `onnotice: () => {}` — only the production pool factory omitted it.

Refs #4650

## Release Notes

none

## Test plan

1. Run `vp run test:db`; 575 pass.
2. Delete the dedupe guard line; two tests fail.
3. Check prod logs after deploy; the collation notice appears once per instance.

## Risk

Risk: 2/5 — one option added to the shared pool factory, no query behaviour changes. The reporting path is new but only runs on NOTICE frames, and both pools plus the backend share the factory so the change is uniform.

## Note on scope

This is log hygiene, not a cost fix. I originally told Marco it would cut a large share of the ~$72/mo Vercel Observability line; measuring it showed otherwise. All console output across the app is ~1,977 lines per 30 min (~95k/day, ~2.9M/mo) against **25.97M billed Observability Events** (~2.0M/day) — log lines are roughly 5% of billed events, which scale with requests and spans rather than console output. Worth doing so the collation warning stops drowning real log lines; it will not move the bill.

The underlying condition is still worth fixing separately on the database: `ALTER DATABASE railway REFRESH COLLATION VERSION` after rebuilding affected indexes.
