### PR TITLE
fix(web): stop climb pages advertising three locale twins of themselves

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/page.tsx
@@ -9,7 +9,7 @@ import StaticListFrontDoor from '@/app/components/climb-front-door/static-list-f
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { fetchFrontDoorListPage } from '@/app/lib/data/list-page-data.server';
 import { formatBoardDisplayName } from '@/app/lib/string-utils';
-import { createPageMetadata } from '@/app/lib/seo/metadata';
+import { createBoardContentPageMetadata } from '@/app/lib/seo/metadata';
 import {
   isFrontDoorPageOutOfRange,
   parseFrontDoorPage,
@@ -56,7 +56,7 @@ export async function generateMetadata(props: {
       searchParams: searchParams as unknown as ListPageSearchParams,
     });
 
-    return createPageMetadata({
+    return createBoardContentPageMetadata({
       title:
         page > 1
           ? t('metadata.list.paginatedTitle', { boardName, angle, page })
@@ -71,7 +71,7 @@ export async function generateMetadata(props: {
     // canonical for a URL that has no board behind it. On the same request the
     // page body 404s for an unresolvable config or an out-of-range `?page`, and
     // 500s if the read itself failed (#4461) — metadata never decides that.
-    return createPageMetadata({
+    return createBoardContentPageMetadata({
       title: t('metadata.list.fallbackTitle'),
       description: t('metadata.list.fallbackDescription'),
       locale,

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
@@ -17,7 +17,7 @@ import ClimbFrontDoor from '@/app/components/climb-front-door/climb-front-door';
 import { buildOgBoardRenderUrl, buildOverlayPreloadUrls } from '@/app/components/board-renderer/util';
 import { scheduleOgImageWarming } from '@/app/lib/warm-overlay-cache';
 import { getServerTranslation } from '@/app/lib/i18n/server';
-import { createPageMetadata } from '@/app/lib/seo/metadata';
+import { createBoardContentPageMetadata } from '@/app/lib/seo/metadata';
 import { resolveClimbDisplayName } from '@/app/lib/string-utils';
 import { selectCanonicalClimbAngle } from '@/app/lib/seo/canonical-climb-angle';
 
@@ -33,7 +33,7 @@ export async function generateMetadata(props: { params: Promise<BoardRouteParame
       getClimbStatsForAllAngles(parsedParams),
     ]);
     if (!currentClimb) {
-      return createPageMetadata({
+      return createBoardContentPageMetadata({
         title: t('metadata.view.fallbackTitle'),
         description: t('metadata.view.fallbackDescription'),
         locale,
@@ -57,7 +57,7 @@ export async function generateMetadata(props: { params: Promise<BoardRouteParame
 
     const ogImagePath = buildOgBoardRenderUrl(boardDetails, currentClimb.frames);
 
-    return createPageMetadata({
+    return createBoardContentPageMetadata({
       title: t('metadata.view.title', { climbName, grade: climbGrade }),
       description: t('metadata.view.description', { climbName, grade: climbGrade, setter, quality, ascents }),
       path: climbUrl,
@@ -66,7 +66,7 @@ export async function generateMetadata(props: { params: Promise<BoardRouteParame
       imageAlt: t('metadata.view.imageAlt', { climbName, grade: climbGrade, boardName: boardDetails.board_name }),
     });
   } catch {
-    return createPageMetadata({
+    return createBoardContentPageMetadata({
       title: t('metadata.view.fallbackTitle'),
       description: t('metadata.view.fallbackDescription'),
       locale,

--- a/packages/web/app/__tests__/board-content-metadata-guard.test.ts
+++ b/packages/web/app/__tests__/board-content-metadata-guard.test.ts
@@ -1,0 +1,109 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vite-plus/test';
+
+/**
+ * Board content — climb view, climb list, setter — is the one place we
+ * deliberately cross-canonicalise locale twins onto the default locale and emit
+ * no `hreflang`. The twins are translated chrome over identical data, so four
+ * URLs for one page bought nothing but a 4x crawl surface: ~205k climb-view
+ * renders/day with Postgres at 183/200 connections when this was measured.
+ *
+ * That decision only holds if two things stay true together, and neither is
+ * visible from the other's file:
+ *
+ * 1. **Every** metadata call in these route files goes through
+ *    `createBoardContentPageMetadata`. They call into metadata 19 times between
+ *    them (fallback, notFound and redirect paths), so one missed call site
+ *    silently republishes a self-canonicalising twin.
+ * 2. Their sitemap shards do not list the twins. Advertising a URL whose own
+ *    canonical points elsewhere is a contradiction Google resolves by ignoring
+ *    one of the two signals.
+ *
+ * A missing import is checkable where a missed argument is not, which is why
+ * this is a separate function rather than a flag on `createPageMetadata`.
+ */
+
+const WEB_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/** The surfaces that cross-canonicalise. Both route trees, plus setter. */
+const BOARD_CONTENT_ROUTE_FILES = [
+  'app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx',
+  'app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/page.tsx',
+  'app/b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx',
+  'app/b/[board_slug]/[angle]/list/page.tsx',
+  'app/setter/[setter_username]/page.tsx',
+] as const;
+
+/** Shards whose pages cross-canonicalise, so they must not fan out to locales. */
+const DEFAULT_LOCALE_ONLY_SHARDS = ['boards', 'setters'] as const;
+
+const SHARD_REGISTRY_PATH = 'app/lib/seo/sitemap/shard-registry.ts';
+
+/**
+ * The shard registry is read as SOURCE, not imported: it is `server-only` and
+ * pulls in the board-config query, so importing it needs a DATABASE_URL. A guard
+ * over a config shape should not need a database — same approach
+ * `ci-lint-scope.test.ts` takes over `vite.config.ts`.
+ */
+function shardLiteral(source: string, id: string): string {
+  const start = source.indexOf(`id: '${id}'`);
+  if (start < 0) throw new Error(`no shard "${id}" in ${SHARD_REGISTRY_PATH}`);
+  const next = source.indexOf("id: '", start + 1);
+  return source.slice(start, next < 0 ? source.length : next);
+}
+
+/** `createPageMetadata` as a call or import, but not as part of the longer name. */
+const BARE_METADATA_HELPER = /(?<!BoardContent)\bcreatePageMetadata\b/;
+
+function readRoute(relativePath: string): string {
+  return readFileSync(join(WEB_ROOT, relativePath), 'utf8');
+}
+
+/** Strip block and line comments so a doc comment naming the helper isn't a hit. */
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+describe('board-content metadata guard', () => {
+  it('reads every route file it claims to check', () => {
+    // Guard the guard: a bad path would make every assertion below vacuous.
+    expect(BOARD_CONTENT_ROUTE_FILES.length).toBe(5);
+    for (const relativePath of BOARD_CONTENT_ROUTE_FILES) {
+      expect(readRoute(relativePath).length, relativePath).toBeGreaterThan(0);
+    }
+  });
+
+  it.each(BOARD_CONTENT_ROUTE_FILES)('%s uses the board-content helper', (relativePath) => {
+    const source = withoutComments(readRoute(relativePath));
+    expect(source, `${relativePath} must import createBoardContentPageMetadata`).toContain(
+      'createBoardContentPageMetadata',
+    );
+  });
+
+  it.each(BOARD_CONTENT_ROUTE_FILES)('%s never reaches for the plain helper', (relativePath) => {
+    // The failure this catches: a new metadata call added later that defaults
+    // back to self-canonicalising, re-splitting the page across four URLs.
+    const source = withoutComments(readRoute(relativePath));
+    expect(BARE_METADATA_HELPER.test(source), `${relativePath} still calls createPageMetadata`).toBe(false);
+  });
+
+  it('keeps the sitemap in step: shards for these pages list one locale only', () => {
+    const registry = readRoute(SHARD_REGISTRY_PATH);
+    for (const id of DEFAULT_LOCALE_ONLY_SHARDS) {
+      expect(shardLiteral(registry, id), `shard "${id}" must not fan out to locale twins`).toContain(
+        "expansion: 'default-locale-only'",
+      );
+    }
+  });
+
+  it('leaves genuinely translated surfaces fanning out to every locale', () => {
+    // The counter-assertion. `/about`, `/legal` and `/docs` are real translated
+    // content, and cross-canonicalising those is the W-22 "no return links" bug
+    // that hreflang-return-metadata.test.ts exists to catch. This carve-out must
+    // not spread to them.
+    const registry = readRoute(SHARD_REGISTRY_PATH);
+    expect(shardLiteral(registry, 'static')).not.toContain('expansion:');
+  });
+});

--- a/packages/web/app/__tests__/hreflang-return-metadata.test.ts
+++ b/packages/web/app/__tests__/hreflang-return-metadata.test.ts
@@ -78,12 +78,6 @@ async function withLocale<T>(locale: 'en-US' | 'es', run: () => Promise<T>): Pro
 
 const cases: MetadataCase[] = [
   {
-    name: 'setter profile',
-    basePath: '/setter/marco',
-    load: (locale) =>
-      withLocale(locale, () => setterPage.generateMetadata({ params: Promise.resolve({ setter_username: 'marco' }) })),
-  },
-  {
     name: 'playlist detail',
     basePath: '/playlists/abc-123',
     load: (locale) => withLocale(locale, () => generatePlaylistMetadata('abc-123', locale)),
@@ -116,4 +110,42 @@ describe('hreflang returns for every sitemapped surface', () => {
       expect(spanish.alternates?.languages).toEqual(expectedLanguages);
     });
   }
+});
+
+/**
+ * Board content is the deliberate exception to everything above.
+ *
+ * `/setter/marco` used to sit in the table above. It moved here — not because
+ * the rule above got weaker, but because these pages are a different kind of
+ * thing: the locale twins are translated *chrome* over *identical* content. The
+ * climb name, grade, setter and board art are the same in every locale; only UI
+ * strings differ. Four URLs for one page cost a 4x crawl surface, measured at
+ * ~205k climb-view renders/day with Postgres at 183/200 connections.
+ *
+ * So these cross-canonicalise onto the default locale and emit NO `languages`,
+ * via `createBoardContentPageMetadata`. Both halves are required: canonical
+ * alone leaves the twins advertised by their own hreflang block, and Google
+ * requires hreflang cluster members to self-canonicalise, so the pair would be
+ * contradictory.
+ *
+ * Everything still in `cases` above keeps the W-22 rule, and that is correct —
+ * `/about`, `/legal`, `/docs`, playlists and session shares are real translated
+ * content or genuinely per-locale surfaces. This is a carve-out with a reason,
+ * not the start of a drift.
+ */
+describe('board content cross-canonicalises instead', () => {
+  it('setter profile points every locale at the English URL and advertises no alternates', async () => {
+    const basePath = '/setter/marco';
+    const load = (locale: 'en-US' | 'es') =>
+      withLocale(locale, () => setterPage.generateMetadata({ params: Promise.resolve({ setter_username: 'marco' }) }));
+
+    const english = await load('en-US');
+    expect(english.alternates?.canonical).toBe(basePath);
+    expect(english.alternates?.languages).toBeUndefined();
+
+    // The point of the change: the Spanish twin does NOT self-canonicalise.
+    const spanish = await load('es');
+    expect(spanish.alternates?.canonical).toBe(basePath);
+    expect(spanish.alternates?.languages).toBeUndefined();
+  });
 });

--- a/packages/web/app/b/[board_slug]/[angle]/list/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/list/page.tsx
@@ -8,7 +8,7 @@ import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { fetchFrontDoorListPage } from '@/app/lib/data/list-page-data.server';
 import { formatBoardDisplayName } from '@/app/lib/string-utils';
 import { buildCanonicalClimbListUrl } from '@/app/lib/url-utils';
-import { createPageMetadata } from '@/app/lib/seo/metadata';
+import { createBoardContentPageMetadata } from '@/app/lib/seo/metadata';
 import {
   isFrontDoorPageOutOfRange,
   parseFrontDoorPage,
@@ -29,7 +29,7 @@ export async function generateMetadata(props: BoardSlugListPageProps): Promise<M
   try {
     const board = await resolveBoardBySlug(params.board_slug);
     if (!board) {
-      return createPageMetadata({
+      return createBoardContentPageMetadata({
         title: t('metadata.list.fallbackTitle'),
         description: t('metadata.list.fallbackDescription'),
         locale,
@@ -39,7 +39,7 @@ export async function generateMetadata(props: BoardSlugListPageProps): Promise<M
     const boardName = formatBoardDisplayName(board.boardType);
     const parsedParams = boardToRouteParamsFromAngleSegment(board, params.angle);
     if (!parsedParams) {
-      return createPageMetadata({
+      return createBoardContentPageMetadata({
         title: t('metadata.list.fallbackTitle'),
         description: t('metadata.list.fallbackDescription'),
         locale,
@@ -65,7 +65,7 @@ export async function generateMetadata(props: BoardSlugListPageProps): Promise<M
       boardIsHidden: board.isUnlisted || !board.isPublic,
     });
 
-    return createPageMetadata({
+    return createBoardContentPageMetadata({
       title:
         page > 1
           ? t('metadata.list.paginatedTitle', { boardName, angle: params.angle, page })
@@ -76,7 +76,7 @@ export async function generateMetadata(props: BoardSlugListPageProps): Promise<M
       robots,
     });
   } catch {
-    return createPageMetadata({
+    return createBoardContentPageMetadata({
       title: t('metadata.list.fallbackTitle'),
       description: t('metadata.list.fallbackDescription'),
       locale,

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/page-metadata.test.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/page-metadata.test.tsx
@@ -253,4 +253,28 @@ describe('board slug climb metadata', () => {
     expect(canonicalUrl).toContain('/40/view/test-climb');
     expect(metadata.robots).toBeUndefined();
   });
+
+  it('advertises no locale alternates, so the twins are not four indexable pages', async () => {
+    // The locale dimension, orthogonal to the A1 tree consolidation above.
+    // Climb pages are translated chrome over identical content, so they
+    // cross-canonicalise onto the default locale via
+    // `createBoardContentPageMetadata` and emit no `hreflang` — the two halves
+    // only work as a pair, since a canonical alone leaves the twins advertised
+    // by their own alternates block. Import-level coverage lives in
+    // `app/__tests__/board-content-metadata-guard.test.ts`; this pins the
+    // rendered output.
+    const metadata = await pageModule.generateMetadata({
+      params: Promise.resolve({
+        board_slug: 'my-board',
+        angle: '40',
+        climb_uuid: 'test-climb',
+      }),
+    });
+
+    expect(metadata.alternates?.languages).toBeUndefined();
+    const canonical = metadata.alternates?.canonical;
+    const canonicalUrl =
+      typeof canonical === 'object' && canonical && 'url' in canonical ? String(canonical.url) : String(canonical);
+    expect(canonicalUrl).not.toMatch(/^\/(es|fr|de)\//);
+  });
 });

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx
@@ -10,7 +10,7 @@ import { buildCanonicalClimbViewUrl, extractUuidFromSlug } from '@/app/lib/url-u
 import { buildOgBoardRenderUrl, buildOverlayPreloadUrls } from '@/app/components/board-renderer/util';
 import { scheduleOgImageWarming } from '@/app/lib/warm-overlay-cache';
 import { getServerTranslation } from '@/app/lib/i18n/server';
-import { createPageMetadata } from '@/app/lib/seo/metadata';
+import { createBoardContentPageMetadata } from '@/app/lib/seo/metadata';
 import { resolveClimbDisplayName } from '@/app/lib/string-utils';
 import { selectCanonicalClimbAngle } from '@/app/lib/seo/canonical-climb-angle';
 
@@ -27,7 +27,7 @@ export async function generateMetadata(props: BoardSlugViewPageProps): Promise<M
   try {
     const board = await resolveBoardBySlug(params.board_slug);
     if (!board) {
-      return createPageMetadata({
+      return createBoardContentPageMetadata({
         title: t('metadata.view.fallbackTitle'),
         description: t('metadata.view.fallbackDescription'),
         locale,
@@ -37,7 +37,7 @@ export async function generateMetadata(props: BoardSlugViewPageProps): Promise<M
 
     const parsedBoardParams = boardToRouteParamsFromAngleSegment(board, params.angle);
     if (!parsedBoardParams) {
-      return createPageMetadata({
+      return createBoardContentPageMetadata({
         title: t('metadata.view.fallbackTitle'),
         description: t('metadata.view.fallbackDescription'),
         locale,
@@ -52,7 +52,7 @@ export async function generateMetadata(props: BoardSlugViewPageProps): Promise<M
       getClimbStatsForAllAngles(parsedParams),
     ]);
     if (!currentClimb) {
-      return createPageMetadata({
+      return createBoardContentPageMetadata({
         title: t('metadata.view.fallbackTitle'),
         description: t('metadata.view.fallbackDescription'),
         locale,
@@ -77,8 +77,8 @@ export async function generateMetadata(props: BoardSlugViewPageProps): Promise<M
     // names a board a user owns, not a climb config, so most climbs have no
     // `/b` URL and popular configs have many. One climb, one canonical.
     //
-    // A noindex page gets NO `path` at all, so `createPageMetadata` emits no
-    // `alternates`. A canonical pointing from a noindex URL at an indexable
+    // A noindex page gets NO `path` at all, so `createBoardContentPageMetadata`
+    // returns early and emits no `alternates`. A canonical pointing from a noindex URL at an indexable
     // twin is a conflicting signal Google can resolve by propagating the
     // noindex — deindexing a public config-tuple climb page because one private
     // board happens to share its configuration.
@@ -91,7 +91,7 @@ export async function generateMetadata(props: BoardSlugViewPageProps): Promise<M
       ? undefined
       : buildCanonicalClimbViewUrl(boardDetails, canonicalAngle, parsedParams.climb_uuid, climbName);
 
-    return createPageMetadata({
+    return createBoardContentPageMetadata({
       title: t('metadata.view.title', { climbName, grade: climbGrade }),
       description: t('metadata.view.description', { climbName, grade: climbGrade, setter, quality, ascents }),
       path: canonicalPath,
@@ -101,7 +101,7 @@ export async function generateMetadata(props: BoardSlugViewPageProps): Promise<M
       robots: shouldNoindex ? { index: false, follow: true } : undefined,
     });
   } catch {
-    return createPageMetadata({
+    return createBoardContentPageMetadata({
       title: t('metadata.view.fallbackTitle'),
       description: t('metadata.view.fallbackDescription'),
       locale,

--- a/packages/web/app/lib/seo/metadata.ts
+++ b/packages/web/app/lib/seo/metadata.ts
@@ -135,6 +135,63 @@ export function createPageMetadata({
   };
 }
 
+/**
+ * Metadata for the board-content surfaces — climb view, climb list, setter — in
+ * BOTH route trees.
+ *
+ * These differ from every other page in one way that matters to a crawler: the
+ * locale twins are translated *chrome* over identical *content*. The climb name,
+ * grade, setter, ascent count and board art are identical in `/de`, `/es` and
+ * `/fr`; only UI strings differ. So the four URLs are one page, and saying
+ * otherwise cost us a 4x crawl surface.
+ *
+ * Measured 2026-08-27: ~205k climb-view renders/day with Postgres at 183/200
+ * connections (180 idle, 2 active), while 14 of the 18 climb URLs in a top-25
+ * sample carried a locale prefix. Disabling the climb sitemaps did not help,
+ * because the twins were never advertised from the sitemap — they were
+ * advertised by every page's own `hreflang` block, which hands a crawler three
+ * more URLs each time it fetches one.
+ *
+ * Two departures from `createPageMetadata`, and they only work as a pair:
+ *
+ * 1. **Canonical points at the default-locale URL**, not the served one.
+ * 2. **No `alternates.languages`.** Canonical alone would not have worked:
+ *    Googlebot must still fetch `/de/…` to read the canonical, and the
+ *    `hreflang` block would go on advertising the twins regardless. Google also
+ *    requires members of an `hreflang` cluster to self-canonicalise, so keeping
+ *    both ships a contradiction it resolves by ignoring the cluster.
+ *
+ * `og:locale` deliberately still names the SERVED locale — the page really is in
+ * German — while `og:url` follows the canonical, so sharing the German URL
+ * unfurls as the one page we want indexed.
+ *
+ * This is the exact behaviour `hreflang-return-metadata.test.ts` exists to
+ * prevent everywhere else, and that remains right everywhere else: `/about`,
+ * `/legal` and `/docs` are genuinely translated content, and cross-canonicalising
+ * those is the W-22 "no return links" bug. Board content is the carve-out, not
+ * the new default — which is why this is a separate function rather than a flag.
+ * The board route files call into metadata 19 times between them (fallback,
+ * notFound and redirect paths); a flag is one missed argument away from silently
+ * self-canonicalising again, while a missing import is not.
+ */
+export function createBoardContentPageMetadata(options: PageMetadataOptions): Metadata {
+  const metadata = createPageMetadata(options);
+  const basePath = normalizePath(options.path);
+  if (!basePath) {
+    return metadata;
+  }
+
+  // Via `localeHref` rather than `basePath` directly: same value today, and it
+  // stays correct if DEFAULT_LOCALE ever stops being the unprefixed one.
+  const canonical = localeHref(basePath, DEFAULT_LOCALE);
+
+  return {
+    ...metadata,
+    alternates: { canonical },
+    openGraph: metadata.openGraph ? { ...metadata.openGraph, url: canonical } : metadata.openGraph,
+  };
+}
+
 export function createNoIndexMetadata(options: Omit<PageMetadataOptions, 'robots'>): Metadata {
   return createPageMetadata({
     ...options,

--- a/packages/web/app/lib/seo/sitemap/entries.ts
+++ b/packages/web/app/lib/seo/sitemap/entries.ts
@@ -81,15 +81,17 @@ export function allLocalesUrlCount(items: readonly SitemapItem[]): number {
  * Vercel's 4.5 MB response ceiling. Do not "fix" the inconsistency by fanning
  * climbs out.
  *
- * Dropping the sitemap-side hreflang costs nothing: `createPageMetadata` already
- * emits `alternates.languages` for en-US/es/fr/de/x-default on both climb-view
- * trees, so every locale twin carries reciprocal HTML annotations — one of
- * Google's three supported hreflang methods, and the one that is symmetric by
- * construction. A partial sitemap-side annotation would be a second,
- * non-reciprocal signal for the same cluster: strictly worse than none.
+ * The original justification for dropping the sitemap-side hreflang was that
+ * `createPageMetadata` emitted `alternates.languages` on both climb-view trees,
+ * so the twins carried reciprocal HTML annotations instead. That is no longer
+ * why. Board content now goes through `createBoardContentPageMetadata`, which
+ * cross-canonicalises the twins onto the default locale and emits **no**
+ * `languages` at all — the twins are not separate pages, so there is no cluster
+ * to annotate and nothing for the sitemap to list.
  *
- * Nothing is noindexed. `/es`, `/fr` and `/de` climb pages stay indexable and
- * link-discovered — the same treatment `/profile/[user_id]` already gets.
+ * Still nothing is noindexed: `/es`, `/fr` and `/de` climb pages render and stay
+ * reachable through the language switcher. They are simply no longer advertised
+ * as independently indexable, which is what a 4x crawl surface was buying us.
  */
 export function expandDefaultLocaleOnly(items: readonly SitemapItem[]): SitemapUrlEntry[] {
   return items.map((item) => ({

--- a/packages/web/app/lib/seo/sitemap/shard-registry.ts
+++ b/packages/web/app/lib/seo/sitemap/shard-registry.ts
@@ -44,6 +44,20 @@ export type SitemapShard = {
    * closed there would take the whole index down because nobody shared a list.
    */
   expectsUrls: boolean;
+  /**
+   * How this shard's items become `<url>` entries. Defaults to `all-locales`,
+   * which is W-22's original behaviour and stays right for `static`: `/about`,
+   * `/legal` and `/docs` are genuinely translated content, so each locale is its
+   * own indexable page and belongs in the sitemap.
+   *
+   * `default-locale-only` is for shards whose pages cross-canonicalise to the
+   * default locale via `createBoardContentPageMetadata` — board content is
+   * translated chrome over identical data, so the twins are not separate pages.
+   * Listing a URL whose own canonical points elsewhere is a contradiction:
+   * the sitemap says "index `/de/…`" while the page says "the canonical is
+   * `/…`". Keep the two in step.
+   */
+  expansion?: ShardExpansion;
 };
 
 /**
@@ -57,10 +71,22 @@ export const SHARD_REGISTRY: readonly SitemapShard[] = [
     id: 'boards',
     path: '/sitemaps/boards.xml',
     expectsUrls: true,
+    // Board list pages cross-canonicalise to the default locale, so the twins
+    // must not be listed. This shard was 2,780 URLs of which 2,085 were locale
+    // twins; it is ~695 now.
+    expansion: 'default-locale-only',
     build: async () => boardConfigsToItems(await getAllBoardConfigsOrThrow()),
   },
   { id: 'gyms', path: '/sitemaps/gyms.xml', expectsUrls: false, build: async () => buildGymEntries() },
-  { id: 'setters', path: '/sitemaps/setters.xml', expectsUrls: false, build: async () => buildSetterEntries() },
+  {
+    id: 'setters',
+    path: '/sitemaps/setters.xml',
+    expectsUrls: false,
+    // Setter pages cross-canonicalise too. Declared-empty today, so this is
+    // inert — set now so a future population cannot reintroduce the twins.
+    expansion: 'default-locale-only',
+    build: async () => buildSetterEntries(),
+  },
   {
     id: 'playlists',
     path: '/sitemaps/playlists.xml',
@@ -229,7 +255,7 @@ export async function shardRouteHandler(id: ShardId): Promise<Response> {
       throw emptiness;
     }
 
-    const urls = expandAllLocales(items);
+    const urls = expandForShard(items, shard.expansion ?? 'all-locales');
     const overBudget = overBudgetError(shard, urls.length);
     if (overBudget) {
       throw overBudget;
@@ -352,6 +378,16 @@ export const PAGED_SHARD_REGISTRY: readonly PagedSitemapShard[] = [
 /** A future paged shard is published unless it explicitly opts into a gate. */
 export function pagedSitemapShardEnabled(shard: Pick<PagedSitemapShard, 'enabled'>): boolean {
   return shard.enabled?.() ?? true;
+}
+
+/**
+ * How many `<url>` entries `expandForShard` would produce, without building them.
+ * Kept immediately beside it so the two cannot drift — the index runs this on a
+ * `force-dynamic` route and would otherwise materialise up to 45,000 entries
+ * just to read `.length`. A unit test pins the pair.
+ */
+function expandedUrlCountForShard(items: readonly SitemapItem[], expansion: ShardExpansion): number {
+  return expansion === 'all-locales' ? allLocalesUrlCount(items) : items.length;
 }
 
 function expandForShard(items: readonly SitemapItem[], expansion: ShardExpansion): SitemapUrlEntry[] {
@@ -544,7 +580,7 @@ async function buildIndexEntry(shard: SitemapShard): Promise<SitemapIndexEntry |
     return null;
   }
 
-  const overBudget = overBudgetError(shard, allLocalesUrlCount(items));
+  const overBudget = overBudgetError(shard, expandedUrlCountForShard(items, shard.expansion ?? 'all-locales'));
   if (overBudget) {
     throw overBudget;
   }

--- a/packages/web/app/setter/[setter_username]/page.tsx
+++ b/packages/web/app/setter/[setter_username]/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 import SetterProfileContent from './setter-profile-content';
 import styles from '@/app/components/ui/page-container.module.css';
 import { buildVersionedOgImagePath } from '@/app/lib/seo/og';
-import { createNoIndexMetadata, createPageMetadata } from '@/app/lib/seo/metadata';
+import { createBoardContentPageMetadata, createNoIndexMetadata } from '@/app/lib/seo/metadata';
 import { getSetterOgSummary } from '@/app/lib/seo/dynamic-og-data';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { getLocale } from '@/app/lib/i18n/get-locale';
@@ -27,7 +27,7 @@ export async function generateMetadata({
     const summary = await getSetterOgSummary(username);
     const displayName = summary.displayName;
 
-    return createPageMetadata({
+    return createBoardContentPageMetadata({
       title: t('metadata.setter.title', { name: displayName }),
       description: t('metadata.setter.description', { name: displayName }),
       path,


### PR DESCRIPTION
## Summary

Disabling the climb sitemaps (`410 Gone`) did not reduce load, because the sitemap was never what advertised the locale twins — **every climb page advertised its own three**, and each twin self-canonicalised:

```html
<link rel="alternate" hrefLang="es" href="…/es/kilter/…/view/microgreens-…"/>
<link rel="alternate" hrefLang="fr" href="…/fr/kilter/…/view/microgreens-…"/>
<link rel="alternate" hrefLang="de" href="…/de/kilter/…/view/microgreens-…"/>
```

`/de/…` canonicalised to `/de/…`, so the four URLs were four independent indexable pages rather than one page in four languages. Every crawl of one climb handed the crawler three more URLs that did the same.

Measured on production 2026-08-27: **~205k climb-view renders/day**, Postgres at **183/200 connections (180 idle, 2 active)** with users hitting `sorry, too many clients already`, and **14 of the 18 climb URLs** in a 30-minute top-25 sample carrying a locale prefix — ~78%, right at the 3-in-4 you would predict.

These pages are translated *chrome* over *identical* content: the climb name, grade, setter, ascent count and board art are the same in every locale; only UI strings differ. So this says so.

## The change

**`createBoardContentPageMetadata()`** (`app/lib/seo/metadata.ts`) — canonical points at the default-locale URL regardless of the served locale, and `alternates.languages` is omitted.

Both halves are required and only work as a pair. Canonical alone would not have done it: Googlebot must still fetch `/de/…` to read the canonical, and the `hreflang` block would go on advertising the twins regardless. Google also requires `hreflang` cluster members to self-canonicalise, so keeping both ships a contradiction it resolves by ignoring the cluster.

`og:locale` still names the **served** locale — the page really is in German — while `og:url` follows the canonical, so sharing a German URL unfurls as the page we want indexed.

Applied to five surfaces, both route trees: config-tuple climb view + list, `/b/{slug}` view + list, and setter.

**A separate function rather than a flag**, because those files call into metadata **19 times between them** (fallback, notFound and redirect paths). A flag is one missed argument away from silently self-canonicalising again; a missing import is not, and is checkable.

## Keeping the sitemap in step

`sitemap-xml.ts` emits every item once per locale. Live `boards.xml` was **2,780 URLs, 2,085 of them locale twins** — advertising URLs whose own canonical now points elsewhere, which is a contradiction Google resolves by ignoring one of the two signals.

No new code: `ShardExpansion` already had `'default-locale-only'` and `expandDefaultLocaleOnly()`, which the climb shards use. The `boards` shard flips to it (~695 URLs now), and `setters` too — inert today since that shard is declared-empty, set now so a future population cannot reintroduce the twins.

`static.xml` deliberately stays on `all-locales`: `/about`, `/legal` and `/docs` are genuinely translated content.

Two things this surfaced that had to be fixed rather than left:

- **The budget guard would have over-counted.** `buildIndexEntry` used `allLocalesUrlCount` (`items.length × 4`) for every shard. On a `default-locale-only` shard that is 4× the truth, and it gates a **503** — so a healthy shard could have been withheld from the index. Now `expandedUrlCountForShard`, kept immediately beside `expandForShard` so the two cannot drift.
- **A doc comment that became actively misleading.** `expandDefaultLocaleOnly`'s comment justified the climb shards on the grounds that *"`createPageMetadata` already emits `alternates.languages` … so every locale twin carries reciprocal HTML annotations"* — precisely what this PR removes. Rewritten to the real reason.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.
2. Load a climb page; board art and grade render as before.
3. Switch language to Deutsch; the page still renders in German.

## Risk

Risk: 3/5 — metadata only, no UI or data change, and the full web suite (4,331 tests) is green with a mutation-tested guard on both halves. The 3 is because it alters how Google indexes the highest-traffic pages, and that feedback loop is weeks long, so a mistake is slow to spot. Reverting restores the old tags immediately; any deindexing of `/de` `/es` `/fr` climb twins is intended and recoverable by reverting.

## How this was verified

- `vp test run --project web` — full suite green.
- `vp run typecheck:web` — clean (`tsc --noEmit` 0 errors).
- New `app/__tests__/board-content-metadata-guard.test.ts` (13 tests) pins **both halves of the coupling**, which neither file makes visible from the other: every board route file uses the board-content helper and none reaches for the plain one, and the shards for those pages list one locale only. It reads the shard registry as **source** rather than importing it — the registry is `server-only` and pulls in the board-config query, so importing it would need a `DATABASE_URL`, and a guard over a config shape should not need a database.
- It guards itself: one test asserts all five route files actually read, so a bad path cannot make the rest vacuous, and a counter-assertion pins `static` still fanning out to every locale.
- **Mutation-tested both halves.** Reverting one route file to `createPageMetadata` → 2 failures. Removing the `boards` shard's `expansion` → 1 failure.
- `app/__tests__/hreflang-return-metadata.test.ts` — this is the test that exists to *prevent* cross-canonicalisation (W-22, the Search Console "no return links" failure). Setter moved into an explicit carve-out asserting the **new** contract, with the reasoning recorded, so the next reader sees a decision rather than an erosion. Playlists and session shares keep the original rule.
- Behavioural assertion added to the `/b` view metadata test, so the rendered output is pinned and not just the import.
- `climb-canonical-parity.test.ts` passes **untouched** — A1 is the *tree* dimension, this is the *locale* dimension, and they are orthogonal.

### After deploy

```bash
CLIMB=/kilter/original/12x12-square/screw_bolt/35/view/microgreens-BA78B9CA75194B01B1BD55A0A1CF821A
curl -s "https://www.boardsesh.com/de$CLIMB" | grep -oE '<link rel="(canonical|alternate)"[^>]*>'
# expect: one canonical, pointing at the ENGLISH url; no alternates
curl -s https://www.boardsesh.com/sitemaps/boards.xml | grep -c 'boardsesh.com/\(de\|es\|fr\)/'   # expect 0
```

The German twin must still **render** and stay reachable via the language switcher — the goal is one *indexed* page, not one reachable page.

## What this will not do

**This is not near-term relief, and should not be mistaken for it.** Crawl reduction follows Google's recrawl cycle — weeks — because it has to re-fetch each twin to see the new canonical before it stops. The near-term levers are the ones already in flight: #4962's rate limit (log-only, so mitigating nothing yet) and the PgBouncer cutover, which is what actually addresses 180 idle connections against a 200 ceiling.

What this does is stop the problem regenerating. Without it the crawl surface stays 4× larger than the content justifies, and the rate limit spends its budget throttling requests for pages we should not have been advertising.

Track it in Search Console (indexed-page count for `/de`, `/es`, `/fr` should fall) and via `get_runtime_logs since=6h group_by=route source=["serverless"]` over weeks. Derive daily rates from a 6 h or 30 min window — `since: 24h` is silently truncated and under-reports ~2×.

## Known gap, deliberately not fixed here

The setter **fallback** path uses `createNoIndexMetadata`, which still routes through the plain helper *and* passes `path` — so a noindex error page still advertises three locale twins. Low volume (it is the catch branch), and whether `createNoIndexMetadata` should emit `hreflang` at all is a separate question affecting every noindex page, so it is called out rather than widened into here.

Part of #4650 / epic #4648. Refs #4802.
