### PR TITLE
fix(ci): take the concurrency block back out of the publisher contract

### DIFF
--- a/.github/workflows/postgres-image-publisher-contract.yml
+++ b/.github/workflows/postgres-image-publisher-contract.yml
@@ -20,10 +20,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: postgres-image-contract-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   verify-trust-boundary:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #5034. `verify-trust-boundary` has been red on `main` since #5004, and every PR inherits it.

## What happened

#5004 (`913c8fff1`, reducing PR runner contention) added a `concurrency:` block to `.github/workflows/postgres-image-publisher-contract.yml`. That workflow sits inside a deliberately exact trust boundary, and the block tripped both guards in `scripts/lib/postgres-image-publisher-contract.ts`:

- `keysEqual(contract, ['name', 'on', 'permissions', 'jobs'])` — `concurrency` is a fifth top-level key
- `canonicalSha256(withoutKey(contract, 'jobs')) !== CONTRACT_WORKFLOW_METADATA_SHA256`

**The tripwire worked exactly as designed.** It exists so that editing the reviewed workflow forces a re-review. The edit simply never completed that step.

## Why remove rather than re-pin

The tempting fix is to extend the allowlist and bump the hash. I think that is the wrong call:

- **`cancel-in-progress: true` on a security gate is the wrong default.** A rapid second push can cancel an in-flight trust-boundary verification.
- **The saving is one short job.** That is a poor trade for loosening an allowlist whose entire value is being exact.
- Bumping the hash to go green converts a working tripwire into a rubber stamp — the failure mode the pinning exists to prevent.

If `concurrency` should live inside this boundary, that deserves its own deliberate change with the `cancel-in-progress` semantics considered, not a hash bump in service of a red CI.

## Verification

The file is now **byte-identical to its state immediately before #5004** (`diff` against `913c8fff1~1` is empty), and the contract test passes **without `CONTRACT_WORKFLOW_METADATA_SHA256` being touched`**. That is the property that matters: this restores the reviewed shape rather than blessing a new one.

```
vp test run --project scripts scripts/postgres-image-publisher-contract.test.ts
Tests  82 passed (82)
```

#5004's concurrency additions to the other seven workflows are untouched — only this one file changes.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green, including `verify-trust-boundary`.

## Risk

Risk: 1/5 — reverts four lines to a previously reviewed state; restores a gate that is currently failing.