### PR TITLE
feat(mobile): stamp the active board's gym on every analytics event

### DIFF
--- a/POSTHOG_INVENTORY.md
+++ b/POSTHOG_INVENTORY.md
@@ -35,6 +35,21 @@ Boardsesh has comprehensive PostHog instrumentation across both web (Next.js) an
 - `pageview(url)` — Captures $pageview with sanitized pathname
 - `capturePosthog(name, properties)` — PostHog-only bypass
 
+### Super Properties (mobile)
+
+Values registered once and stamped onto **every** subsequent event from that
+client until re-registered or cleared. PostHog's `reset()` wipes all of them, and
+`getPostHogClient()` caches the singleton, so each one is re-registered inside
+`reset()` (`/packages/mobile/src/lib/analytics.ts`) — otherwise it silently
+disappears for the rest of the launch after a sign-out.
+
+| Property | Values | Registered from | Why |
+| --- | --- | --- | --- |
+| `connectivity` | `online` \| `offline` | `analytics-connectivity.ts`, on network transition | Slice any event by whether the network was usable at capture time (#4317) |
+| `offline_engine_state` | `baked-on` \| `web-off` (+ legacy flag values) | `analytics-offline-engine-state.ts`, once per launch | Offline-engine bake measurement (#4312) |
+| `render_mode`, `glow_falloff`, `glow_falloff_source` | see `docs/board-render-analytics.md` | `registerRenderSuperProperties`, on settings change | Board-render A/B (#2202) |
+| `gym_uuid`, `gym_name` | the active board's gym, or absent | `analytics-gym.ts` via `AnalyticsGymProperties`, on active-board change | Which venue a climber is at — the only gym dimension on climbing events. Cleared (not left stale) when the active board has no gym |
+
 ### Server-Side Analytics
 
 **File:** `/packages/web/app/lib/analytics.server.ts`

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -87,6 +87,7 @@ import { useDiskCacheSweep } from '../src/hooks/use-disk-cache-sweep';
 import { AnalyticsProvider } from '../src/components/analytics/AnalyticsProvider';
 import { AnalyticsScreenTracker } from '../src/components/analytics/AnalyticsScreenTracker';
 import { ImageCacheTabSweeper } from '../src/components/ImageCacheTabSweeper';
+import { AnalyticsGymProperties } from '../src/components/analytics/AnalyticsGymProperties';
 import { AnalyticsPersonProperties } from '../src/components/analytics/AnalyticsPersonProperties';
 import { OtaUpdateTracker } from '../src/components/analytics/OtaUpdateTracker';
 import { InstallReferrerTracker } from '../src/components/analytics/InstallReferrerTracker';
@@ -585,6 +586,8 @@ function RootLayout() {
                         <PartyProfileProvider>
                           {/* Needs auth + query, both in scope here. Null render. */}
                           <AnalyticsPersonProperties />
+                          {/* Stamps the active board's gym on every event. Null render. */}
+                          <AnalyticsGymProperties />
                           <ConnectionSettingsProvider>
                             <ToastProvider>
                               <ClimbActionsDataWrapper>

--- a/packages/mobile/app/boards/__tests__/edit.test.tsx
+++ b/packages/mobile/app/boards/__tests__/edit.test.tsx
@@ -25,6 +25,14 @@ const trackMock = vi.hoisted(() => vi.fn());
 const alertMock = vi.hoisted(() => vi.fn());
 const buildUpdateInputMock = vi.hoisted(() => vi.fn());
 
+// What each test varies: the gym on file, the gym the picker is showing, and
+// whether the board being edited is also the active one.
+const state = vi.hoisted(() => ({
+  boardGymUuid: null as string | null,
+  selectedGym: null as { uuid: string; name: string } | null,
+  activeBoardUuid: null as string | null,
+}));
+
 const board = {
   uuid: 'board-uuid',
   boardType: 'moonboard',
@@ -68,14 +76,16 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('../../../src/lib/graphql/hooks', () => ({
-  useBoard: () => ({ data: board, isLoading: false }),
+  useBoard: () => ({ data: { ...board, gymUuid: state.boardGymUuid }, isLoading: false }),
   useProfile: () => ({ data: { displayName: 'Marco' } }),
   useUpdateBoard: () => ({ mutateAsync: updateBoardMock }),
   useLinkBoardToGym: () => ({ mutateAsync: linkBoardToGymMock }),
 }));
 
 vi.mock('../../../src/lib/graphql/use-active-board', () => ({
-  useActiveBoard: () => ({ data: null }),
+  useActiveBoard: () => ({
+    data: state.activeBoardUuid ? ({ uuid: state.activeBoardUuid } as unknown as UserBoard) : null,
+  }),
   useSetActiveBoard: () => setActiveBoardMock,
 }));
 
@@ -95,7 +105,7 @@ vi.mock('../../../src/components/board-discovery/use-board-builder', () => ({
     sizes: [],
     sizeId: 1,
     rawLayoutName: 'Standard',
-    selectedGym: null,
+    selectedGym: state.selectedGym,
     buildUpdateInput: buildUpdateInputMock,
   }),
 }));
@@ -142,6 +152,9 @@ function alertButtons(): AlertButton[] {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  state.boardGymUuid = null;
+  state.selectedGym = null;
+  state.activeBoardUuid = null;
   buildUpdateInputMock.mockReturnValue({ boardUuid: 'board-uuid', name: 'Klimmuur MoonBoard' });
   updateBoardMock.mockResolvedValue({ uuid: 'board-uuid', name: 'Klimmuur MoonBoard' } as unknown as UserBoard);
 });
@@ -244,6 +257,83 @@ describe('EditBoard', () => {
     await waitFor(() => expect(screen.getByTestId('error')).toBeTruthy());
     expect(alertMock).not.toHaveBeenCalled();
     expect(backMock).not.toHaveBeenCalled();
+  });
+
+  // `linkBoardToGym` runs after `updateBoard` and invalidates `['board']` /
+  // `['myBoards']`, never the `['activeBoard']` snapshot (staleTime: Infinity).
+  // Re-persisting the `updateBoard` response verbatim would keep the stored copy
+  // on the old venue across relaunches — the play drawer and every analytics
+  // event stamped from it would still name the gym the user just left.
+  it('persists the gym the board was just linked to onto the active board', async () => {
+    state.activeBoardUuid = 'board-uuid';
+    state.selectedGym = { uuid: 'gym-uuid', name: 'Klimmuur Centrum' };
+    // The pre-link answer from `updateBoard`: no gym yet.
+    updateBoardMock.mockResolvedValueOnce({
+      uuid: 'board-uuid',
+      name: 'Klimmuur MoonBoard',
+      gymUuid: null,
+      gymName: null,
+    } as unknown as UserBoard);
+
+    render(createElement(EditBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(setActiveBoardMock).toHaveBeenCalledTimes(1));
+    expect(setActiveBoardMock).toHaveBeenCalledWith(
+      expect.objectContaining({ uuid: 'board-uuid', gymUuid: 'gym-uuid', gymName: 'Klimmuur Centrum' }),
+    );
+  });
+
+  it('clears the gym on the stored copy when the board is unlinked', async () => {
+    state.activeBoardUuid = 'board-uuid';
+    state.boardGymUuid = 'gym-uuid';
+    state.selectedGym = null;
+    updateBoardMock.mockResolvedValueOnce({
+      uuid: 'board-uuid',
+      name: 'Klimmuur MoonBoard',
+      gymUuid: 'gym-uuid',
+      gymName: 'Klimmuur Centrum',
+    } as unknown as UserBoard);
+
+    render(createElement(EditBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(setActiveBoardMock).toHaveBeenCalledTimes(1));
+    expect(linkBoardToGymMock).toHaveBeenCalledWith({ boardUuid: 'board-uuid', gymUuid: null });
+    expect(setActiveBoardMock).toHaveBeenCalledWith(expect.objectContaining({ gymUuid: null, gymName: null }));
+  });
+
+  it('keeps the server gym when the link mutation was rejected', async () => {
+    // Too far from a gym the user doesn't run: the rest of the edit saved, so
+    // the stored copy is still refreshed — with the gym the server still holds,
+    // not the one the picker was showing.
+    state.activeBoardUuid = 'board-uuid';
+    state.selectedGym = { uuid: 'gym-uuid', name: 'Klimmuur Centrum' };
+    linkBoardToGymMock.mockRejectedValueOnce(new Error('not authorized'));
+    updateBoardMock.mockResolvedValueOnce({
+      uuid: 'board-uuid',
+      name: 'Klimmuur MoonBoard',
+      gymUuid: null,
+      gymName: null,
+    } as unknown as UserBoard);
+
+    render(createElement(EditBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(setActiveBoardMock).toHaveBeenCalledTimes(1));
+    expect(setActiveBoardMock).toHaveBeenCalledWith(expect.objectContaining({ gymUuid: null, gymName: null }));
+    expect(backMock).not.toHaveBeenCalled();
+  });
+
+  it('leaves the stored copy alone when the edited board is not the active one', async () => {
+    state.activeBoardUuid = 'another-board';
+    state.selectedGym = { uuid: 'gym-uuid', name: 'Klimmuur Centrum' };
+
+    render(createElement(EditBoard));
+    fireEvent.click(screen.getByText('submit'));
+
+    await waitFor(() => expect(backMock).toHaveBeenCalled());
+    expect(setActiveBoardMock).not.toHaveBeenCalled();
   });
 
   it('names the account cap instead of echoing the server message', async () => {

--- a/packages/mobile/app/boards/create.tsx
+++ b/packages/mobile/app/boards/create.tsx
@@ -64,6 +64,11 @@ function describeInput(input: CreateBoardInput, source: 'popular_seed' | 'scratc
     hasLocationName: !!input.locationName,
     hasCoords: input.latitude != null && input.longitude != null,
     hasGym: !!input.gymUuid,
+    // The gym being ATTACHED, which is not the `gym_uuid` super property — that
+    // one carries the currently ACTIVE board's gym, and the board being created
+    // has not become active yet. Uuid only: this function never carries free
+    // text, and the gym's name is resolvable from it.
+    gymUuid: input.gymUuid ?? undefined,
     source,
   };
 }

--- a/packages/mobile/app/boards/edit.tsx
+++ b/packages/mobile/app/boards/edit.tsx
@@ -179,9 +179,11 @@ function EditBoardForm({ board }: { board: UserBoard }) {
         // run), so it's reported separately rather than failing the whole save.
         const nextGymUuid = builder.selectedGym?.uuid ?? null;
         let gymLinkError: string | null = null;
+        let gymLinked = false;
         if (nextGymUuid !== (board.gymUuid ?? null)) {
           try {
             await linkBoardToGym.mutateAsync({ boardUuid: board.uuid, gymUuid: nextGymUuid });
+            gymLinked = true;
           } catch (error) {
             gymLinkError = extractGraphqlMessage(error) ?? t('mobile.gymPicker.linkError');
           }
@@ -191,7 +193,19 @@ function EditBoardForm({ board }: { board: UserBoard }) {
         // the rename / angle / visibility change reaches BLE + the play drawer.
         // This runs even when the gym link failed: the rest of the edit DID save,
         // and bailing early left the stored copy stale against the server.
-        if (activeBoard?.uuid === updated.uuid) await setActiveBoard(updated);
+        //
+        // The gym link is its own mutation and runs AFTER `updateBoard`, so
+        // `updated` still answers with the pre-link gym, and `linkBoardToGym`
+        // invalidates `['board']` / `['myBoards']` — never the `['activeBoard']`
+        // snapshot, whose query is `staleTime: Infinity`. Persisting `updated`
+        // unchanged therefore leaves the stored board on the old venue until the
+        // user re-picks it, across relaunches: the boards tab shows the new gym
+        // while the play drawer and every analytics event still name the old one.
+        if (activeBoard?.uuid === updated.uuid) {
+          await setActiveBoard(
+            gymLinked ? { ...updated, gymUuid: nextGymUuid, gymName: builder.selectedGym?.name ?? null } : updated,
+          );
+        }
 
         if (gymLinkError) {
           setUpdateError(gymLinkError);

--- a/packages/mobile/src/components/analytics/AnalyticsGymProperties.tsx
+++ b/packages/mobile/src/components/analytics/AnalyticsGymProperties.tsx
@@ -11,7 +11,7 @@ import { registerActiveGym } from '../../lib/analytics-gym';
 import { useActiveBoard } from '../../lib/graphql/use-active-board';
 
 export function AnalyticsGymProperties(): null {
-  const { data: activeBoard } = useActiveBoard();
+  const { data: activeBoard, isPending } = useActiveBoard();
 
   // Depend on the two scalars, not the board object — the query hands back a new
   // object identity on every refetch, and each registration is a persisted write.
@@ -19,11 +19,18 @@ export function AnalyticsGymProperties(): null {
   const gymName = activeBoard?.gymName ?? null;
 
   useEffect(() => {
+    // Leave whatever is registered alone until the stored board resolves.
+    // PostHog super properties survive a relaunch, and `data` is `undefined`
+    // while the AsyncStorage read is in flight — so treating that tick as "no
+    // gym" would clear a real venue on EVERY cold start, and every event fired
+    // before the read landed would lose its gym. Only a resolved query gets to
+    // say there is no gym.
+    if (isPending) return;
     // A board can carry a gym id with no uuid/name resolved yet (or none at all,
     // for a home wall). Both are needed for a usable breakdown, so anything short
     // of the pair clears the property rather than stamping a half-identified gym.
     registerActiveGym(gymUuid && gymName ? { uuid: gymUuid, name: gymName } : null);
-  }, [gymUuid, gymName]);
+  }, [isPending, gymUuid, gymName]);
 
   return null;
 }

--- a/packages/mobile/src/components/analytics/AnalyticsGymProperties.tsx
+++ b/packages/mobile/src/components/analytics/AnalyticsGymProperties.tsx
@@ -1,0 +1,29 @@
+// Stamps the active board's gym onto every PostHog event as super properties,
+// so any existing insight — climb sends, BLE failures, board history, offline
+// downloads — can be sliced by venue. Mounted once at the app root; renders null.
+//
+// Reads the active board (a cheap AsyncStorage read via React Query), not
+// useHomeBoard(), for the same reason AnalyticsPersonProperties does: the latter
+// fans out a logbook-ticks query we don't want to run at app root for analytics.
+
+import { useEffect } from 'react';
+import { registerActiveGym } from '../../lib/analytics-gym';
+import { useActiveBoard } from '../../lib/graphql/use-active-board';
+
+export function AnalyticsGymProperties(): null {
+  const { data: activeBoard } = useActiveBoard();
+
+  // Depend on the two scalars, not the board object — the query hands back a new
+  // object identity on every refetch, and each registration is a persisted write.
+  const gymUuid = activeBoard?.gymUuid ?? null;
+  const gymName = activeBoard?.gymName ?? null;
+
+  useEffect(() => {
+    // A board can carry a gym id with no uuid/name resolved yet (or none at all,
+    // for a home wall). Both are needed for a usable breakdown, so anything short
+    // of the pair clears the property rather than stamping a half-identified gym.
+    registerActiveGym(gymUuid && gymName ? { uuid: gymUuid, name: gymName } : null);
+  }, [gymUuid, gymName]);
+
+  return null;
+}

--- a/packages/mobile/src/components/analytics/AnalyticsGymProperties.tsx
+++ b/packages/mobile/src/components/analytics/AnalyticsGymProperties.tsx
@@ -25,6 +25,13 @@ export function AnalyticsGymProperties(): null {
     // gym" would clear a real venue on EVERY cold start, and every event fired
     // before the read landed would lose its gym. Only a resolved query gets to
     // say there is no gym.
+    //
+    // That relaunch carry-over is what covers the startup window, and it holds
+    // because the SDK runs both `register` and `capture` through `wrap()`, which
+    // defers them behind the client's init promise — nothing touches the props
+    // map until the persisted one has been read back off disk. So the first
+    // `$screen` / `OTA Update Status` of a launch carries last launch's gym, and
+    // this effect corrects it as soon as the board query settles.
     if (isPending) return;
     // A board can carry a gym id with no uuid/name resolved yet (or none at all,
     // for a home wall). Both are needed for a usable breakdown, so anything short

--- a/packages/mobile/src/components/analytics/__tests__/AnalyticsGymProperties.test.tsx
+++ b/packages/mobile/src/components/analytics/__tests__/AnalyticsGymProperties.test.tsx
@@ -6,16 +6,22 @@ import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const analyticsGym = vi.hoisted(() => ({ registerActiveGym: vi.fn() }));
-const state = vi.hoisted(() => ({ activeBoard: null as Record<string, unknown> | null }));
+const state = vi.hoisted(() => ({
+  activeBoard: undefined as Record<string, unknown> | null | undefined,
+  isPending: false,
+}));
 
 vi.mock('../../../lib/analytics-gym', () => ({ registerActiveGym: analyticsGym.registerActiveGym }));
-vi.mock('../../../lib/graphql/use-active-board', () => ({ useActiveBoard: () => ({ data: state.activeBoard }) }));
+vi.mock('../../../lib/graphql/use-active-board', () => ({
+  useActiveBoard: () => ({ data: state.activeBoard, isPending: state.isPending }),
+}));
 
 import { AnalyticsGymProperties } from '../AnalyticsGymProperties';
 
 beforeEach(() => {
   analyticsGym.registerActiveGym.mockClear();
   state.activeBoard = null;
+  state.isPending = false;
 });
 
 describe('AnalyticsGymProperties', () => {
@@ -25,6 +31,39 @@ describe('AnalyticsGymProperties', () => {
     render(createElement(AnalyticsGymProperties));
 
     expect(analyticsGym.registerActiveGym).toHaveBeenCalledWith({ uuid: 'gym-1', name: 'Bloclab' });
+  });
+
+  // PostHog super properties survive a relaunch, so treating the in-flight
+  // AsyncStorage read as "no gym" would clear a real venue on every cold start.
+  it('leaves the registered gym alone while the stored board is still loading', () => {
+    state.isPending = true;
+    state.activeBoard = undefined;
+
+    render(createElement(AnalyticsGymProperties));
+
+    expect(analyticsGym.registerActiveGym).not.toHaveBeenCalled();
+  });
+
+  it('registers once the stored board resolves after loading', () => {
+    state.isPending = true;
+    state.activeBoard = undefined;
+    const { rerender } = render(createElement(AnalyticsGymProperties));
+
+    state.isPending = false;
+    state.activeBoard = { gymUuid: 'gym-1', gymName: 'Bloclab' };
+    rerender(createElement(AnalyticsGymProperties));
+
+    expect(analyticsGym.registerActiveGym).toHaveBeenCalledExactlyOnceWith({ uuid: 'gym-1', name: 'Bloclab' });
+  });
+
+  // Only a RESOLVED query gets to say there is no gym.
+  it('clears once the query resolves with no board at all', () => {
+    state.isPending = false;
+    state.activeBoard = null;
+
+    render(createElement(AnalyticsGymProperties));
+
+    expect(analyticsGym.registerActiveGym).toHaveBeenCalledWith(null);
   });
 
   it('clears the gym for a home wall with no gym linked', () => {

--- a/packages/mobile/src/components/analytics/__tests__/AnalyticsGymProperties.test.tsx
+++ b/packages/mobile/src/components/analytics/__tests__/AnalyticsGymProperties.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+// jsdom is required: @testing-library/react's render() mounts into document.body,
+// even though this component renders null.
+import { render } from '@testing-library/react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const analyticsGym = vi.hoisted(() => ({ registerActiveGym: vi.fn() }));
+const state = vi.hoisted(() => ({ activeBoard: null as Record<string, unknown> | null }));
+
+vi.mock('../../../lib/analytics-gym', () => ({ registerActiveGym: analyticsGym.registerActiveGym }));
+vi.mock('../../../lib/graphql/use-active-board', () => ({ useActiveBoard: () => ({ data: state.activeBoard }) }));
+
+import { AnalyticsGymProperties } from '../AnalyticsGymProperties';
+
+beforeEach(() => {
+  analyticsGym.registerActiveGym.mockClear();
+  state.activeBoard = null;
+});
+
+describe('AnalyticsGymProperties', () => {
+  it('registers the active board gym', () => {
+    state.activeBoard = { gymUuid: 'gym-1', gymName: 'Bloclab' };
+
+    render(createElement(AnalyticsGymProperties));
+
+    expect(analyticsGym.registerActiveGym).toHaveBeenCalledWith({ uuid: 'gym-1', name: 'Bloclab' });
+  });
+
+  it('clears the gym for a home wall with no gym linked', () => {
+    state.activeBoard = { gymUuid: null, gymName: null };
+
+    render(createElement(AnalyticsGymProperties));
+
+    expect(analyticsGym.registerActiveGym).toHaveBeenCalledWith(null);
+  });
+
+  it('clears rather than half-stamping a gym whose name has not resolved', () => {
+    state.activeBoard = { gymUuid: 'gym-1', gymName: null };
+
+    render(createElement(AnalyticsGymProperties));
+
+    expect(analyticsGym.registerActiveGym).toHaveBeenCalledWith(null);
+  });
+
+  // The board a climber switches to is the one their next events belong to.
+  it('re-registers when the active board moves to another gym', () => {
+    state.activeBoard = { gymUuid: 'gym-1', gymName: 'Bloclab' };
+    const { rerender } = render(createElement(AnalyticsGymProperties));
+
+    state.activeBoard = { gymUuid: 'gym-2', gymName: 'Galpon Boulder' };
+    rerender(createElement(AnalyticsGymProperties));
+
+    expect(analyticsGym.registerActiveGym).toHaveBeenLastCalledWith({ uuid: 'gym-2', name: 'Galpon Boulder' });
+  });
+
+  // Each register() is a persisted write and the query hands back a fresh object
+  // identity on every refetch, so a re-render that changed nothing must not write.
+  it('does not re-register when the board object identity changes but the gym does not', () => {
+    state.activeBoard = { gymUuid: 'gym-1', gymName: 'Bloclab' };
+    const { rerender } = render(createElement(AnalyticsGymProperties));
+    analyticsGym.registerActiveGym.mockClear();
+
+    state.activeBoard = { gymUuid: 'gym-1', gymName: 'Bloclab' };
+    rerender(createElement(AnalyticsGymProperties));
+
+    expect(analyticsGym.registerActiveGym).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/analytics-gym.test.ts
+++ b/packages/mobile/src/lib/__tests__/analytics-gym.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const posthog = vi.hoisted(() => ({
+  client: null as { register: ReturnType<typeof vi.fn>; unregister: ReturnType<typeof vi.fn> } | null,
+}));
+
+vi.mock('../posthog-client', () => ({ getPostHogClient: () => posthog.client }));
+
+import {
+  GYM_NAME_SUPER_PROPERTY,
+  GYM_UUID_SUPER_PROPERTY,
+  registerActiveGym,
+  reregisterActiveGym,
+  __resetActiveGymForTests,
+} from '../analytics-gym';
+
+function makeClient() {
+  return { register: vi.fn(() => Promise.resolve()), unregister: vi.fn(() => Promise.resolve()) };
+}
+
+beforeEach(() => {
+  __resetActiveGymForTests();
+  posthog.client = makeClient();
+});
+
+describe('registerActiveGym', () => {
+  it('registers both properties for a board that has a gym', () => {
+    registerActiveGym({ uuid: 'gym-1', name: 'Bloclab' });
+
+    expect(posthog.client?.register).toHaveBeenCalledWith({
+      [GYM_UUID_SUPER_PROPERTY]: 'gym-1',
+      [GYM_NAME_SUPER_PROPERTY]: 'Bloclab',
+    });
+    expect(posthog.client?.unregister).not.toHaveBeenCalled();
+  });
+
+  // The correctness bug this module exists to avoid: a climber moves from a gym
+  // wall to their home board, and every home session keeps landing on the gym's
+  // leaderboard row.
+  it('clears both properties when the active board has no gym', () => {
+    registerActiveGym({ uuid: 'gym-1', name: 'Bloclab' });
+    posthog.client = makeClient();
+
+    registerActiveGym(null);
+
+    expect(posthog.client.unregister).toHaveBeenCalledWith(GYM_UUID_SUPER_PROPERTY);
+    expect(posthog.client.unregister).toHaveBeenCalledWith(GYM_NAME_SUPER_PROPERTY);
+    expect(posthog.client.register).not.toHaveBeenCalled();
+  });
+
+  it('is a silent no-op when analytics is disabled, but still remembers the value', () => {
+    posthog.client = null;
+    expect(() => registerActiveGym({ uuid: 'gym-1', name: 'Bloclab' })).not.toThrow();
+
+    // A client that appears later still gets it on the next re-registration.
+    const client = makeClient();
+    posthog.client = client;
+    reregisterActiveGym();
+
+    expect(client.register).toHaveBeenCalledWith({
+      [GYM_UUID_SUPER_PROPERTY]: 'gym-1',
+      [GYM_NAME_SUPER_PROPERTY]: 'Bloclab',
+    });
+  });
+
+  it('does not reject when the client throws', () => {
+    posthog.client = {
+      register: vi.fn(() => {
+        throw new Error('nope');
+      }),
+      unregister: vi.fn(() => Promise.resolve()),
+    };
+
+    expect(() => registerActiveGym({ uuid: 'gym-1', name: 'Bloclab' })).not.toThrow();
+  });
+});
+
+describe('reregisterActiveGym', () => {
+  // The trap: PostHog's reset() clears every super property, and the active
+  // board does not change on sign-out, so the effect that registered the gym
+  // will not re-run. Without this restore, every event after a sign-out loses
+  // its venue for the rest of the launch.
+  it('restores the remembered gym onto the client reset() hands it', () => {
+    registerActiveGym({ uuid: 'gym-1', name: 'Bloclab' });
+    const clientAfterReset = makeClient();
+
+    reregisterActiveGym(clientAfterReset);
+
+    expect(clientAfterReset.register).toHaveBeenCalledWith({
+      [GYM_UUID_SUPER_PROPERTY]: 'gym-1',
+      [GYM_NAME_SUPER_PROPERTY]: 'Bloclab',
+    });
+  });
+
+  it('re-clears when the remembered state is "no gym"', () => {
+    registerActiveGym(null);
+    const clientAfterReset = makeClient();
+
+    reregisterActiveGym(clientAfterReset);
+
+    expect(clientAfterReset.unregister).toHaveBeenCalledWith(GYM_UUID_SUPER_PROPERTY);
+    expect(clientAfterReset.register).not.toHaveBeenCalled();
+  });
+
+  it('does nothing before the root effect has published anything', () => {
+    const clientAfterReset = makeClient();
+
+    reregisterActiveGym(clientAfterReset);
+
+    expect(clientAfterReset.register).not.toHaveBeenCalled();
+    expect(clientAfterReset.unregister).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/lib/__tests__/analytics-gym.test.ts
+++ b/packages/mobile/src/lib/__tests__/analytics-gym.test.ts
@@ -99,6 +99,7 @@ describe('reregisterActiveGym', () => {
     reregisterActiveGym(clientAfterReset);
 
     expect(clientAfterReset.unregister).toHaveBeenCalledWith(GYM_UUID_SUPER_PROPERTY);
+    expect(clientAfterReset.unregister).toHaveBeenCalledWith(GYM_NAME_SUPER_PROPERTY);
     expect(clientAfterReset.register).not.toHaveBeenCalled();
   });
 

--- a/packages/mobile/src/lib/__tests__/analytics-reset.test.ts
+++ b/packages/mobile/src/lib/__tests__/analytics-reset.test.ts
@@ -95,6 +95,14 @@ describe('analytics reset', () => {
   // effect will not re-run — without this restore, every event for the rest of
   // the launch loses its venue and the gym leaderboard under-counts whoever
   // signed out mid-session.
+  //
+  // The property names are spelled out as literals here, deliberately, rather
+  // than imported from analytics-gym. `gym_uuid` / `gym_name` are a WIRE
+  // contract: PostHog insights and the gym dashboard reference those exact
+  // strings, and renaming one silently re-points every saved insight at a
+  // property that no longer exists. Asserting through the constant would follow
+  // the rename and stay green; the literal is what reds. analytics-gym.test.ts
+  // uses the constants to assert behaviour — this one pins the names.
   it('re-registers the active gym after resetting the client', async () => {
     const fakeClient = { register: vi.fn(), unregister: vi.fn() };
     posthogClientMocks.getPostHogClient.mockReturnValue(fakeClient);

--- a/packages/mobile/src/lib/__tests__/analytics-reset.test.ts
+++ b/packages/mobile/src/lib/__tests__/analytics-reset.test.ts
@@ -91,6 +91,37 @@ describe('analytics reset', () => {
     );
   });
 
+  // The active board does not change on sign-out, so AnalyticsGymProperties'
+  // effect will not re-run — without this restore, every event for the rest of
+  // the launch loses its venue and the gym leaderboard under-counts whoever
+  // signed out mid-session.
+  it('re-registers the active gym after resetting the client', async () => {
+    const fakeClient = { register: vi.fn(), unregister: vi.fn() };
+    posthogClientMocks.getPostHogClient.mockReturnValue(fakeClient);
+    const { registerActiveGym, __resetActiveGymForTests } = await import('../analytics-gym');
+    __resetActiveGymForTests();
+    registerActiveGym({ uuid: 'gym-1', name: 'Bloclab' });
+    fakeClient.register.mockClear();
+    const { reset } = await import('../analytics');
+
+    expect(reset()).toBe(true);
+
+    expect(fakeClient.register).toHaveBeenCalledWith({ gym_uuid: 'gym-1', gym_name: 'Bloclab' });
+  });
+
+  it('registers no gym when the active board has never carried one', async () => {
+    const fakeClient = { register: vi.fn(), unregister: vi.fn() };
+    posthogClientMocks.getPostHogClient.mockReturnValue(fakeClient);
+    const { __resetActiveGymForTests } = await import('../analytics-gym');
+    __resetActiveGymForTests();
+    const { reset } = await import('../analytics');
+
+    expect(reset()).toBe(true);
+
+    expect(fakeClient.register).not.toHaveBeenCalledWith(expect.objectContaining({ gym_uuid: expect.anything() }));
+    expect(fakeClient.unregister).not.toHaveBeenCalled();
+  });
+
   it('does not re-register when analytics is disabled (no client)', async () => {
     posthogClientMocks.getPostHogClient.mockReturnValue(null);
     const { reset } = await import('../analytics');

--- a/packages/mobile/src/lib/analytics-gym.ts
+++ b/packages/mobile/src/lib/analytics-gym.ts
@@ -1,0 +1,86 @@
+import type { PostHog } from 'posthog-react-native';
+import { getPostHogClient } from './posthog-client';
+
+/**
+ * The `gym_uuid` / `gym_name` super properties: WHICH physical venue the
+ * climber's active board belongs to, stamped onto every subsequent event.
+ *
+ * Nothing in the climbing telemetry carried a gym before this. Every climb
+ * event ships `boardName` (the board TYPE — kilter/tension), `layoutId` and
+ * `sizeId`, which describe the catalogue config, not the wall; `Board Created`
+ * ships `hasGym` as a bare boolean. The gym-funnel events do carry `gymUuid`,
+ * but they are www-only (directory, QR landing, claim flow) and never fire from
+ * the app. So "which gyms have the most Boardsesh climbers" — and the whole
+ * per-venue slice of product health — was unanswerable from any existing event.
+ *
+ * Registered as SUPER properties rather than per-event props on purpose: the
+ * question is not only "who sends climbs here" but "does Bluetooth work here",
+ * and `Bluetooth Connection Failed` fires from a hook that holds no board
+ * entity. One registration on active-board change reaches every event instead
+ * of threading a prop into fourteen call sites and still missing the BLE ones.
+ *
+ * It lives in its own module (rather than an inline `registerSuperProperties`
+ * call) because it has to survive `analytics.reset()`: PostHog's reset clears
+ * every registered super property, and the active board does not change on
+ * sign-out, so the effect that registered it will not re-run. Remembering the
+ * last value here is what lets `reset()` put it straight back — the same reason
+ * `connectivity` (#4317) and `offline_engine_state` (#4312) are re-registered.
+ */
+export type ActiveGym = { uuid: string; name: string };
+
+export const GYM_UUID_SUPER_PROPERTY = 'gym_uuid';
+export const GYM_NAME_SUPER_PROPERTY = 'gym_name';
+
+type GymRegisterClient = Pick<PostHog, 'register' | 'unregister'>;
+
+// `undefined` = nothing has been published this launch yet (do not touch the
+// client). `null` = the active board has no gym, which must CLEAR the property
+// rather than leave the previous gym stamped — otherwise a climber who switches
+// from a gym wall to their home board keeps reporting the gym, and every home
+// session lands on that gym's leaderboard row.
+let lastRegisteredGym: ActiveGym | null | undefined;
+
+function apply(gym: ActiveGym | null, client?: GymRegisterClient | null): void {
+  const target = client ?? getPostHogClient();
+  if (!target) return;
+  try {
+    const pending = gym
+      ? [target.register({ [GYM_UUID_SUPER_PROPERTY]: gym.uuid, [GYM_NAME_SUPER_PROPERTY]: gym.name })]
+      : [target.unregister(GYM_UUID_SUPER_PROPERTY), target.unregister(GYM_NAME_SUPER_PROPERTY)];
+    for (const result of pending) {
+      void Promise.resolve(result).catch((error: unknown) => {
+        if (__DEV__) console.warn('[analytics] failed to register the active gym', error);
+      });
+    }
+  } catch (error) {
+    if (__DEV__) console.warn('[analytics] failed to register the active gym', error);
+  }
+}
+
+/**
+ * Registers the active board's gym now and remembers it for the rest of the
+ * launch. Best effort like `registerConnectivitySuperProperty`: a failure must
+ * never break the caller, and it is a silent no-op when analytics is disabled
+ * (dev / no key). The value is remembered even then, so a client that appears
+ * later still gets it on the next re-registration.
+ *
+ * Pass `null` for a board with no gym — that clears the property.
+ */
+export function registerActiveGym(gym: ActiveGym | null): void {
+  lastRegisteredGym = gym;
+  apply(gym);
+}
+
+/**
+ * Puts the remembered gym back after `analytics.reset()` wiped it. No-op before
+ * the root effect has published anything — there is nothing to restore, and the
+ * effect's own registration is still coming.
+ */
+export function reregisterActiveGym(client?: GymRegisterClient | null): void {
+  if (lastRegisteredGym === undefined) return;
+  apply(lastRegisteredGym, client);
+}
+
+export function __resetActiveGymForTests(): void {
+  lastRegisteredGym = undefined;
+}

--- a/packages/mobile/src/lib/analytics-gym.ts
+++ b/packages/mobile/src/lib/analytics-gym.ts
@@ -40,20 +40,28 @@ type GymRegisterClient = Pick<PostHog, 'register' | 'unregister'>;
 // session lands on that gym's leaderboard row.
 let lastRegisteredGym: ActiveGym | null | undefined;
 
+function warnOnFailure(error: unknown): void {
+  if (__DEV__) console.warn('[analytics] failed to register the active gym', error);
+}
+
+// The SDK's register/unregister are declared async but can also throw
+// synchronously, so both shapes are swallowed the same way.
+function settle(result: unknown): void {
+  void Promise.resolve(result).catch(warnOnFailure);
+}
+
 function apply(gym: ActiveGym | null, client?: GymRegisterClient | null): void {
   const target = client ?? getPostHogClient();
   if (!target) return;
   try {
-    const pending = gym
-      ? [target.register({ [GYM_UUID_SUPER_PROPERTY]: gym.uuid, [GYM_NAME_SUPER_PROPERTY]: gym.name })]
-      : [target.unregister(GYM_UUID_SUPER_PROPERTY), target.unregister(GYM_NAME_SUPER_PROPERTY)];
-    for (const result of pending) {
-      void Promise.resolve(result).catch((error: unknown) => {
-        if (__DEV__) console.warn('[analytics] failed to register the active gym', error);
-      });
+    if (gym) {
+      settle(target.register({ [GYM_UUID_SUPER_PROPERTY]: gym.uuid, [GYM_NAME_SUPER_PROPERTY]: gym.name }));
+      return;
     }
+    settle(target.unregister(GYM_UUID_SUPER_PROPERTY));
+    settle(target.unregister(GYM_NAME_SUPER_PROPERTY));
   } catch (error) {
-    if (__DEV__) console.warn('[analytics] failed to register the active gym', error);
+    warnOnFailure(error);
   }
 }
 

--- a/packages/mobile/src/lib/analytics.ts
+++ b/packages/mobile/src/lib/analytics.ts
@@ -3,6 +3,7 @@ import { createAnalytics, type GlowFalloffSource } from '@boardsesh/analytics';
 import { getPostHogClient, registerAppSuperProperties } from './posthog-client';
 import { registerConnectivitySuperProperty } from './analytics-connectivity';
 import { reregisterOfflineEngineState } from './analytics-offline-engine-state';
+import { reregisterActiveGym } from './analytics-gym';
 
 // `sendEvent: false` suppresses the SDK's `$feature_flag_called` capture. Verified
 // in @posthog/core 1.46.1 (shared by posthog-react-native and posthog-js-lite):
@@ -215,6 +216,10 @@ export function registerRenderSuperProperties(effective: {
 // registered exactly once, from a flag effect that will not run again for the
 // rest of the launch, so a dropped value never comes back on its own and the
 // #4312 bake measurement would stop at the first sign-out.
+//
+// `gym_uuid` / `gym_name` are restored for the same reason: the active board
+// does not change on sign-out, so AnalyticsGymProperties' effect will not re-run
+// and every remaining event of the launch would lose its venue.
 export function reset(): boolean {
   const didReset = analytics.reset();
   const client = getClient();
@@ -222,6 +227,7 @@ export function reset(): boolean {
     registerAppSuperProperties(client);
     registerConnectivitySuperProperty(client);
     reregisterOfflineEngineState(client);
+    reregisterActiveGym(client);
   }
   return didReset;
 }

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -316,7 +316,13 @@ export const SHARED_EVENTS = {
   // #4166: this flow had zero telemetry, so a bug that created no rows at all
   // for weeks was invisible in both PostHog and error tracking.
   // Props: { boardType, layoutId, sizeId, setCount, angle, isOwned, isPublic,
-  //          hasLocationName, hasCoords, hasGym, source, allowedDuplicate }.
+  //          hasLocationName, hasCoords, hasGym, gymUuid, source,
+  //          allowedDuplicate }.
+  // `gymUuid` is the gym being ATTACHED, and is deliberately NOT the same thing
+  // as the `gym_uuid` super property (mobile, packages/mobile/src/lib/analytics-gym.ts)
+  // — that one carries the ACTIVE board's gym, and a board being created has not
+  // become active yet. Read them together to see a climber adding a second wall
+  // at a venue they already use.
   BoardCreated: 'Board Created',
   // Props: { boardType, source, error_reason: 'duplicate_config' | 'rate_limited'
   //          | 'auth' | 'board_limit' | 'exception' }. 'board_limit' is the


### PR DESCRIPTION
## Summary

Nothing in the climbing telemetry carried a gym, so "which gyms have the most Boardsesh climbers" was unanswerable from PostHog. Climb events ship `boardName` (the board *type* — kilter/tension), `layoutId` and `sizeId`, which describe the catalogue config rather than the physical wall; `Board Created` ships `hasGym` as a bare boolean. The gym-funnel events do carry `gymUuid`, but they are www-only (directory, QR landing, claim flow) and never fire from the app.

This registers `gym_uuid` / `gym_name` as PostHog **super properties** from the active board, which already carries them — `BOARD_FIELDS` selects `gymUuid`/`gymName`, and `useActiveBoard()` hands back the whole `UserBoard`, so nothing new is fetched.

Super properties rather than per-event props because the question is not only "who sends climbs here" but "does Bluetooth work here", and `Bluetooth Connection Failed` fires from a hook holding no board entity. One registration reaches every event — climb sends, BLE failures, board history, offline downloads — instead of threading a prop into fourteen call sites in `use-board-bluetooth.ts` and still missing the BLE ones.

Two things the module exists to get right:

- **A board with no gym clears the properties.** Left stale, a climber who switches from a gym wall to their home board keeps reporting the gym, and every home session lands on that gym's leaderboard row.
- **`reset()` restores them.** The active board does not change on sign-out, so the effect that registered the gym will not re-run — the same reason `connectivity` (#4317) and `offline_engine_state` (#4312) are restored there.

`Board Created` also gains `gymUuid`. That is deliberately *not* the same value as the super property: it is the gym being **attached**, while the super property carries the **active** board's gym, and a board being created has not become active yet. Read together they show a climber adding a second wall at a venue they already use.

Both guards are mutation-tested — dropping the `reset()` restore reds `analytics-reset`, and turning the no-gym clear into a no-op reds `analytics-gym`.

`POSTHOG_INVENTORY.md` gains a super-properties table. It documents the three existing ones (`connectivity`, `offline_engine_state`, the board-render trio) as well, since none of them were listed and a table showing only the new one would mislead.

### One real bug the gym dimension surfaced

Chasing where the gym could go stale turned up a bug that predates this PR. Linking, unlinking or moving the **active** board between gyms left the stored copy on the old venue: the gym link is its own mutation and runs after `updateBoard`, so the response the edit screen re-persists still carries the pre-link gym, and `useLinkBoardToGym` invalidates `['board']` / `['myBoards']` — never the `['activeBoard']` snapshot, whose query is `staleTime: Infinity`.

That is wider than analytics. The boards tab (invalidated) showed the new gym while the play drawer and the BLE wrapper, which read the denormalised AsyncStorage copy, kept naming the old one — and it survived relaunches until the user re-picked the board. Fixed by folding the linked gym into the board that gets persisted, only when the link succeeded: a rejected link (too far from a gym the user doesn't run) still persists the server's answer. Link, unlink, rejected link, and not-the-active-board are covered; the first two are mutation-tested.

### What this unblocks

A gym dimension on every mobile event, which is what a PostHog gym dashboard needs. Follow-ups, not in this PR: a `gym` group type (gated on confirming group analytics is on our PostHog plan), a nightly `gym_activity_stats` rollup for the pre-ship history, and a derived `gyms.country_code` for the geo rollup — `gyms` has free-text `address` + coords and no country field today.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

The telemetry itself is invisible, so 1-2 and 5 are regression checks on the send path. Steps 3-4 are the gym re-persist fix: before it, step 4 showed the old gym.

1. Sign in, pick a board linked to a gym.
2. Send a climb to the wall. It lights normally.
3. Edit that board, pick a different gym. Save succeeds.
4. Force-quit and reopen. Board shows the new gym.
5. Sign out and back in. App behaves normally.

## Risk

Risk: 2/5 — telemetry, plus the active-board re-persist on the board-edit save path. No new network calls and no change to what the save sends. Touches the app-root provider tree (one null-rendering component), the shared `reset()`, and one branch in `boards/edit.tsx`, all covered by the existing suite plus new mutation-tested cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S48qmEh4fSshzXYrTqjRaf


