### PR TITLE
fix(mobile-screenshots): treat a truncated Android capture log as a failure

### DIFF
--- a/scripts/__tests__/mobile-screenshots.test.ts
+++ b/scripts/__tests__/mobile-screenshots.test.ts
@@ -381,8 +381,13 @@ describe('screenshotLogcatState', () => {
     expect(screenshotLogcatState(null, marker)).toBe('ready');
   });
 
-  it('still reads a log the reader finished writing — the capture is answerable either way', () => {
-    expect(screenshotLogcatState(0, marker)).toBe('ready');
+  // The marker is not the last thing the app logs: a board selector that missed
+  // warns when the shot needing it opens, which on a two-wall flow is long after
+  // the first render. A reader that died mid-capture truncated the log, and this
+  // runs before anything kills the stream, so any exit here is unexpected.
+  it('rejects a log the reader stopped writing, even with the render marker in it', () => {
+    expect(screenshotLogcatState(0, marker)).toBe('reader-died');
+    expect(screenshotLogcatState(1, marker)).toBe('reader-died');
   });
 
   it('calls out a reader that died with nothing to show, which is not a silent app', () => {

--- a/scripts/__tests__/mobile-screenshots.test.ts
+++ b/scripts/__tests__/mobile-screenshots.test.ts
@@ -373,25 +373,24 @@ describe('screenshotLogcatState', () => {
   const marker = '09-02 05:36:21.470 I/ReactNativeJS( 4026): [screenshot] render mode: aura (requested aura, probe ok)';
 
   it('waits while the stream is alive and the app has not said anything yet', () => {
-    expect(screenshotLogcatState(null, '')).toBe('waiting');
-    expect(screenshotLogcatState(null, 'D/Noise( 1 ): booting')).toBe('waiting');
+    expect(screenshotLogcatState(true, '')).toBe('waiting');
+    expect(screenshotLogcatState(true, 'D/Noise( 1 ): booting')).toBe('waiting');
   });
 
   it('reads once the app has said what it drew', () => {
-    expect(screenshotLogcatState(null, marker)).toBe('ready');
+    expect(screenshotLogcatState(true, marker)).toBe('ready');
   });
 
   // The marker is not the last thing the app logs: a board selector that missed
   // warns when the shot needing it opens, which on a two-wall flow is long after
-  // the first render. A reader that died mid-capture truncated the log, and this
-  // runs before anything kills the stream, so any exit here is unexpected.
+  // the first render. A reader that stopped mid-capture truncated the log, and
+  // this runs before anything kills the stream, so that is always unexpected.
   it('rejects a log the reader stopped writing, even with the render marker in it', () => {
-    expect(screenshotLogcatState(0, marker)).toBe('reader-died');
-    expect(screenshotLogcatState(1, marker)).toBe('reader-died');
+    expect(screenshotLogcatState(false, marker)).toBe('reader-died');
   });
 
-  it('calls out a reader that died with nothing to show, which is not a silent app', () => {
-    expect(screenshotLogcatState(1, 'D/Noise( 1 ): booting')).toBe('reader-died');
+  it('calls out a reader that stopped with nothing to show, which is not a silent app', () => {
+    expect(screenshotLogcatState(false, 'D/Noise( 1 ): booting')).toBe('reader-died');
   });
 });
 

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -1094,7 +1094,7 @@ function startLogcatStream(deviceId: string): ChildProcess {
  * Whether the streamed device log is worth reading yet.
  *
  * A dead reader beats a present marker. This runs after Maestro has finished and
- * before anything kills the stream, so an exit code here is always unexpected —
+ * before anything kills the stream, so a stopped reader is always unexpected —
  * and the marker is not the last thing the app logs. A board selector that missed
  * warns whenever the shot that needs it opens, which on a two-wall flow is long
  * after the first render. Accepting a truncated log because the render line
@@ -1103,13 +1103,26 @@ function startLogcatStream(deviceId: string): ChildProcess {
  * `reader-died` and `waiting` are separate because they need different fixes: one
  * is a broken reader, the other an app that has not spoken yet.
  */
-export function screenshotLogcatState(
-  streamExitCode: number | null,
-  logText: string,
-): 'ready' | 'reader-died' | 'waiting' {
-  if (streamExitCode !== null) return 'reader-died';
+export function screenshotLogcatState(streamAlive: boolean, logText: string): 'ready' | 'reader-died' | 'waiting' {
+  if (!streamAlive) return 'reader-died';
   if (RENDER_MODE_LINE.test(logText)) return 'ready';
   return 'waiting';
+}
+
+/**
+ * Whether the log stream is still writing, asked of the OS rather than of Node.
+ *
+ * `ChildProcess.exitCode` is populated when the event loop delivers the child's
+ * exit, and this orchestrator is spawnSync from end to end — the loop never turns
+ * between starting the stream and reading it, so `exitCode` reads `null` however
+ * long ago adb died. `ps` has no such blind spot. An empty result is a process
+ * that is gone; `Z` is one that exited and is still waiting to be reaped by an
+ * event loop that will not run until the capture is over.
+ */
+function logcatStreamAlive(pid: number | undefined): boolean {
+  if (pid === undefined) return false;
+  const state = runCapture('ps', ['-o', 'stat=', '-p', String(pid)]).stdout.trim();
+  return state.length > 0 && !state.startsWith('Z');
 }
 
 /** Bytes written so far, or 0 if the stream has not created the file yet. */
@@ -1142,11 +1155,11 @@ function readSettledLogcat(stream: ChildProcess): string | null {
       lastSize = size;
       logcat = size > 0 ? readFileSync(LOGCAT_LOG_PATH, 'utf8') : '';
     }
-    const state = screenshotLogcatState(stream.exitCode, logcat);
+    const state = screenshotLogcatState(logcatStreamAlive(stream.pid), logcat);
     if (state === 'ready') return logcat;
     if (state === 'reader-died') {
       console.error(
-        `${LOG} FAILED: the adb logcat stream exited (${stream.exitCode}) during the capture, so the log is truncated and anything the app logged after that point is missing.`,
+        `${LOG} FAILED: the adb logcat stream is no longer running, so the log is truncated and anything the app logged after it died is missing.`,
       );
       return null;
     }

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -1093,18 +1093,22 @@ function startLogcatStream(deviceId: string): ChildProcess {
 /**
  * Whether the streamed device log is worth reading yet.
  *
- * `ready` wins over `reader-died` on purpose: once the app has logged what it
- * drew, the capture is answerable, and it does not matter that the reader exited
- * afterwards. Only a stream that died with nothing to show for it is a problem,
- * and it is a different problem from an app that stayed silent — one is a broken
- * reader, the other a broken capture.
+ * A dead reader beats a present marker. This runs after Maestro has finished and
+ * before anything kills the stream, so an exit code here is always unexpected —
+ * and the marker is not the last thing the app logs. A board selector that missed
+ * warns whenever the shot that needs it opens, which on a two-wall flow is long
+ * after the first render. Accepting a truncated log because the render line
+ * happened to land in it is exactly how a fallback wall reaches the store.
+ *
+ * `reader-died` and `waiting` are separate because they need different fixes: one
+ * is a broken reader, the other an app that has not spoken yet.
  */
 export function screenshotLogcatState(
   streamExitCode: number | null,
   logText: string,
 ): 'ready' | 'reader-died' | 'waiting' {
-  if (RENDER_MODE_LINE.test(logText)) return 'ready';
   if (streamExitCode !== null) return 'reader-died';
+  if (RENDER_MODE_LINE.test(logText)) return 'ready';
   return 'waiting';
 }
 
@@ -1142,7 +1146,7 @@ function readSettledLogcat(stream: ChildProcess): string | null {
     if (state === 'ready') return logcat;
     if (state === 'reader-died') {
       console.error(
-        `${LOG} FAILED: the adb logcat stream exited (${stream.exitCode}) before the app logged anything, so this run has no capture log to check.`,
+        `${LOG} FAILED: the adb logcat stream exited (${stream.exitCode}) during the capture, so the log is truncated and anything the app logged after that point is missing.`,
       );
       return null;
     }


### PR DESCRIPTION
## Summary

Follow-up to #5080, which merged before this landed. Codex flagged it there as a P1 and it is right.

`screenshotLogcatState` let a present render marker outrank a dead reader:

```ts
if (RENDER_MODE_LINE.test(logText)) return 'ready';
if (streamExitCode !== null) return 'reader-died';
```

My reasoning was "once the app has logged what it drew, the capture is answerable". That is wrong, because the render marker is not the last thing the app logs. `resolveScreenshotBoard` warns when the shot that needs a selector opens — on a two-wall flow that is long after the first render — so an `adb logcat` stream that died in between leaves a log that reads clean and is missing the failure. Accepting it is precisely how a fallback wall reaches the store, which is the thing this gate exists to prevent.

`readSettledLogcat` runs after Maestro has finished and before anything kills the stream, so an exit code observed there is always unexpected. A truncated log now fails the capture regardless of what did land in it, and the error says the log is truncated rather than implying the app stayed silent.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 1/5 — capture tooling only. Strictly more conservative than before: it can fail a capture it used to pass, never the reverse.
