### PR TITLE
fix(ci): unred main's full-repo lint after #5031

### DIFF
--- a/scripts/mobile-embedded-commit-time-check.test.ts
+++ b/scripts/mobile-embedded-commit-time-check.test.ts
@@ -43,7 +43,10 @@ function createTemporaryDir(): string {
   return dir;
 }
 
-function git(cwd: string, args: string[], env: NodeJS.ProcessEnv = {}): void {
+// Record rather than NodeJS.ProcessEnv: that type requires NODE_ENV, so an env
+// literal naming only the git variables is a TS2741 that only the full-repo,
+// type-aware lint sees.
+function git(cwd: string, args: string[], env: Record<string, string | undefined> = {}): void {
   execFileSync('git', args, { cwd, env: { ...process.env, ...env }, stdio: 'ignore' });
 }
 


### PR DESCRIPTION
## Summary

`main` is red on ci.yml's "Lint full repo" step. My fault: #5031 merged with that check still failing.

```
× typescript(TS2741): Property 'NODE_ENV' is missing in type '{}' but required in type 'ProcessEnv'.
  ╭─[scripts/mobile-embedded-commit-time-check.test.ts:46:43]
```

`NodeJS.ProcessEnv` requires `NODE_ENV`, so an env literal naming only `GIT_COMMITTER_DATE` / `GIT_AUTHOR_DATE` does not satisfy it. Type the parameter as `Record<string, string | undefined>` instead — the same shape `shouldAllowDirtyTree` already uses on `main`. The test only ever reads those two variables.

## Why it got pushed

A scoped `vp check scripts/mobile-embedded-commit-time-check.test.ts` reports the file as clean: type-aware lint needs the whole project graph, so per-file runs cannot see this class of error at all. Only the bare, whole-repo `vp check` that ci.yml's lint job runs does. That step is not gated on `pull_request` any more, so a lint error on `main` also reds every later PR that reaches the job — worth knowing when an unrelated PR fails here.

Verified the way CI does, on this branch:

```
Found 0 errors and 330 warnings in 4803 files
Tests  16 passed (16)
```

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 1/5 — a type annotation in a test helper. No runtime code, no fingerprint input.
