### PR TITLE
fix(ci): make OTA previews reach testers, and say why when they don't

### DIFF
--- a/.github/workflows/mobile-ota-preview-sweep.yml
+++ b/.github/workflows/mobile-ota-preview-sweep.yml
@@ -30,28 +30,30 @@ jobs:
     timeout-minutes: 15
     # Branch deletion is a dashboard-admin action (the eoo_ key can't do it),
     # so the OTA_ADMIN_* creds — which live in the ota-preview-unattended environment —
-    # are required. The read-only channel LIST uses the app-scoped EOO_TOKEN. That
+    # are required. The inventory LIST needs them too: xprem guards GET /channels and
+    # GET /branches with AnyViewer(), which an app-scoped eoo_ key does not satisfy —
+    # it 403s, and because the sweep fails closed that turned every scheduled run red
+    # from 2026-09-01. The admin session this step already mints covers both. That
     # environment carries NO required reviewers by design; declaring one WITH reviewers
     # would hang this scheduled run forever waiting on approval.
     environment: ota-preview-unattended
-    # EOO_TOKEN / OTA_ADMIN_* / GH_TOKEN are NOT job-level env: that would expose them
-    # to checkout, setup-vp, and `vp install`. Each is scoped to the step that uses
+    # OTA_ADMIN_* / GH_TOKEN are NOT job-level env: that would expose them to
+    # checkout, setup-vp, and `vp install`. Each is scoped to the step that uses
     # it — the gate + delete steps.
     steps:
       - name: Skip if OTA isn't wired
         id: gate
         env:
-          EOO_TOKEN: ${{ secrets.EOO_TOKEN }}
           OTA_ADMIN_PASSWORD: ${{ secrets.OTA_ADMIN_PASSWORD }}
           EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
         run: |
-          # The LIST call needs EOO_TOKEN + EXPO_UPDATES_URL, but the whole point of the
-          # sweep is the DELETE — which needs the dashboard admin creds. Skip (not just
-          # warn) when OTA_ADMIN_PASSWORD is absent so we don't list, find stale
-          # channels, and then fail every delete for lack of a login.
-          if [ -z "$EOO_TOKEN" ] || [ -z "$EXPO_UPDATES_URL" ]; then
+          # Both halves of the sweep — the LIST and the DELETE — run on the dashboard
+          # admin session, so the whole job needs OTA_ADMIN_* plus the server URL. Skip
+          # (not just warn) when OTA_ADMIN_PASSWORD is absent so we don't list, find
+          # stale channels, and then fail every delete for lack of a login.
+          if [ -z "$EXPO_UPDATES_URL" ]; then
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Self-hosted OTA not wired (EOO_TOKEN / EXPO_UPDATES_URL) — skipping sweep."
+            echo "::notice::Self-hosted OTA not wired (EXPO_UPDATES_URL) — skipping sweep."
           elif [ -z "$OTA_ADMIN_PASSWORD" ]; then
             echo "run=false" >> "$GITHUB_OUTPUT"
             echo "::warning::OTA_ADMIN_PASSWORD missing (ota-preview-unattended environment) — the delete can't authenticate, so skipping the sweep. Add it to reap stale preview branches."
@@ -77,7 +79,6 @@ jobs:
       - name: Delete preview channels + branches for non-open PRs
         if: steps.gate.outputs.run == 'true'
         env:
-          EOO_TOKEN: ${{ secrets.EOO_TOKEN }}
           OTA_ADMIN_EMAIL: ${{ vars.OTA_ADMIN_EMAIL }}
           OTA_ADMIN_PASSWORD: ${{ secrets.OTA_ADMIN_PASSWORD }}
           EXPO_UPDATES_URL: ${{ vars.EXPO_UPDATES_URL }}
@@ -134,12 +135,14 @@ jobs:
             echo "::error::Dashboard admin login failed (check OTA_ADMIN_EMAIL / OTA_ADMIN_PASSWORD in the ota-preview-unattended environment) — the sweep can't delete anything."
             exit 1
           fi
+          # Reuse that session for the inventory. xprem guards GET /channels and
+          # GET /branches with AnyViewer(), which an app-scoped eoo_ key does NOT
+          # satisfy — it answers 403 and, because this sweep fails closed, turned
+          # every scheduled run red. The token never leaves this step.
+          ADMIN_TOKEN="$(printf '%s' "$LOGIN_JSON" | jq -r '.token')"
 
-          # List channels via the V3 read API. The app-scoped eoo_ key is accepted on
-          # the GET routes when the request carries `Use-Cli-Auth: true`.
           if ! CHANNELS_JSON="$(curl -fsS \
-            -H "Authorization: Bearer $EOO_TOKEN" \
-            -H 'Use-Cli-Auth: true' \
+            -H "Authorization: Bearer $ADMIN_TOKEN" \
             "$BASE_URL/api/apps/$OTA_APP_ID/channels")"; then
             echo "::error::Could not list channels from the V3 server — refusing to sweep without a trustworthy inventory."
             exit 1
@@ -147,8 +150,7 @@ jobs:
           # List branches too — a pr-<n> branch can outlive its channel when a prior
           # delete reaped the channel but the branch delete didn't land.
           if ! BRANCHES_JSON="$(curl -fsS \
-            -H "Authorization: Bearer $EOO_TOKEN" \
-            -H 'Use-Cli-Auth: true' \
+            -H "Authorization: Bearer $ADMIN_TOKEN" \
             "$BASE_URL/api/apps/$OTA_APP_ID/branches")"; then
             echo "::error::Could not list branches from the V3 server — refusing to sweep without a trustworthy inventory."
             exit 1

--- a/.github/workflows/mobile-ota-preview-sweep.yml
+++ b/.github/workflows/mobile-ota-preview-sweep.yml
@@ -140,6 +140,9 @@ jobs:
           # satisfy — it answers 403 and, because this sweep fails closed, turned
           # every scheduled run red. The token never leaves this step.
           ADMIN_TOKEN="$(printf '%s' "$LOGIN_JSON" | jq -r '.token')"
+          # Not a `secrets.*` value, so nothing masks it automatically — an
+          # ACTIONS_STEP_DEBUG run would otherwise print it in raw step output.
+          echo "::add-mask::$ADMIN_TOKEN"
 
           if ! CHANNELS_JSON="$(curl -fsS \
             -H "Authorization: Bearer $ADMIN_TOKEN" \

--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -550,11 +550,21 @@ jobs:
       - name: Detect whether the PR is behind main
         id: behind
         run: |
-          if git merge-base --is-ancestor origin/main HEAD 2>/dev/null; then
-            echo "behind_main=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "behind_main=true" >> "$GITHUB_OUTPUT"
-          fi
+          # --is-ancestor answers 0 (contained), 1 (not contained) or >1 on a real
+          # error. Keep those three apart: folding an error into "not contained"
+          # would tell a genuinely native PR to rebase, which is the opposite of
+          # what it needs. `unknown` falls back to the generic message.
+          set +e
+          git merge-base --is-ancestor origin/main HEAD
+          ancestry=$?
+          set -e
+          case "$ancestry" in
+            0) behind=false ;;
+            1) behind=true ;;
+            *) behind=unknown
+               echo "::warning::Could not determine whether this PR is behind main (git exit $ancestry)." ;;
+          esac
+          echo "behind_main=$behind" >> "$GITHUB_OUTPUT"
 
       # V3 control-plane: `eoas publish` creates the pr-<n> branch. iOS
       # WITHOUT GOOGLE_MAPS_API_KEY (Apple

--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -684,13 +684,20 @@ jobs:
             // (only a store build carries it), or the PR is merely BEHIND a native
             // change already on main (a rebase republishes it). Saying "needs a
             // TestFlight build" for the second sends the author down the wrong path.
+            //
+            // They can also BOTH be true, and containment cannot separate that case:
+            // telling those apart needs the merge-base's own fingerprint, a third
+            // resolve costing another `vp install` on every mobile PR. So the
+            // behind-main wording promises only that rebasing is the next step, not
+            // that it is sufficient — after the rebase this same check re-runs and
+            // says "needs a TestFlight/Play build" if a native delta really remains.
             const behindMain = process.env.BEHIND_MAIN === 'true';
             // success | skipped (native change) | failure | (didn't run)
             const cell = (outcome, verdict) => {
               if (outcome === 'success') return `✅ published \`${sha}\``;
               if (verdict === 'native-change-required') {
                 return behindMain
-                  ? '⚠️ behind a native change on `main` — rebase to get a preview'
+                  ? '⚠️ behind a native change on `main` — rebase, then re-check'
                   : '⚠️ native change — needs a TestFlight/Play build';
               }
               if (outcome === 'failure') return '❌ publish failed (see the run log)';
@@ -736,10 +743,11 @@ jobs:
             } else if (nativeOnly && behindMain) {
               headline =
                 `No \`${branch}\` preview was published: this PR is **behind a native change on \`main\`**, so ` +
-                `its bundle targets a fingerprint no current build runs. Rebase onto \`main\` and push — that ` +
-                `republishes the preview against the fingerprint testers are actually on.`;
+                `its bundle targets a fingerprint no current build runs. Rebase onto \`main\` and push. If this ` +
+                `PR adds no native code of its own, that republishes the preview against the fingerprint ` +
+                `testers are on; if it does, this check will then say so and it needs a TestFlight/Play build.`;
               deployState = 'inactive';
-              deployDesc = `${branch}: behind a native change on main — rebase`;
+              deployDesc = `${branch}: behind a native change on main — rebase, then re-check`;
             } else if (nativeOnly) {
               headline =
                 `This PR is a **native change**, so it can't ride OTA — ship a TestFlight/Play build to test it. ` +

--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -703,7 +703,11 @@ jobs:
             // this pair is the first thing to compare.
             const fingerprintCell = (own, base) => {
               const mine = own || '—';
-              return mine === base ? `\`${mine}\` (matches \`main\`)` : `\`${mine}\` · main \`${base || '—'}\``;
+              const theirs = base || '—';
+              // Two unresolved hashes are equal but tell you nothing — rendering that
+              // as "matches main" would invent a reassurance out of a failed resolve.
+              if (mine === '—') return '`—` (unresolved)';
+              return mine === theirs ? `\`${mine}\` (matches \`main\`)` : `\`${mine}\` · main \`${theirs}\``;
             };
             const iosFingerprint = fingerprintCell(process.env.FINGERPRINT_IOS, process.env.BASE_FINGERPRINT_IOS);
             const androidFingerprint = fingerprintCell(

--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -430,6 +430,13 @@ jobs:
       verdict_android: ${{ steps.compat.outputs.verdict_android }}
       outcome_ios: ${{ steps.publish_ios.outcome }}
       outcome_android: ${{ steps.publish_android.outcome }}
+      # A preview is only offered to a binary whose runtimeVersion matches EXACTLY,
+      # so the announce comment names the fingerprint it targeted and what main is on.
+      fingerprint_ios: ${{ steps.compat.outputs.fingerprint_ios }}
+      fingerprint_android: ${{ steps.compat.outputs.fingerprint_android }}
+      base_fingerprint_ios: ${{ steps.compat.outputs.base_fingerprint_ios }}
+      base_fingerprint_android: ${{ steps.compat.outputs.base_fingerprint_android }}
+      behind_main: ${{ steps.behind.outputs.behind_main }}
     steps:
       # A manual request can wait behind another branch mutation. Re-check the
       # gate's pinned SHA before any deployment or PR-code execution so a queued
@@ -534,6 +541,21 @@ jobs:
         run: |
           vp run check:mobile-ota-compat -- --write-env --base-dir "$RUNNER_TEMP/main-baseline"
 
+      # `native-change-required` has two causes that need OPPOSITE fixes, and the
+      # fingerprint pair alone can't tell them apart: the PR may ADD native code (only
+      # a store build can carry it), or it may merely be BEHIND a native change that
+      # already landed on main (a rebase republishes it). Containment answers that for
+      # free — the baseline fetch above already put origin/main in this repo. The
+      # shallow main is fine: we only ask whether its tip is in the PR's history.
+      - name: Detect whether the PR is behind main
+        id: behind
+        run: |
+          if git merge-base --is-ancestor origin/main HEAD 2>/dev/null; then
+            echo "behind_main=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "behind_main=true" >> "$GITHUB_OUTPUT"
+          fi
+
       # V3 control-plane: `eoas publish` creates the pr-<n> branch. iOS
       # WITHOUT GOOGLE_MAPS_API_KEY (Apple
       # Maps), Android WITH it — the per-platform split that keeps each published
@@ -626,6 +648,11 @@ jobs:
           VERDICT_ANDROID: ${{ needs.publish.outputs.verdict_android }}
           OUTCOME_IOS: ${{ needs.publish.outputs.outcome_ios }}
           OUTCOME_ANDROID: ${{ needs.publish.outputs.outcome_android }}
+          FINGERPRINT_IOS: ${{ needs.publish.outputs.fingerprint_ios }}
+          FINGERPRINT_ANDROID: ${{ needs.publish.outputs.fingerprint_android }}
+          BASE_FINGERPRINT_IOS: ${{ needs.publish.outputs.base_fingerprint_ios }}
+          BASE_FINGERPRINT_ANDROID: ${{ needs.publish.outputs.base_fingerprint_android }}
+          BEHIND_MAIN: ${{ needs.publish.outputs.behind_main }}
         with:
           script: |
             const branch = process.env.BRANCH;
@@ -643,15 +670,36 @@ jobs:
               return;
             }
 
+            // A skip has two causes needing opposite fixes: the PR ADDS native code
+            // (only a store build carries it), or the PR is merely BEHIND a native
+            // change already on main (a rebase republishes it). Saying "needs a
+            // TestFlight build" for the second sends the author down the wrong path.
+            const behindMain = process.env.BEHIND_MAIN === 'true';
             // success | skipped (native change) | failure | (didn't run)
             const cell = (outcome, verdict) => {
               if (outcome === 'success') return `✅ published \`${sha}\``;
-              if (verdict === 'native-change-required') return '⚠️ native change — needs a TestFlight/Play build';
+              if (verdict === 'native-change-required') {
+                return behindMain
+                  ? '⚠️ behind a native change on `main` — rebase to get a preview'
+                  : '⚠️ native change — needs a TestFlight/Play build';
+              }
               if (outcome === 'failure') return '❌ publish failed (see the run log)';
               return '—';
             };
             const iosCell = cell(process.env.OUTCOME_IOS, process.env.VERDICT_IOS);
             const androidCell = cell(process.env.OUTCOME_ANDROID, process.env.VERDICT_ANDROID);
+            // The runtimeVersion the preview targets. A branch is offered only to a
+            // binary whose fingerprint matches EXACTLY, so when a picker looks empty
+            // this pair is the first thing to compare.
+            const fingerprintCell = (own, base) => {
+              const mine = own || '—';
+              return mine === base ? `\`${mine}\` (matches \`main\`)` : `\`${mine}\` · main \`${base || '—'}\``;
+            };
+            const iosFingerprint = fingerprintCell(process.env.FINGERPRINT_IOS, process.env.BASE_FINGERPRINT_IOS);
+            const androidFingerprint = fingerprintCell(
+              process.env.FINGERPRINT_ANDROID,
+              process.env.BASE_FINGERPRINT_ANDROID,
+            );
             const anyPublished =
               process.env.OUTCOME_IOS === 'success' || process.env.OUTCOME_ANDROID === 'success';
             const anyFailed =
@@ -671,6 +719,13 @@ jobs:
                 `gate pinned). Anyone on a compatible TestFlight / App Store build can load it without a new build:`;
               deployState = 'success';
               deployDesc = `OTA branch ${branch} ready`;
+            } else if (nativeOnly && behindMain) {
+              headline =
+                `No \`${branch}\` preview was published: this PR is **behind a native change on \`main\`**, so ` +
+                `its bundle targets a fingerprint no current build runs. Rebase onto \`main\` and push — that ` +
+                `republishes the preview against the fingerprint testers are actually on.`;
+              deployState = 'inactive';
+              deployDesc = `${branch}: behind a native change on main — rebase`;
             } else if (nativeOnly) {
               headline =
                 `This PR is a **native change**, so it can't ride OTA — ship a TestFlight/Play build to test it. ` +
@@ -696,14 +751,15 @@ jobs:
               '',
               headline,
               ...howto,
-              '| Platform | Status |',
-              '| --- | --- |',
-              `| iOS | ${iosCell} |`,
-              `| Android | ${androidCell} |`,
+              '| Platform | Status | Fingerprint |',
+              '| --- | --- | --- |',
+              `| iOS | ${iosCell} | ${iosFingerprint} |`,
+              `| Android | ${androidCell} | ${androidFingerprint} |`,
               '',
               '<sub>Delivers only to a build whose fingerprint matches this commit (a JS-only change vs ' +
-                '`main`). A native change can\'t ride OTA — ship a TestFlight/Play build. Closing the PR ' +
-                'removes the branch.</sub>',
+                '`main`). A native change can\'t ride OTA — ship a TestFlight/Play build. A fingerprint that ' +
+                'no longer matches `main` means the preview is invisible to current builds until this PR is ' +
+                'rebased. Closing the PR removes the branch.</sub>',
             ].join('\n');
 
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/docs/crowdsourced-qa-mobile.md
+++ b/docs/crowdsourced-qa-mobile.md
@@ -100,3 +100,24 @@ shown and prompted → picked/skipped stopped adding up.
 `qaSurfingAvailable()` is false, so every surf action renders disabled with a hint rather than
 throwing. The screens are still openable — More → **QA: pick a PR (dev)** — so the layout and the
 empty/error states can be checked without a store build.
+
+## No PRs listed?
+
+The screen has three states and they come straight off the update server, so diagnose it there
+rather than on a device — `/branch_lists` needs no credentials:
+
+```bash
+vp run mobile:ota-surf-doctor -- --platform ios --runtime-version <hash>
+```
+
+- **"Previews are switched off"** — Branch Surfing is off for the `production` channel. Turn it on in
+  the xprem dashboard: Channels → select `production` → Branch surfing → on, pattern `pr-*`. The card
+  sits inside the selected channel's detail pane, not on the channel list.
+- **"Nothing to test right now"** — surfing is on, but nothing matches this build. Either no PR has
+  published a preview, or a native change has landed on `main` since they did: a `pr-<n>` branch is
+  offered only to a binary whose runtimeVersion matches it exactly, so every un-rebased PR goes
+  invisible at once. Rebasing those PRs onto `main` republishes them.
+
+Take `<hash>` from a native build's `EXPO_UPDATES_FINGERPRINT_OVERRIDE` — a locally resolved
+fingerprint is macOS-flavoured and won't match what the binaries bake. Full detail:
+`docs/mobile-ota-updates.md` ("Previews go stale when `main`'s fingerprint moves").

--- a/docs/crowdsourced-qa-mobile.md
+++ b/docs/crowdsourced-qa-mobile.md
@@ -118,6 +118,7 @@ vp run mobile:ota-surf-doctor -- --platform ios --runtime-version <hash>
   offered only to a binary whose runtimeVersion matches it exactly, so every un-rebased PR goes
   invisible at once. Rebasing those PRs onto `main` republishes them.
 
-Take `<hash>` from a native build's `EXPO_UPDATES_FINGERPRINT_OVERRIDE` — a locally resolved
-fingerprint is macOS-flavoured and won't match what the binaries bake. Full detail:
+Take `<hash>` from a native build's `EXPO_UPDATES_FINGERPRINT_OVERRIDE`. Run the command bare to
+check only the switch — the branch list needs a real fingerprint, so the script declines to read it
+without one rather than showing you a misleading empty list. Full detail:
 `docs/mobile-ota-updates.md` ("Previews go stale when `main`'s fingerprint moves").

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -738,22 +738,30 @@ whether previews are even **offered**. Use it whenever the mobile Test a PR scre
 the exact call a binary makes and maps the answer onto the three states the app renders:
 
 ```bash
-vp run mobile:ota-surf-doctor                                        # resolves a local fingerprint
-vp run mobile:ota-surf-doctor -- --runtime-version <hash>            # authoritative
+vp run mobile:ota-surf-doctor                                        # is the switch on?
+vp run mobile:ota-surf-doctor -- --platform ios --runtime-version <hash>
 vp run mobile:ota-surf-doctor -- --platform ios --json
 ```
 
 | What it prints | What the tester sees | Fix |
 | --- | --- | --- |
 | `HTTP 404, xprem-branch-surfing: off` | "Previews are switched off" | Turn Branch Surfing on for `production` (pattern `pr-*`) |
-| `HTTP 200, 0 branches` | "Nothing to test right now" | No preview published, or every `pr-*` branch predates the last native change — rebase the PRs |
+| `HTTP 200, 0 branches` (with `--runtime-version`) | "Nothing to test right now" | No preview published, or every `pr-*` branch predates the last native change — rebase the PRs |
 | `HTTP 200, N branches` | the PR list | — |
 
-Pass `--runtime-version` wherever the answer matters. Without it the script resolves this checkout's
-fingerprint locally, and `@expo/fingerprint` is not deterministic across macOS and Linux while
-binaries bake the **Linux** hash — so a locally resolved probe can report an empty list that is pure
-artefact. Take the hash from a native build's `EXPO_UPDATES_FINGERPRINT_OVERRIDE`. iOS and Android
-resolve to different fingerprints, so pair `--runtime-version` with `--platform`.
+The two questions need different inputs, and the script keeps them apart. Whether the **channel**
+will surf is a property of the channel — the server answers the same regardless of who asks — so a
+bare run answers it. Which **branches** are offered is filtered by exact runtimeVersion and platform,
+so a bare run explicitly declines to read the list rather than reporting an empty one.
+
+Pass `--runtime-version` to see the list, taking the hash from a native build's
+`EXPO_UPDATES_FINGERPRINT_OVERRIDE`, and pair it with `--platform` — iOS and Android resolve to
+different fingerprints (`GOOGLE_MAPS_API_KEY` is an Android-only input). The script deliberately does
+**not** resolve a fingerprint locally: that value is wrong twice over — `@expo/fingerprint` is not
+deterministic across macOS and Linux while binaries bake the Linux hash, and `app.config.ts` falls
+back to the EAS updates config unless `EXPO_UPDATES_URL` and the native-build env are set, which
+perturbs the hash again. A locally resolved probe would answer the branch question wrong while
+looking authoritative.
 
 It exits non-zero only when surfing is off or the server is unreachable; an empty list exits 0,
 because "nothing published yet" is a diagnosis rather than a fault.

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -34,7 +34,11 @@ Postgres and left V2 running untouched while its fleet drained. The URL cutover 
   stranded install is store-side only.
 - V3 is the Railway service `boardsesh-ota-v3` (image `ghcr.io/mercuretechnologies/xprem:v3.1.2` —
   see [Versions](#versions-the-cli-pin-and-the-server-image)), backed by a dedicated Railway Postgres
-  and a Tigris bucket `boardsesh-ota-v3`.
+  and a Tigris bucket `boardsesh-ota-v3`. Railway currently pulls that exact release through the
+  **pre-rename** repository path (`ghcr.io/mercuretechnologies/expo-open-ota`, same tag) — upstream
+  renamed expo-open-ota → xprem at v3.1.0 and still publishes both names, so a Railway service that
+  doesn't say `xprem` is not a sign the server is behind. Branch surfing answering on the live server
+  confirms the running build: that route first shipped in v3.1.2-beta2.
 - **Recovery on V3 is forward-only:** publish a fixed OTA, or roll back on V3.
 - **The URL cutover already happened (2026-07-27).** The repo variable `EXPO_UPDATES_URL` (consumed
   by the native build workflows + the OTA publish workflow) now reads
@@ -308,10 +312,17 @@ client requesting an unmapped channel gets `No branch mapping found`. Mapping is
 - **Per-PR previews are branches, not channels.** The production channel enables xprem Branch
   Surfing with the narrow pattern `pr-*`; the official `@xprem/control-center` sends
   `xprem-branch: pr-N`. No per-PR channel or mapping is created.
-- **Cutover order matters.** Keep Branch Surfing off until native iOS and Android builds containing
-  the picker and baked `xprem-branch` header are available to testers. Then enable it on the
-  production channel with `pr-*` in the dashboard. The server currently reports
-  `xprem-branch-surfing: off`; this repository change intentionally does not mutate that setting.
+- **Branch Surfing is ON** for `production` with the pattern `pr-*` (enabled 2026-09-01, once native
+  builds carrying the picker and the baked `xprem-branch` header had reached testers — that ordering
+  is the prerequisite, because a binary without the header cannot surf). While it was off, every
+  tester saw "Previews are switched off" on the Test a PR screen: `/branch_lists` answered `404` with
+  `xprem-branch-surfing: off`, which the client maps to `null`.
+  The toggle is easy to miss — it lives on the dashboard's **Channels** page *inside the selected
+  channel's detail pane* (`BranchSurfingCard`), not on the channel list, and an empty pattern makes
+  it un-toggleable. There is also an API, despite xprem's docs calling it dashboard-only:
+  `PUT /api/apps/{APP_ID}/channels/{CHANNEL}/branch-surfing` with `{"enabled":true,"pattern":"pr-*"}`
+  and an admin session token (permission `channel:branch-surfing`, admin-only).
+  Check the live state from a laptop, no credentials needed: `vp run mobile:ota-surf-doctor`.
 - **Cleanup** logs in with `OTA_ADMIN_EMAIL` + `OTA_ADMIN_PASSWORD` and deletes the `pr-N` branch.
   During migration it first deletes a same-named legacy channel when one exists.
 - **Green-field consequence:** a legacy v1 client that sends **no** `expo-app-id` header gets an
@@ -718,6 +729,35 @@ automatic safety net firing — the downloaded JS failed to boot, so the binary 
 **embedded** bundle. A spike in that rate across the production fleet right after a publish is the
 tell-tale of a broken bundle.
 
+### The surf doctor (`scripts/mobile-ota-surf-doctor.ts`)
+
+The health check asks whether shipped updates **boot**. The surf doctor asks the other question:
+whether previews are even **offered**. Use it whenever the mobile Test a PR screen shows nothing.
+
+`/branch_lists` is an unauthenticated *device* endpoint, so this needs no credentials — it replays
+the exact call a binary makes and maps the answer onto the three states the app renders:
+
+```bash
+vp run mobile:ota-surf-doctor                                        # resolves a local fingerprint
+vp run mobile:ota-surf-doctor -- --runtime-version <hash>            # authoritative
+vp run mobile:ota-surf-doctor -- --platform ios --json
+```
+
+| What it prints | What the tester sees | Fix |
+| --- | --- | --- |
+| `HTTP 404, xprem-branch-surfing: off` | "Previews are switched off" | Turn Branch Surfing on for `production` (pattern `pr-*`) |
+| `HTTP 200, 0 branches` | "Nothing to test right now" | No preview published, or every `pr-*` branch predates the last native change — rebase the PRs |
+| `HTTP 200, N branches` | the PR list | — |
+
+Pass `--runtime-version` wherever the answer matters. Without it the script resolves this checkout's
+fingerprint locally, and `@expo/fingerprint` is not deterministic across macOS and Linux while
+binaries bake the **Linux** hash — so a locally resolved probe can report an empty list that is pure
+artefact. Take the hash from a native build's `EXPO_UPDATES_FINGERPRINT_OVERRIDE`. iOS and Android
+resolve to different fingerprints, so pair `--runtime-version` with `--platform`.
+
+It exits non-zero only when surfing is off or the server is unreachable; an empty list exits 0,
+because "nothing published yet" is a diagnosis rather than a fault.
+
 ### The health check (`scripts/mobile-ota-health-check.ts`)
 
 `vp run mobile:ota-health-check` queries PostHog (HogQL) for `OTA Update Status` events on the
@@ -890,8 +930,10 @@ Postgres, server, DNS) stay manual. Run it with no argument for the ordered runb
    exists). **Don't create/map the `production` channel yet** — the branch it maps to doesn't exist
    until the first `eoas publish --branch production`. Come back and map `production` → `production` **after the first production
    publish** (the first `main` OTA, or a manual `vp run mobile:publish -- --channel production`), via
-   the dashboard. `vp run mobile:ota-setup map` prints the steps. Keep Branch Surfing off until new
-   native builds with `@xprem/control-center` are ready, then enable it on `production` with `pr-*`.
+   the dashboard. `vp run mobile:ota-setup map` prints the steps. Enable Branch Surfing on
+   `production` with pattern `pr-*` only once native builds carrying `@xprem/control-center` and the
+   baked `xprem-branch` header have reached testers — a binary without that header cannot surf. The
+   toggle is on the Channels page inside the selected channel's detail pane.
 7. **Publish credential** — mint an app-scoped `eoo_` API key in the dashboard (the control-plane
    rejects Expo-token auth). Add it as the GitHub repo secret **`EOO_TOKEN`** and also to the
    `ota-preview` environment.
@@ -1107,6 +1149,25 @@ above — no per-tester build. Workflow: `.github/workflows/mobile-ota-preview.y
   that platform is **skipped** — `vp run check:mobile-ota-compat` (the same engine as
   `mobile-ota-check.yml`) gates each platform, and the PR comment says so. The env is held
   byte-identical to the native builds + production publish by `scripts/mobile-ci-env-parity.test.ts`.
+- **Previews go stale when `main`'s fingerprint moves — and the picker just looks empty.** This is
+  the failure mode to know about, because nothing about it is loud. `/branch_lists` offers a branch
+  only to a binary whose runtimeVersion AND platform match it exactly, and the compat check compares
+  each PR against **current** `origin/main`. So a native change landing on `main` does two things at
+  once: every already-published `pr-<n>` branch keeps the old fingerprint and becomes invisible to
+  the new binaries, and every open PR that has not rebased now resolves `native-change-required`, so
+  its next push publishes nothing. The result is a tester on the newest build seeing "Nothing to test
+  right now" while the branches still exist on the server.
+  **The remedy is a rebase**: rebasing a PR onto `main` moves it to `main`'s fingerprint, the compat
+  check returns `ota-compatible`, and the push republishes the preview where current builds can see
+  it. Auto-republishing without the rebase would be wrong — the PR tree still lacks the new native
+  code, so its JS would be served to a binary it was never built against.
+  This bit us on 2026-09-01: a native change at 11:04 orphaned every live preview, and the two
+  surviving branches only reappeared after their PRs were rebased. The PR comment now names both
+  fingerprints and says "rebase" instead of "needs a TestFlight build" when a PR is merely behind.
+  To confirm from a laptop, with the fingerprint a native build baked:
+  `vp run mobile:ota-surf-doctor -- --platform ios --runtime-version <hash>` (take `<hash>` from that
+  build's `EXPO_UPDATES_FINGERPRINT_OVERRIDE`; a locally resolved one is macOS-flavoured and will not
+  match).
 - **Who can publish (security).** The publish uses the app-scoped **`EOO_TOKEN`**, which is scoped to
   the **`ota-preview`** environment. Dashboard admin credentials (`OTA_ADMIN_EMAIL` +
   `OTA_ADMIN_PASSWORD`) live in a SEPARATE **`ota-preview-unattended`** environment and are used only

--- a/scripts/__tests__/mobile-ota-surf-doctor.test.ts
+++ b/scripts/__tests__/mobile-ota-surf-doctor.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildProbeHeaders,
+  doctorExitCode,
+  DEFAULT_BASE_URL,
+  interpretProbe,
+  OTA_APP_ID,
+  OTA_CHANNEL,
+  parseDoctorArgs,
+  runSurfDoctor,
+  stripManifestSuffix,
+  summarizeReports,
+  warnsAboutSharedRuntimeVersion,
+  SURFING_DISABLED_HEADER,
+  type FetchLike,
+  type PlatformReport,
+} from '../mobile-ota-surf-doctor';
+
+const report = (overrides: Partial<PlatformReport> = {}): PlatformReport => ({
+  platform: 'ios',
+  runtimeVersion: 'abc',
+  runtimeVersionSource: 'flag',
+  state: 'branches',
+  branches: [{ name: 'pr-1' }],
+  total: 1,
+  detail: 'HTTP 200, 1 branch',
+  ...overrides,
+});
+
+/** A Response stand-in carrying only what interpretProbe reads. */
+const answer = (status: number, headers: Record<string, string>, body: unknown): Response =>
+  ({
+    status,
+    headers: new Headers(headers),
+    json: async () => body,
+  }) as unknown as Response;
+
+describe('stripManifestSuffix', () => {
+  it('drops the /manifest segment expo-updates points at', () => {
+    expect(stripManifestSuffix('https://updates.boardsesh.com/manifest')).toBe('https://updates.boardsesh.com');
+    expect(stripManifestSuffix('https://updates.boardsesh.com/manifest/')).toBe('https://updates.boardsesh.com');
+  });
+
+  it('leaves a bare base URL alone', () => {
+    expect(stripManifestSuffix('https://updates.boardsesh.com')).toBe('https://updates.boardsesh.com');
+  });
+});
+
+describe('parseDoctorArgs', () => {
+  it('defaults to the production server and both platforms', () => {
+    const args = parseDoctorArgs([], {});
+    expect(args.baseUrl).toBe(DEFAULT_BASE_URL);
+    expect(args.platforms).toEqual(['ios', 'android']);
+    expect(args.runtimeVersion).toBeNull();
+    expect(args.json).toBe(false);
+  });
+
+  it('prefers EXPO_UPDATES_URL over the default, minus its /manifest', () => {
+    expect(parseDoctorArgs([], { EXPO_UPDATES_URL: 'https://example.test/manifest' }).baseUrl).toBe(
+      'https://example.test',
+    );
+  });
+
+  it('lets OTA_BASE_URL win over EXPO_UPDATES_URL', () => {
+    const args = parseDoctorArgs([], { OTA_BASE_URL: 'https://a.test', EXPO_UPDATES_URL: 'https://b.test/manifest' });
+    expect(args.baseUrl).toBe('https://a.test');
+  });
+
+  it('reads flags in both --flag value and --flag=value form', () => {
+    expect(parseDoctorArgs(['--runtime-version', 'deadbeef'], {}).runtimeVersion).toBe('deadbeef');
+    expect(parseDoctorArgs(['--runtime-version=deadbeef'], {}).runtimeVersion).toBe('deadbeef');
+  });
+
+  it('narrows to one platform and ignores the vp -- separator', () => {
+    expect(parseDoctorArgs(['--', '--platform', 'android'], {}).platforms).toEqual(['android']);
+  });
+
+  it('rejects an unknown platform rather than probing nothing', () => {
+    expect(() => parseDoctorArgs(['--platform', 'web'], {})).toThrow(/Unknown --platform/);
+  });
+});
+
+describe('buildProbeHeaders', () => {
+  it('sends exactly what a binary sends, and no xprem-branch', () => {
+    // An absent branch header is what "I am on the channel's own branch" looks
+    // like — the state a tester is in before picking a PR.
+    expect(buildProbeHeaders('abc123', 'ios')).toEqual({
+      'expo-app-id': OTA_APP_ID,
+      'expo-channel-name': OTA_CHANNEL,
+      'expo-runtime-version': 'abc123',
+      'expo-platform': 'ios',
+    });
+    expect(buildProbeHeaders('abc123', 'ios')).not.toHaveProperty('xprem-branch');
+  });
+});
+
+describe('interpretProbe', () => {
+  it('reads a 404 carrying the surfing header as "switched off"', () => {
+    const outcome = interpretProbe(404, new Headers({ [SURFING_DISABLED_HEADER]: 'off' }), null);
+    expect(outcome.state).toBe('surfing-off');
+  });
+
+  it('does NOT read a bare 404 as "switched off"', () => {
+    // A bare 404 is a wrong base URL or a stray proxy. Conflating the two would
+    // send someone to the dashboard to fix a setting that is already correct.
+    const outcome = interpretProbe(404, new Headers(), null);
+    expect(outcome.state).toBe('unreachable');
+    expect(outcome.detail).toMatch(/base URL/);
+  });
+
+  it('separates an empty list from a populated one', () => {
+    expect(interpretProbe(200, new Headers(), { branches: [], total: 0 }).state).toBe('no-branches');
+    const populated = interpretProbe(200, new Headers(), {
+      branches: [{ name: 'pr-42', lastUpdateAt: '2026-09-01T09:26:18Z' }],
+      total: 1,
+    });
+    expect(populated.state).toBe('branches');
+    expect(populated.branches).toEqual([{ name: 'pr-42', lastUpdateAt: '2026-09-01T09:26:18Z' }]);
+  });
+
+  it('keeps the server total even when the page is truncated', () => {
+    const outcome = interpretProbe(200, new Headers(), { branches: [{ name: 'pr-1' }], total: 9 });
+    expect(outcome.total).toBe(9);
+  });
+
+  it('treats a 200 with the wrong shape as unreachable, not as an empty list', () => {
+    // A schema change must not read as "nothing to test" — that is the silent
+    // failure this whole script exists to prevent.
+    expect(interpretProbe(200, new Headers(), { error: 'nope' }).state).toBe('unreachable');
+    expect(interpretProbe(200, new Headers(), null).state).toBe('unreachable');
+  });
+
+  it('reports any other status as unreachable', () => {
+    expect(interpretProbe(500, new Headers(), null).state).toBe('unreachable');
+    expect(interpretProbe(400, new Headers(), null).detail).toBe('HTTP 400');
+  });
+});
+
+describe('doctorExitCode', () => {
+  it('fails when any platform refuses to surf or is unreachable', () => {
+    expect(doctorExitCode([report(), report({ platform: 'android', state: 'surfing-off' })])).toBe(1);
+    expect(doctorExitCode([report({ state: 'unreachable' })])).toBe(1);
+  });
+
+  it('passes on an empty list — that is a diagnosis, not a build failure', () => {
+    expect(doctorExitCode([report({ state: 'no-branches', branches: [], total: 0 })])).toBe(0);
+  });
+});
+
+describe('summarizeReports', () => {
+  it('points a switched-off channel at the dashboard toggle', () => {
+    const text = summarizeReports([report({ state: 'surfing-off', branches: [], total: 0 })], 'https://x.test').join(
+      '\n',
+    );
+    expect(text).toMatch(/Branch surfing is OFF/);
+    expect(text).toMatch(/pattern pr-\*/);
+  });
+
+  it('explains an empty list as a possible fingerprint mismatch', () => {
+    const text = summarizeReports([report({ state: 'no-branches', branches: [], total: 0 })], 'https://x.test').join(
+      '\n',
+    );
+    expect(text).toMatch(/rebase to republish/);
+  });
+
+  it('warns that a locally resolved fingerprint may be a false alarm', () => {
+    const text = summarizeReports([report({ runtimeVersionSource: 'resolved' })], 'https://x.test').join('\n');
+    expect(text).toMatch(/not/);
+    expect(text).toMatch(/deterministic across macOS and Linux/);
+  });
+
+  it('does not add that warning for an explicitly supplied fingerprint', () => {
+    const text = summarizeReports([report({ runtimeVersionSource: 'flag' })], 'https://x.test').join('\n');
+    expect(text).not.toMatch(/deterministic across macOS and Linux/);
+  });
+
+  it('lists each branch with its timestamp', () => {
+    const text = summarizeReports(
+      [report({ branches: [{ name: 'pr-4872', lastUpdateAt: '2026-09-01T11:06:04Z' }] })],
+      'https://x.test',
+    ).join('\n');
+    expect(text).toMatch(/pr-4872.*2026-09-01T11:06:04Z/);
+  });
+});
+
+describe('runSurfDoctor', () => {
+  it('probes ?all=1 with the device headers and reports branches', async () => {
+    const calls: { url: string; headers: Record<string, string> }[] = [];
+    const fetchImpl: FetchLike = async (url, init) => {
+      calls.push({ url, headers: init.headers });
+      return answer(200, {}, { branches: [{ name: 'pr-7' }], total: 1 });
+    };
+    const code = await runSurfDoctor(
+      { baseUrl: 'https://x.test', platforms: ['ios'], runtimeVersion: 'abc', json: true },
+      fetchImpl,
+      {},
+    );
+    expect(code).toBe(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('https://x.test/branch_lists?all=1');
+    expect(calls[0].headers['expo-runtime-version']).toBe('abc');
+  });
+
+  it('exits 1 when the channel refuses to surf', async () => {
+    const fetchImpl: FetchLike = async () => answer(404, { [SURFING_DISABLED_HEADER]: 'off' }, null);
+    const code = await runSurfDoctor(
+      { baseUrl: 'https://x.test', platforms: ['ios'], runtimeVersion: 'abc', json: true },
+      fetchImpl,
+      {},
+    );
+    expect(code).toBe(1);
+  });
+
+  it('falls back to EXPO_UPDATES_FINGERPRINT_OVERRIDE when no flag is given', async () => {
+    const seen: string[] = [];
+    const fetchImpl: FetchLike = async (_url, init) => {
+      seen.push(init.headers['expo-runtime-version']);
+      return answer(200, {}, { branches: [], total: 0 });
+    };
+    await runSurfDoctor(
+      { baseUrl: 'https://x.test', platforms: ['ios'], runtimeVersion: null, json: true },
+      fetchImpl,
+      {
+        EXPO_UPDATES_FINGERPRINT_OVERRIDE: 'from-env',
+      },
+    );
+    expect(seen).toEqual(['from-env']);
+  });
+
+  it('turns a thrown request into unreachable rather than crashing', async () => {
+    const fetchImpl: FetchLike = async () => {
+      throw new Error('ECONNREFUSED');
+    };
+    const code = await runSurfDoctor(
+      { baseUrl: 'https://x.test', platforms: ['ios'], runtimeVersion: 'abc', json: true },
+      fetchImpl,
+      {},
+    );
+    expect(code).toBe(1);
+  });
+});
+
+describe('warnsAboutSharedRuntimeVersion', () => {
+  const args = (over: Partial<Parameters<typeof warnsAboutSharedRuntimeVersion>[0]> = {}) => ({
+    baseUrl: 'https://x.test',
+    platforms: ['ios', 'android'] as ('ios' | 'android')[],
+    runtimeVersion: 'abc',
+    json: false,
+    ...over,
+  });
+
+  it('warns when one fingerprint is applied to both platforms', () => {
+    // iOS and Android fingerprints differ, so this would make one of them read
+    // "no branches" for a reason that has nothing to do with the server.
+    expect(warnsAboutSharedRuntimeVersion(args())).toBe(true);
+  });
+
+  it('stays quiet for a single platform', () => {
+    expect(warnsAboutSharedRuntimeVersion(args({ platforms: ['ios'] }))).toBe(false);
+  });
+
+  it('stays quiet when each platform resolves its own fingerprint', () => {
+    expect(warnsAboutSharedRuntimeVersion(args({ runtimeVersion: null }))).toBe(false);
+  });
+});

--- a/scripts/__tests__/mobile-ota-surf-doctor.test.ts
+++ b/scripts/__tests__/mobile-ota-surf-doctor.test.ts
@@ -5,6 +5,8 @@ import {
   DEFAULT_BASE_URL,
   interpretProbe,
   PROBE_TIMEOUT_MS,
+  resolveProbeRuntimeVersion,
+  SWITCH_PROBE_RUNTIME_VERSION,
   OTA_APP_ID,
   OTA_CHANNEL,
   parseDoctorArgs,
@@ -164,15 +166,25 @@ describe('summarizeReports', () => {
     expect(text).toMatch(/rebase to republish/);
   });
 
-  it('warns that a locally resolved fingerprint may be a false alarm', () => {
-    const text = summarizeReports([report({ runtimeVersionSource: 'resolved' })], 'https://x.test').join('\n');
-    expect(text).toMatch(/not/);
-    expect(text).toMatch(/deterministic across macOS and Linux/);
+  it('declines to read the branch list when no fingerprint was supplied', () => {
+    // The list was filtered by a sentinel, so it is empty by construction.
+    // Reporting it as "nothing published" would be the false alarm this exists to stop.
+    const text = summarizeReports(
+      [report({ state: 'no-branches', branches: [], total: 0, runtimeVersionSource: 'none' })],
+      'https://x.test',
+    ).join('\n');
+    expect(text).toMatch(/switch check only/);
+    expect(text).toMatch(/Branch list NOT checked/);
+    expect(text).not.toMatch(/no branch matches/);
   });
 
-  it('does not add that warning for an explicitly supplied fingerprint', () => {
-    const text = summarizeReports([report({ runtimeVersionSource: 'flag' })], 'https://x.test').join('\n');
-    expect(text).not.toMatch(/deterministic across macOS and Linux/);
+  it('reads the branch list normally once a fingerprint is supplied', () => {
+    const text = summarizeReports(
+      [report({ state: 'no-branches', branches: [], total: 0, runtimeVersionSource: 'flag' })],
+      'https://x.test',
+    ).join('\n');
+    expect(text).toMatch(/no branch matches/);
+    expect(text).not.toMatch(/Branch list NOT checked/);
   });
 
   it('lists each branch with its timestamp', () => {
@@ -181,6 +193,40 @@ describe('summarizeReports', () => {
       'https://x.test',
     ).join('\n');
     expect(text).toMatch(/pr-4872.*2026-09-01T11:06:04Z/);
+  });
+});
+
+describe('resolveProbeRuntimeVersion', () => {
+  const args = (over = {}) => ({
+    baseUrl: 'https://x.test',
+    platforms: ['ios'] as ('ios' | 'android')[],
+    runtimeVersion: null as string | null,
+    json: false,
+    ...over,
+  });
+
+  it('prefers the flag', () => {
+    expect(resolveProbeRuntimeVersion(args({ runtimeVersion: 'abc' }), {})).toEqual({
+      runtimeVersion: 'abc',
+      source: 'flag',
+    });
+  });
+
+  it('falls back to EXPO_UPDATES_FINGERPRINT_OVERRIDE', () => {
+    expect(resolveProbeRuntimeVersion(args(), { EXPO_UPDATES_FINGERPRINT_OVERRIDE: ' env-hash ' })).toEqual({
+      runtimeVersion: 'env-hash',
+      source: 'env',
+    });
+  });
+
+  it('falls back to the sentinel rather than resolving a fingerprint locally', () => {
+    // A local resolve is wrong twice over — macOS vs Linux, and the EAS updates
+    // fallback in app.config.ts — so it would answer the branch question wrong
+    // while looking authoritative.
+    expect(resolveProbeRuntimeVersion(args(), {})).toEqual({
+      runtimeVersion: SWITCH_PROBE_RUNTIME_VERSION,
+      source: 'none',
+    });
   });
 });
 
@@ -283,11 +329,11 @@ describe('warnsAboutSharedRuntimeVersion', () => {
     expect(warnsAboutSharedRuntimeVersion([report({ runtimeVersionSource: 'flag' })])).toBe(false);
   });
 
-  it('stays quiet when each platform resolved its own fingerprint', () => {
+  it('stays quiet for a switch-only probe, whose list is never interpreted', () => {
     expect(
       warnsAboutSharedRuntimeVersion([
-        report({ platform: 'ios', runtimeVersion: 'ios-hash', runtimeVersionSource: 'resolved' }),
-        report({ platform: 'android', runtimeVersion: 'android-hash', runtimeVersionSource: 'resolved' }),
+        report({ platform: 'ios', runtimeVersion: SWITCH_PROBE_RUNTIME_VERSION, runtimeVersionSource: 'none' }),
+        report({ platform: 'android', runtimeVersion: SWITCH_PROBE_RUNTIME_VERSION, runtimeVersionSource: 'none' }),
       ]),
     ).toBe(false);
   });

--- a/scripts/__tests__/mobile-ota-surf-doctor.test.ts
+++ b/scripts/__tests__/mobile-ota-surf-doctor.test.ts
@@ -4,6 +4,7 @@ import {
   doctorExitCode,
   DEFAULT_BASE_URL,
   interpretProbe,
+  PROBE_TIMEOUT_MS,
   OTA_APP_ID,
   OTA_CHANNEL,
   parseDoctorArgs,
@@ -225,6 +226,21 @@ describe('runSurfDoctor', () => {
       },
     );
     expect(seen).toEqual(['from-env']);
+  });
+
+  it('caps each probe with an abort signal so an unreachable server reports instead of hanging', async () => {
+    let seen: AbortSignal | undefined;
+    const fetchImpl: FetchLike = async (_url, init) => {
+      seen = init.signal;
+      return answer(200, {}, { branches: [], total: 0 });
+    };
+    await runSurfDoctor(
+      { baseUrl: 'https://x.test', platforms: ['ios'], runtimeVersion: 'abc', json: true },
+      fetchImpl,
+      {},
+    );
+    expect(seen).toBeInstanceOf(AbortSignal);
+    expect(PROBE_TIMEOUT_MS).toBeGreaterThan(0);
   });
 
   it('turns a thrown request into unreachable rather than crashing', async () => {

--- a/scripts/__tests__/mobile-ota-surf-doctor.test.ts
+++ b/scripts/__tests__/mobile-ota-surf-doctor.test.ts
@@ -257,25 +257,47 @@ describe('runSurfDoctor', () => {
 });
 
 describe('warnsAboutSharedRuntimeVersion', () => {
-  const args = (over: Partial<Parameters<typeof warnsAboutSharedRuntimeVersion>[0]> = {}) => ({
-    baseUrl: 'https://x.test',
-    platforms: ['ios', 'android'] as ('ios' | 'android')[],
-    runtimeVersion: 'abc',
-    json: false,
-    ...over,
-  });
-
-  it('warns when one fingerprint is applied to both platforms', () => {
+  it('warns when one flag fingerprint is applied to both platforms', () => {
     // iOS and Android fingerprints differ, so this would make one of them read
     // "no branches" for a reason that has nothing to do with the server.
-    expect(warnsAboutSharedRuntimeVersion(args())).toBe(true);
+    expect(
+      warnsAboutSharedRuntimeVersion([
+        report({ platform: 'ios', runtimeVersion: 'abc', runtimeVersionSource: 'flag' }),
+        report({ platform: 'android', runtimeVersion: 'abc', runtimeVersionSource: 'flag' }),
+      ]),
+    ).toBe(true);
+  });
+
+  it('warns for the env path too, not just the flag', () => {
+    // EXPO_UPDATES_FINGERPRINT_OVERRIDE supplies one string for every platform
+    // exactly like the flag does, so it carries the identical false alarm.
+    expect(
+      warnsAboutSharedRuntimeVersion([
+        report({ platform: 'ios', runtimeVersion: 'abc', runtimeVersionSource: 'env' }),
+        report({ platform: 'android', runtimeVersion: 'abc', runtimeVersionSource: 'env' }),
+      ]),
+    ).toBe(true);
   });
 
   it('stays quiet for a single platform', () => {
-    expect(warnsAboutSharedRuntimeVersion(args({ platforms: ['ios'] }))).toBe(false);
+    expect(warnsAboutSharedRuntimeVersion([report({ runtimeVersionSource: 'flag' })])).toBe(false);
   });
 
-  it('stays quiet when each platform resolves its own fingerprint', () => {
-    expect(warnsAboutSharedRuntimeVersion(args({ runtimeVersion: null }))).toBe(false);
+  it('stays quiet when each platform resolved its own fingerprint', () => {
+    expect(
+      warnsAboutSharedRuntimeVersion([
+        report({ platform: 'ios', runtimeVersion: 'ios-hash', runtimeVersionSource: 'resolved' }),
+        report({ platform: 'android', runtimeVersion: 'android-hash', runtimeVersionSource: 'resolved' }),
+      ]),
+    ).toBe(false);
+  });
+
+  it('stays quiet when the supplied fingerprints actually differ', () => {
+    expect(
+      warnsAboutSharedRuntimeVersion([
+        report({ platform: 'ios', runtimeVersion: 'ios-hash', runtimeVersionSource: 'flag' }),
+        report({ platform: 'android', runtimeVersion: 'android-hash', runtimeVersionSource: 'flag' }),
+      ]),
+    ).toBe(false);
   });
 });

--- a/scripts/lib/eoas.ts
+++ b/scripts/lib/eoas.ts
@@ -27,9 +27,13 @@
 // `publish` gained `--upload-rate` to cap what was an unbounded `Promise.all`
 // over every asset in the export.
 //
-// Two things still wait on the Railway image moving to
-// `ghcr.io/mercuretechnologies/xprem:v3.1.2` (the project renamed
-// expo-open-ota → xprem; the old image name is still published):
+// Two server-side halves ride the same version, and both are now available:
+// Railway runs v3.1.2, published under the PRE-RENAME image name
+// `ghcr.io/mercuretechnologies/expo-open-ota:v3.1.2` (the project renamed
+// expo-open-ota → xprem at v3.1.0 and still publishes the old name), so reading
+// the Railway dashboard for `xprem:` and finding nothing does not mean the server
+// is behind. Branch surfing answering on the live server confirms it: that route
+// first shipped in v3.1.2-beta2.
 //   * server-side reuse of the previous update's assets (xprem #165) — the half
 //     that drops a repeat publish from ~380 uploads to a handful; and
 //   * `vp run mobile:ota-rollback -- --mode republish`: 3.1.2 lists candidates

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -634,7 +634,11 @@ describe('mobile OTA preview branch isolation + S3 lifecycle coupling', () => {
     // opposite of what it needs. Only the literal 'true' claims the PR is behind.
     expect(preview).toContain('*) behind=unknown');
     expect(preview).toContain("const behindMain = process.env.BEHIND_MAIN === 'true';");
-    expect(preview).toContain('behind a native change on `main` — rebase to get a preview');
+    // Worded as "rebase, then re-check", not "rebase to fix": a PR can be behind
+    // main AND add native code of its own, and containment cannot separate those
+    // without a third fingerprint resolve. Promising a rebase is sufficient would
+    // be wrong in that overlap.
+    expect(preview).toContain('behind a native change on `main` — rebase, then re-check');
     expect(preview).toContain('needs a TestFlight/Play build');
   });
 

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -626,6 +626,10 @@ describe('mobile OTA preview branch isolation + S3 lifecycle coupling', () => {
     const preview = readWorkflow(OTA_PREVIEW);
     expect(preview).toContain('git merge-base --is-ancestor origin/main HEAD');
     expect(preview).toContain('behind_main: ${{ steps.behind.outputs.behind_main }}');
+    // Three-valued on purpose. --is-ancestor exits >1 on a real error, and folding
+    // that into "not contained" would tell a genuinely native PR to rebase — the
+    // opposite of what it needs. Only the literal 'true' claims the PR is behind.
+    expect(preview).toContain('*) behind=unknown');
     expect(preview).toContain("const behindMain = process.env.BEHIND_MAIN === 'true';");
     expect(preview).toContain('behind a native change on `main` — rebase to get a preview');
     expect(preview).toContain('needs a TestFlight/Play build');

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -617,6 +617,9 @@ describe('mobile OTA preview branch isolation + S3 lifecycle coupling', () => {
       );
     }
     expect(preview).toContain('| Platform | Status | Fingerprint |');
+    // Two unresolved hashes compare equal; saying "matches main" there would
+    // invent a reassurance out of a failed resolve.
+    expect(preview).toContain("if (mine === '—') return '`—` (unresolved)';");
   });
 
   it('tells "adds native code" apart from "behind a native change on main"', () => {

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -600,6 +600,49 @@ describe('mobile OTA preview branch isolation + S3 lifecycle coupling', () => {
     expect(sweep).toMatch(/Could not list open PRs[^\n]*\n\s*exit 1/);
   });
 
+  it('carries the compat fingerprints through to the preview comment', () => {
+    // A pr-<n> branch is offered only to a binary whose runtimeVersion matches it
+    // EXACTLY. When a native change lands on main, every un-rebased PR keeps the old
+    // fingerprint, its publish is skipped, and the tester's picker silently empties.
+    // Naming both hashes on the PR is what makes that visible, so keep the chain
+    // wired: the check emits them, the job forwards them, the comment prints them.
+    const check = readFileSync(resolve(REPO_ROOT, 'scripts/mobile-ota-compat-check.ts'), 'utf8');
+    const preview = readWorkflow(OTA_PREVIEW);
+    for (const platform of ['ios', 'android']) {
+      expect(check, `compat check must emit fingerprint_${platform}`).toContain(`\`fingerprint_${platform}=`);
+      expect(check, `compat check must emit base_fingerprint_${platform}`).toContain(`\`base_fingerprint_${platform}=`);
+      expect(preview).toContain(`fingerprint_${platform}: \${{ steps.compat.outputs.fingerprint_${platform} }}`);
+      expect(preview).toContain(
+        `FINGERPRINT_${platform.toUpperCase()}: \${{ needs.publish.outputs.fingerprint_${platform} }}`,
+      );
+    }
+    expect(preview).toContain('| Platform | Status | Fingerprint |');
+  });
+
+  it('tells "adds native code" apart from "behind a native change on main"', () => {
+    // The two need opposite fixes — a store build vs a rebase — so the skip must not
+    // give one message. Containment is the free signal: origin/main is already
+    // fetched for the baseline worktree.
+    const preview = readWorkflow(OTA_PREVIEW);
+    expect(preview).toContain('git merge-base --is-ancestor origin/main HEAD');
+    expect(preview).toContain('behind_main: ${{ steps.behind.outputs.behind_main }}');
+    expect(preview).toContain("const behindMain = process.env.BEHIND_MAIN === 'true';");
+    expect(preview).toContain('behind a native change on `main` — rebase to get a preview');
+    expect(preview).toContain('needs a TestFlight/Play build');
+  });
+
+  it('lists the sweep inventory with the dashboard admin session, not the eoo_ key', () => {
+    // xprem guards GET /channels and GET /branches with AnyViewer(), which an
+    // app-scoped eoo_ key does not satisfy. It answers 403, and because the sweep
+    // fails closed that turned every scheduled run red from 2026-09-01. The step
+    // already mints an admin session for the DELETE; both LISTs reuse it.
+    const sweep = readWorkflow(OTA_PREVIEW_SWEEP);
+    expect(sweep).toContain(`ADMIN_TOKEN="$(printf '%s' "$LOGIN_JSON" | jq -r '.token')"`);
+    expect(sweep).toMatch(/Authorization: Bearer \$ADMIN_TOKEN/);
+    expect(sweep, 'the eoo_ key cannot read these routes — it must not come back').not.toContain('EOO_TOKEN');
+    expect(sweep, 'Use-Cli-Auth was the eoo_ escape hatch that stopped working').not.toContain('Use-Cli-Auth');
+  });
+
   it('publishes the preview to a pr-<number> branch, never production', () => {
     const preview = readWorkflow(OTA_PREVIEW);
     expect(preview).toMatch(/--channel "\$BRANCH" --platform ios/);
@@ -652,12 +695,15 @@ describe('mobile OTA preview branch isolation + S3 lifecycle coupling', () => {
     expect(docs, `docs must document the appId-scoped lifecycle prefix \`${s3Prefix}\``).toContain(s3Prefix);
   });
 
-  it('keeps the OTA app id identical across app.config, the shared const, cleanup, and setup', () => {
+  it('keeps the OTA app id identical across app.config, the shared const, cleanup, setup, and the doctor', () => {
     // The expo-app-id header is baked by app.config.ts (inline — Expo's config loader
     // can't import a sibling .ts) and mirrored in src/lib/ota-app-id.ts for the EAS
-    // preview-build switcher; the cleanup helper (DEFAULT_APP_ID) and the setup runbook
-    // (OTA_APP_ID) address the same app. A drift 404s ("Unknown app id") or mis-routes
-    // previews, and the id is a fingerprint input — so pin all four equal.
+    // preview-build switcher; the cleanup helper (DEFAULT_APP_ID), the setup runbook and
+    // the surf doctor (OTA_APP_ID) address the same app. A drift 404s ("Unknown app id")
+    // or mis-routes previews, and the id is a fingerprint input — so pin all five equal.
+    // They stay literals rather than one shared import because ota-preview-cleanup.ts
+    // runs under bare `node --experimental-strip-types` with no install step, and
+    // app.config.ts is read by a loader that cannot resolve a sibling .ts.
     const idFrom = (rel: string, name: string): string | undefined => {
       const src = readFileSync(resolve(REPO_ROOT, rel), 'utf8');
       return (
@@ -672,6 +718,7 @@ describe('mobile OTA preview branch isolation + S3 lifecycle coupling', () => {
       shared,
     );
     expect(idFrom('scripts/mobile-ota-setup.ts', 'OTA_APP_ID'), 'mobile-ota-setup OTA_APP_ID').toBe(shared);
+    expect(idFrom('scripts/mobile-ota-surf-doctor.ts', 'OTA_APP_ID'), 'mobile-ota-surf-doctor OTA_APP_ID').toBe(shared);
   });
 
   it('uses pull_request (never pull_request_target) so fork jobs get no secrets', () => {

--- a/scripts/mobile-ota-compat-check.ts
+++ b/scripts/mobile-ota-compat-check.ts
@@ -401,6 +401,14 @@ function emitGithubOutputs(result: OtaCompatResult, ctx: CommentContext): void {
   if (outputPath) {
     const verdictFor = (platform: Platform): Verdict =>
       result.results.find((entry) => entry.platform === platform)?.verdict ?? 'unknown';
+    // The resolved hashes, not just the verdict. A preview branch is only visible to
+    // a binary whose runtimeVersion matches it EXACTLY, so "which fingerprint did
+    // this preview target, and what is main on?" is the question a tester who sees
+    // an empty picker actually needs answered. `—` when unresolved (shortHash).
+    const fingerprintFor = (platform: Platform, side: 'pr' | 'base'): string => {
+      const entry = result.results.find((candidate) => candidate.platform === platform);
+      return shortHash((side === 'pr' ? entry?.prFingerprint : entry?.baseFingerprint) ?? null);
+    };
     const commentB64 = Buffer.from(renderComment(result, ctx), 'utf8').toString('base64');
     appendFileSync(
       outputPath,
@@ -408,6 +416,10 @@ function emitGithubOutputs(result: OtaCompatResult, ctx: CommentContext): void {
         `overall=${result.overall}`,
         `verdict_ios=${verdictFor('ios')}`,
         `verdict_android=${verdictFor('android')}`,
+        `fingerprint_ios=${fingerprintFor('ios', 'pr')}`,
+        `fingerprint_android=${fingerprintFor('android', 'pr')}`,
+        `base_fingerprint_ios=${fingerprintFor('ios', 'base')}`,
+        `base_fingerprint_android=${fingerprintFor('android', 'base')}`,
         `check_title=${CHECK_TITLE[result.overall]}`,
         `comment_b64=${commentB64}`,
         '',

--- a/scripts/mobile-ota-setup.ts
+++ b/scripts/mobile-ota-setup.ts
@@ -126,9 +126,11 @@ function setupChannel(): void {
   log('`vp run mobile:publish -- --channel production` publishes the production branch.');
   log('');
   log('In the dashboard, map channel `production` → branch `production` once.');
-  log('After native builds containing @xprem/control-center and the xprem-branch header');
-  log('are available to testers, enable Branch Surfing on `production` with pattern `pr-*`.');
-  log('Do not enable it before those native builds are ready.');
+  log('Enable Branch Surfing on `production` with pattern `pr-*` — but only AFTER native builds');
+  log('carrying @xprem/control-center and the baked xprem-branch header have reached testers, since');
+  log('a binary without that header cannot surf. The toggle is on the Channels page INSIDE the');
+  log("selected channel's detail pane, not on the channel list, and an empty pattern makes the");
+  log('switch un-toggleable. Confirm the live state any time with `vp run mobile:ota-surf-doctor`.');
   log('');
   log(`Verify after mapping: vp dlx ${EOAS_PACKAGE_SPEC} doctor --channel ${CHANNEL}  (needs EOO_TOKEN)`);
 }

--- a/scripts/mobile-ota-surf-doctor.ts
+++ b/scripts/mobile-ota-surf-doctor.ts
@@ -1,0 +1,324 @@
+/// <reference types="node" />
+
+/**
+ * Asks the self-hosted xprem update server the same question a device asks, and
+ * says why the mobile "Test a PR" screen is empty.
+ *
+ * The screen (packages/mobile/src/components/qa/QaPickScreen.tsx) renders exactly
+ * three states, and they come straight off `GET /branch_lists`:
+ *
+ *   404 + `xprem-branch-surfing` header → "Previews are switched off"
+ *   200 with an empty list             → "Nothing to test right now"
+ *   200 with branches                  → the PR list
+ *
+ * Telling those apart used to need a device, a tester account, and a TestFlight
+ * build. It doesn't: `/branch_lists` is an unauthenticated DEVICE endpoint, so
+ * this script reproduces the call from a laptop with no credentials at all.
+ *
+ * The subtle failure this exists for is the third one. `/branch_lists` filters on
+ * the device's EXACT runtimeVersion and platform, so a `pr-<n>` branch published
+ * before a native change landed on `main` is invisible to every current binary —
+ * the switch is on, the branch exists, and the tester still sees an empty list.
+ * That is why `--runtime-version` matters more than it looks: probe with the wrong
+ * fingerprint and you get a perfectly healthy-looking empty list.
+ *
+ * Usage:
+ *   vp run mobile:ota-surf-doctor
+ *   vp run mobile:ota-surf-doctor -- --runtime-version <hash>   # authoritative
+ *   vp run mobile:ota-surf-doctor -- --platform ios --json
+ *
+ * Exit codes:
+ *   0  surfing is on (whether or not any branch matched — an empty list is a
+ *      diagnosis, not a build failure)
+ *   1  surfing is off for the channel, or the server could not be reached
+ *
+ * Env:
+ *   OTA_BASE_URL / EXPO_UPDATES_URL  optional — defaults to the production server.
+ *   EXPO_UPDATES_FINGERPRINT_OVERRIDE  optional — used when --runtime-version is absent.
+ *
+ * See docs/mobile-ota-updates.md ("Per-PR preview branches"). Distinct from
+ * scripts/mobile-ota-health-check.ts, which asks PostHog whether shipped updates
+ * BOOT; this one asks the server whether they are OFFERED.
+ */
+
+import { pathToFileURL } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const LOG = '[ota-surf-doctor]';
+
+// The app id the V3 server routes on (the `expo-app-id` header the client sends).
+// Kept as a literal per file rather than shared: scripts/ota-preview-cleanup.ts
+// runs under bare `node --experimental-strip-types` with no install step, and
+// app.config.ts is read by a loader that can't resolve a sibling .ts. All copies
+// are pinned equal by scripts/mobile-ci-env-parity.test.ts.
+export const OTA_APP_ID = '007e6fd7-f200-448c-9449-8d48ba5d51fc';
+
+// The channel every production/TestFlight binary bakes into `expo-channel-name`
+// (packages/mobile/app.config.ts). Branch surfing is a property OF this channel.
+export const OTA_CHANNEL = 'production';
+
+export const DEFAULT_BASE_URL = 'https://updates.boardsesh.com';
+
+// Set by xprem on a 404 that came from branch surfing being off for the channel,
+// as opposed to any other 404 on the way. Mirrors SURFING_DISABLED_HEADER in
+// @xprem/control-center's surf.ts — the client keys the same distinction off it.
+export const SURFING_DISABLED_HEADER = 'xprem-branch-surfing';
+
+export const PLATFORMS = ['ios', 'android'] as const;
+export type Platform = (typeof PLATFORMS)[number];
+
+/** Where a probed runtimeVersion came from — reported, because it changes how much to trust it. */
+export type RuntimeVersionSource = 'flag' | 'env' | 'resolved';
+
+export type SurfState = 'surfing-off' | 'branches' | 'no-branches' | 'unreachable';
+
+export interface SurfableBranch {
+  name: string;
+  lastUpdateAt?: string;
+}
+
+export interface ProbeOutcome {
+  state: SurfState;
+  branches: SurfableBranch[];
+  total: number;
+  /** Human-readable "why" — the status line, or the parse failure. */
+  detail: string;
+}
+
+export interface PlatformReport extends ProbeOutcome {
+  platform: Platform;
+  runtimeVersion: string;
+  runtimeVersionSource: RuntimeVersionSource;
+}
+
+export interface DoctorArgs {
+  baseUrl: string;
+  platforms: Platform[];
+  runtimeVersion: string | null;
+  json: boolean;
+}
+
+/** PURE: strip an EXPO_UPDATES_URL's trailing `/manifest` to the server base URL. */
+export function stripManifestSuffix(url: string): string {
+  return url.replace(/\/manifest\/?$/, '').replace(/\/+$/, '');
+}
+
+function readFlag(argv: string[], name: string): string | null {
+  for (let index = 0; index < argv.length; index++) {
+    if (argv[index] === `--${name}`) return argv[index + 1] ?? null;
+    if (argv[index].startsWith(`--${name}=`)) return argv[index].slice(name.length + 3);
+  }
+  return null;
+}
+
+/** PURE: command line + env → resolved arguments. */
+export function parseDoctorArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): DoctorArgs {
+  const args = argv.filter((entry) => entry !== '--');
+  const configuredUrl = readFlag(args, 'base-url') ?? env.OTA_BASE_URL ?? env.EXPO_UPDATES_URL ?? DEFAULT_BASE_URL;
+  const requestedPlatform = readFlag(args, 'platform');
+  const platforms = requestedPlatform ? PLATFORMS.filter((platform) => platform === requestedPlatform) : [...PLATFORMS];
+  if (requestedPlatform && platforms.length === 0) {
+    throw new Error(`Unknown --platform "${requestedPlatform}" (expected ${PLATFORMS.join(' or ')}).`);
+  }
+  return {
+    baseUrl: stripManifestSuffix(configuredUrl),
+    platforms,
+    runtimeVersion: readFlag(args, 'runtime-version') ?? null,
+    json: args.includes('--json'),
+  };
+}
+
+/**
+ * PURE: the exact header set a binary sends. app.config.ts bakes `expo-app-id`,
+ * `expo-channel-name` and `xprem-branch`; expo-updates adds the runtime version
+ * and platform. `xprem-branch` is deliberately absent here — an empty branch
+ * header is what "I am on the channel's own branch" looks like, and that is the
+ * state we want to probe from.
+ */
+export function buildProbeHeaders(runtimeVersion: string, platform: Platform): Record<string, string> {
+  return {
+    'expo-app-id': OTA_APP_ID,
+    'expo-channel-name': OTA_CHANNEL,
+    'expo-runtime-version': runtimeVersion,
+    'expo-platform': platform,
+  };
+}
+
+/**
+ * PURE: an HTTP answer → one of the three states the app renders, plus
+ * "unreachable" for everything that is neither.
+ *
+ * The 404 split is the whole point: a 404 CARRYING the surfing header means the
+ * channel refuses to surf, while a bare 404 means something else answered — a
+ * proxy, a wrong base URL, a retired server. The app conflates neither, so
+ * neither does this.
+ */
+export function interpretProbe(status: number, headers: Headers, body: unknown): ProbeOutcome {
+  if (status === 404) {
+    return headers.get(SURFING_DISABLED_HEADER) !== null
+      ? { state: 'surfing-off', branches: [], total: 0, detail: `HTTP 404, ${SURFING_DISABLED_HEADER}: off` }
+      : {
+          state: 'unreachable',
+          branches: [],
+          total: 0,
+          detail: `HTTP 404 without a ${SURFING_DISABLED_HEADER} header — is the base URL right?`,
+        };
+  }
+  if (status !== 200) {
+    return { state: 'unreachable', branches: [], total: 0, detail: `HTTP ${status}` };
+  }
+  const payload = body as { branches?: unknown; total?: unknown } | null;
+  if (!payload || !Array.isArray(payload.branches)) {
+    return { state: 'unreachable', branches: [], total: 0, detail: 'HTTP 200 with an unexpected body shape' };
+  }
+  const branches = payload.branches
+    .filter((entry): entry is Record<string, unknown> => typeof entry === 'object' && entry !== null)
+    .map((entry) => ({
+      name: String(entry.name ?? ''),
+      lastUpdateAt: typeof entry.lastUpdateAt === 'string' ? entry.lastUpdateAt : undefined,
+    }))
+    .filter((entry) => entry.name.length > 0);
+  const total = typeof payload.total === 'number' ? payload.total : branches.length;
+  return {
+    state: branches.length > 0 ? 'branches' : 'no-branches',
+    branches,
+    total,
+    detail: `HTTP 200, ${total} branch${total === 1 ? '' : 'es'}`,
+  };
+}
+
+/** PURE: any platform refusing to surf, or unreachable, is the failure. */
+export function doctorExitCode(reports: PlatformReport[]): number {
+  return reports.some((report) => report.state === 'surfing-off' || report.state === 'unreachable') ? 1 : 0;
+}
+
+/**
+ * PURE: true when one explicit fingerprint is being applied to several platforms.
+ *
+ * iOS and Android resolve to DIFFERENT fingerprints — GOOGLE_MAPS_API_KEY is an
+ * Android-only input, so the publish workflows resolve them per platform. Probing
+ * both with one hash makes at least one of them answer "no branches" for a reason
+ * that has nothing to do with the server, which is exactly the false alarm this
+ * script exists to prevent.
+ */
+export function warnsAboutSharedRuntimeVersion(args: DoctorArgs): boolean {
+  return args.runtimeVersion !== null && args.platforms.length > 1;
+}
+
+/** PURE: the report a human reads. */
+export function summarizeReports(reports: PlatformReport[], baseUrl: string): string[] {
+  const lines = [`${LOG} server: ${baseUrl}  app: ${OTA_APP_ID}  channel: ${OTA_CHANNEL}`];
+  for (const report of reports) {
+    lines.push('');
+    lines.push(
+      `${LOG} ── ${report.platform} ─ runtimeVersion ${report.runtimeVersion} (${report.runtimeVersionSource})`,
+    );
+    lines.push(`${LOG}    ${report.detail}`);
+    if (report.state === 'surfing-off') {
+      lines.push(`${LOG}    Branch surfing is OFF for "${OTA_CHANNEL}". Testers see "Previews are switched off".`);
+      lines.push(`${LOG}    Fix: dashboard → Channels → select "${OTA_CHANNEL}" → Branch surfing → on, pattern pr-*`);
+    }
+    if (report.state === 'no-branches') {
+      lines.push(`${LOG}    Surfing is ON, but no branch matches this runtimeVersion + platform.`);
+      lines.push(`${LOG}    Either no PR has published a preview, or every pr-* branch predates the latest`);
+      lines.push(`${LOG}    native change on main. A PR behind that change must rebase to republish.`);
+    }
+    for (const branch of report.branches) {
+      lines.push(`${LOG}    • ${branch.name}${branch.lastUpdateAt ? `  (updated ${branch.lastUpdateAt})` : ''}`);
+    }
+    if (report.runtimeVersionSource === 'resolved') {
+      lines.push(`${LOG}    NOTE: this fingerprint was resolved locally. @expo/fingerprint is not`);
+      lines.push(`${LOG}    deterministic across macOS and Linux, and binaries bake the LINUX one — so an`);
+      lines.push(`${LOG}    empty list here may be a false alarm. Pass --runtime-version with the value from`);
+      lines.push(`${LOG}    a native build's EXPO_UPDATES_FINGERPRINT_OVERRIDE for a trustworthy answer.`);
+    }
+  }
+  return lines;
+}
+
+/** Resolve this checkout's fingerprint for a platform. Returns null when it can't. */
+function resolveLocalRuntimeVersion(platform: Platform): string | null {
+  const result = spawnSync('vp', ['exec', 'expo-updates', 'runtimeversion:resolve', '--platform', platform], {
+    cwd: new URL('../packages/mobile/', import.meta.url).pathname,
+    encoding: 'utf-8',
+  });
+  if (result.status !== 0 || typeof result.stdout !== 'string') return null;
+  return result.stdout.match(/\b([0-9a-f]{40})\b/)?.[1] ?? null;
+}
+
+export type FetchLike = (url: string, init: { headers: Record<string, string> }) => Promise<Response>;
+
+async function probePlatform(
+  fetchImpl: FetchLike,
+  baseUrl: string,
+  runtimeVersion: string,
+  platform: Platform,
+): Promise<ProbeOutcome> {
+  try {
+    // ?all=1 raises the page cap only; it does NOT bypass the runtimeVersion or
+    // platform filter, so a wrong fingerprint still reads as an empty list.
+    const response = await fetchImpl(`${baseUrl}/branch_lists?all=1`, {
+      headers: buildProbeHeaders(runtimeVersion, platform),
+    });
+    const body = response.status === 200 ? await response.json().catch(() => null) : null;
+    return interpretProbe(response.status, response.headers, body);
+  } catch (error) {
+    return {
+      state: 'unreachable',
+      branches: [],
+      total: 0,
+      detail: `request failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+export async function runSurfDoctor(
+  args: DoctorArgs,
+  fetchImpl: FetchLike = fetch,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<number> {
+  const reports: PlatformReport[] = [];
+  for (const platform of args.platforms) {
+    let runtimeVersion = args.runtimeVersion;
+    let source: RuntimeVersionSource = 'flag';
+    if (!runtimeVersion) {
+      const fromEnv = env.EXPO_UPDATES_FINGERPRINT_OVERRIDE?.trim();
+      if (fromEnv) {
+        runtimeVersion = fromEnv;
+        source = 'env';
+      } else {
+        runtimeVersion = resolveLocalRuntimeVersion(platform);
+        source = 'resolved';
+      }
+    }
+    if (!runtimeVersion) {
+      console.error(
+        `${LOG} Could not resolve a runtimeVersion for ${platform}. Pass --runtime-version <hash> (take it from a native build's EXPO_UPDATES_FINGERPRINT_OVERRIDE).`,
+      );
+      return 1;
+    }
+    const outcome = await probePlatform(fetchImpl, args.baseUrl, runtimeVersion, platform);
+    reports.push({ platform, runtimeVersion, runtimeVersionSource: source, ...outcome });
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify({ baseUrl: args.baseUrl, appId: OTA_APP_ID, channel: OTA_CHANNEL, reports }, null, 2));
+  } else {
+    console.log(summarizeReports(reports, args.baseUrl).join('\n'));
+    if (warnsAboutSharedRuntimeVersion(args)) {
+      console.log('');
+      console.log(`${LOG} NOTE: one --runtime-version was applied to ${args.platforms.join(' and ')}, but iOS and`);
+      console.log(`${LOG} Android resolve to different fingerprints. Add --platform to probe one honestly.`);
+    }
+  }
+  return doctorExitCode(reports);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runSurfDoctor(parseDoctorArgs(process.argv.slice(2)))
+    .then((code) => process.exit(code))
+    .catch((error: unknown) => {
+      console.error(`${LOG} ${error instanceof Error ? error.message : String(error)}`);
+      process.exit(1);
+    });
+}

--- a/scripts/mobile-ota-surf-doctor.ts
+++ b/scripts/mobile-ota-surf-doctor.ts
@@ -252,7 +252,18 @@ function resolveLocalRuntimeVersion(platform: Platform): string | null {
   return result.stdout.match(/\b([0-9a-f]{40})\b/)?.[1] ?? null;
 }
 
-export type FetchLike = (url: string, init: { headers: Record<string, string> }) => Promise<Response>;
+export type FetchLike = (
+  url: string,
+  init: { headers: Record<string, string>; signal?: AbortSignal },
+) => Promise<Response>;
+
+/**
+ * Cap on one probe. This is a diagnostic someone reaches for when previews look
+ * broken, so an unreachable server has to come back as a REPORT ("unreachable")
+ * rather than a hang — a script that never returns looks like a fourth, unnamed
+ * failure state.
+ */
+export const PROBE_TIMEOUT_MS = 15_000;
 
 async function probePlatform(
   fetchImpl: FetchLike,
@@ -265,6 +276,7 @@ async function probePlatform(
     // platform filter, so a wrong fingerprint still reads as an empty list.
     const response = await fetchImpl(`${baseUrl}/branch_lists?all=1`, {
       headers: buildProbeHeaders(runtimeVersion, platform),
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
     });
     const body = response.status === 200 ? await response.json().catch(() => null) : null;
     return interpretProbe(response.status, response.headers, body);

--- a/scripts/mobile-ota-surf-doctor.ts
+++ b/scripts/mobile-ota-surf-doctor.ts
@@ -199,16 +199,21 @@ export function doctorExitCode(reports: PlatformReport[]): number {
 }
 
 /**
- * PURE: true when one explicit fingerprint is being applied to several platforms.
+ * PURE: true when ONE fingerprint was applied to several platforms.
  *
  * iOS and Android resolve to DIFFERENT fingerprints — GOOGLE_MAPS_API_KEY is an
  * Android-only input, so the publish workflows resolve them per platform. Probing
  * both with one hash makes at least one of them answer "no branches" for a reason
  * that has nothing to do with the server, which is exactly the false alarm this
  * script exists to prevent.
+ *
+ * Keyed on what was actually probed, not on the flag: `--runtime-version` and
+ * EXPO_UPDATES_FINGERPRINT_OVERRIDE both supply one string for every platform, and
+ * only the locally resolved path is per-platform by construction.
  */
-export function warnsAboutSharedRuntimeVersion(args: DoctorArgs): boolean {
-  return args.runtimeVersion !== null && args.platforms.length > 1;
+export function warnsAboutSharedRuntimeVersion(reports: PlatformReport[]): boolean {
+  const supplied = reports.filter((report) => report.runtimeVersionSource !== 'resolved');
+  return supplied.length > 1 && new Set(supplied.map((report) => report.runtimeVersion)).size === 1;
 }
 
 /** PURE: the report a human reads. */
@@ -323,10 +328,12 @@ export async function runSurfDoctor(
     console.log(JSON.stringify({ baseUrl: args.baseUrl, appId: OTA_APP_ID, channel: OTA_CHANNEL, reports }, null, 2));
   } else {
     console.log(summarizeReports(reports, args.baseUrl).join('\n'));
-    if (warnsAboutSharedRuntimeVersion(args)) {
+    if (warnsAboutSharedRuntimeVersion(reports)) {
       console.log('');
-      console.log(`${LOG} NOTE: one --runtime-version was applied to ${args.platforms.join(' and ')}, but iOS and`);
-      console.log(`${LOG} Android resolve to different fingerprints. Add --platform to probe one honestly.`);
+      console.log(
+        `${LOG} NOTE: one fingerprint was applied to ${reports.map((report) => report.platform).join(' and ')},`,
+      );
+      console.log(`${LOG} but iOS and Android resolve to different ones. Add --platform to probe one honestly.`);
     }
   }
   return doctorExitCode(reports);

--- a/scripts/mobile-ota-surf-doctor.ts
+++ b/scripts/mobile-ota-surf-doctor.ts
@@ -23,9 +23,14 @@
  * fingerprint and you get a perfectly healthy-looking empty list.
  *
  * Usage:
- *   vp run mobile:ota-surf-doctor
- *   vp run mobile:ota-surf-doctor -- --runtime-version <hash>   # authoritative
+ *   vp run mobile:ota-surf-doctor                                    # is the switch on?
+ *   vp run mobile:ota-surf-doctor -- --platform ios --runtime-version <hash>
  *   vp run mobile:ota-surf-doctor -- --platform ios --json
+ *
+ * With no --runtime-version it answers only the switch question, because that one
+ * is a property of the channel. The branch list is filtered by exact
+ * runtimeVersion + platform, so seeing it needs the hash a native build baked
+ * (its EXPO_UPDATES_FINGERPRINT_OVERRIDE) — and iOS and Android differ.
  *
  * Exit codes:
  *   0  surfing is on (whether or not any branch matched — an empty list is a
@@ -35,6 +40,7 @@
  * Env:
  *   OTA_BASE_URL / EXPO_UPDATES_URL  optional — defaults to the production server.
  *   EXPO_UPDATES_FINGERPRINT_OVERRIDE  optional — used when --runtime-version is absent.
+ *     (One value for every platform, same as the flag, so pair it with --platform.)
  *
  * See docs/mobile-ota-updates.md ("Per-PR preview branches"). Distinct from
  * scripts/mobile-ota-health-check.ts, which asks PostHog whether shipped updates
@@ -42,7 +48,6 @@
  */
 
 import { pathToFileURL } from 'node:url';
-import { spawnSync } from 'node:child_process';
 
 const LOG = '[ota-surf-doctor]';
 
@@ -64,11 +69,31 @@ export const DEFAULT_BASE_URL = 'https://updates.boardsesh.com';
 // @xprem/control-center's surf.ts — the client keys the same distinction off it.
 export const SURFING_DISABLED_HEADER = 'xprem-branch-surfing';
 
+/**
+ * Stand-in runtimeVersion for a probe with none supplied.
+ *
+ * The two questions this script answers do not need the same input. Whether the
+ * CHANNEL will surf at all is a property of the channel: the server answers 404 +
+ * `xprem-branch-surfing` regardless of which runtimeVersion asked. Which BRANCHES
+ * are offered is filtered by runtimeVersion and platform, so it needs a real one.
+ *
+ * So a no-flag run still answers the first question honestly and declines the
+ * second, rather than resolving a fingerprint locally and quietly answering both
+ * wrong. A local resolve is untrustworthy twice over: @expo/fingerprint is not
+ * deterministic across macOS and Linux (binaries bake the Linux hash), and
+ * app.config.ts falls back to the EAS updates config unless EXPO_UPDATES_URL and
+ * the native-build env are set, which perturbs the hash again.
+ */
+export const SWITCH_PROBE_RUNTIME_VERSION = 'boardsesh-surf-doctor-switch-probe';
+
 export const PLATFORMS = ['ios', 'android'] as const;
 export type Platform = (typeof PLATFORMS)[number];
 
-/** Where a probed runtimeVersion came from — reported, because it changes how much to trust it. */
-export type RuntimeVersionSource = 'flag' | 'env' | 'resolved';
+/**
+ * Where a probed runtimeVersion came from. `none` means nobody supplied one, so
+ * only the switch verdict is meaningful — see SWITCH_PROBE_RUNTIME_VERSION.
+ */
+export type RuntimeVersionSource = 'flag' | 'env' | 'none';
 
 export type SurfState = 'surfing-off' | 'branches' | 'no-branches' | 'unreachable';
 
@@ -208,11 +233,11 @@ export function doctorExitCode(reports: PlatformReport[]): number {
  * script exists to prevent.
  *
  * Keyed on what was actually probed, not on the flag: `--runtime-version` and
- * EXPO_UPDATES_FINGERPRINT_OVERRIDE both supply one string for every platform, and
- * only the locally resolved path is per-platform by construction.
+ * EXPO_UPDATES_FINGERPRINT_OVERRIDE both supply one string for every platform. A
+ * `none` probe is excluded because its branch list is never interpreted anyway.
  */
 export function warnsAboutSharedRuntimeVersion(reports: PlatformReport[]): boolean {
-  const supplied = reports.filter((report) => report.runtimeVersionSource !== 'resolved');
+  const supplied = reports.filter((report) => report.runtimeVersionSource !== 'none');
   return supplied.length > 1 && new Set(supplied.map((report) => report.runtimeVersion)).size === 1;
 }
 
@@ -221,15 +246,26 @@ export function summarizeReports(reports: PlatformReport[], baseUrl: string): st
   const lines = [`${LOG} server: ${baseUrl}  app: ${OTA_APP_ID}  channel: ${OTA_CHANNEL}`];
   for (const report of reports) {
     lines.push('');
+    const switchOnly = report.runtimeVersionSource === 'none';
     lines.push(
-      `${LOG} ── ${report.platform} ─ runtimeVersion ${report.runtimeVersion} (${report.runtimeVersionSource})`,
+      switchOnly
+        ? `${LOG} ── ${report.platform} ─ switch check only (no runtimeVersion supplied)`
+        : `${LOG} ── ${report.platform} ─ runtimeVersion ${report.runtimeVersion} (${report.runtimeVersionSource})`,
     );
     lines.push(`${LOG}    ${report.detail}`);
     if (report.state === 'surfing-off') {
       lines.push(`${LOG}    Branch surfing is OFF for "${OTA_CHANNEL}". Testers see "Previews are switched off".`);
       lines.push(`${LOG}    Fix: dashboard → Channels → select "${OTA_CHANNEL}" → Branch surfing → on, pattern pr-*`);
     }
-    if (report.state === 'no-branches') {
+    if (report.state === 'no-branches' && switchOnly) {
+      // The list came back filtered by a sentinel runtimeVersion, so it is empty by
+      // construction and says nothing. Claiming otherwise would be the exact false
+      // alarm this script exists to prevent.
+      lines.push(`${LOG}    Surfing is ON for "${OTA_CHANNEL}". Branch list NOT checked.`);
+      lines.push(`${LOG}    Branches are filtered by exact runtimeVersion + platform, so pass`);
+      lines.push(`${LOG}    --runtime-version <hash> --platform <ios|android> to see what a build is offered.`);
+      lines.push(`${LOG}    Take <hash> from a native build's EXPO_UPDATES_FINGERPRINT_OVERRIDE.`);
+    } else if (report.state === 'no-branches') {
       lines.push(`${LOG}    Surfing is ON, but no branch matches this runtimeVersion + platform.`);
       lines.push(`${LOG}    Either no PR has published a preview, or every pr-* branch predates the latest`);
       lines.push(`${LOG}    native change on main. A PR behind that change must rebase to republish.`);
@@ -237,24 +273,8 @@ export function summarizeReports(reports: PlatformReport[], baseUrl: string): st
     for (const branch of report.branches) {
       lines.push(`${LOG}    • ${branch.name}${branch.lastUpdateAt ? `  (updated ${branch.lastUpdateAt})` : ''}`);
     }
-    if (report.runtimeVersionSource === 'resolved') {
-      lines.push(`${LOG}    NOTE: this fingerprint was resolved locally. @expo/fingerprint is not`);
-      lines.push(`${LOG}    deterministic across macOS and Linux, and binaries bake the LINUX one — so an`);
-      lines.push(`${LOG}    empty list here may be a false alarm. Pass --runtime-version with the value from`);
-      lines.push(`${LOG}    a native build's EXPO_UPDATES_FINGERPRINT_OVERRIDE for a trustworthy answer.`);
-    }
   }
   return lines;
-}
-
-/** Resolve this checkout's fingerprint for a platform. Returns null when it can't. */
-function resolveLocalRuntimeVersion(platform: Platform): string | null {
-  const result = spawnSync('vp', ['exec', 'expo-updates', 'runtimeversion:resolve', '--platform', platform], {
-    cwd: new URL('../packages/mobile/', import.meta.url).pathname,
-    encoding: 'utf-8',
-  });
-  if (result.status !== 0 || typeof result.stdout !== 'string') return null;
-  return result.stdout.match(/\b([0-9a-f]{40})\b/)?.[1] ?? null;
 }
 
 export type FetchLike = (
@@ -295,31 +315,29 @@ async function probePlatform(
   }
 }
 
+/**
+ * PURE: which runtimeVersion to probe with, and how much it can be trusted.
+ * Falls back to the sentinel rather than resolving one locally — see
+ * SWITCH_PROBE_RUNTIME_VERSION for why a local resolve cannot be trusted.
+ */
+export function resolveProbeRuntimeVersion(
+  args: DoctorArgs,
+  env: DoctorEnv,
+): { runtimeVersion: string; source: RuntimeVersionSource } {
+  if (args.runtimeVersion) return { runtimeVersion: args.runtimeVersion, source: 'flag' };
+  const fromEnv = env.EXPO_UPDATES_FINGERPRINT_OVERRIDE?.trim();
+  if (fromEnv) return { runtimeVersion: fromEnv, source: 'env' };
+  return { runtimeVersion: SWITCH_PROBE_RUNTIME_VERSION, source: 'none' };
+}
+
 export async function runSurfDoctor(
   args: DoctorArgs,
   fetchImpl: FetchLike = fetch,
   env: DoctorEnv = process.env,
 ): Promise<number> {
+  const { runtimeVersion, source } = resolveProbeRuntimeVersion(args, env);
   const reports: PlatformReport[] = [];
   for (const platform of args.platforms) {
-    let runtimeVersion = args.runtimeVersion;
-    let source: RuntimeVersionSource = 'flag';
-    if (!runtimeVersion) {
-      const fromEnv = env.EXPO_UPDATES_FINGERPRINT_OVERRIDE?.trim();
-      if (fromEnv) {
-        runtimeVersion = fromEnv;
-        source = 'env';
-      } else {
-        runtimeVersion = resolveLocalRuntimeVersion(platform);
-        source = 'resolved';
-      }
-    }
-    if (!runtimeVersion) {
-      console.error(
-        `${LOG} Could not resolve a runtimeVersion for ${platform}. Pass --runtime-version <hash> (take it from a native build's EXPO_UPDATES_FINGERPRINT_OVERRIDE).`,
-      );
-      return 1;
-    }
     const outcome = await probePlatform(fetchImpl, args.baseUrl, runtimeVersion, platform);
     reports.push({ platform, runtimeVersion, runtimeVersionSource: source, ...outcome });
   }

--- a/scripts/mobile-ota-surf-doctor.ts
+++ b/scripts/mobile-ota-surf-doctor.ts
@@ -91,6 +91,12 @@ export interface PlatformReport extends ProbeOutcome {
   runtimeVersionSource: RuntimeVersionSource;
 }
 
+/**
+ * Just the env this script reads. Deliberately NOT NodeJS.ProcessEnv: that type
+ * requires NODE_ENV, so every test would have to invent one to pass a stub.
+ */
+export type DoctorEnv = Record<string, string | undefined>;
+
 export interface DoctorArgs {
   baseUrl: string;
   platforms: Platform[];
@@ -112,7 +118,7 @@ function readFlag(argv: string[], name: string): string | null {
 }
 
 /** PURE: command line + env → resolved arguments. */
-export function parseDoctorArgs(argv: string[], env: NodeJS.ProcessEnv = process.env): DoctorArgs {
+export function parseDoctorArgs(argv: string[], env: DoctorEnv = process.env): DoctorArgs {
   const args = argv.filter((entry) => entry !== '--');
   const configuredUrl = readFlag(args, 'base-url') ?? env.OTA_BASE_URL ?? env.EXPO_UPDATES_URL ?? DEFAULT_BASE_URL;
   const requestedPlatform = readFlag(args, 'platform');
@@ -275,7 +281,7 @@ async function probePlatform(
 export async function runSurfDoctor(
   args: DoctorArgs,
   fetchImpl: FetchLike = fetch,
-  env: NodeJS.ProcessEnv = process.env,
+  env: DoctorEnv = process.env,
 ): Promise<number> {
   const reports: PlatformReport[] = [];
   for (const platform of args.platforms) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1023,6 +1023,13 @@ export default defineConfig({
         command: 'tsx scripts/mobile-ota-health-check.ts',
         cache: false,
       },
+      // Reads /branch_lists exactly as a device does (no credentials — it is a
+      // device endpoint) to say why "Test a PR" is empty: surfing off, or on but
+      // no branch matches this runtimeVersion. See scripts/mobile-ota-surf-doctor.ts.
+      'mobile:ota-surf-doctor': {
+        command: 'tsx scripts/mobile-ota-surf-doctor.ts',
+        cache: false,
+      },
       'mobile:ota-rollback': {
         command: 'tsx scripts/mobile-ota-rollback.ts',
         cache: false,


### PR DESCRIPTION
## Summary

The mobile **Test a PR** screen listed nothing for every tester. Two independent causes, both confirmed against the live update server rather than inferred from docs.

**1. Branch surfing was off** for the `production` channel. `GET /branch_lists` answered `404` with `xprem-branch-surfing: off`, which `@xprem/control-center` maps to `null` and `QaPickScreen` renders as "Previews are switched off". Now enabled in the dashboard with pattern `pr-*`. The toggle is easy to miss — it lives *inside the selected channel's detail pane*, not on the channel list, and an empty pattern makes it un-toggleable. It also has an API, despite xprem's docs calling it dashboard-only: `PUT /api/apps/{APP_ID}/channels/{CHANNEL}/branch-surfing`.

**2. Every live preview branch targeted a superseded fingerprint.** With the switch on, the list was still empty:

| probe runtimeVersion | result |
| --- | --- |
| `15f9b78d…` (current TestFlight/Play binary) | `{"branches":[],"total":0}` |
| `872022f0…` (the previous fingerprint) | `pr-4872`, `pr-5043` |

`/branch_lists` offers a branch only to a binary whose runtimeVersion **and** platform match exactly, and `mobile-ota-compat-check.ts` compares each PR against *current* `origin/main`. So a native change landing on main does two things at once: every published `pr-<n>` branch keeps the old fingerprint and goes invisible, and every un-rebased PR resolves `native-change-required`, skipping its publish. The native change at 2026-09-01 11:04 did exactly that, and nothing about it is loud — the picker just empties.

Auto-republishing would be wrong (the PR tree still lacks the new native code), so the remedy is a rebase. #4872 and #5043 have been rebased; both now list at the current fingerprint.

**3. The preview sweep has been red daily since 2026-09-01.** `GET /channels` and `GET /branches` are `AnyViewer()` in xprem v3.1.2, which an app-scoped `eoo_` key no longer satisfies — 403. It fails closed, so nothing was wrongly deleted, but stale branches stopped being reaped. It now reuses the admin session the same step already mints.

### What's in here

- **`vp run mobile:ota-surf-doctor`** — replays the device call to `/branch_lists` (unauthenticated; it's a device endpoint) and maps the answer onto the three states the app renders. Diagnosable from a laptop instead of needing a device, a tester account and a store build.
- **Fingerprints in the preview PR comment**, and the skip message split: "behind a native change on `main` — rebase" vs "needs a TestFlight/Play build". They need opposite fixes, so one message for both sent authors down the wrong path.
- **Sweep fix** + a parity test so the `eoo_` key can't come back.
- **Docs**: the staleness failure mode and its remedy, the surf doctor, where the dashboard toggle actually lives, and a note that Railway pulls v3.1.2 through the pre-rename repository path (so a service not saying `xprem` isn't a sign the server is behind).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 2/5 — CI, docs, and one read-only diagnostic script. No app code changes. The only production mutation is the sweep's existing delete path, whose fail-closed guards are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrEQHj2NCigM1FzXDbTMn7