### PR TITLE
fix(repo): block on the climb-view rate limit, the only action the Free plan allows

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -203,22 +203,23 @@ Limiting plan is required`. The Free plan's rate-limit expressions cannot
 reference request headers at all, so Next.js router prefetches off a list
 page count toward the limit the same as real page loads.
 
-**It ships in `managed_challenge` mode.** The zone is on Free or Pro, not
-Enterprise, so the softest mitigation, `log`, is rejected on apply —
-Cloudflare restricts observe-only rate limiting to Enterprise. The next
-gentlest action is `managed_challenge`: a real browser passes it
-transparently, a headless farm mostly does not. `block` remains the blunt
-instrument for later if challenge proves insufficient.
+**It ships in `block` mode, because that is the only rate-limit action the
+Free plan allows.** Every gentler option was rejected at apply time: `log` is
+Enterprise-only, and `managed_challenge` came back as `not entitled to use the
+managed_challenge action in ratelimiting` (run 33476545859). A client that
+trips the rule loses `/view/` paths for the 10 s mitigation window and is then
+counted afresh — so the threshold is deliberately generous (below).
 
 **The zone is confirmed Free plan, and the period is fixed at 10s by the
 API.** The first production apply attempted `period: 60` and Cloudflare
 rejected it: `not entitled to use the period 60, can only use a period among
 [10]`. 10s is the only counting window Free accepts — this is not a choice,
-it's a hard constraint from the API. The threshold is tuned around it: 30
-requests per 10s (~180/min sustained) keeps headroom for the original
-~60/min-per-IP-per-colo intent, given both the burstier 10s window and the
-fact that a list-page browser's prefetch burst now counts too (the plan
-won't let the expression exclude it — see above). Read a few days of
+it's a hard constraint from the API. The threshold is tuned around it and
+around the fact that the action is a block: 60 requests per 10s per IP per
+colo (~360/min sustained) trips on a single-address bulk crawler sustaining
+6 req/s, while a gym behind one NAT would need 60 climb-page loads inside 10s
+— prefetch bursts included, since the plan won't let the expression exclude
+them (see above) — to be blocked, and then only for 10s. Read a few days of
 Cloudflare analytics at this setting, size the number against real traffic,
 then re-tune — `requests_per_period` stays free to change; `period` does
 not, and neither does the header restriction on the expression.
@@ -233,7 +234,7 @@ Two things to know:
   `requests_per_period` alone suggests.
 
 Guessing low and blocking on day one throttles a gym full of climbers behind one
-NAT, which is why challenge rather than block is the default. Rollback is the
+NAT, which is why the threshold is generous rather than tight. Rollback is the
 usual one: set `enabled: false` on the rule and re-run
 `vp run cf:apply -- --apply`.
 

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -407,30 +407,27 @@ export const desiredCloudflareState: CloudflareDesiredState = {
     {
       description: CLIMB_VIEW_RATE_LIMIT_RULE_DESCRIPTION,
       expression: CLIMB_VIEW_RATE_LIMIT_EXPRESSION,
-      // `log` is Enterprise-only and the zone is on Free/Pro, so the apply
-      // rejects it outright — `managed_challenge` is the gentlest action this
-      // plan accepts. A real browser passes it transparently; a headless
-      // crawler mostly does not. The threshold below is still a starting
-      // guess, not a measurement: a real reader opens a handful of climbs a
-      // minute, a crawler walks hundreds, but the gap between them is exactly
-      // what we have never measured. Read a few days of Cloudflare analytics
-      // at this setting and size the number against what real traffic does.
+      // The Free plan allows exactly one rate-limit action: `block`. Every
+      // gentler option was rejected at apply time — `log` (Enterprise-only)
+      // and `managed_challenge` (`not entitled to use the managed_challenge
+      // action in ratelimiting`). So the threshold below is deliberately
+      // generous: it is sized to catch a single-IP bulk crawler, not to
+      // shave a busy gym's traffic, because a block — even a 10 s one —
+      // is exactly the failure mode that throttles climbers behind one NAT.
       // Roll back by flipping `enabled: false` and re-applying.
-      action: 'managed_challenge',
+      action: 'block',
       ratelimit: {
         characteristics: ['ip.src', 'cf.colo.id'],
         // The zone is confirmed FREE plan: the production apply of period: 60
         // failed with `not entitled to use the period 60, can only use a
         // period among [10]` — 10s is the only period Free accepts.
         period: 10,
-        // Intent is still ~60 requests/minute per IP per colo, but the
-        // expression cannot exclude Next.js prefetches on this plan (see the
-        // doc comment on CLIMB_VIEW_RATE_LIMIT_EXPRESSION), so a list page in
-        // the viewport can fire a burst of /view/ prefetches from one
-        // browser that now count too, on top of the burstier 10s window
-        // itself. 30 per 10s gives that headroom while still averaging to a
-        // ~180/min sustained ceiling.
-        requests_per_period: 30,
+        // 60 per 10 s per IP per colo (≈360/min sustained). A bulk crawler
+        // sustaining 6 req/s from one address trips it; a gym behind one NAT
+        // would need 60 climb-page loads (prefetches included — the Free
+        // plan cannot exclude them, see the expression note) inside 10 s, and
+        // is then blocked for 10 s, not challenged.
+        requests_per_period: 60,
         // 10s is the Free-plan ceiling (Pro allows up to 60s). Raise to 60
         // once the zone's plan is confirmed Pro or above.
         mitigation_timeout: 10,

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -802,13 +802,13 @@ describe('climb-view rate-limit rule', () => {
     (rule) => rule.description === CLIMB_VIEW_RATE_LIMIT_RULE_DESCRIPTION,
   );
 
-  it('is declared, and challenges rather than blocks', () => {
+  it('is declared, and blocks — the only action the Free plan allows', () => {
     // `log` is Enterprise-only and this zone is Free/Pro, so `managed_challenge`
     // is the gentlest action available: a real browser passes it transparently,
     // a headless crawler mostly does not. Shipping straight to `block` on a
     // guessed threshold would throttle a gym full of climbers behind one NAT.
     expect(rateLimitRule).toBeDefined();
-    expect(rateLimitRule?.action).toBe('managed_challenge');
+    expect(rateLimitRule?.action).toBe('block');
     expect(rateLimitRule?.enabled).toBe(true);
   });
 
@@ -827,7 +827,7 @@ describe('climb-view rate-limit rule', () => {
     // intent given the expression can't exclude prefetches on this plan (see
     // the expression test below), so a list-page browser's prefetch burst
     // counts too, on top of the burstier 10s window itself.
-    expect(rateLimitRule?.ratelimit.requests_per_period).toBe(30);
+    expect(rateLimitRule?.ratelimit.requests_per_period).toBe(60);
   });
 
   it('keys the counter on the client IP and the required colo characteristic', () => {


### PR DESCRIPTION
## Summary

- The fourth production apply of the climb-view rate limit (run 33476545859, after #5026) was rejected with `not entitled to use the managed_challenge action in ratelimiting`. On Cloudflare's Free plan `block` is the only rate-limit action.
- `action: 'block'`, `requests_per_period: 60` (per IP per colo per 10 s ≈ 360/min sustained), `mitigation_timeout: 10` — sized to catch a single-address bulk crawler, not to shave a busy gym; a client that trips it loses `/view/` for 10 s.
- Tests pin the action and threshold; `docs/cloudflare.md` says why block.

Decision: maintainer, 2026-09-01 (block at 60/10 s rather than dropping the rule or upgrading the zone).

Refs #4802

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.
2. After merge, `deploy-cloudflare` applies the `http_ratelimit` phase without a 400.

## Risk

Risk: 3/5 — live edge rule that can block real users during an extreme burst; rollback is `enabled: false` + apply.