### PR TITLE
feat(web): draw Aura everywhere, not just in the app

### DIFF
--- a/docs/board-render-analytics.md
+++ b/docs/board-render-analytics.md
@@ -290,10 +290,27 @@ Unlike the gym funnel (which is www-only and lives in its own module,
 names here live in `packages/shared/analytics/src/events.ts`'s
 `SHARED_EVENTS`. Mobile fires every one of them today, and nothing here is
 platform-exclusive the way the gym directory / claim flow / manage console
-are — a future web board-render surface (there is none today; see
-`docs/expo-web-migration-decision.md`, board rendering moved to the Expo app)
-would reuse the same names and property shape rather than minting a second
-funnel.
+are — www renders boards again (see "www and the share cards" below) but has no
+climb-view session to instrument, so a future web surface would reuse these
+names and property shape rather than minting a second funnel.
+
+## www and the share cards
+
+Board rendering is not mobile-only any more. www's card and feed thumbnails, the
+kiosk and embed slots, and the `GET /og/climb` share cards all draw Aura too, and
+they build their config through the same `buildRenderConfig` +
+`@boardsesh/board-look` path the app does.
+
+None of it is instrumented, and that is deliberate rather than an omission:
+these events measure a **climb-view session** — how long before the first
+action, whether the board was pinched, which look the climber chose — and www
+has none of those. There is no look picker on www (every surface renders the
+shipped default) and no session to open. So `render_mode` on an event still
+means "what the app drew", and the populations these numbers describe are still
+app climbers.
+
+If a www surface ever grows a session worth measuring, it reuses these names
+and this property shape; do not mint a second funnel.
 
 ## `climb-view-session.ts` — the mobile session state machine
 
@@ -437,10 +454,13 @@ erases whichever direction is the minority board.
 **Always split by `glow_falloff_source`.** Only `mode = aura` climbers
 have a `glow_falloff` at all, and among those, `glow_falloff_source: 'user'`
 (a climber who picked a falloff in Settings) is a self-selected population —
-they are not a random sample of `aura` climbers, and mixing them into the
-`'flag'` cohort (the actual A/B) will bias the comparison toward whatever the
-opinionated minority prefers. Read the experiment ONLY on
-`glow_falloff_source = 'flag'`.
+they are not a random sample of `aura` climbers, and pooling them with
+`'default'` biases the comparison toward whatever the opinionated minority
+prefers. Read the shipped falloff on `glow_falloff_source = 'default'` alone.
+
+There is no `'flag'` value any more. It was the third source while
+`board-glow-falloff` was live, and that flag is retired — the type is
+`'user' | 'default'`, and a query filtered on `'flag'` returns nothing.
 
 **Never compare `Climb First Action`'s `ms_since_open` across `render_mode`
 without also fixing `board_name`.** A faster commit time on `aura` could

--- a/docs/og-climb.md
+++ b/docs/og-climb.md
@@ -26,12 +26,19 @@ and reports the cache outcome (`hit` | `base-hit` | `miss`).
 ### Render-mode params (issue #2202)
 
 Optional, shared with the web `/api/internal/board-render` route via
-`boardseshRenderQuerySchema` (`@boardsesh/board-render`). All four default
-closed, so this endpoint (and web) stay classic-by-default until a later PR
-flips it. Every option that affects the output is part of the byte-cache key,
-so an aura render can never be served under a classic key. The base cache
-is keyed only by board config because overlay options do not change its board
-photo backdrop.
+`boardseshRenderQuerySchema` (`@boardsesh/board-render`). `render_mode` defaults
+to `aura`, the drawing the app has shipped since 2.4; the rest default closed.
+Every option that affects the output is part of the byte-cache key, so an aura
+render can never be served under a classic key. The base cache is keyed only by
+board config because overlay options do not change its board photo backdrop.
+
+**Every Boardsesh caller sends `render_mode` and `field_color` explicitly**, even
+though the endpoint would default to them. The query string is the Cloudflare
+cache key and a card is cached `immutable` for a year, so a response already at
+the edge under a bare URL cannot be re-drawn in place — changing the drawing has
+to change the URL. The default is for the callers we do not control: a store
+binary from before the change that prewarms a bare URL, and any third party
+embedding the endpoint.
 
 An `aura` render here draws exactly what the app draws. The look's tuning —
 glow reach, the seam crossfade, the veil buckets, the fill alpha — lives in
@@ -43,7 +50,7 @@ every hold glowing a ring at its placement radius.
 
 | Param          | Default   | Meaning                                                                                                                                       |
 | -------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `render_mode`  | `classic` | `classic` (today's marker-only overlay) or `aura` (veil + glow on traced silhouettes).                                                      |
+| `render_mode`  | `aura`    | `aura` (veil + glow on traced silhouettes — the app's own drawing) or `classic` (the marker-only overlay).                                  |
 | `glow_falloff` | `soft`    | `aura` mode only: glow edge treatment, `soft` or `plateau`.                                                                                 |
 | `glyphs`       | off       | `aura` mode only: `0`\|`1`\|`true`\|`false` — role glyphs inside the glow.                                                                   |
 | `field_color`  | unset     | `#rrggbb`: the play field the veil washes the unlit wall toward. Unset means the light field, on which every board's wall is darker than the field, so `veilOpacityFor` turns the veil off. www and the share cards send `#181225`, the dark field the app's play view composites over. |

--- a/docs/og-smartlinks-roadmap.md
+++ b/docs/og-smartlinks-roadmap.md
@@ -8,10 +8,10 @@ Status of Open Graph metadata, dynamic OG images, and share buttons across all r
 
 | Route                                       | OG Image API                        | Share Button               | Notes                                                  |
 | ------------------------------------------- | ----------------------------------- | -------------------------- | ------------------------------------------------------ |
-| `[board_name]/.../view/[climb_uuid]`        | `https://ws.boardsesh.com/og/climb` | Yes (climb actions drawer) | Immutable Rust-rendered board preview, no text overlay |
+| `[board_name]/.../view/[climb_uuid]`        | `https://ws.boardsesh.com/og/climb` | Yes (climb actions drawer) | Immutable Rust-rendered board preview in Aura, no text overlay |
 | `[board_name]/.../play/[climb_uuid]`        | `https://ws.boardsesh.com/og/climb` | Yes (climb actions drawer) | Same as view, canonical to view URL                    |
-| `/b/[board_slug]/[angle]/view/[climb_uuid]` | `https://ws.boardsesh.com/og/climb` | Yes (inherited)            | Slug route, same immutable board preview               |
-| `/b/[board_slug]/[angle]/play/[climb_uuid]` | `https://ws.boardsesh.com/og/climb` | Yes (inherited)            | Slug route, same immutable board preview               |
+| `/b/[board_slug]/[angle]/view/[climb_uuid]` | `https://ws.boardsesh.com/og/climb` | Yes (inherited)            | Slug route, same immutable Aura board preview          |
+| `/b/[board_slug]/[angle]/play/[climb_uuid]` | `https://ws.boardsesh.com/og/climb` | Yes (inherited)            | Slug route, same immutable Aura board preview          |
 | `/crusher/[user_id]`                        | `/api/og/profile`                   | Yes (header)               | Avatar + grade distribution chart                      |
 | `/setter/[setter_username]`                 | `/api/og/setter`                    | Yes (header)               | Avatar + ascents-per-grade chart for created climbs    |
 | `/session/[sessionId]`                      | `/api/og/session`                   | Yes (header)               | Session name + participants + grade chart              |

--- a/packages/backend/src/__tests__/board-render-service.test.ts
+++ b/packages/backend/src/__tests__/board-render-service.test.ts
@@ -87,6 +87,40 @@ describe('prepareRender — what an Aura request actually sends', () => {
     expect(service.prepareRender(auraParams).config.veil).toBeUndefined();
   });
 
+  it('measures each board its own wall, rather than washing them all alike', () => {
+    // The wiring this pins: `prepareRender` keys `getWallLightness` on the board
+    // config it is rendering. Get that key wrong and every board would take one
+    // board's wash — which looks plausible on the board you happened to open.
+    //
+    // The three numbers are `veilOpacityFor`'s buckets, not measurements of
+    // their own: `veilStrongOpacity` (0.6) above a 0.34 lightness gap,
+    // `veilSoftOpacity` (0.3) above 0.175, and none below the coverage floor.
+    // So if one of these fails, read it this way: a board moving BETWEEN buckets
+    // means its art was re-measured (expected drift — board-art-geometry's
+    // veil.test.ts pins the gaps themselves and will say so), while all three
+    // moving together, or one going undefined, means the server stopped
+    // reaching the measurement at all.
+    const veilFor = (boardName: string, layoutId: number, sizeId: number, setIds: string) =>
+      service.prepareRender({
+        ...standardParams,
+        boardName,
+        layoutId,
+        sizeId,
+        setIds,
+        frames: '',
+        renderMode: 'aura',
+        fieldColor: '#181225',
+      }).config.veil?.opacity;
+
+    // Tension Board 2 Mirror: the loudest wall in the catalogue, strong bucket.
+    expect(veilFor('tension', 10, 6, '12,13')).toBe(0.6);
+    // Kilter Original 12x12: over the soft threshold, under the strong one.
+    expect(veilFor('kilter', 1, 10, '1,20')).toBe(0.3);
+    // MoonBoard 2016 reads only 4 of its 198 placements — under the coverage
+    // floor, so there is no wall to quiet and no veil at all.
+    expect(veilFor('moonboard', 1, 1, '1')).toBeUndefined();
+  });
+
   it('leaves a classic request byte-identical to what it always was', () => {
     const { config } = service.prepareRender(standardParams);
     expect(config.render_mode).toBeUndefined();

--- a/packages/backend/src/__tests__/board-render.test.ts
+++ b/packages/backend/src/__tests__/board-render.test.ts
@@ -104,7 +104,7 @@ describe('handleBoardRender', () => {
       includeBackground: false,
       dimBackground: 0,
       isOgVariant: false,
-      renderMode: 'classic',
+      renderMode: 'aura',
       glowFalloff: 'soft',
       glyphs: false,
       colorScheme: 'light',

--- a/packages/backend/src/__tests__/og-climb.test.ts
+++ b/packages/backend/src/__tests__/og-climb.test.ts
@@ -155,20 +155,30 @@ describe('handleOgClimb', () => {
   });
 
   describe('aura render options (issue #2202)', () => {
-    it('defaults render_mode/glow_falloff/glyphs to classic/soft/off when omitted', async () => {
+    it('draws Aura when the caller names no drawing, with the rest defaulted closed', async () => {
+      // A bare URL is a crawler, an old store binary or a third-party embed —
+      // they get the drawing the app ships, not the one frozen at the moment
+      // their build went out. Boardsesh's own callers name it explicitly, so
+      // their cards get their own Cloudflare entry.
       await run(validParams);
       const [callArgs] = vi.mocked(renderOgClimb).mock.calls[0];
-      expect(callArgs.renderMode).toBe('classic');
+      expect(callArgs.renderMode).toBe('aura');
       expect(callArgs.glowFalloff).toBe('soft');
       expect(callArgs.glyphs).toBe(false);
       expect(callArgs.fieldColor).toBeUndefined();
     });
 
-    it('reaches the service with render_mode=aura and glow_falloff=plateau', async () => {
-      await run({ ...validParams, render_mode: 'aura', glow_falloff: 'plateau' });
+    it('still serves the classic drawing when it is asked for by name', async () => {
+      await run({ ...validParams, render_mode: 'classic' });
+      expect(vi.mocked(renderOgClimb).mock.calls[0][0].renderMode).toBe('classic');
+    });
+
+    it('reaches the service with glow_falloff=plateau, without disturbing the drawing', async () => {
+      await run({ ...validParams, glow_falloff: 'plateau' });
       const [callArgs] = vi.mocked(renderOgClimb).mock.calls[0];
-      expect(callArgs.renderMode).toBe('aura');
       expect(callArgs.glowFalloff).toBe('plateau');
+      // Naming one option must not knock the others off their defaults.
+      expect(callArgs.renderMode).toBe('aura');
     });
 
     it('maps glyphs=1 to true and passes field_color through', async () => {

--- a/packages/backend/src/handlers/og-climb.ts
+++ b/packages/backend/src/handlers/og-climb.ts
@@ -50,8 +50,8 @@ export async function handleOgClimb(req: IncomingMessage, res: ServerResponse, u
     set_ids: rawSetIds,
     frames: url.searchParams.get('frames') ?? '',
     format: url.searchParams.get('format') ?? undefined,
-    // boardsesh-mode render options (issue #2202) — see docs/og-climb.md.
-    // Defaults keep this endpoint classic.
+    // Aura render options (issue #2202) — see docs/og-climb.md. `render_mode`
+    // defaults to aura, the app's own drawing; the rest default closed.
     render_mode: url.searchParams.get('render_mode') ?? undefined,
     glow_falloff: url.searchParams.get('glow_falloff') ?? undefined,
     glyphs: url.searchParams.get('glyphs') ?? undefined,

--- a/packages/mobile/src/hooks/__tests__/use-share-climb.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-share-climb.test.ts
@@ -57,8 +57,13 @@ const climbWithFrames = {
 
 // The backend canonicalises set_ids server-side; the client sorts them too so
 // the raw URL is stable regardless of input order.
+//
+// The render params have to match web's `buildOgBoardRenderUrl` exactly. This
+// URL only warms a cache — the card a crawler fetches is the one in www's
+// og:image — so a disagreement about the drawing warms an entry nobody asks for
+// and leaves the reader on a cold render.
 const expectedOgImageUrl =
-  'https://ws.boardsesh.com/og/climb?board_name=kilter&layout_id=1&size_id=7&set_ids=1%2C20&frames=p1145r15p1146r12&format=jpeg';
+  'https://ws.boardsesh.com/og/climb?board_name=kilter&layout_id=1&size_id=7&set_ids=1%2C20&frames=p1145r15p1146r12&format=jpeg&render_mode=aura&field_color=%23181225';
 
 describe('useShareClimb', () => {
   beforeEach(() => {

--- a/packages/mobile/src/hooks/use-share-climb.ts
+++ b/packages/mobile/src/hooks/use-share-climb.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { Platform, Share } from 'react-native';
 import { buildReadableClimbViewPath } from '@boardsesh/play-view/readable-url-utils';
 import { toFlatFrames } from '@boardsesh/board-constants/hold-states';
+import { BOARD_FIELD_COLORS } from '@boardsesh/board-look';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import { BACKEND_URL, CLIMB_SHARE_BASE_URL } from '../lib/env';
 
@@ -20,6 +21,11 @@ type ShareClimbArgs = {
 // query string need not byte-match web's buildOgBoardRenderUrl: the backend
 // canonicalises set_ids (sort + dedupe) before keying its caches, so both
 // platforms' URLs collapse to the same cache entry.
+//
+// The render params DO have to match, though. This URL only warms a cache — the
+// card a crawler actually fetches is the one in www's og:image — so if the two
+// disagree on the drawing, the prewarm heats an entry nobody asks for and the
+// reader waits on a cold render instead.
 function buildOgImageUrl(args: {
   boardName: string;
   layoutId: number;
@@ -43,6 +49,11 @@ function buildOgImageUrl(args: {
     `set_ids=${encodeURIComponent(sortedSetIds)}`,
     `frames=${encodeURIComponent(flatFrames)}`,
     'format=jpeg',
+    // Kept in step with web's buildOgBoardRenderUrl: the dark play field is the
+    // one the app's own play view composites over, so the card and the board a
+    // climber just looked at are quieted by the same wash.
+    'render_mode=aura',
+    `field_color=${encodeURIComponent(BOARD_FIELD_COLORS.dark)}`,
   ].join('&');
   return `${BACKEND_URL}/og/climb?${query}`;
 }

--- a/packages/mobile/src/lib/__tests__/feature-flag-coercion.test.ts
+++ b/packages/mobile/src/lib/__tests__/feature-flag-coercion.test.ts
@@ -120,13 +120,13 @@ describe('registerRenderSuperProperties', () => {
     registerRenderSuperProperties({
       mode: 'aura',
       glowFalloff: 'plateau',
-      glowFalloffSource: 'flag',
+      glowFalloffSource: 'user',
     });
 
     expect(register).toHaveBeenCalledWith({
       render_mode: 'aura',
       glow_falloff: 'plateau',
-      glow_falloff_source: 'flag',
+      glow_falloff_source: 'user',
     });
   });
 

--- a/packages/mobile/src/lib/analytics.ts
+++ b/packages/mobile/src/lib/analytics.ts
@@ -1,5 +1,5 @@
 import type { PostHog } from 'posthog-react-native';
-import { createAnalytics } from '@boardsesh/analytics';
+import { createAnalytics, type GlowFalloffSource } from '@boardsesh/analytics';
 import { getPostHogClient, registerAppSuperProperties } from './posthog-client';
 import { registerConnectivitySuperProperty } from './analytics-connectivity';
 import { reregisterOfflineEngineState } from './analytics-offline-engine-state';
@@ -184,7 +184,11 @@ export const { track, identify, setPersonProperties, alias } = analytics;
 export function registerRenderSuperProperties(effective: {
   mode: 'classic' | 'aura';
   glowFalloff: 'soft' | 'plateau';
-  glowFalloffSource: 'user' | 'flag' | 'default';
+  // The shared type, not a copy of it. Spelling the union out here is what let
+  // it keep listing `'flag'` after `board-glow-falloff` was retired — a value
+  // nothing could emit, reaching a super property and splitting every query by
+  // a cohort that does not exist.
+  glowFalloffSource: GlowFalloffSource;
 }): void {
   registerSuperProperties({
     render_mode: effective.mode,

--- a/packages/shared/board-render/src/__tests__/validation.test.ts
+++ b/packages/shared/board-render/src/__tests__/validation.test.ts
@@ -182,18 +182,24 @@ describe('ogClimbQuerySchema', () => {
     expect(ogClimbQuerySchema.safeParse({ ...valid, format: 'gif' }).success).toBe(false);
   });
 
-  it('defaults render_mode, glow_falloff and glyphs to classic/soft/off when omitted', () => {
+  it('defaults render_mode to aura, and glow_falloff / glyphs to soft / off', () => {
+    // A caller that names no drawing gets the one the app draws. Every
+    // Boardsesh caller sends it explicitly anyway (the params are the cache
+    // key); this default is for the ones we do not control — a store binary
+    // from before the change, a third-party embed.
     const parsed = ogClimbQuerySchema.parse(valid);
-    expect(parsed.render_mode).toBe('classic');
+    expect(parsed.render_mode).toBe('aura');
     expect(parsed.glow_falloff).toBe('soft');
     expect(parsed.glyphs).toBe(false);
     expect(parsed.field_color).toBeUndefined();
   });
 
-  it('accepts render_mode=boardsesh and glow_falloff=plateau', () => {
-    const parsed = ogClimbQuerySchema.parse({ ...valid, render_mode: 'aura', glow_falloff: 'plateau' });
-    expect(parsed.render_mode).toBe('aura');
-    expect(parsed.glow_falloff).toBe('plateau');
+  it('accepts glow_falloff=plateau', () => {
+    expect(ogClimbQuerySchema.parse({ ...valid, glow_falloff: 'plateau' }).glow_falloff).toBe('plateau');
+  });
+
+  it('still serves classic when it is asked for by name', () => {
+    expect(ogClimbQuerySchema.parse({ ...valid, render_mode: 'classic' }).render_mode).toBe('classic');
   });
 
   it('rejects an invalid render_mode, glow_falloff, or field_color', () => {
@@ -205,9 +211,9 @@ describe('ogClimbQuerySchema', () => {
 });
 
 describe('renderModeSchema / glowFalloffSchema / glyphsQuerySchema / fieldColorSchema', () => {
-  it('renderModeSchema defaults to classic and accepts boardsesh', () => {
-    expect(renderModeSchema.parse(undefined)).toBe('classic');
-    expect(renderModeSchema.parse('aura')).toBe('aura');
+  it('renderModeSchema defaults to aura and still accepts classic', () => {
+    expect(renderModeSchema.parse(undefined)).toBe('aura');
+    expect(renderModeSchema.parse('classic')).toBe('classic');
     expect(renderModeSchema.safeParse('evil').success).toBe(false);
   });
 
@@ -235,6 +241,6 @@ describe('renderModeSchema / glowFalloffSchema / glyphsQuerySchema / fieldColorS
 
   it('boardseshRenderQuerySchema parses all four with defaults', () => {
     const parsed = boardseshRenderQuerySchema.parse({});
-    expect(parsed).toEqual({ render_mode: 'classic', glow_falloff: 'soft', glyphs: false, field_color: undefined });
+    expect(parsed).toEqual({ render_mode: 'aura', glow_falloff: 'soft', glyphs: false, field_color: undefined });
   });
 });

--- a/packages/shared/board-render/src/validation.ts
+++ b/packages/shared/board-render/src/validation.ts
@@ -107,12 +107,20 @@ export function isValidFramesString(frames: string): boolean {
 /**
  * `render_mode`, `glow_falloff`, `glyphs` and `field_color` query params,
  * shared by the web `board-render` route and the backend's `GET /og/climb` —
- * see docs/og-climb.md. All four default closed (classic/soft/off/unset), so
- * an endpoint that never reads a value from this schema still renders
- * classic (issue #2202: web and OG stay classic-by-default in this PR; a
- * later PR flips the default).
+ * see docs/og-climb.md.
+ *
+ * `render_mode` defaults to `aura`, the drawing the app has shipped since 2.4.
+ * Every Boardsesh caller sends it explicitly anyway — the params are the
+ * Cloudflare cache key, and a response cached `immutable` for a year cannot be
+ * re-drawn in place — so this default is for the callers we do not control: a
+ * store binary from before the change that prewarms a bare URL, and any third
+ * party embedding the endpoint. Those get the current drawing rather than one
+ * frozen at the moment their build shipped.
+ *
+ * The other three still default closed (soft/off/unset); `field_color` unset
+ * means the light field, on which `veilOpacityFor` turns the veil off.
  */
-export const renderModeSchema = z.enum(['classic', 'aura']).default('classic');
+export const renderModeSchema = z.enum(['classic', 'aura']).default('aura');
 export const glowFalloffSchema = z.enum(['soft', 'plateau']).default('soft');
 /** Accepts the query-string spellings of a boolean flag; unset -> off. */
 export const glyphsQuerySchema = z

--- a/packages/web/app/components/board-renderer/__tests__/util.test.ts
+++ b/packages/web/app/components/board-renderer/__tests__/util.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import { existsSync, readdirSync } from 'node:fs';
 import path from 'node:path';
+import { BOARD_FIELD_COLORS } from '@boardsesh/board-look';
 import { BOARD_RENDER_VERSION } from '@boardsesh/board-render/version';
 import { STATIC_ASSET_OBJECT_KEYS } from '@boardsesh/static-assets';
 import {
@@ -254,25 +255,30 @@ describe('buildOverlayUrl', () => {
     expect(url).not.toContain('thumbnail');
   });
 
-  it('asks the server for Aura when Aura is what the caller wants', () => {
-    // The canvas renderer and this URL draw the same card — the `<img>` is its
-    // fallback — so if the param were dropped here the two would silently
-    // disagree, and only on the browsers that cannot run the worker.
-    const url = buildBoardRenderUrl(boardDetails, 'p1r12', { includeBackground: true, renderMode: 'aura' });
-    expect(url).toContain('render_mode=aura');
-    expect(url).toContain('field_color=%23181225');
+  it('names the drawing in both directions, never leaving it to the endpoint', () => {
+    // Omitting the param used to mean classic and now means aura, so a caller
+    // that deliberately asks for classic has to say so — otherwise it gets an
+    // aura render, and a `<img>` fallback would disagree with the canvas beside
+    // it. Sending it either way also gives each drawing its own Cloudflare
+    // entry, which is what makes the flip safe under an immutable header.
+    const aura = buildOverlayUrl(boardDetails, 'p1r12');
+    expect(aura).toContain('render_mode=aura');
+    expect(aura).toContain('field_color=%23181225');
 
-    // Classic is the default in this PR and carries neither.
-    const classic = buildBoardRenderUrl(boardDetails, 'p1r12', { includeBackground: true });
-    expect(classic).not.toContain('render_mode');
+    // Naming it explicitly reaches the same URL as taking the default.
+    expect(buildBoardRenderUrl(boardDetails, 'p1r12', { includeBackground: true, renderMode: 'aura' })).toBe(aura);
+
+    const classic = buildOverlayUrl(boardDetails, 'p1r12', undefined, undefined, 'classic');
+    expect(classic).toContain('render_mode=classic');
+    expect(classic).not.toContain('render_mode=aura');
     expect(classic).not.toContain('field_color');
   });
 
   it('threads the drawing through the layered art builder', () => {
     // `BoardImageLayers` builds its overlay through here, so a mode that stopped
     // at the component boundary would leave the fallback drawing classic.
-    const { overlayUrl } = buildBoardArtLayers(boardDetails, 'p1r12', false, 'aura');
-    expect(overlayUrl).toContain('render_mode=aura');
+    expect(buildBoardArtLayers(boardDetails, 'p1r12', false, 'aura').overlayUrl).toContain('render_mode=aura');
+    expect(buildBoardArtLayers(boardDetails, 'p1r12', false, 'classic').overlayUrl).toContain('render_mode=classic');
   });
 
   it.each(['', 'ws://localhost:8080/graphql', 'ws://127.0.0.1:8080/graphql'])(
@@ -319,9 +325,32 @@ describe('buildOgBoardRenderUrl', () => {
     // quote would be an absolute snapshot instead (issue #3947).
     const url = buildOgBoardRenderUrl(boardDetails, 'p1r12,"p2r13');
 
+    // `render_mode` and `field_color` are named rather than left to the
+    // endpoint default on purpose: the params ARE the Cloudflare key, and a card
+    // is cached `immutable` for a year, so a bare URL already sitting at the
+    // edge could not be re-drawn in place. `use-share-climb.ts` in the app
+    // builds the same pair for its prewarm — if the two ever disagree, the app
+    // heats an entry no crawler asks for.
     expect(url).toBe(
       'https://ws.boardsesh.com/og/climb?board_name=kilter&layout_id=1&size_id=7&set_ids=1%2C20' +
-        '&frames=p1r42p2r43&format=jpeg',
+        '&frames=p1r42p2r43&format=jpeg&render_mode=aura&field_color=%23181225',
+    );
+  });
+
+  it('washes toward the same field the renderer measures against', () => {
+    // The coupling that matters is not web-to-mobile, it is either side to the
+    // shared constant: `buildOgBoardRenderUrl` and `use-share-climb.ts` both
+    // read `BOARD_FIELD_COLORS.dark`, so neither can drift from the value the
+    // veil is bucketed against. Asserted against the constant rather than the
+    // literal so this fails if web ever stops reading it — which is the only
+    // way the app's prewarm could start warming an entry no crawler requests.
+    vi.stubEnv('NEXT_PUBLIC_WS_URL', 'wss://ws.boardsesh.com/graphql');
+
+    expect(buildOgBoardRenderUrl(boardDetails, 'p1r12')).toContain(
+      `field_color=${encodeURIComponent(BOARD_FIELD_COLORS.dark)}`,
+    );
+    expect(buildOverlayUrl(boardDetails, 'p1r12')).toContain(
+      `field_color=${encodeURIComponent(BOARD_FIELD_COLORS.dark)}`,
     );
   });
 

--- a/packages/web/app/components/board-renderer/board-canvas-renderer.tsx
+++ b/packages/web/app/components/board-renderer/board-canvas-renderer.tsx
@@ -18,10 +18,10 @@ export type BoardCanvasRendererProps = {
   /** Additional styles for the canvas element */
   style?: React.CSSProperties;
   /**
-   * Which drawing. `aura` glows each lit hold's traced silhouette out of a
-   * washed wall; `classic` draws the marker overlay. The fallback below renders
-   * the same mode, so a browser without OffscreenCanvas does not silently get a
-   * different picture.
+   * Which drawing. Defaults to `aura` — the app's own since 2.4 — which glows
+   * each lit hold's traced silhouette out of a washed wall; `classic` draws the
+   * marker overlay. The fallback below renders the same mode, so a browser
+   * without OffscreenCanvas does not silently get a different picture.
    */
   renderMode?: RenderMode;
   /**
@@ -48,7 +48,7 @@ const BoardCanvasRenderer = React.memo(function BoardCanvasRenderer({
   thumbnail,
   contain,
   style,
-  renderMode = 'classic',
+  renderMode = 'aura',
   cropTop: cropTopOverride,
 }: BoardCanvasRendererProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);

--- a/packages/web/app/components/board-renderer/board-image-layers.tsx
+++ b/packages/web/app/components/board-renderer/board-image-layers.tsx
@@ -45,7 +45,7 @@ export type BoardImageLayersProps = {
   style?: React.CSSProperties;
   /** Set fetchpriority="high" for LCP-critical images */
   fetchPriority?: 'high' | 'low' | 'auto';
-  /** Which drawing the server should render. See `buildBoardRenderUrl`. */
+  /** Which drawing the server should render. Defaults to `aura` — see `buildBoardRenderUrl`. */
   renderMode?: RenderMode;
 };
 

--- a/packages/web/app/components/board-renderer/util.ts
+++ b/packages/web/app/components/board-renderer/util.ts
@@ -30,8 +30,14 @@ type BuildBoardRenderUrlOptions = {
   /** Ask for the dark art siblings. Only meaningful for boards in `BOARDS_WITH_DARK_ART`. */
   colorScheme?: 'light' | 'dark';
   /**
-   * Which drawing the server should render. `aura` also sends the play field
-   * the veil washes toward, so the wash matches what the app draws.
+   * Which drawing the server should render. Defaults to `aura`, the same
+   * drawing the app has shipped since 2.4 — `classic` is the marker overlay,
+   * kept for anything that deliberately wants the old picture.
+   *
+   * Sending it as a query param is what makes the change safe: board-render
+   * responses are cached `immutable` for a year and Cloudflare does not purge on
+   * deploy, so flipping the drawing has to be a URL change. The classic bytes
+   * stay valid under their old URL instead of going stale.
    */
   renderMode?: RenderMode;
 };
@@ -130,7 +136,7 @@ export function getBoardGeometryEndpoint(): string {
 export const buildBoardRenderUrl = (
   boardDetails: BoardDetails,
   frames: string,
-  { thumbnail, includeBackground, variant, format, colorScheme, renderMode }: BuildBoardRenderUrlOptions = {},
+  { thumbnail, includeBackground, variant, format, colorScheme, renderMode = 'aura' }: BuildBoardRenderUrlOptions = {},
 ) => {
   let url =
     `${getBoardRenderEndpoint()}?board_name=${boardDetails.board_name}` +
@@ -159,8 +165,14 @@ export const buildBoardRenderUrl = (
     url += '&color_scheme=dark';
   }
 
+  // Both modes are named, never left to the endpoint's own default. Omitting the
+  // param used to mean classic and now means aura, so a caller that deliberately
+  // asks for classic would otherwise get an aura render — and its `<img>`
+  // fallback would disagree with the canvas beside it.
   if (renderMode === 'aura') {
     url += `&render_mode=aura&field_color=${encodeURIComponent(AURA_FIELD_COLOR)}`;
+  } else {
+    url += '&render_mode=classic';
   }
 
   // Last, always: it reads as the version stamp in a log line, and the route's
@@ -305,6 +317,12 @@ export const buildOgBoardRenderUrl = (boardDetails: BoardDetails, frames: string
       set_ids: boardDetails.set_ids.join(','),
       frames: flatFrames,
       format: 'jpeg',
+      // Explicit, even though the endpoint now defaults to Aura: the params are
+      // the cache key, so a card already sitting in Cloudflare under the bare
+      // URL cannot be served in the old drawing for the rest of its year.
+      // `use-share-climb.ts` in the app builds the same pair for its prewarm.
+      render_mode: 'aura',
+      field_color: AURA_FIELD_COLOR,
     });
     return `${backendOrigin}/og/climb?${backendParams}`;
   }

--- a/packages/web/app/lib/board-render-worker/__tests__/worker-manager.test.ts
+++ b/packages/web/app/lib/board-render-worker/__tests__/worker-manager.test.ts
@@ -707,11 +707,16 @@ describe('renderBoard', () => {
   it('sends the correct render request shape to the worker', async () => {
     const { renderBoard } = await import('../worker-manager');
 
+    // Classic on purpose: the assertions below are the classic config's own
+    // shape — no veil, no glow bundle, no per-hold outlines — and reading them
+    // off the default would make the test change meaning the next time the
+    // default does.
     void renderBoard({
       boardDetails: mockBoardDetails,
       frames: 'p1r42p2r43',
       mirrored: true,
       thumbnail: true,
+      renderMode: 'classic',
     });
 
     await vi.waitFor(() => {
@@ -756,11 +761,16 @@ describe('renderBoard', () => {
   it('issue #2202: prefers the calibrated displayColor over the raw LED color, and boosts Grasshopper stroke width', async () => {
     const { renderBoard } = await import('../worker-manager');
 
+    // Classic on purpose: this pins the CLASSIC palette rule
+    // (`displayColor ?? color`). Aura resolves the same codes through
+    // `boardseshDisplayColor`, which is a different assertion — see the Aura
+    // block below.
     void renderBoard({
       boardDetails: { ...mockBoardDetails, board_name: 'grasshopper' as const },
       frames: 'p1r1p2r2',
       mirrored: false,
       thumbnail: false,
+      renderMode: 'classic',
     });
 
     await vi.waitFor(() => {
@@ -780,11 +790,14 @@ describe('renderBoard', () => {
   it('sets output_width to boardWidth when thumbnail is false', async () => {
     const { renderBoard } = await import('../worker-manager');
 
+    // Classic on purpose: output width is mode-independent, and pinning it on
+    // the cheaper config keeps this test off the geometry fetch entirely.
     void renderBoard({
       boardDetails: mockBoardDetails,
       frames: 'p5r42',
       mirrored: false,
       thumbnail: false,
+      renderMode: 'classic',
     });
 
     await vi.waitFor(() => {
@@ -988,12 +1001,30 @@ describe('Aura', () => {
     fetchMock.mockImplementation(originalImplementation);
   });
 
+  it('is what a caller that names no drawing gets', async () => {
+    const { renderBoard } = await import('../worker-manager');
+    const { resetBoardGeometryCache } = await import('../board-geometry-client');
+    resetBoardGeometryCache();
+
+    void renderBoard({ boardDetails: mockBoardDetails, frames: 'p5r43', mirrored: false });
+
+    await vi.waitFor(() => {
+      expect(findWorkerWithRenderMsg('p5r43')).toBeTruthy();
+    });
+    expect(renderConfig(findWorkerWithRenderMsg('p5r43')!, 'p5r43').render_mode).toBe('aura');
+  });
+
   it('never hands an Aura bitmap back for a classic render of the same climb', async () => {
     const { renderBoard } = await import('../worker-manager');
     const { resetBoardGeometryCache } = await import('../board-geometry-client');
     resetBoardGeometryCache();
 
-    const classicPromise = renderBoard({ boardDetails: mockBoardDetails, frames: 'p6r42', mirrored: false });
+    const classicPromise = renderBoard({
+      boardDetails: mockBoardDetails,
+      frames: 'p6r42',
+      mirrored: false,
+      renderMode: 'classic',
+    });
     await vi.waitFor(() => {
       expect(findWorkerWithRenderMsg('p6r42')).toBeTruthy();
     });

--- a/packages/web/app/lib/board-render-worker/worker-manager.ts
+++ b/packages/web/app/lib/board-render-worker/worker-manager.ts
@@ -229,7 +229,7 @@ export type RenderBoardOptions = {
    *  Callers that already computed cropTop for canvas sizing should pass it here
    *  to guarantee the canvas element and worker render stay in sync. */
   cropTop?: number;
-  /** Which drawing. `classic` is the marker overlay; `aura` is the app's own. */
+  /** Which drawing. Defaults to `aura`, the app's own; `classic` is the marker overlay. */
   renderMode?: RenderMode;
   /** `aura` only: the play field the veil washes the unlit wall toward. */
   fieldColor?: string;
@@ -351,7 +351,8 @@ export function renderBoard(options: RenderBoardOptions): Promise<ImageBitmap> {
   const outputWidth = thumbnail ? THUMBNAIL_WIDTH : boardDetails.boardWidth;
   const resolved: Required<RenderBoardOptions> = {
     thumbnail,
-    renderMode: 'classic',
+    // Aura is what the app draws, so it is what www draws.
+    renderMode: 'aura',
     fieldColor: BOARD_FIELD_COLORS.dark,
     ...options,
     // Last, and computed rather than defaulted: a caller that already sized a


### PR DESCRIPTION
## Summary

Closes #5103. Third of three — stacked on #5114, which is stacked on #5111.

Aura has been the app's default drawing since 2.4. Nothing else drew it. Open a
climb on your phone and it glows the hold's own silhouette out of a quieted
wall; share the same climb and the card is a ring around a circle. Walk up to
the gym kiosk and it is circles again.

Three surfaces flip together, so a climb looks the same wherever a climber sees it:

- **www's board images** — `buildBoardRenderUrl` asks for `render_mode=aura` and
  the dark play field, which reaches the climb-view front door, the LCP preload,
  playlist tiles, the kiosk's seeded raster, the gym-manage kiosk preview and the
  session OG card's board thumbnail.
- **The share cards** — `buildOgBoardRenderUrl` sends the same pair, and the app's
  prewarm in `use-share-climb.ts` matches it exactly. The prewarm only warms a
  cache; if the two disagreed it would heat an entry no crawler asks for and leave
  the reader on a cold render.
- **The browser's own renderer** — the canvas path (card and feed thumbnails,
  similar climbs) and the kiosk slot both default to Aura.

Sending the mode in the query string is what makes the flip safe: board-render
responses are cached `immutable` for a year and Cloudflare does not purge on
deploy, so a new drawing needs a new URL. The classic bytes stay valid under
their old one.

### The wire default flips too

`renderModeSchema` now defaults to `aura`. Every Boardsesh caller names the
drawing explicitly, so that default only reaches callers we do not control — a
store binary from before this change prewarming a bare URL, or a third-party
embed. Those get the current drawing rather than one frozen at the moment their
build shipped.

### The veil

Every surface washes toward `#181225`, the dark field the app's play view
composites over. One render per climb rather than a themed pair, and it is what a
dark-mode app climber already sees.

How hard it lands is measured per board, not fixed — strong (0.6) on Tension,
Touchstone, Kilter Homewall and MoonBoard Masters; soft (0.3) on Kilter Original,
Grasshopper, Decoy, So iLL, Woods and MoonBoard 2016. Exactly one config takes no
wash at all: MoonBoard 2016 Mini, which has an art reading on 4 of its 198
placements — not a wall, and washing an unmeasured one would make it brighter
than the holds it is meant to quiet.

(An earlier revision of this description claimed Woods and every MoonBoard took
no wash. That was wrong — read off two eyeballed renders rather than the
measurement. `board-render-service.test.ts` now pins the three buckets through
`prepareRender`, so the claim is checked rather than asserted.)

### Verified against a running dev server

- List page markup carries `render_mode=aura&field_color=%23181225` on every
  thumbnail URL, and the climb view's `og:image` and LCP preload carry it too.
- `/api/internal/board-geometry?board_name=kilter&layout_id=8&size_id=25` returns
  73 KB gzipped, `immutable`, with 499 outlines and the LED-plate table.
- Rendered and eyeballed the 200px thumbnail, the native-width climb board and
  the 1200×630 share card: silhouette glows, washed wall, LED pips covered.
- `render_mode=classic` still returns the old drawing, byte-different from the
  bare URL's new one.

### Also fixed on the way

`glow_falloff_source` could never be `'flag'` — that flag is retired — but the
mobile type and `docs/board-render-analytics.md` still said it could, so a query
filtered on it silently returned nothing. The doc also called the seven events
five, and pointed at a file that does not exist.

## Release Notes

- Boards look the same everywhere now — shared links, the website and gym kiosks all draw the Aura glow you see in the app.
- Kiosk screens light the hold's own shape instead of a ring around it.

## Test plan

1. Open a climb page on the website — holds glow in their own shape.
2. Paste that climb link into Discord — the preview matches.
3. Scroll a climb list — row thumbnails glow, not circles.
4. Open a gym kiosk screen — the lit climb glows too.

## Risk

Risk: 3/5 — no schema or data changes, but it changes what every board on www, every share card and every kiosk looks like. The drawing itself is the one the app has shipped since 2.4; the flip rides new query params so cached classic images stay valid under their old URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyJ2p57PwKURkzwrxTsAN5

