### PR TITLE
fix(repo): keep the climb-view rate limit within the Free plan's expression fields

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -195,11 +195,13 @@ what the rate-limit rule below is for.
 `/view/` path on www — the segment every climb-view URL shape shares, across the
 config-tuple tree, the `/b/{slug}` tree and the `/de`, `/es` and `/fr` locale
 prefixes. Matching the segment rather than enumerating the trees means the rule
-cannot silently miss whichever tree is added next. The expression also
-excludes requests carrying the `next-router-prefetch` header: a prefetch of a
-dynamic route only renders the loading shell, so a crawler faking the header
-gets nothing useful out of dodging the counter, while a real reader's burst of
-list-page prefetches no longer counts against them either.
+cannot silently miss whichever tree is added next. The expression is host +
+path only, with no header check: a `next-router-prefetch` header exclusion
+shipped here once, and production apply rejected it — `not entitled: the use
+of field http.request.headers.names is not allowed, an higher Advanced Rate
+Limiting plan is required`. The Free plan's rate-limit expressions cannot
+reference request headers at all, so Next.js router prefetches off a list
+page count toward the limit the same as real page loads.
 
 **It ships in `managed_challenge` mode.** The zone is on Free or Pro, not
 Enterprise, so the softest mitigation, `log`, is rejected on apply —
@@ -212,12 +214,14 @@ instrument for later if challenge proves insufficient.
 API.** The first production apply attempted `period: 60` and Cloudflare
 rejected it: `not entitled to use the period 60, can only use a period among
 [10]`. 10s is the only counting window Free accepts — this is not a choice,
-it's a hard constraint from the API. The threshold is tuned around it: 20
-requests per 10s keeps the original ~60/min-per-IP-per-colo intent, but with
-headroom for the burstier 10s window and for a real reader's burst of
-`/view/` loads off one list page. Read a few days of Cloudflare analytics at
-this setting, size the number against real traffic, then re-tune —
-`requests_per_period` stays free to change; `period` does not.
+it's a hard constraint from the API. The threshold is tuned around it: 30
+requests per 10s (~180/min sustained) keeps headroom for the original
+~60/min-per-IP-per-colo intent, given both the burstier 10s window and the
+fact that a list-page browser's prefetch burst now counts too (the plan
+won't let the expression exclude it — see above). Read a few days of
+Cloudflare analytics at this setting, size the number against real traffic,
+then re-tune — `requests_per_period` stays free to change; `period` does
+not, and neither does the header restriction on the expression.
 
 Two things to know:
 

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -315,14 +315,16 @@ export const CRAWLER_BLOCK_EXPRESSION = buildUserAgentExpression(CRAWLER_BLOCK_T
  *
  * Host-scoped so a future origin on another hostname cannot inherit it.
  *
- * Excludes Next.js prefetches (`next-router-prefetch` header): a prefetch of
- * a dynamic route only renders the loading shell, so a crawler that fakes
- * the header gets nothing useful out of dodging the counter, while a full
- * page fetch — what the farm actually does — still counts. Without this, a
- * real reader scrolling a list page fires a burst of prefetches that could
- * trip the limit on its own.
+ * Host + path only — no header check. A prefetch-exclusion clause
+ * (`http.request.headers.names[*] == "next-router-prefetch"`) shipped here
+ * once and production apply rejected it: `not entitled: the use of field
+ * http.request.headers.names is not allowed, an higher Advanced Rate
+ * Limiting plan is required`. The Free plan's rate-limit expressions cannot
+ * reference request headers at all, so Next.js router prefetches off a list
+ * page are counted along with real page loads. That is why the threshold
+ * below carries headroom rather than a tight ~60/min budget.
  */
-export const CLIMB_VIEW_RATE_LIMIT_EXPRESSION = `(http.host eq "${WWW_HOSTNAME}" and http.request.uri.path contains "/view/" and not any(http.request.headers.names[*] == "next-router-prefetch"))`;
+export const CLIMB_VIEW_RATE_LIMIT_EXPRESSION = `(http.host eq "${WWW_HOSTNAME}" and http.request.uri.path contains "/view/")`;
 
 export const desiredCloudflareState: CloudflareDesiredState = {
   zoneName: ZONE_NAME,
@@ -421,12 +423,14 @@ export const desiredCloudflareState: CloudflareDesiredState = {
         // failed with `not entitled to use the period 60, can only use a
         // period among [10]` — 10s is the only period Free accepts.
         period: 10,
-        // Intent is still ~60 requests/minute per IP per colo, but a 10s
-        // window is burstier than a 60s one would have been, and a list page
-        // can fire a burst of /view/ prefetches (excluded above) plus real
-        // full-page loads from one browser. 20 per 10s gives that headroom
-        // while still averaging to a ~120/min sustained ceiling.
-        requests_per_period: 20,
+        // Intent is still ~60 requests/minute per IP per colo, but the
+        // expression cannot exclude Next.js prefetches on this plan (see the
+        // doc comment on CLIMB_VIEW_RATE_LIMIT_EXPRESSION), so a list page in
+        // the viewport can fire a burst of /view/ prefetches from one
+        // browser that now count too, on top of the burstier 10s window
+        // itself. 30 per 10s gives that headroom while still averaging to a
+        // ~180/min sustained ceiling.
+        requests_per_period: 30,
         // 10s is the Free-plan ceiling (Pro allows up to 60s). Raise to 60
         // once the zone's plan is confirmed Pro or above.
         mitigation_timeout: 10,

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -823,9 +823,11 @@ describe('climb-view rate-limit rule', () => {
     // can only use a period among [10]` — Free accepts only a 10s window. A
     // re-tune back to 60 must fail here, not with a 400 on apply.
     expect(rateLimitRule?.ratelimit.period).toBe(10);
-    // 20 per 10s keeps the ~60/min-per-IP-per-colo intent while giving a real
-    // reader's burst of list-page loads headroom against the burstier window.
-    expect(rateLimitRule?.ratelimit.requests_per_period).toBe(20);
+    // 30 per 10s (~180/min) keeps headroom for the ~60/min-per-IP-per-colo
+    // intent given the expression can't exclude prefetches on this plan (see
+    // the expression test below), so a list-page browser's prefetch burst
+    // counts too, on top of the burstier 10s window itself.
+    expect(rateLimitRule?.ratelimit.requests_per_period).toBe(30);
   });
 
   it('keys the counter on the client IP and the required colo characteristic', () => {
@@ -833,7 +835,7 @@ describe('climb-view rate-limit rule', () => {
     expect(rateLimitRule?.ratelimit.characteristics).toEqual(['ip.src', 'cf.colo.id']);
   });
 
-  it('covers every climb-view URL shape on www, including the locale prefixes, but excludes prefetches', () => {
+  it('covers every climb-view URL shape on www, including the locale prefixes', () => {
     // A pattern per route tree would miss whichever tree is added next, so the
     // rule matches the /view/ segment that all of them share.
     const expression = rateLimitRule?.expression ?? '';
@@ -841,10 +843,16 @@ describe('climb-view rate-limit rule', () => {
     expect(expression).toContain('"/view/"');
     // Host-scoped: a future origin on ws must not inherit it.
     expect(expression).not.toContain(WS_HOSTNAME);
-    // A Next.js router prefetch only renders the loading shell, so excluding
-    // it keeps a reader's list-page scroll from tripping the counter while a
-    // farm's full-page fetches still count.
-    expect(expression).toContain('next-router-prefetch');
+  });
+
+  it('never references request headers, which the Free plan rejects', () => {
+    // A prior revision added `http.request.headers.names[*] ==
+    // "next-router-prefetch"` to skip Next.js prefetches, and production
+    // apply rejected it: `not entitled: the use of field
+    // http.request.headers.names is not allowed, an higher Advanced Rate
+    // Limiting plan is required`. Guard against that regressing.
+    const expression = rateLimitRule?.expression ?? '';
+    expect(expression).not.toContain('http.request.headers');
   });
 
   it('treats a threshold change as drift', () => {
@@ -855,7 +863,7 @@ describe('climb-view rate-limit rule', () => {
 
     const retuned = {
       ...desired.rateLimitRules[0],
-      ratelimit: { ...desired.rateLimitRules[0].ratelimit, requests_per_period: 30 },
+      ratelimit: { ...desired.rateLimitRules[0].ratelimit, requests_per_period: 45 },
     };
     expect(cacheRuleMatches(live, retuned)).toBe(false);
   });


### PR DESCRIPTION
## Summary
- Production apply of the merged rule (bf4682914) failed: `not entitled: the use of field http.request.headers.names is not allowed, an higher Advanced Rate Limiting plan is required`. The Free plan's rate-limit expressions cannot reference request headers at all.
- Dropped the `next-router-prefetch` header exclusion from `CLIMB_VIEW_RATE_LIMIT_EXPRESSION`, back to host + path only.
- Since Next.js router prefetches off a list page now count toward the limit the same as real page loads, raised `requests_per_period` 20 → 30 (still per IP per colo per 10s, ~180/min sustained) for headroom. `action` stays `managed_challenge`, `period` stays 10, `mitigation_timeout` stays 10.

Refs #4802

## Release Notes
- [x] No release note needed (internal / technical change)

## Test plan
1. CI green.
2. After merge, deploy-cloudflare applies the http_ratelimit phase without a 400.

## Risk
Risk: 3/5 — live edge rule; rollback is enabled:false + apply.