### PR TITLE
feat(repo): put www and the apex under Cloudflare config-as-code

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -113,18 +113,33 @@ The apex is repo-managed and **originless**: it exists only so Cloudflare
 terminates the request and answers it with a redirect.
 
 ```text
-boardsesh.com AAAA 100::
+boardsesh.com A 192.0.2.0
 TTL: automatic (Cloudflare API value 1)
 Proxy status: Proxied  ← load-bearing
 ```
 
-`100::` is the reserved address Cloudflare documents for a proxied record with
-no origin behind it (the other documented option is `192.0.2.0`). It is the IETF
-discard prefix from RFC 6666, so a packet that somehow escaped the proxy is
-dropped rather than delivered to a real host — which is not true of an address
-picked at random. **Never grey-cloud this record.** DNS-only, the apex resolves
-to an unroutable address with nothing in front of it and boardsesh.com goes
-dark.
+`192.0.2.0` is one of the two reserved addresses Cloudflare documents for a
+proxied record with no origin behind it (the other is `100::`, an AAAA). It is
+RFC 5737 TEST-NET-1, reserved for documentation and guaranteed never to be
+routed, so a packet that somehow escaped the proxy goes nowhere real — which is
+not true of an address picked at random.
+
+**The A form is deliberate, and it is not about IP version.** The apex already
+exists as a DNS-only `A` record to Vercel (`76.76.21.21`), so declaring an `A`
+makes the apply an in-place update of that record: content and the proxied flag,
+nothing else. Declaring the `AAAA` placeholder instead would make the apply
+change the record's *type*, which either lands a second record beside the A —
+split-brain, where some resolvers reach Vercel unproxied while others reach
+Cloudflare — or depends on the API accepting a type change in place. Neither is
+something to discover during a production apply.
+
+**Never grey-cloud this record.** DNS-only, the apex resolves to an unroutable
+address with nothing in front of it and boardsesh.com goes dark.
+
+If the apex ever ends up holding **both** an A and an AAAA record, the apply
+**fails loudly before it mutates anything**: the live-state read refuses to pick
+one of two address records at the same name, and it runs before any write. Fix
+the duplicate in the dashboard, then re-run.
 
 The redirect itself is one rule in the `http_request_dynamic_redirect` phase
 (Cloudflare calls these Single Redirects, or Redirect Rules in the dashboard):
@@ -196,7 +211,7 @@ What it manages (and nothing else on the zone):
     missing and its owned fields (including disabled CNAME flattening) are
     corrected when drifted. The tool refuses to apply while zone-wide CNAME
     flattening would override that record.
-  - the apex `boardsesh.com`: the full proxied, originless `AAAA 100::` shape
+  - the apex `boardsesh.com`: the full proxied, originless `A 192.0.2.0` shape
     shown above, so the redirect rule can answer it.
 
   The lookup is by name, and Cloudflare's list endpoint returns every record type

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -37,6 +37,71 @@ One-time setup order:
 4. Wait for Tigris to report the custom domain and certificate active, then run
    the verification commands below before publishing the first catalog.
 
+## www.boardsesh.com DNS, and the origin flip
+
+`www.boardsesh.com` is a proxied record pointing at Vercel. The repo manages
+**only its orange cloud** today:
+
+```ts
+{ management: 'proxied-only', name: WWW_HOSTNAME, proxied: true }
+```
+
+Same ownership boundary as `ws`: the target stays whatever the dashboard says,
+and a dry-run against the live (already proxied) record reports zero drift. The
+entry exists so the Vercel → Railway origin flip (#4655, epic #4648) is a
+reviewable diff rather than a dashboard click.
+
+The tool cannot read the current target for you and neither can `dig` — a
+proxied record answers with Cloudflare anycast addresses, so the Vercel CNAME is
+only visible inside the dashboard. Do not guess it.
+
+### Flipping www to a new origin
+
+The flip is step 3 of the cut-over sequence in
+[production-deploy.md](./production-deploy.md#cut-over-sequence): only after
+`WEB_DEPLOY_TARGETS=vercel,railway` is shipping both, and the post-deploy smoke
+has passed against `RAILWAY_WEB_ORIGIN`.
+
+1. In Railway, add `www.boardsesh.com` as a custom domain on the `web` service.
+   Railway prints the CNAME target to point at — a per-service hostname like
+   `<something>.up.railway.app`. That printed value is the only source of truth
+   for it; it is not derivable from the service name.
+2. Change the one entry in `infra/cloudflare/config.ts` to take ownership of the
+   target:
+
+   ```ts
+   {
+     management: 'full',
+     name: WWW_HOSTNAME,
+     type: 'CNAME',
+     content: '<the target Railway printed in step 1>',
+     ttl: 1,
+     proxied: true,
+   }
+   ```
+
+   No `settings` block. Cloudflare always flattens a **proxied** CNAME (the
+   public answer is its own anycast address), so `flatten_cname` is not a field
+   we own on this record — unlike the DNS-only `assets` CNAME, where the literal
+   answer has to stay visible for Tigris to verify it. For the same reason the
+   zone-wide "Flatten all CNAMEs" guard does not apply to www; a test pins that.
+
+3. Merge. `deploy-cloudflare` PATCHes the record on the way through. Traffic
+   moves as Cloudflare's edge picks up the new origin — there is no public TTL
+   to wait out, because the record is proxied and the public answer never
+   changes.
+
+**Rollback is `git revert` of that PR.** Reverting restores the Vercel target in
+`content` and the next apply PATCHes it straight back. Vercel keeps deploying
+every commit through the seven-day dual window, so the rollback origin is warm;
+after the scrub step decommissions the Vercel project, this rollback is gone and
+the fix is forward-only.
+
+Zone SSL is already `strict`, so nothing about the flip is held back by the
+SSL gate — but the Railway `web` service must serve a publicly-trusted cert for
+`www.boardsesh.com` before the flip, exactly as `ws` does. Check it with the
+`openssl s_client -servername` recipe in [CI auto-apply](#ci-auto-apply).
+
 ## ws.boardsesh.com edge caching (OG and board images)
 
 `ws.boardsesh.com` is a single-region Railway origin; distant clients (and the
@@ -52,13 +117,19 @@ second run is a no-op).
 
 What it manages (and nothing else on the zone):
 
-- **DNS** — two records with different ownership boundaries:
-  - `ws`: only its proxied flag → orange cloud. Its target/type/content are not
-    managed and the record must already exist.
+- **DNS** — records with different ownership boundaries:
+  - `ws` and `www`: only the proxied flag → orange cloud. Their target/type/content
+    are not managed and the records must already exist.
   - `assets`: the full DNS-only CNAME shape shown above. It is created when
     missing and its owned fields (including disabled CNAME flattening) are
     corrected when drifted. The tool refuses to apply while zone-wide CNAME
     flattening would override that record.
+
+  The lookup is by name, and Cloudflare's list endpoint returns every record type
+  at that name. Only `A`, `AAAA` and `CNAME` are considered, so the MX, TXT and
+  CAA records a hostname (especially the apex) carries alongside its address
+  record do not make it look ambiguous. Two _address_ records at one name still
+  fail closed: that is a real conflict and the tool must not pick one.
 - **Cache** — two rules in the `http_request_cache_settings` phase, one for
   `(http.host eq "ws.boardsesh.com" and starts_with(http.request.uri.path, "/og/"))`
   and one for the exact board-render paths `/render/board` and

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -86,7 +86,12 @@ has passed against `RAILWAY_WEB_ORIGIN`.
    answer has to stay visible for Tigris to verify it. For the same reason the
    zone-wide "Flatten all CNAMEs" guard does not apply to www; a test pins that.
 
-3. Merge. `deploy-cloudflare` PATCHes the record on the way through. Traffic
+3. Update the two places in `scripts/cloudflare-apply.test.ts` that pin today's
+   state: the shape assertion in `www.boardsesh.com under Cloudflare management`,
+   and `liveWwwDnsRecord()`'s `content` (it stands in for the live record, so it
+   becomes the Railway target). Nothing else needs touching — the tests fail
+   loudly if you miss one.
+4. Merge. `deploy-cloudflare` PATCHes the record on the way through. Traffic
    moves as Cloudflare's edge picks up the new origin — there is no public TTL
    to wait out, because the record is proxied and the public answer never
    changes.
@@ -101,6 +106,73 @@ Zone SSL is already `strict`, so nothing about the flip is held back by the
 SSL gate — but the Railway `web` service must serve a publicly-trusted cert for
 `www.boardsesh.com` before the flip, exactly as `ws` does. Check it with the
 `openssl s_client -servername` recipe in [CI auto-apply](#ci-auto-apply).
+
+## boardsesh.com (the apex) → www
+
+The apex is repo-managed and **originless**: it exists only so Cloudflare
+terminates the request and answers it with a redirect.
+
+```text
+boardsesh.com AAAA 100::
+TTL: automatic (Cloudflare API value 1)
+Proxy status: Proxied  ← load-bearing
+```
+
+`100::` is the reserved address Cloudflare documents for a proxied record with
+no origin behind it (the other documented option is `192.0.2.0`). It is the IETF
+discard prefix from RFC 6666, so a packet that somehow escaped the proxy is
+dropped rather than delivered to a real host — which is not true of an address
+picked at random. **Never grey-cloud this record.** DNS-only, the apex resolves
+to an unroutable address with nothing in front of it and boardsesh.com goes
+dark.
+
+The redirect itself is one rule in the `http_request_dynamic_redirect` phase
+(Cloudflare calls these Single Redirects, or Redirect Rules in the dashboard):
+
+| Field                  | Value                                                     |
+| ---------------------- | --------------------------------------------------------- |
+| Description marker     | `boardsesh:apex-to-www`                                    |
+| Expression             | `http.host eq "boardsesh.com"`                             |
+| Action                 | `redirect`, status `301`                                   |
+| Target URL (dynamic)   | `concat("https://www.boardsesh.com", http.request.uri.path)` |
+| Preserve query string  | on                                                         |
+
+`preserve_query_string` is what carries `?a=1`, so the expression only rebuilds
+the path — the simplest shape that keeps both. It is also the only shape
+available: Cloudflare's rules language has no ternary operator, so assembling
+the query string inside the expression is not possible. `target_url` is either
+`{ value }` for a fixed destination or `{ expression }` for a computed one; a
+rule carrying both is rejected.
+
+`http.host` is the request's Host header, so the rule matches the apex and
+nothing else on the zone — `www`, `ws`, `assets`, `app` and `updates` all keep
+serving themselves.
+
+**Once this applies, Vercel is out of the apex path.** The apex used to be a
+DNS-only `A` record to `76.76.21.21` and Vercel served the apex → www 308. The
+record now points at Cloudflare, so the redirect is answered at the edge, it is
+a 301 rather than a 308, and it keeps working after the Vercel project is
+decommissioned in the scrub step of the cut-over.
+
+Verify after the merge:
+
+```bash
+curl -sI 'https://boardsesh.com/kilter/8/25/15,17/40/view/abc?utm_source=x' |
+  grep -iE '^(HTTP|location|cf-ray)'
+```
+
+Expect `HTTP/2 301`, a `location:` of
+`https://www.boardsesh.com/kilter/8/25/15,17/40/view/abc?utm_source=x`, and a
+`cf-ray` header (which is what proves Cloudflare answered rather than an origin).
+
+**If the token lacks `Zone.Dynamic Redirect Edit`,** `deploy-cloudflare` 403s on
+this phase and this phase only. The cache, WAF and rate-limit phases apply
+normally, so the failure mode is a half-converged zone: the apex record flips to
+the originless address while nothing is there to redirect it, and the apex
+serves Cloudflare's error page until the scope is added and the job re-run.
+**Add the scope before merging.** If it happens anyway, add the scope and re-run
+`Actions → Production Deploy → Run workflow`, or roll back by reverting the
+commit (which restores the Vercel `A` record on the next apply).
 
 ## ws.boardsesh.com edge caching (OG and board images)
 
@@ -124,6 +196,8 @@ What it manages (and nothing else on the zone):
     missing and its owned fields (including disabled CNAME flattening) are
     corrected when drifted. The tool refuses to apply while zone-wide CNAME
     flattening would override that record.
+  - the apex `boardsesh.com`: the full proxied, originless `AAAA 100::` shape
+    shown above, so the redirect rule can answer it.
 
   The lookup is by name, and Cloudflare's list endpoint returns every record type
   at that name. Only `A`, `AAAA` and `CNAME` are considered, so the MX, TXT and
@@ -142,6 +216,9 @@ What it manages (and nothing else on the zone):
   1y). Every other rule already in that phase is preserved verbatim (the tool
   finds its own rule by a stable description marker and touches only that one),
   so `/graphql`, REST, and WebSocket upgrades keep bypassing cache.
+- **Redirect** — one rule in the `http_request_dynamic_redirect` phase sending
+  the apex to www with a 301, path and query preserved. Foreign rules in that
+  phase are preserved verbatim, same as every other phase.
 - **SSL** — asserts the zone SSL/TLS mode is `strict` (Full (strict); Flexible
   causes redirect loops with Railway). If the zone-wide mode is weaker the tool
   **reports it but does not change it** — the setting affects every hostname on
@@ -332,6 +409,11 @@ Create a token at <https://dash.cloudflare.com/profile/api-tokens> scoped to the
 - **Zone.Rate Limit Edit** — create/update the climb-view rate-limit rule in the
   `http_ratelimit` phase. Same partial-convergence failure mode as WAF Edit: the
   earlier phases apply, this one 403s.
+- **Zone.Dynamic Redirect Edit** — create/update the apex → www redirect in the
+  `http_request_dynamic_redirect` phase. Same partial-convergence failure mode,
+  and worse in effect: the apex DNS record flips to the originless address while
+  no rule exists to answer it. In the permission picker the row is called
+  **Dynamic Redirect**, not "Redirect Rules" or "Single Redirects".
 - **Zone.Zone Settings Read** — read the SSL/TLS mode
 - **Zone.Zone Settings Edit** — only if you'll run `--allow-zone-ssl`
 
@@ -501,9 +583,11 @@ there is nothing to check.
 
 Measured 2026-08-25: `www` (Vercel), `ws` and `updates` (Railway) are the only
 proxied origins and each serves a Let's Encrypt cert for its exact hostname, so
-`strict` is safe. The apex and `ota.boardsesh.com` are DNS-only and unaffected;
+`strict` is safe. `ota.boardsesh.com` is DNS-only and unaffected;
 `*.preview.boardsesh.com` rides a Cloudflare Tunnel, which does not use the
-zone's origin-encryption mode.
+zone's origin-encryption mode. The apex became proxied with the redirect rule
+above, but it is originless — there is no origin connection for the zone SSL
+mode to govern, so it needs no cert check.
 
 ### Rollback
 

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -48,21 +48,29 @@ export const WWW_HOSTNAME = 'www.boardsesh.com';
 export const APEX_HOSTNAME = ZONE_NAME;
 
 /**
- * Cloudflare's documented originless placeholder address.
+ * Cloudflare's documented originless placeholder address, in its A-record form.
  *
  * The apex has no origin of its own: it exists only so Cloudflare terminates the
- * request and the redirect rule below can answer it. Cloudflare documents
- * exactly two reserved addresses for this — `100::` (AAAA) and `192.0.2.0` (A) —
- * and the IPv6 one is the form its own docs lead with. `100::` is the IETF
- * discard prefix (RFC 6666): a packet that somehow escaped the proxy would be
- * dropped rather than delivered somewhere real, which is not true of a made-up
- * address. `192.0.2.1` is in TEST-NET-1 but is NOT the address Cloudflare names,
- * so it is not used here.
+ * request and the redirect rule below can answer it. Cloudflare documents two
+ * reserved addresses for this — `192.0.2.0` (A) and `100::` (AAAA). The A form
+ * is the one used here for a reason that has nothing to do with IP version: the
+ * apex ALREADY EXISTS as a DNS-only A record to Vercel, so declaring an A keeps
+ * the apply an in-place update of that record — content and proxied flag, and
+ * nothing else. An AAAA would make the apply change the record's TYPE, which
+ * either lands a second record beside the A (split-brain: some resolvers reach
+ * Vercel unproxied while others reach Cloudflare) or leans on the API accepting
+ * a type change in place. Neither is something to find out during a production
+ * apply.
  *
- * The record MUST stay proxied. Grey-cloud it and the apex resolves to a
- * black-hole address and the domain goes dark.
+ * `192.0.2.0` is RFC 5737 TEST-NET-1, reserved for documentation and guaranteed
+ * never to be routed, so a packet that somehow escaped the proxy goes nowhere
+ * real. `192.0.2.1` is in the same block but is NOT the address Cloudflare
+ * names, so it is not used here.
+ *
+ * The record MUST stay proxied. Grey-cloud it and the apex resolves to an
+ * unroutable address with nothing in front of it, and the domain goes dark.
  */
-export const APEX_ORIGINLESS_ADDRESS = '100::';
+export const APEX_ORIGINLESS_ADDRESS = '192.0.2.0';
 
 /**
  * The legacy board-image URL on www, now externally rewritten to Railway. Its responses carry
@@ -154,6 +162,8 @@ export interface FullyManagedDnsRecordDesired extends DnsRecordDesiredBase {
   /**
    * `A`/`AAAA` are here for the originless apex, which points at a reserved
    * placeholder address rather than a hostname — see APEX_ORIGINLESS_ADDRESS.
+   * `AAAA` stays in the union because Cloudflare documents both placeholder
+   * forms; nothing declares one today.
    */
   type: 'A' | 'AAAA' | 'CNAME';
   content: string;
@@ -452,15 +462,19 @@ export const desiredCloudflareState: CloudflareDesiredState = {
     },
     // The apex is originless: it exists so Cloudflare terminates the request and
     // the apex → www redirect rule below answers it. Until now it was a DNS-only
-    // A record to Vercel and VERCEL served the apex → www 308; converging this
-    // record takes Vercel out of that path entirely.
+    // A record to Vercel (76.76.21.21) and VERCEL served the apex → www 308;
+    // converging this record takes Vercel out of that path entirely.
+    //
+    // `A` deliberately matches the type the live record already has, so the
+    // apply is an in-place update of content + the proxied flag rather than a
+    // type change — see APEX_ORIGINLESS_ADDRESS.
     {
       management: 'full',
       name: APEX_HOSTNAME,
-      type: 'AAAA',
+      type: 'A',
       content: APEX_ORIGINLESS_ADDRESS,
       ttl: 1,
-      // Load-bearing. Grey-clouded, this record answers with a black-hole
+      // Load-bearing. Grey-clouded, this record answers with an unroutable
       // address and boardsesh.com stops resolving to anything that serves.
       proxied: true,
     },

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -44,6 +44,26 @@ export const OG_PATH_PREFIX = '/og/';
 /** The Vercel-backed www origin whose crawl cost these rules exist to cap. */
 export const WWW_HOSTNAME = 'www.boardsesh.com';
 
+/** The zone apex. Everything on it redirects to WWW_HOSTNAME. */
+export const APEX_HOSTNAME = ZONE_NAME;
+
+/**
+ * Cloudflare's documented originless placeholder address.
+ *
+ * The apex has no origin of its own: it exists only so Cloudflare terminates the
+ * request and the redirect rule below can answer it. Cloudflare documents
+ * exactly two reserved addresses for this — `100::` (AAAA) and `192.0.2.0` (A) —
+ * and the IPv6 one is the form its own docs lead with. `100::` is the IETF
+ * discard prefix (RFC 6666): a packet that somehow escaped the proxy would be
+ * dropped rather than delivered somewhere real, which is not true of a made-up
+ * address. `192.0.2.1` is in TEST-NET-1 but is NOT the address Cloudflare names,
+ * so it is not used here.
+ *
+ * The record MUST stay proxied. Grey-cloud it and the apex resolves to a
+ * black-hole address and the domain goes dark.
+ */
+export const APEX_ORIGINLESS_ADDRESS = '100::';
+
 /**
  * The legacy board-image URL on www, now externally rewritten to Railway. Its responses carry
  * `cache-control: public, max-age=31536000, immutable` and a matching
@@ -84,6 +104,9 @@ export const CRAWLER_BLOCK_RULE_DESCRIPTION = 'boardsesh:block-seo-scrapers (man
 export const CLIMB_VIEW_RATE_LIMIT_RULE_DESCRIPTION =
   'boardsesh:climb-view-rate-limit (managed by scripts/cloudflare-apply.ts)';
 
+/** Marker for the apex → www redirect rule. Same never-rename contract as above. */
+export const APEX_REDIRECT_RULE_DESCRIPTION = 'boardsesh:apex-to-www (managed by scripts/cloudflare-apply.ts)';
+
 /** The rulesets phase that holds cache-eligibility rules. */
 export const CACHE_RULE_PHASE = 'http_request_cache_settings';
 
@@ -98,6 +121,15 @@ export const WAF_RULE_PHASE = 'http_request_firewall_custom';
  * 404 as an empty phase, so the first apply creates it rather than failing.
  */
 export const RATE_LIMIT_RULE_PHASE = 'http_ratelimit';
+
+/**
+ * The rulesets phase that holds Single Redirects (Cloudflare's "Redirect Rules").
+ *
+ * Like the rate-limit phase, a zone that has never carried a redirect rule has
+ * no entrypoint ruleset here at all; `fetchPhaseRules` reads that 404 as an
+ * empty phase and the first apply creates it.
+ */
+export const DYNAMIC_REDIRECT_RULE_PHASE = 'http_request_dynamic_redirect';
 
 /** Cloudflare SSL/TLS modes ordered weakest → strongest, for the "is the live mode weaker?" check. */
 export const SSL_MODE_STRENGTH = ['off', 'flexible', 'full', 'strict'] as const;
@@ -119,7 +151,11 @@ export interface ProxyOnlyDnsRecordDesired extends DnsRecordDesiredBase {
 /** A record whose complete writable DNS shape is owned by this repo. */
 export interface FullyManagedDnsRecordDesired extends DnsRecordDesiredBase {
   management: 'full';
-  type: 'CNAME';
+  /**
+   * `A`/`AAAA` are here for the originless apex, which points at a reserved
+   * placeholder address rather than a hostname — see APEX_ORIGINLESS_ADDRESS.
+   */
+  type: 'A' | 'AAAA' | 'CNAME';
   content: string;
   /** Cloudflare API value 1 means automatic TTL. */
   ttl: number;
@@ -213,6 +249,33 @@ export interface RateLimitRuleDesired {
   enabled: boolean;
 }
 
+/**
+ * A Cloudflare Single Redirect (the `http_request_dynamic_redirect` phase).
+ *
+ * The nesting is Cloudflare's, not ours: the redirect payload sits under
+ * `action_parameters.from_value`, and `target_url` is a one-key object that is
+ * EITHER `{ value }` for a fixed destination or `{ expression }` for one built
+ * from the request. A rule carrying both is rejected.
+ *
+ * `preserve_query_string` is what keeps the query string, so the expression only
+ * has to rebuild the path. Cloudflare's rules language has no ternary operator,
+ * so hand-assembling `?…` inside the expression is not an option anyway.
+ */
+export interface RedirectRuleDesired {
+  description: string;
+  expression: string;
+  action: 'redirect';
+  action_parameters: {
+    from_value: {
+      /** 301 = permanent. Search engines fold the apex into www rather than treating both as live. */
+      status_code: 301;
+      target_url: { expression: string };
+      preserve_query_string: boolean;
+    };
+  };
+  enabled: boolean;
+}
+
 export interface CloudflareDesiredState {
   zoneName: string;
   dnsRecords: DnsRecordDesired[];
@@ -229,6 +292,8 @@ export interface CloudflareDesiredState {
    * Cloudflare evaluates every matching rule rather than stopping at the first.
    */
   rateLimitRules: RateLimitRuleDesired[];
+  /** Order is not significant: Cloudflare stops at the first matching redirect and there is only one. */
+  redirectRules: RedirectRuleDesired[];
   ssl: SslDesired;
 }
 
@@ -337,6 +402,24 @@ export const CRAWLER_BLOCK_EXPRESSION = buildUserAgentExpression(CRAWLER_BLOCK_T
  */
 export const CLIMB_VIEW_RATE_LIMIT_EXPRESSION = `(http.host eq "${WWW_HOSTNAME}" and http.request.uri.path contains "/view/")`;
 
+/**
+ * The apex, and only the apex. `http.host` is the request's Host header, so this
+ * never matches www, ws, assets, app or updates — each of which is a different
+ * host on the same zone and must keep serving itself.
+ */
+export const APEX_REDIRECT_EXPRESSION = `http.host eq "${APEX_HOSTNAME}"`;
+
+/**
+ * The destination, rebuilt per request so `/kilter/…` lands on the same page
+ * under www rather than on the homepage.
+ *
+ * Only the path is concatenated: `preserve_query_string: true` on the rule
+ * appends the original query string, which is both simpler and the shape
+ * Cloudflare documents. `http.request.uri.path` always starts with `/`, so a
+ * bare `https://boardsesh.com` redirects to `https://www.boardsesh.com/`.
+ */
+export const APEX_REDIRECT_TARGET_EXPRESSION = `concat("https://${WWW_HOSTNAME}", http.request.uri.path)`;
+
 export const desiredCloudflareState: CloudflareDesiredState = {
   zoneName: ZONE_NAME,
   dnsRecords: [
@@ -365,6 +448,20 @@ export const desiredCloudflareState: CloudflareDesiredState = {
     {
       management: 'proxied-only',
       name: WWW_HOSTNAME,
+      proxied: true,
+    },
+    // The apex is originless: it exists so Cloudflare terminates the request and
+    // the apex → www redirect rule below answers it. Until now it was a DNS-only
+    // A record to Vercel and VERCEL served the apex → www 308; converging this
+    // record takes Vercel out of that path entirely.
+    {
+      management: 'full',
+      name: APEX_HOSTNAME,
+      type: 'AAAA',
+      content: APEX_ORIGINLESS_ADDRESS,
+      ttl: 1,
+      // Load-bearing. Grey-clouded, this record answers with a black-hole
+      // address and boardsesh.com stops resolving to anything that serves.
       proxied: true,
     },
   ],
@@ -453,6 +550,21 @@ export const desiredCloudflareState: CloudflareDesiredState = {
         // 10s is the Free-plan ceiling (Pro allows up to 60s). Raise to 60
         // once the zone's plan is confirmed Pro or above.
         mitigation_timeout: 10,
+      },
+      enabled: true,
+    },
+  ],
+  redirectRules: [
+    {
+      description: APEX_REDIRECT_RULE_DESCRIPTION,
+      expression: APEX_REDIRECT_EXPRESSION,
+      action: 'redirect',
+      action_parameters: {
+        from_value: {
+          status_code: 301,
+          target_url: { expression: APEX_REDIRECT_TARGET_EXPRESSION },
+          preserve_query_string: true,
+        },
       },
       enabled: true,
     },

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -18,6 +18,9 @@
 //    ~442,600 Vercel function invocations/day, of which /api/internal/board-render
 //    was ~215,600 and the climb-view page ~203,900, against a published sitemap of
 //    only ~60k URLs and ~2,000 homepage hits. See docs/cloudflare.md.
+//    Its DNS record is managed here too — proxy flag only, for now — so the
+//    Vercel → Railway origin flip is a reviewable diff rather than a dashboard
+//    click (#4655).
 //
 // 3. assets.boardsesh.com is the public, DNS-only custom domain for the Tigris
 //    static-assets bucket. Unlike ws, this tool owns the record's complete shape
@@ -120,8 +123,16 @@ export interface FullyManagedDnsRecordDesired extends DnsRecordDesiredBase {
   content: string;
   /** Cloudflare API value 1 means automatic TTL. */
   ttl: number;
-  /** Keep the literal CNAME visible so the third-party provider can verify it. */
-  settings: {
+  /**
+   * Keep the literal CNAME visible so the third-party provider can verify it.
+   *
+   * Optional, and omitted rather than set to `true` on a PROXIED record:
+   * Cloudflare always flattens a proxied CNAME — the public answer is its own
+   * anycast address — so `flatten_cname` is not a field we get to own there,
+   * and sending it risks a 400 on the record. Leaving it out is also how
+   * `diffDnsRecord` is told the field is unmanaged for that record.
+   */
+  settings?: {
     flatten_cname: false;
   };
 }
@@ -344,6 +355,17 @@ export const desiredCloudflareState: CloudflareDesiredState = {
       settings: {
         flatten_cname: false,
       },
+    },
+    // www is proxied today and points at Vercel, by hand, in the dashboard. This
+    // repo takes over only the orange cloud for now, which is a no-op against
+    // the live record and gives the Vercel → Railway origin flip (#4655, epic
+    // #4648) a single line to change instead of a dashboard click. See the
+    // "Flipping www to a new origin" section of docs/cloudflare.md for the exact
+    // edit and its rollback.
+    {
+      management: 'proxied-only',
+      name: WWW_HOSTNAME,
+      proxied: true,
     },
   ],
   cacheRules: [

--- a/infra/cloudflare/plan.ts
+++ b/infra/cloudflare/plan.ts
@@ -6,18 +6,26 @@
 // scripts/cloudflare-apply.test.ts. The I/O (fetching live state, applying changes)
 // lives in scripts/cloudflare-apply.ts.
 
-import { CACHE_RULE_PHASE, RATE_LIMIT_RULE_PHASE, SSL_MODE_STRENGTH, WAF_RULE_PHASE, ZONE_NAME } from './config';
+import {
+  CACHE_RULE_PHASE,
+  DYNAMIC_REDIRECT_RULE_PHASE,
+  RATE_LIMIT_RULE_PHASE,
+  SSL_MODE_STRENGTH,
+  WAF_RULE_PHASE,
+  ZONE_NAME,
+} from './config';
 import type {
   CacheRuleDesired,
   DnsRecordDesired,
   RateLimitRuleDesired,
+  RedirectRuleDesired,
   SslDesired,
   SslMode,
   WafRuleDesired,
 } from './config';
 
 /** Anything this tool owns inside a ruleset phase. Identity is the description marker. */
-export type ManagedRuleDesired = CacheRuleDesired | WafRuleDesired | RateLimitRuleDesired;
+export type ManagedRuleDesired = CacheRuleDesired | WafRuleDesired | RateLimitRuleDesired | RedirectRuleDesired;
 
 /** A DNS record as Cloudflare returns it. Which fields are owned depends on the desired record's management mode. */
 export interface LiveDnsRecord {
@@ -77,7 +85,7 @@ export interface LiveState {
 }
 
 /** One planned-change kind per managed ruleset phase. */
-export type ManagedRuleResource = 'cache-rule' | 'waf-rule' | 'rate-limit-rule';
+export type ManagedRuleResource = 'cache-rule' | 'waf-rule' | 'rate-limit-rule' | 'redirect-rule';
 
 /**
  * Every ruleset phase this tool owns, in one place.
@@ -105,6 +113,7 @@ export interface DesiredRuleSets {
   cacheRules: CacheRuleDesired[];
   wafRules: WafRuleDesired[];
   rateLimitRules: RateLimitRuleDesired[];
+  redirectRules: RedirectRuleDesired[];
 }
 
 export const MANAGED_RULE_PHASES = [
@@ -128,6 +137,13 @@ export const MANAGED_RULE_PHASES = [
     label: 'Rate-limit rule',
     selectLive: (live) => live.rules['rate-limit-rule'],
     selectDesired: (desired) => desired.rateLimitRules,
+  },
+  {
+    resource: 'redirect-rule',
+    phase: DYNAMIC_REDIRECT_RULE_PHASE,
+    label: 'Redirect rule',
+    selectLive: (live) => live.rules['redirect-rule'],
+    selectDesired: (desired) => desired.redirectRules,
   },
 ] as const satisfies readonly ManagedRulePhase[];
 

--- a/infra/cloudflare/plan.ts
+++ b/infra/cloudflare/plan.ts
@@ -317,14 +317,19 @@ export function diffDnsRecord(desired: DnsRecordDesired, liveRecord: LiveDnsReco
         `DNS record "${desired.name}" is missing. It is proxy-only managed and must be created outside this tool.`,
       );
     }
+    const createdFields = [
+      `${desired.type} ${desired.name} → ${desired.content}`,
+      `ttl ${describeDnsTtl(desired.ttl)}`,
+      `proxied ${desired.proxied}`,
+    ];
+    // Only reported when we actually own the field — a proxied record has no
+    // per-record flattening to disable.
+    if (desired.settings) createdFields.push('CNAME flattening disabled');
     return {
       resource: 'dns',
       dnsName: desired.name,
       summary: `DNS ${desired.name}: missing — will create`,
-      detail:
-        `${desired.type} ${desired.name} → ${desired.content}, ttl ${describeDnsTtl(desired.ttl)}, ` +
-        `proxied ${desired.proxied}, ` +
-        `CNAME flattening disabled`,
+      detail: createdFields.join(', '),
     };
   }
 
@@ -347,7 +352,7 @@ export function diffDnsRecord(desired: DnsRecordDesired, liveRecord: LiveDnsReco
   if (liveRecord.proxied !== desired.proxied) {
     driftedFields.push(`proxied ${liveRecord.proxied} → ${desired.proxied}`);
   }
-  if ((liveRecord.settings?.flatten_cname ?? false) !== desired.settings.flatten_cname) {
+  if (desired.settings && (liveRecord.settings?.flatten_cname ?? false) !== desired.settings.flatten_cname) {
     driftedFields.push(
       `flatten_cname ${liveRecord.settings?.flatten_cname ?? false} → ${desired.settings.flatten_cname}`,
     );
@@ -463,12 +468,15 @@ export function buildPlan(
   live: LiveState,
   options: PlanOptions,
 ): PlannedChange[] {
+  // Only a DNS-only CNAME whose literal answer we own is at risk here. A proxied
+  // CNAME is always flattened by Cloudflare, so the zone-wide switch cannot
+  // change anything about it and must not fail its apply.
   const requiresLiteralCname = desired.dnsRecords.some(
     (record) =>
       record.management === 'full' &&
       record.type === 'CNAME' &&
       !record.proxied &&
-      record.settings.flatten_cname === false,
+      record.settings?.flatten_cname === false,
   );
   if (requiresLiteralCname && live.flattenAllCnames) {
     throw new Error(

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -33,7 +33,14 @@ import {
   upsertCacheRule,
 } from '../infra/cloudflare/plan';
 import type { LiveDnsRecord, LiveState, RulesetRule } from '../infra/cloudflare/plan';
-import { SHARED_TOKEN_SCOPES, TOKEN_SCOPES, fullyManagedDnsBody, parseArgs } from './cloudflare-apply';
+import {
+  MANAGED_DNS_RECORD_TYPES,
+  SHARED_TOKEN_SCOPES,
+  TOKEN_SCOPES,
+  fullyManagedDnsBody,
+  parseArgs,
+  selectManagedDnsRecord,
+} from './cloudflare-apply';
 
 const desired = desiredCloudflareState;
 
@@ -51,6 +58,7 @@ function requiredFullyManagedDnsRecord(name: string): FullyManagedDnsRecordDesir
 
 const wsDnsRecord = requiredDnsRecord(WS_HOSTNAME);
 const assetsDnsRecord = requiredFullyManagedDnsRecord(ASSETS_HOSTNAME);
+const wwwDnsRecord = requiredDnsRecord(WWW_HOSTNAME);
 /** The og cache rule — the one the pre-existing cases in this file were written against. */
 const ogCacheRule = desired.cacheRules[0];
 
@@ -60,6 +68,19 @@ function liveDnsRecord(overrides: Partial<LiveDnsRecord> = {}): LiveDnsRecord {
     name: wsDnsRecord.name,
     type: 'CNAME',
     content: 'boardsesh-backend.up.railway.app',
+    ttl: 1,
+    proxied: true,
+    ...overrides,
+  };
+}
+
+/** www as Cloudflare returns it today: a proxied CNAME to Vercel. */
+function liveWwwDnsRecord(overrides: Partial<LiveDnsRecord> = {}): LiveDnsRecord {
+  return {
+    id: 'www-dns-record-id',
+    name: WWW_HOSTNAME,
+    type: 'CNAME',
+    content: 'cname.vercel-dns.com',
     ttl: 1,
     proxied: true,
     ...overrides,
@@ -139,17 +160,40 @@ function matchingLiveRules(
   }));
 }
 
+/**
+ * Live rules for every REGISTERED phase, keyed off MANAGED_RULE_PHASES rather
+ * than a literal per phase. A phase added to the registry without a fixture here
+ * would otherwise leave its key missing and every buildPlan test reading
+ * `undefined` for it.
+ */
+function rulesForEveryPhase(
+  select: (phase: (typeof MANAGED_RULE_PHASES)[number]) => RulesetRule[],
+): LiveState['rules'] {
+  return Object.fromEntries(MANAGED_RULE_PHASES.map((phase) => [phase.resource, select(phase)])) as LiveState['rules'];
+}
+
+/** Every managed rule present and matching. */
+function inSyncRules(): LiveState['rules'] {
+  return rulesForEveryPhase((phase) => matchingLiveRules([...phase.selectDesired(desired)]));
+}
+
+/** No rules anywhere — a zone that has never carried any of our phases. */
+function emptyRules(): LiveState['rules'] {
+  return rulesForEveryPhase(() => []);
+}
+
+function inSyncDnsRecords(): LiveState['dnsRecords'] {
+  return {
+    [wsDnsRecord.name]: liveDnsRecord(),
+    [assetsDnsRecord.name]: liveAssetsDnsRecord(),
+    [wwwDnsRecord.name]: liveWwwDnsRecord(),
+  };
+}
+
 function inSyncLiveState(): LiveState {
   return {
-    dnsRecords: {
-      [wsDnsRecord.name]: liveDnsRecord(),
-      [assetsDnsRecord.name]: liveAssetsDnsRecord(),
-    },
-    rules: {
-      'cache-rule': matchingLiveRules(desired.cacheRules),
-      'waf-rule': matchingLiveRules(desired.wafRules),
-      'rate-limit-rule': matchingLiveRules(desired.rateLimitRules),
-    },
+    dnsRecords: inSyncDnsRecords(),
+    rules: inSyncRules(),
     sslMode: 'strict',
     flattenAllCnames: false,
   };
@@ -345,17 +389,10 @@ describe('buildPlan', () => {
 
   it('collects every drift (dns + cache + ssl) into one plan', () => {
     const drifted: LiveState = {
-      dnsRecords: {
-        [wsDnsRecord.name]: liveDnsRecord({ proxied: false }),
-        [assetsDnsRecord.name]: liveAssetsDnsRecord(),
-      },
-      rules: {
-        'cache-rule': [foreignRule('foreign-a')],
-        'waf-rule': matchingLiveRules(desired.wafRules),
-        'rate-limit-rule': matchingLiveRules(desired.rateLimitRules),
-      },
+      ...inSyncLiveState(),
+      dnsRecords: { ...inSyncDnsRecords(), [wsDnsRecord.name]: liveDnsRecord({ proxied: false }) },
+      rules: { ...inSyncRules(), 'cache-rule': [foreignRule('foreign-a')] },
       sslMode: 'full',
-      flattenAllCnames: false,
     };
     const changes = buildPlan(desired, drifted, { allowZoneSsl: false });
     // Cutover-safe order: the proxied flip is planned last, after SSL + the rules.
@@ -373,13 +410,9 @@ describe('buildPlan', () => {
 
   it('does not hold back the proxied flip when SSL is already compliant', () => {
     const drifted: LiveState = {
-      dnsRecords: {
-        [wsDnsRecord.name]: liveDnsRecord({ proxied: false }),
-        [assetsDnsRecord.name]: liveAssetsDnsRecord(),
-      },
-      rules: { 'cache-rule': [], 'waf-rule': [], 'rate-limit-rule': [] },
-      sslMode: 'strict',
-      flattenAllCnames: false,
+      ...inSyncLiveState(),
+      dnsRecords: { ...inSyncDnsRecords(), [wsDnsRecord.name]: liveDnsRecord({ proxied: false }) },
+      rules: emptyRules(),
     };
     const changes = buildPlan(desired, drifted, { allowZoneSsl: false });
     const dnsChange = changes.find((change) => change.resource === 'dns');
@@ -388,17 +421,13 @@ describe('buildPlan', () => {
 
   it('plans multiple DNS records independently and does not SSL-block a DNS-only create', () => {
     const drifted: LiveState = {
+      ...inSyncLiveState(),
       dnsRecords: {
+        ...inSyncDnsRecords(),
         [wsDnsRecord.name]: liveDnsRecord({ proxied: false }),
         [assetsDnsRecord.name]: null,
       },
-      rules: {
-        'cache-rule': matchingLiveRules(desired.cacheRules),
-        'waf-rule': matchingLiveRules(desired.wafRules),
-        'rate-limit-rule': matchingLiveRules(desired.rateLimitRules),
-      },
       sslMode: 'full',
-      flattenAllCnames: false,
     };
     const changes = buildPlan(desired, drifted, { allowZoneSsl: false });
     const dnsChanges = changes.filter((change) => change.resource === 'dns');
@@ -446,6 +475,127 @@ describe('assets.boardsesh.com desired state', () => {
   it('keeps DNS record identities unique and adds no assets cache rule', () => {
     expect(new Set(desired.dnsRecords.map((record) => record.name)).size).toBe(desired.dnsRecords.length);
     expect(desired.cacheRules.every((rule) => !rule.expression.includes(ASSETS_HOSTNAME))).toBe(true);
+  });
+});
+
+describe('www.boardsesh.com under Cloudflare management (#4655)', () => {
+  /** The exact entry the origin-flip PR replaces the proxy-only one with. */
+  const flippedToRailway: FullyManagedDnsRecordDesired = {
+    management: 'full',
+    name: WWW_HOSTNAME,
+    type: 'CNAME',
+    content: 'web-production.up.railway.app',
+    ttl: 1,
+    proxied: true,
+  };
+
+  it('owns only the proxy flag today, exactly like ws', () => {
+    // The live record is already an orange-clouded CNAME to Vercel, so this
+    // entry is a no-op on apply. Its job is to give the origin flip a line to
+    // change instead of a dashboard click.
+    expect(wwwDnsRecord).toEqual({
+      management: 'proxied-only',
+      name: 'www.boardsesh.com',
+      proxied: true,
+    });
+  });
+
+  it('is zero drift against the live proxied record, whatever it points at', () => {
+    expect(diffDnsRecord(wwwDnsRecord, liveWwwDnsRecord())).toBeNull();
+    // A proxied record answers with Cloudflare IPs, so its real target cannot be
+    // read from outside the dashboard. The tool must not claim to own it yet.
+    expect(diffDnsRecord(wwwDnsRecord, liveWwwDnsRecord({ content: 'something.else.example' }))).toBeNull();
+    expect(diffDnsRecord(wwwDnsRecord, liveWwwDnsRecord({ type: 'A', content: '76.76.21.21' }))).toBeNull();
+  });
+
+  it('plans the orange cloud back on if www is ever grey-clouded', () => {
+    const change = diffDnsRecord(wwwDnsRecord, liveWwwDnsRecord({ proxied: false }));
+    expect(change?.dnsName).toBe(WWW_HOSTNAME);
+    expect(change?.summary).toContain('proxied false → true');
+  });
+
+  it('fails closed instead of inventing a www record when it is missing', () => {
+    expect(() => diffDnsRecord(wwwDnsRecord, null)).toThrow('proxy-only managed');
+  });
+
+  it('accepts the proxied-CNAME shape the origin flip switches this entry to', () => {
+    // The whole point of landing www here first: `management: 'full'` has to be
+    // able to express a PROXIED CNAME, or the flip PR would still be a dashboard
+    // click. Owning `content` is what makes the flip reviewable and revertable.
+    expect(fullyManagedDnsBody(flippedToRailway)).toEqual({
+      type: 'CNAME',
+      name: WWW_HOSTNAME,
+      content: 'web-production.up.railway.app',
+      ttl: 1,
+      proxied: true,
+    });
+    // `settings` is omitted, not sent as false: Cloudflare always flattens a
+    // proxied CNAME, so flatten_cname is not ours to set on this record.
+    expect('settings' in fullyManagedDnsBody(flippedToRailway)).toBe(false);
+
+    const change = diffDnsRecord(flippedToRailway, liveWwwDnsRecord());
+    expect(change?.detail).toContain('content cname.vercel-dns.com → web-production.up.railway.app');
+    expect(change?.detail).not.toContain('flatten_cname');
+  });
+
+  it('does not put a proxied CNAME behind the zone-wide flattening guard', () => {
+    // That guard exists for the DNS-only Tigris CNAME, whose literal answer has
+    // to stay visible. A proxied record is flattened by Cloudflare no matter
+    // what, so a zone with "Flatten all CNAMEs" on must not fail the www apply.
+    const wwwOnly = {
+      dnsRecords: [flippedToRailway],
+      cacheRules: [],
+      wafRules: [],
+      rateLimitRules: [],
+      ssl: desired.ssl,
+    };
+    const flattenedZone: LiveState = {
+      dnsRecords: { [WWW_HOSTNAME]: liveWwwDnsRecord({ content: flippedToRailway.content }) },
+      rules: emptyRules(),
+      sslMode: 'strict',
+      flattenAllCnames: true,
+    };
+
+    expect(buildPlan(wwwOnly, flattenedZone, { allowZoneSsl: false })).toEqual([]);
+  });
+});
+
+describe('selectManagedDnsRecord', () => {
+  const recordAt = (type: string, content: string, overrides: Partial<LiveDnsRecord> = {}): LiveDnsRecord => ({
+    id: `${type}-id`,
+    name: WWW_HOSTNAME,
+    type,
+    content,
+    ttl: 1,
+    proxied: true,
+    ...overrides,
+  });
+
+  it('ignores the non-address records Cloudflare returns for the same name', () => {
+    // The lookup is by name and Cloudflare answers with every type at it. The
+    // apex carries MX/TXT/CAA as a matter of course, and treating those as
+    // candidates would fail the whole apply with "ambiguous" on an ordinary zone.
+    const records = [
+      recordAt('TXT', 'v=spf1 -all'),
+      recordAt('MX', 'mx.example.com'),
+      recordAt('CNAME', 'cname.vercel-dns.com'),
+      recordAt('CAA', '0 issue "letsencrypt.org"'),
+    ];
+
+    expect(selectManagedDnsRecord(records, WWW_HOSTNAME)?.type).toBe('CNAME');
+    expect(MANAGED_DNS_RECORD_TYPES).toEqual(['A', 'AAAA', 'CNAME']);
+  });
+
+  it('still refuses to guess between two address records at one name', () => {
+    expect(() =>
+      selectManagedDnsRecord([recordAt('A', '203.0.113.1'), recordAt('AAAA', '2001:db8::1')], WWW_HOSTNAME),
+    ).toThrow('ambiguous');
+  });
+
+  it('ignores a different name, and reports absence as null', () => {
+    const elsewhere = recordAt('A', '203.0.113.1', { name: 'other.boardsesh.com' });
+    expect(selectManagedDnsRecord([elsewhere], WWW_HOSTNAME)).toBeNull();
+    expect(selectManagedDnsRecord([], WWW_HOSTNAME)).toBeNull();
   });
 });
 

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -1,9 +1,12 @@
 /// <reference types="node" />
 
 import { readFileSync } from 'node:fs';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  APEX_HOSTNAME,
+  APEX_ORIGINLESS_ADDRESS,
+  APEX_REDIRECT_RULE_DESCRIPTION,
   ASSETS_CNAME_TARGET,
   ASSETS_HOSTNAME,
   BACKEND_BOARD_RENDER_CACHE_RULE_DESCRIPTION,
@@ -14,6 +17,7 @@ import {
   CRAWLER_BLOCK_RULE_DESCRIPTION,
   CRAWLER_BLOCK_TOKENS,
   CLIMB_VIEW_RATE_LIMIT_RULE_DESCRIPTION,
+  DYNAMIC_REDIRECT_RULE_PHASE,
   RATE_LIMIT_RULE_PHASE,
   WWW_HOSTNAME,
   WS_HOSTNAME,
@@ -39,6 +43,7 @@ import {
   TOKEN_SCOPES,
   fullyManagedDnsBody,
   parseArgs,
+  runCloudflareApply,
   selectManagedDnsRecord,
 } from './cloudflare-apply';
 
@@ -59,6 +64,7 @@ function requiredFullyManagedDnsRecord(name: string): FullyManagedDnsRecordDesir
 const wsDnsRecord = requiredDnsRecord(WS_HOSTNAME);
 const assetsDnsRecord = requiredFullyManagedDnsRecord(ASSETS_HOSTNAME);
 const wwwDnsRecord = requiredDnsRecord(WWW_HOSTNAME);
+const apexDnsRecord = requiredFullyManagedDnsRecord(APEX_HOSTNAME);
 /** The og cache rule — the one the pre-existing cases in this file were written against. */
 const ogCacheRule = desired.cacheRules[0];
 
@@ -85,6 +91,24 @@ function liveWwwDnsRecord(overrides: Partial<LiveDnsRecord> = {}): LiveDnsRecord
     proxied: true,
     ...overrides,
   };
+}
+
+/** The apex once converged: a proxied, originless AAAA. */
+function liveApexDnsRecord(overrides: Partial<LiveDnsRecord> = {}): LiveDnsRecord {
+  return {
+    id: 'apex-dns-record-id',
+    name: APEX_HOSTNAME,
+    type: apexDnsRecord.type,
+    content: apexDnsRecord.content,
+    ttl: apexDnsRecord.ttl,
+    proxied: apexDnsRecord.proxied,
+    ...overrides,
+  };
+}
+
+/** The apex as it stands BEFORE this change: a DNS-only A record to Vercel. */
+function liveVercelApexDnsRecord(): LiveDnsRecord {
+  return liveApexDnsRecord({ type: 'A', content: '76.76.21.21', proxied: false });
 }
 
 function liveAssetsDnsRecord(overrides: Partial<LiveDnsRecord> = {}): LiveDnsRecord {
@@ -187,6 +211,7 @@ function inSyncDnsRecords(): LiveState['dnsRecords'] {
     [wsDnsRecord.name]: liveDnsRecord(),
     [assetsDnsRecord.name]: liveAssetsDnsRecord(),
     [wwwDnsRecord.name]: liveWwwDnsRecord(),
+    [apexDnsRecord.name]: liveApexDnsRecord(),
   };
 }
 
@@ -547,6 +572,7 @@ describe('www.boardsesh.com under Cloudflare management (#4655)', () => {
       cacheRules: [],
       wafRules: [],
       rateLimitRules: [],
+      redirectRules: [],
       ssl: desired.ssl,
     };
     const flattenedZone: LiveState = {
@@ -1029,5 +1055,302 @@ describe('climb-view rate-limit rule', () => {
       ratelimit: { ...desired.rateLimitRules[0].ratelimit, requests_per_period: 45 },
     };
     expect(cacheRuleMatches(live, retuned)).toBe(false);
+  });
+});
+
+describe('apex → www redirect (#4655)', () => {
+  const redirectRule = desired.redirectRules.find((rule) => rule.description === APEX_REDIRECT_RULE_DESCRIPTION);
+
+  it('registers the dynamic-redirect phase, so the read, diff and apply all cover it', () => {
+    // The registry is the single array all three iterate. A phase declared
+    // anywhere else gets planned and never written, or written and never
+    // planned — the exact bug MANAGED_RULE_PHASES exists to prevent.
+    const entry = MANAGED_RULE_PHASES.find((phase) => phase.resource === 'redirect-rule');
+    expect(entry?.phase).toBe(DYNAMIC_REDIRECT_RULE_PHASE);
+    expect(DYNAMIC_REDIRECT_RULE_PHASE).toBe('http_request_dynamic_redirect');
+    expect(entry && resolveRulePhase('redirect-rule')).toBe(entry);
+    expect(entry && [...entry.selectDesired(desired)]).toEqual(desired.redirectRules);
+  });
+
+  it('points the apex at Cloudflare rather than at an origin', () => {
+    // Originless by design: the record exists so Cloudflare terminates the
+    // request and the rule below answers it. `100::` is the address Cloudflare
+    // documents for exactly this — the RFC 6666 discard prefix, so a packet
+    // that somehow escaped the proxy is dropped rather than delivered.
+    expect(apexDnsRecord).toEqual({
+      management: 'full',
+      name: 'boardsesh.com',
+      type: 'AAAA',
+      content: '100::',
+      ttl: 1,
+      proxied: true,
+    });
+    expect(APEX_ORIGINLESS_ADDRESS).toBe('100::');
+    // Grey-clouding it would leave the apex resolving to an unroutable address
+    // with nothing in front of it, i.e. the domain goes dark.
+    expect(apexDnsRecord.proxied).toBe(true);
+  });
+
+  it('plans the flip off the Vercel apex A record', () => {
+    const change = diffDnsRecord(apexDnsRecord, liveVercelApexDnsRecord());
+
+    expect(change?.dnsName).toBe(APEX_HOSTNAME);
+    expect(change?.detail).toContain('type A → AAAA');
+    expect(change?.detail).toContain('content 76.76.21.21 → 100::');
+    expect(change?.detail).toContain('proxied false → true');
+    // No settings block on this record, so nothing to say about flattening.
+    expect(change?.detail).not.toContain('flatten_cname');
+  });
+
+  it('writes the apex body without a settings block', () => {
+    expect(fullyManagedDnsBody(apexDnsRecord)).toEqual({
+      type: 'AAAA',
+      name: 'boardsesh.com',
+      content: '100::',
+      ttl: 1,
+      proxied: true,
+    });
+  });
+
+  it('sends a 301 to www, rebuilding the path and preserving the query', () => {
+    // Cloudflare's single-redirect shape: the payload nests under
+    // action_parameters.from_value, and target_url is EITHER { value } for a
+    // fixed destination or { expression } for a computed one — never both.
+    expect(redirectRule).toEqual({
+      description: APEX_REDIRECT_RULE_DESCRIPTION,
+      expression: 'http.host eq "boardsesh.com"',
+      action: 'redirect',
+      action_parameters: {
+        from_value: {
+          status_code: 301,
+          target_url: { expression: 'concat("https://www.boardsesh.com", http.request.uri.path)' },
+          preserve_query_string: true,
+        },
+      },
+      enabled: true,
+    });
+    // preserve_query_string is what carries `?a=1`, which is why the expression
+    // only rebuilds the path. Cloudflare's rules language has no ternary
+    // operator, so assembling the query inside the expression is not an option.
+    expect(redirectRule?.action_parameters.from_value.target_url.expression).not.toContain('uri.query');
+  });
+
+  it('matches the apex and nothing else on the zone', () => {
+    // http.host is the request Host header. Every other name on this zone —
+    // www, ws, assets, app, updates — has to keep serving itself.
+    const expression = redirectRule?.expression ?? '';
+    for (const host of [WWW_HOSTNAME, WS_HOSTNAME, ASSETS_HOSTNAME, 'app.boardsesh.com', 'updates.boardsesh.com']) {
+      expect(expression).not.toContain(`"${host}"`);
+    }
+    expect(expression).toContain(`"${APEX_HOSTNAME}"`);
+  });
+
+  it('keeps the marker distinct from every other managed rule', () => {
+    // Identity is the description marker, across all phases: a collision would
+    // make the upsert treat one rule as another and silently drop it.
+    const everyDescription = MANAGED_RULE_PHASES.flatMap((phase) =>
+      phase.selectDesired(desired).map((rule) => rule.description),
+    );
+    expect(new Set(everyDescription).size).toBe(everyDescription.length);
+    expect(APEX_REDIRECT_RULE_DESCRIPTION).toContain('boardsesh:apex-to-www');
+  });
+
+  it('round-trips through the phase upsert: create, then no-op', () => {
+    const created = upsertCacheRule([], [...desired.redirectRules]);
+    expect(created.changed).toBe(true);
+    expect(created.rules).toHaveLength(desired.redirectRules.length);
+    expect(created.rules[0]).toMatchObject({
+      description: APEX_REDIRECT_RULE_DESCRIPTION,
+      action: 'redirect',
+      action_parameters: desired.redirectRules[0].action_parameters,
+    });
+
+    const live = matchingLiveRules([...desired.redirectRules]);
+    expect(cacheRuleMatches(live[0], desired.redirectRules[0])).toBe(true);
+    expect(upsertCacheRule(live, [...desired.redirectRules]).changed).toBe(false);
+    expect(diffManagedRules(live, desired.redirectRules, 'redirect-rule')).toEqual([]);
+  });
+
+  it('treats a changed status code as drift', () => {
+    // The redirect payload lives entirely in action_parameters, so if that were
+    // dropped from the comparison the rule would be write-once and a later
+    // 301 → 302 edit would diff clean and never reach the zone.
+    const live = matchingLiveRules([...desired.redirectRules])[0];
+    const asDeclared = desired.redirectRules[0];
+    const temporary = {
+      ...asDeclared,
+      action_parameters: {
+        from_value: { ...asDeclared.action_parameters.from_value, status_code: 302 as unknown as 301 },
+      },
+    };
+    expect(cacheRuleMatches(live, temporary)).toBe(false);
+  });
+
+  it('preserves a foreign redirect rule when it writes its own', () => {
+    // The PUT replaces the WHOLE phase. Any redirect someone added by hand — a
+    // vanity URL, a campaign link — is deleted unless it is merged through.
+    const foreignRedirect: RulesetRule = {
+      id: 'foreign-redirect-id',
+      version: '1',
+      description: 'hand-made vanity redirect',
+      expression: '(http.request.uri.path eq "/discord")',
+      action: 'redirect',
+      action_parameters: { from_value: { status_code: 302, target_url: { value: 'https://discord.gg/boardsesh' } } },
+      enabled: true,
+    };
+
+    const { rules } = upsertCacheRule([foreignRedirect], [...desired.redirectRules]);
+
+    expect(rules[0]).toBe(foreignRedirect);
+    expect(rules).toHaveLength(1 + desired.redirectRules.length);
+    expect(rules.at(-1)?.description).toBe(APEX_REDIRECT_RULE_DESCRIPTION);
+  });
+
+  it('plans the redirect rule when the phase is empty', () => {
+    const drifted: LiveState = { ...inSyncLiveState(), rules: { ...inSyncRules(), 'redirect-rule': [] } };
+    const changes = buildPlan(desired, drifted, { allowZoneSsl: false });
+
+    expect(changes.map((change) => change.resource)).toEqual(['redirect-rule']);
+    expect(changes[0].summary).toContain('Redirect rule');
+    expect(changes[0].summary).toContain('missing — will create');
+  });
+
+  it('names the Cloudflare permission the phase needs', () => {
+    // Without it, deploy-cloudflare 403s on THIS phase only: the cache, WAF and
+    // rate-limit phases apply and the zone is left half-converged.
+    expect(TOKEN_SCOPES.join('\n')).toContain('Zone.Dynamic Redirect Edit');
+  });
+});
+
+describe('the apply loop, driven end to end against a stubbed Cloudflare API', () => {
+  // Every test above this one checks a pure function. None of them can see the
+  // failure that actually matters: a plan that reports drift and an apply loop
+  // that never issues the write. This drives the real entry point and asserts
+  // on the requests it makes.
+  interface RecordedRequest {
+    method: string;
+    pathname: string;
+    body: Record<string, unknown> | undefined;
+  }
+
+  const phaseEntrypoint = (phase: string) => `/client/v4/zones/zone-1/rulesets/phases/${phase}/entrypoint`;
+
+  const otherApexRecord = (id: string, type: string, content: string): LiveDnsRecord => ({
+    id,
+    name: APEX_HOSTNAME,
+    type,
+    content,
+    ttl: 1,
+    proxied: false,
+  });
+
+  /** DNS as the zone answers today: everything converged except the apex, which is passed in. */
+  function dnsResponses(apexRecord: LiveDnsRecord): Record<string, LiveDnsRecord[]> {
+    return {
+      [WS_HOSTNAME]: [liveDnsRecord()],
+      [ASSETS_HOSTNAME]: [liveAssetsDnsRecord()],
+      [WWW_HOSTNAME]: [liveWwwDnsRecord()],
+      // The apex carries the mail and verification records every zone has.
+      // Cloudflare returns them from the same by-name lookup, and they must not
+      // make the address record look ambiguous and fail the whole run.
+      [APEX_HOSTNAME]: [
+        otherApexRecord('apex-txt-id', 'TXT', 'v=spf1 -all'),
+        apexRecord,
+        otherApexRecord('apex-mx-id', 'MX', '10 mx.example.com'),
+        otherApexRecord('apex-caa-id', 'CAA', '0 issue "letsencrypt.org"'),
+      ],
+    };
+  }
+
+  /** Stub the API with every managed phase EMPTY, so all of them are drift. */
+  function stubCloudflareApi(dnsByName: Record<string, LiveDnsRecord[]>): RecordedRequest[] {
+    const requests: RecordedRequest[] = [];
+    const envelope = (result: unknown) =>
+      new Response(JSON.stringify({ success: true, errors: [], messages: [], result }), { status: 200 });
+
+    vi.stubGlobal('fetch', (input: string, init?: { method?: string; body?: string }) => {
+      const url = new URL(input);
+      const method = init?.method ?? 'GET';
+      requests.push({
+        method,
+        pathname: url.pathname,
+        body: init?.body ? (JSON.parse(init.body) as Record<string, unknown>) : undefined,
+      });
+
+      if (url.pathname === '/client/v4/zones') return envelope([{ id: 'zone-1', name: desired.zoneName }]);
+      if (url.pathname === '/client/v4/zones/zone-1/dns_records') {
+        return envelope(dnsByName[url.searchParams.get('name') ?? ''] ?? []);
+      }
+      if (url.pathname.startsWith('/client/v4/zones/zone-1/dns_records/')) return envelope({});
+      if (url.pathname === '/client/v4/zones/zone-1/settings/ssl') return envelope({ id: 'ssl', value: 'strict' });
+      if (url.pathname === '/client/v4/zones/zone-1/dns_settings') return envelope({ flatten_all_cnames: false });
+      if (url.pathname.includes('/rulesets/phases/')) return envelope({ id: 'ruleset-id', rules: [] });
+      throw new Error(`Unstubbed Cloudflare request: ${method} ${url.pathname}`);
+    });
+
+    vi.stubEnv('CLOUDFLARE_API_TOKEN', 'test-token');
+    // Empty, so the run exercises the resolve-zone-id-by-name path too.
+    vi.stubEnv('CLOUDFLARE_ZONE_ID', '');
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    return requests;
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('writes EVERY registered rule phase, so a phase can never be planned but not applied', async () => {
+    const requests = stubCloudflareApi(dnsResponses(liveApexDnsRecord()));
+
+    expect(await runCloudflareApply(['--apply'])).toBe(0);
+
+    const written = requests.filter((request) => request.method === 'PUT').map((request) => request.pathname);
+    for (const phase of MANAGED_RULE_PHASES) {
+      expect(written, `${phase.phase} was planned but never written`).toContain(phaseEntrypoint(phase.phase));
+    }
+    // One PUT per phase, not one per drifted rule — the rulesets API only offers
+    // a whole-phase write.
+    expect(written).toHaveLength(MANAGED_RULE_PHASES.length);
+  });
+
+  it('sends the apex redirect rule verbatim in the dynamic-redirect PUT', async () => {
+    const requests = stubCloudflareApi(dnsResponses(liveApexDnsRecord()));
+
+    await runCloudflareApply(['--apply']);
+
+    const redirectPut = requests.find(
+      (request) => request.method === 'PUT' && request.pathname === phaseEntrypoint(DYNAMIC_REDIRECT_RULE_PHASE),
+    );
+    expect(redirectPut?.body).toEqual({ rules: desired.redirectRules });
+  });
+
+  it('converges the apex off Vercel without tripping over its TXT, MX and CAA siblings', async () => {
+    const requests = stubCloudflareApi(dnsResponses(liveVercelApexDnsRecord()));
+
+    expect(await runCloudflareApply(['--apply'])).toBe(0);
+
+    const apexPatch = requests.find(
+      (request) => request.method === 'PATCH' && request.pathname.endsWith('/dns_records/apex-dns-record-id'),
+    );
+    expect(apexPatch?.body).toEqual({
+      type: 'AAAA',
+      name: APEX_HOSTNAME,
+      content: APEX_ORIGINLESS_ADDRESS,
+      ttl: 1,
+      proxied: true,
+    });
+    // www and ws are already converged, so nothing else on the zone is touched.
+    expect(requests.filter((request) => request.method === 'PATCH' || request.method === 'POST')).toHaveLength(1);
+  });
+
+  it('mutates nothing on a dry-run, and still reports the drift with a non-zero exit', async () => {
+    const requests = stubCloudflareApi(dnsResponses(liveVercelApexDnsRecord()));
+
+    expect(await runCloudflareApply([])).toBe(1);
+
+    expect(requests.every((request) => request.method === 'GET')).toBe(true);
   });
 });

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -93,7 +93,7 @@ function liveWwwDnsRecord(overrides: Partial<LiveDnsRecord> = {}): LiveDnsRecord
   };
 }
 
-/** The apex once converged: a proxied, originless AAAA. */
+/** The apex once converged: the same A record, now proxied and originless. */
 function liveApexDnsRecord(overrides: Partial<LiveDnsRecord> = {}): LiveDnsRecord {
   return {
     id: 'apex-dns-record-id',
@@ -1074,39 +1074,50 @@ describe('apex → www redirect (#4655)', () => {
 
   it('points the apex at Cloudflare rather than at an origin', () => {
     // Originless by design: the record exists so Cloudflare terminates the
-    // request and the rule below answers it. `100::` is the address Cloudflare
-    // documents for exactly this — the RFC 6666 discard prefix, so a packet
-    // that somehow escaped the proxy is dropped rather than delivered.
+    // request and the rule below answers it. `192.0.2.0` is one of the two
+    // addresses Cloudflare documents for exactly this — RFC 5737 TEST-NET-1,
+    // reserved and never routed, so a packet that escaped the proxy goes
+    // nowhere real.
     expect(apexDnsRecord).toEqual({
       management: 'full',
       name: 'boardsesh.com',
-      type: 'AAAA',
-      content: '100::',
+      type: 'A',
+      content: '192.0.2.0',
       ttl: 1,
       proxied: true,
     });
-    expect(APEX_ORIGINLESS_ADDRESS).toBe('100::');
+    expect(APEX_ORIGINLESS_ADDRESS).toBe('192.0.2.0');
     // Grey-clouding it would leave the apex resolving to an unroutable address
     // with nothing in front of it, i.e. the domain goes dark.
     expect(apexDnsRecord.proxied).toBe(true);
   });
 
-  it('plans the flip off the Vercel apex A record', () => {
+  it('keeps the record TYPE the live apex already has, so the apply is in place', () => {
+    // The apex is an existing DNS-only A record to Vercel. Declaring the AAAA
+    // placeholder instead would make the apply change the record's type, which
+    // either lands a second record beside the A — split-brain, some resolvers
+    // on Vercel unproxied and some on Cloudflare — or leans on the API
+    // accepting a type change in place. Neither belongs in a production apply.
+    expect(apexDnsRecord.type).toBe(liveVercelApexDnsRecord().type);
+  });
+
+  it('plans the flip off Vercel as content + proxied only', () => {
     const change = diffDnsRecord(apexDnsRecord, liveVercelApexDnsRecord());
 
     expect(change?.dnsName).toBe(APEX_HOSTNAME);
-    expect(change?.detail).toContain('type A → AAAA');
-    expect(change?.detail).toContain('content 76.76.21.21 → 100::');
+    expect(change?.detail).toContain('content 76.76.21.21 → 192.0.2.0');
     expect(change?.detail).toContain('proxied false → true');
+    // No type change: that is the whole point of the A-record placeholder.
+    expect(change?.detail).not.toContain('type ');
     // No settings block on this record, so nothing to say about flattening.
     expect(change?.detail).not.toContain('flatten_cname');
   });
 
   it('writes the apex body without a settings block', () => {
     expect(fullyManagedDnsBody(apexDnsRecord)).toEqual({
-      type: 'AAAA',
+      type: 'A',
       name: 'boardsesh.com',
-      content: '100::',
+      content: '192.0.2.0',
       ttl: 1,
       proxied: true,
     });
@@ -1335,15 +1346,37 @@ describe('the apply loop, driven end to end against a stubbed Cloudflare API', (
     const apexPatch = requests.find(
       (request) => request.method === 'PATCH' && request.pathname.endsWith('/dns_records/apex-dns-record-id'),
     );
+    // PATCH, not POST: the apex record already exists and keeps its id, so the
+    // Vercel A record is updated in place rather than joined by a second one.
     expect(apexPatch?.body).toEqual({
-      type: 'AAAA',
+      type: 'A',
       name: APEX_HOSTNAME,
       content: APEX_ORIGINLESS_ADDRESS,
       ttl: 1,
       proxied: true,
     });
-    // www and ws are already converged, so nothing else on the zone is touched.
+    // www and ws are already converged, so nothing else on the zone is touched,
+    // and nothing is CREATED anywhere.
     expect(requests.filter((request) => request.method === 'PATCH' || request.method === 'POST')).toHaveLength(1);
+    expect(requests.some((request) => request.method === 'POST')).toBe(false);
+  });
+
+  it('aborts before any write when the apex holds two address records', async () => {
+    // With the address-type filter in place, TXT/MX/CAA siblings are ignored —
+    // but an A AND an AAAA at the apex is a real conflict. Picking one would
+    // silently converge half the zone's resolvers onto a black hole, so the
+    // read fails closed, and it runs before every mutation.
+    const both = dnsResponses(liveVercelApexDnsRecord());
+    both[APEX_HOSTNAME] = [
+      ...both[APEX_HOSTNAME],
+      liveApexDnsRecord({ id: 'apex-aaaa-id', type: 'AAAA', content: '100::' }),
+    ];
+    const requests = stubCloudflareApi(both);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(runCloudflareApply(['--apply'])).rejects.toThrow('ambiguous');
+
+    expect(requests.every((request) => request.method === 'GET')).toBe(true);
   });
 
   it('mutates nothing on a dry-run, and still reports the drift with a non-zero exit', async () => {

--- a/scripts/cloudflare-apply.ts
+++ b/scripts/cloudflare-apply.ts
@@ -14,7 +14,12 @@
  *     CNAME flattening disabled. Zone-wide CNAME flattening fails closed because
  *     it would hide the literal answer Tigris verifies.
  *     `www.boardsesh.com` is proxy-only managed like `ws`, so the origin flip
- *     off Vercel is one edit to infra/cloudflare/config.ts (#4655).
+ *     off Vercel is one edit to infra/cloudflare/config.ts (#4655). The apex
+ *     `boardsesh.com` is fully managed as a PROXIED, originless AAAA to the
+ *     reserved `100::` so Cloudflare terminates it and the redirect rule below
+ *     answers — it no longer reaches Vercel at all.
+ *   - Redirect: one rule in the http_request_dynamic_redirect phase sending the
+ *     apex to www with a 301, preserving path and query.
  *   - Cache: one rule in the http_request_cache_settings phase that makes
  *     ws.boardsesh.com/og/* eligible for cache and respects the origin TTL. Any OTHER
  *     rule already in that phase is preserved verbatim.
@@ -52,13 +57,14 @@ const CF_API_BASE = 'https://api.cloudflare.com/client/v4';
 // The exact Cloudflare API token scopes this tool needs, printed when the token is
 // missing so a maintainer can create one with the right (minimal) permissions.
 const TOKEN_SCOPES = [
-  'Zone.Zone Read           — resolve the zone id by name + read zone list',
-  'Zone.DNS Edit            — manage DNS records + read zone CNAME-flattening settings',
-  'Zone.Cache Rules Edit    — create/update the /og/ cache rule',
-  'Zone.WAF Edit            — create/update the two crawler rules',
-  'Zone.Rate Limit Edit     — create/update the climb-view rate-limit rule (http_ratelimit phase)',
-  'Zone.Zone Settings Read  — read the SSL/TLS mode',
-  'Zone.Zone Settings Edit  — ONLY needed with --allow-zone-ssl (to set the zone SSL mode)',
+  'Zone.Zone Read             — resolve the zone id by name + read zone list',
+  'Zone.DNS Edit              — manage DNS records + read zone CNAME-flattening settings',
+  'Zone.Cache Rules Edit      — create/update the /og/ cache rule',
+  'Zone.WAF Edit              — create/update the two crawler rules',
+  'Zone.Rate Limit Edit       — create/update the climb-view rate-limit rule (http_ratelimit phase)',
+  'Zone.Dynamic Redirect Edit — create/update the apex → www redirect (http_request_dynamic_redirect phase)',
+  'Zone.Zone Settings Read    — read the SSL/TLS mode',
+  'Zone.Zone Settings Edit    — ONLY needed with --allow-zone-ssl (to set the zone SSL mode)',
 ];
 
 // Scopes another consumer of the SAME Production-environment CLOUDFLARE_API_TOKEN
@@ -339,8 +345,15 @@ function printTokenScopes(): void {
   console.error('           https://dash.cloudflare.com/profile/api-tokens');
 }
 
-async function main(): Promise<number> {
-  const options = parseArgs(process.argv.slice(2));
+/**
+ * The whole run: read, plan, print, and (with --apply) converge. Exported and
+ * argv-injected so a test can drive it end to end against a stubbed `fetch` and
+ * assert which requests it actually makes — the apply loop routes every rule
+ * phase through one branch, and "the loop quietly skipped a phase" is a bug no
+ * amount of pure-function testing can see.
+ */
+export async function runCloudflareApply(argv: string[] = process.argv.slice(2)): Promise<number> {
+  const options = parseArgs(argv);
 
   if (options.help) {
     console.log(
@@ -445,7 +458,7 @@ async function main(): Promise<number> {
 export { CF_API_BASE, SHARED_TOKEN_SCOPES, TOKEN_SCOPES, ZONE_NAME };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main()
+  runCloudflareApply()
     .then((code) => process.exit(code))
     .catch((error) => {
       console.error(`[cf-apply] ${error instanceof Error ? error.message : String(error)}`);

--- a/scripts/cloudflare-apply.ts
+++ b/scripts/cloudflare-apply.ts
@@ -13,6 +13,8 @@
  *     CNAME → the Tigris bucket target, automatic TTL, DNS-only, with per-record
  *     CNAME flattening disabled. Zone-wide CNAME flattening fails closed because
  *     it would hide the literal answer Tigris verifies.
+ *     `www.boardsesh.com` is proxy-only managed like `ws`, so the origin flip
+ *     off Vercel is one edit to infra/cloudflare/config.ts (#4655).
  *   - Cache: one rule in the http_request_cache_settings phase that makes
  *     ws.boardsesh.com/og/* eligible for cache and respects the origin TTL. Any OTHER
  *     rule already in that phase is preserved verbatim.
@@ -169,17 +171,40 @@ async function resolveZoneId(token: string, zoneName: string): Promise<string> {
   return zone.id;
 }
 
+/**
+ * The record types this tool ever owns.
+ *
+ * The lookup below is by NAME, and Cloudflare's list endpoint returns every type
+ * at that name. `www` and the zone apex routinely carry MX, TXT (SPF, DMARC,
+ * domain-verification) and CAA records alongside their address record, and
+ * counting those as "the record" would make an ordinary hostname look ambiguous
+ * and fail the entire apply. Narrowing to the address types keeps the ambiguity
+ * check meaningful: two ADDRESS records at one name is a genuine conflict this
+ * tool must not guess its way through.
+ */
+export const MANAGED_DNS_RECORD_TYPES = ['A', 'AAAA', 'CNAME'] as const;
+
+/** Pick the one address record at `name`, or null. Throws when the name carries more than one. */
+export function selectManagedDnsRecord(records: LiveDnsRecord[], name: string): LiveDnsRecord | null {
+  const addressRecords = records.filter(
+    (candidate) => candidate.name === name && (MANAGED_DNS_RECORD_TYPES as readonly string[]).includes(candidate.type),
+  );
+  if (addressRecords.length > 1) {
+    throw new Error(
+      `DNS name "${name}" is ambiguous: Cloudflare returned ${addressRecords.length} address records ` +
+        `(${addressRecords.map((record) => record.type).join(', ')}). Resolve it in the Cloudflare dashboard first.`,
+    );
+  }
+  return addressRecords[0] ?? null;
+}
+
 async function fetchDnsRecord(token: string, zoneId: string, name: string): Promise<LiveDnsRecord | null> {
   const records = await cfRequest<LiveDnsRecord[]>(
     token,
     'GET',
     `/zones/${zoneId}/dns_records?name=${encodeURIComponent(name)}`,
   );
-  const exactRecords = records.filter((candidate) => candidate.name === name);
-  if (exactRecords.length > 1) {
-    throw new Error(`DNS name "${name}" is ambiguous: Cloudflare returned ${exactRecords.length} exact records`);
-  }
-  return exactRecords[0] ?? null;
+  return selectManagedDnsRecord(records, name);
 }
 
 /** A phase's entrypoint ruleset. Returns an empty rule set when the phase has no ruleset yet (404). */
@@ -258,7 +283,10 @@ export function fullyManagedDnsBody(desired: FullyManagedDnsRecordDesired): Reco
     content: desired.content,
     ttl: desired.ttl,
     proxied: desired.proxied,
-    settings: desired.settings,
+    // Left out entirely when we do not own it. `settings: undefined` would
+    // serialise away anyway, but an explicit omission is what documents that a
+    // proxied record has no per-record flattening for us to set.
+    ...(desired.settings ? { settings: desired.settings } : {}),
   };
 }
 

--- a/scripts/cloudflare-apply.ts
+++ b/scripts/cloudflare-apply.ts
@@ -15,9 +15,11 @@
  *     it would hide the literal answer Tigris verifies.
  *     `www.boardsesh.com` is proxy-only managed like `ws`, so the origin flip
  *     off Vercel is one edit to infra/cloudflare/config.ts (#4655). The apex
- *     `boardsesh.com` is fully managed as a PROXIED, originless AAAA to the
- *     reserved `100::` so Cloudflare terminates it and the redirect rule below
- *     answers — it no longer reaches Vercel at all.
+ *     `boardsesh.com` is fully managed as a PROXIED, originless A record to the
+ *     reserved `192.0.2.0` so Cloudflare terminates it and the redirect rule
+ *     below answers — it no longer reaches Vercel at all. Keeping it an A record
+ *     makes that an in-place update of the record Vercel already owns rather
+ *     than a record-type change.
  *   - Redirect: one rule in the http_request_dynamic_redirect phase sending the
  *     apex to www with a 301, preserving path and query.
  *   - Cache: one rule in the http_request_cache_settings phase that makes


### PR DESCRIPTION
## Summary

Puts the last two hand-managed hostnames on the `boardsesh.com` zone under
config-as-code, so the Vercel → Railway origin flip is a reviewable diff instead
of a dashboard click.

**Commit 1 — `feat(repo): bring www under Cloudflare DNS management`** (no
production effect). Adds `www.boardsesh.com` to `dnsRecords` with
`management: 'proxied-only'`, the same ownership boundary as `ws`: the target
stays whatever the dashboard says, and a dry-run against the already-proxied
live record reports zero drift. Two things had to change for the later flip line
to be expressible at all:

- `management: 'full'` required a `settings.flatten_cname: false` block, which
  is a DNS-only concept — Cloudflare always flattens a **proxied** CNAME. It is
  now optional and omitted from the write body when absent, so the flip entry
  can own `content` on a proxied record. The zone-wide flattening guard narrows
  to DNS-only records for the same reason.
- The record lookup is by name, and Cloudflare returns *every* type at that
  name. `www` and the apex carry TXT/MX/CAA records, which the old exact-name
  filter counted as duplicates and reported as "ambiguous", failing the whole
  apply. Selection now considers only `A`, `AAAA` and `CNAME`; two *address*
  records at one name still fail closed.

**Commit 2 — `feat(repo): serve the apex → www redirect from Cloudflare`.**
The apex becomes a proxied, originless `A` record to the reserved `192.0.2.0`
(RFC 5737 TEST-NET-1), and a new
managed phase `http_request_dynamic_redirect` carries one rule
(`boardsesh:apex-to-www`) sending 301 to
`concat("https://www.boardsesh.com", http.request.uri.path)` with
`preserve_query_string` on. The phase is wired through read/diff/apply exactly
the way `http_ratelimit` was in #4962.

> ⚠️ **Commit 2 is a LIVE change the moment this merges.** `deploy-cloudflare`
> runs `vp run cf:apply -- --apply` on every push to `main` touching
> `infra/cloudflare/**`. On merge the apex record is updated **in place** from
> the DNS-only Vercel `A` (`76.76.21.21`) to a proxied `A 192.0.2.0`, and
> Cloudflare — not Vercel — starts serving the apex → www redirect (301, not
> Vercel's 308). Keeping the placeholder an `A` record is deliberate: it makes
> that a content + proxy-flag change on the record that already exists, rather
> than a record-type change, which would either land a second record beside the
> A (split-brain: some resolvers on Vercel unproxied, others on Cloudflare) or
> depend on the API accepting a type change in place.
>
> ⚠️ **The token needs a new scope BEFORE this merges.** Add
> **Zone → Dynamic Redirect → Edit** to the Production-environment
> `CLOUDFLARE_API_TOKEN` — it is on the maintainer checklist in #4648. Without
> it the apply 403s on this phase *only*; the cache, WAF and rate-limit phases
> still apply. In Cloudflare's permission picker the row is called **Dynamic
> Redirect**, not "Redirect Rules" or "Single Redirects". Editing the token
> rewrites all its policies, so keep `Account.Cloudflare Pages Edit` on it (see
> `docs/cloudflare.md`).
>
> **Apply order contains that blast radius.** The plan is ordered SSL → rule
> phases → DNS last, and the loop aborts on the first failed request — so a 403
> on the redirect phase stops the run *before* the apex DNS record is touched.
> The apex keeps pointing at Vercel and keeps serving today's 308; nothing is
> half-flipped. On a successful run the same ordering means the redirect rule
> PUT lands before the DNS change, so the apex is never proxied without a rule
> to answer it. The live-state read also fails closed — before any write — if
> the apex ever holds both an A and an AAAA record.

`assets`, `ws`, the cache rules, the WAF rules and the rate-limit rule are
untouched.

`www` itself does **not** move in this PR. Its flip is a separate one-entry edit,
documented in the new "Flipping www to a new origin" section of
`docs/cloudflare.md`, and its rollback is a `git revert` of that PR.

The redirect action shape was verified against
[Create a redirect rule via API](https://developers.cloudflare.com/rules/url-forwarding/single-redirects/create-api/):
the payload nests under `action_parameters.from_value`, and `target_url` is
either `{ value }` (static) or `{ expression }` (dynamic), never both.
`preserve_query_string: true` carries the query string, so the expression only
rebuilds the path — which is also the only option available, since Cloudflare's
rules language has no ternary operator.

`main` is now the exported, argv-injected `runCloudflareApply`, driven end to end
against a stubbed `fetch`. That is what makes "the plan reported drift and the
apply loop never issued the write" a catchable bug rather than a production
surprise.

Part of #4648
Refs #4655

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.
2. After merge: `curl -sI https://boardsesh.com/x?y=1` → 301 to `https://www.boardsesh.com/x?y=1` with `cf-ray` header.
3. `www.boardsesh.com` unchanged (still serves).

## Risk

Risk: 4/5 — first apply changes the apex record and adds a redirect phase; www itself is untouched.

