### PR TITLE
fix(web): reject OAuth profiles without email

### DIFF
--- a/docs/ui/03-auth.md
+++ b/docs/ui/03-auth.md
@@ -118,7 +118,7 @@
 - Cancel icon (48px, error color)
 - "Authentication Error" title (h3)
 - Alert (severity=error) with localized message based on `?error=` param
-- Known error codes: `Configuration`, `AccessDenied`, `Verification`, `OAuthSignin`, `OAuthCallback`, `OAuthCreateAccount`, `EmailCreateAccount`, `Callback`, `OAuthAccountNotLinked`, `SessionRequired`
+- Known error codes: `Configuration`, `AccessDenied`, `Verification`, `OAuthSignin`, `OAuthCallback`, `OAuthCreateAccount`, `OAuthEmailRequired`, `EmailCreateAccount`, `Callback`, `OAuthAccountNotLinked`, `SessionRequired`
 - "Back to login" button (contained, large, full width) linking to `/auth/login`
 
 ### Native Start Page

--- a/packages/shared/i18n/locales/de/auth.json
+++ b/packages/shared/i18n/locales/de/auth.json
@@ -82,6 +82,7 @@
       "OAuthSignin": "Fehler beim Starten der Anmeldung. Bitte versuch es erneut.",
       "OAuthCallback": "Fehler beim Abschließen der Anmeldung. Bitte versuch es erneut.",
       "OAuthCreateAccount": "Mit diesem Anbieter konnte kein Konto erstellt werden.",
+      "OAuthEmailRequired": "Dieser Anmeldedienst hat keine E-Mail-Adresse übermittelt. Erlaube den Zugriff auf deine E-Mail-Adresse und versuch es erneut.",
       "EmailCreateAccount": "Es konnte kein E-Mail-Konto erstellt werden.",
       "Callback": "Fehler beim Authentifizierungs-Callback.",
       "OAuthAccountNotLinked": "Diese E-Mail-Adresse gehört schon zu einem anderen Konto. Bitte melde dich mit deiner ursprünglichen Methode an.",

--- a/packages/shared/i18n/locales/en-US/auth.json
+++ b/packages/shared/i18n/locales/en-US/auth.json
@@ -82,6 +82,7 @@
       "OAuthSignin": "Error starting the sign-in flow. Please try again.",
       "OAuthCallback": "Error completing the sign-in. Please try again.",
       "OAuthCreateAccount": "Could not create an account with this provider.",
+      "OAuthEmailRequired": "This sign-in provider did not share an email address. Allow email access with the provider, then try again.",
       "EmailCreateAccount": "Could not create an email account.",
       "Callback": "Error in the authentication callback.",
       "OAuthAccountNotLinked": "This email is already associated with another account. Please sign in using your original method.",

--- a/packages/shared/i18n/locales/es/auth.json
+++ b/packages/shared/i18n/locales/es/auth.json
@@ -82,6 +82,7 @@
       "OAuthSignin": "Error al iniciar el proceso de inicio de sesión. Inténtalo otra vez.",
       "OAuthCallback": "Error al completar el inicio de sesión. Inténtalo otra vez.",
       "OAuthCreateAccount": "No se pudo crear una cuenta con este proveedor.",
+      "OAuthEmailRequired": "Este proveedor no compartió una dirección de correo electrónico. Permite el acceso al correo electrónico y vuelve a intentarlo.",
       "EmailCreateAccount": "No se pudo crear una cuenta con correo.",
       "Callback": "Error en la respuesta de autenticación.",
       "OAuthAccountNotLinked": "Este correo ya está asociado con otra cuenta. Inicia sesión con el método original que usaste.",

--- a/packages/shared/i18n/locales/fr/auth.json
+++ b/packages/shared/i18n/locales/fr/auth.json
@@ -82,6 +82,7 @@
       "OAuthSignin": "Erreur au lancement de la connexion. Réessayez.",
       "OAuthCallback": "Erreur à la finalisation de la connexion. Réessayez.",
       "OAuthCreateAccount": "Impossible de créer un compte avec ce fournisseur.",
+      "OAuthEmailRequired": "Ce fournisseur n’a pas partagé d’adresse e-mail. Autorisez l’accès à votre e-mail, puis réessayez.",
       "EmailCreateAccount": "Impossible de créer un compte par e-mail.",
       "Callback": "Erreur dans la réponse d'authentification.",
       "OAuthAccountNotLinked": "Cet e-mail est déjà associé à un autre compte. Connectez-vous avec votre méthode d'origine.",

--- a/packages/web/app/api/auth/[...nextauth]/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/[...nextauth]/__tests__/route.test.ts
@@ -419,6 +419,40 @@ describe('POST /api/auth/[...nextauth]', () => {
     expect(destination.searchParams.get('boardseshOAuthError')).toBe('OAuthCallback');
   });
 
+  it('preserves a missing-email callback failure when returning to the Expo app', async () => {
+    const returnUrl =
+      'https://app.boardsesh.com/auth/login?boardseshOAuthProvider=google&boardseshOAuthAttempt=attempt-google-email';
+    nextAuthHandlerMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { Location: 'https://accounts.google.com/o/oauth2/v2/auth?state=google-state-email' },
+      }),
+    );
+    const signInResponse = await POST(
+      request('/api/auth/signin/google', { csrfToken: 'csrf-token', callbackUrl: returnUrl }),
+      context,
+    );
+    const returnCookie = signInResponse.headers
+      .getSetCookie()
+      .find((setCookie) => setCookie.startsWith('boardsesh.oauth-return.'));
+    nextAuthHandlerMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { Location: 'https://www.boardsesh.com/auth/error?error=OAuthEmailRequired' },
+      }),
+    );
+    const callbackRequest = new NextRequest(
+      'https://www.boardsesh.com/api/auth/callback/google?state=google-state-email&code=provider-code',
+      { headers: { Cookie: returnCookie!.split(';', 1)[0]! } },
+    );
+
+    const callbackResponse = await GET(callbackRequest, context);
+
+    const destination = new URL(callbackResponse.headers.get('Location')!);
+    expect(destination.origin + destination.pathname).toBe('https://app.boardsesh.com/auth/login');
+    expect(destination.searchParams.get('boardseshOAuthError')).toBe('OAuthEmailRequired');
+  });
+
   it('returns an Apple form-post callback to the exact Expo registration attempt', async () => {
     const returnUrl =
       'https://www.boardsesh.com/app/auth/register?boardseshOAuthProvider=apple&boardseshOAuthAttempt=attempt-apple-1';

--- a/packages/web/app/auth/error/__tests__/get-error-message.test.ts
+++ b/packages/web/app/auth/error/__tests__/get-error-message.test.ts
@@ -34,6 +34,8 @@ describe('getAuthErrorMessage', () => {
       OAuthSignin: 'Error starting the sign-in flow. Please try again.',
       OAuthCallback: 'Error completing the sign-in. Please try again.',
       OAuthCreateAccount: 'Could not create an account with this provider.',
+      OAuthEmailRequired:
+        'This sign-in provider did not share an email address. Allow email access with the provider, then try again.',
       EmailCreateAccount: 'Could not create an email account.',
       Callback: 'Error in the authentication callback.',
       OAuthAccountNotLinked:
@@ -56,6 +58,7 @@ describe('getAuthErrorMessage', () => {
       'OAuthSignin',
       'OAuthCallback',
       'OAuthCreateAccount',
+      'OAuthEmailRequired',
       'EmailCreateAccount',
       'Callback',
       'OAuthAccountNotLinked',

--- a/packages/web/app/auth/error/get-error-message.ts
+++ b/packages/web/app/auth/error/get-error-message.ts
@@ -7,6 +7,7 @@ export const KNOWN_AUTH_ERROR_CODES: ReadonlySet<string> = new Set([
   'OAuthSignin',
   'OAuthCallback',
   'OAuthCreateAccount',
+  'OAuthEmailRequired',
   'EmailCreateAccount',
   'Callback',
   'OAuthAccountNotLinked',

--- a/packages/web/app/auth/login/__tests__/auth-method-from-error.test.ts
+++ b/packages/web/app/auth/login/__tests__/auth-method-from-error.test.ts
@@ -10,6 +10,7 @@ describe('authMethodFromError', () => {
     expect(authMethodFromError('OAuthSignin')).toBe('oauth');
     expect(authMethodFromError('OAuthCallback')).toBe('oauth');
     expect(authMethodFromError('OAuthCreateAccount')).toBe('oauth');
+    expect(authMethodFromError('OAuthEmailRequired')).toBe('oauth');
     expect(authMethodFromError('OAuthAccountNotLinked')).toBe('oauth');
   });
 
@@ -25,6 +26,7 @@ describe('safeAuthError', () => {
   it('passes through known NextAuth error codes verbatim', () => {
     expect(safeAuthError('CredentialsSignin')).toBe('CredentialsSignin');
     expect(safeAuthError('OAuthCallback')).toBe('OAuthCallback');
+    expect(safeAuthError('OAuthEmailRequired')).toBe('OAuthEmailRequired');
     expect(safeAuthError('AccessDenied')).toBe('AccessDenied');
   });
 

--- a/packages/web/app/auth/login/auth-error-classification.ts
+++ b/packages/web/app/auth/login/auth-error-classification.ts
@@ -10,6 +10,7 @@ const KNOWN_AUTH_ERRORS: ReadonlySet<string> = new Set([
   'OAuthSignin',
   'OAuthCallback',
   'OAuthCreateAccount',
+  'OAuthEmailRequired',
   'OAuthAccountNotLinked',
   'EmailCreateAccount',
   'EmailSignin',

--- a/packages/web/app/lib/auth/__tests__/auth-options.test.ts
+++ b/packages/web/app/lib/auth/__tests__/auth-options.test.ts
@@ -2,6 +2,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
 import type { Session } from 'next-auth';
 import { authOptions } from '../auth-options';
 
+const { mockAdapterCreateUser, mockAdapterUpdateUser } = vi.hoisted(() => ({
+  mockAdapterCreateUser: vi.fn(),
+  mockAdapterUpdateUser: vi.fn(),
+}));
+
 // Mock server-only before any imports
 vi.mock('server-only', () => ({}));
 
@@ -12,9 +17,13 @@ vi.mock('drizzle-orm', () => ({
   isNull: vi.fn((col: unknown) => ({ _type: 'isNull', col })),
 }));
 
-// Mock DrizzleAdapter — we only care about the signIn callback, not adapter internals
+// Adapter mutations stay visible so the OAuth rejection tests can prove that a
+// missing-email callback stops before NextAuth's persistence boundary.
 vi.mock('@auth/drizzle-adapter', () => ({
-  DrizzleAdapter: vi.fn(() => ({})),
+  DrizzleAdapter: vi.fn(() => ({
+    createUser: mockAdapterCreateUser,
+    updateUser: mockAdapterUpdateUser,
+  })),
 }));
 
 // Mock OAuth providers — only present in the array; we test callbacks, not provider config
@@ -111,6 +120,89 @@ describe('authOptions.callbacks.signIn', () => {
   // -------------------------------------------------------------------------
   // OAuth provider paths
   // -------------------------------------------------------------------------
+
+  describe('OAuth profiles without an email', () => {
+    it.each(['google', 'apple', 'facebook'] as const)(
+      'rejects %s before any database create or update',
+      async (provider) => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const result = await callSignIn({
+          user: { id: `${provider}-profile-id`, email: null, name: 'No Email' },
+          account: { provider, type: 'oauth', providerAccountId: `${provider}-account-id` },
+        });
+
+        expect(result).toBe('/auth/error?error=OAuthEmailRequired');
+        expect(mockDbUpdate).not.toHaveBeenCalled();
+        expect(mockDbSelect).not.toHaveBeenCalled();
+        expect(mockAdapterCreateUser).not.toHaveBeenCalled();
+        expect(mockAdapterUpdateUser).not.toHaveBeenCalled();
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(JSON.parse(String(warnSpy.mock.calls[0]?.[0]))).toEqual({
+          event: 'oauth_sign_in_rejected',
+          provider,
+          error_code: 'OAuthEmailRequired',
+        });
+
+        warnSpy.mockRestore();
+      },
+    );
+
+    it.each([undefined, '', '   '])('also rejects a non-usable email value (%s)', async (email) => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await callSignIn({
+        user: { id: 'google-profile-id', email, name: 'No Email' },
+        account: { provider: 'google', type: 'oauth', providerAccountId: 'google-account-id' },
+      });
+
+      expect(result).toBe('/auth/error?error=OAuthEmailRequired');
+      expect(mockDbUpdate).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('allow-lists provider names before writing structured telemetry', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await callSignIn({
+        user: { id: 'unknown-profile-id', email: null },
+        account: {
+          provider: 'attacker@example.com',
+          type: 'oauth',
+          providerAccountId: 'identifier-that-must-not-be-logged',
+        },
+      });
+
+      const telemetry = String(warnSpy.mock.calls[0]?.[0]);
+      expect(JSON.parse(telemetry)).toEqual({
+        event: 'oauth_sign_in_rejected',
+        provider: 'unknown',
+        error_code: 'OAuthEmailRequired',
+      });
+      expect(telemetry).not.toContain('attacker@example.com');
+      expect(telemetry).not.toContain('identifier-that-must-not-be-logged');
+      expect(telemetry).not.toContain('unknown-profile-id');
+
+      warnSpy.mockRestore();
+    });
+
+    it.each(['google', 'apple', 'facebook'] as const)(
+      'keeps an existing linked %s account working when the raw provider profile omits email',
+      async (provider) => {
+        const result = await callSignIn({
+          // NextAuth resolves a linked account before signIn and supplies the
+          // stored user here; the raw provider profile may omit email later.
+          user: { id: 'linked-user', email: 'stored@example.com', name: 'Linked' },
+          account: { provider, type: 'oauth', providerAccountId: `${provider}-linked-id` },
+          profile: { sub: `${provider}-profile-id` },
+        });
+
+        expect(result).toBe(true);
+        expect(mockDbUpdate).toHaveBeenCalledTimes(1);
+        expect(mockDbSet).toHaveBeenCalledWith({ emailVerified: expect.any(Date) });
+      },
+    );
+  });
 
   describe('OAuth provider (google)', () => {
     it('marks email as verified for new user and returns true', async () => {

--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -29,6 +29,27 @@ applyCanonicalAuthUrl();
 // enough that out-of-band edits still surface within a few minutes.
 const PROFILE_CLAIMS_TTL_MS = 5 * 60 * 1000;
 
+const OAUTH_EMAIL_REQUIRED_ERROR = 'OAuthEmailRequired';
+const OAUTH_EMAIL_REQUIRED_REDIRECT = `/auth/error?error=${OAUTH_EMAIL_REQUIRED_ERROR}`;
+const OAUTH_TELEMETRY_PROVIDERS = new Set(['google', 'apple', 'facebook']);
+
+function hasUsableEmail(email: string | null | undefined): email is string {
+  return typeof email === 'string' && email.trim().length > 0;
+}
+
+function reportMissingOAuthEmail(provider: string): void {
+  // Keep this a single JSON record so hosted logs can filter by event/provider.
+  // The provider is allow-listed because an arbitrary identifier must never be
+  // copied from an OAuth callback into telemetry.
+  console.warn(
+    JSON.stringify({
+      event: 'oauth_sign_in_rejected',
+      provider: OAUTH_TELEMETRY_PROVIDERS.has(provider) ? provider : 'unknown',
+      error_code: OAUTH_EMAIL_REQUIRED_ERROR,
+    }),
+  );
+}
+
 // Build providers array conditionally based on available env vars
 const providers: NextAuthOptions['providers'] = [];
 
@@ -292,6 +313,17 @@ export const authOptions: NextAuthOptions = {
       // OAuth providers - allow sign in (emails are pre-verified by provider)
       // Skip native-oauth (transfer token flow) — email is already verified
       if (account?.provider !== 'credentials' && account?.provider !== 'native-oauth') {
+        // NextAuth runs this callback before its adapter creates or links an
+        // OAuth user. Rejecting here prevents a provider profile with no email
+        // from reaching either this callback's verification update or the
+        // adapter's users insert (users.email is intentionally NOT NULL).
+        // For an already-linked account NextAuth supplies the stored user here,
+        // so providers that omit email on later callbacks continue to work.
+        if (!hasUsableEmail(user.email)) {
+          reportMissingOAuthEmail(account?.provider ?? 'unknown');
+          return OAUTH_EMAIL_REQUIRED_REDIRECT;
+        }
+
         // Mark email as verified if not already (provider already verified it)
         if (user.id) {
           try {

--- a/packages/web/app/lib/auth/expo-web-oauth-return.ts
+++ b/packages/web/app/lib/auth/expo-web-oauth-return.ts
@@ -15,6 +15,7 @@ const KNOWN_ERROR_CODES = new Set([
   'OAuthAccountNotLinked',
   'OAuthCallback',
   'OAuthCreateAccount',
+  'OAuthEmailRequired',
   'OAuthSignin',
   'SessionRequired',
   'Signin',


### PR DESCRIPTION
## Summary

- Reject OAuth profiles without a usable email before NextAuth persists them.
- Keep already-linked Google, Apple, and Facebook accounts signing in normally.
- Add PII-free JSON telemetry and localized recovery guidance.

Part of #4340.

## Release Notes

Get a clear next step when your sign-in provider withholds your email.

## Test plan

1. Open OAuth email error → missing-email guidance appears.
2. Switch locales → Spanish, French, and German guidance appears.
3. Sign in with Google → your existing account still opens.

## Risk

Risk: 4/5 — auth-adjacent guard changes OAuth callback acceptance.
