### PR TITLE
feat(ci): move ci.yml's service-free jobs to the homelab fleet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,7 +413,7 @@ jobs:
     # either term would silently stop running the patch and fingerprint guards
     # on exactly the PR shape they exist for. Only ever widen this.
     if: needs.changes.outputs.anyJs == 'true' || needs.changes.outputs.rootCi == 'true' || needs.changes.outputs.mobile == 'true' || needs.changes.outputs.mobileDeps == 'true' || needs.changes.outputs.staticAssets == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -422,7 +422,7 @@ jobs:
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         run: vp install --frozen-lockfile
       - name: Install Expo web lint dependencies
@@ -524,7 +524,7 @@ jobs:
     # PR regardless of which file types changed — a binary-only PR is exactly the
     # case to catch — so it is deliberately not gated on the `changes` filter.
     # Dependency-free (bare node), so no vp install / build artifacts needed.
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
@@ -551,14 +551,14 @@ jobs:
   typecheck:
     needs: [changes]
     if: needs.changes.outputs.anyJs == 'true' || needs.changes.outputs.rootCi == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         run: vp install --frozen-lockfile
       # `vp run typecheck` walks the dependsOn graph defined in root
@@ -606,7 +606,7 @@ jobs:
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         run: vp install --frozen-lockfile
       - name: Validate the migration folder
@@ -636,14 +636,14 @@ jobs:
     # in addition to the schema + shared/graphql, so a web-only PR that edits
     # a gql tag can drift the generated client. Include `web` in the gate.
     if: needs.changes.outputs.sharedSchema == 'true' || needs.changes.outputs.web == 'true' || needs.changes.outputs.rootCi == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         run: vp install --frozen-lockfile
       - name: Regenerate GraphQL types
@@ -665,14 +665,14 @@ jobs:
   # than none (see the `check:db-migrations` / `large-files` precedents). Since it
   # reads no `changes` output, waiting on that job would only add latency.
   board-render-version:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         run: vp install --frozen-lockfile
       - name: Verify the committed board-render version matches the tree
@@ -683,14 +683,14 @@ jobs:
   # catalogue composites, so a paths-filter listing those would drift from the
   # generator's real input set. ~2 minutes of sharp + geometry for 49 configs.
   board-art-geometry:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         run: vp install --frozen-lockfile
       - name: Verify the committed hold silhouettes match the board art
@@ -703,14 +703,14 @@ jobs:
     # label from a mobile-only commit — without this the guard would skip the
     # exact class of PR that introduces the bug.
     if: needs.changes.outputs.web == 'true' || needs.changes.outputs.mobile == 'true' || needs.changes.outputs.i18nCatalogs == 'true' || needs.changes.outputs.rootCi == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         run: vp install --frozen-lockfile
       - name: Check hardcoded user-facing strings
@@ -731,14 +731,14 @@ jobs:
     # second time inside test-default, which reads its project list off the root
     # vite.config.ts — harmless, and no substitute for this job on PRs.)
     if: needs.changes.outputs.deployConfig == 'true' || needs.changes.outputs.rootCi == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         run: vp install --frozen-lockfile
       - name: Validate deploy/app-subdomain config (_headers, _redirects, _routes.json, asset-404 Function, no-CSP rule)
@@ -769,14 +769,14 @@ jobs:
     # scripts project a second time inside test-default — harmless, and no
     # substitute for this job on PRs.)
     if: needs.changes.outputs.storeMetadata == 'true' || needs.changes.outputs.mobileLocales == 'true' || needs.changes.outputs.rootCi == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         run: vp install --frozen-lockfile
       - name: Validate store listing copy and mobile locale parity
@@ -793,14 +793,14 @@ jobs:
     # `.github/workflows/ci.yml` reaches it via rootCi rather than the
     # pg18Artifacts list.
     if: needs.changes.outputs.pg18Artifacts == 'true' || needs.changes.outputs.rootCi == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         run: vp install --frozen-lockfile
       - name: Validate published image digest pins and any prepared patches
@@ -851,14 +851,14 @@ jobs:
     # tree, vercel.json, or the specs' own inputs change. Do not fold these into
     # test-default and do not add `--changed` here.
     if: needs.changes.outputs.restSurface == 'true' || needs.changes.outputs.rootCi == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         run: vp install --frozen-lockfile
       - name: Validate the REST surface inventory and the published OpenAPI spec
@@ -877,7 +877,7 @@ jobs:
     # i18nCatalogs: a catalog-only PR (pure JSON) must still run the
     # catalog-completeness parity test, which lives in this job.
     if: needs.changes.outputs.anyJs == 'true' || needs.changes.outputs.rootCi == 'true' || needs.changes.outputs.i18nCatalogs == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 20
     strategy:
       # Same idiom as test-backend below. fail-fast stays false so a failure in
@@ -905,7 +905,7 @@ jobs:
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         run: vp install --frozen-lockfile
       # Run every project EXCEPT the two with dedicated infra-bearing jobs
@@ -1032,7 +1032,7 @@ jobs:
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         run: vp install --frozen-lockfile
       - name: Run backend tests (shard ${{ matrix.shard }}/${{ matrix.total }})
@@ -1067,7 +1067,7 @@ jobs:
     # @boardsesh/moonboard-ocr has no @boardsesh workspace dependencies. Do not
     # start its native image-processing stack for unrelated shared/DB changes.
     if: needs.changes.outputs.ocr == 'true' || needs.changes.outputs.rootCi == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -1091,7 +1091,7 @@ jobs:
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         run: vp install --frozen-lockfile
       - name: Run OCR tests
@@ -1147,7 +1147,7 @@ jobs:
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         run: vp install --frozen-lockfile
       - name: Apply the full migration journal
@@ -1175,14 +1175,14 @@ jobs:
   mobile-bundle:
     needs: [changes]
     if: needs.changes.outputs.mobile == 'true' || needs.changes.outputs.mobileDeps == 'true' || needs.changes.outputs.rootCi == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         run: vp install --frozen-lockfile
       # The nine cheap `check:mobile-*` guards that used to sit here now run in
@@ -1297,7 +1297,7 @@ jobs:
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - uses: docker/setup-buildx-action@v4
 
       - name: Generate the web Docker context
@@ -1399,7 +1399,7 @@ jobs:
     # release-notes job does — a non-JS mobile/shared change still produces a
     # changelog entry whose category comes from the (conventional) PR title.
     if: needs.changes.outputs.anyJs == 'true' || needs.changes.outputs.rootCi == 'true' || needs.changes.outputs.mobile == 'true' || needs.changes.outputs.mobileDeps == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
@@ -1413,7 +1413,7 @@ jobs:
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         run: vp install --frozen-lockfile
       - name: Lint PR title (hard gate)
@@ -1454,14 +1454,14 @@ jobs:
     # must carry user-facing Release Notes (escape hatch: the skip-changelog
     # label, or `none` under the heading).
     if: github.event_name == 'pull_request' && (needs.changes.outputs.mobile == 'true' || needs.changes.outputs.mobileDeps == 'true')
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: voidzero-dev/setup-vp@v1
         with:
           node-version: '22.x'
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install dependencies
         run: vp install --frozen-lockfile
       - name: Check PR has Release Notes
@@ -1481,7 +1481,7 @@ jobs:
     # PR must never hand-edit it (that would fight the OTA bot and could revert
     # shipped entries). Fail if a PR touches the file.
     if: github.event_name == 'pull_request' && needs.changes.outputs.changelogData == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 2
     steps:
       - name: Reject manual changelog edits
@@ -1502,7 +1502,7 @@ jobs:
         needs.test-ocr.result != 'skipped' ||
         needs.test-location-sync-integration.result != 'skipped'
       )
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/firmware-tests.yml
+++ b/.github/workflows/firmware-tests.yml
@@ -17,15 +17,7 @@ concurrency:
 
 jobs:
   test:
-    # Stays GitHub-hosted until the CI image can host it. Routed once and
-    # reverted: actions/setup-python failed with "version '3.11' with
-    # architecture 'x64' was not found for this operating system" because the
-    # image is Debian and actions/python-versions publishes Ubuntu builds only,
-    # so setup-python can neither find 3.11 in the tool cache nor download one.
-    # Debian's system Python is also PEP 668 externally-managed, so this job's
-    # `pip install platformio` would fail even once the lookup succeeded.
-    # Re-route when the image ships a standalone Python in the tool cache.
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
 
     steps:
       - name: Checkout repository

--- a/scripts/__tests__/ci-runner-routing.test.ts
+++ b/scripts/__tests__/ci-runner-routing.test.ts
@@ -50,17 +50,50 @@ const ROUTED_RUNS_ON = `    runs-on: ${ROUTING_EXPRESSION}`;
  * deploy and release workflows may never be.
  */
 const ROUTED_JOBS: ReadonlyArray<readonly [workflow: string, job: string]> = [
-  // Wave 0 canary: cheap, secret-free, and it exercises the core of the runner
-  // contract — GITHUB_TOKEN, checkout over a seeded git object store, and
-  // `vp install` against the warm pnpm store.
+  // Wave 0: the canary. Cheap, secret-free, and it exercises the core of the
+  // runner contract -- GITHUB_TOKEN, checkout over a seeded git object store,
+  // and `vp install` against the warm pnpm store.
   ['pr-test-plan.yml', 'check'],
-  // firmware-tests.yml `test` was the second canary and is deliberately NOT
-  // here. Routing it surfaced that the image cannot host it at all: the image
-  // is Debian, actions/python-versions ships Ubuntu builds only, and the tool
-  // cache has no Python prefill, so setup-python has nothing to find and
-  // nothing it can download. Re-add once the image ships a standalone Python.
+  // Back after a detour: routing it first time round surfaced that the image
+  // had no Python at all (setup-python only downloads Ubuntu builds, and this
+  // image is Debian). The image now ships 3.11.16 and 3.12.14 in the tool
+  // cache, verified in the published image by installing platformio.
+  ['firmware-tests.yml', 'test'],
+  // Wave 1: the measured worst offenders. Both gates are ~50s of work that
+  // waited ~25 minutes for a slot (1475s and 1666s on runs 33465942874 and
+  // 33465859594). Their macOS/APK build jobs stay hosted.
   ['ios-rn-ci.yml', 'gate'],
   ['android-pr-rn.yml', 'gate'],
+  // Wave 2: ci.yml, everything that needs no service container and no Docker.
+  //
+  // NOT here, deliberately:
+  //   changes / ci-status  -- the control plane. `changes` gates 22 jobs and
+  //     `ci-status` is the required check, so both must be able to run when
+  //     the fleet cannot.
+  //   renderer-rust        -- dtolnay/rust-toolchain downloads a toolchain per
+  //     job (the image carries no Rust) and Swatinem/rust-cache repeats the
+  //     cache upload this wave exists to avoid. Same shape firmware-tests was
+  //     in: it joins once the image can host it.
+  //   db-migrations, test-backend, test-location-sync-integration, docker-web
+  //     -- sub-wave B. Service containers on localhost ports, and buildx.
+  ['ci.yml', 'board-art-geometry'],
+  ['ci.yml', 'board-render-version'],
+  ['ci.yml', 'changelog-owned'],
+  ['ci.yml', 'codegen-drift'],
+  ['ci.yml', 'commit-lint'],
+  ['ci.yml', 'deploy-config'],
+  ['ci.yml', 'i18n'],
+  ['ci.yml', 'large-files'],
+  ['ci.yml', 'lint'],
+  ['ci.yml', 'listing-guards'],
+  ['ci.yml', 'mobile-bundle'],
+  ['ci.yml', 'pg18-artifacts'],
+  ['ci.yml', 'release-notes'],
+  ['ci.yml', 'rest-surface'],
+  ['ci.yml', 'test-default'],
+  ['ci.yml', 'test-ocr'],
+  ['ci.yml', 'test-report'],
+  ['ci.yml', 'typecheck'],
 ];
 
 /**
@@ -218,11 +251,18 @@ describe('self-hosted runner routing', () => {
       // The planned fleet is 36 runners, past the API's 30-per-page default.
       // Reading only page one under-counts online runners and can trip the
       // watchdog into flipping a healthy fleet back to GitHub-hosted.
+      //
+      // Matched without pinning the URL's exact tail: the page size moved into
+      // the query string when the `-F per_page=100` form turned out to switch
+      // `gh api` to POST, and this assertion still searched for the old
+      // `actions/runners"` shape -- so it broke on a change that was correct.
       const script = watchdogScript();
-      const runnersCallIndex = script.indexOf('actions/runners"');
+      const runnersCallIndex = script.indexOf('actions/runners');
       expect(runnersCallIndex, 'expected a call to the runners endpoint').toBeGreaterThan(-1);
-      const runnersCallLine = script.slice(Math.max(0, runnersCallIndex - 120), runnersCallIndex + 20);
+      const runnersCallLine = script.slice(Math.max(0, runnersCallIndex - 120), runnersCallIndex + 40);
       expect(runnersCallLine).toContain('--paginate');
+      // Page size must still be requested, wherever it is expressed.
+      expect(runnersCallLine).toContain('per_page=100');
     });
   });
 });


### PR DESCRIPTION
Wave 2 of #5011 (epic #5005): **18 `ci.yml` jobs**, plus `firmware-tests`
coming back. That takes the fleet from 4 routed jobs to 22.

This PR is its own test — its `ci.yml` run executes on the fleet.

### What moves

Every routed job uses `setup-vp`, which the fleet has run since Wave 0, or
`setup-node` at `22.x`, which the image's tool cache satisfies at `22.23.2`.

`firmware-tests` returns because **the image now ships Python**. Routing it the
first time surfaced that it had none at all — `setup-python` only downloads
Ubuntu builds and the image is Debian, so there was nothing to find and nothing
to fetch. Verified in the published image: `3.11.16` and `3.12.14` in the tool
cache with their `.complete` markers, and `pip install platformio` → `pio
6.1.19`.

### The caches

**Every `cache: true` in `ci.yml` is now gated on `runner.environment`.**
Unguarded, each repeats the 148s cache upload measured in #5048 — nineteen
times over, which would have made this wave a large net loss.

Gating *all* of them rather than only the routed ones is deliberate: on
GitHub-hosted the expression evaluates to the previous value, so it is a no-op
there, and sub-wave B inherits the fix when it migrates.

### What deliberately stays hosted

| job(s) | why |
| --- | --- |
| `changes`, `ci-status` | the control plane — `changes` gates 22 jobs and `ci-status` is the required check, so both must run when the fleet cannot |
| `renderer-rust` | `dtolnay/rust-toolchain` downloads a toolchain per job (no Rust in the image) and `Swatinem/rust-cache` repeats the upload this wave exists to avoid |
| `db-migrations`, `test-backend`, `test-location-sync-integration`, `docker-web` | sub-wave B — service containers on localhost ports, and buildx |

`renderer-rust` is in the same position `firmware-tests` was: it joins once the
image can host it.

### Also

Unbreaks a watchdog assertion that is red on `main`. It pinned the exact string
`actions/runners"`, which stopped matching when the page size moved into the
query string in #5085 — so a correct change broke a test that was checking the
wrong thing. It now asserts the properties that matter (`--paginate`,
`per_page=100`) rather than the URL's tail.

### Prerequisites, all now met

- Rollback drill passed end to end: fleet stopped → watchdog detected 0 →
  flipped the variable for real → cancelled 0 of 3 inspected (correctly, none
  were fleet-bound) → 36 runners restored, 0 failed.
- Byte-identity holds: exactly one distinct `runs-on` expression across all 22
  routed jobs.

## Release Notes

none

## Test plan

1. CI green — and note that `ci.yml`'s own jobs here run on `bs-ci` runners.
2. `firmware-tests` passes on the fleet, having previously failed there on
   `setup-python`.

## Risk

Risk: 3/5 — the largest routing change so far, and it moves the bulk of `ci.yml`.
Mitigated by: the control plane staying hosted, the fork clause sending fork PRs
to `ubuntu-latest`, a one-variable rollback, and a watchdog now proven to fire.