### PR TITLE
fix(ci): give the seeded workspace a real HEAD

### DIFF
--- a/docker/ci/job-started.sh
+++ b/docker/ci/job-started.sh
@@ -105,5 +105,42 @@ if [ "${seeded_refs}" -eq 0 ]; then
   exit 0
 fi
 
+# Give HEAD a real commit. Without this the repo has an UNBORN head -- git
+# init leaves HEAD pointing at a branch that does not exist -- and two things
+# follow, both observed in production:
+#
+#   * `git rev-parse HEAD` fails with "ambiguous argument 'HEAD'", which fails
+#     any step that asks git what it is sitting on before checkout runs;
+#   * `actions/checkout` cannot `git clean`/`git reset` an unborn repo, logs
+#     "Unable to clean or reset the repository. The repository will be
+#     recreated instead", and deletes the whole thing -- taking the alternate
+#     with it. The seed then costs a little time and saves nothing, silently.
+#
+# Pointing a real branch at the seeded tip fixes both: HEAD resolves, checkout
+# takes its normal reset-and-fetch path, and the alternate survives to make
+# that fetch incremental.
+default_branch="${CI_SEED_DEFAULT_BRANCH:-main}"
+seed_tip="$(git -C "${GITHUB_WORKSPACE}" rev-parse --verify --quiet \
+  "refs/ci-seed/current-week" 2>/dev/null || true)"
+if [ -z "${seed_tip}" ]; then
+  # No current-week ref (a fresh baseline, say). Any seeded tip will do -- it
+  # only has to be a real commit for HEAD to resolve.
+  seed_tip="$(git -C "${GITHUB_WORKSPACE}" for-each-ref --count=1 \
+    --format='%(objectname)' 'refs/ci-seed/*' 2>/dev/null || true)"
+fi
+
+if [ -n "${seed_tip}" ] \
+  && git -C "${GITHUB_WORKSPACE}" update-ref "refs/heads/${default_branch}" "${seed_tip}" 2>/dev/null \
+  && git -C "${GITHUB_WORKSPACE}" symbolic-ref HEAD "refs/heads/${default_branch}" 2>/dev/null \
+  && git -C "${GITHUB_WORKSPACE}" reset --hard --quiet "${seed_tip}" 2>/dev/null; then
+  log "HEAD set to ${seed_tip:0:12} on ${default_branch}"
+else
+  # A repo checkout cannot use is worse than no repo at all: it makes checkout
+  # delete and re-clone, which is slower than never having seeded.
+  log "could not give HEAD a commit; removing the partial repo"
+  rm -rf -- "${GITHUB_WORKSPACE}/.git"
+  exit 0
+fi
+
 log "seeded from ${seed_git_dir}: ${seeded_refs} ref(s) resolved through the alternate"
 exit 0

--- a/scripts/__tests__/ci-image-workflow.test.ts
+++ b/scripts/__tests__/ci-image-workflow.test.ts
@@ -239,6 +239,27 @@ describe('docker/ci/job-started.sh: seeds refs, not just the alternate', () => {
     expect(hookCodeLines.some((line) => line.includes('update-ref'))).toBe(true);
   });
 
+  it('leaves HEAD pointing at a real commit', () => {
+    // `git init` leaves HEAD on an unborn branch. In production that meant
+    // `git rev-parse HEAD` failed with "ambiguous argument 'HEAD'", and
+    // actions/checkout logged "Unable to clean or reset the repository. The
+    // repository will be recreated instead" -- deleting the repo and the
+    // alternate with it. The seed then cost time and saved nothing, silently,
+    // on every job since Wave 0.
+    expect(hookCodeLines.some((line) => line.includes('symbolic-ref HEAD'))).toBe(true);
+    expect(hookCodeLines.some((line) => /update-ref "refs\/heads\//.test(line))).toBe(true);
+    // And it must be reachable content, not just a ref: checkout runs
+    // `git reset --hard`, which needs the worktree to match.
+    expect(hookCodeLines.some((line) => line.includes('reset --hard'))).toBe(true);
+  });
+
+  it('removes the repo rather than leave one checkout cannot use', () => {
+    // A half-seeded repo is worse than none: it makes checkout delete and
+    // re-clone, which is slower than never having seeded at all.
+    const headBlock = hookSource.slice(hookSource.indexOf('symbolic-ref HEAD'));
+    expect(headBlock).toMatch(/rm -rf -- "\$\{GITHUB_WORKSPACE\}\/\.git"/);
+  });
+
   it('never exits non-zero -- a failing hook fails the job before it starts', () => {
     // Every failure path must degrade to a cold clone, never to a red job.
     const explicitExits = [...hookSource.matchAll(/^\s*exit\s+(\d+)/gm)].map((match) => match[1]);


### PR DESCRIPTION
**CI is currently rolled back to GitHub-hosted** (`CI_RUNNER_LINUX = "ubuntu-latest"`)
because of this. The fleet is bypassed, not broken.

### What happened

Wave 2 (#5089) merged with failing checks. Those failures were real, and they
exposed a defect that had been silent since Wave 0.

`git init` leaves HEAD on an **unborn branch**, and the job-started hook never
gave it a commit. Two consequences:

1. `git rev-parse HEAD` fails with `ambiguous argument 'HEAD'` — failing any
   step that asks git what it is sitting on before checkout runs. That is what
   broke `typecheck`, `i18n`, `commit-lint`, `listing-guards`, `deploy-config`,
   `rest-surface` and `pg18-artifacts`.
2. `actions/checkout` cannot clean or reset an unborn repo. It logged:

   > Unable to clean or reset the repository. The repository will be recreated instead.

   …and deleted the repo, **taking the alternate with it**.

So the git seed has been inert on every fleet job since Wave 0. It explains the
one number that never made sense: checkout measuring **15s against 8s hosted**,
when the seed should have made it faster. It was being discarded and re-cloned
every time.

Waves 0 and 1 never went red because none of their steps asked for HEAD. They
just paid for a seed they immediately threw away.

### Fix

Point a real branch at the seeded tip. HEAD resolves, checkout takes its normal
reset-and-fetch path, and the alternate survives to make that fetch incremental.

If HEAD cannot be given a commit, the repo is **removed** instead — a repo
checkout cannot use is worse than none, because it forces a delete-and-re-clone
that is slower than never seeding.

### Verified against the published image

```
[job-started] HEAD set to 6d163a7013f5 on main
[job-started] seeded from /ci-seed/git: 7 ref(s) resolved through the alternate
rev-parse HEAD:   6d163a7013f5…      (was: fatal: ambiguous argument)
git clean -ffdx:  rc=0               (was: could not run → repo recreated)
git reset --hard: rc=0
fetch:            2s, .git = 4.1M    (cold: 20s, 397M)
```

Mutation-tested both assertions.

### After merge

1. Rebuild and publish the image.
2. Refresh both VMs **and restart the runner slots** — a `--rm` container only
   adopts a new image when it cycles, and an idle one never does. That gap bit
   this PR's predecessor and wants its own fix.
3. Re-enable `CI_RUNNER_LINUX`.

## Release Notes

none

## Test plan

1. CI green (running GitHub-hosted while rolled back).
2. After the image rebuild, a fleet job's checkout logs no "repository will be
   recreated" warning.

## Risk

Risk: 2/5 — the hook is strictly more careful than before: it either leaves a
repo checkout can use, or removes it. Both paths still exit 0.