### PR TITLE
fix(mobile): move "Reset zoom" off the holds

### DIFF
--- a/packages/mobile/src/components/board-controls/ResetZoomButton.tsx
+++ b/packages/mobile/src/components/board-controls/ResetZoomButton.tsx
@@ -1,0 +1,162 @@
+import { memo, useCallback, useEffect, useState } from 'react';
+import { Pressable, StyleSheet, View, type LayoutChangeEvent, type StyleProp, type ViewStyle } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import { useTranslation } from 'react-i18next';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { timing } from '../../theme/animations';
+import { borderRadius, overlays, spacing } from '../../theme/tokens';
+import { glassSize } from '../../theme/layout';
+import { hasUsedResetZoom, markResetZoomUsed } from '../../lib/reset-zoom-hint';
+
+type ResetZoomButtonProps = {
+  /** Drives the cross-fade, the label reveal, and the pointerEvents / a11y gating. */
+  visible: boolean;
+  onPress: () => void;
+  /** Caller owns POSITION only — every other visual is fixed here. */
+  style?: StyleProp<ViewStyle>;
+};
+
+/** How long the label stays out after a zoom before the button collapses. */
+const LABEL_HOLD_MS = 3000;
+
+/**
+ * The "back to 1x" control shared by every zoomable board.
+ *
+ * It sits ON the board, bottom-right. That is deliberate and was the outcome of
+ * QA on #5113: the original was a wide text pill at the TOP-right whose touch
+ * rect swallowed 14 hold centres, which made the holds under it unselectable
+ * exactly while you were zoomed in to paint them. At 32dp in the corner nearest
+ * the thumb it is small enough not to be in the way, and moving it off the board
+ * entirely cost more than it bought.
+ *
+ * It introduces itself once and then gets out of the way. Until the control has
+ * been used on this device, each zoom extends it to show `common:board.resetZoom`
+ * for three seconds; after the first press it is a bare glyph forever. An icon
+ * alone is not self-evident — a viewfinder is not an established "reset zoom"
+ * idiom — but a label that keeps reappearing is the footprint that caused the
+ * bug it is meant to fix. Staying collapsed is also what keeps the control
+ * locale-invariant: German ("Zoom zurücksetzen") is a ~120dp pill.
+ *
+ * The icon is on the TRAILING edge so it stays put as the pill grows and shrinks
+ * against its right-anchored position.
+ */
+export const ResetZoomButton = memo(function ResetZoomButton({ visible, onPress, style }: ResetZoomButtonProps) {
+  const { t } = useTranslation('common');
+  const label = t('board.resetZoom');
+
+  // Natural width of the extended pill, measured once from the laid-out row. The
+  // width is animated explicitly rather than left to a layout animation: the
+  // button is pinned to a corner, so an unmanaged reflow moves it rather than
+  // just resizing it.
+  const [extendedWidth, setExtendedWidth] = useState<number | null>(null);
+  const handleRowLayout = useCallback((event: LayoutChangeEvent) => {
+    const measured = Math.ceil(event.nativeEvent.layout.width);
+    setExtendedWidth((previous) => (previous === null || Math.abs(previous - measured) > 1 ? measured : previous));
+  }, []);
+
+  // null while the marker is still being read. The hint holds until then rather
+  // than flashing out and snapping away, which would read as a glitch.
+  const [hintPending, setHintPending] = useState<boolean | null>(null);
+  useEffect(() => {
+    let active = true;
+    void hasUsedResetZoom().then((used) => {
+      if (active) setHintPending(!used);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const handlePress = useCallback(() => {
+    if (hintPending !== false) {
+      setHintPending(false);
+      void markResetZoomUsed();
+    }
+    onPress();
+  }, [hintPending, onPress]);
+
+  const opacity = useSharedValue(visible ? 1 : 0);
+  const width = useSharedValue<number>(glassSize.mini);
+
+  useEffect(() => {
+    opacity.value = withTiming(visible ? 1 : 0, { duration: timing.fast });
+  }, [visible, opacity]);
+
+  // Extends on every zoom UNTIL the control has been used once, then never
+  // again — seeing the label is not the same as having learned the glyph, so
+  // the marker is written on press rather than on display.
+  useEffect(() => {
+    if (!visible || extendedWidth === null || hintPending !== true) {
+      width.value = glassSize.mini;
+      return;
+    }
+    width.value = withTiming(extendedWidth, { duration: timing.normal });
+    const collapse = setTimeout(() => {
+      width.value = withTiming(glassSize.mini, { duration: timing.normal });
+    }, LABEL_HOLD_MS);
+    return () => clearTimeout(collapse);
+  }, [visible, extendedWidth, hintPending, width]);
+
+  const fadeStyle = useAnimatedStyle(() => ({ opacity: opacity.value }));
+  const widthStyle = useAnimatedStyle(() => ({ width: width.value }));
+
+  return (
+    <Animated.View
+      style={[styles.wrapper, style, fadeStyle]}
+      pointerEvents={visible ? 'auto' : 'none'}
+      // Faded out is not just invisible: a control left in the a11y tree is a
+      // target VoiceOver lands on that does nothing.
+      accessibilityElementsHidden={!visible}
+      importantForAccessibility={visible ? 'auto' : 'no-hide-descendants'}
+    >
+      <Pressable onPress={handlePress} accessibilityRole="button" accessibilityLabel={label} hitSlop={8}>
+        <Animated.View style={[styles.pill, widthStyle]}>
+          {/* Laid out at natural width and measured; the pill above clips it.
+              Right-aligned so the glyph holds the trailing edge while the label
+              slides out to its left. */}
+          <View style={styles.row} onLayout={handleRowLayout}>
+            <Text variant="footnote" numberOfLines={1} style={styles.label}>
+              {label}
+            </Text>
+            <View style={styles.glyph}>
+              <Icon name="crop.free" size={16} color={overlays.onScrim} />
+            </View>
+          </View>
+        </Animated.View>
+      </Pressable>
+    </Animated.View>
+  );
+});
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: 'absolute',
+  },
+  pill: {
+    height: glassSize.mini,
+    borderRadius: borderRadius.full,
+    // Fixed scrim rather than a theme surface: this sits on board art, which is
+    // arbitrary content in both schemes.
+    backgroundColor: overlays.scrim,
+    overflow: 'hidden',
+    // The row is pinned to the trailing edge so shrinking the pill eats the
+    // label from the left and leaves the glyph where the thumb last saw it.
+    alignItems: 'flex-end',
+    justifyContent: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  label: {
+    color: overlays.onScrim,
+    paddingLeft: spacing[3],
+  },
+  glyph: {
+    width: glassSize.mini,
+    height: glassSize.mini,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/packages/mobile/src/components/board-controls/__tests__/reset-zoom-button.test.tsx
+++ b/packages/mobile/src/components/board-controls/__tests__/reset-zoom-button.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { createElement, useEffect, useRef, type ReactNode } from 'react';
+
+const MEASURED_ROW_WIDTH = 118;
+const COLLAPSED = 32;
+
+// The two shared values the component creates, in order: [opacity, width].
+const sharedValues = vi.hoisted(() => [] as { value: number }[]);
+
+type PressProps = { children?: ReactNode; onPress?: () => void; accessibilityLabel?: string };
+type ViewProps = { children?: ReactNode; onLayout?: (event: unknown) => void; style?: unknown };
+type WrapperProps = {
+  children?: ReactNode;
+  pointerEvents?: string;
+  accessibilityElementsHidden?: boolean;
+  importantForAccessibility?: string;
+};
+
+vi.mock('react-native', () => ({
+  // Fires onLayout the way a real host does, so the component can measure the
+  // extended pill; without it the button could never leave its collapsed width.
+  View: ({ children, onLayout }: ViewProps) => {
+    useEffect(() => {
+      onLayout?.({ nativeEvent: { layout: { width: MEASURED_ROW_WIDTH, height: COLLAPSED } } });
+    }, [onLayout]);
+    return createElement('div', null, children);
+  },
+  Pressable: ({ children, onPress, accessibilityLabel }: PressProps) =>
+    createElement('button', { onClick: onPress, 'data-label': accessibilityLabel }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  Platform: { OS: 'ios', select: (choices: Record<string, unknown>) => choices.ios },
+  PlatformColor: (name: string) => name,
+}));
+
+vi.mock('react-native-reanimated', () => ({
+  default: {
+    View: ({ children, pointerEvents, accessibilityElementsHidden, importantForAccessibility }: WrapperProps) =>
+      createElement(
+        'div',
+        {
+          'data-pointer-events': pointerEvents,
+          'data-a11y-hidden': accessibilityElementsHidden ? 'true' : 'false',
+          'data-a11y-important': importantForAccessibility,
+        },
+        children,
+      ),
+  },
+  // Stable per component instance, like the real hook. A mock that returns a
+  // fresh object each render hands the effects one object and the assertions
+  // another, which reads as "the animation never ran".
+  useSharedValue: (initial: number) => {
+    const ref = useRef<{ value: number } | null>(null);
+    if (ref.current === null) {
+      ref.current = { value: initial };
+      sharedValues.push(ref.current);
+    }
+    return ref.current;
+  },
+  useAnimatedStyle: (build: () => unknown) => build(),
+  // Timings land immediately, so the value reflects the target being animated to.
+  withTiming: (target: number) => target,
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+// The one-shot marker behind the label. Defaults to "never used", so the hint is
+// live unless a test says otherwise.
+const hint = vi.hoisted(() => ({ used: false, marked: 0 }));
+vi.mock('../../../lib/reset-zoom-hint', () => ({
+  hasUsedResetZoom: () => Promise.resolve(hint.used),
+  markResetZoomUsed: () => {
+    hint.marked += 1;
+    return Promise.resolve();
+  },
+}));
+vi.mock('../../Icon', () => ({
+  Icon: ({ name }: { name?: string }) => createElement('span', { 'data-icon': name }),
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', { 'data-label-text': 'true' }, children),
+}));
+
+import { ResetZoomButton } from '../ResetZoomButton';
+
+const wrapper = (container: HTMLElement) => container.querySelector('[data-pointer-events]') as HTMLElement;
+const widthValue = () => sharedValues[1]?.value;
+
+describe('ResetZoomButton', () => {
+  beforeEach(() => {
+    sharedValues.length = 0;
+    hint.used = false;
+    hint.marked = 0;
+    // Only the timer APIs this component uses. Faking the whole clock stalls
+    // React's scheduler, so the onLayout-driven re-render that carries the
+    // measured width never lands and the button looks stuck collapsed.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('is inert and out of the a11y tree while hidden', () => {
+    // Faded out is not just invisible: a control left in the a11y tree is a
+    // target VoiceOver lands on that does nothing.
+    const { container } = render(createElement(ResetZoomButton, { visible: false, onPress: vi.fn() }));
+    expect(wrapper(container).getAttribute('data-pointer-events')).toBe('none');
+    expect(wrapper(container).getAttribute('data-a11y-hidden')).toBe('true');
+    expect(wrapper(container).getAttribute('data-a11y-important')).toBe('no-hide-descendants');
+  });
+
+  it('is tappable and announced while visible', () => {
+    const onPress = vi.fn();
+    const { container } = render(createElement(ResetZoomButton, { visible: true, onPress }));
+    expect(wrapper(container).getAttribute('data-pointer-events')).toBe('auto');
+
+    const button = container.querySelector('button') as HTMLButtonElement;
+    expect(button.getAttribute('data-label')).toBe('board.resetZoom');
+    button.click();
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('extends to show the label on zoom, then collapses to the glyph after 3s', async () => {
+    // The point of the label: an icon alone does not say "reset zoom", but a
+    // label that keeps coming back is the footprint that covered holds.
+    render(createElement(ResetZoomButton, { visible: true, onPress: vi.fn() }));
+    await act(async () => {});
+    expect(widthValue()).toBe(MEASURED_ROW_WIDTH);
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(widthValue()).toBe(COLLAPSED);
+  });
+
+  it('never shows the label again once the control has been used', async () => {
+    hint.used = true;
+    render(createElement(ResetZoomButton, { visible: true, onPress: vi.fn() }));
+    await act(async () => {});
+    expect(widthValue()).toBe(COLLAPSED);
+  });
+
+  it('marks the control used on the first press, once', async () => {
+    // Written on PRESS, not on display: reading the label is not the same as
+    // having connected the glyph to the action.
+    const { container } = render(createElement(ResetZoomButton, { visible: true, onPress: vi.fn() }));
+    await act(async () => {});
+    const button = container.querySelector('button') as HTMLButtonElement;
+
+    await act(async () => {
+      button.click();
+    });
+    expect(hint.marked).toBe(1);
+    expect(widthValue()).toBe(COLLAPSED);
+
+    await act(async () => {
+      button.click();
+    });
+    expect(hint.marked).toBe(1);
+  });
+
+  it('holds the hint collapsed until the marker has been read', () => {
+    // The read is async. Extending first and snapping away on the answer would
+    // read as a glitch, so an unknown marker stays collapsed.
+    render(createElement(ResetZoomButton, { visible: true, onPress: vi.fn() }));
+    expect(widthValue()).toBe(COLLAPSED);
+  });
+
+  it('stays collapsed while not zoomed', async () => {
+    render(createElement(ResetZoomButton, { visible: false, onPress: vi.fn() }));
+    await act(async () => {});
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(widthValue()).toBe(COLLAPSED);
+  });
+
+  it('carries the wording as text as well as the accessibility label', () => {
+    const { container } = render(createElement(ResetZoomButton, { visible: true, onPress: vi.fn() }));
+    expect(container.querySelector('[data-label-text="true"]')?.textContent).toBe('board.resetZoom');
+    expect(container.querySelector('[data-icon="crop.free"]')).toBeTruthy();
+  });
+});

--- a/packages/mobile/src/components/create-climb/CreateDraftStatusRow.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDraftStatusRow.tsx
@@ -13,7 +13,7 @@ type CreateDraftStatusRowProps = {
 };
 
 /** caption1 line box, used as the row's floor when there is no text. */
-const RESERVED_LINE_HEIGHT = 16;
+export const RESERVED_LINE_HEIGHT = 16;
 
 /**
  * The persistent one-line answer to "is my work safe?", sitting directly under
@@ -63,7 +63,7 @@ export const CreateDraftStatusRow = memo(function CreateDraftStatusRow({
   }, [statusText, shouldAnnounce, announce]);
 
   return (
-    <View style={styles.row} testID="create-draft-status-row">
+    <View style={statusRowStyles.row} testID="create-draft-status-row">
       {statusText === null ? null : (
         <Text
           variant="caption1"
@@ -82,13 +82,20 @@ export const CreateDraftStatusRow = memo(function CreateDraftStatusRow({
   );
 });
 
-const styles = StyleSheet.create({
+export const statusRowStyles = StyleSheet.create({
   row: {
     // Left edge lines up with the brush chips and the "Description" label.
     paddingHorizontal: spacing[4],
     paddingTop: spacing[1],
     paddingBottom: spacing[3],
     // Floor, not a fixed height: larger Dynamic Type still grows the line.
-    minHeight: RESERVED_LINE_HEIGHT,
+    //
+    // The padding is part of it. Yoga measures minHeight against the border
+    // box, so a bare RESERVED_LINE_HEIGHT was already satisfied by the 16dp of
+    // padding alone — the row stood 16dp empty and 32dp once it had something
+    // to say. That 16dp step landed the moment the first hold was painted,
+    // which moved the measured above-fold height and re-snapped the sheet: the
+    // exact jolt the comment on this component promises it prevents.
+    minHeight: RESERVED_LINE_HEIGHT + spacing[1] + spacing[3],
   },
 });

--- a/packages/mobile/src/components/create-climb/CreateDrawer.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawer.tsx
@@ -10,7 +10,7 @@ import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import { useTheme } from '../../providers/theme-provider';
 import { spacing, sheetStyles } from '../../theme/tokens';
 import type { BoardHoldTarget } from '../../lib/create-board-holds';
-import { InteractiveCreateBoard } from './InteractiveCreateBoard';
+import { InteractiveCreateBoard, type CreateBoardControls } from './InteractiveCreateBoard';
 import { CreateDrawerHeader } from './CreateDrawerHeader';
 import { CreateDrawerActionBar } from './CreateDrawerActionBar';
 import { CreateDrawerForm } from './CreateDrawerForm';
@@ -98,6 +98,45 @@ export function CreateDrawer({
   // Live snap index, kept current via onChange so the re-snap below targets the
   // index the user is actually at (not a one-shot reset that breaks on rotation).
   const indexRef = useRef(0);
+
+  // The board owns the zoom AND renders the reset control; the drawer only
+  // holds a handle so it can drop the zoom when the frame or the climb changes
+  // underneath it.
+  const boardControlsRef = useRef<CreateBoardControls | null>(null);
+  const resetBoardZoom = useCallback(() => {
+    boardControlsRef.current?.resetZoom();
+  }, []);
+
+  // Zoom is a view of ONE frame. Carrying it across a frame change leaves you
+  // staring at a magnified corner of a climb you didn't ask for, so drop it —
+  // the play drawer already does exactly this (SwipeBoardCarousel, PlayDrawer).
+  //
+  // Keyed on the count as well as the index, because deleting a frame can swap
+  // the frame under you WITHOUT moving the index: DELETE_FRAME clamps, so
+  // removing the middle of three leaves the index at 1 pointing at what used to
+  // be frame 2. The index alone would miss it and keep the old frame's zoom.
+  useEffect(() => {
+    resetBoardZoom();
+  }, [controller.currentFrameIndex, controller.frameCount, resetBoardZoom]);
+
+  // Same reasoning for swapping the climb entirely: a fresh editor or a loaded
+  // draft should open at 1x, not inherit the last climb's zoom.
+  //
+  // Keyed on the epoch, not on the New Climb press: with unsaved work that press
+  // only raises the confirmation banner, and cancelling it leaves you on the
+  // same climb — having silently lost your zoom. The controller bumps the epoch
+  // only once a blank climb has actually started, on either path.
+  useEffect(() => {
+    resetBoardZoom();
+  }, [controller.blankClimbEpoch, resetBoardZoom]);
+
+  const handleLoadDraft = useCallback(
+    (climb: Climb) => {
+      resetBoardZoom();
+      onLoadDraft(climb);
+    },
+    [resetBoardZoom, onLoadDraft],
+  );
 
   const boardMaxHeight = Math.max(200, windowHeight - insets.top - windowInsetBottom - ABOVE_FOLD_CHROME);
 
@@ -239,6 +278,7 @@ export function CreateDrawer({
               showAllHolds={controller.showAllHolds}
               renderWidth={boardRender.width}
               renderHeight={boardRender.height}
+              controlRef={boardControlsRef}
             />
           </View>
 
@@ -282,7 +322,7 @@ export function CreateDrawer({
             showAllHolds={controller.showAllHolds}
             onChangeShowAllHolds={controller.setShowAllHolds}
           />
-          <OpenDraftsSection board={board} onLoadDraft={onLoadDraft} />
+          <OpenDraftsSection board={board} onLoadDraft={handleLoadDraft} />
         </View>
       </BottomSheetScrollView>
     </BottomSheet>

--- a/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
+++ b/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
@@ -1,13 +1,12 @@
-import React, { useMemo, useRef, type ReactNode } from 'react';
-import { useTranslation } from 'react-i18next';
-import { View, StyleSheet, Pressable, PixelRatio } from 'react-native';
+import React, { useImperativeHandle, useMemo, useRef, type ReactNode, type RefObject } from 'react';
+import { View, StyleSheet, PixelRatio } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { GestureDetector, GestureHandlerRootView, type GestureType } from 'react-native-gesture-handler';
 import type { BoardName, LitUpHoldsMap } from '@boardsesh/shared-schema';
 import { BoardImageNative } from '../BoardImageNative';
-import { Text } from '../Text';
+import { ResetZoomButton } from '../board-controls/ResetZoomButton';
 import { useZoomPanGesture } from '../play-drawer/use-zoom-pan-gesture';
-import { overlays } from '../../theme/tokens';
+import { spacing } from '../../theme/tokens';
 import { EDITING_VEIL_OPACITY } from '../../lib/board-render-settings';
 import type { BoardHoldTarget } from '../../lib/create-board-holds';
 import { HoldMarkerLayer } from './HoldMarkerLayer';
@@ -15,6 +14,11 @@ import { HoldTargetLayer } from './HoldTargetLayer';
 import { PaintedHoldsLayer } from './PaintedHoldsLayer';
 import { buildHoldHitTargets } from './holdLayout';
 import { useZoomedHoldTapGesture, PAN_ACTIVATION_OFFSET } from './use-zoomed-hold-tap-gesture';
+
+/** Imperative handle on the board's zoom, mirroring `FilterBoardControls`. */
+export type CreateBoardControls = {
+  resetZoom: () => void;
+};
 
 type InteractiveCreateBoardProps = {
   /**
@@ -41,6 +45,8 @@ type InteractiveCreateBoardProps = {
   renderHeight: number;
   /** Optional overlay (e.g. heatmap) drawn between the board photo and the holds. */
   overlay?: ReactNode;
+  /** Lets the drawer reset the zoom — both from its own chrome and on frame change. */
+  controlRef?: RefObject<CreateBoardControls | null>;
 };
 
 /**
@@ -87,8 +93,8 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
   renderWidth,
   renderHeight,
   overlay,
+  controlRef,
 }: InteractiveCreateBoardProps) {
-  const { t } = useTranslation('common');
   // Shared with the per-hold detectors and the zoomed overlay so they mark
   // themselves simultaneous with the pinch — otherwise two fingers landing on
   // two hold targets each claim a pointer and pinch-to-zoom stalls on Android.
@@ -118,6 +124,8 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
   // (never upscales), so on a 3x phone this is a no-op and on 2x devices it is a
   // real saving — which matters here, where every paint tap mints a new PNG.
   const overlayRenderWidth = useMemo(() => Math.round(renderWidth * PixelRatio.get()), [renderWidth]);
+
+  useImperativeHandle(controlRef, () => ({ resetZoom }), [resetZoom]);
 
   const holdById = useMemo(() => {
     const map = new Map<number, BoardHoldTarget>();
@@ -236,16 +244,18 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
               that, painting and the role sheet are dead while zoomed (#2687). */}
           {isZoomed ? (
             <GestureDetector gesture={overlayGesture}>
-              <View style={StyleSheet.absoluteFill} />
+              <View style={StyleSheet.absoluteFill}>
+                {/* A CHILD of the pan overlay, not a sibling above it. RNGH
+                    offers a touch to the handlers on the touched view and its
+                    ANCESTORS, so nesting is what keeps a drag that starts on the
+                    button panning the board — and this button sits in the corner
+                    the panning thumb rests in. As a sibling it would be a 32dp
+                    dead zone for panning. Mounting with the overlay also means
+                    it re-introduces itself on every zoom, which is the point of
+                    the 3s label. */}
+                <ResetZoomButton visible onPress={resetZoom} style={styles.resetZoom} />
+              </View>
             </GestureDetector>
-          ) : null}
-
-          {isZoomed ? (
-            <Pressable style={styles.resetButton} onPress={resetZoom} hitSlop={8} accessibilityRole="button">
-              <Text variant="footnote" style={styles.resetLabel}>
-                {t('board.resetZoom')}
-              </Text>
-            </Pressable>
           ) : null}
         </View>
       </GestureDetector>
@@ -265,16 +275,10 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
   },
-  resetButton: {
-    position: 'absolute',
-    top: 12,
-    right: 12,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 16,
-    backgroundColor: overlays.scrim,
-  },
-  resetLabel: {
-    color: overlays.onScrim,
+  // Bottom-right: nearest the thumb on a sheet, and the corner it already
+  // covers while panning. See ResetZoomButton for why it is on the board.
+  resetZoom: {
+    right: spacing[2],
+    bottom: spacing[2],
   },
 });

--- a/packages/mobile/src/components/create-climb/__tests__/create-draft-status-row-reserve.test.ts
+++ b/packages/mobile/src/components/create-climb/__tests__/create-draft-status-row-reserve.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// StyleSheet.create is identity here, so the assertions below read the numbers
+// that actually ship. Platform/PlatformColor come in transitively via the theme.
+vi.mock('react-native', () => ({
+  View: 'View',
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  Platform: { OS: 'ios', select: (choices: Record<string, unknown>) => choices.ios },
+  PlatformColor: (name: string) => name,
+}));
+vi.mock('../../Text', () => ({ Text: 'Text' }));
+vi.mock('../../../providers/theme-provider', () => ({ useTheme: () => ({ systemColors: {}, brandColors: {} }) }));
+
+// The style object, read straight off the module. StyleSheet.create is identity
+// in this environment, so these are the numbers that actually ship.
+import { statusRowStyles, RESERVED_LINE_HEIGHT } from '../CreateDraftStatusRow';
+
+/**
+ * Two numbers on this row are load-bearing well beyond the row itself.
+ *
+ * The drawer derives its peek snap-point from the MEASURED above-fold height,
+ * and this row sits inside that measured block. Its whole promise is that it
+ * occupies the same box whether or not it has anything to say — otherwise the
+ * first painted hold changes the row's height, moves `peekHeight`, and
+ * re-snaps a sheet the climber had expanded.
+ *
+ * That promise was quietly broken: Yoga measures `minHeight` against the border
+ * box, so a floor equal to the bare line height was already met by the row's own
+ * padding, and the row stood 16dp empty against 32dp full. The reset-zoom
+ * control now parks in that box too, so a short row also drops the control onto
+ * the Save button above it.
+ */
+describe('CreateDraftStatusRow reserved box', () => {
+  it('floors the row at padding + line, so it is the same height empty as full', () => {
+    const { paddingTop, paddingBottom, minHeight } = statusRowStyles.row;
+    // The height an occupied row lays out to: content plus its own padding.
+    const occupied = RESERVED_LINE_HEIGHT + paddingTop + paddingBottom;
+    expect(minHeight).toBe(occupied);
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-auto-reset-zoom.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-auto-reset-zoom.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, useEffect, type ReactNode, type RefObject } from 'react';
+import type { CreateBoardControls } from '../InteractiveCreateBoard';
+
+// One spy standing in for the board's zoom handle, so the drawer's auto-resets
+// can be asserted without a real gesture stack.
+const resetZoomSpy = vi.hoisted(() => vi.fn());
+
+type ViewMockProps = { children?: ReactNode; onLayout?: unknown; testID?: string };
+vi.mock('react-native', () => ({
+  View: ({ children }: ViewMockProps) => createElement('div', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+  useWindowDimensions: () => ({ width: 405, height: 900 }),
+}));
+vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 24, bottom: 0 }) }));
+vi.mock('../../../hooks/use-window-bottom-inset', () => ({ useWindowBottomInset: () => 48 }));
+vi.mock('@expo/ui/community/bottom-sheet', () => ({
+  default: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  BottomSheetScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { secondaryBackground: '#221A33' } }),
+}));
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 6: 24 },
+  sheetStyles: { background: {} },
+}));
+
+// Publishes the handle the drawer calls, the same way the real board's
+// useImperativeHandle does.
+vi.mock('../InteractiveCreateBoard', () => ({
+  InteractiveCreateBoard: ({ controlRef }: { controlRef?: RefObject<CreateBoardControls | null> }) => {
+    useEffect(() => {
+      if (controlRef) controlRef.current = { resetZoom: resetZoomSpy };
+    }, [controlRef]);
+    return createElement('div', { 'data-node': 'board' });
+  },
+}));
+vi.mock('../CreateDrawerHeader', () => ({ CreateDrawerHeader: () => createElement('div') }));
+vi.mock('../CreateDrawerActionBar', () => ({
+  CreateDrawerActionBar: ({ onNewClimb }: { onNewClimb?: () => void }) =>
+    createElement('button', { 'data-new-climb': 'true', onClick: onNewClimb }),
+}));
+vi.mock('../CreateDrawerForm', () => ({ CreateDrawerForm: () => createElement('div') }));
+vi.mock('../OpenDraftsSection', () => ({
+  OpenDraftsSection: ({ onLoadDraft }: { onLoadDraft?: (climb: unknown) => void }) =>
+    createElement('button', { 'data-load-draft': 'true', onClick: () => onLoadDraft?.({ uuid: 'draft-1' }) }),
+}));
+vi.mock('../InlineConfirmBanner', () => ({
+  InlineConfirmBanner: ({ onConfirm }: { onConfirm?: () => void }) =>
+    createElement('button', { 'data-confirm-new': 'true', onClick: onConfirm }),
+}));
+vi.mock('../DuplicateBanner', () => ({ DuplicateBanner: () => createElement('div') }));
+
+import { CreateDrawer } from '../CreateDrawer';
+
+const board = { boardName: 'kilter' as const, layoutId: 1, sizeId: 10, setIds: '1,2', angle: 40 };
+const boardHolds = { holdTargets: [], boardWidth: 650, boardHeight: 1000 };
+
+type Controller = Parameters<typeof CreateDrawer>[0]['controller'];
+
+function makeController(overrides: Record<string, unknown> = {}): Controller {
+  return {
+    name: '',
+    setName: vi.fn(),
+    startingCount: 0,
+    finishCount: 0,
+    focusNameSignal: 0,
+    bleConnected: false,
+    bleConnecting: false,
+    handleToggleBle: vi.fn(),
+    litUpHoldsMap: {},
+    handlePaint: vi.fn(),
+    showAllHolds: false,
+    selectedBrush: 'HAND',
+    setSelectedBrush: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+    undo: vi.fn(),
+    redo: vi.fn(),
+    handleClearHolds: vi.fn(),
+    handleNewClimb: vi.fn(),
+    frameCount: 1,
+    currentFrameIndex: 0,
+    duplicateFrame: vi.fn(),
+    deleteFrame: vi.fn(),
+    prevFrame: vi.fn(),
+    nextFrame: vi.fn(),
+    canSetActive: false,
+    handleSetActive: vi.fn(),
+    saveState: 'ready',
+    handleSave: vi.fn(),
+    publishBlocked: false,
+    draftStatus: null,
+    pendingNewClimb: false,
+    confirmNewClimb: vi.fn(),
+    blankClimbEpoch: 0,
+    cancelNewClimb: vi.fn(),
+    publishDuplicateError: null,
+    dismissDuplicateError: vi.fn(),
+    description: '',
+    setDescription: vi.fn(),
+    noMatch: false,
+    setNoMatch: vi.fn(),
+    isDraft: true,
+    setIsDraft: vi.fn(),
+    setShowAllHolds: vi.fn(),
+    ...overrides,
+  } as unknown as Controller;
+}
+
+const onLoadDraft = vi.fn();
+const drawer = (controllerOverrides: Record<string, unknown> = {}) =>
+  createElement(CreateDrawer, {
+    board,
+    controller: makeController(controllerOverrides),
+    boardHolds,
+    onLongPressHold: vi.fn(),
+    subSheetOpen: false,
+    onLoadDraft,
+    onClose: vi.fn(),
+    onViewDuplicate: vi.fn(),
+  });
+
+/**
+ * Zoom is a view of ONE frame of ONE climb. Carrying it across a frame or climb
+ * change leaves the climber staring at a magnified corner of something they
+ * didn't ask for. Both sibling surfaces already dropped it on these events
+ * (SwipeBoardCarousel, PlayDrawer); the create board dropped it on none.
+ */
+describe('CreateDrawer auto-reset zoom', () => {
+  beforeEach(() => {
+    resetZoomSpy.mockClear();
+    onLoadDraft.mockClear();
+  });
+
+  it('drops the zoom when the frame changes', () => {
+    const { rerender } = render(drawer({ frameCount: 2, currentFrameIndex: 0 }));
+    resetZoomSpy.mockClear();
+
+    rerender(drawer({ frameCount: 2, currentFrameIndex: 1 }));
+    expect(resetZoomSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops the zoom when a deleted frame swaps the one under you', () => {
+    // DELETE_FRAME clamps, so removing the middle of three leaves the index at
+    // 1 pointing at what used to be frame 2. The index alone misses that.
+    const { rerender } = render(drawer({ frameCount: 3, currentFrameIndex: 1 }));
+    resetZoomSpy.mockClear();
+
+    rerender(drawer({ frameCount: 2, currentFrameIndex: 1 }));
+    expect(resetZoomSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the zoom alone on a re-render that does not change frame', () => {
+    const { rerender } = render(drawer({ frameCount: 2, currentFrameIndex: 1 }));
+    resetZoomSpy.mockClear();
+
+    rerender(drawer({ frameCount: 2, currentFrameIndex: 1 }));
+    expect(resetZoomSpy).not.toHaveBeenCalled();
+  });
+
+  it('drops the zoom when a blank climb actually starts', () => {
+    const { rerender } = render(drawer({ blankClimbEpoch: 0 }));
+    resetZoomSpy.mockClear();
+
+    rerender(drawer({ blankClimbEpoch: 1 }));
+    expect(resetZoomSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the zoom while New Climb is only ASKING to start one', () => {
+    // With unsaved work the press raises the confirmation and returns; the
+    // epoch does not move until the reset lands. Keying this on the press
+    // instead threw away the zoom of a climb the climber then kept.
+    const handleNewClimb = vi.fn();
+    const { container, rerender } = render(drawer({ handleNewClimb }));
+    resetZoomSpy.mockClear();
+
+    (container.querySelector('[data-new-climb="true"]') as HTMLButtonElement).click();
+    expect(handleNewClimb).toHaveBeenCalledTimes(1);
+    expect(resetZoomSpy).not.toHaveBeenCalled();
+
+    // ...and cancelling leaves it untouched too.
+    rerender(drawer({ pendingNewClimb: false, handleNewClimb }));
+    expect(resetZoomSpy).not.toHaveBeenCalled();
+  });
+
+  it('drops the zoom when a draft is loaded', () => {
+    const { container } = render(drawer());
+    resetZoomSpy.mockClear();
+
+    (container.querySelector('[data-load-draft="true"]') as HTMLButtonElement).click();
+    expect(resetZoomSpy).toHaveBeenCalledTimes(1);
+    expect(onLoadDraft).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-measured-region.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-measured-region.test.tsx
@@ -128,6 +128,12 @@ function renderDrawer(overrides: Record<string, unknown>) {
   };
 }
 
+const measuredNodeNames = (result: ReturnType<typeof renderDrawer>) =>
+  result.measured
+    .flatMap((block) => Array.from(block.querySelectorAll('[data-node]')))
+    .map((el) => el.getAttribute('data-node'))
+    .sort();
+
 describe('CreateDrawer measured above-fold region', () => {
   it('measures the header and the board block, which is what sizes the peek', () => {
     const { measured, node } = renderDrawer({});
@@ -156,12 +162,6 @@ describe('CreateDrawer measured above-fold region', () => {
     // height cannot move when one appears.
     const without = renderDrawer({});
     const withBanner = renderDrawer({ pendingNewClimb: true });
-
-    const measuredNodeNames = (r: ReturnType<typeof renderDrawer>) =>
-      r.measured
-        .flatMap((block) => Array.from(block.querySelectorAll('[data-node]')))
-        .map((el) => el.getAttribute('data-node'))
-        .sort();
 
     expect(measuredNodeNames(withBanner)).toEqual(measuredNodeNames(without));
   });

--- a/packages/mobile/src/components/create-climb/__tests__/interactive-create-board-layers.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/interactive-create-board-layers.test.tsx
@@ -20,7 +20,13 @@ vi.mock('react-native-gesture-handler', () => ({
   GestureHandlerRootView: ({ children }: ChildrenProps) => createElement('div', null, children),
 }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
-vi.mock('../../../theme/tokens', () => ({ overlays: { scrim: 'rgba(0,0,0,0.4)' } }));
+vi.mock('../../../theme/tokens', () => ({ overlays: { scrim: 'rgba(0,0,0,0.4)' }, spacing: { 2: 8 } }));
+// Stubbed so the suite doesn't pull the real Icon (and @expo/vector-icons' Flow
+// source) in through the board's zoomed chrome.
+vi.mock('../../board-controls/ResetZoomButton', () => ({
+  ResetZoomButton: ({ onPress }: { onPress?: () => void }) =>
+    createElement('button', { 'data-reset-zoom': 'true', onClick: onPress }),
+}));
 vi.mock('../../Text', () => ({ Text: ({ children }: ChildrenProps) => createElement('span', null, children) }));
 vi.mock('../../play-drawer/use-zoom-pan-gesture', () => ({
   useZoomPanGesture: () => ({

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -258,6 +258,12 @@ export function useCreateClimbScreen({
   // "edited since you saved" and "that save failed" stay true without a timer.
   // Inline "Start over?" confirm, rendered as sheet content — see handleNewClimb.
   const [pendingNewClimb, setPendingNewClimb] = useState(false);
+  // Bumped once per blank climb that ACTUALLY starts, so chrome can react to a
+  // new climb rather than to the intent to start one. `handleNewClimb` only
+  // raises the confirmation when there is unsaved work, and that confirmation
+  // can be cancelled — anything keyed on the press instead of this fires for a
+  // climb that never changed. The create drawer drops the board zoom on it.
+  const [blankClimbEpoch, setBlankClimbEpoch] = useState(0);
   const [savedSignature, setSavedSignature] = useState<string | null>(null);
   const [savedSignatureUnknown, setSavedSignatureUnknown] = useState(false);
   const [failedSignature, setFailedSignature] = useState<string | null>(null);
@@ -742,6 +748,10 @@ export function useCreateClimbScreen({
       setFailedSignature(null);
       // Fresh climb identity for the next WIP so its queue item is independent.
       previewUuidRef.current = randomUUID();
+      // Inside the try on purpose: a storage failure below leaves the editor
+      // and the confirmation intact, so no new climb started and nothing keyed
+      // on this should move.
+      setBlankClimbEpoch((epoch) => epoch + 1);
       if (isEditing || isForking) onStartedNewClimb?.();
     } catch {
       // Keep the editor and confirmation intact when storage cannot retire the
@@ -1141,6 +1151,7 @@ export function useCreateClimbScreen({
     handleNewClimb,
     pendingNewClimb,
     confirmNewClimb,
+    blankClimbEpoch,
     cancelNewClimb,
     showAllHolds,
     setShowAllHolds,

--- a/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
+++ b/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
@@ -1,8 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   View,
-  Pressable,
-  Text,
   StyleSheet,
   useWindowDimensions,
   PixelRatio,
@@ -13,8 +11,6 @@ import Animated, {
   useAnimatedStyle,
   useDerivedValue,
   useAnimatedReaction,
-  useSharedValue,
-  withTiming,
   runOnJS,
   type SharedValue,
 } from 'react-native-reanimated';
@@ -24,12 +20,10 @@ import { computePeekOffset, type PeekDirection } from '@boardsesh/play-view';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { buildBoardRenderTelemetryProps } from '@boardsesh/analytics';
 import { BoardImageNative } from '../BoardImageNative';
-import { Icon } from '../Icon';
 import { useCarouselGesture } from './use-carousel-gesture';
 import { useZoomPanGesture } from './use-zoom-pan-gesture';
 import { computeContainedBoardSize, CAROUSEL_LAYER_Z } from './play-drawer-layout';
-import { timing } from '../../theme/animations';
-import { overlays } from '../../theme/tokens';
+import { ResetZoomButton } from '../board-controls/ResetZoomButton';
 import { useEffectiveBoardRenderSettings } from '../../hooks/use-native-climb-render';
 
 type BoardRenderData = {
@@ -97,10 +91,6 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
   swipeIsAnimating,
 }: SwipeBoardCarouselProps) {
   const { t } = useTranslation('session');
-  // The reset-zoom pill reuses the already-translated `common:board.resetZoom`
-  // that the other two zoomable boards render (InteractiveFilterBoard,
-  // InteractiveCreateBoard) instead of a `session`-local duplicate.
-  const { t: tCommon } = useTranslation('common');
   const { width: screenWidth } = useWindowDimensions();
   // Measured box the board is laid out into. The board is sized to *fit* this
   // box (contain) so the play drawer's full-screen first view can keep the
@@ -185,15 +175,6 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
     externalTranslateX: swipeTranslateX,
     externalIsAnimating: swipeIsAnimating,
   });
-
-  const resetButtonOpacity = useSharedValue(0);
-  useEffect(() => {
-    resetButtonOpacity.value = withTiming(isZoomed ? 1 : 0, { duration: timing.fast });
-  }, [isZoomed, resetButtonOpacity]);
-
-  const resetButtonStyle = useAnimatedStyle(() => ({
-    opacity: resetButtonOpacity.value,
-  }));
 
   // The current board: slides horizontally with the finger, and on release the
   // carousel's withTiming flings translateX off-screen. While zoomed the swipe is
@@ -370,18 +351,11 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
           </GestureDetector>
         )}
 
-        <Animated.View style={[styles.resetZoomWrapper, resetButtonStyle]} pointerEvents={isZoomed ? 'auto' : 'none'}>
-          <Pressable
-            onPress={resetZoom}
-            style={styles.resetZoomButton}
-            accessibilityRole="button"
-            accessibilityLabel={tCommon('board.resetZoom')}
-            hitSlop={8}
-          >
-            <Icon name="crop.free" size={14} color={overlays.onScrim} />
-            <Text style={styles.resetZoomLabel}>{tCommon('board.resetZoom')}</Text>
-          </Pressable>
-        </Animated.View>
+        {/* Bottom-right, matching the create and hold-filter boards so the
+            control is in one learned place across every board in the app. Kept
+            board art. Nothing is selectable on this board, so it costs
+            legibility, not taps. */}
+        <ResetZoomButton visible={isZoomed} onPress={resetZoom} style={styles.resetZoomWrapper} />
       </View>
     </GestureDetector>
   );
@@ -425,23 +399,8 @@ const styles = StyleSheet.create({
     zIndex: CAROUSEL_LAYER_Z.zoomPan,
   },
   resetZoomWrapper: {
-    position: 'absolute',
-    top: 12,
+    bottom: 12,
     right: 12,
     zIndex: CAROUSEL_LAYER_Z.resetZoom,
-  },
-  resetZoomButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 16,
-    backgroundColor: overlays.scrim,
-  },
-  resetZoomLabel: {
-    color: overlays.onScrim,
-    fontSize: 12,
-    fontWeight: '500',
   },
 });

--- a/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
+++ b/packages/mobile/src/components/search/InteractiveFilterBoard.tsx
@@ -7,18 +7,17 @@ import React, {
   type ReactNode,
   type RefObject,
 } from 'react';
-import { useTranslation } from 'react-i18next';
-import { View, StyleSheet, Pressable } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import Animated, { runOnJS, type SharedValue } from 'react-native-reanimated';
 import { Gesture, GestureDetector, type GestureType } from 'react-native-gesture-handler';
 import type { BoardName, HoldsFilter } from '@boardsesh/shared-schema';
 import { BoardImageNative } from '../BoardImageNative';
-import { Text } from '../Text';
+import { ResetZoomButton } from '../board-controls/ResetZoomButton';
 import { useZoomPanGesture } from '../play-drawer/use-zoom-pan-gesture';
 import { HoldTargetLayer } from '../create-climb/HoldTargetLayer';
 import { holdGeometry, buildHoldHitTargets, resolveHoldAtPoint } from '../create-climb/holdLayout';
 import { useZoomedHoldTapGesture, PAN_ACTIVATION_OFFSET } from '../create-climb/use-zoomed-hold-tap-gesture';
-import { overlays } from '../../theme/tokens';
+import { spacing } from '../../theme/tokens';
 import type { BoardHoldTarget } from '../../lib/create-board-holds';
 import { SearchHoldFilterRings } from './SearchHoldFilterRings';
 
@@ -158,7 +157,6 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
   renderAboveBoard,
   controlRef,
 }: InteractiveFilterBoardProps) {
-  const { t } = useTranslation('common');
   // Shared with the per-hold detectors and the rest/zoom tap overlays so they
   // mark themselves simultaneous with the pinch — same Android pinch-stall fix
   // as the create board (two fingers on two hold targets must not block pinch).
@@ -359,6 +357,11 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
                     this gesture is its ancestor and a declined touch falls
                     through to the pan / zoomed hold taps. See the prop's doc. */}
                 {renderAboveBoard ? renderAboveBoard(transformContext) : null}
+                {/* Nested for the same reason, and rendered after so it wins its
+                    own taps: it sits in the corner the panning thumb rests in,
+                    and as a sibling above the overlay it would be a dead zone
+                    for panning. */}
+                <ResetZoomButton visible onPress={resetZoom} style={styles.resetZoom} />
               </View>
             </GestureDetector>
           ) : null}
@@ -374,17 +377,10 @@ export const InteractiveFilterBoard = React.memo(function InteractiveFilterBoard
           ) : null}
 
           {/* At rest there is no pan overlay to nest inside, so the above-board
-              overlay renders as a sibling here — before the reset-zoom button so
-              that button still wins its own touches. */}
+              overlay renders as a sibling here. The reset-zoom control is no
+              longer one of its neighbours — it moved off the board entirely
+              (#5113); the route renders it below the board via `controlRef`. */}
           {!isZoomed && renderAboveBoard ? renderAboveBoard(transformContext) : null}
-
-          {isZoomed ? (
-            <Pressable style={styles.resetButton} onPress={resetZoom} hitSlop={8} accessibilityRole="button">
-              <Text variant="footnote" style={styles.resetLabel}>
-                {t('board.resetZoom')}
-              </Text>
-            </Pressable>
-          ) : null}
         </View>
       </GestureDetector>
     </View>
@@ -407,16 +403,9 @@ const styles = StyleSheet.create({
     position: 'absolute',
     borderColor: '#FFFFFF',
   },
-  resetButton: {
-    position: 'absolute',
-    top: 12,
-    right: 12,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 16,
-    backgroundColor: overlays.scrim,
-  },
-  resetLabel: {
-    color: overlays.onScrim,
+  // Bottom-right, matching every other board. See ResetZoomButton.
+  resetZoom: {
+    right: spacing[2],
+    bottom: spacing[2],
   },
 });

--- a/packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx
+++ b/packages/mobile/src/components/search/__tests__/interactive-filter-board.test.tsx
@@ -36,6 +36,11 @@ vi.mock('react-native-reanimated', () => ({
   runOnJS: (handler: (...args: unknown[]) => unknown) => handler,
 }));
 
+vi.mock('../../board-controls/ResetZoomButton', () => ({
+  ResetZoomButton: ({ onPress }: { onPress?: () => void }) =>
+    createElement('button', { 'data-reset-zoom': 'true', onClick: onPress }),
+}));
+
 vi.mock('react-native-gesture-handler', () => {
   const createGesture = () => {
     const gesture = {
@@ -126,13 +131,14 @@ vi.mock('../../create-climb/HoldTargetLayer', () => ({
 
 vi.mock('../../../theme/tokens', () => ({
   overlays: { scrim: 'rgba(0,0,0,0.6)', onScrim: '#FFF' },
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16 },
 }));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-import { InteractiveFilterBoard } from '../InteractiveFilterBoard';
+import { InteractiveFilterBoard, type FilterBoardControls } from '../InteractiveFilterBoard';
 
 const holdTargets: BoardHoldTarget[] = [
   { id: 10, cx: 100, cy: 100, r: 20 },
@@ -144,6 +150,7 @@ type Overrides = {
   activeHoldId?: number | null;
   onHoldTap?: (id: number) => void;
   showHoldMarkers?: boolean;
+  controlRef?: { current: FilterBoardControls | null };
 };
 
 function renderBoard(overrides: Overrides = {}) {
@@ -163,6 +170,7 @@ function renderBoard(overrides: Overrides = {}) {
       showHoldMarkers={overrides.showHoldMarkers}
       renderWidth={400}
       renderHeight={500}
+      controlRef={overrides.controlRef}
     />,
   );
   return { ...result, onHoldTap };
@@ -197,19 +205,27 @@ describe('InteractiveFilterBoard', () => {
     expect(container.querySelectorAll('[data-hold-id]').length).toBe(holdTargets.length);
   });
 
-  it('hides the pan overlay and reset button while not zoomed', () => {
+  it('shows no reset control while not zoomed', () => {
     const { container } = renderBoard();
-    // Only the active-hold chrome would add a Pressable; with no zoom and no
-    // active hold there is no reset button.
-    expect(container.querySelectorAll('[data-pressable="true"]').length).toBe(0);
+    expect(container.querySelector('[data-reset-zoom="true"]')).toBeNull();
   });
 
-  it('shows a reset button that calls resetZoom while zoomed', () => {
+  it('shows one while zoomed, and pressing it resets', () => {
+    // It lives INSIDE the pan overlay so a drag starting on it still pans the
+    // board — the corner it sits in is where the panning thumb rests.
     zoomState.isZoomed = true;
     const { container } = renderBoard();
-    const resetButton = container.querySelector('[data-pressable="true"]') as HTMLButtonElement;
-    expect(resetButton).not.toBeNull();
-    fireEvent.click(resetButton);
+    const control = container.querySelector('[data-reset-zoom="true"]') as HTMLButtonElement;
+    expect(control).toBeTruthy();
+
+    control.click();
+    expect(zoomState.resetZoom).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes resetZoom through controlRef for callers that drive the zoom', () => {
+    const controlRef = { current: null as FilterBoardControls | null };
+    renderBoard({ controlRef });
+    controlRef.current?.resetZoom();
     expect(zoomState.resetZoom).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/mobile/src/lib/__tests__/board-render-settings.test.ts
+++ b/packages/mobile/src/lib/__tests__/board-render-settings.test.ts
@@ -264,7 +264,7 @@ describe('resolveEffectiveRenderSettings', () => {
 });
 
 describe('the editing-surface veil', () => {
-  it('is off — an editing board gets Aura\'s glow on an unwashed wall', () => {
+  it("is off — an editing board gets Aura's glow on an unwashed wall", () => {
     expect(EDITING_VEIL_OPACITY).toBe(VEIL_SETTING_OPACITY.off);
     expect(EDITING_VEIL_OPACITY).toBe(0);
   });

--- a/packages/mobile/src/lib/__tests__/reset-zoom-hint.test.ts
+++ b/packages/mobile/src/lib/__tests__/reset-zoom-hint.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const store = vi.hoisted(() => ({
+  get: vi.fn<(key: string) => Promise<unknown>>(),
+  set: vi.fn<(key: string, value: unknown) => Promise<void>>(),
+}));
+
+vi.mock('../preference-store', () => ({
+  getPreference: store.get,
+  setPreference: store.set,
+  removePreference: vi.fn(),
+}));
+
+import { hasUsedResetZoom, markResetZoomUsed } from '../reset-zoom-hint';
+
+describe('reset-zoom hint marker', () => {
+  beforeEach(() => {
+    store.get.mockReset();
+    store.set.mockReset();
+    vi.unstubAllEnvs();
+  });
+
+  it('treats a fresh device as never having used the control', async () => {
+    store.get.mockResolvedValue(null);
+    expect(await hasUsedResetZoom()).toBe(false);
+  });
+
+  it('reads a store failure as already used', async () => {
+    // The fail-safe direction matters: the hint covers holds, so a flaky store
+    // must not bring it back on every zoom. Better a missing hint than a
+    // permanent one.
+    store.get.mockRejectedValue(new Error('store unavailable'));
+    expect(await hasUsedResetZoom()).toBe(true);
+  });
+
+  it('reports used only for an exact true', async () => {
+    store.get.mockResolvedValue('true');
+    expect(await hasUsedResetZoom()).toBe(false);
+  });
+
+  it('suppresses the hint in screenshot mode', async () => {
+    // A captured board must never carry the extended pill across it.
+    vi.stubEnv('EXPO_PUBLIC_SCREENSHOT_MODE', '1');
+    expect(await hasUsedResetZoom()).toBe(true);
+    expect(store.get).not.toHaveBeenCalled();
+  });
+
+  it('writes the marker under a stable key', async () => {
+    await markResetZoomUsed();
+    expect(store.set).toHaveBeenCalledWith('resetZoomHintUsed', true);
+  });
+});

--- a/packages/mobile/src/lib/reset-zoom-hint.ts
+++ b/packages/mobile/src/lib/reset-zoom-hint.ts
@@ -1,0 +1,46 @@
+import { getPreference, removePreference, setPreference } from './preference-store';
+
+/**
+ * Whether this device has ever used the board's reset-zoom control.
+ *
+ * The control is a bare glyph, and a viewfinder is not an established "reset
+ * zoom" idiom, so it extends to show its label while zoomed — but only until it
+ * has been used once. After that the climber knows what it is and the label is
+ * just something covering holds, which is the bug the whole change is about
+ * (#5113).
+ *
+ * AsyncStorage rather than SecureStore, for the same reason as
+ * `boardLookStepSeen`: this is a device-local UI marker, and on iOS the keychain
+ * survives an uninstall while the app sandbox does not — a marker kept there
+ * would silently suppress the hint for a reinstalled app.
+ */
+const STORAGE_KEY = 'resetZoomHintUsed';
+
+/**
+ * Errors read as "already used", matching `hasSeenBoardLookStep`: a flaky store
+ * must not turn a one-shot hint into one that reappears on every zoom, which is
+ * exactly the nagging the hint exists to avoid.
+ */
+export async function hasUsedResetZoom(): Promise<boolean> {
+  // Screenshot mode reports used, so a captured board is never covered by the
+  // extended pill. Mirrors `hasSeenBoardLookStep`.
+  if (process.env.EXPO_PUBLIC_SCREENSHOT_MODE === '1') return true;
+  try {
+    return (await getPreference<boolean>(STORAGE_KEY)) === true;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Written when the control is PRESSED, never when the label merely appears.
+ * Seeing the hint is not learning it — a climber who zooms, reads the label and
+ * pans away still has not connected the glyph to the action.
+ */
+export async function markResetZoomUsed(): Promise<void> {
+  await setPreference(STORAGE_KEY, true);
+}
+
+export async function clearResetZoomUsed(): Promise<void> {
+  await removePreference(STORAGE_KEY);
+}


### PR DESCRIPTION
## Summary

The "Reset zoom" pill floated at the board's **top**-right while zoomed — exactly when you're zoomed in to paint holds. With its `hitSlop` its touch rect spanned ~108×46dp and covered **14 hold centres**, six of them fully hidden. Those holds rendered fine; they just couldn't be tapped.

It now sits **bottom-right on the board**, as a 32dp glyph — small enough not to be in the way, and in the corner nearest the thumb.

Because an icon alone doesn't say "reset zoom" (a viewfinder isn't an established idiom for it), the button introduces itself: every time the board goes zoomed it extends to show the label for three seconds, then collapses to the glyph. That keeps the wording without the permanent footprint that caused the bug — and keeps the resting size locale-invariant, which matters because German ("Zoom zurücksetzen") is a ~120dp pill.

One shared `ResetZoomButton` now serves every zoomable board, replacing three copies that had already drifted apart (two had no icon and no fade):

| Surface | Before | After |
|---|---|---|
| Create climb | text pill, top-right, **14 hold centres blocked** | 32dp glyph, bottom-right |
| Search hold filter | same pill, same bug | same fix |
| Zone filter | same pill | same fix |
| Outline editor | same pill | same fix |
| Play drawer | icon + label, top-right | same control, bottom-right |

Because it lives in `InteractiveCreateBoard` / `InteractiveFilterBoard`, the zone filter and outline editor get it from the shared board instead of each wiring their own.

### Two things worth a look in review

**It's a child of the zoomed pan overlay, not a sibling above it.** RNGH offers a touch to the handlers on the touched view *and its ancestors*, so nesting is what keeps a drag that starts on the button panning the board. As a sibling it would turn the corner the panning thumb rests in into a 32dp dead zone. Same reasoning `renderAboveBoard` already documents.

**A pre-existing sheet bug fixed along the way.** `CreateDrawer` has long claimed the draft-status row "reserves its height even when empty, so this doesn't drift as you paint". It didn't: Yoga measures `minHeight` against the border box, so a floor of `RESERVED_LINE_HEIGHT` was already satisfied by the row's own 16dp of padding. The row stood **16dp empty and 32dp with text**, and that step landed on the first painted hold — moving `peekHeight` and re-snapping the sheet. Anyone who noticed the create sheet jolting when they placed their first hold was seeing this. Floored at padding + line, pinned by a test.

Also adds the auto-resets the create board was missing — frame change, New Climb, draft load — which the sibling surfaces already did. Keyed on a `blankClimbEpoch` the controller bumps only when a blank climb actually starts, so tapping New Climb and then cancelling the confirmation keeps your zoom.

Closes #5113

## Release Notes

- Zoom into the board to set a climb and the "Reset zoom" button no longer sits on your holds — it's a small button in the bottom right now, closer to your thumb. It shows its label for a moment each time you zoom, then gets out of the way.
- The zone filter and outline editor got that button too; before, zooming in there left you no way back out.
- Zoom snaps back on its own when you switch frames or start a new climb.
- The create sheet no longer jumps when you place your first hold.

## Test plan

1. Create → pinch to zoom the board.
2. Bottom right: label shows ~3s, then shrinks to an icon.
3. Tap a hold behind where the label was — it paints.
4. Drag from the button — the board pans, doesn't stick.
5. Zoom, tap New Climb, cancel — your zoom survives.

## Risk

Risk: 2/5 — isolated mobile UI across the board surfaces, covered by tests. No BLE, data writes or native config touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShUNQ8oRa3wkQ7vZSEa81v
