### PR TITLE
fix(ci): republish the OTA after a native build, so the new binary gets it

### DIFF
--- a/.github/workflows/android-apk-rn.yml
+++ b/.github/workflows/android-apk-rn.yml
@@ -684,6 +684,12 @@ jobs:
     environment: Production
     permissions:
       contents: read
+      # Dispatches the OTA republish below. `workflow_dispatch` is the documented
+      # exception to "events triggered by GITHUB_TOKEN don't create a workflow run",
+      # so the default token is enough — same as db-migration-renumber-dispatch.yml.
+      # Deliberately NOT folded into the release-tag App token: that would hand
+      # Actions:write to every token minted from that App.
+      actions: write
     env:
       ANDROID_APK_SHA256: ${{ needs.build-and-release.outputs.apk_sha256 }}
       ANDROID_APK_SIZE: ${{ needs.build-and-release.outputs.apk_size }}
@@ -824,6 +830,27 @@ jobs:
             fi
           fi
           unset git_auth
+
+      # Un-strand the binary we just uploaded — see the matching step in
+      # ios-testflight-rn.yml for the full reasoning. Short version: expo-updates
+      # launches whichever update has the newest commitTime, and this binary stamped
+      # its embedded bundle at build time, so an OTA published from a later commit
+      # while we were building is already older than it and would never apply.
+      # Dispatched per-platform: iOS and Android resolve different fingerprints, so
+      # one republish cannot cover the other. Non-blocking — the Play upload has
+      # already succeeded.
+      - name: Republish the production OTA so it outranks this build
+        if: env.FINGERPRINT_ANDROID != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run mobile-ota-production.yml \
+            --ref main \
+            -f platform=android \
+            -f expect_fingerprint="$FINGERPRINT_ANDROID"
+          echo "::notice::Dispatched a production OTA republish for Android fingerprint $FINGERPRINT_ANDROID."
 
       - name: Check whether this build can publish the Android beta
         id: prerelease_eligibility

--- a/.github/workflows/ios-testflight-rn.yml
+++ b/.github/workflows/ios-testflight-rn.yml
@@ -155,6 +155,13 @@ jobs:
     if: needs.gate.outputs.should_build == 'true' && github.ref == 'refs/heads/main'
     permissions:
       contents: read # protected release tags are pushed with the repository App token
+      # Dispatches the OTA republish below. `workflow_dispatch` is the documented
+      # exception to "events triggered by GITHUB_TOKEN don't create a workflow run",
+      # so the default token is enough — same as db-migration-renumber-dispatch.yml.
+      # Deliberately NOT folded into the release-tag App token: that would hand
+      # Actions:write to every token minted from that App, including one live for an
+      # hour in this job while third-party actions run.
+      actions: write
     # macos-26 = Xcode 26 + iOS 26 SDK, which App Store Connect now requires
     # for all uploads. Expo SDK 57 / RN 0.86 ships a fmt that compiles cleanly
     # under Xcode 26's strict C++20 constexpr evaluator.
@@ -725,6 +732,33 @@ jobs:
             fi
           fi
           unset git_auth
+
+      # Un-strand the binary we just uploaded. expo-updates launches whichever
+      # update has the newest commitTime, and this binary stamped its embedded
+      # bundle minutes ago at the end of a ~50-minute build — so any OTA published
+      # from a LATER commit while we were building is already older than it, and
+      # would never be applied even though the fingerprints match. (That is exactly
+      # how #4992's JS failed to reach 2.4.0 build 10 on 2026-09-01.) Publishing now
+      # produces an update strictly newer than this binary's embedded bundle, which
+      # is the whole invariant.
+      #
+      # main may have moved to a NEW native change since the build started; the OTA
+      # workflow re-resolves the fingerprint and skips if so, because publishing
+      # under the new fingerprint would ship JS this binary lacks the native code
+      # for. Non-blocking: the store upload has already succeeded and a failed
+      # dispatch must not red an otherwise good release.
+      - name: Republish the production OTA so it outranks this build
+        if: steps.testflight_upload.outcome == 'success' && env.FINGERPRINT_IOS != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run mobile-ota-production.yml \
+            --ref main \
+            -f platform=ios \
+            -f expect_fingerprint="$FINGERPRINT_IOS"
+          echo "::notice::Dispatched a production OTA republish for iOS fingerprint $FINGERPRINT_IOS."
 
       - name: Clean up keychain and credentials
         if: always()

--- a/.github/workflows/mobile-ota-backport.yml
+++ b/.github/workflows/mobile-ota-backport.yml
@@ -49,6 +49,10 @@ on:
 concurrency:
   group: mobile-ota-production
   cancel-in-progress: false
+  # Keep `queue: max` in lockstep with mobile-ota-production.yml — the two share
+  # this group, and a lane that supersedes pending runs on one side would drop the
+  # per-platform republishes the other side depends on. See the long note there.
+  queue: max
 
 permissions:
   contents: read

--- a/.github/workflows/mobile-ota-production.yml
+++ b/.github/workflows/mobile-ota-production.yml
@@ -7,7 +7,24 @@ name: Mobile OTA Production (Self-Hosted)
 # native change yields a new fingerprint and the OTA simply isn't delivered to old
 # installs (they keep their embedded bundle until a store build with the new
 # fingerprint ships). The matching native builds run in parallel via
-# ios-testflight-rn.yml / android-apk-rn.yml. See docs/mobile-ota-updates.md.
+# ios-testflight-rn.yml / android-apk-rn.yml.
+#
+# Fingerprint identity is necessary but NOT sufficient: expo-updates launches
+# whichever update has the newest commitTime, and a binary stamps its embedded
+# bundle at BUILD time. A ~50-minute macOS build started by an earlier commit
+# therefore finishes with an embedded commitTime NEWER than an OTA published
+# mid-build from a later commit — same fingerprint, but the binary wins forever
+# and that OTA's JS never reaches it. So the native workflows dispatch this
+# workflow again once their store upload lands, passing `expect_fingerprint`: a
+# publish that happens strictly after the build necessarily outranks it. See
+# docs/mobile-ota-updates.md.
+
+# Name the run after what it is doing — `gh workflow run` returns no run id, so
+# this is the only handle for spotting a dispatched republish in the Actions list.
+run-name: >-
+  ${{ github.event.inputs.expect_fingerprint
+  && format('Republish {0} after native build ({1})', github.event.inputs.platform, github.event.inputs.expect_fingerprint)
+  || 'Production OTA' }}
 
 on:
   push:
@@ -38,6 +55,12 @@ on:
         description: 'Platform to publish (ios, android, all)'
         required: false
         default: 'all'
+      expect_fingerprint:
+        description: >-
+          Only publish if the current fingerprint still matches this one. Set by the
+          native build workflows when they republish after a store upload; leave
+          empty for a normal manual publish.
+        required: false
 
 permissions:
   # read only: the push-back to main uses a dedicated GitHub App token (it must
@@ -50,11 +73,22 @@ concurrency:
   # changelog.generated.json (regenerate + push to main), so two concurrent runs
   # would race on that file. A constant group (not per-ref) serializes push +
   # dispatch + any branch into a single lane. cancel-in-progress: false never
-  # kills a publish mid-flight; a newer run just queues behind it and supersedes
-  # an older pending one — harmless, since the generator crawls all merged PRs, so
-  # the run that wins republishes the latest state anyway.
+  # kills a publish mid-flight.
   group: mobile-ota-production
   cancel-in-progress: false
+  # QUEUE, never supersede. cancel-in-progress governs only the RUNNING run —
+  # by default GitHub still cancels an existing *pending* run when a new one
+  # queues. That used to be harmless (the winner republished the latest state
+  # anyway), but the native workflows now dispatch a per-PLATFORM republish to
+  # un-strand a binary they just uploaded, and those don't cover for each other:
+  # an iOS republish running + an Android republish pending + any push to main
+  # would drop the Android one, leaving Android installs frozen on their embedded
+  # bundle until the next Android native build. The cost is real — pushes during a
+  # long publish now queue instead of coalescing, so a busy day is N sequential
+  # ~10-minute publishes rather than one. That is the right trade: never silently
+  # dropping a republish is the whole point. Must stay in lockstep with
+  # mobile-ota-backport.yml, which shares this group.
+  queue: max
 
 # ─── SHARED BUILD ENV (workflow-level) ───────────────────────────────────────
 # MUST stay byte-identical to ios-testflight-rn.yml / android-apk-rn.yml, for two
@@ -190,6 +224,54 @@ jobs:
           EXPO_PUBLIC_USE_RN_FETCH=$EXPO_PUBLIC_USE_RN_FETCH
           EOF
 
+      # Only for a republish dispatched by a native build. That build shipped a
+      # binary with a known fingerprint and wants an OTA stamped after it, but by
+      # the time this run gets a runner `main` may already carry a NEW native
+      # change. Publishing then would resolve the new fingerprint and ship JS that
+      # assumes native code the uploaded binary doesn't have — so skip instead. The
+      # binary stays on its embedded bundle until its own store release, and
+      # mobile-ota-backport.yml is the escape hatch if that cohort needs a JS fix.
+      #
+      # Runs AFTER the .env write: the .env is hashed into the fingerprint, so
+      # resolving before it exists would produce a different (wrong) value. The
+      # comparison itself is a unit-tested pure function rather than inline shell —
+      # an inverted `!=` here would silently disable the guard while every
+      # workflow-text assertion stayed green.
+      - name: Verify the fingerprint still matches the build that asked for this
+        id: expect
+        if: steps.gate.outputs.configured == 'true' && github.event.inputs.expect_fingerprint != ''
+        env:
+          EXPECT_FINGERPRINT: ${{ github.event.inputs.expect_fingerprint }}
+          PLATFORM: ${{ github.event.inputs.platform }}
+          # Android's fingerprint is resolved WITH the maps key, iOS without —
+          # the key enters the resolved config and moves BOTH platforms' hashes.
+          # Mirrors the per-platform split on the publish steps below.
+          GOOGLE_MAPS_API_KEY: ${{ github.event.inputs.platform == 'android' && secrets.GOOGLE_MAPS_API_KEY || '' }}
+        run: |
+          set -uo pipefail
+          # A republish is always for ONE platform: the fingerprints differ per
+          # platform, so a single expect_fingerprint can't validate both.
+          if [ "$PLATFORM" != "ios" ] && [ "$PLATFORM" != "android" ]; then
+            echo "::error::expect_fingerprint requires platform=ios or platform=android (got \"$PLATFORM\")."
+            exit 1
+          fi
+          # Keep stderr visible: a resolve that fails for a reason other than drift
+          # (missing dep, config error) should surface its own cause.
+          raw="$(cd packages/mobile && vp exec expo-updates runtimeversion:resolve --platform "$PLATFORM" || true)"
+          fp="$(printf '%s' "$raw" | jq -r '.runtimeVersion // empty' 2>/dev/null || true)"
+          verdict="$(node --experimental-strip-types scripts/mobile-fingerprint-match.ts \
+            --resolved "$fp" --expected "$EXPECT_FINGERPRINT")"
+          echo "$verdict" >> "$GITHUB_OUTPUT"
+          # Second-precision, no fractional part: the postcondition below compares
+          # this against the server's createdAt as plain strings, and a mixed
+          # `…48.000Z` / `…48Z` pair doesn't order correctly.
+          echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%S)" >> "$GITHUB_OUTPUT"
+          if [ "$verdict" = "mismatch=true" ]; then
+            echo "::warning::main now resolves $PLATFORM fingerprint \"${fp:-<unresolved>}\", not $EXPECT_FINGERPRINT. Skipping the republish: the binary that asked for it can only ever run its embedded bundle now, and a new native build is already on the way. Use mobile-ota-backport.yml if that cohort needs a JS fix."
+          else
+            echo "::notice::$PLATFORM fingerprint still matches $EXPECT_FINGERPRINT — republishing so the new binary has an update newer than its embedded bundle."
+          fi
+
       # This workflow is the SOLE OWNER of packages/mobile/src/data/changelog.generated.json.
       # It regenerates the "What's New" changelog from merged-PR Release Notes and
       # pushes it back to main so the committed copy is the single source of truth
@@ -284,7 +366,7 @@ jobs:
       # single `--platform all` publish with one env could only ever match one side.
       - name: Publish iOS OTA
         id: publish_ios
-        if: steps.gate.outputs.configured == 'true' && steps.generate.outcome == 'success' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'ios')
+        if: steps.gate.outputs.configured == 'true' && steps.generate.outcome == 'success' && steps.expect.outputs.mismatch != 'true' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'ios')
         continue-on-error: true
         env:
           # V3 control-plane rejects Expo tokens; eoas publish authenticates with the
@@ -319,7 +401,7 @@ jobs:
 
       - name: Publish Android OTA
         id: publish_android
-        if: always() && steps.gate.outputs.configured == 'true' && steps.generate.outcome == 'success' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'android')
+        if: always() && steps.gate.outputs.configured == 'true' && steps.generate.outcome == 'success' && steps.expect.outputs.mismatch != 'true' && (env.INPUT_PLATFORM == 'all' || env.INPUT_PLATFORM == 'android')
         continue-on-error: true
         env:
           EOO_TOKEN: ${{ secrets.EOO_TOKEN }}
@@ -384,6 +466,52 @@ jobs:
             echo "::error::At least one requested platform failed. Successful platforms remain published; no automatic rollback was attempted."
             exit 1
           fi
+
+      # The postcondition of a republish, checked against the server rather than
+      # inferred from a green publish step: ask the manifest endpoint exactly what
+      # the app asks, and require an update that (a) is for the fingerprint the
+      # binary embeds and (b) was created after this run started, i.e. after the
+      # build that dispatched us finished bundling. "The publish command exited 0"
+      # is a proxy; this is the actual thing — the 2026-09-01 stranding had a green
+      # publish too. The health check can't cover this: an install running its own
+      # embedded bundle is not an emergency launch, so the fleet reads as healthy.
+      - name: Verify the republished update is the one the fleet will see
+        if: steps.gate.outputs.configured == 'true' && github.event.inputs.expect_fingerprint != '' && steps.expect.outputs.mismatch != 'true' && steps.publish_summary.outputs.all_success == 'true'
+        env:
+          EXPECT_FINGERPRINT: ${{ github.event.inputs.expect_fingerprint }}
+          PLATFORM: ${{ github.event.inputs.platform }}
+          STARTED_AT: ${{ steps.expect.outputs.started_at }}
+        run: |
+          set -euo pipefail
+          body="$(curl -sS --fail-with-body --max-time 60 \
+            -H "expo-platform: $PLATFORM" \
+            -H "expo-runtime-version: $EXPECT_FINGERPRINT" \
+            -H 'expo-channel-name: production' \
+            -H 'expo-app-id: 007e6fd7-f200-448c-9449-8d48ba5d51fc' \
+            -H 'xprem-branch: ' \
+            -H 'expo-protocol-version: 1' \
+            -H 'accept: multipart/mixed' \
+            "$EXPO_UPDATES_URL")"
+          # A `directive` part (noUpdateAvailable / rollBackToEmbedded) means the
+          # server has nothing for this fingerprint — the opposite of what we set
+          # out to guarantee.
+          served_rv="$(printf '%s' "$body" | grep -o '"runtimeVersion":"[0-9a-f]*"' | head -1 | cut -d'"' -f4)"
+          created_at="$(printf '%s' "$body" | grep -o '"createdAt":"[^"]*"' | head -1 | cut -d'"' -f4)"
+          if [ -z "$served_rv" ] || [ -z "$created_at" ]; then
+            echo "::error::No manifest served for $PLATFORM runtimeVersion $EXPECT_FINGERPRINT — the binary that asked for this republish has no update at all."
+            exit 1
+          fi
+          if [ "$served_rv" != "$EXPECT_FINGERPRINT" ]; then
+            echo "::error::Server is serving runtimeVersion $served_rv, not $EXPECT_FINGERPRINT."
+            exit 1
+          fi
+          # Both sides trimmed to whole seconds so a fractional `…48.000Z` and a
+          # bare `…48Z` still order correctly as strings.
+          if [ "${created_at:0:19}" \< "$STARTED_AT" ]; then
+            echo "::error::Served update was created at $created_at, before this run started ($STARTED_AT). The republish did not become the newest update, so the new binary will keep launching its embedded bundle."
+            exit 1
+          fi
+          echo "::notice::$PLATFORM is served an update for $EXPECT_FINGERPRINT created at $created_at — newer than the binary that asked for it."
 
       # Push the refreshed changelog to main so the committed copy is the single
       # source of truth (native builds bundle it; the next OTA diffs against it).
@@ -452,6 +580,7 @@ jobs:
           DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           COMMIT_SHA: ${{ github.sha }}
+          EXPECT_FINGERPRINT: ${{ github.event.inputs.expect_fingerprint }}
           IOS_OUTCOME: ${{ steps.publish_ios.outcome }}
           ANDROID_OUTCOME: ${{ steps.publish_android.outcome }}
         run: |
@@ -479,8 +608,17 @@ jobs:
           else
             BODY="message: ${INPUT_MESSAGE:-$(git log -1 --pretty=%s "$COMMIT_SHA")}"
           fi
-          CONTENT=$(printf '🚀 **Production OTA published** on `%s`\n• platforms: %s\n• channel: production\n\n%s\n<%s>' \
-            "${COMMIT_SHA:0:7}" "$platforms" "$BODY" "$RUN_URL")
+          # A republish dispatched by a native build re-ships JS that is usually
+          # identical to the last push's OTA, so say what it is — otherwise it reads
+          # as a second release of the same commit minutes later.
+          if [ -n "$EXPECT_FINGERPRINT" ]; then
+            HEADER=$(printf '♻️ **Production OTA republished** on `%s` — so the new %s build can receive it' \
+              "${COMMIT_SHA:0:7}" "$platforms")
+          else
+            HEADER=$(printf '🚀 **Production OTA published** on `%s`' "${COMMIT_SHA:0:7}")
+          fi
+          CONTENT=$(printf '%s\n• platforms: %s\n• channel: production\n\n%s\n<%s>' \
+            "$HEADER" "$platforms" "$BODY" "$RUN_URL")
           jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
             | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
               echo "::warning::Failed to post Discord notification (see status above)"

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -152,7 +152,10 @@ OTA whose fingerprint no current binary has yet, so it only lands once the match
 ships. Until the server is wired (no `EXPO_UPDATES_URL` variable or committed cert), the workflow
 skips with a green no-op. The matching native builds (`ios-testflight-rn` / `android-apk-rn`) run
 on the same push but are **fingerprint-gated** — they only build when the fingerprint is new (see
-[Native-build gating](#native-build-gating-ota-only-when-the-fingerprint-is-unchanged) below). A
+[Native-build gating](#native-build-gating-ota-only-when-the-fingerprint-is-unchanged) below).
+Matching fingerprints are necessary but not sufficient: an OTA published while a native build is
+still running loses to that build's embedded bundle, so each native build republishes when it
+finishes — see [Publish ordering](#publish-ordering-a-binary-can-outrank-a-newer-ota) below. A
 successful publish (and any failure) posts to the Discord deploy channel via the
 `DISCORD_DEPLOY_WEBHOOK` secret, the same channel the native build workflows use. The success
 message lists what the OTA newly added: the workflow snapshots `changelog.generated.json` before
@@ -455,7 +458,61 @@ construction — the gate can never skip a fingerprint the binary lacks. This re
 the build-OS value and always-build on cross-OS divergence" scheme, which wasted iOS builds and —
 worse — let the Linux OTA publish strand JS under a runtimeVersion the macOS binary never had.
 Android builds on Linux like its gate, so it was never divergent; it pins the same way for a uniform
-invariant.
+invariant. That claim is about fingerprint **identity** only — it says nothing about publish order,
+which is a separate failure mode covered next.
+
+### Publish ordering: a binary can outrank a newer OTA
+
+Matching fingerprints get an update *offered* to a binary. Whether it is *applied* is decided
+separately, by time. `expo-updates` launches whichever update has the newest `commitTime`
+(`LauncherSelectionPolicyFilterAware` sorts descending; `LoaderSelectionPolicyFilterAware` won't
+even download one that isn't strictly newer than the running update). A binary's embedded
+`commitTime` is stamped when the **build** runs — `createManifestForBuildAsync.ts` uses
+`new Date().getTime()` — not when its commit was authored.
+
+A ~50-minute macOS build therefore finishes with an embedded bundle that is *newer* than any OTA
+published while it was running, even though that OTA came from a later commit. Both share a
+fingerprint, so the OTA is eligible; it just always loses. It happened on 2026-09-01:
+
+| time (UTC) | event |
+| --- | --- |
+| 02:06 | `aa5b4d3` pushed → iOS build starts |
+| 02:31 | `c51fedb` (#4992) pushed → same fingerprint, so the native build skips |
+| 02:37 | OTA published, `createdAt` 02:37:16Z |
+| 02:46 | the *earlier* commit's binary writes `app.manifest`, `commitTime` ≈ 02:46 |
+| 02:49 | uploaded as 2.4.0 build 10 |
+
+Build 10 shipped without #4992's JS and could never receive it. Nothing catches this on its own:
+an install running its own embedded bundle is not an emergency launch, so `mobile:ota-health-check`
+reads the fleet as healthy (the same blind spot noted for the V2 cutover above).
+
+**The fix is an ordering invariant:** for a given fingerprint, at least one publish must happen
+strictly *after* the last binary carrying it finished bundling. Each native workflow therefore
+dispatches `mobile-ota-production.yml` once its store upload lands, passing `expect_fingerprint`
+(the value it just tagged and embedded). The dispatched run re-resolves the fingerprint and
+**skips** if `main` has since moved to a new native change — publishing under the new fingerprint
+would ship JS assuming native code that binary lacks. That leaves the just-shipped binary
+permanently on its embedded bundle, which is correct: its replacement is already building, and
+`mobile-ota-backport.yml` is the escape hatch if that cohort needs a JS fix meanwhile.
+
+Two details that make it hold:
+
+- The dispatch uses the default `GITHUB_TOKEN` with job-level `actions: write`. `workflow_dispatch`
+  is the documented exception to "events triggered by `GITHUB_TOKEN` don't create a workflow run"
+  (same pattern as `db-migration-renumber-dispatch.yml`); no App permission is involved.
+- The shared `mobile-ota-production` lane uses `queue: max`. `cancel-in-progress: false` protects
+  only the *running* run — GitHub still cancels a *pending* one when a new run queues, and the
+  republishes are per-platform, so a superseded pending run would strand that platform. The cost is
+  that pushes during a long publish queue instead of coalescing.
+
+After a successful republish the workflow probes the manifest endpoint the way the app does and
+fails unless the served update is for that fingerprint and was created after the run started. "The
+publish step exited 0" is a proxy; the 2026-09-01 stranding had a green publish too.
+
+The root cause is upstream: `commitTime` is build time rather than commit time. Patching
+`createManifestForBuildAsync` to use the source commit's committer date would remove the race
+outright, at the cost of one native build train (`patches/**` is a fingerprint input). Tracked
+separately; the republish rail needs no native release, which is why it shipped first.
 
 The production OTA publish stays `main`-only and on the `fingerprint` policy.
 After a native change lands, it immediately resolves the new fingerprint; this
@@ -896,6 +953,21 @@ EXPO_UPDATES_URL=https://example.test/manifest vp exec expo prebuild
    the `fingerprint-android-` tag. The publish pins to the same tag the binary embeds, so these match
    by construction — a mismatch means the pin wiring broke (recheck
    `scripts/mobile-ci-env-parity.test.ts`).
+
+   **Publish ordering (the other half of the same check).** A matching fingerprint only makes the
+   update *eligible*; `expo-updates` still launches whichever has the newest `commitTime`. Read the
+   `createdAt` out of that same response and compare it against when the binary was built — the
+   `Bundle React Native code and images` phase in the native run's log, or `Updates.createdAt` on a
+   device already running the embedded bundle:
+
+   ```sh
+   # …same curl as above, then:
+   #   "createdAt":"2026-09-01T04:39:48.000Z"   ← must be LATER than the build
+   ```
+
+   Earlier than the build means that binary will keep launching its embedded bundle no matter how
+   many times the fingerprint matches. Dispatch `mobile-ota-production.yml` to fix it. See
+   [Publish ordering](#publish-ordering-a-binary-can-outrank-a-newer-ota).
 
 3. Ship one native TestFlight build from `main` (bakes in the fingerprint runtimeVersion + server
    URL + cert). Existing `appVersion`-era installs won't receive fingerprint OTAs — they update

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -85,6 +85,14 @@ function readWorkflow(name: string): string {
 }
 
 /** Extract a workflow-level `env:` value (2-space indent) by key, or null. */
+/** One step's YAML block, from its `- name:` line to the next step's. */
+function otaStep(workflow: string, stepName: string): string {
+  const start = workflow.indexOf(`      - name: ${stepName}`);
+  expect(start, `step "${stepName}" not found`).toBeGreaterThanOrEqual(0);
+  const nextStepOffset = workflow.slice(start + 1).indexOf('\n      - name: ');
+  return nextStepOffset >= 0 ? workflow.slice(start, start + 1 + nextStepOffset) : workflow.slice(start);
+}
+
 function workflowEnvValue(source: string, key: string): string | null {
   const match = source.match(new RegExp(`^ {2}${key}:[ \\t]*(.+?)\\s*$`, 'm'));
   return match ? match[1] : null;
@@ -171,9 +179,28 @@ describe('mobile CI env parity (OTA fingerprint invariant)', () => {
 
     expect(androidBuild).toMatch(keyExpr);
     expect(ota, 'OTA workflow must set GOOGLE_MAPS_API_KEY for the Android publish').toMatch(keyExpr);
-    // Exactly one occurrence in the OTA workflow → it scopes to the Android step,
-    // not the iOS publish (which must run without it).
-    expect(ota.match(/GOOGLE_MAPS_API_KEY:/g)?.length ?? 0).toBe(1);
+    // Assert the per-step scoping directly rather than counting occurrences. A
+    // count was a proxy: it happened to imply "Android only" while exactly one
+    // step used the key, and broke the moment a second Android-only step (the
+    // fingerprint resolve) legitimately needed it. Every step that resolves or
+    // publishes must carry the key for Android and omit it for iOS — that is the
+    // actual invariant, and it holds however many such steps exist.
+    for (const stepName of [
+      'Publish Android OTA',
+      'Verify the fingerprint still matches the build that asked for this',
+    ]) {
+      expect(otaStep(ota, stepName), `${stepName} must see GOOGLE_MAPS_API_KEY for Android`).toMatch(
+        /GOOGLE_MAPS_API_KEY:/,
+      );
+    }
+    expect(otaStep(ota, 'Publish iOS OTA'), 'the iOS publish must run WITHOUT the maps key').not.toMatch(
+      /GOOGLE_MAPS_API_KEY:/,
+    );
+    // The Android-only steps gate the key on the platform rather than setting it
+    // unconditionally, so an iOS republish resolves the iOS fingerprint.
+    expect(otaStep(ota, 'Verify the fingerprint still matches the build that asked for this')).toContain(
+      "github.event.inputs.platform == 'android' && secrets.GOOGLE_MAPS_API_KEY || ''",
+    );
   });
 
   it('keeps the OTA publish on the self-hosted production branch', () => {
@@ -222,6 +249,10 @@ describe('mobile CI env parity (OTA fingerprint invariant)', () => {
       { name: NATIVE_IOS, platform: 'ios' },
       { name: NATIVE_ANDROID, platform: 'android' },
       { name: OTA_BACKPORT, platform: '"$PLATFORM"' },
+      // The republish guard: a native build asks the OTA workflow to publish under
+      // the fingerprint it just shipped, and the workflow re-resolves to confirm
+      // main hasn't moved to a new native change in the meantime.
+      { name: OTA, platform: '"$PLATFORM"' },
     ];
     for (const { name, platform } of expectedWorkflowResolvers) {
       const source = readWorkflow(name);

--- a/scripts/mobile-fingerprint-match.test.ts
+++ b/scripts/mobile-fingerprint-match.test.ts
@@ -1,0 +1,48 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from 'vitest';
+
+import { fingerprintPrefixMatches, normalizeFingerprint } from './mobile-fingerprint-match';
+
+const SHIPPED = '532b90278dac7a6a85f320ebe51cc73ba645f6cf';
+const OTHER = '67881966076e4f92ecc1a7c7b64a43d177e57019';
+
+describe('fingerprintPrefixMatches', () => {
+  // The whole point of extracting this: an inverted comparison in YAML would
+  // disable the republish guard while every workflow-text assertion stayed green.
+  // Both directions are asserted so a flipped operator can't survive.
+  it('matches a fingerprint against itself and rejects a different one', () => {
+    expect(fingerprintPrefixMatches(SHIPPED, SHIPPED)).toBe(true);
+    expect(fingerprintPrefixMatches(SHIPPED, OTHER)).toBe(false);
+  });
+
+  it('compares only the short prefix, so a full hash matches its tag form', () => {
+    expect(fingerprintPrefixMatches(SHIPPED, SHIPPED.slice(0, 12))).toBe(true);
+    // Differs only after the prefix — the native tag can't distinguish these, so
+    // neither may this.
+    expect(fingerprintPrefixMatches(SHIPPED, `${SHIPPED.slice(0, 12)}${'0'.repeat(28)}`)).toBe(true);
+  });
+
+  it('ignores case and surrounding whitespace from a shell capture', () => {
+    expect(fingerprintPrefixMatches(SHIPPED.toUpperCase(), SHIPPED)).toBe(true);
+    expect(fingerprintPrefixMatches(`  ${SHIPPED}\n`, SHIPPED)).toBe(true);
+  });
+
+  // Fail closed: an empty or truncated resolve is a resolver error, not a match.
+  // Two blank values comparing equal would republish under an unverified
+  // fingerprint, which is exactly what the guard exists to prevent.
+  it('never matches an unusable fingerprint, including two identical blanks', () => {
+    expect(fingerprintPrefixMatches('', '')).toBe(false);
+    expect(fingerprintPrefixMatches('abc', 'abc')).toBe(false);
+    expect(fingerprintPrefixMatches('not-hex-value', SHIPPED)).toBe(false);
+    expect(fingerprintPrefixMatches(SHIPPED, '')).toBe(false);
+  });
+});
+
+describe('normalizeFingerprint', () => {
+  it('returns the lowercased short prefix or null', () => {
+    expect(normalizeFingerprint(SHIPPED.toUpperCase())).toBe('532b90278dac');
+    expect(normalizeFingerprint('532b90278da')).toBeNull();
+    expect(normalizeFingerprint('')).toBeNull();
+  });
+});

--- a/scripts/mobile-fingerprint-match.ts
+++ b/scripts/mobile-fingerprint-match.ts
@@ -1,0 +1,56 @@
+/// <reference types="node" />
+
+// Decides whether a freshly-resolved runtimeVersion is the same native fingerprint
+// as one a shipped binary embeds. Used by the production OTA workflow when a native
+// build asks it to republish: `main` may have moved on to a native change since the
+// binary was built, and publishing under the NEW fingerprint would ship JS that
+// assumes native code the old binary lacks.
+//
+// The comparison lives here rather than inline in YAML for one reason: an inverted
+// `!=` in a shell script is invisible to a workflow-text assertion and silently
+// disables the guard. A pure function can be unit-tested against both directions.
+// Invoked from YAML the same way scripts/ota-preview-cleanup.ts is
+// (`node --experimental-strip-types`).
+
+import { SHORT_FP_LENGTH } from './lib/release-tags';
+
+/**
+ * True when both fingerprints agree on their first {@link SHORT_FP_LENGTH} hex
+ * characters. Case-insensitive: the tags a native build pushes are lowercase, but
+ * a resolver returning uppercase must not read as a mismatch. Anything shorter
+ * than the prefix, or not hex, is never a match — a truncated or error value must
+ * fail closed rather than compare equal to another truncated value.
+ */
+export function fingerprintPrefixMatches(resolved: string, expected: string): boolean {
+  const left = normalizeFingerprint(resolved);
+  const right = normalizeFingerprint(expected);
+  if (left === null || right === null) return false;
+  return left === right;
+}
+
+/** Lowercased {@link SHORT_FP_LENGTH}-char prefix, or null when it isn't a usable fingerprint. */
+export function normalizeFingerprint(value: string): string | null {
+  const trimmed = value.trim().toLowerCase();
+  if (!new RegExp(`^[0-9a-f]{${SHORT_FP_LENGTH},}$`).test(trimmed)) return null;
+  return trimmed.slice(0, SHORT_FP_LENGTH);
+}
+
+function readFlag(argv: string[], flag: string): string {
+  const index = argv.indexOf(flag);
+  return index >= 0 ? (argv[index + 1] ?? '') : '';
+}
+
+function main(): void {
+  const argv = process.argv.slice(2).filter((arg) => arg !== '--');
+  const resolved = readFlag(argv, '--resolved');
+  const expected = readFlag(argv, '--expected');
+  // Print the verdict for `>> "$GITHUB_OUTPUT"`. A mismatch is a SKIP, not a
+  // failure — a new binary is already building for the new fingerprint — so this
+  // always exits 0 and lets the workflow decide what to do with `mismatch`.
+  const mismatch = !fingerprintPrefixMatches(resolved, expected);
+  process.stdout.write(`mismatch=${mismatch}\n`);
+}
+
+// Only run the CLI when executed directly, so the pure exports stay importable
+// from tests without side effects.
+if (process.argv[1]?.endsWith('mobile-fingerprint-match.ts')) main();

--- a/scripts/mobile-ota-publish-workflow.test.ts
+++ b/scripts/mobile-ota-publish-workflow.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
 
 import { minimumPublishJobTimeoutMinutes, SELF_HOSTED_PUBLISH_JOB_OVERHEAD_MINUTES } from './lib/mobile-publish-retry';
 
@@ -140,6 +141,64 @@ describe('production OTA workflow reliability', () => {
     expect(production.indexOf('      - name: Assert only the changelog is uncommitted\n')).toBeLessThan(
       production.indexOf('      - name: Publish iOS OTA\n'),
     );
+  });
+
+  // A native build dispatches a republish under the fingerprint it just shipped.
+  // If main has moved to a NEW native change by the time that run gets a runner,
+  // publishing would resolve the new fingerprint and ship JS assuming native code
+  // the uploaded binary lacks — so the run must re-resolve and skip.
+  it('re-resolves the fingerprint for a dispatched republish and lets it gate the publish', () => {
+    const inputs = (parse(production) as { on: { workflow_dispatch: { inputs: Record<string, unknown> } } }).on
+      .workflow_dispatch.inputs;
+    expect(Object.keys(inputs)).toContain('expect_fingerprint');
+
+    const verify = stepBlock(production, 'Verify the fingerprint still matches the build that asked for this');
+    expect(verify).toContain('runtimeversion:resolve --platform "$PLATFORM"');
+    expect(verify).toContain('scripts/mobile-fingerprint-match.ts');
+    // A mismatch is a SKIP, not a failure: the binary is simply unreachable now
+    // and a new native build is already on the way.
+    expect(verify).toContain('::warning::');
+
+    // The assertion that stops this being decorative. A resolve step whose output
+    // nothing consumes would leave the guard inert while every check above passed.
+    for (const stepName of ['Publish iOS OTA', 'Publish Android OTA']) {
+      expect(stepBlock(production, stepName), `${stepName} must honour the fingerprint verdict`).toContain(
+        "steps.expect.outputs.mismatch != 'true'",
+      );
+    }
+  });
+
+  // The postcondition, checked against the server rather than inferred from a
+  // green publish step — the 2026-09-01 stranding had a green publish too.
+  it('verifies a republished update is actually served, and is newer than the build', () => {
+    const verify = stepBlock(production, 'Verify the republished update is the one the fleet will see');
+
+    expect(verify).toContain('expo-runtime-version: $EXPECT_FINGERPRINT');
+    expect(verify).toContain('createdAt');
+    expect(verify).toContain('STARTED_AT');
+    expect(verify).toContain('exit 1');
+    expect(verify).toContain("steps.publish_summary.outputs.all_success == 'true'");
+  });
+
+  // cancel-in-progress: false protects only the RUNNING run; GitHub still cancels
+  // a PENDING one when a new run queues. The republishes are dispatched per
+  // platform and do not cover for each other, so a superseded pending run leaves
+  // that platform's fleet stranded.
+  it('queues runs in the shared production lane instead of superseding pending ones', () => {
+    for (const [name, source] of [
+      ['mobile-ota-production.yml', production],
+      ['mobile-ota-backport.yml', backport],
+    ] as const) {
+      // Read the PARSED concurrency block, not the workflow text: both files
+      // explain `queue: max` in a comment right above the setting, so a
+      // `toContain('queue: max')` stays green when the setting itself is deleted.
+      const { concurrency } = parse(source) as {
+        concurrency: { group?: string; queue?: string; 'cancel-in-progress'?: boolean };
+      };
+      expect(concurrency.group, `${name} must share the production lane`).toBe('mobile-ota-production');
+      expect(concurrency.queue, `${name} shares the lane, so it must queue too`).toBe('max');
+      expect(concurrency['cancel-in-progress']).toBe(false);
+    }
   });
 
   it('runs the health check after any successful platform, including partial success', () => {

--- a/scripts/native-release-workflows.test.ts
+++ b/scripts/native-release-workflows.test.ts
@@ -165,7 +165,15 @@ describe('native release workflow contracts', () => {
   // mobile:upload-dsyms` and `restore-keys` both appear in prose comments long
   // before (or instead of) the steps they name, so an indexOf/toContain version
   // of these checks reports on the comments rather than the pipeline.
-  type WorkflowStep = { name?: string; run?: string; uses?: string; with?: Record<string, unknown> };
+  type WorkflowStep = {
+    name?: string;
+    run?: string;
+    uses?: string;
+    with?: Record<string, unknown>;
+    // `if` is the step's condition. Parsed rather than string-matched so an
+    // assertion about a step's gate can't accidentally read a neighbour's.
+    if?: string;
+  };
   const jobsOf = (source: string): Record<string, { steps?: WorkflowStep[] }> =>
     (parse(source) as { jobs: Record<string, { steps?: WorkflowStep[] }> }).jobs;
 
@@ -189,6 +197,65 @@ describe('native release workflow contracts', () => {
 
   const indexOfStepRunning = (steps: readonly WorkflowStep[], command: string): number =>
     steps.findIndex((step) => typeof step.run === 'string' && runsCommand(step.run, command));
+
+  // expo-updates launches whichever update has the newest commitTime, and a binary
+  // stamps its embedded bundle at BUILD time — so an OTA published from a later
+  // commit *while* a ~50-minute build was running is already older than the binary
+  // that build produces, and never applies despite a matching fingerprint (#4992 vs
+  // 2.4.0 build 10, 2026-09-01). Each native build therefore republishes once its
+  // store upload lands: a publish strictly after the build necessarily outranks it.
+  it('republishes the production OTA after each store upload, so the new binary can receive it', () => {
+    for (const [source, job, platform, uploadGate] of [
+      [ios, 'build-and-upload', 'ios', "steps.testflight_upload.outcome == 'success'"],
+      [android, 'record-candidate', 'android', "env.FINGERPRINT_ANDROID != ''"],
+    ] as const) {
+      const steps = stepsOfJob(source, job);
+      const dispatch = indexOfStepRunning(steps, 'gh workflow run mobile-ota-production.yml');
+      expect(dispatch, `${job} must dispatch the OTA republish`).toBeGreaterThanOrEqual(0);
+
+      // After the fingerprint tag: the tag is what makes the next push skip the
+      // native build, so republishing before it could target a fingerprint that
+      // never actually shipped.
+      const tagStep = indexOfStepRunning(steps, 'fingerprint_tag=');
+      expect(tagStep).toBeGreaterThanOrEqual(0);
+      expect(tagStep).toBeLessThan(dispatch);
+
+      // Never republish for a build that failed to reach the store.
+      expect(String(steps[dispatch]?.if ?? '')).toContain(uploadGate);
+
+      const run = String(steps[dispatch]?.run ?? '');
+      // --ref main, not github.ref: we publish what main holds now, not the
+      // (possibly stale) ref this build was cut from.
+      expect(run).toContain('--ref main');
+      expect(run).toContain(`-f platform=${platform}`);
+      expect(run).toContain('-f expect_fingerprint=');
+    }
+  });
+
+  // `gh workflow run -f <unknown>=` fails with a 422 that only surfaces at runtime,
+  // after the store upload — far too late. Pin the two ends together.
+  it('passes only inputs the production OTA workflow actually declares', () => {
+    const declared = new Set(
+      Object.keys(
+        (parse(productionOta) as { on: { workflow_dispatch: { inputs: Record<string, unknown> } } }).on
+          .workflow_dispatch.inputs,
+      ),
+    );
+    expect(declared).toContain('expect_fingerprint');
+
+    for (const [source, job] of [
+      [ios, 'build-and-upload'],
+      [android, 'record-candidate'],
+    ] as const) {
+      const steps = stepsOfJob(source, job);
+      const run = String(steps[indexOfStepRunning(steps, 'gh workflow run mobile-ota-production.yml')]?.run ?? '');
+      const passed = [...run.matchAll(/-f\s+([a-z_]+)=/g)].map(([, key]) => key);
+      expect(passed.length).toBeGreaterThan(0);
+      for (const key of passed) {
+        expect(declared, `mobile-ota-production.yml declares no workflow_dispatch input "${key}"`).toContain(key);
+      }
+    }
+  });
 
   it('checks the embedded framework ABI before anything leaves the runner', () => {
     const ci = workflow('ios-rn-ci.yml');


### PR DESCRIPTION
## Summary

**Stacked on #5006.** A JS commit can be fingerprint-compatible with a shipped binary and still never reach it.

`expo-updates` launches whichever update has the newest `commitTime` (`LauncherSelectionPolicyFilterAware.swift:26` sorts descending; `LoaderSelectionPolicyFilterAware.swift:57` won't even download one that isn't strictly newer). A binary's embedded `commitTime` is stamped at **build** time — `createManifestForBuildAsync.ts:57` uses `new Date().getTime()` — not when its commit was authored.

So a ~50-minute macOS build started by an earlier commit finishes with an embedded bundle *newer* than an OTA published mid-build from a later commit. Same fingerprint, so the update is offered; it just always loses.

That is what happened on 2026-09-01:

| time (UTC) | event |
| --- | --- |
| 02:06 | `aa5b4d3` pushed → iOS build starts |
| 02:31 | `c51fedb` (#4992) pushed → same fingerprint, native build skips |
| 02:37:16 | OTA published |
| 02:46:13 | the *earlier* commit's binary writes `app.manifest` |
| 02:49 | uploaded as 2.4.0 build 10 |

Build 10 shipped without #4992's hold outlines and could never receive them. And it is silent: an install running its own embedded bundle is not an emergency launch, so `ota-health-check` reads the fleet as healthy — the same blind spot the doc already names for the V2 cutover.

**The fix is an ordering invariant:** for a given fingerprint, at least one publish happens strictly *after* the last binary carrying it finished bundling. Each native workflow dispatches `mobile-ota-production.yml` once its store upload lands, passing the fingerprint it just tagged. The dispatched run re-resolves and **skips** if `main` has moved to a new native change — publishing under the new fingerprint would ship JS the old binary lacks native code for.

Three details that make it hold:

1. **No new permissions.** The dispatch uses the default token with job-level `actions: write`. `workflow_dispatch` is the documented exception to "events triggered by `GITHUB_TOKEN` don't create a workflow run" — `db-migration-renumber-dispatch.yml:7-9` already relies on this. Deliberately *not* folded into the release-tag App token, which would hand Actions:write to every token minted from that App.
2. **`queue: max` on the shared production lane.** `cancel-in-progress: false` protects only the *running* run — GitHub still cancels a *pending* one when a new run queues. The republishes are per-platform and don't cover for each other, so iOS-running + Android-pending + any push would have dropped the Android one. Cost, stated plainly: pushes during a long publish now queue instead of coalescing.
3. **A real postcondition.** After publishing, the workflow probes the manifest endpoint exactly as the app does and fails unless the served update is for that fingerprint and was created after the run started. "The publish exited 0" is a proxy — the 2026-09-01 stranding had a green publish too.

The fingerprint comparison is a unit-tested pure function (`scripts/mobile-fingerprint-match.ts`) rather than inline shell: an inverted `!=` would disable the guard while every workflow-text assertion stayed green.

**Root cause, filed separately:** `commitTime` being build time is upstream. A pnpm patch making it the source commit's committer date removes the race outright, at the cost of one native build train (`patches/**` is a fingerprint input). This rail needs no native release, which is why it goes first.

### Guards, and the mutation that reddens each

Every guard here was mutation-tested. One of them (`queue: max`) was **vacuous on first write** — it matched the explanatory comment above the setting, so deleting the setting left it green. It now reads the parsed `concurrency` block.

| Mutation | Result |
| --- | --- |
| Delete the iOS dispatch step | 2 failed |
| Ungate the Android dispatch from the upload | 1 failed |
| Publish steps stop honouring the mismatch verdict | 1 failed |
| Drop `queue: max` from either side of the lane | 1 failed each |
| Rename `expect_fingerprint` on one end only | 2 failed |
| Invert the fingerprint comparison | 3 failed |
| Make two blank fingerprints compare equal | 1 failed |

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 4/5 — changes the production OTA publish pipeline and both native release workflows. No native fingerprint input is touched, so no new store build is required. The unverifiable-until-live parts are `queue: max` parsing on our plan and the dispatch actually firing; both surface on the next native build, and the dispatch is `continue-on-error` so it cannot red a good release.
