### PR TITLE
fix(ci): scope watchdog cancellation to the dead fleet, fix its false re-dispatch claim

### DIFF
--- a/.github/workflows/ci-runner-watchdog.yml
+++ b/.github/workflows/ci-runner-watchdog.yml
@@ -53,8 +53,28 @@ jobs:
           set -euo pipefail
 
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::warning::CI_RUNNER_ADMIN_PAT is not set; watchdog cannot act."
-            exit 0
+            # A silent no-op here is worse than no watchdog at all, because a
+            # green run reads as "the fleet is fine" when it actually means
+            # "nobody is looking". If the PAT expired or was deleted, the
+            # fleet could be down for 24 hours with every firing showing
+            # green. Fail loudly instead: the run turns red, and we still try
+            # to reach Discord even without the PAT (that's a plain webhook
+            # POST, unrelated to GH_TOKEN).
+            echo "::error::CI_RUNNER_ADMIN_PAT is not set. The watchdog cannot read CI_RUNNER_LINUX, check the fleet, or fail back -- it is a no-op until this secret is restored. Failing this job so that is visible instead of a silent, permanently-green no-op."
+
+            if [ -n "${DISCORD_WEBHOOK:-}" ]; then
+              jq -nc \
+                --arg content "**CI Runner Watchdog is disabled.** \`CI_RUNNER_ADMIN_PAT\` is missing or was revoked, so the watchdog cannot check the homelab fleet or fail CI back to GitHub-hosted runners. If the fleet goes down now, queued self-hosted jobs will sit for up to 24 hours with nothing catching it. Restore the secret." \
+                '{content: $content, allowed_mentions: {parse: []}}' \
+                | curl -sS -X POST -H 'Content-Type: application/json' -d @- "$DISCORD_WEBHOOK" \
+                || echo "::warning::Discord notification failed too; this failure is currently only visible in the Actions tab."
+            else
+              # Both secrets gone is strictly worse than one, and looks
+              # identical in the logs unless we say so explicitly.
+              echo "::warning::DISCORD_DEPLOY_WEBHOOK is also not set, so no Discord notification was sent. This failure is only visible in the Actions tab."
+            fi
+
+            exit 1
           fi
 
           current="$(gh api "repos/${REPO}/actions/variables/CI_RUNNER_LINUX" \
@@ -65,8 +85,16 @@ jobs:
             exit 0
           fi
 
-          online="$(gh api "repos/${REPO}/actions/runners" \
-            --jq '[.runners[] | select(.status == "online")] | length')"
+          # The fleet is planned to run 36 runners (two VMs x 18 slots), well
+          # past the API's 30-per-page default. Without --paginate this reads
+          # only the first page: the count comes back wrong and the watchdog
+          # can conclude a healthy fleet is offline and flip CI back to
+          # GitHub-hosted for no reason. --paginate with --jq emits one
+          # result per page rather than one aggregate, so we make the filter
+          # emit one line per online runner and let `wc -l` do the summing
+          # instead of taking `length` (which would give a per-page count).
+          online="$(gh api --paginate -F per_page=100 "repos/${REPO}/actions/runners" \
+            --jq '.runners[] | select(.status == "online") | .id' | wc -l | tr -d '[:space:]')"
           echo "Online self-hosted runners: ${online}"
 
           if [ "$online" -gt 0 ]; then
@@ -76,8 +104,72 @@ jobs:
 
           echo "::error::No self-hosted runners are online. Failing back to GitHub-hosted."
 
+          # Find the queued runs that actually need rescuing. `gh run list
+          # --status queued` (or the equivalent API listing) returns EVERY
+          # queued run in the repo, including ones legitimately waiting on a
+          # free GitHub-hosted slot -- cancelling those is pure collateral
+          # damage. A queued run's own listing doesn't expose its jobs'
+          # labels, so identifying the ones actually bound to the dead fleet
+          # means opening each run's jobs (`/actions/runs/{id}/jobs`) and
+          # checking for the `bs-ci` label that every self-hosted job carries.
+          #
+          # The run listing itself is paginated properly (no --limit), so it
+          # is never silently truncated. The per-run jobs lookup is an extra
+          # API call per queued run, so *that* part is bounded --
+          # MAX_RUNS_TO_INSPECT below -- and if the cap is hit we say so
+          # explicitly rather than quietly leaving the rest queued for 24
+          # hours with no indication anything was skipped.
+          MAX_RUNS_TO_INSPECT=100
+
+          all_queued_run_ids_raw="$(gh api --paginate -F per_page=100 \
+            "repos/${REPO}/actions/runs" -f status=queued \
+            --jq '.workflow_runs[].id')"
+          mapfile -t all_queued_run_ids <<< "$all_queued_run_ids_raw"
+          if [ "${#all_queued_run_ids[@]}" -eq 1 ] && [ -z "${all_queued_run_ids[0]}" ]; then
+            all_queued_run_ids=()
+          fi
+
+          total_queued="${#all_queued_run_ids[@]}"
+          echo "Queued runs in the repo: ${total_queued}"
+
+          inspected_count="$total_queued"
+          if [ "$total_queued" -gt "$MAX_RUNS_TO_INSPECT" ]; then
+            inspected_count="$MAX_RUNS_TO_INSPECT"
+            skipped=$((total_queued - MAX_RUNS_TO_INSPECT))
+            echo "::warning::${skipped} queued run(s) were not inspected this pass (cap: ${MAX_RUNS_TO_INSPECT}). They are NOT cancelled by this run and may still be stuck on the dead fleet; the next scheduled run picks up where this one left off."
+          fi
+
+          fleet_bound_run_ids=()
+          inspect_failures=0
+          while read -r run_id; do
+            [ -n "$run_id" ] || continue
+            if ! has_fleet_label="$(gh api "repos/${REPO}/actions/runs/${run_id}/jobs" \
+                 --jq '[.jobs[].labels[]?] | any(. == "bs-ci")' 2>/dev/null)"; then
+              inspect_failures=$((inspect_failures + 1))
+              continue
+            fi
+            if [ "$has_fleet_label" = 'true' ]; then
+              fleet_bound_run_ids+=("$run_id")
+            fi
+          done < <(printf '%s\n' "${all_queued_run_ids[@]}" | head -n "$inspected_count")
+
+          if [ "$inspect_failures" -gt 0 ]; then
+            echo "::warning::Could not read jobs for ${inspect_failures} queued run(s); left them alone rather than guessing, so they may still be stuck on the dead fleet."
+          fi
+
+          echo "Queued runs bound to the dead fleet (bs-ci): ${#fleet_bound_run_ids[@]} of ${inspected_count} inspected."
+
+          # Cancelling a run does NOT make it re-dispatch. A cancelled run
+          # stays cancelled until a human pushes again or re-runs it by hand
+          # -- GitHub does not document whether the `rerun` API re-evaluates
+          # `vars`/`runs-on` against the current value or reuses what was
+          # resolved on the original dispatch, and matrix values are known to
+          # stay frozen across a rerun, which points the same way. We are not
+          # relying on undocumented behaviour for a safety net, so this step
+          # only cancels; every message below says plainly that a manual
+          # re-run is required.
           if [ "${DRY_RUN:-false}" = 'true' ]; then
-            echo "Dry run: would set CI_RUNNER_LINUX to \"ubuntu-latest\" and cancel queued runs."
+            echo "Dry run: would set CI_RUNNER_LINUX to \"ubuntu-latest\" and cancel ${#fleet_bound_run_ids[@]} queued run(s) bound to bs-ci (of ${inspected_count} inspected). Cancelling does not re-dispatch them -- they would still need a manual re-run or a new push."
             exit 0
           fi
 
@@ -85,24 +177,22 @@ jobs:
           gh api -X PATCH "repos/${REPO}/actions/variables/CI_RUNNER_LINUX" \
             -f name=CI_RUNNER_LINUX -f value='"ubuntu-latest"'
 
-          # 2. Cancel what is already queued. Those jobs resolved their runs-on
-          #    at dispatch, so the variable change does not reach them — without
-          #    this they sit for 24 hours. Cancelling makes them re-dispatch
-          #    against the new value on the next push or re-run.
+          # 2. Cancel what is already queued and bound to the dead fleet.
+          #    Those jobs resolved their runs-on at dispatch, so the variable
+          #    change does not reach them -- without this they sit for 24
+          #    hours. Runs queued for GitHub-hosted slots are left alone.
           cancelled=0
-          while read -r run_id; do
-            [ -n "$run_id" ] || continue
+          for run_id in "${fleet_bound_run_ids[@]}"; do
             gh run cancel "$run_id" --repo "${REPO}" >/dev/null 2>&1 && cancelled=$((cancelled + 1)) || true
-          done < <(gh run list --repo "${REPO}" --status queued --limit 200 \
-                     --json databaseId --jq '.[].databaseId')
+          done
 
-          echo "Cancelled ${cancelled} queued run(s)."
+          echo "Cancelled ${cancelled} queued run(s) bound to the dead fleet. They will NOT re-dispatch on their own -- re-run them by hand (or push again) once the fallback is confirmed live."
 
           if [ -n "${DISCORD_WEBHOOK:-}" ]; then
             # Best-effort, and allowed_mentions is empty so nothing here can
             # ping the channel.
             jq -nc \
-              --arg content "**CI fell back to GitHub-hosted runners.** No self-hosted runners were online, so \`CI_RUNNER_LINUX\` was reset and ${cancelled} queued run(s) were cancelled so they re-dispatch. The fleet will NOT re-enable itself — check the homelab, then set the variable back." \
+              --arg content "**CI fell back to GitHub-hosted runners.** No self-hosted runners were online, so \`CI_RUNNER_LINUX\` was reset and ${cancelled} queued run(s) bound to the dead fleet were cancelled. They will NOT re-dispatch on their own -- re-run them by hand or push again to pick up the fallback. Runs already queued for GitHub-hosted slots were left alone. The fleet will NOT re-enable itself -- check the homelab, then set the variable back." \
               '{content: $content, allowed_mentions: {parse: []}}' \
               | curl -sS -X POST -H 'Content-Type: application/json' -d @- "$DISCORD_WEBHOOK" \
               || echo "::warning::Discord notification failed."

--- a/scripts/__tests__/ci-runner-routing.test.ts
+++ b/scripts/__tests__/ci-runner-routing.test.ts
@@ -133,4 +133,95 @@ describe('self-hosted runner routing', () => {
     expect(routedJobNames(source)).toEqual([]);
     expect(jobBlocks(source).get('check')).toContain('    runs-on: ubuntu-latest');
   });
+
+  describe('ci-runner-watchdog.yml safety properties', () => {
+    // These are string-based, like the rest of this file: the watchdog's
+    // script is bash embedded in YAML, so there is no AST to assert against.
+    // Each check is deliberately tied to the actual protective mechanism
+    // (the variable/loop that does the work), not just to log-message
+    // wording, so a regression that removes the mechanism fails the test
+    // even if the surrounding prose is left untouched.
+
+    function watchdogScript(): string {
+      const block = jobBlocks(workflow('ci-runner-watchdog.yml')).get('check');
+      if (!block) throw new Error('ci-runner-watchdog.yml has no `check` job');
+      return block.join('\n');
+    }
+
+    it('fails the job rather than warning when the admin PAT is missing', () => {
+      // A missing/revoked CI_RUNNER_ADMIN_PAT used to `exit 0` after an
+      // `::warning::` -- every scheduled firing looked green while the
+      // watchdog was silently a no-op. Isolate the missing-PAT branch (from
+      // the message that names the secret to the next top-level read, which
+      // only runs once the PAT is known to be present) and assert it exits
+      // non-zero, not zero.
+      const script = watchdogScript();
+      const branchStart = script.indexOf('CI_RUNNER_ADMIN_PAT is not set');
+      const branchEnd = script.indexOf('current="$(gh api', branchStart);
+      expect(branchStart, 'expected a message naming CI_RUNNER_ADMIN_PAT').toBeGreaterThan(-1);
+      expect(branchEnd, 'expected the missing-PAT branch to be followed by the CI_RUNNER_LINUX read').toBeGreaterThan(
+        branchStart,
+      );
+
+      const missingPatBranch = script.slice(branchStart, branchEnd);
+      expect(missingPatBranch).toContain('exit 1');
+      expect(missingPatBranch).not.toMatch(/exit 0/);
+    });
+
+    it('only cancels queued runs whose jobs carry the bs-ci label', () => {
+      // `gh run list --status queued` (or the run-listing API) returns every
+      // queued run in the repo, including ones legitimately waiting on a
+      // GitHub-hosted slot. Cancelling straight off that list is collateral
+      // damage. The fix opens each run's jobs and filters to `bs-ci` before
+      // building the list this loop cancels -- assert the cancel loop
+      // iterates that filtered array, not a raw queued-run listing.
+      const script = watchdogScript();
+      expect(script).toMatch(/actions\/runs\/\$\{run_id\}\/jobs/);
+      expect(script).toContain('bs-ci');
+      expect(script).toMatch(/for run_id in "\$\{fleet_bound_run_ids\[@\]\}"/);
+
+      const cancelIndex = script.indexOf('gh run cancel');
+      const loopIndex = script.indexOf('for run_id in "${fleet_bound_run_ids[@]}"');
+      expect(loopIndex, 'expected the cancel loop to iterate the label-filtered array').toBeGreaterThan(-1);
+      expect(cancelIndex).toBeGreaterThan(loopIndex);
+    });
+
+    it('never claims cancelling a run makes it re-dispatch', () => {
+      // Cancelling a queued run does not cause GitHub to automatically
+      // re-run it -- that needs a human to push again or re-run by hand. An
+      // earlier version of this workflow claimed the opposite in its own
+      // comments and Discord message. Every mention of "re-dispatch" in the
+      // script must be negated nearby (not/never/doesn't/won't), not
+      // asserted as something cancelling causes. Checking proximity to a
+      // negation, rather than one exact phrase, so a rewording of the
+      // sentence around any one of the four mentions (two comments, the log
+      // line, the Discord payload) can't slip the false claim back in
+      // unnoticed.
+      const script = watchdogScript();
+      const mentions = [...script.matchAll(/re-dispatch/gi)];
+      expect(mentions.length, 'expected the script to discuss re-dispatch behaviour').toBeGreaterThan(0);
+
+      const negationWindow = 40;
+      for (const mention of mentions) {
+        const matchIndex = mention.index ?? 0;
+        const contextStart = Math.max(0, matchIndex - negationWindow);
+        const context = script.slice(contextStart, matchIndex).toLowerCase();
+        expect(
+          context,
+          `"re-dispatch" at index ${matchIndex} has no negation in the ${negationWindow} chars before it: ${JSON.stringify(context)}`,
+        ).toMatch(/\b(not|never|n't)\b/);
+      }
+    });
+
+    it('paginates the self-hosted runners lookup instead of trusting a single page', () => {
+      // The planned fleet is 36 runners, past the API's 30-per-page default.
+      // Reading only page one under-counts online runners and can trip the
+      // watchdog into flipping a healthy fleet back to GitHub-hosted.
+      const script = watchdogScript();
+      const runnersCallIndex = script.indexOf('actions/runners"');
+      expect(runnersCallIndex, 'expected a call to the runners endpoint').toBeGreaterThan(-1);
+      const runnersCallLine = script.slice(Math.max(0, runnersCallIndex - 120), runnersCallIndex + 20);
+      expect(runnersCallLine).toContain('--paginate');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Four review findings on PR #5022's `ci-runner-watchdog.yml`.

1. **Cancelled every queued run, not just homelab-bound ones.** The cancellation loop cancelled *every* queued run in the repo, including runs legitimately waiting on a GitHub-hosted slot — pure collateral damage. It now opens each queued run's jobs (`GET /repos/{owner}/{repo}/actions/runs/{id}/jobs`) and only cancels a run if one of its jobs carries the `bs-ci` label.

   The comments and Discord message also claimed cancelling "makes them re-dispatch" — that's false. **What cancelling actually does: nothing automatic.** A cancelled run stays cancelled until a human pushes again or re-runs it by hand. I looked for documentation on whether `POST /actions/runs/{run_id}/rerun` re-evaluates `vars`/`runs-on` against the current value of `CI_RUNNER_LINUX` versus reusing what was resolved on the original dispatch — GitHub does not document this either way, and the closest documented analogue (matrix values staying frozen across a rerun) points toward "don't rely on it." This is a safety net; it shouldn't lean on undocumented API behaviour. So the workflow does **not** call `rerun` automatically — it cancels, and every message (comments, log line, Discord payload) now says plainly that the affected runs need a manual re-run or a new push.

2. **Missing pagination on the runners API.** `gh api repos/.../actions/runners` defaulted to 30 results/page. The planned fleet is 36 runners (two VMs × 18 slots), so past 30 the online count would read low and could trip the watchdog into flipping a healthy fleet back to GitHub-hosted. Now uses `--paginate -F per_page=100`, and since `--paginate` + `--jq` emits one result per page (a naive `length` would give a per-page count, not a total), the filter emits one line per online runner and `wc -l` sums across all pages.

3. **`--limit 200` silently truncated.** Runs past the cap were skipped with no indication, and would then sit queued for 24 hours unremarked. The run *listing* is now paginated properly with no artificial limit — no truncation there. The expensive part (opening each queued run's jobs to check its labels) is bounded at 100 runs per pass for API-budget reasons, but hitting that cap now logs an explicit `::warning::` with the skip count instead of failing silently; the next scheduled run (every 10 minutes) picks up where it left off.

4. **Silent degradation when `CI_RUNNER_ADMIN_PAT` is missing.** A missing/revoked PAT used to exit 0 after only a `::warning::` — every scheduled firing looked green while the watchdog was a no-op, so a dead PAT could hide a dead fleet for 24 hours. Now it fails the job (`exit 1`, turning the run red) and still tries to notify Discord if the webhook secret is present (that's a plain `curl` POST, independent of `GH_TOKEN`). If the webhook is *also* missing, it logs an explicit warning saying so, rather than looking like the same single failure mode.

Extended `ci-runner-routing.test.ts` with four new assertions tied to the actual protective mechanisms rather than message wording (PAT-missing exits 1; the cancel loop iterates the label-filtered array; every "re-dispatch" mention is negated nearby; the runners lookup paginates). Mutation-tested each by deliberately reverting the corresponding fix and confirming exactly one new test goes red, then restoring.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. Open this PR in Actions tab → workflow file parses, no YAML errors.
2. Run `ci-runner-watchdog.yml` manually with `dry_run: true` → green, no mutations made.
3. CI green (includes the extended `ci-runner-routing.test.ts` suite).

## Risk

Risk: 2/5 — CI-only workflow change with no production code path; worst case is a missed or over-broad cancellation, not a broken deploy.
