### PR TITLE
feat(repo): move the remaining Vercel crons to the scheduler, with Sentry cron monitors

### DIFF
--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -1,8 +1,8 @@
 # Scheduler service (`packages/scheduler`)
 
-A long-lived Node container that fires Boardsesh's scheduled jobs, taking them
-off Vercel crons one at a time. Part of the Phase 0a hosting move (#1859 →
-#1860 → #1874).
+A long-lived Node container that fires Boardsesh's scheduled jobs. Part of the
+Phase 0a hosting move (#1859 → #1860 → #1874). Since #4654 it owns **every**
+cron: `packages/web/vercel.json` no longer declares a `crons` key.
 
 ## What it is (and isn't)
 
@@ -20,27 +20,48 @@ implementation and only the trigger moves.
 
 ## Job ownership
 
-Update this table as each job migrates. `packages/scheduler/src/__tests__/registry.test.ts`
-diffs the "Vercel" rows against `packages/web/vercel.json` and fails if the two
-sides drift, so a job can't end up double-scheduled or unscheduled.
+All seven jobs. `packages/scheduler/src/__tests__/registry.test.ts` pins each
+row's path and slot as data, and asserts `packages/web/vercel.json` declares no
+`crons` key at all — so a schedule reappearing there (which would double-fire
+the route, Vercel and Railway both) reds CI.
 
-| Path                                        | Schedule (UTC) | Runs on                       |
-| ------------------------------------------- | -------------- | ----------------------------- |
-| `/api/internal/cleanup`                     | `0 5 * * *`    | **Scheduler** (job `cleanup`) |
-| `/api/internal/prewarm-heatmap/kilter`      | `0 4 * * 0`    | Vercel cron                   |
-| `/api/internal/prewarm-heatmap/tension`     | `15 4 * * 0`   | Vercel cron                   |
-| `/api/internal/prewarm-heatmap/decoy`       | `30 4 * * 0`   | Vercel cron                   |
-| `/api/internal/prewarm-heatmap/touchstone`  | `45 4 * * 0`   | Vercel cron                   |
-| `/api/internal/prewarm-heatmap/grasshopper` | `0 5 * * 0`    | Vercel cron                   |
-| `/api/internal/profile-percentiles`         | `0 6 * * 0`    | Vercel cron                   |
+| Job                          | Path                                        | Schedule (UTC) | `timeoutMs` | Sentry monitor slug                    |
+| ---------------------------- | ------------------------------------------- | -------------- | ----------- | -------------------------------------- |
+| `cleanup`                    | `/api/internal/cleanup`                     | `0 5 * * *`    | 120 s       | `scheduler-cleanup`                    |
+| `prewarm-heatmap-kilter`     | `/api/internal/prewarm-heatmap/kilter`      | `0 4 * * 0`    | 15 min      | `scheduler-prewarm-heatmap-kilter`     |
+| `prewarm-heatmap-tension`    | `/api/internal/prewarm-heatmap/tension`     | `15 4 * * 0`   | 15 min      | `scheduler-prewarm-heatmap-tension`    |
+| `prewarm-heatmap-decoy`      | `/api/internal/prewarm-heatmap/decoy`       | `30 4 * * 0`   | 15 min      | `scheduler-prewarm-heatmap-decoy`      |
+| `prewarm-heatmap-touchstone` | `/api/internal/prewarm-heatmap/touchstone`  | `45 4 * * 0`   | 15 min      | `scheduler-prewarm-heatmap-touchstone` |
+| `prewarm-heatmap-grasshopper`| `/api/internal/prewarm-heatmap/grasshopper` | `0 5 * * 0`    | 15 min      | `scheduler-prewarm-heatmap-grasshopper`|
+| `profile-percentiles`        | `/api/internal/profile-percentiles`         | `0 6 * * 0`    | 15 min      | `scheduler-profile-percentiles`        |
 
-`packages/web/vercel.json` itself stays until the Phase 1 cutover; it is not
-deleted when the last cron leaves it.
+**The 15-minute stagger between the prewarms is a rate limit, not cosmetics.**
+Each one fans out heatmap aggregates against the same Postgres; collapsing them
+onto one minute puts five boards' worth of that load on the database at once.
 
-The GitHub-Actions-scheduled jobs (`refresh-recommendations`,
-`refresh-climb-grades`, `refresh-content-model`, `refresh-hold-features`,
-`export-board-snapshots`, `refresh-acknowledgements`) are a separate thing and
-are not in scope here.
+**Why 15 minutes and not 300 seconds.** Both weekly routes still export
+`maxDuration = 300`. That number was never a measurement — it is Vercel's Pro
+ceiling, the largest value the platform accepts. A container has no such
+ceiling, so the scheduler grants the headroom the work actually wanted. While
+web still serves from Vercel the route's own limit bites first and the scheduler
+just observes the 504; once web moves to Railway the export goes inert and the
+scheduler's `timeoutMs` becomes the only bound.
+
+`packages/web/vercel.json` itself stays until the Phase 4 scrub; it is not
+deleted now that the last cron has left it.
+
+### Not in scope
+
+- The GitHub-Actions-scheduled jobs (`refresh-recommendations`,
+  `refresh-climb-grades`, `refresh-content-model`, `refresh-hold-features`,
+  `export-board-snapshots`, `refresh-acknowledgements`) are a separate thing.
+- **`user-sync-cron` (#1875) needs no decision — the route is gone.**
+  `git grep user-sync-cron` returns only three prose mentions
+  (`docs/aurora-sync.md` ×2, `docs/branch-deploys.md`), all describing its
+  removal. `/api/internal/user-sync-cron` and the backend's `POST /sync-cron`
+  were both retired in favour of the long-lived aurora/kilter sync daemons,
+  which loop internally and hold their cooldowns in Postgres. There is nothing
+  to register here, and nothing silently drops off the schedule at cutover.
 
 **Keep new jobs on UTC.** Every job declares its own IANA zone, and the ticker
 honours it — but UTC has no DST gaps. A job scheduled inside a spring-forward
@@ -53,13 +74,20 @@ to UTC.
 
 | Variable                  | Required | Default                     | Notes                                                                                                                                                              |
 | ------------------------- | -------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `CRON_SECRET`             | yes      | —                           | **Copy** the Vercel project value, don't regenerate: the remaining Vercel crons authenticate with the same secret. Rotating it means updating both places at once. |
+| `CRON_SECRET`             | yes      | —                           | **Copy** the Vercel project value, don't regenerate: the web routes still validate against the secret in their own environment. Rotating it means updating both places at once. |
 | `BOARDSESH_WEB_URL`       | no       | `https://www.boardsesh.com` | Same env name the backend uses (`packages/backend/src/lib/web-revalidate.ts`).                                                                                     |
 | `PORT`                    | no       | `8080`                      | Health server.                                                                                                                                                     |
 | `SCHEDULER_DISABLED_JOBS` | no       | —                           | Comma-separated job names to leave unscheduled. Read once at startup, so set it and restart the service — no code change, no image rebuild. `run <job>` still works on a disabled job. |
+| `SENTRY_DSN`              | no       | —                           | Turns on the cron monitors below. Use the **same DSN `packages/web` uses server-side** — it is the literal in `packages/web/sentry.server.config.ts`, also the fallback in `packages/backend/src/instrument.ts`. Unset = monitors off, logged once at startup. |
+| `SENTRY_ENVIRONMENT`      | no       | `production`                | Environment tag on the check-ins.                                                                                                                                                  |
 
 A missing `CRON_SECRET` throws at startup, so a misconfigured service
 crash-loops loudly instead of 401ing quietly at 05:00.
+
+Unlike web and backend, the scheduler has **no hardcoded DSN fallback**. The
+same CLI is what an operator runs by hand against production
+(`scheduler run cleanup`), and a baked-in DSN would file that laptop's output
+against the production project.
 
 ## Railway service setup
 
@@ -78,6 +106,7 @@ Dockerfile, no new workflow.
    - `CRON_SECRET` — same value as the Vercel project env var.
    - `BOARDSESH_WEB_URL=https://www.boardsesh.com`
    - `PORT=8080` (or let Railway inject its own `PORT`).
+   - `SENTRY_DSN` — the web server DSN, for the cron monitors.
 5. **Healthcheck path**: `/health`.
 6. **Replicas: 1.** Two instances would double-fire every job; there is no
    leader election in this slice. If it ever needs more than one, `DaemonLease`
@@ -85,7 +114,7 @@ Dockerfile, no new workflow.
 
 ## Cutover order (matters)
 
-Do it in this order, or cleanup silently stops running:
+Do it in this order, or the job silently stops running:
 
 1. Deploy the Railway service with the env above.
 2. Shell into it (or use a one-off run) and confirm a manual trigger works
@@ -95,13 +124,61 @@ Do it in this order, or cleanup silently stops running:
    Vercel WAF / bot rule blocking Railway egress IPs** — nothing local can.
 3. Only then merge the PR that drops the entry from `packages/web/vercel.json`.
 
-Between steps 1 and 3 both schedulers may fire the job. That's safe:
-`/api/internal/cleanup` deletes rows older than a fixed age in deadline-bounded
-batches, so a double run is a no-op on the second pass.
+Between steps 1 and 3 both schedulers may fire the job. That is safe for all
+seven: `cleanup` deletes rows older than a fixed age in deadline-bounded
+batches, each `prewarm-heatmap` writes the same cache entry twice, and
+`profile-percentiles` is an idempotent recompute-and-upsert.
 
-If the PR merges before the service exists, the 180-day feed-item and 90-day
-notification retention pauses. Harmless for weeks — the job is delete-by-age
-and catches up on its next run — but it should not be left that way.
+Merging before the Railway service runs the new image pauses the job instead.
+Consequences, in order of how long you can ignore them:
+
+- `cleanup` — 180-day feed-item and 90-day notification retention pauses.
+  Delete-by-age, so it catches up on its next run. Harmless for weeks.
+- `prewarm-heatmap-*` — the first visitor to each board/angle pays the cold
+  query instead of hitting a warm cache. Slow, not broken.
+- `profile-percentiles` — the "top N%" figure on profiles goes a week stale.
+
+None of these are data loss, but the Sentry monitors will (correctly) raise a
+missed-occurrence issue for each one, which is the signal to finish the cutover.
+
+## Sentry cron monitors (#1876)
+
+`/health/jobs` tells you a job **failed**. It cannot tell you a job never
+**ran** — a dead container, a wrong `TZ`, a stopped ticker all produce silence,
+and silence looks identical to "nothing was due". That gap is what the monitors
+close, and it is why `automaticVercelMonitors` had to be replaced rather than
+just switched off: it only ever worked because Vercel handed Sentry the cron
+metadata out of a deploy, which no longer happens.
+
+Every **scheduled** run is wrapped in `Sentry.withMonitor(slug, run, config)`
+(`packages/scheduler/src/monitoring/`). The config carries the job's own crontab
+expression and UTC timezone, so Sentry knows when the next check-in is due and
+raises an issue when one does not arrive:
+
+- `checkinMargin: 5` minutes late before an occurrence counts as missed —
+  enough to ride out a Railway deploy swap, well inside the 15-minute prewarm
+  stagger.
+- `maxRuntime` = the job's `timeoutMs` rounded up to minutes, plus one.
+- `failureIssueThreshold: 1`, `recoveryThreshold: 1`. These jobs are weekly;
+  waiting for a second consecutive failure means hearing about a broken prewarm
+  a fortnight late.
+
+Sentry creates each monitor from its first check-in — there is nothing to
+provision in the dashboard. Slugs are `scheduler-<job name>` and are pinned in
+`cron-monitor.test.ts`, because Sentry keys a monitor's whole history on its
+slug: renaming a job would orphan the old monitor and start a blank one.
+
+Two paths deliberately send **no** check-in:
+
+- `scheduler run <job>`. A manual run is not a scheduled occurrence; an "ok"
+  from it would resolve a genuinely missed one and report a dead ticker as
+  healthy.
+- A tick skipped because the previous run is still in flight. It did not run, so
+  letting Sentry mark the occurrence missed is the honest outcome — a job
+  overrunning its own interval deserves the issue.
+
+A failing job still fails: the monitor wrapper rethrows, so `lastError`,
+`/health/jobs` and the error log all see the failure exactly as before.
 
 ## Health endpoints
 
@@ -136,9 +213,11 @@ page), `ENOTFOUND` means `BOARDSESH_WEB_URL` is wrong or DNS is broken.
 
 **A job is stuck.** A tick whose predecessor is still in flight is skipped and
 warned, never queued, so a slow run can't stack up. Each run is also bounded by
-the job's `timeoutMs` (120s for `cleanup`) via `AbortController`. If a job is
-misbehaving, set `SCHEDULER_DISABLED_JOBS=<name>` and restart — no code change,
-no redeploy.
+the job's `timeoutMs` (120s for `cleanup`, 15 min for the weekly jobs) via
+`AbortController`. If a job is misbehaving, set `SCHEDULER_DISABLED_JOBS=<name>`
+and restart — no code change, no redeploy. Note that a disabled job stops
+checking in, so its Sentry monitor will report missed occurrences until it is
+re-enabled or the monitor is muted.
 
 **Run one now.** `node --import tsx packages/scheduler/src/cli/index.ts run <job>` runs a
 single job and exits non-zero on failure. It never starts the recurring
@@ -146,10 +225,6 @@ schedule, and it works on a job held back by `SCHEDULER_DISABLED_JOBS`.
 
 ## Follow-ups
 
-- One PR per remaining job (`profile-percentiles`, then the five
-  `prewarm-heatmap` boards), each moving one row in the table above.
-- Sentry cron monitors around job runs (#1876). The runner already records
-  `lastError` and logs failures, so the hook-up point exists.
 - A dedicated `Dockerfile.scheduler` + `scheduler-deploy.yml` +
   `boardsesh-scheduler` image, if the scheduler should release on its own
   cadence instead of riding the sync image. Mechanical, but a second PR's worth

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -21,7 +21,9 @@
     "lint": "vp lint",
     "lint-fix": "vp lint --fix"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@sentry/node": "^10.69.0"
+  },
   "devDependencies": {
     "@types/node": "^25.9.5",
     "tsx": "^4.23.1",

--- a/packages/scheduler/src/__tests__/cron-monitor.test.ts
+++ b/packages/scheduler/src/__tests__/cron-monitor.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createCronMonitor,
+  monitorConfigForJob,
+  monitorSlugForJob,
+  noopCronMonitor,
+  type CronMonitorConfig,
+  type WithMonitorFn,
+} from '../monitoring/cron-monitor';
+import { JOBS } from '../jobs/registry';
+import type { JobDefinition } from '../jobs/types';
+
+type RecordedMonitorCall = { slug: string; config: CronMonitorConfig };
+
+/**
+ * Stands in for `Sentry.withMonitor`, recording the slug and MonitorConfig it
+ * was handed and passing the callback straight through — the same contract the
+ * real one has, so a test that passes here says something about production.
+ */
+function createFakeSentry() {
+  const calls: RecordedMonitorCall[] = [];
+  const withMonitor: WithMonitorFn = (slug, callback, config) => {
+    calls.push({ slug, config });
+    return callback();
+  };
+  return { calls, withMonitor };
+}
+
+const defineJob = (overrides: Partial<JobDefinition> = {}): JobDefinition => ({
+  name: 'cleanup',
+  schedule: '0 5 * * *',
+  timezone: 'UTC',
+  timeoutMs: 120_000,
+  run: async () => ({ ok: true }),
+  ...overrides,
+});
+
+describe('monitorSlugForJob', () => {
+  it('prefixes the job name so scheduler monitors are identifiable in Sentry', () => {
+    expect(monitorSlugForJob('cleanup')).toBe('scheduler-cleanup');
+    expect(monitorSlugForJob('prewarm-heatmap-kilter')).toBe('scheduler-prewarm-heatmap-kilter');
+  });
+
+  it('pins the exact slug of every registered job', () => {
+    // Sentry keys a monitor's entire history on its slug. A renamed job would
+    // silently orphan the monitor that holds this job's check-in history and
+    // start a fresh one, so the seven live slugs are pinned as data.
+    expect(JOBS.map((job) => monitorSlugForJob(job.name))).toEqual([
+      'scheduler-cleanup',
+      'scheduler-prewarm-heatmap-kilter',
+      'scheduler-prewarm-heatmap-tension',
+      'scheduler-prewarm-heatmap-decoy',
+      'scheduler-prewarm-heatmap-touchstone',
+      'scheduler-prewarm-heatmap-grasshopper',
+      'scheduler-profile-percentiles',
+    ]);
+  });
+});
+
+describe('monitorConfigForJob', () => {
+  it('hands Sentry the job registry schedule verbatim', () => {
+    // This is what makes a MISSED run detectable: Sentry computes the next
+    // expected check-in from this expression. A stale or hand-copied value
+    // would have it waiting on the wrong minute.
+    const config = monitorConfigForJob(defineJob({ schedule: '45 4 * * 0' }));
+    expect(config.schedule).toEqual({ type: 'crontab', value: '45 4 * * 0' });
+  });
+
+  it('sends Sentry the exact crontab expression each live job runs on', () => {
+    // Pinned as literals on purpose. Asserting `config.schedule.value ===
+    // job.schedule` would derive both sides from the same field and pass no
+    // matter what the schedule became — it would only prove the function
+    // copies a string. These are the seven slots Vercel used, so a registry
+    // schedule edited without a deliberate change here reds, and Sentry can
+    // never be left waiting on a minute the ticker does not fire.
+    const configBySlug = Object.fromEntries(JOBS.map((job) => [monitorSlugForJob(job.name), monitorConfigForJob(job)]));
+
+    expect(
+      Object.fromEntries(Object.entries(configBySlug).map(([slug, config]) => [slug, config.schedule.value])),
+    ).toEqual({
+      'scheduler-cleanup': '0 5 * * *',
+      'scheduler-prewarm-heatmap-kilter': '0 4 * * 0',
+      'scheduler-prewarm-heatmap-tension': '15 4 * * 0',
+      'scheduler-prewarm-heatmap-decoy': '30 4 * * 0',
+      'scheduler-prewarm-heatmap-touchstone': '45 4 * * 0',
+      'scheduler-prewarm-heatmap-grasshopper': '0 5 * * 0',
+      'scheduler-profile-percentiles': '0 6 * * 0',
+    });
+
+    for (const config of Object.values(configBySlug)) {
+      expect(config.schedule.type).toBe('crontab');
+      // Sentry defaults a monitor to UTC, but only if nothing says otherwise;
+      // an unset timezone here plus a non-UTC host would put the expected
+      // check-in window hours away from when the job actually runs.
+      expect(config.timezone).toBe('UTC');
+    }
+  });
+
+  it('alerts on the first failure and clears on the first success', () => {
+    // These jobs are weekly. A threshold of 2 would mean hearing about a broken
+    // prewarm a fortnight after it broke.
+    const config = monitorConfigForJob(defineJob());
+    expect(config.failureIssueThreshold).toBe(1);
+    expect(config.recoveryThreshold).toBe(1);
+  });
+
+  it('derives maxRuntime from the job timeout, in whole minutes with slack', () => {
+    expect(monitorConfigForJob(defineJob({ timeoutMs: 120_000 })).maxRuntime).toBe(3);
+    expect(monitorConfigForJob(defineJob({ timeoutMs: 900_000 })).maxRuntime).toBe(16);
+    // Rounds up rather than truncating: a 90s job must not be flagged at 1min.
+    expect(monitorConfigForJob(defineJob({ timeoutMs: 90_000 })).maxRuntime).toBe(3);
+  });
+
+  it('leaves room for a late check-in without swallowing an outage', () => {
+    const config = monitorConfigForJob(defineJob());
+    expect(config.checkinMargin).toBeGreaterThan(0);
+    // Must stay under the 15-minute stagger between the heatmap prewarms, or a
+    // late kilter run would still be "on time" when tension is already due.
+    expect(config.checkinMargin).toBeLessThan(15);
+  });
+});
+
+describe('createCronMonitor', () => {
+  it('wraps the run in a check-in and returns its result', async () => {
+    const { calls, withMonitor } = createFakeSentry();
+    const monitor = createCronMonitor(withMonitor);
+
+    await expect(monitor.monitor(defineJob(), async () => 'done')).resolves.toBe('done');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].slug).toBe('scheduler-cleanup');
+    expect(calls[0].config.schedule).toEqual({ type: 'crontab', value: '0 5 * * *' });
+  });
+
+  it('lets a thrown job propagate after the monitor wrapper', async () => {
+    // The runner's bookkeeping, /health/jobs and the error log all depend on
+    // seeing the rejection. A monitor that swallowed it would leave the job
+    // green everywhere except Sentry.
+    const { calls, withMonitor } = createFakeSentry();
+    const monitor = createCronMonitor(withMonitor);
+    const failure = new Error('web returned HTTP 500');
+
+    await expect(monitor.monitor(defineJob(), () => Promise.reject(failure))).rejects.toBe(failure);
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe('noopCronMonitor', () => {
+  it('calls straight through so behaviour is identical without a DSN', async () => {
+    const run = vi.fn().mockResolvedValue({ ok: true });
+    await expect(noopCronMonitor.monitor(defineJob(), run)).resolves.toEqual({ ok: true });
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it('still propagates a failure', async () => {
+    const failure = new Error('boom');
+    await expect(noopCronMonitor.monitor(defineJob(), () => Promise.reject(failure))).rejects.toBe(failure);
+  });
+});

--- a/packages/scheduler/src/__tests__/registry.test.ts
+++ b/packages/scheduler/src/__tests__/registry.test.ts
@@ -10,6 +10,22 @@ const vercelConfigUrl = new URL('../../../web/vercel.json', import.meta.url);
 const vercelConfig = JSON.parse(readFileSync(vercelConfigUrl, 'utf8')) as VercelConfig;
 const vercelCronPaths = (vercelConfig.crons ?? []).map((cron) => cron.path);
 
+/**
+ * Every path the scheduler now owns, with the exact slot it inherited from
+ * `vercel.json`. Pinned as data rather than derived from {@link JOBS}, so a
+ * typo'd minute or a job quietly dropped from the registry reds instead of
+ * being re-derived into agreement with itself.
+ */
+const MIGRATED_SCHEDULES: readonly (readonly [job: string, path: string, schedule: string])[] = [
+  ['cleanup', '/api/internal/cleanup', '0 5 * * *'],
+  ['prewarm-heatmap-kilter', '/api/internal/prewarm-heatmap/kilter', '0 4 * * 0'],
+  ['prewarm-heatmap-tension', '/api/internal/prewarm-heatmap/tension', '15 4 * * 0'],
+  ['prewarm-heatmap-decoy', '/api/internal/prewarm-heatmap/decoy', '30 4 * * 0'],
+  ['prewarm-heatmap-touchstone', '/api/internal/prewarm-heatmap/touchstone', '45 4 * * 0'],
+  ['prewarm-heatmap-grasshopper', '/api/internal/prewarm-heatmap/grasshopper', '0 5 * * 0'],
+  ['profile-percentiles', '/api/internal/profile-percentiles', '0 6 * * 0'],
+];
+
 describe('job registry', () => {
   it('has unique job names', () => {
     const jobNames = JOBS.map((job) => job.name);
@@ -32,6 +48,23 @@ describe('job registry', () => {
     }
   });
 
+  it('names every job in kebab-case, because the Sentry monitor slug is derived from it', () => {
+    // `monitorSlugForJob` turns the name straight into `scheduler-<name>`. A
+    // name with an underscore or a capital would either be rejected by Sentry
+    // or, worse, silently normalised into a slug that no longer matches the
+    // monitor already collecting this job's history.
+    for (const job of JOBS) {
+      expect(job.name, `${job.name} is not kebab-case`).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    }
+  });
+
+  it('has taken every cron off vercel.json', () => {
+    // The whole point of #4654: the `crons` block is gone, not merely emptied
+    // of the jobs we happened to look at.
+    expect(vercelCronPaths).toEqual([]);
+    expect(vercelConfig.crons).toBeUndefined();
+  });
+
   it('never schedules a path that vercel.json still owns', () => {
     const schedulerPaths = JOBS.map((job) => job.webPath).filter((path): path is string => path !== undefined);
     const doubleScheduled = schedulerPaths.filter((path) => vercelCronPaths.includes(path));
@@ -44,13 +77,27 @@ describe('job registry', () => {
     expect([...vercelCronPaths].sort()).toEqual([...VERCEL_OWNED_CRON_PATHS].sort());
   });
 
-  it('has taken the cleanup cron off Vercel', () => {
-    expect(vercelCronPaths).not.toContain('/api/internal/cleanup');
-    expect(findJob('cleanup')?.webPath).toBe('/api/internal/cleanup');
+  it('runs every migrated path on the exact slot vercel.json used', () => {
+    const actual = JOBS.map((job) => [job.name, job.webPath, job.schedule]);
+    expect(actual).toEqual(MIGRATED_SCHEDULES.map((row) => [...row]));
   });
 
-  it('keeps the cleanup job on the slot vercel.json used', () => {
-    expect(findJob('cleanup')?.schedule).toBe('0 5 * * *');
+  it('keeps the five heatmap prewarms staggered rather than firing them together', () => {
+    // Five boards' worth of heatmap aggregates against one Postgres. The
+    // stagger is the rate limit, so a schedule collapsed onto a single minute
+    // is a regression even though every individual job still "runs weekly".
+    const prewarmSlots = JOBS.filter((job) => job.name.startsWith('prewarm-heatmap-')).map((job) => job.schedule);
+    expect(new Set(prewarmSlots).size).toBe(prewarmSlots.length);
+    expect(prewarmSlots).toHaveLength(5);
+  });
+
+  it('gives the weekly warm-ups more than the 300s Vercel capped them at', () => {
+    // These routes were pinned at Vercel's Pro maximum, not at a measured
+    // duration. Dropping the scheduler timeout back to 300s would re-impose a
+    // limit the platform no longer forces on us.
+    for (const job of JOBS.filter((candidate) => candidate.name !== 'cleanup')) {
+      expect(job.timeoutMs, `${job.name} timeoutMs`).toBeGreaterThan(300_000);
+    }
   });
 
   it('returns undefined for an unknown job name', () => {

--- a/packages/scheduler/src/__tests__/runner.test.ts
+++ b/packages/scheduler/src/__tests__/runner.test.ts
@@ -3,6 +3,7 @@ import type { SchedulerConfig } from '../config';
 import type { CronScheduleOptions, CronScheduler, CronTask } from '../cron/scheduler';
 import type { JobDefinition } from '../jobs/types';
 import type { LogFields, SchedulerLogger } from '../logger';
+import { createCronMonitor, type CronMonitorConfig, type WithMonitorFn } from '../monitoring/cron-monitor';
 import { createScheduler } from '../runner';
 
 type RecordedRegistration = {
@@ -55,6 +56,18 @@ const baseConfig: SchedulerConfig = {
   port: 8080,
   disabledJobs: [],
 };
+
+type RecordedMonitorCall = { slug: string; config: CronMonitorConfig };
+
+/** Records what would have been sent to Sentry, and passes the run through. */
+function createRecordingMonitor() {
+  const calls: RecordedMonitorCall[] = [];
+  const withMonitor: WithMonitorFn = (slug, callback, config) => {
+    calls.push({ slug, config });
+    return callback();
+  };
+  return { calls, monitor: createCronMonitor(withMonitor) };
+}
 
 const defineJob = (overrides: Partial<JobDefinition> = {}): JobDefinition => ({
   name: 'cleanup',
@@ -221,6 +234,99 @@ describe('createScheduler', () => {
 
     scheduler.stop();
     expect(registrations.every((registration) => registration.stopped)).toBe(true);
+  });
+
+  it('reports a scheduled tick to the cron monitor with the job schedule', async () => {
+    const { cron, registrations } = createFakeCron();
+    const { logger } = createRecordingLogger();
+    const { calls, monitor } = createRecordingMonitor();
+    const run = vi.fn().mockResolvedValue({ ok: true });
+
+    const scheduler = createScheduler({
+      jobs: [defineJob({ run, name: 'prewarm-heatmap-decoy', schedule: '30 4 * * 0' })],
+      config: baseConfig,
+      cron,
+      logger,
+      monitor,
+    });
+
+    registrations[0].handler();
+    await vi.waitFor(() => expect(scheduler.getStatus()[0].runCount).toBe(1));
+
+    expect(calls).toEqual([
+      {
+        slug: 'scheduler-prewarm-heatmap-decoy',
+        config: expect.objectContaining({
+          schedule: { type: 'crontab', value: '30 4 * * 0' },
+          timezone: 'UTC',
+        }),
+      },
+    ]);
+  });
+
+  it('sends no check-in for a manual runJob, only for a scheduled tick', async () => {
+    // `scheduler run <job>` is an operator debugging a job, not an occurrence
+    // of the schedule. An "ok" check-in from a hand-run would resolve a
+    // genuinely missed occurrence and report a dead ticker as healthy.
+    const { cron, registrations } = createFakeCron();
+    const { logger } = createRecordingLogger();
+    const { calls, monitor } = createRecordingMonitor();
+    const run = vi.fn().mockResolvedValue({ ok: true });
+
+    const scheduler = createScheduler({ jobs: [defineJob({ run })], config: baseConfig, cron, logger, monitor });
+
+    await scheduler.runJob('cleanup');
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual([]);
+
+    // The scheduled path through the same scheduler still checks in.
+    registrations[0].handler();
+    await vi.waitFor(() => expect(calls).toHaveLength(1));
+  });
+
+  it('sends no check-in for a tick skipped while its predecessor is in flight', async () => {
+    // A skipped tick did not run. Letting Sentry record the occurrence as
+    // missed is the honest outcome for a job overrunning its own interval.
+    const { cron, registrations } = createFakeCron();
+    const { logger } = createRecordingLogger();
+    const { calls, monitor } = createRecordingMonitor();
+    const run = vi.fn(() => new Promise<unknown>(() => undefined));
+
+    createScheduler({ jobs: [defineJob({ run })], config: baseConfig, cron, logger, monitor });
+
+    registrations[0].handler();
+    registrations[0].handler();
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('still records a failure after the monitor wrapper rethrows', async () => {
+    const { cron, registrations } = createFakeCron();
+    const { logger, logs } = createRecordingLogger();
+    const { calls, monitor } = createRecordingMonitor();
+    const run = vi.fn().mockRejectedValue(new Error('web returned HTTP 500'));
+
+    const scheduler = createScheduler({ jobs: [defineJob({ run })], config: baseConfig, cron, logger, monitor });
+
+    expect(() => registrations[0].handler()).not.toThrow();
+    await vi.waitFor(() => expect(scheduler.getStatus()[0].failureCount).toBe(1));
+
+    expect(calls).toHaveLength(1);
+    expect(scheduler.getStatus()[0].lastError).toBe('web returned HTTP 500');
+    expect(logs.some((log) => log.level === 'error' && log.message === 'job failed')).toBe(true);
+  });
+
+  it('runs unmonitored when no monitor is supplied', async () => {
+    const { cron, registrations } = createFakeCron();
+    const { logger } = createRecordingLogger();
+    const run = vi.fn().mockResolvedValue({ ok: true });
+
+    const scheduler = createScheduler({ jobs: [defineJob({ run })], config: baseConfig, cron, logger });
+
+    registrations[0].handler();
+    await vi.waitFor(() => expect(scheduler.getStatus()[0].runCount).toBe(1));
+    expect(scheduler.getStatus()[0].lastError).toBeNull();
   });
 
   it('records duration and success timestamps', async () => {

--- a/packages/scheduler/src/__tests__/sentry-monitoring.test.ts
+++ b/packages/scheduler/src/__tests__/sentry-monitoring.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import type { LogFields, SchedulerLogger } from '../logger';
+import { noopCronMonitor } from '../monitoring/cron-monitor';
+import { setupCronMonitoring } from '../monitoring/sentry';
+
+type RecordedLog = { level: 'info' | 'warn' | 'error'; message: string; fields?: LogFields };
+
+function createRecordingLogger() {
+  const logs: RecordedLog[] = [];
+  const logger: SchedulerLogger = {
+    info: (message, fields) => logs.push({ level: 'info', message, fields }),
+    warn: (message, fields) => logs.push({ level: 'warn', message, fields }),
+    error: (message, fields) => logs.push({ level: 'error', message, fields }),
+  };
+  return { logger, logs };
+}
+
+describe('setupCronMonitoring', () => {
+  // Only the no-DSN branch is exercised here. Calling the other one would run
+  // `Sentry.init` against the real SDK for the whole test process — a global
+  // side effect the rest of the suite would inherit. `createCronMonitor` is
+  // tested directly against a fake withMonitor in cron-monitor.test.ts instead.
+
+  it('degrades to a no-op monitor when SENTRY_DSN is unset', () => {
+    const { logger, logs } = createRecordingLogger();
+
+    const monitor = setupCronMonitoring({ env: {}, logger });
+
+    expect(monitor).toBe(noopCronMonitor);
+    expect(logs.filter((log) => log.level === 'warn' && log.message.includes('SENTRY_DSN'))).toHaveLength(1);
+  });
+
+  it('treats a blank SENTRY_DSN as unset rather than initialising with it', () => {
+    // Railway hands an unset variable through as an empty string; passing that
+    // to Sentry.init would produce a client that silently drops everything.
+    const { logger, logs } = createRecordingLogger();
+
+    expect(setupCronMonitoring({ env: { SENTRY_DSN: '   ' }, logger })).toBe(noopCronMonitor);
+    expect(logs.some((log) => log.level === 'warn' && log.message.includes('SENTRY_DSN'))).toBe(true);
+  });
+
+  it('says how to turn monitors on rather than only that they are off', () => {
+    const { logger, logs } = createRecordingLogger();
+    setupCronMonitoring({ env: {}, logger });
+
+    expect(logs[0].fields?.hint).toContain('SENTRY_DSN');
+  });
+});

--- a/packages/scheduler/src/cli/index.ts
+++ b/packages/scheduler/src/cli/index.ts
@@ -4,6 +4,7 @@ import { createMinuteTicker } from '../cron/scheduler';
 import { createHealthServer } from '../health-server';
 import { JOBS } from '../jobs/registry';
 import { consoleLogger, describeError } from '../logger';
+import { setupCronMonitoring } from '../monitoring/sentry';
 import { createScheduler } from '../runner';
 
 const USAGE = `Boardsesh scheduler
@@ -21,6 +22,8 @@ Environment:
   BOARDSESH_WEB_URL         Web app base URL (default https://www.boardsesh.com)
   PORT                      Health server port (default 8080)
   SCHEDULER_DISABLED_JOBS   Comma-separated job names to leave unscheduled
+  SENTRY_DSN                Enables Sentry cron monitors on 'start'. Unset = off.
+  SENTRY_ENVIRONMENT        Sentry environment tag (default production)
 `;
 
 function printUsage(): void {
@@ -29,11 +32,13 @@ function printUsage(): void {
 
 async function runStart(): Promise<void> {
   const config = loadSchedulerConfig();
+  // Once, here: `start` is the only path with a schedule to monitor.
+  const monitor = setupCronMonitoring({ logger: consoleLogger });
   const cron = createMinuteTicker({
     onHandlerError: (error, expression) =>
       consoleLogger.error('cron handler threw', { expression, error: describeError(error) }),
   });
-  const scheduler = createScheduler({ jobs: JOBS, config, cron, logger: consoleLogger });
+  const scheduler = createScheduler({ jobs: JOBS, config, cron, logger: consoleLogger, monitor });
   const healthServer = createHealthServer({
     port: config.port,
     getStatus: () => scheduler.getStatus(),
@@ -83,6 +88,10 @@ async function runOneJob(jobName: string | undefined): Promise<void> {
   // from also starting the recurring schedule, and keeps a job held back by
   // SCHEDULER_DISABLED_JOBS runnable on demand — the env flag only silences
   // the schedule, not an operator's explicit run.
+  //
+  // No `monitor` either, and no setupCronMonitoring(): an operator's manual run
+  // is not a scheduled occurrence. Checking it in would resolve a missed one and
+  // report the job healthy while the ticker that should have fired it is dead.
   const scheduler = createScheduler({
     jobs: JOBS,
     config,

--- a/packages/scheduler/src/config.ts
+++ b/packages/scheduler/src/config.ts
@@ -52,7 +52,7 @@ export function loadSchedulerConfig(env: NodeJS.ProcessEnv = process.env): Sched
   const cronSecret = env.CRON_SECRET?.trim();
   if (!cronSecret) {
     throw new SchedulerConfigError(
-      'CRON_SECRET is required. Use the same value as the Vercel project env var — the remaining Vercel crons authenticate with it too.',
+      'CRON_SECRET is required. Use the same value as the web project env var — requireCronAuth validates against the secret in the web app environment.',
     );
   }
 

--- a/packages/scheduler/src/index.ts
+++ b/packages/scheduler/src/index.ts
@@ -20,4 +20,14 @@ export { findJob, JOBS, VERCEL_OWNED_CRON_PATHS } from './jobs/registry';
 export { triggerWebCron, WebCronRequestError } from './jobs/trigger-web-cron';
 export type { JobContext, JobDefinition, JobRun } from './jobs/types';
 export { consoleLogger, describeError, type LogFields, type SchedulerLogger } from './logger';
+export {
+  createCronMonitor,
+  monitorConfigForJob,
+  monitorSlugForJob,
+  noopCronMonitor,
+  type CronMonitor,
+  type CronMonitorConfig,
+  type WithMonitorFn,
+} from './monitoring/cron-monitor';
+export { setupCronMonitoring, type SetupCronMonitoringOptions } from './monitoring/sentry';
 export { createScheduler, type CreateSchedulerOptions, type JobStatus, type Scheduler } from './runner';

--- a/packages/scheduler/src/jobs/registry.ts
+++ b/packages/scheduler/src/jobs/registry.ts
@@ -4,23 +4,34 @@ import type { JobDefinition } from './types';
 /**
  * `/api/internal/*` cron paths still owned by `packages/web/vercel.json`.
  *
- * This is a checked-in mirror of that file's `crons` array, minus whatever has
- * already moved here. `registry.test.ts` diffs it against the real vercel.json
- * and against {@link JOBS}, so a migration PR that only edits one side fails
- * CI instead of leaving a job double-scheduled or unscheduled.
+ * Now empty: every cron has moved here, and `vercel.json` no longer declares a
+ * `crons` key at all. The list stays because `registry.test.ts` diffs it
+ * against the real vercel.json and against {@link JOBS} — with both sides
+ * empty, re-adding a schedule on the Vercel side without dropping the job here
+ * fails CI instead of leaving a job double-scheduled.
+ *
+ * `vercel.json` itself outlives this: it is deleted in the Phase 4 scrub
+ * (#4648), not here.
  */
-export const VERCEL_OWNED_CRON_PATHS: readonly string[] = [
-  '/api/internal/prewarm-heatmap/kilter',
-  '/api/internal/prewarm-heatmap/tension',
-  '/api/internal/prewarm-heatmap/decoy',
-  '/api/internal/prewarm-heatmap/touchstone',
-  '/api/internal/prewarm-heatmap/grasshopper',
-  '/api/internal/profile-percentiles',
-];
+export const VERCEL_OWNED_CRON_PATHS: readonly string[] = [];
 
 // `/api/internal/cleanup` declares `maxDuration = 60`; give the request room to
 // finish plus headroom rather than cutting a legitimate run short.
 const CLEANUP_TIMEOUT_MS = 120_000;
+
+/**
+ * The heatmap prewarm and percentile routes both declare `maxDuration = 300`.
+ * That number is not a measurement — it is Vercel's Pro ceiling, the largest
+ * value the platform accepts, and both routes were pinned to it precisely
+ * because there was nothing higher to ask for.
+ *
+ * A long-lived container has no such ceiling, so the scheduler grants the real
+ * headroom the work wanted: 15 minutes. While web still serves from Vercel the
+ * route's own 300 s limit bites first and the scheduler simply observes the
+ * resulting 504; once web moves to Railway (`WEB_DEPLOY_TARGETS`, #4648) the
+ * `maxDuration` export goes inert and this timeout becomes the only bound.
+ */
+const WEEKLY_WARMUP_TIMEOUT_MS = 900_000;
 
 export const JOBS: readonly JobDefinition[] = [
   {
@@ -33,6 +44,62 @@ export const JOBS: readonly JobDefinition[] = [
     timeoutMs: CLEANUP_TIMEOUT_MS,
     webPath: '/api/internal/cleanup',
     run: triggerWebCron('/api/internal/cleanup'),
+  },
+
+  // The five heatmap prewarms keep the 15-minute stagger vercel.json used.
+  // They are not independent of each other: each one hammers the same Postgres
+  // with a fan-out of heatmap aggregates, and firing them together would put
+  // five boards' worth of that load on the database at once. The stagger is the
+  // rate limit.
+  {
+    name: 'prewarm-heatmap-kilter',
+    schedule: '0 4 * * 0',
+    timezone: 'UTC',
+    timeoutMs: WEEKLY_WARMUP_TIMEOUT_MS,
+    webPath: '/api/internal/prewarm-heatmap/kilter',
+    run: triggerWebCron('/api/internal/prewarm-heatmap/kilter'),
+  },
+  {
+    name: 'prewarm-heatmap-tension',
+    schedule: '15 4 * * 0',
+    timezone: 'UTC',
+    timeoutMs: WEEKLY_WARMUP_TIMEOUT_MS,
+    webPath: '/api/internal/prewarm-heatmap/tension',
+    run: triggerWebCron('/api/internal/prewarm-heatmap/tension'),
+  },
+  {
+    name: 'prewarm-heatmap-decoy',
+    schedule: '30 4 * * 0',
+    timezone: 'UTC',
+    timeoutMs: WEEKLY_WARMUP_TIMEOUT_MS,
+    webPath: '/api/internal/prewarm-heatmap/decoy',
+    run: triggerWebCron('/api/internal/prewarm-heatmap/decoy'),
+  },
+  {
+    name: 'prewarm-heatmap-touchstone',
+    schedule: '45 4 * * 0',
+    timezone: 'UTC',
+    timeoutMs: WEEKLY_WARMUP_TIMEOUT_MS,
+    webPath: '/api/internal/prewarm-heatmap/touchstone',
+    run: triggerWebCron('/api/internal/prewarm-heatmap/touchstone'),
+  },
+  {
+    name: 'prewarm-heatmap-grasshopper',
+    schedule: '0 5 * * 0',
+    timezone: 'UTC',
+    timeoutMs: WEEKLY_WARMUP_TIMEOUT_MS,
+    webPath: '/api/internal/prewarm-heatmap/grasshopper',
+    run: triggerWebCron('/api/internal/prewarm-heatmap/grasshopper'),
+  },
+  {
+    name: 'profile-percentiles',
+    // Sunday 06:00 UTC — an hour after the last prewarm, so the recompute does
+    // not contend with the heatmap warm-up for database time.
+    schedule: '0 6 * * 0',
+    timezone: 'UTC',
+    timeoutMs: WEEKLY_WARMUP_TIMEOUT_MS,
+    webPath: '/api/internal/profile-percentiles',
+    run: triggerWebCron('/api/internal/profile-percentiles'),
   },
 ];
 

--- a/packages/scheduler/src/monitoring/cron-monitor.ts
+++ b/packages/scheduler/src/monitoring/cron-monitor.ts
@@ -1,0 +1,102 @@
+/**
+ * Sentry cron monitors for scheduled job runs (#1876).
+ *
+ * `automaticVercelMonitors` only ever worked because Vercel handed Sentry the
+ * cron metadata out of a deploy. Off Vercel there is no such metadata, so a job
+ * that stops firing stops being observed — silently, which is the failure mode
+ * this module exists to prevent.
+ *
+ * The important half is absence, not failure. A failing job already surfaces in
+ * `/health/jobs` and in the logs; a job that never runs at all produces nothing
+ * to look at. A Sentry monitor knows the schedule, so it can raise an issue for
+ * an occurrence that never checked in — a dead container, a wrong `TZ`, a
+ * ticker that stopped — none of which the process itself can report.
+ */
+import type { JobDefinition } from '../jobs/types';
+
+/**
+ * Monitor slugs must survive redeploys: Sentry keys a monitor's whole history
+ * (schedule, past check-ins, open issues) on the slug, so a changed slug reads
+ * as a brand-new monitor and abandons the old one still expecting check-ins.
+ * Job names are asserted kebab-case in `registry.test.ts` for exactly this.
+ */
+export function monitorSlugForJob(jobName: string): string {
+  return `scheduler-${jobName}`;
+}
+
+/**
+ * Minutes a check-in may be late before Sentry calls the occurrence missed.
+ *
+ * The ticker fires on the minute, so anything late is a real fault (the
+ * container is down, mid-redeploy, or its clock has drifted). Five minutes
+ * absorbs a Railway deploy swap without swallowing an outage, and stays well
+ * inside the 15-minute stagger between the heatmap prewarms.
+ */
+const CHECKIN_MARGIN_MINUTES = 5;
+
+/**
+ * Sentry expects `maxRuntime` in whole minutes. A run is already hard-bounded
+ * by `timeoutMs`, so derive from that rather than inventing a second number,
+ * and round up plus a minute: the check-in closes after the job returns, and a
+ * `maxRuntime` that equals the timeout exactly would flag the slowest legal run
+ * as a runtime failure.
+ */
+function maxRuntimeMinutes(timeoutMs: number): number {
+  return Math.ceil(timeoutMs / 60_000) + 1;
+}
+
+/** The `MonitorConfig` shape Sentry upserts from the first check-in. */
+export type CronMonitorConfig = {
+  readonly schedule: { readonly type: 'crontab'; readonly value: string };
+  readonly timezone: string;
+  readonly checkinMargin: number;
+  readonly maxRuntime: number;
+  readonly failureIssueThreshold: number;
+  readonly recoveryThreshold: number;
+};
+
+export function monitorConfigForJob(job: JobDefinition): CronMonitorConfig {
+  return {
+    // Sentry derives "when should the next check-in arrive" from this, which is
+    // what makes a *missed* run detectable. It must be the registry's own
+    // expression — a stale copy here would have Sentry waiting for the wrong
+    // minute and reporting a healthy job as missed.
+    schedule: { type: 'crontab', value: job.schedule },
+    timezone: job.timezone,
+    checkinMargin: CHECKIN_MARGIN_MINUTES,
+    maxRuntime: maxRuntimeMinutes(job.timeoutMs),
+    // These jobs are weekly. Waiting for a second consecutive failure before
+    // filing an issue would mean hearing about a broken prewarm two weeks late,
+    // so alert on the first one and clear on the first success.
+    failureIssueThreshold: 1,
+    recoveryThreshold: 1,
+  };
+}
+
+export type CronMonitor = {
+  /**
+   * Runs `run` as one monitored occurrence of `job`. Must rethrow whatever
+   * `run` throws — the runner's own bookkeeping and `/health/jobs` depend on
+   * seeing the failure, and a monitor that swallowed it would leave the job
+   * looking green everywhere except Sentry.
+   */
+  monitor<T>(job: JobDefinition, run: () => Promise<T>): Promise<T>;
+};
+
+/**
+ * What the scheduler uses when `SENTRY_DSN` is unset — local runs, CI, and any
+ * deployment that has deliberately not been given a DSN. Calls straight
+ * through, so job behaviour is identical with and without monitoring.
+ */
+export const noopCronMonitor: CronMonitor = {
+  monitor: (_job, run) => run(),
+};
+
+/** The one Sentry function this package needs; injected so tests can record it. */
+export type WithMonitorFn = <T>(slug: string, callback: () => T, config: CronMonitorConfig) => T;
+
+export function createCronMonitor(withMonitor: WithMonitorFn): CronMonitor {
+  return {
+    monitor: (job, run) => withMonitor(monitorSlugForJob(job.name), run, monitorConfigForJob(job)),
+  };
+}

--- a/packages/scheduler/src/monitoring/sentry.ts
+++ b/packages/scheduler/src/monitoring/sentry.ts
@@ -1,0 +1,61 @@
+/**
+ * Sentry wiring for the scheduler process.
+ *
+ * Deliberately split from `cron-monitor.ts`, which is pure and takes the one
+ * Sentry function it needs as a parameter. Only this module imports the SDK, so
+ * the rest of the package (and every test) stays free of a global init.
+ */
+import * as Sentry from '@sentry/node';
+import type { SchedulerLogger } from '../logger';
+import { createCronMonitor, noopCronMonitor, type CronMonitor } from './cron-monitor';
+
+export type SetupCronMonitoringOptions = {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly logger: SchedulerLogger;
+};
+
+const DEFAULT_SENTRY_ENVIRONMENT = 'production';
+
+/**
+ * Initialises Sentry and returns the monitor the runner should use.
+ *
+ * Unlike `packages/web` and `packages/backend`, there is **no hardcoded DSN
+ * fallback**. Those two run only where we deploy them; the scheduler CLI is
+ * also what an operator runs by hand against production (`scheduler run
+ * cleanup`, see docs/scheduler.md), and a baked-in DSN would file that
+ * laptop's output against the production project. An unset `SENTRY_DSN` is a
+ * supported configuration, not a mistake — so it degrades to a no-op monitor
+ * and says so once, rather than throwing.
+ *
+ * Call exactly once, from `scheduler start`. The one-shot `run <job>` path
+ * never calls it: a manual run is not a scheduled occurrence, and checking it
+ * in would either resolve a genuinely missed occurrence or, worse, teach the
+ * monitor that the job is healthy while the ticker is dead.
+ */
+export function setupCronMonitoring({ env = process.env, logger }: SetupCronMonitoringOptions): CronMonitor {
+  const dsn = env.SENTRY_DSN?.trim();
+  if (!dsn) {
+    logger.warn('SENTRY_DSN is not set; scheduler cron monitors are disabled', {
+      hint: 'Set SENTRY_DSN to the same DSN packages/web uses server-side to get missed-run alerts.',
+    });
+    return noopCronMonitor;
+  }
+
+  const environment = env.SENTRY_ENVIRONMENT?.trim() || DEFAULT_SENTRY_ENVIRONMENT;
+  Sentry.init({
+    dsn,
+    environment,
+    // Matches the backend. Errors from a job are already logged with their HTTP
+    // status; Sentry is here for the crons, and tracing a process that makes
+    // seven requests a week would be noise.
+    enableLogs: true,
+    serverName: 'boardsesh-scheduler',
+  });
+
+  logger.info('sentry cron monitors enabled', { environment });
+  return createCronMonitor(
+    // Sentry's withMonitor is generic over the callback's return type; the
+    // narrower WithMonitorFn signature is what the runner actually needs.
+    (slug, callback, config) => Sentry.withMonitor(slug, callback, config),
+  );
+}

--- a/packages/scheduler/src/runner.ts
+++ b/packages/scheduler/src/runner.ts
@@ -2,6 +2,7 @@ import type { SchedulerConfig } from './config';
 import type { CronScheduler, CronTask } from './cron/scheduler';
 import { describeError, type SchedulerLogger } from './logger';
 import type { JobDefinition } from './jobs/types';
+import { noopCronMonitor, type CronMonitor } from './monitoring/cron-monitor';
 
 export type JobStatus = {
   readonly name: string;
@@ -45,6 +46,13 @@ export type CreateSchedulerOptions = {
    * manual run can never also start the recurring schedule. Defaults to true.
    */
   readonly registerSchedules?: boolean;
+  /**
+   * Reports each *scheduled* run to a Sentry cron monitor. Defaults to a no-op,
+   * which is what `scheduler run <job>` and every test get: a manual run is not
+   * a scheduled occurrence, and checking one in would mark a genuinely missed
+   * occurrence as healthy.
+   */
+  readonly monitor?: CronMonitor;
 };
 
 type MutableJobState = {
@@ -77,6 +85,7 @@ export function createScheduler({
   cron,
   logger,
   registerSchedules = true,
+  monitor = noopCronMonitor,
 }: CreateSchedulerOptions): Scheduler {
   const duplicateName = jobs.find((job, index) => jobs.findIndex((other) => other.name === job.name) !== index);
   if (duplicateName) {
@@ -135,13 +144,19 @@ export function createScheduler({
       if (state?.running) {
         state.skippedCount += 1;
         logger.warn('job tick skipped; previous run still in flight', { job: job.name, schedule: job.schedule });
+        // No check-in on purpose. A skipped tick did not run, so letting Sentry
+        // record the occurrence as missed is the honest outcome — a job slow
+        // enough to overrun its own interval is worth an issue, and an "ok"
+        // check-in here would report a stuck job as healthy.
         return;
       }
 
       logger.info('job tick', { job: job.name, schedule: job.schedule, timezone: job.timezone });
       // A throwing job must never escape into the cron callback — an unhandled
-      // rejection here would take the whole scheduler process down.
-      void executeJob(job).catch(() => undefined);
+      // rejection here would take the whole scheduler process down. The monitor
+      // still sees the rejection first: it wraps executeJob, and .catch() is
+      // applied to the wrapper's result, not to executeJob directly.
+      void monitor.monitor(job, () => executeJob(job)).catch(() => undefined);
     };
 
     tasks.push(cron.schedule(job.schedule, handler, { timezone: job.timezone }));

--- a/packages/web/app/__tests__/rest-surface-inventory.test.ts
+++ b/packages/web/app/__tests__/rest-surface-inventory.test.ts
@@ -16,9 +16,9 @@
  *    entry disk doesn't" direction — this is the one a subset-only check
  *    (`expect(derived).toContain(...)`) would silently survive, which is why
  *    both directions are asserted.
- *  - A Vercel cron target labelled as if in-repo code called it reds a third
- *    check, which reads the schedules out of vercel.json rather than trusting
- *    the comment next to the row. Set equality alone never looks at verdicts.
+ *  - A scheduled cron target labelled as if in-repo code called it reds a third
+ *    check, which walks the scheduler's seven URLs rather than trusting the
+ *    comment next to the row. Set equality alone never looks at verdicts.
  *
  * This file reads the API tree with readdirSync at run time, so nothing
  * relates it to a route-file diff in test-default's `--changed` run. It is
@@ -26,8 +26,8 @@
  * without that job the guarantees above only hold post-merge on main.
  *
  * `keep-external` = published surface with no in-repo runtime caller by
- * design (an ESP32 firmware target, a documented `/api/v1/*` route, a Vercel
- * cron target, a platform healthcheck target, or a crawler-only redirect shim) — "no caller" is the intended
+ * design (an ESP32 firmware target, a documented `/api/v1/*` route, a
+ * scheduler cron target, a platform healthcheck target, or a crawler-only redirect shim) — "no caller" is the intended
  * steady state here, not evidence of deadness. `keep-caller` = has a live
  * in-repo (web, mobile, or backend) caller. Neither verdict means "safe to
  * delete" — see issue #1889 for the full reasoning per route.
@@ -70,10 +70,10 @@ const VERDICTS: Record<string, Verdict> = {
   'app/api/internal/dev-metadata/route.ts': 'keep-external',
   // Cron targets. Their only trigger is a scheduler outside the web app — no
   // in-repo code ever calls them, which is the intended steady state, not
-  // evidence of deadness. The two below are pinned against packages/web/vercel.json
-  // by `classifies every Vercel cron target as an external surface`; cleanup
-  // has moved to the Railway scheduler (packages/scheduler, docs/scheduler.md)
-  // and so is deliberately absent from that file.
+  // evidence of deadness. All three now fire from the Railway scheduler
+  // (packages/scheduler, docs/scheduler.md), which is why none of them appears
+  // in packages/web/vercel.json any more; `classifies every scheduler cron
+  // target as an external surface` pins that below.
   'app/api/internal/cleanup/route.ts': 'keep-external',
   'app/api/internal/prewarm-heatmap/[board_name]/route.ts': 'keep-external',
   'app/api/internal/profile-percentiles/route.ts': 'keep-external',
@@ -145,6 +145,22 @@ function readCronPaths(): string[] {
 }
 
 /**
+ * The URLs the Railway scheduler triggers on a timer (#4654). Kept in step with
+ * `packages/scheduler/src/jobs/registry.ts` by hand: this test lives in the web
+ * package and must not reach across into the scheduler's source, and the
+ * scheduler's registry.test.ts pins the identical seven rows on its side.
+ */
+const SCHEDULER_CRON_PATHS: readonly string[] = [
+  '/api/internal/cleanup',
+  '/api/internal/prewarm-heatmap/kilter',
+  '/api/internal/prewarm-heatmap/tension',
+  '/api/internal/prewarm-heatmap/decoy',
+  '/api/internal/prewarm-heatmap/touchstone',
+  '/api/internal/prewarm-heatmap/grasshopper',
+  '/api/internal/profile-percentiles',
+];
+
+/**
  * Resolve a scheduled URL (`/api/internal/prewarm-heatmap/kilter`) to the route
  * key that serves it (`app/api/internal/prewarm-heatmap/[board_name]/route.ts`),
  * treating a `[param]` segment as a wildcard. Returns undefined when no route
@@ -180,16 +196,20 @@ describe('REST surface inventory (issue #1889)', () => {
     expect(pinned.get('app/api/internal/ws-auth/route.ts')).toBe('keep-external');
   });
 
-  it('classifies every Vercel cron target as an external surface', () => {
+  it('classifies every scheduler cron target as an external surface', () => {
     // Nothing else reconciles the verdict COLUMN against reality — the two
     // set-equality checks above only look at keys, so a cron route silently
     // relabelled `keep-caller` (which is how all four shipped in #4663) would
     // read as "something in the repo calls this" and invite a future audit to
-    // delete it when the grep comes back empty. The expected list is derived
-    // from vercel.json, so adding a schedule for a route that doesn't exist,
-    // or for one classified as having an in-repo caller, reds.
-    const cronPaths = readCronPaths();
-    expect(cronPaths.length).toBeGreaterThan(0);
+    // delete it when the grep comes back empty.
+    //
+    // This list used to be derived from vercel.json. Since #4654 the trigger is
+    // the Railway scheduler (packages/scheduler/src/jobs/registry.ts), which
+    // this package cannot import, so the seven scheduled URLs are pinned here
+    // instead. The scheduler's own registry.test.ts pins the same seven against
+    // its registry, so a job added or renamed there without a matching route
+    // reds on that side.
+    const cronPaths = SCHEDULER_CRON_PATHS;
 
     const routeKeys = [...pinned.keys()];
     const classified = cronPaths.map((cronPath) => {
@@ -200,8 +220,17 @@ describe('REST surface inventory (issue #1889)', () => {
     expect(classified).toEqual(cronPaths.map((cronPath) => ({ cronPath, verdict: 'keep-external' })));
   });
 
-  it('keeps the paused climb sitemap refresh out of Vercel cron', () => {
+  it('leaves no cron in vercel.json for Vercel to fire', () => {
+    // The last six moved to the scheduler in #4654. A schedule reappearing here
+    // would double-fire the route — Vercel and Railway both hitting it — which
+    // is exactly what the scheduler's VERCEL_OWNED_CRON_PATHS guard exists to
+    // prevent from the other direction.
+    expect(readCronPaths()).toEqual([]);
+  });
+
+  it('keeps the paused climb sitemap refresh unscheduled', () => {
     expect(readCronPaths()).not.toContain('/api/internal/refresh-sitemap-climbs');
+    expect(SCHEDULER_CRON_PATHS).not.toContain('/api/internal/refresh-sitemap-climbs');
   });
 
   it('counts exactly the audited surface', () => {

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -569,11 +569,10 @@ export default withVercelToolbar(
     tunnelRoute: '/monitoring',
 
     webpack: {
-      // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
-      // See the following for more information:
-      // https://docs.sentry.io/product/crons/
-      // https://vercel.com/docs/cron-jobs
-      automaticVercelMonitors: true,
+      // Off since #4654: cron monitors now come from packages/scheduler
+      // (Sentry.withMonitor per job), and vercel.json declares no crons for
+      // this to instrument. See docs/scheduler.md.
+      automaticVercelMonitors: false,
 
       // Tree-shaking options for reducing bundle size
       treeshake: {

--- a/packages/web/vercel.json
+++ b/packages/web/vercel.json
@@ -3,31 +3,5 @@
   "installCommand": "npx --yes pnpm@11.22.0 install --frozen-lockfile",
   "buildCommand": "npx --yes pnpm@11.22.0 --filter=@boardsesh/web run build",
   "framework": "nextjs",
-  "git": { "deploymentEnabled": false },
-  "crons": [
-    {
-      "path": "/api/internal/prewarm-heatmap/kilter",
-      "schedule": "0 4 * * 0"
-    },
-    {
-      "path": "/api/internal/prewarm-heatmap/tension",
-      "schedule": "15 4 * * 0"
-    },
-    {
-      "path": "/api/internal/prewarm-heatmap/decoy",
-      "schedule": "30 4 * * 0"
-    },
-    {
-      "path": "/api/internal/prewarm-heatmap/touchstone",
-      "schedule": "45 4 * * 0"
-    },
-    {
-      "path": "/api/internal/prewarm-heatmap/grasshopper",
-      "schedule": "0 5 * * 0"
-    },
-    {
-      "path": "/api/internal/profile-percentiles",
-      "schedule": "0 6 * * 0"
-    }
-  ]
+  "git": { "deploymentEnabled": false }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -871,6 +871,10 @@ importers:
         version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.11)(happy-dom@20.11.6(bufferutil@4.1.0))(jsdom@28.1.0(canvas@3.2.3)(supports-color@8.1.1))(vite@8.2.2(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/scheduler:
+    dependencies:
+      '@sentry/node':
+        specifier: ^10.69.0
+        version: 10.70.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(supports-color@8.1.1)
     devDependencies:
       '@types/node':
         specifier: ^25.9.5


### PR DESCRIPTION
## Summary

- Moves the last six `packages/web/vercel.json` crons onto `packages/scheduler` — the five staggered `prewarm-heatmap/{kilter,tension,decoy,touchstone,grasshopper}` jobs and `profile-percentiles` — on the same UTC slots, using the same `Authorization: Bearer $CRON_SECRET` trigger `cleanup` already used. The `crons` key is now gone from `vercel.json` entirely (the file itself dies in the Phase 4 scrub).
- Both weekly routes were pinned at `maxDuration = 300`. That was never a measurement — it is Vercel's Pro ceiling, the largest value the platform accepts. A long-lived container has no such ceiling, so they get 15 minutes of real headroom.
- Wraps every **scheduled** run in `Sentry.withMonitor(slug, run, config)`, passing the job's own crontab expression and UTC timezone. Sentry therefore knows when the next check-in is due and raises an issue when one never arrives — the "alert on absence" `automaticVercelMonitors` used to give us, which stops working the moment there is no Vercel deploy metadata to read. `failureIssueThreshold`/`recoveryThreshold` are both 1 because these jobs are weekly; waiting for a second consecutive failure means hearing about a broken prewarm a fortnight late.
- `scheduler run <job>` sends **no** check-in: a manual run is not a scheduled occurrence, and an "ok" from one would resolve a genuinely missed occurrence and report a dead ticker as healthy. A tick skipped while its predecessor is in flight also sends none — it did not run, so letting Sentry mark it missed is the honest outcome.
- `automaticVercelMonitors: false` in `next.config.mjs`, and `docs/scheduler.md` gets the full seven-job table (path, slot, `timeoutMs`, monitor slug), the monitor semantics, and `SENTRY_DSN`/`SENTRY_ENVIRONMENT` as service variables.

**#1875 needs no work.** `git grep user-sync-cron` returns three prose mentions only (`docs/aurora-sync.md` ×2, `docs/branch-deploys.md`), all describing its removal — `/api/internal/user-sync-cron` and the backend's `POST /sync-cron` were both retired in favour of the long-lived aurora/kilter sync daemons. There is no route to register and nothing that silently drops off the schedule at cutover. Recorded in `docs/scheduler.md`.

### Drift guards

The migration is pinned from both sides, and both were mutation-tested:

- `packages/scheduler/src/__tests__/registry.test.ts` asserts `vercel.json` declares no `crons` key at all and pins each of the seven paths to its exact slot as literal data. Re-adding one cron to `vercel.json` reds 3 tests.
- `packages/web/app/__tests__/rest-surface-inventory.test.ts` (which cannot import across into the scheduler package) pins the same seven URLs as `keep-external` and asserts nothing has reappeared on the Vercel side to double-fire them. The same mutation reds it too.
- The Sentry schedule assertion is pinned as **literals**, not derived from `job.schedule` — comparing the config back to the field it was built from would pass no matter what the schedule became. Changing `prewarm-heatmap-touchstone` from `45 4 * * 0` to `50 4 * * 0` reds it.

`@sentry/node` pinned at `^10.69.0`, matching `packages/backend` (resolves to 10.70.0, the same instance).

> Note: #4271 merged to `main` while this was in flight, so this branches off `main` directly rather than stacking. No rebase needed.

Closes #4654
Closes #1876
Refs #1875

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.
2. Railway scheduler: `/health/jobs` 200 after the next Sunday 04:00–06:00 UTC window.
3. Sentry → Crons shows seven monitors checking in.

## Risk

Risk: 3/5 — moves the weekly prewarm/percentile triggers; merging before the Railway scheduler runs the new image pauses them for at most one week.
