### PR TITLE
fix(ci): take lint off the fleet, which cannot fit tsgolint's 6 GB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,7 +426,37 @@ jobs:
     # either term would silently stop running the patch and fingerprint guards
     # on exactly the PR shape they exist for. Only ever widen this.
     if: needs.changes.outputs.anyJs == 'true' || needs.changes.outputs.rootCi == 'true' || needs.changes.outputs.mobile == 'true' || needs.changes.outputs.mobileDeps == 'true' || needs.changes.outputs.staticAssets == 'true'
-    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
+    # Deliberately NOT routed to the self-hosted fleet: this job wants more
+    # memory than a slot has.
+    #
+    # `vp check`'s type-aware pass shells out to tsgolint, which builds ONE
+    # TypeScript program over all ~4,900 files. That fit under vite-plus 0.1.24
+    # (oxlint-tsgolint 0.23). The 0.3.0 bump to oxlint-tsgolint 7.0.2001 (#5108)
+    # pushed the peak past a slot's ~3.4 GB `--memory`, so the kernel SIGKILLs
+    # tsgolint mid-run. oxlint can then only say "Linting could not start" and
+    # the job shows a bare exit 1 — run 33687293891, job 100437701580, whose
+    # container reported `oom_kill 1` in memory.events.
+    #
+    # Measured by replaying the job inside the CI image under the launcher's own
+    # bounds (`--cpuset-cpus`, `--memory`, `--memory-swap`), reading the cgroup's
+    # own memory.peak:
+    #
+    #   cap      2 vCPU  3 vCPU   peak when it passed
+    #   3.5 GB   OOM     OOM      --
+    #   4.5 GB   --      OOM      --
+    #   5.5 GB   --      OOM      --
+    #   6.0 GB   pass    pass     4.98-5.63 GB
+    #
+    # So the bar is ~6 GB for this one job, against 3.4 GB per slot. vCPU count
+    # is not the lever: 2 and 3 both die at 3.5 GB, and 16 peaks LOWER (the GC
+    # keeps up with allocation). Neither is GOMEMLIMIT, Go's soft heap ceiling:
+    # at 1 GiB it passed once and then failed three consecutive runs on the same
+    # image, which is worse than a clean routing decision.
+    #
+    # Re-route it when the launcher can give a single job ~6 GB. Same shape
+    # firmware-tests was in — it joins once the fleet can host it. The list it
+    # came off is ROUTED_JOBS in scripts/__tests__/ci-runner-routing.test.ts.
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -529,6 +559,15 @@ jobs:
         run: |
           vp check > vp-check.log 2>&1 && status=0 || status=$?
           cat vp-check.log || true
+          # When the OS kills tsgolint for memory, oxlint reports it as "Linting
+          # could not start" and the only hard evidence is a `signal: 'SIGKILL'`
+          # line buried in a Node stack — the job itself just says "exit code 1".
+          # Say what actually happened, and print the runner's real memory
+          # ceiling, so the next time this job outgrows its runner nobody has to
+          # reconstruct it from a kernel-level symptom.
+          if [ "$status" -ne 0 ] && grep -q "signal: 'SIGKILL'" vp-check.log; then
+            echo "::error::tsgolint was killed by the OS (SIGKILL): this runner ran out of memory. cgroup memory.max=$(cat /sys/fs/cgroup/memory.max 2>/dev/null || echo unknown). A full-repo type-aware lint of this monorepo peaks at 5.0-5.6 GB, so the runner needs ~6 GB."
+          fi
           exit $status
 
   large-files:

--- a/scripts/__tests__/ci-lint-scope.test.ts
+++ b/scripts/__tests__/ci-lint-scope.test.ts
@@ -87,6 +87,18 @@ describe('CI lint scope contract', () => {
     expect(lintSteps).toContain('exit $status');
   });
 
+  it('names an OOM-killed tsgolint instead of leaving a bare exit code', () => {
+    // The vite-plus 0.3.0 bump (oxlint-tsgolint 0.23 -> 7.0.2001, #5108) pushed
+    // the full-repo type-aware pass past the memory a self-hosted slot has, and
+    // the kernel killed tsgolint. All the job surfaced was "Process completed
+    // with exit code 1": oxlint's own line is "Linting could not start", and the
+    // one piece of hard evidence is a `signal: 'SIGKILL'` buried in a Node stack
+    // inside the redirected log. Keep the annotation that reads that stack for us.
+    expect(lintSteps).toContain(`grep -q "signal: 'SIGKILL'" vp-check.log`);
+    expect(lintSteps).toContain('::error::tsgolint was killed by the OS');
+    expect(lintSteps).toContain('/sys/fs/cgroup/memory.max');
+  });
+
   it('still runs when only the workflow itself changes', () => {
     const changesJob = mappingEntry(workflowSource, 'changes', 2);
     const rootCiFilter = mappingEntry(changesJob, 'rootCi', 12);

--- a/scripts/__tests__/ci-runner-routing.test.ts
+++ b/scripts/__tests__/ci-runner-routing.test.ts
@@ -76,6 +76,8 @@ const ROUTED_JOBS: ReadonlyArray<readonly [workflow: string, job: string]> = [
   //     in: it joins once the image can host it.
   //   db-migrations, test-backend, test-location-sync-integration, docker-web
   //     -- sub-wave B. Service containers on localhost ports, and buildx.
+  //   lint                 -- wants ~6 GB against a slot's ~3.4 GB. See
+  //     MEMORY_BOUND_JOBS below and the comment on the job itself.
   ['ci.yml', 'board-art-geometry'],
   ['ci.yml', 'board-render-version'],
   ['ci.yml', 'changelog-owned'],
@@ -84,7 +86,6 @@ const ROUTED_JOBS: ReadonlyArray<readonly [workflow: string, job: string]> = [
   ['ci.yml', 'deploy-config'],
   ['ci.yml', 'i18n'],
   ['ci.yml', 'large-files'],
-  ['ci.yml', 'lint'],
   ['ci.yml', 'listing-guards'],
   ['ci.yml', 'mobile-bundle'],
   ['ci.yml', 'pg18-artifacts'],
@@ -103,6 +104,22 @@ const ROUTED_JOBS: ReadonlyArray<readonly [workflow: string, job: string]> = [
  * report.
  */
 const CI_CONTROL_PLANE_JOBS = ['changes', 'ci-status'] as const;
+
+/**
+ * Jobs held on GitHub-hosted because a fleet slot cannot fit them, not because
+ * of what they can reach.
+ *
+ * `lint` runs `vp check`, whose type-aware pass builds one TypeScript program
+ * over the whole repo inside tsgolint. vite-plus 0.3.0 (oxlint-tsgolint
+ * 0.23 -> 7.0.2001, #5108) pushed its peak to 5.0-5.6 GB; a slot's `--memory`
+ * is ~3.4 GB, so the kernel OOM-killed tsgolint and every routed run of this
+ * job failed with a bare exit 1. Replaying it in the CI image under the
+ * launcher's bounds, it OOMs at 3.5/4.5/5.5 GB and passes at 6.0 GB, on both 2
+ * and 3 vCPU. Re-route it when a slot can hand one job ~6 GB -- not before, and
+ * not by tuning GOMEMLIMIT, which flipped between passing and OOMing run to run
+ * on an unchanged image.
+ */
+const MEMORY_BOUND_JOBS = ['lint'] as const;
 
 function workflow(name: string): string {
   return readFileSync(`.github/workflows/${name}`, 'utf8');
@@ -151,6 +168,19 @@ describe('self-hosted runner routing', () => {
   it('keeps ci.yml`s control plane on GitHub-hosted', () => {
     const blocks = jobBlocks(workflow('ci.yml'));
     for (const jobName of CI_CONTROL_PLANE_JOBS) {
+      const block = blocks.get(jobName);
+      expect(block, `ci.yml has no job \`${jobName}\``).toBeDefined();
+      expect(block).toContain('    runs-on: ubuntu-latest');
+    }
+  });
+
+  it('keeps memory-bound ci.yml jobs on GitHub-hosted', () => {
+    // Routing `lint` back is a one-line edit that looks like tidying up, and it
+    // fails as a bare "Process completed with exit code 1" with no log — the
+    // OOM kill is only visible as `signal: 'SIGKILL'` inside a Node stack. Pin
+    // it here so the edit has to argue with the measurement in MEMORY_BOUND_JOBS.
+    const blocks = jobBlocks(workflow('ci.yml'));
+    for (const jobName of MEMORY_BOUND_JOBS) {
       const block = blocks.get(jobName);
       expect(block, `ci.yml has no job \`${jobName}\``).toBeDefined();
       expect(block).toContain('    runs-on: ubuntu-latest');


### PR DESCRIPTION
## Summary

The hold-outline editor (#4859, #4891) was a re-trace-only tool squeezed into the iPad shell's content pane. Four changes make it a place you can actually work.

**Full width on iPad.** The editor route suppresses both trailing panes — the play pane and the wall column — the way the "On the Wall" destination already does, keeping the sidebar. The board is also sized from its own measured box instead of `useWindowDimensions()` minus a 360pt guess at the chrome; inside the shell the window is up to ~700pt wider than the space the board actually has, so it was overshooting. On a wide screen the toolbar moves into a 320pt rail beside the board.

**Add and erase brushes.** Most corrections are one lobe out of ten, and re-tracing a hold to fix a lobe throws away nine good ones. `@boardsesh/board-art-geometry/brush` rounds an edit through a bitmap: rasterise the current ring, stamp the swept brush disc, walk the border back out. The primitives were already there for the LED plate extractor, so `segmentation/led-ring.ts` splits into `raster.ts` (morphology, components, border follow, hole fill — runtime code now) and the colour classifier, which stays offline-only. `finishOutlineRing` is lifted out of `buildOutlineRing` so both paths share one copy of the `closeRing(roundRing(...))` parity contract with the resolver.

The rules that stop it storing nonsense, each measured against the shipped shard set:

| Rule | Why |
|---|---|
| The blob covering the placement centre wins a split | On a 4 board-px brush, 51% of erase strokes split the shape and 32% of all strokes would otherwise have committed the wrong piece |
| Necks trimmed before the border walk | 0/250 self-intersections, against 2.8–8.8% without |
| Frame capped at four radii | A pencil flick off the hold would otherwise size a megabyte bitmap |
| Mask persists across strokes | Holds drift at −2.4% of area over 20 strokes instead of −4.7% |
| Brush floored at 3 board px | Below that a dab is inside the decimation tolerance and silently does nothing |

**Clearer boundaries.** "Silhouette" / "LED ring" become "Outer edge" / "Inner edge", with a line saying the board lights the ring between them — and the control only appears on a layout that has a plate at all. That is now a declared flag (`hasLedBasePlate`, Kilter Homewall only) rather than inferred from whether the image extractor happened to succeed. Those are different questions and they come apart in both directions: warm-palette art can clear the acceptance rate with no plate behind it, and a plated board reshot in new art can fail it. The generator reads the same flag, and shard output is byte-identical (`generate:board-art-geometry --check`).

**Lit preview.** `holdGeometryOverride` lets the editor render the selected hold through the real renderer using the unsaved edit — the shard on disk still carries the tracer's version until the next export. It is hashed into the render cache key alongside the existing overrides; without that the preview would serve a stale PNG *and* write its own output under the real climb's key for every other surface to pick up.

The editor's pinch ceiling goes to 12x (`maxScale` on `useZoomPanGesture`, mirrored into a shared value so no live gesture is recomposed). The play drawer keeps 4x.

Two limitations the editor now states rather than hides: traced outlines only render in Boardsesh mode behind the native capability probe, and the renderer's LED plate is parked (`LedBaseTuning::default().opacity = 0.0`), so an inner edge changes no pixels today.

### Also not fixed here: `typecheck` is OOMing on the fleet too, on every PR

Same incident, different job, and it is red on `main` independently of this PR. `vp run typecheck` runs up to 4 tasks at once (`--concurrency-limit` defaults to 4), so `next build` and three `tsc --noEmit` processes share the slot. Since #5108 the kernel kills one of them:

```
Killed
[ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] @boardsesh/mobile@ typecheck: `tsc --noEmit`
Exit status 137
```

Exit 137 is SIGKILL. Reproduced across unrelated PRs (runs 33697490038, 33700259582, 33697695801, 33696441507, 33696310195); the four `main` runs before #5108 merged were all green. I did not push a fix because I could not measure one: TypeScript 7's `tsc` shim calls `process.execve`, which fails with EINVAL under x86 emulation, so the container replay that produced the lint numbers above cannot run this job. The two candidates worth measuring on real fleet hardware are `--concurrency-limit 2` (keeps it routed) and de-routing it the way this PR de-routes `lint`.

## Release Notes

- [x] No release note needed (internal / technical change)

Admin-only tool behind the `__DEV__ || isAdmin` gate — nothing user-facing.

## Test plan

1. Profile → More → Hold Outlines → Kilter Homewall.
2. Landscape iPad: board fills, controls in right rail.
3. Tap a hold: its area fills, not just an outline.
4. Erase mode → brush a lobe off → Save.
5. Pick a Tension board: no inner/outer control.

## Risk

Risk: 3/5 — new editing surface, plus a threaded prop through the shared render hook. Blast radius outside the admin editor is the render cache key: a geometry override now contributes a term to it, covered by the hook's own typing and by shard output being byte-identical. Bluetooth untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnTBeHG7oWfyAhZ3LZiATD

