### PR TITLE
feat(db): refresh PostgreSQL 18 image to 18.6

### DIFF
--- a/docs/postgres-18-migration.md
+++ b/docs/postgres-18-migration.md
@@ -1,4 +1,4 @@
-# PostgreSQL 16 to 18.4 Migration and Availability Runbook
+# PostgreSQL 16 to 18.6 Migration and Availability Runbook
 
 This is the proposed one-way Railway PostgreSQL upgrade procedure and PG18
 artifact contract. The producer PR does not activate PG18 in Compose, existing
@@ -7,9 +7,9 @@ to the digest-pinning consumer PR.
 
 ## Decision and boundaries
 
-- Upgrade directly from PostgreSQL 16 to PostgreSQL 18.4. PostgreSQL 17 is not
+- Upgrade directly from PostgreSQL 16 to PostgreSQL 18.6. PostgreSQL 17 is not
   an intermediate step.
-- Build a new Railway PostgreSQL 18.4 candidate on a fresh volume and use
+- Build a new Railway PostgreSQL 18.6 candidate on a fresh volume and use
   built-in logical replication from the PostgreSQL 16 primary. Do not run an
   in-place `pg_upgrade --link` on the Railway volume.
 - The PostgreSQL 16 source remains the only writer until the cutover fence.
@@ -34,9 +34,9 @@ to the digest-pinning consumer PR.
 
 The portable development and CI base is:
 
-- PostgreSQL `18.4`
-- official base `postgres:18.4-bookworm` at
-  `sha256:882236b897e39051d2368c5ccc6cda944904723506b2dfc97f2a8f5bc9afa382`
+- PostgreSQL `18.6`
+- official base `postgres:18.6-bookworm` at
+  `sha256:1c59e2c3c818eaa0f0628f695b36e7c9e362d6b219b36a54a32df645cbd7e1af`
 - PGDG PostGIS `3.6.4+dfsg-2.pgdg12+1`
 - PGDG HypoPG `1.4.3-1.pgdg12+1`
 
@@ -50,7 +50,7 @@ to the protected-main publisher described below.
 The portable image has two independent boot gates: the native runner exercises
 the full catalog/logical-replication rehearsal, and QEMU boots the actual
 `linux/arm64` image, verifies the container is `aarch64`, initializes a fresh
-PG18 parent volume, and asserts the exact PostgreSQL 18.4, PostGIS 3.6.4,
+PG18 parent volume, and asserts the exact PostgreSQL 18.6, PostGIS 3.6.4,
 HypoPG 1.4.3, base-image digest, checksum, and PGDATA contracts. A manifest-only
 ARM build is not enough.
 
@@ -529,7 +529,7 @@ instead of silently copying a filtered subset.
 
 1. Create a new Railway service from the exact attested Boardsesh PG18 image
    digest and a fresh parent volume.
-2. Verify `server_version_num = 180004`, `data_checksums = on`, and PostGIS
+2. Verify `server_version_num = 180006`, `data_checksums = on`, and PostGIS
    `3.6.4`.
 3. Install required extensions as the target admin:
 

--- a/docs/postgres-18-postgis-rehearsal.md
+++ b/docs/postgres-18-postgis-rehearsal.md
@@ -1,14 +1,14 @@
 # PostGIS 3.7.0dev → 3.6.4 rehearsal
 
-Evidence for Blocker 2 of the PostgreSQL 18 rollout. Run 2026-08-23 with
-`vp run test:postgres18-spatial-rehearsal`; the script is
+Evidence for Blocker 2 of the PostgreSQL 18 rollout. Re-run 2026-09-01 against
+the PostgreSQL 18.6 producer candidate with `vp run test:postgres18-spatial-rehearsal`; the script is
 `scripts/postgres18-spatial-rehearsal.sh` and re-running it reproduces every number below.
 
 ## The question
 
 `docs/postgres-18-migration.md` §1 blocks the catalog audit unless source and target PostGIS
 versions are equal. Production reports `3.7.0dev` because the Railway service tracks the mutable
-`postgis/postgis:16-master` tag; the attested PG18 artifact ships stable 3.6.4, and PGDG publishes no
+`postgis/postgis:16-master` tag; the PG18 producer image ships stable 3.6.4, and PGDG publishes no
 stable 3.7 for PostgreSQL 18. `pg_extension.extversion` cannot be downgraded in place — PostGIS ships
 no downgrade script — so "move one side to match the other" is not available in either direction.
 
@@ -24,9 +24,9 @@ no secret involved at any point.
 |                |                                                                                                                                                                                                                                                                                                                 |
 | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Source         | `postgis/postgis:16-master` — the tag the Railway production service tracks                                                                                                                                                                                                                                     |
-| Target         | built from `packages/db/docker/Dockerfile.postgres`, the same pinned inputs as the attested artifact                                                                                                                                                                                                            |
+| Target         | built from `packages/db/docker/Dockerfile.postgres`, the PostgreSQL 18.6 producer candidate                                                                                                                                                                                                                   |
 | Copy mechanics | the dump/restore flags, the byte-identical `pg_restore --list` awk filter, and the exit-status-and-any-diagnostic rule from `scripts/postgres-logical-replication.sh setup`. The real setup also carries the `drizzle` schema, which holds migration bookkeeping and no spatial object; this dumps `public` only |
-| Clients        | PostgreSQL 18.4 `pg_dump`/`pg_restore`, run from inside the target image — newer client, older server                                                                                                                                                                                                           |
+| Clients        | PostgreSQL 18.6 `pg_dump`/`pg_restore`, run from inside the target image — newer client, older server                                                                                                                                                                                                           |
 
 The fixture is the application's complete spatial surface, taken from the migrations that created it:
 the two `geography(Point,4326)` columns (0052, 0054), both partial GiST indexes, and the
@@ -43,7 +43,7 @@ image.
 ```
 source: PostgreSQL 16.14, POSTGIS="3.7.0dev 3.6.0rc2-620-gb8c7b0142"
         GEOS="3.15.0dev-CAPI-1.21.0" PROJ="9.9.0"
-target: PostgreSQL 18.4,  POSTGIS="3.6.4 94d984b"
+target: PostgreSQL 18.6,  POSTGIS="3.6.4 94d984b"
         GEOS="3.11.1-CAPI-1.17.1" PROJ="9.8.1"
 ```
 

--- a/packages/db/docker/Dockerfile.dev-db
+++ b/packages/db/docker/Dockerfile.dev-db
@@ -25,7 +25,7 @@
 # ---------------------------------------------------------------------------
 # Stage 1: postgres + PostGIS base (same as Dockerfile.postgres)
 # ---------------------------------------------------------------------------
-FROM postgres:18.4-bookworm@sha256:882236b897e39051d2368c5ccc6cda944904723506b2dfc97f2a8f5bc9afa382 AS postgres-postgis
+FROM postgres:18.6-bookworm@sha256:1c59e2c3c818eaa0f0628f695b36e7c9e362d6b219b36a54a32df645cbd7e1af AS postgres-postgis
 
 ARG POSTGIS_PACKAGE_VERSION=3.6.4+dfsg-2.pgdg12+1
 ARG HYPOPG_PACKAGE_VERSION=1.4.3-1.pgdg12+1
@@ -37,7 +37,7 @@ RUN apt-get update && \
       "postgresql-18-postgis-3=${POSTGIS_PACKAGE_VERSION}" \
       "postgresql-18-postgis-3-scripts=${POSTGIS_PACKAGE_VERSION}" \
       "postgresql-18-hypopg=${HYPOPG_PACKAGE_VERSION}" && \
-    postgres --version | grep -Eq '^postgres \(PostgreSQL\) 18\.4([ .]|$)' && \
+    postgres --version | grep -Eq '^postgres \(PostgreSQL\) 18\.6([ .]|$)' && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -241,9 +241,9 @@ COPY --from=builder /opt/boardsesh/snapshot-sources.json /usr/local/share/boards
 COPY packages/db/docker/dev-db-entrypoint.sh /usr/local/bin/boardsesh-dev-db-entrypoint
 RUN chmod +x /usr/local/bin/boardsesh-dev-db-entrypoint
 
-LABEL org.boardsesh.postgresql.version="18.4" \
+LABEL org.boardsesh.postgresql.version="18.6" \
       org.boardsesh.postgis.version="3.6.4" \
-      org.boardsesh.postgresql.base-digest="sha256:882236b897e39051d2368c5ccc6cda944904723506b2dfc97f2a8f5bc9afa382"
+      org.boardsesh.postgresql.base-digest="sha256:1c59e2c3c818eaa0f0628f695b36e7c9e362d6b219b36a54a32df645cbd7e1af"
 
 ENTRYPOINT ["boardsesh-dev-db-entrypoint"]
 CMD ["postgres"]

--- a/packages/db/docker/Dockerfile.postgres
+++ b/packages/db/docker/Dockerfile.postgres
@@ -1,4 +1,4 @@
-FROM postgres:18.4-bookworm@sha256:882236b897e39051d2368c5ccc6cda944904723506b2dfc97f2a8f5bc9afa382
+FROM postgres:18.6-bookworm@sha256:1c59e2c3c818eaa0f0628f695b36e7c9e362d6b219b36a54a32df645cbd7e1af
 
 ARG POSTGIS_PACKAGE_VERSION=3.6.4+dfsg-2.pgdg12+1
 ARG HYPOPG_PACKAGE_VERSION=1.4.3-1.pgdg12+1
@@ -10,10 +10,10 @@ RUN apt-get update && \
       "postgresql-18-postgis-3=${POSTGIS_PACKAGE_VERSION}" \
       "postgresql-18-postgis-3-scripts=${POSTGIS_PACKAGE_VERSION}" \
       "postgresql-18-hypopg=${HYPOPG_PACKAGE_VERSION}" && \
-    postgres --version | grep -Eq '^postgres \(PostgreSQL\) 18\.4([ .]|$)' && \
+    postgres --version | grep -Eq '^postgres \(PostgreSQL\) 18\.6([ .]|$)' && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-LABEL org.boardsesh.postgresql.version="18.4" \
+LABEL org.boardsesh.postgresql.version="18.6" \
       org.boardsesh.postgis.version="3.6.4" \
-      org.boardsesh.postgresql.base-digest="sha256:882236b897e39051d2368c5ccc6cda944904723506b2dfc97f2a8f5bc9afa382"
+      org.boardsesh.postgresql.base-digest="sha256:1c59e2c3c818eaa0f0628f695b36e7c9e362d6b219b36a54a32df645cbd7e1af"

--- a/scripts/dev-db-image-smoke.sh
+++ b/scripts/dev-db-image-smoke.sh
@@ -90,8 +90,8 @@ DECLARE
   owner_membership_count integer;
   stats_role_oid oid;
 BEGIN
-  IF current_setting('server_version_num')::integer <> 180004 THEN
-    RAISE EXCEPTION 'expected PostgreSQL server_version_num 180004, got %',
+  IF current_setting('server_version_num')::integer <> 180006 THEN
+    RAISE EXCEPTION 'expected PostgreSQL server_version_num 180006, got %',
       current_setting('server_version_num');
   END IF;
   IF current_setting('data_checksums') <> 'on' THEN
@@ -404,4 +404,4 @@ after_restart="$(docker exec "$CONTAINER_NAME" psql -X -Atq -U postgres -d main 
   -c "SELECT count(*) || '|' || (SELECT count(*) FROM drizzle.__drizzle_migrations) FROM board_climbs;")"
 [[ "$after_restart" == "$before_restart" ]]
 
-printf 'Seeded PostgreSQL 18.4 dev-db fresh-volume and restart smoke test passed for %s.\n' "$IMAGE_REFERENCE"
+printf 'Seeded PostgreSQL 18.6 dev-db fresh-volume and restart smoke test passed for %s.\n' "$IMAGE_REFERENCE"

--- a/scripts/postgres-migration-audit.sh
+++ b/scripts/postgres-migration-audit.sh
@@ -3059,7 +3059,7 @@ SELECT (
          JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = relation.relnamespace
          CROSS JOIN LATERAL pg_catalog.aclexplode(
            coalesce(relation.relacl, pg_catalog.acldefault(
-             CASE WHEN relation.relkind = 'S' THEN 'S'::\"char\" ELSE 'r'::\"char\" END,
+             CASE WHEN relation.relkind = 'S' THEN 's'::\"char\" ELSE 'r'::\"char\" END,
              relation.relowner
            ))
          ) AS privilege

--- a/scripts/postgres-migration-audit.sh
+++ b/scripts/postgres-migration-audit.sh
@@ -12,7 +12,7 @@ EXPECTED_SOURCE_MAJOR="${EXPECTED_SOURCE_MAJOR:-16}"
 EXPECTED_TARGET_MAJOR="${EXPECTED_TARGET_MAJOR:-18}"
 EXPECTED_SOURCE_DATABASE="${EXPECTED_SOURCE_DATABASE:-railway}"
 EXPECTED_TARGET_DATABASE="${EXPECTED_TARGET_DATABASE:-railway}"
-EXPECTED_TARGET_VERSION_NUM="${EXPECTED_TARGET_VERSION_NUM:-180004}"
+EXPECTED_TARGET_VERSION_NUM="${EXPECTED_TARGET_VERSION_NUM:-180006}"
 EXPECTED_POSTGIS_VERSION="${EXPECTED_POSTGIS_VERSION:-3.6.4}"
 MIGRATION_SCHEMAS="${MIGRATION_SCHEMAS:-public drizzle}"
 MIGRATION_EXCLUDED_SCHEMAS="${MIGRATION_EXCLUDED_SCHEMAS:-neon_auth neon_control_plane}"
@@ -47,7 +47,7 @@ Required:
   SOURCE_DATABASE_URL              Direct PostgreSQL source URL (expected PG16).
 
 Optional target comparison:
-  TARGET_DATABASE_URL              Direct PostgreSQL target URL (expected PG18.4).
+  TARGET_DATABASE_URL              Direct PostgreSQL target URL (expected PG18.6).
   MIGRATION_OWNER_ROLE             NOLOGIN, non-superuser owner of app objects.
   MIGRATION_RUNTIME_ROLE           LOGIN least-privilege application role.
   MIGRATION_MIGRATOR_ROLE          LOGIN migration role that can SET ROLE to owner.
@@ -83,7 +83,7 @@ Optional controls:
                                     every published table.
   EXPECTED_SOURCE_MAJOR            Default 16.
   EXPECTED_TARGET_MAJOR            Default 18.
-  EXPECTED_TARGET_VERSION_NUM      Default 180004 (PostgreSQL 18.4).
+  EXPECTED_TARGET_VERSION_NUM      Default 180006 (PostgreSQL 18.6).
   EXPECTED_POSTGIS_VERSION         Default 3.6.4.
   MATERIALIZED_VIEWS_REFRESH_PLANNED
                                     Set true only when every reported materialized view

--- a/scripts/postgres-migration-audit.sh
+++ b/scripts/postgres-migration-audit.sh
@@ -2963,7 +2963,7 @@ WHERE sequence.relkind = 'S'
     OR pg_catalog.has_sequence_privilege(runtime_role.oid, sequence.oid, 'UPDATE')
     OR EXISTS (
       SELECT 1 FROM pg_catalog.aclexplode(
-        coalesce(sequence.relacl, pg_catalog.acldefault('S', sequence.relowner))
+        coalesce(sequence.relacl, pg_catalog.acldefault('s', sequence.relowner))
       ) AS privilege
       WHERE privilege.grantee = 0
         AND privilege.privilege_type IN ('USAGE', 'SELECT', 'UPDATE')

--- a/scripts/postgres18-architecture-smoke.sh
+++ b/scripts/postgres18-architecture-smoke.sh
@@ -14,10 +14,10 @@ EXPECTED_PLATFORM="${2:-}"
 
 readonly CONTAINER_NAME="boardsesh-postgres18-arch-${GITHUB_RUN_ID:-local}-${$}"
 readonly VOLUME_NAME="boardsesh-postgres18-arch-${GITHUB_RUN_ID:-local}-${$}"
-readonly EXPECTED_POSTGRES_VERSION='18.4'
+readonly EXPECTED_POSTGRES_VERSION='18.6'
 readonly EXPECTED_POSTGIS_VERSION='3.6.4'
 readonly EXPECTED_HYPOPG_VERSION='1.4.3'
-readonly EXPECTED_BASE_DIGEST='sha256:882236b897e39051d2368c5ccc6cda944904723506b2dfc97f2a8f5bc9afa382'
+readonly EXPECTED_BASE_DIGEST='sha256:1c59e2c3c818eaa0f0628f695b36e7c9e362d6b219b36a54a32df645cbd7e1af'
 
 cleanup() {
   docker rm --force "$CONTAINER_NAME" >/dev/null 2>&1 || true
@@ -80,8 +80,8 @@ SELECT set_config('boardsesh.expected_postgis_version', :'expected_postgis_versi
 SELECT set_config('boardsesh.expected_hypopg_version', :'expected_hypopg_version', false);
 DO $$
 BEGIN
-  IF current_setting('server_version_num')::integer <> 180004 THEN
-    RAISE EXCEPTION 'expected PostgreSQL 18.4, got %', current_setting('server_version');
+  IF current_setting('server_version_num')::integer <> 180006 THEN
+    RAISE EXCEPTION 'expected PostgreSQL 18.6, got %', current_setting('server_version');
   END IF;
   IF current_setting('data_checksums') <> 'on' THEN
     RAISE EXCEPTION 'expected data_checksums=on';
@@ -108,5 +108,5 @@ END
 $$;
 SQL
 
-printf 'PostgreSQL 18.4 booted with PostGIS 3.6.4 and HypoPG 1.4.3 on %s.\n' \
+printf 'PostgreSQL 18.6 booted with PostGIS 3.6.4 and HypoPG 1.4.3 on %s.\n' \
   "$EXPECTED_PLATFORM"

--- a/scripts/postgres18-image-smoke.sh
+++ b/scripts/postgres18-image-smoke.sh
@@ -461,8 +461,8 @@ SELECT set_config('boardsesh.expected_postgis_version', :'expected_postgis_versi
 
 DO $$
 BEGIN
-  IF current_setting('server_version') NOT LIKE '18.4%' THEN
-    RAISE EXCEPTION 'expected PostgreSQL 18.4, got %', current_setting('server_version');
+  IF current_setting('server_version_num')::integer <> 180006 THEN
+    RAISE EXCEPTION 'expected PostgreSQL 18.6, got %', current_setting('server_version');
   END IF;
   IF current_setting('data_checksums') <> 'on' THEN
     RAISE EXCEPTION 'expected data_checksums=on';
@@ -2064,4 +2064,4 @@ if ! run_two_host_audit_without_publication >"$AUDIT_REPORT_FILE" 2>&1; then
 fi
 assert_report_contains 'Audit result: 0 blocker(s).'
 
-printf 'PostgreSQL 18.4 image, audit, and two-host logical-migration smoke test passed.\n'
+printf 'PostgreSQL 18.6 image, audit, and two-host logical-migration smoke test passed.\n'

--- a/scripts/postgres18-spatial-rehearsal.sh
+++ b/scripts/postgres18-spatial-rehearsal.sh
@@ -103,7 +103,7 @@ source_psql() {
 
 # pg_dump/pg_restore always run from the TARGET container: PostgreSQL supports a
 # newer client against an older server, never the reverse, and the target ships
-# the 18.4 client. `target_client` reaches the source over the private network.
+# the 18.6 client. `target_client` reaches the source over the private network.
 target_psql() {
   docker exec -i -e PGDATABASE="$DATABASE_NAME" -u postgres "$TARGET_CONTAINER" psql -v ON_ERROR_STOP=1 "$@"
 }

--- a/scripts/postgres18-workflow-contract.test.sh
+++ b/scripts/postgres18-workflow-contract.test.sh
@@ -4,14 +4,27 @@ set -Eeuo pipefail
 VALIDATION_WORKFLOW="${1:-.github/workflows/dev-db-docker.yml}"
 CONTRACT_TASK_CONFIG="${2:-vite.config.ts}"
 CONTRACT_SCRIPT="${3:-scripts/postgres18-contract.sh}"
+MIGRATION_AUDIT_SCRIPT="${4:-scripts/postgres-migration-audit.sh}"
 [[ -f "$VALIDATION_WORKFLOW" ]]
 [[ -f "$CONTRACT_TASK_CONFIG" ]]
 [[ -f "$CONTRACT_SCRIPT" ]]
+[[ -f "$MIGRATION_AUDIT_SCRIPT" ]]
 
 fail() {
   printf 'PostgreSQL image workflow contract failed: %s\n' "$*" >&2
   exit 1
 }
+
+# PostgreSQL deliberately uses different object-type discriminators in these
+# two catalog APIs: acldefault() names a sequence with lowercase `s`, while
+# pg_default_acl.defaclobjtype names one with uppercase `S`. Mixing them makes
+# the runtime audit ask for a foreign-server default ACL instead of a sequence
+# ACL whenever pg_class.relacl is NULL.
+grep -Fq "pg_catalog.acldefault('s', sequence.relowner)" "$MIGRATION_AUDIT_SCRIPT" ||
+  fail 'the migration audit must use the lowercase sequence discriminator for acldefault()'
+if grep -Fq "pg_catalog.acldefault('S', sequence.relowner)" "$MIGRATION_AUDIT_SCRIPT"; then
+  fail 'uppercase S is the acldefault() foreign-server discriminator, not sequence'
+fi
 
 # Candidate-controlled pull-request and branch workflows are structurally
 # incapable of registry/package/OIDC mutation.

--- a/scripts/postgres18-workflow-contract.test.sh
+++ b/scripts/postgres18-workflow-contract.test.sh
@@ -25,6 +25,12 @@ grep -Fq "pg_catalog.acldefault('s', sequence.relowner)" "$MIGRATION_AUDIT_SCRIP
 if grep -Fq "pg_catalog.acldefault('S', sequence.relowner)" "$MIGRATION_AUDIT_SCRIPT"; then
   fail 'uppercase S is the acldefault() foreign-server discriminator, not sequence'
 fi
+grep -Fq "CASE WHEN relation.relkind = 'S' THEN 's'::\\\"char\\\" ELSE 'r'::\\\"char\\\" END" \
+  "$MIGRATION_AUDIT_SCRIPT" ||
+  fail 'the mixed relation ACL audit must map pg_class sequence kind S to acldefault sequence kind s'
+if grep -Fq "CASE WHEN relation.relkind = 'S' THEN 'S'::\\\"char\\\"" "$MIGRATION_AUDIT_SCRIPT"; then
+  fail 'the mixed relation ACL audit must not pass pg_class sequence kind S to acldefault unchanged'
+fi
 
 # Candidate-controlled pull-request and branch workflows are structurally
 # incapable of registry/package/OIDC mutation.


### PR DESCRIPTION
## Summary

Refreshes both PostgreSQL image producers from PostgreSQL 18.4 to PostgreSQL 18.6 using the immutable official base:

`postgres:18.6-bookworm@sha256:1c59e2c3c818eaa0f0628f695b36e7c9e362d6b219b36a54a32df645cbd7e1af`

The package contract remains pinned to PostGIS `3.6.4+dfsg-2.pgdg12+1` and HypoPG `1.4.3-1.pgdg12+1`. Version assertions, smoke tests, rehearsals, and runbooks now require `server_version_num = 180006`.

This is producer-only. Consumer digest pins remain untouched until the protected `main` publisher emits and attests new portable and seeded manifests. A separate consumer PR can then update every digest atomically.

## Stack

Base: **#4703** at `8c9ae9abddb43e136e7971f4ea202fbecad022b0`, which is based on **#4702** at `aeb567ccf2fec238d02ee7df1e0aa3167ef90b3c`.

Current head: `2ada5e56ca589556d34f64bea022ada0bc6381ec`.

Merge order: **#4702 → #4703 → #4994**.

The protected publisher runs only after this stack reaches `main`; this draft performs no production or Railway mutation.

## PostgreSQL 18.6 / PostGIS 3.6.4 evidence

The image-producing tree rehearsed at former head `25b77248e16e2be38c2960fc8a21a2fa6c4c7749` is preserved at rebased commit `a616ce323` and passed:

- PostgreSQL 18.6 image audit and two-host logical-migration smoke;
- 21/21 cross-major spatial checks: PostgreSQL 16.14/PostGIS 3.7.0dev → PostgreSQL 18.6/PostGIS 3.6.4;
- seeded image construction with all 211 migrations applied, including generated migration 0210;
- seeded PostgreSQL 18.6/PostGIS 3.6.4 catalog, fresh-volume, and restart smoke;
- migration journal validation, formatting, and full typecheck.

Final head `2ada5e56ca589556d34f64bea022ada0bc6381ec` also fixes both migration-audit sequence fallback shapes: `acldefault('s', ...)` is sequence, while uppercase `S` is foreign server (`pg_default_acl.defaclobjtype = 'S'` remains correct for sequences). The eight-part PostgreSQL contract suite passes, and an isolated exact PostgreSQL 18.6 catalog proof returned sequence `rwU` versus foreign-server `U` defaults. The image inputs themselves are unchanged by these audit-only corrections.

The exact trigger-function catalog guard also passes on the seeded image. The textual guard scans the full body-sanitized CREATE FUNCTION statement and uses PostgreSQL's last-clause semantics across attributes before and after `AS`. It shares quoted/unquoted public-target normalization across CREATE, ALTER, and DROP, trusts only an exact canonical ALTER pin, folds every other ALTER of an inventoried public function unsafe, and leaves a permanent failure sentinel for unparsed CREATE/ALTER grammar. OUT-only identities, alternate string bodies, qualified trigger return types, quoted GUCs, RESET/SET SCHEMA, non-ASCII dollar tags, and backslash-escaped E-string bodies are covered. Empty, missing-schema, reversed-order, extra-schema, unrelated-schema, canonical-before-AS to wrong-after-AS, and canonical-before-AS to `FROM CURRENT` after-AS mutations are rejected by all 70 trigger-fold tests plus the artifact checks; safe final clauses after `AS` remain accepted.

The official Docker Hub manifest digest was verified through tag metadata and an actual pull. Existing consumer digests and `docs/postgres-image-digests.json` are unchanged.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 5/5 — changes the immutable production database image input.
