### PR TITLE
fix(android): show the angle on the real -5 degree Grasshopper setting

### DIFF
--- a/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/SessionPresenceController.kt
+++ b/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/SessionPresenceController.kt
@@ -86,7 +86,9 @@ internal class SessionPresenceController(
         if (!sessionActive) return
         val subtitle = buildString {
             append(options.climbDifficulty)
-            if (options.angle >= 0) {
+            // -1 is the JS/native "no angle" sentinel. Grasshopper has a real
+            // -5° slab setting, so negative can no longer mean absent.
+            if (options.angle != -1) {
                 if (isNotEmpty()) append(" · ")
                 append("${options.angle}°")
             }

--- a/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/SessionPresenceController.kt
+++ b/packages/mobile/modules/live-activity/android/src/main/java/com/boardsesh/liveactivity/SessionPresenceController.kt
@@ -86,9 +86,9 @@ internal class SessionPresenceController(
         if (!sessionActive) return
         val subtitle = buildString {
             append(options.climbDifficulty)
-            // -1 is the JS/native "no angle" sentinel. Grasshopper has a real
-            // -5° slab setting, so negative can no longer mean absent.
-            if (options.angle != -1) {
+            // Grasshopper has a real -5° slab setting, so "negative" can no
+            // longer stand in for "absent" — only the explicit sentinel can.
+            if (options.angle != NO_ANGLE) {
                 if (isNotEmpty()) append(" · ")
                 append("${options.angle}°")
             }
@@ -179,5 +179,18 @@ internal class SessionPresenceController(
 
     companion object {
         private const val TAG = "BoardSession"
+
+        /**
+         * Subtitle sentinel for "this climb has no angle".
+         *
+         * Named rather than inlined, because the contract is weaker than it
+         * looks: JS types `angle` as a required `number` and always sends a
+         * real one, and the Expo `@Field` default is 0, not this. Nothing
+         * outside the unit test currently produces -1, so this is a defensive
+         * convention pinned by that test rather than a live cross-boundary
+         * agreement. If JS ever grows a genuine "no angle" state, it has to
+         * send exactly this value.
+         */
+        internal const val NO_ANGLE = -1
     }
 }

--- a/packages/mobile/modules/live-activity/android/src/test/java/com/boardsesh/liveactivity/SessionPresenceControllerTest.kt
+++ b/packages/mobile/modules/live-activity/android/src/test/java/com/boardsesh/liveactivity/SessionPresenceControllerTest.kt
@@ -143,9 +143,10 @@ class SessionPresenceControllerTest {
         val (controller, launchedIntents) = recordingController()
         controller.startSession(null)
 
-        // -1 is the explicit "no angle" sentinel, so the subtitle is the
-        // difficulty alone even though other negative values can be real.
-        controller.updateActivity(updateOptions().apply { angle = -1 })
+        // The explicit "no angle" sentinel, so the subtitle is the difficulty
+        // alone even though other negative values can be real. Referenced by
+        // name: this test is the only thing that pins the convention.
+        controller.updateActivity(updateOptions().apply { angle = SessionPresenceController.NO_ANGLE })
 
         assertEquals("V5", launchedIntents.last().getStringExtra(BoardSessionService.EXTRA_SUBTITLE))
     }

--- a/packages/mobile/modules/live-activity/android/src/test/java/com/boardsesh/liveactivity/SessionPresenceControllerTest.kt
+++ b/packages/mobile/modules/live-activity/android/src/test/java/com/boardsesh/liveactivity/SessionPresenceControllerTest.kt
@@ -143,11 +143,22 @@ class SessionPresenceControllerTest {
         val (controller, launchedIntents) = recordingController()
         controller.startSession(null)
 
-        // angle < 0 is the "no angle" sentinel (the >= 0 guard renders a flat 0°
-        // but suppresses negatives), so the subtitle is the difficulty alone.
+        // -1 is the explicit "no angle" sentinel, so the subtitle is the
+        // difficulty alone even though other negative values can be real.
         controller.updateActivity(updateOptions().apply { angle = -1 })
 
         assertEquals("V5", launchedIntents.last().getStringExtra(BoardSessionService.EXTRA_SUBTITLE))
+    }
+
+    @Test
+    @Config(sdk = [30])
+    fun `updateActivity includes Grasshopper slab angle in the subtitle`() {
+        val (controller, launchedIntents) = recordingController()
+        controller.startSession(null)
+
+        controller.updateActivity(updateOptions().apply { angle = -5 })
+
+        assertEquals("V5 · -5°", launchedIntents.last().getStringExtra(BoardSessionService.EXTRA_SUBTITLE))
     }
 
     @Test


### PR DESCRIPTION
## Summary

The Android session notification's subtitle gated the angle on `angle >= 0`, treating every negative value as "no angle". Grasshopper has a real **-5° slab setting**, so that gate hides the angle on exactly the boards it matters for. The explicit "no angle" sentinel is `-1`, so it tests for that instead.

Two lines of Kotlin, split out of #4820 at Marco's request so it lands on the native release train.

**Why it is separate:** the rest of #4820 is JS and ships over the air, but any `.kt` edit changes the Android fingerprint, so this half cannot reach an existing build regardless of which branch it merges to. Keeping it here makes #4820 OTA-compatible with `main` and puts this in the next binary.

iOS needs no equivalent change — it models the angle as `Int?` rather than a `-1` sentinel and has no `>= 0` gate.

Refs #4803

## Release Notes

See the angle on Grasshopper's -5° slab setting in the session notification.

## Test plan

1. Start a session on a Grasshopper climb at -5°.
2. Check the Android notification subtitle shows `-5°`.
3. Start a session on a climb with no angle; subtitle omits it.
4. Start a Kilter session at 40°; subtitle still shows `40°`.

## Risk

Risk: 2/5 — one condition in a notification subtitle, covered by the Robolectric test in this PR. Worst case is a cosmetic subtitle regression; no BLE, no data, no migration.
