### PR TITLE
fix(ci): keep typecheck on GitHub-hosted until a slot can hold it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -604,7 +604,16 @@ jobs:
   typecheck:
     needs: [changes]
     if: needs.changes.outputs.anyJs == 'true' || needs.changes.outputs.rootCi == 'true'
-    runs-on: ${{ fromJSON(github.event.pull_request.head.repo.fork && '"ubuntu-latest"' || vars.CI_RUNNER_LINUX || '"ubuntu-latest"') }}
+    # Stays GitHub-hosted: OOM-killed on the fleet, exit 137, on every run.
+    # `vp run typecheck` fans out at --concurrency-limit 4, so `next build` and
+    # three `tsc --noEmit` share one slot's ~3.4 GB. Same failure family as
+    # lint's tsgolint, which is why both sit in MEMORY_BOUND_JOBS.
+    #
+    # Re-route when a slot can hand one job ~6 GB. Lowering the concurrency
+    # limit might also do it, but that trades typecheck wall-clock on every
+    # runner -- hosted and self-hosted alike -- to work around a bound that
+    # only exists on ours, and it has not been measured.
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6

--- a/scripts/__tests__/ci-runner-routing.test.ts
+++ b/scripts/__tests__/ci-runner-routing.test.ts
@@ -76,8 +76,9 @@ const ROUTED_JOBS: ReadonlyArray<readonly [workflow: string, job: string]> = [
   //     in: it joins once the image can host it.
   //   db-migrations, test-backend, test-location-sync-integration, docker-web
   //     -- sub-wave B. Service containers on localhost ports, and buildx.
-  //   lint                 -- wants ~6 GB against a slot's ~3.4 GB. See
-  //     MEMORY_BOUND_JOBS below and the comment on the job itself.
+  //   lint, typecheck      -- both want ~6 GB against a slot's ~3.4 GB and are
+  //     OOM-killed there. See MEMORY_BOUND_JOBS below and the comments on the
+  //     jobs themselves.
   ['ci.yml', 'board-art-geometry'],
   ['ci.yml', 'board-render-version'],
   ['ci.yml', 'changelog-owned'],
@@ -94,7 +95,6 @@ const ROUTED_JOBS: ReadonlyArray<readonly [workflow: string, job: string]> = [
   ['ci.yml', 'test-default'],
   ['ci.yml', 'test-ocr'],
   ['ci.yml', 'test-report'],
-  ['ci.yml', 'typecheck'],
 ];
 
 /**
@@ -119,7 +119,7 @@ const CI_CONTROL_PLANE_JOBS = ['changes', 'ci-status'] as const;
  * not by tuning GOMEMLIMIT, which flipped between passing and OOMing run to run
  * on an unchanged image.
  */
-const MEMORY_BOUND_JOBS = ['lint'] as const;
+const MEMORY_BOUND_JOBS = ['lint', 'typecheck'] as const;
 
 function workflow(name: string): string {
   return readFileSync(`.github/workflows/${name}`, 'utf8');


### PR DESCRIPTION
`main` is red. `typecheck` is **OOM-killed on the fleet on every run**:

```
Killed
[ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] @boardsesh/mobile@ typecheck: `tsc --noEmit`
Exit status 137
```

Reproduced across runs 33697490038, 33700259582, 33697695801, 33696441507 and
33696310195. The four `main` runs before the vite-plus upgrade were green.

### Why

`vp run typecheck` fans out at `--concurrency-limit 4`, so `next build` and
three `tsc --noEmit` share one slot's **~3.4 GB**.

Same failure family as `lint`'s tsgolint in #5119 — measured there at a
4.98–5.63 GB peak against the same 3.4 GB cap — so `typecheck` joins
`MEMORY_BOUND_JOBS` rather than getting its own special case. Both want roughly
6 GB; neither fits.

### Re-route when

A slot can hand a single job ~6 GB. From a 32 GB VM that is 4 slots (6.8 GB,
4 vCPU) instead of the current 8 (3.4 GB, 2 vCPU) — a fleet capacity decision,
not a code one, so it is deliberately not bundled here.

Lowering `--concurrency-limit` might also work, but it trades `typecheck`
wall-clock on **every** runner, GitHub-hosted included, to work around a bound
that only exists on ours — and it has not been measured.

### Guarded

The routing test fails if `typecheck` is re-routed while still listed as
memory-bound. That is the easy mistake later, once the reason has been
forgotten and re-routing looks like tidying up a stale exception.

## Release Notes

none

## Test plan

1. CI green, with `typecheck` running on `ubuntu-latest`.

## Risk

Risk: 1/5 — moves one job back to the runner it used before the migration.
20 of `ci.yml`'s jobs stay on the fleet.