### PR TITLE
fix(mobile): stop the create-climb sheet stealing pinch/pan on Android

### DIFF
--- a/packages/mobile/src/components/create-climb/CreateDrawer.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawer.tsx
@@ -87,6 +87,14 @@ export function CreateDrawer({
   const windowInsetBottom = useWindowBottomInset();
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
   const sheetRef = useRef<BottomSheet>(null);
+  // True while InteractiveCreateBoard is zoomed or mid-pinch. The sheet's own
+  // content-panning gesture is a native Compose gesture (Android), not RNGH —
+  // nothing in the board's gesture tree can block it, so it competes directly
+  // with the board's pinch/pan and can win, sliding the sheet instead of
+  // zooming/panning the board. Disabling it for the duration, the same way
+  // subSheetOpen already does for the role-picker sub-sheet, is the only lever
+  // `@expo/ui`'s bottom sheet exposes for this.
+  const [boardInteractionActive, setBoardInteractionActive] = useState(false);
 
   // Measured above-fold height drives the peek snap-point (the native grabber is
   // a fixed reserve now, not a measured custom handle).
@@ -195,8 +203,8 @@ export function CreateDrawer({
       index={0}
       snapPoints={snapPoints}
       enablePanDownToClose
-      enableContentPanningGesture={!subSheetOpen}
-      enableHandlePanningGesture={!subSheetOpen}
+      enableContentPanningGesture={!subSheetOpen && !boardInteractionActive}
+      enableHandlePanningGesture={!subSheetOpen && !boardInteractionActive}
       backgroundStyle={backgroundStyle}
       keyboardBehavior="interactive"
       keyboardBlurBehavior="restore"
@@ -279,6 +287,7 @@ export function CreateDrawer({
               renderWidth={boardRender.width}
               renderHeight={boardRender.height}
               controlRef={boardControlsRef}
+              onInteractionActiveChange={setBoardInteractionActive}
             />
           </View>
 

--- a/packages/mobile/src/components/create-climb/CreateDrawer.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawer.tsx
@@ -1,11 +1,36 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentRef,
+  type ComponentType,
+  type RefObject,
+} from 'react';
 import { View, StyleSheet, useWindowDimensions, type LayoutChangeEvent } from 'react-native';
+import { GestureHandlerRootView, ScrollView } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useWindowBottomInset } from '../../hooks/use-window-bottom-inset';
 // Migrated off @gorhom/bottom-sheet to Expo's native bottom sheet (#3167). The
 // native sheet draws its own scrim + drag handle, so the measured-handle peek
 // machinery is replaced by a small fixed reserve for the native grabber.
-import BottomSheet, { BottomSheetScrollView } from '@expo/ui/community/bottom-sheet';
+//
+// The scroll container is RNGH's own `ScrollView`, NOT `@expo/ui`'s
+// `BottomSheetScrollView` (a bare re-export of React Native's plain
+// `ScrollView`). A plain ScrollView can't be declared a relation with an RNGH
+// gesture — Android's classic `ScrollView.onInterceptTouchEvent` can win the
+// touch stream on the very first vertical-ish move, before InteractiveCreateBoard's
+// pinch has a chance to activate and call `requestDisallowInterceptTouchEvent`.
+// That raced exactly like the board's per-hold-detector-vs-pinch race the
+// pinchRef fix (#4425/#3045) already solved, just one level further out: a
+// pinch with any vertical component got cancelled by the scroll, so only a
+// carefully horizontal-only pinch survived (issue #5107). Swapping in RNGH's
+// ScrollView + `scrollRef` lets useZoomPanGesture declare the same relation
+// PlayDrawer already uses for its own surrounding scroll — pinch simultaneous
+// with the scroll (never cancelled), zoomed-pan blocks the scroll (drags the
+// board, not the sheet) — eliminating the race instead of reacting to it.
+import BottomSheet from '@expo/ui/community/bottom-sheet';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import { useTheme } from '../../providers/theme-provider';
 import { spacing, sheetStyles } from '../../theme/tokens';
@@ -87,6 +112,12 @@ export function CreateDrawer({
   const windowInsetBottom = useWindowBottomInset();
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
   const sheetRef = useRef<BottomSheet>(null);
+  // The outer RNGH ScrollView, so the board's pinch/zoomed-pan can declare a
+  // relation with it (see the import comment above). Typed as RNGH's
+  // GestureRef shape so useZoomPanGesture/InteractiveCreateBoard need no cast
+  // at the call site — mirrors PlayDrawer's scrollGestureRef.
+  const scrollRef = useRef<ComponentRef<typeof ScrollView>>(null);
+  const scrollGestureRef = scrollRef as unknown as RefObject<ComponentType | undefined | null>;
   // True while InteractiveCreateBoard is zoomed or mid-pinch. The sheet's own
   // pan/drag gesture is a native Compose gesture (Android) / SwiftUI gesture
   // (iOS), not RNGH — nothing in the board's gesture tree can block it, so it
@@ -221,27 +252,29 @@ export function CreateDrawer({
       onChange={handleChange}
       onClose={onClose}
     >
-      <BottomSheetScrollView
-        style={styles.scroll}
-        contentContainerStyle={{ paddingTop: spacing[2], paddingBottom: windowInsetBottom + spacing[4] }}
-        keyboardShouldPersistTaps="handled"
-        keyboardDismissMode="on-drag"
-      >
-        <View onLayout={handleHeaderLayout} testID="create-drawer-measured-header">
-          <CreateDrawerHeader
-            name={controller.name}
-            onChangeName={controller.setName}
-            startingCount={controller.startingCount}
-            finishCount={controller.finishCount}
-            focusSignal={controller.focusNameSignal}
-            onClose={() => sheetRef.current?.close()}
-            bleConnected={controller.bleConnected}
-            bleConnecting={controller.bleConnecting}
-            onToggleBle={controller.handleToggleBle}
-          />
-        </View>
+      <GestureHandlerRootView style={styles.scroll}>
+        <ScrollView
+          ref={scrollRef}
+          style={styles.scroll}
+          contentContainerStyle={{ paddingTop: spacing[2], paddingBottom: windowInsetBottom + spacing[4] }}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="on-drag"
+        >
+          <View onLayout={handleHeaderLayout} testID="create-drawer-measured-header">
+            <CreateDrawerHeader
+              name={controller.name}
+              onChangeName={controller.setName}
+              startingCount={controller.startingCount}
+              finishCount={controller.finishCount}
+              focusSignal={controller.focusNameSignal}
+              onClose={() => sheetRef.current?.close()}
+              bleConnected={controller.bleConnected}
+              bleConnecting={controller.bleConnecting}
+              onToggleBle={controller.handleToggleBle}
+            />
+          </View>
 
-        {/* Transient, and deliberately measured by NEITHER block above or below.
+          {/* Transient, and deliberately measured by NEITHER block above or below.
             The peek snap-point is derived from the measured above-fold height, so
             anything that mounts inside a measured region moves `peekHeight` and
             re-snaps the sheet — which collapsed an expanded drawer the instant a
@@ -253,101 +286,103 @@ export function CreateDrawer({
             exactly where the climber put it. Pinned by "keeps the transient
             banners out of the measured above-fold region" in
             create-drawer-measured-region.test.tsx. */}
-        {controller.pendingNewClimb ? (
-          <InlineConfirmBanner
-            title={t('mobile.create.newClimb.confirm.title')}
-            message={t('mobile.create.newClimb.confirm.message')}
-            confirmLabel={t('mobile.create.newClimb.confirm.action')}
-            cancelLabel={t('createClimbForm.dismiss')}
-            onConfirm={controller.confirmNewClimb}
-            onCancel={controller.cancelNewClimb}
-          />
-        ) : null}
+          {controller.pendingNewClimb ? (
+            <InlineConfirmBanner
+              title={t('mobile.create.newClimb.confirm.title')}
+              message={t('mobile.create.newClimb.confirm.message')}
+              confirmLabel={t('mobile.create.newClimb.confirm.action')}
+              cancelLabel={t('createClimbForm.dismiss')}
+              onConfirm={controller.confirmNewClimb}
+              onCancel={controller.cancelNewClimb}
+            />
+          ) : null}
 
-        {controller.publishDuplicateError ? (
-          <DuplicateBanner
-            name={controller.publishDuplicateError.existingClimbName}
-            onView={
-              controller.publishDuplicateError.existingClimbUuid
-                ? () => {
-                    const uuid = controller.publishDuplicateError?.existingClimbUuid;
-                    if (uuid) onViewDuplicate(uuid);
-                  }
-                : undefined
-            }
-            onDismiss={controller.dismissDuplicateError}
-          />
-        ) : null}
+          {controller.publishDuplicateError ? (
+            <DuplicateBanner
+              name={controller.publishDuplicateError.existingClimbName}
+              onView={
+                controller.publishDuplicateError.existingClimbUuid
+                  ? () => {
+                      const uuid = controller.publishDuplicateError?.existingClimbUuid;
+                      if (uuid) onViewDuplicate(uuid);
+                    }
+                  : undefined
+              }
+              onDismiss={controller.dismissDuplicateError}
+            />
+          ) : null}
 
-        <View onLayout={handleBoardBlockLayout} testID="create-drawer-measured-board-block">
-          <View style={styles.boardSection}>
-            <InteractiveCreateBoard
-              frames={controller.currentFramesString}
-              boardName={board.boardName as BoardName}
-              layoutId={board.layoutId}
-              sizeId={board.sizeId}
-              setIds={board.setIds}
-              boardWidth={boardHolds.boardWidth}
-              boardHeight={boardHolds.boardHeight}
-              holdTargets={boardHolds.holdTargets}
-              litUpHoldsMap={controller.litUpHoldsMap}
-              onPaint={controller.handlePaint}
-              onLongPressHold={onLongPressHold}
-              showAllHolds={controller.showAllHolds}
-              renderWidth={boardRender.width}
-              renderHeight={boardRender.height}
-              controlRef={boardControlsRef}
-              onInteractionActiveChange={setBoardInteractionActive}
+          <View onLayout={handleBoardBlockLayout} testID="create-drawer-measured-board-block">
+            <View style={styles.boardSection}>
+              <InteractiveCreateBoard
+                frames={controller.currentFramesString}
+                boardName={board.boardName as BoardName}
+                layoutId={board.layoutId}
+                sizeId={board.sizeId}
+                setIds={board.setIds}
+                boardWidth={boardHolds.boardWidth}
+                boardHeight={boardHolds.boardHeight}
+                holdTargets={boardHolds.holdTargets}
+                litUpHoldsMap={controller.litUpHoldsMap}
+                onPaint={controller.handlePaint}
+                onLongPressHold={onLongPressHold}
+                showAllHolds={controller.showAllHolds}
+                renderWidth={boardRender.width}
+                renderHeight={boardRender.height}
+                controlRef={boardControlsRef}
+                onInteractionActiveChange={setBoardInteractionActive}
+                scrollRef={scrollGestureRef}
+              />
+            </View>
+
+            <CreateDrawerActionBar
+              boardName={board.boardName}
+              selectedBrush={controller.selectedBrush}
+              onSelectBrush={controller.setSelectedBrush}
+              canUndo={controller.canUndo}
+              canRedo={controller.canRedo}
+              onUndo={controller.undo}
+              onRedo={controller.redo}
+              onClearHolds={controller.handleClearHolds}
+              onNewClimb={controller.handleNewClimb}
+              supportsMultiFrame={controller.supportsMultiFrame}
+              frameCount={controller.frameCount}
+              currentFrameIndex={controller.currentFrameIndex}
+              onDuplicateFrame={controller.duplicateFrame}
+              onDeleteFrame={controller.deleteFrame}
+              onPrevFrame={controller.prevFrame}
+              onNextFrame={controller.nextFrame}
+              canSetActive={controller.canSetActive}
+              onSetActive={controller.handleSetActive}
+              saveState={controller.saveState}
+              onSave={() => void controller.handleSave()}
+              publishBlocked={controller.publishBlocked}
+              draftStatus={controller.draftStatus}
             />
           </View>
 
-          <CreateDrawerActionBar
-            boardName={board.boardName}
-            selectedBrush={controller.selectedBrush}
-            onSelectBrush={controller.setSelectedBrush}
-            canUndo={controller.canUndo}
-            canRedo={controller.canRedo}
-            onUndo={controller.undo}
-            onRedo={controller.redo}
-            onClearHolds={controller.handleClearHolds}
-            onNewClimb={controller.handleNewClimb}
-            supportsMultiFrame={controller.supportsMultiFrame}
-            frameCount={controller.frameCount}
-            currentFrameIndex={controller.currentFrameIndex}
-            onDuplicateFrame={controller.duplicateFrame}
-            onDeleteFrame={controller.deleteFrame}
-            onPrevFrame={controller.prevFrame}
-            onNextFrame={controller.nextFrame}
-            canSetActive={controller.canSetActive}
-            onSetActive={controller.handleSetActive}
-            saveState={controller.saveState}
-            onSave={() => void controller.handleSave()}
-            publishBlocked={controller.publishBlocked}
-            draftStatus={controller.draftStatus}
-          />
-        </View>
-
-        <View style={styles.belowFold}>
-          <CreateDrawerForm
-            description={controller.description}
-            onChangeDescription={controller.setDescription}
-            noMatch={controller.noMatch}
-            onChangeNoMatch={controller.setNoMatch}
-            noKickboard={controller.noKickboard}
-            onChangeNoKickboard={controller.setNoKickboard}
-            campus={controller.campus}
-            onChangeCampus={controller.setCampus}
-            anyFeet={controller.anyFeet}
-            onChangeAnyFeet={controller.setAnyFeet}
-            anyFeetAvailable={controller.anyFeetAvailable}
-            isDraft={controller.isDraft}
-            onChangeIsDraft={controller.setIsDraft}
-            showAllHolds={controller.showAllHolds}
-            onChangeShowAllHolds={controller.setShowAllHolds}
-          />
-          <OpenDraftsSection board={board} onLoadDraft={handleLoadDraft} />
-        </View>
-      </BottomSheetScrollView>
+          <View style={styles.belowFold}>
+            <CreateDrawerForm
+              description={controller.description}
+              onChangeDescription={controller.setDescription}
+              noMatch={controller.noMatch}
+              onChangeNoMatch={controller.setNoMatch}
+              noKickboard={controller.noKickboard}
+              onChangeNoKickboard={controller.setNoKickboard}
+              campus={controller.campus}
+              onChangeCampus={controller.setCampus}
+              anyFeet={controller.anyFeet}
+              onChangeAnyFeet={controller.setAnyFeet}
+              anyFeetAvailable={controller.anyFeetAvailable}
+              isDraft={controller.isDraft}
+              onChangeIsDraft={controller.setIsDraft}
+              showAllHolds={controller.showAllHolds}
+              onChangeShowAllHolds={controller.setShowAllHolds}
+            />
+            <OpenDraftsSection board={board} onLoadDraft={handleLoadDraft} />
+          </View>
+        </ScrollView>
+      </GestureHandlerRootView>
     </BottomSheet>
   );
 }

--- a/packages/mobile/src/components/create-climb/CreateDrawer.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawer.tsx
@@ -88,12 +88,12 @@ export function CreateDrawer({
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
   const sheetRef = useRef<BottomSheet>(null);
   // True while InteractiveCreateBoard is zoomed or mid-pinch. The sheet's own
-  // content-panning gesture is a native Compose gesture (Android), not RNGH —
-  // nothing in the board's gesture tree can block it, so it competes directly
-  // with the board's pinch/pan and can win, sliding the sheet instead of
-  // zooming/panning the board. Disabling it for the duration, the same way
-  // subSheetOpen already does for the role-picker sub-sheet, is the only lever
-  // `@expo/ui`'s bottom sheet exposes for this.
+  // pan/drag gesture is a native Compose gesture (Android) / SwiftUI gesture
+  // (iOS), not RNGH — nothing in the board's gesture tree can block it, so it
+  // competes directly with the board's pinch/pan and can win, sliding the
+  // sheet instead of zooming/panning the board. Disabled for the duration via
+  // enablePanDownToClose below, the same way subSheetOpen already does for the
+  // role-picker sub-sheet.
   const [boardInteractionActive, setBoardInteractionActive] = useState(false);
 
   // Measured above-fold height drives the peek snap-point (the native grabber is
@@ -202,9 +202,19 @@ export function CreateDrawer({
       ref={sheetRef}
       index={0}
       snapPoints={snapPoints}
-      enablePanDownToClose
-      enableContentPanningGesture={!subSheetOpen && !boardInteractionActive}
-      enableHandlePanningGesture={!subSheetOpen && !boardInteractionActive}
+      // `enableContentPanningGesture`/`enableHandlePanningGesture` exist on
+      // BottomSheetProps for gorhom API compatibility but are documented as
+      // having no effect on native platforms — "Native sheets handle content
+      // panning internally" (@expo/ui's own types.ts). `enablePanDownToClose`
+      // is the one prop this library version actually wires up on both
+      // platforms (Android: sheetGesturesEnabled = enablePanDownToClose;
+      // iOS: interactiveDismissDisabled = !enablePanDownToClose) — it's the
+      // real lever for disabling the sheet's own drag while a sub-sheet is
+      // open or the board is zoomed/mid-pinch, at the cost of also disabling
+      // pan-down-to-close (and, on Android, back-press/scrim-tap dismiss) for
+      // the same duration, which is the right tradeoff: an accidental swipe
+      // shouldn't discard the in-progress climb either.
+      enablePanDownToClose={!subSheetOpen && !boardInteractionActive}
       backgroundStyle={backgroundStyle}
       keyboardBehavior="interactive"
       keyboardBlurBehavior="restore"

--- a/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
+++ b/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
@@ -1,4 +1,4 @@
-import React, { useImperativeHandle, useMemo, useRef, type ReactNode, type RefObject } from 'react';
+import React, { useEffect, useImperativeHandle, useMemo, useRef, type ReactNode, type RefObject } from 'react';
 import { View, StyleSheet, PixelRatio } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { GestureDetector, GestureHandlerRootView, type GestureType } from 'react-native-gesture-handler';
@@ -47,6 +47,14 @@ type InteractiveCreateBoardProps = {
   overlay?: ReactNode;
   /** Lets the drawer reset the zoom — both from its own chrome and on frame change. */
   controlRef?: RefObject<CreateBoardControls | null>;
+  /** Fires whenever the board is zoomed or mid-pinch. The create drawer's sheet
+   *  is an `@expo/ui` native bottom sheet (Jetpack Compose on Android), not an
+   *  RNGH surface — RNGH's gesture-relation APIs (the pinchRef simultaneity
+   *  above) can't reach outside this board's own root, so nothing here stops
+   *  the sheet's own pan-to-resize gesture from grabbing a 2-finger pinch or a
+   *  1-finger pan-while-zoomed. The host uses this to disable that gesture for
+   *  the duration (see CreateDrawer's enableContentPanningGesture). */
+  onInteractionActiveChange?: (active: boolean) => void;
 };
 
 /**
@@ -97,6 +105,7 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
   renderHeight,
   overlay,
   controlRef,
+  onInteractionActiveChange,
 }: InteractiveCreateBoardProps) {
   // Shared with the per-hold detectors and the zoomed overlay so they mark
   // themselves simultaneous with the pinch — otherwise two fingers landing on
@@ -106,6 +115,7 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
     pinchGesture,
     zoomPanGesture,
     isZoomed,
+    isPinching,
     isPinchingSV,
     scaleSV,
     translateXSV,
@@ -129,6 +139,12 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
   const overlayRenderWidth = useMemo(() => Math.round(renderWidth * PixelRatio.get()), [renderWidth]);
 
   useImperativeHandle(controlRef, () => ({ resetZoom }), [resetZoom]);
+
+  // Tell the host (CreateDrawer) to disable its native sheet's own pan while
+  // the board is zoomed or mid-pinch — see onInteractionActiveChange above.
+  useEffect(() => {
+    onInteractionActiveChange?.(isZoomed || isPinching);
+  }, [isZoomed, isPinching, onInteractionActiveChange]);
 
   const holdById = useMemo(() => {
     const map = new Map<number, BoardHoldTarget>();

--- a/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
+++ b/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
@@ -48,12 +48,12 @@ type InteractiveCreateBoardProps = {
   /** Lets the drawer reset the zoom — both from its own chrome and on frame change. */
   controlRef?: RefObject<CreateBoardControls | null>;
   /** Fires whenever the board is zoomed or mid-pinch. The create drawer's sheet
-   *  is an `@expo/ui` native bottom sheet (Jetpack Compose on Android), not an
-   *  RNGH surface — RNGH's gesture-relation APIs (the pinchRef simultaneity
-   *  above) can't reach outside this board's own root, so nothing here stops
-   *  the sheet's own pan-to-resize gesture from grabbing a 2-finger pinch or a
-   *  1-finger pan-while-zoomed. The host uses this to disable that gesture for
-   *  the duration (see CreateDrawer's enableContentPanningGesture). */
+   *  is an `@expo/ui` native bottom sheet (Jetpack Compose on Android, SwiftUI
+   *  on iOS), not an RNGH surface — RNGH's gesture-relation APIs (the pinchRef
+   *  simultaneity above) can't reach outside this board's own root, so nothing
+   *  here stops the sheet's own drag gesture from grabbing a 2-finger pinch or
+   *  a 1-finger pan-while-zoomed. The host uses this to disable that gesture
+   *  for the duration (see CreateDrawer's enablePanDownToClose). */
   onInteractionActiveChange?: (active: boolean) => void;
 };
 

--- a/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
+++ b/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
@@ -1,4 +1,12 @@
-import React, { useEffect, useImperativeHandle, useMemo, useRef, type ReactNode, type RefObject } from 'react';
+import React, {
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  type ComponentType,
+  type ReactNode,
+  type RefObject,
+} from 'react';
 import { View, StyleSheet, PixelRatio } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { GestureDetector, GestureHandlerRootView, type GestureType } from 'react-native-gesture-handler';
@@ -55,6 +63,15 @@ type InteractiveCreateBoardProps = {
    *  a 1-finger pan-while-zoomed. The host uses this to disable that gesture
    *  for the duration (see CreateDrawer's enablePanDownToClose). */
   onInteractionActiveChange?: (active: boolean) => void;
+  /** RNGH ref to the surrounding scroll (CreateDrawer's own RNGH `ScrollView`,
+   *  swapped in for `@expo/ui`'s plain-RN-ScrollView `BottomSheetScrollView`
+   *  specifically so this relation is possible). Declares the pinch
+   *  simultaneous with it so a 2-finger pinch with any vertical component
+   *  isn't cancelled by the scroll's own touch interception, and makes that
+   *  scroll wait on the zoomed-only pan so a 1-finger drag while zoomed pans
+   *  the board instead of scrolling the sheet. Mirrors PlayDrawer's
+   *  scrollRef — see the import comment at the top of CreateDrawer.tsx. */
+  scrollRef?: RefObject<ComponentType | undefined | null>;
 };
 
 /**
@@ -106,6 +123,7 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
   overlay,
   controlRef,
   onInteractionActiveChange,
+  scrollRef,
 }: InteractiveCreateBoardProps) {
   // Shared with the per-hold detectors and the zoomed overlay so they mark
   // themselves simultaneous with the pinch — otherwise two fingers landing on
@@ -130,6 +148,7 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
     containerHeight: renderHeight,
     panActivationOffset: PAN_ACTIVATION_OFFSET,
     pinchRef,
+    scrollRef,
   });
 
   // Rasterize the holds overlay at the size it is actually displayed, not the

--- a/packages/mobile/src/components/create-climb/__tests__/InteractiveCreateBoard.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/InteractiveCreateBoard.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// What this test is about: InteractiveCreateBoard's onInteractionActiveChange
+// callback, which CreateDrawer uses to disable its native bottom sheet's own
+// pan gesture while the board is zoomed or mid-pinch (see the doc comment on
+// the prop). Everything else is mocked to a stub — the gesture composition
+// itself is covered by use-zoom-pan-gesture's own tests.
+
+vi.mock('react-native', () => ({
+  View: ({ children, ...props }: { children?: ReactNode }) => createElement('div', props, children),
+  StyleSheet: { create: (styles: unknown) => styles, absoluteFill: {} },
+  Pressable: ({ children, ...props }: { children?: ReactNode }) => createElement('button', props, children),
+}));
+
+vi.mock('react-native-reanimated', () => ({
+  default: { View: ({ children, ...props }: { children?: ReactNode }) => createElement('div', props, children) },
+}));
+
+vi.mock('react-native-gesture-handler', () => ({
+  GestureDetector: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  GestureHandlerRootView: ({ children, ...props }: { children?: ReactNode }) => createElement('div', props, children),
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+vi.mock('../../BoardImageNative', () => ({ BoardImageNative: () => createElement('div') }));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../../theme/tokens', () => ({ overlays: { scrim: '#000', onScrim: '#fff' } }));
+vi.mock('../HoldTargetLayer', () => ({ HoldTargetLayer: () => createElement('div') }));
+vi.mock('../PaintedHoldsLayer', () => ({ PaintedHoldsLayer: () => createElement('div') }));
+vi.mock('../holdLayout', () => ({ buildHoldHitTargets: () => [] }));
+vi.mock('../use-zoomed-hold-tap-gesture', () => ({
+  useZoomedHoldTapGesture: () => ({}),
+  PAN_ACTIVATION_OFFSET: 8,
+}));
+
+const zoomPanState = { isZoomed: false, isPinching: false };
+vi.mock('../../play-drawer/use-zoom-pan-gesture', () => ({
+  useZoomPanGesture: () => ({
+    pinchGesture: {},
+    zoomPanGesture: {},
+    isZoomed: zoomPanState.isZoomed,
+    isPinching: zoomPanState.isPinching,
+    isPinchingSV: { value: false },
+    scaleSV: { value: 1 },
+    translateXSV: { value: 0 },
+    translateYSV: { value: 0 },
+    containerWidthSV: { value: 100 },
+    containerHeightSV: { value: 100 },
+    resetZoom: () => {},
+    animatedZoomStyle: {},
+  }),
+}));
+
+import { InteractiveCreateBoard } from '../InteractiveCreateBoard';
+
+function renderBoard(onInteractionActiveChange: (active: boolean) => void) {
+  return render(
+    createElement(InteractiveCreateBoard, {
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 1,
+      setIds: '1',
+      boardWidth: 1000,
+      boardHeight: 1000,
+      holdTargets: [],
+      litUpHoldsMap: {},
+      onPaint: () => {},
+      onLongPressHold: () => {},
+      renderWidth: 300,
+      renderHeight: 300,
+      onInteractionActiveChange,
+    }),
+  );
+}
+
+describe('InteractiveCreateBoard onInteractionActiveChange', () => {
+  beforeEach(() => {
+    zoomPanState.isZoomed = false;
+    zoomPanState.isPinching = false;
+  });
+
+  it('reports inactive at rest', () => {
+    const onInteractionActiveChange = vi.fn();
+    renderBoard(onInteractionActiveChange);
+    expect(onInteractionActiveChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('reports active while zoomed', () => {
+    zoomPanState.isZoomed = true;
+    const onInteractionActiveChange = vi.fn();
+    renderBoard(onInteractionActiveChange);
+    expect(onInteractionActiveChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it('reports active mid-pinch, before isZoomed has flipped', () => {
+    zoomPanState.isPinching = true;
+    const onInteractionActiveChange = vi.fn();
+    renderBoard(onInteractionActiveChange);
+    expect(onInteractionActiveChange).toHaveBeenLastCalledWith(true);
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/InteractiveCreateBoard.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/InteractiveCreateBoard.test.tsx
@@ -40,26 +40,30 @@ vi.mock('../use-zoomed-hold-tap-gesture', () => ({
 }));
 
 const zoomPanState = { isZoomed: false, isPinching: false };
+let lastUseZoomPanGestureOptions: Record<string, unknown> | null = null;
 vi.mock('../../play-drawer/use-zoom-pan-gesture', () => ({
-  useZoomPanGesture: () => ({
-    pinchGesture: {},
-    zoomPanGesture: {},
-    isZoomed: zoomPanState.isZoomed,
-    isPinching: zoomPanState.isPinching,
-    isPinchingSV: { value: false },
-    scaleSV: { value: 1 },
-    translateXSV: { value: 0 },
-    translateYSV: { value: 0 },
-    containerWidthSV: { value: 100 },
-    containerHeightSV: { value: 100 },
-    resetZoom: () => {},
-    animatedZoomStyle: {},
-  }),
+  useZoomPanGesture: (options: Record<string, unknown>) => {
+    lastUseZoomPanGestureOptions = options;
+    return {
+      pinchGesture: {},
+      zoomPanGesture: {},
+      isZoomed: zoomPanState.isZoomed,
+      isPinching: zoomPanState.isPinching,
+      isPinchingSV: { value: false },
+      scaleSV: { value: 1 },
+      translateXSV: { value: 0 },
+      translateYSV: { value: 0 },
+      containerWidthSV: { value: 100 },
+      containerHeightSV: { value: 100 },
+      resetZoom: () => {},
+      animatedZoomStyle: {},
+    };
+  },
 }));
 
 import { InteractiveCreateBoard } from '../InteractiveCreateBoard';
 
-function renderBoard(onInteractionActiveChange: (active: boolean) => void) {
+function renderBoard(onInteractionActiveChange: (active: boolean) => void, scrollRef?: { current: undefined }) {
   return render(
     createElement(InteractiveCreateBoard, {
       boardName: 'kilter',
@@ -75,6 +79,7 @@ function renderBoard(onInteractionActiveChange: (active: boolean) => void) {
       renderWidth: 300,
       renderHeight: 300,
       onInteractionActiveChange,
+      scrollRef,
     }),
   );
 }
@@ -103,5 +108,11 @@ describe('InteractiveCreateBoard onInteractionActiveChange', () => {
     const onInteractionActiveChange = vi.fn();
     renderBoard(onInteractionActiveChange);
     expect(onInteractionActiveChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it('forwards scrollRef to useZoomPanGesture, so the pinch can be declared simultaneous with the surrounding scroll', () => {
+    const scrollRef = { current: undefined };
+    renderBoard(vi.fn(), scrollRef);
+    expect(lastUseZoomPanGestureOptions?.scrollRef).toBe(scrollRef);
   });
 });

--- a/packages/mobile/src/components/create-climb/__tests__/InteractiveCreateBoard.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/InteractiveCreateBoard.test.tsx
@@ -10,28 +10,35 @@ import { createElement, type ReactNode } from 'react';
 // itself is covered by use-zoom-pan-gesture's own tests.
 
 vi.mock('react-native', () => ({
-  View: ({ children, ...props }: { children?: ReactNode }) => createElement('div', props, children),
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   StyleSheet: { create: (styles: unknown) => styles, absoluteFill: {} },
-  Pressable: ({ children, ...props }: { children?: ReactNode }) => createElement('button', props, children),
+  Pressable: ({ children }: { children?: ReactNode }) => createElement('button', null, children),
+  PixelRatio: { get: () => 3 },
 }));
 
 vi.mock('react-native-reanimated', () => ({
-  default: { View: ({ children, ...props }: { children?: ReactNode }) => createElement('div', props, children) },
+  default: { View: ({ children }: { children?: ReactNode }) => createElement('div', null, children) },
 }));
 
 vi.mock('react-native-gesture-handler', () => ({
   GestureDetector: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
-  GestureHandlerRootView: ({ children, ...props }: { children?: ReactNode }) => createElement('div', props, children),
+  GestureHandlerRootView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
 }));
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 
 vi.mock('../../BoardImageNative', () => ({ BoardImageNative: () => createElement('div') }));
+// Stubbed so the suite doesn't pull the real Icon (and @expo/vector-icons' Flow
+// source) in through the board's zoomed chrome.
+vi.mock('../../board-controls/ResetZoomButton', () => ({
+  ResetZoomButton: () => createElement('button', { 'data-reset-zoom': 'true' }),
+}));
 vi.mock('../../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
-vi.mock('../../../theme/tokens', () => ({ overlays: { scrim: '#000', onScrim: '#fff' } }));
+vi.mock('../../../theme/tokens', () => ({ overlays: { scrim: '#000', onScrim: '#fff' }, spacing: { 2: 8 } }));
 vi.mock('../HoldTargetLayer', () => ({ HoldTargetLayer: () => createElement('div') }));
+vi.mock('../HoldMarkerLayer', () => ({ HoldMarkerLayer: () => createElement('div') }));
 vi.mock('../PaintedHoldsLayer', () => ({ PaintedHoldsLayer: () => createElement('div') }));
 vi.mock('../holdLayout', () => ({ buildHoldHitTargets: () => [] }));
 vi.mock('../use-zoomed-hold-tap-gesture', () => ({
@@ -66,6 +73,7 @@ import { InteractiveCreateBoard } from '../InteractiveCreateBoard';
 function renderBoard(onInteractionActiveChange: (active: boolean) => void, scrollRef?: { current: undefined }) {
   return render(
     createElement(InteractiveCreateBoard, {
+      frames: 'p1r12',
       boardName: 'kilter',
       layoutId: 1,
       sizeId: 1,

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-auto-reset-zoom.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-auto-reset-zoom.test.tsx
@@ -18,7 +18,12 @@ vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ t
 vi.mock('../../../hooks/use-window-bottom-inset', () => ({ useWindowBottomInset: () => 48 }));
 vi.mock('@expo/ui/community/bottom-sheet', () => ({
   default: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
-  BottomSheetScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+// The drawer scrolls in RNGH's own ScrollView (so the board's pinch can declare
+// a relation with it), so the real RNGH module is in this file's import graph.
+vi.mock('react-native-gesture-handler', () => ({
+  GestureHandlerRootView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
 }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('../../../providers/theme-provider', () => ({

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-measured-region.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-measured-region.test.tsx
@@ -24,7 +24,10 @@ vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ t
 vi.mock('../../../hooks/use-window-bottom-inset', () => ({ useWindowBottomInset: () => 48 }));
 vi.mock('@expo/ui/community/bottom-sheet', () => ({
   default: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
-  BottomSheetScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('react-native-gesture-handler', () => ({
+  GestureHandlerRootView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
 }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('../../../providers/theme-provider', () => ({

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-sheet-gestures.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-sheet-gestures.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// What this test is about: CreateDrawer must disable the sheet's own drag
+// while a sub-sheet is open OR the board is zoomed/mid-pinch, via
+// `enablePanDownToClose` — the one prop `@expo/ui/community/bottom-sheet`
+// actually wires up on Android (`sheetGesturesEnabled`) and iOS
+// (`interactiveDismissDisabled`). `enableContentPanningGesture` /
+// `enableHandlePanningGesture` are documented as having no effect on native
+// platforms, so this test captures the real prop instead of those.
+
+type ViewMockProps = { children?: ReactNode; onLayout?: unknown; testID?: string };
+vi.mock('react-native', () => ({
+  View: ({ children, onLayout, testID }: ViewMockProps) =>
+    createElement('div', { 'data-measured': onLayout ? 'true' : undefined, 'data-testid': testID }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  useWindowDimensions: () => ({ width: 405, height: 900 }),
+}));
+vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 24, bottom: 0 }) }));
+vi.mock('../../../hooks/use-window-bottom-inset', () => ({ useWindowBottomInset: () => 48 }));
+
+let lastBottomSheetProps: { enablePanDownToClose?: boolean } = {};
+vi.mock('@expo/ui/community/bottom-sheet', () => ({
+  default: (props: { enablePanDownToClose?: boolean; children?: ReactNode }) => {
+    lastBottomSheetProps = props;
+    return createElement('div', null, props.children);
+  },
+  BottomSheetScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { secondaryBackground: '#221A33' } }),
+}));
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 6: 24 },
+  sheetStyles: { background: {} },
+}));
+
+let capturedOnInteractionActiveChange: ((active: boolean) => void) | null = null;
+vi.mock('../InteractiveCreateBoard', () => ({
+  InteractiveCreateBoard: (props: { onInteractionActiveChange?: (active: boolean) => void }) => {
+    capturedOnInteractionActiveChange = props.onInteractionActiveChange ?? null;
+    return createElement('div', { 'data-node': 'board' });
+  },
+}));
+vi.mock('../CreateDrawerHeader', () => ({
+  CreateDrawerHeader: () => createElement('div', { 'data-node': 'header' }),
+}));
+vi.mock('../CreateDrawerActionBar', () => ({
+  CreateDrawerActionBar: () => createElement('div', { 'data-node': 'action-bar' }),
+}));
+vi.mock('../CreateDrawerForm', () => ({ CreateDrawerForm: () => createElement('div', { 'data-node': 'form' }) }));
+vi.mock('../OpenDraftsSection', () => ({ OpenDraftsSection: () => createElement('div', { 'data-node': 'drafts' }) }));
+vi.mock('../InlineConfirmBanner', () => ({
+  InlineConfirmBanner: () => createElement('div', { 'data-node': 'confirm-banner' }),
+}));
+vi.mock('../DuplicateBanner', () => ({
+  DuplicateBanner: () => createElement('div', { 'data-node': 'duplicate-banner' }),
+}));
+
+import { CreateDrawer } from '../CreateDrawer';
+
+const board = { boardName: 'kilter' as const, layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 };
+const boardHolds = { holdTargets: [], boardWidth: 650, boardHeight: 1000 };
+
+type Controller = Parameters<typeof CreateDrawer>[0]['controller'];
+
+function makeController(): Controller {
+  return {
+    name: '',
+    setName: vi.fn(),
+    startingCount: 0,
+    finishCount: 0,
+    focusNameSignal: 0,
+    bleConnected: false,
+    bleConnecting: false,
+    handleToggleBle: vi.fn(),
+    litUpHoldsMap: {},
+    handlePaint: vi.fn(),
+    showAllHolds: false,
+    selectedBrush: 'HAND',
+    setSelectedBrush: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+    undo: vi.fn(),
+    redo: vi.fn(),
+    handleClearHolds: vi.fn(),
+    handleNewClimb: vi.fn(),
+    frameCount: 1,
+    currentFrameIndex: 0,
+    duplicateFrame: vi.fn(),
+    deleteFrame: vi.fn(),
+    prevFrame: vi.fn(),
+    nextFrame: vi.fn(),
+    canSetActive: false,
+    handleSetActive: vi.fn(),
+    saveState: 'ready',
+    handleSave: vi.fn(),
+    publishBlocked: false,
+    draftStatus: null,
+    pendingNewClimb: false,
+    confirmNewClimb: vi.fn(),
+    cancelNewClimb: vi.fn(),
+    publishDuplicateError: null,
+    dismissDuplicateError: vi.fn(),
+    description: '',
+    setDescription: vi.fn(),
+    noMatch: false,
+    setNoMatch: vi.fn(),
+    isDraft: true,
+    setIsDraft: vi.fn(),
+    setShowAllHolds: vi.fn(),
+  } as unknown as Controller;
+}
+
+function renderDrawer(subSheetOpen: boolean) {
+  return render(
+    createElement(CreateDrawer, {
+      board,
+      controller: makeController(),
+      boardHolds,
+      onLongPressHold: vi.fn(),
+      subSheetOpen,
+      onLoadDraft: vi.fn(),
+      onClose: vi.fn(),
+      onViewDuplicate: vi.fn(),
+    }),
+  );
+}
+
+describe('CreateDrawer sheet-gesture gating', () => {
+  it('starts with pan-down-to-close enabled at rest', () => {
+    renderDrawer(false);
+    expect(lastBottomSheetProps.enablePanDownToClose).toBe(true);
+  });
+
+  it('disables pan-down-to-close while the role-picker sub-sheet is open', () => {
+    renderDrawer(true);
+    expect(lastBottomSheetProps.enablePanDownToClose).toBe(false);
+  });
+
+  it('disables pan-down-to-close when the board reports it is zoomed or mid-pinch', () => {
+    renderDrawer(false);
+    expect(lastBottomSheetProps.enablePanDownToClose).toBe(true);
+
+    act(() => {
+      capturedOnInteractionActiveChange?.(true);
+    });
+    expect(lastBottomSheetProps.enablePanDownToClose).toBe(false);
+
+    act(() => {
+      capturedOnInteractionActiveChange?.(false);
+    });
+    expect(lastBottomSheetProps.enablePanDownToClose).toBe(true);
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-sheet-gestures.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-sheet-gestures.test.tsx
@@ -27,7 +27,10 @@ vi.mock('@expo/ui/community/bottom-sheet', () => ({
     lastBottomSheetProps = props;
     return createElement('div', null, props.children);
   },
-  BottomSheetScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('react-native-gesture-handler', () => ({
+  GestureHandlerRootView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
 }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 vi.mock('../../../providers/theme-provider', () => ({

--- a/packages/mobile/src/components/play-drawer/__tests__/use-zoom-pan-gesture-pinching.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-zoom-pan-gesture-pinching.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// What these tests are about: the JS-thread `isPinching` mirror of
+// isPinchingSV. The create-climb board's host (CreateDrawer) reads this (OR'd
+// with isZoomed) to disable its native bottom sheet's own pan gesture for the
+// duration — see the doc comment on isPinching in use-zoom-pan-gesture.ts and
+// onInteractionActiveChange in InteractiveCreateBoard.tsx.
+
+vi.mock('react-native-reanimated', async () => {
+  const { useRef } = await import('react');
+  return {
+    useSharedValue: (initial: unknown) => {
+      const ref = useRef<{ value: unknown } | null>(null);
+      if (ref.current === null) ref.current = { value: initial };
+      return ref.current;
+    },
+    useAnimatedStyle: (factory: () => unknown) => factory(),
+    withTiming: (toValue: unknown) => toValue,
+    cancelAnimation: () => {},
+    runOnJS:
+      (fn: (...args: unknown[]) => unknown) =>
+      (...args: unknown[]) =>
+        fn(...args),
+  };
+});
+
+type TouchesEvent = { numberOfTouches: number };
+type TouchesHandler = (event: TouchesEvent) => void;
+let capturedOnTouchesDown: TouchesHandler | null = null;
+
+vi.mock('react-native-gesture-handler', () => {
+  const makeBuilder = (kind: string) => {
+    const proxy: Record<string, (...args: unknown[]) => unknown> = new Proxy(
+      {},
+      {
+        get: (_target, method: string) => {
+          return (...args: unknown[]) => {
+            if (kind === 'Pinch' && method === 'onTouchesDown') {
+              capturedOnTouchesDown = args[0] as TouchesHandler;
+            }
+            return proxy;
+          };
+        },
+      },
+    );
+    return proxy;
+  };
+  return {
+    Gesture: { Pinch: () => makeBuilder('Pinch'), Pan: () => makeBuilder('Pan') },
+  };
+});
+
+import { useZoomPanGesture } from '../use-zoom-pan-gesture';
+
+describe('useZoomPanGesture isPinching', () => {
+  beforeEach(() => {
+    capturedOnTouchesDown = null;
+  });
+
+  it('stays false and wires no touches handler when no pinchRef is passed (the play-drawer board)', () => {
+    const { result } = renderHook(() => useZoomPanGesture({ containerWidth: 320, containerHeight: 480 }));
+
+    expect(result.current.isPinching).toBe(false);
+    expect(capturedOnTouchesDown).toBeNull();
+  });
+
+  it('flips true on a 2nd finger and back to false on a fresh 1-finger touch (interactive boards)', () => {
+    const pinchRef = { current: undefined };
+    const { result } = renderHook(() => useZoomPanGesture({ containerWidth: 320, containerHeight: 480, pinchRef }));
+
+    expect(result.current.isPinching).toBe(false);
+    expect(capturedOnTouchesDown).not.toBeNull();
+
+    act(() => {
+      capturedOnTouchesDown?.({ numberOfTouches: 2 });
+    });
+    expect(result.current.isPinching).toBe(true);
+
+    act(() => {
+      capturedOnTouchesDown?.({ numberOfTouches: 1 });
+    });
+    expect(result.current.isPinching).toBe(false);
+  });
+
+  it('does not fire again for a 3rd finger already mid-pinch', () => {
+    const pinchRef = { current: undefined };
+    const { result } = renderHook(() => useZoomPanGesture({ containerWidth: 320, containerHeight: 480, pinchRef }));
+
+    act(() => {
+      capturedOnTouchesDown?.({ numberOfTouches: 2 });
+    });
+    expect(result.current.isPinching).toBe(true);
+
+    // A 3rd finger re-fires the >=2 branch — isPinching should simply stay true.
+    act(() => {
+      capturedOnTouchesDown?.({ numberOfTouches: 3 });
+    });
+    expect(result.current.isPinching).toBe(true);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/use-zoom-pan-gesture-pinching.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/use-zoom-pan-gesture-pinching.test.ts
@@ -2,11 +2,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
-// What these tests are about: the JS-thread `isPinching` mirror of
-// isPinchingSV. The create-climb board's host (CreateDrawer) reads this (OR'd
-// with isZoomed) to disable its native bottom sheet's own pan gesture for the
-// duration — see the doc comment on isPinching in use-zoom-pan-gesture.ts and
-// onInteractionActiveChange in InteractiveCreateBoard.tsx.
+// What these tests are about: the JS-thread `isPinching` mirror of "2+
+// fingers are down on this board". The create-climb board's host
+// (CreateDrawer) reads this (OR'd with isZoomed) to disable its native bottom
+// sheet's own pan gesture for the duration — see the doc comment on
+// isPinching in use-zoom-pan-gesture.ts and onInteractionActiveChange in
+// InteractiveCreateBoard.tsx.
 
 vi.mock('react-native-reanimated', async () => {
   const { useRef } = await import('react');
@@ -29,6 +30,7 @@ vi.mock('react-native-reanimated', async () => {
 type TouchesEvent = { numberOfTouches: number };
 type TouchesHandler = (event: TouchesEvent) => void;
 let capturedOnTouchesDown: TouchesHandler | null = null;
+let capturedOnFinalize: (() => void) | null = null;
 
 vi.mock('react-native-gesture-handler', () => {
   const makeBuilder = (kind: string) => {
@@ -39,6 +41,9 @@ vi.mock('react-native-gesture-handler', () => {
           return (...args: unknown[]) => {
             if (kind === 'Pinch' && method === 'onTouchesDown') {
               capturedOnTouchesDown = args[0] as TouchesHandler;
+            }
+            if (kind === 'Pinch' && method === 'onFinalize') {
+              capturedOnFinalize = args[0] as () => void;
             }
             return proxy;
           };
@@ -57,6 +62,7 @@ import { useZoomPanGesture } from '../use-zoom-pan-gesture';
 describe('useZoomPanGesture isPinching', () => {
   beforeEach(() => {
     capturedOnTouchesDown = null;
+    capturedOnFinalize = null;
   });
 
   it('stays false and wires no touches handler when no pinchRef is passed (the play-drawer board)', () => {
@@ -64,9 +70,10 @@ describe('useZoomPanGesture isPinching', () => {
 
     expect(result.current.isPinching).toBe(false);
     expect(capturedOnTouchesDown).toBeNull();
+    expect(capturedOnFinalize).toBeNull();
   });
 
-  it('flips true on a 2nd finger and back to false on a fresh 1-finger touch (interactive boards)', () => {
+  it('flips true on a 2nd finger and back to false on a subsequent single-finger touch-down (interactive boards)', () => {
     const pinchRef = { current: undefined };
     const { result } = renderHook(() => useZoomPanGesture({ containerWidth: 320, containerHeight: 480, pinchRef }));
 
@@ -98,5 +105,37 @@ describe('useZoomPanGesture isPinching', () => {
       capturedOnTouchesDown?.({ numberOfTouches: 3 });
     });
     expect(result.current.isPinching).toBe(true);
+  });
+
+  it('clears on onFinalize when both fingers lift together (no intervening single-finger touchesDown)', () => {
+    // A lift fires no touchesDown event at all, so onTouchesDown's
+    // numberOfTouches===1 branch never runs in this scenario — onFinalize is
+    // the only thing that can clear the mirror. Without it, a host gating on
+    // isPinching (CreateDrawer) would stay locked until the user happened to
+    // touch the board again — including staying locked for a touch that
+    // never reaches the board at all, e.g. dragging the sheet by its handle.
+    const pinchRef = { current: undefined };
+    const { result } = renderHook(() => useZoomPanGesture({ containerWidth: 320, containerHeight: 480, pinchRef }));
+
+    act(() => {
+      capturedOnTouchesDown?.({ numberOfTouches: 2 });
+    });
+    expect(result.current.isPinching).toBe(true);
+    expect(capturedOnFinalize).not.toBeNull();
+
+    act(() => {
+      capturedOnFinalize?.();
+    });
+    expect(result.current.isPinching).toBe(false);
+  });
+
+  it('onFinalize is a no-op when nothing was pinching', () => {
+    const pinchRef = { current: undefined };
+    const { result } = renderHook(() => useZoomPanGesture({ containerWidth: 320, containerHeight: 480, pinchRef }));
+
+    act(() => {
+      capturedOnFinalize?.();
+    });
+    expect(result.current.isPinching).toBe(false);
   });
 });

--- a/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
@@ -70,6 +70,14 @@ type UseZoomPanGestureReturn = {
    * when the pinch activates — without the gate a small or slow pinch could also
    * paint a hold or open the role sheet. Stays false on boards with no pinchRef. */
   isPinchingSV: SharedValue<boolean>;
+  /** JS-thread mirror of isPinchingSV, true as soon as a 2nd finger touches down
+   * and cleared as soon as a fresh single-finger touch begins (same moments as
+   * the shared value — see its onTouchesDown in the pinch below). A host that
+   * sits inside a foreign, non-RNGH gesture surface (e.g. a native bottom sheet)
+   * can OR this with `isZoomed` to disable that surface's own pan for the
+   * duration, since RNGH's gesture-relation APIs can't reach outside its own
+   * tree. Stays false on boards with no pinchRef. */
+  isPinching: boolean;
   /** Live zoom scale on the UI thread, so an overlay inside the transform can
    * convert screen-pixel drag deltas into unscaled board-pixel deltas. */
   scaleSV: SharedValue<number>;
@@ -189,6 +197,8 @@ export function useZoomPanGesture({
   }, [containerHeight, containerHeightSV]);
 
   const [isZoomed, setIsZoomed] = useState(false);
+  // JS mirror of isPinchingSV — see isPinching in the return type.
+  const [isPinching, setIsPinching] = useState(false);
 
   const updateZoomState = useCallback(
     (zoomed: boolean) => {
@@ -340,8 +350,10 @@ export function useZoomPanGesture({
         'worklet';
         if (event.numberOfTouches >= 2) {
           isPinchingSV.value = true;
+          runOnJS(setIsPinching)(true);
         } else if (event.numberOfTouches === 1) {
           isPinchingSV.value = false;
+          runOnJS(setIsPinching)(false);
         }
       });
     }
@@ -364,6 +376,7 @@ export function useZoomPanGesture({
     pinchScaleMinSV,
     isZoomedSV,
     isPinchingSV,
+    setIsPinching,
     enabledSV,
     containerWidthSV,
     containerHeightSV,
@@ -441,6 +454,7 @@ export function useZoomPanGesture({
     isZoomed,
     isZoomedSV,
     isPinchingSV,
+    isPinching,
     scaleSV: scale,
     translateXSV: translateX,
     translateYSV: translateY,

--- a/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
@@ -70,13 +70,16 @@ type UseZoomPanGestureReturn = {
    * when the pinch activates — without the gate a small or slow pinch could also
    * paint a hold or open the role sheet. Stays false on boards with no pinchRef. */
   isPinchingSV: SharedValue<boolean>;
-  /** JS-thread mirror of isPinchingSV, true as soon as a 2nd finger touches down
-   * and cleared as soon as a fresh single-finger touch begins (same moments as
-   * the shared value — see its onTouchesDown in the pinch below). A host that
-   * sits inside a foreign, non-RNGH gesture surface (e.g. a native bottom sheet)
-   * can OR this with `isZoomed` to disable that surface's own pan for the
-   * duration, since RNGH's gesture-relation APIs can't reach outside its own
-   * tree. Stays false on boards with no pinchRef. */
+  /** JS-thread mirror of "2+ fingers are down on this board", true as soon as a
+   * 2nd finger touches down. Unlike isPinchingSV (which deliberately stays true
+   * past pinch-end for the per-hold tap-race guard above), this clears as soon
+   * as the pinch gesture instance ends — whether that's a fresh single-finger
+   * touch beginning or every finger lifting together, since a lift fires no
+   * touchesDown event at all. A host that sits inside a foreign, non-RNGH
+   * gesture surface (e.g. a native bottom sheet) can OR this with `isZoomed` to
+   * disable that surface's own pan for the duration, since RNGH's
+   * gesture-relation APIs can't reach outside its own tree. Stays false on
+   * boards with no pinchRef. */
   isPinching: boolean;
   /** Live zoom scale on the UI thread, so an overlay inside the transform can
    * convert screen-pixel drag deltas into unscaled board-pixel deltas. */
@@ -197,8 +200,12 @@ export function useZoomPanGesture({
   }, [containerHeight, containerHeightSV]);
 
   const [isZoomed, setIsZoomed] = useState(false);
-  // JS mirror of isPinchingSV — see isPinching in the return type.
+  // JS mirror of "2+ fingers down" — see isPinching in the return type. Tracked
+  // via its own shared value (NOT isPinchingSV, whose sticky-past-pinch-end
+  // semantics are for a different consumer) purely to gate the runOnJS bridge
+  // hop on an actual change.
   const [isPinching, setIsPinching] = useState(false);
+  const isPinchingMirrorSV = useSharedValue(false);
 
   const updateZoomState = useCallback(
     (zoomed: boolean) => {
@@ -349,14 +356,34 @@ export function useZoomPanGesture({
       pinch.onTouchesDown((event) => {
         'worklet';
         if (event.numberOfTouches >= 2) {
-          // Gate the JS mirror's bridge hop on an actual change — a 3rd+
-          // finger landing re-fires this branch without isPinchingSV having
-          // flipped.
-          if (!isPinchingSV.value) runOnJS(setIsPinching)(true);
           isPinchingSV.value = true;
+          // Gate the JS mirror's bridge hop on an actual change — a 3rd+
+          // finger landing re-fires this branch without it having flipped.
+          if (!isPinchingMirrorSV.value) {
+            isPinchingMirrorSV.value = true;
+            runOnJS(setIsPinching)(true);
+          }
         } else if (event.numberOfTouches === 1) {
-          if (isPinchingSV.value) runOnJS(setIsPinching)(false);
           isPinchingSV.value = false;
+          if (isPinchingMirrorSV.value) {
+            isPinchingMirrorSV.value = false;
+            runOnJS(setIsPinching)(false);
+          }
+        }
+      });
+      // Guaranteed clear point for the JS mirror. onTouchesDown above only
+      // fires for a NEW touch landing, never for a lift, so a pinch that ends
+      // with both fingers lifting together — or whose next touch lands
+      // outside the board entirely, e.g. dragging the create-climb sheet by
+      // its own handle — would otherwise leave isPinching stuck true and a
+      // host gating on it (CreateDrawer) permanently unable to re-enable its
+      // own pan. isPinchingSV is deliberately left untouched here — it keeps
+      // its own past-pinch-end semantics for the tap-race guard above.
+      pinch.onFinalize(() => {
+        'worklet';
+        if (isPinchingMirrorSV.value) {
+          isPinchingMirrorSV.value = false;
+          runOnJS(setIsPinching)(false);
         }
       });
     }
@@ -379,6 +406,7 @@ export function useZoomPanGesture({
     pinchScaleMinSV,
     isZoomedSV,
     isPinchingSV,
+    isPinchingMirrorSV,
     setIsPinching,
     enabledSV,
     containerWidthSV,

--- a/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
+++ b/packages/mobile/src/components/play-drawer/use-zoom-pan-gesture.ts
@@ -349,11 +349,14 @@ export function useZoomPanGesture({
       pinch.onTouchesDown((event) => {
         'worklet';
         if (event.numberOfTouches >= 2) {
+          // Gate the JS mirror's bridge hop on an actual change — a 3rd+
+          // finger landing re-fires this branch without isPinchingSV having
+          // flipped.
+          if (!isPinchingSV.value) runOnJS(setIsPinching)(true);
           isPinchingSV.value = true;
-          runOnJS(setIsPinching)(true);
         } else if (event.numberOfTouches === 1) {
+          if (isPinchingSV.value) runOnJS(setIsPinching)(false);
           isPinchingSV.value = false;
-          runOnJS(setIsPinching)(false);
         }
       });
     }


### PR DESCRIPTION
## Summary

- Pinch-zoom and pan on the create-climb board were unreliable on Android — either the sheet slid instead of the board zooming/panning, or the pinch got cancelled outright.
- `InteractiveCreateBoard` renders inside `@expo/ui/community/bottom-sheet`'s native sheet (Jetpack Compose on Android, SwiftUI on iOS). Two **separate** gesture surfaces there compete with the board's pinch/pan, and this PR went through two failed attempts before finding both:
  1. **The sheet's own drag-to-resize/dismiss.** First attempt gated `enableContentPanningGesture`/`enableHandlePanningGesture` — confirmed inert by device testing, then by reading `@expo/ui`'s source: its own `types.ts` says outright *"This prop is accepted for API compatibility but has no effect."* Neither `BottomSheet.android.tsx` nor `BottomSheet.ios.tsx` reads either prop; both drive their real gesture toggle from `enablePanDownToClose` alone. Fixed by deriving `enablePanDownToClose` from `!subSheetOpen && !boardInteractionActive` instead — the one prop both platforms actually wire up. This incidentally fixes the pre-existing `subSheetOpen` gating for the hold-role sub-sheet too, which was equally inert.
  2. **The content scroll.** Still unreliable after (1) — more device testing showed the pinch got cancelled specifically by vertical movement, reliable only when pinching along a careful horizontal axis. `@expo/ui`'s `BottomSheetScrollView` (wrapping all of CreateDrawer's content) is, per its own doc comment, *"a direct re-export of React Native's ScrollView"* — a classic Android View, not an RNGH gesture, so nothing could declare a relation to it. Its `onInterceptTouchEvent` could claim the touch stream on the first vertical-ish move, before the board's pinch (several views deeper, behind a Compose-bridge nested `GestureHandlerRootView`) had a chance to activate. Fixed by swapping in RNGH's own `ScrollView` and threading a `scrollRef`, so `useZoomPanGesture` can declare the same relation PlayDrawer already uses for its own surrounding scroll: pinch simultaneous with the scroll (never cancelled), zoomed-pan blocks the scroll (drags the board, not the sheet).
- Considered patching `@expo/ui` directly for (1) — verified with `expo-updates runtimeversion:resolve` that any edit to that package, even pure JS, bumps the Android OTA fingerprint (autolinking-config embeds pnpm's patch-hash directory suffix per module). That would force a store rebuild before this could reach anyone, including this PR's own OTA preview, so both fixes stayed app-source-only. Fingerprint verified unchanged from `main` after every commit.

## Release Notes

- Pinch-zoom and panning on the board now work smoothly while you're building a climb on Android.

## Test plan

1. Android → Create a new boulder problem → board loads.
2. Two-finger pinch on the board, in any direction → board zooms, sheet stays still.
3. While zoomed, one-finger drag in any direction → board pans, sheet stays still.
4. Tap a hold, then long-press → paints, then opens the role sheet.
5. iOS → repeat steps 1-4 → same result.

## Risk

Risk: 2/5 — the underlying bugs are Android-only (two separate gesture surfaces the board can't declare a relation to by default), both fixes are additive on both platforms, confirmed OTA-compatible (fingerprint verified unchanged after every commit), and mobile typecheck/tests/bundle check are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESKRXzVj6mNfhn8Aaz77Uk