### PR TITLE
feat(mobile): make Aura render failures visible and self-healing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ Read relevant `docs/` before working on the matching area; update docs when the 
 - `docs/live-activity-push-testing.md` — APNs Live Activity push testing
 - `docs/db-migrations.md` — migration numbering, `when`-not-number apply order, the collision/renumber bot, and when it hands work back
 - `docs/feature-flags.md` — client vs server flags, why a server gate fails closed, the resolution reasons, the `/api/internal/feature-flags` diagnostic, and the `FEATURE_FLAG_OVERRIDES` kill switch; the "Mobile flags" section covers the mobile-only catalog, multivariate flags, and precedence
-- `docs/board-render-analytics.md` — the classic-vs-Boardsesh / glow-falloff A/B event contract (issue #2202): the seven events (incl. the paired board-look step events), the common-props builder, the `climb-view-session.ts` state machine, the stratification rule (never pool across `board_name` or `glow_falloff_source`), and the PostHog experiment setup steps
+- `docs/board-render-analytics.md` — the classic-vs-Boardsesh / glow-falloff A/B event contract (issue #2202): the eight events (incl. the paired board-look step events and `Board Render Failed`), the common-props builder, the `climb-view-session.ts` state machine, the stratification rule (never pool across `board_name` or `glow_falloff_source`), and the PostHog experiment setup steps
 - `docs/logging.md` — backend structured logger (winston)
 - `docs/crowdsourced-qa.md` — the PR test-plan + risk gate (`@boardsesh/pr-body`, `pr-test-plan.yml`), and the tester loop that turns it into `qa-approved` / `qa-declined` labels
 - `docs/scheduler.md` — the Railway cron scheduler (`packages/scheduler`): which job runs on Vercel vs the scheduler, env vars, Railway setup, cutover order and runbook

--- a/docs/board-render-analytics.md
+++ b/docs/board-render-analytics.md
@@ -49,7 +49,7 @@ event's name.
 | `Board Render Preset Applied`  | `surface` (`'settings'` \| `'onboarding'`, optional) — otherwise the common props ARE the event | `trackBoardLookApplied` in `packages/mobile/src/lib/board-render/board-look-analytics.ts`, from the board-look carousel on both its surfaces |
 | `Board Look Step Shown`        | `options_shown`                                        | The one-time board-look step (`BoardLookStep.tsx`), once per presentation |
 | `Board Look Step Resolved`     | `outcome` (`'saved'` \| `'customized'` \| `'skipped'`), `selected_option`, `cards_viewed`, `ms_to_resolve` | The same step — exactly once per Shown, including the unmount-without-choosing path |
-| `Board Render Failed`          | `surface`, `stage`, `failure_kind`, `error_code`, `render_width`, `frames_length`, `failures_this_session` | `noteRenderFailure` in `packages/mobile/src/hooks/use-native-climb-render.ts` — the native render's `.catch` (both real failures and the capability fallbacks) and `reportOverlayLoadFailure`, the one writer for every expo-image load failure |
+| `Board Render Failed`          | `surface`, `stage`, `failure_kind`, `error_code`, `render_width`, `frames_length`, `failures_this_session`, plus `lit_count` / `unmatched_count` on the config stage | `noteRenderFailure` in `packages/mobile/src/hooks/use-native-climb-render.ts` — the hold-match check before the render, the native render's `.catch` (real failures and the capability fallbacks), `reportOverlayLoadFailure` (every expo-image load failure) and the paint watchdog |
 
 ### The common properties every event carries
 
@@ -97,13 +97,16 @@ had anything at all. A session where every render failed after the seventh swipe
 (the Aura 12x12 blank-overlay report) looked exactly like a session that never
 failed.
 
-It fires from two places, both in
+It fires from four places, all in
 `packages/mobile/src/hooks/use-native-climb-render.ts`:
 
+- the hold-match check, run just before the native call (see "The config stage"
+  below) — the only failure here that never throws;
 - the native render's `.catch`, for every rejection — including the capability
   fallbacks that Sentry is deliberately never told about (#4240);
 - `reportOverlayLoadFailure`, the single writer behind every `onOverlayError`
-  path, so a load failure cannot be handled without being counted.
+  path, so a load failure cannot be handled without being counted;
+- the paint watchdog, for an overlay expo-image never answered about.
 
 ### Properties
 
@@ -112,12 +115,14 @@ Common props (the table above) plus:
 | Property                | Values                                                                                                                                   |
 | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `surface`               | `full` \| `thumbnail` — the play board or a list / accessory thumbnail (the hook's `filledStyle`)                                          |
-| `stage`                 | `native` \| `image_load` — which half of the path gave up                                                                                  |
-| `failure_kind`          | on `native`: `render_failed` \| `disk_full` \| `capability_fallback`. On `image_load`: `cache_entry_missing` \| `retry_exhausted` \| `cache_entry_present` \| `validation_failed` \| `validation_unsupported` |
-| `error_code`            | `code_<n>` \| `png` \| `cgimage` \| `write` \| `module` \| `capability` \| `other`                                                          |
+| `stage`                 | `config` \| `native` \| `image_load` — which part of the path gave up                                                                       |
+| `failure_kind`          | on `config`: `no_matching_holds` \| `partial_hold_match`. On `native`: `render_failed` \| `disk_full` \| `capability_fallback`. On `image_load`: `cache_entry_missing` \| `retry_exhausted` \| `cache_entry_present` \| `validation_failed` \| `validation_unsupported` \| `paint_timeout` |
+| `error_code`            | `code_<n>` \| `png` \| `cgimage` \| `write` \| `module` \| `capability` \| `no_matching_holds` \| `paint_timeout` \| `other`                  |
 | `render_width`          | requested overlay width in pixels, or `null` for a native-width render                                                                     |
 | `frames_length`         | length of the frames string — a cheap proxy for climb complexity                                                                          |
 | `failures_this_session` | running count for this JS lifetime, INCLUDING this event                                                                                   |
+| `lit_count`             | config stage only: how many placements frame 0 lights. A count, never the ids — the ids are the climb                                     |
+| `unmatched_count`       | config stage only: how many of those the board config has no hold for                                                                     |
 
 `stage` and `failure_kind` are one discriminated pair in
 `BoardRenderFailedInput`, not two free fields: a native rejection can never be
@@ -138,6 +143,43 @@ normalised (`code -002` → `code_-2`); otherwise the message is bucketed by sha
 Overlay filenames are stripped BEFORE the prose match, because every iOS write
 failure carries `"v5_<key>.png"` and a bare `png` test would swallow the entire
 `write` bucket.
+
+### The config stage: the failure that never throws
+
+Confirmed on the Android emulator, and the reason the event needed a stage
+rather than just a failure kind. When a climb's `frames` name placement ids the
+board config has no holds for — a Kilter Homewall climb (ids 4000+) opened under
+Kilter Original 12x12 (ids 1080–1590) — the Rust renderer drops every unmatched
+hold and returns **Ok**. The promise resolves, the PNG is written and cached,
+and the climber gets a veil with nothing drawn on it. No rejection, no log, no
+catch to hang telemetry off. So the check runs BEFORE the native call: parse
+frame 0's lit ids (`parseLitHoldIds`, the one frames grammar) and intersect them
+with the config's hold ids.
+
+- `no_matching_holds` (nothing would draw): report and **skip the render**.
+  Rendering would cache a blank overlay under that key, making the same failure
+  quieter on every later visit. The overlay stays null and the wall photo still
+  shows — the existing missing-layer contract.
+- `partial_hold_match` (some draw, some do not): report and **render anyway**.
+  A climb that legitimately reaches past a smaller layout loses the holds off
+  the edge and keeps the rest, which is degraded, not blank.
+
+### The paint watchdog
+
+The remaining iOS suspect is a correctly rendered file that expo-image never
+paints: the same climbs draw fine on Android and on the host, so the PNG is not
+the problem. expo-image is supposed to answer with `onLoad` or `onError`;
+silence is a third outcome nothing was watching for.
+
+So the full-size board (`filledStyle === false` only — a list would arm one timer
+per visible row) starts a 4s timer when it hands expo-image an overlay, cancelled
+by `onOverlayLoad` for that exact load key, by `onOverlayError`, by the load key
+changing, or by unmount. If it fires, `failure_kind: 'paint_timeout'`.
+
+**Observation only.** The overlay is not nulled and nothing is retried. A file
+that renders correctly but never paints is a different fault from one that
+failed to load, and handling it as the latter — null the overlay, spend the
+once-per-key retry budget — is exactly what would hide it again.
 
 ### The 25-event session cap
 
@@ -163,7 +205,8 @@ Stratify the same way as everything else on this page: never pool across
 - failures per `Climb View Opened`, split by `board_name` × `render_mode` — the
   Aura-vs-classic question the original report raised;
 - `stage` × `failure_kind` × `error_code` for one board, which is what separates
-  "the renderer is rejecting" from "the PNG will not load back".
+  "this climb does not belong to this board" from "the renderer is rejecting"
+  from "the PNG will not load back" from "iOS never painted it".
 
 ## The builder rule
 

--- a/docs/board-render-analytics.md
+++ b/docs/board-render-analytics.md
@@ -179,13 +179,24 @@ catch to hang telemetry off. So the check runs BEFORE the native call: parse
 frame 0's lit ids (`parseLitHoldIds`, the one frames grammar) and intersect them
 with the config's hold ids.
 
-- `no_matching_holds` (nothing would draw): report and **skip the render**.
-  Rendering would cache a blank overlay under that key, making the same failure
-  quieter on every later visit. The overlay stays null and the wall photo still
-  shows — the existing missing-layer contract.
+- `no_matching_holds` (nothing would draw): report, **evict** and **skip the
+  render**. Rendering would cache a blank overlay under that key, making the same
+  failure quieter on every later visit. The overlay stays null and the wall photo
+  still shows — the existing missing-layer contract.
 - `partial_hold_match` (some draw, some do not): report and **render anyway**.
-  A climb that legitimately reaches past a smaller layout loses the holds off
-  the edge and keeps the rest, which is degraded, not blank.
+
+The check runs ABOVE the overlay-cache lookup, and that ordering is the fix, not
+a detail. Builds from before it cached veil-only PNGs under the **same**
+`RENDERER_VERSION`, so the startup warm-up scan restores them from disk; with the
+check below the lookup, that entry was handed straight back and everyone who had
+already hit the bug would have kept a blank board forever on the fixed build too.
+Checking first also makes cache re-insertion moot — a mismatched key is answered
+before anything consults the index — and the stale entry is dropped from the
+index AND cleared off screen, since the state seed reads the index during the
+first render, before this effect runs. Bumping `RENDERER_VERSION` would have
+worked too and was rejected: it flushes every user's overlay cache.
+A climb that legitimately reaches past a smaller layout loses the holds off the
+edge and keeps the rest, which is degraded, not blank.
 
 ### The paint watchdog
 
@@ -233,6 +244,13 @@ promise, so every recycled FlashList row tries again — the storm shape from
 on. Past the cap nothing is sent but `failures_this_session` keeps counting, so
 a stream that stops at 25 reads as truncated rather than as a device that failed
 exactly 25 times.
+
+One `onError` is exactly one `Board Render Failed`. The image_load stage names
+what became of the image — `retry_exhausted` once the one retry is spent, the
+entry kind before that — and never both. PostHog is counting images that failed,
+so firing the entry kind and `retry_exhausted` together made two real errors read
+as three failures and spent the budget a third early. Sentry still hears both
+classes, because there it is diagnosing failure classes rather than counting.
 
 Sentry keeps its own, tighter budget — one report per failure kind per lifetime —
 and now carries `failuresThisSession` in `extra` plus a `board-render` breadcrumb

--- a/docs/board-render-analytics.md
+++ b/docs/board-render-analytics.md
@@ -114,10 +114,10 @@ Common props (the table above) plus:
 
 | Property                | Values                                                                                                                                   |
 | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `surface`               | `full` \| `thumbnail` — the play board or a list / accessory thumbnail (the hook's `filledStyle`)                                          |
+| `surface`               | `play` \| `full` \| `thumbnail` — see below; `play` is opt-in, not derived                                                                 |
 | `stage`                 | `config` \| `native` \| `image_load` — which part of the path gave up                                                                       |
 | `failure_kind`          | on `config`: `no_matching_holds` \| `partial_hold_match`. On `native`: `render_failed` \| `disk_full` \| `capability_fallback`. On `image_load`: `cache_entry_missing` \| `retry_exhausted` \| `cache_entry_present` \| `validation_failed` \| `validation_unsupported` \| `paint_timeout` |
-| `error_code`            | `code_<n>` \| `png` \| `cgimage` \| `write` \| `module` \| `capability` \| `no_matching_holds` \| `paint_timeout` \| `other`                  |
+| `error_code`            | `code_<n>` \| `png` \| `cgimage` \| `write` \| `module` \| `capability` \| `no_matching_holds` \| `partial_hold_match` \| `paint_timeout` \| `other` |
 | `render_width`          | requested overlay width in pixels, or `null` for a native-width render                                                                     |
 | `frames_length`         | length of the frames string — a cheap proxy for climb complexity                                                                          |
 | `failures_this_session` | running count for this JS lifetime, INCLUDING this event                                                                                   |
@@ -128,6 +128,29 @@ Common props (the table above) plus:
 `BoardRenderFailedInput`, not two free fields: a native rejection can never be
 `retry_exhausted` and an image load can never be `disk_full`. Pairing them in the
 type is what stops a call site inventing a combination no query would match.
+
+#### `surface` is opt-in, and `play` means exactly one board
+
+`play` is the play drawer's CURRENT card and nothing else — `SwipeBoardCarousel`
+passes `playSurface` to it explicitly. Twelve other call sites render a board at
+full size and none of them do: the board-look preview cards and rails,
+`CustomLookPreview`, `BoardPreviewSheet`, `ClimbReactionMenu`, `WallHeroStage`,
+and the carousel's own off-screen peek. They are all `full`.
+
+Do not collapse the two. `full` covers surfaces that are off-screen, behind a
+sheet, or one of a dozen preview cards drawn at once, so a failure rate pooled
+across `play` and `full` would not describe anything a climber experienced.
+`thumbnail` is still just the filled style the list and accessory rows ask for.
+
+#### What this event still cannot see
+
+The hold-match check compares placement IDS. Rust drops a hold for a second
+reason it never reports: `parse_frames`
+(`packages/board-renderer/core/src/frames_parser.rs:21`) looks each hold's ROLE
+code up in `hold_state_map` and silently skips the hold when the code is absent.
+A climb whose frames carry only unknown role codes therefore still produces a
+veil-only PNG with no event of any kind. Extending the check to role codes is a
+follow-up.
 
 ### `error_code` is a bucket, never the message
 
@@ -171,20 +194,39 @@ paints: the same climbs draw fine on Android and on the host, so the PNG is not
 the problem. expo-image is supposed to answer with `onLoad` or `onError`;
 silence is a third outcome nothing was watching for.
 
-So the full-size board (`filledStyle === false` only — a list would arm one timer
-per visible row) starts a 4s timer when it hands expo-image an overlay, cancelled
-by `onOverlayLoad` for that exact load key, by `onOverlayError`, by the load key
+So the play board — `surface: 'play'` only — starts a 4s timer, cancelled by
+`onOverlayLoad` for that exact load key, by `onOverlayError`, by the load key
 changing, or by unmount. If it fires, `failure_kind: 'paint_timeout'`.
+
+It arms off the view layer's MOUNT signal (`onOverlayMounted` in
+`LayeredClimbImage`), never off `overlayUri`, and that distinction is the whole
+correctness argument. `LayeredClimbImage` renders a bare `<View>` and no image at
+all while the app is backgrounded or the tab's board art is released — and
+opening `/play` releases it for every other tab surface
+(`board-art-visibility-provider.tsx`). Nothing there can fire `onLoad`, because
+there is no `<Image>` to fire it, so a watchdog armed on the URI would report
+guaranteed-bogus silence, and a backgrounded app's JS timers would land on resume
+before the remount ever got the chance to answer.
 
 **Observation only.** The overlay is not nulled and nothing is retried. A file
 that renders correctly but never paints is a different fault from one that
 failed to load, and handling it as the latter — null the overlay, spend the
 once-per-key retry budget — is exactly what would hide it again.
 
-### The 25-event session cap
+### Two session caps, not one
 
 The hook counts every failure in a module-scoped counter and stops firing after
-25 per JS lifetime. The failure this event exists for is a device that fails
+25 per JS lifetime — with the config stage on its own separate budget of 10.
+
+The split is load-bearing. A config mismatch is a property of a climb-and-board
+pair, so a board whose sets do not cover a climb's holds produces one on every
+row of a list. Sharing a budget would let a single scroll spend the whole
+session's telemetry on one unchanging answer and silence the native and
+image_load signals, which are the ones that move. Config events are also deduped
+by cache key across every hook instance (a bounded 200-key set, so a recycled
+FlashList row cannot re-report a climb it already answered for).
+
+On the 25 for the other stages: The failure this event exists for is a device that fails
 EVERY render from some point on, and `getOrStartInflightRender` drops the settled
 promise, so every recycled FlashList row tries again — the storm shape from
 #3647. 25 events is plenty to see which stage, kind and code a session is stuck

--- a/docs/board-render-analytics.md
+++ b/docs/board-render-analytics.md
@@ -5,8 +5,9 @@ Boardsesh glow-falloff A/B (issue #2202) — mobile only today.
 
 Source of truth: `packages/shared/analytics/src/board-render-events.ts`,
 re-exported from `@boardsesh/analytics`. Tests:
-`packages/shared/analytics/src/__tests__/board-render-events.test.ts` and
-`packages/mobile/src/lib/__tests__/climb-view-session.test.ts`
+`packages/shared/analytics/src/__tests__/board-render-events.test.ts`,
+`packages/mobile/src/lib/__tests__/climb-view-session.test.ts` and
+`packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx`
 (`vp test run --project analytics --reporter=agent` /
 `vp run test:mobile`).
 
@@ -37,7 +38,7 @@ a differently-cased duplicate — and a builder always returns `{ name,
 properties }` together, so a caller cannot pair one event's props with another
 event's name.
 
-## The seven events
+## The eight events
 
 | Event                          | Extra properties (beyond the common ones)             | Fired by                                                                            |
 | ------------------------------ | ------------------------------------------------------- | ------------------------------------------------------------------------------------ |
@@ -48,6 +49,7 @@ event's name.
 | `Board Render Preset Applied`  | `surface` (`'settings'` \| `'onboarding'`, optional) — otherwise the common props ARE the event | `trackBoardLookApplied` in `packages/mobile/src/lib/board-render/board-look-analytics.ts`, from the board-look carousel on both its surfaces |
 | `Board Look Step Shown`        | `options_shown`                                        | The one-time board-look step (`BoardLookStep.tsx`), once per presentation |
 | `Board Look Step Resolved`     | `outcome` (`'saved'` \| `'customized'` \| `'skipped'`), `selected_option`, `cards_viewed`, `ms_to_resolve` | The same step — exactly once per Shown, including the unmount-without-choosing path |
+| `Board Render Failed`          | `surface`, `stage`, `failure_kind`, `error_code`, `render_width`, `frames_length`, `failures_this_session` | `noteRenderFailure` in `packages/mobile/src/hooks/use-native-climb-render.ts` — the native render's `.catch` (both real failures and the capability fallbacks) and `reportOverlayLoadFailure`, the one writer for every expo-image load failure |
 
 ### The common properties every event carries
 
@@ -82,8 +84,86 @@ PostHog super properties (`registerRenderSuperProperties` in
 `packages/mobile/src/lib/analytics.ts`, called from a `useEffect` in
 `queue-provider.tsx` whenever `effectiveRenderSettings` changes) — mirroring
 the existing `connectivity` / `offline_engine_state` super properties. That
-means every OTHER event fired for the rest of the launch, not just the five
+means every OTHER event fired for the rest of the launch, not just the ones
 above, can be sliced by which drawing and which falloff this climber is on.
+
+## `Board Render Failed` — when the board does not draw
+
+Every other event on this page describes a render that worked. This one is the
+opposite, and it was added because a render that fails is otherwise invisible:
+the native rejection was a `console.warn` plus one Sentry event per failure kind
+per JS lifetime, the expo-image load failures were the same, and no dashboard
+had anything at all. A session where every render failed after the seventh swipe
+(the Aura 12x12 blank-overlay report) looked exactly like a session that never
+failed.
+
+It fires from two places, both in
+`packages/mobile/src/hooks/use-native-climb-render.ts`:
+
+- the native render's `.catch`, for every rejection — including the capability
+  fallbacks that Sentry is deliberately never told about (#4240);
+- `reportOverlayLoadFailure`, the single writer behind every `onOverlayError`
+  path, so a load failure cannot be handled without being counted.
+
+### Properties
+
+Common props (the table above) plus:
+
+| Property                | Values                                                                                                                                   |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `surface`               | `full` \| `thumbnail` — the play board or a list / accessory thumbnail (the hook's `filledStyle`)                                          |
+| `stage`                 | `native` \| `image_load` — which half of the path gave up                                                                                  |
+| `failure_kind`          | on `native`: `render_failed` \| `disk_full` \| `capability_fallback`. On `image_load`: `cache_entry_missing` \| `retry_exhausted` \| `cache_entry_present` \| `validation_failed` \| `validation_unsupported` |
+| `error_code`            | `code_<n>` \| `png` \| `cgimage` \| `write` \| `module` \| `capability` \| `other`                                                          |
+| `render_width`          | requested overlay width in pixels, or `null` for a native-width render                                                                     |
+| `frames_length`         | length of the frames string — a cheap proxy for climb complexity                                                                          |
+| `failures_this_session` | running count for this JS lifetime, INCLUDING this event                                                                                   |
+
+`stage` and `failure_kind` are one discriminated pair in
+`BoardRenderFailedInput`, not two free fields: a native rejection can never be
+`retry_exhausted` and an image load can never be `disk_full`. Pairing them in the
+type is what stops a call site inventing a combination no query would match.
+
+### `error_code` is a bucket, never the message
+
+The failure message interpolates the cache key, the cache path and — on iOS — OS
+prose in whatever language the phone is set to. None of that may be sent: the
+cache key identifies the climb, and a message-shaped property would shatter the
+event into one group per file, which is the exact mistake that once split one
+device's disk-full storm across three Sentry issue groups (#3647).
+
+`classifyBoardRenderErrorCode` (in `board-render-events.ts`) is the whole
+boundary. A numeric code the native layer named wins over everything else and is
+normalised (`code -002` → `code_-2`); otherwise the message is bucketed by shape.
+Overlay filenames are stripped BEFORE the prose match, because every iOS write
+failure carries `"v5_<key>.png"` and a bare `png` test would swallow the entire
+`write` bucket.
+
+### The 25-event session cap
+
+The hook counts every failure in a module-scoped counter and stops firing after
+25 per JS lifetime. The failure this event exists for is a device that fails
+EVERY render from some point on, and `getOrStartInflightRender` drops the settled
+promise, so every recycled FlashList row tries again — the storm shape from
+#3647. 25 events is plenty to see which stage, kind and code a session is stuck
+on. Past the cap nothing is sent but `failures_this_session` keeps counting, so
+a stream that stops at 25 reads as truncated rather than as a device that failed
+exactly 25 times.
+
+Sentry keeps its own, tighter budget — one report per failure kind per lifetime —
+and now carries `failuresThisSession` in `extra` plus a `board-render` breadcrumb
+for every failure, so the single report it does send can say whether it was a
+one-off or the first of hundreds.
+
+### Reading it
+
+Stratify the same way as everything else on this page: never pool across
+`board_name`, and never pool `render_mode`. Two useful reads:
+
+- failures per `Climb View Opened`, split by `board_name` × `render_mode` — the
+  Aura-vs-classic question the original report raised;
+- `stage` × `failure_kind` × `error_code` for one board, which is what separates
+  "the renderer is rejecting" from "the PNG will not load back".
 
 ## The builder rule
 
@@ -103,7 +183,7 @@ optional, and `track()` already expects exactly this shape.
 ## Why this IS in `SHARED_EVENTS`
 
 Unlike the gym funnel (which is www-only and lives in its own module,
-`gym-funnel.ts`, specifically to stay out of `SHARED_EVENTS`), the five event
+`gym-funnel.ts`, specifically to stay out of `SHARED_EVENTS`), the event
 names here live in `packages/shared/analytics/src/events.ts`'s
 `SHARED_EVENTS`. Mobile fires every one of them today, and nothing here is
 platform-exclusive the way the gym directory / claim flow / manage console

--- a/packages/mobile/src/components/BoardImageNative.tsx
+++ b/packages/mobile/src/components/BoardImageNative.tsx
@@ -26,6 +26,15 @@ type BoardImageNativeProps = {
    */
   filledStyle?: boolean;
   /**
+   * This is THE board the climber is looking at — the play drawer's current
+   * card. Sets `surface: 'play'` on render-failure telemetry and turns on the
+   * overlay paint watchdog. Every other call site (preview cards and rails, the
+   * preview sheet, the reaction menu, the wall kiosk hero, the carousel's
+   * off-screen peek) leaves it off: pooling those into one rate would describe
+   * nothing anybody experienced.
+   */
+  playSurface?: boolean;
+  /**
    * Target overlay/background width in px for small surfaces (e.g. the
    * 40×40 accessory thumbnail). Forwarded to useNativeClimbRender so the
    * Rust renderer + bundled background resolve at a small size instead of
@@ -104,6 +113,7 @@ const BoardImageNative = React.memo(function BoardImageNative({
   boardHeight,
   mirrored,
   filledStyle = false,
+  playSurface = false,
   renderWidth,
   backgroundVariant,
   recyclingKey,
@@ -113,19 +123,27 @@ const BoardImageNative = React.memo(function BoardImageNative({
   renderSettingsOverride,
   holdColorOverride,
 }: BoardImageNativeProps) {
-  const { overlayUri, overlayLoadKey, onOverlayLoad, onOverlayError, backgroundPaths, missingBackgroundCount } =
-    useNativeClimbRender({
-      frames,
-      boardName,
-      layoutId,
-      sizeId,
-      setIds,
-      filledStyle,
-      renderWidth,
-      backgroundVariant,
-      renderSettingsOverride,
-      holdColorOverride,
-    });
+  const {
+    overlayUri,
+    overlayLoadKey,
+    onOverlayLoad,
+    onOverlayError,
+    onOverlayMounted,
+    backgroundPaths,
+    missingBackgroundCount,
+  } = useNativeClimbRender({
+    frames,
+    boardName,
+    layoutId,
+    sizeId,
+    setIds,
+    filledStyle,
+    playSurface,
+    renderWidth,
+    backgroundVariant,
+    renderSettingsOverride,
+    holdColorOverride,
+  });
 
   const containerStyle: ViewStyle = {
     width: '100%',
@@ -140,6 +158,7 @@ const BoardImageNative = React.memo(function BoardImageNative({
         overlayLoadKey={overlayLoadKey}
         onOverlayLoad={onOverlayLoad}
         onOverlayError={onOverlayError}
+        onOverlayMounted={onOverlayMounted}
         backgroundPaths={backgroundPaths}
         missingBackgroundCount={missingBackgroundCount}
         mirrored={mirrored}

--- a/packages/mobile/src/components/LayeredClimbImage.tsx
+++ b/packages/mobile/src/components/LayeredClimbImage.tsx
@@ -15,6 +15,16 @@ type LayeredClimbImageProps = {
   overlayLoadKey?: string | null;
   onOverlayLoad?: (loadKey: string | null) => void;
   onOverlayError?: (event: ImageErrorEventData, loadKey: string | null) => void;
+  /**
+   * Report whether an overlay `<Image>` is MOUNTED: its load key while one is,
+   * `null` the moment there is none.
+   *
+   * This component renders no image at all while hidden (see `hidden` below), so
+   * `overlayUri` being set is not the same question as "something is on screen
+   * that can call `onLoad`". Anything waiting on a paint has to key off this,
+   * not off the URI.
+   */
+  onOverlayMounted?: (mountedLoadKey: string | null) => void;
   backgroundPaths: string[];
   /**
    * Number of background layers the cache couldn't resolve. Each missing
@@ -71,6 +81,7 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
   overlayLoadKey,
   onOverlayLoad,
   onOverlayError,
+  onOverlayMounted,
   backgroundPaths,
   missingBackgroundCount = 0,
   mirrored,
@@ -115,6 +126,16 @@ const LayeredClimbImage = React.memo(function LayeredClimbImage({
   useEffect(() => {
     setOverlayPainted(false);
   }, [overlayUri, overlayLoadKey]);
+  // Mirror the exact condition the overlay `<Image>` below renders under, so a
+  // consumer waiting on a paint learns the instant there is nothing left to
+  // paint — the app backgrounding, or this tab's board art being released while
+  // the component stays mounted. The cleanup covers unmount as well.
+  const overlayMountedKey = !hidden && overlayUri ? (overlayLoadKey ?? null) : null;
+  const overlayImageMounted = !hidden && !!overlayUri;
+  useEffect(() => {
+    onOverlayMounted?.(overlayImageMounted ? overlayMountedKey : null);
+    return () => onOverlayMounted?.(null);
+  }, [onOverlayMounted, overlayImageMounted, overlayMountedKey]);
   if (hidden) {
     return <View style={[styles.stack, mirrored && styles.mirrored]} />;
   }

--- a/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
+++ b/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
@@ -300,6 +300,10 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
               recyclingKey={currentFrames}
               style={boardStyle}
               overlayTestID="play-drawer-board-overlay"
+              // The one board a climber is actually looking at: `surface: 'play'`
+              // on render-failure telemetry, and the only surface that watches
+              // for an overlay that never paints. Never the peek below.
+              playSurface
             />
           </View>
         ) : (
@@ -325,6 +329,9 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
                 // instant (no-fade) swap lands it before the reset uncovers it —
                 // killing the Android end-of-swipe flash. See isCommitting above.
                 suppressOverlayTransition={isCommitting}
+                // See the screenshot-mode board above: the current card is the
+                // only `surface: 'play'` in the app.
+                playSurface
               />
             </Animated.View>
           </Animated.View>

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-boardsesh.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-boardsesh.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../../lib/background-image-cache', () => ({
 }));
 
 const reportErrorMock = vi.hoisted(() => vi.fn());
-vi.mock('../../lib/error-reporting', () => ({ reportError: reportErrorMock }));
+vi.mock('../../lib/error-reporting', () => ({ reportError: reportErrorMock, addErrorBreadcrumb: vi.fn() }));
 
 // The store hydrates from AsyncStorage; the hook only ever reads its snapshot,
 // so the suite drives that snapshot directly. Referentially stable per case —

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-capability-fallback.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-capability-fallback.test.tsx
@@ -19,11 +19,19 @@ vi.mock('expo-file-system', () => ({
   Paths: { cache: { uri: 'file:///cache/' } },
 }));
 
+// One hold per placement id these frames light. The render path now skips a
+// config whose holds match NONE of the lit ids (the silent blank-overlay case:
+// a climb from another board drawn under this one), so a fixture board has to
+// actually contain the ids its climbs light.
+function mockHolds(ids: number[]) {
+  return ids.map((id) => ({ id, mirroredHoldId: null, cx: 100, cy: 200, r: 20 }));
+}
+
 vi.mock('../../lib/board-details', () => ({
   getBoardRenderData: vi.fn(() => ({
     boardWidth: 1000,
     boardHeight: 1200,
-    holdsData: [{ id: 1, mirroredHoldId: null, cx: 100, cy: 200, r: 20 }],
+    holdsData: mockHolds([1100, 1200]),
   })),
 }));
 

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-capability-fallback.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-capability-fallback.test.tsx
@@ -35,6 +35,7 @@ vi.mock('../../lib/background-image-cache', () => ({
 const reportErrorMock = vi.hoisted(() => vi.fn());
 vi.mock('../../lib/error-reporting', () => ({
   reportError: reportErrorMock,
+  addErrorBreadcrumb: vi.fn(),
 }));
 
 // A climber who set BOTH a colour and a marker shape. Referentially stable so

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-disk-full.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-disk-full.test.tsx
@@ -44,11 +44,19 @@ vi.mock('expo-file-system', () => ({
   },
 }));
 
+// One hold per placement id these frames light. The render path now skips a
+// config whose holds match NONE of the lit ids (the silent blank-overlay case:
+// a climb from another board drawn under this one), so a fixture board has to
+// actually contain the ids its climbs light.
+function mockHolds(ids: number[]) {
+  return ids.map((id) => ({ id, mirroredHoldId: null, cx: 100, cy: 200, r: 20 }));
+}
+
 vi.mock('../../lib/board-details', () => ({
   getBoardRenderData: vi.fn(() => ({
     boardWidth: 1000,
     boardHeight: 1200,
-    holdsData: [{ id: 1, mirroredHoldId: null, cx: 100, cy: 200, r: 20 }],
+    holdsData: mockHolds(Array.from({ length: 40 }, (_, index) => 1000 + index)),
   })),
 }));
 

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-disk-full.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-disk-full.test.tsx
@@ -58,7 +58,7 @@ vi.mock('../../lib/background-image-cache', () => ({
 }));
 
 const reportErrorMock = vi.hoisted(() => vi.fn());
-vi.mock('../../lib/error-reporting', () => ({ reportError: reportErrorMock }));
+vi.mock('../../lib/error-reporting', () => ({ reportError: reportErrorMock, addErrorBreadcrumb: vi.fn() }));
 
 const sweepBoardArtCache = vi.hoisted(() =>
   vi.fn(() => Promise.resolve({ beforeBytes: 0, freedBytes: 0, filesDeleted: 0 })),

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx
@@ -47,11 +47,19 @@ vi.mock('expo-file-system', () => ({
   },
 }));
 
+// One hold per placement id these frames light. The render path now skips a
+// config whose holds match NONE of the lit ids (the silent blank-overlay case:
+// a climb from another board drawn under this one), so a fixture board has to
+// actually contain the ids its climbs light.
+function mockHolds(ids: number[]) {
+  return ids.map((id) => ({ id, mirroredHoldId: null, cx: 100, cy: 200, r: 20 }));
+}
+
 vi.mock('../../lib/board-details', () => ({
   getBoardRenderData: vi.fn(() => ({
     boardWidth: 1000,
     boardHeight: 1200,
-    holdsData: [{ id: 1, mirroredHoldId: null, cx: 100, cy: 200, r: 20 }],
+    holdsData: mockHolds([1100, 1200, 1500, 1600, 9999, ...Array.from({ length: 40 }, (_, index) => 2000 + index)]),
   })),
 }));
 
@@ -159,6 +167,11 @@ beforeAll(async () => {
 beforeEach(() => {
   renderRejection.message = 'Rust render failed with code -2';
   existingOverlayUris.clear();
+  // Resets the whole module's failure state, not just the warm-up latch: the
+  // overlay index, `reportedOverlayLoadTelemetry` (Sentry's once-per-kind set),
+  // `reportedRenderFailures`, the disk back-off and the per-lifetime failure
+  // counter. Without it the counter would carry the beforeAll warm-up's
+  // failures into every `failures_this_session` assertion below.
   _resetWarmupForTests();
   _renderedOverlaysForTests.clear();
   _inflightRendersForTests.clear();
@@ -373,6 +386,145 @@ describe('one bounded self-retry after a native render failure', () => {
       await vi.advanceTimersByTimeAsync(5_000);
     });
     expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
+  });
+});
+
+// The failure the Android emulator repro pinned down: the native render
+// SUCCEEDS and writes a veil-only PNG, because the climb's frames name
+// placement ids this board config has no holds for (a Kilter Homewall climb,
+// ids 4000+, drawn under Kilter Original 12x12). The Rust renderer drops every
+// unmatched hold and returns Ok — no rejection, nothing logged.
+describe('Board Render Failed — the config stage', () => {
+  const OFF_BOARD_FRAMES = 'p4000r12p4001r13';
+
+  it('reports a climb whose frames match no hold on this board, and skips the render', async () => {
+    renderRow({ frames: OFF_BOARD_FRAMES });
+    await waitFor(() => expect(failureEvents()).toHaveLength(1));
+
+    expect(failureEvents()[0]).toMatchObject({
+      stage: 'config',
+      failure_kind: 'no_matching_holds',
+      error_code: 'no_matching_holds',
+      board_name: 'kilter',
+      lit_count: 2,
+      unmatched_count: 2,
+    });
+    // Rendering would write and cache a veil with nothing on it, which makes
+    // the same failure quieter every time the climber comes back to it.
+    expect(fakeNativeModule.renderHoldsOverlay).not.toHaveBeenCalled();
+  });
+
+  it('still renders a climb that only partly overhangs the board', async () => {
+    // 1100 exists on the fixture board, 4000 does not.
+    renderRow({ frames: 'p1100r12p4000r13' });
+    await waitFor(() => expect(failureEvents()).toHaveLength(1));
+
+    expect(failureEvents()[0]).toMatchObject({
+      stage: 'config',
+      failure_kind: 'partial_hold_match',
+      lit_count: 2,
+      unmatched_count: 1,
+    });
+    // Degraded is not blank: the holds that do exist still get drawn.
+    expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves a climb whose holds all exist completely alone', async () => {
+    renderRow();
+    await waitFor(() => expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalled());
+
+    expect(failureEvents().filter((event) => event.stage === 'config')).toHaveLength(0);
+  });
+});
+
+// The remaining iOS suspect: a correctly rendered file that expo-image never
+// paints. The same climbs draw on Android and on the host, so silence — neither
+// onLoad nor onError — is a third outcome nothing was watching for.
+describe('the overlay paint watchdog', () => {
+  /** A cached overlay, so the hook hands one straight to expo-image. */
+  function renderWithCachedOverlay(overrides: { filledStyle?: boolean } = {}) {
+    _cacheRenderedOverlayForTests(cacheKeyFor(FRAMES), 'file:///overlay-cached.png');
+    return renderRow(overrides);
+  }
+
+  it('reports an overlay expo-image never answered for', async () => {
+    vi.useFakeTimers();
+    const { result } = renderWithCachedOverlay();
+    expect(result.current.overlayUri).toBe('file:///overlay-cached.png');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4100);
+    });
+
+    expect(failureEvents()).toHaveLength(1);
+    expect(failureEvents()[0]).toMatchObject({
+      stage: 'image_load',
+      failure_kind: 'paint_timeout',
+      error_code: 'paint_timeout',
+      surface: 'full',
+    });
+    // Observation only: the overlay is still on screen and nothing was retried.
+    expect(result.current.overlayUri).toBe('file:///overlay-cached.png');
+    expect(fakeNativeModule.renderHoldsOverlay).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet when expo-image answers in time', async () => {
+    vi.useFakeTimers();
+    const { result } = renderWithCachedOverlay();
+
+    act(() => result.current.onOverlayLoad(result.current.overlayLoadKey));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(failureEvents()).toHaveLength(0);
+  });
+
+  it('stays quiet when expo-image answers with an error — that is the other path', async () => {
+    vi.useFakeTimers();
+    const { result } = renderWithCachedOverlay();
+
+    act(() => result.current.onOverlayError({ error: 'Failed to load' }, result.current.overlayLoadKey));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(failureEvents().filter((event) => event.failure_kind === 'paint_timeout')).toHaveLength(0);
+  });
+
+  // A list of thumbnails would arm one timer per visible row, and the report is
+  // about the board the climber is actually looking at.
+  it('never watches a thumbnail', async () => {
+    vi.useFakeTimers();
+    _cacheRenderedOverlayForTests(
+      buildCacheKey(BASE.boardName, BASE.layoutId, BASE.sizeId, BASE.setIds, FRAMES, true),
+      'file:///overlay-thumb.png',
+    );
+    renderRow({ filledStyle: true });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(failureEvents().filter((event) => event.failure_kind === 'paint_timeout')).toHaveLength(0);
+  });
+
+  it('does not stack timers across a rapid swipe', async () => {
+    vi.useFakeTimers();
+    _cacheRenderedOverlayForTests(cacheKeyFor(FRAMES), 'file:///overlay-a.png');
+    const otherFrames = 'p1500r12p1600r13';
+    _cacheRenderedOverlayForTests(cacheKeyFor(otherFrames), 'file:///overlay-b.png');
+    const { rerender } = renderHook(({ frames }) => useNativeClimbRender({ ...BASE, frames }), {
+      initialProps: { frames: FRAMES },
+    });
+
+    rerender({ frames: otherFrames });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4100);
+    });
+
+    // One timer per hook instance: the swipe cancelled the first climb's watch.
+    expect(failureEvents().filter((event) => event.failure_kind === 'paint_timeout')).toHaveLength(1);
   });
 });
 

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx
@@ -1,0 +1,395 @@
+// @vitest-environment jsdom
+//
+// Render failures used to be invisible.
+//
+// Field shape: on iOS, the Aura look on Kilter Original 12x12 stopped drawing
+// the play board's hold overlay after ~7 swipes and never came back until the
+// app was restarted — thumbnails kept working the whole time. Nothing in the
+// app could say why. The native rejection was a `console.warn` plus ONE Sentry
+// event per failure kind per JS lifetime, the expo-image load failures were the
+// same, and there was no product-analytics event for a mobile render failure at
+// all. So a session that failed every render after a point looked, in every
+// dashboard we have, exactly like a session that never failed.
+//
+// Two things are asserted here:
+//
+//  1. Every failure — both stages, capability fallbacks included — fires
+//     `Board Render Failed`, carrying enough to stratify (board, drawing,
+//     surface) and nothing that identifies a file or a climb.
+//  2. A native `render_failed` retries itself exactly ONCE per cache key, so a
+//     stationary play board repairs itself instead of sitting blank, and a
+//     recycled FlashList row can never turn that into a storm.
+
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+vi.mock('../../providers/theme-provider', () => ({ useAppColorScheme: () => 'light' }));
+
+/** Overlay URIs the cache directory currently holds. */
+const existingOverlayUris = vi.hoisted(() => new Set<string>());
+class MockFile {
+  constructor(private readonly uri: string) {}
+  get exists(): boolean {
+    return existingOverlayUris.has(this.uri);
+  }
+  get name(): string {
+    return this.uri;
+  }
+}
+
+vi.mock('expo-file-system', () => ({
+  Directory: vi.fn(() => ({ exists: false, list: () => [] })),
+  File: MockFile,
+  Paths: {
+    cache: { uri: 'file:///cache/' },
+    // Plenty of room, so nothing here is ever misread as a full disk.
+    availableDiskSpace: 8 * 1024 * 1024 * 1024,
+  },
+}));
+
+vi.mock('../../lib/board-details', () => ({
+  getBoardRenderData: vi.fn(() => ({
+    boardWidth: 1000,
+    boardHeight: 1200,
+    holdsData: [{ id: 1, mirroredHoldId: null, cx: 100, cy: 200, r: 20 }],
+  })),
+}));
+
+vi.mock('../../lib/background-image-cache', () => ({
+  tryGetBackgroundPathsSync: vi.fn(() => ({ paths: ['file:///bg.png'], missingCount: 0 })),
+  ensureBackgroundsCached: vi.fn(async () => ({ paths: ['file:///bg.png'], missingCount: 0 })),
+}));
+
+const reportErrorMock = vi.hoisted(() => vi.fn());
+const addErrorBreadcrumbMock = vi.hoisted(() => vi.fn());
+vi.mock('../../lib/error-reporting', () => ({
+  reportError: reportErrorMock,
+  addErrorBreadcrumb: addErrorBreadcrumbMock,
+}));
+
+const trackMock = vi.hoisted(() => vi.fn());
+vi.mock('../../lib/analytics', () => ({ track: trackMock }));
+
+vi.mock('../../lib/hold-color-overrides', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../lib/hold-color-overrides')>();
+  // Referentially STABLE: these feed the overlay effect's deps, and a fresh
+  // object per render would re-fire it every tick.
+  const stableOverrides = {
+    overrides: {},
+    shapes: {},
+    brushThickness: original.DEFAULT_HOLD_BRUSH_THICKNESS,
+    shapeSize: original.DEFAULT_HOLD_SHAPE_SIZE,
+    renderSignature: original.DEFAULT_HOLD_COLOR_SIGNATURE,
+  };
+  return { ...original, useHoldColorOverrides: () => stableOverrides };
+});
+
+/** What the native renderer rejects with, per test. */
+const renderRejection = vi.hoisted(() => ({ message: 'Rust render failed with code -2' }));
+
+const fakeNativeModule = {
+  boardRendererNative: {},
+  renderHoldsOverlay: vi.fn((_configJson: string, _cacheKey: string) =>
+    Promise.reject(new Error(renderRejection.message)),
+  ),
+};
+
+const {
+  useNativeClimbRender,
+  buildCacheKey,
+  _cacheRenderedOverlayForTests,
+  _inflightRendersForTests,
+  _renderedOverlaysForTests,
+  _resetWarmupForTests,
+  _setNativeModuleForTests,
+  _RENDER_FAILURE_EVENT_CAP_FOR_TESTS,
+  _MARKER_RENDERER_UNAVAILABLE_MESSAGE_FOR_TESTS,
+} = await import('../use-native-climb-render');
+
+const BASE = { boardName: 'kilter' as const, layoutId: 1, sizeId: 10, setIds: '26,27', filledStyle: false };
+const FRAMES = 'p1100r12p1200r13';
+
+type FailureProperties = {
+  board_name: string;
+  layout_id: number;
+  size_id: number;
+  render_mode: string;
+  glow_falloff: string;
+  glow_falloff_source: string;
+  surface: string;
+  stage: string;
+  failure_kind: string;
+  error_code: string;
+  render_width: number | null;
+  frames_length: number;
+  failures_this_session: number;
+};
+
+/** Every `Board Render Failed` fired so far, in order. */
+function failureEvents(): FailureProperties[] {
+  return trackMock.mock.calls
+    .filter(([name]) => name === 'Board Render Failed')
+    .map(([, properties]) => properties as FailureProperties);
+}
+
+function renderRow(overrides: { frames?: string; filledStyle?: boolean; renderWidth?: number } = {}) {
+  return renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES, ...overrides }));
+}
+
+function cacheKeyFor(frames: string): string {
+  return buildCacheKey(BASE.boardName, BASE.layoutId, BASE.sizeId, BASE.setIds, frames, BASE.filledStyle);
+}
+
+// The Aura capability probe and the render-settings store both latch MODULE-wide
+// on the first mount, and each resolution re-runs the overlay effect — so the
+// very first row rendered in a file fails more than once and every later row
+// exactly once. Settle those latches on a throwaway row, so a per-test failure
+// count means what it says.
+beforeAll(async () => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  _setNativeModuleForTests(fakeNativeModule as unknown as Parameters<typeof _setNativeModuleForTests>[0]);
+  const warmup = renderRow({ frames: 'p9999r12' });
+  await waitFor(() => expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalled());
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  });
+  warmup.unmount();
+});
+
+beforeEach(() => {
+  renderRejection.message = 'Rust render failed with code -2';
+  existingOverlayUris.clear();
+  _resetWarmupForTests();
+  _renderedOverlaysForTests.clear();
+  _inflightRendersForTests.clear();
+  trackMock.mockClear();
+  reportErrorMock.mockClear();
+  addErrorBreadcrumbMock.mockClear();
+  fakeNativeModule.renderHoldsOverlay.mockClear();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  _setNativeModuleForTests(fakeNativeModule as unknown as Parameters<typeof _setNativeModuleForTests>[0]);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('Board Render Failed — the native stage', () => {
+  it('reports a native rejection with the board, the surface and a bucketed error code', async () => {
+    renderRow();
+    await waitFor(() => expect(failureEvents()).toHaveLength(1));
+
+    expect(failureEvents()[0]).toMatchObject({
+      board_name: 'kilter',
+      layout_id: 1,
+      size_id: 10,
+      stage: 'native',
+      failure_kind: 'render_failed',
+      error_code: 'code_-2',
+      surface: 'full',
+      render_width: null,
+      frames_length: FRAMES.length,
+      failures_this_session: 1,
+    });
+    // The stratification props ride along on a failure too — a failure rate
+    // pooled across Aura and classic answers nothing.
+    expect(typeof failureEvents()[0].render_mode).toBe('string');
+    expect(typeof failureEvents()[0].glow_falloff_source).toBe('string');
+  });
+
+  it('names the thumbnail surface separately from the play board', async () => {
+    renderRow({ filledStyle: true, renderWidth: 400 });
+    await waitFor(() => expect(failureEvents()).toHaveLength(1));
+
+    expect(failureEvents()[0]).toMatchObject({ surface: 'thumbnail', render_width: 400 });
+  });
+
+  // The message interpolates the cache key and the cache path. Neither may
+  // reach an event property — it is the climb the climber is looking at, and it
+  // would shatter the event into one group per file.
+  it('sends nothing derived from the message, the filename or the cache key', async () => {
+    renderRejection.message = 'You can’t save the file “v5_secret-cache-key.png” because the volume is out of space';
+    renderRow();
+    await waitFor(() => expect(failureEvents()).toHaveLength(1));
+
+    const serialized = JSON.stringify(failureEvents()[0]);
+    expect(serialized).not.toContain('secret-cache-key');
+    expect(serialized).not.toContain('.png');
+    expect(serialized).not.toContain('file:///');
+  });
+
+  // A binary that cannot honour a config's marker overrides is a designed
+  // fallback, so Sentry deliberately never hears about it (#4240). That is
+  // exactly why it has to be visible somewhere else: the climber is looking at a
+  // different drawing than the one they chose.
+  it('reports the capability fallback that Sentry is told to ignore', async () => {
+    renderRejection.message = _MARKER_RENDERER_UNAVAILABLE_MESSAGE_FOR_TESTS;
+    renderRow();
+    await waitFor(() => expect(failureEvents().length).toBeGreaterThan(0));
+
+    expect(failureEvents()[0]).toMatchObject({
+      stage: 'native',
+      failure_kind: 'capability_fallback',
+      error_code: 'capability',
+    });
+    expect(reportErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('leaves a breadcrumb for every failure, even the ones Sentry never reports', async () => {
+    renderRejection.message = _MARKER_RENDERER_UNAVAILABLE_MESSAGE_FOR_TESTS;
+    renderRow();
+    await waitFor(() => expect(addErrorBreadcrumbMock).toHaveBeenCalled());
+
+    const breadcrumb = addErrorBreadcrumbMock.mock.calls[0][0] as { category: string; message: string };
+    expect(breadcrumb).toMatchObject({
+      category: 'board-render',
+      message: 'Board render failed: native/capability_fallback/capability',
+    });
+    expect(breadcrumb.message).not.toContain('.png');
+  });
+
+  // The Sentry report is once per kind per JS lifetime, so the FIRST failure is
+  // the only one anyone ever sees. Without the running count that report cannot
+  // say whether it was a one-off or the first of hundreds.
+  it('tells the one Sentry report how many failures the session has seen', async () => {
+    renderRow();
+    await waitFor(() => expect(reportErrorMock).toHaveBeenCalled());
+
+    const [, options] = reportErrorMock.mock.calls[0] as [Error, { extra: Record<string, unknown> }];
+    expect(options.extra.failuresThisSession).toBe(1);
+  });
+});
+
+describe('Board Render Failed — the image-load stage', () => {
+  it('reports an expo-image load failure under its own stage', async () => {
+    _cacheRenderedOverlayForTests(cacheKeyFor(FRAMES), 'file:///overlay-cached.png');
+    const { result } = renderRow();
+
+    act(() => result.current.onOverlayError({ error: 'Failed to load resource' }, result.current.overlayLoadKey));
+
+    await waitFor(() => expect(failureEvents().length).toBeGreaterThan(0));
+    expect(failureEvents()[0]).toMatchObject({
+      stage: 'image_load',
+      failure_kind: 'cache_entry_missing',
+      board_name: 'kilter',
+      surface: 'full',
+    });
+  });
+
+  it('buckets what expo-image said rather than passing the message through', async () => {
+    _cacheRenderedOverlayForTests(cacheKeyFor(FRAMES), 'file:///overlay-cached.png');
+    const { result } = renderRow();
+
+    act(() => result.current.onOverlayError({ error: 'PNG decoder returned null' }, result.current.overlayLoadKey));
+
+    await waitFor(() => expect(failureEvents().length).toBeGreaterThan(0));
+    expect(failureEvents()[0].error_code).toBe('png');
+  });
+
+  // Sentry's guard here is once-per-kind too. The PostHog event is what turns
+  // "it happened at least once this launch" into a rate.
+  it('keeps reporting to PostHog after Sentry has gone quiet for that kind', async () => {
+    _cacheRenderedOverlayForTests(cacheKeyFor(FRAMES), 'file:///overlay-a.png');
+    const rowA = renderRow();
+    act(() => rowA.result.current.onOverlayError({ error: 'Failed to load' }, rowA.result.current.overlayLoadKey));
+
+    const otherFrames = 'p1500r12p1600r13';
+    _cacheRenderedOverlayForTests(cacheKeyFor(otherFrames), 'file:///overlay-b.png');
+    const rowB = renderRow({ frames: otherFrames });
+    act(() => rowB.result.current.onOverlayError({ error: 'Failed to load' }, rowB.result.current.overlayLoadKey));
+
+    await waitFor(() => expect(failureEvents().filter((event) => event.stage === 'image_load')).toHaveLength(2));
+    const sentryImageLoadReports = reportErrorMock.mock.calls.filter(([error]) =>
+      String((error as Error).message).startsWith('Generated overlay image load failed'),
+    );
+    expect(sentryImageLoadReports).toHaveLength(1);
+  });
+});
+
+describe('one bounded self-retry after a native render failure', () => {
+  it('retries a failed key exactly once, then leaves it alone', async () => {
+    vi.useFakeTimers();
+    renderRow();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
+
+    // The retry lands, re-enters the render path, and fails again.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1600);
+    });
+    expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(2);
+
+    // …and that is the end of it. A second retry for the same key is the storm
+    // the keyed guard exists to prevent.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a full disk — the back-off owns that path', async () => {
+    renderRejection.message = 'write failed: ENOSPC (No space left on device)';
+    vi.useFakeTimers();
+    renderRow();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(failureEvents()[0]).toMatchObject({ failure_kind: 'disk_full' });
+    const callsAfterFirstFailure = fakeNativeModule.renderHoldsOverlay.mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1600);
+    });
+    // The 60s disk back-off is the only thing allowed to bring this key back.
+    expect(fakeNativeModule.renderHoldsOverlay.mock.calls.length).toBe(callsAfterFirstFailure);
+  });
+
+  it('does not retry a capability fallback — the degraded re-render is the retry', async () => {
+    renderRejection.message = _MARKER_RENDERER_UNAVAILABLE_MESSAGE_FOR_TESTS;
+    vi.useFakeTimers();
+    renderRow();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    const callsAfterFirstFailure = fakeNativeModule.renderHoldsOverlay.mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1600);
+    });
+    expect(fakeNativeModule.renderHoldsOverlay.mock.calls.length).toBe(callsAfterFirstFailure);
+  });
+
+  it('drops a pending retry when the surface unmounts', async () => {
+    vi.useFakeTimers();
+    const { unmount } = renderRow();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('the per-lifetime event cap', () => {
+  it('stops firing after the cap but keeps counting', async () => {
+    vi.useFakeTimers();
+    const cap = _RENDER_FAILURE_EVENT_CAP_FOR_TESTS;
+    // One row per distinct climb, the way a FlashList recycles through a list.
+    for (let index = 0; index < cap + 8; index += 1) renderRow({ frames: `p${2000 + index}r12` });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(failureEvents()).toHaveLength(cap);
+    // The last event that got through still says how many failures there were,
+    // so a stream that stops at the cap reads as truncated rather than as a
+    // device that failed exactly `cap` times.
+    expect(failureEvents().at(-1)?.failures_this_session).toBe(cap);
+  });
+});

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx
@@ -111,6 +111,7 @@ const {
   _resetWarmupForTests,
   _setNativeModuleForTests,
   _RENDER_FAILURE_EVENT_CAP_FOR_TESTS,
+  _CONFIG_FAILURE_EVENT_CAP_FOR_TESTS,
   _MARKER_RENDERER_UNAVAILABLE_MESSAGE_FOR_TESTS,
 } = await import('../use-native-climb-render');
 
@@ -140,7 +141,9 @@ function failureEvents(): FailureProperties[] {
     .map(([, properties]) => properties as FailureProperties);
 }
 
-function renderRow(overrides: { frames?: string; filledStyle?: boolean; renderWidth?: number } = {}) {
+function renderRow(
+  overrides: { frames?: string; filledStyle?: boolean; renderWidth?: number; playSurface?: boolean } = {},
+) {
   return renderHook(() => useNativeClimbRender({ ...BASE, frames: FRAMES, ...overrides }));
 }
 
@@ -210,11 +213,27 @@ describe('Board Render Failed — the native stage', () => {
     expect(typeof failureEvents()[0].glow_falloff_source).toBe('string');
   });
 
-  it('names the thumbnail surface separately from the play board', async () => {
+  it('names the thumbnail surface separately', async () => {
     renderRow({ filledStyle: true, renderWidth: 400 });
     await waitFor(() => expect(failureEvents()).toHaveLength(1));
 
     expect(failureEvents()[0]).toMatchObject({ surface: 'thumbnail', render_width: 400 });
+  });
+
+  // Twelve call sites render a board at full size — preview cards and rails, the
+  // preview sheet, the reaction menu, the wall kiosk hero, the carousel's
+  // off-screen peek. Only the play drawer's CURRENT card opts in, so `play` has
+  // to be its own value: a rate pooled with the others describes nothing anyone
+  // experienced.
+  it('separates the one board the climber is looking at from every other full-size surface', async () => {
+    renderRow({ playSurface: true });
+    await waitFor(() => expect(failureEvents()).toHaveLength(1));
+    expect(failureEvents()[0].surface).toBe('play');
+
+    trackMock.mockClear();
+    renderRow({ frames: 'p1500r12p1600r13' });
+    await waitFor(() => expect(failureEvents()).toHaveLength(1));
+    expect(failureEvents()[0].surface).toBe('full');
   });
 
   // The message interpolates the cache key and the cache path. Neither may
@@ -422,11 +441,31 @@ describe('Board Render Failed — the config stage', () => {
     expect(failureEvents()[0]).toMatchObject({
       stage: 'config',
       failure_kind: 'partial_hold_match',
+      error_code: 'partial_hold_match',
       lit_count: 2,
       unmatched_count: 1,
     });
     // Degraded is not blank: the holds that do exist still get drawn.
     expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  // Nothing is cached when the render is skipped, so the cached-entry
+  // short-circuit at the top of the effect cannot absorb a swipe back — without
+  // a keyed guard the same unanswerable question spends the session budget
+  // again every time the climber returns to the climb.
+  it('reports one mismatch per climb, not one per effect run', async () => {
+    const { rerender } = renderHook(({ frames }) => useNativeClimbRender({ ...BASE, frames }), {
+      initialProps: { frames: OFF_BOARD_FRAMES },
+    });
+    await waitFor(() => expect(failureEvents()).toHaveLength(1));
+
+    rerender({ frames: FRAMES });
+    rerender({ frames: OFF_BOARD_FRAMES });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    expect(failureEvents().filter((event) => event.stage === 'config')).toHaveLength(1);
   });
 
   it('leaves a climb whose holds all exist completely alone', async () => {
@@ -440,73 +479,129 @@ describe('Board Render Failed — the config stage', () => {
 // The remaining iOS suspect: a correctly rendered file that expo-image never
 // paints. The same climbs draw on Android and on the host, so silence — neither
 // onLoad nor onError — is a third outcome nothing was watching for.
+//
+// The watchdog arms off the view layer's MOUNT signal, never off `overlayUri`.
+// `LayeredClimbImage` renders a bare `<View>` and no image at all while the app
+// is backgrounded or the tab's board art is released (opening `/play` does
+// exactly that to every other surface), and nothing there can ever fire
+// `onLoad` — so arming on the URI would have reported guaranteed-bogus silence.
 describe('the overlay paint watchdog', () => {
-  /** A cached overlay, so the hook hands one straight to expo-image. */
-  function renderWithCachedOverlay(overrides: { filledStyle?: boolean } = {}) {
+  /** A cached overlay, so the hook has one to hand the view layer. */
+  function renderPlayBoard(overrides: { playSurface?: boolean; filledStyle?: boolean } = {}) {
     _cacheRenderedOverlayForTests(cacheKeyFor(FRAMES), 'file:///overlay-cached.png');
-    return renderRow(overrides);
+    return renderRow({ playSurface: true, ...overrides });
   }
 
-  it('reports an overlay expo-image never answered for', async () => {
+  function paintTimeouts() {
+    return failureEvents().filter((event) => event.failure_kind === 'paint_timeout');
+  }
+
+  it('reports an overlay a mounted image never answered for', async () => {
     vi.useFakeTimers();
-    const { result } = renderWithCachedOverlay();
-    expect(result.current.overlayUri).toBe('file:///overlay-cached.png');
+    const { result } = renderPlayBoard();
+    act(() => result.current.onOverlayMounted(result.current.overlayLoadKey));
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(4100);
     });
 
-    expect(failureEvents()).toHaveLength(1);
-    expect(failureEvents()[0]).toMatchObject({
+    expect(paintTimeouts()).toHaveLength(1);
+    expect(paintTimeouts()[0]).toMatchObject({
       stage: 'image_load',
       failure_kind: 'paint_timeout',
       error_code: 'paint_timeout',
-      surface: 'full',
+      surface: 'play',
     });
     // Observation only: the overlay is still on screen and nothing was retried.
     expect(result.current.overlayUri).toBe('file:///overlay-cached.png');
     expect(fakeNativeModule.renderHoldsOverlay).not.toHaveBeenCalled();
   });
 
+  // The regression this shape exists to prevent. A surface with an overlay URI
+  // but no `<Image>` mounted cannot answer, so it must never be asked.
+  it('never reports a surface that is rendering no image at all', async () => {
+    vi.useFakeTimers();
+    const { result } = renderPlayBoard();
+    expect(result.current.overlayUri).toBe('file:///overlay-cached.png');
+    // The view layer never reports a mount: hidden by backgrounding, or by this
+    // tab's board art being released.
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(paintTimeouts()).toHaveLength(0);
+  });
+
+  it('disarms the moment a mounted image goes away', async () => {
+    vi.useFakeTimers();
+    const { result } = renderPlayBoard();
+    act(() => result.current.onOverlayMounted(result.current.overlayLoadKey));
+    // The app backgrounds, or /play opens and this tab releases its board art.
+    act(() => result.current.onOverlayMounted(null));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(paintTimeouts()).toHaveLength(0);
+  });
+
   it('stays quiet when expo-image answers in time', async () => {
     vi.useFakeTimers();
-    const { result } = renderWithCachedOverlay();
+    const { result } = renderPlayBoard();
+    act(() => result.current.onOverlayMounted(result.current.overlayLoadKey));
 
     act(() => result.current.onOverlayLoad(result.current.overlayLoadKey));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(10_000);
     });
 
-    expect(failureEvents()).toHaveLength(0);
+    expect(paintTimeouts()).toHaveLength(0);
   });
 
   it('stays quiet when expo-image answers with an error — that is the other path', async () => {
     vi.useFakeTimers();
-    const { result } = renderWithCachedOverlay();
+    const { result } = renderPlayBoard();
+    act(() => result.current.onOverlayMounted(result.current.overlayLoadKey));
 
     act(() => result.current.onOverlayError({ error: 'Failed to load' }, result.current.overlayLoadKey));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(10_000);
     });
 
-    expect(failureEvents().filter((event) => event.failure_kind === 'paint_timeout')).toHaveLength(0);
+    expect(paintTimeouts()).toHaveLength(0);
   });
 
-  // A list of thumbnails would arm one timer per visible row, and the report is
-  // about the board the climber is actually looking at.
+  // The carousel's peek board, the preview cards and rails, the preview sheet,
+  // the reaction menu and the wall kiosk hero all render a full-size board and
+  // none of them opts in.
+  it('never watches a surface that did not opt in', async () => {
+    vi.useFakeTimers();
+    const { result } = renderPlayBoard({ playSurface: false });
+    act(() => result.current.onOverlayMounted(result.current.overlayLoadKey));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(paintTimeouts()).toHaveLength(0);
+  });
+
   it('never watches a thumbnail', async () => {
     vi.useFakeTimers();
     _cacheRenderedOverlayForTests(
       buildCacheKey(BASE.boardName, BASE.layoutId, BASE.sizeId, BASE.setIds, FRAMES, true),
       'file:///overlay-thumb.png',
     );
-    renderRow({ filledStyle: true });
+    const { result } = renderRow({ filledStyle: true });
+    act(() => result.current.onOverlayMounted(result.current.overlayLoadKey));
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(10_000);
     });
 
-    expect(failureEvents().filter((event) => event.failure_kind === 'paint_timeout')).toHaveLength(0);
+    expect(paintTimeouts()).toHaveLength(0);
   });
 
   it('does not stack timers across a rapid swipe', async () => {
@@ -514,21 +609,46 @@ describe('the overlay paint watchdog', () => {
     _cacheRenderedOverlayForTests(cacheKeyFor(FRAMES), 'file:///overlay-a.png');
     const otherFrames = 'p1500r12p1600r13';
     _cacheRenderedOverlayForTests(cacheKeyFor(otherFrames), 'file:///overlay-b.png');
-    const { rerender } = renderHook(({ frames }) => useNativeClimbRender({ ...BASE, frames }), {
-      initialProps: { frames: FRAMES },
-    });
+    const { result, rerender } = renderHook(
+      ({ frames }) => useNativeClimbRender({ ...BASE, frames, playSurface: true }),
+      { initialProps: { frames: FRAMES } },
+    );
+    act(() => result.current.onOverlayMounted(result.current.overlayLoadKey));
 
     rerender({ frames: otherFrames });
+    act(() => result.current.onOverlayMounted(result.current.overlayLoadKey));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(4100);
     });
 
-    // One timer per hook instance: the swipe cancelled the first climb's watch.
-    expect(failureEvents().filter((event) => event.failure_kind === 'paint_timeout')).toHaveLength(1);
+    // One timer per hook instance: the swipe replaced the first climb's watch.
+    expect(paintTimeouts()).toHaveLength(1);
   });
 });
 
-describe('the per-lifetime event cap', () => {
+describe('the per-lifetime event caps', () => {
+  // A board whose sets do not cover a climb's holds produces a config mismatch
+  // on EVERY row of a list. Sharing one budget would let a single scroll spend
+  // the whole session on one answer and silence the native and image_load
+  // signals — the ones that actually move.
+  it('gives the config stage its own budget so a list scroll cannot silence the rest', async () => {
+    vi.useFakeTimers();
+    const configCap = _CONFIG_FAILURE_EVENT_CAP_FOR_TESTS;
+    // Distinct off-board climbs, the way a FlashList recycles through a list.
+    for (let index = 0; index < configCap + 10; index += 1) renderRow({ frames: `p${4000 + index}r12` });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(failureEvents().filter((event) => event.stage === 'config')).toHaveLength(configCap);
+
+    // The native budget is untouched, so a real render failure is still heard.
+    renderRow({ frames: 'p1100r12p1200r13' });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(failureEvents().filter((event) => event.stage === 'native').length).toBeGreaterThan(0);
+  });
+
   it('stops firing after the cap but keeps counting', async () => {
     vi.useFakeTimers();
     const cap = _RENDER_FAILURE_EVENT_CAP_FOR_TESTS;

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-failure-telemetry.test.tsx
@@ -318,6 +318,39 @@ describe('Board Render Failed — the image-load stage', () => {
     expect(failureEvents()[0].error_code).toBe('png');
   });
 
+  // PostHog is counting IMAGES THAT FAILED, so one `onError` must be one event.
+  // The terminal path used to fire the entry kind AND `retry_exhausted`, which
+  // made two real errors read as three failures and burned the budget a third
+  // early — while Sentry still wants both classes.
+  it('counts one failure per image error, even on the terminal path', async () => {
+    // A file that IS on disk and still will not decode: the path that spends the
+    // retry budget without invalidating anything, so two errors stay two errors
+    // with no render in between.
+    const overlayUri = 'file:///overlay-present.png';
+    _cacheRenderedOverlayForTests(cacheKeyFor(FRAMES), overlayUri);
+    existingOverlayUris.add(overlayUri);
+    const { result } = renderRow();
+
+    const imageLoadEvents = () => failureEvents().filter((event) => event.stage === 'image_load');
+
+    // First error spends the one retry; the second is terminal.
+    act(() => result.current.onOverlayError({ error: 'Failed to load' }, result.current.overlayLoadKey));
+    await waitFor(() => expect(imageLoadEvents()).toHaveLength(1));
+    expect(imageLoadEvents()[0].failure_kind).toBe('cache_entry_present');
+
+    act(() => result.current.onOverlayError({ error: 'Failed to load' }, result.current.overlayLoadKey));
+    await waitFor(() => expect(imageLoadEvents()).toHaveLength(2));
+
+    // Two errors, two failures — never three.
+    expect(imageLoadEvents()[1].failure_kind).toBe('retry_exhausted');
+    // Sentry still hears both classes on that terminal error.
+    const sentryKinds = reportErrorMock.mock.calls
+      .map(([error]) => String((error as Error).message))
+      .filter((message) => message.startsWith('Generated overlay image load failed'));
+    expect(sentryKinds).toContain('Generated overlay image load failed: cache_entry_present');
+    expect(sentryKinds).toContain('Generated overlay image load failed: retry_exhausted');
+  });
+
   // Sentry's guard here is once-per-kind too. The PostHog event is what turns
   // "it happened at least once this launch" into a rate.
   it('keeps reporting to PostHog after Sentry has gone quiet for that kind', async () => {
@@ -468,6 +501,49 @@ describe('Board Render Failed — the config stage', () => {
     expect(failureEvents().filter((event) => event.stage === 'config')).toHaveLength(1);
   });
 
+  // The regression that would have shipped: builds before this fix cached
+  // veil-only PNGs under the SAME RENDERER_VERSION, and the startup warm-up scan
+  // restores them from disk. With the check below the cache lookup, that entry
+  // was handed straight back — so everyone who already hit the bug would have
+  // kept a blank board forever, silently, even on the fixed build.
+  it('evicts a veil-only overlay an earlier build cached, instead of serving it forever', async () => {
+    const staleKey = cacheKeyFor(OFF_BOARD_FRAMES);
+    _cacheRenderedOverlayForTests(staleKey, 'file:///stale-veil.png');
+    expect(_renderedOverlaysForTests.get(staleKey)?.uri).toBe('file:///stale-veil.png');
+
+    const { result } = renderRow({ frames: OFF_BOARD_FRAMES });
+    await waitFor(() => expect(failureEvents()).toHaveLength(1));
+
+    expect(failureEvents()[0].failure_kind).toBe('no_matching_holds');
+    // Gone from the index, and never surfaced to the view layer.
+    expect(_renderedOverlaysForTests.get(staleKey)).toBeUndefined();
+    expect(result.current.overlayUri).toBeNull();
+    expect(fakeNativeModule.renderHoldsOverlay).not.toHaveBeenCalled();
+  });
+
+  // The state seed reads the index during the first render, so a stale entry is
+  // already on screen before the effect runs. Dropping it from the index alone
+  // would leave it painted.
+  it('takes a stale veil off screen, not just out of the index', async () => {
+    _cacheRenderedOverlayForTests(cacheKeyFor(OFF_BOARD_FRAMES), 'file:///stale-veil.png');
+    const { result } = renderRow({ frames: OFF_BOARD_FRAMES });
+
+    await waitFor(() => expect(result.current.overlayUri).toBeNull());
+  });
+
+  it('still short-circuits on a cache hit for a climb whose holds all exist', async () => {
+    _cacheRenderedOverlayForTests(cacheKeyFor(FRAMES), 'file:///overlay-good.png');
+    const { result } = renderRow();
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    expect(result.current.overlayUri).toBe('file:///overlay-good.png');
+    expect(fakeNativeModule.renderHoldsOverlay).not.toHaveBeenCalled();
+    expect(failureEvents()).toHaveLength(0);
+  });
+
   it('leaves a climb whose holds all exist completely alone', async () => {
     renderRow();
     await waitFor(() => expect(fakeNativeModule.renderHoldsOverlay).toHaveBeenCalled());
@@ -599,6 +675,41 @@ describe('the overlay paint watchdog', () => {
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(paintTimeouts()).toHaveLength(0);
+  });
+
+  // A late `onError` from the PREVIOUS image lands after the next one is already
+  // mounted and watched. Cancelling on it would silence exactly the case the
+  // watchdog exists to catch.
+  it('is not cancelled by a stale error from the image before it', async () => {
+    vi.useFakeTimers();
+    const { result } = renderPlayBoard();
+    const staleLoadKey = result.current.overlayLoadKey;
+    act(() => result.current.onOverlayMounted(staleLoadKey));
+
+    // A new image mounts and takes over the watch.
+    act(() => result.current.onOverlayMounted('99:0'));
+    // …and only now does the previous image's error arrive.
+    act(() => result.current.onOverlayError({ error: 'Failed to load' }, staleLoadKey));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4100);
+    });
+
+    expect(paintTimeouts()).toHaveLength(1);
+  });
+
+  it('is still cancelled by the error for the image it is actually watching', async () => {
+    vi.useFakeTimers();
+    const { result } = renderPlayBoard();
+    act(() => result.current.onOverlayMounted('99:0'));
+
+    act(() => result.current.onOverlayError({ error: 'Failed to load' }, '99:0'));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4100);
     });
 
     expect(paintTimeouts()).toHaveLength(0);

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-flags.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-flags.test.tsx
@@ -29,7 +29,7 @@ vi.mock('../../lib/background-image-cache', () => ({
   ensureBackgroundsCached: vi.fn(async () => ({ paths: [], missingCount: 0 })),
 }));
 
-vi.mock('../../lib/error-reporting', () => ({ reportError: vi.fn() }));
+vi.mock('../../lib/error-reporting', () => ({ reportError: vi.fn(), addErrorBreadcrumb: vi.fn() }));
 
 // The settings store hydrates from AsyncStorage; the hook only reads its
 // snapshot, so the suite drives that snapshot directly. `mode: 'default'`

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
@@ -45,6 +45,7 @@ vi.mock('../../lib/background-image-cache', () => ({
 const reportErrorMock = vi.hoisted(() => vi.fn());
 vi.mock('../../lib/error-reporting', () => ({
   reportError: reportErrorMock,
+  addErrorBreadcrumb: vi.fn(),
 }));
 
 vi.mock('../../lib/hold-color-overrides', async (importOriginal) => {

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render-race.test.tsx
@@ -29,11 +29,19 @@ vi.mock('expo-file-system', () => ({
   Paths: { cache: { uri: 'file:///cache/' } },
 }));
 
+// One hold per placement id these frames light. The render path now skips a
+// config whose holds match NONE of the lit ids (the silent blank-overlay case:
+// a climb from another board drawn under this one), so a fixture board has to
+// actually contain the ids its climbs light.
+function mockHolds(ids: number[]) {
+  return ids.map((id) => ({ id, mirroredHoldId: null, cx: 100, cy: 200, r: 20 }));
+}
+
 vi.mock('../../lib/board-details', () => ({
   getBoardRenderData: vi.fn(() => ({
     boardWidth: 1000,
     boardHeight: 1200,
-    holdsData: [{ id: 1, mirroredHoldId: null, cx: 100, cy: 200, r: 20 }],
+    holdsData: mockHolds([1100, 1200, 1300, 1400]),
   })),
 }));
 

--- a/packages/mobile/src/hooks/__tests__/use-native-climb-render.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-native-climb-render.test.ts
@@ -619,7 +619,7 @@ describe('withLitHoldGeometry', () => {
         ledBright: {},
         ledInner: { 10: plate, 20: plate, 30: plate },
       },
-      'p10r12p20r13',
+      new Set([10, 20]),
     );
     const byId = new Map(attached.map((hold) => [hold.id, hold]));
 
@@ -632,7 +632,7 @@ describe('withLitHoldGeometry', () => {
     const attached = _withLitHoldGeometryForTests(
       holds,
       { outlines: { 10: outline }, silhouetteLightness: {}, ledBright: {} },
-      'p10r12',
+      new Set([10]),
     );
     for (const hold of attached) {
       expect(hold.led_inner).toBeUndefined();

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -4,6 +4,7 @@ import {
   boardRenderFailed,
   buildBoardRenderTelemetryProps,
   classifyBoardRenderErrorCode,
+  type BoardRenderConfigFailureKind,
   type BoardRenderErrorCode,
   type BoardRenderFailureSurface,
   type BoardRenderImageLoadFailureKind,
@@ -498,9 +499,12 @@ let renderFailuresThisSession = 0;
 type RenderFailureNote = {
   errorCode: BoardRenderErrorCode;
   context: RenderFailureTelemetryContext;
+  /** `config`-stage only: how frame 0's lit ids lined up with the board. */
+  holdMatch?: { litCount: number; unmatchedCount: number };
 } & (
   | { stage: 'native'; failureKind: BoardRenderNativeFailureKind }
   | { stage: 'image_load'; failureKind: BoardRenderImageLoadFailureKind }
+  | { stage: 'config'; failureKind: BoardRenderConfigFailureKind }
 );
 
 /**
@@ -548,14 +552,21 @@ function noteRenderFailure(note: RenderFailureNote): number {
     render_width: context.renderWidth,
     frames_length: context.framesLength,
     failures_this_session: failuresThisSession,
+    // Omitted entirely off the config stage, so a `native` event never carries
+    // a meaningless zero that a query would have to special-case.
+    ...(note.holdMatch ? { lit_count: note.holdMatch.litCount, unmatched_count: note.holdMatch.unmatchedCount } : {}),
   };
   // Branch rather than spread a `{ stage, failure_kind }` pair: the two are one
   // discriminated pair in `BoardRenderFailedInput`, and keeping the branch is
   // what makes a mismatched combination a compile error instead of a cast.
-  const event =
-    note.stage === 'native'
-      ? boardRenderFailed({ ...shared, stage: 'native', failure_kind: note.failureKind })
-      : boardRenderFailed({ ...shared, stage: 'image_load', failure_kind: note.failureKind });
+  let event;
+  if (note.stage === 'native') {
+    event = boardRenderFailed({ ...shared, stage: 'native', failure_kind: note.failureKind });
+  } else if (note.stage === 'image_load') {
+    event = boardRenderFailed({ ...shared, stage: 'image_load', failure_kind: note.failureKind });
+  } else {
+    event = boardRenderFailed({ ...shared, stage: 'config', failure_kind: note.failureKind });
+  }
   track(event.name, event.properties);
   return failuresThisSession;
 }
@@ -723,6 +734,22 @@ const DISK_PRESSURE_MAX_RETRIES = 3;
  * done — see `retriedCacheKeysRef`.
  */
 const RENDER_RETRY_DELAY_MS = 1500;
+
+/**
+ * How long the full-size board waits for expo-image to say ANYTHING about an
+ * overlay it was handed.
+ *
+ * The remaining suspect in the Aura 12x12 report is a correctly rendered file
+ * that iOS never paints: the same climbs draw fine on Android and on the host,
+ * so the PNG is not the problem. expo-image is supposed to answer with `onLoad`
+ * or `onError`; silence for this long is a third outcome nothing was watching
+ * for. 4s is far past a local file decode (tens of ms) and short enough that the
+ * event lands in the same session as the swipe that caused it.
+ *
+ * Observation only — see the watchdog effect. Play board only: a list of
+ * thumbnails would arm one of these per row.
+ */
+const OVERLAY_PAINT_TIMEOUT_MS = 4000;
 
 function latchDiskPressure(): void {
   diskPressureUntilMs = Date.now() + DISK_PRESSURE_BACKOFF_MS;
@@ -938,6 +965,13 @@ const boardConfigCache = new Map<
     configBase: Record<string, unknown>;
     setIdsArray: number[];
     holds: RenderHold[];
+    /**
+     * Every placement id this board config can draw. Built once per entry
+     * because the mismatch check below runs on every render miss, and rebuilding
+     * a ~700-element Set per row of a scrolling list would be the one avoidable
+     * cost on that path.
+     */
+    holdIds: Set<number>;
     boardseshGeometry: BoardArtGeometry | null;
   }
 >();
@@ -1255,7 +1289,7 @@ function getBoardConfig(
       }
     }
 
-    cached = { configBase, setIdsArray, holds, boardseshGeometry };
+    cached = { configBase, setIdsArray, holds, holdIds: new Set(holds.map((hold) => hold.id)), boardseshGeometry };
     boardConfigCache.set(configKey, cached);
   }
 
@@ -1270,9 +1304,10 @@ function getBoardConfig(
   // not read outlines and are unaffected; `led_inner` and `silhouette_lightness`
   // drop out with the silhouette they were traced and measured against.
   if (!boardsesh || !cached.boardseshGeometry || boardsesh.settings.holdShape === 'circle') {
-    return { configBase: cached.configBase, setIdsArray: cached.setIdsArray };
+    return { configBase: cached.configBase, setIdsArray: cached.setIdsArray, holdIds: cached.holdIds };
   }
   return {
+    holdIds: cached.holdIds,
     configBase: {
       ...cached.configBase,
       holds: withLitHoldGeometry(
@@ -1652,6 +1687,10 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
   // Per-instance and keyed, so a recycled FlashList row landing back on a climb
   // that already failed cannot start a second retry, and a key can never storm.
   const retriedCacheKeysRef = useRef(new Set<string>());
+  // The pending paint watchdog, keyed by the load key it is watching, so the
+  // load/error callbacks can cancel exactly the one they answer and rapid swipes
+  // cannot stack timers.
+  const paintWatchdogRef = useRef<{ loadKey: string; timer: ReturnType<typeof setTimeout> } | null>(null);
   // The pending self-retry, held in a ref because it is armed from inside an
   // async .catch — long after the effect body returned its cleanup.
   const renderRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1669,6 +1708,10 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       renderWidth: renderWidth ?? null,
       framesLength: frames.length,
     }),
+    // `frames`, not `frames.length`: the memo only captures the length, but the
+    // effect below already depends on the whole string, so keying on the length
+    // would save nothing and would put a `.length` dep in a hot hook — the one
+    // shape docs/react-native-performance.md tells reviewers to reject.
     [boardName, layoutId, sizeId, effectiveRenderSettings, filledStyle, renderWidth, frames],
   );
 
@@ -1828,6 +1871,48 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       return () => clearTimeout(retryTimer);
     }
 
+    // Does this climb's frames even name holds this board config has?
+    //
+    // The failure this catches is SILENT. A climb from another board — a Kilter
+    // Homewall problem (placement ids 4000+) opened under Kilter Original 12x12
+    // (ids 1080-1590) — asks the renderer to light holds the config has no
+    // geometry for. The Rust renderer drops each unmatched hold and returns Ok,
+    // so the promise resolves, the PNG is written and cached, and the climber
+    // gets a veil with nothing drawn on it. Nothing rejects, nothing logs.
+    // Verified on the Android emulator.
+    const litHoldIds = parseLitHoldIds(frames);
+    if (litHoldIds.size > 0) {
+      let matchedCount = 0;
+      for (const holdId of litHoldIds) {
+        if (boardConfig.holdIds.has(holdId)) matchedCount += 1;
+      }
+      const unmatchedCount = litHoldIds.size - matchedCount;
+      if (unmatchedCount > 0) {
+        const noMatches = matchedCount === 0;
+        noteRenderFailure({
+          stage: 'config',
+          failureKind: noMatches ? 'no_matching_holds' : 'partial_hold_match',
+          errorCode: noMatches ? 'no_matching_holds' : 'other',
+          context: failureTelemetryContext,
+          holdMatch: { litCount: litHoldIds.size, unmatchedCount },
+        });
+        if (noMatches) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[useNativeClimbRender] no matching holds for ${currentCacheKey}: ${litHoldIds.size} lit, 0 on this board`,
+          );
+          // Skip the render. The overlay would be a veil with no holds on it,
+          // and writing it would cache the blank result under this key — making
+          // the same failure quieter on every later visit. Overlay stays null,
+          // backgrounds still show: the existing missing-layer contract.
+          return;
+        }
+        // A partial match still draws: a climb that legitimately reaches past a
+        // smaller layout loses the holds off the edge and keeps the rest. That
+        // is degraded, not blank, so it is reported and then rendered.
+      }
+    }
+
     const renderPromise = getOrStartInflightRender(currentCacheKey, () => {
       const configJson = JSON.stringify({
         ...boardConfig.configBase,
@@ -1970,8 +2055,24 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     failureTelemetryContext,
   ]);
 
+  /**
+   * Cancel the paint watchdog for one load key. A null key cancels whatever is
+   * pending — used by the error path, where any answer at all means expo-image
+   * is not silent, which is the only thing the watchdog is watching for.
+   */
+  const clearPaintWatchdog = useCallback((emittingLoadKey: string | null) => {
+    const pending = paintWatchdogRef.current;
+    if (!pending) return;
+    if (emittingLoadKey !== null && pending.loadKey !== emittingLoadKey) return;
+    clearTimeout(pending.timer);
+    paintWatchdogRef.current = null;
+  }, []);
+
   const onOverlayLoad = useCallback(
     (emittingLoadKey: string | null) => {
+      // Before the key-match guards below: a paint is a paint, and the watchdog
+      // only ever asks whether expo-image answered.
+      clearPaintWatchdog(emittingLoadKey);
       const expected = nativeRenderRef.current;
       if (
         !isLoadedNativeRender(expected) ||
@@ -1987,11 +2088,12 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
         retryBudgetRef.current.used = 0;
       }
     },
-    [currentCacheKey],
+    [currentCacheKey, clearPaintWatchdog],
   );
 
   const onOverlayError = useCallback(
     (event: { error: string }, emittingLoadKey: string | null) => {
+      clearPaintWatchdog(null);
       // expo-image's message names the file it could not load, so it is bucketed
       // to a closed set of codes before it goes anywhere. `png` here means the
       // decoder said so, not that a filename happened to end in `.png`.
@@ -2109,7 +2211,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       );
       setRecoveryRequest((request) => request + 1);
     },
-    [currentCacheKey, failureTelemetryContext],
+    [currentCacheKey, failureTelemetryContext, clearPaintWatchdog],
   );
 
   const verifyOverlayForNativeUse = useCallback(
@@ -2180,6 +2282,41 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     // verifyOverlayForNativeUse owns exact-attempt recovery. This state change
     // withholds the stale path from subsequent notification renders.
   }, [candidateOverlayUri, currentCacheKey, overlayLoadKey, verifyOverlayFile, verifyOverlayForNativeUse]);
+  // Paint watchdog: did expo-image ever answer for the overlay we handed it?
+  //
+  // Observation ONLY. Nothing is nulled and nothing is retried — a file that
+  // renders correctly on Android and on the host but never paints on iOS is a
+  // different fault from one that failed to load, and treating it as the latter
+  // (null the overlay, spend the retry budget) is exactly what would hide it
+  // again. The existing once-per-key retry budget is untouched.
+  //
+  // The cleanup covers three of the four cancel conditions on its own — the load
+  // key changing, the climb changing, and unmount. The fourth, expo-image
+  // answering, is `clearPaintWatchdog` in the two callbacks above.
+  useEffect(() => {
+    // Full-size play board only. A list arms one timer per visible row and the
+    // report is about the board the climber is looking at.
+    if (filledStyle) return;
+    if (!overlayUri || !overlayLoadKey) return;
+    const timer = setTimeout(() => {
+      paintWatchdogRef.current = null;
+      if (!mountedRef.current) return;
+      // eslint-disable-next-line no-console
+      console.warn(`[useNativeClimbRender] overlay never painted within ${OVERLAY_PAINT_TIMEOUT_MS}ms`);
+      noteRenderFailure({
+        stage: 'image_load',
+        failureKind: 'paint_timeout',
+        errorCode: 'paint_timeout',
+        context: failureTelemetryContext,
+      });
+    }, OVERLAY_PAINT_TIMEOUT_MS);
+    paintWatchdogRef.current = { loadKey: overlayLoadKey, timer };
+    return () => {
+      clearTimeout(timer);
+      if (paintWatchdogRef.current?.timer === timer) paintWatchdogRef.current = null;
+    };
+  }, [filledStyle, overlayUri, overlayLoadKey, failureTelemetryContext]);
+
   // Same guard for backgrounds: a stored entry from a prior boardKey
   // (FlashList row recycle case) must not bleed through to the new climb.
   const backgroundPaths = storedBackgrounds?.key === currentBoardKey ? storedBackgrounds.paths : [];

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -147,6 +147,19 @@ type NativeClimbRenderParams = {
    */
   verifyOverlayFile?: boolean;
   /**
+   * This is THE board the climber is looking at — the play drawer's current
+   * card, and nothing else. Two things key off it, and both would be wrong
+   * without an explicit opt-in:
+   *
+   *  * `surface: 'play'` on every failure event. Twelve other call sites render
+   *    at full size (preview cards and rails, the preview sheet, the reaction
+   *    menu, the wall kiosk hero, the carousel's off-screen peek), so a rate
+   *    that pooled them would not describe anything anyone saw.
+   *  * the paint watchdog, which only makes sense for a board on screen that a
+   *    climber is waiting on.
+   */
+  playSurface?: boolean;
+  /**
    * Draw under a DIFFERENT board-render settings bundle than the climber's
    * stored one — the board-look carousel, whose cards each show the same climb
    * under a different preset.
@@ -211,6 +224,12 @@ type NativeClimbRenderResult = {
   /** Exact-attempt callbacks consumed by LayeredClimbImage's overlay Image. */
   onOverlayLoad: (loadKey: string | null) => void;
   onOverlayError: (event: { error: string }, loadKey: string | null) => void;
+  /**
+   * Report whether an overlay `<Image>` is mounted right now: its load key while
+   * one is, `null` when there is none. Drives the paint watchdog, which must
+   * never run against a surface rendering no image at all.
+   */
+  onOverlayMounted: (mountedLoadKey: string | null) => void;
   /** Revalidate immediately before a non-Image native consumer uses the path. */
   verifyOverlayForNativeUse: (uri: string | null, loadKey: string | null) => string | null;
   /**
@@ -488,12 +507,54 @@ type RenderFailureTelemetryContext = {
 const RENDER_FAILURE_EVENT_CAP = 25;
 
 /**
- * Render failures seen this JS lifetime. Keeps counting past the cap, and rides
- * along on every event and Sentry report as `failures_this_session` /
- * `failuresThisSession` — so a stream that stops at 25 reads as truncated rather
- * than as a device that failed exactly 25 times.
+ * A much tighter budget for the config stage, and its OWN budget rather than a
+ * share of the 25 above.
+ *
+ * A config mismatch is a property of a climb-and-board pair, so one list scroll
+ * across a board whose sets do not cover a climb's holds can produce it on every
+ * row. Sharing one budget would let that spend the whole session's telemetry on
+ * a single answer and silence the native and image_load signals — which are the
+ * ones that move. Ten is plenty to establish that a board is serving climbs it
+ * cannot draw.
+ */
+const CONFIG_FAILURE_EVENT_CAP = 10;
+
+/**
+ * Render failures seen this JS lifetime, ALL stages. Keeps counting past every
+ * cap, and rides along on every event and Sentry report as
+ * `failures_this_session` / `failuresThisSession` — so a stream that stops reads
+ * as truncated rather than as a device that failed exactly that many times.
  */
 let renderFailuresThisSession = 0;
+/** Events actually sent, per budget. Only these two gate emission. */
+let configFailureEventsSent = 0;
+let renderFailureEventsSent = 0;
+
+/**
+ * Cache keys already reported as a config mismatch, across every hook instance.
+ *
+ * Module-level, not per instance: a FlashList recycles rows, so a per-instance
+ * guard would still report the same climb once per row that happens to land on
+ * it. A mismatch cannot change for a given cache key — the key already encodes
+ * the board, the sets and the frames — so the first answer is the only one.
+ *
+ * Bounded and insertion-ordered, so a long browse evicts the oldest keys rather
+ * than growing without limit; re-reporting a climb from 200 keys ago is a much
+ * cheaper failure than a set that never stops growing.
+ */
+const CONFIG_MISMATCH_KEY_MEMORY = 200;
+const reportedConfigMismatchKeys = new Set<string>();
+
+/** @returns true the FIRST time this cache key is seen, false afterwards. */
+function claimConfigMismatchKey(cacheKey: string): boolean {
+  if (reportedConfigMismatchKeys.has(cacheKey)) return false;
+  if (reportedConfigMismatchKeys.size >= CONFIG_MISMATCH_KEY_MEMORY) {
+    const oldestKey = reportedConfigMismatchKeys.keys().next().value;
+    if (oldestKey !== undefined) reportedConfigMismatchKeys.delete(oldestKey);
+  }
+  reportedConfigMismatchKeys.add(cacheKey);
+  return true;
+}
 
 /** One failure, as the two reporting paths describe it. */
 type RenderFailureNote = {
@@ -539,7 +600,15 @@ function noteRenderFailure(note: RenderFailureNote): number {
     },
   });
 
-  if (failuresThisSession > RENDER_FAILURE_EVENT_CAP) return failuresThisSession;
+  // Two independent budgets — see CONFIG_FAILURE_EVENT_CAP for why the config
+  // stage must not be able to spend the one the other stages rely on.
+  if (note.stage === 'config') {
+    if (configFailureEventsSent >= CONFIG_FAILURE_EVENT_CAP) return failuresThisSession;
+    configFailureEventsSent += 1;
+  } else {
+    if (renderFailureEventsSent >= RENDER_FAILURE_EVENT_CAP) return failuresThisSession;
+    renderFailureEventsSent += 1;
+  }
 
   const shared = {
     ...buildBoardRenderTelemetryProps(context.effective, {
@@ -766,10 +835,14 @@ export function _resetRenderFailureStateForTests(): void {
   reportedRenderFailures.clear();
   diskPressureUntilMs = 0;
   renderFailuresThisSession = 0;
+  configFailureEventsSent = 0;
+  renderFailureEventsSent = 0;
+  reportedConfigMismatchKeys.clear();
 }
 
-/** Test-only view of the per-lifetime failure counter and its cap. */
+/** Test-only view of the two per-lifetime event budgets. */
 export const _RENDER_FAILURE_EVENT_CAP_FOR_TESTS = RENDER_FAILURE_EVENT_CAP;
+export const _CONFIG_FAILURE_EVENT_CAP_FOR_TESTS = CONFIG_FAILURE_EVENT_CAP;
 
 /**
  * One-time eager scan of the native module's PNG cache directory. The
@@ -1007,10 +1080,9 @@ function parseLitHoldIds(frames: string): Set<number> {
 function withLitHoldGeometry(
   holds: RenderHold[],
   geometry: BoardArtGeometry,
-  frames: string,
+  litHoldIds: Set<number>,
   spillNeighbours = false,
 ): RenderHold[] {
-  const litHoldIds = parseLitHoldIds(frames);
   if (litHoldIds.size === 0) return holds;
   // A spill-bearing style's light spill brightens glow landing on unlit TRACED
   // silhouettes, so those holds need their outline in the config too — but
@@ -1175,7 +1247,11 @@ function getBoardConfig(
   shapeSize = DEFAULT_HOLD_SHAPE_SIZE,
   renderSignature = DEFAULT_HOLD_COLOR_SIGNATURE,
   boardsesh: BoardseshConfigInputs | null = null,
-  frames = '',
+  // Parsed by the caller and passed in rather than re-derived here: the overlay
+  // effect already needs frame 0's lit ids for the hold-match check, and the
+  // frames string is walked with a regex, so parsing it twice per Aura render
+  // is pure waste on the render-miss path.
+  litHoldIds: Set<number> = new Set(),
 ) {
   const widthKey = renderWidth != null ? `${renderWidth}` : 'full';
   const configKey = `${boardName}-${layoutId}-${sizeId}-${setIds}-${filledStyle ? 'f' : 's'}-w${widthKey}-${renderSignature}`;
@@ -1313,7 +1389,7 @@ function getBoardConfig(
       holds: withLitHoldGeometry(
         cached.holds,
         cached.boardseshGeometry,
-        frames,
+        litHoldIds,
         // Aura carries no spill_boost, so no unlit outlines are shipped; a
         // future spill-bearing style flips this to its own gate.
         false,
@@ -1378,6 +1454,8 @@ export function _getBoardConfigForTests(
   shapeSize = DEFAULT_HOLD_SHAPE_SIZE,
   renderSignature = DEFAULT_HOLD_COLOR_SIGNATURE,
   boardsesh: BoardseshConfigInputs | null = null,
+  // The test seam keeps taking a frames STRING and parses it here: a suite is
+  // describing a climb, not the render path's already-parsed intermediate.
   frames = '',
 ): ReturnType<typeof getBoardConfig> {
   return getBoardConfig(
@@ -1393,7 +1471,7 @@ export function _getBoardConfigForTests(
     shapeSize,
     renderSignature,
     boardsesh,
-    frames,
+    parseLitHoldIds(frames),
   );
 }
 
@@ -1473,6 +1551,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     renderSettingsOverride,
     holdColorOverride,
     verifyOverlayFile = false,
+    playSurface = false,
   } = params;
   const {
     overrides: storedHoldColorOverrides,
@@ -1689,7 +1768,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
   const retriedCacheKeysRef = useRef(new Set<string>());
   // The pending paint watchdog, keyed by the load key it is watching, so the
   // load/error callbacks can cancel exactly the one they answer and rapid swipes
-  // cannot stack timers.
+  // cannot stack timers. Armed from `onOverlayMounted`, below.
   const paintWatchdogRef = useRef<{ loadKey: string; timer: ReturnType<typeof setTimeout> } | null>(null);
   // The pending self-retry, held in a ref because it is armed from inside an
   // async .catch — long after the effect body returned its cleanup.
@@ -1704,7 +1783,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       layoutId,
       sizeId,
       effective: effectiveRenderSettings,
-      surface: filledStyle ? 'thumbnail' : 'full',
+      surface: playSurface ? 'play' : filledStyle ? 'thumbnail' : 'full',
       renderWidth: renderWidth ?? null,
       framesLength: frames.length,
     }),
@@ -1712,7 +1791,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     // effect below already depends on the whole string, so keying on the length
     // would save nothing and would put a `.length` dep in a hot hook — the one
     // shape docs/react-native-performance.md tells reviewers to reject.
-    [boardName, layoutId, sizeId, effectiveRenderSettings, filledStyle, renderWidth, frames],
+    [boardName, layoutId, sizeId, effectiveRenderSettings, filledStyle, playSurface, renderWidth, frames],
   );
 
   useEffect(() => {
@@ -1806,6 +1885,16 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     // fallback itself was somehow recorded.
     if (!frames || unsupportedRenderSignatures.has(effectiveOverrideSignature)) return;
 
+    // A retry armed by an earlier run of this effect is stale the moment this
+    // one starts. The cleanup below covers the runs that reach the render, but
+    // a run that returns early (empty frames, no native module, no board config,
+    // a config mismatch) registers no cleanup at all — so without this the old
+    // timer survives and bumps `recoveryRequest` for a key that has moved on.
+    if (renderRetryTimerRef.current !== null) {
+      clearTimeout(renderRetryTimerRef.current);
+      renderRetryTimerRef.current = null;
+    }
+
     const cachedEntry = getRenderedOverlay(currentCacheKey);
     if (cachedEntry) {
       // Sync map already has it — make sure local state reflects that
@@ -1831,6 +1920,10 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     const nativeModule = getNativeModule();
     if (!nativeModule) return;
 
+    // Frame 0's lit placement ids, parsed ONCE: the hold-match check below needs
+    // them, and so does the Aura outline attachment inside getBoardConfig.
+    const litHoldIds = parseLitHoldIds(frames);
+
     const boardConfig = getBoardConfig(
       boardName,
       layoutId,
@@ -1851,7 +1944,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
             veilOpacity,
           }
         : null,
-      frames,
+      litHoldIds,
     );
     if (!boardConfig) return;
     // Backed off after a full-disk failure: the write cannot succeed, and every
@@ -1880,7 +1973,6 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     // so the promise resolves, the PNG is written and cached, and the climber
     // gets a veil with nothing drawn on it. Nothing rejects, nothing logs.
     // Verified on the Android emulator.
-    const litHoldIds = parseLitHoldIds(frames);
     if (litHoldIds.size > 0) {
       let matchedCount = 0;
       for (const holdId of litHoldIds) {
@@ -1889,18 +1981,24 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       const unmatchedCount = litHoldIds.size - matchedCount;
       if (unmatchedCount > 0) {
         const noMatches = matchedCount === 0;
-        noteRenderFailure({
-          stage: 'config',
-          failureKind: noMatches ? 'no_matching_holds' : 'partial_hold_match',
-          errorCode: noMatches ? 'no_matching_holds' : 'other',
-          context: failureTelemetryContext,
-          holdMatch: { litCount: litHoldIds.size, unmatchedCount },
-        });
+        if (claimConfigMismatchKey(currentCacheKey)) {
+          noteRenderFailure({
+            stage: 'config',
+            failureKind: noMatches ? 'no_matching_holds' : 'partial_hold_match',
+            errorCode: noMatches ? 'no_matching_holds' : 'partial_hold_match',
+            context: failureTelemetryContext,
+            holdMatch: { litCount: litHoldIds.size, unmatchedCount },
+          });
+          if (noMatches) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[useNativeClimbRender] no matching holds for ${currentCacheKey}: ${litHoldIds.size} lit, 0 on this board`,
+            );
+          }
+        }
+        // The SKIP is behaviour, not telemetry: it stands on every run, deduped
+        // event or not.
         if (noMatches) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            `[useNativeClimbRender] no matching holds for ${currentCacheKey}: ${litHoldIds.size} lit, 0 on this board`,
-          );
           // Skip the render. The overlay would be a veil with no holds on it,
           // and writing it would cache the blank result under this key — making
           // the same failure quieter on every later visit. Overlay stays null,
@@ -2067,6 +2165,64 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     clearTimeout(pending.timer);
     paintWatchdogRef.current = null;
   }, []);
+
+  // Read through a ref so `onOverlayMounted` — which the view layer calls from an
+  // effect — keeps a stable identity and cannot itself re-arm the watchdog.
+  const failureTelemetryContextRef = useRef(failureTelemetryContext);
+  failureTelemetryContextRef.current = failureTelemetryContext;
+
+  /**
+   * The view layer reports whether an overlay `<Image>` is actually MOUNTED:
+   * its load key while one is, `null` the moment there is none.
+   *
+   * Arming on the mount rather than on `overlayUri` is the whole correctness
+   * argument. `LayeredClimbImage` renders a bare `<View>` and no image at all
+   * while the app is backgrounded or the tab's board art is released (opening
+   * `/play` does exactly that to every other surface). Nothing then fires
+   * `onLoad` — there is nothing there to fire it — so a watchdog armed on the
+   * URI would report silence from a surface that was never asked to paint, and
+   * a backgrounded app's timers would land on resume before the remount.
+   *
+   * `playSurface` gates it to the one board a climber is actually waiting on.
+   */
+  const onOverlayMounted = useCallback(
+    (mountedLoadKey: string | null) => {
+      const pending = paintWatchdogRef.current;
+      if (pending) {
+        clearTimeout(pending.timer);
+        paintWatchdogRef.current = null;
+      }
+      if (!playSurface || mountedLoadKey === null) return;
+      const timer = setTimeout(() => {
+        paintWatchdogRef.current = null;
+        if (!mountedRef.current) return;
+        // eslint-disable-next-line no-console
+        console.warn(`[useNativeClimbRender] overlay never painted within ${OVERLAY_PAINT_TIMEOUT_MS}ms`);
+        noteRenderFailure({
+          stage: 'image_load',
+          failureKind: 'paint_timeout',
+          errorCode: 'paint_timeout',
+          context: failureTelemetryContextRef.current,
+        });
+      }, OVERLAY_PAINT_TIMEOUT_MS);
+      paintWatchdogRef.current = { loadKey: mountedLoadKey, timer };
+    },
+    [playSurface],
+  );
+
+  // The view layer's mount effect disarms on its own teardown, but only while it
+  // is mounted at all. This covers the hook outliving nothing — a surface that
+  // unmounts with a watch still pending.
+  useEffect(
+    () => () => {
+      const pending = paintWatchdogRef.current;
+      if (pending) {
+        clearTimeout(pending.timer);
+        paintWatchdogRef.current = null;
+      }
+    },
+    [],
+  );
 
   const onOverlayLoad = useCallback(
     (emittingLoadKey: string | null) => {
@@ -2282,41 +2438,6 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     // verifyOverlayForNativeUse owns exact-attempt recovery. This state change
     // withholds the stale path from subsequent notification renders.
   }, [candidateOverlayUri, currentCacheKey, overlayLoadKey, verifyOverlayFile, verifyOverlayForNativeUse]);
-  // Paint watchdog: did expo-image ever answer for the overlay we handed it?
-  //
-  // Observation ONLY. Nothing is nulled and nothing is retried — a file that
-  // renders correctly on Android and on the host but never paints on iOS is a
-  // different fault from one that failed to load, and treating it as the latter
-  // (null the overlay, spend the retry budget) is exactly what would hide it
-  // again. The existing once-per-key retry budget is untouched.
-  //
-  // The cleanup covers three of the four cancel conditions on its own — the load
-  // key changing, the climb changing, and unmount. The fourth, expo-image
-  // answering, is `clearPaintWatchdog` in the two callbacks above.
-  useEffect(() => {
-    // Full-size play board only. A list arms one timer per visible row and the
-    // report is about the board the climber is looking at.
-    if (filledStyle) return;
-    if (!overlayUri || !overlayLoadKey) return;
-    const timer = setTimeout(() => {
-      paintWatchdogRef.current = null;
-      if (!mountedRef.current) return;
-      // eslint-disable-next-line no-console
-      console.warn(`[useNativeClimbRender] overlay never painted within ${OVERLAY_PAINT_TIMEOUT_MS}ms`);
-      noteRenderFailure({
-        stage: 'image_load',
-        failureKind: 'paint_timeout',
-        errorCode: 'paint_timeout',
-        context: failureTelemetryContext,
-      });
-    }, OVERLAY_PAINT_TIMEOUT_MS);
-    paintWatchdogRef.current = { loadKey: overlayLoadKey, timer };
-    return () => {
-      clearTimeout(timer);
-      if (paintWatchdogRef.current?.timer === timer) paintWatchdogRef.current = null;
-    };
-  }, [filledStyle, overlayUri, overlayLoadKey, failureTelemetryContext]);
-
   // Same guard for backgrounds: a stored entry from a prior boardKey
   // (FlashList row recycle case) must not bleed through to the new climb.
   const backgroundPaths = storedBackgrounds?.key === currentBoardKey ? storedBackgrounds.paths : [];
@@ -2326,6 +2447,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     overlayLoadKey,
     onOverlayLoad,
     onOverlayError,
+    onOverlayMounted,
     verifyOverlayForNativeUse,
     backgroundPaths,
     missingBackgroundCount,

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -644,37 +644,56 @@ type OverlayLoadTelemetryKind = BoardRenderImageLoadFailureKind;
 
 const reportedOverlayLoadTelemetry = new Set<OverlayLoadTelemetryKind>();
 
-/**
- * Report one overlay load failure.
- *
- * Two destinations with deliberately different budgets: PostHog gets EVERY
- * failure (up to the session cap) because a rate — how often a load fails, on
- * which board, at which stage — is the whole question; Sentry keeps its
- * one-event-per-kind-per-lifetime guard, because a report there is a page and
- * the storm it was added for (#3647) is exactly the shape this path produces.
- */
-function reportOverlayLoadFailure(
+/** Sentry's half: one report per failure class per JS lifetime, and no event. */
+function reportOverlayLoadDiagnosticOnce(
   kind: OverlayLoadTelemetryKind,
-  errorCode: BoardRenderErrorCode,
-  context: RenderFailureTelemetryContext,
+  boardName: BoardName,
+  failuresThisSession: number,
 ): void {
-  const failuresThisSession = noteRenderFailure({
-    stage: 'image_load',
-    failureKind: kind,
-    errorCode,
-    context,
-  });
   if (reportedOverlayLoadTelemetry.has(kind)) return;
   reportedOverlayLoadTelemetry.add(kind);
   reportError(new Error(`Generated overlay image load failed: ${kind}`), {
     level: 'warning',
     tags: {
       feature: 'mobile_board_renderer',
-      boardName: context.boardName,
+      boardName,
       overlayLoadFailure: kind,
     },
     extra: { failuresThisSession },
   });
+}
+
+/**
+ * Report one overlay load failure — ONE `Board Render Failed` per callback.
+ *
+ * The two destinations answer different questions, so they get different
+ * budgets. PostHog is counting IMAGES THAT FAILED, so a single `onError` must
+ * produce exactly one event: the terminal path used to fire the entry kind and
+ * `retry_exhausted` together, which made two real errors read as three failures
+ * and burned the session budget a third early. `kind` is therefore what actually
+ * became of this image.
+ *
+ * Sentry is diagnosing CLASSES OF FAILURE, so it still wants both — knowing a
+ * key was present-but-undecodable AND that the retry was spent is the useful
+ * pair. `alsoDiagnose` carries that second class, and its once-per-kind guard is
+ * unchanged (a report there is a page, and #3647 is exactly this shape).
+ */
+function reportOverlayLoadFailure(params: {
+  kind: OverlayLoadTelemetryKind;
+  /** A second class for Sentry only — never a second event. */
+  alsoDiagnose?: OverlayLoadTelemetryKind;
+  errorCode: BoardRenderErrorCode;
+  context: RenderFailureTelemetryContext;
+}): void {
+  const { kind, alsoDiagnose, errorCode, context } = params;
+  const failuresThisSession = noteRenderFailure({
+    stage: 'image_load',
+    failureKind: kind,
+    errorCode,
+    context,
+  });
+  if (alsoDiagnose) reportOverlayLoadDiagnosticOnce(alsoDiagnose, context.boardName, failuresThisSession);
+  reportOverlayLoadDiagnosticOnce(kind, context.boardName, failuresThisSession);
 }
 
 /**
@@ -911,6 +930,10 @@ onOverlayCacheHydrated(() => {
 /** Test-only handle for re-running the warm-up against a fresh mock list. */
 export function _resetWarmupForTests(): void {
   warmupRun = false;
+  // Board hold ids are memoised per board key, so a suite that swaps what
+  // `getBoardRenderData` returns for the SAME board would otherwise keep
+  // matching against the previous fixture's holds.
+  boardHoldIdsCache.clear();
   _resetOverlayIndexForTests();
   reportedOverlayLoadTelemetry.clear();
   _resetRenderFailureStateForTests();
@@ -1023,6 +1046,51 @@ type BoardseshConfigInputs = {
 const BOARDSESH_GLYPH_ROLES = new Set(['STARTING', 'HAND', 'FINISH', 'FOOT']);
 
 /**
+ * Every placement id a board config can draw, memoised per BOARD.
+ *
+ * Deliberately not derived from `getBoardConfig`: the hold-id question depends
+ * only on board + layout + size + sets, while a config key also carries
+ * `filledStyle`, the render width and the whole render signature — so one board
+ * browsed at two sizes would build the same Set twice. It also has to be
+ * answerable BEFORE the overlay cache lookup (see the effect), which is upstream
+ * of where a config is built at all.
+ *
+ * `null` is never cached: an absent board is a "not loaded yet" answer, and
+ * poisoning the entry would make it permanent.
+ */
+const BOARD_HOLD_IDS_CACHE_MAX = 24;
+const boardHoldIdsCache = new Map<string, Set<number>>();
+
+function getBoardHoldIds(
+  boardName: BoardName,
+  layoutId: number,
+  sizeId: number,
+  setIds: string,
+  setIdsArray: number[],
+): Set<number> | null {
+  const boardKey = `${boardName}-${layoutId}-${sizeId}-${setIds}`;
+  const cached = boardHoldIdsCache.get(boardKey);
+  if (cached) return cached;
+
+  const renderData = getBoardRenderData({ boardName, layoutId, sizeId, setIds: setIdsArray });
+  if (!renderData) return null;
+
+  const holdIds = new Set<number>();
+  for (const hold of renderData.holdsData) holdIds.add(hold.id);
+  if (boardHoldIdsCache.size >= BOARD_HOLD_IDS_CACHE_MAX) {
+    const oldestKey = boardHoldIdsCache.keys().next().value;
+    if (oldestKey !== undefined) boardHoldIdsCache.delete(oldestKey);
+  }
+  boardHoldIdsCache.set(boardKey, holdIds);
+  return holdIds;
+}
+
+/** Test-only handle so a suite can force a fresh board-hold lookup. */
+export function _resetBoardHoldIdsCacheForTests(): void {
+  boardHoldIdsCache.clear();
+}
+
+/**
  * Memoize board render configs to avoid re-computing hold positions.
  *
  * Deliberately frames-independent, Boardsesh mode included: the lit holds'
@@ -1038,13 +1106,6 @@ const boardConfigCache = new Map<
     configBase: Record<string, unknown>;
     setIdsArray: number[];
     holds: RenderHold[];
-    /**
-     * Every placement id this board config can draw. Built once per entry
-     * because the mismatch check below runs on every render miss, and rebuilding
-     * a ~700-element Set per row of a scrolling list would be the one avoidable
-     * cost on that path.
-     */
-    holdIds: Set<number>;
     boardseshGeometry: BoardArtGeometry | null;
   }
 >();
@@ -1365,7 +1426,7 @@ function getBoardConfig(
       }
     }
 
-    cached = { configBase, setIdsArray, holds, holdIds: new Set(holds.map((hold) => hold.id)), boardseshGeometry };
+    cached = { configBase, setIdsArray, holds, boardseshGeometry };
     boardConfigCache.set(configKey, cached);
   }
 
@@ -1380,10 +1441,9 @@ function getBoardConfig(
   // not read outlines and are unaffected; `led_inner` and `silhouette_lightness`
   // drop out with the silhouette they were traced and measured against.
   if (!boardsesh || !cached.boardseshGeometry || boardsesh.settings.holdShape === 'circle') {
-    return { configBase: cached.configBase, setIdsArray: cached.setIdsArray, holdIds: cached.holdIds };
+    return { configBase: cached.configBase, setIdsArray: cached.setIdsArray };
   }
   return {
-    holdIds: cached.holdIds,
     configBase: {
       ...cached.configBase,
       holds: withLitHoldGeometry(
@@ -1897,6 +1957,74 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     // fallback itself was somehow recorded.
     if (!frames || unsupportedRenderSignatures.has(effectiveOverrideSignature)) return;
 
+    // Frame 0's lit placement ids, parsed ONCE: the hold-match check right below
+    // needs them, and so does the Aura outline attachment inside getBoardConfig.
+    const litHoldIds = parseLitHoldIds(frames);
+
+    // Does this climb's frames even name holds this board can draw?
+    //
+    // The failure this catches is SILENT. A climb from another board — a Kilter
+    // Homewall problem (placement ids 4000+) opened under Kilter Original 12x12
+    // (ids 1080-1590) — asks the renderer to light holds the config has no
+    // geometry for. The Rust renderer drops each unmatched hold and returns Ok,
+    // so the promise resolves, the PNG is written and cached, and the climber
+    // gets a veil with nothing drawn on it. Nothing rejects, nothing logs.
+    // Verified on the Android emulator, and again by a reporter running the
+    // pr-5098 preview.
+    //
+    // This runs ABOVE the overlay-cache lookup, which is the whole point.
+    // Builds before this fix cached those veil-only PNGs under the SAME
+    // RENDERER_VERSION, so the startup warm-up scan restores them from disk and
+    // the cache branch below would hand one straight back — the bug would
+    // survive the fix, permanently and silently, for exactly the people who
+    // already hit it. Checking first also makes cache re-insertion moot: a
+    // mismatched key is answered before anything consults the index.
+    const boardHoldIds = litHoldIds.size > 0 ? getBoardHoldIds(boardName, layoutId, sizeId, setIds, setIdsArray) : null;
+    if (boardHoldIds) {
+      let matchedCount = 0;
+      for (const holdId of litHoldIds) {
+        if (boardHoldIds.has(holdId)) matchedCount += 1;
+      }
+      const unmatchedCount = litHoldIds.size - matchedCount;
+      if (unmatchedCount > 0) {
+        const noMatches = matchedCount === 0;
+        if (claimConfigMismatchKey(currentCacheKey)) {
+          noteRenderFailure({
+            stage: 'config',
+            failureKind: noMatches ? 'no_matching_holds' : 'partial_hold_match',
+            errorCode: noMatches ? 'no_matching_holds' : 'partial_hold_match',
+            context: failureTelemetryContext,
+            holdMatch: { litCount: litHoldIds.size, unmatchedCount },
+          });
+          if (noMatches) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[useNativeClimbRender] no matching holds for ${currentCacheKey}: ${litHoldIds.size} lit, 0 on this board`,
+            );
+          }
+        }
+        // The SKIP is behaviour, not telemetry: it stands on every run, deduped
+        // event or not.
+        if (noMatches) {
+          // Evict any veil-only PNG an earlier build already cached under this
+          // key, so the index stops handing it out. Rendering is skipped too —
+          // writing the blank result again would only make the failure quieter
+          // on the next visit. Overlay stays null and the wall photo still
+          // shows: the existing missing-layer contract.
+          const staleEntry = getRenderedOverlay(currentCacheKey);
+          if (staleEntry) invalidateRenderedOverlay(currentCacheKey, staleEntry);
+          // The state seed reads the index during the FIRST render, before this
+          // effect ever runs, so a stale entry is already on screen by now.
+          // Dropping it from the index alone would leave it painted.
+          setNativeRender((previous) => (previous?.key === currentCacheKey ? null : previous));
+          return;
+        }
+        // A partial match still draws: a climb that legitimately reaches past a
+        // smaller layout loses the holds off the edge and keeps the rest. That
+        // is degraded, not blank, so it is reported and then rendered.
+      }
+    }
+
     const cachedEntry = getRenderedOverlay(currentCacheKey);
     if (cachedEntry) {
       // Sync map already has it — make sure local state reflects that
@@ -1921,10 +2049,6 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
 
     const nativeModule = getNativeModule();
     if (!nativeModule) return;
-
-    // Frame 0's lit placement ids, parsed ONCE: the hold-match check below needs
-    // them, and so does the Aura outline attachment inside getBoardConfig.
-    const litHoldIds = parseLitHoldIds(frames);
 
     const boardConfig = getBoardConfig(
       boardName,
@@ -1964,53 +2088,6 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
         if (mountedRef.current) setRecoveryRequest((request) => request + 1);
       }, diskPressureRemainingMs() + 1);
       return () => clearTimeout(retryTimer);
-    }
-
-    // Does this climb's frames even name holds this board config has?
-    //
-    // The failure this catches is SILENT. A climb from another board — a Kilter
-    // Homewall problem (placement ids 4000+) opened under Kilter Original 12x12
-    // (ids 1080-1590) — asks the renderer to light holds the config has no
-    // geometry for. The Rust renderer drops each unmatched hold and returns Ok,
-    // so the promise resolves, the PNG is written and cached, and the climber
-    // gets a veil with nothing drawn on it. Nothing rejects, nothing logs.
-    // Verified on the Android emulator.
-    if (litHoldIds.size > 0) {
-      let matchedCount = 0;
-      for (const holdId of litHoldIds) {
-        if (boardConfig.holdIds.has(holdId)) matchedCount += 1;
-      }
-      const unmatchedCount = litHoldIds.size - matchedCount;
-      if (unmatchedCount > 0) {
-        const noMatches = matchedCount === 0;
-        if (claimConfigMismatchKey(currentCacheKey)) {
-          noteRenderFailure({
-            stage: 'config',
-            failureKind: noMatches ? 'no_matching_holds' : 'partial_hold_match',
-            errorCode: noMatches ? 'no_matching_holds' : 'partial_hold_match',
-            context: failureTelemetryContext,
-            holdMatch: { litCount: litHoldIds.size, unmatchedCount },
-          });
-          if (noMatches) {
-            // eslint-disable-next-line no-console
-            console.warn(
-              `[useNativeClimbRender] no matching holds for ${currentCacheKey}: ${litHoldIds.size} lit, 0 on this board`,
-            );
-          }
-        }
-        // The SKIP is behaviour, not telemetry: it stands on every run, deduped
-        // event or not.
-        if (noMatches) {
-          // Skip the render. The overlay would be a veil with no holds on it,
-          // and writing it would cache the blank result under this key — making
-          // the same failure quieter on every later visit. Overlay stays null,
-          // backgrounds still show: the existing missing-layer contract.
-          return;
-        }
-        // A partial match still draws: a climb that legitimately reaches past a
-        // smaller layout loses the holds off the edge and keeps the rest. That
-        // is degraded, not blank, so it is reported and then rendered.
-      }
     }
 
     const renderPromise = getOrStartInflightRender(currentCacheKey, () => {
@@ -2251,7 +2328,11 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
 
   const onOverlayError = useCallback(
     (event: { error: string }, emittingLoadKey: string | null) => {
-      clearPaintWatchdog(null);
+      // Keyed, exactly like onOverlayLoad. A late `onError` from the PREVIOUS
+      // image arrives after the new one is already mounted and watched, and an
+      // unconditional clear let that stale answer cancel the new image's watch —
+      // silencing the very case the watchdog exists to catch.
+      clearPaintWatchdog(emittingLoadKey);
       // expo-image's message names the file it could not load, so it is bucketed
       // to a closed set of codes before it goes anywhere. `png` here means the
       // decoder said so, not that a filename happened to end in `.png`.
@@ -2275,7 +2356,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
         // the newer generation, so compare generations before classifying an
         // existing file as a terminal decode failure.
         if (retryBudgetRef.current.key !== expected.key || retryBudgetRef.current.used >= 1) {
-          reportOverlayLoadFailure('retry_exhausted', errorCode, failureTelemetryContext);
+          reportOverlayLoadFailure({ kind: 'retry_exhausted', errorCode, context: failureTelemetryContext });
           setNativeRender((previous) => (isExactNativeRender(previous, expected) ? null : previous));
           return;
         }
@@ -2296,7 +2377,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       try {
         entryExists = overlayCacheEntryExists(expectedEntry.uri);
       } catch {
-        reportOverlayLoadFailure('validation_failed', errorCode, failureTelemetryContext);
+        reportOverlayLoadFailure({ kind: 'validation_failed', errorCode, context: failureTelemetryContext });
         setNativeRender((previous) => (isExactNativeRender(previous, expected) ? null : previous));
         return;
       }
@@ -2305,12 +2386,19 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       // Keep the exact generated entry, but remount expo-image once with a new
       // attempt key so it retries the same URI without triggering a render.
       if (entryExists === true) {
-        reportOverlayLoadFailure('cache_entry_present', errorCode, failureTelemetryContext);
         if (retryBudgetRef.current.key !== expected.key || retryBudgetRef.current.used >= 1) {
-          reportOverlayLoadFailure('retry_exhausted', errorCode, failureTelemetryContext);
+          // One event, naming what became of the image; Sentry still hears both
+          // classes.
+          reportOverlayLoadFailure({
+            kind: 'retry_exhausted',
+            alsoDiagnose: 'cache_entry_present',
+            errorCode,
+            context: failureTelemetryContext,
+          });
           setNativeRender((previous) => (isExactNativeRender(previous, expected) ? null : previous));
           return;
         }
+        reportOverlayLoadFailure({ kind: 'cache_entry_present', errorCode, context: failureTelemetryContext });
         retryBudgetRef.current.used += 1;
         setNativeRender((previous) =>
           isExactNativeRender(previous, expected)
@@ -2327,17 +2415,22 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       // Unknown validation (the web twin) is terminal: guessing would turn
       // every unsupported image into a render loop.
       if (entryExists === null) {
-        reportOverlayLoadFailure('validation_unsupported', errorCode, failureTelemetryContext);
+        reportOverlayLoadFailure({ kind: 'validation_unsupported', errorCode, context: failureTelemetryContext });
         setNativeRender((previous) => (isExactNativeRender(previous, expected) ? null : previous));
         return;
       }
 
-      reportOverlayLoadFailure('cache_entry_missing', errorCode, failureTelemetryContext);
       if (retryBudgetRef.current.key !== expected.key || retryBudgetRef.current.used >= 1) {
-        reportOverlayLoadFailure('retry_exhausted', errorCode, failureTelemetryContext);
+        reportOverlayLoadFailure({
+          kind: 'retry_exhausted',
+          alsoDiagnose: 'cache_entry_missing',
+          errorCode,
+          context: failureTelemetryContext,
+        });
         setNativeRender((previous) => (isExactNativeRender(previous, expected) ? null : previous));
         return;
       }
+      reportOverlayLoadFailure({ kind: 'cache_entry_missing', errorCode, context: failureTelemetryContext });
       retryBudgetRef.current.used += 1;
 
       invalidateRenderedOverlay(expected.key, expectedEntry);

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -1880,20 +1880,22 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
   // Overlay-render effect: kick off the native render if we don't already
   // have one for this cache key in the sync map.
   useEffect(() => {
-    // effectiveOverrideSignature has already stepped away from anything the
-    // renderer refused, so this only trips on the pathological case where the
-    // fallback itself was somehow recorded.
-    if (!frames || unsupportedRenderSignatures.has(effectiveOverrideSignature)) return;
-
     // A retry armed by an earlier run of this effect is stale the moment this
     // one starts. The cleanup below covers the runs that reach the render, but
-    // a run that returns early (empty frames, no native module, no board config,
-    // a config mismatch) registers no cleanup at all — so without this the old
-    // timer survives and bumps `recoveryRequest` for a key that has moved on.
+    // EVERY early return in this effect registers no cleanup at all — empty
+    // frames, a refused signature, no native module, no board config, a config
+    // mismatch — so without this the old timer survives and bumps
+    // `recoveryRequest` for a key that has moved on. First statement in the
+    // body, ahead of the guards, so no bail-out path can skip it.
     if (renderRetryTimerRef.current !== null) {
       clearTimeout(renderRetryTimerRef.current);
       renderRetryTimerRef.current = null;
     }
+
+    // effectiveOverrideSignature has already stepped away from anything the
+    // renderer refused, so this only trips on the pathological case where the
+    // fallback itself was somehow recorded.
+    if (!frames || unsupportedRenderSignatures.has(effectiveOverrideSignature)) return;
 
     const cachedEntry = getRenderedOverlay(currentCacheKey);
     if (cachedEntry) {

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -1,5 +1,14 @@
 import { useCallback, useEffect, useMemo, useState, useRef, useSyncExternalStore } from 'react';
 import type { BoardName } from '@boardsesh/shared-schema';
+import {
+  boardRenderFailed,
+  buildBoardRenderTelemetryProps,
+  classifyBoardRenderErrorCode,
+  type BoardRenderErrorCode,
+  type BoardRenderFailureSurface,
+  type BoardRenderImageLoadFailureKind,
+  type BoardRenderNativeFailureKind,
+} from '@boardsesh/analytics';
 import { listOverlayCacheEntries, onOverlayCacheHydrated, overlayCacheEntryExists } from './overlay-cache-warmup';
 import { RENDERER_VERSION } from './renderer-version';
 import {
@@ -22,7 +31,8 @@ import {
   type BackgroundVariant,
 } from '../lib/background-image-cache';
 import { useAppColorScheme } from '../providers/theme-provider';
-import { reportError } from '../lib/error-reporting';
+import { addErrorBreadcrumb, reportError } from '../lib/error-reporting';
+import { track } from '../lib/analytics';
 import { sweepBoardArtCache } from '../lib/sweep-caches';
 import { measureFreeCacheSpaceBytes } from '../lib/cache-dir-io';
 import {
@@ -447,26 +457,143 @@ const BOARD_CONFIG_CACHE_MAX = 40;
 // can forget keys whose PNG it just deleted without importing this hook — see
 // that module for why the cycle mattered.
 
-type OverlayLoadTelemetryKind =
-  | 'cache_entry_missing'
-  | 'retry_exhausted'
-  | 'cache_entry_present'
-  | 'validation_failed'
-  | 'validation_unsupported';
+/**
+ * Everything `Board Render Failed` needs that is not the failure itself. Built
+ * once per hook instance (`useMemo`) so both failure paths — the native
+ * rejection and the expo-image load error — report against exactly the same
+ * board, and neither has to re-derive the common props by hand.
+ */
+type RenderFailureTelemetryContext = {
+  boardName: BoardName;
+  layoutId: number;
+  sizeId: number;
+  effective: EffectiveBoardRenderSettings;
+  surface: BoardRenderFailureSurface;
+  /** The requested overlay width, or null for a native-width render. */
+  renderWidth: number | null;
+  framesLength: number;
+};
+
+/**
+ * Hard ceiling on `Board Render Failed` events per JS lifetime.
+ *
+ * The bug this telemetry exists for is a device that fails EVERY render after a
+ * point, and `getOrStartInflightRender` clears the settled promise, so every
+ * recycled FlashList row tries again — the same shape that once produced 50
+ * Sentry events in 50 minutes (issue #3647). 25 events is more than enough to
+ * see which stage, which kind and which error code a session is stuck on;
+ * beyond that the extra rows say nothing new and cost PostHog volume.
+ */
+const RENDER_FAILURE_EVENT_CAP = 25;
+
+/**
+ * Render failures seen this JS lifetime. Keeps counting past the cap, and rides
+ * along on every event and Sentry report as `failures_this_session` /
+ * `failuresThisSession` — so a stream that stops at 25 reads as truncated rather
+ * than as a device that failed exactly 25 times.
+ */
+let renderFailuresThisSession = 0;
+
+/** One failure, as the two reporting paths describe it. */
+type RenderFailureNote = {
+  errorCode: BoardRenderErrorCode;
+  context: RenderFailureTelemetryContext;
+} & (
+  | { stage: 'native'; failureKind: BoardRenderNativeFailureKind }
+  | { stage: 'image_load'; failureKind: BoardRenderImageLoadFailureKind }
+);
+
+/**
+ * Record one render failure: a Sentry breadcrumb every time, and a
+ * `Board Render Failed` event until the session cap is reached.
+ *
+ * Returns the running failure count so the caller can put it on its own Sentry
+ * report — the once-per-kind guard there means the FIRST failure is the only one
+ * that ever gets reported, and without this number that report cannot say
+ * whether it was a one-off or the start of a storm.
+ *
+ * Nothing derived from the message, the cache key or the file path reaches
+ * either destination: the message is bucketed to a closed set of error codes by
+ * `classifyBoardRenderErrorCode` first.
+ */
+function noteRenderFailure(note: RenderFailureNote): number {
+  const { errorCode, context } = note;
+  renderFailuresThisSession += 1;
+  const failuresThisSession = renderFailuresThisSession;
+
+  addErrorBreadcrumb({
+    category: 'board-render',
+    message: `Board render failed: ${note.stage}/${note.failureKind}/${errorCode}`,
+    level: 'warning',
+    data: {
+      boardName: context.boardName,
+      layoutId: context.layoutId,
+      sizeId: context.sizeId,
+      surface: context.surface,
+      renderMode: context.effective.mode,
+      failuresThisSession,
+    },
+  });
+
+  if (failuresThisSession > RENDER_FAILURE_EVENT_CAP) return failuresThisSession;
+
+  const shared = {
+    ...buildBoardRenderTelemetryProps(context.effective, {
+      boardName: context.boardName,
+      layoutId: context.layoutId,
+      sizeId: context.sizeId,
+    }),
+    surface: context.surface,
+    error_code: errorCode,
+    render_width: context.renderWidth,
+    frames_length: context.framesLength,
+    failures_this_session: failuresThisSession,
+  };
+  // Branch rather than spread a `{ stage, failure_kind }` pair: the two are one
+  // discriminated pair in `BoardRenderFailedInput`, and keeping the branch is
+  // what makes a mismatched combination a compile error instead of a cast.
+  const event =
+    note.stage === 'native'
+      ? boardRenderFailed({ ...shared, stage: 'native', failure_kind: note.failureKind })
+      : boardRenderFailed({ ...shared, stage: 'image_load', failure_kind: note.failureKind });
+  track(event.name, event.properties);
+  return failuresThisSession;
+}
+
+type OverlayLoadTelemetryKind = BoardRenderImageLoadFailureKind;
 
 const reportedOverlayLoadTelemetry = new Set<OverlayLoadTelemetryKind>();
 
-/** One privacy-safe, low-cardinality event per failure class and JS lifetime. */
-function reportOverlayLoadOnce(kind: OverlayLoadTelemetryKind, boardName: BoardName): void {
+/**
+ * Report one overlay load failure.
+ *
+ * Two destinations with deliberately different budgets: PostHog gets EVERY
+ * failure (up to the session cap) because a rate — how often a load fails, on
+ * which board, at which stage — is the whole question; Sentry keeps its
+ * one-event-per-kind-per-lifetime guard, because a report there is a page and
+ * the storm it was added for (#3647) is exactly the shape this path produces.
+ */
+function reportOverlayLoadFailure(
+  kind: OverlayLoadTelemetryKind,
+  errorCode: BoardRenderErrorCode,
+  context: RenderFailureTelemetryContext,
+): void {
+  const failuresThisSession = noteRenderFailure({
+    stage: 'image_load',
+    failureKind: kind,
+    errorCode,
+    context,
+  });
   if (reportedOverlayLoadTelemetry.has(kind)) return;
   reportedOverlayLoadTelemetry.add(kind);
   reportError(new Error(`Generated overlay image load failed: ${kind}`), {
     level: 'warning',
     tags: {
       feature: 'mobile_board_renderer',
-      boardName,
+      boardName: context.boardName,
       overlayLoadFailure: kind,
     },
+    extra: { failuresThisSession },
   });
 }
 
@@ -585,6 +712,18 @@ function diskPressureRemainingMs(nowMs = Date.now()): number {
  */
 const DISK_PRESSURE_MAX_RETRIES = 3;
 
+/**
+ * How long the hook waits before its one self-retry after a native render
+ * rejected for a reason that is not the disk.
+ *
+ * Long enough that whatever transient condition broke the render (a memory
+ * spike from a burst of swipes, a native context the OS reclaimed) has a chance
+ * to clear, short enough that a climber staring at a board with no holds gets it
+ * back rather than reaching for the app switcher. One attempt, then this key is
+ * done — see `retriedCacheKeysRef`.
+ */
+const RENDER_RETRY_DELAY_MS = 1500;
+
 function latchDiskPressure(): void {
   diskPressureUntilMs = Date.now() + DISK_PRESSURE_BACKOFF_MS;
   // Free what we can while we are backed off. The sweeper's own per-trigger rate
@@ -599,7 +738,11 @@ function latchDiskPressure(): void {
 export function _resetRenderFailureStateForTests(): void {
   reportedRenderFailures.clear();
   diskPressureUntilMs = 0;
+  renderFailuresThisSession = 0;
 }
+
+/** Test-only view of the per-lifetime failure counter and its cap. */
+export const _RENDER_FAILURE_EVENT_CAP_FOR_TESTS = RENDER_FAILURE_EVENT_CAP;
 
 /**
  * One-time eager scan of the native module's PNG cache directory. The
@@ -1505,6 +1648,29 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
   if (retryBudgetRef.current.key !== currentCacheKey) {
     retryBudgetRef.current = { key: currentCacheKey, used: 0 };
   }
+  // Cache keys this hook instance has already spent its one self-retry on.
+  // Per-instance and keyed, so a recycled FlashList row landing back on a climb
+  // that already failed cannot start a second retry, and a key can never storm.
+  const retriedCacheKeysRef = useRef(new Set<string>());
+  // The pending self-retry, held in a ref because it is armed from inside an
+  // async .catch — long after the effect body returned its cleanup.
+  const renderRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Everything `Board Render Failed` needs about this surface. Memoized on
+  // exactly its inputs so both failure paths report the same board, and so the
+  // overlay-error callback's identity only moves when the board really changes.
+  const failureTelemetryContext = useMemo<RenderFailureTelemetryContext>(
+    () => ({
+      boardName,
+      layoutId,
+      sizeId,
+      effective: effectiveRenderSettings,
+      surface: filledStyle ? 'thumbnail' : 'full',
+      renderWidth: renderWidth ?? null,
+      framesLength: frames.length,
+    }),
+    [boardName, layoutId, sizeId, effectiveRenderSettings, filledStyle, renderWidth, frames],
+  );
 
   useEffect(() => {
     mountedRef.current = true;
@@ -1714,10 +1880,26 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
         console.warn(`[useNativeClimbRender] render failed for ${currentCacheKey}:`, message);
         // Don't page on the capability fallback — it re-fires once per climb
         // whenever the signature stays default (issue #4240: 29 Sentry events
-        // in 60s from one session).
-        if (isCapabilityFallback) return;
+        // in 60s from one session). It is still a render that did not draw what
+        // the climber asked for, so it is still counted and reported to PostHog,
+        // where the cap rather than a once-guard keeps the volume sane.
+        if (isCapabilityFallback) {
+          noteRenderFailure({
+            stage: 'native',
+            failureKind: 'capability_fallback',
+            errorCode: 'capability',
+            context: failureTelemetryContext,
+          });
+          return;
+        }
         const kind = classifyRenderFailure(message, measureFreeCacheSpaceBytes());
         if (kind === 'disk_full') latchDiskPressure();
+        const failuresThisSession = noteRenderFailure({
+          stage: 'native',
+          failureKind: kind,
+          errorCode: classifyBoardRenderErrorCode(message),
+          context: failureTelemetryContext,
+        });
         reportRenderFailureOnce({
           kind,
           error,
@@ -1731,9 +1913,40 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
             renderWidth,
             framesLength: frames.length,
             cacheKey: currentCacheKey,
+            failuresThisSession,
           },
         });
+        // One self-retry, once per cache key, per hook instance.
+        //
+        // The failure this exists for is a play board that stops drawing holds
+        // mid-session and never comes back: nothing about the climb changed, so
+        // no prop moves, no effect re-runs, and the overlay stays missing until
+        // the app restarts. `getOrStartInflightRender` already dropped the
+        // settled promise in its `.finally`, so bumping the nonce re-enters the
+        // render path cleanly. Deliberately NOT for `disk_full` (the back-off
+        // above owns that, and retrying a write on a full volume is the storm)
+        // and NOT for a capability fallback (the degraded re-render IS the
+        // retry). The keyed guard is what makes a recycled row safe.
+        if (kind === 'render_failed' && !retriedCacheKeysRef.current.has(currentCacheKey)) {
+          retriedCacheKeysRef.current.add(currentCacheKey);
+          if (renderRetryTimerRef.current !== null) clearTimeout(renderRetryTimerRef.current);
+          renderRetryTimerRef.current = setTimeout(() => {
+            renderRetryTimerRef.current = null;
+            if (mountedRef.current) setRecoveryRequest((request) => request + 1);
+          }, RENDER_RETRY_DELAY_MS);
+        }
       });
+
+    return () => {
+      // A retry armed by the run being torn down is stale: the effect is about
+      // to run again anyway (a dep changed) or the surface is unmounting. The
+      // timer that just fired has already nulled this, so the common case is a
+      // no-op.
+      if (renderRetryTimerRef.current !== null) {
+        clearTimeout(renderRetryTimerRef.current);
+        renderRetryTimerRef.current = null;
+      }
+    };
     // nativeRender is intentionally excluded from deps: this effect *sets* it.
     // recoveryRequest is the explicit same-key re-trigger after an exact stale
     // entry is invalidated.
@@ -1754,6 +1967,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
     fieldColor,
     veilOpacity,
     recoveryRequest,
+    failureTelemetryContext,
   ]);
 
   const onOverlayLoad = useCallback(
@@ -1777,7 +1991,11 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
   );
 
   const onOverlayError = useCallback(
-    (_event: { error: string }, emittingLoadKey: string | null) => {
+    (event: { error: string }, emittingLoadKey: string | null) => {
+      // expo-image's message names the file it could not load, so it is bucketed
+      // to a closed set of codes before it goes anywhere. `png` here means the
+      // decoder said so, not that a filename happened to end in `.png`.
+      const errorCode = classifyBoardRenderErrorCode(event.error);
       const expected = nativeRenderRef.current;
       if (
         !isLoadedNativeRender(expected) ||
@@ -1797,7 +2015,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
         // the newer generation, so compare generations before classifying an
         // existing file as a terminal decode failure.
         if (retryBudgetRef.current.key !== expected.key || retryBudgetRef.current.used >= 1) {
-          reportOverlayLoadOnce('retry_exhausted', boardName);
+          reportOverlayLoadFailure('retry_exhausted', errorCode, failureTelemetryContext);
           setNativeRender((previous) => (isExactNativeRender(previous, expected) ? null : previous));
           return;
         }
@@ -1818,7 +2036,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       try {
         entryExists = overlayCacheEntryExists(expectedEntry.uri);
       } catch {
-        reportOverlayLoadOnce('validation_failed', boardName);
+        reportOverlayLoadFailure('validation_failed', errorCode, failureTelemetryContext);
         setNativeRender((previous) => (isExactNativeRender(previous, expected) ? null : previous));
         return;
       }
@@ -1827,9 +2045,9 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       // Keep the exact generated entry, but remount expo-image once with a new
       // attempt key so it retries the same URI without triggering a render.
       if (entryExists === true) {
-        reportOverlayLoadOnce('cache_entry_present', boardName);
+        reportOverlayLoadFailure('cache_entry_present', errorCode, failureTelemetryContext);
         if (retryBudgetRef.current.key !== expected.key || retryBudgetRef.current.used >= 1) {
-          reportOverlayLoadOnce('retry_exhausted', boardName);
+          reportOverlayLoadFailure('retry_exhausted', errorCode, failureTelemetryContext);
           setNativeRender((previous) => (isExactNativeRender(previous, expected) ? null : previous));
           return;
         }
@@ -1849,14 +2067,14 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       // Unknown validation (the web twin) is terminal: guessing would turn
       // every unsupported image into a render loop.
       if (entryExists === null) {
-        reportOverlayLoadOnce('validation_unsupported', boardName);
+        reportOverlayLoadFailure('validation_unsupported', errorCode, failureTelemetryContext);
         setNativeRender((previous) => (isExactNativeRender(previous, expected) ? null : previous));
         return;
       }
 
-      reportOverlayLoadOnce('cache_entry_missing', boardName);
+      reportOverlayLoadFailure('cache_entry_missing', errorCode, failureTelemetryContext);
       if (retryBudgetRef.current.key !== expected.key || retryBudgetRef.current.used >= 1) {
-        reportOverlayLoadOnce('retry_exhausted', boardName);
+        reportOverlayLoadFailure('retry_exhausted', errorCode, failureTelemetryContext);
         setNativeRender((previous) => (isExactNativeRender(previous, expected) ? null : previous));
         return;
       }
@@ -1891,7 +2109,7 @@ export function useNativeClimbRender(params: NativeClimbRenderParams): NativeCli
       );
       setRecoveryRequest((request) => request + 1);
     },
-    [boardName, currentCacheKey],
+    [currentCacheKey, failureTelemetryContext],
   );
 
   const verifyOverlayForNativeUse = useCallback(

--- a/packages/mobile/src/lib/error-reporting.ts
+++ b/packages/mobile/src/lib/error-reporting.ts
@@ -1,6 +1,6 @@
 import { isBleWriteTimeoutError } from '@boardsesh/ble-protocol/connection-error';
 import { getErrorStatus, isNetworkError as isSharedNetworkError } from '@boardsesh/offline-sync/error-classification';
-import { captureToSentry, type ErrorReportContext } from './sentry';
+import { addBreadcrumbToSentry, captureToSentry, type ErrorReportContext } from './sentry';
 import { captureToObserve } from './observe-runtime';
 import {
   isExpectedAuthError,
@@ -29,6 +29,27 @@ export type { ErrorReportContext };
 export function reportError(error: unknown, context?: ErrorReportContext): void {
   captureToSentry(error, context);
   captureToObserve(error);
+}
+
+/**
+ * Leave a breadcrumb on the trail Sentry attaches to the next reported error.
+ * No-op when Sentry is inactive, the same guard `reportError` gets through
+ * `captureToSentry`.
+ *
+ * Use it for a repeating failure whose REPORT is rate-limited: the once-per-kind
+ * guard on `reportError` is what stops a storm, and it also throws away every
+ * occurrence after the first. A breadcrumb costs nothing, is bounded by Sentry's
+ * own ring buffer, and keeps the sequence readable on whatever does get
+ * reported. Keep the message low-cardinality and free of filenames — it is read
+ * as a trail, not grouped on.
+ */
+export function addErrorBreadcrumb(breadcrumb: {
+  category: string;
+  message: string;
+  level?: 'fatal' | 'error' | 'warning' | 'info' | 'debug';
+  data?: Record<string, unknown>;
+}): void {
+  addBreadcrumbToSentry(breadcrumb);
 }
 
 /**

--- a/packages/mobile/src/lib/sentry.ts
+++ b/packages/mobile/src/lib/sentry.ts
@@ -239,6 +239,24 @@ export function captureToSentry(error: unknown, context?: ErrorReportContext): v
   });
 }
 
+/**
+ * A breadcrumb — the trail Sentry attaches to whatever error is reported next.
+ *
+ * Guarded exactly like `captureToSentry`, so a dev / DSN-less build never
+ * touches the SDK. Breadcrumbs are the right shape for a failure that repeats:
+ * the report itself may be suppressed by a once-per-kind guard, but the
+ * breadcrumb trail still shows how many times and in what order it happened.
+ */
+export function addBreadcrumbToSentry(breadcrumb: {
+  category: string;
+  message: string;
+  level?: 'fatal' | 'error' | 'warning' | 'info' | 'debug';
+  data?: Record<string, unknown>;
+}): void {
+  if (!isSentryEnabled) return;
+  Sentry.addBreadcrumb(breadcrumb);
+}
+
 export const LIVE_ACTIVITY_INTENT_INTERRUPTED_FINGERPRINT = 'live-activity-intent-interrupted';
 
 type LiveActivityIntentDiagnosticScope = {

--- a/packages/shared/analytics/src/__tests__/board-render-events.test.ts
+++ b/packages/shared/analytics/src/__tests__/board-render-events.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect } from 'vitest';
 import { SHARED_EVENTS } from '../events';
 import {
   boardPinch,
+  boardRenderFailed,
   boardRenderPresetApplied,
   boardRenderSettingsChanged,
   buildBoardRenderTelemetryProps,
+  classifyBoardRenderErrorCode,
   climbFirstAction,
   climbViewOpened,
   type BoardRenderContext,
@@ -170,5 +172,114 @@ describe('climbViewOpened after the experiment was retired', () => {
     expect(properties.render_mode).toBe('aura');
     expect(properties.glow_falloff).toBe('plateau');
     expect(properties.glow_falloff_source).toBe('user');
+  });
+});
+
+// The message a render failure arrives with is never safe to send: it
+// interpolates the cache key, the cache path and, on iOS, OS prose in whatever
+// language the phone is set to. `classifyBoardRenderErrorCode` is the whole
+// privacy and cardinality boundary for `Board Render Failed`.
+describe('classifyBoardRenderErrorCode', () => {
+  it('prefers a numeric code the native layer named', () => {
+    expect(classifyBoardRenderErrorCode('Rust render failed with code -2')).toBe('code_-2');
+    expect(classifyBoardRenderErrorCode('renderHoldsOverlay failed with code 7')).toBe('code_7');
+  });
+
+  it('normalises a padded code so one fault is one bucket', () => {
+    expect(classifyBoardRenderErrorCode('failed with code -002')).toBe('code_-2');
+  });
+
+  it('buckets the prose shapes when there is no code', () => {
+    expect(classifyBoardRenderErrorCode('PNG encoding returned null')).toBe('png');
+    expect(classifyBoardRenderErrorCode('could not build a CGImage from the surface')).toBe('cgimage');
+    expect(classifyBoardRenderErrorCode('ENOSPC')).toBe('write');
+    expect(classifyBoardRenderErrorCode('BoardRenderer module is not available')).toBe('module');
+    expect(
+      classifyBoardRenderErrorCode(
+        'Marker shape, size, and brush overrides require a rebuilt BoardRenderer native binary',
+      ),
+    ).toBe('capability');
+    expect(classifyBoardRenderErrorCode('something nobody has seen before')).toBe('other');
+  });
+
+  // The generated filename ends in `.png` and rides along in EVERY iOS write
+  // failure, so a bare /png/i test would label a full volume as a PNG-encoding
+  // fault and empty the `write` bucket entirely.
+  it('does not read the overlay filename as a PNG encoding fault', () => {
+    const outOfSpace =
+      'The operation couldn’t be completed. You can’t save the file “v5_abc123.png” because the volume “User” is out of space.';
+    expect(classifyBoardRenderErrorCode(outOfSpace)).toBe('write');
+  });
+
+  it('never returns anything derived from the message itself', () => {
+    const code = classifyBoardRenderErrorCode('You can’t save the file “v5_secret-cache-key.png”');
+    expect(code).not.toContain('secret-cache-key');
+    expect(code).not.toContain('.png');
+  });
+});
+
+describe('boardRenderFailed', () => {
+  const FAILURE_FIELDS = {
+    surface: 'full',
+    error_code: 'code_-2',
+    render_width: null,
+    frames_length: 42,
+    failures_this_session: 3,
+  } as const;
+
+  it('pairs the name with the common props plus the failure fields', () => {
+    const commonProps = buildBoardRenderTelemetryProps(EFFECTIVE_AURA, CONTEXT);
+    expect(
+      boardRenderFailed({ ...commonProps, ...FAILURE_FIELDS, stage: 'native', failure_kind: 'render_failed' }),
+    ).toEqual({
+      name: SHARED_EVENTS.BoardRenderFailed,
+      properties: {
+        board_name: 'kilter',
+        layout_id: 1,
+        size_id: 2,
+        render_mode: 'aura',
+        glow_falloff: 'plateau',
+        glow_falloff_source: 'user',
+        surface: 'full',
+        stage: 'native',
+        failure_kind: 'render_failed',
+        error_code: 'code_-2',
+        render_width: null,
+        frames_length: 42,
+        failures_this_session: 3,
+      },
+    });
+  });
+
+  it('carries the image-load kinds under the image_load stage', () => {
+    const commonProps = buildBoardRenderTelemetryProps(EFFECTIVE_CLASSIC, CONTEXT);
+    const payload = boardRenderFailed({
+      ...commonProps,
+      ...FAILURE_FIELDS,
+      surface: 'thumbnail',
+      error_code: 'other',
+      render_width: 400,
+      stage: 'image_load',
+      failure_kind: 'cache_entry_missing',
+    });
+
+    expect(payload.properties.stage).toBe('image_load');
+    expect(payload.properties.failure_kind).toBe('cache_entry_missing');
+    expect(payload.properties.surface).toBe('thumbnail');
+    expect(payload.properties.render_width).toBe(400);
+  });
+
+  it('stays stratifiable — the common props ride along on a failure too', () => {
+    const commonProps = buildBoardRenderTelemetryProps(EFFECTIVE_AURA, CONTEXT);
+    const payload = boardRenderFailed({
+      ...commonProps,
+      ...FAILURE_FIELDS,
+      stage: 'native',
+      failure_kind: 'capability_fallback',
+    });
+
+    expect(payload.properties.board_name).toBe('kilter');
+    expect(payload.properties.render_mode).toBe('aura');
+    expect(payload.properties.glow_falloff_source).toBe('user');
   });
 });

--- a/packages/shared/analytics/src/__tests__/board-render-events.test.ts
+++ b/packages/shared/analytics/src/__tests__/board-render-events.test.ts
@@ -346,6 +346,38 @@ describe('boardRenderFailed — the config stage', () => {
     expect(Object.hasOwn(payload.properties, 'unmatched_count')).toBe(false);
   });
 
+  it('keeps the play board separate from every other full-size surface', () => {
+    const commonProps = buildBoardRenderTelemetryProps(EFFECTIVE_AURA, CONTEXT);
+    const surfaces = (['play', 'full', 'thumbnail'] as const).map(
+      (surface) =>
+        boardRenderFailed({
+          ...commonProps,
+          ...BASE_FIELDS,
+          surface,
+          stage: 'native',
+          failure_kind: 'render_failed',
+          error_code: 'code_-2',
+        }).properties.surface,
+    );
+
+    expect(surfaces).toEqual(['play', 'full', 'thumbnail']);
+  });
+
+  it('gives partial_hold_match its own error code rather than lumping it into other', () => {
+    const commonProps = buildBoardRenderTelemetryProps(EFFECTIVE_CLASSIC, CONTEXT);
+    const payload = boardRenderFailed({
+      ...commonProps,
+      ...BASE_FIELDS,
+      stage: 'config',
+      failure_kind: 'partial_hold_match',
+      error_code: 'partial_hold_match',
+      lit_count: 9,
+      unmatched_count: 2,
+    });
+
+    expect(payload.properties.error_code).toBe('partial_hold_match');
+  });
+
   it('carries the paint-timeout kind under the image_load stage', () => {
     const commonProps = buildBoardRenderTelemetryProps(EFFECTIVE_AURA, CONTEXT);
     const payload = boardRenderFailed({

--- a/packages/shared/analytics/src/__tests__/board-render-events.test.ts
+++ b/packages/shared/analytics/src/__tests__/board-render-events.test.ts
@@ -283,3 +283,80 @@ describe('boardRenderFailed', () => {
     expect(payload.properties.glow_falloff_source).toBe('user');
   });
 });
+
+// The config stage is the one that fails silently — the Rust renderer drops
+// unmatched holds and returns Ok — so it is the reason this event has a stage
+// at all rather than just a failure kind.
+describe('boardRenderFailed — the config stage', () => {
+  const BASE_FIELDS = {
+    surface: 'full',
+    render_width: null,
+    frames_length: 16,
+    failures_this_session: 1,
+  } as const;
+
+  it('carries the lit and unmatched counts, never the ids', () => {
+    const commonProps = buildBoardRenderTelemetryProps(EFFECTIVE_AURA, CONTEXT);
+    const payload = boardRenderFailed({
+      ...commonProps,
+      ...BASE_FIELDS,
+      stage: 'config',
+      failure_kind: 'no_matching_holds',
+      error_code: 'no_matching_holds',
+      lit_count: 12,
+      unmatched_count: 12,
+    });
+
+    expect(payload.name).toBe(SHARED_EVENTS.BoardRenderFailed);
+    expect(payload.properties).toMatchObject({
+      stage: 'config',
+      failure_kind: 'no_matching_holds',
+      lit_count: 12,
+      unmatched_count: 12,
+    });
+  });
+
+  it('separates a partial overhang from a climb that would draw nothing', () => {
+    const commonProps = buildBoardRenderTelemetryProps(EFFECTIVE_CLASSIC, CONTEXT);
+    const payload = boardRenderFailed({
+      ...commonProps,
+      ...BASE_FIELDS,
+      stage: 'config',
+      failure_kind: 'partial_hold_match',
+      error_code: 'other',
+      lit_count: 12,
+      unmatched_count: 3,
+    });
+
+    expect(payload.properties.failure_kind).toBe('partial_hold_match');
+    expect(payload.properties.unmatched_count).toBeLessThan(payload.properties.lit_count as number);
+  });
+
+  it('omits the counts entirely on the stages they mean nothing for', () => {
+    const commonProps = buildBoardRenderTelemetryProps(EFFECTIVE_AURA, CONTEXT);
+    const payload = boardRenderFailed({
+      ...commonProps,
+      ...BASE_FIELDS,
+      stage: 'native',
+      failure_kind: 'render_failed',
+      error_code: 'code_-2',
+    });
+
+    expect(Object.hasOwn(payload.properties, 'lit_count')).toBe(false);
+    expect(Object.hasOwn(payload.properties, 'unmatched_count')).toBe(false);
+  });
+
+  it('carries the paint-timeout kind under the image_load stage', () => {
+    const commonProps = buildBoardRenderTelemetryProps(EFFECTIVE_AURA, CONTEXT);
+    const payload = boardRenderFailed({
+      ...commonProps,
+      ...BASE_FIELDS,
+      stage: 'image_load',
+      failure_kind: 'paint_timeout',
+      error_code: 'paint_timeout',
+    });
+
+    expect(payload.properties.failure_kind).toBe('paint_timeout');
+    expect(payload.properties.error_code).toBe('paint_timeout');
+  });
+});

--- a/packages/shared/analytics/src/board-render-events.ts
+++ b/packages/shared/analytics/src/board-render-events.ts
@@ -277,3 +277,122 @@ export function boardLookStepResolved(
 ): BoardRenderPayload<typeof SHARED_EVENTS.BoardLookStepResolved, BoardLookStepResolvedInput> {
   return { name: SHARED_EVENTS.BoardLookStepResolved, properties: input };
 }
+
+/**
+ * Which surface the failed overlay belonged to. Mirrors the mobile hook's
+ * `filledStyle` flag: the filled style is what the list / accessory thumbnails
+ * ask for, the stroke-only style is the full-size play board.
+ */
+export type BoardRenderFailureSurface = 'full' | 'thumbnail';
+
+/** Which half of the render path gave up. */
+export type BoardRenderFailureStage = 'native' | 'image_load';
+
+/**
+ * Why the native renderer rejected.
+ *
+ * `capability_fallback` is a binary that predates a config's marker overrides or
+ * the Aura drawing refusing them by design — the hook re-renders degraded, so
+ * this is a "the climber saw the other drawing" signal rather than a defect.
+ */
+export type BoardRenderNativeFailureKind = 'render_failed' | 'disk_full' | 'capability_fallback';
+
+/**
+ * Why the generated PNG would not load. Mirrors the mobile hook's
+ * `OverlayLoadTelemetryKind` one-for-one — the file was gone, the file was there
+ * and still would not decode, validation threw, validation is unavailable
+ * (the web twin), or the one retry the consumer gets was already spent.
+ */
+export type BoardRenderImageLoadFailureKind =
+  | 'cache_entry_missing'
+  | 'retry_exhausted'
+  | 'cache_entry_present'
+  | 'validation_failed'
+  | 'validation_unsupported';
+
+export type BoardRenderFailureKind = BoardRenderNativeFailureKind | BoardRenderImageLoadFailureKind;
+
+/**
+ * A low-cardinality bucket for the failure message.
+ *
+ * `code_<n>` is a numeric error code the native layer named. The rest are
+ * coarse shapes of failure. Never the message itself — see
+ * `classifyBoardRenderErrorCode`.
+ */
+export type BoardRenderErrorCode = `code_${number}` | 'png' | 'cgimage' | 'write' | 'module' | 'capability' | 'other';
+
+/**
+ * Anything that looks like a generated overlay filename. Stripped before the
+ * buckets below are tried, for two reasons that point the same way:
+ *
+ *  * Privacy / cardinality: the cache key is in the filename, and nothing
+ *    derived from it may reach an event property.
+ *  * Correctness: every iOS write failure interpolates `"v5_<key>.png"` into
+ *    its message, so a bare `/png/i` test would swallow the whole `write`
+ *    bucket and label a full disk as a PNG-encoding fault.
+ */
+const OVERLAY_FILENAME_PATTERN = /\S*\.png/gi;
+
+/** A numeric code the native layer named, e.g. `Rust render failed with code -2`. */
+const NATIVE_ERROR_CODE_PATTERN = /code (-?\d+)/i;
+
+/**
+ * Bucket a render failure message into something a dashboard can group on.
+ *
+ * The raw message is never safe to send: it interpolates the cache key, the
+ * cache path and, on iOS, translated OS prose. This returns one of a closed set
+ * of strings instead, so `Board Render Failed` stays groupable and carries no
+ * identifier.
+ *
+ * A named numeric code wins over every prose match — it is the most specific
+ * thing the native layer ever tells us, and it survives translation.
+ */
+export function classifyBoardRenderErrorCode(message: string): BoardRenderErrorCode {
+  const codeMatch = NATIVE_ERROR_CODE_PATTERN.exec(message);
+  if (codeMatch) {
+    const code = Number.parseInt(codeMatch[1], 10);
+    if (Number.isFinite(code)) return `code_${code}`;
+  }
+  const prose = message.replace(OVERLAY_FILENAME_PATTERN, '');
+  if (/png/i.test(prose)) return 'png';
+  if (/CGImage/i.test(prose)) return 'cgimage';
+  if (/write|save|volume|space|ENOSPC/i.test(prose)) return 'write';
+  if (/not available|no usable render/i.test(prose)) return 'module';
+  if (/rebuilt BoardRenderer native binary/.test(prose)) return 'capability';
+  return 'other';
+}
+
+/** The fields every `Board Render Failed` carries on top of the common props. */
+export type BoardRenderFailureFields = {
+  surface: BoardRenderFailureSurface;
+  error_code: BoardRenderErrorCode;
+  /** The requested overlay width in pixels; `null` for a native-width render. */
+  render_width: number | null;
+  /** Length of the frames string — a cheap proxy for climb complexity. */
+  frames_length: number;
+  /**
+   * How many render failures this JS lifetime has seen, INCLUDING this one.
+   * Keeps counting past the 25-event cap, so a stream that stops at 25 is still
+   * legible as truncated rather than as a device that failed 25 times.
+   */
+  failures_this_session: number;
+};
+
+/**
+ * `stage` and `failure_kind` are one discriminated pair, not two free fields: a
+ * native rejection can never be `retry_exhausted` and an image load can never be
+ * `disk_full`, and pairing them in the type is what stops a call site inventing
+ * a combination no dashboard query would ever match.
+ */
+export type BoardRenderFailedInput = BoardRenderTelemetryProps &
+  BoardRenderFailureFields &
+  (
+    | { stage: 'native'; failure_kind: BoardRenderNativeFailureKind }
+    | { stage: 'image_load'; failure_kind: BoardRenderImageLoadFailureKind }
+  );
+
+export function boardRenderFailed(
+  input: BoardRenderFailedInput,
+): BoardRenderPayload<typeof SHARED_EVENTS.BoardRenderFailed, BoardRenderFailedInput> {
+  return { name: SHARED_EVENTS.BoardRenderFailed, properties: input };
+}

--- a/packages/shared/analytics/src/board-render-events.ts
+++ b/packages/shared/analytics/src/board-render-events.ts
@@ -285,8 +285,18 @@ export function boardLookStepResolved(
  */
 export type BoardRenderFailureSurface = 'full' | 'thumbnail';
 
-/** Which half of the render path gave up. */
-export type BoardRenderFailureStage = 'native' | 'image_load';
+/**
+ * Which part of the render path gave up.
+ *
+ * `config` is the one that fails SILENTLY, and it is why this event exists at
+ * all: when a climb's `frames` name placement ids the board config has no holds
+ * for — a Kilter Homewall climb (ids 4000+) drawn under Kilter Original 12x12
+ * (ids 1080-1590), say — the Rust renderer drops every unmatched hold and
+ * returns Ok. There is no rejection, nothing is logged, and the climber gets a
+ * veil with no holds on it. Caught before the native call rather than after,
+ * because there is no "after" to catch.
+ */
+export type BoardRenderFailureStage = 'native' | 'image_load' | 'config';
 
 /**
  * Why the native renderer rejected.
@@ -308,9 +318,33 @@ export type BoardRenderImageLoadFailureKind =
   | 'retry_exhausted'
   | 'cache_entry_present'
   | 'validation_failed'
-  | 'validation_unsupported';
+  | 'validation_unsupported'
+  /**
+   * expo-image was handed a URI and then said nothing — neither `onLoad` nor
+   * `onError` inside the watchdog window. Observation only: nothing is nulled
+   * and nothing is retried, because a file that renders correctly on Android
+   * and on the host but never paints on iOS is a different fault from a file
+   * that failed to load, and treating it as the latter would hide it again.
+   * Full-size surface only.
+   */
+  | 'paint_timeout';
 
-export type BoardRenderFailureKind = BoardRenderNativeFailureKind | BoardRenderImageLoadFailureKind;
+/**
+ * How a climb's frames line up with the board config it is about to be drawn
+ * against.
+ *
+ * `no_matching_holds` means NOTHING would draw — the render is skipped, since
+ * writing and caching a veil-only PNG only makes the failure harder to see.
+ * `partial_hold_match` still renders: a climb that legitimately spans a larger
+ * layout loses the holds off the edge and keeps the rest, which is a real (if
+ * degraded) drawing rather than a blank one.
+ */
+export type BoardRenderConfigFailureKind = 'no_matching_holds' | 'partial_hold_match';
+
+export type BoardRenderFailureKind =
+  | BoardRenderNativeFailureKind
+  | BoardRenderImageLoadFailureKind
+  | BoardRenderConfigFailureKind;
 
 /**
  * A low-cardinality bucket for the failure message.
@@ -319,7 +353,16 @@ export type BoardRenderFailureKind = BoardRenderNativeFailureKind | BoardRenderI
  * coarse shapes of failure. Never the message itself — see
  * `classifyBoardRenderErrorCode`.
  */
-export type BoardRenderErrorCode = `code_${number}` | 'png' | 'cgimage' | 'write' | 'module' | 'capability' | 'other';
+export type BoardRenderErrorCode =
+  | `code_${number}`
+  | 'png'
+  | 'cgimage'
+  | 'write'
+  | 'module'
+  | 'capability'
+  | 'no_matching_holds'
+  | 'paint_timeout'
+  | 'other';
 
 /**
  * Anything that looks like a generated overlay filename. Stripped before the
@@ -376,6 +419,13 @@ export type BoardRenderFailureFields = {
    * legible as truncated rather than as a device that failed 25 times.
    */
   failures_this_session: number;
+  /**
+   * How many placements frame 0 lights. Set on the `config` stage, absent
+   * elsewhere. A count, never the ids — the ids are the climb.
+   */
+  lit_count?: number;
+  /** How many of those the board config has no hold for. Same stage, same rule. */
+  unmatched_count?: number;
 };
 
 /**
@@ -389,6 +439,7 @@ export type BoardRenderFailedInput = BoardRenderTelemetryProps &
   (
     | { stage: 'native'; failure_kind: BoardRenderNativeFailureKind }
     | { stage: 'image_load'; failure_kind: BoardRenderImageLoadFailureKind }
+    | { stage: 'config'; failure_kind: BoardRenderConfigFailureKind }
   );
 
 export function boardRenderFailed(

--- a/packages/shared/analytics/src/board-render-events.ts
+++ b/packages/shared/analytics/src/board-render-events.ts
@@ -279,11 +279,19 @@ export function boardLookStepResolved(
 }
 
 /**
- * Which surface the failed overlay belonged to. Mirrors the mobile hook's
- * `filledStyle` flag: the filled style is what the list / accessory thumbnails
- * ask for, the stroke-only style is the full-size play board.
+ * Which surface the failed overlay belonged to.
+ *
+ * `play` is the ONE board the climber is actually looking at — the play
+ * drawer's current card, which opts in explicitly. Everything else that renders
+ * at full size is `full`: the board-look preview cards and rails, the preview
+ * sheet, the reaction menu, the wall kiosk hero, and the carousel's off-screen
+ * peek. `thumbnail` is the filled style the list and accessory rows ask for.
+ *
+ * The `play` / `full` split is not cosmetic: `full` covers surfaces that are
+ * off-screen, behind a sheet, or one of a dozen preview cards, so a rate
+ * measured across both would not describe anything a climber experienced.
  */
-export type BoardRenderFailureSurface = 'full' | 'thumbnail';
+export type BoardRenderFailureSurface = 'play' | 'full' | 'thumbnail';
 
 /**
  * Which part of the render path gave up.
@@ -325,7 +333,11 @@ export type BoardRenderImageLoadFailureKind =
    * and nothing is retried, because a file that renders correctly on Android
    * and on the host but never paints on iOS is a different fault from a file
    * that failed to load, and treating it as the latter would hide it again.
-   * Full-size surface only.
+   *
+   * `surface: 'play'` only, and armed only while an overlay `<Image>` is really
+   * mounted — a surface that renders no image (backgrounded, or a tab whose
+   * board art is released) cannot report silence, because there is nothing there
+   * to answer.
    */
   | 'paint_timeout';
 
@@ -361,6 +373,7 @@ export type BoardRenderErrorCode =
   | 'module'
   | 'capability'
   | 'no_matching_holds'
+  | 'partial_hold_match'
   | 'paint_timeout'
   | 'other';
 

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -818,6 +818,14 @@ export const SHARED_EVENTS = {
   // (issue #2202, settings-screen PR). `field` names the setting; `value` is
   // its new value stringified.
   BoardRenderSettingsChanged: 'Board Render Settings Changed',
+  // A board overlay failed to draw (issue: the Aura 12x12 blank-overlay
+  // investigation). Fired for BOTH halves of the render path — the native
+  // renderer rejecting, and expo-image failing to load the PNG it produced —
+  // with `stage` separating them. Capped at 25 per JS lifetime in the mobile
+  // hook, so a device stuck in a failure loop reports the shape of the problem
+  // without minting thousands of events; `failures_this_session` still counts
+  // past the cap, so a truncated stream is legible as truncated.
+  BoardRenderFailed: 'Board Render Failed',
   // A saved render preset or CVD palette preset was applied (issue #2202,
   // settings-screen PR). No extra props beyond the common ones — the event IS
   // "the common props now carry a preset_id/palette_id".

--- a/packages/shared/analytics/src/index.ts
+++ b/packages/shared/analytics/src/index.ts
@@ -30,6 +30,8 @@ export {
   boardRenderPresetApplied,
   boardLookStepShown,
   boardLookStepResolved,
+  boardRenderFailed,
+  classifyBoardRenderErrorCode,
   type BoardRenderMode,
   type GlowFalloff,
   type GlowFalloffSource,
@@ -48,6 +50,14 @@ export {
   type BoardLookStepOutcome,
   type BoardLookStepShownInput,
   type BoardLookStepResolvedInput,
+  type BoardRenderFailureSurface,
+  type BoardRenderFailureStage,
+  type BoardRenderNativeFailureKind,
+  type BoardRenderImageLoadFailureKind,
+  type BoardRenderFailureKind,
+  type BoardRenderErrorCode,
+  type BoardRenderFailureFields,
+  type BoardRenderFailedInput,
 } from './board-render-events';
 export {
   buildCohortPersonProperties,

--- a/packages/shared/analytics/src/index.ts
+++ b/packages/shared/analytics/src/index.ts
@@ -54,6 +54,7 @@ export {
   type BoardRenderFailureStage,
   type BoardRenderNativeFailureKind,
   type BoardRenderImageLoadFailureKind,
+  type BoardRenderConfigFailureKind,
   type BoardRenderFailureKind,
   type BoardRenderErrorCode,
   type BoardRenderFailureFields,


### PR DESCRIPTION
## Summary

Part of the Aura 12x12 blank-overlay investigation.

On iOS, the Aura look on Kilter Original 12x12 stops drawing the play board's hold overlay after ~7 swipes and never comes back until the app restarts — thumbnails keep working the whole time. There is currently nothing to investigate it with:

- the native render rejection is a `console.warn` plus ONE Sentry event per failure kind per JS lifetime (`reportRenderFailureOnce`), with no retry until the cache key changes;
- the expo-image load failures report once per kind per lifetime too, then null the overlay after one retry per key;
- there is no PostHog event for a mobile render failure at all — the existing `Board Render Error` is web-only.

So a session that fails every render after the seventh swipe looks, in every dashboard we have, exactly like a session that never failed.

Worse: **the two most likely causes never throw at all**, so no catch block could ever have seen them. Both are now caught. JS only; nothing under `packages/mobile/modules`, `packages/board-renderer`, or any Swift/Kotlin/Rust file is touched.

### The config stage — the Android-emulator repro

The native render **succeeds** and writes a veil-only PNG when a climb's `frames` name placement ids the board config has no holds for: a Kilter Homewall climb (ids 4000+) drawn under Kilter Original 12x12 (ids 1080–1590). The Rust renderer drops every unmatched hold and returns `Ok`, so the promise resolves, the PNG is cached, and the climber gets a veil with nothing on it.

The check now runs **before** the native call — frame 0's lit ids (via the existing `parseLitHoldIds`) intersected with the config's hold ids:

- **`no_matching_holds`** (nothing would draw): report and **skip the render**. Caching a blank overlay under that key only makes the failure quieter every time the climber comes back. Overlay stays null, wall photo still shows — the existing missing-layer contract.
- **`partial_hold_match`** (some draw, some don't): report and **render anyway**. A climb legitimately reaching past a smaller layout is degraded, not blank.

### The paint watchdog — the remaining iOS suspect

These climbs render correctly on Android and on the host, so the PNG is not the problem: the file may simply never be painted. expo-image is supposed to answer with `onLoad` or `onError`; silence is a third outcome nothing was watching for.

The play board only starts a 4s timer, cancelled by `onOverlayLoad` for that exact load key, by `onOverlayError`, by the load key changing, or by unmount. One timer per hook instance, so rapid swipes cannot stack them.

It arms off the view layer's **mount** signal (`onOverlayMounted`), never off `overlayUri`. `LayeredClimbImage` renders a bare `<View>` and no `<Image>` at all while the app is backgrounded or a tab's board art is released — and opening `/play` releases it for every other tab surface — so nothing there can fire `onLoad`, and a URI-armed watchdog would have reported guaranteed-bogus silence (with a backgrounded app's JS timers landing on resume before the remount).

**Observation only.** The overlay is not nulled and nothing is retried — a file that renders correctly but never paints is a different fault from one that failed to load, and handling it as the latter (null the overlay, spend the once-per-key retry budget) is exactly what would hide it again.

### `Board Render Failed`

New event in the shared board-render catalog (`SHARED_EVENTS`), with a typed builder next to `climbViewOpened` / `boardPinch`. Full property set:

| Property | Values |
| --- | --- |
| `board_name`, `layout_id`, `size_id`, `render_mode`, `glow_falloff`, `glow_falloff_source`, `preset_id?`, `palette_id?` | the common props, from `buildBoardRenderTelemetryProps` |
| `surface` | `play` \| `full` \| `thumbnail` — `play` is **opt-in**, see below |
| `stage` | `config` \| `native` \| `image_load` |
| `failure_kind` | on `config`: `no_matching_holds` \| `partial_hold_match`. On `native`: `render_failed` \| `disk_full` \| `capability_fallback`. On `image_load`: `cache_entry_missing` \| `retry_exhausted` \| `cache_entry_present` \| `validation_failed` \| `validation_unsupported` \| `paint_timeout` |
| `error_code` | `code_<n>` \| `png` \| `cgimage` \| `write` \| `module` \| `capability` \| `no_matching_holds` \| `partial_hold_match` \| `paint_timeout` \| `other` |
| `render_width` | number \| `null` |
| `frames_length` | number |
| `failures_this_session` | running count for this JS lifetime, including this event |
| `lit_count` | config stage only: how many placements frame 0 lights (a count, never the ids) |
| `unmatched_count` | config stage only: how many of those the board has no hold for |

`stage` and `failure_kind` are one discriminated pair in the type, so a call site cannot invent a combination no query would match. `lit_count` / `unmatched_count` are omitted entirely off the config stage rather than sent as zeroes.

**`surface: 'play'` is opt-in, and means exactly one board:** the play drawer's current card, which passes `playSurface` explicitly. Twelve other call sites render a board at full size and stay `full` — the board-look preview cards and rails, `CustomLookPreview`, `BoardPreviewSheet`, `ClimbReactionMenu`, `WallHeroStage`, and the carousel's own off-screen peek. Those are off-screen, behind a sheet, or a dozen at a time, so a rate pooled with them would not describe anything a climber experienced.

### `error_code` is a bucket, never the message

The failure message interpolates the cache key, the cache path and — on iOS — OS prose in whatever language the phone is set to. None of that is sent. `classifyBoardRenderErrorCode` is the whole boundary: a numeric code the native layer named wins over everything and is normalised (`code -002` → `code_-2`), otherwise the message is bucketed by shape.

One deviation worth flagging: overlay filenames are stripped **before** the prose match. Every iOS write failure carries `"v5_<key>.png"`, so a bare `/png/i` test would label a full volume as a PNG-encoding fault and empty the `write` bucket entirely. Covered by its own test.

### Budgets

- PostHog: 25 events per JS lifetime for the native and image_load stages, and a **separate** budget of 10 for the config stage. A config mismatch is a property of a climb-and-board pair, so a board whose sets don't cover a climb's holds produces one on every row of a list — sharing a budget would let one scroll spend the whole session on an unchanging answer and silence the signals that move. Config events are also deduped by cache key across every hook instance (bounded 200-key set). Past a cap nothing is sent, but `failures_this_session` keeps counting, so a truncated stream reads as truncated. The caps exist because `getOrStartInflightRender` drops the settled promise, so every recycled FlashList row retries — the storm shape from #3647.
- Sentry: unchanged once-per-kind-per-lifetime, plus `failuresThisSession` in `extra` and a `board-render` breadcrumb for **every** failure (new `addErrorBreadcrumb` in `error-reporting.ts`, guarded the same way `reportError` is). The one report Sentry does send can now say whether it was a one-off or the first of hundreds.

### One bounded self-retry

After a native `render_failed`, the hook bumps `setRecoveryRequest` once, 1500 ms later, guarded by a per-instance `Set` of cache keys so a key can never retry twice and a recycled row cannot storm. The timer is cleared in the effect cleanup. Deliberately **not** for `disk_full` (the 60s back-off owns that path) and **not** for the capability fallbacks (the degraded re-render is the retry).

Where it fires, all in `packages/mobile/src/hooks/use-native-climb-render.ts`:
- `1925-1972` — the hold-match check, before the native call (the config stage)
- `2069-2076` — the capability fallback
- `2080-2085` — every other native rejection
- `656-667` — `reportOverlayLoadFailure`, the single writer behind all seven `onOverlayError` branches
- `2188-2212` — the paint watchdog (`onOverlayMounted`)
- retry armed at `2113-2120`

### Tests

New `use-native-climb-render-failure-telemetry.test.tsx` (28 tests) plus 15 in the shared analytics suite. Full mobile suite: 781 files / 8064 tests green.

Watchdog coverage is explicit about the false-positive shapes: a surface rendering no image → no event; a mounted image that goes away → disarmed; a surface that didn't opt in → no event; a thumbnail → no event; a mounted image and silence → event.

The retry guard was mutation-tested: removing `!retriedCacheKeysRef.current.has(currentCacheKey)` fails `retries a failed key exactly once, then leaves it alone`, and only that test.

The render-hook fixtures also gained the placement ids their frames light — a fixture board with one hold at id 1 whose climbs light id 1100 is exactly the mismatch the new config check refuses to draw, so those mocks had to become realistic.

## Release Notes

- [x] No release note needed (internal / technical change)

none

## Test plan

1. Open any climb on the play board. Holds light up.
2. Swipe through 10 climbs. Every board draws.
3. Open a list of climbs. Thumbnails all draw.
4. CI green.

## Risk

Risk: 2/5 — telemetry, one bounded retry, and a pre-render guard that skips a board-mismatched overlay
