### PR TITLE
fix(ci): bind publisher contract concurrency

### DIFF
--- a/scripts/lib/postgres-image-publisher-contract.ts
+++ b/scripts/lib/postgres-image-publisher-contract.ts
@@ -251,7 +251,7 @@ const CONTRACT_STEPS: ExpectedStep[] = [
   { name: 'Verify publisher authority and artifact contracts' },
 ];
 
-const CONTRACT_WORKFLOW_METADATA_SHA256 = '9f53ade79a7ae06ae71c8938bb4476c2ad6905667ef34f8150c16caed55374af';
+const CONTRACT_WORKFLOW_METADATA_SHA256 = '598a7028d9332760676c83e3481238a5fbd4ca9ac2a4fb0cdecb4df1b66ecf16';
 const CONTRACT_JOB_METADATA_SHA256 = '9e0f951e6bceb41814be7e67f5cfe5cf5d808315af99a39bc312cbce1c7f0cfb';
 const CONTRACT_STEP_SHA256: Record<string, string> = {
   'Checkout repository without persisted credentials':
@@ -960,7 +960,7 @@ function validatePublisherDocument(failures: string[], publisher: UnknownRecord,
 }
 
 function validateContractDocument(failures: string[], contract: UnknownRecord, contractWorkflow: string): void {
-  if (!keysEqual(contract, ['name', 'on', 'permissions', 'jobs'])) {
+  if (!keysEqual(contract, ['name', 'on', 'permissions', 'concurrency', 'jobs'])) {
     failures.push('contract workflow top-level keys must match the exact read-only allowlist with no defaults');
   }
   if (contract.name !== 'PostgreSQL Image Publisher Contract') {
@@ -983,6 +983,14 @@ function validateContractDocument(failures: string[], contract: UnknownRecord, c
   }
   if (!recordsEqual(recordAt(contract, 'permissions'), { contents: 'read' })) {
     failures.push('contract workflow must be globally contents-read-only');
+  }
+  if (
+    !recordsEqual(recordAt(contract, 'concurrency'), {
+      group: 'postgres-image-contract-${{ github.event.pull_request.number || github.ref }}',
+      'cancel-in-progress': "${{ github.event_name == 'pull_request' }}",
+    })
+  ) {
+    failures.push('contract workflow concurrency must cancel only superseded pull-request runs');
   }
   const jobs = recordAt(contract, 'jobs');
   if (!jobs || JSON.stringify(Object.keys(jobs)) !== JSON.stringify(['verify-trust-boundary'])) {

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -80,7 +80,7 @@ function getCommitSubject(): string {
 // lands on main. Locally the clean-tree check stays on — otherwise
 // `vp run mobile:publish -- --channel production` would ship a developer's
 // scratch edits to the fleet.
-export function shouldAllowDirtyTree(env: { readonly GITHUB_ACTIONS?: string } = process.env): boolean {
+export function shouldAllowDirtyTree(env: Readonly<Record<string, string | undefined>> = process.env): boolean {
   return env.GITHUB_ACTIONS === 'true';
 }
 

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -80,7 +80,7 @@ function getCommitSubject(): string {
 // lands on main. Locally the clean-tree check stays on — otherwise
 // `vp run mobile:publish -- --channel production` would ship a developer's
 // scratch edits to the fleet.
-export function shouldAllowDirtyTree(env: NodeJS.ProcessEnv = process.env): boolean {
+export function shouldAllowDirtyTree(env: { readonly GITHUB_ACTIONS?: string } = process.env): boolean {
   return env.GITHUB_ACTIONS === 'true';
 }
 

--- a/scripts/postgres-image-publisher-contract.test.ts
+++ b/scripts/postgres-image-publisher-contract.test.ts
@@ -609,6 +609,20 @@ describe('trusted PostgreSQL image publisher contract', () => {
   });
 
   it.each([
+    [
+      'group',
+      'postgres-image-contract-${{ github.event.pull_request.number || github.ref }}',
+      'postgres-image-contract-${{ github.ref }}',
+    ],
+    ['cancellation policy', "${{ github.event_name == 'pull_request' }}", 'true'],
+  ])('rejects altered contract workflow concurrency %s', (_label, expected, replacement) => {
+    const weakened = replaceRequired(contractWorkflow, expected, replacement);
+    expect(failuresFor(publisherWorkflow, weakened)).toMatch(
+      /concurrency must cancel only superseded pull-request runs/,
+    );
+  });
+
+  it.each([
     ['ref', 'main'],
     ['repository', 'attacker/example'],
     ['path', 'source'],


### PR DESCRIPTION
## Summary

- Teach the fail-closed PostgreSQL publisher parser about the reviewed concurrency block added on `main`.
- Pin the exact pull-request cancellation policy and reject changed groups or cancellation semantics.
- Restore the publisher contract gate currently blocking #5002 and other database PRs.
- Type the mobile publisher CI environment as a readonly string map, fixing the current-main `ProcessEnv` lint regression exposed by clean CI.

## Current validation

Head `e31342a437dd8f75be7a971e21246bd4da83f8b5`, rebased onto current `main`.

- Publisher contract and runner-capacity suites: 97/97 tests passed.
- Mobile publish tests: 11/11 passed.
- Focused formatting, lint, type, and diff checks passed.
- Fresh exact-head CI is running.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 2/5 — restores an internal fail-closed CI trust contract.