### PR TITLE
docs(repo): Railway domain verification needs the dashboard-only ownership TXT

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -481,6 +481,8 @@ gh secret set CLOUDFLARE_ACCOUNT_ID --env Production
 
 ### Flip runbook
 
+> **Railway origins:** before flipping any hostname to a `*.up.railway.app` target, add Railway's `_railway-verify.<host>` ownership TXT (dashboard-only value) and wait for the domain to show `verified: true` — see docs/production-deploy.md, "Railway custom-domain verification".
+
 ```bash
 # 1. Dry-run (default) — prints the diff, exits non-zero if there's drift. Never mutates.
 CLOUDFLARE_API_TOKEN=... vp run cf:apply

--- a/docs/production-deploy.md
+++ b/docs/production-deploy.md
@@ -186,6 +186,29 @@ other stale with nothing to reconcile them. Keep it at one replica until a Redis
 `cacheHandler` exists (#4658). Scale the backend horizontally instead — it is
 stateless and coordinates through Redis.
 
+
+### Railway custom-domain verification (learned the hard way, 2026-09-01)
+
+Railway attaches a custom domain only after TWO records exist, and its API
+reports only one of them:
+
+1. The CNAME (`www` → `<target>.up.railway.app`) — the only record
+   `domain-status` ever lists. Behind the Cloudflare proxy it is invisible to
+   Railway's checker, but that does not matter given record 2.
+2. An ownership TXT: `_railway-verify.<host>` = `railway-verify=<token>`,
+   shown **only in the Railway dashboard's domain panel**. Without it the
+   domain sits at `verified: false` forever — while `domain-status` shows the
+   DNS as `PROPAGATED` and the certificate as `VALIDATING_OWNERSHIP` with no
+   error. The certificate may even be issued and waiting; the host simply
+   never attaches, and Railway's edge serves `Application not found` (404)
+   for the hostname.
+
+TXT records pass through the Cloudflare proxy, so the domain verifies with
+the proxy ON: no DNS-only toggle is needed, and the proxied flip is safe once
+the TXT exists. Add the TXT (and confirm `verified: true`) BEFORE merging any
+origin-flip PR, and never delete the `_railway-verify.*` records — `www`,
+`updates` and `ota` each keep one.
+
 ## Cut-over sequence
 
 Moving www's production traffic from Vercel to Railway happens in order, one


### PR DESCRIPTION
## Summary

- Adds the missing precondition to the cut-over runbook: Railway attaches a custom domain only after the `_railway-verify.<host>` ownership TXT exists, and that token is visible **only in the dashboard** — `domain-status` reports just the CNAME and can read as healthy while `verified` stays false (tonight's ~80-minute www outage).
- Notes that the TXT passes through the Cloudflare proxy (domains verify proxied; no DNS-only toggle), that the cert can be issued yet unattached, and that `_railway-verify.*` records must never be deleted.
- Cross-references from the Cloudflare flip runbook.

Part of #4648.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 1/5 — docs only.