### PR TITLE
fix(ci): install a host C++ toolchain in the CI image

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -233,7 +233,12 @@ RUN apt-get update && \
       python3 python3-venv \
       openssh-client iputils-ping \
       libicu72 \
-      qemu-user-static binfmt-support && \
+      qemu-user-static binfmt-support \
+      # A host C++ toolchain. PlatformIO's `native` platform compiles the
+      # firmware unit tests (embedded/test/platformio.ini, C++17) against the
+      # host compiler, so `pio test -e native` cannot run without one. Also
+      # what any dependency without a usable prebuild falls back to.
+      build-essential && \
     rm -rf /var/lib/apt/lists/*
 
 # Docker CLI only, no daemon: the host's socket is bind-mounted in, so

--- a/scripts/__tests__/ci-image-workflow.test.ts
+++ b/scripts/__tests__/ci-image-workflow.test.ts
@@ -176,6 +176,15 @@ describe('Dockerfile.ci: the hosted tool cache is prefilled', () => {
     expect(codeLines.filter((line) => line.includes('python3-pip'))).toEqual([]);
   });
 
+  it('installs a host C++ toolchain', () => {
+    // PlatformIO's `native` platform compiles the firmware unit tests
+    // (embedded/test/platformio.ini, C++17) against the host compiler, so
+    // `pio test -e native` cannot run without one. The image shipped without
+    // any -- no gcc, g++, make or cc -- which would have failed firmware-tests
+    // on the fleet even after Python landed.
+    expect(codeLines.some((line) => line.includes('build-essential'))).toBe(true);
+  });
+
   it('pins the Python versions so a rebuild cannot change the interpreter', () => {
     const pinned = codeLines.find((line) => line.startsWith('ARG PYTHON_VERSIONS='));
     expect(pinned, 'ARG PYTHON_VERSIONS= not found').toBeDefined();


### PR DESCRIPTION
Addresses the P1 from Codex on #5089, which was right.

The image shipped with **no `gcc`, `g++`, `make` or `cc`**. PlatformIO's
`native` platform compiles the firmware unit tests
(`embedded/test/platformio.ini`, C++17) against the host compiler, so
`pio test -e native` could not have run on the fleet even once Python landed —
`firmware-tests` would have swapped one failure for another.

### Verified, not assumed

The review asked to "add **and verify** a C++ toolchain". Run in the published
image plus `build-essential`, against the repo's real `embedded/test`:

```
g++ (Debian 12.2.0-14+deb12u1) 12.2.0

native:test_aurora_protocol [PASSED] Took 1.04 seconds
native:test_ble_client      [PASSED] Took 1.16 seconds
```

`build-essential` also covers any dependency that has to fall back to compiling
when no usable prebuild exists.

### Where this sits

`CI_RUNNER_LINUX` is still rolled back to `"ubuntu-latest"` after #5091. This
is the last image change needed before rebuilding, refreshing the fleet and
re-enabling.

## Release Notes

none

## Test plan

1. CI green.
2. After the image rebuild, `firmware-tests` passes on the fleet.

## Risk

Risk: 1/5 — adds a package to the CI image. Nothing else changes.