### PR TITLE
feat(repo): build the prebaked CI image

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,341 @@
+name: CI Image
+
+# Builds and publishes the prebaked CI seed the self-hosted homelab fleet
+# pulls before every job (issue #5008, part of epic #5005): the repo's full
+# git history plus the resolved pnpm store, layered so a typical daily
+# rebuild only ever pushes a few MB instead of re-pushing .git's one big
+# packfile (~398 MB) every day. Full design and layer-order rationale live in
+# Dockerfile.ci's header comment -- read that first if any of this workflow
+# is surprising.
+#
+# Two jobs do the real work, after the authority check:
+#
+#   freeze-history   Loops scripts/ci-image/generate-weekly-packs.ts's `plan`
+#                     command against the registry's existing tags and builds
+#                     whatever is missing, ONE layer at a time (baseline
+#                     first if even that is missing, then each completed week
+#                     in order). On a normal day this finds nothing missing
+#                     and exits immediately; it only does real work at a week
+#                     rollover, or when catching up a fresh baseline.
+#
+#   build-daily-image FROM the latest published history tag (guaranteed to
+#                     exist once freeze-history has run), adds the pnpm store
+#                     (keyed on the manifests -- cache hit whenever the
+#                     lockfile is unchanged) and the current, not-yet-frozen
+#                     week's pack, and pushes the image the fleet actually
+#                     pulls.
+#
+# Runs on GitHub-hosted runners on purpose: the fleet this image bootstraps
+# cannot pull its own seed before the seed exists.
+
+on:
+  schedule:
+    # Once a day. Most of the work in Dockerfile.ci's `ci-image` target is a
+    # cache hit on a normal day -- see build-daily-image's comments.
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  GIT_IMAGE: ghcr.io/boardsesh/boardsesh-ci-git
+  DAILY_IMAGE: ghcr.io/boardsesh/boardsesh-ci-image
+  # Quarterly re-baseline anchor (design decision #3 in issue #5008: "Re-
+  # baseline quarterly to stop the chain growing without bound"). To
+  # re-baseline: bump this date and dispatch the workflow -- freeze-history
+  # bootstraps a brand new baseline+week chain from scratch under the new
+  # date, and old week-<date> tags under the previous baseline are simply
+  # abandoned (garbage-collect them from the registry by hand; nothing reads
+  # them once no image's history chain points at them).
+  BASELINE_DATE: '2026-07-28'
+
+concurrency:
+  group: ci-image
+  cancel-in-progress: false
+
+jobs:
+  authorize-main:
+    name: Assert this build was loaded from protected main
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Check workflow authority
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          REF_IS_PROTECTED: ${{ github.ref_protected }}
+        run: |
+          set -Eeuo pipefail
+
+          # This image is trusted by every CI job that runs after it pulls
+          # the image -- a rebuild triggered from anything but protected main
+          # would be arbitrary code execution laundered through the cache.
+          # Same boundary as postgres-image-publisher.yml: `workflow_ref`
+          # records which ref GitHub actually loaded this workflow
+          # DEFINITION from, not just which ref triggered the run, so a
+          # workflow_dispatch against a branch other than main fails this
+          # even though the dispatch itself already requires write access.
+          case "$WORKFLOW_REF" in
+            */.github/workflows/ci-image.yml@refs/heads/main) ;;
+            *)
+              echo "::error::workflow was not loaded from refs/heads/main (got $WORKFLOW_REF)"
+              exit 1
+              ;;
+          esac
+          [[ "$REF_IS_PROTECTED" == 'true' ]] ||
+            { echo "::error::main is not protected for this run"; exit 1; }
+
+  freeze-history:
+    name: Freeze any missing history layers
+    needs: [authorize-main]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v6
+        with:
+          # Every week boundary must be resolvable to a real commit, and a
+          # fresh baseline needs everything up to its own date -- this is the
+          # one job in the repo that legitimately wants the whole thing.
+          fetch-depth: 0
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: '22.x'
+
+      - name: Install dependencies
+        run: vp install --frozen-lockfile
+
+      - name: Create temporary registry credential boundary
+        run: |
+          set -Eeuo pipefail
+          auth_directory="$RUNNER_TEMP/boardsesh-ghcr-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-freeze"
+          install -d -m 700 "$auth_directory"
+          printf 'DOCKER_CONFIG=%s\n' "$auth_directory" >>"$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        with:
+          version: v0.36.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          logout: false
+
+      - name: Freeze every missing baseline/week layer, one at a time
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -Eeuo pipefail
+
+          packs_dir="$RUNNER_TEMP/ci-image-packs"
+          mkdir -p "$packs_dir"
+
+          # Bounded loop, not "while true": a bug that makes `plan` never
+          # report satisfaction should fail loudly instead of running the
+          # scheduled job for an hour. 60 covers a from-scratch bootstrap
+          # (baseline + a full quarter of weeks) with headroom to spare.
+          for _ in $(seq 1 60); do
+            # GHCR container package versions -> every tag already published
+            # under boardsesh-ci-git. A brand-new package (nothing published
+            # yet) 404s; treat that the same as "no tags exist".
+            existing_tags="$(gh api --paginate \
+              '/orgs/boardsesh/packages/container/boardsesh-ci-git/versions' \
+              --jq '.[].metadata.container.tags[]' 2>/dev/null |
+              grep -E '^(baseline|week)-[0-9]{4}-[0-9]{2}-[0-9]{2}$' |
+              sort -u | paste -sd, - || true)"
+
+            plan_json="$(node --import tsx scripts/ci-image/generate-weekly-packs.ts plan \
+              --baseline "$BASELINE_DATE" --existing-tags "$existing_tags")"
+
+            next_tag="$(jq -r '.nextLayer.tag // empty' <<<"$plan_json")"
+            if [[ -z "$next_tag" ]]; then
+              echo "History is fully frozen through today; nothing to build."
+              break
+            fi
+
+            history_base="$(jq -r '.nextLayer.historyBaseTag' <<<"$plan_json")"
+            echo "Freezing $next_tag (history base: $history_base)"
+
+            # The tag's own end-date is embedded after its "baseline-" or
+            # "week-" prefix -- strip it to resolve this layer's own tip.
+            own_end_date="${next_tag#baseline-}"
+            own_end_date="${own_end_date#week-}"
+            tip="$(node --import tsx scripts/ci-image/generate-weekly-packs.ts resolve-tip \
+              --before "$own_end_date" --ref main)"
+
+            # `toolchain` (the fresh-baseline case) has nothing to exclude --
+            # pack every object reachable from the baseline tip. Otherwise
+            # the base's own date, same stripping trick, resolves the
+            # exclude boundary.
+            pack_args=(--tip "$tip" --out-dir "$packs_dir" --name "$next_tag")
+            build_args=(--build-arg "PACK_NAME=$next_tag" --build-context "gitpacks=$packs_dir")
+            if [[ "$history_base" != toolchain ]]; then
+              base_end_date="${history_base#baseline-}"
+              base_end_date="${base_end_date#week-}"
+              exclude_tip="$(node --import tsx scripts/ci-image/generate-weekly-packs.ts resolve-tip \
+                --before "$base_end_date" --ref main)"
+              pack_args+=(--exclude "$exclude_tip")
+              build_args+=(--build-arg "GIT_HISTORY_BASE=${GIT_IMAGE}:${history_base}")
+            fi
+
+            node --import tsx scripts/ci-image/generate-weekly-packs.ts pack "${pack_args[@]}"
+
+            # -f is required: the checkout's context root has no file literally
+            # named `Dockerfile` (it's `Dockerfile.ci`), unlike
+            # .docker-context/ci below, which create-service-docker-context.mjs
+            # writes with that exact name.
+            docker buildx build --target git-history -f Dockerfile.ci "${build_args[@]}" \
+              -t "${GIT_IMAGE}:${next_tag}" --push .
+
+            # Cheap, immediate self-check rather than trusting the push and
+            # discovering a miss on the NEXT loop iteration's registry query.
+            docker buildx imagetools inspect "${GIT_IMAGE}:${next_tag}" >/dev/null
+          done
+
+      - name: Remove temporary registry credentials
+        if: always()
+        run: |
+          set -Eeuo pipefail
+          [[ -n "${DOCKER_CONFIG:-}" ]] || exit 0
+          case "$DOCKER_CONFIG" in
+            "$RUNNER_TEMP"/boardsesh-ghcr-*-freeze) ;;
+            *) printf 'Refusing to clean unexpected DOCKER_CONFIG: %s\n' "$DOCKER_CONFIG" >&2; exit 1 ;;
+          esac
+          docker logout "$REGISTRY" >/dev/null 2>&1 || true
+          find "$DOCKER_CONFIG" -type f -exec sh -c ': >"$1"' _ {} \;
+          find "$DOCKER_CONFIG" -depth -delete
+          [[ ! -e "$DOCKER_CONFIG" ]]
+
+  build-daily-image:
+    name: Build and publish the daily image
+    needs: [authorize-main, freeze-history]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: '22.x'
+
+      - name: Install dependencies
+        run: vp install --frozen-lockfile
+
+      - name: Generate the manifests-only Docker context
+        # scripts/create-service-docker-context.mjs's existing manifest
+        # collector (the `ci` service entry: empty rootPackageNames, so it
+        # emits manifests/ only, no workspace source). Reused rather than a
+        # second manifest collector -- see Dockerfile.ci's header comment.
+        run: vp run docker-context:ci
+
+      - name: Create temporary registry credential boundary
+        run: |
+          set -Eeuo pipefail
+          auth_directory="$RUNNER_TEMP/boardsesh-ghcr-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-daily"
+          install -d -m 700 "$auth_directory"
+          printf 'DOCKER_CONFIG=%s\n' "$auth_directory" >>"$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        with:
+          version: v0.36.1
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          logout: false
+
+      - name: Resolve the latest frozen history tag
+        id: history
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -Eeuo pipefail
+          # Re-query rather than trust freeze-history's own view: that job
+          # may just have pushed a brand new tag, and this is the cheapest
+          # way to see it.
+          existing_tags="$(gh api --paginate \
+            '/orgs/boardsesh/packages/container/boardsesh-ci-git/versions' \
+            --jq '.[].metadata.container.tags[]' 2>/dev/null |
+            grep -E '^(baseline|week)-[0-9]{4}-[0-9]{2}-[0-9]{2}$' |
+            sort -u | paste -sd, - || true)"
+
+          plan_json="$(node --import tsx scripts/ci-image/generate-weekly-packs.ts plan \
+            --baseline "$BASELINE_DATE" --existing-tags "$existing_tags")"
+
+          # freeze-history must have left nothing outstanding; if it did,
+          # building the daily image now would either fail to pull a
+          # nonexistent tag or, worse, silently rebuild history state that
+          # must only ever come from a published, immutable layer.
+          next_tag="$(jq -r '.nextLayer.tag // empty' <<<"$plan_json")"
+          if [[ -n "$next_tag" ]]; then
+            echo "::error::history is not fully frozen ($next_tag still missing); refusing to build the daily image"
+            exit 1
+          fi
+
+          history_base="$(jq -r '.dailyHistoryBaseTag' <<<"$plan_json")"
+          echo "history_base=$history_base" >>"$GITHUB_OUTPUT"
+
+      - name: Generate the current week's pack
+        env:
+          HISTORY_BASE: ${{ steps.history.outputs.history_base }}
+        run: |
+          set -Eeuo pipefail
+          packs_dir="$RUNNER_TEMP/ci-image-packs"
+          mkdir -p "$packs_dir"
+
+          base_end_date="${HISTORY_BASE#baseline-}"
+          base_end_date="${base_end_date#week-}"
+          exclude_tip="$(node --import tsx scripts/ci-image/generate-weekly-packs.ts resolve-tip \
+            --before "$base_end_date" --ref main)"
+          tip="$(git rev-parse HEAD)"
+
+          node --import tsx scripts/ci-image/generate-weekly-packs.ts pack \
+            --tip "$tip" --exclude "$exclude_tip" --out-dir "$packs_dir" --name current-week
+          printf 'PACKS_DIR=%s\n' "$packs_dir" >>"$GITHUB_ENV"
+
+      - name: Build and push the daily image
+        env:
+          HISTORY_BASE: ${{ steps.history.outputs.history_base }}
+        run: |
+          set -Eeuo pipefail
+          # -f explicit rather than relying on the implicit ./Dockerfile
+          # lookup, matching branch-deploy.yml / production-deploy.yml's
+          # `file: .docker-context/<service>/Dockerfile` convention for the
+          # other generated contexts.
+          docker buildx build --target ci-image -f .docker-context/ci/Dockerfile \
+            --build-arg "DAILY_HISTORY_BASE=${GIT_IMAGE}:${HISTORY_BASE}" \
+            --build-context "gitpacks=$PACKS_DIR" \
+            -t "${DAILY_IMAGE}:latest" \
+            -t "${DAILY_IMAGE}:$(date -u +%Y-%m-%d)" \
+            --push \
+            .docker-context/ci
+
+      - name: Remove temporary registry credentials
+        if: always()
+        run: |
+          set -Eeuo pipefail
+          [[ -n "${DOCKER_CONFIG:-}" ]] || exit 0
+          case "$DOCKER_CONFIG" in
+            "$RUNNER_TEMP"/boardsesh-ghcr-*-daily) ;;
+            *) printf 'Refusing to clean unexpected DOCKER_CONFIG: %s\n' "$DOCKER_CONFIG" >&2; exit 1 ;;
+          esac
+          docker logout "$REGISTRY" >/dev/null 2>&1 || true
+          find "$DOCKER_CONFIG" -type f -exec sh -c ': >"$1"' _ {} \;
+          find "$DOCKER_CONFIG" -depth -delete
+          [[ ! -e "$DOCKER_CONFIG" ]]

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -174,7 +174,11 @@ jobs:
             # the base's own date, same stripping trick, resolves the
             # exclude boundary.
             pack_args=(--tip "$tip" --out-dir "$packs_dir" --name "$next_tag")
-            build_args=(--build-arg "PACK_NAME=$next_tag" --build-context "gitpacks=$packs_dir")
+            build_args=(
+              --build-arg "PACK_NAME=$next_tag"
+              --build-arg "PACK_TIP=$tip"
+              --build-context "gitpacks=$packs_dir"
+            )
             if [[ "$history_base" != toolchain ]]; then
               base_end_date="${history_base#baseline-}"
               base_end_date="${base_end_date#week-}"
@@ -308,6 +312,10 @@ jobs:
           node --import tsx scripts/ci-image/generate-weekly-packs.ts pack \
             --tip "$tip" --exclude "$exclude_tip" --out-dir "$packs_dir" --name current-week
           printf 'PACKS_DIR=%s\n' "$packs_dir" >>"$GITHUB_ENV"
+          # Dockerfile.ci names this tip as a ref in the seed. Without it a
+          # job's fetch negotiates from an empty ref list and re-downloads
+          # history the image already has.
+          printf 'CURRENT_PACK_TIP=%s\n' "$tip" >>"$GITHUB_ENV"
 
       - name: Build and push the daily image
         env:
@@ -320,7 +328,9 @@ jobs:
           # other generated contexts.
           docker buildx build --target ci-image -f .docker-context/ci/Dockerfile \
             --build-arg "DAILY_HISTORY_BASE=${GIT_IMAGE}:${HISTORY_BASE}" \
+            --build-arg "CURRENT_PACK_TIP=${CURRENT_PACK_TIP}" \
             --build-context "gitpacks=$PACKS_DIR" \
+            --build-context "ciscripts=docker/ci" \
             -t "${DAILY_IMAGE}:latest" \
             -t "${DAILY_IMAGE}:$(date -u +%Y-%m-%d)" \
             --push \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,185 @@
+# Prebaked CI seed for the self-hosted homelab runners (issue #5008, part of
+# epic #5005). Not a service image -- nothing in it ever runs as a container.
+# .github/workflows/ci-image.yml extracts its filesystem nightly onto the
+# runner hosts, which wire the two things it bakes into a fresh job:
+#
+#   * the git object store, reached via `objects/info/alternates`, so
+#     `actions/checkout` does an incremental fetch instead of a cold clone;
+#   * the pnpm content-addressable store, so `vp install --frozen-lockfile`
+#     is a local hardlink relink instead of a network install.
+#
+# Deliberately NOT `node_modules`. `actions/checkout` defaults to
+# `clean: true` (`git clean -ffdx`), `node_modules` is gitignored
+# (.gitignore:4), and no workflow in this repo sets `clean: false` -- anything
+# seeded inside $GITHUB_WORKSPACE is deleted before the job runs. Only things
+# outside the workspace survive; both the pnpm store (under /ci-seed, never
+# under /app) and the git object store (consumed via alternates, not by
+# copying into the checkout) qualify.
+#
+# LAYER ORDER is strictly most-stable-first, so a daily rebuild invalidates as
+# little as possible (Docker/BuildKit invalidate a layer's cache whenever its
+# own inputs, or anything upstream of it in the FROM chain, changed):
+#
+#   1. toolchain           bumped in weeks-months     (`toolchain` stage)
+#   2. git baseline pack   342.5 MB, quarterly         `git-history` stage,
+#   4. frozen weekly packs 3-11 MB each, immutable    { PACK_NAME=baseline
+#                                                        or week-<date> }
+#   3. pnpm store          ~2 GB, keyed on manifests   (`ci-image` stage)
+#   5. current-week pack   3-30 MB, changes daily      (`ci-image` stage)
+#
+# `git pack-objects` output is NOT guaranteed byte-reproducible across runs or
+# git versions. If a daily build regenerated every historical weekly pack, a
+# single differing byte would invalidate that layer and every layer stacked
+# after it -- destroying the entire point of this scheme (a naive daily
+# rebuild re-pushes .git's one ~398 MB packfile every day; see the issue for
+# the measurements). So historical packs are never regenerated. Instead they
+# are frozen by CHAINING PUBLISHED IMAGES:
+#
+#   ghcr.io/boardsesh/boardsesh-ci-git:baseline-<date>
+#     Everything up to the re-baseline point. Built once per quarterly
+#     re-baseline:
+#       docker build --target git-history \
+#         --build-arg PACK_NAME=baseline-<date> \
+#         --build-context gitpacks=<dir with baseline-<date>.pack/.idx> \
+#         -t ghcr.io/boardsesh/boardsesh-ci-git:baseline-<date> .
+#     (GIT_HISTORY_BASE defaults to the local `toolchain` stage, so a fresh
+#     baseline needs no extra build-arg.)
+#
+#   ghcr.io/boardsesh/boardsesh-ci-git:week-<date>
+#     One immutable layer per completed week, chained FROM the previous
+#     week's tag (or the baseline tag, for the first week after a
+#     re-baseline). Built once, at the week's rollover, and never touched
+#     again -- the NEXT week's freeze starts a fresh build FROM this tag:
+#       docker build --target git-history \
+#         --build-arg GIT_HISTORY_BASE=ghcr.io/boardsesh/boardsesh-ci-git:<previous-tag> \
+#         --build-arg PACK_NAME=week-<date> \
+#         --build-context gitpacks=<dir with week-<date>.pack/.idx> \
+#         -t ghcr.io/boardsesh/boardsesh-ci-git:week-<date> .
+#
+#   ghcr.io/boardsesh/boardsesh-ci-image:<tag>
+#     The actual daily image (this file's default target, `ci-image`). FROM
+#     the latest published week tag -- so it inherits the toolchain and every
+#     frozen pack as ONE pulled base image, never re-deriving them -- then
+#     adds the pnpm store and the CURRENT, still-accumulating week's pack,
+#     the only pack legitimately rebuilt every day because it has not been
+#     frozen yet:
+#       docker build --target ci-image \
+#         --build-arg DAILY_HISTORY_BASE=ghcr.io/boardsesh/boardsesh-ci-git:week-<latest> \
+#         --build-context gitpacks=<dir with current-week.pack/.idx> \
+#         -t ghcr.io/boardsesh/boardsesh-ci-image:latest \
+#         .docker-context/ci
+#     The default build context is `.docker-context/ci` (from
+#     `vp run docker-context:ci`), same convention as Dockerfile.web/backend/
+#     sync -- their `COPY manifests/...` lines resolve against it unchanged.
+#     `gitpacks` is the one EXTRA named context this Dockerfile needs, for the
+#     generated pack files, which live outside that manifests-only directory.
+#
+# scripts/ci-image/generate-weekly-packs.ts produces every *.pack/*.idx file
+# COPY'd below (via the `gitpacks` named build context -- see
+# .github/workflows/ci-image.yml) and never re-derives a week that has
+# already been frozen. scripts/ci-image/weekly-packs.ts has the pure
+# boundary/tag math, unit-tested in scripts/__tests__/.
+#
+# The `manifests` build context comes from `vp run docker-context:ci`, which
+# is scripts/create-service-docker-context.mjs's existing manifest collector
+# (the same one Dockerfile.web/backend/sync use for their install layers),
+# registered here under the `ci` service with an empty rootPackageNames so it
+# emits manifests only -- no workspace source, which this image never needs.
+#
+# Both stage-selector ARGs are declared here, before the FIRST FROM in the
+# file. That positioning is load-bearing, not stylistic: Docker/BuildKit only
+# treats an ARG as usable to parameterize a LATER stage's `FROM` if it was
+# declared before the file's first FROM instruction. Move either of these
+# down next to the stage it parameterizes (which reads as more local and more
+# obviously correct) and the build fails with "base name (...) should not be
+# blank" -- confirmed empirically while building this file locally.
+#
+# GIT_HISTORY_BASE defaults to the local `toolchain` stage below, so a fresh
+# quarterly baseline needs no extra build-arg. DAILY_HISTORY_BASE defaults to
+# `scratch` (Docker's reserved empty image) -- not a usable default, a
+# deliberately inert one: BuildKit validates every FROM line up front
+# regardless of which `--target` was requested, so an ARG with no default at
+# all fails EVERY build, including `--target git-history` for a baseline or
+# weekly freeze that never reaches the `ci-image` stage. `scratch` parses
+# cleanly and only breaks (loudly, at the first COPY/RUN) if `ci-image` is
+# ever actually built without passing this explicitly -- which
+# .github/workflows/ci-image.yml always does, naming the latest frozen week
+# tag. Never let this default silently point at real history.
+ARG GIT_HISTORY_BASE=toolchain
+ARG DAILY_HISTORY_BASE=scratch
+
+# glibc, NOT alpine -- deliberately different from Dockerfile.web/backend/sync.
+# Those images run their own node process, so musl is fine. This image's
+# `pnpm fetch` (below) resolves and runs postinstall for platform-specific
+# native prebuilds (canvas, sharp, esbuild...), and pnpm's lockfile records
+# those per OS+libc+arch: an alpine/musl builder can pull the musl variant of
+# a package into the store while the CI hosts that actually consume it are
+# full Ubuntu VMs on glibc (#5009's ci_runner_host role: "Node 22, Python
+# 3.11+3.12, JDK 21 Temurin" on the bare VM, no container) -- a libc mismatch
+# would seed the wrong prebuilt binaries. Matching glibc also means canvas's
+# vendored prebuild resolves the same way it does in ci.yml's `test-ocr` job
+# (`ubuntu-latest`, glibc): see #5009's "do NOT install cairo/pango/librsvg"
+# note -- installing them here would mask exactly the prebuild regression
+# that job exists to catch.
+FROM node:22-bookworm-slim AS toolchain
+
+# git: holds the seeded object store and writes its multi-pack index. pnpm,
+# pinned to package.json's `packageManager` field like the sibling
+# Dockerfiles: needed at BUILD time to run `pnpm fetch` in the `ci-image`
+# stage below. Neither runs at extraction time -- the runner host supplies
+# its own toolchain (ci_runner_host Ansible role, #5009); this copy only has
+# to be self-consistent for the build that produces the seed.
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends git ca-certificates && \
+    rm -rf /var/lib/apt/lists/* && \
+    npm install --global --no-fund --no-audit pnpm@11.22.0
+
+RUN git init --bare /ci-seed/git
+
+# --- git history: baseline once per quarter, one more pack per week after ---
+# Reused for both purposes (see the header comment for the exact build-arg
+# pairs): either way this stage adds exactly ONE pack and rewrites the
+# multi-pack index, then is published and never rebuilt again.
+FROM ${GIT_HISTORY_BASE} AS git-history
+
+ARG PACK_NAME
+COPY --from=gitpacks ${PACK_NAME}.pack ${PACK_NAME}.idx /ci-seed/git/objects/pack/
+RUN git --git-dir=/ci-seed/git multi-pack-index write
+
+# --- daily image: pnpm store (position 3), then the current week (position 5) ---
+FROM ${DAILY_HISTORY_BASE} AS ci-image
+
+WORKDIR /ci-seed/manifests
+# Only the install inputs, copied BEFORE `pnpm fetch` -- source never enters
+# this image at all, but the ordering still matters: it is what keeps this
+# layer (and the store fetch below) a cache hit on the ~51% of days the
+# lockfile is unchanged (measured: the manifest changed on 88 of the last 180
+# days). Do not add a `source/` COPY here to "match" the other Dockerfiles --
+# this image is data-only by design (see the header comment).
+COPY manifests/package.json manifests/pnpm-lock.yaml manifests/pnpm-workspace.yaml ./
+COPY manifests/packages ./packages
+COPY manifests/patches ./patches
+
+# `pnpm fetch` (not `pnpm install`) populates the content-addressable store
+# from the lockfile alone, without needing a real workspace checkout --
+# pnpm's own Docker-layer-caching recipe, and exactly the shape this layer
+# needs: it must persist in the image, so unlike the sibling Dockerfiles this
+# is a plain RUN, not a `--mount=type=cache` BuildKit cache (which is
+# ephemeral and would leave the store empty in the pushed image).
+#
+# `fetch` also builds a "virtual store" under ./node_modules to run each
+# package's install-time scripts once (canvas, sharp, esbuild...) so the real
+# job's later `pnpm install --frozen-lockfile` only has to hardlink, never
+# re-run a native build. Delete that scratch node_modules afterwards: its
+# entries are hardlinks into --store-dir, so this drops ~350 MB of redundant
+# directory entries from the image layer without touching the store content
+# they point at (measured locally; see the issue for how to reproduce).
+RUN pnpm fetch --store-dir /ci-seed/pnpm-store && rm -rf node_modules
+
+# The only pack rebuilt every day: it has not been frozen into a `week-<date>`
+# tag yet, so unlike the layers above, regenerating it is expected and safe.
+ARG CURRENT_PACK_NAME=current-week
+COPY --from=gitpacks ${CURRENT_PACK_NAME}.pack ${CURRENT_PACK_NAME}.idx /ci-seed/git/objects/pack/
+RUN git --git-dir=/ci-seed/git multi-pack-index write

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,31 +1,64 @@
-# Prebaked CI seed for the self-hosted homelab runners (issue #5008, part of
-# epic #5005). Not a service image -- nothing in it ever runs as a container.
-# .github/workflows/ci-image.yml extracts its filesystem nightly onto the
-# runner hosts, which wire the two things it bakes into a fresh job:
+# The CI image the self-hosted homelab fleet RUNS (issue #5008, part of epic
+# #5005). One GitHub Actions job per container: the runner host starts a
+# container from this image, it serves exactly one job, and `--rm` throws the
+# whole filesystem away.
 #
+# It bakes three things:
+#
+#   * the actions/runner agent and the CI toolchain, so the container is a
+#     working runner rather than a data blob a host has to unpack;
 #   * the git object store, reached via `objects/info/alternates`, so
 #     `actions/checkout` does an incremental fetch instead of a cold clone;
 #   * the pnpm content-addressable store, so `vp install --frozen-lockfile`
 #     is a local hardlink relink instead of a network install.
+#
+# Running the seed rather than extracting it is what makes the per-job reset
+# free. The image layers are read-only and every write a job makes lands in
+# the container's own writable layer, so "a job cannot corrupt the seed for
+# the next job" holds by construction -- no overlay upperdir to manage on the
+# host, no cleanup script that has to enumerate what to discard.
+#
+# Docker is NOT a security boundary here. The container gets the host's
+# docker socket so `services:` and buildx work, and that socket is root on
+# the host. The VM and its VLAN remain the actual boundary; this
+# containerises for RELIABILITY, so one job cannot be broken by what the last
+# one left behind.
 #
 # Deliberately NOT `node_modules`. `actions/checkout` defaults to
 # `clean: true` (`git clean -ffdx`), `node_modules` is gitignored
 # (.gitignore:4), and no workflow in this repo sets `clean: false` -- anything
 # seeded inside $GITHUB_WORKSPACE is deleted before the job runs. Only things
 # outside the workspace survive; both the pnpm store (under /ci-seed, never
-# under /app) and the git object store (consumed via alternates, not by
-# copying into the checkout) qualify.
+# under the workspace) and the git object store (consumed via alternates, not
+# by copying into the checkout) qualify.
 #
 # LAYER ORDER is strictly most-stable-first, so a daily rebuild invalidates as
 # little as possible (Docker/BuildKit invalidate a layer's cache whenever its
 # own inputs, or anything upstream of it in the FROM chain, changed):
 #
-#   1. toolchain           bumped in weeks-months     (`toolchain` stage)
+#   1. seed base           bumped in weeks-months     (`seed-base` stage)
 #   2. git baseline pack   342.5 MB, quarterly         `git-history` stage,
-#   4. frozen weekly packs 3-11 MB each, immutable    { PACK_NAME=baseline
+#   3. frozen weekly packs 3-11 MB each, immutable    { PACK_NAME=baseline
 #                                                        or week-<date> }
-#   3. pnpm store          ~2 GB, keyed on manifests   (`ci-image` stage)
-#   5. current-week pack   3-30 MB, changes daily      (`ci-image` stage)
+#   4. runner + toolchain  pinned, bumped rarely       (`ci-image` stage)
+#   5. pnpm store          ~2 GB, keyed on manifests   (`ci-image` stage)
+#   6. current-week pack   3-30 MB, changes daily      (`ci-image` stage)
+#
+# Position 4 is load-bearing and easy to get wrong. The runner agent and the
+# CI toolchain sit at the TOP of the daily stage, NOT down in `seed-base`
+# where they would be shared by the whole frozen chain and pulled once per
+# quarter instead of once per week. That costs a weekly re-pull of the
+# toolchain layers, and buys two things worth more than the bytes:
+#
+#   * GitHub forces runner-agent upgrades on its own schedule, and the agent
+#     here is pinned with `--disableupdate` (see docker/ci/entrypoint.sh). If
+#     the agent lived in the frozen chain, every forced bump would require an
+#     out-of-cycle quarterly re-baseline of 342 MB of git history that did
+#     not change. Here it is a one-line ARG bump.
+#   * Frozen history layers stay pure git objects. Coupling a mutable
+#     toolchain to layers whose entire contract is "built once, never
+#     rebuilt" means a security update to the toolchain either invalidates
+#     immutable history or silently never lands.
 #
 # `git pack-objects` output is NOT guaranteed byte-reproducible across runs or
 # git versions. If a daily build regenerated every historical weekly pack, a
@@ -40,9 +73,10 @@
 #     re-baseline:
 #       docker build --target git-history \
 #         --build-arg PACK_NAME=baseline-<date> \
+#         --build-arg PACK_TIP=<sha the pack was built to> \
 #         --build-context gitpacks=<dir with baseline-<date>.pack/.idx> \
 #         -t ghcr.io/boardsesh/boardsesh-ci-git:baseline-<date> .
-#     (GIT_HISTORY_BASE defaults to the local `toolchain` stage, so a fresh
+#     (GIT_HISTORY_BASE defaults to the local `seed-base` stage, so a fresh
 #     baseline needs no extra build-arg.)
 #
 #   ghcr.io/boardsesh/boardsesh-ci-git:week-<date>
@@ -53,26 +87,35 @@
 #       docker build --target git-history \
 #         --build-arg GIT_HISTORY_BASE=ghcr.io/boardsesh/boardsesh-ci-git:<previous-tag> \
 #         --build-arg PACK_NAME=week-<date> \
+#         --build-arg PACK_TIP=<sha the pack was built to> \
 #         --build-context gitpacks=<dir with week-<date>.pack/.idx> \
 #         -t ghcr.io/boardsesh/boardsesh-ci-git:week-<date> .
 #
 #   ghcr.io/boardsesh/boardsesh-ci-image:<tag>
-#     The actual daily image (this file's default target, `ci-image`). FROM
-#     the latest published week tag -- so it inherits the toolchain and every
-#     frozen pack as ONE pulled base image, never re-deriving them -- then
-#     adds the pnpm store and the CURRENT, still-accumulating week's pack,
-#     the only pack legitimately rebuilt every day because it has not been
-#     frozen yet:
+#     The actual daily image (this file's default target, `ci-image`), and
+#     the one the fleet runs. FROM the latest published week tag -- so it
+#     inherits every frozen pack as ONE pulled base image, never re-deriving
+#     them -- then adds the runner, the toolchain, the pnpm store and the
+#     CURRENT, still-accumulating week's pack, the only pack legitimately
+#     rebuilt every day because it has not been frozen yet:
 #       docker build --target ci-image \
 #         --build-arg DAILY_HISTORY_BASE=ghcr.io/boardsesh/boardsesh-ci-git:week-<latest> \
+#         --build-arg CURRENT_PACK_TIP=<sha the pack was built to> \
 #         --build-context gitpacks=<dir with current-week.pack/.idx> \
 #         -t ghcr.io/boardsesh/boardsesh-ci-image:latest \
 #         .docker-context/ci
 #     The default build context is `.docker-context/ci` (from
 #     `vp run docker-context:ci`), same convention as Dockerfile.web/backend/
 #     sync -- their `COPY manifests/...` lines resolve against it unchanged.
-#     `gitpacks` is the one EXTRA named context this Dockerfile needs, for the
-#     generated pack files, which live outside that manifests-only directory.
+#     Two EXTRA named contexts carry what lives outside that manifests-only
+#     directory: `gitpacks` for the generated pack files, and `ciscripts`
+#     (= docker/ci/) for the entrypoint and the job-started hook.
+#
+# The published package is PUBLIC on purpose. boardsesh/boardsesh is a public
+# repository, so the git objects and the pnpm store are public content
+# already, and a public package means the fleet needs no registry credential
+# -- which is what keeps "no secrets ever reach a machine that runs PR code"
+# (epic #5005 §5) true of the image pull as well.
 #
 # scripts/ci-image/generate-weekly-packs.ts produces every *.pack/*.idx file
 # COPY'd below (via the `gitpacks` named build context -- see
@@ -94,7 +137,7 @@
 # obviously correct) and the build fails with "base name (...) should not be
 # blank" -- confirmed empirically while building this file locally.
 #
-# GIT_HISTORY_BASE defaults to the local `toolchain` stage below, so a fresh
+# GIT_HISTORY_BASE defaults to the local `seed-base` stage below, so a fresh
 # quarterly baseline needs no extra build-arg. DAILY_HISTORY_BASE defaults to
 # `scratch` (Docker's reserved empty image) -- not a usable default, a
 # deliberately inert one: BuildKit validates every FROM line up front
@@ -105,38 +148,48 @@
 # ever actually built without passing this explicitly -- which
 # .github/workflows/ci-image.yml always does, naming the latest frozen week
 # tag. Never let this default silently point at real history.
-ARG GIT_HISTORY_BASE=toolchain
+ARG GIT_HISTORY_BASE=seed-base
 ARG DAILY_HISTORY_BASE=scratch
 
 # glibc, NOT alpine -- deliberately different from Dockerfile.web/backend/sync.
 # Those images run their own node process, so musl is fine. This image's
-# `pnpm fetch` (below) resolves and runs postinstall for platform-specific
-# native prebuilds (canvas, sharp, esbuild...), and pnpm's lockfile records
-# those per OS+libc+arch: an alpine/musl builder can pull the musl variant of
-# a package into the store while the CI hosts that actually consume it are
-# full Ubuntu VMs on glibc (#5009's ci_runner_host role: "Node 22, Python
-# 3.11+3.12, JDK 21 Temurin" on the bare VM, no container) -- a libc mismatch
-# would seed the wrong prebuilt binaries. Matching glibc also means canvas's
-# vendored prebuild resolves the same way it does in ci.yml's `test-ocr` job
-# (`ubuntu-latest`, glibc): see #5009's "do NOT install cairo/pango/librsvg"
-# note -- installing them here would mask exactly the prebuild regression
-# that job exists to catch.
-FROM node:22-bookworm-slim AS toolchain
+# `pnpm fetch` (below) resolves platform-specific native prebuilds (canvas,
+# sharp, esbuild...), and pnpm's lockfile records those per OS+libc+arch: an
+# alpine/musl builder can pull the musl variant of a package into the store
+# while the jobs that consume it run on glibc -- a libc mismatch would seed
+# the wrong prebuilt binaries. Matching glibc also means canvas's vendored
+# prebuild resolves the same way it does on `ubuntu-latest`, which is what
+# ci.yml's `test-ocr` job depends on: see the "do NOT install
+# cairo/pango/librsvg" note below.
+FROM node:22-bookworm-slim AS seed-base
 
 # git: holds the seeded object store and writes its multi-pack index. pnpm,
 # pinned to package.json's `packageManager` field like the sibling
 # Dockerfiles: needed at BUILD time to run `pnpm fetch` in the `ci-image`
-# stage below. Neither runs at extraction time -- the runner host supplies
-# its own toolchain (ci_runner_host Ansible role, #5009); this copy only has
-# to be self-consistent for the build that produces the seed.
+# stage below.
 ENV PNPM_HOME=/pnpm
 ENV PATH=$PNPM_HOME:$PATH
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends git ca-certificates && \
     rm -rf /var/lib/apt/lists/* && \
-    npm install --global --no-fund --no-audit pnpm@11.22.0
+    npm i --global --no-fund --no-audit pnpm@11.22.0
 
-RUN git init --bare /ci-seed/git
+# The job user is created HERE, in the frozen chain's base, so every /ci-seed
+# path the chain creates already carries the ownership the job needs and no
+# later stage has to `chown -R` a 2 GB store into a duplicate layer. The uid
+# is pinned rather than left to useradd's next-free choice: the host bind-
+# mounts caches in by path, so a uid that shifted when a future base image
+# added a user of its own would silently make those mounts unwritable. 1000
+# is already taken by node:22-bookworm-slim's own `node` user.
+RUN useradd --create-home --uid 1001 --shell /bin/bash runner
+
+RUN git init --bare /ci-seed/git && chown -R runner:runner /ci-seed
+
+# Everything downstream that writes into /ci-seed runs as the job user, so the
+# multi-pack index each history layer rewrites is never left root-owned for a
+# later unprivileged stage to trip over. `ci-image` re-escalates explicitly
+# for its apt work and drops back before the store.
+USER runner
 
 # --- git history: baseline once per quarter, one more pack per week after ---
 # Reused for both purposes (see the header comment for the exact build-arg
@@ -145,24 +198,118 @@ RUN git init --bare /ci-seed/git
 FROM ${GIT_HISTORY_BASE} AS git-history
 
 ARG PACK_NAME
-COPY --from=gitpacks ${PACK_NAME}.pack ${PACK_NAME}.idx /ci-seed/git/objects/pack/
-RUN git --git-dir=/ci-seed/git multi-pack-index write
+ARG PACK_TIP
+COPY --from=gitpacks --chown=runner:runner \
+     ${PACK_NAME}.pack ${PACK_NAME}.idx /ci-seed/git/objects/pack/
+# The ref is not bookkeeping -- it is what makes the seed work at all.
+# `git fetch` negotiation is driven by the fetching repo's REFS: a repo with
+# objects but no refs tells the server "I have nothing" and receives a full
+# pack, so the alternate saves nothing and the seed is silently inert. Naming
+# each layer's tip is what lets a job's fetch say "I already have this" and
+# take only the delta. `update-ref` also fails outright if the pack does not
+# actually contain the tip it claims, which is a free integrity check on the
+# pack this layer just copied.
+RUN git --git-dir=/ci-seed/git update-ref "refs/ci-seed/${PACK_NAME}" "${PACK_TIP}" && \
+    git --git-dir=/ci-seed/git multi-pack-index write
 
-# --- daily image: pnpm store (position 3), then the current week (position 5) ---
+# --- daily image: what the fleet actually runs -------------------------------
 FROM ${DAILY_HISTORY_BASE} AS ci-image
 
+# --- position 4: the runner agent and the CI toolchain -----------------------
+USER root
+
+# Everything a job needs that is not already in node:22-bookworm-slim. Kept
+# to what the workflows actually use; the Android SDK and JDK 21 are Wave 4
+# (see epic #5005 §8) and add ~20 GB, so they stay out until that wave needs
+# them.
+#
+# Deliberately NOT cairo/pango/librsvg: ci.yml documents that `test-ocr`
+# relies on canvas@3.2.3's vendored prebuild resolving via RUNPATH $ORIGIN.
+# Installing the system libraries would let a broken prebuild fall back to
+# them and silently mask the regression that job exists to catch.
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends \
+      curl jq unzip zip sudo gnupg \
+      python3 python3-venv \
+      openssh-client iputils-ping \
+      libicu72 \
+      qemu-user-static binfmt-support && \
+    rm -rf /var/lib/apt/lists/*
+
+# Docker CLI only, no daemon: the host's socket is bind-mounted in, so
+# `services:` containers and buildx builders are siblings on the host rather
+# than nested. That socket is root on the host, which is exactly why the
+# container is not treated as a security boundary.
+RUN install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg \
+      -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc && \
+    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" \
+      > /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install --yes --no-install-recommends \
+      docker-ce-cli docker-buildx-plugin docker-compose-plugin && \
+    rm -rf /var/lib/apt/lists/*
+
+# Passwordless sudo because workflows assume it -- GitHub-hosted runners
+# provide it and plenty of third-party actions shell out to `sudo apt-get`.
+# It grants nothing extra here: the container is discarded after one job, and
+# the mounted docker socket already exceeds anything sudo could reach.
+RUN echo 'runner ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/runner && \
+    chmod 0440 /etc/sudoers.d/runner
+
+# `setup-node` and friends re-download their toolchain on EVERY job unless
+# the hosted tool cache has the exact layout AND the sibling `.complete`
+# marker file -- the marker is what the actions test for, not the directory.
+# Node is the only one worth prefilling today: it is the one every workflow
+# sets up, and the exact version is already here because the base is node:22.
+ENV AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache
+RUN node_version="$(node --version)" && \
+    tool_directory="/opt/hostedtoolcache/node/${node_version#v}/x64" && \
+    mkdir -p "$tool_directory" && \
+    cp -a /usr/local/bin /usr/local/lib /usr/local/include "$tool_directory/" && \
+    touch "/opt/hostedtoolcache/node/${node_version#v}/x64.complete" && \
+    chown -R runner:runner /opt/hostedtoolcache
+
+# The agent, pinned with a checksum rather than "whatever is latest at build
+# time": a rebuild must not silently change the thing that executes every
+# job. `--disableupdate` is passed at configure time (docker/ci/entrypoint.sh)
+# so a running container never drifts from the image it came from, which
+# would defeat the point of rebuilding per job. Bumping these two ARGs is the
+# supported way to take a new agent, and because this layer is in the daily
+# stage rather than the frozen chain, that costs no re-baseline.
+ARG RUNNER_VERSION=2.337.0
+ARG RUNNER_SHA256=70920811a4f8ad4328818682bca5c6469c1c942fab52448868071d0063816613
+RUN mkdir -p /home/runner/actions-runner && \
+    cd /home/runner/actions-runner && \
+    curl -fsSL -o runner.tar.gz \
+      "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" && \
+    echo "${RUNNER_SHA256}  runner.tar.gz" | sha256sum -c - && \
+    tar xzf runner.tar.gz && \
+    rm runner.tar.gz && \
+    ./bin/installdependencies.sh && \
+    mkdir -p /home/runner/_work && \
+    chown -R runner:runner /home/runner
+
+COPY --from=ciscripts --chmod=0755 entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY --from=ciscripts --chmod=0755 job-started.sh /usr/local/bin/job-started.sh
+
+# --- position 5: the pnpm store ----------------------------------------------
+USER runner
 WORKDIR /ci-seed/manifests
+
 # Only the install inputs, copied BEFORE `pnpm fetch` -- source never enters
 # this image at all, but the ordering still matters: it is what keeps this
 # layer (and the store fetch below) a cache hit on the ~51% of days the
 # lockfile is unchanged (measured: the manifest changed on 88 of the last 180
 # days). Do not add a `source/` COPY here to "match" the other Dockerfiles --
-# this image is data-only by design (see the header comment).
-COPY manifests/package.json manifests/pnpm-lock.yaml manifests/pnpm-workspace.yaml ./
-COPY manifests/packages ./packages
-COPY manifests/patches ./patches
+# a job brings its own source via `actions/checkout`.
+COPY --chown=runner:runner \
+     manifests/package.json manifests/pnpm-lock.yaml manifests/pnpm-workspace.yaml ./
+COPY --chown=runner:runner manifests/packages ./packages
+COPY --chown=runner:runner manifests/patches ./patches
 
-# `pnpm fetch` (not `pnpm install`) populates the content-addressable store
+# `pnpm fetch` (not a full install) populates the content-addressable store
 # from the lockfile alone, without needing a real workspace checkout --
 # pnpm's own Docker-layer-caching recipe, and exactly the shape this layer
 # needs: it must persist in the image, so unlike the sibling Dockerfiles this
@@ -170,16 +317,34 @@ COPY manifests/patches ./patches
 # ephemeral and would leave the store empty in the pushed image).
 #
 # `fetch` also builds a "virtual store" under ./node_modules to run each
-# package's install-time scripts once (canvas, sharp, esbuild...) so the real
-# job's later `pnpm install --frozen-lockfile` only has to hardlink, never
-# re-run a native build. Delete that scratch node_modules afterwards: its
-# entries are hardlinks into --store-dir, so this drops ~350 MB of redundant
-# directory entries from the image layer without touching the store content
-# they point at (measured locally; see the issue for how to reproduce).
+# package's install-time scripts once (canvas, sharp, esbuild...) so a job's
+# later `vp install --frozen-lockfile` only has to hardlink, never re-run a
+# native build. Delete that scratch node_modules afterwards: its entries are
+# hardlinks into --store-dir, so this drops ~350 MB of redundant directory
+# entries from the image layer without touching the store content they point
+# at (measured locally; see the issue for how to reproduce).
+ENV PNPM_STORE_DIR=/ci-seed/pnpm-store
 RUN pnpm fetch --store-dir /ci-seed/pnpm-store && rm -rf node_modules
 
+# --- position 6: the current week's pack -------------------------------------
 # The only pack rebuilt every day: it has not been frozen into a `week-<date>`
 # tag yet, so unlike the layers above, regenerating it is expected and safe.
 ARG CURRENT_PACK_NAME=current-week
-COPY --from=gitpacks ${CURRENT_PACK_NAME}.pack ${CURRENT_PACK_NAME}.idx /ci-seed/git/objects/pack/
-RUN git --git-dir=/ci-seed/git multi-pack-index write
+ARG CURRENT_PACK_TIP
+COPY --from=gitpacks --chown=runner:runner \
+     ${CURRENT_PACK_NAME}.pack ${CURRENT_PACK_NAME}.idx /ci-seed/git/objects/pack/
+# Same reasoning as the frozen layers above: without a ref naming this tip, a
+# job's fetch negotiates from nothing and re-downloads history the image
+# already holds.
+RUN git --git-dir=/ci-seed/git update-ref "refs/ci-seed/${CURRENT_PACK_NAME}" "${CURRENT_PACK_TIP}" && \
+    git --git-dir=/ci-seed/git multi-pack-index write
+
+# The job-started hook is what makes the baked git store do anything: it
+# points a fresh checkout's alternates at /ci-seed/git before
+# `actions/checkout` runs. Without it the seed is inert and every job pays
+# for a cold clone.
+ENV ACTIONS_RUNNER_HOOK_JOB_STARTED=/usr/local/bin/job-started.sh
+ENV CI_SEED_GIT_DIR=/ci-seed/git
+
+WORKDIR /home/runner/actions-runner
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/ci/entrypoint.sh
+++ b/docker/ci/entrypoint.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Configure one ephemeral runner, serve exactly one job, exit.
+#
+# The host starts this container with `--rm`, so exiting throws the whole
+# filesystem away and the next job starts from the image again. That is the
+# entire point of running the CI image rather than extracting it: a job cannot
+# be broken by whatever the previous one left behind, and no cleanup script
+# has to anticipate what that might be.
+#
+# RUNNER_TOKEN is a *registration* token, not the PAT that minted it. The PAT
+# lives in a root-only file on the host and never enters this container; the
+# host's privileged ExecStartPre exchanges it for this short-lived token,
+# which expires in an hour and only permits registering a runner on one repo.
+# That split is what keeps a job that reads its own environment from getting
+# anything worth having -- see roles/github_actions_runner/README.md in
+# marcodejongh/blackheathdc-ansible.
+
+set -euo pipefail
+
+: "${RUNNER_TOKEN:?RUNNER_TOKEN is required}"
+: "${RUNNER_REPO:?RUNNER_REPO is required (owner/name)}"
+: "${RUNNER_NAME:?RUNNER_NAME is required}"
+: "${RUNNER_LABELS:?RUNNER_LABELS is required}"
+
+cd /home/runner/actions-runner
+
+# --disableupdate: the agent version is pinned with a checksum in
+# Dockerfile.ci. Letting it self-update would make a running container drift
+# from the image it came from, which is exactly what rebuilding per job
+# exists to prevent. Bump the ARG to take a new agent.
+./config.sh \
+  --url "https://github.com/${RUNNER_REPO}" \
+  --token "${RUNNER_TOKEN}" \
+  --name "${RUNNER_NAME}" \
+  --labels "${RUNNER_LABELS}" \
+  --work /home/runner/_work \
+  --ephemeral \
+  --unattended \
+  --replace \
+  --disableupdate
+
+# Drop the token before handing control to job code. The original value is
+# still readable in /proc/1/environ, so this is tidiness rather than a
+# control -- the real bound is that the token expires in an hour and can only
+# register a runner.
+unset RUNNER_TOKEN
+
+exec ./run.sh

--- a/docker/ci/job-started.sh
+++ b/docker/ci/job-started.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# ACTIONS_RUNNER_HOOK_JOB_STARTED -- runs before the job's first step.
+#
+# Points a fresh workspace at the git object store baked into this image, so
+# `actions/checkout` does an incremental fetch of the PR's commits instead of
+# a cold ~400 MB clone. Without this the baked history is inert and only the
+# pnpm half of the seed pays off.
+#
+# How it survives checkout: `actions/checkout` defaults to `clean: true`,
+# which is `git clean -ffdx` INSIDE the repo -- it never removes `.git`
+# itself. So an existing `.git` with the right remote is honoured (checkout
+# fetches into it) while anything seeded next to it in the workspace would be
+# swept away. The alternate itself lives outside the workspace entirely.
+#
+# BEST-EFFORT BY DESIGN. A hook that exits non-zero fails the job before it
+# starts, and this is an optimisation: every branch below falls through to
+# `exit 0`, leaving checkout to do the cold clone it would have done anyway.
+# The cost of being wrong here is a slow job, never a failed one.
+
+set -uo pipefail
+
+log() { echo "[job-started] $*"; }
+
+seed_git_dir="${CI_SEED_GIT_DIR:-/ci-seed/git}"
+
+if [ ! -d "${seed_git_dir}/objects" ]; then
+  log "no seeded object store at ${seed_git_dir}; leaving checkout to clone"
+  exit 0
+fi
+
+if [ -z "${GITHUB_WORKSPACE:-}" ] || [ ! -d "${GITHUB_WORKSPACE}" ]; then
+  log "no GITHUB_WORKSPACE; nothing to seed"
+  exit 0
+fi
+
+# The seed holds one repository's objects. Pointing another repository's
+# checkout at it would not corrupt anything (alternates are read-only extra
+# object sources) but it would be pure overhead, so only seed the match.
+seed_repo="${CI_SEED_REPOSITORY:-boardsesh/boardsesh}"
+if [ "${GITHUB_REPOSITORY:-}" != "${seed_repo}" ]; then
+  log "job is for ${GITHUB_REPOSITORY:-<unset>}, seed is for ${seed_repo}; skipping"
+  exit 0
+fi
+
+# A workspace that already has a repo is not ours to rewrite -- the runner
+# reuses workspaces within a job, and re-initialising underneath a checkout
+# that already ran would be destructive.
+if [ -e "${GITHUB_WORKSPACE}/.git" ]; then
+  log "workspace already has .git; leaving it alone"
+  exit 0
+fi
+
+if ! git init --quiet "${GITHUB_WORKSPACE}" 2>/dev/null; then
+  log "git init failed; leaving checkout to clone"
+  exit 0
+fi
+
+# checkout compares this against the repository it was asked for and re-clones
+# from scratch if it disagrees, so a wrong URL costs a slow job, not a broken
+# one.
+server_url="${GITHUB_SERVER_URL:-https://github.com}"
+if ! git -C "${GITHUB_WORKSPACE}" remote add origin \
+     "${server_url}/${GITHUB_REPOSITORY}" 2>/dev/null; then
+  log "could not set origin; removing the partial repo"
+  rm -rf -- "${GITHUB_WORKSPACE}/.git"
+  exit 0
+fi
+
+# The alternate is the whole trick: an extra READ-ONLY object source. Git
+# resolves objects from it but writes new ones into the workspace's own
+# object directory, so a job physically cannot mutate the seed even before
+# `--rm` discards the container.
+alternates_file="${GITHUB_WORKSPACE}/.git/objects/info/alternates"
+mkdir -p "$(dirname "${alternates_file}")"
+if ! printf '%s\n' "${seed_git_dir}/objects" > "${alternates_file}"; then
+  log "could not write alternates; removing the partial repo"
+  rm -rf -- "${GITHUB_WORKSPACE}/.git"
+  exit 0
+fi
+
+# Copy the seed's refs across. THIS IS THE HALF THAT ACTUALLY SAVES THE
+# DOWNLOAD, and it is easy to leave out because the alternate alone looks
+# like it should be enough. It is not: `git fetch` negotiation is driven by
+# the fetching repo's refs, so a workspace with every object but no refs tells
+# the server "I have nothing" and receives a full pack anyway. Naming the
+# seeded tips is what lets the fetch resolve to a delta.
+seeded_refs=0
+while read -r object_id ref_name; do
+  [ -n "${object_id}" ] || continue
+  # update-ref refuses an object it cannot resolve, so this doubles as the
+  # proof that the alternate is really wired up.
+  if git -C "${GITHUB_WORKSPACE}" update-ref "${ref_name}" "${object_id}" 2>/dev/null; then
+    seeded_refs=$((seeded_refs + 1))
+  fi
+done <<EOF
+$(git --git-dir="${seed_git_dir}" for-each-ref --format='%(objectname) %(refname)' 'refs/ci-seed/*' 2>/dev/null)
+EOF
+
+if [ "${seeded_refs}" -eq 0 ]; then
+  # Either the seed carries no refs or the alternate does not resolve them.
+  # Both mean a fetch would negotiate from nothing, so the seeded repo buys
+  # nothing and only risks confusing checkout. Hand it a clean slate instead.
+  log "no seed refs resolved through the alternate; removing the partial repo"
+  rm -rf -- "${GITHUB_WORKSPACE}/.git"
+  exit 0
+fi
+
+log "seeded from ${seed_git_dir}: ${seeded_refs} ref(s) resolved through the alternate"
+exit 0

--- a/scripts/__tests__/ci-image-weekly-packs.test.ts
+++ b/scripts/__tests__/ci-image-weekly-packs.test.ts
@@ -1,0 +1,195 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  baselineTag,
+  computeWeekBoundaries,
+  latestHistoryTag,
+  nextHistoryLayer,
+  packObjectsRevListInput,
+  parseDateOnlyUTC,
+  planCompletedWeeks,
+  TOOLCHAIN_STAGE,
+  toDateOnlyUTC,
+  weekTag,
+} from '../ci-image/weekly-packs';
+
+/**
+ * scripts/ci-image/weekly-packs.ts is the pure math behind the prebaked CI
+ * image's git-history layering (issue #5008). It decides which week a commit
+ * falls into, what tag that week gets, and what `git pack-objects --revs`
+ * receives on stdin -- get any of these wrong and either a "weekly" pack
+ * quietly repacks the whole 340+ MB history, or the freeze chain builds FROM
+ * the wrong base image and corrupts the seeded git store.
+ *
+ * The measured boundaries below (baseline 2026-07-28 -> 2026-08-04,
+ * 2026-08-11, 2026-08-18, 2026-08-25, 2026-09-01) are the exact table from
+ * the issue, reproduced here as a fixture so this test also documents where
+ * those numbers came from.
+ */
+
+const MEASURED_BASELINE = '2026-07-28';
+const MEASURED_WEEK_ENDS = ['2026-08-04', '2026-08-11', '2026-08-18', '2026-08-25', '2026-09-01'];
+
+describe('parseDateOnlyUTC / toDateOnlyUTC', () => {
+  it('round-trips a valid date', () => {
+    expect(toDateOnlyUTC(parseDateOnlyUTC('2026-07-28'))).toBe('2026-07-28');
+  });
+
+  it('parses as UTC midnight, not local midnight', () => {
+    expect(parseDateOnlyUTC('2026-07-28').toISOString()).toBe('2026-07-28T00:00:00.000Z');
+  });
+
+  it.each(['2026-7-28', '07-28-2026', '2026/07/28', '2026-07-28T00:00:00Z', 'not-a-date', ''])(
+    'rejects %s',
+    (input) => {
+      expect(() => parseDateOnlyUTC(input)).toThrow();
+    },
+  );
+
+  it('rejects a calendar date that does not exist', () => {
+    // Date() silently rolls Feb 30 forward into March; parseDateOnlyUTC must not.
+    expect(() => parseDateOnlyUTC('2026-02-30')).toThrow();
+  });
+});
+
+describe('computeWeekBoundaries', () => {
+  it('reproduces the exact boundaries measured in issue #5008', () => {
+    const boundaries = computeWeekBoundaries(parseDateOnlyUTC(MEASURED_BASELINE), parseDateOnlyUTC('2026-09-01'));
+    expect(boundaries.map(toDateOnlyUTC)).toEqual(MEASURED_WEEK_ENDS);
+  });
+
+  it('is exactly 7 days between consecutive boundaries', () => {
+    const boundaries = computeWeekBoundaries(parseDateOnlyUTC('2026-01-01'), parseDateOnlyUTC('2026-03-01'));
+    for (let index = 1; index < boundaries.length; index += 1) {
+      expect(boundaries[index].getTime() - boundaries[index - 1].getTime()).toBe(7 * 24 * 60 * 60 * 1000);
+    }
+  });
+
+  it('excludes the baseline date itself (boundaries are strictly after it)', () => {
+    const boundaries = computeWeekBoundaries(parseDateOnlyUTC('2026-07-28'), parseDateOnlyUTC('2026-07-28'));
+    expect(boundaries).toEqual([]);
+  });
+
+  it('includes an asOf that lands exactly on a boundary', () => {
+    const boundaries = computeWeekBoundaries(parseDateOnlyUTC('2026-07-28'), parseDateOnlyUTC('2026-08-04'));
+    expect(boundaries.map(toDateOnlyUTC)).toEqual(['2026-08-04']);
+  });
+
+  it('rejects asOf before baselineDate', () => {
+    expect(() => computeWeekBoundaries(parseDateOnlyUTC('2026-08-01'), parseDateOnlyUTC('2026-07-01'))).toThrow();
+  });
+
+  it('is NOT calendar weeks -- a re-baselined anchor keeps its own weekday, not Monday', () => {
+    // 2026-07-29 is a Wednesday. If this were calendar weeks the first
+    // boundary would land on the following Sunday/Monday instead of exactly
+    // 7 days later.
+    const boundaries = computeWeekBoundaries(parseDateOnlyUTC('2026-07-29'), parseDateOnlyUTC('2026-08-05'));
+    expect(boundaries.map(toDateOnlyUTC)).toEqual(['2026-08-05']);
+  });
+});
+
+describe('baselineTag / weekTag', () => {
+  it('formats the baseline tag', () => {
+    expect(baselineTag(parseDateOnlyUTC('2026-07-28'))).toBe('baseline-2026-07-28');
+  });
+
+  it('formats a week tag', () => {
+    expect(weekTag(parseDateOnlyUTC('2026-08-04'))).toBe('week-2026-08-04');
+  });
+});
+
+describe('planCompletedWeeks', () => {
+  it('chains each week to the previous week, and the first week to baseline', () => {
+    const plan = planCompletedWeeks(parseDateOnlyUTC(MEASURED_BASELINE), parseDateOnlyUTC('2026-09-01'));
+    expect(plan.map((week) => week.tag)).toEqual(MEASURED_WEEK_ENDS.map((date) => `week-${date}`));
+    expect(plan[0].historyBaseTag).toBe('baseline-2026-07-28');
+    for (let index = 1; index < plan.length; index += 1) {
+      expect(plan[index].historyBaseTag).toBe(plan[index - 1].tag);
+    }
+  });
+});
+
+describe('nextHistoryLayer', () => {
+  const baselineDate = parseDateOnlyUTC(MEASURED_BASELINE);
+  const asOf = parseDateOnlyUTC('2026-09-01');
+
+  it('bootstraps the baseline first when nothing exists yet', () => {
+    const layer = nextHistoryLayer(baselineDate, asOf, new Set());
+    expect(layer).toEqual({ tag: 'baseline-2026-07-28', historyBaseTag: TOOLCHAIN_STAGE });
+  });
+
+  it('does not consider ANY week until the baseline itself exists', () => {
+    // Even if every week tag happens to already be present (e.g. stale
+    // entries from an abandoned baseline), a missing baseline must still be
+    // the very next thing built -- every week ultimately chains back to it.
+    const allWeekTags = new Set(MEASURED_WEEK_ENDS.map((date) => `week-${date}`));
+    const layer = nextHistoryLayer(baselineDate, asOf, allWeekTags);
+    expect(layer?.tag).toBe('baseline-2026-07-28');
+  });
+
+  it('finds the earliest missing week once the baseline exists', () => {
+    const existing = new Set(['baseline-2026-07-28', 'week-2026-08-04']);
+    const layer = nextHistoryLayer(baselineDate, asOf, existing);
+    expect(layer).toEqual({ tag: 'week-2026-08-11', historyBaseTag: 'week-2026-08-04' });
+  });
+
+  it('returns null once baseline and every completed week exist', () => {
+    const existing = new Set(['baseline-2026-07-28', ...MEASURED_WEEK_ENDS.map((date) => `week-${date}`)]);
+    expect(nextHistoryLayer(baselineDate, asOf, existing)).toBeNull();
+  });
+
+  it('catches up one step at a time after downtime (not a batch)', () => {
+    // Simulates the scheduled job having missed several rollovers: only the
+    // FIRST missing week should be reported, since freezing must happen in
+    // order (later weeks depend on the immediately preceding tag existing).
+    const existing = new Set(['baseline-2026-07-28']);
+    const layer = nextHistoryLayer(baselineDate, asOf, existing);
+    expect(layer?.tag).toBe('week-2026-08-04');
+  });
+});
+
+describe('latestHistoryTag', () => {
+  const baselineDate = parseDateOnlyUTC(MEASURED_BASELINE);
+  const asOf = parseDateOnlyUTC('2026-09-01');
+
+  it('falls back to the baseline tag when no week has been frozen yet', () => {
+    expect(latestHistoryTag(baselineDate, asOf, new Set(['baseline-2026-07-28']))).toBe('baseline-2026-07-28');
+  });
+
+  it('picks the most recently frozen week, not just any frozen week', () => {
+    const existing = new Set(['baseline-2026-07-28', 'week-2026-08-04', 'week-2026-08-11']);
+    expect(latestHistoryTag(baselineDate, asOf, existing)).toBe('week-2026-08-11');
+  });
+
+  it('matches nextHistoryLayer returning null once fully caught up', () => {
+    const existing = new Set(['baseline-2026-07-28', ...MEASURED_WEEK_ENDS.map((date) => `week-${date}`)]);
+    expect(nextHistoryLayer(baselineDate, asOf, existing)).toBeNull();
+    expect(latestHistoryTag(baselineDate, asOf, existing)).toBe('week-2026-09-01');
+  });
+});
+
+describe('packObjectsRevListInput', () => {
+  it('is just the tip, newline-terminated, when nothing is excluded', () => {
+    expect(packObjectsRevListInput('abc123', null)).toBe('abc123\n');
+  });
+
+  it('prefixes the exclude line with ^, matching git rev-list syntax', () => {
+    expect(packObjectsRevListInput('abc123', 'def456')).toBe('abc123\n^def456\n');
+  });
+
+  it('rejects an empty tip', () => {
+    expect(() => packObjectsRevListInput('', null)).toThrow();
+  });
+
+  it('rejects an empty exclude when one was explicitly requested', () => {
+    expect(() => packObjectsRevListInput('abc123', '')).toThrow();
+  });
+
+  it('matches the exact form issue #5008 specifies: printf "%s\\n^%s\\n"', () => {
+    const tip = 'a'.repeat(40);
+    const exclude = 'b'.repeat(40);
+    expect(packObjectsRevListInput(tip, exclude)).toBe(`${tip}\n^${exclude}\n`);
+  });
+});

--- a/scripts/__tests__/ci-image-workflow.test.ts
+++ b/scripts/__tests__/ci-image-workflow.test.ts
@@ -1,0 +1,181 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+import { getServiceSourcePackageDirs, services } from '../create-service-docker-context.mjs';
+import { jobBlocks, withoutCommentLines } from './helpers/workflow-yaml';
+
+/**
+ * Pins the invisible pairings in Dockerfile.ci and ci-image.yml (issue
+ * #5008) that review cannot easily catch: a Dockerfile that "looks more
+ * obviously correct" after a refactor but silently breaks the freeze chain,
+ * or a workflow authority check drifting out of sync with
+ * postgres-image-publisher.yml's boundary.
+ */
+
+const DOCKERFILE_PATH = 'Dockerfile.ci';
+const WORKFLOW_PATH = '.github/workflows/ci-image.yml';
+
+const dockerfileSource = readFileSync(DOCKERFILE_PATH, 'utf8');
+const workflowSource = readFileSync(WORKFLOW_PATH, 'utf8');
+
+function dockerfileLines(): string[] {
+  return withoutCommentLines(dockerfileSource).filter((line) => line.trim().length > 0);
+}
+
+function firstLineIndexMatching(lines: string[], pattern: RegExp): number {
+  return lines.findIndex((line) => pattern.test(line));
+}
+
+describe('Dockerfile.ci: ARG-before-FROM positioning', () => {
+  // Confirmed empirically while building this file locally: Docker/BuildKit
+  // only lets an ARG parameterize a LATER stage's `FROM ${ARG}` if that ARG
+  // was declared before the file's FIRST FROM instruction. Declaring it
+  // right next to the FROM it parameterizes reads as more obviously correct
+  // and fails the build with "base name (...) should not be blank" -- see
+  // the comment directly above these ARGs in Dockerfile.ci.
+  it('declares GIT_HISTORY_BASE and DAILY_HISTORY_BASE before the first FROM', () => {
+    const lines = dockerfileLines();
+    const firstFromIndex = firstLineIndexMatching(lines, /^FROM\s/);
+    expect(firstFromIndex).toBeGreaterThan(-1);
+
+    const gitHistoryArgIndex = firstLineIndexMatching(lines, /^ARG GIT_HISTORY_BASE=/);
+    const dailyHistoryArgIndex = firstLineIndexMatching(lines, /^ARG DAILY_HISTORY_BASE=/);
+    expect(gitHistoryArgIndex, 'ARG GIT_HISTORY_BASE=... not found').toBeGreaterThan(-1);
+    expect(dailyHistoryArgIndex, 'ARG DAILY_HISTORY_BASE=... not found').toBeGreaterThan(-1);
+
+    expect(gitHistoryArgIndex).toBeLessThan(firstFromIndex);
+    expect(dailyHistoryArgIndex).toBeLessThan(firstFromIndex);
+  });
+
+  it('has exactly three FROM instructions: toolchain, git-history, ci-image', () => {
+    const stageNames = [...dockerfileSource.matchAll(/^FROM\s+\S+\s+AS\s+(\S+)/gm)].map((match) => match[1]);
+    expect(stageNames).toEqual(['toolchain', 'git-history', 'ci-image']);
+  });
+});
+
+describe('Dockerfile.ci: manifests feed pnpm fetch, never the other way round', () => {
+  it('copies every manifest input before RUN pnpm fetch', () => {
+    const fetchIndex = dockerfileSource.indexOf('RUN pnpm fetch');
+    expect(fetchIndex).toBeGreaterThan(-1);
+
+    for (const copyLine of [
+      'COPY manifests/package.json manifests/pnpm-lock.yaml manifests/pnpm-workspace.yaml ./',
+      'COPY manifests/packages ./packages',
+      'COPY manifests/patches ./patches',
+    ]) {
+      const copyIndex = dockerfileSource.indexOf(copyLine);
+      expect(copyIndex, `missing ${JSON.stringify(copyLine)}`).toBeGreaterThan(-1);
+      expect(copyIndex, `${JSON.stringify(copyLine)} must appear before pnpm fetch`).toBeLessThan(fetchIndex);
+    }
+  });
+
+  it('uses `pnpm fetch`, not `pnpm install` -- fetch is what makes a lockfile-only layer possible', () => {
+    const codeLines = dockerfileLines();
+    expect(codeLines.some((line) => line.includes('pnpm fetch'))).toBe(true);
+    // Scoped to non-comment lines: the header comment legitimately DISCUSSES
+    // `pnpm install` (contrasting this file with the sibling Dockerfiles), so
+    // scanning the whole file text would false-positive on that prose.
+    expect(codeLines.some((line) => /\bpnpm install\b/.test(line))).toBe(false);
+  });
+
+  it('never copies real workspace source -- this image is manifests + git packs only', () => {
+    // The sibling Dockerfiles copy `source/packages` after their install
+    // layer; Dockerfile.ci must never do the equivalent, on purpose (see its
+    // header comment: "this image is data-only by design").
+    expect(dockerfileSource).not.toMatch(/^COPY source\//m);
+    expect(dockerfileSource).not.toMatch(/^COPY packages\//m);
+  });
+});
+
+describe('create-service-docker-context.mjs: the `ci` service is manifests-only', () => {
+  const ciService = services.ci as { dockerfile: string; rootPackageNames: string[] };
+
+  it('declares no root packages, so the dependency walk finds no source dirs', () => {
+    expect(ciService.rootPackageNames).toEqual([]);
+    expect(getServiceSourcePackageDirs('ci')).toEqual([]);
+  });
+
+  it('points at Dockerfile.ci', () => {
+    expect(ciService.dockerfile).toBe('Dockerfile.ci');
+  });
+});
+
+describe('ci-image.yml: build authority is main only', () => {
+  const authorizeBlock = jobBlocks(workflowSource).get('authorize-main');
+
+  it('has an authorize-main job', () => {
+    expect(authorizeBlock).toBeDefined();
+  });
+
+  it('asserts workflow_ref ends with the protected main path, mirroring postgres-image-publisher.yml', () => {
+    const joined = (authorizeBlock ?? []).join('\n');
+    expect(joined).toContain('*/.github/workflows/ci-image.yml@refs/heads/main');
+  });
+
+  it('asserts github.ref_protected is true', () => {
+    const joined = (authorizeBlock ?? []).join('\n');
+    expect(joined).toContain('REF_IS_PROTECTED');
+    expect(joined).toContain("REF_IS_PROTECTED\" == 'true'");
+  });
+
+  it('every other job needs authorize-main, directly or transitively', () => {
+    const blocks = jobBlocks(workflowSource);
+    for (const [jobName, lines] of blocks) {
+      if (jobName === 'authorize-main') continue;
+      const needsLine = lines.find((line) => line.trim().startsWith('needs:'));
+      expect(needsLine, `job ${jobName} has no needs: line`).toBeDefined();
+      expect(needsLine, `job ${jobName} does not need authorize-main`).toContain('authorize-main');
+    }
+  });
+
+  it('is never triggered by pull_request or push -- only schedule and workflow_dispatch', () => {
+    const lines = withoutCommentLines(workflowSource);
+    const onIndex = lines.findIndex((line) => line === 'on:');
+    expect(onIndex).toBeGreaterThan(-1);
+    const onBlock: string[] = [];
+    for (const line of lines.slice(onIndex + 1)) {
+      if (line.trim() && !line.startsWith(' ')) break;
+      onBlock.push(line);
+    }
+    const triggers = onBlock.filter((line) => /^  [a-z_]+:/.test(line)).map((line) => line.trim().replace(':', ''));
+    expect(triggers.sort()).toEqual(['schedule', 'workflow_dispatch']);
+  });
+});
+
+describe('ci-image.yml: freeze-history builds against the right Dockerfile', () => {
+  // Real bug caught while writing this workflow: `docker build` with no `-f`
+  // looks for a file literally named `Dockerfile` in the context root. The
+  // checkout's root has `Dockerfile.ci`, not `Dockerfile` -- omitting `-f`
+  // here fails the build the moment a week actually needs freezing (i.e. not
+  // on the day this ships, but the next time a week rolls over).
+  it('passes -f Dockerfile.ci to the git-history build', () => {
+    const block = jobBlocks(workflowSource).get('freeze-history') ?? [];
+    const joined = block.join('\n');
+    expect(joined).toContain('docker buildx build --target git-history -f Dockerfile.ci');
+  });
+});
+
+describe('ci-image.yml: vp toolchain pairing for its own vp run step', () => {
+  // Same invisible-pairing concern as ci-vp-toolchain.test.ts, scoped to this
+  // new workflow: `vp run docker-context:ci` dies on `vp: command not found`
+  // without voidzero-dev/setup-vp having run first in the same job.
+  it('installs setup-vp before running `vp run docker-context:ci`', () => {
+    const block = jobBlocks(workflowSource).get('build-daily-image') ?? [];
+    const vpRunIndex = block.findIndex((line) => line.includes('vp run docker-context:ci'));
+    const setupVpIndex = block.findIndex((line) => line.includes('voidzero-dev/setup-vp'));
+    expect(vpRunIndex).toBeGreaterThan(-1);
+    expect(setupVpIndex).toBeGreaterThan(-1);
+    expect(setupVpIndex).toBeLessThan(vpRunIndex);
+  });
+});
+
+describe('ci-image.yml: concurrency prevents overlapping runs', () => {
+  it('has a single, non-cancelling concurrency group', () => {
+    const lines = withoutCommentLines(workflowSource);
+    const groupIndex = lines.findIndex((line) => line.trim() === 'group: ci-image');
+    expect(groupIndex).toBeGreaterThan(-1);
+    expect(lines.some((line) => line.trim() === 'cancel-in-progress: false')).toBe(true);
+  });
+});

--- a/scripts/__tests__/ci-image-workflow.test.ts
+++ b/scripts/__tests__/ci-image-workflow.test.ts
@@ -49,9 +49,9 @@ describe('Dockerfile.ci: ARG-before-FROM positioning', () => {
     expect(dailyHistoryArgIndex).toBeLessThan(firstFromIndex);
   });
 
-  it('has exactly three FROM instructions: toolchain, git-history, ci-image', () => {
+  it('has exactly three FROM instructions: seed-base, git-history, ci-image', () => {
     const stageNames = [...dockerfileSource.matchAll(/^FROM\s+\S+\s+AS\s+(\S+)/gm)].map((match) => match[1]);
-    expect(stageNames).toEqual(['toolchain', 'git-history', 'ci-image']);
+    expect(stageNames).toEqual(['seed-base', 'git-history', 'ci-image']);
   });
 });
 
@@ -60,14 +60,20 @@ describe('Dockerfile.ci: manifests feed pnpm fetch, never the other way round', 
     const fetchIndex = dockerfileSource.indexOf('RUN pnpm fetch');
     expect(fetchIndex).toBeGreaterThan(-1);
 
-    for (const copyLine of [
-      'COPY manifests/package.json manifests/pnpm-lock.yaml manifests/pnpm-workspace.yaml ./',
-      'COPY manifests/packages ./packages',
-      'COPY manifests/patches ./patches',
+    // Matched by manifest path rather than whole-line, so adding a flag
+    // (--chown, --link) stays legal while MOVING a manifest below the fetch
+    // -- the thing that would silently un-cache the store layer -- still
+    // fails.
+    for (const manifestPath of [
+      'manifests/package.json',
+      'manifests/pnpm-lock.yaml',
+      'manifests/pnpm-workspace.yaml',
+      'manifests/packages',
+      'manifests/patches',
     ]) {
-      const copyIndex = dockerfileSource.indexOf(copyLine);
-      expect(copyIndex, `missing ${JSON.stringify(copyLine)}`).toBeGreaterThan(-1);
-      expect(copyIndex, `${JSON.stringify(copyLine)} must appear before pnpm fetch`).toBeLessThan(fetchIndex);
+      const copyIndex = dockerfileSource.indexOf(manifestPath);
+      expect(copyIndex, `missing COPY of ${manifestPath}`).toBeGreaterThan(-1);
+      expect(copyIndex, `${manifestPath} must be copied before pnpm fetch`).toBeLessThan(fetchIndex);
     }
   });
 
@@ -80,12 +86,137 @@ describe('Dockerfile.ci: manifests feed pnpm fetch, never the other way round', 
     expect(codeLines.some((line) => /\bpnpm install\b/.test(line))).toBe(false);
   });
 
-  it('never copies real workspace source -- this image is manifests + git packs only', () => {
+  it('never copies real workspace source -- a job brings its own via actions/checkout', () => {
     // The sibling Dockerfiles copy `source/packages` after their install
-    // layer; Dockerfile.ci must never do the equivalent, on purpose (see its
-    // header comment: "this image is data-only by design").
+    // layer; Dockerfile.ci must never do the equivalent. A job checks out
+    // its own ref, so baked source would be both redundant and a stale
+    // shadow of what the job is actually testing.
     expect(dockerfileSource).not.toMatch(/^COPY source\//m);
     expect(dockerfileSource).not.toMatch(/^COPY packages\//m);
+  });
+});
+
+describe('Dockerfile.ci: the image is runnable, not a data blob', () => {
+  // The whole reason this image carries a runner agent: the fleet RUNS it,
+  // one job per container, and `--rm` is what resets the machine between
+  // jobs. Regress any of these and the image silently reverts to something
+  // a host has to unpack, taking the per-job reset with it.
+  const codeLines = dockerfileLines();
+
+  it('declares an ENTRYPOINT so `docker run <image>` serves a job', () => {
+    expect(codeLines.some((line) => /^ENTRYPOINT\s/.test(line))).toBe(true);
+  });
+
+  it('installs the actions/runner agent with a pinned version AND checksum', () => {
+    // Unpinned, this layer is the one thing every job's code passes through
+    // and a rebuild could silently change it.
+    expect(codeLines.some((line) => /^ARG RUNNER_VERSION=\d+\.\d+\.\d+$/.test(line))).toBe(true);
+    expect(codeLines.some((line) => /^ARG RUNNER_SHA256=[0-9a-f]{64}$/.test(line))).toBe(true);
+    expect(codeLines.some((line) => line.includes('sha256sum -c -'))).toBe(true);
+  });
+
+  it('runs jobs as a non-root user -- the agent refuses to start as root', () => {
+    const lastUserLine = [...codeLines].reverse().find((line) => /^USER\s/.test(line));
+    expect(lastUserLine).toBe('USER runner');
+  });
+
+  it('wires the job-started hook, without which the baked git store is inert', () => {
+    // The seed only pays off if a fresh checkout is pointed at it before
+    // actions/checkout runs. Drop this and every job silently goes back to a
+    // cold ~400 MB clone while the image still looks correct.
+    expect(codeLines.some((line) => line.startsWith('ENV ACTIONS_RUNNER_HOOK_JOB_STARTED='))).toBe(true);
+    expect(dockerfileSource).toMatch(/COPY --from=ciscripts[^\n]*job-started\.sh/);
+  });
+
+  it('keeps the runner agent OUT of the frozen history chain', () => {
+    // Position 4 in the header's layer order. If the agent install moved up
+    // into seed-base it would be shared by every frozen `week-<date>` tag,
+    // so GitHub's next forced agent upgrade would demand an out-of-cycle
+    // re-baseline of 342 MB of git history that did not change.
+    const seedBaseStart = codeLines.findIndex((line) => /^FROM .* AS seed-base$/.test(line));
+    const ciImageStart = codeLines.findIndex((line) => /^FROM .* AS ci-image$/.test(line));
+    const runnerVersionIndex = codeLines.findIndex((line) => line.startsWith('ARG RUNNER_VERSION='));
+
+    expect(seedBaseStart).toBeGreaterThan(-1);
+    expect(ciImageStart).toBeGreaterThan(seedBaseStart);
+    expect(runnerVersionIndex).toBeGreaterThan(ciImageStart);
+  });
+
+  it('adds the pnpm store AFTER the toolchain, so a daily rebuild reuses it', () => {
+    const runnerVersionIndex = codeLines.findIndex((line) => line.startsWith('ARG RUNNER_VERSION='));
+    const fetchIndex = codeLines.findIndex((line) => line.includes('pnpm fetch'));
+    const currentPackIndex = codeLines.findIndex((line) => line.startsWith('ARG CURRENT_PACK_NAME='));
+
+    expect(runnerVersionIndex).toBeLessThan(fetchIndex);
+    expect(fetchIndex).toBeLessThan(currentPackIndex);
+  });
+});
+
+describe('Dockerfile.ci: every pack layer names its tip as a ref', () => {
+  // The bug this pins was found by running the image, not by reading it.
+  // `git fetch` negotiation is driven by the fetching repo's REFS: a seed
+  // with every object but no refs makes a job advertise "I have nothing", so
+  // the server sends a full pack and the entire git half of the seed is
+  // silently inert -- while the image still looks completely correct. Only a
+  // timing measurement would ever have caught it.
+  const codeLines = dockerfileLines();
+
+  it('records a ref for the frozen history pack', () => {
+    expect(codeLines.some((line) => /^ARG PACK_TIP$/.test(line))).toBe(true);
+    expect(dockerfileSource).toMatch(/update-ref "refs\/ci-seed\/\$\{PACK_NAME\}" "\$\{PACK_TIP\}"/);
+  });
+
+  it('records a ref for the current week pack', () => {
+    expect(codeLines.some((line) => /^ARG CURRENT_PACK_TIP$/.test(line))).toBe(true);
+    expect(dockerfileSource).toMatch(/update-ref "refs\/ci-seed\/\$\{CURRENT_PACK_NAME\}" "\$\{CURRENT_PACK_TIP\}"/);
+  });
+
+  it('has ci-image.yml supply both tips', () => {
+    expect(workflowSource).toMatch(/--build-arg "PACK_TIP=/);
+    expect(workflowSource).toMatch(/--build-arg "CURRENT_PACK_TIP=/);
+  });
+});
+
+describe('docker/ci/job-started.sh: seeds refs, not just the alternate', () => {
+  const hookSource = readFileSync('docker/ci/job-started.sh', 'utf8');
+  const hookCodeLines = withoutCommentLines(hookSource);
+
+  it('writes the alternate', () => {
+    expect(hookCodeLines.some((line) => line.includes('objects/info/alternates'))).toBe(true);
+  });
+
+  it('installs the seed refs -- the half that actually saves the download', () => {
+    expect(hookCodeLines.some((line) => line.includes('for-each-ref'))).toBe(true);
+    expect(hookCodeLines.some((line) => line.includes('update-ref'))).toBe(true);
+  });
+
+  it('never exits non-zero -- a failing hook fails the job before it starts', () => {
+    // Every failure path must degrade to a cold clone, never to a red job.
+    const explicitExits = [...hookSource.matchAll(/^\s*exit\s+(\d+)/gm)].map((match) => match[1]);
+    expect(explicitExits.length).toBeGreaterThan(0);
+    expect(explicitExits.every((code) => code === '0')).toBe(true);
+    // `set -e` would turn any unchecked command into exactly that failure.
+    expect(hookCodeLines.some((line) => /^set -[a-z]*e/.test(line.trim()))).toBe(false);
+  });
+});
+
+describe('ci-image.yml: the daily build passes every named context Dockerfile.ci reads', () => {
+  // A missing --build-context fails the build outright, but only at the line
+  // that reads it -- after the expensive layers. Cheaper to catch here.
+  it('passes each COPY --from=<context> a matching --build-context', () => {
+    const namedContexts = new Set(
+      [...dockerfileSource.matchAll(/^COPY --from=([a-z][a-z0-9-]*)/gm)].map((match) => match[1]),
+    );
+    // Stage names are legitimate COPY --from= targets too; only the named
+    // build contexts need a flag.
+    const stageNames = new Set([...dockerfileSource.matchAll(/^FROM\s+\S+\s+AS\s+(\S+)/gm)].map((match) => match[1]));
+
+    for (const contextName of namedContexts) {
+      if (stageNames.has(contextName)) continue;
+      expect(workflowSource, `--build-context ${contextName}= missing from ci-image.yml`).toMatch(
+        new RegExp(`--build-context "${contextName}=`),
+      );
+    }
   });
 });
 

--- a/scripts/ci-image/generate-weekly-packs.ts
+++ b/scripts/ci-image/generate-weekly-packs.ts
@@ -1,0 +1,196 @@
+/// <reference types="node" />
+
+/**
+ * git/filesystem driver for the prebaked CI image's history layering
+ * (issue #5008). The pure math (week boundaries, tags, the pack-objects revlist
+ * format) lives in ./weekly-packs.ts and is unit-tested there without any git
+ * repo; this file is the thin, mostly-untested IO layer that shells out to git
+ * and the filesystem on top of it.
+ *
+ * Three subcommands, composed by .github/workflows/ci-image.yml:
+ *
+ *   plan --baseline <YYYY-MM-DD> [--asof <YYYY-MM-DD>] [--existing-tags tag1,tag2,...]
+ *     Prints JSON describing every completed week, the SINGLE next history
+ *     layer that still needs building (baseline first if even that is
+ *     missing, otherwise the earliest missing week) given the tags already
+ *     published, and which tag the daily build should use as its history
+ *     base. No git or network calls — pure date math, so the workflow can
+ *     call this before checkout even finishes. The workflow loops this
+ *     command (build what it returns, re-query the registry, call again)
+ *     until `nextLayer` comes back `null`.
+ *
+ *   resolve-tip --before <YYYY-MM-DD> [--ref main] [--repo-root .]
+ *     Prints the SHA of the last commit on `--ref` at or before 23:59:59 UTC
+ *     on the given date. Requires full history (`fetch-depth: 0`).
+ *
+ *   pack --tip <sha> [--exclude <sha>] --out-dir <dir> --name <basename> [--repo-root .]
+ *     Runs `git pack-objects --revs` with the exact stdin
+ *     packObjectsRevListInput() builds, then renames git's SHA-suffixed
+ *     output (`<basename>-<sha1>.pack`/`.idx`) to `<basename>.pack`/`.idx` so
+ *     the Dockerfile can COPY a name it knows ahead of time.
+ *
+ * NEVER re-run `pack` for a week that has already been frozen and published —
+ * see Dockerfile.ci's header comment for why a regenerated historical pack
+ * would invalidate every layer built on top of it. This script does not
+ * itself enforce that (it has no notion of "already published"); the
+ * workflow enforces it by only ever calling `pack` for the week `plan`
+ * reports as needing freezing, plus the always-regenerated current week.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, renameSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import {
+  baselineTag,
+  latestHistoryTag,
+  nextHistoryLayer,
+  packObjectsRevListInput,
+  parseDateOnlyUTC,
+  planCompletedWeeks,
+  toDateOnlyUTC,
+} from './weekly-packs';
+
+function fail(message: string): never {
+  console.error(`generate-weekly-packs: ${message}`);
+  process.exit(1);
+}
+
+function requireFlag(flags: Map<string, string>, name: string): string {
+  const value = flags.get(name);
+  if (value === undefined) fail(`missing required --${name}`);
+  return value;
+}
+
+function parseFlags(argv: string[]): Map<string, string> {
+  const flags = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith('--')) fail(`unexpected positional argument ${JSON.stringify(arg)}`);
+    const name = arg.slice(2);
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('--')) fail(`--${name} requires a value`);
+    flags.set(name, value);
+    index += 1;
+  }
+  return flags;
+}
+
+function runPlan(flags: Map<string, string>): void {
+  const baselineDate = parseDateOnlyUTC(requireFlag(flags, 'baseline'));
+  const asOf = flags.has('asof') ? parseDateOnlyUTC(requireFlag(flags, 'asof')) : new Date();
+  // Baseline AND week tags share one namespace here -- see nextHistoryLayer's
+  // doc comment for why the baseline's own existence has to be checked
+  // before any week can be considered.
+  const existingTags = new Set((flags.get('existing-tags') ?? '').split(',').filter((tag) => tag.length > 0));
+
+  const completedWeeks = planCompletedWeeks(baselineDate, asOf);
+  // `nextHistoryLayer` returns only the SINGLE next thing to build. The
+  // workflow loops: build it, re-query the registry, call `plan` again — so
+  // this prints one candidate per call, never a multi-step queue.
+  const nextLayer = nextHistoryLayer(baselineDate, asOf, existingTags);
+  const dailyHistoryBaseTag = latestHistoryTag(baselineDate, asOf, existingTags);
+
+  console.log(
+    JSON.stringify(
+      {
+        baselineDate: toDateOnlyUTC(baselineDate),
+        baselineTag: baselineTag(baselineDate),
+        completedWeeks: completedWeeks.map((week) => ({
+          weekEndDate: toDateOnlyUTC(week.weekEndDate),
+          tag: week.tag,
+          historyBaseTag: week.historyBaseTag,
+          exists: existingTags.has(week.tag),
+        })),
+        nextLayer,
+        // Only trustworthy once nextLayer is null (i.e. baseline and every
+        // completed week already exist) -- the daily build step checks that.
+        dailyHistoryBaseTag,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+function runResolveTip(flags: Map<string, string>): void {
+  const before = parseDateOnlyUTC(requireFlag(flags, 'before'));
+  const ref = flags.get('ref') ?? 'main';
+  const repoRoot = resolve(flags.get('repo-root') ?? '.');
+
+  const cutoff = `${toDateOnlyUTC(before)}T23:59:59Z`;
+  const sha = execFileSync('git', ['log', '--before', cutoff, '-1', '--format=%H', ref], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  }).trim();
+
+  if (sha.length === 0) fail(`no commit on ${JSON.stringify(ref)} at or before ${cutoff}`);
+  console.log(sha);
+}
+
+/** Directory entries matching `${name}-<anything>${extension}`, e.g. git's SHA-suffixed pack output. */
+function findSuffixedOutput(directory: string, name: string, extension: string): string {
+  const prefix = `${name}-`;
+  const matches = readdirSync(directory).filter((entry) => entry.startsWith(prefix) && entry.endsWith(extension));
+  if (matches.length !== 1) {
+    fail(
+      `expected exactly one ${JSON.stringify(`${prefix}*${extension}`)} in ${directory}, found ${matches.length}: ${matches.join(', ')}`,
+    );
+  }
+  return matches[0];
+}
+
+function runPack(flags: Map<string, string>): void {
+  const tip = requireFlag(flags, 'tip');
+  const excludeTip = flags.get('exclude') ?? null;
+  const outDir = resolve(requireFlag(flags, 'out-dir'));
+  const name = requireFlag(flags, 'name');
+  const repoRoot = resolve(flags.get('repo-root') ?? '.');
+
+  if (!existsSync(outDir)) fail(`--out-dir ${outDir} does not exist`);
+  // Fail loudly on a stale name collision rather than silently picking up a
+  // leftover file from a previous run when we look for the SHA-suffixed
+  // output below.
+  const stalePrefix = `${name}-`;
+  const staleEntries = readdirSync(outDir).filter(
+    (entry) => entry.startsWith(stalePrefix) || entry === `${name}.pack` || entry === `${name}.idx`,
+  );
+  if (staleEntries.length > 0) {
+    fail(`${outDir} already has output for ${JSON.stringify(name)}: ${staleEntries.join(', ')}`);
+  }
+
+  const stdinText = packObjectsRevListInput(tip, excludeTip);
+  execFileSync('git', ['pack-objects', '--revs', join(outDir, name)], {
+    cwd: repoRoot,
+    input: stdinText,
+    stdio: ['pipe', 'inherit', 'inherit'],
+  });
+
+  const packFile = findSuffixedOutput(outDir, name, '.pack');
+  const idxFile = findSuffixedOutput(outDir, name, '.idx');
+  renameSync(join(outDir, packFile), join(outDir, `${name}.pack`));
+  renameSync(join(outDir, idxFile), join(outDir, `${name}.idx`));
+
+  console.log(`Wrote ${join(outDir, `${name}.pack`)} and ${join(outDir, `${name}.idx`)}`);
+}
+
+function main(): void {
+  const [command, ...rest] = process.argv.slice(2);
+  const flags = parseFlags(rest);
+
+  switch (command) {
+    case 'plan':
+      runPlan(flags);
+      return;
+    case 'resolve-tip':
+      runResolveTip(flags);
+      return;
+    case 'pack':
+      runPack(flags);
+      return;
+    default:
+      fail(`unknown command ${JSON.stringify(command)}; expected plan | resolve-tip | pack`);
+  }
+}
+
+main();

--- a/scripts/ci-image/weekly-packs.ts
+++ b/scripts/ci-image/weekly-packs.ts
@@ -1,0 +1,167 @@
+/// <reference types="node" />
+
+/**
+ * Pure date/tag/revlist math for the prebaked CI image's git-history layering
+ * (issue #5008, part of epic #5005). No filesystem or git I/O here — that
+ * lives in generate-weekly-packs.ts, which imports this module. Kept separate
+ * so the arithmetic that decides "which week is this, and what does
+ * `git pack-objects` need on stdin" can be unit-tested without a git repo.
+ *
+ * Why this math exists at all: `.git` is one big packfile that grows without
+ * bound, so a naive daily CI-image rebuild re-pushes the whole thing (~400 MB
+ * measured on this repo) every day. Splitting history into 7-day slices turns
+ * that into a handful of small, PERMANENTLY FROZEN layers plus one small
+ * layer that legitimately changes daily — see Dockerfile.ci's header comment
+ * for the full chaining rationale (historical packs are never regenerated,
+ * only ever chained via `FROM <previous week's published tag>`).
+ */
+
+/** One week, in milliseconds. Boundaries are always exactly this far apart. */
+export const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/** `YYYY-MM-DD` in UTC, the format every tag in this scheme is built from. */
+export function toDateOnlyUTC(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Parse a strict `YYYY-MM-DD` as UTC midnight. Deliberately rejects anything
+ * looser (a full ISO timestamp, a locale-formatted date) — this value flows
+ * straight into an image tag and into `git log --before`, so an ambiguous
+ * parse would silently shift which commits land in which week.
+ */
+export function parseDateOnlyUTC(dateOnly: string): Date {
+  if (!DATE_ONLY_PATTERN.test(dateOnly)) {
+    throw new Error(`expected an ISO date (YYYY-MM-DD), got ${JSON.stringify(dateOnly)}`);
+  }
+  const date = new Date(`${dateOnly}T00:00:00.000Z`);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`invalid calendar date ${JSON.stringify(dateOnly)}`);
+  }
+  // Reject e.g. 2026-02-30, which Date() silently rolls forward into March.
+  if (toDateOnlyUTC(date) !== dateOnly) {
+    throw new Error(`invalid calendar date ${JSON.stringify(dateOnly)}`);
+  }
+  return date;
+}
+
+/**
+ * Every week-end boundary strictly after `baselineDate` up to and including
+ * `asOf`, one every 7 days. Deliberately NOT calendar weeks (Mon-Sun) —
+ * boundaries are 7-day multiples of the baseline date, so a quarterly
+ * re-baseline resets the cadence to whatever day it lands on rather than
+ * snapping to a fixed weekday. Matches the measured layering in issue #5008:
+ * baseline 2026-07-28 -> 2026-08-04, 2026-08-11, 2026-08-18, 2026-08-25,
+ * 2026-09-01.
+ */
+export function computeWeekBoundaries(baselineDate: Date, asOf: Date): Date[] {
+  if (asOf.getTime() < baselineDate.getTime()) {
+    throw new Error('asOf must not be before baselineDate');
+  }
+  const boundaries: Date[] = [];
+  for (let boundary = baselineDate.getTime() + WEEK_MS; boundary <= asOf.getTime(); boundary += WEEK_MS) {
+    boundaries.push(new Date(boundary));
+  }
+  return boundaries;
+}
+
+/** Tag for the quarterly re-baseline image: `boardsesh-ci-git:baseline-<date>`. */
+export function baselineTag(baselineDate: Date): string {
+  return `baseline-${toDateOnlyUTC(baselineDate)}`;
+}
+
+/** Tag for one frozen week: `boardsesh-ci-git:week-<date>`. Immutable once pushed. */
+export function weekTag(weekEndDate: Date): string {
+  return `week-${toDateOnlyUTC(weekEndDate)}`;
+}
+
+/** Fixed name for the still-accumulating, NOT-yet-frozen current week's pack. */
+export const CURRENT_WEEK_PACK_NAME = 'current-week';
+
+export interface WeekPlanEntry {
+  readonly weekEndDate: Date;
+  readonly tag: string;
+  /** The image tag this week's freeze must build `FROM` — the previous week, or baseline for the first week. */
+  readonly historyBaseTag: string;
+}
+
+/**
+ * The full list of completed (freezable) weeks between `baselineDate` and
+ * `asOf`, each carrying the tag of the image its freeze must chain from. Pure
+ * function of the two dates — no registry state, no git state. The caller
+ * (generate-weekly-packs.ts) intersects this with "which tags already exist
+ * in the registry" to decide what actually needs building today.
+ */
+export function planCompletedWeeks(baselineDate: Date, asOf: Date): WeekPlanEntry[] {
+  const boundaries = computeWeekBoundaries(baselineDate, asOf);
+  return boundaries.map((weekEndDate, index) => ({
+    weekEndDate,
+    tag: weekTag(weekEndDate),
+    historyBaseTag: index === 0 ? baselineTag(baselineDate) : weekTag(boundaries[index - 1]),
+  }));
+}
+
+/** The literal `GIT_HISTORY_BASE` Dockerfile.ci's `toolchain` stage's own default resolves to. */
+export const TOOLCHAIN_STAGE = 'toolchain';
+
+export interface HistoryLayerToBuild {
+  readonly tag: string;
+  /** `TOOLCHAIN_STAGE` for a fresh baseline (no external base image), else a previously published tag. */
+  readonly historyBaseTag: string;
+}
+
+/**
+ * The next single git-history layer that needs building, given the set of
+ * tags that already exist in the registry (baseline AND week tags, same
+ * namespace). `null` once everything through `asOf` is frozen.
+ *
+ * The baseline check comes first and is not folded into `planCompletedWeeks`
+ * on purpose: on a brand-new repo for this scheme (or right after a
+ * re-baseline), NEITHER the baseline NOR any week exists yet, and every week
+ * ultimately chains back to the baseline tag — building a week before the
+ * baseline exists would try to `FROM` an image that is not there. Callers
+ * loop this function (build the returned layer, re-query the registry, call
+ * again) until it returns `null`, which correctly bootstraps baseline then
+ * each missing week in order, one build per call.
+ */
+export function nextHistoryLayer(
+  baselineDate: Date,
+  asOf: Date,
+  existingTags: ReadonlySet<string>,
+): HistoryLayerToBuild | null {
+  const baseline = baselineTag(baselineDate);
+  if (!existingTags.has(baseline)) {
+    return { tag: baseline, historyBaseTag: TOOLCHAIN_STAGE };
+  }
+  const nextWeek = planCompletedWeeks(baselineDate, asOf).find((week) => !existingTags.has(week.tag));
+  return nextWeek ? { tag: nextWeek.tag, historyBaseTag: nextWeek.historyBaseTag } : null;
+}
+
+/**
+ * The image tag the DAILY build's `FROM` must resolve to: the most recently
+ * frozen week, or the baseline itself if no week has been frozen yet (e.g.
+ * immediately after a re-baseline, before the first week has elapsed). Only
+ * meaningful once `nextHistoryLayer` returns `null` for the same arguments —
+ * callers are expected to finish freezing before computing this.
+ */
+export function latestHistoryTag(baselineDate: Date, asOf: Date, existingTags: ReadonlySet<string>): string {
+  const completed = planCompletedWeeks(baselineDate, asOf).filter((week) => existingTags.has(week.tag));
+  return completed.length > 0 ? completed[completed.length - 1].tag : baselineTag(baselineDate);
+}
+
+/**
+ * The exact stdin `git pack-objects --revs` expects: the pack tip, optionally
+ * excluding everything reachable from `excludeTip`. This is the invisible
+ * pairing the whole freeze scheme depends on — get the `^` prefix or a
+ * trailing newline wrong and `git pack-objects` either silently packs the
+ * WHOLE history again (a 340+ MB "weekly" layer) or errors on bad revision
+ * syntax. See scripts/ci-image/generate-weekly-packs.ts for the caller.
+ */
+export function packObjectsRevListInput(tip: string, excludeTip: string | null): string {
+  if (tip.length === 0) throw new Error('tip must not be empty');
+  if (excludeTip === null) return `${tip}\n`;
+  if (excludeTip.length === 0) throw new Error('excludeTip must not be empty when provided');
+  return `${tip}\n^${excludeTip}\n`;
+}

--- a/scripts/create-service-docker-context.mjs
+++ b/scripts/create-service-docker-context.mjs
@@ -53,6 +53,16 @@ const services = {
     // command, not baked into the image.
     rootPackageNames: ['@boardsesh/kilter-sync', '@boardsesh/aurora-sync', '@boardsesh/moonboard-sync'],
   },
+  ci: {
+    dockerfile: 'Dockerfile.ci',
+    // The prebaked CI seed (#5008) bakes the pnpm store and a separately
+    // generated git object store, never workspace source — an empty
+    // rootPackageNames short-circuits the dependency walk below to [], so
+    // this context is `manifests/` only, same set every other service gets
+    // for its install layer (every workspace package.json plus the lockfile,
+    // workspace yaml and patches), reused rather than hand-picked here.
+    rootPackageNames: [],
+  },
 };
 
 const dependencyFields = ['dependencies', 'optionalDependencies', 'peerDependencies'];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -600,6 +600,10 @@ export default defineConfig({
         command: 'node scripts/create-service-docker-context.mjs sync',
         cache: false,
       },
+      'docker-context:ci': {
+        command: 'node scripts/create-service-docker-context.mjs ci',
+        cache: false,
+      },
       'test:service-deploy-inputs': {
         command:
           'node --test scripts/check-service-deploy-inputs.test.mjs scripts/production-backend-smoke.test.mjs scripts/production-deploy-changes.test.mjs scripts/production-deploy-watchdog.test.mjs scripts/production-web-deploy-targets.test.mjs scripts/railway-deployment-status.test.mjs',


### PR DESCRIPTION
Builds the CI image the self-hosted homelab fleet **runs** — one GitHub Actions
job per container, `--rm` between jobs. Closes #5008 (epic #5005).

Originally this was data-only: git packs plus a pnpm store that a host unpacked,
with the toolchain living on the VM. It now carries the actions/runner agent and
the CI toolchain too, so the container *is* the runner.

That makes the per-job reset free. Image layers are read-only and every write a
job makes lands in the container's own writable layer, so "a job cannot corrupt
the seed for the next job" holds by construction — no overlay upperdir on the
host, no cleanup script enumerating what to discard. Docker is **not** a security
boundary here (the container gets the host docker socket, which is root on the
host); the VM and its VLAN remain that. This containerises for reliability.

### Layer order

Strictly most-stable-first, so a daily rebuild pushes and pulls as little as
possible:

| # | Layer | Changes |
| - | ----- | ------- |
| 1 | seed base | weeks–months |
| 2 | git baseline pack (342.5 MB) | quarterly |
| 3 | frozen weekly packs (3–11 MB each) | never, once written |
| 4 | runner agent + toolchain | rarely (pinned) |
| 5 | pnpm store (~2 GB) | lockfile hash, ~49% of days |
| 6 | current-week pack (3–30 MB) | daily |

Position 4 is the load-bearing one. The agent sits at the top of the *daily*
stage, not in `seed-base`: in the frozen chain it would be shared by every
`week-<date>` tag, so GitHub's next forced agent upgrade would demand an
out-of-cycle re-baseline of 342 MB of git history that did not change. It also
keeps frozen layers pure git objects, so a toolchain security update can't
either invalidate immutable history or silently never land.

### A bug this found

Building and *running* the image locally caught something reading it never would
have: **the seed carried objects but no refs.** `git fetch` negotiation is driven
by the fetching repo's refs, so a job would have advertised "I have nothing",
taken a full pack, and the entire git half of the seed would have been silently
inert — while the image still looked completely correct. Only a timing
measurement would ever have surfaced it.

Each pack layer now records its tip as `refs/ci-seed/<name>`, and the
job-started hook installs those refs alongside the alternate.

### Verified locally

The workflow's authority check means it cannot be dispatched from a branch, so
this was validated by building and running the real image:

```
entrypoint=[/usr/local/bin/entrypoint.sh] user=runner
runner agent:  2.337.0        node: v22.23.2      docker CLI: 29.7.2
toolcache:     22.23.2        pnpm store: 2.1G    seed objects: 398M
seed refs:     refs/ci-seed/baseline-local refs/ci-seed/current-week
[job-started] seeded from /ci-seed/git: 2 ref(s) resolved through the alternate
commits reachable with zero fetching: 11065
```

The package is public, so the fleet pulls it without a credential — keeping "no
secrets on a machine that runs PR code" (#5005 §5) true of the image pull too.

Consumed by the fleet via `marcodejongh/blackheathdc-ansible#395`.

## Release Notes

none

## Test plan

1. CI green.

## Risk

Risk: 2/5 — new workflow and image, nothing in the existing CI path changes until
`CI_RUNNER_LINUX` is flipped. The workflow is schedule/dispatch-only and gated on
protected `main`.