### PR TITLE
fix(ci): title OTA updates with the commit, not a hash or merge boilerplate

### DIFF
--- a/scripts/mobile-publish.test.ts
+++ b/scripts/mobile-publish.test.ts
@@ -1,12 +1,16 @@
 /// <reference types="node" />
 
+import { execFileSync } from 'node:child_process';
 import { describe, expect, it } from 'vitest';
 import { EOAS_PACKAGE_SPEC, SELF_HOSTED_UPLOAD_RATE_PER_SECOND } from './lib/eoas';
 import {
   buildEasUpdateArgs,
   buildSelfHostedEoasArgs,
+  messageArgs,
   parseArgs,
   requestedSelfHostedPlatforms,
+  resolveUpdateMessage,
+  titleFromCommitMessage,
   selfHostedPublishModeLabel,
   selfHostedPublishSuccessMessages,
   shouldAllowDirtyTree,
@@ -103,6 +107,80 @@ describe('mobile publish argument routing', () => {
     ]);
     // `eas update` has no --upload-rate; passing one would abort the EAS path.
     expect(args).not.toContain('--upload-rate');
+  });
+
+  // An update's title used to be `git log --oneline`-shaped, `<short sha> <subject>`.
+  // eoas already stores commitHash as its own field, so the sha rendered twice on
+  // every dashboard row and stole width from the part a human actually reads. This
+  // asserts against REAL git in this checkout, not a fixture: a re-added prefix
+  // would have to survive here, not just in a builder that takes the message as an
+  // argument.
+  it('titles an update from real git, with neither a commit hash nor merge boilerplate', () => {
+    const headSubject = execFileSync('git', ['log', '-1', '--format=%s'], { encoding: 'utf-8' }).trim();
+    const headShortHash = execFileSync('git', ['rev-parse', '--short', 'HEAD'], { encoding: 'utf-8' }).trim();
+
+    const derived = resolveUpdateMessage(null);
+
+    expect(derived).not.toBe('');
+    expect(derived.startsWith(headShortHash)).toBe(false);
+    expect(derived).not.toMatch(/^[0-9a-f]{7,40}\s/);
+    expect(derived).not.toMatch(/^Merge pull request /);
+    // A plain commit is its own title; only a merge commit gets rewritten.
+    if (!headSubject.startsWith('Merge pull request ')) {
+      expect(derived).toBe(headSubject);
+    }
+  });
+
+  // `Merge pull request #5020 from boardsesh/fix/ota-republish-after-native-build`
+  // says nothing about the change. GitHub puts the PR title on the first body
+  // line, so use that and re-attach the number — the same `<title> (#N)` shape a
+  // squash merge already writes.
+  describe('titleFromCommitMessage', () => {
+    it('replaces a GitHub merge subject with the PR title and number', () => {
+      expect(
+        titleFromCommitMessage(
+          'Merge pull request #5020 from boardsesh/fix/ota-republish-after-native-build',
+          'fix(ci): republish the OTA after a native build, so the new binary gets it\n',
+        ),
+      ).toBe('fix(ci): republish the OTA after a native build, so the new binary gets it (#5020)');
+    });
+
+    it('does not double up a number the PR title already carries', () => {
+      expect(
+        titleFromCommitMessage('Merge pull request #5022 from boardsesh/ci/kill-switch', 'ci: kill switch (#5022)'),
+      ).toBe('ci: kill switch (#5022)');
+    });
+
+    it('falls back to the number when a merge commit has no body', () => {
+      expect(titleFromCommitMessage('Merge pull request #77 from boardsesh/x', '')).toBe('Merge #77');
+      expect(titleFromCommitMessage('Merge pull request #77 from boardsesh/x', '\n  \n')).toBe('Merge #77');
+    });
+
+    it('leaves every other subject alone', () => {
+      expect(titleFromCommitMessage('ci: add the kill switch (#5022)', 'body')).toBe('ci: add the kill switch (#5022)');
+      // A local `git merge`, not a GitHub PR merge — nothing to recover from the body.
+      expect(titleFromCommitMessage("Merge branch 'main' into fix/thing", 'body')).toBe(
+        "Merge branch 'main' into fix/thing",
+      );
+      // Close to the pattern but not it: no PR number to re-attach.
+      expect(titleFromCommitMessage('Merge pull request from boardsesh/x', 'body')).toBe(
+        'Merge pull request from boardsesh/x',
+      );
+    });
+  });
+
+  it('lets an explicit --message win over the commit subject', () => {
+    expect(resolveUpdateMessage('Backport to v2.4.0 (abc1234)')).toBe('Backport to v2.4.0 (abc1234)');
+  });
+
+  // Outside a git checkout getCommitSubject() yields ''. Publishing `--message ""`
+  // would title the row with an empty string; dropping the flag instead lets eoas
+  // fall back to `git log -1 --pretty=%B`.
+  it('omits --message entirely rather than publishing an empty title', () => {
+    expect(messageArgs('')).toEqual([]);
+    expect(messageArgs('fix the queue')).toEqual(['--message', 'fix the queue']);
+    expect(buildEasUpdateArgs('fix-branch', '', 'all')).not.toContain('--message');
+    expect(buildSelfHostedEoasArgs('production', 'ios', '', { allowDirtyTree: true })).not.toContain('--message');
   });
 
   it('expands all to sequential iOS and Android targets', () => {

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -49,28 +49,77 @@ function resolveCurrentBranchName(): string | null {
   }
 }
 
-function getShortCommitHash(): string {
-  try {
-    return execFileSync('git', ['rev-parse', '--short', 'HEAD'], {
-      cwd: ROOT_DIR,
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
-  } catch {
-    return 'unknown';
+/**
+ * A GitHub "Create a merge commit" subject, which says nothing about the change.
+ *
+ * `Merge pull request #5020 from boardsesh/fix/ota-republish-after-native-build`
+ */
+const MERGE_PULL_REQUEST_SUBJECT = /^Merge pull request #(\d+) from \S+$/;
+
+/**
+ * The human-readable title of the commit at HEAD.
+ *
+ * Normally the subject. For a merge commit GitHub puts the PR title on the first
+ * body line, so use that and re-attach the PR number — which lands on exactly the
+ * `<title> (#N)` shape a squash merge already produces, so both merge styles read
+ * the same on the OTA dashboard.
+ */
+export function titleFromCommitMessage(subject: string, body: string): string {
+  const mergeSubject = MERGE_PULL_REQUEST_SUBJECT.exec(subject);
+  if (mergeSubject === null) {
+    return subject;
   }
+  const pullRequestNumber = mergeSubject[1];
+  const pullRequestTitle = body
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line !== '');
+  if (pullRequestTitle === undefined) {
+    // A merge commit with an empty body. The number is all there is to say.
+    return `Merge #${pullRequestNumber}`;
+  }
+  return pullRequestTitle.includes(`(#${pullRequestNumber})`)
+    ? pullRequestTitle
+    : `${pullRequestTitle} (#${pullRequestNumber})`;
 }
 
-function getCommitSubject(): string {
+function getCommitTitle(): string {
   try {
-    return execFileSync('git', ['log', '-1', '--format=%s'], {
+    // NUL-separated: a body may contain anything, including blank lines and the
+    // separator patterns a printable delimiter would use.
+    const [subject = '', body = ''] = execFileSync('git', ['log', '-1', '--format=%s%x00%b'], {
       cwd: ROOT_DIR,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
+    }).split('\0');
+    return titleFromCommitMessage(subject.trim(), body);
   } catch {
     return '';
   }
+}
+
+/**
+ * The title an update carries on the OTA server: the commit's own title, nothing else.
+ *
+ * Deliberately NOT `git log --oneline`-shaped. eoas records `commitHash` as its
+ * own field on every row (`git rev-parse HEAD`), so a `<short sha> <subject>`
+ * message printed the sha twice — once in the dashboard's Commit column, once
+ * eating the width the subject needed.
+ */
+export function resolveUpdateMessage(explicitMessage: string | null): string {
+  return explicitMessage ?? getCommitTitle();
+}
+
+/**
+ * `--message <text>`, or nothing at all when there is no text.
+ *
+ * Passing an empty string would publish an update titled `""`; omitting the flag
+ * instead lets eoas fall back to its own default, `git log -1 --pretty=%B`. Only
+ * reachable outside a git checkout, since `getCommitTitle` is the sole source of
+ * an empty message.
+ */
+export function messageArgs(updateMessage: string): string[] {
+  return updateMessage === '' ? [] : ['--message', updateMessage];
 }
 
 // Whether this publish may run against a dirty working tree. CI only: the
@@ -120,8 +169,7 @@ export function buildSelfHostedEoasArgs(
     branchName,
     '--platform',
     platform,
-    '--message',
-    updateMessage,
+    ...messageArgs(updateMessage),
     ...sourceMapArgs,
     ...repositoryCheckArgs,
     // Cap how fast eoas starts asset uploads. Before 3.1.2 it fired every asset
@@ -174,9 +222,7 @@ async function publishToSelfHostedBranch(
     return 1;
   }
 
-  const commitHash = getShortCommitHash();
-  const commitSubject = getCommitSubject();
-  const updateMessage = explicitMessage ?? `${commitHash} ${commitSubject}`.trim();
+  const updateMessage = resolveUpdateMessage(explicitMessage);
 
   // eoas publish targets a server BRANCH (--branch holds the uploaded
   // update). We deliberately do NOT pass --channel: in eoas@3 it's a DEPRECATED
@@ -193,7 +239,7 @@ async function publishToSelfHostedBranch(
   console.log(`[mobile:publish] Mode:     ${selfHostedPublishModeLabel(branchName)}`);
   console.log(`[mobile:publish] Server:   ${serverUrl}`);
   console.log(`[mobile:publish] Branch:   ${branchName}`);
-  console.log(`[mobile:publish] Message:  ${updateMessage}`);
+  console.log(`[mobile:publish] Message:  ${updateMessage || '(none — eoas will use the commit body)'}`);
   console.log(`[mobile:publish] Platform: ${platform}`);
 
   // EXPO_UPDATES_URL must resolve in app.config so eoas finds the server.
@@ -316,8 +362,7 @@ export function buildEasUpdateArgs(sanitizedBranch: string, updateMessage: strin
     'update',
     '--branch',
     sanitizedBranch,
-    '--message',
-    updateMessage,
+    ...messageArgs(updateMessage),
     '--platform',
     platform,
     '--non-interactive',
@@ -345,12 +390,10 @@ export async function main(args: string[] = process.argv.slice(2)): Promise<numb
   }
 
   const sanitizedBranch = branchName.replace(/[^a-zA-Z0-9._-]/g, '-');
-  const commitHash = getShortCommitHash();
-  const commitSubject = getCommitSubject();
-  const updateMessage = explicitMessage ?? `${commitHash} ${commitSubject}`.trim();
+  const updateMessage = resolveUpdateMessage(explicitMessage);
 
   console.log(`[mobile:publish] Branch:   ${sanitizedBranch}`);
-  console.log(`[mobile:publish] Message:  ${updateMessage}`);
+  console.log(`[mobile:publish] Message:  ${updateMessage || '(none — eoas will use the commit body)'}`);
   console.log(`[mobile:publish] Platform: ${platform}`);
   console.log('');
 


### PR DESCRIPTION
## Summary

Every production OTA row on `updates.boardsesh.com` was titled `git log --oneline`-style, `<short sha> <subject>`. eoas already records `commitHash` as its own field on the row (`git rev-parse HEAD`), so the sha rendered twice — once in the Commit column, once eating the width the readable half needed.

Merge commits were worse. `Merge pull request #5020 from boardsesh/fix/ota-republish-after-native-build` says nothing about the change, and 4 of the last 25 commits on `main` look like that. GitHub puts the PR title on the first body line, so use that and re-attach the number — which lands on the exact `<title> (#N)` shape a squash merge already writes, so both merge styles read alike:

| commit | before | after |
| --- | --- | --- |
| `d171ce8` (merge) | `d171ce8 Merge pull request #5020 from boardsesh/fix/ota-republish-after-native-build` | `fix(ci): republish the OTA after a native build, so the new binary gets it (#5020)` |
| `14dbbe4` (squash) | `14dbbe4 ci: add the self-hosted runner kill switch, its guards and a watchdog (#5022)` | `ci: add the self-hosted runner kill switch, its guards and a watchdog (#5022)` |

An empty title (no git to read) now omits `--message` entirely instead of publishing `""`, letting eoas fall back to its own default, `git log -1 --pretty=%B`.

Nothing in the workflows changes: `mobile-ota-production.yml` only passes `--message` for a manual `workflow_dispatch` input, and `mobile-ota-backport.yml` passes a deliberate literal. Both still win over the derived title.

### Guards, and the mutation that reddens each

The title assertion runs against **real git in the checkout**, not a fixture — a re-added prefix would have to survive there, not just in a builder that takes the message as an argument.

| Mutation | Result |
| --- | --- |
| Re-add a short-hash prefix to the derived title | 1 failed |
| Keep the raw `Merge pull request …` subject | 3 failed |
| Publish `--message ""` instead of omitting the flag | 1 failed |
| Drop the `(#N)` re-attachment on a merge title | 1 failed |

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 2/5 — changes only the title text on OTA rows. `commitHash`, branch, platform, fingerprint and the publish flags are untouched, and an explicit `--message` still wins.
