### PR TITLE
ci(db): run production migrations as the dedicated migrator role

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -432,7 +432,12 @@ jobs:
 
       - name: Run database migrations
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          # Migrations run as the dedicated boardsesh_migrator role, never as
+          # the shared secrets.DATABASE_URL identity: that secret is also what
+          # the Vercel build's page-data collection connects with, and after
+          # the PG16 role transition it carries the boardsesh_runtime
+          # credential, which deliberately cannot run DDL.
+          DATABASE_URL: ${{ secrets.MIGRATOR_DATABASE_URL }}
           VERIFY_MIGRATION_JOURNAL: '1'
         run: vp exec pnpm --filter @boardsesh/db run db:migrate
 


### PR DESCRIPTION
## Summary

W2 of the PG18 rollout (#4340): the migrate job moves off the shared `secrets.DATABASE_URL` onto the new Production-environment secret `MIGRATOR_DATABASE_URL` (already set, and proven against production by `postgres18-production-role-transition.sh verify-migrator`). The shared secret is about to be rotated to the `boardsesh_runtime` credential — which deliberately cannot run DDL — because the Vercel build's page-data collection also reads it.

Sequencing: this merges **before** the shared secret rotates; between now and the rotation, builds keep using the current credential and migrations use the migrator, both valid.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 2/5 — one env line in the deploy workflow; a wrong secret name would fail the next migrate job loudly, before any deploy proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAsksAJopQNZQwYQQbz7sn