### PR TITLE
fix(mobile): draw each climb on the board it belongs to (#5099)

### DIFF
--- a/packages/mobile/src/components/QueueItemRow.tsx
+++ b/packages/mobile/src/components/QueueItemRow.tsx
@@ -17,6 +17,7 @@ import { ClimbListItemContent } from './ClimbListItemContent';
 import { THUMBNAIL_WIDTH } from './ClimbListThumbnail';
 import { BoardDriverAvatar } from './board-presence/BoardDriverAvatar';
 import { resolveQueueRowAttribution } from '../lib/queue-attribution';
+import { resolveClimbRenderBoard } from '../lib/boards/climb-render-board';
 import { iosSystemColors } from '../theme/ios-colors';
 import { spacing } from '../theme/tokens';
 import { springs } from '../theme/animations';
@@ -51,6 +52,8 @@ export type QueueItemRowBoard = {
 type QueueItemRowProps = {
   item: ClimbQueueItem;
   position: number;
+  /** The queue's board. Used as the fallback for climbs that carry no board of
+   *  their own — each row resolves its own thumbnail board from its climb. */
   board: QueueItemRowBoard;
   isCurrentClimb: boolean;
   onPress: (item: ClimbQueueItem) => void;
@@ -144,6 +147,15 @@ function QueueItemRowComponent({
   // new `onPress`/`onTickHistory` and forces a re-render despite the memo.
   const itemRef = useRef(item);
   itemRef.current = item;
+
+  // A mixed-board queue is a supported state — `decideAdd`'s "add anyway" keeps
+  // a climb from another wall, and a board switch leaves the whole queue behind.
+  // Drawing such a row against the queue's board matches none of its hold ids and
+  // the thumbnail comes out as bare board art (#5099), so resolve per row. O(1):
+  // board data and the compatibility target are both cached by board key, and
+  // nothing here scans the queue.
+  const rowClimb = item.climb;
+  const rowBoard = useMemo(() => resolveClimbRenderBoard(rowClimb, board)?.boardConfig ?? board, [rowClimb, board]);
 
   // Refs so the drag handle's Pan gesture can `blocksExternalGesture` the row's own
   // tap/long-press (see dragHandleGesture below) — a touch that starts on the handle
@@ -473,11 +485,11 @@ function QueueItemRowComponent({
         {/* Shared climb visual: thumbnail + name/subtitle + grade */}
         <ClimbListItemContent
           climb={item.climb}
-          boardName={board.boardName}
-          layoutId={board.layoutId}
-          sizeId={board.sizeId}
-          setIds={board.setIds}
-          angle={board.angle}
+          boardName={rowBoard.boardName as BoardName}
+          layoutId={rowBoard.layoutId}
+          sizeId={rowBoard.sizeId}
+          setIds={rowBoard.setIds}
+          angle={rowBoard.angle}
         />
 
         {/* Sent-at-angle chip: history climbed at an angle other than the wall's */}

--- a/packages/mobile/src/components/__tests__/queue-item-row-cross-board.test.tsx
+++ b/packages/mobile/src/components/__tests__/queue-item-row-cross-board.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+// #5099 — a queue can legitimately hold climbs from more than one board:
+// `decideAdd`'s "add anyway", a party peer on another wall, or a board switch
+// that leaves the whole queue behind. Each row's thumbnail has to be drawn on
+// the board its own climb belongs to; the queue's board is only the fallback.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, useRef, type ReactNode } from 'react';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+import type { QueueItemRowBoard } from '../QueueItemRow';
+
+type BoardProps = { boardName?: string; layoutId?: number; sizeId?: number; setIds?: string; angle?: number };
+const recorded = vi.hoisted(() => ({ rows: [] as BoardProps[] }));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({ children }: { children?: ReactNode }) => createElement('button', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+vi.mock('react-native-reanimated', () => ({
+  default: { View: ({ children }: { children?: ReactNode }) => createElement('div', null, children) },
+  useAnimatedStyle: (fn: () => unknown) => fn(),
+  useSharedValue: (initial: unknown) => {
+    const ref = useRef({ value: initial });
+    return ref.current;
+  },
+  withSpring: (value: unknown) => value,
+  withTiming: (value: unknown) => value,
+  runOnJS: (fn: unknown) => fn,
+}));
+vi.mock('react-native-gesture-handler', () => {
+  const proxy: Record<string, unknown> = new Proxy({}, { get: () => () => proxy }) as unknown as Record<
+    string,
+    unknown
+  >;
+  return {
+    GestureDetector: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+    Gesture: { Pan: () => proxy, Tap: () => proxy, LongPress: () => proxy, Exclusive: () => ({}) },
+  };
+});
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { secondaryBackground: '#fff', separator: '#ccc' },
+    brandColors: { primary: '#6D28D9', success: '#0a0', error: '#a00' },
+  }),
+}));
+vi.mock('../../lib/haptics', () => ({ hapticSelection: vi.fn(), hapticMedium: vi.fn() }));
+vi.mock('../Text', () => ({ Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children) }));
+vi.mock('../Icon', () => ({ Icon: () => createElement('span', { 'data-icon': 'true' }) }));
+vi.mock('../ClimbListItemContent', () => ({
+  ClimbListItemContent: (props: BoardProps) => {
+    recorded.rows.push(props);
+    return createElement('span');
+  },
+}));
+vi.mock('../ClimbListThumbnail', () => ({ THUMBNAIL_WIDTH: 96 }));
+vi.mock('../board-presence/BoardDriverAvatar', () => ({ BoardDriverAvatar: () => createElement('span') }));
+vi.mock('../../theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 3: 12 } }));
+vi.mock('../../theme/animations', () => ({ springs: { interactive: {} } }));
+vi.mock('../play-drawer/queue-drag-math', () => ({ rowReorderShift: () => 0 }));
+
+const { QueueItemRow } = await import('../QueueItemRow');
+
+// The queue is bound to the Kilter Original 12x12.
+const queueBoard: QueueItemRowBoard = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20', angle: 40 };
+
+function makeItem(uuid: string, climb: Record<string, unknown>): ClimbQueueItem {
+  return { uuid, climb: { uuid: `climb-${uuid}`, name: uuid, frames: 'p1145r15', ...climb } } as ClimbQueueItem;
+}
+
+function renderRow(item: ClimbQueueItem) {
+  return render(
+    createElement(QueueItemRow, {
+      item,
+      position: 1,
+      board: queueBoard,
+      isCurrentClimb: false,
+      onPress: vi.fn(),
+      onRemove: vi.fn(),
+    }),
+  );
+}
+
+beforeEach(() => {
+  recorded.rows = [];
+  vi.clearAllMocks();
+});
+
+describe('QueueItemRow board resolution (#5099)', () => {
+  it('draws a Homewall row on the Homewall while the queue sits on the 12x12', () => {
+    renderRow(makeItem('homewall', { boardType: 'kilter', layoutId: 8, angle: 30 }));
+
+    const row = recorded.rows.at(-1);
+    expect(row?.layoutId).toBe(8);
+    expect(row?.sizeId).not.toBe(queueBoard.sizeId);
+    // The angle its grade was baked at, not the wall the queue is bound to.
+    expect(row?.angle).toBe(30);
+  });
+
+  it('leaves a row from the queue board on the queue board', () => {
+    renderRow(makeItem('twelve', { boardType: 'kilter', layoutId: 1, angle: 40 }));
+
+    expect(recorded.rows.at(-1)).toMatchObject({
+      boardName: queueBoard.boardName,
+      layoutId: queueBoard.layoutId,
+      sizeId: queueBoard.sizeId,
+      setIds: queueBoard.setIds,
+      angle: queueBoard.angle,
+    });
+  });
+
+  it('falls back to the queue board for a row that carries no board metadata', () => {
+    // Older queue items and party-synced climbs from before the metadata
+    // round-trip. These render fine today and must keep rendering.
+    renderRow(makeItem('legacy', {}));
+
+    expect(recorded.rows.at(-1)).toMatchObject({
+      boardName: queueBoard.boardName,
+      layoutId: queueBoard.layoutId,
+      sizeId: queueBoard.sizeId,
+    });
+  });
+});

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -27,9 +27,8 @@ import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import type { ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
 import { randomUUID } from 'expo-crypto';
 import { computeNavigationStateWithSuggestions, boardSupportsMirroring } from '@boardsesh/play-view';
-import { formatBoardDisplayName } from '@boardsesh/board-config';
 import { climbToQueueItem } from '../../lib/climb-to-queue-item';
-import { resolveClimbRenderBoard, sameRenderBoard } from '../../lib/boards/climb-render-board';
+import { formatRenderBoardLabel, resolveClimbRenderBoard, sameRenderBoard } from '../../lib/boards/climb-render-board';
 import type { ActiveSubDrawer } from '@boardsesh/play-view';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { DeferredBoard } from './DeferredBoard';
@@ -436,14 +435,19 @@ export function PlayDrawer({
     [displayedClimb, boardConfig],
   );
   const renderBoardConfig = renderBoardResolution?.boardConfig ?? boardConfig;
-  // The climb's own board disagrees with the selected one. Same gate as an
+  // The climb belongs to a genuinely DIFFERENT board model. Same gate as an
   // explicit board override (`boardMismatch` from the host), just discovered
   // from the climb rather than handed in by the opener.
-  const climbBoardMismatch = renderBoardResolution?.incompatible ?? false;
+  //
+  // Only `'incompatible'` raises it — never `'upsized'`, which is the same board
+  // name and layout on a bigger wall (and a MoonBoard climb wanting a set this
+  // wall hasn't got). There is no other board to switch TO in that case: the
+  // host matches owned boards by name + layout, so the scrim's one button would
+  // "switch" to the board the climber is already on and never clear. Playlist
+  // rows already draw those on the upsized board without a prompt; so do we.
+  const climbBoardMismatch = renderBoardResolution?.fit === 'incompatible';
   const showBoardMismatch = boardMismatch || climbBoardMismatch;
-  const switchBoardLabel = climbBoardMismatch
-    ? formatBoardDisplayName(renderBoardConfig.boardName)
-    : mismatchBoardLabel;
+  const switchBoardLabel = climbBoardMismatch ? formatRenderBoardLabel(renderBoardConfig) : mismatchBoardLabel;
   // The host resolves an explicit override on its own; when the mismatch came
   // from the climb there is no override to read, so hand it the board we
   // resolved so "Switch board" lands on the CLIMB's board.
@@ -551,7 +555,13 @@ export function PlayDrawer({
     // (the Browsing chrome promises "the wall stays put", and even without the
     // chrome a preview is not a commit). The live climb's writes resume when
     // the preview clears.
-    suppressWallWrites: isPreview,
+    //
+    // A climb from another board is suppressed for a harder reason: its hold ids
+    // address a different wall, so writing them lights the WRONG holds on the
+    // connected board. The scrim hides the play controls, but a party peer's
+    // playback event starts the engine with no local tap, so the guard belongs
+    // here rather than on the button (#5099).
+    suppressWallWrites: isPreview || climbBoardMismatch,
   });
 
   // Auto-close tick bar and drop the favorite override when climb changes, so the
@@ -1454,7 +1464,9 @@ export function PlayDrawer({
           onClose={handleCloseSubDrawer}
           boardName={boardConfig.boardName}
           layoutId={boardConfig.layoutId}
-          climbUuid={displayedClimb?.uuid}
+          // Per-angle stats are read against the board above; a climb from
+          // another board has none there, so ask for none.
+          climbUuid={climbBoardMismatch ? undefined : displayedClimb?.uuid}
           currentAngle={activeAngle}
           onAngleChange={(newAngle) => {
             onAngleChange?.(newAngle);

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -27,7 +27,9 @@ import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import type { ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
 import { randomUUID } from 'expo-crypto';
 import { computeNavigationStateWithSuggestions, boardSupportsMirroring } from '@boardsesh/play-view';
+import { formatBoardDisplayName } from '@boardsesh/board-config';
 import { climbToQueueItem } from '../../lib/climb-to-queue-item';
+import { resolveClimbRenderBoard, sameRenderBoard } from '../../lib/boards/climb-render-board';
 import type { ActiveSubDrawer } from '@boardsesh/play-view';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { DeferredBoard } from './DeferredBoard';
@@ -154,8 +156,11 @@ type PlayDrawerProps = {
   boardMismatch?: boolean;
   /** Human-readable name of the climb's board, shown in the overlay message. */
   mismatchBoardLabel?: string;
-  /** Switch to the climb's board (one-tap if owned, else the board picker). */
-  onSwitchBoard?: () => void;
+  /** Switch to the climb's board (one-tap if owned, else the board picker). The
+   *  drawer passes the board it resolved for the displayed climb when the
+   *  mismatch was discovered from the climb rather than handed in as an
+   *  override — the host has no override to read in that case. */
+  onSwitchBoard?: (boardConfig?: BoardConfig) => void;
   /** Opens the climb reaction menu (DrawerHostProvider's openClimbActions). On iOS
    *  the ellipsis uses this instead of the in-drawer bottom sheet. The drawer passes
    *  its own in-tree beta opener via `options.onAddBetaVideo` so the beta sheet
@@ -188,6 +193,22 @@ type PlayDrawerProps = {
   /** Anonymous only: hand this URL to login. Wired to the tick prompt. */
   onSignIn?: () => void;
 };
+
+/**
+ * The frames a swipe peek may draw, or null when the neighbouring climb belongs
+ * to a different board than the one currently on screen. Board art is one
+ * picture: a peek is drawn over it, so a climb whose holds live on another wall
+ * has nothing to show there.
+ */
+function peekFramesOnBoard(
+  peek: Climb | null | undefined,
+  activeBoardConfig: BoardConfig,
+  renderBoardConfig: BoardConfig,
+): string | null {
+  if (!peek) return null;
+  const resolved = resolveClimbRenderBoard(peek, activeBoardConfig);
+  return sameRenderBoard(resolved?.boardConfig ?? activeBoardConfig, renderBoardConfig) ? peek.frames : null;
+}
 
 // Fallback used for the first-screen reserve before the Logbook header has
 // been measured, so the board fits without a visible jump on first open.
@@ -396,7 +417,46 @@ export function PlayDrawer({
   const { boardseshActive } = useDisplayGrade();
   const { isAuthenticated } = useAuth();
 
-  const { boardName, layoutId, sizeId, setIds, angle } = boardConfig;
+  const displayedQueueItem = drawerPreviewItem ?? currentClimbQueueItem;
+  const displayedClimb = displayedQueueItem?.climb;
+  // A view-only preview is showing (not the active/wall climb). Commit paths
+  // never set `drawerPreviewItem`, so this is true only for genuine previews
+  // (workout builder, logbook/cross-board, the peer-driven accessory wall climb).
+  const isPreview = drawerPreviewItem != null;
+
+  // #5099: the shown climb does not have to belong to the board the climber has
+  // selected. A queue item left over from a board switch, a party peer on
+  // another wall, or a restored launch snapshot all keep their own
+  // `boardType`/`layoutId` — and drawing them against the active board's
+  // placements matches none of their hold ids, so the renderer drops every hold
+  // and paints a veil over bare board art. Draw each climb on ITS board instead,
+  // at its own angle, and let the mismatch raise the switch-board gate below.
+  const renderBoardResolution = useMemo(
+    () => resolveClimbRenderBoard(displayedClimb, boardConfig),
+    [displayedClimb, boardConfig],
+  );
+  const renderBoardConfig = renderBoardResolution?.boardConfig ?? boardConfig;
+  // The climb's own board disagrees with the selected one. Same gate as an
+  // explicit board override (`boardMismatch` from the host), just discovered
+  // from the climb rather than handed in by the opener.
+  const climbBoardMismatch = renderBoardResolution?.incompatible ?? false;
+  const showBoardMismatch = boardMismatch || climbBoardMismatch;
+  const switchBoardLabel = climbBoardMismatch
+    ? formatBoardDisplayName(renderBoardConfig.boardName)
+    : mismatchBoardLabel;
+  // The host resolves an explicit override on its own; when the mismatch came
+  // from the climb there is no override to read, so hand it the board we
+  // resolved so "Switch board" lands on the CLIMB's board.
+  const handleSwitchBoard = useCallback(() => {
+    onSwitchBoard?.(climbBoardMismatch ? renderBoardConfig : undefined);
+  }, [onSwitchBoard, climbBoardMismatch, renderBoardConfig]);
+
+  // Everything the DISPLAYED climb is drawn from reads the resolved board. The
+  // selected board's own angle stays behind `activeAngle`: the angle pill and
+  // the angle sheet drive the wall the climber is standing at, not the picture.
+  const { boardName, layoutId, sizeId, setIds, angle } = renderBoardConfig;
+  const activeAngle = boardConfig.angle;
+
   // The play route hosts its OWN BLE controls sheet (below) rather than the
   // app-root one — a native sheet presented from root lands BEHIND this modal
   // route. Local visibility, opened by the lightbulb long-press.
@@ -414,13 +474,6 @@ export function PlayDrawer({
       setIds: parsedSetIds,
     });
   }, [boardName, layoutId, sizeId, setIds]);
-
-  const displayedQueueItem = drawerPreviewItem ?? currentClimbQueueItem;
-  const displayedClimb = displayedQueueItem?.climb;
-  // A view-only preview is showing (not the active/wall climb). Commit paths
-  // never set `drawerPreviewItem`, so this is true only for genuine previews
-  // (workout builder, logbook/cross-board, the peer-driven accessory wall climb).
-  const isPreview = drawerPreviewItem != null;
 
   // Real favorite status for the heart, keyed on (boardName, climbUuid, angle).
   // Gated on the sheet being open so it doesn't fetch while the drawer is closed.
@@ -459,6 +512,19 @@ export function PlayDrawer({
   // During the commit hand-off use the frozen climb (captured at fling start) so
   // the peek doesn't jump to the new climb's neighbour mid-swap.
   const headerPeekClimb = isSwipeCommitting ? frozenPeekClimb : peekClimb;
+
+  // The swipe peeks paint the neighbouring climbs' holds under the CURRENT
+  // board art. A neighbour from another board has no holds there, so it would
+  // peek as an empty wall (or, worse, light unrelated holds that happen to share
+  // ids). Withhold its frames and let the board swap on commit instead (#5099).
+  const nextPeekFrames = useMemo(
+    () => peekFramesOnBoard(navigationState.nextItem?.climb, boardConfig, renderBoardConfig),
+    [navigationState.nextItem, boardConfig, renderBoardConfig],
+  );
+  const prevPeekFrames = useMemo(
+    () => peekFramesOnBoard(navigationState.prevItem?.climb, boardConfig, renderBoardConfig),
+    [navigationState.prevItem, boardConfig, renderBoardConfig],
+  );
 
   // Host-owned post-fling reset: once the swiped-to climb has actually rendered
   // (the displayed queue item changes), snap the shared swipe offset back to 0 and
@@ -603,7 +669,7 @@ export function PlayDrawer({
     setWallCalloutOpen(false);
   }, [markLatchExit]);
 
-  // When the board angle changes, drop the locally-pinned climb so the drawer
+  // When the SELECTED board's angle changes, drop the locally-pinned climb so the drawer
   // re-derives the displayed climb from currentClimbQueueItem — which the queue
   // re-grade effect patches with the new angle's grade. Without this, the header
   // would keep showing the stale grade baked into the locally-held climb. The
@@ -615,7 +681,7 @@ export function PlayDrawer({
     // The wall flag rides the pinned preview: with the preview gone there is no
     // "displayed climb IS the lit one" claim left to make.
     setDrawerPreviewIsWallClimb(false);
-  }, [angle]);
+  }, [activeAngle]);
 
   const { showToast } = useToast();
 
@@ -696,7 +762,7 @@ export function PlayDrawer({
   // Apply the host's open target. A new target is a fresh object with a bumped
   // nonce, so its identity changes on every open request — this fires on mount
   // (first open) AND when the user re-taps a climb while the route is already up
-  // (where `router.navigate('/play')` is a no-op). Defined AFTER the `[angle]`
+  // (where `router.navigate('/play')` is a no-op). Defined AFTER the `[activeAngle]`
   // preview-clear effect so that on a board-override open (angle + target both
   // change) the preview this sets wins over that effect's clear. The ref keeps
   // the latest `openDrawer` without making it a dep (we key only on the target).
@@ -1165,8 +1231,8 @@ export function PlayDrawer({
                             setIds={setIds}
                             currentFrames={displayedClimb.frames}
                             currentFrameOverride={playback.isAnimatable ? playback.currentFrameString : null}
-                            nextFrames={navigationState.nextItem?.climb.frames ?? null}
-                            prevFrames={navigationState.prevItem?.climb.frames ?? null}
+                            nextFrames={nextPeekFrames}
+                            prevFrames={prevPeekFrames}
                             mirrored={isMirrored}
                             canSwipeNext={navigationState.canNext}
                             canSwipePrevious={navigationState.canPrevious}
@@ -1199,8 +1265,8 @@ export function PlayDrawer({
                     "Switch board" action remains focusable. */}
                       <View style={styles.controlsRegion}>
                         <View
-                          accessibilityElementsHidden={boardMismatch}
-                          importantForAccessibility={boardMismatch ? 'no-hide-descendants' : 'auto'}
+                          accessibilityElementsHidden={showBoardMismatch}
+                          importantForAccessibility={showBoardMismatch ? 'no-hide-descendants' : 'auto'}
                         >
                           {playback.isAnimatable && (
                             <PlaybackControls
@@ -1266,13 +1332,13 @@ export function PlayDrawer({
                             onTickLongPress={handleTickFabLongPress}
                             viewer={viewer}
                             onSignInPress={onSignIn}
-                            currentAngle={angle}
+                            currentAngle={activeAngle}
                             onOpenAngleSelector={isAngleAdjustable ? handleOpenAngleSelector : undefined}
                           />
                         </View>
 
-                        {boardMismatch && onSwitchBoard ? (
-                          <SwitchBoardOverlay boardLabel={mismatchBoardLabel ?? ''} onSwitchBoard={onSwitchBoard} />
+                        {showBoardMismatch && onSwitchBoard ? (
+                          <SwitchBoardOverlay boardLabel={switchBoardLabel ?? ''} onSwitchBoard={handleSwitchBoard} />
                         ) : null}
                       </View>
                     </View>
@@ -1386,10 +1452,10 @@ export function PlayDrawer({
         <AngleSelectorSheet
           visible={angleSelectorVisible}
           onClose={handleCloseSubDrawer}
-          boardName={boardName}
-          layoutId={layoutId}
+          boardName={boardConfig.boardName}
+          layoutId={boardConfig.layoutId}
           climbUuid={displayedClimb?.uuid}
-          currentAngle={angle}
+          currentAngle={activeAngle}
           onAngleChange={(newAngle) => {
             onAngleChange?.(newAngle);
             handleCloseSubDrawer();

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-cross-board.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-cross-board.test.tsx
@@ -30,6 +30,8 @@ const recorded = vi.hoisted(() => ({
   deferredSections: [] as Props[],
   logAscent: [] as Props[],
   favoriteStatus: [] as Props[],
+  playback: [] as Props[],
+  angleSheet: [] as Props[],
 }));
 const queueState = vi.hoisted(() => ({
   queue: [] as unknown[],
@@ -139,7 +141,12 @@ vi.mock('../PlayDrawerHeader', () => ({ LivePlayDrawerHeader: () => null }));
 vi.mock('../SwipeableHeader', () => ({
   SwipeableHeader: ({ current }: { current?: ReactNode }) => createElement('div', null, current),
 }));
-vi.mock('../AngleSelectorSheet', () => ({ AngleSelectorSheet: () => null }));
+vi.mock('../AngleSelectorSheet', () => ({
+  AngleSelectorSheet: (props: Props) => {
+    recorded.angleSheet.push(props);
+    return null;
+  },
+}));
 vi.mock('../../ClimbActionsSheet', () => ({ ClimbActionsSheet: () => null }));
 vi.mock('../../AddBetaVideoSheet', () => ({ AddBetaVideoSheet: () => null }));
 vi.mock('../../ble/BleControlSheetHost', () => ({ BleControlSheetHost: () => null }));
@@ -171,7 +178,12 @@ vi.mock('../../../lib/graphql/hooks', () => ({
 vi.mock('../../../hooks/use-display-grade', () => ({ useDisplayGrade: () => ({ boardseshActive: false }) }));
 vi.mock('../../../hooks/use-share-climb', () => ({ useShareClimb: () => vi.fn() }));
 vi.mock('../../../hooks/use-mounted-on-first-open', () => ({ useMountedOnFirstOpen: (open: boolean) => open }));
-vi.mock('../use-mobile-playback', () => ({ useMobilePlayback: () => ({ isAnimatable: false }) }));
+vi.mock('../use-mobile-playback', () => ({
+  useMobilePlayback: (args: Props) => {
+    recorded.playback.push(args);
+    return { isAnimatable: false };
+  },
+}));
 vi.mock('../use-below-fold-content-request', () => ({
   useBelowFoldContentRequest: () => ({ requested: false, request: vi.fn(), requestFromScrollOffset: vi.fn() }),
 }));
@@ -206,6 +218,10 @@ function queueItem(climb: Climb, uuid: string): ClimbQueueItem {
   return { uuid, climb } as unknown as ClimbQueueItem;
 }
 
+// A smaller wall on the SAME Kilter layout, so a climb set on the 12x12 needs
+// an upsize rather than another board.
+const SMALL_TWELVE_LAYOUT = { boardName: 'kilter', layoutId: 1, sizeId: 14, setIds: '1,20', angle: 40 };
+
 // A Kilter Homewall climb (layout 8) — the board the climber was browsing.
 const HOMEWALL_CLIMB = climbOn('kilter', 8, 30, 'HOMEWALL00000000000000000000AAAA');
 // A climb that genuinely belongs to the selected 12x12.
@@ -237,6 +253,8 @@ beforeEach(() => {
   recorded.deferredSections = [];
   recorded.logAscent = [];
   recorded.favoriteStatus = [];
+  recorded.playback = [];
+  recorded.angleSheet = [];
   queueState.queue = [];
   queueState.currentClimbQueueItem = null;
   navigation.state = { nextItem: null, prevItem: null, canNext: false, canPrevious: false };
@@ -263,7 +281,9 @@ describe('PlayDrawer draws the climb on its own board (#5099)', () => {
     renderDrawer(vi.fn());
 
     expect(recorded.switchOverlay).not.toHaveLength(0);
-    expect(recorded.switchOverlay.at(-1)?.boardLabel).toBe('Kilter');
+    // Not the bare brand: "Switch to Kilter" reads as a no-op on a Kilter board,
+    // and Homewall vs Original is the whole of #5099.
+    expect(recorded.switchOverlay.at(-1)?.boardLabel).toBe('Kilter Board Homewall');
   });
 
   it('sends "Switch board" to the CLIMB board, so the host has something to switch to', () => {
@@ -292,6 +312,33 @@ describe('PlayDrawer draws the climb on its own board (#5099)', () => {
     expect(board.setIds).toBe(TWELVE_BY_TWELVE.setIds);
     // Nothing to switch to — the controls stay live.
     expect(recorded.switchOverlay).toHaveLength(0);
+  });
+
+  it('draws a climb that needs a bigger wall on the bigger wall, with no switch prompt', () => {
+    // Same board name and layout, one size up. There is no other board to
+    // switch TO — the host matches owned boards by name + layout, so a prompt
+    // here would "switch" to the board the climber is already on and never
+    // clear. Playlist rows already render these without a prompt.
+    queueState.currentClimbQueueItem = queueItem(
+      { ...TWELVE_CLIMB, compatibleSizeIds: [10] } as unknown as Climb,
+      'queue-upsized',
+    );
+    render(
+      createElement(PlayDrawer, {
+        presentation: 'pane' as const,
+        boardConfig: SMALL_TWELVE_LAYOUT,
+        openTarget: null,
+        onOpenQueue: vi.fn(),
+        onSwitchBoard: vi.fn(),
+      }),
+    );
+
+    const board = lastBoardProps();
+    expect(board.layoutId).toBe(1);
+    expect(board.sizeId).toBe(10);
+    expect(recorded.switchOverlay).toHaveLength(0);
+    // Same board, so the wall can still be driven.
+    expect(recorded.playback.at(-1)?.suppressWallWrites).toBe(false);
   });
 
   it('withholds a peek whose climb lives on another board', () => {
@@ -328,6 +375,38 @@ describe('PlayDrawer draws the climb on its own board (#5099)', () => {
 
     expect(recorded.logAscent.at(-1)?.layoutId).toBe(8);
     expect(recorded.logAscent.at(-1)?.angle).toBe(30);
+  });
+
+  it('never lets a wrong-board climb reach the wall', () => {
+    // Its hold ids address a different wall. The scrim hides the play button,
+    // but a party peer's playback event starts the engine with no local tap —
+    // so the suppression flag, not the UI, is what keeps the board dark.
+    queueState.currentClimbQueueItem = queueItem(HOMEWALL_CLIMB, 'queue-homewall');
+    renderDrawer(vi.fn());
+
+    expect(recorded.playback.at(-1)?.suppressWallWrites).toBe(true);
+  });
+
+  it('leaves wall writes armed for a climb that belongs to this board', () => {
+    queueState.currentClimbQueueItem = queueItem(TWELVE_CLIMB, 'queue-twelve');
+    renderDrawer(vi.fn());
+
+    expect(recorded.playback.at(-1)?.suppressWallWrites).toBe(false);
+  });
+
+  it('asks the angle sheet for no per-climb stats on a wrong-board climb', () => {
+    // The sheet reads by-angle stats against the SELECTED board, where this
+    // climb does not exist.
+    queueState.currentClimbQueueItem = queueItem(HOMEWALL_CLIMB, 'queue-homewall');
+    renderDrawer(vi.fn());
+
+    act(() => {
+      (recorded.actionBar.at(-1)?.onOpenAngleSelector as () => void)();
+    });
+
+    expect(recorded.angleSheet.at(-1)?.climbUuid).toBeUndefined();
+    // Still the selected board's angles — that is the wall the pill moves.
+    expect(recorded.angleSheet.at(-1)?.currentAngle).toBe(TWELVE_BY_TWELVE.angle);
   });
 
   it('still shows the angle pill for the board the climber is standing at', () => {

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-cross-board.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-cross-board.test.tsx
@@ -1,0 +1,341 @@
+// @vitest-environment jsdom
+// #5099 — the drawer draws the climb it is SHOWING, on the board that climb
+// belongs to.
+//
+// Browse the Kilter Homewall (layout 8), switch the selected board to the
+// Original 12x12 (layout 1), and the climb that carries over as
+// `currentClimbQueueItem` is still a Homewall climb. Rendered against the
+// 12x12's placements none of its hold ids exist, the renderer drops every hold
+// and returns Ok, and the board comes out as a wash over bare art — no throw,
+// nothing logged.
+//
+// The resolver is unit-tested next to itself (`lib/boards/__tests__`); this file
+// exists because a sound resolver nobody calls leaves the bug exactly where it
+// was. It renders the real PlayDrawer and asserts the joins: which board reaches
+// DeferredBoard, whether the switch gate is up, which board "Switch board"
+// targets, and that a neighbouring climb from another board is not peeked under
+// the current art.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { Climb } from '@boardsesh/shared-schema';
+import type { ClimbQueueItem } from '@boardsesh/queue';
+
+type Props = Record<string, unknown>;
+
+const recorded = vi.hoisted(() => ({
+  board: [] as Props[],
+  switchOverlay: [] as Props[],
+  actionBar: [] as Props[],
+  deferredSections: [] as Props[],
+  logAscent: [] as Props[],
+  favoriteStatus: [] as Props[],
+}));
+const queueState = vi.hoisted(() => ({
+  queue: [] as unknown[],
+  currentClimbQueueItem: null as unknown,
+}));
+const navigation = vi.hoisted(() => ({
+  state: {
+    nextItem: null as unknown,
+    prevItem: null as unknown,
+    canNext: false,
+    canPrevious: false,
+  },
+}));
+
+// --- Host platform -----------------------------------------------------------
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
+    createElement('button', { onClick: onPress }, children),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1, absoluteFillObject: {} },
+  Platform: { OS: 'web', select: (spec: Record<string, unknown>) => spec.web ?? spec.default },
+  useWindowDimensions: () => ({ width: 390, height: 844 }),
+  AccessibilityInfo: { announceForAccessibility: vi.fn() },
+}));
+vi.mock('react-native-mmkv', () => {
+  const store = new Map<string, string>();
+  return {
+    createMMKV: () => ({
+      getString: (key: string) => store.get(key),
+      set: (key: string, value: string) => store.set(key, value),
+      remove: (key: string) => store.delete(key),
+      clearAll: () => store.clear(),
+    }),
+  };
+});
+vi.mock('react-native-gesture-handler', () => ({
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  GestureDetector: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('react-native-reanimated', () => ({
+  default: { View: ({ children }: { children?: ReactNode }) => createElement('div', null, children) },
+  useAnimatedStyle: () => ({}),
+  useAnimatedReaction: () => undefined,
+  useSharedValue: (initial: unknown) => ({ value: initial }),
+  runOnJS: (fn: unknown) => fn,
+}));
+vi.mock('expo-router', () => ({ router: { dismiss: vi.fn() } }));
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'random-uuid' }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0, bottom: 0 }) }));
+
+// --- Shared packages ---------------------------------------------------------
+// Navigation is driven per-case so a peek can be aimed at another board.
+// `@boardsesh/board-config` and `lib/board-details` stay REAL: the resolver
+// reads real layouts, sizes and hold placements, which is the whole question.
+vi.mock('@boardsesh/play-view', () => ({
+  computeNavigationStateWithSuggestions: () => navigation.state,
+  boardSupportsMirroring: () => true,
+}));
+vi.mock('@boardsesh/analytics', () => ({
+  SHARED_EVENTS: {
+    ClimbShared: 'Climb Shared',
+    FavoriteToggle: 'Favorite Toggle',
+    QuickTickOpened: 'Quick Tick Opened',
+  },
+}));
+vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
+
+// --- Children ----------------------------------------------------------------
+vi.mock('../DeferredBoard', () => ({
+  DeferredBoard: (props: Props) => {
+    recorded.board.push(props);
+    return createElement('div', { 'data-testid': 'board' });
+  },
+}));
+vi.mock('../SwitchBoardOverlay', () => ({
+  SwitchBoardOverlay: (props: Props) => {
+    recorded.switchOverlay.push(props);
+    return createElement('div', { 'data-testid': 'switch-board-overlay' });
+  },
+}));
+vi.mock('../PlayDrawerActionBar', () => ({
+  PlayDrawerActionBar: (props: Props) => {
+    recorded.actionBar.push(props);
+    return createElement('div', { 'data-testid': 'action-bar' });
+  },
+}));
+vi.mock('../DeferredSections', () => ({
+  DeferredSections: (props: Props) => {
+    recorded.deferredSections.push(props);
+    return createElement('div', { 'data-testid': 'deferred-sections' });
+  },
+}));
+vi.mock('../../LogAscentSheet', () => ({
+  LogAscentSheet: (props: Props) => {
+    recorded.logAscent.push(props);
+    return createElement('div', { 'data-testid': 'log-ascent' });
+  },
+}));
+vi.mock('../WallStatePill', () => ({ WallStatePill: () => null }));
+vi.mock('../WallStateCallout', () => ({ WallStateCallout: () => null }));
+vi.mock('../BrowseFrameOverlay', () => ({ BrowseFrameOverlay: () => null }));
+vi.mock('../PanePlaceholder', () => ({ PanePlaceholder: () => null }));
+vi.mock('../BoardRenderUnavailable', () => ({ BoardRenderUnavailable: () => null }));
+vi.mock('../PlaybackControls', () => ({ PlaybackControls: () => null }));
+vi.mock('../PlayDrawerHeader', () => ({ LivePlayDrawerHeader: () => null }));
+vi.mock('../SwipeableHeader', () => ({
+  SwipeableHeader: ({ current }: { current?: ReactNode }) => createElement('div', null, current),
+}));
+vi.mock('../AngleSelectorSheet', () => ({ AngleSelectorSheet: () => null }));
+vi.mock('../../ClimbActionsSheet', () => ({ ClimbActionsSheet: () => null }));
+vi.mock('../../AddBetaVideoSheet', () => ({ AddBetaVideoSheet: () => null }));
+vi.mock('../../ble/BleControlSheetHost', () => ({ BleControlSheetHost: () => null }));
+vi.mock('../../Icon', () => ({ Icon: () => null }));
+
+// --- Hooks / providers -------------------------------------------------------
+vi.mock('../../../providers/queue-provider', () => ({
+  useQueueData: () => queueState,
+  useQueueActions: () => ({
+    setCurrentClimb: vi.fn(),
+    nextClimb: vi.fn(),
+    previousClimb: vi.fn(),
+    addToQueue: vi.fn(async () => 'added'),
+    noteClimbViewed: vi.fn(),
+  }),
+  useQueueSessionId: () => ({ sessionId: null }),
+  usePlaylistSuggestionSource: () => null,
+}));
+vi.mock('../../../providers/bluetooth-provider', () => ({ useOptionalBluetoothContext: () => null }));
+vi.mock('../../../providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
+vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useToggleFavorite: () => ({ mutate: vi.fn() }),
+  useFavoriteStatus: (boardName: string, uuid: string | null, angle: number) => {
+    recorded.favoriteStatus.push({ boardName, uuid, angle });
+    return { data: undefined };
+  },
+}));
+vi.mock('../../../hooks/use-display-grade', () => ({ useDisplayGrade: () => ({ boardseshActive: false }) }));
+vi.mock('../../../hooks/use-share-climb', () => ({ useShareClimb: () => vi.fn() }));
+vi.mock('../../../hooks/use-mounted-on-first-open', () => ({ useMountedOnFirstOpen: (open: boolean) => open }));
+vi.mock('../use-mobile-playback', () => ({ useMobilePlayback: () => ({ isAnimatable: false }) }));
+vi.mock('../use-below-fold-content-request', () => ({
+  useBelowFoldContentRequest: () => ({ requested: false, request: vi.fn(), requestFromScrollOffset: vi.fn() }),
+}));
+vi.mock('../use-drawer-dismiss-gesture', () => ({
+  useDrawerDismissGesture: () => ({ gesture: { enabled: () => ({}) }, translateY: { value: 0 } }),
+}));
+vi.mock('../use-play-drawer-wake-lock', () => ({ usePlayDrawerWakeLock: () => undefined }));
+vi.mock('../../ble/use-lightbulb-control', () => ({
+  useLightbulbControl: () => ({ lit: false, localConnected: false, pending: false, onPress: vi.fn() }),
+}));
+vi.mock('../copy-climb-name', () => ({ copyClimbName: vi.fn() }));
+vi.mock('../../../lib/haptics', () => ({ hapticSuccess: vi.fn() }));
+
+const { PlayDrawer } = await import('../PlayDrawer');
+
+// The Original 12x12 the climber switched TO.
+const TWELVE_BY_TWELVE = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20', angle: 40 };
+
+function climbOn(boardType: string, layoutId: number, angle: number, uuid: string): Climb {
+  return {
+    uuid,
+    name: `Climb ${uuid}`,
+    frames: 'p1145r15',
+    difficulty: '7A',
+    boardType,
+    layoutId,
+    angle,
+  } as unknown as Climb;
+}
+
+function queueItem(climb: Climb, uuid: string): ClimbQueueItem {
+  return { uuid, climb } as unknown as ClimbQueueItem;
+}
+
+// A Kilter Homewall climb (layout 8) — the board the climber was browsing.
+const HOMEWALL_CLIMB = climbOn('kilter', 8, 30, 'HOMEWALL00000000000000000000AAAA');
+// A climb that genuinely belongs to the selected 12x12.
+const TWELVE_CLIMB = climbOn('kilter', 1, 40, 'TWELVE0000000000000000000000BBBB');
+
+function renderDrawer(onSwitchBoard?: (boardConfig?: unknown) => void) {
+  return render(
+    createElement(PlayDrawer, {
+      presentation: 'pane' as const,
+      boardConfig: TWELVE_BY_TWELVE,
+      openTarget: null,
+      onOpenQueue: vi.fn(),
+      onSwitchBoard,
+    }),
+  );
+}
+
+function lastBoardProps(): Props {
+  const props = recorded.board.at(-1);
+  if (!props) throw new Error('DeferredBoard never rendered');
+  return props;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  recorded.board = [];
+  recorded.switchOverlay = [];
+  recorded.actionBar = [];
+  recorded.deferredSections = [];
+  recorded.logAscent = [];
+  recorded.favoriteStatus = [];
+  queueState.queue = [];
+  queueState.currentClimbQueueItem = null;
+  navigation.state = { nextItem: null, prevItem: null, canNext: false, canPrevious: false };
+});
+
+describe('PlayDrawer draws the climb on its own board (#5099)', () => {
+  it('renders a carried-over Homewall climb on the Homewall, not on the selected 12x12', () => {
+    queueState.currentClimbQueueItem = queueItem(HOMEWALL_CLIMB, 'queue-homewall');
+    renderDrawer(vi.fn());
+
+    const board = lastBoardProps();
+    // Layout 8 is the Homewall. Rendering it under layout 1's placements is the
+    // bug: every hold id is dropped and the board comes out as a plain wash.
+    expect(board.layoutId).toBe(8);
+    expect(board.boardName).toBe('kilter');
+    expect(board.sizeId).not.toBe(TWELVE_BY_TWELVE.sizeId);
+    expect(board.currentFrames).toBe(HOMEWALL_CLIMB.frames);
+  });
+
+  it('raises the switch-board gate for a carried-over climb, with no override in play', () => {
+    queueState.currentClimbQueueItem = queueItem(HOMEWALL_CLIMB, 'queue-homewall');
+    // `boardMismatch` is NOT passed: nobody set a board override — the drawer has
+    // to notice the disagreement from the climb itself.
+    renderDrawer(vi.fn());
+
+    expect(recorded.switchOverlay).not.toHaveLength(0);
+    expect(recorded.switchOverlay.at(-1)?.boardLabel).toBe('Kilter');
+  });
+
+  it('sends "Switch board" to the CLIMB board, so the host has something to switch to', () => {
+    queueState.currentClimbQueueItem = queueItem(HOMEWALL_CLIMB, 'queue-homewall');
+    const onSwitchBoard = vi.fn();
+    renderDrawer(onSwitchBoard);
+
+    act(() => {
+      (recorded.switchOverlay.at(-1)?.onSwitchBoard as () => void)();
+    });
+
+    // Without the board, the host reads its (empty) override, returns early, and
+    // the only button on the scrim does nothing.
+    expect(onSwitchBoard).toHaveBeenCalledTimes(1);
+    expect(onSwitchBoard.mock.calls[0][0]).toMatchObject({ boardName: 'kilter', layoutId: 8, angle: 30 });
+  });
+
+  it('leaves a climb from the selected board completely alone', () => {
+    queueState.currentClimbQueueItem = queueItem(TWELVE_CLIMB, 'queue-twelve');
+    renderDrawer(vi.fn());
+
+    const board = lastBoardProps();
+    expect(board.boardName).toBe(TWELVE_BY_TWELVE.boardName);
+    expect(board.layoutId).toBe(TWELVE_BY_TWELVE.layoutId);
+    expect(board.sizeId).toBe(TWELVE_BY_TWELVE.sizeId);
+    expect(board.setIds).toBe(TWELVE_BY_TWELVE.setIds);
+    // Nothing to switch to — the controls stay live.
+    expect(recorded.switchOverlay).toHaveLength(0);
+  });
+
+  it('withholds a peek whose climb lives on another board', () => {
+    // Swiping from a 12x12 climb toward a Homewall neighbour: the peek is drawn
+    // over the 12x12 art, where the neighbour has no holds.
+    queueState.currentClimbQueueItem = queueItem(TWELVE_CLIMB, 'queue-twelve');
+    navigation.state = {
+      nextItem: queueItem(HOMEWALL_CLIMB, 'queue-homewall'),
+      prevItem: queueItem(TWELVE_CLIMB, 'queue-twelve-prev'),
+      canNext: true,
+      canPrevious: true,
+    };
+    renderDrawer(vi.fn());
+
+    const board = lastBoardProps();
+    expect(board.nextFrames).toBeNull();
+    // The same-board neighbour still peeks — this must not blanket-disable peeks.
+    expect(board.prevFrames).toBe(TWELVE_CLIMB.frames);
+  });
+
+  it('keeps the below-fold sections and the tick sheet on the climb board', () => {
+    queueState.currentClimbQueueItem = queueItem(HOMEWALL_CLIMB, 'queue-homewall');
+    renderDrawer(vi.fn());
+
+    // Logbook / beta / similar climbs are all per-board reads.
+    expect(recorded.deferredSections.at(-1)?.layoutId).toBe(8);
+    // The favourite heart is keyed on (board, climb, angle); keyed on the wrong
+    // board it reads and writes another board's favourite.
+    expect(recorded.favoriteStatus.at(-1)?.angle).toBe(30);
+
+    act(() => {
+      (recorded.actionBar.at(-1)?.onTickPress as () => void)();
+    });
+
+    expect(recorded.logAscent.at(-1)?.layoutId).toBe(8);
+    expect(recorded.logAscent.at(-1)?.angle).toBe(30);
+  });
+
+  it('still shows the angle pill for the board the climber is standing at', () => {
+    queueState.currentClimbQueueItem = queueItem(HOMEWALL_CLIMB, 'queue-homewall');
+    renderDrawer(vi.fn());
+
+    // The pill changes the SELECTED board's angle — it must not offer to move a
+    // wall the climber is not on.
+    expect(recorded.actionBar.at(-1)?.currentAngle).toBe(TWELVE_BY_TWELVE.angle);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/use-mobile-playback.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-mobile-playback.test.ts
@@ -9,7 +9,7 @@ import type { BoardName, Climb, PlaybackStateChangedEvent } from '@boardsesh/sha
 // latest-wins GATT-safe drain, the climb-change reset, and party-sync wiring.
 
 type EngineInput = {
-  externalState?: { clientId: string | null; frameCount?: number | null } | null;
+  externalState?: { clientId: string | null; frameCount?: number | null; isPlaying?: boolean } | null;
   onLocalStateChange?: (state: {
     frameIndex: number;
     frameCount: number;
@@ -190,6 +190,36 @@ describe('useMobilePlayback — BLE drain', () => {
     await act(async () => {
       mocks.sendCalls[0].resolve(true);
     });
+  });
+
+  // #5099: a climb from another board addresses a DIFFERENT wall's hold ids, so
+  // its frames would light the wrong holds on the connected board. The scrim
+  // hides the play button, but a party peer's playback event starts the engine
+  // with no local tap at all — so the suppression, not the UI, is what has to
+  // hold. Peer-driven, connected, engine playing: still nothing on the wall.
+  it('keeps a peer-driven animation off the wall while writes are suppressed', async () => {
+    const climb = climbWith('c1');
+    const { rerender } = renderPlayback(climb, { suppressWallWrites: true });
+
+    await act(async () => {
+      emitPlayback(playbackEvent({ climbUuid: 'c1', isPlaying: true }));
+    });
+    expect(mocks.lastEngineInput.current?.externalState?.isPlaying).toBe(true);
+
+    // The engine advances on the peer's clock; every frame it produces is a
+    // write candidate.
+    await act(async () => {
+      mocks.playback.isPlaying = true;
+      mocks.playback.currentFrameString = 'F1';
+      rerender({ climb, suppressWallWrites: true });
+    });
+    await act(async () => {
+      mocks.playback.currentFrameString = 'F2';
+      rerender({ climb, suppressWallWrites: true });
+    });
+
+    expect(mocks.bluetooth.isConnected).toBe(true);
+    expect(mocks.bluetooth.sendFramesToBoard).not.toHaveBeenCalled();
   });
 
   it('collapses overlapping frame writes to the latest (GATT-safe)', async () => {

--- a/packages/mobile/src/components/queue-control/AccessoryClimbThumbnail.tsx
+++ b/packages/mobile/src/components/queue-control/AccessoryClimbThumbnail.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { StyleSheet, View, type ViewStyle } from 'react-native';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { getBoardRenderData } from '../../lib/board-details';
+import { resolveClimbRenderBoard } from '../../lib/boards/climb-render-board';
 import { type BoardConfig } from '../../providers/drawer-host-provider';
 import { BoardImageNative } from '../BoardImageNative';
 
@@ -13,6 +14,15 @@ const ACCESSORY_THUMBNAIL_ART_RADIUS = 10;
 type AccessoryThumbnailClimb = {
   frames: string;
   mirrored?: boolean | null;
+  // Board identity, when the caller has it. A climb carried over from another
+  // board (a queue left behind by a board switch, a party peer on another wall)
+  // is drawn on ITS board rather than on placements it has no holds in (#5099).
+  // Presence climbs carry none of this and fall through to the passed board,
+  // which is the wall they were lit on.
+  boardType?: string | null;
+  layoutId?: number | null;
+  angle?: number | null;
+  compatibleSizeIds?: readonly number[] | null;
 };
 
 function getAccessoryThumbnailBoardSize(boardWidth: number, boardHeight: number, maxSize: number) {
@@ -53,22 +63,35 @@ export function AccessoryClimbThumbnail({
   boardConfig: BoardConfig | null;
   size?: number;
 }) {
+  // Keyed on the climb's own fields, not the `climb` object: several callers pass
+  // a fresh literal every render, which would make an object-keyed memo a
+  // guaranteed miss on a bar that re-renders on every queue swipe.
+  const { boardType, layoutId: climbLayoutId, angle: climbAngle, frames, compatibleSizeIds } = climb;
+  const renderBoard = useMemo(
+    () =>
+      resolveClimbRenderBoard(
+        { boardType, layoutId: climbLayoutId, angle: climbAngle, frames, compatibleSizeIds },
+        boardConfig,
+      )?.boardConfig ?? boardConfig,
+    [boardType, climbLayoutId, climbAngle, frames, compatibleSizeIds, boardConfig],
+  );
+
   const boardRenderData = useMemo(() => {
-    if (!boardConfig) return null;
-    const setIdValues = boardConfig.setIds
+    if (!renderBoard) return null;
+    const setIdValues = renderBoard.setIds
       .split(',')
       .map((setIdText) => Number(setIdText))
       .filter((setIdValue) => Number.isFinite(setIdValue));
     if (setIdValues.length === 0) return null;
     return getBoardRenderData({
-      boardName: boardConfig.boardName as BoardName,
-      layoutId: boardConfig.layoutId,
-      sizeId: boardConfig.sizeId,
+      boardName: renderBoard.boardName as BoardName,
+      layoutId: renderBoard.layoutId,
+      sizeId: renderBoard.sizeId,
       setIds: setIdValues,
     });
-  }, [boardConfig]);
+  }, [renderBoard]);
 
-  if (!boardRenderData || !boardConfig) return null;
+  if (!boardRenderData || !renderBoard) return null;
 
   // Fit the board art into the 40×40 slot at its native aspect ratio, then
   // hand BoardImageNative an explicitly-sized, rounded, clipped box. (Its
@@ -86,10 +109,10 @@ export function AccessoryClimbThumbnail({
     <View style={[styles.thumbnailSlot, { width: size, height: size }]}>
       <BoardImageNative
         frames={climb.frames}
-        boardName={boardConfig.boardName as BoardName}
-        layoutId={boardConfig.layoutId}
-        sizeId={boardConfig.sizeId}
-        setIds={boardConfig.setIds}
+        boardName={renderBoard.boardName as BoardName}
+        layoutId={renderBoard.layoutId}
+        sizeId={renderBoard.sizeId}
+        setIds={renderBoard.setIds}
         boardWidth={boardRenderData.boardWidth}
         boardHeight={boardRenderData.boardHeight}
         mirrored={climb.mirrored === true}

--- a/packages/mobile/src/components/queue-control/__tests__/accessory-climb-thumbnail-board.test.tsx
+++ b/packages/mobile/src/components/queue-control/__tests__/accessory-climb-thumbnail-board.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+// #5099 — the accessory bar's little board render is the first thing a climber
+// sees after switching boards: the capsule, the "On the wall" strip and the iPad
+// sidebar cell all go through it. A climb carried over from another board has to
+// be drawn on that board, not on the selected one, where none of its holds exist.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { BoardConfig } from '../../../providers/drawer-host-provider';
+
+type ImageProps = { boardName?: string; layoutId?: number; sizeId?: number; setIds?: string; frames?: string };
+const recorded = vi.hoisted(() => ({ images: [] as ImageProps[] }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+vi.mock('../../BoardImageNative', () => ({
+  BoardImageNative: (props: ImageProps) => {
+    recorded.images.push(props);
+    return createElement('div', { 'data-testid': 'board-image' });
+  },
+}));
+
+// `lib/board-details` stays REAL — the whole point is which board's placements
+// the thumbnail is built from.
+const { AccessoryClimbThumbnail } = await import('../AccessoryClimbThumbnail');
+
+const TWELVE_BY_TWELVE: BoardConfig = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20', angle: 40 };
+
+beforeEach(() => {
+  recorded.images = [];
+});
+
+describe('AccessoryClimbThumbnail board resolution (#5099)', () => {
+  it('draws a Homewall climb on the Homewall while the selected board is the 12x12', () => {
+    render(
+      createElement(AccessoryClimbThumbnail, {
+        climb: { frames: 'p1145r15', boardType: 'kilter', layoutId: 8, angle: 30 },
+        boardConfig: TWELVE_BY_TWELVE,
+      }),
+    );
+
+    expect(recorded.images.at(-1)?.layoutId).toBe(8);
+    expect(recorded.images.at(-1)?.boardName).toBe('kilter');
+  });
+
+  it('keeps a climb from the selected board on the selected board', () => {
+    render(
+      createElement(AccessoryClimbThumbnail, {
+        climb: { frames: 'p1145r15', boardType: 'kilter', layoutId: 1, angle: 40 },
+        boardConfig: TWELVE_BY_TWELVE,
+      }),
+    );
+
+    expect(recorded.images.at(-1)).toMatchObject({
+      boardName: TWELVE_BY_TWELVE.boardName,
+      layoutId: TWELVE_BY_TWELVE.layoutId,
+      sizeId: TWELVE_BY_TWELVE.sizeId,
+      setIds: TWELVE_BY_TWELVE.setIds,
+    });
+  });
+
+  it('uses the passed board for a presence climb, which carries no board of its own', () => {
+    // Board-presence climbs are, by construction, lit on the board the strip is
+    // bound to — they only carry frames.
+    render(
+      createElement(AccessoryClimbThumbnail, {
+        climb: { frames: 'p1145r15' },
+        boardConfig: TWELVE_BY_TWELVE,
+      }),
+    );
+
+    expect(recorded.images.at(-1)).toMatchObject({
+      boardName: TWELVE_BY_TWELVE.boardName,
+      layoutId: TWELVE_BY_TWELVE.layoutId,
+      sizeId: TWELVE_BY_TWELVE.sizeId,
+    });
+  });
+
+  it('renders nothing without a board', () => {
+    const { container } = render(
+      createElement(AccessoryClimbThumbnail, { climb: { frames: 'p1145r15' }, boardConfig: null }),
+    );
+
+    expect(container.querySelector('[data-testid="board-image"]')).toBeNull();
+  });
+});

--- a/packages/mobile/src/lib/boards/__tests__/climb-render-board.test.ts
+++ b/packages/mobile/src/lib/boards/__tests__/climb-render-board.test.ts
@@ -5,7 +5,7 @@
 import { describe, expect, it } from 'vitest';
 import type { BoardConfig } from '../../../providers/drawer-host-provider';
 import { getBoardConfigForPlaylist } from '../../playlists/board-details-for-playlist';
-import { resolveClimbRenderBoard, type ClimbRenderBoardClimb } from '../climb-render-board';
+import { formatRenderBoardLabel, resolveClimbRenderBoard, type ClimbRenderBoardClimb } from '../climb-render-board';
 
 function knownBoard(boardType: string, layoutId: number, angle = 40): BoardConfig {
   const config = getBoardConfigForPlaylist(boardType, layoutId);
@@ -104,6 +104,19 @@ describe('resolveClimbRenderBoard', () => {
     expect(result?.incompatible).toBe(false);
   });
 
+  it('fails open for a climb from another brand that names no layout', () => {
+    // Without a layout the only way to place it is to GUESS one — the brand's
+    // first layout, via `getDefaultRenderBoard`. That guess can land on exactly
+    // the wrong-placement render this resolver exists to prevent, so a missing
+    // layout stays on the active board even when the brand disagrees.
+    const activeBoard = knownBoard('kilter', 1);
+    const result = resolveClimbRenderBoard({ boardType: 'tension', angle: 40, frames: '' }, activeBoard);
+
+    expect(result?.boardConfig).toBe(activeBoard);
+    expect(result?.fit).toBe('exact');
+    expect(result?.incompatible).toBe(false);
+  });
+
   it('fails open for a climb naming a board we cannot build render data for', () => {
     const activeBoard = knownBoard('kilter', 1);
     const result = resolveClimbRenderBoard(
@@ -135,5 +148,24 @@ describe('resolveClimbRenderBoard', () => {
   it('keeps the active board when there is no climb to place', () => {
     const activeBoard = knownBoard('kilter', 1);
     expect(resolveClimbRenderBoard(null, activeBoard)?.boardConfig).toBe(activeBoard);
+  });
+});
+
+describe('formatRenderBoardLabel', () => {
+  it('names the layout when the layout name already carries the brand', () => {
+    // "Kilter" alone cannot tell the #5099 case apart: Homewall and Original are
+    // both Kilter, and the prompt would read "Switch to Kilter" on a Kilter board.
+    expect(formatRenderBoardLabel(knownBoard('kilter', 8))).toBe('Kilter Board Homewall');
+    expect(formatRenderBoardLabel(knownBoard('kilter', 1))).toBe('Kilter Board Original');
+  });
+
+  it('keeps the brand when the layout name would read as a different product', () => {
+    // Tension layout 9 is catalogued as "Original Layout" — on its own that
+    // names no board the climber would recognise.
+    expect(formatRenderBoardLabel(knownBoard('tension', 9))).toBe('Tension');
+  });
+
+  it('falls back to the brand for a board with no catalogued layout name', () => {
+    expect(formatRenderBoardLabel({ ...knownBoard('kilter', 1), layoutId: 9999 })).toBe('Kilter');
   });
 });

--- a/packages/mobile/src/lib/boards/__tests__/climb-render-board.test.ts
+++ b/packages/mobile/src/lib/boards/__tests__/climb-render-board.test.ts
@@ -128,6 +128,46 @@ describe('resolveClimbRenderBoard', () => {
     expect(result?.incompatible).toBe(false);
   });
 
+  // Woods is the one board whose two sizes number their holds from their OWN
+  // origins — the 8x10 runs 0-484, the 12x12 runs 0-893 — so an 8x10 climb's ids
+  // all exist on the 12x12 as completely different holds. Falling back to the
+  // layout default (always the 12x12) would not fail to render; it would quietly
+  // render a different climb. See docs/board-art-geometry.md.
+  it('draws a Woods 8x10 climb on the 8x10, not on the layout default 12x12', () => {
+    const result = resolveClimbRenderBoard(
+      { boardType: 'woods', layoutId: 1, angle: 40, frames: '', compatibleSizeIds: [1] },
+      knownBoard('kilter', 1),
+    );
+
+    expect(result?.boardConfig.boardName).toBe('woods');
+    expect(result?.boardConfig.sizeId).toBe(1);
+    expect(result?.incompatible).toBe(true);
+  });
+
+  it('keeps a Woods 8x10 climb off the 12x12 the climber is standing at', () => {
+    // Same brand and layout, so this is the upsize/size-fit path rather than the
+    // cross-model one — the answer still has to be the size the climb fits.
+    const woods12x12 = { boardName: 'woods', layoutId: 1, sizeId: 2, setIds: '1', angle: 40 };
+    const result = resolveClimbRenderBoard(
+      { boardType: 'woods', layoutId: 1, angle: 40, frames: '', compatibleSizeIds: [1] },
+      woods12x12,
+    );
+
+    expect(result?.boardConfig.sizeId).toBe(1);
+  });
+
+  it('keeps the layout default for a Woods climb that names no sizes', () => {
+    // No compatibility data (a legacy row, or unpopulated columns) imposes no
+    // constraint — today's 12x12 default stands.
+    const result = resolveClimbRenderBoard(
+      { boardType: 'woods', layoutId: 1, angle: 40, frames: '' },
+      knownBoard('kilter', 1),
+    );
+
+    expect(result?.boardConfig.boardName).toBe('woods');
+    expect(result?.boardConfig.sizeId).toBe(2);
+  });
+
   it('resolves the climb own board when there is no active board yet', () => {
     const result = resolveClimbRenderBoard(homewallClimb, null);
 

--- a/packages/mobile/src/lib/boards/__tests__/climb-render-board.test.ts
+++ b/packages/mobile/src/lib/boards/__tests__/climb-render-board.test.ts
@@ -1,0 +1,139 @@
+// #5099: a climb must be drawn on the board it belongs to, not on whatever
+// board the climber happens to have selected. Every case below is a state the
+// app reaches by ordinary use — switching boards mid-session, a party peer on
+// another wall, an older queue item with no board metadata at all.
+import { describe, expect, it } from 'vitest';
+import type { BoardConfig } from '../../../providers/drawer-host-provider';
+import { getBoardConfigForPlaylist } from '../../playlists/board-details-for-playlist';
+import { resolveClimbRenderBoard, type ClimbRenderBoardClimb } from '../climb-render-board';
+
+function knownBoard(boardType: string, layoutId: number, angle = 40): BoardConfig {
+  const config = getBoardConfigForPlaylist(boardType, layoutId);
+  if (!config) throw new Error(`Missing board config for ${boardType}:${layoutId}`);
+  return {
+    boardName: config.boardName,
+    layoutId: config.layoutId,
+    sizeId: config.sizeId,
+    setIds: config.setIds.join(','),
+    angle,
+  };
+}
+
+const homewallClimb: ClimbRenderBoardClimb = { boardType: 'kilter', layoutId: 8, angle: 30, frames: '' };
+
+describe('resolveClimbRenderBoard', () => {
+  it('leaves a climb from the active board on the active board, untouched', () => {
+    const activeBoard = knownBoard('kilter', 1, 45);
+    const result = resolveClimbRenderBoard({ boardType: 'kilter', layoutId: 1, angle: 40, frames: '' }, activeBoard);
+
+    // Identity, not equality: the drawer memoises board-render data on this
+    // object, so a fresh copy would churn the render on every queue update.
+    expect(result?.boardConfig).toBe(activeBoard);
+    expect(result?.fit).toBe('exact');
+    expect(result?.incompatible).toBe(false);
+  });
+
+  it('draws a climb from another board model on its own board, at its own angle', () => {
+    // The #5099 repro: browse the Homewall (layout 8), switch the active board
+    // to the Original 12x12 (layout 1), and the carried-over climb is still a
+    // Homewall climb.
+    const activeBoard = knownBoard('kilter', 1, 45);
+    const result = resolveClimbRenderBoard(homewallClimb, activeBoard);
+
+    expect(result?.boardConfig.boardName).toBe('kilter');
+    expect(result?.boardConfig.layoutId).toBe(8);
+    // The angle the climb was graded at, not the wall the climber walked to.
+    expect(result?.boardConfig.angle).toBe(30);
+    expect(result?.fit).toBe('incompatible');
+    expect(result?.incompatible).toBe(true);
+  });
+
+  it('draws a cross-brand climb on its own board', () => {
+    const result = resolveClimbRenderBoard(
+      { boardType: 'tension', layoutId: 9, angle: 35, frames: '' },
+      knownBoard('kilter', 1),
+    );
+
+    expect(result?.boardConfig.boardName).toBe('tension');
+    expect(result?.boardConfig.layoutId).toBe(9);
+    expect(result?.incompatible).toBe(true);
+  });
+
+  it('upsizes to a larger wall on the same layout when the climb needs one', () => {
+    // Same board model, but `compatibleSizeIds` says the climb was set on a
+    // bigger size — the small wall would silently drop holds.
+    const activeBoard: BoardConfig = { boardName: 'kilter', layoutId: 1, sizeId: 14, setIds: '1,20', angle: 40 };
+    const result = resolveClimbRenderBoard(
+      { boardType: 'kilter', layoutId: 1, angle: 40, frames: '', compatibleSizeIds: [10] },
+      activeBoard,
+    );
+
+    expect(result?.boardConfig.layoutId).toBe(1);
+    expect(result?.boardConfig.sizeId).toBe(10);
+    expect(result?.fit).toBe('upsized');
+    expect(result?.incompatible).toBe(true);
+  });
+
+  it('keeps the active board when the climb fits its size list', () => {
+    const activeBoard: BoardConfig = { boardName: 'kilter', layoutId: 1, sizeId: 14, setIds: '1,20', angle: 40 };
+    const result = resolveClimbRenderBoard(
+      { boardType: 'kilter', layoutId: 1, angle: 40, frames: '', compatibleSizeIds: [10, 14] },
+      activeBoard,
+    );
+
+    expect(result?.boardConfig).toBe(activeBoard);
+    expect(result?.incompatible).toBe(false);
+  });
+
+  it('fails open for a climb that carries no board metadata', () => {
+    // Older queue items and party-synced climbs from before the metadata
+    // round-trip. We cannot judge them; blanking them would be a regression on
+    // surfaces that work today.
+    const activeBoard = knownBoard('kilter', 1);
+    const result = resolveClimbRenderBoard({ angle: 40, frames: 'p1145r15' }, activeBoard);
+
+    expect(result?.boardConfig).toBe(activeBoard);
+    expect(result?.incompatible).toBe(false);
+  });
+
+  it('fails open for a climb that names the active board but no layout', () => {
+    const activeBoard = knownBoard('kilter', 1);
+    const result = resolveClimbRenderBoard({ boardType: 'kilter', angle: 40, frames: '' }, activeBoard);
+
+    expect(result?.boardConfig).toBe(activeBoard);
+    expect(result?.incompatible).toBe(false);
+  });
+
+  it('fails open for a climb naming a board we cannot build render data for', () => {
+    const activeBoard = knownBoard('kilter', 1);
+    const result = resolveClimbRenderBoard(
+      { boardType: 'not-a-board', layoutId: 999, angle: 40, frames: '' },
+      activeBoard,
+    );
+
+    expect(result?.boardConfig).toBe(activeBoard);
+    expect(result?.incompatible).toBe(false);
+  });
+
+  it('resolves the climb own board when there is no active board yet', () => {
+    const result = resolveClimbRenderBoard(homewallClimb, null);
+
+    expect(result?.boardConfig.boardName).toBe('kilter');
+    expect(result?.boardConfig.layoutId).toBe(8);
+    expect(result?.boardConfig.angle).toBe(30);
+    // Nothing to disagree with, so no board-switch prompt.
+    expect(result?.incompatible).toBe(false);
+  });
+
+  it('returns null when there is neither an active board nor a resolvable one', () => {
+    expect(
+      resolveClimbRenderBoard({ boardType: 'not-a-board', layoutId: 999, angle: 40, frames: '' }, null),
+    ).toBeNull();
+    expect(resolveClimbRenderBoard(null, null)).toBeNull();
+  });
+
+  it('keeps the active board when there is no climb to place', () => {
+    const activeBoard = knownBoard('kilter', 1);
+    expect(resolveClimbRenderBoard(null, activeBoard)?.boardConfig).toBe(activeBoard);
+  });
+});

--- a/packages/mobile/src/lib/boards/climb-render-board.ts
+++ b/packages/mobile/src/lib/boards/climb-render-board.ts
@@ -17,7 +17,8 @@
 // The size/hold-containment half of that decision already exists for playlist
 // rows; this module is the named, board-shaped door onto it.
 
-import { classifyClimbBoardCompatibility, toBoardName, type BoardCompatibilityTarget } from '@boardsesh/board-config';
+import { classifyClimbBoardCompatibility, formatBoardDisplayName, toBoardName } from '@boardsesh/board-config';
+import { getLayoutName } from '@boardsesh/board-constants/product-sizes';
 import type { BoardConfig } from '../../providers/drawer-host-provider';
 import {
   getPlaylistRenderBoardTarget,
@@ -54,25 +55,6 @@ export type ClimbRenderBoardClimb = {
   frames?: string | null;
   compatibleSizeIds?: readonly number[] | null;
 };
-
-// `getPlaylistRenderBoardTarget` builds a fresh target object per call, and
-// `canAddClimbToBoard` caches its hold-id Set on that object's IDENTITY — so an
-// uncached call rebuilds a ~1400-entry Set every time, once per queue row per
-// render. Every caller hands us a memoised board config (the drawer host's
-// `activeBoardConfig`, the route's `queueBoard`), so keying on that object hands
-// the same target back and lets the Set cache hit. A WeakMap because the entry
-// should die with the config it describes — no eviction policy to get wrong,
-// and no stale entry outliving a board change.
-const compatibilityTargetsByBoard = new WeakMap<BoardConfig, BoardCompatibilityTarget>();
-
-function getCompatibilityTarget(boardConfig: BoardConfig): BoardCompatibilityTarget {
-  const cached = compatibilityTargetsByBoard.get(boardConfig);
-  if (cached) return cached;
-
-  const target = getPlaylistRenderBoardTarget(boardConfig);
-  compatibilityTargetsByBoard.set(boardConfig, target);
-  return target;
-}
 
 function drawOnActiveBoard(boardConfig: BoardConfig): ClimbRenderBoardResult {
   return { boardConfig, fit: 'exact', incompatible: false };
@@ -119,14 +101,17 @@ export function resolveClimbRenderBoard(
   // No usable board signal on either side: keep today's behaviour and draw the
   // climb on the active board rather than guessing a board for it.
   if (identity === 'unknown') return drawOnActiveBoard(activeBoardConfig);
-  // Same board model, but the climb names no layout — there is nothing left to
-  // check it against, so the active board stands.
-  if (identity === 'compatible' && climb.layoutId == null) return drawOnActiveBoard(activeBoardConfig);
+  // A climb with no layout can only be placed by GUESSING one — the brand's
+  // first layout, via `getDefaultRenderBoard`. That guess can land on exactly
+  // the wrong-placement render this resolver exists to prevent, so a missing
+  // layout always fails open, even when the brand disagrees with the active
+  // board. (With a layout in hand the fallback is the climb's real board.)
+  if (climb.layoutId == null) return drawOnActiveBoard(activeBoardConfig);
 
   const resolved = resolvePlaylistClimbRenderBoard(
     toResolverInput(climb, activeBoardConfig.angle),
     activeBoardConfig,
-    getCompatibilityTarget(activeBoardConfig),
+    getPlaylistRenderBoardTarget(activeBoardConfig),
   );
   // The climb names a board we can't build render data for (an unknown board
   // string, a retired layout). Drawing it on the active board is what happened
@@ -134,6 +119,23 @@ export function resolveClimbRenderBoard(
   if (!resolved) return drawOnActiveBoard(activeBoardConfig);
 
   return { boardConfig: resolved.renderBoard, fit: resolved.fit, incompatible: resolved.incompatible };
+}
+
+/**
+ * How to name a board in the switch-board prompt.
+ *
+ * The brand alone ("Kilter") cannot tell the #5099 case apart — Homewall and
+ * Original are both Kilter — so prefer the layout's own catalogue name when it
+ * already carries the brand ("Kilter Board Homewall"). Layout names that don't
+ * ("Original Layout" on Tension) would read as a different product, so those
+ * keep the brand. No new strings either way: this is the `{{board}}` value the
+ * existing `session.boardMismatch.*` copy interpolates.
+ */
+export function formatRenderBoardLabel(boardConfig: BoardConfig): string {
+  const brand = formatBoardDisplayName(boardConfig.boardName);
+  const boardName = toBoardName(boardConfig.boardName);
+  const layoutName = boardName ? getLayoutName(boardName, boardConfig.layoutId) : '';
+  return layoutName.toLowerCase().includes(brand.toLowerCase()) ? layoutName : brand;
 }
 
 /**

--- a/packages/mobile/src/lib/boards/climb-render-board.ts
+++ b/packages/mobile/src/lib/boards/climb-render-board.ts
@@ -1,0 +1,163 @@
+// Which board a single climb should be DRAWN on.
+//
+// A queue item, a party peer's "spill" climb, or a restored launch snapshot
+// carries its own `boardType` + `layoutId` and can outlive the board it came
+// from: browse the Homewall, switch the active board to the 12x12, and the
+// climb that carries over as `currentClimbQueueItem` still belongs to the
+// Homewall. Drawing it against the 12x12's placements matches none of its hold
+// ids, so the renderer drops every hold and paints a veil over bare board art
+// (#5099).
+//
+// The rule: the active board keeps the climb whenever it can actually render
+// it; otherwise the climb goes back to its OWN board, at its own angle, and the
+// caller is told the two boards disagree so it can offer the switch. A climb
+// with no board metadata is drawn on the active board exactly as before — we
+// can't judge it, and failing closed would blank surfaces that work today.
+//
+// The size/hold-containment half of that decision already exists for playlist
+// rows; this module is the named, board-shaped door onto it.
+
+import { classifyClimbBoardCompatibility, toBoardName, type BoardCompatibilityTarget } from '@boardsesh/board-config';
+import type { BoardConfig } from '../../providers/drawer-host-provider';
+import {
+  getPlaylistRenderBoardTarget,
+  resolvePlaylistClimbRenderBoard,
+  type ClimbRenderBoardInput,
+  type PlaylistClimbRenderBoardFit,
+} from '../playlists/playlist-climb-render-board';
+
+/**
+ * `'exact'` — drawn on the active board.
+ * `'upsized'` — same board model, but the climb needs a bigger size than the
+ *   wall the climber is on.
+ * `'incompatible'` — a different board model entirely; drawn on its own board.
+ */
+export type ClimbRenderBoardFit = PlaylistClimbRenderBoardFit;
+
+export type ClimbRenderBoardResult = {
+  /** The board to draw this climb on. */
+  boardConfig: BoardConfig;
+  fit: ClimbRenderBoardFit;
+  /** The active board can't render this climb — offer the board switch. */
+  incompatible: boolean;
+};
+
+/**
+ * The climb fields this resolver reads. Structural on purpose so the queue
+ * `Climb`, the schema `Climb`, and the thinner board-presence climbs all
+ * satisfy it without a cast.
+ */
+export type ClimbRenderBoardClimb = {
+  boardType?: string | null;
+  layoutId?: number | null;
+  angle?: number | null;
+  frames?: string | null;
+  compatibleSizeIds?: readonly number[] | null;
+};
+
+// `getPlaylistRenderBoardTarget` builds a fresh target object per call, and
+// `canAddClimbToBoard` caches its hold-id Set on that object's identity — so an
+// uncached call rebuilds a ~1400-entry Set every time. Queue rows resolve once
+// per row per render, so key the target by board config and hand the SAME
+// object back; the FIFO cap only bounds memory (a session touches a handful of
+// boards).
+const COMPATIBILITY_TARGET_CACHE_LIMIT = 16;
+const compatibilityTargetCache = new Map<string, BoardCompatibilityTarget>();
+
+function getCompatibilityTarget(boardConfig: BoardConfig): BoardCompatibilityTarget {
+  const cacheKey = `${boardConfig.boardName}-${boardConfig.layoutId}-${boardConfig.sizeId}-${boardConfig.setIds}`;
+  const cached = compatibilityTargetCache.get(cacheKey);
+  if (cached) return cached;
+
+  const target = getPlaylistRenderBoardTarget(boardConfig);
+  if (compatibilityTargetCache.size >= COMPATIBILITY_TARGET_CACHE_LIMIT) {
+    const oldestKey = compatibilityTargetCache.keys().next().value;
+    if (oldestKey !== undefined) compatibilityTargetCache.delete(oldestKey);
+  }
+  compatibilityTargetCache.set(cacheKey, target);
+  return target;
+}
+
+function drawOnActiveBoard(boardConfig: BoardConfig): ClimbRenderBoardResult {
+  return { boardConfig, fit: 'exact', incompatible: false };
+}
+
+function toResolverInput(climb: ClimbRenderBoardClimb, fallbackAngle: number): ClimbRenderBoardInput {
+  return {
+    boardType: climb.boardType ?? undefined,
+    layoutId: climb.layoutId,
+    frames: climb.frames,
+    compatibleSizeIds: climb.compatibleSizeIds,
+    // The angle the climb was graded at — that's the angle its own board should
+    // be drawn at when it falls back off the active one.
+    angle: typeof climb.angle === 'number' ? climb.angle : fallbackAngle,
+  };
+}
+
+/**
+ * Resolve the board a single climb should be rendered on.
+ *
+ * Returns `null` only when there is nothing to draw on at all: no active board
+ * AND no resolvable board of the climb's own.
+ */
+export function resolveClimbRenderBoard(
+  climb: ClimbRenderBoardClimb | null | undefined,
+  activeBoardConfig: BoardConfig | null,
+): ClimbRenderBoardResult | null {
+  if (!climb) return activeBoardConfig ? drawOnActiveBoard(activeBoardConfig) : null;
+
+  if (!activeBoardConfig) {
+    const resolved = resolvePlaylistClimbRenderBoard(toResolverInput(climb, 0), null);
+    if (!resolved) return null;
+    return { boardConfig: resolved.renderBoard, fit: resolved.fit, incompatible: resolved.incompatible };
+  }
+
+  const activeBoardName = toBoardName(activeBoardConfig.boardName);
+  const identity = activeBoardName
+    ? classifyClimbBoardCompatibility(
+        { boardName: activeBoardName, layoutId: activeBoardConfig.layoutId },
+        { boardType: climb.boardType, layoutId: climb.layoutId },
+      )
+    : 'unknown';
+
+  // No usable board signal on either side: keep today's behaviour and draw the
+  // climb on the active board rather than guessing a board for it.
+  if (identity === 'unknown') return drawOnActiveBoard(activeBoardConfig);
+  // Same board model, but the climb names no layout — there is nothing left to
+  // check it against, so the active board stands.
+  if (identity === 'compatible' && climb.layoutId == null) return drawOnActiveBoard(activeBoardConfig);
+
+  const resolved = resolvePlaylistClimbRenderBoard(
+    toResolverInput(climb, activeBoardConfig.angle),
+    activeBoardConfig,
+    getCompatibilityTarget(activeBoardConfig),
+  );
+  // The climb names a board we can't build render data for (an unknown board
+  // string, a retired layout). Drawing it on the active board is what happened
+  // before this resolver existed, and it beats blanking the surface.
+  if (!resolved) return drawOnActiveBoard(activeBoardConfig);
+
+  return { boardConfig: resolved.renderBoard, fit: resolved.fit, incompatible: resolved.incompatible };
+}
+
+/**
+ * Same board ART: name, layout, size and hold sets. Angle is deliberately not
+ * compared — it tilts the picture, it does not change which holds exist. Used
+ * to decide whether a neighbouring climb can be peeked under the board the
+ * drawer is currently drawing.
+ */
+export function sameRenderBoard(left: BoardConfig | null, right: BoardConfig | null): boolean {
+  if (!left || !right) return false;
+  if (left === right) return true;
+  return (
+    left.boardName === right.boardName &&
+    left.layoutId === right.layoutId &&
+    left.sizeId === right.sizeId &&
+    left.setIds === right.setIds
+  );
+}
+
+/** Test seam: the target cache is keyed on static board data in production. */
+export function clearClimbRenderBoardCache(): void {
+  compatibilityTargetCache.clear();
+}

--- a/packages/mobile/src/lib/boards/climb-render-board.ts
+++ b/packages/mobile/src/lib/boards/climb-render-board.ts
@@ -56,25 +56,21 @@ export type ClimbRenderBoardClimb = {
 };
 
 // `getPlaylistRenderBoardTarget` builds a fresh target object per call, and
-// `canAddClimbToBoard` caches its hold-id Set on that object's identity — so an
-// uncached call rebuilds a ~1400-entry Set every time. Queue rows resolve once
-// per row per render, so key the target by board config and hand the SAME
-// object back; the FIFO cap only bounds memory (a session touches a handful of
-// boards).
-const COMPATIBILITY_TARGET_CACHE_LIMIT = 16;
-const compatibilityTargetCache = new Map<string, BoardCompatibilityTarget>();
+// `canAddClimbToBoard` caches its hold-id Set on that object's IDENTITY — so an
+// uncached call rebuilds a ~1400-entry Set every time, once per queue row per
+// render. Every caller hands us a memoised board config (the drawer host's
+// `activeBoardConfig`, the route's `queueBoard`), so keying on that object hands
+// the same target back and lets the Set cache hit. A WeakMap because the entry
+// should die with the config it describes — no eviction policy to get wrong,
+// and no stale entry outliving a board change.
+const compatibilityTargetsByBoard = new WeakMap<BoardConfig, BoardCompatibilityTarget>();
 
 function getCompatibilityTarget(boardConfig: BoardConfig): BoardCompatibilityTarget {
-  const cacheKey = `${boardConfig.boardName}-${boardConfig.layoutId}-${boardConfig.sizeId}-${boardConfig.setIds}`;
-  const cached = compatibilityTargetCache.get(cacheKey);
+  const cached = compatibilityTargetsByBoard.get(boardConfig);
   if (cached) return cached;
 
   const target = getPlaylistRenderBoardTarget(boardConfig);
-  if (compatibilityTargetCache.size >= COMPATIBILITY_TARGET_CACHE_LIMIT) {
-    const oldestKey = compatibilityTargetCache.keys().next().value;
-    if (oldestKey !== undefined) compatibilityTargetCache.delete(oldestKey);
-  }
-  compatibilityTargetCache.set(cacheKey, target);
+  compatibilityTargetsByBoard.set(boardConfig, target);
   return target;
 }
 
@@ -155,9 +151,4 @@ export function sameRenderBoard(left: BoardConfig | null, right: BoardConfig | n
     left.sizeId === right.sizeId &&
     left.setIds === right.setIds
   );
-}
-
-/** Test seam: the target cache is keyed on static board data in production. */
-export function clearClimbRenderBoardCache(): void {
-  compatibilityTargetCache.clear();
 }

--- a/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
+++ b/packages/mobile/src/lib/live-activity/__tests__/live-activity-bridge.test.tsx
@@ -417,3 +417,41 @@ describe('LiveActivityBridge session-presence gating', () => {
     );
   });
 });
+
+// #5099 — the Android foreground-service notification renders its thumbnail from
+// the queue head, which can belong to another board (a climb carried over from a
+// board switch, or a party peer's). Rendered against the selected board's
+// placements it matches no holds and comes out as bare board art.
+describe('LiveActivityBridge notification thumbnail board', () => {
+  function boardClimbItem(boardType: string, layoutId: number): ClimbQueueItem {
+    return {
+      uuid: 'queue-cross-board',
+      climb: { uuid: 'climb-cross-board', frames: 'p1145r15', boardType, layoutId, angle: 30 },
+    } as unknown as ClimbQueueItem;
+  }
+
+  beforeEach(() => {
+    queue.sessionId = 'session-1';
+    climbRender.useNativeClimbRender.mockClear();
+  });
+
+  it('renders a Homewall queue head on the Homewall, not on the selected 12x12', () => {
+    const item = boardClimbItem('kilter', 8);
+    queue.state = { queue: [item], currentClimbQueueItem: item };
+    renderBridge();
+
+    expect(climbRender.useNativeClimbRender).toHaveBeenCalledWith(
+      expect.objectContaining({ boardName: 'kilter', layoutId: 8 }),
+    );
+  });
+
+  it('keeps the selected board for a climb that carries no board of its own', () => {
+    const item = makeItem(0);
+    queue.state = { queue: [item], currentClimbQueueItem: item };
+    renderBridge();
+
+    expect(climbRender.useNativeClimbRender).toHaveBeenCalledWith(
+      expect.objectContaining({ boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' }),
+    );
+  });
+});

--- a/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
+++ b/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getBoardCapabilities, toBoardName } from '@boardsesh/board-config';
+import { resolveClimbRenderBoard } from '../boards/climb-render-board';
 import { useQueue } from '../../providers/queue-provider';
 import { useBoardConnectionState } from '../../components/ble/use-board-connection-state';
 import { useNativeClimbRender } from '../../hooks/use-native-climb-render';
@@ -44,12 +45,23 @@ export function LiveActivityBridge({ boardName, layoutId, sizeId, setIds }: Live
   // frames — useNativeClimbRender then no-ops its render effect instead of doing
   // work iOS discards.
   const displayClimb = state.currentClimbQueueItem?.climb ?? state.queue[0]?.climb ?? null;
+  // The queue head can belong to another board — a climb carried over from a
+  // board switch, or a party peer's. Rendered against the selected board's
+  // placements it matches no holds and the notification thumbnail comes out as
+  // bare board art (#5099), so draw it on its own board. A climb with no board
+  // metadata falls through to the selected board, as before.
+  // The angle only tilts the picture, never which holds exist, so the selected
+  // board's angle stands in for a config this component is not handed.
+  const notificationBoard = useMemo(
+    () => resolveClimbRenderBoard(displayClimb, { boardName, layoutId, sizeId, setIds, angle: 0 })?.boardConfig,
+    [displayClimb, boardName, layoutId, sizeId, setIds],
+  );
   const { overlayUri, overlayLoadKey, verifyOverlayForNativeUse, backgroundPaths } = useNativeClimbRender({
     frames: isAndroidSessionPresence ? (displayClimb?.frames ?? '') : '',
-    boardName: toBoardName(boardName) ?? 'kilter',
-    layoutId,
-    sizeId,
-    setIds,
+    boardName: toBoardName(notificationBoard?.boardName ?? boardName) ?? 'kilter',
+    layoutId: notificationBoard?.layoutId ?? layoutId,
+    sizeId: notificationBoard?.sizeId ?? sizeId,
+    setIds: notificationBoard?.setIds ?? setIds,
     // Filled markers read as solid lit dots once scaled into the small notification
     // thumbnail; 384px gives the ~88dp expanded image enough resolution while the
     // service caps the composited bitmap so the RemoteViews stays under the Binder

--- a/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
+++ b/packages/mobile/src/lib/live-activity/live-activity-bridge.tsx
@@ -45,16 +45,23 @@ export function LiveActivityBridge({ boardName, layoutId, sizeId, setIds }: Live
   // frames — useNativeClimbRender then no-ops its render effect instead of doing
   // work iOS discards.
   const displayClimb = state.currentClimbQueueItem?.climb ?? state.queue[0]?.climb ?? null;
+  // The selected board as a config, memoised on its primitives. Its own identity
+  // is what keys the resolver's compatibility-target memo, so a literal built
+  // inline would miss that cache on every render. The angle only tilts the
+  // picture, never which holds exist, so 0 stands in for an angle this component
+  // is not handed.
+  const selectedBoardConfig = useMemo(
+    () => ({ boardName, layoutId, sizeId, setIds, angle: 0 }),
+    [boardName, layoutId, sizeId, setIds],
+  );
   // The queue head can belong to another board — a climb carried over from a
   // board switch, or a party peer's. Rendered against the selected board's
   // placements it matches no holds and the notification thumbnail comes out as
   // bare board art (#5099), so draw it on its own board. A climb with no board
   // metadata falls through to the selected board, as before.
-  // The angle only tilts the picture, never which holds exist, so the selected
-  // board's angle stands in for a config this component is not handed.
   const notificationBoard = useMemo(
-    () => resolveClimbRenderBoard(displayClimb, { boardName, layoutId, sizeId, setIds, angle: 0 })?.boardConfig,
-    [displayClimb, boardName, layoutId, sizeId, setIds],
+    () => resolveClimbRenderBoard(displayClimb, selectedBoardConfig)?.boardConfig,
+    [displayClimb, selectedBoardConfig],
   );
   const { overlayUri, overlayLoadKey, verifyOverlayForNativeUse, backgroundPaths } = useNativeClimbRender({
     frames: isAndroidSessionPresence ? (displayClimb?.frames ?? '') : '',

--- a/packages/mobile/src/lib/playlists/__tests__/playlist-climb-render-board.test.ts
+++ b/packages/mobile/src/lib/playlists/__tests__/playlist-climb-render-board.test.ts
@@ -38,6 +38,29 @@ function getKnownBoard(boardType: string, layoutId: number, angle = 40): Playlis
   };
 }
 
+describe('getPlaylistRenderBoardTarget', () => {
+  it('hands the same target object back for the same board', () => {
+    // `canAddClimbToBoard` caches its ~1400-entry valid-hold-id Set on the
+    // target's IDENTITY. A fresh target per call rebuilds that Set once per
+    // queue row AND once per candidate size inside the upsize search, so the
+    // memo is what keeps a mixed queue sheet off an O(rows x holds) rebuild.
+    const board = getKnownBoard('kilter', 1);
+    const first = getPlaylistRenderBoardTarget(board);
+    const second = getPlaylistRenderBoardTarget({ ...board, angle: board.angle + 5 });
+
+    // Same name/layout/size/sets — the angle never changes which holds exist.
+    expect(second).toBe(first);
+  });
+
+  it('builds a separate target for a different board', () => {
+    const original = getPlaylistRenderBoardTarget(getKnownBoard('kilter', 1));
+    const homewall = getPlaylistRenderBoardTarget(getKnownBoard('kilter', 8));
+
+    expect(homewall).not.toBe(original);
+    expect(homewall.layout_id).toBe(8);
+  });
+});
+
 describe('resolvePlaylistClimbRenderBoard', () => {
   it('uses the active board when the climb is compatible with it', () => {
     const activeBoard = getKnownBoard('kilter', 1, 45);

--- a/packages/mobile/src/lib/playlists/board-details-for-playlist.ts
+++ b/packages/mobile/src/lib/playlists/board-details-for-playlist.ts
@@ -1,5 +1,10 @@
 import type { BoardName } from '@boardsesh/shared-schema';
-import { getDefaultRenderBoard, toBoardName, type RenderBoardConfig } from '@boardsesh/board-config';
+import {
+  getDefaultRenderBoard,
+  resolveRenderBoard,
+  toBoardName,
+  type RenderBoardConfig,
+} from '@boardsesh/board-config';
 
 export type PlaylistBoardConfig = {
   boardName: BoardName;
@@ -49,6 +54,36 @@ export function getBoardConfigForPlaylist(
   }
   boardConfigCache.set(cacheKey, result);
   return result;
+}
+
+/**
+ * The board config to draw a specific CLIMB on its own board — the same rung-4
+ * fallback as `getBoardConfigForPlaylist`, except the climb's own
+ * `compatibleSizeIds` picks the size.
+ *
+ * That distinction only matters where a board's sizes have independent hold
+ * coordinate spaces. Woods numbers the 8x10's holds 0-484 and the 12x12's 0-893
+ * each from its own origin, so an 8x10 climb's ids all exist on the 12x12 as
+ * COMPLETELY DIFFERENT holds: the layout default (always the 12x12) doesn't fail
+ * to render, it silently renders a different climb. `resolveRenderBoard` has the
+ * per-board rules for this; with no tick board and no owner boards it degrades to
+ * exactly `getDefaultRenderBoard` whenever the climb names no sizes, so a climb
+ * without `compatibleSizeIds` keeps today's answer.
+ *
+ * See `docs/board-art-geometry.md` for the coordinate contract.
+ */
+export function getBoardConfigForClimb(
+  boardType: string,
+  layoutId: number | null | undefined,
+  compatibleSizeIds: readonly number[] | null | undefined,
+): PlaylistBoardConfig | null {
+  const boardName = toBoardName(boardType);
+  if (!boardName) return null;
+  // Cheap to compute (no per-hold work) and called once per resolve rather than
+  // once per row, so this deliberately skips the memo above: keying a cache on a
+  // size LIST is more bookkeeping than the reduce it would save.
+  const resolved = resolveRenderBoard({ boardType, climbLayoutId: layoutId, compatibleSizeIds });
+  return resolved ? { boardName, ...resolved } : null;
 }
 
 /**

--- a/packages/mobile/src/lib/playlists/playlist-climb-render-board.ts
+++ b/packages/mobile/src/lib/playlists/playlist-climb-render-board.ts
@@ -1,12 +1,24 @@
 import type { BoardName } from '@boardsesh/shared-schema';
-import type { Climb } from '@boardsesh/queue';
-import { canAddClimbToBoard, type BoardCompatibilityTarget } from '@boardsesh/board-config';
+import {
+  canAddClimbToBoard,
+  type BoardCompatibilityTarget,
+  type ClimbCompatibilityInput,
+} from '@boardsesh/board-config';
 import { getProductSize, getSetsForLayoutAndSize, getSizesForLayoutId } from '@boardsesh/board-constants/product-sizes';
 import { getBoardRenderData } from '../board-details';
 import { getBoardConfigForPlaylist } from './board-details-for-playlist';
 import type { PlaylistRenderBoard } from './use-playlist-render-board';
 
 export type PlaylistClimbRenderBoardFit = 'exact' | 'upsized' | 'incompatible';
+
+/**
+ * The climb fields this resolver reads: board identity + the frames/sizes the
+ * fit check needs, plus the angle the fallback board is drawn at. Structural
+ * rather than the queue `Climb` so queue items, schema climbs and the thinner
+ * board-presence climbs all satisfy it without a cast (see
+ * `lib/boards/climb-render-board`, which is the board-shaped door onto this).
+ */
+export type ClimbRenderBoardInput = ClimbCompatibilityInput & { angle: number };
 
 export type PlaylistClimbRenderBoardResult = {
   renderBoard: PlaylistRenderBoard;
@@ -59,7 +71,10 @@ export function getPlaylistRenderBoardTarget(renderBoard: PlaylistRenderBoard): 
   };
 }
 
-function resolveGenericRenderBoard(climb: Climb, fallbackBoardName?: BoardName): PlaylistClimbRenderBoardResult | null {
+function resolveGenericRenderBoard(
+  climb: ClimbRenderBoardInput,
+  fallbackBoardName?: BoardName,
+): PlaylistClimbRenderBoardResult | null {
   const boardType = climb.boardType ?? fallbackBoardName;
   if (!boardType) return null;
   const resolved = getBoardConfigForPlaylist(boardType, climb.layoutId);
@@ -72,7 +87,7 @@ function resolveGenericRenderBoard(climb: Climb, fallbackBoardName?: BoardName):
 }
 
 function resolveIncompatibleRenderBoard(
-  climb: Climb,
+  climb: ClimbRenderBoardInput,
   fallbackBoardName: BoardName,
 ): PlaylistClimbRenderBoardResult | null {
   const resolved = getBoardConfigForPlaylist(climb.boardType ?? fallbackBoardName, climb.layoutId);
@@ -85,7 +100,7 @@ function resolveIncompatibleRenderBoard(
 }
 
 function resolveUpsizedRenderBoard(
-  climb: Climb,
+  climb: ClimbRenderBoardInput,
   activeBoard: PlaylistRenderBoard,
 ): PlaylistClimbRenderBoardResult | null {
   const boardName = activeBoard.boardName as BoardName;
@@ -141,7 +156,7 @@ function resolveUpsizedRenderBoard(
  * dimmed while still opening the drawer.
  */
 export function resolvePlaylistClimbRenderBoard(
-  climb: Climb,
+  climb: ClimbRenderBoardInput,
   activeBoard: PlaylistRenderBoard | null,
   activeBoardTarget?: BoardCompatibilityTarget,
 ): PlaylistClimbRenderBoardResult | null {

--- a/packages/mobile/src/lib/playlists/playlist-climb-render-board.ts
+++ b/packages/mobile/src/lib/playlists/playlist-climb-render-board.ts
@@ -43,7 +43,30 @@ function toRenderBoard(boardName: BoardName, layoutId: number, sizeId: number, s
   };
 }
 
+// `canAddClimbToBoard` caches its ~1400-entry valid-hold-id Set on the target
+// object's IDENTITY, so a fresh target per call rebuilds that Set every time —
+// once per queue row, and once per candidate size inside the upsize search. The
+// board data behind a `name-layout-size-sets` key is static, so hand the same
+// target back for the same key. The FIFO cap only bounds memory; a session
+// touches a handful of boards. Mirrors `getBoardRenderData`'s memo.
+const RENDER_BOARD_TARGET_CACHE_LIMIT = 32;
+const renderBoardTargetCache = new Map<string, BoardCompatibilityTarget>();
+
 export function getPlaylistRenderBoardTarget(renderBoard: PlaylistRenderBoard): BoardCompatibilityTarget {
+  const cacheKey = `${renderBoard.boardName}-${renderBoard.layoutId}-${renderBoard.sizeId}-${renderBoard.setIds}`;
+  const cached = renderBoardTargetCache.get(cacheKey);
+  if (cached) return cached;
+
+  const target = buildPlaylistRenderBoardTarget(renderBoard);
+  if (renderBoardTargetCache.size >= RENDER_BOARD_TARGET_CACHE_LIMIT) {
+    const oldestKey = renderBoardTargetCache.keys().next().value;
+    if (oldestKey !== undefined) renderBoardTargetCache.delete(oldestKey);
+  }
+  renderBoardTargetCache.set(cacheKey, target);
+  return target;
+}
+
+function buildPlaylistRenderBoardTarget(renderBoard: PlaylistRenderBoard): BoardCompatibilityTarget {
   const boardName = renderBoard.boardName as BoardName;
   const setIds = parseSetIds(renderBoard.setIds);
   const renderData = getBoardRenderData({

--- a/packages/mobile/src/lib/playlists/playlist-climb-render-board.ts
+++ b/packages/mobile/src/lib/playlists/playlist-climb-render-board.ts
@@ -6,7 +6,7 @@ import {
 } from '@boardsesh/board-config';
 import { getProductSize, getSetsForLayoutAndSize, getSizesForLayoutId } from '@boardsesh/board-constants/product-sizes';
 import { getBoardRenderData } from '../board-details';
-import { getBoardConfigForPlaylist } from './board-details-for-playlist';
+import { getBoardConfigForClimb } from './board-details-for-playlist';
 import type { PlaylistRenderBoard } from './use-playlist-render-board';
 
 export type PlaylistClimbRenderBoardFit = 'exact' | 'upsized' | 'incompatible';
@@ -100,7 +100,7 @@ function resolveGenericRenderBoard(
 ): PlaylistClimbRenderBoardResult | null {
   const boardType = climb.boardType ?? fallbackBoardName;
   if (!boardType) return null;
-  const resolved = getBoardConfigForPlaylist(boardType, climb.layoutId);
+  const resolved = getBoardConfigForClimb(boardType, climb.layoutId, climb.compatibleSizeIds);
   if (!resolved) return null;
   return {
     renderBoard: toRenderBoard(resolved.boardName, resolved.layoutId, resolved.sizeId, resolved.setIds, climb.angle),
@@ -113,7 +113,11 @@ function resolveIncompatibleRenderBoard(
   climb: ClimbRenderBoardInput,
   fallbackBoardName: BoardName,
 ): PlaylistClimbRenderBoardResult | null {
-  const resolved = getBoardConfigForPlaylist(climb.boardType ?? fallbackBoardName, climb.layoutId);
+  const resolved = getBoardConfigForClimb(
+    climb.boardType ?? fallbackBoardName,
+    climb.layoutId,
+    climb.compatibleSizeIds,
+  );
   if (!resolved) return null;
   return {
     renderBoard: toRenderBoard(resolved.boardName, resolved.layoutId, resolved.sizeId, resolved.setIds, climb.angle),

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -1041,6 +1041,62 @@ describe('DrawerHostProvider switch board keeps the climb angle', () => {
     expect(routerPush).toHaveBeenCalledWith(expect.objectContaining({ pathname: '/boards' }));
   });
 
+  // An override is pinned once, at open time; the drawer can then be swiped onto
+  // a climb from a THIRD board. The overlay names the shown climb's board, so
+  // reading the stale override would switch to a board the prompt never named.
+  it('prefers the shown climb board over a stale opener override', async () => {
+    const ownedThirdBoard: UserBoard = {
+      ...activeBoard.defaultStored,
+      uuid: 'board-kilter-homewall',
+      slug: 'board-kilter-homewall',
+      name: 'Kilter Homewall',
+      boardType: 'kilter',
+      layoutId: 8,
+      sizeId: 17,
+      setIds: '1,20',
+      angle: 30,
+      isAngleAdjustable: true,
+    };
+    myBoards.boards = [ownedAdjustable, ownedThirdBoard];
+
+    const hosts: Array<HostValue> = [];
+    const routes: Array<RouteValue> = [];
+    renderHost(
+      (host) => hosts.push(host),
+      (route) => routes.push(route),
+    );
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    // Opened with an override for board A (Tension layout 8).
+    const overrideBoardA: BoardConfig = {
+      boardName: 'tension',
+      layoutId: 8,
+      sizeId: 7,
+      setIds: '5,6',
+      angle: 55,
+    };
+    const climb = makeQueueItem('queue-x', 'climb-third-board').climb as unknown as Climb;
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(climb, { boardConfig: overrideBoardA });
+    });
+    await waitFor(() => expect(routes.at(-1)?.activeBoardConfig).toMatchObject(overrideBoardA));
+
+    // Swiped onto a climb from board B (Kilter Homewall); the drawer resolves and
+    // names THAT board, so that is the board the switch must land on.
+    act(() => {
+      routes.at(-1)?.onSwitchBoard({
+        boardName: 'kilter',
+        layoutId: 8,
+        sizeId: 17,
+        setIds: '1,20',
+        angle: 30,
+      });
+    });
+
+    expect(activeBoard.setActiveBoard).toHaveBeenCalledWith(expect.objectContaining({ uuid: 'board-kilter-homewall' }));
+    expect(activeBoard.setActiveBoard).not.toHaveBeenCalledWith(expect.objectContaining({ uuid: 'board-tension' }));
+  });
+
   it('does nothing when neither an override nor a climb board is offered', async () => {
     myBoards.boards = [ownedAdjustable];
     const routes: Array<RouteValue> = [];

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -973,6 +973,62 @@ describe('DrawerHostProvider switch board keeps the climb angle', () => {
     );
   });
 
+  // #5099: the drawer can discover the mismatch from the climb it is SHOWING —
+  // a queue item carried over from a board switch — with nobody having set an
+  // override. It then hands the board it resolved to this handler; without that
+  // the handler reads its empty override, returns early, and the only button on
+  // the switch-board scrim does nothing.
+  it('switches to the board the drawer resolved for the climb when no override is set', async () => {
+    myBoards.boards = [ownedAdjustable];
+    const hosts: Array<HostValue> = [];
+    const routes: Array<RouteValue> = [];
+    renderHost(
+      (host) => hosts.push(host),
+      (route) => routes.push(route),
+    );
+    await waitFor(() => expect(hosts.at(-1)).toBeDefined());
+
+    const climb = makeQueueItem('queue-x', 'climb-switch-no-override').climb as unknown as Climb;
+    act(() => {
+      hosts.at(-1)?.openPlayDrawer(climb, { committedExternally: true });
+    });
+    await waitFor(() => expect(routes.at(-1)?.playTarget?.climb).toBe(climb));
+    // No override was set by the open, so the gate below is climb-driven only.
+    expect(routes.at(-1)?.boardMismatch).toBe(false);
+
+    const climbBoard: BoardConfig = {
+      boardName: 'tension',
+      layoutId: 8,
+      sizeId: 7,
+      setIds: '5,6',
+      angle: 55,
+    };
+    act(() => {
+      routes.at(-1)?.onSwitchBoard(climbBoard);
+    });
+
+    expect(activeBoard.setActiveBoard).toHaveBeenCalledWith(
+      expect.objectContaining({ uuid: 'board-tension', angle: 55 }),
+    );
+  });
+
+  it('does nothing when neither an override nor a climb board is offered', async () => {
+    myBoards.boards = [ownedAdjustable];
+    const routes: Array<RouteValue> = [];
+    renderHost(
+      () => {},
+      (route) => routes.push(route),
+    );
+    await waitFor(() => expect(routes.at(-1)).toBeDefined());
+
+    act(() => {
+      routes.at(-1)?.onSwitchBoard();
+    });
+
+    expect(activeBoard.setActiveBoard).not.toHaveBeenCalled();
+    expect(routerPush).not.toHaveBeenCalled();
+  });
+
   it('routes to the board picker when the user owns no board matching the climb override', async () => {
     // Owned board is a genuinely different model (board name + layout) than the
     // climb's override, so boardLooselyMatches finds nothing to switch to.

--- a/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/drawer-host-provider.test.tsx
@@ -1012,6 +1012,35 @@ describe('DrawerHostProvider switch board keeps the climb angle', () => {
     );
   });
 
+  // `boardLooselyMatches` only compares name + layout, so the board it "finds"
+  // can be the one the climber is already standing at (a same-layout, bigger-size
+  // climb). Setting it active changes nothing, the prompt that sent them here
+  // never clears, and the scrim's only button is dead.
+  it('routes to the picker rather than re-selecting the board already active', async () => {
+    myBoards.boards = [{ ...activeBoard.defaultStored }];
+    const routes: Array<RouteValue> = [];
+    renderHost(
+      () => {},
+      (route) => routes.push(route),
+    );
+    await waitFor(() => expect(routes.at(-1)).toBeDefined());
+
+    const stored = activeBoard.defaultStored;
+    act(() => {
+      routes.at(-1)?.onSwitchBoard({
+        boardName: stored.boardType,
+        layoutId: stored.layoutId,
+        sizeId: stored.sizeId,
+        setIds: stored.setIds,
+        angle: stored.angle,
+      });
+    });
+
+    expect(activeBoard.setActiveBoard).not.toHaveBeenCalled();
+    expect(routerDismiss).toHaveBeenCalledTimes(1);
+    expect(routerPush).toHaveBeenCalledWith(expect.objectContaining({ pathname: '/boards' }));
+  });
+
   it('does nothing when neither an override nor a climb board is offered', async () => {
     myBoards.boards = [ownedAdjustable];
     const routes: Array<RouteValue> = [];

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -132,7 +132,7 @@ export type PlayDrawerPaneProps = {
   onOpenQueue: () => void;
   boardMismatch: boolean;
   mismatchBoardLabel: string | undefined;
-  onSwitchBoard: () => void;
+  onSwitchBoard: (climbBoardConfig?: BoardConfig) => void;
   onOpenClimbActions: (climb: Climb, boardConfigOverride?: BoardConfig, options?: OpenClimbActionsOptions) => void;
   /** The climb to show in the pane, with a bumped nonce per selection so the pane
    *  re-applies even when the same climb is re-tapped. Set by `openPlayDrawer` on
@@ -247,7 +247,7 @@ type PlayDrawerRouteValue = {
   boardMismatch: boolean;
   mismatchBoardLabel?: string;
   onAngleChange: (angle: number) => void;
-  onSwitchBoard: () => void;
+  onSwitchBoard: (climbBoardConfig?: BoardConfig) => void;
   /** Run from the route's unmount cleanup: clears the board override + open
    *  target so the next open starts clean. */
   onPlayDrawerClosed: () => void;
@@ -638,27 +638,33 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   // the user already owns the climb's board (set it active and clear the override
   // so the drawer shows the now-active board and the overlay clears); otherwise
   // route to the board picker, mirroring the playlist mismatch banner.
-  const handleSwitchBoardFromDrawer = useCallback(() => {
-    const override = boardConfigOverrideRef.current;
-    if (!override) return;
-    const owned = myBoardsRef.current?.boards.find((board) =>
-      boardLooselyMatches({ boardName: board.boardType, layoutId: board.layoutId }, override),
-    );
-    if (owned) {
-      // boardLooselyMatches ignores angle, so `owned`'s stored angle can differ
-      // from the climb's override angle. Switch to the board CARRYING the override
-      // angle so the climb keeps rendering at the same angle and the now-enabled
-      // queue/tick/favorite/LED controls act on it — unless the board's angle is
-      // fixed, in which case its own angle stands.
-      const switchedBoard = owned.isAngleAdjustable === false ? owned : { ...owned, angle: override.angle };
-      void setActiveBoard(switchedBoard);
-      setBoardConfigOverride(null);
-      return;
-    }
-    // Dismiss the player route, then route to the board picker.
-    router.dismiss();
-    router.push({ pathname: '/boards', params: { returnTo: '/(tabs)/home' } });
-  }, [setActiveBoard]);
+  const handleSwitchBoardFromDrawer = useCallback(
+    (climbBoardConfig?: BoardConfig) => {
+      // The opener's override when there is one; otherwise the board the drawer
+      // resolved for the climb it is showing (#5099 — a carried-over queue item
+      // raises the gate without anybody having set an override).
+      const override = boardConfigOverrideRef.current ?? climbBoardConfig;
+      if (!override) return;
+      const owned = myBoardsRef.current?.boards.find((board) =>
+        boardLooselyMatches({ boardName: board.boardType, layoutId: board.layoutId }, override),
+      );
+      if (owned) {
+        // boardLooselyMatches ignores angle, so `owned`'s stored angle can differ
+        // from the climb's override angle. Switch to the board CARRYING the override
+        // angle so the climb keeps rendering at the same angle and the now-enabled
+        // queue/tick/favorite/LED controls act on it — unless the board's angle is
+        // fixed, in which case its own angle stands.
+        const switchedBoard = owned.isAngleAdjustable === false ? owned : { ...owned, angle: override.angle };
+        void setActiveBoard(switchedBoard);
+        setBoardConfigOverride(null);
+        return;
+      }
+      // Dismiss the player route, then route to the board picker.
+      router.dismiss();
+      router.push({ pathname: '/boards', params: { returnTo: '/(tabs)/home' } });
+    },
+    [setActiveBoard],
+  );
 
   // The switch-board gate fires only when the drawer is showing a climb from a
   // genuinely DIFFERENT board model (board name + layout) than the user's stored

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -655,9 +655,22 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
         // queue/tick/favorite/LED controls act on it — unless the board's angle is
         // fixed, in which case its own angle stands.
         const switchedBoard = owned.isAngleAdjustable === false ? owned : { ...owned, angle: override.angle };
-        void setActiveBoard(switchedBoard);
-        setBoardConfigOverride(null);
-        return;
+        const switchedConfig: BoardConfig = {
+          boardName: switchedBoard.boardType,
+          layoutId: switchedBoard.layoutId,
+          sizeId: switchedBoard.sizeId,
+          setIds: switchedBoard.setIds,
+          angle: switchedBoard.angle,
+        };
+        // `boardLooselyMatches` only compares name + layout, so the "owned" board
+        // it found can BE the board the climber is already on. Setting it active
+        // changes nothing and the prompt that sent them here never clears, so
+        // hand them the picker instead of a button that does nothing (#5099).
+        if (!boardConfigsMatch(switchedConfig, storedActiveBoardConfigRef.current)) {
+          void setActiveBoard(switchedBoard);
+          setBoardConfigOverride(null);
+          return;
+        }
       }
       // Dismiss the player route, then route to the board picker.
       router.dismiss();

--- a/packages/mobile/src/providers/drawer-host-provider.tsx
+++ b/packages/mobile/src/providers/drawer-host-provider.tsx
@@ -640,10 +640,13 @@ export function DrawerHostProvider({ children }: { children: ReactNode }) {
   // route to the board picker, mirroring the playlist mismatch banner.
   const handleSwitchBoardFromDrawer = useCallback(
     (climbBoardConfig?: BoardConfig) => {
-      // The opener's override when there is one; otherwise the board the drawer
-      // resolved for the climb it is showing (#5099 — a carried-over queue item
-      // raises the gate without anybody having set an override).
-      const override = boardConfigOverrideRef.current ?? climbBoardConfig;
+      // The board the drawer resolved for the climb it is SHOWING wins; the
+      // opener's override is only the fallback. An override is pinned once, at
+      // open time, but the drawer can then be swiped onto a climb from a third
+      // board — and it is the shown climb that the overlay names, so switching
+      // to the opener's board would send the climber somewhere the prompt never
+      // mentioned (#5099).
+      const override = climbBoardConfig ?? boardConfigOverrideRef.current;
       if (!override) return;
       const owned = myBoardsRef.current?.boards.find((board) =>
         boardLooselyMatches({ boardName: board.boardType, layoutId: board.layoutId }, override),


### PR DESCRIPTION
## Summary

Fixes #5099.

Browse the Kilter Homewall, switch the active board to the Original 12x12, and the climb that carries over as `currentClimbQueueItem` was still drawn under the 12x12's hold placements. None of its hold ids exist there, so the renderer dropped every hold, returned `Ok`, and painted a veil over bare board art — nothing threw, nothing was logged. #5098 made that state visible (`Board Render Failed / no_matching_holds`); this is the cause.

A new resolver, `resolveClimbRenderBoard(climb, activeBoardConfig)` (`packages/mobile/src/lib/boards/climb-render-board.ts`), answers one question: which board should this climb be drawn on?

- Compatible with the active board (same model, and the wall's size is in `compatibleSizeIds` when the climb names them) → the active board config, unchanged (same object identity, so nothing downstream churns).
- Same model but the climb needs a bigger wall (or a MoonBoard set this wall hasn't got) → the smallest larger size on that layout, `fit: 'upsized'`. Drawn there, **no** switch prompt: there is no other board to switch to, since the host matches owned boards by name + layout. Playlist rows already behave this way.
- Another board model → the climb's own board, at `climb.angle`, `fit: 'incompatible'`. This is the only case that raises the switch prompt.
- No board metadata, **or no `layoutId`** → the active board, exactly as today. Fail open: placing a layout-less climb means guessing a layout, and a wrong guess re-creates the very bug this fixes.

It is a named wrapper over the resolver the playlist rows already use, so cross-board playlist behaviour and this fix cannot drift apart.

Wired into every surface that draws a climb against a board it did not necessarily come from:

- **PlayDrawer** draws the displayed climb from the resolved board — board render data, `DeferredBoard`, the header, the favourite key, the below-fold sections, the tick sheet and the beta-video sheet. The selected board keeps the angle pill and the angle sheet (they move the wall the climber is standing at, not the picture). A swipe peek whose climb lives on another board is withheld rather than drawn under the current art; the board swaps on commit.
- **Switch-board gate** now also fires when the mismatch is discovered from the climb, with no board override in play. The drawer hands `DrawerHostProvider` the board it resolved so "Switch board" lands on the *climb's* board — one tap if the climber owns it, else the board picker. `handleSwitchBoardFromDrawer` also falls through to the picker when the board it would select is the one already active, so the button can never be a no-op that leaves the scrim up. The prompt names the layout ("Kilter Board Homewall") rather than the brand, since Homewall vs Original is the whole of #5099 — same `session.boardMismatch.*` copy, no new strings.
- **Accessory thumbnail** (the capsule, the "On the wall" strip, the iPad sidebar cell), the **Android session notification** thumbnail, and **queue-sheet rows** all resolve per climb, so a mixed queue draws each row on its own board.

**Bluetooth note (one prop).** A wrong-board climb's hold ids address a different wall, so animating it would light the *wrong holds* on the connected board. The scrim hides the play controls, but a party peer's playback event starts the engine with no local tap — so `PlayDrawer` now passes `suppressWallWrites: isPreview || climbBoardMismatch` to `useMobilePlayback`. That is the only Bluetooth-touching line in the PR; it can only withhold writes, never add them. Flagging it for the Fable review rule.

The mixed-board queue stays a supported state: nothing clears the queue or the current climb on a board switch. Perf: `getPlaylistRenderBoardTarget` is now memoised by board key, so `canAddClimbToBoard`'s hold-id Set is built once per board instead of once per queue row (and once per candidate size inside the upsize search).

`Climb View Opened` keeps reporting the stored active board — the documented contract in `docs/board-render-analytics.md` is untouched.

## Release Notes

- A climb from your other board now shows on that board, holds and all, instead of a blank wall — with a one-tap switch to go there.
- Queue rows, the "On the wall" capsule and the Android session notification each draw their climb on the board it belongs to.

## Test plan

1. Homewall board → open a climb → close it.
2. Boards → switch active board to Kilter Original 12x12.
3. Tap "On the wall" capsule → Homewall art, holds lit, switch prompt.
4. Tap Switch board → Homewall goes active, prompt clears.
5. Next → 12x12 climbs draw normally; queue rows match their boards.

## Risk

Risk: 3/5 — play-view board resolution touches every render surface
