### PR TITLE
feat(repo): let Cloudflare actually cache www HTML

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -348,6 +348,94 @@ themselves honestly. A UA-rotating farm walked ~2,500 climb-view URLs on
 one pageview each, `$referring_domain` null on every event). That population is
 what the rate-limit rule below is for.
 
+### Caching list and climb-view HTML (#4652)
+
+`packages/web/middleware.ts` has decorated list pages and climb-view pages with
+`CDN-Cache-Control: s-maxage=86400, stale-while-revalidate=604800` since long
+before www moved to Railway (TTLs from `app/lib/list-page-cache.ts`). Those
+headers were **inert**: Cloudflare had no cache rule for www HTML, and it caches
+by file extension by default, which a page route does not have. Measured against
+production on 2026-09-02, a logged-out list page returned the header and
+`cf-cache-status: DYNAMIC` — so every crawler hit re-rendered at the single
+`us-west2` Railway replica against Postgres. The fourth cache rule,
+`boardsesh:www-html-edge-cache`, is what makes the origin's own TTL take effect.
+
+Same action as the other three: eligible for cache, edge TTL
+`bypass_by_default`, browser TTL `respect_origin`. `bypass_by_default` is the
+safety model, not a detail — the origin decides, and anything it does not
+decorate stays out of the edge. A list page carrying a user-specific filter
+(`?onlyDrafts=true`, `?minUserRating=4`) was measured returning
+`Cache-Control: private, no-cache, no-store` and **no** `CDN-Cache-Control`, so
+the expression never has to enumerate `USER_SPECIFIC_SEARCH_PARAMS`. The
+sticky-locale 307 (`/kilter/…` → `/es/kilter/…` for a visitor carrying
+`boardsesh-locale`) returns before the middleware's cache-header block and
+carries no cache directive at all, so it bypasses too. **Never switch this rule
+to `override_origin`:** it ignores the origin *and* strips `Set-Cookie` in order
+to cache.
+
+The expression carries three explicit bypasses on top of the host and path
+gates. All three exist because **Cloudflare honours `Vary` only for
+`Accept-Encoding` below Enterprise** and these responses ship
+`Vary: rsc, next-router-state-tree, next-router-prefetch,
+next-router-segment-prefetch, Accept-Encoding`.
+
+1. **The session cookie.** `not (http.cookie contains "next-auth.session-token")`.
+   The origin does not help here: a request carrying a session cookie was
+   measured still getting `CDN-Cache-Control: s-maxage=86400`. One substring
+   covers `__Secure-next-auth.session-token` (production), the bare
+   `next-auth.session-token` (which the read path still honours — see
+   `sessionCookieNameCandidates`), and the `<name>.0`, `<name>.1` chunks
+   next-auth splits an oversized session into.
+2. **The RSC header.** `not (any(http.request.headers["rsc"][*] != ""))`. This
+   is the one that would have hurt. `RSC: 1` on a list page returns a **307 to
+   `?_rsc`** carrying `CDN-Cache-Control: s-maxage=86400` and no
+   `Cache-Control` — a redirect the edge would store under the *same cache key
+   as the HTML document* and serve to real browsers for 24 hours. Anyone can
+   send that header. `list-page-cache.ts` already carries the #4592 warning that
+   a cacheable redirect loop at this TTL pins for a full day. Bypassing on any
+   non-empty value rather than on `== "1"` (the only value Next acts on today)
+   keeps a Next.js change from reopening it.
+3. **`?_rsc`.** `not (http.request.uri.query contains "_rsc")`, the redirect's
+   own target and the shape Next's router actually fetches.
+
+Two things about that second clause:
+
+- It reads the header through the documented map accessor
+  `http.request.headers["rsc"]`, **not** `http.request.headers.names` — the
+  field production rejected in the `http_ratelimit` phase with `not entitled:
+  the use of field http.request.headers.names is not allowed, an higher
+  Advanced Rate Limiting plan is required`. That entitlement is rate-limiting
+  specific (Advanced Rate Limiting is a rate-limiting SKU); it is not a
+  zone-wide ban on header fields. Cloudflare's cache-rule docs list
+  **Request Headers — `http.request.headers`** among the fields a cache rule
+  expression may use, and Cloudflare's field catalogue tags 70 of its 173
+  fields with a `plan_info_label` (`http.request.body.raw` → `Enterprise`) while
+  tagging `http.request.headers` and `http.cookie` with none. **This has not
+  been proven against the live zone** — nobody has applied it yet.
+- If Cloudflare *does* reject it, the failure is safe: the `http_request_cache_settings`
+  PUT 400s, no rule is created, and www HTML keeps behaving exactly as it does
+  today. `deploy-cloudflare` goes red and the fix is a deliberate one. The
+  dangerous state — a rule that caches HTML *without* the RSC bypass — cannot
+  be reached by that failure, only by someone deleting the clause.
+
+The path gate is the full {locale prefix} × {board tree root} cross product
+(4 × 9 = 36 `starts_with` clauses, 2,187 of the 4,096 characters a rule
+expression may hold), because the middleware tests the first segment of the
+**locale-stripped** path and Cloudflare cannot strip a prefix. A test reads
+`SUPPORTED_BOARDS` and `SUPPORTED_LOCALES` from their real source files and
+fails if either list grows without this one; another fails at 3,072 characters,
+so the cross product's growth gets compacted deliberately rather than
+discovered as a 400 during a production apply.
+
+**Known behaviour change: `/es`, `/fr` and `/de` pages stop handing out the
+sticky-locale cookie once they are served from cache.** The middleware sets
+`boardsesh-locale` on every non-default-locale response for a non-crawler, and
+Cloudflare does not cache a response carrying `Set-Cookie` under
+`bypass_by_default`. Crawlers never receive that cookie, so their responses are
+the ones that populate the edge — and a human landing on a cached `/es` page
+gets no cookie. Navigation within `/es` is locale-prefixed anyway
+(`LocaleLink`), so this only affects a later unprefixed entry point.
+
 ### Rate limiting the climb-view path
 
 `http_ratelimit` is the third managed phase. One rule,
@@ -535,6 +623,55 @@ for UA in "AhrefsBot/7.0" "SemrushBot/7~bl" "Brave-Search/1.0" "Googlebot/2.1" "
   curl -sSI -A "$UA" https://www.boardsesh.com/ | grep -ci '^x-vercel-id' | sed 's/^/reached-vercel:/'
 done
 ```
+
+#### After the www HTML cache rule applies (#4652)
+
+Run these in order. Step 4 is the one that matters: a cached RSC redirect is the
+failure this rule was designed around, and it is invisible until a browser hits
+it. Use `-o /dev/null -D -` (a GET) rather than `-I` — a HEAD is a different
+cache entry.
+
+```bash
+L='https://www.boardsesh.com/kilter/homewall/7x10-full-ride/main_aux/40/list'
+show() { curl -s -o /dev/null -D - "$@" | grep -iE '^(HTTP|cf-cache-status|age|location|cdn-cache-control|set-cookie)'; }
+
+# 1. Anonymous list page: DYNAMIC before the rule, MISS then HIT after it.
+show "$L"
+show "$L"
+
+# 2. Same for a climb view, and for a locale twin. Pick a real climb URL from
+#    https://www.boardsesh.com/sitemap.xml.
+show 'https://www.boardsesh.com/b/<board-slug>/40/view/<climb-uuid>'
+
+# 3. Signed in: BYPASS, every time. Paste a real session cookie from a logged-in
+#    browser (DevTools -> Application -> Cookies).
+show -H 'Cookie: __Secure-next-auth.session-token=<paste>' "$L"
+
+# 4. THE ONE THAT MATTERS. The RSC request must stay uncached, and — critically —
+#    must not have poisoned the entry for everyone else.
+show -H 'RSC: 1' "$L"          # expect: 307, location .../list?_rsc, cf-cache-status BYPASS
+show "$L"                      # expect: STILL 200 HTML. A 307 here means the rule is broken.
+show "$L?_rsc"                 # expect: BYPASS
+
+# 5. A user-specific filter must never share the anonymous entry.
+show "$L?onlyDrafts=true"      # expect: no cdn-cache-control, cf-cache-status BYPASS
+```
+
+Expected: step 1's second call is `HIT` with a growing `age`; step 3 and steps
+4–5 are all `BYPASS`; step 4's middle call is a 200 HTML document, not a
+redirect. **If step 4's middle call returns a 307, purge immediately** —
+Caching → Configuration → Purge Everything in the dashboard (there is no purge
+tooling and the CI token has no `Zone.Cache Purge` scope) — then set
+`enabled: false` on the rule in `infra/cloudflare/config.ts` and re-apply.
+
+Then confirm it actually moved the needle: Railway `web` CPU and the Postgres
+query rate should fall, and Cloudflare Analytics → Caching should show a
+non-trivial cached share of HTML requests on www.
+
+Rolling back is the usual one-liner: `enabled: false` on
+`boardsesh:www-html-edge-cache` and `vp run cf:apply -- --apply`. That stops new
+entries but does **not** evict what is already cached, so pair it with a purge
+whenever the reason for rolling back is a wrong cached response.
 
 Expect Ahrefs and Semrush at `403 reached-vercel:0`; Brave, Google and Bing at
 `200 reached-vercel:1`.

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -118,6 +118,9 @@ export const BOARD_RENDER_CACHE_RULE_DESCRIPTION =
 export const BACKEND_BOARD_RENDER_CACHE_RULE_DESCRIPTION =
   'boardsesh:backend-board-render-edge-cache (managed by scripts/cloudflare-apply.ts)';
 
+/** Marker for the www list/climb-view HTML cache rule. Never rename without migrating the live rule. */
+export const WWW_HTML_CACHE_RULE_DESCRIPTION = 'boardsesh:www-html-edge-cache (managed by scripts/cloudflare-apply.ts)';
+
 /** Markers for the two WAF custom rules. Same never-rename contract as above. */
 export const CRAWLER_ALLOW_RULE_DESCRIPTION =
   'boardsesh:allow-search-crawlers (managed by scripts/cloudflare-apply.ts)';
@@ -332,6 +335,147 @@ export const BOARD_RENDER_CACHE_EXPRESSION = `(http.host eq "${WWW_HOSTNAME}" an
 export const BACKEND_BOARD_RENDER_CACHE_EXPRESSION = `(http.host eq "${WS_HOSTNAME}" and (http.request.uri.path eq "${BACKEND_BOARD_RENDER_PATH}" or http.request.uri.path eq "${BOARD_RENDER_PATH_PREFIX}"))`;
 
 /**
+ * Locale path prefixes on www, in the shape a Cloudflare expression sees them.
+ *
+ * The empty string is en-US, which is served UNPREFIXED (see `detectLocale` in
+ * packages/web/app/lib/i18n/detect-locale.ts — it skips DEFAULT_LOCALE). The
+ * other three are real path prefixes, and the middleware strips them before it
+ * decides whether to decorate the response, so `/es/kilter/…/list` gets the
+ * same CDN-Cache-Control as `/kilter/…/list`. Cloudflare has no way to strip a
+ * prefix, so the prefixes are enumerated here instead.
+ */
+export const WWW_HTML_CACHE_LOCALE_PREFIXES = ['', '/es', '/fr', '/de'] as const;
+
+/**
+ * The first path segment of every page tree that renders a board list or climb
+ * view: `b` for the slug tree (`/b/{board_slug}/{angle}/…`) plus one segment per
+ * board for the legacy numeric tree (`/{board}/{layout}/{size}/{sets}/{angle}/…`).
+ *
+ * Mirrors SUPPORTED_BOARDS in packages/shared-schema/src/types/board-config.ts,
+ * which is what `getListPageCacheTTL` / `getClimbViewPageCacheTTL` test the first
+ * segment against. It is duplicated rather than imported because
+ * infra/cloudflare is declarative data with no workspace dependencies, and
+ * because the web list is feature-flag-gated at runtime (MoonBoard) while a
+ * desired-state file has to be deterministic. A test reads the schema file and
+ * fails if a board is added there and not here — a missed board only costs the
+ * cache, but it costs it silently.
+ */
+export const WWW_HTML_CACHE_ROOT_SEGMENTS = [
+  'b',
+  'kilter',
+  'tension',
+  'moonboard',
+  'decoy',
+  'touchstone',
+  'grasshopper',
+  'soill',
+  'woods',
+] as const;
+
+/** Path suffix of every list page (`getListPageCacheTTL` fast-paths on exactly this). */
+export const LIST_PAGE_PATH_SUFFIX = '/list';
+
+/** Path segment every climb-view URL shape shares, in both trees and all four locales. */
+export const CLIMB_VIEW_PATH_SEGMENT = '/view/';
+
+/**
+ * The substring shared by every name the NextAuth session cookie can carry.
+ *
+ * Production writes `__Secure-next-auth.session-token`; a non-HTTPS context
+ * writes the bare `next-auth.session-token`, which the read paths still honour
+ * (see sessionCookieNameCandidates in packages/web/app/lib/auth/secure-cookies.ts);
+ * an oversized session is split into `<name>.0`, `<name>.1`, … Every one of
+ * those contains this substring, so one `http.cookie contains` clause covers the
+ * lot — including a chunked cookie, which an equality test would miss.
+ */
+export const SESSION_COOKIE_NAME_SUBSTRING = 'next-auth.session-token';
+
+/**
+ * Next's React Server Component request header, lowercased (Cloudflare
+ * lowercases the keys of `http.request.headers`).
+ *
+ * Measured against production on 2026-09-02: `RSC: 1` on a list page returns a
+ * **307 to `?_rsc`** that carries `CDN-Cache-Control: s-maxage=86400,
+ * stale-while-revalidate=604800` and NO `Cache-Control` — i.e. a redirect the
+ * edge would happily store for a day. `RSC: 2` and an empty `RSC:` both return
+ * the ordinary 200 HTML, so `1` is today's only trigger; the rule bypasses on
+ * ANY non-empty value so a Next.js change cannot quietly reopen it.
+ *
+ * The response's `Vary: rsc, next-router-state-tree, next-router-prefetch,
+ * next-router-segment-prefetch, Accept-Encoding` does NOT save us: Cloudflare
+ * honours Vary for Accept-Encoding only below Enterprise and ignores the rest,
+ * so the 307 and the HTML document share one cache key. That is the failure
+ * this clause exists to prevent, and `list-page-cache.ts` already carries the
+ * matching warning from #4592 — a cacheable redirect loop at this TTL pins for
+ * a full day.
+ *
+ * The other three Vary'd headers need no clause of their own: sent WITHOUT
+ * `RSC`, each was measured returning the byte-identical anonymous HTML, and
+ * Next's router never sends them without `RSC: 1`.
+ */
+export const RSC_REQUEST_HEADER_NAME = 'rsc';
+
+/** The query parameter Next appends to RSC fetches, and the target of that 307. */
+export const RSC_QUERY_PARAM = '_rsc';
+
+/** Every `{locale}{root}` path prefix the middleware decorates, as Cloudflare sees it. */
+export function buildWwwHtmlCachePathPrefixes(): string[] {
+  return WWW_HTML_CACHE_LOCALE_PREFIXES.flatMap((localePrefix) =>
+    WWW_HTML_CACHE_ROOT_SEGMENTS.map((rootSegment) => `${localePrefix}/${rootSegment}/`),
+  );
+}
+
+/**
+ * List and climb-view HTML on www — the surface `packages/web/middleware.ts`
+ * decorates with `CDN-Cache-Control: s-maxage=86400, stale-while-revalidate=604800`
+ * (TTLs from app/lib/list-page-cache.ts).
+ *
+ * Those headers have been inert since www moved behind this proxy: measured
+ * 2026-09-02, a logged-out list page returns the header and
+ * `cf-cache-status: DYNAMIC`, because Cloudflare caches by file extension by
+ * default and an HTML page route has none. Every crawler hit re-renders at the
+ * single us-west2 Railway replica against Postgres. This rule is what makes the
+ * origin's own declared TTL take effect.
+ *
+ * Read as five ANDed gates:
+ *
+ * 1. `http.host` — www only. ws, assets, app and updates keep serving themselves.
+ * 2. Shape — a `/list` suffix or a `/view/` segment, the two things
+ *    `getListPageCacheTTL` and `getClimbViewPageCacheTTL` key on. Cloudflare
+ *    cannot count path segments without `matches`, which needs a Business plan,
+ *    so the segment-count half of those functions is not reproduced; the origin
+ *    still applies it, and gate 5 defers to the origin.
+ * 3. Prefix — the full {locale} × {board tree root} cross product, because the
+ *    middleware tests the first segment of the LOCALE-STRIPPED path and
+ *    Cloudflare cannot strip. Enumerated rather than loosened so a future www
+ *    route that happens to end in `/list` and sets its own public max-age
+ *    cannot inherit this rule.
+ * 4. Bypasses — session cookie, RSC header, `?_rsc`. See the constants above.
+ *    `Vary` is not a substitute for any of them: Cloudflare ignores it except
+ *    for Accept-Encoding.
+ * 5. `edge_ttl: bypass_by_default` on the rule itself, which is the real
+ *    guarantee: a response with no cacheable directive never enters the edge.
+ *    A list page carrying a user-specific filter (`?onlyDrafts=true`,
+ *    `?minUserRating=4`) was measured returning `Cache-Control: private,
+ *    no-cache, no-store` and NO `CDN-Cache-Control`, so it bypasses without the
+ *    expression having to enumerate USER_SPECIFIC_SEARCH_PARAMS.
+ *
+ * Not bypassed on purpose: the legacy numeric `/view/` URLs that 308 to their
+ * slug form. Caching that deterministic redirect is the point — see the comment
+ * on CLIMB_VIEW_PAGE_CACHE_TTL_SECONDS in list-page-cache.ts.
+ */
+export const WWW_HTML_CACHE_EXPRESSION =
+  `(http.host eq "${WWW_HOSTNAME}"` +
+  ` and (ends_with(http.request.uri.path, "${LIST_PAGE_PATH_SUFFIX}")` +
+  ` or http.request.uri.path contains "${CLIMB_VIEW_PATH_SEGMENT}")` +
+  ` and (${buildWwwHtmlCachePathPrefixes()
+    .map((pathPrefix) => `starts_with(http.request.uri.path, "${pathPrefix}")`)
+    .join(' or ')})` +
+  ` and not (http.cookie contains "${SESSION_COOKIE_NAME_SUBSTRING}")` +
+  ` and not (any(http.request.headers["${RSC_REQUEST_HEADER_NAME}"][*] != ""))` +
+  ` and not (http.request.uri.query contains "${RSC_QUERY_PARAM}"))`;
+
+/**
  * Search engines and social unfurlers that must never be blocked. Brave runs its
  * OWN index (not a Bing/Google reseller), so losing it loses real coverage — it is
  * listed explicitly rather than assumed.
@@ -535,6 +679,31 @@ export const desiredCloudflareState: CloudflareDesiredState = {
       action: 'set_cache_settings',
       action_parameters: {
         cache: true,
+        edge_ttl: { mode: 'bypass_by_default' },
+        browser_ttl: { mode: 'respect_origin' },
+      },
+      enabled: true,
+    },
+    // The www HTML pages the middleware already marks CDN-cacheable (#4652).
+    // Without this rule those headers are inert — Cloudflare caches by file
+    // extension by default, so a page route measured `cf-cache-status: DYNAMIC`
+    // while sending `s-maxage=86400`, and every crawler hit re-rendered at the
+    // single Railway replica. See WWW_HTML_CACHE_EXPRESSION for what each gate
+    // in the expression is holding back.
+    {
+      description: WWW_HTML_CACHE_RULE_DESCRIPTION,
+      expression: WWW_HTML_CACHE_EXPRESSION,
+      action: 'set_cache_settings',
+      action_parameters: {
+        cache: true,
+        // Load-bearing, and the reason the expression does not have to
+        // enumerate every dynamic case. Next overwrites `Cache-Control` with
+        // `private, no-cache, no-store` on these routes and the middleware adds
+        // `CDN-Cache-Control` alongside it, which Cloudflare ranks higher; a
+        // genuinely dynamic response (a user-specific filter, the sticky-locale
+        // 307) reaches the edge with NO CDN-Cache-Control and so bypasses on
+        // its own. `override_origin` would be the dangerous setting here: it
+        // ignores the origin AND strips Set-Cookie in order to cache.
         edge_ttl: { mode: 'bypass_by_default' },
         browser_ttl: { mode: 'respect_origin' },
       },

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -16,12 +16,21 @@ import {
   CRAWLER_ALLOW_TOKENS,
   CRAWLER_BLOCK_RULE_DESCRIPTION,
   CRAWLER_BLOCK_TOKENS,
+  CLIMB_VIEW_PATH_SEGMENT,
   CLIMB_VIEW_RATE_LIMIT_RULE_DESCRIPTION,
   DYNAMIC_REDIRECT_RULE_PHASE,
+  LIST_PAGE_PATH_SUFFIX,
   RATE_LIMIT_RULE_PHASE,
+  RSC_QUERY_PARAM,
+  RSC_REQUEST_HEADER_NAME,
+  SESSION_COOKIE_NAME_SUBSTRING,
   WWW_HOSTNAME,
+  WWW_HTML_CACHE_LOCALE_PREFIXES,
+  WWW_HTML_CACHE_ROOT_SEGMENTS,
+  WWW_HTML_CACHE_RULE_DESCRIPTION,
   WWW_RAILWAY_CNAME_TARGET,
   WS_HOSTNAME,
+  buildWwwHtmlCachePathPrefixes,
   desiredCloudflareState,
 } from '../infra/cloudflare/config';
 import type { DnsRecordDesired, FullyManagedDnsRecordDesired } from '../infra/cloudflare/config';
@@ -422,9 +431,15 @@ describe('buildPlan', () => {
     };
     const changes = buildPlan(desired, drifted, { allowZoneSsl: false });
     // Cutover-safe order: the proxied flip is planned last, after SSL + the rules.
-    // All three cache rules are missing (the phase holds only a foreign rule), and the
-    // WAF phase is already in sync, so it contributes nothing.
-    expect(changes.map((change) => change.resource)).toEqual(['ssl', 'cache-rule', 'cache-rule', 'cache-rule', 'dns']);
+    // EVERY cache rule is missing (the phase holds only a foreign rule), and the
+    // WAF phase is already in sync, so it contributes nothing. Derived from the
+    // declared rules rather than a literal count, so adding a cache rule does not
+    // silently narrow what this asserts about the ORDER.
+    expect(changes.map((change) => change.resource)).toEqual([
+      'ssl',
+      ...desired.cacheRules.map(() => 'cache-rule'),
+      'dns',
+    ]);
     // The SSL change is blocked without the opt-in flag, but still reported as drift.
     expect(changes.find((change) => change.resource === 'ssl')?.blocked).toBe(true);
     // And the proxied flip is held back while the required SSL change is blocked —
@@ -690,13 +705,14 @@ describe('www cost-control rules (#4650)', () => {
     expect(backendBoardRenderRule?.action_parameters.browser_ttl.mode).toBe('respect_origin');
   });
 
-  it('keeps all three cache rules separately addressable', () => {
+  it('keeps every cache rule separately addressable', () => {
     // Identity is the description marker; a duplicate would make the upsert treat
     // one rule as the other and silently drop it.
     expect(new Set(desired.cacheRules.map((rule) => rule.description)).size).toBe(desired.cacheRules.length);
     expect(CACHE_RULE_DESCRIPTION).not.toBe(BOARD_RENDER_CACHE_RULE_DESCRIPTION);
     expect(BACKEND_BOARD_RENDER_CACHE_RULE_DESCRIPTION).not.toBe(BOARD_RENDER_CACHE_RULE_DESCRIPTION);
     expect(BACKEND_BOARD_RENDER_CACHE_RULE_DESCRIPTION).not.toBe(CACHE_RULE_DESCRIPTION);
+    expect(WWW_HTML_CACHE_RULE_DESCRIPTION).not.toBe(BOARD_RENDER_CACHE_RULE_DESCRIPTION);
   });
 
   it('lowercases the user agent in every WAF expression', () => {
@@ -1396,5 +1412,187 @@ describe('the apply loop, driven end to end against a stubbed Cloudflare API', (
     expect(await runCloudflareApply([])).toBe(1);
 
     expect(requests.every((request) => request.method === 'GET')).toBe(true);
+  });
+});
+
+describe('www list + climb-view HTML cache rule (#4652)', () => {
+  const htmlCacheRule = desired.cacheRules.find((rule) => rule.description === WWW_HTML_CACHE_RULE_DESCRIPTION);
+  const expression = htmlCacheRule?.expression ?? '';
+
+  /** Pull a `['a', 'b']`-shaped literal out of a repo source file, so a drift guard reads the real list. */
+  function stringArrayLiteral(source: string, declaration: string): string[] {
+    const match = source.match(new RegExp(`${declaration} = \\[([\\s\\S]*?)\\]`));
+    if (!match) throw new Error(`Could not find "${declaration}" — the drift guard is reading the wrong file`);
+    return [...match[1].matchAll(/'([^']+)'/g)].map((quoted) => quoted[1]);
+  }
+
+  it('is declared, eligible for cache, and leaves both TTLs to the origin', () => {
+    // bypass_by_default is the whole safety model: Next overwrites Cache-Control
+    // with `private, no-cache, no-store` on these routes and the middleware adds
+    // CDN-Cache-Control alongside, which Cloudflare ranks higher — so a response
+    // the origin did NOT decorate (a user-specific filter, the sticky-locale
+    // 307) arrives with no cacheable directive and bypasses on its own.
+    // override_origin would be actively dangerous: it ignores the origin and
+    // strips Set-Cookie in order to cache.
+    expect(htmlCacheRule).toBeDefined();
+    expect(htmlCacheRule?.action).toBe('set_cache_settings');
+    expect(htmlCacheRule?.action_parameters.cache).toBe(true);
+    expect(htmlCacheRule?.action_parameters.edge_ttl.mode).toBe('bypass_by_default');
+    expect(htmlCacheRule?.action_parameters.browser_ttl.mode).toBe('respect_origin');
+    expect(htmlCacheRule?.enabled).toBe(true);
+  });
+
+  it('is scoped to www and to the two page shapes the middleware decorates', () => {
+    expect(expression).toContain(`http.host eq "${WWW_HOSTNAME}"`);
+    expect(expression).toContain(`ends_with(http.request.uri.path, "${LIST_PAGE_PATH_SUFFIX}")`);
+    expect(expression).toContain(`http.request.uri.path contains "${CLIMB_VIEW_PATH_SEGMENT}"`);
+    // Host-scoped, like every other rule here: ws serves /graphql, WebSocket
+    // upgrades and the og cards, none of which may become cache-eligible HTML.
+    expect(expression).not.toContain(WS_HOSTNAME);
+    expect(expression).not.toContain(ASSETS_HOSTNAME);
+  });
+
+  it('admits the real board page URLs and nothing else on www', () => {
+    const pathPrefixes = buildWwwHtmlCachePathPrefixes();
+    const admitted = (pathname: string) => pathPrefixes.some((pathPrefix) => pathname.startsWith(pathPrefix));
+
+    // Both trees, plus a locale twin of each — the four shapes getListPageCacheTTL
+    // and getClimbViewPageCacheTTL decorate.
+    expect(admitted('/kilter/homewall/7x10-full-ride/main_aux/40/list')).toBe(true);
+    expect(admitted('/b/some-gym-kilter/40/list')).toBe(true);
+    expect(admitted('/de/tension/8/25/15,17/40/view/abc-uuid')).toBe(true);
+    expect(admitted('/fr/b/some-gym-kilter/40/view/abc-uuid')).toBe(true);
+    // Everything else on www stays out of the rule even before the origin gets
+    // a say: a future route ending in /list must not inherit a 24h edge TTL
+    // just because it shares a suffix.
+    expect(admitted('/gyms/kilter/list')).toBe(false);
+    expect(admitted('/setter/marco')).toBe(false);
+    expect(admitted('/playlists/abc/list')).toBe(false);
+    expect(admitted('/api/v1/kilter/list')).toBe(false);
+  });
+
+  it('carries a prefix for every board tree root, in every locale prefix', () => {
+    // The middleware tests the first segment of the LOCALE-STRIPPED path against
+    // SUPPORTED_BOARDS; Cloudflare cannot strip a prefix, so the rule enumerates
+    // the cross product. A board or locale added upstream and not here costs the
+    // cache SILENTLY, which is exactly the failure this reads the real lists to
+    // catch.
+    const schemaBoards = stringArrayLiteral(
+      readFileSync('packages/shared-schema/src/types/board-config.ts', 'utf8'),
+      'export const SUPPORTED_BOARDS',
+    );
+    const i18nConfig = readFileSync('packages/shared/i18n/src/config.ts', 'utf8');
+    const supportedLocales = stringArrayLiteral(i18nConfig, 'export const SUPPORTED_LOCALES');
+    const defaultLocale = i18nConfig.match(/export const DEFAULT_LOCALE: Locale = '([^']+)'/)?.[1];
+
+    expect(schemaBoards.length).toBeGreaterThan(1);
+    expect(defaultLocale).toBeDefined();
+    // The default locale is served unprefixed, so it is the empty-string entry.
+    expect([...WWW_HTML_CACHE_LOCALE_PREFIXES]).toEqual([
+      '',
+      ...supportedLocales.filter((locale) => locale !== defaultLocale).map((locale) => `/${locale}`),
+    ]);
+    // `b` is the slug tree's root and has no board of its own.
+    expect([...WWW_HTML_CACHE_ROOT_SEGMENTS]).toEqual(['b', ...schemaBoards]);
+
+    for (const localePrefix of WWW_HTML_CACHE_LOCALE_PREFIXES) {
+      for (const rootSegment of ['b', ...schemaBoards]) {
+        expect(expression).toContain(`starts_with(http.request.uri.path, "${localePrefix}/${rootSegment}/")`);
+      }
+    }
+  });
+
+  it('bypasses a signed-in request on every session-cookie name variant', () => {
+    // The origin does NOT help here: a request carrying a session cookie was
+    // measured still getting `CDN-Cache-Control: s-maxage=86400`, so without
+    // this clause a signed-in response could populate the shared anonymous
+    // entry. Vary is no substitute — Cloudflare ignores it below Enterprise for
+    // everything except Accept-Encoding.
+    expect(expression).toContain(`not (http.cookie contains "${SESSION_COOKIE_NAME_SUBSTRING}")`);
+    // Spelled out as well as interpolated: a constant renamed to something that
+    // matches no real cookie would satisfy the interpolated form on its own.
+    expect(expression).toContain('not (http.cookie contains "next-auth.session-token")');
+
+    const secureCookies = readFileSync('packages/web/app/lib/auth/secure-cookies.ts', 'utf8');
+    const cookieNames = [
+      secureCookies.match(/export const SECURE_SESSION_COOKIE_NAME = '([^']+)'/)?.[1],
+      secureCookies.match(/export const PLAIN_SESSION_COOKIE_NAME = '([^']+)'/)?.[1],
+    ];
+    expect(cookieNames).toEqual(['__Secure-next-auth.session-token', 'next-auth.session-token']);
+    // One substring has to cover both names — the read path honours either
+    // (sessionCookieNameCandidates) — and the `<name>.0`, `<name>.1` chunks
+    // next-auth splits an oversized session into.
+    for (const cookieName of cookieNames) {
+      expect(cookieName).toContain(SESSION_COOKIE_NAME_SUBSTRING);
+      expect(`${cookieName}.0`).toContain(SESSION_COOKIE_NAME_SUBSTRING);
+    }
+  });
+
+  it('bypasses RSC requests on BOTH the header and the ?_rsc query', () => {
+    // The trap. `RSC: 1` on a list page returns a 307 to `?_rsc` carrying
+    // `CDN-Cache-Control: s-maxage=86400` and no Cache-Control, and Cloudflare
+    // ignores the response's `Vary: rsc, …` — so that redirect and the HTML
+    // document share one cache key. Cached, it bounces every browser off the
+    // canonical URL for a day.
+    expect(expression).toContain(`not (any(http.request.headers["${RSC_REQUEST_HEADER_NAME}"][*] != ""))`);
+    expect(expression).toContain(`not (http.request.uri.query contains "${RSC_QUERY_PARAM}")`);
+    // Same reason as the cookie clause: assert the literals, so a constant
+    // pointed at the wrong header or param cannot satisfy the interpolated form.
+    expect(expression).toContain('not (any(http.request.headers["rsc"][*] != ""))');
+    expect(expression).toContain('not (http.request.uri.query contains "_rsc")');
+    // Presence, not equality: `RSC: 1` is the only value Next acts on today
+    // (measured 2026-09-02 — `RSC: 2` and an empty `RSC:` both return the
+    // ordinary 200), and pinning to "1" would let a Next.js change reopen this.
+    expect(expression).not.toContain(`http.request.headers["${RSC_REQUEST_HEADER_NAME}"][*] == "1"`);
+  });
+
+  it('reads the RSC header through the map accessor, not the field the plan rejects', () => {
+    // `http.request.headers.names` is the field production rejected in the
+    // http_ratelimit phase: `not entitled: the use of field
+    // http.request.headers.names is not allowed, an higher Advanced Rate
+    // Limiting plan is required`. That entitlement is rate-limiting-specific
+    // (Advanced Rate Limiting), and Cloudflare lists Request Headers among the
+    // fields a CACHE rule may use — but there is no reason to reach for the one
+    // field with a known rejection when the documented map accessor does the job.
+    expect(expression).not.toContain('http.request.headers.names');
+    expect(expression).not.toContain('http.request.headers.values');
+  });
+
+  it('stays well inside the 4096-character ruleset expression limit', () => {
+    // Cloudflare caps a rule expression at 4096 characters and the locale ×
+    // board prefix set is a cross product, so it grows multiplicatively. Failing
+    // at 3072 leaves room to compact the prefix set deliberately (e.g. down to
+    // `contains "/{root}/"`) instead of discovering a 400 during a production
+    // apply.
+    expect(expression.length).toBeGreaterThan(0);
+    expect(expression.length).toBeLessThan(3072);
+  });
+
+  it('is planned as a create against a zone that only has the three older rules', () => {
+    const olderRules = matchingLiveRules(
+      desired.cacheRules.filter((rule) => rule.description !== WWW_HTML_CACHE_RULE_DESCRIPTION),
+    );
+
+    const changes = diffManagedRules(olderRules, desired.cacheRules, 'cache-rule');
+
+    expect(changes).toHaveLength(1);
+    expect(changes[0].summary).toContain(WWW_HTML_CACHE_RULE_DESCRIPTION);
+    expect(changes[0].summary).toContain('missing — will create');
+    expect(upsertCacheRule(olderRules, desired.cacheRules).changed).toBe(true);
+  });
+
+  it('keeps the og rule first, so the older fixtures still address it by index', () => {
+    expect(desired.cacheRules[0].description).toBe(CACHE_RULE_DESCRIPTION);
+    expect(desired.cacheRules.at(-1)?.description).toBe(WWW_HTML_CACHE_RULE_DESCRIPTION);
+  });
+
+  it('still has an origin that sets the header this rule exists to honour', () => {
+    // The rule is a no-op the moment the middleware stops emitting
+    // CDN-Cache-Control, and a no-op cache rule looks exactly like a working
+    // one from the outside.
+    const middleware = readFileSync('packages/web/middleware.ts', 'utf8');
+    expect(middleware).toContain("response.headers.set('CDN-Cache-Control', cdnCacheValue)");
+    expect(middleware).toContain('getListPageCacheTTL');
+    expect(middleware).toContain('getClimbViewPageCacheTTL');
   });
 });


### PR DESCRIPTION
## Summary

Adds a fourth managed Cloudflare cache rule so `www.boardsesh.com` HTML actually caches at the edge. Closes #4652.

The app has emitted `CDN-Cache-Control: s-maxage=86400, stale-while-revalidate=604800` on list and climb-view pages since before the migration, but Cloudflare has no cache rule for www HTML, so the header is inert — every one of those requests renders at a single Railway replica in `us-west2` against Postgres. Measured: `cf-cache-status: DYNAMIC` on every HTML URL.

#4652 said this had to be proven **before** the origin flip. It wasn't, so it is being proven now.

## The trap this PR exists to avoid

The origin sends `Vary: rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch, Accept-Encoding`. **Cloudflare honours `Vary` only for `Accept-Encoding` below Enterprise.** And the same URL requested with `RSC: 1` returns a **307 to `?_rsc` that itself carries `CDN-Cache-Control: s-maxage=86400` and no `Cache-Control`**.

So a naive cache rule stores that redirect under the HTML's cache key and serves it to real browsers for 24 hours — the "cacheable redirect pinned for a full day" hazard `list-page-cache.ts` already warns about from #4592. Anyone can send that header.

Mitigated by two clauses: the `RSC` request header via the map accessor `http.request.headers["rsc"]`, and `?_rsc` in the query. The header check bypasses on **any non-empty value**, not `== "1"` — measured that `RSC: 2` and an empty `RSC:` both return ordinary 200 HTML, so pinning to `1` would let a future Next change reopen the hole.

## The Free-plan question, answered by evidence rather than assumption

Request-header fields were rejected with a 400 for `http_ratelimit` rules on this plan (#4802), so the obvious worry was that this rule would be too. **Determination: a cache rule may reference request headers on Free.** Three independent lines:

1. Cloudflare's cache-rules docs list `Request Headers — http.request.headers` among the fields a cache rule may match on. The Enterprise gate on that page is on custom **cache keys** by header — a different feature.
2. Cloudflare's machine-readable field catalogue carries `plan_info_label` on 70 of 173 fields (`http.request.body.raw` → Enterprise, `http.request.cookies` → Pro or above). `http.request.headers` and `http.cookie` carry **none**.
3. The rejection this repo hit was product-scoped, not field-scoped: the error named *"an higher Advanced Rate Limiting plan"*, and header fields appear only in the Advanced Rate Limiting row of Cloudflare's per-plan table. That says nothing about `http_request_cache_settings`.

**Not proven against the live zone** — there are no Cloudflare credentials in this worktree and none were sought. But the failure mode is safe either way: if Cloudflare rejects it, the cache-phase PUT 400s, no rule is created, www HTML behaves exactly as today, and `deploy-cloudflare` goes red. The dangerous state — HTML cached *without* the RSC bypass — is not reachable from that failure, only from someone deleting the clause.

## Four things found while measuring

- **The session cookie is not one name.** The read path honours bare `next-auth.session-token` as well as `__Secure-`, and next-auth chunks an oversized session into `.0`, `.1`. One `contains` substring covers all of them; an equality test would have missed the chunks.
- **A signed-in request still receives the CDN header** (verified with a bogus session cookie) — the origin does not suppress it. So the cookie bypass is load-bearing, not belt-and-braces.
- **A second `Set-Cookie` surface:** every `/es|/fr|/de` list and climb-view page sets `boardsesh-locale` for non-crawlers. Under `bypass_by_default` Cloudflare will not cache a `Set-Cookie` response, so those entries get populated by *crawler* responses — meaning a human landing on a cached `/es` page no longer receives the sticky-locale cookie. Documented as a known behaviour change; impact is low because in-locale navigation is prefixed via `LocaleLink`.
- **The other three `Vary`'d headers need no clause.** Sent without `RSC`, each returns byte-identical anonymous HTML, and Next's router never sends them alone.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 3/5 — a wrong expression here serves the wrong body from the edge for 24 hours, and the CI token has no `Zone.Cache Purge` scope, so recovery is a manual dashboard purge.

Against that: 12 new tests and **18 mutations, each of which failed the suite and was restored** — including deleting the RSC clause, weakening it to `== "1"`, swapping the map accessor for `headers.names`, deleting the cookie clause, narrowing it to `__Secure-`-only, dropping a locale or a board from the prefix cross-product, adding a board to `board-config.ts` without updating the rule, and the middleware ceasing to emit `CDN-Cache-Control` at all.

`bypass_by_default` is doing the real work: a response with no cacheable directive never enters the edge, which is why a filtered list page (`?onlyDrafts=true`) bypasses without the expression enumerating `USER_SPECIFIC_SEARCH_PARAMS`.

**Post-merge verification is in `docs/cloudflare.md`.** Step 4 is the one that matters: `curl -H 'RSC: 1'` must return 307 + `BYPASS`, and the bare URL must still return 200 HTML afterwards. A 307 there means the rule is broken — purge everything from the dashboard, set `enabled: false`, re-apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVqNy32ChhSYgeEDn4SV63
