### PR TITLE
feat(web): republish the climb sitemaps now that www is off Vercel

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -141,6 +141,23 @@ ENV BOARDSESH_WEB=$BOARDSESH_WEB
 ARG BASE_URL
 ENV BASE_URL=$BASE_URL
 
+# Climb sitemap publication (#4618). Roughly 53,000 URLs, paused since the
+# crawler-driven render and transfer spike, and republished now that www serves
+# from a container instead of Vercel.
+#
+# This is the "on" position of the switch, not a replacement for it. Railway
+# injects service variables into the running container, and those override an
+# image `ENV` of the same name, so the kill switch is a variable on the web
+# service: set `CLIMB_SITEMAPS_ENABLED` to anything other than `true`, redeploy,
+# and every climb shard goes back to a cacheable 410 with no climb entries in
+# /sitemap.xml — no code change, no image rebuild, no revert.
+#
+# Baked here rather than left to the dashboard so the deployed default is in the
+# repository and reviewable. `scripts/production-smoke.ts` verifies the enabled
+# contract against the live origin after every deploy, so an image that lost
+# this line turns a deploy red instead of quietly withdrawing 53,000 URLs.
+ENV CLIMB_SITEMAPS_ENABLED=true
+
 # Create non-root user
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -40,15 +40,16 @@ the route, Vercel and Railway both) reds CI.
 Each one fans out heatmap aggregates against the same Postgres; collapsing them
 onto one minute puts five boards' worth of that load on the database at once.
 
-**`refresh-sitemap-climbs` is the one job that never ran on Vercel.** Climb
-sitemap publication was paused before web moved off the platform, so its
-six-hourly cron was deleted rather than migrated; #4648 republishes the surface
-and brings the schedule back here. `registry.test.ts` keeps it in a separate
-`NATIVE_SCHEDULES` list so the migrated pin above keeps meaning "the slot Vercel
-used". It is overlap-safe the way `JobDefinition` requires: the refresher takes
-`pg_try_advisory_xact_lock` as the first statement of its write transaction, so
-a second run that meets a first in flight answers `skipped: "locked"` and writes
-nothing. See [sitemap.md](./sitemap.md).
+**`refresh-sitemap-climbs` is the one job that missed the migration.** Vercel
+fired it at `0 */6 * * *` from 2026-08-22 until the climb-sitemap pause deleted
+the row on 2026-08-29 (`git show 98ef8e32b -- packages/web/vercel.json`), so by
+the time #4654 moved the crons across there was nothing left to move. #4648
+republishes the surface and brings the same slot back here — which is why it
+sits in `registry.test.ts`'s one pinned list with the rest: the slot really is
+the slot Vercel ran. It is overlap-safe the way `JobDefinition` requires: the
+refresher takes `pg_try_advisory_xact_lock` as the first statement of its write
+transaction, so a second run that meets a first in flight answers
+`skipped: "locked"` and writes nothing. See [sitemap.md](./sitemap.md).
 
 **Why 15 minutes and not 300 seconds.** Both weekly routes still export
 `maxDuration = 300`. That number was never a measurement — it is Vercel's Pro

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -20,7 +20,7 @@ implementation and only the trigger moves.
 
 ## Job ownership
 
-All seven jobs. `packages/scheduler/src/__tests__/registry.test.ts` pins each
+All eight jobs. `packages/scheduler/src/__tests__/registry.test.ts` pins each
 row's path and slot as data, and asserts `packages/web/vercel.json` declares no
 `crons` key at all — so a schedule reappearing there (which would double-fire
 the route, Vercel and Railway both) reds CI.
@@ -34,10 +34,21 @@ the route, Vercel and Railway both) reds CI.
 | `prewarm-heatmap-touchstone` | `/api/internal/prewarm-heatmap/touchstone`  | `45 4 * * 0`   | 15 min      | `scheduler-prewarm-heatmap-touchstone` |
 | `prewarm-heatmap-grasshopper`| `/api/internal/prewarm-heatmap/grasshopper` | `0 5 * * 0`    | 15 min      | `scheduler-prewarm-heatmap-grasshopper`|
 | `profile-percentiles`        | `/api/internal/profile-percentiles`         | `0 6 * * 0`    | 15 min      | `scheduler-profile-percentiles`        |
+| `refresh-sitemap-climbs`     | `/api/internal/refresh-sitemap-climbs`      | `0 */6 * * *`  | 15 min      | `scheduler-refresh-sitemap-climbs`     |
 
 **The 15-minute stagger between the prewarms is a rate limit, not cosmetics.**
 Each one fans out heatmap aggregates against the same Postgres; collapsing them
 onto one minute puts five boards' worth of that load on the database at once.
+
+**`refresh-sitemap-climbs` is the one job that never ran on Vercel.** Climb
+sitemap publication was paused before web moved off the platform, so its
+six-hourly cron was deleted rather than migrated; #4648 republishes the surface
+and brings the schedule back here. `registry.test.ts` keeps it in a separate
+`NATIVE_SCHEDULES` list so the migrated pin above keeps meaning "the slot Vercel
+used". It is overlap-safe the way `JobDefinition` requires: the refresher takes
+`pg_try_advisory_xact_lock` as the first statement of its write transaction, so
+a second run that meets a first in flight answers `skipped: "locked"` and writes
+nothing. See [sitemap.md](./sitemap.md).
 
 **Why 15 minutes and not 300 seconds.** Both weekly routes still export
 `maxDuration = 300`. That number was never a measurement — it is Vercel's Pro
@@ -124,10 +135,11 @@ Do it in this order, or the job silently stops running:
    Vercel WAF / bot rule blocking Railway egress IPs** — nothing local can.
 3. Only then merge the PR that drops the entry from `packages/web/vercel.json`.
 
-Between steps 1 and 3 both schedulers may fire the job. That is safe for all
-seven: `cleanup` deletes rows older than a fixed age in deadline-bounded
-batches, each `prewarm-heatmap` writes the same cache entry twice, and
-`profile-percentiles` is an idempotent recompute-and-upsert.
+Between steps 1 and 3 both schedulers may fire the job. That is safe for every
+job: `cleanup` deletes rows older than a fixed age in deadline-bounded batches,
+each `prewarm-heatmap` writes the same cache entry twice, `profile-percentiles`
+is an idempotent recompute-and-upsert, and `refresh-sitemap-climbs` declines the
+second writer on its advisory lock.
 
 Merging before the Railway service runs the new image pauses the job instead.
 Consequences, in order of how long you can ignore them:
@@ -137,6 +149,10 @@ Consequences, in order of how long you can ignore them:
 - `prewarm-heatmap-*` — the first visitor to each board/angle pays the cold
   query instead of hitting a warm cache. Slow, not broken.
 - `profile-percentiles` — the "top N%" figure on profiles goes a week stale.
+- `refresh-sitemap-climbs` — the climb sitemap store's `<lastmod>` values drift.
+  The `after()` self-heal on `/sitemap.xml` still repopulates a missing or 48-h-old
+  store on the next crawl, so this one degrades to "slower to notice new climbs"
+  rather than to a broken sitemap.
 
 None of these are data loss, but the Sentry monitors will (correctly) raise a
 missed-occurrence issue for each one, which is the signal to finish the cutover.

--- a/docs/sitemap.md
+++ b/docs/sitemap.md
@@ -27,9 +27,18 @@ count into the directory tree.
 
 ## The climb sitemap switch
 
-Climb sitemap publication is paused by default. It is enabled only when the
+Climb sitemaps are **published** (#4648). The surface was paused while www ran on
+Vercel, where ~53,000 URLs of crawl drove a render and transfer spike the platform
+billed by the invocation; the container on Railway has no per-request ceiling to
+buy back, so the pages went out again.
+
+The gate itself stayed, as a kill switch. Publication is on only when the
 server-side environment variable `CLIMB_SITEMAPS_ENABLED` is exactly `true`.
-Unset values and variants such as `1` or `TRUE` stay disabled.
+Unset values and variants such as `1` or `TRUE` read as off. `Dockerfile.web`
+bakes `ENV CLIMB_SITEMAPS_ENABLED=true` into the runner stage, so the deployed
+default lives in the repository; a Railway service variable overrides an image
+`ENV`, so setting it to anything else on the web service and redeploying
+withdraws the whole surface with no code change and no image rebuild.
 
 Disabled mode has one contract across every entry point:
 
@@ -44,9 +53,10 @@ Disabled mode has one contract across every entry point:
   `{ "shard": "climbs", "skipped": "disabled" }` without scanning the database.
   Authentication still runs first, so an unauthenticated request remains `401`.
 
-The tables, refresh code, and enabled read behavior remain in place. Set
-`CLIMB_SITEMAPS_ENABLED=true` to restore publication; all other sitemap shards are
-unaffected by the switch.
+The tables, refresh code, and enabled read behavior remain in place either way,
+and all other sitemap shards are unaffected by the switch. Turning it off and back
+on costs nothing but a redeploy: the store is a cache, and the `after()` self-heal
+below repopulates it on the first crawl.
 
 ## Degrade at the index, fail closed at the shard
 
@@ -105,10 +115,9 @@ stats update no longer makes all six pages look changed. It is strictly
 best-effort — an empty store or a failed aggregate falls back to the shard-wide
 value and never degrades the shard.
 
-Both tables are a **cache, not a source of truth**, and are retained while climb
-sitemaps are paused. When the switch is enabled, truncating them loses no source
-data: the read paths fall back to the live scan they replaced, and the next refresh
-repopulates them.
+Both tables are a **cache, not a source of truth**, and are retained even when the
+switch is off. Truncating them loses no source data: the read paths fall back to the
+live scan they replaced, and the next refresh repopulates them.
 
 ### Read behaviour
 
@@ -148,27 +157,47 @@ So a fallback names itself, on two channels:
 - **A Sentry event**, from `reportStoreFallback` in `climb-store.ts`, at most once
   per reason per instance per six hours (`summary-empty`, `summary-read-failed`,
   `page-empty`, `page-read-failed`). The page-path event fires _before_ the 51 s
-  fallback build, so a Vercel timeout cannot swallow it.
+  fallback build, so a request killed partway through cannot swallow it.
 
-While publication is paused, `scripts/production-smoke.ts` requires this header to
-be absent. It also requires the index to omit climb shard URLs and requires a direct
-climb shard request to return the cacheable 410. Re-enabling the surface therefore
-requires an intentional smoke-test update; changing only an environment variable
-cannot silently restore the crawler load.
+`scripts/production-smoke.ts` asserts this header on every deploy, and the
+assertion is deliberately the inverse of what it used to be. While publication was
+paused the smoke required the header to be **absent**, the index to omit climb
+shard URLs, and a direct climb shard request to return the cacheable 410 — so
+re-enabling the surface could not be done by changing an environment variable
+alone. #4648 flipped all three together in one change: the index must now carry
+climb `<loc>` entries, `/sitemaps/climbs/1.xml` must be a cacheable 200 XML, and
+both must name a source. The tripwire still works in the other direction — an
+image that lost `CLIMB_SITEMAPS_ENABLED` turns the post-deploy smoke red instead
+of silently withdrawing 53,000 URLs. A `live` source is a WARN rather than a FAIL:
+correct, complete, and paying the scan the store exists to retire.
 
 One honest limit, shared with `X-Sitemap-Degraded`: the header rides a CDN-cached
 response. A healthy index is `s-maxage=3600` and the shard pages are
-`s-maxage=21600`, and Vercel's edge ignores the smoke's `Cache-Control: no-cache`
-request header, so the value read can be up to that old in either direction. It is a
-signal that a wedged store gets noticed within the hour, not a live probe. The Sentry
-event has no such lag.
+`s-maxage=21600`, and the edge in front of the origin is free to ignore the smoke's
+`Cache-Control: no-cache` request header, so the value read can be up to that old in
+either direction. It is a signal that a wedged store gets noticed within the hour,
+not a live probe. The Sentry event has no such lag.
 
-### Who refreshes it when enabled
+### Who refreshes it
 
-The former six-hour Vercel cron has been removed while publication is paused.
-There are two refresh paths when `CLIMB_SITEMAPS_ENABLED=true`:
+Three paths, in order of who does the work:
 
-1. **The `after()` self-heal** on `/sitemap.xml` itself. After the response has
+1. **The scheduler.** `refresh-sitemap-climbs` in
+   `packages/scheduler/src/jobs/registry.ts` triggers
+   `/api/internal/refresh-sitemap-climbs` at `0 */6 * * *` UTC with a 15-minute
+   `timeoutMs`, and Sentry raises a missed-occurrence issue on
+   `scheduler-refresh-sitemap-climbs` if a run does not check in. Six hours
+   matches `s-maxage=21600` on the shard pages: refreshing less often would
+   publish `<lastmod>` values the CDN had already aged out, more often would
+   re-run sixteen `DISTINCT ON` scans more frequently than any crawler re-reads
+   the file. `SCHEDULER_DISABLED_JOBS=refresh-sitemap-climbs` unschedules it
+   without a deploy. See [scheduler.md](./scheduler.md).
+
+   This replaces the bespoke one-shot Railway cron service an earlier draft of
+   the runbook called for. The scheduler is that service and already has the
+   monitors, the per-job timeout and the kill switch.
+
+2. **The `after()` self-heal** on `/sitemap.xml` itself. After the response has
    flushed — so it cannot touch the 3 s deadline or the latency a crawler sees — the
    index kicks a refresh if the summary row is missing or past 48 h, **or if
    `sitemap_climb_urls` is empty**. That last probe matters on the deploy that adds
@@ -177,7 +206,7 @@ There are two refresh paths when `CLIMB_SITEMAPS_ENABLED=true`:
    request took the 51 s fallback. Single-flighted per instance behind a 15-minute floor.
    This keeps the enabled surface scheduler-independent: a missing or old store
    degrades to "healed by the next crawl", not to a permanently broken sitemap.
-2. **By hand**, after enabling the switch or a deploy that leaves the store empty:
+3. **By hand**, after re-enabling the switch or a deploy that leaves the store empty:
 
    ```
    curl --fail-with-body --silent --show-error \
@@ -185,38 +214,52 @@ There are two refresh paths when `CLIMB_SITEMAPS_ENABLED=true`:
      https://www.boardsesh.com/api/internal/refresh-sitemap-climbs
    ```
 
-   The `after()` hook fires on the first enabled `/sitemap.xml` request, so the curl
-   is not required. It closes the window immediately and reports refusals directly:
-   a 409 prints why the refresh was declined and exits non-zero, while the self-heal
-   only writes that to the log. While the switch is disabled, the same authenticated
-   curl returns `skipped: "disabled"` and performs no scan.
+   Neither the scheduler nor the `after()` hook makes this necessary — both fire
+   on their own — but it closes the window immediately and reports refusals
+   directly: a 409 prints why the refresh was declined and exits non-zero, while
+   the self-heal only writes that to the log. While the switch is off, the same
+   authenticated curl returns `skipped: "disabled"` and performs no scan.
 
-### Railway re-enable runbook
+### Post-deploy verification, and the way back
 
-1. In the cutover change, update the production smoke contract from paused/410 to
-   enabled/store so that the same deployment verifies the intended state.
-2. Set `CLIMB_SITEMAPS_ENABLED=true` and `CRON_SECRET` on the Railway web service,
-   then deploy the cutover before starting a scheduler.
-3. Run the Node validator command in step 4 once from a shell with both variables
-   set. Continue only after it exits zero; it rejects non-200 responses, disabled or
-   concurrent skips, invalid JSON, empty results, and timeouts.
-4. Create a separate one-shot Railway cron service from this repository. Give it
-   `BOARDSESH_WEB_ORIGIN` and a reference to the web service's `CRON_SECRET`, set
-   its UTC schedule to `0 */6 * * *`, and use this exact start command:
+Publication is on, so there is no re-enable to run. What follows is the check
+list for a deploy that touches this surface and the way to withdraw it again.
 
-   ```sh
-   node -e 'const origin=process.env.BOARDSESH_WEB_ORIGIN;const secret=process.env.CRON_SECRET;if(!origin||!secret)throw new Error("missing BOARDSESH_WEB_ORIGIN or CRON_SECRET");fetch(new URL("/api/internal/refresh-sitemap-climbs",origin),{headers:{Authorization:`Bearer ${secret}`},signal:AbortSignal.timeout(330000)}).then(async response=>{const body=await response.text();console.log(body);const payload=JSON.parse(body);if(!response.ok||payload.shard!=="climbs"||payload.skipped!==null||!Number.isInteger(payload.itemCount)||payload.itemCount<1)throw new Error(`refresh rejected: HTTP ${response.status}`)}).catch(error=>{console.error(error);process.exitCode=1})'
-   ```
+**After a deploy**, `production-smoke.ts` already asserts the shape: the index
+lists `/sitemaps/climbs/1.xml`, the shard answers 200 XML, and both name a
+source. Read the source it reports. `store` is healthy; `live` is a WARN that
+means the store is empty or unreadable and every page fetch behind it is
+rebuilding the whole ordered list, so trigger a refresh by hand and confirm it
+comes back `store`:
 
-   The command exits zero only after a stored, non-empty refresh. It exits non-zero
-   on HTTP errors, refusal bodies, missing configuration, invalid JSON, or timeout.
-   It must terminate after each run; Railway skips later schedules while an earlier
-   cron process remains active. Do not attach this schedule to the web service and
-   do not restore the Vercel cron.
-5. Verify `/sitemap.xml` includes `/sitemaps/climbs/1.xml` with
-   `X-Sitemap-Climbs-Source: store`, then verify that direct shard returns HTTP 200
-   XML with the same source header. Confirm the scheduler's next run succeeds before
-   removing migration monitoring.
+```sh
+curl --fail-with-body --silent --show-error \
+  -H "Authorization: Bearer $CRON_SECRET" \
+  https://www.boardsesh.com/api/internal/refresh-sitemap-climbs
+```
+
+A stored, non-empty refresh answers 200 with `"skipped": null` and an
+`itemCount` in the tens of thousands. A 409 names the refusal — see the table
+below — and leaves both tables untouched.
+
+**Watch, for the first day**, the two open connection-pressure issues (#4842,
+#4861) that this surface's crawl load feeds: `/health/db`, the web service's 500
+rate, and `pg_stat_activity` web connections.
+
+**To withdraw the surface again**, set `CLIMB_SITEMAPS_ENABLED` to `false` on
+the Railway `web` service (Variables → the web service → deploy the staged
+change). The service variable overrides the image `ENV`, so this takes effect on
+the next deploy with no code change and no rebuild. Within one CDN window the
+index stops listing climb pages and `/sitemaps/climbs/*.xml` returns the
+cacheable 410. The store keeps its rows; nothing needs repopulating on the way
+back. The post-deploy smoke will then go red on the enabled contract, which is
+the intended tripwire — flip the smoke back in the same change if the withdrawal
+is meant to last.
+
+**Do not** re-add a schedule to `packages/web/vercel.json`, and do not stand up
+a second cron service: the refresh runs on the Railway scheduler
+(`refresh-sitemap-climbs`), and `registry.test.ts` reds if a path is scheduled
+on both sides.
 
 ### Refusals, and how to get out of one
 
@@ -276,8 +319,11 @@ computations of the production index on 2026-08-19, `playlists` was named in
 It gets the boards treatment, not the climbs treatment, and the difference is a size
 question. The rows are the whole answer and they are small: 2,688 rows of
 `{ uuid, updatedAtIso }` is ~200 KB of JSON, ~840 KB at the hard `MAX_ITEMS_PER_SHARD`
-cap, against Vercel's 2 MB Data Cache entry ceiling. The climb item list is >10 MB,
-which is the only reason it needed the Postgres-backed store instead. So
+cap. That was measured against Vercel's 2 MB Data Cache entry ceiling; off Vercel the
+thing to stay small against is the standalone server's in-process incremental-cache
+budget, and a megabyte of rows fits where the climb item list (>10 MB) would evict
+everything around it. That size gap is the whole reason climbs needed the
+Postgres-backed store instead. So
 playlists caches the answer, which fixes the index _and_ `/sitemaps/playlists.xml`;
 a summary would have fixed only the index.
 
@@ -312,8 +358,9 @@ On a first-population miss, `unstable_cache` registers its cache write in
 `workStore.pendingRevalidates` only **after** the callback resolves, while the route
 module snapshots `Object.values(workStore.pendingRevalidates)` into `pendingWaitUntil`
 at response time. An index that abandoned the query at the 3 s deadline has already
-returned, so its eventual write goes into an array nobody is holding and a freezing
-Vercel instance can drop it — and the next request misses again. Running the same
+returned, so its eventual write goes into an array nobody is holding and a container
+that restarts or a serverless instance that freezes drops it — and the next request
+misses again. Running the same
 fetch inside `after()` puts it under `withExecuteRevalidates`, whose `finally` diffs
 the store and awaits writes that appeared while the callbacks ran. The abandoned
 query is covered too, because the warm shares its in-flight promise.
@@ -339,27 +386,43 @@ and fails every connection (`packages/db/src/client/postgres.ts`, `docs/db-conne
 
 ## What is still slow
 
-When enabled, `/sitemaps/climbs/N.xml` is fixed (#4552) — a stored page reads in
+`/sitemaps/climbs/N.xml` is fixed (#4552) — a stored page reads in
 milliseconds. What remains slow is the **fallback**: an empty
 `sitemap_climb_urls` (a truncation or local dev) still takes the 51 s live build until
 the first refresh runs. The self-heal's empty-table probe bounds that window to one
 crawl of `/sitemap.xml`; the manual curl closes it immediately. Disabled requests do
 not reach either path; they return the cacheable 410.
 
-Fixed shards have **no byte budget**. `shardRouteHandler` checks `MAX_URLS_PER_SHARD`
-on the fixed path but never `MAX_SHARD_BYTES` — that guard exists only on the paged
-path. `/sitemaps/playlists.xml` already renders 2,326,713 bytes for 2,688 items
-(~866 B/item), so it crosses Vercel's 4.5 MB response ceiling at roughly 5,200 items
-while `MAX_ITEMS_PER_SHARD` lets it reach 11,250. Tracked separately.
+Fixed shards have **no byte budget**. `shardRouteHandler` checks
+`MAX_URLS_PER_SHARD` and nothing else; `MAX_SHARD_BYTES` is enforced only on the
+paged path. That was #4618, and leaving Vercel is what closed it — the gap was
+never the missing check, it was that Vercel's ceiling sat *below* what the URL cap
+allowed.
+
+The arithmetic, re-measured on www on 2026-09-02. `/sitemaps/playlists.xml` serves
+2,615,676 bytes across 3,020 `<url>` entries: **866 bytes per URL** for an
+`all-locales` shard, dominated by the five-entry `xhtml:link` block. (#4618 records
+~216 B/URL, from before the alternates block existed, so every row in its table
+understates the cost by about four times.) At 866 B/URL the worst case a fixed shard
+can reach is `MAX_URLS_PER_SHARD` × 866 B ≈ **39 MB** — inside sitemaps.org's 50 MB.
+Against Vercel's 4.5 MB it was not: the URL cap permitted a body nine times what the
+platform could return, and the failure was a truncation rather than the
+503-and-retry the design intends.
+
+Two things follow, neither urgent. `MAX_ITEMS_PER_SHARD` (11,250) is the only cap
+the fixed path applies and it allows ~39 MB — a lot of file to hand a crawler even
+when it is legal. And a per-shard byte budget is what would let the fixed path share
+the paged guard without 503ing a shard that is merely large.
 
 ## Operational gotchas
 
-- **After enabling, a deploy that changes climb URL shape needs a manual refresh.**
+- **A deploy that changes climb URL shape needs a manual refresh.**
   `sitemap_climb_urls.path` is rendered at refresh time, so new URL logic keeps
-  serving the old shape until the store is stale enough for the self-heal or someone
-  runs the curl above. The old URLs still resolve and point at the climb's selected
-  canonical angle, so
-  this is a staleness window, not an outage.
-- **`scripts/production-smoke.ts` pins the paused state.** It fails if climb URLs
-  or source headers return, and it requires the direct shard's cacheable 410. The
-  Railway cutover must update that contract alongside the environment switch.
+  serving the old shape until the next scheduled run, the self-heal's staleness
+  threshold, or someone runs the curl above. The old URLs still resolve and point at
+  the climb's selected canonical angle, so this is a staleness window, not an outage.
+- **`scripts/production-smoke.ts` pins the published state.** It fails if the index
+  stops listing climb pages, if the shard stops answering 200 XML, or if either
+  drops its source header. Withdrawing the surface therefore takes a smoke change
+  as well as the environment variable — the same tripwire that used to point the
+  other way.

--- a/docs/sitemap.md
+++ b/docs/sitemap.md
@@ -256,6 +256,18 @@ back. The post-deploy smoke will then go red on the enabled contract, which is
 the intended tripwire — flip the smoke back in the same change if the withdrawal
 is meant to last.
 
+**A DNS rollback to Vercel withdraws this surface.** `CLIMB_SITEMAPS_ENABLED`
+is baked into `Dockerfile.web`, which only the Railway image build reads, and
+`WEB_DEPLOY_TARGETS` still lists `vercel` for the rollback window
+([production-deploy.md](./production-deploy.md#web-deploy-targets)). So the
+Vercel deployment serves the withdrawn contract — no climb entries in the index,
+410 from `/sitemaps/climbs/*.xml` — and rolling www back to it drops ~53,000
+URLs until `CLIMB_SITEMAPS_ENABLED=true` is set on the Vercel project and it
+redeploys. That deployment's `/sitemap.xml` also runs on the platform's default
+function duration now that #4648 removed `maxDuration = 300`, which was the
+Vercel Pro ceiling. Nothing catches either: the Vercel post-deploy smoke is
+commented out in `production-deploy.yml`.
+
 **Do not** re-add a schedule to `packages/web/vercel.json`, and do not stand up
 a second cron service: the refresh runs on the Railway scheduler
 (`refresh-sitemap-climbs`), and `registry.test.ts` reds if a path is scheduled
@@ -393,26 +405,36 @@ the first refresh runs. The self-heal's empty-table probe bounds that window to 
 crawl of `/sitemap.xml`; the manual curl closes it immediately. Disabled requests do
 not reach either path; they return the cacheable 410.
 
-Fixed shards have **no byte budget**. `shardRouteHandler` checks
-`MAX_URLS_PER_SHARD` and nothing else; `MAX_SHARD_BYTES` is enforced only on the
-paged path. That was #4618, and leaving Vercel is what closed it — the gap was
-never the missing check, it was that Vercel's ceiling sat *below* what the URL cap
-allowed.
+Both shard paths now check bytes, and they check different numbers on purpose
+(#4618, closed by #4648).
+
+`MAX_SHARD_BYTES` (45 MB) is the **protocol backstop** on any file, fixed or
+paged: sitemaps.org rejects one over 50 MB uncompressed and Search Console
+rejects it whole rather than reading part of it, so 503-and-retry beats serving
+it. 45 MB is that limit with the same 10% headroom `MAX_URLS_PER_SHARD` keeps
+against 50,000 URLs. Until #4648 the fixed path had no byte check at all, and the
+constant it was missing was Vercel's 4.5 MB response ceiling — a number *below*
+what the URL cap allowed, which is what made #4618 a bug rather than a gap.
+
+`pagedShardByteBudget(urlsPerShard)` is the **working guard** on a paged page:
+its own page size at 500 bytes/URL, so the climbs pages get 5 MB rather than 45.
+A ceiling eighteen times the page it guards cannot see the regression that
+matters, which is a per-URL cost that multiplied rather than a shard that grew.
 
 The arithmetic, re-measured on www on 2026-09-02. `/sitemaps/playlists.xml` serves
 2,615,676 bytes across 3,020 `<url>` entries: **866 bytes per URL** for an
 `all-locales` shard, dominated by the five-entry `xhtml:link` block. (#4618 records
 ~216 B/URL, from before the alternates block existed, so every row in its table
-understates the cost by about four times.) At 866 B/URL the worst case a fixed shard
-can reach is `MAX_URLS_PER_SHARD` × 866 B ≈ **39 MB** — inside sitemaps.org's 50 MB.
-Against Vercel's 4.5 MB it was not: the URL cap permitted a body nine times what the
-platform could return, and the failure was a truncation rather than the
-503-and-retry the design intends.
+understates the cost by about four times.) A climbs page is `default-locale-only`
+with no alternates block and costs ~250 B/URL, so fanning it out to locales — the
+change `entries.ts` warns against — would take a page from 2.5 MB to 8.7 MB. That
+is what the 5 MB page budget catches and a 45 MB one would not.
 
-Two things follow, neither urgent. `MAX_ITEMS_PER_SHARD` (11,250) is the only cap
-the fixed path applies and it allows ~39 MB — a lot of file to hand a crawler even
-when it is legal. And a per-shard byte budget is what would let the fixed path share
-the paged guard without 503ing a shard that is merely large.
+One thing still follows, not urgent: at 866 B/URL, `MAX_ITEMS_PER_SHARD` (11,250
+items → 45,000 URLs) lets a fixed shard reach ~**39 MB**. That is legal and it
+still serves, and it is a lot of file to hand a crawler. Paging `playlists` onto
+the `PagedSitemapShard` machinery — which would give it a page-sized budget the
+way climbs has one — is #5073.
 
 ## Operational gotchas
 

--- a/docs/web-reposition.md
+++ b/docs/web-reposition.md
@@ -526,12 +526,15 @@ _second_, non-reciprocal signal for the same cluster — strictly worse than non
 `/profile/[user_id]` already gets exactly this treatment.
 
 **The byte guard runs on the rendered body, not on a row count.**
-`CLIMB_URLS_PER_SHARD` is 10,000 (~2.5 MB at our path lengths) and
-`MAX_SHARD_BYTES` is 4,000,000. A constant that nothing measures is a comment, so
+`CLIMB_URLS_PER_SHARD` is 10,000 (~2.5 MB at our path lengths), and the page it
+renders is checked against `pagedShardByteBudget()` — its page size at 500
+bytes/URL, so 5 MB. A constant that nothing measures is a comment, so
 `pagedShardRouteHandler` byte-lengths the XML it is about to serve and 503s
-instead of letting Vercel truncate a 200 into something that looks like a sitemap
-outage. `MAX_URLS_PER_SHARD` (45,000) stays as the protocol guard for the fixed
-shards.
+instead of serving a page whose per-URL cost multiplied. Off Vercel (#4648) the
+budget is no longer the platform's 4.5 MB response ceiling: `MAX_SHARD_BYTES`
+(45 MB) is now the protocol backstop on *both* paths, and `shardRouteHandler`
+checks it too (#4618). `MAX_URLS_PER_SHARD` (45,000) stays as the protocol URL
+guard for the fixed shards.
 
 **Shard shape is count-driven.** `app/sitemaps/climbs/[page]/route.ts` serves
 `/sitemaps/climbs/1.xml … N.xml`; `N` comes from a cached summary at request

--- a/packages/scheduler/src/__tests__/cron-monitor.test.ts
+++ b/packages/scheduler/src/__tests__/cron-monitor.test.ts
@@ -44,7 +44,7 @@ describe('monitorSlugForJob', () => {
   it('pins the exact slug of every registered job', () => {
     // Sentry keys a monitor's entire history on its slug. A renamed job would
     // silently orphan the monitor that holds this job's check-in history and
-    // start a fresh one, so the seven live slugs are pinned as data.
+    // start a fresh one, so every live slug is pinned as data.
     expect(JOBS.map((job) => monitorSlugForJob(job.name))).toEqual([
       'scheduler-cleanup',
       'scheduler-prewarm-heatmap-kilter',
@@ -53,6 +53,7 @@ describe('monitorSlugForJob', () => {
       'scheduler-prewarm-heatmap-touchstone',
       'scheduler-prewarm-heatmap-grasshopper',
       'scheduler-profile-percentiles',
+      'scheduler-refresh-sitemap-climbs',
     ]);
   });
 });
@@ -70,7 +71,8 @@ describe('monitorConfigForJob', () => {
     // Pinned as literals on purpose. Asserting `config.schedule.value ===
     // job.schedule` would derive both sides from the same field and pass no
     // matter what the schedule became — it would only prove the function
-    // copies a string. These are the seven slots Vercel used, so a registry
+    // copies a string. Seven of these are the slots Vercel used and the eighth
+    // is the six-hourly sitemap refresh #4648 brought back, so a registry
     // schedule edited without a deliberate change here reds, and Sentry can
     // never be left waiting on a minute the ticker does not fire.
     const configBySlug = Object.fromEntries(JOBS.map((job) => [monitorSlugForJob(job.name), monitorConfigForJob(job)]));
@@ -85,6 +87,7 @@ describe('monitorConfigForJob', () => {
       'scheduler-prewarm-heatmap-touchstone': '45 4 * * 0',
       'scheduler-prewarm-heatmap-grasshopper': '0 5 * * 0',
       'scheduler-profile-percentiles': '0 6 * * 0',
+      'scheduler-refresh-sitemap-climbs': '0 */6 * * *',
     });
 
     for (const config of Object.values(configBySlug)) {

--- a/packages/scheduler/src/__tests__/registry.test.ts
+++ b/packages/scheduler/src/__tests__/registry.test.ts
@@ -11,12 +11,19 @@ const vercelConfig = JSON.parse(readFileSync(vercelConfigUrl, 'utf8')) as Vercel
 const vercelCronPaths = (vercelConfig.crons ?? []).map((cron) => cron.path);
 
 /**
- * Every path the scheduler inherited from `vercel.json`, with the exact slot it
- * came over on. Pinned as data rather than derived from {@link JOBS}, so a
- * typo'd minute or a job quietly dropped from the registry reds instead of
- * being re-derived into agreement with itself.
+ * Every path Vercel used to fire, with the exact slot it ran on. Pinned as data
+ * rather than derived from {@link JOBS}, so a typo'd minute or a job quietly
+ * dropped from the registry reds instead of being re-derived into agreement
+ * with itself.
+ *
+ * `refresh-sitemap-climbs` is here for the same reason as the rest even though
+ * it did not travel with them: Vercel ran it on the six-hourly slot pinned
+ * below, from 2026-08-22 until the climb-sitemap pause deleted the row on
+ * 2026-08-29 — before #4654 moved the remaining crons across. #4648
+ * republishes the surface and brings that slot back, so the pin still means
+ * what it says.
  */
-const MIGRATED_SCHEDULES: readonly (readonly [job: string, path: string, schedule: string])[] = [
+const VERCEL_SCHEDULES: readonly (readonly [job: string, path: string, schedule: string])[] = [
   ['cleanup', '/api/internal/cleanup', '0 5 * * *'],
   ['prewarm-heatmap-kilter', '/api/internal/prewarm-heatmap/kilter', '0 4 * * 0'],
   ['prewarm-heatmap-tension', '/api/internal/prewarm-heatmap/tension', '15 4 * * 0'],
@@ -24,22 +31,8 @@ const MIGRATED_SCHEDULES: readonly (readonly [job: string, path: string, schedul
   ['prewarm-heatmap-touchstone', '/api/internal/prewarm-heatmap/touchstone', '45 4 * * 0'],
   ['prewarm-heatmap-grasshopper', '/api/internal/prewarm-heatmap/grasshopper', '0 5 * * 0'],
   ['profile-percentiles', '/api/internal/profile-percentiles', '0 6 * * 0'],
-];
-
-/**
- * Jobs that never had a `vercel.json` row to inherit. `refresh-sitemap-climbs`
- * is the first: climb sitemap publication was paused before web left Vercel, so
- * the six-hourly cron was deleted rather than migrated, and #4648 brings the
- * schedule back on this side only.
- *
- * Kept as a separate list so the pin above keeps meaning what it says — a slot
- * that must match what Vercel ran — while {@link JOBS} is still pinned whole.
- */
-const NATIVE_SCHEDULES: readonly (readonly [job: string, path: string, schedule: string])[] = [
   ['refresh-sitemap-climbs', '/api/internal/refresh-sitemap-climbs', '0 */6 * * *'],
 ];
-
-const ALL_SCHEDULES = [...MIGRATED_SCHEDULES, ...NATIVE_SCHEDULES];
 
 describe('job registry', () => {
   it('has unique job names', () => {
@@ -92,19 +85,14 @@ describe('job registry', () => {
     expect([...vercelCronPaths].sort()).toEqual([...VERCEL_OWNED_CRON_PATHS].sort());
   });
 
-  it('runs every job on its pinned slot, migrated or not', () => {
+  it('runs every path on the exact slot vercel.json used', () => {
+    // `refresh-sitemap-climbs` included: `s-maxage=21600` on the shard pages is
+    // why six hours was the right slot on Vercel and is still the right slot
+    // here — longer publishes `<lastmod>` values the CDN has already aged out,
+    // shorter re-scans sixteen `DISTINCT ON` groups against production Postgres
+    // more often than any crawler re-reads the file.
     const actual = JOBS.map((job) => [job.name, job.webPath, job.schedule]);
-    expect(actual).toEqual(ALL_SCHEDULES.map((row) => [...row]));
-  });
-
-  it('keeps the climb sitemap refresh on its own six-hourly slot', () => {
-    // The shard pages are served under `s-maxage=21600`, so a refresh interval
-    // longer than six hours would publish `<lastmod>` values the CDN had already
-    // aged out, and a shorter one would re-scan sixteen `DISTINCT ON` groups
-    // against production Postgres more often than any crawler re-reads the file.
-    const refresh = findJob('refresh-sitemap-climbs');
-    expect(refresh?.schedule).toBe('0 */6 * * *');
-    expect(refresh?.webPath).toBe('/api/internal/refresh-sitemap-climbs');
+    expect(actual).toEqual(VERCEL_SCHEDULES.map((row) => [...row]));
   });
 
   it('keeps the five heatmap prewarms staggered rather than firing them together', () => {

--- a/packages/scheduler/src/__tests__/registry.test.ts
+++ b/packages/scheduler/src/__tests__/registry.test.ts
@@ -11,8 +11,8 @@ const vercelConfig = JSON.parse(readFileSync(vercelConfigUrl, 'utf8')) as Vercel
 const vercelCronPaths = (vercelConfig.crons ?? []).map((cron) => cron.path);
 
 /**
- * Every path the scheduler now owns, with the exact slot it inherited from
- * `vercel.json`. Pinned as data rather than derived from {@link JOBS}, so a
+ * Every path the scheduler inherited from `vercel.json`, with the exact slot it
+ * came over on. Pinned as data rather than derived from {@link JOBS}, so a
  * typo'd minute or a job quietly dropped from the registry reds instead of
  * being re-derived into agreement with itself.
  */
@@ -25,6 +25,21 @@ const MIGRATED_SCHEDULES: readonly (readonly [job: string, path: string, schedul
   ['prewarm-heatmap-grasshopper', '/api/internal/prewarm-heatmap/grasshopper', '0 5 * * 0'],
   ['profile-percentiles', '/api/internal/profile-percentiles', '0 6 * * 0'],
 ];
+
+/**
+ * Jobs that never had a `vercel.json` row to inherit. `refresh-sitemap-climbs`
+ * is the first: climb sitemap publication was paused before web left Vercel, so
+ * the six-hourly cron was deleted rather than migrated, and #4648 brings the
+ * schedule back on this side only.
+ *
+ * Kept as a separate list so the pin above keeps meaning what it says — a slot
+ * that must match what Vercel ran — while {@link JOBS} is still pinned whole.
+ */
+const NATIVE_SCHEDULES: readonly (readonly [job: string, path: string, schedule: string])[] = [
+  ['refresh-sitemap-climbs', '/api/internal/refresh-sitemap-climbs', '0 */6 * * *'],
+];
+
+const ALL_SCHEDULES = [...MIGRATED_SCHEDULES, ...NATIVE_SCHEDULES];
 
 describe('job registry', () => {
   it('has unique job names', () => {
@@ -77,9 +92,19 @@ describe('job registry', () => {
     expect([...vercelCronPaths].sort()).toEqual([...VERCEL_OWNED_CRON_PATHS].sort());
   });
 
-  it('runs every migrated path on the exact slot vercel.json used', () => {
+  it('runs every job on its pinned slot, migrated or not', () => {
     const actual = JOBS.map((job) => [job.name, job.webPath, job.schedule]);
-    expect(actual).toEqual(MIGRATED_SCHEDULES.map((row) => [...row]));
+    expect(actual).toEqual(ALL_SCHEDULES.map((row) => [...row]));
+  });
+
+  it('keeps the climb sitemap refresh on its own six-hourly slot', () => {
+    // The shard pages are served under `s-maxage=21600`, so a refresh interval
+    // longer than six hours would publish `<lastmod>` values the CDN had already
+    // aged out, and a shorter one would re-scan sixteen `DISTINCT ON` groups
+    // against production Postgres more often than any crawler re-reads the file.
+    const refresh = findJob('refresh-sitemap-climbs');
+    expect(refresh?.schedule).toBe('0 */6 * * *');
+    expect(refresh?.webPath).toBe('/api/internal/refresh-sitemap-climbs');
   });
 
   it('keeps the five heatmap prewarms staggered rather than firing them together', () => {
@@ -91,10 +116,11 @@ describe('job registry', () => {
     expect(prewarmSlots).toHaveLength(5);
   });
 
-  it('gives the weekly warm-ups more than the 300s Vercel capped them at', () => {
+  it('gives the long jobs more than the 300s Vercel capped them at', () => {
     // These routes were pinned at Vercel's Pro maximum, not at a measured
-    // duration. Dropping the scheduler timeout back to 300s would re-impose a
-    // limit the platform no longer forces on us.
+    // duration — `refresh-sitemap-climbs` included, whose route still exports
+    // it. Dropping the scheduler timeout back to 300s would re-impose a limit
+    // the platform no longer forces on us.
     for (const job of JOBS.filter((candidate) => candidate.name !== 'cleanup')) {
       expect(job.timeoutMs, `${job.name} timeoutMs`).toBeGreaterThan(300_000);
     }

--- a/packages/scheduler/src/jobs/registry.ts
+++ b/packages/scheduler/src/jobs/registry.ts
@@ -118,12 +118,14 @@ export const JOBS: readonly JobDefinition[] = [
     run: triggerWebCron('/api/internal/profile-percentiles'),
   },
 
-  // The first job that never ran on Vercel at all. Climb sitemap publication
-  // was paused before web moved off Vercel, so its six-hourly cron was deleted
-  // rather than migrated; #4648 republishes the surface and this is where the
-  // schedule comes back. docs/sitemap.md's runbook used to call for a separate
-  // one-shot Railway cron service — this is that service, except it already
-  // exists, already has Sentry monitors, and already has a disable switch.
+  // The one job that missed the #4654 migration. Vercel ran this cron at
+  // `0 */6 * * *` from 2026-08-22 until the pause deleted the row on 2026-08-29
+  // (`git show 98ef8e32b -- packages/web/vercel.json`), so by the time the crons
+  // moved to the scheduler there was nothing left in `vercel.json` to carry
+  // over. #4648 republishes the surface and brings the same slot back here.
+  // docs/sitemap.md's runbook used to call for a separate one-shot Railway cron
+  // service — this is that service, except it already exists, already has
+  // Sentry monitors, and already has a disable switch.
   //
   // Overlap-safe, which JobDefinition requires: the refresher takes
   // `pg_try_advisory_xact_lock` as the first statement of its write
@@ -131,8 +133,8 @@ export const JOBS: readonly JobDefinition[] = [
   // `skipped: "locked"` and writes nothing.
   {
     name: 'refresh-sitemap-climbs',
-    // Six-hourly, the slot the deleted Vercel cron used, against a shard whose
-    // pages the CDN holds for six hours anyway.
+    // Six-hourly, the slot Vercel ran this on, against a shard whose pages the
+    // CDN holds for six hours anyway.
     schedule: '0 */6 * * *',
     // Load-bearing for the same reason as every row above: a container's local
     // zone is not guaranteed to be UTC, and `0 */6 * * *` evaluated somewhere

--- a/packages/scheduler/src/jobs/registry.ts
+++ b/packages/scheduler/src/jobs/registry.ts
@@ -33,6 +33,22 @@ const CLEANUP_TIMEOUT_MS = 120_000;
  */
 const WEEKLY_WARMUP_TIMEOUT_MS = 900_000;
 
+/**
+ * The climb sitemap refresh scans sixteen `(board_type, layout_id)` groups
+ * sequentially — deliberately sequential, because concurrent `DISTINCT ON`
+ * scans against a ten-connection pool is the #4461 starvation — and then writes
+ * ~53,000 URL rows in 1,000-row chunks inside one transaction. Measured on the
+ * full-board dev image the largest single group alone is 16.7 s cold, and the
+ * whole build was 51 s in production (#4552).
+ *
+ * The route still exports `maxDuration = 300`, so on Vercel it would be cut off
+ * first; off Vercel that export is inert and this is the only bound. 15 minutes
+ * — the same headroom the weekly warm-ups get — leaves a cold, contended run
+ * room to finish rather than turning a slow refresh into a failed one, and a
+ * genuinely wedged scan still cannot outlive the six-hour gap to the next tick.
+ */
+const SITEMAP_REFRESH_TIMEOUT_MS = 900_000;
+
 export const JOBS: readonly JobDefinition[] = [
   {
     name: 'cleanup',
@@ -100,6 +116,31 @@ export const JOBS: readonly JobDefinition[] = [
     timeoutMs: WEEKLY_WARMUP_TIMEOUT_MS,
     webPath: '/api/internal/profile-percentiles',
     run: triggerWebCron('/api/internal/profile-percentiles'),
+  },
+
+  // The first job that never ran on Vercel at all. Climb sitemap publication
+  // was paused before web moved off Vercel, so its six-hourly cron was deleted
+  // rather than migrated; #4648 republishes the surface and this is where the
+  // schedule comes back. docs/sitemap.md's runbook used to call for a separate
+  // one-shot Railway cron service — this is that service, except it already
+  // exists, already has Sentry monitors, and already has a disable switch.
+  //
+  // Overlap-safe, which JobDefinition requires: the refresher takes
+  // `pg_try_advisory_xact_lock` as the first statement of its write
+  // transaction, so a second run that meets a first in flight answers
+  // `skipped: "locked"` and writes nothing.
+  {
+    name: 'refresh-sitemap-climbs',
+    // Six-hourly, the slot the deleted Vercel cron used, against a shard whose
+    // pages the CDN holds for six hours anyway.
+    schedule: '0 */6 * * *',
+    // Load-bearing for the same reason as every row above: a container's local
+    // zone is not guaranteed to be UTC, and `0 */6 * * *` evaluated somewhere
+    // else drifts the refresh off the window the cache expiry assumes.
+    timezone: 'UTC',
+    timeoutMs: SITEMAP_REFRESH_TIMEOUT_MS,
+    webPath: '/api/internal/refresh-sitemap-climbs',
+    run: triggerWebCron('/api/internal/refresh-sitemap-climbs'),
   },
 ];
 

--- a/packages/web/app/__tests__/rest-surface-inventory.test.ts
+++ b/packages/web/app/__tests__/rest-surface-inventory.test.ts
@@ -231,13 +231,19 @@ describe('REST surface inventory (issue #1889)', () => {
     expect(readCronPaths()).toEqual([]);
   });
 
-  it('schedules the climb sitemap refresh on the scheduler, never on Vercel', () => {
+  it('never lets the climb sitemap refresh back into vercel.json', () => {
     // Inverted by #4648. While climb sitemaps were paused this asserted the
     // refresh had no schedule at all; now that publication is on it needs one,
     // and it needs to be the Railway scheduler's — the runbook's alternative
     // was a bespoke one-shot Railway cron service, which would have been a
-    // second scheduler with no monitors and no disable switch.
-    expect(SCHEDULER_CRON_PATHS).toContain('/api/internal/refresh-sitemap-climbs');
+    // second scheduler with no monitors and no disable switch. Vercel ran this
+    // path itself until the pause deleted the row, so re-adding it there is a
+    // plausible mistake rather than a theoretical one, and it would double-fire
+    // a refresh that scans sixteen `DISTINCT ON` groups.
+    //
+    // That the scheduler owns it is asserted where the registry lives
+    // (`packages/scheduler/src/__tests__/registry.test.ts`); asserting it
+    // against this file's own list would only prove the list says what it says.
     expect(readCronPaths()).not.toContain('/api/internal/refresh-sitemap-climbs');
   });
 

--- a/packages/web/app/__tests__/rest-surface-inventory.test.ts
+++ b/packages/web/app/__tests__/rest-surface-inventory.test.ts
@@ -17,7 +17,7 @@
  *    (`expect(derived).toContain(...)`) would silently survive, which is why
  *    both directions are asserted.
  *  - A scheduled cron target labelled as if in-repo code called it reds a third
- *    check, which walks the scheduler's seven URLs rather than trusting the
+ *    check, which walks every URL the scheduler fires rather than trusting the
  *    comment next to the row. Set equality alone never looks at verdicts.
  *
  * This file reads the API tree with readdirSync at run time, so nothing
@@ -77,8 +77,10 @@ const VERDICTS: Record<string, Verdict> = {
   'app/api/internal/cleanup/route.ts': 'keep-external',
   'app/api/internal/prewarm-heatmap/[board_name]/route.ts': 'keep-external',
   'app/api/internal/profile-percentiles/route.ts': 'keep-external',
-  // Retained for a manual initial refresh when Railway takes over scheduling.
-  // It must remain absent from Vercel's scheduler while climb sitemaps are paused.
+  // Now a scheduler cron target like the three above: the `refresh-sitemap-climbs`
+  // job fires it every six hours (#4648). Still reachable by hand for the initial
+  // refresh after a re-enable, which is why it also answers a bare authenticated
+  // curl. Absent from vercel.json, like every other cron.
   'app/api/internal/refresh-sitemap-climbs/route.ts': 'keep-external',
   'app/api/internal/beta-link-thumbnail/route.ts': 'keep-caller',
   'app/api/internal/revalidate-climb/route.ts': 'keep-caller',
@@ -148,7 +150,7 @@ function readCronPaths(): string[] {
  * The URLs the Railway scheduler triggers on a timer (#4654). Kept in step with
  * `packages/scheduler/src/jobs/registry.ts` by hand: this test lives in the web
  * package and must not reach across into the scheduler's source, and the
- * scheduler's registry.test.ts pins the identical seven rows on its side.
+ * scheduler's registry.test.ts pins the identical rows on its side.
  */
 const SCHEDULER_CRON_PATHS: readonly string[] = [
   '/api/internal/cleanup',
@@ -158,6 +160,7 @@ const SCHEDULER_CRON_PATHS: readonly string[] = [
   '/api/internal/prewarm-heatmap/touchstone',
   '/api/internal/prewarm-heatmap/grasshopper',
   '/api/internal/profile-percentiles',
+  '/api/internal/refresh-sitemap-climbs',
 ];
 
 /**
@@ -205,10 +208,10 @@ describe('REST surface inventory (issue #1889)', () => {
     //
     // This list used to be derived from vercel.json. Since #4654 the trigger is
     // the Railway scheduler (packages/scheduler/src/jobs/registry.ts), which
-    // this package cannot import, so the seven scheduled URLs are pinned here
-    // instead. The scheduler's own registry.test.ts pins the same seven against
-    // its registry, so a job added or renamed there without a matching route
-    // reds on that side.
+    // this package cannot import, so the scheduled URLs are pinned here instead.
+    // The scheduler's own registry.test.ts pins the same rows against its
+    // registry, so a job added or renamed there without a matching route reds on
+    // that side.
     const cronPaths = SCHEDULER_CRON_PATHS;
 
     const routeKeys = [...pinned.keys()];
@@ -228,9 +231,14 @@ describe('REST surface inventory (issue #1889)', () => {
     expect(readCronPaths()).toEqual([]);
   });
 
-  it('keeps the paused climb sitemap refresh unscheduled', () => {
+  it('schedules the climb sitemap refresh on the scheduler, never on Vercel', () => {
+    // Inverted by #4648. While climb sitemaps were paused this asserted the
+    // refresh had no schedule at all; now that publication is on it needs one,
+    // and it needs to be the Railway scheduler's — the runbook's alternative
+    // was a bespoke one-shot Railway cron service, which would have been a
+    // second scheduler with no monitors and no disable switch.
+    expect(SCHEDULER_CRON_PATHS).toContain('/api/internal/refresh-sitemap-climbs');
     expect(readCronPaths()).not.toContain('/api/internal/refresh-sitemap-climbs');
-    expect(SCHEDULER_CRON_PATHS).not.toContain('/api/internal/refresh-sitemap-climbs');
   });
 
   it('counts exactly the audited surface', () => {

--- a/packages/web/app/api/internal/refresh-sitemap-climbs/route.ts
+++ b/packages/web/app/api/internal/refresh-sitemap-climbs/route.ts
@@ -10,15 +10,24 @@ import { refreshClimbSitemapStore } from '@/app/lib/seo/sitemap/climb-store';
  * `/sitemaps/climbs/N.xml` serves as an ordinal range read instead of a 51 s
  * full rebuild per cold page (#4552).
  *
- * The Vercel schedule is paused with climb sitemap publication. This route stays
- * available for authenticated manual refreshes when the switch is enabled;
- * `requireCronAuth` checks `Authorization: Bearer $CRON_SECRET`.
+ * Fired every six hours by the Railway scheduler's `refresh-sitemap-climbs` job
+ * (packages/scheduler/src/jobs/registry.ts, docs/scheduler.md), and reachable by
+ * hand for the first refresh after a re-enable; `requireCronAuth` checks
+ * `Authorization: Bearer $CRON_SECRET` either way. With the switch off it answers
+ * `skipped: "disabled"` after the auth check and scans nothing.
  *
  * `?force=1` bypasses the >50%-shrink guard. It exists so the guard cannot wedge
  * the store permanently: if the catalogue genuinely shrank, every scheduled run
  * would otherwise decline forever while the read path kept serving a frozen count.
  */
 export const dynamic = 'force-dynamic';
+/**
+ * Vercel's Pro ceiling, kept only because the frozen rollback deployment still
+ * runs there. On the Railway container it is inert, and the real bound is the
+ * scheduler job's `timeoutMs` (15 minutes) — the sixteen sequential
+ * `DISTINCT ON` scans behind this route have been measured at 51 s and have no
+ * reason to fit inside 300.
+ */
 export const maxDuration = 300;
 
 export async function GET(request: Request) {

--- a/packages/web/app/lib/seo/sitemap/__tests__/climb-shards.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/climb-shards.test.ts
@@ -195,15 +195,19 @@ describe('the paged climbs shard', () => {
 
   it('503s rather than serving a body past the response-payload ceiling', async () => {
     // Driven by a fixture of long paths, not by mutating MAX_SHARD_BYTES: the
-    // guard has to measure the body it is about to serve.
+    // guard has to measure the body it is about to serve. The padding is derived
+    // from the two constants rather than hardcoded, because a hardcoded 500 that
+    // used to clear a 4 MB cap stops exceeding a 12 MB one and the test goes on
+    // passing while proving nothing.
+    const paddingChars = Math.ceil(MAX_SHARD_BYTES / CLIMB_URLS_PER_SHARD) + 1;
     climbs.itemCount = CLIMB_URLS_PER_SHARD;
-    climbs.pathLength = 500;
+    climbs.pathLength = paddingChars;
 
     const response = await pagedShardRouteHandler('climbs', '1.xml');
 
     expect(response.status).toBe(503);
     expect(response.headers.get('cache-control')).toBe('no-store');
-    expect(CLIMB_URLS_PER_SHARD * 500).toBeGreaterThan(MAX_SHARD_BYTES);
+    expect(CLIMB_URLS_PER_SHARD * paddingChars).toBeGreaterThan(MAX_SHARD_BYTES);
   });
 
   it('503s when the builder throws', async () => {

--- a/packages/web/app/lib/seo/sitemap/__tests__/climb-shards.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/climb-shards.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import type { PopularBoardConfig } from '@boardsesh/shared-schema';
-import { CLIMB_URLS_PER_SHARD, MAX_SHARD_BYTES } from '../sitemap-xml';
+import { CLIMB_URLS_PER_SHARD, MAX_SHARD_BYTES, pagedShardByteBudget } from '../sitemap-xml';
 import type { SitemapItem } from '../entries';
 
 vi.mock('server-only', () => ({}));
@@ -193,13 +193,14 @@ describe('the paged climbs shard', () => {
     expect((await pagedShardRouteHandler('climbs', '3.xml')).status).toBe(404);
   });
 
-  it('503s rather than serving a body past the response-payload ceiling', async () => {
-    // Driven by a fixture of long paths, not by mutating MAX_SHARD_BYTES: the
-    // guard has to measure the body it is about to serve. The padding is derived
-    // from the two constants rather than hardcoded, because a hardcoded 500 that
-    // used to clear a 4 MB cap stops exceeding a 12 MB one and the test goes on
-    // passing while proving nothing.
-    const paddingChars = Math.ceil(MAX_SHARD_BYTES / CLIMB_URLS_PER_SHARD) + 1;
+  it('503s rather than serving a page past its own byte budget', async () => {
+    // Driven by a fixture of long paths, not by mutating the budget: the guard
+    // has to measure the body it is about to serve. The padding is derived from
+    // the page size rather than hardcoded, because a hardcoded 500 that used to
+    // clear a 4 MB cap stops exceeding a raised one and the test goes on passing
+    // while proving nothing.
+    const budget = pagedShardByteBudget(CLIMB_URLS_PER_SHARD);
+    const paddingChars = Math.ceil(budget / CLIMB_URLS_PER_SHARD) + 1;
     climbs.itemCount = CLIMB_URLS_PER_SHARD;
     climbs.pathLength = paddingChars;
 
@@ -207,7 +208,19 @@ describe('the paged climbs shard', () => {
 
     expect(response.status).toBe(503);
     expect(response.headers.get('cache-control')).toBe('no-store');
-    expect(CLIMB_URLS_PER_SHARD * paddingChars).toBeGreaterThan(MAX_SHARD_BYTES);
+    expect(CLIMB_URLS_PER_SHARD * paddingChars).toBeGreaterThan(budget);
+  });
+
+  it('sizes the page budget to the page, not to the protocol backstop', async () => {
+    // The regression this exists for is a per-URL cost that multiplied, not a
+    // shard that grew: fanning the climbs pages out to locales adds the hreflang
+    // block `entries.ts` warns against and takes a page from ~2.5 MB to ~8.7 MB.
+    // Against `MAX_SHARD_BYTES` (45 MB) that page serves silently.
+    const budget = pagedShardByteBudget(CLIMB_URLS_PER_SHARD);
+    expect(budget).toBeLessThan(MAX_SHARD_BYTES);
+    expect(budget).toBeLessThan(CLIMB_URLS_PER_SHARD * 866);
+    // ...and still comfortably above the ~250 bytes/URL the pages actually cost.
+    expect(budget).toBeGreaterThan(CLIMB_URLS_PER_SHARD * 250);
   });
 
   it('503s when the builder throws', async () => {

--- a/packages/web/app/lib/seo/sitemap/__tests__/shard-route-handler.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/shard-route-handler.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import type { PopularBoardConfig } from '@boardsesh/shared-schema';
 import type { SitemapItem } from '../entries';
-import { CLIMB_URLS_PER_SHARD, MAX_ITEMS_PER_SHARD } from '../sitemap-xml';
+import { expandAllLocales } from '../entries';
+import { playlistRowsToItems } from '../playlist-entries';
+import { CLIMB_URLS_PER_SHARD, MAX_ITEMS_PER_SHARD, MAX_SHARD_BYTES, renderUrlset } from '../sitemap-xml';
 
 vi.mock('server-only', () => ({}));
 
@@ -24,7 +26,7 @@ const KILTER_CONFIG: PopularBoardConfig = {
 };
 
 const boardConfigs = vi.hoisted(() => ({ shouldThrow: false, empty: false, hang: false, delayMs: 0 }));
-const playlistRows = vi.hoisted(() => ({ count: 1, shouldThrow: false, hang: false, delayMs: 0 }));
+const playlistRows = vi.hoisted(() => ({ count: 1, uuidLength: 0, shouldThrow: false, hang: false, delayMs: 0 }));
 const climbSummary = vi.hoisted(() => ({ itemCount: 25_000, shouldThrow: false, hang: false, delayMs: 0 }));
 /** `static`, `gyms` and `setters` are pure builders — flags let the full index fail, or stall, at once. */
 const pureBuilders = vi.hoisted(() => ({ shouldThrow: false, hang: false, delayMs: 0 }));
@@ -60,10 +62,13 @@ vi.mock('../playlist-query', () => ({
       await after(playlistRows.delayMs);
     }
     const updatedAt = new Date('2026-04-30T00:00:00.000Z');
-    return Array.from({ length: playlistRows.count }, (_, index) => ({
-      uuid: index === 0 ? 'abc-123' : `playlist-${index}`,
-      updatedAt,
-    }));
+    return Array.from({ length: playlistRows.count }, (_, index) => {
+      const uuid = index === 0 ? 'abc-123' : `playlist-${index}`;
+      // `uuidLength` is how the byte-budget test buys expensive URLs without
+      // building millions of cheap ones: the uuid lands in every `<loc>` and in
+      // all four `xhtml:link` alternates of all four locale entries.
+      return { uuid: playlistRows.uuidLength > 0 ? uuid.padEnd(playlistRows.uuidLength, 'x') : uuid, updatedAt };
+    });
   },
 }));
 
@@ -144,7 +149,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
   Object.assign(boardConfigs, { shouldThrow: false, empty: false, hang: false, delayMs: 0 });
-  Object.assign(playlistRows, { count: 1, shouldThrow: false, hang: false, delayMs: 0 });
+  Object.assign(playlistRows, { count: 1, uuidLength: 0, shouldThrow: false, hang: false, delayMs: 0 });
   Object.assign(climbSummary, { itemCount: 25_000, shouldThrow: false, hang: false, delayMs: 0 });
   Object.assign(pureBuilders, { shouldThrow: false, hang: false, delayMs: 0 });
   vi.unstubAllEnvs();
@@ -198,6 +203,30 @@ describe('shardRouteHandler', () => {
     // only mean something if the handler counts what it is about to serve.
     // One item past the item budget is, after locale expansion, past the URL cap.
     playlistRows.count = MAX_ITEMS_PER_SHARD + 1;
+
+    const response = await shardRouteHandler('playlists');
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('answers 503 rather than serving a shard past the byte budget', async () => {
+    // The half of the same rule the fixed path went without until #4648 (#4618):
+    // `MAX_URLS_PER_SHARD` counts URLs and cannot see how expensive one is.
+    // Past `MAX_SHARD_BYTES` Search Console rejects the file whole, so an
+    // over-budget 200 loses the shard anyway — and silently.
+    //
+    // The fixture is sized from the real render rather than guessed, so raising
+    // the budget cannot leave this passing while proving nothing. Deliberately
+    // few, very expensive items: the URL cap must not be what fires.
+    const uuidLength = 20_000;
+    const bytesPerItem = Buffer.byteLength(
+      renderUrlset(expandAllLocales(playlistRowsToItems([{ uuid: 'x'.repeat(uuidLength), updatedAt: new Date() }]))),
+      'utf8',
+    );
+    playlistRows.uuidLength = uuidLength;
+    playlistRows.count = Math.ceil(MAX_SHARD_BYTES / bytesPerItem) + 1;
+    expect(playlistRows.count * 4).toBeLessThan(MAX_ITEMS_PER_SHARD * 4);
 
     const response = await shardRouteHandler('playlists');
 

--- a/packages/web/app/lib/seo/sitemap/climb-query.ts
+++ b/packages/web/app/lib/seo/sitemap/climb-query.ts
@@ -236,9 +236,12 @@ async function computeTier2Summary(): Promise<{ itemCount: number; lastModifiedI
 }
 
 /**
- * `unstable_cache`d, and only the summary is: the production 52,842-item payload
- * serialises to well over 10 MB, past Vercel's 2 MB Data Cache entry ceiling, so
- * caching the items there would silently never cache.
+ * `unstable_cache`d, and only the summary is. On Vercel the item list could not
+ * be cached at all: the production 52,842-item payload serialises to well over
+ * 10 MB and the 2 MB Data Cache entry ceiling meant an `unstable_cache` around
+ * it silently never cached. Off Vercel (#4648) there is no entry ceiling, and
+ * the items still do not belong here — see `buildTier2ClimbItems` below for the
+ * reason that replaced it.
  *
  * Dates do not survive the Data Cache intact, so the ISO string is what gets
  * stored and the public wrapper rehydrates it.
@@ -366,11 +369,18 @@ async function buildAllTier2Items(): Promise<SitemapItem[]> {
  * deploy that adds the store, every page request takes this path until the first
  * refresh runs.
  *
- * The item list is deliberately not in the Next Data Cache (~20 MB, past the
- * 2 MB entry ceiling), so on Vercel the only cross-instance protection on this
- * fallback is the CDN — a genuinely cold crawl of N pages that all miss it
- * really is N full builds. That is the burn the URL table exists to stop; do not
- * try to fix the fallback instead of refreshing the store.
+ * The item list is deliberately not in the Next Data Cache, and the reason
+ * changed with the host. On Vercel it *could* not be: ~20 MB is past the 2 MB
+ * entry ceiling, so the cache was a no-op. Self-hosted on Railway there is no
+ * entry ceiling, and it still should not go in — the standalone server's
+ * incremental cache holds entries in a bounded in-process budget before
+ * spilling to disk, so one 20 MB entry would evict the small ones that are
+ * actually load-bearing, `getAllBoardConfigsOrThrow` among them (#4519).
+ *
+ * So the only protection on this fallback stays the in-process TTL above plus
+ * the CDN: a genuinely cold crawl of N pages that all miss it really is N full
+ * builds. That is the burn the URL table exists to stop; do not try to make the
+ * fallback comfortable instead of refreshing the store.
  */
 export async function buildTier2ClimbItems(): Promise<SitemapItem[]> {
   if (cachedItems && Date.now() - cachedItems.builtAt < ITEMS_TTL_MS) {

--- a/packages/web/app/lib/seo/sitemap/climb-sitemaps-enabled.ts
+++ b/packages/web/app/lib/seo/sitemap/climb-sitemaps-enabled.ts
@@ -1,10 +1,23 @@
 import 'server-only';
 
 /**
- * Climb sitemaps are paused by default because publishing roughly 53,000 climb
- * URLs created the crawler-driven render and transfer spike. Keep the check
- * strict so values such as `1`, `TRUE`, or an unset variable cannot enable the
- * surface accidentally.
+ * The kill switch for climb sitemap publication — roughly 53,000 URLs, and the
+ * crawler-driven render and transfer spike that paused them in the first place.
+ *
+ * The surface is published again (#4648): www serves from a Railway container
+ * rather than Vercel, so the per-request ceilings that made the crawl expensive
+ * to absorb are gone. `Dockerfile.web` bakes `CLIMB_SITEMAPS_ENABLED=true` into
+ * the runner stage, which is what makes the deployed image publish by default.
+ *
+ * The gate itself deliberately stays. A Railway service variable overrides the
+ * image's `ENV`, so setting `CLIMB_SITEMAPS_ENABLED` to anything but `true` on
+ * the web service and redeploying pulls the whole surface back to its withdrawn
+ * state — 410 on the shard pages, no climb entries in the index — with no code
+ * change and no image rebuild. Flipping the default in this function instead
+ * would have thrown that lever away.
+ *
+ * The check stays strict for the same reason it always was: `1`, `TRUE` and a
+ * typo must all read as "not enabled" rather than as an accidental republish.
  */
 export function climbSitemapsEnabled(): boolean {
   return process.env.CLIMB_SITEMAPS_ENABLED === 'true';

--- a/packages/web/app/lib/seo/sitemap/entries.ts
+++ b/packages/web/app/lib/seo/sitemap/entries.ts
@@ -77,9 +77,16 @@ export function allLocalesUrlCount(items: readonly SitemapItem[]): number {
  * shard (which does fan out to all four locales). The difference is volume:
  * boards is 690 items → 2,760 URLs; production emits 52,842 climb items, which
  * would fan out to 211,368 locale URLs with a 5-entry alternates block on each.
- * Even one 10,000-item page would expand to 40,000 URL entries and exceed
- * Vercel's 4.5 MB response ceiling. Do not "fix" the inconsistency by fanning
- * climbs out.
+ * Do not "fix" the inconsistency by fanning climbs out.
+ *
+ * One of the two reasons for that died with Vercel and one did not, so be clear
+ * about which is load-bearing. The byte argument — even one 10,000-item page
+ * expands to 40,000 URL entries, past Vercel's 4.5 MB response ceiling — is
+ * gone: the container has no such ceiling, and #4648 republished the surface
+ * without it. The SEO argument below is the whole reason now, and it is the
+ * stronger of the two: fanning out would submit ~158,000 URLs that are not
+ * independently indexable pages, against two open issues (#4842, #4861) about
+ * what crawl peak already does to the connection pool.
  *
  * The original justification for dropping the sitemap-side hreflang was that
  * `createPageMetadata` emitted `alternates.languages` on both climb-view trees,

--- a/packages/web/app/lib/seo/sitemap/playlist-query.ts
+++ b/packages/web/app/lib/seo/sitemap/playlist-query.ts
@@ -86,10 +86,16 @@ type CachedPlaylistRow = { uuid: string; updatedAtIso: string };
  * Caching the ROWS rather than a summary is what makes this different from the
  * climbs shard, and it is a size question: 2,688 production rows of
  * `{ uuid, updatedAtIso }` is ~200 KB of JSON, and even at the hard
- * `MAX_ITEMS_PER_SHARD` cap it is ~840 KB — comfortably inside Vercel's 2 MB
- * entry ceiling. The climb item list is >10 MB, which is the only reason #4523
- * had to materialise a summary into Postgres instead. Caching the rows fixes both
- * the index AND `/sitemaps/playlists.xml`, measured at 1.3–4.3 s per CDN miss.
+ * `MAX_ITEMS_PER_SHARD` cap it is ~840 KB. That number used to be measured
+ * against Vercel's 2 MB Data Cache entry ceiling; off Vercel (#4648) there is no
+ * entry ceiling and the thing to stay small against is the standalone server's
+ * in-process incremental-cache budget — a megabyte of playlist rows sits in it
+ * without evicting anything, where the >10 MB climb item list would (see
+ * `SHARD_DEADLINE_MS` in shard-registry.ts, and `buildTier2ClimbItems` in
+ * climb-query.ts). That size gap is why #4523 had to materialise a climbs
+ * summary into Postgres and this one can just be cached. Caching the rows fixes
+ * both the index AND `/sitemaps/playlists.xml`, measured at 1.3–4.3 s per CDN
+ * miss.
  *
  * `row.updatedAt.toISOString()` round-trips exactly: `playlists.updated_at` is a
  * `timestamp` holding UTC and comes back through drizzle's timestamp decoder
@@ -178,8 +184,9 @@ export async function fetchPlaylistSitemapRows(): Promise<PlaylistSitemapRow[]> 
  * while the route module snapshots `Object.values(workStore.pendingRevalidates)`
  * into `pendingWaitUntil` at response time (route-modules/app-route/module.js). So
  * an index that abandoned this query at 3 s has already returned, its eventual
- * write is registered into an array nobody is holding, and a freezing Vercel
- * instance can drop it — leaving the next request to miss again. Running the same
+ * write is registered into an array nobody is holding, and a container that
+ * restarts (or a serverless instance that freezes) can drop it — leaving the
+ * next request to miss again. Running the same
  * fetch inside `after()` puts it under `withExecuteRevalidates`
  * (server/after/after-context.js), whose `finally` diffs the store and awaits the
  * writes that appeared while the callbacks ran. That covers the abandoned query

--- a/packages/web/app/lib/seo/sitemap/shard-registry.ts
+++ b/packages/web/app/lib/seo/sitemap/shard-registry.ts
@@ -464,8 +464,9 @@ export async function pagedShardRouteHandler(id: PagedShardId, rawPage: string):
 
     body = renderUrlset(urls);
     // The guard runs on the rendered body, not on a row count: a constant that
-    // nothing measures is a comment, and Vercel truncates a response past
-    // 4.5 MB into a platform error that looks like a sitemap outage.
+    // nothing measures is a comment, and the URL count cannot see per-URL size.
+    // What it protects against is no longer a platform truncation but Search
+    // Console rejecting an oversized file whole — see MAX_SHARD_BYTES.
     const bytes = Buffer.byteLength(body, 'utf8');
     if (bytes > MAX_SHARD_BYTES) {
       throw new Error(
@@ -518,9 +519,12 @@ function sourceHeaders(shard: PagedSitemapShard, source: PagedShardSource | unde
  * pay for it — a cold miss on sixteen sequential `DISTINCT ON` scans could never
  * meet 3 s at any cache temperature (#4523). `fetchPlaylistSitemapRows` is cached
  * like boards rather than precomputed like climbs, because its answer is small
- * enough to hold — ~200 KB of rows today, ~840 KB at the item cap, against
- * Vercel's 2 MB Data Cache entry ceiling (#4524). All three data-backed builders
- * are covered now; none of them is covered on a genuinely cold entry.
+ * enough to hold — ~200 KB of rows today, ~840 KB at the item cap (#4524). That
+ * used to be measured against Vercel's 2 MB Data Cache entry ceiling; off Vercel
+ * (#4648) the number to stay small against is the standalone server's in-process
+ * incremental-cache budget, which the climbs item list would evict on its own and
+ * a megabyte of playlist rows will not. All three data-backed builders are
+ * covered now; none of them is covered on a genuinely cold entry.
  *
  * None of that makes the deadline redundant. It makes it *reachable*: the first
  * boards or playlists miss after a cold start still pays full price, and an empty

--- a/packages/web/app/lib/seo/sitemap/shard-registry.ts
+++ b/packages/web/app/lib/seo/sitemap/shard-registry.ts
@@ -20,6 +20,7 @@ import {
   CLIMB_URLS_PER_SHARD,
   MAX_SHARD_BYTES,
   MAX_URLS_PER_SHARD,
+  pagedShardByteBudget,
   renderSitemapIndex,
   renderUrlset,
   type SitemapIndexEntry,
@@ -228,6 +229,24 @@ function overBudgetError(shard: SitemapShard, urlCount: number): Error | null {
 }
 
 /**
+ * The byte half of the same rule, and the one the fixed path went without until
+ * #4648 (#4618). A URL count cannot see how expensive one URL is: at the 866
+ * bytes/URL `/sitemaps/playlists.xml` renders, `MAX_URLS_PER_SHARD` alone permits
+ * a body many times what any crawler should be handed, and past `MAX_SHARD_BYTES`
+ * Search Console rejects the file whole rather than reading part of it.
+ *
+ * Measured on the RENDERED body for the same reason as the paged path: the
+ * constant is worth having only if something checks it.
+ */
+function oversizedError(shard: SitemapShard, bytes: number): Error | null {
+  return bytes > MAX_SHARD_BYTES
+    ? new Error(
+        `[sitemap] shard "${shard.id}" rendered ${bytes} bytes, past the ${MAX_SHARD_BYTES} budget — split it into paged shards`,
+      )
+    : null;
+}
+
+/**
  * **Deliberately unbounded, unlike the index walk below.** A `withDeadline` here
  * would 503 a legitimately slow-but-working shard: `getAllBoardConfigsOrThrow`
  * budgets itself 10 s, and any index-sized deadline would fail a URL that serves
@@ -262,6 +281,10 @@ export async function shardRouteHandler(id: ShardId): Promise<Response> {
     }
 
     body = renderUrlset(urls);
+    const oversized = oversizedError(shard, Buffer.byteLength(body, 'utf8'));
+    if (oversized) {
+      throw oversized;
+    }
   } catch (err) {
     console.error(`[sitemap] shard "${id}" failed to build:`, err instanceof Error ? err.message : err);
     return unavailableResponse();
@@ -465,12 +488,15 @@ export async function pagedShardRouteHandler(id: PagedShardId, rawPage: string):
     body = renderUrlset(urls);
     // The guard runs on the rendered body, not on a row count: a constant that
     // nothing measures is a comment, and the URL count cannot see per-URL size.
-    // What it protects against is no longer a platform truncation but Search
-    // Console rejecting an oversized file whole — see MAX_SHARD_BYTES.
+    // Sized to THIS shard's page rather than to the protocol backstop, because
+    // what it has to catch is a per-URL cost that multiplied — a climbs page
+    // accidentally fanned out to locales renders 8.7 MB where it should render
+    // 2.5 MB, and a 45 MB ceiling would serve it without comment.
+    const byteBudget = pagedShardByteBudget(shard.urlsPerShard);
     const bytes = Buffer.byteLength(body, 'utf8');
-    if (bytes > MAX_SHARD_BYTES) {
+    if (bytes > byteBudget) {
       throw new Error(
-        `[sitemap] paged shard "${shard.id}" page ${page} rendered ${bytes} bytes, past the ${MAX_SHARD_BYTES} response budget — lower urlsPerShard`,
+        `[sitemap] paged shard "${shard.id}" page ${page} rendered ${bytes} bytes, past its ${byteBudget} page budget — lower urlsPerShard`,
       );
     }
   } catch (err) {

--- a/packages/web/app/lib/seo/sitemap/sitemap-xml.ts
+++ b/packages/web/app/lib/seo/sitemap/sitemap-xml.ts
@@ -14,22 +14,55 @@ export const MAX_URLS_PER_SHARD = 45_000;
 export const MAX_ITEMS_PER_SHARD = Math.floor(MAX_URLS_PER_SHARD / SUPPORTED_LOCALES.length);
 
 /**
- * Climb shards are byte-bound long before they are URL-bound.
+ * Page size for the climbs shard. It used to be a byte ceiling in disguise:
+ * 45,000 climb URLs render ~11 MB at our path lengths (`/kilter/original/
+ * 12x12-square/screw_bolt/40/view/{slug}-{uuid}` plus the `<lastmod>`, ~250
+ * bytes each), which Vercel truncated or 500'd at its 4.5 MB serverless
+ * response ceiling. www serves from a Railway container now (#4648), so that
+ * ceiling is gone and nothing forces this below the protocol's 45,000.
  *
- * A climb `<url>` is ~250 bytes at our path lengths (`/kilter/original/
- * 12x12-square/screw_bolt/40/view/{slug}-{uuid}` plus the `<lastmod>`), so a
- * 45,000-URL climb shard renders ~11 MB — past Vercel's 4.5 MB serverless
- * response ceiling, where the platform truncates or 500s instead of serving it.
- * 10,000 URLs lands around 2.5 MB with headroom for a long climb name.
+ * It stays at 10,000 anyway, for two reasons that have nothing to do with a
+ * platform:
+ *
+ * - **`<lastmod>` granularity.** `fetchStoredClimbPageLastmods` gives each page
+ *   its own `max(last_modified)` so one stats update no longer makes the whole
+ *   surface look changed (#4552). Six pages localise that to a sixth of the
+ *   catalogue; two pages of 45,000 would put half of it back in play on every
+ *   refresh, which is exactly the re-crawl volume #4842/#4861 are open about.
+ * - **Bounded work per request.** A page is one ordinal-range read plus one
+ *   rendered string held whole in memory. At 10,000 rows that is ~21 ms and
+ *   ~2.5 MB on a container whose RSS the deploy runbook watches; at 45,000 it
+ *   is four and a half times both.
+ *
+ * Raising it is a deliberate change with a crawl-shape argument behind it, not
+ * a leftover to clean up.
  */
 export const CLIMB_URLS_PER_SHARD = 10_000;
 
 /**
- * Hard stop, enforced on the RENDERED BODY rather than on a row count — a
- * constant alone is a comment. Vercel caps a serverless response at 4.5 MB and
- * a truncated 200 is strictly worse than a 503 the crawler retries.
+ * Hard stop on a PAGED shard page, enforced on the RENDERED BODY rather than on
+ * a row count — a constant alone is a comment, and a URL count cannot see how
+ * expensive one URL is.
+ *
+ * The old 4 MB was Vercel's 4.5 MB serverless response ceiling with headroom.
+ * Off Vercel (#4648) the outer authority is sitemaps.org: 50 MB uncompressed per
+ * file, above which Search Console rejects the shard whole.
+ *
+ * 12 MB is the largest body a paged shard can *intend* to serve at the two
+ * per-URL costs this site actually renders, measured on www on 2026-09-02:
+ *
+ * - **~250 bytes**, `default-locale-only` with no alternates block — what the
+ *   climbs pages cost. `MAX_URLS_PER_SHARD` (45,000) of those is ~11 MB.
+ * - **866 bytes**, `all-locales` with the five-entry hreflang block —
+ *   `/sitemaps/playlists.xml` is 2,615,676 bytes across 3,020 `<url>` entries.
+ *   A paged shard on that expansion trips this at ~13,850 URLs, which is the
+ *   right answer: it has to page smaller, not render a 39 MB file.
+ *
+ * So the guard fires on a page whose rendered body ran several times past what
+ * its row budget predicted, and no longer 503s a legitimately large one for a
+ * platform we left.
  */
-export const MAX_SHARD_BYTES = 4_000_000;
+export const MAX_SHARD_BYTES = 12_000_000;
 
 export type ChangeFrequency = 'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
 

--- a/packages/web/app/lib/seo/sitemap/sitemap-xml.ts
+++ b/packages/web/app/lib/seo/sitemap/sitemap-xml.ts
@@ -40,29 +40,59 @@ export const MAX_ITEMS_PER_SHARD = Math.floor(MAX_URLS_PER_SHARD / SUPPORTED_LOC
 export const CLIMB_URLS_PER_SHARD = 10_000;
 
 /**
- * Hard stop on a PAGED shard page, enforced on the RENDERED BODY rather than on
- * a row count — a constant alone is a comment, and a URL count cannot see how
- * expensive one URL is.
+ * Hard stop on ANY sitemap file, fixed or paged, enforced on the RENDERED BODY
+ * rather than on a row count — a constant alone is a comment, and a URL count
+ * cannot see how expensive one URL is.
  *
- * The old 4 MB was Vercel's 4.5 MB serverless response ceiling with headroom.
- * Off Vercel (#4648) the outer authority is sitemaps.org: 50 MB uncompressed per
- * file, above which Search Console rejects the shard whole.
+ * The old 4 MB was Vercel's 4.5 MB serverless response ceiling with headroom, and
+ * it was applied only on the paged path (#4618). Off Vercel (#4648) the platform
+ * ceiling is gone and the outer authority is the protocol: sitemaps.org rejects a
+ * file over 50 MB uncompressed, and Search Console rejects it whole rather than
+ * truncating, so serving one is strictly worse than serving nothing. 45 MB is
+ * that limit with the same 10% headroom `MAX_URLS_PER_SHARD` keeps against
+ * 50,000 URLs, and both handlers enforce it now.
  *
- * 12 MB is the largest body a paged shard can *intend* to serve at the two
- * per-URL costs this site actually renders, measured on www on 2026-09-02:
+ * It is a *backstop*, not the working guard, and at today's costs it does not
+ * bind: measured on www on 2026-09-02, `/sitemaps/playlists.xml` renders 866
+ * bytes per URL (2,615,676 bytes across 3,020 `<url>` entries — an `all-locales`
+ * shard dominated by the five-entry `xhtml:link` block), so the worst body
+ * `MAX_URLS_PER_SHARD` permits is ~39 MB. This fires above ~1,000 B/URL, i.e.
+ * when a per-URL cost grew rather than when a shard did.
  *
- * - **~250 bytes**, `default-locale-only` with no alternates block — what the
- *   climbs pages cost. `MAX_URLS_PER_SHARD` (45,000) of those is ~11 MB.
- * - **866 bytes**, `all-locales` with the five-entry hreflang block —
- *   `/sitemaps/playlists.xml` is 2,615,676 bytes across 3,020 `<url>` entries.
- *   A paged shard on that expansion trips this at ~13,850 URLs, which is the
- *   right answer: it has to page smaller, not render a 39 MB file.
- *
- * So the guard fires on a page whose rendered body ran several times past what
- * its row budget predicted, and no longer 503s a legitimately large one for a
- * platform we left.
+ * A paged shard gets a tighter, page-sized budget on top — see
+ * {@link pagedShardByteBudget}. A 39 MB fixed shard is legal but still far more
+ * file than anyone should hand a crawler; paging `playlists` is tracked in
+ * #5073.
  */
-export const MAX_SHARD_BYTES = 12_000_000;
+export const MAX_SHARD_BYTES = 45_000_000;
+
+/**
+ * Bytes per URL a PAGED shard page may average before its own guard fires.
+ *
+ * `MAX_SHARD_BYTES` cannot do this job: it is sized to the protocol, and the only
+ * paged shard configured today renders 10,000 URLs at ~250 bytes each — ~2.5 MB,
+ * eighteen times under it. A ceiling that far above the page it guards cannot see
+ * the regression that matters, which is a per-URL cost that multiplied. Fanning
+ * the climbs pages out to locales would do exactly that: it adds the hreflang
+ * alternates block `entries.ts` warns against, taking each URL from ~250 B to the
+ * 866 B measured on `/sitemaps/playlists.xml` and a page from 2.5 MB to 8.7 MB.
+ *
+ * 500 is double the measured cost and well under the fanned-out one, so a page
+ * that grew legitimately long paths still serves and that regression still 503s.
+ */
+const PAGED_SHARD_BYTES_PER_URL = 500;
+
+/**
+ * The byte budget for one page of a paged shard: its own page size at
+ * {@link PAGED_SHARD_BYTES_PER_URL}, never above the protocol backstop.
+ *
+ * Derived from `urlsPerShard` rather than pinned as a constant so the number
+ * tracks the page it guards — a shard that halves its page size halves its byte
+ * budget instead of keeping a ceiling sized for the old one.
+ */
+export function pagedShardByteBudget(urlsPerShard: number): number {
+  return Math.min(urlsPerShard * PAGED_SHARD_BYTES_PER_URL, MAX_SHARD_BYTES);
+}
 
 export type ChangeFrequency = 'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
 

--- a/packages/web/app/sitemap.xml/route.ts
+++ b/packages/web/app/sitemap.xml/route.ts
@@ -16,16 +16,13 @@ import { sitemapIndexRouteHandler } from '@/app/lib/seo/sitemap/shard-registry';
  */
 export const dynamic = 'force-dynamic';
 
-/**
- * Not for the response — the handler bounds every shard at `SHARD_DEADLINE_MS` and
- * answers in well under a second. This is headroom for the `after()` work below,
- * which recomputes the climbs summary and takes tens of seconds when it fires.
- *
- * Vercel-only, and inert everywhere else: on self-hosted Node (the Railway target,
- * #3795) there is no per-invocation ceiling to raise and the `after()` work runs to
- * completion regardless. Harmless to keep after the move, and load-bearing until it.
- */
-export const maxDuration = 300;
+// There is deliberately no `maxDuration` export here. It was 300 — Vercel's Pro
+// ceiling — bought not for the response (every shard is bounded at
+// `SHARD_DEADLINE_MS` and the handler answers in well under a second) but as
+// headroom for the `after()` refresh below, which takes tens of seconds when it
+// fires. www serves from a Railway container now (#4648), where there is no
+// per-invocation ceiling and the `after()` work runs to completion regardless,
+// so the export only described a platform this route no longer runs on.
 
 export async function GET(): Promise<Response> {
   const response = await sitemapIndexRouteHandler();

--- a/scripts/__tests__/dockerfile-web-climb-sitemaps.test.ts
+++ b/scripts/__tests__/dockerfile-web-climb-sitemaps.test.ts
@@ -1,0 +1,36 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Nothing in CI runs the web image, so a text pin is the only in-repo oracle
+// that the deployed default publishes climb sitemaps. Same reasoning as
+// dockerfile-web-auth-origin.test.ts.
+//
+// What is being pinned: `CLIMB_SITEMAPS_ENABLED=true` in the RUNNER stage.
+// `climbSitemapsEnabled()` reads it at request time, so a builder-stage-only
+// declaration would not reach the standalone server — Next's standalone writer
+// copies only `.env` and `.env.production`, and the runner stage does not
+// inherit the builder's ENV. Losing the line withdraws ~53,000 URLs from
+// /sitemap.xml, which is a change nobody would notice from the build log.
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const dockerfile = readFileSync(join(repositoryRoot, 'Dockerfile.web'), 'utf8');
+const runnerStage = dockerfile.slice(dockerfile.indexOf('AS runner'));
+
+describe('Dockerfile.web climb sitemap publication', () => {
+  it('bakes the enabled default into the runner stage', () => {
+    // Whole-line match: `toContain('ENV CLIMB_SITEMAPS_ENABLED')` is happily
+    // satisfied by `ENV CLIMB_SITEMAPS_ENABLED=false`, and the value is the
+    // entire point of the pin.
+    expect(runnerStage).toMatch(/^ENV CLIMB_SITEMAPS_ENABLED=true$/m);
+  });
+
+  it('documents that a Railway service variable is the kill switch', () => {
+    // The gate stays in code precisely so the surface can be withdrawn without
+    // a rebuild. If that lever is not written down next to the ENV that hides
+    // it, the next operator reaches for a revert instead.
+    expect(runnerStage).toMatch(/kill switch/i);
+  });
+});

--- a/scripts/production-smoke.test.ts
+++ b/scripts/production-smoke.test.ts
@@ -42,6 +42,26 @@ function checkNamed(fragment: string) {
   return matches[0];
 }
 
+const SHARD_LOCS = {
+  static: 'https://www.boardsesh.com/sitemaps/static.xml',
+  boards: 'https://www.boardsesh.com/sitemaps/boards.xml',
+  playlists: 'https://www.boardsesh.com/sitemaps/playlists.xml',
+  climbs: 'https://www.boardsesh.com/sitemaps/climbs/1.xml',
+} as const;
+
+/** A `<sitemapindex>` listing exactly the shards named, in order. */
+function indexBody(...shards: (keyof typeof SHARD_LOCS)[]): string {
+  const entries = shards.map((shard) => `<sitemap><loc>${SHARD_LOCS[shard]}</loc></sitemap>`).join('');
+  return `<sitemapindex>${entries}</sitemapindex>`;
+}
+
+/**
+ * A climbs `<loc>` on its own does not prove the paged shard ran — the source
+ * header is what says which path answered — so every fixture that lists climbs
+ * as healthy carries it too.
+ */
+const CLIMBS_FROM_STORE = { 'x-sitemap-climbs-source': 'store' };
+
 describe('www production smoke checks', () => {
   it('covers the surfaces other systems depend on', () => {
     const paths = WWW_CHECKS.filter((check) => !check.fixtureEnvVar).map((check) => check.path);
@@ -67,8 +87,13 @@ describe('www production smoke checks', () => {
     // response that is not fully healthy. It is safe exactly where the server
     // declares the degradation on the response, and nowhere else — a check that
     // grew one by copy-paste would be silently unable to go red.
+    //
+    // Two checks qualify. The index declares dropped shards in
+    // `X-Sitemap-Degraded`; the climbs shard declares which path built it in
+    // `X-Sitemap-Climbs-Source`, where `live` is a correct answer that costs a
+    // full rebuild per request. Both are the server saying so on the response.
     const withDegradation = WWW_CHECKS.filter((check) => check.degradation).map((check) => check.path);
-    expect(withDegradation).toEqual(['/sitemap.xml']);
+    expect(withDegradation).toEqual(['/sitemap.xml', '/sitemaps/climbs/1.xml']);
   });
 
   it('rejects a homepage that 200s with a spinner-only shell', () => {
@@ -150,24 +175,26 @@ describe('www production smoke checks', () => {
 
   it('rejects a sitemap.xml that is not an index pointing at shards', () => {
     const check = checkNamed('sitemap index');
-    const healthyIndex =
-      '<sitemapindex>' +
-      '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
-      '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
-      '<sitemap><loc>https://www.boardsesh.com/sitemaps/playlists.xml</loc></sitemap>' +
-      '</sitemapindex>';
-    expect(check.assert(response({ contentType: 'application/xml', body: healthyIndex }))).toBeNull();
+    const healthyIndex = indexBody('static', 'boards', 'playlists', 'climbs');
+    expect(
+      check.assert(response({ contentType: 'application/xml', body: healthyIndex, headers: CLIMBS_FROM_STORE })),
+    ).toBeNull();
 
     // #4524: `playlists` was excluded from the required list as "legitimately
     // empty". It is not — production serves 2,688 public playlists holding a
     // climb — so an index that quietly drops it is 10,752 URLs gone and now goes
     // red exactly like boards does.
-    const withoutPlaylists =
-      '<sitemapindex>' +
-      '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
-      '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
-      '</sitemapindex>';
-    expect(check.assert(response({ contentType: 'application/xml', body: withoutPlaylists }))).toMatch(/playlists/);
+    const withoutPlaylists = indexBody('static', 'boards', 'climbs');
+    expect(
+      check.assert(response({ contentType: 'application/xml', body: withoutPlaylists, headers: CLIMBS_FROM_STORE })),
+    ).toMatch(/playlists/);
+
+    // #4648: climbs is required for the same reason, an order of magnitude
+    // larger. While publication was paused this smoke asserted the opposite —
+    // that a climbs entry was a failure — so an index that silently stopped
+    // listing ~53,000 URLs would have passed.
+    const withoutClimbs = indexBody('static', 'boards', 'playlists');
+    expect(check.assert(response({ contentType: 'application/xml', body: withoutClimbs }))).toMatch(/climbs/);
 
     // The regression this check has to keep catching after #4476. The index now
     // degrades rather than 503ing, so a cold-start failure of the boards builder
@@ -177,8 +204,7 @@ describe('www production smoke checks', () => {
     //
     // Silent is the operative word: with no `X-Sitemap-Degraded` header there is
     // nothing to say the omission was deliberate, so it stays a hard failure.
-    const degradedIndex =
-      '<sitemapindex><sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap></sitemapindex>';
+    const degradedIndex = indexBody('static');
     expect(check.assert(response({ contentType: 'application/xml', body: degradedIndex }))).toMatch(/boards/);
 
     // A regression to the old flat urlset — the shape this replaced.
@@ -204,8 +230,8 @@ describe('www production smoke checks', () => {
     const check = checkNamed('sitemap index');
     const withoutBoards = response({
       contentType: 'application/xml',
-      body: '<sitemapindex><sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap></sitemapindex>',
-      headers: { 'x-sitemap-degraded': 'boards,playlists' },
+      body: indexBody('static'),
+      headers: { 'x-sitemap-degraded': 'boards,playlists,climbs' },
     });
     expect(check.assert(withoutBoards)).toBeNull();
     // Names the shards, so the annotation is actionable without opening the site.
@@ -217,7 +243,7 @@ describe('www production smoke checks', () => {
     // must not become a blanket amnesty for anything absent from the body.
     const wrongShardDeclared = response({
       contentType: 'application/xml',
-      body: '<sitemapindex><sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap></sitemapindex>',
+      body: indexBody('static'),
       headers: { 'x-sitemap-degraded': 'playlists' },
     });
     expect(check.assert(wrongShardDeclared)).toMatch(/boards/);
@@ -228,12 +254,8 @@ describe('www production smoke checks', () => {
     // optional shard was quiet".
     const declaredDegradable = response({
       contentType: 'application/xml',
-      body:
-        '<sitemapindex>' +
-        '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
-        '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
-        '</sitemapindex>',
-      headers: { 'x-sitemap-degraded': 'playlists' },
+      body: indexBody('static', 'boards', 'climbs'),
+      headers: { ...CLIMBS_FROM_STORE, 'x-sitemap-degraded': 'playlists' },
     });
     expect(check.assert(declaredDegradable)).toBeNull();
     expect(check.degradation?.(declaredDegradable)).toMatch(/playlists/);
@@ -243,13 +265,8 @@ describe('www production smoke checks', () => {
     // missing mandatory, so nothing is flagged as required.
     const optionalOnly = response({
       contentType: 'application/xml',
-      body:
-        '<sitemapindex>' +
-        '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
-        '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
-        '<sitemap><loc>https://www.boardsesh.com/sitemaps/playlists.xml</loc></sitemap>' +
-        '</sitemapindex>',
-      headers: { 'x-sitemap-degraded': 'gyms' },
+      body: indexBody('static', 'boards', 'playlists', 'climbs'),
+      headers: { ...CLIMBS_FROM_STORE, 'x-sitemap-degraded': 'gyms' },
     });
     expect(check.assert(optionalOnly)).toBeNull();
     expect(check.degradation?.(optionalOnly)).toMatch(/gyms/);
@@ -284,85 +301,108 @@ describe('www production smoke checks', () => {
     // A healthy index carries no header and must not warn.
     const healthy = response({
       contentType: 'application/xml',
-      body:
-        '<sitemapindex>' +
-        '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
-        '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
-        '<sitemap><loc>https://www.boardsesh.com/sitemaps/playlists.xml</loc></sitemap>' +
-        '</sitemapindex>',
+      body: indexBody('static', 'boards', 'playlists', 'climbs'),
+      headers: CLIMBS_FROM_STORE,
     });
     expect(check.degradation?.(healthy) ?? null).toBeNull();
   });
 
-  it('fails if production exposes any climb sitemap publication signal', () => {
+  it('fails when the published climb surface is missing or unproven', () => {
+    // The inverse of what this asserted while publication was paused (#4648).
+    // Then, a climbs `<loc>` or a source header was the failure; now their
+    // absence is. Flipping the switch back off therefore takes a change here as
+    // well as an environment variable — which is the point of the tripwire, in
+    // whichever direction it currently points.
     const check = checkNamed('sitemap index');
-    const pausedIndex =
-      '<sitemapindex>' +
-      '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
-      '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
-      '<sitemap><loc>https://www.boardsesh.com/sitemaps/playlists.xml</loc></sitemap>' +
-      '</sitemapindex>';
+    const publishedIndex = indexBody('static', 'boards', 'playlists', 'climbs');
+
     expect(
-      check.assert(
-        response({
-          contentType: 'application/xml',
-          body: pausedIndex.replace(
-            '</sitemapindex>',
-            '<sitemap><loc>https://www.boardsesh.com/sitemaps/climbs/1.xml</loc></sitemap></sitemapindex>',
-          ),
-        }),
-      ),
-    ).toMatch(/still publishes/);
+      check.assert(response({ contentType: 'application/xml', body: publishedIndex, headers: CLIMBS_FROM_STORE })),
+    ).toBeNull();
+
+    // Climbs listed with nothing saying which path built it. That is the
+    // half-enabled shape: the index rendered the page URLs without the paged
+    // summary ever answering, so nothing proves the shard behind them serves.
+    expect(check.assert(response({ contentType: 'application/xml', body: publishedIndex }))).toMatch(/climbs/);
+
+    // A withdrawn surface with no header to excuse it — the silent regression
+    // an image that lost CLIMB_SITEMAPS_ENABLED would produce.
     expect(
-      check.assert(
-        response({
-          contentType: 'application/xml',
-          body: pausedIndex,
-          headers: { 'x-sitemap-climbs-source': 'store' },
-        }),
-      ),
-    ).toMatch(/source/);
-    expect(
-      check.assert(
-        response({
-          contentType: 'application/xml',
-          body: pausedIndex,
-          headers: { 'x-sitemap-degraded': 'climbs' },
-        }),
-      ),
-    ).toMatch(/intentional/);
+      check.assert(response({ contentType: 'application/xml', body: indexBody('static', 'boards', 'playlists') })),
+    ).toMatch(/climbs/);
+
+    // Dropped on purpose and said so: the summary lost the 3 s deadline against
+    // an empty store. Reporting no source there is documented behaviour, not a
+    // gap, so it warns rather than failing.
+    const declaredDegraded = response({
+      contentType: 'application/xml',
+      body: indexBody('static', 'boards', 'playlists'),
+      headers: { 'x-sitemap-degraded': 'climbs' },
+    });
+    expect(check.assert(declaredDegraded)).toBeNull();
+    expect(check.degradation?.(declaredDegraded)).toMatch(/climbs/);
+
+    // Correct, complete, and rebuilding the whole ordered list per request.
+    const fromLiveScan = response({
+      contentType: 'application/xml',
+      body: publishedIndex,
+      headers: { 'x-sitemap-climbs-source': 'live' },
+    });
+    expect(check.assert(fromLiveScan)).toBeNull();
+    expect(check.degradation?.(fromLiveScan)).toMatch(/refresh-sitemap-climbs/);
   });
 
-  it('requires a cacheable 410 from the paused climb shard at either origin', () => {
+  it('requires cacheable XML from the climb shard at either origin', () => {
     // The check used to string-compare the whole header against Vercel's
-    // downstream form. The route emits `public, s-maxage=3600, must-revalidate`;
-    // only Vercel strips `s-maxage`, so pointing this smoke at the Railway origin
-    // failed a check on a header that was exactly right. Directives, not strings.
-    const check = checkNamed('paused climb sitemap shard');
+    // downstream form, so pointing this smoke at a Railway origin failed on a
+    // header that was exactly right. Directives, not strings — and the set of
+    // tolerated ones widened with the flip, because the published shard runs on
+    // `s-maxage=21600, stale-while-revalidate=604800` where the withdrawn one
+    // ran on `must-revalidate`.
+    const check = checkNamed('climb sitemap shard');
     const healthy = response({
-      status: 410,
-      contentType: 'text/plain; charset=utf-8',
-      body: 'climbs sitemaps are disabled',
-      headers: { 'cache-control': 'public, must-revalidate' },
+      status: 200,
+      contentType: 'application/xml',
+      body: '<urlset><url><loc>https://www.boardsesh.com/kilter/original/12x12-square/screw_bolt/40/view/x</loc></url></urlset>',
+      headers: { ...CLIMBS_FROM_STORE, 'cache-control': 'public, s-maxage=21600, stale-while-revalidate=604800' },
     });
     expect(check.assert(healthy)).toBeNull();
-    // What the route actually emits, and what a non-Vercel origin serves.
+    // What an edge that consumes `s-maxage` as a private instruction forwards.
     expect(
-      check.assert({ ...healthy, headers: { 'cache-control': 'public, s-maxage=3600, must-revalidate' } }),
+      check.assert({
+        ...healthy,
+        headers: { ...CLIMBS_FROM_STORE, 'cache-control': 'public, max-age=0, must-revalidate' },
+      }),
     ).toBeNull();
     // Whitespace and casing are the header's business, not the contract's.
-    expect(check.assert({ ...healthy, headers: { 'cache-control': 'Public,  Must-Revalidate' } })).toBeNull();
+    expect(
+      check.assert({ ...healthy, headers: { ...CLIMBS_FROM_STORE, 'cache-control': ' Public,  S-MaxAge=21600' } }),
+    ).toBeNull();
 
-    expect(check.assert({ ...healthy, status: 200 })).toMatch(/410/);
-    expect(check.assert({ ...healthy, headers: { 'cache-control': 'no-store' } })).toMatch(/cache-control/);
-    // Tolerating `s-maxage` must not turn into tolerating anything: a bare
-    // `public` is a shard that stops revalidating, cached at every hop.
-    expect(check.assert({ ...healthy, headers: { 'cache-control': 'public' } })).toMatch(/must-revalidate/);
-    expect(check.assert({ ...healthy, headers: {} })).toMatch(/cache-control/);
-    // A directive nobody asked for is a real change to the pause, not plumbing.
-    expect(check.assert({ ...healthy, headers: { 'cache-control': 'public, must-revalidate, private' } })).toMatch(
-      /private/,
+    // The withdrawn shape. A 410 here means the deploy lost the switch.
+    expect(check.assert({ ...healthy, status: 410 })).toMatch(/200/);
+    // A shard that rendered nothing is a regressed query, not an empty surface —
+    // the summary already said there were items on this page.
+    expect(check.assert({ ...healthy, body: '<urlset></urlset>' })).toMatch(/loc/);
+    expect(check.assert({ ...healthy, headers: { ...CLIMBS_FROM_STORE, 'cache-control': 'no-store' } })).toMatch(
+      /no-store/,
     );
+    expect(
+      check.assert({ ...healthy, headers: { ...CLIMBS_FROM_STORE, 'cache-control': 'private, max-age=60' } }),
+    ).toMatch(/public/);
+    expect(check.assert({ ...healthy, headers: { 'cache-control': 'public, s-maxage=21600' } })).toMatch(
+      /x-sitemap-climbs-source/,
+    );
+
+    // Served, but from the fallback the URL table exists to retire. Green with
+    // a warning, because the pages are correct and the cure is a refresh.
+    const fromLiveScan = {
+      ...healthy,
+      headers: { ...healthy.headers, 'x-sitemap-climbs-source': 'live' },
+    };
+    expect(check.assert(fromLiveScan)).toBeNull();
+    expect(check.degradation?.(fromLiveScan)).toMatch(/live/);
+    expect(check.degradation?.(healthy) ?? null).toBeNull();
   });
 
   it('rejects an empty static sitemap shard', () => {

--- a/scripts/production-smoke.test.ts
+++ b/scripts/production-smoke.test.ts
@@ -82,7 +82,7 @@ describe('www production smoke checks', () => {
     );
   });
 
-  it('keeps the warning channel on the index alone', () => {
+  it('keeps the warning channel on the index and the climb shard, and nowhere else', () => {
     // `degradation` is the only thing in this file that can end a run green on a
     // response that is not fully healthy. It is safe exactly where the server
     // declares the degradation on the response, and nowhere else — a check that
@@ -94,6 +94,22 @@ describe('www production smoke checks', () => {
     // full rebuild per request. Both are the server saying so on the response.
     const withDegradation = WWW_CHECKS.filter((check) => check.degradation).map((check) => check.path);
     expect(withDegradation).toEqual(['/sitemap.xml', '/sitemaps/climbs/1.xml']);
+  });
+
+  it('buys the climb shard a request budget longer than its 51 s fallback', () => {
+    // The WARN above is only reachable if the request survives long enough to
+    // read the header. `pagedShardRouteHandler` puts no deadline on
+    // `buildPage()`, and the empty-store fallback it describes is a 51 s rebuild
+    // (#4552), so on the suite's shared 30 s budget the documented degradation
+    // would abort and report as three hard failures instead — which, once
+    // `WEB_DEPLOY_TARGETS` drops `vercel`, is grounds for an automatic rollback.
+    const check = checkNamed('climb sitemap shard');
+    expect(check.timeoutMs ?? 0).toBeGreaterThan(51_000);
+    // Every other check keeps the shared budget: a longer one belongs only where
+    // a slow answer is a state the check reports on, not a symptom.
+    expect(
+      WWW_CHECKS.filter((candidate) => candidate.timeoutMs !== undefined).map((candidate) => candidate.path),
+    ).toEqual(['/sitemaps/climbs/1.xml']);
   });
 
   it('rejects a homepage that 200s with a spinner-only shell', () => {
@@ -390,6 +406,15 @@ describe('www production smoke checks', () => {
     expect(
       check.assert({ ...healthy, headers: { ...CLIMBS_FROM_STORE, 'cache-control': 'private, max-age=60' } }),
     ).toMatch(/public/);
+    // Cacheable by anything, forever, with nothing to revalidate against. It
+    // carries `public`, so a required-directives check alone would pass a shard
+    // that had lost its entire CDN window.
+    expect(check.assert({ ...healthy, headers: { ...CLIMBS_FROM_STORE, 'cache-control': 'public' } })).toMatch(
+      /s-maxage/,
+    );
+    expect(
+      check.assert({ ...healthy, headers: { ...CLIMBS_FROM_STORE, 'cache-control': 'public, must-revalidate' } }),
+    ).toMatch(/s-maxage/);
     expect(check.assert({ ...healthy, headers: { 'cache-control': 'public, s-maxage=21600' } })).toMatch(
       /x-sitemap-climbs-source/,
     );

--- a/scripts/production-smoke.ts
+++ b/scripts/production-smoke.ts
@@ -43,6 +43,19 @@ const DEFAULT_BASE_URL = 'https://www.boardsesh.com';
 
 /** Per-request ceiling. Generous: a cold serverless route can be slow. */
 const REQUEST_TIMEOUT_MS = 30_000;
+/**
+ * The climb shard's own ceiling, and the reason a check may override the one
+ * above.
+ *
+ * `pagedShardRouteHandler` puts no deadline on `buildPage()`, and the empty-store
+ * fallback behind it is a full grouped rebuild measured at 51 s in production
+ * (#4552) — longer than `REQUEST_TIMEOUT_MS`. That state is exactly the one this
+ * check's `degradation` channel describes as a WARN, so smoking it on the shared
+ * 30 s budget would abort the fetch and report the documented warning as three
+ * hard failures instead. 90 s clears the 51 s fallback with room for a cold
+ * container, and the three attempts still cannot outlive the deploy job.
+ */
+const CLIMB_SHARD_TIMEOUT_MS = 90_000;
 /** Attempts per check, to ride out a single edge/CDN blip. */
 const ATTEMPTS = 3;
 const RETRY_DELAY_MS = 5_000;
@@ -107,6 +120,14 @@ export type SmokeCheck = {
   fixtureEnvVar?: string;
   /** Stop immediately after this check exhausts its retries with a failure. */
   stopSuiteOnFailure?: boolean;
+  /**
+   * Per-request ceiling for this check only. Defaults to `REQUEST_TIMEOUT_MS`.
+   *
+   * Raise it only where a slow answer is a *documented* state the check reports
+   * on rather than a symptom — otherwise an abort is the right verdict and a
+   * longer budget just delays it.
+   */
+  timeoutMs?: number;
 };
 
 function expectStatus(response: SmokeResponse, expected: number): string | null {
@@ -178,7 +199,9 @@ const SITEMAP_DEGRADED_HEADER = 'x-sitemap-degraded';
  *
  * `live` is not a failure. On the deploy that turns publication on, and on any
  * deploy that leaves the store empty, the fallback is the correct answer until
- * the first refresh lands. It is expensive enough to be worth a WARN.
+ * the first refresh lands. It is expensive enough to be worth a WARN — and slow
+ * enough that the shard check has to buy `CLIMB_SHARD_TIMEOUT_MS` for it, or the
+ * fetch aborts and the WARN is reported as a failure instead.
  */
 const SITEMAP_CLIMBS_SOURCE_HEADER = 'x-sitemap-climbs-source';
 const CLIMB_SITEMAP_PATH_PREFIX = '/sitemaps/climbs/';
@@ -196,13 +219,21 @@ const CLIMB_SITEMAP_STORE_SOURCE = 'store';
  * origin or the other, so this parses directives instead.
  *
  * `public` is the contract — the shard has to be cacheable by something other
- * than the browser that asked. The freshness directives are plumbing that may or
- * may not survive the edge. Anything else (`no-store`, `private`, `no-cache`)
+ * than the browser that asked. Anything else (`no-store`, `private`, `no-cache`)
  * means every crawler fetch reaches Postgres, which is the failure this window
  * was built to prevent.
+ *
+ * Which freshness directive survives is the edge's business, but at least one of
+ * them has to. A bare `public` is cacheable forever with nothing to revalidate
+ * against, so requiring only `public` would pass a shard that had lost its whole
+ * CDN window — the regression this check exists for. Requiring one of the three
+ * accepts both the origin form and the `max-age=0, must-revalidate` an edge that
+ * consumes `s-maxage` rewrites it to, and rejects a header with no freshness
+ * story at all.
  */
 const REQUIRED_CLIMB_CACHE_DIRECTIVES = ['public'] as const;
-const TOLERATED_CLIMB_CACHE_DIRECTIVES = ['s-maxage', 'stale-while-revalidate', 'max-age', 'must-revalidate'] as const;
+const FRESHNESS_CLIMB_CACHE_DIRECTIVES = ['s-maxage', 'max-age', 'stale-while-revalidate'] as const;
+const TOLERATED_CLIMB_CACHE_DIRECTIVES = [...FRESHNESS_CLIMB_CACHE_DIRECTIVES, 'must-revalidate'] as const;
 
 /** Directive NAMES only — `s-maxage=21600` reads as `s-maxage`. */
 function cacheControlDirectiveNames(header: string): string[] {
@@ -218,6 +249,10 @@ function expectClimbShardCacheControl(response: SmokeResponse): string | null {
 
   const missing = REQUIRED_CLIMB_CACHE_DIRECTIVES.filter((directive) => !names.includes(directive));
   if (missing.length > 0) return `expected cache-control to carry ${missing.join(' and ')}, got "${header}"`;
+
+  if (!FRESHNESS_CLIMB_CACHE_DIRECTIVES.some((directive) => names.includes(directive))) {
+    return `expected cache-control to carry one of ${FRESHNESS_CLIMB_CACHE_DIRECTIVES.join(', ')}, got "${header}"`;
+  }
 
   const unexpected = names.filter(
     (name) =>
@@ -462,9 +497,11 @@ export const WWW_CHECKS: SmokeCheck[] = [
   },
   {
     // The index check above can only see that climbs was listed. This is the
-    // page a crawler actually fetches, and the one that used to cost 51 s cold.
+    // page a crawler actually fetches, and the one that still costs 51 s when
+    // the store is empty — hence the check's own timeout.
     name: 'the climb sitemap shard serves cacheable URLs',
     path: `${CLIMB_SITEMAP_PATH_PREFIX}1.xml`,
+    timeoutMs: CLIMB_SHARD_TIMEOUT_MS,
     assert: (response) =>
       firstFailure(
         expectStatus(response, 200),
@@ -580,9 +617,9 @@ function resolvePath(check: SmokeCheck, env: NodeJS.ProcessEnv): string | null {
   return buildPath ? buildPath(fixtureValue) : null;
 }
 
-async function fetchOnce(url: string): Promise<SmokeResponse> {
+async function fetchOnce(url: string, timeoutMs: number): Promise<SmokeResponse> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const response = await fetch(url, {
       signal: controller.signal,
@@ -650,7 +687,7 @@ async function runCheck(check: SmokeCheck, baseUrl: string, env: NodeJS.ProcessE
   for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
     let detail: string;
     try {
-      const response = await fetchOnce(url);
+      const response = await fetchOnce(url, check.timeoutMs ?? REQUEST_TIMEOUT_MS);
       const failure =
         originFailure(response, baseUrl) ??
         check.assert(response, {

--- a/scripts/production-smoke.ts
+++ b/scripts/production-smoke.ts
@@ -170,28 +170,41 @@ const MIN_RENDERED_PAGE_CHARS = 4_000;
 const SITEMAP_DEGRADED_HEADER = 'x-sitemap-degraded';
 
 /**
- * This header must be absent while climb sitemap publication is paused. Checking
- * it alongside the body catches a partial re-enable where the paged shard still
- * runs but its `<loc>` is missing from the index.
+ * Which path answered the climbs shard: `store` (the materialised
+ * `sitemap_climb_urls` rows) or `live` (the full grouped rebuild those rows
+ * exist to retire). It must be PRESENT now that publication is on — its absence
+ * is the signature of a half-enabled surface, where the index is built but the
+ * paged shard never ran.
+ *
+ * `live` is not a failure. On the deploy that turns publication on, and on any
+ * deploy that leaves the store empty, the fallback is the correct answer until
+ * the first refresh lands. It is expensive enough to be worth a WARN.
  */
 const SITEMAP_CLIMBS_SOURCE_HEADER = 'x-sitemap-climbs-source';
 const CLIMB_SITEMAP_PATH_PREFIX = '/sitemaps/climbs/';
-/**
- * `Cache-Control` directives the paused climb shard must and may carry.
- *
- * The route emits `public, s-maxage=3600, must-revalidate`
- * (packages/web/app/lib/seo/sitemap/shard-registry.ts). Vercel consumes
- * `s-maxage` as its private CDN instruction and strips it, so www serves
- * `public, must-revalidate` while a Railway origin serves the header verbatim.
- * A string compare against either one is wrong at the other origin, which is
- * why this parses directives: `public` and `must-revalidate` are the contract,
- * `s-maxage` is CDN plumbing that may or may not survive, and anything else
- * (`no-store`, `private`, `max-age=0`) is a real regression in the pause.
- */
-const REQUIRED_CLIMB_CACHE_DIRECTIVES = ['public', 'must-revalidate'] as const;
-const TOLERATED_CLIMB_CACHE_DIRECTIVES = ['s-maxage'] as const;
+const CLIMB_SITEMAP_STORE_SOURCE = 'store';
 
-/** Directive NAMES only — `s-maxage=3600` reads as `s-maxage`. */
+/**
+ * `Cache-Control` directives a published climb shard must and may carry.
+ *
+ * The route emits `public, s-maxage=21600, stale-while-revalidate=604800`
+ * (packages/web/app/lib/seo/sitemap/shard-registry.ts), and that long window is
+ * the whole reason a crawl of six 2.5 MB pages does not reach a ten-connection
+ * pool six times over. What a CDN forwards, though, is its own business: an edge
+ * that consumes `s-maxage` as a private instruction commonly rewrites the client
+ * copy to `public, max-age=0, must-revalidate`. A string compare is wrong at one
+ * origin or the other, so this parses directives instead.
+ *
+ * `public` is the contract — the shard has to be cacheable by something other
+ * than the browser that asked. The freshness directives are plumbing that may or
+ * may not survive the edge. Anything else (`no-store`, `private`, `no-cache`)
+ * means every crawler fetch reaches Postgres, which is the failure this window
+ * was built to prevent.
+ */
+const REQUIRED_CLIMB_CACHE_DIRECTIVES = ['public'] as const;
+const TOLERATED_CLIMB_CACHE_DIRECTIVES = ['s-maxage', 'stale-while-revalidate', 'max-age', 'must-revalidate'] as const;
+
+/** Directive NAMES only — `s-maxage=21600` reads as `s-maxage`. */
 function cacheControlDirectiveNames(header: string): string[] {
   return header
     .split(',')
@@ -199,7 +212,7 @@ function cacheControlDirectiveNames(header: string): string[] {
     .filter((name) => name.length > 0);
 }
 
-function expectPausedShardCacheControl(response: SmokeResponse): string | null {
+function expectClimbShardCacheControl(response: SmokeResponse): string | null {
   const header = response.headers['cache-control'] ?? '';
   const names = cacheControlDirectiveNames(header);
 
@@ -258,9 +271,14 @@ export function originFailure(response: SmokeResponse, baseUrl: string): string 
  * entry can still lose the 3 s deadline once and self-heal on the `after()` warm —
  * a WARN. The shard vanishing without the header saying so is still a FAIL.
  *
- * `climbs` is deliberately not required because this smoke pins the production
- * pause: its index entries and source signals must be absent, and its direct
- * route must return the cacheable 410 checked below.
+ * `climbs` is required again (#4648). While publication was paused this smoke
+ * pinned the opposite — entries absent, source header absent, direct route 410 —
+ * so that turning the surface back on could not be done with an environment
+ * variable alone. It is now the largest published surface by two orders of
+ * magnitude, ~53,000 URLs across six pages, and page 1 exists whenever the shard
+ * has any items at all. `degradable: true` for the same reason as `playlists`:
+ * an empty store makes the summary fall back to a scan that cannot meet the 3 s
+ * deadline, which drops the shard for sixty seconds and says so in the header.
  *
  * `degradable` is what `X-Sitemap-Degraded` may excuse. `boards` is genuinely
  * transient — a cold cache, a slow backend — and self-heals under the 60s window.
@@ -278,6 +296,7 @@ const REQUIRED_SITEMAP_SHARDS = [
   { id: 'static', loc: 'https://www.boardsesh.com/sitemaps/static.xml', degradable: false },
   { id: 'boards', loc: 'https://www.boardsesh.com/sitemaps/boards.xml', degradable: true },
   { id: 'playlists', loc: 'https://www.boardsesh.com/sitemaps/playlists.xml', degradable: true },
+  { id: 'climbs', loc: `https://www.boardsesh.com${CLIMB_SITEMAP_PATH_PREFIX}1.xml`, degradable: true },
 ] as const;
 
 type RequiredSitemapShard = (typeof REQUIRED_SITEMAP_SHARDS)[number];
@@ -397,18 +416,17 @@ export const WWW_CHECKS: SmokeCheck[] = [
       if (structural) return structural;
 
       const declared = declaredDegradedShards(response);
-      const pauseFailure = firstFailure(
-        response.body.includes(CLIMB_SITEMAP_PATH_PREFIX)
-          ? `response still publishes the paused ${CLIMB_SITEMAP_PATH_PREFIX} surface`
-          : null,
-        declared.includes('climbs')
-          ? `the ${SITEMAP_DEGRADED_HEADER} header names climbs instead of treating the pause as intentional`
-          : null,
-        response.headers[SITEMAP_CLIMBS_SOURCE_HEADER]
-          ? `the paused surface emitted ${SITEMAP_CLIMBS_SOURCE_HEADER}: ${response.headers[SITEMAP_CLIMBS_SOURCE_HEADER]}`
-          : null,
-      );
-      if (pauseFailure) return pauseFailure;
+      // A climbs entry with no source header is the half-enabled shape: the
+      // index listed the pages without the paged summary ever answering, so
+      // nothing proves the shard behind those `<loc>`s can be served. When the
+      // header names climbs the summary was dropped on purpose and reporting no
+      // source is the documented behaviour, not a gap.
+      const climbsPublished = response.body.includes(CLIMB_SITEMAP_PATH_PREFIX);
+      const sourceFailure =
+        climbsPublished && !declared.includes('climbs') && !response.headers[SITEMAP_CLIMBS_SOURCE_HEADER]
+          ? `index published ${CLIMB_SITEMAP_PATH_PREFIX} entries without a ${SITEMAP_CLIMBS_SOURCE_HEADER} header`
+          : null;
+      if (sourceFailure) return sourceFailure;
 
       const unexcused = missingRequiredShards(response).filter(
         (shard) => !shard.degradable || !declared.includes(shard.id),
@@ -429,18 +447,41 @@ export const WWW_CHECKS: SmokeCheck[] = [
         );
       }
 
+      // Correct, complete, and paying the 16.7 s scan the store exists to
+      // retire. Nothing external goes red on it, which is exactly why #4583 put
+      // the source on the wire in the first place — so say it out loud.
+      const climbsSource = response.headers[SITEMAP_CLIMBS_SOURCE_HEADER];
+      if (climbsSource && climbsSource !== CLIMB_SITEMAP_STORE_SOURCE) {
+        reasons.push(
+          `climb shard summary served from "${climbsSource}", not the store — run /api/internal/refresh-sitemap-climbs`,
+        );
+      }
+
       return reasons.length === 0 ? null : reasons.join('; ');
     },
   },
   {
-    name: 'the paused climb sitemap shard returns a cacheable Gone response',
-    path: '/sitemaps/climbs/1.xml',
+    // The index check above can only see that climbs was listed. This is the
+    // page a crawler actually fetches, and the one that used to cost 51 s cold.
+    name: 'the climb sitemap shard serves cacheable URLs',
+    path: `${CLIMB_SITEMAP_PATH_PREFIX}1.xml`,
     assert: (response) =>
       firstFailure(
-        expectStatus(response, 410),
-        expectContentType(response, 'text/plain'),
-        expectPausedShardCacheControl(response),
+        expectStatus(response, 200),
+        expectContentType(response, 'xml'),
+        expectBodyContains(response, '<urlset', '<urlset> root element'),
+        expectBodyContains(response, '<loc>', '<loc> entry'),
+        expectClimbShardCacheControl(response),
+        response.headers[SITEMAP_CLIMBS_SOURCE_HEADER]
+          ? null
+          : `shard served without a ${SITEMAP_CLIMBS_SOURCE_HEADER} header`,
       ),
+    degradation: (response) => {
+      const source = response.headers[SITEMAP_CLIMBS_SOURCE_HEADER];
+      return source && source !== CLIMB_SITEMAP_STORE_SOURCE
+        ? `page built from "${source}", not the store — the empty-store fallback rebuilds the whole ordered list per request`
+        : null;
+    },
   },
   {
     name: 'the static sitemap shard serves URLs',


### PR DESCRIPTION
## Summary

www serves from a Railway container. Verified 2026-09-02: `curl -sI https://www.boardsesh.com/` returns `x-railway-edge: sin1` and `x-railway-request-id`, with no `x-vercel-id`. So the platform ceilings that paused the climb sitemaps — a 4.5 MB serverless response cap, a 2 MB Data Cache entry cap, a 300 s invocation cap — describe a host we no longer run on. This republishes roughly 53,000 climb URLs and re-justifies (or deletes) every cap that was only ever a Vercel number.

**Closes #4618.** `shardRouteHandler` now byte-lengths the body it is about to serve, the same as the paged path — see "The byte guards" below, which also corrects that issue's arithmetic and files the remaining half as #5073.

### The switch, and why it stays

`Dockerfile.web` bakes `ENV CLIMB_SITEMAPS_ENABLED=true` into the runner stage. `climbSitemapsEnabled()` is byte-for-byte unchanged.

Flipping the default in code instead would have thrown the lever away. Railway injects service variables into the running container and those override an image `ENV`, so the kill switch is a variable on the `boardsesh-web` service: set `CLIMB_SITEMAPS_ENABLED` to anything but `true`, redeploy, and within one CDN window the index stops listing climb pages and `/sitemaps/climbs/*.xml` returns the cacheable 410 again. No code change, no rebuild, no revert. Railway config-as-code (`railway.web.toml`) cannot carry variables — its schema is build and deploy settings only, and it is deprecated as of 2026-12-01 — so the image `ENV` is the repo-visible half and the service variable is the operational half. A new text-pin test (`scripts/__tests__/dockerfile-web-climb-sitemaps.test.ts`) keeps the `ENV` from being dropped silently; nothing in CI runs this image, so a text pin is the only in-repo oracle.

### The smoke contract flips in the same commit

That is the point of the tripwire, and `docs/sitemap.md` said so: "changing only an environment variable cannot silently restore the crawler load." `scripts/production-smoke.ts` required the source header absent, the index without climb entries, and a 410 from the shard. It now requires the inverse — `climbs` joins the required-shard list, `/sitemaps/climbs/1.xml` must answer 200 XML with URLs, and both must name a source. The tripwire still works, pointing the other way: an image that loses the `ENV` turns the post-deploy smoke red instead of quietly withdrawing 53,000 URLs. `X-Sitemap-Climbs-Source: live` is a WARN, not a FAIL — correct, complete, and paying the scan the store exists to retire.

Two things that WARN needs in order to be reachable at all:

- **The shard check gets its own 90 s request budget.** `pagedShardRouteHandler` puts no deadline on `buildPage()`, and the empty-store fallback behind it is the 51 s rebuild — longer than the suite's shared `REQUEST_TIMEOUT_MS` of 30 s. On the shared budget the fetch aborts, all three attempts record a failure, and the documented WARN reports as a hard FAIL — which is grounds for the automatic web rollback the moment `WEB_DEPLOY_TARGETS` drops `vercel`. `SmokeCheck` grew an optional `timeoutMs`, and a test pins that this is the only check using one.
- **The cache-control contract keeps a freshness directive required.** Relaxing `['public', 'must-revalidate']` to `['public']` alone would pass a bare `cache-control: public` — cacheable forever at every hop with nothing to revalidate against, i.e. a shard that lost its entire CDN window. It now needs `public` **and** at least one of `s-maxage` / `max-age` / `stale-while-revalidate`, which accepts both the origin form and the `max-age=0, must-revalidate` an edge rewrites it to.

### The refresh runs on the scheduler that already exists

`docs/sitemap.md`'s runbook called for a separate one-shot Railway cron service with a `node -e` start command. `packages/scheduler` **is** that service, and it already has Sentry cron monitors, per-job timeouts, retry-on-502/503 and a `SCHEDULER_DISABLED_JOBS` kill switch. One `JobDefinition` added:

| field | value |
| --- | --- |
| `name` | `refresh-sitemap-climbs` |
| `schedule` | `0 */6 * * *` (matches `s-maxage=21600` on the shard pages) |
| `timezone` | `UTC` |
| `timeoutMs` | `900_000` |
| `webPath` | `/api/internal/refresh-sitemap-climbs` |

15 minutes rather than the route's `maxDuration = 300`: that export is Vercel's Pro ceiling and is inert on the container, and the work behind it is sixteen sequential `DISTINCT ON` scans measured at 51 s in production. It is overlap-safe as `JobDefinition` requires — the refresher takes `pg_try_advisory_xact_lock` as the first statement of its write transaction, so a second run answers `skipped: "locked"` and writes nothing.

`registry.test.ts` diffs `VERCEL_OWNED_CRON_PATHS` against `vercel.json` and against `JOBS`; this path is in neither, so the guard is satisfied. The row joins the one existing pinned list rather than a second one, because the six-hourly slot **is** the slot Vercel ran: `git show c69611d0b:packages/web/vercel.json` carries `{"path": "/api/internal/refresh-sitemap-climbs", "schedule": "0 */6 * * *"}`, live from 2026-08-22 until `98ef8e32b` ("fix(web): pause climb sitemap publication") deleted it on 2026-08-29 — before #4654 moved the rest across. This job missed the migration; it did not skip Vercel. The runbook in `docs/sitemap.md` now points at the scheduler.

### Caps lifted

| constant | was | now | why |
| --- | --- | --- | --- |
| `MAX_SHARD_BYTES` | 4,000,000, paged path only | 45,000,000, both paths | 4 MB was Vercel's 4.5 MB response ceiling with headroom. Off Vercel the authority is the protocol: sitemaps.org's 50 MB, with the same 10% headroom `MAX_URLS_PER_SHARD` keeps against 50,000 URLs. |
| paged page budget | — | `pagedShardByteBudget()`, page size x 500 B | New. A protocol-sized number cannot guard a 2.5 MB page; this one is sized to the page it guards. See below. |
| `maxDuration` on `/sitemap.xml` | 300 | deleted | Its own comment already said it was inert off Vercel. |
| climb items in the Next Data Cache | out (2 MB entry cap) | still out, new reason | The entry cap is gone; one 20 MB entry would evict the small load-bearing ones from the standalone server's in-process incremental-cache budget, `getAllBoardConfigsOrThrow` among them (#4519). |
| playlist rows cached, not precomputed | vs 2 MB entry cap | vs the in-process cache budget | ~200 KB today, ~840 KB at the item cap. Still small enough to hold. |

`CLIMB_URLS_PER_SHARD` keeps its 10,000 and gets a non-platform argument instead: per-page `<lastmod>` granularity (six pages localise a stats update to a sixth of the catalogue; two pages of 45,000 would put half of it back in play on every refresh) and bounded work per request (~21 ms and ~2.5 MB versus 4.5× both). Raising it is a crawl-shape decision, not leftover cleanup.

Untouched, because none of them is a Vercel number: `MAX_URLS_PER_SHARD` (sitemaps.org protocol), `TIER_2_MIN_ASCENTS`, `FRONT_DOOR_MAX_INDEXABLE_PAGE` / `FRONT_DOOR_MAX_PAGE`, `DIRECTORY_MAX_PAGE`, `MAX_ROWS_PER_GROUP`, `SHARD_DEADLINE_MS`, and `expectsUrls: false` on gyms and setters.

### Mitigations kept

- The angle `DISTINCT ON (climb_uuid)` in `buildChosenSubquery` is untouched. #4767 measured ~203,900 climb-view renders/day against a ~60k-URL surface; that dedup is what keeps this at ~53k instead of ~200k.
- Locales are **not** fanned out. `entries.ts` had two reasons and one of them died with Vercel; the comment now says which. The SEO reason stands and is the stronger one — board content cross-canonicalises its locale twins, so there is no cluster to annotate, and fanning out would submit ~158,000 URLs that are not independently indexable pages.

### The byte guards

Two numbers doing two jobs, because one number cannot do both.

**`MAX_SHARD_BYTES` (45 MB) is the protocol backstop, and it now runs on both paths.** #4618 asks for `bytes > MAX_SHARD_BYTES` on `shardRouteHandler`; that is what landed. The fixed path byte-lengths its rendered body and 503s rather than serving a file Search Console rejects whole. The constant is derived from sitemaps.org's 50 MB rather than from a platform ceiling, so it fails closed where the protocol does and not a byte earlier — a shard that merely grew keeps serving.

**`pagedShardByteBudget(urlsPerShard)` is the working guard on a paged page.** `climbs` is the only entry in `PAGED_SHARD_REGISTRY` and renders 10,000 URLs at ~250 B each — ~2.5 MB. A 45 MB ceiling is eighteen times that and cannot see the regression that matters: a per-URL cost that multiplied rather than a shard that grew. Adding an hreflang alternates block to the default-locale expansion — exactly what `entries.ts` warns against — costs 866 B/URL, i.e. 8.7 MB per climbs page. At 500 B/URL the page budget is 5 MB: double the measured cost, well under the fanned-out one, so that regression 503s and a page with legitimately long paths still serves. Both guards are mutation-tested — removing either turns a test red.

The arithmetic, re-measured live on www 2026-09-02: `/sitemaps/playlists.xml` is 2,615,676 bytes across 3,020 `<url>` entries and 15,100 `xhtml:link` elements — **866 bytes per URL**. #4618 records ~216 B/URL, from before the five-entry alternates block existed, so every row in its table understates the cost about fourfold: `MAX_ITEMS_PER_SHARD` (11,250 items → 45,000 URLs) renders ~39 MB, not the ~9.7 MB the issue assumes. That is legal under the protocol and still a lot of file to hand a crawler, so **#5073** is filed for paging `playlists` onto the `PagedSitemapShard` machinery — which is what gives it a page-sized budget the way climbs has one. `docs/sitemap.md` records both.

### Rollback

**A DNS rollback to Vercel also withdraws this surface, and nothing catches it.** `WEB_DEPLOY_TARGETS` still lists `vercel` for the rollback window, and the Vercel build does not read `Dockerfile.web`, so that deployment has no `CLIMB_SITEMAPS_ENABLED` and keeps serving the withdrawn contract — no climb entries in the index, 410 from the shard pages. Rolling www back to it drops ~53,000 URLs until `CLIMB_SITEMAPS_ENABLED=true` is set on the Vercel project and it redeploys. That deployment's `/sitemap.xml` also runs on the platform default function duration now that `maxDuration = 300` is gone, and the Vercel post-deploy smoke that would have reported either is commented out in `production-deploy.yml`. Recorded in `docs/sitemap.md`'s "the way back".

To withdraw the surface on the deployment that actually serves it: set `CLIMB_SITEMAPS_ENABLED=false` on the Railway `boardsesh-web` service (Variables tab → deploy the staged change) and redeploy. The gate fails closed on anything that is not exactly `true`, so the surface returns to withdrawn — index without climb entries, `410 Gone` with a one-hour cache on every shard page — with no code change and no image rebuild. The store keeps its rows; nothing needs repopulating on the way back. The post-deploy smoke will then go red on the enabled contract, which is intended; flip the smoke back in the same change if the withdrawal is meant to last. `git revert` also works and additionally removes the scheduler job.

### Sequencing and watch list

- **#4849 ("fix(db): bound production connection pressure") should land first.** #4842 (~3,090 500s/day from front-door SSR at crawl peak) and #4861 (idle connections exhausting `max_connections=200`) are both still open, and republishing ~53,000 URLs is what drove that load.
- After deploy, watch `/health/db`, the web service's 500 rate, and `pg_stat_activity` web connections for at least the first day.
- The shard pages carry `s-maxage=21600, stale-while-revalidate=604800`, so Cloudflare absorbs a crawl burst before it reaches the pool — that window is load-bearing here, not decoration.

Closes #5078

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.
2. After deploy, open `/sitemap.xml`. It lists `/sitemaps/climbs/1.xml`.
3. Open `/sitemaps/climbs/1.xml`. XML loads with climb URLs.
4. Run `curl -sI` on it. `x-sitemap-climbs-source: store` is present.

## Risk

Risk: 4/5 — restores a ~53k-URL crawl surface while two connection-exhaustion issues are open.

