### PR TITLE
feat(ci): ship Python in the CI image's hosted tool cache

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -268,8 +268,19 @@ RUN node_version="$(node --version)" && \
     tool_directory="/opt/hostedtoolcache/node/${node_version#v}/x64" && \
     mkdir -p "$tool_directory" && \
     cp -a /usr/local/bin /usr/local/lib /usr/local/include "$tool_directory/" && \
-    touch "/opt/hostedtoolcache/node/${node_version#v}/x64.complete" && \
-    chown -R runner:runner /opt/hostedtoolcache
+    touch "/opt/hostedtoolcache/node/${node_version#v}/x64.complete"
+
+# Python for the tool cache too. See docker/ci/install-python.sh for why apt
+# cannot serve this (setup-python only downloads Ubuntu builds, and Debian's
+# system Python is PEP 668 externally-managed so `pip install` fails against
+# it). Versions are pinned so a rebuild cannot silently change the interpreter
+# a job runs; setup-python resolves a request like '3.11' to the highest match
+# present, so a pinned patch release still satisfies it.
+ARG PYTHON_VERSIONS="3.11.16 3.12.14"
+COPY --from=ciscripts --chmod=0755 install-python.sh /usr/local/bin/install-python.sh
+RUN /usr/local/bin/install-python.sh ${PYTHON_VERSIONS}
+
+RUN chown -R runner:runner /opt/hostedtoolcache
 
 # The agent, pinned with a checksum rather than "whatever is latest at build
 # time": a rebuild must not silently change the thing that executes every

--- a/docker/ci/install-python.sh
+++ b/docker/ci/install-python.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Install one or more Pythons into the hosted tool cache, in the exact layout
+# actions/setup-python looks for (issue #5050).
+#
+#   install-python.sh 3.11.16 3.12.14
+#
+# Why not apt. Two independent reasons, either of which alone would be fatal:
+#
+#   * setup-python checks the tool cache and otherwise downloads a build from
+#     actions/python-versions, which publishes UBUNTU builds only. On this
+#     Debian image the lookup fails outright with "The version '3.11' with
+#     architecture 'x64' was not found for this operating system", so an apt
+#     Python would not be found even if it were present.
+#   * Debian's system Python is PEP 668 externally-managed, so `pip install`
+#     into it fails. firmware-tests does exactly that (`pip install platformio`).
+#
+# The upstream tarballs solve both: relocatable, not externally managed, and
+# their own setup.sh writes the layout plus the `.complete` marker file that
+# setup-python actually tests for (the marker, not the directory, is what it
+# checks).
+
+set -Eeuo pipefail
+
+# 22.04 is deliberate, not merely "recent enough". That build targets glibc
+# 2.35, older than bookworm's 2.36, so it runs here. The 24.04 build targets
+# 2.39 and would fail at exec time — on a runner that would look like a broken
+# job rather than a bad image.
+: "${PYTHON_BUILD_PLATFORM:=22.04}"
+: "${AGENT_TOOLSDIRECTORY:=/opt/hostedtoolcache}"
+export AGENT_TOOLSDIRECTORY
+
+MANIFEST_URL=https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+
+[ "$#" -gt 0 ] || { echo "usage: $0 <version>..." >&2; exit 2; }
+
+manifest="$(mktemp)"
+trap 'rm -rf -- "$manifest" "${workdir:-}"' EXIT
+curl -fsSL -o "$manifest" "$MANIFEST_URL"
+
+for version in "$@"; do
+  # node, not python: the whole point is that this runs before a usable Python
+  # exists, and the base image is node:22.
+  download_url="$(
+    MANIFEST_PATH="$manifest" WANT_VERSION="$version" WANT_PLATFORM="$PYTHON_BUILD_PLATFORM" \
+      node -e '
+        const releases = JSON.parse(require("fs").readFileSync(process.env.MANIFEST_PATH, "utf8"));
+        const release = releases.find((entry) => entry.version === process.env.WANT_VERSION);
+        if (!release) throw new Error(`no release for ${process.env.WANT_VERSION}`);
+        const file = release.files.find(
+          (candidate) =>
+            candidate.platform === "linux" &&
+            candidate.platform_version === process.env.WANT_PLATFORM &&
+            candidate.arch === "x64",
+        );
+        if (!file) {
+          throw new Error(
+            `no linux-${process.env.WANT_PLATFORM}-x64 build for ${process.env.WANT_VERSION}`,
+          );
+        }
+        process.stdout.write(file.download_url);
+      '
+  )"
+
+  echo "Installing Python ${version} from ${download_url}"
+  workdir="$(mktemp -d)"
+  curl -fsSL "$download_url" | tar xz -C "$workdir"
+  # setup.sh ships without the executable bit in the tarball.
+  ( cd "$workdir" && bash ./setup.sh )
+  rm -rf -- "$workdir"
+
+  # Prove it landed where setup-python will look, rather than trusting
+  # setup.sh's exit code. A missing marker is the failure mode that would only
+  # show up later as a mysterious re-download on every job.
+  marker="${AGENT_TOOLSDIRECTORY}/Python/${version}/x64.complete"
+  [ -f "$marker" ] || { echo "expected marker missing: ${marker}" >&2; exit 1; }
+  "${AGENT_TOOLSDIRECTORY}/Python/${version}/x64/bin/python3" --version
+done

--- a/scripts/__tests__/ci-image-workflow.test.ts
+++ b/scripts/__tests__/ci-image-workflow.test.ts
@@ -152,6 +152,55 @@ describe('Dockerfile.ci: the image is runnable, not a data blob', () => {
   });
 });
 
+describe('Dockerfile.ci: the hosted tool cache is prefilled', () => {
+  // setup-node/setup-python re-download their toolchain on EVERY job unless
+  // the tool cache has the exact layout AND the sibling `.complete` marker --
+  // the marker is what the actions test for, not the directory.
+  //
+  // Python additionally cannot come from apt, for two independent reasons:
+  // setup-python only downloads Ubuntu builds and this image is Debian (so the
+  // lookup fails outright), and Debian's system Python is PEP 668
+  // externally-managed so `pip install` fails against it. Issue #5050.
+  const codeLines = dockerfileLines();
+
+  it('prefills Node with its .complete marker', () => {
+    expect(dockerfileSource).toMatch(/hostedtoolcache\/node\/\$\{node_version#v\}\/x64\.complete/);
+  });
+
+  it('installs Python from actions/python-versions, not apt', () => {
+    expect(dockerfileSource).toMatch(/COPY --from=ciscripts[^\n]*install-python\.sh/);
+    expect(codeLines.some((line) => line.includes('/usr/local/bin/install-python.sh'))).toBe(true);
+    // An apt Python would be found by neither setup-python nor pip. Checked
+    // per code line rather than with a regex over the apt block, because that
+    // block is line-continued and `[^\n]*` cannot cross the continuations.
+    expect(codeLines.filter((line) => line.includes('python3-pip'))).toEqual([]);
+  });
+
+  it('pins the Python versions so a rebuild cannot change the interpreter', () => {
+    const pinned = codeLines.find((line) => line.startsWith('ARG PYTHON_VERSIONS='));
+    expect(pinned, 'ARG PYTHON_VERSIONS= not found').toBeDefined();
+    // Every entry must be a full x.y.z, not a floating '3.11'.
+    const versions = (pinned as string)
+      .replace(/^ARG PYTHON_VERSIONS=/, '')
+      .replace(/"/g, '')
+      .trim()
+      .split(/\s+/);
+    expect(versions.length).toBeGreaterThan(0);
+    for (const version of versions) {
+      expect(version, `${version} is not a pinned patch release`).toMatch(/^\d+\.\d+\.\d+$/);
+    }
+  });
+
+  it('chowns the tool cache to the job user AFTER Python lands in it', () => {
+    // Jobs run as `runner`. A chown that ran before the Python install would
+    // leave it root-owned, and setup-python would fail to use it.
+    const pythonIndex = codeLines.findIndex((line) => line.includes('install-python.sh') && line.startsWith('RUN'));
+    const chownIndex = codeLines.findIndex((line) => /^RUN chown -R runner:runner \/opt\/hostedtoolcache$/.test(line));
+    expect(pythonIndex).toBeGreaterThan(-1);
+    expect(chownIndex).toBeGreaterThan(pythonIndex);
+  });
+});
+
 describe('Dockerfile.ci: every pack layer names its tip as a ref', () => {
   // The bug this pins was found by running the image, not by reading it.
   // `git fetch` negotiation is driven by the fetching repo's REFS: a seed


### PR DESCRIPTION
Closes #5050.

Routing `firmware-tests` to the fleet failed with:

```
##[error]The version '3.11' with architecture 'x64' was not found for this operating system.
```

Two independent causes, either fatal on its own:

- **`setup-python` had nothing to find and nothing to fetch.** It checks the tool cache, then falls back to downloading from `actions/python-versions` — which publishes **Ubuntu** builds only. The image is Debian, and only Node was prefilled.
- **Debian's system Python is PEP 668 externally-managed**, so `pip install` fails against it — and this job does `pip install platformio`.

The upstream tarballs fix both: relocatable, not externally managed, and their own `setup.sh` writes the layout plus the `.complete` marker that setup-python actually tests for (the marker, not the directory, is what it checks).

**The 22.04 build is deliberate, not just "recent enough".** It targets glibc 2.35, older than bookworm's 2.36, so it runs here. The 24.04 build targets 2.39 and would fail at exec time — which on a runner looks like a broken job rather than a bad image.

### Verified in the built image, as the `runner` user

```
tool cache:  3.11.16  3.12.14
markers:     /opt/hostedtoolcache/Python/3.11.16/x64.complete
             /opt/hostedtoolcache/Python/3.12.14/x64.complete
ownership:   runner:runner
pip:         pio → PlatformIO Core, version 6.1.19
node cache:  22.23.2 (intact)
```

Logic lives in `docker/ci/install-python.sh` (shellcheck-clean) rather than an inline URL construction in the Dockerfile, which was unreadable.

### Follow-up

`firmware-tests` is **not** re-routed here. That waits until this image is published and confirmed to carry Python — a job joins the fleet when the fleet can run it.

## Release Notes

none

## Test plan

1. CI green.
2. After merge, dispatch `ci-image.yml`; the published image carries both interpreters.

## Risk

Risk: 2/5 — CI image only. Adds two layers to the image and nothing to the
existing CI path. If the install broke, the image build fails loudly rather
than shipping a subtly broken interpreter.