### PR TITLE
feat(web): keep postgres.js external so Sentry can trace DB queries

### DIFF
--- a/packages/web/app/__tests__/next-config-server-externals.test.ts
+++ b/packages/web/app/__tests__/next-config-server-externals.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vite-plus/test';
+
+type NextConfigWithExternals = {
+  serverExternalPackages?: string[];
+};
+
+const configModule = await import('../../next.config.mjs');
+const nextConfig = configModule.default as unknown as NextConfigWithExternals;
+
+// The major @sentry/node's postgresJsIntegration declares it can instrument
+// (SUPPORTED_VERSIONS = [">=3.0.0 <4"] in
+// @sentry/node/build/cjs/integrations/tracing/postgresjs.js).
+const SENTRY_SUPPORTED_POSTGRES_MAJOR = 3;
+
+describe('serverExternalPackages', () => {
+  it('keeps postgres.js external so Sentry can instrument it', () => {
+    // Sentry's postgresJsIntegration patches postgres.js through
+    // OpenTelemetry's require-hook, which only fires for modules the bundler
+    // leaves external. Neither Next's own externals list nor @sentry/nextjs's
+    // DEFAULT_SERVER_EXTERNAL_PACKAGES includes `postgres` — both list `pg`,
+    // which this repo does not use.
+    //
+    // Drop this and every db.query span disappears with no error anywhere. The
+    // failure mode is an empty Sentry Queries view, which is exactly the panel
+    // that replaced Vercel Observability Plus's per-route latency breakdown.
+    expect(nextConfig.serverExternalPackages).toContain('postgres');
+  });
+
+  it('pins postgres.js to a major Sentry can still instrument', () => {
+    // The externals entry above is necessary but not sufficient: the
+    // integration only patches `>=3.0.0 <4`. A bump to postgres@4 would leave
+    // the config looking correct while DB spans silently stopped, so fail here
+    // instead — loudly, at the moment of the bump.
+    const dbPackageJsonPath = path.join(import.meta.dirname, '../../../db/package.json');
+    const dbPackageJson = JSON.parse(readFileSync(dbPackageJsonPath, 'utf8')) as {
+      dependencies?: Record<string, string>;
+    };
+    const postgresRange = dbPackageJson.dependencies?.postgres;
+
+    expect(postgresRange).toBeDefined();
+    expect(postgresRange).toMatch(new RegExp(`^\\^?${SENTRY_SUPPORTED_POSTGRES_MAJOR}\\.`));
+  });
+});

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -364,6 +364,15 @@ const nextConfig = {
     '@boardsesh/logbook',
     '@boardsesh/email',
   ],
+  // `postgres` (postgres.js, used by @boardsesh/db via drizzle-orm/postgres-js)
+  // must stay OUT of the server bundle. Sentry's postgresJsIntegration patches
+  // the driver through OpenTelemetry's require-hook, which only fires for
+  // modules the bundler leaves external. Neither Next's own externals list nor
+  // @sentry/nextjs's DEFAULT_SERVER_EXTERNAL_PACKAGES includes it — both list
+  // `pg`, which we do not use — so without this line every `db.query` span is
+  // silently missing and Sentry's Queries view is empty with no error anywhere.
+  // withSentryConfig merges rather than replaces this list, so it composes.
+  serverExternalPackages: ['postgres'],
   // Empty turbopack config to silence warning about webpack config
   turbopack: {},
   experimental: {


### PR DESCRIPTION
## Summary

Adds `serverExternalPackages: ['postgres']` to `packages/web/next.config.mjs`.

Sentry's `postgresJsIntegration` patches postgres.js through OpenTelemetry's require-hook, which only fires for modules the bundler leaves external. Neither Next 16's `server-external-packages.jsonc` nor `@sentry/nextjs`'s `DEFAULT_SERVER_EXTERNAL_PACKAGES` lists `postgres` — both list `pg`, which this repo does not use — so Turbopack was bundling it into the server chunk and the hook never ran.

The failure mode is silent: no error, no warning, just an empty **Queries** view in Sentry. That view is what replaces the per-route latency breakdown Vercel Observability Plus gave us, so it has to work before tracing goes on.

Groundwork for the post-Vercel observability work under #4648. Ships alone so the "did DB spans appear?" question has exactly one variable.

**Verified, not assumed:**

- `next/dist/lib/server-external-packages.jsonc` line 67 is `"pg"`; `postgres` is absent.
- `@sentry/nextjs`'s `DEFAULT_SERVER_EXTERNAL_PACKAGES` lists `pg` and `pg-pool`; `postgres` is absent.
- `withSentryConfig` **merges** rather than replaces (`getServerExternalPackagesPatch` → `mergeExternals` spreads `userProvided` before the defaults), so this composes. The exported config resolves to `["postgres", …23 Sentry defaults]`.
- `@sentry/node`'s `postgresJsIntegration` declares `SUPPORTED_VERSIONS = [">=3.0.0 <4"]` and is in `getAutoPerformanceIntegrations()`. This repo pins `postgres@^3.4.9`.

The second test guards that version contract: a bump to `postgres@4` would leave the externals entry looking correct while DB spans quietly stopped.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 1/5 — one build-config key plus two tests. `serverExternalPackages` only moves `postgres` from the server bundle to a runtime require, which is how `@boardsesh/db` already resolves it everywhere else. A full `vp run typecheck:web` (which runs `build:web`) succeeded with the new config. Both new tests were mutation-tested: removing the config key fails the first, bumping `postgres` to `^4.0.0` fails the second.

Note: `vp check` is red on `main` for two pre-existing `restrict-template-expressions` errors in `packages/db/scripts/analyze-led-mapping.ts` — untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVqNy32ChhSYgeEDn4SV63
