### PR TITLE
fix(ci): take the daily pack's boundary from the frozen layer, not from a date

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -305,12 +305,35 @@ jobs:
 
           base_end_date="${HISTORY_BASE#baseline-}"
           base_end_date="${base_end_date#week-}"
-          exclude_tip="$(node --import tsx scripts/ci-image/generate-weekly-packs.ts resolve-tip \
-            --before "$base_end_date" --ref main)"
+
+          # Resolve against the commit this run checked out, NOT against `main`.
+          # `main` keeps moving while the build runs -- PRs merge -- so
+          # resolving against it can hand back a tip that is not an ancestor of
+          # $tip, and `--exclude` then strips the very commit the pack is built
+          # for. The result is an empty pack whose only symptom is a "nonexistent
+          # object" failure several Docker layers later.
           tip="$(git rev-parse HEAD)"
+          exclude_tip="$(node --import tsx scripts/ci-image/generate-weekly-packs.ts resolve-tip \
+            --before "$base_end_date" --ref "$tip")"
+
+          # Cheap ancestry check before spending a build on it.
+          if ! git merge-base --is-ancestor "$exclude_tip" "$tip"; then
+            echo "::error::exclude tip ${exclude_tip} is not an ancestor of ${tip}; the pack would be empty"
+            exit 1
+          fi
 
           node --import tsx scripts/ci-image/generate-weekly-packs.ts pack \
             --tip "$tip" --exclude "$exclude_tip" --out-dir "$packs_dir" --name current-week
+
+          # The pack MUST contain the commit Dockerfile.ci is about to name as a
+          # ref. Without this the build fails deep inside a Docker layer with
+          # "trying to write ref ... with nonexistent object", which says
+          # nothing about which of the inputs was wrong.
+          if ! git verify-pack -v "$packs_dir/current-week.idx" | grep -q "^${tip}"; then
+            echo "::error::generated pack does not contain its own tip ${tip}"
+            exit 1
+          fi
+
           printf 'PACKS_DIR=%s\n' "$packs_dir" >>"$GITHUB_ENV"
           # Dockerfile.ci names this tip as a ref in the seed. Without it a
           # job's fetch negotiates from an empty ref list and re-downloads

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -303,18 +303,22 @@ jobs:
           packs_dir="$RUNNER_TEMP/ci-image-packs"
           mkdir -p "$packs_dir"
 
-          base_end_date="${HISTORY_BASE#baseline-}"
-          base_end_date="${base_end_date#week-}"
-
-          # Resolve against the commit this run checked out, NOT against `main`.
-          # `main` keeps moving while the build runs -- PRs merge -- so
-          # resolving against it can hand back a tip that is not an ancestor of
-          # $tip, and `--exclude` then strips the very commit the pack is built
-          # for. The result is an empty pack whose only symptom is a "nonexistent
-          # object" failure several Docker layers later.
+          # Read the boundary OUT OF THE BASE IMAGE rather than re-deriving it
+          # from a date. Re-deriving is what broke the published build: the
+          # newest frozen layer is `week-<today>` while commits are still
+          # landing on that date, so `--before <that date>` keeps moving after
+          # the layer was frozen. The two then disagree -- observed
+          # 41b73995e frozen vs 1c4546409 re-derived -- and the exclude can
+          # strip the very commit the pack exists for, yielding an empty pack
+          # whose only symptom is a "nonexistent object" failure several Docker
+          # layers later.
+          #
+          # The frozen layer records its own tip as refs/ci-seed/<tag> (added
+          # so a job's fetch can negotiate). That ref is authoritative and
+          # cannot drift, so use it.
           tip="$(git rev-parse HEAD)"
-          exclude_tip="$(node --import tsx scripts/ci-image/generate-weekly-packs.ts resolve-tip \
-            --before "$base_end_date" --ref "$tip")"
+          exclude_tip="$(docker run --rm --entrypoint git "${GIT_IMAGE}:${HISTORY_BASE}" \
+            --git-dir=/ci-seed/git rev-parse "refs/ci-seed/${HISTORY_BASE}")"
 
           # Cheap ancestry check before spending a build on it.
           if ! git merge-base --is-ancestor "$exclude_tip" "$tip"; then

--- a/scripts/__tests__/ci-image-workflow.test.ts
+++ b/scripts/__tests__/ci-image-workflow.test.ts
@@ -249,6 +249,34 @@ describe('docker/ci/job-started.sh: seeds refs, not just the alternate', () => {
   });
 });
 
+describe('ci-image.yml: the current-week pack is checked before it is baked', () => {
+  // A published build failed with "trying to write ref refs/ci-seed/current-week
+  // with nonexistent object", several Docker layers deep, saying nothing about
+  // which input was wrong. The pack is generated from $tip while the exclude
+  // boundary was resolved against `main` -- which keeps moving as PRs merge
+  // during the build -- so the exclude could stop being an ancestor of $tip and
+  // strip the very commit the pack exists for.
+
+  it('resolves the exclude boundary against the checked-out commit, not main', () => {
+    // `--ref main` here is the race. The frozen-history job may legitimately
+    // use main; this one must not.
+    const packStep = workflowSource.slice(
+      workflowSource.indexOf("Generate the current week's pack"),
+      workflowSource.indexOf('Build and push the daily image'),
+    );
+    expect(packStep).not.toMatch(/resolve-tip[\s\S]*?--ref main/);
+    expect(packStep).toMatch(/--ref "\$tip"/);
+  });
+
+  it('fails loudly if the exclude tip is not an ancestor of the pack tip', () => {
+    expect(workflowSource).toMatch(/git merge-base --is-ancestor "\$exclude_tip" "\$tip"/);
+  });
+
+  it('fails loudly if the pack does not contain its own tip', () => {
+    expect(workflowSource).toMatch(/git verify-pack[^\n]*current-week\.idx/);
+  });
+});
+
 describe('ci-image.yml: the daily build passes every named context Dockerfile.ci reads', () => {
   // A missing --build-context fails the build outright, but only at the line
   // that reads it -- after the expensive layers. Cheaper to catch here.

--- a/scripts/__tests__/ci-image-workflow.test.ts
+++ b/scripts/__tests__/ci-image-workflow.test.ts
@@ -257,15 +257,18 @@ describe('ci-image.yml: the current-week pack is checked before it is baked', ()
   // during the build -- so the exclude could stop being an ancestor of $tip and
   // strip the very commit the pack exists for.
 
-  it('resolves the exclude boundary against the checked-out commit, not main', () => {
-    // `--ref main` here is the race. The frozen-history job may legitimately
-    // use main; this one must not.
+  it('reads the exclude boundary from the base image, never re-derives it', () => {
+    // Re-deriving from a date is the bug: the newest frozen layer is
+    // `week-<today>` while commits are still landing on that date, so the
+    // derived boundary drifts away from what the layer was actually frozen to
+    // (observed: 41b73995e frozen vs 1c4546409 re-derived). The layer records
+    // its own tip as refs/ci-seed/<tag>, which cannot drift.
     const packStep = workflowSource.slice(
       workflowSource.indexOf("Generate the current week's pack"),
       workflowSource.indexOf('Build and push the daily image'),
     );
-    expect(packStep).not.toMatch(/resolve-tip[\s\S]*?--ref main/);
-    expect(packStep).toMatch(/--ref "\$tip"/);
+    expect(packStep).not.toMatch(/resolve-tip/);
+    expect(packStep).toMatch(/rev-parse "refs\/ci-seed\/\$\{HISTORY_BASE\}"/);
   });
 
   it('fails loudly if the exclude tip is not an ancestor of the pack tip', () => {


### PR DESCRIPTION
The published image build fails, twice in a row with different SHAs:

```
fatal: update_ref failed for ref 'refs/ci-seed/current-week': cannot update ref
'refs/ci-seed/current-week': trying to write ref 'refs/ci-seed/current-week'
with nonexistent object …
```

…several Docker layers deep, saying nothing about which input was wrong.

### Cause

The daily pack's exclude boundary was **re-derived from a date**:
`resolve-tip --before <base_end_date>`. But the newest frozen layer is
`week-<today>` while commits are still landing on that date, so that boundary
keeps moving *after* the layer was frozen.

Measured — the two have genuinely diverged:

| | |
| --- | --- |
| `week-2026-09-01` was frozen to | `41b73995e` |
| `--before 2026-09-01` returns now | `1c4546409` |

Once they disagree, `--exclude` can strip the very commit the pack exists for.
The pack comes out empty and nothing notices until `update-ref` fails inside
the image.

### Correcting my first diagnosis

I initially blamed a race with `main` moving mid-build and pushed a fix that
resolved against the checked-out commit instead. **That was wrong.** The
re-run failed identically with a new SHA while `main` was static, which ruled
it out — and resolving against the checked-out commit does not help anyway,
because the date filter then selects that same commit and the pack is still
empty. That commit is superseded here.

### Fix

The frozen layer already records its own tip as `refs/ci-seed/<tag>` — added
in #5033 so a job's `git fetch` can negotiate. That ref is authoritative and
cannot drift, so read the boundary out of the base image instead of
recomputing it. Works for a fresh baseline too (`refs/ci-seed/baseline-<date>`).

Plus two guards, so a bad boundary can never again surface as a mystery several
layers later: the exclude must be an ancestor of the tip, and the finished pack
must contain the tip it is about to be named after. Either failure now names
the offending SHAs.

### Verified

Reproduced the failing `update-ref` by hand against the real
`week-2026-09-01` base image — it succeeds when the exclude genuinely is an
ancestor, which is what eliminated the pack generator, the base image and the
Dockerfile. With the boundary read from the frozen ref, ancestry holds and the
pack contains its own tip.

All three behaviours are mutation-tested.

## Release Notes

none

## Test plan

1. CI green.
2. Dispatch `ci-image.yml`; it publishes without the `nonexistent object` failure.

## Risk

Risk: 2/5 — CI image pipeline only, and strictly more conservative: it fails
earlier and louder on inputs that previously produced a silently empty pack.