### PR TITLE
feat(shared): the server draws the Aura the app draws

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,7 @@ jobs:
               - 'packages/shared/board-presence/**'
               - 'packages/shared/board-presence-react/**'
               - 'packages/shared/board-react/**'
+              - 'packages/shared/board-look/**'
               - 'packages/shared/board-render/**'
               - 'packages/shared/climb-actions/**'
               - 'packages/shared/climb-filters/**'

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,12 @@ packages/web/e2e/screenshots/
 # next.js
 .next/
 out/
+# Written (and re-written) by `next dev` — see
+# node_modules/next/dist/server/lib/generate-agent-files.js. Ignored rather than
+# committed so it stops turning up in the diff of whichever PR last ran the dev
+# server; the file is regenerated on demand and carries no repo-specific rules.
+packages/web/AGENTS.md
+packages/web/CLAUDE.md
 
 # production
 build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ We'll always create a PR, never asks if a PR should be created, open as a draft.
     /play-view/     # Play-drawer logic (queue nav, tick utils, grade display)
     /queue/         # Queue state machine (reducer, types, event utils)
     /board-config/  # Board metadata, hold maps, angle tables
+    /board-look/    # The Aura board look as data: tuning constants + the render-config fields they produce
     /board-react/   # Renderer-agnostic BoardProvider + logbook/tick hooks (useSaveTick/useUpdateTick/useDeleteTick)
     /offline-sync/  # Offline sync engine: mutation outbox + drainer, pull client, SQLite DDL (platform I/O injected)
     /profile-stats/ # Pure climbing-stats aggregation for the You page / profile (chart builders, deriveProfileViewModel)

--- a/docs/board-art-geometry.md
+++ b/docs/board-art-geometry.md
@@ -290,6 +290,29 @@ Metro, webpack, bare Node ESM and vitest at once.
 690 holds) — well under `scripts/check-large-files.mjs`'s 2 MB per-file limit, so no
 allowlist entry is needed.
 
+### Who reads it
+
+- **The mobile app** — `packages/mobile/src/hooks/use-native-climb-render.ts` loads the
+  shard for the board being drawn and attaches the lit holds' outlines to the native
+  render config.
+- **The server renderer** — `packages/backend/src/services/board-render.ts` does the same
+  for `/render/board` and `GET /og/climb`, so a share card and an in-app render draw the
+  same silhouettes. It reads `getWallLightness` too, for the veil.
+- **The tracer's own gates** and the iPad outline editor (`hold_outline_overrides` below).
+
+The renderer-facing half of the contract is `HoldGeometryInput` in
+`packages/shared/board-render/src/render-config.ts`: outlines, LED plates, LED offsets and
+silhouette lightness go in, per-hold `outline` / `led_inner` / `led` /
+`silhouette_lightness` come out on the WASM config. It is a parameter and not an import,
+so the browser can fetch the one config it needs rather than bundling all 51 shards.
+
+### `@boardsesh/board-art-geometry/spill`, `/veil`, `/types`
+
+Three more subpaths that reach nothing else, for the same reason `ring` exists: a config
+builder needs `isWithinSpillRange` or `veilOpacityFor`, not 3.0 MB of polygons.
+`packages/shared/board-render/src/render-config.ts` imports through them precisely so it
+stays safe to pull into a browser bundle.
+
 ### `@boardsesh/board-art-geometry/ring`
 
 Ring maths — `simplifyRing` (the tracer's own Douglas-Peucker, plus `SIMPLIFY_EPSILON`),

--- a/docs/og-climb.md
+++ b/docs/og-climb.md
@@ -33,12 +33,20 @@ so an aura render can never be served under a classic key. The base cache
 is keyed only by board config because overlay options do not change its board
 photo backdrop.
 
+An `aura` render here draws exactly what the app draws. The look's tuning —
+glow reach, the seam crossfade, the veil buckets, the fill alpha — lives in
+`@boardsesh/board-look` and is applied by `buildAuraRenderFields`, which the
+mobile native path and this pipeline both call. The per-hold half (traced
+silhouettes, LED plates, silhouette lightness) is read per board config from
+`@boardsesh/board-art-geometry`; a config the tracer skipped still renders, with
+every hold glowing a ring at its placement radius.
+
 | Param          | Default   | Meaning                                                                                                                                       |
 | -------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `render_mode`  | `classic` | `classic` (today's marker-only overlay) or `aura` (veil + glow on traced silhouettes).                                                      |
 | `glow_falloff` | `soft`    | `aura` mode only: glow edge treatment, `soft` or `plateau`.                                                                                 |
 | `glyphs`       | off       | `aura` mode only: `0`\|`1`\|`true`\|`false` — role glyphs inside the glow.                                                                   |
-| `field_color`  | unset     | `#rrggbb`; feeds the veil color. **No visible effect yet:** opacity is hardcoded to 0 for now — see the `TODO(#2202)` in the callers of `buildRenderConfig` — until `@boardsesh/board-art-geometry` supplies real wall-lightness data. |
+| `field_color`  | unset     | `#rrggbb`: the play field the veil washes the unlit wall toward. Unset means the light field, on which every board's wall is darker than the field, so `veilOpacityFor` turns the veil off. www and the share cards send `#181225`, the dark field the app's play view composites over. |
 
 ## How a render works
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -29,6 +29,7 @@
     "@boardsesh/board-art-geometry": "workspace:*",
     "@boardsesh/board-config": "workspace:*",
     "@boardsesh/board-constants": "workspace:*",
+    "@boardsesh/board-look": "workspace:*",
     "@boardsesh/board-render": "workspace:*",
     "@boardsesh/board-renderer-wasm": "workspace:*",
     "@boardsesh/crypto": "workspace:*",

--- a/packages/backend/src/__tests__/board-render-service.test.ts
+++ b/packages/backend/src/__tests__/board-render-service.test.ts
@@ -51,6 +51,51 @@ describe('board renderer initialization', () => {
   }, 30_000);
 });
 
+describe('prepareRender — what an Aura request actually sends', () => {
+  // Kilter Original 12x12: traced (99.1% of placements) and bright enough to
+  // take a veil against the dark field. `p1080r15` lights hold 1080.
+  const auraParams = { ...standardParams, renderMode: 'aura' as const };
+
+  it('sends the shipped Aura tuning, not the renderer defaults', () => {
+    // The regression this guards: the server used to emit only render_mode /
+    // glow_falloff / glyphs, so an OG card drew the Rust neutral glow — a
+    // flatter light with a hard colour seam between neighbouring roles — while
+    // the app drew the tuned one from the same climb.
+    const { config } = service.prepareRender(auraParams);
+    expect(config.render_mode).toBe('aura');
+    expect(config.mark_style).toBe('glow');
+    expect(config.glow).toMatchObject({ spread_fraction: 0.91, seam_sharpness: 3, merge_softness: 0.6 });
+    expect(config.fill).toEqual({ opacity: 0.55 });
+  });
+
+  it('attaches the traced silhouette to the lit holds', () => {
+    const { config } = service.prepareRender(auraParams);
+    const lit = config.holds.find((hold) => hold.id === 1080);
+    expect(lit?.outline?.length).toBeGreaterThan(0);
+    // An unlit, un-neighboured hold carries no polygon — the config would
+    // otherwise ship all ~500 of the board's outlines on every request.
+    expect(config.holds.filter((hold) => hold.outline !== undefined).length).toBeLessThan(config.holds.length);
+  });
+
+  it('washes the wall against the dark field and leaves it alone on the light one', () => {
+    const { veil } = service.prepareRender({ ...auraParams, fieldColor: '#181225' }).config;
+    expect(veil?.color).toBe('#181225');
+    expect(veil?.opacity).toBeGreaterThan(0);
+
+    // No field named means the light field, on which every board's wall is
+    // darker than the field — nothing to quiet, so no veil at all.
+    expect(service.prepareRender(auraParams).config.veil).toBeUndefined();
+  });
+
+  it('leaves a classic request byte-identical to what it always was', () => {
+    const { config } = service.prepareRender(standardParams);
+    expect(config.render_mode).toBeUndefined();
+    expect(config.glow).toBeUndefined();
+    expect(config.veil).toBeUndefined();
+    for (const hold of config.holds) expect(hold.outline).toBeUndefined();
+  });
+});
+
 describe('board renderer memory and concurrency core', () => {
   beforeEach(async () => {
     await service.initBoardRenderer();
@@ -91,6 +136,23 @@ describe('board renderer memory and concurrency core', () => {
     expect(standardParams).not.toHaveProperty('v');
     const versionAlias = { ...standardParams, v: '0123456789ab' };
     expect(service.buildBoardRenderByteCacheKey(versionAlias)).toBe(baseKey);
+  });
+
+  it('keys an unnamed field colour the same as an explicit light one', () => {
+    // Both draw the same pixels — the light field is what "unset" means — so
+    // minting two cache entries for them would be paying twice for one render.
+    const auraParams = { ...standardParams, renderMode: 'aura' as const };
+    expect(service.buildBoardRenderByteCacheKey({ ...auraParams, fieldColor: '#FFFFFF' })).toBe(
+      service.buildBoardRenderByteCacheKey(auraParams),
+    );
+    // Case is not a third variant either.
+    expect(service.buildBoardRenderByteCacheKey({ ...auraParams, fieldColor: '#ffffff' })).toBe(
+      service.buildBoardRenderByteCacheKey(auraParams),
+    );
+    // A real wash still keys apart from no wash.
+    expect(service.buildBoardRenderByteCacheKey({ ...auraParams, fieldColor: '#181225' })).not.toBe(
+      service.buildBoardRenderByteCacheKey(auraParams),
+    );
   });
 
   it('normalizes classic render options and the default light art in the byte key', () => {

--- a/packages/backend/src/services/board-render.ts
+++ b/packages/backend/src/services/board-render.ts
@@ -2,6 +2,8 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
+import { getWallLightness, loadBoardArtGeometry } from '@boardsesh/board-art-geometry';
+import { BOARD_FIELD_COLORS } from '@boardsesh/board-look';
 import { HOLD_STATE_MAP } from '@boardsesh/board-constants/hold-states';
 import {
   BoundedLru,
@@ -193,13 +195,17 @@ export type BoardImageRenderParams = {
   setIds: string;
   frames: string;
   format: OutputFormat;
-  /** "boardsesh" draws the veil + glow treatment; omitted/"classic" renders exactly as today (issue #2202). */
+  /** "aura" draws the veil + glow treatment; omitted/"classic" renders exactly as today (issue #2202). */
   renderMode?: 'classic' | 'aura';
-  /** `boardsesh` mode only. Renderer defaults to "soft" when omitted. */
+  /** `aura` mode only. The look's own default is "soft". */
   glowFalloff?: 'soft' | 'plateau';
-  /** `boardsesh` mode only: role glyphs inside the glow. */
+  /** `aura` mode only: role glyphs inside the glow. */
   glyphs?: boolean;
-  /** `boardsesh` mode only: feeds the placeholder veil color in prepareRender. */
+  /**
+   * `aura` mode only: the play field the veil washes the unlit wall toward.
+   * Omitted means the light field, on which every board's wall is darker than
+   * the field and the veil resolves to nothing.
+   */
   fieldColor?: string;
   colorScheme?: BoardArtColorScheme;
   thumbnail: boolean;
@@ -244,9 +250,9 @@ function isOgClimbRenderResult(
 }
 
 /**
- * Render-option suffix on the byte cache key, so a boardsesh render — and any
+ * Render-option suffix on the byte cache key, so an Aura render — and any
  * combination of its options — can never be served under a classic (or a
- * different boardsesh option's) key. The base cache does NOT carry it: the
+ * different Aura option's) key. The base cache does NOT carry it: the
  * base is the board-photo backdrop the overlay is composited onto, which no
  * overlay option can change, so one base serves every mode and the boot
  * warm-up is not wasted on the first boardsesh request.
@@ -261,7 +267,11 @@ function renderOptionsCacheKeySuffix(options: {
   // `classic` whatever a caller happened to pass — an explicit `glow_falloff`
   // on a classic request must hit the same entry as the request without it.
   if (options.renderMode !== 'aura') return 'classic';
-  return `boardsesh:${options.glowFalloff ?? 'soft'}:${options.glyphs ? '1' : '0'}:${options.fieldColor ?? 'unset'}`;
+  // `fieldColor` is normalised, not passed through: an unset field means the
+  // light field, so a caller that names `#FFFFFF` and one that names nothing
+  // draw the same pixels and must not mint two entries for them.
+  const fieldColor = (options.fieldColor ?? BOARD_FIELD_COLORS.light).toLowerCase();
+  return `boardsesh:${options.glowFalloff ?? 'soft'}:${options.glyphs ? '1' : '0'}:${fieldColor}`;
 }
 
 export function buildBoardRenderByteCacheKey(params: BoardImageRenderParams): string {
@@ -283,7 +293,13 @@ export function buildBoardRenderByteCacheKey(params: BoardImageRenderParams): st
   ].join(':');
 }
 
-function prepareRender(params: BoardImageRenderParams): {
+/**
+ * Assemble the WASM config for one request: board details, the traced art for
+ * this board config, and the veil measured against the requested play field.
+ * Pure — no I/O beyond the memoised shard read, and no renderer. Exported for
+ * the tests that pin what an Aura request actually sends.
+ */
+export function prepareRender(params: BoardImageRenderParams): {
   boardDetails: RenderableBoardDetails;
   config: WasmRenderConfig;
 } {
@@ -305,6 +321,19 @@ function prepareRender(params: BoardImageRenderParams): {
   } catch {
     throw new InvalidBoardRenderConfigError();
   }
+
+  const isAura = params.renderMode === 'aura';
+  const geometryQuery = {
+    boardName: params.boardName as BoardName,
+    layoutId: params.layoutId,
+    sizeId: params.sizeId,
+  };
+  // The traced art for this board config, and the reading of its wall the
+  // `auto` veil is bucketed from. Both are `null` for a config the tracer
+  // skipped, which is a normal answer: every hold falls back to a ring at its
+  // placement radius and the wall goes unwashed. The shard loader memoises per
+  // board key, so a burst of climbs on one wall reads it once.
+  const geometry = isAura ? loadBoardArtGeometry(geometryQuery) : null;
   const { config } = buildRenderConfig({
     boardName: params.boardName,
     boardDetails,
@@ -315,10 +344,22 @@ function prepareRender(params: BoardImageRenderParams): {
     renderMode: params.renderMode,
     glowFalloff: params.glowFalloff,
     glyphs: params.glyphs,
-    // TODO(#2202): veil opacity from @boardsesh/board-art-geometry — nothing
-    // computes real wall-lightness data yet, so boardsesh mode ships a no-op
-    // (opacity 0) veil until that package lands.
-    ...(params.renderMode === 'aura' ? { veil: { color: params.fieldColor ?? '#181225', opacity: 0 } } : {}),
+    ...(isAura
+      ? {
+          fieldColor: params.fieldColor,
+          wallLightness: getWallLightness(geometryQuery),
+          ...(geometry
+            ? {
+                holdGeometry: {
+                  outlines: geometry.outlines,
+                  ledInner: geometry.ledInner,
+                  ledBright: geometry.ledBright,
+                  silhouetteLightness: geometry.silhouetteLightness,
+                },
+              }
+            : {}),
+        }
+      : {}),
   });
   const outputHeight = Math.round((config.output_width * config.board_height) / config.board_width);
   if (config.output_width * outputHeight > MAX_RENDER_OUTPUT_PIXELS) {

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -14,6 +14,7 @@
     "@boardsesh/board-art-geometry": "workspace:*",
     "@boardsesh/board-config": "workspace:*",
     "@boardsesh/board-constants": "workspace:*",
+    "@boardsesh/board-look": "workspace:*",
     "@boardsesh/board-presence-react": "workspace:*",
     "@boardsesh/board-react": "workspace:*",
     "@boardsesh/climb-actions": "workspace:*",

--- a/packages/mobile/src/hooks/use-native-climb-render.ts
+++ b/packages/mobile/src/hooks/use-native-climb-render.ts
@@ -46,13 +46,10 @@ import {
   type HoldColorOverrides,
   type HoldShapeOverrides,
 } from '../lib/hold-color-overrides';
+import { buildAuraRenderFields } from '@boardsesh/board-look';
 import {
-  BOARDSESH_SMALL_HOLD_MAX_BOOST,
-  BOARDSESH_SMALL_HOLD_NO_BOOST,
-  BOARDSESH_SOFT_DISC_OPACITY,
   boardFieldColorForScheme,
   buildBoardRenderSignature,
-  AURA_GLOW_TUNING,
   requestedBoardRenderMode,
   resolveEffectiveRenderSettings,
   resolveVeilOpacity,
@@ -1101,7 +1098,16 @@ function getBoardConfig(
       hold_state_map: holdStateMap,
       // Nothing below this line exists for a classic config, which must stay
       // byte-identical to what every cached PNG was drawn from.
-      ...(boardsesh ? buildBoardseshFields(boardsesh, filledStyle, ledOffsets) : {}),
+      ...(boardsesh
+        ? buildAuraRenderFields({
+            settings: boardsesh.settings,
+            glowFalloff: boardsesh.glowFalloff,
+            fieldColor: boardsesh.fieldColor,
+            veilOpacity: boardsesh.veilOpacity,
+            thumbnail: filledStyle,
+            hasLedOffsets: ledOffsets !== null && Object.keys(ledOffsets).length > 0,
+          })
+        : {}),
     };
 
     // Evict oldest entry when the cache exceeds the cap
@@ -1142,48 +1148,6 @@ function getBoardConfig(
       ),
     },
     setIdsArray: cached.setIdsArray,
-  };
-}
-
-/** The board-level half of a Boardsesh config — everything that is not per hold. */
-function buildBoardseshFields(
-  boardsesh: BoardseshConfigInputs,
-  filledStyle: boolean,
-  ledOffsets: Record<number, [number, number]> | null,
-): Record<string, unknown> {
-  const { settings, glowFalloff, fieldColor, veilOpacity } = boardsesh;
-  return {
-    render_mode: 'aura',
-    // Omitted entirely at zero rather than sent as `opacity: 0`: a light-mode
-    // field is brighter than every board's wall, so there is nothing to quiet.
-    ...(veilOpacity > 0 ? { veil: { color: fieldColor, opacity: veilOpacity } } : {}),
-    // A bare glow reads faint once a thumbnail is scaled to ~76px, so the small
-    // surface takes the fill under it unless the climber asked for the glow.
-    // `'fill'` maps to `'glow-fill'`, not a bare fill, on purpose: the spike
-    // measured the filled thumbnail WITH its own small glow (the "veil + tint"
-    // arm) as the winner, not the fill alone.
-    mark_style: filledStyle ? (settings.thumbnailStyle === 'glow' ? 'glow' : 'glow-fill') : settings.markStyle,
-    glow_falloff: glowFalloff,
-    glow: {
-      reach_scale: settings.glowReach,
-      plateau_share: settings.plateauShare,
-      disc_opacity: settings.softDisc ? BOARDSESH_SOFT_DISC_OPACITY : 0,
-      small_hold_max_boost: settings.smallHoldBoost ? BOARDSESH_SMALL_HOLD_MAX_BOOST : BOARDSESH_SMALL_HOLD_NO_BOOST,
-      // The Aura glow. Unconditional at full size since the Glow-style knob
-      // was retired — there is no `plain` to fall back to any more. Still
-      // skipped on thumbnails: at 200px the difference is invisible and the
-      // wider distance field is ~2.5× the render. Only binaries built with
-      // these Rust fields can ever receive this JS — the committed renderer
-      // artifacts moved the native fingerprint together with it — so there is
-      // no silent-ignore path to gate against.
-      ...(filledStyle ? {} : AURA_GLOW_TUNING),
-    },
-    fill: { opacity: settings.fillOpacity },
-    glyphs: settings.roleGlyphs ? 'role' : 'off',
-    // `{}` takes the renderer's own tuned cover. Sent only where the board art
-    // actually paints LEDs bright — Kilter draws a dark bolt hole, so its table
-    // is empty and a cover there would be ink spent on nothing.
-    ...(settings.ledDots && ledOffsets && Object.keys(ledOffsets).length > 0 ? { led_cover: {} } : {}),
   };
 }
 

--- a/packages/mobile/src/lib/board-render-settings.ts
+++ b/packages/mobile/src/lib/board-render-settings.ts
@@ -1,7 +1,44 @@
 import { useCallback, useEffect, useSyncExternalStore } from 'react';
-import { veilOpacityFor, type WallLightness } from '@boardsesh/board-art-geometry';
+import {
+  BOARD_RENDER_SETTING_BOUNDS,
+  DEFAULT_BOARDSESH_RENDER_SETTINGS,
+  GLOW_FALLOFF_SETTINGS,
+  HOLD_SHAPE_SETTINGS,
+  MARK_STYLE_SETTINGS,
+  THUMBNAIL_STYLE_SETTINGS,
+  VEIL_SETTINGS,
+  type BoardseshRenderSettings,
+} from '@boardsesh/board-look';
 import { getPreference, removePreference, setPreference } from './preference-store';
 import { SCREENSHOT_RENDER_MODE } from './screenshot-mode';
+
+/**
+ * The look's tuning — every constant, every default and `resolveVeilOpacity` —
+ * lives in `@boardsesh/board-look` so www, the OG cards and the backend draw
+ * Aura with the same numbers this app does. Re-exported here because the mobile
+ * codebase reaches for them through this module, and because this is where the
+ * climber's stored preference turns into them.
+ */
+export type {
+  BoardseshRenderSettings,
+  GlowFalloffSetting,
+  HoldShapeSetting,
+  MarkStyleSetting,
+  ThumbnailStyleSetting,
+  VeilSetting,
+} from '@boardsesh/board-look';
+export {
+  AURA_GLOW_TUNING,
+  BOARD_FIELD_COLORS,
+  BOARD_RENDER_SETTING_BOUNDS,
+  BOARDSESH_SMALL_HOLD_MAX_BOOST,
+  BOARDSESH_SMALL_HOLD_NO_BOOST,
+  BOARDSESH_SOFT_DISC_OPACITY,
+  DEFAULT_BOARDSESH_RENDER_SETTINGS,
+  VEIL_SETTING_OPACITY,
+  boardFieldColorForScheme,
+  resolveVeilOpacity,
+} from '@boardsesh/board-look';
 
 /**
  * Which board drawing the app renders, and every knob the Aura drawing
@@ -35,58 +72,6 @@ import { SCREENSHOT_RENDER_MODE } from './screenshot-mode';
  * `core/src/aura/` module path in every committed binary.
  */
 export type BoardRenderModeSetting = 'default' | 'classic' | 'aura';
-/** The glow's alpha curve. `default` defers to the rollout flag, then to `soft`. */
-export type GlowFalloffSetting = 'default' | 'soft' | 'plateau';
-/**
- * How hard the field-colour veil washes the unlit wall. `auto` measures the
- * board's own art against the field (`veilOpacityFor`); the rest are fixed.
- */
-export type VeilSetting = 'auto' | 'off' | 'soft' | 'strong' | 'custom';
-/** What the Aura drawing puts on a lit hold at full size. */
-export type MarkStyleSetting = 'glow' | 'glow-fill' | 'fill';
-/**
- * The same choice for a list thumbnail, where a bare glow reads faint at
- * ~76px. `fill` renders as `glow-fill`, not a bare fill — the spike's
- * winning thumbnail arm was the filled mark WITH its own small glow
- * ("veil + tint"), so that pairing is what this maps to (see
- * `buildBoardseshFields` in `use-native-climb-render.ts`).
- */
-export type ThumbnailStyleSetting = 'fill' | 'glow';
-/**
- * What the Aura drawing lights on a hold: the traced silhouette from
- * `@boardsesh/board-art-geometry`, or the placement circle.
- *
- * `'circle'` is not a fallback — it is the Modern Classic look. The renderer
- * already draws the placement circle for any hold the tracer skipped
- * (`aura/geometry.rs`), so withholding the outlines is all it takes: the veil
- * punches circles out of the wash and the glow follows them, with no Rust
- * change and no new binary.
- */
-export type HoldShapeSetting = 'silhouette' | 'circle';
-export type BoardseshRenderSettings = {
-  glowFalloff: GlowFalloffSetting;
-  /** Overall glow reach multiplier. */
-  glowReach: number;
-  /** `plateau` falloff only: the share of the reach held at full alpha. */
-  plateauShare: number;
-  veil: VeilSetting;
-  /** `custom` veil only: the wash's alpha. */
-  veilOpacity: number;
-  markStyle: MarkStyleSetting;
-  /** `fill` / `glow-fill` only: alpha of the role-colour fill. */
-  fillOpacity: number;
-  /** The soft disc under the glow — the spike's rejected arm, kept as an A/B. */
-  softDisc: boolean;
-  /** Give a fingernail-sized foot chip a bigger glow instead of a second mark. */
-  smallHoldBoost: boolean;
-  /** Cover the LED pips the board art itself paints bright. */
-  ledDots: boolean;
-  /** Opt-in accessibility glyphs (FOOT ring, STARTING bar, HAND bar, FINISH X). */
-  roleGlyphs: boolean;
-  thumbnailStyle: ThumbnailStyleSetting;
-  holdShape: HoldShapeSetting;
-};
-
 export type BoardRenderSettings = {
   mode: BoardRenderModeSetting;
   boardsesh: BoardseshRenderSettings;
@@ -112,11 +97,6 @@ export type EffectiveBoardRenderSettings = {
 };
 
 const BOARD_RENDER_MODE_SETTINGS = ['default', 'classic', 'aura'] as const;
-const GLOW_FALLOFF_SETTINGS = ['default', 'soft', 'plateau'] as const;
-const VEIL_SETTINGS = ['auto', 'off', 'soft', 'strong', 'custom'] as const;
-const MARK_STYLE_SETTINGS = ['glow', 'glow-fill', 'fill'] as const;
-const THUMBNAIL_STYLE_SETTINGS = ['fill', 'glow'] as const;
-const HOLD_SHAPE_SETTINGS = ['silhouette', 'circle'] as const;
 
 export const BOARD_RENDER_MODE_OPTIONS = BOARD_RENDER_MODE_SETTINGS;
 export const GLOW_FALLOFF_OPTIONS = GLOW_FALLOFF_SETTINGS;
@@ -125,108 +105,10 @@ export const MARK_STYLE_OPTIONS = MARK_STYLE_SETTINGS;
 export const THUMBNAIL_STYLE_OPTIONS = THUMBNAIL_STYLE_SETTINGS;
 export const HOLD_SHAPE_OPTIONS = HOLD_SHAPE_SETTINGS;
 
-/** Slider ranges, exported so the settings screen and the clamps cannot drift. */
-export const BOARD_RENDER_SETTING_BOUNDS = {
-  glowReach: { min: 0.5, max: 2 },
-  plateauShare: { min: 0.2, max: 0.7 },
-  veilOpacity: { min: 0, max: 0.9 },
-  fillOpacity: { min: 0.3, max: 0.9 },
-} as const;
-
-/**
- * The two fixed veil buckets, matching `VEIL_TUNING`'s soft and strong opacities
- * — a climber who overrides `auto` is choosing one of the same two washes the
- * measurement would have picked, not a third strength.
- */
-export const VEIL_SETTING_OPACITY = { off: 0, soft: 0.3, strong: 0.6 } as const;
-
-/** Peak alpha of the optional soft disc under the glow. */
-export const BOARDSESH_SOFT_DISC_OPACITY = 0.3;
-/** The renderer's own small-hold boost ceiling, and the value that turns it off. */
-export const BOARDSESH_SMALL_HOLD_MAX_BOOST = 1.7;
-export const BOARDSESH_SMALL_HOLD_NO_BOOST = 1;
-
-/**
- * The Aura glow, as renderer tuning, spread into the config's `glow` object
- * (snake_case: the Rust `GlowTuning` fields).
- *
- * Unconditional at full size since the Glow-style knob was retired: `plain`
- * was the flat per-hold glow the drawing launched with, and it lost on every
- * board the glow lab measured, so keeping it as a setting only offered a worse
- * render under a name that collided with the look's own.
- * The owner's pick from PR #4972's three-way design review, tuned in the glow
- * lab against real climbs on five boards:
- *
- * - `spread_fraction` 0.91 is the reach-1.3 look shipped WITHOUT touching
- *   `reach_scale`, so the climber's Glow-reach slider keeps multiplying on
- *   top (pixel-identical to a reach_scale of 1.3 — verified RMSE 0).
- * - `merge_softness` fuses same-colour neighbours across their bisector (the
- *   dark V-notch the plain glow shows between adjacent holds).
- * - The seam pair replaces the hard colour switch between DIFFERENT-colour
- *   neighbours with a continuous, power-curved crossfade: `seam_sharpness` 3
- *   keeps the blend at a true 50/50 exactly on the bisector (a capped mix
- *   left a visible hard line there — the Grasshopper pie-slice bug) while
- *   collapsing to near-pure hold colour within a few pixels, so the
- *   ambiguous mid-mix (which can read as a THIRD role, worse under the CVD
- *   palettes) is confined to a thin sliver instead of an area.
- * - `fringe_deepen` keeps the falloff coloured to its edge instead of greying.
- * - No spill, no rim, no gamma, no white core: the review measured spill at
- *   this reach inventing lit-looking holds, and the stylised looks lost to
- *   the drawing's own character.
- *
- * Thumbnails skip the bundle (`buildBoardseshFields`): at 200px the
- * difference is invisible and the extra distance-field work is ~2.5× the
- * render. Every field left unnamed stays at its neutral Rust default; an old
- * binary would ignore these fields — safe only because they ship inside a
- * native-fingerprint bump (see the PR).
- */
-// `seam_max_mix` is deliberately OMITTED: its Rust default (0.5) is
-// load-bearing — the crossfade must reach a true 50/50 on the bisector for
-// colour continuity; any lower cap re-creates the hard seam line.
-export const AURA_GLOW_TUNING = {
-  spread_fraction: 0.91,
-  merge_softness: 0.6,
-  seam_blend_fraction: 0.9,
-  seam_sharpness: 3.0,
-  fringe_deepen: 0.4,
-} as const;
-
-export const DEFAULT_BOARDSESH_RENDER_SETTINGS: BoardseshRenderSettings = {
-  glowFalloff: 'default',
-  glowReach: 1,
-  plateauShare: 0.4,
-  veil: 'auto',
-  veilOpacity: 0.6,
-  markStyle: 'glow',
-  fillOpacity: 0.55,
-  softDisc: false,
-  smallHoldBoost: true,
-  ledDots: true,
-  roleGlyphs: false,
-  thumbnailStyle: 'fill',
-  holdShape: 'silhouette',
-};
-
 export const DEFAULT_BOARD_RENDER_SETTINGS: BoardRenderSettings = {
   mode: 'default',
   boardsesh: DEFAULT_BOARDSESH_RENDER_SETTINGS,
 };
-
-/**
- * The play field the veil washes toward, per colour scheme — the theme's
- * `secondaryBackground` (`packages/mobile/src/theme/colors.ts`), restated as a
- * plain hex because that module resolves to an iOS `PlatformColor` the veil
- * cannot subtract a lightness from. Pinned by a test against the theme so the
- * two cannot drift.
- *
- * On the white light-mode field every board's wall is DARKER than the field, so
- * `veilOpacityFor` turns the veil off there without a special case.
- */
-export const BOARD_FIELD_COLORS = { light: '#FFFFFF', dark: '#181225' } as const;
-
-export function boardFieldColorForScheme(colorScheme: 'light' | 'dark'): string {
-  return BOARD_FIELD_COLORS[colorScheme];
-}
 
 const STORAGE_KEY = 'boardRenderSettings';
 
@@ -336,35 +218,6 @@ export function resolveEffectiveRenderSettings(
     boardsesh: settings.boardsesh,
     rendererAvailable,
   };
-}
-
-/**
- * How hard the veil washes this board, given the climber's choice and the
- * board's own measured wall.
- *
- * `auto` with no wall row is 0, not a guess: a board the tracer skipped (both
- * Woods sizes) has no reading to bucket, and washing an unmeasured wall is how
- * a field colour ends up brighter than the art it was meant to quiet.
- */
-export function resolveVeilOpacity(
-  settings: BoardseshRenderSettings,
-  wallLightness: WallLightness | null,
-  fieldColor: string,
-): number {
-  switch (settings.veil) {
-    case 'off':
-      return VEIL_SETTING_OPACITY.off;
-    case 'soft':
-      return VEIL_SETTING_OPACITY.soft;
-    case 'strong':
-      return VEIL_SETTING_OPACITY.strong;
-    case 'custom':
-      return settings.veilOpacity;
-    case 'auto':
-      return wallLightness
-        ? veilOpacityFor({ wallLightness: wallLightness.mean, coverage: wallLightness.coverage, fieldColor })
-        : 0;
-  }
 }
 
 function formatSettingNumber(value: number): string {

--- a/packages/shared/board-art-geometry/package.json
+++ b/packages/shared/board-art-geometry/package.json
@@ -20,6 +20,11 @@
       "import": "./src/ring.ts",
       "default": "./src/ring.ts"
     },
+    "./spill": {
+      "types": "./src/spill.ts",
+      "import": "./src/spill.ts",
+      "default": "./src/spill.ts"
+    },
     "./veil": {
       "types": "./src/veil.ts",
       "import": "./src/veil.ts",

--- a/packages/shared/board-look/README.md
+++ b/packages/shared/board-look/README.md
@@ -1,0 +1,43 @@
+# @boardsesh/board-look
+
+The Aura board look, as data: its tuning constants and the render-config fields
+they produce.
+
+Aura is the app's default drawing since 2.4 — a field-colour veil over the unlit
+wall with each lit hold's traced silhouette glowing out of it. The look is
+defined by ~20 numbers (glow reach, seam crossfade, veil buckets, fill alpha),
+and every renderer has to send the same ones or it draws a different picture from
+the same climb.
+
+Those numbers used to live in `packages/mobile/src/lib/board-render-settings.ts`
+next to the preference store, which imports React — so www and the backend could
+not read them. Their Aura renders fell back to the Rust `GlowTuning` defaults and
+drew a flatter, seam-notched glow than the app. This package is the fix: pure
+data and pure functions, no React, no renderer, importable from mobile, web and
+the backend alike.
+
+## What is here
+
+- `settings.ts` — the setting types, their option lists and slider bounds, the
+  shipped defaults (`DEFAULT_BOARDSESH_RENDER_SETTINGS`), the glow tuning
+  (`AURA_GLOW_TUNING`), the play-field colours, and `resolveVeilOpacity`.
+- `aura-fields.ts` — `buildAuraRenderFields`, which turns a settings object plus
+  the per-board veil measurement into the snake_case block the Rust renderer
+  consumes (`render_mode`, `veil`, `mark_style`, `glow_falloff`, `glow`, `fill`,
+  `glyphs`, `led_cover`).
+
+## What is not
+
+The preference store, its sanitisers and migrations, the native capability probe
+and the board-look onboarding step stay in `packages/mobile` — they are
+preference plumbing, not tuning. The per-hold half of the config (silhouette
+outlines, LED plates, silhouette lightness) comes from
+`@boardsesh/board-art-geometry` and is assembled by each renderer's config
+builder.
+
+## Naming
+
+The identifiers keep the pre-2.4 `boardsesh` spelling (`BoardseshRenderSettings`,
+`DEFAULT_BOARDSESH_RENDER_SETTINGS`). Only the wire values were renamed to
+`aura`; renaming the ~90 mobile call sites would buy a string nobody sees. New
+names added here use `aura`.

--- a/packages/shared/board-look/package.json
+++ b/packages/shared/board-look/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@boardsesh/board-look",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@boardsesh/board-art-geometry": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "~7.0.2"
+  }
+}

--- a/packages/shared/board-look/src/__tests__/aura-fields.test.ts
+++ b/packages/shared/board-look/src/__tests__/aura-fields.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { buildAuraRenderFields } from '../aura-fields';
+import { BOARD_FIELD_COLORS, DEFAULT_BOARDSESH_RENDER_SETTINGS, resolveVeilOpacity } from '../settings';
+
+// A wall bright enough to take the strong veil bucket against the dark field
+// (gap 0.541 - 0.200 = 0.341, over `veilStrongGap`), with enough of the board
+// carrying an art reading to be allowed it. Tension Original's real numbers.
+const brightWall = { mean: 0.541, coverage: 0.9 };
+
+const baseInput = {
+  settings: DEFAULT_BOARDSESH_RENDER_SETTINGS,
+  glowFalloff: 'soft' as const,
+  fieldColor: BOARD_FIELD_COLORS.dark,
+  veilOpacity: 0,
+  thumbnail: false,
+  hasLedOffsets: false,
+};
+
+describe('buildAuraRenderFields', () => {
+  it('draws the shipped look, field for field', () => {
+    // A frozen literal, not a computed expectation: these numbers ARE the
+    // drawing. Every renderer sends them, and a cached render lives a year
+    // behind an immutable header, so a change here has to be a change somebody
+    // meant to make.
+    expect(buildAuraRenderFields(baseInput)).toEqual({
+      render_mode: 'aura',
+      mark_style: 'glow',
+      glow_falloff: 'soft',
+      glow: {
+        reach_scale: 1,
+        plateau_share: 0.4,
+        disc_opacity: 0,
+        small_hold_max_boost: 1.7,
+        spread_fraction: 0.91,
+        merge_softness: 0.6,
+        seam_blend_fraction: 0.9,
+        seam_sharpness: 3,
+        fringe_deepen: 0.4,
+      },
+      fill: { opacity: 0.55 },
+      glyphs: 'off',
+    });
+  });
+
+  it("collapses the 'default' falloff itself rather than trusting the caller to", () => {
+    // `'default'` is a setting value, not something the Rust renderer
+    // understands. Resolving it here means a caller that forgets cannot hand the
+    // string through to the renderer — there would be no type error to catch it.
+    expect(buildAuraRenderFields({ ...baseInput, glowFalloff: 'default' }).glow_falloff).toBe('soft');
+    expect(buildAuraRenderFields({ ...baseInput, glowFalloff: 'plateau' }).glow_falloff).toBe('plateau');
+  });
+
+  it('drops the glow bundle on a thumbnail and puts the fill under the mark', () => {
+    const fields = buildAuraRenderFields({ ...baseInput, thumbnail: true });
+    expect(fields.mark_style).toBe('glow-fill');
+    expect(fields.glow).toEqual({
+      reach_scale: 1,
+      plateau_share: 0.4,
+      disc_opacity: 0,
+      small_hold_max_boost: 1.7,
+    });
+  });
+
+  it('keeps the bare glow on a thumbnail when the climber asked for it', () => {
+    const settings = { ...DEFAULT_BOARDSESH_RENDER_SETTINGS, thumbnailStyle: 'glow' as const };
+    expect(buildAuraRenderFields({ ...baseInput, settings, thumbnail: true }).mark_style).toBe('glow');
+  });
+
+  it('omits the veil at zero rather than sending opacity 0', () => {
+    // A light-mode field is brighter than every board's wall, so there is
+    // nothing to quiet — and `opacity: 0` would still cost a cache variant.
+    expect(buildAuraRenderFields(baseInput).veil).toBeUndefined();
+    expect(buildAuraRenderFields({ ...baseInput, veilOpacity: 0.6 }).veil).toEqual({
+      color: BOARD_FIELD_COLORS.dark,
+      opacity: 0.6,
+    });
+  });
+
+  it('covers the painted LED pips only where the art paints them', () => {
+    expect(buildAuraRenderFields(baseInput).led_cover).toBeUndefined();
+    expect(buildAuraRenderFields({ ...baseInput, hasLedOffsets: true }).led_cover).toEqual({});
+
+    const settings = { ...DEFAULT_BOARDSESH_RENDER_SETTINGS, ledDots: false };
+    expect(buildAuraRenderFields({ ...baseInput, settings, hasLedOffsets: true }).led_cover).toBeUndefined();
+  });
+
+  it('turns the soft disc and the small-hold boost into their renderer values', () => {
+    const settings = { ...DEFAULT_BOARDSESH_RENDER_SETTINGS, softDisc: true, smallHoldBoost: false };
+    const { glow } = buildAuraRenderFields({ ...baseInput, settings });
+    expect(glow.disc_opacity).toBe(0.3);
+    expect(glow.small_hold_max_boost).toBe(1);
+  });
+});
+
+describe('resolveVeilOpacity', () => {
+  it('washes a bright wall against the dark field and nothing against the light one', () => {
+    expect(resolveVeilOpacity(DEFAULT_BOARDSESH_RENDER_SETTINGS, brightWall, BOARD_FIELD_COLORS.dark)).toBe(0.6);
+    expect(resolveVeilOpacity(DEFAULT_BOARDSESH_RENDER_SETTINGS, brightWall, BOARD_FIELD_COLORS.light)).toBe(0);
+  });
+
+  it('does not guess at an unmeasured wall', () => {
+    expect(resolveVeilOpacity(DEFAULT_BOARDSESH_RENDER_SETTINGS, null, BOARD_FIELD_COLORS.dark)).toBe(0);
+  });
+
+  it('takes a fixed bucket over the measurement when the climber picked one', () => {
+    const fixed = { ...DEFAULT_BOARDSESH_RENDER_SETTINGS, veil: 'soft' as const };
+    expect(resolveVeilOpacity(fixed, brightWall, BOARD_FIELD_COLORS.dark)).toBe(0.3);
+
+    const off = { ...DEFAULT_BOARDSESH_RENDER_SETTINGS, veil: 'off' as const };
+    expect(resolveVeilOpacity(off, brightWall, BOARD_FIELD_COLORS.dark)).toBe(0);
+
+    const custom = { ...DEFAULT_BOARDSESH_RENDER_SETTINGS, veil: 'custom' as const, veilOpacity: 0.42 };
+    expect(resolveVeilOpacity(custom, brightWall, BOARD_FIELD_COLORS.dark)).toBe(0.42);
+  });
+});

--- a/packages/shared/board-look/src/aura-fields.ts
+++ b/packages/shared/board-look/src/aura-fields.ts
@@ -1,0 +1,121 @@
+import {
+  AURA_GLOW_TUNING,
+  BOARDSESH_SMALL_HOLD_MAX_BOOST,
+  BOARDSESH_SMALL_HOLD_NO_BOOST,
+  BOARDSESH_SOFT_DISC_OPACITY,
+  type BoardseshRenderSettings,
+  type GlowFalloffSetting,
+} from './settings';
+
+/** The glow's alpha curve. The renderer defaults to `soft` when omitted. */
+export type GlowFalloff = 'soft' | 'plateau';
+
+/** How a lit hold is marked. The renderer defaults to `glow` when omitted. */
+export type MarkStyle = 'glow' | 'glow-fill' | 'fill' | 'none';
+
+/** Role glyph (shape-per-role) overlay inside the glow. */
+export type GlyphsMode = 'off' | 'role';
+
+/** Translucent wash of the play-field colour over the whole board. */
+export type VeilConfig = { color: string; opacity: number };
+
+/** A ring drawn under a hold's LED position. `{}` takes the renderer's own tuned cover. */
+export type LedCoverConfig = { radius_fraction?: number; color?: string; opacity?: number };
+
+/**
+ * The glow geometry the config carries, as the Rust `GlowTuning` field names.
+ * Every field the drawing does not name stays at its neutral Rust default.
+ */
+export type GlowTuningFields = {
+  reach_scale: number;
+  plateau_share: number;
+  disc_opacity: number;
+  small_hold_max_boost: number;
+  spread_fraction?: number;
+  merge_softness?: number;
+  seam_blend_fraction?: number;
+  seam_sharpness?: number;
+  fringe_deepen?: number;
+};
+
+/** The role-colour fill drawn over the silhouette (`fill` and `glow-fill`). */
+export type FillConfig = { opacity: number };
+
+/** Everything an Aura render config carries that a classic one does not. */
+export type AuraRenderFields = {
+  render_mode: 'aura';
+  veil?: VeilConfig;
+  mark_style: MarkStyle;
+  glow_falloff: GlowFalloff;
+  glow: GlowTuningFields;
+  fill: FillConfig;
+  glyphs: GlyphsMode;
+  led_cover?: LedCoverConfig;
+};
+
+export type AuraRenderFieldsInput = {
+  settings: BoardseshRenderSettings;
+  /**
+   * The falloff, straight from the setting. `'default'` is collapsed here rather
+   * than by each caller: it is not a value the renderer understands, and a
+   * caller that forgot to resolve it would have handed the string through to
+   * Rust with no type error to catch it.
+   */
+  glowFalloff: GlowFalloffSetting;
+  /** The play field the veil washes toward, `#rrggbb`. */
+  fieldColor: string;
+  /** Already resolved through `resolveVeilOpacity`; 0 omits the veil entirely. */
+  veilOpacity: number;
+  /**
+   * The thumbnail treatment: a bare glow reads faint once scaled to ~76px, and
+   * the wider distance field the glow bundle needs is ~2.5× the render for a
+   * difference invisible at 200px.
+   */
+  thumbnail: boolean;
+  /** Whether this board's art paints LED pips bright anywhere — see `led_cover`. */
+  hasLedOffsets: boolean;
+};
+
+/**
+ * The board-level half of an Aura render config — everything that is not per
+ * hold.
+ *
+ * One implementation for every renderer: the mobile native module, the web
+ * worker's WASM build and the backend's. Before this was shared, the server
+ * emitted only `render_mode`/`glow_falloff`/`glyphs` and rode the Rust neutral
+ * defaults, so an OG card drew a flatter glow than the app did from the same
+ * climb.
+ */
+export function buildAuraRenderFields({
+  settings,
+  glowFalloff,
+  fieldColor,
+  veilOpacity,
+  thumbnail,
+  hasLedOffsets,
+}: AuraRenderFieldsInput): AuraRenderFields {
+  return {
+    render_mode: 'aura',
+    // Omitted entirely at zero rather than sent as `opacity: 0`: a light-mode
+    // field is brighter than every board's wall, so there is nothing to quiet.
+    ...(veilOpacity > 0 ? { veil: { color: fieldColor, opacity: veilOpacity } } : {}),
+    // `'fill'` maps to `'glow-fill'`, not a bare fill, on purpose: the spike
+    // measured the filled thumbnail WITH its own small glow (the "veil + tint"
+    // arm) as the winner, not the fill alone.
+    mark_style: thumbnail ? (settings.thumbnailStyle === 'glow' ? 'glow' : 'glow-fill') : settings.markStyle,
+    glow_falloff: glowFalloff === 'default' ? 'soft' : glowFalloff,
+    glow: {
+      reach_scale: settings.glowReach,
+      plateau_share: settings.plateauShare,
+      disc_opacity: settings.softDisc ? BOARDSESH_SOFT_DISC_OPACITY : 0,
+      small_hold_max_boost: settings.smallHoldBoost ? BOARDSESH_SMALL_HOLD_MAX_BOOST : BOARDSESH_SMALL_HOLD_NO_BOOST,
+      ...(thumbnail ? {} : AURA_GLOW_TUNING),
+    },
+    fill: { opacity: settings.fillOpacity },
+    glyphs: settings.roleGlyphs ? 'role' : 'off',
+    // `{}` takes the renderer's own tuned cover. Sent only where the board art
+    // actually paints LEDs bright — Kilter draws a dark bolt hole, so its table
+    // is empty and a cover there would be ink spent on nothing.
+    ...(settings.ledDots && hasLedOffsets ? { led_cover: {} } : {}),
+  };
+}

--- a/packages/shared/board-look/src/index.ts
+++ b/packages/shared/board-look/src/index.ts
@@ -1,0 +1,37 @@
+export type {
+  BoardseshRenderSettings,
+  GlowFalloffSetting,
+  HoldShapeSetting,
+  MarkStyleSetting,
+  ThumbnailStyleSetting,
+  VeilSetting,
+} from './settings';
+export {
+  AURA_GLOW_TUNING,
+  BOARD_FIELD_COLORS,
+  BOARD_RENDER_SETTING_BOUNDS,
+  BOARDSESH_SMALL_HOLD_MAX_BOOST,
+  BOARDSESH_SMALL_HOLD_NO_BOOST,
+  BOARDSESH_SOFT_DISC_OPACITY,
+  DEFAULT_BOARDSESH_RENDER_SETTINGS,
+  GLOW_FALLOFF_SETTINGS,
+  HOLD_SHAPE_SETTINGS,
+  MARK_STYLE_SETTINGS,
+  THUMBNAIL_STYLE_SETTINGS,
+  VEIL_SETTING_OPACITY,
+  VEIL_SETTINGS,
+  boardFieldColorForScheme,
+  resolveVeilOpacity,
+} from './settings';
+export type {
+  AuraRenderFields,
+  AuraRenderFieldsInput,
+  FillConfig,
+  GlowFalloff,
+  GlowTuningFields,
+  GlyphsMode,
+  LedCoverConfig,
+  MarkStyle,
+  VeilConfig,
+} from './aura-fields';
+export { buildAuraRenderFields } from './aura-fields';

--- a/packages/shared/board-look/src/settings.ts
+++ b/packages/shared/board-look/src/settings.ts
@@ -1,0 +1,197 @@
+import { veilOpacityFor } from '@boardsesh/board-art-geometry/veil';
+import type { WallLightness } from '@boardsesh/board-art-geometry/types';
+
+/**
+ * Every knob the Aura board look exposes, and the values it ships at.
+ *
+ * This module is the single source of the drawing's tuning. It used to live in
+ * `packages/mobile/src/lib/board-render-settings.ts`, which also holds the
+ * preference store and therefore imports React — so www and the backend could
+ * not read it, and their Aura renders drew the renderer's own neutral defaults
+ * instead of the look the app ships. Everything here is pure data and pure
+ * functions; the preference store, its sanitisers and the capability probe stay
+ * in mobile.
+ *
+ * The identifiers keep the pre-2.4 `boardsesh` spelling on purpose: only the
+ * wire values were renamed to `aura`, and renaming the ~90 mobile call sites
+ * would buy a string nobody sees. New names added here use `aura`.
+ */
+
+/** The glow's alpha curve. `default` defers to the app default, `soft`. */
+export type GlowFalloffSetting = 'default' | 'soft' | 'plateau';
+/**
+ * How hard the field-colour veil washes the unlit wall. `auto` measures the
+ * board's own art against the field (`veilOpacityFor`); the rest are fixed.
+ */
+export type VeilSetting = 'auto' | 'off' | 'soft' | 'strong' | 'custom';
+/** What the Aura drawing puts on a lit hold at full size. */
+export type MarkStyleSetting = 'glow' | 'glow-fill' | 'fill';
+/**
+ * The same choice for a list thumbnail, where a bare glow reads faint at
+ * ~76px. `fill` renders as `glow-fill`, not a bare fill — the spike's winning
+ * thumbnail arm was the filled mark WITH its own small glow ("veil + tint"),
+ * so that pairing is what this maps to (see `buildAuraRenderFields`).
+ */
+export type ThumbnailStyleSetting = 'fill' | 'glow';
+/**
+ * What the Aura drawing lights on a hold: the traced silhouette from
+ * `@boardsesh/board-art-geometry`, or the placement circle.
+ *
+ * `'circle'` is not a fallback — it is the Modern Classic look. The renderer
+ * already draws the placement circle for any hold the tracer skipped
+ * (`aura/geometry.rs`), so withholding the outlines is all it takes: the veil
+ * punches circles out of the wash and the glow follows them.
+ */
+export type HoldShapeSetting = 'silhouette' | 'circle';
+
+export type BoardseshRenderSettings = {
+  glowFalloff: GlowFalloffSetting;
+  /** Overall glow reach multiplier. */
+  glowReach: number;
+  /** `plateau` falloff only: the share of the reach held at full alpha. */
+  plateauShare: number;
+  veil: VeilSetting;
+  /** `custom` veil only: the wash's alpha. */
+  veilOpacity: number;
+  markStyle: MarkStyleSetting;
+  /** `fill` / `glow-fill` only: alpha of the role-colour fill. */
+  fillOpacity: number;
+  /** The soft disc under the glow — the spike's rejected arm, kept as an A/B. */
+  softDisc: boolean;
+  /** Give a fingernail-sized foot chip a bigger glow instead of a second mark. */
+  smallHoldBoost: boolean;
+  /** Cover the LED pips the board art itself paints bright. */
+  ledDots: boolean;
+  /** Opt-in accessibility glyphs (FOOT ring, STARTING bar, HAND bar, FINISH X). */
+  roleGlyphs: boolean;
+  thumbnailStyle: ThumbnailStyleSetting;
+  holdShape: HoldShapeSetting;
+};
+
+export const GLOW_FALLOFF_SETTINGS = ['default', 'soft', 'plateau'] as const;
+export const VEIL_SETTINGS = ['auto', 'off', 'soft', 'strong', 'custom'] as const;
+export const MARK_STYLE_SETTINGS = ['glow', 'glow-fill', 'fill'] as const;
+export const THUMBNAIL_STYLE_SETTINGS = ['fill', 'glow'] as const;
+export const HOLD_SHAPE_SETTINGS = ['silhouette', 'circle'] as const;
+
+/** Slider ranges, exported so the settings screen and the clamps cannot drift. */
+export const BOARD_RENDER_SETTING_BOUNDS = {
+  glowReach: { min: 0.5, max: 2 },
+  plateauShare: { min: 0.2, max: 0.7 },
+  veilOpacity: { min: 0, max: 0.9 },
+  fillOpacity: { min: 0.3, max: 0.9 },
+} as const;
+
+/**
+ * The two fixed veil buckets, matching `VEIL_TUNING`'s soft and strong opacities
+ * — a climber who overrides `auto` is choosing one of the same two washes the
+ * measurement would have picked, not a third strength.
+ */
+export const VEIL_SETTING_OPACITY = { off: 0, soft: 0.3, strong: 0.6 } as const;
+
+/** Peak alpha of the optional soft disc under the glow. */
+export const BOARDSESH_SOFT_DISC_OPACITY = 0.3;
+/** The renderer's own small-hold boost ceiling, and the value that turns it off. */
+export const BOARDSESH_SMALL_HOLD_MAX_BOOST = 1.7;
+export const BOARDSESH_SMALL_HOLD_NO_BOOST = 1;
+
+/**
+ * The Aura glow, as renderer tuning, spread into the config's `glow` object
+ * (snake_case: the Rust `GlowTuning` fields).
+ *
+ * The owner's pick from PR #4972's three-way design review, tuned in the glow
+ * lab against real climbs on five boards:
+ *
+ * - `spread_fraction` 0.91 is the reach-1.3 look shipped WITHOUT touching
+ *   `reach_scale`, so the climber's Glow-reach slider keeps multiplying on
+ *   top (pixel-identical to a reach_scale of 1.3 — verified RMSE 0).
+ * - `merge_softness` fuses same-colour neighbours across their bisector (the
+ *   dark V-notch the plain glow shows between adjacent holds).
+ * - The seam pair replaces the hard colour switch between DIFFERENT-colour
+ *   neighbours with a continuous, power-curved crossfade: `seam_sharpness` 3
+ *   keeps the blend at a true 50/50 exactly on the bisector (a capped mix
+ *   left a visible hard line there — the Grasshopper pie-slice bug) while
+ *   collapsing to near-pure hold colour within a few pixels.
+ * - `fringe_deepen` keeps the falloff coloured to its edge instead of greying.
+ * - No spill, no rim, no gamma, no white core: the review measured spill at
+ *   this reach inventing lit-looking holds, and the stylised looks lost to
+ *   the drawing's own character.
+ *
+ * Thumbnails skip the bundle (`buildAuraRenderFields`): at 200px the
+ * difference is invisible and the extra distance-field work is ~2.5× the
+ * render. Every field left unnamed stays at its neutral Rust default.
+ *
+ * `seam_max_mix` is deliberately OMITTED: its Rust default (0.5) is
+ * load-bearing — the crossfade must reach a true 50/50 on the bisector for
+ * colour continuity; any lower cap re-creates the hard seam line.
+ */
+export const AURA_GLOW_TUNING = {
+  spread_fraction: 0.91,
+  merge_softness: 0.6,
+  seam_blend_fraction: 0.9,
+  seam_sharpness: 3.0,
+  fringe_deepen: 0.4,
+} as const;
+
+export const DEFAULT_BOARDSESH_RENDER_SETTINGS: BoardseshRenderSettings = {
+  glowFalloff: 'default',
+  glowReach: 1,
+  plateauShare: 0.4,
+  veil: 'auto',
+  veilOpacity: 0.6,
+  markStyle: 'glow',
+  fillOpacity: 0.55,
+  softDisc: false,
+  smallHoldBoost: true,
+  ledDots: true,
+  roleGlyphs: false,
+  thumbnailStyle: 'fill',
+  holdShape: 'silhouette',
+};
+
+/**
+ * The play field the veil washes toward, per colour scheme — the mobile theme's
+ * `secondaryBackground` (`packages/mobile/src/theme/colors.ts`), restated as a
+ * plain hex because that module resolves to an iOS `PlatformColor` the veil
+ * cannot subtract a lightness from. Pinned by a mobile test against the theme so
+ * the two cannot drift.
+ *
+ * On the white light-mode field every board's wall is DARKER than the field, so
+ * `veilOpacityFor` turns the veil off there without a special case. www and the
+ * OG cards render against the dark field, which is what an app climber in the
+ * default dark theme sees.
+ */
+export const BOARD_FIELD_COLORS = { light: '#FFFFFF', dark: '#181225' } as const;
+
+export function boardFieldColorForScheme(colorScheme: 'light' | 'dark'): string {
+  return BOARD_FIELD_COLORS[colorScheme];
+}
+
+/**
+ * How hard the veil washes this board, given the climber's choice and the
+ * board's own measured wall.
+ *
+ * `auto` with no wall row is 0, not a guess: a board the tracer skipped has no
+ * reading to bucket, and washing an unmeasured wall is how a field colour ends
+ * up brighter than the art it was meant to quiet.
+ */
+export function resolveVeilOpacity(
+  settings: BoardseshRenderSettings,
+  wallLightness: WallLightness | null,
+  fieldColor: string,
+): number {
+  switch (settings.veil) {
+    case 'off':
+      return VEIL_SETTING_OPACITY.off;
+    case 'soft':
+      return VEIL_SETTING_OPACITY.soft;
+    case 'strong':
+      return VEIL_SETTING_OPACITY.strong;
+    case 'custom':
+      return settings.veilOpacity;
+    case 'auto':
+      return wallLightness
+        ? veilOpacityFor({ wallLightness: wallLightness.mean, coverage: wallLightness.coverage, fieldColor })
+        : 0;
+  }
+}

--- a/packages/shared/board-look/tsconfig.json
+++ b/packages/shared/board-look/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/shared/board-look/vite.config.ts
+++ b/packages/shared/board-look/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'board-look',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/shared/board-render/package.json
+++ b/packages/shared/board-render/package.json
@@ -10,6 +10,11 @@
       "import": "./src/index.ts",
       "default": "./src/index.ts"
     },
+    "./render-config": {
+      "types": "./src/render-config.ts",
+      "import": "./src/render-config.ts",
+      "default": "./src/render-config.ts"
+    },
     "./pipeline": {
       "types": "./src/pipeline.ts",
       "import": "./src/pipeline.ts",
@@ -33,6 +38,7 @@
     "@boardsesh/board-art-geometry": "workspace:*",
     "@boardsesh/board-config": "workspace:*",
     "@boardsesh/board-constants": "workspace:*",
+    "@boardsesh/board-look": "workspace:*",
     "@boardsesh/board-renderer-wasm": "workspace:*",
     "@boardsesh/play-view": "workspace:*",
     "@boardsesh/shared-schema": "workspace:*",

--- a/packages/shared/board-render/src/__tests__/render-config.test.ts
+++ b/packages/shared/board-render/src/__tests__/render-config.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { HOLD_STATE_MAP } from '@boardsesh/board-constants/hold-states';
+import {
+  AURA_GLOW_TUNING,
+  BOARDSESH_SMALL_HOLD_MAX_BOOST,
+  DEFAULT_BOARDSESH_RENDER_SETTINGS,
+  VEIL_SETTING_OPACITY,
+} from '@boardsesh/board-look';
 import { getBoardDetailsForBoard } from '../board-details';
 import { buildRenderConfig, THUMBNAIL_WIDTH } from '../render-config';
 import type { RenderableBoardDetails } from '../types';
@@ -51,14 +57,16 @@ describe('buildRenderConfig', () => {
       isOgVariant: false,
       glowFalloff: 'plateau',
       glyphs: true,
-      veil: { color: '#181225', opacity: 0.6 },
-      markStyle: 'fill',
+      fieldColor: '#181225',
+      wallLightness: { mean: 0.541, coverage: 0.9 },
     });
     expect(config.render_mode).toBeUndefined();
     expect(config.veil).toBeUndefined();
     expect(config.glyphs).toBeUndefined();
     expect(config.glow_falloff).toBeUndefined();
     expect(config.mark_style).toBeUndefined();
+    expect(config.glow).toBeUndefined();
+    expect(config.fill).toBeUndefined();
     expect(config.led_cover).toBeUndefined();
     for (const hold of config.holds) {
       expect(hold.outline).toBeUndefined();
@@ -110,9 +118,21 @@ describe('buildRenderConfig — boardsesh mode', () => {
     expect(config.glyphs).toBe('off');
   });
 
-  it('threads an explicit glow_falloff through', () => {
-    const { config } = buildRenderConfig({ ...boardseshParams, glowFalloff: 'plateau' });
-    expect(config.glow_falloff).toBe('plateau');
+  it('threads an explicit glow_falloff through, and honours the setting otherwise', () => {
+    expect(buildRenderConfig({ ...boardseshParams, glowFalloff: 'plateau' }).config.glow_falloff).toBe('plateau');
+
+    // `auraSettings` is an override surface, so a falloff set there has to
+    // reach the renderer rather than being silently dropped for the default.
+    const fromSettings = buildRenderConfig({ ...boardseshParams, auraSettings: { glowFalloff: 'plateau' } }).config;
+    expect(fromSettings.glow_falloff).toBe('plateau');
+
+    // The query param still wins when both are named.
+    const both = buildRenderConfig({
+      ...boardseshParams,
+      glowFalloff: 'soft',
+      auraSettings: { glowFalloff: 'plateau' },
+    }).config;
+    expect(both.glow_falloff).toBe('soft');
   });
 
   it('maps glyphs: true to "role"', () => {
@@ -120,18 +140,68 @@ describe('buildRenderConfig — boardsesh mode', () => {
     expect(config.glyphs).toBe('role');
   });
 
-  it('emits veil and mark_style only when passed', () => {
-    const withoutExtras = buildRenderConfig(boardseshParams).config;
-    expect(withoutExtras.veil).toBeUndefined();
-    expect(withoutExtras.mark_style).toBeUndefined();
+  it('draws the shipped Aura look — the same glow bundle the app sends', () => {
+    const { config } = buildRenderConfig(boardseshParams);
+    expect(config.mark_style).toBe('glow');
+    expect(config.fill).toEqual({ opacity: DEFAULT_BOARDSESH_RENDER_SETTINGS.fillOpacity });
+    expect(config.glow).toEqual({
+      reach_scale: 1,
+      plateau_share: 0.4,
+      disc_opacity: 0,
+      small_hold_max_boost: BOARDSESH_SMALL_HOLD_MAX_BOOST,
+      ...AURA_GLOW_TUNING,
+    });
+  });
 
-    const withExtras = buildRenderConfig({
+  it('skips the glow bundle on thumbnails and fills the mark instead', () => {
+    // A bare glow reads faint at ~76px, and the wider distance field the bundle
+    // needs is ~2.5x the render for a difference invisible at 200px.
+    const { config } = buildRenderConfig({ ...boardseshParams, thumbnail: true });
+    expect(config.mark_style).toBe('glow-fill');
+    expect(config.glow).toEqual({
+      reach_scale: 1,
+      plateau_share: 0.4,
+      disc_opacity: 0,
+      small_hold_max_boost: BOARDSESH_SMALL_HOLD_MAX_BOOST,
+    });
+  });
+
+  it('takes the play view glow on an OG card, which is nothing like a 76px thumbnail', () => {
+    const { config } = buildRenderConfig({ ...boardseshParams, isOgVariant: true });
+    // The thumbnail flag is about stroke weight; the mark treatment is not.
+    expect(config.thumbnail).toBe(true);
+    expect(config.mark_style).toBe('glow');
+    expect(config.glow).toMatchObject(AURA_GLOW_TUNING);
+  });
+
+  it('washes the wall against a dark field, and not at all against a light one', () => {
+    const wallLightness = { mean: 0.541, coverage: 0.9 };
+    const dark = buildRenderConfig({ ...boardseshParams, fieldColor: '#181225', wallLightness }).config;
+    expect(dark.veil).toEqual({ color: '#181225', opacity: VEIL_SETTING_OPACITY.strong });
+
+    // Every board's wall is darker than the white field, so there is nothing to
+    // quiet and the veil is omitted rather than sent at opacity 0.
+    const light = buildRenderConfig({ ...boardseshParams, fieldColor: '#FFFFFF', wallLightness }).config;
+    expect(light.veil).toBeUndefined();
+
+    // No measurement is not a guess: an unmeasured wall gets no wash.
+    const unmeasured = buildRenderConfig({ ...boardseshParams, fieldColor: '#181225' }).config;
+    expect(unmeasured.veil).toBeUndefined();
+  });
+
+  it('withholds the silhouettes for Modern Classic, but keeps the LED covers', () => {
+    const holdGeometry = { outlines: { 100: [1, 0, 0, 1, -1, 0] }, ledBright: { 100: [0.1, 0.2] as [number, number] } };
+    const silhouette = buildRenderConfig({ ...boardseshParams, holdGeometry }).config;
+    expect(silhouette.holds.find((hold) => hold.id === 100)?.outline).toEqual([1, 0, 0, 1, -1, 0]);
+
+    const modernClassic = buildRenderConfig({
       ...boardseshParams,
-      veil: { color: '#181225', opacity: 0.6 },
-      markStyle: 'fill',
+      holdGeometry,
+      auraSettings: { holdShape: 'circle' },
     }).config;
-    expect(withExtras.veil).toEqual({ color: '#181225', opacity: 0.6 });
-    expect(withExtras.mark_style).toBe('fill');
+    expect(modernClassic.holds.find((hold) => hold.id === 100)?.outline).toBeUndefined();
+    expect(modernClassic.holds.find((hold) => hold.id === 100)?.led).toEqual([0.1, 0.2]);
+    expect(modernClassic.led_cover).toEqual({});
   });
 
   it('paints the Aura palette, not the classic one, when Aura is what was asked for', () => {

--- a/packages/shared/board-render/src/generated/render-version.ts
+++ b/packages/shared/board-render/src/generated/render-version.ts
@@ -8,4 +8,4 @@
 //
 // Deliberately import-free: this module is reachable from web's client bundle
 // through buildBoardRenderUrl, and must never drag sharp or the WASM glue with it.
-export const BOARD_RENDER_VERSION = '9f6e8586d17b';
+export const BOARD_RENDER_VERSION = 'd145ce0ecf4d';

--- a/packages/shared/board-render/src/render-config.ts
+++ b/packages/shared/board-render/src/render-config.ts
@@ -1,5 +1,13 @@
 import type { BoardName } from '@boardsesh/shared-schema';
-import { isWithinSpillRange } from '@boardsesh/board-art-geometry';
+import { isWithinSpillRange } from '@boardsesh/board-art-geometry/spill';
+import type { WallLightness } from '@boardsesh/board-art-geometry/types';
+import {
+  DEFAULT_BOARDSESH_RENDER_SETTINGS,
+  BOARD_FIELD_COLORS,
+  buildAuraRenderFields,
+  resolveVeilOpacity,
+  type BoardseshRenderSettings,
+} from '@boardsesh/board-look';
 import {
   getBoardStrokeWidthMultiplier,
   getHoldDisplayColor,
@@ -11,10 +19,8 @@ import type {
   GlowFalloff,
   HoldRole,
   HoldStateRecord,
-  MarkStyle,
   RenderableBoardDetails,
   RenderMode,
-  VeilConfig,
   WasmRenderConfig,
   WasmRenderHold,
 } from './types';
@@ -23,11 +29,12 @@ import type {
 export const THUMBNAIL_WIDTH = 200;
 
 /**
- * Per-hold silhouette geometry for `boardsesh` mode, keyed by hold id. Every
- * field is optional and this whole param is optional — `@boardsesh/board-art-geometry`
- * (issue #2202) is the eventual source and isn't wired in yet, so this is a
- * structural injection point: pass it once that package ships, and boardsesh
- * mode keeps rendering veil + glow with no traced outlines until then.
+ * Per-hold silhouette geometry for `aura` mode, keyed by hold id, as loaded from
+ * `@boardsesh/board-art-geometry`. Injected rather than imported here so the
+ * browser can fetch the one config it needs instead of bundling all 51 shards.
+ * Every field is optional, and so is the whole param: a hold with no outline
+ * glows a ring at its placement radius, which is also how the Modern Classic
+ * look is drawn.
  */
 export type HoldGeometryInput = {
   /** Flat `[x0, y0, x1, y1, …]` outline per hold, in units of `r` relative to its centre. */
@@ -55,20 +62,36 @@ type BuildRenderConfigParams = {
   boardStates: HoldStateRecord;
   /** Injected so web can pass its (mockable) THUMBNAIL_WIDTH; defaults to the shared constant. */
   thumbnailWidth?: number;
-  /** "boardsesh" draws the veil + glow treatment; omitted/"classic" renders exactly as today (issue #2202). */
+  /** "aura" draws the veil + glow treatment; omitted/"classic" renders exactly as today (issue #2202). */
   renderMode?: RenderMode;
-  /** `boardsesh` mode only. Renderer defaults to "soft" when omitted. */
+  /** `aura` mode only. The look's own default is "soft". */
   glowFalloff?: GlowFalloff;
-  /** `boardsesh` mode only: role glyphs inside the glow. Defaults to off. */
+  /** `aura` mode only: role glyphs inside the glow. Defaults to off. */
   glyphs?: boolean;
-  /** `boardsesh` mode only: translucent wash over the whole board. */
-  veil?: VeilConfig;
-  /** `boardsesh` mode only. Renderer defaults to "glow" (or "glow-fill" for thumbnails) when omitted. */
-  markStyle?: MarkStyle;
-  /** `boardsesh` mode only — see `HoldGeometryInput`. */
+  /**
+   * `aura` mode only: knobs to layer over the shipped look. The glow lab passes
+   * its variants here; the render endpoints leave it unset and draw exactly what
+   * the app draws.
+   */
+  auraSettings?: Partial<BoardseshRenderSettings>;
+  /**
+   * `aura` mode only: the play field the veil washes toward, `#rrggbb`. Defaults
+   * to the light field, on which every board's wall is darker than the field and
+   * `veilOpacityFor` turns the veil off — so a caller that says nothing gets no
+   * wash rather than an arbitrary one.
+   */
+  fieldColor?: string;
+  /**
+   * `aura` mode only: this board config's measured wall, from
+   * `getWallLightness`. Without it the `auto` veil resolves to 0 — a board the
+   * tracer skipped has no reading to bucket, and washing an unmeasured wall is
+   * how a field colour ends up brighter than the art it was meant to quiet.
+   */
+  wallLightness?: WallLightness | null;
+  /** `aura` mode only — see `HoldGeometryInput`. */
   holdGeometry?: HoldGeometryInput;
   /**
-   * `boardsesh` mode only: also attach outlines to unlit holds within
+   * `aura` mode only: also attach outlines to unlit holds within
    * `SPILL_NEIGHBOUR_RADII` of a lit one, so the renderer's light-spill
    * effect (`glow.spill_boost`) has silhouettes to brighten. Off by default —
    * the OG/share-card path renders with `spill_boost` at its 0 default and
@@ -84,7 +107,7 @@ export type RenderConfigResult = {
   ogScale: number | null;
 };
 
-/** `HoldStateInfo.name` values `boardsesh` mode maps onto a per-role render treatment. */
+/** `HoldStateInfo.name` values `aura` mode maps onto a per-role render treatment. */
 const BOARDSESH_ROLE_NAMES = new Set(['STARTING', 'HAND', 'FINISH', 'FOOT']);
 
 function roleForHoldStateName(name: string | undefined): HoldRole | undefined {
@@ -126,8 +149,9 @@ export function buildRenderConfig({
   renderMode,
   glowFalloff,
   glyphs,
-  veil,
-  markStyle,
+  auraSettings,
+  fieldColor = BOARD_FIELD_COLORS.light,
+  wallLightness = null,
   holdGeometry,
   spillNeighbourOutlines = false,
 }: BuildRenderConfigParams): RenderConfigResult {
@@ -146,6 +170,13 @@ export function buildRenderConfig({
   const outputWidth = computeOutputWidth();
 
   const isAura = renderMode === 'aura';
+  // The shipped look, with the caller's overrides on top. `glyphs` stays a
+  // separate param because it is a query param on both render endpoints.
+  const auraLook: BoardseshRenderSettings = {
+    ...DEFAULT_BOARDSESH_RENDER_SETTINGS,
+    ...auraSettings,
+    ...(glyphs === undefined ? {} : { roleGlyphs: glyphs }),
+  };
 
   // Prefer each role's calibrated on-screen displayColor over its raw LED
   // color — the LED color is only correct for driving physical board
@@ -170,11 +201,27 @@ export function buildRenderConfig({
     };
   }
 
-  // Lit holds get their silhouette geometry attached in boardsesh mode — plus
+  // Lit holds get their silhouette geometry attached in aura mode — plus
   // their mirroredHoldId partner, so the geometry is already in place for
   // whenever a mirrored render is requested (this builder always emits
   // `mirrored: false` today; see the comment below).
   const litHoldIds = isAura ? litHoldIdsFromFirstFrame(frames) : null;
+
+  // Modern Classic IS Aura without the silhouettes: the renderer already
+  // falls back to the placement circle for any hold the tracer skipped, so
+  // withholding the outlines is the whole look — the veil punches circles and
+  // the glow follows them. `ledBright` stays, because the LED cover goes on a
+  // placement rather than on a silhouette; `ledInner` and
+  // `silhouetteLightness` were measured against the outline and mean nothing
+  // without it.
+  const auraGeometry: HoldGeometryInput | undefined =
+    isAura && auraLook.holdShape === 'circle'
+      ? // `ledBright` and nothing else — spelled out rather than
+        // `{ ledBright: holdGeometry?.ledBright }`, which would hand the renderer
+        // a truthy object carrying an undefined table on a board with no painted
+        // pips, where `undefined` is the honest answer.
+        (holdGeometry?.ledBright && { ledBright: holdGeometry.ledBright }) || undefined
+      : holdGeometry;
 
   // Unlit holds NEAR a lit one also carry their outline when asked to
   // (`spillNeighbourOutlines`), so the renderer's light-spill effect
@@ -198,19 +245,19 @@ export function buildRenderConfig({
     if (!litHoldIds) return base;
     // The LED cover goes on EVERY placement whose art paints the LED bright,
     // lit or not — an unlit hold's white pip is exactly what it hides.
-    const led = holdGeometry?.ledBright?.[hold.id];
+    const led = auraGeometry?.ledBright?.[hold.id];
     const isLit = litHoldIds.has(hold.id) || (hold.mirroredHoldId !== null && litHoldIds.has(hold.mirroredHoldId));
     if (!isLit) {
-      const spillOutline = holdGeometry?.outlines?.[hold.id];
+      const spillOutline = auraGeometry?.outlines?.[hold.id];
       const withSpill = spillOutline && isNearLitHold(hold) ? { ...base, outline: spillOutline } : base;
       return led ? { ...withSpill, led } : withSpill;
     }
 
-    const outline = holdGeometry?.outlines?.[hold.id];
-    const silhouetteLightness = holdGeometry?.silhouetteLightness?.[hold.id];
+    const outline = auraGeometry?.outlines?.[hold.id];
+    const silhouetteLightness = auraGeometry?.silhouetteLightness?.[hold.id];
     // The plate ring only means anything against the silhouette it was traced
     // inside, so it rides along with `outline` and never on its own.
-    const ledInner = outline ? holdGeometry?.ledInner?.[hold.id] : undefined;
+    const ledInner = outline ? auraGeometry?.ledInner?.[hold.id] : undefined;
     return {
       ...base,
       ...(outline ? { outline } : {}),
@@ -220,7 +267,7 @@ export function buildRenderConfig({
     };
   });
 
-  const hasLedBright = Object.keys(holdGeometry?.ledBright ?? {}).length > 0;
+  const hasLedBright = Object.keys(auraGeometry?.ledBright ?? {}).length > 0;
 
   const config: WasmRenderConfig = {
     board_name: boardName,
@@ -241,14 +288,23 @@ export function buildRenderConfig({
     holds,
     hold_state_map: holdStateMap,
     ...(isAura
-      ? {
-          render_mode: 'aura' as const,
-          glow_falloff: glowFalloff ?? 'soft',
-          glyphs: glyphs ? ('role' as const) : ('off' as const),
-          ...(veil ? { veil } : {}),
-          ...(markStyle ? { mark_style: markStyle } : {}),
-          ...(hasLedBright ? { led_cover: {} } : {}),
-        }
+      ? buildAuraRenderFields({
+          settings: auraLook,
+          // The query param wins; otherwise the look's own setting, which
+          // `buildAuraRenderFields` collapses from `'default'`. Reading it here
+          // is what keeps `auraSettings` an honest override surface — passing
+          // `{ glowFalloff: 'plateau' }` used to do nothing at all.
+          glowFalloff: glowFalloff ?? auraLook.glowFalloff,
+          fieldColor,
+          veilOpacity: resolveVeilOpacity(auraLook, wallLightness, fieldColor),
+          // NOT `thumbnail || isOgVariant`. The thumbnail treatment (fill under
+          // the glow, glow bundle skipped) exists because a bare glow reads
+          // faint at ~76px; an OG card draws the board ~500px tall, so it takes
+          // the play view's own full-size glow. The `thumbnail` flag on the
+          // config above is about stroke weight, which is a separate question.
+          thumbnail,
+          hasLedOffsets: hasLedBright,
+        })
       : {}),
   };
 

--- a/packages/shared/board-render/src/types.ts
+++ b/packages/shared/board-render/src/types.ts
@@ -1,3 +1,12 @@
+import type {
+  FillConfig,
+  GlowFalloff,
+  GlowTuningFields,
+  GlyphsMode,
+  LedCoverConfig,
+  MarkStyle,
+  VeilConfig,
+} from '@boardsesh/board-look';
 import type { BoardName } from '@boardsesh/shared-schema';
 import type { SetIdList } from '@boardsesh/board-config';
 
@@ -68,29 +77,30 @@ export type HoldStateRecord = Record<
  */
 export type RenderMode = 'classic' | 'aura';
 
-/** Glow edge treatment, `aura` mode only. Renderer defaults to `soft`. */
-export type GlowFalloff = 'soft' | 'plateau';
-
-/** How a lit hold is marked in `aura` mode. Renderer defaults to `glow` (or `glow-fill` for thumbnails when unset). */
-export type MarkStyle = 'glow' | 'glow-fill' | 'fill' | 'none';
-
-/** Role glyph (shape-per-role) overlay inside the glow, `aura` mode only. */
-export type GlyphsMode = 'off' | 'role';
+/**
+ * The `aura` config vocabulary is owned by `@boardsesh/board-look`, which is
+ * where the look's tuning lives — the app, the web worker and this pipeline all
+ * build the same block from it. Re-exported here so the renderer's own types
+ * still read as one vocabulary at the call site.
+ */
+export type {
+  FillConfig,
+  GlowFalloff,
+  GlowTuningFields,
+  GlyphsMode,
+  LedCoverConfig,
+  MarkStyle,
+  VeilConfig,
+} from '@boardsesh/board-look';
 
 /** The four hold roles `aura` mode draws a distinct glyph/role treatment for. */
 export type HoldRole = 'starting' | 'hand' | 'finish' | 'foot';
 
-/** Translucent wash over the whole board, `aura` mode only. */
-export type VeilConfig = { color: string; opacity: number };
-
-/** A ring drawn under a hold's LED position. `{}` enables the renderer's own defaults. */
-export type LedCoverConfig = { radius_fraction?: number; color?: string; opacity?: number };
-
 /**
  * `RenderableHold` plus the per-hold silhouette geometry `buildRenderConfig`
- * attaches to lit holds (and their mirror partners) in `aura` mode. All
- * three are optional and only ever set when the caller passes `holdGeometry` —
- * `@boardsesh/board-art-geometry` is the eventual source, not yet wired in.
+ * attaches to lit holds (and their mirror partners) in `aura` mode. All of them
+ * are optional and only ever set when the caller passes `holdGeometry`, read per
+ * board config from `@boardsesh/board-art-geometry`.
  */
 export type WasmRenderHold = RenderableHold & {
   /** Flat `[x0, y0, x1, y1, …]` outline, in units of `r` relative to the hold centre. */
@@ -134,11 +144,19 @@ export type WasmRenderConfig = {
    * default rather than relying on the renderer's own (issue #2202 drift fix).
    */
   shape_size_multiplier?: number;
-  /** Set only in `aura` mode — see `RenderMode`. Unset (classic) renders exactly as before. */
+  /**
+   * Set only in `aura` mode — see `RenderMode`. Unset (classic) renders exactly
+   * as before. The whole block comes from `buildAuraRenderFields`
+   * (`@boardsesh/board-look`), so every renderer sends the same tuning.
+   */
   render_mode?: RenderMode;
   veil?: VeilConfig;
   mark_style?: MarkStyle;
   glow_falloff?: GlowFalloff;
+  /** Glow geometry — the Rust `GlowTuning` fields. Omitted fields stay at their neutral defaults. */
+  glow?: GlowTuningFields;
+  /** The role-colour fill drawn over the silhouette (`fill` and `glow-fill`). */
+  fill?: FillConfig;
   glyphs?: GlyphsMode;
   led_cover?: LedCoverConfig;
   holds: WasmRenderHold[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       '@boardsesh/board-constants':
         specifier: workspace:*
         version: link:../board-constants
+      '@boardsesh/board-look':
+        specifier: workspace:*
+        version: link:../shared/board-look
       '@boardsesh/board-render':
         specifier: workspace:*
         version: link:../shared/board-render
@@ -499,6 +502,9 @@ importers:
       '@boardsesh/board-constants':
         specifier: workspace:*
         version: link:../board-constants
+      '@boardsesh/board-look':
+        specifier: workspace:*
+        version: link:../shared/board-look
       '@boardsesh/board-presence-react':
         specifier: workspace:*
         version: link:../shared/board-presence-react
@@ -959,6 +965,16 @@ importers:
         specifier: ~7.0.2
         version: 7.0.2
 
+  packages/shared/board-look:
+    dependencies:
+      '@boardsesh/board-art-geometry':
+        specifier: workspace:*
+        version: link:../board-art-geometry
+    devDependencies:
+      typescript:
+        specifier: ~7.0.2
+        version: 7.0.2
+
   packages/shared/board-presence:
     dependencies:
       '@boardsesh/shared-schema':
@@ -1048,6 +1064,9 @@ importers:
       '@boardsesh/board-constants':
         specifier: workspace:*
         version: link:../../board-constants
+      '@boardsesh/board-look':
+        specifier: workspace:*
+        version: link:../board-look
       '@boardsesh/board-renderer-wasm':
         specifier: workspace:*
         version: link:../../board-renderer/wasm

--- a/scripts/generate-board-render-version.test.ts
+++ b/scripts/generate-board-render-version.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { BOARD_RENDER_VERSION } from '../packages/shared/board-render/src/generated/render-version';
 import {
+  BOARD_ART_GEOMETRY_ROOT,
   checkBoardRenderVersion,
   computeBoardRenderVersion,
   GENERATED_VERSION_FILE,
@@ -12,6 +13,26 @@ import {
 } from './generate-board-render-version';
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '..');
+
+/**
+ * A throwaway tree carrying the real opaque inputs and one stand-in traced-art
+ * shard. It has no board photos, so its version legitimately differs from the
+ * repo's — these tests are about which inputs reach the digest, not the value.
+ */
+function scratchTree({ geometryShard }: { geometryShard: string | null }): string {
+  const scratchRoot = mkdtempSync(path.join(tmpdir(), 'board-render-version-'));
+  for (const relativePath of OPAQUE_RENDER_INPUTS) {
+    const target = path.join(scratchRoot, relativePath);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, readFileSync(path.join(REPO_ROOT, relativePath)));
+  }
+  if (geometryShard !== null) {
+    const shardTarget = path.join(scratchRoot, BOARD_ART_GEOMETRY_ROOT, 'kilter', '1-10.cjs');
+    mkdirSync(path.dirname(shardTarget), { recursive: true });
+    writeFileSync(shardTarget, geometryShard);
+  }
+  return scratchRoot;
+}
 
 describe('computeBoardRenderVersion', () => {
   it('is stable across two runs over the same tree', () => {
@@ -31,6 +52,30 @@ describe('computeBoardRenderVersion', () => {
   it('names the missing path when an opaque input is absent', () => {
     const emptyRoot = mkdtempSync(path.join(tmpdir(), 'board-render-version-'));
     expect(() => computeBoardRenderVersion(emptyRoot)).toThrow(OPAQUE_RENDER_INPUTS[0]);
+  });
+
+  it('names the traced-art directory when it is absent', () => {
+    const withoutGeometry = scratchTree({ geometryShard: null });
+    expect(() => computeBoardRenderVersion(withoutGeometry)).toThrow(BOARD_ART_GEOMETRY_ROOT);
+  });
+
+  it('still produces a version when the traced-art directory is empty', () => {
+    // An empty directory is not the same as a missing one: the tables can
+    // legitimately regenerate to nothing for a catalogue with no traced board,
+    // and the version must stay a real digest rather than collapse or throw.
+    const emptyGeometry = scratchTree({ geometryShard: null });
+    mkdirSync(path.join(emptyGeometry, BOARD_ART_GEOMETRY_ROOT), { recursive: true });
+    expect(computeBoardRenderVersion(emptyGeometry)).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  it('moves when a traced silhouette changes', () => {
+    // The projection cannot see a polygon — it probes with an empty frames
+    // string, so no hold is lit and no outline is ever attached. Without the
+    // directory hash, re-tracing a board would move no version and Cloudflare
+    // would serve the old silhouettes `immutable` for a year.
+    const before = computeBoardRenderVersion(scratchTree({ geometryShard: 'module.exports = { outlines: {} };' }));
+    const after = computeBoardRenderVersion(scratchTree({ geometryShard: 'module.exports = { outlines: {1:[0]} };' }));
+    expect(after).not.toBe(before);
   });
 });
 
@@ -103,12 +148,7 @@ describe('checkBoardRenderVersion', () => {
     // Mirror the real inputs into a scratch tree, then stale only the generated
     // file — proves the check reads the committed file rather than recomputing
     // both sides and always agreeing with itself.
-    const scratchRoot = mkdtempSync(path.join(tmpdir(), 'board-render-version-'));
-    for (const relativePath of OPAQUE_RENDER_INPUTS) {
-      const target = path.join(scratchRoot, relativePath);
-      mkdirSync(path.dirname(target), { recursive: true });
-      writeFileSync(target, readFileSync(path.join(REPO_ROOT, relativePath)));
-    }
+    const scratchRoot = scratchTree({ geometryShard: 'module.exports = { outlines: {} };' });
     const generatedTarget = path.join(scratchRoot, GENERATED_VERSION_FILE);
     mkdirSync(path.dirname(generatedTarget), { recursive: true });
     writeFileSync(generatedTarget, renderVersionModuleSource('000000000000'));

--- a/scripts/generate-board-render-version.ts
+++ b/scripts/generate-board-render-version.ts
@@ -43,7 +43,7 @@
  */
 
 import { createHash } from 'node:crypto';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import {
@@ -79,11 +79,47 @@ export const OPAQUE_RENDER_INPUTS: readonly string[] = [
   'packages/shared/board-render/src/background.ts',
 ];
 
+/**
+ * The traced board art, hashed as a directory rather than projected.
+ *
+ * The projection cannot see a single polygon: it probes `buildRenderConfig` with
+ * an empty frames string, so no hold is lit and no `outline`, `led_inner` or
+ * `silhouette_lightness` is ever attached. Re-tracing a board would therefore
+ * move no version, and Cloudflare would keep serving the old silhouettes
+ * `immutable` for a year.
+ *
+ * Hashed whole (sorted, path + bytes) rather than listed file by file: the shards
+ * are one generated artefact, and a new board must not be able to slip in
+ * unhashed. `wall-lightness.cjs` rides along, which is right — it decides every
+ * board's veil strength.
+ */
+export const BOARD_ART_GEOMETRY_ROOT = 'packages/shared/board-art-geometry/src/generated';
+
 /** Board photos live in web's public tree; the backend gets a copy of the same files. */
 const PUBLIC_IMAGE_ROOT = 'packages/web/public';
 
 function hashFile(absolutePath: string): string {
   return createHash('sha256').update(readFileSync(absolutePath)).digest('hex');
+}
+
+/** Every file under `directory`, repo-relative and sorted, so the walk is stable. */
+function listFilesRecursively(directory: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) found.push(...listFilesRecursively(entryPath));
+    else if (entry.isFile()) found.push(entryPath);
+  }
+  return found.sort();
+}
+
+/** Content hash of a whole generated directory: sorted relative paths plus their bytes. */
+function hashDirectory(absoluteRoot: string): string {
+  const directoryHash = createHash('sha256');
+  for (const filePath of listFilesRecursively(absoluteRoot)) {
+    directoryHash.update(`${path.relative(absoluteRoot, filePath)}=${hashFile(filePath)}\n`);
+  }
+  return directoryHash.digest('hex');
 }
 
 /**
@@ -102,6 +138,15 @@ export function computeBoardRenderVersion(repoRoot: string): string {
     }
     fileHashes[relativePath] = hashFile(absolutePath);
   }
+
+  const geometryRoot = path.join(repoRoot, BOARD_ART_GEOMETRY_ROOT);
+  if (!existsSync(geometryRoot)) {
+    throw new Error(
+      `board-render version input is missing: ${BOARD_ART_GEOMETRY_ROOT}. ` +
+        'Run `vp run generate:board-art-geometry`, or fix BOARD_ART_GEOMETRY_ROOT.',
+    );
+  }
+  fileHashes[BOARD_ART_GEOMETRY_ROOT] = hashDirectory(geometryRoot);
 
   const projections = buildBoardRenderProjections();
   const boardHashes: Record<string, string> = {};

--- a/scripts/glow-lab.ts
+++ b/scripts/glow-lab.ts
@@ -37,7 +37,6 @@ import sharp from 'sharp';
 import type { BoardName } from '../packages/shared-schema/src/types/board-config';
 import { HOLD_STATE_MAP } from '../packages/board-constants/src/hold-states';
 import { loadBoardArtGeometry, getWallLightness } from '../packages/shared/board-art-geometry/src/loader';
-import { veilOpacityFor } from '../packages/shared/board-art-geometry/src/veil';
 import { getBoardDetailsForBoard } from '../packages/shared/board-render/src/board-details';
 import { getBackgroundRelPaths } from '../packages/shared/board-render/src/background';
 import { buildRenderConfig, THUMBNAIL_WIDTH } from '../packages/shared/board-render/src/render-config';
@@ -237,13 +236,6 @@ async function main(): Promise<void> {
   const geometry = loadBoardArtGeometry(labBoard);
   if (!geometry) throw new Error(`no board-art-geometry shard for ${boardName}/${layoutId}-${sizeId}`);
   const wallLightness = getWallLightness(labBoard);
-  const veilOpacity = wallLightness
-    ? veilOpacityFor({
-        wallLightness: wallLightness.mean,
-        coverage: wallLightness.coverage,
-        fieldColor: FIELD_COLOR,
-      })
-    : 0;
 
   // Board art composite, built once: dark play field, then every art layer.
   const { boardWidth, boardHeight } = boardDetails;
@@ -283,10 +275,12 @@ async function main(): Promise<void> {
         boardStates,
         renderMode: 'aura',
         glowFalloff: 'soft',
-        // Production thumbnails take the fill under the glow (`glow-fill`);
-        // the play view takes the bare glow.
-        markStyle: thumbnail ? 'glow-fill' : 'glow',
-        ...(veilOpacity > 0 ? { veil: { color: FIELD_COLOR, opacity: veilOpacity } } : {}),
+        // The look's own mark treatment and veil come out of the shared builder:
+        // production thumbnails take the fill under the glow (`glow-fill`), the
+        // play view takes the bare glow, and the wash is measured from this
+        // board's wall against the field. The lab's variants layer on top.
+        fieldColor: FIELD_COLOR,
+        wallLightness,
         // The lab layers spill overrides onto the built config, so the unlit
         // neighbour outlines must be present — but only where there are
         // outlines at all, which Modern Classic is defined by not having.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -129,6 +129,7 @@ export default defineConfig({
       './packages/shared/ble-protocol/vite.config.ts',
       './packages/shared/board-config/vite.config.ts',
       './packages/shared/board-art-geometry/vite.config.ts',
+      './packages/shared/board-look/vite.config.ts',
       './packages/shared/board-render/vite.config.ts',
       './packages/shared/velvet-tokens/vite.config.ts',
       './packages/shared/text-redaction/vite.config.ts',
@@ -182,7 +183,12 @@ export default defineConfig({
     // pixels `immutable` for a year (#4773). Broad globs on purpose: the generator
     // derives its inputs from the board catalogue, so a narrow paths list here
     // would be a guard that silently stops guarding.
-    '{packages/board-renderer/wasm/pkg/**,packages/shared/board-render/src/**,packages/shared/board-config/src/**,packages/board-constants/src/**,packages/web/public/images/**}':
+    //
+    // `board-look` holds the Aura tuning the projection reads (glow reach, the
+    // seam crossfade, the veil buckets), and the traced-art shards are hashed
+    // into the version directly — both change pixels without touching anything
+    // else listed here.
+    '{packages/board-renderer/wasm/pkg/**,packages/shared/board-look/src/**,packages/shared/board-art-geometry/src/generated/**,packages/shared/board-render/src/**,packages/shared/board-config/src/**,packages/board-constants/src/**,packages/web/public/images/**}':
       () => 'vp run check:board-render-version',
   },
   run: {


### PR DESCRIPTION
## Summary

First of three, towards #5103 (kiosks still draw the old circles) and the same
gap on www and the share cards.

First of three. Aura has been the app's default drawing since 2.4, but every other
surface still renders classic circles. This one does not flip anything — it makes the
server *able* to draw Aura properly, which today it cannot.

Ask `/og/climb` or `/render/board` for `render_mode=aura` on `main` and you get
something that is not the app's picture:

- The config carried `render_mode`, `glow_falloff` and `glyphs` and nothing else, so
  the Rust renderer filled in its own neutral `GlowTuning` — a flatter light, a hard
  colour seam where two roles' glows meet, no fill, no LED covers.
- Nothing ever passed `holdGeometry`, so every lit hold glowed a **circle** instead of
  its traced silhouette.
- `field_color` was a documented no-op: `prepareRender` hardcoded
  `veil: { opacity: 0 }` behind a `TODO(#2202)`.

The root cause is where the tuning lives. `AURA_GLOW_TUNING`, the veil buckets and the
shipped defaults sat in `packages/mobile/src/lib/board-render-settings.ts`, next to the
preference store — which imports React, so www and the backend could not read them.

### What changed

- **New `@boardsesh/board-look`** — the look as data. Setting types, shipped defaults,
  `AURA_GLOW_TUNING`, veil buckets, play-field colours, and `buildAuraRenderFields`: the
  one function that turns them into the snake_case block the renderer consumes. Mobile's
  `buildBoardseshFields` is now a call into it, so the two cannot drift. The preference
  store, its sanitisers and the capability probe stay in mobile.
- **`buildRenderConfig`** takes `fieldColor`, `wallLightness` and `auraSettings`, and
  emits the whole block including `glow` and `fill`. `holdShape: 'circle'` withholds the
  silhouettes, which is all Modern Classic ever was.
- **The backend** loads this board config's shard from `@boardsesh/board-art-geometry`
  and measures its wall against the requested field, so an Aura render carries real
  outlines, LED plates and a real veil.
- **Import hygiene** — `render-config.ts` reaches the geometry package through its
  `/spill`, `/veil` and `/types` leaves instead of the barrel, which drags all 51 shards
  (5.2 MB) in. That keeps it safe to pull into a browser bundle, which PR 2 does.
- **The version generator** hashes the traced-art directory. The projection probes with
  an empty frames string, so no hold is lit and no polygon ever reaches the digest —
  without this, re-tracing a board moved no version and Cloudflare would serve the old
  silhouettes `immutable` for a year.

Verified by rendering Kilter, Tension, MoonBoard, Grasshopper and Woods through the real
backend service both ways: Aura now draws hold-shaped glows, the LED pips are covered,
and the veil quiets the wall on the boards whose art was measured bright enough for it
(Woods and MoonBoard 1-1 correctly get no veil — no wall reading to bucket).

No committed WASM or native rebuild: the shipped artifact already contains `core/src/aura/`,
`seam_sharpness`, `merge_softness`, `fringe_deepen`, `led_inner` and `silhouette_lightness`,
and all three copies are byte-identical.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 2/5 — no surface changes behaviour yet; every caller still defaults to classic, and the classic config is pinned byte-identical by test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyJ2p57PwKURkzwrxTsAN5
