### PR TITLE
fix(mobile): satisfy type-aware lint NODE_ENV requirement in mobile-publish tests

### DIFF
--- a/scripts/mobile-publish.test.ts
+++ b/scripts/mobile-publish.test.ts
@@ -12,6 +12,12 @@ import {
   shouldAllowDirtyTree,
 } from './mobile-publish';
 
+// The repo's Next global.d.ts augments NodeJS.ProcessEnv to require NODE_ENV, so
+// the partial env fixtures below need the assertion to be assignable.
+function processEnv(values: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  return values as NodeJS.ProcessEnv;
+}
+
 describe('mobile publish argument routing', () => {
   it('maps the wrapper channel selector to an eoas branch without a deprecated channel flag', () => {
     const args = buildSelfHostedEoasArgs('production', 'ios', 'fix the queue', { allowDirtyTree: true });
@@ -59,9 +65,9 @@ describe('mobile publish argument routing', () => {
   });
 
   it('allows a dirty tree only under GitHub Actions', () => {
-    expect(shouldAllowDirtyTree({ GITHUB_ACTIONS: 'true' })).toBe(true);
-    expect(shouldAllowDirtyTree({ GITHUB_ACTIONS: 'false' })).toBe(false);
-    expect(shouldAllowDirtyTree({})).toBe(false);
+    expect(shouldAllowDirtyTree(processEnv({ GITHUB_ACTIONS: 'true' }))).toBe(true);
+    expect(shouldAllowDirtyTree(processEnv({ GITHUB_ACTIONS: 'false' }))).toBe(false);
+    expect(shouldAllowDirtyTree(processEnv({}))).toBe(false);
   });
 
   // The per-PR previews are the concurrent publishes, so they are the ones that


### PR DESCRIPTION
## Summary

`main` fails `vp check` with `Found 5 errors and 330 warnings in 4783 files`. This has gone unnoticed because the `lint` job in `.github/workflows/ci.yml` is path-gated by the `changes` job, so most pushes to `main` (including ones that add or shift a type error) skip it entirely.

Console diagnostics all render with the same `!`/`x` glyph, so severity isn't visible by eye — `.oxlintrc.json`'s per-path `overrides` also make correlating rule names to severity unreliable. Bisecting confirmed the actual breakdown:

**2 of the "5" were an environment artifact, not a code bug.** `packages/mobile/src/web-shims/bottom-sheet.tsx` resolves the `@gorhom/bottom-sheet` types through a path mapping in `packages/mobile/tsconfig.json` into the isolated `packages/mobile/web-runtime` nested install (see CLAUDE.md: "Its isolated install is in `packages/mobile/web-runtime`"). That nested lock wasn't installed in this worktree. CI's `lint` job already runs `vp run mobile:web-runtime:install` unconditionally before `vp check` for exactly this reason (see the comment on that step in `ci.yml`). Running it locally made both `typescript(TS2307)` diagnostics disappear — no source change needed, and `main` is not actually broken here.

**The real 3 errors, all in `scripts/mobile-publish.test.ts`:**

- **File**: `scripts/mobile-publish.test.ts:62-64`
- **Rule**: `typescript(TS2741)` — "Property 'NODE_ENV' is missing in type '{ GITHUB_ACTIONS: string }' but required in type 'ProcessEnv'"
- **Why it fired**: `vp check` runs oxlint with type-aware checking (`lint.options.typeAware`/`typeCheck` in `vite.config.ts`) across the whole repo. Next.js ships its own `next/types/global.d.ts`, which augments `NodeJS.ProcessEnv` with a required `NODE_ENV: 'development' | 'production' | 'test'` field — that ambient augmentation applies repo-wide once Next is anywhere in the program, not just inside `packages/web`. The test called `shouldAllowDirtyTree({ GITHUB_ACTIONS: 'true' })` (and two more partial-env literals) directly against a param typed `NodeJS.ProcessEnv`, which now requires `NODE_ENV`.
- **Why `vp run typecheck` never caught it**: `scripts/mobile-publish.test.ts` isn't in `scripts/tsconfig.json`'s `include` list (that tsconfig is intentionally scoped to a handful of type-clean scripts), so real `tsc` never typechecks this file at all. Only the full-repo type-aware lint pass does — which is exactly the gap issue #4488 (referenced in `ci.yml`) was about.
- **What I changed**: added a small `processEnv()` helper that casts a partial env object to `NodeJS.ProcessEnv`, and used it at the three call sites. This is the exact pattern already established elsewhere in the repo for this identical issue — see `scripts/mobile-dsyms.test.ts` and `scripts/mobile-sourcemaps.test.ts`, both of which carry the same comment ("The repo's Next global.d.ts augments NodeJS.ProcessEnv to require NODE_ENV...").

No production code changed — this is a test-only type-satisfaction fix, mirroring prior art in the same directory. `.oxlintrc.json` and rule severities were not touched; the 330 pre-existing warnings are untouched.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 1/5 — test-only type fix, no production code touched, matches an existing repo pattern.
