### PR TITLE
perf(ci): split the dependency fetch from the install in the service images

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,3 +1,10 @@
+# syntax=docker/dockerfile:1.26@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
+#
+# Pinned by digest, like every external action in this repo's workflows.
+# Without a `# syntax=` line the frontend is whatever BuildKit the runner
+# happens to ship, so a Dockerfile feature can work on one machine and fail
+# on another; with it, a feature either works everywhere or fails loudly at
+# pin-bump time.
 # Backend service - runs TypeScript directly via tsx
 FROM node:22-alpine
 
@@ -15,14 +22,45 @@ RUN npm install --global --no-fund --no-audit pnpm@11.22.0
 # workspace manifests for the pnpm install layer and only backend source after
 # it. pnpm-workspace.yaml carries the workspace globs, overrides and patches.
 COPY manifests/package.json manifests/pnpm-lock.yaml manifests/pnpm-workspace.yaml ./
-COPY manifests/packages ./packages
-# Patch files referenced by pnpm-workspace.yaml must be present before install.
+# Patch files referenced by pnpm-workspace.yaml must be present before the
+# fetch: pnpm resolves patch hashes from the lockfile and needs the files.
 COPY manifests/patches ./patches
+
+# --- the NETWORK layer -------------------------------------------------------
+# `pnpm fetch` populates the store from the LOCKFILE ALONE, so this layer's
+# cache key excludes the 49 workspace package.json files that land below. That
+# matters because they move far more often than the lockfile does: over the
+# last 3264 first-parent commits, pnpm-lock.yaml changed on 6 and a workspace
+# manifest on 225. Before this split, a version bump in any one package
+# re-resolved and re-downloaded the whole registry.
+#
+# It also splits the ~843 MB export blob into a stable lockfile-keyed layer
+# plus a small manifest-keyed delta, so a version-bump commit stops
+# re-uploading the big one.
+#
+# Same in-repo recipe as Dockerfile.ci's seed layer, which has run `pnpm fetch`
+# under this pnpm since #5008. Unlike that one, do NOT `rm -rf node_modules`
+# afterwards: fetch builds a virtual store there and runs each package's
+# install-time scripts once (canvas, sharp, esbuild), which is exactly what
+# makes the step below a hardlink relink rather than a rebuild.
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm fetch
+
+# --- the LINK layer ----------------------------------------------------------
+# The workspace manifests land AFTER the fetch, so a manifest-only change
+# relinks from the already-populated store instead of re-resolving.
+COPY manifests/packages ./packages
 
 # Keep devDependencies because tsx is the runtime TypeScript loader. The store
 # cache never enters an image layer.
+# `--offline` comes AFTER `--frozen-lockfile`, not before:
+# scripts/check-service-deploy-inputs.mjs finds this layer by the raw
+# substring `pnpm install --frozen-lockfile`, and the reversed order silently
+# fails that guard. Everything needed is already in the store from the fetch
+# above; if a package ever has to resolve outside the registry,
+# `--prefer-offline` is the one-word fallback that still satisfies the guard.
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
-    pnpm install --frozen-lockfile
+    pnpm install --frozen-lockfile --offline
 
 # Source-only edits land after install, so they do not invalidate the dependency layer.
 COPY source/packages ./packages

--- a/Dockerfile.sync
+++ b/Dockerfile.sync
@@ -1,3 +1,10 @@
+# syntax=docker/dockerfile:1.26@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
+#
+# Pinned by digest, like every external action in this repo's workflows.
+# Without a `# syntax=` line the frontend is whatever BuildKit the runner
+# happens to ship, so a Dockerfile feature can work on one machine and fail
+# on another; with it, a feature either works everywhere or fails loudly at
+# pin-bump time.
 # Long-lived Node CLIs - runs any sync CLI (kilter/aurora/moonboard) or the cron
 # scheduler directly via tsx.
 # Sibling of Dockerfile.backend. The actual command is supplied by the container
@@ -22,13 +29,44 @@ RUN npm install --global --no-fund --no-audit pnpm@11.22.0
 # workspace manifests for the pnpm install layer and only the sync packages'
 # (and their transitive workspace deps') source after it.
 COPY manifests/package.json manifests/pnpm-lock.yaml manifests/pnpm-workspace.yaml ./
-COPY manifests/packages ./packages
-# Patch files referenced by pnpm-workspace.yaml must be present before install.
+# Patch files referenced by pnpm-workspace.yaml must be present before the
+# fetch: pnpm resolves patch hashes from the lockfile and needs the files.
 COPY manifests/patches ./patches
 
-# Keep devDependencies because tsx is the runtime TypeScript loader.
+# --- the NETWORK layer -------------------------------------------------------
+# `pnpm fetch` populates the store from the LOCKFILE ALONE, so this layer's
+# cache key excludes the 49 workspace package.json files that land below. That
+# matters because they move far more often than the lockfile does: over the
+# last 3264 first-parent commits, pnpm-lock.yaml changed on 6 and a workspace
+# manifest on 225. Before this split, a version bump in any one package
+# re-resolved and re-downloaded the whole registry.
+#
+# It also splits the ~843 MB export blob into a stable lockfile-keyed layer
+# plus a small manifest-keyed delta, so a version-bump commit stops
+# re-uploading the big one.
+#
+# Same in-repo recipe as Dockerfile.ci's seed layer, which has run `pnpm fetch`
+# under this pnpm since #5008. Unlike that one, do NOT `rm -rf node_modules`
+# afterwards: fetch builds a virtual store there and runs each package's
+# install-time scripts once (canvas, sharp, esbuild), which is exactly what
+# makes the step below a hardlink relink rather than a rebuild.
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
-    pnpm install --frozen-lockfile
+    pnpm fetch
+
+# --- the LINK layer ----------------------------------------------------------
+# The workspace manifests land AFTER the fetch, so a manifest-only change
+# relinks from the already-populated store instead of re-resolving.
+COPY manifests/packages ./packages
+
+# Keep devDependencies because tsx is the runtime TypeScript loader.
+# `--offline` comes AFTER `--frozen-lockfile`, not before:
+# scripts/check-service-deploy-inputs.mjs finds this layer by the raw
+# substring `pnpm install --frozen-lockfile`, and the reversed order silently
+# fails that guard. Everything needed is already in the store from the fetch
+# above; if a package ever has to resolve outside the registry,
+# `--prefer-offline` is the one-word fallback that still satisfies the guard.
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm install --frozen-lockfile --offline
 
 # Source-only edits land after install, so they do not invalidate the dependency layer.
 COPY source/packages ./packages

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,3 +1,10 @@
+# syntax=docker/dockerfile:1.26@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
+#
+# Pinned by digest, like every external action in this repo's workflows.
+# Without a `# syntax=` line the frontend is whatever BuildKit the runner
+# happens to ship, so a Dockerfile feature can work on one machine and fail
+# on another; with it, a feature either works everywhere or fails loudly at
+# pin-bump time.
 # Stage 1: Install dependencies and build the Next.js application.
 #
 # pnpm's isolated linker creates per-workspace node_modules symlink farms. Keep
@@ -17,13 +24,44 @@ RUN npm install --global --no-fund --no-audit pnpm@11.22.0
 # workspace manifests for the pnpm install layer and only web build source after
 # it. pnpm-workspace.yaml carries workspace globs, overrides and patch metadata.
 COPY manifests/package.json manifests/pnpm-lock.yaml manifests/pnpm-workspace.yaml ./
-COPY manifests/packages ./packages
-# Patch files referenced by pnpm-workspace.yaml must be present before install.
+# Patch files referenced by pnpm-workspace.yaml must be present before the
+# fetch: pnpm resolves patch hashes from the lockfile and needs the files.
 COPY manifests/patches ./patches
 
-# Install all dependencies because the build uses root development tooling.
+# --- the NETWORK layer -------------------------------------------------------
+# `pnpm fetch` populates the store from the LOCKFILE ALONE, so this layer's
+# cache key excludes the 49 workspace package.json files that land below. That
+# matters because they move far more often than the lockfile does: over the
+# last 3264 first-parent commits, pnpm-lock.yaml changed on 6 and a workspace
+# manifest on 225. Before this split, a version bump in any one package
+# re-resolved and re-downloaded the whole registry.
+#
+# It also splits the ~843 MB export blob into a stable lockfile-keyed layer
+# plus a small manifest-keyed delta, so a version-bump commit stops
+# re-uploading the big one.
+#
+# Same in-repo recipe as Dockerfile.ci's seed layer, which has run `pnpm fetch`
+# under this pnpm since #5008. Unlike that one, do NOT `rm -rf node_modules`
+# afterwards: fetch builds a virtual store there and runs each package's
+# install-time scripts once (canvas, sharp, esbuild), which is exactly what
+# makes the step below a hardlink relink rather than a rebuild.
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
-    pnpm install --frozen-lockfile
+    pnpm fetch
+
+# --- the LINK layer ----------------------------------------------------------
+# The workspace manifests land AFTER the fetch, so a manifest-only change
+# relinks from the already-populated store instead of re-resolving.
+COPY manifests/packages ./packages
+
+# Install all dependencies because the build uses root development tooling.
+# `--offline` comes AFTER `--frozen-lockfile`, not before:
+# scripts/check-service-deploy-inputs.mjs finds this layer by the raw
+# substring `pnpm install --frozen-lockfile`, and the reversed order silently
+# fails that guard. Everything needed is already in the store from the fetch
+# above; if a package ever has to resolve outside the registry,
+# `--prefer-offline` is the one-word fallback that still satisfies the guard.
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm install --frozen-lockfile --offline
 
 # Source-only edits land after install, so they do not invalidate the dependency layer.
 # COPY merges into the installed workspace directories, preserving the

--- a/scripts/check-service-deploy-inputs.mjs
+++ b/scripts/check-service-deploy-inputs.mjs
@@ -117,6 +117,38 @@ function requireDockerContextFile(failures, repoRoot, dockerfilePath) {
     }
   }
 
+  // The fetch/install split, pinned. `pnpm fetch` resolves the whole dependency
+  // graph from the LOCKFILE alone, so keeping it ABOVE `manifests/packages` is
+  // what stops a version bump in any one of the 49 workspace manifests
+  // re-downloading the registry. Measured on Dockerfile.backend: with the split,
+  // such a bump leaves the fetch layer CACHED and the install drops from ~47s to
+  // ~5s.
+  //
+  // This has to be a check rather than a comment because collapsing the two
+  // COPYs back together is a natural-looking tidy-up that every other assertion
+  // in this function would still pass — the benefit would vanish silently.
+  const fetchIndex = indexOfInstruction(dockerfileContents, 'pnpm fetch');
+  if (fetchIndex === -1) {
+    failures.push(`${dockerfilePath}: missing the \`pnpm fetch\` layer that keys on the lockfile alone`);
+  } else {
+    if (fetchIndex > installIndex) {
+      failures.push(`${dockerfilePath}: \`pnpm fetch\` must run before the install layer`);
+    }
+    const manifestPackagesIndex = indexOfInstruction(dockerfileContents, manifestPackagesCopy);
+    if (manifestPackagesIndex !== -1 && manifestPackagesIndex < fetchIndex) {
+      failures.push(
+        `${dockerfilePath}: ${manifestPackagesCopy} must come AFTER \`pnpm fetch\`, ` +
+          'otherwise the fetch layer keys on all 49 workspace manifests and one version bump re-downloads everything',
+      );
+    }
+    for (const preFetchCopy of [manifestRootCopy, 'COPY manifests/patches ./patches']) {
+      const preFetchIndex = indexOfInstruction(dockerfileContents, preFetchCopy);
+      if (preFetchIndex !== -1 && preFetchIndex > fetchIndex) {
+        failures.push(`${dockerfilePath}: ${preFetchCopy} must appear before \`pnpm fetch\``);
+      }
+    }
+  }
+
   if (indexOfInstruction(dockerfileContents, sourcePackagesCopy) === -1) {
     failures.push(`${dockerfilePath}: missing ${sourcePackagesCopy}`);
   }

--- a/scripts/check-service-deploy-inputs.test.mjs
+++ b/scripts/check-service-deploy-inputs.test.mjs
@@ -60,10 +60,17 @@ function dockerfileLines(extraLines = []) {
     'FROM node:22-alpine',
     `RUN npm install --global --no-fund --no-audit pnpm@${PINNED_PNPM_VERSION}`,
     'COPY manifests/package.json manifests/pnpm-lock.yaml manifests/pnpm-workspace.yaml ./',
-    'COPY manifests/packages ./packages',
+    // extraLines is where callers put the patches COPY, which the real
+    // Dockerfiles keep above the fetch — patch hashes are resolved from the
+    // lockfile, so the files have to be there before it runs.
     ...extraLines,
     'RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \\',
-    '    pnpm install --frozen-lockfile',
+    '    pnpm fetch',
+    // AFTER the fetch, mirroring the real Dockerfiles: the fetch layer must key
+    // on the lockfile alone, not on all 49 workspace manifests.
+    'COPY manifests/packages ./packages',
+    'RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \\',
+    '    pnpm install --frozen-lockfile --offline',
     'COPY source/packages ./packages',
     '',
   ].join('\n');


### PR DESCRIPTION
## Summary

Stacked on #5094. The three service images re-resolved and re-downloaded the **entire registry** whenever any one of the 49 workspace `package.json` files changed, because the manifests and the lockfile fed a single layer.

Splitting fixes the cache key: `pnpm fetch` populates the store from the **lockfile alone**, so it goes above the workspace manifests, and the offline install below only has to relink.

Over the last 3264 first-parent commits, `pnpm-lock.yaml` changed on **6** and a workspace manifest on **225**. The common case is exactly the one that used to pay full price.

### Verified with a real local build, not reasoning

Built `Dockerfile.backend`, bumped one workspace manifest version, rebuilt:

```
#12 RUN ... pnpm fetch                                CACHED
#13 COPY manifests/packages ./packages                DONE 0.5s
#14 RUN ... pnpm install --frozen-lockfile --offline  DONE 5.3s
```

**5.3s against a measured 47.1s.** The fetch layer survived a manifest change, which is the whole point.

`Dockerfile.sync` was built the same way and shares the entire prefix (every layer cached off the backend build - the three images now have one common install prefix). `Dockerfile.web`'s build is covered by `ci.yml`'s `docker-web` job, which builds it on every PR touching `Dockerfile.web`.

**The open question from planning is settled:** `pnpm fetch` needs no workspace manifests at all. If a package ever has to resolve outside the registry, `--prefer-offline` is a one-word fallback that still satisfies the guard.

### Two details that are easy to get wrong - both now pinned, not commented

**`manifests/packages` must come AFTER the fetch.** Collapsing the two `COPY`s back together is a natural-looking tidy-up that every other assertion in `check-service-deploy-inputs.mjs` would still pass, and the benefit would vanish silently. Mutation-tested:

```
Dockerfile.backend: COPY manifests/packages ./packages must come AFTER `pnpm fetch`,
otherwise the fetch layer keys on all 49 workspace manifests and one version bump
re-downloads everything
```

**`--offline` must come AFTER `--frozen-lockfile`.** The guard locates the layer by raw substring, so the reversed order reports "missing frozen install layer" instead of anything useful.

### Also

- Digest-pinned `# syntax=docker/dockerfile:1.26` on all three files. None had one, so the frontend was whatever BuildKit the runner happened to ship - a feature could work on one machine and fail on another. Pinned by digest, matching how this repo pins external actions. (Digest verified live against `docker/dockerfile:1`.)
- The split also breaks the ~843 MB export blob into a stable lockfile-keyed layer plus a small manifest-keyed delta, so a version-bump commit stops re-uploading the big one. That export is CPU-bound gzip, so it is real wall time.

### Deliberately not done

**No production-only prune on the backend.** `node --import tsx src/index.ts` makes `tsx` a runtime dependency, so pruning devDependencies yields an image that does not boot. The registry cache in #5093 already makes that layer's size irrelevant to build time, which was the actual goal.

**No `COPY --link`.** On the web runner stage it buys 2-5s against a 161.8 MB export while changing intermediate-directory ownership on a service where a cookie/origin regression already caused a fleet-wide logout (#4651). On the backend, the release-stamp `RUN` immediately after forces materialisation anyway, so it buys nothing.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green - `docker-web` builds the web image with the new layers.
2. After merge: a deploy whose commit changes no `package.json` shows the fetch layer `CACHED`.
3. Backend image still boots - deploy healthcheck `/health` passes.

## Risk

Risk: 3/5 - changes how every service image installs dependencies. Mitigated by a real local build of two of the three images (the third builds in CI), a mutation-tested ordering guard, and a one-word fallback (`--prefer-offline`) if `--offline` ever proves too strict. A failure here is loud at build time, not silent at runtime.
