### PR TITLE
perf(ci): drop setup-vp from the deploy build jobs, bound every job

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -94,6 +94,7 @@ env:
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read
@@ -148,6 +149,7 @@ jobs:
   # and fires notify-failure rather than guessing at what was meant.
   resolve-web-targets:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     environment: Production
     outputs:
       web_railway: ${{ steps.resolve.outputs.web_railway }}
@@ -227,6 +229,7 @@ jobs:
       && needs.detect-changes.outputs.web_changed == 'true'
       && (needs.sync-static-assets.result == 'success' || needs.sync-static-assets.result == 'skipped')
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     environment: Production
     permissions:
       contents: read
@@ -239,10 +242,11 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
-        with:
-          node-version: '22.x'
-          cache: true
+      # No setup-vp. This job's only `vp` use was `vp run docker-context:web`,
+      # and that task is literally `node scripts/create-service-docker-context.mjs
+      # web` (vite.config.ts) — a script that imports node: builtins only and is
+      # written to run before any install. Restoring the vp toolchain cost a
+      # measured 35s and bought this job nothing.
 
       # --- The GHCR web image -------------------------------------------------
       # Deliberately UNGATED by WEB_DEPLOY_TARGETS. The image is the artifact:
@@ -275,7 +279,12 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Generate web Docker context
-        run: vp run docker-context:web
+        # Not `vp run docker-context:web`: that vp task is exactly this command
+        # (vite.config.ts), and calling node directly lets the job skip a 35s
+        # toolchain restore it needs for nothing else. Pinned by
+        # scripts/check-service-deploy-inputs.mjs, which now asserts the real
+        # command rather than a task alias.
+        run: node scripts/create-service-docker-context.mjs web
 
       # The image is UNGATED by WEB_DEPLOY_TARGETS (always builds, see the
       # comment above), so this guard is the only thing standing between a blank
@@ -371,6 +380,7 @@ jobs:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.backend_changed == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment: Production
     permissions:
       contents: read
@@ -383,10 +393,8 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
-        with:
-          node-version: '22.x'
-          cache: true
+      # No setup-vp — see the note in build-web. The context generator is plain
+      # node with no dependencies.
 
       - name: Log in to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
@@ -413,7 +421,8 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Generate backend Docker context
-        run: vp run docker-context:backend
+        # See the note in build-web's equivalent step.
+        run: node scripts/create-service-docker-context.mjs backend
 
       - name: Build and push backend image
         id: build
@@ -460,6 +469,7 @@ jobs:
       && (needs.sync-static-assets.result == 'success' || needs.sync-static-assets.result == 'skipped')
       && !(needs.build-web.result == 'skipped' && needs.build-backend.result == 'skipped')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: Production
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -482,6 +492,7 @@ jobs:
     needs: [detect-changes, build-backend, migrate]
     if: always() && needs.detect-changes.outputs.backend_changed == 'true' && needs.build-backend.result == 'success' && needs.migrate.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     environment: Production
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -557,17 +568,19 @@ jobs:
       && (needs.detect-changes.outputs.backend_changed != 'true' || needs.deploy-production-backend.result == 'success')
       && (needs.detect-changes.outputs.cloudflare_changed != 'true' || needs.deploy-cloudflare.result == 'success')
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     environment: Production
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       # The smoke below is a .ts file run by plain `node` (type stripping), so
-      # this job needs the pinned Node 22.x that setup-vp installs — and the
-      # composite action's poll runs a repo script from the checkout above.
-      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
+      # this job needs a pinned Node 22.x — and the composite action's poll runs
+      # a repo script from the checkout above. setup-node rather than setup-vp:
+      # this job runs no `vp` command, and setup-vp additionally restores the vp
+      # toolchain cache, a measured 35s for a job that only needs a node binary.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22.x'
-          cache: true
 
       - name: Show image being deployed
         run: |
@@ -670,6 +683,7 @@ jobs:
     if: >-
       needs.detect-changes.outputs.cloudflare_changed == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: Production
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -708,6 +722,7 @@ jobs:
     needs: [detect-changes, sync-static-assets]
     if: always() && needs.detect-changes.outputs.app_changed == 'true' && (needs.sync-static-assets.result == 'success' || needs.sync-static-assets.result == 'skipped') && vars.APP_WEB_DEPLOY_HOLD == ''
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: Production
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -1028,6 +1043,7 @@ jobs:
     needs: [detect-changes, sync-static-assets]
     if: always() && needs.detect-changes.outputs.app_changed == 'true' && (needs.sync-static-assets.result == 'success' || needs.sync-static-assets.result == 'skipped') && vars.APP_WEB_DEPLOY_HOLD != ''
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     environment: Production
     steps:
       - name: Notify Discord (app.boardsesh.com deploy held)
@@ -1060,6 +1076,7 @@ jobs:
       && needs.resolve-web-targets.outputs.web_targets == 'none'
       && needs.build-web.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     environment: Production
     steps:
       - name: Notify Discord (www deploy held)
@@ -1104,6 +1121,7 @@ jobs:
       always()
       && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     environment: Production
     steps:
       - name: Notify Discord
@@ -1169,6 +1187,7 @@ jobs:
       needs.deploy-production-backend.result == 'success' || needs.deploy-cloudflare.result == 'success' ||
       needs.deploy-app-web.result == 'success')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: Production
     permissions:
       # Need contents:read to fetch full history and pull-requests:read so

--- a/.github/workflows/sync-deploy.yml
+++ b/.github/workflows/sync-deploy.yml
@@ -41,10 +41,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: voidzero-dev/setup-vp@v1
-        with:
-          node-version: '22.x'
-          cache: true
+      # No setup-vp. This job's only `vp` use was `vp run docker-context:sync`,
+      # and that task is literally the node command below — a script importing
+      # node: builtins only. Restoring the vp toolchain cost ~35s for nothing.
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -71,7 +70,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Generate sync Docker context
-        run: vp run docker-context:sync
+        run: node scripts/create-service-docker-context.mjs sync
 
       - name: Build and push sync image
         id: build

--- a/scripts/__tests__/production-deploy-web-targets.test.ts
+++ b/scripts/__tests__/production-deploy-web-targets.test.ts
@@ -174,7 +174,7 @@ describe('production-deploy web deploy targets', () => {
   });
 
   it('builds the generated context, pushes it, and attests it', () => {
-    expect(buildWebJob).toContain('run: vp run docker-context:web');
+    expect(buildWebJob).toContain('run: node scripts/create-service-docker-context.mjs web');
     expect(buildWebJob).toContain('context: .docker-context/web');
     expect(buildWebJob).toContain('file: .docker-context/web/Dockerfile');
     expect(buildWebJob).toContain('push: true');
@@ -325,6 +325,25 @@ describe('production-deploy web deploy targets', () => {
     expect(backendRecoveryFailureStep).toContain('verified automatic rollback restored');
     expect(backendRecoveryFailureStep).toContain('automatic recovery was not verified');
     expect(backendRecoveryFailureStep).toContain('exit 1');
+  });
+
+  it('bounds every job, so a hung one cannot hold the concurrency group for six hours', () => {
+    // `concurrency: production-deploy` with `cancel-in-progress: false` means a
+    // job that hangs blocks EVERY later deploy for GitHub's 6-hour default.
+    // That is the wedge docs/production-deploy.md's runbook and
+    // production-deploy-watchdog.mjs exist to clean up after; bounding the jobs
+    // stops most of it happening. The watchdog only cancels a run that is
+    // PARKED — a job that is genuinely executing and hung is not, so the
+    // timeout is the only thing that ends it.
+    // Scoped to the `jobs:` section: the `on:` block also has two-space keys
+    // (`push:`, `workflow_dispatch:`) and they are not jobs.
+    const jobsSection = workflowSource.slice(workflowSource.indexOf('\njobs:\n'));
+    const jobNames = [...jobsSection.matchAll(/^ {2}([a-z][\w-]*):$/gm)].map(([, name]) => name);
+    expect(jobNames.length).toBeGreaterThan(10);
+    for (const jobName of jobNames) {
+      const job = mappingEntry(workflowSource, jobName, 2);
+      expect(job, jobName).toMatch(/^ {4}timeout-minutes: \d+$/m);
+    }
   });
 
   it('pins every external action in the credentialed production workflow to a full commit', () => {

--- a/scripts/check-service-deploy-inputs.mjs
+++ b/scripts/check-service-deploy-inputs.mjs
@@ -327,7 +327,7 @@ function createServiceDeployInputFailures({ repoRoot = defaultRepoRoot } = {}) {
     failures,
     repoRoot,
     '.github/workflows/production-deploy.yml',
-    'vp run docker-context:backend',
+    'node scripts/create-service-docker-context.mjs backend',
     'Production deploy must generate the backend Docker context before building.',
   );
   requireFileIncludes(
@@ -341,7 +341,7 @@ function createServiceDeployInputFailures({ repoRoot = defaultRepoRoot } = {}) {
     failures,
     repoRoot,
     '.github/workflows/production-deploy.yml',
-    'vp run docker-context:web',
+    'node scripts/create-service-docker-context.mjs web',
     'Production deploy must generate the web Docker context before building.',
   );
   requireFileIncludes(

--- a/scripts/check-service-deploy-inputs.test.mjs
+++ b/scripts/check-service-deploy-inputs.test.mjs
@@ -144,10 +144,10 @@ function createFixtureRepo() {
       'run: vp run upload:static-assets',
       "needs.sync-static-assets.result == 'success' || needs.sync-static-assets.result == 'skipped'",
       'SYNC_STATIC_ASSETS: ${{ needs.sync-static-assets.result }}',
-      'run: vp run docker-context:backend',
+      'run: node scripts/create-service-docker-context.mjs backend',
       'context: .docker-context/backend',
       'file: .docker-context/backend/Dockerfile',
-      'run: vp run docker-context:web',
+      'run: node scripts/create-service-docker-context.mjs web',
       'context: .docker-context/web',
       'file: .docker-context/web/Dockerfile',
       'uses: ./.github/actions/railway-redeploy',
@@ -454,7 +454,11 @@ void test('requires the production web build to use the generated Docker context
     const workflowPath = '.github/workflows/production-deploy.yml';
     const original = readFileSync(join(repoRoot, workflowPath), 'utf8');
 
-    writeFixtureFile(repoRoot, workflowPath, original.replace('run: vp run docker-context:web\n', ''));
+    writeFixtureFile(
+      repoRoot,
+      workflowPath,
+      original.replace('run: node scripts/create-service-docker-context.mjs web\n', ''),
+    );
     assert.match(createServiceDeployInputFailures({ repoRoot }).join('\n'), /generate the web Docker context/);
 
     writeFixtureFile(repoRoot, workflowPath, original.replace('context: .docker-context/web\n', ''));


### PR DESCRIPTION
## Summary

Stacked on #5093. Two independent wins in the deploy workflow.

### 1. Three jobs restored the vp toolchain for nothing (−35s each)

`build-web`, `build-backend` and `sync-deploy`'s `build-sync` each used exactly one `vp` command: `vp run docker-context:<svc>`. That task is *literally* `node scripts/create-service-docker-context.mjs <svc>` (`vite.config.ts:616`), and the script imports `node:fs`, `node:path`, `node:url` and nothing else — it is deliberately written to run before any install, with a hand-rolled YAML reader for exactly that reason.

So `setup-vp` was buying a 35s toolchain restore and nothing else. Once #5090 removed the Vercel half of `build-web`, that was the last `vp` use in all three.

`deploy-web-railway` runs **no** `vp` command at all — its `setup-vp` existed only for the pinned Node 22.x that `node scripts/production-smoke.ts` needs for type stripping. `actions/setup-node` gives it that without restoring a ~615 MB toolchain cache.

Jobs that genuinely use `vp` keep it: `sync-static-assets`, `migrate`, `deploy-cloudflare`, `deploy-app-web`.

**The coupling this had to clear:** `scripts/check-service-deploy-inputs.mjs:330,344` pinned the literal string `vp run docker-context:web`. It now pins the node command instead, which makes the guard *stronger* — it pins the command that actually runs rather than a task alias that could be redefined out from under it. The `branch-deploy.yml` assertions are untouched; that workflow keeps `vp`.

### 2. Every job is now bounded (reliability, not tidiness)

Only `sync-static-assets` had `timeout-minutes`. Under `concurrency: production-deploy` with `cancel-in-progress: false`, **a job that hangs holds the group for GitHub's 6-hour default and blocks every later deploy.**

That is the exact wedge `docs/production-deploy.md`'s runbook and `production-deploy-watchdog.mjs` exist to clean up after — and the watchdog only cancels a run that is **parked**. A job that is genuinely executing and hung is not parked, so the timeout is the only thing that ends it.

| Job | Observed | Bound |
|---|---|---|
| `build-web` | ~4m30 | 25 |
| `build-backend` | ~2m10 | 20 |
| `migrate` | 47s | 15 |
| `deploy-production-backend` / `deploy-web-railway` | ~1m50 | 25 (redeploy polls up to 90×10s) |
| `deploy-app-web` | 2m56 | 30 |
| notifies | ≤24s | 5 |

A new guard pins this. **It was mutation-tested** — removing `build-web`'s `timeout-minutes` makes it fail:

```
AssertionError: build-web: expected '  build-web:\n    needs: [detect-chan…'
  to match /^ {4}timeout-minutes: \d+$/m
```

(The first draft of that guard also matched `push:` under `on:`; it is now scoped to the `jobs:` section.)

## Expected effect

`build-web` ~4m30 → **~3m55**, `build-backend` ~2m10 → **~1m35**, and ~30s off `deploy-web-railway`, which is on the critical path. Roughly **−65s** on the run overall.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.
2. After merge: `build-web` log has no "Setup vp" step.
3. Deploy still publishes the image — `build-backend` shows `Generate backend Docker context`.

## Risk

Risk: 2/5 — removes a setup step three jobs did not use and adds timeouts. The context generator is unchanged and `check-service-deploy-inputs.mjs` verifies its output against the Dockerfiles on every PR. Worst case is a job that needed `vp` failing immediately and loudly on a missing binary, not a bad deploy.
