### PR TITLE
fix(backend): say why GitHub refused, so a scope problem reads as one

### DIFF
--- a/docs/crowdsourced-qa.md
+++ b/docs/crowdsourced-qa.md
@@ -156,9 +156,15 @@ reason. Expand/contract, per the production-migration rule.
 | `QA_GITHUB_REPO`  | `FEEDBACK_GITHUB_REPO`, else `boardsesh/boardsesh` | Which repo to read PRs from and comment on.               |
 
 The token is a fine-grained PAT on `boardsesh/boardsesh` with **Pull requests read+write**, **Issues
-read+write**, and **Contents read**. Issues write is not optional and not sufficient on its own: PR
-comments live on the issues endpoint (so they need Issues), and the PR list and commit lookups need
-Pull requests and Contents. An Issues-only token 403s.
+read+write**, and **Contents read**.
+
+**Pull requests write is the one that gets missed.** The verdict comment and the label go through
+`/issues/{n}/comments` and `/issues/{n}/labels`, but the target is a pull request, and GitHub grants
+those on the *Pull requests* permission. Issues write covers creating the two labels in the repo, not
+applying one to a PR; Contents read covers the head-commit lookup. So a token that happily opens
+bug-report issues still 403s on both writes — while reads keep working, which is the trap: testers
+see the PR list, file verdicts, get a success screen, and every verdict lands in the table and
+nowhere else. `FEEDBACK_GITHUB_TOKEN` without PR write did exactly that here for a week.
 
 Empty counts as unset for both variables — `.env.development` ships `QA_GITHUB_TOKEN=`, and a
 dashboard hands back `''` for a variable someone cleared. Either would otherwise shadow the
@@ -171,8 +177,12 @@ Every backend log line for this feature is tagged `[qa]`.
 - **A verdict is missing from a PR.** `SELECT * FROM qa_verdicts WHERE github_comment_id IS NULL` —
   those rows were recorded but never mirrored. The row is the record; the comment is a copy. The
   usual cause is a missing or under-scoped token (grep `[qa] no QA_GITHUB_TOKEN`) or a 403
-  (`[qa] posting the verdict comment`). There is no retry queue: fix the token, and new verdicts
-  mirror again. Older rows can be replayed by hand from the table.
+  (`[qa] posting the verdict comment`). The 403 says which it is — GitHub's own reason and the
+  permission it wanted are in the log line:
+  `responded 403 (Resource not accessible by personal access token; token needs pull_requests=write)`
+  is a scope problem, `rate limit exhausted` is not. There is no retry queue: fix the token, and new
+  verdicts mirror again. Older rows can be replayed by hand from the table, or the tester can just
+  file the verdict again — nothing rejects a second one, and latest wins.
 - **Testers see an empty list.** `[qa] open pull request lookup failed` means GitHub said no —
   usually the anonymous 60/hr ceiling on a deploy with no token. It self-heals in 30 seconds once
   GitHub answers.

--- a/packages/backend/src/lib/__tests__/github-client.test.ts
+++ b/packages/backend/src/lib/__tests__/github-client.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The GitHub error path.
+ *
+ * A failed call has to say *why* it failed: the crowdsourced-QA mirror spent a
+ * week posting nothing because `responded 403` reads identically whether the
+ * token is missing a permission or the hour's rate limit is gone. The other
+ * half of the contract is what must never come out — the response body is not
+ * logged whole, because some GitHub error shapes echo the request back.
+ *
+ * `fetch` is stubbed throughout; nothing here touches the network.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vite-plus/test';
+import { githubRequest } from '../github-client';
+
+const errorResponse = (body: unknown, status: number, headers: Record<string, string> = {}): Response =>
+  ({
+    ok: false,
+    status,
+    headers: new Headers(headers),
+    json: async () => {
+      if (typeof body === 'string') throw new SyntaxError('Unexpected token');
+      return body;
+    },
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  }) as Response;
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('githubRequest failures', () => {
+  it('names the permission a fine-grained token is missing', async () => {
+    fetchMock.mockResolvedValue(
+      errorResponse({ message: 'Resource not accessible by personal access token' }, 403, {
+        'x-accepted-github-permissions': 'pull_requests=write',
+      }),
+    );
+
+    await expect(githubRequest('/repos/o/r/issues/1/comments', { method: 'POST' }, 'tok')).rejects.toThrow(
+      'GitHub POST /repos/o/r/issues/1/comments responded 403 (Resource not accessible by personal access token; token needs pull_requests=write)',
+    );
+  });
+
+  it('separates an exhausted rate limit from a permission problem', async () => {
+    fetchMock.mockResolvedValue(
+      errorResponse({ message: 'API rate limit exceeded' }, 403, { 'x-ratelimit-remaining': '0' }),
+    );
+
+    await expect(githubRequest('/repos/o/r/pulls', undefined, 'tok')).rejects.toThrow(
+      'GitHub GET /repos/o/r/pulls responded 403 (API rate limit exceeded; rate limit exhausted)',
+    );
+  });
+
+  it('says only the status when the body carries no reason', async () => {
+    fetchMock.mockResolvedValue(errorResponse('<html>502 Bad Gateway</html>', 502));
+
+    await expect(githubRequest('/repos/o/r/pulls', undefined, 'tok')).rejects.toThrow(
+      'GitHub GET /repos/o/r/pulls responded 502',
+    );
+  });
+
+  it('leaves the rest of the body out, echoed credentials included', async () => {
+    fetchMock.mockResolvedValue(
+      errorResponse(
+        {
+          message: 'Bad credentials',
+          documentation_url: 'https://docs.github.com/rest',
+          request: { headers: { authorization: 'Bearer ghp_supersecret' } },
+        },
+        401,
+      ),
+    );
+
+    const failure = await githubRequest('/repos/o/r/pulls', undefined, 'ghp_supersecret').catch(
+      (error: unknown) => error,
+    );
+    expect(String(failure)).toContain('Bad credentials');
+    expect(String(failure)).not.toContain('ghp_supersecret');
+    expect(String(failure)).not.toContain('documentation_url');
+  });
+
+  it('truncates a long message rather than pasting a whole page into the log', async () => {
+    fetchMock.mockResolvedValue(errorResponse({ message: 'x'.repeat(5000) }, 422));
+
+    const failure = await githubRequest('/repos/o/r/labels', { method: 'POST' }, 'tok').catch(
+      (error: unknown) => error,
+    );
+    expect(String(failure)).toHaveLength('Error: GitHub POST /repos/o/r/labels responded 422 ()'.length + 200);
+  });
+});

--- a/packages/backend/src/lib/github-client.ts
+++ b/packages/backend/src/lib/github-client.ts
@@ -55,8 +55,7 @@ export async function ensureLabels(owner: string, repo: string, token: string, l
         body: JSON.stringify({ name: label, color: LABEL_COLORS[label] ?? 'ededed' }),
       });
       if (!response.ok && response.status !== 422) {
-        const errorText = await response.text().catch(() => '<unreadable>');
-        logger.warn(`[github] ensureLabel ${label}: ${response.status} ${errorText}`);
+        logger.warn(`[github] ensureLabel ${label}: ${response.status}${await describeFailure(response)}`);
       }
     } catch (error) {
       logger.warn(`[github] ensureLabel ${label} error:`, error);
@@ -64,10 +63,46 @@ export async function ensureLabels(owner: string, repo: string, token: string, l
   }
 }
 
+/** Cap on GitHub's own error text. The real ones are a short sentence. */
+const ERROR_MESSAGE_MAX = 200;
+
+/**
+ * Why GitHub refused a call, reduced to the parts that are safe to log.
+ *
+ * The body is never logged whole — some error shapes echo the request back,
+ * token and all. Two fields earn their place: `message` is a fixed sentence
+ * ("Resource not accessible by personal access token"), and on a
+ * fine-grained-PAT refusal `x-accepted-github-permissions` names the permission
+ * the token lacks (`pull_requests=write`). Without them, a 403 for a missing
+ * scope and a 403 for an exhausted rate limit read identically — which is how a
+ * QA token that could not comment on a pull request went a week unnoticed,
+ * every verdict recorded and none of them mirrored.
+ */
+async function describeFailure(response: Response): Promise<string> {
+  const reasons: string[] = [];
+  const message = await readGitHubMessage(response);
+  if (message) reasons.push(message);
+  const acceptedPermissions = response.headers.get('x-accepted-github-permissions');
+  if (acceptedPermissions) reasons.push(`token needs ${acceptedPermissions}`);
+  if (response.headers.get('x-ratelimit-remaining') === '0') reasons.push('rate limit exhausted');
+  return reasons.length > 0 ? ` (${reasons.join('; ')})` : '';
+}
+
+/** GitHub's `message` field, or null when the body is missing or not JSON. */
+async function readGitHubMessage(response: Response): Promise<string | null> {
+  try {
+    const payload = (await response.json()) as { message?: unknown };
+    return typeof payload.message === 'string' ? payload.message.slice(0, ERROR_MESSAGE_MAX) : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * A single GitHub REST call, JSON in and out. Throws on a non-2xx status with
- * the status in the message so a caller can negative-cache or log it; the body
- * is not included (it can carry a token echo in some error shapes).
+ * the status and GitHub's own reason in the message, so a caller can
+ * negative-cache it or log it and know what to fix — see {@link describeFailure}
+ * for what is and isn't safe to carry out of the body.
  *
  * `token` is optional: the public repo answers unauthenticated reads at 60/hr
  * per IP, which the caching readers stay under. Writes always need one.
@@ -86,7 +121,9 @@ export async function githubRequest<T>(path: string, init?: RequestInit, token?:
     headers: { ...headers, ...((init?.headers as Record<string, string> | undefined) ?? {}) },
   });
   if (!response.ok) {
-    throw new Error(`GitHub ${init?.method ?? 'GET'} ${path} responded ${response.status}`);
+    throw new Error(
+      `GitHub ${init?.method ?? 'GET'} ${path} responded ${response.status}${await describeFailure(response)}`,
+    );
   }
   // 204 No Content (label DELETE) has no body to parse.
   if (response.status === 204) return undefined as T;

--- a/packages/backend/src/services/__tests__/github-qa.test.ts
+++ b/packages/backend/src/services/__tests__/github-qa.test.ts
@@ -81,10 +81,13 @@ const githubPull = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
-const jsonResponse = (body: unknown, status = 200): Response =>
+const jsonResponse = (body: unknown, status = 200, headers: Record<string, string> = {}): Response =>
   ({
     ok: status >= 200 && status < 300,
     status,
+    // Real headers, because the error path reads them: a fine-grained-PAT
+    // refusal carries the permission it wanted in `x-accepted-github-permissions`.
+    headers: new Headers(headers),
     json: async () => body,
     text: async () => JSON.stringify(body),
   }) as Response;
@@ -606,6 +609,29 @@ describe('postVerdictComment', () => {
     fetchMock.mockResolvedValue(jsonResponse({ message: 'forbidden' }, 403));
 
     await expect(postVerdictComment(4792, 'body')).resolves.toBeNull();
+  });
+
+  // The failure this repo actually shipped: the QA token could read pull
+  // requests but not write to them, so every verdict was recorded and none of
+  // them reached the PR. A bare "responded 403" reads the same as a rate limit,
+  // so the log has to name the permission.
+  it('logs which permission the token is missing when GitHub refuses the write', async () => {
+    const errorLog = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+    fetchMock.mockResolvedValue(
+      jsonResponse({ message: 'Resource not accessible by personal access token' }, 403, {
+        'x-accepted-github-permissions': 'pull_requests=write',
+      }),
+    );
+
+    await expect(postVerdictComment(4792, 'body')).resolves.toBeNull();
+    // Flattened, because winston's typed overload says `error` takes one arg
+    // and the call carries two: the message and the failure.
+    const logged = errorLog.mock.calls
+      .flat()
+      .map((part) => String(part))
+      .join(' ');
+    expect(logged).toContain('Resource not accessible by personal access token');
+    expect(logged).toContain('token needs pull_requests=write');
   });
 });
 


### PR DESCRIPTION
## Summary

A tester approved #4978 from the app this morning. The verdict is in `qa_verdicts`; the PR has no comment and no label. Both writes 403'd, and have been since the feature shipped — no PR in this repo has ever carried `qa-approved` or `qa-declined`.

The cause was config: `boardsesh-backend` has no `QA_GITHUB_TOKEN`, so it falls back to `FEEDBACK_GITHUB_TOKEN`, which can open bug-report issues but has no **Pull requests: write**. That token is now re-scoped. This PR is about why it took a log dig to find out.

- `githubRequest` threw with the status and nothing else, so a missing permission and an exhausted rate limit produced the same line. It now carries GitHub's own `message` and, on a fine-grained-PAT refusal, `x-accepted-github-permissions` — which names the exact permission the token wants. The body still never goes in whole (some error shapes echo the request back, token and all), and the message is capped at 200 characters.
- `ensureLabels` was logging the raw response body. Same summary now, so that echo hazard is gone from the one place it existed.
- `docs/crowdsourced-qa.md` said PR comments need Issues write. They need Pull requests write — Issues write covers creating the two labels in the repo, not applying one to a PR. That sentence is what would send the next person back to the same broken scope.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 1/5 — error-path logging and a doc; no behaviour change on the success path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSyhzefoihv1qSfX8LMWRm
