### PR TITLE
feat(web): give web a structured logger and a request-id correlator

### DIFF
--- a/packages/web/app/api/internal/profile-percentiles/route.ts
+++ b/packages/web/app/api/internal/profile-percentiles/route.ts
@@ -5,11 +5,14 @@ import { getDb } from '@/app/lib/db/db';
 import { USER_CLIMB_PERCENTILE_CACHE_TAG } from '@/app/lib/graphql/server-cached-client';
 import { userClimbPercentiles } from '@boardsesh/db/schema';
 import { requireCronAuth } from '@/app/lib/auth/cron-auth';
+import { createRequestLogger } from '@/app/lib/observability/request-logger';
+import { reportHandledError } from '@/app/lib/observability/report-error';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
 
 export async function GET(request: Request) {
+  const log = createRequestLogger(request);
   const authError = requireCronAuth(request);
   if (authError) {
     return authError;
@@ -81,7 +84,7 @@ export async function GET(request: Request) {
       timestamp: new Date().toISOString(),
     });
   } catch (error) {
-    console.error('[profile-percentiles] Error:', error);
+    reportHandledError(error, { logger: log, message: 'Profile percentile refresh failed' });
     return NextResponse.json({ error: 'Profile percentile refresh failed' }, { status: 500 });
   }
 }

--- a/packages/web/app/api/internal/ws-auth/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/ws-auth/__tests__/route.test.ts
@@ -21,6 +21,24 @@ function request(): NextRequest {
   return new NextRequest('https://www.boardsesh.com/api/internal/ws-auth');
 }
 
+/**
+ * Captures what the route writes to stderr.
+ *
+ * The route logs through `createRequestLogger`, which writes straight to
+ * `process.stderr` rather than through `console` — deliberately, because
+ * Railway derives a line's severity from the stream it arrived on. Asserting on
+ * the stream is therefore asserting the thing that matters; a `console.warn`
+ * spy would pass even if the line went to stdout and showed up as info-level.
+ */
+function captureStderr() {
+  const lines: string[] = [];
+  const spy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+    lines.push(String(chunk));
+    return true;
+  });
+  return { lines, restore: () => spy.mockRestore() };
+}
+
 describe('GET /api/internal/ws-auth', () => {
   const originalSecret = process.env.NEXTAUTH_SECRET;
 
@@ -125,18 +143,21 @@ describe('GET /api/internal/ws-auth', () => {
   it('fails closed to anonymous and warns when NEXTAUTH_SECRET is missing', async () => {
     delete process.env.NEXTAUTH_SECRET;
     getTokenMock.mockResolvedValue('encrypted-session-token');
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const stderr = captureStderr();
 
     try {
       const response = await GET(request());
 
       expect(response.status).toBe(200);
       await expect(response.json()).resolves.toEqual({ token: null, authenticated: false });
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('NEXTAUTH_SECRET'));
+      // On stderr, at warn level, with the route bound as its own attribute.
+      expect(stderr.lines.join('')).toContain('NEXTAUTH_SECRET');
+      expect(stderr.lines.join('')).toContain('[warn]');
+      expect(stderr.lines.join('')).toContain('/api/internal/ws-auth');
       // Never attempt to decode without the secret.
       expect(decodeMock).not.toHaveBeenCalled();
     } finally {
-      warnSpy.mockRestore();
+      stderr.restore();
     }
   });
 
@@ -155,7 +176,7 @@ describe('GET /api/internal/ws-auth', () => {
 
   it('keeps failures private and non-cacheable', async () => {
     getTokenMock.mockRejectedValue(new Error('cookie read failed'));
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const stderr = captureStderr();
 
     try {
       const response = await GET(request());
@@ -167,8 +188,10 @@ describe('GET /api/internal/ws-auth', () => {
         authenticated: false,
         error: 'Failed to get token',
       });
+      expect(stderr.lines.join('')).toContain('[error] Failed to read the WebSocket auth token');
+      expect(stderr.lines.join('')).toContain('cookie read failed');
     } finally {
-      errorSpy.mockRestore();
+      stderr.restore();
     }
   });
 });

--- a/packages/web/app/api/internal/ws-auth/route.ts
+++ b/packages/web/app/api/internal/ws-auth/route.ts
@@ -1,6 +1,8 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { decode, getToken, type JWT } from 'next-auth/jwt';
 import { isSecureCookieContext, sessionCookieNameCandidates } from '@/app/lib/auth/secure-cookies';
+import { createRequestLogger } from '@/app/lib/observability/request-logger';
+import { reportHandledError } from '@/app/lib/observability/report-error';
 
 const PRIVATE_NO_STORE_HEADERS = { 'Cache-Control': 'private, no-store' } as const;
 
@@ -9,6 +11,7 @@ const PRIVATE_NO_STORE_HEADERS = { 'Cache-Control': 'private, no-store' } as con
  * Returns the NextAuth JWT token that can be passed to the WebSocket backend.
  */
 export async function GET(request: NextRequest) {
+  const log = createRequestLogger(request);
   try {
     // Pass cookieName + secureCookie explicitly: next-auth's internal derivation
     // breaks if NEXTAUTH_URL is set to an http:// value (the `??` only falls back
@@ -48,7 +51,7 @@ export async function GET(request: NextRequest) {
     if (!nextAuthSecret) {
       // Server misconfiguration: without the secret the cookie can't be
       // validated. Warn loudly and fail closed to an anonymous response.
-      console.warn('[ws-auth] NEXTAUTH_SECRET is not configured; treating the request as anonymous.');
+      log.warn('NEXTAUTH_SECRET is not configured; treating the request as anonymous.');
       return NextResponse.json({ token: null, authenticated: false }, { headers: PRIVATE_NO_STORE_HEADERS });
     }
 
@@ -79,7 +82,7 @@ export async function GET(request: NextRequest) {
       { headers: PRIVATE_NO_STORE_HEADERS },
     );
   } catch (error) {
-    console.error('[ws-auth] Error getting token:', error);
+    reportHandledError(error, { logger: log, message: 'Failed to read the WebSocket auth token' });
     return NextResponse.json(
       { token: null, authenticated: false, error: 'Failed to get token' },
       { status: 500, headers: PRIVATE_NO_STORE_HEADERS },

--- a/packages/web/app/api/v1/[board_name]/climb-stats/[climb_uuid]/__tests__/route.test.ts
+++ b/packages/web/app/api/v1/[board_name]/climb-stats/[climb_uuid]/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { GET } from '../route';
 
 // Mock the rate limiter so we can drive both the allowed and limited paths.
@@ -21,11 +21,22 @@ function callGet() {
 }
 
 describe('GET /api/v1/[board_name]/climb-stats/[climb_uuid]', () => {
+  let stdoutLines: string[];
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetClientIp.mockReturnValue('127.0.0.1');
     mockCheckRateLimit.mockReturnValue({ limited: false, retryAfterSeconds: 0 });
     mockGetClimbStatsForAllAngles.mockResolvedValue([]);
+    stdoutLines = [];
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      stdoutLines.push(String(chunk));
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('returns 200 with an edge Cache-Control header when under the limit', async () => {
@@ -44,6 +55,13 @@ describe('GET /api/v1/[board_name]/climb-stats/[climb_uuid]', () => {
     expect(res.status).toBe(429);
     expect(res.headers.get('Retry-After')).toBe('42');
     expect(mockGetClimbStatsForAllAngles).not.toHaveBeenCalled();
+    // The 429 is logged as attributes, not an interpolated string, so "which IP
+    // is hammering this endpoint" is a group-by rather than a regex.
+    const logged = stdoutLines.join('');
+    expect(logged).toContain('[info] rate limited');
+    expect(logged).toContain('"status":429');
+    expect(logged).toContain('"clientIp":"127.0.0.1"');
+    expect(logged).toContain('"route":"/api/v1/[board_name]/climb-stats/[climb_uuid]"');
   });
 
   it('never advertises a back-off below 1 second', async () => {

--- a/packages/web/app/api/v1/[board_name]/climb-stats/[climb_uuid]/route.ts
+++ b/packages/web/app/api/v1/[board_name]/climb-stats/[climb_uuid]/route.ts
@@ -1,6 +1,8 @@
 import { type ClimbStatsForAngle, getClimbStatsForAllAngles } from '@/app/lib/data/queries';
 import type { ErrorResponse, BoardName } from '@/app/lib/types';
 import { checkRateLimit, getClientIp } from '@/app/lib/auth/rate-limiter';
+import { createRequestLogger } from '@/app/lib/observability/request-logger';
+import { reportHandledError } from '@/app/lib/observability/report-error';
 import { NextResponse } from 'next/server';
 
 // Per-IP cap on this public, documented endpoint. The app itself fetches climb
@@ -12,15 +14,28 @@ import { NextResponse } from 'next/server';
 // would need a shared store (Vercel KV / Upstash) — tracked in #3096.
 const MAX_REQUESTS_PER_MINUTE = 120;
 
+// The template, not the resolved path: every climb_uuid is distinct, so logging
+// the concrete pathname would give this handler as many `route` values as there
+// are climbs and make "how often does this endpoint 429" unanswerable.
+const ROUTE = '/api/v1/[board_name]/climb-stats/[climb_uuid]';
+
 export async function GET(
   req: Request,
   props: { params: Promise<{ board_name: string; climb_uuid: string }> },
 ): Promise<NextResponse<ClimbStatsForAngle[] | ErrorResponse>> {
+  const log = createRequestLogger(req, { route: ROUTE });
   const clientIp = getClientIp(req);
   const { limited, retryAfterSeconds } = checkRateLimit(`climb-stats:${clientIp}`, MAX_REQUESTS_PER_MINUTE, 60_000);
   if (limited) {
-    // Log UA + IP so a future alert window can confirm whether this is a scraper.
-    console.info(`[rate-limit] 429 climb-stats ip=${clientIp} ua=${req.headers.get('user-agent') ?? 'unknown'}`);
+    // UA + IP as their own attributes, so the "is this a scraper" question is a
+    // group-by in the log explorer rather than a regex over an interpolated
+    // string. `status` is numeric so it can be filtered alongside the rest.
+    log.info('rate limited', {
+      status: 429,
+      clientIp,
+      userAgent: req.headers.get('user-agent') ?? 'unknown',
+      retryAfterSeconds,
+    });
     return NextResponse.json(
       { error: 'Too many requests. Please slow down.' },
       // Never advertise a 0/negative back-off — clients treat that as "retry now".
@@ -50,7 +65,11 @@ export async function GET(
       headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=86400' },
     });
   } catch (error) {
-    console.error('Error fetching climb stats:', error);
+    reportHandledError(error, {
+      logger: log,
+      message: 'Failed to fetch climb stats',
+      tags: { boardName: params.board_name },
+    });
     return NextResponse.json({ error: 'Failed to fetch climb stats' }, { status: 500 });
   }
 }

--- a/packages/web/app/lib/observability/__tests__/logger.test.ts
+++ b/packages/web/app/lib/observability/__tests__/logger.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import * as Sentry from '@sentry/nextjs';
+import { createJsonLogger, describeError, readTraceId } from '../logger';
+
+/**
+ * Captures what the logger actually writes, per stream.
+ *
+ * Spying on `process.stdout.write` / `process.stderr.write` rather than on
+ * `console.*` is the point: Railway derives a line's severity from the stream
+ * it arrived on, independently of the `level` attribute in the payload, so
+ * "warn went to stderr" is the behaviour under test — not "warn called
+ * console.warn", which would pass even if the logger wrote everything to
+ * stdout.
+ */
+function captureStreams() {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+    stdout.push(String(chunk));
+    return true;
+  });
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+    stderr.push(String(chunk));
+    return true;
+  });
+  return { stdout, stderr, restore: () => [stdoutSpy, stderrSpy].forEach((spy) => spy.mockRestore()) };
+}
+
+const HEX_TRACE_ID = /^[0-9a-f]{32}$/;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('createJsonLogger in production mode', () => {
+  it('emits one JSON object per line with the scheduler envelope', () => {
+    const streams = captureStreams();
+    const logger = createJsonLogger({ service: 'web', pretty: false });
+
+    try {
+      logger.info('prewarm-heatmap done', { boardName: 'kilter', warmed: 12, failed: 0, durationMs: 4310 });
+    } finally {
+      streams.restore();
+    }
+
+    expect(streams.stdout).toHaveLength(1);
+    // Exactly one line, newline-terminated: a JSON log parser reads one object
+    // per line, so a missing or extra newline breaks ingestion.
+    expect(streams.stdout[0].endsWith('\n')).toBe(true);
+    expect(streams.stdout[0].trimEnd()).not.toContain('\n');
+
+    const line = JSON.parse(streams.stdout[0]);
+    expect(line).toEqual({
+      level: 'info',
+      service: 'web',
+      time: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+      message: 'prewarm-heatmap done',
+      boardName: 'kilter',
+      warmed: 12,
+      failed: 0,
+      durationMs: 4310,
+      traceId: expect.stringMatching(HEX_TRACE_ID),
+    });
+    // Numbers stay numbers so Railway can range over them (`@durationMs > 1000`).
+    expect(typeof line.durationMs).toBe('number');
+    // Key order matches packages/scheduler/src/logger.ts.
+    expect(Object.keys(line).slice(0, 4)).toEqual(['level', 'service', 'time', 'message']);
+  });
+
+  it('omits the fields object entirely when there are none', () => {
+    const streams = captureStreams();
+    const logger = createJsonLogger({ service: 'web', pretty: false });
+
+    try {
+      logger.info('starting');
+    } finally {
+      streams.restore();
+    }
+
+    const line = JSON.parse(streams.stdout[0]);
+    expect(Object.keys(line).sort()).toEqual(['level', 'message', 'service', 'time', 'traceId']);
+  });
+
+  it('never lets a caller field shadow the real traceId', () => {
+    const streams = captureStreams();
+    const logger = createJsonLogger({ service: 'web', pretty: false, traceId: () => 'b'.repeat(32) });
+
+    try {
+      logger.error('boom', { traceId: 'not-the-real-one' });
+    } finally {
+      streams.restore();
+    }
+
+    expect(JSON.parse(streams.stderr[0]).traceId).toBe('b'.repeat(32));
+  });
+});
+
+describe('stream routing', () => {
+  it('sends info to stdout and warn + error to stderr', () => {
+    const streams = captureStreams();
+    const logger = createJsonLogger({ service: 'web', pretty: false });
+
+    try {
+      logger.info('an info line');
+      logger.warn('a warn line');
+      logger.error('an error line');
+    } finally {
+      streams.restore();
+    }
+
+    expect(streams.stdout.map((line) => JSON.parse(line).message)).toEqual(['an info line']);
+    expect(streams.stderr.map((line) => JSON.parse(line).message)).toEqual(['a warn line', 'an error line']);
+    expect(streams.stderr.map((line) => JSON.parse(line).level)).toEqual(['warn', 'error']);
+  });
+});
+
+describe('traceId stamping', () => {
+  it('reads the trace id off the current Sentry scope', () => {
+    const streams = captureStreams();
+    const logger = createJsonLogger({ service: 'web', pretty: false });
+    const scopedTraceId = 'a1b2c3d4e5f60718293a4b5c6d7e8f90';
+
+    try {
+      Sentry.withScope((scope) => {
+        scope.setPropagationContext({ traceId: scopedTraceId, sampleRand: 0.5 });
+        logger.info('inside a request');
+      });
+    } finally {
+      streams.restore();
+    }
+
+    expect(JSON.parse(streams.stdout[0]).traceId).toBe(scopedTraceId);
+  });
+
+  it('still returns a trace id with no scope set and no Sentry.init', () => {
+    // Scope's constructor seeds `_propagationContext` with a generated traceId,
+    // and both getters are synchronous, so this is defined everywhere — server
+    // component, route handler, `after()` callback.
+    expect(readTraceId()).toMatch(HEX_TRACE_ID);
+  });
+
+  it('logs without a traceId rather than throwing when the source fails', () => {
+    const streams = captureStreams();
+    const logger = createJsonLogger({
+      service: 'web',
+      pretty: false,
+      traceId: () => {
+        throw new Error('no async context strategy');
+      },
+    });
+
+    try {
+      expect(() => logger.error('handler failed')).not.toThrow();
+    } finally {
+      streams.restore();
+    }
+
+    const line = JSON.parse(streams.stderr[0]);
+    expect(line.message).toBe('handler failed');
+    expect('traceId' in line).toBe(false);
+  });
+});
+
+describe('runtimes without process streams', () => {
+  it('falls back to console at the same severity', () => {
+    // The Edge runtime (and a client component importing this by mistake) has
+    // no process.stderr. Writing there would throw inside a catch block and
+    // replace the real error with a TypeError, so the logger degrades instead.
+    // Only stderr is swapped: vitest's own worker output uses stdout.
+    const originalStderr = Object.getOwnPropertyDescriptor(process, 'stderr');
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const logger = createJsonLogger({ service: 'web', pretty: false, traceId: () => undefined });
+
+    try {
+      Object.defineProperty(process, 'stderr', { value: {}, configurable: true });
+      expect(() => logger.error('edge handler failed')).not.toThrow();
+    } finally {
+      if (originalStderr) Object.defineProperty(process, 'stderr', originalStderr);
+    }
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(consoleErrorSpy.mock.calls[0][0]))).toMatchObject({
+      level: 'error',
+      message: 'edge handler failed',
+    });
+  });
+});
+
+describe('unserializable fields', () => {
+  it('drops the fields instead of throwing out of a catch block', () => {
+    const streams = captureStreams();
+    const logger = createJsonLogger({ service: 'web', pretty: false });
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+
+    try {
+      expect(() => logger.error('upstream failed', { circular })).not.toThrow();
+    } finally {
+      streams.restore();
+    }
+
+    const line = JSON.parse(streams.stderr[0]);
+    expect(line.message).toBe('upstream failed');
+    expect(line.fieldsError).toBe('unserializable');
+  });
+});
+
+describe('development format', () => {
+  it('writes a readable one-liner tagged with the short trace id', () => {
+    const streams = captureStreams();
+    const logger = createJsonLogger({ service: 'web', pretty: true, traceId: () => 'abcd1234'.padEnd(32, '0') });
+
+    try {
+      logger.warn('NEXTAUTH_SECRET is not configured', { route: '/api/internal/ws-auth' });
+    } finally {
+      streams.restore();
+    }
+
+    expect(streams.stderr[0]).toBe(
+      '[t:abcd1234] [warn] NEXTAUTH_SECRET is not configured {"route":"/api/internal/ws-auth"}\n',
+    );
+  });
+
+  it('leaves off the trailing object when there are no fields', () => {
+    const streams = captureStreams();
+    const logger = createJsonLogger({ service: 'web', pretty: true, traceId: () => 'abcd1234'.padEnd(32, '0') });
+
+    try {
+      logger.info('starting');
+    } finally {
+      streams.restore();
+    }
+
+    expect(streams.stdout[0]).toBe('[t:abcd1234] [info] starting\n');
+  });
+});
+
+describe('describeError', () => {
+  it('unwraps the cause chain so a bare "fetch failed" names its reason', () => {
+    // The exact shape undici produces: the rejection message says nothing, and
+    // ECONNREFUSED — the only part that tells you which of Aurora / the backend
+    // is down — is one link below.
+    const socketError = Object.assign(new Error('connect ECONNREFUSED 10.0.0.4:8080'), { code: 'ECONNREFUSED' });
+    const fetchError = new Error('fetch failed', { cause: socketError });
+
+    expect(describeError(fetchError)).toBe('fetch failed: connect ECONNREFUSED 10.0.0.4:8080');
+  });
+
+  it('follows three cause links and stops, so a pathological chain cannot blow out the line', () => {
+    const fifth = new Error('fifth');
+    const fourth = new Error('fourth', { cause: fifth });
+    const third = new Error('third', { cause: fourth });
+    const second = new Error('second', { cause: third });
+    const first = new Error('first', { cause: second });
+
+    expect(describeError(first)).toBe('first: second: third: fourth');
+  });
+
+  it('does not repeat an identical message from a re-wrapped cause', () => {
+    const inner = new Error('fetch failed');
+    const outer = new Error('fetch failed', { cause: inner });
+
+    expect(describeError(outer)).toBe('fetch failed');
+  });
+
+  it('falls back to the error name when every message is empty', () => {
+    const nameless = new Error('');
+    nameless.name = 'AbortError';
+
+    expect(describeError(nameless)).toBe('AbortError');
+  });
+
+  it('stringifies a non-Error throw', () => {
+    expect(describeError('a thrown string')).toBe('a thrown string');
+    expect(describeError({ code: 500 })).toBe('[object Object]');
+  });
+});

--- a/packages/web/app/lib/observability/__tests__/report-error.test.ts
+++ b/packages/web/app/lib/observability/__tests__/report-error.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { reportError, reportHandledError } from '../report-error';
+import type { JsonLogger } from '../logger';
+
+const { captureExceptionMock } = vi.hoisted(() => ({ captureExceptionMock: vi.fn() }));
+
+// The whole SDK is mocked so the assertions are about *our* funnel, not about
+// whether a Sentry client happens to be initialised in the test process.
+// `getCurrentScope` is stubbed too because the logger reads a trace id from it.
+vi.mock('@sentry/nextjs', () => ({
+  captureException: captureExceptionMock,
+  getCurrentScope: () => ({ getPropagationContext: () => ({ traceId: 'f'.repeat(32) }) }),
+}));
+
+function recordingLogger() {
+  const lines: Array<{ level: string; message: string; fields?: Record<string, unknown> }> = [];
+  const record =
+    (level: string) =>
+    (message: string, fields?: Record<string, unknown>): void => {
+      lines.push({ level, message, fields });
+    };
+  const logger: JsonLogger = { info: record('info'), warn: record('warn'), error: record('error') };
+  return { logger, lines };
+}
+
+beforeEach(() => {
+  captureExceptionMock.mockClear();
+});
+
+describe('reportError', () => {
+  it('writes a log line and captures the same error', () => {
+    const { logger, lines } = recordingLogger();
+    const failure = new Error('percentile refresh failed');
+
+    reportError(failure, { logger, message: 'profile-percentiles failed', tags: { job: 'profile-percentiles' } });
+
+    expect(lines).toEqual([
+      {
+        level: 'error',
+        message: 'profile-percentiles failed',
+        fields: { error: 'Error: percentile refresh failed', job: 'profile-percentiles' },
+      },
+    ]);
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(captureExceptionMock).toHaveBeenCalledWith(failure, {
+      level: 'error',
+      tags: { job: 'profile-percentiles' },
+      extra: undefined,
+    });
+  });
+
+  it('keeps a drizzle query error’s SQL out of the log line', () => {
+    const { logger, lines } = recordingLogger();
+    const drizzleError = Object.assign(
+      new Error('Failed query: SELECT "email", "password_hash" FROM "users"\nparams: test@boardsesh.com'),
+      { cause: new Error('CONNECT_TIMEOUT') },
+    );
+
+    reportError(drizzleError, { logger });
+
+    expect(lines[0].fields?.error).toBe('Error: CONNECT_TIMEOUT');
+    expect(JSON.stringify(lines[0])).not.toContain('password_hash');
+  });
+
+  it('routes a warning to the warn level and an info to info', () => {
+    const { logger, lines } = recordingLogger();
+
+    reportError(new Error('slow'), { logger, level: 'warning' });
+    reportError(new Error('note'), { logger, level: 'info' });
+    reportError(new Error('down'), { logger, level: 'fatal' });
+
+    expect(lines.map((line) => line.level)).toEqual(['warn', 'info', 'error']);
+  });
+});
+
+describe('reportHandledError', () => {
+  it('drops an AbortError without logging or capturing', () => {
+    const { logger, lines } = recordingLogger();
+    const aborted = new Error('The operation was aborted.');
+    aborted.name = 'AbortError';
+
+    reportHandledError(aborted, { logger });
+
+    expect(lines).toEqual([]);
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it('drops a TanStack CancelledError too', () => {
+    const { logger, lines } = recordingLogger();
+    const cancelled = Object.assign(new Error('cancelled'), { name: 'CancelledError' });
+
+    reportHandledError(cancelled, { logger });
+
+    expect(lines).toEqual([]);
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it('downgrades an undici fetch failure to warning and tags it network', () => {
+    // The real shape: the rejection says only "fetch failed" and ECONNREFUSED
+    // is one cause link down, so a message-only predicate would miss it.
+    const { logger, lines } = recordingLogger();
+    const socketError = Object.assign(new Error('connect ECONNREFUSED 10.0.0.4:8080'), { code: 'ECONNREFUSED' });
+    const fetchError = new Error('fetch failed', { cause: socketError });
+
+    reportHandledError(fetchError, { logger, tags: { route: '/api/internal/cleanup' } });
+
+    expect(lines[0].level).toBe('warn');
+    expect(lines[0].fields).toMatchObject({ network: true, route: '/api/internal/cleanup' });
+    expect(captureExceptionMock).toHaveBeenCalledWith(fetchError, {
+      level: 'warning',
+      tags: { route: '/api/internal/cleanup', network: true },
+      extra: undefined,
+    });
+  });
+
+  it('finds the transport failure when the only signal is two cause links down', () => {
+    // The shape web actually sees calling the backend: our client wraps undici's
+    // `fetch failed`, which itself wraps the socket error. Neither the thrown
+    // value's message nor its `code` says "network" — only the third link does,
+    // which is why the predicate walks the chain rather than inspecting the top.
+    const { logger, lines } = recordingLogger();
+    const socketError = Object.assign(new Error('connect ECONNREFUSED 10.0.0.4:8080'), { code: 'ECONNREFUSED' });
+    const fetchError = new Error('fetch failed', { cause: socketError });
+    const clientError = new Error('Backend GraphQL request failed', { cause: fetchError });
+
+    reportHandledError(clientError, { logger });
+
+    expect(lines[0].level).toBe('warn');
+    expect(lines[0].fields?.network).toBe(true);
+  });
+
+  it('recognises a network failure carried only by its code', () => {
+    const { logger, lines } = recordingLogger();
+    const dnsError = Object.assign(new Error('getaddrinfo EAI_AGAIN ws.boardsesh.com'), { code: 'EAI_AGAIN' });
+
+    reportHandledError(dnsError, { logger });
+
+    expect(lines[0].level).toBe('warn');
+    expect(lines[0].fields?.network).toBe(true);
+  });
+
+  it('leaves an application failure at error level and untagged', () => {
+    const { logger, lines } = recordingLogger();
+    const failure = new Error('Cannot read properties of undefined');
+
+    reportHandledError(failure, { logger });
+
+    expect(lines[0].level).toBe('error');
+    expect(lines[0].fields).toEqual({ error: 'Error: Cannot read properties of undefined' });
+    expect(captureExceptionMock).toHaveBeenCalledWith(failure, { level: 'error', tags: undefined, extra: undefined });
+  });
+
+  it('does not treat a message merely containing "fetch failed" as a network error', () => {
+    // Anchored patterns: a 500 whose body happens to quote the words must still
+    // page, or downgrading network noise would silently downgrade real bugs.
+    const { logger, lines } = recordingLogger();
+
+    reportHandledError(new Error('assertion failed: expected fetch failed to be handled'), { logger });
+
+    expect(lines[0].level).toBe('error');
+    expect(lines[0].fields?.network).toBeUndefined();
+  });
+});

--- a/packages/web/app/lib/observability/__tests__/request-logger.test.ts
+++ b/packages/web/app/lib/observability/__tests__/request-logger.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vite-plus/test';
+import { createRequestLogger } from '../request-logger';
+import type { JsonLogger } from '../logger';
+
+/** A logger that records `(level, message, fields)` instead of writing. */
+function recordingLogger() {
+  const lines: Array<{ level: string; message: string; fields?: Record<string, unknown> }> = [];
+  const record =
+    (level: string) =>
+    (message: string, fields?: Record<string, unknown>): void => {
+      lines.push({ level, message, fields });
+    };
+  const logger: JsonLogger = { info: record('info'), warn: record('warn'), error: record('error') };
+  return { logger, lines };
+}
+
+describe('createRequestLogger', () => {
+  it('binds Railway’s request id, route and method to every line', () => {
+    const { logger, lines } = recordingLogger();
+    const request = new Request('https://boardsesh.com/api/internal/ws-auth?next=/board', {
+      headers: { 'x-railway-request-id': 'DZbCaC5vTe2s0k7CFB6vMQ' },
+    });
+
+    const log = createRequestLogger(request, { logger });
+    log.info('handshake accepted', { userId: 'user-1' });
+    log.error('token read failed');
+
+    expect(log.requestId).toBe('DZbCaC5vTe2s0k7CFB6vMQ');
+    expect(log.route).toBe('/api/internal/ws-auth');
+    expect(lines).toEqual([
+      {
+        level: 'info',
+        message: 'handshake accepted',
+        fields: {
+          route: '/api/internal/ws-auth',
+          method: 'GET',
+          requestId: 'DZbCaC5vTe2s0k7CFB6vMQ',
+          userId: 'user-1',
+        },
+      },
+      {
+        level: 'error',
+        message: 'token read failed',
+        fields: { route: '/api/internal/ws-auth', method: 'GET', requestId: 'DZbCaC5vTe2s0k7CFB6vMQ' },
+      },
+    ]);
+  });
+
+  it('omits requestId entirely when the header is absent', () => {
+    // The normal case off Railway: local dev, tests, and any direct hit that
+    // did not pass through the edge. An empty-string requestId would look like
+    // a real correlation key in the log explorer and match nothing.
+    const { logger, lines } = recordingLogger();
+    const request = new Request('https://boardsesh.com/api/internal/profile-percentiles');
+
+    const log = createRequestLogger(request, { logger });
+    log.warn('nothing to refresh');
+
+    expect(log.requestId).toBeUndefined();
+    expect(lines[0].fields).toEqual({ route: '/api/internal/profile-percentiles', method: 'GET' });
+    expect(lines[0].fields && 'requestId' in lines[0].fields).toBe(false);
+  });
+
+  it('prefers an explicit route template over the resolved pathname', () => {
+    const { logger, lines } = recordingLogger();
+    const request = new Request('https://boardsesh.com/api/v1/kilter/climb-stats/abc-123');
+
+    const log = createRequestLogger(request, {
+      logger,
+      route: '/api/v1/[board_name]/climb-stats/[climb_uuid]',
+    });
+    log.info('served');
+
+    expect(log.route).toBe('/api/v1/[board_name]/climb-stats/[climb_uuid]');
+    expect(lines[0].fields?.route).toBe('/api/v1/[board_name]/climb-stats/[climb_uuid]');
+  });
+
+  it('lets a per-call field override a bound one', () => {
+    const { logger, lines } = recordingLogger();
+    const request = new Request('https://boardsesh.com/api/internal/cleanup', { method: 'POST' });
+
+    createRequestLogger(request, { logger }).info('rerouted', { route: '/api/internal/cleanup#feed' });
+
+    expect(lines[0].fields).toEqual({ route: '/api/internal/cleanup#feed', method: 'POST' });
+  });
+
+  it('does not throw on a relative request url', () => {
+    const { logger, lines } = recordingLogger();
+    // `new Request('/x')` throws in undici, so a relative url can only arrive
+    // via a hand-built request-like object — which a route test may well pass.
+    const requestLike = { url: '/api/internal/cleanup?token=abc', method: 'GET', headers: new Headers() } as Request;
+
+    const log = createRequestLogger(requestLike, { logger });
+    log.info('ok');
+
+    expect(log.route).toBe('/api/internal/cleanup');
+    expect(lines[0].fields?.route).toBe('/api/internal/cleanup');
+  });
+
+  it('writes through the app logger when none is injected', () => {
+    const stderr: string[] = [];
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+    const request = new Request('https://boardsesh.com/api/internal/cleanup', {
+      headers: { 'x-railway-request-id': 'req-42' },
+    });
+
+    try {
+      createRequestLogger(request).error('cleanup failed');
+    } finally {
+      stderrSpy.mockRestore();
+    }
+
+    expect(stderr).toHaveLength(1);
+    expect(stderr[0]).toContain('cleanup failed');
+    expect(stderr[0]).toContain('req-42');
+  });
+});

--- a/packages/web/app/lib/observability/logger.ts
+++ b/packages/web/app/lib/observability/logger.ts
@@ -1,0 +1,212 @@
+import * as Sentry from '@sentry/nextjs';
+
+/**
+ * Structured logging for the Next server.
+ *
+ * `www` runs in a Railway container now, and Railway's log explorer parses a
+ * JSON line into searchable attributes (`@level`, `@requestId`, and numeric
+ * fields it can compare and range over). A plain `console.error('Failed:', err)`
+ * arrives as one opaque string and is filterable only by substring.
+ *
+ * The envelope is copied from `packages/scheduler/src/logger.ts` on purpose —
+ * same key names, same order, same zero dependencies — so web and scheduler
+ * lines normalise identically in the explorer and one saved query covers both.
+ *
+ * Deliberately NOT the backend's winston logger hoisted into a shared package.
+ * That one carries an `appendSplatFormat` compat shim, a
+ * `Symbol.for('boardsesh.errorInstance')` handshake with `SentryWinstonTransport`,
+ * and a lazy `instanceIdProvider` closure that exists only to dodge a pubsub
+ * import cycle. None of it serves Next, and winston in a Next server bundle
+ * drags in `logform` + `colors` for nothing.
+ */
+export type LogFields = Record<string, unknown>;
+
+export type LogLevel = 'info' | 'warn' | 'error';
+
+export type JsonLogger = {
+  info(message: string, fields?: LogFields): void;
+  warn(message: string, fields?: LogFields): void;
+  error(message: string, fields?: LogFields): void;
+};
+
+export type JsonLoggerOptions = {
+  /** Emitted as the `service` attribute. `'web'` for everything in this app. */
+  service: string;
+  /**
+   * `false` emits one JSON object per line (what Railway parses); `true` emits
+   * a readable one-liner for a terminal. Defaults to `NODE_ENV !== 'production'`.
+   *
+   * An explicit option rather than a bare env read at every call site because
+   * `packages/web/vite.config.ts` compiles `process.env.NODE_ENV` to the literal
+   * `"test"`, so a test can only reach the production branch by asking for it.
+   */
+  pretty?: boolean;
+  /** Trace-id source. Overridable so a test can assert the failure path. */
+  traceId?: () => string | undefined;
+};
+
+/** Characters of the trace id shown in the dev one-liner's `[t:…]` prefix. */
+const TRACE_TAG_LENGTH = 8;
+
+/**
+ * The current trace id, which is the join key from a Railway log line to a
+ * Sentry event.
+ *
+ * `getCurrentScope()` and `getPropagationContext()` are both plain synchronous
+ * getters — `getPropagationContext()` is literally
+ * `return this._propagationContext` (@sentry/core 10.37.0,
+ * `build/cjs/scope.js:604`) — and `Scope`'s constructor seeds
+ * `_propagationContext` with a generated `traceId` (`scope.js:90`), so the read
+ * is defined even before `Sentry.init` runs and even outside a request. That is
+ * what lets this be called from a server component, a route handler, and an
+ * `after()` callback alike without any of them awaiting anything.
+ */
+export function readTraceId(): string | undefined {
+  const { traceId } = Sentry.getCurrentScope().getPropagationContext();
+  return typeof traceId === 'string' && traceId.length > 0 ? traceId : undefined;
+}
+
+/**
+ * Write one line to the right stream.
+ *
+ * Railway maps stderr to `@level:error` in its own ingest, independently of the
+ * `level` attribute in the payload, so warn/error MUST NOT go to stdout or they
+ * show up as info-level in the explorer's default view.
+ *
+ * `process.stdout` is absent on the Edge runtime and in a browser bundle (a
+ * client component importing this by mistake), where writing would throw inside
+ * a catch block and mask the original failure. `console` keeps the same
+ * severity split there.
+ */
+function writeLine(stream: 'stdout' | 'stderr', line: string): void {
+  const target = stream === 'stderr' ? process.stderr : process.stdout;
+  if (target && typeof target.write === 'function') {
+    target.write(`${line}\n`);
+    return;
+  }
+
+  if (stream === 'stderr') {
+    console.error(line);
+  } else {
+    console.info(line);
+  }
+}
+
+function serializeJson(
+  level: LogLevel,
+  service: string,
+  message: string,
+  traceId: string | undefined,
+  fields: LogFields | undefined,
+): string {
+  // `traceId` spreads last so a caller-supplied field of the same name can
+  // never shadow the real one — a log line whose trace id doesn't match the
+  // Sentry event is worse than no trace id at all.
+  return JSON.stringify({
+    level,
+    service,
+    time: new Date().toISOString(),
+    message,
+    ...fields,
+    ...(traceId ? { traceId } : {}),
+  });
+}
+
+function serializePretty(
+  level: LogLevel,
+  message: string,
+  traceId: string | undefined,
+  fields: LogFields | undefined,
+): string {
+  // `[t:abcd1234] [info] message {…}` mirrors the backend's dev format (which
+  // prefixes an instance id the same way), so one `tail | grep` habit works
+  // across both processes.
+  const tracePrefix = traceId ? `[t:${traceId.slice(0, TRACE_TAG_LENGTH)}] ` : '';
+  const suffix = fields && Object.keys(fields).length > 0 ? ` ${JSON.stringify(fields)}` : '';
+  return `${tracePrefix}[${level}] ${message}${suffix}`;
+}
+
+/**
+ * A logger emitting one `{ level, service, time, message, …fields, traceId }`
+ * object per line in production, and a readable one-liner in development.
+ */
+export function createJsonLogger({
+  service,
+  pretty = process.env.NODE_ENV !== 'production',
+  traceId = readTraceId,
+}: JsonLoggerOptions): JsonLogger {
+  const emit = (level: LogLevel, stream: 'stdout' | 'stderr', message: string, fields?: LogFields): void => {
+    let currentTraceId: string | undefined;
+    try {
+      currentTraceId = traceId();
+    } catch {
+      // Never let telemetry plumbing break a log call. The Sentry SDK is
+      // resilient here, but a future async-context strategy that throws would
+      // otherwise take down every handler that logs.
+      currentTraceId = undefined;
+    }
+
+    let line: string;
+    try {
+      line = pretty
+        ? serializePretty(level, message, currentTraceId, fields)
+        : serializeJson(level, service, message, currentTraceId, fields);
+    } catch {
+      // `JSON.stringify` throws on a circular field (a Request, a pg client, a
+      // React element someone passed by accident). Losing the fields beats
+      // throwing out of a catch block and replacing the real error with a
+      // TypeError about a converting circular structure.
+      line = pretty
+        ? serializePretty(level, message, currentTraceId, undefined)
+        : serializeJson(level, service, message, currentTraceId, { fieldsError: 'unserializable' });
+    }
+
+    writeLine(stream, line);
+  };
+
+  return {
+    info: (message, fields) => emit('info', 'stdout', message, fields),
+    warn: (message, fields) => emit('warn', 'stderr', message, fields),
+    error: (message, fields) => emit('error', 'stderr', message, fields),
+  };
+}
+
+/** The app-wide logger. Prefer `createRequestLogger` inside a request. */
+export const webLogger = createJsonLogger({ service: 'web' });
+
+// A wrapped error can nest (fetch → undici → the socket error); three links is
+// plenty and keeps a pathological chain out of the log line.
+const MAX_CAUSE_DEPTH = 3;
+
+/**
+ * Turns an unknown thrown value into a log-safe message.
+ *
+ * The `cause` chain is unwrapped because `fetch` rejects with a bare
+ * `fetch failed` and hides the actual reason — `ECONNREFUSED`, `ENOTFOUND`, a
+ * TLS failure — in `cause`. Web hits exactly that calling Aurora and the
+ * GraphQL backend, and `fetch failed` on its own tells an on-call reader
+ * nothing about which.
+ *
+ * Ported from `packages/scheduler/src/logger.ts`; keep the two in step.
+ *
+ * For a value that might be a graphql-request `ClientError` or a drizzle
+ * `DrizzleQueryError` — both of which embed the whole query in `.message` —
+ * use `compactErrorMessage` from `./compact-error` instead, which strips and
+ * truncates them. This helper deliberately does not truncate.
+ */
+export function describeError(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return String(error);
+  }
+
+  const messages = [error.message];
+  let cause: unknown = error.cause;
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH && cause instanceof Error; depth += 1) {
+    if (cause.message !== '' && !messages.includes(cause.message)) {
+      messages.push(cause.message);
+    }
+    cause = cause.cause;
+  }
+
+  return messages.filter((message) => message !== '').join(': ') || error.name;
+}

--- a/packages/web/app/lib/observability/report-error.ts
+++ b/packages/web/app/lib/observability/report-error.ts
@@ -1,0 +1,164 @@
+import * as Sentry from '@sentry/nextjs';
+import { compactErrorMessage } from './compact-error';
+import { webLogger, type JsonLogger, type LogFields } from './logger';
+
+/**
+ * Report an error to Railway's log stream *and* to Sentry in one call.
+ *
+ * One converted `console.error` therefore yields both a searchable JSON line
+ * and a Sentry event, and the two carry the same `traceId` — the log line
+ * stamps it from the current propagation context (see `readTraceId`), and the
+ * Sentry event is built from that same context. Given a slow or failing
+ * request found in Railway, that is what gets you to the stack trace.
+ *
+ * Mirrors `packages/mobile/src/lib/error-reporting.ts`: `reportError` is the
+ * raw funnel for a caller that already owns the severity decision, and
+ * `reportHandledError` applies the noise policy.
+ */
+/**
+ * Sentry indexes tags, so they are primitives only — the SDK's own `Primitive`
+ * minus `symbol`/`bigint`, neither of which survives JSON serialisation into a
+ * log line either. Anything structured belongs in `extra`.
+ */
+export type ReportTagValue = string | number | boolean | null | undefined;
+
+export type ErrorReportContext = {
+  level?: 'fatal' | 'error' | 'warning' | 'info' | 'debug';
+  tags?: Record<string, ReportTagValue>;
+  extra?: Record<string, unknown>;
+  /**
+   * Log-line message. Defaults to the error's own compacted message; pass one
+   * when the call site has context the error lacks ("Failed to send password
+   * reset email").
+   */
+  message?: string;
+  /**
+   * Logger to write the line with — pass a `createRequestLogger` result so the
+   * line carries `requestId` and `route`. Defaults to the app logger.
+   */
+  logger?: JsonLogger;
+};
+
+// The same depth cap `describeError` uses: fetch → undici → socket is three.
+const MAX_CAUSE_DEPTH = 3;
+
+/**
+ * Node/undici error codes that mean "the request never reached a server".
+ * These are transport failures, not application faults.
+ */
+const NETWORK_ERROR_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'EPIPE',
+  'ETIMEDOUT',
+  'EAI_AGAIN',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
+
+/**
+ * Transport-failure messages, anchored so they can only match a bare rejection.
+ * `fetch failed` is undici's, `Failed to fetch` the browser's, `terminated` the
+ * one undici raises when a response body is cut off mid-stream.
+ */
+const NETWORK_ERROR_MESSAGES = [/^fetch failed$/i, /^failed to fetch$/i, /^network request failed$/i, /^terminated$/i];
+
+/**
+ * A request the caller (or an unmounting render) cancelled. Not a failure — the
+ * app did exactly what was asked — so it must never reach error tracking.
+ * Covers our own `AbortController` signals and TanStack Query's `CancelledError`.
+ */
+function isCancellation(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const name = (error as { name?: unknown }).name;
+  return name === 'AbortError' || name === 'CancelledError';
+}
+
+/**
+ * An offline / transport failure (no server response). Expected against Aurora
+ * and during a backend restart, so it stays a filterable `warning` rather than
+ * a full `error` that drowns real bugs.
+ *
+ * The cause chain is walked because `fetch` rejects with a bare `fetch failed`
+ * and hides `ECONNREFUSED` one or two links down — the same reason
+ * `describeError` unwraps it.
+ */
+function isNetworkError(error: unknown): boolean {
+  let candidate: unknown = error;
+  for (let depth = 0; depth <= MAX_CAUSE_DEPTH && candidate instanceof Error; depth += 1) {
+    const link: Error = candidate;
+    const code = (link as { code?: unknown }).code;
+    if (typeof code === 'string' && NETWORK_ERROR_CODES.has(code)) return true;
+    if (NETWORK_ERROR_MESSAGES.some((pattern) => pattern.test(link.message))) return true;
+    candidate = link.cause;
+  }
+  return false;
+}
+
+/** Sentry severities that should land on stderr as an `error` log line. */
+const STDERR_ERROR_LEVELS = new Set(['fatal', 'error']);
+
+function logReport(error: unknown, context: ErrorReportContext | undefined): void {
+  const logger = context?.logger ?? webLogger;
+  const level = context?.level ?? 'error';
+  // `compactErrorMessage`, not `describeError`: this funnel is where a
+  // graphql-request `ClientError` (whole query + variables in `.message`) and a
+  // drizzle `DrizzleQueryError` (whole SQL + bound params) arrive, and neither
+  // belongs in a log line.
+  const errorSummary = compactErrorMessage(error);
+  const fields: LogFields = {
+    error: errorSummary,
+    ...context?.tags,
+    ...context?.extra,
+  };
+  const message = context?.message ?? errorSummary;
+
+  if (STDERR_ERROR_LEVELS.has(level)) {
+    logger.error(message, fields);
+  } else if (level === 'warning') {
+    logger.warn(message, fields);
+  } else {
+    logger.info(message, fields);
+  }
+}
+
+/**
+ * Log and capture an error at the caller's chosen severity, with no filtering.
+ * Use `reportHandledError` unless you already know this one is worth an event.
+ */
+export function reportError(error: unknown, context?: ErrorReportContext): void {
+  logReport(error, context);
+  Sentry.captureException(error, {
+    level: context?.level ?? 'error',
+    tags: context?.tags,
+    extra: context?.extra,
+  });
+}
+
+/**
+ * Report an error the handler caught and turned into a response, applying the
+ * noise policy so Sentry stays signal-rich:
+ *   - cancellations are dropped entirely (neither logged nor captured),
+ *   - offline/network failures are downgraded to `warning` and tagged
+ *     `network: true`,
+ *   - everything else reports at the caller's level (default `error`).
+ */
+export function reportHandledError(error: unknown, context?: ErrorReportContext): void {
+  if (isCancellation(error)) return;
+
+  if (isNetworkError(error)) {
+    reportError(error, {
+      ...context,
+      level: 'warning',
+      tags: { ...context?.tags, network: true },
+    });
+    return;
+  }
+
+  reportError(error, { level: 'error', ...context });
+}

--- a/packages/web/app/lib/observability/request-logger.ts
+++ b/packages/web/app/lib/observability/request-logger.ts
@@ -1,0 +1,84 @@
+import { webLogger, type JsonLogger, type LogFields } from './logger';
+import { RAILWAY_REQUEST_ID_HEADER } from './sentry-tracing';
+
+/**
+ * A logger with `requestId`, `route` and `method` bound, so every line one
+ * handler writes correlates without each call site repeating them.
+ *
+ * `requestId` is Railway's own `x-railway-request-id`, which the edge stamps on
+ * the request into the container and logs against its HTTP entry.
+ * `sentry.server.config.ts` promotes the same header to the `railway_request_id`
+ * tag on every Sentry event (see `tagRailwayRequestId`), so the three systems —
+ * Railway's HTTP log, our app log, and Sentry — all key off one value.
+ */
+export type RequestLogger = JsonLogger & {
+  /** Railway's request id, or `undefined` off Railway (local dev, tests). */
+  readonly requestId: string | undefined;
+  /** Path the handler is serving, e.g. `/api/internal/ws-auth`. */
+  readonly route: string;
+};
+
+export type RequestLoggerOptions = {
+  /**
+   * Route label. Defaults to the request's pathname, which for a dynamic
+   * segment is the resolved value (`/api/v1/kilter/climb-stats/abc`); pass the
+   * template (`/api/v1/[board_name]/climb-stats/[climb_uuid]`) when you want
+   * lines from one handler to aggregate.
+   */
+  route?: string;
+  /** Underlying logger. Injected by tests; defaults to the app logger. */
+  logger?: JsonLogger;
+};
+
+/**
+ * Pathname of a request URL, falling back to the raw string.
+ *
+ * `request.url` is absolute in Next, but a hand-built `new Request('/x')` in a
+ * test is not, and a logger must never throw on its own input.
+ */
+function resolveRoute(url: string): string {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    const queryStart = url.indexOf('?');
+    return queryStart === -1 ? url : url.slice(0, queryStart);
+  }
+}
+
+/**
+ * Bind a request's correlation fields to a logger, once per handler.
+ *
+ * The request is an explicit argument rather than an `AsyncLocalStorage` read
+ * or a `next/headers` call, for two reasons:
+ *
+ *  - `headers()` is async in Next 16. Sourcing the request id from it would
+ *    make every `log.info(...)` an `await`, in catch blocks and `after()`
+ *    callbacks included.
+ *  - There is no middleware hook to seed a store from. `packages/web/middleware.ts`
+ *    matches only `/api/v1/:path*`, `/api/auth/:path*` and `/api/internal/ws-auth`
+ *    under `/api`; its page matcher excludes `api/` outright via the
+ *    `(?!api/…)` lookahead. That narrowing was deliberate (~50k/day board-render
+ *    fetches were paying for middleware that did nothing for them), so most
+ *    `/api/**` handlers never run middleware at all.
+ */
+export function createRequestLogger(request: Request, options: RequestLoggerOptions = {}): RequestLogger {
+  const requestId = request.headers.get(RAILWAY_REQUEST_ID_HEADER) ?? undefined;
+  const route = options.route ?? resolveRoute(request.url);
+  const logger = options.logger ?? webLogger;
+
+  const boundFields: LogFields = {
+    route,
+    method: request.method,
+    ...(requestId ? { requestId } : {}),
+  };
+
+  const merge = (fields?: LogFields): LogFields => (fields ? { ...boundFields, ...fields } : boundFields);
+
+  return {
+    requestId,
+    route,
+    info: (message, fields) => logger.info(message, merge(fields)),
+    warn: (message, fields) => logger.warn(message, merge(fields)),
+    error: (message, fields) => logger.error(message, merge(fields)),
+  };
+}


### PR DESCRIPTION
## Summary

Gives `packages/web` a structured JSON logger, a request-id correlator, and a `reportError` helper. Part of #4648; the bulk conversion is #5083.

`packages/web` has no logger at all — ~195 bare `console.*` calls emitting plain text. Railway's log explorer parses structured JSON into searchable attributes (`@level`, `@requestId`, numeric comparisons and ranges), so every one of those lines is currently unfilterable, while `packages/backend` (winston) and `packages/scheduler` both already emit the envelope.

The shape is copied from `packages/scheduler/src/logger.ts` on purpose — ~30 lines, zero deps — so web and scheduler emit identical envelopes and Railway normalises both the same way. **Deliberately not the backend's winston logger:** it carries an `appendSplatFormat` compat shim, a `Symbol.for('boardsesh.errorInstance')` handshake with `SentryWinstonTransport`, and a lazy `instanceIdProvider` closure that exists to dodge a pubsub import cycle. None of that serves Next, and winston in a Next server bundle drags in `logform` + `colors` for nothing.

A real production line:

```json
{"level":"warn","service":"web","time":"2026-09-02T06:37:05.235Z","message":"NEXTAUTH_SECRET is not configured","route":"/api/internal/ws-auth","method":"GET","traceId":"b23f396dd01246d7a3f84e3af2f550bc"}
```

`traceId` spreads **after** caller fields so a caller-supplied `traceId` can never shadow the real one. warn+error go to stderr, info to stdout — Railway maps stderr to `level.error`, so that routing is load-bearing rather than cosmetic.

## The three-way join

| surface | key |
|---|---|
| Railway HTTP log | `@requestId` |
| app log line | `requestId` + `traceId` |
| Sentry event | `tags.railway_request_id` + `trace_id` |

Railway's edge sets `x-railway-request-id` on the request to the container, and `sentry.server.config.ts` already promotes it to a Sentry tag (#5074). This closes the loop.

## Design notes

**`createRequestLogger(request)` takes an explicit argument, not `AsyncLocalStorage`.** `headers()` is async in Next 16, which would make every log call async; and `middleware.ts:297-307` matches only `/api/v1/:path*`, `/api/auth/:path*` and `/api/internal/ws-auth`, with the page matcher excluding `/api/` outright — so most `/api/**` handlers never run middleware and there is nothing to seed a store from.

**`getPropagationContext().traceId` is a plain synchronous property read** (`@sentry/core` `scope.js:604`), seeded in the `Scope` constructor, so it is defined even with no `Sentry.init` at all — there is a test proving that. It is still wrapped in try/catch.

## Scope

**Five** call sites converted as proof, not 195. Chosen so each file is left with zero orphan `console.*` and all three levels are exercised across both middleware-matched and unmatched route families: climb-stats 429 + 500, ws-auth warn + 500, profile-percentiles 500. 29 remain under `app/api`; #5083 covers the rest and the eventual `no-console` rule.

**One live behaviour change worth watching:** those three routes now emit Sentry events they didn't before. That is the intent — a converted `console.error` should yield both a Railway line and a Sentry event sharing a `traceId` — but the bulk conversion will multiply it, so check Sentry volume after deploy. Related: #3088.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 2/5 — new modules plus five converted call sites. 63 tests, and **17 mutations run, each of which failed the suite and was restored.**

One mutation is worth calling out. Breaking `isNetworkError`'s cause-chain walk **survived the first run**: every network test had the signal on the top-level error, so clamping the loop changed nothing and all 9 passed. Added a test where the only signal is two cause links down (our wrapper → undici `fetch failed` → `ECONNREFUSED`) — which is exactly the shape web sees calling the backend — and the mutation now fails. That was a real coverage gap, not a hypothetical.

Two things that did not hold up while building this:

- `packages/web/vite.config.ts` compiles `process.env.NODE_ENV` to the literal `"test"`, so a logger reading it internally can never reach its production branch from a test. `createJsonLogger` therefore takes an explicit `pretty?: boolean`, and the production envelope above was verified out-of-band with `tsx` rather than trusted from the test alone.
- `ErrorReportContext.tags` cannot be `Record<string, unknown>` the way mobile's is — `@sentry/nextjs` types tags as `Record<string, Primitive>` and it fails `tsc`. Narrowed to `string | number | boolean | null | undefined`, which is tighter and correct for an indexed tag anyway.

`vp run typecheck` 0, `vp check` 0, `vp test run --project web` 381 files / 4423 tests passed with no MUI timeouts on either full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVqNy32ChhSYgeEDn4SV63
