### PR TITLE
fix(ci): name the real commit on every production OTA row

### DIFF
--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -191,24 +191,35 @@ jobs:
           EOF
 
       # This workflow is the SOLE OWNER of packages/mobile/src/data/changelog.generated.json.
-      # It regenerates the "What's New" changelog from merged-PR Release Notes,
-      # commits it, and pushes it back to main so the committed copy is the single
-      # source of truth (native builds bundle it; the next OTA diffs against it).
-      # Nothing else writes this file: a CI guard blocks PRs from editing it, and
-      # the native-build / refresh workflows only read it. We commit (not just
-      # regenerate) for two reasons: `eoas publish` refuses to run on a dirty tree,
-      # and the committed copy must reach main. The commit carries [skip ci], so the
-      # push can't re-trigger this workflow. Rebase-and-retry guards a non-OTA push
-      # landing on main since checkout (OTA runs are serialized on main, so two of
-      # these never race). Degrades gracefully: a gh/network failure leaves the file
-      # unchanged (no diff → no commit/push) and exits 0. The default GITHUB_TOKEN
-      # reads public PRs. The file is JS-only, so it never affects the fingerprint.
-      # Commit (not just regenerate) for two reasons: `eoas publish` refuses to run
-      # on a dirty tree, and the committed copy is pushed to main below. [skip ci]
-      # keeps the later push from re-triggering this workflow. The file is JS-only,
-      # so it never affects the fingerprint. `changed` tells the push step whether
-      # there's anything to push.
-      - name: Generate changelog and commit
+      # It regenerates the "What's New" changelog from merged-PR Release Notes and
+      # pushes it back to main so the committed copy is the single source of truth
+      # (native builds bundle it; the next OTA diffs against it). Nothing else writes
+      # this file: a CI guard blocks PRs from editing it, and the native-build /
+      # refresh workflows only read it.
+      #
+      # It is deliberately NOT committed here. It used to be, purely because `eoas
+      # publish` aborts on a dirty tree — but that made HEAD a throwaway
+      # `chore(changelog)` commit at publish time, and eoas records BOTH the update
+      # message and its commitHash from HEAD (`git rev-parse HEAD` / `git log -1`).
+      # Every row on the OTA server was therefore stamped with a sha that the push
+      # step below never even pushed (it resets to origin/main and commits afresh),
+      # which made the dashboard's Message and Commit columns useless for finding an
+      # update. Publishing from an uncommitted tree instead keeps HEAD on the real
+      # triggering commit; scripts/mobile-publish.ts passes --disableRepositoryCheck
+      # (CI only) to allow it, and the step after this one asserts the tree is dirty
+      # in exactly these two files — the integrity check eoas' guard was incidentally
+      # providing.
+      #
+      # `expo export` reads the working tree, so the regenerated file still ships in
+      # the bundle. The push step below commits it to main after every platform
+      # succeeds, carrying [skip ci] so it can't re-trigger this workflow.
+      # Rebase-and-retry guards a non-OTA push landing on main since checkout (OTA
+      # runs are serialized on main, so two of these never race). Degrades
+      # gracefully: a gh/network failure leaves the file unchanged (no diff → no
+      # push) and exits 0. The default GITHUB_TOKEN reads public PRs. The file is
+      # JS-only, so it never affects the fingerprint. `changed` tells the push step
+      # whether there's anything to push.
+      - name: Generate changelog
         id: generate
         if: steps.gate.outputs.configured == 'true'
         env:
@@ -230,18 +241,40 @@ jobs:
             --prev "$RUNNER_TEMP/changelog.prev.json" \
             --next packages/mobile/src/data/changelog.generated.json \
             --out "$RUNNER_TEMP/discord-changelog.md" || true
+          # Configured here, not in the push step: that step is the one that
+          # commits, and would otherwise author as nobody.
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           # Both outputs of the generator: the mobile JSON feed and the root
           # human-readable CHANGELOG.md (deterministic from the same entries).
+          # Staged, never committed — `git add` is what makes an untracked
+          # CHANGELOG.md (bootstrap case) visible to the --cached diff below.
           git add packages/mobile/src/data/changelog.generated.json CHANGELOG.md
           if git diff --cached --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "Changelog unchanged — nothing to commit."
+            echo "Changelog unchanged — nothing to push."
           else
-            git commit -m "chore(changelog): refresh from merged PRs [skip ci]"
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # The integrity check eoas' clean-tree guard was giving us for free, now that
+      # --disableRepositoryCheck turns that guard off: prove the only uncommitted
+      # changes are the two files the step above regenerates. Anything else (a dep
+      # install that dirtied a tracked file, a stray build artifact) would otherwise
+      # be silently bundled into a production OTA.
+      - name: Assert only the changelog is uncommitted
+        if: steps.gate.outputs.configured == 'true' && steps.generate.outcome == 'success'
+        run: |
+          set -euo pipefail
+          changed="$(git status --porcelain --untracked-files=all | awk '{print $NF}' | sort | paste -sd' ' -)"
+          case "$changed" in
+            '' | 'CHANGELOG.md packages/mobile/src/data/changelog.generated.json') ;;
+            *)
+              echo "::error::Unexpected working-tree changes before the OTA publish: $changed"
+              exit 1
+              ;;
+          esac
+          echo "Working tree carries only the regenerated changelog (or nothing)."
 
       # iOS and Android are published in SEPARATE steps with platform-specific env.
       # GOOGLE_MAPS_API_KEY is set only on the Android native prebuild (iOS uses
@@ -358,9 +391,11 @@ jobs:
       # The commit carries [skip ci], so this push can't re-trigger the workflow.
       # Rebase-and-retry guards a non-OTA push landing on main since checkout (OTA
       # runs are serialized on main, so two of these never race; only this workflow
-      # writes the file, so the rebase can't conflict). The generated commit stays
-      # local when any requested platform fails; the next successful run regenerates
-      # it from merged PRs and pushes it.
+      # writes the file, so the rebase can't conflict). This step is where the
+      # changelog is committed at all — the generate step only regenerates it, so
+      # that the publish above keeps HEAD on the real triggering commit. When any
+      # requested platform fails the regenerated files stay unpushed; the next
+      # successful run regenerates them from merged PRs and pushes them.
       # Auth is the app token that checkout persisted (the app is in main's
       # PR-bypass list; github-actions[bot] is not, so it would 403). Skips when the
       # app isn't configured — checkout then holds only the default token, the OTA
@@ -430,9 +465,11 @@ jobs:
           # Prefer the "What's new" block the generate step rendered from the
           # changelog diff (the entries this OTA newly added). It's empty when
           # nothing new shipped (changelog unchanged) — then fall back to the
-          # triggering commit's subject. Read the subject from $COMMIT_SHA, NOT
-          # `git log -1`: by now HEAD is this workflow's own changelog commit, so a
-          # bare `git log -1` would always echo "chore(changelog): refresh…".
+          # triggering commit's subject. Read the subject from $COMMIT_SHA rather
+          # than a bare `git log -1`: HEAD is the triggering commit on a push, but
+          # not on a workflow_dispatch, and $COMMIT_SHA is right either way. It is
+          # also the subject the OTA itself now carries, so a Discord line and a row
+          # on the update server name one and the same commit.
           SUMMARY_FILE="$RUNNER_TEMP/discord-changelog.md"
           if [ -s "$SUMMARY_FILE" ]; then
             # Build the header and the block in ONE printf so the newline between

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -809,10 +809,25 @@ be requested.
 
 `packages/mobile/src/data/changelog.generated.json` is owned **solely** by the
 `mobile-ota-production.yml` workflow. On every production OTA it regenerates the file from merged-PR
-`## Release Notes` sections and commits it locally before `eoas publish` (which needs a clean tree).
-It **pushes the commit back to `main`** only after every requested platform succeeds (the commit is
-tagged `[skip ci]` so the push can't re-trigger the OTA). A partial or total publish failure leaves
-the local CI commit unpushed; the next run regenerates the same source-of-truth files.
+`## Release Notes` sections and publishes it **uncommitted** — `expo export` reads the working tree,
+so the fresh entries ship in the bundle either way. It **commits and pushes to `main`** only after
+every requested platform succeeds (the commit is tagged `[skip ci]` so the push can't re-trigger the
+OTA). A partial or total publish failure leaves the regenerated files unpushed; the next run
+regenerates the same source-of-truth files.
+
+**Why it is not committed before the publish.** It used to be, because `eoas publish` aborts on a
+dirty tree. But eoas reads an update's `message` **and** its `commitHash` from `HEAD`
+(`git log -1` / `git rev-parse HEAD`), so committing first stamped every row on the update server
+with a throwaway `chore(changelog): refresh…` commit — and a sha that never even reached `main`,
+since the push-back resets to `origin/main` and commits afresh. The V3 dashboard's only identifying
+columns are `Message` and a 7-char `Commit`, and it has no search box, so both were useless.
+`scripts/mobile-publish.ts` now passes eoas' `--disableRepositoryCheck` for production publishes
+**running under GitHub Actions only** (`shouldAllowDirtyTree`) — locally the clean-tree guard stays
+on, so `vp run mobile:publish -- --channel production` can't ship a developer's scratch edits. The
+workflow's "Assert only the changelog is uncommitted" step replaces the integrity check eoas' guard
+was incidentally providing: it fails the publish if anything other than the two changelog files is
+dirty. The flag is `hidden: true` upstream, so it is only safe because `EOAS_PACKAGE_SPEC`
+(`scripts/lib/eoas.ts`) pins the exact eoas version — re-check it on any eoas bump.
 Nothing else writes the file: the native build workflows and `refresh-acknowledgements.yml` only
 _read_ it, and a CI guard (`changelog-owned` in `ci.yml`) fails any PR that edits it. A fully
 successful OTA still publishes when the push-back identity is not wired — the push-back just keeps

--- a/scripts/mobile-ota-publish-workflow.test.ts
+++ b/scripts/mobile-ota-publish-workflow.test.ts
@@ -106,6 +106,42 @@ describe('production OTA workflow reliability', () => {
     expect(success).not.toContain("steps.publish_ios.outcome == 'success' ||");
   });
 
+  // eoas records an update's message AND its commitHash from HEAD. Committing the
+  // regenerated changelog before publishing made HEAD a throwaway
+  // `chore(changelog)` commit, so every row on the OTA server was stamped with a
+  // sha that the push step never even pushed (it resets to origin/main and commits
+  // afresh) — leaving the dashboard's Message and Commit columns useless. The
+  // publish must run with HEAD still on the triggering commit.
+  it('publishes with HEAD on the triggering commit, committing the changelog only afterwards', () => {
+    const generateIndex = production.indexOf('      - name: Generate changelog\n');
+    const publishIndex = production.indexOf('      - name: Publish iOS OTA\n');
+    expect(generateIndex).toBeGreaterThanOrEqual(0);
+    expect(publishIndex).toBeGreaterThan(generateIndex);
+
+    const beforePublish = production.slice(generateIndex, publishIndex);
+    expect(
+      beforePublish,
+      'nothing may commit before the publish — it would move HEAD off the triggering commit',
+    ).not.toMatch(/^\s*git commit\b/m);
+    // Guard the guard: the changelog must still reach main, just later. Without
+    // this, deleting the commit everywhere would satisfy the assertion above.
+    expect(stepBlock(production, 'Push changelog to main')).toMatch(/^\s*git commit -m/m);
+  });
+
+  // Disabling eoas' clean-tree check removes an accidental integrity guard: a
+  // stray dirtied file would otherwise be bundled into a production OTA unnoticed.
+  // This step is the replacement, so it must run before the first publish.
+  it('asserts the working tree carries only the regenerated changelog before publishing', () => {
+    const assertion = stepBlock(production, 'Assert only the changelog is uncommitted');
+
+    expect(assertion).toContain('git status --porcelain --untracked-files=all');
+    expect(assertion).toContain('CHANGELOG.md packages/mobile/src/data/changelog.generated.json');
+    expect(assertion).toContain('exit 1');
+    expect(production.indexOf('      - name: Assert only the changelog is uncommitted\n')).toBeLessThan(
+      production.indexOf('      - name: Publish iOS OTA\n'),
+    );
+  });
+
   it('runs the health check after any successful platform, including partial success', () => {
     const health = stepBlock(production, 'OTA health check (non-blocking)');
 

--- a/scripts/mobile-publish.test.ts
+++ b/scripts/mobile-publish.test.ts
@@ -9,11 +9,12 @@ import {
   requestedSelfHostedPlatforms,
   selfHostedPublishModeLabel,
   selfHostedPublishSuccessMessages,
+  shouldAllowDirtyTree,
 } from './mobile-publish';
 
 describe('mobile publish argument routing', () => {
   it('maps the wrapper channel selector to an eoas branch without a deprecated channel flag', () => {
-    const args = buildSelfHostedEoasArgs('production', 'ios', 'fix the queue');
+    const args = buildSelfHostedEoasArgs('production', 'ios', 'fix the queue', { allowDirtyTree: true });
 
     expect(args).toEqual([
       EOAS_PACKAGE_SPEC,
@@ -27,6 +28,7 @@ describe('mobile publish argument routing', () => {
       '--dumpSourcemap',
       '--outputDir',
       'dist',
+      '--disableRepositoryCheck',
       '--upload-rate',
       String(SELF_HOSTED_UPLOAD_RATE_PER_SECOND),
       '--nonInteractive',
@@ -34,6 +36,32 @@ describe('mobile publish argument routing', () => {
       'vp exec',
     ]);
     expect(args).not.toContain('--channel');
+  });
+
+  // The production workflow publishes the regenerated changelog from an
+  // UNCOMMITTED tree, so HEAD stays on the triggering commit and the update's
+  // message + commitHash name a real commit on main. That only works while eoas'
+  // clean-tree guard is off — but only in CI, and only for production. A local
+  // `vp run mobile:publish -- --channel production` must still abort on a dirty
+  // tree rather than shipping a developer's scratch edits to the fleet.
+  it('disables the eoas clean-tree guard only for a production publish running in CI', () => {
+    expect(buildSelfHostedEoasArgs('production', 'ios', 'm', { allowDirtyTree: true })).toContain(
+      '--disableRepositoryCheck',
+    );
+    expect(buildSelfHostedEoasArgs('production', 'ios', 'm', { allowDirtyTree: false })).not.toContain(
+      '--disableRepositoryCheck',
+    );
+    expect(buildSelfHostedEoasArgs('production', 'ios', 'm')).not.toContain('--disableRepositoryCheck');
+    // Previews publish from a clean PR checkout, so they stay strict even in CI.
+    expect(buildSelfHostedEoasArgs('pr-1234', 'ios', 'm', { allowDirtyTree: true })).not.toContain(
+      '--disableRepositoryCheck',
+    );
+  });
+
+  it('allows a dirty tree only under GitHub Actions', () => {
+    expect(shouldAllowDirtyTree({ GITHUB_ACTIONS: 'true' })).toBe(true);
+    expect(shouldAllowDirtyTree({ GITHUB_ACTIONS: 'false' })).toBe(false);
+    expect(shouldAllowDirtyTree({})).toBe(false);
   });
 
   // The per-PR previews are the concurrent publishes, so they are the ones that

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -73,11 +73,32 @@ function getCommitSubject(): string {
   }
 }
 
+// Whether this publish may run against a dirty working tree. CI only: the
+// production OTA workflow regenerates the changelog into the tree and publishes
+// it WITHOUT committing, so the update's commitHash and message name the real
+// triggering commit instead of a throwaway `chore(changelog)` commit that never
+// lands on main. Locally the clean-tree check stays on — otherwise
+// `vp run mobile:publish -- --channel production` would ship a developer's
+// scratch edits to the fleet.
+export function shouldAllowDirtyTree(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.GITHUB_ACTIONS === 'true';
+}
+
 export function buildSelfHostedEoasArgs(
   branchName: string,
   platform: OtaPublishPlatform,
   updateMessage: string,
+  options: { allowDirtyTree?: boolean } = {},
 ): string[] {
+  // eoas aborts on a dirty tree before it ever reads the commit. Skipping that
+  // check is what lets the workflow publish the regenerated changelog from an
+  // uncommitted tree, keeping HEAD on the triggering commit — eoas reads
+  // commitHash with `git rev-parse HEAD` regardless of this flag. The flag is
+  // `hidden: true` upstream, so it is undocumented and could be dropped; it is
+  // safe only because EOAS_PACKAGE_SPEC pins the exact eoas version. Production
+  // only: previews publish from a clean PR checkout and stay strict.
+  const repositoryCheckArgs =
+    branchName === 'production' && options.allowDirtyTree === true ? ['--disableRepositoryCheck'] : [];
   const sourceMapArgs =
     branchName === 'production'
       ? [
@@ -99,6 +120,7 @@ export function buildSelfHostedEoasArgs(
     '--message',
     updateMessage,
     ...sourceMapArgs,
+    ...repositoryCheckArgs,
     // Cap how fast eoas starts asset uploads. Before 3.1.2 it fired every asset
     // of the export (380 in a current bundle) through one unbounded
     // `Promise.all`, which is what tripped Tigris `SlowDown` (#3620). Applies to
@@ -190,7 +212,9 @@ async function publishToSelfHostedBranch(
   const outcomes = await publishPlatformsSequentially(platforms, async (requestedPlatform) => {
     const platformEnv = { ...eoasEnv };
     if (requestedPlatform === 'ios') delete platformEnv.GOOGLE_MAPS_API_KEY;
-    const eoasArgs = buildSelfHostedEoasArgs(branchName, requestedPlatform, updateMessage);
+    const eoasArgs = buildSelfHostedEoasArgs(branchName, requestedPlatform, updateMessage, {
+      allowDirtyTree: shouldAllowDirtyTree(),
+    });
     console.log('');
     console.log(`[mobile:publish] Running ${requestedPlatform}: vp dlx ${eoasArgs.join(' ')}`);
     console.log('');


### PR DESCRIPTION
## Summary

Every row on `updates.boardsesh.com` was labelled with a phantom commit, so there was no way to tell which OTA is which.

`eoas publish` aborts on a dirty tree, so the OTA workflow committed the regenerated changelog before publishing. That made `HEAD` a throwaway `chore(changelog): refresh from merged PRs [skip ci]` commit at publish time — and eoas reads **both** an update's `message` and its `commitHash` from `HEAD` (`git log -1` / `git rev-parse HEAD`, upstream `apps/eoas/src/commands/publish.ts:212-217`).

Worse, that sha never reached `main`: "Push changelog to main" does `git reset --hard origin/main` and commits afresh, so the recorded sha exists nowhere. The V3 dashboard's only identifying columns are `Message` and a 7-char `Commit`, and it has no search box — both were useless.

**Fix:** publish from the uncommitted tree (`expo export` reads the working tree, so the fresh changelog still ships) and pass eoas' `--disableRepositoryCheck`, gated on `GITHUB_ACTIONS` so a local `vp run mobile:publish -- --channel production` still refuses a dirty tree rather than shipping scratch edits to the fleet. A new step asserts the tree is dirty in exactly the two changelog files, restoring the integrity check eoas' guard was incidentally providing.

The update's message and commit now match the Discord deploy line verbatim.

**Before:** `938aa45fb chore(changelog): refresh from merged PRs [skip ci]` — a sha that is not in the repo.
**After:** `c51fedb1a feat(mobile): crisp hold outlines cut once per hold, so the glow meets the edge`

Found while diagnosing why the 2026-09-01 OTA for #4992 never reached TestFlight build 10. The other half of that (a race where a binary's embedded bundle outranks a newer OTA) is a follow-up PR.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 4/5 — touches the production OTA publish pipeline. Behaviour is verified by four guards, each mutation-tested (re-add the commit, drop the flag, make it unconditional, neuter the tree assertion — all turn red). The first real proof is the next production OTA row naming a commit that resolves on `main`.
