### PR TITLE
fix(ci): stop routed jobs saving a dependency cache on the fleet

### DIFF
--- a/.github/actions/mobile-native-gate/action.yml
+++ b/.github/actions/mobile-native-gate/action.yml
@@ -34,7 +34,12 @@ runs:
     - uses: voidzero-dev/setup-vp@v1
       with:
         node-version: '22.x'
-        cache: true
+        # Only on GitHub-hosted runners. Both callers of this composite are
+        # routed to the self-hosted fleet, where the CI image already bakes the
+        # pnpm store (boardsesh#5008) so a restore buys nothing, while the
+        # matching SAVE uploads to GitHub's cache service over the open
+        # internet. Measured on a bs-ci runner: 148s of a 210s job.
+        cache: ${{ runner.environment == 'github-hosted' }}
 
     - name: Decide whether to build
       id: decide

--- a/.github/workflows/firmware-tests.yml
+++ b/.github/workflows/firmware-tests.yml
@@ -17,7 +17,15 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
+    # Stays GitHub-hosted until the CI image can host it. Routed once and
+    # reverted: actions/setup-python failed with "version '3.11' with
+    # architecture 'x64' was not found for this operating system" because the
+    # image is Debian and actions/python-versions publishes Ubuntu builds only,
+    # so setup-python can neither find 3.11 in the tool cache nor download one.
+    # Debian's system Python is also PEP 668 externally-managed, so this job's
+    # `pip install platformio` would fail even once the lookup succeeded.
+    # Re-route when the image ships a standalone Python in the tool cache.
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/firmware-tests.yml
+++ b/.github/workflows/firmware-tests.yml
@@ -27,7 +27,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # Only on GitHub-hosted runners. From a self-hosted runner the
+          # matching cache SAVE uploads to GitHub's cache service over the
+          # open internet, which costs far more than the restore saves.
+          # Empty disables caching; setup-python's input is a string, not a
+          # boolean, so the gate selects the value.
+          cache: ${{ runner.environment == 'github-hosted' && 'pip' || '' }}
 
       - name: Install PlatformIO
         run: |

--- a/.github/workflows/pr-test-plan.yml
+++ b/.github/workflows/pr-test-plan.yml
@@ -113,7 +113,12 @@ jobs:
         if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
         with:
           node-version: '22.x'
-          cache: true
+          # Only on GitHub-hosted runners. The self-hosted CI image already
+          # bakes the pnpm store (boardsesh#5008), so a cache restore buys
+          # nothing there while the matching SAVE uploads to GitHub's cache
+          # service over the open internet. Measured on a bs-ci runner: the
+          # setup-vp post step took 148s of a 210s job, against 0s hosted.
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
         run: vp install --frozen-lockfile

--- a/scripts/__tests__/ci-runner-routing.test.ts
+++ b/scripts/__tests__/ci-runner-routing.test.ts
@@ -50,15 +50,15 @@ const ROUTED_RUNS_ON = `    runs-on: ${ROUTING_EXPRESSION}`;
  * deploy and release workflows may never be.
  */
 const ROUTED_JOBS: ReadonlyArray<readonly [workflow: string, job: string]> = [
-  // Wave 0 canaries: cheap, secret-free, and between them they exercise the
-  // whole runner contract — GITHUB_TOKEN, checkout over a seeded git object
-  // store, `vp install` against the warm pnpm store, and the hostedtoolcache
-  // Python prefill.
+  // Wave 0 canary: cheap, secret-free, and it exercises the core of the runner
+  // contract — GITHUB_TOKEN, checkout over a seeded git object store, and
+  // `vp install` against the warm pnpm store.
   ['pr-test-plan.yml', 'check'],
-  ['firmware-tests.yml', 'test'],
-  // Wave 1: the measured worst offenders. Both gates are ~50s of work that
-  // waited ~25 minutes for a slot (1475s and 1666s on runs 33465942874 and
-  // 33465859594). Their macOS/APK build jobs stay hosted.
+  // firmware-tests.yml `test` was the second canary and is deliberately NOT
+  // here. Routing it surfaced that the image cannot host it at all: the image
+  // is Debian, actions/python-versions ships Ubuntu builds only, and the tool
+  // cache has no Python prefill, so setup-python has nothing to find and
+  // nothing it can download. Re-add once the image ships a standalone Python.
   ['ios-rn-ci.yml', 'gate'],
   ['android-pr-rn.yml', 'gate'],
 ];

--- a/scripts/__tests__/ci-runner-routing.test.ts
+++ b/scripts/__tests__/ci-runner-routing.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import {
   githubYamlPaths,
   isRoutedRunsOn,
+  isWorkflow,
   jobBlocks,
   routedJobNames,
   withoutCommentLines,
@@ -224,4 +225,41 @@ describe('self-hosted runner routing', () => {
       expect(runnersCallLine).toContain('--paginate');
     });
   });
+});
+
+describe('routed jobs must not save a dependency cache on the fleet', () => {
+  // Measured on bs-ci-1-12: the setup-vp POST step (its cache save) took 148s
+  // of a 210s job, against 0s on GitHub-hosted, because a self-hosted runner
+  // uploads to GitHub's cache service over the open internet. It is also
+  // redundant there -- the CI image bakes the pnpm store, which is why
+  // `vp install` measured 1s on both. Left unguarded, migrating a workflow to
+  // the fleet silently makes it several times SLOWER while still passing.
+  const cacheEnabled = /^\s*cache:\s*true\s*$/;
+  // Actions differ in what their `cache` input accepts -- setup-vp takes a
+  // boolean, setup-python a string like 'pip' -- so the invariant is that the
+  // value is gated on runner.environment, not that it takes one exact form.
+  const gated = /^\s*cache:\s*\$\{\{.*runner\.environment\s*==\s*'github-hosted'.*\}\}\s*$/;
+
+  for (const workflowPath of githubYamlPaths()) {
+    const source = readFileSync(workflowPath, 'utf8');
+    if (!isWorkflow(source)) continue;
+
+    const blocks = jobBlocks(source);
+    for (const jobName of routedJobNames(source)) {
+      const lines = withoutCommentLines((blocks.get(jobName) ?? []).join('\n'));
+
+      it(`${workflowPath} :: ${jobName} gates any dependency cache on runner.environment`, () => {
+        expect(
+          lines.filter((line) => cacheEnabled.test(line)),
+          `${jobName} runs on the fleet, so \`cache: true\` costs more than it saves; ` +
+            `gate it with \`cache: \${{ runner.environment == 'github-hosted' }}\``,
+        ).toEqual([]);
+
+        // A job that configures caching at all must use the gated form.
+        if (lines.some((line) => /^\s*cache:/.test(line))) {
+          expect(lines.some((line) => gated.test(line))).toBe(true);
+        }
+      });
+    }
+  }
 });

--- a/scripts/__tests__/ci-runner-routing.test.ts
+++ b/scripts/__tests__/ci-runner-routing.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -234,11 +234,45 @@ describe('routed jobs must not save a dependency cache on the fleet', () => {
   // redundant there -- the CI image bakes the pnpm store, which is why
   // `vp install` measured 1s on both. Left unguarded, migrating a workflow to
   // the fleet silently makes it several times SLOWER while still passing.
+  //
+  // This MUST follow local composite actions. The first version of this test
+  // only read the workflow job block and passed while both Wave 1 gates still
+  // paid the upload, because their `cache: true` lives in
+  // .github/actions/mobile-native-gate rather than in the job.
   const cacheEnabled = /^\s*cache:\s*true\s*$/;
   // Actions differ in what their `cache` input accepts -- setup-vp takes a
   // boolean, setup-python a string like 'pip' -- so the invariant is that the
   // value is gated on runner.environment, not that it takes one exact form.
   const gated = /^\s*cache:\s*\$\{\{.*runner\.environment\s*==\s*'github-hosted'.*\}\}\s*$/;
+  const localAction = /^\s*-?\s*uses:\s*\.\/(\.github\/actions\/[A-Za-z0-9._-]+)\s*$/;
+
+  /** Job body plus every local composite action it reaches, transitively. */
+  function reachableSources(jobLines: string[]): string[] {
+    const collected = [jobLines.join('\n')];
+    const pending = [...jobLines];
+    const visited = new Set<string>();
+
+    while (pending.length > 0) {
+      const match = localAction.exec(pending.shift() ?? '');
+      if (!match) continue;
+
+      const actionDir = match[1];
+      if (visited.has(actionDir)) continue;
+      visited.add(actionDir);
+
+      // action.yml or action.yaml, whichever exists.
+      const actionPath = [`${actionDir}/action.yml`, `${actionDir}/action.yaml`].find((candidate) =>
+        existsSync(candidate),
+      );
+      expect(actionPath, `${actionDir} is used but has no action.yml`).toBeDefined();
+
+      const actionSource = readFileSync(actionPath as string, 'utf8');
+      collected.push(actionSource);
+      // Composites can invoke composites.
+      pending.push(...actionSource.split('\n'));
+    }
+    return collected;
+  }
 
   for (const workflowPath of githubYamlPaths()) {
     const source = readFileSync(workflowPath, 'utf8');
@@ -246,16 +280,17 @@ describe('routed jobs must not save a dependency cache on the fleet', () => {
 
     const blocks = jobBlocks(source);
     for (const jobName of routedJobNames(source)) {
-      const lines = withoutCommentLines((blocks.get(jobName) ?? []).join('\n'));
+      const lines = reachableSources(blocks.get(jobName) ?? []).flatMap((text) => withoutCommentLines(text));
 
-      it(`${workflowPath} :: ${jobName} gates any dependency cache on runner.environment`, () => {
+      it(`${workflowPath} :: ${jobName} gates every dependency cache it reaches`, () => {
         expect(
           lines.filter((line) => cacheEnabled.test(line)),
-          `${jobName} runs on the fleet, so \`cache: true\` costs more than it saves; ` +
+          `${jobName} runs on the fleet, so \`cache: true\` costs more than it saves ` +
+            `(check the local composite actions it uses, not just the job body); ` +
             `gate it with \`cache: \${{ runner.environment == 'github-hosted' }}\``,
         ).toEqual([]);
 
-        // A job that configures caching at all must use the gated form.
+        // Anything that configures caching at all must use the gated form.
         if (lines.some((line) => /^\s*cache:/.test(line))) {
           expect(lines.some((line) => gated.test(line))).toBe(true);
         }


### PR DESCRIPTION
The first real job on the homelab fleet (epic #5005) ran in **210s** against
**50s** GitHub-hosted. The step breakdown says where it went:

| step | self-hosted | GitHub-hosted |
| --- | ---: | ---: |
| `actions/checkout` | 15s | 8s |
| `setup-vp` | 33s | 37s |
| Install dependencies | **1s** | **1s** |
| **Post `setup-vp`** | **148s** | **0s** |

That post step is the cache **save**. From a self-hosted runner it uploads to
GitHub's cache service over the open internet; hosted, the service is internal
and it's free.

The restore buys nothing on the fleet either — the CI image bakes the pnpm store
(#5008), which is exactly why `vp install` measured 1s on *both*. So the cache
was pure overhead. Gating it should bring the job back in line with hosted.

`firmware-tests` had the same pattern through `setup-python`'s `cache: 'pip'`.
That input is a string rather than a boolean, so the gate selects the value
instead of a true/false.

### Why a test

This failure mode is invisible. Migrating a workflow to the fleet with caching
left on makes it several times **slower while still passing** — nothing in
review or in a green check would show it. The guard asserts over every job
carrying the routing expression, so the next wave can't reintroduce it.

Mutation-tested; it also caught a mistake of mine mid-change (I'd edited
`ios-rn-ci`'s `setup-vp`, which is in `build-and-test` on `macos-26`, not on the
fleet — reverted).

Not addressed here: checkout is still 15s vs 8s. The seeded alternates should
help most on `fetch-depth: 0` workflows, and this job is shallow, so that wants
its own measurement rather than a guess.

## Release Notes

none

## Test plan

1. CI green.
2. On a routed job, the post-`setup-vp` step drops from ~148s to ~0s.

## Risk

Risk: 1/5 — CI-only. On GitHub-hosted runners the expression evaluates to the
previous value, so hosted behaviour is unchanged.