### PR TITLE
fix(web): give the climb front doors real typography and a breadcrumb

### DIFF
--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -90,7 +90,10 @@
     "title": {
       "noClimbSelected": "Kein Boulder ausgewählt",
       "project": "Projekt",
-      "projectAtAngle": "Projekt @ {{angle}}°"
+      "projectAtAngle": "Projekt @ {{angle}}°",
+      "setBy": "Von {{setter}}",
+      "setByWithSends": "Von {{setter}} - {{sends}}",
+      "draftBy": "Entwurf von {{setter}}"
     },
     "method": {
       "footless": "Ohne Füße",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -90,7 +90,10 @@
     "title": {
       "noClimbSelected": "No climb selected",
       "project": "project",
-      "projectAtAngle": "project @ {{angle}}°"
+      "projectAtAngle": "project @ {{angle}}°",
+      "setBy": "By {{setter}}",
+      "setByWithSends": "By {{setter}} - {{sends}}",
+      "draftBy": "Draft by {{setter}}"
     },
     "method": {
       "footless": "Footless",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -90,7 +90,10 @@
     "title": {
       "noClimbSelected": "Ningún bloque seleccionado",
       "project": "proyecto",
-      "projectAtAngle": "proyecto @ {{angle}}°"
+      "projectAtAngle": "proyecto @ {{angle}}°",
+      "setBy": "Por {{setter}}",
+      "setByWithSends": "Por {{setter}} - {{sends}}",
+      "draftBy": "Borrador de {{setter}}"
     },
     "method": {
       "footless": "Sin pies",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -90,7 +90,10 @@
     "title": {
       "noClimbSelected": "Aucun bloc sélectionné",
       "project": "projet",
-      "projectAtAngle": "projet @ {{angle}}°"
+      "projectAtAngle": "projet @ {{angle}}°",
+      "setBy": "Par {{setter}}",
+      "setByWithSends": "Par {{setter}} - {{sends}}",
+      "draftBy": "Brouillon de {{setter}}"
     },
     "method": {
       "footless": "Sans pieds",

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx
@@ -1,4 +1,5 @@
 import React, { type PropsWithChildren } from 'react';
+import Box from '@mui/material/Box';
 import { headers } from 'next/headers';
 import type { BoardRouteParameters } from '@/app/lib/types';
 import {
@@ -13,7 +14,7 @@ import { getBoardDetailsForBoard, generateBoardTitle } from '@/app/lib/board-uti
 import type { Metadata } from 'next';
 import I18nProvider from '@/app/components/providers/i18n-provider';
 import { getLocale } from '@/app/lib/i18n/get-locale';
-import { themeTokens } from '@/app/theme/theme-config';
+import { boardShellSx } from '@/app/components/climb-front-door/board-shell-sx';
 
 export async function generateMetadata(props: { params: Promise<BoardRouteParameters> }): Promise<Metadata> {
   const params = await props.params;
@@ -90,27 +91,7 @@ export default async function BoardLayout(props: PropsWithChildren<BoardLayoutPr
 
   return (
     <I18nProvider locale={locale} namespaces={['common', 'climbs', 'session', 'boards', 'profile', 'feed']}>
-      <div
-        style={{
-          minHeight: '100dvh',
-          display: 'flex',
-          flexDirection: 'column',
-          padding: 0,
-          background: 'var(--semantic-surface)',
-        }}
-      >
-        <main
-          id="content-for-scrollable"
-          style={{
-            flex: 1,
-            paddingLeft: `${themeTokens.spacing[2]}px`,
-            paddingRight: `${themeTokens.spacing[2]}px`,
-            paddingTop: 'var(--global-header-height)',
-          }}
-        >
-          {children}
-        </main>
-      </div>
+      <Box sx={boardShellSx}>{children}</Box>
     </I18nProvider>
   );
 }

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/__tests__/list-front-door.test.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/__tests__/list-front-door.test.tsx
@@ -147,7 +147,10 @@ describe('front door pagination anchors', () => {
 
     expect(html).not.toContain('rel="prev"');
     expect(html).not.toContain('rel="next"');
-    expect(html.match(/<button[^>]*disabled/g) ?? []).toHaveLength(2);
+    // `\sdisabled=""`, not a bare `disabled` inside `[^>]*`: MUI also puts a
+    // `Mui-disabled` token in the class list, so the loose form would pass on a
+    // control that merely LOOKS inert while still being a focusable dead link.
+    expect(html.match(/<button[^>]*\sdisabled=""/g) ?? []).toHaveLength(2);
   });
 });
 

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/__tests__/list-front-door.test.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/__tests__/list-front-door.test.tsx
@@ -10,6 +10,7 @@ import {
   isIndexableFrontDoorPage,
   parseFrontDoorPage,
 } from '@/app/lib/seo/list-page-robots';
+import { resolveServerTree } from '@/app/lib/__tests__/helpers/resolve-server-tree';
 import type { BoardDetails } from '@/app/lib/types';
 
 /**
@@ -99,7 +100,9 @@ const boardDetails = {
   set_ids: [1, 20],
 } as unknown as BoardDetails;
 
-async function renderPagination(page: number, hasMore: boolean): Promise<string> {
+// `FrontDoorBreadcrumb` is an async server component nested in the returned
+// tree, and `renderToString` cannot suspend — expand the async layer first.
+async function renderFrontDoor(page: number, hasMore: boolean, noindex = false): Promise<string> {
   const tree = await StaticListFrontDoor({
     boardDetails,
     angle: 40,
@@ -108,20 +111,21 @@ async function renderPagination(page: number, hasMore: boolean): Promise<string>
     page,
     basePath: BASE,
     tree: 'config-tuple',
+    noindex,
   });
-  return renderToString(<>{tree}</>);
+  return renderToString(<>{await resolveServerTree(tree)}</>);
 }
 
 describe('front door pagination anchors', () => {
   it('links onward while the next page is still indexable', async () => {
-    const html = await renderPagination(FRONT_DOOR_MAX_INDEXABLE_PAGE - 1, true);
+    const html = await renderFrontDoor(FRONT_DOOR_MAX_INDEXABLE_PAGE - 1, true);
 
     expect(html).toContain(`rel="next"`);
     expect(html).toContain(`href="${BASE}?page=${FRONT_DOOR_MAX_INDEXABLE_PAGE}"`);
   });
 
   it('stops the walk at the last indexable page even when more climbs exist', async () => {
-    const html = await renderPagination(FRONT_DOOR_MAX_INDEXABLE_PAGE, true);
+    const html = await renderFrontDoor(FRONT_DOOR_MAX_INDEXABLE_PAGE, true);
 
     // `noindex, follow` past the cap is an explicit "keep following links", so a
     // `next` chain gated on `hasMore` alone would invite crawlers into a
@@ -131,10 +135,48 @@ describe('front door pagination anchors', () => {
   });
 
   it('still walks a deep grace-band page BACK into the indexable set', async () => {
-    const html = await renderPagination(FRONT_DOOR_MAX_INDEXABLE_PAGE + 1, true);
+    const html = await renderFrontDoor(FRONT_DOOR_MAX_INDEXABLE_PAGE + 1, true);
 
     expect(html).not.toContain('rel="next"');
     expect(html).toContain('rel="prev"');
     expect(html).toContain(`href="${BASE}?page=${FRONT_DOOR_MAX_INDEXABLE_PAGE}"`);
+  });
+
+  it('offers no anchor at either end of the walk — a disabled control, not a dead link', async () => {
+    const html = await renderFrontDoor(1, false);
+
+    expect(html).not.toContain('rel="prev"');
+    expect(html).not.toContain('rel="next"');
+    expect(html.match(/<button[^>]*disabled/g) ?? []).toHaveLength(2);
+  });
+});
+
+describe('front door breadcrumb', () => {
+  it('gives the list page an upward link home', async () => {
+    const html = await renderFrontDoor(1, false);
+
+    expect(html).toContain('href="/"');
+    expect(html).toContain('aria-current="page"');
+  });
+
+  it('emits BreadcrumbList on page 1 of an indexed board', async () => {
+    const html = await renderFrontDoor(1, false);
+
+    expect(html).toContain('"@type":"BreadcrumbList"');
+  });
+
+  it('omits BreadcrumbList past page 1 — those pages are self-canonical', async () => {
+    // The crumbs describe the clean list URL. On `?page=2` that contradicts the
+    // page's own canonical, so the visible crumbs stay and the schema does not.
+    const html = await renderFrontDoor(2, true);
+
+    expect(html).not.toContain('"@type":"BreadcrumbList"');
+    expect(html).toContain('aria-current="page"');
+  });
+
+  it('omits BreadcrumbList on a noindex board, which the CreativeWork payload also skips', async () => {
+    const html = await renderFrontDoor(1, false, true);
+
+    expect(html).not.toContain('"@type":"BreadcrumbList"');
   });
 });

--- a/packages/web/app/b/[board_slug]/[angle]/layout.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/layout.tsx
@@ -1,11 +1,11 @@
 import React, { type PropsWithChildren } from 'react';
+import Box from '@mui/material/Box';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import { resolveBoardBySlug } from '@/app/lib/board-slug-utils';
 import I18nProvider from '@/app/components/providers/i18n-provider';
 import { getLocale } from '@/app/lib/i18n/get-locale';
-
-import { themeTokens } from '@/app/theme/theme-config';
+import { boardShellSx } from '@/app/components/climb-front-door/board-shell-sx';
 
 type BoardSlugRouteParams = {
   board_slug: string;
@@ -48,27 +48,7 @@ export default async function BoardSlugLayout(props: PropsWithChildren<{ params:
 
   return (
     <I18nProvider locale={locale} namespaces={['common', 'climbs', 'session', 'boards', 'profile', 'feed']}>
-      <div
-        style={{
-          minHeight: '100dvh',
-          display: 'flex',
-          flexDirection: 'column',
-          padding: 0,
-          background: 'var(--semantic-surface)',
-        }}
-      >
-        <main
-          id="content-for-scrollable"
-          style={{
-            flex: 1,
-            paddingLeft: `${themeTokens.spacing[2]}px`,
-            paddingRight: `${themeTokens.spacing[2]}px`,
-            paddingTop: 'var(--global-header-height)',
-          }}
-        >
-          {children}
-        </main>
-      </div>
+      <Box sx={boardShellSx}>{children}</Box>
     </I18nProvider>
   );
 }

--- a/packages/web/app/b/[board_slug]/[angle]/list/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/list/page.tsx
@@ -120,6 +120,10 @@ export default async function BoardSlugListPage(props: BoardSlugListPageProps) {
         // not move them off the board they arrived through.
         basePath={`/b/${params.board_slug}/${params.angle}/list`}
         tree="slug"
+        // Same hidden-board test `generateMetadata` feeds `resolveListPageIndexation`.
+        // A noindex page must not emit a BreadcrumbList naming the public
+        // config-tuple twin it canonicalises nowhere near.
+        noindex={board.isUnlisted || !board.isPublic}
       />
     </>
   );

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/view-seo-fragment.test.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/view-seo-fragment.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { renderToString } from 'react-dom/server';
 import ClimbViewSeoFragment from '@/app/components/climb-detail/climb-view-seo-fragment';
+import { resolveServerTree } from '@/app/lib/__tests__/helpers/resolve-server-tree';
 import { getClimbStatsForAllAngles, type ClimbStatsForAngle } from '@/app/lib/data/queries';
 
 /**
@@ -176,42 +177,6 @@ function treeContainsElementOfType(node: React.ReactNode, type: React.ElementTyp
   });
 }
 
-/**
- * `renderToString` can't await async server components, so expand them first:
- * walk the element tree and replace every async function component with what it
- * resolves to, leaving sync components (the client islands and MUI's `Box`)
- * for `renderToString` to render normally. `AsyncFunction` is the
- * discriminator — invoking a client component outside a render would blow up on
- * its first hook.
- *
- * `stopAt` holds back components the caller wants to observe by identity rather
- * than by output.
- */
-function isAsyncComponent(type: unknown): boolean {
-  return (
-    typeof type === 'function' && (type as { constructor?: { name?: string } }).constructor?.name === 'AsyncFunction'
-  );
-}
-
-async function resolveServerTree(
-  node: React.ReactNode,
-  stopAt: ReadonlySet<unknown> = new Set(),
-): Promise<React.ReactNode> {
-  if (Array.isArray(node)) return Promise.all(node.map((child) => resolveServerTree(child, stopAt)));
-  if (!React.isValidElement(node)) return node;
-
-  const element = node as React.ReactElement<{ children?: React.ReactNode }>;
-  if (isAsyncComponent(element.type) && !stopAt.has(element.type)) {
-    const produced = await (element.type as (props: unknown) => Promise<unknown>)(element.props);
-    if (React.isValidElement(produced)) return resolveServerTree(produced, stopAt);
-    return (produced ?? null) as React.ReactNode;
-  }
-
-  const { children } = element.props;
-  if (children === undefined) return element;
-  return React.cloneElement(element, undefined, await resolveServerTree(children, stopAt));
-}
-
 async function renderFrontDoor(params = PARAMS): Promise<string> {
   const element = (await pageModule.default({ params: Promise.resolve(params) })) as React.ReactElement;
   return renderToString(<>{await resolveServerTree(element)}</>);
@@ -289,7 +254,9 @@ describe('climb front door server HTML', () => {
   it('keeps an alternate angle at 200 but omits entity and breadcrumb JSON-LD', async () => {
     const html = await renderFrontDoor({ ...PARAMS, angle: '25' });
 
-    expect(html).toContain('<h1>');
+    // `<h1[\s>]`, not a bare `<h1>`: the heading renders through `Typography
+    // component="h1"`, which lands a class attribute on the real tag.
+    expect(html).toMatch(/<h1[\s>]/);
     expect(html).not.toContain('"@type":"CreativeWork"');
     expect(html).not.toContain('"@type":"BreadcrumbList"');
   });

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/view-seo-fragment.test.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/view-seo-fragment.test.tsx
@@ -195,13 +195,24 @@ const CURRENT_ANGLE_STATS: ClimbStatsForAngle = {
   rating_count: '12',
 };
 
-function creativeWorkPayload(html: string): Record<string, unknown> {
-  const payloads = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)].map(
+function jsonLdPayloads(html: string): Record<string, unknown>[] {
+  return [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)].map(
     (match) => JSON.parse(match[1]) as Record<string, unknown>,
   );
-  const creativeWork = payloads.find((payload) => payload['@type'] === 'CreativeWork');
+}
+
+function creativeWorkPayload(html: string): Record<string, unknown> {
+  const creativeWork = jsonLdPayloads(html).find((payload) => payload['@type'] === 'CreativeWork');
   if (!creativeWork) throw new Error(`no CreativeWork payload rendered: ${html}`);
   return creativeWork;
+}
+
+type BreadcrumbItem = { '@type': string; position: number; name: string; item: string };
+
+function breadcrumbItems(html: string): BreadcrumbItem[] {
+  const breadcrumb = jsonLdPayloads(html).find((payload) => payload['@type'] === 'BreadcrumbList');
+  if (!breadcrumb) throw new Error(`no BreadcrumbList payload rendered: ${html}`);
+  return breadcrumb.itemListElement as BreadcrumbItem[];
 }
 
 describe('board slug climb view SEO fragment', () => {
@@ -249,6 +260,23 @@ describe('climb front door server HTML', () => {
     expect(html).toMatch(/href="\/kilter\/[^"]*\/25\/view\//);
     expect(html).not.toMatch(/href="\/kilter\/[^"]*\/40\/view\//);
     expect(html).toContain('aria-current="page"');
+  });
+
+  it('pins the BreadcrumbList crumbs, board name included', async () => {
+    const html = await renderFrontDoor();
+    const items = breadcrumbItems(html);
+
+    // Home → board list → this climb, in that order, and nothing else.
+    expect(items.map((item) => item.position)).toEqual([1, 2, 3]);
+    expect(items[2].name).toBe('Test Climb');
+    // Casing is pinned deliberately. The board crumb reaches the payload through
+    // `formatBoardDisplayName`, so the name a crawler reads is "Kilter", not the
+    // lowercase `board_name` column value — the trademark rule applies to the
+    // crumb the reader sees, and structured data must not drift from it.
+    expect(items[1].name).toContain('boardName=Kilter');
+    expect(items[1].name).not.toContain('boardName=kilter');
+    // Twice: once in the payload, once as the visible crumb.
+    expect(html.split(items[1].name).length - 1).toBeGreaterThanOrEqual(2);
   });
 
   it('keeps an alternate angle at 200 but omits entity and breadcrumb JSON-LD', async () => {

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -308,8 +308,13 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
     const largeGradeElement = displayDifficulty && largeGradeContent;
 
     const setterText = climb.is_draft
-      ? `Draft by ${climb.setter_username}`
-      : `By ${climb.setter_username}${climb.ascensionist_count ? ` - ${formatSends(climb.ascensionist_count)}` : ''}`;
+      ? t('card.title.draftBy', { setter: climb.setter_username })
+      : climb.ascensionist_count
+        ? t('card.title.setByWithSends', {
+            setter: climb.setter_username,
+            sends: formatSends(climb.ascensionist_count, t),
+          })
+        : t('card.title.setBy', { setter: climb.setter_username });
 
     const setterElement = showSetterInfo && climb.setter_username && (
       <Typography variant="body2" component="span" color="text.secondary" sx={setterSx}>
@@ -320,10 +325,10 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
     if (gradePosition === 'right') {
       const subtitleParts: string[] = [];
       if (climb.is_draft) {
-        subtitleParts.push('Draft');
+        subtitleParts.push(t('createClimbForm.draftBadge'));
       }
       if (!climb.is_draft && climb.ascensionist_count) {
-        subtitleParts.push(formatSends(climb.ascensionist_count));
+        subtitleParts.push(formatSends(climb.ascensionist_count, t));
       }
       if (hasGrade) {
         subtitleParts.push(`${formatQuality(climb.quality_average!)}\u2605`);
@@ -377,7 +382,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
     if (layout === 'horizontal') {
       const secondLineContent = [];
       if (climb.is_draft) {
-        secondLineContent.push('Draft');
+        secondLineContent.push(t('createClimbForm.draftBadge'));
       }
       if (hasGrade) {
         secondLineContent.push(`${displayDifficulty} ${formatQuality(climb.quality_average!)}★`);
@@ -386,7 +391,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
         secondLineContent.push(`${climb.setter_username}`);
       }
       if (!climb.is_draft && climb.ascensionist_count) {
-        secondLineContent.push(formatSends(climb.ascensionist_count));
+        secondLineContent.push(formatSends(climb.ascensionist_count, t));
       }
 
       return (

--- a/packages/web/app/components/climb-detail/climb-view-seo-fragment.tsx
+++ b/packages/web/app/components/climb-detail/climb-view-seo-fragment.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import type { BoardDetails, Climb } from '@/app/lib/types';
 import { getServerTranslation } from '@/app/lib/i18n/server';
+import { themeTokens } from '@/app/theme/theme-config';
 
 type ClimbViewSeoFragmentProps = {
   climb: Climb;
   boardDetails: BoardDetails;
 };
+
+const headingSx = { fontWeight: themeTokens.typography.fontWeight.bold, mb: 1 };
+
+const summarySx = { m: 0, mb: 2, maxWidth: '68ch' };
 
 /**
  * The climb front door's page heading: the `<h1>` and the one-paragraph summary
@@ -16,7 +22,9 @@ type ClimbViewSeoFragmentProps = {
  * the PlayViewDrawer, which hydrated and covered the viewport. W-15 removed the
  * drawer from this route, so there is nothing left to double up with and no
  * reason to hide the only heading the page has. Element identity (`<h1>` + `<p>`)
- * is deliberately unchanged; `view-seo-fragment.test.tsx` pins it.
+ * is deliberately unchanged; `view-seo-fragment.test.tsx` pins it. `Typography`
+ * only supplies the site's type ramp — `component` keeps the tags themselves,
+ * which is why both assertions there match `<h1[\s>]` rather than a bare `<h1>`.
  *
  * This is the page's ONLY `<h1>`. Every other front-door section heading is an
  * `<h2>`.
@@ -37,12 +45,14 @@ export default async function ClimbViewSeoFragment({ climb, boardDetails }: Clim
 
   return (
     <Box component="header">
-      <h1>{heading}</h1>
-      <p>
+      <Typography variant="h3" component="h1" sx={headingSx}>
+        {heading}
+      </Typography>
+      <Typography variant="body1" component="p" color="text.secondary" sx={summarySx}>
         {summary}
         {setterSuffix}
         {ascentsSuffix}.
-      </p>
+      </Typography>
     </Box>
   );
 }

--- a/packages/web/app/components/climb-front-door/angle-cross-links.tsx
+++ b/packages/web/app/components/climb-front-door/angle-cross-links.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { themeTokens } from '@/app/theme/theme-config';
@@ -15,12 +16,17 @@ type AngleCrossLinksProps = {
   angleStats: ClimbStatsForAngle[];
 };
 
+// Matches the section rhythm the other `<h2>` bands use in `climb-front-door`.
+const sectionSx = { mt: 4 };
+
+const sectionHeadingSx = { fontWeight: themeTokens.typography.fontWeight.semibold, mb: 1.5 };
+
 const listSx = {
   display: 'flex',
   flexWrap: 'wrap' as const,
   gap: `${themeTokens.spacing[2]}px`,
   listStyle: 'none',
-  margin: `${themeTokens.spacing[2]}px 0 0`,
+  margin: 0,
   padding: 0,
 };
 
@@ -50,8 +56,10 @@ export default async function AngleCrossLinks({
   if (angleStats.length === 0) return null;
 
   return (
-    <Box component="section">
-      <Box component="h2">{t('frontDoor.angles.heading')}</Box>
+    <Box component="section" sx={sectionSx}>
+      <Typography variant="h5" component="h2" sx={sectionHeadingSx}>
+        {t('frontDoor.angles.heading')}
+      </Typography>
       <Box component="ul" sx={listSx}>
         {angleStats.map((stats) => {
           const grade = stats.difficulty || t('frontDoor.facts.unknown');

--- a/packages/web/app/components/climb-front-door/board-shell-sx.ts
+++ b/packages/web/app/components/climb-front-door/board-shell-sx.ts
@@ -1,0 +1,25 @@
+/**
+ * The board shell both `/list` trees hang off — the config-tuple route and
+ * `/b/{slug}`. One object so the two can't drift into two different insets.
+ *
+ * What it deliberately does NOT do:
+ *
+ *  - **No `<main>` of its own.** Every page under these shells renders one
+ *    (`StaticListFrontDoor`, `ClimbFrontDoor`), matching how the rest of www
+ *    puts the landmark on the page content component. Two nested `<main>`s is
+ *    invalid HTML and two landmarks for one region.
+ *  - **No horizontal padding.** The front doors already inset themselves by
+ *    `spacing[4]`; the shell's old `spacing[2]` on top of that was a leftover
+ *    from the pivot and made a 24px gutter on a phone.
+ *
+ * `minHeight: 100dvh` stays. The site header is `position: fixed` and
+ * `box-sizing` is border-box, so the padding-top sits INSIDE the 100dvh: the
+ * shell ends exactly at the fold and `SiteFooter` starts there. That is the
+ * sticky-footer behaviour; dropping it would float the footer mid-screen on a
+ * board with three climbs.
+ */
+export const boardShellSx = {
+  minHeight: '100dvh',
+  paddingTop: 'var(--global-header-height)',
+  background: 'var(--semantic-surface)',
+} as const;

--- a/packages/web/app/components/climb-front-door/climb-front-door.tsx
+++ b/packages/web/app/components/climb-front-door/climb-front-door.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import { getDisplayDescription, type SimilarClimb } from '@boardsesh/shared-schema';
 import ClimbViewSeoFragment from '@/app/components/climb-detail/climb-view-seo-fragment';
 import SimilarClimbsList from '@/app/components/similar-climbs/similar-climbs-list';
@@ -9,7 +10,7 @@ import { buildBoardArtLayers, toDarkArtUrl } from '@/app/components/board-render
 import boardArtStyles from '@/app/components/board-renderer/board-art-theme.module.css';
 import { buildCanonicalClimbListUrl, buildCanonicalClimbViewUrl } from '@/app/lib/url-utils';
 import { getServerTranslation } from '@/app/lib/i18n/server';
-import { resolveClimbDisplayName } from '@/app/lib/string-utils';
+import { formatBoardDisplayName, resolveClimbDisplayName } from '@/app/lib/string-utils';
 import { themeTokens } from '@/app/theme/theme-config';
 import type { ClimbStatsForAngle } from '@/app/lib/data/queries';
 import type { BetaLink } from '@/app/lib/beta-video-url';
@@ -77,6 +78,14 @@ const setterNotesSx = {
   whiteSpace: 'pre-line',
   margin: 0,
 };
+
+// One rhythm for every `<h2>` band below the board art, so the page reads as a
+// stack of sections rather than a run of UA-default headings.
+const sectionSx = { mt: 4 };
+
+const sectionHeadingSx = { fontWeight: themeTokens.typography.fontWeight.semibold, mb: 1.5 };
+
+const emptySectionSx = { m: 0, color: 'var(--neutral-400)' };
 
 /**
  * The SSR climb page: everything a reader (or a crawler) needs about one climb,
@@ -156,11 +165,10 @@ export default async function ClimbFrontDoor({
   return (
     <Box component="main" sx={containerSx}>
       <FrontDoorBreadcrumb
-        boardName={boardDetails.board_name}
+        boardName={formatBoardDisplayName(boardDetails.board_name)}
         angle={angle}
         boardListUrl={boardListUrl}
-        currentLabel={climbName}
-        currentUrl={canonicalClimbUrl}
+        leaf={{ label: climbName, url: canonicalClimbUrl }}
         emitJsonLd={!noindex && isCanonicalAngle}
       />
 
@@ -229,11 +237,13 @@ export default async function ClimbFrontDoor({
       <ClimbFacts climb={climb} boardDetails={boardDetails} angle={angle} currentAngleStats={currentAngleStats} />
 
       {setterNotes ? (
-        <Box component="section">
-          <Box component="h2">{t('frontDoor.setterNotes.heading')}</Box>
-          <Box component="p" sx={setterNotesSx}>
+        <Box component="section" sx={sectionSx}>
+          <Typography variant="h5" component="h2" sx={sectionHeadingSx}>
+            {t('frontDoor.setterNotes.heading')}
+          </Typography>
+          <Typography variant="body1" component="p" sx={setterNotesSx}>
             {setterNotes}
-          </Box>
+          </Typography>
         </Box>
       ) : null}
 
@@ -259,17 +269,23 @@ export default async function ClimbFrontDoor({
         angleStats={angleStats}
       />
 
-      <Box component="section">
-        <Box component="h2">{t('frontDoor.beta.heading')}</Box>
+      <Box component="section" sx={sectionSx}>
+        <Typography variant="h5" component="h2" sx={sectionHeadingSx}>
+          {t('frontDoor.beta.heading')}
+        </Typography>
         {betaLinks.length > 0 ? (
           <BoardseshBetaList links={betaLinks} isLoading={false} source="drawer" />
         ) : (
-          <p>{t('frontDoor.beta.empty')}</p>
+          <Typography variant="body2" component="p" sx={emptySectionSx}>
+            {t('frontDoor.beta.empty')}
+          </Typography>
         )}
       </Box>
 
-      <Box component="section">
-        <Box component="h2">{t('frontDoor.similar.heading')}</Box>
+      <Box component="section" sx={sectionSx}>
+        <Typography variant="h5" component="h2" sx={sectionHeadingSx}>
+          {t('frontDoor.similar.heading')}
+        </Typography>
         <SimilarClimbsList
           boardType={boardDetails.board_name as BoardName}
           layoutId={boardDetails.layout_id}
@@ -283,8 +299,10 @@ export default async function ClimbFrontDoor({
         />
       </Box>
 
-      <Box component="section">
-        <Box component="h2">{t('frontDoor.community.heading')}</Box>
+      <Box component="section" sx={sectionSx}>
+        <Typography variant="h5" component="h2" sx={sectionHeadingSx}>
+          {t('frontDoor.community.heading')}
+        </Typography>
         <ClimbSocialSection
           climbUuid={climb.uuid}
           boardType={boardDetails.board_name}

--- a/packages/web/app/components/climb-front-door/front-door-breadcrumb.tsx
+++ b/packages/web/app/components/climb-front-door/front-door-breadcrumb.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Box from '@mui/material/Box';
+import MuiLink from '@mui/material/Link';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { absoluteUrl } from '@/app/lib/seo/base-url';
@@ -11,10 +12,14 @@ type FrontDoorBreadcrumbProps = {
   angle: number;
   /** Canonical `/list` URL for this board config at this angle. */
   boardListUrl: string;
-  /** The leaf. Rendered as plain text, not a self-link. */
-  currentLabel: string;
-  /** The climb's own canonical path — the JSON-LD leaf's `item`. */
-  currentUrl: string;
+  /**
+   * The climb crumb: its label and its own canonical path (the JSON-LD leaf's
+   * `item`). Rendered as plain text, not a self-link.
+   *
+   * Omitted on the `/list` front door, where the board crumb IS the current
+   * page — a third crumb there would name a climb the reader is not on.
+   */
+  leaf?: { label: string; url: string };
   /** Alternate-angle and noindex pages keep visible crumbs but omit schema data. */
   emitJsonLd?: boolean;
 };
@@ -33,16 +38,18 @@ const listSx = {
 
 const separatorSx = { color: 'var(--neutral-400)' };
 
+const currentCrumbSx = { color: 'text.primary', fontWeight: themeTokens.typography.fontWeight.medium };
+
 /**
- * Home → board list → this climb. Two of the front door's internal links, and
- * the hierarchy signal for `BreadcrumbList`-shaped crawling.
+ * Home → board list → this climb, or Home → board list on the `/list` page
+ * itself. The front door's upward links, and the hierarchy signal for
+ * `BreadcrumbList`-shaped crawling.
  */
 export default async function FrontDoorBreadcrumb({
   boardName,
   angle,
   boardListUrl,
-  currentLabel,
-  currentUrl,
+  leaf,
   emitJsonLd = true,
 }: FrontDoorBreadcrumbProps) {
   const { t } = await getServerTranslation('climbs');
@@ -57,7 +64,7 @@ export default async function FrontDoorBreadcrumb({
     itemListElement: [
       { '@type': 'ListItem', position: 1, name: t('frontDoor.breadcrumb.home'), item: absoluteUrl('/') },
       { '@type': 'ListItem', position: 2, name: boardCrumbLabel, item: absoluteUrl(boardListUrl) },
-      { '@type': 'ListItem', position: 3, name: currentLabel, item: absoluteUrl(currentUrl) },
+      ...(leaf ? [{ '@type': 'ListItem', position: 3, name: leaf.label, item: absoluteUrl(leaf.url) }] : []),
     ],
   };
 
@@ -66,20 +73,32 @@ export default async function FrontDoorBreadcrumb({
       {emitJsonLd ? <JsonLd data={breadcrumbJsonLd} /> : null}
       <Box component="ol" sx={listSx}>
         <li>
-          <LocaleLink href="/">{t('frontDoor.breadcrumb.home')}</LocaleLink>
+          <MuiLink component={LocaleLink} href="/" underline="hover" color="inherit">
+            {t('frontDoor.breadcrumb.home')}
+          </MuiLink>
         </li>
         <Box component="li" aria-hidden sx={separatorSx}>
           /
         </Box>
-        <li>
-          <LocaleLink href={boardListUrl}>{boardCrumbLabel}</LocaleLink>
-        </li>
-        <Box component="li" aria-hidden sx={separatorSx}>
-          /
-        </Box>
-        <Box component="li" aria-current="page">
-          {currentLabel}
-        </Box>
+        {leaf ? (
+          <>
+            <li>
+              <MuiLink component={LocaleLink} href={boardListUrl} underline="hover" color="inherit">
+                {boardCrumbLabel}
+              </MuiLink>
+            </li>
+            <Box component="li" aria-hidden sx={separatorSx}>
+              /
+            </Box>
+            <Box component="li" aria-current="page" sx={currentCrumbSx}>
+              {leaf.label}
+            </Box>
+          </>
+        ) : (
+          <Box component="li" aria-current="page" sx={currentCrumbSx}>
+            {boardCrumbLabel}
+          </Box>
+        )}
       </Box>
     </Box>
   );

--- a/packages/web/app/components/climb-front-door/static-list-front-door.tsx
+++ b/packages/web/app/components/climb-front-door/static-list-front-door.tsx
@@ -46,6 +46,12 @@ const introSx = { color: 'var(--neutral-400)', m: 0, mb: 3, maxWidth: '68ch' };
 
 // Prev / page label / next as a three-column grid rather than a flex row with
 // `<span />` spacers: the label stays centred whether or not both arrows exist.
+//
+// Under 480px the two controls share row 1 and the label drops to row 2. Both
+// buttons plus a centred label do not fit side by side on a 320–360px phone
+// once the labels are translated ("Página anterior" / "Página siguiente"), and
+// a grid track defaults to `min-width: auto`, so a three-column row there would
+// push the whole page into horizontal scroll rather than shrink.
 const paginationSx = {
   display: 'grid',
   gridTemplateColumns: '1fr auto 1fr',
@@ -53,13 +59,38 @@ const paginationSx = {
   gap: 2,
   mt: 5,
   mb: 2,
+  '@media (max-width: 480px)': {
+    gridTemplateColumns: '1fr 1fr',
+    columnGap: 1,
+  },
 };
 
-const previousSx = { gridColumn: 1, justifySelf: 'start' };
+// `minWidth: 0` overrides both the track's `auto` minimum and MUI's 64px button
+// minimum; `maxWidth: 100%` plus wrapping keeps a long label inside its track
+// instead of spilling out of the container.
+const paginationControlSx = {
+  minWidth: 0,
+  maxWidth: '100%',
+  whiteSpace: 'normal' as const,
+  gridRow: 1,
+};
 
-const pageLabelSx = { gridColumn: 2, justifySelf: 'center', color: 'var(--neutral-400)' };
+const previousSx = { ...paginationControlSx, gridColumn: 1, justifySelf: 'start' };
 
-const nextSx = { gridColumn: 3, justifySelf: 'end' };
+const pageLabelSx = {
+  gridColumn: 2,
+  gridRow: 1,
+  justifySelf: 'center',
+  color: 'var(--neutral-400)',
+  '@media (max-width: 480px)': { gridColumn: '1 / -1', gridRow: 2 },
+};
+
+const nextSx = {
+  ...paginationControlSx,
+  gridColumn: 3,
+  justifySelf: 'end',
+  '@media (max-width: 480px)': { gridColumn: 2 },
+};
 
 const emptyStateSx = {
   textAlign: 'center' as const,

--- a/packages/web/app/components/climb-front-door/static-list-front-door.tsx
+++ b/packages/web/app/components/climb-front-door/static-list-front-door.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import StaticClimbList from '@/app/components/climb-list/static-climb-list';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { formatBoardDisplayName } from '@/app/lib/string-utils';
+import { buildCanonicalClimbListUrl } from '@/app/lib/url-utils';
 import { frontDoorPagePath, isIndexableFrontDoorPage } from '@/app/lib/seo/list-page-robots';
 import { themeTokens } from '@/app/theme/theme-config';
 import type { BoardDetails, Climb } from '@/app/lib/types';
 import ClimbHandoffCta, { type HandoffTree } from './climb-handoff-cta';
 import ClimbListJsonLd from './climb-list-json-ld';
+import FrontDoorBreadcrumb from './front-door-breadcrumb';
 
 type StaticListFrontDoorProps = {
   boardDetails: BoardDetails;
@@ -21,6 +24,14 @@ type StaticListFrontDoorProps = {
   /** The clean base path with no query string — pagination anchors hang off it. */
   basePath: string;
   tree: HandoffTree;
+  /**
+   * True when the page is asking Google not to index it — today only `/b/{slug}`
+   * on an unlisted or non-public board. Gates the `BreadcrumbList` payload for
+   * the same reason `ClimbFrontDoor` gates `CreativeWork`: a noindex URL whose
+   * structured data names an indexable twin is a conflicting signal Google can
+   * resolve by propagating the noindex onto the public page.
+   */
+  noindex?: boolean;
 };
 
 const containerSx = {
@@ -29,15 +40,35 @@ const containerSx = {
   padding: `${themeTokens.spacing[4]}px`,
 };
 
+const headingSx = { fontWeight: themeTokens.typography.fontWeight.bold, mt: 1, mb: 1 };
+
+const introSx = { color: 'var(--neutral-400)', m: 0, mb: 3, maxWidth: '68ch' };
+
+// Prev / page label / next as a three-column grid rather than a flex row with
+// `<span />` spacers: the label stays centred whether or not both arrows exist.
 const paginationSx = {
-  display: 'flex',
+  display: 'grid',
+  gridTemplateColumns: '1fr auto 1fr',
   alignItems: 'center',
-  justifyContent: 'space-between',
-  gap: `${themeTokens.spacing[4]}px`,
-  margin: `${themeTokens.spacing[6]}px 0`,
+  gap: 2,
+  mt: 5,
+  mb: 2,
 };
 
-const introSx = { color: 'var(--neutral-400)', marginBottom: `${themeTokens.spacing[4]}px` };
+const previousSx = { gridColumn: 1, justifySelf: 'start' };
+
+const pageLabelSx = { gridColumn: 2, justifySelf: 'center', color: 'var(--neutral-400)' };
+
+const nextSx = { gridColumn: 3, justifySelf: 'end' };
+
+const emptyStateSx = {
+  textAlign: 'center' as const,
+  color: 'var(--neutral-400)',
+  padding: `${themeTokens.spacing[6]}px ${themeTokens.spacing[4]}px`,
+  border: '1px dashed var(--neutral-300)',
+  borderRadius: `${themeTokens.borderRadius.md}px`,
+  m: 0,
+};
 
 /**
  * The SSR `/list` page: one fixed page of climbs, every row a real anchor.
@@ -59,17 +90,35 @@ export default async function StaticListFrontDoor({
   page,
   basePath,
   tree,
+  noindex = false,
 }: StaticListFrontDoorProps) {
   const { t, locale } = await getServerTranslation('climbs');
   const boardName = formatBoardDisplayName(boardDetails.board_name);
+  // The breadcrumb's leaf is this page's CANONICAL, which on `/b/{slug}` is the
+  // config-tuple URL rather than the path the reader is on — same split
+  // `ClimbFrontDoor` handles, same builder on both trees.
+  const canonicalListUrl = buildCanonicalClimbListUrl(boardDetails, angle);
+  // `?page=2` is self-canonical, so a BreadcrumbList there whose leaf names page
+  // 1 would be a second, contradicting answer to "which URL is this?". Page 1 is
+  // the only page whose canonical the crumbs actually describe.
+  const emitBreadcrumbJsonLd = !noindex && page === 1;
 
   return (
     <Box component="main" sx={containerSx}>
       <ClimbListJsonLd climbs={climbs} boardDetails={boardDetails} page={page} locale={locale} />
 
+      <FrontDoorBreadcrumb
+        boardName={boardName}
+        angle={angle}
+        boardListUrl={canonicalListUrl}
+        emitJsonLd={emitBreadcrumbJsonLd}
+      />
+
       <Box component="header">
-        <h1>{t('list.frontDoor.heading', { boardName, angle })}</h1>
-        <Typography component="p" sx={introSx}>
+        <Typography variant="h3" component="h1" sx={headingSx}>
+          {t('list.frontDoor.heading', { boardName, angle })}
+        </Typography>
+        <Typography variant="body1" component="p" sx={introSx}>
           {t('list.frontDoor.intro', { boardName, angle })}
         </Typography>
       </Box>
@@ -82,18 +131,33 @@ export default async function StaticListFrontDoor({
         // renderer: this page paints 50 rows at once, and the first screenful
         // is what LCP measures.
         initialImageCount={6}
-        emptyState={<Typography component="p">{t('list.frontDoor.empty')}</Typography>}
+        emptyState={
+          <Typography variant="body1" component="p" sx={emptyStateSx}>
+            {t('list.frontDoor.empty')}
+          </Typography>
+        }
       />
 
       <Box component="nav" aria-label={t('list.frontDoor.pagination.aria')} sx={paginationSx}>
         {page > 1 ? (
-          <LocaleLink href={frontDoorPagePath(basePath, page - 1)} rel="prev">
+          <Button
+            component={LocaleLink}
+            href={frontDoorPagePath(basePath, page - 1)}
+            rel="prev"
+            variant="outlined"
+            size="small"
+            sx={previousSx}
+          >
             {t('list.frontDoor.pagination.previous')}
-          </LocaleLink>
+          </Button>
         ) : (
-          <span />
+          <Button disabled variant="outlined" size="small" sx={previousSx}>
+            {t('list.frontDoor.pagination.previous')}
+          </Button>
         )}
-        <span>{t('list.frontDoor.pagination.pageLabel', { page })}</span>
+        <Typography variant="body2" component="span" sx={pageLabelSx}>
+          {t('list.frontDoor.pagination.pageLabel', { page })}
+        </Typography>
         {/*
           The walk stops at the last indexable page, not at the last page with
           climbs behind it. `noindex, follow` past the cap tells a crawler to
@@ -103,11 +167,20 @@ export default async function StaticListFrontDoor({
           the sitemap and the per-climb cross-links.
         */}
         {hasMore && isIndexableFrontDoorPage(page + 1) ? (
-          <LocaleLink href={frontDoorPagePath(basePath, page + 1)} rel="next">
+          <Button
+            component={LocaleLink}
+            href={frontDoorPagePath(basePath, page + 1)}
+            rel="next"
+            variant="outlined"
+            size="small"
+            sx={nextSx}
+          >
             {t('list.frontDoor.pagination.next')}
-          </LocaleLink>
+          </Button>
         ) : (
-          <span />
+          <Button disabled variant="outlined" size="small" sx={nextSx}>
+            {t('list.frontDoor.pagination.next')}
+          </Button>
         )}
       </Box>
 

--- a/packages/web/app/components/similar-climbs/similar-climbs-list.tsx
+++ b/packages/web/app/components/similar-climbs/similar-climbs-list.tsx
@@ -12,7 +12,7 @@ import BoardCanvasRenderer from '@/app/components/board-renderer/board-canvas-re
 import { useCanvasRendererReady } from '@/app/lib/board-render-worker/worker-manager';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
-import { formatSends } from '@/app/lib/format-climb-stats';
+import { formatSends, type TranslateSends } from '@/app/lib/format-climb-stats';
 import { useGradeFormat } from '@/app/hooks/use-grade-format';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
@@ -304,7 +304,7 @@ function SimilarClimbCard({ climb, boardType, viewerBoardDetails, compatible }: 
           </span>
         ) : null}
       </div>
-      <div className={`${styles.byline}${dimClass}`}>{formatByline(climb)}</div>
+      <div className={`${styles.byline}${dimClass}`}>{formatByline(climb, t)}</div>
     </>
   );
 
@@ -330,14 +330,14 @@ function SimilarClimbCard({ climb, boardType, viewerBoardDetails, compatible }: 
  * Skips any segment that's missing data — most user-created climbs have no
  * quality rating or ascent count yet, so we don't want to show stale zeros.
  */
-function formatByline(climb: SimilarClimb): string {
+function formatByline(climb: SimilarClimb, t: TranslateSends): string {
   const parts: string[] = [];
   if (climb.setterUsername) parts.push(climb.setterUsername);
   if (typeof climb.qualityAverage === 'number' && climb.qualityAverage > 0) {
     parts.push(`★${climb.qualityAverage.toFixed(1)}`);
   }
   if (typeof climb.ascensionistCount === 'number' && climb.ascensionistCount > 0) {
-    parts.push(formatSends(climb.ascensionistCount));
+    parts.push(formatSends(climb.ascensionistCount, t));
   }
   return parts.join(' · ');
 }

--- a/packages/web/app/lib/__tests__/format-climb-stats.test.ts
+++ b/packages/web/app/lib/__tests__/format-climb-stats.test.ts
@@ -40,19 +40,29 @@ describe('formatCount', () => {
 });
 
 describe('formatSends', () => {
-  it('uses singular for count of 1', () => {
-    expect(formatSends(1)).toBe('1 send');
+  // Fake translate mirroring the en-US `sends` plural key shape, so these cases
+  // pin what `formatSends` HANDS the catalog — the true count for plural
+  // selection, the compact string for display — rather than the catalog itself.
+  const t = (_key: string, options: { count: number; formattedCount: string }) =>
+    `${options.formattedCount} send${options.count === 1 ? '' : 's'}`;
+
+  it('passes the true count for plural selection, so 1 stays singular', () => {
+    expect(formatSends(1, t)).toBe('1 send');
   });
 
   it('uses plural for counts other than 1', () => {
-    expect(formatSends(0)).toBe('0 sends');
-    expect(formatSends(2)).toBe('2 sends');
-    expect(formatSends(999)).toBe('999 sends');
+    expect(formatSends(0, t)).toBe('0 sends');
+    expect(formatSends(2, t)).toBe('2 sends');
+    expect(formatSends(999, t)).toBe('999 sends');
   });
 
-  it('uses plural with compact notation', () => {
-    expect(formatSends(1000)).toBe('1k sends');
-    expect(formatSends(1500000)).toBe('1.5m sends');
+  it('hands the catalog the compact count, not the raw one', () => {
+    expect(formatSends(1000, t)).toBe('1k sends');
+    expect(formatSends(1500000, t)).toBe('1.5m sends');
+  });
+
+  it('asks for the `sends` key in the climbs namespace', () => {
+    expect(formatSends(3, (key) => key)).toBe('sends');
   });
 });
 

--- a/packages/web/app/lib/__tests__/helpers/resolve-server-tree.tsx
+++ b/packages/web/app/lib/__tests__/helpers/resolve-server-tree.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+/**
+ * Walk a server-component tree and await every async component in it, so the
+ * result can go through `renderToString`.
+ *
+ * `renderToString` cannot suspend — hand it a tree with an unresolved async
+ * server component anywhere inside and it throws "A component suspended while
+ * responding to synchronous input" rather than rendering. Awaiting the page
+ * function alone is not enough: it resolves only the outermost component, and
+ * any async child it returned is still a promise at its first hook.
+ *
+ * `stopAt` holds back components the caller wants to observe by identity rather
+ * than by output.
+ */
+function isAsyncComponent(type: unknown): boolean {
+  return (
+    typeof type === 'function' && (type as { constructor?: { name?: string } }).constructor?.name === 'AsyncFunction'
+  );
+}
+
+export async function resolveServerTree(
+  node: React.ReactNode,
+  stopAt: ReadonlySet<unknown> = new Set(),
+): Promise<React.ReactNode> {
+  if (Array.isArray(node)) return Promise.all(node.map((child) => resolveServerTree(child, stopAt)));
+  if (!React.isValidElement(node)) return node;
+
+  const element = node as React.ReactElement<{ children?: React.ReactNode }>;
+  if (isAsyncComponent(element.type) && !stopAt.has(element.type)) {
+    const produced = await (element.type as (props: unknown) => Promise<unknown>)(element.props);
+    if (React.isValidElement(produced)) return resolveServerTree(produced, stopAt);
+    return (produced ?? null) as React.ReactNode;
+  }
+
+  const { children } = element.props;
+  if (children === undefined) return element;
+  return React.cloneElement(element, undefined, await resolveServerTree(children, stopAt));
+}

--- a/packages/web/app/lib/format-climb-stats.ts
+++ b/packages/web/app/lib/format-climb-stats.ts
@@ -15,9 +15,14 @@ export function formatCount(count: number): string {
   return `${Math.round(thousands)}k`;
 }
 
-/** Format send count with singular/plural label: "1 send", "5 sends", "1.2k sends" */
-export function formatSends(count: number): string {
-  return `${formatCount(count)} send${count === 1 ? '' : 's'}`;
+/** Minimal translate signature so this pure util stays out of React.
+ *  Resolves the `sends` plural key in the `climbs` namespace. */
+export type TranslateSends = (key: string, options: { count: number; formattedCount: string }) => string;
+
+/** Localized send count with compact number: t('sends') → "1.5k sends" / "1 send".
+ *  Passes the true `count` for plural selection and `formattedCount` for display. */
+export function formatSends(count: number, t: TranslateSends): string {
+  return t('sends', { count, formattedCount: formatCount(count) });
 }
 
 /** Round quality_average to 1 decimal place */


### PR DESCRIPTION
## Summary

The SSR climb pages were SEO-correct but visually unstyled. `packages/web/app/components/index.css` carries no h1/h2 rules, so every heading on the two front doors fell back to browser defaults (2em/1.5em with large UA margins) while the rest of www renders through MUI `Typography` and the design tokens.

Presentation only. Epic #4358 locked the list page as a minimal static top-50 with `?page` pagination, and this PR adds no search, filters or queue — those stay in the app.

**Typography.** Every heading now goes through `Typography variant=... component=...`, mirroring `gyms/directory-page.tsx`. `component` keeps the tags, so the `<h1>` + `<p>` identity the SEO layer depends on is byte-for-byte the same element; only the type ramp changed. The one bare-tag assertion in `view-seo-fragment.test.tsx` moves to the `/<h1[\s>]/` form the same file already used two tests earlier, since a Typography class attribute makes the tag `<h1 class="...">`.

**Structure on the list page.**

- Both route shells rendered `<main id="content-for-scrollable">` around front doors that render their own `<main>` — invalid HTML and two landmarks for one region. The shells drop theirs; every page under them already has one, matching how the rest of www places the landmark. The id was a leftover from the deleted queue scroll container and nothing referenced it. The shells' 8px horizontal padding goes with it: the front doors already inset by 16px, so a phone was getting a 24px gutter.
- Pagination was two bare links with `<span />` spacers. It is now outlined buttons in a three-column grid, with a disabled control at either end of the walk so the page label stays centred. `rel="prev"` / `rel="next"` and the `isIndexableFrontDoorPage(page + 1)` ceiling are untouched — that gating is the crawl-budget contract, and three tests still pin it.
- The list page had no upward navigation and no `BreadcrumbList`. `FrontDoorBreadcrumb` grows a two-crumb form (the board crumb is the leaf there) and the schema goes out only on page 1 of an indexed board: `?page=2` is self-canonical, so crumbs naming page 1 would contradict it.
- The empty state was a bare paragraph; it now reads as a real empty card.

**An i18n bug on the highest-traffic component.** `formatSends` emitted "12 sends" as hardcoded English, so every climb row's subtitle was untranslated on /es, /fr and /de. It now takes a `t`, exactly as the mobile twin already does, and resolves the `sends_one` / `sends_other` keys that were sitting unused in the climbs catalog. The neighbouring hardcoded strings in `climb-title.tsx` (`'Draft'`, `` `By ${setter}` ``, `` `Draft by ${setter}` ``) go through the catalog too, with three new keys in all four locales.

`resolveServerTree` moves out of `view-seo-fragment.test.tsx` into a shared test helper: the list front door now has an async server component nested in its tree, and `renderToString` cannot suspend on one.

Part of epic #4358.

Closes #5077

## Release Notes

- Climb pages are readable again — real headings, spacing and a breadcrumb back to the board.
- Send counts finally speak Spanish, French and German instead of falling back to English.

## Test plan

1. Open any board's climb list. Headings look sized, not raw.
2. Tap Previous/Next. Real buttons, greyed out at the ends.
3. Tap a climb. Breadcrumb sits above the name.
4. Add `/es` to the URL. Row subtitles read "encadenes", not "sends".
5. Check the list on a phone width. One gutter, not two.

## Risk

Risk: 2/5 — presentation and i18n on SSR pages, guarded by the canonical, metadata and front-door SEO tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nkd1PyBEMjrq4Zr3j5VY3o


## QA follow-ups (second pass)

- **Pagination on narrow phones.** The three grid tracks defaulted to `min-width: auto`, so the translated row ("Página anterior" / "Página siguiente" / "Página 1") could not shrink below ~340px while a 320px device leaves 288px. Under 480px the two buttons now share a row and the page label drops beneath them; both controls carry `minWidth: 0` so a long label wraps inside its track.
- **BreadcrumbList is now pinned.** `formatBoardDisplayName` on the board crumb changes that payload's `position: 2` name from "kilter — …" to "Kilter — …". Kept deliberately: the crumb is user-visible text, the repo's trademark rule ("Capitalise correctly: MoonBoard, Kilter, Tension") applies to it, and structured data must not drift from what the page shows. The new `view-seo-fragment` test pins all three crumbs and that casing, so the payload can't move again unnoticed. Say the word if you'd rather it ship as its own PR and I'll revert the one line.
- **Disabled-control assertion tightened.** `<button[^>]*disabled` was also satisfied by MUI's `Mui-disabled` class token; it now anchors on the `disabled=""` attribute. Mutation-checked: a class-only "disabled" button fails it.
- **Not done, on purpose:** `formatSends`/`formatQuality` still exist twice (web + mobile, now byte-identical bar one comment). Extracting them into a shared package is the right call but drags mobile typecheck/tests/bundle into a web presentation PR — better as its own change. The `Draft` badge keeps reading `createClimbForm.draftBadge`, which is exactly what mobile's `ClimbListItemContent` does for the same badge; a web-only `card.title.draftBadge` twin would split them.
