### PR TITLE
fix(mobile): thread the app colour scheme into every native Compose host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,6 +502,12 @@ jobs:
       # `vp check`, so this grep guard is the real backstop.
       - name: Check offline-sync adapter boundary
         run: vp run check:mobile-offline-sync-imports
+      # `Host` (@expo/ui), `Text` and `useColorScheme` (react-native) must be
+      # imported through their theme-aware wrappers — a bare one silently renders
+      # BLACK text on the dark Android surfaces. Same story as the two guards
+      # above: the .oxlintrc rules aren't enforced by `vp check`.
+      - name: Check mobile theme-aware imports
+        run: vp run check:mobile-theme-imports
       # PRs and main lint the SAME thing: the whole repo. This job used to lint
       # only a PR's changed files and reserve the full-repo pass for push-to-main,
       # which meant an error in a file no PR happened to touch could not be caught

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -172,6 +172,21 @@
                 "name": "@boardsesh/offline-sync",
                 "importNames": ["drainMutationQueue", "startSyncScheduler", "triggerSync", "pullSync"],
                 "message": "Import these from src/offline/offline-sync-adapter instead \u2014 the package leaves the connectivity probe, AppState/NetInfo triggers, and Sentry telemetry injected, and only the adapter binds them."
+              },
+              {
+                "name": "@expo/ui",
+                "importNames": ["Host"],
+                "message": "Use ThemedHost (src/components/ThemedHost) instead. A bare `Host` themes its native subtree from the DEVICE colour scheme \u2014 on Android both the JS palette (react-native useColorScheme) and the Compose theme (isSystemInDarkTheme) ignore the in-app Light/Dark override, so a dark app on a light phone renders near-black Compose text on the dark surface."
+              },
+              {
+                "name": "react-native",
+                "importNames": ["Text"],
+                "message": "Use the Text primitive (src/components/Text) instead \u2014 it resolves the per-variant type scale and defaults the colour to the adaptive theme.systemColors.label. RN's own Text defaults to non-adaptive BLACK and breaks in dark mode. See docs/ai-design-guidelines.md."
+              },
+              {
+                "name": "react-native",
+                "importNames": ["useColorScheme"],
+                "message": "Use useAppColorScheme() from src/providers/theme-provider. RN's useColorScheme follows the OS trait collection and on Android does NOT track Appearance.setColorScheme, so it reads 'light' for a user running the app's own Dark theme on a light-mode phone (issue #3885)."
               }
             ]
           }
@@ -189,6 +204,28 @@
                 "group": ["@expo/ui/jetpack-compose", "@expo/ui/jetpack-compose/*"],
                 "message": "@expo/ui/jetpack-compose is Android-only \u2014 it must not be imported from a *.ios file. Put Compose code in the matching *.android.tsx file."
               }
+            ],
+            "paths": [
+              {
+                "name": "@boardsesh/offline-sync",
+                "importNames": ["drainMutationQueue", "startSyncScheduler", "triggerSync", "pullSync"],
+                "message": "Import these from src/offline/offline-sync-adapter instead \u2014 the package leaves the connectivity probe, AppState/NetInfo triggers, and Sentry telemetry injected, and only the adapter binds them."
+              },
+              {
+                "name": "@expo/ui",
+                "importNames": ["Host"],
+                "message": "Use ThemedHost (src/components/ThemedHost) instead. A bare `Host` themes its native subtree from the DEVICE colour scheme \u2014 on Android both the JS palette (react-native useColorScheme) and the Compose theme (isSystemInDarkTheme) ignore the in-app Light/Dark override, so a dark app on a light phone renders near-black Compose text on the dark surface."
+              },
+              {
+                "name": "react-native",
+                "importNames": ["Text"],
+                "message": "Use the Text primitive (src/components/Text) instead \u2014 it resolves the per-variant type scale and defaults the colour to the adaptive theme.systemColors.label. RN's own Text defaults to non-adaptive BLACK and breaks in dark mode. See docs/ai-design-guidelines.md."
+              },
+              {
+                "name": "react-native",
+                "importNames": ["useColorScheme"],
+                "message": "Use useAppColorScheme() from src/providers/theme-provider. RN's useColorScheme follows the OS trait collection and on Android does NOT track Appearance.setColorScheme, so it reads 'light' for a user running the app's own Dark theme on a light-mode phone (issue #3885)."
+              }
             ]
           }
         ]
@@ -205,9 +242,41 @@
                 "group": ["@expo/ui/swift-ui", "@expo/ui/swift-ui/*"],
                 "message": "@expo/ui/swift-ui is iOS-only \u2014 it must not be imported from a *.android file. Put SwiftUI code in the matching *.ios.tsx file."
               }
+            ],
+            "paths": [
+              {
+                "name": "@boardsesh/offline-sync",
+                "importNames": ["drainMutationQueue", "startSyncScheduler", "triggerSync", "pullSync"],
+                "message": "Import these from src/offline/offline-sync-adapter instead \u2014 the package leaves the connectivity probe, AppState/NetInfo triggers, and Sentry telemetry injected, and only the adapter binds them."
+              },
+              {
+                "name": "@expo/ui",
+                "importNames": ["Host"],
+                "message": "Use ThemedHost (src/components/ThemedHost) instead. A bare `Host` themes its native subtree from the DEVICE colour scheme \u2014 on Android both the JS palette (react-native useColorScheme) and the Compose theme (isSystemInDarkTheme) ignore the in-app Light/Dark override, so a dark app on a light phone renders near-black Compose text on the dark surface."
+              },
+              {
+                "name": "react-native",
+                "importNames": ["Text"],
+                "message": "Use the Text primitive (src/components/Text) instead \u2014 it resolves the per-variant type scale and defaults the colour to the adaptive theme.systemColors.label. RN's own Text defaults to non-adaptive BLACK and breaks in dark mode. See docs/ai-design-guidelines.md."
+              },
+              {
+                "name": "react-native",
+                "importNames": ["useColorScheme"],
+                "message": "Use useAppColorScheme() from src/providers/theme-provider. RN's useColorScheme follows the OS trait collection and on Android does NOT track Appearance.setColorScheme, so it reads 'light' for a user running the app's own Dark theme on a light-mode phone (issue #3885)."
+              }
             ]
           }
         ]
+      }
+    },
+    {
+      "files": [
+        "packages/mobile/src/components/ThemedHost.tsx",
+        "packages/mobile/src/components/Text.tsx",
+        "packages/mobile/src/providers/theme-provider.tsx"
+      ],
+      "rules": {
+        "no-restricted-imports": "off"
       }
     }
   ],

--- a/packages/mobile/app/_layout.tsx
+++ b/packages/mobile/app/_layout.tsx
@@ -15,7 +15,7 @@ import '../src/lib/analytics-bootstrap';
 // this cannot become a hook or an effect. See observe-bootstrap.ts.
 import '../src/lib/observe-bootstrap';
 import { useCallback, useEffect, useRef, useMemo, useState, type ReactNode } from 'react';
-import { LogBox, Pressable, StyleSheet, View } from 'react-native';
+import { Appearance, LogBox, Pressable, StyleSheet, View } from 'react-native';
 // Navigation theme comes from expo-router's vendored React Navigation. Expo
 // SDK 57's expo-router is not compatible with a separately-installed
 // @react-navigation/* package, so import these from `expo-router` directly.
@@ -73,8 +73,7 @@ import { useActiveBoardSelfHeal } from '../src/lib/boards/use-active-board-self-
 import { ScreenshotBoardAutoActivator } from '../src/components/screenshot-board-auto-activator';
 import { Text } from '../src/components/Text';
 import { Icon } from '../src/components/Icon';
-import { brandColors } from '../src/theme/colors';
-import { iosDarkColors } from '../src/theme/ios-colors';
+import { brandColors, brandColorsDark, materialSurfaces } from '../src/theme/colors';
 import { spacing } from '../src/theme/tokens';
 import { glassStackScreenOptions } from '../src/theme/navigation';
 import { reportError, reportHandledError } from '../src/lib/error-reporting';
@@ -342,18 +341,25 @@ export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
   const recoveryLabel =
     recovery.kind === 'busy' ? (recovery.phase === 'downloading' ? 'Downloading…' : 'Checking…') : 'Check for a fix';
 
+  // This boundary can render OUTSIDE ThemeProvider, so `useTheme()` would throw and
+  // the `Text` primitive's `useOptionalTheme()` returns null — leaving RN's
+  // non-adaptive BLACK ink on a container that painted no ground of its own, i.e.
+  // black on the near-black nav scene. Read the scheme straight from `Appearance`
+  // (ThemeProvider drives it from the in-app override, so it tracks the user's
+  // choice) and paint both the ground and the ink explicitly.
+  const crashScheme = Appearance.getColorScheme() === 'dark' ? 'dark' : 'light';
+  const crashSurface = materialSurfaces[crashScheme];
+  const crashBrand = crashScheme === 'dark' ? brandColorsDark : brandColors;
+
   return (
-    <View style={errorStyles.container}>
+    <View style={[errorStyles.container, { backgroundColor: crashSurface.background }]}>
       <View style={errorStyles.iconContainer}>
-        {/* Static brand colour on purpose: this boundary can render outside the
-            ThemeProvider (the crash screen), where useTheme() would throw — so
-            it can't read the scheme-aware brand. */}
-        <Icon name="warning" size={48} color={brandColors.warning} />
+        <Icon name="warning" size={48} color={crashBrand.warning} />
       </View>
-      <Text variant="title2" style={errorStyles.title}>
+      <Text variant="title2" style={errorStyles.title} color={crashSurface.label}>
         Something went wrong
       </Text>
-      <Text variant="body" style={errorStyles.message}>
+      <Text variant="body" style={errorStyles.message} color={crashSurface.secondaryLabel}>
         The app hit an unexpected error. You can try again or head back home.
       </Text>
       <View style={errorStyles.buttonRow}>
@@ -375,7 +381,7 @@ export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
               isBusy && errorStyles.disabledButton,
             ]}
           >
-            <Text variant="body" color={brandColors.onPrimary} style={errorStyles.buttonLabel}>
+            <Text variant="body" color={crashBrand.onPrimary} style={errorStyles.buttonLabel}>
               {recoveryLabel}
             </Text>
           </Pressable>
@@ -391,7 +397,7 @@ export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
         >
           <Text
             variant="body"
-            color={showRecoveryButton ? brandColors.primary : brandColors.onPrimary}
+            color={showRecoveryButton ? crashBrand.primary : crashBrand.onPrimary}
             style={errorStyles.buttonLabel}
           >
             Try again
@@ -403,18 +409,18 @@ export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
           accessibilityLabel="Go home"
           style={({ pressed }) => [errorStyles.secondaryButton, pressed && errorStyles.pressedButton]}
         >
-          <Text variant="body" color={brandColors.primary} style={errorStyles.buttonLabel}>
+          <Text variant="body" color={crashBrand.primary} style={errorStyles.buttonLabel}>
             Go home
           </Text>
         </Pressable>
       </View>
       {recovery.kind === 'no-fix-available' && (
-        <Text variant="footnote" style={errorStyles.statusText}>
+        <Text variant="footnote" style={errorStyles.statusText} color={crashSurface.secondaryLabel}>
           No fix available yet — try again in a few minutes.
         </Text>
       )}
       {recovery.kind === 'failed' && (
-        <Text variant="footnote" style={errorStyles.statusText}>
+        <Text variant="footnote" style={errorStyles.statusText} color={crashSurface.secondaryLabel}>
           Couldn&apos;t reach the update server. Check your connection and try again.
         </Text>
       )}
@@ -464,7 +470,7 @@ function BoardProviderWrapper({ children }: { children: ReactNode }) {
 // honours the appearance override) rather than a separate useColorScheme(), so
 // the nav chrome and the app theme can't disagree for a frame.
 function ThemedNavigation({ children }: { children: ReactNode }) {
-  const { colorScheme } = useTheme();
+  const { colorScheme, chartColors } = useTheme();
   const navTheme = useMemo(
     () =>
       colorScheme === 'dark'
@@ -472,12 +478,18 @@ function ThemedNavigation({ children }: { children: ReactNode }) {
             ...DarkTheme,
             colors: {
               ...DarkTheme.colors,
-              background: iosDarkColors.background,
-              card: iosDarkColors.secondaryBackground,
+              // The resolved variant's own surfaces, not the iOS neutrals this
+              // used to hardcode: on Material those were a hard #000/#1C1C1E
+              // scene sitting behind violet-tinted M3 cards, so every screen
+              // edge read as a seam. `chartColors` is the plain-string mirror of
+              // `systemColors`, which React Navigation needs (it cannot take a
+              // PlatformColor).
+              background: chartColors.background,
+              card: chartColors.secondaryBackground,
             },
           }
         : DefaultTheme,
-    [colorScheme],
+    [colorScheme, chartColors],
   );
   return (
     <NavigationThemeProvider value={navTheme}>

--- a/packages/mobile/app/auth/login.tsx
+++ b/packages/mobile/app/auth/login.tsx
@@ -203,7 +203,9 @@ export default function LoginScreen() {
           <>
             <View style={styles.dividerRow}>
               <View style={[styles.dividerLine, { backgroundColor: theme.systemColors.separator }]} />
-              <Text style={styles.dividerLabel}>{t('nativeStart.orContinueWith')}</Text>
+              <Text style={[styles.dividerLabel, { color: theme.systemColors.secondaryLabel }]}>
+                {t('nativeStart.orContinueWith')}
+              </Text>
               <View style={[styles.dividerLine, { backgroundColor: theme.systemColors.separator }]} />
             </View>
 

--- a/packages/mobile/src/components/AppMenu.android.tsx
+++ b/packages/mobile/src/components/AppMenu.android.tsx
@@ -7,10 +7,10 @@
 // closed on each select.
 
 import { useMemo, useState } from 'react';
-import { Host } from '@expo/ui';
 import { DropdownMenu, DropdownMenuItem, Row, Text } from '@expo/ui/jetpack-compose';
 import { clickable, padding } from '@expo/ui/jetpack-compose/modifiers';
 import { useTheme } from '../providers/theme-provider';
+import { ThemedHost } from './ThemedHost';
 import { brandAccentColor } from '../theme/expo-ui-modifiers';
 import { spacing } from '../theme/tokens';
 import { resolveMenuActions } from './AppMenu.logic';
@@ -30,7 +30,7 @@ export function AppMenu({
   accessibilityHint,
   style,
 }: AppMenuProps) {
-  const { brandColors, m3, systemColors, colorScheme } = useTheme();
+  const { brandColors, m3, systemColors } = useTheme();
   const [expanded, setExpanded] = useState(false);
   const resolved = useMemo(() => resolveMenuActions(actions), [actions]);
 
@@ -50,18 +50,17 @@ export function AppMenu({
     // gym name isn't clipped in the open list (symmetric with the iOS Menu, which caps
     // the anchor, not the popup).
     //
-    // `colorScheme` forces the Compose MaterialTheme (the menu surface + default
-    // content colours) to follow our in-app Light/Dark toggle (`themeOverride`)
-    // instead of the OS scheme — same fix MoreForm uses; without it the menu surface
-    // and text track the device scheme and clash with the app.
+    // `ThemedHost` forces the Compose MaterialTheme (the menu surface + default
+    // content colours) onto our in-app Light/Dark toggle (`themeOverride`) instead of
+    // the OS scheme; a bare `Host` would let the menu surface and text track the
+    // device scheme and clash with the app.
     //
     // Accessibility rides the RN Host boundary: @expo/ui/jetpack-compose has no
     // content-description modifier, and the Host forwards these props to its native
     // view — so the trigger reads as a labelled button to TalkBack, matching the iOS
     // `Menu` a11y modifiers and the old Paper Pressable anchor.
-    <Host
+    <ThemedHost
       matchContents
-      colorScheme={colorScheme}
       accessibilityRole="button"
       accessibilityLabel={accessibilityLabel ?? label}
       accessibilityHint={accessibilityHint}
@@ -110,6 +109,6 @@ export function AppMenu({
           })}
         </DropdownMenu.Items>
       </DropdownMenu>
-    </Host>
+    </ThemedHost>
   );
 }

--- a/packages/mobile/src/components/AppMenu.ios.tsx
+++ b/packages/mobile/src/components/AppMenu.ios.tsx
@@ -10,7 +10,6 @@
 // The menu popup is always a native UIMenu, so this file is OS-split (iOS), not
 // variant-routed — a user who forces the Material variant on iOS still gets it.
 
-import { Host } from '@expo/ui';
 import { Menu, Button, HStack, Text, Image } from '@expo/ui/swift-ui';
 import {
   buttonStyle,
@@ -25,6 +24,7 @@ import {
 import { useMemo, type ComponentProps } from 'react';
 import { StyleSheet } from 'react-native';
 import { useTheme } from '../providers/theme-provider';
+import { ThemedHost } from './ThemedHost';
 import { spacing } from '../theme/tokens';
 import { resolveMenuActions } from './AppMenu.logic';
 import type { AppMenuProps } from './AppMenu.types';
@@ -64,7 +64,7 @@ export function AppMenu({
   );
 
   return (
-    <Host matchContents style={[styles.host, style]}>
+    <ThemedHost matchContents style={[styles.host, style]}>
       <Menu
         modifiers={menuModifiers}
         label={
@@ -92,7 +92,7 @@ export function AppMenu({
           />
         ))}
       </Menu>
-    </Host>
+    </ThemedHost>
   );
 }
 

--- a/packages/mobile/src/components/AuthFieldset.ios.tsx
+++ b/packages/mobile/src/components/AuthFieldset.ios.tsx
@@ -19,7 +19,6 @@
 
 import { useCallback, useEffect, useRef, type RefObject } from 'react';
 import { AccessibilityInfo, StyleSheet } from 'react-native';
-import { Host } from '@expo/ui';
 import {
   TextField,
   SecureField,
@@ -45,6 +44,7 @@ import {
   tint,
 } from '@expo/ui/swift-ui/modifiers';
 import { useTheme } from '../providers/theme-provider';
+import { ThemedHost } from './ThemedHost';
 import { brandAccentColor } from '../theme/expo-ui-modifiers';
 import { iosSystemColors } from '../theme/ios-colors';
 import {
@@ -189,7 +189,7 @@ export function AuthFieldset({ fields, onSubmit }: AuthFieldsetProps) {
   const lastIndex = fields.length - 1;
 
   return (
-    <Host matchContents={{ vertical: true }} style={styles.host}>
+    <ThemedHost matchContents={{ vertical: true }} style={styles.host}>
       <VStack alignment="leading" spacing={12}>
         {fields.map((spec, index) => (
           <AuthField
@@ -202,7 +202,7 @@ export function AuthFieldset({ fields, onSubmit }: AuthFieldsetProps) {
           />
         ))}
       </VStack>
-    </Host>
+    </ThemedHost>
   );
 }
 

--- a/packages/mobile/src/components/AuthTextInput.android.tsx
+++ b/packages/mobile/src/components/AuthTextInput.android.tsx
@@ -26,13 +26,13 @@ import {
   type ComponentProps,
 } from 'react';
 import { StyleSheet } from 'react-native';
-import { Host } from '@expo/ui';
 // useNativeState comes from the platform module (not the @expo/ui root) so its
 // ObservableState type matches the field's `value` prop — the root re-export
 // resolves to the universal, simplified ObservableState that doesn't.
 import { Icon, IconButton, OutlinedTextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
 import { semantics, testID as testIDModifier } from '@expo/ui/jetpack-compose/modifiers';
 import { useTheme } from '../providers/theme-provider';
+import { ThemedHost } from './ThemedHost';
 import { textFieldBrandColors } from '../theme/expo-ui-modifiers';
 import {
   computeMasked,
@@ -71,7 +71,9 @@ export const AuthTextInput = forwardRef<AuthTextInputHandle, AuthTextInputProps>
   },
   ref,
 ) {
-  const { brandColors } = useTheme();
+  // `chartColors` (not `systemColors`) because native Compose props need plain
+  // strings — it is the same palette, guaranteed hex rather than PlatformColor.
+  const { brandColors, chartColors } = useTheme();
   const textState = useNativeState(value);
   const lastEmittedRef = useRef(value);
   const fieldRef = useRef<{ focus: () => Promise<void> }>(null);
@@ -155,7 +157,7 @@ export const AuthTextInput = forwardRef<AuthTextInputHandle, AuthTextInputProps>
   const supportingText = error ?? hint;
 
   return (
-    <Host matchContents={{ vertical: true }} style={styles.host}>
+    <ThemedHost matchContents={{ vertical: true }} style={styles.host}>
       <OutlinedTextField
         ref={fieldRef as unknown as ComponentProps<typeof OutlinedTextField>['ref']}
         value={textState}
@@ -169,7 +171,7 @@ export const AuthTextInput = forwardRef<AuthTextInputHandle, AuthTextInputProps>
         visualTransformation={masked ? 'password' : 'none'}
         keyboardOptions={keyboardOptions}
         keyboardActions={keyboardActions}
-        colors={textFieldBrandColors(brandColors)}
+        colors={textFieldBrandColors(brandColors, chartColors)}
         modifiers={[
           // Autofill (Google Autofill / password managers).
           ...(contentType ? [semantics({ contentType })] : []),
@@ -198,7 +200,7 @@ export const AuthTextInput = forwardRef<AuthTextInputHandle, AuthTextInputProps>
           </OutlinedTextField.TrailingIcon>
         ) : null}
       </OutlinedTextField>
-    </Host>
+    </ThemedHost>
   );
 });
 

--- a/packages/mobile/src/components/AuthTextInput.ios.tsx
+++ b/packages/mobile/src/components/AuthTextInput.ios.tsx
@@ -23,7 +23,6 @@
 
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, type RefObject } from 'react';
 import { StyleSheet, View } from 'react-native';
-import { Host } from '@expo/ui';
 // useNativeState comes from the platform module (not the @expo/ui root) so its
 // ObservableState type matches the field's `text` prop — the root re-export
 // resolves to the universal, simplified ObservableState that doesn't.
@@ -43,6 +42,7 @@ import {
   tint,
 } from '@expo/ui/swift-ui/modifiers';
 import { useTheme } from '../providers/theme-provider';
+import { ThemedHost } from './ThemedHost';
 import { brandAccentColor } from '../theme/expo-ui-modifiers';
 import { iosSystemColors } from '../theme/ios-colors';
 import { Text } from './Text';
@@ -154,7 +154,7 @@ export const AuthTextInput = forwardRef<AuthTextInputHandle, AuthTextInputProps>
 
   return (
     <View>
-      <Host matchContents={{ vertical: true }} style={styles.host}>
+      <ThemedHost matchContents={{ vertical: true }} style={styles.host}>
         {secureTextEntry ? (
           <SecureField
             ref={fieldRef as RefObject<SecureFieldRef>}
@@ -172,7 +172,7 @@ export const AuthTextInput = forwardRef<AuthTextInputHandle, AuthTextInputProps>
             modifiers={modifiers}
           />
         )}
-      </Host>
+      </ThemedHost>
       {error ? (
         <Text
           variant="footnote"

--- a/packages/mobile/src/components/Button.android.tsx
+++ b/packages/mobile/src/components/Button.android.tsx
@@ -12,7 +12,6 @@
 // (no native equivalent) swaps the leading icon for a CircularProgressIndicator
 // and disables the button. The press/haptic guard lives in Button.logic.ts.
 
-import { Host } from '@expo/ui';
 import {
   Button as ComposeButton,
   FilledTonalButton,
@@ -26,6 +25,7 @@ import {
 import { defaultMinSize, fillMaxWidth, padding, size } from '@expo/ui/jetpack-compose/modifiers';
 import type { ImageSourcePropType } from 'react-native';
 import { useTheme } from '../providers/theme-provider';
+import { ThemedHost } from './ThemedHost';
 import { brandAccentColor } from '../theme/expo-ui-modifiers';
 import { isFullWidthStyle, makeButtonPressHandler } from './Button.logic';
 import { sizeConfig, type ButtonProps } from './Button.types';
@@ -70,7 +70,7 @@ export function Button({
   testID,
   style,
 }: ButtonProps) {
-  const { brandColors, colorScheme } = useTheme();
+  const { brandColors } = useTheme();
   const handlePress = makeButtonPressHandler({ onPress, disabled, loading, haptic });
 
   // A Compose Button takes its accessible name from its Text content (the title),
@@ -145,12 +145,7 @@ export function Button({
   ];
 
   return (
-    <Host
-      matchContents={isFullWidth ? { vertical: true } : true}
-      colorScheme={colorScheme}
-      style={style}
-      testID={testID}
-    >
+    <ThemedHost matchContents={isFullWidth ? { vertical: true } : true} style={style} testID={testID}>
       <Comp
         onClick={handlePress}
         enabled={!(disabled || loading)}
@@ -176,6 +171,6 @@ export function Button({
           <Text>{title}</Text>
         </Row>
       </Comp>
-    </Host>
+    </ThemedHost>
   );
 }

--- a/packages/mobile/src/components/Button.ios.tsx
+++ b/packages/mobile/src/components/Button.ios.tsx
@@ -22,7 +22,6 @@
 // equivalent, so it swaps the leading icon for an indeterminate `ProgressView` and
 // disables the button. The press/haptic guard lives in Button.logic.ts.
 
-import { Host } from '@expo/ui';
 import { Button as SwiftUIButton, HStack, Image, ProgressView, Text } from '@expo/ui/swift-ui';
 import {
   accessibilityLabel as accessibilityLabelModifier,
@@ -38,6 +37,7 @@ import {
 } from '@expo/ui/swift-ui/modifiers';
 import { useGlassCapability } from '../hooks/use-glass-capability';
 import { useTheme } from '../providers/theme-provider';
+import { ThemedHost } from './ThemedHost';
 import { brandAccentColor } from '../theme/expo-ui-modifiers';
 import { overlays } from '../theme/tokens';
 import { isFullWidthStyle, makeButtonPressHandler } from './Button.logic';
@@ -74,7 +74,7 @@ export function Button({
   testID,
   style,
 }: ButtonProps) {
-  const { brandColors, radii, colorScheme } = useTheme();
+  const { brandColors, radii } = useTheme();
   const supportsGlass = useGlassCapability();
   const surfaceFromContext = useButtonSurface();
   const effectiveOver = over ?? surfaceFromContext;
@@ -141,12 +141,7 @@ export function Button({
   const buttonRole = isDestructive ? 'destructive' : role === 'cancel' ? 'cancel' : undefined;
 
   return (
-    <Host
-      matchContents={isFullWidth ? { vertical: true } : true}
-      colorScheme={colorScheme}
-      style={style}
-      testID={testID}
-    >
+    <ThemedHost matchContents={isFullWidth ? { vertical: true } : true} style={style} testID={testID}>
       <SwiftUIButton role={buttonRole} onPress={handlePress} modifiers={modifiers}>
         <HStack spacing={6}>
           {loading ? (
@@ -157,6 +152,6 @@ export function Button({
           <Text>{title}</Text>
         </HStack>
       </SwiftUIButton>
-    </Host>
+    </ThemedHost>
   );
 }

--- a/packages/mobile/src/components/FeatureFlagsForm.android.tsx
+++ b/packages/mobile/src/components/FeatureFlagsForm.android.tsx
@@ -15,7 +15,6 @@
 //
 // All copy is hardcoded English with `i18n-ignore` — tester-only.
 
-import { Host } from '@expo/ui';
 import {
   LazyColumn,
   Card,
@@ -28,26 +27,33 @@ import {
 import { fillMaxWidth, padding, alpha } from '@expo/ui/jetpack-compose/modifiers';
 import { StyleSheet } from 'react-native';
 import { useTheme } from '../providers/theme-provider';
+import { ThemedHost } from './ThemedHost';
 import { segmentedBrandColors } from '../theme/expo-ui-modifiers';
 import { spacing } from '../theme/tokens';
 import type { FeatureFlagsFormProps } from './FeatureFlagsForm.types';
 
 export function FeatureFlagsForm({ rows, onSelect, onReset, canReset, noticeText, title }: FeatureFlagsFormProps) {
-  const { brandColors, colorScheme } = useTheme();
+  // `chartColors` mirrors `systemColors` as guaranteed plain strings, which is
+  // what native Compose colour props need.
+  const { brandColors, chartColors } = useTheme();
   const segmentColors = segmentedBrandColors(brandColors);
 
   return (
-    // `colorScheme` forces the Compose MaterialTheme to follow the in-app
-    // Light/Dark toggle (`themeOverride`) instead of the OS scheme — without it the
+    // `ThemedHost` forces the Compose MaterialTheme onto the in-app Light/Dark
+    // toggle (`themeOverride`) instead of the OS scheme — with a bare `Host` the
     // cards stay dark when the user picks "Light" in-app.
-    <Host style={styles.host} colorScheme={colorScheme}>
+    <ThemedHost style={styles.host}>
       <LazyColumn
         contentPadding={{ start: spacing[4], top: spacing[4], end: spacing[4], bottom: spacing[10] }}
         verticalArrangement={{ spacedBy: spacing[3] }}
       >
+        {/* These two sit OUTSIDE the Cards below, so nothing provides Compose's
+            `LocalContentColor` — its default is black. Explicit colour required. */}
         {/* i18n-ignore-next-line — tester-only screen */}
-        <Text style={{ typography: 'titleLarge' }}>{title}</Text>
-        <Text style={{ typography: 'bodySmall' }} modifiers={[alpha(0.6)]}>
+        <Text style={{ typography: 'titleLarge' }} color={chartColors.label}>
+          {title}
+        </Text>
+        <Text style={{ typography: 'bodySmall' }} color={chartColors.secondaryLabel}>
           {noticeText}
         </Text>
 
@@ -92,7 +98,7 @@ export function FeatureFlagsForm({ rows, onSelect, onReset, canReset, noticeText
           <Text>Reset all overrides</Text>
         </Button>
       </LazyColumn>
-    </Host>
+    </ThemedHost>
   );
 }
 

--- a/packages/mobile/src/components/FeatureFlagsForm.ios.tsx
+++ b/packages/mobile/src/components/FeatureFlagsForm.ios.tsx
@@ -19,7 +19,6 @@
 // rest of the screen. The screen precomputes every derived string; this tree only
 // renders props.
 
-import { Host } from '@expo/ui';
 import { Form, Section, Picker, Text, Button, VStack } from '@expo/ui/swift-ui';
 import {
   pickerStyle,
@@ -32,19 +31,20 @@ import {
 } from '@expo/ui/swift-ui/modifiers';
 import { StyleSheet } from 'react-native';
 import { useTheme } from '../providers/theme-provider';
+import { ThemedHost } from './ThemedHost';
 import { brandAccentColor } from '../theme/expo-ui-modifiers';
 import { spacing } from '../theme/tokens';
 import { isKnownFeatureFlagChoice } from './FeatureFlagsForm.logic';
 import type { FeatureFlagsFormProps } from './FeatureFlagsForm.types';
 
 export function FeatureFlagsForm({ rows, onSelect, onReset, canReset, noticeText, title }: FeatureFlagsFormProps) {
-  const { brandColors, colorScheme } = useTheme();
+  const { brandColors } = useTheme();
   const accent = brandAccentColor(brandColors);
 
   return (
     // `colorScheme` forces the native appearance to follow the in-app Light/Dark
     // toggle (`themeOverride`) instead of the OS scheme.
-    <Host style={styles.host} useViewportSizeMeasurement colorScheme={colorScheme}>
+    <ThemedHost style={styles.host} useViewportSizeMeasurement>
       <Form>
         {/* `title` is the section header; `footer` carries the notice. A footer is a
             view slot, so it's a `<Text>` child, not a raw string. */}
@@ -104,7 +104,7 @@ export function FeatureFlagsForm({ rows, onSelect, onReset, canReset, noticeText
           />
         </Section>
       </Form>
-    </Host>
+    </ThemedHost>
   );
 }
 

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -240,7 +240,12 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
       enableDynamicSizing={useContentFitting}
       enablePanDownToClose={enablePanDownToClose}
       handleIndicatorStyle={sheet.handleStyle}
-      backgroundStyle={surface === 'solid' ? solidBackground : undefined}
+      // Android has no glass: @expo/ui's Compose BottomSheet falls back to
+      // `BottomSheetDefaults.ContainerColor`, which comes from the OS Compose theme
+      // (wallpaper-derived on Android 12+). So a "glass" sheet took a container
+      // colour unrelated to the app while its RN content used app-theme ink. Give
+      // Android an explicit ground either way; iOS keeps `undefined` for real glass.
+      backgroundStyle={surface === 'solid' || Platform.OS === 'android' ? solidBackground : undefined}
       onChange={handleChange}
       onFullyDismissed={managed.onFullyDismissed}
       style={styles.sheet}

--- a/packages/mobile/src/components/MoreForm.android.tsx
+++ b/packages/mobile/src/components/MoreForm.android.tsx
@@ -18,7 +18,6 @@
 
 import { useEffect, useState, type ReactNode } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { Host } from '@expo/ui';
 import {
   LazyColumn,
   Card,
@@ -43,6 +42,7 @@ import {
 import { fillMaxWidth, padding, alpha, weight, clickable, height } from '@expo/ui/jetpack-compose/modifiers';
 import { StyleSheet, type ColorValue, type ImageSourcePropType } from 'react-native';
 import { useTheme } from '../providers/theme-provider';
+import { ThemedHost } from './ThemedHost';
 import {
   segmentedBrandColors,
   sliderBrandColors,
@@ -331,7 +331,9 @@ function SliderRow({ row, colors }: { row: MoreSliderRow; colors: RowColors }) {
 }
 
 export function MoreForm({ model }: MoreFormProps) {
-  const { brandColors, systemColors, colorScheme } = useTheme();
+  // `chartColors` mirrors `systemColors` as guaranteed plain strings, which is
+  // what native Compose colour props need.
+  const { brandColors, systemColors, chartColors } = useTheme();
   const colors: RowColors = {
     brandColors,
     switchColors: switchBrandColors(brandColors),
@@ -340,12 +342,15 @@ export function MoreForm({ model }: MoreFormProps) {
   };
 
   // Flatten sections into LazyColumn items: title Text, the rows (carded unless
-  // the section is all buttons), then footer Text.
+  // the section is all buttons), then footer Text. The title/footer sit OUTSIDE the
+  // Card, so nothing provides `LocalContentColor` for them — Compose's default is
+  // black, in both schemes. They carry an explicit colour; the carded rows below
+  // inherit the Card's content colour and correctly do not.
   const items: ReactNode[] = [];
   for (const section of model.sections) {
     if (section.title) {
       items.push(
-        <Text key={`${section.key}-title`} style={{ typography: 'titleSmall' }} modifiers={[alpha(0.6)]}>
+        <Text key={`${section.key}-title`} style={{ typography: 'titleSmall' }} color={chartColors.secondaryLabel}>
           {section.title}
         </Text>,
       );
@@ -363,7 +368,7 @@ export function MoreForm({ model }: MoreFormProps) {
     }
     if (section.footer) {
       items.push(
-        <Text key={`${section.key}-footer`} style={{ typography: 'bodySmall' }} modifiers={[alpha(0.6)]}>
+        <Text key={`${section.key}-footer`} style={{ typography: 'bodySmall' }} color={chartColors.secondaryLabel}>
           {section.footer}
         </Text>,
       );
@@ -371,17 +376,17 @@ export function MoreForm({ model }: MoreFormProps) {
   }
 
   return (
-    // `colorScheme` forces the Compose MaterialTheme to follow our in-app
-    // Light/Dark toggle (`themeOverride`) instead of the OS scheme — without it the
+    // `ThemedHost` forces the Compose MaterialTheme onto our in-app Light/Dark
+    // toggle (`themeOverride`) instead of the OS scheme — with a bare `Host` the
     // cards stay dark when the user picks "Light" in-app.
-    <Host style={styles.host} colorScheme={colorScheme}>
+    <ThemedHost style={styles.host}>
       <LazyColumn
         contentPadding={{ start: spacing[4], top: spacing[4], end: spacing[4], bottom: spacing[10] }}
         verticalArrangement={{ spacedBy: spacing[3] }}
       >
         {items}
       </LazyColumn>
-    </Host>
+    </ThemedHost>
   );
 }
 

--- a/packages/mobile/src/components/MoreForm.ios.tsx
+++ b/packages/mobile/src/components/MoreForm.ios.tsx
@@ -18,7 +18,6 @@
 // (destructive colours it red).
 
 import type { ComponentProps } from 'react';
-import { Host } from '@expo/ui';
 import {
   Form,
   Section,
@@ -49,6 +48,7 @@ import {
 } from '@expo/ui/swift-ui/modifiers';
 import { StyleSheet, View } from 'react-native';
 import { useTheme } from '../providers/theme-provider';
+import { ThemedHost } from './ThemedHost';
 import { brandAccentColor } from '../theme/expo-ui-modifiers';
 import { spacing } from '../theme/tokens';
 import { assertNeverRow } from './MoreForm.logic';
@@ -265,14 +265,14 @@ function SliderRow({ row, accent }: { row: MoreSliderRow; accent: string }) {
 }
 
 export function MoreForm({ model }: MoreFormProps) {
-  const { brandColors, colorScheme } = useTheme();
+  const { brandColors } = useTheme();
   const accent = brandAccentColor(brandColors);
 
   return (
     // `colorScheme` forces the native appearance to follow our in-app Light/Dark
     // toggle (`themeOverride`) instead of the OS scheme — harmless on iOS but the
     // way the SwiftUI tree honours a non-system choice.
-    <Host style={styles.host} useViewportSizeMeasurement colorScheme={colorScheme}>
+    <ThemedHost style={styles.host} useViewportSizeMeasurement>
       <Form>
         {model.sections.map((section) => (
           <Section
@@ -284,7 +284,7 @@ export function MoreForm({ model }: MoreFormProps) {
           </Section>
         ))}
       </Form>
-    </Host>
+    </ThemedHost>
   );
 }
 

--- a/packages/mobile/src/components/RadioGroup.android.tsx
+++ b/packages/mobile/src/components/RadioGroup.android.tsx
@@ -8,13 +8,14 @@
 // RadioButton's own `onClick` is left undefined so the tap fires once, not twice.
 // Unlike iOS, Android CAN show the per-option `description` and disable a row, so
 // the public API's full fidelity survives here. Brand tint comes from the Compose
-// Material theme the Host sets up (RadioButton has no colours prop — it reads M3
-// `primary`, which is the brand accent under our theme).
+// Material theme `ThemedHost` sets up (RadioButton has no colours prop — it reads
+// M3 `primary`, which is the brand accent under our theme). Every `Text` carries an
+// explicit colour: Compose's `LocalContentColor` defaults to BLACK outside a
+// Surface-family composable, so an uncoloured label is black in both schemes.
 //
 // One Host per control is intentional for now (RadioGroup is used one-per-card).
 
 import { useMemo } from 'react';
-import { Host } from '@expo/ui';
 import { Column, Row, Text, RadioButton } from '@expo/ui/jetpack-compose';
 import {
   fillMaxWidth,
@@ -26,7 +27,9 @@ import {
   alpha,
 } from '@expo/ui/jetpack-compose/modifiers';
 import { StyleSheet } from 'react-native';
+import { useTheme } from '../providers/theme-provider';
 import { spacing } from '../theme/tokens';
+import { ThemedHost } from './ThemedHost';
 import { makeRadioSelectHandler } from './RadioGroup.logic';
 import type { RadioGroupProps } from './RadioGroup.types';
 
@@ -34,12 +37,15 @@ export function RadioGroup<T extends string>({ options, value, onChange }: Radio
   // Memoize so a stable `onChange` doesn't push a new handler into the native Host
   // (and re-render the Compose tree) on every parent render.
   const handleSelect = useMemo(() => makeRadioSelectHandler(onChange), [onChange]);
+  // `chartColors` (not `systemColors`) because native Compose props need plain
+  // strings — it is the same palette, guaranteed hex rather than PlatformColor.
+  const { chartColors } = useTheme();
 
   return (
     // `matchContents={{ vertical: true }}` (NOT the boolean form, which sizes both
     // axes): the Host fills the parent's width so each Row's `fillMaxWidth()` has a
     // bounded width, while height tracks content. Mirrors SwitchRow.
-    <Host matchContents={{ vertical: true }} style={styles.host}>
+    <ThemedHost matchContents={{ vertical: true }} style={styles.host}>
       <Column modifiers={[fillMaxWidth(), selectableGroup()]}>
         {options.map((option) => {
           const selected = option.value === value;
@@ -60,9 +66,11 @@ export function RadioGroup<T extends string>({ options, value, onChange }: Radio
                   so a tap on it doesn't double-fire the selection. */}
               <RadioButton selected={selected} />
               <Column modifiers={disabled ? [weight(1), alpha(0.4)] : [weight(1)]}>
-                <Text style={{ typography: 'bodyLarge' }}>{option.label}</Text>
+                <Text style={{ typography: 'bodyLarge' }} color={chartColors.label}>
+                  {option.label}
+                </Text>
                 {option.description ? (
-                  <Text style={{ typography: 'bodySmall' }} modifiers={[alpha(0.6)]}>
+                  <Text style={{ typography: 'bodySmall' }} color={chartColors.secondaryLabel}>
                     {option.description}
                   </Text>
                 ) : null}
@@ -71,7 +79,7 @@ export function RadioGroup<T extends string>({ options, value, onChange }: Radio
           );
         })}
       </Column>
-    </Host>
+    </ThemedHost>
   );
 }
 

--- a/packages/mobile/src/components/RadioGroup.ios.tsx
+++ b/packages/mobile/src/components/RadioGroup.ios.tsx
@@ -14,11 +14,11 @@
 // handles that at the call site, so this is a graceful degrade, not a regression.
 
 import { useMemo } from 'react';
-import { Host } from '@expo/ui';
 import { Picker, Text } from '@expo/ui/swift-ui';
 import { pickerStyle, tint, tag } from '@expo/ui/swift-ui/modifiers';
 import { StyleSheet } from 'react-native';
 import { useTheme } from '../providers/theme-provider';
+import { ThemedHost } from './ThemedHost';
 import { brandAccentColor } from '../theme/expo-ui-modifiers';
 import { makeRadioSelectHandler } from './RadioGroup.logic';
 import type { RadioGroupProps } from './RadioGroup.types';
@@ -40,7 +40,7 @@ export function RadioGroup<T extends string>({ options, value, onChange }: Radio
   const handleSelect = useMemo(() => makeRadioSelectHandler(onChange), [onChange]);
 
   return (
-    <Host
+    <ThemedHost
       matchContents={{ vertical: true }}
       style={[
         styles.host,
@@ -68,7 +68,7 @@ export function RadioGroup<T extends string>({ options, value, onChange }: Radio
           </Text>
         ))}
       </Picker>
-    </Host>
+    </ThemedHost>
   );
 }
 

--- a/packages/mobile/src/components/SegmentedControl.ios.tsx
+++ b/packages/mobile/src/components/SegmentedControl.ios.tsx
@@ -15,11 +15,11 @@
 // One Host per control is intentional for now (SegmentedControl is used
 // one-per-card). A later pass consolidates whole settings screens under one Host.
 
-import { Host } from '@expo/ui';
 import { Picker, Text } from '@expo/ui/swift-ui';
 import { pickerStyle, tint, tag, accessibilityLabel as accessibilityLabelModifier } from '@expo/ui/swift-ui/modifiers';
 import { StyleSheet } from 'react-native';
 import { useTheme } from '../providers/theme-provider';
+import { ThemedHost } from './ThemedHost';
 import { brandAccentColor } from '../theme/expo-ui-modifiers';
 import { makeSelectHandler } from './SegmentedControl.logic';
 import type { SegmentedControlProps } from './SegmentedControl.types';
@@ -46,7 +46,7 @@ export function SegmentedControl<K extends string = string>({
     // with `overflow: 'hidden'` (the profile chrome's rounded glass track) clipped
     // the bottom of the selected pill. A fixed frame sizes the control
     // deterministically across every container.
-    <Host style={styles.host}>
+    <ThemedHost style={styles.host}>
       <Picker
         selection={selectedKey}
         onSelectionChange={(value) => {
@@ -71,7 +71,7 @@ export function SegmentedControl<K extends string = string>({
           </Text>
         ))}
       </Picker>
-    </Host>
+    </ThemedHost>
   );
 }
 

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -233,7 +233,12 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
       onChange={handleChange}
       onFullyDismissed={managed.onFullyDismissed}
       handleIndicatorStyle={sheetChrome.handleStyle}
-      backgroundStyle={surface === 'solid' ? solidBackground : undefined}
+      // Android has no glass: @expo/ui's Compose BottomSheet falls back to
+      // `BottomSheetDefaults.ContainerColor`, which comes from the OS Compose theme
+      // (wallpaper-derived on Android 12+). So a "glass" sheet took a container
+      // colour unrelated to the app while its RN content used app-theme ink. Give
+      // Android an explicit ground either way; iOS keeps `undefined` for real glass.
+      backgroundStyle={surface === 'solid' || Platform.OS === 'android' ? solidBackground : undefined}
       style={styles.sheet}
     >
       {/* #3922 instrumentation, dev builds only. The sentinel is in-flow but

--- a/packages/mobile/src/components/SwitchRow.android.tsx
+++ b/packages/mobile/src/components/SwitchRow.android.tsx
@@ -6,23 +6,28 @@
 // tap anywhere flips it and TalkBack reads the row as a switch labelled by its
 // text. The Switch's own `onCheckedChange` is left undefined so the tap fires
 // once, not twice. We bridge only the brand on-track colour; M3 surface/label
-// colours come from the Compose Material theme the Host sets up.
+// colours come from the Compose Material theme `ThemedHost` sets up, and every
+// `Text` carries an explicit colour (Compose's `LocalContentColor` defaults to
+// BLACK outside a Surface-family composable, so an uncoloured label is black in
+// both schemes).
 //
 // One Host per row is intentional for PR-1 (SwitchRow is used one-per-card
 // today). PR-2 consolidates whole settings screens into a single Compose list.
 
-import { Host } from '@expo/ui';
 import { Row, Column, Text, Switch } from '@expo/ui/jetpack-compose';
 import { fillMaxWidth, weight, toggleable, padding, defaultMinSize, alpha } from '@expo/ui/jetpack-compose/modifiers';
 import { StyleSheet } from 'react-native';
 import { useTheme } from '../providers/theme-provider';
+import { ThemedHost } from './ThemedHost';
 import { switchBrandColors } from '../theme/expo-ui-modifiers';
 import { spacing } from '../theme/tokens';
 import { makeToggleHandler } from './SwitchRow.logic';
 import type { SwitchRowProps } from './SwitchRow.types';
 
 export function SwitchRow({ label, description, value, onValueChange, disabled = false, tint }: SwitchRowProps) {
-  const { brandColors } = useTheme();
+  // `chartColors` (not `systemColors`) because native Compose props need plain
+  // strings — it is the same palette, guaranteed hex rather than PlatformColor.
+  const { brandColors, chartColors } = useTheme();
   const handleToggle = makeToggleHandler(onValueChange, disabled);
   // On-track colour: brand accent (purple) by default; the logbook passes amber.
   const switchColors = tint ? { checkedTrackColor: tint } : switchBrandColors(brandColors);
@@ -44,12 +49,14 @@ export function SwitchRow({ label, description, value, onValueChange, disabled =
     // Row's `fillMaxWidth()` has a bounded width to fill, while height still tracks
     // content. The boolean form collapsed the label Column and jammed the Switch
     // to the left. Mirrors the iOS Host.
-    <Host matchContents={{ vertical: true }} style={styles.host}>
+    <ThemedHost matchContents={{ vertical: true }} style={styles.host}>
       <Row horizontalArrangement="spaceBetween" verticalAlignment="center" modifiers={rowModifiers}>
         <Column modifiers={disabled ? [weight(1), alpha(0.4)] : [weight(1)]}>
-          <Text style={{ typography: 'bodyLarge' }}>{label}</Text>
+          <Text style={{ typography: 'bodyLarge' }} color={chartColors.label}>
+            {label}
+          </Text>
           {description ? (
-            <Text style={{ typography: 'bodySmall' }} modifiers={[alpha(0.6)]}>
+            <Text style={{ typography: 'bodySmall' }} color={chartColors.secondaryLabel}>
               {description}
             </Text>
           ) : null}
@@ -63,7 +70,7 @@ export function SwitchRow({ label, description, value, onValueChange, disabled =
           colors={switchColors}
         />
       </Row>
-    </Host>
+    </ThemedHost>
   );
 }
 

--- a/packages/mobile/src/components/SwitchRow.ios.tsx
+++ b/packages/mobile/src/components/SwitchRow.ios.tsx
@@ -10,11 +10,11 @@
 // One Host per row is intentional for PR-1 (SwitchRow is used one-per-card
 // today). PR-2 consolidates whole settings screens into a single SwiftUI Form.
 
-import { Host } from '@expo/ui';
 import { Toggle, Text } from '@expo/ui/swift-ui';
 import { tint, disabled as disabledModifier, padding } from '@expo/ui/swift-ui/modifiers';
 import { StyleSheet } from 'react-native';
 import { useTheme } from '../providers/theme-provider';
+import { ThemedHost } from './ThemedHost';
 import { brandAccentColor } from '../theme/expo-ui-modifiers';
 import { spacing } from '../theme/tokens';
 import { makeToggleHandler } from './SwitchRow.logic';
@@ -43,7 +43,7 @@ export function SwitchRow({
   const onTrack = tintColor ?? brandAccentColor(brandColors);
 
   return (
-    <Host
+    <ThemedHost
       matchContents={{ vertical: true }}
       style={[styles.host, { minHeight: description ? ROW_MIN_HEIGHT_WITH_SUBTITLE : ROW_MIN_HEIGHT }]}
     >
@@ -69,7 +69,7 @@ export function SwitchRow({
         <Text>{label}</Text>
         {description ? <Text>{description}</Text> : null}
       </Toggle>
-    </Host>
+    </ThemedHost>
   );
 }
 

--- a/packages/mobile/src/components/SwitcherForm.android.tsx
+++ b/packages/mobile/src/components/SwitcherForm.android.tsx
@@ -4,8 +4,8 @@
 // The whole OTA Channel / Branch switcher screen is ONE `Host` containing a single
 // `LazyColumn` — the Compose counterpart to the iOS `Form`. Same consolidation as
 // MoreForm / FeatureFlagsForm. A `LazyColumn` virtualizes its items, so the Host is
-// `style={{ flex: 1 }}` (NOT `matchContents`). `colorScheme` forces the Compose
-// MaterialTheme to follow the in-app Light/Dark toggle.
+// `style={{ flex: 1 }}` (NOT `matchContents`). `ThemedHost` forces the Compose
+// MaterialTheme onto the in-app Light/Dark toggle.
 //
 // Each section flattens to: an optional title `Text`, an optional intro `Text`, a
 // Material `Card` wrapping ALL its rows (info / status / target / field / action),
@@ -16,7 +16,6 @@
 // Compose Material theme.
 
 import { useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react';
-import { Host } from '@expo/ui';
 import {
   LazyColumn,
   Card,
@@ -31,6 +30,7 @@ import {
 import { fillMaxWidth, padding, alpha, weight, clickable, size } from '@expo/ui/jetpack-compose/modifiers';
 import { StyleSheet } from 'react-native';
 import { useTheme } from '../providers/theme-provider';
+import { ThemedHost } from './ThemedHost';
 import { textFieldBrandColors } from '../theme/expo-ui-modifiers';
 import { spacing } from '../theme/tokens';
 import { shouldPushValueToNative, toAndroidKeyboardOptions } from './AuthTextInput.logic';
@@ -106,7 +106,7 @@ function TargetRow({ row }: { row: SwitcherTargetRow }) {
 }
 
 function FieldRow({ row }: { row: SwitcherFieldRow }) {
-  const { brandColors } = useTheme();
+  const { brandColors, chartColors } = useTheme();
   const textState = useNativeState(row.value);
   const lastEmittedRef = useRef(row.value);
   // `row.onSubmit` is rebuilt each render (the screen makes it inline), so keep the
@@ -133,7 +133,7 @@ function FieldRow({ row }: { row: SwitcherFieldRow }) {
     [row.onChangeText],
   );
   const keyboardActions = useMemo(() => ({ onGo: () => submitRef.current() }), []);
-  const colors = useMemo(() => textFieldBrandColors(brandColors), [brandColors]);
+  const colors = useMemo(() => textFieldBrandColors(brandColors, chartColors), [brandColors, chartColors]);
 
   return (
     <Column modifiers={[fillMaxWidth(), ROW_PADDING]}>
@@ -213,30 +213,40 @@ function renderRow(row: SwitcherRow, errorColor: string): ReactNode {
   }
 }
 
-function flattenSection(section: SwitcherSection, errorColor: string): ReactNode[] {
+type SectionColors = {
+  error: string;
+  /** Ink for the section title / intro / footer, which sit outside the Card. */
+  muted: string;
+};
+
+// The title, intro and footer are siblings of the Card, not children of it, so
+// nothing supplies Compose's ambient `LocalContentColor` — its default is black in
+// BOTH schemes. They take an explicit colour; the carded rows inherit the Card's
+// content colour and correctly do not.
+function flattenSection(section: SwitcherSection, colors: SectionColors): ReactNode[] {
   const items: ReactNode[] = [];
   if (section.title) {
     items.push(
-      <Text key={`${section.key}-title`} style={{ typography: 'titleSmall' }} modifiers={[alpha(0.6)]}>
+      <Text key={`${section.key}-title`} style={{ typography: 'titleSmall' }} color={colors.muted}>
         {section.title}
       </Text>,
     );
   }
   if (section.intro) {
     items.push(
-      <Text key={`${section.key}-intro`} style={{ typography: 'bodySmall' }} modifiers={[alpha(0.6)]}>
+      <Text key={`${section.key}-intro`} style={{ typography: 'bodySmall' }} color={colors.muted}>
         {section.intro}
       </Text>,
     );
   }
   items.push(
     <Card key={`${section.key}-card`} modifiers={[fillMaxWidth()]}>
-      <Column modifiers={[fillMaxWidth()]}>{section.rows.map((row) => renderRow(row, errorColor))}</Column>
+      <Column modifiers={[fillMaxWidth()]}>{section.rows.map((row) => renderRow(row, colors.error))}</Column>
     </Card>,
   );
   if (section.footer) {
     items.push(
-      <Text key={`${section.key}-footer`} style={{ typography: 'bodySmall' }} modifiers={[alpha(0.6)]}>
+      <Text key={`${section.key}-footer`} style={{ typography: 'bodySmall' }} color={colors.muted}>
         {section.footer}
       </Text>,
     );
@@ -245,18 +255,22 @@ function flattenSection(section: SwitcherSection, errorColor: string): ReactNode
 }
 
 export function SwitcherForm({ model }: SwitcherFormProps) {
-  const { brandColors, colorScheme } = useTheme();
-  const items = model.sections.flatMap((section) => flattenSection(section, brandColors.error));
+  // `chartColors` mirrors `systemColors` as guaranteed plain strings, which is
+  // what native Compose colour props need.
+  const { brandColors, chartColors } = useTheme();
+  const items = model.sections.flatMap((section) =>
+    flattenSection(section, { error: brandColors.error, muted: chartColors.secondaryLabel }),
+  );
 
   return (
-    <Host style={styles.host} colorScheme={colorScheme}>
+    <ThemedHost style={styles.host}>
       <LazyColumn
         contentPadding={{ start: spacing[4], top: spacing[4], end: spacing[4], bottom: spacing[10] }}
         verticalArrangement={{ spacedBy: spacing[3] }}
       >
         {items}
       </LazyColumn>
-    </Host>
+    </ThemedHost>
   );
 }
 

--- a/packages/mobile/src/components/SwitcherForm.ios.tsx
+++ b/packages/mobile/src/components/SwitcherForm.ios.tsx
@@ -14,7 +14,6 @@
 // model. Each row kind maps to the idiomatic SwiftUI control.
 
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { Host } from '@expo/ui';
 import {
   Form,
   Section,
@@ -42,6 +41,7 @@ import {
 } from '@expo/ui/swift-ui/modifiers';
 import { StyleSheet } from 'react-native';
 import { useTheme } from '../providers/theme-provider';
+import { ThemedHost } from './ThemedHost';
 import { brandAccentColor } from '../theme/expo-ui-modifiers';
 import { spacing } from '../theme/tokens';
 import { shouldPushValueToNative } from './AuthTextInput.logic';
@@ -183,12 +183,12 @@ function ActionRow({ row, iconColors }: { row: SwitcherActionRow; iconColors: Ac
 }
 
 export function SwitcherForm({ model }: SwitcherFormProps) {
-  const { brandColors, colorScheme } = useTheme();
+  const { brandColors } = useTheme();
   const accent = brandAccentColor(brandColors);
   const iconColors: ActionIconColors = { accent, warning: brandColors.warning, error: brandColors.error };
 
   return (
-    <Host style={styles.host} useViewportSizeMeasurement colorScheme={colorScheme}>
+    <ThemedHost style={styles.host} useViewportSizeMeasurement>
       <Form>
         {model.sections.map((section) => (
           <Section
@@ -227,7 +227,7 @@ export function SwitcherForm({ model }: SwitcherFormProps) {
           </Section>
         ))}
       </Form>
-    </Host>
+    </ThemedHost>
   );
 }
 

--- a/packages/mobile/src/components/ThemedHost.tsx
+++ b/packages/mobile/src/components/ThemedHost.tsx
@@ -1,0 +1,36 @@
+// ThemedHost — the only `@expo/ui` `Host` the app mounts.
+//
+// A bare `<Host>` themes its native subtree from the DEVICE colour scheme, not
+// ours. On Android that happens twice over:
+//
+//   - JS: `@expo/ui/src/jetpack-compose/Host` reads react-native's
+//     `useColorScheme()` and publishes the resulting M3 palette to descendants
+//     through `HostPaletteContext` (a null scheme collapses to 'light').
+//   - Native: `HostView.kt` falls back to `isSystemInDarkTheme()`, which reads
+//     `resources.configuration.uiMode`.
+//
+// Neither follows `themeOverride`, because `Appearance.setColorScheme` does not
+// reach them on Android (see the comment on `useAppColorScheme`). So a user
+// running the app's Dark theme on a light-mode phone got a light Compose theme —
+// near-black `onSurface` text — inside RN views painted `#15101E`. That shipped
+// once already as issue #3885, and again as the black settings/auth text this
+// component fixes.
+//
+// Passing `colorScheme` is a one-word fix that is trivially forgotten, so the
+// bare `Host` import is lint-banned (`no-restricted-imports`, packages/mobile)
+// and everything routes through here instead. Callers may still pass an explicit
+// `colorScheme` to pin a subtree (the pre-provider crash screen does).
+
+// This file is the one place allowed to import `Host` directly — `.oxlintrc.json`
+// exempts it from the `no-restricted-imports` rule that points everyone else here.
+import { Host, type UniversalHostProps } from '@expo/ui';
+import { useAppColorScheme } from '../providers/theme-provider';
+
+export type ThemedHostProps = UniversalHostProps;
+
+export function ThemedHost({ colorScheme, ...props }: ThemedHostProps) {
+  // The app-resolved scheme, which honours the in-app Light/Dark override —
+  // deliberately not react-native's `useColorScheme()`.
+  const appColorScheme = useAppColorScheme();
+  return <Host colorScheme={colorScheme ?? appColorScheme} {...props} />;
+}

--- a/packages/mobile/src/components/gym-directory/GymMap.tsx
+++ b/packages/mobile/src/components/gym-directory/GymMap.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
 } from 'react';
 import { Platform, StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
+import { useAppColorScheme } from '../../providers/theme-provider';
 
 export type GymMapMarker = {
   id: string;
@@ -113,7 +114,27 @@ const NativeGymMap = forwardRef<GymMapHandle, GymMapProps>(function NativeGymMap
     nativeRef.current = (instance as NativeMapHandle | null) ?? null;
   }, []);
 
-  const MapView = Platform.OS === 'ios' ? Maps?.AppleMaps?.View : Maps?.GoogleMaps?.View;
+  // Pinned to ONE of the two view types rather than left as a union: TypeScript
+  // intersects a union component's props, and the two platforms declare separate
+  // (identically-shaped) enums, so no platform-specific value — `colorScheme`
+  // below — can satisfy both. Only props both views share are passed, and the
+  // runtime view is still chosen per platform.
+  const MapView = (Platform.OS === 'ios' ? Maps?.AppleMaps?.View : Maps?.GoogleMaps?.View) as
+    | NonNullable<typeof Maps>['GoogleMaps']['View']
+    | undefined;
+
+  // Both platform views default to following the OS scheme, so a dark app on a
+  // light-mode phone drew the light basemap — black place labels on a dark screen.
+  // Drive it from the app-resolved scheme instead. Apple and Google each declare
+  // their own `MapColorScheme` enum with the same members; read the one belonging
+  // to the platform view we picked, off the same lazily-required module.
+  // Read Google's enum to match the pinned view type above. Apple declares its own
+  // with the same `LIGHT`/`DARK` members and identical string values, so the value
+  // is valid for either native view. (Apple's default is already AUTOMATIC, which
+  // follows the app; it is Google's FOLLOW_SYSTEM default that tracked the OS.)
+  const MapColorScheme = Maps?.GoogleMaps?.MapColorScheme;
+  const appColorScheme = useAppColorScheme();
+  const mapColorScheme = appColorScheme === 'dark' ? MapColorScheme?.DARK : MapColorScheme?.LIGHT;
 
   // Report a missing native map exactly once (the module or platform view is
   // absent — e.g. a build without expo-maps). Read through a ref so the effect
@@ -168,6 +189,7 @@ const NativeGymMap = forwardRef<GymMapHandle, GymMapProps>(function NativeGymMap
     <MapView
       ref={assignNativeRef}
       style={[styles.map, style]}
+      colorScheme={mapColorScheme}
       cameraPosition={cameraPosition}
       markers={mapMarkers}
       onCameraMove={handleCameraMove}

--- a/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
+++ b/packages/mobile/src/components/integrations/BoardAccountsSection.tsx
@@ -34,7 +34,6 @@ import { useToast } from '../../providers/toast-provider';
 import { useConfirm } from '../../providers/dialog-provider';
 import { useFeatureFlag } from '../../providers/feature-flags-provider';
 import { borderRadius, spacing } from '../../theme/tokens';
-import { iosSystemColors } from '../../theme/ios-colors';
 import {
   BoardAccountError,
   deleteAuroraCredential,
@@ -263,7 +262,7 @@ function errorMessageFor(error: unknown, t: TFunction<'settings'>): string {
 export function BoardAccountsSection() {
   const { t } = useTranslation('settings');
   const { t: tCommon } = useTranslation('common');
-  const { systemColors, brandColors, colorScheme } = useTheme();
+  const { systemColors, brandColors } = useTheme();
   const { showToast } = useToast();
   const confirm = useConfirm();
   const queryClient = useQueryClient();
@@ -488,9 +487,18 @@ export function BoardAccountsSection() {
     })();
   }, [importBoard, importData, queryClient, showToast, t]);
 
-  const inputBackground = colorScheme === 'dark' ? iosSystemColors.white : '#FFFFFF';
-  const inputBorder = colorScheme === 'dark' ? 'rgba(60, 60, 67, 0.36)' : 'rgba(60, 60, 67, 0.18)';
-  const inputStyle = [styles.input, { backgroundColor: inputBackground, borderColor: inputBorder, color: '#000000' }];
+  // These were pinned to a white field with black ink in BOTH schemes — a glaring
+  // white box in the dark app, and the placeholder (an iOS light-mode grey) was
+  // near-invisible on it once the field went dark. Use the elevated dark surface
+  // and the adaptive label, per the repo's dark-input rule.
+  const inputStyle = [
+    styles.input,
+    {
+      backgroundColor: systemColors.elevatedSurface,
+      borderColor: systemColors.separator,
+      color: systemColors.label,
+    },
+  ];
 
   const credentials = credentialsQuery.data?.credentials;
   const hasKilterCredential = getCredential(credentials ?? [], 'kilter') !== null;
@@ -580,7 +588,7 @@ export function BoardAccountsSection() {
               value={username}
               onChangeText={setUsername}
               placeholder={t('aurora.linkDialog.usernamePlaceholder')}
-              placeholderTextColor="rgba(60, 60, 67, 0.6)"
+              placeholderTextColor={systemColors.tertiaryLabel}
               autoCapitalize="none"
               autoCorrect={false}
               style={inputStyle}
@@ -589,7 +597,7 @@ export function BoardAccountsSection() {
               value={password}
               onChangeText={setPassword}
               placeholder={t('aurora.linkDialog.passwordPlaceholder')}
-              placeholderTextColor="rgba(60, 60, 67, 0.6)"
+              placeholderTextColor={systemColors.tertiaryLabel}
               autoCapitalize="none"
               autoCorrect={false}
               secureTextEntry

--- a/packages/mobile/src/components/play-drawer/AngleSlider.android.tsx
+++ b/packages/mobile/src/components/play-drawer/AngleSlider.android.tsx
@@ -17,10 +17,10 @@
 // the angle on Android. TalkBack announces the range position; the visible label
 // carries the angle. Revisit if @expo/ui adds a state-description modifier.
 
-import { Host } from '@expo/ui';
 import { Slider } from '@expo/ui/jetpack-compose';
 import { StyleSheet } from 'react-native';
 import { useTheme } from '../../providers/theme-provider';
+import { ThemedHost } from '../ThemedHost';
 import { sliderBrandColors } from '../../theme/expo-ui-modifiers';
 import { makeAngleSliderHandler, sliderIndexForAngle } from './AngleSlider.logic';
 import type { AngleSliderProps } from './AngleSlider.types';
@@ -49,7 +49,7 @@ export function AngleSlider({ angles, value, onChange }: AngleSliderProps) {
   const steps = Math.max(0, count - 2);
 
   return (
-    <Host matchContents={{ vertical: true }} style={styles.host}>
+    <ThemedHost matchContents={{ vertical: true }} style={styles.host}>
       <Slider
         value={valueIndex}
         min={0}
@@ -59,7 +59,7 @@ export function AngleSlider({ angles, value, onChange }: AngleSliderProps) {
         onValueChange={handleValueChange}
         colors={sliderBrandColors(brandColors)}
       />
-    </Host>
+    </ThemedHost>
   );
 }
 

--- a/packages/mobile/src/components/play-drawer/AngleSlider.ios.tsx
+++ b/packages/mobile/src/components/play-drawer/AngleSlider.ios.tsx
@@ -10,11 +10,11 @@
 //
 // One Host per control is intentional for now (AngleSlider is used one-per-card).
 
-import { Host } from '@expo/ui';
 import { Slider } from '@expo/ui/swift-ui';
 import { tint, accessibilityValue } from '@expo/ui/swift-ui/modifiers';
 import { StyleSheet } from 'react-native';
 import { useTheme } from '../../providers/theme-provider';
+import { ThemedHost } from '../ThemedHost';
 import { brandAccentColor } from '../../theme/expo-ui-modifiers';
 import { makeAngleSliderHandler, sliderIndexForAngle } from './AngleSlider.logic';
 import type { AngleSliderProps } from './AngleSlider.types';
@@ -32,7 +32,7 @@ export function AngleSlider({ angles, value, onChange }: AngleSliderProps) {
     // minHeight floors the row in RN's layout: the native iOS Host (matchContents
     // vertical) under-reports the Slider's height, so without a floor the control
     // collapses and overlaps adjacent content.
-    <Host matchContents={{ vertical: true }} style={[styles.host, styles.minRow]}>
+    <ThemedHost matchContents={{ vertical: true }} style={[styles.host, styles.minRow]}>
       <Slider
         value={valueIndex}
         min={0}
@@ -50,7 +50,7 @@ export function AngleSlider({ angles, value, onChange }: AngleSliderProps) {
           accessibilityValue(`${value}°`),
         ]}
       />
-    </Host>
+    </ThemedHost>
   );
 }
 

--- a/packages/mobile/src/components/search/FilterChipRow.android.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.android.tsx
@@ -24,7 +24,6 @@
 import { memo, useState, type ReactNode } from 'react';
 import { StyleSheet, type ImageSourcePropType } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { Host } from '@expo/ui';
 import {
   Row,
   Text,
@@ -39,6 +38,7 @@ import { PROGRESS_FILTER_VALUES, SORT_OPTIONS, GRADE_ACCURACY_VALUES } from '@bo
 import { getFilterKey } from '../../lib/recent-filter-store';
 import { POPULARITY_BUCKETS, RATING_BUCKETS } from '../../lib/filter-chip-menus';
 import { useTheme } from '../../providers/theme-provider';
+import { ThemedHost } from '../ThemedHost';
 import { spacing } from '../../theme/tokens';
 import { filterChipBrandColors } from '../../theme/expo-ui-modifiers';
 import { useMaterialAngleControl } from '../chrome/use-material-angle-control';
@@ -201,7 +201,7 @@ function FilterChipRowComponent({
   onToggleBeta,
 }: FilterChipRowProps) {
   const { t } = useTranslation('climbs');
-  const { brandColors, colorScheme } = useTheme();
+  const { brandColors } = useTheme();
   const chipColors = filterChipBrandColors(brandColors);
   // Built once per render (and only when Sort is actually pinned), reused for the
   // resting label + all 7 menu items.
@@ -231,11 +231,11 @@ function FilterChipRowComponent({
 
   return (
     <>
-      {/* `colorScheme` keeps the Compose MaterialTheme on our in-app Light/Dark toggle.
+      {/* `ThemedHost` keeps the Compose MaterialTheme on our in-app Light/Dark toggle.
           `matchContents={{ vertical: true }}` (NOT the boolean form) fills the parent
           width so the Row's `fillMaxWidth()` has a bounded width to scroll within, while
           height tracks the chip content — mirrors SwitchRow/SegmentedControl. */}
-      <Host matchContents={{ vertical: true }} colorScheme={colorScheme} style={styles.host}>
+      <ThemedHost matchContents={{ vertical: true }} style={styles.host}>
         <Row
           modifiers={[fillMaxWidth(), horizontalScroll(), padding(spacing[4], spacing[2], spacing[4], spacing[2])]}
           verticalAlignment="center"
@@ -509,7 +509,7 @@ function FilterChipRowComponent({
             />
           ) : null}
         </Row>
-      </Host>
+      </ThemedHost>
       {canAdjustAngle && activeBoard ? (
         <AngleSelectorSheet
           visible={angleSheetVisible}

--- a/packages/mobile/src/components/settings/sections/AccessibilitySection.tsx
+++ b/packages/mobile/src/components/settings/sections/AccessibilitySection.tsx
@@ -163,7 +163,7 @@ function MarkerSwatch({
   thickness?: number;
   size?: number;
 }) {
-  const { systemColors } = useTheme();
+  const { systemColors, chartColors } = useTheme();
   const strokeWidth = Math.max(1.5, 2.25 * thickness);
   const shapeSize = normalizeHoldShapeSize(size);
   const diameter = 20 * shapeSize;
@@ -173,9 +173,11 @@ function MarkerSwatch({
       importantForAccessibility="no-hide-descendants"
       style={[styles.swatch, { borderColor: systemColors.separator }]}
     >
+      {/* The colour fallback is the adaptive label rather than black: a PlatformColor
+          reaching here would otherwise draw an invisible swatch on the dark surface. */}
       <HoldMarkerShapeSvg
         shape={shape}
-        color={typeof color === 'string' ? color : '#000000'}
+        color={typeof color === 'string' ? color : chartColors.label}
         diameter={diameter}
         strokeWidth={strokeWidth}
         fillOpacity={0.25}

--- a/packages/mobile/src/theme/__tests__/palette-contrast.test.ts
+++ b/packages/mobile/src/theme/__tests__/palette-contrast.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+//
+// The palettes document their WCAG ratios in prose ("opaque so secondary text
+// clears WCAG AA — 6.44:1 on bg") but nothing checked them, so a surface tweak
+// could quietly push a label under AA. These assertions are that check.
+//
+// They cover the two palettes Android can resolve — `materialSurfaces` (the
+// Material variant, Android's default) and `androidFallbackColors` (Liquid Glass
+// on Android) — in both schemes. iOS Liquid Glass resolves PlatformColor, which
+// Apple guarantees and which has no hex to measure.
+import { describe, it, expect, vi } from 'vitest';
+
+// colors.ts touches Platform/PlatformColor at import; the Android branch skips
+// the iOS PlatformColor path. Same shim as material-surfaces.test.ts.
+vi.mock('react-native', () => ({ Platform: { OS: 'android' }, PlatformColor: (name: string) => name }));
+
+import { contrastRatio, relativeLuminance } from '@boardsesh/velvet-tokens';
+import { androidFallbackColors, materialSurfaces } from '../colors';
+
+const SCHEMES = ['light', 'dark'] as const;
+
+// WCAG 2.1 AA: 4.5:1 for body text, 3:1 for large text and UI components.
+const AA_BODY = 4.5;
+const AA_LARGE = 3;
+
+const PALETTES = {
+  materialSurfaces,
+  androidFallbackColors,
+} as const;
+
+// Grounds a label can actually sit on. `separator` / `fill` are strokes and
+// translucent washes, not text grounds, so they are not asserted here.
+const GROUNDS = ['background', 'secondaryBackground', 'groupedBackground', 'elevatedSurface'] as const;
+
+describe('relativeLuminance', () => {
+  it('anchors at the ends of the range', () => {
+    expect(relativeLuminance('#000000')).toBe(0);
+    expect(relativeLuminance('#FFFFFF')).toBeCloseTo(1, 5);
+  });
+
+  it('returns null for anything that is not opaque hex', () => {
+    expect(relativeLuminance('rgba(0, 0, 0, 0.5)')).toBeNull();
+    expect(relativeLuminance('label')).toBeNull();
+  });
+});
+
+describe('contrastRatio', () => {
+  it('gives 21:1 for black on white and 1:1 for a colour on itself', () => {
+    expect(contrastRatio('#000000', '#FFFFFF')).toBeCloseTo(21, 2);
+    expect(contrastRatio('#15101E', '#15101E')).toBeCloseTo(1, 5);
+  });
+
+  it('is symmetric — it measures the pair, not a direction', () => {
+    expect(contrastRatio('#F5F2FB', '#15101E')).toBe(contrastRatio('#15101E', '#F5F2FB'));
+  });
+});
+
+describe.each(Object.entries(PALETTES))('%s label contrast', (paletteName, palette) => {
+  it.each(SCHEMES)(`clears WCAG AA in %s`, (scheme) => {
+    const colors = palette[scheme];
+    for (const ground of GROUNDS) {
+      // The primary label carries body copy everywhere, so it must clear 4.5:1.
+      const labelRatio = contrastRatio(colors.label, colors[ground]);
+      expect(labelRatio, `${paletteName}.${scheme}: label on ${ground}`).not.toBeNull();
+      expect(labelRatio ?? 0, `${paletteName}.${scheme}: label on ${ground}`).toBeGreaterThanOrEqual(AA_BODY);
+
+      // Secondary label is body copy too (descriptions, section footers) — the
+      // palettes went opaque rather than 0.6-alpha specifically to clear this.
+      const secondaryRatio = contrastRatio(colors.secondaryLabel, colors[ground]);
+      expect(secondaryRatio ?? 0, `${paletteName}.${scheme}: secondaryLabel on ${ground}`).toBeGreaterThanOrEqual(
+        AA_BODY,
+      );
+
+      // Tertiary is reserved for de-emphasised, large or non-essential glyphs,
+      // so it is held to the AA large-text / UI-component bar.
+      const tertiaryRatio = contrastRatio(colors.tertiaryLabel, colors[ground]);
+      expect(tertiaryRatio ?? 0, `${paletteName}.${scheme}: tertiaryLabel on ${ground}`).toBeGreaterThanOrEqual(
+        AA_LARGE,
+      );
+    }
+  });
+
+  it.each(SCHEMES)(`keeps the interactive accent legible in %s`, (scheme) => {
+    const colors = palette[scheme];
+    // `accent` is link/affordance text on the base ground — the reason the dark
+    // sets lift the violet to #A78BFA instead of reusing #6D28D9.
+    const ratio = contrastRatio(colors.accent, colors.background);
+    expect(ratio ?? 0, `${paletteName}.${scheme}: accent on background`).toBeGreaterThanOrEqual(AA_LARGE);
+  });
+});
+
+describe('the regression this suite exists for', () => {
+  it('fails a near-black label on the dark purple ground', () => {
+    // Compose's `LocalContentColor` default, on `materialSurfaces.dark.background`.
+    // This is what every un-coloured @expo/ui `<Text>` rendered as.
+    const ratio = contrastRatio('#1D1B20', materialSurfaces.dark.background);
+    expect(ratio ?? 0).toBeLessThan(AA_LARGE);
+  });
+});

--- a/packages/mobile/src/theme/expo-ui-modifiers.ts
+++ b/packages/mobile/src/theme/expo-ui-modifiers.ts
@@ -1,11 +1,22 @@
 // Theming bridge for @expo/ui native primitives.
 //
-// Native @expo/ui controls read system colours automatically — iOS via
-// PlatformColor / SwiftUI semantic styles, Android via the Compose Material
-// theme — so only the BRAND ACCENT needs bridging from our theme tokens. This
-// module is the single place that maps `useTheme().brandColors` onto the plain
-// colour values the native modifiers / props want, so the brand colour is
-// sourced once and every primitive tints identically.
+// iOS controls read system colours automatically via PlatformColor / SwiftUI
+// semantic styles, so only the BRAND ACCENT needs bridging there. Android does
+// NOT get that for free, and this comment used to claim it did — which is how the
+// app shipped black-on-dark-purple settings and auth text. Two Android caveats:
+//
+//   1. The Compose theme follows the DEVICE scheme unless the host is told
+//      otherwise. Mount every host through `components/ThemedHost`, never a bare
+//      `@expo/ui` `Host`.
+//   2. Compose's ambient `LocalContentColor` defaults to `Color.Black`, and
+//      `MaterialTheme` does not provide it — only Surface-family composables
+//      (Surface / Card / Button / Chip / ListItem / text-field slots) do. A
+//      `<Text>` outside one of those is literally black in BOTH schemes, so it
+//      needs an explicit `color`.
+//
+// This module is the single place that maps `useTheme()` colours onto the plain
+// values the native modifiers / props want, so they are sourced once and every
+// primitive tints identically.
 //
 // WHY THIS FILE IMPORTS NOTHING FROM @expo/ui
 // It is shared by both `*.ios.tsx` and `*.android.tsx` component files, and the
@@ -99,21 +110,67 @@ export function sliderBrandColors(brandColors: BrandControlColors): {
 }
 
 /**
- * Plain Compose `TextFieldColors` bridging the brand accent onto a native Android
- * `OutlinedTextField` — the focused outline and the cursor. Every other state
- * (unfocused outline, error red, label, supporting text) reads the Compose
- * Material theme. Returned as a minimal object — every `TextFieldColors` field is
- * optional — so this shared file needs no `@expo/ui/jetpack-compose` import; the
- * `.android.tsx` file passes it straight to the field's `colors` prop. Both fields
- * read `brandAccentColor` so they can't drift from the other primitives.
+ * The subset of resolved system colours the native-control bridge reads for text
+ * ink. `useTheme().systemColors` satisfies this structurally on the Material
+ * variant, where every value is a plain string. (On the Liquid Glass iOS branch
+ * these are `PlatformColor`s, which is why only Android call sites pass them.)
  */
-export function textFieldBrandColors(brandColors: BrandControlColors): {
+export type SystemInkColors = {
+  label: string;
+  secondaryLabel: string;
+};
+
+/**
+ * Plain Compose `TextFieldColors` for a native Android `OutlinedTextField`: the
+ * brand accent on the focused outline + cursor, and our own label/supporting/value
+ * ink for every text state.
+ *
+ * The ink matters. Left to the Compose theme these resolve from `onSurface` /
+ * `onSurfaceVariant` of a palette that is wallpaper-derived on Android 12+
+ * (`dynamicDark/LightColorScheme`), so the auth fields drifted away from the rest
+ * of the screen — and read near-black outright whenever the host's scheme didn't
+ * match the app's. Pinning them keeps the field legible and on-brand.
+ *
+ * Returned as a plain object — every `TextFieldColors` field is optional — so this
+ * shared file needs no `@expo/ui/jetpack-compose` import; the `.android.tsx` file
+ * passes it straight to the field's `colors` prop. The branded fields read
+ * `brandAccentColor` so they can't drift from the other primitives.
+ */
+export function textFieldBrandColors(
+  brandColors: BrandControlColors,
+  systemColors: SystemInkColors,
+): {
   focusedIndicatorColor: string;
   cursorColor: string;
+  focusedTextColor: string;
+  unfocusedTextColor: string;
+  focusedLabelColor: string;
+  unfocusedLabelColor: string;
+  focusedPlaceholderColor: string;
+  unfocusedPlaceholderColor: string;
+  focusedSupportingTextColor: string;
+  unfocusedSupportingTextColor: string;
+  focusedTrailingIconColor: string;
+  unfocusedTrailingIconColor: string;
 } {
   return {
     focusedIndicatorColor: brandAccentColor(brandColors),
     cursorColor: brandAccentColor(brandColors),
+    // The typed value — the one that went near-black on the dark auth screen.
+    focusedTextColor: systemColors.label,
+    unfocusedTextColor: systemColors.label,
+    // Floating label: brand accent while focused (it sits on the outline), the
+    // secondary ink at rest.
+    focusedLabelColor: brandAccentColor(brandColors),
+    unfocusedLabelColor: systemColors.secondaryLabel,
+    focusedPlaceholderColor: systemColors.secondaryLabel,
+    unfocusedPlaceholderColor: systemColors.secondaryLabel,
+    focusedSupportingTextColor: systemColors.secondaryLabel,
+    unfocusedSupportingTextColor: systemColors.secondaryLabel,
+    // The password reveal eye — an `Icon` with no tint, so it would otherwise
+    // inherit the black `LocalContentColor`.
+    focusedTrailingIconColor: systemColors.secondaryLabel,
+    unfocusedTrailingIconColor: systemColors.secondaryLabel,
   };
 }
 

--- a/packages/shared/velvet-tokens/src/index.ts
+++ b/packages/shared/velvet-tokens/src/index.ts
@@ -118,7 +118,12 @@ export const materialSurfaces = {
     elevatedSurface: '#2A2142',
     label: '#F5F2FB',
     secondaryLabel: '#A9A2B6',
-    tertiaryLabel: '#6E687C',
+    // Lifted from #6E687C, which measured 2.82:1 against `elevatedSurface`
+    // (#2A2142) — under the 3:1 AA bar for large/de-emphasised text on the most
+    // raised dark surface. #746E82 clears it on every dark ground (3.08–3.82)
+    // while staying far below `secondaryLabel` (6.12:1), so the hierarchy holds.
+    // Enforced by theme/__tests__/palette-contrast.test.ts.
+    tertiaryLabel: '#746E82',
     separator: 'rgba(180, 168, 205, 0.18)',
     fill: 'rgba(199, 184, 232, 0.14)',
     accent: '#A78BFA',
@@ -192,6 +197,37 @@ export function blendOpaque(foreground: string, background: string, alpha: numbe
   const a = clampAlpha(alpha);
   const mix = (channel: 0 | 1 | 2) => fg[channel] * a + bg[channel] * (1 - a);
   return `#${toHexByte(mix(0))}${toHexByte(mix(1))}${toHexByte(mix(2))}`;
+}
+
+/**
+ * WCAG 2.1 relative luminance of an opaque `#RGB`/`#RRGGBB` colour, or `null` for
+ * any other format (`rgba()`, a named colour, a PlatformColor). Exported mainly so
+ * `contrastRatio` can be tested directly.
+ */
+export function relativeLuminance(color: string): number | null {
+  const rgb = parseHex(color);
+  if (!rgb) return null;
+  const channel = (value: number) => {
+    const srgb = value / 255;
+    return srgb <= 0.03928 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(rgb[0]) + 0.7152 * channel(rgb[1]) + 0.0722 * channel(rgb[2]);
+}
+
+/**
+ * WCAG 2.1 contrast ratio between two opaque hex colours (1–21), or `null` if
+ * either is not opaque hex. AA body text needs >= 4.5, AA large text >= 3.
+ *
+ * The palettes document their ratios in prose; this is what lets a test assert
+ * them, so a "small tweak" to a surface can't quietly push a label under AA.
+ */
+export function contrastRatio(foreground: string, background: string): number | null {
+  const foregroundLuminance = relativeLuminance(foreground);
+  const backgroundLuminance = relativeLuminance(background);
+  if (foregroundLuminance === null || backgroundLuminance === null) return null;
+  const lighter = Math.max(foregroundLuminance, backgroundLuminance);
+  const darker = Math.min(foregroundLuminance, backgroundLuminance);
+  return (lighter + 0.05) / (darker + 0.05);
 }
 
 export type BrandColors = typeof brandColors;

--- a/scripts/lib/android-emulator.ts
+++ b/scripts/lib/android-emulator.ts
@@ -25,7 +25,11 @@ const EMULATOR_PORT = 5554;
 export const EMULATOR_SERIAL = `emulator-${EMULATOR_PORT}`;
 
 export function avdExists(name: string, env: NodeJS.ProcessEnv): boolean {
-  const result = runCapture(avdmanagerPath(resolveAndroidHome()), ['list', 'avd', '-c'], { env });
+  // `emulator -list-avds` rather than `avdmanager list avd -c`: avdmanager is a JVM
+  // tool, so a missing or wrong-arch JDK makes it exit non-zero and we'd read that
+  // as "no AVD" and try to create one that is already there. The emulator binary is
+  // native, and it is the same binary that has to launch the AVD anyway.
+  const result = runCapture(emulatorPath(resolveAndroidHome()), ['-list-avds'], { env });
   if (result.status !== 0) return false;
   return result.stdout
     .split(/\r?\n/)

--- a/scripts/lib/android-sdk.ts
+++ b/scripts/lib/android-sdk.ts
@@ -28,14 +28,25 @@ export const JDK21_HOME = join(CACHE_ROOT, 'jdk-21');
 // Pinned Android command-line tools (linux). Bump deliberately; the build number
 // only gates sdkmanager itself, not which platform/image packages it can fetch.
 const CMDLINE_TOOLS_VERSION = '11076708';
-const CMDLINE_TOOLS_URL = `https://dl.google.com/android/repository/commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip`;
+// Google names the cmdline-tools zip by host OS, and Adoptium keys the JDK by
+// os/arch. Both were pinned to linux/x64, which downloads "successfully" on a Mac
+// and then dies with "cannot execute binary file" the first time avdmanager runs.
+const CMDLINE_TOOLS_OS = process.platform === 'darwin' ? 'mac' : 'linux';
+const CMDLINE_TOOLS_URL = `https://dl.google.com/android/repository/commandlinetools-${CMDLINE_TOOLS_OS}-${CMDLINE_TOOLS_VERSION}_latest.zip`;
 
-// Latest Temurin 21 GA for linux/x64. Redirects to the actual tarball.
-const ADOPTIUM_JDK21_URL = 'https://api.adoptium.net/v3/binary/latest/21/ga/linux/x64/jdk/hotspot/normal/eclipse';
+// Latest Temurin 21 GA for the host os/arch. Redirects to the actual tarball.
+const ADOPTIUM_OS = process.platform === 'darwin' ? 'mac' : 'linux';
+const ADOPTIUM_ARCH = process.arch === 'arm64' ? 'aarch64' : 'x64';
+const ADOPTIUM_JDK21_URL = `https://api.adoptium.net/v3/binary/latest/21/ga/${ADOPTIUM_OS}/${ADOPTIUM_ARCH}/jdk/hotspot/normal/eclipse`;
 
 // API level for the platform + system image. Matches CI (android-36).
 export const ANDROID_API_LEVEL = 36;
-export const SYSTEM_IMAGE = `system-images;android-${ANDROID_API_LEVEL};google_apis;x86_64`;
+// The emulator runs the guest ABI natively or not at all: x86_64 on Linux/Intel CI
+// (KVM), arm64-v8a on an Apple Silicon Mac (HVF). Picking the wrong one falls back
+// to TCG interpretation, which is too slow to boot in practice — so key the image
+// off the host arch rather than pinning CI's.
+export const SYSTEM_IMAGE_ABI = process.arch === 'arm64' ? 'arm64-v8a' : 'x86_64';
+export const SYSTEM_IMAGE = `system-images;android-${ANDROID_API_LEVEL};google_apis;${SYSTEM_IMAGE_ABI}`;
 export const BUILD_TOOLS_VERSION = `${ANDROID_API_LEVEL}.0.0`;
 
 // Core packages to boot an emulator and install/run an APK (no Java build needed).
@@ -83,20 +94,41 @@ export function emulatorPath(home: string): string {
   return join(home, 'emulator', 'emulator');
 }
 
+/**
+ * A macOS JDK bundle puts the real JAVA_HOME under `Contents/Home`, so after a
+ * `--strip-components=1` extract our cache dir holds `Contents/Home/bin/java`
+ * rather than `bin/java`. Resolve either layout to the dir that owns `bin/java`.
+ */
+function javaHomeWithin(dir: string): string | null {
+  if (existsSync(join(dir, 'bin', 'java'))) return dir;
+  const macHome = join(dir, 'Contents', 'Home');
+  if (existsSync(join(macHome, 'bin', 'java'))) return macHome;
+  return null;
+}
+
 /** Locate a JDK 21 (override env, our cache, a system install) without downloading. */
 function findJava21(): string | null {
   const override = process.env.JAVA21_HOME ?? process.env.JAVA_21_HOME;
-  if (override && existsSync(join(override, 'bin', 'java'))) return override;
-  if (existsSync(join(JDK21_HOME, 'bin', 'java'))) return JDK21_HOME;
+  if (override) {
+    const overrideHome = javaHomeWithin(override);
+    if (overrideHome) return overrideHome;
+  }
+  const cached = javaHomeWithin(JDK21_HOME);
+  if (cached) return cached;
 
-  const searchDirs = ['/usr/lib/jvm', '/usr/java', join(homedir(), '.sdkman', 'candidates', 'java')];
+  const searchDirs = [
+    '/usr/lib/jvm',
+    '/usr/java',
+    '/Library/Java/JavaVirtualMachines',
+    join(homedir(), '.sdkman', 'candidates', 'java'),
+  ];
   for (const dir of searchDirs) {
     if (!existsSync(dir)) continue;
     for (const entry of readdirSync(dir)) {
       if (!entry.includes('21')) continue;
-      const javaHome = join(dir, entry);
+      const javaHome = javaHomeWithin(join(dir, entry));
+      if (!javaHome) continue;
       const javaBin = join(javaHome, 'bin', 'java');
-      if (!existsSync(javaBin)) continue;
       const version = runCapture(javaBin, ['-version']);
       if (/(version "21|openjdk 21|\b21\.\d)/.test(`${version.stderr}${version.stdout}`)) return javaHome;
     }
@@ -117,8 +149,9 @@ function downloadJava21(): string {
   const extract = runCapture('tar', ['-xzf', tarball, '-C', JDK21_HOME, '--strip-components=1']);
   if (extract.status !== 0) throw new Error(`Failed to extract JDK 21: ${extract.stderr || extract.status}`);
   rmSync(tarball, { force: true });
-  if (!existsSync(join(JDK21_HOME, 'bin', 'java'))) throw new Error('JDK 21 extracted but bin/java is missing');
-  return JDK21_HOME;
+  const javaHome = javaHomeWithin(JDK21_HOME);
+  if (!javaHome) throw new Error('JDK 21 extracted but bin/java is missing');
+  return javaHome;
 }
 
 /** JDK 21 path, downloading a Temurin build into the cache when none is found. */
@@ -192,8 +225,8 @@ function acceptLicenses(home: string, env: NodeJS.ProcessEnv): void {
 
 /**
  * Ensure the SDK is present: cmdline-tools, platform-tools, emulator, platform, and
- * an x86_64 system image (plus build-tools when includeBuildTools is set). No-op when
- * everything is already installed.
+ * a host-native system image (plus build-tools when includeBuildTools is set). No-op
+ * when everything is already installed.
  */
 export function ensureAndroidSdk(options: EnsureSdkOptions = {}): AndroidToolchain {
   const home = resolveAndroidHome();

--- a/scripts/mobile-android-doctor.ts
+++ b/scripts/mobile-android-doctor.ts
@@ -22,6 +22,7 @@ import {
   ensureAndroidSdk,
   resolveAndroidHome,
   resolveJava21,
+  SYSTEM_IMAGE_ABI,
 } from './lib/android-sdk';
 import { avdExists, resolveAvdName } from './lib/android-emulator';
 import { resolveLatestDevTag } from './mobile-android-apk';
@@ -54,9 +55,15 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
   console.log(`${LOG} Android emulator screenshot environment\n`);
 
   // Host capabilities (read-only).
-  const kvm = existsSync('/dev/kvm');
-  if (kvm) ok('KVM', '/dev/kvm present — hardware-accelerated x86_64 emulation');
-  else warn('KVM', '/dev/kvm missing — x86_64 emulation will be slow (TCG)');
+  // macOS accelerates through Hypervisor.framework, which has no /dev/kvm node —
+  // reporting a missing KVM there reads as broken when the box is actually fine.
+  if (process.platform === 'darwin') {
+    ok('hypervisor', `Hypervisor.framework — hardware-accelerated ${SYSTEM_IMAGE_ABI} emulation`);
+  } else if (existsSync('/dev/kvm')) {
+    ok('KVM', `/dev/kvm present — hardware-accelerated ${SYSTEM_IMAGE_ABI} emulation`);
+  } else {
+    warn('KVM', `/dev/kvm missing — ${SYSTEM_IMAGE_ABI} emulation will be slow (TCG)`);
+  }
 
   const systemJava = runCapture('java', ['-version']);
   ok('system java', (systemJava.stderr || systemJava.stdout).split(/\r?\n/)[0] || 'unknown');

--- a/scripts/mobile-theme-imports-check.sh
+++ b/scripts/mobile-theme-imports-check.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Guards the three import boundaries that keep Android text readable in dark mode.
+# Each one silently renders BLACK text when bypassed, so the failure mode is a
+# shipped-and-unreadable screen rather than a crash:
+#
+#   1. `Host` from '@expo/ui' -> src/components/ThemedHost
+#      A bare Host themes its native subtree from the DEVICE scheme. On Android the
+#      JS palette (react-native useColorScheme) and the Compose theme
+#      (isSystemInDarkTheme) both ignore the in-app Light/Dark override, so a dark
+#      app on a light phone drew near-black Compose text on the dark surface.
+#
+#   2. `Text` from 'react-native' -> src/components/Text
+#      RN's own Text defaults to a non-adaptive BLACK and breaks in dark mode. The
+#      primitive defaults to theme.systemColors.label. See docs/ai-design-guidelines.md.
+#
+#   3. `useColorScheme` from 'react-native' -> useAppColorScheme (theme-provider)
+#      RN's hook follows the OS trait collection and on Android does NOT track
+#      Appearance.setColorScheme, so it reads 'light' for a user running the app's
+#      own Dark theme on a light-mode phone (issue #3885).
+#
+# Why a bash guard and not just lint: `.oxlintrc.json` carries the equivalent
+# `no-restricted-imports` rules (so editors / raw oxlint flag them), but `vp check`
+# runs a reduced oxlint ruleset that silently drops `no-restricted-imports` — so it
+# is NOT enforced by `vp check` or the pre-commit hook. This CI guard is the real
+# backstop.
+#
+# Mirrors scripts/mobile-offline-sync-imports-check.sh. Exit 1 (CI failure) on any
+# violation; 0 when clean.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+scan_dirs=(packages/mobile/src packages/mobile/app)
+status=0
+
+# Null-data mode treats each file as one record so multi-line import statements
+# match; the specifier list is bounded by `[^;]*` so only a single statement is
+# spanned. Each check excludes the wrapper that legitimately owns the import.
+find_violations() {
+  local pattern="$1"
+  shift
+  local allowed
+  allowed=$(printf '%s\n' "$@")
+  grep -rlzE "$pattern" "${scan_dirs[@]}" --include='*.ts' --include='*.tsx' \
+    | tr '\0' '\n' \
+    | grep -vxF "$allowed" \
+    || true
+}
+
+# Files that predate the Text primitive and were audited when this guard landed:
+# every `<Text>` in them already carries an explicit colour (a brand red for the
+# auth error lines, theme.systemColors.* elsewhere), or they are the browser-only
+# / dev-only surfaces. They stay on RN's Text so this guard can block NEW
+# violations without a risky type-scale migration. Do not extend this list —
+# migrate to the primitive instead.
+text_primitive_legacy=(
+  packages/mobile/app/auth/forgot-password.tsx
+  packages/mobile/app/auth/login.tsx
+  packages/mobile/app/auth/reset-password.tsx
+  packages/mobile/src/components/AppMenu.web.tsx
+  packages/mobile/src/components/BottomChromeDebugOverlay.tsx
+  packages/mobile/src/components/ClimbAttributeIcons.tsx
+  packages/mobile/src/components/SwitcherForm.web.tsx
+  packages/mobile/src/components/auth/OAuthProviderButtons.web.tsx
+  packages/mobile/src/components/play-drawer/AngleSlider.web.tsx
+)
+
+report() {
+  local found="$1" title="$2" guidance="$3"
+  if [ -n "$found" ]; then
+    echo "✖ ${title}"
+    echo "$found"
+    echo
+    echo "$guidance"
+    echo
+    status=1
+  fi
+}
+
+report \
+  "$(find_violations \
+    "import[^;]*[{,[:space:]]Host[,[:space:]}][^;]*from[[:space:]]*['\"]@expo/ui['\"]" \
+    "packages/mobile/src/components/ThemedHost.tsx")" \
+  "\`Host\` imported from '@expo/ui' outside ThemedHost:" \
+  "  Use ThemedHost (src/components/ThemedHost) instead — it passes the app-resolved
+  colour scheme, so the Compose/SwiftUI subtree follows the in-app Light/Dark
+  toggle rather than the device scheme."
+
+report \
+  "$(find_violations \
+    "import[^;]*[{,[:space:]]Text[,[:space:]}][^;]*from[[:space:]]*['\"]react-native['\"]" \
+    packages/mobile/src/components/Text.tsx "${text_primitive_legacy[@]}")" \
+  "\`Text\` imported from 'react-native' outside the Text primitive:" \
+  "  Use the Text primitive (src/components/Text) instead — it resolves the
+  per-variant type scale and defaults the colour to theme.systemColors.label.
+  RN's own Text defaults to a non-adaptive black."
+
+report \
+  "$(find_violations \
+    "import[^;]*[{,[:space:]]useColorScheme[,[:space:]}][^;]*from[[:space:]]*['\"]react-native['\"]" \
+    "packages/mobile/src/providers/theme-provider.tsx")" \
+  "\`useColorScheme\` imported from 'react-native' outside the theme provider:" \
+  "  Use useAppColorScheme() from src/providers/theme-provider — it honours the
+  in-app appearance override, which RN's hook does not track on Android."
+
+if [ "$status" -ne 0 ]; then
+  exit 1
+fi
+
+echo "✓ Host, Text and useColorScheme are only imported through their theme-aware wrappers."

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -957,6 +957,16 @@ export default defineConfig({
         command: 'bash scripts/mobile-offline-sync-imports-check.sh',
         cache: false,
       },
+      'check:mobile-theme-imports': {
+        // Guards the three import boundaries that keep Android text readable in
+        // dark mode: `Host` (@expo/ui) must come from src/components/ThemedHost,
+        // `Text` and `useColorScheme` (react-native) from the Text primitive and
+        // useAppColorScheme. Each bypass silently renders BLACK text rather than
+        // crashing. Like the platform-imports guard, the .oxlintrc.json rules
+        // aren't enforced by `vp check`, so this is the real backstop.
+        command: 'bash scripts/mobile-theme-imports-check.sh',
+        cache: false,
+      },
       'check:mobile-bundle': {
         command: 'bash scripts/mobile-bundle-check.sh',
         cache: false,


### PR DESCRIPTION
## Summary

Android users reported unreadable text — near-black glyphs on the app's dark purple
background. Android is the only platform that resolves the **Material** variant by default, so
it renders native Jetpack Compose trees behind `@expo/ui`'s `<Host>` that iPhone users never
exercise, and a bare `Host` themes that subtree from the **device** scheme rather than the
in-app Light/Dark override — `useColorScheme()` on the JS side, `isSystemInDarkTheme()` in
`HostView.kt`. Six hosts passed `colorScheme` explicitly; four did not, including the widest-reach
controls: `SwitchRow` (~17 call sites), `RadioGroup`, `AuthTextInput` (the whole auth flow) and
`AngleSlider`.

**Honest caveat up front: I could not reproduce the reported symptom.** On an API 36 emulator,
with the app's theme deliberately mismatched against the OS scheme, and with the fix reverted,
the Compose surfaces rendered correctly in both directions — `Appearance.setColorScheme` does
reach the activity config on RN 0.86, and `MaterialExpressiveTheme` does supply a content colour.
So this PR is **hardening plus a permanent guard**, not a confirmed fix for what users are seeing.
See "What's still open" below — I need a screenshot and an Android version to close the loop.

What did change, all of it real and independently correct:

- **`ThemedHost`** replaces every `@expo/ui` `Host` (Android *and* iOS) and always supplies the
  app-resolved scheme, so the pattern can't be half-applied again.
- **Compose text carries explicit colour.** `AppMenu.android` already documented that a custom
  `Text` in a slot does not inherit its parent's content colour; every `<Text>` outside a Card now
  states its colour instead of relying on ambient inheritance, and `OutlinedTextField` bridges its
  label / placeholder / supporting / value ink rather than taking a wallpaper-derived Material You
  palette.
- **Sheets.** `@expo/ui`'s Compose BottomSheet has no glass, so a `surface="glass"` sheet took
  `BottomSheetDefaults.ContainerColor` from the OS theme while its RN content used app-theme ink.
  Android now always gets an explicit ground (~20 sheets).
- **Nav theme** used iOS neutrals (`#000` / `#1C1C1E`) for the dark scene behind violet-tinted M3
  surfaces; now derived from the resolved variant's own surfaces.
- **Crash screen** renders outside `ThemeProvider`, so `Text` fell back to RN's non-adaptive black
  on a container that painted no ground — black on black.
- **GymMap** left Google's basemap on `FOLLOW_SYSTEM`, so a dark app on a light phone drew the
  light basemap with black place labels.
- **BoardAccountsSection** pinned the board-account fields to a white box with black ink in *both*
  schemes, with an iOS light-mode placeholder grey.

### Guardrails

This class of bug ships silently rather than crashing, so it needs a backstop:

- `scripts/mobile-theme-imports-check.sh` (wired into CI) bans bare `Host`, react-native `Text`
  and react-native `useColorScheme` outside their theme-aware wrappers. It mirrors the existing
  platform-imports guard: `.oxlintrc.json` gets the equivalent `no-restricted-imports` rules for
  editors, but `vp check` runs a reduced ruleset that drops them, so the shell guard is what
  actually enforces this. Verified by reverting a `Host` and watching it fail.
- `palette-contrast.test.ts` asserts the WCAG ratios the palettes previously only claimed in prose.
  It caught one real miss: dark `tertiaryLabel` measured **2.82:1** on `elevatedSurface`, under the
  3:1 bar — lifted to `#746E82` (3.08–3.82 across the dark grounds, still far below
  `secondaryLabel`'s 6.12 so the hierarchy holds).

### Also

`vp run mobile:android-shots` pinned an x86_64 system image and Linux-only cmdline-tools/JDK
downloads, so it could not run on an Apple Silicon Mac. Those are now host-aware, and `avdExists`
no longer needs a JVM (a wrong-arch JDK made it report "no AVD" and try to recreate an existing
one). It boots and captures on this machine now.

### What's still open

I could not reproduce black-on-dark-purple in either scheme on API 36. To close it out I need:
a screenshot, the Android version, and whether the app's theme was set to Light, Dark or System.
One untested hypothesis worth checking on a real device: Android's **force-dark** override
(`Theme.AppCompat.DayNight` allows it) auto-darkening light surfaces while native text stays dark.

Deliberately out of scope, worth follow-ups: `seedColor` on Compose hosts (Android 12+ uses the
wallpaper palette, not Boardsesh violet); ~30 bare `Alert.alert` sites that bypass the themed
`DialogProvider`; RN `TextInput` never setting `selectionColor` / `cursorColor`.

## Release Notes

- Settings, sign-in and sheet text now stay readable on Android in both light and dark.

## Test plan

1. Android, dark theme → More. Section headers readable.
2. Profile → Accessibility. Toggle labels and hints readable.
3. Sign out → sign-in screen. Field labels and typed text readable.
4. Phone in Light mode, app theme Dark. Repeat 1–3.
5. Flip app theme to Light. Nothing turns black-on-black.

## Risk

Risk: 3/5 — touches every Android native Compose surface and the shared dark palette; no BLE, migrations or OTA changes. Reverting is a clean revert.
