### PR TITLE
feat(ci): bake Rust into the CI image for renderer-rust

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -287,6 +287,34 @@ RUN /usr/local/bin/install-python.sh ${PYTHON_VERSIONS}
 
 RUN chown -R runner:runner /opt/hostedtoolcache
 
+# Rust, for ci.yml's renderer-rust job (cargo fmt / clippy / test).
+#
+# Baked rather than left to dtolnay/rust-toolchain because that action would
+# download the toolchain on EVERY run of that job. Measured here: 623 MB of
+# toolchain, against ~200 MB fetched per job. As an image layer it is pulled
+# once per host and then shared by every job; as an action it is paid for
+# again each time.
+#
+# `stable` is deliberately NOT pinned, unlike Python and the runner agent
+# above. The workflow asks dtolnay/rust-toolchain for `stable`, and that
+# action installs whatever upstream currently calls stable -- so pinning a
+# version here would simply be ignored and re-downloaded the moment upstream
+# moved. Tracking `stable` means the action finds what it wants already
+# present. The cost is that this layer changes when Rust releases, roughly
+# every six weeks, rather than never.
+#
+# RUSTUP_HOME and CARGO_HOME are explicit and outside $HOME so the paths are
+# stable regardless of which user a step runs as.
+ENV RUSTUP_HOME=/opt/rustup
+ENV CARGO_HOME=/opt/cargo
+ENV PATH=/opt/cargo/bin:$PATH
+RUN curl -fsSL https://sh.rustup.rs -o /tmp/rustup-init.sh && \
+    sh /tmp/rustup-init.sh -y --no-modify-path --profile minimal \
+      --default-toolchain stable -c rustfmt -c clippy && \
+    rm -f /tmp/rustup-init.sh && \
+    chown -R runner:runner /opt/rustup /opt/cargo && \
+    rustc --version && cargo clippy --version && cargo fmt --version
+
 # The agent, pinned with a checksum rather than "whatever is latest at build
 # time": a rebuild must not silently change the thing that executes every
 # job. `--disableupdate` is passed at configure time (docker/ci/entrypoint.sh)

--- a/scripts/__tests__/ci-image-workflow.test.ts
+++ b/scripts/__tests__/ci-image-workflow.test.ts
@@ -176,6 +176,19 @@ describe('Dockerfile.ci: the hosted tool cache is prefilled', () => {
     expect(codeLines.filter((line) => line.includes('python3-pip'))).toEqual([]);
   });
 
+  it('installs Rust with the components renderer-rust needs', () => {
+    // ci.yml's renderer-rust runs cargo fmt / clippy / test. Without rustfmt
+    // and clippy in the image, dtolnay/rust-toolchain downloads the whole
+    // toolchain on every run of that job -- ~200 MB each time, against 623 MB
+    // baked once per host and shared by every job.
+    expect(codeLines.some((line) => line.includes('rustup-init.sh'))).toBe(true);
+    expect(dockerfileSource).toMatch(/-c rustfmt/);
+    expect(dockerfileSource).toMatch(/-c clippy/);
+    // Paths outside $HOME so they resolve the same whichever user a step runs as.
+    expect(codeLines.some((line) => line.startsWith('ENV RUSTUP_HOME='))).toBe(true);
+    expect(codeLines.some((line) => line.startsWith('ENV CARGO_HOME='))).toBe(true);
+  });
+
   it('installs a host C++ toolchain', () => {
     // PlatformIO's `native` platform compiles the firmware unit tests
     // (embedded/test/platformio.ini, C++17) against the host compiler, so


### PR DESCRIPTION
`renderer-rust` is the last `ci.yml` job Wave 2 left hosted. It needs a Rust
toolchain with `rustfmt` and `clippy`; the image had none.

### Why bake it

`dtolnay/rust-toolchain` would download the toolchain on **every run** of that
job. Measured in the published image:

| | |
| --- | --- |
| toolchain baked into the image | 623 MB, pulled once per host, shared by every job |
| downloaded by the action | ~200 MB, paid again on every run |

### Why `stable` is not pinned

Deliberately different from Python and the runner agent, which are pinned. The
workflow asks `dtolnay/rust-toolchain` for `stable`, and that action installs
whatever upstream currently calls stable — so a pinned version here would be
ignored and re-downloaded the moment upstream moved. Tracking `stable` means
the action finds what it wants already present. The cost is that this layer
changes when Rust releases, roughly every six weeks, rather than never.

### Verified with the job's own commands

Run against the real crate inside the published image:

```
cargo fmt --all -- --check                          PASS
cargo clippy --workspace --all-targets -- -D warnings   clean
cargo test --workspace                              70 + 1 + 7 passed, 0 failed
```

One test failed on the first attempt —
`committed_native_artifacts_embed_the_aura_render_contract` — because it reads
a committed artifact at `core/../../mobile/modules/board-renderer/ios/…`, which
reaches outside the crate. That was my harness mounting only
`packages/board-renderer`; with the sibling packages present it passes.

### Not routed here

`renderer-rust` stays on `ubuntu-latest` in this PR. The image has to ship
first — routing a job the image cannot host is the mistake `firmware-tests`
already made once, and it is not worth repeating for the sake of one PR.

## Release Notes

none

## Test plan

1. CI green.
2. After the image rebuild, `renderer-rust` can be routed in a follow-up.

## Risk

Risk: 2/5 — image only, and adds ~623 MB uncompressed to a layer that is
stable between Rust releases. Nothing in the CI path changes.