### PR TITLE
feat(repo): flip www.boardsesh.com to the Railway web service

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -39,23 +39,32 @@ One-time setup order:
 
 ## www.boardsesh.com DNS, and the origin flip
 
-`www.boardsesh.com` is a proxied record pointing at Vercel. The repo manages
-**only its orange cloud** today:
+`www.boardsesh.com` is a proxied CNAME to the Railway `boardsesh-web` service
+(#4655, epic #4648), fully managed by the repo:
 
 ```ts
-{ management: 'proxied-only', name: WWW_HOSTNAME, proxied: true }
+{
+  management: 'full',
+  name: WWW_HOSTNAME,
+  type: 'CNAME',
+  content: 'nefrfe3c.up.railway.app',
+  ttl: 1,
+  proxied: true,
+}
 ```
 
-Same ownership boundary as `ws`: the target stays whatever the dashboard says,
-and a dry-run against the live (already proxied) record reports zero drift. The
-entry exists so the Vercel → Railway origin flip (#4655, epic #4648) is a
-reviewable diff rather than a dashboard click.
-
-The tool cannot read the current target for you and neither can `dig` — a
-proxied record answers with Cloudflare anycast addresses, so the Vercel CNAME is
-only visible inside the dashboard. Do not guess it.
+It started life as `management: 'proxied-only'` — same boundary as `ws`, target
+left to the dashboard. A proxied record answers with Cloudflare anycast
+addresses, so that target was not readable from outside the dashboard (`dig`
+included); that was the point — it let this entry land as a reviewable no-op
+before the flip PR took ownership of `type`/`content`/`ttl` too and PATCHed the
+record from the Vercel CNAME onto the Railway target above.
 
 ### Flipping www to a new origin
+
+This is the general playbook for pointing www at a new origin. #4655
+(2026-09-01) exercised it once, moving www from Vercel to Railway; follow the
+same steps for any future origin change.
 
 The flip is step 3 of the cut-over sequence in
 [production-deploy.md](./production-deploy.md#cut-over-sequence): only after

--- a/docs/production-deploy.md
+++ b/docs/production-deploy.md
@@ -100,6 +100,89 @@ step at a time:
    `production-deploy.yml` (the Vercel half of `build-web`, and `deploy-web`),
    set `WEB_DEPLOY_TARGETS=railway`, and decommission the Vercel project.
 
+### www → Railway cut-over (#4655, 2026-09-01)
+
+This is step 3 of the sequence above, carried out by the flip PR. It moves
+production traffic for www.boardsesh.com from Vercel to the Railway
+`boardsesh-web` service. Steps 1 and 2 were already done ahead of the flip:
+`WEB_DEPLOY_TARGETS` has been `vercel,railway` since 09:35Z, and the
+post-deploy smoke has passed against `RAILWAY_WEB_ORIGIN` twice.
+
+#### Pre-flight evidence (2026-09-01)
+
+| Check                        | Result                                                                                                                                                                                                                                                                                                                        |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `scripts/production-smoke.ts` | 8 passed, 0 failed, 2 skipped (kiosk and embed fixtures unset) against the Railway origin. Run twice: manually, and by the `deploy-web-railway` job on production run 33497302050.                                                                                                                                          |
+| `/api/auth/csrf` cookies      | Byte-identical to www: `__Host-next-auth.csrf-token; Path=/; HttpOnly; Secure; SameSite=Lax` and `__Secure-next-auth.callback-url; Domain=.boardsesh.com; Path=/; HttpOnly; Secure; SameSite=None`.                                                                                                                          |
+| Page and API parity           | `/`, `/robots.txt`, `/sitemap.xml`, `/sitemaps/static.xml`, `/auth/login`, `/gyms`, `/docs`, `/legal`, `/es`, `/de/gyms`, `/api/v1/kilter/grades`, `/api/v1/tension/grades`, `/opengraph-image`, `/api/og/setter?username=nobody`, `/.well-known/apple-app-site-association`, `/.well-known/assetlinks.json` — all 200, all byte-identical to www. |
+| Boot log                      | Clean. No canonical-origin or `NEXTAUTH_URL` warnings.                                                                                                                                                                                                                                                                        |
+| Dual deploy                   | Green since `WEB_DEPLOY_TARGETS=vercel,railway` took effect at 09:35Z.                                                                                                                                                                                                                                                        |
+
+#### Merge gates
+
+The flip PR must not merge until every one of these is checked:
+
+1. Web-only secrets are pasted onto the `boardsesh-web` Railway service, with
+   Vercel's exact values where continuity depends on it: `NEXTAUTH_SECRET` and
+   `CRON_SECRET`, plus `GOOGLE_CLIENT_SECRET`, `APPLE_ID`, `APPLE_SECRET`,
+   `IRON_SESSION_PASSWORD`, `EMAIL_VERIFICATION_ENABLED`, and
+   `BOARDSESH_EXPO_WEB_ORIGIN`. Check by hitting `/api/auth/providers` on the
+   Railway origin and confirming it lists both `apple` and `google`.
+2. #5027, the apex → www redirect, is merged and applied. Verify with
+   `curl -sI https://boardsesh.com/x?y=1`: it must answer 301 to
+   `https://www.boardsesh.com/x?y=1` with a `cf-ray` header.
+3. The Cloudflare API token `deploy-cloudflare` uses carries
+   `Zone → Dynamic Redirect → Edit`, the scope #5027's redirect rule needs.
+4. A maintainer has signed in on www and confirmed the session survives the
+   flip. Before the flip the only available check is that `NEXTAUTH_SECRET`
+   matches Vercel's value exactly (gate 1) — a live cross-host cookie check
+   isn't possible pre-flip, because the Railway origin and www don't share a
+   session until DNS actually points there.
+5. A low-traffic window is picked for the merge. The #1909 playbook's answer
+   is Tuesday.
+6. `WEB_DEPLOY_TARGETS` stays `vercel,railway` for seven days after the flip
+   — it must not be set to `railway` early.
+
+#### Flip procedure
+
+1. Merge the flip PR only once every gate above is checked.
+2. `deploy-cloudflare` PATCHes the `www.boardsesh.com` DNS record onto the
+   Railway CNAME target on the next `production-deploy.yml` run.
+3. Within a few minutes, `curl -sI https://www.boardsesh.com/` stops
+   returning `x-vercel-id` and instead shows Railway's edge headers.
+4. Purge the Cloudflare cache from the dashboard (Caching → Configuration →
+   Purge Everything). There is no purge tooling and the CI token has no
+   `Zone.Cache Purge` scope — see [cloudflare.md](./cloudflare.md).
+5. Watch, for at least the first hour: Sentry error rate, PostHog session
+   counts, Cloudflare 5xx rate and cache hit rate, the Railway
+   `boardsesh-web` service's CPU, RSS and restart count, `pg_stat_activity`
+   web connections (stay at or under 10), and `/api/health`.
+
+#### Seven-day warm window
+
+Keep `WEB_DEPLOY_TARGETS=vercel,railway` for seven days after the flip.
+Vercel keeps deploying every commit and stays warm as the rollback origin even
+though it no longer receives traffic, matching step 4 of the cut-over
+sequence above.
+
+#### Rollback
+
+For a bad Railway image, use the [rollback runbook](#rollback-runbook-web-on-railway)
+below. For the DNS flip itself: `git revert` the flip PR, and the next
+`deploy-cloudflare` run converges the record back to the Vercel CNAME on
+record in the PR body. If `deploy-cloudflare` is itself unavailable, make the
+same change by hand in the Cloudflare dashboard: set www's CNAME back to the
+Vercel target noted in the flip PR.
+
+#### After seven clean days
+
+1. Cancel the Vercel Pro subscription and the Speed Insights add-on.
+2. Delete `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` from the
+   Production environment.
+3. Land the scrub PR (#4656): set `WEB_DEPLOY_TARGETS=railway` and delete the
+   Vercel half of `build-web` and the `deploy-web` job, matching step 5 of
+   the cut-over sequence above.
+
 ## Rollback runbook (web on Railway)
 
 1. **Hold.** Set `WEB_DEPLOY_TARGETS=none` so further pushes to `main` stop

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -13,14 +13,16 @@
 //    must bypass the cache.
 //    The manual runbook this replaces lives in docs/og-climb.md.
 //
-// 2. www.boardsesh.com is the Vercel-backed marketing/SEO surface, and the two rules
-//    below are cost controls for it (#4650, epic #4648). Measured 2026-08-25:
-//    ~442,600 Vercel function invocations/day, of which /api/internal/board-render
-//    was ~215,600 and the climb-view page ~203,900, against a published sitemap of
+// 2. www.boardsesh.com is the marketing/SEO surface. It moved from Vercel to the
+//    Railway web service in #4655 (epic #4648); the two rules below are cost
+//    controls dating from the Vercel era (#4650) and still apply now that
+//    Railway sits behind the same proxy. Measured 2026-08-25 against Vercel:
+//    ~442,600 function invocations/day, of which /api/internal/board-render was
+//    ~215,600 and the climb-view page ~203,900, against a published sitemap of
 //    only ~60k URLs and ~2,000 homepage hits. See docs/cloudflare.md.
-//    Its DNS record is managed here too — proxy flag only, for now — so the
-//    Vercel → Railway origin flip is a reviewable diff rather than a dashboard
-//    click (#4655).
+//    Its DNS record is fully managed here — type, content, TTL and the proxy
+//    flag — so a future origin change is a reviewable diff rather than a
+//    dashboard click.
 //
 // 3. assets.boardsesh.com is the public, DNS-only custom domain for the Tigris
 //    static-assets bucket. Unlike ws, this tool owns the record's complete shape
@@ -41,8 +43,21 @@ export const ASSETS_CNAME_TARGET = 'boardsesh-static-assets.t3.tigrisbucket.io';
 /** Path prefix whose responses are immutable (`Cache-Control: … immutable`, 1y) and safe to edge-cache. */
 export const OG_PATH_PREFIX = '/og/';
 
-/** The Vercel-backed www origin whose crawl cost these rules exist to cap. */
+/** The marketing/SEO www origin whose crawl cost the rules below exist to cap. */
 export const WWW_HOSTNAME = 'www.boardsesh.com';
+
+/**
+ * Railway's required CNAME target for the `www.boardsesh.com` custom domain,
+ * registered on the `boardsesh-web` service
+ * (id `c60e7c36-9080-4968-8370-381ec8804b9c`), origin
+ * `https://boardsesh-web-production.up.railway.app`. This is the value Railway
+ * printed when the custom domain was added — it is not derivable from the
+ * service name — and is the only source of truth for it. Changing it here
+ * without first re-registering the domain in Railway breaks TLS termination
+ * for www (the zone's SSL mode is Full (strict); Railway serves a cert for
+ * this host only once DNS resolves to it).
+ */
+export const WWW_RAILWAY_CNAME_TARGET = 'nefrfe3c.up.railway.app';
 
 /** The zone apex. Everything on it redirects to WWW_HOSTNAME. */
 export const APEX_HOSTNAME = ZONE_NAME;
@@ -449,15 +464,21 @@ export const desiredCloudflareState: CloudflareDesiredState = {
         flatten_cname: false,
       },
     },
-    // www is proxied today and points at Vercel, by hand, in the dashboard. This
-    // repo takes over only the orange cloud for now, which is a no-op against
-    // the live record and gives the Vercel → Railway origin flip (#4655, epic
-    // #4648) a single line to change instead of a dashboard click. See the
-    // "Flipping www to a new origin" section of docs/cloudflare.md for the exact
-    // edit and its rollback.
+    // www points at the Railway web service (#4655, epic #4648). It landed here
+    // first as proxy-only, orange-cloud-only ownership of a record that still
+    // pointed at Vercel; this entry is the flip that took ownership of the
+    // target too and PATCHed it onto Railway. The apex → www redirect (#5027)
+    // must already be live before this record is applied, or the apex briefly
+    // has nothing behind it. No `settings`: Cloudflare always flattens a
+    // proxied CNAME, so flatten_cname is not a field this record can own (see
+    // FullyManagedDnsRecordDesired.settings). See the "Flipping www to a new
+    // origin" section of docs/cloudflare.md for the full mechanics and rollback.
     {
-      management: 'proxied-only',
+      management: 'full',
       name: WWW_HOSTNAME,
+      type: 'CNAME',
+      content: WWW_RAILWAY_CNAME_TARGET,
+      ttl: 1,
       proxied: true,
     },
     // The apex is originless: it exists so Cloudflare terminates the request and

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -20,6 +20,7 @@ import {
   DYNAMIC_REDIRECT_RULE_PHASE,
   RATE_LIMIT_RULE_PHASE,
   WWW_HOSTNAME,
+  WWW_RAILWAY_CNAME_TARGET,
   WS_HOSTNAME,
   desiredCloudflareState,
 } from '../infra/cloudflare/config';
@@ -63,7 +64,7 @@ function requiredFullyManagedDnsRecord(name: string): FullyManagedDnsRecordDesir
 
 const wsDnsRecord = requiredDnsRecord(WS_HOSTNAME);
 const assetsDnsRecord = requiredFullyManagedDnsRecord(ASSETS_HOSTNAME);
-const wwwDnsRecord = requiredDnsRecord(WWW_HOSTNAME);
+const wwwDnsRecord = requiredFullyManagedDnsRecord(WWW_HOSTNAME);
 const apexDnsRecord = requiredFullyManagedDnsRecord(APEX_HOSTNAME);
 /** The og cache rule — the one the pre-existing cases in this file were written against. */
 const ogCacheRule = desired.cacheRules[0];
@@ -80,15 +81,15 @@ function liveDnsRecord(overrides: Partial<LiveDnsRecord> = {}): LiveDnsRecord {
   };
 }
 
-/** www as Cloudflare returns it today: a proxied CNAME to Vercel. */
+/** www as Cloudflare returns it once converged: a proxied CNAME to the Railway web service (#4655). */
 function liveWwwDnsRecord(overrides: Partial<LiveDnsRecord> = {}): LiveDnsRecord {
   return {
     id: 'www-dns-record-id',
     name: WWW_HOSTNAME,
-    type: 'CNAME',
-    content: 'cname.vercel-dns.com',
-    ttl: 1,
-    proxied: true,
+    type: wwwDnsRecord.type,
+    content: wwwDnsRecord.content,
+    ttl: wwwDnsRecord.ttl,
+    proxied: wwwDnsRecord.proxied,
     ...overrides,
   };
 }
@@ -504,63 +505,73 @@ describe('assets.boardsesh.com desired state', () => {
 });
 
 describe('www.boardsesh.com under Cloudflare management (#4655)', () => {
-  /** The exact entry the origin-flip PR replaces the proxy-only one with. */
-  const flippedToRailway: FullyManagedDnsRecordDesired = {
-    management: 'full',
-    name: WWW_HOSTNAME,
-    type: 'CNAME',
-    content: 'web-production.up.railway.app',
-    ttl: 1,
-    proxied: true,
-  };
-
-  it('owns only the proxy flag today, exactly like ws', () => {
-    // The live record is already an orange-clouded CNAME to Vercel, so this
-    // entry is a no-op on apply. Its job is to give the origin flip a line to
-    // change instead of a dashboard click.
+  it('is a fully managed proxied CNAME to the Railway web service', () => {
+    // Landed here first as `management: 'proxied-only'` (target left to the
+    // dashboard, same boundary as ws) so the origin flip could be a reviewable
+    // diff instead of a dashboard click. This PR is that flip: `management: 'full'`
+    // now owns type, content and TTL too.
     expect(wwwDnsRecord).toEqual({
-      management: 'proxied-only',
-      name: 'www.boardsesh.com',
+      management: 'full',
+      name: WWW_HOSTNAME,
+      type: 'CNAME',
+      content: WWW_RAILWAY_CNAME_TARGET,
+      ttl: 1,
       proxied: true,
     });
   });
 
-  it('is zero drift against the live proxied record, whatever it points at', () => {
-    expect(diffDnsRecord(wwwDnsRecord, liveWwwDnsRecord())).toBeNull();
-    // A proxied record answers with Cloudflare IPs, so its real target cannot be
-    // read from outside the dashboard. The tool must not claim to own it yet.
-    expect(diffDnsRecord(wwwDnsRecord, liveWwwDnsRecord({ content: 'something.else.example' }))).toBeNull();
-    expect(diffDnsRecord(wwwDnsRecord, liveWwwDnsRecord({ type: 'A', content: '76.76.21.21' }))).toBeNull();
+  it('is a proxied CNAME to a Railway host, not Vercel', () => {
+    // Read directly off the desired state rather than a fixture, so pointing
+    // `content` back at a Vercel target — by accident, or a bad revert — fails
+    // this test instead of passing silently.
+    expect(wwwDnsRecord.type).toBe('CNAME');
+    expect(wwwDnsRecord.proxied).toBe(true);
+    expect(wwwDnsRecord.content).toMatch(/\.up\.railway\.app$/);
   });
 
-  it('plans the orange cloud back on if www is ever grey-clouded', () => {
-    const change = diffDnsRecord(wwwDnsRecord, liveWwwDnsRecord({ proxied: false }));
-    expect(change?.dnsName).toBe(WWW_HOSTNAME);
-    expect(change?.summary).toContain('proxied false → true');
-  });
-
-  it('fails closed instead of inventing a www record when it is missing', () => {
-    expect(() => diffDnsRecord(wwwDnsRecord, null)).toThrow('proxy-only managed');
-  });
-
-  it('accepts the proxied-CNAME shape the origin flip switches this entry to', () => {
-    // The whole point of landing www here first: `management: 'full'` has to be
-    // able to express a PROXIED CNAME, or the flip PR would still be a dashboard
-    // click. Owning `content` is what makes the flip reviewable and revertable.
-    expect(fullyManagedDnsBody(flippedToRailway)).toEqual({
+  it('sends the exact CNAME body Cloudflare needs, without a flatten_cname setting', () => {
+    // `management: 'full'` has to be able to express a PROXIED CNAME, or the
+    // flip would still be a dashboard click. Owning `content` is what makes it
+    // reviewable and revertable.
+    expect(fullyManagedDnsBody(wwwDnsRecord)).toEqual({
       type: 'CNAME',
       name: WWW_HOSTNAME,
-      content: 'web-production.up.railway.app',
+      content: WWW_RAILWAY_CNAME_TARGET,
       ttl: 1,
       proxied: true,
     });
     // `settings` is omitted, not sent as false: Cloudflare always flattens a
     // proxied CNAME, so flatten_cname is not ours to set on this record.
-    expect('settings' in fullyManagedDnsBody(flippedToRailway)).toBe(false);
+    expect('settings' in fullyManagedDnsBody(wwwDnsRecord)).toBe(false);
+  });
 
-    const change = diffDnsRecord(flippedToRailway, liveWwwDnsRecord());
-    expect(change?.detail).toContain('content cname.vercel-dns.com → web-production.up.railway.app');
-    expect(change?.detail).not.toContain('flatten_cname');
+  it('is zero drift once the live record already matches Railway', () => {
+    expect(diffDnsRecord(wwwDnsRecord, liveWwwDnsRecord())).toBeNull();
+  });
+
+  it('plans the flip when the live record still points at Vercel', () => {
+    // What `deploy-cloudflare` actually does on merge: the zone still answers
+    // with the Vercel CNAME until the apply PATCHes it onto Railway.
+    const change = diffDnsRecord(wwwDnsRecord, liveWwwDnsRecord({ content: 'cname.vercel-dns.com' }));
+    expect(change?.summary).toContain('managed fields differ — will update');
+    expect(change?.detail).toContain(`content cname.vercel-dns.com → ${WWW_RAILWAY_CNAME_TARGET}`);
+  });
+
+  it('plans the orange cloud back on if www is ever grey-clouded', () => {
+    const change = diffDnsRecord(wwwDnsRecord, liveWwwDnsRecord({ proxied: false }));
+    expect(change?.dnsName).toBe(WWW_HOSTNAME);
+    expect(change?.summary).toContain('managed fields differ — will update');
+    expect(change?.detail).toContain('proxied false → true');
+  });
+
+  it('plans creation of the www record if it is ever missing', () => {
+    const change = diffDnsRecord(wwwDnsRecord, null);
+    expect(change).toMatchObject({
+      resource: 'dns',
+      dnsName: WWW_HOSTNAME,
+      summary: expect.stringContaining('missing — will create'),
+    });
+    expect(change?.detail).toContain(WWW_RAILWAY_CNAME_TARGET);
   });
 
   it('does not put a proxied CNAME behind the zone-wide flattening guard', () => {
@@ -568,7 +579,7 @@ describe('www.boardsesh.com under Cloudflare management (#4655)', () => {
     // to stay visible. A proxied record is flattened by Cloudflare no matter
     // what, so a zone with "Flatten all CNAMEs" on must not fail the www apply.
     const wwwOnly = {
-      dnsRecords: [flippedToRailway],
+      dnsRecords: [wwwDnsRecord],
       cacheRules: [],
       wafRules: [],
       rateLimitRules: [],
@@ -576,7 +587,7 @@ describe('www.boardsesh.com under Cloudflare management (#4655)', () => {
       ssl: desired.ssl,
     };
     const flattenedZone: LiveState = {
-      dnsRecords: { [WWW_HOSTNAME]: liveWwwDnsRecord({ content: flippedToRailway.content }) },
+      dnsRecords: { [WWW_HOSTNAME]: liveWwwDnsRecord() },
       rules: emptyRules(),
       sslMode: 'strict',
       flattenAllCnames: true,


### PR DESCRIPTION
⚠️ Merging this PR moves production traffic. Stacked on #5027 — do not merge before it.

## Summary

Changes `www.boardsesh.com`'s Cloudflare DNS record from proxy-only management of a Vercel-pointed CNAME to full management of a proxied CNAME onto the Railway `boardsesh-web` service (`c60e7c36-9080-4968-8370-381ec8804b9c`, origin `https://boardsesh-web-production.up.railway.app`, Railway CNAME target `nefrfe3c.up.railway.app`). Merging causes `deploy-cloudflare` to PATCH the live record on its next run, moving production web traffic from Vercel to Railway.

The maintainer must fill in before merging: **the current Vercel CNAME target for `www.boardsesh.com`**, noted from the Cloudflare dashboard (a proxied record can't be read from outside, so this can't be captured automatically) — record it here so the rollback path is unambiguous:

- Current Vercel CNAME target: `___________` (fill in before merge)

## Merge gates

- [ ] Web-only secrets pasted onto `boardsesh-web` on Railway, matching Vercel's exact values where continuity depends on it: `NEXTAUTH_SECRET`, `CRON_SECRET`, `GOOGLE_CLIENT_SECRET`, `APPLE_ID`, `APPLE_SECRET`, `IRON_SESSION_PASSWORD`, `EMAIL_VERIFICATION_ENABLED`, `BOARDSESH_EXPO_WEB_ORIGIN`. Check: `/api/auth/providers` on the Railway origin lists both `apple` and `google`.
- [ ] #5027 merged and applied — apex 301 verified: `curl -sI https://boardsesh.com/x?y=1` → 301 to `https://www.boardsesh.com/x?y=1` with `cf-ray` present.
- [ ] Cloudflare API token has `Zone → Dynamic Redirect → Edit` (needed by #5027's redirect rule).
- [ ] A maintainer has signed in on www and confirmed the session survives the flip. Pre-flip, the only available check is `NEXTAUTH_SECRET` parity (gate 1) — a live cross-host cookie check isn't possible until DNS actually points at Railway.
- [ ] Low-traffic window chosen for the merge (the #1909 playbook says Tuesday).
- [ ] `WEB_DEPLOY_TARGETS` stays `vercel,railway` for 7 days after the flip — do not set it to `railway` early.

Full pre-flight evidence, the flip procedure, what to watch, and the after-7-days checklist: `docs/production-deploy.md` (new "www → Railway cut-over" section).

Closes #4655
Part of #4648

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.
2. After merge: `curl -sI https://www.boardsesh.com/` → no `x-vercel-id`, `cf-ray` present, 200.
3. Sign in on www → session still valid after the flip.

## Risk

Risk: 5/5 — production origin change for www; rollback is a git revert (or the dashboard CNAME).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QMRRaT7Jpq2KC6nzDLej48