### PR TITLE
fix(mobile): resolve a null dispatch flag the same way as an unresolved one

### DIFF
--- a/packages/mobile/src/hooks/use-observe-runtime-config.ts
+++ b/packages/mobile/src/hooks/use-observe-runtime-config.ts
@@ -18,6 +18,14 @@ import { configureObserve } from '../lib/observe-runtime';
  * that never reaches PostHog keeps reporting instead of going quiet forever.
  *
  * A no-op when no runtime is registered (node tests, Expo web).
+ *
+ * On a cold start this re-applies the same defaults `observe-bootstrap.ts`
+ * already set, because PostHog has not resolved yet. That second call is
+ * deliberate rather than something to optimise away: skipping it would mean
+ * branching on "are these the defaults", and the whole point of this effect is
+ * that it is the single place the runtime settings come from once flags exist.
+ * The call is idempotent and passes the same integrations constant, so it costs
+ * one no-op configure per launch.
  */
 export function useObserveRuntimeConfig(): void {
   const flags = useFeatureFlags();

--- a/packages/mobile/src/lib/__tests__/observe-config.test.ts
+++ b/packages/mobile/src/lib/__tests__/observe-config.test.ts
@@ -48,6 +48,7 @@ describe('resolveObserveDispatchEnabled', () => {
     // A device that never reaches PostHog must keep reporting rather than go
     // permanently quiet — the failure mode docs/feature-flags.md calls out.
     expect(resolveObserveDispatchEnabled(undefined)).toBe(true);
+    expect(resolveObserveDispatchEnabled(null)).toBe(true);
   });
 
   it('disables only on an explicit false', () => {

--- a/packages/mobile/src/lib/observe-config.ts
+++ b/packages/mobile/src/lib/observe-config.ts
@@ -82,7 +82,10 @@ function clampSampleRate(value: number): number {
  * "false" into it is the wrong way round for a kill switch to fail.
  */
 export function resolveObserveDispatchEnabled(raw: unknown): boolean {
-  if (raw === undefined) return OBSERVE_DEFAULT_DISPATCHING_ENABLED;
+  // `null` alongside `undefined` for the same reason parseObserveSampleRate
+  // takes both: the flag bag never holds one today, and the two must not drift
+  // apart if the shipped default ever flips to off.
+  if (raw === undefined || raw === null) return OBSERVE_DEFAULT_DISPATCHING_ENABLED;
   if (raw === false || raw === 'false') return false;
   return true;
 }


### PR DESCRIPTION
## Summary

Two review points from #5038 that arrived after it was merged. Both cosmetic — no
behaviour changes today.

`resolveObserveDispatchEnabled` guarded `undefined` but let `null` fall through to
"enabled". Same outcome right now, because the shipped default *is* enabled — but
`parseObserveSampleRate` sitting next to it already handles both, and the two would
diverge the moment that default flipped. Handled explicitly and covered by a test.

Also wrote down why `Observe.configure` runs twice on a cold start, since it looks like a
bug and isn't: the effect re-applies the defaults the bootstrap already set, because
PostHog hasn't resolved yet. Skipping it would mean branching on "are these the
defaults", and the point of that effect is to be the single place the runtime settings
come from once flags exist. It's idempotent and passes the same integrations constant, so
it costs one no-op configure per launch.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 1/5 — a null guard that changes no current behaviour, plus a comment. JS-only, so
it rides OTA.
