### PR TITLE
fix(mobile): fix black section titles in Android settings dark mode

### DIFF
--- a/packages/mobile/src/components/MoreForm.android.tsx
+++ b/packages/mobile/src/components/MoreForm.android.tsx
@@ -104,6 +104,14 @@ type RowColors = {
    * runs dark on a light-mode device (same fix as AppMenu.android).
    */
   itemColor: string;
+  /**
+   * Section title/footer colour. These `Text` nodes sit directly in the
+   * `LazyColumn`, not inside a `Card` — so unlike row text they get no M3
+   * on-surface content colour from a surrounding container and render black
+   * regardless of `colorScheme` unless given one explicitly (same class of bug
+   * as `itemColor` above).
+   */
+  sectionTextColor: string;
 };
 
 function SelectRow({ row, colors }: { row: MoreSelectRow; colors: RowColors }) {
@@ -349,6 +357,7 @@ export function MoreForm({ model }: MoreFormProps) {
     segmentColors: segmentedBrandColors(brandColors),
     iconTint: systemColors.secondaryLabel,
     itemColor: systemColors.label as string,
+    sectionTextColor: systemColors.secondaryLabel as string,
   };
 
   // Flatten sections into LazyColumn items: title Text, the rows (carded unless
@@ -357,7 +366,7 @@ export function MoreForm({ model }: MoreFormProps) {
   for (const section of model.sections) {
     if (section.title) {
       items.push(
-        <Text key={`${section.key}-title`} style={{ typography: 'titleSmall' }} modifiers={[alpha(0.6)]}>
+        <Text key={`${section.key}-title`} style={{ typography: 'titleSmall' }} color={colors.sectionTextColor}>
           {section.title}
         </Text>,
       );
@@ -375,7 +384,7 @@ export function MoreForm({ model }: MoreFormProps) {
     }
     if (section.footer) {
       items.push(
-        <Text key={`${section.key}-footer`} style={{ typography: 'bodySmall' }} modifiers={[alpha(0.6)]}>
+        <Text key={`${section.key}-footer`} style={{ typography: 'bodySmall' }} color={colors.sectionTextColor}>
           {section.footer}
         </Text>,
       );


### PR DESCRIPTION
## Summary

On Android in dark mode, the settings ("More") screen's section titles and footer text render in black, making them unreadable against the dark background. Row content inside each section's `Card` picks up Material's on-surface text colour automatically, but the section title/footer `Text` nodes sit directly in the `LazyColumn`, outside any `Card`, so they never get that colour and default to black regardless of `colorScheme`. Same class of bug already fixed for the select-row dropdown popup a few lines up in the same file.

Fix: give section title/footer text an explicit colour (`systemColors.secondaryLabel`), matching what the iOS/RN `SectionHeader` component already does.

## Release Notes

- [x] No release note needed (internal / technical change)

(Bug only affects Android — reads as a fix a user would notice, but "section titles are readable" isn't really changelog-worthy copy; happy to add a line if preferred.)

## Test plan

1. Android, dark mode → More tab → section titles ("Account", "Preferences", etc.) are legible, not black-on-black.
2. Toggle in-app Light/Dark theme override → titles stay legible in both.

## Risk

Risk: 1/5 — text colour prop on two `Text` nodes, no logic change.
