### PR TITLE
feat(backend): serve user media from the CDN, and manage R2 as code

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -647,6 +647,10 @@ jobs:
       - name: Apply Cloudflare config
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # R2 is ACCOUNT-scoped, unlike the rest of the zone config. Both this
+          # and the token's Account.Workers R2 Storage scope degrade to "skip R2
+          # and say so" when absent, so neither can fail the deploy on its own.
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           # Only a manual dispatch can carry this; a push always resolves to ''.
           # That is the point: an SSL drift should be a decision someone makes,
           # not something a routine merge applies zone-wide on their behalf.

--- a/.gitignore
+++ b/.gitignore
@@ -154,4 +154,13 @@ __pycache__/
 *.pyc
 
 # Credential dumps pasted from provider dashboards — never commit.
+# Deliberately broad: these arrive with ad-hoc, hand-typed names, and an
+# `admin.secet` typo slipped past a `*.secret`-only rule once already.
 *.secret
+*.secret.*
+*.secet
+*secrets*
+/token.*
+/admin.*
+*.credentials
+*.pem

--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ ml/climb2vec/artifacts/
 # Python bytecode
 __pycache__/
 *.pyc
+
+# Credential dumps pasted from provider dashboards — never commit.
+*.secret

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -3,6 +3,24 @@
 Everything Cloudflare for the `boardsesh.com` zone: the config-as-code tooling,
 token setup, CI auto-apply, and the Pages deploy of `app.boardsesh.com`.
 
+
+## R2 buckets
+
+`infra/cloudflare/config.ts` declares the R2 buckets alongside the zone, and `vp run cf:apply` converges them: it creates a declared bucket that is missing and attaches its custom domain. See `docs/user-media-storage.md` for what lives in each one.
+
+**`customDomain` is the whole access-control story.** R2 implements no object ACLs and no bucket policies, so there is no way to make one prefix of a bucket private — attaching a custom domain publishes every object in it. `boardsesh-user-private` holds user data exports and is declared `customDomain: null`; if it is ever found serving a domain, the apply reports it `BLOCKED` and stops rather than detaching it on its own. Buckets are created when absent and never deleted by this tool.
+
+### Token scopes
+
+R2 is **account**-scoped, unlike everything else here, so managing it needs two things the zone work does not:
+
+- `CLOUDFLARE_ACCOUNT_ID` in the environment. Without it, R2 is skipped with a notice.
+- `Account.Workers R2 Storage:Edit` on `CLOUDFLARE_API_TOKEN`. Without it, the R2 read fails authorization and is skipped with a warning — the zone config still applies.
+
+Both degrade to "skip and say so" rather than failing, so the secret and the scope can be added in either order without a window where production deploys break. Attaching a custom domain needs **both** the R2 scope and zone access, because the call takes a `zoneId`: an R2-only token can create the bucket but cannot resolve the zone.
+
+> **Editing the token replaces ALL of its policies.** Re-add every existing scope in the same edit — the `Zone.*` list above and `Account.Cloudflare Pages Edit`. A rotation that granted only the zone scopes is what took `app.boardsesh.com` off the deploy train on 2026-08-25, and it presents as `Authentication error [code: 10000]` while `wrangler whoami` still succeeds.
+
 ## assets.boardsesh.com DNS-only Tigris domain
 
 The public static-assets hostname is repo-managed DNS. `vp run cf:apply` creates

--- a/infra/cloudflare/config.ts
+++ b/infra/cloudflare/config.ts
@@ -589,6 +589,40 @@ export const APEX_REDIRECT_EXPRESSION = `http.host eq "${APEX_HOSTNAME}"`;
  */
 export const APEX_REDIRECT_TARGET_EXPRESSION = `concat("https://${WWW_HOSTNAME}", http.request.uri.path)`;
 
+/** Public custom domain for the R2 user-media bucket. */
+export const MEDIA_HOSTNAME = 'media.boardsesh.com';
+
+/**
+ * R2 buckets this repo owns, and whether each one is public.
+ *
+ * `customDomain` is the entire access-control story for an R2 bucket. R2
+ * implements no object ACLs and no bucket policies, so there is no way to make
+ * one prefix private: attaching a custom domain publishes EVERY object in the
+ * bucket. That is why user data exports live in their own bucket rather than
+ * under a prefix, and why `customDomain: null` is a hard assertion here rather
+ * than a default — the apply fails if such a bucket ever grows a domain.
+ *
+ * Buckets are created when absent and NEVER deleted by this tool. Deleting
+ * object storage is not something a converge loop should be able to do.
+ */
+export interface R2BucketDesired {
+  name: string;
+  /** Hostname serving this bucket publicly, or null when it must stay unreachable. */
+  customDomain: string | null;
+  /**
+   * Cloudflare location hint, applied only at creation time and immutable
+   * afterwards. Omitted lets Cloudflare choose on first write.
+   */
+  locationHint?: 'apac' | 'eeur' | 'enam' | 'oc' | 'weur' | 'wnam';
+}
+
+export const desiredR2Buckets: readonly R2BucketDesired[] = [
+  // Avatars, gym images, beta-link thumbnails and every resize variant.
+  { name: 'boardsesh-user-media', customDomain: MEDIA_HOSTNAME },
+  // User data exports and MoonBoard OCR submissions. MUST stay domain-less.
+  { name: 'boardsesh-user-private', customDomain: null },
+];
+
 export const desiredCloudflareState: CloudflareDesiredState = {
   zoneName: ZONE_NAME,
   dnsRecords: [

--- a/infra/cloudflare/plan.ts
+++ b/infra/cloudflare/plan.ts
@@ -17,6 +17,7 @@ import {
 import type {
   CacheRuleDesired,
   DnsRecordDesired,
+  R2BucketDesired,
   RateLimitRuleDesired,
   RedirectRuleDesired,
   SslDesired,
@@ -185,13 +186,15 @@ export interface PlanOptions {
 }
 
 export interface PlannedChange {
-  resource: 'dns' | ManagedRuleResource | 'ssl';
+  resource: 'dns' | ManagedRuleResource | 'ssl' | 'r2-bucket';
   /** One-line human-readable summary of what would change. */
   summary: string;
   /** Optional extra context printed under the summary. */
   detail?: string;
   /** Present for DNS changes so the apply layer can select the right desired/live record. */
   dnsName?: string;
+  /** Present for R2 changes so the apply layer knows which bucket to act on. */
+  r2BucketName?: string;
   /**
    * true = a change that is NOT auto-applied: the zone-wide SSL mutation
    * requires an explicit opt-in flag (it affects every host on the zone), and
@@ -476,6 +479,71 @@ export function diffSslMode(desiredMode: SslMode, liveMode: string, allowZoneSsl
 }
 
 /** Full desired-vs-live diff: the ordered list of changes --apply would attempt. Empty = in sync. */
+/** What the R2 API reports for one bucket, reduced to what this tool owns. */
+export interface LiveR2Bucket {
+  name: string;
+  exists: boolean;
+  customDomains: string[];
+}
+
+/**
+ * Diff one declared R2 bucket against the account.
+ *
+ * Three outcomes, and the third is the point of this function:
+ *  - the bucket is missing            → create it
+ *  - it is public and lacks its domain → attach it
+ *  - it is declared private but HAS a domain → BLOCKED, never auto-removed
+ *
+ * Detaching a domain is left to a human because the tool cannot tell an
+ * accident from a deliberate change made under incident pressure, and because
+ * the safe direction is to shout rather than to silently take a hostname
+ * offline. Attaching one to a bucket declared private is a data exposure: R2
+ * has no prefix-level privacy, so the domain publishes every object in it.
+ */
+export function diffR2Bucket(desired: R2BucketDesired, live: LiveR2Bucket | null): PlannedChange[] {
+  const changes: PlannedChange[] = [];
+
+  if (!live || !live.exists) {
+    changes.push({
+      resource: 'r2-bucket',
+      r2BucketName: desired.name,
+      summary: `R2 ${desired.name}: missing — will create`,
+      detail: desired.locationHint ? `location hint: ${desired.locationHint}` : undefined,
+    });
+    // Nothing else is knowable until it exists; the domain lands on the re-run.
+    return changes;
+  }
+
+  const domains = live.customDomains;
+
+  if (desired.customDomain === null) {
+    if (domains.length > 0) {
+      changes.push({
+        resource: 'r2-bucket',
+        r2BucketName: desired.name,
+        summary: `R2 ${desired.name}: declared PRIVATE but serves ${domains.join(', ')}`,
+        detail:
+          'R2 has no object ACLs and no bucket policies, so a custom domain publishes every object in the bucket. ' +
+          'This bucket holds user data exports. Remove the domain in the Cloudflare dashboard, or change the ' +
+          'declaration if it is now meant to be public.',
+        blocked: true,
+      });
+    }
+    return changes;
+  }
+
+  if (!domains.includes(desired.customDomain)) {
+    changes.push({
+      resource: 'r2-bucket',
+      r2BucketName: desired.name,
+      summary: `R2 ${desired.name}: will attach ${desired.customDomain}`,
+      detail: domains.length > 0 ? `already serves: ${domains.join(', ')}` : undefined,
+    });
+  }
+
+  return changes;
+}
+
 export function buildPlan(
   desired: DesiredRuleSets & {
     dnsRecords: DnsRecordDesired[];

--- a/packages/backend/src/__tests__/avatar-upload-s3.test.ts
+++ b/packages/backend/src/__tests__/avatar-upload-s3.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { ALLOWED_IMAGE_SIZES } from '@boardsesh/shared-schema';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { once } from 'node:events';
@@ -65,8 +66,8 @@ describe('avatar upload S3 path (write-first, clean-after)', () => {
     validateTokenMock.mockResolvedValue({ userId: USER_ID });
     isS3ConfiguredMock.mockReturnValue(true);
     const callOrder: string[] = [];
-    uploadToS3Mock.mockImplementation(async () => {
-      callOrder.push('upload');
+    uploadToS3Mock.mockImplementation(async (_bucket: string, _body: Buffer, key: string) => {
+      callOrder.push(key.includes('@') ? 'variant' : 'base');
     });
     deleteUserAvatarsFromS3Mock.mockImplementation(async () => {
       callOrder.push('delete');
@@ -77,8 +78,23 @@ describe('avatar upload S3 path (write-first, clean-after)', () => {
       const response = await uploadJpegAvatar(baseUrl);
 
       expect(response.status).toBe(200);
-      expect(callOrder).toEqual(['upload', 'delete']);
+      // Variants, then the base, then the cleanup. A reader that can see the
+      // new avatar can always see its sizes, and nothing stale is removed
+      // until the replacement is durably saved.
+      const baseIndex = callOrder.indexOf('base');
+      expect(callOrder.slice(0, baseIndex).every((entry) => entry === 'variant')).toBe(true);
+      expect(callOrder.slice(baseIndex)).toEqual(['base', 'delete']);
+      expect(callOrder.filter((entry) => entry === 'variant')).toHaveLength(ALLOWED_IMAGE_SIZES.length);
       expect(uploadToS3Mock).toHaveBeenCalledWith('media', expect.any(Buffer), `avatars/${USER_ID}.jpg`, 'image/jpeg');
+      for (const size of ALLOWED_IMAGE_SIZES) {
+        expect(uploadToS3Mock).toHaveBeenCalledWith(
+          'media',
+          expect.any(Buffer),
+          `avatars/${USER_ID}.jpg@${size}.jpg`,
+          'image/jpeg',
+          expect.objectContaining({ cacheControl: expect.any(String) }),
+        );
+      }
       // keepExt must match the freshly written file so it is never deleted.
       expect(deleteUserAvatarsFromS3Mock).toHaveBeenCalledWith(USER_ID, 'jpg');
     } finally {

--- a/packages/backend/src/__tests__/media-url.test.ts
+++ b/packages/backend/src/__tests__/media-url.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { buildMediaObjectUrl, mediaVariantKey, staticPathToMediaRedirect } from '../lib/media-url';
+import { resizedVariantKey } from '../lib/image-resize';
+
+const BASE = 'https://media.boardsesh.com';
+
+function redirect(path: string, query = ''): string | null {
+  return staticPathToMediaRedirect(path, new URLSearchParams(query), BASE);
+}
+
+describe('mediaVariantKey', () => {
+  it('matches the key the resize path actually writes', () => {
+    // These two must agree or every sized request 404s: one builds the URL,
+    // the other names the object.
+    expect(mediaVariantKey('avatars/u1.jpg', 280)).toBe(resizedVariantKey('avatars/u1.jpg', 280));
+  });
+
+  it('returns the base key when no size is requested', () => {
+    expect(mediaVariantKey('avatars/u1.jpg', null)).toBe('avatars/u1.jpg');
+  });
+});
+
+describe('buildMediaObjectUrl', () => {
+  it('joins base and key with a single slash', () => {
+    expect(buildMediaObjectUrl('https://media.boardsesh.com/', 'avatars/u1.jpg')).toBe(
+      'https://media.boardsesh.com/avatars/u1.jpg',
+    );
+  });
+
+  it('appends the version as a query param, not into the key', () => {
+    // The object store ignores unknown query params, so ?v= gives per-version
+    // URL immutability without a versioned key layout to garbage-collect.
+    expect(buildMediaObjectUrl(BASE, 'avatars/u1.jpg', null, 'abc-123')).toBe(
+      'https://media.boardsesh.com/avatars/u1.jpg?v=abc-123',
+    );
+  });
+
+  it('encodes a version containing URL-significant characters', () => {
+    expect(buildMediaObjectUrl(BASE, 'avatars/u1.jpg', null, 'a&b c')).toBe(
+      'https://media.boardsesh.com/avatars/u1.jpg?v=a%26b%20c',
+    );
+  });
+});
+
+describe('staticPathToMediaRedirect', () => {
+  it('maps an avatar with size and version', () => {
+    expect(redirect('/static/avatars/u1.jpg', 'v=abc&size=64')).toBe(
+      'https://media.boardsesh.com/avatars/u1.jpg@64.jpg?v=abc',
+    );
+  });
+
+  it('maps an avatar without a size to the base object', () => {
+    expect(redirect('/static/avatars/u1.jpg', 'v=abc')).toBe('https://media.boardsesh.com/avatars/u1.jpg?v=abc');
+  });
+
+  it.each([
+    ['/static/gym-logos/g1.png', 'gym-logos/g1.png'],
+    ['/static/gym-photos/g1.jpg', 'gym-photos/g1.jpg'],
+  ])('maps %s', (path, key) => {
+    expect(redirect(path)).toBe(`${BASE}/${key}`);
+  });
+
+  it('maps a beta thumbnail, including the platform segment', () => {
+    expect(redirect('/static/beta-link-thumbnails/instagram/ABC.jpg', 'size=280')).toBe(
+      'https://media.boardsesh.com/beta-link-thumbnails/instagram/ABC.jpg@280.jpg',
+    );
+    expect(redirect('/static/beta-link-thumbnails/tiktok/cache_42.jpg')).toBe(
+      'https://media.boardsesh.com/beta-link-thumbnails/tiktok/cache_42.jpg',
+    );
+  });
+
+  it('drops an off-allowlist size rather than honouring it', () => {
+    // Matches parseSizeParam: a size we never generated resolves to the base
+    // object instead of a guaranteed 404.
+    expect(redirect('/static/avatars/u1.jpg', 'size=999')).toBe('https://media.boardsesh.com/avatars/u1.jpg');
+    expect(redirect('/static/avatars/u1.jpg', 'size=abc')).toBe('https://media.boardsesh.com/avatars/u1.jpg');
+  });
+
+  describe('refuses to map anything it does not recognise', () => {
+    it.each([
+      ['a non-static path', '/api/whatever'],
+      ['an unknown static route', '/static/secrets/key.txt'],
+      ['a missing filename', '/static/avatars/'],
+      ['a nested path under a simple route', '/static/avatars/nested/u1.jpg'],
+      ['a nested path under a thumbnail platform', '/static/beta-link-thumbnails/instagram/a/b.jpg'],
+      ['an unknown thumbnail platform', '/static/beta-link-thumbnails/youtube/ABC.jpg'],
+      ['a thumbnail filename that is not .jpg', '/static/beta-link-thumbnails/instagram/ABC.png'],
+      ['a bare thumbnail path', '/static/beta-link-thumbnails/instagram'],
+    ])('%s', (_label, path) => {
+      expect(redirect(path)).toBeNull();
+    });
+
+    it.each([
+      ['parent traversal', '/static/avatars/..'],
+      ['current directory', '/static/avatars/.'],
+      ['an encoded separator', '/static/avatars/a%2Fb.jpg'],
+      ['a filename with a space', '/static/avatars/a b.jpg'],
+    ])('%s', (_label, path) => {
+      // A path this rejects falls through to the existing proxy, which applies
+      // the same guard — so a rejection here is never a hole, only a slower path.
+      expect(redirect(path)).toBeNull();
+    });
+  });
+
+  it('never lets a crafted path escape the media prefix', () => {
+    // The redirect target is a Location header: a value that resolved outside
+    // the media host would be an open redirect.
+    const crafted = [
+      '/static/avatars/u1.jpg',
+      '/static/gym-logos/g1.png',
+      '/static/beta-link-thumbnails/instagram/ABC.jpg',
+    ];
+    for (const path of crafted) {
+      const target = redirect(path);
+      expect(target).not.toBeNull();
+      expect(new URL(target!).origin).toBe('https://media.boardsesh.com');
+    }
+  });
+});

--- a/packages/backend/src/handlers/avatars.ts
+++ b/packages/backend/src/handlers/avatars.ts
@@ -8,6 +8,7 @@ import { validateToken } from '../middleware/auth';
 import { isS3Configured, uploadToS3, deleteUserAvatarsFromS3 } from '../storage/s3';
 import { logger } from '../utils/logger';
 import { buildStaticAvatarUrl } from '../lib/avatar-url';
+import { MUTABLE_IMAGE_CACHE_CONTROL, writeImageVariants } from '../lib/image-resize';
 
 // Avatar upload configuration
 const AVATARS_DIR = './avatars';
@@ -274,6 +275,17 @@ export async function handleAvatarUpload(req: IncomingMessage, res: ServerRespon
         avatarUrl = await serializePerUser(uploadUserId, async () => {
           if (useS3) {
             const s3Key = `avatars/${avatarFileName}`;
+            // Variants first, then the base: a reader that can see the new
+            // avatar can always see its sizes. Direct-from-bucket serving has
+            // no resizer, so a size that does not exist is a 404.
+            await writeImageVariants(
+              uploadBuffer,
+              s3Key,
+              (key, body, contentType) =>
+                uploadToS3('media', body, key, contentType, { cacheControl: MUTABLE_IMAGE_CACHE_CONTROL }),
+              undefined,
+              uploadMimeType,
+            );
             await uploadToS3('media', uploadBuffer, s3Key, uploadMimeType);
             await deleteUserAvatarsFromS3(uploadUserId, ext);
           } else {

--- a/packages/backend/src/handlers/gym-image-upload.ts
+++ b/packages/backend/src/handlers/gym-image-upload.ts
@@ -7,6 +7,7 @@ import { eq, and, isNull } from 'drizzle-orm';
 import { applyCorsHeaders } from './cors';
 import { validateToken } from '../middleware/auth';
 import { isS3Configured, uploadToS3 } from '../storage/s3';
+import { MUTABLE_IMAGE_CACHE_CONTROL, writeImageVariants } from '../lib/image-resize';
 import { logger } from '../utils/logger';
 import { db } from '../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
@@ -389,6 +390,15 @@ export function createGymImageUploadHandler(
         try {
           if (useS3) {
             const s3Key = `${config.storagePrefix}/${imageFileName}`;
+            // Variants first, then the base — see the note in handlers/avatars.ts.
+            await writeImageVariants(
+              fileBuffer,
+              s3Key,
+              (key, body, contentType) =>
+                uploadToS3('media', body, key, contentType, { cacheControl: MUTABLE_IMAGE_CACHE_CONTROL }),
+              undefined,
+              mimeType,
+            );
             await uploadToS3('media', fileBuffer, s3Key, mimeType);
             // Backend-relative URL — we proxy the bytes from S3 ourselves, so no
             // public-read ACL is required.

--- a/packages/backend/src/lib/image-resize.ts
+++ b/packages/backend/src/lib/image-resize.ts
@@ -8,6 +8,15 @@ import { ALLOWED_IMAGE_SIZES, type AllowedImageSize } from '@boardsesh/shared-sc
 export { ALLOWED_IMAGE_SIZES, type AllowedImageSize };
 
 /**
+ * Cache lifetime for a variant of a MUTABLE key (avatars, gym images).
+ *
+ * Matches what the proxying path served, so a client that drops the `?v=`
+ * cache buster still self-heals within a day rather than pinning a replaced
+ * image forever.
+ */
+export const MUTABLE_IMAGE_CACHE_CONTROL = 'public, max-age=86400';
+
+/**
  * Parse a `?size=` query value against the allowlist. Returns null for
  * missing / non-numeric / out-of-allowlist values, in which case the
  * caller serves the original image (back-compat).
@@ -47,4 +56,47 @@ export async function streamToBuffer(stream: Readable): Promise<Buffer> {
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as ArrayBuffer));
   }
   return Buffer.concat(chunks);
+}
+
+/**
+ * Write every allowed resize variant of a freshly uploaded image.
+ *
+ * Called for the MUTABLE media keys (avatars, gym logos, gym photos), which the
+ * proxying path deliberately never cached a variant for: the key is overwritten
+ * in place on re-upload, so a cached variant could shadow a new image. Serving
+ * the bucket directly removes the on-the-fly resizer, so every size a client can
+ * request has to exist as an object — and the `?v=` cache buster already in the
+ * stored URL is what keeps a replacement visible instead.
+ *
+ * Variants are written BEFORE their base object by the callers, so a reader who
+ * can see a new base can always see its variants; a partial failure leaves the
+ * previous image and its variants fully consistent and surfaces as a 500.
+ */
+export async function writeImageVariants(
+  original: Buffer,
+  baseKey: string,
+  writeObject: (key: string, body: Buffer, contentType: string) => Promise<unknown>,
+  sizes: readonly AllowedImageSize[] = ALLOWED_IMAGE_SIZES,
+  originalContentType = 'image/jpeg',
+): Promise<void> {
+  const resized = await Promise.all(
+    sizes.map(async (size) => {
+      try {
+        return {
+          key: resizedVariantKey(baseKey, size),
+          body: await resizeImageBuffer(original, size),
+          contentType: 'image/jpeg',
+        };
+      } catch {
+        // A source sharp cannot decode still has to produce an OBJECT at every
+        // variant key, because direct-from-bucket serving has no fallback: a
+        // missing key is a 404, not a slightly-too-large image. Storing the
+        // original bytes mirrors what the proxying resize path did on a failed
+        // resize — serve the original unchanged — and keeps the upload itself
+        // succeeding, which matters more than the pixels being the right size.
+        return { key: resizedVariantKey(baseKey, size), body: original, contentType: originalContentType };
+      }
+    }),
+  );
+  await Promise.all(resized.map(({ key, body, contentType }) => writeObject(key, body, contentType)));
 }

--- a/packages/backend/src/lib/media-url.ts
+++ b/packages/backend/src/lib/media-url.ts
@@ -1,0 +1,108 @@
+// Maps the backend's `/static/*` routes onto public media-bucket URLs.
+//
+// Pure and side-effect free so the mapping can be tested without a server —
+// `handlers/static.ts` has no tests of its own, and this is the part where a
+// mistake either 404s every avatar or, worse, lets a crafted path escape its
+// prefix.
+//
+// Why a redirect rather than just changing the stored URLs: the persisted
+// values in `user_profiles.avatar_url`, `gyms.image_url` and `gyms.logo_url`
+// are backend-relative `/static/…?v=` paths, and released mobile builds
+// string-match `/static/avatars/` before appending `?size=` (see
+// packages/mobile/src/components/Avatar.tsx). Rewriting those columns to
+// absolute URLs would make every shipped client fetch the full-res original
+// for a 40px circle. A 301 keeps those clients correct while taking the byte
+// path off the backend: one permanently-cached redirect, then the CDN.
+
+import { ALLOWED_IMAGE_SIZES, type AllowedImageSize } from '@boardsesh/shared-schema';
+
+/** Object-key prefixes reachable through `/static/<segment>/`. */
+const SIMPLE_STATIC_ROUTES: Readonly<Record<string, string>> = {
+  avatars: 'avatars',
+  'gym-logos': 'gym-logos',
+  'gym-photos': 'gym-photos',
+};
+
+/** Mirrors the validation in handlers/static.ts — kept identical on purpose. */
+const SIMPLE_FILENAME = /^[A-Za-z0-9._-]+$/;
+const BETA_THUMBNAIL_PLATFORMS = new Set(['instagram', 'tiktok']);
+const BETA_THUMBNAIL_FILENAME = /^[A-Za-z0-9_-]+\.jpg$/;
+
+/** The query parameter carrying the per-version cache buster. */
+export const VERSION_QUERY_PARAM = 'v';
+
+/**
+ * Key of the resized variant of an object, or the base key when `size` is null.
+ *
+ * Deliberately the same shape as `resizedVariantKey` in `lib/image-resize.ts`
+ * (`<baseKey>@<size>.jpg`) so a variant written by the resize path and a URL
+ * built here address the same object. Changing one without the other silently
+ * 404s every sized request.
+ */
+export function mediaVariantKey(baseKey: string, size: AllowedImageSize | null): string {
+  return size === null ? baseKey : `${baseKey}@${size}.jpg`;
+}
+
+/**
+ * Absolute URL for a media object.
+ *
+ * `version` is passed through as `?v=` rather than baked into the key: the
+ * object store ignores unknown query parameters, so it gives per-version URL
+ * immutability for the mutable keys (avatars, gym images are overwritten in
+ * place) without a versioned key layout to garbage-collect.
+ */
+export function buildMediaObjectUrl(
+  baseUrl: string,
+  key: string,
+  size: AllowedImageSize | null = null,
+  version?: string | null,
+): string {
+  const normalizedBase = baseUrl.replace(/\/+$/, '');
+  const url = `${normalizedBase}/${mediaVariantKey(key, size)}`;
+  return version ? `${url}?${VERSION_QUERY_PARAM}=${encodeURIComponent(version)}` : url;
+}
+
+function parseSize(raw: string | null): AllowedImageSize | null {
+  if (!raw) return null;
+  const parsed = Number(raw);
+  return (ALLOWED_IMAGE_SIZES as readonly number[]).includes(parsed) ? (parsed as AllowedImageSize) : null;
+}
+
+/**
+ * Translate a `/static/…` request into the media-bucket URL it should redirect
+ * to, or null when the path is not one this maps (caller falls through to the
+ * existing proxy behaviour).
+ *
+ * Returning null rather than throwing keeps the caller's shape simple: a path
+ * this does not recognise is served exactly as it is today.
+ *
+ * `?size=` is folded into the object key because a bucket has no resizer; an
+ * off-allowlist value is dropped rather than honoured, matching
+ * `parseSizeParam`, so a request for a size we never generated resolves to the
+ * base object instead of a guaranteed 404.
+ */
+export function staticPathToMediaRedirect(pathname: string, search: URLSearchParams, baseUrl: string): string | null {
+  if (!pathname.startsWith('/static/')) return null;
+
+  const segments = pathname.slice('/static/'.length).split('/');
+  const size = parseSize(search.get('size'));
+  const version = search.get(VERSION_QUERY_PARAM);
+
+  // `/static/beta-link-thumbnails/<platform>/<file>`
+  if (segments[0] === 'beta-link-thumbnails') {
+    const [, platform, fileName, ...rest] = segments;
+    if (rest.length > 0 || !platform || !fileName) return null;
+    if (!BETA_THUMBNAIL_PLATFORMS.has(platform) || !BETA_THUMBNAIL_FILENAME.test(fileName)) return null;
+    return buildMediaObjectUrl(baseUrl, `beta-link-thumbnails/${platform}/${fileName}`, size, version);
+  }
+
+  // `/static/<avatars|gym-logos|gym-photos>/<file>`
+  const [routeSegment, fileName, ...rest] = segments;
+  const prefix = routeSegment ? SIMPLE_STATIC_ROUTES[routeSegment] : undefined;
+  if (!prefix || rest.length > 0 || !fileName) return null;
+  // Rejects `..`, empty names and anything with a path separator, which is the
+  // same guard the proxying handlers apply via `path.basename`.
+  if (!SIMPLE_FILENAME.test(fileName) || fileName === '.' || fileName === '..') return null;
+
+  return buildMediaObjectUrl(baseUrl, `${prefix}/${fileName}`, size, version);
+}

--- a/packages/backend/src/scripts/backfill-image-variants.ts
+++ b/packages/backend/src/scripts/backfill-image-variants.ts
@@ -1,0 +1,193 @@
+/**
+ * Generate the resized image variants that direct-from-bucket serving needs.
+ *
+ * While `/static/*` proxied every byte, a `?size=N` request could resize on the
+ * fly and (for immutable keys) cache the result. Serving the object store
+ * directly has no resizer: every size a client can ask for must already exist
+ * as an object, or the request 404s.
+ *
+ * Two different rules, because the keys differ in kind:
+ *
+ * - `beta-link-thumbnails/` is keyed by the social media id, so the bytes never
+ *   change and the variant is safe to keep forever. Only 280 is ever requested
+ *   (BETA_THUMBNAIL_REQUEST_SIZE), and the proxy has been caching that size
+ *   lazily on first view — so the gap here is exactly the thumbnails nobody has
+ *   looked at yet.
+ * - `avatars/`, `gym-logos/` and `gym-photos/` are overwritten in place on
+ *   re-upload, which is why the proxy deliberately never cached a variant for
+ *   them (a stale variant would shadow a new image). Direct serving removes
+ *   that option, so every allowed size is generated and the `?v=` cache buster
+ *   already in the stored URL is what keeps a replacement visible.
+ *
+ * Idempotent: a variant that already exists is skipped, so this is safe to
+ * re-run and safe to interrupt.
+ *
+ * Usage:
+ *   vp exec tsx packages/backend/src/scripts/backfill-image-variants.ts --dry-run
+ *   vp exec tsx packages/backend/src/scripts/backfill-image-variants.ts --prefix avatars/
+ */
+
+import { ALLOWED_IMAGE_SIZES, BETA_THUMBNAIL_REQUEST_SIZE, type AllowedImageSize } from '@boardsesh/shared-schema';
+import { resizeImageBuffer, resizedVariantKey, streamToBuffer } from '../lib/image-resize';
+import { getFromS3, listS3Objects, uploadToS3 } from '../storage/s3';
+import { logger } from '../utils/logger';
+
+type VariantRule = Readonly<{
+  prefix: string;
+  sizes: readonly AllowedImageSize[];
+  cacheControl: string;
+}>;
+
+const IMMUTABLE_CACHE_CONTROL = 'public, max-age=31536000, immutable';
+/** Matches what the proxy served for avatars and gym images, so a client that drops `?v=` self-heals within a day. */
+const MUTABLE_CACHE_CONTROL = 'public, max-age=86400';
+
+const VARIANT_RULES: readonly VariantRule[] = [
+  { prefix: 'beta-link-thumbnails/', sizes: [BETA_THUMBNAIL_REQUEST_SIZE], cacheControl: IMMUTABLE_CACHE_CONTROL },
+  { prefix: 'avatars/', sizes: ALLOWED_IMAGE_SIZES, cacheControl: MUTABLE_CACHE_CONTROL },
+  { prefix: 'gym-logos/', sizes: ALLOWED_IMAGE_SIZES, cacheControl: MUTABLE_CACHE_CONTROL },
+  { prefix: 'gym-photos/', sizes: ALLOWED_IMAGE_SIZES, cacheControl: MUTABLE_CACHE_CONTROL },
+];
+
+const DEFAULT_CONCURRENCY = 8;
+
+type Options = Readonly<{ dryRun: boolean; prefixFilters: readonly string[]; concurrency: number }>;
+
+function parseOptions(argv: readonly string[]): Options {
+  const prefixFilters: string[] = [];
+  let concurrency = DEFAULT_CONCURRENCY;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--dry-run') continue;
+    if (argument === '--prefix') {
+      const value = argv[index + 1];
+      if (!value) throw new Error('--prefix requires a value');
+      prefixFilters.push(value);
+      index += 1;
+      continue;
+    }
+    if (argument === '--concurrency') {
+      concurrency = Number(argv[index + 1]);
+      if (!Number.isInteger(concurrency) || concurrency <= 0)
+        throw new Error('--concurrency must be a positive integer');
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+
+  return { dryRun: argv.includes('--dry-run'), prefixFilters, concurrency };
+}
+
+/** A key that is itself a variant, e.g. `avatars/u1.jpg@64.jpg`. */
+function isVariantKey(key: string): boolean {
+  return /@\d+\.jpg$/.test(key);
+}
+
+async function withConcurrency<T>(
+  items: readonly T[],
+  limit: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  let nextIndex = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, async () => {
+      while (true) {
+        const index = nextIndex;
+        nextIndex += 1;
+        if (index >= items.length) return;
+        await worker(items[index]);
+      }
+    }),
+  );
+}
+
+type PendingVariant = Readonly<{ baseKey: string; size: AllowedImageSize; cacheControl: string }>;
+
+async function main(): Promise<void> {
+  const options = parseOptions(process.argv.slice(2));
+  const rules = VARIANT_RULES.filter(
+    (rule) =>
+      options.prefixFilters.length === 0 ||
+      options.prefixFilters.some((filter) => rule.prefix.startsWith(filter) || filter.startsWith(rule.prefix)),
+  );
+
+  const pending: PendingVariant[] = [];
+  const emptySources: string[] = [];
+
+  for (const rule of rules) {
+    const objects = await listS3Objects('media', rule.prefix);
+    const present = new Set(objects.map((object) => object.key));
+    const bases = objects.filter((object) => !isVariantKey(object.key));
+
+    let rulePending = 0;
+    for (const base of bases) {
+      // sharp throws on an empty buffer, and a zero-byte source is a broken
+      // upload rather than something a variant can be made from.
+      if (base.size === 0) {
+        emptySources.push(base.key);
+        continue;
+      }
+      for (const size of rule.sizes) {
+        if (present.has(resizedVariantKey(base.key, size))) continue;
+        pending.push({ baseKey: base.key, size, cacheControl: rule.cacheControl });
+        rulePending += 1;
+      }
+    }
+    logger.info(
+      `[backfill-variants] ${rule.prefix}: ${bases.length} base objects, sizes [${rule.sizes.join(', ')}], ${rulePending} variant(s) to generate`,
+    );
+  }
+
+  if (emptySources.length > 0) {
+    logger.warn(`[backfill-variants] skipped ${emptySources.length} zero-byte source object(s)`);
+  }
+  if (options.dryRun) {
+    logger.info(`[backfill-variants] dry run: ${pending.length} variant(s) would be generated`);
+    return;
+  }
+  if (pending.length === 0) {
+    logger.info('[backfill-variants] nothing to generate');
+    return;
+  }
+
+  let generated = 0;
+  let failed = 0;
+  const startedAt = Date.now();
+
+  await withConcurrency(pending, options.concurrency, async (variant) => {
+    try {
+      const original = await getFromS3('media', variant.baseKey);
+      if (!original) {
+        failed += 1;
+        logger.warn(`[backfill-variants] base object vanished: ${variant.baseKey}`);
+        return;
+      }
+      const body = await resizeImageBuffer(await streamToBuffer(original.stream), variant.size);
+      await uploadToS3('media', body, resizedVariantKey(variant.baseKey, variant.size), 'image/jpeg', {
+        cacheControl: variant.cacheControl,
+      });
+      generated += 1;
+      if (generated % 500 === 0) {
+        const rate = generated / Math.max((Date.now() - startedAt) / 1000, 0.001);
+        logger.info(`[backfill-variants] ${generated}/${pending.length} · ${rate.toFixed(1)}/s`);
+      }
+    } catch (error) {
+      // One unreadable source must not abort the run; it is reported and the
+      // re-run picks it up if it was transient.
+      failed += 1;
+      logger.warn(`[backfill-variants] failed ${variant.baseKey}@${variant.size}:`, error);
+    }
+  });
+
+  logger.info(
+    `[backfill-variants] done: ${generated} generated, ${failed} failed, ${Math.round((Date.now() - startedAt) / 1000)}s`,
+  );
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((error: unknown) => {
+  logger.error('[backfill-variants] fatal:', error);
+  process.exit(1);
+});

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -19,6 +19,8 @@ import {
   handleStaticGymLogo,
   handleStaticGymPhoto,
 } from './handlers/static';
+import { staticPathToMediaRedirect } from './lib/media-url';
+import { getMediaPublicBaseUrl } from './storage/s3';
 import { handleOgClimb } from './handlers/og-climb';
 import { handleBoardRender, isBoardRenderPath } from './handlers/board-render';
 import { initBoardRenderer } from './services/board-render';
@@ -477,6 +479,36 @@ export async function startServer(): Promise<ServerResources> {
       if (pathname === '/board-credentials/kilter/callback' && req.method === 'GET') {
         await handleKilterCredentialsCallback(req, res, url);
         return;
+      }
+
+      // Once the media bucket has a public base URL, /static/* stops streaming
+      // bytes through this process and hands the client the CDN object instead.
+      //
+      // A redirect rather than only rewriting the stored URLs, because the
+      // persisted values are backend-relative `/static/…?v=` paths and released
+      // mobile builds string-match `/static/avatars/` before appending `?size=`
+      // (packages/mobile/src/components/Avatar.tsx). Rewriting the columns
+      // would make every shipped client fetch the full-res original for a 40px
+      // circle; this keeps them correct while taking the bytes off the backend.
+      //
+      // 302 with a bounded TTL, not a permanent redirect: unsetting
+      // MEDIA_PUBLIC_BASE_URL has to be a complete rollback, and browsers cache
+      // a 301 far too aggressively (Safari has historically kept them forever)
+      // for that promise to hold. An hour of edge caching absorbs effectively
+      // all of the traffic anyway.
+      if (pathname.startsWith('/static/')) {
+        const mediaBaseUrl = getMediaPublicBaseUrl();
+        if (mediaBaseUrl) {
+          const target = staticPathToMediaRedirect(pathname, url.searchParams, mediaBaseUrl);
+          // A path this does not recognise falls through to the proxy below,
+          // which applies the same validation — so a null here is never a hole.
+          if (target) {
+            if (!applyCorsHeaders(req, res)) return;
+            res.writeHead(302, { Location: target, 'Cache-Control': 'public, max-age=3600' });
+            res.end();
+            return;
+          }
+        }
       }
 
       // Static avatar files (optional ?size= for a resized variant)

--- a/packages/backend/src/storage/__tests__/delete-user-avatars.test.ts
+++ b/packages/backend/src/storage/__tests__/delete-user-avatars.test.ts
@@ -21,6 +21,13 @@ vi.mock('../../utils/logger', () => ({
 }));
 
 const { deleteUserAvatarsFromS3 } = await import('../s3');
+const { ALLOWED_IMAGE_SIZES, resizedVariantKey } = await import('../../lib/image-resize');
+
+/** Every key a stale extension now owns: the base object plus each resize variant. */
+function keysFor(userId: string, extension: string): string[] {
+  const baseKey = `avatars/${userId}.${extension}`;
+  return [baseKey, ...ALLOWED_IMAGE_SIZES.map((size) => resizedVariantKey(baseKey, size))];
+}
 
 const USER_ID = '33333333-3333-4333-8333-333333333333';
 
@@ -43,7 +50,13 @@ describe('deleteUserAvatarsFromS3', () => {
 
     const deleteCommands = sendMock.mock.calls.map((call) => call[0] as { input: { Key: string } });
     const deletedKeys = deleteCommands.map((command) => command.input.Key);
-    expect(deletedKeys.sort()).toEqual([`avatars/${USER_ID}.gif`, `avatars/${USER_ID}.png`, `avatars/${USER_ID}.webp`]);
+    // Variants are keyed off the BASE key, so a stale `.png` leaves
+    // `.png@64.jpg` behind that nothing can ever reach again — it has to go too.
+    expect(deletedKeys.sort()).toEqual(
+      [...keysFor(USER_ID, 'gif'), ...keysFor(USER_ID, 'png'), ...keysFor(USER_ID, 'webp')].sort(),
+    );
+    expect(deletedKeys).not.toContain(`avatars/${USER_ID}.jpg`);
+    expect(deletedKeys).not.toContain(resizedVariantKey(`avatars/${USER_ID}.jpg`, 64));
   });
 
   it('deletes every extension when no keepExt is given', async () => {
@@ -52,12 +65,9 @@ describe('deleteUserAvatarsFromS3', () => {
     await deleteUserAvatarsFromS3(USER_ID);
 
     const deletedKeys = sendMock.mock.calls.map((call) => (call[0] as { input: { Key: string } }).input.Key);
-    expect(deletedKeys.sort()).toEqual([
-      `avatars/${USER_ID}.gif`,
-      `avatars/${USER_ID}.jpg`,
-      `avatars/${USER_ID}.png`,
-      `avatars/${USER_ID}.webp`,
-    ]);
+    expect(deletedKeys.sort()).toEqual(
+      ['gif', 'jpg', 'png', 'webp'].flatMap((extension) => keysFor(USER_ID, extension)).sort(),
+    );
   });
 
   it('logs a warning and resolves when a delete fails (new avatar is already saved)', async () => {
@@ -65,7 +75,8 @@ describe('deleteUserAvatarsFromS3', () => {
 
     await expect(deleteUserAvatarsFromS3(USER_ID, 'jpg')).resolves.toBeUndefined();
 
-    expect(loggerWarnMock).toHaveBeenCalledTimes(3);
+    // Three stale extensions, each with a base object and one variant per size.
+    expect(loggerWarnMock).toHaveBeenCalledTimes(3 * (1 + ALLOWED_IMAGE_SIZES.length));
     expect(loggerWarnMock).toHaveBeenCalledWith(expect.stringContaining(`avatars/${USER_ID}.png`), expect.any(Error));
   });
 });

--- a/packages/backend/src/storage/s3.ts
+++ b/packages/backend/src/storage/s3.ts
@@ -87,6 +87,23 @@ function getS3Client(bucket: StorageBucket): S3Client {
   return client;
 }
 
+/**
+ * The media bucket's public base URL, or null when there isn't one.
+ *
+ * Never throws, unlike `getPublicUrl`: callers use this to decide *whether* to
+ * serve from the CDN at all, so "not configured" is an ordinary answer rather
+ * than an error. Returning null is what keeps `/static/*` proxying in local
+ * dev and makes unsetting `MEDIA_PUBLIC_BASE_URL` a complete rollback.
+ */
+export function getMediaPublicBaseUrl(): string | null {
+  if (!isBucketConfigured('media')) return null;
+  try {
+    return getConfig('media').publicBaseUrl;
+  } catch {
+    return null;
+  }
+}
+
 /** The configured bucket name for a handle. */
 export function getBucketName(bucket: StorageBucket): string {
   return getConfig(bucket).bucketName;

--- a/packages/backend/src/storage/s3.ts
+++ b/packages/backend/src/storage/s3.ts
@@ -10,6 +10,7 @@ import {
 } from '@aws-sdk/client-s3';
 import type { Readable } from 'stream';
 import { logger } from '../utils/logger';
+import { ALLOWED_IMAGE_SIZES, resizedVariantKey } from '../lib/image-resize';
 import {
   BUCKET_ENV_PREFIX,
   describeBucketConfig,
@@ -359,9 +360,17 @@ const IMAGE_EXTENSIONS = ['jpg', 'png', 'gif', 'webp'] as const;
 async function deleteStaleMediaExtensions(prefix: string, id: string, label: string, keepExt?: string): Promise<void> {
   const extensions = IMAGE_EXTENSIONS.filter((ext) => ext !== keepExt);
 
+  // Each stale extension now carries its resize variants too. Missing these
+  // would leave `<id>.png@64.jpg` behind after a re-upload as `<id>.jpg`, and
+  // because a variant key is derived from the BASE key, that orphan is
+  // unreachable rather than merely stale — it just accumulates.
+  const keys = extensions.flatMap((ext) => {
+    const baseKey = `${prefix}/${id}.${ext}`;
+    return [baseKey, ...ALLOWED_IMAGE_SIZES.map((size) => resizedVariantKey(baseKey, size))];
+  });
+
   await Promise.all(
-    extensions.map(async (ext) => {
-      const key = `${prefix}/${id}.${ext}`;
+    keys.map(async (key) => {
       try {
         await deleteFromS3('media', key);
       } catch (deleteError) {

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -3,12 +3,14 @@
 import { readFileSync } from 'node:fs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { diffR2Bucket } from '../infra/cloudflare/plan';
 import {
   APEX_HOSTNAME,
   APEX_ORIGINLESS_ADDRESS,
   APEX_REDIRECT_RULE_DESCRIPTION,
   ASSETS_CNAME_TARGET,
   ASSETS_HOSTNAME,
+  desiredR2Buckets,
   BACKEND_BOARD_RENDER_CACHE_RULE_DESCRIPTION,
   BOARD_RENDER_CACHE_RULE_DESCRIPTION,
   CACHE_RULE_DESCRIPTION,
@@ -1598,5 +1600,76 @@ describe('www list + climb-view HTML cache rule (#4652)', () => {
     expect(middleware).toContain("response.headers.set('CDN-Cache-Control', cdnCacheValue)");
     expect(middleware).toContain('getListPageCacheTTL');
     expect(middleware).toContain('getClimbViewPageCacheTTL');
+  });
+});
+
+describe('diffR2Bucket', () => {
+  const MEDIA = { name: 'boardsesh-user-media', customDomain: 'media.boardsesh.com' } as const;
+  const PRIVATE = { name: 'boardsesh-user-private', customDomain: null } as const;
+
+  function live(name: string, customDomains: string[] = []) {
+    return { name, exists: true, customDomains };
+  }
+
+  it('plans a create when the bucket is absent', () => {
+    const changes = diffR2Bucket(MEDIA, null);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].summary).toContain('missing — will create');
+    expect(changes[0].r2BucketName).toBe('boardsesh-user-media');
+    expect(changes[0].blocked).toBeUndefined();
+  });
+
+  it('does not plan the domain in the same pass as the create', () => {
+    // The domain call needs the bucket to exist; the next run attaches it.
+    expect(diffR2Bucket(MEDIA, { name: MEDIA.name, exists: false, customDomains: [] })).toHaveLength(1);
+  });
+
+  it('attaches a missing custom domain to a public bucket', () => {
+    const changes = diffR2Bucket(MEDIA, live(MEDIA.name));
+    expect(changes).toHaveLength(1);
+    expect(changes[0].summary).toContain('will attach media.boardsesh.com');
+  });
+
+  it('is a no-op once the public bucket serves its domain', () => {
+    expect(diffR2Bucket(MEDIA, live(MEDIA.name, ['media.boardsesh.com']))).toEqual([]);
+  });
+
+  it('is a no-op for a private bucket with no domain', () => {
+    expect(diffR2Bucket(PRIVATE, live(PRIVATE.name))).toEqual([]);
+  });
+
+  it('BLOCKS when a bucket declared private has grown a custom domain', () => {
+    // R2 has no object ACLs and no bucket policies, so a custom domain
+    // publishes every object — and this bucket holds user data exports. The
+    // tool refuses to auto-detach: it shouts and leaves the decision to a human.
+    const changes = diffR2Bucket(PRIVATE, live(PRIVATE.name, ['oops.boardsesh.com']));
+    expect(changes).toHaveLength(1);
+    expect(changes[0].blocked).toBe(true);
+    expect(changes[0].summary).toContain('declared PRIVATE but serves oops.boardsesh.com');
+    expect(changes[0].detail).toContain('user data exports');
+  });
+
+  it('never plans a delete, whatever the live state', () => {
+    const everyState = [
+      diffR2Bucket(MEDIA, null),
+      diffR2Bucket(MEDIA, live(MEDIA.name, ['stale.boardsesh.com'])),
+      diffR2Bucket(PRIVATE, live(PRIVATE.name, ['oops.boardsesh.com'])),
+    ].flat();
+    for (const change of everyState) {
+      expect(change.summary.toLowerCase()).not.toContain('delete');
+      expect(change.summary.toLowerCase()).not.toContain('remove');
+    }
+  });
+});
+
+describe('desiredR2Buckets', () => {
+  it('keeps the exports bucket domain-less', () => {
+    const exportsBucket = desiredR2Buckets.find((bucket) => bucket.name === 'boardsesh-user-private');
+    expect(exportsBucket?.customDomain).toBeNull();
+  });
+
+  it('gives exactly one bucket a public domain', () => {
+    const publicBuckets = desiredR2Buckets.filter((bucket) => bucket.customDomain !== null);
+    expect(publicBuckets.map((bucket) => bucket.name)).toEqual(['boardsesh-user-media']);
   });
 });

--- a/scripts/cloudflare-apply.test.ts
+++ b/scripts/cloudflare-apply.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { diffR2Bucket } from '../infra/cloudflare/plan';
+import { CloudflareApiRequestError, isAuthorizationError } from './cloudflare-apply';
 import {
   APEX_HOSTNAME,
   APEX_ORIGINLESS_ADDRESS,
@@ -1671,5 +1672,31 @@ describe('desiredR2Buckets', () => {
   it('gives exactly one bucket a public domain', () => {
     const publicBuckets = desiredR2Buckets.filter((bucket) => bucket.customDomain !== null);
     expect(publicBuckets.map((bucket) => bucket.name)).toEqual(['boardsesh-user-media']);
+  });
+});
+
+describe('isAuthorizationError', () => {
+  class FakeCfError extends Error {
+    constructor(readonly status: number) {
+      super('cf');
+      this.name = 'CloudflareApiRequestError';
+    }
+  }
+
+  it.each([401, 403])('treats HTTP %d as a missing scope', (status) => {
+    // A token that has not been granted Account.Workers R2 Storage must skip
+    // R2 and leave the zone converge alone, not fail the production deploy.
+    expect(isAuthorizationError(new CloudflareApiRequestError('nope', status, []))).toBe(true);
+  });
+
+  it.each([404, 429, 500, 502])('treats HTTP %d as a real fault', (status) => {
+    expect(isAuthorizationError(new CloudflareApiRequestError('boom', status, []))).toBe(false);
+  });
+
+  it('does not match a look-alike error from elsewhere', () => {
+    // Name-based matching would let an unrelated 403 silently disable the guard.
+    expect(isAuthorizationError(new FakeCfError(403))).toBe(false);
+    expect(isAuthorizationError(new Error('403'))).toBe(false);
+    expect(isAuthorizationError(null)).toBe(false);
   });
 });

--- a/scripts/cloudflare-apply.ts
+++ b/scripts/cloudflare-apply.ts
@@ -78,7 +78,7 @@ const TOKEN_SCOPES = [
   'Zone.Dynamic Redirect Edit — create/update the apex → www redirect (http_request_dynamic_redirect phase)',
   'Zone.Zone Settings Read    — read the SSL/TLS mode',
   'Zone.Zone Settings Edit    — ONLY needed with --allow-zone-ssl (to set the zone SSL mode)',
-  'Account.Workers R2 Storage Write — create R2 buckets + attach their custom domains',
+  'Account.Workers R2 Storage Edit — create R2 buckets + attach their custom domains (Read is not enough:\n                               it detects drift but cannot converge it). Needs CLOUDFLARE_ACCOUNT_ID too.',
 ];
 
 // Scopes another consumer of the SAME Production-environment CLOUDFLARE_API_TOKEN

--- a/scripts/cloudflare-apply.ts
+++ b/scripts/cloudflare-apply.ts
@@ -127,7 +127,7 @@ interface CloudflareEnvelope<TResult> {
 }
 
 /** Error carrying the HTTP status + surfaced Cloudflare error messages, so callers can branch on status. */
-class CloudflareApiRequestError extends Error {
+export class CloudflareApiRequestError extends Error {
   constructor(
     message: string,
     readonly status: number,
@@ -233,12 +233,46 @@ interface R2CustomDomainListing {
  * Only the declared buckets are inspected: this tool has no opinion about
  * buckets it does not own, and listing domains for all of them would be noise.
  */
+/**
+ * True for "this token is not allowed to do that", as opposed to a real fault.
+ *
+ * Exported so the decision is testable without standing up the API: the whole
+ * point of it is that a missing scope must not be treated like an outage.
+ */
+export function isAuthorizationError(error: unknown): boolean {
+  return error instanceof CloudflareApiRequestError && (error.status === 401 || error.status === 403);
+}
+
+/**
+ * Read the account's R2 buckets, or null when this token cannot.
+ *
+ * Returning null rather than throwing on an authorization failure is
+ * deliberate. `cf:apply --apply` runs on every production deploy and owns DNS,
+ * WAF, rate-limit and redirect rules for the whole zone; R2 drift detection is
+ * a nice-to-have beside that. A token that has not (yet) been granted
+ * `Account.Workers R2 Storage` must therefore degrade to "skip R2 and say so",
+ * not take www off the deploy train — which is exactly how a token rotation
+ * that dropped the Pages scope broke app.boardsesh.com on 2026-08-25.
+ *
+ * It also means the account-id secret and the token scope can be added in
+ * either order without a window where deploys fail.
+ */
 async function fetchR2State(
   token: string,
   accountId: string,
   desired: readonly R2BucketDesired[],
-): Promise<Map<string, LiveR2Bucket>> {
-  const listing = await cfRequest<R2BucketListing>(token, 'GET', `/accounts/${accountId}/r2/buckets`);
+): Promise<Map<string, LiveR2Bucket> | null> {
+  let listing: R2BucketListing;
+  try {
+    listing = await cfRequest<R2BucketListing>(token, 'GET', `/accounts/${accountId}/r2/buckets`);
+  } catch (error) {
+    if (!isAuthorizationError(error)) throw error;
+    console.warn(
+      '[cf-apply] Token lacks Account.Workers R2 Storage — skipping R2 buckets. Zone config was still applied. ' +
+        'Grant that scope (keeping every existing one: editing a token REPLACES all its policies) to manage R2 here.',
+    );
+    return null;
+  }
   const existing = new Set((listing.buckets ?? []).map((bucket) => bucket.name));
 
   const state = new Map<string, LiveR2Bucket>();
@@ -478,8 +512,10 @@ export async function runCloudflareApply(argv: string[] = process.argv.slice(2))
   let r2State: Map<string, LiveR2Bucket> | null = null;
   if (accountId) {
     r2State = await fetchR2State(token, accountId, desiredR2Buckets);
-    for (const bucket of desiredR2Buckets) {
-      changes.push(...diffR2Bucket(bucket, r2State.get(bucket.name) ?? null));
+    if (r2State) {
+      for (const bucket of desiredR2Buckets) {
+        changes.push(...diffR2Bucket(bucket, r2State.get(bucket.name) ?? null));
+      }
     }
   } else {
     console.log('[cf-apply] CLOUDFLARE_ACCOUNT_ID not set — skipping R2 buckets (needs Workers R2 Storage:Write).');

--- a/scripts/cloudflare-apply.ts
+++ b/scripts/cloudflare-apply.ts
@@ -49,10 +49,21 @@
  */
 
 import { pathToFileURL } from 'node:url';
-import { ZONE_NAME, desiredCloudflareState } from '../infra/cloudflare/config';
-import type { DnsRecordDesired, FullyManagedDnsRecordDesired, SslMode } from '../infra/cloudflare/config';
-import { MANAGED_RULE_PHASES, buildPlan, resolveRulePhase, upsertCacheRule } from '../infra/cloudflare/plan';
-import type { LiveDnsRecord, LiveState, PlannedChange, RulesetRule } from '../infra/cloudflare/plan';
+import { ZONE_NAME, desiredCloudflareState, desiredR2Buckets } from '../infra/cloudflare/config';
+import type {
+  DnsRecordDesired,
+  FullyManagedDnsRecordDesired,
+  R2BucketDesired,
+  SslMode,
+} from '../infra/cloudflare/config';
+import {
+  MANAGED_RULE_PHASES,
+  buildPlan,
+  diffR2Bucket,
+  resolveRulePhase,
+  upsertCacheRule,
+} from '../infra/cloudflare/plan';
+import type { LiveDnsRecord, LiveR2Bucket, LiveState, PlannedChange, RulesetRule } from '../infra/cloudflare/plan';
 
 const CF_API_BASE = 'https://api.cloudflare.com/client/v4';
 
@@ -67,6 +78,7 @@ const TOKEN_SCOPES = [
   'Zone.Dynamic Redirect Edit — create/update the apex → www redirect (http_request_dynamic_redirect phase)',
   'Zone.Zone Settings Read    — read the SSL/TLS mode',
   'Zone.Zone Settings Edit    — ONLY needed with --allow-zone-ssl (to set the zone SSL mode)',
+  'Account.Workers R2 Storage Write — create R2 buckets + attach their custom domains',
 ];
 
 // Scopes another consumer of the SAME Production-environment CLOUDFLARE_API_TOKEN
@@ -204,6 +216,77 @@ export function selectManagedDnsRecord(records: LiveDnsRecord[], name: string): 
     );
   }
   return addressRecords[0] ?? null;
+}
+
+/** One entry from `GET /accounts/:id/r2/buckets`. */
+interface R2BucketListing {
+  buckets?: { name: string }[];
+}
+
+interface R2CustomDomainListing {
+  domains?: { domain: string; enabled?: boolean }[];
+}
+
+/**
+ * Read the account's R2 buckets and the custom domain attached to each declared one.
+ *
+ * Only the declared buckets are inspected: this tool has no opinion about
+ * buckets it does not own, and listing domains for all of them would be noise.
+ */
+async function fetchR2State(
+  token: string,
+  accountId: string,
+  desired: readonly R2BucketDesired[],
+): Promise<Map<string, LiveR2Bucket>> {
+  const listing = await cfRequest<R2BucketListing>(token, 'GET', `/accounts/${accountId}/r2/buckets`);
+  const existing = new Set((listing.buckets ?? []).map((bucket) => bucket.name));
+
+  const state = new Map<string, LiveR2Bucket>();
+  for (const bucket of desired) {
+    if (!existing.has(bucket.name)) {
+      state.set(bucket.name, { name: bucket.name, exists: false, customDomains: [] });
+      continue;
+    }
+    const domains = await cfRequest<R2CustomDomainListing>(
+      token,
+      'GET',
+      `/accounts/${accountId}/r2/buckets/${encodeURIComponent(bucket.name)}/domains/custom`,
+    );
+    state.set(bucket.name, {
+      name: bucket.name,
+      exists: true,
+      customDomains: (domains.domains ?? []).map((entry) => entry.domain),
+    });
+  }
+  return state;
+}
+
+async function applyR2Bucket(
+  token: string,
+  accountId: string,
+  zoneId: string,
+  desired: R2BucketDesired,
+  live: LiveR2Bucket | null,
+): Promise<void> {
+  if (!live || !live.exists) {
+    await cfRequest(token, 'POST', `/accounts/${accountId}/r2/buckets`, {
+      name: desired.name,
+      ...(desired.locationHint && { locationHint: desired.locationHint }),
+    });
+    console.log(`[cf-apply] created R2 bucket ${desired.name}`);
+    // The domain needs the bucket to exist first; the next run attaches it.
+    return;
+  }
+
+  if (desired.customDomain && !live.customDomains.includes(desired.customDomain)) {
+    await cfRequest(
+      token,
+      'POST',
+      `/accounts/${accountId}/r2/buckets/${encodeURIComponent(desired.name)}/domains/custom`,
+      { domain: desired.customDomain, zoneId, enabled: true },
+    );
+    console.log(`[cf-apply] attached ${desired.customDomain} to R2 bucket ${desired.name}`);
+  }
 }
 
 async function fetchDnsRecord(token: string, zoneId: string, name: string): Promise<LiveDnsRecord | null> {
@@ -388,6 +471,20 @@ export async function runCloudflareApply(argv: string[] = process.argv.slice(2))
   const live = await fetchLiveState(token, zoneId, desired.dnsRecords);
   const changes = buildPlan(desired, live, { allowZoneSsl: options.allowZoneSsl });
 
+  // R2 is ACCOUNT-scoped, unlike everything else here. It is skipped rather
+  // than fatal when the account id is absent, so the existing zone-only CI job
+  // (which passes no account id and holds no R2 scope) keeps working untouched.
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim();
+  let r2State: Map<string, LiveR2Bucket> | null = null;
+  if (accountId) {
+    r2State = await fetchR2State(token, accountId, desiredR2Buckets);
+    for (const bucket of desiredR2Buckets) {
+      changes.push(...diffR2Bucket(bucket, r2State.get(bucket.name) ?? null));
+    }
+  } else {
+    console.log('[cf-apply] CLOUDFLARE_ACCOUNT_ID not set — skipping R2 buckets (needs Workers R2 Storage:Write).');
+  }
+
   if (changes.length === 0) {
     console.log('[cf-apply] In sync — nothing to do.');
     return 0;
@@ -414,6 +511,13 @@ export async function runCloudflareApply(argv: string[] = process.argv.slice(2))
       console.warn(`[cf-apply] SKIPPED (blocked): ${change.summary}`);
       if (change.detail) console.warn(`             ${change.detail.split('\n')[0]}`);
       blockedRemaining += 1;
+      continue;
+    }
+
+    if (change.resource === 'r2-bucket') {
+      const bucket = desiredR2Buckets.find((candidate) => candidate.name === change.r2BucketName);
+      if (!bucket || !accountId || !r2State) throw new Error(`Unresolvable R2 change: ${change.summary}`);
+      await applyR2Bucket(token, accountId, zoneId, bucket, r2State.get(bucket.name) ?? null);
       continue;
     }
 


### PR DESCRIPTION
## Summary

Second of three PRs moving user media off the Railway bucket. **PR 1 (#5061) is already merged, the data is copied, and production is serving from R2** — this PR is the edge-serving half.

Everything here is inert until `MEDIA_PUBLIC_BASE_URL` is set, so it merges with no behaviour change and rolls back by unsetting that one variable.

### Already done in production (not in this diff)

- 53,966 objects / 5.6 GB copied to `boardsesh-user-media` and `boardsesh-user-private`, verified `0 missing · 0 size mismatches · 0 unroutable`.
- Backend cut over: `storage[media] bucket=boardsesh-user-media source=prefixed … acl=none`.
- 7,737 resize variants generated (0 failed) — including the 6,987 thumbnails that had never been viewed at `?size=280` and so had no cached variant.

### What this PR adds

**`/static/*` → media-bucket redirect.** A redirect rather than only rewriting the stored URLs, because the persisted values in `user_profiles.avatar_url`, `gyms.image_url` and `gyms.logo_url` are backend-relative `/static/…?v=` paths, and released mobile builds string-match `/static/avatars/` before appending `?size=` (`packages/mobile/src/components/Avatar.tsx:25`). Rewriting those columns would make every shipped client fetch the full-res original to render a 40px circle.

It is a **302 with a one-hour TTL, not the 301 the plan called for**: unsetting `MEDIA_PUBLIC_BASE_URL` has to be a complete rollback, and browsers cache a 301 far too aggressively for that promise to hold — Safari has historically kept them indefinitely. An hour of edge caching absorbs effectively all of the traffic anyway.

The mapping is a pure function with 24 tests. `handlers/static.ts` has none of its own, and this is where a mistake either 404s every avatar or lets a crafted path escape its prefix. A path it does not recognise returns null and falls through to today's proxy rather than guessing.

**Variants are generated at upload.** Direct-from-bucket serving has no resizer, so every size a client can ask for must exist as an object. Uploads now write all six sizes *before* the base object, so a reader that can see a new avatar can always see its sizes; a partial failure leaves the previous image and its variants fully consistent.

A size whose resize fails still gets an object — the original bytes, which is what the proxy served on a failed resize. Direct serving has no such fallback (a missing key is a 404, not a slightly-too-large image), and an upload should not fail outright because sharp could not decode one frame. This surfaced as a real 500 in `gym-logo-upload.test.ts` before it was fixed.

**Stale-extension cleanup widened.** A variant key derives from the *base* key, so a re-upload from `.png` to `.jpg` used to strand `.png@64.jpg` — unreachable rather than merely stale, and accumulating forever.

**R2 buckets under config-as-code.** `infra/cloudflare/config.ts` now declares them, answering "can't we manage this as code?" — yes: `POST /accounts/{id}/r2/buckets` and `.../domains/custom`. `customDomain` there is the entire access-control story, because R2 implements no object ACLs and no bucket policies: attaching a domain publishes **every** object in the bucket. So a bucket declared private that has grown one is reported `BLOCKED` rather than auto-detached — the tool shouts, a human decides — and buckets are never deleted by a converge loop.

### Custom domain attaches itself on merge

No token change is needed — the GH Actions token already carries both R2 permission groups on the account (`bf7481a1…` Workers R2 Storage Write, `d229766a…` Read). It just never received `CLOUDFLARE_ACCOUNT_ID`, which the workflow passed only to the Pages step; that is a one-line env addition here.

So on merge, the production deploy's `cf:apply` step attaches `media.boardsesh.com` to `boardsesh-user-media` by itself. Serving still does not change until `MEDIA_PUBLIC_BASE_URL` is set on the backend — a separate, reversible step once the domain is verified.

Both R2 inputs degrade independently: a missing account id skips R2 with a notice, a missing token scope skips it with a warning and still applies the zone config. Neither can fail a production deploy on its own. That matters more than it sounds — without it, adding the account id before the scope would have broken every deploy in between, which is the shape of the rotation that took `app.boardsesh.com` off the deploy train on 2026-08-25.

### Still to come (PR 2b / PR 3)

- Backfill `board_beta_links.thumbnail` to the `@280.jpg` variant key — an 8.6× byte reduction (177 KB average base vs 20.5 KB variant). Gated on the domain being live.
- Avatar/gym column backfills wait for a client release that understands media URLs, per the finding above.
- PR 3 retires the Railway bucket.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 2/5 — inert until `MEDIA_PUBLIC_BASE_URL` is set; the upload-path change is covered by the existing gym-logo and avatar upload suites, and a failed resize now degrades to storing the original rather than failing the upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHe2mZRTgFnkWzYim3Zqqj

