### PR TITLE
fix(ci): stop the runner watchdog POSTing to a GET-only endpoint

### DIFF
--- a/.github/workflows/ci-runner-watchdog.yml
+++ b/.github/workflows/ci-runner-watchdog.yml
@@ -93,7 +93,13 @@ jobs:
           # result per page rather than one aggregate, so we make the filter
           # emit one line per online runner and let `wc -l` do the summing
           # instead of taking `length` (which would give a per-page count).
-          online="$(gh api --paginate -F per_page=100 "repos/${REPO}/actions/runners" \
+          # Query params go in the URL, NOT via -f/-F. `gh api` switches the
+          # request method to POST as soon as any -f/-F field is set, so
+          # `-F per_page=100` turned this into POST /actions/runners -- a route
+          # that does not exist, so every call returned 404 and the watchdog
+          # failed on every scheduled run. It looked exactly like a token
+          # permissions problem.
+          online="$(gh api --paginate "repos/${REPO}/actions/runners?per_page=100" \
             --jq '.runners[] | select(.status == "online") | .id' | wc -l | tr -d '[:space:]')"
           echo "Online self-hosted runners: ${online}"
 
@@ -121,8 +127,9 @@ jobs:
           # hours with no indication anything was skipped.
           MAX_RUNS_TO_INSPECT=100
 
-          all_queued_run_ids_raw="$(gh api --paginate -F per_page=100 \
-            "repos/${REPO}/actions/runs" -f status=queued \
+          # Same POST trap as above: both per_page and status belong in the URL.
+          all_queued_run_ids_raw="$(gh api --paginate \
+            "repos/${REPO}/actions/runs?per_page=100&status=queued" \
             --jq '.workflow_runs[].id')"
           mapfile -t all_queued_run_ids <<< "$all_queued_run_ids_raw"
           if [ "${#all_queued_run_ids[@]}" -eq 1 ] && [ -z "${all_queued_run_ids[0]}" ]; then

--- a/scripts/__tests__/gh-api-implicit-post.test.ts
+++ b/scripts/__tests__/gh-api-implicit-post.test.ts
@@ -1,0 +1,70 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+import { githubYamlPaths, withoutCommentLines } from './helpers/workflow-yaml';
+
+/**
+ * `gh api` picks its HTTP method implicitly: GET normally, but **POST** as soon
+ * as any `-f` / `-F` / `--field` / `--raw-field` parameter is set.
+ *
+ * So writing a query parameter the natural-looking way:
+ *
+ *   gh api --paginate -F per_page=100 "repos/OWNER/REPO/actions/runners"
+ *
+ * silently issues `POST /actions/runners` — a route that does not exist. The
+ * response is a bare `404 Not Found`, which is indistinguishable from a token
+ * that lacks permission on the resource.
+ *
+ * That is not hypothetical: it took down ci-runner-watchdog.yml on every
+ * scheduled run, and the 404 sent us through several rounds of rebuilding a
+ * fine-grained PAT before the method turned out to be the culprit. The token
+ * had been correct the whole time.
+ *
+ * The rule: query parameters belong in the URL. Use `-f`/`-F` only for a real
+ * request body, alongside an explicit `-X`.
+ */
+
+const FIELD_FLAG = /(^|\s)(-f|-F|--field|--raw-field)(\s|=)/;
+const EXPLICIT_METHOD = /(^|\s)(-X|--method)(\s|=)/;
+
+/** Whole `gh api ...` invocations, rejoined across YAML line continuations. */
+function ghApiInvocations(source: string): string[] {
+  const lines = withoutCommentLines(source);
+  const invocations: string[] = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!/(^|[\s"'(=$])gh api(\s|$)/.test(lines[index])) continue;
+
+    let invocation = lines[index];
+    // A backslash at end-of-line continues the shell command onto the next.
+    while (/\\\s*$/.test(invocation) && index + 1 < lines.length) {
+      index += 1;
+      invocation = `${invocation.replace(/\\\s*$/, '')} ${lines[index].trim()}`;
+    }
+    invocations.push(invocation);
+  }
+  return invocations;
+}
+
+describe('gh api calls never take an implicit POST', () => {
+  for (const workflowPath of githubYamlPaths()) {
+    const source = readFileSync(workflowPath, 'utf8');
+    const invocations = ghApiInvocations(source);
+    if (invocations.length === 0) continue;
+
+    it(`${workflowPath} passes query params in the URL, not via -f/-F`, () => {
+      const offenders = invocations.filter(
+        (invocation) => FIELD_FLAG.test(invocation) && !EXPLICIT_METHOD.test(invocation),
+      );
+
+      expect(
+        offenders,
+        'gh api switches to POST when any -f/-F field is set, so these would hit a ' +
+          'route that does not exist and return a 404 that looks exactly like a ' +
+          'permissions failure. Put query parameters in the URL, or add an explicit -X.',
+      ).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
`ci-runner-watchdog.yml` has failed on **every scheduled run** since it shipped,
with a bare:

```
gh: Not Found (HTTP 404)
```

### Cause

`gh api` picks its HTTP method implicitly: GET normally, but **POST** as soon as
any `-f`/`-F`/`--field` is set. So this:

```
gh api --paginate -F per_page=100 "repos/OWNER/REPO/actions/runners"
```

issued `POST /repos/OWNER/REPO/actions/runners` — a route that does not exist.
The same call as a GET returns all 36 runners:

```
$ gh api --paginate -F per_page=100 ".../actions/runners"   → {"message":"Not Found"}
$ gh api --paginate ".../actions/runners?per_page=100"      → 36
```

### Why it was expensive

A 404 is indistinguishable from a token lacking permission on the resource, and
that is exactly how it read. It cost several rounds of rebuilding a fine-grained
PAT — resource owner, Administration, Actions, Variables — before the request
*method* turned out to be the culprit. **The token was correct throughout.**

Introduced by the `--paginate` correctness fix in #5030: that fix was right
about pagination and wrong about how to pass the page size.

### Fix

Both affected calls now pass query parameters in the URL. The `PATCH` further
down is unaffected — it sets `-f` alongside an explicit `-X`.

Guarded by a test over every workflow, because this failure is silent by
construction: the call looks correct, and the error it produces points at
credentials rather than at itself. Mutation-tested, including re-introducing
the original bug and dropping the explicit `-X` from the PATCH.

## Release Notes

none

## Test plan

1. CI green.
2. Dispatch `ci-runner-watchdog.yml` with `dry_run: true`; it reports the online
   runner count instead of failing, and takes no action while the fleet is up.

## Risk

Risk: 2/5 — restores a safety net that has never functioned. No behaviour
change while the fleet is healthy; the failback path stays untouched.