### PR TITLE
fix(web): size Next's build workers from availableParallelism

### DIFF
--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -1,4 +1,5 @@
 import { withSentryConfig } from '@sentry/nextjs';
+import os from 'node:os';
 import path from 'node:path';
 // next.config.js
 
@@ -373,6 +374,27 @@ const nextConfig = {
   // Empty turbopack config to silence warning about webpack config
   turbopack: {},
   experimental: {
+    // Size the page-data workers from availableParallelism, not Next's
+    // default. Next derives its worker count from `os.cpus().length`, which
+    // reports every CPU on the machine and ignores cgroup/cpuset limits --
+    // Node's own docs warn against using it for exactly this.
+    //
+    // Measured in the CI runner image under `--cpuset-cpus=0-2`:
+    //
+    //   nproc                       3
+    //   os.cpus().length           18   <-- what Next reads
+    //   os.availableParallelism()   3
+    //
+    // So on a 3-CPU container Next spawned 17 workers (18 - 1), each a Node
+    // process good for ~1 GB, and the host ran out of memory. It surfaced as
+    // `Next.js build worker exited with code: null and signal: SIGBUS` on
+    // every self-hosted runner while passing GitHub-hosted, where a runner
+    // has 4 CPUs and the arithmetic happens to be survivable.
+    //
+    // availableParallelism respects affinity, so this is correct on a
+    // constrained container, an unconstrained one, and a developer laptop
+    // alike -- no environment variable to keep in sync with the runner config.
+    cpus: Math.max(1, os.availableParallelism() - 1),
     optimizePackageImports: ['@mui/material', '@mui/icons-material', '@mui/material-nextjs'],
     // Next's build-time type check normally drives the TypeScript compiler API,
     // which 7.0 no longer ships. This routes that step through `tsc` instead.


### PR DESCRIPTION
The application half of the SIGBUS incident. Pairs with
`marcodejongh/blackheathdc-ansible#405`, and is the part that actually stops
the over-forking.

Next derives its page-data worker count from `os.cpus().length`, which reports
every CPU on the machine and **ignores cgroup/cpuset limits**. [Node's own docs
warn against using it for this](https://nodejs.org/api/os.html#oscpus).

Measured in the CI runner image under `--cpuset-cpus=0-2`:

| | |
| --- | ---: |
| `nproc` | 3 |
| **`os.cpus().length`** | **18** ← what Next reads |
| `os.availableParallelism()` | 3 |

So on a 3-CPU container Next spawned **17** workers (`18 - 1`), each a Node
process good for ~1 GB, and the host ran out of memory:

```
Collecting page data using 17 workers ...
⨯ Next.js build worker exited with code: null and signal: SIGBUS
```

5/5 self-hosted runners, zero passes, while GitHub-hosted passed the same job —
a hosted runner has 4 CPUs, so the arithmetic there happens to be survivable.

### The part I had wrong

I claimed restricting CPU affinity would fix this. It does not: cpuset changes
what `nproc` reports, not what `os.cpus()` reports. Codex caught it in review on
ansible#405 and the measurement above confirms it. Left as-is, adding a memory
limit would have converted a sporadic SIGBUS into a *deterministic* OOM.

### Fix

`availableParallelism()` respects affinity, so it is correct on a constrained
container, an unconstrained one, and a laptop alike — with no environment
variable to keep in sync with the runner config.

Verified:

| | Next default | this |
| --- | ---: | ---: |
| `--cpuset-cpus=0-2` | 17 workers | **2** |
| unrestricted | 17 | 17 |
| GitHub-hosted (4 CPU) | 3 | 3 |

Hosted behaviour is unchanged.

## Release Notes

none

## Test plan

1. CI green.
2. `typecheck` passes on a self-hosted runner once ansible#405 has converged.

## Risk

Risk: 2/5 — build-time worker count only. Unchanged wherever CPUs are not
restricted, which includes GitHub-hosted and local development.