### PR TITLE
feat(mobile): report per-update timings, logs and errors to Observe

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -106,6 +106,11 @@ diagnostic) applies on native. The whole surface lives in three files:
   `packages/mobile/src/providers/feature-flags-provider.tsx` — `{ key, label,
   description, variants? }`. Add a flag once here and it shows up in the live
   PostHog read AND the tester-only Feature Flags screen (More → Feature Flags).
+  Two of them steer telemetry rather than UI: `observe-dispatch-enabled` is the
+  kill switch for expo-observe, and `observe-sample-rate` is the live
+  multivariate flag carrying its sample rate. Both are read in
+  `packages/mobile/src/hooks/use-observe-runtime-config.ts`; see
+  `docs/mobile-ota-updates.md`.
 - **Live read**: `readPosthogFeatureFlags` in `packages/mobile/src/lib/analytics.ts`.
 - **Dev override**: `packages/mobile/src/lib/feature-flag-overrides.ts` — an
   on-device `Record<string, boolean | string>`, persisted to AsyncStorage,
@@ -133,13 +138,23 @@ with `useFeatureFlag(key)` (`=== true`, or `!== true` for a kill switch).
 
 A flag with a `variants: readonly string[]` list on its definition is
 **multivariate** — PostHog resolves it to one of those strings instead of a
-boolean. Read it with `useFeatureFlagVariant<V extends string>(key, variants)`,
-which returns `V | undefined` and — this is the part a plain `useFeatureFlag`
-cast would get wrong — narrows away anything that is NOT a declared member:
-a boolean read (a build that predates the variant, or a flag PostHog says
-`false` for because it didn't match anything), an unknown string, or an
-unresolved read are all `undefined`. `undefined` always means "fall back to the
-shipped default", the same contract every boolean flag follows.
+boolean. Read it with `useFeatureFlag(key)`, which returns
+`boolean | string | undefined`, and narrow it yourself; there is no
+`useFeatureFlagVariant` helper (an earlier version of this doc described one
+that never came back after 2.4). The narrowing that matters happens before the
+hook, in the coercion below: anything that is NOT a declared member — a boolean
+read (a build that predates the variant, or a flag PostHog says `false` for
+because it matched nothing), an unknown string, or an unresolved read — never
+reaches the bag at all. A missing key always means "fall back to the shipped
+default", the same contract every boolean flag follows.
+
+> **The multivariate path is only as alive as its last consumer.** It was
+> deleted wholesale for 2.4 when the last two variant flags were retired — the
+> `variants` property, the coercion branch, and the read helper — while this doc
+> and several comments went on describing it. `observe-sample-rate` restored the
+> first two in #5038. If you retire the last multivariate flag again, update this
+> section in the same change rather than leaving it describing a path that no
+> longer exists.
 
 The coercion happens once, in `readPosthogFeatureFlags` /
 `coerceFeatureFlagValue` (`packages/mobile/src/lib/analytics.ts`): pass the
@@ -165,11 +180,20 @@ installed binary that cannot draw the Aura mode is forced to `classic` by
 (`packages/mobile/src/lib/board-render-settings.ts`), and that is now the only
 thing standing between an older build and a drawing it cannot produce.
 
-They were also the last two **multivariate** flags. With them gone the catalog
-is boolean-only: `useFeatureFlagVariant`, the variant row rendering and the
-`variants` field on a definition were removed with them. A future multivariate
-flag needs that machinery rebuilt — see the history of
-`feature-flags-provider.tsx` and `feature-flag-rows.ts` for the shape it had.
+They were also the last two **multivariate** flags, and their removal took the
+whole path with them: `useFeatureFlagVariant`, the variant row rendering, the
+coercion branch and the `variants` field on a definition.
+
+`observe-sample-rate` (#5038) brought back the two pieces a live flag actually
+needs — `variants` on the definition, and the coercion branch that lets a
+declared member survive `readPosthogFeatureFlags`. **The tester screen was not
+rebuilt.** `buildFeatureFlagRows` and `FeatureFlagOverrideAction`
+(`packages/mobile/src/components/feature-flag-rows.ts`) are still boolean-only,
+so a multivariate flag renders there as On/Off and an on-device override can
+only write a boolean. For `observe-sample-rate` that is harmless — a boolean
+parses back to the shipped rate — but it does mean **the sample rate can only be
+changed from the PostHog dashboard, not from the device.** Rebuild the row
+rendering if a future flag needs on-device variant selection.
 
 Full event contract, the PostHog dashboard setup (both flags plus the
 Experiment), and the stratification rule for reading the results:

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -650,6 +650,34 @@ still logs `[analytics] OTA Update Status …` to Metro so you can confirm the t
 In PostHog (project 412845), count distinct installs with `isEmbeddedLaunch = false` per `updateId` to
 measure how many pulled a given OTA.
 
+### expo-observe (per-update timings, logs and errors)
+
+Alongside the PostHog events above, the app reports to xprem's own **Observe** through
+`expo-observe`. Different question: PostHog answers "did the update reach users", Observe answers
+"did it make the app worse", because every row is attributed server-side to the `updateId` that
+produced it — the per-update comparison neither PostHog nor Sentry can express.
+
+- **Wiring**: `packages/mobile/src/lib/observe-bootstrap.ts` calls `Observe.configure()` at module
+  scope, imported third in `app/_layout.tsx`. It must run before any screen mounts — the router
+  integration throws if its initialized value changes during a screen's lifecycle — so it can never
+  become a hook or an effect. It is also the ONLY module that imports `expo-observe`; everything
+  else goes through the dependency-free slot in `observe-runtime.ts`, which keeps Expo's runtime out
+  of the node-env test graph that `error-reporting.ts` sits in.
+- **What it sends**: per-screen `cold_ttr` / `warm_ttr` / `tti` (expo-router integration), log
+  events, and every error that reaches `reportError` — so Sentry and Observe always agree on what
+  counted as an error. `tti` needs `markInteractive` per screen and is not wired up yet.
+- **Endpoint**: derived from `EXPO_UPDATES_URL`'s origin plus the OTA app id
+  (`resolveObserveEndpoint` in `app.config.ts`), so telemetry and manifests can never point at
+  different servers. A build with no self-hosted URL, or an EAS-hosted one, reports nothing.
+- **Control without a build**: `observe-dispatch-enabled` (kill switch) and `observe-sample-rate`
+  (multivariate, ships at `1`) in PostHog. Unresolved flags read as the shipped defaults, so a
+  device that never reaches PostHog keeps reporting.
+- **Native.** `expo-observe` pulls in `expo-app-metrics` and `expo-eas-client`, so it moved the
+  fingerprint. Only binaries built after it shipped report at all — an older store build stays
+  silent however long it runs.
+
+Where the rows land, and what they cost to keep: `docs/railway.md`.
+
 ## Health monitoring & rollback
 
 A default production OTA reaches **every** matching install on the next launch, but V3 also supports

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -146,25 +146,34 @@ stops accepting writes, and since xprem calls `log.Fatalf` when ClickHouse is
 unreachable at boot, the next OTA restart would then fail to come up at all — a full
 disk here is an availability risk for `updates.boardsesh.com`.
 
-### The three tables that fill without any app release
+### Where each table's rows come from
 
-`observe_metrics` and `observe_logs` are fed by the app's telemetry sink, so they
-stay empty until the mobile app ships `expo-observe`. The other three fill straight
-away from ordinary manifest check-ins, because Postgres triggers enqueue into
-`device_health_outbox` and a worker drains it into ClickHouse:
+Two independent producers, which is why the tables filled at very different times.
 
-| Table | Time column | Retention | Why |
+| Table | Time column | Retention | Producer |
 | --- | --- | --- | --- |
-| `update_health_snapshots` | `bucket` | 90d | One-minute samples; nothing reads minute grain a quarter later |
-| `update_health_segment_snapshots` | `bucket` | 90d | Five-minute samples, but eight dimensions wide |
-| `device_health_events` | `occurred_at` | 180d | Lowest volume and the raw record the other two summarise |
+| `update_health_snapshots` | `bucket` | 90d | Server. One-minute samples; nothing reads minute grain a quarter later |
+| `update_health_segment_snapshots` | `bucket` | 90d | Server. Five-minute samples, but eight dimensions wide |
+| `device_health_events` | `occurred_at` | 180d | Server. Lowest volume and the raw record the other two summarise |
+| `observe_metrics` | `timestamp` | 90d | App. Per-screen `cold_ttr` / `warm_ttr` / `tti` |
+| `observe_logs` | `timestamp` | 30d | App. Log events and error reports |
 
-`observe_metrics` and `observe_logs` need `expo-observe` in the mobile app, which is a
-native module — so a new fingerprint and a store release. **The three above need
-nothing from the app.** Postgres triggers enqueue into `device_health_outbox` on every
-device update-state change, driven by the manifest check-ins every production binary
-already makes, and a worker drains that into ClickHouse. So the rollout and adoption
-views work today; only the startup and navigation timings wait on a release.
+**The three server-side tables need nothing from the app.** Postgres triggers enqueue
+into `device_health_outbox` on every device update-state change, driven by the manifest
+check-ins every production binary already makes, and a worker drains that into
+ClickHouse. They have been filling since Observe was switched on.
+
+**The two app-side tables are fed by `expo-observe`**, wired up in
+`packages/mobile/src/lib/observe-bootstrap.ts`. Because that pulls in native modules the
+fingerprint moved, so rows only arrive from binaries built after that shipped — an older
+store build reports nothing no matter how long it runs. Two PostHog flags control it
+without a new build: `observe-dispatch-enabled` (kill switch) and `observe-sample-rate`.
+See `docs/feature-flags.md`.
+
+> **The 90d/30d windows on the app-side tables were chosen while both were empty.**
+> `observe_metrics` takes a row per navigation per device, which is a different order of
+> magnitude from the server-side tables. Re-measure once real traffic has been flowing
+> for a week — the query is under "What fills the disk" above.
 
 ## Why services are not created
 

--- a/packages/mobile/app.config.ts
+++ b/packages/mobile/app.config.ts
@@ -88,6 +88,29 @@ const HEALTH_SHARE_USAGE_DESCRIPTION =
 // self-hosted OTA binary that can't verify update signatures.
 const CODE_SIGNING_CERT_PATH = './certs/certificate.pem';
 
+// Resolves the expo-observe ingest endpoint, read by the SDK from
+// `extra.eas.observe.endpointUrl`.
+//
+// Derived from EXPO_UPDATES_URL rather than hardcoded, so the telemetry and the
+// manifest can never point at different servers: one env var moves both. Gated
+// on the same two conditions as the self-hosted updates path below — an
+// EAS-hosted build has no server of ours to report to, and neither does a build
+// with no server URL. Those builds simply collect nothing.
+//
+// The path is `/observe/{APP_ID}`; xprem's ingest router mounts
+// `/observe/{APP_ID}/{PROJECT_ID}/v1/{logs,metrics}` and ignores PROJECT_ID
+// (internal/router/routes_ingest.go), which the SDK appends.
+//
+// Exported for unit tests, like resolveUpdatesConfig.
+export function resolveObserveEndpoint(otaAppId: string): string | undefined {
+  if (process.env.EAS_BUILD) return undefined;
+
+  const selfHostUrl = process.env.EXPO_UPDATES_URL;
+  if (!selfHostUrl) return undefined;
+
+  return `${new URL(selfHostUrl).origin}/observe/${otaAppId}`;
+}
+
 // Resolves the expo-updates block. Two distinct hosting paths:
 //   • Preview/dev builds (made with `eas build`, EAS_BUILD set) stay on EAS
 //     free-tier hosting at u.expo.dev — channel comes from eas.json. Unchanged.
@@ -268,6 +291,10 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
   const googleSignInPlugin: PluginEntry[] = googleIosUrlScheme
     ? [['@react-native-google-signin/google-signin', { iosUrlScheme: googleIosUrlScheme }]]
     : [];
+
+  // Telemetry ingest for expo-observe. Undefined on EAS-hosted and
+  // no-server builds, which is what keeps them from reporting anywhere.
+  const observeEndpointUrl = resolveObserveEndpoint(OTA_APP_ID);
 
   return {
     ...config,
@@ -703,7 +730,17 @@ export default ({ config, projectRoot }: ConfigContext): ExpoConfig & { newArchE
     extra: {
       ...config.extra,
       ...(webHeadOrigin ? { router: { headOrigin: webHeadOrigin } } : {}),
-      ...(EAS_PROJECT_ID ? { eas: { projectId: EAS_PROJECT_ID } } : {}),
+      // `eas` carries two unrelated things the SDKs read positionally: the EAS
+      // project id, and the expo-observe endpoint. Kept in one spread so an
+      // unset EAS_PROJECT_ID cannot take the observe endpoint down with it.
+      ...(EAS_PROJECT_ID || observeEndpointUrl
+        ? {
+            eas: {
+              ...(EAS_PROJECT_ID ? { projectId: EAS_PROJECT_ID } : {}),
+              ...(observeEndpointUrl ? { observe: { endpointUrl: observeEndpointUrl } } : {}),
+            },
+          }
+        : {}),
       ...(hasDevMetadata
         ? {
             devMetadata: {

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -9,6 +9,11 @@ import { wrapWithSentry } from '../src/lib/sentry';
 // distinct_id with, before the SDK's own module-eval side effect constructs
 // the client and fires its app-lifecycle autocapture. See analytics-bootstrap.ts.
 import '../src/lib/analytics-bootstrap';
+// Import third: calls Observe.configure() at module scope. It MUST have run
+// before the first screen mounts — expo-observe's router integration reads
+// isInitialized() when a screen mounts and throws if it changes afterwards — so
+// this cannot become a hook or an effect. See observe-bootstrap.ts.
+import '../src/lib/observe-bootstrap';
 import { useCallback, useEffect, useRef, useMemo, useState, type ReactNode } from 'react';
 import { LogBox, Pressable, StyleSheet, View } from 'react-native';
 // Navigation theme comes from expo-router's vendored React Navigation. Expo
@@ -27,6 +32,7 @@ import { SystemBars } from 'react-native-edge-to-edge';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { BottomSheetModalProvider } from '@expo/ui/community/bottom-sheet';
 import { ControlCenter } from '@xprem/control-center';
+import { ObserveRoot } from 'expo-observe';
 import Constants from 'expo-constants';
 import { QueryProvider } from '../src/providers/query-provider';
 import { ThemeProvider, useTheme } from '../src/providers/theme-provider';
@@ -46,6 +52,7 @@ import { ShareTargetProvider } from '../src/providers/share-target-provider';
 import { TabBarHeightProvider } from '../src/providers/tab-bar-height-provider';
 import { BottomChromeMetricsProvider } from '../src/hooks/use-bottom-chrome-metrics';
 import { FeatureFlagsProvider, type FeatureFlags } from '../src/providers/feature-flags-provider';
+import { useObserveRuntimeConfig } from '../src/hooks/use-observe-runtime-config';
 import { MobileBoardPresenceProvider } from '../src/providers/board-presence-provider';
 import { SheetPresentationProvider } from '../src/providers/sheet-presentation-provider';
 import { PartyProfileProvider } from '../src/providers/party-profile-provider';
@@ -487,6 +494,16 @@ function ThemedNavigation({ children }: { children: ReactNode }) {
   );
 }
 
+/**
+ * Applies the runtime Observe settings from the feature flags. Split out as a
+ * null-render child so the flag change re-runs one effect rather than
+ * re-rendering the whole root, matching OfflineEngineFlagSync above it.
+ */
+function ObserveRuntimeConfigSync(): null {
+  useObserveRuntimeConfig();
+  return null;
+}
+
 function RootLayout() {
   const [authReady, setAuthReady] = useState(false);
   const [fontsReady, setFontsReady] = useState(false);
@@ -560,6 +577,10 @@ function RootLayout() {
                       {/* First child on purpose: publishes the offline-engine flag to the
                           non-React store before any later sibling's query effects run. */}
                       <OfflineEngineFlagSync />
+                      {/* Applies the Observe kill switch and sample rate once PostHog
+                          resolves them. Until then the shipped defaults from
+                          observe-bootstrap stand. Null render. */}
+                      <ObserveRuntimeConfigSync />
                       <AuthProvider onReady={onAuthReady}>
                         <PartyProfileProvider>
                           {/* Needs auth + query, both in scope here. Null render. */}
@@ -838,4 +859,10 @@ function RootLayout() {
 // Wrap with Sentry so the root and its children report render errors and feed
 // the navigation/performance instrumentation. No-op when Sentry is disabled
 // (dev / no DSN), so it's safe in every build.
-export default wrapWithSentry(RootLayout);
+//
+// ObserveRoot sits inside it, mounting AppMetricsRoot plus the expo-router
+// integration context that the per-screen timings hang off. Wrapping the root is
+// all TTR needs; `tti` additionally wants markInteractive on the screens that
+// keep working after first paint, which is a deliberate follow-up rather than
+// part of turning this on.
+export default wrapWithSentry(ObserveRoot.wrap(RootLayout));

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -76,6 +76,7 @@
     "expo-maps": "57.0.2",
     "expo-modules-core": "57.0.14",
     "expo-notifications": "57.0.15",
+    "expo-observe": "57.0.17",
     "expo-router": "57.0.17",
     "expo-secure-store": "57.0.2",
     "expo-share-intent": "8.0.1",

--- a/packages/mobile/src/__tests__/app-config-observe.test.ts
+++ b/packages/mobile/src/__tests__/app-config-observe.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveObserveEndpoint, OTA_APP_ID } from '../../app.config';
+
+// The expo-observe ingest endpoint is derived rather than hardcoded, so the
+// telemetry and the manifest can never point at different servers. These cover
+// the gates that decide whether a build reports at all — a wrong answer here is
+// silent (telemetry simply never arrives, or arrives from a build that should
+// not be sending).
+
+const SELF_HOST_URL = 'https://ota.example.test/manifest';
+const ENV_KEYS = ['EAS_BUILD', 'EXPO_UPDATES_URL'] as const;
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+});
+
+describe('resolveObserveEndpoint', () => {
+  it('builds the ingest path from the updates origin and the OTA app id', () => {
+    process.env.EXPO_UPDATES_URL = SELF_HOST_URL;
+    // xprem mounts /observe/{APP_ID}/{PROJECT_ID}/v1/{logs,metrics} and ignores
+    // PROJECT_ID; the SDK appends the rest.
+    expect(resolveObserveEndpoint('app-id-123')).toBe('https://ota.example.test/observe/app-id-123');
+  });
+
+  it('takes only the origin, dropping the manifest path', () => {
+    process.env.EXPO_UPDATES_URL = 'https://ota.example.test/manifest';
+    expect(resolveObserveEndpoint('app-id-123')).not.toContain('/manifest');
+  });
+
+  it('keeps a non-default port, so a proxied or local server still works', () => {
+    process.env.EXPO_UPDATES_URL = 'http://localhost:3000/manifest';
+    expect(resolveObserveEndpoint('app-id-123')).toBe('http://localhost:3000/observe/app-id-123');
+  });
+
+  it('reports nothing when no self-hosted server is configured', () => {
+    // Such a build has no server of ours to talk to; collecting would be pointless.
+    expect(resolveObserveEndpoint('app-id-123')).toBeUndefined();
+  });
+
+  it('reports nothing from an EAS-hosted build', () => {
+    // Matches the updates gate: EAS_BUILD keeps a build on u.expo.dev, where
+    // there is no Observe ingest at all.
+    process.env.EAS_BUILD = '1';
+    process.env.EXPO_UPDATES_URL = SELF_HOST_URL;
+    expect(resolveObserveEndpoint('app-id-123')).toBeUndefined();
+  });
+
+  it('uses the real OTA app id, not the EAS project id', () => {
+    // The two are different values for Boardsesh, and the server routes on the
+    // OTA one. Getting this wrong 404s every batch.
+    process.env.EXPO_UPDATES_URL = SELF_HOST_URL;
+    expect(resolveObserveEndpoint(OTA_APP_ID)).toBe(`https://ota.example.test/observe/${OTA_APP_ID}`);
+  });
+});

--- a/packages/mobile/src/components/feature-flag-rows.ts
+++ b/packages/mobile/src/components/feature-flag-rows.ts
@@ -16,6 +16,12 @@ import type { FeatureFlagRow } from './FeatureFlagsForm.types';
  * `board-glow-falloff`), retired for 2.4 when the board drawing and its glow
  * falloff became plain user settings instead of rollout controls.
  *
+ * `observe-sample-rate` is multivariate again, but this screen was NOT rebuilt
+ * for it: it renders as On/Off and an override here writes a boolean. That is
+ * harmless — the consumer parses a boolean back to the shipped rate — but the
+ * rate itself can only be changed from PostHog. Rebuild the select if a flag
+ * ever needs on-device variant selection. See docs/feature-flags.md.
+ *
  * Permanently shipped capabilities are not listed here.
  */
 export function buildFeatureFlagRows(

--- a/packages/mobile/src/hooks/__tests__/use-observe-runtime-config.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-observe-runtime-config.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { FeatureFlagsProvider, type FeatureFlags } from '../../providers/feature-flags-provider';
+import { resetObserveRuntimeForTests, setObserveRuntime } from '../../lib/observe-runtime';
+import { useObserveRuntimeConfig } from '../use-observe-runtime-config';
+
+// Proves the flag → SDK wiring. The parsing rules themselves are
+// observe-config.test.ts's contract; this file is about what actually reaches
+// the SDK, including the case that matters most — flags that have not resolved.
+
+afterEach(() => {
+  resetObserveRuntimeForTests();
+});
+
+function wrapperFor(flags: FeatureFlags) {
+  return ({ children }: { children: ReactNode }) => (
+    <FeatureFlagsProvider flags={flags}>{children}</FeatureFlagsProvider>
+  );
+}
+
+function renderWithFlags(flags: FeatureFlags) {
+  const configure = vi.fn();
+  setObserveRuntime({ configure, reportError: vi.fn() });
+  const view = renderHook(() => useObserveRuntimeConfig(), { wrapper: wrapperFor(flags) });
+  return { configure, ...view };
+}
+
+describe('useObserveRuntimeConfig', () => {
+  it('keeps dispatching at full rate while the flags are unresolved', () => {
+    // The cold-start case, and the one that must not go quiet: a device that
+    // never reaches PostHog has to keep reporting.
+    const { configure } = renderWithFlags({});
+
+    expect(configure).toHaveBeenCalledWith({ dispatchingEnabled: true, sampleRate: 1 });
+  });
+
+  it('applies the kill switch', () => {
+    const { configure } = renderWithFlags({ 'observe-dispatch-enabled': false });
+
+    expect(configure).toHaveBeenCalledWith(expect.objectContaining({ dispatchingEnabled: false }));
+  });
+
+  it('applies a sample rate from the multivariate flag', () => {
+    const { configure } = renderWithFlags({ 'observe-sample-rate': '0.25' });
+
+    expect(configure).toHaveBeenCalledWith(expect.objectContaining({ sampleRate: 0.25 }));
+  });
+
+  it('falls back to full sampling when the variant is unparseable', () => {
+    // A typo in the dashboard must not reach the SDK as NaN and disable
+    // collection for everyone who read the flag.
+    const { configure } = renderWithFlags({ 'observe-sample-rate': 'half' });
+
+    expect(configure).toHaveBeenCalledWith(expect.objectContaining({ sampleRate: 1 }));
+  });
+
+  it('does not re-apply on a re-render with unchanged flags', () => {
+    // The effect deps are the two flag values, not the flags object, so an
+    // unrelated re-render must not churn the SDK's config.
+    const { configure, rerender } = renderWithFlags({ 'observe-sample-rate': '0.5' });
+    expect(configure).toHaveBeenCalledTimes(1);
+
+    rerender();
+    expect(configure).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when no SDK is registered', () => {
+    // Expo web and the node test runner never register one.
+    expect(() => renderHook(() => useObserveRuntimeConfig(), { wrapper: wrapperFor({}) })).not.toThrow();
+  });
+});

--- a/packages/mobile/src/hooks/use-observe-runtime-config.ts
+++ b/packages/mobile/src/hooks/use-observe-runtime-config.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { useFeatureFlags } from '../providers/feature-flags-provider';
+import { parseObserveSampleRate, resolveObserveDispatchEnabled } from '../lib/observe-config';
+import { configureObserve } from '../lib/observe-runtime';
+
+/**
+ * Re-applies the Observe dispatch settings whenever the PostHog flags change.
+ *
+ * `observe-bootstrap.ts` has already configured the SDK with the shipped
+ * defaults by the time this runs — it has to, because the router integration
+ * cannot be turned on after a screen mounts. This only ever adjusts the two
+ * settings that ARE safe to change at runtime, and `buildObserveConfig` passes
+ * the same integrations constant back so the integration never looks toggled.
+ *
+ * Flags resolve asynchronously, so a cold start always collects at the shipped
+ * default for a moment. That is intended per docs/feature-flags.md — an
+ * unresolved flag reads as the shipped default rather than as "off", so a device
+ * that never reaches PostHog keeps reporting instead of going quiet forever.
+ *
+ * A no-op when no runtime is registered (node tests, Expo web).
+ */
+export function useObserveRuntimeConfig(): void {
+  const flags = useFeatureFlags();
+  const dispatchFlag = flags['observe-dispatch-enabled'];
+  const sampleRateFlag = flags['observe-sample-rate'];
+
+  useEffect(() => {
+    configureObserve({
+      dispatchingEnabled: resolveObserveDispatchEnabled(dispatchFlag),
+      sampleRate: parseObserveSampleRate(sampleRateFlag),
+    });
+  }, [dispatchFlag, sampleRateFlag]);
+}

--- a/packages/mobile/src/lib/__tests__/error-reporting.test.ts
+++ b/packages/mobile/src/lib/__tests__/error-reporting.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { GRAPHQL_EMPTY_RESPONSE_ERROR_NAME } from '@boardsesh/offline-sync/error-classification';
 import { reportError, reportHandledError } from '../error-reporting';
 import { captureToSentry } from '../sentry';
+import { resetObserveRuntimeForTests, setObserveRuntime } from '../observe-runtime';
 
 // captureToSentry is the only side-effecting dependency; mocking it keeps this a
 // pure test of the noise policy (and avoids sentry.ts's import-time Sentry.init +
@@ -327,5 +328,70 @@ describe('reportError', () => {
     const error = new Error('x');
     reportError(error, { level: 'error', tags: { source: 's' } });
     expect(mockedCaptureToSentry).toHaveBeenCalledWith(error, { level: 'error', tags: { source: 's' } });
+  });
+});
+
+describe('Observe forwarding', () => {
+  // Sentry and Observe hang off the same funnel so the two can never disagree
+  // about what counted as an error. The real slot is used rather than a mock, so
+  // these also prove the slot itself behaves under the funnel.
+  afterEach(() => {
+    resetObserveRuntimeForTests();
+  });
+
+  function registerObserve(reportError_ = vi.fn()) {
+    setObserveRuntime({ configure: vi.fn(), reportError: reportError_ });
+    return reportError_;
+  }
+
+  it('sends a reported error to both destinations', () => {
+    const observeReport = registerObserve();
+    const error = new Error('boom');
+
+    reportError(error);
+
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(error, undefined);
+    expect(observeReport).toHaveBeenCalledWith(error);
+  });
+
+  it('drops from both what the noise policy drops from Sentry', () => {
+    // A cancellation is not a failure; it must not reach either destination.
+    const observeReport = registerObserve();
+
+    reportHandledError(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+
+    expect(mockedCaptureToSentry).not.toHaveBeenCalled();
+    expect(observeReport).not.toHaveBeenCalled();
+  });
+
+  it('still forwards an error the policy downgraded rather than dropped', () => {
+    const observeReport = registerObserve();
+
+    reportHandledError(Object.assign(new Error('Network request failed'), { name: 'TypeError' }));
+
+    expect(observeReport).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports to Sentry even when Observe throws', () => {
+    // The whole point of the try/catch in the slot: telemetry must never be
+    // able to lose the actual error.
+    setObserveRuntime({
+      configure: vi.fn(),
+      reportError: () => {
+        throw new Error('native module exploded');
+      },
+    });
+    const error = new Error('boom');
+
+    expect(() => reportError(error)).not.toThrow();
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(error, undefined);
+  });
+
+  it('reports to Sentry when no Observe runtime is registered', () => {
+    const error = new Error('boom');
+
+    reportError(error);
+
+    expect(mockedCaptureToSentry).toHaveBeenCalledWith(error, undefined);
   });
 });

--- a/packages/mobile/src/lib/__tests__/feature-flag-coercion.test.ts
+++ b/packages/mobile/src/lib/__tests__/feature-flag-coercion.test.ts
@@ -12,6 +12,10 @@ import { readPosthogFeatureFlags, registerRenderSuperProperties } from '../analy
 // flags (a `variants` list on the definition) must only ever surface one of
 // their declared members — anything else, including a stale boolean, reads as
 // unresolved so callers fall back to the shipped default.
+//
+// The multivariate path was removed for 2.4 along with the last two variant
+// flags and only restored for observe-sample-rate; these tests are what keep it
+// from being deleted again while a flag still depends on it.
 describe('readPosthogFeatureFlags', () => {
   let getFeatureFlag: ReturnType<typeof vi.fn>;
 
@@ -63,6 +67,40 @@ describe('readPosthogFeatureFlags', () => {
     it('drops an unresolved read', () => {
       getFeatureFlag.mockReturnValue(undefined);
       expect(readPosthogFeatureFlags([definition])).toEqual({});
+    });
+  });
+
+  describe('a multivariate flag (a variants list on the definition)', () => {
+    // observe-sample-rate is the live one. Without this path its value is
+    // coerced to a boolean and dropped, so the flag silently does nothing.
+    const definition = { key: 'observe-sample-rate', variants: ['1', '0.5', '0.25'] as const };
+
+    it('keeps a declared variant verbatim', () => {
+      getFeatureFlag.mockReturnValue('0.25');
+      expect(readPosthogFeatureFlags([definition])).toEqual({ 'observe-sample-rate': '0.25' });
+    });
+
+    it('drops a string that is not a declared member', () => {
+      getFeatureFlag.mockReturnValue('0.42');
+      expect(readPosthogFeatureFlags([definition])).toEqual({});
+    });
+
+    it('drops a boolean, which is what PostHog returns when nothing matched', () => {
+      getFeatureFlag.mockReturnValue(false);
+      expect(readPosthogFeatureFlags([definition])).toEqual({});
+    });
+
+    it('drops an unresolved read', () => {
+      getFeatureFlag.mockReturnValue(undefined);
+      expect(readPosthogFeatureFlags([definition])).toEqual({});
+    });
+
+    it('does not turn a boolean flag multivariate by accident', () => {
+      // An empty variants list must keep the plain boolean behaviour.
+      getFeatureFlag.mockReturnValue(true);
+      expect(readPosthogFeatureFlags([{ key: 'strava-integration', variants: [] }])).toEqual({
+        'strava-integration': true,
+      });
     });
   });
 

--- a/packages/mobile/src/lib/__tests__/observe-config.test.ts
+++ b/packages/mobile/src/lib/__tests__/observe-config.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  OBSERVE_DEFAULT_SAMPLE_RATE,
+  OBSERVE_INTEGRATIONS,
+  buildObserveConfig,
+  parseObserveSampleRate,
+  resolveObserveDispatchEnabled,
+} from '../observe-config';
+
+describe('parseObserveSampleRate', () => {
+  // PostHog hands back a string, and the value is typed by hand in a dashboard.
+  it('reads the declared variant strings', () => {
+    expect(parseObserveSampleRate('1')).toBe(1);
+    expect(parseObserveSampleRate('0.25')).toBe(0.25);
+    expect(parseObserveSampleRate('0')).toBe(0);
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseObserveSampleRate(' 0.5 ')).toBe(0.5);
+  });
+
+  it('accepts a number, in case the flag is ever typed as one', () => {
+    expect(parseObserveSampleRate(0.25)).toBe(0.25);
+  });
+
+  // The important cases: a typo must not reach the SDK as NaN, which would
+  // silently stop collection for every device that read the flag.
+  it('falls back to the shipped default for unparseable input', () => {
+    expect(parseObserveSampleRate('half')).toBe(OBSERVE_DEFAULT_SAMPLE_RATE);
+    expect(parseObserveSampleRate('')).toBe(OBSERVE_DEFAULT_SAMPLE_RATE);
+    expect(parseObserveSampleRate(Number.NaN)).toBe(OBSERVE_DEFAULT_SAMPLE_RATE);
+  });
+
+  it('falls back when the flag has not resolved yet', () => {
+    expect(parseObserveSampleRate(undefined)).toBe(OBSERVE_DEFAULT_SAMPLE_RATE);
+    expect(parseObserveSampleRate(null)).toBe(OBSERVE_DEFAULT_SAMPLE_RATE);
+  });
+
+  it('clamps out-of-range values instead of passing them through', () => {
+    expect(parseObserveSampleRate('2')).toBe(1);
+    expect(parseObserveSampleRate('-1')).toBe(0);
+    expect(parseObserveSampleRate(Number.POSITIVE_INFINITY)).toBe(OBSERVE_DEFAULT_SAMPLE_RATE);
+  });
+});
+
+describe('resolveObserveDispatchEnabled', () => {
+  it('treats an unresolved flag as the shipped default, not as off', () => {
+    // A device that never reaches PostHog must keep reporting rather than go
+    // permanently quiet — the failure mode docs/feature-flags.md calls out.
+    expect(resolveObserveDispatchEnabled(undefined)).toBe(true);
+  });
+
+  it('disables only on an explicit false', () => {
+    expect(resolveObserveDispatchEnabled(false)).toBe(false);
+    expect(resolveObserveDispatchEnabled(true)).toBe(true);
+  });
+
+  it('treats a stray string as enabled rather than silently disabling', () => {
+    expect(resolveObserveDispatchEnabled('true')).toBe(true);
+    expect(resolveObserveDispatchEnabled('')).toBe(true);
+  });
+});
+
+describe('buildObserveConfig', () => {
+  it('never dispatches from a debug build', () => {
+    // Without this a Metro dev session writes into production ClickHouse.
+    expect(buildObserveConfig().dispatchInDebug).toBe(false);
+  });
+
+  it('applies the shipped defaults when given no overrides', () => {
+    const config = buildObserveConfig();
+    expect(config.sampleRate).toBe(OBSERVE_DEFAULT_SAMPLE_RATE);
+    expect(config.dispatchingEnabled).toBe(true);
+  });
+
+  it('applies overrides', () => {
+    const config = buildObserveConfig({ dispatchingEnabled: false, sampleRate: 0.1 });
+    expect(config.dispatchingEnabled).toBe(false);
+    expect(config.sampleRate).toBe(0.1);
+  });
+
+  it('hands back the same integrations object every time', () => {
+    // Not a micro-optimisation: expo-observe's router integration throws if the
+    // initialized value changes for a mounted screen, so the runtime re-apply
+    // must pass the identical value the startup call did.
+    expect(buildObserveConfig().integrations).toBe(OBSERVE_INTEGRATIONS);
+    expect(buildObserveConfig({ sampleRate: 0.5 }).integrations).toBe(OBSERVE_INTEGRATIONS);
+  });
+
+  it('enables the expo-router integration, which is what produces the timings', () => {
+    expect(OBSERVE_INTEGRATIONS['expo-router']).toBe(true);
+  });
+});

--- a/packages/mobile/src/lib/__tests__/observe-config.test.ts
+++ b/packages/mobile/src/lib/__tests__/observe-config.test.ts
@@ -59,6 +59,12 @@ describe('resolveObserveDispatchEnabled', () => {
     expect(resolveObserveDispatchEnabled('true')).toBe(true);
     expect(resolveObserveDispatchEnabled('')).toBe(true);
   });
+
+  it("honours the string 'false', so a kill switch typed as text still kills", () => {
+    // A boolean flag resolves to a real boolean, but the same key typed as a
+    // multivariate flag in the dashboard arrives as a string.
+    expect(resolveObserveDispatchEnabled('false')).toBe(false);
+  });
 });
 
 describe('buildObserveConfig', () => {

--- a/packages/mobile/src/lib/__tests__/observe-runtime.test.ts
+++ b/packages/mobile/src/lib/__tests__/observe-runtime.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { captureToObserve, configureObserve, resetObserveRuntimeForTests, setObserveRuntime } from '../observe-runtime';
+
+afterEach(() => {
+  resetObserveRuntimeForTests();
+});
+
+describe('observe-runtime slot', () => {
+  it('is a no-op before the SDK registers', () => {
+    // The normal state under test and on Expo web. Must not throw, because
+    // error-reporting calls straight through it.
+    expect(() => captureToObserve(new Error('boom'))).not.toThrow();
+    expect(() => configureObserve({ sampleRate: 0.5 })).not.toThrow();
+  });
+
+  it('forwards to the registered runtime', () => {
+    const reportError = vi.fn();
+    const configure = vi.fn();
+    setObserveRuntime({ configure, reportError });
+
+    const error = new Error('boom');
+    captureToObserve(error);
+    configureObserve({ sampleRate: 0.25 });
+
+    expect(reportError).toHaveBeenCalledWith(error);
+    expect(configure).toHaveBeenCalledWith({ sampleRate: 0.25 });
+  });
+
+  it('swallows a throwing reporter', () => {
+    // This runs inside the error-reporting funnel, so a throw here would take
+    // out the Sentry report that follows it — telemetry must never be able to
+    // lose the actual error.
+    setObserveRuntime({
+      configure: vi.fn(),
+      reportError: () => {
+        throw new Error('native module exploded');
+      },
+    });
+
+    expect(() => captureToObserve(new Error('boom'))).not.toThrow();
+  });
+
+  it('swallows a throwing configure', () => {
+    setObserveRuntime({
+      configure: () => {
+        throw new Error('bad config');
+      },
+      reportError: vi.fn(),
+    });
+
+    expect(() => configureObserve({ sampleRate: 2 })).not.toThrow();
+  });
+
+  it('stops forwarding once unregistered', () => {
+    const reportError = vi.fn();
+    setObserveRuntime({ configure: vi.fn(), reportError });
+    setObserveRuntime(null);
+
+    captureToObserve(new Error('boom'));
+    expect(reportError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/analytics.ts
+++ b/packages/mobile/src/lib/analytics.ts
@@ -62,13 +62,23 @@ export function registerSuperProperties(properties: Record<string, string | numb
 }
 
 /**
- * Coerce one raw PostHog flag value to the boolean the catalog expects.
+ * Coerce one raw PostHog flag value to what the catalog expects.
  *
- * Anything that is not a boolean reads as `undefined` — "unresolved, fall back
- * to the shipped default" — which also absorbs a stale variant string left over
- * from when a flag was multivariate.
+ * A definition carrying a `variants` list is **multivariate**: PostHog resolves
+ * it to one of those strings, and only a declared member survives verbatim.
+ * Anything else — a boolean (which is what PostHog returns when the flag
+ * matched no variant), an unknown string, an unresolved read — is `undefined`,
+ * meaning "fall back to the shipped default".
+ *
+ * Without a `variants` list the flag is a plain boolean and anything that is
+ * not one reads as `undefined`, which also absorbs a stale variant string left
+ * over from when a flag used to be multivariate.
  */
-function coerceFeatureFlagValue(value: unknown): boolean | undefined {
+function coerceFeatureFlagValue(value: unknown, variants?: readonly string[]): boolean | string | undefined {
+  if (variants && variants.length > 0) {
+    return typeof value === 'string' && variants.includes(value) ? value : undefined;
+  }
+
   if (typeof value === 'boolean') return value;
   // The SDK sometimes hands back the string form; normalise it rather than
   // dropping a flag that IS resolved.
@@ -104,7 +114,7 @@ const READ_WITHOUT_EXPOSURE_EVENT: FeatureFlagReadOptions = { sendEvent: false }
  * module already imports this function — a type-only import back would form a
  * circular dependency for no benefit.
  */
-type FeatureFlagDefinitionLike = { key: string };
+type FeatureFlagDefinitionLike = { key: string; variants?: readonly string[] };
 
 export function readPosthogFeatureFlags(
   definitions: readonly FeatureFlagDefinitionLike[],
@@ -121,7 +131,7 @@ export function readPosthogFeatureFlags(
     } else if (typeof featureFlagClient.isFeatureEnabled === 'function') {
       rawFlagValue = featureFlagClient.isFeatureEnabled(definition.key, READ_WITHOUT_EXPOSURE_EVENT);
     }
-    const flagValue = coerceFeatureFlagValue(rawFlagValue);
+    const flagValue = coerceFeatureFlagValue(rawFlagValue, definition.variants);
     if (flagValue !== undefined) {
       flags[definition.key] = flagValue;
     }

--- a/packages/mobile/src/lib/error-reporting.ts
+++ b/packages/mobile/src/lib/error-reporting.ts
@@ -1,6 +1,7 @@
 import { isBleWriteTimeoutError } from '@boardsesh/ble-protocol/connection-error';
 import { getErrorStatus, isNetworkError as isSharedNetworkError } from '@boardsesh/offline-sync/error-classification';
 import { captureToSentry, type ErrorReportContext } from './sentry';
+import { captureToObserve } from './observe-runtime';
 import {
   isExpectedAuthError,
   isExpectedBetaValidationError,
@@ -14,12 +15,20 @@ import {
 export type { ErrorReportContext };
 
 /**
- * Report an error to Sentry if it is active. No-op otherwise. The optional
- * context lets callers attach triage data such as source, board path, or HTTP
- * status.
+ * Report an error to Sentry if it is active, and to xprem's Observe. No-op for
+ * either destination that is inactive. The optional context lets callers attach
+ * triage data such as source, board path, or HTTP status.
+ *
+ * Both destinations hang off this one funnel deliberately. Everything the
+ * filters in `reportHandledError` already dropped (cancellations, expected auth
+ * and validation rejections) stays dropped for both, so the two can never
+ * disagree about what counted as an error. Observe takes no context — it records
+ * the error against the OTA update id that produced it, which is the question
+ * Sentry cannot answer; Sentry keeps the triage detail.
  */
 export function reportError(error: unknown, context?: ErrorReportContext): void {
   captureToSentry(error, context);
+  captureToObserve(error);
 }
 
 /**

--- a/packages/mobile/src/lib/observe-bootstrap.ts
+++ b/packages/mobile/src/lib/observe-bootstrap.ts
@@ -1,0 +1,30 @@
+// Side-effect-only module: registers the expo-observe SDK and configures it at
+// module scope, before anything mounts. Import it exactly once, from
+// app/_layout.tsx.
+//
+// The ordering is not a style choice. expo-observe's router integration reads
+// `isInitialized()` when a screen's provider mounts and throws if that value
+// ever changes afterwards ("Router integration was toggled during a screen's
+// lifecycle"), so configure cannot move into a hook, an effect, or a provider —
+// it has to have already happened by the time the first screen renders. Same
+// reason `analytics-bootstrap.ts` next to it is an import rather than a call.
+//
+// This is also the ONLY module that imports `expo-observe` directly. Everything
+// else reaches the SDK through the dependency-free slot in
+// `observe-runtime.ts`, which is what keeps Expo's winter runtime out of the
+// node-env test graph that `error-reporting.ts` sits in — importing the SDK
+// there fails 33 test files with `Cannot find module './ImportMetaRegistry'`.
+//
+// The feature flags re-apply dispatchingEnabled / sampleRate later (see
+// hooks/use-observe-runtime-config.ts); that is safe precisely because
+// buildObserveConfig hands the same OBSERVE_INTEGRATIONS constant back.
+import { Observe } from 'expo-observe';
+import { buildObserveConfig, type ObserveRuntimeOverrides } from './observe-config';
+import { setObserveRuntime } from './observe-runtime';
+
+setObserveRuntime({
+  configure: (overrides: ObserveRuntimeOverrides) => Observe.configure(buildObserveConfig(overrides)),
+  reportError: (error: unknown) => Observe.reportError(error),
+});
+
+Observe.configure(buildObserveConfig());

--- a/packages/mobile/src/lib/observe-config.ts
+++ b/packages/mobile/src/lib/observe-config.ts
@@ -72,11 +72,17 @@ function clampSampleRate(value: number): number {
 /**
  * Resolve the dispatch flag.
  *
- * Only an explicit `false` disables dispatch: PostHog leaves a flag `undefined`
+ * Only an explicit off disables dispatch: PostHog leaves a flag `undefined`
  * until it resolves, and a device that never reaches PostHog would otherwise
  * stop reporting permanently — the failure mode docs/feature-flags.md calls out.
+ *
+ * The string `'false'` counts as off too. A boolean flag resolves to a real
+ * boolean, but the same key typed as a multivariate flag in the dashboard would
+ * arrive as a string, and a kill switch that silently ignores someone typing
+ * "false" into it is the wrong way round for a kill switch to fail.
  */
 export function resolveObserveDispatchEnabled(raw: unknown): boolean {
   if (raw === undefined) return OBSERVE_DEFAULT_DISPATCHING_ENABLED;
-  return raw !== false;
+  if (raw === false || raw === 'false') return false;
+  return true;
 }

--- a/packages/mobile/src/lib/observe-config.ts
+++ b/packages/mobile/src/lib/observe-config.ts
@@ -1,0 +1,82 @@
+import type { ObserveConfig, ObserveIntegrationsConfig } from 'expo-observe';
+import { resolveAppEnvironment } from './app-environment';
+
+/**
+ * Pure config for expo-observe. Type-only import of the SDK, so this module —
+ * and everything that reads it — stays out of the Expo runtime's module graph
+ * and importable from the node-env test runner. `observe-bootstrap.ts` is the
+ * one place that pulls the real SDK in.
+ */
+
+/**
+ * The integrations config, defined once as a module constant.
+ *
+ * `useObserveForRouter` asserts the initialized value never changes for the
+ * lifetime of a screen and throws when it does, so every `configure` call — the
+ * one at startup and every later one from the feature flags — must pass this
+ * same value. Handing back a fresh object literal each time is exactly the bug
+ * that assertion exists to catch.
+ */
+export const OBSERVE_INTEGRATIONS: ObserveIntegrationsConfig = { 'expo-router': true };
+
+/**
+ * Shipped defaults, in force until PostHog resolves the flags.
+ *
+ * Full sampling: the store fleet is the population we want, and the rate can be
+ * dialled back from PostHog without a build if the volume proves too high.
+ * `docs/railway.md` records the measured growth this trades against.
+ */
+export const OBSERVE_DEFAULT_SAMPLE_RATE = 1;
+export const OBSERVE_DEFAULT_DISPATCHING_ENABLED = true;
+
+export type ObserveRuntimeOverrides = {
+  dispatchingEnabled?: boolean;
+  sampleRate?: number;
+};
+
+/** Build the full config, so startup and the runtime re-apply can't drift. */
+export function buildObserveConfig(overrides: ObserveRuntimeOverrides = {}): ObserveConfig {
+  return {
+    environment: resolveAppEnvironment(),
+    // Debug builds mark metrics as sent without dispatching. Left at the
+    // default so a Metro dev session never writes into production ClickHouse.
+    dispatchInDebug: false,
+    dispatchingEnabled: overrides.dispatchingEnabled ?? OBSERVE_DEFAULT_DISPATCHING_ENABLED,
+    sampleRate: overrides.sampleRate ?? OBSERVE_DEFAULT_SAMPLE_RATE,
+    integrations: OBSERVE_INTEGRATIONS,
+  };
+}
+
+/**
+ * Read a sample rate out of a multivariate flag value.
+ *
+ * PostHog hands back a string (or nothing at all before it resolves), so this
+ * has to survive a typo in the dashboard: anything unparseable or outside
+ * [0, 1] falls back to the shipped default rather than reaching the SDK as NaN
+ * and silently disabling collection for everyone.
+ */
+export function parseObserveSampleRate(raw: unknown): number {
+  if (typeof raw === 'number') return clampSampleRate(raw);
+  if (typeof raw !== 'string') return OBSERVE_DEFAULT_SAMPLE_RATE;
+
+  return clampSampleRate(Number.parseFloat(raw.trim()));
+}
+
+function clampSampleRate(value: number): number {
+  if (!Number.isFinite(value)) return OBSERVE_DEFAULT_SAMPLE_RATE;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+/**
+ * Resolve the dispatch flag.
+ *
+ * Only an explicit `false` disables dispatch: PostHog leaves a flag `undefined`
+ * until it resolves, and a device that never reaches PostHog would otherwise
+ * stop reporting permanently — the failure mode docs/feature-flags.md calls out.
+ */
+export function resolveObserveDispatchEnabled(raw: unknown): boolean {
+  if (raw === undefined) return OBSERVE_DEFAULT_DISPATCHING_ENABLED;
+  return raw !== false;
+}

--- a/packages/mobile/src/lib/observe-runtime.ts
+++ b/packages/mobile/src/lib/observe-runtime.ts
@@ -1,0 +1,56 @@
+import type { ObserveRuntimeOverrides } from './observe-config';
+
+/**
+ * Pure in-memory slot for the expo-observe SDK, registered by
+ * `observe-bootstrap.ts` (imported once, from app/_layout.tsx).
+ *
+ * Deliberately dependency-free — no `expo-observe`, no react-native — for the
+ * same reason `analytics-bootstrap-id.ts` is: `error-reporting.ts` reads this,
+ * and error-reporting is imported by a large part of the app that the node-env
+ * test runner loads. Importing the SDK directly there drags in Expo's winter
+ * runtime (`Cannot find module './ImportMetaRegistry'`) and takes 33 test files
+ * down with it.
+ *
+ * Unregistered is the normal state under test and on Expo web, so every call
+ * here is a no-op rather than an error.
+ */
+export type ObserveRuntime = {
+  configure(overrides: ObserveRuntimeOverrides): void;
+  reportError(error: unknown): void;
+};
+
+let runtime: ObserveRuntime | null = null;
+
+export function setObserveRuntime(next: ObserveRuntime | null): void {
+  runtime = next;
+}
+
+/** Test-only reset, so one test registering a runtime cannot leak into the next. */
+export function resetObserveRuntimeForTests(): void {
+  runtime = null;
+}
+
+export function configureObserve(overrides: ObserveRuntimeOverrides = {}): void {
+  if (!runtime) return;
+  try {
+    runtime.configure(overrides);
+  } catch {
+    // A telemetry misconfiguration must not take the app down.
+  }
+}
+
+/**
+ * Report an error to Observe.
+ *
+ * Swallows its own failures. This runs inside the app's error-reporting funnel,
+ * so a throw here would take out the Sentry report that follows it — telemetry
+ * must never be able to lose the actual error.
+ */
+export function captureToObserve(error: unknown): void {
+  if (!runtime) return;
+  try {
+    runtime.reportError(error);
+  } catch {
+    // Nothing useful to do: the reporting path itself is what failed.
+  }
+}

--- a/packages/mobile/src/providers/feature-flags-provider.tsx
+++ b/packages/mobile/src/providers/feature-flags-provider.tsx
@@ -11,10 +11,12 @@
 //
 // A definition may still declare `variants` — the tester-only Feature Flags
 // screen renders those as a select instead of On/Off, and `readPosthogFeatureFlags`
-// keeps a declared variant string verbatim. Nothing in the app reads one today:
-// the last two multivariate flags (`board-render-mode-default`,
-// `board-glow-falloff`) were both retired for 2.4, when the board drawing and
-// its glow falloff became plain user settings rather than rollout controls.
+// keeps a declared variant string verbatim. `observe-sample-rate` is the one
+// the app reads today (see use-observe-runtime-config.ts); the two before it
+// (`board-render-mode-default`, `board-glow-falloff`) were retired for 2.4, when
+// the board drawing and its glow falloff became plain user settings rather than
+// rollout controls — which is when the `variants` property itself was dropped
+// from the definition type and had to be restored here.
 
 import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { readPosthogFeatureFlags, subscribePosthogFeatureFlags } from '../lib/analytics';
@@ -37,6 +39,7 @@ export type FeatureFlagDefinition = {
    * strings (or nothing, when unresolved) instead of a boolean. Omit for a
    * plain on/off flag.
    */
+  variants?: readonly string[];
 };
 
 export const FEATURE_FLAG_DEFINITIONS = [
@@ -76,6 +79,19 @@ export const FEATURE_FLAG_DEFINITIONS = [
     label: 'Disable the anonymous climb view',
     description:
       'Emergency kill switch: send signed-out visitors on app.boardsesh.com climb URLs back to the login wall instead of rendering the read-only climb. Web export only — native never serves those routes signed-out.',
+  },
+  {
+    key: 'observe-dispatch-enabled',
+    label: 'Observe telemetry dispatch',
+    description:
+      'Emergency kill switch for expo-observe. Off stops the app dispatching metrics, logs and error reports to updates.boardsesh.com; pending ones are marked sent and discarded. Manifest polling and OTA updates are unaffected.',
+  },
+  {
+    key: 'observe-sample-rate',
+    label: 'Observe sample rate',
+    description:
+      'Fraction of installations that dispatch Observe telemetry. Deterministic per install, so the sampled cohort is stable across launches. Ships at 1 (everyone); lower it here if ClickHouse volume needs cutting without a store release.',
+    variants: ['1', '0.5', '0.25', '0.1', '0'],
   },
   {
     key: 'moonboard-wide-angles',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,6 +684,9 @@ importers:
       expo-notifications:
         specifier: 57.0.15
         version: 57.0.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@7.0.2)
+      expo-observe:
+        specifier: 57.0.17
+        version: 57.0.17(expo-router@57.0.17)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       expo-router:
         specifier: 57.0.17
         version: 57.0.17(6cb3000118c7cca45b0d29acad696f08)
@@ -7837,6 +7840,13 @@ packages:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
+  expo-app-metrics@57.0.15:
+    resolution: {integrity: sha512-mNzR5rINHXORvpJXYLSZRHcpeWgDe0ENJQcZj/u75sANVrSBH8JgeCAInLSNgreSW1K80215+JIaM3X2SfMAlA==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
+
   expo-apple-authentication@57.0.1:
     resolution: {integrity: sha512-pqAIaiTa/ycNl+XqNg5UMVT5TBgl6q6djTtoIcUmDItjVBA1IDHsQEs+leo+8+fG5hhuempZLSqBVVn+RJKKWA==}
     peerDependencies:
@@ -8034,6 +8044,20 @@ packages:
       expo: '*'
       react: '*'
       react-native: '*'
+
+  expo-observe@57.0.17:
+    resolution: {integrity: sha512-tbC1jRmXN//O+CA9ghM0O2yjNnW1YlyCf4l1qACJ5vC0RtuIwqikpWUFxWLdHxosr8HlTFFDtlJnTKQI6ZFNIw==}
+    peerDependencies:
+      '@react-navigation/native': ^7.0.0
+      expo: '*'
+      expo-router: '*'
+      react: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      '@react-navigation/native':
+        optional: true
+      expo-router:
+        optional: true
 
   expo-router@57.0.17:
     resolution: {integrity: sha512-zKAfGLxrbdkUFzzW1xHezLXPSa0V4DlYKEWweDUUFGgnPWPNy3OY0EKYAqOhlBGSDebAvtnJXn+2zyyJjYKwyg==}
@@ -18706,6 +18730,13 @@ snapshots:
 
   expect-type@1.4.0: {}
 
+  expo-app-metrics@57.0.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
+    dependencies:
+      expo: 57.0.18(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.14)(bufferutil@4.1.0)(expo-router@57.0.17)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@7.0.2)
+      expo-updates-interface: 57.0.1(expo@57.0.18)
+      react: 19.2.3
+      react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)
+
   expo-apple-authentication@57.0.1(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
     dependencies:
       expo: 57.0.18(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.14)(bufferutil@4.1.0)(expo-router@57.0.17)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@7.0.2)
@@ -18991,6 +19022,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  expo-observe@57.0.17(expo-router@57.0.17)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
+    dependencies:
+      expo: 57.0.18(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.14)(bufferutil@4.1.0)(expo-router@57.0.17)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@7.0.2)
+      expo-app-metrics: 57.0.15(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+      expo-eas-client: 57.0.2
+      react: 19.2.3
+      react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)
+    optionalDependencies:
+      expo-router: 57.0.17(6cb3000118c7cca45b0d29acad696f08)
 
   expo-router@57.0.17(6cb3000118c7cca45b0d29acad696f08):
     dependencies:


### PR DESCRIPTION
## Summary

Adds `expo-observe` so the app fills the two Observe tables the server cannot fill for itself.

The ClickHouse side has been live since #5023, but only three of its five tables are
server-fed (from manifest check-ins, via the Postgres outbox triggers). `observe_metrics`
and `observe_logs` can only come from the app, and have sat at zero rows since cutover.

It answers a question our existing SDKs can't. PostHog says whether an update *reached*
users and Sentry says *what* broke; every Observe row is attributed server-side to the
`updateId` that produced it, so a bad release reads as a per-update health regression
rather than a vague uptick.

### What it sends

- Per-screen `cold_ttr` / `warm_ttr` / `tti` via the expo-router integration
- Log events
- Every error that already reaches `reportError`

`tti` additionally wants `markInteractive` on screens that keep working after first
paint. Deliberately left for a follow-up rather than bundled into turning this on.

### Shape, and why

- **`observe-bootstrap.ts` calls `Observe.configure()` at module scope**, imported third in
  `_layout.tsx`. The router integration reads `isInitialized()` when a screen mounts and
  throws if it changes afterwards, so this can never be a hook or an effect — the same
  constraint that makes `analytics-bootstrap` an import rather than a call.
- **It is the only module that imports `expo-observe`.** Everything else goes through a
  dependency-free slot (`observe-runtime.ts`), for the reason `analytics-bootstrap-id.ts`
  exists: `error-reporting.ts` is loaded by much of the node-env test suite, and importing
  the SDK there drags in Expo's winter runtime and fails 33 test files with
  `Cannot find module './ImportMetaRegistry'`. I hit exactly that, then followed the
  existing pattern.
- **Errors hook `reportError`**, the single funnel, rather than being sprinkled at call
  sites. Whatever the existing noise policy already drops (cancellations, expected auth and
  validation rejections) stays dropped for both destinations, so Sentry and Observe can
  never disagree about what counted as an error.
- **The endpoint is derived**, not hardcoded — `EXPO_UPDATES_URL`'s origin plus the OTA app
  id — so telemetry and manifests cannot end up pointing at different servers. Builds with
  no self-hosted server, and EAS-hosted ones, report nothing.

### Control without a store release

Two PostHog flags, through the existing mobile catalog:

| Flag | Effect |
| --- | --- |
| `observe-dispatch-enabled` | Kill switch. Off stops dispatch; manifest polling and OTA are untouched |
| `observe-sample-rate` | Multivariate, ships at `1`. Deterministic per install |

Both read as their shipped default while unresolved, so a device that never reaches
PostHog keeps reporting rather than going permanently silent. Adding the multivariate one
meant restoring `variants` to `FeatureFlagDefinition` — the property was dropped when the
last two multivariate flags were retired for 2.4, but its doc comment was left behind, so
any new multivariate flag would have failed to typecheck.

### This moves the fingerprint

`532b9027` → `fc49c3f6`. `expo-observe` pulls in `expo-app-metrics` and `expo-eas-client`,
both autolinked native modules with AppDelegate subscribers. **It cannot ship over OTA**
and needs the store release being prepared — older store builds report nothing however
long they run. No config plugin is required; neither package ships an `app.plugin.js`.

### Privacy

No new permissions and no GPS. `country_code` / `lat` / `lng` in the schema are resolved
**server-side from the request IP** (`ee/observe/flatten.go`: "not carried by the
payload"), on our own infrastructure.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. Install the new TestFlight build.
2. Open Climbs, then You — screens load as before.
3. Force-quit and reopen twice.
4. Log a tick — it saves as normal.
5. Report anything slower or crashier than the last build.

## Risk

Risk: 4/5 — moves the native fingerprint, so it forces a store build and cannot be undone
over OTA; app-facing behaviour is additive telemetry behind a kill switch.
