### PR TITLE
fix(ci): harden the Railway redeploy rollback path

### DIFF
--- a/.github/actions/railway-redeploy/action.yml
+++ b/.github/actions/railway-redeploy/action.yml
@@ -156,7 +156,10 @@ runs:
               # one was cancelled — a real failure, not a transient status the
               # poll should wait out.
               echo "deployment_id=${CURRENT_ID}" >> "$GITHUB_OUTPUT"
-              rollback_previous_deployment
+              # `set -e` is active in this step: a bare call would abort here on
+              # a non-zero return from the function, skipping the log capture
+              # and the `exit 1` below in favour of a raw, unannotated failure.
+              rollback_previous_deployment || true
               railway logs --service "$RAILWAY_SERVICE_ID" --latest --lines 100 || true
               exit 1
               ;;
@@ -165,7 +168,7 @@ runs:
           sleep 10
         done
 
-        rollback_previous_deployment
+        rollback_previous_deployment || true
         railway logs --service "$RAILWAY_SERVICE_ID" --latest --lines 100 || true
         echo "Railway deployment did not reach SUCCESS in time"
         exit 1

--- a/.github/actions/railway-redeploy/action.yml
+++ b/.github/actions/railway-redeploy/action.yml
@@ -109,10 +109,26 @@ runs:
           echo "Attempting Railway rollback to ${PREVIOUS_DEPLOYMENT_ID}..."
           node -e 'process.stdout.write(JSON.stringify({ query: "mutation deploymentRollback($id: String!) { deploymentRollback(id: $id) }", variables: { id: process.env.PREVIOUS_DEPLOYMENT_ID } }))' > railway-rollback-payload.json
 
-          curl -fsS https://backboard.railway.com/graphql/v2 \
+          # GraphQL returns HTTP 200 even when the mutation is rejected (stale
+          # deployment id, auth failure, etc.) — `-fsS` alone exits 0 on a
+          # rejected rollback and leaves production on the broken deployment
+          # with no signal. Capture the body and check its `errors` field too.
+          if ! ROLLBACK_RESPONSE=$(curl -sS https://backboard.railway.com/graphql/v2 \
             -H "Authorization: Bearer ${RAILWAY_TOKEN}" \
             -H "Content-Type: application/json" \
-            --data @railway-rollback-payload.json || echo "Railway rollback request failed; check Railway manually."
+            --data @railway-rollback-payload.json); then
+            echo "::error::Railway rollback request failed (network/HTTP error); check Railway manually."
+            return 1
+          fi
+
+          echo "$ROLLBACK_RESPONSE"
+
+          if ! node -e 'const body = JSON.parse(process.argv[1]); process.exit(Array.isArray(body.errors) && body.errors.length > 0 ? 1 : 0)' "$ROLLBACK_RESPONSE"; then
+            echo "::error::Railway rejected the rollback to ${PREVIOUS_DEPLOYMENT_ID}; check Railway manually. Response above."
+            return 1
+          fi
+
+          echo "Railway rollback to ${PREVIOUS_DEPLOYMENT_ID} accepted."
         }
 
         for attempt in $(seq 1 90); do
@@ -131,7 +147,14 @@ runs:
               echo "deployment_id=${CURRENT_ID}" >> "$GITHUB_OUTPUT"
               exit 0
               ;;
-            FAILED|CRASHED|REMOVED)
+            FAILED|CRASHED|REMOVED|CANCELLED)
+              # CANCELLED is what Railway leaves behind when a newer deployment
+              # supersedes a queued one. railway-deployment-status.mjs already
+              # prefers a non-cancelled candidate over a cancelled one when both
+              # are newer than the captured previous deployment, so reaching
+              # CANCELLED here means every deployment newer than the previous
+              # one was cancelled — a real failure, not a transient status the
+              # poll should wait out.
               echo "deployment_id=${CURRENT_ID}" >> "$GITHUB_OUTPUT"
               rollback_previous_deployment
               railway logs --service "$RAILWAY_SERVICE_ID" --latest --lines 100 || true

--- a/.github/actions/railway-redeploy/action.yml
+++ b/.github/actions/railway-redeploy/action.yml
@@ -110,14 +110,20 @@ runs:
           node -e 'process.stdout.write(JSON.stringify({ query: "mutation deploymentRollback($id: String!) { deploymentRollback(id: $id) }", variables: { id: process.env.PREVIOUS_DEPLOYMENT_ID } }))' > railway-rollback-payload.json
 
           # GraphQL returns HTTP 200 even when the mutation is rejected (stale
-          # deployment id, auth failure, etc.) — `-fsS` alone exits 0 on a
-          # rejected rollback and leaves production on the broken deployment
-          # with no signal. Capture the body and check its `errors` field too.
-          if ! ROLLBACK_RESPONSE=$(curl -sS https://backboard.railway.com/graphql/v2 \
+          # deployment id, auth failure, etc.), so an HTTP-status-only check
+          # isn't enough on its own — the body's `errors` field needs checking
+          # too. But dropping HTTP-status checking entirely (plain `-sS`) is
+          # its own bug: a 4xx/5xx with a JSON body that happens to carry no
+          # top-level `errors` array (a plain gateway/proxy error, say) would
+          # then read as accepted. `--fail-with-body` gets both: it fails the
+          # command on an HTTP error status while still writing the body to
+          # stdout (unlike plain `-f`, which discards it on failure), so the
+          # capture below always has the response to check or to log.
+          if ! ROLLBACK_RESPONSE=$(curl --fail-with-body -sS https://backboard.railway.com/graphql/v2 \
             -H "Authorization: Bearer ${RAILWAY_TOKEN}" \
             -H "Content-Type: application/json" \
             --data @railway-rollback-payload.json); then
-            echo "::error::Railway rollback request failed (network/HTTP error); check Railway manually."
+            echo "::error::Railway rollback request failed (HTTP/network error); check Railway manually. Response: ${ROLLBACK_RESPONSE}"
             return 1
           fi
 

--- a/.github/actions/railway-redeploy/action.yml
+++ b/.github/actions/railway-redeploy/action.yml
@@ -123,7 +123,29 @@ runs:
 
           echo "$ROLLBACK_RESPONSE"
 
-          if ! node -e 'const body = JSON.parse(process.argv[1]); process.exit(Array.isArray(body.errors) && body.errors.length > 0 ? 1 : 0)' "$ROLLBACK_RESPONSE"; then
+          # Exit 2 for an unparseable body (a non-JSON 200 — proxy intercept,
+          # empty response) vs 1 for a parsed body carrying `errors`, so the
+          # message below never claims Railway rejected a mutation it may
+          # never have actually received.
+          # ROLLBACK_CHECK_STATUS capture (not `|| true`, which would discard
+          # the exit code) so `set -e` doesn't abort the step on the non-zero
+          # codes this deliberately uses to signal "invalid JSON" vs "errors".
+          ROLLBACK_CHECK_STATUS=0
+          node -e '
+            let body;
+            try {
+              body = JSON.parse(process.argv[1]);
+            } catch {
+              process.exit(2);
+            }
+            process.exit(Array.isArray(body.errors) && body.errors.length > 0 ? 1 : 0);
+          ' "$ROLLBACK_RESPONSE" || ROLLBACK_CHECK_STATUS=$?
+
+          if [ "$ROLLBACK_CHECK_STATUS" -eq 2 ]; then
+            echo "::error::Railway's rollback response for ${PREVIOUS_DEPLOYMENT_ID} was not valid JSON; check Railway manually. Response above."
+            return 1
+          fi
+          if [ "$ROLLBACK_CHECK_STATUS" -ne 0 ]; then
             echo "::error::Railway rejected the rollback to ${PREVIOUS_DEPLOYMENT_ID}; check Railway manually. Response above."
             return 1
           fi

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -426,6 +426,22 @@ jobs:
       - name: Generate web Docker context
         run: vp run docker-context:web
 
+      # The Vercel build above passes this same var straight through with no
+      # runtime check, so a blank value there also ships silently — but that
+      # half is deleted once www is off Vercel. The GHCR image is UNGATED by
+      # WEB_DEPLOY_TARGETS (always builds, see the comment above), so this is
+      # the one guard that has to survive: without it, a missing key produces
+      # a Railway image with client analytics disabled and nothing says so.
+      - name: Require a PostHog key for the web image build
+        env:
+          NEXT_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NEXT_PUBLIC_POSTHOG_KEY:-}" ]; then
+            echo "::error::vars.NEXT_PUBLIC_POSTHOG_KEY is unset — the web image would ship with analytics disabled." >&2
+            exit 1
+          fi
+
       - name: Build and push web image
         id: build
         uses: docker/build-push-action@v7
@@ -766,6 +782,7 @@ jobs:
           service-label: web
 
       - name: Post-deploy smoke against the Railway web origin
+        id: railway-smoke
         # Runs AFTER the deploy, so it is a detector, not a gate — it can turn
         # the job red (and fire notify-failure) but can never block a deploy from
         # going out. A fail-closed deploy gate stopped production deploys for two
@@ -785,6 +802,36 @@ jobs:
         # Plain `node` executes the TypeScript directly (type stripping). The
         # script imports only node: builtins, so no workspace install is needed.
         run: node scripts/production-smoke.ts --base "$RAILWAY_WEB_ORIGIN"
+
+      # `continue-on-error` above keeps this job's own result green while
+      # Vercel is still serving www, so notify-failure's
+      # `contains(needs.*.result, 'failure')` never sees the Railway smoke
+      # failing during the confidence-building window — it would otherwise go
+      # completely silent. Post a standalone warning instead of promoting the
+      # smoke back to a hard gate (see the comment above on why it stays soft).
+      - name: Notify Discord (Railway smoke failed, Vercel still serving)
+        if: >-
+          needs.check-rollback.outputs.active != 'true'
+          && needs.resolve-web-targets.outputs.web_vercel == 'true'
+          && steps.railway-smoke.outcome == 'failure'
+        env:
+          DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          if [ -z "$DISCORD_DEPLOY_WEBHOOK" ]; then
+            echo "DISCORD_DEPLOY_WEBHOOK not set — skipping notification"
+            exit 0
+          fi
+          # URL wrapped in <…> so Discord suppresses the inline preview embed.
+          CONTENT=$(printf '⚠️ **Railway web smoke failed** on `%s` — Vercel is still serving www so this did not block the release, but the Railway container is broken ahead of the DNS flip.\n<%s>' \
+            "${COMMIT_SHA:0:7}" "$RUN_URL")
+          # --fail-with-body surfaces Discord's status + error body (e.g. 429,
+          # rotated webhook) in the log instead of failing silently. Don't let a
+          # webhook hiccup fail the job — the alert is best-effort.
+          jq -n --arg content "$CONTENT" '{content: $content, allowed_mentions: {parse: []}}' \
+            | curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d @- "$DISCORD_DEPLOY_WEBHOOK" || \
+              echo "::warning::Failed to post Discord notification (see status above)"
 
   # Deploys app.boardsesh.com — the STANDALONE Expo web export (baseUrl `/`)
   # served at the root of its own subdomain via Cloudflare Pages (project

--- a/docs/production-deploy.md
+++ b/docs/production-deploy.md
@@ -109,7 +109,8 @@ step at a time:
 2. **Dashboard rollback.** Railway → the `web` service → Deployments → pick the
    last-good deployment → Rollback. This is the same `deploymentRollback`
    GraphQL mutation the `railway-redeploy` composite action fires automatically
-   when its poll ends in `FAILED`, `CRASHED`, `REMOVED`, or times out.
+   when its poll ends in `FAILED`, `CRASHED`, `REMOVED`, `CANCELLED` (Railway's
+   status for a queued deployment a newer one superseded), or times out.
 3. **Belt-and-braces.** If the dashboard rollback isn't enough — the bad image
    is still tagged `:production` in GHCR — retag a known-good digest and
    redeploy:

--- a/scripts/__tests__/production-deploy-web-targets.test.ts
+++ b/scripts/__tests__/production-deploy-web-targets.test.ts
@@ -307,4 +307,30 @@ describe('production-deploy web deploy targets', () => {
     expect(successJob).toContain('deployed (Vercel + Railway)');
     expect(successJob).toContain('deployed (Railway)');
   });
+
+  it('fails the web image build when the PostHog key is empty', () => {
+    // The GHCR image is UNGATED by WEB_DEPLOY_TARGETS (always builds), so a
+    // missing key here would silently ship a Railway image with client
+    // analytics disabled — unlike the Vercel path, nothing else catches it.
+    const guardStep = stepNamed(buildWebJob, 'Require a PostHog key for the web image build');
+    expect(guardStep).toContain('NEXT_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}');
+    expect(guardStep).toContain('vars.NEXT_PUBLIC_POSTHOG_KEY is unset');
+    expect(guardStep).toContain('exit 1');
+    // Must run before the image build actually consumes the var.
+    expect(buildWebJob.indexOf('Require a PostHog key for the web image build')).toBeLessThan(
+      buildWebJob.indexOf('name: Build and push web image'),
+    );
+  });
+
+  it('warns Discord when the Railway smoke fails while Vercel still serves www', () => {
+    // continue-on-error keeps the job green in the dual-target window, so
+    // notify-failure's contains(needs.*.result, 'failure') never sees this —
+    // without a standalone notification a broken Railway container goes
+    // completely undetected ahead of the DNS flip.
+    expect(deployWebRailwayJob).toContain('id: railway-smoke');
+    const warnStep = stepNamed(deployWebRailwayJob, 'Notify Discord (Railway smoke failed, Vercel still serving)');
+    expect(warnStep).toContain("needs.resolve-web-targets.outputs.web_vercel == 'true'");
+    expect(warnStep).toContain("steps.railway-smoke.outcome == 'failure'");
+    expect(warnStep).toContain('DISCORD_DEPLOY_WEBHOOK');
+  });
 });

--- a/scripts/__tests__/railway-redeploy-action.test.ts
+++ b/scripts/__tests__/railway-redeploy-action.test.ts
@@ -25,6 +25,15 @@ describe('railway-redeploy rollback failure modes', () => {
     expect(actionSource).toContain('Railway rejected the rollback to');
   });
 
+  it('distinguishes an unparseable rollback response from a parsed error body', () => {
+    // A non-JSON HTTP 200 (proxy intercept, empty body) would otherwise crash
+    // the check with an uncaught SyntaxError and print the "rejected" message,
+    // falsely implying Railway received and rejected the mutation.
+    expect(actionSource).toContain('was not valid JSON');
+    expect(actionSource).toMatch(/catch\s*\{\s*process\.exit\(2\);?\s*\}/);
+    expect(actionSource).toContain('"$ROLLBACK_CHECK_STATUS" -eq 2');
+  });
+
   it('treats CANCELLED as a terminal poll status alongside FAILED/CRASHED/REMOVED', () => {
     // Without this, a cancelled deployment falls through every case branch and
     // the poll exhausts all 90 attempts (15 minutes) before rolling back.

--- a/scripts/__tests__/railway-redeploy-action.test.ts
+++ b/scripts/__tests__/railway-redeploy-action.test.ts
@@ -30,4 +30,18 @@ describe('railway-redeploy rollback failure modes', () => {
     // the poll exhausts all 90 attempts (15 minutes) before rolling back.
     expect(actionSource).toContain('FAILED|CRASHED|REMOVED|CANCELLED)');
   });
+
+  it('never lets a rollback failure abort the step before the log capture', () => {
+    // The poll step runs under `set -euo pipefail`. A bare
+    // `rollback_previous_deployment` call aborts the step immediately on the
+    // function's `return 1`, skipping the `railway logs` diagnostic capture
+    // and the terminal `exit 1` below it.
+    expect(actionSource).not.toMatch(/^\s*rollback_previous_deployment\s*$/m);
+    // Excludes the `rollback_previous_deployment() {` definition line itself.
+    const callSites = [...actionSource.matchAll(/^\s*rollback_previous_deployment(?!\(\))(.*)$/gm)];
+    expect(callSites.length).toBeGreaterThan(0);
+    for (const [, rest] of callSites) {
+      expect(rest.trim()).toBe('|| true');
+    }
+  });
 });

--- a/scripts/__tests__/railway-redeploy-action.test.ts
+++ b/scripts/__tests__/railway-redeploy-action.test.ts
@@ -1,0 +1,33 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const ACTION_PATH = '.github/actions/railway-redeploy/action.yml';
+const actionSource = readFileSync(ACTION_PATH, 'utf8');
+
+describe('railway-redeploy rollback failure modes', () => {
+  it('checks the GraphQL response body for errors, not just the HTTP status', () => {
+    // GraphQL returns HTTP 200 even when the mutation is rejected (stale
+    // deployment id, auth failure) — a bare `curl -fsS ... || echo` swallows
+    // that and leaves production on the broken deployment with no signal.
+    expect(actionSource).not.toMatch(/curl -fsS https:\/\/backboard\.railway\.com\/graphql\/v2/);
+    expect(actionSource).toContain('ROLLBACK_RESPONSE=$(curl -sS https://backboard.railway.com/graphql/v2');
+    expect(actionSource).toContain('Array.isArray(body.errors) && body.errors.length > 0');
+  });
+
+  it('fails the rollback step when the GraphQL call itself errors', () => {
+    expect(actionSource).toMatch(/if ! ROLLBACK_RESPONSE=\$\(curl[\s\S]*?\); then/);
+    expect(actionSource).toContain('Railway rollback request failed (network/HTTP error)');
+  });
+
+  it('fails the rollback step when the GraphQL body carries errors', () => {
+    expect(actionSource).toContain('Railway rejected the rollback to');
+  });
+
+  it('treats CANCELLED as a terminal poll status alongside FAILED/CRASHED/REMOVED', () => {
+    // Without this, a cancelled deployment falls through every case branch and
+    // the poll exhausts all 90 attempts (15 minutes) before rolling back.
+    expect(actionSource).toContain('FAILED|CRASHED|REMOVED|CANCELLED)');
+  });
+});

--- a/scripts/__tests__/railway-redeploy-action.test.ts
+++ b/scripts/__tests__/railway-redeploy-action.test.ts
@@ -12,13 +12,24 @@ describe('railway-redeploy rollback failure modes', () => {
     // deployment id, auth failure) — a bare `curl -fsS ... || echo` swallows
     // that and leaves production on the broken deployment with no signal.
     expect(actionSource).not.toMatch(/curl -fsS https:\/\/backboard\.railway\.com\/graphql\/v2/);
-    expect(actionSource).toContain('ROLLBACK_RESPONSE=$(curl -sS https://backboard.railway.com/graphql/v2');
+    expect(actionSource).toContain(
+      'ROLLBACK_RESPONSE=$(curl --fail-with-body -sS https://backboard.railway.com/graphql/v2',
+    );
     expect(actionSource).toContain('Array.isArray(body.errors) && body.errors.length > 0');
+  });
+
+  it('still fails on an HTTP error status, not just a bare -sS that would accept any response', () => {
+    // A 4xx/5xx with a JSON body that happens to carry no top-level `errors`
+    // field (a plain gateway/proxy error) would read as "accepted" under a
+    // bare `-sS`. `--fail-with-body` fails the curl command on the HTTP
+    // status while still writing the body to stdout for the capture below.
+    expect(actionSource).not.toMatch(/curl -sS https:\/\/backboard\.railway\.com\/graphql\/v2/);
+    expect(actionSource).toContain('curl --fail-with-body -sS https://backboard.railway.com/graphql/v2');
   });
 
   it('fails the rollback step when the GraphQL call itself errors', () => {
     expect(actionSource).toMatch(/if ! ROLLBACK_RESPONSE=\$\(curl[\s\S]*?\); then/);
-    expect(actionSource).toContain('Railway rollback request failed (network/HTTP error)');
+    expect(actionSource).toContain('Railway rollback request failed (HTTP/network error)');
   });
 
   it('fails the rollback step when the GraphQL body carries errors', () => {

--- a/scripts/railway-deployment-status.mjs
+++ b/scripts/railway-deployment-status.mjs
@@ -96,7 +96,13 @@ function isNewerThanPrevious(candidate, candidateIndex, previous) {
     return candidateIndex < previous.index;
   }
 
-  return false;
+  // Timestamps were unusable AND the previous deployment has aged out of the
+  // (10-item) deployment list entirely. It was captured as the newest
+  // deployment before the redeploy that started this poll, so anything the
+  // API is still returning must postdate it — the alternative (returning
+  // false here) never finds a "newer" deployment and exhausts every poll
+  // attempt even after the redeploy has already succeeded.
+  return true;
 }
 
 function findNewDeployment(payload, previous) {
@@ -107,11 +113,19 @@ function findNewDeployment(payload, previous) {
   const deployments = asDeploymentList(payload);
   const previousIndex = deployments.findIndex((deployment) => getDeploymentId(deployment) === previous.id);
   const previousWithIndex = { ...previous, index: previousIndex };
-  const deployment = deployments.find((candidate, index) => isNewerThanPrevious(candidate, index, previousWithIndex));
+  const candidates = deployments.filter((candidate, index) => isNewerThanPrevious(candidate, index, previousWithIndex));
 
-  if (!deployment) {
+  if (candidates.length === 0) {
     return { id: '', status: '', createdAt: '' };
   }
+
+  // Railway marks a queued deployment CANCELLED when a newer one supersedes
+  // it. If both the cancelled entry and its successor are newer than the
+  // captured previous deployment, prefer the non-cancelled one — otherwise a
+  // superseded queue entry can mask the redeploy that actually ran, and the
+  // poller would sit on CANCELLED until it times out even after the real
+  // deployment reached SUCCESS.
+  const deployment = candidates.find((candidate) => getDeploymentStatus(candidate) !== 'CANCELLED') ?? candidates[0];
 
   return {
     id: getDeploymentId(deployment),

--- a/scripts/railway-deployment-status.test.mjs
+++ b/scripts/railway-deployment-status.test.mjs
@@ -106,3 +106,39 @@ void test('treats every remaining deployment as newer once the previous one ages
     { id: 'deploy-11', status: 'SUCCESS', createdAt: '' },
   );
 });
+
+void test('picks the newest (list-first) non-cancelled candidate once the previous deployment ages out with no usable timestamp', () => {
+  const previous = { id: 'deploy-1', createdAt: '' };
+
+  // Every remaining entry counts as "newer than previous" here (see the test
+  // above), so with several candidates the CANCELLED-preference pick is what
+  // has to fall back to Railway's newest-first list order — deploy-12 (index
+  // 0) must win over deploy-11 (index 1), not the other way round.
+  assert.deepEqual(
+    findNewDeployment(
+      {
+        deployments: [
+          { id: 'deploy-12', status: 'SUCCESS', createdAt: '' },
+          { id: 'deploy-11', status: 'SUCCESS', createdAt: '' },
+        ],
+      },
+      previous,
+    ),
+    { id: 'deploy-12', status: 'SUCCESS', createdAt: '' },
+  );
+
+  // Same shape, but the newest (list-first) entry is a cancelled superseded
+  // one — the non-cancelled preference must still pick deploy-11 over it.
+  assert.deepEqual(
+    findNewDeployment(
+      {
+        deployments: [
+          { id: 'deploy-12', status: 'CANCELLED', createdAt: '' },
+          { id: 'deploy-11', status: 'SUCCESS', createdAt: '' },
+        ],
+      },
+      previous,
+    ),
+    { id: 'deploy-11', status: 'SUCCESS', createdAt: '' },
+  );
+});

--- a/scripts/railway-deployment-status.test.mjs
+++ b/scripts/railway-deployment-status.test.mjs
@@ -44,3 +44,65 @@ void test('fails explicitly when the previous Railway deployment cannot be captu
     /could not capture previous Railway deployment ID/,
   );
 });
+
+void test('prefers a non-cancelled deployment over a cancelled one that superseded it', () => {
+  const previous = capturePreviousDeployment({
+    deployments: [{ id: 'deploy-1', status: 'SUCCESS', createdAt: '2026-05-31T09:00:00.000Z' }],
+  });
+
+  // Railway can list a cancelled superseded deployment ahead of the one that
+  // actually ran (e.g. it was queued first, then bumped). Picking the first
+  // "newer than previous" match by list order alone would get stuck reporting
+  // CANCELLED forever even though deploy-3 already succeeded.
+  assert.deepEqual(
+    findNewDeployment(
+      {
+        deployments: [
+          { id: 'deploy-2', status: 'CANCELLED', createdAt: '2026-05-31T10:01:00.000Z' },
+          { id: 'deploy-3', status: 'SUCCESS', createdAt: '2026-05-31T10:00:00.000Z' },
+          { id: 'deploy-1', status: 'SUCCESS', createdAt: '2026-05-31T09:00:00.000Z' },
+        ],
+      },
+      previous,
+    ),
+    { id: 'deploy-3', status: 'SUCCESS', createdAt: '2026-05-31T10:00:00.000Z' },
+  );
+});
+
+void test('reports CANCELLED when every deployment newer than previous was cancelled', () => {
+  const previous = capturePreviousDeployment({
+    deployments: [{ id: 'deploy-1', status: 'SUCCESS', createdAt: '2026-05-31T09:00:00.000Z' }],
+  });
+
+  assert.deepEqual(
+    findNewDeployment(
+      {
+        deployments: [
+          { id: 'deploy-2', status: 'CANCELLED', createdAt: '2026-05-31T10:00:00.000Z' },
+          { id: 'deploy-1', status: 'SUCCESS', createdAt: '2026-05-31T09:00:00.000Z' },
+        ],
+      },
+      previous,
+    ),
+    { id: 'deploy-2', status: 'CANCELLED', createdAt: '2026-05-31T10:00:00.000Z' },
+  );
+});
+
+void test('treats every remaining deployment as newer once the previous one ages out of the list with no usable timestamp', () => {
+  const previous = { id: 'deploy-1', createdAt: '' };
+
+  // previous.id is not present anywhere in this 10-item page (it aged out),
+  // and createdAt is empty on both sides, so neither the timestamp nor the
+  // index comparison can settle it. Returning false here (the old behaviour)
+  // means the poll never finds a "newer" deployment and exhausts every
+  // attempt even after the redeploy already succeeded.
+  assert.deepEqual(
+    findNewDeployment(
+      {
+        deployments: [{ id: 'deploy-11', status: 'SUCCESS', createdAt: '' }],
+      },
+      previous,
+    ),
+    { id: 'deploy-11', status: 'SUCCESS', createdAt: '' },
+  );
+});


### PR DESCRIPTION
## Summary

Fixes reliability gaps in the Railway redeploy/rollback mechanism found in review:

- **Silent rollback failure**: `railway-redeploy/action.yml`'s rollback curl only checked the HTTP status (`-fsS`). GraphQL returns 200 even when the mutation is rejected, so a rejected rollback (stale deployment id, auth failure) exited 0 with production still on the broken deployment. Now the response body's `errors` field is checked explicitly and a rejection is logged with `::error::` and returns non-zero.
- **CANCELLED status caused a 15-minute timeout**: the poll's `case` statement didn't handle `CANCELLED` (Railway's status when a newer deployment supersedes a queued one), so it fell through all 90 attempts before ever rolling back. `CANCELLED` is now a terminal status alongside `FAILED|CRASHED|REMOVED`. `railway-deployment-status.mjs`'s `findNewDeployment` also now prefers any non-cancelled candidate over a cancelled one when both are newer than the captured previous deployment, so a superseded queue entry can't mask a deployment that already reached `SUCCESS`.
- **Timestamp fallback broke on empty `createdAt`**: `isNewerThanPrevious` returned `false` for every candidate when `createdAt` was empty and the previous deployment had aged out of the 10-item deployment list (`previousIndex === -1`), silently exhausting all 90 poll attempts even after a successful deploy. It now returns `true` in that case — the previous deployment was captured as the newest before this redeploy, so anything the API still returns must postdate it.
- **Missing PostHog key guard for the Docker/Railway build**: the Vercel path already surfaces a build-time failure mode for this class of bug elsewhere in the workflow; the GHCR/Railway image build (which is unconditional — it always runs regardless of `WEB_DEPLOY_TARGETS`) had no equivalent guard, so a missing `vars.NEXT_PUBLIC_POSTHOG_KEY` would silently ship an image with analytics disabled. Added a hard-fail step before the image build.
- **No signal during the dual-target smoke window**: `deploy-web-railway`'s smoke uses `continue-on-error` while Vercel is also a target (intentionally — it's a detector, not a gate, and a fail-closed gate stopped production deploys for two days once already). That also means `notify-failure`'s `contains(needs.*.result, 'failure')` never sees it fail. Added a standalone Discord warning for exactly that case, without turning the smoke into a hard gate.
- **Test coverage**: added unit tests for the `findNewDeployment`/`isNewerThanPrevious` fixes (CANCELLED preference, all-cancelled, aged-out-index) and structural tests asserting the composite action checks GraphQL errors and handles `CANCELLED`, plus the new PostHog guard and Discord-warning steps in the workflow.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 3/5 — touches the production deploy rollback path (Railway redeploy/poll/rollback for both web and backend services) and the production-deploy workflow; no BLE, OTA, or migration involved. Verified with `node --test scripts/railway-deployment-status.test.mjs` and `vp test run` on the affected workflow-contract test files, all passing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KooYyMoednGHsZTkrjXqc4)_