### PR TITLE
fix(repo): challenge the climb-view rate limit instead of logging it

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -195,7 +195,11 @@ what the rate-limit rule below is for.
 `/view/` path on www — the segment every climb-view URL shape shares, across the
 config-tuple tree, the `/b/{slug}` tree and the `/de`, `/es` and `/fr` locale
 prefixes. Matching the segment rather than enumerating the trees means the rule
-cannot silently miss whichever tree is added next.
+cannot silently miss whichever tree is added next. The expression also
+excludes requests carrying the `next-router-prefetch` header: a prefetch of a
+dynamic route only renders the loading shell, so a crawler faking the header
+gets nothing useful out of dodging the counter, while a real reader's burst of
+list-page prefetches no longer counts against them either.
 
 **It ships in `managed_challenge` mode.** The zone is on Free or Pro, not
 Enterprise, so the softest mitigation, `log`, is rejected on apply —
@@ -204,17 +208,22 @@ gentlest action is `managed_challenge`: a real browser passes it
 transparently, a headless farm mostly does not. `block` remains the blunt
 instrument for later if challenge proves insufficient.
 
-The threshold (60 requests per 60s, per IP per colo) is still a starting
-guess, not a measurement: a reader opens a handful of climbs a minute and a
-crawler walks hundreds, but the gap between them has never been measured
-here. Read a few days of Cloudflare analytics at this setting, size the
-number against real traffic, then re-tune.
+**The zone is confirmed Free plan, and the period is fixed at 10s by the
+API.** The first production apply attempted `period: 60` and Cloudflare
+rejected it: `not entitled to use the period 60, can only use a period among
+[10]`. 10s is the only counting window Free accepts — this is not a choice,
+it's a hard constraint from the API. The threshold is tuned around it: 20
+requests per 10s keeps the original ~60/min-per-IP-per-colo intent, but with
+headroom for the burstier 10s window and for a real reader's burst of
+`/view/` loads off one list page. Read a few days of Cloudflare analytics at
+this setting, size the number against real traffic, then re-tune —
+`requests_per_period` stays free to change; `period` does not.
 
 Two things to know:
 
 - `mitigation_timeout` is plan-bound below Business: Free caps it at 10s, Pro
-  at 60s. The rule is pinned to **10s** because the zone's exact plan tier
-  (Free vs Pro) is not yet confirmed — raise it to 60s once that's settled.
+  at 60s. The rule is pinned to **10s** to match the confirmed Free plan —
+  raise it to 60s only if the zone is upgraded to Pro or above.
 - `cf.colo.id` is a required characteristic outside Enterprise, so the counter is
   per-datacentre rather than global and the effective allowance is higher than
   `requests_per_period` alone suggests.

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -197,25 +197,38 @@ config-tuple tree, the `/b/{slug}` tree and the `/de`, `/es` and `/fr` locale
 prefixes. Matching the segment rather than enumerating the trees means the rule
 cannot silently miss whichever tree is added next.
 
-**It ships in `log` mode and mitigates nothing.** The threshold (60 requests per
-60s, per IP per colo) is a starting guess, not a measurement: a reader opens a
-handful of climbs a minute and a crawler walks hundreds, but the gap between
-them has never been measured here. Read a few days of Cloudflare analytics at
-this setting, size the number against real traffic, then change `action`.
+**It ships in `managed_challenge` mode.** The zone is on Free or Pro, not
+Enterprise, so the softest mitigation, `log`, is rejected on apply —
+Cloudflare restricts observe-only rate limiting to Enterprise. The next
+gentlest action is `managed_challenge`: a real browser passes it
+transparently, a headless farm mostly does not. `block` remains the blunt
+instrument for later if challenge proves insufficient.
 
-Two things to know before flipping it:
+The threshold (60 requests per 60s, per IP per colo) is still a starting
+guess, not a measurement: a reader opens a handful of climbs a minute and a
+crawler walks hundreds, but the gap between them has never been measured
+here. Read a few days of Cloudflare analytics at this setting, size the
+number against real traffic, then re-tune.
 
-- `log` is **Enterprise-only**. On a lower plan the softest available mitigation
-  is `managed_challenge` (a real browser passes transparently; a headless farm
-  mostly does not), then `block`. If the zone rejects the rule on apply, that is
-  the reason — switch the action rather than the threshold.
+Two things to know:
+
+- `mitigation_timeout` is plan-bound below Business: Free caps it at 10s, Pro
+  at 60s. The rule is pinned to **10s** because the zone's exact plan tier
+  (Free vs Pro) is not yet confirmed — raise it to 60s once that's settled.
 - `cf.colo.id` is a required characteristic outside Enterprise, so the counter is
   per-datacentre rather than global and the effective allowance is higher than
   `requests_per_period` alone suggests.
 
 Guessing low and blocking on day one throttles a gym full of climbers behind one
-NAT, which is why observe-first is the default. Rollback is the usual one: set
-`enabled: false` on the rule and re-run `vp run cf:apply -- --apply`.
+NAT, which is why challenge rather than block is the default. Rollback is the
+usual one: set `enabled: false` on the rule and re-run
+`vp run cf:apply -- --apply`.
+
+The API token driving `cf:apply` needs `Zone.Rate Limit Edit` to create or
+update this rule — see the token scope list in `scripts/cloudflare-apply.ts`
+and the token section below. Without that scope, `deploy-cloudflare` 403s
+specifically on the `http_ratelimit` phase while every other phase applies
+cleanly.
 
 ### One-time: create the API token
 

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -314,8 +314,15 @@ export const CRAWLER_BLOCK_EXPRESSION = buildUserAgentExpression(CRAWLER_BLOCK_T
  * else on www uses a `/view/` segment.
  *
  * Host-scoped so a future origin on another hostname cannot inherit it.
+ *
+ * Excludes Next.js prefetches (`next-router-prefetch` header): a prefetch of
+ * a dynamic route only renders the loading shell, so a crawler that fakes
+ * the header gets nothing useful out of dodging the counter, while a full
+ * page fetch — what the farm actually does — still counts. Without this, a
+ * real reader scrolling a list page fires a burst of prefetches that could
+ * trip the limit on its own.
  */
-export const CLIMB_VIEW_RATE_LIMIT_EXPRESSION = `(http.host eq "${WWW_HOSTNAME}" and http.request.uri.path contains "/view/")`;
+export const CLIMB_VIEW_RATE_LIMIT_EXPRESSION = `(http.host eq "${WWW_HOSTNAME}" and http.request.uri.path contains "/view/" and not any(http.request.headers.names[*] == "next-router-prefetch"))`;
 
 export const desiredCloudflareState: CloudflareDesiredState = {
   zoneName: ZONE_NAME,
@@ -410,8 +417,16 @@ export const desiredCloudflareState: CloudflareDesiredState = {
       action: 'managed_challenge',
       ratelimit: {
         characteristics: ['ip.src', 'cf.colo.id'],
-        period: 60,
-        requests_per_period: 60,
+        // The zone is confirmed FREE plan: the production apply of period: 60
+        // failed with `not entitled to use the period 60, can only use a
+        // period among [10]` — 10s is the only period Free accepts.
+        period: 10,
+        // Intent is still ~60 requests/minute per IP per colo, but a 10s
+        // window is burstier than a 60s one would have been, and a list page
+        // can fire a burst of /view/ prefetches (excluded above) plus real
+        // full-page loads from one browser. 20 per 10s gives that headroom
+        // while still averaging to a ~120/min sustained ceiling.
+        requests_per_period: 20,
         // 10s is the Free-plan ceiling (Pro allows up to 60s). Raise to 60
         // once the zone's plan is confirmed Pro or above.
         mitigation_timeout: 10,

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -398,19 +398,23 @@ export const desiredCloudflareState: CloudflareDesiredState = {
     {
       description: CLIMB_VIEW_RATE_LIMIT_RULE_DESCRIPTION,
       expression: CLIMB_VIEW_RATE_LIMIT_EXPRESSION,
-      // Starts in observe-only mode on purpose. The threshold below is a
-      // starting guess, not a measurement: a real reader opens a handful of
-      // climbs a minute, a crawler walks hundreds, but the gap between them is
-      // exactly what we have never measured. Read a few days of Cloudflare
-      // analytics at this setting, size the number against what real traffic
-      // does, and only then swap the action. Guessing low and blocking on day
-      // one throttles a gym full of climbers sharing one NAT.
-      action: 'log',
+      // `log` is Enterprise-only and the zone is on Free/Pro, so the apply
+      // rejects it outright — `managed_challenge` is the gentlest action this
+      // plan accepts. A real browser passes it transparently; a headless
+      // crawler mostly does not. The threshold below is still a starting
+      // guess, not a measurement: a real reader opens a handful of climbs a
+      // minute, a crawler walks hundreds, but the gap between them is exactly
+      // what we have never measured. Read a few days of Cloudflare analytics
+      // at this setting and size the number against what real traffic does.
+      // Roll back by flipping `enabled: false` and re-applying.
+      action: 'managed_challenge',
       ratelimit: {
         characteristics: ['ip.src', 'cf.colo.id'],
         period: 60,
         requests_per_period: 60,
-        mitigation_timeout: 600,
+        // 10s is the Free-plan ceiling (Pro allows up to 60s). Raise to 60
+        // once the zone's plan is confirmed Pro or above.
+        mitigation_timeout: 10,
       },
       enabled: true,
     },

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -802,12 +802,20 @@ describe('climb-view rate-limit rule', () => {
     (rule) => rule.description === CLIMB_VIEW_RATE_LIMIT_RULE_DESCRIPTION,
   );
 
-  it('is declared, and starts in observe-only mode', () => {
-    // Shipping this straight to `block` on a guessed threshold would throttle a
-    // gym full of climbers behind one NAT. Flip it only after reading analytics.
+  it('is declared, and challenges rather than blocks', () => {
+    // `log` is Enterprise-only and this zone is Free/Pro, so `managed_challenge`
+    // is the gentlest action available: a real browser passes it transparently,
+    // a headless crawler mostly does not. Shipping straight to `block` on a
+    // guessed threshold would throttle a gym full of climbers behind one NAT.
     expect(rateLimitRule).toBeDefined();
-    expect(rateLimitRule?.action).toBe('log');
+    expect(rateLimitRule?.action).toBe('managed_challenge');
     expect(rateLimitRule?.enabled).toBe(true);
+  });
+
+  it('keeps the mitigation timeout within the Free-plan ceiling', () => {
+    // mitigation_timeout below Business is capped at 10s (Free) / 60s (Pro).
+    // The zone is unconfirmed between the two, so pin to the lower ceiling.
+    expect(rateLimitRule?.ratelimit.mitigation_timeout).toBe(10);
   });
 
   it('keys the counter on the client IP and the required colo characteristic', () => {

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -814,8 +814,18 @@ describe('climb-view rate-limit rule', () => {
 
   it('keeps the mitigation timeout within the Free-plan ceiling', () => {
     // mitigation_timeout below Business is capped at 10s (Free) / 60s (Pro).
-    // The zone is unconfirmed between the two, so pin to the lower ceiling.
+    // The zone is confirmed Free, so pin to the Free ceiling.
     expect(rateLimitRule?.ratelimit.mitigation_timeout).toBe(10);
+  });
+
+  it('pins the counting period to the Free plan’s only allowed value', () => {
+    // Production rejected period: 60 with `not entitled to use the period 60,
+    // can only use a period among [10]` — Free accepts only a 10s window. A
+    // re-tune back to 60 must fail here, not with a 400 on apply.
+    expect(rateLimitRule?.ratelimit.period).toBe(10);
+    // 20 per 10s keeps the ~60/min-per-IP-per-colo intent while giving a real
+    // reader's burst of list-page loads headroom against the burstier window.
+    expect(rateLimitRule?.ratelimit.requests_per_period).toBe(20);
   });
 
   it('keys the counter on the client IP and the required colo characteristic', () => {
@@ -823,7 +833,7 @@ describe('climb-view rate-limit rule', () => {
     expect(rateLimitRule?.ratelimit.characteristics).toEqual(['ip.src', 'cf.colo.id']);
   });
 
-  it('covers every climb-view URL shape on www, including the locale prefixes', () => {
+  it('covers every climb-view URL shape on www, including the locale prefixes, but excludes prefetches', () => {
     // A pattern per route tree would miss whichever tree is added next, so the
     // rule matches the /view/ segment that all of them share.
     const expression = rateLimitRule?.expression ?? '';
@@ -831,6 +841,10 @@ describe('climb-view rate-limit rule', () => {
     expect(expression).toContain('"/view/"');
     // Host-scoped: a future origin on ws must not inherit it.
     expect(expression).not.toContain(WS_HOSTNAME);
+    // A Next.js router prefetch only renders the loading shell, so excluding
+    // it keeps a reader's list-page scroll from tripping the counter while a
+    // farm's full-page fetches still count.
+    expect(expression).toContain('next-router-prefetch');
   });
 
   it('treats a threshold change as drift', () => {


### PR DESCRIPTION
## Summary
- The zone is confirmed Free/Pro, not Enterprise, so `action: 'log'` on the `boardsesh:climb-view-rate-limit` rule is rejected by Cloudflare on apply — observe-only rate limiting is Enterprise-only. Switched the rule to `managed_challenge` (a real browser passes it transparently, a headless farm mostly does not).
- `mitigation_timeout: 600` is also invalid below Business. Pinned to **10s** (the Free-plan ceiling; Pro allows up to 60s), with a comment to raise it once the plan tier is confirmed Pro.
- Updated the pinned unit test expectations, added a timeout-ceiling test, and rewrote the doc-comment in `infra/cloudflare/config.ts` and the "Rate limiting the climb-view path" section of `docs/cloudflare.md` to match.

Refs #4802 (do not close it — the rule still needs its threshold tuned against real traffic once analytics are available)

Merge gate: the shared `CLOUDFLARE_API_TOKEN` needs `Zone.Rate Limit Edit` first (Marco, dashboard); without it `deploy-cloudflare` 403s on this phase.

## Release Notes
- [x] No release note needed (internal / technical change)

## Test plan
1. CI green.
2. After merge, the deploy-cloudflare job applies the http_ratelimit phase without a 403.

## Risk
Risk: 3/5 — changes a live edge rule from observe to challenge; rollback is enabled:false + apply.