### PR TITLE
fix(sync): point the sync .env.1password files at the live database item

### DIFF
--- a/docs/aurora-sync.md
+++ b/docs/aurora-sync.md
@@ -289,12 +289,21 @@ AURORA_CREDENTIALS_SECRET="<encryption key>"
 
 ### Using 1Password CLI
 
-Create `.env.1password`:
+`.env.1password` is already tracked for both sync packages
+(`packages/aurora-sync/`, `packages/kilter-sync/`) — it holds `op://` references
+only, never a secret:
 
 ```
-DATABASE_URL="op://Boardsesh/Postgres PROD/connection_string"
+DATABASE_URL="op://Boardsesh/DATABASE_URL/notesPlain"
 AURORA_CREDENTIALS_SECRET="op://Boardsesh/Encryption key/password"
 ```
+
+The `DATABASE_URL` item is the one the homelab sync daemons read
+(`roles/boardsesh_sync/` in blackheathdc-ansible), so both paths point at the
+same production connection string. The older `Postgres PROD` item is a Neon-era
+leftover — it still resolves, but authenticates as the retired `default` role
+and fails against Railway with `password authentication failed for user
+'default'`.
 
 Run with:
 

--- a/packages/kilter-sync/.env.1password
+++ b/packages/kilter-sync/.env.1password
@@ -1,2 +1,3 @@
 DATABASE_URL="op://Boardsesh/DATABASE_URL/notesPlain"
 AURORA_CREDENTIALS_SECRET="op://Boardsesh/Encryption key/password"
+KILTER_OAUTH_CLIENT_ID="kilter"


### PR DESCRIPTION
Found while diagnosing the sync daemon outage (both daemons were crash-looping for ~21h; the actual fix is in the ansible repo, marcodejongh/blackheathdc-ansible#401).

## What

`op run --env-file=packages/aurora-sync/.env.1password` has been resolving `op://Boardsesh/Postgres PROD/notesPlain`, a Neon-era item. It still resolves, so it fails late and confusingly — at the database rather than at 1Password:

```
PostgresError: password authentication failed for user 'default'
```

`default` was Neon's role. Production is Railway now.

The item the homelab sync daemons actually read is `op://Boardsesh/DATABASE_URL/notesPlain` (`roles/boardsesh_sync/` in blackheathdc-ansible). Both paths now point at it, so they stay in lockstep.

Also adds `packages/kilter-sync/.env.1password`, which `docs/kilter-sync.md:418` has been telling people to run against since the daemon shipped, without the file ever existing. It carries `KILTER_OAUTH_CLIENT_ID` alongside the two shared values, matching the daemon's `sync.env`.

Both files hold `op://` references only — no secrets, which is why they're tracked.

## Release Notes

none

## Test plan

1. CI green.
2. Optional: `op run --env-file=packages/kilter-sync/.env.1password -- node --import tsx packages/kilter-sync/src/cli/index.ts list` prints credentials rather than an auth error.

Verified against production while writing this: the command returns all 85 kilter credentials (76 active, 9 expired). On `main` it fails with the `user 'default'` error above.

## Risk

1/5 — two `op://` reference files and a docs block. No runtime code, no schema, nothing shipped to users. `vp check` reports the same 2 pre-existing errors as `main` (`packages/db/.../grade-model/__tests__/constants.test.ts`, untouched here).