### PR TITLE
fix(repo): unbreak vp lint on main

### DIFF
--- a/scripts/mobile-embedded-commit-time-check.test.ts
+++ b/scripts/mobile-embedded-commit-time-check.test.ts
@@ -43,7 +43,11 @@ function createTemporaryDir(): string {
   return dir;
 }
 
-function git(cwd: string, args: string[], env: NodeJS.ProcessEnv = {}): void {
+// Overrides layered onto process.env, not a whole environment. Typing this as
+// NodeJS.ProcessEnv fails to compile: Next's ambient global.d.ts augments that
+// interface to require NODE_ENV, so neither the `{}` default nor a caller's
+// partial literal satisfies it.
+function git(cwd: string, args: string[], env: Record<string, string> = {}): void {
   execFileSync('git', args, { cwd, env: { ...process.env, ...env }, stdio: 'ignore' });
 }
 


### PR DESCRIPTION
`vp lint` fails on `main` with two TS2741 errors in
`scripts/mobile-embedded-commit-time-check.test.ts`, which arrived with #5031.

The helper declares `env: NodeJS.ProcessEnv = {}`. Next's ambient `global.d.ts`
augments `NodeJS.ProcessEnv` to require `NODE_ENV`, so neither the `{}` default
nor a caller's partial literal satisfies it. The parameter is only ever spread
over `process.env`, so `Record<string, string>` is what it actually is — the
narrower type is also the more honest one.

This is the same breakage #5029 fixed in `mobile-publish.test.ts`, reintroduced
by a new file. #5029 reached for a `processEnv()` cast helper because its call
sites pass literals directly; here the bad type is on the helper signature
itself, so fixing the signature removes the need for any cast.

## Release Notes

none

## Test plan

1. CI green.

## Risk

Risk: 1/5 — test-only type change, no runtime behaviour touched.