### PR TITLE
ci(db): activate the migration runner's owner-role contract

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -438,6 +438,19 @@ jobs:
           # the PG16 role transition it carries the boardsesh_runtime
           # credential, which deliberately cannot run DDL.
           DATABASE_URL: ${{ secrets.MIGRATOR_DATABASE_URL }}
+          # The five-variable migration execution contract
+          # (docs/postgres-18-migration.md §"Target roles and secrets") makes
+          # the runner reserve one session, SET ROLE to the NOLOGIN owner for
+          # DDL — the migrator itself deliberately cannot CREATE — and
+          # reconcile runtime ACLs afterward. All five must be set together;
+          # without them the runner's own `CREATE SCHEMA IF NOT EXISTS
+          # "drizzle"` fails as the migrator with "permission denied for
+          # database railway".
+          MIGRATION_OWNER_ROLE: boardsesh_owner
+          MIGRATION_LOGIN_ROLE: boardsesh_migrator
+          EXPECTED_MIGRATION_DATABASE: railway
+          MIGRATION_RUNTIME_ROLE: boardsesh_runtime
+          MIGRATION_RUNTIME_SCHEMAS: public drizzle
           VERIFY_MIGRATION_JOURNAL: '1'
         run: vp exec pnpm --filter @boardsesh/db run db:migrate
 


### PR DESCRIPTION
## Summary

Fixes the production deploy failure on the migrate step (run 33681783370). The step now runs as `boardsesh_migrator`, which deliberately cannot CREATE — the runner must reserve a session and `SET ROLE boardsesh_owner` for DDL, and that path only activates when the five-variable migration execution contract is set together (`migration-owner-role.ts` requires all five). The runbook gates those on the production roles, verified migrator credential, rollback probes, and secret rotation — all complete as of W2, so this flips them on.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.
2. Next main deploy: migrate step green, deploys resume.

## Risk

Risk: 2/5 — env-only workflow change; the runner validates the contract and fails loudly on any mismatch before touching the ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAsksAJopQNZQwYQQbz7sn