### PR TITLE
fix(ci): stop the pack guard failing on the packs that are correct

### DIFF
--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -333,7 +333,15 @@ jobs:
           # ref. Without this the build fails deep inside a Docker layer with
           # "trying to write ref ... with nonexistent object", which says
           # nothing about which of the inputs was wrong.
-          if ! git verify-pack -v "$packs_dir/current-week.idx" | grep -q "^${tip}"; then
+          # `grep -c`, not `grep -q`. Under `set -o pipefail`, `grep -q` exits
+          # the moment it matches, git verify-pack dies of SIGPIPE, and
+          # pipefail turns that into a failed pipeline -- so the check fires
+          # exactly when the tip IS present. `grep -c` drains the stream, and
+          # `|| true` absorbs its exit 1 on no-match so the count is what
+          # decides.
+          tip_object_count="$(git verify-pack -v "$packs_dir/current-week.idx" \
+            | grep -c "^${tip}" || true)"
+          if [ "${tip_object_count:-0}" -eq 0 ]; then
             echo "::error::generated pack does not contain its own tip ${tip}"
             exit 1
           fi

--- a/scripts/__tests__/ci-image-workflow.test.ts
+++ b/scripts/__tests__/ci-image-workflow.test.ts
@@ -278,6 +278,19 @@ describe('ci-image.yml: the current-week pack is checked before it is baked', ()
   it('fails loudly if the pack does not contain its own tip', () => {
     expect(workflowSource).toMatch(/git verify-pack[^\n]*current-week\.idx/);
   });
+
+  it('does not check that with `grep -q`, which false-positives under pipefail', () => {
+    // The step runs `set -Eeuo pipefail`. `grep -q` exits the moment it
+    // matches, git verify-pack dies of SIGPIPE, and pipefail turns that into a
+    // failed pipeline -- so the check fires exactly when the tip IS present.
+    // It shipped that way and failed a build whose pack was perfectly fine.
+    const packStep = workflowSource.slice(
+      workflowSource.indexOf("Generate the current week's pack"),
+      workflowSource.indexOf('Build and push the daily image'),
+    );
+    expect(packStep).not.toMatch(/verify-pack[\s\S]{0,200}?grep -q/);
+    expect(packStep).toMatch(/verify-pack[\s\S]{0,200}?grep -c/);
+  });
 });
 
 describe('ci-image.yml: the daily build passes every named context Dockerfile.ci reads', () => {


### PR DESCRIPTION
The guard I added in #5057 to catch an empty pack **fires when the pack is fine**.

```
##[error]generated pack does not contain its own tip ac5f8ece…
```

…on a pack that contains all 130 expected commits *and* that tip.

### Cause

The step runs `set -Eeuo pipefail`:

```
git verify-pack -v "$packs_dir/current-week.idx" | grep -q "^${tip}"
```

`grep -q` exits the instant it matches, closing the pipe. `git verify-pack`
then dies of SIGPIPE, `pipefail` propagates the non-zero, and `if !` reads that
as "tip missing". So it fails *precisely when the tip is present*. My local
check passed because it ran without `pipefail`.

### Fix

`grep -c` drains the stream, and `|| true` absorbs its exit 1 on no-match so
the count decides. Verified all three ways under `pipefail`:

| form | tip present | tip absent |
| --- | --- | --- |
| `grep -q` (old) | **fires — wrong** | fires |
| `grep -c` (new) | passes | fires |

### The good news

#5057's actual fix is confirmed working. The exclude read from the frozen
layer resolved to `41b73995e` — an ancestor of the tip, 130 commits between —
which is exactly right. Only the guard was broken.

## Release Notes

none

## Test plan

1. CI green.
2. Dispatch `ci-image.yml`; it publishes.

## Risk

Risk: 1/5 — corrects a false-positive check in the image pipeline. Cannot make
a bad pack pass: the absent-tip case still fires.