### PR TITLE
feat: show Woods rules and enable climb authoring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ Boardsesh is a monorepo. Next.js 16 web app + React Native (Expo) mobile app for
 - No AI-generated images. Real photos or diagrams only.
 - No buzzwords. Concrete numbers, plain language.
 - Default to action. Full autonomy except no data deletion without asking.
-- **Bluetooth changes require a Fable review.** Any change touching Bluetooth/BLE code — `packages/shared/ble-protocol/`, `packages/mobile/src/lib/ble/`, `packages/mobile/modules/live-activity/ios/`, or the web Bluetooth LED control in `packages/web` — must be reviewed by Fable before merge.
+- **Bluetooth changes require a Fable or Astra review.** Any change touching Bluetooth/BLE code — `packages/shared/ble-protocol/`, `packages/mobile/src/lib/ble/`, `packages/mobile/modules/live-activity/ios/`, or the web Bluetooth LED control in `packages/web` — must be reviewed by Fable or Astra before merge.
 
 ## PR Lifecycle (mandatory)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Boardsesh is a monorepo. Next.js 16 web app + React Native (Expo) mobile app for
 - No AI-generated images. Real photos or diagrams only.
 - No buzzwords. Concrete numbers, plain language.
 - Default to action. Full autonomy except no data deletion without asking.
-- **Bluetooth changes require a Fable review.** Any change touching Bluetooth/BLE code — `packages/shared/ble-protocol/`, `packages/mobile/src/lib/ble/`, `packages/mobile/modules/live-activity/ios/`, or the web Bluetooth LED control in `packages/web` — must be reviewed by Fable before merge.
+- **Bluetooth changes require a Fable or Astra review.** Any change touching Bluetooth/BLE code — `packages/shared/ble-protocol/`, `packages/mobile/src/lib/ble/`, `packages/mobile/modules/live-activity/ios/`, or the web Bluetooth LED control in `packages/web` — must be reviewed by Fable or Astra before merge.
 
 ## PR Lifecycle (mandatory)
 

--- a/docs/woods-climb-rules.md
+++ b/docs/woods-climb-rules.md
@@ -15,7 +15,11 @@ means the rules have not been imported, so the drawer shows unknown states.
 The importer validates both booleans and refreshes only these two tokens on
 re-import. Other app-authored tokens survive. Aurora catalog sync similarly
 owns only `no_match` and preserves characteristics authored in Boardsesh.
-MoonBoard imports similarly refresh only method tokens.
+MoonBoard imports similarly refresh only method tokens. Published Aurora climbs
+are immutable upstream: sync preserves known rules on Boardsesh-authored
+published climbs. Drafts still accept upstream rule changes, but an unchanged
+description echo cannot undo an explicit matching-allowed choice just because
+the setter's prose begins with "No matching…".
 
 ## Repair existing rows
 
@@ -68,5 +72,5 @@ physical board size. The editor refuses to preview on a different Woods wall,
 and queue sending skips climbs whose recorded physical size differs.
 
 Before enabling authoring in production, complete the repair and test painting,
-saving, reopening, and lighting climbs on both Woods sizes. Fable review is required for Bluetooth changes. Automated geometry and protocol
+saving, reopening, and lighting climbs on both Woods sizes. Fable or Astra review is required for Bluetooth changes. Automated geometry and protocol
 checks do not establish physical LED behavior; verify both walls on hardware.

--- a/docs/woods-climb-rules.md
+++ b/docs/woods-climb-rules.md
@@ -1,0 +1,72 @@
+# Woods climb rules and authoring
+
+Woods catalog problems carry independent `matching` and `anyFeet` booleans. The
+scraper stores both in `woodsboard_8x10.json` and `woodsboard_12x12.json`; no new
+scrape is required to repair the catalog imported before issue #4827.
+
+## Stored rules
+
+`board_climbs.characteristics` is the source of truth, shared by GraphQL, party
+queues, and offline downloads. `matching: false` maps to `no_match`;
+`anyFeet: true` maps to `any_feet`. An empty array on Woods means the rules are
+known: matching is allowed and only marked holds may be used for feet. NULL
+means the rules have not been imported, so the drawer shows unknown states.
+
+The importer validates both booleans and refreshes only these two tokens on
+re-import. Other app-authored tokens survive. Aurora catalog sync similarly
+owns only `no_match` and preserves characteristics authored in Boardsesh.
+MoonBoard imports similarly refresh only method tokens.
+
+## Repair existing rows
+
+Supply the catalog directory and a database connection through the environment.
+The default mode opens a read-only transaction and reports matching, unmatched,
+unchanged, and proposed update counts:
+
+```sh
+vp run db:repair-woods-rules -- /path/to/woodsboard-scraper/catalog
+```
+
+The audited September 2026 snapshot has 5,418 source records, including two
+without holds and 24 duplicate identities, resolving to 5,392 stored climbs.
+All 5,392 UUIDs matched. The reported "Treat yo self" (12×12, 40°) has matching
+allowed and any feet off. A newer catalog or database may produce different
+counts; inspect the dry-run before applying.
+
+With a write-capable connection, apply exactly this repair:
+
+```sh
+WOODS_IMPORT_ALLOW_REMOTE=1 vp run db:repair-woods-rules -- /path/to/woodsboard-scraper/catalog --apply
+```
+
+The remote override is unnecessary for a local database. The read-only
+connection used for investigation cannot apply the repair. The repair only
+updates characteristics on existing imported Woods climbs whose UUID, hold
+frames, and size match. It leaves authored climbs and unmatched records alone,
+rejects conflicting catalog flags, and rolls back on concurrent row changes.
+Re-running an applied repair reports no changes. Existing database triggers
+advance the sync cursor, delivering repaired rules to downloaded boards.
+
+## Authoring and compatibility
+
+New Woods climbs are stored in Boardsesh; there is no upstream Woods publish
+request. Board size is mandatory and immutable because the two physical sizes
+reuse hold numbers at different positions. Creation uses existing geometry and
+Woods role codes, one static frame, and normal ownership/edit-window rules.
+
+New clients send explicit `noMatch` and `anyFeet` booleans. Omission preserves
+the existing rule on update. The older characteristics input continues to own
+only campus and no-kickboard, so an old client cannot clear any-feet by sending
+an empty list. Backend support must ship before clients send the new fields.
+
+Woods displays both rules in the drawer. Campus and any-feet are incompatible;
+kickboard restrictions remain independent. Fork navigation carries structured
+characteristics rather than reconstructing them from description text. Rules
+participate in duplicate detection, so changing rules can produce a distinct
+climb with identical holds. Woods duplicates and similar climbs are scoped to
+physical board size. The editor refuses to preview on a different Woods wall,
+and queue sending skips climbs whose recorded physical size differs.
+
+Before enabling authoring in production, complete the repair and test painting,
+saving, reopening, and lighting climbs on both Woods sizes. Fable review is required for Bluetooth changes. Automated geometry and protocol
+checks do not establish physical LED behavior; verify both walls on hardware.

--- a/packages/aurora-sync/src/sync/index.ts
+++ b/packages/aurora-sync/src/sync/index.ts
@@ -1,6 +1,6 @@
 export { syncUserData, getLastSyncTimes, getLastSharedSyncTimes } from './user-sync';
 export type { SyncUserDataResult } from './user-sync';
-export { syncSharedData, createSetterSyncNotifications } from './shared-sync';
+export { syncSharedData, createSetterSyncNotifications, climbCharacteristicsConflictSql } from './shared-sync';
 export type { SharedSyncResult, NewClimbInfo } from './shared-sync';
 export {
   AURORA_LOCATION_BOARDS,

--- a/packages/aurora-sync/src/sync/json-import.ts
+++ b/packages/aurora-sync/src/sync/json-import.ts
@@ -20,6 +20,7 @@ import {
   normalizePlaylistColor,
 } from '@boardsesh/shared-schema';
 import {
+  mergeCatalogCharacteristicsSql,
   populateDenormalizedColumns,
   recomputeClimbStatsBulk,
   foreignPlaylistOwnerGuard,
@@ -1321,7 +1322,11 @@ export async function importJsonExportData(
                 name: sql`excluded.name`,
                 setterUsername: sql`excluded.setter_username`,
                 description: sql`excluded.description`,
-                characteristics: sql`excluded.characteristics`,
+                characteristics: mergeCatalogCharacteristicsSql(
+                  boardClimbs.characteristics,
+                  sql`excluded.characteristics`,
+                  [CLIMB_CHARACTERISTICS.NO_MATCH],
+                ),
                 frames: sql`excluded.frames`,
                 isDraft: sql`excluded.is_draft`,
                 isListed: sql`excluded.is_listed`,

--- a/packages/aurora-sync/src/sync/shared-sync.test.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.test.ts
@@ -993,6 +993,25 @@ describe('climb conflict policies (SQL)', () => {
   const dialect = new PgDialect();
   const render = (fragment: Parameters<typeof dialect.sqlToQuery>[0]) => dialect.sqlToQuery(fragment).sql.toLowerCase();
 
+  it('uses the authored-rule guard on actual shared-sync climb writes', async () => {
+    mockSharedSync.mockReset();
+    shimConflictSets.length = 0;
+    mockSharedSync.mockResolvedValueOnce(
+      complete({
+        climbs: [{ uuid: 'RULE-ECHO', frames: '', layout_id: 1, description: 'No matching hands' }],
+      } as Partial<SyncData>),
+    );
+    await syncSharedData(fakePostgresClient(), 'kilter', 'token');
+    const [climbConflict] = shimConflictSets.filter((set) => 'characteristics' in set) as Array<Record<string, SQL>>;
+    expect(climbConflict).toBeDefined();
+    const ruleSql = render(climbConflict.characteristics);
+    expect(ruleSql).toContain('"user_id" is not null');
+    expect(ruleSql).toContain('"characteristics" is not null');
+    expect(ruleSql).toContain('"is_draft" is false');
+    expect(ruleSql).toContain('is not distinct from excluded.description');
+    expect(ruleSql).toContain('excluded.characteristics');
+  });
+
   it('is_listed / is_draft: verbatim from Aurora for non-user climbs, preserved for user climbs', () => {
     const { isListed, isDraft } = climbListingConflictSet();
     const listedSql = render(isListed);

--- a/packages/aurora-sync/src/sync/shared-sync.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.ts
@@ -26,6 +26,7 @@ import { UNIFIED_TABLES } from '../db/table-select';
 import { normalizeQualityTo5, isNoMatchClimb, CLIMB_CHARACTERISTICS } from '@boardsesh/shared-schema';
 import { convertLitUpHoldsStringToMap, isSentinelHoldState } from '@boardsesh/board-constants/hold-states';
 import {
+  mergeCatalogCharacteristicsSql,
   populateDenormalizedColumns,
   blendedQualityAverageSql,
   setterSyncNotificationUuid,
@@ -747,8 +748,8 @@ async function upsertClimbs(db: DrizzleDb, board: AuroraBoardName, data: Climb[]
           createdAt: item.created_at,
           angle: item.angle,
           // Derive the structured no_match characteristic from Aurora's "No match"
-          // description convention on ingest. Aurora boards carry no other
-          // characteristic, so the array is fully determined by the description.
+          // description convention on ingest. Other stored rules are preserved
+          // by the conflict merge below.
           characteristics: isNoMatchClimb(item.description) ? [CLIMB_CHARACTERISTICS.NO_MATCH] : null,
         })),
       )
@@ -762,7 +763,11 @@ async function upsertClimbs(db: DrizzleDb, board: AuroraBoardName, data: Climb[]
           description: sql`excluded.description`,
           // Description is overwritten from excluded, so keep the derived
           // characteristic in sync with it (handles remote no-match toggles).
-          characteristics: sql`excluded.characteristics`,
+          characteristics: mergeCatalogCharacteristicsSql(
+            UNIFIED_TABLES.climbs.characteristics,
+            sql`excluded.characteristics`,
+            [CLIMB_CHARACTERISTICS.NO_MATCH],
+          ),
         },
       });
   });

--- a/packages/aurora-sync/src/sync/shared-sync.ts
+++ b/packages/aurora-sync/src/sync/shared-sync.ts
@@ -114,6 +114,26 @@ export function climbListingConflictSet() {
   };
 }
 
+/** Preserve explicit authoring rules across Aurora's description-only wire format. */
+export function climbCharacteristicsConflictSql() {
+  const climbsSchema = UNIFIED_TABLES.climbs;
+  const refreshed = mergeCatalogCharacteristicsSql(climbsSchema.characteristics, sql`excluded.characteristics`, [
+    CLIMB_CHARACTERISTICS.NO_MATCH,
+  ]);
+  // Published Aurora climbs are immutable. Their first echo may add a wire
+  // prefix, but must not reinterpret the rules explicitly saved in Boardsesh.
+  // Drafts can change upstream; preserve explicit false only on an unchanged
+  // echo, where the legacy fuzzy parser could mistake setter prose for a rule.
+  return sql`CASE WHEN ${climbsSchema.userId} IS NOT NULL
+    AND ${climbsSchema.characteristics} IS NOT NULL
+    AND (${climbsSchema.isDraft} IS FALSE OR (
+      ${climbsSchema.description} IS NOT DISTINCT FROM excluded.description
+      AND NOT (${CLIMB_CHARACTERISTICS.NO_MATCH} = ANY(${climbsSchema.characteristics}))
+    ))
+    THEN ${climbsSchema.characteristics}
+    ELSE ${refreshed} END`;
+}
+
 /**
  * Conflict policy for board_climb_stats upstream/total ascent counts on the
  * Aurora shared sync. Takes the incoming (cursored) upstream count verbatim —
@@ -761,13 +781,7 @@ async function upsertClimbs(db: DrizzleDb, board: AuroraBoardName, data: Climb[]
           ...climbListingConflictSet(),
           name: sql`excluded.name`,
           description: sql`excluded.description`,
-          // Description is overwritten from excluded, so keep the derived
-          // characteristic in sync with it (handles remote no-match toggles).
-          characteristics: mergeCatalogCharacteristicsSql(
-            UNIFIED_TABLES.climbs.characteristics,
-            sql`excluded.characteristics`,
-            [CLIMB_CHARACTERISTICS.NO_MATCH],
-          ),
+          characteristics: climbCharacteristicsConflictSql(),
         },
       });
   });

--- a/packages/backend/src/__tests__/aurora-rule-roundtrip.test.ts
+++ b/packages/backend/src/__tests__/aurora-rule-roundtrip.test.ts
@@ -1,0 +1,98 @@
+import { test, expect } from 'vite-plus/test';
+import { sql, eq } from 'drizzle-orm';
+import { pgTable, text, boolean } from 'drizzle-orm/pg-core';
+import { climbCharacteristicsConflictSql } from '@boardsesh/aurora-sync/sync';
+import { isNoMatchClimb, withNoMatch } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+
+const temporaryClimbs = pgTable('board_climbs', {
+  uuid: text().primaryKey(),
+  userId: text('user_id'),
+  description: text(),
+  characteristics: text().array(),
+  isDraft: boolean('is_draft'),
+});
+
+test('Aurora round trips preserve explicit false without freezing upstream rule changes', async () => {
+  const prose = 'No matching hands';
+  const cases = [
+    { before: [], description: prose, incoming: withNoMatch(prose, false), expected: [], authored: true },
+    {
+      before: ['any_feet', 'no_kickboard'],
+      description: prose,
+      incoming: prose,
+      expected: ['any_feet', 'no_kickboard'],
+      authored: true,
+    },
+    { before: [], description: prose, incoming: `No match\n${prose}`, expected: ['no_match'], authored: true },
+    { before: ['no_match'], description: 'Beta', incoming: 'Beta', expected: null, authored: true },
+    {
+      before: ['no_match', 'no_kickboard'],
+      description: 'No match\nBeta',
+      incoming: 'Beta',
+      expected: ['no_kickboard'],
+      authored: true,
+    },
+    { before: [], description: 'Beta', incoming: prose, expected: ['no_match'], authored: true },
+    { before: null, description: prose, incoming: prose, expected: ['no_match'], authored: true },
+    { before: [], description: prose, incoming: prose, expected: ['no_match'], authored: false },
+    // Published Aurora climbs are immutable: first sync may add the wire
+    // prefix, but the explicit Boardsesh rules must remain authoritative.
+    { before: [], description: prose, incoming: prose, expected: [], authored: true, published: true },
+    {
+      before: ['no_match', 'any_feet'],
+      description: prose,
+      incoming: `No match\n${prose}`,
+      expected: ['no_match', 'any_feet'],
+      authored: true,
+      published: true,
+    },
+    {
+      before: ['no_match'],
+      description: 'Beta',
+      incoming: 'Beta',
+      expected: ['no_match'],
+      authored: true,
+      published: true,
+    },
+    { before: null, description: prose, incoming: prose, expected: ['no_match'], authored: true, published: true },
+    { before: [], description: prose, incoming: prose, expected: ['no_match'], authored: false, published: true },
+  ];
+  await db.transaction(async (transaction) => {
+    await transaction.execute(sql`CREATE TEMP TABLE board_climbs (
+      uuid text PRIMARY KEY, user_id text, description text, characteristics text[], is_draft boolean
+    ) ON COMMIT DROP`);
+
+    for (const [index, example] of cases.entries()) {
+      const uuid = `aurora-rules-${index}`;
+      await transaction.insert(temporaryClimbs).values({
+        uuid,
+        userId: example.authored ? 'author' : null,
+        description: example.description,
+        characteristics: example.before,
+        isDraft: !example.published,
+      });
+      // Repeating the actual conflict expression catches [] becoming NULL on
+      // the first echo, then being reinterpreted as no_match on the second.
+      for (let pass = 0; pass < 2; pass++) {
+        await transaction
+          .insert(temporaryClimbs)
+          .values({
+            uuid,
+            description: example.incoming,
+            characteristics: isNoMatchClimb(example.incoming) ? ['no_match'] : null,
+          })
+          .onConflictDoUpdate({
+            target: temporaryClimbs.uuid,
+            set: {
+              description: sql`excluded.description`,
+              characteristics: climbCharacteristicsConflictSql(),
+            },
+          });
+        const [saved] = await transaction.select().from(temporaryClimbs).where(eq(temporaryClimbs.uuid, uuid));
+        expect(saved.characteristics, `case ${index}, sync ${pass}`).toEqual(example.expected);
+        expect(saved.description).toBe(example.incoming);
+      }
+    }
+  });
+});

--- a/packages/backend/src/__tests__/climb-mutations.test.ts
+++ b/packages/backend/src/__tests__/climb-mutations.test.ts
@@ -1431,6 +1431,453 @@ describe('climb mutations', () => {
     expect(mockPublishSocialEvent).not.toHaveBeenCalled();
   });
 
+  // -----------------------------------------------------------------------
+  // Rule flags: no_match and any_feet ride their own booleans rather than the
+  // `characteristics` array, so an old client that has never heard of them
+  // cannot clear one by sending the array it does know about.
+  // -----------------------------------------------------------------------
+
+  function mockCreateChain() {
+    mockDb.execute.mockResolvedValueOnce([]);
+    mockDb.select.mockReturnValueOnce(
+      createMockChain([{ name: 'Alice', displayName: 'Alice Setter', image: null, avatarUrl: null }]),
+    );
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+  }
+
+  function auroraSaveInput(overrides: Record<string, unknown> = {}) {
+    return {
+      boardType: 'kilter',
+      layoutId: 1,
+      name: 'Rule Flag Climb',
+      description: '',
+      isDraft: false,
+      frames: 'p1r43',
+      angle: 40,
+      ...overrides,
+    };
+  }
+
+  it('saveClimb stores an explicit noMatch flag', async () => {
+    mockCreateChain();
+    await climbMutations.saveClimb({}, { input: auroraSaveInput({ noMatch: true }) }, makeCtx());
+    expect(insertCalls[0].values).toMatchObject({ characteristics: ['no_match'] });
+  });
+
+  it('saveClimb lets an explicit noMatch:false beat the legacy description prefix', async () => {
+    mockCreateChain();
+    await climbMutations.saveClimb(
+      {},
+      { input: auroraSaveInput({ description: 'No match\nbeta', noMatch: false }) },
+      makeCtx(),
+    );
+    const stored = insertCalls[0].values as { characteristics: string[] | null; description: string };
+    expect(stored.characteristics).toBeNull();
+    expect(stored.description).toBe('beta');
+  });
+
+  it('saveClimb still derives no_match from the description when the flag is absent (old client)', async () => {
+    mockCreateChain();
+    await climbMutations.saveClimb({}, { input: auroraSaveInput({ description: 'No match\nbeta' }) }, makeCtx());
+    expect(insertCalls[0].values).toMatchObject({ characteristics: ['no_match'] });
+  });
+
+  it('saveClimb stores anyFeet alongside a toggleable characteristic', async () => {
+    mockCreateChain();
+    await climbMutations.saveClimb(
+      {},
+      { input: auroraSaveInput({ anyFeet: true, characteristics: ['no_kickboard'] }) },
+      makeCtx(),
+    );
+    const stored = insertCalls[0].values as { characteristics: string[] };
+    expect([...stored.characteristics].sort()).toEqual(['any_feet', 'no_kickboard']);
+  });
+
+  it('saveClimb rejects anyFeet combined with campus', async () => {
+    await expect(
+      climbMutations.saveClimb(
+        {},
+        { input: auroraSaveInput({ anyFeet: true, characteristics: ['campus'] }) },
+        makeCtx(),
+      ),
+    ).rejects.toThrow(/"any_feet" cannot be combined with "campus"/);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it('saveClimb accepts anyFeet with no_kickboard — "any hold but the kickboard" is a real rule', async () => {
+    mockCreateChain();
+    await expect(
+      climbMutations.saveClimb(
+        {},
+        { input: auroraSaveInput({ anyFeet: true, characteristics: ['no_kickboard'] }) },
+        makeCtx(),
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  function makeExistingRow(overrides: Record<string, unknown> = {}) {
+    return {
+      uuid: 'climb-flags',
+      userId: 'user-123',
+      isDraft: true,
+      publishedAt: null,
+      createdAt: '2026-05-14T20:00:00.000Z',
+      angle: 35,
+      layoutId: 8,
+      // Real Kilter role codes (12 = STARTING, 15 = FOOT). A code the board's
+      // HOLD_STATE_MAP doesn't know is dropped by the frames parser, which would
+      // leave an empty hold signature and silently disable the duplicate gate.
+      frames: 'p1117r12p1140r15',
+      framesCount: 1,
+      setterUsername: 'Alice Setter',
+      characteristics: null,
+      description: '',
+      compatibleSizeIds: null,
+      ...overrides,
+    };
+  }
+
+  function mockUpdateChain(existing: Record<string, unknown>): { get: () => Record<string, unknown> | undefined } {
+    let updateSet: Record<string, unknown> | undefined;
+    mockDb.select.mockReturnValueOnce(createMockChain([existing]));
+    const updateChain: Record<string, unknown> = {
+      set: vi.fn((values: Record<string, unknown>) => {
+        updateSet = values;
+        return updateChain;
+      }),
+      where: vi.fn(() => updateChain),
+    };
+    mockDb.update = vi.fn().mockReturnValue(updateChain);
+    mockDb.delete.mockReturnValue(createMockChain(undefined));
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+    return { get: () => updateSet };
+  }
+
+  it('updateClimb leaves the new flags alone when an old client omits them', async () => {
+    // The regression this guards: an old build sends only `characteristics`, the
+    // full desired state of the two toggles it knows about. If no_match/any_feet
+    // were merged into that list, every save from that build would silently clear
+    // both.
+    const captured = mockUpdateChain(makeExistingRow({ characteristics: ['no_match', 'any_feet', 'campus'] }));
+
+    await climbMutations.updateClimb(
+      {},
+      { input: { boardType: 'kilter', uuid: 'climb-flags', characteristics: ['no_kickboard'] } },
+      makeCtx(),
+    );
+
+    expect((captured.get()?.characteristics as string[]).sort()).toEqual(['any_feet', 'no_kickboard', 'no_match']);
+  });
+
+  it('updateClimb clears a flag only when the client says so explicitly', async () => {
+    const captured = mockUpdateChain(makeExistingRow({ characteristics: ['no_match', 'any_feet'] }));
+
+    await climbMutations.updateClimb(
+      {},
+      { input: { boardType: 'kilter', uuid: 'climb-flags', noMatch: false } },
+      makeCtx(),
+    );
+
+    expect(captured.get()?.characteristics).toEqual(['any_feet']);
+  });
+
+  it('updateClimb treats an explicit null flag as "leave it alone", not "turn it off"', async () => {
+    const captured = mockUpdateChain(makeExistingRow({ characteristics: ['no_match', 'any_feet'] }));
+
+    await climbMutations.updateClimb(
+      {},
+      { input: { boardType: 'kilter', uuid: 'climb-flags', noMatch: null, anyFeet: null, name: 'Renamed' } },
+      makeCtx(),
+    );
+
+    // Nothing touched the rules, so the column is not in the update set at all.
+    expect(captured.get()).not.toHaveProperty('characteristics');
+  });
+
+  it('updateClimb lets an explicit noMatch beat the description in the same call', async () => {
+    const captured = mockUpdateChain(makeExistingRow());
+
+    await climbMutations.updateClimb(
+      {},
+      { input: { boardType: 'kilter', uuid: 'climb-flags', description: 'No match\nbeta', noMatch: false } },
+      makeCtx(),
+    );
+
+    expect(captured.get()?.characteristics).toBeNull();
+    expect(captured.get()?.description).toBe('beta');
+  });
+
+  it('updateClimb carries a legacy description-derived no_match into the first explicit array it writes', async () => {
+    // characteristics IS NULL + a "No match" description is the un-backfilled
+    // shape. Turning on any_feet must not be the moment the climb quietly stops
+    // being a no-match climb.
+    const captured = mockUpdateChain(makeExistingRow({ characteristics: null, description: 'No match\nbeta' }));
+
+    await climbMutations.updateClimb(
+      {},
+      { input: { boardType: 'kilter', uuid: 'climb-flags', anyFeet: true } },
+      makeCtx(),
+    );
+
+    expect((captured.get()?.characteristics as string[]).sort()).toEqual(['any_feet', 'no_match']);
+  });
+
+  it('updateClimb rejects anyFeet on a climb already stored as footless', async () => {
+    const captured = mockUpdateChain(makeExistingRow({ boardType: 'moonboard', characteristics: ['method_footless'] }));
+
+    await expect(
+      climbMutations.updateClimb(
+        {},
+        { input: { boardType: 'moonboard', uuid: 'climb-flags', anyFeet: true } },
+        makeCtx(),
+      ),
+    ).rejects.toThrow(/"any_feet" cannot be combined with "method_footless"/);
+    expect(captured.get()).toBeUndefined();
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // Rule variants are distinct climbs, so a rule-only edit is a fork and has
+  // to face the duplicate gate.
+  // -----------------------------------------------------------------------
+
+  it('updateClimb re-runs the duplicate gate on a rule-only edit', async () => {
+    const publishedAt = new Date(Date.now() - 60 * 1000).toISOString();
+    mockUpdateChain(makeExistingRow({ isDraft: false, publishedAt, createdAt: publishedAt, characteristics: [] }));
+    // findExactDuplicateMatch → a no-match version of these holds already exists.
+    mockDb.execute.mockResolvedValueOnce([
+      { uuid: 'twin', name: 'No Match Twin', setter_username: 'somebody', angle: 30 },
+    ]);
+
+    await expect(
+      climbMutations.updateClimb({}, { input: { boardType: 'kilter', uuid: 'climb-flags', noMatch: true } }, makeCtx()),
+    ).rejects.toThrow(/holds already exists/);
+
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('updateClimb skips the gate when an edit leaves the rule signature unchanged', async () => {
+    const publishedAt = new Date(Date.now() - 60 * 1000).toISOString();
+    mockUpdateChain(
+      makeExistingRow({ isDraft: false, publishedAt, createdAt: publishedAt, characteristics: ['no_match'] }),
+    );
+
+    await climbMutations.updateClimb(
+      {},
+      // Re-asserting a flag the row already carries is not a fork.
+      { input: { boardType: 'kilter', uuid: 'climb-flags', noMatch: true } },
+      makeCtx(),
+    );
+
+    expect(mockDb.execute).not.toHaveBeenCalled();
+    expect(mockDb.update).toHaveBeenCalledTimes(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // Woods authoring. The board is code-driven — no placements, no product
+  // sizes — so saveClimb has to write the denormalised columns itself and
+  // validate the shape against the shared geometry tables.
+  // -----------------------------------------------------------------------
+
+  function woodsSaveInput(overrides: Record<string, unknown> = {}) {
+    return {
+      boardType: 'woods',
+      layoutId: 1,
+      sizeId: 2,
+      name: 'Woods Problem',
+      description: '',
+      isDraft: false,
+      // Wire roles: 4 = start, 2 = hand, 3 = finish.
+      frames: 'p10r4p20r2p30r3',
+      angle: 40,
+      ...overrides,
+    };
+  }
+
+  it('saveClimb writes a Woods climb with its size, empty rule set and hold fingerprint', async () => {
+    mockCreateChain();
+
+    const result = await climbMutations.saveClimb({}, { input: woodsSaveInput() }, makeCtx());
+
+    const climbRow = insertCalls[0].values as Record<string, unknown>;
+    expect(climbRow).toMatchObject({
+      boardType: 'woods',
+      layoutId: 1,
+      isDraft: false,
+      isListed: true,
+      // Boardsesh-only: there is no Aurora account to push a Woods climb to, so
+      // `synced: false` would park it as pending forever.
+      synced: true,
+      compatibleSizeIds: [2],
+      // `{} <@ anything` is true, so an empty required-set array can never filter
+      // the climb out; NULL would read as "not backfilled yet" and drop it.
+      requiredSetIds: [],
+    });
+    // `[]` and not NULL: on Woods a NULL characteristics column means "rules
+    // unknown until the catalog repair fills them in".
+    expect(climbRow.characteristics).toEqual([]);
+    expect(climbRow.holdFingerprint).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.synced).toBe(true);
+
+    expect(insertCalls[1].values).toEqual([
+      expect.objectContaining({ boardType: 'woods', holdId: 10, holdState: 'STARTING' }),
+      expect.objectContaining({ boardType: 'woods', holdId: 20, holdState: 'HAND' }),
+      expect.objectContaining({ boardType: 'woods', holdId: 30, holdState: 'FINISH' }),
+    ]);
+    expect(insertCalls[2].values).toMatchObject({ boardType: 'woods', angle: 40, ascensionistCount: 0 });
+  });
+
+  it('saveClimb stores Woods rules as an explicit array', async () => {
+    mockCreateChain();
+    await climbMutations.saveClimb({}, { input: woodsSaveInput({ anyFeet: true, noMatch: true }) }, makeCtx());
+    const stored = insertCalls[0].values as { characteristics: string[] };
+    expect([...stored.characteristics].sort()).toEqual(['any_feet', 'no_match']);
+  });
+
+  it('keeps Woods description prose beginning with No match on save and edit', async () => {
+    mockCreateChain();
+    const description = 'No match for these crimps anywhere else.';
+    await climbMutations.saveClimb({}, { input: woodsSaveInput({ description }) }, makeCtx());
+    expect(insertCalls[0].values).toMatchObject({ description, characteristics: [] });
+    const captured = mockUpdateChain(makeWoodsRow());
+    await climbMutations.updateClimb({}, { input: { boardType: 'woods', uuid: 'woods-1', description } }, makeCtx());
+    expect(captured.get()).toMatchObject({ description });
+  });
+
+  it('explicit matching defaults override Aurora prose when no other rules survive', async () => {
+    mockCreateChain();
+    const description = 'No matching hands';
+    await climbMutations.saveClimb(
+      {},
+      {
+        input: {
+          boardType: 'kilter',
+          layoutId: 1,
+          name: 'Prose',
+          frames: 'p1r12p2r14',
+          angle: 40,
+          isDraft: true,
+          description,
+          noMatch: false,
+        },
+      },
+      makeCtx(),
+    );
+    expect(insertCalls[0].values).toMatchObject({ description, characteristics: [] });
+    const captured = mockUpdateChain(makeWoodsRow({ characteristics: ['no_match'], description }));
+    await climbMutations.updateClimb(
+      {},
+      { input: { boardType: 'kilter', uuid: 'climb-1', noMatch: false, description } },
+      makeCtx(),
+    );
+    expect(captured.get()).toMatchObject({ description, characteristics: [] });
+  });
+
+  it('saveClimb rejects a Woods climb with no board size', async () => {
+    await expect(
+      climbMutations.saveClimb({}, { input: woodsSaveInput({ sizeId: undefined }) }, makeCtx()),
+    ).rejects.toThrow(/must name the board size/i);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it('saveClimb rejects a Woods angle off the 5 degree grid', async () => {
+    await expect(climbMutations.saveClimb({}, { input: woodsSaveInput({ angle: 42 }) }, makeCtx())).rejects.toThrow(
+      /5° steps/,
+    );
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it('saveClimb rejects a hold that only exists on the other Woods wall', async () => {
+    // Hold 600 is on the 12x12 (0-893) and not on the 8x10 (0-484).
+    await expect(
+      climbMutations.saveClimb({}, { input: woodsSaveInput({ sizeId: 1, frames: 'p600r4p20r2p30r3' }) }, makeCtx()),
+    ).rejects.toThrow(/Hold 600 does not exist on the 8x10/);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it('saveClimb rejects Aurora role codes on a Woods climb', async () => {
+    await expect(
+      climbMutations.saveClimb({}, { input: woodsSaveInput({ frames: 'p10r12p20r13' }) }, makeCtx()),
+    ).rejects.toThrow(/Unknown Woods hold role 12/);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it('saveClimb rejects publishing a Woods climb with no finish hold', async () => {
+    await expect(
+      climbMutations.saveClimb({}, { input: woodsSaveInput({ frames: 'p10r4p20r2' }) }, makeCtx()),
+    ).rejects.toThrow(/needs at least one finish hold/);
+  });
+
+  it('saveClimb allows a Woods draft without a start or finish', async () => {
+    mockCreateChain();
+    await expect(
+      climbMutations.saveClimb({}, { input: woodsSaveInput({ isDraft: true, frames: 'p20r2' }) }, makeCtx()),
+    ).resolves.toBeDefined();
+  });
+
+  function makeWoodsRow(overrides: Record<string, unknown> = {}) {
+    return makeExistingRow({
+      uuid: 'woods-1',
+      layoutId: 1,
+      angle: 40,
+      frames: 'p10r4p20r2p30r3',
+      characteristics: [],
+      compatibleSizeIds: [2],
+      ...overrides,
+    });
+  }
+
+  it('updateClimb refuses to move a Woods climb to the other wall', async () => {
+    mockUpdateChain(makeWoodsRow());
+
+    await expect(
+      climbMutations.updateClimb({}, { input: { boardType: 'woods', uuid: 'woods-1', sizeId: 1 } }, makeCtx()),
+    ).rejects.toThrow(/board size cannot be changed/i);
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('updateClimb validates Woods edits against the STORED size', async () => {
+    // The request names no size; the 8x10 row is what makes hold 600 illegal.
+    mockUpdateChain(makeWoodsRow({ compatibleSizeIds: [1], frames: 'p10r4p20r2p30r3' }));
+
+    await expect(
+      climbMutations.updateClimb(
+        {},
+        { input: { boardType: 'woods', uuid: 'woods-1', frames: 'p600r4p20r2p30r3' } },
+        makeCtx(),
+      ),
+    ).rejects.toThrow(/Hold 600 does not exist on the 8x10/);
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it('updateClimb accepts a Woods edit that agrees with the stored size and refreshes the fingerprint', async () => {
+    const captured = mockUpdateChain(makeWoodsRow());
+
+    await climbMutations.updateClimb(
+      {},
+      { input: { boardType: 'woods', uuid: 'woods-1', sizeId: 2, frames: 'p10r4p25r2p30r3' } },
+      makeCtx(),
+    );
+
+    expect(captured.get()?.frames).toBe('p10r4p25r2p30r3');
+    // A stale fingerprint would describe the climb the user just replaced, and
+    // nothing downstream re-derives it for Woods.
+    expect(captured.get()?.holdFingerprint).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('updateClimb keeps Woods rules as an explicit array when the last rule is turned off', async () => {
+    const captured = mockUpdateChain(makeWoodsRow({ characteristics: ['any_feet'] }));
+
+    await climbMutations.updateClimb({}, { input: { boardType: 'woods', uuid: 'woods-1', anyFeet: false } }, makeCtx());
+
+    // NULL would demote the climb back to "rules unknown".
+    expect(captured.get()?.characteristics).toEqual([]);
+  });
+
   it('deletes an owned draft climb', async () => {
     mockDb.select.mockReturnValueOnce(createMockChain([{ uuid: 'draft-1', userId: 'user-123', isDraft: true }]));
     mockDb.delete.mockReturnValue(createMockChain([{ uuid: 'draft-1' }]));

--- a/packages/backend/src/__tests__/climb-similar-resolver.test.ts
+++ b/packages/backend/src/__tests__/climb-similar-resolver.test.ts
@@ -78,6 +78,25 @@ describe('climbQueries.similarClimbs', () => {
     mockDb.select.mockReset();
   });
 
+  it('looks up Woods physical size from the target climb', async () => {
+    mockDb.select.mockReturnValueOnce(mockSelectChain([{ holdId: 0, holdState: 'STARTING' }]));
+    mockDb.select.mockReturnValueOnce(mockSelectChain([{ frames: 'p0r4', compatibleSizeIds: [2] }]));
+    await climbQueries.similarClimbs(
+      {},
+      { input: { boardType: 'woods', layoutId: 1, climbUuid: 'target' } },
+      makeCtx(),
+    );
+    expect(findSimilarClimbsMock).toHaveBeenCalledWith(expect.objectContaining({ sizeId: 2 }));
+  });
+
+  it('does not compare Woods frames across unknown physical sizes', async () => {
+    parseFramesToHoldEntriesMock.mockReturnValue([{ holdId: 0, holdState: 'STARTING' }]);
+    expect(
+      await climbQueries.similarClimbs({}, { input: { boardType: 'woods', layoutId: 1, frames: 'p0r4' } }, makeCtx()),
+    ).toEqual([]);
+    expect(findSimilarClimbsMock).not.toHaveBeenCalled();
+  });
+
   it('rejects invalid board names before reaching the helper', async () => {
     await expect(
       climbQueries.similarClimbs({}, { input: { boardType: 'not-a-board', layoutId: 1, climbUuid: 'x' } }, makeCtx()),

--- a/packages/backend/src/__tests__/climb-similarity.test.ts
+++ b/packages/backend/src/__tests__/climb-similarity.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import { PgDialect } from 'drizzle-orm/pg-core';
 import type { SQL } from 'drizzle-orm';
 import {
+  acquireDuplicateGateLock,
   buildDuplicateClimbErrorMessage,
   buildHoldSignature,
+  buildStoredRuleSignature,
   CLIMB_DUPLICATE_ERROR_CODE,
   findExactDuplicateMatch,
   findSimilarClimbs,
@@ -150,6 +152,7 @@ describe('findExactDuplicateMatch', () => {
       boardType: 'kilter',
       layoutId: 1,
       signature: '',
+      ruleSignature: '',
     });
     expect(match).toBeNull();
     expect(mockDb.execute).not.toHaveBeenCalled();
@@ -168,6 +171,7 @@ describe('findExactDuplicateMatch', () => {
       boardType: 'kilter',
       layoutId: 1,
       signature: '1117:STARTING,1140:FOOT',
+      ruleSignature: '',
     });
     expect(match).toEqual({
       uuid: 'existing-uuid',
@@ -183,6 +187,7 @@ describe('findExactDuplicateMatch', () => {
       boardType: 'tension',
       layoutId: 8,
       signature: '999:STARTING',
+      ruleSignature: '',
     });
     expect(match).toBeNull();
   });
@@ -193,6 +198,7 @@ describe('findExactDuplicateMatch', () => {
       boardType: 'kilter',
       layoutId: 1,
       signature: '1:STARTING',
+      ruleSignature: '',
     });
     // Render the SQL through Drizzle's public PgDialect rather than walking
     // its internal AST. Without this filter, an existing climb with one extra
@@ -207,23 +213,137 @@ describe('findExactDuplicateMatch', () => {
     }
   });
 
-  it("excludes 'No match' placeholder climbs from the gate via the characteristic", async () => {
-    // "No match" placeholder climbs are not real routes. Without this filter a
-    // real setter typing in the same holds as a placeholder gets a false-positive
-    // duplicate error citing the placeholder. The filter reads the structured
-    // no_match characteristic (backfilled from the Aurora description convention).
+  it('keys the gate on the rule signature instead of excluding no-match climbs', async () => {
+    // The old gate skipped every no_match climb, treating them as Aurora
+    // placeholder rows. Rules are part of the duplicate key now, so a no-match
+    // climb is a real candidate and only collides with another no-match climb on
+    // the same holds — which is the same problem, and should be blocked.
     mockDb.execute.mockResolvedValueOnce([]);
     await findExactDuplicateMatch({
       boardType: 'kilter',
       layoutId: 1,
       signature: '1:STARTING',
+      ruleSignature: 'no_match',
+    });
+    const [query] = mockDb.execute.mock.calls[0];
+    const { sql: rendered, params } = new PgDialect().sqlToQuery(query as SQL);
+    expect(rendered).not.toContain("@> ARRAY['no_match']");
+    expect(params).toContain('no_match');
+    // Byte ordering on both sides — the JS twin sorts by code unit, so the SQL
+    // must not defer to a locale collation that ignores underscores.
+    expect(rendered).toContain('@> ARRAY[');
+    expect(rendered).toContain('<@ ARRAY[');
+  });
+
+  it('keeps the legacy description fallback for rows with no characteristics array yet', async () => {
+    mockDb.execute.mockResolvedValueOnce([]);
+    await findExactDuplicateMatch({
+      boardType: 'kilter',
+      layoutId: 1,
+      signature: '1:STARTING',
+      ruleSignature: '',
     });
     const [query] = mockDb.execute.mock.calls[0];
     const { sql: rendered } = new PgDialect().sqlToQuery(query as SQL);
-    expect(rendered).toContain("@> ARRAY['no_match']");
-    // ...plus the description-prefix fallback for rows synced in the window
-    // between the backfill migration and this code deploy.
     expect(rendered).toContain("LIKE 'no match%'");
+    // Only when there is no array to trust — an explicit `noMatch: false` on a
+    // climb whose description opens with "No matching feet" must stick.
+    expect(rendered).toMatch(/COALESCE\("board_climbs"\."characteristics", CASE WHEN LOWER/);
+  });
+
+  it('drops the description fallback on the code-driven boards', async () => {
+    // On Woods a NULL characteristics column means "rules unknown until the
+    // catalog repair runs", not "no rules the description forgot to mention".
+    mockDb.execute.mockResolvedValueOnce([]);
+    await findExactDuplicateMatch({
+      boardType: 'woods',
+      layoutId: 1,
+      signature: '1:STARTING',
+      ruleSignature: '',
+      sizeId: 2,
+    });
+    const [query] = mockDb.execute.mock.calls[0];
+    const { sql: rendered } = new PgDialect().sqlToQuery(query as SQL);
+    expect(rendered).not.toContain("LIKE 'no match%'");
+  });
+
+  it('scopes the gate to one physical size when a size-scoped board asks for it', async () => {
+    mockDb.execute.mockResolvedValueOnce([]);
+    await findExactDuplicateMatch({
+      boardType: 'woods',
+      layoutId: 1,
+      signature: '300:HAND',
+      ruleSignature: '',
+      sizeId: 1,
+    });
+    const [query] = mockDb.execute.mock.calls[0];
+    const { sql: rendered, params } = new PgDialect().sqlToQuery(query as SQL);
+    expect(rendered).toContain('compatible_size_ids');
+    expect(params).toContain(1);
+  });
+
+  it('leaves the candidate set unscoped when no size is supplied', async () => {
+    // Aurora climbs legitimately fit several product sizes at once; scoping them
+    // to one would hide real duplicates.
+    mockDb.execute.mockResolvedValueOnce([]);
+    await findExactDuplicateMatch({
+      boardType: 'kilter',
+      layoutId: 1,
+      signature: '1:STARTING',
+      ruleSignature: '',
+    });
+    const [query] = mockDb.execute.mock.calls[0];
+    const { sql: rendered } = new PgDialect().sqlToQuery(query as SQL);
+    expect(rendered).not.toContain('compatible_size_ids');
+  });
+});
+
+describe('buildStoredRuleSignature', () => {
+  it('sorts and dedupes the stored tokens', () => {
+    expect(buildStoredRuleSignature('kilter', ['no_match', 'campus', 'campus'], '')).toBe('campus,no_match');
+  });
+
+  it('reads no_match out of the description only when there is no array yet', () => {
+    expect(buildStoredRuleSignature('kilter', null, 'No match\nbeta')).toBe('no_match');
+    // An explicit array is taken at its word, so `noMatch: false` sticks even on
+    // a climb whose prose starts with "No matching…".
+    expect(buildStoredRuleSignature('kilter', [], 'No matching feet allowed')).toBe('');
+  });
+
+  it('never reads the description on the code-driven boards', () => {
+    expect(buildStoredRuleSignature('woods', null, 'no match for the feet here')).toBe('');
+    expect(buildStoredRuleSignature('moonboard', null, 'no match for the feet here')).toBe('');
+  });
+});
+
+describe('acquireDuplicateGateLock', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('takes no lock without a hold signature', async () => {
+    await acquireDuplicateGateLock(mockDb, 'kilter', 1, '', { ruleSignature: '' });
+    expect(mockDb.execute).not.toHaveBeenCalled();
+  });
+
+  it('keys the lock on board, layout, size, rules and holds', async () => {
+    // The lock key has to stay at least as coarse as the gate's WHERE clause. A
+    // FINER key would let two colliding publishes take different locks and both
+    // pass the gate — the exact race the lock exists to close.
+    mockDb.execute.mockResolvedValueOnce([]);
+    await acquireDuplicateGateLock(mockDb, 'woods', 1, '300:HAND', { ruleSignature: 'any_feet', sizeId: 2 });
+    const { params } = new PgDialect().sqlToQuery(mockDb.execute.mock.calls[0][0] as SQL);
+    expect(params).toContain('woods|1|2|any_feet|300:HAND');
+  });
+
+  it('differs between rule variants of the same holds', async () => {
+    mockDb.execute.mockResolvedValue([]);
+    await acquireDuplicateGateLock(mockDb, 'kilter', 1, '1:STARTING', { ruleSignature: '' });
+    await acquireDuplicateGateLock(mockDb, 'kilter', 1, '1:STARTING', { ruleSignature: 'no_match' });
+    const [first, second] = mockDb.execute.mock.calls.map(
+      ([statement]) => new PgDialect().sqlToQuery(statement as SQL).params,
+    );
+    expect(first).not.toEqual(second);
   });
 });
 
@@ -367,6 +487,40 @@ describe('findSimilarClimbs', () => {
     });
     // Two distinct positions despite three input tuples.
     expect(result[0]?.targetHoldCount).toBe(2);
+  });
+
+  it('scopes candidates to one physical size when asked', async () => {
+    // Woods' 8x10 and 12x12 walls both number holds from 0, so hold 300 is a
+    // different hold on each. Without the scope the two walls' catalogues cross-
+    // match at 100% and the similar list is nonsense.
+    mockSimilarClimbRows([]);
+    await findSimilarClimbs({
+      boardType: 'woods',
+      layoutId: 1,
+      holds: [{ holdId: 300, holdState: 'HAND' }],
+      threshold: 0.5,
+      sizeId: 2,
+    });
+    const { sql: rendered, params } = getRenderedSimilarityQuery();
+    expect(rendered).toContain('compatible_size_ids');
+    expect(params).toContain(2);
+  });
+
+  it('leaves candidates unscoped without a size, and no longer hides no-match climbs', async () => {
+    // Discovery similarity is about the holds on the wall, not the rules: the
+    // no-match version of a route is exactly what someone looking at this one
+    // wants to find.
+    mockSimilarClimbRows([]);
+    await findSimilarClimbs({
+      boardType: 'kilter',
+      layoutId: 1,
+      holds: [{ holdId: 1117, holdState: 'STARTING' }],
+      threshold: 0.5,
+    });
+    const { sql: rendered } = getRenderedSimilarityQuery();
+    expect(rendered).not.toContain('compatible_size_ids @>');
+    expect(rendered).not.toContain("@> ARRAY['no_match']");
+    expect(rendered).not.toContain("LIKE 'no match%'");
   });
 
   it('disables parallel workers before running the similarity CTE on the same transaction', async () => {

--- a/packages/backend/src/__tests__/woods-catalog-rule-repair.test.ts
+++ b/packages/backend/src/__tests__/woods-catalog-rule-repair.test.ts
@@ -1,0 +1,129 @@
+import { test, expect } from 'vite-plus/test';
+import { sql, eq } from 'drizzle-orm';
+import { pgTable, text } from 'drizzle-orm/pg-core';
+import { db } from '../db/client';
+import { mergeCatalogCharacteristicsSql, applyWoodsRuleUpdates, type WoodsRuleUpdate } from '@boardsesh/db/queries';
+
+const temporaryClimbs = pgTable('board_climbs', {
+  uuid: text().primaryKey(),
+  boardType: text('board_type'),
+  userId: text('user_id'),
+  frames: text(),
+  characteristics: text().array(),
+});
+
+test('catalog SQL preserves app rules while refreshing upstream flags', async () => {
+  const array = (tokens: string[] | null) =>
+    tokens === null
+      ? sql`NULL::text[]`
+      : sql`ARRAY[${sql.join(
+          tokens.map((token) => sql`${token}`),
+          sql`, `,
+        )}]::text[]`;
+  await db.transaction(
+    async (transaction) => {
+      const cases = [
+        {
+          before: ['no_match', 'any_feet', 'no_kickboard'],
+          incoming: null,
+          managed: ['no_match'],
+          keepEmpty: false,
+          expected: ['any_feet', 'no_kickboard'],
+        },
+        {
+          before: ['campus'],
+          incoming: ['no_match'],
+          managed: ['no_match'],
+          keepEmpty: false,
+          expected: ['campus', 'no_match'],
+        },
+        { before: ['no_match'], incoming: null, managed: ['no_match'], keepEmpty: false, expected: null },
+        { before: null, incoming: [], managed: ['no_match', 'any_feet'], keepEmpty: true, expected: [] },
+        {
+          before: ['no_match', 'any_feet', 'future_rule'],
+          incoming: ['any_feet'],
+          managed: ['no_match', 'any_feet'],
+          keepEmpty: true,
+          expected: ['future_rule', 'any_feet'],
+        },
+        {
+          before: ['method_footless', 'no_kickboard'],
+          incoming: ['method_no_kickboard'],
+          managed: ['method_footless', 'method_footless_kickboard', 'method_no_kickboard'],
+          keepEmpty: false,
+          expected: ['no_kickboard', 'method_no_kickboard'],
+        },
+      ];
+      for (const example of cases) {
+        const expression = mergeCatalogCharacteristicsSql(
+          array(example.before),
+          array(example.incoming),
+          example.managed,
+          example.keepEmpty,
+        );
+        const [row] = await transaction.execute<{ characteristics: string[] | null }>(
+          sql`SELECT ${expression} AS characteristics`,
+        );
+        expect(row.characteristics).toEqual(example.expected);
+      }
+    },
+    { accessMode: 'read only' },
+  );
+});
+
+test('repair batches roll back together and protect authored rows', async () => {
+  await db.transaction(async (transaction) => {
+    // The temporary table shadows the catalog only on this transaction's connection.
+    await transaction.execute(sql`CREATE TEMP TABLE board_climbs (
+      uuid text PRIMARY KEY, board_type text, user_id text, frames text, characteristics text[]
+    ) ON COMMIT DROP`);
+    const updates: WoodsRuleUpdate[] = Array.from({ length: 101 }, (_, index) => ({
+      uuid: `woods-repair-${index}`,
+      frames: 'p1r4p2r3',
+      sizeId: 2,
+      previousCharacteristics: null,
+      characteristics: index % 2 ? ['any_feet'] : [],
+    }));
+    await transaction.insert(temporaryClimbs).values(
+      updates.map((update) => ({
+        uuid: update.uuid,
+        boardType: 'woods',
+        userId: null,
+        frames: update.frames,
+        characteristics: null,
+      })),
+    );
+    const stale = updates.map((update, index) =>
+      index === 100 ? { ...update, previousCharacteristics: ['no_match'] } : update,
+    );
+    await expect(transaction.transaction((savepoint) => applyWoodsRuleUpdates(savepoint, stale))).rejects.toThrow(
+      'changed during repair',
+    );
+    const afterRollback = await transaction.select().from(temporaryClimbs);
+    expect(afterRollback).toHaveLength(101);
+    expect(afterRollback.every((climb) => climb.characteristics === null)).toBe(true);
+
+    await applyWoodsRuleUpdates(transaction, updates);
+    const repaired = await transaction.select().from(temporaryClimbs);
+    const byUuid = new Map(repaired.map((climb) => [climb.uuid, climb]));
+    for (const update of updates) {
+      expect(byUuid.get(update.uuid)?.characteristics).toEqual(update.characteristics);
+      expect(byUuid.get(update.uuid)?.frames).toBe(update.frames);
+    }
+    await transaction
+      .update(temporaryClimbs)
+      .set({ userId: 'author' })
+      .where(eq(temporaryClimbs.uuid, updates[0].uuid));
+    await expect(
+      transaction.transaction((savepoint) =>
+        applyWoodsRuleUpdates(savepoint, [
+          {
+            ...updates[0],
+            previousCharacteristics: [],
+            characteristics: ['no_match'],
+          },
+        ]),
+      ),
+    ).rejects.toThrow('changed during repair');
+  });
+});

--- a/packages/backend/src/__tests__/woods-climb-authoring.test.ts
+++ b/packages/backend/src/__tests__/woods-climb-authoring.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { WOODS_SIZES } from '@boardsesh/board-config';
+import {
+  WOODS_LAYOUT_ID,
+  isWoodsBoard,
+  parseWoodsFrames,
+  requireWoodsSizeId,
+  resolveWoodsUpdateSizeId,
+  storedWoodsSizeId,
+  validateWoodsClimb,
+} from '../graphql/resolvers/climbs/woods-authoring';
+
+const SMALL_SIZE_ID = WOODS_SIZES['8x10'].id;
+const LARGE_SIZE_ID = WOODS_SIZES['12x12'].id;
+
+// Wire role codes (spec §6, via WOODS_WIRE_ROLE): Foot 1, Hand 2, Finish 3, Start 4.
+const START_HAND_FINISH = 'p10r4p20r2p30r3';
+
+// Hold 600 exists on the 12x12 (0-893) and does not on the 8x10 (0-484). That
+// asymmetry is the whole reason Woods climbs carry a size.
+const LARGE_ONLY_HOLD = 600;
+
+function publishable(overrides: Partial<Parameters<typeof validateWoodsClimb>[0]> = {}) {
+  return validateWoodsClimb({
+    layoutId: WOODS_LAYOUT_ID,
+    sizeId: LARGE_SIZE_ID,
+    angle: 40,
+    frames: START_HAND_FINISH,
+    framesCount: 1,
+    framesPace: 0,
+    isDraft: false,
+    ...overrides,
+  });
+}
+
+describe('isWoodsBoard', () => {
+  it('is true only for the Woods board', () => {
+    expect(isWoodsBoard('woods')).toBe(true);
+    expect(isWoodsBoard('kilter')).toBe(false);
+    expect(isWoodsBoard('moonboard')).toBe(false);
+  });
+});
+
+describe('requireWoodsSizeId', () => {
+  it('accepts the two real Woods sizes', () => {
+    expect(requireWoodsSizeId(SMALL_SIZE_ID)).toBe(SMALL_SIZE_ID);
+    expect(requireWoodsSizeId(LARGE_SIZE_ID)).toBe(LARGE_SIZE_ID);
+  });
+
+  it('rejects a missing size — nothing about the hold ids can recover it later', () => {
+    expect(() => requireWoodsSizeId(null)).toThrow(/must name the board size/i);
+    expect(() => requireWoodsSizeId(undefined)).toThrow(/must name the board size/i);
+  });
+
+  it('rejects a size that is not a Woods board', () => {
+    expect(() => requireWoodsSizeId(7)).toThrow(/Unknown Woods board size/i);
+  });
+});
+
+describe('validateWoodsClimb', () => {
+  it('accepts a publishable climb and reports its holds with Woods roles', () => {
+    const shape = publishable();
+    expect(shape.sizeId).toBe(LARGE_SIZE_ID);
+    expect(shape.dimension).toBe('12x12');
+    expect(shape.holds).toEqual([
+      { holdId: 10, holdState: 'STARTING', roleCode: 4 },
+      { holdId: 20, holdState: 'HAND', roleCode: 2 },
+      { holdId: 30, holdState: 'FINISH', roleCode: 3 },
+    ]);
+  });
+
+  it('rejects any layout but the single Woods one', () => {
+    expect(() => publishable({ layoutId: WOODS_LAYOUT_ID + 1 })).toThrow(/live on layout/i);
+  });
+
+  it('accepts 20-70 in 5 degree steps and nothing else', () => {
+    for (const angle of [20, 45, 70]) {
+      expect(() => publishable({ angle })).not.toThrow();
+    }
+    for (const angle of [15, 22, 75, 0]) {
+      expect(() => publishable({ angle })).toThrow(/5° steps/);
+    }
+    expect(() => publishable({ angle: null })).toThrow(/5° steps/);
+  });
+
+  it('rejects multi-frame shapes', () => {
+    expect(() => publishable({ framesCount: 2 })).toThrow(/single static frame/i);
+    expect(() => publishable({ framesPace: 500 })).toThrow(/frame pace must be 0/i);
+    expect(() => publishable({ frames: 'p10r4p20r2,p30r3' })).toThrow(/single frame of p<hold>r<role>/);
+    // `x` off-tokens are an Aurora animation feature the Woods wire format has no
+    // concept of; they must not survive into a stored Woods frames string.
+    expect(() => publishable({ frames: 'p10r4x10p20r2p30r3' })).toThrow(/single frame of p<hold>r<role>/);
+  });
+
+  it('rejects a role code the Woods firmware does not speak', () => {
+    // 13 is a Kilter HAND code — exactly what a create screen that fell through
+    // to the Aurora role table would send.
+    expect(() => publishable({ frames: 'p10r13p20r2p30r3' })).toThrow(/Unknown Woods hold role 13/);
+  });
+
+  it('rejects a hold that does not exist on the selected size', () => {
+    expect(() => publishable({ sizeId: LARGE_SIZE_ID, frames: `p${LARGE_ONLY_HOLD}r4p20r2p30r3` })).not.toThrow();
+    expect(() => publishable({ sizeId: SMALL_SIZE_ID, frames: `p${LARGE_ONLY_HOLD}r4p20r2p30r3` })).toThrow(
+      new RegExp(`Hold ${LARGE_ONLY_HOLD} does not exist on the 8x10`),
+    );
+  });
+
+  it('rejects a repeated hold id', () => {
+    // board_climb_holds is keyed on (board, climb, hold) and inserts with ON
+    // CONFLICT DO NOTHING, so a repeat would leave frames, the hold rows and the
+    // fingerprint describing three different climbs.
+    expect(() => publishable({ frames: 'p10r4p10r2p30r3' })).toThrow(/listed more than once/);
+  });
+
+  it('requires a start and a finish to publish, but not to draft', () => {
+    expect(() => publishable({ frames: 'p10r2p20r3' })).toThrow(/needs at least one start hold/);
+    expect(() => publishable({ frames: 'p10r4p20r2' })).toThrow(/needs at least one finish hold/);
+    expect(() => publishable({ frames: 'p10r2', isDraft: true })).not.toThrow();
+  });
+
+  it('still requires at least one real hold on a draft', () => {
+    expect(() => publishable({ frames: '', isDraft: true })).toThrow(/single frame of p<hold>r<role>/);
+  });
+});
+
+describe('parseWoodsFrames', () => {
+  it('keeps the authored hold order rather than re-sorting', () => {
+    // The frames string is what the BLE encoder reads back, so the parse must be
+    // a faithful read of it, not a normalisation.
+    expect(parseWoodsFrames('p30r3p10r4', '12x12').map((hold) => hold.holdId)).toEqual([30, 10]);
+  });
+});
+
+describe('storedWoodsSizeId', () => {
+  it('reads the size back out of compatible_size_ids', () => {
+    expect(storedWoodsSizeId([LARGE_SIZE_ID])).toBe(LARGE_SIZE_ID);
+    expect(storedWoodsSizeId([SMALL_SIZE_ID])).toBe(SMALL_SIZE_ID);
+  });
+
+  it('is null for a row that has no Woods size recorded', () => {
+    expect(storedWoodsSizeId(null)).toBeNull();
+    expect(storedWoodsSizeId([])).toBeNull();
+    expect(storedWoodsSizeId([99])).toBeNull();
+  });
+});
+
+describe('resolveWoodsUpdateSizeId', () => {
+  it('uses the stored size when the request says nothing', () => {
+    expect(resolveWoodsUpdateSizeId({ storedSizeId: SMALL_SIZE_ID, requestedSizeId: null })).toBe(SMALL_SIZE_ID);
+    expect(resolveWoodsUpdateSizeId({ storedSizeId: SMALL_SIZE_ID, requestedSizeId: undefined })).toBe(SMALL_SIZE_ID);
+  });
+
+  it('accepts a request that agrees with the stored size', () => {
+    expect(resolveWoodsUpdateSizeId({ storedSizeId: LARGE_SIZE_ID, requestedSizeId: LARGE_SIZE_ID })).toBe(
+      LARGE_SIZE_ID,
+    );
+  });
+
+  it('rejects a request that would move the climb to the other wall', () => {
+    expect(() => resolveWoodsUpdateSizeId({ storedSizeId: SMALL_SIZE_ID, requestedSizeId: LARGE_SIZE_ID })).toThrow(
+      /cannot be changed/i,
+    );
+  });
+
+  it('refuses to edit a row whose size was never recorded', () => {
+    expect(() => resolveWoodsUpdateSizeId({ storedSizeId: null, requestedSizeId: SMALL_SIZE_ID })).toThrow(
+      /no recorded board size/i,
+    );
+  });
+});

--- a/packages/backend/src/__tests__/woods-duplicate-sql.test.ts
+++ b/packages/backend/src/__tests__/woods-duplicate-sql.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from 'vite-plus/test';
+import { boardClimbs, boardClimbHolds } from '@boardsesh/db/schema';
+import { db } from '../db/client';
+import { findExactDuplicateMatch } from '../graphql/resolvers/climbs/climb-similarity';
+
+test('duplicate SQL distinguishes rule sets and Woods physical sizes', async () => {
+  const cases = [
+    { uuid: 'woods-default', boardType: 'woods', sizeId: 2, characteristics: [], description: '' },
+    { uuid: 'woods-no-match', boardType: 'woods', sizeId: 2, characteristics: ['no_match'], description: '' },
+    { uuid: 'woods-small', boardType: 'woods', sizeId: 1, characteristics: ['no_match'], description: '' },
+    { uuid: 'aurora-legacy', boardType: 'kilter', sizeId: 2, characteristics: null, description: 'No matching hands' },
+    { uuid: 'aurora-explicit', boardType: 'kilter', sizeId: 2, characteristics: [], description: 'No matching hands' },
+  ];
+  await db.insert(boardClimbs).values(
+    cases.map((climb) => ({
+      boardType: climb.boardType,
+      uuid: climb.uuid,
+      layoutId: 1,
+      name: climb.uuid,
+      frames: 'p0r4p1r3',
+      framesCount: 1,
+      angle: 40,
+      isDraft: false,
+      isListed: true,
+      characteristics: climb.characteristics,
+      description: climb.description,
+      compatibleSizeIds: [climb.sizeId],
+    })),
+  );
+  await db.insert(boardClimbHolds).values(
+    cases.flatMap((climb) => [
+      { boardType: climb.boardType, climbUuid: climb.uuid, frameNumber: 0, holdId: 0, holdState: 'STARTING' },
+      { boardType: climb.boardType, climbUuid: climb.uuid, frameNumber: 0, holdId: 1, holdState: 'FINISH' },
+    ]),
+  );
+  const signature = '0:STARTING,1:FINISH';
+  for (const example of [
+    { boardType: 'woods' as const, sizeId: 2, ruleSignature: '', expected: 'woods-default' },
+    { boardType: 'woods' as const, sizeId: 2, ruleSignature: 'no_match', expected: 'woods-no-match' },
+    { boardType: 'woods' as const, sizeId: 1, ruleSignature: 'no_match', expected: 'woods-small' },
+    { boardType: 'kilter' as const, sizeId: undefined, ruleSignature: 'no_match', expected: 'aurora-legacy' },
+    { boardType: 'kilter' as const, sizeId: undefined, ruleSignature: '', expected: 'aurora-explicit' },
+  ]) {
+    const match = await findExactDuplicateMatch({ ...example, layoutId: 1, signature });
+    expect(match?.uuid).toBe(example.expected);
+  }
+  expect(
+    await findExactDuplicateMatch({ boardType: 'woods', sizeId: 2, layoutId: 1, signature, ruleSignature: 'any_feet' }),
+  ).toBeNull();
+});

--- a/packages/backend/src/graphql/resolvers/climbs/climb-similarity.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/climb-similarity.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm';
-import type { SQLWrapper } from 'drizzle-orm';
+import type { SQL, SQLWrapper } from 'drizzle-orm';
 import * as dbSchema from '@boardsesh/db/schema';
 import {
   STATE_TO_PRIMARY_CODE,
@@ -7,6 +7,12 @@ import {
   isSentinelHoldState,
 } from '@boardsesh/board-constants/hold-states';
 import type { BoardName } from '@boardsesh/board-constants';
+import {
+  CLIMB_CHARACTERISTICS,
+  buildRuleSignature,
+  isNoMatchClimb,
+  usesAuroraNoMatchDescription,
+} from '@boardsesh/shared-schema';
 import { executeRows } from '@boardsesh/db/client';
 import { withSerialPlan } from '@boardsesh/db/queries';
 import { db } from '../../../db/client';
@@ -134,10 +140,80 @@ export function buildHoldSignature(entries: ReadonlyArray<NormalizedHold>): stri
     .join(',');
 }
 
+/**
+ * A climb's canonical rule string, computed from the values as they are (or are
+ * about to be) STORED on the row — the JS twin of {@link ruleMatchSql}.
+ *
+ * Callers must feed it what the row will hold after their write, not what the
+ * client sent, because the query it is compared against reads the row. The
+ * legacy branch is the reason: `no_match` used to live only in the Aurora
+ * `"No match\n"` description prefix, and a row the backfill hasn't reached
+ * (`characteristics IS NULL`) still gets it from there. A row that HAS an
+ * explicit array is taken at its word — that is what makes `noMatch: false`
+ * stick on a climb whose description happens to open with "No matching feet".
+ *
+ * Keep this and `ruleMatchSql` edited together; if they disagree the gate
+ * silently stops matching anything, which reads as "duplicates allowed".
+ */
+export function buildStoredRuleSignature(
+  boardType: BoardName,
+  characteristics: readonly string[] | null | undefined,
+  description: string | null | undefined,
+): string {
+  if (characteristics == null) {
+    const legacyNoMatch = usesAuroraNoMatchDescription(boardType) && isNoMatchClimb(description);
+    return buildRuleSignature(legacyNoMatch ? [CLIMB_CHARACTERISTICS.NO_MATCH] : []);
+  }
+  return buildRuleSignature(characteristics);
+}
+
+/** Compare rule sets without a per-candidate aggregate; ordering and duplicate tokens do not matter. */
+function ruleMatchSql(
+  boardType: BoardName,
+  characteristics: SQLWrapper,
+  description: SQLWrapper,
+  signature: string,
+): SQL {
+  const legacyNoMatch = usesAuroraNoMatchDescription(boardType)
+    ? sql`CASE WHEN LOWER(COALESCE(${description}, '')) LIKE 'no match%' THEN ARRAY['no_match']::text[] ELSE '{}'::text[] END`
+    : sql`'{}'::text[]`;
+  const stored = sql`COALESCE(${characteristics}, ${legacyNoMatch})`;
+  const tokens = signature ? signature.split(',') : [];
+  const expected = sql`ARRAY[${sql.join(
+    tokens.map((token) => sql`${token}`),
+    sql`, `,
+  )}]::text[]`;
+  return sql`(${stored} @> ${expected} AND ${stored} <@ ${expected})`;
+}
+
+/**
+ * Restrict candidates to one physical board size, for boards where the size is
+ * part of a climb's identity.
+ *
+ * Woods is the whole reason this exists: its 8x10 and 12x12 walls both number
+ * holds from 0, so hold 300 is a different hold on each, and an unscoped
+ * comparison reports two unrelated climbs as the same route. Boards that derive
+ * `compatible_size_ids` from a bounding box (every Aurora board) pass `undefined`
+ * and keep the old cross-size behaviour, where a climb legitimately fits several
+ * sizes at once.
+ */
+function sizeScopeSql(sizeId: number | undefined, compatibleSizeIds: SQLWrapper): SQL {
+  if (sizeId === undefined) return sql``;
+  return sql` AND COALESCE(${compatibleSizeIds}, '{}'::int[]) @> ARRAY[${sizeId}]::int[]`;
+}
+
 type FindExactDuplicateArgs = {
   boardType: BoardName;
   layoutId: number;
   signature: string;
+  /**
+   * The candidate's canonical rule string (`buildRuleSignature`). Two climbs on
+   * the same holds with different rules are different problems, so this is part
+   * of the duplicate key, not a filter on top of it.
+   */
+  ruleSignature: string;
+  /** Physical board size, on boards where it is part of the identity (Woods). */
+  sizeId?: number;
   excludeUuid?: string;
   /** When provided, runs the gate query on this connection (typically a
    *  transaction handle). Required when callers want the check serialized
@@ -148,7 +224,17 @@ type FindExactDuplicateArgs = {
 
 /**
  * Look up a published, single-frame climb on the same board+layout whose set
- * of (hold_id, hold_state) tuples produces the same signature.
+ * of (hold_id, hold_state) tuples produces the same signature AND whose rules
+ * match — plus, on a size-scoped board, the same physical wall.
+ *
+ * Rules are part of the key because a rule variant is a real, separate problem:
+ * the same holds climbed no-match, or with every hold open as a foot, is a
+ * different climb from the plain version and deserves its own row, its own
+ * grade and its own ascents. That is also why `no_match` climbs are no longer
+ * excluded from this query — the exclusion existed to stop Aurora's "No match"
+ * PLACEHOLDER rows from blocking real setters, but with rules in the key a
+ * placeholder can only ever collide with another no-match climb on identical
+ * holds, which genuinely is the same problem.
  *
  * Returns the most prominent match (highest ascensionist count, then uuid)
  * when several exist, so the error message points at the canonical version.
@@ -157,6 +243,8 @@ export async function findExactDuplicateMatch({
   boardType,
   layoutId,
   signature,
+  ruleSignature,
+  sizeId,
   excludeUuid,
   executor,
 }: FindExactDuplicateArgs): Promise<ExactDuplicateMatch | null> {
@@ -196,15 +284,11 @@ export async function findExactDuplicateMatch({
         AND ${dbSchema.boardClimbs.isDraft} = FALSE
         AND ${dbSchema.boardClimbs.isListed} IS NOT FALSE
         AND ${dbSchema.boardClimbs.framesCount} = 1
-        -- "No match" placeholder climbs are not real routes; never block a real
-        -- setter's save by citing a placeholder. Reads the structured no_match
-        -- characteristic (backfilled from the Aurora description convention); the
-        -- description LIKE is a transition fallback for any row synced in the
-        -- window between the backfill migration and this code deploy.
-        AND NOT (
-          COALESCE(${dbSchema.boardClimbs.characteristics}, '{}') @> ARRAY['no_match']
-          OR LOWER(COALESCE(${dbSchema.boardClimbs.description}, '')) LIKE 'no match%'
-        )
+        -- Rules are part of the duplicate key. A no-match version of a climb, or
+        -- an any-feet version, is its own problem and must be publishable
+        -- alongside the plain one; only an identical rule set collides.
+        AND ${ruleMatchSql(boardType, dbSchema.boardClimbs.characteristics, dbSchema.boardClimbs.description, ruleSignature)}
+        ${sizeScopeSql(sizeId, dbSchema.boardClimbs.compatibleSizeIds)}
         ${excludeUuid ? sql`AND ${dbSchema.boardClimbs.uuid} <> ${excludeUuid}` : sql``}
       GROUP BY
         ${dbSchema.boardClimbs.uuid},
@@ -241,6 +325,12 @@ type FindSimilarClimbsArgs = {
   layoutId: number;
   holds: ReadonlyArray<NormalizedHold>;
   threshold: number;
+  /**
+   * Physical board size to scope candidates to (Woods). Without it the two Woods
+   * walls, which both number their holds from 0, produce spurious 100% matches
+   * between unrelated climbs.
+   */
+  sizeId?: number;
   excludeUuid?: string;
   limit?: number;
   /** Viewer angle. When set, joins board_climb_stats on this angle so each
@@ -279,6 +369,7 @@ export async function findSimilarClimbs({
   layoutId,
   holds,
   threshold,
+  sizeId,
   excludeUuid,
   limit = 25,
   statsAngle,
@@ -347,15 +438,13 @@ export async function findSimilarClimbs({
           -- left is_listed NULL (most kilter/tension Aurora-synced climbs).
           AND c.is_listed IS NOT FALSE
           AND c.frames_count = 1
-          -- "No match" placeholder climbs are not real routes; exclude them from
-          -- both the gate and the similarity list. Reads the structured no_match
-          -- characteristic (backfilled from the Aurora description convention); the
-          -- description LIKE is a transition fallback for any row synced in the
-          -- window between the backfill migration and this code deploy.
-          AND NOT (
-            COALESCE(c.characteristics, '{}') @> ARRAY['no_match']
-            OR LOWER(COALESCE(c.description, '')) LIKE 'no match%'
-          )
+          -- No rule filter here, deliberately. Discovery similarity is about
+          -- which holds are on the wall, not how they're climbed: the no-match
+          -- version of a route is exactly what someone looking at this one wants
+          -- to find. (The duplicate GATE does key on rules — see
+          -- findExactDuplicateMatch — which is also why no_match climbs are no
+          -- longer excluded here as "placeholders".)
+          ${sizeScopeSql(sizeId, sql`c.compatible_size_ids`)}
           ${excludeUuid ? sql`AND h.climb_uuid <> ${excludeUuid}` : sql``}
         GROUP BY h.climb_uuid
         HAVING COUNT(DISTINCT h.hold_id) >= CEIL(${targetSize}::float * ${safeThreshold})::int
@@ -455,15 +544,18 @@ export async function acquireDuplicateGateLock(
   boardType: BoardName,
   layoutId: number,
   signature: string,
+  options: { ruleSignature: string; sizeId?: number },
 ): Promise<void> {
   if (!signature) return;
-  // Lock key composition mirrors the gate's WHERE clause: (board, layout,
-  // hold-set). Angle is intentionally absent — see `findExactDuplicateMatch`
-  // for the rationale — so two callers publishing the same holds at
-  // different angles still serialize behind the same lock.
-  await executor.execute(
-    sql`SELECT pg_advisory_xact_lock(${CLIMB_DUPLICATE_LOCK_NAMESPACE}, hashtext(${`${boardType}|${layoutId}|${signature}`}))`,
-  );
+  // Lock key composition mirrors the gate's WHERE clause: (board, layout, size,
+  // rules, hold-set). It has to stay in lock-step with it — a key COARSER than
+  // the query serialises unrelated publishes (correct but slower), while a key
+  // FINER than the query re-opens the TOCTOU race the lock exists to close, as
+  // two colliding callers would take different locks and both pass the gate.
+  // Angle is intentionally absent — see `findExactDuplicateMatch` — so two
+  // callers publishing the same holds at different angles still serialize.
+  const lockKey = `${boardType}|${layoutId}|${options.sizeId ?? ''}|${options.ruleSignature}|${signature}`;
+  await executor.execute(sql`SELECT pg_advisory_xact_lock(${CLIMB_DUPLICATE_LOCK_NAMESPACE}, hashtext(${lockKey}))`);
 }
 
 export const CLIMB_DUPLICATE_ERROR_CODE = 'CLIMB_IS_DUPLICATE';

--- a/packages/backend/src/graphql/resolvers/climbs/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/mutations.ts
@@ -8,11 +8,14 @@ import {
   SUPPORTED_BOARDS,
   CLIMB_CHARACTERISTICS,
   TOGGLEABLE_CLIMB_CHARACTERISTICS,
+  findCharacteristicConflict,
   isNoMatchClimb,
+  usesAuroraNoMatchDescription,
   withCharacteristic,
   withNoMatch,
 } from '@boardsesh/shared-schema';
 import type { BoardName } from '@boardsesh/board-constants';
+import { fingerprintFromHolds } from '@boardsesh/kilter-sync/sync';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { UNIFIED_TABLES, isValidBoardName } from '../../../db/queries/util/table-select';
@@ -32,10 +35,19 @@ import {
   CLIMB_DUPLICATE_ERROR_CODE,
   buildDuplicateClimbErrorMessage,
   buildHoldSignature,
+  buildStoredRuleSignature,
   acquireDuplicateGateLock,
   findExactDuplicateMatch,
   parseFramesToHoldEntries,
 } from './climb-similarity';
+import {
+  WOODS_AUTHORED_REQUIRED_SET_IDS,
+  isWoodsBoard,
+  requireWoodsSizeId,
+  resolveWoodsUpdateSizeId,
+  storedWoodsSizeId,
+  validateWoodsClimb,
+} from './woods-authoring';
 import {
   BoardNameSchema,
   ExternalUUIDSchema,
@@ -116,6 +128,69 @@ export const climbMutations = {
         `Invalid board type: ${String(validated.boardType)}. Must be one of ${SUPPORTED_BOARDS.join(', ')}`,
       );
     }
+    const boardType = validated.boardType as BoardName;
+
+    // Woods is code-driven: no board_placements to validate a hold against and
+    // no board_product_sizes to derive compatibility from, so the shared
+    // geometry/role tables are the only schema there is and every rule has to be
+    // checked here. Doing it up front also fixes the size for the rest of the
+    // resolver — the duplicate key, the denormalised columns and the hold rows
+    // all need it.
+    const woodsShape = isWoodsBoard(boardType)
+      ? validateWoodsClimb({
+          layoutId: validated.layoutId,
+          sizeId: requireWoodsSizeId(validated.sizeId),
+          angle: validated.angle,
+          frames: validated.frames,
+          framesCount: validated.framesCount,
+          framesPace: validated.framesPace,
+          isDraft: validated.isDraft,
+        })
+      : null;
+
+    // Build the row's rules before anything touches the database: they are half
+    // the duplicate key now, so the gate below needs them, and a contradictory
+    // rule set should be rejected without a round-trip.
+    //
+    // `noMatch` is explicit and wins outright; when the client omits it (or is an
+    // old build that has never heard of the field) we fall back to deriving it
+    // from the raw description, which may still carry the Aurora "No match\n"
+    // prefix. Without that derivation a climb created with no_match AND a toggle
+    // stored characteristics=['no_kickboard'] — non-null, so readers that prefer
+    // the array over the description fallback silently dropped the no-match badge
+    // until the next edit.
+    const noMatch =
+      validated.noMatch ?? (usesAuroraNoMatchDescription(boardType) && isNoMatchClimb(validated.description));
+    let nextCharacteristics = withCharacteristic(
+      validated.characteristics ?? [],
+      CLIMB_CHARACTERISTICS.NO_MATCH,
+      noMatch,
+    );
+    nextCharacteristics = withCharacteristic(
+      nextCharacteristics,
+      CLIMB_CHARACTERISTICS.ANY_FEET,
+      validated.anyFeet ?? false,
+    );
+    const conflict = findCharacteristicConflict(nextCharacteristics);
+    if (conflict) {
+      throw new GraphQLError(`"${conflict.token}" cannot be combined with "${conflict.conflictsWith}"`, {
+        extensions: { code: 'BAD_USER_INPUT' },
+      });
+    }
+
+    // Woods persists `[]` where other boards persist NULL. On Woods a NULL means
+    // "rules unknown, waiting on the catalog repair" (the imported catalog has no
+    // rule data), so an authored climb that genuinely has no rules must say so
+    // explicitly or it reads as an un-repaired import forever.
+    const storedDescription = usesAuroraNoMatchDescription(boardType)
+      ? withNoMatch(validated.description ?? '', false)
+      : (validated.description ?? '');
+    const storedCharacteristics =
+      woodsShape ||
+      nextCharacteristics.length > 0 ||
+      (usesAuroraNoMatchDescription(boardType) && isNoMatchClimb(storedDescription))
+        ? nextCharacteristics
+        : null;
 
     const now = new Date().toISOString();
     const publishedAt = validated.isDraft ? null : now;
@@ -123,7 +198,7 @@ export const climbMutations = {
     const preferredSetter = displayName || name || null;
 
     const framesCount = validated.framesCount ?? 1;
-    const holdEntries = parseFramesToHoldEntries(validated.boardType as BoardName, validated.frames);
+    const holdEntries = parseFramesToHoldEntries(boardType, validated.frames);
     const uuid = generateClimbUuid();
 
     // Atomicity envelope: gate-check, insert, holds seed, and stats seed all
@@ -136,13 +211,22 @@ export const climbMutations = {
     // fire there anyway.
     const shouldGate = !validated.isDraft && framesCount === 1;
     const gateSignature = shouldGate ? buildHoldSignature(holdEntries) : '';
+    // Derived from what will be STORED, not from the input, so it matches the
+    // signature the gate query computes over the rows it reads.
+    const gateRuleSignature = buildStoredRuleSignature(boardType, storedCharacteristics, storedDescription);
+    const gateSizeId = woodsShape?.sizeId;
     await db.transaction(async (tx) => {
       if (shouldGate) {
-        await acquireDuplicateGateLock(tx, validated.boardType as BoardName, validated.layoutId, gateSignature);
+        await acquireDuplicateGateLock(tx, boardType, validated.layoutId, gateSignature, {
+          ruleSignature: gateRuleSignature,
+          sizeId: gateSizeId,
+        });
         const existing = await findExactDuplicateMatch({
-          boardType: validated.boardType as BoardName,
+          boardType,
           layoutId: validated.layoutId,
           signature: gateSignature,
+          ruleSignature: gateRuleSignature,
+          sizeId: gateSizeId,
           executor: tx,
         });
         if (existing) {
@@ -156,23 +240,6 @@ export const climbMutations = {
         }
       }
 
-      // Derive no_match from the raw incoming description (may carry the Aurora
-      // "No match\n" prefix) the same way updateClimb does, and merge it with any
-      // client-supplied toggleable tokens (no_kickboard/campus). Without this, a
-      // climb created with no_match AND a toggle stored characteristics=['no_kickboard']
-      // — non-null, so readers that prefer the array over the description fallback
-      // (ClimbAttributeIcons, the is_no_match resolver) silently dropped the
-      // no-match badge until the next edit. no_match is Aurora-family only — this
-      // resolver never serves MoonBoard (that's saveMoonBoardClimb), but the guard
-      // mirrors updateClimb's for the same reason: a "no match" description prefix
-      // on MoonBoard would just be user prose.
-      const isNoMatchFromDesc = validated.boardType !== 'moonboard' && isNoMatchClimb(validated.description);
-      const nextCharacteristics = withCharacteristic(
-        validated.characteristics ?? [],
-        CLIMB_CHARACTERISTICS.NO_MATCH,
-        isNoMatchFromDesc,
-      );
-
       await tx.insert(UNIFIED_TABLES.climbs).values({
         boardType: validated.boardType,
         uuid,
@@ -181,7 +248,7 @@ export const climbMutations = {
         setterId: null,
         setterUsername: preferredSetter,
         name: validated.name,
-        description: withNoMatch(validated.description ?? '', false),
+        description: storedDescription,
         angle: validated.angle,
         framesCount,
         framesPace: validated.framesPace ?? 0,
@@ -190,9 +257,26 @@ export const climbMutations = {
         isListed,
         createdAt: now,
         publishedAt,
-        synced: false,
+        // Woods climbs are Boardsesh-only: there is no Aurora account to push
+        // them to, so `synced: false` would park them in a pending-sync state
+        // forever. Every other board still owes Aurora a round-trip.
+        synced: !!woodsShape,
         syncError: null,
-        characteristics: nextCharacteristics.length > 0 ? nextCharacteristics : null,
+        characteristics: storedCharacteristics,
+        // Woods' denormalised columns can't be re-derived downstream —
+        // populateDenormalizedColumns bails out for the board precisely because
+        // there are no placements or product sizes behind it — so they are
+        // authoritative at write time. The empty required-set array is the honest
+        // answer for a board with one synthetic set (`{} <@ anything` is true),
+        // and NULL would read as "not backfilled" and drop the row from any
+        // set-filtered search.
+        ...(woodsShape
+          ? {
+              compatibleSizeIds: [woodsShape.sizeId],
+              requiredSetIds: [...WOODS_AUTHORED_REQUIRED_SET_IDS],
+              holdFingerprint: fingerprintFromHolds(holdEntries),
+            }
+          : {}),
       });
 
       // Aurora's sync-back round-trip eventually populates board_climb_holds for
@@ -270,7 +354,9 @@ export const climbMutations = {
       });
     }
 
-    return { uuid, synced: false, createdAt: now, publishedAt };
+    // Mirrors the column: a Woods climb has nowhere to sync to and is already
+    // final, so the client shouldn't show it as pending.
+    return { uuid, synced: !!woodsShape, createdAt: now, publishedAt };
   },
 
   /**
@@ -465,6 +551,7 @@ export const climbMutations = {
         `Invalid board type: ${String(validated.boardType)}. Must be one of ${SUPPORTED_BOARDS.join(', ')}`,
       );
     }
+    const boardType = validated.boardType as BoardName;
 
     // Load the existing row and verify ownership + edit window.
     const [existing] = await db
@@ -480,6 +567,13 @@ export const climbMutations = {
         framesCount: dbSchema.boardClimbs.framesCount,
         setterUsername: dbSchema.boardClimbs.setterUsername,
         characteristics: dbSchema.boardClimbs.characteristics,
+        // Needed to reproduce the rule signature the gate query computes over
+        // this row: a legacy climb whose no_match lives only in the "No match"
+        // description prefix still counts as a no-match climb.
+        description: dbSchema.boardClimbs.description,
+        // The Woods board size. Immutable, and the only record of which of the
+        // two walls the climb's hold ids belong to.
+        compatibleSizeIds: dbSchema.boardClimbs.compatibleSizeIds,
       })
       .from(dbSchema.boardClimbs)
       .where(
@@ -556,18 +650,142 @@ export const climbMutations = {
     const framesChanged = validated.frames !== undefined && validated.frames !== existing.frames;
     const nextFrames = validated.frames ?? existing.frames ?? '';
     const nextFramesCount = validated.framesCount ?? existing.framesCount ?? 1;
-    const shouldGate = !nextIsDraft && (transitioningToPublished || framesChanged) && nextFramesCount === 1;
-    const gateSignature = shouldGate
-      ? buildHoldSignature(parseFramesToHoldEntries(validated.boardType as BoardName, nextFrames))
-      : '';
+    const nextHoldEntries = parseFramesToHoldEntries(boardType, nextFrames);
+
+    // Woods: the board size is fixed at creation and is what makes the hold ids
+    // mean anything, so it comes from the row rather than the request. Re-run the
+    // full rule set over the post-update shape — an edit can add a hold that
+    // doesn't exist on this wall, drop the last start hold, or publish a draft
+    // that never had a finish. Runs BEFORE the UPDATE for the same reason the
+    // angle check does: a rejected edit must leave the row untouched.
+    const woodsSizeId = isWoodsBoard(boardType)
+      ? resolveWoodsUpdateSizeId({
+          storedSizeId: storedWoodsSizeId(existing.compatibleSizeIds),
+          requestedSizeId: validated.sizeId,
+        })
+      : undefined;
+    if (woodsSizeId !== undefined) {
+      validateWoodsClimb({
+        layoutId: existing.layoutId,
+        sizeId: woodsSizeId,
+        angle: resolvedAngle,
+        frames: nextFrames,
+        framesCount: nextFramesCount,
+        framesPace: validated.framesPace,
+        isDraft: nextIsDraft,
+      });
+    }
+
+    // Build the row's next rule set before the transaction: rules are half the
+    // duplicate key, so a rule-only edit has to re-run the gate, and the gate
+    // needs the values this update is about to store.
+    //
+    // Seeded from the row's EFFECTIVE rules (the stored array, or the legacy
+    // description-derived no_match when there is no array yet) so writing an
+    // explicit array for the first time carries the legacy flag forward instead
+    // of quietly dropping it.
+    let nextCharacteristics =
+      existing.characteristics != null
+        ? [...existing.characteristics]
+        : usesAuroraNoMatchDescription(boardType) && isNoMatchClimb(existing.description)
+          ? [CLIMB_CHARACTERISTICS.NO_MATCH as string]
+          : [];
+    let characteristicsChanged = false;
+    let nextDescription = existing.description ?? '';
+
+    if (validated.description !== undefined) {
+      // Derive no_match from the raw incoming description (may still carry the
+      // Aurora "No match\n" prefix), then strip the prefix from the stored value
+      // so characteristics is the sole source of truth going forward.
+      nextDescription = usesAuroraNoMatchDescription(boardType)
+        ? withNoMatch(validated.description, false)
+        : validated.description;
+      // no_match is an Aurora-family concept — never derive it for the
+      // code-driven boards, where a description starting with "no match" is just
+      // user prose and would otherwise clobber the climb's other tokens.
+      if (usesAuroraNoMatchDescription(boardType)) {
+        nextCharacteristics = withCharacteristic(
+          nextCharacteristics,
+          CLIMB_CHARACTERISTICS.NO_MATCH,
+          isNoMatchClimb(validated.description),
+        );
+        characteristicsChanged = true;
+      }
+    }
+
+    // Explicit flags win over the description derivation above, and null/omitted
+    // preserves whatever the row already says — that third state is what stops an
+    // old client, which sends neither field, from clearing a rule it has never
+    // heard of.
+    if (validated.noMatch != null) {
+      nextCharacteristics = withCharacteristic(nextCharacteristics, CLIMB_CHARACTERISTICS.NO_MATCH, validated.noMatch);
+      characteristicsChanged = true;
+    }
+    if (validated.anyFeet != null) {
+      nextCharacteristics = withCharacteristic(nextCharacteristics, CLIMB_CHARACTERISTICS.ANY_FEET, validated.anyFeet);
+      characteristicsChanged = true;
+    }
+    if (validated.characteristics !== undefined) {
+      // Client sends the full desired boolean state of each freely-toggleable
+      // token; anything else already on the row (no_match, any_feet, MoonBoard
+      // method) is left alone. `null` (both toggles off) is equivalent to `[]`
+      // here — the field is nullable because clients send explicit null, not
+      // omission, when nothing is toggled on.
+      const desiredCharacteristics = validated.characteristics ?? [];
+      for (const token of TOGGLEABLE_CLIMB_CHARACTERISTICS) {
+        nextCharacteristics = withCharacteristic(nextCharacteristics, token, desiredCharacteristics.includes(token));
+      }
+      characteristicsChanged = true;
+    }
+
+    if (characteristicsChanged) {
+      const conflict = findCharacteristicConflict(nextCharacteristics);
+      if (conflict) {
+        throw new GraphQLError(`"${conflict.token}" cannot be combined with "${conflict.conflictsWith}"`, {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+    }
+
+    // Woods persists `[]` where other boards persist NULL — see saveClimb.
+    const storedCharacteristics =
+      woodsSizeId !== undefined ||
+      nextCharacteristics.length > 0 ||
+      (usesAuroraNoMatchDescription(boardType) && isNoMatchClimb(nextDescription))
+        ? nextCharacteristics
+        : null;
+
+    // Both signatures are read off the row as it is and as it will be, not off
+    // the request: the gate query computes its side from the stored columns, so
+    // anything this update doesn't actually write has to be taken from `existing`
+    // or the two sides drift apart on the edits that touch neither field.
+    const previousRuleSignature = buildStoredRuleSignature(boardType, existing.characteristics, existing.description);
+    const nextRuleSignature = buildStoredRuleSignature(
+      boardType,
+      characteristicsChanged ? storedCharacteristics : existing.characteristics,
+      validated.description !== undefined ? nextDescription : existing.description,
+    );
+    const rulesChanged = nextRuleSignature !== previousRuleSignature;
+
+    // A rule-only edit is a real fork of the climb's identity, so it has to face
+    // the gate too: flipping "no match" on can land the climb straight on top of
+    // an existing no-match version of the same holds.
+    const shouldGate =
+      !nextIsDraft && (transitioningToPublished || framesChanged || rulesChanged) && nextFramesCount === 1;
+    const gateSignature = shouldGate ? buildHoldSignature(nextHoldEntries) : '';
 
     await db.transaction(async (tx) => {
       if (shouldGate) {
-        await acquireDuplicateGateLock(tx, validated.boardType as BoardName, existing.layoutId, gateSignature);
+        await acquireDuplicateGateLock(tx, boardType, existing.layoutId, gateSignature, {
+          ruleSignature: nextRuleSignature,
+          sizeId: woodsSizeId,
+        });
         const existingMatch = await findExactDuplicateMatch({
-          boardType: validated.boardType as BoardName,
+          boardType,
           layoutId: existing.layoutId,
           signature: gateSignature,
+          ruleSignature: nextRuleSignature,
+          sizeId: woodsSizeId,
           excludeUuid: validated.uuid,
           executor: tx,
         });
@@ -589,51 +807,24 @@ export const climbMutations = {
         publishedAt: nextPublishedAt,
       };
       if (validated.name !== undefined) updateSet.name = validated.name;
-      // Build the characteristics array once so a no_match-from-description
-      // derivation and an explicit characteristics update (no_kickboard/campus)
-      // in the same call compose instead of one clobbering the other. Starts
-      // from the existing row so any other token (MoonBoard method) survives
-      // untouched unless explicitly touched below.
-      let nextCharacteristics = existing.characteristics ? [...existing.characteristics] : [];
-      let characteristicsChanged = false;
-
-      if (validated.description !== undefined) {
-        // Derive no_match from the raw incoming description (may still carry the
-        // Aurora "No match\n" prefix), then strip the prefix from the stored value
-        // so characteristics is the sole source of truth going forward.
-        const isNoMatchFromDesc = isNoMatchClimb(validated.description);
-        updateSet.description = withNoMatch(validated.description, false);
-        // no_match is an Aurora-family concept — never derive it for MoonBoard,
-        // where a description starting with "no match" is just user prose and
-        // would otherwise clobber the climb's method token.
-        if (validated.boardType !== 'moonboard') {
-          nextCharacteristics = withCharacteristic(
-            nextCharacteristics,
-            CLIMB_CHARACTERISTICS.NO_MATCH,
-            isNoMatchFromDesc,
-          );
-          characteristicsChanged = true;
-        }
-      }
-      if (validated.characteristics !== undefined) {
-        // Client sends the full desired boolean state of each freely-toggleable
-        // token; anything else already on the row (no_match, MoonBoard method)
-        // is left alone. `null` (both toggles off) is equivalent to `[]` here —
-        // the field is nullable because clients send explicit null, not omission,
-        // when nothing is toggled on.
-        const desiredCharacteristics = validated.characteristics ?? [];
-        for (const token of TOGGLEABLE_CLIMB_CHARACTERISTICS) {
-          nextCharacteristics = withCharacteristic(nextCharacteristics, token, desiredCharacteristics.includes(token));
-        }
-        characteristicsChanged = true;
-      }
-      if (characteristicsChanged) {
-        updateSet.characteristics = nextCharacteristics.length > 0 ? nextCharacteristics : null;
-      }
+      // The description and the rule array were both resolved above, before the
+      // transaction, so the gate could key on them. Write them only when this
+      // call actually touched them — a metadata-only edit must not rewrite the
+      // characteristics column (and, on MoonBoard, must not disturb the method
+      // token it never asked about).
+      if (validated.description !== undefined) updateSet.description = nextDescription;
+      if (characteristicsChanged) updateSet.characteristics = storedCharacteristics;
       if (validated.frames !== undefined) updateSet.frames = validated.frames;
       if (validated.angle !== undefined) updateSet.angle = validated.angle;
       if (validated.framesCount !== undefined) updateSet.framesCount = validated.framesCount;
       if (validated.framesPace !== undefined) updateSet.framesPace = validated.framesPace;
+      // Woods writes its own hold fingerprint (nothing downstream can re-derive
+      // it for that board), so an edit that moves the holds has to move it too or
+      // it describes the climb the user replaced. Other boards get theirs from
+      // the Aurora sync and are left alone here.
+      if (woodsSizeId !== undefined && framesChanged) {
+        updateSet.holdFingerprint = fingerprintFromHolds(nextHoldEntries);
+      }
 
       await tx
         .update(dbSchema.boardClimbs)
@@ -649,7 +840,7 @@ export const climbMutations = {
         await populateDenormalizedColumns(tx, validated.boardType, [validated.uuid]);
 
         if (framesChanged) {
-          const refreshedHolds = parseFramesToHoldEntries(validated.boardType as BoardName, nextFrames);
+          const refreshedHolds = nextHoldEntries;
           await tx
             .delete(dbSchema.boardClimbHolds)
             .where(

--- a/packages/backend/src/graphql/resolvers/climbs/queries.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/queries.ts
@@ -1,3 +1,4 @@
+import { storedWoodsSizeId } from './woods-authoring';
 import { eq, and, gte, desc, asc, inArray, sql } from 'drizzle-orm';
 import {
   type CheckMoonBoardClimbDuplicatesInput,
@@ -39,6 +40,20 @@ import * as dbSchema from '@boardsesh/db/schema';
 // Debug logging flag - only log in development
 const DEBUG = process.env.NODE_ENV === 'development';
 
+/**
+ * Boards where a hold id only means something once you know which physical wall
+ * it is on, so similarity has to be scoped to one size.
+ *
+ * Woods is the case: its 8x10 and 12x12 walls both number holds from 0, and the
+ * 8x10's ids are a numeric subset of the 12x12's sitting at completely different
+ * positions. Every Aurora board derives `compatible_size_ids` from a bounding box
+ * against a shared placement grid, so one climb legitimately fits several sizes
+ * and scoping would just hide results.
+ */
+function isSizeScopedSimilarityBoard(boardType: BoardName): boolean {
+  return boardType === 'woods';
+}
+
 export const climbQueries = {
   checkMoonBoardClimbDuplicates: async (
     _: unknown,
@@ -78,6 +93,9 @@ export const climbQueries = {
 
     let holds: NormalizedHold[];
     let excludeUuid = validated.excludeClimbUuid ?? undefined;
+    // Size scope, only meaningful on Woods (see below). Starts from the request
+    // and can be filled in from the target climb.
+    let sizeId = isSizeScopedSimilarityBoard(boardType) ? (validated.sizeId ?? undefined) : undefined;
 
     if (validated.climbUuid) {
       const targetHoldRows = await db
@@ -100,18 +118,26 @@ export const climbQueries = {
       // a MoonBoard duplicate-publish that points the UI at the existing
       // climb via `climbUuid` would surface an empty "no identical climbs"
       // state for the exact match it just rejected.
-      if (holds.length === 0) {
+      //
+      // The same lookup answers "which wall is the target on?" on a size-scoped
+      // board, so it also runs when only the size is missing.
+      const needsTargetSize = isSizeScopedSimilarityBoard(boardType) && sizeId === undefined;
+      if (holds.length === 0 || needsTargetSize) {
         const [climbRow] = await db
-          .select({ frames: dbSchema.boardClimbs.frames })
+          .select({
+            frames: dbSchema.boardClimbs.frames,
+            compatibleSizeIds: dbSchema.boardClimbs.compatibleSizeIds,
+          })
           .from(dbSchema.boardClimbs)
           .where(and(eq(dbSchema.boardClimbs.boardType, boardType), eq(dbSchema.boardClimbs.uuid, validated.climbUuid)))
           .limit(1);
-        if (climbRow?.frames) {
+        if (holds.length === 0 && climbRow?.frames) {
           holds = parseFramesToHoldEntries(boardType, climbRow.frames).map(({ holdId, holdState }) => ({
             holdId,
             holdState,
           }));
         }
+        if (needsTargetSize) sizeId = storedWoodsSizeId(climbRow?.compatibleSizeIds) ?? undefined;
       }
 
       // Always exclude the target climb itself from its own similar list.
@@ -125,12 +151,20 @@ export const climbQueries = {
 
     if (holds.length === 0) return [];
 
+    // Fail closed rather than comparing across walls. On Woods the 8x10 and the
+    // 12x12 both number their holds from 0, so an unscoped comparison happily
+    // reports two unrelated climbs as a 100% match — worse than returning
+    // nothing. Callers that can't supply a size (a frames-only lookup on a climb
+    // that isn't saved yet) have to start sending one.
+    if (isSizeScopedSimilarityBoard(boardType) && sizeId === undefined) return [];
+
     return findSimilarClimbs({
       boardType,
       layoutId: validated.layoutId,
       holds,
       threshold: validated.threshold ?? 0.5,
       limit: validated.limit ?? 25,
+      sizeId,
       excludeUuid,
       statsAngle: validated.angle ?? undefined,
     });
@@ -196,19 +230,19 @@ export const climbQueries = {
       };
     }
 
-    // MoonBoard data changes frequently via local creation/import flows, so keep
-    // GraphQL search results uncached there. Other boards can still use Redis
-    // when the query is anonymous and has no user-specific filters.
+    // MoonBoard and Woods data changes under the search, so keep GraphQL search
+    // results uncached for both. Other boards can still use Redis when the query
+    // is anonymous and has no user-specific filters.
     //
-    // Woods stays cacheable despite also being code-driven: its catalog is a
-    // static import with no in-app creation or import flow writing to it, so a
-    // cached anonymous search can't go stale between requests the way MoonBoard's
-    // can. Revisit this line when Woods gets a create path (#4750) — a board
-    // users can write to has to leave the cacheable set.
+    // Woods used to be cacheable because its catalog was a read-only static
+    // import. It now has a create path (#4750, this change), so a cached
+    // anonymous search would keep serving a page that doesn't contain the climb
+    // the setter just published — the same staleness MoonBoard's creation/import
+    // flows cause.
     const hasUserSpecificFilters = USER_SPECIFIC_SEARCH_PARAMS.some(
       (param) => !!searchParams[param as keyof typeof searchParams],
     );
-    const isCacheableBoard = parsedInput.boardName !== 'moonboard';
+    const isCacheableBoard = parsedInput.boardName !== 'moonboard' && parsedInput.boardName !== 'woods';
 
     // Only resolve userId when user-specific filters are active — otherwise the query
     // results are identical to anonymous and can be served from Redis cache.

--- a/packages/backend/src/graphql/resolvers/climbs/woods-authoring.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/woods-authoring.ts
@@ -1,0 +1,260 @@
+import { GraphQLError } from 'graphql';
+import {
+  WOODS_ANGLES,
+  WOODS_LAYOUTS,
+  WOODS_SIZES,
+  getWoodsHoldGridPosition,
+  woodsSizeIdToDimension,
+  type WoodsBoardSize,
+} from '@boardsesh/board-config';
+import { HOLD_STATE_MAP, WOODS_WIRE_ROLE } from '@boardsesh/board-constants';
+import type { HoldState } from '@boardsesh/shared-schema';
+
+/**
+ * Woods climb authoring — every rule a Woods climb has to satisfy before it can
+ * be written to `board_climbs`, in one place.
+ *
+ * Woods is code-driven: there are no `board_placements` / `board_product_sizes`
+ * rows to validate a hold against, and `populateDenormalizedColumns` bails out
+ * for the board precisely because nothing in the database can re-derive its
+ * denormalised columns. So the shared geometry and role tables ARE the schema
+ * here, and this module is what enforces them:
+ *
+ *  - one layout (1), two physical sizes (1 = 8x10, 2 = 12x12);
+ *  - 20°–70° in 5° steps, the range the Woods app itself offers;
+ *  - one static frame — no animation, no `x` off-tokens;
+ *  - every hold id present on the SELECTED size (the two walls number their
+ *    holds from their own origins, so an id valid on the 12x12 is very often a
+ *    different hold, or no hold at all, on the 8x10);
+ *  - roles drawn from `WOODS_WIRE_ROLE`, so the stored frames feed the BLE
+ *    encoder unchanged;
+ *  - a start and a finish before it can be published.
+ *
+ * No BLE code is touched: this only reads the same role table the encoder does.
+ */
+
+/** Woods ships a single hold layout; every Woods climb lives on it. */
+export const WOODS_LAYOUT_ID = WOODS_LAYOUTS.woods.id;
+
+/**
+ * `required_set_ids` for an authored Woods climb: the empty set.
+ *
+ * Woods has one synthetic hold set, so "which sets must be bolted on" is
+ * genuinely nothing, and `{} <@ ARRAY[...]` is true in Postgres — a Woods climb
+ * can never be filtered out by a set list. NULL would read as "not backfilled
+ * yet" and `NULL <@ …` drops the row wherever the filter runs. Matches what the
+ * catalog importer writes (`WOODS_REQUIRED_SET_IDS`).
+ */
+export const WOODS_AUTHORED_REQUIRED_SET_IDS: number[] = [];
+
+/**
+ * Wire role code → hold state, for the four codes the Woods firmware speaks.
+ *
+ * Built from both shared tables rather than either alone: `WOODS_WIRE_ROLE` says
+ * which codes exist and `HOLD_STATE_MAP.woods` says what each means, and the
+ * module refuses to load if they disagree. A silent mismatch would let a role
+ * through validation and then store it with the wrong state.
+ */
+const WOODS_ROLE_STATES: ReadonlyMap<number, HoldState> = new Map(
+  Object.values(WOODS_WIRE_ROLE).map((roleCode) => {
+    const state = HOLD_STATE_MAP.woods[roleCode]?.name;
+    if (!state) throw new Error(`HOLD_STATE_MAP.woods is missing Woods wire role ${roleCode}`);
+    return [roleCode, state];
+  }),
+);
+
+const WOODS_SIZE_IDS: ReadonlyArray<number> = Object.values(WOODS_SIZES).map((size) => size.id);
+
+/** Only `p<holdId>r<roleCode>` pairs, at least one, and nothing else. */
+const WOODS_FRAMES_PATTERN = /^(?:p\d+r\d+)+$/;
+
+export type WoodsAuthoredHold = { holdId: number; holdState: HoldState; roleCode: number };
+
+export type WoodsClimbShape = {
+  sizeId: number;
+  dimension: WoodsBoardSize;
+  holds: WoodsAuthoredHold[];
+};
+
+function invalid(message: string): GraphQLError {
+  // BAD_USER_INPUT rather than a bare Error: these are all "you sent something
+  // the board can't hold", not server faults, and the create screen surfaces the
+  // message verbatim.
+  return new GraphQLError(message, { extensions: { code: 'BAD_USER_INPUT' } });
+}
+
+/** Whether this board type is the Woods board. */
+export function isWoodsBoard(boardType: string): boolean {
+  return boardType === 'woods';
+}
+
+/**
+ * The Woods size id a request is authoring on, or a thrown error.
+ *
+ * `null`/omitted is only acceptable on update, where the stored size is the
+ * answer — creation has to say which of the two walls the climb is on, because
+ * nothing about the hold ids can tell us afterwards.
+ */
+export function requireWoodsSizeId(sizeId: number | null | undefined): number {
+  if (sizeId == null) {
+    throw invalid(`A Woods climb must name the board size it is set on (${WOODS_SIZE_IDS.join(' or ')})`);
+  }
+  if (!woodsSizeIdToDimension(sizeId)) {
+    throw invalid(`Unknown Woods board size: ${sizeId}. Must be one of ${WOODS_SIZE_IDS.join(', ')}`);
+  }
+  return sizeId;
+}
+
+/** Reject any layout other than the single Woods one. */
+export function assertWoodsLayout(layoutId: number): void {
+  if (layoutId !== WOODS_LAYOUT_ID) {
+    throw invalid(`Woods climbs live on layout ${WOODS_LAYOUT_ID}, not ${layoutId}`);
+  }
+}
+
+/** Reject an angle the Woods app itself can't set (20–70 in 5° steps). */
+export function assertWoodsAngle(angle: number | null | undefined): void {
+  if (angle == null || !(WOODS_ANGLES as readonly number[]).includes(angle)) {
+    throw invalid(
+      `Woods supports ${WOODS_ANGLES[0]}–${WOODS_ANGLES[WOODS_ANGLES.length - 1]}° in 5° steps, not ${angle ?? 'no angle'}`,
+    );
+  }
+}
+
+/**
+ * Reject anything but a single static frame.
+ *
+ * The Woods firmware lights one static hold set; there is no pace, no delta
+ * frames, and no `x` off-token in its wire format. Rejecting the shape here also
+ * keeps the duplicate gate's `frames_count = 1` precondition true for every
+ * Woods row we write.
+ */
+export function assertWoodsSingleFrame(framesCount: number | null | undefined, framesPace: number | null | undefined) {
+  if (framesCount != null && framesCount !== 1) {
+    throw invalid('Woods climbs are a single static frame; multi-frame routes are not supported');
+  }
+  if (framesPace != null && framesPace !== 0) {
+    throw invalid('Woods climbs are a single static frame; frame pace must be 0');
+  }
+}
+
+/**
+ * Parse and validate a Woods frames string against the selected physical size.
+ *
+ * Deliberately parses the raw string itself rather than going through
+ * `parseFramesToHoldEntries`, which silently DROPS tokens whose role code isn't
+ * in `HOLD_STATE_MAP` — exactly the input we have to reject. Duplicated hold ids
+ * are rejected for the same reason: `board_climb_holds` is keyed on
+ * (board, climb, hold) and inserts with ON CONFLICT DO NOTHING, so a repeated id
+ * would leave `frames`, the holds rows and the fingerprint describing three
+ * different climbs.
+ */
+export function parseWoodsFrames(frames: string, dimension: WoodsBoardSize): WoodsAuthoredHold[] {
+  if (!WOODS_FRAMES_PATTERN.test(frames)) {
+    throw invalid('Woods frames must be a single frame of p<hold>r<role> pairs');
+  }
+
+  const holds: WoodsAuthoredHold[] = [];
+  const seenHoldIds = new Set<number>();
+  for (const match of frames.matchAll(/p(\d+)r(\d+)/g)) {
+    const holdId = Number(match[1]);
+    const roleCode = Number(match[2]);
+
+    const holdState = WOODS_ROLE_STATES.get(roleCode);
+    if (!holdState) {
+      throw invalid(`Unknown Woods hold role ${roleCode} on hold ${holdId}`);
+    }
+    if (!getWoodsHoldGridPosition(holdId, dimension)) {
+      throw invalid(`Hold ${holdId} does not exist on the ${dimension} Woods board`);
+    }
+    if (seenHoldIds.has(holdId)) {
+      throw invalid(`Hold ${holdId} is listed more than once`);
+    }
+    seenHoldIds.add(holdId);
+
+    holds.push({ holdId, holdState, roleCode });
+  }
+
+  if (holds.length === 0) {
+    throw invalid('A Woods climb needs at least one hold');
+  }
+  return holds;
+}
+
+/**
+ * A published Woods climb needs somewhere to start and somewhere to top out.
+ * Drafts don't: the create screen saves a draft the moment the first hold is
+ * tapped, long before either exists.
+ */
+export function assertWoodsPublishableHolds(holds: ReadonlyArray<WoodsAuthoredHold>): void {
+  if (!holds.some((hold) => hold.holdState === 'STARTING')) {
+    throw invalid('A published Woods climb needs at least one start hold');
+  }
+  if (!holds.some((hold) => hold.holdState === 'FINISH')) {
+    throw invalid('A published Woods climb needs at least one finish hold');
+  }
+}
+
+/**
+ * Run every Woods rule over one authoring request and return the validated
+ * shape. `sizeId` is already resolved by the caller — on create from the input,
+ * on update from the stored row — because "where does the size come from" is the
+ * one rule that differs between the two paths.
+ */
+export function validateWoodsClimb(args: {
+  layoutId: number;
+  sizeId: number;
+  angle: number | null | undefined;
+  frames: string;
+  framesCount: number | null | undefined;
+  framesPace: number | null | undefined;
+  isDraft: boolean;
+}): WoodsClimbShape {
+  assertWoodsLayout(args.layoutId);
+  const dimension = woodsSizeIdToDimension(args.sizeId);
+  if (!dimension) {
+    throw invalid(`Unknown Woods board size: ${args.sizeId}. Must be one of ${WOODS_SIZE_IDS.join(', ')}`);
+  }
+  assertWoodsAngle(args.angle);
+  assertWoodsSingleFrame(args.framesCount, args.framesPace);
+
+  const holds = parseWoodsFrames(args.frames, dimension);
+  if (!args.isDraft) assertWoodsPublishableHolds(holds);
+
+  return { sizeId: args.sizeId, dimension, holds };
+}
+
+/**
+ * The stored Woods size for an existing climb, read back from the denormalised
+ * `compatible_size_ids` the create path writes. Returns null for a row that
+ * predates it (or an imported row the catalog repair hasn't reached), which the
+ * caller treats as "size unknown" rather than guessing a wall.
+ */
+export function storedWoodsSizeId(compatibleSizeIds: number[] | null | undefined): number | null {
+  const sizeId = compatibleSizeIds?.find((candidate) => woodsSizeIdToDimension(candidate) !== undefined);
+  return sizeId ?? null;
+}
+
+/**
+ * Resolve the size an update applies to. The size is immutable: a Woods climb
+ * cannot move to the other wall, because its hold ids mean different holds
+ * there — the "same" climb on the 12x12 is a different climb and gets its own
+ * row. A request naming a different size is rejected rather than ignored, so a
+ * client bug surfaces instead of silently doing nothing.
+ */
+export function resolveWoodsUpdateSizeId(args: {
+  storedSizeId: number | null;
+  requestedSizeId: number | null | undefined;
+}): number {
+  const { storedSizeId, requestedSizeId } = args;
+  if (storedSizeId === null) {
+    // Nothing on the row says which wall this climb is on, so no hold-id check
+    // we could run would mean anything. Editing it needs the catalog repair to
+    // fill the size in first.
+    throw invalid('This Woods climb has no recorded board size and cannot be edited yet');
+  }
+  if (requestedSizeId != null && requestedSizeId !== storedSizeId) {
+    throw invalid("A Woods climb's board size cannot be changed; set it on the other board as a new climb");
+  }
+  return storedSizeId;
+}

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -266,6 +266,19 @@ const ToggleableCharacteristicsSchema = z
   .optional()
   .nullable();
 
+// `no_match` and `any_feet` are sent as their own booleans rather than through
+// `characteristics`, and both are three-valued on the wire: `true` / `false` /
+// absent-or-null. The third state is what keeps an old client — which has never
+// heard of these fields — from clearing a flag on every save it makes. On create
+// null means "off"; on update it means "leave the row alone". Nullable for the
+// same reason as ToggleableCharacteristicsSchema: clients send explicit null.
+const RuleFlagSchema = z.boolean().optional().nullable();
+
+// Physical board size. Only Woods requires it (and only at creation) — the
+// resolver enforces that, because "which boards care" is a board-capability
+// question, not a shape question.
+const ClimbSizeIdSchema = z.number().int().positive('Size ID must be positive').optional().nullable();
+
 export const SaveClimbInputSchema = z
   .object({
     boardType: BoardNameSchema,
@@ -278,6 +291,9 @@ export const SaveClimbInputSchema = z
     framesPace: z.number().int().min(0).optional(),
     angle: z.number().int().min(-5).max(90),
     characteristics: ToggleableCharacteristicsSchema,
+    noMatch: RuleFlagSchema,
+    anyFeet: RuleFlagSchema,
+    sizeId: ClimbSizeIdSchema,
   })
   .refine((input) => isBoardAngleSupported(input.boardType, input.angle), {
     message: BOARD_ANGLE_VALIDATION_MESSAGE,
@@ -296,6 +312,9 @@ export const UpdateClimbInputSchema = z
     framesCount: z.number().int().min(1).optional(),
     framesPace: z.number().int().min(0).optional(),
     characteristics: ToggleableCharacteristicsSchema,
+    noMatch: RuleFlagSchema,
+    anyFeet: RuleFlagSchema,
+    sizeId: ClimbSizeIdSchema,
   })
   .refine((input) => isBoardAngleSupported(input.boardType, input.angle), {
     message: BOARD_ANGLE_VALIDATION_MESSAGE,
@@ -360,6 +379,10 @@ export const SimilarClimbsInputSchema = z
   .object({
     boardType: BoardNameSchema,
     layoutId: z.number().int().positive('Layout ID must be positive'),
+    // Size-scopes the candidate set on boards whose sizes reuse hold ids (Woods).
+    // Optional everywhere: other boards ignore it, and on Woods the target
+    // climb's own compatible sizes fill it in when a climbUuid is supplied.
+    sizeId: z.number().int().positive('Size ID must be positive').optional().nullable(),
     threshold: z.number().min(0).max(1).optional(),
     limit: z.number().int().min(1).max(200).optional(),
     // ExternalUUIDSchema keeps these aligned with the rest of the codebase

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -94,6 +94,7 @@
     "db:export-outline-overrides": "tsx scripts/export-outline-overrides.ts",
     "db:backfill-moonboard-set-ids": "tsx scripts/backfill-moonboard-set-ids.ts",
     "db:backfill-moonboard-hardware": "tsx scripts/backfill-moonboard-hardware.ts",
+    "db:repair-woods-rules": "tsx scripts/repair-woods-rules.ts",
     "db:repair-moonboard-8c-grades": "tsx scripts/repair-moonboard-8c-grades.ts",
     "db:backfill-clamped-send-attempts": "tsx scripts/backfill-clamped-send-attempts.ts",
     "db:dedupe-gyms": "tsx scripts/dedupe-gym-locations.ts",

--- a/packages/db/scripts/import-moonboard-2024.ts
+++ b/packages/db/scripts/import-moonboard-2024.ts
@@ -1,7 +1,9 @@
+import { mergeCatalogCharacteristicsSql } from '../src/queries/climbs/catalog-characteristics.js';
+import { CLIMB_CHARACTERISTICS, isMethodCharacteristic } from '@boardsesh/shared-schema/characteristics';
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
-import { sql } from 'drizzle-orm';
+import { sql, isNull } from 'drizzle-orm';
 import { boardClimbs, boardClimbStats, boardClimbHolds, boardClimbAliases } from '../src/schema/boards/unified.js';
 import {
   MOONBOARD_2024_LAYOUT_ID,
@@ -207,7 +209,15 @@ async function importMoonBoard2024() {
           .values(climbRecords.slice(i, i + BATCH_SIZE))
           .onConflictDoUpdate({
             target: boardClimbs.uuid,
-            set: { characteristics: sql`excluded.characteristics`, description: sql`excluded.description` },
+            setWhere: isNull(boardClimbs.userId),
+            set: {
+              characteristics: mergeCatalogCharacteristicsSql(
+                boardClimbs.characteristics,
+                sql`excluded.characteristics`,
+                Object.values(CLIMB_CHARACTERISTICS).filter(isMethodCharacteristic),
+              ),
+              description: sql`excluded.description`,
+            },
           });
       }
 

--- a/packages/db/scripts/import-moonboard-catalog.ts
+++ b/packages/db/scripts/import-moonboard-catalog.ts
@@ -1,3 +1,5 @@
+import { mergeCatalogCharacteristicsSql } from '../src/queries/climbs/catalog-characteristics.js';
+import { CLIMB_CHARACTERISTICS, isMethodCharacteristic } from '@boardsesh/shared-schema/characteristics';
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
@@ -228,7 +230,15 @@ async function importMoonBoardCatalog() {
             .values(climbRecords.slice(i, i + BATCH_SIZE))
             .onConflictDoUpdate({
               target: boardClimbs.uuid,
-              set: { characteristics: sql`excluded.characteristics`, description: sql`excluded.description` },
+              setWhere: isNull(boardClimbs.userId),
+              set: {
+                characteristics: mergeCatalogCharacteristicsSql(
+                  boardClimbs.characteristics,
+                  sql`excluded.characteristics`,
+                  Object.values(CLIMB_CHARACTERISTICS).filter(isMethodCharacteristic),
+                ),
+                description: sql`excluded.description`,
+              },
             });
         }
 

--- a/packages/db/scripts/import-moonboard-problems.ts
+++ b/packages/db/scripts/import-moonboard-problems.ts
@@ -1,7 +1,9 @@
+import { mergeCatalogCharacteristicsSql } from '../src/queries/climbs/catalog-characteristics.js';
+import { CLIMB_CHARACTERISTICS, isMethodCharacteristic } from '@boardsesh/shared-schema/characteristics';
 import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
-import { sql } from 'drizzle-orm';
+import { sql, isNull } from 'drizzle-orm';
 import { boardClimbs, boardClimbStats, boardClimbHolds } from '../src/schema/boards/unified.js';
 import { blendedQualityAverageSql } from '../src/queries/climb-stats/quality-blend.js';
 import {
@@ -287,7 +289,14 @@ async function importMoonBoardProblems() {
           .values(batch)
           .onConflictDoUpdate({
             target: boardClimbs.uuid,
-            set: { characteristics: sql`excluded.characteristics` },
+            setWhere: isNull(boardClimbs.userId),
+            set: {
+              characteristics: mergeCatalogCharacteristicsSql(
+                boardClimbs.characteristics,
+                sql`excluded.characteristics`,
+                Object.values(CLIMB_CHARACTERISTICS).filter(isMethodCharacteristic),
+              ),
+            },
           });
         if ((i + BATCH_SIZE) % 5000 === 0 || i + BATCH_SIZE >= climbRecords.length) {
           process.stdout.write(`\r   Climbs: ${Math.min(i + BATCH_SIZE, climbRecords.length)}/${climbRecords.length}`);

--- a/packages/db/scripts/import-woods-catalog.ts
+++ b/packages/db/scripts/import-woods-catalog.ts
@@ -3,7 +3,9 @@ import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
-import { sql } from 'drizzle-orm';
+import { sql, isNull } from 'drizzle-orm';
+import { mergeCatalogCharacteristicsSql } from '../src/queries/climbs/catalog-characteristics.js';
+import { CLIMB_CHARACTERISTICS } from '@boardsesh/shared-schema/characteristics';
 import {
   boardClimbs,
   boardClimbStats,
@@ -17,6 +19,7 @@ import {
   WOODS_REQUIRED_SET_IDS,
   parseWoodsCatalogFile,
 } from './woods-catalog-helpers.js';
+import { buildWoodsRuleCatalog } from './woods-rule-repair.js';
 import { assertWoodsImportAllowed } from './woods-import-guard.js';
 import { getScriptDatabaseUrl, describeDatabaseHost } from './db-connection.js';
 import { blendedQualityAverageSql } from '../src/queries/climb-stats/quality-blend.js';
@@ -95,6 +98,12 @@ async function importWoodsCatalog() {
     process.exit(1);
   }
 
+  // Validate every source before opening a write connection, including rule flags.
+  const catalogs = files.map((file) => ({
+    file,
+    dump: parseWoodsCatalogFile(fs.readFileSync(path.join(catalogDir, file), 'utf8'), file),
+  }));
+  buildWoodsRuleCatalog(catalogs.map(({ dump }) => dump));
   const databaseUrl = getScriptDatabaseUrl();
   console.info(`🔄 Importing Woods catalog to: ${describeDatabaseHost(databaseUrl)}`);
   assertWoodsImportAllowed(databaseUrl, 'import-woods-catalog.ts');
@@ -135,9 +144,7 @@ async function importWoodsCatalog() {
       });
     console.info(`   Seeded ${gradeRows.length} Woods difficulty grades`);
 
-    for (const file of files) {
-      const raw = fs.readFileSync(path.join(catalogDir, file), 'utf-8');
-      const dump = parseWoodsCatalogFile(raw, file);
+    for (const { file, dump } of catalogs) {
       console.info(`\n📖 ${file} — ${dump.boardDimension}, ${dump.problems.length} problems`);
 
       // Dedupe in memory (last wins) keyed per conflict target so a single batch
@@ -215,7 +222,7 @@ async function importWoodsCatalog() {
           requiredSetIds: [...WOODS_REQUIRED_SET_IDS],
           compatibleSizeIds: mapped.compatibleSizeIds,
           holdFingerprint: mapped.holdFingerprint,
-          characteristics: null,
+          characteristics: mapped.characteristics,
         });
 
         statsByKey.set(statsKey, {
@@ -301,7 +308,14 @@ async function importWoodsCatalog() {
             .values(climbRecords.slice(offset, offset + BATCH_SIZE))
             .onConflictDoUpdate({
               target: boardClimbs.uuid,
+              setWhere: isNull(boardClimbs.userId),
               set: {
+                characteristics: mergeCatalogCharacteristicsSql(
+                  boardClimbs.characteristics,
+                  sql`excluded.characteristics`,
+                  [CLIMB_CHARACTERISTICS.NO_MATCH, CLIMB_CHARACTERISTICS.ANY_FEET],
+                  true,
+                ),
                 name: sql`excluded.name`,
                 frames: sql`excluded.frames`,
                 angle: sql`excluded.angle`,

--- a/packages/db/scripts/repair-woods-rules.ts
+++ b/packages/db/scripts/repair-woods-rules.ts
@@ -1,0 +1,67 @@
+/** Repair existing catalog rules. Defaults to a read-only transaction; --apply opts into writes. */
+import fs from 'node:fs';
+import path from 'node:path';
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { and, eq, isNull } from 'drizzle-orm';
+import { applyWoodsRuleUpdates } from '../src/queries/climbs/woods-rule-repair.js';
+import { boardClimbs } from '../src/schema/boards/unified.js';
+import { parseWoodsCatalogFile } from './woods-catalog-helpers.js';
+import { buildWoodsRuleCatalog, planWoodsRuleRepair, parseWoodsRuleRepairArgs } from './woods-rule-repair.js';
+import { describeDatabaseHost, getScriptDatabaseUrl } from './db-connection.js';
+import { assertWoodsImportAllowed } from './woods-import-guard.js';
+
+async function main() {
+  const { directory, apply } = parseWoodsRuleRepairArgs(process.argv.slice(2), process.env.WOODS_CATALOG_DIR);
+  const catalogDir = path.resolve(process.env.INIT_CWD ?? process.cwd(), directory);
+  const catalogs = ['8x10', '12x12'].map((dimension) => {
+    const fileName = `woodsboard_${dimension}.json`;
+    const catalog = parseWoodsCatalogFile(fs.readFileSync(path.join(catalogDir, fileName), 'utf8'), fileName);
+    if (catalog.boardDimension !== dimension || catalog.problems.length === 0) {
+      throw new Error(`Catalog ${fileName} has an incorrect size or no problems`);
+    }
+    return catalog;
+  });
+  const catalog = buildWoodsRuleCatalog(catalogs);
+  const databaseUrl = getScriptDatabaseUrl();
+  console.info(`Woods rules ${apply ? 'apply' : 'dry-run'}: ${describeDatabaseHost(databaseUrl)}`);
+  if (apply) assertWoodsImportAllowed(databaseUrl, 'repair-woods-rules.ts');
+  const client = postgres(databaseUrl, { max: 1, connect_timeout: 15 });
+  const db = drizzle(client);
+  try {
+    await db.transaction(
+      async (transaction) => {
+        const stored = await transaction
+          .select({
+            uuid: boardClimbs.uuid,
+            boardType: boardClimbs.boardType,
+            userId: boardClimbs.userId,
+            frames: boardClimbs.frames,
+            compatibleSizeIds: boardClimbs.compatibleSizeIds,
+            characteristics: boardClimbs.characteristics,
+          })
+          .from(boardClimbs)
+          .where(and(eq(boardClimbs.boardType, 'woods'), isNull(boardClimbs.userId)));
+        const { updates, ...counts } = planWoodsRuleRepair(catalog, stored);
+        console.info(
+          JSON.stringify({
+            mode: apply ? 'apply' : 'dry-run',
+            catalogClimbs: catalog.size,
+            ...counts,
+            updates: updates.length,
+          }),
+        );
+        if (!apply) return;
+        await applyWoodsRuleUpdates(transaction, updates);
+      },
+      { accessMode: apply ? 'read write' : 'read only', isolationLevel: 'repeatable read' },
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+void main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/packages/db/scripts/woods-catalog-helpers.test.ts
+++ b/packages/db/scripts/woods-catalog-helpers.test.ts
@@ -29,6 +29,8 @@ import { getWoodsBoardDetails } from '@boardsesh/board-config';
 // below were cross-checked against the catalog's first problem.
 const IMPOSSIBLE: WoodsCatalogProblem = {
   id: 5228,
+  matching: true,
+  anyFeet: false,
   problemName: 'Impossible ',
   problemGrade: 0,
   proposedGrade: 0,
@@ -387,7 +389,7 @@ void test('woodsGradeRows is ascending and covers every id mapWoodsProblemToClim
 
 void test('parseWoodsCatalogFile round-trips a valid dump', () => {
   const dump = parseWoodsCatalogFile(
-    JSON.stringify({ boardDimension: '8x10', count: 1, problems: [{ id: 1 }] }),
+    JSON.stringify({ boardDimension: '8x10', count: 1, problems: [{ id: 1, matching: true, anyFeet: false }] }),
     'woodsboard_8x10.json',
   );
   assert.equal(dump.boardDimension, '8x10');

--- a/packages/db/scripts/woods-catalog-helpers.ts
+++ b/packages/db/scripts/woods-catalog-helpers.ts
@@ -1,3 +1,4 @@
+import { CLIMB_CHARACTERISTICS } from '@boardsesh/shared-schema/characteristics';
 import { uuidv5 } from './moonboard-helpers.js';
 import { fingerprintFromHolds } from './moonboard-2024-helpers.js';
 import {
@@ -103,6 +104,8 @@ export type WoodsHoldListItem = { type: string; baseHoldLocation: number };
 
 export type WoodsCatalogProblem = {
   id: number;
+  matching: boolean;
+  anyFeet: boolean;
   problemName: string;
   problemGrade: number; // integer 0-17
   proposedGrade?: number;
@@ -120,6 +123,19 @@ export type WoodsCatalogProblem = {
   isProject?: boolean;
   firstAscent?: string | null;
 };
+
+/** Missing upstream flags are unknown, never implicit false values. */
+export function woodsProblemCharacteristics(
+  problem: Pick<WoodsCatalogProblem, 'id' | 'matching' | 'anyFeet'>,
+): string[] {
+  if (typeof problem.matching !== 'boolean' || typeof problem.anyFeet !== 'boolean') {
+    throw new Error(`Woods problem ${problem.id} requires boolean matching and anyFeet flags`);
+  }
+  const characteristics: string[] = [];
+  if (!problem.matching) characteristics.push(CLIMB_CHARACTERISTICS.NO_MATCH);
+  if (problem.anyFeet) characteristics.push(CLIMB_CHARACTERISTICS.ANY_FEET);
+  return characteristics;
+}
 
 export type WoodsCatalogFile = {
   boardDimension: string;
@@ -155,6 +171,14 @@ export function parseWoodsCatalogFile(raw: string, fileName: string): WoodsCatal
   if (!Array.isArray(candidate.problems)) {
     throw new Error(`Catalog file ${fileName} has no "problems" array — is this a Woods catalog dump?`);
   }
+  for (const problem of candidate.problems) {
+    if (!problem || typeof problem !== 'object') throw new Error(`Catalog file ${fileName} has an invalid problem`);
+    try {
+      woodsProblemCharacteristics(problem);
+    } catch (error) {
+      throw new Error(`Catalog file ${fileName}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
   return candidate as WoodsCatalogFile;
 }
 
@@ -166,6 +190,7 @@ export type ParsedWoodsHold = { holdId: number; holdState: WoodsHoldState; roleC
 
 export type MappedWoodsClimb = {
   uuid: string;
+  characteristics: string[];
   layoutId: number;
   angle: number;
   name: string;
@@ -303,6 +328,7 @@ export function normalizeWoodsPublishedDate(raw: string | null | undefined): str
  * problem has no real holds (empty or Clear-only) and so can't be imported.
  */
 export function mapWoodsProblemToClimb(problem: WoodsCatalogProblem): MappedWoodsClimb | null {
+  const characteristics = woodsProblemCharacteristics(problem);
   const parsedHolds = parseHoldList(problem.holdList ?? []);
   if (parsedHolds.length === 0) return null;
   const frames = holdsToFrames(parsedHolds);
@@ -311,6 +337,7 @@ export function mapWoodsProblemToClimb(problem: WoodsCatalogProblem): MappedWood
   const firstAscent = (problem.firstAscent ?? '').trim();
   const difficulty = woodsGradeToDifficulty(problem.problemGrade);
   return {
+    characteristics,
     // Key the UUID off the same trimmed author that lands in setter_username —
     // keying off the raw value would mint a different UUID for " ada" and "ada"
     // while storing the same display name.

--- a/packages/db/scripts/woods-import-guard.ts
+++ b/packages/db/scripts/woods-import-guard.ts
@@ -55,7 +55,11 @@ export function assertWoodsImportAllowed(databaseUrl: string, scriptLabel: strin
   }
 
   console.error(`❌ ${scriptLabel} refuses to run against a non-local database without an explicit opt-in.`);
-  console.error('   It upserts the entire Woods catalog (5,400+ climbs, stats, holds and aliases) in one pass.');
+  console.error(
+    scriptLabel === 'repair-woods-rules.ts'
+      ? '   It updates matching and feet rules on existing imported Woods climbs.'
+      : '   It upserts the entire Woods catalog (5,400+ climbs, stats, holds and aliases) in one pass.',
+  );
   console.error('   That is a deliberate, signed-off operation against prod — not something to do by accident');
   console.error('   because DB_URL was inherited from the shell or pointed at the wrong host.');
   console.error(

--- a/packages/db/scripts/woods-rule-repair.test.ts
+++ b/packages/db/scripts/woods-rule-repair.test.ts
@@ -1,0 +1,134 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildWoodsRuleCatalog,
+  planWoodsRuleRepair,
+  parseWoodsRuleRepairArgs,
+  type WoodsStoredRules,
+} from './woods-rule-repair.js';
+import { mapWoodsProblemToClimb, parseWoodsCatalogFile, type WoodsCatalogProblem } from './woods-catalog-helpers.js';
+
+const problem: WoodsCatalogProblem = {
+  id: 1,
+  problemName: 'Rule fixture',
+  author: 'Setter',
+  problemGrade: 4,
+  angle: 40,
+  boardDimension: '12x12',
+  matching: true,
+  anyFeet: false,
+  holdList: [
+    { type: 'Start', baseHoldLocation: 10 },
+    { type: 'Finish', baseHoldLocation: 20 },
+  ],
+};
+
+void test('repair defaults to dry-run and accepts vp forwarded arguments', () => {
+  assert.deepEqual(parseWoodsRuleRepairArgs(['--', '/catalog']), { directory: '/catalog', apply: false });
+  assert.deepEqual(parseWoodsRuleRepairArgs(['--', '/catalog', '--apply']), { directory: '/catalog', apply: true });
+  assert.deepEqual(parseWoodsRuleRepairArgs([], '/env-catalog'), { directory: '/env-catalog', apply: false });
+  assert.throws(() => parseWoodsRuleRepairArgs(['/catalog', '--aply']), /Usage/);
+  assert.throws(() => parseWoodsRuleRepairArgs([]), /Usage/);
+});
+
+function fixture(matching = true, anyFeet = false) {
+  const source = { ...problem, matching, anyFeet };
+  const catalog = buildWoodsRuleCatalog([{ boardDimension: '12x12', count: 1, problems: [source] }]);
+  const mapped = mapWoodsProblemToClimb(source)!;
+  const stored: WoodsStoredRules = {
+    uuid: mapped.uuid,
+    boardType: 'woods',
+    userId: null,
+    frames: mapped.frames,
+    compatibleSizeIds: [2],
+    characteristics: null,
+  };
+  return { catalog, stored };
+}
+
+void test('imports every rule combination without changing a climb identity', () => {
+  const expectations = [
+    { matching: true, anyFeet: false, expected: [] },
+    { matching: false, anyFeet: false, expected: ['no_match'] },
+    { matching: true, anyFeet: true, expected: ['any_feet'] },
+    { matching: false, anyFeet: true, expected: ['no_match', 'any_feet'] },
+  ];
+  const uuid = mapWoodsProblemToClimb(problem)!.uuid;
+  for (const { matching, anyFeet, expected } of expectations) {
+    const mapped = mapWoodsProblemToClimb({ ...problem, matching, anyFeet })!;
+    assert.equal(mapped.uuid, uuid);
+    assert.deepEqual(mapped.characteristics, expected);
+  }
+});
+
+void test('rejects missing/nonboolean flags before producing a repair plan', () => {
+  for (const matching of [undefined, null, 0, 'false']) {
+    assert.throws(
+      () =>
+        parseWoodsCatalogFile(
+          JSON.stringify({
+            boardDimension: '12x12',
+            problems: [{ ...problem, matching }],
+          }),
+          'bad.json',
+        ),
+      /bad.json.*boolean matching and anyFeet/,
+    );
+  }
+  assert.throws(
+    () =>
+      parseWoodsCatalogFile(
+        JSON.stringify({
+          boardDimension: '12x12',
+          problems: [{ ...problem, anyFeet: undefined }],
+        }),
+        'bad.json',
+      ),
+    /boolean matching and anyFeet/,
+  );
+});
+
+void test('repairs null defaults to known empty rules and is idempotent', () => {
+  const { catalog, stored } = fixture();
+  const plan = planWoodsRuleRepair(catalog, [stored]);
+  assert.equal(plan.matched, 1);
+  assert.deepEqual(plan.updates[0].characteristics, []);
+  assert.equal(stored.characteristics, null);
+  const repeated = planWoodsRuleRepair(catalog, [{ ...stored, characteristics: plan.updates[0].characteristics }]);
+  assert.equal(repeated.updates.length, 0);
+  assert.equal(repeated.unchanged, 1);
+});
+
+void test('refreshes catalog flags while preserving app-owned rules', () => {
+  const { catalog, stored } = fixture(true, false);
+  stored.characteristics = ['no_match', 'any_feet', 'no_kickboard', 'future_rule'];
+  assert.deepEqual(planWoodsRuleRepair(catalog, [stored]).updates[0].characteristics, ['no_kickboard', 'future_rule']);
+});
+
+void test('does not update authored, non-Woods, or unmatched rows', () => {
+  const { catalog, stored } = fixture();
+  const plan = planWoodsRuleRepair(catalog, [
+    { ...stored, userId: 'author' },
+    { ...stored, boardType: 'kilter' },
+    { ...stored, uuid: 'unmatched' },
+  ]);
+  assert.equal(plan.updates.length, 0);
+  assert.equal(plan.unmatched, 1);
+});
+
+void test('rejects changed geometry and conflicting duplicate catalog rules', () => {
+  const { catalog, stored } = fixture();
+  assert.throws(() => planWoodsRuleRepair(catalog, [{ ...stored, compatibleSizeIds: [1] }]), /holds or size/);
+  assert.throws(() => planWoodsRuleRepair(catalog, [{ ...stored, frames: 'p99r4' }]), /holds or size/);
+  assert.throws(
+    () =>
+      buildWoodsRuleCatalog([
+        {
+          boardDimension: '12x12',
+          count: 2,
+          problems: [problem, { ...problem, matching: false }],
+        },
+      ]),
+    /Conflicting Woods rules/,
+  );
+});

--- a/packages/db/scripts/woods-rule-repair.ts
+++ b/packages/db/scripts/woods-rule-repair.ts
@@ -1,0 +1,87 @@
+import { CLIMB_CHARACTERISTICS } from '@boardsesh/shared-schema/characteristics';
+import { mapWoodsProblemToClimb, type WoodsCatalogFile } from './woods-catalog-helpers.js';
+
+export type WoodsCatalogRules = {
+  uuid: string;
+  frames: string;
+  sizeId: number;
+  characteristics: string[];
+};
+
+export type WoodsStoredRules = {
+  uuid: string;
+  boardType: string;
+  userId: string | null;
+  frames: string | null;
+  compatibleSizeIds: number[] | null;
+  characteristics: string[] | null;
+};
+
+import type { WoodsRuleUpdate } from '../src/queries/climbs/woods-rule-repair.js';
+export type { WoodsRuleUpdate } from '../src/queries/climbs/woods-rule-repair.js';
+
+export function parseWoodsRuleRepairArgs(args: string[], envDirectory?: string) {
+  const forwarded = args.filter((argument) => argument !== '--');
+  const directories = forwarded.filter((argument) => !argument.startsWith('--'));
+  const directory = directories[0] ?? envDirectory;
+  if (
+    !directory ||
+    directories.length > 1 ||
+    forwarded.some((argument) => argument.startsWith('--') && argument !== '--apply')
+  ) {
+    throw new Error('Usage: vp run db:repair-woods-rules -- /path/to/catalog [--apply]');
+  }
+  return { directory, apply: forwarded.includes('--apply') };
+}
+
+/** Resolve the same catalog identities as the importer, without minting replacements. */
+export function buildWoodsRuleCatalog(catalogs: WoodsCatalogFile[]): Map<string, WoodsCatalogRules> {
+  const byUuid = new Map<string, WoodsCatalogRules>();
+  for (const catalog of catalogs) {
+    for (const problem of catalog.problems) {
+      if (problem.boardDimension !== catalog.boardDimension) {
+        throw new Error(`Woods problem ${problem.id} has a conflicting board size`);
+      }
+      const mapped = mapWoodsProblemToClimb(problem);
+      if (!mapped) continue;
+      if (mapped.compatibleSizeIds.length !== 1) throw new Error(`Unknown Woods size: ${problem.boardDimension}`);
+      const existing = byUuid.get(mapped.uuid);
+      if (existing && JSON.stringify(existing.characteristics) !== JSON.stringify(mapped.characteristics)) {
+        throw new Error(`Conflicting Woods rules for catalog UUID ${mapped.uuid}`);
+      }
+      byUuid.set(mapped.uuid, {
+        uuid: mapped.uuid,
+        frames: mapped.frames,
+        sizeId: mapped.compatibleSizeIds[0],
+        characteristics: mapped.characteristics,
+      });
+    }
+  }
+  return byUuid;
+}
+
+/** Updates only catalog-owned flags; other characteristics and authored climbs survive. */
+export function planWoodsRuleRepair(catalog: ReadonlyMap<string, WoodsCatalogRules>, stored: WoodsStoredRules[]) {
+  const updates: WoodsRuleUpdate[] = [];
+  let matched = 0;
+  let unmatched = 0;
+  for (const climb of stored) {
+    if (climb.boardType !== 'woods' || climb.userId !== null) continue;
+    const source = catalog.get(climb.uuid);
+    if (!source) {
+      unmatched++;
+      continue;
+    }
+    if (climb.frames !== source.frames || JSON.stringify(climb.compatibleSizeIds) !== JSON.stringify([source.sizeId])) {
+      throw new Error(`Stored Woods climb ${climb.uuid} differs from its catalog holds or size`);
+    }
+    matched++;
+    const retained = (climb.characteristics ?? []).filter(
+      (token) => token !== CLIMB_CHARACTERISTICS.NO_MATCH && token !== CLIMB_CHARACTERISTICS.ANY_FEET,
+    );
+    const characteristics = [...retained, ...source.characteristics];
+    if (JSON.stringify(climb.characteristics) === JSON.stringify(characteristics)) continue;
+    updates.push({ ...source, characteristics, previousCharacteristics: climb.characteristics });
+  }
+  return { matched, unmatched, unchanged: matched - updates.length, updates };
+}

--- a/packages/db/src/queries/climbs/catalog-characteristics.ts
+++ b/packages/db/src/queries/climbs/catalog-characteristics.ts
@@ -1,0 +1,14 @@
+import { sql, type SQL, type SQLWrapper } from 'drizzle-orm';
+
+/** Refresh only the rule tokens owned by an upstream catalog. */
+export function mergeCatalogCharacteristicsSql(
+  current: SQLWrapper,
+  incoming: SQLWrapper,
+  managedTokens: readonly string[],
+  keepEmpty = false,
+): SQL {
+  let retained: SQL = sql`coalesce(${current}, '{}'::text[])`;
+  for (const token of managedTokens) retained = sql`array_remove(${retained}, ${token})`;
+  const merged = sql`${retained} || coalesce(${incoming}, '{}'::text[])`;
+  return keepEmpty ? merged : sql`nullif(${merged}, '{}'::text[])`;
+}

--- a/packages/db/src/queries/climbs/index.ts
+++ b/packages/db/src/queries/climbs/index.ts
@@ -1,4 +1,5 @@
 export { searchClimbs, MAX_SEARCH_PAGE, clampSearchPage } from './search-climbs';
+export { mergeCatalogCharacteristicsSql } from './catalog-characteristics';
 export { createClimbFilters } from './create-climb-filters';
 export { getClimbStars } from './climb-stars';
 export { resolveMoonBoardTickAngle, type MoonBoardTickAngleInput } from './moonboard-tick-angle';
@@ -8,3 +9,5 @@ export { getSetterStats } from './setter-stats';
 export type { SetterStat } from './setter-stats';
 export type { BoardRouteParams, ClimbSearchParams, ClimbSearchInputLike, ClimbRow, ClimbSearchResult } from './types';
 export { mapSearchInputToParams } from './types';
+
+export { applyWoodsRuleUpdates, type WoodsRuleUpdate } from './woods-rule-repair';

--- a/packages/db/src/queries/climbs/woods-rule-repair.ts
+++ b/packages/db/src/queries/climbs/woods-rule-repair.ts
@@ -1,0 +1,45 @@
+import { and, eq, isNull, or, sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { boardClimbs } from '../../schema/boards/unified';
+export type WoodsRuleUpdate = {
+  uuid: string;
+  frames: string;
+  sizeId: number;
+  characteristics: string[];
+  previousCharacteristics: string[] | null;
+};
+
+/** Must run inside the caller's transaction so a stale batch rolls back all writes. */
+export async function applyWoodsRuleUpdates(
+  transaction: Pick<PostgresJsDatabase, 'update'>,
+  updates: WoodsRuleUpdate[],
+): Promise<void> {
+  const ruleArraySql = (tokens: string[] | null) =>
+    tokens === null
+      ? sql`NULL::text[]`
+      : sql`ARRAY[${sql.join(
+          tokens.map((token) => sql`${token}`),
+          sql`, `,
+        )}]::text[]`;
+  // One request per batch keeps remote repairs bounded by 54 round trips,
+  // rather than 5,392 individual updates for the audited catalog.
+  for (let offset = 0; offset < updates.length; offset += 100) {
+    const batch = updates.slice(offset, offset + 100);
+    const cases = batch.map((update) => sql`WHEN ${update.uuid} THEN ${ruleArraySql(update.characteristics)}`);
+    const predicates = batch.map((update) =>
+      and(
+        eq(boardClimbs.uuid, update.uuid),
+        eq(boardClimbs.frames, update.frames),
+        sql`${boardClimbs.characteristics} IS NOT DISTINCT FROM ${ruleArraySql(update.previousCharacteristics)}`,
+      ),
+    );
+    const changed = await transaction
+      .update(boardClimbs)
+      .set({
+        characteristics: sql`CASE ${boardClimbs.uuid} ${sql.join(cases, sql` `)} ELSE ${boardClimbs.characteristics} END`,
+      })
+      .where(and(eq(boardClimbs.boardType, 'woods'), isNull(boardClimbs.userId), or(...predicates)))
+      .returning({ uuid: boardClimbs.uuid });
+    if (changed.length !== batch.length) throw new Error('Woods climbs changed during repair; transaction rolled back');
+  }
+}

--- a/packages/kilter-sync/src/sync/catalog-sync.ts
+++ b/packages/kilter-sync/src/sync/catalog-sync.ts
@@ -9,7 +9,11 @@ import {
   boardPlacements,
   type NewBoardClimb,
 } from '@boardsesh/db/schema';
-import { populateDenormalizedColumns, blendedQualityAverageSql } from '@boardsesh/db/queries';
+import {
+  populateDenormalizedColumns,
+  blendedQualityAverageSql,
+  mergeCatalogCharacteristicsSql,
+} from '@boardsesh/db/queries';
 import { isNoMatchClimb, CLIMB_CHARACTERISTICS } from '@boardsesh/shared-schema';
 
 import type { KilterTokenProvider } from '../api/token-provider';
@@ -387,19 +391,12 @@ export async function flushKilterLayoutBatch(
             set: {
               holdFingerprint: sql`COALESCE(${boardClimbs.holdFingerprint}, excluded.hold_fingerprint)`,
               frames: sql`COALESCE(${boardClimbs.frames}, excluded.frames)`,
-              // Track the latest derived no_match on a re-sync that reaches this
-              // branch (the dedup path normally skips existing UUIDs). Overwrite
-              // (not COALESCE) so a "No match" prefix removed upstream actually
-              // clears the token — matching aurora-sync's excluded.characteristics.
-              //
-              // ASSUMPTION: Kilter/Tension characteristics currently only carry
-              // `no_match`; method tags are MoonBoard-only. A blind overwrite is
-              // therefore safe — the incoming value is either ['no_match'] or null,
-              // and we want null to clear a stale token. If Kilter ever gains its
-              // own characteristic tokens (e.g. board-specific flags), switch this
-              // to a merge expression (e.g. array_cat + dedup) so that tokens not
-              // managed by this sync path aren't silently dropped.
-              characteristics: sql`excluded.characteristics`,
+              // Aurora owns no_match; preserve rules authored in Boardsesh.
+              characteristics: mergeCatalogCharacteristicsSql(
+                boardClimbs.characteristics,
+                sql`excluded.characteristics`,
+                [CLIMB_CHARACTERISTICS.NO_MATCH],
+              ),
             },
           });
       });

--- a/packages/mobile/app/(tabs)/climbs/__tests__/create.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/create.test.tsx
@@ -128,49 +128,47 @@ describe('CreateClimbRoute board resolution', () => {
   });
 });
 
-describe('CreateClimbRoute on a board that cannot have climbs set on it', () => {
-  // A cold `…/climbs/create?boardName=woods` used to resolve to no board at all
-  // and paint a spinner that never resolved.
-  it('replaces to the climbs tab when a Woods link opens cold', () => {
-    routeParams.current = { boardName: 'woods', layoutId: '1', sizeId: '1', setIds: '1', angle: '40' };
+describe('CreateClimbRoute Woods authoring', () => {
+  it.each(['1', '2'])('opens Woods size %s from a cold link', (sizeId) => {
+    routeParams.current = { boardName: 'woods', layoutId: '1', sizeId, setIds: '1', angle: '40' };
     activeBoard.current = KILTER_ACTIVE_BOARD;
-    router.canGoBack.mockReturnValue(false);
-
     const { container } = render(<CreateClimbRoute />);
-
-    expect(router.replace).toHaveBeenCalledWith('/(tabs)/climbs');
-    expect(router.back).not.toHaveBeenCalled();
-    // Never silently swaps in the active board — the link asked for Woods.
-    expect(container.querySelector('[data-editor]')).toBeNull();
-    expect(editorBoard.latest).toBeNull();
-  });
-
-  it('pops back instead when there is history to pop', () => {
-    routeParams.current = { boardName: 'woods' };
-    activeBoard.current = KILTER_ACTIVE_BOARD;
-    router.canGoBack.mockReturnValue(true);
-
-    render(<CreateClimbRoute />);
-
-    expect(router.back).toHaveBeenCalled();
+    expect(container.querySelector('[data-editor]')).not.toBeNull();
+    expect(editorBoard.latest).toMatchObject({ boardName: 'woods', sizeId: Number(sizeId) });
     expect(router.replace).not.toHaveBeenCalled();
   });
 
-  it('leaves a bare open when the ACTIVE board is the one that cannot be set on', () => {
-    activeBoard.current = WOODS_ACTIVE_BOARD;
-
+  it('leaves an incomplete Woods link instead of loading a different board', () => {
+    routeParams.current = { boardName: 'woods', forkFrames: 'p0r4p1r3' };
+    activeBoard.current = KILTER_ACTIVE_BOARD;
+    router.canGoBack.mockReturnValue(true);
     render(<CreateClimbRoute />);
+    expect(router.back).toHaveBeenCalled();
+    expect(editorBoard.latest).toBeNull();
+  });
 
+  it.each([
+    { layoutId: '1', sizeId: '99', angle: '40' },
+    { layoutId: '8', sizeId: '1', angle: '40' },
+    { layoutId: '1', sizeId: '1', angle: '42' },
+  ])('rejects invalid Woods geometry: %j', (geometry) => {
+    routeParams.current = { boardName: 'woods', setIds: '1', ...geometry };
+    activeBoard.current = KILTER_ACTIVE_BOARD;
+    render(<CreateClimbRoute />);
     expect(router.replace).toHaveBeenCalledWith('/(tabs)/climbs');
     expect(editorBoard.latest).toBeNull();
   });
 
-  // Still loading: `data` is undefined, so there is nothing to decide on yet.
-  it('waits on the spinner while the active board is still loading', () => {
+  it('opens bare on the active Woods board', () => {
+    activeBoard.current = WOODS_ACTIVE_BOARD;
+    render(<CreateClimbRoute />);
+    expect(editorBoard.latest).toMatchObject({ boardName: 'woods', sizeId: 1 });
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it('waits while the active board is still loading', () => {
     activeBoard.current = undefined;
-
     const { container } = render(<CreateClimbRoute />);
-
     expect(container.querySelector('[data-spinner]')).not.toBeNull();
     expect(router.replace).not.toHaveBeenCalled();
     expect(router.back).not.toHaveBeenCalled();

--- a/packages/mobile/app/(tabs)/climbs/create.tsx
+++ b/packages/mobile/app/(tabs)/climbs/create.tsx
@@ -1,7 +1,13 @@
 import { useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
-import { getBoardCapabilities, SUPPORTED_BOARDS } from '@boardsesh/board-config';
+import {
+  getBoardCapabilities,
+  SUPPORTED_BOARDS,
+  WOODS_ANGLES,
+  WOODS_LAYOUTS,
+  woodsSizeIdToDimension,
+} from '@boardsesh/board-config';
 import type { BoardName, UserBoard } from '@boardsesh/shared-schema';
 import { CreateClimbScreen } from '../../../src/components/create-climb/CreateClimbScreen';
 import { ActivityIndicator } from '../../../src/components/ActivityIndicator';
@@ -18,6 +24,7 @@ type CreateClimbParams = {
   forkFrames?: string;
   forkName?: string;
   forkDescription?: string;
+  forkCharacteristics?: string;
   editClimbUuid?: string;
 };
 
@@ -39,24 +46,46 @@ type EditorBoard = {
  * render on the remix/edit path (#3804). Treating an unsupported value as absent
  * makes it fall back to the active board, exactly like a missing param.
  *
- * A board that cannot have climbs set on it (the climbCreation capability;
- * Woods, until #4750) is NOT handled here — it would look identical to a typo and
- * fall back to some other board's wall, which is not what a link saying "create
- * on Woods" asked for. `CreateClimbRoute` checks it separately and leaves the
- * route.
+ * A board that cannot have climbs set on it (the climbCreation capability) is
+ * NOT handled here — it would look identical to a typo and fall back to some
+ * other board's wall, which is not what a link naming that board asked for.
+ * `CreateClimbRoute` checks it separately and leaves the route.
  */
 function supportedBoardName(candidate: string | undefined): BoardName | undefined {
   if (candidate == null) return undefined;
   return (SUPPORTED_BOARDS as readonly string[]).includes(candidate) ? (candidate as BoardName) : undefined;
 }
 
-/** The active board as an editor tuple, or null when it can't open the editor. */
+/** The active board as an editor tuple, or null when its board name isn't one we support. */
 function activeBoardTuple(activeBoard: UserBoard | null | undefined): EditorBoard | null {
   if (!activeBoard) return null;
   const boardName = supportedBoardName(activeBoard.boardType);
-  if (!boardName || !getBoardCapabilities(boardName).climbCreation) return null;
+  if (!boardName) return null;
   const { layoutId, sizeId, setIds, angle } = activeBoard;
   return { boardName, layoutId, sizeId, setIds, angle };
+}
+
+/**
+ * Can the editor actually open on this exact tuple?
+ *
+ * Two separate questions, both of which used to be one board-name check:
+ *  - does the board allow authoring at all (the capability), and
+ *  - is the SIZE one the board really has. That second one only bites on Woods,
+ *    whose two sizes number their holds from their own origins (8x10: 0-484,
+ *    12x12: 0-893). A link carrying any other size id resolves to no hold table,
+ *    which would otherwise render an empty wall you can paint nothing on.
+ */
+function isAuthorableBoard(board: EditorBoard | null): board is EditorBoard {
+  if (!board) return false;
+  if (!getBoardCapabilities(board.boardName).climbCreation) return false;
+  if (board.boardName === 'woods') {
+    return (
+      board.layoutId === WOODS_LAYOUTS.woods.id &&
+      woodsSizeIdToDimension(board.sizeId) !== undefined &&
+      (WOODS_ANGLES as readonly number[]).includes(board.angle)
+    );
+  }
+  return true;
 }
 
 /**
@@ -79,7 +108,7 @@ function resolveEditorBoard(params: CreateClimbParams, activeBoard: UserBoard | 
   const sizeId = params.sizeId ? Number(params.sizeId) : sameBoard?.sizeId;
   const setIds = params.setIds ?? sameBoard?.setIds;
   const angle = params.angle ? Number(params.angle) : sameBoard?.angle;
-  if (layoutId == null || sizeId == null || setIds == null || angle == null) return activeTuple;
+  if (layoutId == null || sizeId == null || setIds == null || angle == null) return null;
   return { boardName, layoutId, sizeId, setIds, angle };
 }
 
@@ -92,27 +121,27 @@ export default function CreateClimbRoute() {
   const params = useLocalSearchParams<CreateClimbParams>();
   const { data: activeBoard } = useActiveBoard();
 
-  // A board that can't have climbs set on it (Woods, #4750) has nowhere to land:
-  // the editor cannot paint its holds, and silently swapping in a different
-  // board would set the climb on the wrong wall. That's true whether the link
-  // names it or it's simply the user's active board — either way, leave the
-  // route rather than render a spinner that never resolves. Checking
-  // `boardType` (not the absent tuple) keeps this off the still-loading case,
-  // where `activeBoard` is undefined and the spinner is the right answer.
+  const resolvedBoard = useMemo(() => resolveEditorBoard(params, activeBoard), [params, activeBoard]);
+
+  // A board config the editor can't open has nowhere to land: it cannot paint
+  // the holds, and silently swapping in a different board would set the climb on
+  // the wrong wall. Leave the route rather than render a spinner that never
+  // resolves.
+  //
+  // Checked on the LINK first (not just the resolved tuple), because a link that
+  // names an uncreatable board must not fall through to the active board's wall —
+  // it asked for that one. Then on the resolved tuple, which catches an
+  // uncreatable or wrong-sized ACTIVE board by the same rule. `resolvedBoard`
+  // being null while `activeBoard` is still undefined is the loading case, where
+  // the spinner is the right answer, so it is deliberately not an exit.
   const linkNamesUncreatableBoard = params.boardName != null && !getBoardCapabilities(params.boardName).climbCreation;
-  // A missing or unrecognised board name falls back to the active board whole,
-  // so an uncreatable ACTIVE board is the same dead end by another route.
-  const fallsBackToUncreatableBoard =
-    supportedBoardName(params.boardName) == null &&
-    activeBoard != null &&
-    !getBoardCapabilities(activeBoard.boardType).climbCreation;
-  const cannotCreateHere = linkNamesUncreatableBoard || fallsBackToUncreatableBoard;
+  const resolvedBoardUnusable = resolvedBoard != null && !isAuthorableBoard(resolvedBoard);
+  const namedBoardMissingGeometry =
+    supportedBoardName(params.boardName) != null && resolvedBoard == null && activeBoard !== undefined;
+  const cannotCreateHere = linkNamesUncreatableBoard || resolvedBoardUnusable || namedBoardMissingGeometry;
   useUnsupportedBoardExit(cannotCreateHere);
 
-  const board = useMemo(
-    () => (cannotCreateHere ? null : resolveEditorBoard(params, activeBoard)),
-    [cannotCreateHere, params, activeBoard],
-  );
+  const board = cannotCreateHere ? null : resolvedBoard;
 
   if (!board) {
     return (
@@ -134,6 +163,7 @@ export default function CreateClimbRoute() {
       forkFrames={params.forkFrames}
       forkName={params.forkName}
       forkDescription={params.forkDescription}
+      forkCharacteristics={params.forkCharacteristics}
       editClimbUuid={params.editClimbUuid}
     />
   );

--- a/packages/mobile/src/components/ClimbAttributeIcons.tsx
+++ b/packages/mobile/src/components/ClimbAttributeIcons.tsx
@@ -5,6 +5,7 @@ import type { TFunction } from 'i18next';
 import {
   CLIMB_CHARACTERISTICS,
   getMoonBoardMethod,
+  isAnyFeet,
   isCampus,
   isNoKickboard,
   isNoMatch,
@@ -45,13 +46,21 @@ function methodLabel(characteristics: string[] | null | undefined, t: TFunction<
 }
 
 /**
- * Text badges for the freely-toggleable no-kickboard / campus characteristics —
- * same reasoning as `methodLabel` above: no clean SF-Symbol exists for either
- * rule, so they render as text rather than joining the icon-map.
+ * Text badges for the freely-toggleable any-feet / no-kickboard / campus
+ * characteristics — same reasoning as `methodLabel` above: no clean SF-Symbol
+ * exists for any of them, so they render as text rather than joining the
+ * icon-map.
+ *
+ * Any-feet is a DEPARTURE from the default on every board (feet normally follow
+ * the marked holds), so it earns a badge in a compact row the same way campus
+ * does. The play drawer's Woods header says both rules in full instead — see
+ * `explicitClimbRules` — and suppresses this cluster's characteristics so the
+ * two don't repeat each other.
  */
 function extraCharacteristicLabels(characteristics: string[] | null | undefined, t: TFunction<'climbs'>): string[] {
   const labels: string[] = [];
   if (isCampus(characteristics)) labels.push(t('mobile.climbRow.campus'));
+  else if (isAnyFeet(characteristics)) labels.push(t('mobile.climbRow.anyFeet'));
   if (isNoKickboard(characteristics)) labels.push(t('mobile.climbRow.noKickboard'));
   return labels;
 }

--- a/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-actions-sheet.test.tsx
@@ -220,16 +220,14 @@ describe('ClimbActionsSheet controlled visible (always-mounted toggle)', () => {
     expect(container.querySelector('[data-icon="open.external"]')?.getAttribute('data-color')).toBe('#00f');
   });
 
-  // Woods has no create-climb path (its holds cannot be painted in the editor), so
-  // both entry points into that editor must be absent — the rest of the sheet stays.
-  it('hides Fork and Edit on a board that cannot have climbs set on it', () => {
+  it('offers Fork and Edit on Woods now that authoring is supported', () => {
     ctrl.canUpdate = true;
     const { container } = render(
       <ClimbActionsSheet visible={true} {...baseProps} climb={ownerClimb} boardName="woods" currentUserId="user-1" />,
     );
 
-    expect(container.querySelector('[data-row="mobile.climbActions.fork"]')).toBeNull();
-    expect(container.querySelector('[data-row="mobile.climbActions.edit"]')).toBeNull();
+    expect(container.querySelector('[data-row="mobile.climbActions.fork"]')).not.toBeNull();
+    expect(container.querySelector('[data-row="mobile.climbActions.edit"]')).not.toBeNull();
     expect(container.querySelector('[data-row="mobile.climbActions.copyLink"]')).not.toBeNull();
   });
 

--- a/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/use-climb-actions.test.tsx
@@ -139,9 +139,7 @@ describe('useClimbActions gating', () => {
     ).not.toContain('edit');
   });
 
-  // Woods climbs can't be forked or edited — the create-climb editor has no way to
-  // paint its holds — so both rows drop out while the rest of the sheet stays.
-  it('drops "Fork" and "Edit" on a board that cannot have climbs set on it', () => {
+  it('offers Fork and Edit on Woods with the usual ownership rules', () => {
     ctrl.canUpdate = true;
     const woodsIds = ids({
       climb: ownerClimb,
@@ -150,9 +148,9 @@ describe('useClimbActions gating', () => {
       currentUserId: 'user-1',
     });
 
-    expect(woodsIds).not.toContain('fork');
-    expect(woodsIds).not.toContain('edit');
-    expect(woodsIds).toEqual(['preview', 'queue', 'playlist', 'favorite', 'tick', 'share']);
+    expect(woodsIds).toContain('fork');
+    expect(woodsIds).toContain('edit');
+    expect(woodsIds).toEqual(expect.arrayContaining(['preview', 'queue', 'playlist', 'favorite', 'tick', 'share']));
   });
 
   it('returns nothing without a climb or board config', () => {

--- a/packages/mobile/src/components/create-climb/CreateClimbScreen.tsx
+++ b/packages/mobile/src/components/create-climb/CreateClimbScreen.tsx
@@ -21,6 +21,8 @@ type CreateClimbScreenProps = {
   forkFrames?: string;
   forkName?: string;
   forkDescription?: string;
+  /** JSON-encoded `characteristics` of the climb being remixed (#4832). */
+  forkCharacteristics?: string;
   editClimbUuid?: string;
 };
 
@@ -36,6 +38,7 @@ export function CreateClimbScreen({
   forkFrames,
   forkName,
   forkDescription,
+  forkCharacteristics,
   editClimbUuid,
 }: CreateClimbScreenProps) {
   const { t } = useTranslation('climbs');
@@ -61,6 +64,7 @@ export function CreateClimbScreen({
     forkFrames,
     forkName,
     forkDescription,
+    forkCharacteristics,
     editClimbUuid,
     onPublished: () => router.back(),
     onStartedNewClimb: handleStartedNewClimb,
@@ -138,7 +142,10 @@ export function CreateClimbScreen({
     [openPlayDrawer, router, board],
   );
 
-  if (!boardHolds) {
+  // No hold geometry for this config, or a climb that doesn't belong on this
+  // board size — either way there is no honest editor to draw, so say so rather
+  // than seeding one with holds that mean something else on this wall.
+  if (!boardHolds || controller.editSizeMismatch) {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: systemColors.background }]} edges={['bottom']}>
         <View style={styles.centered}>
@@ -147,7 +154,9 @@ export function CreateClimbScreen({
             {t('mobile.create.unavailable.title')}
           </Text>
           <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.centeredSubtitle}>
-            {t('mobile.create.unavailable.subtitle')}
+            {controller.editSizeMismatch
+              ? t('mobile.create.unavailable.wrongSize')
+              : t('mobile.create.unavailable.subtitle')}
           </Text>
         </View>
       </SafeAreaView>

--- a/packages/mobile/src/components/create-climb/CreateDrawer.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawer.tsx
@@ -251,6 +251,7 @@ export function CreateDrawer({
             onRedo={controller.redo}
             onClearHolds={controller.handleClearHolds}
             onNewClimb={controller.handleNewClimb}
+            supportsMultiFrame={controller.supportsMultiFrame}
             frameCount={controller.frameCount}
             currentFrameIndex={controller.currentFrameIndex}
             onDuplicateFrame={controller.duplicateFrame}
@@ -276,6 +277,9 @@ export function CreateDrawer({
             onChangeNoKickboard={controller.setNoKickboard}
             campus={controller.campus}
             onChangeCampus={controller.setCampus}
+            anyFeet={controller.anyFeet}
+            onChangeAnyFeet={controller.setAnyFeet}
+            anyFeetAvailable={controller.anyFeetAvailable}
             isDraft={controller.isDraft}
             onChangeIsDraft={controller.setIsDraft}
             showAllHolds={controller.showAllHolds}

--- a/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
@@ -39,6 +39,9 @@ type CreateDrawerActionBarProps = {
   onClearHolds: () => void;
   /** Park this climb and start a blank one (confirms when nothing is saved yet). */
   onNewClimb: () => void;
+  /** Whether this board's climbs can hold more than one frame. False on Woods,
+   *  which lights one static frame — the whole frame cluster is hidden then. */
+  supportsMultiFrame: boolean;
   frameCount: number;
   currentFrameIndex: number;
   onDuplicateFrame: () => void;
@@ -78,6 +81,7 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
   onRedo,
   onClearHolds,
   onNewClimb,
+  supportsMultiFrame,
   frameCount,
   currentFrameIndex,
   onDuplicateFrame,
@@ -213,13 +217,18 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
             onPress={onClearHolds}
             accessibilityLabel={t('mobile.create.actions.clear')}
           />
-          <ActionButton
-            size="sm"
-            iconName="copy"
-            onPress={handleDuplicateFrame}
-            accessibilityLabel={t('mobile.create.frames.duplicate')}
-          />
-          {frameCount > 1 && (
+          {/* Duplicate is what MAKES a second frame, so it goes with the stepper
+              on a board that can't have one. Leaving it would offer a control
+              whose only outcome is a climb the wall then refuses to light. */}
+          {supportsMultiFrame && (
+            <ActionButton
+              size="sm"
+              iconName="copy"
+              onPress={handleDuplicateFrame}
+              accessibilityLabel={t('mobile.create.frames.duplicate')}
+            />
+          )}
+          {supportsMultiFrame && frameCount > 1 && (
             <>
               <ActionButton
                 size="sm"

--- a/packages/mobile/src/components/create-climb/CreateDrawerForm.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawerForm.tsx
@@ -18,6 +18,11 @@ type CreateDrawerFormProps = {
   onChangeNoKickboard: (next: boolean) => void;
   campus: boolean;
   onChangeCampus: (next: boolean) => void;
+  anyFeet: boolean;
+  onChangeAnyFeet: (next: boolean) => void;
+  /** False while the climb's MoonBoard method already forbids feet — the row is
+   *  hidden rather than shown as a toggle that contradicts the climb. */
+  anyFeetAvailable: boolean;
   isDraft: boolean;
   onChangeIsDraft: (next: boolean) => void;
   showAllHolds: boolean;
@@ -39,6 +44,9 @@ export function CreateDrawerForm({
   onChangeNoKickboard,
   campus,
   onChangeCampus,
+  anyFeet,
+  onChangeAnyFeet,
+  anyFeetAvailable,
   isDraft,
   onChangeIsDraft,
   showAllHolds,
@@ -87,6 +95,17 @@ export function CreateDrawerForm({
           value={noKickboard}
           onValueChange={onChangeNoKickboard}
         />
+        {/* The two feet rules sit next to each other because they answer the same
+            question, and the controller keeps them mutually exclusive: turning one
+            on turns the other off. */}
+        {anyFeetAvailable ? (
+          <SwitchRow
+            label={t('mobile.create.settings.anyFeetLabel')}
+            description={t('mobile.create.settings.anyFeetDescription')}
+            value={anyFeet}
+            onValueChange={onChangeAnyFeet}
+          />
+        ) : null}
         <SwitchRow
           label={t('mobile.create.settings.campusLabel')}
           description={t('mobile.create.settings.campusDescription')}

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-action-bar.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-action-bar.test.tsx
@@ -73,6 +73,7 @@ const baseProps = {
   onRedo: vi.fn(),
   onClearHolds: vi.fn(),
   onNewClimb: vi.fn(),
+  supportsMultiFrame: true,
   frameCount: 1,
   currentFrameIndex: 0,
   onDuplicateFrame: vi.fn(),

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-navigation.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-navigation.test.tsx
@@ -35,6 +35,25 @@ beforeEach(() => {
 });
 
 describe('useCreateClimbNavigation serialized handoff', () => {
+  it.each([{ characteristics: [] }, { characteristics: ['campus', 'no_kickboard'] }, { characteristics: null }])(
+    'carries source rules and physical size into a Woods remix: $characteristics',
+    ({ characteristics }) => {
+      const { result } = renderHook(() => useCreateClimbNavigation());
+      const source = {
+        ...climb,
+        boardType: 'woods',
+        layoutId: 1,
+        frames: 'p0r4p1r3',
+        compatibleSizeIds: [1],
+        characteristics,
+      };
+      result.current.openRemix(source, { boardName: 'woods', layoutId: 1, sizeId: 2, setIds: '1', angle: 40 });
+      const params = router.push.mock.calls[0][0].params;
+      expect(params.sizeId).toBe('1');
+      expect(params.forkCharacteristics).toBe(characteristics ? JSON.stringify(characteristics) : undefined);
+    },
+  );
+
   it('claims one action before overlay dismissal, then waits source → player → push', async () => {
     const sourceDeferred = deferredDismiss();
     const playerDeferred = deferredDismiss();

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-analytics.test.tsx
@@ -71,20 +71,12 @@ vi.mock('@tanstack/react-query', () => ({
   useQueryClient: () => reactQuery,
 }));
 
-vi.mock('@boardsesh/shared-schema', () => ({
+// Partial: the controller now reads @boardsesh/board-config too, which imports
+// this package for real (SUPPORTED_BOARDS). A total mock breaks that import.
+vi.mock('@boardsesh/shared-schema', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/shared-schema')>()),
   isNoMatchClimb: () => false,
   withNoMatch: (description: string) => description,
-  CLIMB_CHARACTERISTICS: { NO_KICKBOARD: 'no_kickboard', CAMPUS: 'campus', NO_MATCH: 'no_match' },
-  hasCharacteristic: (characteristics: string[] | null | undefined, token: string) =>
-    !!characteristics && characteristics.includes(token),
-  isNoKickboard: (characteristics: string[] | null | undefined) =>
-    !!characteristics && characteristics.includes('no_kickboard'),
-  isCampus: (characteristics: string[] | null | undefined) => !!characteristics && characteristics.includes('campus'),
-  withCharacteristic: (characteristics: string[] | null | undefined, token: string, enabled: boolean) => {
-    const current = characteristics ? [...characteristics] : [];
-    if (!enabled) return current.filter((existing) => existing !== token);
-    return current.includes(token) ? current : [...current, token];
-  },
 }));
 
 vi.mock('@boardsesh/create-climb-react', () => ({

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-angle.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-angle.test.tsx
@@ -64,20 +64,12 @@ vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => k
 vi.mock('@tanstack/react-query', () => ({
   useQueryClient: () => ({ invalidateQueries: vi.fn() }),
 }));
-vi.mock('@boardsesh/shared-schema', () => ({
+// Partial: the controller now reads @boardsesh/board-config too, which imports
+// this package for real (SUPPORTED_BOARDS). A total mock breaks that import.
+vi.mock('@boardsesh/shared-schema', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/shared-schema')>()),
   isNoMatchClimb: () => false,
   withNoMatch: (description: string) => description,
-  CLIMB_CHARACTERISTICS: { NO_KICKBOARD: 'no_kickboard', CAMPUS: 'campus', NO_MATCH: 'no_match' },
-  hasCharacteristic: (characteristics: string[] | null | undefined, token: string) =>
-    !!characteristics && characteristics.includes(token),
-  isNoKickboard: (characteristics: string[] | null | undefined) =>
-    !!characteristics && characteristics.includes('no_kickboard'),
-  isCampus: (characteristics: string[] | null | undefined) => !!characteristics && characteristics.includes('campus'),
-  withCharacteristic: (characteristics: string[] | null | undefined, token: string, enabled: boolean) => {
-    const current = characteristics ? [...characteristics] : [];
-    if (!enabled) return current.filter((existing) => existing !== token);
-    return current.includes(token) ? current : [...current, token];
-  },
 }));
 vi.mock('@boardsesh/create-climb-react', () => ({
   useCreateClimb: () => createClimb,

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-autosave.test.tsx
@@ -82,20 +82,16 @@ vi.mock('@tanstack/react-query', () => ({
 vi.mock('react-native', () => ({
   AppState: { addEventListener: appState.addEventListener },
 }));
-vi.mock('@boardsesh/shared-schema', () => ({
+// Partial, for two reasons: the controller now reads @boardsesh/board-config,
+// which imports this package for real (SUPPORTED_BOARDS) — and only the two
+// description helpers want stubbing here, since this suite is about which slot
+// gets written, not about the `No match` wire convention. The characteristic
+// helpers run for real; a hand-rolled copy of that table drifts from it the day
+// a token is added.
+vi.mock('@boardsesh/shared-schema', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/shared-schema')>()),
   isNoMatchClimb: () => false,
   withNoMatch: (description: string) => description,
-  CLIMB_CHARACTERISTICS: { NO_KICKBOARD: 'no_kickboard', CAMPUS: 'campus', NO_MATCH: 'no_match' },
-  hasCharacteristic: (characteristics: string[] | null | undefined, token: string) =>
-    !!characteristics && characteristics.includes(token),
-  isNoKickboard: (characteristics: string[] | null | undefined) =>
-    !!characteristics && characteristics.includes('no_kickboard'),
-  isCampus: (characteristics: string[] | null | undefined) => !!characteristics && characteristics.includes('campus'),
-  withCharacteristic: (characteristics: string[] | null | undefined, token: string, enabled: boolean) => {
-    const current = characteristics ? [...characteristics] : [];
-    if (!enabled) return current.filter((existing) => existing !== token);
-    return current.includes(token) ? current : [...current, token];
-  },
 }));
 vi.mock('@boardsesh/create-climb-react', () => ({
   useCreateClimb: () => createClimb,

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-clear.test.tsx
@@ -64,23 +64,15 @@ vi.mock('@tanstack/react-query', () => ({
 // Real-ish no-match encoding: enabling prepends the canonical marker so the
 // leaked-toggle bug is observable in the description sent to saveClimb.
 const NO_MATCH_PREFIX = 'No match\n';
-vi.mock('@boardsesh/shared-schema', () => ({
+// Partial: the controller now reads @boardsesh/board-config too, which imports
+// this package for real (SUPPORTED_BOARDS). A total mock breaks that import.
+vi.mock('@boardsesh/shared-schema', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/shared-schema')>()),
   isNoMatchClimb: (description: string | null | undefined) => /^no match/i.test(description ?? ''),
   withNoMatch: (description: string | null | undefined, enabled: boolean) => {
     const current = description ?? '';
     if (enabled) return /^no match/i.test(current) ? current : `${NO_MATCH_PREFIX}${current}`;
     return current.replace(/^no match(?:\r?\n|$)/i, '');
-  },
-  CLIMB_CHARACTERISTICS: { NO_KICKBOARD: 'no_kickboard', CAMPUS: 'campus', NO_MATCH: 'no_match' },
-  hasCharacteristic: (characteristics: string[] | null | undefined, token: string) =>
-    !!characteristics && characteristics.includes(token),
-  isNoKickboard: (characteristics: string[] | null | undefined) =>
-    !!characteristics && characteristics.includes('no_kickboard'),
-  isCampus: (characteristics: string[] | null | undefined) => !!characteristics && characteristics.includes('campus'),
-  withCharacteristic: (characteristics: string[] | null | undefined, token: string, enabled: boolean) => {
-    const current = characteristics ? [...characteristics] : [];
-    if (!enabled) return current.filter((existing) => existing !== token);
-    return current.includes(token) ? current : [...current, token];
   },
 }));
 

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-paint.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-paint.test.tsx
@@ -57,7 +57,10 @@ vi.mock('@tanstack/react-query', () => ({
   useQueryClient: () => ({ invalidateQueries: vi.fn() }),
 }));
 
-vi.mock('@boardsesh/shared-schema', () => ({
+// Partial: the controller now reads @boardsesh/board-config too, which imports
+// this package for real (SUPPORTED_BOARDS). A total mock breaks that import.
+vi.mock('@boardsesh/shared-schema', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/shared-schema')>()),
   isNoMatchClimb: () => false,
   withNoMatch: (description: string | null | undefined) => description ?? '',
 }));

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-queue.test.tsx
@@ -65,20 +65,12 @@ vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => k
 vi.mock('@tanstack/react-query', () => ({
   useQueryClient: () => ({ invalidateQueries: vi.fn() }),
 }));
-vi.mock('@boardsesh/shared-schema', () => ({
+// Partial: the controller now reads @boardsesh/board-config too, which imports
+// this package for real (SUPPORTED_BOARDS). A total mock breaks that import.
+vi.mock('@boardsesh/shared-schema', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/shared-schema')>()),
   isNoMatchClimb: () => false,
   withNoMatch: (description: string) => description,
-  CLIMB_CHARACTERISTICS: { NO_KICKBOARD: 'no_kickboard', CAMPUS: 'campus', NO_MATCH: 'no_match' },
-  hasCharacteristic: (characteristics: string[] | null | undefined, token: string) =>
-    !!characteristics && characteristics.includes(token),
-  isNoKickboard: (characteristics: string[] | null | undefined) =>
-    !!characteristics && characteristics.includes('no_kickboard'),
-  isCampus: (characteristics: string[] | null | undefined) => !!characteristics && characteristics.includes('campus'),
-  withCharacteristic: (characteristics: string[] | null | undefined, token: string, enabled: boolean) => {
-    const current = characteristics ? [...characteristics] : [];
-    if (!enabled) return current.filter((existing) => existing !== token);
-    return current.includes(token) ? current : [...current, token];
-  },
 }));
 vi.mock('@boardsesh/create-climb-react', () => ({
   useCreateClimb: () => createClimb,

--- a/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-rules.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/use-create-climb-screen-rules.test.tsx
@@ -1,0 +1,543 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The climb-RULE half of the create controller: the "any feet" switch, its
+// exclusivity with campus, what a save/update actually puts on the wire, and what
+// a remix inherits from the climb it was remixed from (#4832).
+//
+// The real @boardsesh/shared-schema characteristic helpers run here on purpose —
+// a hand-rolled copy of that token table is exactly what would let an any_feet
+// regression pass.
+
+const ble = vi.hoisted(() => ({
+  context: null as null | {
+    boardName: string;
+    layoutId: number;
+    sizeId: number;
+    isConnected: boolean;
+    loading: boolean;
+    sendFramesToBoard: ReturnType<typeof vi.fn>;
+    connect: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+  },
+}));
+
+const graphql = vi.hoisted(() => ({
+  climb: undefined as undefined | Record<string, unknown>,
+  climbFailed: false,
+}));
+const boardActions = vi.hoisted(() => ({ saveClimb: vi.fn(), updateClimb: vi.fn() }));
+const queue = vi.hoisted(() => ({ setCurrentClimb: vi.fn() }));
+const draftStore = vi.hoisted(() => ({
+  loadDraft: vi.fn(async () => null as null | Record<string, unknown>),
+  saveDraft: vi.fn(async () => {}),
+  clearDraft: vi.fn(async () => {}),
+}));
+
+const createClimb = vi.hoisted(() => ({
+  litUpHoldsMap: { 1: { state: 'STARTING' } } as Record<number, { state: string }>,
+  frames: [{ 1: { state: 'STARTING' } }] as Array<Record<number, { state: string }>>,
+  frameCount: 1,
+  currentFrameIndex: 0,
+  setHoldState: vi.fn(),
+  generateFramesString: vi.fn(() => 'p1r4p2r2p3r3'),
+  currentFrameBleString: vi.fn(() => 'p1r4p2r2p3r3'),
+  startingCount: 1,
+  finishCount: 1,
+  isValid: true,
+  canSave: true,
+  canPublish: true,
+  resetHolds: vi.fn(),
+  loadHolds: vi.fn(),
+  loadFrames: vi.fn(),
+  duplicateFrame: vi.fn(),
+  deleteFrame: vi.fn(),
+  goToFrame: vi.fn(),
+  nextFrame: vi.fn(),
+  prevFrame: vi.fn(),
+  undo: vi.fn(),
+  redo: vi.fn(),
+  canUndo: false,
+  canRedo: false,
+}));
+
+vi.mock('react-native', () => ({ AppState: { addEventListener: () => ({ remove: () => {} }) } }));
+vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'preview-uuid' }));
+vi.mock('expo-router', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@tanstack/react-query', () => ({ useQueryClient: () => ({ invalidateQueries: vi.fn() }) }));
+vi.mock('@boardsesh/create-climb-react', () => ({
+  useCreateClimb: () => createClimb,
+  computeCanUpdate: (savedClimb: unknown) => savedClimb != null,
+  computeEditLocked: () => false,
+  buildInitialFrames: () => [{}],
+}));
+vi.mock('@boardsesh/board-react', () => ({
+  useBoardActions: () => ({
+    isAuthenticated: true,
+    saveClimb: boardActions.saveClimb,
+    updateClimb: boardActions.updateClimb,
+  }),
+  isDuplicateClimbError: () => false,
+}));
+vi.mock('@boardsesh/graphql-client', () => ({
+  GraphQLOperationError: class GraphQLOperationError extends Error {},
+}));
+vi.mock('../../../providers/auth-provider', () => ({ useAuth: () => ({ refreshAuthState: vi.fn() }) }));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useProfile: () => ({ data: { id: 'user-1', displayName: 'Tester' } }),
+  useClimb: () => ({ data: graphql.climb, isError: graphql.climbFailed }),
+}));
+vi.mock('../../../providers/queue-provider', () => ({
+  useQueueActions: () => ({ setCurrentClimb: queue.setCurrentClimb }),
+}));
+vi.mock('../../../providers/bluetooth-provider', () => ({ useOptionalBluetoothContext: () => ble.context }));
+vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../../../providers/dialog-provider', () => ({ useConfirm: () => vi.fn(async () => true) }));
+vi.mock('../../../lib/climb-to-queue-item', () => ({
+  climbToQueueItem: (climb: unknown) => ({ uuid: 'queue-item', climb }),
+}));
+vi.mock('../../../lib/create-climb-draft-store', () => ({
+  loadDraft: draftStore.loadDraft,
+  saveDraft: draftStore.saveDraft,
+  clearDraft: draftStore.clearDraft,
+  createClimbDraftKey: () => 'draft-key',
+  createClimbEditDraftKey: (boardType: string, uuid: string) => `edit:${boardType}:${uuid}`,
+  createClimbForkDraftKey: (boardKey: string) => `fork:${boardKey}`,
+  isDraftStorageAvailable: () => true,
+}));
+vi.mock('../brush-roles', () => ({
+  getPaintRoles: () => ['HAND', 'STARTING', 'FINISH', 'FOOT'],
+  computeRoleCapacity: () => ({}),
+  getNextBrushRole: () => 'HAND',
+}));
+
+import { useCreateClimbScreen, parseForkCharacteristics } from '../use-create-climb-screen';
+
+const WOODS_BOARD = { boardName: 'woods' as const, layoutId: 1, sizeId: 2, setIds: '1', angle: 40 };
+const KILTER_BOARD = { boardName: 'kilter' as const, layoutId: 8, sizeId: 17, setIds: '26,27', angle: 40 };
+
+beforeEach(() => {
+  ble.context = null;
+  graphql.climb = undefined;
+  graphql.climbFailed = false;
+  boardActions.saveClimb.mockReset();
+  boardActions.saveClimb.mockResolvedValue({ uuid: 'saved-1', createdAt: null, publishedAt: null, isDraft: true });
+  boardActions.updateClimb.mockReset();
+  boardActions.updateClimb.mockResolvedValue({ uuid: 'saved-1', createdAt: null, publishedAt: null, isDraft: true });
+  queue.setCurrentClimb.mockReset();
+  draftStore.loadDraft.mockReset();
+  draftStore.loadDraft.mockResolvedValue(null);
+  draftStore.saveDraft.mockReset();
+  draftStore.saveDraft.mockResolvedValue(undefined);
+  createClimb.duplicateFrame.mockClear();
+  createClimb.loadFrames.mockClear();
+});
+
+describe('parseForkCharacteristics', () => {
+  it('keeps an explicitly empty array distinct from an absent param', () => {
+    // The whole reason the param is JSON and not a comma list: `[]` (a source
+    // whose rules are all defaults) must not read as "we were told nothing".
+    expect(parseForkCharacteristics('[]')).toEqual([]);
+    expect(parseForkCharacteristics(undefined)).toBeNull();
+    expect(parseForkCharacteristics('')).toBeNull();
+  });
+
+  it('parses a token list', () => {
+    expect(parseForkCharacteristics('["no_match","any_feet"]')).toEqual(['no_match', 'any_feet']);
+  });
+
+  it('reads malformed input as absent rather than throwing during render', () => {
+    // This runs in a useState initialiser, i.e. DURING RENDER, where a throw is
+    // unrecoverable — the #3804 lesson one route over.
+    expect(parseForkCharacteristics('not json')).toBeNull();
+    expect(parseForkCharacteristics('{"campus":true}')).toBeNull();
+  });
+
+  it('drops non-string entries', () => {
+    expect(parseForkCharacteristics('["campus",3,null]')).toEqual(['campus']);
+  });
+});
+
+describe('any feet / campus exclusivity', () => {
+  it('starts a new climb with every rule at its default', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: WOODS_BOARD }));
+    expect(result.current.anyFeet).toBe(false);
+    expect(result.current.campus).toBe(false);
+    expect(result.current.noMatch).toBe(false);
+    expect(result.current.noKickboard).toBe(false);
+  });
+
+  it('turns campus off when any feet goes on', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: WOODS_BOARD }));
+    act(() => result.current.setCampus(true));
+    act(() => result.current.setAnyFeet(true));
+    expect(result.current.anyFeet).toBe(true);
+    expect(result.current.campus).toBe(false);
+  });
+
+  it('turns any feet off when campus goes on', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: WOODS_BOARD }));
+    act(() => result.current.setAnyFeet(true));
+    act(() => result.current.setCampus(true));
+    expect(result.current.campus).toBe(true);
+    expect(result.current.anyFeet).toBe(false);
+  });
+
+  it('leaves no-kickboard alone — it answers a different question', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: KILTER_BOARD }));
+    act(() => result.current.setNoKickboard(true));
+    act(() => result.current.setAnyFeet(true));
+    expect(result.current.noKickboard).toBe(true);
+    expect(result.current.anyFeet).toBe(true);
+  });
+
+  it('offers the any-feet row by default', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: WOODS_BOARD }));
+    expect(result.current.anyFeetAvailable).toBe(true);
+  });
+
+  it('withdraws the any-feet row for a climb whose MoonBoard method already forbids feet', async () => {
+    // The editor cannot clear a method token, so the row would keep saying "no
+    // feet" whatever this switch sent — a climb that contradicts itself.
+    graphql.climb = {
+      uuid: 'moon-1',
+      name: 'Footless problem',
+      description: '',
+      frames: 'p1r12',
+      characteristics: ['method_footless'],
+      is_draft: true,
+    };
+    const { result } = renderHook(() =>
+      useCreateClimbScreen({ board: { ...KILTER_BOARD, boardName: 'moonboard' }, editClimbUuid: 'moon-1' }),
+    );
+
+    await waitFor(() => expect(result.current.anyFeetAvailable).toBe(false));
+    act(() => result.current.setAnyFeet(true));
+    await waitFor(() => expect(result.current.anyFeet).toBe(false));
+  });
+});
+
+describe('rules on the save payload', () => {
+  it('sends both booleans and the board size when creating', async () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: WOODS_BOARD }));
+
+    act(() => result.current.setName('Treat yo self'));
+    act(() => {
+      result.current.setNoMatch(true);
+      result.current.setAnyFeet(true);
+    });
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(boardActions.saveClimb).toHaveBeenCalledWith(
+      expect.objectContaining({ no_match: true, any_feet: true, size_id: 2, layout_id: 1 }),
+    );
+  });
+
+  it('keeps any_feet OUT of the legacy characteristics array', async () => {
+    // The array is the FULL desired state of the tokens an old client knows, so
+    // putting any_feet in it lets one of those clients clear a rule it has never
+    // heard of.
+    const { result } = renderHook(() => useCreateClimbScreen({ board: WOODS_BOARD }));
+
+    act(() => result.current.setName('Open feet'));
+    act(() => result.current.setAnyFeet(true));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(boardActions.saveClimb.mock.calls[0][0].characteristics).toBeNull();
+  });
+
+  it('sends explicit false to clear a rule on update, never null', async () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: WOODS_BOARD }));
+
+    act(() => result.current.setName('Rules off'));
+    act(() => result.current.setAnyFeet(true));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    act(() => result.current.setAnyFeet(false));
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    // `updateClimb` takes the camelCase GraphQL input directly (no snake_case
+    // mapper in between), and omission would PRESERVE the flag rather than clear it.
+    expect(boardActions.updateClimb).toHaveBeenCalledWith(
+      expect.objectContaining({ anyFeet: false, noMatch: false, sizeId: 2 }),
+    );
+  });
+
+  it('leaves the Woods description alone instead of prefixing "No match"', async () => {
+    // The prefix is an Aurora wire convention. On Woods it would be the setter's
+    // prose, silently rewritten.
+    const { result } = renderHook(() => useCreateClimbScreen({ board: WOODS_BOARD }));
+
+    act(() => {
+      result.current.setName('Prose');
+      result.current.setDescription('Sit start, big move right.');
+      result.current.setNoMatch(true);
+    });
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    const payload = boardActions.saveClimb.mock.calls[0][0];
+    expect(payload.description).toBe('Sit start, big move right.');
+    expect(payload.no_match).toBe(true);
+  });
+
+  it('still encodes the marker into an Aurora climb description', async () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: KILTER_BOARD }));
+
+    act(() => {
+      result.current.setName('Aurora climb');
+      result.current.setDescription('Crimpy.');
+      result.current.setNoMatch(true);
+    });
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(boardActions.saveClimb.mock.calls[0][0].description).toBe('No match\nCrimpy.');
+  });
+});
+
+describe('the provisional queue row', () => {
+  function queuedClimb(): Record<string, unknown> {
+    const calls = queue.setCurrentClimb.mock.calls;
+    return (calls[calls.length - 1]?.[0] as { climb: Record<string, unknown> }).climb;
+  }
+
+  it('carries any_feet so the queue row shows the same rule the editor does', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: WOODS_BOARD }));
+
+    act(() => result.current.setName('Open feet'));
+    act(() => result.current.setAnyFeet(true));
+    act(() => result.current.handleSetActive());
+
+    expect(queuedClimb().characteristics).toEqual(expect.arrayContaining(['any_feet']));
+  });
+
+  it('records a default-rules Woods climb as [] rather than "rules unknown"', () => {
+    // On a board that states both rules, null means "nobody recorded them" —
+    // which is the one thing the editor definitely knows is false.
+    const { result } = renderHook(() => useCreateClimbScreen({ board: WOODS_BOARD }));
+
+    act(() => result.current.setName('All defaults'));
+    act(() => result.current.handleSetActive());
+
+    expect(queuedClimb().characteristics).toEqual([]);
+    expect(queuedClimb().compatibleSizeIds).toEqual([2]);
+  });
+
+  it('keeps a default-rules Aurora climb at null, as before', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: KILTER_BOARD }));
+
+    act(() => result.current.setName('All defaults'));
+    act(() => result.current.handleSetActive());
+
+    expect(queuedClimb().characteristics).toBeNull();
+  });
+});
+
+describe('remix seeding (#4832)', () => {
+  const forkArgs = {
+    board: WOODS_BOARD,
+    forkFrames: 'p1r4p2r2',
+    forkName: 'Treat yo self',
+    forkDescription: 'Sit start.',
+  };
+
+  it('inherits every supported rule from the source climb', () => {
+    const { result } = renderHook(() =>
+      useCreateClimbScreen({
+        ...forkArgs,
+        forkCharacteristics: JSON.stringify(['no_match', 'any_feet', 'no_kickboard']),
+      }),
+    );
+
+    expect(result.current.noMatch).toBe(true);
+    expect(result.current.anyFeet).toBe(true);
+    expect(result.current.noKickboard).toBe(true);
+    expect(result.current.campus).toBe(false);
+  });
+
+  it('inherits campus without any feet', () => {
+    const { result } = renderHook(() =>
+      useCreateClimbScreen({ ...forkArgs, forkCharacteristics: JSON.stringify(['campus']) }),
+    );
+
+    expect(result.current.campus).toBe(true);
+    expect(result.current.anyFeet).toBe(false);
+  });
+
+  it('reads an explicitly empty array as all-defaults, not as "look at the description"', () => {
+    const { result } = renderHook(() =>
+      useCreateClimbScreen({ ...forkArgs, forkDescription: 'No match\nSit start.', forkCharacteristics: '[]' }),
+    );
+
+    expect(result.current.noMatch).toBe(false);
+    expect(result.current.anyFeet).toBe(false);
+  });
+
+  it('falls back to the legacy description prefix only when the array is absent', () => {
+    const { result } = renderHook(() =>
+      useCreateClimbScreen({ ...forkArgs, board: KILTER_BOARD, forkDescription: 'No match\nSit start.' }),
+    );
+
+    expect(result.current.noMatch).toBe(true);
+    // ...and the editable description is left clean.
+    expect(result.current.description).toBe('Sit start.');
+  });
+
+  it('never sniffs the description on a board with no such convention', () => {
+    const { result } = renderHook(() =>
+      useCreateClimbScreen({ ...forkArgs, forkDescription: 'No match holds on this one, just jugs.' }),
+    );
+
+    expect(result.current.noMatch).toBe(false);
+  });
+
+  it('carries the inherited rules straight into the save payload', async () => {
+    const { result } = renderHook(() =>
+      useCreateClimbScreen({ ...forkArgs, forkCharacteristics: JSON.stringify(['no_match', 'any_feet']) }),
+    );
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(boardActions.saveClimb).toHaveBeenCalledWith(
+      expect.objectContaining({ no_match: true, any_feet: true, size_id: 2 }),
+    );
+  });
+});
+
+describe('editing an existing climb', () => {
+  it('seeds the rules from the structured flags', async () => {
+    graphql.climb = {
+      uuid: 'woods-1',
+      name: 'Treat yo self',
+      description: 'Sit start.',
+      frames: 'p1r4',
+      characteristics: ['no_match', 'any_feet'],
+      is_draft: true,
+      compatibleSizeIds: [2],
+    };
+    const { result } = renderHook(() => useCreateClimbScreen({ board: WOODS_BOARD, editClimbUuid: 'woods-1' }));
+
+    await waitFor(() => expect(result.current.noMatch).toBe(true));
+    expect(result.current.anyFeet).toBe(true);
+    expect(result.current.editSizeMismatch).toBe(false);
+  });
+
+  it('prefers the structured flags over a description that merely starts with the words', async () => {
+    graphql.climb = {
+      uuid: 'kilter-1',
+      name: 'Prose climb',
+      description: 'No match for this one anywhere in the gym.',
+      frames: 'p1r12',
+      characteristics: [],
+      is_draft: true,
+    };
+    const { result } = renderHook(() => useCreateClimbScreen({ board: KILTER_BOARD, editClimbUuid: 'kilter-1' }));
+
+    await waitFor(() => expect(result.current.name).toBe('Prose climb'));
+    expect(result.current.noMatch).toBe(false);
+  });
+
+  it('falls back to the description only for a row that carries no characteristics at all', async () => {
+    graphql.climb = {
+      uuid: 'kilter-2',
+      name: 'Legacy row',
+      description: 'No match\nCrimpy.',
+      frames: 'p1r12',
+      characteristics: null,
+      is_draft: true,
+    };
+    const { result } = renderHook(() => useCreateClimbScreen({ board: KILTER_BOARD, editClimbUuid: 'kilter-2' }));
+
+    await waitFor(() => expect(result.current.noMatch).toBe(true));
+  });
+
+  it('refuses to seed a climb set on a different board size', async () => {
+    // Woods hold ids are size-relative, so the 8x10's frames "fit" the 12x12 by
+    // id and would seed a completely different set of holds — then save them back
+    // over the original.
+    graphql.climb = {
+      uuid: 'woods-8x10',
+      name: 'Eight by ten',
+      description: '',
+      frames: 'p1r4',
+      characteristics: [],
+      is_draft: true,
+      compatibleSizeIds: [1],
+    };
+    const { result } = renderHook(() => useCreateClimbScreen({ board: WOODS_BOARD, editClimbUuid: 'woods-8x10' }));
+
+    await waitFor(() => expect(result.current.editSizeMismatch).toBe(true));
+    expect(createClimb.loadFrames).not.toHaveBeenCalled();
+    expect(result.current.name).toBe('');
+  });
+});
+
+describe('single-frame boards', () => {
+  it('hides the frame controls and refuses to make a second frame on Woods', () => {
+    // `getWoodsBluetoothPacket` throws on the comma a second frame introduces, so
+    // a two-frame Woods climb would save and then refuse to light the wall.
+    const { result } = renderHook(() => useCreateClimbScreen({ board: WOODS_BOARD }));
+
+    expect(result.current.supportsMultiFrame).toBe(false);
+    act(() => result.current.duplicateFrame());
+    expect(createClimb.duplicateFrame).not.toHaveBeenCalled();
+  });
+
+  it('still duplicates frames on a board that supports them', () => {
+    const { result } = renderHook(() => useCreateClimbScreen({ board: KILTER_BOARD }));
+
+    expect(result.current.supportsMultiFrame).toBe(true);
+    act(() => result.current.duplicateFrame());
+    expect(createClimb.duplicateFrame).toHaveBeenCalled();
+  });
+});
+
+describe('Woods preview wall size', () => {
+  it.each([1, 2])('only writes frames when connected size %s matches the editor', async (sizeId) => {
+    vi.useFakeTimers();
+    try {
+      const sendFramesToBoard = vi.fn();
+      const connect = vi.fn();
+      ble.context = {
+        boardName: 'woods',
+        layoutId: 1,
+        sizeId,
+        isConnected: true,
+        loading: false,
+        sendFramesToBoard,
+        connect,
+        disconnect: vi.fn(),
+      };
+      const { result, unmount } = renderHook(() => useCreateClimbScreen({ board: WOODS_BOARD }));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      if (sizeId === 2) expect(sendFramesToBoard).toHaveBeenCalled();
+      else {
+        expect(sendFramesToBoard).not.toHaveBeenCalled();
+        ble.context.isConnected = false;
+        act(() => result.current.handleToggleBle());
+        expect(connect).not.toHaveBeenCalled();
+      }
+      unmount();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/mobile/src/components/create-climb/use-create-climb-navigation.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-navigation.ts
@@ -1,3 +1,4 @@
+import { resolveClimbRenderBoard } from '../../lib/boards/climb-render-board';
 import { useCallback, useRef } from 'react';
 import { useRouter } from 'expo-router';
 import type { Climb } from '@boardsesh/shared-schema';
@@ -91,7 +92,14 @@ export function useCreateClimbNavigation({
           forkFrames: climb.frames,
           forkName: climb.name,
           forkDescription: climb.description ?? '',
-          ...boardParams(board),
+          // Carry the source's climb rules across (#4832) — a remix that silently
+          // dropped "no matching" or "any feet" published a different climb from
+          // the one it was remixed from. Serialised only when the source actually
+          // HAS an array: an absent param is what tells the editor to fall back
+          // to the legacy `No match` description prefix, and `"[]"` (a source
+          // whose rules are all at their defaults) must not read as absent.
+          ...(climb.characteristics ? { forkCharacteristics: JSON.stringify(climb.characteristics) } : {}),
+          ...boardParams(resolveClimbRenderBoard(climb, board)?.boardConfig ?? board),
         },
         onActionAccepted,
       ),
@@ -103,7 +111,7 @@ export function useCreateClimbNavigation({
       navigateToCreate(
         {
           editClimbUuid: climb.uuid,
-          ...boardParams(board),
+          ...boardParams(resolveClimbRenderBoard(climb, board)?.boardConfig ?? board),
         },
         onActionAccepted,
       ),

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -6,12 +6,17 @@ import { useQueryClient } from '@tanstack/react-query';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
 import {
   isNoMatchClimb,
+  usesAuroraNoMatchDescription,
   withNoMatch,
   CLIMB_CHARACTERISTICS,
+  getMoonBoardMethod,
+  isAnyFeet,
   isNoKickboard,
   isCampus,
+  isNoMatch,
   withCharacteristic,
 } from '@boardsesh/shared-schema';
+import { getBoardCapabilities } from '@boardsesh/board-config';
 import {
   useCreateClimb,
   computeCanUpdate,
@@ -62,6 +67,12 @@ type UseCreateClimbScreenArgs = {
   forkFrames?: string;
   forkName?: string;
   forkDescription?: string;
+  /** The source climb's `characteristics`, JSON-encoded by the route param, so a
+   *  remix inherits its climb rules instead of silently resetting them (#4832).
+   *  Absent means the source carried none; `"[]"` means it carried an explicitly
+   *  empty set (all rules at their defaults) — a real difference for `noMatch`,
+   *  whose legacy fallback is only consulted when the array is absent. */
+  forkCharacteristics?: string;
   /** When set, fetch and edit this existing climb in place. */
   editClimbUuid?: string;
   /** Called after a successful publish (non-draft save) so the screen can
@@ -85,6 +96,7 @@ type PayloadSignatureFields = {
   noMatch: boolean;
   noKickboard: boolean;
   campus: boolean;
+  anyFeet: boolean;
   isDraft: boolean;
 };
 
@@ -97,8 +109,30 @@ function createPayloadSignature(fields: PayloadSignatureFields): string {
     fields.noMatch ? '1' : '0',
     fields.noKickboard ? '1' : '0',
     fields.campus ? '1' : '0',
+    fields.anyFeet ? '1' : '0',
     fields.isDraft ? '1' : '0',
   ].join(SIGNATURE_SEPARATOR);
+}
+
+/**
+ * Decode the `forkCharacteristics` route param.
+ *
+ * Returns `null` for an absent or unusable param and the array (possibly empty)
+ * for a well-formed one, because the two mean different things downstream: an
+ * absent array is the only case where `noMatch` falls back to sniffing the
+ * source description for the legacy `No match` prefix. A malformed param reads
+ * as absent — a fork with slightly wrong rules is recoverable, a render crash on
+ * a hand-edited deep link is not (#3804 is the same lesson one route over).
+ */
+export function parseForkCharacteristics(serialized: string | undefined): string[] | null {
+  if (!serialized) return null;
+  try {
+    const parsed: unknown = JSON.parse(serialized);
+    if (!Array.isArray(parsed)) return null;
+    return parsed.filter((token): token is string => typeof token === 'string');
+  } catch {
+    return null;
+  }
 }
 
 function parseSavedClimbSnapshot(serialized: string | undefined): SavedClimbSnapshot | null {
@@ -151,19 +185,32 @@ function buildToggleableCharacteristics(noKickboard: boolean, campus: boolean): 
 }
 
 /**
- * Same as {@link buildToggleableCharacteristics}, but also folds in no_match —
- * used only for the LOCAL provisional queue-item display (buildProvisionalClimb),
- * never for the save/update payload. `ClimbAttributeIcons` prefers the
- * `characteristics` array over the legacy `is_no_match` bool the moment the array
- * is non-null, so a provisional row with, say, campus=true and noMatch=true would
- * otherwise show the campus badge but silently drop the no-match one. The real
- * saved row doesn't have this problem: the server derives no_match from
- * `description` independently of the client-supplied `characteristics` field.
+ * Same as {@link buildToggleableCharacteristics}, but also folds in no_match and
+ * any_feet — used only for the LOCAL provisional queue-item display
+ * (buildProvisionalClimb), never for the save/update payload.
+ * `ClimbAttributeIcons` prefers the `characteristics` array over the legacy
+ * `is_no_match` bool the moment the array is non-null, so a provisional row with,
+ * say, campus=true and noMatch=true would otherwise show the campus badge but
+ * silently drop the no-match one. The real saved row doesn't have this problem:
+ * the server derives both from their own input fields independently of the
+ * client-supplied `characteristics` field, and rejects any_feet inside it.
+ *
+ * Always non-null on a board that states its rules explicitly (Woods): there,
+ * `[]` is the meaningful "all defaults" answer and null would read as "we don't
+ * know this climb's rules" — which is exactly what the editor DOES know.
  */
-function buildProvisionalCharacteristics(noMatch: boolean, noKickboard: boolean, campus: boolean): string[] | null {
-  const toggleable = buildToggleableCharacteristics(noKickboard, campus) ?? [];
-  const withNoMatchToken = withCharacteristic(toggleable, CLIMB_CHARACTERISTICS.NO_MATCH, noMatch);
-  return withNoMatchToken.length > 0 ? withNoMatchToken : null;
+function buildProvisionalCharacteristics(
+  noMatch: boolean,
+  noKickboard: boolean,
+  campus: boolean,
+  anyFeet: boolean,
+  rulesAlwaysKnown: boolean,
+): string[] | null {
+  let characteristics = buildToggleableCharacteristics(noKickboard, campus) ?? [];
+  characteristics = withCharacteristic(characteristics, CLIMB_CHARACTERISTICS.NO_MATCH, noMatch);
+  characteristics = withCharacteristic(characteristics, CLIMB_CHARACTERISTICS.ANY_FEET, anyFeet);
+  if (characteristics.length > 0) return characteristics;
+  return rulesAlwaysKnown ? [] : null;
 }
 
 /**
@@ -177,6 +224,7 @@ export function useCreateClimbScreen({
   forkFrames,
   forkName,
   forkDescription,
+  forkCharacteristics,
   editClimbUuid,
   onPublished,
   onStartedNewClimb,
@@ -193,6 +241,24 @@ export function useCreateClimbScreen({
 
   const isForking = !!forkFrames;
   const isEditing = !!editClimbUuid;
+  const boardCapabilities = getBoardCapabilities(board.boardName);
+  // Aurora carries "no matching" as a `No match` line at the head of the climb
+  // description, so that prefix is a real signal there and must keep round-tripping.
+  // On the code-driven boards it is not a convention at all — a description
+  // starting with those words is the setter's prose — so neither the seed nor the
+  // save payload is allowed to touch it.
+  const usesNoMatchDescription = usesAuroraNoMatchDescription(board.boardName);
+  // Woods says both climb rules on every problem, so an authored Woods climb has
+  // to store a KNOWN answer for each of them — `[]` (all defaults), never the
+  // null that reads as "nobody recorded the rules for this climb".
+  const rulesAlwaysKnown = boardCapabilities.explicitClimbRules;
+
+  // A remix inherits its source's rules. Parsed once from the route param, which
+  // preserves the absent-vs-empty distinction the noMatch fallback below turns on.
+  const seededForkCharacteristics = useMemo(
+    () => (isForking ? parseForkCharacteristics(forkCharacteristics) : null),
+    [isForking, forkCharacteristics],
+  );
 
   // Seed the editor from a fork's frames once, preserving every frame of a
   // multi-frame source route (an empty single frame otherwise). Edit mode
@@ -232,22 +298,79 @@ export function useCreateClimbScreen({
   const [selectedBrush, setSelectedBrush] = useState<BrushRole>('HAND');
   const [name, setName] = useState(isForking && forkName ? `${forkName} remix` : '');
   const [description, setDescription] = useState(
-    isForking && forkDescription ? withNoMatch(forkDescription, false) : '',
+    isForking && forkDescription
+      ? usesNoMatchDescription
+        ? withNoMatch(forkDescription, false)
+        : forkDescription
+      : '',
   );
-  // The "no match" climb rule is a separate boolean in the editor; we encode it
-  // into the description (a leading "No match" line — see isNoMatchClimb) only at
-  // save time, so the editable description field stays clean and the toggle never
-  // gets stuck on a fuzzy match. A follow-up migrates this to a real column.
-  const [noMatch, setNoMatch] = useState(isForking && forkDescription ? isNoMatchClimb(forkDescription) : false);
-  // Forking doesn't currently carry characteristics through (no forkCharacteristics
-  // param exists, unlike forkFrames/forkName/forkDescription) — a pre-existing,
-  // acceptable gap consistent with how forking already works for everything except
-  // no_match, which rides in the description text. Both default false on a fork.
-  // Tracked in https://github.com/boardsesh/boardsesh/issues/4832.
-  const [noKickboard, setNoKickboard] = useState(false);
-  const [campus, setCampus] = useState(false);
+  // The "no match" climb rule is a separate boolean in the editor. It rides the
+  // save payload as an explicit field AND (for older servers, and for Aurora
+  // round-tripping) as a leading "No match" line in the description, encoded only
+  // at save time so the editable description field stays clean.
+  //
+  // Seeding PREFERS the structured flag: a stripped description is a string
+  // sniff, and it is wrong for a source climb whose description happens to start
+  // with those words, or whose no-match rule was set without one. The legacy
+  // sniff is the fallback for exactly one case — a source that carried no
+  // characteristics array at all, where the description is the only signal there
+  // is.
+  const [noMatch, setNoMatch] = useState(() => {
+    if (!isForking) return false;
+    if (seededForkCharacteristics) return isNoMatch(seededForkCharacteristics);
+    return usesNoMatchDescription && forkDescription ? isNoMatchClimb(forkDescription) : false;
+  });
+  // A remix now carries every supported rule across (#4832). An absent
+  // `forkCharacteristics` leaves them at their defaults, which is what a fork
+  // from a source with no recorded rules should be.
+  const [noKickboard, setNoKickboard] = useState(() => isNoKickboard(seededForkCharacteristics));
+  // The raw setters are used by the restore/seed/reset paths, which apply a
+  // whole coherent rule set at once. The UI gets the mutually-exclusive wrappers
+  // below instead.
+  const [campus, setCampusState] = useState(() => isCampus(seededForkCharacteristics));
+  const [anyFeet, setAnyFeetState] = useState(() => isAnyFeet(seededForkCharacteristics));
   const [isDraft, setIsDraft] = useState(true);
   const [showAllHolds, setShowAllHolds] = useState(false);
+
+  // The MoonBoard "method" of the climb this session is attached to, if any. The
+  // editor cannot set or clear a method token (that is creation-time-only, via
+  // SaveMoonBoardClimbInput), so a footless problem's own row keeps saying "no
+  // feet" whatever this editor sends. Offering "Any feet" on top of it would let
+  // a climber publish a climb that contradicts itself. Seeded from the edit
+  // fetch and from a fork's characteristics.
+  const [seededMethod, setSeededMethod] = useState<string | null>(() => getMoonBoardMethod(seededForkCharacteristics));
+  const footlessMethod =
+    seededMethod === CLIMB_CHARACTERISTICS.METHOD_FOOTLESS ||
+    seededMethod === CLIMB_CHARACTERISTICS.METHOD_FOOTLESS_KICKBOARD;
+  const anyFeetAvailable = !footlessMethod;
+
+  // "Any feet" and "Campus" are opposite answers to the same question — where
+  // may your feet go — so each one turns the other off rather than leaving a
+  // climb that says both "anywhere" and "nowhere". `noKickboard` is a separate
+  // question (may the kickboard be one of those places) and stays independent of
+  // both.
+  const setCampus = useCallback((next: boolean) => {
+    setCampusState(next);
+    if (next) setAnyFeetState(false);
+  }, []);
+  // Guarded, not just hidden: the row's MoonBoard method is authoritative and
+  // this editor cannot change it, so "any feet" must be unreachable while the
+  // method says there are none — through a stale render of the form as much as
+  // through the switch.
+  const setAnyFeet = useCallback(
+    (next: boolean) => {
+      if (next && footlessMethod) return;
+      setAnyFeetState(next);
+      if (next) setCampusState(false);
+    },
+    [footlessMethod],
+  );
+
+  // A footless method arriving after the toggle was already on (the edit fetch
+  // resolves asynchronously) has to win for the same reason.
+  useEffect(() => {
+    if (footlessMethod) setAnyFeetState(false);
+  }, [footlessMethod]);
 
   const [savedClimb, setSavedClimb] = useState<SavedClimbSnapshot | null>(null);
   const [isSaving, setIsSaving] = useState(false);
@@ -362,6 +485,17 @@ export function useCreateClimbScreen({
   );
   const { data: editClimb, isError: editClimbFailed } = useClimb(editVariables);
 
+  // The climb the link asked to edit does not fit the wall the link opened.
+  //
+  // Hold ids are size-relative on Woods — the 8x10 numbers its holds 0-484 and
+  // the 12x12 its own 0-893 — so every 8x10 climb "fits" a 12x12 by id and would
+  // seed the editor with a completely different set of holds, then save that back
+  // over the original. `compatible_size_ids` is the column that tells them apart
+  // (`canAddClimbToBoard` rule 5); a row that carries none imposes no constraint,
+  // exactly as it does for the queue.
+  const editSizeMismatch =
+    editClimb != null && editClimb.compatibleSizeIds != null && !editClimb.compatibleSizeIds.includes(board.sizeId);
+
   // Apply a stored working copy over whatever the editor currently holds.
   const applyStoredDraft = useCallback(
     (draft: CreateClimbDraft) => {
@@ -374,13 +508,20 @@ export function useCreateClimbScreen({
         // Corrupt holds payload — keep whatever is already loaded.
       }
       setName(draft.name);
-      setDescription(withNoMatch(draft.description, false));
-      setNoMatch(isNoMatchClimb(draft.description));
+      setDescription(usesNoMatchDescription ? withNoMatch(draft.description, false) : draft.description);
+      // Explicit flag first; the description sniff only reaches slots written
+      // before the flag existed, which were all Aurora-convention anyway.
+      setNoMatch(draft.noMatch ?? (usesNoMatchDescription && isNoMatchClimb(draft.description)));
       setNoKickboard(draft.noKickboard ?? false);
-      setCampus(draft.campus ?? false);
+      // Raw setters: a stored slot is one coherent rule set written by this same
+      // editor, so re-running the exclusivity rules over it would only reorder
+      // what it already agreed on. Campus still wins if an old slot somehow
+      // carries both — the stricter rule, same as everywhere else.
+      setCampusState(draft.campus ?? false);
+      setAnyFeetState(!draft.campus && (draft.anyFeet ?? false));
       setIsDraft(draft.isDraft);
     },
-    [loadFrames],
+    [loadFrames, usesNoMatchDescription],
   );
 
   type EditFailureRestoreState = 'idle' | 'loading' | 'found' | 'empty';
@@ -439,13 +580,20 @@ export function useCreateClimbScreen({
   }, [isEditing, editClimbUuid, editClimbFailed, board.boardName, applyStoredDraft, markRestored]);
 
   useEffect(() => {
-    if (!editClimb || editSeededRef.current || editFailureRestoreState === 'loading') return;
+    if (!editClimb || editSizeMismatch || editSeededRef.current || editFailureRestoreState === 'loading') return;
     editSeededRef.current = true;
     const serverFrames = buildInitialFrames(editClimb.frames, board.boardName);
-    const serverDescription = withNoMatch(editClimb.description ?? '', false);
-    const serverNoMatch = isNoMatchClimb(editClimb.description);
+    const serverDescription = usesNoMatchDescription
+      ? withNoMatch(editClimb.description ?? '', false)
+      : (editClimb.description ?? '');
+    // Structured flag first, description sniff only when the row carries no
+    // characteristics array at all — same rule as the fork seed above.
+    const serverNoMatch = editClimb.characteristics
+      ? isNoMatch(editClimb.characteristics)
+      : usesNoMatchDescription && isNoMatchClimb(editClimb.description);
     const serverNoKickboard = isNoKickboard(editClimb.characteristics);
     const serverCampus = isCampus(editClimb.characteristics);
+    const serverAnyFeet = !serverCampus && isAnyFeet(editClimb.characteristics);
     const serverIsDraft = editClimb.is_draft ?? false;
     const serverSignature = createPayloadSignature({
       holdsJson: JSON.stringify(serverFrames[0] ?? {}),
@@ -455,6 +603,7 @@ export function useCreateClimbScreen({
       noMatch: serverNoMatch,
       noKickboard: serverNoKickboard,
       campus: serverCampus,
+      anyFeet: serverAnyFeet,
       isDraft: serverIsDraft,
     });
     const serverSnapshot: SavedClimbSnapshot = {
@@ -467,6 +616,10 @@ export function useCreateClimbScreen({
     setSavedClimb(serverSnapshot);
     setSavedSignature(serverSignature);
     setSavedSignatureUnknown(false);
+    // Outside the reseed guard below: the row's MoonBoard method belongs to the
+    // ROW, not to the working copy, so it applies even when a restored phone
+    // copy wins the editor.
+    setSeededMethod(getMoonBoardMethod(editClimb.characteristics));
 
     // The failure path already restored the phone copy. A retry may attach the
     // authoritative server identity and baseline, but must never reseed the
@@ -485,7 +638,8 @@ export function useCreateClimbScreen({
     setDescription(serverDescription);
     setNoMatch(serverNoMatch);
     setNoKickboard(serverNoKickboard);
-    setCampus(serverCampus);
+    setCampusState(serverCampus);
+    setAnyFeetState(serverAnyFeet);
     setIsDraft(serverIsDraft);
 
     // ORDERING IS LOAD-BEARING. The `edit:` slot is applied OVER the server copy,
@@ -510,7 +664,16 @@ export function useCreateClimbScreen({
       .finally(() => {
         markRestored();
       });
-  }, [editClimb, editFailureRestoreState, board.boardName, loadFrames, applyStoredDraft, markRestored]);
+  }, [
+    editClimb,
+    editSizeMismatch,
+    editFailureRestoreState,
+    board.boardName,
+    usesNoMatchDescription,
+    loadFrames,
+    applyStoredDraft,
+    markRestored,
+  ]);
 
   // ---- Local autosave restore on mount (plain new climb). ----
   useEffect(() => {
@@ -583,6 +746,7 @@ export function useCreateClimbScreen({
     noMatch,
     noKickboard,
     campus,
+    anyFeet,
     isDraft,
   });
   const payloadSignatureRef = useRef(payloadSignature);
@@ -597,10 +761,16 @@ export function useCreateClimbScreen({
       holdsJson,
       framesJson,
       name,
-      description: withNoMatch(description, noMatch),
+      // The slot keeps the description the user actually typed and the rule as
+      // its own flag. Encoding the rule into the prose was only ever an Aurora
+      // wire convention, and re-parsing it on restore made "No match" the first
+      // word of a description a rule the climber never set.
+      description,
+      noMatch,
       isDraft,
       noKickboard,
       campus,
+      anyFeet,
       savedClimbJson,
       savedPayloadSignature: savedSignature ?? undefined,
       origin: isEditing ? 'edit' : isForking ? 'fork' : 'new',
@@ -614,6 +784,7 @@ export function useCreateClimbScreen({
       noMatch,
       noKickboard,
       campus,
+      anyFeet,
       isDraft,
       savedClimbJson,
       savedSignature,
@@ -638,9 +809,14 @@ export function useCreateClimbScreen({
   // ---- BLE preview (debounced) while connected. ----
   const sendFramesRef = useRef(bluetooth?.sendFramesToBoard);
   sendFramesRef.current = bluetooth?.sendFramesToBoard;
-  const bleConnected = bluetooth?.isConnected ?? false;
+  const wallMatchesEditor =
+    board.boardName !== 'woods' ||
+    (bluetooth?.boardName === board.boardName &&
+      bluetooth.layoutId === board.layoutId &&
+      bluetooth.sizeId === board.sizeId);
+  const bleConnected = (bluetooth?.isConnected ?? false) && wallMatchesEditor;
   useEffect(() => {
-    if (!bleConnected) return;
+    if (!bleConnected || editSizeMismatch) return;
     const handle = setTimeout(() => {
       // The active frame only — the wall mirrors whatever you're painting
       // right now, not multi-frame route syntax the BLE packet builder can't
@@ -648,7 +824,7 @@ export function useCreateClimbScreen({
       void sendFramesRef.current?.(currentFrameBleString());
     }, BLE_PREVIEW_DEBOUNCE_MS);
     return () => clearTimeout(handle);
-  }, [holdsJson, bleConnected, currentFrameBleString]);
+  }, [holdsJson, bleConnected, editSizeMismatch, currentFrameBleString]);
 
   // ---- Painting + role assignment. ----
   // A tap sets the tapped hold straight to the selected brush — cycling only
@@ -729,7 +905,11 @@ export function useCreateClimbScreen({
       setDescription('');
       setNoMatch(false);
       setNoKickboard(false);
-      setCampus(false);
+      setCampusState(false);
+      setAnyFeetState(false);
+      // A blank climb is nobody's remix and nobody's edit, so it inherits no
+      // MoonBoard method either — the Any-feet row comes back with it.
+      setSeededMethod(null);
       setIsDraft(true);
       setSavedClimb(null);
       setPublishDuplicateError(null);
@@ -796,6 +976,7 @@ export function useCreateClimbScreen({
       uuid,
       boardType: board.boardName,
       layoutId: board.layoutId,
+      ...(board.boardName === 'woods' ? { compatibleSizeIds: [board.sizeId] } : {}),
       name: name.trim() || t('createClimbForm.draftBadge'),
       frames,
       setter_username: profile?.displayName ?? '',
@@ -813,7 +994,7 @@ export function useCreateClimbScreen({
       difficulty_error: '0',
       benchmark_difficulty: null,
       is_no_match: noMatch,
-      characteristics: buildProvisionalCharacteristics(noMatch, noKickboard, campus),
+      characteristics: buildProvisionalCharacteristics(noMatch, noKickboard, campus, anyFeet, rulesAlwaysKnown),
       // Not-yet-saved climbs are drafts by definition; once saved, mirror the
       // tracked row so a published climb doesn't queue as a draft.
       is_draft: savedClimb?.isDraft ?? true,
@@ -831,11 +1012,14 @@ export function useCreateClimbScreen({
       noMatch,
       noKickboard,
       campus,
+      anyFeet,
+      rulesAlwaysKnown,
       profile,
       savedClimb,
       board.angle,
       board.boardName,
       board.layoutId,
+      board.sizeId,
       t,
       frameCount,
     ],
@@ -866,12 +1050,16 @@ export function useCreateClimbScreen({
   // the current holds; tapping again disconnects. ----
   const handleToggleBle = useCallback(() => {
     if (!bluetooth) return;
+    if (!wallMatchesEditor || editSizeMismatch) {
+      showToast(t('mobile.create.wallSizeMismatch'), 'info');
+      return;
+    }
     // Ignore taps while a connect is already running — a second concurrent
     // connect tears down the first attempt's scan and strands the picker.
     if (bluetooth.loading) return;
     if (bluetooth.isConnected) void bluetooth.disconnect();
     else void bluetooth.connect(currentFrameBleString());
-  }, [bluetooth, currentFrameBleString]);
+  }, [bluetooth, currentFrameBleString, wallMatchesEditor, editSizeMismatch, showToast, t]);
 
   // ---- Save state machine. ----
   const editLocked = computeEditLocked(savedClimb);
@@ -939,8 +1127,10 @@ export function useCreateClimbScreen({
     // below check that before acting on a stale result.
     const signatureAtSave = payloadSignatureRef.current;
     const frames = generateFramesString();
-    // Encode the no-match marker into the description only at save time.
-    const fullDescription = withNoMatch(description, noMatch);
+    // Encode the no-match marker into the description only at save time, and only
+    // on the boards whose wire format uses it. `noMatch` also rides the payload as
+    // its own field, which is what the code-driven boards go on.
+    const fullDescription = usesNoMatchDescription ? withNoMatch(description, noMatch) : description;
     // The reducer removes OFF-state holds from the map, so key count equals
     // web's `totalHolds` (non-OFF hold count, used in Climb Created events).
     const holdCount = Object.keys(litUpHoldsMap).length;
@@ -960,10 +1150,20 @@ export function useCreateClimbScreen({
           description: fullDescription,
           frames,
           angle: board.angle,
+          // The size the editor painted on. Immutable server-side for a board
+          // whose hold ids are size-relative (Woods); sent on every update so the
+          // server can reject a mismatch outright instead of rewriting a climb
+          // against the wrong wall.
+          sizeId: board.sizeId,
           framesCount: frameCount,
           framesPace: 0,
           isDraft,
           characteristics,
+          // Explicit booleans, never null: an omitted flag PRESERVES whatever the
+          // row has, and the editor's switches are the whole desired state. Sending
+          // `false` is how a rule gets turned back off.
+          noMatch,
+          anyFeet,
         });
         nextSavedClimb = {
           uuid: result.uuid,
@@ -985,6 +1185,7 @@ export function useCreateClimbScreen({
       } else {
         const result = await saveClimb({
           layout_id: board.layoutId,
+          size_id: board.sizeId,
           name: name.trim(),
           description: fullDescription,
           is_draft: isDraft,
@@ -993,6 +1194,8 @@ export function useCreateClimbScreen({
           frames_pace: 0,
           angle: board.angle,
           characteristics,
+          no_match: noMatch,
+          any_feet: anyFeet,
         });
         nextSavedClimb = {
           uuid: result.uuid,
@@ -1087,8 +1290,10 @@ export function useCreateClimbScreen({
     board,
     description,
     noMatch,
+    usesNoMatchDescription,
     noKickboard,
     campus,
+    anyFeet,
     isDraft,
     autosaveSlotKey,
     discardAutosaveSlot,
@@ -1102,6 +1307,17 @@ export function useCreateClimbScreen({
   ]);
 
   const dismissDuplicateError = useCallback(() => setPublishDuplicateError(null), []);
+
+  // Hiding the control is the visible half; this is the other one. A stale render
+  // of the action bar, a restored draft that somehow carries two frames, or a
+  // future caller reaching the controller directly must not be able to give a
+  // single-frame board a second frame — the frames string would then carry a
+  // comma, which `getWoodsBluetoothPacket` rejects outright.
+  const supportsMultiFrame = boardCapabilities.multiFrameClimbs;
+  const guardedDuplicateFrame = useCallback(() => {
+    if (!supportsMultiFrame) return;
+    duplicateFrame();
+  }, [supportsMultiFrame, duplicateFrame]);
 
   const canSetActive = isValid;
 
@@ -1142,7 +1358,7 @@ export function useCreateClimbScreen({
     // frames (route/circuit editing)
     frameCount,
     currentFrameIndex,
-    duplicateFrame,
+    duplicateFrame: guardedDuplicateFrame,
     deleteFrame,
     nextFrame,
     prevFrame,
@@ -1164,6 +1380,19 @@ export function useCreateClimbScreen({
     setNoKickboard,
     campus,
     setCampus,
+    anyFeet,
+    setAnyFeet,
+    /** False while the tracked climb's MoonBoard method already says "no feet",
+     *  which the editor cannot change — the form hides the row rather than
+     *  offering a toggle that would contradict the row it is editing. */
+    anyFeetAvailable,
+    /** Whether this board's climbs can hold more than one frame. Off on Woods,
+     *  whose BLE packet builder rejects the comma a second frame introduces. */
+    supportsMultiFrame,
+    /** True when the climb being edited doesn't belong on this board size — the
+     *  screen shows the unavailable state instead of an editor seeded with the
+     *  wrong holds. */
+    editSizeMismatch,
     // save
     saveState,
     handleSave,

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -516,6 +516,10 @@ export function PlayDrawer({
   // During the commit hand-off use the frozen climb (captured at fling start) so
   // the peek doesn't jump to the new climb's neighbour mid-swap.
   const headerPeekClimb = isSwipeCommitting ? frozenPeekClimb : peekClimb;
+  const headerPeekBoard = useMemo(
+    () => resolveClimbRenderBoard(headerPeekClimb, boardConfig)?.boardConfig ?? renderBoardConfig,
+    [headerPeekClimb, boardConfig, renderBoardConfig],
+  );
 
   // The swipe peeks paint the neighbouring climbs' holds under the CURRENT
   // board art. A neighbour from another board has no holds there, so it would
@@ -1209,9 +1213,9 @@ export function PlayDrawer({
                             headerPeekClimb ? (
                               <LivePlayDrawerHeader
                                 climb={headerPeekClimb}
-                                boardName={boardName as BoardName}
-                                layoutId={layoutId}
-                                angle={angle}
+                                boardName={headerPeekBoard.boardName as BoardName}
+                                layoutId={headerPeekBoard.layoutId}
+                                angle={headerPeekBoard.angle}
                                 // The incoming header reserves the same flank the
                                 // current one spends on the pill, so the name and
                                 // its attribute glyphs slide across at a fixed

--- a/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerHeader.tsx
@@ -1,8 +1,9 @@
 import { memo, useMemo, type ReactNode } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import type { BoardName, Climb } from '@boardsesh/shared-schema';
+import { CLIMB_CHARACTERISTICS, type BoardName, type Climb } from '@boardsesh/shared-schema';
 import { useEffectiveClimbStats } from '@boardsesh/board-react';
+import { getBoardCapabilities } from '@boardsesh/board-config';
 import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
 import { formatSends, formatQuality } from '../../lib/format-climb-stats';
 import { Text } from '../Text';
@@ -12,6 +13,7 @@ import { ClimbAttributeIcons } from '../ClimbAttributeIcons';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { WALL_STATE_PILL_TOUCH_HEIGHT } from '../../theme/layout';
 import { useDisplayGrade } from '../../hooks/use-display-grade';
+import { resolveClimbRuleLabels } from './climb-rule-labels';
 
 type PlayDrawerHeaderProps = {
   name: string;
@@ -32,6 +34,10 @@ type PlayDrawerHeaderProps = {
   benchmarkDifficulty?: string | null;
   /** Climb characteristics; no-match and MoonBoard method_* tokens render as glyphs/labels. */
   characteristics?: string[] | null;
+  /** The board being played. Boards whose `explicitClimbRules` capability is on
+   *  (Woods) print both climb rules under the subtitle; everything else keeps the
+   *  exception-only glyph cluster beside the name. */
+  boardName?: BoardName;
   /** Left-aligned element on the name's row (e.g. the on-wall status). The header
    *  balances both flanks so the name stays centered. The swipe peek passes a
    *  reserve-only copy so the incoming header matches this one exactly. */
@@ -51,6 +57,7 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
   setterUsername,
   benchmarkDifficulty,
   characteristics,
+  boardName,
   leading,
   onLongPressName,
 }: PlayDrawerHeaderProps) {
@@ -65,6 +72,23 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
   const qualityNum = qualityAverage == null ? Number.NaN : parseFloat(qualityAverage);
   if (qualityAverage != null && qualityNum > 0) subtitleParts.push(`${formatQuality(qualityAverage)}★`);
   if (setterUsername) subtitleParts.push(setterUsername);
+
+  // Woods states both rules on every problem, so we do too — see the
+  // `explicitClimbRules` capability. Recomputed per climb, which is also what
+  // makes the swipe peek show the INCOMING climb's rules: both headers are this
+  // component with their own climb's characteristics.
+  const ruleLabels = getBoardCapabilities(boardName).explicitClimbRules
+    ? resolveClimbRuleLabels(characteristics, t)
+    : null;
+
+  const residualCharacteristics = ruleLabels
+    ? characteristics?.filter(
+        (token) =>
+          token !== CLIMB_CHARACTERISTICS.NO_MATCH &&
+          token !== CLIMB_CHARACTERISTICS.ANY_FEET &&
+          token !== CLIMB_CHARACTERISTICS.CAMPUS,
+      )
+    : characteristics;
 
   return (
     <DrawerHeader
@@ -94,11 +118,30 @@ export const PlayDrawerHeader = memo(function PlayDrawerHeader({
                 {name}
               </MarqueeText>
             </Pressable>
-            <ClimbAttributeIcons benchmarkDifficulty={benchmarkDifficulty} characteristics={characteristics} />
+            {/* Keep rules the matching/feet line does not state, including no kickboard. */}
+            <ClimbAttributeIcons
+              benchmarkDifficulty={benchmarkDifficulty}
+              characteristics={residualCharacteristics?.length ? residualCharacteristics : null}
+            />
           </View>
           <Text variant="caption1" style={styles.subtitleText} numberOfLines={1}>
             {subtitleParts.join(' · ')}
           </Text>
+          {/* Deliberately unbounded lines: at the largest Dynamic Type sizes, or
+              on a narrow phone in German, "Matching allowed · Marked holds only"
+              does not fit one line, and a truncated climb RULE is worse than a
+              taller header — the header is measured with onLayout, so wrapping
+              just moves the board down a row. */}
+          {ruleLabels ? (
+            <Text
+              variant="caption1"
+              style={styles.rulesText}
+              accessibilityLabel={ruleLabels.accessibilityLabel}
+              testID="play-drawer-climb-rules"
+            >
+              {ruleLabels.parts.join(' · ')}
+            </Text>
+          ) : null}
         </>
       }
       trailing={
@@ -150,6 +193,7 @@ export const LivePlayDrawerHeader = memo(function LivePlayDrawerHeader({
       setterUsername={climb.setter_username}
       benchmarkDifficulty={climb.benchmark_difficulty}
       characteristics={climb.characteristics}
+      boardName={boardName}
       leading={leading}
       onLongPressName={onLongPressName}
     />
@@ -185,6 +229,13 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   subtitleText: {
+    color: iosSystemColors.systemGray,
+    marginTop: 2,
+    textAlign: 'center',
+  },
+  // Same grey as the subtitle it sits under — the rules are context, not a
+  // second headline competing with the name and the grade.
+  rulesText: {
     color: iosSystemColors.systemGray,
     marginTop: 2,
     textAlign: 'center',

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-climb-rules.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-climb-rules.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { CLIMB_CHARACTERISTICS } from '@boardsesh/shared-schema';
+
+// The Woods play-drawer header states BOTH climb rules under the subtitle — the
+// point being that a climber never has to work out whether a missing label meant
+// "default" or "we didn't render it".
+//
+// react-native isn't satisfiable under jsdom; stub the surface the header touches.
+// @boardsesh/board-config is deliberately NOT stubbed: the whole gate is its
+// `explicitClimbRules` capability, and a local copy of that table would let this
+// suite pass while the real one says something else.
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+  Platform: { OS: 'ios' },
+  PlatformColor: (name: string) => name,
+  Pressable: ({ children }: { children?: ReactNode }) => createElement('button', null, children),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) =>
+      options ? `${key}(${Object.values(options).join('|')})` : key,
+  }),
+}));
+vi.mock('@boardsesh/board-constants/grade-colors', () => ({
+  getGradeColor: () => '#abcdef',
+  DEFAULT_GRADE_COLOR: '#000000',
+}));
+vi.mock('../../../lib/format-climb-stats', () => ({
+  formatSends: (count: number) => `${count} sends`,
+  formatQuality: (value: string) => value,
+}));
+// `numberOfLines` is forwarded as a data attribute so the "must not truncate"
+// case below is testing the real prop rather than an attribute jsdom would drop
+// on the floor either way.
+vi.mock('../../Text', () => ({
+  Text: ({
+    children,
+    testID,
+    accessibilityLabel,
+    numberOfLines,
+  }: {
+    children?: ReactNode;
+    testID?: string;
+    accessibilityLabel?: string;
+    numberOfLines?: number;
+  }) =>
+    createElement(
+      'span',
+      {
+        'data-testid': testID,
+        'aria-label': accessibilityLabel,
+        'data-number-of-lines': numberOfLines == null ? undefined : String(numberOfLines),
+      },
+      children,
+    ),
+}));
+vi.mock('../../MarqueeText', () => ({
+  MarqueeText: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../DrawerHeader', () => ({
+  DrawerHeader: ({ center }: { center?: ReactNode }) => createElement('div', null, center),
+}));
+// Rendered as a marker element carrying whatever characteristics it was handed,
+// so a test can prove the header stops feeding it the tokens the rules line
+// already spells out.
+vi.mock('../../ClimbAttributeIcons', () => ({
+  ClimbAttributeIcons: ({ characteristics }: { characteristics?: string[] | null }) =>
+    createElement('i', { 'data-attr-icons': characteristics === null ? 'null' : JSON.stringify(characteristics) }),
+}));
+
+import { PlayDrawerHeader } from '../PlayDrawerHeader';
+
+const { NO_MATCH, CAMPUS, ANY_FEET } = CLIMB_CHARACTERISTICS;
+
+const baseProps = {
+  name: 'Treat yo self',
+  difficulty: 'V6',
+  qualityAverage: '0',
+  ascensionistCount: 0,
+  setterUsername: '',
+};
+
+function renderHeader(props: Partial<Parameters<typeof PlayDrawerHeader>[0]>) {
+  const { container } = render(createElement(PlayDrawerHeader, { ...baseProps, ...props }));
+  return {
+    container,
+    rules: container.querySelector('[data-testid="play-drawer-climb-rules"]'),
+    attrIcons: container.querySelector('[data-attr-icons]'),
+  };
+}
+
+describe('play-drawer climb rules line', () => {
+  it('states both rules on a Woods climb', () => {
+    const { rules } = renderHeader({ boardName: 'woods', characteristics: [] });
+    expect(rules?.textContent).toBe('mobile.climbRules.matchingAllowed · mobile.climbRules.markedHoldsOnly');
+  });
+
+  it.each([
+    [[NO_MATCH], 'mobile.climbRules.noMatching · mobile.climbRules.markedHoldsOnly'],
+    [[ANY_FEET], 'mobile.climbRules.matchingAllowed · mobile.climbRules.anyFeet'],
+    [[CAMPUS], 'mobile.climbRules.matchingAllowed · mobile.climbRules.noFeet'],
+    [[NO_MATCH, ANY_FEET], 'mobile.climbRules.noMatching · mobile.climbRules.anyFeet'],
+    [[NO_MATCH, CAMPUS], 'mobile.climbRules.noMatching · mobile.climbRules.noFeet'],
+  ])('renders %j as its own pair of rules', (characteristics, expected) => {
+    const { rules } = renderHeader({ boardName: 'woods', characteristics });
+    expect(rules?.textContent).toBe(expected);
+  });
+
+  it('says both rules are unrecorded when the climb carries no characteristics', () => {
+    // A Woods row imported before the catalogue carried rule metadata. Showing
+    // the defaults here would invent a rule the setter never authored.
+    const { rules } = renderHeader({ boardName: 'woods', characteristics: null });
+    expect(rules?.textContent).toBe('mobile.climbRules.matchingUnknown · mobile.climbRules.feetUnknown');
+  });
+
+  it('speaks the pair as one phrase for a screen reader', () => {
+    const { rules } = renderHeader({ boardName: 'woods', characteristics: [ANY_FEET] });
+    expect(rules?.getAttribute('aria-label')).toBe(
+      'mobile.climbRules.spoken(mobile.climbRules.matchingAllowed|mobile.climbRules.anyFeet)',
+    );
+  });
+
+  it('lets the rules wrap rather than truncating them', () => {
+    // A truncated climb RULE is worse than a taller header, which the drawer
+    // measures anyway. `numberOfLines` on this Text would silently ellipsize
+    // "Matching allowed · Marked holds only" at large Dynamic Type sizes and on a
+    // narrow phone in German. The subtitle above it DOES cap at one line, which
+    // is what makes this an easy thing to copy by accident.
+    const { container, rules } = renderHeader({ boardName: 'woods', characteristics: [] });
+    expect(rules?.getAttribute('data-number-of-lines')).toBeNull();
+    const subtitle = container.querySelector('span[data-number-of-lines="1"]');
+    expect(subtitle).not.toBeNull();
+    expect(subtitle).not.toBe(rules);
+  });
+
+  it('stops repeating those tokens in the glyph cluster beside the name', () => {
+    const { attrIcons } = renderHeader({ boardName: 'woods', characteristics: [NO_MATCH, ANY_FEET] });
+    expect(attrIcons?.getAttribute('data-attr-icons')).toBe('null');
+  });
+
+  it('keeps no-kickboard visible alongside Woods matching and feet rules', () => {
+    const { attrIcons, rules } = renderHeader({
+      boardName: 'woods',
+      characteristics: [NO_MATCH, ANY_FEET, 'no_kickboard'],
+    });
+    expect(attrIcons?.getAttribute('data-attr-icons')).toBe(JSON.stringify(['no_kickboard']));
+    expect(rules).not.toBeNull();
+  });
+
+  describe('boards that show only the exceptions', () => {
+    it.each(['kilter', 'tension', 'moonboard'] as const)('renders no rules line on %s', (boardName) => {
+      const { rules, attrIcons } = renderHeader({ boardName, characteristics: [NO_MATCH, ANY_FEET] });
+      expect(rules).toBeNull();
+      // ...and the glyph cluster keeps every token, exactly as before.
+      expect(attrIcons?.getAttribute('data-attr-icons')).toBe(JSON.stringify([NO_MATCH, ANY_FEET]));
+    });
+
+    it('renders no rules line when the header is given no board at all', () => {
+      expect(renderHeader({ characteristics: [NO_MATCH] }).rules).toBeNull();
+    });
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-cross-board.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-cross-board.test.tsx
@@ -25,6 +25,7 @@ type Props = Record<string, unknown>;
 
 const recorded = vi.hoisted(() => ({
   board: [] as Props[],
+  headers: [] as Props[],
   switchOverlay: [] as Props[],
   actionBar: [] as Props[],
   deferredSections: [] as Props[],
@@ -137,9 +138,15 @@ vi.mock('../BrowseFrameOverlay', () => ({ BrowseFrameOverlay: () => null }));
 vi.mock('../PanePlaceholder', () => ({ PanePlaceholder: () => null }));
 vi.mock('../BoardRenderUnavailable', () => ({ BoardRenderUnavailable: () => null }));
 vi.mock('../PlaybackControls', () => ({ PlaybackControls: () => null }));
-vi.mock('../PlayDrawerHeader', () => ({ LivePlayDrawerHeader: () => null }));
+vi.mock('../PlayDrawerHeader', () => ({
+  LivePlayDrawerHeader: (props: Props) => {
+    recorded.headers.push(props);
+    return null;
+  },
+}));
 vi.mock('../SwipeableHeader', () => ({
-  SwipeableHeader: ({ current }: { current?: ReactNode }) => createElement('div', null, current),
+  SwipeableHeader: ({ current, peek }: { current?: ReactNode; peek?: ReactNode }) =>
+    createElement('div', null, current, peek),
 }));
 vi.mock('../AngleSelectorSheet', () => ({
   AngleSelectorSheet: (props: Props) => {
@@ -248,6 +255,7 @@ function lastBoardProps(): Props {
 beforeEach(() => {
   vi.clearAllMocks();
   recorded.board = [];
+  recorded.headers = [];
   recorded.switchOverlay = [];
   recorded.actionBar = [];
   recorded.deferredSections = [];
@@ -339,6 +347,23 @@ describe('PlayDrawer draws the climb on its own board (#5099)', () => {
     expect(recorded.switchOverlay).toHaveLength(0);
     // Same board, so the wall can still be driven.
     expect(recorded.playback.at(-1)?.suppressWallWrites).toBe(false);
+  });
+
+  it('uses the incoming Woods board for the swipe header while Kilter stays current', () => {
+    const woods = {
+      ...TWELVE_CLIMB,
+      uuid: 'woods-peek',
+      boardType: 'woods',
+      layoutId: 1,
+      frames: 'p0r4p1r3',
+      compatibleSizeIds: [1],
+      characteristics: [],
+    };
+    queueState.currentClimbQueueItem = queueItem(TWELVE_CLIMB, 'queue-twelve');
+    navigation.state = { nextItem: queueItem(woods, 'queue-woods'), prevItem: null, canNext: true, canPrevious: false };
+    renderDrawer(vi.fn());
+    const header = recorded.headers.find((props) => (props.climb as Climb).uuid === 'woods-peek');
+    expect(header).toMatchObject({ boardName: 'woods', layoutId: 1 });
   });
 
   it('withholds a peek whose climb lives on another board', () => {

--- a/packages/mobile/src/components/play-drawer/climb-rule-labels.ts
+++ b/packages/mobile/src/components/play-drawer/climb-rule-labels.ts
@@ -1,0 +1,57 @@
+import type { TFunction } from 'i18next';
+import { decodeClimbRules, type ClimbRules } from '@boardsesh/play-view';
+
+/**
+ * The two rule labels a Woods climb shows under its subtitle, plus the sentence
+ * a screen reader hears instead of the middot-joined line.
+ *
+ * Always two parts, never one: the point of the Woods rules line is that BOTH
+ * rules are stated, so a climber never has to work out whether a missing label
+ * meant "default" or "we didn't render it". `unknown` is a label of its own for
+ * the same reason.
+ *
+ * Each branch uses a string-literal key so the i18n orphan/key analyzer can
+ * verify the catalog entries (`t(variable)` is lint-blocked).
+ */
+export type ClimbRuleLabels = {
+  parts: [string, string];
+  accessibilityLabel: string;
+};
+
+function matchingLabel(rules: ClimbRules, t: TFunction<'climbs'>): string {
+  switch (rules.matching) {
+    case 'not_allowed':
+      return t('mobile.climbRules.noMatching');
+    case 'allowed':
+      return t('mobile.climbRules.matchingAllowed');
+    default:
+      return t('mobile.climbRules.matchingUnknown');
+  }
+}
+
+function feetLabel(rules: ClimbRules, t: TFunction<'climbs'>): string {
+  switch (rules.feet) {
+    case 'any_feet':
+      return t('mobile.climbRules.anyFeet');
+    case 'marked_holds_only':
+      return t('mobile.climbRules.markedHoldsOnly');
+    case 'no_feet':
+      return t('mobile.climbRules.noFeet');
+    default:
+      return t('mobile.climbRules.feetUnknown');
+  }
+}
+
+export function resolveClimbRuleLabels(
+  characteristics: readonly string[] | null | undefined,
+  t: TFunction<'climbs'>,
+): ClimbRuleLabels {
+  const rules = decodeClimbRules(characteristics);
+  const parts: [string, string] = [matchingLabel(rules, t), feetLabel(rules, t)];
+  return {
+    parts,
+    // Spoken as one phrase with the section named, so the rules don't arrive as
+    // two bare fragments after the setter and the send count.
+    accessibilityLabel: t('mobile.climbRules.spoken', { matching: parts[0], feet: parts[1] }),
+  };
+}

--- a/packages/mobile/src/lib/__tests__/create-board-holds.test.ts
+++ b/packages/mobile/src/lib/__tests__/create-board-holds.test.ts
@@ -57,6 +57,22 @@ describe('getCreateBoardHolds', () => {
     });
   });
 
+  it.each([
+    { sizeId: 1, holds: 485, width: 720, height: 1000 },
+    { sizeId: 2, holds: 894, width: 1225, height: 1400 },
+  ])('uses real Woods geometry for size $sizeId, including hold zero', async ({ sizeId, holds, width, height }) => {
+    const actual = await vi.importActual<typeof import('../board-details')>('../board-details');
+    mockedGetBoardRenderData.mockImplementation(actual.getBoardRenderData);
+    const result = getCreateBoardHolds({ boardName: 'woods', layoutId: 1, sizeId, setIds: [1] });
+    expect(result).toMatchObject({ family: 'woods', boardWidth: width, boardHeight: height });
+    expect(result?.holdTargets).toHaveLength(holds);
+    expect(result?.holdTargets.some((hold) => hold.id === 0)).toBe(true);
+    expect(new Set(result?.holdTargets.map((hold) => hold.id)).size).toBe(holds);
+    expect(
+      result?.holdTargets.every((hold) => Number.isFinite(hold.cx) && Number.isFinite(hold.cy) && hold.r > 0),
+    ).toBe(true);
+  });
+
   it('returns null when render data is unavailable', () => {
     mockedGetBoardRenderData.mockReturnValue(null);
 

--- a/packages/mobile/src/lib/create-board-holds.ts
+++ b/packages/mobile/src/lib/create-board-holds.ts
@@ -4,17 +4,26 @@ import { getBoardRenderData } from './board-details';
 
 /**
  * The minimal per-hold geometry the interactive editor needs to place a tap
- * target + painted indicator. Both Aurora (`getBoardRenderData`) and MoonBoard
- * (`getMoonBoardDetails`, added in the MoonBoard PR) already produce
- * `{id, cx, cy, r}` in board-space pixels, so one editor renders either family.
+ * target + painted indicator. Aurora (`getBoardRenderData`), MoonBoard
+ * (`getMoonBoardDetails`) and Woods (`getWoodsBoardDetails`) all produce
+ * `{id, cx, cy, r}` in board-space pixels, so one editor renders any family.
  */
 export type BoardHoldTarget = { id: number; cx: number; cy: number; r: number };
+
+/**
+ * Which geometry pipeline the hold targets came out of. Aurora holds come from
+ * per-set hole placements; MoonBoard and Woods are code-driven, with hold ids
+ * numbered from each board's own origin — which is why Woods is its own family
+ * rather than another code-driven MoonBoard: an id means a different hold on
+ * each of its two sizes (see `canAddClimbToBoard` rule 5).
+ */
+export type CreateBoardFamily = 'aurora' | 'moonboard' | 'woods';
 
 export type CreateBoardHolds = BoardEdges & {
   holdTargets: BoardHoldTarget[];
   boardWidth: number;
   boardHeight: number;
-  family: 'aurora' | 'moonboard';
+  family: CreateBoardFamily;
 };
 
 type CreateBoardHoldsConfig = {
@@ -41,10 +50,16 @@ export function parseSetIdsParam(setIds: string): number[] {
   return setIds.split(',').map(Number).filter(Boolean);
 }
 
+function resolveCreateBoardFamily(boardName: BoardName): CreateBoardFamily {
+  if (boardName === 'moonboard') return 'moonboard';
+  if (boardName === 'woods') return 'woods';
+  return 'aurora';
+}
+
 /**
  * Resolve the full set of tappable holds for a board configuration, board-family
- * agnostic. Aurora boards come from the hole-placement pipeline; MoonBoard comes
- * from the grid-backed render data branch.
+ * agnostic. Aurora boards come from the hole-placement pipeline; MoonBoard and
+ * Woods come from their code-driven render-data branches.
  */
 export function getCreateBoardHolds(cfg: CreateBoardHoldsConfig): CreateBoardHolds | null {
   const cacheKey = createBoardHoldsCacheKey(cfg);
@@ -65,7 +80,7 @@ export function getCreateBoardHolds(cfg: CreateBoardHoldsConfig): CreateBoardHol
         edgeRight: data.edgeRight,
         edgeBottom: data.edgeBottom,
         edgeTop: data.edgeTop,
-        family: cfg.boardName === 'moonboard' ? ('moonboard' as const) : ('aurora' as const),
+        family: resolveCreateBoardFamily(cfg.boardName),
       }
     : null;
 

--- a/packages/mobile/src/lib/create-climb-draft-store.ts
+++ b/packages/mobile/src/lib/create-climb-draft-store.ts
@@ -24,12 +24,25 @@ export type CreateClimbDraft = {
   framesJson?: string;
   name: string;
   description: string;
+  /**
+   * "No matching" toggle. Explicit since the rule stopped being inferable from
+   * the description on every board: the leading `No match` line is an Aurora wire
+   * convention, and on the code-driven boards a description that starts with
+   * those words is just prose. Optional so a slot written before this field
+   * still restores — from the description sniff, which is all it ever had.
+   */
+  noMatch?: boolean;
   isDraft: boolean;
   /** "No kickboard" toggle — feet allowed, kickboard off-limits. Optional so old
    *  persisted drafts without it still pass the type guard and default to false. */
   noKickboard?: boolean;
   /** "Campus" toggle — no feet at all. Optional for the same back-compat reason. */
   campus?: boolean;
+  /** "Any feet" toggle — feet may use any hold, not only the marked ones. The
+   *  opposite of `campus`, and mutually exclusive with it. Optional for the same
+   *  back-compat reason: a slot written before this rule existed restores with the
+   *  board's default (feet on the marked holds). */
+  anyFeet?: boolean;
   /**
    * JSON.stringify of the `SavedClimbSnapshot` this working copy is attached to,
    * once it has been saved to the server at least once. Restoring it re-links a

--- a/packages/mobile/src/lib/create-climb-draft-store.web.ts
+++ b/packages/mobile/src/lib/create-climb-draft-store.web.ts
@@ -14,11 +14,15 @@ export type CreateClimbDraft = {
   framesJson?: string;
   name: string;
   description: string;
+  /** "No matching" toggle. Optional for drafts created before this field. */
+  noMatch?: boolean;
   isDraft: boolean;
   /** "No kickboard" toggle. Optional for drafts created before this field. */
   noKickboard?: boolean;
   /** "Campus" toggle. Optional for drafts created before this field. */
   campus?: boolean;
+  /** "Any feet" toggle. Optional for drafts created before this field. */
+  anyFeet?: boolean;
   /** JSON.stringify of the attached `SavedClimbSnapshot`. See the native fork. */
   savedClimbJson?: string;
   /** Payload signature at the last successful server save. See the native fork. */

--- a/packages/mobile/src/providers/bluetooth-provider.tsx
+++ b/packages/mobile/src/providers/bluetooth-provider.tsx
@@ -116,6 +116,8 @@ type BluetoothContextValue = {
   /** The board type this provider is scoped to (route-derived), so BLE-controls
    * UI can gate MoonBoard-only affordances. Undefined off a board route. */
   boardName: string | undefined;
+  layoutId?: number;
+  sizeId?: number;
   /**
    * MoonBoard "V2" BLE feature: also light each active hold's firmware-
    * defined neighbour LED (typically the hold above), dimmer, alongside its
@@ -1549,6 +1551,8 @@ export function BluetoothProvider({
       autoDisconnectTimeoutSeconds,
       autoDisconnectWarning,
       boardName,
+      layoutId,
+      sizeId,
       moonboardLightAdjacentHolds,
       setMoonboardLightAdjacentHolds,
     }),
@@ -1569,6 +1573,8 @@ export function BluetoothProvider({
       autoDisconnectTimeoutSeconds,
       autoDisconnectWarning,
       boardName,
+      layoutId,
+      sizeId,
       moonboardLightAdjacentHolds,
       setMoonboardLightAdjacentHolds,
     ],

--- a/packages/shared-schema/src/characteristics.ts
+++ b/packages/shared-schema/src/characteristics.ts
@@ -18,6 +18,16 @@ export const CLIMB_CHARACTERISTICS = {
   NO_KICKBOARD: 'no_kickboard',
   /** No feet allowed at all (hands only). Independent toggle — any board type. */
   CAMPUS: 'campus',
+  /**
+   * Any hold on the wall may be used as a foot, not just the ones the setter lit
+   * as feet. The Woods app calls this "open feet"; it is the default on that
+   * board and the reason a Woods problem often lights no foot holds at all.
+   *
+   * Board-agnostic as a token (nothing about it is Woods-specific), but it is
+   * only authored on Woods today. It contradicts {@link CLIMB_CHARACTERISTICS.CAMPUS}
+   * and the two footless MoonBoard methods — see {@link ANY_FEET_CONFLICTS}.
+   */
+  ANY_FEET: 'any_feet',
   /** MoonBoard "Footless": no foot holds, kickboard not used. */
   METHOD_FOOTLESS: 'method_footless',
   /** MoonBoard "Footless + kickboard": no foot holds, the kickboard may be used. */
@@ -66,16 +76,92 @@ export function isCampus(characteristics: readonly string[] | null | undefined):
   return hasCharacteristic(characteristics, CLIMB_CHARACTERISTICS.CAMPUS);
 }
 
+/** Whether any hold on the wall counts as a foot on this climb. */
+export function isAnyFeet(characteristics: readonly string[] | null | undefined): boolean {
+  return hasCharacteristic(characteristics, CLIMB_CHARACTERISTICS.ANY_FEET);
+}
+
 /**
  * Tokens that are freely toggleable and independent of each other (unlike the
  * mutually-exclusive METHOD_* group). A client sends the full desired boolean
  * state of each of these; the server merges them in without touching any other
  * characteristic (no_match, MoonBoard method) already on the row.
+ *
+ * Deliberately still just no_kickboard + campus. `no_match` and `any_feet` ride
+ * their own dedicated boolean input fields (`noMatch` / `anyFeet`), so adding
+ * them here would let an old client — which sends this array as the FULL desired
+ * state of every token in the list — silently clear a flag it has never heard of.
  */
 export const TOGGLEABLE_CLIMB_CHARACTERISTICS = [
   CLIMB_CHARACTERISTICS.NO_KICKBOARD,
   CLIMB_CHARACTERISTICS.CAMPUS,
 ] as const;
+
+/**
+ * Tokens that cannot be true at the same time as `any_feet`.
+ *
+ * `campus` is "no feet at all" and `any_feet` is "every hold is a foot" — a climb
+ * cannot be both. The two footless MoonBoard methods say the same thing in the
+ * MoonBoard vocabulary. `method_no_kickboard` and `no_kickboard` are NOT in here:
+ * "use any hold as a foot, except the kickboard" is a coherent rule and a real
+ * one on boards with a kickboard.
+ */
+export const ANY_FEET_CONFLICTS: readonly ClimbCharacteristic[] = [
+  CLIMB_CHARACTERISTICS.CAMPUS,
+  CLIMB_CHARACTERISTICS.METHOD_FOOTLESS,
+  CLIMB_CHARACTERISTICS.METHOD_FOOTLESS_KICKBOARD,
+];
+
+/**
+ * The first token in `characteristics` that contradicts another one in the same
+ * array, or null when the set is coherent. Callers reject the write on a
+ * non-null result rather than silently dropping one side of the contradiction.
+ *
+ * Runs over the FINAL merged array (client input plus whatever was already on
+ * the row), so it also catches a conflict a client couldn't see — e.g. turning
+ * on `any_feet` for a MoonBoard problem stored as `method_footless`.
+ */
+export function findCharacteristicConflict(
+  characteristics: readonly string[] | null | undefined,
+): { token: ClimbCharacteristic; conflictsWith: ClimbCharacteristic } | null {
+  if (!characteristics || !characteristics.includes(CLIMB_CHARACTERISTICS.ANY_FEET)) return null;
+  const conflict = ANY_FEET_CONFLICTS.find((token) => characteristics.includes(token));
+  return conflict ? { token: CLIMB_CHARACTERISTICS.ANY_FEET, conflictsWith: conflict } : null;
+}
+
+/**
+ * Whether a board's `no_match` can still be carried by the description alone.
+ *
+ * The `"No match\n"` prefix is an Aurora wire convention, backfilled into
+ * `characteristics` by migration. A row synced between that backfill and a given
+ * deploy can still carry it in prose only, so readers fall back to the
+ * description when `characteristics` is NULL. The code-driven boards never had
+ * the convention: on MoonBoard a description starting with "no match" is user
+ * prose, and on Woods a NULL `characteristics` means "rules unknown until the
+ * catalog repair fills them in", not "no rules the description forgot".
+ */
+export function usesAuroraNoMatchDescription(boardType: string): boolean {
+  return boardType !== 'moonboard' && boardType !== 'woods';
+}
+
+/**
+ * The canonical rule string for a climb: its characteristic tokens deduped,
+ * sorted and comma-joined.
+ *
+ * This is duplicate-detection identity, not display. Two climbs with the same
+ * holds but different rules ("no match" vs not, "any feet" vs not) are two
+ * different problems on the wall, so the rule string is part of the key the
+ * duplicate gate compares — see `findExactDuplicateMatch` in the backend, whose
+ * SQL builds the same string from `board_climbs.characteristics`.
+ *
+ * Used for the advisory-lock key. SQL compares the corresponding arrays as
+ * sets, so ordering and duplicate tokens do not change duplicate identity.
+ * Unknown tokens remain part of the identity for compatibility with newer clients.
+ */
+export function buildRuleSignature(characteristics: readonly string[] | null | undefined): string {
+  if (!characteristics || characteristics.length === 0) return '';
+  return Array.from(new Set(characteristics)).sort().join(',');
+}
 
 /** The MoonBoard method token on a climb, or null for the "feet follow hands" default. */
 export function getMoonBoardMethod(characteristics: readonly string[] | null | undefined): ClimbCharacteristic | null {

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -4675,8 +4675,14 @@ input SaveClimbInput {
   framesCount: Int
   framesPace: Int
   angle: Int!
-  "Freely-toggleable characteristics to set at creation. Only CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS are accepted here — no_match is server-derived from description, and MoonBoard method is creation-time-only via SaveMoonBoardClimbInput."
+  "Freely-toggleable characteristics to set at creation. Only CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS are accepted here — MoonBoard method is creation-time-only via SaveMoonBoardClimbInput, and no_match / any_feet ride noMatch / anyFeet below."
   characteristics: [String!]
+  "Matching disallowed. Wins over the legacy 'No match' description prefix; null or omitted falls back to that prefix and otherwise means false."
+  noMatch: Boolean
+  "Any hold on the wall counts as a foot. Null or omitted means false."
+  anyFeet: Boolean
+  "Physical board size the climb is set on. Required on Woods (1 = 8x10, 2 = 12x12), where the two walls number their holds from their own origins. Ignored on boards that derive size compatibility from the hold bounding box."
+  sizeId: Int
 }
 
 """
@@ -4733,8 +4739,14 @@ input UpdateClimbInput {
   isDraft: Boolean
   framesCount: Int
   framesPace: Int
-  "Freely-toggleable characteristics: the full desired boolean state of CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS. Any other characteristic already on the row (no_match, MoonBoard method) is left untouched."
+  "Freely-toggleable characteristics: the full desired boolean state of CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS. Any other characteristic already on the row (no_match, any_feet, MoonBoard method) is left untouched."
   characteristics: [String!]
+  "Matching disallowed. Null or omitted preserves the stored value, so an old client cannot clear it. When set it wins over the legacy 'No match' description prefix in the same call."
+  noMatch: Boolean
+  "Any hold counts as a foot. Null or omitted preserves the stored value."
+  anyFeet: Boolean
+  "Physical board size, where it is part of the climb's identity (Woods). Immutable — a size that differs from the stored one is rejected. Null or omitted keeps the stored size."
+  sizeId: Int
 }
 
 type UpdateClimbResult {
@@ -4752,6 +4764,15 @@ frames (compare against a not-yet-saved hold set).
 input SimilarClimbsInput {
   boardType: String!
   layoutId: Int!
+  """
+  Physical board size to scope candidates to. Load-bearing on Woods, whose two
+  walls reuse the same hold-id range for different holds — without it an 8x10
+  climb reads as near-identical to an unrelated 12x12 one. On Woods the target
+  climb's own compatible sizes fill this in when climbUuid is given; a
+  frames-only Woods lookup must send it or the result is empty. Ignored on
+  every other board.
+  """
+  sizeId: Int
   "Jaccard threshold (0..1). Returns climbs at or above this similarity."
   threshold: Float
   "Max number of results to return. Defaults to 25, capped at 200 server-side."

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -6562,8 +6562,10 @@ export type SaveAuroraCredentialInput = {
 
 export type SaveClimbInput = {
   angle: Scalars['Int']['input'];
+  /** Any hold on the wall counts as a foot. Null or omitted means false. */
+  anyFeet?: InputMaybe<Scalars['Boolean']['input']>;
   boardType: Scalars['String']['input'];
-  /** Freely-toggleable characteristics to set at creation. Only CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS are accepted here — no_match is server-derived from description, and MoonBoard method is creation-time-only via SaveMoonBoardClimbInput. */
+  /** Freely-toggleable characteristics to set at creation. Only CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS are accepted here — MoonBoard method is creation-time-only via SaveMoonBoardClimbInput, and no_match / any_feet ride noMatch / anyFeet below. */
   characteristics?: InputMaybe<Array<Scalars['String']['input']>>;
   description?: InputMaybe<Scalars['String']['input']>;
   frames: Scalars['String']['input'];
@@ -6572,6 +6574,10 @@ export type SaveClimbInput = {
   isDraft: Scalars['Boolean']['input'];
   layoutId: Scalars['Int']['input'];
   name: Scalars['String']['input'];
+  /** Matching disallowed. Wins over the legacy 'No match' description prefix; null or omitted falls back to that prefix and otherwise means false. */
+  noMatch?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Physical board size the climb is set on. Required on Woods (1 = 8x10, 2 = 12x12), where the two walls number their holds from their own origins. Ignored on boards that derive size compatibility from the hold bounding box. */
+  sizeId?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type SaveClimbResult = {
@@ -7451,6 +7457,15 @@ export type SimilarClimbsInput = {
   layoutId: Scalars['Int']['input'];
   /** Max number of results to return. Defaults to 25, capped at 200 server-side. */
   limit?: InputMaybe<Scalars['Int']['input']>;
+  /**
+   * Physical board size to scope candidates to. Load-bearing on Woods, whose two
+   * walls reuse the same hold-id range for different holds — without it an 8x10
+   * climb reads as near-identical to an unrelated 12x12 one. On Woods the target
+   * climb's own compatible sizes fill this in when climbUuid is given; a
+   * frames-only Woods lookup must send it or the result is empty. Ignored on
+   * every other board.
+   */
+  sizeId?: InputMaybe<Scalars['Int']['input']>;
   /** Jaccard threshold (0..1). Returns climbs at or above this similarity. */
   threshold?: InputMaybe<Scalars['Float']['input']>;
 };
@@ -7977,8 +7992,10 @@ export type UpdateBoardInput = {
  */
 export type UpdateClimbInput = {
   angle?: InputMaybe<Scalars['Int']['input']>;
+  /** Any hold counts as a foot. Null or omitted preserves the stored value. */
+  anyFeet?: InputMaybe<Scalars['Boolean']['input']>;
   boardType: Scalars['String']['input'];
-  /** Freely-toggleable characteristics: the full desired boolean state of CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS. Any other characteristic already on the row (no_match, MoonBoard method) is left untouched. */
+  /** Freely-toggleable characteristics: the full desired boolean state of CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS. Any other characteristic already on the row (no_match, any_feet, MoonBoard method) is left untouched. */
   characteristics?: InputMaybe<Array<Scalars['String']['input']>>;
   description?: InputMaybe<Scalars['String']['input']>;
   frames?: InputMaybe<Scalars['String']['input']>;
@@ -7987,6 +8004,10 @@ export type UpdateClimbInput = {
   /** When set, flips the draft state. A climb can go from draft→published but not the other way around. */
   isDraft?: InputMaybe<Scalars['Boolean']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
+  /** Matching disallowed. Null or omitted preserves the stored value, so an old client cannot clear it. When set it wins over the legacy 'No match' description prefix in the same call. */
+  noMatch?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Physical board size, where it is part of the climb's identity (Woods). Immutable — a size that differs from the stored one is rejected. Null or omitted keeps the stored size. */
+  sizeId?: InputMaybe<Scalars['Int']['input']>;
   uuid: Scalars['ID']['input'];
 };
 

--- a/packages/shared-schema/src/schema/new-climb-feed.ts
+++ b/packages/shared-schema/src/schema/new-climb-feed.ts
@@ -81,8 +81,14 @@ export const newClimbFeedTypeDefs = /* GraphQL */ `
     framesCount: Int
     framesPace: Int
     angle: Int!
-    "Freely-toggleable characteristics to set at creation. Only CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS are accepted here — no_match is server-derived from description, and MoonBoard method is creation-time-only via SaveMoonBoardClimbInput."
+    "Freely-toggleable characteristics to set at creation. Only CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS are accepted here — MoonBoard method is creation-time-only via SaveMoonBoardClimbInput, and no_match / any_feet ride noMatch / anyFeet below."
     characteristics: [String!]
+    "Matching disallowed. Wins over the legacy 'No match' description prefix; null or omitted falls back to that prefix and otherwise means false."
+    noMatch: Boolean
+    "Any hold on the wall counts as a foot. Null or omitted means false."
+    anyFeet: Boolean
+    "Physical board size the climb is set on. Required on Woods (1 = 8x10, 2 = 12x12), where the two walls number their holds from their own origins. Ignored on boards that derive size compatibility from the hold bounding box."
+    sizeId: Int
   }
 
   """
@@ -139,8 +145,14 @@ export const newClimbFeedTypeDefs = /* GraphQL */ `
     isDraft: Boolean
     framesCount: Int
     framesPace: Int
-    "Freely-toggleable characteristics: the full desired boolean state of CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS. Any other characteristic already on the row (no_match, MoonBoard method) is left untouched."
+    "Freely-toggleable characteristics: the full desired boolean state of CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS. Any other characteristic already on the row (no_match, any_feet, MoonBoard method) is left untouched."
     characteristics: [String!]
+    "Matching disallowed. Null or omitted preserves the stored value, so an old client cannot clear it. When set it wins over the legacy 'No match' description prefix in the same call."
+    noMatch: Boolean
+    "Any hold counts as a foot. Null or omitted preserves the stored value."
+    anyFeet: Boolean
+    "Physical board size, where it is part of the climb's identity (Woods). Immutable — a size that differs from the stored one is rejected. Null or omitted keeps the stored size."
+    sizeId: Int
   }
 
   type UpdateClimbResult {
@@ -158,6 +170,15 @@ export const newClimbFeedTypeDefs = /* GraphQL */ `
   input SimilarClimbsInput {
     boardType: String!
     layoutId: Int!
+    """
+    Physical board size to scope candidates to. Load-bearing on Woods, whose two
+    walls reuse the same hold-id range for different holds — without it an 8x10
+    climb reads as near-identical to an unrelated 12x12 one. On Woods the target
+    climb's own compatible sizes fill this in when climbUuid is given; a
+    frames-only Woods lookup must send it or the result is empty. Ignored on
+    every other board.
+    """
+    sizeId: Int
     "Jaccard threshold (0..1). Returns climbs at or above this similarity."
     threshold: Float
     "Max number of results to return. Defaults to 25, capped at 200 server-side."

--- a/packages/shared-schema/src/types/climb.ts
+++ b/packages/shared-schema/src/types/climb.ts
@@ -248,10 +248,25 @@ export type SaveClimbInput = {
   framesPace?: number | null;
   angle: number;
   // Freely-toggleable characteristics to set at creation. Only
-  // CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS are accepted here — no_match is
-  // server-derived from description, and MoonBoard method is creation-time-only
-  // via SaveMoonBoardClimbInput.
+  // CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS are accepted here — MoonBoard
+  // method is creation-time-only via SaveMoonBoardClimbInput, and no_match /
+  // any_feet ride the dedicated booleans below.
   characteristics?: string[] | null;
+  /**
+   * Matching disallowed. When set, this WINS over the legacy "No match\n"
+   * description prefix; null/omitted falls back to that prefix (old clients) and
+   * otherwise means false.
+   */
+  noMatch?: boolean | null;
+  /** Any hold on the wall counts as a foot. Null/omitted means false. */
+  anyFeet?: boolean | null;
+  /**
+   * Physical board size the climb is set on. Required on Woods (1 = 8x10,
+   * 2 = 12x12), whose two walls number their holds from their own origins, so
+   * the size is part of the climb's identity. Ignored on every other board,
+   * which derives `compatible_size_ids` from the hold bounding box.
+   */
+  sizeId?: number | null;
 };
 
 export type SaveMoonBoardClimbInput = {
@@ -300,8 +315,23 @@ export type UpdateClimbInput = {
   framesPace?: number | null;
   // Freely-toggleable characteristics: the full desired boolean state of
   // CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS. Any other characteristic
-  // already on the row (no_match, MoonBoard method) is left untouched.
+  // already on the row (no_match, any_feet, MoonBoard method) is left untouched.
   characteristics?: string[] | null;
+  /**
+   * Matching disallowed. Null/omitted preserves whatever the row already says —
+   * an old client that has never heard of this field can't clear it. When set it
+   * WINS over the legacy "No match\n" description prefix in the same call.
+   */
+  noMatch?: boolean | null;
+  /** Any hold counts as a foot. Null/omitted preserves the row's current value. */
+  anyFeet?: boolean | null;
+  /**
+   * Physical board size, for boards where it is part of the climb's identity
+   * (Woods). Immutable: sending a size that differs from the stored one is
+   * rejected rather than silently moving the climb to the other wall. Null or
+   * omitted keeps the stored size.
+   */
+  sizeId?: number | null;
 };
 
 export type UpdateClimbResult = {

--- a/packages/shared-schema/src/types/new-climb-feed.ts
+++ b/packages/shared-schema/src/types/new-climb-feed.ts
@@ -70,6 +70,14 @@ export type MoonBoardClimbDuplicateMatch = {
 export type SimilarClimbsInput = {
   boardType: string;
   layoutId: number;
+  /**
+   * Physical board size to scope candidates to. Load-bearing on Woods, where the
+   * 8x10 and 12x12 walls reuse the same hold-id range for different holds, so an
+   * unscoped comparison reports cross-wall coincidences as near-identical climbs.
+   * Optional: on Woods the target climb's own `compatible_size_ids` fills it in
+   * when a `climbUuid` is given, and it is ignored on every other board.
+   */
+  sizeId?: number | null;
   threshold?: number | null;
   limit?: number | null;
   excludeClimbUuid?: string | null;

--- a/packages/shared/board-config/src/__tests__/board-capabilities.test.ts
+++ b/packages/shared/board-config/src/__tests__/board-capabilities.test.ts
@@ -2,34 +2,37 @@ import { describe, it, expect } from 'vitest';
 import { AURORA_BOARDS, SUPPORTED_BOARDS } from '@boardsesh/shared-schema';
 import { getBoardCapabilities, type BoardCapabilities } from '../board-capabilities';
 
+const AURORA_ROW: BoardCapabilities = {
+  crowdGrade: true,
+  climbCreation: true,
+  explicitClimbRules: false,
+  multiFrameClimbs: true,
+  nativeBoardControl: true,
+  auroraAppLink: true,
+};
+
 // The whole table in one place: change a row here and the reviewer sees exactly
 // which surface turns on or off.
 const EXPECTED: Record<string, BoardCapabilities> = {
-  kilter: { crowdGrade: true, climbCreation: true, nativeBoardControl: true, auroraAppLink: true },
-  tension: { crowdGrade: true, climbCreation: true, nativeBoardControl: true, auroraAppLink: true },
-  decoy: { crowdGrade: true, climbCreation: true, nativeBoardControl: true, auroraAppLink: true },
-  touchstone: {
-    crowdGrade: true,
-    climbCreation: true,
-    nativeBoardControl: true,
-    auroraAppLink: true,
-  },
-  grasshopper: {
-    crowdGrade: true,
-    climbCreation: true,
-    nativeBoardControl: true,
-    auroraAppLink: true,
-  },
-  soill: { crowdGrade: true, climbCreation: true, nativeBoardControl: true, auroraAppLink: true },
+  kilter: AURORA_ROW,
+  tension: AURORA_ROW,
+  decoy: AURORA_ROW,
+  touchstone: AURORA_ROW,
+  grasshopper: AURORA_ROW,
+  soill: AURORA_ROW,
   moonboard: {
     crowdGrade: false,
     climbCreation: true,
+    explicitClimbRules: false,
+    multiFrameClimbs: true,
     nativeBoardControl: true,
     auroraAppLink: false,
   },
   woods: {
     crowdGrade: false,
-    climbCreation: false,
+    climbCreation: true,
+    explicitClimbRules: true,
+    multiFrameClimbs: false,
     nativeBoardControl: false,
     auroraAppLink: false,
   },
@@ -48,34 +51,45 @@ describe('getBoardCapabilities', () => {
 
   it('gives every Aurora board the full feature set', () => {
     for (const auroraBoard of AURORA_BOARDS) {
-      expect(getBoardCapabilities(auroraBoard)).toEqual({
-        crowdGrade: true,
-        climbCreation: true,
-        nativeBoardControl: true,
-        auroraAppLink: true,
-      });
+      expect(getBoardCapabilities(auroraBoard)).toEqual(AURORA_ROW);
     }
+  });
+
+  it('lets climbs be authored on every supported board', () => {
+    // Woods was the last board that could be browsed but not authored on
+    // (#4750). If a new board arrives that genuinely can't, give it its own row
+    // above and delete this case — don't loosen it.
+    for (const boardName of SUPPORTED_BOARDS) {
+      expect(getBoardCapabilities(boardName).climbCreation).toBe(true);
+    }
+  });
+
+  it('states both climb rules explicitly on Woods only', () => {
+    const explicit = SUPPORTED_BOARDS.filter((boardName) => getBoardCapabilities(boardName).explicitClimbRules);
+    expect(explicit).toEqual(['woods']);
+  });
+
+  it('withholds multi-frame climbs from Woods only', () => {
+    // `getWoodsBluetoothPacket` throws WoodsMultiFrameError on the comma a second
+    // frame introduces, so a multi-frame Woods climb would save and then refuse
+    // to light the wall.
+    const singleFrameOnly = SUPPORTED_BOARDS.filter((boardName) => !getBoardCapabilities(boardName).multiFrameClimbs);
+    expect(singleFrameOnly).toEqual(['woods']);
   });
 
   it('is case-insensitive', () => {
     // The play drawer passes the board name straight through from a climb row,
     // where it has shown up capitalised ("MoonBoard").
     expect(getBoardCapabilities('MoonBoard').crowdGrade).toBe(false);
-    expect(getBoardCapabilities('Woods').climbCreation).toBe(false);
+    expect(getBoardCapabilities('Woods').explicitClimbRules).toBe(true);
   });
 
   it('falls back to the Aurora defaults for an unknown or absent board', () => {
     // Today's behaviour for every caller that used to ask `boardName !== 'woods'`:
     // anything unrecognised keeps every feature on, and callers that care about a
     // missing board guard on it separately.
-    const auroraDefaults = {
-      crowdGrade: true,
-      climbCreation: true,
-      nativeBoardControl: true,
-      auroraAppLink: true,
-    };
-    expect(getBoardCapabilities(undefined)).toEqual(auroraDefaults);
-    expect(getBoardCapabilities('')).toEqual(auroraDefaults);
-    expect(getBoardCapabilities('not-a-board')).toEqual(auroraDefaults);
+    expect(getBoardCapabilities(undefined)).toEqual(AURORA_ROW);
+    expect(getBoardCapabilities('')).toEqual(AURORA_ROW);
+    expect(getBoardCapabilities('not-a-board')).toEqual(AURORA_ROW);
   });
 });

--- a/packages/shared/board-config/src/__tests__/board-compatibility.test.ts
+++ b/packages/shared/board-config/src/__tests__/board-compatibility.test.ts
@@ -49,6 +49,24 @@ describe('classifyClimbBoardCompatibility', () => {
     expect(classifyClimbBoardCompatibility(KILTER_L1, { boardType: undefined, layoutId: 8 })).toBe('incompatible');
   });
 
+  it('treats Woods physical size as part of lighting identity', () => {
+    const wall = { boardName: 'woods' as const, layoutId: 1, sizeId: 2 };
+    expect(classifyClimbBoardCompatibility(wall, { boardType: 'woods', layoutId: 1, compatibleSizeIds: [1] })).toBe(
+      'incompatible',
+    );
+    expect(classifyClimbBoardCompatibility(wall, { boardType: 'woods', layoutId: 1, compatibleSizeIds: [2] })).toBe(
+      'compatible',
+    );
+    const queue = [
+      makeItem('small', { boardType: 'woods', layoutId: 1, compatibleSizeIds: [1] }),
+      makeItem('large', { boardType: 'woods', layoutId: 1, compatibleSizeIds: [2] }),
+    ];
+    expect(findNextCompatibleQueueItem(queue, 'small', wall)).toMatchObject({
+      item: { uuid: 'large' },
+      skippedCount: 1,
+    });
+  });
+
   // Production repros from issue #3193 (Sentry BOARDSESH-39 / BOARDSESH-6P):
   // kilter layout-1 climbs sent while the app was on a Homewall or MoonBoard config.
   it('flags a kilter original climb as incompatible with a kilter Homewall board (BOARDSESH-39)', () => {

--- a/packages/shared/board-config/src/board-capabilities.ts
+++ b/packages/shared/board-config/src/board-capabilities.ts
@@ -37,19 +37,44 @@ export type BoardCapabilities = {
    * New climbs can be set on the board from inside Boardsesh (create / fork /
    * edit).
    *
-   * False on Woods: the create-climb editor paints holds through
-   * `getCreateBoardHolds`, whose `family` falls through to `'aurora'` for
-   * anything that isn't MoonBoard — so a Woods draft would be saved with Aurora
-   * role codes instead of the Woods wire roles (`p{loc}r{code}`, spec §6) the
-   * board's LEDs and our own frames parser speak. It would also be published
-   * against a board with no `board_placements` rows behind it, which the hold
-   * filters and the setter surfaces both read.
+   * True everywhere now. Woods was the last holdout: the editor paints holds
+   * through `getCreateBoardHolds`, which reported the Aurora family for it, and
+   * a Woods board has no `board_placements` rows. Both were answered by #4750 —
+   * `getCreateBoardHolds` reports `'woods'` off the code-driven geometry
+   * (`getWoodsRenderData`), and the shared role machine already encodes the
+   * Woods wire roles (`p{loc}r{code}`, spec §6) because
+   * `STATE_TO_PRIMARY_CODE.woods` has carried them since the catalog import.
    *
-   * So Create / Fork / Edit are HIDDEN for Woods rather than left to fail:
-   * browsing, lighting up and ticking the imported Woods catalog all work.
-   * Setting your own Woods climbs is boardsesh/boardsesh#4750.
+   * The row stays in the table: a future board can arrive with a catalog and no
+   * way to author on it, which is exactly the state Woods shipped in.
    */
   climbCreation: boolean;
+  /**
+   * The board's climbs state BOTH climb rules (matching, feet) as data, so the
+   * play drawer prints both under the climb's subtitle instead of showing only
+   * the exceptions.
+   *
+   * True on Woods only. The Woods app states both rules on every problem and its
+   * catalogue carries them per climb, so a Woods climber reads "Matching
+   * allowed · Marked holds only" as part of the problem. Aurora and MoonBoard
+   * climbs carry the same tokens, but their apps (and ours, for years) show only
+   * the departures from the default — a no-match glyph, a method badge — and
+   * spelling out two extra lines under every Kilter climb would bury the grade
+   * and the setter under boilerplate nobody asked for.
+   */
+  explicitClimbRules: boolean;
+  /**
+   * A climb on this board can hold more than one frame (a route / circuit that
+   * steps through hold sets), so the editor offers duplicate/delete/step frame
+   * controls.
+   *
+   * False on Woods. Its wire format is one flat `p{loc}r{code}` run per message
+   * and `getWoodsBluetoothPacket` throws `WoodsMultiFrameError` on the comma a
+   * second frame introduces (spec §5) — so a two-frame Woods climb would save
+   * fine and then refuse to light the wall. The controls are hidden rather than
+   * left to fail, the same way Create was before #4750.
+   */
+  multiFrameClimbs: boolean;
   /**
    * Native code can encode and drive the board without going through JS.
    *
@@ -87,6 +112,8 @@ export type BoardCapabilities = {
 const AURORA_CAPABILITIES: BoardCapabilities = {
   crowdGrade: true,
   climbCreation: true,
+  explicitClimbRules: false,
+  multiFrameClimbs: true,
   nativeBoardControl: true,
   auroraAppLink: true,
 };
@@ -100,18 +127,22 @@ const AURORA_CAPABILITIES: BoardCapabilities = {
 const MOONBOARD_CAPABILITIES: BoardCapabilities = {
   crowdGrade: false,
   climbCreation: true,
+  explicitClimbRules: false,
+  multiFrameClimbs: true,
   nativeBoardControl: true,
   auroraAppLink: false,
 };
 
 /**
- * Woods: a static catalog import — browse, search, light up and tick all work.
- * Each remaining `false` has its own follow-up: #4750 (create), #3314 (the Swift
- * encoder).
+ * Woods: a code-driven catalog — browse, search, light up, tick and (since
+ * #4750) author. `nativeBoardControl` stays false until the Swift encoder learns
+ * Woods (#3314); `crowdGrade` until there is community grade data behind it.
  */
 const WOODS_CAPABILITIES: BoardCapabilities = {
   crowdGrade: false,
-  climbCreation: false,
+  climbCreation: true,
+  explicitClimbRules: true,
+  multiFrameClimbs: false,
   nativeBoardControl: false,
   auroraAppLink: false,
 };

--- a/packages/shared/board-config/src/board-compatibility.ts
+++ b/packages/shared/board-config/src/board-compatibility.ts
@@ -120,12 +120,14 @@ export type ClimbBoardCompatibility = 'compatible' | 'incompatible' | 'unknown';
 export type ActiveBoardForCompatibility = {
   boardName: BoardName;
   layoutId: number;
+  sizeId?: number;
 };
 
 /** The climb fields that carry board identity. Both are optional in most fetch paths. */
 export type ClimbBoardIdentity = {
   boardType?: string | null;
   layoutId?: number | null;
+  compatibleSizeIds?: readonly number[] | null;
 };
 
 /**
@@ -139,8 +141,8 @@ export type ClimbBoardIdentity = {
  * - `compatible` — the known metadata matches the active board.
  *
  * An unrecognised `boardType` string is treated as no board signal (we can't
- * judge it), falling through to the layout check. Identity only — hold-ID
- * containment stays in `canAddClimbToBoard` so same-layout different-size
+ * judge it), falling through to the layout check. Woods physical size is part of identity; hold-ID
+ * containment for other boards stays in `canAddClimbToBoard` so same-layout different-size
  * climbs keep their partial-light behaviour at send time.
  */
 export function classifyClimbBoardCompatibility(
@@ -153,6 +155,15 @@ export function classifyClimbBoardCompatibility(
   if (climbBoardName == null && !hasLayoutSignal) return 'unknown';
   if (climbBoardName != null && climbBoardName !== activeConfig.boardName) return 'incompatible';
   if (hasLayoutSignal && climb.layoutId !== activeConfig.layoutId) return 'incompatible';
+  // Woods ids are local to each physical wall, so a size mismatch lights different holds.
+  if (
+    activeConfig.boardName === 'woods' &&
+    activeConfig.sizeId != null &&
+    climb.compatibleSizeIds?.length &&
+    !climb.compatibleSizeIds.includes(activeConfig.sizeId)
+  ) {
+    return 'incompatible';
+  }
   return 'compatible';
 }
 

--- a/packages/shared/board-react/src/__tests__/climb-helpers.test.ts
+++ b/packages/shared/board-react/src/__tests__/climb-helpers.test.ts
@@ -18,6 +18,7 @@ describe('toSaveClimbInput', () => {
     expect(toSaveClimbInput('kilter', options)).toEqual({
       boardType: 'kilter',
       layoutId: 8,
+      sizeId: undefined,
       name: 'Test Climb',
       description: 'desc',
       isDraft: true,
@@ -26,7 +27,32 @@ describe('toSaveClimbInput', () => {
       framesPace: 0,
       angle: 40,
       characteristics: null,
+      noMatch: undefined,
+      anyFeet: undefined,
     });
+  });
+
+  it('carries the board size a Woods climb was painted on', () => {
+    // Woods numbers each size's holds from its own origin, so the same frames
+    // string means different holds on the 8x10 and the 12x12.
+    const result = toSaveClimbInput('woods', { ...options, size_id: 2 });
+    expect(result.sizeId).toBe(2);
+  });
+
+  it('forwards the rule booleans, including an explicit false', () => {
+    // `false` and "omitted" are different on the wire: omitted preserves whatever
+    // the row already has, false is how a rule gets turned back off.
+    const enabled = toSaveClimbInput('woods', { ...options, no_match: true, any_feet: true });
+    expect(enabled).toMatchObject({ noMatch: true, anyFeet: true });
+
+    const cleared = toSaveClimbInput('woods', { ...options, no_match: false, any_feet: false });
+    expect(cleared).toMatchObject({ noMatch: false, anyFeet: false });
+  });
+
+  it('leaves the rule booleans undefined when the caller says nothing about them', () => {
+    const result = toSaveClimbInput('kilter', options);
+    expect(result.noMatch).toBeUndefined();
+    expect(result.anyFeet).toBeUndefined();
   });
 
   it('defaults a missing description to an empty string', () => {

--- a/packages/shared/board-react/src/climb-helpers.ts
+++ b/packages/shared/board-react/src/climb-helpers.ts
@@ -6,6 +6,13 @@ import type { BoardName, SaveClimbInput } from '@boardsesh/shared-schema';
 // forwarded unchanged from existing create-climb forms on both platforms.
 export type SaveClimbOptions = {
   layout_id: number;
+  /**
+   * The board size the climb was painted on. Optional because the Aurora forms
+   * never needed it — a hold id means the same hold on every Aurora size. It is
+   * load-bearing on Woods, whose two sizes number their holds from their own
+   * origins, so the same frames string describes different holds on each.
+   */
+  size_id?: number;
   name: string;
   description: string;
   is_draft: boolean;
@@ -14,7 +21,14 @@ export type SaveClimbOptions = {
   frames_pace?: number;
   angle: number;
   // Freely-toggleable characteristics to set at creation (no_kickboard / campus).
+  // any_feet and no_match ride their own fields below — the server rejects them
+  // inside this array.
   characteristics?: string[] | null;
+  /** Matching (both hands on one hold) is disallowed. */
+  no_match?: boolean;
+  /** Feet may use any hold, not only the marked ones. Mutually exclusive with the
+   *  `campus` characteristic, which the editor enforces. */
+  any_feet?: boolean;
 };
 
 export type SaveClimbResponse = {
@@ -30,11 +44,19 @@ export type UpdateClimbResponse = {
   isDraft: boolean;
 };
 
-/** Maps the snake_case form payload to the camelCase GraphQL `SaveClimbInput`. */
+/**
+ * Maps the snake_case form payload to the camelCase GraphQL `SaveClimbInput`.
+ *
+ * The three optional flags are forwarded as `undefined` when the caller omits
+ * them rather than coerced to `false`/`null`: omission means "say nothing about
+ * this", and on the update path that is what preserves a flag already on the row.
+ * A form that owns the switch sends the boolean either way, including `false`.
+ */
 export function toSaveClimbInput(boardName: BoardName, options: SaveClimbOptions): SaveClimbInput {
   return {
     boardType: boardName,
     layoutId: options.layout_id,
+    sizeId: options.size_id,
     name: options.name,
     description: options.description || '',
     isDraft: options.is_draft,
@@ -43,6 +65,8 @@ export function toSaveClimbInput(boardName: BoardName, options: SaveClimbOptions
     framesPace: options.frames_pace,
     angle: options.angle,
     characteristics: options.characteristics ?? null,
+    noMatch: options.no_match,
+    anyFeet: options.any_feet,
   };
 }
 

--- a/packages/shared/create-climb-react/src/__tests__/use-create-climb.test.ts
+++ b/packages/shared/create-climb-react/src/__tests__/use-create-climb.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
+import { buildInitialFrames } from '../helpers';
 import { useCreateClimb, framesReducer, HISTORY_LIMIT } from '../use-create-climb';
 import type { FramesHistory, FramesSnapshot } from '../use-create-climb';
 import type { LitUpHoldsMap } from '@boardsesh/shared-schema';
@@ -11,6 +12,7 @@ vi.mock('@boardsesh/board-constants/hold-states', async () => {
   return {
     ...actual,
     HOLD_STATE_MAP: {
+      woods: actual.HOLD_STATE_MAP.woods,
       kilter: {
         42: { name: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
         43: { name: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' },
@@ -30,6 +32,7 @@ vi.mock('@boardsesh/board-constants/hold-states', async () => {
       },
     },
     STATE_TO_PRIMARY_CODE: {
+      woods: actual.STATE_TO_PRIMARY_CODE.woods,
       kilter: { STARTING: 42, HAND: 43, FINISH: 44, FOOT: 45 },
       tension: { STARTING: 1, HAND: 2, FINISH: 3, FOOT: 4 },
       moonboard: { STARTING: 42, HAND: 43, FINISH: 44 },
@@ -38,6 +41,16 @@ vi.mock('@boardsesh/board-constants/hold-states', async () => {
 });
 
 describe('useCreateClimb', () => {
+  it('roundtrips all four Woods roles, including hold zero', () => {
+    const encoded = 'p0r4p1r2p2r3p3r1';
+    const { result } = renderHook(() =>
+      useCreateClimb('woods', { initialFrames: buildInitialFrames(encoded, 'woods') }),
+    );
+    expect(result.current.generateFramesString()).toBe(encoded);
+    expect(result.current.litUpHoldsMap[0].state).toBe('STARTING');
+    expect(result.current.litUpHoldsMap[3].state).toBe('FOOT');
+  });
+
   describe('initial state', () => {
     it('has empty holdsMap and a single frame', () => {
       const { result } = renderHook(() => useCreateClimb('kilter'));

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -6559,8 +6559,10 @@ export type SaveAuroraCredentialInput = {
 
 export type SaveClimbInput = {
   angle: Scalars['Int']['input'];
+  /** Any hold on the wall counts as a foot. Null or omitted means false. */
+  anyFeet?: InputMaybe<Scalars['Boolean']['input']>;
   boardType: Scalars['String']['input'];
-  /** Freely-toggleable characteristics to set at creation. Only CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS are accepted here — no_match is server-derived from description, and MoonBoard method is creation-time-only via SaveMoonBoardClimbInput. */
+  /** Freely-toggleable characteristics to set at creation. Only CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS are accepted here — MoonBoard method is creation-time-only via SaveMoonBoardClimbInput, and no_match / any_feet ride noMatch / anyFeet below. */
   characteristics?: InputMaybe<Array<Scalars['String']['input']>>;
   description?: InputMaybe<Scalars['String']['input']>;
   frames: Scalars['String']['input'];
@@ -6569,6 +6571,10 @@ export type SaveClimbInput = {
   isDraft: Scalars['Boolean']['input'];
   layoutId: Scalars['Int']['input'];
   name: Scalars['String']['input'];
+  /** Matching disallowed. Wins over the legacy 'No match' description prefix; null or omitted falls back to that prefix and otherwise means false. */
+  noMatch?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Physical board size the climb is set on. Required on Woods (1 = 8x10, 2 = 12x12), where the two walls number their holds from their own origins. Ignored on boards that derive size compatibility from the hold bounding box. */
+  sizeId?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type SaveClimbResult = {
@@ -7448,6 +7454,15 @@ export type SimilarClimbsInput = {
   layoutId: Scalars['Int']['input'];
   /** Max number of results to return. Defaults to 25, capped at 200 server-side. */
   limit?: InputMaybe<Scalars['Int']['input']>;
+  /**
+   * Physical board size to scope candidates to. Load-bearing on Woods, whose two
+   * walls reuse the same hold-id range for different holds — without it an 8x10
+   * climb reads as near-identical to an unrelated 12x12 one. On Woods the target
+   * climb's own compatible sizes fill this in when climbUuid is given; a
+   * frames-only Woods lookup must send it or the result is empty. Ignored on
+   * every other board.
+   */
+  sizeId?: InputMaybe<Scalars['Int']['input']>;
   /** Jaccard threshold (0..1). Returns climbs at or above this similarity. */
   threshold?: InputMaybe<Scalars['Float']['input']>;
 };
@@ -7974,8 +7989,10 @@ export type UpdateBoardInput = {
  */
 export type UpdateClimbInput = {
   angle?: InputMaybe<Scalars['Int']['input']>;
+  /** Any hold counts as a foot. Null or omitted preserves the stored value. */
+  anyFeet?: InputMaybe<Scalars['Boolean']['input']>;
   boardType: Scalars['String']['input'];
-  /** Freely-toggleable characteristics: the full desired boolean state of CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS. Any other characteristic already on the row (no_match, MoonBoard method) is left untouched. */
+  /** Freely-toggleable characteristics: the full desired boolean state of CLIMB_CHARACTERISTICS.NO_KICKBOARD / .CAMPUS. Any other characteristic already on the row (no_match, any_feet, MoonBoard method) is left untouched. */
   characteristics?: InputMaybe<Array<Scalars['String']['input']>>;
   description?: InputMaybe<Scalars['String']['input']>;
   frames?: InputMaybe<Scalars['String']['input']>;
@@ -7984,6 +8001,10 @@ export type UpdateClimbInput = {
   /** When set, flips the draft state. A climb can go from draft→published but not the other way around. */
   isDraft?: InputMaybe<Scalars['Boolean']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
+  /** Matching disallowed. Null or omitted preserves the stored value, so an old client cannot clear it. When set it wins over the legacy 'No match' description prefix in the same call. */
+  noMatch?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Physical board size, where it is part of the climb's identity (Woods). Immutable — a size that differs from the stored one is rejected. Null or omitted keeps the stored size. */
+  sizeId?: InputMaybe<Scalars['Int']['input']>;
   uuid: Scalars['ID']['input'];
 };
 

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -99,7 +99,8 @@
       "footless": "Ohne Füße",
       "footlessKickboard": "Ohne Füße + KB",
       "noKickboard": "Ohne KB"
-    }
+    },
+    "anyFeet": "Freie Füße"
   },
   "boardseshGrade": {
     "title": "Boardsesh-Grad",
@@ -475,6 +476,7 @@
       },
       "noMatch": "Kein Matchen",
       "campus": "Campus",
+      "anyFeet": "Freie Füße",
       "noKickboard": "Ohne FL",
       "benchmark": "Benchmark",
       "method": {
@@ -482,6 +484,16 @@
         "footlessKickboard": "Ohne Füße + KB",
         "noKickboard": "Ohne KB"
       }
+    },
+    "climbRules": {
+      "matchingAllowed": "Matchen erlaubt",
+      "noMatching": "Kein Matchen",
+      "matchingUnknown": "Match-Regel nicht erfasst",
+      "anyFeet": "Freie Füße",
+      "markedHoldsOnly": "Nur markierte Griffe",
+      "noFeet": "Ohne Füße",
+      "feetUnknown": "Fußregel nicht erfasst",
+      "spoken": "Regeln: {{matching}}, {{feet}}"
     },
     "climbActions": {
       "preview": "Vorschau",
@@ -540,7 +552,9 @@
         "noKickboardLabel": "Ohne Fußleiste",
         "noKickboardDescription": "Füße dürfen die Fußleiste nicht benutzen",
         "campusLabel": "Campus (ohne Füße)",
-        "campusDescription": "Nur Hände, keine Füße"
+        "campusDescription": "Nur Hände, keine Füße",
+        "anyFeetLabel": "Freie Füße",
+        "anyFeetDescription": "Füße dürfen jeden Griff nutzen, nicht nur die markierten"
       },
       "drafts": {
         "holds_one": "{{count}} Griff",
@@ -551,7 +565,8 @@
       },
       "unavailable": {
         "title": "Hier lässt sich noch nichts bauen",
-        "subtitle": "Für dieses Board-Layout kannst du noch keine Boulder bauen."
+        "subtitle": "Für dieses Board-Layout kannst du noch keine Boulder bauen.",
+        "wrongSize": "Dieser Boulder wurde auf einer anderen Board-Größe gebaut. Wechsle die Größe, um ihn zu bearbeiten."
       },
       "fab": {
         "ariaLabel": "Boulder bauen"
@@ -584,7 +599,8 @@
       },
       "publish": {
         "blocked": "Füge einen Startgriff und einen Topgriff hinzu, um zu veröffentlichen"
-      }
+      },
+      "wallSizeMismatch": "Wähle diese Woods-Größe als aktives Board, um es zu beleuchten."
     },
     "holdFilter": {
       "title": "Grifftypen",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -99,7 +99,8 @@
       "footless": "Footless",
       "footlessKickboard": "Footless + KB",
       "noKickboard": "No KB"
-    }
+    },
+    "anyFeet": "Any feet"
   },
   "boardseshGrade": {
     "title": "Boardsesh grade",
@@ -475,6 +476,7 @@
       },
       "noMatch": "No matching",
       "campus": "Campus",
+      "anyFeet": "Any feet",
       "noKickboard": "No KB",
       "benchmark": "Benchmark",
       "method": {
@@ -482,6 +484,16 @@
         "footlessKickboard": "Footless + KB",
         "noKickboard": "No KB"
       }
+    },
+    "climbRules": {
+      "matchingAllowed": "Matching allowed",
+      "noMatching": "No matching",
+      "matchingUnknown": "Matching rule not recorded",
+      "anyFeet": "Any feet",
+      "markedHoldsOnly": "Marked holds only",
+      "noFeet": "No feet",
+      "feetUnknown": "Feet rule not recorded",
+      "spoken": "Rules: {{matching}}, {{feet}}"
     },
     "climbActions": {
       "preview": "Preview",
@@ -540,7 +552,9 @@
         "noKickboardLabel": "No kickboard",
         "noKickboardDescription": "Feet can't use the kickboard",
         "campusLabel": "Campus (no feet)",
-        "campusDescription": "Hands only — no feet allowed"
+        "campusDescription": "Hands only — no feet allowed",
+        "anyFeetLabel": "Any feet",
+        "anyFeetDescription": "Feet can use any hold, not just the marked ones"
       },
       "drafts": {
         "holds_one": "{{count}} hold",
@@ -551,7 +565,8 @@
       },
       "unavailable": {
         "title": "Can't build here yet",
-        "subtitle": "This board layout is not supported for creating climbs."
+        "subtitle": "This board layout is not supported for creating climbs.",
+        "wrongSize": "This climb was set on a different board size. Switch sizes to edit it."
       },
       "fab": {
         "ariaLabel": "Create a climb"
@@ -584,7 +599,8 @@
       },
       "publish": {
         "blocked": "Add a start and a finish hold to publish"
-      }
+      },
+      "wallSizeMismatch": "Switch your active board to this Woods size to light it."
     },
     "holdFilter": {
       "title": "Hold types",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -99,7 +99,8 @@
       "footless": "Sin pies",
       "footlessKickboard": "Sin pies + KB",
       "noKickboard": "Sin KB"
-    }
+    },
+    "anyFeet": "Pies libres"
   },
   "boardseshGrade": {
     "title": "Grado Boardsesh",
@@ -475,6 +476,7 @@
       },
       "noMatch": "Sin igualar",
       "campus": "Campus",
+      "anyFeet": "Pies libres",
       "noKickboard": "Sin repisa",
       "benchmark": "Benchmark",
       "method": {
@@ -482,6 +484,16 @@
         "footlessKickboard": "Sin pies + KB",
         "noKickboard": "Sin KB"
       }
+    },
+    "climbRules": {
+      "matchingAllowed": "Se puede igualar",
+      "noMatching": "Sin igualar",
+      "matchingUnknown": "Regla de igualar sin registrar",
+      "anyFeet": "Pies libres",
+      "markedHoldsOnly": "Solo presas marcadas",
+      "noFeet": "Sin pies",
+      "feetUnknown": "Regla de pies sin registrar",
+      "spoken": "Reglas: {{matching}}, {{feet}}"
     },
     "climbActions": {
       "preview": "Vista previa",
@@ -540,7 +552,9 @@
         "noKickboardLabel": "Sin repisa inferior",
         "noKickboardDescription": "Los pies no pueden apoyarse en la repisa inferior",
         "campusLabel": "Campus (sin pies)",
-        "campusDescription": "Solo manos, sin apoyar los pies"
+        "campusDescription": "Solo manos, sin apoyar los pies",
+        "anyFeetLabel": "Pies libres",
+        "anyFeetDescription": "Los pies pueden usar cualquier presa, no solo las marcadas"
       },
       "drafts": {
         "holds_one": "{{count}} presa",
@@ -551,7 +565,8 @@
       },
       "unavailable": {
         "title": "Aún no se puede crear aquí",
-        "subtitle": "Esta configuración de plafón no admite la creación de vías."
+        "subtitle": "Esta configuración de plafón no admite la creación de vías.",
+        "wrongSize": "Este bloque se montó en otro tamaño de plafón. Cambia de tamaño para editarlo."
       },
       "fab": {
         "ariaLabel": "Crear una vía"
@@ -584,7 +599,8 @@
       },
       "publish": {
         "blocked": "Añade una presa de salida y una de final para publicar"
-      }
+      },
+      "wallSizeMismatch": "Cambia tu plafón activo a este tamaño de Woods para iluminarlo."
     },
     "holdFilter": {
       "title": "Tipos de presa",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -99,7 +99,8 @@
       "footless": "Sans pieds",
       "footlessKickboard": "Sans pieds + KB",
       "noKickboard": "Sans KB"
-    }
+    },
+    "anyFeet": "Pieds libres"
   },
   "boardseshGrade": {
     "title": "Grade Boardsesh",
@@ -475,6 +476,7 @@
       },
       "noMatch": "Une main par prise",
       "campus": "Campus",
+      "anyFeet": "Pieds libres",
       "noKickboard": "Sans KB",
       "benchmark": "Benchmark",
       "method": {
@@ -482,6 +484,16 @@
         "footlessKickboard": "Sans pieds + KB",
         "noKickboard": "Sans KB"
       }
+    },
+    "climbRules": {
+      "matchingAllowed": "Deux mains par prise autorisées",
+      "noMatching": "Une main par prise",
+      "matchingUnknown": "Règle des mains non renseignée",
+      "anyFeet": "Pieds libres",
+      "markedHoldsOnly": "Prises marquées uniquement",
+      "noFeet": "Sans pieds",
+      "feetUnknown": "Règle des pieds non renseignée",
+      "spoken": "Règles : {{matching}}, {{feet}}"
     },
     "climbActions": {
       "preview": "Aperçu",
@@ -540,7 +552,9 @@
         "noKickboardLabel": "Sans kickboard",
         "noKickboardDescription": "Les pieds ne peuvent pas utiliser le kickboard",
         "campusLabel": "Campus (sans pieds)",
-        "campusDescription": "Mains seulement, sans les pieds"
+        "campusDescription": "Mains seulement, sans les pieds",
+        "anyFeetLabel": "Pieds libres",
+        "anyFeetDescription": "Les pieds peuvent utiliser n’importe quelle prise, pas seulement les prises marquées"
       },
       "drafts": {
         "holds_one": "{{count}} prise",
@@ -551,7 +565,8 @@
       },
       "unavailable": {
         "title": "Création indisponible ici",
-        "subtitle": "Cette configuration de board ne permet pas de créer des voies."
+        "subtitle": "Cette configuration de board ne permet pas de créer des voies.",
+        "wrongSize": "Ce bloc a été ouvert sur une autre taille de board. Change de taille pour le modifier."
       },
       "fab": {
         "ariaLabel": "Créer une voie"
@@ -584,7 +599,8 @@
       },
       "publish": {
         "blocked": "Ajoutez une prise de départ et une prise d'arrivée pour publier"
-      }
+      },
+      "wallSizeMismatch": "Sélectionne ce format de Woods comme pan actif pour l’allumer."
     },
     "holdFilter": {
       "title": "Types de prise",

--- a/packages/shared/play-view/src/__tests__/climb-rules.test.ts
+++ b/packages/shared/play-view/src/__tests__/climb-rules.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { CLIMB_CHARACTERISTICS } from '@boardsesh/shared-schema';
+import { decodeClimbRules } from '../climb-rules';
+
+const { NO_MATCH, CAMPUS, ANY_FEET, NO_KICKBOARD, METHOD_FOOTLESS } = CLIMB_CHARACTERISTICS;
+
+describe('decodeClimbRules', () => {
+  it('reads an empty array as the fully-default climb, not as unknown', () => {
+    // The distinction the whole Woods rules line rests on: `[]` is a climb whose
+    // rules were recorded and are all defaults.
+    expect(decodeClimbRules([])).toEqual({ matching: 'allowed', feet: 'marked_holds_only' });
+  });
+
+  it.each([[null], [undefined]])('reads %s as unknown on BOTH rules', (characteristics) => {
+    // The column is written whole, so an absent array says nothing about either
+    // rule. Guessing the defaults would put a rule on screen nobody authored.
+    expect(decodeClimbRules(characteristics)).toEqual({ matching: 'unknown', feet: 'unknown' });
+  });
+
+  it('reports no matching when the no_match token is present', () => {
+    expect(decodeClimbRules([NO_MATCH])).toEqual({ matching: 'not_allowed', feet: 'marked_holds_only' });
+  });
+
+  it('reports any feet when the any_feet token is present', () => {
+    expect(decodeClimbRules([ANY_FEET])).toEqual({ matching: 'allowed', feet: 'any_feet' });
+  });
+
+  it('reports no feet for a campus climb rather than "marked holds only"', () => {
+    // Rendering a campus problem as "marked holds only" would describe feet the
+    // setter forbade entirely.
+    expect(decodeClimbRules([CAMPUS])).toEqual({ matching: 'allowed', feet: 'no_feet' });
+  });
+
+  it('decodes both rules together', () => {
+    expect(decodeClimbRules([NO_MATCH, ANY_FEET])).toEqual({ matching: 'not_allowed', feet: 'any_feet' });
+  });
+
+  it('lets campus win over any_feet on a contradictory row', () => {
+    // The editor keeps them exclusive, but a legacy or hand-written row need not
+    // be — an ambiguous row may only ever under-promise.
+    expect(decodeClimbRules([ANY_FEET, CAMPUS]).feet).toBe('no_feet');
+    expect(decodeClimbRules([CAMPUS, ANY_FEET]).feet).toBe('no_feet');
+  });
+
+  it('ignores tokens that are not one of the two rules', () => {
+    expect(decodeClimbRules([NO_KICKBOARD, METHOD_FOOTLESS])).toEqual({
+      matching: 'allowed',
+      feet: 'marked_holds_only',
+    });
+  });
+});

--- a/packages/shared/play-view/src/climb-rules.ts
+++ b/packages/shared/play-view/src/climb-rules.ts
@@ -1,0 +1,51 @@
+import { isAnyFeet, isCampus, isNoMatch } from '@boardsesh/shared-schema';
+
+/**
+ * The two rules a climb is set under, decoded from `board_climbs.characteristics`.
+ *
+ * Every board has always carried both rules; what differs is how they are shown.
+ * Aurora and MoonBoard state only the EXCEPTIONS (a no-match glyph, a method
+ * badge) and leave the default implied. The Woods app states both rules on every
+ * problem, and Woods climbers read them that way — so the play drawer says both
+ * out loud for a board whose `explicitClimbRules` capability is true.
+ *
+ * `unknown` is a real answer, not a fallback. Woods rows imported before the
+ * catalogue carried rule metadata have `characteristics = null`, which means "we
+ * were never told", and is different from `[]` — the array a Woods problem set
+ * under the defaults (matching allowed, marked holds only) stores. Guessing the
+ * defaults for a null row would put a rule on screen that nobody authored.
+ */
+export type ClimbMatchingRule = 'allowed' | 'not_allowed' | 'unknown';
+
+/**
+ * `no_feet` is the campus rule (hands only) — reported separately from
+ * `marked_holds_only` because rendering a campus problem as "marked holds only"
+ * describes feet the setter forbade entirely.
+ */
+export type ClimbFeetRule = 'any_feet' | 'marked_holds_only' | 'no_feet' | 'unknown';
+
+export type ClimbRules = {
+  matching: ClimbMatchingRule;
+  feet: ClimbFeetRule;
+};
+
+/**
+ * Decode a climb's characteristics array into its matching + feet rules.
+ *
+ * A null/undefined array is unknown on BOTH rules: the column is written as a
+ * whole, so an absent array carries no information about either. An array that
+ * is present but empty is the fully-default climb — matching allowed, feet on
+ * the marked holds only.
+ *
+ * Campus wins over any-feet when both tokens are somehow on the row (the editor
+ * makes them mutually exclusive, but a hand-written or legacy row need not be):
+ * "no feet" is the stricter reading, so an ambiguous row can only ever
+ * under-promise.
+ */
+export function decodeClimbRules(characteristics: readonly string[] | null | undefined): ClimbRules {
+  if (characteristics == null) return { matching: 'unknown', feet: 'unknown' };
+  return {
+    matching: isNoMatch(characteristics) ? 'not_allowed' : 'allowed',
+    feet: isCampus(characteristics) ? 'no_feet' : isAnyFeet(characteristics) ? 'any_feet' : 'marked_holds_only',
+  };
+}

--- a/packages/shared/play-view/src/index.ts
+++ b/packages/shared/play-view/src/index.ts
@@ -6,6 +6,7 @@ export * from './marquee-timing';
 export * from './tick-utils';
 export * from './quick-tick-state';
 export * from './board-utils';
+export * from './climb-rules';
 export * from './swipe-carousel';
 export * from './wall-confirm-bus';
 export * from './wall-confirm-fallback';

--- a/packages/web/app/components/climb-card/climb-icons.tsx
+++ b/packages/web/app/components/climb-card/climb-icons.tsx
@@ -12,6 +12,9 @@ type ClimbIconsProps = {
   isNoMatch?: boolean;
   /** Already-translated MoonBoard method label (e.g. "Footless"). Parent resolves via i18n. */
   methodLabel?: string | null;
+  /** Already-translated "any feet" label, or null when the climb keeps the marked
+   *  holds. Same shape as `methodLabel` — the parent resolves it via i18n. */
+  anyFeetLabel?: string | null;
 };
 
 const benchmarkIconSx = {
@@ -44,6 +47,7 @@ export default function ClimbIcons({
   isBenchmark = false,
   isNoMatch = false,
   methodLabel = null,
+  anyFeetLabel = null,
 }: ClimbIconsProps) {
   const benchmarkValue = benchmarkDifficulty != null ? Number(benchmarkDifficulty) : null;
   const isBenchmarkOrClassic =
@@ -56,6 +60,11 @@ export default function ClimbIcons({
       {methodLabel && (
         <Typography component="span" sx={methodLabelSx}>
           {methodLabel}
+        </Typography>
+      )}
+      {anyFeetLabel && (
+        <Typography component="span" sx={methodLabelSx}>
+          {anyFeetLabel}
         </Typography>
       )}
     </>

--- a/packages/web/app/components/climb-card/climb-title.tsx
+++ b/packages/web/app/components/climb-card/climb-title.tsx
@@ -11,8 +11,8 @@ import { themeTokens } from '@/app/theme/theme-config';
 import { useIsDarkMode } from '@/app/hooks/use-is-dark-mode';
 import { formatSends, formatQuality } from '@/app/lib/format-climb-stats';
 import { useGradeFormat } from '@/app/hooks/use-grade-format';
-import { resolveMoonBoardMethodLabel } from '@/app/lib/climb-method';
-import { getMoonBoardMethod } from '@boardsesh/shared-schema';
+import { resolveAnyFeetLabel, resolveMoonBoardMethodLabel } from '@/app/lib/climb-method';
+import { getMoonBoardMethod, isAnyFeet, isCampus } from '@boardsesh/shared-schema';
 
 export type ClimbTitleData = {
   name?: string;
@@ -260,6 +260,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
     const hasGrade = displayDifficulty && climb.quality_average && climb.quality_average !== '0';
     const resolvedIsNoMatch = isNoMatch || Boolean(climb.is_no_match);
     const methodLabel = resolveMoonBoardMethodLabel(climb.characteristics, t);
+    const anyFeetLabel = resolveAnyFeetLabel(climb.characteristics, t);
 
     const renderDifficultyText = () => {
       if (hasGrade) {
@@ -282,6 +283,7 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
             benchmarkDifficulty={climb.benchmark_difficulty}
             isNoMatch={resolvedIsNoMatch}
             methodLabel={methodLabel}
+            anyFeetLabel={anyFeetLabel}
           />
         </Typography>
       </MarqueeText>
@@ -475,6 +477,11 @@ const ClimbTitle: React.FC<ClimbTitleProps> = React.memo(
       prevClimb.communityGrade === nextClimb.communityGrade &&
       prevClimb.is_no_match === nextClimb.is_no_match &&
       getMoonBoardMethod(prevClimb.characteristics) === getMoonBoardMethod(nextClimb.characteristics) &&
+      // The other two characteristic-derived labels this row renders. Without
+      // them a climb whose only change is its feet rule would keep the previous
+      // climb's badge.
+      isAnyFeet(prevClimb.characteristics) === isAnyFeet(nextClimb.characteristics) &&
+      isCampus(prevClimb.characteristics) === isCampus(nextClimb.characteristics) &&
       prev.showAngle === next.showAngle &&
       prev.showSetterInfo === next.showSetterInfo &&
       prev.nameAddon === next.nameAddon &&

--- a/packages/web/app/lib/__tests__/app-handoff.test.ts
+++ b/packages/web/app/lib/__tests__/app-handoff.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vite-plus/test';
-import { buildAppHandoffUrl } from '../app-handoff';
+import { buildAppHandoffUrl, buildAppCreateClimbUrl } from '../app-handoff';
 
 /**
  * The "Climb this" hand-off (#4369) is APP_URL plus the same pathname, with any
@@ -61,5 +61,25 @@ describe('buildAppHandoffUrl', () => {
 
   it('is idempotent on a path that carries no locale prefix', () => {
     expect(buildAppHandoffUrl(CLIMB_PATH)).toBe(buildAppHandoffUrl(`/es${CLIMB_PATH}`));
+  });
+});
+
+describe('create-climb handoff rules', () => {
+  const board = { boardName: 'woods' as const, layoutId: 1, sizeId: 2, setIds: [1], angle: 40 };
+
+  it.each([
+    { characteristics: [] },
+    { characteristics: ['no_match', 'any_feet'] },
+    { characteristics: ['campus', 'no_kickboard'] },
+  ])('preserves explicit rule metadata: $characteristics', ({ characteristics }) => {
+    const url = new URL(buildAppCreateClimbUrl(board, { frames: 'p0r4p1r3', characteristics }));
+    expect(JSON.parse(url.searchParams.get('forkCharacteristics')!)).toEqual(characteristics);
+    expect(url.searchParams.get('sizeId')).toBe('2');
+  });
+
+  it('keeps unknown rules absent for the legacy fallback', () => {
+    const url = new URL(buildAppCreateClimbUrl(board, { description: 'No match\nOld climb', characteristics: null }));
+    expect(url.searchParams.has('forkCharacteristics')).toBe(false);
+    expect(url.searchParams.get('forkDescription')).toBe('No match\nOld climb');
   });
 });

--- a/packages/web/app/lib/app-handoff.ts
+++ b/packages/web/app/lib/app-handoff.ts
@@ -45,6 +45,15 @@ export type AppCreateClimbSeed = {
   frames?: string;
   name?: string;
   description?: string;
+  /**
+   * The source climb's `characteristics`, so a remix started on www inherits its
+   * climb rules instead of opening with them reset (#4832). Null/undefined means
+   * the source carried none and the param is left off entirely — the app reads an
+   * ABSENT param as "fall back to the legacy `No match` description prefix", and
+   * an explicitly empty array as "all rules at their defaults", which are
+   * different answers.
+   */
+  characteristics?: string[] | null;
   editClimbUuid?: string;
 };
 
@@ -78,6 +87,9 @@ export function buildAppCreateClimbUrl(board?: AppCreateClimbBoard | null, seed?
   if (seed?.frames) params.set('forkFrames', seed.frames);
   if (seed?.name) params.set('forkName', seed.name);
   if (seed?.description) params.set('forkDescription', seed.description);
+  // Not `if (seed?.characteristics?.length)`: an empty array is a real value here
+  // (a climb whose rules are all at their defaults) and must still be sent.
+  if (seed?.characteristics) params.set('forkCharacteristics', JSON.stringify(seed.characteristics));
   if (seed?.editClimbUuid) params.set('editClimbUuid', seed.editClimbUuid);
 
   const query = params.toString();

--- a/packages/web/app/lib/climb-method.ts
+++ b/packages/web/app/lib/climb-method.ts
@@ -1,5 +1,5 @@
 import type { TFunction } from 'i18next';
-import { getMoonBoardMethod, CLIMB_CHARACTERISTICS } from '@boardsesh/shared-schema';
+import { getMoonBoardMethod, isAnyFeet, isCampus, CLIMB_CHARACTERISTICS } from '@boardsesh/shared-schema';
 
 /**
  * Resolve the translated short label for a climb's MoonBoard method
@@ -20,4 +20,21 @@ export function resolveMoonBoardMethodLabel(
     default:
       return null;
   }
+}
+
+/**
+ * The short "any feet" badge for a climb whose feet may use any hold, not only
+ * the marked ones — a departure from the default on every board, so it earns a
+ * label next to the climb name the way the MoonBoard method does.
+ *
+ * Campus (no feet at all) suppresses it: the two are opposite answers to the same
+ * question and the editor keeps them exclusive, so a row carrying both is
+ * malformed and the stricter rule is the safe read.
+ */
+export function resolveAnyFeetLabel(
+  characteristics: string[] | null | undefined,
+  t: TFunction<'climbs'>,
+): string | null {
+  if (isCampus(characteristics) || !isAnyFeet(characteristics)) return null;
+  return t('card.anyFeet');
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -387,6 +387,11 @@ export default defineConfig({
         command: 'pnpm --filter @boardsesh/db run db:backfill-moonboard-hardware',
         cache: false,
       },
+      // Repairs existing Woods matching/feet metadata. Read-only unless --apply is passed.
+      'db:repair-woods-rules': {
+        command: 'pnpm --filter @boardsesh/db run db:repair-woods-rules',
+        cache: false,
+      },
       // Repairs only existing catalog-backed MoonBoard 8C/8C+ rows whose grade
       // columns are still NULL. Requires the full app catalog as input, reports
       // only by default, and writes only with an explicit `--apply`.


### PR DESCRIPTION
## Summary

Woods problems now show both matching and feet rules in the play drawer, including swipe previews. Woods users can create, edit and fork Boardsesh problems on either board size, and forks retain matching, any-feet, campus and kickboard settings. Physical size follows the source climb and guards editor previews and queue lighting.

The scraper already records both flags. The importer now preserves them, and a dry-run-first repair updates existing imported climb metadata without changing holds, UUIDs or stats. Production repair completed on 2026-09-05: all 5,392 catalog climbs were updated. A repeat dry run reports 5,392 unchanged and zero updates. Read-back verification confirmed climb content stayed unchanged and all repaired sync cursors advanced; Treat yo self now has matching allowed and marked holds only. Deploy backend support before shipping clients that send the new fields. Repair commands and rollout details are in `docs/woods-climb-rules.md`.

Rule variants are distinct problems; exact duplicates compare holds, rules and Woods size. Catalog refreshes retain app-owned flags. Aurora sync preserves explicit rules on immutable, published Boardsesh climbs and preserves matching-allowed draft rules on unchanged description echoes. The www fork URL helper carries structured rules; www currently has no production caller for that helper.

Closes #4827
Closes #4750
Closes #4832

## Validation

- Review follow-up: 296 Aurora tests and the real PostgreSQL round-trip regression pass; independent Astra review found no blockers.
- Workspace typecheck and lint pass; four-locale completeness and i18n checks pass.
- Full mobile suite: 8,141 passed initially; stale Woods-disabled expectations and one worker startup timeout were rerun after fixes. Targeted editor, header, fork, geometry and BLE tests pass.
- 628 shared-package tests, 63 web tests and 48 catalog tests pass. Backend authoring, rule persistence, similarity, PostgreSQL duplicate queries and atomic repair rollback tested.
- iOS, Android and Expo browser bundles pass.
- Independent Opus backend/frontend reviews and required Fable review passed after fixes. Physical Woods hardware has not been tested.

## Release Notes

See matching and feet rules before you climb on Woods.
Set and remix Woods problems on either board size. Your remix keeps the original climb’s rules.

## Test plan

1. Sign in with Woods selected; Create opens a paintable board.
2. Open Treat yo self; matching and feet rules appear.
3. Toggle Any feet; Campus turns off.
4. Remix a restricted climb; its rules stay selected.
5. Light your saved problem; holds match your Woods board size.

## Risk

Risk: 5/5 — Woods authoring, metadata repair and Bluetooth size guards; Fable reviewed.

