### PR TITLE
feat(mobile): add the Modern Classic board look and tidy the look picker

### DIFF
--- a/docs/board-render-analytics.md
+++ b/docs/board-render-analytics.md
@@ -320,7 +320,11 @@ Two properties are worth naming:
 - `selected_option` is `null` on a skip, and is the card id otherwise —
   including `'custom'`, whose apply also reports `preset_id: 'aura'`, because
   Custom lands the climber on the plain Aura bundle before opening the Board
-  look screen.
+  look screen. That is the ONBOARDING path. On the settings screen Custom does
+  not apply a preset at all — it restores the climber's remembered bundle
+  (`restoreCustomLook`) and reports from there, so the props describe the look
+  that was restored rather than the Aura bundle. A first-time custom pick, where
+  there is nothing remembered, still reports.
 
 `outcome = 'skipped'` no longer means "accepted the default". The step became
 mandatory in #4961 — there is no decline button, and the one-shot "seen" flag

--- a/docs/board-render-analytics.md
+++ b/docs/board-render-analytics.md
@@ -44,7 +44,7 @@ event's name.
 | `Climb View Opened`            | `climb_uuid`, `reopened_in_session`, plus `$feature_flag` / `$feature_flag_response` on an exposure | `markClimbViewed`, from the current-climb effect in `queue-provider.tsx` and the play drawer's preview latch |
 | `Board Pinch`                  | `scale_max`, `scale_min`, `scale_delta` (signed)       | `noteBoardPinch`, called from `use-zoom-pan-gesture.ts`'s pinch `onEnd` (via `SwipeBoardCarousel`'s `boardRenderTelemetryProps`) |
 | `Climb First Action`           | `climb_uuid`, `action_type` (`'queue'` \| `'ble'`), `ms_since_open` | `markClimbAction`, called from `commitQueueAdd` in `queue-provider.tsx` (`'queue'`) and the three `ClimbSentToBoardSuccess` sites in `use-board-bluetooth.ts` (`'ble'`) |
-| `Board Render Settings Changed`| `field`, `value`                                       | The board-look carousel's Classic card, on both surfaces (Classic is a mode change, not a preset). The individual Board look setting ROWS are still unwired. |
+| `Board Render Settings Changed`| `field`, `value`                                       | Two places: the board-look carousel's Classic card, on both surfaces (Classic is a mode change, not a preset); and every hand adjustment on a Board look screen, via `setMode` / `setBoardseshField` in `use-board-look-settings.ts` — the one writer, so a knob cannot be wired up and miss the event. Silent when there is no preview board to report against, since the common props are built around a board identity. |
 | `Board Render Preset Applied`  | `surface` (`'settings'` \| `'onboarding'`, optional) — otherwise the common props ARE the event | `trackBoardLookApplied` in `packages/mobile/src/lib/board-render/board-look-analytics.ts`, from the board-look carousel on both its surfaces |
 | `Board Look Step Shown`        | `options_shown`                                        | The one-time board-look step (`BoardLookStep.tsx`), once per presentation |
 | `Board Look Step Resolved`     | `outcome` (`'saved'` \| `'customized'` \| `'skipped'`), `selected_option`, `cards_viewed`, `ms_to_resolve` | The same step — exactly once per Shown, including the unmount-without-choosing path |
@@ -315,7 +315,7 @@ Two properties are worth naming:
 
 - `cards_viewed` counts the DISTINCT cards that actually scrolled into view, not
   the number offered. A `saved` with one card viewed ("took the default on
-  sight") and one with five ("swiped through, then chose") are different
+  sight") and one with six ("swiped through, then chose") are different
   signals and must not be pooled.
 - `selected_option` is `null` on a skip, and is the card id otherwise —
   including `'custom'`, whose apply also reports `preset_id: 'aura'`, because

--- a/embedded/libs/moonboard-protocol/src/moonboard_protocol.cpp
+++ b/embedded/libs/moonboard-protocol/src/moonboard_protocol.cpp
@@ -23,7 +23,12 @@ constexpr int MOONBOARD_ADDITIONAL_LED_OFFSETS[MOONBOARD_STRIP_LED_COUNT] = {
 constexpr uint8_t COLOR_GREEN[3] = {0, 255, 0};
 constexpr uint8_t COLOR_BLUE[3] = {0, 0, 255};
 constexpr uint8_t COLOR_RED[3] = {255, 0, 0};
-constexpr uint8_t COLOR_CYAN[3] = {0, 255, 255};
+// Amber, not cyan, for FOOT. On an RGB strip a cyan foot sits right next to the
+// blue HAND and the two are hard to call apart mid-climb. Kept byte-identical to
+// HOLD_STATE_MAP.moonboard[45].color in packages/board-constants, which is what
+// the app draws for the same role — moonboard-firmware-color-parity.test.ts
+// fails if the two ever drift.
+constexpr uint8_t COLOR_AMBER[3] = {255, 170, 0};
 constexpr uint8_t COLOR_YELLOW[3] = {255, 255, 0};
 constexpr uint8_t COLOR_VIOLET[3] = {128, 0, 255};
 constexpr uint8_t COLOR_PINK[3] = {255, 0, 160};
@@ -289,7 +294,7 @@ void MoonBoardProtocol::tokenToColor(char token, uint8_t& r, uint8_t& g, uint8_t
             break;
         case 'F':
         case 'f':
-            color = COLOR_CYAN;
+            color = COLOR_AMBER;
             break;
         case 'E':
         case 'e':

--- a/packages/board-constants/src/__tests__/hold-states.test.ts
+++ b/packages/board-constants/src/__tests__/hold-states.test.ts
@@ -98,7 +98,8 @@ describe('getHoldDisplayColor', () => {
     // MoonBoard 2024's holds are blue plastic, so BOARDSESH_HAND_BLUE put a blue
     // mark on a blue hold. Asserted against Kilter's own entry rather than a
     // literal: the promise is "one HAND colour across the two boards", and a
-    // literal here would let Kilter move without failing anything.
+    // literal here would let Kilter move without failing anything. The two read
+    // one shared constant now, so this is a second lock on the same promise.
     const moonboardHand = HOLD_STATE_MAP.moonboard[43];
     expect(moonboardHand.name).toBe('HAND');
     expect(getHoldDisplayColor(moonboardHand, 'aura')).toBe(getHoldDisplayColor(HOLD_STATE_MAP.kilter[13], 'aura'));

--- a/packages/board-constants/src/__tests__/hold-states.test.ts
+++ b/packages/board-constants/src/__tests__/hold-states.test.ts
@@ -59,96 +59,112 @@ describe('getBoardStrokeWidthMultiplier', () => {
 });
 
 describe('getHoldDisplayColor', () => {
-  const BOARDSESH_HAND_BLUE = '#6980FF';
+  const AURA_HAND_CYAN = '#4DF5FD';
+  const RETIRED_AURA_BLUE = '#6980FF';
 
-  // Every board whose HAND is a near-black blue in classic. The Boardsesh mode
-  // veils the wall around a lit hold, and #0000FF / #4444FF / #4455FF has too
-  // little lightness of its own to separate from that field (issue #2202).
-  //
-  // MoonBoard and Grasshopper are NOT here. Their HAND is the same near-black
-  // blue, but their own holds are blue — MoonBoard 2024's are #2f8bcb and
-  // Grasshopper's `flow` set is #058fca — so the Aura blue marked a blue hold
-  // with a blue glow. Both take the cyan instead, pinned below.
-  const darkBlueHands: [BoardName, number][] = [
-    ['tension', 2],
-    ['tension', 6],
-    ['touchstone', 2],
-    ['soill', 2],
-    ['woods', 2],
-    ['decoy', 2],
-  ];
-
-  for (const [board, code] of darkBlueHands) {
-    it(`${board} code ${code} resolves to the Boardsesh blue in boardsesh mode`, () => {
-      const info = HOLD_STATE_MAP[board][code];
-      expect(info.name).toBe('HAND');
-      expect(getHoldDisplayColor(info, 'aura')).toBe(BOARDSESH_HAND_BLUE);
-    });
-
-    it(`${board} code ${code} is unchanged in classic mode`, () => {
-      const info = HOLD_STATE_MAP[board][code];
-      expect(getHoldDisplayColor(info, 'classic')).toBe(info.displayColor);
-      // The wire colour the BLE encoders send is never what a renderer paints
-      // for these, and the Boardsesh override must not have leaked into it.
-      expect(info.color).toBe('#0000FF');
-    });
-  }
-
-  // The boards whose own holds are blue, so the Aura blue marked a blue hold
-  // with a blue glow: MoonBoard 2024's art is #2f8bcb, Grasshopper's `flow` set
-  // is #058fca. Both take the cyan.
-  const blueWalledHands: [BoardName, number, string][] = [
+  /**
+   * Every HAND that Aura repaints, with the Classic colour it must NOT disturb.
+   *
+   * One Aura colour on every board is the promise, so this is one table rather
+   * than a per-board story: any board drifting off the shared cyan, or any board
+   * whose Classic value moves because Aura's did, fails here.
+   */
+  const auraHands: [BoardName, number, string][] = [
+    ['kilter', 13, '#00FFFF'],
+    ['kilter', 21, '#00FFFF'],
+    ['kilter', 25, '#00FFFF'],
+    ['kilter', 29, '#00FFFF'],
+    ['kilter', 33, '#00FFFF'],
+    ['kilter', 43, '#00FFFF'],
+    ['tension', 2, '#4444FF'],
+    ['tension', 6, '#4444FF'],
+    ['touchstone', 2, '#4444FF'],
+    ['soill', 2, '#4444FF'],
+    ['woods', 2, '#4444FF'],
+    ['decoy', 2, '#0000FF'],
     ['moonboard', 43, '#4444FF'],
     ['grasshopper', 2, '#4455FF'],
   ];
 
-  for (const [board, code, classicColor] of blueWalledHands) {
-    it(`${board} code ${code} takes Kilter’s cyan, not the Aura blue its wall would swallow`, () => {
-      // Asserted against Kilter's own entry rather than a literal: the promise
-      // is "one HAND colour across these boards", and a literal here would let
-      // Kilter move without failing anything. They read one shared constant
-      // now, so this is a second lock on the same promise.
+  for (const [board, code, classicColor] of auraHands) {
+    it(`${board} code ${code} draws the one Aura HAND cyan`, () => {
       const info = HOLD_STATE_MAP[board][code];
       expect(info.name).toBe('HAND');
-      expect(getHoldDisplayColor(info, 'aura')).toBe(getHoldDisplayColor(HOLD_STATE_MAP.kilter[13], 'aura'));
-      expect(getHoldDisplayColor(info, 'aura')).not.toBe(BOARDSESH_HAND_BLUE);
+      expect(getHoldDisplayColor(info, 'aura')).toBe(AURA_HAND_CYAN);
+      expect(getHoldDisplayColor(info, 'aura')).not.toBe(RETIRED_AURA_BLUE);
     });
 
-    it(`${board} code ${code} keeps the board's own colour in Classic`, () => {
+    it(`${board} code ${code} keeps its own colour in Classic`, () => {
       // The whole point of `boardseshDisplayColor` being a separate field:
       // Classic is what the original apps drew, and it must not move because
       // Aura did. Cached classic overlays and the hold-filter swatches read it.
-      const info = HOLD_STATE_MAP[board][code];
-      expect(getHoldDisplayColor(info, 'classic')).toBe(classicColor);
-      expect(info.color).toBe('#0000FF');
+      expect(getHoldDisplayColor(HOLD_STATE_MAP[board][code], 'classic')).toBe(classicColor);
     });
   }
 
-  it('leaves Kilter identical in both modes — its cyan HAND already reads on the veil', () => {
-    for (const [code, info] of Object.entries(HOLD_STATE_MAP.kilter)) {
+  it('never lets the Aura cyan reach the wire', () => {
+    // `packages/shared/ble-protocol/src/aurora.ts` transmits `color` to the
+    // wall, so an Aura screen colour leaking into that field would change which
+    // colour a physical board lights. Kilter's HAND wire value is its own
+    // constant for exactly this reason; the two were briefly one constant, which
+    // made retuning the palette a silent BLE change.
+    for (const [board, states] of Object.entries(HOLD_STATE_MAP)) {
+      for (const [code, info] of Object.entries(states)) {
+        expect(info.color, `${board} code ${code} wire colour`).not.toBe(AURA_HAND_CYAN);
+      }
+    }
+    expect(HOLD_STATE_MAP.kilter[13].color).toBe('#00FFFF');
+  });
+
+  it('retires the Aura blue completely', () => {
+    for (const [board, states] of Object.entries(HOLD_STATE_MAP)) {
+      for (const [code, info] of Object.entries(states)) {
+        expect(info.boardseshDisplayColor, `${board} code ${code}`).not.toBe(RETIRED_AURA_BLUE);
+      }
+    }
+  });
+
+  it('leaves Kilter’s Tycho colour-mode codes out of it', () => {
+    // 36-41 are a colour-mode palette where HAND comes in six colours; 36 being
+    // cyan is that palette's business, and it must not follow the HAND colour.
+    for (const code of [36, 37, 38, 39, 40, 41]) {
+      const info = HOLD_STATE_MAP.kilter[code];
       expect(info.boardseshDisplayColor, `kilter code ${code}`).toBeUndefined();
       expect(getHoldDisplayColor(info, 'aura')).toBe(getHoldDisplayColor(info, 'classic'));
     }
   });
 
   it('falls back to displayColor then color when no Boardsesh override exists', () => {
-    // Kilter carries no displayColor at all, so `color` is the last resort.
-    expect(getHoldDisplayColor(HOLD_STATE_MAP.kilter[43], 'aura')).toBe('#00FFFF');
+    // Kilter's Tycho colour-mode codes carry no displayColor and no Aura
+    // override, so `color` is the last resort for them.
+    expect(getHoldDisplayColor(HOLD_STATE_MAP.kilter[38], 'aura')).toBe('#FFFF00');
     // Tension's FINISH has a displayColor and no override: both modes use it.
     expect(getHoldDisplayColor(HOLD_STATE_MAP.tension[3], 'aura')).toBe('#FF0000');
   });
 
-  it('only the dark-blue HANDs carry an override, board-wide', () => {
+  it('gives every Aura-repainted HAND an override, and nothing else', () => {
+    // The list IS the promise: one Aura HAND colour on every board, and no role
+    // other than HAND repainted. A new board arriving without its HAND here is
+    // a board that silently keeps its Classic blue in Aura.
     const overridden: string[] = [];
     for (const [board, states] of Object.entries(HOLD_STATE_MAP)) {
       for (const [code, info] of Object.entries(states)) {
-        if (info.boardseshDisplayColor) overridden.push(`${board}:${code}`);
+        if (info.boardseshDisplayColor) {
+          expect(info.name, `${board} code ${code}`).toBe('HAND');
+          overridden.push(`${board}:${code}`);
+        }
       }
     }
     expect(overridden.sort()).toEqual(
       [
         'decoy:2',
         'grasshopper:2',
+        'kilter:13',
+        'kilter:21',
+        'kilter:25',
+        'kilter:29',
+        'kilter:33',
+        'kilter:43',
         'moonboard:43',
         'soill:2',
         'tension:2',

--- a/packages/board-constants/src/__tests__/hold-states.test.ts
+++ b/packages/board-constants/src/__tests__/hold-states.test.ts
@@ -64,6 +64,10 @@ describe('getHoldDisplayColor', () => {
   // Every board whose HAND is a near-black blue in classic. The Boardsesh mode
   // veils the wall around a lit hold, and #0000FF / #4444FF / #4455FF has too
   // little lightness of its own to separate from that field (issue #2202).
+  //
+  // MoonBoard is NOT here. Its HAND is the same near-black blue, but its own
+  // holds are blue too, so the Aura blue marked a blue hold with a blue glow —
+  // it takes Kilter's cyan instead, pinned below.
   const darkBlueHands: [BoardName, number][] = [
     ['tension', 2],
     ['tension', 6],
@@ -72,7 +76,6 @@ describe('getHoldDisplayColor', () => {
     ['woods', 2],
     ['grasshopper', 2],
     ['decoy', 2],
-    ['moonboard', 43],
   ];
 
   for (const [board, code] of darkBlueHands) {
@@ -90,6 +93,21 @@ describe('getHoldDisplayColor', () => {
       expect(info.color).toBe('#0000FF');
     });
   }
+
+  it('gives MoonBoard Kilter’s cyan HAND, not the Aura blue its wall would swallow', () => {
+    // MoonBoard 2024's holds are blue plastic, so BOARDSESH_HAND_BLUE put a blue
+    // mark on a blue hold. Asserted against Kilter's own entry rather than a
+    // literal: the promise is "one HAND colour across the two boards", and a
+    // literal here would let Kilter move without failing anything.
+    const moonboardHand = HOLD_STATE_MAP.moonboard[43];
+    expect(moonboardHand.name).toBe('HAND');
+    expect(getHoldDisplayColor(moonboardHand, 'aura')).toBe(getHoldDisplayColor(HOLD_STATE_MAP.kilter[13], 'aura'));
+    expect(getHoldDisplayColor(moonboardHand, 'aura')).not.toBe(BOARDSESH_HAND_BLUE);
+    // Classic is untouched: cached classic overlays and the hold-filter swatches
+    // keep the colour they have always drawn.
+    expect(getHoldDisplayColor(moonboardHand, 'classic')).toBe('#4444FF');
+    expect(moonboardHand.color).toBe('#0000FF');
+  });
 
   it('leaves Kilter identical in both modes — its cyan HAND already reads on the veil', () => {
     for (const [code, info] of Object.entries(HOLD_STATE_MAP.kilter)) {

--- a/packages/board-constants/src/__tests__/hold-states.test.ts
+++ b/packages/board-constants/src/__tests__/hold-states.test.ts
@@ -65,16 +65,16 @@ describe('getHoldDisplayColor', () => {
   // veils the wall around a lit hold, and #0000FF / #4444FF / #4455FF has too
   // little lightness of its own to separate from that field (issue #2202).
   //
-  // MoonBoard is NOT here. Its HAND is the same near-black blue, but its own
-  // holds are blue too, so the Aura blue marked a blue hold with a blue glow —
-  // it takes Kilter's cyan instead, pinned below.
+  // MoonBoard and Grasshopper are NOT here. Their HAND is the same near-black
+  // blue, but their own holds are blue — MoonBoard 2024's are #2f8bcb and
+  // Grasshopper's `flow` set is #058fca — so the Aura blue marked a blue hold
+  // with a blue glow. Both take the cyan instead, pinned below.
   const darkBlueHands: [BoardName, number][] = [
     ['tension', 2],
     ['tension', 6],
     ['touchstone', 2],
     ['soill', 2],
     ['woods', 2],
-    ['grasshopper', 2],
     ['decoy', 2],
   ];
 
@@ -94,21 +94,35 @@ describe('getHoldDisplayColor', () => {
     });
   }
 
-  it('gives MoonBoard Kilter’s cyan HAND, not the Aura blue its wall would swallow', () => {
-    // MoonBoard 2024's holds are blue plastic, so BOARDSESH_HAND_BLUE put a blue
-    // mark on a blue hold. Asserted against Kilter's own entry rather than a
-    // literal: the promise is "one HAND colour across the two boards", and a
-    // literal here would let Kilter move without failing anything. The two read
-    // one shared constant now, so this is a second lock on the same promise.
-    const moonboardHand = HOLD_STATE_MAP.moonboard[43];
-    expect(moonboardHand.name).toBe('HAND');
-    expect(getHoldDisplayColor(moonboardHand, 'aura')).toBe(getHoldDisplayColor(HOLD_STATE_MAP.kilter[13], 'aura'));
-    expect(getHoldDisplayColor(moonboardHand, 'aura')).not.toBe(BOARDSESH_HAND_BLUE);
-    // Classic is untouched: cached classic overlays and the hold-filter swatches
-    // keep the colour they have always drawn.
-    expect(getHoldDisplayColor(moonboardHand, 'classic')).toBe('#4444FF');
-    expect(moonboardHand.color).toBe('#0000FF');
-  });
+  // The boards whose own holds are blue, so the Aura blue marked a blue hold
+  // with a blue glow: MoonBoard 2024's art is #2f8bcb, Grasshopper's `flow` set
+  // is #058fca. Both take the cyan.
+  const blueWalledHands: [BoardName, number, string][] = [
+    ['moonboard', 43, '#4444FF'],
+    ['grasshopper', 2, '#4455FF'],
+  ];
+
+  for (const [board, code, classicColor] of blueWalledHands) {
+    it(`${board} code ${code} takes Kilter’s cyan, not the Aura blue its wall would swallow`, () => {
+      // Asserted against Kilter's own entry rather than a literal: the promise
+      // is "one HAND colour across these boards", and a literal here would let
+      // Kilter move without failing anything. They read one shared constant
+      // now, so this is a second lock on the same promise.
+      const info = HOLD_STATE_MAP[board][code];
+      expect(info.name).toBe('HAND');
+      expect(getHoldDisplayColor(info, 'aura')).toBe(getHoldDisplayColor(HOLD_STATE_MAP.kilter[13], 'aura'));
+      expect(getHoldDisplayColor(info, 'aura')).not.toBe(BOARDSESH_HAND_BLUE);
+    });
+
+    it(`${board} code ${code} keeps the board's own colour in Classic`, () => {
+      // The whole point of `boardseshDisplayColor` being a separate field:
+      // Classic is what the original apps drew, and it must not move because
+      // Aura did. Cached classic overlays and the hold-filter swatches read it.
+      const info = HOLD_STATE_MAP[board][code];
+      expect(getHoldDisplayColor(info, 'classic')).toBe(classicColor);
+      expect(info.color).toBe('#0000FF');
+    });
+  }
 
   it('leaves Kilter identical in both modes — its cyan HAND already reads on the veil', () => {
     for (const [code, info] of Object.entries(HOLD_STATE_MAP.kilter)) {

--- a/packages/board-constants/src/__tests__/moonboard-firmware-color-parity.test.ts
+++ b/packages/board-constants/src/__tests__/moonboard-firmware-color-parity.test.ts
@@ -1,0 +1,117 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { HOLD_STATE_MAP } from '../hold-states';
+
+/**
+ * The app and this repo's own ESP32 MoonBoard firmware must light a role the
+ * same colour.
+ *
+ * MoonBoard's BLE wire format carries role LETTERS, not RGB, so nothing forces
+ * the two to agree — `HOLD_STATE_MAP.moonboard[].color` is the app's mirror of
+ * what the controller lights, kept in step by hand. That is exactly how it
+ * drifted: FOOT was moved to amber in the app while
+ * `embedded/libs/moonboard-protocol` still lit it cyan, which would have shown
+ * a foot hold cyan on the wall and amber in the app.
+ *
+ * The firmware also feeds frames back — `p<id>r45` strings the app renders
+ * through this same map — so the two really are two ends of one contract.
+ *
+ * Parsed out of the C++ rather than duplicated as a list: a hardcoded copy of
+ * the firmware's palette here would drift from the firmware just as silently as
+ * the app did.
+ */
+
+const FIRMWARE_SOURCE = join(
+  import.meta.dirname,
+  '../../../../embedded/libs/moonboard-protocol/src/moonboard_protocol.cpp',
+);
+
+/** `constexpr uint8_t COLOR_NAME[3] = {r, g, b};` → `{ COLOR_NAME: '#rrggbb' }`. */
+function firmwarePalette(source: string): Record<string, string> {
+  const palette: Record<string, string> = {};
+  const declaration = /constexpr uint8_t (COLOR_[A-Z]+)\[3\] = \{\s*(\d+),\s*(\d+),\s*(\d+)\s*\};/g;
+  let match: RegExpExecArray | null;
+  while ((match = declaration.exec(source)) !== null) {
+    const [, name, ...channels] = match;
+    palette[name] = `#${channels.map((value) => Number(value).toString(16).padStart(2, '0')).join('')}`.toUpperCase();
+  }
+  return palette;
+}
+
+/** The `case 'X': color = COLOR_NAME;` arms of `tokenToColor`, as token → colour. */
+function firmwareTokenColors(source: string, palette: Record<string, string>): Record<string, string> {
+  const body = source.slice(source.indexOf('void MoonBoardProtocol::tokenToColor'));
+  const arms = body.slice(0, body.indexOf('\n}'));
+  const colors: Record<string, string> = {};
+  const arm = /case '([A-Z])':\s*case '[a-z]':\s*color = (COLOR_[A-Z]+);/g;
+  let match: RegExpExecArray | null;
+  while ((match = arm.exec(arms)) !== null) {
+    const [, token, colorName] = match;
+    colors[token] = palette[colorName];
+  }
+  return colors;
+}
+
+/**
+ * Firmware token → the MoonBoard role code it decodes to, from
+ * `tokenToRoleCode` in the same file. `P`/`R` both mean HAND; the colour switch
+ * only names the non-default tokens, since HAND is the `default:` arm.
+ */
+const TOKEN_TO_ROLE: [token: string, roleCode: number, role: string][] = [
+  ['S', 42, 'STARTING'],
+  ['F', 45, 'FOOT'],
+  ['E', 44, 'FINISH'],
+];
+
+describe('MoonBoard firmware colour parity', () => {
+  const source = readFileSync(FIRMWARE_SOURCE, 'utf8');
+  const palette = firmwarePalette(source);
+  const tokenColors = firmwareTokenColors(source, palette);
+
+  it('parses the firmware palette (guards the parser itself, not the colours)', () => {
+    // If the firmware is refactored so these regexes stop matching, every
+    // assertion below would vacuously pass. This is what makes them mean
+    // something.
+    expect(Object.keys(palette).length).toBeGreaterThanOrEqual(5);
+    expect(Object.keys(tokenColors).sort()).toEqual(['E', 'F', 'L', 'M', 'S']);
+  });
+
+  it('lights FOOT the amber the app draws, not the cyan it used to', () => {
+    // The regression this file exists for. Cyan sat next to the blue HAND on an
+    // RGB strip and was hard to call apart mid-climb.
+    expect(tokenColors.F).toBe('#FFAA00');
+    expect(HOLD_STATE_MAP.moonboard[45].color.toUpperCase()).toBe(tokenColors.F);
+  });
+
+  it.each(TOKEN_TO_ROLE)('agrees with the app on the %s token (role %i, %s)', (token, roleCode) => {
+    expect(HOLD_STATE_MAP.moonboard[roleCode].color.toUpperCase()).toBe(tokenColors[token]);
+  });
+
+  it('agrees with the app on HAND, and HAND is still the firmware’s default arm', () => {
+    // HAND is the `default:` case, so it has no `case 'X':` arm to parse. Assert
+    // the arm itself as well as the constant — otherwise the firmware could
+    // switch its default to another colour and this test would not notice.
+    expect(source).toMatch(/default:\s*color = COLOR_BLUE;/);
+    expect(palette.COLOR_BLUE).toBe('#0000FF');
+    expect(HOLD_STATE_MAP.moonboard[43].color.toUpperCase()).toBe(palette.COLOR_BLUE);
+  });
+
+  /**
+   * Roles 46-48 do NOT agree, and did not before this test existed.
+   *
+   * Pinned as the divergence they are rather than left silent: the app draws
+   * screen-tuned values while the firmware lights raw LED primaries. Both sides
+   * are frozen here, so changing either one fails this test and forces the
+   * decision to be made deliberately instead of discovered on a wall.
+   */
+  it.each([
+    ['AUX', 46, '#FFE066', 'COLOR_YELLOW', '#FFFF00'],
+    ['LEFT hand', 47, '#8B5CF6', 'COLOR_VIOLET', '#8000FF'],
+    ['MATCH hand', 48, '#FF4FA3', 'COLOR_PINK', '#FF00A0'],
+  ])('records the known %s divergence (role %i)', (_role, roleCode, appColor, firmwareName, firmwareColor) => {
+    expect(HOLD_STATE_MAP.moonboard[roleCode].color.toUpperCase()).toBe(appColor);
+    expect(palette[firmwareName]).toBe(firmwareColor);
+    expect(appColor).not.toBe(firmwareColor);
+  });
+});

--- a/packages/board-constants/src/hold-states.ts
+++ b/packages/board-constants/src/hold-states.ts
@@ -74,12 +74,18 @@ const BOARDSESH_HAND_BLUE = '#6980FF';
  * a mark on it. This cyan is far enough round the wheel, and bright enough, to
  * separate from blue plastic under the veil.
  *
- * One constant shared by both boards rather than a second hex that happens to
- * match: a climber who owns a Kilter and a MoonBoard should see one HAND
- * colour, and this is the only way the code says so. Kilter's colour-mode
- * products (Tycho, codes 36-41) keep their own literals — 36 being cyan is that
- * palette's business, not this relationship's, and it must not follow this
- * constant if the HAND colour ever moves.
+ * One constant shared by every board that needs it rather than a hex repeated
+ * per board: a climber who owns a Kilter, a MoonBoard and a Grasshopper should
+ * see one HAND colour, and this is the only way the code says so. Kilter's
+ * colour-mode products (Tycho, codes 36-41) keep their own literals — 36 being
+ * cyan is that palette's business, not this relationship's, and it must not
+ * follow this constant if the HAND colour ever moves.
+ *
+ * Which boards take it is a measured question, not a taste one. The art says:
+ * MoonBoard 2024's holds are #2f8bcb and Grasshopper's `flow` set is #058fca —
+ * both mid-lightness azure, both a hue the Aura blue sits inside. Grasshopper's
+ * other sets are neutral grey (#4d4a4a), so `flow` is what forces its hand.
+ * Every remaining board's holds are plywood-neutral and keep the Aura blue.
  */
 const KILTER_HAND_CYAN = '#00FFFF';
 
@@ -162,7 +168,7 @@ export const HOLD_STATE_MAP: Record<BoardName, Record<HoldCode, HoldStateInfo>> 
   },
   grasshopper: {
     1: { name: 'STARTING', displayColor: '#00DD00', color: '#00FF00' },
-    2: { name: 'HAND', displayColor: '#4455FF', boardseshDisplayColor: BOARDSESH_HAND_BLUE, color: '#0000FF' },
+    2: { name: 'HAND', displayColor: '#4455FF', boardseshDisplayColor: KILTER_HAND_CYAN, color: '#0000FF' },
     3: { name: 'FINISH', displayColor: '#FF0000', color: '#FF0000' },
     4: { name: 'FOOT', displayColor: '#FF00FF', color: '#FF00FF' },
   },

--- a/packages/board-constants/src/hold-states.ts
+++ b/packages/board-constants/src/hold-states.ts
@@ -29,6 +29,15 @@ export type HoldStateInfo = {
 export type BoardRenderMode = 'classic' | 'aura';
 
 /**
+ * The three fields the colour rule reads.
+ *
+ * A structural subset rather than the whole `HoldStateInfo` so the shared render
+ * pipeline (`@boardsesh/board-render`), whose own hold-state record carries no
+ * `name`, can call this instead of re-deriving the rule and drifting from it.
+ */
+export type HoldDisplayColorInput = Pick<HoldStateInfo, 'color' | 'displayColor' | 'boardseshDisplayColor'>;
+
+/**
  * The screen colour for a hold state under a given render mode.
  *
  * `classic` is the long-standing `displayColor ?? color` rule, unchanged.
@@ -39,17 +48,37 @@ export type BoardRenderMode = 'classic' | 'aura';
  * the right thing to paint on screen where a display colour exists — it is the
  * last resort here only because Kilter's entries carry no `displayColor`.
  */
-export function getHoldDisplayColor(info: HoldStateInfo, mode: BoardRenderMode): string {
+export function getHoldDisplayColor(info: HoldDisplayColorInput, mode: BoardRenderMode): string {
   if (mode === 'aura' && info.boardseshDisplayColor) return info.boardseshDisplayColor;
   return info.displayColor ?? info.color;
 }
 
 /**
  * The one Boardsesh-mode HAND blue (issue #2202). Every dark-blue HAND across
- * the Aurora-style boards and MoonBoard resolves to this single hex, so the role
- * reads the same whichever wall you are on.
+ * the Aurora-style boards resolves to this single hex, so the role reads the
+ * same whichever of those walls you are on.
+ *
+ * MoonBoard is the deliberate exception — see `MOONBOARD_AURA_HAND`. The rule
+ * this constant encodes is "lift the HAND off the wall", not "one blue
+ * everywhere", and on a wall whose own holds are blue the two goals disagree.
  */
 const BOARDSESH_HAND_BLUE = '#6980FF';
+
+/**
+ * MoonBoard's Aura HAND: Kilter's HAND cyan.
+ *
+ * `BOARDSESH_HAND_BLUE` lifts a dark-blue HAND off a wall of neutral plywood
+ * and grey-brown holds, which is every Aurora board. MoonBoard 2024's holds are
+ * themselves blue, so there it lands blue-on-blue — the marker and the thing it
+ * marks are the same hue, and the glow reads as part of the hold rather than as
+ * a mark on it. Kilter's cyan is far enough round the wheel, and bright enough,
+ * to separate from blue plastic under the veil.
+ *
+ * Written as Kilter's own hand colour rather than a fresh hex on purpose: a
+ * climber who owns both boards should see one HAND colour, and
+ * `hold-states.test.ts` pins the two equal so they cannot drift apart.
+ */
+const MOONBOARD_AURA_HAND = '#00FFFF';
 
 // Canonical mapping of board-specific hold role codes to their state and LED colors.
 // Each board product has its own set of role codes.
@@ -108,7 +137,7 @@ export const HOLD_STATE_MAP: Record<BoardName, Record<HoldCode, HoldStateInfo>> 
   // Values 45-48 are additional live-BLE preview roles emitted by the ESP32 dev firmware.
   moonboard: {
     42: { name: 'STARTING', color: '#00FF00', displayColor: '#44FF44' },
-    43: { name: 'HAND', color: '#0000FF', displayColor: '#4444FF', boardseshDisplayColor: BOARDSESH_HAND_BLUE },
+    43: { name: 'HAND', color: '#0000FF', displayColor: '#4444FF', boardseshDisplayColor: MOONBOARD_AURA_HAND },
     44: { name: 'FINISH', color: '#FF0000', displayColor: '#FF3333' },
     45: { name: 'FOOT', color: '#00FFFF', displayColor: '#66F0FF' },
     46: { name: 'AUX', color: '#FFE066', displayColor: '#FFE066', renderStyle: 'above-marker' },

--- a/packages/board-constants/src/hold-states.ts
+++ b/packages/board-constants/src/hold-states.ts
@@ -153,11 +153,31 @@ export const HOLD_STATE_MAP: Record<BoardName, Record<HoldCode, HoldStateInfo>> 
   // MoonBoard hold states (no foot holds in standard climbs)
   // Values 42-44 are used by saved MoonBoard climbs.
   // Values 45-48 are additional live-BLE preview roles emitted by the ESP32 dev firmware.
+  //
+  // MoonBoard's wire format carries ROLE LETTERS, not colours (`MOONBOARD_ROLE_MAP`
+  // in `ble-protocol/src/moonboard.ts` sends S/P/E), so `color` here is not a wire
+  // value the way it is on the Aurora boards — it is the colour the controller
+  // firmware lights for that role, mirrored so the app can draw the same thing.
+  //
+  // Which firmware: OUR ESP32 one, `embedded/libs/moonboard-protocol`. Codes
+  // 45-48 are its roles, not the official protocol's — the official format has no
+  // foot role at all ("Foot-only holds are not separately lit in this format",
+  // docs/MOONBOARD_BLUETOOTH_PROTOCOL_SPEC.md §5.2) — and Boardsesh never
+  // transmits them, since `MOONBOARD_ROLE_MAP` stops at 44. The firmware emits
+  // `p<id>r45` frames back to the app, which is the only way this colour is ever
+  // read. So the two ends move together, in this repo:
+  // `moonboard-firmware-color-parity.test.ts` fails if they drift.
   moonboard: {
     42: { name: 'STARTING', color: '#00FF00', displayColor: '#44FF44' },
     43: { name: 'HAND', color: '#0000FF', displayColor: '#4444FF', boardseshDisplayColor: AURA_HAND_CYAN },
     44: { name: 'FINISH', color: '#FF0000', displayColor: '#FF3333' },
-    45: { name: 'FOOT', color: '#00FFFF', displayColor: '#66F0FF' },
+    // Amber, not the cyan this used to be. Two reasons, and the wall is the
+    // bigger one: on an RGB strip a cyan foot next to the blue HAND is very hard
+    // to call apart mid-climb. On screen it collided with the Aura HAND cyan too
+    // — #66F0FF is dE00 2.0 from #4DF5FD in normal vision and 0.4 under
+    // deuteranopia, i.e. the same colour. Matches Kilter's FOOT amber so a
+    // climber reads feet the same way on both boards.
+    45: { name: 'FOOT', color: '#FFAA00', displayColor: '#FFBB44' },
     46: { name: 'AUX', color: '#FFE066', displayColor: '#FFE066', renderStyle: 'above-marker' },
     47: { name: 'HAND', color: '#8B5CF6', displayColor: '#C084FC' },
     48: { name: 'HAND', color: '#FF4FA3', displayColor: '#FF7DBB' },

--- a/packages/board-constants/src/hold-states.ts
+++ b/packages/board-constants/src/hold-states.ts
@@ -65,20 +65,23 @@ export function getHoldDisplayColor(info: HoldDisplayColorInput, mode: BoardRend
 const BOARDSESH_HAND_BLUE = '#6980FF';
 
 /**
- * MoonBoard's Aura HAND: Kilter's HAND cyan.
+ * Kilter's HAND cyan, and MoonBoard's Aura HAND.
  *
  * `BOARDSESH_HAND_BLUE` lifts a dark-blue HAND off a wall of neutral plywood
  * and grey-brown holds, which is every Aurora board. MoonBoard 2024's holds are
  * themselves blue, so there it lands blue-on-blue — the marker and the thing it
  * marks are the same hue, and the glow reads as part of the hold rather than as
- * a mark on it. Kilter's cyan is far enough round the wheel, and bright enough,
- * to separate from blue plastic under the veil.
+ * a mark on it. This cyan is far enough round the wheel, and bright enough, to
+ * separate from blue plastic under the veil.
  *
- * Written as Kilter's own hand colour rather than a fresh hex on purpose: a
- * climber who owns both boards should see one HAND colour, and
- * `hold-states.test.ts` pins the two equal so they cannot drift apart.
+ * One constant shared by both boards rather than a second hex that happens to
+ * match: a climber who owns a Kilter and a MoonBoard should see one HAND
+ * colour, and this is the only way the code says so. Kilter's colour-mode
+ * products (Tycho, codes 36-41) keep their own literals — 36 being cyan is that
+ * palette's business, not this relationship's, and it must not follow this
+ * constant if the HAND colour ever moves.
  */
-const MOONBOARD_AURA_HAND = '#00FFFF';
+const KILTER_HAND_CYAN = '#00FFFF';
 
 // Canonical mapping of board-specific hold role codes to their state and LED colors.
 // Each board product has its own set of role codes.
@@ -86,27 +89,27 @@ export const HOLD_STATE_MAP: Record<BoardName, Record<HoldCode, HoldStateInfo>> 
   kilter: {
     // Product 1 – Kilter Board Original
     12: { name: 'STARTING', color: '#00FF00' },
-    13: { name: 'HAND', color: '#00FFFF' },
+    13: { name: 'HAND', color: KILTER_HAND_CYAN },
     14: { name: 'FINISH', color: '#FF00FF' },
     15: { name: 'FOOT', color: '#FFAA00' },
     // Product 2 – JUUL
     20: { name: 'STARTING', color: '#00FF00' },
-    21: { name: 'HAND', color: '#00FFFF' },
+    21: { name: 'HAND', color: KILTER_HAND_CYAN },
     22: { name: 'FINISH', color: '#FF00FF' },
     23: { name: 'FOOT', color: '#FFA500' },
     // Product 3 – Demo Board
     24: { name: 'STARTING', color: '#00FF00' },
-    25: { name: 'HAND', color: '#00FFFF' },
+    25: { name: 'HAND', color: KILTER_HAND_CYAN },
     26: { name: 'FINISH', color: '#FF00FF' },
     27: { name: 'FOOT', color: '#FFA500' },
     // Product 4 – BKB Board
     28: { name: 'STARTING', color: '#00FF00' },
-    29: { name: 'HAND', color: '#00FFFF' },
+    29: { name: 'HAND', color: KILTER_HAND_CYAN },
     30: { name: 'FINISH', color: '#FF00FF' },
     31: { name: 'FOOT', color: '#FFA500' },
     // Product 5 – Spire
     32: { name: 'STARTING', color: '#00FF00' },
-    33: { name: 'HAND', color: '#00FFFF' },
+    33: { name: 'HAND', color: KILTER_HAND_CYAN },
     34: { name: 'FINISH', color: '#FF00FF' },
     35: { name: 'FOOT', color: '#FFA500' },
     // Product 6 – Tycho (color mode, no start/finish semantics)
@@ -118,7 +121,7 @@ export const HOLD_STATE_MAP: Record<BoardName, Record<HoldCode, HoldStateInfo>> 
     41: { name: 'HAND', color: '#0000FF' },
     // Product 7 – Kilter Board Homewall
     42: { name: 'STARTING', color: '#00FF00' },
-    43: { name: 'HAND', color: '#00FFFF' },
+    43: { name: 'HAND', color: KILTER_HAND_CYAN },
     44: { name: 'FINISH', color: '#FF00FF' },
     45: { name: 'FOOT', color: '#FFAA00' },
   },
@@ -137,7 +140,7 @@ export const HOLD_STATE_MAP: Record<BoardName, Record<HoldCode, HoldStateInfo>> 
   // Values 45-48 are additional live-BLE preview roles emitted by the ESP32 dev firmware.
   moonboard: {
     42: { name: 'STARTING', color: '#00FF00', displayColor: '#44FF44' },
-    43: { name: 'HAND', color: '#0000FF', displayColor: '#4444FF', boardseshDisplayColor: MOONBOARD_AURA_HAND },
+    43: { name: 'HAND', color: '#0000FF', displayColor: '#4444FF', boardseshDisplayColor: KILTER_HAND_CYAN },
     44: { name: 'FINISH', color: '#FF0000', displayColor: '#FF3333' },
     45: { name: 'FOOT', color: '#00FFFF', displayColor: '#66F0FF' },
     46: { name: 'AUX', color: '#FFE066', displayColor: '#FFE066', renderStyle: 'above-marker' },

--- a/packages/board-constants/src/hold-states.ts
+++ b/packages/board-constants/src/hold-states.ts
@@ -54,40 +54,49 @@ export function getHoldDisplayColor(info: HoldDisplayColorInput, mode: BoardRend
 }
 
 /**
- * The one Boardsesh-mode HAND blue (issue #2202). Every dark-blue HAND across
- * the Aurora-style boards resolves to this single hex, so the role reads the
- * same whichever of those walls you are on.
+ * The one Aura HAND colour, on every board.
  *
- * MoonBoard is the deliberate exception — see `MOONBOARD_AURA_HAND`. The rule
- * this constant encodes is "lift the HAND off the wall", not "one blue
- * everywhere", and on a wall whose own holds are blue the two goals disagree.
+ * Aura's HAND used to be two colours: #6980FF on plywood walls, and Kilter's LED
+ * cyan #00FFFF on the boards whose own holds are blue (MoonBoard 2024's #2f8bcb,
+ * Grasshopper's `flow` #058fca), where a blue mark on blue plastic read as part
+ * of the hold rather than a mark on it. #00FFFF fixed that but is the sRGB cyan
+ * corner: a system default, not a decision.
+ *
+ * This is ours at L* 88.9, C*ab 42.8, hue 202.4deg — 94% of the sRGB hull with no
+ * channel pinned, dE00 3.97 off #00FFFF. The lightness is load-bearing and is why
+ * it is not softer: the renderer paints the role at 0.55 over unlifted hold art
+ * (blue holds sit at OkL 0.61, above `normalise_target` 0.588, so they get no
+ * lift), which leaves the composited mark dE00 15.7 from the hold it sits on
+ * under the worst of normal/protan/deutan vision — 3.6x the #6980FF failure it
+ * replaces (4.3), and 1.2 short of #00FFFF. That 1.2 is the entire price, and
+ * nothing else pays: HAND against FOOT magenta under deuteranopia (the pair that
+ * actually binds, ~6% of men) improves to 18.3 from 17.9, and cyan against green
+ * improves to 30.8 from 29.2 because the hue leans 6deg blue rather than green.
+ *
+ * ONE constant for every board, because the old split — "is this board's art
+ * blue?" — is invisible to a climber and never partitioned cleanly anyway:
+ * Grasshopper qualified on one of its eight hold sets. Two near-miss cyans
+ * (dE00 4.0 apart) would read as a stale cache, not as a decision.
+ *
+ * Tritanopia is NOT solved by this or any cyan — the best achievable separation
+ * from STARTING green across the whole cyan gamut is dE00 8.9, because the
+ * S-cone signal that tells cyan from green is the missing one. That is the role
+ * glyphs' job, not the hex's.
  */
-const BOARDSESH_HAND_BLUE = '#6980FF';
+const AURA_HAND_CYAN = '#4DF5FD';
 
 /**
- * Kilter's HAND cyan, and MoonBoard's Aura HAND.
+ * Kilter's HAND cyan as it goes ON THE WIRE.
  *
- * `BOARDSESH_HAND_BLUE` lifts a dark-blue HAND off a wall of neutral plywood
- * and grey-brown holds, which is every Aurora board. MoonBoard 2024's holds are
- * themselves blue, so there it lands blue-on-blue — the marker and the thing it
- * marks are the same hue, and the glow reads as part of the hold rather than as
- * a mark on it. This cyan is far enough round the wheel, and bright enough, to
- * separate from blue plastic under the veil.
- *
- * One constant shared by every board that needs it rather than a hex repeated
- * per board: a climber who owns a Kilter, a MoonBoard and a Grasshopper should
- * see one HAND colour, and this is the only way the code says so. Kilter's
- * colour-mode products (Tycho, codes 36-41) keep their own literals — 36 being
- * cyan is that palette's business, not this relationship's, and it must not
- * follow this constant if the HAND colour ever moves.
- *
- * Which boards take it is a measured question, not a taste one. The art says:
- * MoonBoard 2024's holds are #2f8bcb and Grasshopper's `flow` set is #058fca —
- * both mid-lightness azure, both a hue the Aura blue sits inside. Grasshopper's
- * other sets are neutral grey (#4d4a4a), so `flow` is what forces its hand.
- * Every remaining board's holds are plywood-neutral and keep the Aura blue.
+ * This is not a screen colour. `packages/shared/ble-protocol/src/aurora.ts` reads
+ * `HOLD_STATE_MAP[board][code].color` and transmits it to the wall, so editing
+ * this changes which LEDs a physical Kilter lights and in what colour. It is
+ * deliberately its own constant, and deliberately NOT the one above: the two were
+ * briefly the same constant, which made retuning the Aura palette a silent BLE
+ * change. Kilter's screen colour now comes from `boardseshDisplayColor` like
+ * every other board's.
  */
-const KILTER_HAND_CYAN = '#00FFFF';
+const KILTER_HAND_LED_CYAN = '#00FFFF';
 
 // Canonical mapping of board-specific hold role codes to their state and LED colors.
 // Each board product has its own set of role codes.
@@ -95,27 +104,27 @@ export const HOLD_STATE_MAP: Record<BoardName, Record<HoldCode, HoldStateInfo>> 
   kilter: {
     // Product 1 – Kilter Board Original
     12: { name: 'STARTING', color: '#00FF00' },
-    13: { name: 'HAND', color: KILTER_HAND_CYAN },
+    13: { name: 'HAND', color: KILTER_HAND_LED_CYAN, boardseshDisplayColor: AURA_HAND_CYAN },
     14: { name: 'FINISH', color: '#FF00FF' },
     15: { name: 'FOOT', color: '#FFAA00' },
     // Product 2 – JUUL
     20: { name: 'STARTING', color: '#00FF00' },
-    21: { name: 'HAND', color: KILTER_HAND_CYAN },
+    21: { name: 'HAND', color: KILTER_HAND_LED_CYAN, boardseshDisplayColor: AURA_HAND_CYAN },
     22: { name: 'FINISH', color: '#FF00FF' },
     23: { name: 'FOOT', color: '#FFA500' },
     // Product 3 – Demo Board
     24: { name: 'STARTING', color: '#00FF00' },
-    25: { name: 'HAND', color: KILTER_HAND_CYAN },
+    25: { name: 'HAND', color: KILTER_HAND_LED_CYAN, boardseshDisplayColor: AURA_HAND_CYAN },
     26: { name: 'FINISH', color: '#FF00FF' },
     27: { name: 'FOOT', color: '#FFA500' },
     // Product 4 – BKB Board
     28: { name: 'STARTING', color: '#00FF00' },
-    29: { name: 'HAND', color: KILTER_HAND_CYAN },
+    29: { name: 'HAND', color: KILTER_HAND_LED_CYAN, boardseshDisplayColor: AURA_HAND_CYAN },
     30: { name: 'FINISH', color: '#FF00FF' },
     31: { name: 'FOOT', color: '#FFA500' },
     // Product 5 – Spire
     32: { name: 'STARTING', color: '#00FF00' },
-    33: { name: 'HAND', color: KILTER_HAND_CYAN },
+    33: { name: 'HAND', color: KILTER_HAND_LED_CYAN, boardseshDisplayColor: AURA_HAND_CYAN },
     34: { name: 'FINISH', color: '#FF00FF' },
     35: { name: 'FOOT', color: '#FFA500' },
     // Product 6 – Tycho (color mode, no start/finish semantics)
@@ -127,17 +136,17 @@ export const HOLD_STATE_MAP: Record<BoardName, Record<HoldCode, HoldStateInfo>> 
     41: { name: 'HAND', color: '#0000FF' },
     // Product 7 – Kilter Board Homewall
     42: { name: 'STARTING', color: '#00FF00' },
-    43: { name: 'HAND', color: KILTER_HAND_CYAN },
+    43: { name: 'HAND', color: KILTER_HAND_LED_CYAN, boardseshDisplayColor: AURA_HAND_CYAN },
     44: { name: 'FINISH', color: '#FF00FF' },
     45: { name: 'FOOT', color: '#FFAA00' },
   },
   tension: {
     1: { name: 'STARTING', displayColor: '#00DD00', color: '#00FF00' },
-    2: { name: 'HAND', displayColor: '#4444FF', boardseshDisplayColor: BOARDSESH_HAND_BLUE, color: '#0000FF' },
+    2: { name: 'HAND', displayColor: '#4444FF', boardseshDisplayColor: AURA_HAND_CYAN, color: '#0000FF' },
     3: { name: 'FINISH', displayColor: '#FF0000', color: '#FF0000' },
     4: { name: 'FOOT', displayColor: '#FF00FF', color: '#FF00FF' },
     5: { name: 'STARTING', displayColor: '#00DD00', color: '#00FF00' },
-    6: { name: 'HAND', displayColor: '#4444FF', boardseshDisplayColor: BOARDSESH_HAND_BLUE, color: '#0000FF' },
+    6: { name: 'HAND', displayColor: '#4444FF', boardseshDisplayColor: AURA_HAND_CYAN, color: '#0000FF' },
     7: { name: 'FINISH', displayColor: '#FF0000', color: '#FF0000' },
     8: { name: 'FOOT', displayColor: '#FF00FF', color: '#FF00FF' },
   },
@@ -146,7 +155,7 @@ export const HOLD_STATE_MAP: Record<BoardName, Record<HoldCode, HoldStateInfo>> 
   // Values 45-48 are additional live-BLE preview roles emitted by the ESP32 dev firmware.
   moonboard: {
     42: { name: 'STARTING', color: '#00FF00', displayColor: '#44FF44' },
-    43: { name: 'HAND', color: '#0000FF', displayColor: '#4444FF', boardseshDisplayColor: KILTER_HAND_CYAN },
+    43: { name: 'HAND', color: '#0000FF', displayColor: '#4444FF', boardseshDisplayColor: AURA_HAND_CYAN },
     44: { name: 'FINISH', color: '#FF0000', displayColor: '#FF3333' },
     45: { name: 'FOOT', color: '#00FFFF', displayColor: '#66F0FF' },
     46: { name: 'AUX', color: '#FFE066', displayColor: '#FFE066', renderStyle: 'above-marker' },
@@ -156,25 +165,25 @@ export const HOLD_STATE_MAP: Record<BoardName, Record<HoldCode, HoldStateInfo>> 
   // New Aurora boards use the same 1/2/3/4 role codes as Tension-style layouts.
   decoy: {
     1: { name: 'STARTING', displayColor: '#00DD00', color: '#00FF00' },
-    2: { name: 'HAND', displayColor: '#0000FF', boardseshDisplayColor: BOARDSESH_HAND_BLUE, color: '#0000FF' },
+    2: { name: 'HAND', displayColor: '#0000FF', boardseshDisplayColor: AURA_HAND_CYAN, color: '#0000FF' },
     3: { name: 'FINISH', displayColor: '#FF0000', color: '#FF0000' },
     4: { name: 'FOOT', displayColor: '#FF00FF', color: '#FF00FF' },
   },
   touchstone: {
     1: { name: 'STARTING', displayColor: '#00DD00', color: '#00FF00' },
-    2: { name: 'HAND', displayColor: '#4444FF', boardseshDisplayColor: BOARDSESH_HAND_BLUE, color: '#0000FF' },
+    2: { name: 'HAND', displayColor: '#4444FF', boardseshDisplayColor: AURA_HAND_CYAN, color: '#0000FF' },
     3: { name: 'FINISH', displayColor: '#FF0000', color: '#FF0000' },
     4: { name: 'FOOT', displayColor: '#FF00FF', color: '#FF00FF' },
   },
   grasshopper: {
     1: { name: 'STARTING', displayColor: '#00DD00', color: '#00FF00' },
-    2: { name: 'HAND', displayColor: '#4455FF', boardseshDisplayColor: KILTER_HAND_CYAN, color: '#0000FF' },
+    2: { name: 'HAND', displayColor: '#4455FF', boardseshDisplayColor: AURA_HAND_CYAN, color: '#0000FF' },
     3: { name: 'FINISH', displayColor: '#FF0000', color: '#FF0000' },
     4: { name: 'FOOT', displayColor: '#FF00FF', color: '#FF00FF' },
   },
   soill: {
     1: { name: 'STARTING', displayColor: '#00DD00', color: '#00FF00' },
-    2: { name: 'HAND', displayColor: '#4444FF', boardseshDisplayColor: BOARDSESH_HAND_BLUE, color: '#0000FF' },
+    2: { name: 'HAND', displayColor: '#4444FF', boardseshDisplayColor: AURA_HAND_CYAN, color: '#0000FF' },
     3: { name: 'FINISH', displayColor: '#FF0000', color: '#FF0000' },
     4: { name: 'FOOT', displayColor: '#FF00FF', color: '#FF00FF' },
   },
@@ -184,7 +193,7 @@ export const HOLD_STATE_MAP: Record<BoardName, Record<HoldCode, HoldStateInfo>> 
     // Magenta foot holds match every Aurora board — the hold-filter swatches read
     // their colour straight out of this map, and colour never goes on the wire.
     1: { name: 'FOOT', displayColor: '#FF00FF', color: '#FF00FF' },
-    2: { name: 'HAND', displayColor: '#4444FF', boardseshDisplayColor: BOARDSESH_HAND_BLUE, color: '#0000FF' },
+    2: { name: 'HAND', displayColor: '#4444FF', boardseshDisplayColor: AURA_HAND_CYAN, color: '#0000FF' },
     3: { name: 'FINISH', displayColor: '#FF0000', color: '#FF0000' },
     4: { name: 'STARTING', displayColor: '#00DD00', color: '#00FF00' },
   },

--- a/packages/mobile/src/components/board-look/BoardLookCarousel.tsx
+++ b/packages/mobile/src/components/board-look/BoardLookCarousel.tsx
@@ -48,6 +48,15 @@ type BoardLookCarouselProps = {
    * would fire one write per card scrolled past.
    */
   selectOnSnap?: boolean;
+  /**
+   * Whether each card carries its one-line description.
+   *
+   * A property of the SURFACE, not of the card size: onboarding drops the
+   * descriptions at every size, so the smallest screen — the one that falls back
+   * to rail-sized cards because a hero does not fit — does not answer a cramped
+   * layout by adding two lines of copy to every card.
+   */
+  showDescriptions?: boolean;
   contentStyle?: ViewStyle;
 };
 
@@ -74,6 +83,7 @@ export function BoardLookCarousel({
   heroThumb,
   windowWidth,
   selectOnSnap,
+  showDescriptions = true,
   contentStyle,
 }: BoardLookCarouselProps) {
   const { t } = useTranslation('common');
@@ -121,6 +131,7 @@ export function BoardLookCarousel({
         // The 416px bundled thumb photo would upscale ~2x here, and the wall
         // texture is precisely what a climber is being asked to judge.
         backgroundVariant: 'full',
+        showDescription: showDescriptions,
       };
     }
     return {
@@ -129,8 +140,9 @@ export function BoardLookCarousel({
       thumbHeight: RAIL_THUMB_HEIGHT,
       renderWidth: RAIL_RENDER_WIDTH,
       backgroundVariant: 'thumb',
+      showDescription: showDescriptions,
     };
-  }, [heroThumb, preview.boardWidth, preview.boardHeight]);
+  }, [heroThumb, preview.boardWidth, preview.boardHeight, showDescriptions]);
 
   // Held in a ref and read through a stable handler: a list's
   // onViewableItemsChanged identity must not change between renders.

--- a/packages/mobile/src/components/board-look/BoardLookPreviewCard.tsx
+++ b/packages/mobile/src/components/board-look/BoardLookPreviewCard.tsx
@@ -33,6 +33,15 @@ export type BoardLookCardLayout = {
    * rather than per climb, so every card in the rail shares one decode.
    */
   backgroundVariant: BackgroundVariant;
+  /**
+   * Whether the caption carries the option's one-line description.
+   *
+   * Off in the onboarding step: six cards each restating what the picture is
+   * already showing is copy the climber has to read past to get to the board,
+   * and the freed height goes to the hero instead. The settings rail keeps it —
+   * there the thumb is small and the sentence is doing real work.
+   */
+  showDescription: boolean;
 };
 
 type BoardLookPreviewCardProps = {
@@ -129,7 +138,6 @@ export const BoardLookPreviewCard = React.memo(function BoardLookPreviewCard({
   }, [onEnlarge, option.id]);
 
   const label = t(option.labelI18nKey);
-  const description = t(option.descriptionI18nKey);
   const descriptionLineHeight = resolvedTextStyles[style.descriptionVariant].lineHeight ?? 16;
 
   // Colour only — the width is constant in `thumbStyle`. Every card draws the
@@ -276,21 +284,30 @@ export const BoardLookPreviewCard = React.memo(function BoardLookPreviewCard({
           </Pressable>
         </View>
 
-        <Text variant={style.titleVariant} numberOfLines={1} style={styles.title}>
+        {/* `alignSelf: 'stretch'` is what makes the centring work: the container
+            is `alignItems: 'flex-start'`, which shrinks the Text to its content
+            and leaves `textAlign` with nothing to centre inside. */}
+        <Text
+          variant={style.titleVariant}
+          numberOfLines={1}
+          style={[styles.title, layout.showDescription ? null : styles.titleCentered]}
+        >
           {label}
         </Text>
-        <Text
-          variant={style.descriptionVariant}
-          color={systemColors.secondaryLabel}
-          numberOfLines={2}
-          // Reserved so every card in the rail keeps its bottom edge on one
-          // baseline. Scaled by the text size, because React Native scales
-          // lineHeight by the font multiplier — a reservation computed from the
-          // unscaled value silently goes inert above fontScale 1.
-          style={{ minHeight: descriptionMinHeight(descriptionLineHeight, fontScale) }}
-        >
-          {description}
-        </Text>
+        {layout.showDescription ? (
+          <Text
+            variant={style.descriptionVariant}
+            color={systemColors.secondaryLabel}
+            numberOfLines={2}
+            // Reserved so every card in the rail keeps its bottom edge on one
+            // baseline. Scaled by the text size, because React Native scales
+            // lineHeight by the font multiplier — a reservation computed from the
+            // unscaled value silently goes inert above fontScale 1.
+            style={{ minHeight: descriptionMinHeight(descriptionLineHeight, fontScale) }}
+          >
+            {t(option.descriptionI18nKey)}
+          </Text>
+        ) : null}
       </PressableSurface>
     </Animated.View>
   );
@@ -336,5 +353,9 @@ const styles = StyleSheet.create({
   },
   title: {
     fontWeight: '600',
+  },
+  titleCentered: {
+    alignSelf: 'stretch',
+    textAlign: 'center',
   },
 });

--- a/packages/mobile/src/components/board-look/BoardLookPreviewCard.tsx
+++ b/packages/mobile/src/components/board-look/BoardLookPreviewCard.tsx
@@ -138,7 +138,6 @@ export const BoardLookPreviewCard = React.memo(function BoardLookPreviewCard({
   }, [onEnlarge, option.id]);
 
   const label = t(option.labelI18nKey);
-  const descriptionLineHeight = resolvedTextStyles[style.descriptionVariant].lineHeight ?? 16;
 
   // Colour only — the width is constant in `thumbStyle`. Every card draws the
   // SAME climb and selection changes on every tap, so a border-WIDTH change would
@@ -303,7 +302,9 @@ export const BoardLookPreviewCard = React.memo(function BoardLookPreviewCard({
             // baseline. Scaled by the text size, because React Native scales
             // lineHeight by the font multiplier — a reservation computed from the
             // unscaled value silently goes inert above fontScale 1.
-            style={{ minHeight: descriptionMinHeight(descriptionLineHeight, fontScale) }}
+            style={{
+              minHeight: descriptionMinHeight(resolvedTextStyles[style.descriptionVariant].lineHeight ?? 16, fontScale),
+            }}
           >
             {t(option.descriptionI18nKey)}
           </Text>

--- a/packages/mobile/src/components/board-look/BoardLookStep.tsx
+++ b/packages/mobile/src/components/board-look/BoardLookStep.tsx
@@ -107,7 +107,8 @@ export function BoardLookStep({
 
   const heroThumb = useMemo(() => {
     if (railSlotHeight <= 0) return null;
-    const caption = captionBlockHeight(captionLineHeights('hero', textStyles), fontScale);
+    // No description under a hero card, so nothing to reserve for one.
+    const caption = captionBlockHeight(captionLineHeights('hero', textStyles), fontScale, 0);
     return resolveHeroThumb({
       aspect: preview.boardWidth / preview.boardHeight,
       windowWidth,
@@ -300,6 +301,10 @@ export function BoardLookStep({
             // footer button is pressed. In settings the same callback writes
             // through to the physical board's LEDs.
             selectOnSnap={heroThumb != null}
+            // Six cards each restating what the picture already shows is copy to
+            // read past on a step with no exit. The name under the board is the
+            // whole caption here.
+            showDescriptions={false}
           />
         ) : null}
       </View>
@@ -310,10 +315,18 @@ export function BoardLookStep({
 
       <GlassSurface glassEffectStyle="regular" style={[styles.footer, { paddingBottom: footerPadding }]}>
         {/* Fine print about what the button will and will not do, so it sits with
-            the button rather than floating as a third block of copy. */}
-        <Text variant="caption1" color={systemColors.secondaryLabel} style={styles.footnote}>
-          {t('mobile.more.boardLook.intro.accessibilityNote')}
-        </Text>
+            the button rather than floating as a third block of copy. The second
+            line is the exit this step does not otherwise have: it is mandatory
+            and has no "Not now", so saying the choice is reversible is what
+            makes committing to one cheap. */}
+        <View style={styles.footnotes}>
+          <Text variant="caption1" color={systemColors.secondaryLabel} style={styles.footnote}>
+            {t('mobile.more.boardLook.intro.accessibilityNote')}
+          </Text>
+          <Text variant="caption1" color={systemColors.secondaryLabel} style={styles.footnote}>
+            {t('mobile.more.boardLook.intro.changeLaterNote')}
+          </Text>
+        </View>
         <Button
           title={ctaLabel}
           onPress={() => void handleSave()}
@@ -351,6 +364,9 @@ const styles = StyleSheet.create({
     paddingTop: spacing[3],
     paddingHorizontal: spacing[5],
     gap: spacing[3],
+  },
+  footnotes: {
+    gap: spacing[1],
   },
   footnote: {
     textAlign: 'center',

--- a/packages/mobile/src/components/board-look/__tests__/BoardLookPreviewCard.test.tsx
+++ b/packages/mobile/src/components/board-look/__tests__/BoardLookPreviewCard.test.tsx
@@ -17,13 +17,17 @@ const hapticLightMock = vi.hoisted(() => vi.fn());
 const reduceMotion = vi.hoisted(() => ({ value: false }));
 const reduceTransparency = vi.hoisted(() => ({ value: false }));
 
-vi.mock('react-native', () => {
-  /** Flattens the nested style arrays RN accepts into one object. */
-  const flattenStyle = (style: unknown): Record<string, unknown> => {
-    if (Array.isArray(style)) return Object.assign({}, ...style.map(flattenStyle));
+/** Flattens the nested style arrays RN accepts into one object. */
+const flattenStyle = vi.hoisted(() => {
+  const flatten = (style: unknown): Record<string, unknown> => {
+    if (Array.isArray(style)) return Object.assign({}, ...style.map(flatten));
     if (style && typeof style === 'object') return style as Record<string, unknown>;
     return {};
   };
+  return flatten;
+});
+
+vi.mock('react-native', () => {
   const asDiv =
     (tag: string) =>
     ({ children, style, testID }: { children?: ReactNode; style?: unknown; testID?: string }) =>
@@ -119,10 +123,29 @@ vi.mock('../../../providers/theme-provider', () => ({
 }));
 vi.mock('../../../lib/haptics', () => ({ hapticLight: hapticLightMock }));
 vi.mock('../../Text', () => ({
-  // Forwards `variant` and `numberOfLines`, so a test can assert which line of
-  // the caption reserves the spare row height.
-  Text: ({ children, variant, numberOfLines }: { children?: ReactNode; variant?: string; numberOfLines?: number }) =>
-    createElement('span', { 'data-variant': variant, 'data-number-of-lines': numberOfLines?.toString() }, children),
+  // Forwards `variant`, `numberOfLines` and the flattened style, so a test can
+  // assert which line of the caption reserves the spare row height and how the
+  // title is aligned.
+  Text: ({
+    children,
+    variant,
+    numberOfLines,
+    style,
+  }: {
+    children?: ReactNode;
+    variant?: string;
+    numberOfLines?: number;
+    style?: unknown;
+  }) =>
+    createElement(
+      'span',
+      {
+        'data-variant': variant,
+        'data-number-of-lines': numberOfLines?.toString(),
+        'data-style': JSON.stringify(flattenStyle(style)),
+      },
+      children,
+    ),
 }));
 vi.mock('../../Icon', () => ({
   Icon: ({ name }: { name: string }) => createElement('span', { 'data-icon': name }),
@@ -158,6 +181,7 @@ const RAIL_LAYOUT = {
   thumbHeight: 168,
   renderWidth: 600,
   backgroundVariant: 'thumb' as const,
+  showDescription: true,
 };
 
 const HERO_LAYOUT = {
@@ -166,6 +190,7 @@ const HERO_LAYOUT = {
   thumbHeight: 361,
   renderWidth: 1024,
   backgroundVariant: 'full' as const,
+  showDescription: false,
 };
 
 function renderCard(overrides: Partial<ComponentProps<typeof BoardLookPreviewCard>> = {}) {
@@ -276,6 +301,32 @@ describe('BoardLookPreviewCard', () => {
 
     expect(title?.getAttribute('data-number-of-lines')).toBe('1');
     expect(description?.getAttribute('data-number-of-lines')).toBe('2');
+  });
+
+  it('drops the description and centres the name under a hero preview', () => {
+    // Six cards each restating what the picture already shows is copy to read
+    // past. With the sentence gone the name has to sit under the middle of the
+    // board rather than hanging off its left edge — and `textAlign` alone would
+    // do nothing inside a `flex-start` container, so the stretch is the test.
+    const { container } = renderCard({ layout: HERO_LAYOUT });
+    const captionNodes = Array.from(container.querySelectorAll('[data-variant]'));
+
+    expect(captionNodes.filter((node) => node.getAttribute('data-variant') === 'subheadline')).toHaveLength(0);
+
+    const title = captionNodes.find((node) => node.getAttribute('data-variant') === 'title3');
+    const titleStyle = JSON.parse(title?.getAttribute('data-style') ?? '{}') as Record<string, unknown>;
+    expect(titleStyle.textAlign).toBe('center');
+    expect(titleStyle.alignSelf).toBe('stretch');
+  });
+
+  it('keeps the description and the left-aligned name in the settings rail', () => {
+    const { container } = renderCard({ selected: false });
+    const captionNodes = Array.from(container.querySelectorAll('[data-variant]'));
+    const title = captionNodes.find((node) => node.getAttribute('data-variant') === 'subheadline');
+    const titleStyle = JSON.parse(title?.getAttribute('data-style') ?? '{}') as Record<string, unknown>;
+
+    expect(captionNodes.filter((node) => node.getAttribute('data-variant') === 'caption1')).toHaveLength(1);
+    expect(titleStyle.textAlign).toBeUndefined();
   });
 
   it('stops animating the press when Reduce Motion is on', () => {

--- a/packages/mobile/src/components/board-look/__tests__/BoardLookStep.test.tsx
+++ b/packages/mobile/src/components/board-look/__tests__/BoardLookStep.test.tsx
@@ -19,6 +19,7 @@ const carouselCtrl = vi.hoisted(() => ({
   onSelect: null as ((id: string) => void) | null,
   onCardSeen: null as ((id: string) => void) | null,
   optionIds: [] as string[],
+  showDescriptions: undefined as boolean | undefined,
 }));
 
 vi.mock('react-native', () => ({
@@ -69,10 +70,12 @@ vi.mock('../BoardLookCarousel', () => ({
     options: { id: string }[];
     onSelect: (id: string) => void;
     onCardSeen?: (id: string) => void;
+    showDescriptions?: boolean;
   }) => {
     carouselCtrl.onSelect = props.onSelect;
     carouselCtrl.onCardSeen = props.onCardSeen ?? null;
     carouselCtrl.optionIds = props.options.map((option) => option.id);
+    carouselCtrl.showDescriptions = props.showDescriptions;
     return createElement('div', { 'data-testid': 'carousel' });
   },
 }));
@@ -177,6 +180,21 @@ describe('BoardLookStep', () => {
 
       expect(markTipSeenMock).toHaveBeenCalledOnce();
     });
+  });
+
+  it('offers six looks and no per-card sentences', () => {
+    // The order the product asks for, and the reason there is room for six: the
+    // caption under each board is its name, nothing more.
+    renderStep();
+    expect(carouselCtrl.optionIds).toEqual([
+      'aura',
+      'aura-subtle',
+      'modern-classic',
+      'classic',
+      'max-contrast',
+      'custom',
+    ]);
+    expect(carouselCtrl.showDescriptions).toBe(false);
   });
 
   it('leads with the climber’s current look — the plain Aura card by default', () => {

--- a/packages/mobile/src/components/board-look/__tests__/board-look-card-metrics.test.ts
+++ b/packages/mobile/src/components/board-look/__tests__/board-look-card-metrics.test.ts
@@ -87,6 +87,16 @@ describe('Dynamic Type reservation', () => {
     expect(boardLookCardHeight(1.5)).toBeGreaterThan(boardLookCardHeight(1));
   });
 
+  it('reserves nothing for a description the card does not draw', () => {
+    // The onboarding hero has a title and no description, and it sizes itself
+    // against `railSlotHeight - captionBlockHeight(...)` — so two reserved
+    // lines nobody draws are two lines taken off the picture.
+    const withDescription = captionBlockHeight({ title: 25, description: 20 });
+    const titleOnly = captionBlockHeight({ title: 25, description: 20 }, 1, 0);
+    expect(withDescription - titleOnly).toBe(40);
+    expect(titleOnly).toBeLessThan(withDescription);
+  });
+
   it('takes the caption line heights from the caller, for the variant that differs', () => {
     // `title3` is 25 on HIG and 28 on Material. Reading it from the theme is the
     // only thing that keeps a hero caption from clipping on Android.

--- a/packages/mobile/src/components/board-look/board-look-card-metrics.ts
+++ b/packages/mobile/src/components/board-look/board-look-card-metrics.ts
@@ -120,10 +120,19 @@ export const RAIL_CAPTION_LINE_HEIGHTS: CaptionLineHeights = {
  * agree across HIG and Material, but the hero's title (`title3`) does not — 25
  * on HIG, 28 on Material — so reading them from the theme is the only thing that
  * keeps a hero caption from clipping on Android.
+ *
+ * `descriptionLines` is `0` on a card that draws no description (the onboarding
+ * hero). It has to be passed rather than assumed: the step sizes its hero
+ * against `railSlotHeight - captionBlockHeight(...)`, so reserving two lines
+ * nobody draws costs the picture ~32pt of the height it exists to spend.
  */
-export function captionBlockHeight(lineHeights: CaptionLineHeights, fontScale = 1): number {
+export function captionBlockHeight(
+  lineHeights: CaptionLineHeights,
+  fontScale = 1,
+  descriptionLines: number = DESCRIPTION_LINES,
+): number {
   const scale = Math.min(Math.max(fontScale, 1), MAX_FONT_SCALE);
-  return spacing[2] + TITLE_LINES * lineHeights.title * scale + DESCRIPTION_LINES * lineHeights.description * scale;
+  return spacing[2] + TITLE_LINES * lineHeights.title * scale + descriptionLines * lineHeights.description * scale;
 }
 
 /** Reserved height for a card's description, so every card's bottom edge lines up. */

--- a/packages/mobile/src/components/settings/__tests__/BoardLookAccessibilityScreen.test.tsx
+++ b/packages/mobile/src/components/settings/__tests__/BoardLookAccessibilityScreen.test.tsx
@@ -48,6 +48,7 @@ const TEST_DEFAULT_BOARDSESH_SETTINGS = {
   ledDots: true,
   roleGlyphs: false,
   thumbnailStyle: 'fill',
+  holdShape: 'silhouette',
 } as const;
 
 const boardRenderSettingsState = vi.hoisted(() => ({

--- a/packages/mobile/src/components/settings/board-look/custom-look-model.ts
+++ b/packages/mobile/src/components/settings/board-look/custom-look-model.ts
@@ -1,6 +1,7 @@
 import {
   BOARD_RENDER_SETTING_BOUNDS,
   GLOW_FALLOFF_OPTIONS,
+  HOLD_SHAPE_OPTIONS,
   MARK_STYLE_OPTIONS,
   THUMBNAIL_STYLE_OPTIONS,
   VEIL_OPTIONS,
@@ -133,6 +134,21 @@ export function buildCustomLookModel(input: CustomLookModelInput): MoreFormModel
   }
 
   const marksRows: MoreRow[] = [
+    // Above mark style, because it decides WHAT the mark is drawn on: the
+    // traced hold, or the placement circle. This is the knob the Modern Classic
+    // card writes, and the only way back to the traced silhouettes for a climber
+    // who picked it and then came in here to tune.
+    {
+      kind: 'segmented',
+      key: 'holdShape',
+      label: t('mobile.more.boardLook.marks.holdShape.title'),
+      options: HOLD_SHAPE_OPTIONS.map((option) => ({
+        key: option,
+        label: t(`mobile.more.boardLook.marks.holdShape.options.${option}`),
+      })),
+      selectedKey: boardsesh.holdShape,
+      onSelect: (key) => setField('holdShape', key as BoardseshRenderSettings['holdShape']),
+    },
     {
       kind: 'segmented',
       key: 'markStyle',

--- a/packages/mobile/src/hooks/__tests__/renderer-version.test.ts
+++ b/packages/mobile/src/hooks/__tests__/renderer-version.test.ts
@@ -12,8 +12,9 @@ describe('RENDERER_VERSION', () => {
     //
     // 8 belongs to the Woods work; the LED base plate took 9, and parking it
     // again took 10; Aura-by-default took 11; the Aura seam fix took 12; the
-    // crisp silhouette re-cut took 13, and extending it to MoonBoard took 14.
-    expect(RENDERER_VERSION).toBe(14);
+    // crisp silhouette re-cut took 13, extending it to MoonBoard took 14, and
+    // MoonBoard's cyan Aura HAND took 15.
+    expect(RENDERER_VERSION).toBe(15);
   });
 
   it('stamps the prefix every cached overlay is matched on', () => {

--- a/packages/mobile/src/hooks/__tests__/renderer-version.test.ts
+++ b/packages/mobile/src/hooks/__tests__/renderer-version.test.ts
@@ -13,7 +13,7 @@ describe('RENDERER_VERSION', () => {
     // 8 belongs to the Woods work; the LED base plate took 9, and parking it
     // again took 10; Aura-by-default took 11; the Aura seam fix took 12; the
     // crisp silhouette re-cut took 13, extending it to MoonBoard took 14, and
-    // MoonBoard's cyan Aura HAND took 15.
+    // the one Aura HAND cyan on every board took 15.
     expect(RENDERER_VERSION).toBe(15);
   });
 

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-boardsesh.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-boardsesh.test.tsx
@@ -424,6 +424,29 @@ describe('per-hold geometry', () => {
     expect('silhouette_lightness' in unlitHold).toBe(false);
   });
 
+  it('withholds every outline for Modern Classic, and keeps the veil and LED covers', () => {
+    // This IS the Modern Classic drawing: with no outline the renderer falls
+    // back to the placement circle, so the veil punches circles and the glow
+    // follows them. `led_inner` and `silhouette_lightness` go with the
+    // silhouette they were traced and measured against; the veil and the LED
+    // covers never read an outline and must survive.
+    const configBase = buildConfig(GRASSHOPPER, {
+      frames: GRASSHOPPER_FRAMES,
+      boardsesh: boardseshInputs({ holdShape: 'circle' }),
+      renderSignature: 'modern-classic-geometry',
+    });
+
+    const litHold = holdById(configBase, 1);
+    expect('outline' in litHold).toBe(false);
+    expect('led_inner' in litHold).toBe(false);
+    expect('silhouette_lightness' in litHold).toBe(false);
+    // The LED cover rides the placement, not the silhouette — Grasshopper's art
+    // paints those pips bright whether or not anything is traced over them.
+    expect(Array.isArray(litHold.led)).toBe(true);
+    expect(asRecord(configBase.veil).opacity).toBeCloseTo(0.6);
+    expect(configBase.led_cover).toBeDefined();
+  });
+
   it('aura ships its tuning on full renders but never on thumbnails, and no spill outlines', () => {
     const fullConfig = buildConfig(GRASSHOPPER, {
       frames: GRASSHOPPER_FRAMES,
@@ -735,6 +758,7 @@ describe('the cache key', () => {
     ledDots: false,
     roleGlyphs: true,
     thumbnailStyle: 'glow',
+    holdShape: 'circle',
   };
 
   /**

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-boardsesh.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-boardsesh.test.tsx
@@ -729,7 +729,7 @@ describe('the cache key', () => {
 
   it('carries the current renderer version and is otherwise the classic key', () => {
     const classicKey = keyFor('');
-    expect(classicKey).toMatch(/^v14_/);
+    expect(classicKey).toMatch(/^v15_/);
     expect(classicKey).toBe(
       buildCacheKey(CLIMB.boardName, CLIMB.layoutId, CLIMB.sizeId, CLIMB.setIds, GRASSHOPPER_FRAMES),
     );

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-boardsesh.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-boardsesh.test.tsx
@@ -370,7 +370,7 @@ describe('the Boardsesh config', () => {
     expect(stateInfoByColorRole(moonboardConfig, 46)?.role).toBeUndefined();
   });
 
-  it('lifts the dark-blue HAND to #6980FF, and still lets the climber overrule it', () => {
+  it('repaints the dark-blue HAND to the Aura cyan, and still lets the climber overrule it', () => {
     getBoardRenderDataMock.mockReturnValue(TENSION_HOLDS);
 
     const auraConfig = buildConfig(TB2_MIRROR, {
@@ -378,7 +378,7 @@ describe('the Boardsesh config', () => {
       boardsesh: boardseshInputs(),
       renderSignature: 'boardsesh-hand',
     });
-    expect(stateInfoByColorRole(auraConfig, 2)?.color).toBe('#6980FF');
+    expect(stateInfoByColorRole(auraConfig, 2)?.color).toBe('#4DF5FD');
 
     const overriddenConfig = buildConfig(TB2_MIRROR, {
       frames: 'p304r2',

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render.test.ts
@@ -127,7 +127,7 @@ describe('buildCacheKey', () => {
     expect(small).not.toBe(full);
   });
 
-  it('uses RENDERER_VERSION v14 to invalidate overlays drawn from the pre-crisp outlines', () => {
+  it('uses RENDERER_VERSION v15 to invalidate overlays drawn with the old MoonBoard HAND blue', () => {
     // v5 kept a newly built native client from trusting a v4 file that the old
     // direct-to-destination write may have truncated. v6 (issue #4495) dropped
     // every overlay the stale web WASM drew at the wrong stroke width. v7
@@ -136,9 +136,11 @@ describe('buildCacheKey', () => {
     // before Aura became the default glow, v12 the ones with the hard Aura
     // seam baked in. v13 dropped overlays drawn from the pre-crisp
     // silhouettes, and v14 the MoonBoard ones cut before the crisp profile
-    // reached that board — the key describes the settings a render was asked
-    // for, not the pixels that came back, and shard data is not a setting.
-    expect(buildCacheKey('kilter', 1, 10, '24', 'p1r42')).toMatch(/^v14_/);
+    // reached that board. v15 drops the MoonBoard overlays that marked a blue
+    // hold with the Aura blue — the key describes the settings a render was
+    // asked for, not the pixels that came back, and a palette value is no more
+    // a setting than shard data is.
+    expect(buildCacheKey('kilter', 1, 10, '24', 'p1r42')).toMatch(/^v15_/);
   });
 
   it('uses a distinct style token so filled (list) and stroke (play view) never collide', () => {
@@ -457,9 +459,9 @@ describe('renderedOverlays warm-up from disk cache', () => {
 
   it('exposes the populated map so a fresh hook init can hit it synchronously', () => {
     expect(_renderedOverlaysForTests).toBeInstanceOf(Map);
-    _cacheRenderedOverlayForTests('v14_kilter_1_10_24_deadbeef', 'file:///prior/session.png');
-    expect(_renderedOverlaysForTests.get('v14_kilter_1_10_24_deadbeef')?.uri).toBe('file:///prior/session.png');
-    _renderedOverlaysForTests.delete('v14_kilter_1_10_24_deadbeef');
+    _cacheRenderedOverlayForTests('v15_kilter_1_10_24_deadbeef', 'file:///prior/session.png');
+    expect(_renderedOverlaysForTests.get('v15_kilter_1_10_24_deadbeef')?.uri).toBe('file:///prior/session.png');
+    _renderedOverlaysForTests.delete('v15_kilter_1_10_24_deadbeef');
   });
 
   it('mints a new generation when a render replaces the same URI', () => {
@@ -496,7 +498,7 @@ describe('renderedOverlays warm-up from disk cache', () => {
     // Mix older leftovers (v4 files written before atomic publication, v5 files
     // the stale WASM drew at the wrong stroke width, v6 files from before the
     // Boardsesh drawing, v7 files from before the LED base plate) with current
-    // v14 entries. The warm-up must surface only v14 keys; every older file is
+    // v15 entries. The warm-up must surface only v15 keys; every older file is
     // invalid.
     const v1Entry = makeMockEntry('v1_kilter_1_10_24_aaaaaaaa.png');
     const v2Entry = makeMockEntry('v2_kilter_1_10_24_bbbbbbbb.png');
@@ -513,8 +515,8 @@ describe('renderedOverlays warm-up from disk cache', () => {
     // v9 is what TestFlight build 6 wrote, with the LED plate lit. Those PNGs
     // are on real devices and are the whole reason v11 existed.
     const v9Entry = makeMockEntry('v9_kilter_1_10_24_litplate.png');
-    const currentEntryA = makeMockEntry('v14_kilter_1_10_24_cccccccc.png');
-    const currentEntryB = makeMockEntry('v14_tension_2_8_15_dddddddd.png');
+    const currentEntryA = makeMockEntry('v15_kilter_1_10_24_cccccccc.png');
+    const currentEntryB = makeMockEntry('v15_tension_2_8_15_dddddddd.png');
     directoryListSpy.mockReturnValue([
       v1Entry,
       v2Entry,
@@ -531,8 +533,8 @@ describe('renderedOverlays warm-up from disk cache', () => {
 
     _runWarmupForTests();
 
-    expect(_renderedOverlaysForTests.has('v14_kilter_1_10_24_cccccccc')).toBe(true);
-    expect(_renderedOverlaysForTests.has('v14_tension_2_8_15_dddddddd')).toBe(true);
+    expect(_renderedOverlaysForTests.has('v15_kilter_1_10_24_cccccccc')).toBe(true);
+    expect(_renderedOverlaysForTests.has('v15_tension_2_8_15_dddddddd')).toBe(true);
     expect(_renderedOverlaysForTests.has('v1_kilter_1_10_24_aaaaaaaa')).toBe(false);
     expect(_renderedOverlaysForTests.has('v2_kilter_1_10_24_bbbbbbbb')).toBe(false);
     expect(_renderedOverlaysForTests.has('v3_kilter_1_10_24_eeeeeeee')).toBe(false);
@@ -556,7 +558,7 @@ describe('renderedOverlays warm-up from disk cache', () => {
     const v7Entry = makeMockEntry('v7_kilter_1_10_24_preplate.png');
     const v8Entry = makeMockEntry('v8_kilter_1_10_24_neverpublished.png');
     const v9Entry = makeMockEntry('v9_kilter_1_10_24_litplate.png');
-    const currentEntry = makeMockEntry('v14_kilter_1_10_24_cccccccc.png');
+    const currentEntry = makeMockEntry('v15_kilter_1_10_24_cccccccc.png');
     directoryListSpy.mockReturnValue([
       v1Entry,
       v2Entry,
@@ -591,11 +593,11 @@ describe('renderedOverlays warm-up from disk cache', () => {
     v1Entry.delete.mockImplementation(() => {
       throw new Error('EACCES');
     });
-    const currentEntry = makeMockEntry('v14_kilter_1_10_24_bbbbbbbb.png');
+    const currentEntry = makeMockEntry('v15_kilter_1_10_24_bbbbbbbb.png');
     directoryListSpy.mockReturnValue([v1Entry, currentEntry]);
 
     expect(() => _runWarmupForTests()).not.toThrow();
-    expect(_renderedOverlaysForTests.has('v14_kilter_1_10_24_bbbbbbbb')).toBe(true);
+    expect(_renderedOverlaysForTests.has('v15_kilter_1_10_24_bbbbbbbb')).toBe(true);
   });
 });
 

--- a/packages/mobile/src/hooks/renderer-version.ts
+++ b/packages/mobile/src/hooks/renderer-version.ts
@@ -105,16 +105,18 @@
  * meets its edge too. Same reasoning as v13 — shard data is not a setting, and
  * a cached overlay would be reused with the old outlines baked in.
  *
- * v15 gives the blue-walled boards' Aura HAND Kilter's cyan instead of the Aura
- * blue the rest use. MoonBoard 2024's holds are #2f8bcb and Grasshopper's `flow`
- * set is #058fca, so on both the blue marker was drawn on a blue hold and read
- * as part of it. One integer covers both because no build has shipped v15 yet;
- * a second bump would evict the same PNGs twice. A palette value is not a
- * setting — the cache key hashes board, frames and settings, and nothing derived
- * from the hold-state map — so every cached MoonBoard overlay would be reused
- * with the old blue baked in. Exactly the case v4 hit when hold colours moved to
- * their calibrated displayColor. Every other board is byte-identical and pays a
- * one-time re-render, the same trade v4, v6, v7, v9 and v13 made.
+ * v15 repaints the Aura HAND on EVERY board to one cyan, #4DF5FD. It started as
+ * a fix for the blue-walled boards — MoonBoard 2024's holds are #2f8bcb and
+ * Grasshopper's `flow` set is #058fca, so the old Aura blue #6980FF marked a blue
+ * hold with a blue glow — but a per-board split ("is this board's art blue?") is
+ * invisible to a climber and never partitioned cleanly, so the whole role moved
+ * and #6980FF is retired. A palette value is not a setting — the cache key hashes
+ * board, frames and settings, and nothing derived from the hold-state map — so
+ * every cached Aura overlay on every board would be reused with the old blue
+ * baked in. Exactly the case v4 hit when hold colours moved to their calibrated
+ * displayColor. Classic overlays are byte-identical and pay a one-time
+ * re-render, the same trade v4, v6, v7, v9 and v13 made. One integer covers the
+ * whole palette move because no build has shipped v15.
  *
  * Lives in its own module so both the hook (use-native-climb-render.ts) and the
  * web overlay warm-up (overlay-cache-warmup.web.ts) can read it without a

--- a/packages/mobile/src/hooks/renderer-version.ts
+++ b/packages/mobile/src/hooks/renderer-version.ts
@@ -105,12 +105,21 @@
  * meets its edge too. Same reasoning as v13 — shard data is not a setting, and
  * a cached overlay would be reused with the old outlines baked in.
  *
+ * v15 gives MoonBoard's Aura HAND Kilter's cyan instead of the Aura blue every
+ * other board uses. MoonBoard 2024's holds are blue plastic, so the blue marker
+ * was drawn on a blue hold and read as part of it. A palette value is not a
+ * setting — the cache key hashes board, frames and settings, and nothing derived
+ * from the hold-state map — so every cached MoonBoard overlay would be reused
+ * with the old blue baked in. Exactly the case v4 hit when hold colours moved to
+ * their calibrated displayColor. Every other board is byte-identical and pays a
+ * one-time re-render, the same trade v4, v6, v7, v9 and v13 made.
+ *
  * Lives in its own module so both the hook (use-native-climb-render.ts) and the
  * web overlay warm-up (overlay-cache-warmup.web.ts) can read it without a
  * circular import — the hook imports the warm-up, so the warm-up must not import
  * back from the hook.
  */
-export const RENDERER_VERSION = 14;
+export const RENDERER_VERSION = 15;
 
 /** Cache-key prefix stamped on every overlay produced by the current renderer. */
 export const currentOverlayVersionPrefix = (): string => `v${RENDERER_VERSION}_`;

--- a/packages/mobile/src/hooks/renderer-version.ts
+++ b/packages/mobile/src/hooks/renderer-version.ts
@@ -105,9 +105,11 @@
  * meets its edge too. Same reasoning as v13 — shard data is not a setting, and
  * a cached overlay would be reused with the old outlines baked in.
  *
- * v15 gives MoonBoard's Aura HAND Kilter's cyan instead of the Aura blue every
- * other board uses. MoonBoard 2024's holds are blue plastic, so the blue marker
- * was drawn on a blue hold and read as part of it. A palette value is not a
+ * v15 gives the blue-walled boards' Aura HAND Kilter's cyan instead of the Aura
+ * blue the rest use. MoonBoard 2024's holds are #2f8bcb and Grasshopper's `flow`
+ * set is #058fca, so on both the blue marker was drawn on a blue hold and read
+ * as part of it. One integer covers both because no build has shipped v15 yet;
+ * a second bump would evict the same PNGs twice. A palette value is not a
  * setting — the cache key hashes board, frames and settings, and nothing derived
  * from the hold-state map — so every cached MoonBoard overlay would be reused
  * with the old blue baked in. Exactly the case v4 hit when hold colours moved to

--- a/packages/mobile/src/hooks/renderer-version.ts
+++ b/packages/mobile/src/hooks/renderer-version.ts
@@ -118,6 +118,11 @@
  * re-render, the same trade v4, v6, v7, v9 and v13 made. One integer covers the
  * whole palette move because no build has shipped v15.
  *
+ * v15 also carries MoonBoard's FOOT moving from cyan to amber, which changes
+ * CLASSIC pixels too (it is a `displayColor`, not just an Aura one). If that
+ * ever gets split into a later PR after a v15 build has shipped, it needs its
+ * own bump — the two rode one integer only because neither had shipped.
+ *
  * Lives in its own module so both the hook (use-native-climb-render.ts) and the
  * web overlay warm-up (overlay-cache-warmup.web.ts) can read it without a
  * circular import — the hook imports the warm-up, so the warm-up must not import

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -1116,10 +1116,17 @@ function getBoardConfig(
     boardConfigCache.set(configKey, cached);
   }
 
-  // A classic config, and a Boardsesh one on a board the tracer skipped, is
-  // exactly what the cache holds. Otherwise the lit holds' outlines go on now —
-  // the one per-climb part of an otherwise per-board config.
-  if (!boardsesh || !cached.boardseshGeometry) {
+  // A classic config, a Boardsesh one on a board the tracer skipped, and Modern
+  // Classic — which asks for the circle on purpose — are exactly what the cache
+  // holds. Otherwise the lit holds' outlines go on now, the one per-climb part
+  // of an otherwise per-board config.
+  //
+  // Withholding the outlines IS the Modern Classic drawing: the renderer falls
+  // back to the placement circle for any hold without one, so the veil punches
+  // circles and the glow follows them. `led_cover` and the veil measurement do
+  // not read outlines and are unaffected; `led_inner` and `silhouette_lightness`
+  // drop out with the silhouette they were traced and measured against.
+  if (!boardsesh || !cached.boardseshGeometry || boardsesh.settings.holdShape === 'circle') {
     return { configBase: cached.configBase, setIdsArray: cached.setIdsArray };
   }
   return {

--- a/packages/mobile/src/lib/__tests__/board-render-presets.test.ts
+++ b/packages/mobile/src/lib/__tests__/board-render-presets.test.ts
@@ -47,6 +47,7 @@ describe('BOARD_RENDER_PRESETS', () => {
       'aura',
       'aura-bold',
       'aura-subtle',
+      'modern-classic',
       'max-contrast',
     ]);
   });
@@ -75,6 +76,17 @@ describe('BOARD_RENDER_PRESETS', () => {
       glowFalloff: 'soft',
       glowReach: 0.8,
       veil: 'soft',
+    });
+  });
+
+  it('modern-classic preset: Aura, drawn on the placement circle', () => {
+    // Every other knob is Aura's, on purpose — the veil, the glow and its
+    // falloff are what makes it "modern"; the circle is what makes it "classic".
+    const preset = BOARD_RENDER_PRESETS.find((entry) => entry.id === 'modern-classic')!;
+    expect(preset.values.mode).toBe('aura');
+    expect(preset.values.boardsesh).toEqual({
+      ...DEFAULT_BOARDSESH_RENDER_SETTINGS,
+      holdShape: 'circle',
     });
   });
 

--- a/packages/mobile/src/lib/__tests__/board-render-settings.test.ts
+++ b/packages/mobile/src/lib/__tests__/board-render-settings.test.ts
@@ -78,6 +78,7 @@ describe('defaults', () => {
       ledDots: true,
       roleGlyphs: false,
       thumbnailStyle: 'fill',
+      holdShape: 'silhouette',
     });
   });
 
@@ -328,6 +329,7 @@ describe('buildBoardRenderSignature', () => {
     ledDots: false,
     roleGlyphs: true,
     thumbnailStyle: 'glow',
+    holdShape: 'circle',
   };
 
   /** The substring `buildBoardRenderSignature` mints for each field above. */
@@ -346,6 +348,7 @@ describe('buildBoardRenderSignature', () => {
     ledDots: 'noleds',
     roleGlyphs: 'glyphs',
     thumbnailStyle: 'thumb-glow',
+    holdShape: 'shape-circle',
   };
 
   /**

--- a/packages/mobile/src/lib/__tests__/overlay-cache.web.test.ts
+++ b/packages/mobile/src/lib/__tests__/overlay-cache.web.test.ts
@@ -154,7 +154,7 @@ describe('overlay-cache-store hydration + snapshot (warmup contract)', () => {
     expect(snapshotOverlayEntries()).toHaveLength(limit);
   });
 
-  it('flushes shared web entries when the native and web renderer contract moves to v14', async () => {
+  it('flushes shared web entries when the native and web renderer contract moves to v15', async () => {
     const { store } = installCaches();
     await writeOverlayToCache('v2_s_wfull_kilter_1_2_25_old', new Blob() as Blob);
     await writeOverlayToCache('v4_s_wfull_kilter_1_2_25_pre_atomic', new Blob() as Blob);
@@ -168,13 +168,13 @@ describe('overlay-cache-store hydration + snapshot (warmup contract)', () => {
     // line, so no shipped build ever published it — its PNGs are as invalid
     // here as any other generation's.
     await writeOverlayToCache('v8_s_wfull_kilter_1_2_25_never_published', new Blob() as Blob);
-    // Drawn under an older generation — the pre-crisp MoonBoard outlines v14 exists to evict.
+    // Drawn under an older generation — the MoonBoard HAND blue v15 exists to evict.
     await writeOverlayToCache('v9_s_wfull_kilter_1_2_25_lit_plate', new Blob() as Blob);
-    await writeOverlayToCache('v14_s_wfull_kilter_1_2_25_keep', new Blob() as Blob);
+    await writeOverlayToCache('v15_s_wfull_kilter_1_2_25_keep', new Blob() as Blob);
     await writeOverlayToCache('v1_f_w400_kilter_1_2_25_ancient', new Blob() as Blob);
     _overlayCacheStoreForTests.renderedObjectUrls.clear();
 
-    expect(currentOverlayVersionPrefix()).toBe('v14_');
+    expect(currentOverlayVersionPrefix()).toBe('v15_');
     await hydrateOverlayCache(currentOverlayVersionPrefix());
 
     // Stale-version PNGs are deleted from the Cache API, not hydrated — so they
@@ -188,10 +188,10 @@ describe('overlay-cache-store hydration + snapshot (warmup contract)', () => {
     expect(store.has(_overlayCacheStoreForTests.overlayKeyUrl('v7_s_wfull_kilter_1_2_25_pre_plate'))).toBe(false);
     expect(store.has(_overlayCacheStoreForTests.overlayKeyUrl('v8_s_wfull_kilter_1_2_25_never_published'))).toBe(false);
     expect(store.has(_overlayCacheStoreForTests.overlayKeyUrl('v9_s_wfull_kilter_1_2_25_lit_plate'))).toBe(false);
-    expect(store.has(_overlayCacheStoreForTests.overlayKeyUrl('v14_s_wfull_kilter_1_2_25_keep'))).toBe(true);
+    expect(store.has(_overlayCacheStoreForTests.overlayKeyUrl('v15_s_wfull_kilter_1_2_25_keep'))).toBe(true);
     const entries = snapshotOverlayEntries();
     expect(entries).toHaveLength(1);
-    expect(entries[0].name).toBe('v14_s_wfull_kilter_1_2_25_keep.png');
+    expect(entries[0].name).toBe('v15_s_wfull_kilter_1_2_25_keep.png');
   });
 
   it('releaseAllObjectUrls revokes every retained URL', async () => {

--- a/packages/mobile/src/lib/board-render-presets.ts
+++ b/packages/mobile/src/lib/board-render-presets.ts
@@ -15,7 +15,7 @@ import {
  * uses — so applying one always lands on an exact, reproducible bundle rather
  * than layering on top of whatever the climber had before.
  */
-export type BoardRenderPresetId = 'aura' | 'aura-bold' | 'aura-subtle' | 'max-contrast';
+export type BoardRenderPresetId = 'aura' | 'aura-bold' | 'aura-subtle' | 'modern-classic' | 'max-contrast';
 
 export type BoardRenderPreset = {
   id: BoardRenderPresetId;
@@ -52,6 +52,10 @@ export const BOARD_RENDER_PRESET_VALUES = {
     glowReach: 0.8,
     veil: 'soft',
   },
+  /** Aura's veil and glow, drawn on the placement circle instead of the traced hold. */
+  'modern-classic': {
+    holdShape: 'circle',
+  },
   /** Strongest separation: full wash, solid marks, plus the non-colour glyphs. */
   'max-contrast': {
     glowFalloff: 'plateau',
@@ -78,6 +82,11 @@ export const BOARD_RENDER_PRESETS: readonly BoardRenderPreset[] = [
     id: 'aura-subtle',
     labelI18nKey: 'mobile.more.boardLook.presets.auraSubtle',
     values: { mode: 'aura', boardsesh: boardseshPreset(BOARD_RENDER_PRESET_VALUES['aura-subtle']) },
+  },
+  {
+    id: 'modern-classic',
+    labelI18nKey: 'mobile.more.boardLook.presets.modernClassic',
+    values: { mode: 'aura', boardsesh: boardseshPreset(BOARD_RENDER_PRESET_VALUES['modern-classic']) },
   },
   {
     id: 'max-contrast',

--- a/packages/mobile/src/lib/board-render-settings.ts
+++ b/packages/mobile/src/lib/board-render-settings.ts
@@ -51,6 +51,17 @@ export type MarkStyleSetting = 'glow' | 'glow-fill' | 'fill';
  * `buildBoardseshFields` in `use-native-climb-render.ts`).
  */
 export type ThumbnailStyleSetting = 'fill' | 'glow';
+/**
+ * What the Aura drawing lights on a hold: the traced silhouette from
+ * `@boardsesh/board-art-geometry`, or the placement circle.
+ *
+ * `'circle'` is not a fallback — it is the Modern Classic look. The renderer
+ * already draws the placement circle for any hold the tracer skipped
+ * (`aura/geometry.rs`), so withholding the outlines is all it takes: the veil
+ * punches circles out of the wash and the glow follows them, with no Rust
+ * change and no new binary.
+ */
+export type HoldShapeSetting = 'silhouette' | 'circle';
 export type BoardseshRenderSettings = {
   glowFalloff: GlowFalloffSetting;
   /** Overall glow reach multiplier. */
@@ -72,6 +83,7 @@ export type BoardseshRenderSettings = {
   /** Opt-in accessibility glyphs (FOOT ring, STARTING bar, HAND bar, FINISH X). */
   roleGlyphs: boolean;
   thumbnailStyle: ThumbnailStyleSetting;
+  holdShape: HoldShapeSetting;
 };
 
 export type BoardRenderSettings = {
@@ -103,12 +115,14 @@ const GLOW_FALLOFF_SETTINGS = ['default', 'soft', 'plateau'] as const;
 const VEIL_SETTINGS = ['auto', 'off', 'soft', 'strong', 'custom'] as const;
 const MARK_STYLE_SETTINGS = ['glow', 'glow-fill', 'fill'] as const;
 const THUMBNAIL_STYLE_SETTINGS = ['fill', 'glow'] as const;
+const HOLD_SHAPE_SETTINGS = ['silhouette', 'circle'] as const;
 
 export const BOARD_RENDER_MODE_OPTIONS = BOARD_RENDER_MODE_SETTINGS;
 export const GLOW_FALLOFF_OPTIONS = GLOW_FALLOFF_SETTINGS;
 export const VEIL_OPTIONS = VEIL_SETTINGS;
 export const MARK_STYLE_OPTIONS = MARK_STYLE_SETTINGS;
 export const THUMBNAIL_STYLE_OPTIONS = THUMBNAIL_STYLE_SETTINGS;
+export const HOLD_SHAPE_OPTIONS = HOLD_SHAPE_SETTINGS;
 
 /** Slider ranges, exported so the settings screen and the clamps cannot drift. */
 export const BOARD_RENDER_SETTING_BOUNDS = {
@@ -189,6 +203,7 @@ export const DEFAULT_BOARDSESH_RENDER_SETTINGS: BoardseshRenderSettings = {
   ledDots: true,
   roleGlyphs: false,
   thumbnailStyle: 'fill',
+  holdShape: 'silhouette',
 };
 
 export const DEFAULT_BOARD_RENDER_SETTINGS: BoardRenderSettings = {
@@ -254,6 +269,7 @@ export function sanitizeBoardseshRenderSettings(rawSettings: unknown): Boardsesh
     ledDots: pickFlag(stored.ledDots, defaults.ledDots),
     roleGlyphs: pickFlag(stored.roleGlyphs, defaults.roleGlyphs),
     thumbnailStyle: pickOption(stored.thumbnailStyle, THUMBNAIL_STYLE_SETTINGS, defaults.thumbnailStyle),
+    holdShape: pickOption(stored.holdShape, HOLD_SHAPE_SETTINGS, defaults.holdShape),
   };
 }
 
@@ -406,6 +422,10 @@ export function buildBoardRenderSignature(
   if (!boardsesh.ledDots) tokens.push('noleds');
   if (boardsesh.roleGlyphs) tokens.push('glyphs');
   if (boardsesh.thumbnailStyle !== defaults.thumbnailStyle) tokens.push(`thumb-${boardsesh.thumbnailStyle}`);
+  // Load-bearing: Modern Classic is Aura's every other knob, so without this
+  // token the two looks share a cache entry and whichever rendered first is
+  // what both draw.
+  if (boardsesh.holdShape !== defaults.holdShape) tokens.push(`shape-${boardsesh.holdShape}`);
 
   return tokens.join('.');
 }

--- a/packages/mobile/src/lib/board-render/__tests__/board-look-options.test.ts
+++ b/packages/mobile/src/lib/board-render/__tests__/board-look-options.test.ts
@@ -45,14 +45,15 @@ afterEach(() => {
 });
 
 describe('the option lists', () => {
-  it('offers the onboarding step the product order: the new default, then Classic', () => {
-    // Classic is second, not fourth: the question is really "the new look, or
-    // the one you had?", and the familiar answer should not read as an
-    // afterthought behind three unfamiliar ones.
+  it('offers the onboarding step the product order, with the two circle looks adjacent', () => {
+    // Modern Classic sits immediately before Classic: a climber who came for
+    // the circles they already know meets the veiled version of them first, and
+    // the pair can be compared with one swipe.
     expect(BOARD_LOOK_ONBOARDING_OPTIONS.map((option) => option.id)).toEqual([
       'aura',
-      'classic',
       'aura-subtle',
+      'modern-classic',
+      'classic',
       'max-contrast',
       'custom',
     ]);
@@ -61,10 +62,11 @@ describe('the option lists', () => {
   it('offers the settings screen Aura Bold as well, in the same order as the step', () => {
     expect(BOARD_LOOK_SETTINGS_OPTIONS.map((option) => option.id)).toEqual([
       'aura',
-      'classic',
       'aura-subtle',
-      'max-contrast',
       'aura-bold',
+      'modern-classic',
+      'classic',
+      'max-contrast',
       'custom',
     ]);
   });
@@ -135,6 +137,19 @@ describe('matchingBoardLookOptionId', () => {
 
   it('reads an explicit classic choice as Classic, not as a preset', () => {
     expect(matchingBoardLookOptionId({ ...DEFAULT_BOARD_RENDER_SETTINGS, mode: 'classic' })).toBe('classic');
+  });
+
+  it('tells Modern Classic apart from Aura on the hold shape alone', () => {
+    // The two bundles differ in exactly one field. If `holdShape` ever stopped
+    // being part of the comparison, picking Modern Classic would highlight the
+    // Aura card and the climber's own choice would read back as somebody else's.
+    expect(
+      matchingBoardLookOptionId({
+        mode: 'aura',
+        boardsesh: { ...DEFAULT_BOARDSESH_RENDER_SETTINGS, holdShape: 'circle' },
+      }),
+    ).toBe('modern-classic');
+    expect(matchingBoardLookOptionId({ ...DEFAULT_BOARD_RENDER_SETTINGS, mode: 'aura' })).toBe('aura');
   });
 
   it('reads a hand-tuned bundle as Custom', () => {

--- a/packages/mobile/src/lib/board-render/__tests__/use-board-look-settings.test.tsx
+++ b/packages/mobile/src/lib/board-render/__tests__/use-board-look-settings.test.tsx
@@ -17,6 +17,8 @@ const mocks = vi.hoisted(() => ({
   setBoardRenderSettingsPreference: vi.fn(() => Promise.resolve()),
   applyBoardLookOption: vi.fn(() => Promise.resolve()),
   trackBoardLookApplied: vi.fn(),
+  trackBoardRenderSettingChanged: vi.fn(),
+  preview: null as { boardName: string; layoutId: number; sizeId: number } | null,
   settings: {
     mode: 'aura' as const,
     boardsesh: {
@@ -32,6 +34,7 @@ const mocks = vi.hoisted(() => ({
       ledDots: true,
       roleGlyphs: false,
       thumbnailStyle: 'fill' as const,
+      holdShape: 'silhouette' as const,
     },
   },
 }));
@@ -63,7 +66,7 @@ vi.mock('../../../hooks/use-native-climb-render', () => ({
 }));
 
 vi.mock('../../../hooks/use-board-preview-climb', () => ({
-  useBoardPreviewClimb: () => ({ status: 'ready', preview: null }),
+  useBoardPreviewClimb: () => ({ status: 'ready', preview: mocks.preview }),
 }));
 
 vi.mock('../custom-board-look', () => ({
@@ -72,13 +75,17 @@ vi.mock('../custom-board-look', () => ({
   loadCustomBoardLook: mocks.loadCustomBoardLook,
 }));
 
-vi.mock('../board-look-analytics', () => ({ trackBoardLookApplied: mocks.trackBoardLookApplied }));
+vi.mock('../board-look-analytics', () => ({
+  trackBoardLookApplied: mocks.trackBoardLookApplied,
+  trackBoardRenderSettingChanged: mocks.trackBoardRenderSettingChanged,
+}));
 
 const { useBoardLookSettings } = await import('../use-board-look-settings');
 
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.settings.boardsesh.roleGlyphs = false;
+  mocks.preview = null;
 });
 
 describe('useBoardLookSettings — the one mirroring writer', () => {
@@ -106,6 +113,57 @@ describe('useBoardLookSettings — the one mirroring writer', () => {
     expect(mocks.rememberCustomBoardLook).toHaveBeenCalledWith(
       expect.objectContaining({ glowReach: 1.4, veil: 'auto', markStyle: 'glow' }),
     );
+  });
+});
+
+describe('useBoardLookSettings — what the funnel sees', () => {
+  const PREVIEW = { boardName: 'kilter', layoutId: 8, sizeId: 25 };
+
+  it('reports every hand adjustment, against the settings it produces', async () => {
+    mocks.preview = PREVIEW;
+    const { result } = renderHook(() => useBoardLookSettings());
+
+    await act(async () => {
+      result.current.setBoardseshField('holdShape', 'circle');
+    });
+
+    expect(mocks.trackBoardRenderSettingChanged).toHaveBeenCalledWith(
+      'holdShape',
+      'circle',
+      expect.objectContaining({ mode: 'aura', boardsesh: expect.objectContaining({ holdShape: 'circle' }) }),
+      PREVIEW,
+    );
+  });
+
+  it('reports a mode switch under the mode it lands on, not the one it left', async () => {
+    mocks.preview = PREVIEW;
+    const { result } = renderHook(() => useBoardLookSettings());
+
+    await act(async () => {
+      result.current.setMode('classic');
+    });
+
+    expect(mocks.setMode).toHaveBeenCalledWith('classic');
+    expect(mocks.trackBoardRenderSettingChanged).toHaveBeenCalledWith(
+      'mode',
+      'classic',
+      expect.objectContaining({ mode: 'classic' }),
+      PREVIEW,
+    );
+  });
+
+  it('stays silent with no board to report against', async () => {
+    // The common props are built around a board identity, and an event with no
+    // `board_name` cannot be stratified — the one rule board-render telemetry
+    // has. The write itself still happens.
+    const { result } = renderHook(() => useBoardLookSettings());
+
+    await act(async () => {
+      result.current.setBoardseshField('glowReach', 1.4);
+    });
+
+    expect(mocks.rawSetBoardseshField).toHaveBeenCalledWith('glowReach', 1.4);
+    expect(mocks.trackBoardRenderSettingChanged).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/mobile/src/lib/board-render/__tests__/use-board-look-settings.test.tsx
+++ b/packages/mobile/src/lib/board-render/__tests__/use-board-look-settings.test.tsx
@@ -154,26 +154,40 @@ describe('useBoardLookSettings — what the funnel sees', () => {
     );
   });
 
-  it('reports Custom against the Aura bundle it writes, not the look it replaces', () => {
-    // The settings-screen Custom card previews the climber's LIVE look, which is
-    // the look being REPLACED. Reporting from it filed a Classic-to-Custom
-    // journey as classic-derived settings under `preset_id: 'aura'`.
+  it('reports the Custom pick from the restore, which is where it actually happens', async () => {
+    // The settings screen intercepts `custom` before `applyPreset` ever sees it
+    // (BoardLookScreen's handleSelect runs restoreCustomLook and navigates), so
+    // reporting it from applyPreset reported nothing at all. Reported against the
+    // bundle actually restored, not the plain Aura one a preset apply would write.
     mocks.preview = PREVIEW;
-    const previousSettings = mocks.settings;
-    mocks.settings = { ...mocks.settings, mode: 'classic' as const };
+    mocks.loadCustomBoardLook.mockResolvedValueOnce({ ...mocks.settings.boardsesh, glowReach: 1.9 });
     const { result } = renderHook(() => useBoardLookSettings());
 
-    act(() => {
-      result.current.applyPreset('custom');
+    await act(async () => {
+      await result.current.restoreCustomLook();
     });
-    mocks.settings = previousSettings;
 
     expect(mocks.trackBoardLookApplied).toHaveBeenCalledWith(
       'custom',
-      expect.objectContaining({ mode: 'aura' }),
+      expect.objectContaining({ boardsesh: expect.objectContaining({ glowReach: 1.9 }) }),
       PREVIEW,
       'settings',
     );
+  });
+
+  it('still reports a Custom pick when there is nothing remembered to restore', async () => {
+    // A climber going custom for the first time is the most interesting one in
+    // the funnel, and they are exactly the case with no stored bundle.
+    mocks.preview = PREVIEW;
+    mocks.loadCustomBoardLook.mockResolvedValueOnce(null);
+    const { result } = renderHook(() => useBoardLookSettings());
+
+    await act(async () => {
+      await result.current.restoreCustomLook();
+    });
+
+    expect(mocks.trackBoardLookApplied).toHaveBeenCalledWith('custom', expect.anything(), PREVIEW, 'settings');
+    expect(mocks.setBoardRenderSettingsPreference).not.toHaveBeenCalled();
   });
 
   it('stays silent with no board to report against', async () => {

--- a/packages/mobile/src/lib/board-render/__tests__/use-board-look-settings.test.tsx
+++ b/packages/mobile/src/lib/board-render/__tests__/use-board-look-settings.test.tsx
@@ -20,7 +20,9 @@ const mocks = vi.hoisted(() => ({
   trackBoardRenderSettingChanged: vi.fn(),
   preview: null as { boardName: string; layoutId: number; sizeId: number } | null,
   settings: {
-    mode: 'aura' as const,
+    // Widened, not `as const`: one test drives a Classic-to-Custom apply and has
+    // to move this field.
+    mode: 'aura' as 'default' | 'classic' | 'aura',
     boardsesh: {
       glowFalloff: 'default' as const,
       glowReach: 1,
@@ -149,6 +151,28 @@ describe('useBoardLookSettings — what the funnel sees', () => {
       'classic',
       expect.objectContaining({ mode: 'classic' }),
       PREVIEW,
+    );
+  });
+
+  it('reports Custom against the Aura bundle it writes, not the look it replaces', () => {
+    // The settings-screen Custom card previews the climber's LIVE look, which is
+    // the look being REPLACED. Reporting from it filed a Classic-to-Custom
+    // journey as classic-derived settings under `preset_id: 'aura'`.
+    mocks.preview = PREVIEW;
+    const previousSettings = mocks.settings;
+    mocks.settings = { ...mocks.settings, mode: 'classic' as const };
+    const { result } = renderHook(() => useBoardLookSettings());
+
+    act(() => {
+      result.current.applyPreset('custom');
+    });
+    mocks.settings = previousSettings;
+
+    expect(mocks.trackBoardLookApplied).toHaveBeenCalledWith(
+      'custom',
+      expect.objectContaining({ mode: 'aura' }),
+      PREVIEW,
+      'settings',
     );
   });
 

--- a/packages/mobile/src/lib/board-render/board-look-analytics.ts
+++ b/packages/mobile/src/lib/board-render/board-look-analytics.ts
@@ -64,6 +64,35 @@ export function trackBoardLookApplied(
   track(name, properties);
 }
 
+/**
+ * One knob moved on a Board look screen.
+ *
+ * Fires for every hand adjustment — a mode switch, a segmented pick, a slider
+ * settle, a toggle — so the funnel can tell a climber who accepted a card from
+ * one who went and built their own look. The preset cards report through
+ * `trackBoardLookApplied` instead: applying a bundle is one decision, not the
+ * twelve field writes it happens to perform.
+ *
+ * `effective` must be the settings the change PRODUCES. The write is async and
+ * the store has not caught up at call time, so the caller resolves them from the
+ * value it just wrote rather than re-reading — the same rule `applyPreset`
+ * follows, and the reason a change would otherwise be filed under the look it
+ * replaced.
+ */
+export function trackBoardRenderSettingChanged(
+  field: string,
+  value: string | number | boolean,
+  effective: BoardRenderEffectiveSettings,
+  context: BoardLookAnalyticsContext,
+): void {
+  const { name, properties } = boardRenderSettingsChanged({
+    ...buildBoardRenderTelemetryProps(effective, context),
+    field,
+    value: String(value),
+  });
+  track(name, properties);
+}
+
 export function trackBoardLookStepShown(
   effective: BoardRenderEffectiveSettings,
   context: BoardLookAnalyticsContext,

--- a/packages/mobile/src/lib/board-render/board-look-analytics.ts
+++ b/packages/mobile/src/lib/board-render/board-look-analytics.ts
@@ -19,7 +19,15 @@ import {
   type BoardLookStepOutcome,
 } from '@boardsesh/analytics';
 import { track } from '../analytics';
+import type { BoardseshRenderSettings } from '../board-render-settings';
 import type { BoardLookOptionId } from './board-look-options';
+
+/**
+ * What `field` on a `Board Render Settings Changed` event may name: the render
+ * mode, or one of the Aura knobs. Closed rather than `string` so a renamed knob
+ * cannot quietly start reporting under a name no dashboard is grouping by.
+ */
+export type BoardRenderSettingField = 'mode' | keyof BoardseshRenderSettings;
 
 /** The board identity a board-render event is about. */
 export type BoardLookAnalyticsContext = Omit<BoardRenderContext, 'presetId' | 'paletteId'>;
@@ -80,7 +88,7 @@ export function trackBoardLookApplied(
  * replaced.
  */
 export function trackBoardRenderSettingChanged(
-  field: string,
+  field: BoardRenderSettingField,
   value: string | number | boolean,
   effective: BoardRenderEffectiveSettings,
   context: BoardLookAnalyticsContext,

--- a/packages/mobile/src/lib/board-render/board-look-options.ts
+++ b/packages/mobile/src/lib/board-render/board-look-options.ts
@@ -86,6 +86,15 @@ const AURA_SUBTLE_OPTION: BoardLookOption = {
   requiresBoardseshRenderer: true,
 };
 
+const MODERN_CLASSIC_OPTION: BoardLookOption = {
+  id: 'modern-classic',
+  labelI18nKey: 'mobile.more.boardLook.presets.modernClassic',
+  descriptionI18nKey: 'mobile.more.boardLook.presets.descriptions.modernClassic',
+  previewSettings: presetValues('modern-classic'),
+  placeholderOverlay: false,
+  requiresBoardseshRenderer: true,
+};
+
 const MAX_CONTRAST_OPTION: BoardLookOption = {
   id: 'max-contrast',
   labelI18nKey: 'mobile.more.boardLook.presets.maxContrast',
@@ -138,32 +147,37 @@ const CUSTOM_SETTINGS_OPTION: BoardLookOption = {
 };
 
 /**
- * Product order: the new default first, then Classic.
+ * Product order: strongest to plainest, with the two circle-drawing looks
+ * adjacent.
  *
- * Classic sits second rather than after the Aura variants because it is the
- * drawing the climber already knows — the question this step asks is really
- * "the new look, or the one you had?", and burying the familiar answer behind
- * three unfamiliar ones misrepresents it as an afterthought. The remaining
- * Aura variants follow, and Custom is last.
+ * The rail reads as a dimmer switch rather than a menu — Aura, then its quieter
+ * variant, then the two looks that draw circles instead of traced holds (Modern
+ * Classic keeps the veil, Classic drops it), then the strongest wash. Modern
+ * Classic sits immediately before Classic on purpose: a climber who came here
+ * for the circles they already know meets the veiled version of them first, and
+ * the pair can be compared with one swipe. Custom is last.
  */
 export const BOARD_LOOK_ONBOARDING_OPTIONS: readonly BoardLookOption[] = [
   AURA_OPTION,
-  CLASSIC_OPTION,
   AURA_SUBTLE_OPTION,
+  MODERN_CLASSIC_OPTION,
+  CLASSIC_OPTION,
   MAX_CONTRAST_OPTION,
   CUSTOM_ONBOARDING_OPTION,
 ];
 
 /**
  * The settings screen shows Aura Bold too — there is room, and no decision to rush.
- * Same ordering as the step, so the two surfaces read the same way.
+ * Same ordering as the step, with Bold kept next to the other Aura variants so
+ * the two surfaces read the same way.
  */
 export const BOARD_LOOK_SETTINGS_OPTIONS: readonly BoardLookOption[] = [
   AURA_OPTION,
-  CLASSIC_OPTION,
   AURA_SUBTLE_OPTION,
-  MAX_CONTRAST_OPTION,
   AURA_BOLD_OPTION,
+  MODERN_CLASSIC_OPTION,
+  CLASSIC_OPTION,
+  MAX_CONTRAST_OPTION,
   CUSTOM_SETTINGS_OPTION,
 ];
 

--- a/packages/mobile/src/lib/board-render/use-board-look-settings.ts
+++ b/packages/mobile/src/lib/board-render/use-board-look-settings.ts
@@ -18,7 +18,7 @@ import {
   type BoardLookOptionId,
 } from './board-look-options';
 import { clearCustomBoardLook, loadCustomBoardLook, rememberCustomBoardLook } from './custom-board-look';
-import { trackBoardLookApplied } from './board-look-analytics';
+import { trackBoardLookApplied, trackBoardRenderSettingChanged } from './board-look-analytics';
 
 /**
  * Everything the three Board look screens share, in one place — because the
@@ -54,7 +54,13 @@ export type BoardLookSettings = {
 };
 
 export function useBoardLookSettings(): BoardLookSettings {
-  const { settings, loaded, setMode, setBoardseshField: rawSetBoardseshField, reset } = useBoardRenderSettings();
+  const {
+    settings,
+    loaded,
+    setMode: rawSetMode,
+    setBoardseshField: rawSetBoardseshField,
+    reset,
+  } = useBoardRenderSettings();
   const { effectiveRenderSettings, boardseshRendererAvailable } = useEffectiveBoardRenderSettings();
   const { preview } = useBoardPreviewClimb();
 
@@ -72,6 +78,46 @@ export function useBoardLookSettings(): BoardLookSettings {
     [preview],
   );
 
+  // Held in a ref for the same reason the settings are: the trackers below run
+  // inside stable callbacks and must report against the CURRENT board, not the
+  // one mounted when the callback was built.
+  const rendererAvailableRef = useRef(boardseshRendererAvailable);
+  rendererAvailableRef.current = boardseshRendererAvailable;
+  const analyticsContextRef = useRef(analyticsContext);
+  analyticsContextRef.current = analyticsContext;
+
+  /**
+   * Report one knob change, against the settings it produces.
+   *
+   * Silent without a preview board: the common props are built around a board
+   * identity, and an event with no `board_name` cannot be stratified — the one
+   * rule `docs/board-render-analytics.md` says never to break. Same bail
+   * `applyPreset` makes.
+   */
+  const reportFieldChange = useCallback(
+    (field: string, value: string | number | boolean, next: BoardRenderSettings) => {
+      const context = analyticsContextRef.current;
+      if (!context) return;
+      trackBoardRenderSettingChanged(
+        field,
+        value,
+        resolveEffectiveRenderSettings(next, rendererAvailableRef.current === true),
+        context,
+      );
+    },
+    [],
+  );
+
+  const setMode = useCallback<BoardLookSettings['setMode']>(
+    (mode) => {
+      rawSetMode(mode);
+      const next = { ...settingsRef.current, mode };
+      settingsRef.current = next;
+      reportFieldChange('mode', mode, next);
+    },
+    [rawSetMode, reportFieldChange],
+  );
+
   const setBoardseshField = useCallback<BoardLookSettings['setBoardseshField']>(
     (field, value) => {
       rawSetBoardseshField(field, value);
@@ -83,10 +129,12 @@ export function useBoardLookSettings(): BoardLookSettings {
       // pre-change snapshot and dropping it. The next render overwrites the ref
       // with the store's own value, which is the truth once the write lands.
       const nextLook = { ...settingsRef.current.boardsesh, [field]: value };
-      settingsRef.current = { ...settingsRef.current, boardsesh: nextLook };
+      const next = { ...settingsRef.current, boardsesh: nextLook };
+      settingsRef.current = next;
       void rememberCustomBoardLook(nextLook);
+      reportFieldChange(field, value, next);
     },
-    [rawSetBoardseshField],
+    [rawSetBoardseshField, reportFieldChange],
   );
 
   const applyPreset = useCallback(

--- a/packages/mobile/src/lib/board-render/use-board-look-settings.ts
+++ b/packages/mobile/src/lib/board-render/use-board-look-settings.ts
@@ -18,7 +18,11 @@ import {
   type BoardLookOptionId,
 } from './board-look-options';
 import { clearCustomBoardLook, loadCustomBoardLook, rememberCustomBoardLook } from './custom-board-look';
-import { trackBoardLookApplied, trackBoardRenderSettingChanged } from './board-look-analytics';
+import {
+  trackBoardLookApplied,
+  trackBoardRenderSettingChanged,
+  type BoardRenderSettingField,
+} from './board-look-analytics';
 
 /**
  * Everything the three Board look screens share, in one place — because the
@@ -95,7 +99,7 @@ export function useBoardLookSettings(): BoardLookSettings {
    * `applyPreset` makes.
    */
   const reportFieldChange = useCallback(
-    (field: string, value: string | number | boolean, next: BoardRenderSettings) => {
+    (field: BoardRenderSettingField, value: string | number | boolean, next: BoardRenderSettings) => {
       const context = analyticsContextRef.current;
       if (!context) return;
       trackBoardRenderSettingChanged(
@@ -143,18 +147,15 @@ export function useBoardLookSettings(): BoardLookSettings {
       if (!analyticsContext) return;
       // Report the settings the choice PRODUCES: the write above is async and
       // the store has not caught up, so resolve them here rather than re-reading.
-      // `custom` is read through the plain Aura bundle, because that is what
-      // `applyBoardLookOption` writes before the Board look screen opens — the
-      // settings-screen Custom card previews the climber's LIVE look
-      // (`previewSettings: null`), which is the look being replaced, not the one
-      // produced. Falling back to it filed a Classic-to-Custom journey under
-      // `preset_id: 'aura'` with classic-derived settings attached.
-      const appliedFrom = id === 'custom' ? 'aura' : id;
+      // No `custom` case: both surfaces route that id elsewhere before it gets
+      // here — settings to `restoreCustomLook` (which reports it itself) and
+      // onboarding to its own apply — so a branch for it here would be dead code
+      // that looks live.
       const applied =
         id === 'classic'
           ? { ...settings, mode: 'classic' as const }
           : mergePresetPreservingAccessibility(
-              BOARD_LOOK_SETTINGS_OPTIONS.find((option) => option.id === appliedFrom)?.previewSettings ?? settings,
+              BOARD_LOOK_SETTINGS_OPTIONS.find((option) => option.id === id)?.previewSettings ?? settings,
               settings,
             );
       trackBoardLookApplied(
@@ -169,7 +170,25 @@ export function useBoardLookSettings(): BoardLookSettings {
 
   const restoreCustomLook = useCallback(async () => {
     const custom = await loadCustomBoardLook();
-    if (!custom) return;
+    // Reported even with nothing to restore. Picking Custom is the decision the
+    // funnel measures; whether a remembered bundle happened to exist is an
+    // implementation detail, and skipping the event there would under-count the
+    // climbers who go custom for the first time — the ones most worth seeing.
+    // The settings reported are the ones that result either way.
+    const report = (applied: BoardRenderSettings) => {
+      const context = analyticsContextRef.current;
+      if (!context) return;
+      trackBoardLookApplied(
+        'custom',
+        resolveEffectiveRenderSettings(applied, rendererAvailableRef.current === true),
+        context,
+        'settings',
+      );
+    };
+    if (!custom) {
+      report(settingsRef.current);
+      return;
+    }
     // Through the same merge every preset apply obeys, not a raw write. A restore
     // may raise the accessibility-owned fields but never lower them — otherwise
     // coming back to Custom could silently switch someone's role glyphs off.
@@ -178,9 +197,9 @@ export function useBoardLookSettings(): BoardLookSettings {
     // callback was built may be a render old by the time the storage read lands,
     // and merging against a stale bundle is exactly how the glyph the merge
     // exists to protect would get dropped. Same rule `setBoardseshField` follows.
-    await setBoardRenderSettingsPreference(
-      mergePresetPreservingAccessibility({ mode: 'aura', boardsesh: custom }, settingsRef.current),
-    );
+    const restored = mergePresetPreservingAccessibility({ mode: 'aura', boardsesh: custom }, settingsRef.current);
+    await setBoardRenderSettingsPreference(restored);
+    report(restored);
   }, []);
 
   // Deliberately does NOT touch the hold-colour overrides. Those are colours and

--- a/packages/mobile/src/lib/board-render/use-board-look-settings.ts
+++ b/packages/mobile/src/lib/board-render/use-board-look-settings.ts
@@ -143,11 +143,18 @@ export function useBoardLookSettings(): BoardLookSettings {
       if (!analyticsContext) return;
       // Report the settings the choice PRODUCES: the write above is async and
       // the store has not caught up, so resolve them here rather than re-reading.
+      // `custom` is read through the plain Aura bundle, because that is what
+      // `applyBoardLookOption` writes before the Board look screen opens — the
+      // settings-screen Custom card previews the climber's LIVE look
+      // (`previewSettings: null`), which is the look being replaced, not the one
+      // produced. Falling back to it filed a Classic-to-Custom journey under
+      // `preset_id: 'aura'` with classic-derived settings attached.
+      const appliedFrom = id === 'custom' ? 'aura' : id;
       const applied =
         id === 'classic'
           ? { ...settings, mode: 'classic' as const }
           : mergePresetPreservingAccessibility(
-              BOARD_LOOK_SETTINGS_OPTIONS.find((option) => option.id === id)?.previewSettings ?? settings,
+              BOARD_LOOK_SETTINGS_OPTIONS.find((option) => option.id === appliedFrom)?.previewSettings ?? settings,
               settings,
             );
       trackBoardLookApplied(

--- a/packages/shared/analytics/src/board-render-events.ts
+++ b/packages/shared/analytics/src/board-render-events.ts
@@ -231,7 +231,14 @@ export function boardRenderPresetApplied(
 }
 
 /** Which card the climber landed on in the board-look step. */
-export type BoardLookOptionId = 'aura' | 'aura-bold' | 'aura-subtle' | 'max-contrast' | 'classic' | 'custom';
+export type BoardLookOptionId =
+  | 'aura'
+  | 'aura-bold'
+  | 'aura-subtle'
+  | 'modern-classic'
+  | 'max-contrast'
+  | 'classic'
+  | 'custom';
 
 export type BoardLookStepShownInput = BoardRenderTelemetryProps & {
   /**

--- a/packages/shared/board-config/src/__tests__/moonboard-hold-state-drift.test.ts
+++ b/packages/shared/board-config/src/__tests__/moonboard-hold-state-drift.test.ts
@@ -50,7 +50,7 @@ describe('MoonBoard hold-state colour drift', () => {
   // typo would satisfy the per-role comparison above and still ship the wrong
   // blue on every MoonBoard render.
   it('the HAND role carries the shared Boardsesh blue on both copies', () => {
-    expect(MOONBOARD_HOLD_STATES.hand.boardseshDisplayColor).toBe('#00FFFF');
-    expect(HOLD_STATE_MAP.moonboard[MOONBOARD_HOLD_STATE_CODES.hand].boardseshDisplayColor).toBe('#00FFFF');
+    expect(MOONBOARD_HOLD_STATES.hand.boardseshDisplayColor).toBe('#4DF5FD');
+    expect(HOLD_STATE_MAP.moonboard[MOONBOARD_HOLD_STATE_CODES.hand].boardseshDisplayColor).toBe('#4DF5FD');
   });
 });

--- a/packages/shared/board-config/src/__tests__/moonboard-hold-state-drift.test.ts
+++ b/packages/shared/board-config/src/__tests__/moonboard-hold-state-drift.test.ts
@@ -49,7 +49,7 @@ describe('MoonBoard hold-state colour drift', () => {
   // Pins the hex itself, not just the fact that both copies agree: a mirrored
   // typo would satisfy the per-role comparison above and still ship the wrong
   // blue on every MoonBoard render.
-  it('the HAND role carries the shared Boardsesh blue on both copies', () => {
+  it('the HAND role carries the shared Boardsesh cyan on both copies', () => {
     expect(MOONBOARD_HOLD_STATES.hand.boardseshDisplayColor).toBe('#4DF5FD');
     expect(HOLD_STATE_MAP.moonboard[MOONBOARD_HOLD_STATE_CODES.hand].boardseshDisplayColor).toBe('#4DF5FD');
   });

--- a/packages/shared/board-config/src/__tests__/moonboard-hold-state-drift.test.ts
+++ b/packages/shared/board-config/src/__tests__/moonboard-hold-state-drift.test.ts
@@ -50,7 +50,7 @@ describe('MoonBoard hold-state colour drift', () => {
   // typo would satisfy the per-role comparison above and still ship the wrong
   // blue on every MoonBoard render.
   it('the HAND role carries the shared Boardsesh blue on both copies', () => {
-    expect(MOONBOARD_HOLD_STATES.hand.boardseshDisplayColor).toBe('#6980FF');
-    expect(HOLD_STATE_MAP.moonboard[MOONBOARD_HOLD_STATE_CODES.hand].boardseshDisplayColor).toBe('#6980FF');
+    expect(MOONBOARD_HOLD_STATES.hand.boardseshDisplayColor).toBe('#00FFFF');
+    expect(HOLD_STATE_MAP.moonboard[MOONBOARD_HOLD_STATE_CODES.hand].boardseshDisplayColor).toBe('#00FFFF');
   });
 });

--- a/packages/shared/board-config/src/moonboard-config.ts
+++ b/packages/shared/board-config/src/moonboard-config.ts
@@ -148,11 +148,10 @@ export const MOONBOARD_SIZE = {
 export const MOONBOARD_HOLD_STATES = {
   start: { name: 'STARTING' as const, color: '#00FF00', displayColor: '#44FF44' },
   // boardseshDisplayColor mirrors HOLD_STATE_MAP.moonboard[43] (issue #2202):
-  // the Aura render mode lifts the HAND off the veiled wall. MoonBoard takes
-  // Kilter's cyan rather than the Aura blue every other board uses — MoonBoard
-  // 2024's own holds are blue, so the blue marker disappeared into them.
-  // Pinned by moonboard-hold-state-drift.test.ts.
-  hand: { name: 'HAND' as const, color: '#0000FF', displayColor: '#4444FF', boardseshDisplayColor: '#00FFFF' },
+  // the one Aura HAND cyan, which every board now shares. MoonBoard is where it
+  // started — its 2024 holds are #2f8bcb, so the old Aura blue marked a blue
+  // hold with a blue glow. Pinned by moonboard-hold-state-drift.test.ts.
+  hand: { name: 'HAND' as const, color: '#0000FF', displayColor: '#4444FF', boardseshDisplayColor: '#4DF5FD' },
   finish: { name: 'FINISH' as const, color: '#FF0000', displayColor: '#FF3333' },
 } as const;
 

--- a/packages/shared/board-config/src/moonboard-config.ts
+++ b/packages/shared/board-config/src/moonboard-config.ts
@@ -148,9 +148,11 @@ export const MOONBOARD_SIZE = {
 export const MOONBOARD_HOLD_STATES = {
   start: { name: 'STARTING' as const, color: '#00FF00', displayColor: '#44FF44' },
   // boardseshDisplayColor mirrors HOLD_STATE_MAP.moonboard[43] (issue #2202):
-  // the Boardsesh render mode lifts the dark-blue HAND off the veiled wall.
+  // the Aura render mode lifts the HAND off the veiled wall. MoonBoard takes
+  // Kilter's cyan rather than the Aura blue every other board uses — MoonBoard
+  // 2024's own holds are blue, so the blue marker disappeared into them.
   // Pinned by moonboard-hold-state-drift.test.ts.
-  hand: { name: 'HAND' as const, color: '#0000FF', displayColor: '#4444FF', boardseshDisplayColor: '#6980FF' },
+  hand: { name: 'HAND' as const, color: '#0000FF', displayColor: '#4444FF', boardseshDisplayColor: '#00FFFF' },
   finish: { name: 'FINISH' as const, color: '#FF0000', displayColor: '#FF3333' },
 } as const;
 

--- a/packages/shared/board-render/src/__tests__/render-config.test.ts
+++ b/packages/shared/board-render/src/__tests__/render-config.test.ts
@@ -134,6 +134,42 @@ describe('buildRenderConfig — boardsesh mode', () => {
     expect(withExtras.mark_style).toBe('fill');
   });
 
+  it('paints the Aura palette, not the classic one, when Aura is what was asked for', () => {
+    // The regression this guards: `buildRenderConfig` applied the classic
+    // `displayColor ?? color` rule whatever mode was requested, so a server
+    // render asked for Aura came back in the colours the app shows only in
+    // classic. MoonBoard's HAND is the loudest case — Aura draws it cyan and
+    // classic draws it a near-black blue, so a swap is a different hue, not a
+    // shade.
+    const moonboardHand = HOLD_STATE_MAP.moonboard[43];
+    const auraConfig = buildRenderConfig({
+      ...boardseshParams,
+      boardName: 'moonboard',
+      boardStates: HOLD_STATE_MAP.moonboard,
+    }).config;
+    expect(auraConfig.hold_state_map[43].color).toBe(moonboardHand.boardseshDisplayColor);
+
+    const classicConfig = buildRenderConfig({
+      ...boardseshParams,
+      boardName: 'moonboard',
+      boardStates: HOLD_STATE_MAP.moonboard,
+      renderMode: 'classic',
+    }).config;
+    expect(classicConfig.hold_state_map[43].color).toBe(moonboardHand.displayColor);
+    expect(classicConfig.hold_state_map[43].color).not.toBe(auraConfig.hold_state_map[43].color);
+  });
+
+  it('leaves a role without an Aura colour identical in both modes', () => {
+    // Only the roles that carry a `boardseshDisplayColor` may move. Kilter has
+    // none, so every one of its codes must render the same either way — the
+    // guard that the fix above changed one rule, not every colour.
+    const aura = buildRenderConfig(boardseshParams).config;
+    const classic = buildRenderConfig({ ...boardseshParams, renderMode: 'classic' }).config;
+    for (const code of Object.keys(aura.hold_state_map)) {
+      expect(aura.hold_state_map[Number(code)].color).toBe(classic.hold_state_map[Number(code)].color);
+    }
+  });
+
   it('lower-cases HoldStateInfo.name onto role, only for STARTING/HAND/FINISH/FOOT', () => {
     const { config } = buildRenderConfig(boardseshParams);
     // Kilter set 1/20 codes: 12 STARTING, 13 HAND, 14 FINISH, 15 FOOT, 36 HAND

--- a/packages/shared/board-render/src/__tests__/render-config.test.ts
+++ b/packages/shared/board-render/src/__tests__/render-config.test.ts
@@ -159,14 +159,23 @@ describe('buildRenderConfig — boardsesh mode', () => {
     expect(classicConfig.hold_state_map[43].color).not.toBe(auraConfig.hold_state_map[43].color);
   });
 
-  it('leaves a role without an Aura colour identical in both modes', () => {
-    // Only the roles that carry a `boardseshDisplayColor` may move. Kilter has
-    // none, so every one of its codes must render the same either way — the
-    // guard that the fix above changed one rule, not every colour.
+  it('moves only the roles that carry an Aura colour, and leaves the rest alone', () => {
+    // The guard that the palette fix changed one rule, not every colour: a code
+    // moves between modes exactly when it has a `boardseshDisplayColor`. On
+    // Kilter that is the six product HANDs and nothing else — the Tycho
+    // colour-mode codes and every STARTING/FINISH/FOOT must be identical.
     const aura = buildRenderConfig(boardseshParams).config;
     const classic = buildRenderConfig({ ...boardseshParams, renderMode: 'classic' }).config;
     for (const code of Object.keys(aura.hold_state_map)) {
-      expect(aura.hold_state_map[Number(code)].color).toBe(classic.hold_state_map[Number(code)].color);
+      const auraColor = aura.hold_state_map[Number(code)].color;
+      const classicColor = classic.hold_state_map[Number(code)].color;
+      const override = HOLD_STATE_MAP.kilter[Number(code)]?.boardseshDisplayColor;
+      if (override) {
+        expect(auraColor, `kilter code ${code}`).toBe(override);
+        expect(auraColor, `kilter code ${code}`).not.toBe(classicColor);
+      } else {
+        expect(auraColor, `kilter code ${code}`).toBe(classicColor);
+      }
     }
   });
 

--- a/packages/shared/board-render/src/generated/render-version.ts
+++ b/packages/shared/board-render/src/generated/render-version.ts
@@ -8,4 +8,4 @@
 //
 // Deliberately import-free: this module is reachable from web's client bundle
 // through buildBoardRenderUrl, and must never drag sharp or the WASM glue with it.
-export const BOARD_RENDER_VERSION = '5b04c117e297';
+export const BOARD_RENDER_VERSION = '9f6e8586d17b';

--- a/packages/shared/board-render/src/render-config.ts
+++ b/packages/shared/board-render/src/render-config.ts
@@ -1,6 +1,10 @@
 import type { BoardName } from '@boardsesh/shared-schema';
 import { isWithinSpillRange } from '@boardsesh/board-art-geometry';
-import { getBoardStrokeWidthMultiplier, parseFramesSegments } from '@boardsesh/board-constants/hold-states';
+import {
+  getBoardStrokeWidthMultiplier,
+  getHoldDisplayColor,
+  parseFramesSegments,
+} from '@boardsesh/board-constants/hold-states';
 import { OG_BOARD_PADDING_X, OG_BOARD_PADDING_Y } from './background';
 import { OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from './headers';
 import type {
@@ -149,11 +153,18 @@ export function buildRenderConfig({
   // sees on screen (issue #2202: raw LED blue renders far too dark against a
   // busy board photo). Boards without a displayColor (e.g. Kilter) render
   // unchanged.
+  //
+  // Through `getHoldDisplayColor` rather than the `displayColor ?? color` rule
+  // inline, so an Aura render on the server draws the SAME palette the app
+  // does. This path used to apply the classic rule whatever mode was asked for,
+  // which meant an `aura` OG card drew a role in a colour the app never shows it
+  // in — MoonBoard's HAND most visibly, whose Aura colour is a different hue
+  // entirely.
   const holdStateMap: Record<number, { color: string; renderStyle?: string; role?: HoldRole }> = {};
   for (const [code, info] of Object.entries(boardStates)) {
     const role = isAura ? roleForHoldStateName(info.name) : undefined;
     holdStateMap[Number(code)] = {
-      color: info.displayColor ?? info.color,
+      color: getHoldDisplayColor(info, isAura ? 'aura' : 'classic'),
       ...(info.renderStyle ? { renderStyle: info.renderStyle } : {}),
       ...(role ? { role } : {}),
     };

--- a/packages/shared/board-render/src/render-version-projection.ts
+++ b/packages/shared/board-render/src/render-version-projection.ts
@@ -38,6 +38,9 @@ import { buildRenderConfig } from './render-config';
  * multipliers, thumbnail width, OG canvas size and MoonBoard/Woods geometry
  * without naming any of them, and it cannot rot when a new one is added.
  *
+ * It records the config for BOTH drawings — classic and Aura — because the route
+ * serves both and they do not share a palette.
+ *
  * The two halves the projection cannot see — the compiled WASM binary and the
  * imperative sharp pipeline — stay file hashes, added by
  * `scripts/generate-board-render-version.ts`. Both are genuinely low-churn.
@@ -170,12 +173,31 @@ function projectCatalogueEntry(entry: CatalogueEntry): Record<string, unknown> {
     isOgVariant: true,
     boardStates,
   });
+  // The Aura render, which the route serves whenever `render_mode=aura` is asked
+  // for. Probed separately because the config it produces is genuinely different:
+  // it carries `render_mode`/`glow_falloff`/`glyphs`, a per-hold `role`, and — the
+  // reason this probe exists — the Aura palette, where a role may resolve to a
+  // different colour than in classic (`boardseshDisplayColor`). Without it a
+  // change to the Aura HAND colour moved no version, and Cloudflare would serve
+  // the old colour `immutable` for a year.
+  const aura = buildRenderConfig({
+    boardName: entry.boardName,
+    boardDetails,
+    frames: FRAMES_PROBE,
+    thumbnail: false,
+    isOgVariant: false,
+    boardStates,
+    renderMode: 'aura',
+  });
 
   return {
     ...identity,
     // The full WASM input for the native render: board dimensions, every hold's
     // (id, cx, cy, r), the hold-state colour map and the stroke multiplier.
     wasm_config: native.config,
+    // The same, for the Aura drawing — a different palette and a different set of
+    // config fields, both of which change pixels.
+    wasm_config_aura: aura.config,
     // The other two output widths, which is all the variants change in the config.
     output_width_thumbnail: thumbnail.outputWidth,
     output_width_og: ogCard.outputWidth,

--- a/packages/shared/board-render/src/types.ts
+++ b/packages/shared/board-render/src/types.ts
@@ -58,7 +58,7 @@ export type OutputFormat = 'webp' | 'png' | 'jpeg';
 /** Per-board hold-state colour/style map (subset of board-constants HoldStateInfo). */
 export type HoldStateRecord = Record<
   number | string,
-  { color: string; displayColor?: string; renderStyle?: string; name?: string }
+  { color: string; displayColor?: string; boardseshDisplayColor?: string; renderStyle?: string; name?: string }
 >;
 
 /**

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -36,10 +36,12 @@
           "aura": "Aura",
           "auraBold": "Aura kräftig",
           "auraSubtle": "Aura dezent",
+          "modernClassic": "Klassisch modern",
           "maxContrast": "Maximaler Kontrast",
           "descriptions": {
             "aura": "Beleuchtete Griffe leuchten auf gedämpfter Wand.",
             "auraSubtle": "Ein sanfteres Leuchten, dicht am Griff.",
+            "modernClassic": "Die gewohnten Kreise auf gedämpfter Wand.",
             "maxContrast": "Stärkster Schleier, gefüllte Griffe und Rollen-Glyphen.",
             "auraBold": "Ein breiteres, härteres Leuchten — auch von weitem sichtbar.",
             "classic": "Die runden Marker, die Boardsesh immer gezeichnet hat.",
@@ -85,6 +87,13 @@
         },
         "marks": {
           "title": "Markierungen",
+          "holdShape": {
+            "title": "Griffform",
+            "options": {
+              "silhouette": "Kontur",
+              "circle": "Kreise"
+            }
+          },
           "style": {
             "title": "Markierungsstil",
             "options": {
@@ -138,8 +147,9 @@
         "resetAll": "Board-Look zurücksetzen",
         "intro": {
           "title": "Wähl deinen Board-Look",
-          "subtitle": "Boardsesh beleuchtet jetzt die Form jedes Griffs. Wisch, um jeden Look auf deinem Board zu sehen.",
-          "accessibilityNote": "Deine Grifffarben und Barrierefreiheits-Einstellungen bleiben unverändert.",
+          "subtitle": "Wir haben bessere Darstellungen für dein Board ergänzt, drängen sie dir aber nicht auf. Wisch durch und nimm die, die dir gefällt — oder bau dir deine eigene.",
+          "accessibilityNote": "Deine Wahl hier überschreibt deine Barrierefreiheits-Einstellungen nicht",
+          "changeLaterNote": "Du kannst das jederzeit in den Einstellungen ändern",
           "saveNamed": "{{look}} nehmen",
           "customCta": "Einrichten",
           "replayTitle": "Board-Look-Auswahl erneut zeigen",

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -36,10 +36,12 @@
           "aura": "Aura",
           "auraBold": "Aura Bold",
           "auraSubtle": "Aura Subtle",
+          "modernClassic": "Modern Classic",
           "maxContrast": "Max contrast",
           "descriptions": {
             "aura": "Lit holds glow on a quietened wall.",
             "auraSubtle": "A softer glow that stays close to each hold.",
+            "modernClassic": "The circles you know, on a quietened wall.",
             "maxContrast": "The strongest wash, filled holds and role glyphs.",
             "auraBold": "A wider, harder glow that carries across the room.",
             "classic": "The circle markers Boardsesh has always drawn.",
@@ -85,6 +87,13 @@
         },
         "marks": {
           "title": "Marks",
+          "holdShape": {
+            "title": "Hold shape",
+            "options": {
+              "silhouette": "Traced",
+              "circle": "Circles"
+            }
+          },
           "style": {
             "title": "Mark style",
             "options": {
@@ -138,8 +147,9 @@
         "resetAll": "Reset board look",
         "intro": {
           "title": "Pick your board look",
-          "subtitle": "Boardsesh now lights up each hold’s own shape. Swipe to see each look on your board.",
-          "accessibilityNote": "Your hold colours and accessibility settings stay exactly as they are.",
+          "subtitle": "We added improved ways of rendering your board, but we won’t force them on you. Swipe through and pick the one you like, or go completely custom.",
+          "accessibilityNote": "Your decision here won’t override your accessibility settings",
+          "changeLaterNote": "You can change this anytime from the settings screen",
           "saveNamed": "Use {{look}}",
           "customCta": "Set it up",
           "replayTitle": "Replay board look picker",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -215,10 +215,12 @@
           "aura": "Aura",
           "auraBold": "Aura intensa",
           "auraSubtle": "Aura sutil",
+          "modernClassic": "Clásico moderno",
           "maxContrast": "Máximo contraste",
           "descriptions": {
             "aura": "Las presas encendidas brillan sobre un muro atenuado.",
             "auraSubtle": "Un brillo más suave, pegado a cada presa.",
+            "modernClassic": "Los círculos de siempre, sobre un muro atenuado.",
             "maxContrast": "El lavado más fuerte, presas rellenas y glifos de rol.",
             "auraBold": "Un brillo más amplio y duro que se ve desde lejos.",
             "classic": "Los marcadores circulares de siempre.",
@@ -264,6 +266,13 @@
         },
         "marks": {
           "title": "Marcas",
+          "holdShape": {
+            "title": "Forma de la presa",
+            "options": {
+              "silhouette": "Contorno",
+              "circle": "Círculos"
+            }
+          },
           "style": {
             "title": "Estilo de marca",
             "options": {
@@ -317,8 +326,9 @@
         "resetAll": "Restablecer aspecto del plafón",
         "intro": {
           "title": "Elige el aspecto de tu plafón",
-          "subtitle": "Boardsesh ahora ilumina la forma de cada presa. Desliza para ver cada aspecto en tu plafón.",
-          "accessibilityNote": "Tus colores de presa y ajustes de accesibilidad se quedan como están.",
+          "subtitle": "Hemos añadido mejores formas de dibujar tu plafón, pero no te las vamos a imponer. Desliza y elige la que más te guste, o hazte una a medida.",
+          "accessibilityNote": "Lo que elijas aquí no anulará tus ajustes de accesibilidad",
+          "changeLaterNote": "Puedes cambiarlo cuando quieras desde los ajustes",
           "saveNamed": "Usar {{look}}",
           "customCta": "Configurarlo",
           "replayTitle": "Repetir el selector de aspecto",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -36,10 +36,12 @@
           "aura": "Aura",
           "auraBold": "Aura intense",
           "auraSubtle": "Aura discrète",
+          "modernClassic": "Classique moderne",
           "maxContrast": "Contraste max",
           "descriptions": {
             "aura": "Les prises allumées brillent sur un mur assourdi.",
             "auraSubtle": "Une lueur plus douce, au plus près de chaque prise.",
+            "modernClassic": "Les cercles habituels, sur un mur assourdi.",
             "maxContrast": "Le voile le plus fort, prises pleines et glyphes de rôle.",
             "auraBold": "Une lueur plus large et plus dure, visible de loin.",
             "classic": "Les marqueurs ronds que Boardsesh a toujours dessinés.",
@@ -85,6 +87,13 @@
         },
         "marks": {
           "title": "Marques",
+          "holdShape": {
+            "title": "Forme de la prise",
+            "options": {
+              "silhouette": "Contour",
+              "circle": "Cercles"
+            }
+          },
           "style": {
             "title": "Style de marque",
             "options": {
@@ -138,8 +147,9 @@
         "resetAll": "Réinitialiser le look de la board",
         "intro": {
           "title": "Choisis ton rendu",
-          "subtitle": "Boardsesh allume désormais la forme de chaque prise. Balaie pour voir chaque rendu sur ton mur.",
-          "accessibilityNote": "Tes couleurs de prises et tes réglages d’accessibilité ne bougent pas.",
+          "subtitle": "On a ajouté de meilleurs rendus pour ton mur, sans rien t’imposer. Balaie et choisis celui qui te plaît, ou pars sur du sur-mesure.",
+          "accessibilityNote": "Ton choix ici ne remplacera pas tes réglages d’accessibilité",
+          "changeLaterNote": "Tu peux en changer quand tu veux depuis les réglages",
           "saveNamed": "Utiliser {{look}}",
           "customCta": "Le configurer",
           "replayTitle": "Revoir le choix du rendu",

--- a/scripts/glow-lab.ts
+++ b/scripts/glow-lab.ts
@@ -9,6 +9,7 @@
  *   ./node_modules/.bin/tsx scripts/glow-lab.ts --out .boardsesh/glow-lab
  *   ./node_modules/.bin/tsx scripts/glow-lab.ts --board tension/10-6 \
  *     --frames p1234r2p1240r1 --climb-name Prime
+ *   ./node_modules/.bin/tsx scripts/glow-lab.ts --hold-shape circle   # Modern Classic
  *
  * A variants file is `[{ "name": "...", "overrides": { ...RenderConfig subset } }]`;
  * each variant's overrides are merged over the production-shaped config (one
@@ -34,7 +35,7 @@ import path from 'node:path';
 import sharp from 'sharp';
 
 import type { BoardName } from '../packages/shared-schema/src/types/board-config';
-import { HOLD_STATE_MAP, getHoldDisplayColor } from '../packages/board-constants/src/hold-states';
+import { HOLD_STATE_MAP } from '../packages/board-constants/src/hold-states';
 import { loadBoardArtGeometry, getWallLightness } from '../packages/shared/board-art-geometry/src/loader';
 import { veilOpacityFor } from '../packages/shared/board-art-geometry/src/veil';
 import { getBoardDetailsForBoard } from '../packages/shared/board-render/src/board-details';
@@ -71,6 +72,13 @@ type CliArguments = {
   /** `--frames`; null keeps the frozen `GLOW_LAB_CLIMBS` set. */
   frames: string | null;
   climbName: string;
+  /**
+   * `--hold-shape circle` withholds the traced outlines, which IS the Modern
+   * Classic look: the renderer falls back to the placement circle for any hold
+   * without one, so the veil punches circles and the glow follows them. Mirrors
+   * `holdShape` in the app's board-render settings.
+   */
+  holdShape: 'silhouette' | 'circle';
 };
 
 /** `<boardName>/<layoutId>-<sizeId>`, the same shape as a board-art-geometry shard key. */
@@ -91,13 +99,19 @@ function parseCliArguments(): CliArguments {
   let board: LabBoard | null = null;
   let frames: string | null = null;
   let climbName = 'custom';
+  let holdShape: 'silhouette' | 'circle' = 'silhouette';
   for (let index = 0; index < cliArguments.length; index += 1) {
     if (cliArguments[index] === '--variants') variantsPath = cliArguments[++index];
     else if (cliArguments[index] === '--out') outDir = path.resolve(cliArguments[++index]);
     else if (cliArguments[index] === '--board') board = parseBoardArgument(cliArguments[++index]);
     else if (cliArguments[index] === '--frames') frames = cliArguments[++index];
     else if (cliArguments[index] === '--climb-name') climbName = cliArguments[++index];
-    else if (cliArguments[index] === '--scale') {
+    else if (cliArguments[index] === '--hold-shape') {
+      const raw = cliArguments[++index];
+      if (raw !== 'silhouette' && raw !== 'circle')
+        throw new Error(`--hold-shape must be silhouette|circle, got ${raw}`);
+      holdShape = raw;
+    } else if (cliArguments[index] === '--scale') {
       renderScale = Number(cliArguments[++index]);
       if (!Number.isInteger(renderScale) || renderScale < 1 || renderScale > 4) {
         throw new Error('--scale must be an integer 1..4');
@@ -107,7 +121,7 @@ function parseCliArguments(): CliArguments {
   if (frames !== null && !/^(p\d+r\d+)+$/.test(frames)) {
     throw new Error(`--frames must be a single frame like p1234r43p1235r42, got ${frames}`);
   }
-  return { variantsPath, outDir, renderScale, board, frames, climbName };
+  return { variantsPath, outDir, renderScale, board, frames, climbName, holdShape };
 }
 
 function loadVariants(variantsPath: string | null): GlowVariant[] {
@@ -201,7 +215,7 @@ function labelBanner(text: string, width: number, height: number): Buffer {
 }
 
 async function main(): Promise<void> {
-  const { variantsPath, outDir, renderScale, board, frames, climbName } = parseCliArguments();
+  const { variantsPath, outDir, renderScale, board, frames, climbName, holdShape } = parseCliArguments();
   const variants = loadVariants(variantsPath);
   fs.mkdirSync(outDir, { recursive: true });
   ensureRendererBinary();
@@ -274,21 +288,23 @@ async function main(): Promise<void> {
         markStyle: thumbnail ? 'glow-fill' : 'glow',
         ...(veilOpacity > 0 ? { veil: { color: FIELD_COLOR, opacity: veilOpacity } } : {}),
         // The lab layers spill overrides onto the built config, so the unlit
-        // neighbour outlines must be present.
-        spillNeighbourOutlines: true,
-        holdGeometry: {
-          outlines: geometry.outlines,
-          ledInner: geometry.ledInner,
-          ledBright: geometry.ledBright,
-          silhouetteLightness: geometry.silhouetteLightness,
-        },
+        // neighbour outlines must be present — but only where there are
+        // outlines at all, which Modern Classic is defined by not having.
+        spillNeighbourOutlines: holdShape === 'silhouette',
+        // Modern Classic keeps `ledBright` and drops the rest, exactly like the
+        // app: the LED cover goes on a placement, not on a silhouette, while
+        // `ledInner` and `silhouetteLightness` are measured against the outline
+        // and mean nothing without it.
+        holdGeometry:
+          holdShape === 'circle'
+            ? { ledBright: geometry.ledBright }
+            : {
+                outlines: geometry.outlines,
+                ledInner: geometry.ledInner,
+                ledBright: geometry.ledBright,
+                silhouetteLightness: geometry.silhouetteLightness,
+              },
       });
-      // Mobile prefers the boardsesh display palette (e.g. Tension's lifted
-      // HAND blue); the shared builder only knows displayColor. No-op on Kilter.
-      const holdStateMap = config.hold_state_map as Record<string, { color: string }>;
-      for (const [code, stateInfo] of Object.entries(boardStates)) {
-        if (holdStateMap[code]) holdStateMap[code].color = getHoldDisplayColor(stateInfo, 'aura');
-      }
       return config as unknown as Record<string, unknown>;
     };
 


### PR DESCRIPTION
## Summary

Adds **Modern Classic**, a sixth board look: Aura's measured veil and glow, drawn on the placement circle instead of the traced hold silhouette. The Aura renderer already falls back to that circle for any hold the tracer skipped (`aura/geometry.rs`), so the whole look is a JS-side `holdShape` setting that withholds the outlines — **no Rust change, no fingerprint move, ships to the current store fleet by OTA.** The veil punches circles out of the wash and the glow follows them; `led_cover` and the veil measurement never read an outline and are untouched.

Also tidies the one-time "Pick your board look" step:

- New order: Aura → Aura Subtle → **Modern Classic** → Classic → Max contrast → Custom. The two circle-drawing looks sit next to each other, so the veiled version of the familiar circles is one swipe from the familiar circles.
- No per-card sentences in onboarding (the settings rail keeps them, where the thumb is small and the sentence does real work). The hero's height budget stops reserving two lines for a description nobody draws — on a device where the hero is height-limited that goes into the picture; on a big phone, where it is width-limited, it just stops being reserved.
- Each card's name is centred under its board.
- New header subtitle, and the footer now says both that the choice does not touch accessibility settings and that it can be changed later.

And it closes an analytics hole: `Board Render Settings Changed` was only ever fired by the Classic card, so a climber who went and hand-built a look was invisible in the funnel. It now fires for every knob, from the single writer (`use-board-look-settings.ts`) — so a new control cannot be wired up and miss the event. Silent when there is no preview board, since the common props are built around a board identity.

`holdShape` is also a segmented row on **Custom look**, above Mark style. Without it a climber who picked Modern Classic and then came in to tune would have no way back to the traced silhouettes.

**Known and intended:** on a board the tracer has not covered (MoonBoard's grid is largely untraced), Aura already draws circles, so Aura and Modern Classic render the same there and the two cards look alike.

### MoonBoard's Aura HAND colour

MoonBoard 2024's holds are blue plastic, so `BOARDSESH_HAND_BLUE` (#6980FF) marked a blue hold with a blue glow — the mark read as part of the hold rather than as a mark on it. MoonBoard's Aura HAND is now Kilter's own HAND cyan, far enough round the wheel to separate from blue holds under the veil. Asserted against Kilter's entry rather than a literal, so the two boards cannot drift to different "hand blues". Classic mode, Kilter, every Aurora board and every other role are untouched.

While verifying it, I found the shared render pipeline **never applied the Aura palette at all**: `buildRenderConfig` used the classic `displayColor ?? color` rule whatever `render_mode` was asked for, so an `aura` render on the server drew roles in colours the app never shows. `getHoldDisplayColor` already existed for exactly this and had no caller on that path — it does now. Practical blast radius today is small (web never sends `render_mode`), but it is what makes this colour change land on OG/share cards too rather than only in the app.

`RENDERER_VERSION` 14 → 15: a palette value is not a setting, so every cached MoonBoard overlay would otherwise be reused with the old blue baked in — the case v4 hit when hold colours moved to their calibrated `displayColor`.

## Release Notes

- New board look: Modern Classic keeps the circles you know and adds Aura's quietened wall behind them
- The board look picker is easier to read — bigger previews, no small print, and you can change your pick anytime
- MoonBoard hand holds now light up cyan, so they stand out from the board's own blue holds

## Test plan

1. Fresh install → onboarding → six looks, Modern Classic third.
2. Swipe the rail → names centred, no sentences under them.
3. Pick Modern Classic → Use Modern Classic → board shows circles.
4. More → Board look → Modern Classic card is Active.
5. MoonBoard 2024 climb → hand holds glow cyan, not blue.

## Risk

Risk: 3/5 — new render preset + reordered onboarding; JS-only, ships by OTA, no BLE, native or migration changes.
