### PR TITLE
feat(repo): config-as-code for the Railway OTA project, and turn on xprem Observe

### DIFF
--- a/.github/workflows/postgres-image-publisher-contract.yml
+++ b/.github/workflows/postgres-image-publisher-contract.yml
@@ -20,10 +20,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: postgres-image-contract-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   verify-trust-boundary:
     runs-on: ubuntu-latest

--- a/.github/workflows/railway-drift.yml
+++ b/.github/workflows/railway-drift.yml
@@ -37,8 +37,9 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # RAILWAY_TOKEN is the same secret the production deploy uses. CLICKHOUSE_URL is
-    # optional: without it the retention assertion is skipped rather than failed.
+    # RAILWAY_TOKEN is the same secret the production deploy uses. It is the only
+    # credential this job has, so the retention assertion always skips here and
+    # what actually runs nightly is the service, variable and disk checks.
     environment: Production
     steps:
       - name: Checkout repository
@@ -56,12 +57,21 @@ jobs:
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
-          CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+          # CLICKHOUSE_URL is deliberately NOT passed. The retention assertion
+          # connects to boardsesh-ota-clickhouse.railway.internal, which resolves
+          # only inside Railway's private network, so a runner setting this would
+          # fail the job on a connection timeout rather than on real drift. The
+          # disk check below needs nothing here — it reads the volume through
+          # Railway's API. Re-add once the check runs through a tunnel or from
+          # inside the network. See docs/railway.md.
         run: |
           set -euo pipefail
 
           # Skip cleanly rather than failing red on a fork PR or before the repo
           # variable is set — an unconfigured check must not look like real drift.
+          # An expired token lands here too: Railway answers a dead project token
+          # with HTTP 200 and `Not Authorized`, which the client turns into a
+          # thrown error, so the job goes red rather than pretending it is in sync.
           if [ -z "${RAILWAY_TOKEN:-}" ] || [ -z "${RAILWAY_PROJECT_ID:-}" ]; then
             echo "::notice::RAILWAY_TOKEN or RAILWAY_PROJECT_ID unavailable; skipping the Railway drift check."
             exit 0

--- a/.github/workflows/railway-drift.yml
+++ b/.github/workflows/railway-drift.yml
@@ -1,0 +1,63 @@
+name: Railway Drift Check
+
+# Daily dry-run of the OTA project's config-as-code. Reports (never applies) drift
+# between infra/railway/config.ts and the live Railway project, and fails the run
+# when it finds any — the non-zero exit is the whole point of the schedule.
+#
+# --apply is deliberately NOT run here. Converging is a deliberate act: the only
+# thing this tool writes is a variable, and only when handed its value, which is not
+# something an unattended nightly job should be doing to the server every production
+# binary talks to. Same reasoning as cf:apply holding back the zone-wide SSL change.
+#
+# See docs/railway.md.
+on:
+  schedule:
+    - cron: '30 6 * * *' # 06:30 UTC daily, just after refresh-recommendations
+  workflow_dispatch:
+  # Config changes are worth checking before they merge: a typo'd service name
+  # reads as "service does not exist" against the live project.
+  pull_request:
+    paths:
+      - 'infra/railway/**'
+      - 'scripts/railway-apply.ts'
+      - '.github/workflows/railway-drift.yml'
+
+concurrency:
+  group: railway-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # RAILWAY_TOKEN is the same secret the production deploy uses. CLICKHOUSE_URL is
+    # optional: without it the retention assertion is skipped rather than failed.
+    environment: Production
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: '22.x'
+          cache: true
+
+      - name: Install dependencies
+        run: vp install --frozen-lockfile
+
+      - name: Check for drift
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+          CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+        run: |
+          set -euo pipefail
+
+          # Skip cleanly rather than failing red on a fork PR or before the repo
+          # variable is set — an unconfigured check must not look like real drift.
+          if [ -z "${RAILWAY_TOKEN:-}" ] || [ -z "${RAILWAY_PROJECT_ID:-}" ]; then
+            echo "::notice::RAILWAY_TOKEN or RAILWAY_PROJECT_ID unavailable; skipping the Railway drift check."
+            exit 0
+          fi
+
+          vp run railway:apply

--- a/.github/workflows/railway-drift.yml
+++ b/.github/workflows/railway-drift.yml
@@ -27,7 +27,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The live check needs RAILWAY_TOKEN, which lives in the Production environment,
+  # and that environment's branch policy admits `main` alone. A pull_request run is
+  # `refs/pull/N/merge`, so asking for the environment there fails the job outright
+  # ("not allowed to deploy to Production") rather than skipping. Hence the split:
+  # schedule and manual dispatch get the live project, pull requests get the layers
+  # that need no credentials.
   drift:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # RAILWAY_TOKEN is the same secret the production deploy uses. CLICKHOUSE_URL is
@@ -61,3 +68,30 @@ jobs:
           fi
 
           vp run railway:apply
+
+  # No Railway credentials are reachable from a PR, so assert what does not need
+  # them: the plan layer's unit tests and the script's types. This does NOT catch a
+  # service name that is misspelled relative to the live project — only the nightly
+  # run does. Giving PRs that reach would mean a second environment holding the
+  # token with no branch policy, which is a deliberate call, not a workflow tweak.
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: '22.x'
+          cache: true
+
+      - name: Install dependencies
+        run: vp install --frozen-lockfile
+
+      - name: Test the plan layer
+        run: vp test run scripts/railway-apply.test.ts --reporter=agent
+
+      - name: Typecheck the apply script
+        run: vp exec tsc -p scripts/tsconfig.json --noEmit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ Read relevant `docs/` before working on the matching area; update docs when the 
 - `docs/db-connectivity.md` — Postgres connect retries (what is retried and why it can't double-execute a write), the retry budgets, and the `/health` vs `/health/db` split
 - `docs/og-climb.md` — backend-served climb OG share cards (`GET /og/climb`: caches, env vars, timings)
 - `docs/cloudflare.md` — the boardsesh.com Cloudflare zone: config-as-code (`vp run cf:apply`), token scopes/secrets, CI auto-apply, og edge caching, planned OpenNext web deploy
+- `docs/railway.md` — the OTA project's Railway config-as-code (`vp run railway:apply`): what it asserts vs. applies, why services are never created from a script, the `RAILWAY_VAR_*` secret contract, and the xprem ClickHouse retention guard
 - `docs/mobile-sheets-vs-routes.md` — mobile: which surface to use (bottom sheet vs route), with the decision tree + the hard rules (incl. why `fullScreenModal` breaks the iOS 26 native tab bar)
 - `docs/gym-funnel-analytics.md` — the www gym funnel event contract in `@boardsesh/analytics` (seven event names, their property sets, the QR `?src=qr&medium=` landing params, and why `boardTypes` must be a joined string)
 - `docs/sitemap.md` — the shard registry, the degrade-at-the-index / fail-closed-at-the-shard split, and the climb store (`sitemap_shard_refreshes` + the `sitemap_climb_urls` ordinal table the shard pages read): who refreshes it, the `?force=1` escape hatch, and why the write lock is transaction-scoped

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -1,0 +1,117 @@
+# Railway (OTA project config-as-code)
+
+Config-as-code for the Railway project that runs the self-hosted xprem OTA server
+(`updates.boardsesh.com`). It is the same three-file shape as
+[cloudflare.md](./cloudflare.md): typed desired state, a pure diff, and one script
+that does all the I/O.
+
+| File | Role |
+| --- | --- |
+| `infra/railway/config.ts` | Declarative desired state. No side effects, no API calls, **no secret values**. |
+| `infra/railway/plan.ts` | Pure diff → `PlannedChange[]`. Unit-tested; no I/O. |
+| `scripts/railway-apply.ts` | Fetches live state, builds the plan, reports or converges. |
+| `scripts/railway-apply.test.ts` | Tests the plan layer. Needs no live project. |
+
+```bash
+RAILWAY_TOKEN=... RAILWAY_PROJECT_ID=... vp run railway:apply              # dry-run
+RAILWAY_TOKEN=... RAILWAY_PROJECT_ID=... vp run railway:apply -- --apply   # converge
+```
+
+Dry-run is the default and **exits non-zero when there is drift**, so CI can gate on
+it. A second `--apply` with nothing to do is a no-op.
+
+## What it manages
+
+- **Services.** Asserts `boardsesh-ota-v3` exists; reports when the ClickHouse
+  service is missing. It never creates or deletes a service — see
+  [Why services are not created](#why-services-are-not-created).
+- **Variables.** Asserts the declared variables are set and are not still an
+  unfilled `<placeholder>`.
+- **ClickHouse retention.** Asserts the TTLs on xprem's `observe_metrics` and
+  `observe_logs` tables.
+
+A service that is live but not declared here is **reported and left alone**. The
+project also holds Postgres and other services on purpose; a tool that removed what
+it did not recognise would be a catastrophe rather than a convenience.
+
+## Secrets
+
+`infra/railway/config.ts` never holds a value. It declares that a variable must
+exist and must not be a placeholder — the value lives in Railway.
+
+`--apply` writes a variable only when the caller supplies its value in the script's
+own environment as `RAILWAY_VAR_<NAME>`:
+
+```bash
+RAILWAY_VAR_CLICKHOUSE_URL='clickhouse://…' vp run railway:apply -- --apply
+```
+
+Without one, the drift is reported and left unapplied. A variable that is already
+set and is not a placeholder is **never overwritten** — this tool cannot clobber a
+working DSN with a stale one.
+
+Values never reach a log line. `infra/railway/plan.ts` reduces every variable to
+`set` / `absent` / `placeholder` before it can appear in a `PlannedChange`, and one
+of the unit tests asserts a password cannot survive into the plan.
+
+### Why placeholders are their own state
+
+`npx eoas server:init` writes `CLICKHOUSE_URL=<clickhouse://user:password@host:9000/xprem>`
+when you enable Observe without pasting a DSN. That value passes a naive "is it
+set?" check and then fails at boot, so it is classified separately and reported with
+a different message. The pattern is borrowed from xprem's own CLI, which uses the
+identical regex to catch the identical mistake.
+
+## ClickHouse retention
+
+xprem's ClickHouse migrations ship **no TTL on any table**. Left alone,
+`observe_metrics` and `observe_logs` grow until the volume fills.
+
+The declared windows are 90 days for metrics and 30 for logs — logs carry the event
+bodies and attribute blobs that dominate the bytes, while metrics are narrow numeric
+rows worth comparing across releases months apart.
+
+The check is skipped, not failed, when the script has no `CLICKHOUSE_URL` of its own
+(the same way `scripts/mobile-ota-health-check.ts` skips without a PostHog key). It
+reads over ClickHouse's HTTP interface on port 8123 and never writes.
+
+> **These tables are not ours.** xprem creates and migrates them through goose, so a
+> server upgrade can recreate a table and silently drop a TTL we set out of band.
+> That is why this is asserted on every run rather than being a one-time runbook
+> step. The durable fix is a retention knob upstream in xprem; until that exists,
+> this assertion is the guard.
+
+To set or repair a TTL:
+
+```sql
+ALTER TABLE observe_metrics MODIFY TTL timestamp + INTERVAL 90 DAY;
+ALTER TABLE observe_logs    MODIFY TTL timestamp + INTERVAL 30 DAY;
+```
+
+## Why services are not created
+
+A ClickHouse service is only correct with a persistent volume mounted at
+`/var/lib/clickhouse`. A service created without one looks perfectly healthy and
+loses every row on each redeploy, and a name lookup that misses would create a
+*second* service rather than reusing the first. Neither has a cheap undo.
+
+So the tool reports exactly what is missing and what to create, and applies only
+variables — which are safe and idempotent. This mirrors how the Cloudflare tool
+reports a zone-wide SSL change instead of applying it. Widening this to
+`serviceCreate` + `volumeCreate` is a deliberate follow-up, not an oversight.
+
+## Env
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `RAILWAY_TOKEN` | yes | Railway API token. The same secret the production deploy already uses against `backboard.railway.com`. |
+| `RAILWAY_PROJECT_ID` | yes | The project holding the OTA services. |
+| `RAILWAY_VAR_<NAME>` | no | A value `--apply` may write for a declared variable. Never logged. |
+| `CLICKHOUSE_URL` | no | Enables the retention assertion. Read-only. |
+
+## Related
+
+- [mobile-ota-updates.md](./mobile-ota-updates.md) — the OTA server itself: hosting,
+  versions, the publish path, and the cutover history.
+- [cloudflare.md](./cloudflare.md) — the same config-as-code pattern for the
+  `boardsesh.com` zone.

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -104,23 +104,67 @@ Code: 450. DB::Exception: TTL expression result column should have DateTime or
 Date type, but has DateTime64(9, 'UTC'). (BAD_TTL_EXPRESSION)
 ```
 
-### The three tables with no declared retention
+### What fills the disk
+
+Two separate things grow, and they are not the same size.
+
+**xprem's Observe tables are small.** `update_health_snapshots` is the busiest by a
+wide margin — `ee/observe/health_history.go` snapshots every current (update, role) on
+a **one-minute** ticker, measured at ~259 rows per minute bucket, so ~373k rows/day.
+That sounds alarming and is not: the rows are narrow and repetitive, and ClickHouse
+stores them at about **2.6 bytes/row**, so ninety days is roughly 33.6M rows ≈ 87 MB.
+Segment snapshots use a fixed five-minute bucket but fan out over eight dimensions.
+`device_health_events` is the smallest, since it only fires when a device genuinely
+changes update.
+
+Note that this growth tracks how many *update rows* exist, not how many climbers use
+the app — the per-PR `pr-*` branches are what drive it.
+
+**ClickHouse's own system logs are the real consumer.** They ship almost no TTL:
+`asynchronous_metric_log` alone wrote 55M rows in the first hour. Left alone the
+`system` database grows by roughly 38 MB/day, unbounded — about a hundred times what
+Observe itself uses. Every `system.*_log` MergeTree table has since been given a TTL
+(14 days for the high-frequency instrumentation, 30 for the diagnostics worth
+reading). These are ClickHouse's tables, not xprem's, so **re-check them after an image
+upgrade** — a new server version can recreate a log table and drop the TTL with it.
+
+### Disk headroom
+
+`CLICKHOUSE_VOLUME_USAGE_LIMIT_PERCENT` in `infra/railway/config.ts` fails the run once
+the volume passes 80% of its capacity. Every run prints the reading regardless:
+
+```
+[railway-apply] ClickHouse volume: 0.8 GiB of 48.8 GiB (1.7%).
+```
+
+Unlike the retention assertion, **this one does run in CI**, because it reads the volume
+through Railway's own API rather than by connecting to ClickHouse. Railway answers a
+GitHub Actions runner; `boardsesh-ota-clickhouse.railway.internal` does not.
+
+It is worth gating on because a full volume is not merely a storage problem. ClickHouse
+stops accepting writes, and since xprem calls `log.Fatalf` when ClickHouse is
+unreachable at boot, the next OTA restart would then fail to come up at all — a full
+disk here is an availability risk for `updates.boardsesh.com`.
+
+### The three tables that fill without any app release
 
 `observe_metrics` and `observe_logs` are fed by the app's telemetry sink, so they
 stay empty until the mobile app ships `expo-observe`. The other three fill straight
 away from ordinary manifest check-ins, because Postgres triggers enqueue into
 `device_health_outbox` and a worker drains it into ClickHouse:
 
-| Table | Time column | Declared retention |
-| --- | --- | --- |
-| `device_health_events` | `occurred_at` | none |
-| `update_health_snapshots` | `bucket` | none |
-| `update_health_segment_snapshots` | `bucket` | none |
+| Table | Time column | Retention | Why |
+| --- | --- | --- | --- |
+| `update_health_snapshots` | `bucket` | 90d | One-minute samples; nothing reads minute grain a quarter later |
+| `update_health_segment_snapshots` | `bucket` | 90d | Five-minute samples, but eight dimensions wide |
+| `device_health_events` | `occurred_at` | 180d | Lowest volume and the raw record the other two summarise |
 
-None of them carry a TTL from xprem either. They are narrower and slower-growing
-than the log table, so this is not urgent, but "no retention at all on the only
-tables currently receiving rows" is worth a deliberate decision rather than an
-oversight.
+`observe_metrics` and `observe_logs` need `expo-observe` in the mobile app, which is a
+native module — so a new fingerprint and a store release. **The three above need
+nothing from the app.** Postgres triggers enqueue into `device_health_outbox` on every
+device update-state change, driven by the manifest check-ins every production binary
+already makes, and a worker drains that into ClickHouse. So the rollout and adoption
+views work today; only the startup and navigation timings wait on a release.
 
 ## Why services are not created
 

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -91,8 +91,17 @@ reads over ClickHouse's HTTP interface on port 8123 and never writes.
 To set or repair a TTL:
 
 ```sql
-ALTER TABLE observe_metrics MODIFY TTL timestamp + INTERVAL 90 DAY;
-ALTER TABLE observe_logs    MODIFY TTL timestamp + INTERVAL 30 DAY;
+ALTER TABLE observe_metrics MODIFY TTL toDateTime(timestamp) + INTERVAL 90 DAY;
+ALTER TABLE observe_logs    MODIFY TTL toDateTime(timestamp) + INTERVAL 30 DAY;
+```
+
+`toDateTime()` is required, not decoration. Both `timestamp` columns are
+`DateTime64(9, 'UTC')`, and ClickHouse refuses a TTL whose result is not `Date` or
+`DateTime`:
+
+```
+Code: 450. DB::Exception: TTL expression result column should have DateTime or
+Date type, but has DateTime64(9, 'UTC'). (BAD_TTL_EXPRESSION)
 ```
 
 ### The three tables with no declared retention

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -75,6 +75,13 @@ The check is skipped, not failed, when the script has no `CLICKHOUSE_URL` of its
 (the same way `scripts/mobile-ota-health-check.ts` skips without a PostHog key). It
 reads over ClickHouse's HTTP interface on port 8123 and never writes.
 
+> **The assertion cannot run from CI as written.** The DSN host is
+> `boardsesh-ota-clickhouse.railway.internal`, which resolves only inside Railway's
+> private network, so a GitHub Actions runner cannot reach port 8123 there. Setting
+> `secrets.CLICKHOUSE_URL` today would turn the nightly drift check red on a
+> connection error rather than on real drift — leave it unset until the check either
+> runs through a tunnel or moves inside the network.
+
 > **These tables are not ours.** xprem creates and migrates them through goose, so a
 > server upgrade can recreate a table and silently drop a TTL we set out of band.
 > That is why this is asserted on every run rather than being a one-time runbook
@@ -88,6 +95,24 @@ ALTER TABLE observe_metrics MODIFY TTL timestamp + INTERVAL 90 DAY;
 ALTER TABLE observe_logs    MODIFY TTL timestamp + INTERVAL 30 DAY;
 ```
 
+### The three tables with no declared retention
+
+`observe_metrics` and `observe_logs` are fed by the app's telemetry sink, so they
+stay empty until the mobile app ships `expo-observe`. The other three fill straight
+away from ordinary manifest check-ins, because Postgres triggers enqueue into
+`device_health_outbox` and a worker drains it into ClickHouse:
+
+| Table | Time column | Declared retention |
+| --- | --- | --- |
+| `device_health_events` | `occurred_at` | none |
+| `update_health_snapshots` | `bucket` | none |
+| `update_health_segment_snapshots` | `bucket` | none |
+
+None of them carry a TTL from xprem either. They are narrower and slower-growing
+than the log table, so this is not urgent, but "no retention at all on the only
+tables currently receiving rows" is worth a deliberate decision rather than an
+oversight.
+
 ## Why services are not created
 
 A ClickHouse service is only correct with a persistent volume mounted at
@@ -100,14 +125,36 @@ variables — which are safe and idempotent. This mirrors how the Cloudflare too
 reports a zone-wide SSL change instead of applying it. Widening this to
 `serviceCreate` + `volumeCreate` is a deliberate follow-up, not an oversight.
 
+## How it runs in CI
+
+`.github/workflows/railway-drift.yml` has two jobs, split by trigger:
+
+- **`drift`** — schedule (06:30 UTC) and `workflow_dispatch`. Runs the real dry-run
+  against the live project and fails on drift. It needs `secrets.RAILWAY_TOKEN`, which
+  lives in the **Production** environment.
+- **`validate`** — pull requests touching `infra/railway/**` or the apply script. Runs
+  the plan layer's tests and typechecks the script.
+
+They are split because the Production environment's deployment branch policy admits
+`main` alone. A pull request runs as `refs/pull/N/merge`, so a job asking for that
+environment is rejected outright — "Branch is not allowed to deploy to Production" —
+before any step executes, which no in-script skip can catch.
+
+The cost is that a service name misspelled against the *live* project is caught by the
+nightly run rather than on the PR. Closing that gap means a second environment holding
+the token with no branch policy; that is a security call, not a workflow tweak.
+
+`vars.RAILWAY_PROJECT_ID` must be set as a repository variable or the `drift` job skips
+itself with a notice.
+
 ## Env
 
 | Variable | Required | Purpose |
 | --- | --- | --- |
-| `RAILWAY_TOKEN` | yes | Railway API token. The same secret the production deploy already uses against `backboard.railway.com`. |
+| `RAILWAY_TOKEN` | yes | Railway API token. The same secret the production deploy already uses against `backboard.railway.com`. It is a **project** token, scoped to this project and its production environment, so it authenticates with `Project-Access-Token` — not `Authorization: Bearer`, which is for account tokens. The script tries one and falls back to the other, so either kind works. |
 | `RAILWAY_PROJECT_ID` | yes | The project holding the OTA services. |
 | `RAILWAY_VAR_<NAME>` | no | A value `--apply` may write for a declared variable. Never logged. |
-| `CLICKHOUSE_URL` | no | Enables the retention assertion. Read-only. |
+| `CLICKHOUSE_URL` | no | Enables the retention assertion. Read-only. **Do not add this as a CI secret yet** — see the reachability note under ClickHouse retention. |
 
 ## Related
 

--- a/infra/railway/config.ts
+++ b/infra/railway/config.ts
@@ -49,6 +49,9 @@ export const CLICKHOUSE_IMAGE = 'clickhouse/clickhouse-server:25.3';
 /** ClickHouse's data directory. A service without a volume here loses telemetry on redeploy. */
 export const CLICKHOUSE_VOLUME_MOUNT_PATH = '/var/lib/clickhouse';
 
+/** Railway's name for that volume, used to read its utilisation back. */
+export const CLICKHOUSE_VOLUME_NAME = 'boardsesh-ota-clickhouse-data';
+
 /**
  * The dedicated database xprem writes Observe telemetry into.
  *
@@ -126,10 +129,29 @@ export interface TableRetentionDesired {
   reason: string;
 }
 
+/**
+ * Volume headroom for the ClickHouse service.
+ *
+ * A full volume is the failure that actually bites: ClickHouse stops accepting
+ * writes, and because xprem calls log.Fatalf when ClickHouse is unreachable at
+ * boot, the next OTA restart would then fail to come up at all. So this is
+ * watched, not just the row counts.
+ *
+ * Railway's metrics API is reachable from CI even though ClickHouse itself is
+ * not (its DSN host resolves only inside the private network), which is why this
+ * assertion can run nightly while the retention one cannot.
+ *
+ * 80% of a 50 GB volume leaves ~10 GB of runway — weeks of headroom at any
+ * growth rate this workload has shown, and enough warning to resize or trim.
+ */
+export const CLICKHOUSE_VOLUME_USAGE_LIMIT_PERCENT = 80;
+
 export interface RailwayDesiredState {
   environmentName: string;
   services: ServiceDesired[];
   clickhouseRetention: TableRetentionDesired[];
+  /** Fail the run when the ClickHouse volume passes this much of its capacity. */
+  clickhouseVolumeUsageLimitPercent: number;
 }
 
 /**
@@ -161,6 +183,37 @@ export const CLICKHOUSE_RETENTION: TableRetentionDesired[] = [
     ttlDays: 30,
     reason: 'Event and error bodies; the widest rows, and stale ones are rarely read.',
   },
+  // The three below fill from ordinary manifest check-ins, with no app-side
+  // telemetry involved, so they are the ones actually accumulating today.
+  {
+    table: 'update_health_snapshots',
+    column: 'bucket',
+    ttlDays: 90,
+    // ee/observe/health_history.go snapshots every current (update, role) on a
+    // one-minute ticker, so this grows ~288k rows/day independently of how many
+    // climbers are using the app — the per-PR pr-* branches drive it. Nothing
+    // reads minute resolution a quarter later; the dashboard plots rollouts over
+    // hours and days.
+    reason: 'One-minute rollout samples: the highest-volume table, and useless at minute grain once old.',
+  },
+  {
+    table: 'update_health_segment_snapshots',
+    column: 'bucket',
+    ttlDays: 90,
+    // Coarser in time than the table above (a fixed five-minute bucket) but far
+    // wider: eight dimensions, each fanning out over its own segment values.
+    reason: 'Five-minute samples split eight ways by dimension, so width replaces the cadence.',
+  },
+  {
+    table: 'device_health_events',
+    column: 'occurred_at',
+    ttlDays: 180,
+    // Only written when a device genuinely changes update (first_seen /
+    // switched / failure), so this is the smallest of the three and the one
+    // worth keeping longest: it is the raw adoption record the snapshots
+    // summarise.
+    reason: 'Raw per-device adoption events: the lowest volume here and the record the rest is derived from.',
+  },
 ];
 
 export const desiredRailwayState: RailwayDesiredState = {
@@ -189,4 +242,5 @@ export const desiredRailwayState: RailwayDesiredState = {
     },
   ],
   clickhouseRetention: CLICKHOUSE_RETENTION,
+  clickhouseVolumeUsageLimitPercent: CLICKHOUSE_VOLUME_USAGE_LIMIT_PERCENT,
 };

--- a/infra/railway/config.ts
+++ b/infra/railway/config.ts
@@ -1,0 +1,192 @@
+/// <reference types="node" />
+
+// Declarative desired-state for the Railway project that runs the self-hosted xprem
+// OTA server. This is plain typed data — no side effects, no API calls.
+// scripts/railway-apply.ts reads it, diffs it against the live project, and (only
+// with --apply) converges the delta.
+//
+// Why this exists:
+//
+// 1. `boardsesh-ota-v3` is the Railway service every production and TestFlight
+//    binary talks to for OTA manifests (docs/mobile-ota-updates.md). Its
+//    configuration was set by hand in the Railway dashboard, so nothing in the repo
+//    records what it is supposed to look like and nothing notices when it drifts.
+//
+// 2. Enabling xprem's Observe feature adds a ClickHouse service and one env var
+//    (`CLICKHOUSE_URL`) whose absence silently disables telemetry and whose
+//    *unreachability at boot* is a `log.Fatalf` that takes the update server down.
+//    That is worth a CI check rather than a runbook step.
+//
+// The Cloudflare tool next door (infra/cloudflare/) is the model: typed desired
+// state here, pure diffing in ./plan.ts, all I/O in scripts/railway-apply.ts.
+//
+// SECRET VALUES NEVER APPEAR IN THIS FILE. It declares that a variable must exist
+// and must not still be a placeholder. The value lives in Railway, and the apply
+// script reads what it needs from its own environment — the same contract
+// scripts/cloudflare-apply.ts uses for CLOUDFLARE_API_TOKEN.
+
+/**
+ * The Railway environment these services live in. Railway projects are
+ * environment-scoped and every service/variable read is keyed on one, so this is
+ * part of the address, not a preference.
+ */
+export const RAILWAY_ENVIRONMENT_NAME = 'production';
+
+/** The xprem OTA server. Named in docs/mobile-ota-updates.md; matched by name, not id. */
+export const OTA_SERVICE_NAME = 'boardsesh-ota-v3';
+
+/** The ClickHouse service backing xprem's Observe feature. */
+export const CLICKHOUSE_SERVICE_NAME = 'boardsesh-ota-clickhouse';
+
+/**
+ * Image for the ClickHouse service. Pinned to the version xprem itself tests
+ * against — docker-compose.yml and .github/workflows/push.yml in the xprem repo
+ * both use `clickhouse/clickhouse-server:25.3`. Running a version xprem's goose
+ * migrations have never been exercised on is an avoidable risk.
+ */
+export const CLICKHOUSE_IMAGE = 'clickhouse/clickhouse-server:25.3';
+
+/** ClickHouse's data directory. A service without a volume here loses telemetry on redeploy. */
+export const CLICKHOUSE_VOLUME_MOUNT_PATH = '/var/lib/clickhouse';
+
+/**
+ * The dedicated database xprem writes Observe telemetry into.
+ *
+ * It must be dedicated and it must be named in the DSN: xprem refuses to boot on a
+ * `CLICKHOUSE_URL` with no database segment (NewClickHouseEngine in
+ * internal/database/clickhouse/clickhouse.go).
+ */
+export const CLICKHOUSE_DATABASE = 'expo_observe';
+
+/**
+ * Matches a value that is structurally present but was never filled in — the shape
+ * `npx eoas server:init` writes when you enable Observe without pasting a DSN
+ * (`CLICKHOUSE_URL=<clickhouse://user:password@host:9000/xprem>`).
+ *
+ * Borrowed deliberately from xprem's own CLI, which uses the identical pattern to
+ * flag the identical mistake (PLACEHOLDER_PATTERN in
+ * apps/eoas/src/lib/serverConfig/envCatalog.ts). A placeholder passes a
+ * "is the variable set?" check and fails at boot, so it is worth its own state.
+ */
+export const PLACEHOLDER_PATTERN = /<[^>]+>/;
+
+/**
+ * How much of a service this repo owns.
+ *
+ * `assert-only` — the service already exists and is configured elsewhere. We check
+ * the variables we care about and touch nothing else. This is deliberately the
+ * setting for `boardsesh-ota-v3`: it carries storage credentials, code-signing
+ * config and the JWT secret that this tool has no business reasoning about.
+ *
+ * `report-only` — we know the service should exist and what shape it should have,
+ * but creating it is left to a human. See CREATION_IS_NOT_AUTOMATED below.
+ */
+export type ServiceManagement = 'assert-only' | 'report-only';
+
+/**
+ * Creating a stateful Railway service is NOT automated by this tool, on purpose.
+ *
+ * A ClickHouse service is only correct with a persistent volume attached, and a
+ * service created without one looks healthy while losing every row on each
+ * redeploy. Getting that wrong from a script — or worse, creating a second service
+ * because a name lookup missed — is a failure mode with no cheap undo, which is the
+ * same reason the Cloudflare tool reports a zone-wide SSL change instead of
+ * applying it.
+ *
+ * So: this tool tells you precisely what is missing and what to create. It applies
+ * variables, which are safe and idempotent. Widening it to `serviceCreate` +
+ * `volumeCreate` is a deliberate follow-up, not an oversight.
+ */
+export const CREATION_IS_NOT_AUTOMATED = true;
+
+export interface RequiredEnvVar {
+  /** Variable name. The value is never declared here. */
+  name: string;
+  /** Why the service needs it — printed in the plan so drift is self-explaining. */
+  reason: string;
+}
+
+export interface ServiceDesired {
+  name: string;
+  management: ServiceManagement;
+  requiredVars: RequiredEnvVar[];
+  /** Only meaningful for a report-only service we describe but do not create. */
+  expected?: {
+    image: string;
+    volumeMountPath: string;
+  };
+}
+
+/** One table's retention rule, asserted against ClickHouse rather than Railway. */
+export interface TableRetentionDesired {
+  table: string;
+  /** The DateTime column the TTL is measured from. */
+  column: string;
+  ttlDays: number;
+  reason: string;
+}
+
+export interface RailwayDesiredState {
+  environmentName: string;
+  services: ServiceDesired[];
+  clickhouseRetention: TableRetentionDesired[];
+}
+
+/**
+ * Retention for the two Observe fact tables.
+ *
+ * xprem's ClickHouse migrations ship NO TTL on any table — verified across both
+ * files in internal/database/clickhouse/migrations/. Left alone these grow without
+ * bound, and the growth is invisible until a volume fills.
+ *
+ * Logs get the shorter window because their bodies and attribute blobs dominate the
+ * bytes, while the metrics are narrow numeric rows that compress well and are the
+ * ones worth comparing across releases months apart.
+ *
+ * These tables are created and migrated by xprem via goose, not by us, so a server
+ * upgrade can silently drop a TTL we set out of band. That is exactly why this is
+ * asserted on every run instead of being a one-time runbook step. The durable fix is
+ * a retention knob upstream in xprem; until that exists, this check is the guard.
+ */
+export const CLICKHOUSE_RETENTION: TableRetentionDesired[] = [
+  {
+    table: 'observe_metrics',
+    column: 'timestamp',
+    ttlDays: 90,
+    reason: 'Startup/navigation timings, compared across releases over a long window.',
+  },
+  {
+    table: 'observe_logs',
+    column: 'timestamp',
+    ttlDays: 30,
+    reason: 'Event and error bodies; the widest rows, and stale ones are rarely read.',
+  },
+];
+
+export const desiredRailwayState: RailwayDesiredState = {
+  environmentName: RAILWAY_ENVIRONMENT_NAME,
+  services: [
+    {
+      name: OTA_SERVICE_NAME,
+      management: 'assert-only',
+      requiredVars: [
+        {
+          name: 'CLICKHOUSE_URL',
+          reason:
+            'Enables xprem Observe. Unset means telemetry ingest is silently dropped and the ' +
+            'dashboard renders the "turn on telemetry" placeholder instead of metrics.',
+        },
+      ],
+    },
+    {
+      name: CLICKHOUSE_SERVICE_NAME,
+      management: 'report-only',
+      requiredVars: [],
+      expected: {
+        image: CLICKHOUSE_IMAGE,
+        volumeMountPath: CLICKHOUSE_VOLUME_MOUNT_PATH,
+      },
+    },
+  ],
+  clickhouseRetention: CLICKHOUSE_RETENTION,
+};

--- a/infra/railway/plan.ts
+++ b/infra/railway/plan.ts
@@ -188,16 +188,19 @@ export function diffTableRetention(
   desired: TableRetentionDesired,
   liveExpression: string | undefined,
 ): PlannedChange | null {
-  const expected = `${desired.column} + toIntervalDay(${desired.ttlDays})`;
+  // toDateTime() is not cosmetic: these columns are DateTime64, and ClickHouse
+  // rejects a TTL whose result is not Date or DateTime ("TTL expression result
+  // column should have DateTime or Date type"). A remediation line that fails
+  // when pasted is worse than none, so emit the form that actually runs. On a
+  // plain DateTime column the wrapper is a no-op.
+  const expected = `toDateTime(${desired.column}) + toIntervalDay(${desired.ttlDays})`;
+  const fix = `ALTER TABLE ${desired.table} MODIFY TTL toDateTime(${desired.column}) + INTERVAL ${desired.ttlDays} DAY;`;
 
   if (liveExpression === undefined || liveExpression.trim() === '') {
     return {
       resource: 'clickhouse-ttl',
       summary: `${desired.table}: no TTL set`,
-      detail:
-        `${desired.reason}\n` +
-        `Expected roughly: ${expected}\n` +
-        `Fix: ALTER TABLE ${desired.table} MODIFY TTL ${desired.column} + INTERVAL ${desired.ttlDays} DAY;`,
+      detail: `${desired.reason}\n` + `Expected roughly: ${expected}\n` + `Fix: ${fix}`,
       blocked: true,
     };
   }
@@ -214,7 +217,7 @@ export function diffTableRetention(
       `Live: ${liveExpression}\n` +
       `Expected roughly: ${expected}\n` +
       `A server upgrade can recreate these tables and drop a TTL we set out of band.\n` +
-      `Fix: ALTER TABLE ${desired.table} MODIFY TTL ${desired.column} + INTERVAL ${desired.ttlDays} DAY;`,
+      `Fix: ${fix}`,
     blocked: true,
   };
 }

--- a/infra/railway/plan.ts
+++ b/infra/railway/plan.ts
@@ -228,13 +228,6 @@ export function diffTableRetention(
 }
 
 /**
- * Build the full plan.
- *
- * Order is service existence -> variables -> retention, so the output reads
- * outside-in: a missing service explains its own missing variables, and the
- * retention rows only make sense once ClickHouse exists at all.
- */
-/**
  * Diff the ClickHouse volume's utilisation against its declared budget.
  *
  * Reported as blocked because there is nothing this tool can safely do about it:
@@ -262,6 +255,13 @@ export function diffVolumeUsage(
   };
 }
 
+/**
+ * Build the full plan.
+ *
+ * Order is service existence -> variables -> retention -> disk, so the output
+ * reads outside-in: a missing service explains its own missing variables, and
+ * the retention and disk rows only make sense once ClickHouse exists at all.
+ */
 export function buildPlan(desired: RailwayDesiredState, live: LiveState, options: PlanOptions): PlannedChange[] {
   const changes: PlannedChange[] = [];
 

--- a/infra/railway/plan.ts
+++ b/infra/railway/plan.ts
@@ -1,0 +1,263 @@
+/// <reference types="node" />
+
+// Pure planning logic for the Railway apply tool: diff desired-vs-live and decide
+// what may be converged automatically and what may only be reported. No I/O, no
+// globals — everything here is deterministic and unit-tested in
+// scripts/railway-apply.test.ts. The I/O (fetching live state, applying changes)
+// lives in scripts/railway-apply.ts.
+//
+// Three safety rules are encoded here rather than in the apply layer, so they are
+// testable without a live project and cannot be bypassed by a caller:
+//
+//   1. Never delete. A live service or variable absent from config is reported and
+//      left alone, the way the Cloudflare tool preserves foreign rules verbatim.
+//   2. Never overwrite a value that is already set and not a placeholder. Only
+//      `absent` and `placeholder` are drift this tool will fix.
+//   3. Never surface a secret value. Variables are reduced to a three-state
+//      classification before they reach a PlannedChange, so no code path can print
+//      a DSN or a token.
+
+import {
+  PLACEHOLDER_PATTERN,
+  type RailwayDesiredState,
+  type ServiceDesired,
+  type TableRetentionDesired,
+} from './config';
+
+/** A service as Railway reports it. */
+export interface LiveService {
+  id: string;
+  name: string;
+}
+
+/**
+ * Live state for one environment.
+ *
+ * `variables` maps service name -> variable name -> raw value. The raw values are
+ * needed to classify placeholder-vs-set and never leave this module: `classifyVar`
+ * is the only thing that reads them, and it returns a state, not a value.
+ */
+export interface LiveState {
+  services: LiveService[];
+  variables: Record<string, Record<string, string>>;
+  /**
+   * Live TTL expressions keyed by table name, as read from ClickHouse's
+   * system.tables. `null` means the retention check did not run — no ClickHouse
+   * DSN was available to the tool — which is a skip, not a failure.
+   */
+  clickhouseTtl: Record<string, string> | null;
+}
+
+export type VarState = 'set' | 'absent' | 'placeholder';
+
+export interface PlannedChange {
+  resource: 'service' | 'env-var' | 'volume' | 'clickhouse-ttl';
+  /** One-line human-readable summary of what would change. Never contains a secret value. */
+  summary: string;
+  /** Optional extra context printed under the summary. */
+  detail?: string;
+  /** Present for env-var changes so the apply layer can select the right service/variable. */
+  target?: { serviceName: string; varName: string };
+  /**
+   * true = a change that is NOT auto-applied. Creating a stateful service, and
+   * anything that would remove live configuration, are reported for a human.
+   */
+  blocked?: boolean;
+}
+
+export interface PlanOptions {
+  /**
+   * Keys (`"<service>:<VAR>"`) whose value the apply layer actually holds, having
+   * found it in its own environment as `RAILWAY_VAR_<VAR>`.
+   *
+   * This is what separates "drift we can fix" from "drift we can only report".
+   * Keeping it a plain set of keys — never the values — is what lets the whole plan
+   * layer stay pure and keeps secrets out of every PlannedChange.
+   */
+  suppliedVars: ReadonlySet<string>;
+}
+
+/** The key shape used by PlanOptions.suppliedVars. */
+export function varKey(serviceName: string, varName: string): string {
+  return `${serviceName}:${varName}`;
+}
+
+/**
+ * Reduce a raw variable to the only three states this tool distinguishes.
+ *
+ * A placeholder is treated as absent-with-a-hint rather than as set: it passes a
+ * naive "is it defined?" check and then fails at boot, which is the confusing
+ * failure this classification exists to prevent.
+ */
+export function classifyVar(rawValue: string | undefined): VarState {
+  if (rawValue === undefined) return 'absent';
+  const trimmed = rawValue.trim();
+  if (trimmed === '') return 'absent';
+  if (PLACEHOLDER_PATTERN.test(trimmed)) return 'placeholder';
+  return 'set';
+}
+
+/** Find a live service by name. Names are Railway-unique within an environment. */
+export function findService(live: LiveState, name: string): LiveService | null {
+  return live.services.find((service) => service.name === name) ?? null;
+}
+
+/**
+ * Diff one declared service's existence.
+ *
+ * An `assert-only` service that is missing is an error in the config or a renamed
+ * service — either way a human question, so it is blocked rather than created.
+ */
+export function diffService(desired: ServiceDesired, live: LiveState): PlannedChange | null {
+  if (findService(live, desired.name)) return null;
+
+  if (desired.management === 'report-only' && desired.expected) {
+    return {
+      resource: 'service',
+      summary: `Service "${desired.name}" does not exist`,
+      detail:
+        `Create it in Railway with image ${desired.expected.image} and a persistent volume ` +
+        `mounted at ${desired.expected.volumeMountPath}, in the same project so private ` +
+        `networking reaches it.\n` +
+        `Not created automatically: a ClickHouse service without a volume looks healthy and ` +
+        `loses every row on redeploy.`,
+      blocked: true,
+    };
+  }
+
+  return {
+    resource: 'service',
+    summary: `Service "${desired.name}" does not exist`,
+    detail:
+      `Expected an existing service to assert against. Either it was renamed, or this tool is ` +
+      `pointed at the wrong Railway project/environment.`,
+    blocked: true,
+  };
+}
+
+/**
+ * Diff the variables one service must carry.
+ *
+ * Returns nothing for a service that does not exist — diffService already reported
+ * that, and repeating it once per variable buries the real message.
+ */
+export function diffServiceVars(desired: ServiceDesired, live: LiveState, options: PlanOptions): PlannedChange[] {
+  if (!findService(live, desired.name)) return [];
+
+  const serviceVars = live.variables[desired.name] ?? {};
+  const changes: PlannedChange[] = [];
+
+  for (const required of desired.requiredVars) {
+    const state = classifyVar(serviceVars[required.name]);
+    if (state === 'set') continue;
+
+    const supplied = options.suppliedVars.has(varKey(desired.name, required.name));
+
+    changes.push({
+      resource: 'env-var',
+      summary: `${desired.name}: ${required.name} is ${state}`,
+      detail:
+        `${required.reason}\n` +
+        (state === 'placeholder'
+          ? 'The variable still holds an unfilled <placeholder> value and will fail at boot.'
+          : 'The variable is not set on this service.') +
+        `\n` +
+        (supplied
+          ? `A value is available as RAILWAY_VAR_${required.name}; --apply will set it.`
+          : `No value available. Export RAILWAY_VAR_${required.name} to let --apply set it, ` +
+            `or set it directly in Railway.`),
+      target: { serviceName: desired.name, varName: required.name },
+      // Convergeable only when the caller actually supplied a value. Without one
+      // this is a report, not a fix — the tool never invents a secret.
+      blocked: !supplied,
+    });
+  }
+
+  return changes;
+}
+
+/**
+ * Diff one table's retention against the live TTL expression.
+ *
+ * The comparison is intentionally loose — ClickHouse normalizes a TTL expression
+ * when it stores it, so matching the column name and the day count is the honest
+ * check. An exact string match would report drift on every server that formats it
+ * differently.
+ */
+export function diffTableRetention(
+  desired: TableRetentionDesired,
+  liveExpression: string | undefined,
+): PlannedChange | null {
+  const expected = `${desired.column} + toIntervalDay(${desired.ttlDays})`;
+
+  if (liveExpression === undefined || liveExpression.trim() === '') {
+    return {
+      resource: 'clickhouse-ttl',
+      summary: `${desired.table}: no TTL set`,
+      detail:
+        `${desired.reason}\n` +
+        `Expected roughly: ${expected}\n` +
+        `Fix: ALTER TABLE ${desired.table} MODIFY TTL ${desired.column} + INTERVAL ${desired.ttlDays} DAY;`,
+      blocked: true,
+    };
+  }
+
+  const normalized = liveExpression.replace(/\s+/g, '');
+  const mentionsColumn = normalized.includes(desired.column);
+  const mentionsDays = new RegExp(`toIntervalDay\\(${desired.ttlDays}\\)`).test(normalized);
+  if (mentionsColumn && mentionsDays) return null;
+
+  return {
+    resource: 'clickhouse-ttl',
+    summary: `${desired.table}: TTL is not ${desired.ttlDays} days`,
+    detail:
+      `Live: ${liveExpression}\n` +
+      `Expected roughly: ${expected}\n` +
+      `A server upgrade can recreate these tables and drop a TTL we set out of band.\n` +
+      `Fix: ALTER TABLE ${desired.table} MODIFY TTL ${desired.column} + INTERVAL ${desired.ttlDays} DAY;`,
+    blocked: true,
+  };
+}
+
+/**
+ * Build the full plan.
+ *
+ * Order is service existence -> variables -> retention, so the output reads
+ * outside-in: a missing service explains its own missing variables, and the
+ * retention rows only make sense once ClickHouse exists at all.
+ */
+export function buildPlan(desired: RailwayDesiredState, live: LiveState, options: PlanOptions): PlannedChange[] {
+  const changes: PlannedChange[] = [];
+
+  for (const service of desired.services) {
+    const serviceChange = diffService(service, live);
+    if (serviceChange) changes.push(serviceChange);
+  }
+
+  for (const service of desired.services) {
+    changes.push(...diffServiceVars(service, live, options));
+  }
+
+  // A null map means the check was skipped for want of a DSN, which must not read
+  // as "retention is fine". The apply layer prints the skip separately.
+  if (live.clickhouseTtl !== null) {
+    for (const table of desired.clickhouseRetention) {
+      const change = diffTableRetention(table, live.clickhouseTtl[table.table]);
+      if (change) changes.push(change);
+    }
+  }
+
+  return changes;
+}
+
+/**
+ * Live services this repo does not declare.
+ *
+ * Reported so a human can decide, never removed — the Railway project holds
+ * Postgres and other services on purpose, and a tool that deleted what it did not
+ * recognise would be a catastrophe rather than a convenience.
+ */
+export function undeclaredServices(desired: RailwayDesiredState, live: LiveState): string[] {
+  const declared = new Set(desired.services.map((service) => service.name));
+  return live.services.map((service) => service.name).filter((name) => !declared.has(name));
+}

--- a/infra/railway/plan.ts
+++ b/infra/railway/plan.ts
@@ -46,12 +46,17 @@ export interface LiveState {
    * DSN was available to the tool — which is a skip, not a failure.
    */
   clickhouseTtl: Record<string, string> | null;
+  /**
+   * ClickHouse volume utilisation. `null` means the reading was unavailable,
+   * which is a skip rather than "there is plenty of room".
+   */
+  clickhouseVolume: { usedMb: number; capacityMb: number } | null;
 }
 
 export type VarState = 'set' | 'absent' | 'placeholder';
 
 export interface PlannedChange {
-  resource: 'service' | 'env-var' | 'volume' | 'clickhouse-ttl';
+  resource: 'service' | 'env-var' | 'volume' | 'volume-usage' | 'clickhouse-ttl';
   /** One-line human-readable summary of what would change. Never contains a secret value. */
   summary: string;
   /** Optional extra context printed under the summary. */
@@ -229,6 +234,34 @@ export function diffTableRetention(
  * outside-in: a missing service explains its own missing variables, and the
  * retention rows only make sense once ClickHouse exists at all.
  */
+/**
+ * Diff the ClickHouse volume's utilisation against its declared budget.
+ *
+ * Reported as blocked because there is nothing this tool can safely do about it:
+ * growing a volume and deleting data are both decisions for a human.
+ */
+export function diffVolumeUsage(
+  limitPercent: number,
+  live: { usedMb: number; capacityMb: number } | null,
+): PlannedChange | null {
+  if (live === null || live.capacityMb <= 0) return null;
+
+  const usedPercent = (live.usedMb / live.capacityMb) * 100;
+  if (usedPercent < limitPercent) return null;
+
+  const gb = (mb: number) => (mb / 1024).toFixed(1);
+  return {
+    resource: 'volume-usage',
+    summary: `ClickHouse volume is ${usedPercent.toFixed(1)}% full (limit ${limitPercent}%)`,
+    detail:
+      `Using ${gb(live.usedMb)} GiB of ${gb(live.capacityMb)} GiB.\n` +
+      `A full volume stops ClickHouse accepting writes, and xprem exits at boot when\n` +
+      `ClickHouse is unreachable — so a full disk here also blocks the next OTA restart.\n` +
+      `Fix: grow the volume in Railway, or shorten a retention window in config.ts.`,
+    blocked: true,
+  };
+}
+
 export function buildPlan(desired: RailwayDesiredState, live: LiveState, options: PlanOptions): PlannedChange[] {
   const changes: PlannedChange[] = [];
 
@@ -249,6 +282,9 @@ export function buildPlan(desired: RailwayDesiredState, live: LiveState, options
       if (change) changes.push(change);
     }
   }
+
+  const volumeChange = diffVolumeUsage(desired.clickhouseVolumeUsageLimitPercent, live.clickhouseVolume);
+  if (volumeChange) changes.push(volumeChange);
 
   return changes;
 }

--- a/scripts/__tests__/ci-capacity-workflows.test.ts
+++ b/scripts/__tests__/ci-capacity-workflows.test.ts
@@ -30,7 +30,6 @@ describe('PR workflow capacity controls', () => {
     ['claude-code-review.yml', 'cancel-in-progress: true'],
     ['dev-db-docker.yml', "cancel-in-progress: ${{ github.event_name == 'pull_request' }}"],
     ['service-deploy-inputs.yml', "cancel-in-progress: ${{ github.event_name == 'pull_request' }}"],
-    ['postgres-image-publisher-contract.yml', "cancel-in-progress: ${{ github.event_name == 'pull_request' }}"],
     ['firmware-tests.yml', "cancel-in-progress: ${{ github.event_name == 'pull_request' }}"],
   ])('cancels superseded PR-head runs in %s', (name, cancellation) => {
     const source = workflow(name);

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -80,7 +80,10 @@ function getCommitSubject(): string {
 // lands on main. Locally the clean-tree check stays on — otherwise
 // `vp run mobile:publish -- --channel production` would ship a developer's
 // scratch edits to the fleet.
-export function shouldAllowDirtyTree(env: NodeJS.ProcessEnv = process.env): boolean {
+// Reads one key, so it takes one key's worth of type. NodeJS.ProcessEnv now
+// requires NODE_ENV, which made every `{ GITHUB_ACTIONS: 'true' }` in the tests
+// a type error without saying anything true about what this needs.
+export function shouldAllowDirtyTree(env: Record<string, string | undefined> = process.env): boolean {
   return env.GITHUB_ACTIONS === 'true';
 }
 

--- a/scripts/railway-apply.test.ts
+++ b/scripts/railway-apply.test.ts
@@ -652,3 +652,151 @@ describe('diffVolumeUsage', () => {
     expect(plan.filter((change) => change.resource === 'volume-usage')).toHaveLength(1);
   });
 });
+
+describe('apply mode', () => {
+  // The mutation path: the only thing this tool writes, and the only place a bug
+  // reaches the server every production binary talks to.
+  const SECRET_VALUE = 'clickhouse://svc:hunter2@ch.railway.internal:9000/expo_observe';
+
+  interface Upsert {
+    serviceId: string;
+    name: string;
+    value: string;
+  }
+
+  function collectStdout(): { lines: string[]; restore: () => void } {
+    const lines: string[] = [];
+    const originalLog = console.log;
+    const originalWarn = console.warn;
+    console.log = (...args: unknown[]) => void lines.push(args.join(' '));
+    console.warn = (...args: unknown[]) => void lines.push(args.join(' '));
+    return {
+      lines,
+      restore: () => {
+        console.log = originalLog;
+        console.warn = originalWarn;
+      },
+    };
+  }
+
+  function stubApply(variables: Record<string, string>): {
+    fetch: typeof globalThis.fetch;
+    upserts: Upsert[];
+  } {
+    const upserts: Upsert[] = [];
+    const fetchStub = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const rawBody = typeof init?.body === 'string' ? init.body : '{}';
+      const body = JSON.parse(rawBody) as { query: string; variables: Record<string, unknown> };
+
+      if (body.query.includes('variableUpsert')) {
+        upserts.push((body.variables as { input: Upsert }).input);
+        return new Response(JSON.stringify({ data: { variableUpsert: true } }), { status: 200 });
+      }
+      if (body.query.includes('volumes {')) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              project: {
+                volumes: {
+                  edges: [
+                    {
+                      node: {
+                        name: CLICKHOUSE_VOLUME_NAME,
+                        volumeInstances: {
+                          edges: [{ node: { sizeMB: 50000, currentSizeMB: 853, mountPath: '/var/lib/clickhouse' } }],
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      if (body.query.includes('variables(')) {
+        return new Response(JSON.stringify({ data: { variables } }), { status: 200 });
+      }
+      return new Response(
+        JSON.stringify({
+          data: {
+            project: {
+              name: 'boardsesh-ota',
+              environments: { edges: [{ node: { id: 'env-prod', name: 'production' } }] },
+              services: {
+                edges: [
+                  { node: { id: 'svc-ota', name: OTA_SERVICE_NAME } },
+                  { node: { id: 'svc-ch', name: CLICKHOUSE_SERVICE_NAME } },
+                ],
+              },
+            },
+          },
+        }),
+        { status: 200 },
+      );
+    }) as typeof globalThis.fetch;
+
+    return { fetch: fetchStub, upserts };
+  }
+
+  async function runApply(
+    variables: Record<string, string>,
+    env: Record<string, string> = {},
+  ): Promise<{ code: number; output: string; upserts: Upsert[] }> {
+    const originalFetch = globalThis.fetch;
+    const originalEnv = { ...process.env };
+    const captured = collectStdout();
+    const stub = stubApply(variables);
+
+    globalThis.fetch = stub.fetch;
+    process.env.RAILWAY_TOKEN = 'test-token';
+    process.env.RAILWAY_PROJECT_ID = 'test-project';
+    delete process.env.CLICKHOUSE_URL;
+    for (const [key, value] of Object.entries(env)) process.env[key] = value;
+
+    try {
+      const code = await main(['--apply']);
+      return { code, output: captured.lines.join('\n'), upserts: stub.upserts };
+    } finally {
+      captured.restore();
+      globalThis.fetch = originalFetch;
+      process.env = originalEnv;
+    }
+  }
+
+  it('writes the missing variable when handed its value', async () => {
+    const { code, upserts } = await runApply({}, { RAILWAY_VAR_CLICKHOUSE_URL: SECRET_VALUE });
+    expect(code).toBe(0);
+    expect(upserts).toEqual([
+      {
+        projectId: 'test-project',
+        environmentId: 'env-prod',
+        serviceId: 'svc-ota',
+        name: 'CLICKHOUSE_URL',
+        value: SECRET_VALUE,
+      },
+    ]);
+  });
+
+  it('writes nothing at all when the project is already converged', async () => {
+    const { code, upserts } = await runApply({ CLICKHOUSE_URL: SECRET_VALUE });
+    expect(code).toBe(0);
+    expect(upserts).toEqual([]);
+  });
+
+  it('refuses to invent a value it was not given', async () => {
+    // Drift with no RAILWAY_VAR_*: the change is blocked, so nothing is written
+    // and the run still exits non-zero.
+    const { code, upserts, output } = await runApply({});
+    expect(upserts).toEqual([]);
+    expect(code).toBe(1);
+    expect(output).toContain('blocked');
+  });
+
+  it('never prints the value it just wrote', async () => {
+    const { output } = await runApply({}, { RAILWAY_VAR_CLICKHOUSE_URL: SECRET_VALUE });
+    expect(output).not.toContain('hunter2');
+    expect(output).not.toContain(SECRET_VALUE);
+  });
+});

--- a/scripts/railway-apply.test.ts
+++ b/scripts/railway-apply.test.ts
@@ -544,7 +544,9 @@ describe('fetchClickHouseTtl', () => {
     const originalFetch = globalThis.fetch;
     const calls: { url: string; init?: RequestInit }[] = [];
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-      calls.push({ url: String(input), init });
+      // String() on a Request would give '[object Object]'; read the URL off it.
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      calls.push({ url, init });
       return stub(input as RequestInfo, init);
     }) as typeof globalThis.fetch;
     try {

--- a/scripts/railway-apply.test.ts
+++ b/scripts/railway-apply.test.ts
@@ -20,7 +20,7 @@ import {
   varKey,
 } from '../infra/railway/plan';
 import type { LiveState } from '../infra/railway/plan';
-import { collectSuppliedVars, main, parseArgs, suppliedVarKeys } from './railway-apply';
+import { collectSuppliedVars, main, parseArgs, suppliedVarKeys, ttlFromEngineFull } from './railway-apply';
 
 const NO_SUPPLIED = { suppliedVars: new Set<string>() };
 
@@ -308,5 +308,46 @@ describe('main', () => {
     const { output } = await runMain({}, { RAILWAY_VAR_CLICKHOUSE_URL: SECRET_DSN });
     expect(output).toContain('Values supplied for: CLICKHOUSE_URL');
     expect(output).not.toContain('hunter2');
+  });
+});
+
+describe('ttlFromEngineFull', () => {
+  // Verbatim from ClickHouse 25.3 after the retention ALTER landed.
+  const WITH_TTL =
+    'MergeTree PARTITION BY toYYYYMM(timestamp) ORDER BY (app_id, update_id, timestamp) ' +
+    'TTL toDateTime(timestamp) + toIntervalDay(90) SETTINGS index_granularity = 8192';
+
+  it('reads the TTL clause out of engine_full', () => {
+    expect(ttlFromEngineFull(WITH_TTL)).toBe('toDateTime(timestamp) + toIntervalDay(90)');
+  });
+
+  it('stops at SETTINGS rather than swallowing it', () => {
+    expect(ttlFromEngineFull(WITH_TTL)).not.toContain('index_granularity');
+  });
+
+  it('handles a TTL that runs to the end of the string', () => {
+    expect(ttlFromEngineFull('MergeTree ORDER BY x TTL toDateTime(ts) + toIntervalDay(7)')).toBe(
+      'toDateTime(ts) + toIntervalDay(7)',
+    );
+  });
+
+  it('reports a table with no TTL as empty, which the plan reads as "no retention"', () => {
+    const noTtl = 'MergeTree PARTITION BY toYYYYMM(bucket) ORDER BY (app_id) SETTINGS index_granularity = 8192';
+    expect(ttlFromEngineFull(noTtl)).toBe('');
+    expect(diffTableRetention(CLICKHOUSE_RETENTION[0], ttlFromEngineFull(noTtl))?.summary).toContain('no TTL set');
+  });
+});
+
+describe('the retention remediation line', () => {
+  // ClickHouse rejects a TTL on a DateTime64 column, and both of these are
+  // DateTime64(9). A Fix: line that fails when pasted is worse than none.
+  it('wraps the column so the suggested ALTER actually runs', () => {
+    const change = diffTableRetention(CLICKHOUSE_RETENTION[0], '');
+    expect(change?.detail).toContain(`MODIFY TTL toDateTime(${CLICKHOUSE_RETENTION[0].column})`);
+  });
+
+  it('suggests the same form when the window is merely wrong', () => {
+    const change = diffTableRetention(CLICKHOUSE_RETENTION[1], 'toDateTime(timestamp) + toIntervalDay(31)');
+    expect(change?.detail).toContain('MODIFY TTL toDateTime(timestamp)');
   });
 });

--- a/scripts/railway-apply.test.ts
+++ b/scripts/railway-apply.test.ts
@@ -1,0 +1,312 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  CLICKHOUSE_RETENTION,
+  CLICKHOUSE_SERVICE_NAME,
+  OTA_SERVICE_NAME,
+  PLACEHOLDER_PATTERN,
+  desiredRailwayState,
+} from '../infra/railway/config';
+import {
+  buildPlan,
+  classifyVar,
+  diffService,
+  diffServiceVars,
+  diffTableRetention,
+  findService,
+  undeclaredServices,
+  varKey,
+} from '../infra/railway/plan';
+import type { LiveState } from '../infra/railway/plan';
+import { collectSuppliedVars, main, parseArgs, suppliedVarKeys } from './railway-apply';
+
+const NO_SUPPLIED = { suppliedVars: new Set<string>() };
+
+function liveState(overrides: Partial<LiveState> = {}): LiveState {
+  return {
+    services: [
+      { id: 'svc-ota', name: OTA_SERVICE_NAME },
+      { id: 'svc-ch', name: CLICKHOUSE_SERVICE_NAME },
+    ],
+    variables: { [OTA_SERVICE_NAME]: { CLICKHOUSE_URL: 'clickhouse://u:p@host:9000/expo_observe' } },
+    clickhouseTtl: {
+      observe_metrics: 'timestamp + toIntervalDay(90)',
+      observe_logs: 'timestamp + toIntervalDay(30)',
+    },
+    ...overrides,
+  };
+}
+
+describe('parseArgs', () => {
+  it('defaults to a dry run', () => {
+    expect(parseArgs([])).toEqual({ apply: false, help: false });
+  });
+
+  it('accepts --apply and the -- separator vp forwards', () => {
+    expect(parseArgs(['--', '--apply'])).toEqual({ apply: true, help: false });
+  });
+
+  it('rejects a typo rather than silently dry-running', () => {
+    expect(() => parseArgs(['--appply'])).toThrow(/Unknown flag/);
+  });
+});
+
+describe('classifyVar', () => {
+  it('treats an unfilled eoas placeholder as not set', () => {
+    expect(classifyVar('<clickhouse://user:password@host:9000/xprem>')).toBe('placeholder');
+    expect(PLACEHOLDER_PATTERN.test('<clickhouse://user:password@host:9000/xprem>')).toBe(true);
+  });
+
+  it('treats undefined and whitespace as absent', () => {
+    expect(classifyVar(undefined)).toBe('absent');
+    expect(classifyVar('   ')).toBe('absent');
+  });
+
+  it('treats a real DSN as set', () => {
+    expect(classifyVar('clickhouse://u:p@host:9000/expo_observe')).toBe('set');
+  });
+});
+
+describe('diffService', () => {
+  it('is silent when the service exists', () => {
+    expect(diffService(desiredRailwayState.services[0], liveState())).toBeNull();
+  });
+
+  it('blocks rather than creates a missing stateful service', () => {
+    const live = liveState({ services: [{ id: 'svc-ota', name: OTA_SERVICE_NAME }] });
+    const change = diffService(desiredRailwayState.services[1], live);
+    expect(change).toMatchObject({ resource: 'service', blocked: true });
+    expect(change?.detail).toMatch(/persistent volume/);
+  });
+});
+
+describe('diffServiceVars', () => {
+  const otaService = desiredRailwayState.services[0];
+
+  it('is silent when the variable is set', () => {
+    expect(diffServiceVars(otaService, liveState(), NO_SUPPLIED)).toEqual([]);
+  });
+
+  it('reports an absent variable and blocks it when no value was supplied', () => {
+    const live = liveState({ variables: { [OTA_SERVICE_NAME]: {} } });
+    const [change] = diffServiceVars(otaService, live, NO_SUPPLIED);
+    expect(change).toMatchObject({ resource: 'env-var', blocked: true });
+    expect(change.summary).toContain('absent');
+  });
+
+  it('unblocks the change when the caller supplied a value', () => {
+    const live = liveState({ variables: { [OTA_SERVICE_NAME]: {} } });
+    const supplied = { suppliedVars: new Set([varKey(OTA_SERVICE_NAME, 'CLICKHOUSE_URL')]) };
+    const [change] = diffServiceVars(otaService, live, supplied);
+    expect(change.blocked).toBe(false);
+  });
+
+  it('flags a placeholder that a naive is-it-set check would pass', () => {
+    const live = liveState({
+      variables: { [OTA_SERVICE_NAME]: { CLICKHOUSE_URL: '<clickhouse://user:password@host:9000/xprem>' } },
+    });
+    const [change] = diffServiceVars(otaService, live, NO_SUPPLIED);
+    expect(change.summary).toContain('placeholder');
+  });
+
+  it('stays quiet about variables on a service that does not exist', () => {
+    const live = liveState({ services: [] });
+    expect(diffServiceVars(otaService, live, NO_SUPPLIED)).toEqual([]);
+  });
+
+  it('never puts a variable value in the plan output', () => {
+    const secret = 'clickhouse://user:hunter2@host:9000/expo_observe';
+    const live = liveState({ variables: { [OTA_SERVICE_NAME]: { CLICKHOUSE_URL: `<${secret}>` } } });
+    const [change] = diffServiceVars(otaService, live, NO_SUPPLIED);
+    expect(JSON.stringify(change)).not.toContain('hunter2');
+  });
+});
+
+describe('diffTableRetention', () => {
+  const metrics = CLICKHOUSE_RETENTION[0];
+
+  it('accepts a matching TTL regardless of whitespace', () => {
+    expect(diffTableRetention(metrics, 'timestamp  +  toIntervalDay(90)')).toBeNull();
+  });
+
+  it('reports a table with no TTL at all', () => {
+    const change = diffTableRetention(metrics, '');
+    expect(change).toMatchObject({ resource: 'clickhouse-ttl', blocked: true });
+    expect(change?.detail).toMatch(/ALTER TABLE observe_metrics MODIFY TTL/);
+  });
+
+  it('reports a TTL that drifted to a different window', () => {
+    const change = diffTableRetention(metrics, 'timestamp + toIntervalDay(7)');
+    expect(change?.summary).toContain('not 90 days');
+  });
+});
+
+describe('buildPlan', () => {
+  it('is empty when everything matches', () => {
+    expect(buildPlan(desiredRailwayState, liveState(), NO_SUPPLIED)).toEqual([]);
+  });
+
+  it('skips the retention check entirely when ClickHouse was not reachable', () => {
+    const plan = buildPlan(desiredRailwayState, liveState({ clickhouseTtl: null }), NO_SUPPLIED);
+    expect(plan.filter((change) => change.resource === 'clickhouse-ttl')).toEqual([]);
+  });
+
+  it('does not repeat variable drift for a service it already reported missing', () => {
+    const live = liveState({ services: [], variables: {} });
+    const plan = buildPlan(desiredRailwayState, live, NO_SUPPLIED);
+    expect(plan.filter((change) => change.resource === 'env-var')).toEqual([]);
+    expect(plan.filter((change) => change.resource === 'service')).toHaveLength(2);
+  });
+
+  it('reports missing TTLs', () => {
+    const plan = buildPlan(desiredRailwayState, liveState({ clickhouseTtl: {} }), NO_SUPPLIED);
+    expect(plan.filter((change) => change.resource === 'clickhouse-ttl')).toHaveLength(2);
+  });
+});
+
+describe('undeclaredServices', () => {
+  it('reports a foreign service without proposing to remove it', () => {
+    const live = liveState({
+      services: [
+        { id: 'svc-ota', name: OTA_SERVICE_NAME },
+        { id: 'svc-ch', name: CLICKHOUSE_SERVICE_NAME },
+        { id: 'svc-pg', name: 'Postgres' },
+      ],
+    });
+    expect(undeclaredServices(desiredRailwayState, live)).toEqual(['Postgres']);
+    const plan = buildPlan(desiredRailwayState, live, NO_SUPPLIED);
+    expect(plan.some((change) => /Postgres/.test(change.summary))).toBe(false);
+  });
+});
+
+describe('supplied values', () => {
+  it('picks up RAILWAY_VAR_* and ignores everything else', () => {
+    const supplied = collectSuppliedVars({
+      RAILWAY_VAR_CLICKHOUSE_URL: 'clickhouse://u:p@h:9000/expo_observe',
+      RAILWAY_TOKEN: 'not-a-variable-value',
+      RAILWAY_VAR_EMPTY: '  ',
+    });
+    expect([...supplied.keys()]).toEqual(['CLICKHOUSE_URL']);
+  });
+
+  it('only keys variables the config actually declares', () => {
+    const supplied = new Map([
+      ['CLICKHOUSE_URL', 'dsn'],
+      ['JWT_SECRET', 'should-be-ignored'],
+    ]);
+    const keys = suppliedVarKeys(desiredRailwayState, supplied);
+    expect([...keys]).toEqual([varKey(OTA_SERVICE_NAME, 'CLICKHOUSE_URL')]);
+  });
+});
+
+describe('findService', () => {
+  it('matches by name', () => {
+    expect(findService(liveState(), OTA_SERVICE_NAME)?.id).toBe('svc-ota');
+    expect(findService(liveState(), 'nope')).toBeNull();
+  });
+});
+
+/**
+ * End-to-end coverage of the I/O layer against a stubbed Railway API. The unit
+ * tests above cover the diffing; this covers the wiring the diffing sits behind —
+ * environment resolution, the variables fetch, the exit codes CI gates on, and the
+ * promise that a DSN never reaches stdout.
+ */
+describe('main', () => {
+  const SECRET_DSN = 'clickhouse://svc:hunter2@ch.railway.internal:9000/expo_observe';
+
+  function stubRailway(variables: Record<string, string>): typeof globalThis.fetch {
+    return (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      // The client always sends a JSON string; narrowing beats String() on the
+      // BodyInit union, which would stringify a Blob to '[object Object]'.
+      const rawBody = typeof init?.body === 'string' ? init.body : '{}';
+      const body = JSON.parse(rawBody) as { query: string };
+      const data = body.query.includes('variables(')
+        ? { variables }
+        : {
+            project: {
+              name: 'boardsesh-ota',
+              environments: { edges: [{ node: { id: 'env-prod', name: 'production' } }] },
+              services: {
+                edges: [
+                  { node: { id: 'svc-ota', name: OTA_SERVICE_NAME } },
+                  { node: { id: 'svc-ch', name: CLICKHOUSE_SERVICE_NAME } },
+                ],
+              },
+            },
+          };
+      return new Response(JSON.stringify({ data }), { status: 200 });
+    }) as typeof globalThis.fetch;
+  }
+
+  function captureStdout(): { lines: string[]; restore: () => void } {
+    const lines: string[] = [];
+    const originalLog = console.log;
+    const originalWarn = console.warn;
+    console.log = (...args: unknown[]) => void lines.push(args.join(' '));
+    console.warn = (...args: unknown[]) => void lines.push(args.join(' '));
+    return {
+      lines,
+      restore: () => {
+        console.log = originalLog;
+        console.warn = originalWarn;
+      },
+    };
+  }
+
+  async function runMain(
+    variables: Record<string, string>,
+    env: Record<string, string> = {},
+  ): Promise<{ code: number; output: string }> {
+    const originalFetch = globalThis.fetch;
+    const originalEnv = { ...process.env };
+    const captured = captureStdout();
+
+    globalThis.fetch = stubRailway(variables);
+    process.env.RAILWAY_TOKEN = 'test-token';
+    process.env.RAILWAY_PROJECT_ID = 'test-project';
+    delete process.env.CLICKHOUSE_URL;
+    for (const [key, value] of Object.entries(env)) process.env[key] = value;
+
+    try {
+      const code = await main([]);
+      return { code, output: captured.lines.join('\n') };
+    } finally {
+      captured.restore();
+      globalThis.fetch = originalFetch;
+      process.env = originalEnv;
+    }
+  }
+
+  it('exits 0 and reports in-sync when the variable is set', async () => {
+    const { code, output } = await runMain({ CLICKHOUSE_URL: SECRET_DSN });
+    expect(code).toBe(0);
+    expect(output).toContain('In sync');
+  });
+
+  it('exits non-zero on drift so CI can gate on it', async () => {
+    const { code, output } = await runMain({});
+    expect(code).toBe(1);
+    expect(output).toContain('CLICKHOUSE_URL is absent');
+    expect(output).toContain('Dry-run');
+  });
+
+  it('skips the retention check, rather than passing it, without a ClickHouse DSN', async () => {
+    const { output } = await runMain({ CLICKHOUSE_URL: SECRET_DSN });
+    expect(output).toContain('Retention check skipped');
+  });
+
+  it('never prints a variable value, even the one it read', async () => {
+    const { output } = await runMain({ CLICKHOUSE_URL: SECRET_DSN });
+    expect(output).not.toContain('hunter2');
+    expect(output).not.toContain(SECRET_DSN);
+  });
+
+  it('names a supplied value without printing it', async () => {
+    const { output } = await runMain({}, { RAILWAY_VAR_CLICKHOUSE_URL: SECRET_DSN });
+    expect(output).toContain('Values supplied for: CLICKHOUSE_URL');
+    expect(output).not.toContain('hunter2');
+  });
+});

--- a/scripts/railway-apply.test.ts
+++ b/scripts/railway-apply.test.ts
@@ -20,7 +20,15 @@ import {
   varKey,
 } from '../infra/railway/plan';
 import type { LiveState } from '../infra/railway/plan';
-import { collectSuppliedVars, main, parseArgs, suppliedVarKeys, ttlFromEngineFull } from './railway-apply';
+import {
+  collectSuppliedVars,
+  fetchClickHouseTtl,
+  main,
+  parseArgs,
+  resetAuthScheme,
+  suppliedVarKeys,
+  ttlFromEngineFull,
+} from './railway-apply';
 
 const NO_SUPPLIED = { suppliedVars: new Set<string>() };
 
@@ -349,5 +357,193 @@ describe('the retention remediation line', () => {
   it('suggests the same form when the window is merely wrong', () => {
     const change = diffTableRetention(CLICKHOUSE_RETENTION[1], 'toDateTime(timestamp) + toIntervalDay(31)');
     expect(change?.detail).toContain('MODIFY TTL toDateTime(timestamp)');
+  });
+});
+
+describe('Railway authentication', () => {
+  // Railway hands out two token kinds. A project token in an Authorization
+  // header — the shipped bug — comes back HTTP 200 with `Not Authorized`, so a
+  // naive `response.ok` check treats total failure as success.
+  const PROJECT_DATA = {
+    project: {
+      name: 'boardsesh-ota',
+      environments: { edges: [{ node: { id: 'env-prod', name: 'production' } }] },
+      services: {
+        edges: [
+          { node: { id: 'svc-ota', name: OTA_SERVICE_NAME } },
+          { node: { id: 'svc-ch', name: CLICKHOUSE_SERVICE_NAME } },
+        ],
+      },
+    },
+  };
+
+  function headerOf(init: RequestInit | undefined, name: string): string | undefined {
+    return (init?.headers as Record<string, string> | undefined)?.[name];
+  }
+
+  function silenceStdout(): () => void {
+    const originalLog = console.log;
+    const originalWarn = console.warn;
+    console.log = () => {};
+    console.warn = () => {};
+    return () => {
+      console.log = originalLog;
+      console.warn = originalWarn;
+    };
+  }
+
+  /** Accept exactly one scheme; answer the other the way Railway really does. */
+  function stubAcceptingOnly(accepted: 'project' | 'account'): {
+    fetch: typeof globalThis.fetch;
+    schemesTried: string[];
+  } {
+    const schemesTried: string[] = [];
+    const fetchStub = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const usedProject = headerOf(init, 'Project-Access-Token') !== undefined;
+      schemesTried.push(usedProject ? 'project' : 'account');
+
+      if ((accepted === 'project') !== usedProject) {
+        return new Response(JSON.stringify({ errors: [{ message: 'Not Authorized' }], data: null }), { status: 200 });
+      }
+
+      const rawBody = typeof init?.body === 'string' ? init.body : '{}';
+      const query = (JSON.parse(rawBody) as { query: string }).query;
+      const data = query.includes('variables(') ? { variables: { CLICKHOUSE_URL: 'clickhouse://x/y' } } : PROJECT_DATA;
+      return new Response(JSON.stringify({ data }), { status: 200 });
+    }) as typeof globalThis.fetch;
+
+    return { fetch: fetchStub, schemesTried };
+  }
+
+  async function runAgainst(accepted: 'project' | 'account'): Promise<{ code: number; schemesTried: string[] }> {
+    const originalFetch = globalThis.fetch;
+    const originalEnv = { ...process.env };
+    const restoreStdout = silenceStdout();
+    const stub = stubAcceptingOnly(accepted);
+
+    globalThis.fetch = stub.fetch;
+    process.env.RAILWAY_TOKEN = 'test-token';
+    process.env.RAILWAY_PROJECT_ID = 'test-project';
+    delete process.env.CLICKHOUSE_URL;
+
+    try {
+      return { code: await main([]), schemesTried: stub.schemesTried };
+    } finally {
+      restoreStdout();
+      globalThis.fetch = originalFetch;
+      process.env = originalEnv;
+    }
+  }
+
+  it('authenticates a project token, the kind this repo actually stores', async () => {
+    const { code, schemesTried } = await runAgainst('project');
+    expect(code).toBe(0);
+    expect(schemesTried[0]).toBe('project');
+  });
+
+  it('falls back to Bearer for an account token instead of failing', async () => {
+    const { code, schemesTried } = await runAgainst('account');
+    expect(code).toBe(0);
+    expect(schemesTried.slice(0, 2)).toEqual(['project', 'account']);
+  });
+
+  it('stops re-probing once a scheme answers', async () => {
+    // Several requests are made per run; only the first should pay for a probe.
+    const { schemesTried } = await runAgainst('account');
+    expect(schemesTried.filter((scheme) => scheme === 'project')).toHaveLength(1);
+  });
+
+  it('does not leak a discovered scheme into the next run', async () => {
+    await runAgainst('account');
+    const { code, schemesTried } = await runAgainst('project');
+    expect(code).toBe(0);
+    expect(schemesTried[0]).toBe('project');
+  });
+
+  it('resets to the project scheme on demand', async () => {
+    await runAgainst('account');
+    resetAuthScheme();
+    const { schemesTried } = await runAgainst('project');
+    expect(schemesTried[0]).toBe('project');
+  });
+});
+
+describe('fetchClickHouseTtl', () => {
+  const ENGINE_WITH_TTL =
+    'MergeTree ORDER BY (app_id) TTL toDateTime(timestamp) + toIntervalDay(90) SETTINGS index_granularity = 8192';
+
+  async function withStub<T>(
+    stub: typeof globalThis.fetch,
+    run: () => Promise<T>,
+  ): Promise<{ result?: T; error?: Error; calls: { url: string; init?: RequestInit }[] }> {
+    const originalFetch = globalThis.fetch;
+    const calls: { url: string; init?: RequestInit }[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(input), init });
+      return stub(input as RequestInfo, init);
+    }) as typeof globalThis.fetch;
+    try {
+      return { result: await run(), calls };
+    } catch (error) {
+      return { error: error as Error, calls };
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }
+
+  const ok = (body: string) => (async () => new Response(body, { status: 200 })) as typeof globalThis.fetch;
+
+  it('treats a missing DSN as "not checked" rather than "no drift"', async () => {
+    expect(await fetchClickHouseTtl(undefined, 'expo_observe')).toBeNull();
+  });
+
+  it('reads the HTTP interface on 8123 when the DSN names the native port', async () => {
+    const { calls } = await withStub(ok(''), () =>
+      fetchClickHouseTtl('clickhouse://u:p@ch.internal:9000/expo_observe', 'expo_observe'),
+    );
+    expect(calls[0].url).toBe('http://ch.internal:8123/');
+  });
+
+  it('keeps a non-default port, so a proxied endpoint still works', async () => {
+    const { calls } = await withStub(ok(''), () =>
+      fetchClickHouseTtl('clickhouse://u:p@proxy.rlwy.net:22497/expo_observe', 'expo_observe'),
+    );
+    expect(calls[0].url).toBe('http://proxy.rlwy.net:22497/');
+  });
+
+  it('sends the DSN credentials as ClickHouse auth headers', async () => {
+    const { calls } = await withStub(ok(''), () =>
+      fetchClickHouseTtl('clickhouse://someone:s3cret@ch.internal:9000/expo_observe', 'expo_observe'),
+    );
+    const headers = calls[0].init?.headers as Record<string, string>;
+    expect(headers['X-ClickHouse-User']).toBe('someone');
+    expect(headers['X-ClickHouse-Key']).toBe('s3cret');
+  });
+
+  it('parses the TTL out of each engine_full row', async () => {
+    const body = `observe_metrics\t${ENGINE_WITH_TTL}\nobserve_logs\tMergeTree ORDER BY (app_id)\n`;
+    const { result } = await withStub(ok(body), () =>
+      fetchClickHouseTtl('clickhouse://u:p@ch.internal:9000/expo_observe', 'expo_observe'),
+    );
+    expect(result).toEqual({
+      observe_metrics: 'toDateTime(timestamp) + toIntervalDay(90)',
+      observe_logs: '',
+    });
+  });
+
+  it('surfaces an HTTP error instead of reporting no drift', async () => {
+    const failing = (async () => new Response('boom', { status: 500 })) as typeof globalThis.fetch;
+    const { error } = await withStub(failing, () =>
+      fetchClickHouseTtl('clickhouse://u:p@ch.internal:9000/expo_observe', 'expo_observe'),
+    );
+    expect(error?.message).toContain('500');
+  });
+
+  it('refuses a database name that is not a plain identifier', async () => {
+    const { error, calls } = await withStub(ok(''), () =>
+      fetchClickHouseTtl('clickhouse://u:p@ch.internal:9000/x', "expo_observe'; DROP TABLE x --"),
+    );
+    expect(error?.message).toContain('plain identifier');
+    expect(calls).toHaveLength(0);
   });
 });

--- a/scripts/railway-apply.test.ts
+++ b/scripts/railway-apply.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from 'vitest';
 
 import {
   CLICKHOUSE_RETENTION,
+  CLICKHOUSE_VOLUME_NAME,
+  CLICKHOUSE_VOLUME_USAGE_LIMIT_PERCENT,
   CLICKHOUSE_SERVICE_NAME,
   OTA_SERVICE_NAME,
   PLACEHOLDER_PATTERN,
@@ -15,6 +17,7 @@ import {
   diffService,
   diffServiceVars,
   diffTableRetention,
+  diffVolumeUsage,
   findService,
   undeclaredServices,
   varKey,
@@ -39,10 +42,14 @@ function liveState(overrides: Partial<LiveState> = {}): LiveState {
       { id: 'svc-ch', name: CLICKHOUSE_SERVICE_NAME },
     ],
     variables: { [OTA_SERVICE_NAME]: { CLICKHOUSE_URL: 'clickhouse://u:p@host:9000/expo_observe' } },
-    clickhouseTtl: {
-      observe_metrics: 'timestamp + toIntervalDay(90)',
-      observe_logs: 'timestamp + toIntervalDay(30)',
-    },
+    // 853 MiB of 50 GiB — the real reading when the volume was provisioned.
+    clickhouseVolume: { usedMb: 853, capacityMb: 50000 },
+    clickhouseTtl: Object.fromEntries(
+      CLICKHOUSE_RETENTION.map((table) => [
+        table.table,
+        `toDateTime(${table.column}) + toIntervalDay(${table.ttlDays})`,
+      ]),
+    ),
     ...overrides,
   };
 }
@@ -170,7 +177,20 @@ describe('buildPlan', () => {
 
   it('reports missing TTLs', () => {
     const plan = buildPlan(desiredRailwayState, liveState({ clickhouseTtl: {} }), NO_SUPPLIED);
-    expect(plan.filter((change) => change.resource === 'clickhouse-ttl')).toHaveLength(2);
+    // One per declared table, so this keeps counting whatever config.ts declares.
+    expect(plan.filter((change) => change.resource === 'clickhouse-ttl')).toHaveLength(CLICKHOUSE_RETENTION.length);
+  });
+
+  it('covers every table xprem creates, so none grows unbounded unnoticed', () => {
+    // The five tables in xprem's two ClickHouse migrations. A new one appearing
+    // upstream should fail here rather than quietly accumulate forever.
+    expect(CLICKHOUSE_RETENTION.map((table) => table.table).sort()).toEqual([
+      'device_health_events',
+      'observe_logs',
+      'observe_metrics',
+      'update_health_segment_snapshots',
+      'update_health_snapshots',
+    ]);
   });
 });
 
@@ -231,6 +251,30 @@ describe('main', () => {
       // BodyInit union, which would stringify a Blob to '[object Object]'.
       const rawBody = typeof init?.body === 'string' ? init.body : '{}';
       const body = JSON.parse(rawBody) as { query: string };
+      if (body.query.includes('volumes {')) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              project: {
+                volumes: {
+                  edges: [
+                    {
+                      node: {
+                        name: CLICKHOUSE_VOLUME_NAME,
+                        volumeInstances: {
+                          edges: [{ node: { sizeMB: 50000, currentSizeMB: 853, mountPath: '/var/lib/clickhouse' } }],
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
       const data = body.query.includes('variables(')
         ? { variables }
         : {
@@ -377,6 +421,23 @@ describe('Railway authentication', () => {
     },
   };
 
+  const VOLUMES_DATA = {
+    project: {
+      volumes: {
+        edges: [
+          {
+            node: {
+              name: CLICKHOUSE_VOLUME_NAME,
+              volumeInstances: {
+                edges: [{ node: { sizeMB: 50000, currentSizeMB: 853, mountPath: '/var/lib/clickhouse' } }],
+              },
+            },
+          },
+        ],
+      },
+    },
+  };
+
   function headerOf(init: RequestInit | undefined, name: string): string | undefined {
     return (init?.headers as Record<string, string> | undefined)?.[name];
   }
@@ -408,7 +469,11 @@ describe('Railway authentication', () => {
 
       const rawBody = typeof init?.body === 'string' ? init.body : '{}';
       const query = (JSON.parse(rawBody) as { query: string }).query;
-      const data = query.includes('variables(') ? { variables: { CLICKHOUSE_URL: 'clickhouse://x/y' } } : PROJECT_DATA;
+      const data = query.includes('volumes {')
+        ? VOLUMES_DATA
+        : query.includes('variables(')
+          ? { variables: { CLICKHOUSE_URL: 'clickhouse://x/y' } }
+          : PROJECT_DATA;
       return new Response(JSON.stringify({ data }), { status: 200 });
     }) as typeof globalThis.fetch;
 
@@ -545,5 +610,43 @@ describe('fetchClickHouseTtl', () => {
     );
     expect(error?.message).toContain('plain identifier');
     expect(calls).toHaveLength(0);
+  });
+});
+
+describe('diffVolumeUsage', () => {
+  const limit = CLICKHOUSE_VOLUME_USAGE_LIMIT_PERCENT;
+
+  it('says nothing while there is headroom', () => {
+    expect(diffVolumeUsage(limit, { usedMb: 853, capacityMb: 50000 })).toBeNull();
+  });
+
+  it('reports once past the limit, and cannot fix it itself', () => {
+    const change = diffVolumeUsage(limit, { usedMb: 45000, capacityMb: 50000 });
+    expect(change).toMatchObject({ resource: 'volume-usage', blocked: true });
+    expect(change?.summary).toContain('90.0% full');
+  });
+
+  it('explains that a full volume also blocks the next OTA restart', () => {
+    // Not a nicety: xprem exits at boot when ClickHouse is unreachable, so a
+    // disk alert is really an availability alert for updates.boardsesh.com.
+    const change = diffVolumeUsage(limit, { usedMb: 49000, capacityMb: 50000 });
+    expect(change?.detail).toMatch(/blocks the next OTA restart|exits at boot/);
+  });
+
+  it('treats an unavailable reading as unchecked, not as plenty of room', () => {
+    expect(diffVolumeUsage(limit, null)).toBeNull();
+  });
+
+  it('does not divide by a zero capacity', () => {
+    expect(diffVolumeUsage(limit, { usedMb: 10, capacityMb: 0 })).toBeNull();
+  });
+
+  it('is reached through buildPlan, not only in isolation', () => {
+    const plan = buildPlan(
+      desiredRailwayState,
+      liveState({ clickhouseVolume: { usedMb: 49000, capacityMb: 50000 } }),
+      NO_SUPPLIED,
+    );
+    expect(plan.filter((change) => change.resource === 'volume-usage')).toHaveLength(1);
   });
 });

--- a/scripts/railway-apply.ts
+++ b/scripts/railway-apply.ts
@@ -1,0 +1,405 @@
+/// <reference types="node" />
+
+/**
+ * Config-as-code for the Railway project running the self-hosted xprem OTA server.
+ * Reads the declarative desired state (infra/railway/config.ts), fetches the live
+ * project state, diffs them (infra/railway/plan.ts), and reports or converges the
+ * delta. Idempotent: a second run with no drift is a no-op.
+ *
+ * What it manages (and nothing else in the project):
+ *   - Services: asserts `boardsesh-ota-v3` exists, and reports when the ClickHouse
+ *     service is missing. Services are NEVER created or deleted by this tool — see
+ *     CREATION_IS_NOT_AUTOMATED in infra/railway/config.ts for why.
+ *   - Variables: asserts the declared variables are set and are not still an
+ *     unfilled `<placeholder>`. A variable is only WRITTEN when the caller supplies
+ *     its value as `RAILWAY_VAR_<NAME>` in this process's own environment; without
+ *     one, drift is reported and left alone. A value that is already set is never
+ *     overwritten.
+ *   - ClickHouse retention: asserts the TTLs on xprem's Observe tables. Skipped
+ *     (not failed) when no CLICKHOUSE_URL is available to this process, matching how
+ *     scripts/mobile-ota-health-check.ts skips without a PostHog key.
+ *
+ * Secrets are never printed. Variables are reduced to set/absent/placeholder in
+ * infra/railway/plan.ts before they reach any output path.
+ *
+ * Modes:
+ *   (default)  Dry-run. Fetch live state, print the diff, exit non-zero if any drift
+ *              exists (so CI can gate on it). Never mutates.
+ *   --apply    Perform only the needed, non-blocked mutations. No-op when live
+ *              matches desired.
+ *
+ * Usage:
+ *   RAILWAY_TOKEN=... RAILWAY_PROJECT_ID=... vp run railway:apply
+ *   RAILWAY_TOKEN=... RAILWAY_PROJECT_ID=... RAILWAY_VAR_CLICKHOUSE_URL=... \
+ *     vp run railway:apply -- --apply
+ *
+ * Env:
+ *   RAILWAY_TOKEN       (required) Railway API token. Same secret the deploy
+ *                       workflow already uses against backboard.railway.com.
+ *   RAILWAY_PROJECT_ID  (required) The project holding the OTA services.
+ *   RAILWAY_VAR_<NAME>  (optional) Value for a declared variable, enabling --apply
+ *                       to converge it. Never logged.
+ *   CLICKHOUSE_URL      (optional) Enables the retention assertion. Read-only use.
+ *
+ * See docs/railway.md and infra/railway/config.ts.
+ */
+
+import { pathToFileURL } from 'node:url';
+import { desiredRailwayState } from '../infra/railway/config';
+import type { RailwayDesiredState } from '../infra/railway/config';
+import { buildPlan, undeclaredServices, varKey } from '../infra/railway/plan';
+import type { LiveService, LiveState, PlannedChange } from '../infra/railway/plan';
+
+const RAILWAY_API = 'https://backboard.railway.com/graphql/v2';
+
+/** Prefix for caller-supplied variable values. `RAILWAY_VAR_CLICKHOUSE_URL` -> `CLICKHOUSE_URL`. */
+const SUPPLIED_VAR_PREFIX = 'RAILWAY_VAR_';
+
+export interface CliOptions {
+  apply: boolean;
+  help: boolean;
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+  let apply = false;
+  let help = false;
+
+  for (const argument of argv) {
+    if (argument === '--') continue;
+    else if (argument === '--apply') apply = true;
+    else if (argument === '--dry-run') apply = false;
+    else if (argument === '--help' || argument === '-h') help = true;
+    // Reject typos loudly — a silently ignored --appply would dry-run when the
+    // operator believed they applied.
+    else throw new Error(`Unknown flag: ${argument} (see --help)`);
+  }
+
+  return { apply, help };
+}
+
+/**
+ * Collect the variable values the caller supplied, as a name -> value map.
+ *
+ * Exported for tests. The returned values are secrets; only their KEYS ever reach
+ * the plan layer or any log line.
+ */
+export function collectSuppliedVars(env: NodeJS.ProcessEnv): Map<string, string> {
+  const supplied = new Map<string, string>();
+  for (const [key, value] of Object.entries(env)) {
+    if (!key.startsWith(SUPPLIED_VAR_PREFIX)) continue;
+    const name = key.slice(SUPPLIED_VAR_PREFIX.length);
+    if (name && value !== undefined && value.trim() !== '') supplied.set(name, value);
+  }
+  return supplied;
+}
+
+/**
+ * Build the plan-layer key set from supplied values and the desired state.
+ *
+ * A value is only usable for a variable the config actually declares, so an
+ * accidental `RAILWAY_VAR_JWT_SECRET` in the environment can never cause a write.
+ */
+export function suppliedVarKeys(desired: RailwayDesiredState, supplied: Map<string, string>): Set<string> {
+  const keys = new Set<string>();
+  for (const service of desired.services) {
+    for (const required of service.requiredVars) {
+      if (supplied.has(required.name)) keys.add(varKey(service.name, required.name));
+    }
+  }
+  return keys;
+}
+
+interface GraphQLResponse<TData> {
+  data?: TData;
+  errors?: { message: string }[];
+}
+
+async function railwayRequest<TData>(token: string, query: string, variables: Record<string, unknown>): Promise<TData> {
+  const response = await fetch(RAILWAY_API, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const rawBody = await response.text();
+  let envelope: GraphQLResponse<TData> | null = null;
+  try {
+    envelope = rawBody ? (JSON.parse(rawBody) as GraphQLResponse<TData>) : null;
+  } catch {
+    // Non-JSON body (e.g. an HTML error page) — handled below via the raw text.
+  }
+
+  if (!response.ok || !envelope || envelope.errors?.length) {
+    const rendered = (envelope?.errors ?? []).map((error) => `  - ${error.message}`).join('\n');
+    throw new Error(
+      `Railway API request failed (HTTP ${response.status}).` +
+        (rendered ? `\n${rendered}` : `\n  ${rawBody.slice(0, 500)}`),
+    );
+  }
+
+  if (!envelope.data) throw new Error('Railway API returned no data.');
+  return envelope.data;
+}
+
+const PROJECT_QUERY = `
+  query Project($projectId: String!) {
+    project(id: $projectId) {
+      name
+      environments { edges { node { id name } } }
+      services { edges { node { id name } } }
+    }
+  }
+`;
+
+const VARIABLES_QUERY = `
+  query Variables($projectId: String!, $environmentId: String!, $serviceId: String!) {
+    variables(projectId: $projectId, environmentId: $environmentId, serviceId: $serviceId)
+  }
+`;
+
+const VARIABLE_UPSERT = `
+  mutation VariableUpsert($input: VariableUpsertInput!) {
+    variableUpsert(input: $input)
+  }
+`;
+
+interface ProjectData {
+  project: {
+    name: string;
+    environments: { edges: { node: { id: string; name: string } }[] };
+    services: { edges: { node: { id: string; name: string } }[] };
+  };
+}
+
+interface ResolvedProject {
+  projectName: string;
+  environmentId: string;
+  services: LiveService[];
+}
+
+async function fetchProject(token: string, projectId: string, environmentName: string): Promise<ResolvedProject> {
+  const data = await railwayRequest<ProjectData>(token, PROJECT_QUERY, { projectId });
+  const environment = data.project.environments.edges.find((edge) => edge.node.name === environmentName);
+  if (!environment) {
+    const available = data.project.environments.edges.map((edge) => edge.node.name).join(', ');
+    throw new Error(`No "${environmentName}" environment in project "${data.project.name}". Found: ${available}`);
+  }
+
+  return {
+    projectName: data.project.name,
+    environmentId: environment.node.id,
+    services: data.project.services.edges.map((edge) => ({ id: edge.node.id, name: edge.node.name })),
+  };
+}
+
+/**
+ * Read the variables for every service we declare.
+ *
+ * Only declared services are queried: this tool has no reason to pull the secrets
+ * of the Postgres service or anything else sharing the project.
+ */
+async function fetchVariables(
+  token: string,
+  projectId: string,
+  environmentId: string,
+  desired: RailwayDesiredState,
+  services: LiveService[],
+): Promise<Record<string, Record<string, string>>> {
+  const variables: Record<string, Record<string, string>> = {};
+
+  for (const declared of desired.services) {
+    const live = services.find((service) => service.name === declared.name);
+    if (!live || declared.requiredVars.length === 0) continue;
+    const data = await railwayRequest<{ variables: Record<string, string> }>(token, VARIABLES_QUERY, {
+      projectId,
+      environmentId,
+      serviceId: live.id,
+    });
+    variables[declared.name] = data.variables ?? {};
+  }
+
+  return variables;
+}
+
+/**
+ * Read the live TTL expressions from ClickHouse over its HTTP interface.
+ *
+ * Returns null when no DSN is available, which the plan layer treats as "not
+ * checked" rather than "no drift". A failure to reach a ClickHouse that WAS
+ * configured is a real error and propagates.
+ */
+export async function fetchClickHouseTtl(
+  dsn: string | undefined,
+  database: string,
+): Promise<Record<string, string> | null> {
+  if (!dsn) return null;
+
+  const url = new URL(dsn);
+  // The native-protocol DSN xprem uses names port 9000; the HTTP interface this
+  // read-only query needs is 8123 on the same host.
+  const httpPort = url.port === '9000' || url.port === '' ? '8123' : url.port;
+  const endpoint = `${url.protocol === 'clickhouses:' ? 'https' : 'http'}://${url.hostname}:${httpPort}/`;
+  const query =
+    `SELECT name, ttl_expression FROM system.tables ` + `WHERE database = '${database}' FORMAT TabSeparated`;
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'X-ClickHouse-User': decodeURIComponent(url.username),
+      'X-ClickHouse-Key': decodeURIComponent(url.password),
+    },
+    body: query,
+  });
+
+  if (!response.ok) {
+    throw new Error(`ClickHouse TTL query failed (HTTP ${response.status}): ${(await response.text()).slice(0, 300)}`);
+  }
+
+  const ttl: Record<string, string> = {};
+  for (const line of (await response.text()).split('\n')) {
+    if (!line.trim()) continue;
+    const [table, expression = ''] = line.split('\t');
+    ttl[table] = expression;
+  }
+  return ttl;
+}
+
+function printPlan(changes: PlannedChange[]): void {
+  for (const change of changes) {
+    const marker = change.blocked ? '[blocked]' : '[change] ';
+    console.log(`  ${marker} (${change.resource}) ${change.summary}`);
+    if (change.detail) {
+      for (const line of change.detail.split('\n')) console.log(`             ${line}`);
+    }
+  }
+}
+
+function printHelp(): void {
+  console.log(
+    [
+      'railway-apply — config-as-code for the Railway OTA project.',
+      '',
+      '  vp run railway:apply                 dry-run; exits non-zero on drift',
+      '  vp run railway:apply -- --apply      converge what can be converged',
+      '',
+      'Required env: RAILWAY_TOKEN, RAILWAY_PROJECT_ID',
+      'Optional env: RAILWAY_VAR_<NAME> (a value --apply may set), CLICKHOUSE_URL (TTL check)',
+    ].join('\n'),
+  );
+}
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printHelp();
+    return 0;
+  }
+
+  const token = process.env.RAILWAY_TOKEN?.trim();
+  const projectId = process.env.RAILWAY_PROJECT_ID?.trim();
+  if (!token || !projectId) {
+    console.error('[railway-apply] RAILWAY_TOKEN and RAILWAY_PROJECT_ID are both required.');
+    console.error('                RAILWAY_TOKEN is the same secret the production deploy uses.');
+    return 1;
+  }
+
+  const desired = desiredRailwayState;
+  const supplied = collectSuppliedVars(process.env);
+
+  const project = await fetchProject(token, projectId, desired.environmentName);
+  console.log(`[railway-apply] Project: ${project.projectName} (${desired.environmentName})`);
+  console.log(`[railway-apply] Mode: ${options.apply ? 'APPLY' : 'dry-run (pass --apply to converge)'}`);
+  if (supplied.size > 0) {
+    // Names only, never values.
+    console.log(`[railway-apply] Values supplied for: ${[...supplied.keys()].sort().join(', ')}`);
+  }
+  console.log('');
+
+  const clickhouseTtl = await fetchClickHouseTtl(process.env.CLICKHOUSE_URL?.trim(), 'expo_observe');
+  if (clickhouseTtl === null) {
+    console.log('[railway-apply] Retention check skipped: no CLICKHOUSE_URL in this environment.');
+  }
+
+  const live: LiveState = {
+    services: project.services,
+    variables: await fetchVariables(token, projectId, project.environmentId, desired, project.services),
+    clickhouseTtl,
+  };
+
+  for (const name of undeclaredServices(desired, live)) {
+    console.log(`[railway-apply] note: service "${name}" is live but not declared here — left untouched.`);
+  }
+
+  const changes = buildPlan(desired, live, { suppliedVars: suppliedVarKeys(desired, supplied) });
+
+  if (changes.length === 0) {
+    console.log('[railway-apply] In sync — nothing to do.');
+    return 0;
+  }
+
+  console.log(`[railway-apply] Planned changes (${changes.length}):`);
+  printPlan(changes);
+  console.log('');
+
+  if (!options.apply) {
+    console.log('[railway-apply] Dry-run: no changes applied. Re-run with --apply to converge.');
+    // Non-zero exit signals drift so CI can gate on it.
+    return 1;
+  }
+
+  let blockedRemaining = 0;
+
+  for (const change of changes) {
+    if (change.blocked) {
+      console.warn(`[railway-apply] SKIPPED (blocked): ${change.summary}`);
+      blockedRemaining += 1;
+      continue;
+    }
+
+    if (change.resource === 'env-var' && change.target) {
+      const service = project.services.find((candidate) => candidate.name === change.target?.serviceName);
+      const value = supplied.get(change.target.varName);
+      if (!service || value === undefined) {
+        throw new Error(`Cannot apply ${change.summary}: service or supplied value went missing mid-run.`);
+      }
+      await railwayRequest(token, VARIABLE_UPSERT, {
+        input: {
+          projectId,
+          environmentId: project.environmentId,
+          serviceId: service.id,
+          name: change.target.varName,
+          value,
+        },
+      });
+      console.log(`[railway-apply] applied: ${change.summary}`);
+    } else {
+      // Every other resource is report-only by construction; reaching here means a
+      // new resource type was added to the plan without an apply path.
+      throw new Error(`No apply path for resource "${change.resource}" — ${change.summary}`);
+    }
+  }
+
+  console.log('');
+  if (blockedRemaining > 0) {
+    console.log(
+      `[railway-apply] Done, but ${blockedRemaining} change(s) were blocked and left unapplied ` +
+        `(they need a human, or a value this tool was not given).`,
+    );
+    return 1;
+  }
+
+  console.log('[railway-apply] Done — project converged to desired state.');
+  return 0;
+}
+
+// Exported for docs/tests: the module can be imported without running the CLI.
+export { RAILWAY_API, SUPPLIED_VAR_PREFIX };
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((error) => {
+      console.error(`[railway-apply] ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    });
+}

--- a/scripts/railway-apply.ts
+++ b/scripts/railway-apply.ts
@@ -133,6 +133,17 @@ const AUTH_HEADER: Record<AuthScheme, (token: string) => Record<string, string>>
 
 let authScheme: AuthScheme = 'project';
 
+/**
+ * Reset the memoized scheme. The memo is what stops every request paying for a
+ * failed probe, but a value that survives for the life of the process is a
+ * hazard: one run (or one test) that flips it silently changes the header every
+ * later caller sends. main() resets on entry so each run starts from a known
+ * state, and tests can do the same.
+ */
+export function resetAuthScheme(): void {
+  authScheme = 'project';
+}
+
 function isNotAuthorized(response: Response, rawBody: string): boolean {
   if (response.status === 401 || response.status === 403) return true;
   return rawBody.includes('Not Authorized');
@@ -286,6 +297,10 @@ export async function fetchClickHouseTtl(
 ): Promise<Record<string, string> | null> {
   if (!dsn) return null;
 
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(database)) {
+    throw new Error(`Refusing to query a database name that is not a plain identifier: ${database}`);
+  }
+
   const url = new URL(dsn);
   // The native-protocol DSN xprem uses names port 9000; the HTTP interface this
   // read-only query needs is 8123 on the same host.
@@ -343,6 +358,7 @@ function printHelp(): void {
 }
 
 export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  resetAuthScheme();
   const options = parseArgs(argv);
   if (options.help) {
     printHelp();

--- a/scripts/railway-apply.ts
+++ b/scripts/railway-apply.ts
@@ -263,6 +263,17 @@ async function fetchVariables(
 }
 
 /**
+ * Pull the TTL clause out of a table's `engine_full`.
+ *
+ * Returns '' for a table with no TTL, which is what the plan layer already
+ * treats as "no retention set".
+ */
+export function ttlFromEngineFull(engineFull: string): string {
+  const match = /\bTTL\s+(.*?)(?:\s+SETTINGS\b|$)/.exec(engineFull);
+  return match ? match[1].trim() : '';
+}
+
+/**
  * Read the live TTL expressions from ClickHouse over its HTTP interface.
  *
  * Returns null when no DSN is available, which the plan layer treats as "not
@@ -280,8 +291,10 @@ export async function fetchClickHouseTtl(
   // read-only query needs is 8123 on the same host.
   const httpPort = url.port === '9000' || url.port === '' ? '8123' : url.port;
   const endpoint = `${url.protocol === 'clickhouses:' ? 'https' : 'http'}://${url.hostname}:${httpPort}/`;
-  const query =
-    `SELECT name, ttl_expression FROM system.tables ` + `WHERE database = '${database}' FORMAT TabSeparated`;
+  // system.tables has no ttl_expression column — asking for one is an
+  // UNKNOWN_IDENTIFIER error, not an empty result. The TTL clause lives inside
+  // engine_full, between the engine's ORDER BY and its SETTINGS.
+  const query = `SELECT name, engine_full FROM system.tables ` + `WHERE database = '${database}' FORMAT TabSeparated`;
 
   const response = await fetch(endpoint, {
     method: 'POST',
@@ -299,8 +312,8 @@ export async function fetchClickHouseTtl(
   const ttl: Record<string, string> = {};
   for (const line of (await response.text()).split('\n')) {
     if (!line.trim()) continue;
-    const [table, expression = ''] = line.split('\t');
-    ttl[table] = expression;
+    const [table, engineFull = ''] = line.split('\t');
+    ttl[table] = ttlFromEngineFull(engineFull);
   }
   return ttl;
 }

--- a/scripts/railway-apply.ts
+++ b/scripts/railway-apply.ts
@@ -41,11 +41,14 @@
  *                       to converge it. Never logged.
  *   CLICKHOUSE_URL      (optional) Enables the retention assertion. Read-only use.
  *
+ * The disk assertion needs no extra config: it reads the volume through Railway's
+ * API, which CI can reach even though ClickHouse's private DSN host it cannot.
+ *
  * See docs/railway.md and infra/railway/config.ts.
  */
 
 import { pathToFileURL } from 'node:url';
-import { desiredRailwayState } from '../infra/railway/config';
+import { CLICKHOUSE_VOLUME_NAME, desiredRailwayState } from '../infra/railway/config';
 import type { RailwayDesiredState } from '../infra/railway/config';
 import { buildPlan, undeclaredServices, varKey } from '../infra/railway/plan';
 import type { LiveService, LiveState, PlannedChange } from '../infra/railway/plan';
@@ -209,6 +212,21 @@ const VARIABLES_QUERY = `
   }
 `;
 
+const VOLUMES_QUERY = `
+  query Volumes($projectId: String!) {
+    project(id: $projectId) {
+      volumes {
+        edges {
+          node {
+            name
+            volumeInstances { edges { node { sizeMB currentSizeMB mountPath } } }
+          }
+        }
+      }
+    }
+  }
+`;
+
 const VARIABLE_UPSERT = `
   mutation VariableUpsert($input: VariableUpsertInput!) {
     variableUpsert(input: $input)
@@ -271,6 +289,43 @@ async function fetchVariables(
   }
 
   return variables;
+}
+
+interface VolumesData {
+  project: {
+    volumes: {
+      edges: {
+        node: {
+          name: string;
+          volumeInstances: { edges: { node: { sizeMB: number; currentSizeMB: number; mountPath: string } }[] };
+        };
+      }[];
+    };
+  };
+}
+
+/**
+ * Read the ClickHouse volume's utilisation.
+ *
+ * Deliberately sourced from Railway's API rather than from ClickHouse: the DSN
+ * host resolves only inside Railway's private network, so a CI runner cannot ask
+ * ClickHouse anything — but it can ask Railway. That is what lets the disk
+ * assertion run nightly when the retention one cannot.
+ *
+ * Returns null when the volume is not found, which the plan treats as "not
+ * checked" rather than "plenty of room".
+ */
+export async function fetchClickHouseVolume(
+  token: string,
+  projectId: string,
+  volumeName: string,
+): Promise<{ usedMb: number; capacityMb: number } | null> {
+  const data = await railwayRequest<VolumesData>(token, VOLUMES_QUERY, { projectId });
+  const volume = data.project.volumes.edges.find((edge) => edge.node.name === volumeName);
+  const instance = volume?.node.volumeInstances.edges[0]?.node;
+  if (!instance) return null;
+
+  return { usedMb: instance.currentSizeMB, capacityMb: instance.sizeMB };
 }
 
 /**
@@ -390,10 +445,23 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
     console.log('[railway-apply] Retention check skipped: no CLICKHOUSE_URL in this environment.');
   }
 
+  // Railway's API answers this even from CI, unlike ClickHouse itself.
+  const clickhouseVolume = await fetchClickHouseVolume(token, projectId, CLICKHOUSE_VOLUME_NAME);
+  if (clickhouseVolume === null) {
+    console.log(`[railway-apply] Disk check skipped: no volume named "${CLICKHOUSE_VOLUME_NAME}".`);
+  } else {
+    const usedPercent = (clickhouseVolume.usedMb / clickhouseVolume.capacityMb) * 100;
+    console.log(
+      `[railway-apply] ClickHouse volume: ${(clickhouseVolume.usedMb / 1024).toFixed(1)} GiB of ` +
+        `${(clickhouseVolume.capacityMb / 1024).toFixed(1)} GiB (${usedPercent.toFixed(1)}%).`,
+    );
+  }
+
   const live: LiveState = {
     services: project.services,
     variables: await fetchVariables(token, projectId, project.environmentId, desired, project.services),
     clickhouseTtl,
+    clickhouseVolume,
   };
 
   for (const name of undeclaredServices(desired, live)) {

--- a/scripts/railway-apply.ts
+++ b/scripts/railway-apply.ts
@@ -114,14 +114,55 @@ interface GraphQLResponse<TData> {
   errors?: { message: string }[];
 }
 
-async function railwayRequest<TData>(token: string, query: string, variables: Record<string, unknown>): Promise<TData> {
-  const response = await fetch(RAILWAY_API, {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ query, variables }),
-  });
+/**
+ * Railway issues two kinds of token and they authenticate differently: an
+ * account token travels in `Authorization: Bearer`, while a project token —
+ * what this repo stores as RAILWAY_TOKEN, scoped to the OTA project and its
+ * production environment — must travel in `Project-Access-Token`. The wrong
+ * header comes back as a bare `Not Authorized` with HTTP 200, which reads like
+ * a permissions problem rather than a header problem. Rather than make the
+ * operator declare which kind they hold, try the other scheme once and keep
+ * whichever answered.
+ */
+type AuthScheme = 'project' | 'account';
 
-  const rawBody = await response.text();
+const AUTH_HEADER: Record<AuthScheme, (token: string) => Record<string, string>> = {
+  project: (token) => ({ 'Project-Access-Token': token }),
+  account: (token) => ({ Authorization: `Bearer ${token}` }),
+};
+
+let authScheme: AuthScheme = 'project';
+
+function isNotAuthorized(response: Response, rawBody: string): boolean {
+  if (response.status === 401 || response.status === 403) return true;
+  return rawBody.includes('Not Authorized');
+}
+
+function postGraphQL(token: string, scheme: AuthScheme, body: string): Promise<Response> {
+  return fetch(RAILWAY_API, {
+    method: 'POST',
+    headers: { ...AUTH_HEADER[scheme](token), 'Content-Type': 'application/json' },
+    body,
+  });
+}
+
+async function railwayRequest<TData>(token: string, query: string, variables: Record<string, unknown>): Promise<TData> {
+  const body = JSON.stringify({ query, variables });
+
+  let response = await postGraphQL(token, authScheme, body);
+  let rawBody = await response.text();
+
+  if (isNotAuthorized(response, rawBody)) {
+    const fallback: AuthScheme = authScheme === 'project' ? 'account' : 'project';
+    const retried = await postGraphQL(token, fallback, body);
+    const retriedBody = await retried.text();
+    if (!isNotAuthorized(retried, retriedBody)) {
+      authScheme = fallback;
+      response = retried;
+      rawBody = retriedBody;
+    }
+  }
+
   let envelope: GraphQLResponse<TData> | null = null;
   try {
     envelope = rawBody ? (JSON.parse(rawBody) as GraphQLResponse<TData>) : null;

--- a/scripts/railway-apply.ts
+++ b/scripts/railway-apply.ts
@@ -48,7 +48,7 @@
  */
 
 import { pathToFileURL } from 'node:url';
-import { CLICKHOUSE_VOLUME_NAME, desiredRailwayState } from '../infra/railway/config';
+import { CLICKHOUSE_DATABASE, CLICKHOUSE_VOLUME_NAME, desiredRailwayState } from '../infra/railway/config';
 import type { RailwayDesiredState } from '../infra/railway/config';
 import { buildPlan, undeclaredServices, varKey } from '../infra/railway/plan';
 import type { LiveService, LiveState, PlannedChange } from '../infra/railway/plan';
@@ -359,8 +359,14 @@ export async function fetchClickHouseTtl(
   const url = new URL(dsn);
   // The native-protocol DSN xprem uses names port 9000; the HTTP interface this
   // read-only query needs is 8123 on the same host.
-  const httpPort = url.port === '9000' || url.port === '' ? '8123' : url.port;
-  const endpoint = `${url.protocol === 'clickhouses:' ? 'https' : 'http'}://${url.hostname}:${httpPort}/`;
+  // Native 9000 maps to HTTP 8123, and native-over-TLS 9440 to HTTPS 8443. An
+  // explicit port is passed through, which is what lets a Railway TCP proxy
+  // (some arbitrary high port) be pointed at directly.
+  const secure = url.protocol === 'clickhouses:';
+  const defaultHttpPort = secure ? '8443' : '8123';
+  const nativePorts = secure ? ['9440', ''] : ['9000', ''];
+  const httpPort = nativePorts.includes(url.port) ? defaultHttpPort : url.port;
+  const endpoint = `${secure ? 'https' : 'http'}://${url.hostname}:${httpPort}/`;
   // system.tables has no ttl_expression column — asking for one is an
   // UNKNOWN_IDENTIFIER error, not an empty result. The TTL clause lives inside
   // engine_full, between the engine's ORDER BY and its SETTINGS.
@@ -440,7 +446,7 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
   }
   console.log('');
 
-  const clickhouseTtl = await fetchClickHouseTtl(process.env.CLICKHOUSE_URL?.trim(), 'expo_observe');
+  const clickhouseTtl = await fetchClickHouseTtl(process.env.CLICKHOUSE_URL?.trim(), CLICKHOUSE_DATABASE);
   if (clickhouseTtl === null) {
     console.log('[railway-apply] Retention check skipped: no CLICKHOUSE_URL in this environment.');
   }

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -27,6 +27,10 @@
     "outline-overrides-merge.ts",
     "outline-overrides-merge.test.ts",
     "canonical-outlines.ts",
-    "canonical-outlines.test.ts"
+    "canonical-outlines.test.ts",
+    "railway-apply.ts",
+    "railway-apply.test.ts",
+    "../infra/railway/config.ts",
+    "../infra/railway/plan.ts"
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1030,6 +1030,15 @@ export default defineConfig({
         cache: false,
       },
 
+      // Railway config-as-code for the OTA project (service + variable assertions
+      // and the ClickHouse retention check). Dry-run by default and exits non-zero
+      // on drift; forward `-- --apply` to converge what it can.
+      // See scripts/railway-apply.ts + docs/railway.md.
+      'railway:apply': {
+        command: 'tsx scripts/railway-apply.ts',
+        cache: false,
+      },
+
       // --- Dev servers ---
       'dev:mobile': {
         command: 'tsx scripts/mobile-dev-start.ts',


### PR DESCRIPTION
## Summary

Config-as-code for the Railway OTA project, plus the fixes that came out of actually running it.

xprem's **Observe** feature is now on in production. It shipped in xprem v3.1.0 and the deployed
image is already `v3.1.2`, so this needed no server upgrade and no xprem code change — it was off
only because `CLICKHOUSE_URL` was unset.

### Applied live (not in this diff)

- New Railway service `boardsesh-ota-clickhouse` on `clickhouse/clickhouse-server:25.3` — the
  version xprem pins in its own `docker-compose.yml` and CI, so its goose migrations run on a
  version they have been tested against.
- Persistent volume at `/var/lib/clickhouse`. Without it the service looks healthy and loses every
  row on redeploy.
- Dedicated database `expo_observe`. xprem refuses to boot on a DSN with no database segment
  (`NewClickHouseEngine`, `internal/database/clickhouse/clickhouse.go`).
- `CLICKHOUSE_URL` on `boardsesh-ota-v3`, over private networking. Credentials live in 1Password
  (`Boardsesh` vault → "Boardsesh OTA ClickHouse (Railway)"); no DSN appears anywhere in this repo.
- Retention on all five Observe tables, and on ClickHouse's own `system.*_log` tables,
  which ship almost none and were the real growth driver.
- `RAILWAY_PROJECT_ID` set as a repository variable, so the drift check stops skipping itself.

The cutover was the risky step: xprem calls `log.Fatalf` if ClickHouse is unreachable at boot
(`internal/router/wire.go:183`) rather than degrading. It came up clean first try — connection
established, goose migrations ran, schema up to date — and `updates.boardsesh.com` served manifests
throughout, verified with a real `/manifest` request before, during and after.

### Two corrections to the plan this work came from

**ClickHouse does not sit empty until the mobile app ships `expo-observe`.** Postgres triggers
enqueue into `device_health_outbox` whenever a device's `current_update_id` changes, which is driven
by the manifest check-ins every production binary already makes. Forty minutes after the cutover:

| Table | Rows |
| --- | --- |
| `update_health_snapshots` | 8009 |
| `update_health_segment_snapshots` | 48 |
| `device_health_events` | 3 |
| `observe_metrics` | 0 |
| `observe_logs` | 0 |

Only the last two wait on the app. **And those rows were previously being destroyed** — with
`CLICKHOUSE_URL` unset, `StartHealthOutboxDiscarder` (`wire.go:194`) was deleting them continuously.
Update-adoption history now accrues.

### In this diff

`infra/railway/` holds the desired state as typed data plus a pure diff, mirroring
`infra/cloudflare/`. `scripts/railway-apply.ts` reports and converges; `railway-drift.yml` runs it.
On top of that, four defects found by running it against a real project and a real server:

1. **Auth.** `RAILWAY_TOKEN` is a Railway *project* token, which authenticates with
   `Project-Access-Token`. The script sent `Authorization: Bearer`, which only account tokens use,
   so every call returned `Not Authorized` with HTTP 200 — the tool had never once reached the live
   API. Both GraphQL query shapes turned out to be correct; only the header was wrong.
2. **`system.tables` has no `ttl_expression` column.** Selecting it is an `UNKNOWN_IDENTIFIER`
   error, not an empty result, so the retention assertion could only ever have crashed. The TTL
   clause is parsed out of `engine_full` instead.
3. **The remediation it printed did not run.** Both `timestamp` columns are `DateTime64(9)`, and
   ClickHouse rejects a TTL whose result is not `Date`/`DateTime` (`BAD_TTL_EXPRESSION`). The
   suggested `ALTER` now wraps the column in `toDateTime()`, a no-op on a plain `DateTime`.
4. **The drift workflow failed on every pull request.** It asks for the Production environment,
   whose branch policy admits `main` alone, so GitHub rejected the job before any step ran and the
   in-script skip never fired. Split by trigger: schedule and dispatch get the live check, PRs get
   the layers that need no credentials.

Also fixes an unrelated conflict already on `main`: `913c8fff1` added a `concurrency:` block to
`postgres-image-publisher-contract.yml` and taught `ci-capacity-workflows.test.ts` to require it,
but the trust boundary in `scripts/lib/postgres-image-publisher-contract.ts` asserts that workflow's
top-level keys are exactly `name`/`on`/`permissions`/`jobs`. Both cannot hold. It merged green
because the contract check runs on a narrow path filter — one that includes `vite.config.ts`,
`package.json` and `pnpm-lock.yaml`, so it reddens most PRs rather than the one that caused it. The
block is removed, keeping the security contract exactly as reviewed.

### Verification

Against the live project: the dry-run resolves `boardsesh (production)`, reports the four undeclared
services (Postgres, PostGIS, Redis, backend) as untouched rather than deleting them, and exits 0
with `In sync`. `--apply` is a no-op when converged. The retention guard was proved to bite by
deliberately drifting `observe_logs` to 31 days and confirming it reported the drift rather than
passing silently, then restoring 30. 36/36 unit tests, `tsc` clean, `vp check` clean, trust boundary
82/82, capacity 12/12.

### Disk

Observe was never going to be what fills the volume. Measured in the first hour:
`update_health_snapshots` is the busiest table — snapshotted every minute for each
current (update, role), ~373k rows/day — but it compresses to **2.6 bytes/row**, so 90
days is ~87 MB. Meanwhile ClickHouse's *own* system logs ship almost no TTL, and
`asynchronous_metric_log` alone wrote 55M rows in that hour: the `system` database was
growing ~38 MB/day unbounded, roughly a hundred times the Observe tables. Every
`system.*_log` table now has a TTL — 14 days for the high-frequency instrumentation, 30
for the diagnostics worth reading. They belong to ClickHouse rather than xprem, so
`docs/railway.md` flags re-checking them after an image upgrade.

`railway-apply` now also fails once the volume passes 80% of capacity, printing the
reading on every run:

```
[railway-apply] ClickHouse volume: 0.8 GiB of 48.8 GiB (1.7%).
```

**That check does run in CI**, because it reads the volume through Railway's API instead
of connecting to ClickHouse. It is worth gating on: a full volume stops ClickHouse
accepting writes, and since xprem exits at boot when ClickHouse is unreachable, a full
disk here would also block the next OTA restart.

### Known gap

The retention assertion still cannot run from CI. The DSN host is
`boardsesh-ota-clickhouse.railway.internal`, which resolves only inside Railway's private network,
so a GitHub Actions runner cannot reach it — the checks above went through a temporary TCP proxy
that has since been removed. **Leave `secrets.CLICKHOUSE_URL` unset**, or the nightly run goes red on
a connection error instead of on drift. Closing it properly means a tunnel in CI or moving the
assertion inside the network.

Retention itself is no longer a gap — all five tables are declared and applied. Windows were
picked from measured rates rather than guessed: 90d for the two snapshot tables (nothing reads
minute grain a quarter later), 180d for `device_health_events` (lowest volume, and the raw record
the snapshots summarise), 30d for `observe_logs`, 90d for `observe_metrics`.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 2/5 — repo tooling only in this diff; the script reads unless passed `--apply`, and the
production change it documents is already applied and verified serving manifests.
