### PR TITLE
fix(ci): add the .ts extension mobile-fingerprint-match.ts needs under node ESM

### DIFF
--- a/scripts/mobile-fingerprint-match.test.ts
+++ b/scripts/mobile-fingerprint-match.test.ts
@@ -1,5 +1,7 @@
 /// <reference types="node" />
 
+import { execFileSync } from 'node:child_process';
+
 import { describe, expect, it } from 'vitest';
 
 import { fingerprintPrefixMatches, normalizeFingerprint } from './mobile-fingerprint-match';
@@ -44,5 +46,23 @@ describe('normalizeFingerprint', () => {
     expect(normalizeFingerprint(SHIPPED.toUpperCase())).toBe('532b90278dac');
     expect(normalizeFingerprint('532b90278da')).toBeNull();
     expect(normalizeFingerprint('')).toBeNull();
+  });
+});
+
+// Vitest resolves `./lib/release-tags` (no extension) through its own bundler-style
+// resolver, so the tests above pass even when the specifier is missing the `.ts`
+// extension Node's native ESM loader requires. The production OTA workflow invokes
+// this file with plain `node --experimental-strip-types`, which has no such
+// fallback — that gap shipped a broken republish job (ERR_MODULE_NOT_FOUND) that
+// every unit test above stayed green through. Spawn it exactly as the workflow does.
+describe('CLI invocation (node --experimental-strip-types)', () => {
+  it('resolves its imports and prints a verdict, matching the workflow invocation', () => {
+    const scriptPath = new URL('./mobile-fingerprint-match.ts', import.meta.url).pathname;
+    const stdout = execFileSync(
+      process.execPath,
+      ['--experimental-strip-types', scriptPath, '--resolved', SHIPPED, '--expected', SHIPPED],
+      { encoding: 'utf8' },
+    );
+    expect(stdout.trim()).toBe('mismatch=false');
   });
 });

--- a/scripts/mobile-fingerprint-match.ts
+++ b/scripts/mobile-fingerprint-match.ts
@@ -12,7 +12,7 @@
 // Invoked from YAML the same way scripts/ota-preview-cleanup.ts is
 // (`node --experimental-strip-types`).
 
-import { SHORT_FP_LENGTH } from './lib/release-tags';
+import { SHORT_FP_LENGTH } from './lib/release-tags.ts';
 
 /**
  * True when both fingerprints agree on their first {@link SHORT_FP_LENGTH} hex


### PR DESCRIPTION
## Summary

The production OTA workflow's post-native-build republish job (`mobile-ota-production.yml`, `expect_fingerprint` step) has failed on every run since it was introduced — see runs [33485607291](https://github.com/boardsesh/boardsesh/actions/runs/33485607291) and [33486100797](https://github.com/boardsesh/boardsesh/actions/runs/33486100797), both failing identically for iOS and Android.

Root cause: `node --experimental-strip-types scripts/mobile-fingerprint-match.ts` throws `ERR_MODULE_NOT_FOUND` resolving `./lib/release-tags`, because Node's native ESM loader requires an explicit extension on relative import specifiers. Vitest's own resolver doesn't have that requirement, which is exactly why every existing unit test for this file (which imports the module directly, not via the CLI) stayed green through the breakage.

Fix: add the `.ts` extension to the import in `scripts/mobile-fingerprint-match.ts`, which Node's type-stripping mode resolves correctly. Verified by reproducing the exact failure locally with the same `node --experimental-strip-types` invocation the workflow uses, confirming it's fixed, and confirming the fix regresses back to the original error when reverted.

Also added a regression test that spawns the script exactly as the workflow does (mirroring the existing pattern in `scripts/ota-preview-cleanup.test.ts`), so this class of bug — correct under the test runner, broken under the real `node` invocation — can't silently ship again.

No functional/behavioral change to the fingerprint-comparison logic itself; any successful platform's prior OTA publish remains live, and no rollback was needed.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.
2. Next native build's automatic republish job succeeds instead of skipping iOS/Android publish.

## Risk

Risk: 2/5 — one-line import fix in a CI-only script, covered by a new regression test that reproduces the exact failure mode.


---
_Generated by [Claude Code](https://claude.ai/code/session_012xSuGppFSBDNFLzK9hr4az)_