### PR TITLE
feat(web): put the gym finder in the nav, footer and homepage

### DIFF
--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -558,7 +558,7 @@
       "about": "Über uns",
       "help": "Hilfe"
     },
-    "navLabel": "Hauptmenü"
+    "navLabel": "Hauptnavigation"
   },
   "share": {
     "profileTitle": "Kletterprofil von {{name}}",

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -540,7 +540,8 @@
     "userMenu": "Nutzer*innen-Menü",
     "startClimbing": "In der App loslegen",
     "home": "Boardsesh-Startseite",
-    "yourProfile": "Dein Profil"
+    "yourProfile": "Dein Profil",
+    "openMenu": "Menü öffnen"
   },
   "header": {
     "you": "Du",
@@ -550,7 +551,14 @@
     "createdClimbs": "Gebaute Boulder",
     "auroraMigration": "Aurora-Migration",
     "startClimbing": "Loslegen",
-    "signIn": "Anmelden"
+    "signIn": "Anmelden",
+    "nav": {
+      "gyms": "Hallen",
+      "playlists": "Playlists",
+      "about": "Über uns",
+      "help": "Hilfe"
+    },
+    "navLabel": "Hauptmenü"
   },
   "share": {
     "profileTitle": "Kletterprofil von {{name}}",
@@ -727,7 +735,16 @@
       "playlists": "Playlists",
       "auroraMigration": "Aurora-Migration",
       "legal": "Impressum",
-      "privacy": "Datenschutz"
+      "privacy": "Datenschutz",
+      "gymsKilter": "Hallen mit einem Kilter Board",
+      "gymsTension": "Hallen mit einem Tension Board",
+      "gymsMoonboard": "Hallen mit einem MoonBoard",
+      "gyms": "Alle Hallen und Wände"
+    },
+    "groups": {
+      "findAGym": "Halle finden",
+      "explore": "Entdecken",
+      "smallPrint": "Kleingedrucktes"
     }
   }
 }

--- a/packages/shared/i18n/locales/de/marketing.json
+++ b/packages/shared/i18n/locales/de/marketing.json
@@ -53,7 +53,9 @@
       "bluetoothTitle": "Verbinde dein Board",
       "bluetoothDescription": "Per Bluetooth koppeln und den nächsten Boulder beleuchten",
       "discordTitle": "Komm auf Discord zur Crew",
-      "discordDescription": "Beta teilen, Fehler melden und mitbestimmen, was als Nächstes kommt"
+      "discordDescription": "Beta teilen, Fehler melden und mitbestimmen, was als Nächstes kommt",
+      "gymTitle": "Finde eine Halle in deiner Nähe",
+      "gymDescription": "Sieh, welche Wände ein Kilter Board, Tension Board oder MoonBoard haben"
     },
     "gymCard": {
       "ownerSubtitle": "Die Halle deiner Crew, nur einen Fingertipp entfernt",

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -540,7 +540,8 @@
     "userMenu": "User menu",
     "startClimbing": "Start climbing in the app",
     "home": "Boardsesh home",
-    "yourProfile": "Your profile"
+    "yourProfile": "Your profile",
+    "openMenu": "Open menu"
   },
   "header": {
     "you": "You",
@@ -550,7 +551,14 @@
     "createdClimbs": "Created Climbs",
     "auroraMigration": "Aurora Migration",
     "startClimbing": "Start climbing",
-    "signIn": "Sign in"
+    "signIn": "Sign in",
+    "nav": {
+      "gyms": "Gyms",
+      "playlists": "Playlists",
+      "about": "About",
+      "help": "Help"
+    },
+    "navLabel": "Main"
   },
   "share": {
     "profileTitle": "{{name}}'s climbing profile",
@@ -727,7 +735,16 @@
       "playlists": "Playlists",
       "auroraMigration": "Aurora migration",
       "legal": "Legal",
-      "privacy": "Privacy"
+      "privacy": "Privacy",
+      "gymsKilter": "Gyms with a Kilter board",
+      "gymsTension": "Gyms with a Tension board",
+      "gymsMoonboard": "Gyms with a MoonBoard",
+      "gyms": "All gyms and walls"
+    },
+    "groups": {
+      "findAGym": "Find a gym",
+      "explore": "Explore",
+      "smallPrint": "Small print"
     }
   }
 }

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -558,7 +558,7 @@
       "about": "About",
       "help": "Help"
     },
-    "navLabel": "Main"
+    "navLabel": "Main navigation"
   },
   "share": {
     "profileTitle": "{{name}}'s climbing profile",

--- a/packages/shared/i18n/locales/en-US/marketing.json
+++ b/packages/shared/i18n/locales/en-US/marketing.json
@@ -53,7 +53,9 @@
       "bluetoothTitle": "Connect your board",
       "bluetoothDescription": "Pair via Bluetooth and light up your next climb",
       "discordTitle": "Join the crew on Discord",
-      "discordDescription": "Share beta, report bugs, and help shape what's next"
+      "discordDescription": "Share beta, report bugs, and help shape what's next",
+      "gymTitle": "Find a gym near you",
+      "gymDescription": "See which walls run a Kilter, Tension or MoonBoard"
     },
     "gymCard": {
       "ownerSubtitle": "Your crew's gym, one tap away",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -46,7 +46,7 @@
       "about": "Sobre nosotros",
       "help": "Ayuda"
     },
-    "navLabel": "Principal"
+    "navLabel": "Navegación principal"
   },
   "share": {
     "profileTitle": "Perfil de escalada de {{name}}",

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -28,7 +28,8 @@
     "userMenu": "Menú de usuario",
     "startClimbing": "Empieza a escalar en la app",
     "home": "Inicio de Boardsesh",
-    "yourProfile": "Tu perfil"
+    "yourProfile": "Tu perfil",
+    "openMenu": "Abrir menú"
   },
   "header": {
     "you": "Tú",
@@ -38,7 +39,14 @@
     "createdClimbs": "Bloques creados",
     "auroraMigration": "Migración de Aurora",
     "startClimbing": "Empieza a escalar",
-    "signIn": "Iniciar sesión"
+    "signIn": "Iniciar sesión",
+    "nav": {
+      "gyms": "Rocódromos",
+      "playlists": "Listas",
+      "about": "Sobre nosotros",
+      "help": "Ayuda"
+    },
+    "navLabel": "Principal"
   },
   "share": {
     "profileTitle": "Perfil de escalada de {{name}}",
@@ -727,7 +735,16 @@
       "playlists": "Listas",
       "auroraMigration": "Migración desde Aurora",
       "legal": "Aviso legal",
-      "privacy": "Privacidad"
+      "privacy": "Privacidad",
+      "gymsKilter": "Rocódromos con un plafón Kilter",
+      "gymsTension": "Rocódromos con un plafón Tension",
+      "gymsMoonboard": "Rocódromos con un MoonBoard",
+      "gyms": "Todos los rocódromos y muros"
+    },
+    "groups": {
+      "findAGym": "Encuentra un rocódromo",
+      "explore": "Explora",
+      "smallPrint": "Letra pequeña"
     }
   }
 }

--- a/packages/shared/i18n/locales/es/marketing.json
+++ b/packages/shared/i18n/locales/es/marketing.json
@@ -53,7 +53,9 @@
       "bluetoothTitle": "Conecta tu plafón",
       "bluetoothDescription": "Vincula por Bluetooth e ilumina tu siguiente problema",
       "discordTitle": "Únete al grupo en Discord",
-      "discordDescription": "Comparte beta, reporta fallos y ayuda a decidir qué viene"
+      "discordDescription": "Comparte beta, reporta fallos y ayuda a decidir qué viene",
+      "gymTitle": "Encuentra un rocódromo cerca",
+      "gymDescription": "Mira qué muros tienen un plafón Kilter, uno Tension o un MoonBoard"
     },
     "gymCard": {
       "ownerSubtitle": "El rocódromo de tu equipo, a un toque",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -540,7 +540,8 @@
     "userMenu": "Menu utilisateur",
     "startClimbing": "Commencer à grimper dans l'appli",
     "home": "Accueil Boardsesh",
-    "yourProfile": "Votre profil"
+    "yourProfile": "Votre profil",
+    "openMenu": "Ouvrir le menu"
   },
   "header": {
     "you": "Vous",
@@ -550,7 +551,14 @@
     "createdClimbs": "Blocs créés",
     "auroraMigration": "Migration Aurora",
     "startClimbing": "Commencer à grimper",
-    "signIn": "Se connecter"
+    "signIn": "Se connecter",
+    "nav": {
+      "gyms": "Salles",
+      "playlists": "Playlists",
+      "about": "À propos",
+      "help": "Aide"
+    },
+    "navLabel": "Principal"
   },
   "share": {
     "profileTitle": "Profil de grimpeur de {{name}}",
@@ -727,7 +735,16 @@
       "playlists": "Playlists",
       "auroraMigration": "Migration Aurora",
       "legal": "Mentions légales",
-      "privacy": "Confidentialité"
+      "privacy": "Confidentialité",
+      "gymsKilter": "Salles avec une board Kilter",
+      "gymsTension": "Salles avec une board Tension",
+      "gymsMoonboard": "Salles avec un MoonBoard",
+      "gyms": "Toutes les salles et tous les murs"
+    },
+    "groups": {
+      "findAGym": "Trouver une salle",
+      "explore": "Explorer",
+      "smallPrint": "Mentions légales"
     }
   }
 }

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -558,7 +558,7 @@
       "about": "À propos",
       "help": "Aide"
     },
-    "navLabel": "Principal"
+    "navLabel": "Navigation principale"
   },
   "share": {
     "profileTitle": "Profil de grimpeur de {{name}}",
@@ -744,7 +744,7 @@
     "groups": {
       "findAGym": "Trouver une salle",
       "explore": "Explorer",
-      "smallPrint": "Mentions légales"
+      "smallPrint": "Petits caractères"
     }
   }
 }

--- a/packages/shared/i18n/locales/fr/marketing.json
+++ b/packages/shared/i18n/locales/fr/marketing.json
@@ -53,7 +53,9 @@
       "bluetoothTitle": "Connectez votre board",
       "bluetoothDescription": "Appairez en Bluetooth et allumez votre prochain bloc",
       "discordTitle": "Rejoignez le crew sur Discord",
-      "discordDescription": "Partagez la beta, signalez des bugs et donnez votre avis sur la suite"
+      "discordDescription": "Partagez la beta, signalez des bugs et donnez votre avis sur la suite",
+      "gymTitle": "Trouve une salle près de chez toi",
+      "gymDescription": "Vois quels murs ont une board Kilter, une board Tension ou un MoonBoard"
     },
     "gymCard": {
       "ownerSubtitle": "La salle de votre crew, à portée de main",

--- a/packages/web/app/__tests__/home-page-content.test.tsx
+++ b/packages/web/app/__tests__/home-page-content.test.tsx
@@ -289,6 +289,19 @@ describe('HomePageContent', () => {
       expect(hrefs).toContain('/playlists');
     });
 
+    // The gym nudge came out with the search drawer and left a comment behind
+    // promising its return "when #4372 builds the gyms directory". It did, so
+    // the card is back — and unlike HomeGymCard, which self-gates to null, this
+    // one renders for the signed-out visitor this suite mocks.
+    it('points the "find a gym" card at the directory', () => {
+      render(<HomePageContent {...defaultProps} />);
+
+      const card = screen.getByRole('link', {
+        name: new RegExp(resolveMarketingKey('home.cards.gymTitle'), 'i'),
+      });
+      expect(card.getAttribute('href')).toBe('/gyms');
+    });
+
     it('hands the "Connect your board" card off to the app origin', () => {
       render(<HomePageContent {...defaultProps} />);
 

--- a/packages/web/app/components/site-chrome/__tests__/marketing-header.test.tsx
+++ b/packages/web/app/components/site-chrome/__tests__/marketing-header.test.tsx
@@ -124,6 +124,81 @@ describe('MarketingHeader', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Primary nav
+  //
+  // The header shipped with no nav at all, which is how the gym directory ended
+  // up reachable only by typing the URL. These cases pin both halves of the
+  // contract: which four destinations it carries, and that the anchors are in
+  // the markup at every viewport (the responsive swap is CSS — the component
+  // must not learn how wide the screen is).
+  // -----------------------------------------------------------------------
+  describe('primary nav', () => {
+    const NAV_PATHS = ['/gyms', '/playlists', '/about', '/help'];
+
+    for (const [label, pathname] of [
+      ['the default header', '/some-page'],
+      ['the transparent home header', '/'],
+    ] as const) {
+      it(`carries the four nav links on ${label}`, () => {
+        mockPathname = pathname;
+        const { container } = render(<MarketingHeader />);
+
+        const nav = container.querySelector('nav');
+        expect(nav?.getAttribute('aria-label')).toBe(tFromCatalog('common', 'header.navLabel'));
+
+        const hrefs = Array.from(nav?.querySelectorAll('a') ?? []).map((anchor) => anchor.getAttribute('href'));
+        expect(hrefs).toEqual(NAV_PATHS);
+      });
+    }
+
+    it('labels each nav link from the catalog', () => {
+      const { container } = render(<MarketingHeader />);
+
+      const labels = Array.from(container.querySelectorAll('nav a')).map((anchor) => anchor.textContent);
+      expect(labels).toEqual(['Gyms', 'Playlists', 'About', 'Help']);
+    });
+
+    // The wireframe draws a "Boards" tab. `/boards` does not exist, so linking
+    // it would put a 404 in the chrome of every page.
+    it('links nowhere into /boards — the route does not exist', () => {
+      const { container } = render(<MarketingHeader />);
+
+      expect(container.querySelectorAll('a[href^="/boards"]').length).toBe(0);
+    });
+
+    // The narrow-viewport treatment is a menu button, not a second set of
+    // always-rendered anchors: the inline row is the crawlable copy and it is
+    // hidden with CSS rather than unmounted, so it is present here too.
+    it('offers a menu button whose items repeat the same four destinations', () => {
+      render(<MarketingHeader />);
+
+      const menuButton = screen.getByLabelText('Open menu');
+      expect(menuButton.getAttribute('aria-expanded')).toBe('false');
+
+      fireEvent.click(menuButton);
+
+      expect(menuButton.getAttribute('aria-expanded')).toBe('true');
+      const menuItemHrefs = screen
+        .getAllByRole('menuitem')
+        .map((item) => item.closest('a')?.getAttribute('href') ?? item.getAttribute('href'));
+      expect(menuItemHrefs).toEqual(NAV_PATHS);
+    });
+
+    // The centred and brand-only variants own their whole bar — a profile
+    // header is a back button, a title and one action, and /settings is the
+    // brand link alone. Neither gets the nav.
+    for (const pathname of ['/profile/user-2', '/profile/user-2/statistics', '/settings', '/aurora-migration']) {
+      it(`leaves ${pathname} without a nav`, () => {
+        mockPathname = pathname;
+        const { container } = render(<MarketingHeader />);
+
+        expect(container.querySelector('nav')).toBeNull();
+        expect(container.querySelectorAll('a[href="/gyms"]').length).toBe(0);
+      });
+    }
+  });
+
+  // -----------------------------------------------------------------------
   // The account affordance that replaces the deleted UserDrawer
   // -----------------------------------------------------------------------
   describe('account affordance', () => {

--- a/packages/web/app/components/site-chrome/__tests__/site-footer-ssr.test.tsx
+++ b/packages/web/app/components/site-chrome/__tests__/site-footer-ssr.test.tsx
@@ -37,11 +37,22 @@ vi.mock('@/app/components/i18n/locale-link', () => ({
 /** Every static entry in `app/sitemap.ts`. */
 const SITEMAP_PATHS = ['/', '/about', '/help', '/docs', '/playlists', '/aurora-migration', '/legal', '/privacy'];
 
+/**
+ * Every path the footer links to — a superset of `SITEMAP_PATHS`.
+ *
+ * The `/gyms*` routes are `noindex, follow` and out of the sitemap on purpose
+ * until the duplicate-gym queue drains (#4372, #4381). A crawler still follows
+ * them, but only if the anchors are in the first HTML — which is exactly what
+ * this file exists to prove, so they belong here and not in `SITEMAP_PATHS`.
+ */
+const GYM_DIRECTORY_PATHS = ['/gyms', '/gyms/kilter', '/gyms/tension', '/gyms/moonboard'];
+const FOOTER_PATHS = [...SITEMAP_PATHS, ...GYM_DIRECTORY_PATHS];
+
 describe('SiteFooter server-rendered HTML', () => {
-  it('ships every sitemap link as a real anchor in the first render', () => {
+  it('ships every footer link as a real anchor in the first render', () => {
     const html = renderToString(<SiteFooter />);
 
-    for (const path of SITEMAP_PATHS) {
+    for (const path of FOOTER_PATHS) {
       expect(html, `first HTML must carry an anchor to ${path}`).toContain(`href="${path}"`);
     }
   });
@@ -61,6 +72,10 @@ describe('SiteFooter server-rendered HTML', () => {
       'footer.links.auroraMigration',
       'footer.links.legal',
       'footer.links.privacy',
+      'footer.links.gyms',
+      'footer.links.gymsKilter',
+      'footer.links.gymsTension',
+      'footer.links.gymsMoonboard',
     ]) {
       expect(html).toContain(key);
     }

--- a/packages/web/app/components/site-chrome/__tests__/site-footer.test.tsx
+++ b/packages/web/app/components/site-chrome/__tests__/site-footer.test.tsx
@@ -43,6 +43,17 @@ vi.mock('next/link', () => ({
 /** Every static entry in `app/sitemap.ts`. */
 const SITEMAP_PATHS = ['/', '/about', '/help', '/docs', '/playlists', '/aurora-migration', '/legal', '/privacy'];
 
+/**
+ * Every path the footer links to — a superset of `SITEMAP_PATHS`.
+ *
+ * The four `/gyms*` routes are deliberately NOT sitemap entries: the directory
+ * is `noindex, follow` until the duplicate-gym queue drains (#4372, #4381), so
+ * the footer anchors are its only crawl path. Keeping the two constants apart
+ * is the point — folding `/gyms` into `SITEMAP_PATHS` would make that
+ * constant's name a lie and quietly assert a sitemap entry that must not exist.
+ */
+const FOOTER_PATHS = [...SITEMAP_PATHS, '/gyms', '/gyms/kilter', '/gyms/tension', '/gyms/moonboard'];
+
 describe('SiteFooter', () => {
   beforeEach(() => {
     mockPathname = '/';
@@ -64,13 +75,50 @@ describe('SiteFooter', () => {
     }
   });
 
+  // The gym directory has no sitemap entry, so the footer is the crawl path
+  // into it. Descriptive anchor text is the SEO half of that — "Gyms with a
+  // Kilter board" is the query shape, "Gyms" is not.
+  it('links to each board-type gym directory with descriptive anchor text', () => {
+    const { container } = render(<SiteFooter />);
+
+    const anchorsByHref = new Map(
+      Array.from(container.querySelectorAll('a')).map((anchor) => [anchor.getAttribute('href'), anchor.textContent]),
+    );
+
+    expect(anchorsByHref.get('/gyms/kilter')).toBe('Gyms with a Kilter board');
+    expect(anchorsByHref.get('/gyms/tension')).toBe('Gyms with a Tension board');
+    expect(anchorsByHref.get('/gyms/moonboard')).toBe('Gyms with a MoonBoard');
+    expect(anchorsByHref.get('/gyms')).toBe('All gyms and walls');
+  });
+
+  // The wireframe drew `/gyms?board=kilter`; the routes shipped literal. A
+  // query-param href would point at a URL that self-canonicalises to `/gyms`,
+  // throwing away the per-board landing page the anchor exists to feed.
+  it('points at the literal facet routes, never the query-param form', () => {
+    const { container } = render(<SiteFooter />);
+
+    const hrefs = Array.from(container.querySelectorAll('a')).map((anchor) => anchor.getAttribute('href'));
+    expect(hrefs.filter((href) => href?.includes('?'))).toEqual([]);
+  });
+
   it('renders those links as real anchors inside a labelled nav', () => {
     const { container } = render(<SiteFooter />);
 
     const nav = container.querySelector('nav');
     expect(nav).toBeTruthy();
     expect(nav?.getAttribute('aria-label')).toBe(tFromCatalog('common', 'footer.navLabel'));
-    expect(nav?.querySelectorAll('a').length).toBe(SITEMAP_PATHS.length);
+    expect(nav?.querySelectorAll('a').length).toBe(FOOTER_PATHS.length);
+  });
+
+  it('groups the links under headings so twelve of them stay scannable', () => {
+    const { container } = render(<SiteFooter />);
+
+    const headings = Array.from(container.querySelectorAll('nav h2')).map((heading) => heading.textContent);
+    expect(headings).toEqual([
+      tFromCatalog('common', 'footer.groups.findAGym'),
+      tFromCatalog('common', 'footer.groups.explore'),
+      tFromCatalog('common', 'footer.groups.smallPrint'),
+    ]);
   });
 
   it('hands off to the app', () => {

--- a/packages/web/app/components/site-chrome/__tests__/site-footer.test.tsx
+++ b/packages/web/app/components/site-chrome/__tests__/site-footer.test.tsx
@@ -97,8 +97,14 @@ describe('SiteFooter', () => {
   it('points at the literal facet routes, never the query-param form', () => {
     const { container } = render(<SiteFooter />);
 
-    const hrefs = Array.from(container.querySelectorAll('a')).map((anchor) => anchor.getAttribute('href'));
-    expect(hrefs.filter((href) => href?.includes('?'))).toEqual([]);
+    const gymHrefs = Array.from(container.querySelectorAll('a'))
+      .map((anchor) => anchor.getAttribute('href'))
+      .filter((href): href is string => href !== null && href.startsWith('/gyms'));
+
+    // Guards the filter itself: a renamed route would otherwise make the
+    // no-`?` assertion below pass over an empty list.
+    expect(gymHrefs).toHaveLength(4);
+    expect(gymHrefs.filter((href) => href.includes('?'))).toEqual([]);
   });
 
   it('renders those links as real anchors inside a labelled nav', () => {

--- a/packages/web/app/components/site-chrome/marketing-header.module.css
+++ b/packages/web/app/components/site-chrome/marketing-header.module.css
@@ -28,6 +28,41 @@
   gap: 4px;
 }
 
+/*
+ * Two treatments of the same four links, swapped by viewport alone — the repo
+ * bans JS breakpoint detection, so neither treatment may know how wide the
+ * screen is.
+ *
+ * The inline row stays mounted at every width (hidden, not removed) so the
+ * anchors are in the first server-rendered HTML for a crawler. Below 900px it
+ * is `display: none` and the menu button takes over; from 900px up the button
+ * is the one that disappears. 900px is where the brand, four links, the
+ * account slot and the "Start climbing" pill all fit on one row without the
+ * nav pushing the CTA off the end.
+ */
+.nav {
+  display: none;
+  align-items: center;
+  gap: 20px;
+  min-width: 0;
+}
+
+.navMenuSlot {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+@media (min-width: 900px) {
+  .nav {
+    display: flex;
+  }
+
+  .navMenuSlot {
+    display: none;
+  }
+}
+
 .iconButtonWrapper {
   position: relative;
   flex-shrink: 0;
@@ -64,6 +99,16 @@
 
 .headerTransparent > * {
   pointer-events: auto;
+}
+
+/* The menu button costs the narrowest phones ~30px they did not have to spend
+   before. Tighten the header's own gaps rather than let it squeeze the CTA.
+   Declared after both bar rules so it wins on equal specificity. */
+@media (max-width: 599px) {
+  .header,
+  .headerTransparent {
+    gap: 8px;
+  }
 }
 
 :global(html[data-theme='dark']) .header {

--- a/packages/web/app/components/site-chrome/marketing-header.tsx
+++ b/packages/web/app/components/site-chrome/marketing-header.tsx
@@ -1,12 +1,16 @@
 'use client';
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Button from '@mui/material/Button';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import MuiLink from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 import SettingsOutlined from '@mui/icons-material/SettingsOutlined';
 import IosShareOutlined from '@mui/icons-material/IosShare';
+import MenuOutlined from '@mui/icons-material/Menu';
 import PersonOutlined from '@mui/icons-material/PersonOutlined';
 import TuneOutlined from '@mui/icons-material/TuneOutlined';
 import { useSession } from 'next-auth/react';
@@ -48,6 +52,14 @@ const BRAND_SX = {
   color: 'var(--bs-text-brand-primary)',
   px: 0.5,
   '&:hover': { backgroundColor: 'transparent' },
+} as const;
+
+const NAV_LINK_SX = {
+  color: 'var(--bs-text-brand-muted)',
+  fontWeight: themeTokens.typography.fontWeight.medium,
+  textDecoration: 'none',
+  whiteSpace: 'nowrap',
+  '&:hover': { color: 'var(--bs-text-brand-primary)', textDecoration: 'underline' },
 } as const;
 
 /** Route prefixes that render a simple title header instead of the default marketing header */
@@ -171,6 +183,7 @@ export default function MarketingHeader() {
   const { t } = useTranslation('common');
   const { data: session } = useSession();
   const { showMessage } = useSnackbar();
+  const [navMenuAnchor, setNavMenuAnchor] = useState<HTMLElement | null>(null);
 
   const statsFilterBridge = useStatsFilterBridge();
   const profileHeaderShare = useProfileHeaderShare();
@@ -202,6 +215,56 @@ export default function MarketingHeader() {
       {/* i18n-ignore-next-line — brand name, never translated (CLAUDE.md) */}
       Boardsesh
     </Button>
+  );
+
+  // The four destinations www still owns. `/boards` is deliberately absent —
+  // the route does not exist, and the climbing UI it would have pointed at
+  // moved to the app in W-16.
+  const navLinks: { href: string; label: string }[] = [
+    { href: '/gyms', label: t('header.nav.gyms') },
+    { href: '/playlists', label: t('header.nav.playlists') },
+    { href: '/about', label: t('header.nav.about') },
+    { href: '/help', label: t('header.nav.help') },
+  ];
+
+  // Both treatments render the same four anchors. The inline row is always in
+  // the DOM (CSS hides it below 900px rather than unmounting it), so a crawler
+  // reads the links on every page regardless of viewport — the menu below is a
+  // touch affordance, not the only copy of them.
+  const primaryNav = (
+    <>
+      <Box component="nav" aria-label={t('header.navLabel')} className={styles.nav}>
+        {navLinks.map(({ href, label }) => (
+          <MuiLink key={href} component={LocaleLink} href={href} variant="body2" sx={NAV_LINK_SX}>
+            {label}
+          </MuiLink>
+        ))}
+      </Box>
+      <div className={styles.navMenuSlot}>
+        <IconButton
+          aria-label={t('ariaLabels.openMenu')}
+          aria-haspopup="menu"
+          aria-expanded={navMenuAnchor !== null}
+          onClick={(event) => setNavMenuAnchor(event.currentTarget)}
+          size="small"
+        >
+          <MenuOutlined />
+        </IconButton>
+        <Menu
+          anchorEl={navMenuAnchor}
+          open={navMenuAnchor !== null}
+          onClose={() => setNavMenuAnchor(null)}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        >
+          {navLinks.map(({ href, label }) => (
+            <MenuItem key={href} component={LocaleLink} href={href} onClick={() => setNavMenuAnchor(null)}>
+              {label}
+            </MenuItem>
+          ))}
+        </Menu>
+      </div>
+    </>
   );
 
   // Signed-in climbers get two destinations here: the public profile and
@@ -287,6 +350,7 @@ export default function MarketingHeader() {
     return (
       <header className={styles.headerTransparent} data-testid="marketing-header">
         {brandLink}
+        {primaryNav}
         <Box sx={{ flex: 1 }} />
         {accountAction}
         <StartClimbingButton
@@ -314,6 +378,7 @@ export default function MarketingHeader() {
   return (
     <header className={styles.header} data-testid="marketing-header">
       {brandLink}
+      {primaryNav}
       <Box sx={{ flex: 1 }} />
       {accountAction}
       <StartClimbingButton

--- a/packages/web/app/components/site-chrome/site-footer.module.css
+++ b/packages/web/app/components/site-chrome/site-footer.module.css
@@ -19,10 +19,22 @@
   gap: 12px;
 }
 
+/* Three named groups rather than one flat row: with twelve links the flat row
+   wrapped into an unscannable block, and "Find a gym" needs a heading a reader
+   can aim at. auto-fit collapses to two columns on a phone and three from the
+   900px breakpoint the row layout already uses — no JS, no fixed count. */
 .links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 24px 32px;
+}
+
+.linkGroup {
   display: flex;
-  flex-wrap: wrap;
-  gap: 12px 24px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
 }
 
 .bottom {
@@ -44,7 +56,8 @@
   }
 
   .links {
+    grid-template-columns: repeat(3, minmax(150px, auto));
     justify-content: flex-end;
-    max-width: 520px;
+    max-width: 620px;
   }
 }

--- a/packages/web/app/components/site-chrome/site-footer.tsx
+++ b/packages/web/app/components/site-chrome/site-footer.tsx
@@ -32,6 +32,15 @@ const LINK_SX = {
   '&:hover': { color: 'text.primary' },
 } as const;
 
+const GROUP_HEADING_SX = {
+  m: 0,
+  color: 'text.primary',
+  fontWeight: themeTokens.typography.fontWeight.semibold,
+  fontSize: themeTokens.typography.fontSize.xs,
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+} as const;
+
 /**
  * Site-wide footer, rendered in normal flow at the end of every page.
  *
@@ -49,15 +58,44 @@ export default function SiteFooter() {
     return null;
   }
 
-  const links: { href: string; label: string }[] = [
-    { href: '/', label: t('footer.links.home') },
-    { href: '/about', label: t('footer.links.about') },
-    { href: '/help', label: t('footer.links.help') },
-    { href: '/docs', label: t('footer.links.docs') },
-    { href: '/playlists', label: t('footer.links.playlists') },
-    { href: '/aurora-migration', label: t('footer.links.auroraMigration') },
-    { href: '/legal', label: t('footer.links.legal') },
-    { href: '/privacy', label: t('footer.links.privacy') },
+  // "Find a gym" leads because it is the only crawl path into the directory:
+  // `/gyms` is `noindex, follow` until the duplicate-gym queue drains and it is
+  // out of the sitemap on purpose, so these anchors are what a crawler follows
+  // to reach the per-board listings at all. The hrefs are the LITERAL routes,
+  // not `/gyms?board=kilter` — `/gyms/kilter` is a page with its own copy and
+  // its own canonical (see `app/gyms/page.tsx`), and the query form would point
+  // at a URL that self-canonicalises away.
+  const linkGroups: { id: string; heading: string; links: { href: string; label: string }[] }[] = [
+    {
+      id: 'gyms',
+      heading: t('footer.groups.findAGym'),
+      links: [
+        { href: '/gyms/kilter', label: t('footer.links.gymsKilter') },
+        { href: '/gyms/tension', label: t('footer.links.gymsTension') },
+        { href: '/gyms/moonboard', label: t('footer.links.gymsMoonboard') },
+        { href: '/gyms', label: t('footer.links.gyms') },
+      ],
+    },
+    {
+      id: 'explore',
+      heading: t('footer.groups.explore'),
+      links: [
+        { href: '/', label: t('footer.links.home') },
+        { href: '/about', label: t('footer.links.about') },
+        { href: '/help', label: t('footer.links.help') },
+        { href: '/playlists', label: t('footer.links.playlists') },
+        { href: '/aurora-migration', label: t('footer.links.auroraMigration') },
+        { href: '/docs', label: t('footer.links.docs') },
+      ],
+    },
+    {
+      id: 'small-print',
+      heading: t('footer.groups.smallPrint'),
+      links: [
+        { href: '/legal', label: t('footer.links.legal') },
+        { href: '/privacy', label: t('footer.links.privacy') },
+      ],
+    },
   ];
 
   return (
@@ -80,10 +118,17 @@ export default function SiteFooter() {
         </Box>
 
         <Box component="nav" aria-label={t('footer.navLabel')} className={styles.links}>
-          {links.map(({ href, label }) => (
-            <MuiLink key={href} component={LocaleLink} href={href} variant="body2" sx={LINK_SX}>
-              {label}
-            </MuiLink>
+          {linkGroups.map((group) => (
+            <Box key={group.id} className={styles.linkGroup}>
+              <Typography variant="subtitle2" component="h2" sx={GROUP_HEADING_SX}>
+                {group.heading}
+              </Typography>
+              {group.links.map(({ href, label }) => (
+                <MuiLink key={href} component={LocaleLink} href={href} variant="body2" sx={LINK_SX}>
+                  {label}
+                </MuiLink>
+              ))}
+            </Box>
           ))}
         </Box>
       </Box>

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -13,6 +13,7 @@ import SystemUpdateOutlined from '@mui/icons-material/SystemUpdateOutlined';
 import PeopleOutlined from '@mui/icons-material/PeopleOutlined';
 import BluetoothOutlined from '@mui/icons-material/BluetoothOutlined';
 import LocalOfferOutlined from '@mui/icons-material/LocalOfferOutlined';
+import PlaceOutlined from '@mui/icons-material/PlaceOutlined';
 import WarningAmberOutlined from '@mui/icons-material/WarningAmberOutlined';
 import AndroidOutlined from '@mui/icons-material/AndroidOutlined';
 import Skeleton from '@mui/material/Skeleton';
@@ -485,9 +486,19 @@ export default function HomePageContent({ initialPopularConfigs, initialRecentBe
 
           {/* Signed-in only: the gym you help run, with Manage / View links.
               Self-gates to null for signed-out visitors and for climbers with
-              no gym — the "Find your gym" nudge left with the drawers it
-              opened, and comes back when #4372 builds the gyms directory. */}
+              no gym. */}
           <HomeGymCard />
+
+          {/* The "find a gym" nudge the drawers used to carry, restored now that
+              the directory exists. Everyone sees it, including the signed-out
+              visitors HomeGymCard renders nothing for. */}
+          <OnboardingCard
+            icon={<PlaceOutlined />}
+            title={t('home.cards.gymTitle')}
+            description={t('home.cards.gymDescription')}
+            accent="v11"
+            href="/gyms"
+          />
 
           <OnboardingCard
             icon={<WarningAmberOutlined />}

--- a/packages/web/e2e/site-chrome.spec.ts
+++ b/packages/web/e2e/site-chrome.spec.ts
@@ -100,11 +100,52 @@ test.describe('Site chrome - footer links', () => {
     }
   });
 
+  // `/gyms` is `noindex, follow` and out of the sitemap until the duplicate-gym
+  // queue drains, so the footer is the only crawl path into the directory.
+  test('carries the gym directory links, one per board type', async ({ page }) => {
+    await page.goto('/');
+    await expectChrome(page);
+
+    const footer = page.locator(siteFooter);
+    for (const href of ['/gyms', '/gyms/kilter', '/gyms/tension', '/gyms/moonboard']) {
+      await expect(footer.locator(`a[href="${href}"]`)).toHaveCount(1);
+    }
+  });
+
   test('keeps a locale switcher — the user drawer that used to host it is gone', async ({ page }) => {
     await page.goto('/');
     await expectChrome(page);
 
     await expect(page.locator(siteFooter).getByRole('button', { name: /language/i })).toBeVisible();
+  });
+});
+
+test.describe('Site chrome - header nav', () => {
+  // The nav row stays mounted at every width — CSS hides it below 900px and
+  // shows the menu button instead — so the anchors are in the markup on a phone
+  // too. `toHaveCount`, not `toBeVisible`, is the assertion that survives both.
+  for (const [label, url] of [
+    ['the home page', '/'],
+    ['the about page', '/about'],
+  ] as const) {
+    test(`links to gyms, playlists, about and help on ${label}`, async ({ page }) => {
+      await page.goto(url);
+      await expectChrome(page);
+
+      const header = page.locator(marketingHeader);
+      for (const href of ['/gyms', '/playlists', '/about', '/help']) {
+        await expect(header.locator(`nav a[href="${href}"]`)).toHaveCount(1);
+      }
+    });
+  }
+
+  // `/boards` is drawn in the wireframe but the route does not exist. A link to
+  // it would be a chrome-wide 404 on every page at once.
+  test('links nowhere into /boards — the route does not exist', async ({ page }) => {
+    await page.goto('/');
+    await expectChrome(page);
+
+    await expect(page.locator(marketingHeader).locator('a[href^="/boards"]')).toHaveCount(0);
   });
 });
 


### PR DESCRIPTION
## Summary

The gym directory has been live and open to everyone since #4372, and nothing on www linked to it. `/gyms`, `/gyms/kilter`, `/gyms/tension` and `/gyms/moonboard` were reachable only by typing the URL. This links it from the three surfaces a visitor actually lands on. Part of #4386 (design notes 1, 4 and 11 in `docs/design/web-reposition/homepage-marketing.html`).

**Header.** `MarketingHeader` shipped with no nav at all, which is how the directory ended up orphaned. It now carries Gyms, Playlists, About and Help on the `/` and default branches. The centred profile header and the brand-only `/settings` bar own their whole bar and keep it. `/boards` is drawn in the wireframe but the route does not exist, so it is not linked — a chrome link to it would be a 404 on every page at once.

The responsive treatment is pure CSS, per the repo's no-JS-breakpoints rule. The inline row stays mounted at every width (hidden with `display: none`, not unmounted) so the anchors are in the first server-rendered HTML for a crawler; a 900px media query swaps it for a menu button below that, and an 8px gap below 600px keeps the new button off the "Start climbing" pill on a 390px phone.

**Footer.** Twelve links do not read as one flat row, so they are grouped under "Find a gym", "Explore" and "Small print", laid out with `auto-fit` grid columns — two on a phone, three from 900px. The gym group is the load-bearing one: design note 11's point is that "kilter board near me" traffic is near-zero because we have no surface for it, not because nobody searches it.

The hrefs are the **literal** facet routes, not the wireframe's `/gyms?board=kilter`. Each facet page has its own copy and its own canonical (`app/gyms/page.tsx`), and the query form points at a URL that self-canonicalises back to `/gyms`, throwing away the landing page the anchor exists to feed. A test pins that no footer href carries a query string.

**Homepage.** Restores the "find a gym" onboarding card next to `HomeGymCard` — which self-gates to null, so a signed-out visitor saw nothing there at all — and deletes the stale comment promising the affordance would return "when #4372 builds the gyms directory". The full search form from design note 4 stays on #4386.

**Deliberately untouched.** The `noindex` on `app/gyms/directory-page.tsx`, `STATIC_ENTRIES`, and `buildGymEntries()`. Those wait on the duplicate-gym queue (#4381, #4382). `noindex, follow` still lets a crawler walk these anchors, which is the whole point of adding them now.

**i18n.** 12 new `common` keys and 2 new `marketing` keys, in all four locales. Spanish follows the gyms catalog's `rocódromo` / `plafón`, French its `salle` / `board`, German its `Halle` / `Board`.

**Test constants.** `SITEMAP_PATHS` in both footer suites stays the sitemap-parity subset and a new `FOOTER_PATHS` superset takes over the exact anchor-count assertion. `/gyms` is deliberately not a sitemap entry, so folding it into the first constant would have made its documented name false.

Closes #5076

## Release Notes

- Find a gym with a Kilter, Tension or MoonBoard from any page — it is in the nav, the footer and the homepage now

## Test plan

1. Open the homepage on desktop. Header shows Gyms, Playlists, About, Help.
2. Narrow the window under 900px. Links collapse into a menu button.
3. Tap the menu button. Same four links, "Start climbing" still fits.
4. Scroll to the footer. "Find a gym" lists three board types plus all gyms.
5. Tap "Gyms with a Kilter board". Lands on the Kilter gym listing.

## Risk

Risk: 2/5 — navigation and copy only, no data writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nkd1PyBEMjrq4Zr3j5VY3o
