### PR TITLE
fix(mobile): unreadable dark-mode text in Android Settings menus & forms

### DIFF
--- a/packages/mobile/src/components/AuthTextInput.android.tsx
+++ b/packages/mobile/src/components/AuthTextInput.android.tsx
@@ -71,7 +71,7 @@ export const AuthTextInput = forwardRef<AuthTextInputHandle, AuthTextInputProps>
   },
   ref,
 ) {
-  const { brandColors } = useTheme();
+  const { brandColors, colorScheme } = useTheme();
   const textState = useNativeState(value);
   const lastEmittedRef = useRef(value);
   const fieldRef = useRef<{ focus: () => Promise<void> }>(null);
@@ -155,7 +155,11 @@ export const AuthTextInput = forwardRef<AuthTextInputHandle, AuthTextInputProps>
   const supportingText = error ?? hint;
 
   return (
-    <Host matchContents={{ vertical: true }} style={styles.host}>
+    // `colorScheme` forces the Compose MaterialTheme to follow our in-app
+    // Light/Dark toggle instead of the OS scheme — without it the typed text,
+    // floating label and supporting text render dark-on-dark when the app runs
+    // dark on a light-mode device (same fix as MoreForm/FilterChipRow's Hosts).
+    <Host matchContents={{ vertical: true }} colorScheme={colorScheme} style={styles.host}>
       <OutlinedTextField
         ref={fieldRef as unknown as ComponentProps<typeof OutlinedTextField>['ref']}
         value={textState}

--- a/packages/mobile/src/components/AuthTextInput.android.tsx
+++ b/packages/mobile/src/components/AuthTextInput.android.tsx
@@ -155,10 +155,10 @@ export const AuthTextInput = forwardRef<AuthTextInputHandle, AuthTextInputProps>
   const supportingText = error ?? hint;
 
   return (
-    // `colorScheme` forces the Compose MaterialTheme to follow our in-app
-    // Light/Dark toggle instead of the OS scheme — without it the typed text,
-    // floating label and supporting text render dark-on-dark when the app runs
-    // dark on a light-mode device (same fix as MoreForm/FilterChipRow's Hosts).
+    // `colorScheme` pins the Compose MaterialTheme to our in-app Light/Dark
+    // toggle, not the OS scheme — else the typed text, floating label and
+    // supporting text go dark-on-dark when the app runs dark on a light-mode
+    // phone (as SwitchRow/AppMenu do).
     <Host matchContents={{ vertical: true }} colorScheme={colorScheme} style={styles.host}>
       <OutlinedTextField
         ref={fieldRef as unknown as ComponentProps<typeof OutlinedTextField>['ref']}

--- a/packages/mobile/src/components/MoreForm.android.tsx
+++ b/packages/mobile/src/components/MoreForm.android.tsx
@@ -97,8 +97,11 @@ type RowColors = {
   /** Tint for a nav row's leading Material icon — the secondary-label colour. */
   iconTint: ColorValue;
   /**
-   * Scheme-aware label colour for the select-row DropdownMenu popup, which
-   * renders outside the Host and so doesn't get its `colorScheme`.
+   * Scheme-aware label colour for the select-row DropdownMenu popup. The popup is
+   * a separate Compose composition the Host's `colorScheme` doesn't reach, and a
+   * custom `Text` in an item slot doesn't inherit `DropdownMenuItem`'s content
+   * colour — so without this the option labels render dark-on-dark when the app
+   * runs dark on a light-mode device (same fix as AppMenu.android).
    */
   itemColor: string;
 };
@@ -106,12 +109,6 @@ type RowColors = {
 function SelectRow({ row, colors }: { row: MoreSelectRow; colors: RowColors }) {
   const [expanded, setExpanded] = useState(false);
   const currentLabel = selectedOptionLabel(row.options, row.selectedKey);
-  // The DropdownMenu popup is a separate Compose composition — the Host's
-  // `colorScheme` does not reach it, and a custom `Text` in an item slot does
-  // NOT inherit `DropdownMenuItem`'s content colour. Without an explicit
-  // scheme-aware colour the option labels render dark-on-dark when the app runs
-  // dark on a light-mode device (same fix as AppMenu.android).
-  const itemColor = colors.itemColor;
   return (
     <DropdownMenu expanded={expanded} onDismissRequest={() => setExpanded(false)}>
       <DropdownMenu.Trigger>
@@ -131,14 +128,16 @@ function SelectRow({ row, colors }: { row: MoreSelectRow; colors: RowColors }) {
         {row.options.map((option) => (
           <DropdownMenuItem
             key={option.key}
-            elementColors={{ textColor: itemColor }}
+            // Both the item's own content colour and the custom `Text` in its
+            // slot need setting — see the `RowColors.itemColor` doc comment.
+            elementColors={{ textColor: colors.itemColor }}
             onClick={() => {
               row.onSelect(option.key);
               setExpanded(false);
             }}
           >
             <DropdownMenuItem.Text>
-              <Text color={itemColor}>{option.label}</Text>
+              <Text color={colors.itemColor}>{option.label}</Text>
             </DropdownMenuItem.Text>
           </DropdownMenuItem>
         ))}

--- a/packages/mobile/src/components/MoreForm.android.tsx
+++ b/packages/mobile/src/components/MoreForm.android.tsx
@@ -96,11 +96,22 @@ type RowColors = {
   segmentColors: ReturnType<typeof segmentedBrandColors>;
   /** Tint for a nav row's leading Material icon — the secondary-label colour. */
   iconTint: ColorValue;
+  /**
+   * Scheme-aware label colour for the select-row DropdownMenu popup, which
+   * renders outside the Host and so doesn't get its `colorScheme`.
+   */
+  itemColor: string;
 };
 
-function SelectRow({ row }: { row: MoreSelectRow }) {
+function SelectRow({ row, colors }: { row: MoreSelectRow; colors: RowColors }) {
   const [expanded, setExpanded] = useState(false);
   const currentLabel = selectedOptionLabel(row.options, row.selectedKey);
+  // The DropdownMenu popup is a separate Compose composition — the Host's
+  // `colorScheme` does not reach it, and a custom `Text` in an item slot does
+  // NOT inherit `DropdownMenuItem`'s content colour. Without an explicit
+  // scheme-aware colour the option labels render dark-on-dark when the app runs
+  // dark on a light-mode device (same fix as AppMenu.android).
+  const itemColor = colors.itemColor;
   return (
     <DropdownMenu expanded={expanded} onDismissRequest={() => setExpanded(false)}>
       <DropdownMenu.Trigger>
@@ -120,13 +131,14 @@ function SelectRow({ row }: { row: MoreSelectRow }) {
         {row.options.map((option) => (
           <DropdownMenuItem
             key={option.key}
+            elementColors={{ textColor: itemColor }}
             onClick={() => {
               row.onSelect(option.key);
               setExpanded(false);
             }}
           >
             <DropdownMenuItem.Text>
-              <Text>{option.label}</Text>
+              <Text color={itemColor}>{option.label}</Text>
             </DropdownMenuItem.Text>
           </DropdownMenuItem>
         ))}
@@ -223,7 +235,7 @@ function renderRow(row: MoreRow, colors: RowColors): ReactNode {
         </Column>
       );
     case 'select':
-      return <SelectRow key={row.key} row={row} />;
+      return <SelectRow key={row.key} row={row} colors={colors} />;
     case 'info':
       return (
         <Column key={row.key} modifiers={[fillMaxWidth(), ROW_PADDING]} verticalArrangement={{ spacedBy: spacing[1] }}>
@@ -337,6 +349,7 @@ export function MoreForm({ model }: MoreFormProps) {
     switchColors: switchBrandColors(brandColors),
     segmentColors: segmentedBrandColors(brandColors),
     iconTint: systemColors.secondaryLabel,
+    itemColor: systemColors.label as string,
   };
 
   // Flatten sections into LazyColumn items: title Text, the rows (carded unless

--- a/packages/mobile/src/components/RadioGroup.android.tsx
+++ b/packages/mobile/src/components/RadioGroup.android.tsx
@@ -26,11 +26,13 @@ import {
   alpha,
 } from '@expo/ui/jetpack-compose/modifiers';
 import { StyleSheet } from 'react-native';
+import { useTheme } from '../providers/theme-provider';
 import { spacing } from '../theme/tokens';
 import { makeRadioSelectHandler } from './RadioGroup.logic';
 import type { RadioGroupProps } from './RadioGroup.types';
 
 export function RadioGroup<T extends string>({ options, value, onChange }: RadioGroupProps<T>) {
+  const { colorScheme } = useTheme();
   // Memoize so a stable `onChange` doesn't push a new handler into the native Host
   // (and re-render the Compose tree) on every parent render.
   const handleSelect = useMemo(() => makeRadioSelectHandler(onChange), [onChange]);
@@ -39,7 +41,12 @@ export function RadioGroup<T extends string>({ options, value, onChange }: Radio
     // `matchContents={{ vertical: true }}` (NOT the boolean form, which sizes both
     // axes): the Host fills the parent's width so each Row's `fillMaxWidth()` has a
     // bounded width, while height tracks content. Mirrors SwitchRow.
-    <Host matchContents={{ vertical: true }} style={styles.host}>
+    //
+    // `colorScheme` forces the Compose MaterialTheme to follow our in-app
+    // Light/Dark toggle instead of the OS scheme — without it the option
+    // labels render dark-on-dark when the app runs dark on a light-mode
+    // device (same fix as MoreForm/FilterChipRow's Hosts).
+    <Host matchContents={{ vertical: true }} colorScheme={colorScheme} style={styles.host}>
       <Column modifiers={[fillMaxWidth(), selectableGroup()]}>
         {options.map((option) => {
           const selected = option.value === value;

--- a/packages/mobile/src/components/RadioGroup.android.tsx
+++ b/packages/mobile/src/components/RadioGroup.android.tsx
@@ -42,10 +42,9 @@ export function RadioGroup<T extends string>({ options, value, onChange }: Radio
     // axes): the Host fills the parent's width so each Row's `fillMaxWidth()` has a
     // bounded width, while height tracks content. Mirrors SwitchRow.
     //
-    // `colorScheme` forces the Compose MaterialTheme to follow our in-app
-    // Light/Dark toggle instead of the OS scheme — without it the option
-    // labels render dark-on-dark when the app runs dark on a light-mode
-    // device (same fix as MoreForm/FilterChipRow's Hosts).
+    // `colorScheme` pins the Compose MaterialTheme to our in-app Light/Dark
+    // toggle, not the OS scheme — else the option labels go dark-on-dark when
+    // the app runs dark on a light-mode phone (as SwitchRow/AppMenu do).
     <Host matchContents={{ vertical: true }} colorScheme={colorScheme} style={styles.host}>
       <Column modifiers={[fillMaxWidth(), selectableGroup()]}>
         {options.map((option) => {

--- a/packages/mobile/src/components/SwitchRow.android.tsx
+++ b/packages/mobile/src/components/SwitchRow.android.tsx
@@ -45,10 +45,9 @@ export function SwitchRow({ label, description, value, onValueChange, disabled =
     // content. The boolean form collapsed the label Column and jammed the Switch
     // to the left. Mirrors the iOS Host.
     //
-    // `colorScheme` forces the Compose MaterialTheme to follow our in-app
-    // Light/Dark toggle instead of the OS scheme — without it the label text
-    // renders dark-on-dark when the app runs dark on a light-mode device
-    // (same fix as MoreForm/FilterChipRow's Hosts).
+    // `colorScheme` pins the Compose MaterialTheme to our in-app Light/Dark
+    // toggle, not the OS scheme — else the label goes dark-on-dark when the app
+    // runs dark on a light-mode phone (as MoreForm/FilterChipRow/AppMenu do).
     <Host matchContents={{ vertical: true }} colorScheme={colorScheme} style={styles.host}>
       <Row horizontalArrangement="spaceBetween" verticalAlignment="center" modifiers={rowModifiers}>
         <Column modifiers={disabled ? [weight(1), alpha(0.4)] : [weight(1)]}>

--- a/packages/mobile/src/components/SwitchRow.android.tsx
+++ b/packages/mobile/src/components/SwitchRow.android.tsx
@@ -22,7 +22,7 @@ import { makeToggleHandler } from './SwitchRow.logic';
 import type { SwitchRowProps } from './SwitchRow.types';
 
 export function SwitchRow({ label, description, value, onValueChange, disabled = false, tint }: SwitchRowProps) {
-  const { brandColors } = useTheme();
+  const { brandColors, colorScheme } = useTheme();
   const handleToggle = makeToggleHandler(onValueChange, disabled);
   // On-track colour: brand accent (purple) by default; the logbook passes amber.
   const switchColors = tint ? { checkedTrackColor: tint } : switchBrandColors(brandColors);
@@ -44,7 +44,12 @@ export function SwitchRow({ label, description, value, onValueChange, disabled =
     // Row's `fillMaxWidth()` has a bounded width to fill, while height still tracks
     // content. The boolean form collapsed the label Column and jammed the Switch
     // to the left. Mirrors the iOS Host.
-    <Host matchContents={{ vertical: true }} style={styles.host}>
+    //
+    // `colorScheme` forces the Compose MaterialTheme to follow our in-app
+    // Light/Dark toggle instead of the OS scheme — without it the label text
+    // renders dark-on-dark when the app runs dark on a light-mode device
+    // (same fix as MoreForm/FilterChipRow's Hosts).
+    <Host matchContents={{ vertical: true }} colorScheme={colorScheme} style={styles.host}>
       <Row horizontalArrangement="spaceBetween" verticalAlignment="center" modifiers={rowModifiers}>
         <Column modifiers={disabled ? [weight(1), alpha(0.4)] : [weight(1)]}>
           <Text style={{ typography: 'bodyLarge' }}>{label}</Text>

--- a/packages/mobile/src/components/play-drawer/AngleSlider.android.tsx
+++ b/packages/mobile/src/components/play-drawer/AngleSlider.android.tsx
@@ -49,9 +49,8 @@ export function AngleSlider({ angles, value, onChange }: AngleSliderProps) {
   const steps = Math.max(0, count - 2);
 
   return (
-    // `colorScheme` keeps the Compose MaterialTheme (the slider's inactive track)
-    // on our in-app Light/Dark toggle instead of the OS scheme (same fix as
-    // MoreForm/FilterChipRow's Hosts).
+    // `colorScheme` pins the Compose MaterialTheme (the slider's inactive track)
+    // to our in-app Light/Dark toggle, not the OS scheme (as SwitchRow/AppMenu do).
     <Host matchContents={{ vertical: true }} colorScheme={colorScheme} style={styles.host}>
       <Slider
         value={valueIndex}

--- a/packages/mobile/src/components/play-drawer/AngleSlider.android.tsx
+++ b/packages/mobile/src/components/play-drawer/AngleSlider.android.tsx
@@ -26,7 +26,7 @@ import { makeAngleSliderHandler, sliderIndexForAngle } from './AngleSlider.logic
 import type { AngleSliderProps } from './AngleSlider.types';
 
 export function AngleSlider({ angles, value, onChange }: AngleSliderProps) {
-  const { brandColors } = useTheme();
+  const { brandColors, colorScheme } = useTheme();
   const count = angles.length;
   // An empty angle set (unknown-board `[]` fallback) has nothing to pick — render
   // nothing rather than a degenerate Slider. Mirrors the iOS impl.
@@ -49,7 +49,10 @@ export function AngleSlider({ angles, value, onChange }: AngleSliderProps) {
   const steps = Math.max(0, count - 2);
 
   return (
-    <Host matchContents={{ vertical: true }} style={styles.host}>
+    // `colorScheme` keeps the Compose MaterialTheme (the slider's inactive track)
+    // on our in-app Light/Dark toggle instead of the OS scheme (same fix as
+    // MoreForm/FilterChipRow's Hosts).
+    <Host matchContents={{ vertical: true }} colorScheme={colorScheme} style={styles.host}>
       <Slider
         value={valueIndex}
         min={0}

--- a/packages/mobile/src/components/search/FilterChipRow.android.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.android.tsx
@@ -138,6 +138,12 @@ function MenuChip({
 
 // A single menu row: optional leading check, a text label, optional text colour
 // (for the destructive Clear).
+//
+// The DropdownMenu popup is a separate Compose composition — the Host's
+// `colorScheme` does not reach it, and a custom `Text` in an item slot does NOT
+// inherit `DropdownMenuItem`'s content colour. Without an explicit scheme-aware
+// colour the labels render dark-on-dark when the app runs dark on a light-mode
+// device (same fix as AppMenu.android).
 function MenuItem({
   label,
   checked,
@@ -151,15 +157,17 @@ function MenuItem({
   textColor?: string;
   enabled?: boolean;
 }) {
+  const { systemColors } = useTheme();
+  const itemColor = textColor ?? (systemColors.label as string);
   return (
-    <DropdownMenuItem onClick={onClick} enabled={enabled} elementColors={textColor ? { textColor } : undefined}>
+    <DropdownMenuItem onClick={onClick} enabled={enabled} elementColors={{ textColor: itemColor }}>
       {checked ? (
         <DropdownMenuItem.LeadingIcon>
           <Icon source={ICON.check} size={ICON_SIZE} />
         </DropdownMenuItem.LeadingIcon>
       ) : null}
       <DropdownMenuItem.Text>
-        <Text>{label}</Text>
+        <Text color={itemColor}>{label}</Text>
       </DropdownMenuItem.Text>
     </DropdownMenuItem>
   );

--- a/packages/mobile/src/components/search/FilterChipRow.android.tsx
+++ b/packages/mobile/src/components/search/FilterChipRow.android.tsx
@@ -117,6 +117,9 @@ function MenuChip({
   renderItems: (close: () => void) => ReactNode;
 }) {
   const [expanded, setExpanded] = useState(false);
+  // Only the popup (`DropdownMenu.Items` → MenuItem) needs an explicit text
+  // colour: the trigger chip renders inside FilterChipRow's single `colorScheme`-
+  // pinned Host, so its label already tracks the in-app theme.
   return (
     <DropdownMenu expanded={expanded} onDismissRequest={() => setExpanded(false)}>
       <DropdownMenu.Trigger>


### PR DESCRIPTION
## Summary

Some Android menus and form labels were dark-on-dark and unreadable in dark mode (reported for the More / Settings tab).

Cause: several `@expo/ui` Jetpack Compose `<Host>` islands didn't pin the app's colour scheme, so their text followed the phone's OS light/dark setting rather than the in-app theme. Run the app dark on a light-mode phone (a common setup) and the labels went dark on a dark surface. Six other Compose components already pass `colorScheme`; these were missed.

- `SwitchRow`, `RadioGroup`, `AuthTextInput`, `AngleSlider` — `<Host>` now pinned to the in-app `colorScheme`.
- `MoreForm` select-row menu and `FilterChipRow` menu items — the `DropdownMenu` popup renders as a separate Compose composition the Host's `colorScheme` can't reach, and a custom `Text` in an item slot doesn't inherit the item's content colour, so option labels now carry an explicit scheme-aware colour (same fix already shipped for `AppMenu.android`).

Touches the More screen (Language picker, BLE auto-disconnect timeout, and every toggle / radio / text field on the settings sub-screens) plus the climb-search filter-chip menus. No BLE code touched.

Not verified on an emulator: the repo's Android screenshot tooling is Linux-x64-only and can't bootstrap on Apple Silicon. Validated by typecheck, lint, and the full mobile test suite (8070 passing). CI's Android screenshot job runs on Linux and will exercise it.

## Release Notes

- Fixed unreadable dark-on-dark text in Settings menus and forms when using the app in dark mode on a light-mode phone

## Test plan

1. Phone in light mode, app appearance set to Dark (More → Appearance).
2. More tab → open Language: menu text is readable.
3. More → a settings sub-screen (Storage, Board look): toggle and option labels readable.
4. Climbs tab → tap a filter chip with a dropdown: menu text readable.
5. Repeat 2–4 with phone in dark mode + app appearance Light.

## Risk

Risk: 2/5 — Android-only theming prop on existing UI components, covered by the test suite; no logic or data changes.
