### PR TITLE
fix(mobile-screenshots): read Android's log from a stream, not the ring buffer

### DIFF
--- a/packages/mobile/.maestro/README.md
+++ b/packages/mobile/.maestro/README.md
@@ -120,8 +120,10 @@ on boot. They live only in screenshot-only builds; the separate prod-stripping o
   time the account follows a wall — which is how a MoonBoard ended up as the hero
   shot's wall.
 - **Capture integrity**: after Maestro finishes, the orchestrator reads the app's own
-  `[screenshot]` markers back out of the capture log (Metro's tee on iOS, `adb logcat`
-  on Android) and fails the run if the board was drawn in a mode the run didn't ask
+  `[screenshot]` markers back out of the capture log — Metro's tee on iOS, and on Android
+  a `adb logcat` stream opened before the app launches (a post-hoc `logcat -d` reads the
+  ring buffer as it stands, and a capture pushes ~64k lines through it, so the markers
+  had already rotated out) — and fails the run if the board was drawn in a mode the run didn't ask
   for — the Aura capability probe vetoes it silently on a binary too old to draw it —
   or if a board selector matched nothing and the shot fell back to a position.
   Neither failure looks wrong in the PNGs, and neither trips the byte-identical gate.

--- a/packages/mobile/.maestro/README.md
+++ b/packages/mobile/.maestro/README.md
@@ -121,7 +121,7 @@ on boot. They live only in screenshot-only builds; the separate prod-stripping o
   shot's wall.
 - **Capture integrity**: after Maestro finishes, the orchestrator reads the app's own
   `[screenshot]` markers back out of the capture log — Metro's tee on iOS, and on Android
-  a `adb logcat` stream opened before the app launches (a post-hoc `logcat -d` reads the
+  an `adb logcat` stream opened before the app launches (a post-hoc `logcat -d` reads the
   ring buffer as it stands, and a capture pushes ~64k lines through it, so the markers
   had already rotated out) — and fails the run if the board was drawn in a mode the run didn't ask
   for — the Aura capability probe vetoes it silently on a binary too old to draw it —

--- a/scripts/__tests__/mobile-screenshots.test.ts
+++ b/scripts/__tests__/mobile-screenshots.test.ts
@@ -14,6 +14,7 @@ import {
   findDuplicateScreenshotGroups,
   findScreenshotRenderProblems,
   iosSourceFlowFile,
+  screenshotLogcatState,
   summariseScreenshotRender,
   isIpadScreenshotDevice,
   metroDevClientUrl,
@@ -365,6 +366,27 @@ describe('findScreenshotRenderProblems', () => {
     const fallback = source.match(/EXPO_PUBLIC_SCREENSHOT_RENDER_MODE\?\.trim\(\) \|\| '([a-z]+)'/)?.[1];
     expect(fallback, 'screenshot-mode.ts must keep a literal render-mode fallback').toBeTruthy();
     expect(fallback).toBe(DEFAULT_SCREENSHOT_RENDER_MODE);
+  });
+});
+
+describe('screenshotLogcatState', () => {
+  const marker = '09-02 05:36:21.470 I/ReactNativeJS( 4026): [screenshot] render mode: aura (requested aura, probe ok)';
+
+  it('waits while the stream is alive and the app has not said anything yet', () => {
+    expect(screenshotLogcatState(null, '')).toBe('waiting');
+    expect(screenshotLogcatState(null, 'D/Noise( 1 ): booting')).toBe('waiting');
+  });
+
+  it('reads once the app has said what it drew', () => {
+    expect(screenshotLogcatState(null, marker)).toBe('ready');
+  });
+
+  it('still reads a log the reader finished writing — the capture is answerable either way', () => {
+    expect(screenshotLogcatState(0, marker)).toBe('ready');
+  });
+
+  it('calls out a reader that died with nothing to show, which is not a silent app', () => {
+    expect(screenshotLogcatState(1, 'D/Noise( 1 ): booting')).toBe('reader-died');
   });
 });
 

--- a/scripts/__tests__/mobile-screenshots.test.ts
+++ b/scripts/__tests__/mobile-screenshots.test.ts
@@ -338,6 +338,24 @@ describe('findScreenshotRenderProblems', () => {
     expect(summary[2]).toBe('[screenshot] render mode: aura (requested aura, probe ok)');
   });
 
+  // Regression: the Android gate first read `adb logcat -d`, which dumps the ring
+  // buffer as it stands. A capture pushes ~64k lines through it, so the app's own
+  // markers had rotated out by the time the gate looked and a correct capture
+  // failed with "the board never rendered". A streamed log keeps the early lines
+  // no matter how much noise follows them.
+  it('still finds the markers when the capture buried them under thousands of lines', () => {
+    const noise = Array.from({ length: 5000 }, (_, index) => `09-02 05:36:14.868 D/Noise( 4026): line ${index}`);
+    const log = [
+      '09-02 05:36:20.497 I/ReactNativeJS( 4026): [screenshot] board[0] "Marco\'s Board" -> "Marco\'s Board" (kilter L8 S25 @35°)',
+      '09-02 05:36:21.470 I/ReactNativeJS( 4026): [screenshot] render mode: aura (requested aura, probe ok)',
+      ...noise,
+    ].join('\n');
+
+    expect(findScreenshotRenderProblems(log, { renderMode: null, requireRenderLine: true })).toEqual([]);
+    // And the logcat timestamp/tag prefix is stripped off the provenance lines.
+    expect(summariseScreenshotRender(log)[1]).toBe('[screenshot] render mode: aura (requested aura, probe ok)');
+  });
+
   // The gate asserts the app asked for the run's mode, so this constant has to be
   // the same value screenshot-mode.ts falls back to. Read as text rather than
   // imported: that module is bundled for React Native and pulling it into a node

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -1074,7 +1074,15 @@ function captureIosDevice(
 function startLogcatStream(deviceId: string): ChildProcess {
   writeFileSync(LOGCAT_LOG_PATH, '');
   const logFile = openSync(LOGCAT_LOG_PATH, 'a');
-  const stream = spawn('adb', ['-s', deviceId, 'logcat'], { stdio: ['ignore', logFile, 'ignore'] });
+  let stream: ChildProcess;
+  try {
+    stream = spawn('adb', ['-s', deviceId, 'logcat'], { stdio: ['ignore', logFile, 'ignore'] });
+  } catch (error) {
+    // The exit handler below is what normally closes this; if the spawn never
+    // happened there is nothing to hang it on.
+    closeSync(logFile);
+    throw error;
+  }
   stream.on('exit', () => closeSync(logFile));
   // Named rather than swallowed: a stream that never started reads to the gate as
   // an app that never logged, and those have different fixes.
@@ -1144,7 +1152,7 @@ function readSettledLogcat(stream: ChildProcess): string | null {
   // missing from it — "no render mode line" says more than "timed out" — but say
   // out loud that we stopped waiting, so a genuinely slow emulator is
   // distinguishable from an app that never logged.
-  console.error(`${LOG} the capture log never showed a render-mode line after 15s; checking what did land.`);
+  console.error(`${LOG} the capture log never showed a render-mode line in 15 polls; checking what did land.`);
   return logcat;
 }
 

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -1100,15 +1100,6 @@ export function screenshotLogcatState(
   return 'waiting';
 }
 
-/**
- * The streamed device log, once the app's markers have actually landed in it.
- *
- * Waits for the marker rather than sleeping a fixed two seconds: `adb logcat`
- * buffers, and a slow emulator can trail the capture by more than a guess — a
- * gate that reads too early is the bug this whole file just fixed.
- *
- * Returns null when the stream died before recording anything.
- */
 /** Bytes written so far, or 0 if the stream has not created the file yet. */
 function logcatSize(): number {
   try {
@@ -1118,6 +1109,15 @@ function logcatSize(): number {
   }
 }
 
+/**
+ * The streamed device log, once the app's markers have actually landed in it.
+ *
+ * Waits for the marker rather than sleeping a fixed two seconds: `adb logcat`
+ * buffers, and a slow emulator can trail the capture by more than a guess — a
+ * gate that reads too early is the bug this whole file just fixed.
+ *
+ * Returns null when the stream died before recording anything.
+ */
 function readSettledLogcat(stream: ChildProcess): string | null {
   let lastSize = -1;
   let logcat = '';

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -1075,7 +1075,39 @@ function startLogcatStream(deviceId: string): ChildProcess {
   const logFile = openSync(LOGCAT_LOG_PATH, 'a');
   const stream = spawn('adb', ['-s', deviceId, 'logcat'], { stdio: ['ignore', logFile, 'ignore'] });
   stream.on('exit', () => closeSync(logFile));
+  // Named rather than swallowed: a stream that never started reads to the gate as
+  // an app that never logged, and those have different fixes.
+  stream.on('error', (error) => console.error(`${LOG} adb logcat stream failed to start: ${error.message}`));
   return stream;
+}
+
+/**
+ * The streamed device log, once the app's markers have actually landed in it.
+ *
+ * Waits for the marker rather than sleeping a fixed two seconds: `adb logcat`
+ * buffers, and a slow emulator can trail the capture by more than a guess. The
+ * distinction that matters on failure is "the app never logged it" (a real
+ * capture problem, which the gate then reports) versus "we read too early" (a
+ * gate problem, which is what a fixed sleep risks re-introducing).
+ *
+ * Returns null when the stream itself died — a dead reader looks exactly like a
+ * silent app to the gate, and the two need different fixes.
+ */
+function readSettledLogcat(stream: ChildProcess): string | null {
+  for (let attempt = 0; attempt < 15; attempt += 1) {
+    if (stream.exitCode !== null) {
+      console.error(
+        `${LOG} FAILED: the adb logcat stream exited (${stream.exitCode}) during the capture, so the app's markers were never recorded.`,
+      );
+      return null;
+    }
+    const logcat = existsSync(LOGCAT_LOG_PATH) ? readFileSync(LOGCAT_LOG_PATH, 'utf8') : '';
+    if (RENDER_MODE_LINE.test(logcat)) return logcat;
+    runCapture('sleep', ['1']);
+  }
+  // Out of patience: hand back whatever landed and let the gate say what is
+  // missing from it, which is a more useful message than "timed out".
+  return existsSync(LOGCAT_LOG_PATH) ? readFileSync(LOGCAT_LOG_PATH, 'utf8') : '';
 }
 
 function runAndroid(options: ScreenshotOptions): number {
@@ -1149,9 +1181,8 @@ function runAndroid(options: ScreenshotOptions): number {
       return maestroStatus;
     }
 
-    // Give the streamer a moment to flush the tail of the run before reading it.
-    runCapture('sleep', ['2']);
-    const logcat = existsSync(LOGCAT_LOG_PATH) ? readFileSync(LOGCAT_LOG_PATH, 'utf8') : '';
+    const logcat = readSettledLogcat(logcatStream);
+    if (logcat === null) return 1;
     if (!reportScreenshotRenderProblems(logcat, options, LOGCAT_LOG_PATH)) return 1;
 
     const duplicateGroups = findDuplicateScreenshotGroups(captureDir);

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -37,7 +37,18 @@
 
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  closeSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -53,6 +64,17 @@ const OUTPUT_ROOT = resolve(ROOT_DIR, 'app-stores');
 // "$screen /home" readiness marker — the JS console logs land in Metro's output,
 // not the device's unified log.
 export const METRO_LOG_PATH = join(tmpdir(), 'boardsesh-screenshot-metro.log');
+/**
+ * Android's answer to the Metro tee: the device log, streamed to a file for the
+ * whole capture.
+ *
+ * `adb logcat -d` after the fact is not equivalent and was the bug — it dumps the
+ * ring buffer as it stands, and a capture run pushes ~64k lines through a buffer
+ * that holds a fraction of that, so the app's own markers had already rotated out
+ * by the time the gate looked. A reader open from before the app launches sees
+ * every line regardless of how much follows it.
+ */
+export const LOGCAT_LOG_PATH = join(tmpdir(), 'boardsesh-screenshot-logcat.log');
 // Metro dev server port the dev-client loads its JS bundle from. Defaults to
 // 8081; override with BOARDSESH_METRO_PORT when it's taken (this repo runs a
 // Metro per worktree). The orchestrator passes the matching dev-client URL to
@@ -1040,6 +1062,22 @@ function captureIosDevice(
   return 0;
 }
 
+/**
+ * Stream the device log to `LOGCAT_LOG_PATH` until the returned process is killed.
+ *
+ * Started before Maestro launches the app, so the app's `[screenshot]` markers
+ * cannot rotate out from under the capture gate. Multiple readers on logcat are
+ * fine — the CI wrapper keeps its own stream for the debug artifact, and neither
+ * consumes the buffer.
+ */
+function startLogcatStream(deviceId: string): ChildProcess {
+  writeFileSync(LOGCAT_LOG_PATH, '');
+  const logFile = openSync(LOGCAT_LOG_PATH, 'a');
+  const stream = spawn('adb', ['-s', deviceId, 'logcat'], { stdio: ['ignore', logFile, 'ignore'] });
+  stream.on('exit', () => closeSync(logFile));
+  return stream;
+}
+
 function runAndroid(options: ScreenshotOptions): number {
   if (!commandExists('adb') || runCapture('adb', ['version']).status !== 0) {
     console.error(`${LOG} FAILED: Android platform tooling (adb) is not available.`);
@@ -1069,9 +1107,11 @@ function runAndroid(options: ScreenshotOptions): number {
   // so reruns against an already-installed, same-signature APK also start signed
   // out with no stale active board.
   runCapture('adb', ['-s', deviceId, 'shell', 'pm', 'clear', APP_ID]);
-  // The app's `[screenshot]` markers come back out of logcat below; drop anything
-  // an earlier run left in the ring buffer so the gate reads only this capture.
+  // Drop whatever an earlier run left in the ring buffer, then start streaming to
+  // a file BEFORE Maestro launches the app — see LOGCAT_LOG_PATH for why a
+  // post-hoc `logcat -d` loses the app's markers on a chatty run.
   runCapture('adb', ['-s', deviceId, 'logcat', '-c']);
+  const logcatStream = startLogcatStream(deviceId);
   applyCleanAndroidStatusBar(deviceId);
 
   const flowFile = flowFileForPlatform(options, 'android');
@@ -1109,8 +1149,10 @@ function runAndroid(options: ScreenshotOptions): number {
       return maestroStatus;
     }
 
-    const logcat = runCapture('adb', ['-s', deviceId, 'logcat', '-d']);
-    if (!reportScreenshotRenderProblems(logcat.stdout, options, `adb logcat on ${deviceId}`)) return 1;
+    // Give the streamer a moment to flush the tail of the run before reading it.
+    runCapture('sleep', ['2']);
+    const logcat = existsSync(LOGCAT_LOG_PATH) ? readFileSync(LOGCAT_LOG_PATH, 'utf8') : '';
+    if (!reportScreenshotRenderProblems(logcat, options, LOGCAT_LOG_PATH)) return 1;
 
     const duplicateGroups = findDuplicateScreenshotGroups(captureDir);
     if (duplicateGroups.length > 0) {
@@ -1132,6 +1174,7 @@ function runAndroid(options: ScreenshotOptions): number {
     );
     for (const file of saved) console.log(`${LOG}   ${file}`);
   } finally {
+    logcatStream.kill();
     clearAndroidStatusBar(deviceId);
     rmSync(captureDir, { force: true, recursive: true });
     if (options.shutdown && deviceId.startsWith('emulator-')) {

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -47,6 +47,7 @@ import {
   readdirSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -1082,32 +1083,57 @@ function startLogcatStream(deviceId: string): ChildProcess {
 }
 
 /**
+ * Whether the streamed device log is worth reading yet.
+ *
+ * `ready` wins over `reader-died` on purpose: once the app has logged what it
+ * drew, the capture is answerable, and it does not matter that the reader exited
+ * afterwards. Only a stream that died with nothing to show for it is a problem,
+ * and it is a different problem from an app that stayed silent — one is a broken
+ * reader, the other a broken capture.
+ */
+export function screenshotLogcatState(
+  streamExitCode: number | null,
+  logText: string,
+): 'ready' | 'reader-died' | 'waiting' {
+  if (RENDER_MODE_LINE.test(logText)) return 'ready';
+  if (streamExitCode !== null) return 'reader-died';
+  return 'waiting';
+}
+
+/**
  * The streamed device log, once the app's markers have actually landed in it.
  *
  * Waits for the marker rather than sleeping a fixed two seconds: `adb logcat`
- * buffers, and a slow emulator can trail the capture by more than a guess. The
- * distinction that matters on failure is "the app never logged it" (a real
- * capture problem, which the gate then reports) versus "we read too early" (a
- * gate problem, which is what a fixed sleep risks re-introducing).
+ * buffers, and a slow emulator can trail the capture by more than a guess — a
+ * gate that reads too early is the bug this whole file just fixed.
  *
- * Returns null when the stream itself died — a dead reader looks exactly like a
- * silent app to the gate, and the two need different fixes.
+ * Returns null when the stream died before recording anything.
  */
 function readSettledLogcat(stream: ChildProcess): string | null {
+  let lastSize = -1;
+  let logcat = '';
   for (let attempt = 0; attempt < 15; attempt += 1) {
-    if (stream.exitCode !== null) {
+    // A real capture writes ~9MB here; re-reading all of it 15 times to answer
+    // one boolean is 130MB of pointless I/O, so only re-read once adb has
+    // actually appended something.
+    const size = existsSync(LOGCAT_LOG_PATH) ? statSync(LOGCAT_LOG_PATH).size : 0;
+    if (size !== lastSize) {
+      lastSize = size;
+      logcat = size > 0 ? readFileSync(LOGCAT_LOG_PATH, 'utf8') : '';
+    }
+    const state = screenshotLogcatState(stream.exitCode, logcat);
+    if (state === 'ready') return logcat;
+    if (state === 'reader-died') {
       console.error(
-        `${LOG} FAILED: the adb logcat stream exited (${stream.exitCode}) during the capture, so the app's markers were never recorded.`,
+        `${LOG} FAILED: the adb logcat stream exited (${stream.exitCode}) before the app logged anything, so this run has no capture log to check.`,
       );
       return null;
     }
-    const logcat = existsSync(LOGCAT_LOG_PATH) ? readFileSync(LOGCAT_LOG_PATH, 'utf8') : '';
-    if (RENDER_MODE_LINE.test(logcat)) return logcat;
     runCapture('sleep', ['1']);
   }
-  // Out of patience: hand back whatever landed and let the gate say what is
-  // missing from it, which is a more useful message than "timed out".
-  return existsSync(LOGCAT_LOG_PATH) ? readFileSync(LOGCAT_LOG_PATH, 'utf8') : '';
+  // Out of patience: hand back whatever landed and let the gate name what is
+  // missing from it, which is more useful than "timed out".
+  return logcat;
 }
 
 function runAndroid(options: ScreenshotOptions): number {

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -1109,6 +1109,15 @@ export function screenshotLogcatState(
  *
  * Returns null when the stream died before recording anything.
  */
+/** Bytes written so far, or 0 if the stream has not created the file yet. */
+function logcatSize(): number {
+  try {
+    return statSync(LOGCAT_LOG_PATH).size;
+  } catch {
+    return 0;
+  }
+}
+
 function readSettledLogcat(stream: ChildProcess): string | null {
   let lastSize = -1;
   let logcat = '';
@@ -1116,7 +1125,7 @@ function readSettledLogcat(stream: ChildProcess): string | null {
     // A real capture writes ~9MB here; re-reading all of it 15 times to answer
     // one boolean is 130MB of pointless I/O, so only re-read once adb has
     // actually appended something.
-    const size = existsSync(LOGCAT_LOG_PATH) ? statSync(LOGCAT_LOG_PATH).size : 0;
+    const size = logcatSize();
     if (size !== lastSize) {
       lastSize = size;
       logcat = size > 0 ? readFileSync(LOGCAT_LOG_PATH, 'utf8') : '';
@@ -1131,8 +1140,11 @@ function readSettledLogcat(stream: ChildProcess): string | null {
     }
     runCapture('sleep', ['1']);
   }
-  // Out of patience: hand back whatever landed and let the gate name what is
-  // missing from it, which is more useful than "timed out".
+  // Out of patience. Hand back whatever landed and let the gate name what is
+  // missing from it — "no render mode line" says more than "timed out" — but say
+  // out loud that we stopped waiting, so a genuinely slow emulator is
+  // distinguishable from an app that never logged.
+  console.error(`${LOG} the capture log never showed a render-mode line after 15s; checking what did land.`);
   return logcat;
 }
 


### PR DESCRIPTION
## Summary

The first gated Android capture (run 33593455251) failed with `no "[screenshot] render mode:" line in the capture log — the board never rendered`, on a capture that had rendered perfectly. The debug artifact's logcat has the markers right there:

```
I/ReactNativeJS( 4026): [screenshot] board[0] "Marco's Board" -> "Marco's Board" (kilter L8 S25 @35°)
I/ReactNativeJS( 4026): [screenshot] render mode: aura (requested aura, probe ok)
```

The gate read `adb logcat -d`, which dumps the ring buffer as it stands. That run pushed 64,110 lines through a buffer that holds a fraction of it, so the app's markers — written at 05:36:20, read at 05:37:51 — had rotated out well before anything looked for them. A gate that reds a good capture is worse than no gate: it teaches people to rerun until it passes, which is exactly the habit that let a MoonBoard reach the store listing.

An `adb logcat` stream now opens before Maestro launches the app and writes to a file for the whole run, mirroring the Metro tee iOS already had. Multiple readers on logcat are fine and neither consumes the buffer, so the CI wrapper keeps its own stream for the debug artifact.

Regression test feeds the gate a log with the markers buried under 5,000 later lines, and pins that the logcat timestamp/tag prefix is still stripped off the provenance lines.

Found by running the Android capture-only leg after #5059; the iOS half was unaffected (it reads Metro's tee, which is a file from the start).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 1/5 — capture tooling only. No app code, no shipped bundle, no listing writes.
