### PR TITLE
feat(mobile-screenshots): lead the store listings with the lit board

### DIFF
--- a/app-stores/apple/app-store-metadata.md
+++ b/app-stores/apple/app-store-metadata.md
@@ -62,16 +62,20 @@ Generated iPhone portrait and iPad landscape screenshots, captured + uploaded by
 `packages/mobile/.maestro/README.md`). Ten slots, in store display order (the
 filename prefix sets the order):
 
-1. `00-home` — the global "Everyone" activity feed
-2. `01-climbs` — browse the board's climbs, on Marco's Kilter board
-3. `02-board-view` — a climb with the holds lit on Marco's Kilter board (the signature view)
-4. `03-board-view-2` — a climb lit on a gym Tension board, showing multi-board support
+1. `00-board-view` — a climb with the holds lit on Marco's Kilter board (the signature view)
+2. `01-board-view-2` — a climb lit on a gym Tension board, showing multi-board support
+3. `02-home` — the global "Everyone" activity feed
+4. `03-climbs` — browse the board's climbs, on Marco's Kilter board
 5. `04-session-detail` — a session recap: stats, leaderboard, sends
 6. `05-workout-generator` — the Record tab's workout generator
 7. `06-discover` — the playlist library
 8. `07-playlist-detail` — a smart playlist (crowd favourites)
 9. `08-logbook` — your logged sends and progression
 10. `09-profile` — your stats and progression
+
+The lit board leads. It is the thing nothing else does, and the first shot is the
+only one most people see — the feed and the climb list read like any app's until
+you already know what the board is for.
 
 Apple allows up to 10; the current generated set uploads 10 screenshots. Google Play caps phones at 8, so its set drops playlist detail and logbook (see the Play metadata).
 

--- a/app-stores/google/play-store-metadata.md
+++ b/app-stores/google/play-store-metadata.md
@@ -78,14 +78,17 @@ data) and auto-committing would churn the live listing daily.
 
 **Screens to capture** (8 = the Play Store phone max; captured by `vp run mobile:screenshots --platform android`, in store display order):
 
-1. `00-home` — activity feed, your crew's sessions
-2. `01-climbs` — browse the board's climbs, on Marco's Kilter board
-3. `02-board-view` — a climb with the holds lit on Marco's Kilter board (the signature view)
+1. `00-board-view` — a climb with the holds lit on Marco's Kilter board (the signature view)
+2. `01-home` — activity feed, your crew's sessions
+3. `02-climbs` — browse the board's climbs, on Marco's Kilter board
 4. `03-discover` — the playlist library
 5. `04-workout-generator` — the Record tab's workout generator
 6. `05-profile` — your stats and progression
 7. `06-board-sheet` — the board switcher
 8. `07-session-detail` — a session recap: stats, leaderboard, sends
+
+The lit board leads here too, matching the App Store set — Play has no second
+board-view slot, so the Tension wall stays an App Store-only shot.
 
 (Party Mode, playlist detail, and the logbook are on the iOS 10-shot set but don't fit Android's 8-shot cap.)
 

--- a/packages/mobile/.maestro/README.md
+++ b/packages/mobile/.maestro/README.md
@@ -48,8 +48,9 @@ before running Maestro (replacing the old `login.yaml` readiness gate), so each 
 directly into its shots — no Maestro element races a transient auth screen.
 
 - `app-store.yaml` (iOS) — capture Home, Discover, Profile, Logbook, session detail,
-  Climbs, the workout generator, playlist detail, and the board view (10 store slots; the
-  `03` live-party slot is filled by the party flow, PR2).
+  Climbs, the workout generator, playlist detail, and the board view (10 store slots).
+  The board shots are numbered `00`/`01` so the listing leads with them, but they are
+  captured LAST — the play drawer they open overlays anything shot after it.
 - `app-store-android.yaml` — the eight Play Store shots: Home, Discover, Profile,
   session detail, Climbs, the workout generator, board view, and the board sheet.
 - `onboarding.yaml` / `onboarding-android.yaml` — capture app screens for

--- a/packages/mobile/.maestro/README.md
+++ b/packages/mobile/.maestro/README.md
@@ -48,9 +48,9 @@ before running Maestro (replacing the old `login.yaml` readiness gate), so each 
 directly into its shots — no Maestro element races a transient auth screen.
 
 - `app-store.yaml` (iOS) — capture Home, Discover, Profile, Logbook, session detail,
-  Climbs, the workout generator, playlist detail, and the board view (10 store slots).
-  The board shots are numbered `00`/`01` so the listing leads with them, but they are
-  captured LAST — the play drawer they open overlays anything shot after it.
+  Climbs, the workout generator, playlist detail, and the two board views (10 store
+  slots). The board shots are numbered `00`/`01` so the listing leads with them, but
+  they are captured LAST — the play drawer they open overlays anything shot after it.
 - `app-store-android.yaml` — the eight Play Store shots: Home, Discover, Profile,
   session detail, Climbs, the workout generator, board view, and the board sheet.
 - `onboarding.yaml` / `onboarding-android.yaml` — capture app screens for

--- a/packages/mobile/.maestro/app-store-android.yaml
+++ b/packages/mobile/.maestro/app-store-android.yaml
@@ -42,7 +42,7 @@ name: app-store screenshots android
     timeout: 90000
 - waitForAnimationToEnd:
     timeout: 30000
-- takeScreenshot: 00-home
+- takeScreenshot: 01-home
 
 # Discover — playlist library ("For You" smart playlists + saved/community playlists).
 - openLink: com.boardsesh.app://discover
@@ -76,7 +76,7 @@ name: app-store screenshots android
     timeout: 60000
 - waitForAnimationToEnd:
     timeout: 30000
-- takeScreenshot: 01-climbs
+- takeScreenshot: 02-climbs
 
 # Workout generator — the Record screen with a workout pre-selected.
 - openLink: com.boardsesh.app://record
@@ -109,7 +109,7 @@ name: app-store screenshots android
     timeout: 60000
 - waitForAnimationToEnd:
     timeout: 30000
-- takeScreenshot: 02-board-view
+- takeScreenshot: 00-board-view
 
 # Board sheet — relaunch first so the play drawer from the board-view shot is gone, then
 # open the board-presence sheet deterministically via the screenshot-mode param (no fragile

--- a/packages/mobile/.maestro/app-store.yaml
+++ b/packages/mobile/.maestro/app-store.yaml
@@ -42,9 +42,9 @@ name: app-store screenshots
 #   shots no longer depend on an in-flow board-pick step.)
 # - The Record/session screen renders the WORKOUT GENERATOR because Metro bundles
 #   EXPO_PUBLIC_SCREENSHOT_WORKOUT (default volume).
-# - Filenames are numbered for store DISPLAY order (00..09), not capture order. Slot 03 is
-#   the second board-view (SCREENSHOT_BOARDS[1]); it was reserved for a party shot the flow
-#   never took.
+# - Filenames are numbered for store DISPLAY order (00..09), not capture order, and the two
+#   diverge hard here: the listing leads with the board (00, 01) while the flow captures it
+#   LAST, because the play drawer it opens overlays everything shot after it.
 #
 # The screenshot build auto-signs-in on boot and lands straight on home (no login screen);
 # the orchestrator waits for home (the `$screen /home` log) before running Maestro, so the
@@ -86,7 +86,7 @@ name: app-store screenshots
 # Home — the global "Everyone" feed. The home screen defaults to it in screenshot
 # mode (see home/index.tsx) for a livelier hero than the test user's own crew.
 - waitForAnimationToEnd
-- takeScreenshot: 00-home
+- takeScreenshot: 02-home
 
 # Discover — the playlist library (smart "Your Picks" + saved playlists). The dialog was
 # primed away above, so this navigates cleanly; the optional tap is just a backup.
@@ -136,7 +136,7 @@ name: app-store screenshots
     text: 'Open'
     optional: true
 - waitForAnimationToEnd
-- takeScreenshot: 01-climbs
+- takeScreenshot: 03-climbs
 
 # Workout generator — the Record screen with a workout pre-selected (volume): target
 # grade, warm-up, set config + the generated preview queue.
@@ -171,7 +171,7 @@ name: app-store screenshots
     optional: true
 - waitForAnimationToEnd
 - waitForAnimationToEnd
-- takeScreenshot: 02-board-view
+- takeScreenshot: 00-board-view
 
 # Board view on the second pinned wall (SCREENSHOT_BOARDS[1], the Tension Board 2) — a
 # second wall lit up, so the listing shows Boardsesh works across boards.
@@ -184,4 +184,4 @@ name: app-store screenshots
     optional: true
 - waitForAnimationToEnd
 - waitForAnimationToEnd
-- takeScreenshot: 03-board-view-2
+- takeScreenshot: 01-board-view-2

--- a/scripts/__tests__/mobile-screenshots.test.ts
+++ b/scripts/__tests__/mobile-screenshots.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 // workspace package names (same as mobile-locales-parity.test.ts).
 import { SUPPORTED_LOCALES } from '../../packages/shared/i18n/src/config';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -15,6 +15,7 @@ import {
   findScreenshotRenderProblems,
   iosSourceFlowFile,
   summariseScreenshotRender,
+  writeCapturedScreenshots,
   isIpadScreenshotDevice,
   metroDevClientUrl,
   parseArgs,
@@ -395,6 +396,46 @@ describe('findDuplicateScreenshotGroups', () => {
       expect(findDuplicateScreenshotGroups(captureDir)).toEqual([]);
     } finally {
       rmSync(captureDir, { force: true, recursive: true });
+    }
+  });
+});
+
+describe('writeCapturedScreenshots', () => {
+  it('replaces the folder rather than merging into it', () => {
+    const captureDir = mkdtempSync(join(tmpdir(), 'capture-'));
+    const outputDir = mkdtempSync(join(tmpdir(), 'store-'));
+    try {
+      // Renumbering a slot renames its file, so the previous set's names are not
+      // a subset of the new one's. Merging would upload both, in an order nobody
+      // chose, and hand Play more phone shots than it accepts.
+      writeFileSync(join(outputDir, '00-home.png'), 'stale');
+      writeFileSync(join(outputDir, '01-climbs.png'), 'stale');
+      writeFileSync(join(outputDir, 'notes.txt'), 'keep me');
+      writeFileSync(join(captureDir, '00-board-view.png'), 'fresh');
+      writeFileSync(join(captureDir, '01-home.png'), 'fresh');
+
+      const saved = writeCapturedScreenshots(captureDir, outputDir);
+
+      expect(readdirSync(outputDir).sort()).toEqual(['00-board-view.png', '01-home.png', 'notes.txt']);
+      expect(saved).toHaveLength(2);
+    } finally {
+      rmSync(captureDir, { force: true, recursive: true });
+      rmSync(outputDir, { force: true, recursive: true });
+    }
+  });
+
+  it('creates the folder on a first capture', () => {
+    const captureDir = mkdtempSync(join(tmpdir(), 'capture-'));
+    const parent = mkdtempSync(join(tmpdir(), 'store-'));
+    const outputDir = join(parent, 'de-DE', 'iphone-16-pro-max');
+    try {
+      writeFileSync(join(captureDir, '00-board-view.png'), 'fresh');
+
+      expect(writeCapturedScreenshots(captureDir, outputDir)).toHaveLength(1);
+      expect(readdirSync(outputDir)).toEqual(['00-board-view.png']);
+    } finally {
+      rmSync(captureDir, { force: true, recursive: true });
+      rmSync(parent, { force: true, recursive: true });
     }
   });
 });

--- a/scripts/__tests__/mobile-screenshots.test.ts
+++ b/scripts/__tests__/mobile-screenshots.test.ts
@@ -424,6 +424,24 @@ describe('writeCapturedScreenshots', () => {
     }
   });
 
+  it('leaves the live set alone when the capture produced nothing', () => {
+    const captureDir = mkdtempSync(join(tmpdir(), 'capture-'));
+    const outputDir = mkdtempSync(join(tmpdir(), 'store-'));
+    try {
+      writeFileSync(join(outputDir, '00-board-view.png'), 'live');
+
+      // The caller fails the run on the empty result. It must not ALSO have wiped
+      // the folder on the way there — the Play set is committed to git, and a
+      // capture that produced nothing should not stage the deletion of the shots
+      // currently on the listing.
+      expect(writeCapturedScreenshots(captureDir, outputDir)).toEqual([]);
+      expect(readdirSync(outputDir)).toEqual(['00-board-view.png']);
+    } finally {
+      rmSync(captureDir, { force: true, recursive: true });
+      rmSync(outputDir, { force: true, recursive: true });
+    }
+  });
+
   it('creates the folder on a first capture', () => {
     const captureDir = mkdtempSync(join(tmpdir(), 'capture-'));
     const parent = mkdtempSync(join(tmpdir(), 'store-'));

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -756,6 +756,11 @@ function reportScreenshotRenderProblems(logText: string, options: ScreenshotOpti
  */
 export function writeCapturedScreenshots(captureDir: string, outputDir: string): string[] {
   const pngs = readdirSync(captureDir).filter((file) => file.toLowerCase().endsWith('.png'));
+  // Nothing to replace the old set with, so leave it alone. The caller fails the
+  // run on an empty result either way, and the Play folder is committed to git —
+  // a capture that produced nothing should not also stage the deletion of the
+  // set that is currently live.
+  if (pngs.length === 0) return [];
   mkdirSync(outputDir, { recursive: true });
   for (const existingFile of readdirSync(outputDir)) {
     if (existingFile.toLowerCase().endsWith('.png')) {

--- a/scripts/mobile-screenshots.ts
+++ b/scripts/mobile-screenshots.ts
@@ -746,44 +746,45 @@ function reportScreenshotRenderProblems(logText: string, options: ScreenshotOpti
   return false;
 }
 
+/**
+ * Replace a store folder's PNGs with the ones this capture produced.
+ *
+ * Replace, not merge: the numeric prefix is display order, so renumbering a slot
+ * renames its file and a copy-over would leave the old name sitting next to the
+ * new one. Both then upload, in an order nobody chose, and Play would be handed
+ * more phone shots than it accepts.
+ */
+export function writeCapturedScreenshots(captureDir: string, outputDir: string): string[] {
+  const pngs = readdirSync(captureDir).filter((file) => file.toLowerCase().endsWith('.png'));
+  mkdirSync(outputDir, { recursive: true });
+  for (const existingFile of readdirSync(outputDir)) {
+    if (existingFile.toLowerCase().endsWith('.png')) {
+      rmSync(join(outputDir, existingFile), { force: true });
+    }
+  }
+  const saved: string[] = [];
+  for (const png of pngs) {
+    const outputFile = join(outputDir, png);
+    cpSync(join(captureDir, png), outputFile);
+    saved.push(outputFile);
+  }
+  return saved;
+}
+
 function collectScreenshots(
   captureDir: string,
   platform: 'ios' | 'android',
   deviceName: string,
   appStoreLocales: readonly string[] | null = null,
 ): string[] {
-  const pngs = readdirSync(captureDir).filter((file) => file.toLowerCase().endsWith('.png'));
-  const saved: string[] = [];
+  const storeRoot = join(OUTPUT_ROOT, STORE_BY_PLATFORM[platform], 'screenshots');
   if (!appStoreLocales) {
-    const outputDir = join(OUTPUT_ROOT, STORE_BY_PLATFORM[platform], 'screenshots', deviceSlug(deviceName));
-    mkdirSync(outputDir, { recursive: true });
-    for (const png of pngs) {
-      const outputFile = join(outputDir, png);
-      cpSync(join(captureDir, png), outputFile);
-      saved.push(outputFile);
-    }
-    return saved;
+    return writeCapturedScreenshots(captureDir, join(storeRoot, deviceSlug(deviceName)));
   }
 
+  const saved: string[] = [];
   for (const appStoreLocale of appStoreLocales) {
-    const outputDir = join(
-      OUTPUT_ROOT,
-      STORE_BY_PLATFORM[platform],
-      'screenshots',
-      appStoreLocale,
-      deviceSlug(deviceName),
-    );
-    mkdirSync(outputDir, { recursive: true });
-    for (const existingFile of readdirSync(outputDir)) {
-      if (existingFile.toLowerCase().endsWith('.png')) {
-        rmSync(join(outputDir, existingFile), { force: true });
-      }
-    }
-    for (const png of pngs) {
-      const outputFile = join(outputDir, png);
-      cpSync(join(captureDir, png), outputFile);
-      saved.push(outputFile);
-    }
+    saved.push(...writeCapturedScreenshots(captureDir, join(storeRoot, appStoreLocale, deviceSlug(deviceName))));
   }
   return saved;
 }


### PR DESCRIPTION
## Summary

The listing opened on the activity feed, which reads like any other app's until you already know what a board is for. The lit wall is the thing nothing else does, and the first shot is the only one most people see — so the board views lead now.

**App Store** (`app-store.yaml`): `00-board-view`, `01-board-view-2`, `02-home`, `03-climbs`, then 04–09 unchanged.
**Play** (`app-store-android.yaml`): `00-board-view`, `01-home`, `02-climbs`, then 03–07 unchanged.

Everything else keeps its relative order, and slots 04 onward keep their numbers, so this is a four-label change on iOS and three on Android.

The iPad flow is untouched — it already opens on `00-wall`, the On the Wall kiosk, which is the same idea.

**Capture order does not change**, and now diverges from display order on purpose: the board shots are still taken *last*, because the play drawer they open overlays anything shot after them. The flow comments say so.

### One thing this surfaced

Renumbering a slot renames its file, and `collectScreenshots` cleared the folder first on the App Store path but copied over it on the Play path. The old names would have survived beside the new ones — `00-home.png` next to `00-board-view.png` — and both would upload, handing Play 11 phone shots for its 8 slots, in an order nobody chose. Both paths now replace, behind one `writeCapturedScreenshots` helper with tests.

The committed Play PNGs keep their old names in this PR. They are pre-Aura captures about to be replaced wholesale by the next Android capture; renaming them here would push a reordered *classic* set to the live listing for no gain.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 2/5 — changes what the store listings lead with, which is a visible product decision, but no app code and no upload happens from this PR. The Play folder-clearing fix is the only behaviour change in the tooling.
