### PR TITLE
perf(ci): cache Docker builds to GHCR instead of the Actions cache

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -102,9 +102,15 @@ jobs:
             NEXT_PUBLIC_WS_URL=wss://${{ env.PR_NUMBER }}.ws.preview.boardsesh.com/graphql
             BASE_URL=https://${{ env.PR_NUMBER }}.preview.boardsesh.com
             BOARDSESH_BUILD_RELEASE=${{ github.sha }}
+          # The PR's own scope, then main's cache. The `-main` FALLBACK is a
+          # registry ref, not `type=gha,scope=web-main`: production-deploy.yml
+          # writes its cache to GHCR now, so that scope is orphaned and a
+          # fallback to it is a guaranteed miss. (`web-main` was never written
+          # by anything even before that.) A cold preview build is only slow,
+          # but a fallback that cannot hit is just a lie in the config.
           cache-from: |
             type=gha,scope=web-pr-${{ env.PR_NUMBER }}
-            type=gha,scope=web-main
+            type=registry,ref=ghcr.io/boardsesh/boardsesh-web:buildcache-main
           cache-to: type=gha,mode=max,scope=web-pr-${{ env.PR_NUMBER }}
 
       - name: Generate backend Docker context
@@ -121,9 +127,15 @@ jobs:
           tags: ghcr.io/boardsesh/boardsesh-daemon:pr-${{ env.PR_NUMBER }}
           build-args: |
             BOARDSESH_BUILD_RELEASE=${{ github.sha }}
+          # The PR's own scope, then main's cache. The `-main` FALLBACK is a
+          # registry ref, not `type=gha,scope=backend-main`: production-deploy.yml
+          # writes its cache to GHCR now, so that scope is orphaned and a
+          # fallback to it is a guaranteed miss. (`web-main` was never written
+          # by anything even before that.) A cold preview build is only slow,
+          # but a fallback that cannot hit is just a lie in the config.
           cache-from: |
             type=gha,scope=backend-pr-${{ env.PR_NUMBER }}
-            type=gha,scope=backend-main
+            type=registry,ref=ghcr.io/boardsesh/boardsesh-daemon:buildcache-main
           cache-to: type=gha,mode=max,scope=backend-pr-${{ env.PR_NUMBER }}
 
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,9 @@ jobs:
               - 'scripts/__tests__/production-deploy-web-targets.test.ts'
               - 'scripts/__tests__/static-asset-deploy-origin.test.ts'
               - 'scripts/cloudflare-apply.test.ts'
+              # Reads ci.yml, which reaches this job via rootCi; named here so
+              # editing the suite alone also triggers it.
+              - 'scripts/__tests__/ci-docker-web-workflow.test.ts'
             # Everything scripts/store-metadata-limits.test.ts reads via fs at
             # run time, plus the test itself.
             storeMetadata:
@@ -782,6 +785,7 @@ jobs:
           scripts/__tests__/production-deploy-web-targets.test.ts
           scripts/__tests__/static-asset-deploy-origin.test.ts
           scripts/cloudflare-apply.test.ts
+          scripts/__tests__/ci-docker-web-workflow.test.ts
 
   listing-guards:
     needs: [changes]
@@ -1357,29 +1361,23 @@ jobs:
       # they are passed in production SHAPE to exercise the real code path. This
       # image is never pushed or served — do not treat these as deploy config.
       #
-      # THERE IS NO `cache-to`, ON PURPOSE — do not add one back.
+      # THERE IS NO `cache-to`, ON PURPOSE — do not add one back. This job must
+      # never publish anything, which is what
+      # scripts/__tests__/ci-docker-web-workflow.test.ts guards by asserting no
+      # docker/login-action and no `packages: write`.
       #
-      # A fully cold build of this image measured 2m53s (4m09s for the whole
-      # job) on ubuntu-latest, so a warm cache saves a minute or two at most.
-      # Writing it costs 2.72 GB against a repo cache that is already at 9.15 GB
-      # of GitHub's 10 GB ceiling (measured 2026-08-25, 69 entries), which means
-      # the write evicts other scopes by LRU — the gradle and vp toolchain
-      # caches among them, and those serve mobile PRs, the dominant PR shape in
-      # this repo. Spending someone else's cache to save 90 seconds here is
-      # net-negative.
+      # `cache-from` reads the registry cache production-deploy.yml writes.
+      # ghcr.io/boardsesh/boardsesh-web is a PUBLIC package, so BuildKit gets a
+      # pull token anonymously and this job keeps its no-credentials property
+      # (verified 2026-09-02: ghcr.io issues an anonymous bearer token for it and
+      # /tags/list answers 200). It previously read `type=gha,scope=web-main` — a
+      # scope nothing ever wrote, so a guaranteed miss and a fully cold 2m53s
+      # build every run. Unlike the gha cache, this one also works for fork PRs.
       #
-      # `cache-from` stays: it costs no quota and is a harmless no-op. Note that
-      # NEITHER job writes `web-main` — production-deploy.yml's build-web made
-      # the same call for the same reason (a 2.72 GB write evicting the mobile
-      # caches). If the minute ever matters, a registry-backed cache on GHCR is
-      # the quota-free option, but only for a job that already has push
-      # credentials — this one deliberately does not.
-      #
-      # If this ever does need a writable cache, note that the registry-backed
-      # option (type=registry on GHCR) requires push credentials, which would
-      # destroy this job's "never publishes anything" property — the one
-      # scripts/__tests__/ci-docker-web-workflow.test.ts guards. Weigh that
-      # first; it is worth more than the minute.
+      # Expect somewhere between -40s and +10s, not a clear win: the cache hit
+      # skips the dependency layer (47s) but pays to pull ~843 MB and unpack it,
+      # because `next build` runs on top of that layer. Measure over ten runs
+      # before assuming; reverting is one line.
       - name: Build the web image
         uses: docker/build-push-action@v7
         with:
@@ -1391,8 +1389,14 @@ jobs:
           build-args: |
             NEXT_PUBLIC_WS_URL=wss://ws.boardsesh.com/graphql
             BASE_URL=https://www.boardsesh.com
-            BOARDSESH_BUILD_RELEASE=${{ github.sha }}
-          cache-from: type=gha,scope=web-main
+            # A constant, NOT github.sha. Dockerfile.web seds this into
+            # app/api/health/build-release.ts, so a per-commit value invalidates
+            # that layer and everything after it — including the 118s
+            # `next build` — on every push. This image is only inspected by the
+            # openapi check below and is never served, so it needs no real build
+            # identity; it only needs to satisfy the 40-lowercase-hex validation.
+            BOARDSESH_BUILD_RELEASE=0000000000000000000000000000000000000000
+          cache-from: type=registry,ref=ghcr.io/boardsesh/boardsesh-web:buildcache-main
 
       # public/openapi.json is gitignored and written by the `generate:openapi`
       # half of packages/web's build script, so its presence in the image is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,10 @@ jobs:
               # Reads ci.yml, which reaches this job via rootCi; named here so
               # editing the suite alone also triggers it.
               - 'scripts/__tests__/ci-docker-web-workflow.test.ts'
+              # The image build-cache contract, and the workflows it reads.
+              - 'scripts/__tests__/service-image-build-cache.test.ts'
+              - '.github/workflows/sync-deploy.yml'
+              - '.github/workflows/branch-deploy.yml'
             # Everything scripts/store-metadata-limits.test.ts reads via fs at
             # run time, plus the test itself.
             storeMetadata:
@@ -786,6 +790,7 @@ jobs:
           scripts/__tests__/static-asset-deploy-origin.test.ts
           scripts/cloudflare-apply.test.ts
           scripts/__tests__/ci-docker-web-workflow.test.ts
+          scripts/__tests__/service-image-build-cache.test.ts
 
   listing-guards:
     needs: [changes]

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -320,15 +320,45 @@ jobs:
           # present in the build env.
           secrets: |
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-          cache-from: type=gha,scope=web-main
-          # THERE IS NO `cache-to`, ON PURPOSE — do not add one back. Writing this
-          # scope costs 2.72 GB against a repo cache measured at 9.15 GB of
-          # GitHub's 10 GB ceiling (2026-08-25), so the write evicts other scopes
-          # by LRU — the gradle and vp toolchain caches among them, which serve
-          # mobile PRs, the dominant PR shape here. It would save ~90 s on a job
-          # that runs once per merge. If a writable cache is ever genuinely
-          # needed, the registry-backed option (type=registry on GHCR) is
-          # quota-free and this job already has push credentials.
+          # A REGISTRY cache on GHCR, not `type=gha`. The gha backend cannot
+          # work for these images: the repo cache measured 36.45 GB across 227
+          # entries on 2026-09-02 against GitHub's 10 GB ceiling, so eviction is
+          # continuous — four distinct ~843 MB dependency-layer blobs were
+          # written in 19 hours, meaning the scope missed on essentially every
+          # build. Two of them were byte-identical to layers GHCR was already
+          # storing, so the same blob was paid for twice.
+          #
+          # `web-main` was additionally a scope NOBODY wrote (the `cache-to` was
+          # removed on purpose to protect the mobile gradle caches), so this
+          # `cache-from` was a guaranteed miss and every production web build
+          # ran cold — 8m00s-9m24s across six deploys with zero variance.
+          #
+          # Moving to the registry RETURNS 5.91 GB to the gha budget rather than
+          # spending it, which is strictly better for the mobile PRs the original
+          # refusal was protecting. GitHub Packages storage and bandwidth are
+          # free for public packages, and this job already holds push
+          # credentials.
+          #
+          # The ref is a tag on the SAME image repository on purpose: when a
+          # cached layer is also an image layer, the blob already exists there
+          # under the same digest, so the export is a manifest write plus "layer
+          # already exists" instead of a second upload of the same bytes.
+          #
+          # `mode=max` is mandatory here, not cosmetic: Dockerfile.web is
+          # multi-stage, and both the dependency layer (47.0s) and `next build`
+          # (118.0s) live in the `builder` stage and contribute nothing to the
+          # final image. `mode=min` would cache the three cheap runner COPYs and
+          # none of the expensive work.
+          #
+          # `image-manifest=true` + `oci-mediatypes=true` are the pair GHCR
+          # needs; neither works without the other. No `compression=zstd` — the
+          # image export stays gzip for Railway, and a zstd cache would force
+          # every layer to be compressed a second time.
+          #
+          # `ignore-error=true` because this is the production deploy path: a
+          # GHCR 5xx while exporting a cache must not turn a shipped release red.
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.WEB_IMAGE_NAME }}:buildcache-main
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.WEB_IMAGE_NAME }}:buildcache-main,mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true
 
       - name: Generate web artifact attestation
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
@@ -396,8 +426,20 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BOARDSESH_BUILD_RELEASE=${{ github.sha }}
-          cache-from: type=gha,scope=backend-main
-          cache-to: type=gha,mode=max,scope=backend-main
+          # Registry cache on GHCR — see the long note in build-web for why
+          # `type=gha` cannot work for these images. This job's move is the one
+          # that reclaims the budget: `backend-main` and `sync-main` were the
+          # ONLY buildkit scopes ever written, and between them they held
+          # 5.91 GB across 64 blob entries.
+          #
+          # It also deletes a measured 36.2s `exporting cache to gha` step, and
+          # takes most of the 91.1s image export with it: that export is
+          # CPU-bound gzip of the 843.2 MB dependency layer (2.6 GB raw at
+          # 28.6 MB/s), and a cache hit means the blob already exists in this
+          # same repository under a known digest, so BuildKit reuses the
+          # descriptor instead of recompressing.
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:buildcache-main
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:buildcache-main,mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4

--- a/.github/workflows/sync-deploy.yml
+++ b/.github/workflows/sync-deploy.yml
@@ -82,8 +82,16 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=sync-main
-          cache-to: type=gha,mode=max,scope=sync-main
+          # Registry cache on GHCR, not `type=gha` — same reasoning as
+          # production-deploy.yml's build-backend, and the same image shape
+          # (a ~843 MB dependency layer in a single-stage image). `sync-main`
+          # was one of only two buildkit scopes ever written; between them they
+          # held 5.91 GB of a repo cache measured at 36.45 GB against GitHub's
+          # 10 GB ceiling, so it missed almost every build while evicting the
+          # mobile caches. The ref is a tag on the same image repository so a
+          # cached layer that is also an image layer is not uploaded twice.
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:buildcache-main
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:buildcache-main,mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4

--- a/docs/branch-deploys.md
+++ b/docs/branch-deploys.md
@@ -944,7 +944,7 @@ jobs:
             BOARDSESH_BUILD_RELEASE=${{ github.sha }}
           cache-from: |
             type=gha,scope=web-pr-${{ github.event.pull_request.number }}
-            type=gha,scope=web-main
+            type=registry,ref=ghcr.io/boardsesh/boardsesh-web:buildcache-main
           cache-to: type=gha,mode=max,scope=web-pr-${{ github.event.pull_request.number }}
 
       - name: Build and push backend image
@@ -960,7 +960,7 @@ jobs:
             BOARDSESH_BUILD_RELEASE=${{ github.sha }}
           cache-from: |
             type=gha,scope=backend-pr-${{ github.event.pull_request.number }}
-            type=gha,scope=backend-main
+            type=registry,ref=ghcr.io/boardsesh/boardsesh-daemon:buildcache-main
           cache-to: type=gha,mode=max,scope=backend-pr-${{ github.event.pull_request.number }}
 
   deploy:

--- a/scripts/__tests__/ci-docker-web-workflow.test.ts
+++ b/scripts/__tests__/ci-docker-web-workflow.test.ts
@@ -200,16 +200,26 @@ describe('docker-web CI job contract', () => {
     expect(dockerWebSteps).not.toContain('attest-build-provenance');
   });
 
-  it('reads the shared buildx cache but never writes it', () => {
-    // A fully cold build measured 2m53s, so a warm cache is worth a minute or
-    // two. Writing it costs 2.72 GB against a repo cache already at 9.15 GB of
-    // GitHub's 10 GB ceiling (measured 2026-08-25), which evicts other scopes by
-    // LRU — including the gradle and vp toolchain caches that serve mobile PRs,
-    // the dominant PR shape here. Adding `cache-to` back looks like a free
-    // speedup in review and only shows up as unrelated jobs getting slower, so
-    // its absence is pinned rather than left to memory.
-    expect(dockerWebSteps).toContain('cache-from: type=gha,scope=web-main');
+  it('reads the registry cache anonymously but never writes anything', () => {
+    // The cache production-deploy.yml writes, read over an anonymous GHCR pull
+    // — boardsesh-web is a public package — so this job gains no credentials.
+    // It used to read `type=gha,scope=web-main`, a scope nothing ever wrote:
+    // a guaranteed miss and a fully cold 2m53s build every run.
+    expect(dockerWebSteps).toContain('cache-from: type=registry,ref=ghcr.io/boardsesh/boardsesh-web:buildcache-main');
+    expect(dockerWebSteps).not.toContain('type=gha');
+    // `cache-to` would need push credentials and would destroy this job's
+    // "never publishes anything" property, asserted above. It looks like a free
+    // speedup in review, so its absence is pinned rather than left to memory.
     expect(dockerWebSteps).not.toContain('cache-to');
+  });
+
+  it('builds with a constant release stamp so the layer survives across pushes', () => {
+    // Dockerfile.web seds BOARDSESH_BUILD_RELEASE into
+    // app/api/health/build-release.ts. Passing github.sha here invalidated that
+    // layer and everything after it — including the 118s `next build` — on
+    // every push, for an image that is only inspected and never served.
+    expect(dockerWebSteps).toContain('BOARDSESH_BUILD_RELEASE=0000000000000000000000000000000000000000');
+    expect(dockerWebSteps).not.toContain('BOARDSESH_BUILD_RELEASE=${{ github.sha }}');
   });
 
   it('asserts the generated artifacts the web image is built to prove', () => {

--- a/scripts/__tests__/production-deploy-web-targets.test.ts
+++ b/scripts/__tests__/production-deploy-web-targets.test.ts
@@ -237,32 +237,14 @@ describe('production-deploy web deploy targets', () => {
   });
 
   it('caches the image build to the registry, never to the Actions cache', () => {
-    // `type=gha` cannot work for these images. The repo cache measured 36.45 GB
-    // across 227 entries on 2026-09-02 against a 10 GB ceiling, so eviction is
-    // continuous: four distinct ~843 MB dependency-layer blobs were written in
-    // 19 hours, i.e. the scope missed on essentially every build. Falling back
-    // to it would ALSO re-evict the mobile gradle caches, which is what the
-    // original no-`cache-to` rule was protecting.
-    //
-    // The ref must stay a tag on the same image repository: a cached layer that
-    // is also an image layer is then already present under its own digest, so
-    // the export writes a manifest instead of re-uploading ~843 MB.
+    // The full contract — ref, mode, media types, ignore-error, no zstd — lives
+    // in service-image-build-cache.test.ts, which asserts it identically for
+    // web, backend and sync. Duplicating it here is how build-backend ended up
+    // with only half the assertions build-web had. This keeps the one property
+    // that belongs to THIS file: the web image build never silently falls back
+    // to an Actions cache that cannot hit.
     expect(buildWebJob).not.toContain('type=gha');
     expect(buildBackendJob).not.toContain('type=gha');
-    expect(buildWebJob).toContain(
-      'cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.WEB_IMAGE_NAME }}:buildcache-main',
-    );
-    // mode=max is load-bearing: Dockerfile.web is multi-stage and every
-    // expensive step lives in a stage the final image does not keep.
-    expect(buildWebJob).toContain('mode=max');
-    // The GHCR-specific pair; neither works without the other.
-    expect(buildWebJob).toContain('image-manifest=true');
-    expect(buildWebJob).toContain('oci-mediatypes=true');
-    // A cache-export hiccup must not fail a shipped release.
-    expect(buildWebJob).toContain('ignore-error=true');
-    // Double compression: the image stays gzip for Railway, so a zstd cache
-    // would compress every layer twice.
-    expect(buildWebJob).not.toContain('compression=zstd');
   });
 
   it('gates the Railway web deploy behind every release gate', () => {

--- a/scripts/__tests__/production-deploy-web-targets.test.ts
+++ b/scripts/__tests__/production-deploy-web-targets.test.ts
@@ -94,6 +94,7 @@ describe('production-deploy web deploy targets', () => {
   const migrateJob = withoutComments(mappingEntry(workflowSource, 'migrate', 2));
   const deployWebRailwayJob = withoutComments(mappingEntry(workflowSource, 'deploy-web-railway', 2));
   const deployBackendJob = withoutComments(mappingEntry(workflowSource, 'deploy-production-backend', 2));
+  const buildBackendJob = withoutComments(mappingEntry(workflowSource, 'build-backend', 2));
 
   it('never reads WEB_DEPLOY_TARGETS from a job-level if', () => {
     // The whole reason resolve-web-targets is a job. A job-level `if:` is
@@ -235,12 +236,33 @@ describe('production-deploy web deploy targets', () => {
     expect(undeclared, `build-args with no ARG in ${DOCKERFILE_PATH}'s builder stage`).toEqual([]);
   });
 
-  it('reads the shared buildx cache but never writes it', () => {
-    // Writing `web-main` costs 2.72 GB against a repo cache measured at 9.15 GB
-    // of GitHub's 10 GB ceiling, evicting the gradle and vp toolchain caches
-    // that serve mobile PRs to save ~90 s on a once-per-merge job.
-    expect(buildWebJob).toContain('cache-from: type=gha,scope=web-main');
-    expect(buildWebJob).not.toContain('cache-to');
+  it('caches the image build to the registry, never to the Actions cache', () => {
+    // `type=gha` cannot work for these images. The repo cache measured 36.45 GB
+    // across 227 entries on 2026-09-02 against a 10 GB ceiling, so eviction is
+    // continuous: four distinct ~843 MB dependency-layer blobs were written in
+    // 19 hours, i.e. the scope missed on essentially every build. Falling back
+    // to it would ALSO re-evict the mobile gradle caches, which is what the
+    // original no-`cache-to` rule was protecting.
+    //
+    // The ref must stay a tag on the same image repository: a cached layer that
+    // is also an image layer is then already present under its own digest, so
+    // the export writes a manifest instead of re-uploading ~843 MB.
+    expect(buildWebJob).not.toContain('type=gha');
+    expect(buildBackendJob).not.toContain('type=gha');
+    expect(buildWebJob).toContain(
+      'cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.WEB_IMAGE_NAME }}:buildcache-main',
+    );
+    // mode=max is load-bearing: Dockerfile.web is multi-stage and every
+    // expensive step lives in a stage the final image does not keep.
+    expect(buildWebJob).toContain('mode=max');
+    // The GHCR-specific pair; neither works without the other.
+    expect(buildWebJob).toContain('image-manifest=true');
+    expect(buildWebJob).toContain('oci-mediatypes=true');
+    // A cache-export hiccup must not fail a shipped release.
+    expect(buildWebJob).toContain('ignore-error=true');
+    // Double compression: the image stays gzip for Railway, so a zstd cache
+    // would compress every layer twice.
+    expect(buildWebJob).not.toContain('compression=zstd');
   });
 
   it('gates the Railway web deploy behind every release gate', () => {

--- a/scripts/__tests__/service-image-build-cache.test.ts
+++ b/scripts/__tests__/service-image-build-cache.test.ts
@@ -1,0 +1,134 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+import { jobBlocks } from './helpers/workflow-yaml';
+
+/**
+ * The BuildKit cache contract for every service image, in one place.
+ *
+ * Why it is its own file rather than assertions bolted onto each workflow's
+ * test: the three images share one contract, and the failure mode is asymmetry
+ * — build-web fully asserted while build-backend only checked that it was NOT
+ * using the old backend, and sync-deploy.yml asserted by nothing at all. A
+ * shared table makes adding a fourth image a one-line change and makes a
+ * missing image obvious.
+ *
+ * Background, so the option list below is not cargo-culted. `type=gha` cannot
+ * work for these images: the repo Actions cache measured 36.45 GB across 227
+ * entries against GitHub's 10 GB ceiling on 2026-09-02, so eviction is
+ * continuous — four distinct ~843 MB dependency-layer blobs were written in 19
+ * hours, i.e. the scope missed on essentially every build, while evicting the
+ * mobile gradle caches it was competing with.
+ */
+const SERVICE_IMAGES = [
+  {
+    label: 'web',
+    workflow: '.github/workflows/production-deploy.yml',
+    job: 'build-web',
+    // Written with the workflow's `env.` indirection, which is what keeps the
+    // cache ref and the pushed image on the same repository.
+    ref: '${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.WEB_IMAGE_NAME }}:buildcache-main',
+  },
+  {
+    label: 'backend',
+    workflow: '.github/workflows/production-deploy.yml',
+    job: 'build-backend',
+    ref: '${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:buildcache-main',
+  },
+  {
+    label: 'sync',
+    workflow: '.github/workflows/sync-deploy.yml',
+    job: 'build-sync',
+    ref: '${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:buildcache-main',
+  },
+] as const;
+
+function jobSource(workflow: string, job: string): string {
+  const block = jobBlocks(readFileSync(workflow, 'utf8')).get(job);
+  if (!block) throw new Error(`${workflow} has no \`${job}\` job`);
+  // Strip comment lines so a job's own rationale can never satisfy an assertion.
+  return block.filter((line) => !line.trimStart().startsWith('#')).join('\n');
+}
+
+describe('service image build cache', () => {
+  it('covers every job that builds and pushes a service image', () => {
+    // Guards the table itself: a new service image whose build job nobody added
+    // here would otherwise be silently unasserted, which is exactly how
+    // sync-deploy.yml ended up with no coverage.
+    const pushingJobs: string[] = [];
+    for (const workflow of ['.github/workflows/production-deploy.yml', '.github/workflows/sync-deploy.yml']) {
+      for (const [job, block] of jobBlocks(readFileSync(workflow, 'utf8'))) {
+        const body = block.join('\n');
+        if (body.includes('docker/build-push-action') && body.includes('push: true')) {
+          pushingJobs.push(`${workflow}:${job}`);
+        }
+      }
+    }
+    expect(pushingJobs.sort()).toEqual(SERVICE_IMAGES.map((image) => `${image.workflow}:${image.job}`).sort());
+  });
+
+  describe.each(SERVICE_IMAGES)('$label', ({ workflow, job, ref }) => {
+    const source = jobSource(workflow, job);
+
+    it('reads and writes a registry cache on the same repository as the image', () => {
+      // Same repository, not a separate `*-cache` package: when a cached layer
+      // is also an image layer the blob already exists there under its own
+      // digest, so the export is a manifest write plus "layer already exists"
+      // instead of a second upload of the same ~843 MB.
+      expect(source).toContain(`cache-from: type=registry,ref=${ref}`);
+      expect(source).toContain(`cache-to: type=registry,ref=${ref},`);
+    });
+
+    it('exports every stage, in the media type GHCR accepts, without failing the release', () => {
+      const cacheTo = source.split('\n').find((line) => line.includes('cache-to:'));
+      expect(cacheTo, 'expected a cache-to line').toBeDefined();
+
+      // mode=max is not cosmetic: Dockerfile.web is multi-stage, and both the
+      // dependency layer and `next build` live in a stage the final image
+      // discards. mode=min would cache the cheap runner COPYs and none of the
+      // expensive work.
+      expect(cacheTo).toContain('mode=max');
+      // GHCR needs this pair; neither works without the other.
+      expect(cacheTo).toContain('image-manifest=true');
+      expect(cacheTo).toContain('oci-mediatypes=true');
+      // This runs on the production deploy path: a GHCR 5xx while exporting a
+      // cache must not turn a shipped release red.
+      expect(cacheTo).toContain('ignore-error=true');
+    });
+
+    it('does not compress every layer twice', () => {
+      // The image export stays gzip because that is what Railway pulls. A zstd
+      // cache cannot share those blobs, so BuildKit would compress each layer
+      // once for the image and again for the cache.
+      expect(source).not.toContain('compression=zstd');
+    });
+
+    it('does not fall back to the Actions cache', () => {
+      expect(source).not.toContain('type=gha');
+    });
+  });
+
+  it('leaves no build pointing at an orphaned `-main` Actions cache scope', () => {
+    // branch-deploy.yml used to fall back to `type=gha,scope=backend-main` and
+    // `scope=web-main`. Nothing writes either any more — production-deploy.yml
+    // exports to GHCR, and `web-main` was never written by anything — so those
+    // fallbacks were guaranteed misses. A fallback that cannot hit is a lie in
+    // the config, so it is asserted gone rather than left to reading.
+    for (const workflow of [
+      '.github/workflows/production-deploy.yml',
+      '.github/workflows/sync-deploy.yml',
+      '.github/workflows/branch-deploy.yml',
+      '.github/workflows/ci.yml',
+    ]) {
+      const live = readFileSync(workflow, 'utf8')
+        .split('\n')
+        .filter((line) => !line.trimStart().startsWith('#'))
+        .join('\n');
+      for (const scope of ['scope=web-main', 'scope=backend-main', 'scope=sync-main']) {
+        expect(live, `${workflow} still uses ${scope}`).not.toContain(scope);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Follows #5090 (now merged); this targets `main` directly. Moves the Docker layer cache from the GitHub Actions cache to a registry cache on GHCR, for `build-web`, `build-backend`, `build-sync` and `ci.yml`'s `docker-web`.

**`type=gha` cannot work for these images**, and the measurements say so plainly (2026-09-02):

- The repo Actions cache is at **36.45 GB across 227 entries** against GitHub's 10 GB ceiling, so eviction is continuous.
- **Four distinct ~843 MB dependency-layer blobs were written in 19 hours** — `backend-main` missed on essentially every build.
- Two of them were **byte-identical to layers GHCR was already storing**. The same blob was being paid for twice.
- `web-main` was worse: **nothing ever wrote it.** The `cache-to` was removed on purpose to stop a 2.72 GB write evicting the mobile gradle caches, which left `build-web` reading a scope that never existed — a guaranteed miss, and a fully cold build every merge (8m00s–9m24s across six deploys, zero variance).

### This gives cache budget back, it doesn't spend it

The original refusal was protecting the mobile gradle caches, and that was right at the time (9.15 GB / 69 entries). The picture has changed:

| Category | Size |
|---|---|
| vp toolchain | 16.00 GB (26 entries) |
| gradle | 9.27 GB (3) |
| **buildkit** | **5.91 GB (64)** |
| other | 5.28 GB |

Moving Docker off `type=gha` **returns 5.91 GB**. Both existing in-code comments already named `type=registry` on GHCR as the quota-free option; storage and bandwidth are free for public packages.

### Option choices, all load-bearing

- **Same image repo, `:buildcache-main` tag** — when a cached layer is also an image layer the blob already exists there under its own digest, so the export writes a manifest instead of re-uploading ~843 MB. A separate cache package would upload it twice.
- **`mode=max`** — `Dockerfile.web` is multi-stage; both the dependency layer (47.0s) and `next build` (118.0s) live in the `builder` stage. `mode=min` would cache the three cheap runner COPYs and none of the expensive work.
- **`image-manifest=true` + `oci-mediatypes=true`** — the pair GHCR needs; neither works alone.
- **No `compression=zstd`** — the image export stays gzip for Railway, and a zstd cache would force every layer to be compressed a second time.
- **`ignore-error=true`** — a GHCR 5xx while exporting a cache must not turn a shipped release red.

### `ci.yml`'s `docker-web` keeps its no-credentials property

`ghcr.io/boardsesh/boardsesh-web` is a **public** package, so BuildKit gets a pull token anonymously — no `docker/login-action`, no `packages: write`, no `cache-to`. Verified: ghcr.io issues an anonymous bearer token and `/tags/list` answers 200. The "never publishes anything" assertions are untouched and still green. This also works for fork PRs, which the gha cache never did.

It also stops passing `github.sha` as `BOARDSESH_BUILD_RELEASE`. That invalidated the release-stamp layer and everything after it — including the 118s `next build` — on every push, for an image that is only inspected and never served.

### Honest scope

**This does not shorten a web-touching production deploy.** `migrate` gates on both builds, so the critical path is `max(build-web, build-backend)`, and `build-web` is roughly a wash: restoring the 843 MB builder layer costs about what running the dependency layer costs. What it buys:

- `build-backend` **3m44s → ~2m10s** (backend-only deploys), by deleting the measured 36.2s gha cache export and most of the 91.1s image export — that export is CPU-bound gzip of the 843.2 MB dependency layer (2.6 GB raw at 28.6 MB/s), and a cache hit reuses the existing blob descriptor instead of recompressing.
- 5.91 GB of Actions cache back.
- The precondition for the rest of the build-speed work.

For `docker-web` expect **−40s to +10s** — the hit skips the dependency layer but pays to pull ~843 MB and unpack it, because `next build` runs on top. Measure over ten runs; reverting is one line.

### Also here

Adds `ci-docker-web-workflow.test.ts` to the PR-CI guard step #5090 introduces — it has the same `readFileSync` blind spot and was never running on PRs either.

### Post-merge

Reclaim the orphaned blobs explicitly (they age out otherwise):

```
gh api --paginate --slurp "repos/boardsesh/boardsesh/actions/caches?per_page=100" \
  | jq -r '.[].actions_caches[] | select(.key|test("^(index-(backend|sync)-main|buildkit-blob)")) | .id' \
  | xargs -I{} gh api -X DELETE "repos/boardsesh/boardsesh/actions/caches/{}"
```

The first deploy after merge writes the cache and is still cold; the second is the one to measure.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.
2. After merge: second deploy's `build-backend` log shows `importing cache manifest from ghcr.io`.
3. `exporting cache to gha` no longer appears in the build log.

## Risk

Risk: 2/5 — build-time caching only, no application code and no deploy-topology change. `ignore-error=true` means a registry hiccup degrades to a cold build rather than failing a release; the worst realistic outcome is a build that is no faster than today.

