### PR TITLE
feat(db): add guarded production task roles

### DIFF
--- a/.github/workflows/postgres-secure-network.yml
+++ b/.github/workflows/postgres-secure-network.yml
@@ -8,6 +8,10 @@ on:
       - '.github/actions/connect-production-db/action.yml'
       - '.github/workflows/postgres-secure-network.yml'
       - 'scripts/postgres-secure-network-contract.test.ts'
+      - 'scripts/production-db-task-roles-contract.test.ts'
+      - 'scripts/production-db-task-roles-smoke.sh'
+      - 'scripts/production-db-task-roles.mjs'
+      - 'scripts/lib/production-db-task-role-contract.mjs'
       - 'scripts/validate-production-db-network-url.mjs'
       - 'vite.config.ts'
   push:
@@ -55,7 +59,14 @@ jobs:
         run: go vet ./...
 
       - name: Check workflow and policy contracts
-        run: vp test run --project scripts scripts/postgres-secure-network-contract.test.ts --reporter=agent
+        run: >-
+          vp test run --project scripts
+          scripts/postgres-secure-network-contract.test.ts
+          scripts/production-db-task-roles-contract.test.ts
+          --reporter=agent
+
+      - name: Smoke exact task roles on disposable PostgreSQL 18
+        run: bash scripts/production-db-task-roles-smoke.sh
 
       - name: Build the non-root image
         run: docker build --file deploy/postgres-tailscale-forwarder/Dockerfile deploy/postgres-tailscale-forwarder

--- a/.github/workflows/postgres-secure-network.yml
+++ b/.github/workflows/postgres-secure-network.yml
@@ -12,6 +12,7 @@ on:
       - 'scripts/production-db-task-roles-smoke.sh'
       - 'scripts/production-db-task-roles.mjs'
       - 'scripts/lib/production-db-task-role-contract.mjs'
+      - 'scripts/lib/production-db-task-role-sql.mjs'
       - 'scripts/validate-production-db-network-url.mjs'
       - 'vite.config.ts'
   push:

--- a/docs/postgres-secure-network.md
+++ b/docs/postgres-secure-network.md
@@ -125,16 +125,18 @@ references.
 | Secret | `TS_AUDIENCE` | Federated identity audience |
 | Variable | `POSTGRES_FORWARDER_HOST` | Full `boardsesh-db-forwarder.<tailnet>.ts.net` MagicDNS name |
 
-Use a different SCRAM URL and exact login role for every trust surface:
+Use a different SCRAM URL and exact login role for every trust surface. The
+`application_name` is part of the URL contract as well as a per-database role
+default, so an unexpected job is visible in `pg_stat_activity`.
 
-| Workflow | Protected secret | Required login role |
-| --- | --- | --- |
-| Production migration | `MIGRATION_DATABASE_DIRECT_URL` | `boardsesh_migrator` |
-| Snapshot export | `SNAPSHOT_DATABASE_DIRECT_URL` | `boardsesh_snapshot_exporter` |
-| Climb grades | `CLIMB_GRADES_DATABASE_DIRECT_URL` | `boardsesh_climb_grades_refresh` |
-| Content model | `CONTENT_MODEL_DATABASE_DIRECT_URL` | `boardsesh_content_model_refresh` |
-| Hold features | `HOLD_FEATURES_DATABASE_DIRECT_URL` | `boardsesh_hold_features_refresh` |
-| Recommendations | `RECOMMENDATIONS_DATABASE_DIRECT_URL` | `boardsesh_recommendations_refresh` |
+| Workflow | Protected secret | Required login role | `application_name` | Connection limit |
+| --- | --- | --- | --- | --- |
+| Production migration | `MIGRATION_DATABASE_DIRECT_URL` | `boardsesh_migrator` | `boardsesh-ci-migrate` | 2 |
+| Snapshot export | `SNAPSHOT_DATABASE_DIRECT_URL` | `boardsesh_snapshot_exporter` | `boardsesh-ci-snapshot-export` | 10 |
+| Climb grades | `CLIMB_GRADES_DATABASE_DIRECT_URL` | `boardsesh_climb_grades_refresh` | `boardsesh-ci-climb-grades` | 2 |
+| Content model | `CONTENT_MODEL_DATABASE_DIRECT_URL` | `boardsesh_content_model_refresh` | `boardsesh-ci-content-model` | 2 |
+| Hold features | `HOLD_FEATURES_DATABASE_DIRECT_URL` | `boardsesh_hold_features_refresh` | `boardsesh-ci-hold-features` | 2 |
+| Recommendations | `RECOMMENDATIONS_DATABASE_DIRECT_URL` | `boardsesh_recommendations_refresh` | `boardsesh-ci-recommendations` | 2 |
 
 Every role must be a login with `NOSUPERUSER`, `NOCREATEDB`, `NOCREATEROLE`,
 `NOREPLICATION`, and `NOBYPASSRLS`; own no schema or table; and have only the
@@ -143,6 +145,122 @@ role is read-only. The migrator retains only the separately audited `SET ROLE`
 path documented in `docs/postgres-18-migration.md`. Verify `current_user`, role
 attributes, memberships, owned objects, and effective privileges with each
 stored credential before enabling its workflow.
+
+### Guarded task-role provisioning
+
+`scripts/production-db-task-roles.mjs` is the reviewed manifest, diff, apply,
+audit, and rollback path for these six roles. It does not call Railway,
+Tailscale, or GitHub and is not run automatically. It accepts only a command on
+argv. Administrator and generated credentials enter through the environment or
+a protected file, and neither URLs nor passwords are printed.
+
+The manifest grants relation-level privileges proven by the checked-in workflow
+queries:
+
+- `boardsesh_migrator`: no direct schema or relation privileges; `SET TRUE`,
+  `INHERIT FALSE`, and `ADMIN FALSE` membership in the existing restricted
+  `boardsesh_owner` role only.
+- `boardsesh_snapshot_exporter`: `SELECT` on `board_climbs`,
+  `board_climb_stats`, `board_climb_grades`, and every table in
+  `CATALOG_SNAPSHOT_TABLES`. It has `default_transaction_read_only=on` and must
+  use the primary, not a replica, because of snapshot cursor ordering. Its
+  connection limit matches the exporter's checked-in pool maximum of 10.
+- `boardsesh_climb_grades_refresh`: `SELECT` on its climb, tick, alias, history,
+  board, and embedding inputs; write access only to `board_grade_coefficients`
+  and `board_climb_grades`; `TEMPORARY` only for the refresh key table.
+- `boardsesh_content_model_refresh`: `SELECT` on its hold/climb/placement
+  training inputs; write access only to `board_climb_embeddings` and
+  `board_climb_similar`.
+- `boardsesh_hold_features_refresh`: `SELECT` on geometry and climb inputs;
+  `INSERT` on the reserved system user; and upsert access only to
+  `board_hold_features` and `user_hold_classifications`. PostgreSQL upserts need
+  `SELECT` as well as `INSERT/UPDATE` on those two targets.
+- `boardsesh_recommendations_refresh`: `SELECT` on climb and stats inputs;
+  relation-level writes only to the generated setter/send stats, generated
+  playlists, ownership/climbs, weekly history/cursor, reserved system user, and
+  the playlist-delete trigger's `sync_deletions` target.
+
+For an `INSERT` target backed by an owned sequence, the tool derives and grants
+only `USAGE` on that sequence. It grants no default privileges, grant options,
+routine execution, object ownership, role creation, replication, or RLS bypass.
+The audit covers direct database, schema, relation, sequence, column, routine,
+type, large-object, parameter, language, foreign-data, server, tablespace, and
+default-ACL privileges. Any unexpected ownership, membership, default ACL, or
+grant option, plus any RLS policy naming a managed role, stops apply for manual
+review.
+
+Generate credentials once in an operator-only directory outside the repository.
+The destination must not already exist and is created mode `0600`:
+
+```sh
+install -d -m 700 /secure/operator/boardsesh-db-rollout
+export ROLE_CREDENTIALS_FILE=/secure/operator/boardsesh-db-rollout/task-roles.json
+export POSTGRES_FORWARDER_HOST=boardsesh-db-forwarder.example-tailnet.ts.net
+node scripts/production-db-task-roles.mjs generate
+```
+
+Keep the file out of shell history, CI artifacts, issue attachments, and chat.
+Transfer each `databaseUrl` to its matching protected `Production` environment
+secret through the GitHub UI or a secret-manager integration that reads the
+value from stdin. Never pass a URL to a CLI argument. Retain the file in the
+approved password manager only for the rollout and credential-revocation
+window.
+
+Before changing a database, enter the administrator URL with terminal echo
+disabled. The tool requires the exact `railway` database, `sslmode=require` for
+the sole URL query parameter, the exact `POSTGRES_FORWARDER_HOST` on port 5432,
+the pre-existing restricted `boardsesh_owner`, and a PostgreSQL superuser so
+every possible direct ACL can be inspected and reconciled in one transaction.
+This makes the forwarder's PostGIS-only target validation part of the database
+guard and prevents accidentally provisioning the separate OTA `Postgres`
+service:
+
+```sh
+export POSTGRES_FORWARDER_HOST=boardsesh-db-forwarder.example-tailnet.ts.net
+read -rsp 'PostGIS - PROD admin URL: ' ADMIN_DATABASE_URL
+printf '\n'
+export ADMIN_DATABASE_URL
+node scripts/production-db-task-roles.mjs plan
+```
+
+Review and retain the sorted `[task-role-diff]` output as the before-state. It
+contains object names and privilege types, never credentials. Apply has a
+second explicit guard, uses a transaction-level advisory lock, rotates all six
+passwords to client-built SCRAM verifiers, prints its pre-apply diff, and fails
+unless the post-apply diff is empty:
+
+```sh
+export APPLY_TASK_ROLE_CHANGES=APPLY_EXACT_SIX_TASK_ROLES
+node scripts/production-db-task-roles.mjs apply
+unset APPLY_TASK_ROLE_CHANGES
+node scripts/production-db-task-roles.mjs audit
+unset ADMIN_DATABASE_URL ROLE_CREDENTIALS_FILE POSTGRES_FORWARDER_HOST
+```
+
+Do not run `apply` until the foundation is merged, the grant diff is reviewed,
+and a rollback owner is named. This repository change itself does not execute
+any command above against production.
+
+Rollback is deliberately narrower than `DROP OWNED`: it refuses partial or
+drifted roles, active sessions, unexpected membership, default ACLs, grant
+options, or owned objects. First disable the six workflows and revoke their
+GitHub secrets. Then obtain a fresh hidden administrator URL, run `audit`, and
+only after the empty diff proves the exact managed state:
+
+```sh
+export POSTGRES_FORWARDER_HOST=boardsesh-db-forwarder.example-tailnet.ts.net
+read -rsp 'PostGIS - PROD admin URL: ' ADMIN_DATABASE_URL
+printf '\n'
+export ADMIN_DATABASE_URL
+export ROLLBACK_TASK_ROLES=DROP_EXACT_SIX_TASK_ROLES
+node scripts/production-db-task-roles.mjs rollback
+unset ROLLBACK_TASK_ROLES ADMIN_DATABASE_URL POSTGRES_FORWARDER_HOST
+```
+
+Rollback revokes the exact direct grants and `boardsesh_owner` membership, then
+drops only the six ownership-free login roles. It does not change application
+data, schemas, the migration owner, the forwarder, tailnet policy, or Railway.
+Running it again after all six roles are absent is a no-op.
 
 The local `connect-production-db` action uses workload identity federation, an
 ephemeral CI node, and immutable pins for both the official action and the
@@ -167,21 +285,24 @@ weaken SCRAM or embed credentials in workflow YAML.
 
 1. Merge the foundation PR, publish its attested image, and deploy the verified
    immutable digest. Keep the existing PostGIS public TCP proxy.
-2. Prove `/readyz`, tailnet policy allow/deny tests, restart identity
+2. Merge the stacked task-role tooling PR. Review its `plan` evidence, run its
+   guarded `apply` through the PostGIS-only forwarder, store the six generated
+   URLs in their exact protected secrets, and retain the empty `audit` evidence.
+3. Prove `/readyz`, tailnet policy allow/deny tests, restart identity
    persistence, and every task-specific credential before merging consumers.
-3. Merge the separate activation PR only after its external actions and
+4. Merge the separate activation PR only after its external actions and
    dependency surfaces are immutable. From protected manual dispatches, prove
    the Tailscale ping and a rollback-only database probe for each direct URL.
-4. Run the migration job, each refresh workflow in dry-run mode where offered,
+5. Run the migration job, each refresh workflow in dry-run mode where offered,
    and one snapshot watermark probe. Confirm the database role and
    `application_name` for each session.
-5. Observe 24 hours with zero forwarder dial errors or session rejections. Alert
+6. Observe 24 hours with zero forwarder dial errors or session rejections. Alert
    on `/readyz != 200`, any increase in `dial_errors_total` or
    `rejections_total`, active sessions above 24 for five minutes, and node
    identity changes.
-6. Add the homelab node as `tag:boardsesh-dr` and prove it can reach only port
+7. Add the homelab node as `tag:boardsesh-dr` and prove it can reach only port
    5432. Do not use this route as an application read replica.
-7. Remove the PostGIS public TCP proxy only as a separately approved Railway
+8. Remove the PostGIS public TCP proxy only as a separately approved Railway
    change after all direct consumers pass. This repository change does not
    remove it.
 
@@ -200,9 +321,15 @@ longer needed.
 
 ```sh
 vp run test:postgres-forwarder
-vp test run --project scripts scripts/postgres-secure-network-contract.test.ts --reporter=agent
+vp test run --project scripts scripts/postgres-secure-network-contract.test.ts scripts/production-db-task-roles-contract.test.ts --reporter=agent
+bash scripts/production-db-task-roles-smoke.sh
 docker build -f deploy/postgres-tailscale-forwarder/Dockerfile deploy/postgres-tailscale-forwarder
 ```
 
-The unit suite uses in-memory connections and never joins a tailnet or opens a
-database connection.
+The unit suite never joins a tailnet or opens a database connection. The task
+role smoke starts only the digest-pinned official PostgreSQL 18.6 base selected
+by the upgrade project. PostGIS is unnecessary because the fixture exercises
+core role, ACL, RLS, SCRAM, and catalog behavior only. It provisions
+all six roles, proves allowed and denied operations, injects an unexpected
+grant, proves audit and rollback refusal, repairs it, and verifies idempotent
+rollback without losing the owner role or fixture data.

--- a/docs/postgres-secure-network.md
+++ b/docs/postgres-secure-network.md
@@ -186,10 +186,13 @@ routine execution, object ownership, role creation, replication, or RLS bypass.
 The audit covers direct database, schema, relation, sequence, column, routine,
 type, large-object, parameter, language, foreign-data, server, tablespace, and
 default-ACL privileges. It also resolves PostgreSQL's implicit `PUBLIC` ACLs
-with `acldefault` for every connectable database, the `public` and `drizzle`
-schemas, and every non-extension application relation, sequence, column,
-routine, and user-defined type in those schemas. `PUBLIC CONNECT` is allowed
-only on `railway`, because it is inside all six explicit database contracts.
+with `acldefault` for every connectable database; every non-system,
+non-extension schema; and every non-extension application relation, sequence,
+column, routine, user-defined type, and large object in scope. It also inspects
+`PUBLIC SET`/`ALTER SYSTEM` parameter ACLs. Any non-extension schema outside
+the exact `public`/`drizzle` manifest is itself a blocker, even when its current
+ACL is empty. `PUBLIC CONNECT` is allowed only on `railway`, because it is
+inside all six explicit database contracts.
 `PUBLIC` access to another connectable database, `PUBLIC TEMPORARY`, schema
 `CREATE`/`USAGE`, and application-object privileges are outside at least one
 role's contract and therefore fail audit. This prevents a leaked cluster-wide
@@ -199,12 +202,13 @@ reaches `public` and `drizzle` only after the guarded owner transition. Only the
 climb-grade refresh gets `TEMPORARY`.
 
 Future objects are covered too. The audit resolves the migration owner's global
-defaults and inspects its schema-local defaults for tables, sequences, routines,
-and types. PostgreSQL's built-in `PUBLIC EXECUTE` routine and `PUBLIC USAGE`
-type defaults must already have been removed by the reviewed PG18 owner/runtime
-transition. Extension-owned objects are excluded from this task-role manifest;
-their vendor ACLs and extension membership are handled by the PG18 catalog
-audit. Any unexpected ownership, membership, default ACL, or grant option, plus
+defaults for tables, sequences, routines, types, schemas, and large objects,
+then inspects its schema-local defaults where PostgreSQL supports them.
+PostgreSQL's built-in `PUBLIC EXECUTE` routine and `PUBLIC USAGE` type defaults
+must already have been removed by the reviewed PG18 owner/runtime transition.
+Extension-owned objects are excluded from this task-role manifest; their vendor
+ACLs and extension membership are handled by the PG18 catalog audit. Any
+unexpected ownership, membership, default ACL, schema, or grant option, plus
 any RLS policy naming a managed role, stops apply for manual review.
 
 No task role receives application-type `USAGE`. PostgreSQL 18 defines that
@@ -222,7 +226,12 @@ new privilege boundary, or adds an application routine default, update the
 manifest and smoke rather than restoring a PUBLIC default.
 
 Generate credentials once in an operator-only directory outside the repository.
-The destination must not already exist and is created mode `0600`:
+The existing parent must be owned by the operator and inaccessible to group and
+other users. The tool resolves that parent and the real repository root before
+accepting the destination, so a symlink cannot redirect the bundle into the
+checkout. The destination must not already exist and is opened with exclusive,
+no-follow flags at mode `0600`; apply reads the same single-link file through
+its already-verified descriptor:
 
 ```sh
 install -d -m 700 /secure/operator/boardsesh-db-rollout
@@ -284,10 +293,10 @@ and a rollback owner is named. This repository change itself does not execute
 any command above against production.
 
 Rollback is deliberately narrower than `DROP OWNED`: it refuses partial or
-drifted roles, active sessions, unexpected membership, default ACLs, grant
-options, or owned objects. First disable the six workflows and revoke their
-GitHub secrets. Then obtain a fresh hidden administrator URL, run `audit`, and
-only after the empty diff proves the exact managed state:
+drifted roles, unexpected membership, default ACLs, grant options, or owned
+objects. First disable the six workflows and revoke their GitHub secrets. Then
+obtain a fresh hidden administrator URL, run `audit`, and only after the empty
+diff proves the exact managed state:
 
 ```sh
 export POSTGRES_FORWARDER_HOST=boardsesh-db-forwarder.example-tailnet.ts.net
@@ -299,10 +308,24 @@ node scripts/production-db-task-roles.mjs rollback
 unset ROLLBACK_TASK_ROLES ADMIN_DATABASE_URL POSTGRES_FORWARDER_HOST
 ```
 
-Rollback revokes the exact direct grants and `boardsesh_owner` membership, then
-drops only the six ownership-free login roles. It does not change application
-data, schemas, the migration owner, the forwarder, tailnet policy, or Railway.
-Running it again after all six roles are absent is a no-op.
+Rollback holds the task-role advisory lock across two committed phases. Its
+first transaction changes all six roles to `NOLOGIN` and commits that durable
+fence. Only then does it inspect `pg_stat_activity.usesysid`, which remains the
+authenticated login identity even after `SET ROLE boardsesh_owner`. If any such
+session remains, rollback refuses without revoking membership or dropping a
+role. The safer `NOLOGIN` state is intentional: `plan` exposes it as role drift,
+`audit` refuses activation readiness, and a later rollback invocation accepts
+the fence, checks the sessions again, and resumes. Drain the reported sessions
+and rerun the same command. If rollback must instead be abandoned, review the
+state and rerun guarded `apply` with the original protected credential bundle;
+do not restore `LOGIN` manually.
+
+After an empty session proof, the second transaction rechecks the complete
+fenced contract and session set, revokes the exact direct grants and
+`boardsesh_owner` membership, and drops only the six ownership-free roles. It
+does not change application data, schemas, the migration owner, the forwarder,
+tailnet policy, or Railway. Running it again after all six roles are absent is a
+no-op.
 
 The local `connect-production-db` action uses workload identity federation, an
 ephemeral CI node, and immutable pins for both the official action and the

--- a/docs/postgres-secure-network.md
+++ b/docs/postgres-secure-network.md
@@ -180,6 +180,19 @@ queries:
   playlists, ownership/climbs, weekly history/cursor, reserved system user, and
   the playlist-delete trigger's `sync_deletions` target.
 
+PostgreSQL has no bind parameter for a privilege keyword, an identifier, or
+`CONNECTION LIMIT`, so those interpolate literally into the statements the tool
+runs. `scripts/lib/production-db-task-role-sql.mjs` is the only place that
+builds them, and it fails closed. A privilege must match one of the exact
+keywords the manifest declares — `CONNECT`/`TEMPORARY` on the database, `USAGE`
+on the schema, `DELETE`/`INSERT`/`SELECT`/`UPDATE` on relations. An identifier
+must match `^[a-z_][a-z0-9_]*$`. A connection limit must be a plain integer
+between 0 and 100. Anything else — a stray space, a lowercase keyword, a
+comma-joined pair, a `;`, a float, `-1` — throws before a statement exists. The
+whole manifest goes through that gate at startup, so `plan` and `audit` reject a
+bad entry as firmly as `apply` does. Granting a privilege the tool has never
+granted before means widening the allowlist in review.
+
 For an `INSERT` target backed by an owned sequence, the tool derives and grants
 only `USAGE` on that sequence. It grants no default privileges, grant options,
 routine execution, object ownership, role creation, replication, or RLS bypass.

--- a/docs/postgres-secure-network.md
+++ b/docs/postgres-secure-network.md
@@ -186,14 +186,17 @@ routine execution, object ownership, role creation, replication, or RLS bypass.
 The audit covers direct database, schema, relation, sequence, column, routine,
 type, large-object, parameter, language, foreign-data, server, tablespace, and
 default-ACL privileges. It also resolves PostgreSQL's implicit `PUBLIC` ACLs
-with `acldefault` for the `railway` database, the `public` and `drizzle`
+with `acldefault` for every connectable database, the `public` and `drizzle`
 schemas, and every non-extension application relation, sequence, column,
 routine, and user-defined type in those schemas. `PUBLIC CONNECT` is allowed
-because it is inside all six explicit database contracts. `PUBLIC TEMPORARY`,
-schema `CREATE`/`USAGE`, and application-object privileges are outside at least
-one role's contract and therefore fail audit. The migrator deliberately has no
-direct schema `USAGE`: it reaches `public` and `drizzle` only after the guarded
-`SET ROLE boardsesh_owner`; only the climb-grade refresh gets `TEMPORARY`.
+only on `railway`, because it is inside all six explicit database contracts.
+`PUBLIC` access to another connectable database, `PUBLIC TEMPORARY`, schema
+`CREATE`/`USAGE`, and application-object privileges are outside at least one
+role's contract and therefore fail audit. This prevents a leaked cluster-wide
+credential from bypassing the pinned URL by naming `postgres`, `template1`, or
+another database. The migrator deliberately has no direct schema `USAGE`; it
+reaches `public` and `drizzle` only after the guarded owner transition. Only the
+climb-grade refresh gets `TEMPORARY`.
 
 Future objects are covered too. The audit resolves the migration owner's global
 defaults and inspects its schema-local defaults for tables, sequences, routines,

--- a/docs/postgres-secure-network.md
+++ b/docs/postgres-secure-network.md
@@ -185,9 +185,38 @@ only `USAGE` on that sequence. It grants no default privileges, grant options,
 routine execution, object ownership, role creation, replication, or RLS bypass.
 The audit covers direct database, schema, relation, sequence, column, routine,
 type, large-object, parameter, language, foreign-data, server, tablespace, and
-default-ACL privileges. Any unexpected ownership, membership, default ACL, or
-grant option, plus any RLS policy naming a managed role, stops apply for manual
-review.
+default-ACL privileges. It also resolves PostgreSQL's implicit `PUBLIC` ACLs
+with `acldefault` for the `railway` database, the `public` and `drizzle`
+schemas, and every non-extension application relation, sequence, column,
+routine, and user-defined type in those schemas. `PUBLIC CONNECT` is allowed
+because it is inside all six explicit database contracts. `PUBLIC TEMPORARY`,
+schema `CREATE`/`USAGE`, and application-object privileges are outside at least
+one role's contract and therefore fail audit. The migrator deliberately has no
+direct schema `USAGE`: it reaches `public` and `drizzle` only after the guarded
+`SET ROLE boardsesh_owner`; only the climb-grade refresh gets `TEMPORARY`.
+
+Future objects are covered too. The audit resolves the migration owner's global
+defaults and inspects its schema-local defaults for tables, sequences, routines,
+and types. PostgreSQL's built-in `PUBLIC EXECUTE` routine and `PUBLIC USAGE`
+type defaults must already have been removed by the reviewed PG18 owner/runtime
+transition. Extension-owned objects are excluded from this task-role manifest;
+their vendor ACLs and extension membership are handled by the PG18 catalog
+audit. Any unexpected ownership, membership, default ACL, or grant option, plus
+any RLS policy naming a managed role, stops apply for manual review.
+
+No task role receives application-type `USAGE`. PostgreSQL 18 defines that
+privilege as permission to create schema objects that depend on a type, not as
+permission to read or write values of that type in existing table columns (see
+the [PostgreSQL privilege contract](https://www.postgresql.org/docs/18/ddl-priv.html)).
+The latest schema snapshot pins the only task-table enum values to
+`boardsesh_ticks` and `user_hold_classifications`, and pins task-table routine
+defaults to the built-in `pg_catalog.now()`. The PG18.6 smoke revokes PUBLIC
+type access, proves enum and domain reads/writes still work without direct
+`USAGE`, and proves the playlist deletion trigger fires without granting its
+application routine `EXECUTE`. A direct call to that routine remains denied.
+If a future workflow creates a dependent object, explicitly casts through a
+new privilege boundary, or adds an application routine default, update the
+manifest and smoke rather than restoring a PUBLIC default.
 
 Generate credentials once in an operator-only directory outside the repository.
 The destination must not already exist and is created mode `0600`:
@@ -224,10 +253,19 @@ node scripts/production-db-task-roles.mjs plan
 ```
 
 Review and retain the sorted `[task-role-diff]` output as the before-state. It
-contains object names and privilege types, never credentials. Apply has a
-second explicit guard, uses a transaction-level advisory lock, rotates all six
-passwords to client-built SCRAM verifiers, prints its pre-apply diff, and fails
-unless the post-apply diff is empty:
+contains object names and privilege types, never credentials. A cluster-wide
+line includes an exact candidate `REVOKE` or `ALTER DEFAULT PRIVILEGES` statement
+for review. Do not paste those statements into production as a bundle: they can
+change access for every database login. Reconcile them through the reviewed
+PG18 owner/runtime transition, or approve a narrowly scoped cluster-policy patch
+with before/after ACL evidence. This task-role tool never executes a `PUBLIC` or
+migration-owner default-ACL remediation; `apply` refuses while any such boundary
+diff remains.
+
+After that separate review is complete, apply has a second boundary check inside
+its advisory-locked transaction, rotates all six passwords to client-built SCRAM
+verifiers, prints its pre-apply diff, and fails unless the post-apply diff is
+empty:
 
 ```sh
 export APPLY_TASK_ROLE_CHANGES=APPLY_EXACT_SIX_TASK_ROLES
@@ -237,7 +275,8 @@ node scripts/production-db-task-roles.mjs audit
 unset ADMIN_DATABASE_URL ROLE_CREDENTIALS_FILE POSTGRES_FORWARDER_HOST
 ```
 
-Do not run `apply` until the foundation is merged, the grant diff is reviewed,
+Do not run `apply` until the foundation is merged, the PG18 owner/runtime ACL
+transition is complete, the cluster-wide and six-role grant diffs are reviewed,
 and a rollback owner is named. This repository change itself does not execute
 any command above against production.
 

--- a/scripts/lib/production-db-task-role-contract.mjs
+++ b/scripts/lib/production-db-task-role-contract.mjs
@@ -1,0 +1,243 @@
+const role = (contract) => Object.freeze(contract);
+
+export const PRODUCTION_DATABASE_NAME = 'railway';
+export const PRODUCTION_SCHEMA_NAME = 'public';
+export const MIGRATION_OWNER_ROLE = 'boardsesh_owner';
+
+export const PRODUCTION_TASK_ROLES = Object.freeze([
+  role({
+    name: 'boardsesh_migrator',
+    applicationName: 'boardsesh-ci-migrate',
+    githubSecret: 'MIGRATION_DATABASE_DIRECT_URL',
+    connectionLimit: 2,
+    databasePrivileges: ['CONNECT'],
+    schemaPrivileges: [],
+    readOnly: false,
+    setOnlyRole: MIGRATION_OWNER_ROLE,
+    evidence: ['packages/db/scripts/migrate.ts', 'packages/db/scripts/migration-owner-role.ts'],
+  }),
+  role({
+    name: 'boardsesh_snapshot_exporter',
+    applicationName: 'boardsesh-ci-snapshot-export',
+    githubSecret: 'SNAPSHOT_DATABASE_DIRECT_URL',
+    connectionLimit: 10,
+    databasePrivileges: ['CONNECT'],
+    schemaPrivileges: ['USAGE'],
+    readOnly: true,
+    setOnlyRole: null,
+    evidence: [
+      'packages/backend/src/scripts/export-board-snapshots.ts',
+      'packages/backend/src/scripts/export-board-catalog.ts',
+      'packages/db/src/catalog-snapshot.ts',
+      'packages/db/src/client/postgres.ts',
+    ],
+  }),
+  role({
+    name: 'boardsesh_climb_grades_refresh',
+    applicationName: 'boardsesh-ci-climb-grades',
+    githubSecret: 'CLIMB_GRADES_DATABASE_DIRECT_URL',
+    connectionLimit: 2,
+    databasePrivileges: ['CONNECT', 'TEMPORARY'],
+    schemaPrivileges: ['USAGE'],
+    readOnly: false,
+    setOnlyRole: null,
+    evidence: ['packages/db/scripts/refresh-climb-grades.ts', 'packages/db/src/queries/grade-model'],
+  }),
+  role({
+    name: 'boardsesh_content_model_refresh',
+    applicationName: 'boardsesh-ci-content-model',
+    githubSecret: 'CONTENT_MODEL_DATABASE_DIRECT_URL',
+    connectionLimit: 2,
+    databasePrivileges: ['CONNECT'],
+    schemaPrivileges: ['USAGE'],
+    readOnly: false,
+    setOnlyRole: null,
+    evidence: [
+      'packages/db/scripts/extract-training-matrix.ts',
+      'packages/db/scripts/load-content-model.ts',
+      'packages/db/scripts/load-similarity.ts',
+    ],
+  }),
+  role({
+    name: 'boardsesh_hold_features_refresh',
+    applicationName: 'boardsesh-ci-hold-features',
+    githubSecret: 'HOLD_FEATURES_DATABASE_DIRECT_URL',
+    connectionLimit: 2,
+    databasePrivileges: ['CONNECT'],
+    schemaPrivileges: ['USAGE'],
+    readOnly: false,
+    setOnlyRole: null,
+    evidence: ['packages/db/scripts/refresh-hold-features.ts'],
+  }),
+  role({
+    name: 'boardsesh_recommendations_refresh',
+    applicationName: 'boardsesh-ci-recommendations',
+    githubSecret: 'RECOMMENDATIONS_DATABASE_DIRECT_URL',
+    connectionLimit: 2,
+    databasePrivileges: ['CONNECT'],
+    schemaPrivileges: ['USAGE'],
+    readOnly: false,
+    setOnlyRole: null,
+    evidence: [
+      'packages/db/scripts/refresh-recommendations.ts',
+      'packages/db/src/queries/recommendations',
+      'packages/db/src/queries/climb-stats/history-snapshot.ts',
+      'packages/db/src/queries/sync/weekly-gate.ts',
+      'packages/db/drizzle/0146_offline_sync_followups.sql',
+    ],
+  }),
+]);
+
+const grants = [];
+function grant(roleName, privileges, relations, evidence) {
+  for (const relation of relations) {
+    grants.push(
+      Object.freeze({
+        role: roleName,
+        relation,
+        privileges: [...privileges].sort((left, right) => left.localeCompare(right)),
+        evidence,
+      }),
+    );
+  }
+}
+
+grant(
+  'boardsesh_snapshot_exporter',
+  ['SELECT'],
+  ['board_climbs', 'board_climb_stats', 'board_climb_grades'],
+  'packages/backend/src/scripts/export-board-snapshots.ts',
+);
+grant(
+  'boardsesh_snapshot_exporter',
+  ['SELECT'],
+  [
+    'board_products',
+    'board_layouts',
+    'board_product_sizes',
+    'board_sets',
+    'board_placement_roles',
+    'board_holes',
+    'board_placements',
+    'board_leds',
+    'board_product_sizes_layouts_sets',
+    'board_kits',
+    'board_difficulty_grades',
+    'board_attempts',
+    'board_climb_aliases',
+    'board_beta_links',
+  ],
+  'packages/db/src/catalog-snapshot.ts',
+);
+
+grant(
+  'boardsesh_climb_grades_refresh',
+  ['SELECT'],
+  [
+    'board_climb_embeddings',
+    'board_climbs',
+    'board_climb_stats',
+    'boardsesh_ticks',
+    'board_climb_aliases',
+    'board_climb_stats_history',
+    'user_boards',
+  ],
+  'packages/db/scripts/refresh-climb-grades.ts + packages/db/src/queries/grade-model',
+);
+grant(
+  'boardsesh_climb_grades_refresh',
+  ['INSERT', 'SELECT', 'UPDATE'],
+  ['board_grade_coefficients'],
+  'packages/db/scripts/refresh-climb-grades.ts',
+);
+grant(
+  'boardsesh_climb_grades_refresh',
+  ['DELETE', 'INSERT', 'SELECT', 'UPDATE'],
+  ['board_climb_grades'],
+  'packages/db/scripts/refresh-climb-grades.ts',
+);
+
+grant(
+  'boardsesh_content_model_refresh',
+  ['SELECT'],
+  ['board_hold_features', 'board_climb_stats', 'board_climbs', 'board_climb_holds', 'board_placements'],
+  'packages/db/scripts/extract-training-matrix.ts',
+);
+grant(
+  'boardsesh_content_model_refresh',
+  ['INSERT', 'SELECT', 'UPDATE'],
+  ['board_climb_embeddings'],
+  'packages/db/scripts/load-content-model.ts',
+);
+grant(
+  'boardsesh_content_model_refresh',
+  ['DELETE', 'INSERT', 'SELECT'],
+  ['board_climb_similar'],
+  'packages/db/scripts/load-similarity.ts',
+);
+
+grant(
+  'boardsesh_hold_features_refresh',
+  ['SELECT'],
+  [
+    'board_placements',
+    'board_holes',
+    'board_sets',
+    'board_climb_stats',
+    'board_climbs',
+    'board_climb_holds',
+    'board_product_sizes_layouts_sets',
+  ],
+  'packages/db/scripts/refresh-hold-features.ts',
+);
+grant('boardsesh_hold_features_refresh', ['INSERT'], ['users'], 'packages/db/scripts/refresh-hold-features.ts');
+grant(
+  'boardsesh_hold_features_refresh',
+  ['INSERT', 'SELECT', 'UPDATE'],
+  ['board_hold_features', 'user_hold_classifications'],
+  'packages/db/scripts/refresh-hold-features.ts',
+);
+
+grant(
+  'boardsesh_recommendations_refresh',
+  ['SELECT'],
+  ['board_climbs', 'board_climb_stats'],
+  'packages/db/scripts/refresh-recommendations.ts + packages/db/src/queries/recommendations',
+);
+grant('boardsesh_recommendations_refresh', ['INSERT'], ['users'], 'packages/db/scripts/refresh-recommendations.ts');
+grant(
+  'boardsesh_recommendations_refresh',
+  ['INSERT'],
+  ['board_climb_stats_history'],
+  'packages/db/src/queries/climb-stats/history-snapshot.ts',
+);
+grant(
+  'boardsesh_recommendations_refresh',
+  ['INSERT'],
+  ['sync_deletions'],
+  'packages/db/drizzle/0146_offline_sync_followups.sql',
+);
+grant(
+  'boardsesh_recommendations_refresh',
+  ['INSERT', 'SELECT', 'UPDATE'],
+  ['board_setter_stats', 'playlists', 'board_shared_syncs'],
+  'packages/db/scripts/refresh-recommendations.ts',
+);
+grant(
+  'boardsesh_recommendations_refresh',
+  ['DELETE', 'INSERT', 'SELECT'],
+  ['board_climb_send_stats', 'playlist_climbs'],
+  'packages/db/scripts/refresh-recommendations.ts',
+);
+grant(
+  'boardsesh_recommendations_refresh',
+  ['INSERT', 'SELECT'],
+  ['playlist_ownership'],
+  'packages/db/scripts/refresh-recommendations.ts + packages/db/drizzle/0146_offline_sync_followups.sql',
+);
+
+export const PRODUCTION_TASK_RELATION_GRANTS = Object.freeze(
+  grants.sort((left, right) => `${left.role}:${left.relation}`.localeCompare(`${right.role}:${right.relation}`)),
+);
+
+export const PRODUCTION_TASK_ROLE_BY_NAME = new Map(PRODUCTION_TASK_ROLES.map((entry) => [entry.name, entry]));

--- a/scripts/lib/production-db-task-role-contract.mjs
+++ b/scripts/lib/production-db-task-role-contract.mjs
@@ -2,6 +2,7 @@ const role = (contract) => Object.freeze(contract);
 
 export const PRODUCTION_DATABASE_NAME = 'railway';
 export const PRODUCTION_SCHEMA_NAME = 'public';
+export const PRODUCTION_MANAGED_SCHEMAS = Object.freeze(['public', 'drizzle']);
 export const MIGRATION_OWNER_ROLE = 'boardsesh_owner';
 
 export const PRODUCTION_TASK_ROLES = Object.freeze([

--- a/scripts/lib/production-db-task-role-sql.mjs
+++ b/scripts/lib/production-db-task-role-sql.mjs
@@ -1,0 +1,101 @@
+// Every contract value that reaches `sqlClient.unsafe()` in the production task-role
+// provisioner is quoted or allowlisted here. PostgreSQL has no bind parameters for
+// privilege keywords, identifiers or CONNECTION LIMIT, so those interpolate literally --
+// which makes an unvalidated contract entry such as
+// `databasePrivileges: ['CONNECT; DROP ROLE boardsesh_owner --']` an executable statement.
+// These helpers fail closed: only the exact keywords the contract legitimately uses pass,
+// and adding a new privilege means widening the allowlist in review.
+
+const IDENTIFIER_PATTERN = /^[a-z_][a-z0-9_]*$/;
+
+// Upper bound for a CI task role. Every managed role today asks for 2 or 10 connections;
+// anything larger is a contract mistake rather than a legitimate task-role need.
+export const MAX_TASK_CONNECTION_LIMIT = 100;
+
+export const ALLOWED_DATABASE_PRIVILEGES = Object.freeze(['CONNECT', 'TEMPORARY']);
+export const ALLOWED_SCHEMA_PRIVILEGES = Object.freeze(['USAGE']);
+export const ALLOWED_RELATION_PRIVILEGES = Object.freeze(['DELETE', 'INSERT', 'SELECT', 'UPDATE']);
+
+const ALLOWED_PRIVILEGES_BY_SCOPE = new Map([
+  ['database', new Set(ALLOWED_DATABASE_PRIVILEGES)],
+  ['schema', new Set(ALLOWED_SCHEMA_PRIVILEGES)],
+  ['relation', new Set(ALLOWED_RELATION_PRIVILEGES)],
+]);
+
+export function fail(message) {
+  throw new Error(message);
+}
+
+export function quoteIdentifier(identifier) {
+  if (typeof identifier !== 'string' || !IDENTIFIER_PATTERN.test(identifier)) {
+    fail(`unsafe PostgreSQL identifier: ${String(identifier)}`);
+  }
+  return `"${identifier}"`;
+}
+
+export function quoteLiteral(literal) {
+  return `'${String(literal).replaceAll("'", "''")}'`;
+}
+
+export function valuesList(values) {
+  return values.map(quoteLiteral).join(', ');
+}
+
+export function qualifiedRelationSql(schemaName, relationName) {
+  return `${quoteIdentifier(schemaName)}.${quoteIdentifier(relationName)}`;
+}
+
+// Validates one privilege array without building SQL; an empty array is a role that asks
+// for nothing at that scope (the migrator holds no schema privileges).
+export function assertPrivileges(scope, privileges, context) {
+  const allowedPrivileges = ALLOWED_PRIVILEGES_BY_SCOPE.get(scope);
+  if (!allowedPrivileges) fail(`unknown privilege scope ${String(scope)}`);
+  if (!Array.isArray(privileges)) fail(`${context} must declare ${scope} privileges as an array`);
+  const seenPrivileges = new Set();
+  for (const privilege of privileges) {
+    if (typeof privilege !== 'string' || !allowedPrivileges.has(privilege)) {
+      fail(`unsafe ${scope} privilege for ${context}: ${JSON.stringify(privilege)}`);
+    }
+    if (seenPrivileges.has(privilege)) fail(`duplicate ${scope} privilege for ${context}: ${privilege}`);
+    seenPrivileges.add(privilege);
+  }
+}
+
+// The only way a privilege keyword is allowed into a GRANT statement.
+export function privilegeListSql(scope, privileges, context) {
+  assertPrivileges(scope, privileges, context);
+  if (privileges.length === 0) fail(`${context} must grant at least one ${scope} privilege`);
+  return privileges.join(', ');
+}
+
+// The only way a connection limit is allowed into an ALTER ROLE statement. PostgreSQL
+// accepts -1 for "unlimited"; no managed task role wants that, so it is rejected too.
+export function connectionLimitSql(connectionLimit, context) {
+  if (
+    typeof connectionLimit !== 'number' ||
+    !Number.isSafeInteger(connectionLimit) ||
+    connectionLimit < 0 ||
+    connectionLimit > MAX_TASK_CONNECTION_LIMIT
+  ) {
+    fail(`unsafe connection limit for ${context}: ${JSON.stringify(connectionLimit) ?? String(connectionLimit)}`);
+  }
+  return String(connectionLimit);
+}
+
+// Fail-closed gate over the whole static contract, run before any command touches the
+// database so `plan` and `audit` reject a poisoned contract just as `apply` does.
+export function assertContractSqlSafety(taskRoles, relationGrants) {
+  for (const roleContract of taskRoles) {
+    quoteIdentifier(roleContract.name);
+    connectionLimitSql(roleContract.connectionLimit, roleContract.name);
+    assertPrivileges('database', roleContract.databasePrivileges, roleContract.name);
+    assertPrivileges('schema', roleContract.schemaPrivileges, roleContract.name);
+  }
+  for (const grantContract of relationGrants) {
+    quoteIdentifier(grantContract.role);
+    quoteIdentifier(grantContract.relation);
+    const grantContext = `${grantContract.role} on ${grantContract.relation}`;
+    assertPrivileges('relation', grantContract.privileges, grantContext);
+    if (grantContract.privileges.length === 0) fail(`empty privileges for ${grantContract.role}`);
+  }
+}

--- a/scripts/production-db-task-roles-contract.test.ts
+++ b/scripts/production-db-task-roles-contract.test.ts
@@ -311,6 +311,8 @@ describe('production database task-role contract', () => {
     const provisionerSource = readFileSync('scripts/production-db-task-roles.mjs', 'utf8');
     expect(provisionerSource).toContain('collectClusterWideBoundaryDifferences');
     expect(provisionerSource).toContain("pg_catalog.acldefault('d', database.datdba)");
+    expect(provisionerSource).toContain('WHERE database.datallowconn');
+    expect(provisionerSource).not.toContain('WHERE database.datname = ${quoteLiteral(PRODUCTION_DATABASE_NAME)}');
     expect(provisionerSource).toContain("pg_catalog.acldefault('n', namespace.nspowner)");
     expect(provisionerSource).toContain("pg_catalog.acldefault('f', procedure.proowner)");
     expect(provisionerSource).toContain("pg_catalog.acldefault('T', type_row.typowner)");

--- a/scripts/production-db-task-roles-contract.test.ts
+++ b/scripts/production-db-task-roles-contract.test.ts
@@ -314,6 +314,8 @@ describe('production database task-role contract', () => {
     expect(provisionerSource).toContain("pg_catalog.acldefault('n', namespace.nspowner)");
     expect(provisionerSource).toContain("pg_catalog.acldefault('f', procedure.proowner)");
     expect(provisionerSource).toContain("pg_catalog.acldefault('T', type_row.typowner)");
+    expect(provisionerSource).toContain("CASE WHEN relation.relkind = 'S' THEN 's'::\"char\"");
+    expect(provisionerSource).toContain("('S'::\"char\", 's'::\"char\", 'SEQUENCES'::text)");
     expect(provisionerSource).toContain('AND privilege.grantee = 0');
     expect(provisionerSource).toContain(
       'cluster-wide PUBLIC/default ACL prerequisites require separate reviewed remediation; apply never changes them',

--- a/scripts/production-db-task-roles-contract.test.ts
+++ b/scripts/production-db-task-roles-contract.test.ts
@@ -1,6 +1,17 @@
 /// <reference types="node" />
 
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  linkSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -267,6 +278,65 @@ describe('production database task-role contract', () => {
     expect(`${argvResult.stdout}${argvResult.stderr}`).not.toContain(sentinelSecret);
   });
 
+  it('resolves credential parents and rejects unsafe parent or linked-file boundaries', () => {
+    const temporaryDirectory = mkdtempSync(join(tmpdir(), 'boardsesh-role-path-boundary-'));
+    temporaryDirectories.push(temporaryDirectory);
+
+    const repositoryLink = join(temporaryDirectory, 'repository-link');
+    symlinkSync(resolve('.'), repositoryLink, 'dir');
+    const repositoryLinkResult = spawnSync(process.execPath, ['scripts/production-db-task-roles.mjs', 'generate'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ROLE_CREDENTIALS_FILE: join(repositoryLink, 'roles.json'),
+        POSTGRES_FORWARDER_HOST: 'boardsesh-db-forwarder.test.tailnet.ts.net',
+      },
+    });
+    expect(repositoryLinkResult.status).toBe(1);
+    expect(repositoryLinkResult.stderr).toContain('must be outside the repository');
+
+    chmodSync(temporaryDirectory, 0o755);
+    const permissiveParentResult = spawnSync(process.execPath, ['scripts/production-db-task-roles.mjs', 'generate'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ROLE_CREDENTIALS_FILE: join(temporaryDirectory, 'permissive-parent.json'),
+        POSTGRES_FORWARDER_HOST: 'boardsesh-db-forwarder.test.tailnet.ts.net',
+      },
+    });
+    expect(permissiveParentResult.status).toBe(1);
+    expect(permissiveParentResult.stderr).toContain('parent must not be accessible by group or other users');
+    chmodSync(temporaryDirectory, 0o700);
+
+    const linkedTarget = join(temporaryDirectory, 'linked-target.json');
+    writeFileSync(linkedTarget, '{}\n', { mode: 0o600 });
+    const symbolicCredentialFile = join(temporaryDirectory, 'symbolic-roles.json');
+    symlinkSync(linkedTarget, symbolicCredentialFile);
+    const symbolicFileResult = spawnSync(process.execPath, ['scripts/production-db-task-roles.mjs', 'apply'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        APPLY_TASK_ROLE_CHANGES: 'APPLY_EXACT_SIX_TASK_ROLES',
+        ROLE_CREDENTIALS_FILE: symbolicCredentialFile,
+      },
+    });
+    expect(symbolicFileResult.status).toBe(1);
+    expect(symbolicFileResult.stderr).toContain('existing regular non-symlink file');
+
+    const hardLinkedCredentialFile = join(temporaryDirectory, 'hard-linked-roles.json');
+    linkSync(linkedTarget, hardLinkedCredentialFile);
+    const hardLinkResult = spawnSync(process.execPath, ['scripts/production-db-task-roles.mjs', 'apply'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        APPLY_TASK_ROLE_CHANGES: 'APPLY_EXACT_SIX_TASK_ROLES',
+        ROLE_CREDENTIALS_FILE: hardLinkedCredentialFile,
+      },
+    });
+    expect(hardLinkResult.status).toBe(1);
+    expect(hardLinkResult.stderr).toContain('must be one regular, non-linked file');
+  });
+
   it('rejects OTA, public, and unconfirmed loopback administrator targets before connecting', () => {
     const wrongServiceResult = spawnSync(process.execPath, ['scripts/production-db-task-roles.mjs', 'plan'], {
       encoding: 'utf8',
@@ -305,6 +375,15 @@ describe('production database task-role contract', () => {
     expect(smokeSource).toContain(
       'ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner GRANT EXECUTE ON ROUTINES TO PUBLIC',
     );
+    expect(smokeSource).toContain(
+      'ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner GRANT CREATE ON SCHEMAS TO PUBLIC',
+    );
+    expect(smokeSource).toContain(
+      'ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner GRANT SELECT ON LARGE OBJECTS TO PUBLIC',
+    );
+    expect(smokeSource).toContain('GRANT SELECT ON LARGE OBJECT 918273 TO PUBLIC');
+    expect(smokeSource).toContain('GRANT SET ON PARAMETER statement_timeout TO PUBLIC');
+    expect(smokeSource).toContain('boardsesh-ci-migrate-rollback-race');
   });
 
   it('audits effective PUBLIC and owner-default boundaries without applying broad revokes', () => {
@@ -316,11 +395,41 @@ describe('production database task-role contract', () => {
     expect(provisionerSource).toContain("pg_catalog.acldefault('n', namespace.nspowner)");
     expect(provisionerSource).toContain("pg_catalog.acldefault('f', procedure.proowner)");
     expect(provisionerSource).toContain("pg_catalog.acldefault('T', type_row.typowner)");
+    expect(provisionerSource).toContain("pg_catalog.acldefault('n', namespace.nspowner)");
+    expect(provisionerSource).toContain("pg_catalog.acldefault('L', large_object.lomowner)");
+    expect(provisionerSource).toContain("('n'::\"char\", 'n'::\"char\", 'SCHEMAS'::text)");
+    expect(provisionerSource).toContain("('L'::\"char\", 'L'::\"char\", 'LARGE OBJECTS'::text)");
+    expect(provisionerSource).toContain('FROM pg_catalog.pg_parameter_acl AS parameter');
+    expect(provisionerSource).toContain('cluster prerequisite unexpected schema');
     expect(provisionerSource).toContain("CASE WHEN relation.relkind = 'S' THEN 's'::\"char\"");
     expect(provisionerSource).toContain("('S'::\"char\", 's'::\"char\", 'SEQUENCES'::text)");
     expect(provisionerSource).toContain('AND privilege.grantee = 0');
     expect(provisionerSource).toContain(
       'cluster-wide PUBLIC/default ACL prerequisites require separate reviewed remediation; apply never changes them',
     );
+  });
+
+  it('uses a durable two-phase rollback fence before session drain and drop', () => {
+    const provisionerSource = readFileSync('scripts/production-db-task-roles.mjs', 'utf8');
+    const rollbackStart = provisionerSource.indexOf('async function rollbackContract');
+    const rollbackSource = provisionerSource.slice(rollbackStart);
+    const noLoginIndex = rollbackSource.indexOf('ALTER ROLE ${quoteIdentifier(roleContract.name)} NOLOGIN');
+    const sessionProofIndex = rollbackSource.indexOf('collectManagedSessionRows(sqlClient)');
+    const dropIndex = rollbackSource.indexOf('DROP ROLE ${quoteIdentifier(roleContract.name)}');
+    expect(noLoginIndex).toBeGreaterThan(0);
+    expect(sessionProofIndex).toBeGreaterThan(noLoginIndex);
+    expect(dropIndex).toBeGreaterThan(sessionProofIndex);
+    expect(rollbackSource).toContain("managedRoleLoginState: 'nologin'");
+    expect(rollbackSource).toContain('roles remain fenced for recovery');
+    expect(rollbackSource).toContain('pg_catalog.pg_advisory_unlock');
+  });
+
+  it('reads and writes credentials only through verified no-follow descriptors', () => {
+    const provisionerSource = readFileSync('scripts/production-db-task-roles.mjs', 'utf8');
+    expect(provisionerSource).toContain('fileConstants.O_NOFOLLOW');
+    expect(provisionerSource).toContain('fileConstants.O_EXCL');
+    expect(provisionerSource).toContain("readFileSync(fileDescriptor, 'utf8')");
+    expect(provisionerSource).toContain('assertCredentialsParentStable(fileTarget)');
+    expect(provisionerSource).toContain('fileStats.nlink !== 1');
   });
 });

--- a/scripts/production-db-task-roles-contract.test.ts
+++ b/scripts/production-db-task-roles-contract.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { CATALOG_SNAPSHOT_TABLES } from '../packages/db/src/catalog-snapshot';
 import {
   MIGRATION_OWNER_ROLE,
+  PRODUCTION_MANAGED_SCHEMAS,
   PRODUCTION_TASK_RELATION_GRANTS,
   PRODUCTION_TASK_ROLES,
 } from './lib/production-db-task-role-contract.mjs';
@@ -75,6 +76,15 @@ describe('production database task-role contract', () => {
       MIGRATION_OWNER_ROLE,
     );
     expect(PRODUCTION_TASK_ROLES.find(({ name }) => name === 'boardsesh_snapshot_exporter')?.readOnly).toBe(true);
+    expect(PRODUCTION_MANAGED_SCHEMAS).toEqual(['public', 'drizzle']);
+    expect(PRODUCTION_TASK_ROLES.find(({ name }) => name === 'boardsesh_migrator')).toMatchObject({
+      databasePrivileges: ['CONNECT'],
+      schemaPrivileges: [],
+    });
+    expect(PRODUCTION_TASK_ROLES.find(({ name }) => name === 'boardsesh_climb_grades_refresh')).toMatchObject({
+      databasePrivileges: ['CONNECT', 'TEMPORARY'],
+      schemaPrivileges: ['USAGE'],
+    });
   });
 
   it('pins the workflow-derived relation privileges without duplicates', () => {
@@ -168,6 +178,45 @@ describe('production database task-role contract', () => {
     }
   });
 
+  it('proves application type values and defaults need no extra task-role grants', () => {
+    const latestSnapshotName = readdirSync('packages/db/drizzle/meta')
+      .filter((fileName) => /^\d+_snapshot\.json$/.test(fileName))
+      .sort((left, right) => left.localeCompare(right))
+      .at(-1);
+    expect(latestSnapshotName).toBeDefined();
+    const snapshot = JSON.parse(readFileSync(join('packages/db/drizzle/meta', latestSnapshotName!), 'utf8')) as {
+      enums: Record<string, { name: string }>;
+      tables: Record<
+        string,
+        { columns: Record<string, { name: string; type: string; default?: string | number | boolean }> }
+      >;
+    };
+    const enumNames = new Set(Object.values(snapshot.enums).map(({ name }) => name));
+    const taskTypeValueDependencies: string[] = [];
+    const taskDefaultRoutineNames = new Set<string>();
+    for (const { role, relation } of PRODUCTION_TASK_RELATION_GRANTS) {
+      const table = snapshot.tables[`public.${relation}`];
+      expect(table, `latest schema snapshot is missing public.${relation}`).toBeDefined();
+      for (const column of Object.values(table.columns)) {
+        if (enumNames.has(column.type)) {
+          taskTypeValueDependencies.push(`${role}|${relation}|${column.name}:${column.type}`);
+        }
+        if (typeof column.default === 'string') {
+          const routineMatch = /^([a-z_][a-z0-9_.]*)\(/i.exec(column.default);
+          if (routineMatch) taskDefaultRoutineNames.add(routineMatch[1]);
+        }
+      }
+    }
+    expect(taskTypeValueDependencies.sort((left, right) => left.localeCompare(right))).toEqual([
+      'boardsesh_climb_grades_refresh|boardsesh_ticks|aurora_type:aurora_table_type',
+      'boardsesh_climb_grades_refresh|boardsesh_ticks|kilter_type:kilter_table_type',
+      'boardsesh_climb_grades_refresh|boardsesh_ticks|origin:tick_origin',
+      'boardsesh_climb_grades_refresh|boardsesh_ticks|status:tick_status',
+      'boardsesh_hold_features_refresh|user_hold_classifications|hold_type:hold_type',
+    ]);
+    expect(taskDefaultRoutineNames).toEqual(new Set(['now']));
+  });
+
   it('generates a protected off-repository credential bundle without logging secrets', () => {
     const temporaryDirectory = mkdtempSync(join(tmpdir(), 'boardsesh-role-contract-'));
     temporaryDirectories.push(temporaryDirectory);
@@ -252,5 +301,22 @@ describe('production database task-role contract', () => {
     expect(smokeSource).not.toMatch(/--env\s+PGPASSWORD/);
     expect(smokeSource).not.toMatch(/postgresql:\/\/[^"']+\$\{?[^"']*password/i);
     expect(smokeSource).toContain("ROLLBACK_TASK_ROLES='DROP_EXACT_SIX_TASK_ROLES'");
+    expect(smokeSource).toContain('GRANT SELECT ON role_forbidden_probe TO PUBLIC');
+    expect(smokeSource).toContain(
+      'ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner GRANT EXECUTE ON ROUTINES TO PUBLIC',
+    );
+  });
+
+  it('audits effective PUBLIC and owner-default boundaries without applying broad revokes', () => {
+    const provisionerSource = readFileSync('scripts/production-db-task-roles.mjs', 'utf8');
+    expect(provisionerSource).toContain('collectClusterWideBoundaryDifferences');
+    expect(provisionerSource).toContain("pg_catalog.acldefault('d', database.datdba)");
+    expect(provisionerSource).toContain("pg_catalog.acldefault('n', namespace.nspowner)");
+    expect(provisionerSource).toContain("pg_catalog.acldefault('f', procedure.proowner)");
+    expect(provisionerSource).toContain("pg_catalog.acldefault('T', type_row.typowner)");
+    expect(provisionerSource).toContain('AND privilege.grantee = 0');
+    expect(provisionerSource).toContain(
+      'cluster-wide PUBLIC/default ACL prerequisites require separate reviewed remediation; apply never changes them',
+    );
   });
 });

--- a/scripts/production-db-task-roles-contract.test.ts
+++ b/scripts/production-db-task-roles-contract.test.ts
@@ -2,8 +2,10 @@
 
 import {
   chmodSync,
+  copyFileSync,
   existsSync,
   linkSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
@@ -23,6 +25,15 @@ import {
   PRODUCTION_TASK_RELATION_GRANTS,
   PRODUCTION_TASK_ROLES,
 } from './lib/production-db-task-role-contract.mjs';
+import {
+  ALLOWED_DATABASE_PRIVILEGES,
+  ALLOWED_RELATION_PRIVILEGES,
+  ALLOWED_SCHEMA_PRIVILEGES,
+  assertContractSqlSafety,
+  connectionLimitSql,
+  privilegeListSql,
+  quoteIdentifier,
+} from './lib/production-db-task-role-sql.mjs';
 
 const temporaryDirectories: string[] = [];
 
@@ -431,5 +442,204 @@ describe('production database task-role contract', () => {
     expect(provisionerSource).toContain("readFileSync(fileDescriptor, 'utf8')");
     expect(provisionerSource).toContain('assertCredentialsParentStable(fileTarget)');
     expect(provisionerSource).toContain('fileStats.nlink !== 1');
+  });
+});
+
+describe('production task-role SQL construction', () => {
+  const migratorContract = PRODUCTION_TASK_ROLES.find(({ name }) => name === 'boardsesh_migrator')!;
+
+  const poisonedRole = (overrides: Record<string, unknown>) => [{ ...migratorContract, ...overrides }];
+
+  const sortedKeywords = (keywords: Iterable<string>) => [...keywords].sort((left, right) => left.localeCompare(right));
+
+  it('accepts the shipped contract and grants only the keywords it declares', () => {
+    expect(() => assertContractSqlSafety(PRODUCTION_TASK_ROLES, PRODUCTION_TASK_RELATION_GRANTS)).not.toThrow();
+
+    const declaredDatabasePrivileges = sortedKeywords(
+      new Set(PRODUCTION_TASK_ROLES.flatMap(({ databasePrivileges }) => databasePrivileges)),
+    );
+    const declaredSchemaPrivileges = sortedKeywords(
+      new Set(PRODUCTION_TASK_ROLES.flatMap(({ schemaPrivileges }) => schemaPrivileges)),
+    );
+    const declaredRelationPrivileges = sortedKeywords(
+      new Set(PRODUCTION_TASK_RELATION_GRANTS.flatMap(({ privileges }) => privileges)),
+    );
+    expect(declaredDatabasePrivileges).toEqual(['CONNECT', 'TEMPORARY']);
+    expect(declaredSchemaPrivileges).toEqual(['USAGE']);
+    expect(declaredRelationPrivileges).toEqual(['DELETE', 'INSERT', 'SELECT', 'UPDATE']);
+
+    // The allowlists stay exactly as wide as the contract needs; widening one is a review decision.
+    expect(sortedKeywords(ALLOWED_DATABASE_PRIVILEGES)).toEqual(declaredDatabasePrivileges);
+    expect(sortedKeywords(ALLOWED_SCHEMA_PRIVILEGES)).toEqual(declaredSchemaPrivileges);
+    expect(sortedKeywords(ALLOWED_RELATION_PRIVILEGES)).toEqual(declaredRelationPrivileges);
+
+    expect(privilegeListSql('database', ['CONNECT', 'TEMPORARY'], 'test')).toBe('CONNECT, TEMPORARY');
+    expect(privilegeListSql('relation', ['DELETE', 'INSERT', 'SELECT', 'UPDATE'], 'test')).toBe(
+      'DELETE, INSERT, SELECT, UPDATE',
+    );
+  });
+
+  it('rejects a privilege that smuggles a statement past the contract shape', () => {
+    const injectedPrivilege = 'CONNECT; DROP ROLE boardsesh_owner --';
+    expect(() => privilegeListSql('database', [injectedPrivilege], 'boardsesh_migrator')).toThrow(
+      /unsafe database privilege/,
+    );
+    expect(() => assertContractSqlSafety(poisonedRole({ databasePrivileges: [injectedPrivilege] }), [])).toThrow(
+      /unsafe database privilege/,
+    );
+    expect(() =>
+      assertContractSqlSafety(poisonedRole({ schemaPrivileges: ['USAGE; DROP SCHEMA public'] }), []),
+    ).toThrow(/unsafe schema privilege/);
+    expect(() =>
+      assertContractSqlSafety(
+        [migratorContract],
+        [{ role: 'boardsesh_migrator', relation: 'board_climbs', privileges: ['SELECT; DROP TABLE board_climbs --'] }],
+      ),
+    ).toThrow(/unsafe relation privilege/);
+  });
+
+  it('rejects whitespace, case, and separator tricks around an allowed keyword', () => {
+    for (const disguisedPrivilege of [
+      ' CONNECT',
+      'CONNECT ',
+      'CONNECT\n',
+      'CONNECT\t',
+      'CON NECT',
+      'connect',
+      'Connect',
+      'CONNECT,TEMPORARY',
+      'CONNECT, TEMPORARY',
+      'CONNECT/*x*/',
+    ]) {
+      expect(() => privilegeListSql('database', [disguisedPrivilege], 'test'), disguisedPrivilege).toThrow(
+        /unsafe database privilege/,
+      );
+    }
+  });
+
+  it('rejects unknown keywords, cross-scope keywords, and non-string privileges', () => {
+    for (const unknownPrivilege of ['ALL', 'ALL PRIVILEGES', 'CREATE', 'EXECUTE', 'SUPERUSER', 'SELECT']) {
+      expect(() => privilegeListSql('database', [unknownPrivilege], 'test'), unknownPrivilege).toThrow(
+        /unsafe database privilege/,
+      );
+    }
+    // USAGE is a schema privilege only; CONNECT is a database privilege only.
+    expect(() => privilegeListSql('relation', ['USAGE'], 'test')).toThrow(/unsafe relation privilege/);
+    expect(() => privilegeListSql('relation', ['CONNECT'], 'test')).toThrow(/unsafe relation privilege/);
+    expect(() => privilegeListSql('schema', ['CREATE'], 'test')).toThrow(/unsafe schema privilege/);
+
+    for (const nonString of [null, undefined, 7, ['CONNECT'], { toString: () => 'CONNECT' }]) {
+      expect(() => privilegeListSql('database', [nonString], 'test')).toThrow(/unsafe database privilege/);
+    }
+    expect(() => privilegeListSql('database', 'CONNECT', 'test')).toThrow(
+      /must declare database privileges as an array/,
+    );
+    expect(() => privilegeListSql('database', [], 'test')).toThrow(/must grant at least one database privilege/);
+    expect(() => privilegeListSql('database', ['CONNECT', 'CONNECT'], 'test')).toThrow(/duplicate database privilege/);
+    expect(() => privilegeListSql('cluster', ['CONNECT'], 'test')).toThrow(/unknown privilege scope/);
+  });
+
+  it('rejects a connection limit that is not a bounded non-negative integer', () => {
+    expect(connectionLimitSql(2, 'test')).toBe('2');
+    expect(connectionLimitSql(10, 'test')).toBe('10');
+    expect(connectionLimitSql(0, 'test')).toBe('0');
+
+    for (const unsafeLimit of [
+      '2',
+      '2; DROP ROLE boardsesh_owner --',
+      '-1',
+      2.5,
+      -1,
+      -0.5,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.MAX_SAFE_INTEGER + 1,
+      1000,
+      null,
+      undefined,
+      true,
+      [2],
+    ]) {
+      expect(() => connectionLimitSql(unsafeLimit, 'test'), String(unsafeLimit)).toThrow(/unsafe connection limit/);
+      expect(() => assertContractSqlSafety(poisonedRole({ connectionLimit: unsafeLimit }), [])).toThrow(
+        /unsafe connection limit/,
+      );
+    }
+  });
+
+  it('rejects identifiers that would break out of double quotes', () => {
+    expect(quoteIdentifier('board_climbs')).toBe('"board_climbs"');
+    for (const unsafeIdentifier of [
+      'public"; DROP ROLE boardsesh_owner --',
+      'board climbs',
+      'Board_Climbs',
+      '1_climbs',
+      'board-climbs',
+      'board.climbs',
+      '',
+      null,
+      undefined,
+    ]) {
+      expect(() => quoteIdentifier(unsafeIdentifier), String(unsafeIdentifier)).toThrow(/unsafe PostgreSQL identifier/);
+    }
+    expect(() => assertContractSqlSafety(poisonedRole({ name: 'boardsesh_migrator"; DROP ROLE x --' }), [])).toThrow(
+      /unsafe PostgreSQL identifier/,
+    );
+    expect(() =>
+      assertContractSqlSafety(
+        [migratorContract],
+        [{ role: 'boardsesh_migrator', relation: 'board_climbs; DROP TABLE users', privileges: ['SELECT'] }],
+      ),
+    ).toThrow(/unsafe PostgreSQL identifier/);
+  });
+
+  it('refuses to run any command when the contract carries an injected privilege', () => {
+    const temporaryDirectory = mkdtempSync(join(tmpdir(), 'boardsesh-role-injection-'));
+    temporaryDirectories.push(temporaryDirectory);
+    // Bare specifiers such as `postgres` resolve by walking up from the copied script.
+    symlinkSync(resolve('node_modules'), join(temporaryDirectory, 'node_modules'), 'dir');
+    const scriptDirectory = join(temporaryDirectory, 'scripts');
+    mkdirSync(join(scriptDirectory, 'lib'), { recursive: true });
+    copyFileSync('scripts/production-db-task-roles.mjs', join(scriptDirectory, 'production-db-task-roles.mjs'));
+    copyFileSync(
+      'scripts/lib/production-db-task-role-sql.mjs',
+      join(scriptDirectory, 'lib', 'production-db-task-role-sql.mjs'),
+    );
+
+    const contractSource = readFileSync('scripts/lib/production-db-task-role-contract.mjs', 'utf8');
+    const poisonedSource = contractSource.replace(
+      "databasePrivileges: ['CONNECT'],",
+      "databasePrivileges: ['CONNECT; DROP ROLE boardsesh_owner --'],",
+    );
+    expect(poisonedSource, 'contract poisoning must actually change the source').not.toBe(contractSource);
+    writeFileSync(join(scriptDirectory, 'lib', 'production-db-task-role-contract.mjs'), poisonedSource);
+
+    for (const command of ['plan', 'audit', 'apply', 'rollback']) {
+      const result = spawnSync(process.execPath, [join(scriptDirectory, 'production-db-task-roles.mjs'), command], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ADMIN_DATABASE_URL: 'postgresql://postgres:sentinel@127.0.0.1:1/railway',
+          ALLOW_DISPOSABLE_TASK_ROLE_SMOKE: 'ALLOW_EXACT_LOOPBACK_FIXTURE',
+          APPLY_TASK_ROLE_CHANGES: 'APPLY_EXACT_SIX_TASK_ROLES',
+          ROLLBACK_TASK_ROLES: 'DROP_EXACT_SIX_TASK_ROLES',
+        },
+      });
+      expect(result.status, `${command}: ${result.stdout}${result.stderr}`).toBe(1);
+      expect(result.stderr, command).toContain('unsafe database privilege');
+    }
+  });
+
+  it('never interpolates a raw privilege list or connection limit into unsafe SQL', () => {
+    const provisionerSource = readFileSync('scripts/production-db-task-roles.mjs', 'utf8');
+    expect(provisionerSource).not.toMatch(/privileges\.join\(/);
+    expect(provisionerSource).not.toContain('CONNECTION LIMIT ${roleContract.connectionLimit}');
+    expect(provisionerSource).toContain(
+      'assertContractSqlSafety(PRODUCTION_TASK_ROLES, PRODUCTION_TASK_RELATION_GRANTS)',
+    );
+    expect(provisionerSource).toContain("privilegeListSql('database'");
+    expect(provisionerSource).toContain("privilegeListSql('schema'");
+    expect(provisionerSource).toContain("privilegeListSql('relation'");
+    expect(provisionerSource).toContain('connectionLimitSql(roleContract.connectionLimit');
   });
 });

--- a/scripts/production-db-task-roles-contract.test.ts
+++ b/scripts/production-db-task-roles-contract.test.ts
@@ -1,0 +1,256 @@
+/// <reference types="node" />
+
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CATALOG_SNAPSHOT_TABLES } from '../packages/db/src/catalog-snapshot';
+import {
+  MIGRATION_OWNER_ROLE,
+  PRODUCTION_TASK_RELATION_GRANTS,
+  PRODUCTION_TASK_ROLES,
+} from './lib/production-db-task-role-contract.mjs';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const temporaryDirectory of temporaryDirectories.splice(0)) {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+describe('production database task-role contract', () => {
+  it('pins the exact six activation identities and isolated credentials', () => {
+    expect(
+      PRODUCTION_TASK_ROLES.map(({ name, applicationName, githubSecret, connectionLimit }) => ({
+        name,
+        applicationName,
+        githubSecret,
+        connectionLimit,
+      })),
+    ).toEqual([
+      {
+        name: 'boardsesh_migrator',
+        applicationName: 'boardsesh-ci-migrate',
+        githubSecret: 'MIGRATION_DATABASE_DIRECT_URL',
+        connectionLimit: 2,
+      },
+      {
+        name: 'boardsesh_snapshot_exporter',
+        applicationName: 'boardsesh-ci-snapshot-export',
+        githubSecret: 'SNAPSHOT_DATABASE_DIRECT_URL',
+        connectionLimit: 10,
+      },
+      {
+        name: 'boardsesh_climb_grades_refresh',
+        applicationName: 'boardsesh-ci-climb-grades',
+        githubSecret: 'CLIMB_GRADES_DATABASE_DIRECT_URL',
+        connectionLimit: 2,
+      },
+      {
+        name: 'boardsesh_content_model_refresh',
+        applicationName: 'boardsesh-ci-content-model',
+        githubSecret: 'CONTENT_MODEL_DATABASE_DIRECT_URL',
+        connectionLimit: 2,
+      },
+      {
+        name: 'boardsesh_hold_features_refresh',
+        applicationName: 'boardsesh-ci-hold-features',
+        githubSecret: 'HOLD_FEATURES_DATABASE_DIRECT_URL',
+        connectionLimit: 2,
+      },
+      {
+        name: 'boardsesh_recommendations_refresh',
+        applicationName: 'boardsesh-ci-recommendations',
+        githubSecret: 'RECOMMENDATIONS_DATABASE_DIRECT_URL',
+        connectionLimit: 2,
+      },
+    ]);
+
+    expect(new Set(PRODUCTION_TASK_ROLES.map(({ name }) => name)).size).toBe(6);
+    expect(new Set(PRODUCTION_TASK_ROLES.map(({ applicationName }) => applicationName)).size).toBe(6);
+    expect(new Set(PRODUCTION_TASK_ROLES.map(({ githubSecret }) => githubSecret)).size).toBe(6);
+    expect(PRODUCTION_TASK_ROLES.find(({ name }) => name === 'boardsesh_migrator')?.setOnlyRole).toBe(
+      MIGRATION_OWNER_ROLE,
+    );
+    expect(PRODUCTION_TASK_ROLES.find(({ name }) => name === 'boardsesh_snapshot_exporter')?.readOnly).toBe(true);
+  });
+
+  it('pins the workflow-derived relation privileges without duplicates', () => {
+    const grantKeys = PRODUCTION_TASK_RELATION_GRANTS.map(
+      ({ role, relation, privileges }) => `${role}|${relation}|${privileges.join(',')}`,
+    );
+    expect(grantKeys).toEqual([
+      'boardsesh_climb_grades_refresh|board_climb_aliases|SELECT',
+      'boardsesh_climb_grades_refresh|board_climb_embeddings|SELECT',
+      'boardsesh_climb_grades_refresh|board_climb_grades|DELETE,INSERT,SELECT,UPDATE',
+      'boardsesh_climb_grades_refresh|board_climb_stats|SELECT',
+      'boardsesh_climb_grades_refresh|board_climb_stats_history|SELECT',
+      'boardsesh_climb_grades_refresh|board_climbs|SELECT',
+      'boardsesh_climb_grades_refresh|board_grade_coefficients|INSERT,SELECT,UPDATE',
+      'boardsesh_climb_grades_refresh|boardsesh_ticks|SELECT',
+      'boardsesh_climb_grades_refresh|user_boards|SELECT',
+      'boardsesh_content_model_refresh|board_climb_embeddings|INSERT,SELECT,UPDATE',
+      'boardsesh_content_model_refresh|board_climb_holds|SELECT',
+      'boardsesh_content_model_refresh|board_climb_similar|DELETE,INSERT,SELECT',
+      'boardsesh_content_model_refresh|board_climb_stats|SELECT',
+      'boardsesh_content_model_refresh|board_climbs|SELECT',
+      'boardsesh_content_model_refresh|board_hold_features|SELECT',
+      'boardsesh_content_model_refresh|board_placements|SELECT',
+      'boardsesh_hold_features_refresh|board_climb_holds|SELECT',
+      'boardsesh_hold_features_refresh|board_climb_stats|SELECT',
+      'boardsesh_hold_features_refresh|board_climbs|SELECT',
+      'boardsesh_hold_features_refresh|board_hold_features|INSERT,SELECT,UPDATE',
+      'boardsesh_hold_features_refresh|board_holes|SELECT',
+      'boardsesh_hold_features_refresh|board_placements|SELECT',
+      'boardsesh_hold_features_refresh|board_product_sizes_layouts_sets|SELECT',
+      'boardsesh_hold_features_refresh|board_sets|SELECT',
+      'boardsesh_hold_features_refresh|user_hold_classifications|INSERT,SELECT,UPDATE',
+      'boardsesh_hold_features_refresh|users|INSERT',
+      'boardsesh_recommendations_refresh|board_climb_send_stats|DELETE,INSERT,SELECT',
+      'boardsesh_recommendations_refresh|board_climb_stats|SELECT',
+      'boardsesh_recommendations_refresh|board_climb_stats_history|INSERT',
+      'boardsesh_recommendations_refresh|board_climbs|SELECT',
+      'boardsesh_recommendations_refresh|board_setter_stats|INSERT,SELECT,UPDATE',
+      'boardsesh_recommendations_refresh|board_shared_syncs|INSERT,SELECT,UPDATE',
+      'boardsesh_recommendations_refresh|playlist_climbs|DELETE,INSERT,SELECT',
+      'boardsesh_recommendations_refresh|playlist_ownership|INSERT,SELECT',
+      'boardsesh_recommendations_refresh|playlists|INSERT,SELECT,UPDATE',
+      'boardsesh_recommendations_refresh|sync_deletions|INSERT',
+      'boardsesh_recommendations_refresh|users|INSERT',
+      'boardsesh_snapshot_exporter|board_attempts|SELECT',
+      'boardsesh_snapshot_exporter|board_beta_links|SELECT',
+      'boardsesh_snapshot_exporter|board_climb_aliases|SELECT',
+      'boardsesh_snapshot_exporter|board_climb_grades|SELECT',
+      'boardsesh_snapshot_exporter|board_climb_stats|SELECT',
+      'boardsesh_snapshot_exporter|board_climbs|SELECT',
+      'boardsesh_snapshot_exporter|board_difficulty_grades|SELECT',
+      'boardsesh_snapshot_exporter|board_holes|SELECT',
+      'boardsesh_snapshot_exporter|board_kits|SELECT',
+      'boardsesh_snapshot_exporter|board_layouts|SELECT',
+      'boardsesh_snapshot_exporter|board_leds|SELECT',
+      'boardsesh_snapshot_exporter|board_placement_roles|SELECT',
+      'boardsesh_snapshot_exporter|board_placements|SELECT',
+      'boardsesh_snapshot_exporter|board_product_sizes|SELECT',
+      'boardsesh_snapshot_exporter|board_product_sizes_layouts_sets|SELECT',
+      'boardsesh_snapshot_exporter|board_products|SELECT',
+      'boardsesh_snapshot_exporter|board_sets|SELECT',
+    ]);
+    expect(new Set(PRODUCTION_TASK_RELATION_GRANTS.map(({ role, relation }) => `${role}|${relation}`)).size).toBe(
+      PRODUCTION_TASK_RELATION_GRANTS.length,
+    );
+  });
+
+  it('keeps snapshot SELECT grants synchronized with the catalog exporter', () => {
+    const snapshotRelations = new Set(
+      PRODUCTION_TASK_RELATION_GRANTS.filter(({ role }) => role === 'boardsesh_snapshot_exporter').map(
+        ({ relation }) => relation,
+      ),
+    );
+    expect(snapshotRelations).toEqual(
+      new Set([
+        'board_climbs',
+        'board_climb_stats',
+        'board_climb_grades',
+        ...CATALOG_SNAPSHOT_TABLES.map(({ name }) => name),
+      ]),
+    );
+  });
+
+  it('keeps every least-privilege grant tied to checked-in query evidence', () => {
+    for (const roleContract of PRODUCTION_TASK_ROLES) {
+      expect(roleContract.evidence.length).toBeGreaterThan(0);
+      for (const evidencePath of roleContract.evidence) expect(existsSync(evidencePath)).toBe(true);
+    }
+    for (const grantContract of PRODUCTION_TASK_RELATION_GRANTS) {
+      for (const evidencePath of grantContract.evidence.split(' + ')) expect(existsSync(evidencePath)).toBe(true);
+    }
+  });
+
+  it('generates a protected off-repository credential bundle without logging secrets', () => {
+    const temporaryDirectory = mkdtempSync(join(tmpdir(), 'boardsesh-role-contract-'));
+    temporaryDirectories.push(temporaryDirectory);
+    const credentialsFile = join(temporaryDirectory, 'roles.json');
+    const result = spawnSync(process.execPath, ['scripts/production-db-task-roles.mjs', 'generate'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ROLE_CREDENTIALS_FILE: credentialsFile,
+        POSTGRES_FORWARDER_HOST: 'boardsesh-db-forwarder.test.tailnet.ts.net',
+      },
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(statSync(credentialsFile).mode & 0o077).toBe(0);
+
+    const credentials = JSON.parse(readFileSync(credentialsFile, 'utf8')) as {
+      roles: Record<string, { password: string; databaseUrl: string }>;
+    };
+    expect(Object.keys(credentials.roles)).toHaveLength(6);
+    for (const credential of Object.values(credentials.roles)) {
+      expect(credential.password).toMatch(/^[a-f0-9]{64}$/);
+      expect(`${result.stdout}${result.stderr}`).not.toContain(credential.password);
+      expect(`${result.stdout}${result.stderr}`).not.toContain(credential.databaseUrl);
+    }
+  });
+
+  it('refuses repository credential files and secret argv', () => {
+    const repositoryCredentialPath = resolve('.boardsesh-production-task-roles.json');
+    const repositoryFileResult = spawnSync(process.execPath, ['scripts/production-db-task-roles.mjs', 'generate'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ROLE_CREDENTIALS_FILE: repositoryCredentialPath,
+        POSTGRES_FORWARDER_HOST: 'boardsesh-db-forwarder.test.tailnet.ts.net',
+      },
+    });
+    expect(repositoryFileResult.status).toBe(1);
+    expect(repositoryFileResult.stderr).toContain('must be outside the repository');
+    expect(existsSync(repositoryCredentialPath)).toBe(false);
+
+    const sentinelSecret = 'must-not-echo-this-secret';
+    const argvResult = spawnSync(
+      process.execPath,
+      ['scripts/production-db-task-roles.mjs', 'generate', sentinelSecret],
+      { encoding: 'utf8' },
+    );
+    expect(argvResult.status).toBe(1);
+    expect(`${argvResult.stdout}${argvResult.stderr}`).not.toContain(sentinelSecret);
+  });
+
+  it('rejects OTA, public, and unconfirmed loopback administrator targets before connecting', () => {
+    const wrongServiceResult = spawnSync(process.execPath, ['scripts/production-db-task-roles.mjs', 'plan'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ADMIN_DATABASE_URL: 'postgresql://postgres:sentinel@postgres.railway.internal:5432/railway?sslmode=require',
+        POSTGRES_FORWARDER_HOST: 'boardsesh-db-forwarder.test.tailnet.ts.net',
+      },
+    });
+    expect(wrongServiceResult.status).toBe(1);
+    expect(wrongServiceResult.stderr).toContain('must use the exact PostGIS forwarder host:5432');
+    expect(`${wrongServiceResult.stdout}${wrongServiceResult.stderr}`).not.toContain('sentinel');
+
+    const loopbackResult = spawnSync(process.execPath, ['scripts/production-db-task-roles.mjs', 'plan'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ADMIN_DATABASE_URL: 'postgresql://postgres:sentinel@127.0.0.1:1/railway',
+      },
+    });
+    expect(loopbackResult.status).toBe(1);
+    expect(loopbackResult.stderr).toContain('allowed only by the disposable-smoke confirmation');
+    expect(`${loopbackResult.stdout}${loopbackResult.stderr}`).not.toContain('sentinel');
+  });
+
+  it('keeps the disposable smoke credential-free on process argv', () => {
+    const smokeSource = readFileSync('scripts/production-db-task-roles-smoke.sh', 'utf8');
+    expect(statSync('scripts/production-db-task-roles-smoke.sh').mode & 0o111).not.toBe(0);
+    expect(smokeSource).toContain(
+      'postgres:18.6-bookworm@sha256:1c59e2c3c818eaa0f0628f695b36e7c9e362d6b219b36a54a32df645cbd7e1af',
+    );
+    expect(smokeSource).not.toMatch(/--env\s+PGPASSWORD/);
+    expect(smokeSource).not.toMatch(/postgresql:\/\/[^"']+\$\{?[^"']*password/i);
+    expect(smokeSource).toContain("ROLLBACK_TASK_ROLES='DROP_EXACT_SIX_TASK_ROLES'");
+  });
+});

--- a/scripts/production-db-task-roles-smoke.sh
+++ b/scripts/production-db-task-roles-smoke.sh
@@ -59,10 +59,23 @@ export ALLOW_DISPOSABLE_TASK_ROLE_SMOKE='ALLOW_EXACT_LOOPBACK_FIXTURE'
 
 {
   cat <<'SQL'
-REVOKE ALL PRIVILEGES ON DATABASE railway FROM PUBLIC;
-REVOKE ALL PRIVILEGES ON SCHEMA public FROM PUBLIC;
 CREATE ROLE boardsesh_owner NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION NOBYPASSRLS;
 GRANT CREATE ON DATABASE railway TO boardsesh_owner;
+GRANT CREATE, USAGE ON SCHEMA public TO boardsesh_owner;
+CREATE SCHEMA drizzle AUTHORIZATION boardsesh_owner;
+
+-- Model the reviewed PG18 role-transition baseline explicitly. PUBLIC keeps
+-- CONNECT, which every task role is allowed, but not TEMPORARY or access to
+-- either application schema. The migration owner cannot create future PUBLIC
+-- routines or types through PostgreSQL's built-in defaults.
+REVOKE TEMPORARY ON DATABASE railway FROM PUBLIC;
+REVOKE CREATE, USAGE ON SCHEMA public FROM PUBLIC;
+REVOKE CREATE, USAGE ON SCHEMA drizzle FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner REVOKE EXECUTE ON ROUTINES FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner REVOKE USAGE ON TYPES FROM PUBLIC;
+SET ROLE boardsesh_owner;
+CREATE TYPE public.hold_type AS ENUM ('jug', 'sloper', 'pinch', 'crimp', 'pocket');
+CREATE DOMAIN public.task_role_marker_domain AS text CHECK (VALUE <> 'domain-rejected');
 SQL
   ROLE_CONTRACT_MODULE="file://$REPOSITORY_ROOT/scripts/lib/production-db-task-role-contract.mjs" \
     node --input-type=module -e '
@@ -77,6 +90,10 @@ SQL
     done
   cat <<'SQL'
 CREATE TABLE public.role_forbidden_probe (id bigint PRIMARY KEY, marker text NOT NULL);
+ALTER TABLE public.user_hold_classifications
+  ADD COLUMN classification public.hold_type;
+ALTER TABLE public.board_climb_grades
+  ADD COLUMN typed_marker public.task_role_marker_domain;
 INSERT INTO public.role_forbidden_probe VALUES (1, 'must stay private');
 
 CREATE FUNCTION public.task_role_playlist_delete_probe() RETURNS trigger
@@ -97,15 +114,15 @@ CREATE TRIGGER task_role_playlist_delete
   AFTER DELETE ON public.playlist_climbs
   FOR EACH ROW EXECUTE FUNCTION public.task_role_playlist_delete_probe();
 
+CREATE FUNCTION public.task_role_forbidden_call() RETURNS text
+LANGUAGE sql AS 'SELECT ''must stay private''::text';
+
 INSERT INTO public.playlists(marker, uuid) VALUES ('seed', 'playlist-seed');
 INSERT INTO public.playlist_ownership(playlist_id, user_id, role)
 SELECT id, 'system-recommendations', 'owner' FROM public.playlists WHERE uuid = 'playlist-seed';
 INSERT INTO public.playlist_climbs(playlist_id, climb_uuid, marker)
 SELECT id, 'climb-seed', 'seed' FROM public.playlists WHERE uuid = 'playlist-seed';
-
-REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM PUBLIC;
-REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM PUBLIC;
-REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC;
+RESET ROLE;
 SQL
 } >"$FIXTURE_SQL"
 
@@ -166,11 +183,50 @@ assert_identity() {
   [[ "$identity" == "$role_name|$application_name" ]] || fail "identity/application_name mismatch for $role_name"
 }
 
+assert_no_type_usage() {
+  local role_name="$1" application_name="$2" privilege_state
+  privilege_state="$(run_role "$role_name" "$application_name" -Atq -c \
+    "SELECT has_type_privilege(current_user, 'public.hold_type', 'USAGE')::text || '|' || has_type_privilege(current_user, 'public.task_role_marker_domain', 'USAGE')::text;")"
+  [[ "$privilege_state" == 'false|false' ]] || fail "$role_name unexpectedly has application type USAGE"
+}
+
 assert_denied() {
   local role_name="$1" application_name="$2" statement="$3"
   if run_role "$role_name" "$application_name" -c "$statement" >/dev/null 2>&1; then
     fail "$role_name unexpectedly passed a denied privilege probe"
   fi
+}
+
+assert_cluster_boundary_drift() {
+  local expected_difference="$1" drift_label="$2"
+  if ADMIN_DATABASE_URL="$admin_url" \
+    node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" audit >"$REPORT_FILE" 2>&1; then
+    fail "expected $drift_label to fail audit"
+  fi
+  grep -Fq "$expected_difference" "$REPORT_FILE" || {
+    cat "$REPORT_FILE" >&2
+    fail "audit did not identify $drift_label"
+  }
+  if ADMIN_DATABASE_URL="$admin_url" \
+    APPLY_TASK_ROLE_CHANGES='APPLY_EXACT_SIX_TASK_ROLES' \
+    ROLE_CREDENTIALS_FILE="$CREDENTIALS_FILE" \
+    node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" apply >"$REPORT_FILE" 2>&1; then
+    fail "apply accepted $drift_label"
+  fi
+  grep -Fq \
+    'cluster-wide PUBLIC/default ACL prerequisites require separate reviewed remediation; apply never changes them' \
+    "$REPORT_FILE" || {
+    cat "$REPORT_FILE" >&2
+    fail "apply did not refuse $drift_label as a cluster-wide prerequisite"
+  }
+  if ADMIN_DATABASE_URL="$admin_url" \
+    node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" audit >"$REPORT_FILE" 2>&1; then
+    fail "apply silently remediated $drift_label"
+  fi
+  grep -Fq "$expected_difference" "$REPORT_FILE" || {
+    cat "$REPORT_FILE" >&2
+    fail "apply changed $drift_label before refusing it"
+  }
 }
 
 assert_identity boardsesh_migrator boardsesh-ci-migrate
@@ -179,6 +235,12 @@ assert_identity boardsesh_climb_grades_refresh boardsesh-ci-climb-grades
 assert_identity boardsesh_content_model_refresh boardsesh-ci-content-model
 assert_identity boardsesh_hold_features_refresh boardsesh-ci-hold-features
 assert_identity boardsesh_recommendations_refresh boardsesh-ci-recommendations
+
+assert_no_type_usage boardsesh_climb_grades_refresh boardsesh-ci-climb-grades
+assert_no_type_usage boardsesh_hold_features_refresh boardsesh-ci-hold-features
+trigger_execute_state="$(run_role boardsesh_recommendations_refresh boardsesh-ci-recommendations -Atq -c \
+  "SELECT has_function_privilege(current_user, 'public.task_role_playlist_delete_probe()', 'EXECUTE')::text;")"
+[[ "$trigger_execute_state" == 'false' ]] || fail 'recommendations role unexpectedly has trigger routine EXECUTE'
 
 run_role boardsesh_migrator boardsesh-ci-migrate <<'SQL' >/dev/null
 BEGIN;
@@ -208,6 +270,8 @@ SELECT 1 FROM boardsesh_ticks LIMIT 0;
 INSERT INTO board_grade_coefficients(marker) VALUES ('probe');
 UPDATE board_grade_coefficients SET marker = 'updated' WHERE marker = 'probe';
 INSERT INTO board_climb_grades(marker) VALUES ('probe');
+UPDATE board_climb_grades SET typed_marker = 'domain-probe' WHERE marker = 'probe';
+SELECT typed_marker FROM board_climb_grades WHERE marker = 'probe';
 DELETE FROM board_climb_grades WHERE marker = 'probe';
 ROLLBACK;
 SQL
@@ -231,6 +295,8 @@ INSERT INTO users(marker) VALUES ('probe');
 INSERT INTO board_hold_features(marker) VALUES ('probe');
 UPDATE board_hold_features SET marker = 'updated' WHERE marker = 'probe';
 INSERT INTO user_hold_classifications(marker) VALUES ('probe');
+UPDATE user_hold_classifications SET classification = 'crimp' WHERE marker = 'probe';
+SELECT classification FROM user_hold_classifications WHERE marker = 'probe';
 UPDATE user_hold_classifications SET marker = 'updated' WHERE marker = 'probe';
 ROLLBACK;
 SQL
@@ -265,9 +331,86 @@ for identity_pair in \
   role_name="${identity_pair%%|*}"
   application_name="${identity_pair#*|}"
   assert_denied "$role_name" "$application_name" 'SELECT * FROM role_forbidden_probe'
+  assert_denied "$role_name" "$application_name" 'SELECT task_role_forbidden_call()'
   assert_denied "$role_name" "$application_name" \
     "BEGIN; CREATE SCHEMA ${role_name}_must_not_create; ROLLBACK;"
 done
+
+# PUBLIC is an implicit member of every login. Prove that plan/audit resolves
+# PostgreSQL defaults, apply refuses to change cluster-wide policy, and a
+# separately reviewed operator remediation returns the exact contract to green.
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'GRANT TEMPORARY ON DATABASE railway TO PUBLIC' >/dev/null
+assert_cluster_boundary_drift \
+  'cluster prerequisite PUBLIC|database|railway|TEMPORARY|grantable=false; reviewed remediation: REVOKE TEMPORARY ON DATABASE railway FROM PUBLIC' \
+  'PUBLIC database TEMPORARY drift'
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'REVOKE TEMPORARY ON DATABASE railway FROM PUBLIC' >/dev/null
+
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'GRANT CREATE, USAGE ON SCHEMA public TO PUBLIC' >/dev/null
+assert_cluster_boundary_drift \
+  'cluster prerequisite PUBLIC|schema|public|CREATE|grantable=false; reviewed remediation: REVOKE CREATE ON SCHEMA public FROM PUBLIC' \
+  'PUBLIC schema CREATE/USAGE drift'
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'REVOKE CREATE, USAGE ON SCHEMA public FROM PUBLIC' >/dev/null
+
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'GRANT SELECT ON role_forbidden_probe TO PUBLIC' >/dev/null
+assert_cluster_boundary_drift \
+  'cluster prerequisite PUBLIC|relation|public.role_forbidden_probe|SELECT|grantable=false; reviewed remediation: REVOKE SELECT ON TABLE public.role_forbidden_probe FROM PUBLIC' \
+  'PUBLIC table drift'
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'REVOKE SELECT ON role_forbidden_probe FROM PUBLIC' >/dev/null
+
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'GRANT USAGE ON SEQUENCE playlists_id_seq TO PUBLIC' >/dev/null
+assert_cluster_boundary_drift \
+  'cluster prerequisite PUBLIC|sequence|public.playlists_id_seq|USAGE|grantable=false; reviewed remediation: REVOKE USAGE ON SEQUENCE public.playlists_id_seq FROM PUBLIC' \
+  'PUBLIC sequence drift'
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'REVOKE USAGE ON SEQUENCE playlists_id_seq FROM PUBLIC' >/dev/null
+
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'GRANT EXECUTE ON FUNCTION task_role_playlist_delete_probe() TO PUBLIC' >/dev/null
+assert_cluster_boundary_drift \
+  'cluster prerequisite PUBLIC|routine|task_role_playlist_delete_probe()|EXECUTE|grantable=false; reviewed remediation: REVOKE EXECUTE ON ROUTINE task_role_playlist_delete_probe() FROM PUBLIC' \
+  'PUBLIC current-routine drift'
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'REVOKE EXECUTE ON FUNCTION task_role_playlist_delete_probe() FROM PUBLIC' >/dev/null
+
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner GRANT EXECUTE ON ROUTINES TO PUBLIC' >/dev/null
+assert_cluster_boundary_drift \
+  'cluster prerequisite PUBLIC|default_acl|boardsesh_owner:*:f|EXECUTE|grantable=false; reviewed remediation: ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner REVOKE EXECUTE ON ROUTINES FROM PUBLIC' \
+  'migration-owner global default-routine drift'
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner REVOKE EXECUTE ON ROUTINES FROM PUBLIC' >/dev/null
+
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner IN SCHEMA public GRANT SELECT ON TABLES TO PUBLIC' >/dev/null
+assert_cluster_boundary_drift \
+  'cluster prerequisite PUBLIC|default_acl|boardsesh_owner:public:r|SELECT|grantable=false; reviewed remediation: ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner IN SCHEMA public REVOKE SELECT ON TABLES FROM PUBLIC' \
+  'migration-owner schema default-table drift'
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner IN SCHEMA public REVOKE SELECT ON TABLES FROM PUBLIC' >/dev/null
+
+ADMIN_DATABASE_URL="$admin_url" \
+  node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" audit >/dev/null
 
 # Add one reviewed-role ACL outside the manifest. Audit must show the exact diff,
 # rollback must refuse the drift, and apply must remove it without touching data.

--- a/scripts/production-db-task-roles-smoke.sh
+++ b/scripts/production-db-task-roles-smoke.sh
@@ -65,10 +65,13 @@ GRANT CREATE, USAGE ON SCHEMA public TO boardsesh_owner;
 CREATE SCHEMA drizzle AUTHORIZATION boardsesh_owner;
 
 -- Model the reviewed PG18 role-transition baseline explicitly. PUBLIC keeps
--- CONNECT, which every task role is allowed, but not TEMPORARY or access to
--- either application schema. The migration owner cannot create future PUBLIC
--- routines or types through PostgreSQL's built-in defaults.
+-- CONNECT to railway, which every task role is allowed, but not TEMPORARY or
+-- access to another connectable database/application schema. The migration
+-- owner cannot create future PUBLIC routines or types through PostgreSQL's
+-- built-in defaults.
 REVOKE TEMPORARY ON DATABASE railway FROM PUBLIC;
+REVOKE CONNECT, TEMPORARY ON DATABASE postgres FROM PUBLIC;
+REVOKE CONNECT, TEMPORARY ON DATABASE template1 FROM PUBLIC;
 REVOKE CREATE, USAGE ON SCHEMA public FROM PUBLIC;
 REVOKE CREATE, USAGE ON SCHEMA drizzle FROM PUBLIC;
 ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner REVOKE EXECUTE ON ROUTINES FROM PUBLIC;
@@ -339,6 +342,16 @@ done
 # PUBLIC is an implicit member of every login. Prove that plan/audit resolves
 # PostgreSQL defaults, apply refuses to change cluster-wide policy, and a
 # separately reviewed operator remediation returns the exact contract to green.
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'GRANT CONNECT ON DATABASE postgres TO PUBLIC' >/dev/null
+assert_cluster_boundary_drift \
+  'cluster prerequisite PUBLIC|database|postgres|CONNECT|grantable=false; reviewed remediation: REVOKE CONNECT ON DATABASE postgres FROM PUBLIC' \
+  'PUBLIC alternate-database CONNECT drift'
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'REVOKE CONNECT ON DATABASE postgres FROM PUBLIC' >/dev/null
+
 docker exec "$CONTAINER_NAME" \
   psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
   -c 'GRANT TEMPORARY ON DATABASE railway TO PUBLIC' >/dev/null

--- a/scripts/production-db-task-roles-smoke.sh
+++ b/scripts/production-db-task-roles-smoke.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+if [[ $- == *x* ]]; then
+  set +x
+fi
+set -Eeuo pipefail
+umask 077
+
+REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly REPOSITORY_ROOT
+readonly POSTGRES_IMAGE='postgres:18.6-bookworm@sha256:1c59e2c3c818eaa0f0628f695b36e7c9e362d6b219b36a54a32df645cbd7e1af'
+readonly CONTAINER_NAME="boardsesh-task-roles-${GITHUB_RUN_ID:-local}-${$}"
+TASK_TEMP_DIRECTORY="$(mktemp -d "${TMPDIR:-/tmp}/boardsesh-task-roles.XXXXXX")"
+readonly TASK_TEMP_DIRECTORY
+readonly CREDENTIALS_FILE="$TASK_TEMP_DIRECTORY/credentials.json"
+readonly PGPASS_FILE="$TASK_TEMP_DIRECTORY/pgpass"
+readonly FIXTURE_SQL="$TASK_TEMP_DIRECTORY/fixture.sql"
+readonly REPORT_FILE="$TASK_TEMP_DIRECTORY/report.txt"
+
+cleanup() {
+  docker rm --force "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  rm -rf "$TASK_TEMP_DIRECTORY"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+docker run --detach \
+  --name "$CONTAINER_NAME" \
+  --env POSTGRES_USER=postgres \
+  --env POSTGRES_PASSWORD=postgres \
+  --env POSTGRES_DB=railway \
+  --volume "$TASK_TEMP_DIRECTORY:/run/boardsesh-task-roles" \
+  --publish 127.0.0.1::5432 \
+  "$POSTGRES_IMAGE" >/dev/null
+
+host_port="$(docker port "$CONTAINER_NAME" 5432/tcp | sed -n 's/^127\.0\.0\.1://p' | head -n 1)"
+[[ "$host_port" =~ ^[0-9]+$ ]] || fail 'could not resolve disposable PostgreSQL port'
+readonly host_port
+
+attempt=0
+while [[ "$attempt" -lt 120 ]]; do
+  if docker exec "$CONTAINER_NAME" \
+    pg_isready --quiet -h 127.0.0.1 -p 5432 -U postgres -d railway; then
+    break
+  fi
+  attempt=$((attempt + 1))
+  sleep 1
+done
+if [[ "$attempt" -eq 120 ]]; then
+  docker logs "$CONTAINER_NAME" >&2 || true
+  fail 'disposable PostgreSQL did not become ready'
+fi
+
+readonly admin_url="postgresql://postgres:postgres@127.0.0.1:${host_port}/railway"
+export ALLOW_DISPOSABLE_TASK_ROLE_SMOKE='ALLOW_EXACT_LOOPBACK_FIXTURE'
+
+{
+  cat <<'SQL'
+REVOKE ALL PRIVILEGES ON DATABASE railway FROM PUBLIC;
+REVOKE ALL PRIVILEGES ON SCHEMA public FROM PUBLIC;
+CREATE ROLE boardsesh_owner NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION NOBYPASSRLS;
+GRANT CREATE ON DATABASE railway TO boardsesh_owner;
+SQL
+  ROLE_CONTRACT_MODULE="file://$REPOSITORY_ROOT/scripts/lib/production-db-task-role-contract.mjs" \
+    node --input-type=module -e '
+      const contract = await import(process.env.ROLE_CONTRACT_MODULE);
+      const relationNames = [...new Set(contract.PRODUCTION_TASK_RELATION_GRANTS.map(({ relation }) => relation))]
+        .sort((left, right) => left.localeCompare(right));
+      for (const relationName of relationNames) process.stdout.write(`${relationName}\n`);
+    ' | while IFS= read -r relation_name; do
+      [[ "$relation_name" =~ ^[a-z_][a-z0-9_]*$ ]] || fail "unsafe fixture relation $relation_name"
+      printf 'CREATE TABLE public.%s (id bigserial PRIMARY KEY, marker text, board_type text, climb_uuid text, playlist_id bigint, user_id text, uuid text, role text, table_name text, record_id text);\n' \
+        "$relation_name"
+    done
+  cat <<'SQL'
+CREATE TABLE public.role_forbidden_probe (id bigint PRIMARY KEY, marker text NOT NULL);
+INSERT INTO public.role_forbidden_probe VALUES (1, 'must stay private');
+
+CREATE FUNCTION public.task_role_playlist_delete_probe() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+  playlist_uuid text;
+  owner_id text;
+BEGIN
+  SELECT uuid INTO playlist_uuid FROM public.playlists WHERE id = OLD.playlist_id;
+  SELECT user_id INTO owner_id FROM public.playlist_ownership
+    WHERE playlist_id = OLD.playlist_id AND role = 'owner' LIMIT 1;
+  INSERT INTO public.sync_deletions(table_name, record_id, user_id)
+  VALUES ('playlist_climbs', playlist_uuid || ':' || OLD.climb_uuid, owner_id);
+  RETURN OLD;
+END;
+$$;
+CREATE TRIGGER task_role_playlist_delete
+  AFTER DELETE ON public.playlist_climbs
+  FOR EACH ROW EXECUTE FUNCTION public.task_role_playlist_delete_probe();
+
+INSERT INTO public.playlists(marker, uuid) VALUES ('seed', 'playlist-seed');
+INSERT INTO public.playlist_ownership(playlist_id, user_id, role)
+SELECT id, 'system-recommendations', 'owner' FROM public.playlists WHERE uuid = 'playlist-seed';
+INSERT INTO public.playlist_climbs(playlist_id, climb_uuid, marker)
+SELECT id, 'climb-seed', 'seed' FROM public.playlists WHERE uuid = 'playlist-seed';
+
+REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM PUBLIC;
+REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM PUBLIC;
+REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC;
+SQL
+} >"$FIXTURE_SQL"
+
+docker exec --interactive "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  <"$FIXTURE_SQL" >/dev/null
+
+ROLE_CREDENTIALS_FILE="$CREDENTIALS_FILE" \
+POSTGRES_FORWARDER_HOST='boardsesh-db-forwarder.smoke.tailnet.ts.net' \
+  node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" generate >/dev/null
+
+if ! ADMIN_DATABASE_URL="$admin_url" \
+  APPLY_TASK_ROLE_CHANGES='APPLY_EXACT_SIX_TASK_ROLES' \
+  ROLE_CREDENTIALS_FILE="$CREDENTIALS_FILE" \
+  node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" apply >"$REPORT_FILE" 2>&1; then
+  cat "$REPORT_FILE" >&2
+  fail 'initial task-role apply failed'
+fi
+
+# The second apply proves idempotency while rotating to the same six passwords.
+ADMIN_DATABASE_URL="$admin_url" \
+APPLY_TASK_ROLE_CHANGES='APPLY_EXACT_SIX_TASK_ROLES' \
+ROLE_CREDENTIALS_FILE="$CREDENTIALS_FILE" \
+  node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" apply >/dev/null
+
+ADMIN_DATABASE_URL="$admin_url" \
+  node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" audit >/dev/null
+
+ROLE_CREDENTIALS_FILE="$CREDENTIALS_FILE" \
+PGPASS_TARGET="$PGPASS_FILE" \
+PGPASS_HOST=127.0.0.1 \
+PGPASS_PORT=5432 \
+  node --input-type=module -e '
+    import { readFileSync, writeFileSync } from "node:fs";
+    const credentials = JSON.parse(readFileSync(process.env.ROLE_CREDENTIALS_FILE, "utf8"));
+    const lines = Object.entries(credentials.roles).map(
+      ([roleName, credential]) =>
+        `${process.env.PGPASS_HOST}:${process.env.PGPASS_PORT}:railway:${roleName}:${credential.password}`,
+    );
+    writeFileSync(process.env.PGPASS_TARGET, `${lines.join("\n")}\n`, { mode: 0o600 });
+  '
+
+run_role() {
+  local role_name="$1" application_name="$2"
+  shift 2
+  docker exec --interactive \
+    --env PGPASSFILE=/run/boardsesh-task-roles/pgpass \
+    --env PGAPPNAME="$application_name" \
+    "$CONTAINER_NAME" \
+    psql -X -v ON_ERROR_STOP=1 \
+      -h 127.0.0.1 -p 5432 -U "$role_name" -d railway "$@"
+}
+
+assert_identity() {
+  local role_name="$1" application_name="$2" identity
+  identity="$(run_role "$role_name" "$application_name" -Atq \
+    -c "SELECT current_user || '|' || current_setting('application_name');")"
+  [[ "$identity" == "$role_name|$application_name" ]] || fail "identity/application_name mismatch for $role_name"
+}
+
+assert_denied() {
+  local role_name="$1" application_name="$2" statement="$3"
+  if run_role "$role_name" "$application_name" -c "$statement" >/dev/null 2>&1; then
+    fail "$role_name unexpectedly passed a denied privilege probe"
+  fi
+}
+
+assert_identity boardsesh_migrator boardsesh-ci-migrate
+assert_identity boardsesh_snapshot_exporter boardsesh-ci-snapshot-export
+assert_identity boardsesh_climb_grades_refresh boardsesh-ci-climb-grades
+assert_identity boardsesh_content_model_refresh boardsesh-ci-content-model
+assert_identity boardsesh_hold_features_refresh boardsesh-ci-hold-features
+assert_identity boardsesh_recommendations_refresh boardsesh-ci-recommendations
+
+run_role boardsesh_migrator boardsesh-ci-migrate <<'SQL' >/dev/null
+BEGIN;
+SET LOCAL ROLE boardsesh_owner;
+CREATE SCHEMA boardsesh_task_role_migrator_rollback_probe;
+ROLLBACK;
+SQL
+
+run_role boardsesh_snapshot_exporter boardsesh-ci-snapshot-export <<'SQL' >/dev/null
+BEGIN;
+SELECT current_setting('transaction_read_only') = 'on';
+SELECT 1 FROM board_climbs LIMIT 0;
+SELECT 1 FROM board_climb_stats LIMIT 0;
+SELECT 1 FROM board_climb_grades LIMIT 0;
+SELECT 1 FROM board_products LIMIT 0;
+SELECT 1 FROM board_beta_links LIMIT 0;
+ROLLBACK;
+SQL
+assert_denied boardsesh_snapshot_exporter boardsesh-ci-snapshot-export \
+  "INSERT INTO board_climbs(marker) VALUES ('forbidden')"
+
+run_role boardsesh_climb_grades_refresh boardsesh-ci-climb-grades <<'SQL' >/dev/null
+BEGIN;
+CREATE TEMP TABLE grade_refresh_keys(id bigint);
+SELECT 1 FROM board_climb_embeddings LIMIT 0;
+SELECT 1 FROM boardsesh_ticks LIMIT 0;
+INSERT INTO board_grade_coefficients(marker) VALUES ('probe');
+UPDATE board_grade_coefficients SET marker = 'updated' WHERE marker = 'probe';
+INSERT INTO board_climb_grades(marker) VALUES ('probe');
+DELETE FROM board_climb_grades WHERE marker = 'probe';
+ROLLBACK;
+SQL
+
+run_role boardsesh_content_model_refresh boardsesh-ci-content-model <<'SQL' >/dev/null
+BEGIN;
+SELECT 1 FROM board_hold_features LIMIT 0;
+SELECT 1 FROM board_climb_holds LIMIT 0;
+INSERT INTO board_climb_embeddings(marker) VALUES ('probe');
+UPDATE board_climb_embeddings SET marker = 'updated' WHERE marker = 'probe';
+INSERT INTO board_climb_similar(marker) VALUES ('probe');
+DELETE FROM board_climb_similar WHERE marker = 'probe';
+ROLLBACK;
+SQL
+
+run_role boardsesh_hold_features_refresh boardsesh-ci-hold-features <<'SQL' >/dev/null
+BEGIN;
+SELECT 1 FROM board_placements LIMIT 0;
+SELECT 1 FROM board_product_sizes_layouts_sets LIMIT 0;
+INSERT INTO users(marker) VALUES ('probe');
+INSERT INTO board_hold_features(marker) VALUES ('probe');
+UPDATE board_hold_features SET marker = 'updated' WHERE marker = 'probe';
+INSERT INTO user_hold_classifications(marker) VALUES ('probe');
+UPDATE user_hold_classifications SET marker = 'updated' WHERE marker = 'probe';
+ROLLBACK;
+SQL
+
+run_role boardsesh_recommendations_refresh boardsesh-ci-recommendations <<'SQL' >/dev/null
+BEGIN;
+SELECT 1 FROM board_climbs LIMIT 0;
+INSERT INTO users(marker) VALUES ('probe');
+INSERT INTO board_setter_stats(marker) VALUES ('probe');
+UPDATE board_setter_stats SET marker = 'updated' WHERE marker = 'probe';
+INSERT INTO board_climb_send_stats(marker) VALUES ('probe');
+DELETE FROM board_climb_send_stats WHERE marker = 'probe';
+INSERT INTO board_climb_stats_history(marker) VALUES ('probe');
+INSERT INTO board_shared_syncs(marker) VALUES ('probe');
+UPDATE board_shared_syncs SET marker = 'updated' WHERE marker = 'probe';
+INSERT INTO playlists(marker, uuid) VALUES ('probe', 'playlist-probe');
+INSERT INTO playlist_ownership(playlist_id, user_id, role)
+SELECT id, 'system-recommendations', 'owner' FROM playlists WHERE uuid = 'playlist-probe';
+INSERT INTO playlist_climbs(playlist_id, climb_uuid, marker)
+SELECT id, 'climb-probe', 'probe' FROM playlists WHERE uuid = 'playlist-probe';
+DELETE FROM playlist_climbs WHERE marker = 'probe';
+ROLLBACK;
+SQL
+
+for identity_pair in \
+  'boardsesh_migrator|boardsesh-ci-migrate' \
+  'boardsesh_snapshot_exporter|boardsesh-ci-snapshot-export' \
+  'boardsesh_climb_grades_refresh|boardsesh-ci-climb-grades' \
+  'boardsesh_content_model_refresh|boardsesh-ci-content-model' \
+  'boardsesh_hold_features_refresh|boardsesh-ci-hold-features' \
+  'boardsesh_recommendations_refresh|boardsesh-ci-recommendations'; do
+  role_name="${identity_pair%%|*}"
+  application_name="${identity_pair#*|}"
+  assert_denied "$role_name" "$application_name" 'SELECT * FROM role_forbidden_probe'
+  assert_denied "$role_name" "$application_name" \
+    "BEGIN; CREATE SCHEMA ${role_name}_must_not_create; ROLLBACK;"
+done
+
+# Add one reviewed-role ACL outside the manifest. Audit must show the exact diff,
+# rollback must refuse the drift, and apply must remove it without touching data.
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'GRANT SELECT ON role_forbidden_probe TO boardsesh_content_model_refresh WITH GRANT OPTION' >/dev/null
+if ADMIN_DATABASE_URL="$admin_url" \
+  node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" audit >"$REPORT_FILE" 2>&1; then
+  fail 'expected an injected grant drift to fail audit'
+fi
+grep -Fq \
+  'unexpected grant boardsesh_content_model_refresh|relation|public.role_forbidden_probe|SELECT' \
+  "$REPORT_FILE" || { cat "$REPORT_FILE" >&2; fail 'grant diff did not identify the injected ACL'; }
+grep -Fq \
+  'grant option forbidden boardsesh_content_model_refresh|relation|public.role_forbidden_probe|SELECT' \
+  "$REPORT_FILE" || { cat "$REPORT_FILE" >&2; fail 'grant diff did not identify the injected grant option'; }
+
+if ADMIN_DATABASE_URL="$admin_url" \
+  ROLLBACK_TASK_ROLES='DROP_EXACT_SIX_TASK_ROLES' \
+  node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" rollback >"$REPORT_FILE" 2>&1; then
+  fail 'rollback accepted a drifted role contract'
+fi
+grep -Fq 'rollback refuses a partial or drifted role contract' "$REPORT_FILE" || {
+  cat "$REPORT_FILE" >&2
+  fail 'rollback drift guard did not report its refusal'
+}
+
+if ADMIN_DATABASE_URL="$admin_url" \
+  APPLY_TASK_ROLE_CHANGES='APPLY_EXACT_SIX_TASK_ROLES' \
+  ROLE_CREDENTIALS_FILE="$CREDENTIALS_FILE" \
+  node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" apply >"$REPORT_FILE" 2>&1; then
+  fail 'apply accepted an unexpected grant option'
+fi
+grep -Fq 'managed role has a grant option; downstream grants require manual review' "$REPORT_FILE" || {
+  cat "$REPORT_FILE" >&2
+  fail 'apply grant-option guard did not report its refusal'
+}
+
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'REVOKE GRANT OPTION FOR SELECT ON role_forbidden_probe FROM boardsesh_content_model_refresh' >/dev/null
+
+ADMIN_DATABASE_URL="$admin_url" \
+APPLY_TASK_ROLE_CHANGES='APPLY_EXACT_SIX_TASK_ROLES' \
+ROLE_CREDENTIALS_FILE="$CREDENTIALS_FILE" \
+  node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" apply >/dev/null
+
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'CREATE POLICY task_role_forbidden_policy ON role_forbidden_probe TO boardsesh_content_model_refresh USING (true)' >/dev/null
+if ADMIN_DATABASE_URL="$admin_url" \
+  node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" audit >"$REPORT_FILE" 2>&1; then
+  fail 'expected an injected RLS role reference to fail audit'
+fi
+grep -Fq \
+  'unexpected RLS policy boardsesh_content_model_refresh|public.role_forbidden_probe|task_role_forbidden_policy' \
+  "$REPORT_FILE" || { cat "$REPORT_FILE" >&2; fail 'audit did not identify the injected RLS policy'; }
+if ADMIN_DATABASE_URL="$admin_url" \
+  APPLY_TASK_ROLE_CHANGES='APPLY_EXACT_SIX_TASK_ROLES' \
+  ROLE_CREDENTIALS_FILE="$CREDENTIALS_FILE" \
+  node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" apply >"$REPORT_FILE" 2>&1; then
+  fail 'apply accepted an unexpected RLS role reference'
+fi
+grep -Fq 'managed role is named in an RLS policy; manual policy review is required' "$REPORT_FILE" || {
+  cat "$REPORT_FILE" >&2
+  fail 'apply RLS-policy guard did not report its refusal'
+}
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'DROP POLICY task_role_forbidden_policy ON role_forbidden_probe' >/dev/null
+ADMIN_DATABASE_URL="$admin_url" \
+  node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" audit >/dev/null
+
+ADMIN_DATABASE_URL="$admin_url" \
+ROLLBACK_TASK_ROLES='DROP_EXACT_SIX_TASK_ROLES' \
+  node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" rollback >/dev/null
+ADMIN_DATABASE_URL="$admin_url" \
+ROLLBACK_TASK_ROLES='DROP_EXACT_SIX_TASK_ROLES' \
+  node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" rollback >/dev/null
+
+survival_contract="$(docker exec "$CONTAINER_NAME" \
+  psql -X -Atq -U postgres -d railway -c "
+SELECT (SELECT count(*) = 0 FROM pg_roles WHERE rolname IN (
+         'boardsesh_migrator', 'boardsesh_snapshot_exporter', 'boardsesh_climb_grades_refresh',
+         'boardsesh_content_model_refresh', 'boardsesh_hold_features_refresh',
+         'boardsesh_recommendations_refresh'))::text || '|' ||
+       (to_regrole('boardsesh_owner') IS NOT NULL)::text || '|' ||
+       (to_regclass('public.role_forbidden_probe') IS NOT NULL)::text || '|' ||
+       (SELECT marker FROM role_forbidden_probe WHERE id = 1);")"
+[[ "$survival_contract" == 'true|true|true|must stay private' ]] || fail 'rollback touched owner or application data'
+
+printf 'Production task-role disposable PostgreSQL smoke passed.\n'

--- a/scripts/production-db-task-roles-smoke.sh
+++ b/scripts/production-db-task-roles-smoke.sh
@@ -120,6 +120,8 @@ CREATE TRIGGER task_role_playlist_delete
 CREATE FUNCTION public.task_role_forbidden_call() RETURNS text
 LANGUAGE sql AS 'SELECT ''must stay private''::text';
 
+SELECT pg_catalog.lo_create(918273);
+
 INSERT INTO public.playlists(marker, uuid) VALUES ('seed', 'playlist-seed');
 INSERT INTO public.playlist_ownership(playlist_id, user_id, role)
 SELECT id, 'system-recommendations', 'owner' FROM public.playlists WHERE uuid = 'playlist-seed';
@@ -354,6 +356,19 @@ docker exec "$CONTAINER_NAME" \
 
 docker exec "$CONTAINER_NAME" \
   psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'CREATE SCHEMA task_role_unexpected_schema AUTHORIZATION boardsesh_owner; GRANT USAGE ON SCHEMA task_role_unexpected_schema TO PUBLIC' >/dev/null
+assert_cluster_boundary_drift \
+  'cluster prerequisite unexpected schema task_role_unexpected_schema|owner=boardsesh_owner; reviewed remediation: classify ownership and add a narrow manifest exception or remove the schema separately' \
+  'unexpected non-extension schema drift'
+grep -Fq \
+  'cluster prerequisite PUBLIC|schema|task_role_unexpected_schema|USAGE|grantable=false; reviewed remediation: REVOKE USAGE ON SCHEMA task_role_unexpected_schema FROM PUBLIC' \
+  "$REPORT_FILE" || { cat "$REPORT_FILE" >&2; fail 'audit did not identify unexpected-schema PUBLIC privilege drift'; }
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'DROP SCHEMA task_role_unexpected_schema' >/dev/null
+
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
   -c 'GRANT TEMPORARY ON DATABASE railway TO PUBLIC' >/dev/null
 assert_cluster_boundary_drift \
   'cluster prerequisite PUBLIC|database|railway|TEMPORARY|grantable=false; reviewed remediation: REVOKE TEMPORARY ON DATABASE railway FROM PUBLIC' \
@@ -394,6 +409,26 @@ docker exec "$CONTAINER_NAME" \
 
 docker exec "$CONTAINER_NAME" \
   psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'GRANT SELECT ON LARGE OBJECT 918273 TO PUBLIC' >/dev/null
+assert_cluster_boundary_drift \
+  'cluster prerequisite PUBLIC|large_object|918273|SELECT|grantable=false; reviewed remediation: REVOKE SELECT ON LARGE OBJECT 918273 FROM PUBLIC' \
+  'PUBLIC current-large-object drift'
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'REVOKE SELECT ON LARGE OBJECT 918273 FROM PUBLIC' >/dev/null
+
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'GRANT SET ON PARAMETER statement_timeout TO PUBLIC' >/dev/null
+assert_cluster_boundary_drift \
+  'cluster prerequisite PUBLIC|parameter|statement_timeout|SET|grantable=false; reviewed remediation: REVOKE SET ON PARAMETER statement_timeout FROM PUBLIC' \
+  'PUBLIC parameter-SET drift'
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'REVOKE SET ON PARAMETER statement_timeout FROM PUBLIC' >/dev/null
+
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
   -c 'GRANT EXECUTE ON FUNCTION task_role_playlist_delete_probe() TO PUBLIC' >/dev/null
 assert_cluster_boundary_drift \
   'cluster prerequisite PUBLIC|routine|task_role_playlist_delete_probe()|EXECUTE|grantable=false; reviewed remediation: REVOKE EXECUTE ON ROUTINE task_role_playlist_delete_probe() FROM PUBLIC' \
@@ -411,6 +446,26 @@ assert_cluster_boundary_drift \
 docker exec "$CONTAINER_NAME" \
   psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
   -c 'ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner REVOKE EXECUTE ON ROUTINES FROM PUBLIC' >/dev/null
+
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner GRANT CREATE ON SCHEMAS TO PUBLIC' >/dev/null
+assert_cluster_boundary_drift \
+  'cluster prerequisite PUBLIC|default_acl|boardsesh_owner:*:n|CREATE|grantable=false; reviewed remediation: ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner REVOKE CREATE ON SCHEMAS FROM PUBLIC' \
+  'migration-owner global default-schema drift'
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner REVOKE CREATE ON SCHEMAS FROM PUBLIC' >/dev/null
+
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner GRANT SELECT ON LARGE OBJECTS TO PUBLIC' >/dev/null
+assert_cluster_boundary_drift \
+  'cluster prerequisite PUBLIC|default_acl|boardsesh_owner:*:L|SELECT|grantable=false; reviewed remediation: ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner REVOKE SELECT ON LARGE OBJECTS FROM PUBLIC' \
+  'migration-owner global default-large-object drift'
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'ALTER DEFAULT PRIVILEGES FOR ROLE boardsesh_owner REVOKE SELECT ON LARGE OBJECTS FROM PUBLIC' >/dev/null
 
 docker exec "$CONTAINER_NAME" \
   psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
@@ -496,6 +551,81 @@ docker exec "$CONTAINER_NAME" \
   -c 'DROP POLICY task_role_forbidden_policy ON role_forbidden_probe' >/dev/null
 ADMIN_DATABASE_URL="$admin_url" \
   node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" audit >/dev/null
+
+# PostgreSQL keeps session authorization after a login role becomes NOLOGIN (or
+# is dropped), and SET ROLE owner remains effective in that backend. Hold a real
+# migrator session after SET ROLE, prove rollback commits the durable login
+# fence but refuses to drop, then prove that already-authenticated session can
+# still run owner DDL. Draining it and rerunning must complete idempotently.
+coproc ROLLBACK_RACE_SESSION {
+  run_role boardsesh_migrator boardsesh-ci-migrate -Atq
+}
+rollback_race_input_fd="${ROLLBACK_RACE_SESSION[1]}"
+rollback_race_pid="$ROLLBACK_RACE_SESSION_PID"
+printf '%s\n' \
+  'SET ROLE boardsesh_owner;' \
+  "SET application_name TO 'boardsesh-ci-migrate-rollback-race';" \
+  >&"$rollback_race_input_fd"
+
+rollback_race_visible='false'
+for _attempt in $(seq 1 100); do
+  rollback_race_visible="$(docker exec "$CONTAINER_NAME" \
+    psql -X -Atq -U postgres -d railway -c "
+      SELECT (count(*) = 1)::text
+      FROM pg_catalog.pg_stat_activity
+      WHERE usename = 'boardsesh_migrator'
+        AND application_name = 'boardsesh-ci-migrate-rollback-race';")"
+  [[ "$rollback_race_visible" == 'true' ]] && break
+  sleep 0.1
+done
+[[ "$rollback_race_visible" == 'true' ]] || fail 'active SET ROLE rollback-race session did not become visible'
+
+if ADMIN_DATABASE_URL="$admin_url" \
+  ROLLBACK_TASK_ROLES='DROP_EXACT_SIX_TASK_ROLES' \
+  node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" rollback >"$REPORT_FILE" 2>&1; then
+  fail 'rollback dropped a managed login role with an active SET ROLE owner session'
+fi
+grep -Fq \
+  'rollback fenced all six managed roles NOLOGIN but refuses active authenticated sessions (boardsesh_migrator:1); drain them and rerun rollback' \
+  "$REPORT_FILE" || { cat "$REPORT_FILE" >&2; fail 'rollback did not report its durable session-drain fence'; }
+
+fenced_state="$(docker exec "$CONTAINER_NAME" \
+  psql -X -Atq -U postgres -d railway -c "
+    SELECT (count(*) = 6 AND bool_and(NOT rolcanlogin))::text
+    FROM pg_catalog.pg_roles
+    WHERE rolname IN (
+      'boardsesh_migrator', 'boardsesh_snapshot_exporter', 'boardsesh_climb_grades_refresh',
+      'boardsesh_content_model_refresh', 'boardsesh_hold_features_refresh',
+      'boardsesh_recommendations_refresh');")"
+[[ "$fenced_state" == 'true' ]] || fail 'rollback refusal did not leave all six managed roles NOLOGIN'
+
+ADMIN_DATABASE_URL="$admin_url" \
+  node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" plan >"$REPORT_FILE" 2>&1
+grep -Fq 'role attributes differ for boardsesh_migrator' "$REPORT_FILE" || {
+  cat "$REPORT_FILE" >&2
+  fail 'plan did not expose the intentional NOLOGIN rollback fence'
+}
+if ADMIN_DATABASE_URL="$admin_url" \
+  node "$REPOSITORY_ROOT/scripts/production-db-task-roles.mjs" audit >"$REPORT_FILE" 2>&1; then
+  fail 'audit accepted the intentionally fenced NOLOGIN contract as activation-ready'
+fi
+grep -Fq 'task-role audit found drift' "$REPORT_FILE" || {
+  cat "$REPORT_FILE" >&2
+  fail 'audit did not reject the intentionally fenced NOLOGIN contract'
+}
+
+printf '%s\n' \
+  'CREATE SCHEMA boardsesh_task_role_surviving_session_probe;' \
+  '\q' \
+  >&"$rollback_race_input_fd"
+wait "$rollback_race_pid"
+surviving_session_ddl="$(docker exec "$CONTAINER_NAME" \
+  psql -X -Atq -U postgres -d railway -c \
+    "SELECT (to_regnamespace('boardsesh_task_role_surviving_session_probe') IS NOT NULL)::text;")"
+[[ "$surviving_session_ddl" == 'true' ]] || fail 'active SET ROLE owner session did not retain DDL after NOLOGIN commit'
+docker exec "$CONTAINER_NAME" \
+  psql -X -v ON_ERROR_STOP=1 -U postgres -d railway \
+  -c 'DROP SCHEMA boardsesh_task_role_surviving_session_probe' >/dev/null
 
 ADMIN_DATABASE_URL="$admin_url" \
 ROLLBACK_TASK_ROLES='DROP_EXACT_SIX_TASK_ROLES' \

--- a/scripts/production-db-task-roles.mjs
+++ b/scripts/production-db-task-roles.mjs
@@ -1,0 +1,979 @@
+#!/usr/bin/env node
+import { createHash, createHmac, pbkdf2Sync, randomBytes } from 'node:crypto';
+import { closeSync, fstatSync, lstatSync, openSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import postgres from 'postgres';
+import {
+  MIGRATION_OWNER_ROLE,
+  PRODUCTION_DATABASE_NAME,
+  PRODUCTION_SCHEMA_NAME,
+  PRODUCTION_TASK_RELATION_GRANTS,
+  PRODUCTION_TASK_ROLES,
+  PRODUCTION_TASK_ROLE_BY_NAME,
+} from './lib/production-db-task-role-contract.mjs';
+
+const IDENTIFIER_PATTERN = /^[a-z_][a-z0-9_]*$/;
+const APPLICATION_NAME_PATTERN = /^[a-z0-9-]+$/;
+const PASSWORD_PATTERN = /^[a-f0-9]{64}$/;
+const FORWARDER_HOST_PATTERN = /^boardsesh-db-forwarder\.([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+ts\.net$/;
+const APPLY_CONFIRMATION = 'APPLY_EXACT_SIX_TASK_ROLES';
+const ROLLBACK_CONFIRMATION = 'DROP_EXACT_SIX_TASK_ROLES';
+const DISPOSABLE_LOCAL_CONFIRMATION = 'ALLOW_EXACT_LOOPBACK_FIXTURE';
+const MANAGED_ROLE_NAMES = PRODUCTION_TASK_ROLES.map(({ name }) => name);
+const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function quoteIdentifier(identifier) {
+  if (!IDENTIFIER_PATTERN.test(identifier)) fail(`unsafe PostgreSQL identifier: ${identifier}`);
+  return `"${identifier}"`;
+}
+
+function quoteLiteral(literal) {
+  return `'${String(literal).replaceAll("'", "''")}'`;
+}
+
+function valuesList(values) {
+  return values.map(quoteLiteral).join(', ');
+}
+
+function roleNameListSql() {
+  return valuesList(MANAGED_ROLE_NAMES);
+}
+
+function assertStaticContract() {
+  if (PRODUCTION_TASK_ROLES.length !== 6 || new Set(MANAGED_ROLE_NAMES).size !== 6) {
+    fail('task-role contract must contain exactly six unique LOGIN roles');
+  }
+  const applicationNames = new Set();
+  const githubSecrets = new Set();
+  const relationGrantKeys = new Set();
+  for (const roleContract of PRODUCTION_TASK_ROLES) {
+    quoteIdentifier(roleContract.name);
+    if (!APPLICATION_NAME_PATTERN.test(roleContract.applicationName)) {
+      fail(`invalid application_name for ${roleContract.name}`);
+    }
+    if (applicationNames.has(roleContract.applicationName)) fail('task application_name values must be unique');
+    if (githubSecrets.has(roleContract.githubSecret)) fail('task GitHub secret names must be unique');
+    applicationNames.add(roleContract.applicationName);
+    githubSecrets.add(roleContract.githubSecret);
+  }
+  for (const grantContract of PRODUCTION_TASK_RELATION_GRANTS) {
+    if (!PRODUCTION_TASK_ROLE_BY_NAME.has(grantContract.role)) fail(`unknown grant role ${grantContract.role}`);
+    quoteIdentifier(grantContract.relation);
+    if (grantContract.privileges.length === 0) fail(`empty privileges for ${grantContract.role}`);
+    const relationGrantKey = `${grantContract.role}|${grantContract.relation}`;
+    if (relationGrantKeys.has(relationGrantKey)) fail(`duplicate relation grant ${relationGrantKey}`);
+    relationGrantKeys.add(relationGrantKey);
+  }
+}
+
+function credentialsFilePath() {
+  const filePath = process.env.ROLE_CREDENTIALS_FILE;
+  if (!filePath || !isAbsolute(filePath)) fail('ROLE_CREDENTIALS_FILE must be an absolute path');
+  const relativeToRepository = relative(REPOSITORY_ROOT, resolve(filePath));
+  if (
+    relativeToRepository === '' ||
+    (!relativeToRepository.startsWith(`..${sep}`) && relativeToRepository !== '..' && !isAbsolute(relativeToRepository))
+  ) {
+    fail('ROLE_CREDENTIALS_FILE must be outside the repository');
+  }
+  return filePath;
+}
+
+function readProtectedCredentials() {
+  const filePath = credentialsFilePath();
+  const fileStats = lstatSync(filePath);
+  if (!fileStats.isFile() || fileStats.isSymbolicLink())
+    fail('ROLE_CREDENTIALS_FILE must be a regular non-symlink file');
+  if ((fileStats.mode & 0o077) !== 0) fail('ROLE_CREDENTIALS_FILE must not be accessible by group or other users');
+  if (typeof process.getuid === 'function' && fileStats.uid !== process.getuid()) {
+    fail('ROLE_CREDENTIALS_FILE must be owned by the current user');
+  }
+  if (fileStats.size > 32768) fail('ROLE_CREDENTIALS_FILE is unexpectedly large');
+
+  let parsedCredentials;
+  try {
+    parsedCredentials = JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch {
+    fail('ROLE_CREDENTIALS_FILE is not valid JSON');
+  }
+  if (parsedCredentials?.version !== 1 || typeof parsedCredentials.forwarderHost !== 'string') {
+    fail('ROLE_CREDENTIALS_FILE has an unsupported format');
+  }
+  if (!FORWARDER_HOST_PATTERN.test(parsedCredentials.forwarderHost)) {
+    fail('ROLE_CREDENTIALS_FILE contains an invalid forwarder host');
+  }
+  const credentialRoleNames = Object.keys(parsedCredentials.roles ?? {}).sort((left, right) =>
+    left.localeCompare(right),
+  );
+  const expectedRoleNames = [...MANAGED_ROLE_NAMES].sort((left, right) => left.localeCompare(right));
+  if (JSON.stringify(credentialRoleNames) !== JSON.stringify(expectedRoleNames)) {
+    fail('ROLE_CREDENTIALS_FILE must contain exactly the six managed roles');
+  }
+
+  for (const roleContract of PRODUCTION_TASK_ROLES) {
+    const credential = parsedCredentials.roles[roleContract.name];
+    if (
+      credential?.applicationName !== roleContract.applicationName ||
+      credential?.githubSecret !== roleContract.githubSecret ||
+      !PASSWORD_PATTERN.test(credential?.password ?? '')
+    ) {
+      fail(`ROLE_CREDENTIALS_FILE entry for ${roleContract.name} does not match its exact contract`);
+    }
+    validateGeneratedDatabaseUrl(
+      credential.databaseUrl,
+      parsedCredentials.forwarderHost,
+      roleContract,
+      credential.password,
+    );
+  }
+  return parsedCredentials;
+}
+
+function validateGeneratedDatabaseUrl(rawDatabaseUrl, expectedHost, roleContract, expectedPassword) {
+  let databaseUrl;
+  try {
+    databaseUrl = new URL(rawDatabaseUrl);
+  } catch {
+    fail(`generated database URL for ${roleContract.name} is invalid`);
+  }
+  const queryEntries = [...databaseUrl.searchParams.entries()];
+  if (
+    databaseUrl.protocol !== 'postgresql:' ||
+    databaseUrl.hostname !== expectedHost ||
+    databaseUrl.port !== '5432' ||
+    databaseUrl.pathname !== `/${PRODUCTION_DATABASE_NAME}` ||
+    decodeURIComponent(databaseUrl.username) !== roleContract.name ||
+    decodeURIComponent(databaseUrl.password) !== expectedPassword ||
+    databaseUrl.hash !== '' ||
+    queryEntries.length !== 2 ||
+    databaseUrl.searchParams.getAll('application_name').length !== 1 ||
+    databaseUrl.searchParams.get('application_name') !== roleContract.applicationName ||
+    databaseUrl.searchParams.getAll('sslmode').length !== 1 ||
+    databaseUrl.searchParams.get('sslmode') !== 'require'
+  ) {
+    fail(`generated database URL for ${roleContract.name} does not match its exact private route`);
+  }
+}
+
+function generateCredentials() {
+  const filePath = credentialsFilePath();
+  const forwarderHost = process.env.POSTGRES_FORWARDER_HOST ?? '';
+  if (!FORWARDER_HOST_PATTERN.test(forwarderHost)) {
+    fail('POSTGRES_FORWARDER_HOST must be the full boardsesh-db-forwarder MagicDNS name');
+  }
+
+  const protectedCredentials = { version: 1, forwarderHost, roles: {} };
+  for (const roleContract of PRODUCTION_TASK_ROLES) {
+    const password = randomBytes(32).toString('hex');
+    const databaseUrl = new URL(`postgresql://${roleContract.name}:${password}@${forwarderHost}:5432/railway`);
+    databaseUrl.searchParams.set('application_name', roleContract.applicationName);
+    databaseUrl.searchParams.set('sslmode', 'require');
+    protectedCredentials.roles[roleContract.name] = {
+      applicationName: roleContract.applicationName,
+      githubSecret: roleContract.githubSecret,
+      password,
+      databaseUrl: databaseUrl.toString(),
+    };
+  }
+
+  const fileDescriptor = openSync(filePath, 'wx', 0o600);
+  try {
+    writeFileSync(fileDescriptor, `${JSON.stringify(protectedCredentials, null, 2)}\n`, { encoding: 'utf8' });
+    const fileStats = fstatSync(fileDescriptor);
+    if ((fileStats.mode & 0o077) !== 0) fail('generated credential file mode is not private');
+  } finally {
+    closeSync(fileDescriptor);
+  }
+  console.info('Generated one protected credential file for all six task roles; no credential was printed.');
+}
+
+function adminDatabaseUrl() {
+  const rawDatabaseUrl = process.env.ADMIN_DATABASE_URL;
+  delete process.env.ADMIN_DATABASE_URL;
+  if (!rawDatabaseUrl) fail('ADMIN_DATABASE_URL is required through the environment');
+  let databaseUrl;
+  try {
+    databaseUrl = new URL(rawDatabaseUrl);
+  } catch {
+    fail('ADMIN_DATABASE_URL is invalid');
+  }
+  if (!['postgres:', 'postgresql:'].includes(databaseUrl.protocol)) fail('ADMIN_DATABASE_URL must use PostgreSQL');
+  if (!databaseUrl.username || !databaseUrl.password) fail('ADMIN_DATABASE_URL must contain administrator credentials');
+  if (decodeURIComponent(databaseUrl.pathname.slice(1)) !== PRODUCTION_DATABASE_NAME) {
+    fail(`ADMIN_DATABASE_URL must name the canonical ${PRODUCTION_DATABASE_NAME} database`);
+  }
+  const isLocal = ['localhost', '127.0.0.1', '::1'].includes(databaseUrl.hostname.replace(/^\[|\]$/g, ''));
+  const disposableLocalConfirmation = process.env.ALLOW_DISPOSABLE_TASK_ROLE_SMOKE;
+  delete process.env.ALLOW_DISPOSABLE_TASK_ROLE_SMOKE;
+  if (isLocal) {
+    if (disposableLocalConfirmation !== DISPOSABLE_LOCAL_CONFIRMATION) {
+      fail('loopback ADMIN_DATABASE_URL is allowed only by the disposable-smoke confirmation');
+    }
+    if (databaseUrl.searchParams.size !== 0 || databaseUrl.hash !== '') {
+      fail('disposable loopback ADMIN_DATABASE_URL must not contain query parameters or a fragment');
+    }
+    return rawDatabaseUrl;
+  }
+
+  const forwarderHost = process.env.POSTGRES_FORWARDER_HOST ?? '';
+  delete process.env.POSTGRES_FORWARDER_HOST;
+  if (!FORWARDER_HOST_PATTERN.test(forwarderHost)) {
+    fail('POSTGRES_FORWARDER_HOST must be the full boardsesh-db-forwarder MagicDNS name');
+  }
+  if (
+    databaseUrl.hostname !== forwarderHost ||
+    databaseUrl.port !== '5432' ||
+    databaseUrl.hash !== '' ||
+    databaseUrl.searchParams.size !== 1 ||
+    databaseUrl.searchParams.getAll('sslmode').length !== 1 ||
+    databaseUrl.searchParams.get('sslmode') !== 'require'
+  ) {
+    fail('remote ADMIN_DATABASE_URL must use the exact PostGIS forwarder host:5432 with only sslmode=require');
+  }
+  return rawDatabaseUrl;
+}
+
+function createAdminClient(rawDatabaseUrl) {
+  return postgres(rawDatabaseUrl, {
+    max: 1,
+    prepare: false,
+    onnotice: (notice) => console.info(`[task-role-notice] ${notice.code ?? 'unknown'}`),
+  });
+}
+
+async function assertAdminBoundary(sqlClient) {
+  const [databaseIdentity] = await sqlClient.unsafe(`
+    SELECT current_database() AS database_name,
+           current_user AS admin_role,
+           coalesce((SELECT rolsuper FROM pg_catalog.pg_roles WHERE rolname = current_user), false)
+             AS is_superuser
+  `);
+  if (databaseIdentity?.database_name !== PRODUCTION_DATABASE_NAME) {
+    fail(`administrator connected to ${databaseIdentity?.database_name ?? 'unknown'}, not ${PRODUCTION_DATABASE_NAME}`);
+  }
+  if (MANAGED_ROLE_NAMES.includes(databaseIdentity.admin_role)) fail('a managed task role cannot provision itself');
+  if (!databaseIdentity.is_superuser) {
+    fail('administrator must be SUPERUSER so every direct grant can be audited and reconciled atomically');
+  }
+
+  const [ownerContract] = await sqlClient.unsafe(
+    `SELECT count(*) = 1
+       AND bool_and(NOT rolcanlogin AND NOT rolsuper AND NOT rolcreatedb AND NOT rolcreaterole
+                    AND rolinherit AND NOT rolreplication AND NOT rolbypassrls) AS matches
+     FROM pg_catalog.pg_roles WHERE rolname = ${quoteLiteral(MIGRATION_OWNER_ROLE)}`,
+  );
+  if (!ownerContract?.matches) fail(`${MIGRATION_OWNER_ROLE} must already exist as the exact restricted NOLOGIN owner`);
+}
+
+async function expectedSequenceAclKeys(sqlClient) {
+  const insertContracts = PRODUCTION_TASK_RELATION_GRANTS.filter(({ privileges }) => privileges.includes('INSERT'));
+  if (insertContracts.length === 0) return new Set();
+  const expectedValues = insertContracts
+    .map(({ role, relation }) => `(${quoteLiteral(role)}, ${quoteLiteral(relation)})`)
+    .join(',\n');
+  const sequenceRows = await sqlClient.unsafe(`
+    WITH expected(role_name, relation_name) AS (VALUES ${expectedValues})
+    SELECT DISTINCT expected.role_name,
+           pg_catalog.format('%I.%I', sequence_namespace.nspname, sequence_relation.relname) AS object_name
+    FROM expected
+    JOIN pg_catalog.pg_namespace AS table_namespace ON table_namespace.nspname = ${quoteLiteral(PRODUCTION_SCHEMA_NAME)}
+    JOIN pg_catalog.pg_class AS table_relation
+      ON table_relation.relnamespace = table_namespace.oid AND table_relation.relname = expected.relation_name
+    JOIN pg_catalog.pg_attribute AS attribute
+      ON attribute.attrelid = table_relation.oid AND attribute.attnum > 0 AND NOT attribute.attisdropped
+    JOIN pg_catalog.pg_depend AS dependency
+      ON dependency.refclassid = 'pg_catalog.pg_class'::pg_catalog.regclass
+     AND dependency.refobjid = table_relation.oid
+     AND dependency.refobjsubid = attribute.attnum
+     AND dependency.classid = 'pg_catalog.pg_class'::pg_catalog.regclass
+     AND dependency.deptype IN ('a', 'i')
+    JOIN pg_catalog.pg_class AS sequence_relation
+      ON sequence_relation.oid = dependency.objid AND sequence_relation.relkind = 'S'
+    JOIN pg_catalog.pg_namespace AS sequence_namespace ON sequence_namespace.oid = sequence_relation.relnamespace
+  `);
+  return new Set(
+    sequenceRows.map(({ role_name: roleName, object_name: objectName }) => `${roleName}|sequence|${objectName}|USAGE`),
+  );
+}
+
+async function missingRelations(sqlClient) {
+  const expectedRelations = [...new Set(PRODUCTION_TASK_RELATION_GRANTS.map(({ relation }) => relation))].sort(
+    (left, right) => left.localeCompare(right),
+  );
+  const rows = await sqlClient.unsafe(`
+    SELECT relation_name
+    FROM unnest(ARRAY[${valuesList(expectedRelations)}]::text[]) AS expected(relation_name)
+    WHERE pg_catalog.to_regclass(${quoteLiteral(PRODUCTION_SCHEMA_NAME)} || '.' || relation_name) IS NULL
+    ORDER BY relation_name
+  `);
+  return rows.map(({ relation_name: relationName }) => relationName);
+}
+
+async function collectDirectAclKeys(sqlClient) {
+  const rows = await sqlClient.unsafe(`
+    WITH managed AS (
+      SELECT oid, rolname FROM pg_catalog.pg_roles WHERE rolname IN (${roleNameListSql()})
+    ), direct_acl AS (
+      SELECT managed.rolname AS role_name, 'database'::text AS object_kind,
+             database.datname AS object_name, privilege.privilege_type, privilege.is_grantable
+      FROM pg_catalog.pg_database AS database
+      CROSS JOIN LATERAL pg_catalog.aclexplode(database.datacl) AS privilege
+      JOIN managed ON managed.oid = privilege.grantee
+      UNION ALL
+      SELECT managed.rolname, 'schema', namespace.nspname,
+             privilege.privilege_type, privilege.is_grantable
+      FROM pg_catalog.pg_namespace AS namespace
+      CROSS JOIN LATERAL pg_catalog.aclexplode(namespace.nspacl) AS privilege
+      JOIN managed ON managed.oid = privilege.grantee
+      UNION ALL
+      SELECT managed.rolname,
+             CASE WHEN relation.relkind = 'S' THEN 'sequence' ELSE 'relation' END,
+             pg_catalog.format('%I.%I', namespace.nspname, relation.relname),
+             privilege.privilege_type, privilege.is_grantable
+      FROM pg_catalog.pg_class AS relation
+      JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+      CROSS JOIN LATERAL pg_catalog.aclexplode(relation.relacl) AS privilege
+      JOIN managed ON managed.oid = privilege.grantee
+      UNION ALL
+      SELECT managed.rolname, 'column',
+             pg_catalog.format('%I.%I.%I', namespace.nspname, relation.relname, attribute.attname),
+             privilege.privilege_type, privilege.is_grantable
+      FROM pg_catalog.pg_attribute AS attribute
+      JOIN pg_catalog.pg_class AS relation ON relation.oid = attribute.attrelid
+      JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+      CROSS JOIN LATERAL pg_catalog.aclexplode(attribute.attacl) AS privilege
+      JOIN managed ON managed.oid = privilege.grantee
+      WHERE attribute.attnum > 0 AND NOT attribute.attisdropped
+      UNION ALL
+      SELECT managed.rolname, 'routine', procedure.oid::pg_catalog.regprocedure::text,
+             privilege.privilege_type, privilege.is_grantable
+      FROM pg_catalog.pg_proc AS procedure
+      CROSS JOIN LATERAL pg_catalog.aclexplode(procedure.proacl) AS privilege
+      JOIN managed ON managed.oid = privilege.grantee
+      UNION ALL
+      SELECT managed.rolname, 'type',
+             pg_catalog.format('%I.%I', namespace.nspname, type_row.typname),
+             privilege.privilege_type, privilege.is_grantable
+      FROM pg_catalog.pg_type AS type_row
+      JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = type_row.typnamespace
+      CROSS JOIN LATERAL pg_catalog.aclexplode(type_row.typacl) AS privilege
+      JOIN managed ON managed.oid = privilege.grantee
+      UNION ALL
+      SELECT managed.rolname, 'large_object', large_object.oid::text,
+             privilege.privilege_type, privilege.is_grantable
+      FROM pg_catalog.pg_largeobject_metadata AS large_object
+      CROSS JOIN LATERAL pg_catalog.aclexplode(large_object.lomacl) AS privilege
+      JOIN managed ON managed.oid = privilege.grantee
+      UNION ALL
+      SELECT managed.rolname, 'parameter', parameter.parname,
+             privilege.privilege_type, privilege.is_grantable
+      FROM pg_catalog.pg_parameter_acl AS parameter
+      CROSS JOIN LATERAL pg_catalog.aclexplode(parameter.paracl) AS privilege
+      JOIN managed ON managed.oid = privilege.grantee
+      UNION ALL
+      SELECT managed.rolname, 'language', language.lanname,
+             privilege.privilege_type, privilege.is_grantable
+      FROM pg_catalog.pg_language AS language
+      CROSS JOIN LATERAL pg_catalog.aclexplode(language.lanacl) AS privilege
+      JOIN managed ON managed.oid = privilege.grantee
+      UNION ALL
+      SELECT managed.rolname, 'foreign_data_wrapper', wrapper.fdwname,
+             privilege.privilege_type, privilege.is_grantable
+      FROM pg_catalog.pg_foreign_data_wrapper AS wrapper
+      CROSS JOIN LATERAL pg_catalog.aclexplode(wrapper.fdwacl) AS privilege
+      JOIN managed ON managed.oid = privilege.grantee
+      UNION ALL
+      SELECT managed.rolname, 'foreign_server', server.srvname,
+             privilege.privilege_type, privilege.is_grantable
+      FROM pg_catalog.pg_foreign_server AS server
+      CROSS JOIN LATERAL pg_catalog.aclexplode(server.srvacl) AS privilege
+      JOIN managed ON managed.oid = privilege.grantee
+      UNION ALL
+      SELECT managed.rolname, 'tablespace', tablespace.spcname,
+             privilege.privilege_type, privilege.is_grantable
+      FROM pg_catalog.pg_tablespace AS tablespace
+      CROSS JOIN LATERAL pg_catalog.aclexplode(tablespace.spcacl) AS privilege
+      JOIN managed ON managed.oid = privilege.grantee
+      UNION ALL
+      SELECT managed.rolname, 'default',
+             grantor.rolname || ':' || coalesce(namespace.nspname, '*') || ':' || default_acl.defaclobjtype::text,
+             privilege.privilege_type, privilege.is_grantable
+      FROM pg_catalog.pg_default_acl AS default_acl
+      JOIN pg_catalog.pg_roles AS grantor ON grantor.oid = default_acl.defaclrole
+      LEFT JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = default_acl.defaclnamespace
+      CROSS JOIN LATERAL pg_catalog.aclexplode(default_acl.defaclacl) AS privilege
+      JOIN managed ON managed.oid = privilege.grantee
+    )
+    SELECT * FROM direct_acl ORDER BY role_name, object_kind, object_name, privilege_type
+  `);
+  const keys = new Set();
+  const grantableKeys = [];
+  for (const aclRow of rows) {
+    const aclKey = `${aclRow.role_name}|${aclRow.object_kind}|${aclRow.object_name}|${aclRow.privilege_type}`;
+    keys.add(aclKey);
+    if (aclRow.is_grantable) grantableKeys.push(aclKey);
+  }
+  return { keys, grantableKeys };
+}
+
+async function collectRoleRows(sqlClient) {
+  return sqlClient.unsafe(`
+    SELECT rolname, rolcanlogin, rolsuper, rolcreatedb, rolcreaterole, rolinherit,
+           rolreplication, rolbypassrls, rolconnlimit, rolvaliduntil::text AS valid_until,
+           rolpassword LIKE 'SCRAM-SHA-256$%' AS has_scram_password
+    FROM pg_catalog.pg_authid WHERE rolname IN (${roleNameListSql()}) ORDER BY rolname
+  `);
+}
+
+async function collectSettingKeys(sqlClient) {
+  const rows = await sqlClient.unsafe(`
+    SELECT role_row.rolname AS role_name, coalesce(database.datname, '*') AS database_name,
+           setting.setting
+    FROM pg_catalog.pg_db_role_setting AS role_setting
+    JOIN pg_catalog.pg_roles AS role_row ON role_row.oid = role_setting.setrole
+    LEFT JOIN pg_catalog.pg_database AS database ON database.oid = role_setting.setdatabase
+    CROSS JOIN LATERAL unnest(role_setting.setconfig) AS setting(setting)
+    WHERE role_row.rolname IN (${roleNameListSql()})
+    ORDER BY role_name, database_name, setting.setting
+  `);
+  return new Set(
+    rows.map(
+      ({ role_name: roleName, database_name: databaseName, setting }) => `${roleName}|${databaseName}|${setting}`,
+    ),
+  );
+}
+
+async function collectMembershipKeys(sqlClient) {
+  const rows = await sqlClient.unsafe(`
+    SELECT member_role.rolname AS member_role, granted_role.rolname AS granted_role,
+           membership.admin_option, membership.inherit_option, membership.set_option
+    FROM pg_catalog.pg_auth_members AS membership
+    JOIN pg_catalog.pg_roles AS member_role ON member_role.oid = membership.member
+    JOIN pg_catalog.pg_roles AS granted_role ON granted_role.oid = membership.roleid
+    WHERE member_role.rolname IN (${roleNameListSql()}) OR granted_role.rolname IN (${roleNameListSql()})
+    ORDER BY member_role, granted_role
+  `);
+  return new Set(
+    rows.map(
+      (membership) =>
+        `${membership.member_role}|${membership.granted_role}|admin=${membership.admin_option}|inherit=${membership.inherit_option}|set=${membership.set_option}`,
+    ),
+  );
+}
+
+async function collectOwnershipRows(sqlClient) {
+  return sqlClient.unsafe(`
+    SELECT role_row.rolname AS role_name, dependency.classid::pg_catalog.regclass::text AS class_name,
+           dependency.dbid::text AS database_oid, dependency.objid::text AS object_oid
+    FROM pg_catalog.pg_shdepend AS dependency
+    JOIN pg_catalog.pg_roles AS role_row ON role_row.oid = dependency.refobjid
+    WHERE dependency.refclassid = 'pg_catalog.pg_authid'::pg_catalog.regclass
+      AND dependency.deptype = 'o'
+      AND role_row.rolname IN (${roleNameListSql()})
+    ORDER BY role_name, class_name, database_oid, object_oid
+  `);
+}
+
+async function collectPolicyReferenceRows(sqlClient) {
+  return sqlClient.unsafe(`
+    WITH managed AS (
+      SELECT oid, rolname FROM pg_catalog.pg_roles WHERE rolname IN (${roleNameListSql()})
+    )
+    SELECT managed.rolname AS role_name,
+           pg_catalog.format('%I.%I', namespace.nspname, relation.relname) AS relation_name,
+           policy.polname AS policy_name
+    FROM pg_catalog.pg_policy AS policy
+    JOIN pg_catalog.pg_class AS relation ON relation.oid = policy.polrelid
+    JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+    CROSS JOIN LATERAL unnest(policy.polroles) AS policy_role(role_oid)
+    JOIN managed ON managed.oid = policy_role.role_oid
+    ORDER BY role_name, relation_name, policy_name
+  `);
+}
+
+async function collectOwnedDefaultAclRows(sqlClient) {
+  return sqlClient.unsafe(`
+    SELECT role_row.rolname AS role_name,
+           coalesce(namespace.nspname, '*') AS schema_name,
+           default_acl.defaclobjtype::text AS object_type
+    FROM pg_catalog.pg_default_acl AS default_acl
+    JOIN pg_catalog.pg_roles AS role_row ON role_row.oid = default_acl.defaclrole
+    LEFT JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = default_acl.defaclnamespace
+    WHERE role_row.rolname IN (${roleNameListSql()})
+    ORDER BY role_name, schema_name, object_type
+  `);
+}
+
+function expectedDirectAclKeys(sequenceKeys) {
+  const expectedKeys = new Set(sequenceKeys);
+  for (const roleContract of PRODUCTION_TASK_ROLES) {
+    for (const privilege of roleContract.databasePrivileges) {
+      expectedKeys.add(`${roleContract.name}|database|${PRODUCTION_DATABASE_NAME}|${privilege}`);
+    }
+    for (const privilege of roleContract.schemaPrivileges) {
+      expectedKeys.add(`${roleContract.name}|schema|${PRODUCTION_SCHEMA_NAME}|${privilege}`);
+    }
+  }
+  for (const grantContract of PRODUCTION_TASK_RELATION_GRANTS) {
+    for (const privilege of grantContract.privileges) {
+      expectedKeys.add(
+        `${grantContract.role}|relation|${PRODUCTION_SCHEMA_NAME}.${grantContract.relation}|${privilege}`,
+      );
+    }
+  }
+  return expectedKeys;
+}
+
+async function auditContract(sqlClient) {
+  const differences = [];
+  const relationGaps = await missingRelations(sqlClient);
+  differences.push(...relationGaps.map((relationName) => `missing object ${PRODUCTION_SCHEMA_NAME}.${relationName}`));
+
+  const roleRows = await collectRoleRows(sqlClient);
+  const actualRoleByName = new Map(roleRows.map((roleRow) => [roleRow.rolname, roleRow]));
+  for (const roleContract of PRODUCTION_TASK_ROLES) {
+    const roleRow = actualRoleByName.get(roleContract.name);
+    if (!roleRow) {
+      differences.push(`missing role ${roleContract.name}`);
+      continue;
+    }
+    const attributesMatch =
+      roleRow.rolcanlogin &&
+      !roleRow.rolsuper &&
+      !roleRow.rolcreatedb &&
+      !roleRow.rolcreaterole &&
+      roleRow.rolinherit &&
+      !roleRow.rolreplication &&
+      !roleRow.rolbypassrls &&
+      roleRow.rolconnlimit === roleContract.connectionLimit &&
+      (roleRow.valid_until === null || roleRow.valid_until === 'infinity') &&
+      roleRow.has_scram_password;
+    if (!attributesMatch) differences.push(`role attributes differ for ${roleContract.name}`);
+  }
+
+  const expectedSettings = new Set();
+  for (const roleContract of PRODUCTION_TASK_ROLES) {
+    expectedSettings.add(
+      `${roleContract.name}|${PRODUCTION_DATABASE_NAME}|application_name=${roleContract.applicationName}`,
+    );
+    if (roleContract.readOnly) {
+      expectedSettings.add(`${roleContract.name}|${PRODUCTION_DATABASE_NAME}|default_transaction_read_only=on`);
+    }
+  }
+  const actualSettings = await collectSettingKeys(sqlClient);
+  for (const expectedSetting of expectedSettings) {
+    if (!actualSettings.has(expectedSetting)) differences.push(`missing setting ${expectedSetting}`);
+  }
+  for (const actualSetting of actualSettings) {
+    if (!expectedSettings.has(actualSetting)) differences.push(`unexpected setting ${actualSetting}`);
+  }
+
+  const expectedMemberships = new Set([
+    `boardsesh_migrator|${MIGRATION_OWNER_ROLE}|admin=false|inherit=false|set=true`,
+  ]);
+  const actualMemberships = await collectMembershipKeys(sqlClient);
+  for (const expectedMembership of expectedMemberships) {
+    if (!actualMemberships.has(expectedMembership)) differences.push(`missing membership ${expectedMembership}`);
+  }
+  for (const actualMembership of actualMemberships) {
+    if (!expectedMemberships.has(actualMembership)) differences.push(`unexpected membership ${actualMembership}`);
+  }
+
+  const ownershipRows = await collectOwnershipRows(sqlClient);
+  for (const ownershipRow of ownershipRows) {
+    differences.push(
+      `unexpected ownership ${ownershipRow.role_name}|${ownershipRow.class_name}|db=${ownershipRow.database_oid}|oid=${ownershipRow.object_oid}`,
+    );
+  }
+
+  const policyReferenceRows = await collectPolicyReferenceRows(sqlClient);
+  for (const policyReference of policyReferenceRows) {
+    differences.push(
+      `unexpected RLS policy ${policyReference.role_name}|${policyReference.relation_name}|${policyReference.policy_name}`,
+    );
+  }
+
+  const ownedDefaultAclRows = await collectOwnedDefaultAclRows(sqlClient);
+  for (const defaultAcl of ownedDefaultAclRows) {
+    differences.push(
+      `unexpected owned default ACL ${defaultAcl.role_name}|${defaultAcl.schema_name}|${defaultAcl.object_type}`,
+    );
+  }
+
+  const sequenceKeys = await expectedSequenceAclKeys(sqlClient);
+  const expectedAclKeys = expectedDirectAclKeys(sequenceKeys);
+  const actualAcl = await collectDirectAclKeys(sqlClient);
+  for (const expectedAclKey of expectedAclKeys) {
+    if (!actualAcl.keys.has(expectedAclKey)) differences.push(`missing grant ${expectedAclKey}`);
+  }
+  for (const actualAclKey of actualAcl.keys) {
+    if (!expectedAclKeys.has(actualAclKey)) differences.push(`unexpected grant ${actualAclKey}`);
+  }
+  for (const grantableKey of actualAcl.grantableKeys) differences.push(`grant option forbidden ${grantableKey}`);
+  return differences.sort((left, right) => left.localeCompare(right));
+}
+
+function printDifferences(differences) {
+  if (differences.length === 0) {
+    console.info('Exact six-role contract matches; grant diff is empty.');
+    return;
+  }
+  console.info(`Grant/role diff (${differences.length}):`);
+  for (const difference of differences) console.info(`[task-role-diff] ${difference}`);
+}
+
+async function formattedStatements(sqlClient, selectSql) {
+  const rows = await sqlClient.unsafe(selectSql);
+  return rows.map(({ statement }) => statement);
+}
+
+async function executeStatements(sqlClient, statements) {
+  for (const statement of statements) await sqlClient.unsafe(statement);
+}
+
+async function assertNoUnsafeExistingRoleState(sqlClient) {
+  const ownershipRows = await collectOwnershipRows(sqlClient);
+  if (ownershipRows.length > 0) fail('managed role owns objects; refusing to reconcile it');
+
+  if ((await collectPolicyReferenceRows(sqlClient)).length > 0) {
+    fail('managed role is named in an RLS policy; manual policy review is required');
+  }
+  if ((await collectOwnedDefaultAclRows(sqlClient)).length > 0) {
+    fail('managed role owns a default ACL; manual grantor review is required');
+  }
+
+  const existingMemberships = await collectMembershipKeys(sqlClient);
+  const allowedMembership = `boardsesh_migrator|${MIGRATION_OWNER_ROLE}|admin=false|inherit=false|set=true`;
+  for (const membership of existingMemberships) {
+    if (membership !== allowedMembership) fail(`unexpected role membership requires manual review: ${membership}`);
+  }
+
+  const directAcl = await collectDirectAclKeys(sqlClient);
+  if ([...directAcl.keys].some((aclKey) => aclKey.includes('|default|'))) {
+    fail('managed role appears in a default ACL; manual grantor review is required');
+  }
+  if (directAcl.grantableKeys.length > 0) {
+    fail('managed role has a grant option; downstream grants require manual review');
+  }
+}
+
+async function revokeManagedDirectPrivileges(sqlClient) {
+  const roleNamesSql = roleNameListSql();
+  const statements = await formattedStatements(
+    sqlClient,
+    `WITH managed AS (
+       SELECT oid, rolname FROM pg_catalog.pg_roles WHERE rolname IN (${roleNamesSql})
+     )
+     SELECT DISTINCT pg_catalog.format(
+              'REVOKE ALL PRIVILEGES ON DATABASE %I FROM %I', database.datname, managed.rolname) AS statement
+       FROM pg_catalog.pg_database AS database
+       CROSS JOIN LATERAL pg_catalog.aclexplode(database.datacl) AS privilege
+       JOIN managed ON managed.oid = privilege.grantee
+     UNION ALL
+     SELECT DISTINCT pg_catalog.format(
+              'REVOKE ALL PRIVILEGES ON SCHEMA %I FROM %I', namespace.nspname, managed.rolname)
+       FROM pg_catalog.pg_namespace AS namespace
+       CROSS JOIN LATERAL pg_catalog.aclexplode(namespace.nspacl) AS privilege
+       JOIN managed ON managed.oid = privilege.grantee
+     UNION ALL
+     SELECT DISTINCT pg_catalog.format(
+              CASE WHEN relation.relkind = 'S'
+                THEN 'REVOKE ALL PRIVILEGES ON SEQUENCE %I.%I FROM %I'
+                ELSE 'REVOKE ALL PRIVILEGES ON TABLE %I.%I FROM %I' END,
+              namespace.nspname, relation.relname, managed.rolname)
+       FROM pg_catalog.pg_class AS relation
+       JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+       CROSS JOIN LATERAL pg_catalog.aclexplode(relation.relacl) AS privilege
+       JOIN managed ON managed.oid = privilege.grantee
+      WHERE relation.relkind IN ('r', 'p', 'v', 'm', 'f', 'S')
+     UNION ALL
+     SELECT DISTINCT pg_catalog.format('REVOKE ALL PRIVILEGES (%I) ON TABLE %I.%I FROM %I',
+              attribute.attname, namespace.nspname, relation.relname, managed.rolname)
+       FROM pg_catalog.pg_attribute AS attribute
+       JOIN pg_catalog.pg_class AS relation ON relation.oid = attribute.attrelid
+       JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+       CROSS JOIN LATERAL pg_catalog.aclexplode(attribute.attacl) AS privilege
+       JOIN managed ON managed.oid = privilege.grantee
+      WHERE attribute.attnum > 0 AND NOT attribute.attisdropped
+     UNION ALL
+     SELECT DISTINCT pg_catalog.format('REVOKE ALL PRIVILEGES ON ROUTINE %s FROM %I',
+              procedure.oid::pg_catalog.regprocedure, managed.rolname)
+       FROM pg_catalog.pg_proc AS procedure
+       CROSS JOIN LATERAL pg_catalog.aclexplode(procedure.proacl) AS privilege
+       JOIN managed ON managed.oid = privilege.grantee
+     UNION ALL
+     SELECT DISTINCT pg_catalog.format('REVOKE ALL PRIVILEGES ON TYPE %I.%I FROM %I',
+              namespace.nspname, type_row.typname, managed.rolname)
+       FROM pg_catalog.pg_type AS type_row
+       JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = type_row.typnamespace
+       CROSS JOIN LATERAL pg_catalog.aclexplode(type_row.typacl) AS privilege
+       JOIN managed ON managed.oid = privilege.grantee
+     UNION ALL
+     SELECT DISTINCT pg_catalog.format(
+              'REVOKE ALL PRIVILEGES ON LARGE OBJECT %s FROM %I', large_object.oid, managed.rolname)
+       FROM pg_catalog.pg_largeobject_metadata AS large_object
+       CROSS JOIN LATERAL pg_catalog.aclexplode(large_object.lomacl) AS privilege
+       JOIN managed ON managed.oid = privilege.grantee
+     UNION ALL
+     SELECT DISTINCT pg_catalog.format(
+              'REVOKE ALL PRIVILEGES ON PARAMETER %I FROM %I', parameter.parname, managed.rolname)
+       FROM pg_catalog.pg_parameter_acl AS parameter
+       CROSS JOIN LATERAL pg_catalog.aclexplode(parameter.paracl) AS privilege
+       JOIN managed ON managed.oid = privilege.grantee
+     UNION ALL
+     SELECT DISTINCT pg_catalog.format(
+              'REVOKE ALL PRIVILEGES ON LANGUAGE %I FROM %I', language.lanname, managed.rolname)
+       FROM pg_catalog.pg_language AS language
+       CROSS JOIN LATERAL pg_catalog.aclexplode(language.lanacl) AS privilege
+       JOIN managed ON managed.oid = privilege.grantee
+     UNION ALL
+     SELECT DISTINCT pg_catalog.format(
+              'REVOKE ALL PRIVILEGES ON FOREIGN DATA WRAPPER %I FROM %I', wrapper.fdwname, managed.rolname)
+       FROM pg_catalog.pg_foreign_data_wrapper AS wrapper
+       CROSS JOIN LATERAL pg_catalog.aclexplode(wrapper.fdwacl) AS privilege
+       JOIN managed ON managed.oid = privilege.grantee
+     UNION ALL
+     SELECT DISTINCT pg_catalog.format(
+              'REVOKE ALL PRIVILEGES ON FOREIGN SERVER %I FROM %I', server.srvname, managed.rolname)
+       FROM pg_catalog.pg_foreign_server AS server
+       CROSS JOIN LATERAL pg_catalog.aclexplode(server.srvacl) AS privilege
+       JOIN managed ON managed.oid = privilege.grantee
+     UNION ALL
+     SELECT DISTINCT pg_catalog.format(
+              'REVOKE ALL PRIVILEGES ON TABLESPACE %I FROM %I', tablespace.spcname, managed.rolname)
+       FROM pg_catalog.pg_tablespace AS tablespace
+       CROSS JOIN LATERAL pg_catalog.aclexplode(tablespace.spcacl) AS privilege
+       JOIN managed ON managed.oid = privilege.grantee
+     ORDER BY statement`,
+  );
+  await executeStatements(sqlClient, statements);
+}
+
+function scramVerifier(password) {
+  if (!PASSWORD_PATTERN.test(password)) fail('task password does not meet the generated credential contract');
+  const iterations = 4096;
+  const salt = randomBytes(16);
+  const saltedPassword = pbkdf2Sync(Buffer.from(password, 'utf8'), salt, iterations, 32, 'sha256');
+  const clientKey = createHmac('sha256', saltedPassword).update('Client Key').digest();
+  const storedKey = createHash('sha256').update(clientKey).digest();
+  const serverKey = createHmac('sha256', saltedPassword).update('Server Key').digest();
+  const verifier = `SCRAM-SHA-256$${iterations}:${salt.toString('base64')}$${storedKey.toString('base64')}:${serverKey.toString('base64')}`;
+  if (!/^SCRAM-SHA-256\$4096:[A-Za-z0-9+/=]+\$[A-Za-z0-9+/=]+:[A-Za-z0-9+/=]+$/.test(verifier)) {
+    fail('failed to build a safe SCRAM verifier');
+  }
+  return verifier;
+}
+
+async function applyContract(sqlClient, protectedCredentials) {
+  const preflightDifferences = await auditContract(sqlClient);
+  console.info('Pre-apply evidence:');
+  printDifferences(preflightDifferences);
+
+  await sqlClient.begin(async (transaction) => {
+    await transaction.unsafe(
+      `SELECT pg_catalog.pg_advisory_xact_lock(hashtextextended('boardsesh:production-task-roles:v1', 0))`,
+    );
+    await assertAdminBoundary(transaction);
+    const relationGaps = await missingRelations(transaction);
+    if (relationGaps.length > 0) fail(`required relations are missing: ${relationGaps.join(', ')}`);
+    await assertNoUnsafeExistingRoleState(transaction);
+
+    for (const roleContract of PRODUCTION_TASK_ROLES) {
+      const roleIdentifier = quoteIdentifier(roleContract.name);
+      const [existingRole] = await transaction.unsafe(
+        `SELECT true AS present FROM pg_catalog.pg_roles WHERE rolname = ${quoteLiteral(roleContract.name)}`,
+      );
+      if (!existingRole) await transaction.unsafe(`CREATE ROLE ${roleIdentifier}`);
+      await transaction.unsafe(
+        `ALTER ROLE ${roleIdentifier} WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION NOBYPASSRLS CONNECTION LIMIT ${roleContract.connectionLimit}`,
+      );
+      await transaction.unsafe(`ALTER ROLE ${roleIdentifier} RESET ALL`);
+      await transaction.unsafe(
+        `ALTER ROLE ${roleIdentifier} IN DATABASE ${quoteIdentifier(PRODUCTION_DATABASE_NAME)} RESET ALL`,
+      );
+      await transaction.unsafe(
+        `ALTER ROLE ${roleIdentifier} IN DATABASE ${quoteIdentifier(PRODUCTION_DATABASE_NAME)} SET application_name TO ${quoteLiteral(roleContract.applicationName)}`,
+      );
+      if (roleContract.readOnly) {
+        await transaction.unsafe(
+          `ALTER ROLE ${roleIdentifier} IN DATABASE ${quoteIdentifier(PRODUCTION_DATABASE_NAME)} SET default_transaction_read_only TO on`,
+        );
+      }
+      const verifier = scramVerifier(protectedCredentials.roles[roleContract.name].password);
+      await transaction.unsafe(`ALTER ROLE ${roleIdentifier} PASSWORD ${quoteLiteral(verifier)}`);
+    }
+
+    await revokeManagedDirectPrivileges(transaction);
+    await transaction.unsafe(
+      `GRANT ${quoteIdentifier(MIGRATION_OWNER_ROLE)} TO ${quoteIdentifier('boardsesh_migrator')} WITH ADMIN FALSE, INHERIT FALSE, SET TRUE`,
+    );
+
+    for (const roleContract of PRODUCTION_TASK_ROLES) {
+      if (roleContract.databasePrivileges.length > 0) {
+        await transaction.unsafe(
+          `GRANT ${roleContract.databasePrivileges.join(', ')} ON DATABASE ${quoteIdentifier(PRODUCTION_DATABASE_NAME)} TO ${quoteIdentifier(roleContract.name)}`,
+        );
+      }
+      if (roleContract.schemaPrivileges.length > 0) {
+        await transaction.unsafe(
+          `GRANT ${roleContract.schemaPrivileges.join(', ')} ON SCHEMA ${quoteIdentifier(PRODUCTION_SCHEMA_NAME)} TO ${quoteIdentifier(roleContract.name)}`,
+        );
+      }
+    }
+    for (const grantContract of PRODUCTION_TASK_RELATION_GRANTS) {
+      await transaction.unsafe(
+        `GRANT ${grantContract.privileges.join(', ')} ON TABLE ${quoteIdentifier(PRODUCTION_SCHEMA_NAME)}.${quoteIdentifier(grantContract.relation)} TO ${quoteIdentifier(grantContract.role)}`,
+      );
+    }
+
+    const sequenceKeys = await expectedSequenceAclKeys(transaction);
+    for (const sequenceKey of sequenceKeys) {
+      const [roleName, , qualifiedSequence] = sequenceKey.split('|');
+      const [schemaName, sequenceName] = qualifiedSequence.split('.');
+      await transaction.unsafe(
+        `GRANT USAGE ON SEQUENCE ${quoteIdentifier(schemaName)}.${quoteIdentifier(sequenceName)} TO ${quoteIdentifier(roleName)}`,
+      );
+    }
+  });
+
+  const differences = await auditContract(sqlClient);
+  printDifferences(differences);
+  if (differences.length > 0) fail('post-apply role audit failed');
+}
+
+async function allManagedRolesAbsent(sqlClient) {
+  const [result] = await sqlClient.unsafe(
+    `SELECT count(*) = 0 AS absent FROM pg_catalog.pg_roles WHERE rolname IN (${roleNameListSql()})`,
+  );
+  return Boolean(result?.absent);
+}
+
+async function rollbackContract(sqlClient) {
+  if (await allManagedRolesAbsent(sqlClient)) {
+    console.info('All six managed task roles are already absent; rollback is idempotently complete.');
+    return;
+  }
+  const preflightDifferences = await auditContract(sqlClient);
+  printDifferences(preflightDifferences);
+  if (preflightDifferences.length > 0) fail('rollback refuses a partial or drifted role contract');
+
+  const activeSessions = await sqlClient.unsafe(`
+    SELECT usename, count(*)::integer AS session_count
+    FROM pg_catalog.pg_stat_activity
+    WHERE usename IN (${roleNameListSql()}) AND pid <> pg_catalog.pg_backend_pid()
+    GROUP BY usename ORDER BY usename
+  `);
+  if (activeSessions.length > 0) fail('rollback refuses managed roles with active database sessions');
+
+  await sqlClient.begin(async (transaction) => {
+    await transaction.unsafe(
+      `SELECT pg_catalog.pg_advisory_xact_lock(hashtextextended('boardsesh:production-task-roles:v1', 0))`,
+    );
+    await transaction.unsafe(
+      `REVOKE ${quoteIdentifier(MIGRATION_OWNER_ROLE)} FROM ${quoteIdentifier('boardsesh_migrator')}`,
+    );
+    await revokeManagedDirectPrivileges(transaction);
+    for (const roleContract of PRODUCTION_TASK_ROLES) {
+      const roleIdentifier = quoteIdentifier(roleContract.name);
+      await transaction.unsafe(`ALTER ROLE ${roleIdentifier} NOLOGIN`);
+      await transaction.unsafe(`ALTER ROLE ${roleIdentifier} RESET ALL`);
+      await transaction.unsafe(
+        `ALTER ROLE ${roleIdentifier} IN DATABASE ${quoteIdentifier(PRODUCTION_DATABASE_NAME)} RESET ALL`,
+      );
+    }
+    for (const roleContract of [...PRODUCTION_TASK_ROLES].reverse()) {
+      await transaction.unsafe(`DROP ROLE ${quoteIdentifier(roleContract.name)}`);
+    }
+  });
+  if (!(await allManagedRolesAbsent(sqlClient))) fail('rollback did not remove all managed task roles');
+  console.info('Rolled back exactly six ownership-free task roles; application data and owner roles were untouched.');
+}
+
+async function withAdminClient(run) {
+  const rawDatabaseUrl = adminDatabaseUrl();
+  const sqlClient = createAdminClient(rawDatabaseUrl);
+  try {
+    await assertAdminBoundary(sqlClient);
+    await run(sqlClient);
+  } finally {
+    await sqlClient.end({ timeout: 5 }).catch(() => {});
+  }
+}
+
+function usage() {
+  console.info(`Usage: node scripts/production-db-task-roles.mjs COMMAND
+
+Commands:
+  generate  Write six random credentials and exact forwarder URLs to a new 0600 file.
+  plan      Print the read-only role/grant diff and exit successfully.
+  audit     Require an empty read-only role/grant diff.
+  apply     Reconcile the exact contract and rotate all six passwords atomically.
+  rollback  Drop only an exact, inactive, ownership-free managed contract.
+
+Environment:
+  ROLE_CREDENTIALS_FILE       Absolute protected JSON path (generate/apply).
+  POSTGRES_FORWARDER_HOST     Full MagicDNS hostname (generate and remote database commands).
+  ADMIN_DATABASE_URL          Canonical railway admin URL (plan/audit/apply/rollback).
+  APPLY_TASK_ROLE_CHANGES     Must equal ${APPLY_CONFIRMATION} for apply.
+  ROLLBACK_TASK_ROLES         Must equal ${ROLLBACK_CONFIRMATION} for rollback.
+  ALLOW_DISPOSABLE_TASK_ROLE_SMOKE
+                              Test-only; exact ${DISPOSABLE_LOCAL_CONFIRMATION} enables loopback.
+
+Passwords and generated URLs are never accepted on argv or printed.`);
+}
+
+assertStaticContract();
+const command = process.argv[2];
+if (process.argv.length > 3) fail('only the non-secret command is accepted on argv');
+
+try {
+  switch (command) {
+    case 'generate':
+      generateCredentials();
+      break;
+    case 'plan':
+      await withAdminClient(async (sqlClient) => printDifferences(await auditContract(sqlClient)));
+      break;
+    case 'audit':
+      await withAdminClient(async (sqlClient) => {
+        const differences = await auditContract(sqlClient);
+        printDifferences(differences);
+        if (differences.length > 0) fail('task-role audit found drift');
+      });
+      break;
+    case 'apply': {
+      if (process.env.APPLY_TASK_ROLE_CHANGES !== APPLY_CONFIRMATION) {
+        fail(`APPLY_TASK_ROLE_CHANGES must equal ${APPLY_CONFIRMATION}`);
+      }
+      delete process.env.APPLY_TASK_ROLE_CHANGES;
+      const protectedCredentials = readProtectedCredentials();
+      await withAdminClient((sqlClient) => applyContract(sqlClient, protectedCredentials));
+      break;
+    }
+    case 'rollback':
+      if (process.env.ROLLBACK_TASK_ROLES !== ROLLBACK_CONFIRMATION) {
+        fail(`ROLLBACK_TASK_ROLES must equal ${ROLLBACK_CONFIRMATION}`);
+      }
+      delete process.env.ROLLBACK_TASK_ROLES;
+      await withAdminClient(rollbackContract);
+      break;
+    case 'help':
+    case '--help':
+    case '-h':
+      usage();
+      break;
+    default:
+      usage();
+      process.exitCode = 1;
+  }
+} catch (error) {
+  const message = error instanceof Error ? error.message : 'unknown task-role provisioning error';
+  const code = typeof error === 'object' && error !== null && 'code' in error ? String(error.code) : 'guard';
+  console.error(`error [${code}]: ${message}`);
+  process.exitCode = 1;
+}

--- a/scripts/production-db-task-roles.mjs
+++ b/scripts/production-db-task-roles.mjs
@@ -486,7 +486,7 @@ async function collectClusterWideBoundaryDifferences(sqlClient) {
         coalesce(
           relation.relacl,
           pg_catalog.acldefault(
-            CASE WHEN relation.relkind = 'S' THEN 'S'::"char" ELSE 'r'::"char" END,
+            CASE WHEN relation.relkind = 'S' THEN 's'::"char" ELSE 'r'::"char" END,
             relation.relowner
           )
         )
@@ -571,12 +571,15 @@ async function collectClusterWideBoundaryDifferences(sqlClient) {
     ), owner_role AS (
       SELECT oid, rolname FROM pg_catalog.pg_roles
       WHERE rolname = ${quoteLiteral(MIGRATION_OWNER_ROLE)}
-    ), default_kind(object_type, sql_kind) AS (
-      VALUES ('r'::"char", 'TABLES'::text), ('S'::"char", 'SEQUENCES'::text),
-             ('f'::"char", 'ROUTINES'::text), ('T'::"char", 'TYPES'::text)
+    ), default_kind(catalog_object_type, acl_default_object_type, sql_kind) AS (
+      VALUES ('r'::"char", 'r'::"char", 'TABLES'::text),
+             ('S'::"char", 's'::"char", 'SEQUENCES'::text),
+             ('f'::"char", 'f'::"char", 'ROUTINES'::text),
+             ('T'::"char", 'T'::"char", 'TYPES'::text)
     ), owner_global_default AS (
       SELECT 'default_acl'::text AS object_kind,
-             pg_catalog.format('%I:*:%s', owner_role.rolname, default_kind.object_type::text) AS object_name,
+             pg_catalog.format('%I:*:%s', owner_role.rolname,
+                               default_kind.catalog_object_type::text) AS object_name,
              privilege.privilege_type,
              privilege.is_grantable,
              pg_catalog.format('ALTER DEFAULT PRIVILEGES FOR ROLE %I REVOKE %s ON %s FROM PUBLIC',
@@ -584,11 +587,14 @@ async function collectClusterWideBoundaryDifferences(sqlClient) {
       FROM owner_role
       CROSS JOIN default_kind
       LEFT JOIN pg_catalog.pg_default_acl AS default_acl
-        ON default_acl.defaclrole = owner_role.oid
+       ON default_acl.defaclrole = owner_role.oid
        AND default_acl.defaclnamespace = 0
-       AND default_acl.defaclobjtype = default_kind.object_type
+       AND default_acl.defaclobjtype = default_kind.catalog_object_type
       CROSS JOIN LATERAL pg_catalog.aclexplode(
-        coalesce(default_acl.defaclacl, pg_catalog.acldefault(default_kind.object_type, owner_role.oid))
+        coalesce(
+          default_acl.defaclacl,
+          pg_catalog.acldefault(default_kind.acl_default_object_type, owner_role.oid)
+        )
       ) AS privilege
       WHERE privilege.grantee = 0
     ), owner_schema_default AS (

--- a/scripts/production-db-task-roles.mjs
+++ b/scripts/production-db-task-roles.mjs
@@ -23,8 +23,17 @@ import {
   PRODUCTION_TASK_ROLES,
   PRODUCTION_TASK_ROLE_BY_NAME,
 } from './lib/production-db-task-role-contract.mjs';
+import {
+  assertContractSqlSafety,
+  connectionLimitSql,
+  fail,
+  privilegeListSql,
+  qualifiedRelationSql,
+  quoteIdentifier,
+  quoteLiteral,
+  valuesList,
+} from './lib/production-db-task-role-sql.mjs';
 
-const IDENTIFIER_PATTERN = /^[a-z_][a-z0-9_]*$/;
 const APPLICATION_NAME_PATTERN = /^[a-z0-9-]+$/;
 const PASSWORD_PATTERN = /^[a-f0-9]{64}$/;
 const FORWARDER_HOST_PATTERN = /^boardsesh-db-forwarder\.([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+ts\.net$/;
@@ -41,23 +50,6 @@ const ALLOWED_PUBLIC_BOUNDARY_KEYS = new Set(
     .map((privilege) => `database|${PRODUCTION_DATABASE_NAME}|${privilege}`),
 );
 
-function fail(message) {
-  throw new Error(message);
-}
-
-function quoteIdentifier(identifier) {
-  if (!IDENTIFIER_PATTERN.test(identifier)) fail(`unsafe PostgreSQL identifier: ${identifier}`);
-  return `"${identifier}"`;
-}
-
-function quoteLiteral(literal) {
-  return `'${String(literal).replaceAll("'", "''")}'`;
-}
-
-function valuesList(values) {
-  return values.map(quoteLiteral).join(', ');
-}
-
 function roleNameListSql() {
   return valuesList(MANAGED_ROLE_NAMES);
 }
@@ -66,11 +58,15 @@ function assertStaticContract() {
   if (PRODUCTION_TASK_ROLES.length !== 6 || new Set(MANAGED_ROLE_NAMES).size !== 6) {
     fail('task-role contract must contain exactly six unique LOGIN roles');
   }
+  assertContractSqlSafety(PRODUCTION_TASK_ROLES, PRODUCTION_TASK_RELATION_GRANTS);
+  quoteIdentifier(PRODUCTION_DATABASE_NAME);
+  quoteIdentifier(PRODUCTION_SCHEMA_NAME);
+  quoteIdentifier(MIGRATION_OWNER_ROLE);
+  for (const schemaName of PRODUCTION_MANAGED_SCHEMAS) quoteIdentifier(schemaName);
   const applicationNames = new Set();
   const githubSecrets = new Set();
   const relationGrantKeys = new Set();
   for (const roleContract of PRODUCTION_TASK_ROLES) {
-    quoteIdentifier(roleContract.name);
     if (!APPLICATION_NAME_PATTERN.test(roleContract.applicationName)) {
       fail(`invalid application_name for ${roleContract.name}`);
     }
@@ -81,8 +77,6 @@ function assertStaticContract() {
   }
   for (const grantContract of PRODUCTION_TASK_RELATION_GRANTS) {
     if (!PRODUCTION_TASK_ROLE_BY_NAME.has(grantContract.role)) fail(`unknown grant role ${grantContract.role}`);
-    quoteIdentifier(grantContract.relation);
-    if (grantContract.privileges.length === 0) fail(`empty privileges for ${grantContract.role}`);
     const relationGrantKey = `${grantContract.role}|${grantContract.relation}`;
     if (relationGrantKeys.has(relationGrantKey)) fail(`duplicate relation grant ${relationGrantKey}`);
     relationGrantKeys.add(relationGrantKey);
@@ -1171,7 +1165,7 @@ async function applyContract(sqlClient, protectedCredentials) {
       );
       if (!existingRole) await transaction.unsafe(`CREATE ROLE ${roleIdentifier}`);
       await transaction.unsafe(
-        `ALTER ROLE ${roleIdentifier} WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION NOBYPASSRLS CONNECTION LIMIT ${roleContract.connectionLimit}`,
+        `ALTER ROLE ${roleIdentifier} WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION NOBYPASSRLS CONNECTION LIMIT ${connectionLimitSql(roleContract.connectionLimit, roleContract.name)}`,
       );
       await transaction.unsafe(`ALTER ROLE ${roleIdentifier} RESET ALL`);
       await transaction.unsafe(
@@ -1197,27 +1191,29 @@ async function applyContract(sqlClient, protectedCredentials) {
     for (const roleContract of PRODUCTION_TASK_ROLES) {
       if (roleContract.databasePrivileges.length > 0) {
         await transaction.unsafe(
-          `GRANT ${roleContract.databasePrivileges.join(', ')} ON DATABASE ${quoteIdentifier(PRODUCTION_DATABASE_NAME)} TO ${quoteIdentifier(roleContract.name)}`,
+          `GRANT ${privilegeListSql('database', roleContract.databasePrivileges, roleContract.name)} ON DATABASE ${quoteIdentifier(PRODUCTION_DATABASE_NAME)} TO ${quoteIdentifier(roleContract.name)}`,
         );
       }
       if (roleContract.schemaPrivileges.length > 0) {
         await transaction.unsafe(
-          `GRANT ${roleContract.schemaPrivileges.join(', ')} ON SCHEMA ${quoteIdentifier(PRODUCTION_SCHEMA_NAME)} TO ${quoteIdentifier(roleContract.name)}`,
+          `GRANT ${privilegeListSql('schema', roleContract.schemaPrivileges, roleContract.name)} ON SCHEMA ${quoteIdentifier(PRODUCTION_SCHEMA_NAME)} TO ${quoteIdentifier(roleContract.name)}`,
         );
       }
     }
     for (const grantContract of PRODUCTION_TASK_RELATION_GRANTS) {
+      const grantContext = `${grantContract.role} on ${grantContract.relation}`;
       await transaction.unsafe(
-        `GRANT ${grantContract.privileges.join(', ')} ON TABLE ${quoteIdentifier(PRODUCTION_SCHEMA_NAME)}.${quoteIdentifier(grantContract.relation)} TO ${quoteIdentifier(grantContract.role)}`,
+        `GRANT ${privilegeListSql('relation', grantContract.privileges, grantContext)} ON TABLE ${qualifiedRelationSql(PRODUCTION_SCHEMA_NAME, grantContract.relation)} TO ${quoteIdentifier(grantContract.role)}`,
       );
     }
 
     const sequenceKeys = await expectedSequenceAclKeys(transaction);
     for (const sequenceKey of sequenceKeys) {
       const [roleName, , qualifiedSequence] = sequenceKey.split('|');
-      const [schemaName, sequenceName] = qualifiedSequence.split('.');
+      const sequenceParts = qualifiedSequence.split('.');
+      if (sequenceParts.length !== 2) fail(`unsafe sequence name for ${roleName}: ${qualifiedSequence}`);
       await transaction.unsafe(
-        `GRANT USAGE ON SEQUENCE ${quoteIdentifier(schemaName)}.${quoteIdentifier(sequenceName)} TO ${quoteIdentifier(roleName)}`,
+        `GRANT USAGE ON SEQUENCE ${qualifiedRelationSql(sequenceParts[0], sequenceParts[1])} TO ${quoteIdentifier(roleName)}`,
       );
     }
   });

--- a/scripts/production-db-task-roles.mjs
+++ b/scripts/production-db-task-roles.mjs
@@ -1,7 +1,17 @@
 #!/usr/bin/env node
 import { createHash, createHmac, pbkdf2Sync, randomBytes } from 'node:crypto';
-import { closeSync, fstatSync, lstatSync, openSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
+import {
+  closeSync,
+  constants as fileConstants,
+  fstatSync,
+  fsyncSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, isAbsolute, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import postgres from 'postgres';
 import {
@@ -22,7 +32,7 @@ const APPLY_CONFIRMATION = 'APPLY_EXACT_SIX_TASK_ROLES';
 const ROLLBACK_CONFIRMATION = 'DROP_EXACT_SIX_TASK_ROLES';
 const DISPOSABLE_LOCAL_CONFIRMATION = 'ALLOW_EXACT_LOOPBACK_FIXTURE';
 const MANAGED_ROLE_NAMES = PRODUCTION_TASK_ROLES.map(({ name }) => name);
-const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const REPOSITORY_ROOT = realpathSync(resolve(dirname(fileURLToPath(import.meta.url)), '..'));
 const ALLOWED_PUBLIC_BOUNDARY_KEYS = new Set(
   PRODUCTION_TASK_ROLES[0].databasePrivileges
     .filter((privilege) =>
@@ -79,67 +89,147 @@ function assertStaticContract() {
   }
 }
 
-function credentialsFilePath() {
-  const filePath = process.env.ROLE_CREDENTIALS_FILE;
-  if (!filePath || !isAbsolute(filePath)) fail('ROLE_CREDENTIALS_FILE must be an absolute path');
-  const relativeToRepository = relative(REPOSITORY_ROOT, resolve(filePath));
-  if (
+function isInsideRepository(canonicalPath) {
+  const relativeToRepository = relative(REPOSITORY_ROOT, canonicalPath);
+  return (
     relativeToRepository === '' ||
     (!relativeToRepository.startsWith(`..${sep}`) && relativeToRepository !== '..' && !isAbsolute(relativeToRepository))
-  ) {
-    fail('ROLE_CREDENTIALS_FILE must be outside the repository');
-  }
-  return filePath;
+  );
 }
 
-function readProtectedCredentials() {
-  const filePath = credentialsFilePath();
-  const fileStats = lstatSync(filePath);
-  if (!fileStats.isFile() || fileStats.isSymbolicLink())
-    fail('ROLE_CREDENTIALS_FILE must be a regular non-symlink file');
+function credentialsFileTarget() {
+  const filePath = process.env.ROLE_CREDENTIALS_FILE;
+  if (!filePath || !isAbsolute(filePath)) fail('ROLE_CREDENTIALS_FILE must be an absolute path');
+  const requestedPath = resolve(filePath);
+  const requestedParent = dirname(requestedPath);
+  let canonicalParent;
+  try {
+    canonicalParent = realpathSync(requestedParent);
+  } catch {
+    fail('ROLE_CREDENTIALS_FILE parent must already exist');
+  }
+  const canonicalPath = resolve(canonicalParent, basename(requestedPath));
+  if (isInsideRepository(canonicalPath)) {
+    fail('ROLE_CREDENTIALS_FILE must be outside the repository');
+  }
+  const parentStats = statSync(canonicalParent);
+  if (!parentStats.isDirectory()) fail('ROLE_CREDENTIALS_FILE parent must be a directory');
+  if ((parentStats.mode & 0o077) !== 0) {
+    fail('ROLE_CREDENTIALS_FILE parent must not be accessible by group or other users');
+  }
+  if (typeof process.getuid === 'function' && parentStats.uid !== process.getuid()) {
+    fail('ROLE_CREDENTIALS_FILE parent must be owned by the current user');
+  }
+  return {
+    canonicalParent,
+    canonicalPath,
+    parentDevice: parentStats.dev,
+    parentInode: parentStats.ino,
+  };
+}
+
+function assertCredentialsParentStable(fileTarget) {
+  let canonicalParent;
+  try {
+    canonicalParent = realpathSync(fileTarget.canonicalParent);
+  } catch {
+    fail('ROLE_CREDENTIALS_FILE parent changed during validation');
+  }
+  const parentStats = statSync(canonicalParent);
+  if (
+    canonicalParent !== fileTarget.canonicalParent ||
+    parentStats.dev !== fileTarget.parentDevice ||
+    parentStats.ino !== fileTarget.parentInode ||
+    !parentStats.isDirectory() ||
+    (parentStats.mode & 0o077) !== 0 ||
+    (typeof process.getuid === 'function' && parentStats.uid !== process.getuid())
+  ) {
+    fail('ROLE_CREDENTIALS_FILE parent changed during validation');
+  }
+}
+
+function assertOpenedCredentialsFile(fileTarget, fileDescriptor, fileStats) {
+  if (!fileStats.isFile() || fileStats.nlink !== 1) {
+    fail('ROLE_CREDENTIALS_FILE must be one regular, non-linked file');
+  }
   if ((fileStats.mode & 0o077) !== 0) fail('ROLE_CREDENTIALS_FILE must not be accessible by group or other users');
   if (typeof process.getuid === 'function' && fileStats.uid !== process.getuid()) {
     fail('ROLE_CREDENTIALS_FILE must be owned by the current user');
   }
-  if (fileStats.size > 32768) fail('ROLE_CREDENTIALS_FILE is unexpectedly large');
-
-  let parsedCredentials;
+  assertCredentialsParentStable(fileTarget);
+  let canonicalOpenedPath;
   try {
-    parsedCredentials = JSON.parse(readFileSync(filePath, 'utf8'));
+    canonicalOpenedPath = realpathSync(fileTarget.canonicalPath);
   } catch {
-    fail('ROLE_CREDENTIALS_FILE is not valid JSON');
+    fail('ROLE_CREDENTIALS_FILE changed during validation');
   }
-  if (parsedCredentials?.version !== 1 || typeof parsedCredentials.forwarderHost !== 'string') {
-    fail('ROLE_CREDENTIALS_FILE has an unsupported format');
+  const pathStats = statSync(fileTarget.canonicalPath);
+  if (
+    canonicalOpenedPath !== fileTarget.canonicalPath ||
+    pathStats.dev !== fileStats.dev ||
+    pathStats.ino !== fileStats.ino ||
+    fstatSync(fileDescriptor).ino !== fileStats.ino
+  ) {
+    fail('ROLE_CREDENTIALS_FILE changed during validation');
   }
-  if (!FORWARDER_HOST_PATTERN.test(parsedCredentials.forwarderHost)) {
-    fail('ROLE_CREDENTIALS_FILE contains an invalid forwarder host');
-  }
-  const credentialRoleNames = Object.keys(parsedCredentials.roles ?? {}).sort((left, right) =>
-    left.localeCompare(right),
-  );
-  const expectedRoleNames = [...MANAGED_ROLE_NAMES].sort((left, right) => left.localeCompare(right));
-  if (JSON.stringify(credentialRoleNames) !== JSON.stringify(expectedRoleNames)) {
-    fail('ROLE_CREDENTIALS_FILE must contain exactly the six managed roles');
-  }
+}
 
-  for (const roleContract of PRODUCTION_TASK_ROLES) {
-    const credential = parsedCredentials.roles[roleContract.name];
-    if (
-      credential?.applicationName !== roleContract.applicationName ||
-      credential?.githubSecret !== roleContract.githubSecret ||
-      !PASSWORD_PATTERN.test(credential?.password ?? '')
-    ) {
-      fail(`ROLE_CREDENTIALS_FILE entry for ${roleContract.name} does not match its exact contract`);
-    }
-    validateGeneratedDatabaseUrl(
-      credential.databaseUrl,
-      parsedCredentials.forwarderHost,
-      roleContract,
-      credential.password,
+function readProtectedCredentials() {
+  const fileTarget = credentialsFileTarget();
+  let fileDescriptor;
+  try {
+    fileDescriptor = openSync(
+      fileTarget.canonicalPath,
+      fileConstants.O_RDONLY | fileConstants.O_NOFOLLOW | fileConstants.O_CLOEXEC,
     );
+  } catch {
+    fail('ROLE_CREDENTIALS_FILE must be an existing regular non-symlink file');
   }
-  return parsedCredentials;
+  try {
+    const fileStats = fstatSync(fileDescriptor);
+    assertOpenedCredentialsFile(fileTarget, fileDescriptor, fileStats);
+    if (fileStats.size > 32768) fail('ROLE_CREDENTIALS_FILE is unexpectedly large');
+
+    let parsedCredentials;
+    try {
+      parsedCredentials = JSON.parse(readFileSync(fileDescriptor, 'utf8'));
+    } catch {
+      fail('ROLE_CREDENTIALS_FILE is not valid JSON');
+    }
+    if (parsedCredentials?.version !== 1 || typeof parsedCredentials.forwarderHost !== 'string') {
+      fail('ROLE_CREDENTIALS_FILE has an unsupported format');
+    }
+    if (!FORWARDER_HOST_PATTERN.test(parsedCredentials.forwarderHost)) {
+      fail('ROLE_CREDENTIALS_FILE contains an invalid forwarder host');
+    }
+    const credentialRoleNames = Object.keys(parsedCredentials.roles ?? {}).sort((left, right) =>
+      left.localeCompare(right),
+    );
+    const expectedRoleNames = [...MANAGED_ROLE_NAMES].sort((left, right) => left.localeCompare(right));
+    if (JSON.stringify(credentialRoleNames) !== JSON.stringify(expectedRoleNames)) {
+      fail('ROLE_CREDENTIALS_FILE must contain exactly the six managed roles');
+    }
+
+    for (const roleContract of PRODUCTION_TASK_ROLES) {
+      const credential = parsedCredentials.roles[roleContract.name];
+      if (
+        credential?.applicationName !== roleContract.applicationName ||
+        credential?.githubSecret !== roleContract.githubSecret ||
+        !PASSWORD_PATTERN.test(credential?.password ?? '')
+      ) {
+        fail(`ROLE_CREDENTIALS_FILE entry for ${roleContract.name} does not match its exact contract`);
+      }
+      validateGeneratedDatabaseUrl(
+        credential.databaseUrl,
+        parsedCredentials.forwarderHost,
+        roleContract,
+        credential.password,
+      );
+    }
+    return parsedCredentials;
+  } finally {
+    closeSync(fileDescriptor);
+  }
 }
 
 function validateGeneratedDatabaseUrl(rawDatabaseUrl, expectedHost, roleContract, expectedPassword) {
@@ -169,7 +259,7 @@ function validateGeneratedDatabaseUrl(rawDatabaseUrl, expectedHost, roleContract
 }
 
 function generateCredentials() {
-  const filePath = credentialsFilePath();
+  const fileTarget = credentialsFileTarget();
   const forwarderHost = process.env.POSTGRES_FORWARDER_HOST ?? '';
   if (!FORWARDER_HOST_PATTERN.test(forwarderHost)) {
     fail('POSTGRES_FORWARDER_HOST must be the full boardsesh-db-forwarder MagicDNS name');
@@ -189,11 +279,20 @@ function generateCredentials() {
     };
   }
 
-  const fileDescriptor = openSync(filePath, 'wx', 0o600);
+  const fileDescriptor = openSync(
+    fileTarget.canonicalPath,
+    fileConstants.O_WRONLY |
+      fileConstants.O_CREAT |
+      fileConstants.O_EXCL |
+      fileConstants.O_NOFOLLOW |
+      fileConstants.O_CLOEXEC,
+    0o600,
+  );
   try {
-    writeFileSync(fileDescriptor, `${JSON.stringify(protectedCredentials, null, 2)}\n`, { encoding: 'utf8' });
     const fileStats = fstatSync(fileDescriptor);
-    if ((fileStats.mode & 0o077) !== 0) fail('generated credential file mode is not private');
+    assertOpenedCredentialsFile(fileTarget, fileDescriptor, fileStats);
+    writeFileSync(fileDescriptor, `${JSON.stringify(protectedCredentials, null, 2)}\n`, { encoding: 'utf8' });
+    fsyncSync(fileDescriptor);
   } finally {
     closeSync(fileDescriptor);
   }
@@ -444,8 +543,38 @@ async function collectClusterWideBoundaryDifferences(sqlClient) {
     );
   }
 
+  const unexpectedSchemaRows = await sqlClient.unsafe(`
+    SELECT pg_catalog.format('%I', namespace.nspname) AS schema_name,
+           pg_catalog.pg_get_userbyid(namespace.nspowner) AS owner_name
+    FROM pg_catalog.pg_namespace AS namespace
+    WHERE namespace.nspname NOT IN (${valuesList(PRODUCTION_MANAGED_SCHEMAS)})
+      AND namespace.nspname <> 'information_schema'
+      AND namespace.nspname !~ '^pg_'
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_depend AS dependency
+        WHERE dependency.classid = 'pg_catalog.pg_namespace'::pg_catalog.regclass
+          AND dependency.objid = namespace.oid AND dependency.deptype = 'e'
+      )
+    ORDER BY namespace.nspname
+  `);
+  for (const { schema_name: schemaName, owner_name: ownerName } of unexpectedSchemaRows) {
+    differences.push(
+      `cluster prerequisite unexpected schema ${schemaName}|owner=${ownerName}; reviewed remediation: classify ownership and add a narrow manifest exception or remove the schema separately`,
+    );
+  }
+
   const publicAclRows = await sqlClient.unsafe(`
-    WITH public_acl AS (
+    WITH audited_schema AS (
+      SELECT namespace.*
+      FROM pg_catalog.pg_namespace AS namespace
+      WHERE namespace.nspname <> 'information_schema'
+        AND namespace.nspname !~ '^pg_'
+        AND NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_depend AS dependency
+          WHERE dependency.classid = 'pg_catalog.pg_namespace'::pg_catalog.regclass
+            AND dependency.objid = namespace.oid AND dependency.deptype = 'e'
+        )
+    ), public_acl AS (
       SELECT 'database'::text AS object_kind,
              database.datname AS object_name,
              privilege.privilege_type,
@@ -463,12 +592,11 @@ async function collectClusterWideBoundaryDifferences(sqlClient) {
       SELECT 'schema', namespace.nspname, privilege.privilege_type, privilege.is_grantable,
              pg_catalog.format('REVOKE %s ON SCHEMA %I FROM PUBLIC',
                                privilege.privilege_type, namespace.nspname)
-      FROM pg_catalog.pg_namespace AS namespace
+      FROM audited_schema AS namespace
       CROSS JOIN LATERAL pg_catalog.aclexplode(
         coalesce(namespace.nspacl, pg_catalog.acldefault('n', namespace.nspowner))
       ) AS privilege
-      WHERE namespace.nspname IN (${valuesList(PRODUCTION_MANAGED_SCHEMAS)})
-        AND privilege.grantee = 0
+      WHERE privilege.grantee = 0
 
       UNION ALL
       SELECT CASE WHEN relation.relkind = 'S' THEN 'sequence' ELSE 'relation' END,
@@ -568,6 +696,33 @@ async function collectClusterWideBoundaryDifferences(sqlClient) {
           WHERE dependency.classid = 'pg_catalog.pg_type'::pg_catalog.regclass
             AND dependency.objid = type_row.oid AND dependency.deptype = 'e'
         )
+
+      UNION ALL
+      SELECT 'large_object', large_object.oid::text,
+             privilege.privilege_type,
+             privilege.is_grantable,
+             pg_catalog.format('REVOKE %s ON LARGE OBJECT %s FROM PUBLIC',
+                               privilege.privilege_type, large_object.oid)
+      FROM pg_catalog.pg_largeobject_metadata AS large_object
+      CROSS JOIN LATERAL pg_catalog.aclexplode(
+        coalesce(large_object.lomacl, pg_catalog.acldefault('L', large_object.lomowner))
+      ) AS privilege
+      WHERE privilege.grantee = 0
+        AND NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_depend AS dependency
+          WHERE dependency.classid = 'pg_catalog.pg_largeobject_metadata'::pg_catalog.regclass
+            AND dependency.objid = large_object.oid AND dependency.deptype = 'e'
+        )
+
+      UNION ALL
+      SELECT 'parameter', parameter.parname,
+             privilege.privilege_type,
+             privilege.is_grantable,
+             pg_catalog.format('REVOKE %s ON PARAMETER %I FROM PUBLIC',
+                               privilege.privilege_type, parameter.parname)
+      FROM pg_catalog.pg_parameter_acl AS parameter
+      CROSS JOIN LATERAL pg_catalog.aclexplode(parameter.paracl) AS privilege
+      WHERE privilege.grantee = 0
     ), owner_role AS (
       SELECT oid, rolname FROM pg_catalog.pg_roles
       WHERE rolname = ${quoteLiteral(MIGRATION_OWNER_ROLE)}
@@ -575,7 +730,9 @@ async function collectClusterWideBoundaryDifferences(sqlClient) {
       VALUES ('r'::"char", 'r'::"char", 'TABLES'::text),
              ('S'::"char", 's'::"char", 'SEQUENCES'::text),
              ('f'::"char", 'f'::"char", 'ROUTINES'::text),
-             ('T'::"char", 'T'::"char", 'TYPES'::text)
+             ('T'::"char", 'T'::"char", 'TYPES'::text),
+             ('n'::"char", 'n'::"char", 'SCHEMAS'::text),
+             ('L'::"char", 'L'::"char", 'LARGE OBJECTS'::text)
     ), owner_global_default AS (
       SELECT 'default_acl'::text AS object_kind,
              pg_catalog.format('%I:*:%s', owner_role.rolname,
@@ -741,7 +898,7 @@ function expectedDirectAclKeys(sequenceKeys) {
   return expectedKeys;
 }
 
-async function auditContract(sqlClient) {
+async function auditContract(sqlClient, { managedRoleLoginState = 'login' } = {}) {
   const differences = [];
   differences.push(...(await collectClusterWideBoundaryDifferences(sqlClient)));
   const relationGaps = await missingRelations(sqlClient);
@@ -755,8 +912,10 @@ async function auditContract(sqlClient) {
       differences.push(`missing role ${roleContract.name}`);
       continue;
     }
+    const loginStateMatches =
+      managedRoleLoginState === 'either' || roleRow.rolcanlogin === (managedRoleLoginState === 'login');
     const attributesMatch =
-      roleRow.rolcanlogin &&
+      loginStateMatches &&
       !roleRow.rolsuper &&
       !roleRow.rolcreatedb &&
       !roleRow.rolcreaterole &&
@@ -1075,45 +1234,89 @@ async function allManagedRolesAbsent(sqlClient) {
   return Boolean(result?.absent);
 }
 
-async function rollbackContract(sqlClient) {
-  if (await allManagedRolesAbsent(sqlClient)) {
-    console.info('All six managed task roles are already absent; rollback is idempotently complete.');
-    return;
-  }
-  const preflightDifferences = await auditContract(sqlClient);
-  printDifferences(preflightDifferences);
-  if (preflightDifferences.length > 0) fail('rollback refuses a partial or drifted role contract');
-
-  const activeSessions = await sqlClient.unsafe(`
-    SELECT usename, count(*)::integer AS session_count
-    FROM pg_catalog.pg_stat_activity
-    WHERE usename IN (${roleNameListSql()}) AND pid <> pg_catalog.pg_backend_pid()
-    GROUP BY usename ORDER BY usename
+async function collectManagedSessionRows(sqlClient) {
+  return sqlClient.unsafe(`
+    SELECT role_row.rolname AS role_name, count(*)::integer AS session_count
+    FROM pg_catalog.pg_stat_activity AS activity
+    JOIN pg_catalog.pg_roles AS role_row ON role_row.oid = activity.usesysid
+    WHERE role_row.rolname IN (${roleNameListSql()})
+      AND activity.pid <> pg_catalog.pg_backend_pid()
+    GROUP BY role_row.rolname
+    ORDER BY role_row.rolname
   `);
-  if (activeSessions.length > 0) fail('rollback refuses managed roles with active database sessions');
+}
 
-  await sqlClient.begin(async (transaction) => {
-    await transaction.unsafe(
-      `SELECT pg_catalog.pg_advisory_xact_lock(hashtextextended('boardsesh:production-task-roles:v1', 0))`,
-    );
-    await transaction.unsafe(
-      `REVOKE ${quoteIdentifier(MIGRATION_OWNER_ROLE)} FROM ${quoteIdentifier('boardsesh_migrator')}`,
-    );
-    await revokeManagedDirectPrivileges(transaction);
-    for (const roleContract of PRODUCTION_TASK_ROLES) {
-      const roleIdentifier = quoteIdentifier(roleContract.name);
-      await transaction.unsafe(`ALTER ROLE ${roleIdentifier} NOLOGIN`);
-      await transaction.unsafe(`ALTER ROLE ${roleIdentifier} RESET ALL`);
+function failForManagedSessions(activeSessions) {
+  if (activeSessions.length === 0) return;
+  const sessionSummary = activeSessions
+    .map(({ role_name: roleName, session_count: sessionCount }) => `${roleName}:${sessionCount}`)
+    .join(', ');
+  fail(
+    `rollback fenced all six managed roles NOLOGIN but refuses active authenticated sessions (${sessionSummary}); drain them and rerun rollback`,
+  );
+}
+
+async function rollbackContract(sqlClient) {
+  await sqlClient.unsafe(
+    `SELECT pg_catalog.pg_advisory_lock(hashtextextended('boardsesh:production-task-roles:v1', 0))`,
+  );
+  try {
+    if (await allManagedRolesAbsent(sqlClient)) {
+      console.info('All six managed task roles are already absent; rollback is idempotently complete.');
+      return;
+    }
+
+    const fenceResult = await sqlClient.begin(async (transaction) => {
+      if (await allManagedRolesAbsent(transaction)) return 'already-absent';
+      const preflightDifferences = await auditContract(transaction, { managedRoleLoginState: 'either' });
+      printDifferences(preflightDifferences);
+      if (preflightDifferences.length > 0) fail('rollback refuses a partial or drifted role contract');
+      for (const roleContract of PRODUCTION_TASK_ROLES) {
+        await transaction.unsafe(`ALTER ROLE ${quoteIdentifier(roleContract.name)} NOLOGIN`);
+      }
+      return 'fenced';
+    });
+    if (fenceResult === 'already-absent') {
+      console.info('All six managed task roles are already absent; rollback is idempotently complete.');
+      return;
+    }
+    console.info('Committed NOLOGIN fencing for all six managed task roles before session drain proof.');
+
+    failForManagedSessions(await collectManagedSessionRows(sqlClient));
+
+    const dropResult = await sqlClient.begin(async (transaction) => {
+      if (await allManagedRolesAbsent(transaction)) return 'already-absent';
+      const fencedDifferences = await auditContract(transaction, { managedRoleLoginState: 'nologin' });
+      if (fencedDifferences.length > 0) {
+        printDifferences(fencedDifferences);
+        fail('rollback refuses drift after NOLOGIN fencing; roles remain fenced for recovery');
+      }
+      failForManagedSessions(await collectManagedSessionRows(transaction));
       await transaction.unsafe(
-        `ALTER ROLE ${roleIdentifier} IN DATABASE ${quoteIdentifier(PRODUCTION_DATABASE_NAME)} RESET ALL`,
+        `REVOKE ${quoteIdentifier(MIGRATION_OWNER_ROLE)} FROM ${quoteIdentifier('boardsesh_migrator')}`,
       );
+      await revokeManagedDirectPrivileges(transaction);
+      for (const roleContract of PRODUCTION_TASK_ROLES) {
+        const roleIdentifier = quoteIdentifier(roleContract.name);
+        await transaction.unsafe(`ALTER ROLE ${roleIdentifier} RESET ALL`);
+        await transaction.unsafe(
+          `ALTER ROLE ${roleIdentifier} IN DATABASE ${quoteIdentifier(PRODUCTION_DATABASE_NAME)} RESET ALL`,
+        );
+      }
+      for (const roleContract of [...PRODUCTION_TASK_ROLES].reverse()) {
+        await transaction.unsafe(`DROP ROLE ${quoteIdentifier(roleContract.name)}`);
+      }
+      return 'dropped';
+    });
+    if (dropResult !== 'already-absent' && !(await allManagedRolesAbsent(sqlClient))) {
+      fail('rollback did not remove all managed task roles');
     }
-    for (const roleContract of [...PRODUCTION_TASK_ROLES].reverse()) {
-      await transaction.unsafe(`DROP ROLE ${quoteIdentifier(roleContract.name)}`);
-    }
-  });
-  if (!(await allManagedRolesAbsent(sqlClient))) fail('rollback did not remove all managed task roles');
-  console.info('Rolled back exactly six ownership-free task roles; application data and owner roles were untouched.');
+    console.info('Rolled back exactly six ownership-free task roles; application data and owner roles were untouched.');
+  } finally {
+    await sqlClient
+      .unsafe(`SELECT pg_catalog.pg_advisory_unlock(hashtextextended('boardsesh:production-task-roles:v1', 0))`)
+      .catch(() => {});
+  }
 }
 
 async function withAdminClient(run) {

--- a/scripts/production-db-task-roles.mjs
+++ b/scripts/production-db-task-roles.mjs
@@ -7,6 +7,7 @@ import postgres from 'postgres';
 import {
   MIGRATION_OWNER_ROLE,
   PRODUCTION_DATABASE_NAME,
+  PRODUCTION_MANAGED_SCHEMAS,
   PRODUCTION_SCHEMA_NAME,
   PRODUCTION_TASK_RELATION_GRANTS,
   PRODUCTION_TASK_ROLES,
@@ -22,6 +23,13 @@ const ROLLBACK_CONFIRMATION = 'DROP_EXACT_SIX_TASK_ROLES';
 const DISPOSABLE_LOCAL_CONFIRMATION = 'ALLOW_EXACT_LOOPBACK_FIXTURE';
 const MANAGED_ROLE_NAMES = PRODUCTION_TASK_ROLES.map(({ name }) => name);
 const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const ALLOWED_PUBLIC_BOUNDARY_KEYS = new Set(
+  PRODUCTION_TASK_ROLES[0].databasePrivileges
+    .filter((privilege) =>
+      PRODUCTION_TASK_ROLES.every(({ databasePrivileges }) => databasePrivileges.includes(privilege)),
+    )
+    .map((privilege) => `database|${PRODUCTION_DATABASE_NAME}|${privilege}`),
+);
 
 function fail(message) {
   throw new Error(message);
@@ -421,6 +429,204 @@ async function collectDirectAclKeys(sqlClient) {
   return { keys, grantableKeys };
 }
 
+async function collectClusterWideBoundaryDifferences(sqlClient) {
+  const differences = [];
+  const schemaRows = await sqlClient.unsafe(`
+    SELECT expected.schema_name
+    FROM unnest(ARRAY[${valuesList(PRODUCTION_MANAGED_SCHEMAS)}]::text[]) AS expected(schema_name)
+    LEFT JOIN pg_catalog.pg_namespace AS namespace ON namespace.nspname = expected.schema_name
+    WHERE namespace.oid IS NULL
+    ORDER BY expected.schema_name
+  `);
+  for (const { schema_name: schemaName } of schemaRows) {
+    differences.push(
+      `cluster prerequisite missing schema ${schemaName}; reviewed remediation: complete the PG18 owner/runtime schema transition`,
+    );
+  }
+
+  const publicAclRows = await sqlClient.unsafe(`
+    WITH public_acl AS (
+      SELECT 'database'::text AS object_kind,
+             database.datname AS object_name,
+             privilege.privilege_type,
+             privilege.is_grantable,
+             pg_catalog.format('REVOKE %s ON DATABASE %I FROM PUBLIC',
+                               privilege.privilege_type, database.datname) AS remediation
+      FROM pg_catalog.pg_database AS database
+      CROSS JOIN LATERAL pg_catalog.aclexplode(
+        coalesce(database.datacl, pg_catalog.acldefault('d', database.datdba))
+      ) AS privilege
+      WHERE database.datname = ${quoteLiteral(PRODUCTION_DATABASE_NAME)}
+        AND privilege.grantee = 0
+
+      UNION ALL
+      SELECT 'schema', namespace.nspname, privilege.privilege_type, privilege.is_grantable,
+             pg_catalog.format('REVOKE %s ON SCHEMA %I FROM PUBLIC',
+                               privilege.privilege_type, namespace.nspname)
+      FROM pg_catalog.pg_namespace AS namespace
+      CROSS JOIN LATERAL pg_catalog.aclexplode(
+        coalesce(namespace.nspacl, pg_catalog.acldefault('n', namespace.nspowner))
+      ) AS privilege
+      WHERE namespace.nspname IN (${valuesList(PRODUCTION_MANAGED_SCHEMAS)})
+        AND privilege.grantee = 0
+
+      UNION ALL
+      SELECT CASE WHEN relation.relkind = 'S' THEN 'sequence' ELSE 'relation' END,
+             pg_catalog.format('%I.%I', namespace.nspname, relation.relname),
+             privilege.privilege_type,
+             privilege.is_grantable,
+             pg_catalog.format(
+               CASE WHEN relation.relkind = 'S'
+                 THEN 'REVOKE %s ON SEQUENCE %I.%I FROM PUBLIC'
+                 ELSE 'REVOKE %s ON TABLE %I.%I FROM PUBLIC' END,
+               privilege.privilege_type, namespace.nspname, relation.relname)
+      FROM pg_catalog.pg_class AS relation
+      JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+      CROSS JOIN LATERAL pg_catalog.aclexplode(
+        coalesce(
+          relation.relacl,
+          pg_catalog.acldefault(
+            CASE WHEN relation.relkind = 'S' THEN 'S'::"char" ELSE 'r'::"char" END,
+            relation.relowner
+          )
+        )
+      ) AS privilege
+      WHERE relation.relkind IN ('r', 'p', 'v', 'm', 'f', 'S')
+        AND namespace.nspname IN (${valuesList(PRODUCTION_MANAGED_SCHEMAS)})
+        AND privilege.grantee = 0
+        AND NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_depend AS dependency
+          WHERE dependency.classid = 'pg_catalog.pg_class'::pg_catalog.regclass
+            AND dependency.objid = relation.oid AND dependency.deptype = 'e'
+        )
+
+      UNION ALL
+      SELECT 'column',
+             pg_catalog.format('%I.%I.%I', namespace.nspname, relation.relname, attribute.attname),
+             privilege.privilege_type,
+             privilege.is_grantable,
+             pg_catalog.format('REVOKE %s (%I) ON TABLE %I.%I FROM PUBLIC',
+                               privilege.privilege_type, attribute.attname,
+                               namespace.nspname, relation.relname)
+      FROM pg_catalog.pg_attribute AS attribute
+      JOIN pg_catalog.pg_class AS relation ON relation.oid = attribute.attrelid
+      JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+      CROSS JOIN LATERAL pg_catalog.aclexplode(attribute.attacl) AS privilege
+      WHERE relation.relkind IN ('r', 'p', 'v', 'm', 'f')
+        AND namespace.nspname IN (${valuesList(PRODUCTION_MANAGED_SCHEMAS)})
+        AND attribute.attnum > 0
+        AND NOT attribute.attisdropped
+        AND privilege.grantee = 0
+        AND NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_depend AS dependency
+          WHERE dependency.classid = 'pg_catalog.pg_class'::pg_catalog.regclass
+            AND dependency.objid = relation.oid AND dependency.deptype = 'e'
+        )
+
+      UNION ALL
+      SELECT 'routine', procedure.oid::pg_catalog.regprocedure::text,
+             privilege.privilege_type,
+             privilege.is_grantable,
+             pg_catalog.format('REVOKE %s ON ROUTINE %s FROM PUBLIC',
+                               privilege.privilege_type, procedure.oid::pg_catalog.regprocedure)
+      FROM pg_catalog.pg_proc AS procedure
+      JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = procedure.pronamespace
+      CROSS JOIN LATERAL pg_catalog.aclexplode(
+        coalesce(procedure.proacl, pg_catalog.acldefault('f', procedure.proowner))
+      ) AS privilege
+      WHERE namespace.nspname IN (${valuesList(PRODUCTION_MANAGED_SCHEMAS)})
+        AND privilege.grantee = 0
+        AND NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_depend AS dependency
+          WHERE dependency.classid = 'pg_catalog.pg_proc'::pg_catalog.regclass
+            AND dependency.objid = procedure.oid AND dependency.deptype = 'e'
+        )
+
+      UNION ALL
+      SELECT 'type', pg_catalog.format('%I.%I', namespace.nspname, type_row.typname),
+             privilege.privilege_type,
+             privilege.is_grantable,
+             pg_catalog.format('REVOKE %s ON TYPE %I.%I FROM PUBLIC',
+                               privilege.privilege_type, namespace.nspname, type_row.typname)
+      FROM pg_catalog.pg_type AS type_row
+      JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = type_row.typnamespace
+      CROSS JOIN LATERAL pg_catalog.aclexplode(
+        coalesce(type_row.typacl, pg_catalog.acldefault('T', type_row.typowner))
+      ) AS privilege
+      WHERE type_row.typtype IN ('c', 'd', 'e', 'r')
+        AND (
+          type_row.typrelid = 0
+          OR EXISTS (
+            SELECT 1 FROM pg_catalog.pg_class AS composite_relation
+            WHERE composite_relation.oid = type_row.typrelid AND composite_relation.relkind = 'c'
+          )
+        )
+        AND namespace.nspname IN (${valuesList(PRODUCTION_MANAGED_SCHEMAS)})
+        AND privilege.grantee = 0
+        AND NOT EXISTS (
+          SELECT 1 FROM pg_catalog.pg_depend AS dependency
+          WHERE dependency.classid = 'pg_catalog.pg_type'::pg_catalog.regclass
+            AND dependency.objid = type_row.oid AND dependency.deptype = 'e'
+        )
+    ), owner_role AS (
+      SELECT oid, rolname FROM pg_catalog.pg_roles
+      WHERE rolname = ${quoteLiteral(MIGRATION_OWNER_ROLE)}
+    ), default_kind(object_type, sql_kind) AS (
+      VALUES ('r'::"char", 'TABLES'::text), ('S'::"char", 'SEQUENCES'::text),
+             ('f'::"char", 'ROUTINES'::text), ('T'::"char", 'TYPES'::text)
+    ), owner_global_default AS (
+      SELECT 'default_acl'::text AS object_kind,
+             pg_catalog.format('%I:*:%s', owner_role.rolname, default_kind.object_type::text) AS object_name,
+             privilege.privilege_type,
+             privilege.is_grantable,
+             pg_catalog.format('ALTER DEFAULT PRIVILEGES FOR ROLE %I REVOKE %s ON %s FROM PUBLIC',
+                               owner_role.rolname, privilege.privilege_type, default_kind.sql_kind) AS remediation
+      FROM owner_role
+      CROSS JOIN default_kind
+      LEFT JOIN pg_catalog.pg_default_acl AS default_acl
+        ON default_acl.defaclrole = owner_role.oid
+       AND default_acl.defaclnamespace = 0
+       AND default_acl.defaclobjtype = default_kind.object_type
+      CROSS JOIN LATERAL pg_catalog.aclexplode(
+        coalesce(default_acl.defaclacl, pg_catalog.acldefault(default_kind.object_type, owner_role.oid))
+      ) AS privilege
+      WHERE privilege.grantee = 0
+    ), owner_schema_default AS (
+      SELECT 'default_acl'::text AS object_kind,
+             pg_catalog.format('%I:%I:%s', owner_role.rolname, namespace.nspname,
+                               default_acl.defaclobjtype::text) AS object_name,
+             privilege.privilege_type,
+             privilege.is_grantable,
+             pg_catalog.format(
+               'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I REVOKE %s ON %s FROM PUBLIC',
+               owner_role.rolname, namespace.nspname, privilege.privilege_type,
+               CASE default_acl.defaclobjtype
+                 WHEN 'r' THEN 'TABLES' WHEN 'S' THEN 'SEQUENCES'
+                 WHEN 'f' THEN 'ROUTINES' WHEN 'T' THEN 'TYPES' END)
+      FROM pg_catalog.pg_default_acl AS default_acl
+      JOIN owner_role ON owner_role.oid = default_acl.defaclrole
+      JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = default_acl.defaclnamespace
+      CROSS JOIN LATERAL pg_catalog.aclexplode(default_acl.defaclacl) AS privilege
+      WHERE namespace.nspname IN (${valuesList(PRODUCTION_MANAGED_SCHEMAS)})
+        AND default_acl.defaclobjtype IN ('r', 'S', 'f', 'T')
+        AND privilege.grantee = 0
+    )
+    SELECT * FROM public_acl
+    UNION ALL SELECT * FROM owner_global_default
+    UNION ALL SELECT * FROM owner_schema_default
+    ORDER BY object_kind, object_name, privilege_type, is_grantable
+  `);
+
+  for (const publicAcl of publicAclRows) {
+    const boundaryKey = `${publicAcl.object_kind}|${publicAcl.object_name}|${publicAcl.privilege_type}`;
+    if (ALLOWED_PUBLIC_BOUNDARY_KEYS.has(boundaryKey) && !publicAcl.is_grantable) continue;
+    differences.push(
+      `cluster prerequisite PUBLIC|${boundaryKey}|grantable=${publicAcl.is_grantable}; reviewed remediation: ${publicAcl.remediation}`,
+    );
+  }
+  return differences;
+}
+
 async function collectRoleRows(sqlClient) {
   return sqlClient.unsafe(`
     SELECT rolname, rolcanlogin, rolsuper, rolcreatedb, rolcreaterole, rolinherit,
@@ -531,6 +737,7 @@ function expectedDirectAclKeys(sequenceKeys) {
 
 async function auditContract(sqlClient) {
   const differences = [];
+  differences.push(...(await collectClusterWideBoundaryDifferences(sqlClient)));
   const relationGaps = await missingRelations(sqlClient);
   differences.push(...relationGaps.map((relationName) => `missing object ${PRODUCTION_SCHEMA_NAME}.${relationName}`));
 
@@ -773,12 +980,21 @@ async function applyContract(sqlClient, protectedCredentials) {
   const preflightDifferences = await auditContract(sqlClient);
   console.info('Pre-apply evidence:');
   printDifferences(preflightDifferences);
+  const clusterBoundaryDifferences = await collectClusterWideBoundaryDifferences(sqlClient);
+  if (clusterBoundaryDifferences.length > 0) {
+    fail(
+      'cluster-wide PUBLIC/default ACL prerequisites require separate reviewed remediation; apply never changes them',
+    );
+  }
 
   await sqlClient.begin(async (transaction) => {
     await transaction.unsafe(
       `SELECT pg_catalog.pg_advisory_xact_lock(hashtextextended('boardsesh:production-task-roles:v1', 0))`,
     );
     await assertAdminBoundary(transaction);
+    if ((await collectClusterWideBoundaryDifferences(transaction)).length > 0) {
+      fail('cluster-wide PUBLIC/default ACL prerequisites changed after preflight; refusing apply');
+    }
     const relationGaps = await missingRelations(transaction);
     if (relationGaps.length > 0) fail(`required relations are missing: ${relationGaps.join(', ')}`);
     await assertNoUnsafeExistingRoleState(transaction);

--- a/scripts/production-db-task-roles.mjs
+++ b/scripts/production-db-task-roles.mjs
@@ -456,7 +456,7 @@ async function collectClusterWideBoundaryDifferences(sqlClient) {
       CROSS JOIN LATERAL pg_catalog.aclexplode(
         coalesce(database.datacl, pg_catalog.acldefault('d', database.datdba))
       ) AS privilege
-      WHERE database.datname = ${quoteLiteral(PRODUCTION_DATABASE_NAME)}
+      WHERE database.datallowconn
         AND privilege.grantee = 0
 
       UNION ALL


### PR DESCRIPTION
## Summary

- Stack guarded production task-role provisioning on secure-network foundation #4997.
- Pin the exact six LOGIN roles, unique `application_name` values, connection caps, and query-derived relation/sequence grants required by activation PR #4999.
- Add secret-safe generate/plan/audit/apply/rollback tooling with PostGIS-forwarder target guards, sorted grant-diff evidence, and refusal paths for ownership, memberships, grant options, default ACLs, RLS references, active sessions, and drifted rollback.
- Resolve effective privileges inherited from `PUBLIC` with PostgreSQL `acldefault` across every connectable database, every relevant non-system/non-extension schema, non-extension application objects, large objects, parameter ACLs, and all migration-owner default kinds.
- Keep cluster-wide policy review separate: `plan` prints exact candidate remediation, while `apply` refuses and proves it did not execute a broad `PUBLIC` or creator-default revoke.
- Fence rollback in two committed phases: all six roles become `NOLOGIN`, authenticated sessions (including migrator sessions after `SET ROLE`) must drain, then a second guarded transaction revokes and drops. Refusal intentionally leaves the durable fence for a safe rerun.
- Resolve and validate the protected credential parent, reject repository redirects/permissive parents/linked files, and read or write secrets only through exclusive no-follow verified descriptors.
- Prove the contract on digest-pinned PostgreSQL 18.6 with PUBLIC database/schema/table/sequence/routine/large-object/parameter/default-ACL mutations, a live `SET ROLE` rollback race, enum/domain DML, idempotency, and owner/data survival.

`PUBLIC CONNECT` remains allowed only on `railway`, because every one of the six role contracts includes that exact grant. Access to another connectable database, an unexpected non-extension schema, `PUBLIC TEMPORARY`, schema/object/large-object/parameter access, and unsafe migration-owner defaults exceed the explicit contract and fail closed. Extension-owned ACLs remain under the PG18 catalog/extension audit.

This PR does not connect to production, create live roles or credentials, set GitHub secrets, deploy Railway services, change Tailscale policy, or modify any live ACL.

## BLOCKED — provisioning prerequisites

- [ ] #4997 merged and its attested forwarder deployed without public networking.
- [ ] Narrow live tailnet policy patch reviewed and all policy tests passing.
- [ ] PG18 owner/runtime role transition completed and independently audited.
- [ ] Sorted `plan` evidence reviewed against PostGIS - PROD, including every cluster-wide prerequisite.
- [ ] Any PUBLIC/default-ACL remediation approved separately with cluster-wide before/after evidence.
- [ ] Guarded `apply` explicitly authorized and run only through the forwarder.
- [ ] Empty `audit` evidence retained; six credentials independently probed; rollback fence/drain recovery rehearsed.
- [ ] Six exact protected GitHub secrets stored before #4999 can merge.

Validation completed locally at `1b8d43caf` and again at exact restacked consumer head `2016e6220`:

- stack-scoped `vp check` on every changed supported file
- 43 artifact/secure-network/task-role/activation tests (9 artifact + 34 contract), including credential-path adversarial cases and the lowercase `acldefault('s', ...)` sequence discriminator contract
- digest-pinned PostgreSQL 18.6 disposable smoke, including the live rollback race and every new PUBLIC/default-ACL mutation
- forwarder `go test -race ./...` and `go vet ./...`
- full `vp run typecheck`
- `actionlint .github/workflows/postgres-secure-network.yml`
- mandatory staged pre-commit hook

The repository-wide `vp check` panics after reporting unrelated current-main warnings. All stack-changed files pass type-aware lint, the full typecheck passes, and CI remains the clean-host repository-wide lint gate.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 4/5 — guarded production role tooling; this PR performs no live write.
