### PR TITLE
perf(ci): build the deploy images on a persistent BuildKit daemon

### DIFF
--- a/.github/workflows/ci-runner-watchdog.yml
+++ b/.github/workflows/ci-runner-watchdog.yml
@@ -77,11 +77,30 @@ jobs:
             exit 1
           fi
 
-          current="$(gh api "repos/${REPO}/actions/variables/CI_RUNNER_LINUX" \
-            --jq '.value' 2>/dev/null || echo '')"
+          # BOTH routing variables. DEPLOY_RUNNER_LINUX sends
+          # production-deploy.yml's build jobs to the same hosts, and it has a
+          # nastier failure mode than CI's: `runs-on` resolves at DISPATCH, so a
+          # queued fleet job holds the `production-deploy` concurrency group
+          # (cancel-in-progress: false) and every later push to main queues
+          # behind it, silently — notify-failure never fires because nothing
+          # failed. production-deploy-watchdog.yml does cancel a run parked like
+          # that, but only after 45 minutes and only once per head SHA, and its
+          # single re-dispatch re-resolves `runs-on` from this variable. So this
+          # watchdog's 10-minute cadence has to have already reset it, or that
+          # one retry lands back on the dead fleet and there is no second chance.
+          routing_variables=(CI_RUNNER_LINUX DEPLOY_RUNNER_LINUX)
 
-          if [ -z "$current" ] || [ "$current" = '"ubuntu-latest"' ]; then
-            echo "CI_RUNNER_LINUX is already the GitHub-hosted fallback; nothing to do."
+          needs_failback=false
+          for variable in "${routing_variables[@]}"; do
+            value="$(gh api "repos/${REPO}/actions/variables/${variable}" \
+              --jq '.value' 2>/dev/null || echo '')"
+            if [ -n "$value" ] && [ "$value" != '"ubuntu-latest"' ]; then
+              needs_failback=true
+            fi
+          done
+
+          if [ "$needs_failback" = 'false' ]; then
+            echo "CI_RUNNER_LINUX and DEPLOY_RUNNER_LINUX are already the GitHub-hosted fallback; nothing to do."
             exit 0
           fi
 
@@ -176,13 +195,22 @@ jobs:
           # only cancels; every message below says plainly that a manual
           # re-run is required.
           if [ "${DRY_RUN:-false}" = 'true' ]; then
-            echo "Dry run: would set CI_RUNNER_LINUX to \"ubuntu-latest\" and cancel ${#fleet_bound_run_ids[@]} queued run(s) bound to bs-ci (of ${inspected_count} inspected). Cancelling does not re-dispatch them -- they would still need a manual re-run or a new push."
+            echo "Dry run: would set CI_RUNNER_LINUX and DEPLOY_RUNNER_LINUX to \"ubuntu-latest\" and cancel ${#fleet_bound_run_ids[@]} queued run(s) bound to bs-ci (of ${inspected_count} inspected). Cancelling does not re-dispatch them -- they would still need a manual re-run or a new push."
             exit 0
           fi
 
           # 1. Stop new work being dispatched to labels nothing answers.
-          gh api -X PATCH "repos/${REPO}/actions/variables/CI_RUNNER_LINUX" \
-            -f name=CI_RUNNER_LINUX -f value='"ubuntu-latest"'
+          #    A variable that has never been created 404s; that is a no-op, not
+          #    a failure, so the loop warns and continues rather than aborting
+          #    before it has reset the other one.
+          for variable in "${routing_variables[@]}"; do
+            if gh api -X PATCH "repos/${REPO}/actions/variables/${variable}" \
+              -f "name=${variable}" -f value='"ubuntu-latest"'; then
+              echo "Reset ${variable} to the GitHub-hosted fallback."
+            else
+              echo "::warning::Could not reset ${variable} (it may not exist yet); continuing."
+            fi
+          done
 
           # 2. Cancel what is already queued and bound to the dead fleet.
           #    Those jobs resolved their runs-on at dispatch, so the variable

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -228,7 +228,16 @@ jobs:
       always()
       && needs.detect-changes.outputs.web_changed == 'true'
       && (needs.sync-static-assets.result == 'success' || needs.sync-static-assets.result == 'skipped')
-    runs-on: ubuntu-latest
+    # Deliberately NOT `vars.CI_RUNNER_LINUX`. The CI fleet and the deploy fleet
+    # are different decisions: taking CI off the homelab because a VM rebooted
+    # must not silently move where production images are built, and taking the
+    # deploy builds off the fleet after a security review must not cost the CI
+    # speedup. No fork clause either — this workflow has no pull_request trigger,
+    # so the CI expression's fork branch would be dead code here.
+    #
+    # Unset (the default) means ubuntu-latest, so merging this changes nothing.
+    # See docs/production-deploy.md for what flipping it costs and how to revert.
+    runs-on: ${{ fromJSON(vars.DEPLOY_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 25
     environment: Production
     permissions:
@@ -261,7 +270,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
+      # The fleet's BuildKit daemon outlives the ephemeral job container, so
+      # `--mount=type=cache` finally survives between deploys. Fails the job if
+      # the daemon will not start: a red deploy with a clear error beats one
+      # that quietly falls back to a cold builder and looks fine.
+      - name: Ensure the persistent BuildKit daemon is running on this host
+        if: runner.environment == 'self-hosted'
+        run: bash scripts/ci/ensure-buildkitd.sh
+
+      # `driver: remote`, NOT docker-container. This action's post step runs
+      # `docker buildx rm`, which for the docker-container driver would delete
+      # the shared daemon and its cache; for remote it removes only the local
+      # instance record.
+      - name: Set up Docker Buildx (persistent fleet builder)
+        if: runner.environment == 'self-hosted'
+        id: buildx-fleet
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        with:
+          driver: remote
+          endpoint: docker-container://boardsesh-buildkitd-deploy
+
+      - name: Set up Docker Buildx (GitHub-hosted)
+        if: runner.environment == 'github-hosted'
+        id: buildx-hosted
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Extract web image metadata
@@ -304,6 +335,7 @@ jobs:
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
+          builder: ${{ steps.buildx-fleet.outputs.name || steps.buildx-hosted.outputs.name }}
           context: .docker-context/web
           file: .docker-context/web/Dockerfile
           push: true
@@ -379,7 +411,16 @@ jobs:
   build-backend:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.backend_changed == 'true'
-    runs-on: ubuntu-latest
+    # Deliberately NOT `vars.CI_RUNNER_LINUX`. The CI fleet and the deploy fleet
+    # are different decisions: taking CI off the homelab because a VM rebooted
+    # must not silently move where production images are built, and taking the
+    # deploy builds off the fleet after a security review must not cost the CI
+    # speedup. No fork clause either — this workflow has no pull_request trigger,
+    # so the CI expression's fork branch would be dead code here.
+    #
+    # Unset (the default) means ubuntu-latest, so merging this changes nothing.
+    # See docs/production-deploy.md for what flipping it costs and how to revert.
+    runs-on: ${{ fromJSON(vars.DEPLOY_RUNNER_LINUX || '"ubuntu-latest"') }}
     timeout-minutes: 20
     environment: Production
     permissions:
@@ -403,7 +444,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
+      # The fleet's BuildKit daemon outlives the ephemeral job container, so
+      # `--mount=type=cache` finally survives between deploys. Fails the job if
+      # the daemon will not start: a red deploy with a clear error beats one
+      # that quietly falls back to a cold builder and looks fine.
+      - name: Ensure the persistent BuildKit daemon is running on this host
+        if: runner.environment == 'self-hosted'
+        run: bash scripts/ci/ensure-buildkitd.sh
+
+      # `driver: remote`, NOT docker-container. This action's post step runs
+      # `docker buildx rm`, which for the docker-container driver would delete
+      # the shared daemon and its cache; for remote it removes only the local
+      # instance record.
+      - name: Set up Docker Buildx (persistent fleet builder)
+        if: runner.environment == 'self-hosted'
+        id: buildx-fleet
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        with:
+          driver: remote
+          endpoint: docker-container://boardsesh-buildkitd-deploy
+
+      - name: Set up Docker Buildx (GitHub-hosted)
+        if: runner.environment == 'github-hosted'
+        id: buildx-hosted
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Extract metadata
@@ -428,6 +491,7 @@ jobs:
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
+          builder: ${{ steps.buildx-fleet.outputs.name || steps.buildx-hosted.outputs.name }}
           context: .docker-context/backend
           file: .docker-context/backend/Dockerfile
           push: true

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -129,7 +129,29 @@ RUN if [ "${#BOARDSESH_BUILD_RELEASE}" -ne 40 ]; then \
 # `|| true` keeps the value empty when nothing is mounted (ci.yml's build-only
 # job, branch-deploy, a local build), and withSentryConfig skips the source-map
 # upload on an empty token rather than failing the build.
+#
+# The .next/cache mount is what makes `next build` incremental. Next 16 builds
+# with Turbopack, and `experimental.turbopackFileSystemCacheForBuild` DEFAULTS
+# TO TRUE (verified in the installed next@16.3.2: config-shared.d.ts's resolved
+# default map, and next-post-build.js computing `<distDir>/cache/turbopack`).
+# packages/web/next.config.mjs sets no distDir, so the database lands exactly
+# here — and until now it was written and thrown away on every single build.
+#
+# `sharing=locked`, not the default `shared`: that cache is a DATABASE, not a
+# content-addressed store, and two builds writing it concurrently risks
+# corruption. `concurrency: production-deploy` already serialises deploys, but
+# on a persistent builder concurrency stops being hypothetical.
+#
+# This only pays off on a builder that outlives the job — see
+# scripts/ci/ensure-buildkitd.sh. On a GitHub-hosted runner the mount is created
+# empty and discarded, exactly as the pnpm-store mount is, which costs nothing.
+#
+# The trade to be aware of: cache-mount contents are never part of a layer,
+# never exported by any `cache-to` backend, and not covered by this job's
+# provenance attestation. The image now depends on host state. That was already
+# true of the pnpm-store mount; it is worth writing down rather than discovering.
 RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN \
+    --mount=type=cache,id=next-turbopack-web,target=/app/packages/web/.next/cache,sharing=locked \
     SENTRY_AUTH_TOKEN="$(cat /run/secrets/SENTRY_AUTH_TOKEN 2>/dev/null || true)" \
     pnpm --filter @boardsesh/web run build
 

--- a/docs/production-deploy.md
+++ b/docs/production-deploy.md
@@ -456,6 +456,87 @@ served as the warm rollback during the cut-over window is gone. Steps 2 and 3
 above — the dashboard rollback and the immutable `:sha-<short>` retag — are the
 web rollback levers.
 
+## Where the images are built
+
+`build-web` and `build-backend` run on GitHub-hosted runners by default. They
+can be moved to the self-hosted `bs-ci` fleet by setting the Production-
+environment variable `DEPLOY_RUNNER_LINUX` to `["self-hosted","bs-ci"]`; unset
+means `ubuntu-latest`, so the wiring merging changed nothing.
+
+### Why a second variable
+
+`CI_RUNNER_LINUX` routes CI. This is deliberately separate, because the two are
+different decisions: taking CI off the homelab because a VM rebooted must not
+silently move where production images are built, and taking the deploy builds
+off the fleet after a security review must not cost the CI speedup.
+
+### What it buys
+
+A BuildKit daemon that outlives the ephemeral job container, so
+`--mount=type=cache` finally survives between deploys — the pnpm store, and
+Turbopack's build database for `next build`. `scripts/ci/ensure-buildkitd.sh`
+starts it as a sibling container on the host via the bind-mounted docker socket;
+`scripts/ci/buildkitd.toml` bounds its disk. It attaches with buildx's `remote`
+driver, **not** `docker-container`: `docker/setup-buildx-action`'s post step runs
+`docker buildx rm`, which under the docker-container driver would delete the
+shared daemon and its cache.
+
+The daemon is per host, and there are two (`bs-ci-1`, `bs-ci-2`), so roughly half
+of deploys land on a cold one. The registry cache covers that case — the
+expensive layers are the stable ones — which is why it is one daemon per host
+rather than a shared one or a pinned host.
+
+### What it costs, stated plainly
+
+`scripts/__tests__/ci-self-hosted-secret-boundary.test.ts` holds the invariant
+that no fleet-routed job may carry a secret other than `GITHUB_TOKEN` or declare
+an `environment:`, because *"a self-hosted runner has no meaningful boundary
+between a job and the host… the only durable mitigation is that there is nothing
+on the fleet worth stealing"*. These two jobs are the one deliberate exception,
+and the test now carries a named allowlist saying so rather than being blind to
+them.
+
+Concretely: anyone who can get a step onto `bs-ci` can obtain
+`SENTRY_AUTH_TOKEN` and a `packages: write` `GITHUB_TOKEN` — i.e. the ability to
+move the `:production` GHCR tag Railway pulls. Fork PRs cannot reach the fleet,
+so that is people with write access, not the internet. `DATABASE_URL` (`migrate`)
+and `RAILWAY_TOKEN` (every deploy job) stay GitHub-hosted, and a test asserts it.
+
+The end state is a separate `bs-deploy` host that never runs PR code — an
+Ansible change in `marcodejongh/blackheathdc-ansible`. Until then, the allowlist
+is the whole exception.
+
+### Turning it off
+
+Set `DEPLOY_RUNNER_LINUX` to `"ubuntu-latest"` (or delete it). No deploy needed.
+
+`ci-runner-watchdog.yml` does this automatically when no self-hosted runner is
+online, resetting **both** routing variables. That matters more here than for
+CI: `runs-on` resolves at dispatch, so a queued fleet job holds the
+`production-deploy` concurrency group (`cancel-in-progress: false`) and every
+later push queues behind it silently — `notify-failure` never fires because
+nothing failed. `production-deploy-watchdog.yml` cancels a run parked that way,
+but only after 45 minutes and only once per head SHA, and its single re-dispatch
+re-resolves `runs-on` from the variable — so the 10-minute watchdog has to have
+already reset it.
+
+### Reclaiming disk on a fleet host
+
+`docker system prune -af` reclaims **none** of the BuildKit state: it lives in a
+docker volume held by a running container.
+
+```
+docker exec boardsesh-buildkitd-deploy buildctl du -v
+docker exec boardsesh-buildkitd-deploy buildctl prune --reserved-space 10GB --verbose
+```
+
+Nuclear (next deploy on that host is cold, nothing else breaks):
+
+```
+docker rm -f boardsesh-buildkitd-deploy
+docker volume rm boardsesh-buildkitd-deploy-state boardsesh-buildkitd-deploy-config
+```
+
 ## Migrations stay backward-compatible
 
 A rollback reverts the running web image, never the database — `migrate` has
@@ -475,6 +556,7 @@ web deploy targets:
 | Name                       | Kind   | Purpose                                                                          |
 | --------------------------- | ------ | --------------------------------------------------------------------------------- |
 | `WEB_DEPLOY_TARGETS`        | var    | `railway` (or unset) / `none` — see the table above.                             |
+| `DEPLOY_RUNNER_LINUX`       | var    | Where build-web/build-backend run. Unset = `ubuntu-latest`; see "Where the images are built". |
 | `RAILWAY_WEB_SERVICE_ID`    | var    | The Railway `web` service. Required before targeting railway.                    |
 | `RAILWAY_WEB_ORIGIN`        | var    | Direct `https://*.up.railway.app` smoke origin; custom domains are rejected.     |
 | `RAILWAY_TOKEN`             | secret | Production-environment Railway project token used by both verified deploy paths. |

--- a/scripts/__tests__/ci-runner-routing.test.ts
+++ b/scripts/__tests__/ci-runner-routing.test.ts
@@ -191,9 +191,11 @@ describe('self-hosted runner routing', () => {
       // non-zero, not zero.
       const script = watchdogScript();
       const branchStart = script.indexOf('CI_RUNNER_ADMIN_PAT is not set');
-      const branchEnd = script.indexOf('current="$(gh api', branchStart);
+      // Anchored on the routing-variable read that follows, which only runs
+      // once the PAT is known to be present.
+      const branchEnd = script.indexOf('routing_variables=(', branchStart);
       expect(branchStart, 'expected a message naming CI_RUNNER_ADMIN_PAT').toBeGreaterThan(-1);
-      expect(branchEnd, 'expected the missing-PAT branch to be followed by the CI_RUNNER_LINUX read').toBeGreaterThan(
+      expect(branchEnd, 'expected the missing-PAT branch to be followed by the routing-variable read').toBeGreaterThan(
         branchStart,
       );
 

--- a/scripts/__tests__/ci-self-hosted-secret-boundary.test.ts
+++ b/scripts/__tests__/ci-self-hosted-secret-boundary.test.ts
@@ -3,7 +3,14 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-import { githubYamlPaths, isRoutedRunsOn, isWorkflow, jobBlocks, withoutCommentLines } from './helpers/workflow-yaml';
+import {
+  githubYamlPaths,
+  isDeployRoutedRunsOn,
+  isRoutedRunsOn,
+  isWorkflow,
+  jobBlocks,
+  withoutCommentLines,
+} from './helpers/workflow-yaml';
 
 /**
  * The invariant that makes self-hosted runners acceptable at all:
@@ -30,6 +37,36 @@ import { githubYamlPaths, isRoutedRunsOn, isWorkflow, jobBlocks, withoutCommentL
  */
 
 const ALLOWED_SECRET = 'GITHUB_TOKEN';
+
+/**
+ * The ONE deliberate exception to the invariant above, written out so it is
+ * argued rather than assumed.
+ *
+ * production-deploy.yml's two image builds may run on the fleet, via the
+ * separate `DEPLOY_RUNNER_LINUX` variable, so that a BuildKit daemon which
+ * outlives the ephemeral job container can keep `--mount=type=cache` warm —
+ * the pnpm store and Turbopack's build database. That is worth real minutes on
+ * a workflow whose concurrency group is serialised.
+ *
+ * What it costs, stated plainly: the runner container is not a security
+ * boundary (Dockerfile.ci says so), jobs hold the host docker socket, and a job
+ * can read a later job's environment. So anyone who can get a step onto `bs-ci`
+ * can obtain these two secrets. SENTRY_AUTH_TOKEN is a source-map upload token;
+ * GITHUB_TOKEN here carries `packages: write`, i.e. the ability to move the
+ * `:production` GHCR tag that Railway pulls. Fork PRs cannot reach the fleet,
+ * so the exposure is to people with write access, not the internet.
+ *
+ * What is deliberately NOT on this list: `migrate` (DATABASE_URL — production
+ * Postgres) and every deploy job (RAILWAY_TOKEN). Those stay GitHub-hosted.
+ *
+ * The end state remains a separate `bs-deploy` host that never runs PR code, as
+ * the invariant above describes. Until then this list is the whole exception,
+ * and adding to it should be as uncomfortable as it looks.
+ */
+const DEPLOY_FLEET_ALLOWLIST: Readonly<Record<string, readonly string[]>> = Object.freeze({
+  'build-web': Object.freeze(['GITHUB_TOKEN', 'SENTRY_AUTH_TOKEN']),
+  'build-backend': Object.freeze(['GITHUB_TOKEN']),
+});
 
 /** `secrets.FOO` / `secrets['FOO']` / `secrets["FOO"]`. */
 const SECRET_REFERENCE = /secrets\.([A-Za-z0-9_]+)|secrets\[['"]([A-Za-z0-9_]+)['"]\]/g;
@@ -118,5 +155,88 @@ describe('self-hosted secret boundary', () => {
       .filter(({ source }) => withoutCommentLines(source).some((line) => /^\s{2}pull_request_target:/.test(line)))
       .map(({ path, jobName }) => `${path}:${jobName}`);
     expect(offenders).toEqual([]);
+  });
+});
+
+/**
+ * Jobs routed through `DEPLOY_RUNNER_LINUX`. Collected separately from
+ * routedJobs() because they are the exception, not the rule — see
+ * DEPLOY_FLEET_ALLOWLIST.
+ */
+function deployRoutedJobs(): RoutedJob[] {
+  const jobs: RoutedJob[] = [];
+  for (const path of githubYamlPaths()) {
+    const source = readFileSync(path, 'utf8');
+    if (!isWorkflow(source)) continue;
+    for (const [jobName, block] of jobBlocks(source)) {
+      if (block.some(isDeployRoutedRunsOn)) {
+        jobs.push({ path, jobName, block, source });
+      }
+    }
+  }
+  return jobs;
+}
+
+describe('deploy fleet routing (the one deliberate exception)', () => {
+  const jobs = deployRoutedJobs();
+
+  it('routes only the jobs on the allowlist', () => {
+    // The allowlist is the argument. A job appearing here that nobody wrote a
+    // justification for is the regression this catches.
+    expect(jobs.map((job) => job.jobName).sort()).toEqual(Object.keys(DEPLOY_FLEET_ALLOWLIST).sort());
+    for (const job of jobs) {
+      expect(job.path, job.jobName).toBe('.github/workflows/production-deploy.yml');
+    }
+  });
+
+  it('carries only the secrets its allowlist entry accounts for', () => {
+    const offenders = jobs.flatMap(({ jobName, block }) => {
+      const allowed = DEPLOY_FLEET_ALLOWLIST[jobName] ?? [];
+      return [...new Set(secretNames(block.join('\n')))]
+        .filter((name) => !allowed.includes(name))
+        .map((name) => `${jobName} → secrets.${name} (not in DEPLOY_FLEET_ALLOWLIST)`);
+    });
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps the database and Railway credentials off the fleet', () => {
+    // The line that matters most. These are not "a token someone could abuse";
+    // they are production Postgres and the ability to redeploy any service.
+    const forbidden = ['DATABASE_URL', 'RAILWAY_TOKEN'];
+    const offenders = jobs.flatMap(({ jobName, block }) =>
+      secretNames(block.join('\n'))
+        .filter((name) => forbidden.includes(name))
+        .map((name) => `${jobName} → secrets.${name}`),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it('uses a builder instance that no PR-code job can share', () => {
+    // A job whose Dockerfile is attacker-controlled sharing this daemon could
+    // write a trojaned package into the shared pnpm-store cache mount, and the
+    // next production build would install it into a published, attested image.
+    // The daemon name is the isolation, so it is asserted rather than trusted.
+    const workflow = readFileSync('.github/workflows/production-deploy.yml', 'utf8');
+    expect(workflow).toContain('docker-container://boardsesh-buildkitd-deploy');
+    for (const path of githubYamlPaths()) {
+      if (path === '.github/workflows/production-deploy.yml') continue;
+      expect(readFileSync(path, 'utf8'), path).not.toContain('boardsesh-buildkitd-deploy');
+    }
+  });
+
+  it('is left OFF by default, so merging the wiring is a no-op', () => {
+    // `fromJSON(vars.X || '"ubuntu-latest"')` — an unset variable means
+    // GitHub-hosted. Flipping it is a deliberate, separately-revertible act.
+    const workflow = readFileSync('.github/workflows/production-deploy.yml', 'utf8');
+    expect(workflow).toContain(`fromJSON(vars.DEPLOY_RUNNER_LINUX || '"ubuntu-latest"')`);
+  });
+
+  it('is reset by the runner watchdog alongside the CI variable', () => {
+    // `runs-on` resolves at dispatch, and a queued fleet job holds the
+    // production-deploy concurrency group silently. The watchdog resetting only
+    // CI_RUNNER_LINUX would leave deploys wedged for 24h.
+    const watchdog = readFileSync('.github/workflows/ci-runner-watchdog.yml', 'utf8');
+    expect(watchdog).toContain('DEPLOY_RUNNER_LINUX');
+    expect(watchdog).toMatch(/routing_variables=\(CI_RUNNER_LINUX DEPLOY_RUNNER_LINUX\)/);
   });
 });

--- a/scripts/__tests__/helpers/workflow-yaml.ts
+++ b/scripts/__tests__/helpers/workflow-yaml.ts
@@ -92,6 +92,23 @@ export function isRoutedRunsOn(line: string): boolean {
 }
 
 /**
+ * A `runs-on:` line that resolves through `vars.DEPLOY_RUNNER_LINUX` — the
+ * SECOND routing variable, used only by production-deploy.yml's build jobs.
+ *
+ * It exists as its own function, and its own variable, for a reason that is
+ * easy to lose: `isRoutedRunsOn` matches only `CI_RUNNER_LINUX`, so a job
+ * routed through a different variable is invisible to
+ * ci-self-hosted-secret-boundary.test.ts. Routing deploy work through a new
+ * name would therefore leave that boundary test green while the boundary was
+ * gone — exactly the silent regression its header warns about. Everything that
+ * reasons about "jobs that can land on the homelab" must consider BOTH.
+ */
+export function isDeployRoutedRunsOn(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed.startsWith('runs-on:') && trimmed.includes('vars.DEPLOY_RUNNER_LINUX');
+}
+
+/**
  * True when the document has a top-level `jobs:` key, i.e. is a workflow rather
  * than a composite action, dependabot config, or issue-form template. `.github`
  * is full of those, and jobBlocks() throws on them by design.

--- a/scripts/__tests__/production-deploy-web-targets.test.ts
+++ b/scripts/__tests__/production-deploy-web-targets.test.ts
@@ -159,11 +159,11 @@ describe('production-deploy web deploy targets', () => {
   it('publishes the web image regardless of which deployer is selected', () => {
     // The image is the artifact: pushing it is free and reversible, and it is
     // what makes a later `railway redeploy` possible without a rebuild. Gating
-    // it would also make merging this wiring a production change instead of a
-    // no-op. Every one of these steps must be unconditional.
+    // it on a deploy target would also make merging deploy wiring a production
+    // change instead of a no-op. Every one of these steps must be
+    // unconditional.
     for (const stepName of [
       'Log in to GHCR',
-      'Set up Docker Buildx',
       'Extract web image metadata',
       'Generate web Docker context',
       'Build and push web image',
@@ -171,6 +171,26 @@ describe('production-deploy web deploy targets', () => {
     ]) {
       expect(stepNamed(buildWebJob, stepName), stepName).not.toContain('if:');
     }
+
+    // The buildx setup is the one exception, and it is NOT a gate: it is split
+    // into a self-hosted and a GitHub-hosted variant, exactly one of which runs.
+    // `runner.environment` is the only thing either may branch on — a
+    // WEB_DEPLOY_TARGETS or rollback condition creeping in here would silently
+    // skip the whole image publish.
+    const fleetSetup = stepNamed(buildWebJob, 'Set up Docker Buildx (persistent fleet builder)');
+    const hostedSetup = stepNamed(buildWebJob, 'Set up Docker Buildx (GitHub-hosted)');
+    expect(fleetSetup).toContain("if: runner.environment == 'self-hosted'");
+    expect(hostedSetup).toContain("if: runner.environment == 'github-hosted'");
+    for (const step of [fleetSetup, hostedSetup]) {
+      expect(step).not.toContain('needs.');
+      expect(step).not.toContain('vars.');
+    }
+
+    // And the build step must consume whichever one ran, or a fleet build would
+    // silently use the default builder and lose every cache mount.
+    expect(stepNamed(buildWebJob, 'Build and push web image')).toContain(
+      'builder: ${{ steps.buildx-fleet.outputs.name || steps.buildx-hosted.outputs.name }}',
+    );
   });
 
   it('builds the generated context, pushes it, and attests it', () => {

--- a/scripts/ci/buildkitd.toml
+++ b/scripts/ci/buildkitd.toml
@@ -1,0 +1,50 @@
+# BuildKit daemon config for the LONG-LIVED deploy builder on the bs-ci hosts.
+#
+# The whole reason this daemon exists: the runner containers are started
+# `--rm --ephemeral`, so `~/.docker/buildx` and everything a job's builder wrote
+# die with the job. That is why `RUN --mount=type=cache,id=pnpm-store` has never
+# once survived a CI run — cache mounts live in the BUILDER's state, and the
+# builder was always thrown away. A sibling container on the host keeps
+# /var/lib/buildkit in a named volume that every later job on that host dials.
+#
+# scripts/ci/ensure-buildkitd.sh hashes this file into a container label, so
+# editing it recreates the daemon on the next deploy. The state volume is kept
+# across that recreate — a config bump should not cost a cold build.
+
+root = "/var/lib/buildkit"
+
+[worker.oci]
+enabled = true
+gc = true
+
+# The v0.32+ spelling. `gckeepstorage` / `keepBytes` are the DEPRECATED names
+# and are silently ignored, which would leave the cache unbounded — the exact
+# failure this block exists to prevent.
+#
+# Sized for a host that also runs ~18 ephemeral runner containers and the CI
+# image (git seed + ~2 GB pnpm store + tool cache). Re-check `df -h` on
+# bs-ci-1 and bs-ci-2 before raising these: a percentage cap can starve the
+# thing that runs the jobs.
+reservedSpace = "10GB"
+maxUsedSpace = "60GB"
+minFreeSpace = "20%"
+
+# The least reproducible, most expensive-to-rebuild records. The pnpm store
+# (~2 GB) and Turbopack's build database are `exec.cachemount`; a tighter
+# keepDuration would evict exactly what this daemon exists to preserve.
+# 168h keeps them across a week of deploys.
+[[worker.oci.gcpolicy]]
+keepDuration = "168h"
+maxUsedSpace = "20GB"
+filters = ["type==source.local", "type==exec.cachemount", "type==source.git.checkout"]
+
+[[worker.oci.gcpolicy]]
+all = true
+reservedSpace = "10GB"
+maxUsedSpace = "60GB"
+minFreeSpace = "20%"
+
+# Unbounded by default, and small but not free.
+[history]
+maxAge = 172800
+maxEntries = 50

--- a/scripts/ci/ensure-buildkitd.sh
+++ b/scripts/ci/ensure-buildkitd.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# A BuildKit daemon that OUTLIVES the ephemeral job container.
+#
+# The runner containers are started `--rm` with `--ephemeral` registration, so
+# ~/.docker/buildx and anything a job's builder writes die with the job. That is
+# the entire reason `RUN --mount=type=cache,id=pnpm-store` has never survived a
+# CI run: cache mounts live in the BUILDER's state, and the builder was always
+# discarded. The host docker socket is bind-mounted into the job container, so
+# the daemon can instead be a SIBLING container on the host, keeping
+# /var/lib/buildkit in a named volume that every later job on this host dials.
+#
+# `remote` driver, NOT `docker-container`: docker/setup-buildx-action's post
+# step runs `docker buildx rm <name>`, which for the docker-container driver
+# would DELETE this daemon and its cache. For the remote driver Rm() removes
+# only the local instance record, so a stray cleanup — or a job that dies before
+# its post step — cannot wipe the cache for every later deploy.
+#
+# DELIBERATELY separate from any CI builder. A job whose Dockerfile is
+# attacker-controlled and which shared this daemon could write a trojaned
+# package into the shared pnpm store cache mount, and the next production image
+# build would install it — into a published, attested image. Anything that is
+# not already trusted with Production secrets gets its own daemon name.
+#
+# NOTE FOR WHOEVER IS FREEING DISK: `docker system prune -af` reclaims NONE of
+# this. The state lives in a docker VOLUME held by a running container. See the
+# reclaim commands at the bottom of this file.
+set -euo pipefail
+
+name="${BUILDKITD_NAME:-boardsesh-buildkitd-deploy}"
+state_volume="${name}-state"
+config_volume="${name}-config"
+# Pinned by digest, same as postgres-image-publisher.yml. This container is
+# long-lived; it must not change under a production deploy.
+image="${BUILDKITD_IMAGE:-moby/buildkit:v0.32.2@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+config="$(cat "${script_dir}/buildkitd.toml")"
+config_hash="$(printf '%s' "$config" | sha256sum | cut -d' ' -f1)"
+
+current_image="$(docker inspect -f '{{.Config.Image}}' "$name" 2>/dev/null || true)"
+current_hash="$(docker inspect -f '{{index .Config.Labels "boardsesh.buildkitd.config"}}' "$name" 2>/dev/null || true)"
+running="$(docker inspect -f '{{.State.Running}}' "$name" 2>/dev/null || echo false)"
+
+if [ -n "$current_image" ] && { [ "$current_image" != "$image" ] || [ "$current_hash" != "$config_hash" ]; }; then
+  # Recreate on drift, but KEEP the state volume: a version or config bump
+  # should not cost a cold build. BuildKit migrates its own state.
+  echo "buildkitd image or config changed; recreating (state volume kept)"
+  docker rm -f "$name" >/dev/null 2>&1 || true
+  running=false
+fi
+
+if [ "$running" != 'true' ]; then
+  # The config has to arrive over stdin into a named volume. The job container's
+  # filesystem is NOT visible to the host daemon (sibling containers, not
+  # nested), so `-v "$PWD/scripts/ci:/etc/buildkit"` would silently mount a host
+  # path that does not exist and the daemon would start with default (unbounded)
+  # GC. This is the single most likely way to get this script wrong.
+  printf '%s' "$config" | docker run --rm -i -v "${config_volume}:/cfg" \
+    --entrypoint sh "$image" -c 'cat > /cfg/buildkitd.toml'
+
+  # `docker run` on an existing name fails; the `||` branch is what makes two
+  # deploy jobs landing on this host in the same second safe.
+  docker run -d \
+    --name "$name" \
+    --restart unless-stopped \
+    --privileged \
+    --label "boardsesh.buildkitd.config=${config_hash}" \
+    -v "${state_volume}:/var/lib/buildkit" \
+    -v "${config_volume}:/etc/buildkit" \
+    "$image" --config /etc/buildkit/buildkitd.toml \
+    >/dev/null 2>&1 \
+    || docker start "$name" >/dev/null
+fi
+
+# Prove the exact endpoint buildx will dial actually answers, here, rather than
+# discovering it half way through build-push-action. Fails the job on purpose:
+# a production deploy going red with a clear error beats one that quietly falls
+# back to a cold local builder and looks fine.
+for _ in $(seq 1 30); do
+  if docker exec "$name" buildctl debug workers >/dev/null 2>&1; then
+    echo "buildkitd '${name}' ready on $(hostname)"
+    docker exec "$name" buildctl du 2>/dev/null | tail -1 || true
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "::error::buildkitd '${name}' did not become ready on $(hostname) within 30s" >&2
+exit 1
+
+# Reclaiming space by hand (buildkitd state is invisible to `docker system df`):
+#
+#   docker exec boardsesh-buildkitd-deploy buildctl du -v
+#   docker exec boardsesh-buildkitd-deploy buildctl prune --reserved-space 10GB --verbose
+#   docker exec boardsesh-buildkitd-deploy buildctl prune --all
+#
+# Nuclear (next deploy on this host is cold, nothing else breaks):
+#
+#   docker rm -f boardsesh-buildkitd-deploy
+#   docker volume rm boardsesh-buildkitd-deploy-state boardsesh-buildkitd-deploy-config


### PR DESCRIPTION
## Summary

Stacked on #5095, and the last of the build-speed series. Adds the wiring to build the deploy images on the self-hosted `bs-ci` fleet against a BuildKit daemon that outlives the ephemeral job container.

**Merging this changes nothing.** `DEPLOY_RUNNER_LINUX` is unset, which resolves to `ubuntu-latest`. Flipping it is a separate, one-API-call act — and a one-API-call revert.

### Why a persistent daemon is the only way to get this

The runner containers are started `--rm` with `--ephemeral` registration, so `~/.docker/buildx` and everything a job's builder wrote die with the job. That is why `RUN --mount=type=cache,id=pnpm-store` in the Dockerfiles **has never once survived a CI run** — cache mounts live in the *builder's* state, and the builder was always discarded. No `cache-to` backend exports them either.

The host docker socket is already bind-mounted (proved by `branch-deploy.yml`'s self-hosted job running raw `docker` commands), so `scripts/ci/ensure-buildkitd.sh` runs the daemon as a sibling container on the host with its state in a named volume.

**buildx's `remote` driver, not `docker-container`** — this is the load-bearing choice. `docker/setup-buildx-action`'s post step runs `docker buildx rm`, which under `docker-container` would **delete the shared daemon and its cache**. Under `remote` it removes only the local instance record, so a stray cleanup, or a job that dies before its post step, cannot wipe the cache for every later deploy.

### `next build` finally gets an incremental cache

`Dockerfile.web` gains a `.next/cache` mount. I was wrong when I doubted this in planning: Next 16 builds with Turbopack and `experimental.turbopackFileSystemCacheForBuild` **defaults to `true`** — verified in the installed `next@16.3.2`, both the resolved default map in `config-shared.d.ts` and `next-post-build.js` computing `<distDir>/cache/turbopack`. `next.config.mjs` sets no `distDir`, so that database was being written and thrown away on every single build. No config change needed.

`sharing=locked`, not the default `shared`: it is a database, not a content-addressed store, and on a persistent builder concurrent writes stop being hypothetical.

### Two hosts, one daemon each

`bs-ci-1` and `bs-ci-2`, so roughly half of deploys land on a cold daemon. That is fine — the registry cache from #5093 covers it, because the expensive layers are the stable ones. A shared daemon would need a LAN-exposed root-equivalent service with mTLS; pinning to one host would make every production deploy depend on one VM being up.

`scripts/ci/buildkitd.toml` bounds the disk using the **v0.32 spelling** (`reservedSpace`/`maxUsedSpace`/`minFreeSpace`) — the deprecated `gckeepstorage` names are silently ignored, which would leave it unbounded. Note `docker system prune -af` reclaims **none** of this (it lives in a volume held by a running container), so the reclaim commands are in the script header and the docs.

## The boundary this crosses — deliberately, and visibly

`scripts/__tests__/ci-self-hosted-secret-boundary.test.ts` holds the invariant that no fleet-routed job may carry a secret other than `GITHUB_TOKEN` or declare an `environment:`, because *"a self-hosted runner has no meaningful boundary between a job and the host… the only durable mitigation is that there is nothing on the fleet worth stealing."* #5011 says `production-deploy.yml` stays hosted, and #5005's blocker **D1** (1Password vault readable by any job) is still open.

**These two jobs are an exception to that invariant, and this is the trap that made it worth care:** `isRoutedRunsOn()` matches only `CI_RUNNER_LINUX`, so routing through a new variable would have left that boundary test **green while the boundary was gone** — exactly the silent regression its own header warns about.

So the test now sees `DEPLOY_RUNNER_LINUX` jobs too, through a **named allowlist** that writes down which secrets each job may carry and why, plus assertions that:

- `DATABASE_URL` (production Postgres) and `RAILWAY_TOKEN` never reach the fleet — `migrate` and every deploy job stay hosted;
- no PR-code job can share the deploy daemon (a job with an attacker-controlled Dockerfile sharing the pnpm-store cache mount could plant a package into a published, *attested* image);
- the variable is off by default;
- the watchdog resets it.

Stated plainly for the record: anyone who can get a step onto `bs-ci` can obtain `SENTRY_AUTH_TOKEN` and a `packages: write` `GITHUB_TOKEN` — the ability to move the `:production` GHCR tag Railway pulls. Fork PRs cannot reach the fleet, so that is people with write access, not the internet. The correct end state is a separate `bs-deploy` host that never runs PR code (an Ansible change in `blackheathdc-ansible`); until then the allowlist is the whole exception.

### The outage path, closed

`ci-runner-watchdog.yml` now resets **both** routing variables. This matters more for deploys than CI: `runs-on` resolves at **dispatch**, so a queued fleet job holds the `production-deploy` concurrency group (`cancel-in-progress: false`) and every later push queues behind it **silently** — `notify-failure` never fires because nothing failed. `production-deploy-watchdog.yml` cancels a run parked that way, but only after 45 minutes and only once per head SHA, and its single re-dispatch re-resolves `runs-on` from this variable. So the 10-minute watchdog has to have reset it first.

## Rollout

1. Merge (no-op).
2. Set `DEPLOY_RUNNER_LINUX` to `["self-hosted","bs-ci"]`.
3. Measure **two** deploys per host — the daemon is per-host, so the first on each is cold.
4. `docker exec boardsesh-buildkitd-deploy buildctl du` on both hosts to confirm the cache is retained and bounded.

Revert is `DEPLOY_RUNNER_LINUX="ubuntu-latest"`, no deploy needed.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.
2. After merge: a deploy still runs on `ubuntu-latest` (the variable is unset).
3. Only after step 2: set the variable, then confirm the deploy log shows `buildkitd 'boardsesh-buildkitd-deploy' ready`.

## Risk

Risk: 5/5 — puts Production-environment secrets on hardware whose own guard test says they should not be, and touches the only production deploy path. Every mitigation available short of a separate host is here: off by default, one-call revert, an explicit allowlist instead of a silently-blind test, a deploy-only daemon name, `DATABASE_URL`/`RAILWAY_TOKEN` asserted off the fleet, and the watchdog closing the wedge path. The security trade is a judgement call for the maintainer, not something CI can settle — please read "The boundary this crosses" before approving.

