### PR TITLE
ci: add the self-hosted runner kill switch, its guards and a watchdog

### DIFF
--- a/.github/workflows/android-pr-rn.yml
+++ b/.github/workflows/android-pr-rn.yml
@@ -72,7 +72,7 @@ jobs:
     # Expo fingerprint (file-hash based — no Android SDK needed), so it always
     # reports a check even when it skips the build, which keeps a required-check
     # config from waiting on a job that never arrives.
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/ci-runner-watchdog.yml
+++ b/.github/workflows/ci-runner-watchdog.yml
@@ -1,0 +1,109 @@
+name: CI Runner Watchdog
+
+# Puts CI back on GitHub-hosted runners when the homelab fleet goes away.
+#
+# The failure this exists for: a job whose `runs-on` labels never come online
+# sits queued for **24 hours** before GitHub cancels it. Worse, flipping
+# `CI_RUNNER_LINUX` does not rescue jobs that are already queued — their
+# `runs-on` was resolved at dispatch time. So recovery is two steps, and both
+# have to happen without a human noticing first.
+#
+# Deliberately NOT routed to the fleet (see ci-runner-routing.test.ts, which
+# asserts that). It must be able to run at exactly the moment the fleet cannot.
+#
+# It does not automatically re-enable the fleet. Coming back is a decision that
+# wants a human who knows why it went down.
+
+on:
+  schedule:
+    # Every 10 minutes. The worst case this bounds is a 24-hour queue, so the
+    # exact cadence matters less than it always running.
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report what would happen without changing anything'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-runner-watchdog
+  cancel-in-progress: false
+
+jobs:
+  check:
+    # Hardcoded, never routed. See the note above.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check fleet health and fail back if it is gone
+        env:
+          # Fine-grained PAT: Variables (write), Actions (write),
+          # Administration (read). GITHUB_TOKEN cannot write repository
+          # variables, which is the whole reason this secret exists.
+          GH_TOKEN: ${{ secrets.CI_RUNNER_ADMIN_PAT }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::CI_RUNNER_ADMIN_PAT is not set; watchdog cannot act."
+            exit 0
+          fi
+
+          current="$(gh api "repos/${REPO}/actions/variables/CI_RUNNER_LINUX" \
+            --jq '.value' 2>/dev/null || echo '')"
+
+          if [ -z "$current" ] || [ "$current" = '"ubuntu-latest"' ]; then
+            echo "CI_RUNNER_LINUX is already the GitHub-hosted fallback; nothing to do."
+            exit 0
+          fi
+
+          online="$(gh api "repos/${REPO}/actions/runners" \
+            --jq '[.runners[] | select(.status == "online")] | length')"
+          echo "Online self-hosted runners: ${online}"
+
+          if [ "$online" -gt 0 ]; then
+            echo "Fleet is up."
+            exit 0
+          fi
+
+          echo "::error::No self-hosted runners are online. Failing back to GitHub-hosted."
+
+          if [ "${DRY_RUN:-false}" = 'true' ]; then
+            echo "Dry run: would set CI_RUNNER_LINUX to \"ubuntu-latest\" and cancel queued runs."
+            exit 0
+          fi
+
+          # 1. Stop new work being dispatched to labels nothing answers.
+          gh api -X PATCH "repos/${REPO}/actions/variables/CI_RUNNER_LINUX" \
+            -f name=CI_RUNNER_LINUX -f value='"ubuntu-latest"'
+
+          # 2. Cancel what is already queued. Those jobs resolved their runs-on
+          #    at dispatch, so the variable change does not reach them — without
+          #    this they sit for 24 hours. Cancelling makes them re-dispatch
+          #    against the new value on the next push or re-run.
+          cancelled=0
+          while read -r run_id; do
+            [ -n "$run_id" ] || continue
+            gh run cancel "$run_id" --repo "${REPO}" >/dev/null 2>&1 && cancelled=$((cancelled + 1)) || true
+          done < <(gh run list --repo "${REPO}" --status queued --limit 200 \
+                     --json databaseId --jq '.[].databaseId')
+
+          echo "Cancelled ${cancelled} queued run(s)."
+
+          if [ -n "${DISCORD_WEBHOOK:-}" ]; then
+            # Best-effort, and allowed_mentions is empty so nothing here can
+            # ping the channel.
+            jq -nc \
+              --arg content "**CI fell back to GitHub-hosted runners.** No self-hosted runners were online, so \`CI_RUNNER_LINUX\` was reset and ${cancelled} queued run(s) were cancelled so they re-dispatch. The fleet will NOT re-enable itself — check the homelab, then set the variable back." \
+              '{content: $content, allowed_mentions: {parse: []}}' \
+              | curl -sS -X POST -H 'Content-Type: application/json' -d @- "$DISCORD_WEBHOOK" \
+              || echo "::warning::Discord notification failed."
+          fi

--- a/.github/workflows/firmware-tests.yml
+++ b/.github/workflows/firmware-tests.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ios-rn-ci.yml
+++ b/.github/workflows/ios-rn-ci.yml
@@ -43,7 +43,7 @@ jobs:
     # fingerprint unchanged vs main — mirroring main's native-skip for JS-only
     # merges. Runs on ubuntu: the fingerprint resolve is
     # file-hash based and needs no Xcode, so this spends no macOS minutes.
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/pr-test-plan.yml
+++ b/.github/workflows/pr-test-plan.yml
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 5
     steps:
       - name: Label migration PRs

--- a/scripts/__tests__/ci-runner-routing.test.ts
+++ b/scripts/__tests__/ci-runner-routing.test.ts
@@ -1,0 +1,136 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+import {
+  githubYamlPaths,
+  isRoutedRunsOn,
+  jobBlocks,
+  routedJobNames,
+  withoutCommentLines,
+} from './helpers/workflow-yaml';
+
+/**
+ * Routing between GitHub-hosted and the self-hosted homelab fleet.
+ *
+ * Every migrated job carries the SAME expression, byte for byte:
+ *
+ *   runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
+ *
+ * Two properties matter and neither is visible at review time.
+ *
+ * 1. The fork clause. boardsesh/boardsesh is public with 33 forks, and the
+ *    self-hosted runners have no meaningful sandbox — jobs are in the `docker`
+ *    group, which is root on the VM. Fork PRs must resolve to `ubuntu-latest`
+ *    even though the repo also requires approval for outside collaborators;
+ *    approving a diff is not the same as vouching for it running as root on the
+ *    LAN. Paraphrase the expression and drop that clause and nothing looks
+ *    wrong in review — hence the byte-identity check rather than a shape check.
+ *
+ * 2. The single kill switch. `vars.CI_RUNNER_LINUX` unset (or set to the JSON
+ *    string "ubuntu-latest") puts everything back on GitHub-hosted with no
+ *    commit. That only holds while every migrated job reads the same variable.
+ *
+ * Everything inside fromJSON is a JSON literal, so the result is always
+ * well-typed: either the string "ubuntu-latest" or the label array from the
+ * variable. On push/schedule/workflow_dispatch the fork property is null, so it
+ * falls through to the variable.
+ */
+
+const ROUTING_EXPRESSION =
+  '${{ fromJSON(github.event.pull_request.head.repo.fork && \'"ubuntu-latest"\' || vars.CI_RUNNER_LINUX || \'"ubuntu-latest"\') }}';
+
+const ROUTED_RUNS_ON = `    runs-on: ${ROUTING_EXPRESSION}`;
+
+/**
+ * Jobs that are allowed to be routed. Anything else asking for a self-hosted
+ * runner is a mistake — see ci-self-hosted-secret-boundary.test.ts for why the
+ * deploy and release workflows may never be.
+ */
+const ROUTED_JOBS: ReadonlyArray<readonly [workflow: string, job: string]> = [
+  // Wave 0 canaries: cheap, secret-free, and between them they exercise the
+  // whole runner contract — GITHUB_TOKEN, checkout over a seeded git object
+  // store, `vp install` against the warm pnpm store, and the hostedtoolcache
+  // Python prefill.
+  ['pr-test-plan.yml', 'check'],
+  ['firmware-tests.yml', 'test'],
+  // Wave 1: the measured worst offenders. Both gates are ~50s of work that
+  // waited ~25 minutes for a slot (1475s and 1666s on runs 33465942874 and
+  // 33465859594). Their macOS/APK build jobs stay hosted.
+  ['ios-rn-ci.yml', 'gate'],
+  ['android-pr-rn.yml', 'gate'],
+];
+
+/**
+ * ci.yml's control plane. `changes` gates 22 jobs and `ci-status` is the
+ * required check, so both must be able to run when the fleet cannot. Two of
+ * GitHub's 20 slots is a cheap price for the aggregator always being able to
+ * report.
+ */
+const CI_CONTROL_PLANE_JOBS = ['changes', 'ci-status'] as const;
+
+function workflow(name: string): string {
+  return readFileSync(`.github/workflows/${name}`, 'utf8');
+}
+
+describe('self-hosted runner routing', () => {
+  it.each(ROUTED_JOBS)('%s job `%s` is routed', (workflowName, jobName) => {
+    const block = jobBlocks(workflow(workflowName)).get(jobName);
+    expect(block, `${workflowName} has no job \`${jobName}\``).toBeDefined();
+    expect(block).toContain(ROUTED_RUNS_ON);
+  });
+
+  it('uses one byte-identical expression everywhere it appears', () => {
+    // The failure this catches: someone copies the line, reformats it, and
+    // drops the fork clause. The result still routes to the fleet, still reads
+    // fine, and now runs fork PRs as root on the homelab.
+    const variants = new Map<string, string[]>();
+
+    for (const path of githubYamlPaths()) {
+      for (const line of withoutCommentLines(readFileSync(path, 'utf8'))) {
+        if (!isRoutedRunsOn(line)) continue;
+        const expression = line.trim().slice('runs-on:'.length).trim();
+        variants.set(expression, [...(variants.get(expression) ?? []), path]);
+      }
+    }
+
+    expect(variants.size, `runs-on expressions drifted: ${JSON.stringify([...variants], null, 2)}`).toBe(1);
+    expect([...variants.keys()][0]).toBe(ROUTING_EXPRESSION);
+  });
+
+  it('routes exactly the jobs on the list and no others', () => {
+    const routed = new Set<string>();
+    for (const path of githubYamlPaths()) {
+      const workflowName = path.split('/').pop() as string;
+      for (const jobName of routedJobNames(readFileSync(path, 'utf8'))) {
+        routed.add(`${workflowName}:${jobName}`);
+      }
+    }
+
+    const expected = new Set(ROUTED_JOBS.map(([workflowName, jobName]) => `${workflowName}:${jobName}`));
+    // Adding a job here is a deliberate act that should come with a wave and a
+    // measurement, not a drive-by edit.
+    expect([...routed].sort()).toEqual([...expected].sort());
+  });
+
+  it('keeps ci.yml`s control plane on GitHub-hosted', () => {
+    const blocks = jobBlocks(workflow('ci.yml'));
+    for (const jobName of CI_CONTROL_PLANE_JOBS) {
+      const block = blocks.get(jobName);
+      expect(block, `ci.yml has no job \`${jobName}\``).toBeDefined();
+      expect(block).toContain('    runs-on: ubuntu-latest');
+    }
+  });
+
+  it('keeps the watchdog independent of the thing it watches', () => {
+    // ci-runner-watchdog.yml is what puts the fleet back on GitHub-hosted when
+    // the runners die. If it were routed, it could not run at exactly the
+    // moment it is needed.
+    const source = workflow('ci-runner-watchdog.yml');
+    // It reads and writes CI_RUNNER_LINUX in its script, so assert on the
+    // runs-on specifically rather than on the string appearing in the file.
+    expect(routedJobNames(source)).toEqual([]);
+    expect(jobBlocks(source).get('check')).toContain('    runs-on: ubuntu-latest');
+  });
+});

--- a/scripts/__tests__/ci-self-hosted-secret-boundary.test.ts
+++ b/scripts/__tests__/ci-self-hosted-secret-boundary.test.ts
@@ -1,0 +1,122 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+import { githubYamlPaths, isRoutedRunsOn, isWorkflow, jobBlocks, withoutCommentLines } from './helpers/workflow-yaml';
+
+/**
+ * The invariant that makes self-hosted runners acceptable at all:
+ *
+ *   No job routed to the homelab fleet may reference any secret other than
+ *   `secrets.GITHUB_TOKEN`, and none may declare an `environment:`.
+ *
+ * Why it has to be a test rather than a rule people remember:
+ *
+ * A self-hosted runner has no meaningful boundary between a job and the host.
+ * Jobs are in the `docker` group (root-equivalent), and the runner's own
+ * `.credentials` file must be readable by the runner user — so a job that reads
+ * it can impersonate the runner and receive *subsequent* jobs, including their
+ * secrets. That is inherent to self-hosted runners, not a bug we can fix. The
+ * only durable mitigation is that there is nothing on the fleet worth stealing.
+ *
+ * The good news is this costs nothing today: ci.yml already references only
+ * `GITHUB_TOKEN`. The rule keeps App Store Connect, Google Play, Vercel,
+ * Railway, Cloudflare, AWS, the OTA admin credentials, Sentry and the
+ * 1Password service account off homelab hardware by construction.
+ *
+ * Deploy and release work moves to a *separate protected fleet* later — a
+ * different trust domain that never runs PR code — not onto this one.
+ */
+
+const ALLOWED_SECRET = 'GITHUB_TOKEN';
+
+/** `secrets.FOO` / `secrets['FOO']` / `secrets["FOO"]`. */
+const SECRET_REFERENCE = /secrets\.([A-Za-z0-9_]+)|secrets\[['"]([A-Za-z0-9_]+)['"]\]/g;
+
+function secretNames(text: string): string[] {
+  return [...text.matchAll(SECRET_REFERENCE)].map((match) => match[1] ?? match[2]);
+}
+
+interface RoutedJob {
+  path: string;
+  jobName: string;
+  block: string[];
+  source: string;
+}
+
+function routedJobs(): RoutedJob[] {
+  const jobs: RoutedJob[] = [];
+  for (const path of githubYamlPaths()) {
+    const source = readFileSync(path, 'utf8');
+    // .github also holds composite actions and dependabot config, which have no
+    // top-level `jobs:` key.
+    if (!isWorkflow(source)) continue;
+    for (const [jobName, block] of jobBlocks(source)) {
+      if (block.some(isRoutedRunsOn)) {
+        jobs.push({ path, jobName, block, source });
+      }
+    }
+  }
+  return jobs;
+}
+
+describe('self-hosted secret boundary', () => {
+  const jobs = routedJobs();
+
+  it('finds the routed jobs (guards against the checks below passing vacuously)', () => {
+    // Without this, deleting the routing expression everywhere would make every
+    // assertion below pass on an empty set.
+    expect(jobs.length).toBeGreaterThan(0);
+  });
+
+  it('routes no job that references a secret other than GITHUB_TOKEN', () => {
+    const offenders = jobs.flatMap(({ path, jobName, block }) =>
+      secretNames(block.join('\n'))
+        .filter((name) => name !== ALLOWED_SECRET)
+        .map((name) => `${path}:${jobName} → secrets.${name}`),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it('routes no job whose workflow-level env references a secret other than GITHUB_TOKEN', () => {
+    // A workflow-level `env:` is inherited by every job in the file, so a
+    // routed job in a workflow with a secret up top is just as exposed as one
+    // that names it directly.
+    const offenders: string[] = [];
+    for (const path of new Set(jobs.map((job) => job.path))) {
+      const lines = withoutCommentLines(readFileSync(path, 'utf8'));
+      const envIndex = lines.findIndex((line) => line === 'env:');
+      if (envIndex < 0) continue;
+      for (const line of lines.slice(envIndex + 1)) {
+        if (!line.trim()) continue;
+        if (!line.startsWith('  ')) break;
+        for (const name of secretNames(line)) {
+          if (name !== ALLOWED_SECRET) offenders.push(`${path} → workflow env secrets.${name}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('routes no job that declares an environment', () => {
+    // GitHub Environments are how the high-value secrets are gated today
+    // (Production, ota-preview, ota-preview-unattended, postgres-image-publisher).
+    // An `environment:` on a routed job hands that environment's secrets to the
+    // fleet, which is exactly what this boundary exists to prevent.
+    const offenders = jobs
+      .filter(({ block }) => block.some((line) => /^ {4}environment:/.test(line)))
+      .map(({ path, jobName }) => `${path}:${jobName}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it('routes no job in a workflow that can be triggered by pull_request_target', () => {
+    // pull_request_target runs with the base repo's token and secrets while
+    // checking out PR-author-controlled refs. Combining that with a runner that
+    // has no sandbox is the worst available shape.
+    const offenders = jobs
+      .filter(({ source }) => withoutCommentLines(source).some((line) => /^\s{2}pull_request_target:/.test(line)))
+      .map(({ path, jobName }) => `${path}:${jobName}`);
+    expect(offenders).toEqual([]);
+  });
+});

--- a/scripts/__tests__/helpers/workflow-yaml.ts
+++ b/scripts/__tests__/helpers/workflow-yaml.ts
@@ -1,0 +1,110 @@
+/// <reference types="node" />
+
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Minimal workflow-YAML readers shared by the specs that pin invisible pairings
+ * in `.github/workflows` (a `uses:` step and the `run:` forty lines below it, a
+ * `runs-on` label and the secrets the job is allowed to see).
+ *
+ * Deliberately string-based rather than a YAML parse: several of these specs
+ * assert on things a parse throws away — that an expression is *byte*-identical
+ * everywhere, that a value is a literal rather than an expression, that a line
+ * is commented out. Extracted from ci-vp-toolchain.test.ts, which had the first
+ * copy.
+ */
+
+/** Every `.yml`/`.yaml` under `.github`, recursively. */
+export function githubYamlPaths(directory = '.github'): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = join(directory, entry.name);
+    if (entry.isDirectory()) return githubYamlPaths(entryPath);
+    return entry.name.endsWith('.yml') || entry.name.endsWith('.yaml') ? [entryPath] : [];
+  });
+}
+
+/** Strip full-line comments so a commented-out example isn't read as live config. */
+export function withoutCommentLines(source: string): string[] {
+  return source.split('\n').filter((line) => !line.trimStart().startsWith('#'));
+}
+
+/**
+ * Split a workflow into its top-level jobs. Jobs sit at indentation 2 under a
+ * column-0 `jobs:` key; a job's block runs until the next line at indentation
+ * <= 2 that isn't blank.
+ */
+export function jobBlocks(source: string): Map<string, string[]> {
+  const lines = withoutCommentLines(source);
+  const jobsIndex = lines.findIndex((line) => line === 'jobs:');
+  if (jobsIndex < 0) throw new Error('workflow has no top-level `jobs:` key');
+
+  const blocks = new Map<string, string[]>();
+  let currentName: string | null = null;
+  let currentLines: string[] = [];
+
+  for (const line of lines.slice(jobsIndex + 1)) {
+    const jobHeader = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
+    if (jobHeader) {
+      if (currentName) blocks.set(currentName, currentLines);
+      currentName = jobHeader[1];
+      currentLines = [];
+      continue;
+    }
+    // A non-blank line back at column 0 ends the jobs mapping entirely.
+    if (line.trim() && !line.startsWith(' ')) break;
+    if (currentName) currentLines.push(line);
+  }
+  if (currentName) blocks.set(currentName, currentLines);
+
+  return blocks;
+}
+
+/**
+ * The workflow-level `env:` block: lines at indentation 2 under a column-0
+ * `env:` key. Job-level env is invisible to this, which is the point — the
+ * mobile fingerprint specs care specifically about the workflow-level values.
+ */
+export function workflowEnvLines(source: string): string[] {
+  const lines = withoutCommentLines(source);
+  const envIndex = lines.findIndex((line) => line === 'env:');
+  if (envIndex < 0) return [];
+
+  const collected: string[] = [];
+  for (const line of lines.slice(envIndex + 1)) {
+    if (!line.trim()) continue;
+    if (!line.startsWith('  ')) break;
+    collected.push(line);
+  }
+  return collected;
+}
+
+/**
+ * A `runs-on:` line that resolves through `vars.CI_RUNNER_LINUX`.
+ *
+ * Matching on the runs-on line specifically, not on the variable name appearing
+ * anywhere in the block: ci-runner-watchdog.yml reads and writes that variable
+ * in its script, and it is emphatically not a routed job.
+ */
+export function isRoutedRunsOn(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed.startsWith('runs-on:') && trimmed.includes('vars.CI_RUNNER_LINUX');
+}
+
+/**
+ * True when the document has a top-level `jobs:` key, i.e. is a workflow rather
+ * than a composite action, dependabot config, or issue-form template. `.github`
+ * is full of those, and jobBlocks() throws on them by design.
+ */
+export function isWorkflow(source: string): boolean {
+  return withoutCommentLines(source).includes('jobs:');
+}
+
+/**
+ * Job names in `source` whose runs-on routes through the fleet variable. Returns
+ * [] for non-workflow YAML so callers can scan all of `.github` freely.
+ */
+export function routedJobNames(source: string): string[] {
+  if (!isWorkflow(source)) return [];
+  return [...jobBlocks(source)].filter(([, block]) => block.some(isRoutedRunsOn)).map(([jobName]) => jobName);
+}


### PR DESCRIPTION
## Summary

Groundwork for #5005 — moving the per-PR CI hot path onto self-hosted homelab runners. Part of #5010.

**Nothing changes until someone sets a repository variable.** With `CI_RUNNER_LINUX` unset, every routed job still resolves to `ubuntu-latest`. Flipping it is a separate, deliberate act that comes after the fleet exists (#5009).

### The problem, measured

The org is on the GitHub **Free** plan: 20 concurrent jobs. Queue wait vs. actual execution, in seconds, from real runs:

| Job | Queued | Ran |
| --- | ---: | ---: |
| `ios-rn-ci` → `gate` | 1475 | 55 |
| `android-pr-rn` → `gate` | 1666 | 46 |
| `ci.yml` → `ci-status` | 1369 | 2 |
| `ci.yml` → `db-migrations` | 1337 | 67 |

Jobs that finish in under a minute wait 25 minutes for a slot. Both of the worst offenders are `ubuntu-latest` **gate** jobs, not the macOS builds behind them — `ios-rn-ci.yml` says as much itself ("the fingerprint resolve is file-hash based and needs no Xcode").

### One expression, one kill switch

```yaml
runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
```

Four jobs carry it: `pr-test-plan` → `check` and `firmware-tests` → `test` (Wave 0 canaries, which between them exercise `GITHUB_TOKEN`, checkout, `vp install` and the `setup-python` tool cache), plus the `ios-rn-ci` and `android-pr-rn` **gate** jobs (Wave 1, the measured win). Their macOS and APK build jobs stay hosted.

Everything inside `fromJSON` is a JSON literal, so the result is always well-typed — either the string `ubuntu-latest` or the label array. On push/schedule/dispatch the fork property is null and it falls through to the variable. Confirmed against the docs that both `github` and `vars` are available in `runs-on`.

### Two invisible properties, both pinned by tests

**The fork clause.** This repo is public with 33 forks, and self-hosted runners have no meaningful sandbox — jobs sit in the `docker` group, which is root on the VM. Fork PRs must resolve to `ubuntu-latest` even though the repo separately requires approval for outside collaborators; approving a diff is not the same as vouching for it running as root on someone's LAN. Paraphrase the expression, drop that clause, and **nothing looks wrong in review** — so `ci-runner-routing.test.ts` compares it byte for byte rather than by shape. It also pins the approved job list, keeps `ci.yml`'s `changes`/`ci-status` control plane hosted, and keeps the watchdog off the fleet it watches.

**The secret boundary.** `ci-self-hosted-secret-boundary.test.ts` asserts no routed job references a secret other than `GITHUB_TOKEN`, inherits one from a workflow-level `env:`, declares an `environment:`, or lives in a workflow with a `pull_request_target` trigger.

This is worth stating plainly: a job on a self-hosted runner can read the runner's own `.credentials` file and impersonate it to receive *subsequent* jobs, including their secrets. That is inherent to self-hosted runners, not something we can patch. The only durable mitigation is that there is nothing on the fleet worth stealing — and it costs nothing today, because `ci.yml` already references only `GITHUB_TOKEN`. Deploy and release work moves to a separate protected fleet later (#5019), never onto this one.

Both suites were **mutation-tested** — each of these turns them red:

```
caught: fork clause dropped from the expression
caught: expression whitespace drift
caught: an unlisted job routed to the fleet
caught: ci-status control-plane job routed
caught: routed job references a non-GITHUB_TOKEN secret
caught: routed job declares an environment
caught: watchdog routed to the fleet it watches
```

### The watchdog, and the trap it exists for

A job whose labels never come online sits queued for **24 hours** before GitHub cancels it. Worse, flipping `CI_RUNNER_LINUX` does **not** rescue jobs that already dispatched — their `runs-on` resolved at dispatch time. So recovery is two steps and both have to happen before a human notices.

`ci-runner-watchdog.yml` runs every 10 minutes, hardcoded to `ubuntu-latest` because it has to work at exactly the moment the fleet does not. When zero self-hosted runners are online it resets the variable, cancels queued runs so they re-dispatch, and posts to Discord. It deliberately does **not** re-enable the fleet — coming back is a decision that wants a human who knows why it went down.

### Also here

Extracts the workflow-YAML readers `ci-vp-toolchain.test.ts` had grown into `scripts/__tests__/helpers/workflow-yaml.ts` rather than copying them a third time. They stay string-based on purpose: these specs assert things a YAML parse throws away, like byte-identity and whether a line is commented out.

### Needs before the variable can be flipped

- Repo secret **`CI_RUNNER_ADMIN_PAT`** — fine-grained: Variables (write), Actions (write), Administration (read). `GITHUB_TOKEN` cannot write repository variables, which is the only reason this secret exists.
- The fleet itself (#5009) and the hardened runner role (marcodejongh/blackheathdc-ansible#393).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.
2. `pr-test-plan` ran on this PR — proves the expression evaluates.

## Risk

Risk: 2/5 — no behaviour change while `CI_RUNNER_LINUX` is unset; every routed job still resolves to `ubuntu-latest`. The one live risk is the expression failing to evaluate, which this PR's own `pr-test-plan` run exercises. The watchdog is inert without `CI_RUNNER_ADMIN_PAT` and warns rather than failing.
