### PR TITLE
feat(mobile): require a board and a render mode in onboarding

### DIFF
--- a/docs/offline-sync-plan.md
+++ b/docs/offline-sync-plan.md
@@ -1237,21 +1237,18 @@ accept and `dismissKind` on dismiss. State lives in one AsyncStorage key,
 `board_card` is the exception: the glyph emits `Accepted` only. A card scrolling
 past in a carousel is not a suggestion the way a prompt is, so there is no
 impression event to divide by — read that surface as accepts joined to
-`Offline Board Download Completed`, not as a conversion rate. It is also the one
-surface not behind `offline-discovery-nudges`: it is a status badge on a screen
-the user opened, gated only by native offline availability.
+`Offline Board Download Completed`, not as a conversion rate.
 
 ### Flag ramp
 
-`offline-discovery-nudges`, ANDed with native offline availability. Ramp from 0%.
-Before going past 25%, check `Offline Nudge Accepted` against the completed /
-failed split per board type — nudging someone into a download that takes minutes
-is a worse first impression than not nudging at all.
+Retired. The nudges shipped behind `offline-discovery-nudges`; the flag and its
+`useOfflineNudgesEnabled` gate were deleted rather than left parked at 0%. Every
+surface now carries only the platform check `useOfflineDownloadsEnabled` — the
+same gate `board_card` always had on its own, native offline availability.
 
-**Bake it at 100%, do not leave it flagged.** Once the accept-to-complete rate
-holds for two weeks at 100%, delete the flag definition and the
-`useOfflineNudgesEnabled` gate in the same PR. The old engine flags have already
-been removed; this remaining discovery-only flag gets an owner and a date.
+Keep watching `Offline Nudge Accepted` against the completed / failed split per
+board type: nudging someone into a download that takes minutes is a worse first
+impression than not nudging at all.
 
 ### Hand-off to #3621 (sign-out wipe)
 

--- a/packages/mobile/app/boards/__tests__/create-serial-privacy.test.tsx
+++ b/packages/mobile/app/boards/__tests__/create-serial-privacy.test.tsx
@@ -8,6 +8,10 @@ import type { CreateBoardInput, UserBoard } from '@boardsesh/shared-schema';
 const routerMock = vi.hoisted(() => ({ dismissTo: vi.fn() }));
 const trackMock = vi.hoisted(() => vi.fn());
 const setActiveBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const adoptFoundBoardMock = vi.hoisted(() => vi.fn());
+const showToastMock = vi.hoisted(() => vi.fn());
+const markOnboardingSeenMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const setBoardRevealTipPendingMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const createBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue({}));
 const followBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const fetchBoardByUuidMock = vi.hoisted(() => vi.fn().mockResolvedValue(null));
@@ -59,6 +63,20 @@ vi.mock('../../../src/lib/graphql/hooks', () => ({
 vi.mock('../../../src/lib/graphql/use-active-board', () => ({
   useSetActiveBoard: () => setActiveBoardMock,
 }));
+
+// `useActivateBoard` is the real bind sequence now (issue #4961): the builder no
+// longer has its own shorter version, which is why creating a board from
+// onboarding used to fire no activation event. Its collaborators are stubbed so
+// the sequence itself stays under test.
+vi.mock('../../../src/lib/board-discovery/use-adopt-found-board', () => ({
+  useAdoptFoundBoard: () => adoptFoundBoardMock,
+}));
+vi.mock('../../../src/providers/toast-provider', () => ({ useToast: () => ({ showToast: showToastMock }) }));
+vi.mock('../../../src/lib/onboarding/onboarding-storage', () => ({
+  markOnboardingSeen: markOnboardingSeenMock,
+  setBoardRevealTipPending: setBoardRevealTipPendingMock,
+}));
+vi.mock('../../../src/lib/error-reporting', () => ({ reportError: vi.fn() }));
 
 vi.mock('../../../src/providers/auth-provider', () => ({
   useAuth: () => ({ isAuthenticated: true }),

--- a/packages/mobile/app/boards/__tests__/create.test.tsx
+++ b/packages/mobile/app/boards/__tests__/create.test.tsx
@@ -18,6 +18,10 @@ type Children = { children?: ReactNode };
 
 const createBoardMock = vi.hoisted(() => vi.fn());
 const setActiveBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const adoptFoundBoardMock = vi.hoisted(() => vi.fn());
+const showToastMock = vi.hoisted(() => vi.fn());
+const markOnboardingSeenMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const setBoardRevealTipPendingMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const followBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const fetchBoardsBySerialNumbersMock = vi.hoisted(() => vi.fn().mockResolvedValue([]));
 const fetchBoardByUuidMock = vi.hoisted(() => vi.fn());
@@ -92,6 +96,20 @@ vi.mock('../../../src/lib/graphql/hooks', () => ({
 vi.mock('../../../src/lib/graphql/use-active-board', () => ({
   useSetActiveBoard: () => setActiveBoardMock,
 }));
+
+// `useActivateBoard` is the real bind sequence now (issue #4961): the builder no
+// longer has its own shorter version, which is why creating a board from
+// onboarding used to fire no activation event. Its collaborators are stubbed so
+// the sequence itself stays under test.
+vi.mock('../../../src/lib/board-discovery/use-adopt-found-board', () => ({
+  useAdoptFoundBoard: () => adoptFoundBoardMock,
+}));
+vi.mock('../../../src/providers/toast-provider', () => ({ useToast: () => ({ showToast: showToastMock }) }));
+vi.mock('../../../src/lib/onboarding/onboarding-storage', () => ({
+  markOnboardingSeen: markOnboardingSeenMock,
+  setBoardRevealTipPending: setBoardRevealTipPendingMock,
+}));
+vi.mock('../../../src/lib/error-reporting', () => ({ reportError: vi.fn() }));
 
 vi.mock('../../../src/lib/analytics', () => ({ track: trackMock }));
 

--- a/packages/mobile/app/boards/create.tsx
+++ b/packages/mobile/app/boards/create.tsx
@@ -11,7 +11,7 @@ import {
   fetchBoardByUuid,
   fetchBoardsBySerialNumbers,
 } from '../../src/lib/graphql/hooks';
-import { useSetActiveBoard } from '../../src/lib/graphql/use-active-board';
+import { useActivateBoard } from '../../src/lib/boards/use-activate-board';
 import {
   extractGraphqlMessage,
   isGraphqlRateLimitedError,
@@ -81,16 +81,20 @@ export default function CreateBoard() {
   const router = useRouter();
   const params = useLocalSearchParams<{
     returnTo?: string;
+    source?: string;
     seedBoardName?: string;
     seedLayoutId?: string;
     seedSizeId?: string;
     seedSetIds?: string;
   }>();
   const boardReturnTo = resolveBoardReturnTo(params.returnTo);
+  // Threaded through the picker from the first-run flow. Creating a board is one
+  // of the ways a climber binds their first one, so it has to close out
+  // onboarding exactly like picking an existing board does.
+  const fromOnboarding = params.source === 'onboarding';
   const { isAuthenticated } = useAuth();
   const { t } = useTranslation('boards');
 
-  const setActiveBoard = useSetActiveBoard();
   const createBoard = useCreateBoard();
   const followBoard = useFollowBoard();
   const { data: profile } = useProfile({ enabled: isAuthenticated });
@@ -150,13 +154,13 @@ export default function CreateBoard() {
   // set synchronously and is the real in-flight lock.
   const inFlightRef = useRef(false);
 
-  const finish = useCallback(
-    async (board: UserBoard) => {
-      await setActiveBoard(board);
-      router.dismissTo(boardReturnTo);
-    },
-    [setActiveBoard, router, boardReturnTo],
-  );
+  // A board the climber just built is theirs by construction, so there is
+  // nothing to adopt — `isLocalOnly` skips the follow-and-download pass.
+  const finish = useActivateBoard({
+    source: fromOnboarding ? 'onboarding' : undefined,
+    returnTo: boardReturnTo,
+    isLocalOnly: true,
+  });
 
   /**
    * Always calls the server. The old short-circuit — activate an owned board

--- a/packages/mobile/app/boards/create.tsx
+++ b/packages/mobile/app/boards/create.tsx
@@ -156,10 +156,17 @@ export default function CreateBoard() {
 
   // A board the climber just built is theirs by construction, so there is
   // nothing to adopt — `isLocalOnly` skips the follow-and-download pass.
+  //
+  // `rethrow` is load-bearing: every caller below has submit state to unwind and
+  // renders its failure inline (a toast is invisible behind this modal route), so
+  // a swallowed write failure would leave the CTA spinning with nothing to
+  // explain it. `haptic: false` because the submit tap already buzzed.
   const finish = useActivateBoard({
     source: fromOnboarding ? 'onboarding' : undefined,
     returnTo: boardReturnTo,
     isLocalOnly: true,
+    writeFailure: 'rethrow',
+    haptic: false,
   });
 
   /**

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -12,8 +12,7 @@ import {
   useDeleteBoard,
   useUnfollowBoard,
 } from '../../src/lib/graphql/hooks';
-import { useActiveBoard, useSetActiveBoard, useClearActiveBoard } from '../../src/lib/graphql/use-active-board';
-import { useAdoptFoundBoard } from '../../src/lib/board-discovery/use-adopt-found-board';
+import { useActiveBoard, useClearActiveBoard } from '../../src/lib/graphql/use-active-board';
 import { useDeviceLocation } from '../../src/lib/use-device-location';
 import { useAuth } from '../../src/providers/auth-provider';
 import { useToast } from '../../src/providers/toast-provider';
@@ -38,19 +37,17 @@ import type { DiscoveryBoardItem } from '../../src/components/board-discovery/Bo
 import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metrics';
 import { useIsOffline } from '../../src/hooks/use-is-offline';
 import { useStoredUserId } from '../../src/hooks/use-current-user-id';
-import { forgetOfflineBoard, offlineBoardKeyForBoard, useOfflineBoards, useSetting } from '../../src/settings';
+import { forgetOfflineBoard, offlineBoardKeyForBoard, useOfflineBoards } from '../../src/settings';
 import { useRememberDownloadedBoards } from '../../src/offline/use-remember-downloaded-boards';
 import { useDownloadedScopeKeys } from '../../src/offline/use-downloaded-scope-keys';
 import { useConfirmBoardDownload } from '../../src/offline/use-confirm-board-download';
 import { useOfflineCatalogState } from '../../src/offline/use-offline-catalog-state';
 import { useOfflineDownloadsEnabled } from '../../src/providers/feature-flags-provider';
-import { boardDownloadState, type BoardDownloadState } from '../../src/components/board-discovery/board-offline-state';
+import { useBoardOfflineState } from '../../src/components/board-discovery/use-board-offline-state';
 import { OfflineCatalogCta } from '../../src/components/offline/OfflineCatalogCta';
 import { trackNudgeAccepted } from '../../src/lib/offline-nudges/nudge-analytics';
 import { resolveBoardReturnTo } from '../../src/lib/boards/board-return-to';
-import { setBoardRevealTipPending } from '../../src/lib/onboarding/onboarding-storage';
-import { track } from '../../src/lib/analytics';
-import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { useActivateBoard } from '../../src/lib/boards/use-activate-board';
 import { iosSystemColors } from '../../src/theme/ios-colors';
 import { spacing } from '../../src/theme/tokens';
 
@@ -78,8 +75,6 @@ export default function BoardSelection() {
   // Clear the bottom tab bar and whichever queue controls are actually visible.
   const scrollBottomPadding = bottomChrome.scrollBottomPadding;
 
-  const setActiveBoard = useSetActiveBoard();
-  const adoptFoundBoard = useAdoptFoundBoard();
   const { data: activeBoard } = useActiveBoard();
   const clearActiveBoard = useClearActiveBoard();
   const deleteBoard = useDeleteBoard();
@@ -168,63 +163,14 @@ export default function BoardSelection() {
     if (isError) void refreshAuthState();
   }, [isError, refreshAuthState]);
 
-  const activateBoard = useCallback(
-    async (board: UserBoard) => {
-      hapticSelection();
-      try {
-        // Persists to AsyncStorage + the ['activeBoard'] cache, then navigates
-        // only once the write succeeds (a failed write must not strand the user
-        // on a board that won't survive the next cold start).
-        await setActiveBoard(board);
-        if (fromOnboarding) {
-          // The real activation metric — board history turns on the moment a
-          // named board is bound — and the one-time Climbs reveal banner is armed
-          // for the board they just followed.
-          track(SHARED_EVENTS.OnboardingBoardActivated, { boardType: board.boardType, source: 'onboarding' });
-          void setBoardRevealTipPending();
-        }
-        // Dismiss the boards modal back onto the tab it was opened from — Climbs
-        // by default (including the onboarding hand-off), Discover when the pill
-        // there opened it (replaces with that tab if it isn't already underneath,
-        // e.g. opened from a deep link).
-        router.dismissTo(boardReturnTo);
-        // Follow the board if it's new to the user (so it lands in My Boards) and
-        // offer/auto-run its offline download. The isNew guard makes re-selecting a
-        // board already in My Boards a no-op for follow. Fire-and-forget: its own
-        // errors are handled inside and intentionally don't reach the catch below
-        // (which only guards the board-switch write above).
-        //
-        // Skipped whenever the rows came from the local snapshots: adoption is a follow
-        // mutation plus a download confirm, so with no usable connection the only thing
-        // it can produce is a "Could not follow X" error toast on a board the user
-        // already has downloaded. Gated on `isLocalOnly`, not `isOffline` — the
-        // lying-connection branch (captive portal, dead upstream) renders the same rows
-        // with `isOffline === false`, and its requests fail just as hard.
-        if (!isLocalOnly) void adoptFoundBoard(board);
-      } catch {
-        showToast(t('mobile.boardSwitchError'), 'error');
-      }
-    },
-    [setActiveBoard, adoptFoundBoard, router, boardReturnTo, showToast, t, fromOnboarding, isLocalOnly],
-  );
+  const activateBoard = useActivateBoard({
+    source: fromOnboarding ? 'onboarding' : undefined,
+    returnTo: boardReturnTo,
+    isLocalOnly,
+  });
 
-  // Only the user's OWN boards carry a download state. Derived from the setting
-  // + the downloaded checkpoints, not from useSyncStatus(): the card only needs
-  // "on my phone / on the way / not yet", and subscribing to the live progress
-  // frame would re-render three carousels on every tick.
-  const enabledScopeKeys = useSetting('syncEnabledBoards')[0];
-  const boardOfflineState = useCallback(
-    (board: UserBoard): BoardDownloadState =>
-      boardDownloadState({
-        scopeKey: offlineBoardKeyForBoard(board),
-        enabled: enabledScopeKeys.includes(offlineBoardKeyForBoard(board)),
-        isBootstrapDone: false,
-        downloaded: (downloadedScopeKeys ?? []).includes(offlineBoardKeyForBoard(board)),
-        isSyncing: false,
-        currentTable: null,
-      }),
-    [enabledScopeKeys, downloadedScopeKeys],
-  );
+  // Only the user's OWN boards carry a download state.
+  const boardOfflineState = useBoardOfflineState();
   const myBoardItems = useMemo(
     // Viewer-owned first (the server's `desc(isOwned)` means "a real wall", not
     // "yours"), and `currentUserId` stamps `isViewerOwner` once per list build so
@@ -526,8 +472,11 @@ export default function BoardSelection() {
   // Deliberate "create an owned board" flow: the full-screen builder (a home
   // board owner's board isn't in the DB yet, so this is the primary path).
   const onModeCreate = useCallback(() => {
-    router.push({ pathname: '/boards/create', params: { returnTo: boardReturnTo } });
-  }, [router, boardReturnTo]);
+    // `source` rides along so the builder closes out onboarding: creating a board
+    // is how a home-wall owner binds their first one, and without this it was the
+    // one bind path that fired no activation event and armed no reveal banner.
+    router.push({ pathname: '/boards/create', params: { returnTo: boardReturnTo, source } });
+  }, [router, boardReturnTo, source]);
 
   const onModeFindGym = useCallback(() => {
     router.push({ pathname: '/gyms', params: { returnTo: boardReturnTo } });
@@ -542,6 +491,7 @@ export default function BoardSelection() {
         pathname: '/boards/create',
         params: {
           returnTo: boardReturnTo,
+          source,
           seedBoardName: item.boardName,
           seedLayoutId: String(item.layoutId),
           seedSizeId: String(item.sizeId),
@@ -549,7 +499,7 @@ export default function BoardSelection() {
         },
       });
     },
-    [router, boardReturnTo],
+    [router, boardReturnTo, source],
   );
 
   // Drive the Find Nearby card off both the location permission and the nearby

--- a/packages/mobile/app/onboarding.tsx
+++ b/packages/mobile/app/onboarding.tsx
@@ -3,36 +3,36 @@ import { View } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useTheme as usePaperTheme } from 'react-native-paper';
 import { OnboardingPrompt } from '../src/components/onboarding/OnboardingPrompt';
+import { OnboardingBoardRoute } from '../src/components/onboarding/OnboardingBoardRoute';
 import { BoardLookStep } from '../src/components/board-look/BoardLookStep';
 import { useTheme } from '../src/providers/theme-provider';
 import { useVariantValue } from '../src/theme/variants';
-import { markOnboardingSeen } from '../src/lib/onboarding/onboarding-storage';
 import { useBoardPreviewClimb } from '../src/hooks/use-board-preview-climb';
 import { useEffectiveBoardRenderSettings } from '../src/hooks/use-native-climb-render';
-import { reportError } from '../src/lib/error-reporting';
 
 /**
- * The onboarding route, which hosts two independent steps.
+ * The onboarding route, which hosts the mandatory first-run flow (issue #4961).
+ * Nobody reaches the app without a board bound and a board look chosen.
  *
- * `/onboarding` is the first-run framing screen. `/onboarding?step=board-look`
- * is the one-time "pick your board look" question that 2.4 asks when the
- * Boardsesh drawing became the default — shown on its own to a climber who
- * already finished the tour, and after board activation on a fresh install
- * (there is no board to preview until they have picked one). Both live behind
- * this one route so the app keeps a single launch-time interruption rather than
- * growing a second one.
+ * Three steps, none of them skippable:
  *
- * First-run framing screen. Presented as a full-screen cover over the Climbs tab
- * (see app/_layout.tsx) with the swipe-to-dismiss gesture disabled — the user
- * leaves via the primary CTA (find a board) or the quiet exit (look around).
+ *   `/onboarding`                  the framing card — why a named board matters
+ *   `/onboarding?step=board`       pick one, and take it offline while you're here
+ *   `/onboarding?step=board-look`  the 2.4 "which drawing?" question
  *
- * The prompt is variant-agnostic; this route resolves the palette from the
- * active UI variant (Liquid Glass / HIG vs Material 3) and injects it. Both
- * exits persist the "seen" flag so the prompt shows exactly once; the primary
- * CTA hands off to the real /boards picker (tagged `source=onboarding` so the
- * picker auto-resolves location, frames the header, and fires the activation
- * event), returning to Climbs where the board's climbs and the one-time reveal
- * banner live. The quiet exit drops to Home.
+ * They live behind one route so the app keeps a single launch-time interruption
+ * rather than growing one per question.
+ *
+ * The first two steps chain directly. The third does NOT: it stays owned by
+ * `BoardLookStepGate`, which refuses to present it unless there is a synced climb
+ * to draw and the native renderer probe has answered `true`. That guarantee is
+ * what makes a step with no exit safe, and chaining past the gate would throw it
+ * away. So the board step leaves to Climbs and the gate takes over from there.
+ *
+ * Presented as a full-screen cover over the Climbs tab (see app/_layout.tsx) with
+ * the swipe-to-dismiss gesture disabled; each step swallows Android hardware back
+ * as well. The steps are variant-agnostic — this route resolves the palette from
+ * the active UI variant (Liquid Glass / HIG vs Material 3) and injects it.
  */
 export default function OnboardingScreen() {
   const { step } = useLocalSearchParams<{ step?: string }>();
@@ -57,33 +57,20 @@ export default function OnboardingScreen() {
     },
   });
 
-  // Persist the "seen" flag without blocking the exit. If the SecureStore write
-  // rejects (keychain locked / unavailable), navigation still happens — but we
-  // log + report it, because a silent failure would reshow the prompt on every
-  // cold start. console.warn for dev visibility, reportError for production.
-  const persistSeen = useCallback(() => {
-    markOnboardingSeen().catch((error: unknown) => {
-      // eslint-disable-next-line no-console
-      console.warn('[onboarding] Failed to persist "seen" flag', error);
-      reportError(error);
-    });
+  // The seen flag is no longer written here. `OnboardingGate` now shows the flow
+  // whenever there is no active board, so completion means a board is bound, and
+  // `useActivateBoard` records it at the moment of the bind — on every path,
+  // including the ones that never come back through this route.
+  const goToBoardStep = useCallback(() => {
+    router.replace({ pathname: '/onboarding', params: { step: 'board' } });
   }, []);
-
-  const lookAround = useCallback(() => {
-    persistSeen();
-    router.replace('/(tabs)/home');
-  }, [persistSeen]);
-
-  const findBoard = useCallback(() => {
-    persistSeen();
-    // `source=onboarding` drives the framing header + location pre-resolve + the
-    // activation event; returnTo defaults to Climbs, where the user browses the
-    // board they just picked and the one-time reveal banner points at its wall.
-    router.replace({ pathname: '/boards', params: { source: 'onboarding' } });
-  }, [persistSeen]);
 
   if (step === 'board-look') {
     return <BoardLookRoute accentColor={accentColor} bodyColor={bodyColor} backgroundColor={backgroundColor} />;
+  }
+
+  if (step === 'board') {
+    return <OnboardingBoardRoute accentColor={accentColor} bodyColor={bodyColor} backgroundColor={backgroundColor} />;
   }
 
   return (
@@ -92,8 +79,7 @@ export default function OnboardingScreen() {
       iconColor={iconColor}
       bodyColor={bodyColor}
       backgroundColor={backgroundColor}
-      onFindBoard={findBoard}
-      onLookAround={lookAround}
+      onContinue={goToBoardStep}
     />
   );
 }
@@ -148,7 +134,6 @@ function BoardLookRoute({
       boardseshRendererAvailable={boardseshRendererAvailable}
       onSaved={leave}
       onCustomize={customize}
-      onSkip={leave}
     />
   );
 }

--- a/packages/mobile/app/user-drawer.tsx
+++ b/packages/mobile/app/user-drawer.tsx
@@ -17,7 +17,7 @@ import { useUserDrawer } from '../src/components/user-drawer/UserDrawerProvider'
 import { latestEntryDate } from '../src/lib/changelog';
 import { getLastSeenChangelogDate, hasUnseenChangelog } from '../src/lib/changelog-seen';
 import { hasUnseenOfflineSpotlight } from '../src/lib/offline-nudges/spotlight-unseen';
-import { useOfflineDownloadsEnabled, useOfflineNudgesEnabled } from '../src/providers/feature-flags-provider';
+import { useOfflineDownloadsEnabled } from '../src/providers/feature-flags-provider';
 import { useActiveBoard } from '../src/lib/graphql/use-active-board';
 import { useOtaBranchSurfingState } from '../src/lib/ota-branch-surfing-state';
 import { readRunningPrNumber } from '../src/lib/qa/qa-surf';
@@ -58,16 +58,15 @@ export default function UserDrawerScreen() {
   // the marker and the next drawer open re-reads it.
   // ...OR'd with the curated offline spotlight pinned inside that screen, which
   // is otherwise unreachable for anyone whose changelog is already read — but
-  // ONLY when that card can actually render. Both flags gate the card itself, so
-  // without this the pill would light for every user with nothing downloaded
-  // while the nudge flag sits at 0%, and opening What's New would never clear it
-  // (the card never renders, so its "shown" marker is never written). The active
-  // board is the same kind of precondition: the card names a board, so someone
-  // who has never picked one would carry the pill forever.
+  // ONLY when that card can actually render, or the pill would light with no way
+  // to clear it (the card never renders, so its "shown" marker is never
+  // written). The engine gate is the card's own: on the Expo web fork there is
+  // no download to offer. The active board is the same kind of precondition —
+  // the card names a board, so someone who has never picked one would carry the
+  // pill forever.
   const offlineEngineEnabled = useOfflineDownloadsEnabled();
-  const offlineNudgesEnabled = useOfflineNudgesEnabled();
   const { data: activeBoard } = useActiveBoard();
-  const spotlightReachable = offlineEngineEnabled && offlineNudgesEnabled && !!activeBoard;
+  const spotlightReachable = offlineEngineEnabled && !!activeBoard;
   const [changelogUnseen, setChangelogUnseen] = useState(false);
   useEffect(() => {
     let active = true;

--- a/packages/mobile/src/components/__tests__/feature-flag-rows.test.ts
+++ b/packages/mobile/src/components/__tests__/feature-flag-rows.test.ts
@@ -22,6 +22,7 @@ describe('buildFeatureFlagRows', () => {
     expect(keys).not.toContain('offline-download-progress');
     expect(keys).not.toContain('offline-download-task-api');
     expect(keys).not.toContain('offline-download-background-session');
+    expect(keys).not.toContain('offline-discovery-nudges');
   });
 
   it('keeps ordinary flags on `=== true` semantics', () => {

--- a/packages/mobile/src/components/board-discovery/__tests__/use-board-offline-state.test.tsx
+++ b/packages/mobile/src/components/board-discovery/__tests__/use-board-offline-state.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+const settingsCtrl = vi.hoisted(() => ({ enabled: [] as string[] }));
+const downloadedCtrl = vi.hoisted(() => ({ keys: undefined as string[] | undefined }));
+
+vi.mock('../../../settings', () => ({
+  offlineBoardKeyForBoard: (board: UserBoard) => `${board.boardType}:${board.layoutId}:${board.sizeId}`,
+  useSetting: () => [settingsCtrl.enabled],
+}));
+vi.mock('../../../offline/use-downloaded-scope-keys', () => ({
+  useDownloadedScopeKeys: () => ({ data: downloadedCtrl.keys }),
+}));
+
+import { useBoardOfflineState } from '../use-board-offline-state';
+
+function board(layoutId: number, sizeId: number): UserBoard {
+  return { uuid: `b-${layoutId}-${sizeId}`, boardType: 'kilter', layoutId, sizeId } as unknown as UserBoard;
+}
+
+describe('useBoardOfflineState', () => {
+  beforeEach(() => {
+    settingsCtrl.enabled = [];
+    downloadedCtrl.keys = undefined;
+  });
+
+  it('reports a board nobody has asked for as off', () => {
+    const { result } = renderHook(() => useBoardOfflineState());
+    expect(result.current(board(1, 10))).toBe('off');
+  });
+
+  it('reports an armed board as pending until its own scope lands', () => {
+    settingsCtrl.enabled = ['kilter:1:10'];
+    const { result } = renderHook(() => useBoardOfflineState());
+    expect(result.current(board(1, 10))).toBe('pending');
+  });
+
+  it('reports a board with its own checkpoint as downloaded', () => {
+    settingsCtrl.enabled = ['kilter:1:10'];
+    downloadedCtrl.keys = ['kilter:1:10'];
+    const { result } = renderHook(() => useBoardOfflineState());
+    expect(result.current(board(1, 10))).toBe('downloaded');
+  });
+
+  // Two sizes of the same layout are separate scopes. A sibling finishing first
+  // must not make its neighbour read as downloaded.
+  it('keys strictly on the board’s own scope', () => {
+    settingsCtrl.enabled = ['kilter:1:10', 'kilter:1:50'];
+    downloadedCtrl.keys = ['kilter:1:10'];
+    const { result } = renderHook(() => useBoardOfflineState());
+
+    expect(result.current(board(1, 10))).toBe('downloaded');
+    expect(result.current(board(1, 50))).toBe('pending');
+  });
+
+  it('stays stable across renders so memoised rows hold', () => {
+    const { result, rerender } = renderHook(() => useBoardOfflineState());
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});

--- a/packages/mobile/src/components/board-discovery/use-board-offline-state.ts
+++ b/packages/mobile/src/components/board-discovery/use-board-offline-state.ts
@@ -1,0 +1,41 @@
+// "Is this board on my phone?", as a per-board lookup a carousel can call.
+//
+// Derived from the syncEnabledBoards setting plus the downloaded checkpoints,
+// NOT from useSyncStatus(): a card only needs "on my phone / on the way / not
+// yet", and useSyncStatus republishes on every progress frame, which would
+// re-render every stacked carousel on every tick. The screens that DO want live
+// progress (My Boards) subscribe once at screen level and pass primitives down.
+
+import { useCallback } from 'react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { offlineBoardKeyForBoard, useSetting } from '../../settings';
+import { useDownloadedScopeKeys } from '../../offline/use-downloaded-scope-keys';
+import { boardDownloadState, type BoardDownloadState } from './board-offline-state';
+
+export type BoardOfflineStateLookup = (board: UserBoard) => BoardDownloadState;
+
+/**
+ * A stable `(board) => BoardDownloadState` for the boards a climber owns or
+ * follows. Only those carry a download state — a popular config has no `uuid`,
+ * so it could never appear in the offline picker even though its data would
+ * download.
+ */
+export function useBoardOfflineState(): BoardOfflineStateLookup {
+  const [enabledScopeKeys] = useSetting('syncEnabledBoards');
+  const { data: downloadedScopeKeys } = useDownloadedScopeKeys();
+
+  return useCallback(
+    (board: UserBoard): BoardDownloadState => {
+      const scopeKey = offlineBoardKeyForBoard(board);
+      return boardDownloadState({
+        scopeKey,
+        enabled: enabledScopeKeys.includes(scopeKey),
+        isBootstrapDone: false,
+        downloaded: (downloadedScopeKeys ?? []).includes(scopeKey),
+        isSyncing: false,
+        currentTable: null,
+      });
+    },
+    [enabledScopeKeys, downloadedScopeKeys],
+  );
+}

--- a/packages/mobile/src/components/board-look/BoardLookStep.tsx
+++ b/packages/mobile/src/components/board-look/BoardLookStep.tsx
@@ -24,6 +24,7 @@ import {
 import type { BoardPreviewSource } from '../../hooks/use-board-preview-climb';
 import { markBoardLookStepSeen } from '../../lib/board-render/board-look-step-seen';
 import { reportError } from '../../lib/error-reporting';
+import { useBlockBack } from '../onboarding/use-block-back';
 import { spacing } from '../../theme/tokens';
 
 type BoardLookStepProps = {
@@ -41,8 +42,6 @@ type BoardLookStepProps = {
   onSaved: () => void;
   /** They picked Custom. The Boardsesh bundle is written; open Board look next. */
   onCustomize: () => void;
-  /** They skipped. Nothing is written, so the app default applies. */
-  onSkip: () => void;
 };
 
 /**
@@ -50,8 +49,17 @@ type BoardLookStepProps = {
  * they want, now that 2.4 makes the Boardsesh one the default.
  *
  * Every card is a render of THEIR board, so the choice is made on what it
- * actually looks like. Skipping is a real answer: it leaves `mode: 'default'`,
- * which is the new default, and the step never returns.
+ * actually looks like.
+ *
+ * **There is no exit** (issue #4961): the "Not now" secondary is gone, because
+ * declining silently accepted the new default — the one outcome this step exists
+ * to stop being silent. Android hardware back is swallowed too. The funnel still
+ * has a `skipped` outcome, fired by the unmount guard, for the nav-away that no
+ * button produced.
+ *
+ * Safe to make mandatory only because `decideBoardLookStep` refuses to present it
+ * unless there is a synced climb to draw AND the renderer probe has answered
+ * `true`. If that gate is ever relaxed, the exit has to come back.
  *
  * Variant-agnostic like `OnboardingPrompt` — the route resolves the palette from
  * the active UI variant and injects it, so one component serves both skins.
@@ -64,12 +72,13 @@ export function BoardLookStep({
   boardseshRendererAvailable,
   onSaved,
   onCustomize,
-  onSkip,
 }: BoardLookStepProps) {
   const { t } = useTranslation('common');
   const { systemColors, variant } = useTheme();
   const insets = useSafeAreaInsets();
   const { settings } = useBoardRenderSettings();
+
+  useBlockBack();
 
   // Whatever they are on today leads the carousel — for this step's whole
   // audience (`mode: 'default'`) that is the plain Boardsesh card.
@@ -202,11 +211,6 @@ export function BoardLookStep({
     onSaved();
   }, [onCustomize, onSaved, report]);
 
-  const handleSkip = useCallback(() => {
-    resolve('skipped', null);
-    onSkip();
-  }, [onSkip, resolve]);
-
   const footerPadding = useMemo(() => Math.max(insets.bottom, spacing[4]), [insets.bottom]);
 
   return (
@@ -246,13 +250,6 @@ export function BoardLookStep({
           tintColor={selectByVariant(variant, { material: undefined, liquidGlass: accentColor })}
           haptic={false}
           style={styles.primary}
-        />
-        <Button
-          title={t('mobile.more.boardLook.intro.skip')}
-          onPress={handleSkip}
-          variant="text"
-          size="large"
-          haptic={false}
         />
       </GlassSurface>
     </View>

--- a/packages/mobile/src/components/board-look/__tests__/BoardLookStep.test.tsx
+++ b/packages/mobile/src/components/board-look/__tests__/BoardLookStep.test.tsx
@@ -30,6 +30,7 @@ vi.mock('react-native', () => ({
   // The step swallows Android back (useBlockBack); here it only has to exist.
   BackHandler: { addEventListener: () => ({ remove: () => {} }) },
 }));
+vi.mock('expo-router', () => ({ useIsFocused: () => true }));
 vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0, bottom: 0 }) }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('../../../providers/theme-provider', () => ({

--- a/packages/mobile/src/components/board-look/__tests__/BoardLookStep.test.tsx
+++ b/packages/mobile/src/components/board-look/__tests__/BoardLookStep.test.tsx
@@ -27,6 +27,8 @@ vi.mock('react-native', () => ({
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1, absoluteFill: {} },
   Platform: { OS: 'ios', select: (spec: Record<string, unknown>) => spec.ios },
   PlatformColor: (color: string) => color,
+  // The step swallows Android back (useBlockBack); here it only has to exist.
+  BackHandler: { addEventListener: () => ({ remove: () => {} }) },
 }));
 vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0, bottom: 0 }) }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
@@ -89,7 +91,6 @@ function renderStep(overrides: Partial<Parameters<typeof BoardLookStep>[0]> = {}
     boardseshRendererAvailable: true,
     onSaved: vi.fn(),
     onCustomize: vi.fn(),
-    onSkip: vi.fn(),
     ...overrides,
   };
   return { props, ...render(<BoardLookStep {...props} />) };
@@ -112,7 +113,7 @@ describe('BoardLookStep', () => {
     expect(analytics.trackBoardLookStepShown.mock.calls[0][2]).toBe(carouselCtrl.optionIds.length);
   });
 
-  it('marks itself seen on arrival, so skipping and a force-quit both count', () => {
+  it('marks itself seen on arrival, so a force-quit still counts as asked', () => {
     // Written by the STEP, not the route: the flag means "this climber has been
     // asked", and a route that mounts with nothing to preview (or on a build
     // that cannot draw the mode) must not burn the one-time question.
@@ -140,25 +141,12 @@ describe('BoardLookStep', () => {
       });
     });
 
-    it('on skip', () => {
-      const { props, getByText } = renderStep();
-
-      fireEvent.click(getByText('mobile.more.boardLook.intro.skip'));
-
-      expect(props.onSkip).toHaveBeenCalled();
-      expect(analytics.trackBoardLookStepResolved).toHaveBeenCalledOnce();
-      expect(analytics.trackBoardLookStepResolved.mock.calls[0][2]).toMatchObject({
-        outcome: 'skipped',
-        selectedOption: null,
-      });
-    });
-
     it('on an unmount with no choice at all', () => {
       const { unmount } = renderStep();
 
       unmount();
 
-      // The back-button / nav-away exit. Without this the Shown would dangle.
+      // The nav-away exit. Without this the Shown would dangle.
       expect(analytics.trackBoardLookStepResolved).toHaveBeenCalledOnce();
       expect(analytics.trackBoardLookStepResolved.mock.calls[0][2]).toMatchObject({ outcome: 'skipped' });
     });
@@ -215,16 +203,27 @@ describe('BoardLookStep', () => {
     });
   });
 
-  it('counts the distinct cards that actually came into view', () => {
-    const { getByText } = renderStep();
+  it('counts the distinct cards that actually came into view', async () => {
+    const { props, getByText } = renderStep();
 
     carouselCtrl.onCardSeen?.('boardsesh');
     carouselCtrl.onCardSeen?.('subtle');
     carouselCtrl.onCardSeen?.('boardsesh');
-    fireEvent.click(getByText('mobile.more.boardLook.intro.skip'));
+    fireEvent.click(getByText('mobile.more.boardLook.intro.save'));
+    await vi.waitFor(() => expect(props.onSaved).toHaveBeenCalled());
 
     // Distinct, not a tally of viewability callbacks — "took the default on
     // sight" and "swiped through, then chose" must stay tellable apart.
     expect(analytics.trackBoardLookStepResolved.mock.calls[0][2]).toMatchObject({ cardsViewed: 2 });
+  });
+
+  // Issue #4961: declining used to accept the new default in silence, which is
+  // the one outcome this step exists to prevent. Its absence is the assertion.
+  it('offers no way out beside the primary call to action', () => {
+    const { container } = renderStep();
+
+    const buttons = container.querySelectorAll('button');
+    expect(buttons.length).toBe(1);
+    expect(buttons[0]?.textContent).toBe('mobile.more.boardLook.intro.save');
   });
 });

--- a/packages/mobile/src/components/offline/__tests__/OfflineCatalogCta.test.tsx
+++ b/packages/mobile/src/components/offline/__tests__/OfflineCatalogCta.test.tsx
@@ -9,7 +9,6 @@ const state = vi.hoisted(() => ({
   downloadedScopeKeys: [] as string[],
   autoOfflineBoards: false,
   offlineEngineEnabled: true,
-  nudgesEnabled: true,
   // This surface exists for the no-signal case, so offline is the default here.
   isOffline: true,
 }));
@@ -55,7 +54,6 @@ vi.mock('../../../offline/use-downloaded-scope-keys', () => ({
 }));
 vi.mock('../../../providers/feature-flags-provider', () => ({
   useOfflineDownloadsEnabled: () => state.offlineEngineEnabled,
-  useOfflineNudgesEnabled: () => state.nudgesEnabled,
 }));
 vi.mock('../../../hooks/use-is-offline', () => ({ useIsOffline: () => state.isOffline }));
 vi.mock('../../../settings', () => ({
@@ -79,7 +77,6 @@ beforeEach(() => {
   state.downloadedScopeKeys = [];
   state.autoOfflineBoards = false;
   state.offlineEngineEnabled = true;
-  state.nudgesEnabled = true;
   state.isOffline = true;
 });
 afterEach(() => cleanup());
@@ -143,7 +140,6 @@ describe('OfflineCatalogCta', () => {
   it.each([
     ['the scope is already armed', () => (state.enabledBoards = ['tension:8:25'])],
     ['the offline engine is off', () => (state.offlineEngineEnabled = false)],
-    ['the nudge flag is off', () => (state.nudgesEnabled = false)],
     ['there is no board', () => undefined],
   ])('renders nothing when %s', async (label, mutate) => {
     mutate();

--- a/packages/mobile/src/components/offline/__tests__/OfflineSpotlightCard.test.tsx
+++ b/packages/mobile/src/components/offline/__tests__/OfflineSpotlightCard.test.tsx
@@ -10,7 +10,6 @@ const state = vi.hoisted(() => ({
   downloadedScopeKeys: [] as string[],
   autoOfflineBoards: false,
   offlineEngineEnabled: true,
-  nudgesEnabled: true,
 }));
 
 const spies = vi.hoisted(() => ({
@@ -49,7 +48,6 @@ vi.mock('../../../offline/use-downloaded-scope-keys', () => ({
 }));
 vi.mock('../../../providers/feature-flags-provider', () => ({
   useOfflineDownloadsEnabled: () => state.offlineEngineEnabled,
-  useOfflineNudgesEnabled: () => state.nudgesEnabled,
 }));
 vi.mock('../../../hooks/use-is-offline', () => ({ useIsOffline: () => false }));
 vi.mock('../../../settings', () => ({
@@ -75,7 +73,6 @@ beforeEach(() => {
   state.downloadedScopeKeys = [];
   state.autoOfflineBoards = false;
   state.offlineEngineEnabled = true;
-  state.nudgesEnabled = true;
 });
 afterEach(() => cleanup());
 

--- a/packages/mobile/src/components/offline/__tests__/PostSessionOfflineNudge.test.tsx
+++ b/packages/mobile/src/components/offline/__tests__/PostSessionOfflineNudge.test.tsx
@@ -11,7 +11,6 @@ const state = vi.hoisted(() => ({
   downloadedScopeKeys: [] as string[],
   autoOfflineBoards: false,
   offlineEngineEnabled: true,
-  nudgesEnabled: true,
   isOffline: false,
   nudgeState: null as unknown,
 }));
@@ -72,7 +71,6 @@ vi.mock('../../../offline/use-downloaded-scope-keys', () => ({
 }));
 vi.mock('../../../providers/feature-flags-provider', () => ({
   useOfflineDownloadsEnabled: () => state.offlineEngineEnabled,
-  useOfflineNudgesEnabled: () => state.nudgesEnabled,
 }));
 vi.mock('../../../hooks/use-is-offline', () => ({ useIsOffline: () => state.isOffline }));
 vi.mock('../../../settings', () => ({
@@ -105,7 +103,6 @@ beforeEach(() => {
   state.downloadedScopeKeys = [];
   state.autoOfflineBoards = false;
   state.offlineEngineEnabled = true;
-  state.nudgesEnabled = true;
   state.isOffline = false;
   state.nudgeState = null;
 });
@@ -156,7 +153,6 @@ describe('PostSessionOfflineNudge', () => {
     ['already enabled', () => (state.enabledBoards = ['kilter:1:10'])],
     ['auto-downloading every board', () => (state.autoOfflineBoards = true)],
     ['the offline engine is off', () => (state.offlineEngineEnabled = false)],
-    ['the nudge flag is off', () => (state.nudgesEnabled = false)],
     ['dismissed forever', () => (state.nudgeState = suppressedNudgeState())],
     ['there is no active board', () => (state.activeBoard = null)],
   ])('renders nothing when %s', async (_label, mutate) => {

--- a/packages/mobile/src/components/onboarding/OnboardingBoardRoute.tsx
+++ b/packages/mobile/src/components/onboarding/OnboardingBoardRoute.tsx
@@ -1,0 +1,166 @@
+import { useCallback, useMemo } from 'react';
+import { router } from 'expo-router';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { OnboardingBoardStep } from './OnboardingBoardStep';
+import { useMyBoards, useProfile } from '../../lib/graphql/hooks';
+import { useAuth } from '../../providers/auth-provider';
+import { useIsOffline } from '../../hooks/use-is-offline';
+import { useStoredUserId } from '../../hooks/use-current-user-id';
+import { useActivateBoard } from '../../lib/boards/use-activate-board';
+import { useOfflineDownloadsEnabled } from '../../providers/feature-flags-provider';
+import { useConfirmBoardDownload } from '../../offline/use-confirm-board-download';
+import { useDownloadedScopeKeys } from '../../offline/use-downloaded-scope-keys';
+import { useBoardOfflineState } from '../board-discovery/use-board-offline-state';
+import { trackNudgeAccepted, trackNudgeDismissed, trackNudgeShown } from '../../lib/offline-nudges/nudge-analytics';
+import type { NudgeEventContext } from '../../lib/offline-nudges/nudge-analytics';
+import { offlineBoardKeyForBoard } from '../../settings';
+
+// Module-level so an absent board list keeps a stable identity — a fresh `[]`
+// per render would rebuild the carousel's items on every commit.
+const EMPTY_BOARDS: UserBoard[] = [];
+
+/**
+ * The board step's data and exits.
+ *
+ * Its own component, like `BoardLookRoute`, so the queries behind it (the board
+ * list, the downloaded-scope index) mount only while this step is the one on
+ * screen — the framing card must not pay for them.
+ */
+export function OnboardingBoardRoute({
+  accentColor,
+  bodyColor,
+  backgroundColor,
+}: {
+  accentColor: string;
+  bodyColor: string;
+  backgroundColor: string;
+}) {
+  const { isAuthenticated } = useAuth();
+  // Who is looking, so viewer-owned boards lead the row. Same degraded-never-
+  // blocked read as `/boards`: the stored id answers with no network, and a
+  // missing id only costs the ordering, never the ability to pick.
+  const { data: profile } = useProfile({ enabled: isAuthenticated });
+  const { userId: storedUserId } = useStoredUserId(isAuthenticated && !profile?.id);
+  const currentUserId = profile?.id ?? storedUserId;
+
+  const { data: boardConnection, isLoading, isError } = useMyBoards(undefined, { enabled: isAuthenticated });
+  const boards = boardConnection?.boards ?? EMPTY_BOARDS;
+
+  const isOffline = useIsOffline();
+  const offlineDownloadsEnabled = useOfflineDownloadsEnabled();
+  const { confirmAndDownload } = useConfirmBoardDownload();
+  const { data: downloadedScopeKeys } = useDownloadedScopeKeys();
+  const boardOfflineState = useBoardOfflineState();
+
+  const nudgeContextFor = useCallback(
+    (board: UserBoard, surface: NudgeEventContext['surface']): NudgeEventContext => ({
+      surface,
+      boardType: board.boardType,
+      layoutId: board.layoutId,
+      scopeKey: offlineBoardKeyForBoard(board),
+      downloadedBoardCount: (downloadedScopeKeys ?? []).length,
+    }),
+    [downloadedScopeKeys],
+  );
+
+  /**
+   * The download offer, run after the board is bound and before we leave.
+   *
+   * Only for a scope that isn't already on the phone or on its way — a dialog
+   * quoting a download the climber has already asked for is noise. Offline it is
+   * skipped entirely rather than armed silently: this is a first-run screen, and
+   * arming something invisible that lands "sometime after you reconnect" is not
+   * a promise worth making without asking.
+   *
+   * `confirmAndDownload` quotes the real artifact size, so the Cancel here is the
+   * informed "not now" — the download stays skippable, unlike the board itself.
+   */
+  const offerDownload = useCallback(
+    async (board: UserBoard) => {
+      if (!offlineDownloadsEnabled || isOffline) return;
+      if (boardOfflineState(board) !== 'off') return;
+
+      const context = nudgeContextFor(board, 'onboarding');
+      trackNudgeShown(context);
+      const confirmed = await confirmAndDownload(board, { trigger: 'onboarding', source: 'onboarding' });
+      if (confirmed) trackNudgeAccepted(context, 'download');
+      else trackNudgeDismissed(context, 'once');
+    },
+    [offlineDownloadsEnabled, isOffline, boardOfflineState, nudgeContextFor, confirmAndDownload],
+  );
+
+  // `replace`, not the picker's `dismissTo`: onboarding is a full-screen cover
+  // with nothing of its own left to return to, and the board-look gate picks the
+  // climber up on Climbs.
+  const leaveToClimbs = useCallback(() => {
+    router.replace('/(tabs)/climbs');
+  }, []);
+
+  const activateBoard = useActivateBoard({
+    source: 'onboarding',
+    returnTo: '/(tabs)/climbs',
+    navigate: leaveToClimbs,
+    onBound: offerDownload,
+  });
+
+  const onSelect = useCallback((board: UserBoard) => void activateBoard(board), [activateBoard]);
+
+  /**
+   * The card glyph: download a board WITHOUT binding it.
+   *
+   * Deliberately reported as `board_card`, not `onboarding` — it is the same
+   * glyph, on the same card, doing the same thing as the one on `/boards`, and
+   * it is accept-only there because a card scrolling past in a carousel is not a
+   * suggestion the way a dialog is. Filing it under `onboarding` would mix an
+   * impression-tracked offer with an untracked one and quietly wreck that
+   * surface's shown-to-accepted rate.
+   */
+  const onDownload = useCallback(
+    (board: UserBoard) => {
+      void confirmAndDownload(board, { trigger: 'onboarding', source: 'onboarding' }).then((confirmed) => {
+        if (confirmed) trackNudgeAccepted(nudgeContextFor(board, 'board_card'), 'download');
+      });
+    },
+    [confirmAndDownload, nudgeContextFor],
+  );
+
+  const onFindBoard = useCallback(() => {
+    // `source=onboarding` drives the picker's framing header, its location
+    // pre-resolve, and — through `useActivateBoard` — the activation event and
+    // the one-time Climbs reveal banner, whether they pick a board there or
+    // build one in `/boards/create`.
+    router.push({ pathname: '/boards', params: { source: 'onboarding' } });
+  }, []);
+
+  /**
+   * The single escape hatch, and the conditions are narrow on purpose: no usable
+   * connection AND nothing to show. `/boards` cannot help either — its offline
+   * branch lists boards this device has downloaded, and a fresh install has
+   * none — so this is a screen that genuinely cannot resolve.
+   *
+   * It does not mark onboarding complete. The gate is "has a board", so the
+   * climber is asked again on the next launch, when the network may be back.
+   *
+   * `isError` is in here alongside `isOffline` for the lying-connection case:
+   * captive-portal or gym wifi with a dead upstream reports ONLINE while every
+   * request fails, so `isOffline` alone would leave that climber stuck.
+   */
+  const canOfferNothing = (isOffline || isError) && boards.length === 0 && !isLoading;
+  const onSkipUnusable = useMemo(() => (canOfferNothing ? leaveToClimbs : null), [canOfferNothing, leaveToClimbs]);
+
+  return (
+    <OnboardingBoardStep
+      accentColor={accentColor}
+      bodyColor={bodyColor}
+      backgroundColor={backgroundColor}
+      boards={boards}
+      isLoading={isLoading}
+      offlineDownloadsEnabled={offlineDownloadsEnabled}
+      currentUserId={currentUserId}
+      onSkipUnusable={onSkipUnusable}
+      onSelect={onSelect}
+      onDownload={onDownload}
+      onFindBoard={onFindBoard}
+    />
+  );
+}

--- a/packages/mobile/src/components/onboarding/OnboardingBoardStep.tsx
+++ b/packages/mobile/src/components/onboarding/OnboardingBoardStep.tsx
@@ -1,0 +1,206 @@
+import { useCallback, useMemo } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { Button } from '../Button';
+import { GlassSurface } from '../GlassSurface';
+import { Text } from '../Text';
+import { ActivityIndicator } from '../ActivityIndicator';
+import { BoardCarousel } from '../board-discovery/BoardCarousel';
+import type { DiscoveryBoardItem } from '../board-discovery/BoardDiscoveryCard';
+import { userBoardsToItems } from '../board-discovery/board-items';
+import { sortViewerOwnedFirst } from '../board-discovery/board-card-actions';
+import { useBoardOfflineState } from '../board-discovery/use-board-offline-state';
+import { useOnboardingBoardCopy } from '../../lib/onboarding/use-onboarding-copy';
+import { useBlockBack } from './use-block-back';
+import { useTheme } from '../../providers/theme-provider';
+import { selectByVariant } from '../../theme/variants';
+import { spacing } from '../../theme/tokens';
+
+export type OnboardingBoardStepProps = {
+  /** Primary CTA accent (HIG: systemColors.accent; Material: colors.primary). */
+  accentColor: string;
+  /** Body/subtext colour. */
+  bodyColor: string;
+  /** Opaque background under the reading text. */
+  backgroundColor: string;
+  /** The climber's own boards. Empty while loading, and empty on a failed load. */
+  boards: UserBoard[];
+  /** The board list request is still in flight. */
+  isLoading: boolean;
+  /** Whether the offline engine can offer a download at all (platform gate). */
+  offlineDownloadsEnabled: boolean;
+  /** Signed-in user id, so the carousel can put viewer-owned boards first. */
+  currentUserId: string | undefined;
+  /**
+   * The one condition under which this step may be left without a board: no
+   * usable connection AND nothing cached to choose from. `null` when there is no
+   * such dead end, which is the normal case.
+   */
+  onSkipUnusable: (() => void) | null;
+  /** Bind this board and move on. */
+  onSelect: (board: UserBoard) => void;
+  /** Download this board without binding it. */
+  onDownload: (board: UserBoard) => void;
+  /** Hand off to the full /boards picker. */
+  onFindBoard: () => void;
+};
+
+/**
+ * "Which board do you climb on?" — the second onboarding step, and the one that
+ * makes the whole flow worth being mandatory.
+ *
+ * Two things happen here beyond picking a board. It **names the mechanism**:
+ * board history is shared per named board, so which board you pick is what
+ * decides whose sends you see. And it **offers the download**, because a board
+ * on the phone opens instantly and works on gym wifi that has given up.
+ *
+ * Reuses `BoardCarousel` / `BoardDiscoveryCard` rather than growing a second
+ * board slider — same cards, same download glyph, same active tick as `/boards`.
+ *
+ * **There is no exit** (issue #4961), with exactly one exception: a climber who
+ * is offline with nothing cached cannot be shown a usable choice, and stranding
+ * them on a screen that can never resolve is worse than letting them past.
+ * `onSkipUnusable` is that hatch, and it deliberately does not mark onboarding
+ * complete — the gate brings them back on the next launch, when the network may
+ * be there.
+ */
+export function OnboardingBoardStep({
+  accentColor,
+  bodyColor,
+  backgroundColor,
+  boards,
+  isLoading,
+  offlineDownloadsEnabled,
+  currentUserId,
+  onSkipUnusable,
+  onSelect,
+  onDownload,
+  onFindBoard,
+}: OnboardingBoardStepProps) {
+  const copy = useOnboardingBoardCopy();
+  const insets = useSafeAreaInsets();
+  const { variant, systemColors } = useTheme();
+
+  useBlockBack();
+
+  const boardOfflineState = useBoardOfflineState();
+  const items = useMemo(
+    () => userBoardsToItems(sortViewerOwnedFirst(boards, currentUserId), null, boardOfflineState, currentUserId),
+    [boards, boardOfflineState, currentUserId],
+  );
+
+  // Both handlers resolve the item back to its UserBoard. A refetch that drops a
+  // board between render and tap is the only way to miss, and the right answer
+  // there is to do nothing rather than bind something else.
+  const findBoard = useCallback((key: string) => boards.find((board) => board.uuid === key), [boards]);
+
+  const handleSelect = useCallback(
+    (item: DiscoveryBoardItem) => {
+      const board = findBoard(item.key);
+      if (board) onSelect(board);
+    },
+    [findBoard, onSelect],
+  );
+
+  const handleDownload = useCallback(
+    (item: DiscoveryBoardItem) => {
+      const board = findBoard(item.key);
+      if (board) onDownload(board);
+    },
+    [findBoard, onDownload],
+  );
+
+  const downloadLabelFor = useCallback((item: DiscoveryBoardItem) => copy.downloadLabelFor(item.title), [copy]);
+
+  const footerPadding = useMemo(() => Math.max(insets.bottom, spacing[4]), [insets.bottom]);
+  const hasBoards = items.length > 0;
+
+  return (
+    <View style={[styles.root, { backgroundColor, paddingTop: insets.top }]} accessibilityViewIsModal>
+      <ScrollView contentContainerStyle={styles.body} showsVerticalScrollIndicator={false}>
+        <View style={styles.copy}>
+          <Text variant="title1">{copy.title}</Text>
+          <Text variant="body" color={bodyColor} style={styles.description}>
+            {copy.body}
+          </Text>
+        </View>
+
+        {isLoading && !hasBoards ? (
+          <View style={styles.spinner}>
+            <ActivityIndicator />
+          </View>
+        ) : null}
+
+        {hasBoards ? (
+          <>
+            <BoardCarousel
+              items={items}
+              onSelect={handleSelect}
+              onDownload={offlineDownloadsEnabled ? handleDownload : undefined}
+              downloadLabelFor={downloadLabelFor}
+            />
+            {offlineDownloadsEnabled ? (
+              <View style={styles.copy}>
+                <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.description}>
+                  {copy.offlineHint}
+                </Text>
+              </View>
+            ) : null}
+          </>
+        ) : null}
+      </ScrollView>
+
+      <GlassSurface glassEffectStyle="regular" style={[styles.footer, { paddingBottom: footerPadding }]}>
+        {/* With boards on screen the picker is the alternative, so it takes the
+            quiet slot; with none — including a list that failed to load — it is
+            the only way forward and takes the primary. Never a dead end. */}
+        <Button
+          title={hasBoards ? copy.findAnother : copy.findFirst}
+          onPress={onFindBoard}
+          variant={hasBoards ? 'text' : 'filled'}
+          size="large"
+          tintColor={
+            hasBoards ? undefined : selectByVariant(variant, { material: undefined, liquidGlass: accentColor })
+          }
+          haptic={false}
+          style={hasBoards ? undefined : styles.primary}
+        />
+        {onSkipUnusable ? (
+          <Button title={copy.offlineSkip} onPress={onSkipUnusable} variant="text" size="large" haptic={false} />
+        ) : null}
+      </GlassSurface>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  body: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    gap: spacing[5],
+    paddingVertical: spacing[5],
+  },
+  copy: {
+    paddingHorizontal: spacing[5],
+    gap: spacing[2],
+  },
+  description: {
+    lineHeight: 20,
+  },
+  spinner: {
+    paddingVertical: spacing[8],
+    alignItems: 'center',
+  },
+  footer: {
+    paddingTop: spacing[3],
+    paddingHorizontal: spacing[5],
+    gap: spacing[2],
+  },
+  primary: {
+    alignSelf: 'stretch',
+  },
+});

--- a/packages/mobile/src/components/onboarding/OnboardingGate.tsx
+++ b/packages/mobile/src/components/onboarding/OnboardingGate.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import { router, useSegments } from 'expo-router';
 import * as Linking from 'expo-linking';
-import { hasSeenOnboarding } from '../../lib/onboarding/onboarding-storage';
+import { hasSeenOnboarding, markOnboardingSeen } from '../../lib/onboarding/onboarding-storage';
 import { DEEP_LINK_SEGMENTS } from '../../lib/deep-link-segments';
 import { useProfile } from '../../lib/graphql/hooks';
+import { useActiveBoard } from '../../lib/graphql/use-active-board';
+import { reportError } from '../../lib/error-reporting';
 import { BoardLookStepGate } from '../board-look/BoardLookStepGate';
 
 type OnboardingGateProps = {
@@ -13,11 +15,22 @@ type OnboardingGateProps = {
 
 /**
  * First-run gate. Once the app is ready (auth + fonts loaded, splash hidden) it
- * reads the persisted "seen" flag; if the walkthrough is unseen and the user
- * isn't mid deep-link / auth flow, it pushes the onboarding route once. Renders
- * nothing. Mounting it below AuthProvider means it only runs for an
+ * pushes the onboarding route unless the climber already has a board bound.
+ * Renders nothing. Mounting it below AuthProvider means it only runs for an
  * authenticated session — an unauthenticated cold start is redirected to login
  * by the auth gate, and the walkthrough shows after they sign in.
+ *
+ * **The gate is "has a board", not "has seen the tour"** (issue #4961). The flow
+ * is mandatory and its whole job is to leave the climber with a bound board, so
+ * the absence of one is the only honest signal that it has not done its job.
+ * Keying on the seen flag alone had a real hole: on iOS that flag lives in
+ * SecureStore, which survives an uninstall, while the active board lives in
+ * AsyncStorage, which does not — so a reinstall landed on empty states with no
+ * board and no way back to the picker.
+ *
+ * The seen flag is still written (by `useActivateBoard`, on every bind path), and
+ * backfilled here for climbers who bound a board before this gate existed. It is
+ * now a record of completion rather than the gate itself.
  *
  * The decision is keyed on the signed-in profile id, not the app process: on a
  * shared device a user can sign out and a different user sign in without a
@@ -51,8 +64,17 @@ export function OnboardingGate({ ready }: OnboardingGateProps) {
     decidedRef.current = false;
   }
 
+  // The gate's real input. `isFetched` is load-bearing: `data` is `undefined`
+  // while the AsyncStorage read is in flight, which is indistinguishable from
+  // "no board" and would flash the tour at every climber on every cold start.
+  // Read through a ref inside the effect so a board bound LATER in the session
+  // (the picker, a Bluetooth adopt) doesn't re-run a decision already made.
+  const { data: activeBoard, isFetched: boardResolved } = useActiveBoard();
+  const hasBoardRef = useRef(activeBoard != null);
+  hasBoardRef.current = activeBoard != null;
+
   useEffect(() => {
-    if (!ready || decidedRef.current) return;
+    if (!ready || !boardResolved || decidedRef.current) return;
     // Screenshot builds never auto-present the tour: the app-store flow needs to
     // reach the tabs, and the onboarding-capture flow opens /onboarding itself.
     // Nothing else auto-presents in a capture run either, so this stays `pending`.
@@ -90,11 +112,24 @@ export function OnboardingGate({ ready }: OnboardingGateProps) {
         }
         if (cancelled || initialUrl) return;
 
-        const seen = await hasSeenOnboarding();
-        if (cancelled || seen) return;
+        // A bound board means the flow has already done its job, however the
+        // climber got there — the picker, the builder, a Bluetooth adopt, or a
+        // build that predates this gate. Backfill the seen flag for that last
+        // group so it stays a truthful record of completion.
+        if (hasBoardRef.current) {
+          const seen = await hasSeenOnboarding();
+          if (cancelled || seen) return;
+          markOnboardingSeen().catch((error: unknown) => {
+            // eslint-disable-next-line no-console
+            console.warn('[onboarding] Failed to backfill "seen" flag', error);
+            reportError(error);
+          });
+          return;
+        }
+
         // Re-check the route after the async reads — a deep link may have arrived
         // in the meantime — so we never cover an intentional destination.
-        if (topSegmentRef.current && DEEP_LINK_SEGMENTS.has(topSegmentRef.current)) return;
+        if (cancelled || (topSegmentRef.current && DEEP_LINK_SEGMENTS.has(topSegmentRef.current))) return;
         router.push('/onboarding');
       } finally {
         setTourEvaluated(true);
@@ -106,7 +141,7 @@ export function OnboardingGate({ ready }: OnboardingGateProps) {
     };
     // `userId` is here so the effect re-runs after a sign-out/sign-in resets
     // `decidedRef` above — the new account gets its own first-run evaluation.
-  }, [ready, userId]);
+  }, [ready, boardResolved, userId]);
 
   return <BoardLookStepGate ready={ready} tourDecided={tourEvaluated} />;
 }

--- a/packages/mobile/src/components/onboarding/OnboardingGate.tsx
+++ b/packages/mobile/src/components/onboarding/OnboardingGate.tsx
@@ -112,25 +112,35 @@ export function OnboardingGate({ ready }: OnboardingGateProps) {
         }
         if (cancelled || initialUrl) return;
 
+        const seen = await hasSeenOnboarding();
+        if (cancelled) return;
+
         // A bound board means the flow has already done its job, however the
         // climber got there — the picker, the builder, a Bluetooth adopt, or a
         // build that predates this gate. Backfill the seen flag for that last
         // group so it stays a truthful record of completion.
         if (hasBoardRef.current) {
-          const seen = await hasSeenOnboarding();
-          if (cancelled || seen) return;
-          markOnboardingSeen().catch((error: unknown) => {
-            // eslint-disable-next-line no-console
-            console.warn('[onboarding] Failed to backfill "seen" flag', error);
-            reportError(error);
-          });
+          if (!seen) {
+            markOnboardingSeen().catch((error: unknown) => {
+              // eslint-disable-next-line no-console
+              console.warn('[onboarding] Failed to backfill "seen" flag', error);
+              reportError(error);
+            });
+          }
           return;
         }
 
         // Re-check the route after the async reads — a deep link may have arrived
         // in the meantime — so we never cover an intentional destination.
-        if (cancelled || (topSegmentRef.current && DEEP_LINK_SEGMENTS.has(topSegmentRef.current))) return;
-        router.push('/onboarding');
+        if (topSegmentRef.current && DEEP_LINK_SEGMENTS.has(topSegmentRef.current)) return;
+
+        // Someone who has already been through the framing card starts at the
+        // board step instead. A sign-out, a token expiry and a remote sign-out
+        // all clear the device-wide active board (`clearPersistedUserStores`),
+        // so without this every re-login would re-teach a climber who already
+        // knows why a named board matters. They still cannot leave without one —
+        // only the explaining is skipped, not the requirement.
+        router.push(seen ? { pathname: '/onboarding', params: { step: 'board' } } : '/onboarding');
       } finally {
         setTourEvaluated(true);
       }

--- a/packages/mobile/src/components/onboarding/OnboardingPrompt.tsx
+++ b/packages/mobile/src/components/onboarding/OnboardingPrompt.tsx
@@ -10,13 +10,13 @@ import {
   trackStepViewed,
   trackTourCompleted,
   trackTourDismissed,
-  trackTourSkipped,
   trackTourStarted,
 } from '../../lib/onboarding/onboarding-analytics';
 import { hapticSelection } from '../../lib/haptics';
 import { useTheme } from '../../providers/theme-provider';
 import { selectByVariant } from '../../theme/variants';
 import { spacing } from '../../theme/tokens';
+import { useBlockBack } from './use-block-back';
 
 type OnboardingPromptProps = {
   /** Primary CTA accent (HIG: systemColors.accent; Material: colors.primary). */
@@ -27,18 +27,21 @@ type OnboardingPromptProps = {
   bodyColor: string;
   /** Opaque background under the reading text. */
   backgroundColor: string;
-  /** Primary CTA — hand off to the real /boards picker (the activation action). */
-  onFindBoard: () => void;
-  /** Quiet exit — dismiss to Home; the Home empty state re-nudges later. */
-  onLookAround: () => void;
+  /** The only way on — continue to the board step. */
+  onContinue: () => void;
 };
 
 /**
  * First-run framing screen. A single value-promise card (live board history)
- * whose primary button drops the user straight into the real /boards follow
- * flow — following a named board is the one action that turns board history on,
- * so understand-and-do collapse into one motion. The quiet secondary exit leaves
- * to Home without guilt; nothing is taught that the user can't yet act on.
+ * whose one button carries on to the board step. Following a named board is the
+ * action that turns board history on, so the promise and the thing that delivers
+ * it sit one tap apart.
+ *
+ * **There is no exit** (issue #4961). The quiet "Look around first" secondary
+ * used to drop the climber on Home with no board bound — where every screen is
+ * an empty state and the promise this card just made never lands. Android
+ * hardware back is swallowed too; `gestureEnabled: false` on the route only
+ * closes the iOS half.
  *
  * Variant-agnostic: the route resolves the palette from the active UI variant
  * and injects it, so one component serves both the HIG and Material skins.
@@ -48,17 +51,19 @@ export function OnboardingPrompt({
   iconColor,
   bodyColor,
   backgroundColor,
-  onFindBoard,
-  onLookAround,
+  onContinue,
 }: OnboardingPromptProps) {
   const copy = useOnboardingCopy();
   const insets = useSafeAreaInsets();
   const { variant } = useTheme();
   const startedAtRef = useRef<number>(Date.now());
-  // Tracks whether the user chose a button. If they leave via Android back or a
-  // nav-away without choosing, the unmount cleanup fires Dismissed so the Start
-  // still resolves to a terminal outcome.
+  // Tracks whether the user chose a button. Android back is now swallowed, but a
+  // nav-away (a deep link arriving mid-step) can still unmount this without an
+  // answer, and the cleanup fires Dismissed so the Start resolves to a terminal
+  // outcome either way.
   const resolvedRef = useRef(false);
+
+  useBlockBack();
 
   // Tour Started + the single Step Viewed fire once on mount. On unmount, if no
   // button resolved the prompt, fire Dismissed (the back/kill exit).
@@ -73,19 +78,16 @@ export function OnboardingPrompt({
     };
   }, []);
 
-  const handleFindBoard = useCallback(() => {
+  // Completed means "read the framing and moved on", which is all this one card
+  // can attest to. The activation metric — a named board actually bound — is
+  // `Onboarding Board Activated`, fired from the bind itself.
+  const handleContinue = useCallback(() => {
     resolvedRef.current = true;
     const durationSeconds = Math.max(0, Math.round((Date.now() - startedAtRef.current) / 1000));
     trackTourCompleted(durationSeconds);
     hapticSelection();
-    onFindBoard();
-  }, [onFindBoard]);
-
-  const handleLookAround = useCallback(() => {
-    resolvedRef.current = true;
-    trackTourSkipped(ONBOARDING_PROMPT_CARD, 0);
-    onLookAround();
-  }, [onLookAround]);
+    onContinue();
+  }, [onContinue]);
 
   const footerPadding = useMemo(() => Math.max(insets.bottom, spacing[4]), [insets.bottom]);
 
@@ -110,15 +112,14 @@ export function OnboardingPrompt({
         style={[styles.footer, { paddingBottom: footerPadding }]}
       >
         <Button
-          title={copy.findBoard}
-          onPress={handleFindBoard}
+          title={copy.continueLabel}
+          onPress={handleContinue}
           variant="filled"
           size="large"
           tintColor={selectByVariant(variant, { material: undefined, liquidGlass: accentColor })}
           haptic={false}
           style={styles.primary}
         />
-        <Button title={copy.lookAround} onPress={handleLookAround} variant="text" size="large" haptic={false} />
       </GlassSurface>
     </View>
   );

--- a/packages/mobile/src/components/onboarding/__tests__/OnboardingBoardRoute.test.tsx
+++ b/packages/mobile/src/components/onboarding/__tests__/OnboardingBoardRoute.test.tsx
@@ -1,0 +1,246 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import type { OnboardingBoardStepProps } from '../OnboardingBoardStep';
+
+const stepCtrl = vi.hoisted(() => ({ props: null as OnboardingBoardStepProps | null }));
+const boardsCtrl = vi.hoisted(() => ({
+  boards: [] as UserBoard[],
+  isLoading: false,
+  isError: false,
+}));
+const envCtrl = vi.hoisted(() => ({
+  isOffline: false,
+  offlineDownloadsEnabled: true,
+  offlineState: 'off' as string,
+}));
+
+const replaceMock = vi.hoisted(() => vi.fn());
+const pushMock = vi.hoisted(() => vi.fn());
+const confirmAndDownloadMock = vi.hoisted(() => vi.fn().mockResolvedValue(true));
+const activateBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const activateOptionsCtrl = vi.hoisted(() => ({ last: null as Record<string, unknown> | null }));
+const nudgeMocks = vi.hoisted(() => ({
+  trackNudgeShown: vi.fn(),
+  trackNudgeAccepted: vi.fn(),
+  trackNudgeDismissed: vi.fn(),
+}));
+
+vi.mock('expo-router', () => ({ router: { replace: replaceMock, push: pushMock } }));
+vi.mock('../OnboardingBoardStep', () => ({
+  OnboardingBoardStep: (props: OnboardingBoardStepProps) => {
+    stepCtrl.props = props;
+    return null;
+  },
+}));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useMyBoards: () => ({
+    data: { boards: boardsCtrl.boards },
+    isLoading: boardsCtrl.isLoading,
+    isError: boardsCtrl.isError,
+  }),
+  useProfile: () => ({ data: { id: 'user-a' } }),
+}));
+vi.mock('../../../providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
+vi.mock('../../../hooks/use-is-offline', () => ({ useIsOffline: () => envCtrl.isOffline }));
+vi.mock('../../../hooks/use-current-user-id', () => ({
+  useStoredUserId: () => ({ userId: undefined, isLoading: false }),
+}));
+vi.mock('../../../providers/feature-flags-provider', () => ({
+  useOfflineDownloadsEnabled: () => envCtrl.offlineDownloadsEnabled,
+}));
+vi.mock('../../../offline/use-confirm-board-download', () => ({
+  useConfirmBoardDownload: () => ({ confirmAndDownload: confirmAndDownloadMock }),
+}));
+vi.mock('../../../offline/use-downloaded-scope-keys', () => ({
+  useDownloadedScopeKeys: () => ({ data: ['kilter:9:99'] }),
+}));
+vi.mock('../../board-discovery/use-board-offline-state', () => ({
+  useBoardOfflineState: () => () => envCtrl.offlineState,
+}));
+vi.mock('../../../lib/offline-nudges/nudge-analytics', () => nudgeMocks);
+vi.mock('../../../settings', () => ({
+  offlineBoardKeyForBoard: (board: UserBoard) => `${board.boardType}:${board.layoutId}:${board.sizeId}`,
+}));
+vi.mock('../../../lib/boards/use-activate-board', () => ({
+  useActivateBoard: (options: Record<string, unknown>) => {
+    activateOptionsCtrl.last = options;
+    return activateBoardMock;
+  },
+}));
+
+import { OnboardingBoardRoute } from '../OnboardingBoardRoute';
+
+const BOARD = {
+  uuid: 'board-1',
+  name: 'Klimmuur',
+  boardType: 'kilter',
+  layoutId: 1,
+  sizeId: 10,
+  setIds: '20,1',
+} as unknown as UserBoard;
+
+const NUDGE_CONTEXT = {
+  boardType: 'kilter',
+  layoutId: 1,
+  scopeKey: 'kilter:1:10',
+  downloadedBoardCount: 1,
+};
+
+function renderRoute() {
+  return render(<OnboardingBoardRoute accentColor="#6D28D9" bodyColor="#888" backgroundColor="#fff" />);
+}
+
+/** Run the `onBound` hook the route hands to `useActivateBoard`. */
+async function runOnBound(board: UserBoard = BOARD) {
+  const onBound = activateOptionsCtrl.last?.onBound as ((value: UserBoard) => Promise<void>) | undefined;
+  await onBound?.(board);
+}
+
+describe('OnboardingBoardRoute', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    confirmAndDownloadMock.mockResolvedValue(true);
+    boardsCtrl.boards = [BOARD];
+    boardsCtrl.isLoading = false;
+    boardsCtrl.isError = false;
+    envCtrl.isOffline = false;
+    envCtrl.offlineDownloadsEnabled = true;
+    envCtrl.offlineState = 'off';
+    stepCtrl.props = null;
+    activateOptionsCtrl.last = null;
+    cleanup();
+  });
+
+  it('binds as the onboarding activation, and leaves to Climbs rather than dismissing', () => {
+    renderRoute();
+
+    expect(activateOptionsCtrl.last?.source).toBe('onboarding');
+    (activateOptionsCtrl.last?.navigate as () => void)();
+    expect(replaceMock).toHaveBeenCalledWith('/(tabs)/climbs');
+  });
+
+  describe('the download offer', () => {
+    it('quotes the size and records the whole funnel when accepted', async () => {
+      renderRoute();
+      await runOnBound();
+
+      expect(nudgeMocks.trackNudgeShown).toHaveBeenCalledWith({ surface: 'onboarding', ...NUDGE_CONTEXT });
+      expect(confirmAndDownloadMock).toHaveBeenCalledWith(BOARD, {
+        trigger: 'onboarding',
+        source: 'onboarding',
+      });
+      expect(nudgeMocks.trackNudgeAccepted).toHaveBeenCalledWith(
+        { surface: 'onboarding', ...NUDGE_CONTEXT },
+        'download',
+      );
+      expect(nudgeMocks.trackNudgeDismissed).not.toHaveBeenCalled();
+    });
+
+    it('records a decline, so the take rate is readable', async () => {
+      confirmAndDownloadMock.mockResolvedValue(false);
+      renderRoute();
+      await runOnBound();
+
+      expect(nudgeMocks.trackNudgeDismissed).toHaveBeenCalledWith({ surface: 'onboarding', ...NUDGE_CONTEXT }, 'once');
+      expect(nudgeMocks.trackNudgeAccepted).not.toHaveBeenCalled();
+    });
+
+    // Quoting a download the climber has already asked for is noise, and the
+    // dialog would have nothing to offer.
+    it('stays quiet for a board already on the phone or on its way', async () => {
+      envCtrl.offlineState = 'downloaded';
+      renderRoute();
+      await runOnBound();
+
+      expect(confirmAndDownloadMock).not.toHaveBeenCalled();
+      expect(nudgeMocks.trackNudgeShown).not.toHaveBeenCalled();
+    });
+
+    // Arming something invisible that lands "sometime after you reconnect" is
+    // not a promise worth making on a first-run screen without asking.
+    it('stays quiet with no connection', async () => {
+      envCtrl.isOffline = true;
+      renderRoute();
+      await runOnBound();
+
+      expect(confirmAndDownloadMock).not.toHaveBeenCalled();
+    });
+
+    it('stays quiet where the engine cannot run', async () => {
+      envCtrl.offlineDownloadsEnabled = false;
+      renderRoute();
+      await runOnBound();
+
+      expect(confirmAndDownloadMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // The glyph is the same affordance as the one on /boards, which is accept-only
+  // there. Filing it under `onboarding` would mix an impression-tracked offer
+  // with an untracked one and wreck that surface's shown-to-accepted rate.
+  it('reports the card glyph as the board_card surface, accept-only', async () => {
+    renderRoute();
+    stepCtrl.props?.onDownload(BOARD);
+
+    await waitFor(() =>
+      expect(nudgeMocks.trackNudgeAccepted).toHaveBeenCalledWith(
+        { surface: 'board_card', ...NUDGE_CONTEXT },
+        'download',
+      ),
+    );
+    expect(nudgeMocks.trackNudgeShown).not.toHaveBeenCalled();
+  });
+
+  it('hands off to the full picker tagged as the onboarding flow', () => {
+    renderRoute();
+    stepCtrl.props?.onFindBoard();
+
+    expect(pushMock).toHaveBeenCalledWith({ pathname: '/boards', params: { source: 'onboarding' } });
+  });
+
+  describe('the escape hatch', () => {
+    it('is withheld while there is any board to choose from', () => {
+      envCtrl.isOffline = true;
+      renderRoute();
+      expect(stepCtrl.props?.onSkipUnusable).toBeNull();
+    });
+
+    it('is withheld while the list is still loading', () => {
+      boardsCtrl.boards = [];
+      boardsCtrl.isLoading = true;
+      envCtrl.isOffline = true;
+      renderRoute();
+      expect(stepCtrl.props?.onSkipUnusable).toBeNull();
+    });
+
+    it('is withheld when the list simply came back empty online', () => {
+      boardsCtrl.boards = [];
+      renderRoute();
+      // A climber with no boards and a working connection is not stuck — the
+      // full picker can still find or build one for them.
+      expect(stepCtrl.props?.onSkipUnusable).toBeNull();
+    });
+
+    it('opens when there is no connection and nothing cached', () => {
+      boardsCtrl.boards = [];
+      envCtrl.isOffline = true;
+      renderRoute();
+
+      stepCtrl.props?.onSkipUnusable?.();
+      expect(replaceMock).toHaveBeenCalledWith('/(tabs)/climbs');
+    });
+
+    // Captive-portal or gym wifi with a dead upstream reports ONLINE while every
+    // request fails, so `isOffline` alone would leave that climber stuck.
+    it('opens on a lying connection too', () => {
+      boardsCtrl.boards = [];
+      boardsCtrl.isError = true;
+      envCtrl.isOffline = false;
+      renderRoute();
+
+      expect(stepCtrl.props?.onSkipUnusable).not.toBeNull();
+    });
+  });
+});

--- a/packages/mobile/src/components/onboarding/__tests__/OnboardingBoardStep.test.tsx
+++ b/packages/mobile/src/components/onboarding/__tests__/OnboardingBoardStep.test.tsx
@@ -1,0 +1,235 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+const backHandlerCtrl = vi.hoisted(() => ({ handler: null as (() => boolean) | null, removed: false }));
+const offlineStateCtrl = vi.hoisted(() => ({ state: 'off' as string }));
+const carouselCtrl = vi.hoisted(() => ({
+  items: [] as { key: string; title: string }[],
+  onSelect: null as ((item: { key: string }) => void) | null,
+  onDownload: null as ((item: { key: string }) => void) | null,
+  downloadLabelFor: null as ((item: { key: string; title: string }) => string) | null,
+}));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  Platform: { OS: 'ios', select: (spec: Record<string, unknown>) => spec.ios },
+  PlatformColor: (color: string) => color,
+  BackHandler: {
+    addEventListener: (_event: string, handler: () => boolean) => {
+      backHandlerCtrl.handler = handler;
+      return {
+        remove: () => {
+          backHandlerCtrl.removed = true;
+        },
+      };
+    },
+  },
+}));
+vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0, bottom: 0 }) }));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../GlassSurface', () => ({
+  GlassSurface: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('../../ActivityIndicator', () => ({
+  ActivityIndicator: () => createElement('div', { 'data-testid': 'spinner' }),
+}));
+vi.mock('../../Button', () => ({
+  Button: ({ title, onPress }: { title: string; onPress: () => void }) =>
+    createElement('button', { onClick: onPress }, title),
+}));
+vi.mock('../../board-discovery/BoardCarousel', () => ({
+  BoardCarousel: (props: {
+    items: { key: string; title: string }[];
+    onSelect: (item: { key: string }) => void;
+    onDownload?: (item: { key: string }) => void;
+    downloadLabelFor?: (item: { key: string; title: string }) => string;
+  }) => {
+    carouselCtrl.items = props.items;
+    carouselCtrl.onSelect = props.onSelect;
+    carouselCtrl.onDownload = props.onDownload ?? null;
+    carouselCtrl.downloadLabelFor = props.downloadLabelFor ?? null;
+    return createElement('div', { 'data-testid': 'carousel' });
+  },
+}));
+vi.mock('../../board-discovery/use-board-offline-state', () => ({
+  useBoardOfflineState: () => () => offlineStateCtrl.state,
+}));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ variant: 'liquidGlass', systemColors: { secondaryLabel: '#888' } }),
+}));
+vi.mock('../../../theme/variants', () => ({
+  selectByVariant: (_v: string, spec: { liquidGlass: unknown }) => spec.liquidGlass,
+}));
+vi.mock('../../../lib/onboarding/use-onboarding-copy', () => ({
+  useOnboardingBoardCopy: () => ({
+    title: 'Which board?',
+    body: 'Every board keeps its own history.',
+    offlineHint: 'Keep it on your phone.',
+    findAnother: 'Find another board',
+    findFirst: 'Find my board',
+    offlineSkip: 'Skip for now',
+    downloadLabelFor: (name: string) => `Keep ${name} on this phone`,
+  }),
+}));
+
+import { OnboardingBoardStep, type OnboardingBoardStepProps } from '../OnboardingBoardStep';
+
+function board(uuid: string, name: string): UserBoard {
+  return {
+    uuid,
+    name,
+    boardType: 'kilter',
+    layoutId: 1,
+    sizeId: 10,
+    setIds: '20,1',
+  } as unknown as UserBoard;
+}
+
+const BOARDS = [board('board-1', 'Klimmuur'), board('board-2', 'Sterk')];
+
+function renderStep(overrides: Partial<OnboardingBoardStepProps> = {}) {
+  const props: OnboardingBoardStepProps = {
+    accentColor: '#6D28D9',
+    bodyColor: '#888888',
+    backgroundColor: '#ffffff',
+    boards: BOARDS,
+    isLoading: false,
+    offlineDownloadsEnabled: true,
+    currentUserId: 'user-a',
+    onSkipUnusable: null,
+    onSelect: vi.fn(),
+    onDownload: vi.fn(),
+    onFindBoard: vi.fn(),
+    ...overrides,
+  };
+  return { props, ...render(<OnboardingBoardStep {...props} />) };
+}
+
+function buttonTitles(container: HTMLElement): string[] {
+  return [...container.querySelectorAll('button')].map((node) => node.textContent ?? '');
+}
+
+describe('OnboardingBoardStep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    backHandlerCtrl.handler = null;
+    backHandlerCtrl.removed = false;
+    offlineStateCtrl.state = 'off';
+    carouselCtrl.items = [];
+    carouselCtrl.onSelect = null;
+    carouselCtrl.onDownload = null;
+    cleanup();
+  });
+
+  it('renders the climber’s own boards in the shared carousel', () => {
+    const { queryByTestId } = renderStep();
+
+    expect(queryByTestId('carousel')).toBeTruthy();
+    expect(carouselCtrl.items.map((item) => item.title)).toEqual(['Klimmuur', 'Sterk']);
+  });
+
+  // No board is pre-selected: the tick on a card means "this is your active
+  // board", and during onboarding there isn't one yet.
+  it('marks no card as active', () => {
+    renderStep();
+    expect(carouselCtrl.items.every((item) => !('isActive' in item && item.isActive))).toBe(true);
+  });
+
+  it('binds the tapped board', () => {
+    const { props } = renderStep();
+
+    carouselCtrl.onSelect?.({ key: 'board-2' });
+
+    expect(props.onSelect).toHaveBeenCalledWith(BOARDS[1]);
+  });
+
+  // A refetch can drop a board between render and tap. Binding something else
+  // would be worse than doing nothing.
+  it('does nothing when the tapped board is no longer in the list', () => {
+    const { props } = renderStep();
+
+    carouselCtrl.onSelect?.({ key: 'vanished' });
+
+    expect(props.onSelect).not.toHaveBeenCalled();
+  });
+
+  it('offers a per-card download, labelled with the board it would save', () => {
+    const { props } = renderStep();
+
+    expect(carouselCtrl.downloadLabelFor?.({ key: 'board-1', title: 'Klimmuur' })).toBe('Keep Klimmuur on this phone');
+    carouselCtrl.onDownload?.({ key: 'board-1' });
+    expect(props.onDownload).toHaveBeenCalledWith(BOARDS[0]);
+  });
+
+  it('hides the download glyph where the engine cannot run', () => {
+    renderStep({ offlineDownloadsEnabled: false });
+    expect(carouselCtrl.onDownload).toBeNull();
+  });
+
+  describe('with boards to choose from', () => {
+    it('keeps the full picker as the quiet alternative', () => {
+      const { container, props, getByText } = renderStep();
+
+      expect(buttonTitles(container)).toEqual(['Find another board']);
+      fireEvent.click(getByText('Find another board'));
+      expect(props.onFindBoard).toHaveBeenCalled();
+    });
+  });
+
+  // Issue #4961: "Failure there should fall through to the full /boards picker,
+  // not a dead end." An empty list and a failed load look the same from here,
+  // and both must offer the way forward rather than an empty slider.
+  describe('with no boards', () => {
+    it('leads with the full picker and shows no carousel', () => {
+      const { container, queryByTestId } = renderStep({ boards: [] });
+
+      expect(queryByTestId('carousel')).toBeNull();
+      expect(buttonTitles(container)).toEqual(['Find my board']);
+    });
+
+    it('shows a spinner only while the list is still in flight', () => {
+      const { queryByTestId } = renderStep({ boards: [], isLoading: true });
+      expect(queryByTestId('spinner')).toBeTruthy();
+
+      cleanup();
+      const settled = renderStep({ boards: [], isLoading: false });
+      expect(settled.queryByTestId('spinner')).toBeNull();
+    });
+  });
+
+  describe('the escape hatch', () => {
+    it('is absent unless the host says the screen cannot resolve', () => {
+      const { container } = renderStep();
+      expect(buttonTitles(container)).not.toContain('Skip for now');
+    });
+
+    it('appears — and only then — when there is nothing usable to show', () => {
+      const onSkipUnusable = vi.fn();
+      const { container, getByText } = renderStep({ boards: [], onSkipUnusable });
+
+      expect(buttonTitles(container)).toEqual(['Find my board', 'Skip for now']);
+      fireEvent.click(getByText('Skip for now'));
+      expect(onSkipUnusable).toHaveBeenCalled();
+    });
+  });
+
+  describe('Android hardware back', () => {
+    it('is swallowed, so the step has no exit the UI does not show', () => {
+      renderStep();
+      expect(backHandlerCtrl.handler?.()).toBe(true);
+    });
+
+    it('releases the handler on unmount', () => {
+      const { unmount } = renderStep();
+      unmount();
+      expect(backHandlerCtrl.removed).toBe(true);
+    });
+  });
+});

--- a/packages/mobile/src/components/onboarding/__tests__/OnboardingBoardStep.test.tsx
+++ b/packages/mobile/src/components/onboarding/__tests__/OnboardingBoardStep.test.tsx
@@ -30,6 +30,7 @@ vi.mock('react-native', () => ({
     },
   },
 }));
+vi.mock('expo-router', () => ({ useIsFocused: () => true }));
 vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0, bottom: 0 }) }));
 vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),

--- a/packages/mobile/src/components/onboarding/__tests__/OnboardingPrompt.test.tsx
+++ b/packages/mobile/src/components/onboarding/__tests__/OnboardingPrompt.test.tsx
@@ -9,7 +9,6 @@ const analyticsMock = vi.hoisted(() => ({
   trackTourStarted: vi.fn(),
   trackStepViewed: vi.fn(),
   trackTourCompleted: vi.fn(),
-  trackTourSkipped: vi.fn(),
   trackTourDismissed: vi.fn(),
 }));
 vi.mock('../../../lib/onboarding/onboarding-analytics', () => analyticsMock);
@@ -19,13 +18,16 @@ vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   StyleSheet: { create: (styles: Record<string, unknown>) => styles },
   Platform: { select: (spec: Record<string, unknown>) => spec.ios ?? spec.default },
+  // The step swallows Android back via useBlockBack; the handler is exercised in
+  // its own test, so here it only has to exist.
+  BackHandler: { addEventListener: () => ({ remove: () => {} }) },
 }));
 
 vi.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));
 
-// Button stub: a <button> carrying its title + onPress so either CTA is clickable.
+// Button stub: a <button> carrying its title + onPress so the CTA is clickable.
 vi.mock('../../Button', () => ({
   Button: ({ title, onPress }: { title: string; onPress?: () => void }) =>
     createElement('button', { onClick: onPress }, title),
@@ -42,8 +44,7 @@ vi.mock('../../../lib/onboarding/use-onboarding-copy', () => ({
     title: 'Title',
     body: 'Body',
     footnote: 'Footnote',
-    findBoard: 'Find a board',
-    lookAround: 'Look around',
+    continueLabel: 'Pick my board',
   }),
 }));
 
@@ -66,8 +67,7 @@ function renderPrompt() {
       iconColor="#000"
       bodyColor="#000"
       backgroundColor="#fff"
-      onFindBoard={() => {}}
-      onLookAround={() => {}}
+      onContinue={() => {}}
     />,
   );
 }
@@ -89,22 +89,22 @@ describe('OnboardingPrompt telemetry', () => {
     unmount();
     expect(analyticsMock.trackTourDismissed).toHaveBeenCalledTimes(1);
     expect(analyticsMock.trackTourCompleted).not.toHaveBeenCalled();
-    expect(analyticsMock.trackTourSkipped).not.toHaveBeenCalled();
   });
 
-  it('does not fire Dismissed when the primary CTA resolved the prompt', () => {
+  it('does not fire Dismissed when the CTA resolved the prompt', () => {
     const { getByText, unmount } = renderPrompt();
-    fireEvent.click(getByText('Find a board'));
+    fireEvent.click(getByText('Pick my board'));
     unmount();
     expect(analyticsMock.trackTourCompleted).toHaveBeenCalledTimes(1);
     expect(analyticsMock.trackTourDismissed).not.toHaveBeenCalled();
   });
 
-  it('does not fire Dismissed when the look-around exit resolved the prompt', () => {
-    const { getByText, unmount } = renderPrompt();
-    fireEvent.click(getByText('Look around'));
-    unmount();
-    expect(analyticsMock.trackTourSkipped).toHaveBeenCalledTimes(1);
-    expect(analyticsMock.trackTourDismissed).not.toHaveBeenCalled();
+  // Issue #4961 made the flow mandatory. A second button here would be a way out
+  // of it, so its absence is the assertion, not an implementation detail.
+  it('renders no exit beside the CTA', () => {
+    const { container } = renderPrompt();
+    const buttons = container.querySelectorAll('button');
+    expect(buttons.length).toBe(1);
+    expect(buttons[0]?.textContent).toBe('Pick my board');
   });
 });

--- a/packages/mobile/src/components/onboarding/__tests__/OnboardingPrompt.test.tsx
+++ b/packages/mobile/src/components/onboarding/__tests__/OnboardingPrompt.test.tsx
@@ -23,6 +23,7 @@ vi.mock('react-native', () => ({
   BackHandler: { addEventListener: () => ({ remove: () => {} }) },
 }));
 
+vi.mock('expo-router', () => ({ useIsFocused: () => true }));
 vi.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
 }));

--- a/packages/mobile/src/components/onboarding/__tests__/onboarding-gate.test.tsx
+++ b/packages/mobile/src/components/onboarding/__tests__/onboarding-gate.test.tsx
@@ -93,8 +93,19 @@ describe('OnboardingGate', () => {
   // The hole this replaced the seen-flag gate to close. On iOS the flag lives in
   // SecureStore and survives an uninstall; the active board lives in AsyncStorage
   // and does not. A reinstall used to land on empty states with no board.
+  //
+  // It starts at the BOARD step, not the framing card: sign-out, token expiry and
+  // remote sign-out all clear the active board too, and re-teaching a climber who
+  // already knows why a named board matters is friction, not onboarding.
   it('shows the flow when the board is gone even though the seen flag survived', async () => {
     hasSeenMock.mockResolvedValue(true);
+    activeBoardCtrl.board = null;
+    render(<OnboardingGate ready />);
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith({ pathname: '/onboarding', params: { step: 'board' } }));
+  });
+
+  it('starts a genuinely new climber at the framing card', async () => {
+    hasSeenMock.mockResolvedValue(false);
     activeBoardCtrl.board = null;
     render(<OnboardingGate ready />);
     await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/onboarding'));

--- a/packages/mobile/src/components/onboarding/__tests__/onboarding-gate.test.tsx
+++ b/packages/mobile/src/components/onboarding/__tests__/onboarding-gate.test.tsx
@@ -5,7 +5,15 @@ import { render, waitFor } from '@testing-library/react';
 const pushMock = vi.hoisted(() => vi.fn());
 const segmentsCtrl = vi.hoisted(() => ({ segments: ['(tabs)', 'climbs'] as string[] }));
 const hasSeenMock = vi.hoisted(() => vi.fn());
+const markSeenMock = vi.hoisted(() => vi.fn());
 const getInitialURLMock = vi.hoisted(() => vi.fn());
+// The gate's real input since issue #4961: onboarding shows whenever there is no
+// bound board. `isFetched` is separate because `data: undefined` mid-read is not
+// the same answer as `data: null`.
+const activeBoardCtrl = vi.hoisted(() => ({
+  board: null as { uuid: string } | null,
+  isFetched: true,
+}));
 // Controllable signed-in profile: the gate keys its first-run decision on the
 // profile id, so tests drive sign-out/sign-in by swapping this id.
 const profileCtrl = vi.hoisted(() => ({ id: undefined as string | undefined }));
@@ -22,7 +30,12 @@ vi.mock('expo-linking', () => ({
 }));
 vi.mock('../../../lib/onboarding/onboarding-storage', () => ({
   hasSeenOnboarding: hasSeenMock,
+  markOnboardingSeen: markSeenMock,
 }));
+vi.mock('../../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: activeBoardCtrl.board, isFetched: activeBoardCtrl.isFetched }),
+}));
+vi.mock('../../../lib/error-reporting', () => ({ reportError: vi.fn() }));
 vi.mock('../../../lib/graphql/hooks', () => ({
   useProfile: () => ({ data: profileCtrl.id ? { id: profileCtrl.id } : undefined }),
 }));
@@ -42,7 +55,13 @@ describe('OnboardingGate', () => {
   beforeEach(() => {
     pushMock.mockClear();
     hasSeenMock.mockReset();
+    markSeenMock.mockReset();
+    markSeenMock.mockResolvedValue(undefined);
     getInitialURLMock.mockReset();
+    // Default: no board bound, so the flow is due — the state every test that
+    // asserts a push relies on.
+    activeBoardCtrl.board = null;
+    activeBoardCtrl.isFetched = true;
     // Default: a plain launch (no cold-start deep link).
     getInitialURLMock.mockResolvedValue(null);
     segmentsCtrl.segments = ['(tabs)', 'climbs'];
@@ -63,10 +82,49 @@ describe('OnboardingGate', () => {
     await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/onboarding'));
   });
 
-  it('does not re-show the tour once it has been seen', async () => {
+  it('does not show the flow once a board is bound', async () => {
     hasSeenMock.mockResolvedValue(true);
+    activeBoardCtrl.board = { uuid: 'board-1' };
     render(<OnboardingGate ready />);
     await waitFor(() => expect(hasSeenMock).toHaveBeenCalled());
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  // The hole this replaced the seen-flag gate to close. On iOS the flag lives in
+  // SecureStore and survives an uninstall; the active board lives in AsyncStorage
+  // and does not. A reinstall used to land on empty states with no board.
+  it('shows the flow when the board is gone even though the seen flag survived', async () => {
+    hasSeenMock.mockResolvedValue(true);
+    activeBoardCtrl.board = null;
+    render(<OnboardingGate ready />);
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/onboarding'));
+  });
+
+  it('backfills the seen flag for a climber who bound a board before this gate existed', async () => {
+    hasSeenMock.mockResolvedValue(false);
+    activeBoardCtrl.board = { uuid: 'board-1' };
+    render(<OnboardingGate ready />);
+    await waitFor(() => expect(markSeenMock).toHaveBeenCalledTimes(1));
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('leaves the seen flag alone when it is already set', async () => {
+    hasSeenMock.mockResolvedValue(true);
+    activeBoardCtrl.board = { uuid: 'board-1' };
+    render(<OnboardingGate ready />);
+    await waitFor(() => expect(hasSeenMock).toHaveBeenCalled());
+    expect(markSeenMock).not.toHaveBeenCalled();
+  });
+
+  // `data: undefined` while the AsyncStorage read is in flight is indistinguishable
+  // from "no board", so deciding early would flash the flow at everyone.
+  it('waits for the active-board read before deciding', async () => {
+    hasSeenMock.mockResolvedValue(true);
+    activeBoardCtrl.isFetched = false;
+    render(<OnboardingGate ready />);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(hasSeenMock).not.toHaveBeenCalled();
     expect(pushMock).not.toHaveBeenCalled();
   });
 
@@ -126,24 +184,27 @@ describe('OnboardingGate', () => {
   });
 
   it('re-evaluates first-run when a different user signs in during the session', async () => {
-    // User A has already seen the tour — no push.
+    // User A already has a board — no push.
     hasSeenMock.mockResolvedValue(true);
+    activeBoardCtrl.board = { uuid: 'board-1' };
     profileCtrl.id = 'user-a';
     const { rerender } = render(<OnboardingGate ready />);
     await waitFor(() => expect(hasSeenMock).toHaveBeenCalledTimes(1));
     expect(pushMock).not.toHaveBeenCalled();
 
-    // User B signs in (different id) and hasn't seen it — the gate must
-    // re-check and push, rather than staying "decided" from user A.
+    // User B signs in (different id) with the board cleared out from under them —
+    // the gate must re-check and push, rather than staying "decided" from user A.
     hasSeenMock.mockResolvedValue(false);
+    activeBoardCtrl.board = null;
     profileCtrl.id = 'user-b';
     rerender(<OnboardingGate ready />);
-    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/onboarding'));
-    expect(hasSeenMock).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(pushMock).toHaveBeenCalledTimes(1));
+    expect(pushMock).toHaveBeenCalledWith('/onboarding');
   });
 
   it('does not re-decide when the same user id stays stable across rerenders', async () => {
     hasSeenMock.mockResolvedValue(true);
+    activeBoardCtrl.board = { uuid: 'board-1' };
     profileCtrl.id = 'user-a';
     const { rerender } = render(<OnboardingGate ready />);
     await waitFor(() => expect(hasSeenMock).toHaveBeenCalledTimes(1));
@@ -159,6 +220,7 @@ describe('OnboardingGate', () => {
       // Synchronous first render: the tour's flag read is still in flight, so
       // nothing else may decide to interrupt yet.
       hasSeenMock.mockResolvedValue(true);
+      activeBoardCtrl.board = { uuid: 'board-1' };
       render(<OnboardingGate ready />);
 
       expect(boardLookGateCtrl.lastProps?.tourDecided).toBe(false);
@@ -166,6 +228,7 @@ describe('OnboardingGate', () => {
 
     it('releases the board-look branch once the tour stands down', async () => {
       hasSeenMock.mockResolvedValue(true);
+      activeBoardCtrl.board = { uuid: 'board-1' };
       render(<OnboardingGate ready />);
 
       await waitFor(() => expect(boardLookGateCtrl.lastProps?.tourDecided).toBe(true));
@@ -204,6 +267,7 @@ describe('OnboardingGate', () => {
       // returned immediately — leaving the board-look step waiting on a flag
       // nothing would ever set again.
       hasSeenMock.mockResolvedValue(true);
+      activeBoardCtrl.board = { uuid: 'board-1' };
       profileCtrl.id = undefined;
       const { rerender } = render(<OnboardingGate ready />);
 
@@ -218,6 +282,7 @@ describe('OnboardingGate', () => {
       // `decidedRef` (it is guarded on a concrete id), so the re-run early-returns
       // — the flag must already be published by then.
       hasSeenMock.mockResolvedValue(true);
+      activeBoardCtrl.board = { uuid: 'board-1' };
       profileCtrl.id = undefined;
       const { rerender } = render(<OnboardingGate ready />);
 

--- a/packages/mobile/src/components/onboarding/__tests__/use-block-back.test.tsx
+++ b/packages/mobile/src/components/onboarding/__tests__/use-block-back.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const focusCtrl = vi.hoisted(() => ({ isFocused: true }));
+const backCtrl = vi.hoisted(() => ({
+  handlers: [] as (() => boolean)[],
+  removals: 0,
+}));
+
+vi.mock('expo-router', () => ({ useIsFocused: () => focusCtrl.isFocused }));
+vi.mock('react-native', () => ({
+  BackHandler: {
+    addEventListener: (_event: string, handler: () => boolean) => {
+      backCtrl.handlers.push(handler);
+      return {
+        remove: () => {
+          backCtrl.removals += 1;
+          backCtrl.handlers = backCtrl.handlers.filter((entry) => entry !== handler);
+        },
+      };
+    },
+  },
+}));
+
+import { useBlockBack } from '../use-block-back';
+
+describe('useBlockBack', () => {
+  beforeEach(() => {
+    focusCtrl.isFocused = true;
+    backCtrl.handlers = [];
+    backCtrl.removals = 0;
+  });
+
+  it('swallows the press while the step is in front', () => {
+    renderHook(() => useBlockBack());
+
+    expect(backCtrl.handlers).toHaveLength(1);
+    expect(backCtrl.handlers[0]?.()).toBe(true);
+  });
+
+  it('releases the handler on unmount', () => {
+    const { unmount } = renderHook(() => useBlockBack());
+    unmount();
+
+    expect(backCtrl.removals).toBe(1);
+    expect(backCtrl.handlers).toHaveLength(0);
+  });
+
+  // BackHandler dispatches newest-first and stops at the first `true`, and React
+  // Navigation registers its handler once at container mount — so a blocker added
+  // later always runs ahead of it, including while its screen sits mounted
+  // UNDERNEATH a pushed one. Unregistering on blur is what keeps back working
+  // inside /boards, /boards/create and /gyms after "Find another board".
+  it('registers nothing while the step is behind a pushed screen', () => {
+    focusCtrl.isFocused = false;
+    renderHook(() => useBlockBack());
+
+    expect(backCtrl.handlers).toHaveLength(0);
+  });
+
+  it('re-registers when the step comes back to the front', () => {
+    focusCtrl.isFocused = true;
+    const { rerender } = renderHook(() => useBlockBack());
+    expect(backCtrl.handlers).toHaveLength(1);
+
+    focusCtrl.isFocused = false;
+    rerender();
+    expect(backCtrl.handlers).toHaveLength(0);
+
+    focusCtrl.isFocused = true;
+    rerender();
+    expect(backCtrl.handlers).toHaveLength(1);
+  });
+});

--- a/packages/mobile/src/components/onboarding/use-block-back.ts
+++ b/packages/mobile/src/components/onboarding/use-block-back.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { BackHandler } from 'react-native';
+
+/**
+ * Swallow the Android hardware back button while a mandatory onboarding step is
+ * mounted.
+ *
+ * The onboarding route is registered `presentation: 'fullScreenModal'` with
+ * `gestureEnabled: false` (app/_layout.tsx), which closes the iOS swipe-dismiss.
+ * Android's hardware back is a separate exit and pops the screen regardless — so
+ * without this, every "no way to skip" step still has one, and it is the exit
+ * that leaves no trace in the funnel beyond a Dismissed event.
+ *
+ * Returning `true` marks the press handled and stops the default pop. There is
+ * deliberately no escape argument: a step that can be backed out of is not a
+ * mandatory step, and the one screen that legitimately needs an exit (the board
+ * step with no connection and nothing cached) offers it as a visible button.
+ */
+export function useBlockBack(): void {
+  useEffect(() => {
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => true);
+    return () => subscription.remove();
+  }, []);
+}

--- a/packages/mobile/src/components/onboarding/use-block-back.ts
+++ b/packages/mobile/src/components/onboarding/use-block-back.ts
@@ -1,9 +1,10 @@
 import { useEffect } from 'react';
 import { BackHandler } from 'react-native';
+import { useIsFocused } from 'expo-router';
 
 /**
  * Swallow the Android hardware back button while a mandatory onboarding step is
- * mounted.
+ * the screen in front of the climber.
  *
  * The onboarding route is registered `presentation: 'fullScreenModal'` with
  * `gestureEnabled: false` (app/_layout.tsx), which closes the iOS swipe-dismiss.
@@ -11,14 +12,27 @@ import { BackHandler } from 'react-native';
  * without this, every "no way to skip" step still has one, and it is the exit
  * that leaves no trace in the funnel beyond a Dismissed event.
  *
- * Returning `true` marks the press handled and stops the default pop. There is
- * deliberately no escape argument: a step that can be backed out of is not a
- * mandatory step, and the one screen that legitimately needs an exit (the board
- * step with no connection and nothing cached) offers it as a visible button.
+ * Returning `true` marks the press handled and stops the default pop.
+ *
+ * **Focus-gated, and that is not optional.** `BackHandler` dispatches to its
+ * listeners newest-first and stops at the first one to return `true`. React
+ * Navigation registers its own handler once, when the container mounts, so a
+ * blocker added later always runs ahead of it — including while the step sits
+ * mounted UNDERNEATH a pushed screen. Without the focus check, tapping "Find
+ * another board" would leave this handler eating back presses inside `/boards`,
+ * `/boards/create` and `/gyms`, killing the back button across the whole
+ * find-a-board detour rather than on the one step that wants it blocked.
+ *
+ * There is deliberately no escape argument: a step that can be backed out of is
+ * not a mandatory step, and the one screen that legitimately needs an exit (the
+ * board step with no connection and nothing cached) offers it as a button.
  */
 export function useBlockBack(): void {
+  const isFocused = useIsFocused();
+
   useEffect(() => {
+    if (!isFocused) return;
     const subscription = BackHandler.addEventListener('hardwareBackPress', () => true);
     return () => subscription.remove();
-  }, []);
+  }, [isFocused]);
 }

--- a/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/user-drawer-provider.test.tsx
@@ -105,7 +105,6 @@ vi.mock('../../../lib/offline-nudges/spotlight-unseen', () => ({
 // could render at all.
 vi.mock('../../../providers/feature-flags-provider', () => ({
   useOfflineDownloadsEnabled: () => true,
-  useOfflineNudgesEnabled: () => true,
 }));
 // AsyncStorage-backed; the spotlight names a board, so the pill asks whether
 // there is one.

--- a/packages/mobile/src/lib/boards/__tests__/use-activate-board.test.tsx
+++ b/packages/mobile/src/lib/boards/__tests__/use-activate-board.test.tsx
@@ -8,6 +8,7 @@ const adoptFoundBoardMock = vi.hoisted(() => vi.fn());
 const dismissToMock = vi.hoisted(() => vi.fn());
 const showToastMock = vi.hoisted(() => vi.fn());
 const trackMock = vi.hoisted(() => vi.fn());
+const hapticMock = vi.hoisted(() => vi.fn());
 const markOnboardingSeenMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const setBoardRevealTipPendingMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const reportErrorMock = vi.hoisted(() => vi.fn());
@@ -17,7 +18,7 @@ vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => k
 vi.mock('../../graphql/use-active-board', () => ({ useSetActiveBoard: () => setActiveBoardMock }));
 vi.mock('../../board-discovery/use-adopt-found-board', () => ({ useAdoptFoundBoard: () => adoptFoundBoardMock }));
 vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: showToastMock }) }));
-vi.mock('../../haptics', () => ({ hapticSelection: vi.fn() }));
+vi.mock('../../haptics', () => ({ hapticSelection: hapticMock }));
 vi.mock('../../analytics', () => ({ track: trackMock }));
 vi.mock('../../onboarding/onboarding-storage', () => ({
   markOnboardingSeen: markOnboardingSeenMock,
@@ -61,6 +62,42 @@ describe('useActivateBoard', () => {
     expect(dismissToMock).not.toHaveBeenCalled();
     expect(adoptFoundBoardMock).not.toHaveBeenCalled();
     expect(showToastMock).toHaveBeenCalledWith('mobile.boardSwitchError', 'error');
+  });
+
+  // The builder renders its failure inline and has submit state to unwind — a
+  // toast is invisible behind its modal route, and a swallowed rejection would
+  // leave its CTA spinning forever with nothing on screen to explain why.
+  it('rethrows the write failure when the caller owns the error UI', async () => {
+    setActiveBoardMock.mockRejectedValue(new Error('storage full'));
+    const result = activate({ writeFailure: 'rethrow' });
+
+    await expect(result.current(BOARD)).rejects.toThrow('storage full');
+    expect(showToastMock).not.toHaveBeenCalled();
+    expect(dismissToMock).not.toHaveBeenCalled();
+  });
+
+  it('buzzes on the bind, unless the caller already did', async () => {
+    const result = activate();
+    await result.current(BOARD);
+    expect(hapticMock).toHaveBeenCalledTimes(1);
+
+    hapticMock.mockClear();
+    const quiet = activate({ haptic: false });
+    await quiet.current(BOARD);
+    expect(hapticMock).not.toHaveBeenCalled();
+  });
+
+  // The board IS bound by the time we navigate, so a stale-route throw must not
+  // surface as a write failure and undo the caller's submit state.
+  it('reports a navigation failure rather than raising it as a write failure', async () => {
+    dismissToMock.mockImplementation(() => {
+      throw new Error('navigate before mounting');
+    });
+    const result = activate({ writeFailure: 'rethrow' });
+
+    await expect(result.current(BOARD)).resolves.toBeUndefined();
+    expect(reportErrorMock).toHaveBeenCalled();
+    expect(adoptFoundBoardMock).toHaveBeenCalled();
   });
 
   it('skips adoption when the rows came from the on-device snapshots', async () => {

--- a/packages/mobile/src/lib/boards/__tests__/use-activate-board.test.tsx
+++ b/packages/mobile/src/lib/boards/__tests__/use-activate-board.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { UserBoard } from '@boardsesh/shared-schema';
+
+const setActiveBoardMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const adoptFoundBoardMock = vi.hoisted(() => vi.fn());
+const dismissToMock = vi.hoisted(() => vi.fn());
+const showToastMock = vi.hoisted(() => vi.fn());
+const trackMock = vi.hoisted(() => vi.fn());
+const markOnboardingSeenMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const setBoardRevealTipPendingMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const reportErrorMock = vi.hoisted(() => vi.fn());
+
+vi.mock('expo-router', () => ({ useRouter: () => ({ dismissTo: dismissToMock }) }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../graphql/use-active-board', () => ({ useSetActiveBoard: () => setActiveBoardMock }));
+vi.mock('../../board-discovery/use-adopt-found-board', () => ({ useAdoptFoundBoard: () => adoptFoundBoardMock }));
+vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: showToastMock }) }));
+vi.mock('../../haptics', () => ({ hapticSelection: vi.fn() }));
+vi.mock('../../analytics', () => ({ track: trackMock }));
+vi.mock('../../onboarding/onboarding-storage', () => ({
+  markOnboardingSeen: markOnboardingSeenMock,
+  setBoardRevealTipPending: setBoardRevealTipPendingMock,
+}));
+vi.mock('../../error-reporting', () => ({ reportError: reportErrorMock }));
+
+import { useActivateBoard, type ActivateBoardOptions } from '../use-activate-board';
+
+const BOARD = { uuid: 'board-1', name: 'Klimmuur', boardType: 'kilter' } as unknown as UserBoard;
+
+function activate(options: Partial<ActivateBoardOptions> = {}) {
+  const { result } = renderHook(() => useActivateBoard({ returnTo: '/(tabs)/climbs', ...options }));
+  return result;
+}
+
+describe('useActivateBoard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActiveBoardMock.mockResolvedValue(undefined);
+    markOnboardingSeenMock.mockResolvedValue(undefined);
+    setBoardRevealTipPendingMock.mockResolvedValue(undefined);
+  });
+
+  it('persists the board, then navigates, then adopts', async () => {
+    const result = activate();
+    await result.current(BOARD);
+
+    expect(setActiveBoardMock).toHaveBeenCalledWith(BOARD);
+    expect(dismissToMock).toHaveBeenCalledWith('/(tabs)/climbs');
+    expect(adoptFoundBoardMock).toHaveBeenCalledWith(BOARD);
+  });
+
+  // A board that won't survive the next cold start is worse than no board, so a
+  // failed write must not be followed by a navigation that implies success.
+  it('does not navigate when the write fails', async () => {
+    setActiveBoardMock.mockRejectedValue(new Error('storage full'));
+    const result = activate();
+    await result.current(BOARD);
+
+    expect(dismissToMock).not.toHaveBeenCalled();
+    expect(adoptFoundBoardMock).not.toHaveBeenCalled();
+    expect(showToastMock).toHaveBeenCalledWith('mobile.boardSwitchError', 'error');
+  });
+
+  it('skips adoption when the rows came from the on-device snapshots', async () => {
+    const result = activate({ isLocalOnly: true });
+    await result.current(BOARD);
+
+    expect(dismissToMock).toHaveBeenCalled();
+    expect(adoptFoundBoardMock).not.toHaveBeenCalled();
+  });
+
+  describe('an ordinary board switch', () => {
+    it('fires no onboarding side effects', async () => {
+      const result = activate();
+      await result.current(BOARD);
+
+      expect(trackMock).not.toHaveBeenCalled();
+      expect(setBoardRevealTipPendingMock).not.toHaveBeenCalled();
+      expect(markOnboardingSeenMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the onboarding bind', () => {
+    it('tracks the activation, arms the reveal banner and closes out first-run', async () => {
+      const result = activate({ source: 'onboarding' });
+      await result.current(BOARD);
+
+      expect(trackMock).toHaveBeenCalledWith('Onboarding Board Activated', {
+        boardType: 'kilter',
+        source: 'onboarding',
+      });
+      expect(setBoardRevealTipPendingMock).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(markOnboardingSeenMock).toHaveBeenCalledTimes(1));
+    });
+
+    // The gate shows onboarding whenever there is no board, so a keychain that
+    // refuses the write would loop the climber back through a flow they finished.
+    // It still must not block the bind — report and carry on.
+    it('navigates even when the seen flag cannot be written', async () => {
+      markOnboardingSeenMock.mockRejectedValue(new Error('keychain locked'));
+      const result = activate({ source: 'onboarding' });
+      await result.current(BOARD);
+
+      expect(dismissToMock).toHaveBeenCalled();
+      await waitFor(() => expect(reportErrorMock).toHaveBeenCalled());
+    });
+  });
+
+  describe('onBound', () => {
+    it('runs after the bind and before the navigation', async () => {
+      const order: string[] = [];
+      setActiveBoardMock.mockImplementation(async () => void order.push('bind'));
+      dismissToMock.mockImplementation(() => void order.push('navigate'));
+      const result = activate({ onBound: async () => void order.push('onBound') });
+
+      await result.current(BOARD);
+
+      expect(order).toEqual(['bind', 'onBound', 'navigate']);
+    });
+
+    // The board IS bound by this point. Refusing to navigate over a failed extra
+    // would strand the climber on a step they have already completed.
+    it('still navigates when it throws', async () => {
+      const result = activate({
+        onBound: () => Promise.reject(new Error('dialog blew up')),
+      });
+
+      await result.current(BOARD);
+
+      expect(dismissToMock).toHaveBeenCalled();
+      expect(reportErrorMock).toHaveBeenCalled();
+      expect(showToastMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('uses the injected navigate when one is given', async () => {
+    const navigate = vi.fn();
+    const result = activate({ navigate });
+    await result.current(BOARD);
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(dismissToMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/boards/use-activate-board.ts
+++ b/packages/mobile/src/lib/boards/use-activate-board.ts
@@ -1,0 +1,128 @@
+// Binding a board to the app — the one path every surface that picks a board
+// goes through.
+//
+// This used to live inside app/boards/index.tsx, which made it the only place
+// that got the whole sequence right. app/boards/create.tsx had its own shorter
+// version (write, then navigate), so a climber who arrived from onboarding and
+// CREATED their first board silently skipped both the activation metric and the
+// Climbs reveal banner — the two things that exist to mark exactly that moment.
+// One hook, three callers, no second version to drift.
+
+import { useCallback } from 'react';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import type { UserBoard } from '@boardsesh/shared-schema';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
+import { useSetActiveBoard } from '../graphql/use-active-board';
+import { useAdoptFoundBoard } from '../board-discovery/use-adopt-found-board';
+import { useToast } from '../../providers/toast-provider';
+import { hapticSelection } from '../haptics';
+import { markOnboardingSeen, setBoardRevealTipPending } from '../onboarding/onboarding-storage';
+import { reportError } from '../error-reporting';
+import { track } from '../analytics';
+import type { BoardReturnTo } from './board-return-to';
+
+export type ActivateBoardOptions = {
+  /**
+   * Where the pick came from. `'onboarding'` is the activation flow: it fires
+   * the activation metric, arms the one-time Climbs reveal banner, and closes
+   * out first-run. Everything else is an ordinary board switch.
+   */
+  source?: 'onboarding';
+  /** Which tab to dismiss back to once the board is bound. */
+  returnTo: BoardReturnTo;
+  /**
+   * How to leave, when `router.dismissTo(returnTo)` is wrong. The boards modal
+   * dismisses back onto the tab underneath it; the onboarding steps `replace`
+   * instead, because there is nothing of theirs left to return to.
+   */
+  navigate?: () => void;
+  /**
+   * The board list came from the on-device snapshots rather than the network.
+   * Adoption is a follow mutation plus a download confirm, so with no usable
+   * connection the only thing it can produce is a "Could not follow X" toast for
+   * a board the climber already has on their phone.
+   *
+   * Deliberately NOT `useIsOffline()`: the lying-connection case (captive
+   * portal, dead upstream) renders the same rows with `isOffline === false` and
+   * its requests fail just as hard.
+   */
+  isLocalOnly?: boolean;
+  /**
+   * Runs after the board is bound and before navigation, so a caller can offer
+   * something that belongs to this moment — the onboarding step quotes the
+   * offline download here. Awaited, because navigating out from under a dialog
+   * would dismiss it. A throw here is reported and then ignored: the board IS
+   * bound by this point, and refusing to navigate would strand the climber over
+   * a failed extra.
+   */
+  onBound?: (board: UserBoard) => Promise<void>;
+};
+
+/**
+ * Returns the bind action. It persists the board FIRST and only navigates once
+ * that write succeeds — a failed write must not strand the climber on a board
+ * that won't survive the next cold start.
+ */
+export function useActivateBoard({ source, returnTo, navigate, isLocalOnly = false, onBound }: ActivateBoardOptions) {
+  const router = useRouter();
+  const { t } = useTranslation('boards');
+  const { showToast } = useToast();
+  const setActiveBoard = useSetActiveBoard();
+  const adoptFoundBoard = useAdoptFoundBoard();
+
+  return useCallback(
+    async (board: UserBoard) => {
+      hapticSelection();
+      try {
+        // Persists to AsyncStorage + the ['activeBoard'] cache.
+        await setActiveBoard(board);
+
+        if (source === 'onboarding') {
+          // The real activation metric — board history turns on the moment a
+          // named board is bound — and the one-time Climbs reveal banner is
+          // armed for the board they just followed.
+          track(SHARED_EVENTS.OnboardingBoardActivated, { boardType: board.boardType, source: 'onboarding' });
+          void setBoardRevealTipPending();
+          // First-run is over the moment a board exists. OnboardingGate now
+          // shows the flow whenever there is no active board, so this flag is
+          // the record of completion rather than the gate itself — but leaving
+          // it unwritten would make the gate re-mark it on every launch.
+          // Fire-and-forget: a locked keychain must not block the bind, but it
+          // must be reported, because swallowing it hides a re-showing tour.
+          markOnboardingSeen().catch((error: unknown) => {
+            // eslint-disable-next-line no-console
+            console.warn('[onboarding] Failed to persist "seen" flag', error);
+            reportError(error);
+          });
+        }
+      } catch {
+        showToast(t('mobile.boardSwitchError'), 'error');
+        return;
+      }
+
+      if (onBound) {
+        try {
+          await onBound(board);
+        } catch (error: unknown) {
+          reportError(error);
+        }
+      }
+
+      // Dismiss the boards modal back onto the tab it was opened from — Climbs
+      // by default (including the onboarding hand-off), Discover when the pill
+      // there opened it (replaces with that tab if it isn't already underneath,
+      // e.g. opened from a deep link).
+      if (navigate) navigate();
+      else router.dismissTo(returnTo);
+
+      // Follow the board if it's new to the climber (so it lands in My Boards)
+      // and offer/auto-run its offline download. The isNew guard inside makes
+      // re-selecting a board already in My Boards a no-op for follow.
+      // Fire-and-forget: its own errors are handled inside and intentionally
+      // don't reach the catch above, which only guards the bind.
+      if (!isLocalOnly) void adoptFoundBoard(board);
+    },
+    [setActiveBoard, adoptFoundBoard, router, returnTo, navigate, showToast, t, source, isLocalOnly, onBound],
+  );
+}

--- a/packages/mobile/src/lib/boards/use-activate-board.ts
+++ b/packages/mobile/src/lib/boards/use-activate-board.ts
@@ -57,6 +57,24 @@ export type ActivateBoardOptions = {
    * a failed extra.
    */
   onBound?: (board: UserBoard) => Promise<void>;
+  /**
+   * What a failed board write does.
+   *
+   * `'toast'` (the default) shows the switch-failed toast and resolves — right
+   * for the picker, where the climber is still looking at a list they can tap
+   * again.
+   *
+   * `'rethrow'` re-raises so a caller with its own error UI keeps it. The
+   * builder needs this: it is a `presentation: 'modal'` route and the toast
+   * overlay draws BEHIND it, so a toast there is invisible, and it has submit
+   * state to unwind. Swallowing the failure would leave its CTA spinning
+   * forever with nothing on screen to explain why.
+   */
+  writeFailure?: 'toast' | 'rethrow';
+  /**
+   * Whether the bind buzzes. Off for the builder, whose submit tap already did.
+   */
+  haptic?: boolean;
 };
 
 /**
@@ -64,7 +82,15 @@ export type ActivateBoardOptions = {
  * that write succeeds — a failed write must not strand the climber on a board
  * that won't survive the next cold start.
  */
-export function useActivateBoard({ source, returnTo, navigate, isLocalOnly = false, onBound }: ActivateBoardOptions) {
+export function useActivateBoard({
+  source,
+  returnTo,
+  navigate,
+  isLocalOnly = false,
+  onBound,
+  writeFailure = 'toast',
+  haptic = true,
+}: ActivateBoardOptions) {
   const router = useRouter();
   const { t } = useTranslation('boards');
   const { showToast } = useToast();
@@ -73,7 +99,7 @@ export function useActivateBoard({ source, returnTo, navigate, isLocalOnly = fal
 
   return useCallback(
     async (board: UserBoard) => {
-      hapticSelection();
+      if (haptic) hapticSelection();
       try {
         // Persists to AsyncStorage + the ['activeBoard'] cache.
         await setActiveBoard(board);
@@ -96,7 +122,8 @@ export function useActivateBoard({ source, returnTo, navigate, isLocalOnly = fal
             reportError(error);
           });
         }
-      } catch {
+      } catch (error: unknown) {
+        if (writeFailure === 'rethrow') throw error;
         showToast(t('mobile.boardSwitchError'), 'error');
         return;
       }
@@ -113,8 +140,18 @@ export function useActivateBoard({ source, returnTo, navigate, isLocalOnly = fal
       // by default (including the onboarding hand-off), Discover when the pill
       // there opened it (replaces with that tab if it isn't already underneath,
       // e.g. opened from a deep link).
-      if (navigate) navigate();
-      else router.dismissTo(returnTo);
+      //
+      // Reported, not rethrown, and deliberately not routed to `writeFailure`:
+      // the board IS bound by now, so a navigation that fails (a stale route,
+      // a dismissed stack) is not the write failure the caller's error UI is
+      // written for, and raising it would undo submit state over a board that
+      // really did land.
+      try {
+        if (navigate) navigate();
+        else router.dismissTo(returnTo);
+      } catch (error: unknown) {
+        reportError(error);
+      }
 
       // Follow the board if it's new to the climber (so it lands in My Boards)
       // and offer/auto-run its offline download. The isNew guard inside makes
@@ -123,6 +160,19 @@ export function useActivateBoard({ source, returnTo, navigate, isLocalOnly = fal
       // don't reach the catch above, which only guards the bind.
       if (!isLocalOnly) void adoptFoundBoard(board);
     },
-    [setActiveBoard, adoptFoundBoard, router, returnTo, navigate, showToast, t, source, isLocalOnly, onBound],
+    [
+      setActiveBoard,
+      adoptFoundBoard,
+      router,
+      returnTo,
+      navigate,
+      showToast,
+      t,
+      source,
+      isLocalOnly,
+      onBound,
+      writeFailure,
+      haptic,
+    ],
   );
 }

--- a/packages/mobile/src/lib/offline-nudges/__tests__/nudge-policy.test.ts
+++ b/packages/mobile/src/lib/offline-nudges/__tests__/nudge-policy.test.ts
@@ -23,7 +23,6 @@ function input(overrides: Partial<NudgeDecisionInput> = {}): NudgeDecisionInput 
     state: emptyNudgeState(),
     nowMs: NOW,
     offlineEngineEnabled: true,
-    nudgesEnabled: true,
     offlineState: 'off',
     autoOfflineBoards: false,
     ...overrides,
@@ -45,27 +44,26 @@ describe('shouldShowNudge — eligibility', () => {
   // which is NOT in downloadedScopeKeys and has no sync in flight, so a naive
   // gate would re-prompt for the board it just armed.
   it.each(['pending', 'downloading', 'downloaded'] as const)('suppresses when the board is %s', (offlineState) => {
-    for (const surface of ['post_session', 'no_catalog', 'whats_new', 'board_card'] as NudgeSurface[]) {
+    for (const surface of ['post_session', 'no_catalog', 'whats_new', 'board_card', 'onboarding'] as NudgeSurface[]) {
       expect(shouldShowNudge(input({ surface, offlineState }))).toBe(false);
     }
   });
 
   it('suppresses every surface when the user auto-downloads all boards', () => {
-    for (const surface of ['post_session', 'no_catalog', 'whats_new', 'board_card'] as NudgeSurface[]) {
+    for (const surface of ['post_session', 'no_catalog', 'whats_new', 'board_card', 'onboarding'] as NudgeSurface[]) {
       expect(shouldShowNudge(input({ surface, autoOfflineBoards: true }))).toBe(false);
     }
   });
 
   it('suppresses every surface in screenshot mode', () => {
     process.env.EXPO_PUBLIC_SCREENSHOT_MODE = '1';
-    for (const surface of ['post_session', 'no_catalog', 'whats_new', 'board_card'] as NudgeSurface[]) {
+    for (const surface of ['post_session', 'no_catalog', 'whats_new', 'board_card', 'onboarding'] as NudgeSurface[]) {
       expect(shouldShowNudge(input({ surface }))).toBe(false);
     }
   });
 
-  it('suppresses when either flag is off', () => {
+  it('suppresses when the offline engine is unavailable', () => {
     expect(shouldShowNudge(input({ offlineEngineEnabled: false }))).toBe(false);
-    expect(shouldShowNudge(input({ nudgesEnabled: false }))).toBe(false);
   });
 
   it('respects dismiss-forever per surface', () => {
@@ -76,7 +74,7 @@ describe('shouldShowNudge — eligibility', () => {
 
   it('suppresses everything from the storage-failure state', () => {
     const state = suppressedNudgeState();
-    for (const surface of ['post_session', 'no_catalog', 'whats_new', 'board_card'] as NudgeSurface[]) {
+    for (const surface of ['post_session', 'no_catalog', 'whats_new', 'board_card', 'onboarding'] as NudgeSurface[]) {
       expect(shouldShowNudge(input({ surface, state }))).toBe(false);
     }
   });
@@ -115,7 +113,9 @@ describe('shouldShowNudge — caps apply to the interruptive prompt only', () =>
 
   // The affordance regression the design review flagged: an empty state that
   // reverts to a dead end because an unrelated prompt fired two days ago.
-  it.each(['no_catalog', 'whats_new', 'board_card'] as NudgeSurface[])(
+  // `onboarding` is in here for a stronger reason still — first run happens
+  // once, so a cooldown could only ever mean the offer is never made at all.
+  it.each(['no_catalog', 'whats_new', 'board_card', 'onboarding'] as NudgeSurface[])(
     'never cools down the %s affordance',
     (surface) => {
       let state: OfflineNudgeState = { ...emptyNudgeState(), lastPromptAtMs: NOW, lastAcceptedAtMs: NOW };

--- a/packages/mobile/src/lib/offline-nudges/nudge-policy.ts
+++ b/packages/mobile/src/lib/offline-nudges/nudge-policy.ts
@@ -10,17 +10,25 @@
 //   They carry a cooldown, a lifetime cap, a cross-surface cooldown and a
 //   post-acceptance quiet period.
 //
-//   Affordances (`no_catalog`, `whats_new`, `board_card`) live inside a screen
-//   the user chose to look at, usually in place of a dead end. Capping them is
-//   a regression: an empty state that reverts to "nothing here" 72 hours after
-//   an unrelated prompt is worse than the empty state we set out to fix. They
-//   are bounded by eligibility and dismiss-forever alone.
+//   Affordances (`no_catalog`, `whats_new`, `board_card`, `onboarding`) live
+//   inside a screen the user chose to look at, usually in place of a dead end.
+//   Capping them is a regression: an empty state that reverts to "nothing here"
+//   72 hours after an unrelated prompt is worse than the empty state we set out
+//   to fix. They are bounded by eligibility and dismiss-forever alone.
+//   `onboarding` is the extreme case — first run happens once, so it is capped
+//   by construction and any frequency machinery could only ever silence it.
 
 import type { BoardDownloadState } from '../../components/board-discovery/board-offline-state';
 
-export type NudgeSurface = 'post_session' | 'no_catalog' | 'whats_new' | 'board_card';
+export type NudgeSurface = 'post_session' | 'no_catalog' | 'whats_new' | 'board_card' | 'onboarding';
 
-export const NUDGE_SURFACES: readonly NudgeSurface[] = ['post_session', 'no_catalog', 'whats_new', 'board_card'];
+export const NUDGE_SURFACES: readonly NudgeSurface[] = [
+  'post_session',
+  'no_catalog',
+  'whats_new',
+  'board_card',
+  'onboarding',
+];
 
 /** Surfaces that interrupt, and therefore carry frequency machinery. */
 const CAPPED_SURFACES: ReadonlySet<NudgeSurface> = new Set<NudgeSurface>(['post_session']);
@@ -57,6 +65,7 @@ export function emptyNudgeState(): OfflineNudgeState {
       no_catalog: emptySurfaceState(),
       whats_new: emptySurfaceState(),
       board_card: emptySurfaceState(),
+      onboarding: emptySurfaceState(),
     },
     lastPromptAtMs: null,
     lastAcceptedAtMs: null,
@@ -78,8 +87,6 @@ export type NudgeDecisionInput = {
   nowMs: number;
   /** `useOfflineDownloadsEnabled()` — native/web platform availability. */
   offlineEngineEnabled: boolean;
-  /** `useOfflineNudgesEnabled()` — this feature's own ramp flag. */
-  nudgesEnabled: boolean;
   /**
    * The candidate board's download state, from `boardDownloadState()`. Anything
    * but `'off'` means the user already asked for this board — including
@@ -111,7 +118,7 @@ function isScreenshotMode(): boolean {
 
 export function shouldShowNudge(input: NudgeDecisionInput): boolean {
   if (isScreenshotMode()) return false;
-  if (!input.offlineEngineEnabled || !input.nudgesEnabled) return false;
+  if (!input.offlineEngineEnabled) return false;
   // The board is already downloaded, downloading, or armed — there is nothing
   // to suggest.
   if (input.offlineState !== 'off') return false;

--- a/packages/mobile/src/lib/offline-nudges/use-offline-nudge.ts
+++ b/packages/mobile/src/lib/offline-nudges/use-offline-nudge.ts
@@ -11,7 +11,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import { boardDownloadState } from '../../components/board-discovery/board-offline-state';
-import { useOfflineDownloadsEnabled, useOfflineNudgesEnabled } from '../../providers/feature-flags-provider';
+import { useOfflineDownloadsEnabled } from '../../providers/feature-flags-provider';
 import { useDownloadedScopeKeys } from '../../offline/use-downloaded-scope-keys';
 import { offlineBoardKeyForBoard, useSetting } from '../../settings';
 import {
@@ -52,7 +52,6 @@ export type OfflineNudgeController = {
 
 export function useOfflineNudge({ surface, board, storeReviewWillPrompt }: UseOfflineNudgeInput) {
   const offlineEngineEnabled = useOfflineDownloadsEnabled();
-  const nudgesEnabled = useOfflineNudgesEnabled();
   const [enabledBoards] = useSetting('syncEnabledBoards');
   const [autoOfflineBoards] = useSetting('autoOfflineBoards');
   const { data: downloadedScopeKeys } = useDownloadedScopeKeys();
@@ -125,7 +124,6 @@ export function useOfflineNudge({ surface, board, storeReviewWillPrompt }: UseOf
       state: nudgeState,
       nowMs: Date.now(),
       offlineEngineEnabled,
-      nudgesEnabled,
       offlineState,
       autoOfflineBoards: autoOfflineBoards === true,
       storeReviewWillPrompt,

--- a/packages/mobile/src/lib/onboarding/__tests__/onboarding-analytics.test.ts
+++ b/packages/mobile/src/lib/onboarding/__tests__/onboarding-analytics.test.ts
@@ -3,13 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const trackMock = vi.hoisted(() => vi.fn());
 vi.mock('../../analytics', () => ({ track: trackMock }));
 
-import {
-  trackStepViewed,
-  trackTourCompleted,
-  trackTourDismissed,
-  trackTourSkipped,
-  trackTourStarted,
-} from '../onboarding-analytics';
+import { trackStepViewed, trackTourCompleted, trackTourDismissed, trackTourStarted } from '../onboarding-analytics';
 import { ONBOARDING_PROMPT_CARD, ONBOARDING_TOTAL_STEPS } from '../onboarding-cards';
 
 describe('onboarding analytics', () => {
@@ -40,21 +34,20 @@ describe('onboarding analytics', () => {
     expect(trackMock).toHaveBeenCalledWith('Onboarding Tour Completed', { durationSeconds: 42 });
   });
 
-  it('fires "Onboarding Tour Skipped" tagged as the intentional look-around exit', () => {
-    trackTourSkipped(ONBOARDING_PROMPT_CARD, 0);
-    expect(trackMock).toHaveBeenCalledWith('Onboarding Tour Skipped', {
-      atStepId: ONBOARDING_PROMPT_CARD.id,
-      stepIndex: 0,
-      exitReason: 'look-around',
-    });
-  });
-
-  it('fires "Onboarding Tour Dismissed" for the back / nav-away exit', () => {
+  it('fires "Onboarding Tour Dismissed" for the nav-away exit', () => {
     trackTourDismissed(ONBOARDING_PROMPT_CARD, 0);
     expect(trackMock).toHaveBeenCalledWith('Onboarding Tour Dismissed', {
       atStepId: ONBOARDING_PROMPT_CARD.id,
       stepIndex: 0,
       exitReason: 'unresolved',
     });
+  });
+
+  // Issue #4961 removed the only exit that produced a Skipped, so mobile must not
+  // emit one at all. Asserting the missing export keeps a re-added wrapper from
+  // quietly reopening the funnel branch.
+  it('exports no Skipped wrapper — the mandatory flow has no skip', async () => {
+    const analytics = await import('../onboarding-analytics');
+    expect('trackTourSkipped' in analytics).toBe(false);
   });
 });

--- a/packages/mobile/src/lib/onboarding/__tests__/onboarding-cards.test.ts
+++ b/packages/mobile/src/lib/onboarding/__tests__/onboarding-cards.test.ts
@@ -12,7 +12,7 @@ function resolveKey(catalog: unknown, dottedKey: string): unknown {
   }, catalog);
 }
 
-const PROMPT_COPY_KEYS = ['title', 'body', 'footnote', 'findBoard', 'lookAround'];
+const PROMPT_COPY_KEYS = ['title', 'body', 'footnote', 'continue'];
 
 describe('ONBOARDING_PROMPT_CARD', () => {
   it('is a single framing step', () => {

--- a/packages/mobile/src/lib/onboarding/__tests__/use-onboarding-copy.test.tsx
+++ b/packages/mobile/src/lib/onboarding/__tests__/use-onboarding-copy.test.tsx
@@ -13,9 +13,10 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: translatorRef.t }),
 }));
 
-import { useOnboardingCopy } from '../use-onboarding-copy';
+import { useOnboardingBoardCopy, useOnboardingCopy } from '../use-onboarding-copy';
 
-const PROMPT_KEYS = ['title', 'body', 'footnote', 'findBoard', 'lookAround'] as const;
+const PROMPT_KEYS = ['title', 'body', 'footnote', 'continue'] as const;
+const BOARD_KEYS = ['title', 'body', 'offlineHint', 'findAnother', 'findFirst', 'offlineSkip', 'downloadAria'] as const;
 
 describe('useOnboardingCopy', () => {
   beforeEach(() => {
@@ -28,8 +29,7 @@ describe('useOnboardingCopy', () => {
       title: 'mobile.onboarding.prompt.title',
       body: 'mobile.onboarding.prompt.body',
       footnote: 'mobile.onboarding.prompt.footnote',
-      findBoard: 'mobile.onboarding.prompt.findBoard',
-      lookAround: 'mobile.onboarding.prompt.lookAround',
+      continueLabel: 'mobile.onboarding.prompt.continue',
     });
   });
 
@@ -62,5 +62,29 @@ describe('useOnboardingCopy', () => {
     translatorRef.t = (key: string) => key;
     rerender();
     expect(result.current).not.toBe(first);
+  });
+
+  describe('useOnboardingBoardCopy', () => {
+    it('uses static literal keys for every board-step field', () => {
+      const seen: string[] = [];
+      translatorRef.t = (key: string) => {
+        seen.push(key);
+        return key;
+      };
+      const { result } = renderHook(() => useOnboardingBoardCopy());
+      // `downloadAria` is only read when the label function is called, so pull it
+      // through here rather than expecting it from the render alone.
+      result.current.downloadLabelFor('Kilter 12x12');
+      for (const key of BOARD_KEYS) {
+        expect(seen).toContain(`mobile.onboarding.board.${key}`);
+      }
+    });
+
+    it('stays stable across renders so the carousel keeps its memo', () => {
+      const { result, rerender } = renderHook(() => useOnboardingBoardCopy());
+      const first = result.current;
+      rerender();
+      expect(result.current).toBe(first);
+    });
   });
 });

--- a/packages/mobile/src/lib/onboarding/onboarding-analytics.ts
+++ b/packages/mobile/src/lib/onboarding/onboarding-analytics.ts
@@ -7,10 +7,19 @@ import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../analytics';
 import { ONBOARDING_TOTAL_STEPS, type OnboardingCard } from './onboarding-cards';
 
-// The mobile tour is now a single framing screen: Started + one Step Viewed on
-// mount, then exactly one terminal outcome — Completed (primary CTA), Skipped
-// (the "look around" tap), or Dismissed (back / nav-away without choosing).
-// There's no multi-step advance, so `trackStepAdvanced` was removed.
+// The mobile tour is a single framing screen: Started + one Step Viewed on
+// mount, then exactly one terminal outcome — Completed (the primary CTA) or
+// Dismissed (a nav-away without choosing). There's no multi-step advance, so
+// `trackStepAdvanced` was removed.
+//
+// There is no Skipped wrapper any more either: issue #4961 made the flow
+// mandatory and deleted the "look around" exit, so no code path can produce one.
+// `SHARED_EVENTS.OnboardingTourSkipped` stays defined for web and for the
+// historical funnel; mobile simply never emits it.
+//
+// Note what Completed does and does not claim. It says the climber read the
+// framing card and moved on — nothing more. The metric for a board actually
+// bound is `Onboarding Board Activated`, fired from `useActivateBoard`.
 
 export function trackTourStarted(): void {
   // The mobile tour always starts fresh on a first run (no resume / restart
@@ -35,21 +44,11 @@ export function trackTourCompleted(durationSeconds: number): void {
   track(SHARED_EVENTS.OnboardingTourCompleted, { durationSeconds });
 }
 
-export function trackTourSkipped(card: OnboardingCard, stepIndex: number): void {
-  track(SHARED_EVENTS.OnboardingTourSkipped, {
-    atStepId: card.id,
-    stepIndex,
-    // The intentional secondary-CTA exit ("look around"), tagged so it can't be
-    // read as abandonment. Involuntary exits fire Dismissed instead.
-    exitReason: 'look-around',
-  });
-}
-
-// Fired when the prompt unmounts without the user choosing either button — an
-// Android hardware-back or a programmatic nav-away. Without this, ~a third of
-// first-run Starts resolved to no terminal outcome at all, deflating Completed.
-// `exitReason: 'unresolved'` stays mechanism-neutral: the guard can't tell a
-// hardware-back from a programmatic unmount, so it claims neither.
+// Fired when the prompt unmounts without the user pressing the button — now only
+// a programmatic nav-away, since Android hardware-back is swallowed. Without
+// this, ~a third of first-run Starts resolved to no terminal outcome at all,
+// deflating Completed. `exitReason: 'unresolved'` stays mechanism-neutral: the
+// guard can't tell one unmount cause from another, so it claims neither.
 export function trackTourDismissed(card: OnboardingCard, stepIndex: number): void {
   track(SHARED_EVENTS.OnboardingTourDismissed, {
     atStepId: card.id,

--- a/packages/mobile/src/lib/onboarding/use-onboarding-copy.ts
+++ b/packages/mobile/src/lib/onboarding/use-onboarding-copy.ts
@@ -5,8 +5,17 @@ export type OnboardingPromptCopy = {
   title: string;
   body: string;
   footnote: string;
-  findBoard: string;
-  lookAround: string;
+  continueLabel: string;
+};
+
+export type OnboardingBoardCopy = {
+  title: string;
+  body: string;
+  offlineHint: string;
+  findAnother: string;
+  findFirst: string;
+  offlineSkip: string;
+  downloadLabelFor: (name: string) => string;
 };
 
 /**
@@ -21,8 +30,31 @@ export function useOnboardingCopy(): OnboardingPromptCopy {
       title: t('mobile.onboarding.prompt.title'),
       body: t('mobile.onboarding.prompt.body'),
       footnote: t('mobile.onboarding.prompt.footnote'),
-      findBoard: t('mobile.onboarding.prompt.findBoard'),
-      lookAround: t('mobile.onboarding.prompt.lookAround'),
+      continueLabel: t('mobile.onboarding.prompt.continue'),
+    }),
+    [t],
+  );
+}
+
+/**
+ * The board step's copy. Same static-literal rule as above.
+ *
+ * `downloadLabelFor` is a function rather than a string because the download
+ * glyph's accessibility label names the board it would download. Building it
+ * inside the memo keeps `BoardCarousel`'s `downloadLabelFor` prop referentially
+ * stable, so its `renderItem` doesn't rebuild every card on every commit.
+ */
+export function useOnboardingBoardCopy(): OnboardingBoardCopy {
+  const { t } = useTranslation('common');
+  return useMemo(
+    () => ({
+      title: t('mobile.onboarding.board.title'),
+      body: t('mobile.onboarding.board.body'),
+      offlineHint: t('mobile.onboarding.board.offlineHint'),
+      findAnother: t('mobile.onboarding.board.findAnother'),
+      findFirst: t('mobile.onboarding.board.findFirst'),
+      offlineSkip: t('mobile.onboarding.board.offlineSkip'),
+      downloadLabelFor: (name: string) => t('mobile.onboarding.board.downloadAria', { name }),
     }),
     [t],
   );

--- a/packages/mobile/src/offline/__tests__/use-offline-catalog-state.test.tsx
+++ b/packages/mobile/src/offline/__tests__/use-offline-catalog-state.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 // The catalog states are promises the SCREEN makes, so they have to answer to
-// the same flags the download offer does — see the hook's own doc.
+// the same engine gate the download offer does — see the hook's own doc.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, renderHook } from '@testing-library/react';
 import type { OfflineBoardLike } from '@boardsesh/offline-sync';
@@ -9,7 +9,6 @@ const state = vi.hoisted(() => ({
   enabledScopeKeys: [] as string[],
   downloadedScopeKeys: [] as string[],
   offlineEngineEnabled: true,
-  nudgesEnabled: true,
 }));
 
 vi.mock('@boardsesh/offline-sync', () => ({
@@ -17,7 +16,6 @@ vi.mock('@boardsesh/offline-sync', () => ({
 }));
 vi.mock('../../providers/feature-flags-provider', () => ({
   useOfflineDownloadsEnabled: () => state.offlineEngineEnabled,
-  useOfflineNudgesEnabled: () => state.nudgesEnabled,
 }));
 vi.mock('../../settings', () => ({
   useSetting: () => [state.enabledScopeKeys, vi.fn()],
@@ -34,7 +32,6 @@ beforeEach(() => {
   state.enabledScopeKeys = [];
   state.downloadedScopeKeys = [];
   state.offlineEngineEnabled = true;
-  state.nudgesEnabled = true;
 });
 afterEach(() => cleanup());
 
@@ -68,23 +65,5 @@ describe('useOfflineCatalogState', () => {
     state.offlineEngineEnabled = false;
     const { result } = renderHook(() => useOfflineCatalogState(board));
     expect(result.current).toBeNull();
-  });
-
-  // 'missing' exists to host the download offer, and the offer reads this flag
-  // too: selecting it anyway leaves the screen naming the problem with nothing
-  // to tap, a worse dead end than the generic empty state.
-  it('drops the missing state when the nudge surface is off', () => {
-    state.nudgesEnabled = false;
-    const { result } = renderHook(() => useOfflineCatalogState(board));
-    expect(result.current).toBeNull();
-  });
-
-  // The armed board still gets its wait: that came from My Boards, not from a
-  // nudge, and the download really is coming.
-  it('keeps the queued state when the nudge surface is off', () => {
-    state.enabledScopeKeys = ['kilter:1:10'];
-    state.nudgesEnabled = false;
-    const { result } = renderHook(() => useOfflineCatalogState(board));
-    expect(result.current).toBe('queued');
   });
 });

--- a/packages/mobile/src/offline/use-board-downloads.ts
+++ b/packages/mobile/src/offline/use-board-downloads.ts
@@ -22,7 +22,7 @@ import { useSnapshotSource } from './use-snapshot-source';
 import { useOfflineSchemaReady } from '../db/use-offline-schema-ready';
 
 /** Which surface flipped the switch, for the Toggled event (issue #4316). */
-export type ToggleSource = 'manage' | 'storage' | 'more' | 'adopt';
+export type ToggleSource = 'manage' | 'storage' | 'more' | 'adopt' | 'onboarding';
 
 const ARM_REACHABILITY_RETRY_DELAYS_MS = [750, 3_000] as const;
 

--- a/packages/mobile/src/offline/use-offline-catalog-state.ts
+++ b/packages/mobile/src/offline/use-offline-catalog-state.ts
@@ -11,7 +11,7 @@ import { useMemo } from 'react';
 import type { OfflineBoardLike } from '@boardsesh/offline-sync';
 import { offlineBoardKeyForBoard } from '@boardsesh/offline-sync';
 import { offlineCatalogState, type OfflineCatalogState } from '../components/board-discovery/board-offline-state';
-import { useOfflineDownloadsEnabled, useOfflineNudgesEnabled } from '../providers/feature-flags-provider';
+import { useOfflineDownloadsEnabled } from '../providers/feature-flags-provider';
 import { useSetting } from '../settings';
 import { useDownloadedScopeKeys } from './use-downloaded-scope-keys';
 
@@ -20,22 +20,14 @@ import { useDownloadedScopeKeys } from './use-downloaded-scope-keys';
  * `'queued'` — the user already asked; it lands on the next reconnect.
  * `null` — the catalog is here, or there is no board, so say nothing about it.
  *
- * Both flags are read HERE and not only inside the CTA, because each state is a
- * promise the screen makes on its own:
- *
- *   Kill switch off — `OfflineSyncBridge` starts no scheduler, no listeners and
- *   no pull, so a scope left enabled in settings from before the flip is never
- *   downloading. "It lands on the next reconnect" would simply be false.
- *
- *   Nudges off — `'missing'` exists to host the download offer, and the offer
- *   checks the same flag. Selecting it anyway leaves the screen telling the
- *   user their board isn't on their phone with nothing to do about it, which is
- *   a worse dead end than the generic empty state it replaced. `'queued'`
- *   survives: that board was armed from My Boards, and the wait is real.
+ * The engine gate is read HERE and not only inside the CTA, because each state
+ * is a promise the screen makes on its own: with the engine off (the Expo web
+ * fork) `OfflineSyncBridge` starts no scheduler, no listeners and no pull, so a
+ * scope left enabled in settings is never downloading and "it lands on the next
+ * reconnect" would simply be false.
  */
 export function useOfflineCatalogState(board: OfflineBoardLike | null | undefined): OfflineCatalogState {
   const offlineEngineEnabled = useOfflineDownloadsEnabled();
-  const nudgesEnabled = useOfflineNudgesEnabled();
   const [enabledScopeKeys] = useSetting('syncEnabledBoards');
   // One cheap indexed read, shared with My Boards / the boards picker via the
   // ['downloadedScopeKeys'] cache entry — not a useSyncStatus() subscription,
@@ -44,8 +36,6 @@ export function useOfflineCatalogState(board: OfflineBoardLike | null | undefine
   const scopeKey = board ? offlineBoardKeyForBoard(board) : null;
   return useMemo(() => {
     if (!offlineEngineEnabled) return null;
-    const state = offlineCatalogState({ scopeKey, enabledScopeKeys, downloadedScopeKeys });
-    if (state === 'missing' && !nudgesEnabled) return null;
-    return state;
-  }, [scopeKey, enabledScopeKeys, downloadedScopeKeys, offlineEngineEnabled, nudgesEnabled]);
+    return offlineCatalogState({ scopeKey, enabledScopeKeys, downloadedScopeKeys });
+  }, [scopeKey, enabledScopeKeys, downloadedScopeKeys, offlineEngineEnabled]);
 }

--- a/packages/mobile/src/providers/feature-flags-provider.tsx
+++ b/packages/mobile/src/providers/feature-flags-provider.tsx
@@ -66,12 +66,6 @@ export const FEATURE_FLAG_DEFINITIONS = [
     description: 'Show the "Pair a Garmin watch" row in More. Off until the Connect IQ watch app ships.',
   },
   {
-    key: 'offline-discovery-nudges',
-    label: 'Offline discovery nudges',
-    description:
-      "Suggest taking a board offline: the post-session prompt, the no-signal empty states, the board-card download glyph and the What's New spotlight.",
-  },
-  {
     key: 'boardsesh-grade',
     label: 'Boardsesh grade',
     description:
@@ -168,18 +162,6 @@ export function useSnapshotBootstrapEnabled(): boolean {
  */
 export function useOfflineDownloadProgressEnabled(): boolean {
   return true;
-}
-
-/**
- * Gate for the offline discovery nudges (issue #4318). Missing/undefined reads
- * as OFF so this ramps from zero — nudging users into a download before the
- * download itself is fast burns the one first impression they get.
- *
- * Callers still pair this with `useOfflineDownloadsEnabled()` for the native vs
- * Expo web platform split.
- */
-export function useOfflineNudgesEnabled(): boolean {
-  return useFeatureFlag('offline-discovery-nudges') === true;
 }
 
 /**

--- a/packages/mobile/src/settings/offline-boards.ts
+++ b/packages/mobile/src/settings/offline-boards.ts
@@ -145,6 +145,10 @@ const TRIGGER_SETTING_KEY = 'offlineDownloadTriggers';
  *   NOT a tap.
  * - `adopt-confirmed` — a discovered board the climber confirmed in the dialog.
  * - `retry` — a manual re-run of a failed download.
+ * - `onboarding` — the download offered while the climber binds their board
+ *   during first-run onboarding. A tap, but its own bucket: it is the only one
+ *   taken before the climber has used the app at all, so folding it into
+ *   `toggle` would hide whether the offer lands at the moment it is made.
  * - `unknown` — no attribution recorded: a scope enabled by a build that predates
  *   this, or one whose entry was already consumed. An explicit, expected value.
  */
@@ -155,6 +159,7 @@ export type OfflineDownloadTrigger =
   | 'adopt-auto'
   | 'adopt-confirmed'
   | 'retry'
+  | 'onboarding'
   | 'unknown';
 
 const KNOWN_TRIGGERS: readonly OfflineDownloadTrigger[] = [
@@ -164,6 +169,7 @@ const KNOWN_TRIGGERS: readonly OfflineDownloadTrigger[] = [
   'adopt-auto',
   'adopt-confirmed',
   'retry',
+  'onboarding',
   'unknown',
 ];
 

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -141,7 +141,6 @@
           "accessibilityNote": "Deine Grifffarben und Barrierefreiheits-Einstellungen bleiben unverändert.",
           "save": "Diesen Look nehmen",
           "customCta": "Einrichten",
-          "skip": "Jetzt nicht",
           "replayTitle": "Board-Look-Auswahl erneut zeigen",
           "replaySubtitle": "Fragt noch mal nach deinem Look — deine Farben bleiben"
         }
@@ -384,8 +383,16 @@
         "title": "Sieh live, was auf deiner Wand leuchtet",
         "body": "Folge dem Board in deiner Halle und Boardsesh zeigt, was gerade leuchtet: wer ihn beleuchtet hat, den Grad, wer ihn gebaut hat, die letzten Begehungen. Du startest nichts, es ist einfach da.",
         "footnote": "Dazu Crew-Sessions, der Workout-Builder und deine Begehungen, sobald du an einer Wand stehst.",
-        "findBoard": "Mein Board finden",
-        "lookAround": "Erst mal umschauen"
+        "continue": "Mein Board auswählen"
+      },
+      "board": {
+        "title": "Auf welchem Board kletterst du?",
+        "body": "Jedes Board hat seinen eigenen Verlauf. Wähl das, auf dem du kletterst, und du siehst die Begehungen von allen anderen darauf.",
+        "offlineHint": "Tipp auf den Pfeil, um ein Board auf diesem Handy zu behalten. Es öffnet sofort und läuft auch, wenn das Hallen-WLAN streikt.",
+        "findAnother": "Anderes Board finden",
+        "findFirst": "Mein Board finden",
+        "offlineSkip": "Jetzt nicht",
+        "downloadAria": "{{name}} auf diesem Handy behalten"
       },
       "boardRevealTip": "Tippen, um zu sehen, was andere Boardsesh-Nutzer*innen auf der Wand beleuchtet haben.",
       "quickActionsTip": "Drück lange auf einen Boulder für Schnellaktionen wie Warteschlange, Eintrag und Playlists.",

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -141,7 +141,6 @@
           "accessibilityNote": "Your hold colours and accessibility settings stay exactly as they are.",
           "save": "Use this look",
           "customCta": "Set it up",
-          "skip": "Not now",
           "replayTitle": "Replay board look picker",
           "replaySubtitle": "Ask again which look you want, without touching your colours"
         }
@@ -384,8 +383,16 @@
         "title": "See what's lit on your wall, live",
         "body": "Follow your gym's board and Boardsesh shows what's lit right now: who lit it, the grade, who set it, recent sends. You don't start anything; it's just there.",
         "footnote": "Plus crew sessions, the workout builder, and send tracking once you're on a wall.",
-        "findBoard": "Find my board",
-        "lookAround": "Look around first"
+        "continue": "Pick my board"
+      },
+      "board": {
+        "title": "Which board do you climb on?",
+        "body": "Every board keeps its own history. Pick the one you climb on and you'll see what everyone else on it has been sending.",
+        "offlineHint": "Tap the arrow to keep a board on this phone. It opens instantly and still works when the gym wifi doesn't.",
+        "findAnother": "Find another board",
+        "findFirst": "Find my board",
+        "offlineSkip": "Skip for now",
+        "downloadAria": "Keep {{name}} on this phone"
       },
       "boardRevealTip": "Tap to see what other Boardsesh users have sent to the wall.",
       "quickActionsTip": "Long-press a climb for quick actions like queue, tick and playlists.",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -320,7 +320,6 @@
           "accessibilityNote": "Tus colores de presa y ajustes de accesibilidad se quedan como están.",
           "save": "Usar este aspecto",
           "customCta": "Configurarlo",
-          "skip": "Ahora no",
           "replayTitle": "Repetir el selector de aspecto",
           "replaySubtitle": "Vuelve a preguntar qué aspecto quieres, sin tocar tus colores"
         }
@@ -563,8 +562,16 @@
         "title": "Mira lo que está encendido en tu muro, en directo",
         "body": "Sigue el plafón de tu rocódromo y Boardsesh te muestra lo que está encendido ahora mismo: quién lo encendió, el grado, quién lo montó y los encadenes recientes. No tienes que abrir nada; está ahí.",
         "footnote": "Además, sesiones con tu peña, el generador de entrenos y el registro de encadenes, cuando estés en un muro.",
-        "findBoard": "Buscar mi plafón",
-        "lookAround": "Echar un vistazo primero"
+        "continue": "Elegir mi plafón"
+      },
+      "board": {
+        "title": "¿En qué plafón escalas?",
+        "body": "Cada plafón guarda su propio historial. Elige el que escalas y verás lo que ha encadenado el resto de gente que está en él.",
+        "offlineHint": "Toca la flecha para guardar un plafón en este móvil. Se abre al instante y sigue funcionando aunque falle el wifi del rocódromo.",
+        "findAnother": "Buscar otro plafón",
+        "findFirst": "Buscar mi plafón",
+        "offlineSkip": "Ahora no",
+        "downloadAria": "Guardar {{name}} en este móvil"
       },
       "boardRevealTip": "Toca para ver lo que otros usuarios de Boardsesh han mandado al muro.",
       "quickActionsTip": "Mantén pulsado un bloque para acciones rápidas como cola, encadene y listas.",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -141,7 +141,6 @@
           "accessibilityNote": "Tes couleurs de prises et tes réglages d’accessibilité ne bougent pas.",
           "save": "Utiliser ce rendu",
           "customCta": "Le configurer",
-          "skip": "Plus tard",
           "replayTitle": "Revoir le choix du rendu",
           "replaySubtitle": "Repose la question du rendu, sans toucher à tes couleurs"
         }
@@ -384,8 +383,16 @@
         "title": "Vois ce qui est allumé sur ton mur, en direct",
         "body": "Suis la board de ta salle et Boardsesh te montre ce qui est allumé en ce moment : qui l'a allumé, la cotation, qui l'a ouvert, et les croix récentes. Tu ne lances rien ; c'est juste là.",
         "footnote": "En plus : les séances avec ta crew, le générateur d'entraînement et le suivi de tes croix, une fois sur un mur.",
-        "findBoard": "Trouver ma board",
-        "lookAround": "Jeter un œil d'abord"
+        "continue": "Choisir ma board"
+      },
+      "board": {
+        "title": "Sur quelle board tu grimpes ?",
+        "body": "Chaque board garde son propre historique. Choisis celle que tu grimpes et tu verras les croix de tous les autres qui y passent.",
+        "offlineHint": "Touche la flèche pour garder une board sur ce téléphone. Elle s'ouvre instantanément et marche même quand le wifi de la salle lâche.",
+        "findAnother": "Trouver une autre board",
+        "findFirst": "Trouver ma board",
+        "offlineSkip": "Plus tard",
+        "downloadAria": "Garder {{name}} sur ce téléphone"
       },
       "boardRevealTip": "Touche pour voir ce que d'autres utilisateurs de Boardsesh ont allumé au mur.",
       "quickActionsTip": "Appuie longuement sur un bloc pour des actions rapides : file, croix, listes.",


### PR DESCRIPTION
## Summary

Follow-up to #4960, from Marco's review comments on it. **Nobody reaches the app without a
board bound and a look chosen.**

Both halves were escapable. The framing card had a quiet "Look around first" that dropped the
climber on Home with no board — where every screen is an empty state and the board-history
promise the card had just made never lands. The board-look step had a "Not now" that silently
accepted the new default, which is the one outcome that step exists to stop being silent.

Three steps now, none of them skippable:

```
/onboarding                    why a named board matters
/onboarding?step=board         pick one, and take it offline while you're here   ← new
/onboarding?step=board-look    which drawing (#4960)
```

### The new board step

It reuses `BoardCarousel` / `BoardDiscoveryCard` rather than growing a second board slider —
same cards, same download glyph, same layout as `/boards`. Only someone with no boards goes to
the full picker.

Two things happen there beyond picking a board, both at Marco's request:

- **It names the mechanism.** Board history is shared *per named board*, so which board you
  pick is what decides whose sends you see. That is the thing the framing card promises and
  the thing nothing in the app previously said out loud.
- **It offers the download.** A board on the phone opens instantly, works on gym wifi that has
  given up, and stops hitting our hosting bill. `confirmAndDownload` already quotes the real
  artifact size, so this is the existing dialog at the moment it makes most sense to ask — no
  new UI, and the download stays skippable while the board and the look do not.

Android hardware back is swallowed on all three steps. `gestureEnabled: false` on the route
only closes the iOS half; on Android the back button popped the screen regardless, so "no exit"
had one the UI never showed.

### The gate is now "has a board", not "has seen the tour"

That is what makes mandatory mean anything — the flow's whole job is to leave the climber with
a board, so the absence of one is the only honest signal that it has not done that job.

It also closes a live hole. On iOS the seen flag lives in SecureStore, which survives an
uninstall, while the active board lives in AsyncStorage, which does not. A reinstall today
lands on empty states with no board *and* no tour. The flag is still written — by
`useActivateBoard`, on every bind path — as a record of completion rather than as the gate.

### The thing that makes "no exit" safe

`decideBoardLookStep` still refuses to present the look step unless there is a synced climb to
draw **and** the renderer capability probe has answered `true`. Removing that step's exit is
only safe while that holds, so the board step does **not** chain into it: it leaves to Climbs
and `BoardLookStepGate` takes over, exactly as before. Chaining past the gate would have thrown
the guarantee away.

The board step needs the same property, and gets it three ways: a failed or empty board list
falls through to the full `/boards` picker rather than an empty slider; and offline with
nothing cached — the one state where no usable choice can be shown at all — gets a "Skip for
now" that deliberately does **not** mark onboarding complete, so the gate asks again next
launch.

### Extracted along the way

- **`useActivateBoard`** — the bind sequence `app/boards/index.tsx` owned alone.
  `app/boards/create.tsx` had a shorter copy (write, then navigate), which is why a climber who
  arrived from onboarding and *built* their first board silently fired no activation event and
  armed no Climbs reveal banner. That is fixed here as a side effect of having one version.
- **`useBoardOfflineState`** — the per-board download-state lookup, so both carousels derive it
  the same way and neither subscribes to `useSyncStatus()` per row.

### Retiring `offline-discovery-nudges`

Marco: *"remove the flag."* It sat at 0%, so shipping the onboarding download offer behind it
would have shipped it dark. Every nudge surface — the post-session prompt, the no-signal empty
states, the board-card glyph, the What's New spotlight — is now gated on the platform check
alone, which is where the engine gate already lived.

The onboarding offer reports as a new `'onboarding'` nudge surface. It is an **affordance, not
a capped prompt** (it shows exactly once by construction), so it stays out of `CAPPED_SURFACES`.
The card glyph keeps reporting as `'board_card'`: it is the same accept-only affordance as on
`/boards`, and filing it under `onboarding` would mix an impression-tracked offer with an
untracked one and quietly wreck that surface's shown-to-accepted rate.

### Worth a look at review

- `OnboardingGate` gating its effect on `useActiveBoard().isFetched`. `data: undefined` mid-read
  is indistinguishable from "no board", so deciding early would flash the flow at everyone.
- The escape hatch's condition includes `isError`, not just `isOffline` — captive-portal or gym
  wifi with a dead upstream reports ONLINE while every request fails, and `isOffline` alone
  would leave that climber stuck.
- `trackTourSkipped` is gone from mobile. No code path can produce one any more;
  `SHARED_EVENTS.OnboardingTourSkipped` stays defined for web and the historical funnel.

## Release Notes

- Setting up now walks you all the way to a board — pick yours, choose how it looks, and you land on climbs you can actually see.
- Boardsesh keeps history per board, so picking the named board you climb on is what shows you everyone else's sends on it.
- Save your board to your phone while you're setting up. It opens instantly and keeps working when the gym wifi doesn't.

## Test plan

1. Fresh install, sign in. You see "Which board do you climb on?"
2. Tap a board. A dialog quotes the download size.
3. Tap Cancel. You land on the board-look picker.
4. Press Android back on each step. Nothing moves.
5. No step offers a skip.

## Risk

Risk: 3/5 — a mandatory launch-time flow plus a feature-flag deletion.

Bounded three ways: the board-look step keeps its own can-it-render gate untouched, the board
step falls through to the real picker on any load failure, and the one genuinely unresolvable
state (offline, nothing cached) keeps an honest escape that does not burn the flow.

The blast radius worth watching is the gate change. Anyone with no bound board now gets
onboarding, including climbers who dismissed it long ago — that is the intent, and binding a
board ends it for good, but it is the one behaviour here that reaches existing installs.

JS/JSON only, no fingerprint input touched, but the branch sits on `release/next` ancestry, so
`ota-check` will correctly report a native change and this ships with the 2.4 store build
alongside #4960.

Closes #4961

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3jRkK5KxMfH6PUmhGFNwE
