### PR TITLE
fix(mobile): stop max contrast preset from turning on role glyphs

### DIFF
--- a/packages/mobile/src/lib/__tests__/board-render-presets.test.ts
+++ b/packages/mobile/src/lib/__tests__/board-render-presets.test.ts
@@ -100,7 +100,6 @@ describe('BOARD_RENDER_PRESETS', () => {
       markStyle: 'fill',
       fillOpacity: 0.85,
     });
-    expect(preset.values.boardsesh.roleGlyphs).toBe(false);
   });
 
   it('every preset value is already sanitary — applying one never gets silently altered on write', async () => {

--- a/packages/mobile/src/lib/__tests__/board-render-presets.test.ts
+++ b/packages/mobile/src/lib/__tests__/board-render-presets.test.ts
@@ -90,7 +90,7 @@ describe('BOARD_RENDER_PRESETS', () => {
     });
   });
 
-  it('max-contrast preset: plateau, custom 0.7 veil, fill marks at 0.85, role glyphs on', () => {
+  it('max-contrast preset: plateau, custom 0.7 veil, fill marks at 0.85, role glyphs untouched', () => {
     const preset = BOARD_RENDER_PRESETS.find((entry) => entry.id === 'max-contrast')!;
     expect(preset.values.boardsesh).toEqual({
       ...DEFAULT_BOARDSESH_RENDER_SETTINGS,
@@ -99,8 +99,8 @@ describe('BOARD_RENDER_PRESETS', () => {
       veilOpacity: 0.7,
       markStyle: 'fill',
       fillOpacity: 0.85,
-      roleGlyphs: true,
     });
+    expect(preset.values.boardsesh.roleGlyphs).toBe(false);
   });
 
   it('every preset value is already sanitary — applying one never gets silently altered on write', async () => {
@@ -198,12 +198,24 @@ describe('accessibility-owned fields survive a preset', () => {
     expect(matchingPresetId(await loadBoardRenderSettings())).toBe('aura-subtle');
   });
 
-  it('lets a preset turn glyphs ON — the merge only ever raises the floor', async () => {
+  it('max-contrast does not turn glyphs on — raising contrast and adding glyphs are separate choices', async () => {
     expect((await loadBoardRenderSettings()).boardsesh.roleGlyphs).toBe(false);
 
     await applyBoardRenderPreset('max-contrast');
 
-    expect((await loadBoardRenderSettings()).boardsesh.roleGlyphs).toBe(true);
+    expect((await loadBoardRenderSettings()).boardsesh.roleGlyphs).toBe(false);
+  });
+
+  it('the merge itself would raise an accessibility-owned field a preset turned ON, if one ever does', () => {
+    const preset = BOARD_RENDER_PRESETS.find((entry) => entry.id === 'aura')!;
+    const hypotheticalPreset = {
+      ...preset.values,
+      boardsesh: { ...preset.values.boardsesh, roleGlyphs: true },
+    };
+
+    const merged = mergePresetPreservingAccessibility(hypotheticalPreset, DEFAULT_BOARD_RENDER_SETTINGS);
+
+    expect(merged.boardsesh.roleGlyphs).toBe(true);
   });
 
   it('merges without mutating either input', () => {

--- a/packages/mobile/src/lib/board-render-presets.ts
+++ b/packages/mobile/src/lib/board-render-presets.ts
@@ -56,14 +56,17 @@ export const BOARD_RENDER_PRESET_VALUES = {
   'modern-classic': {
     holdShape: 'circle',
   },
-  /** Strongest separation: full wash, solid marks, plus the non-colour glyphs. */
+  /**
+   * Strongest separation: full wash, solid marks. Role glyphs are a separate,
+   * climber-owned choice (see `ACCESSIBILITY_OWNED_BOARDSESH_FIELDS`) — this
+   * preset raises colour contrast only and must not flip that switch itself.
+   */
   'max-contrast': {
     glowFalloff: 'plateau',
     veil: 'custom',
     veilOpacity: 0.7,
     markStyle: 'fill',
     fillOpacity: 0.85,
-    roleGlyphs: true,
   },
 } as const satisfies Record<BoardRenderPresetId, Partial<BoardseshRenderSettings>>;
 
@@ -111,13 +114,13 @@ type BooleanBoardseshField = {
  * "Aura Subtle" would quietly switch them back off and hand a colour-blind climber a
  * colour-only board.
  *
- * The rule is one-directional: a preset may turn one of these ON (`max-contrast`
- * ships `roleGlyphs: true` deliberately) but never OFF, so applying a preset can
- * only ever raise the accessibility floor. That is why every entry has to be a
- * boolean whose `true` is the stronger affordance — the merge below is an OR and
- * the match below reads `true` as "at least the preset". `BooleanBoardseshField`
- * makes adding a non-boolean here a compile error rather than a silent
- * misbehaviour.
+ * The rule is one-directional: a preset may turn one of these ON but never OFF,
+ * so applying a preset can only ever raise the accessibility floor — no shipped
+ * preset currently does, but the merge stays in place for a climber who has
+ * turned the field on by hand. That is why every entry has to be a boolean whose
+ * `true` is the stronger affordance — the merge below is an OR and the match
+ * below reads `true` as "at least the preset". `BooleanBoardseshField` makes
+ * adding a non-boolean here a compile error rather than a silent misbehaviour.
  */
 export const ACCESSIBILITY_OWNED_BOARDSESH_FIELDS = ['roleGlyphs'] as const satisfies readonly BooleanBoardseshField[];
 

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -42,7 +42,7 @@
             "aura": "Beleuchtete Griffe leuchten auf gedämpfter Wand.",
             "auraSubtle": "Ein sanfteres Leuchten, dicht am Griff.",
             "modernClassic": "Die gewohnten Kreise auf gedämpfter Wand.",
-            "maxContrast": "Stärkster Schleier, gefüllte Griffe und Rollen-Glyphen.",
+            "maxContrast": "Stärkster Schleier und gefüllte Griffe.",
             "auraBold": "Ein breiteres, härteres Leuchten — auch von weitem sichtbar.",
             "classic": "Die runden Marker, die Boardsesh immer gezeichnet hat.",
             "custom": "Stell dir jeden Teil des Looks selbst ein."

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -42,7 +42,7 @@
             "aura": "Lit holds glow on a quietened wall.",
             "auraSubtle": "A softer glow that stays close to each hold.",
             "modernClassic": "The circles you know, on a quietened wall.",
-            "maxContrast": "The strongest wash, filled holds and role glyphs.",
+            "maxContrast": "The strongest wash and filled holds.",
             "auraBold": "A wider, harder glow that carries across the room.",
             "classic": "The circle markers Boardsesh has always drawn.",
             "custom": "Tune every part of the look yourself."

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -235,7 +235,7 @@
             "aura": "Las presas encendidas brillan sobre un muro atenuado.",
             "auraSubtle": "Un brillo más suave, pegado a cada presa.",
             "modernClassic": "Los círculos de siempre, sobre un muro atenuado.",
-            "maxContrast": "El lavado más fuerte, presas rellenas y glifos de rol.",
+            "maxContrast": "El lavado más fuerte y presas rellenas.",
             "auraBold": "Un brillo más amplio y duro que se ve desde lejos.",
             "classic": "Los marcadores circulares de siempre.",
             "custom": "Ajusta cada parte del aspecto a tu gusto."

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -42,7 +42,7 @@
             "aura": "Les prises allumées brillent sur un mur assourdi.",
             "auraSubtle": "Une lueur plus douce, au plus près de chaque prise.",
             "modernClassic": "Les cercles habituels, sur un mur assourdi.",
-            "maxContrast": "Le voile le plus fort, prises pleines et glyphes de rôle.",
+            "maxContrast": "Le voile le plus fort et des prises pleines.",
             "auraBold": "Une lueur plus large et plus dure, visible de loin.",
             "classic": "Les marqueurs ronds que Boardsesh a toujours dessinés.",
             "custom": "Règle toi-même chaque partie du rendu."


### PR DESCRIPTION
## Summary

Max contrast is a colour/wash preset (plateau falloff, custom veil, filled marks) — it was also flipping `roleGlyphs` on as a side effect. Role glyphs are a separate accessibility choice, already surfaced on its own via the greyscale suggestion and the Accessibility settings toggle; a climber picking Max contrast purely for stronger colour contrast shouldn't get glyphs added without asking. `mergePresetPreservingAccessibility` still preserves a climber's own `roleGlyphs: true` through any preset — this only removes the preset's own implicit opt-in.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. More tab → Board look → tap Max contrast card.
2. Open Board look → Accessibility. Role glyphs toggle shows OFF.
3. Toggle Role glyphs on, then tap a different preset and back to Max contrast — it should stay ON (still climber-owned).

## Risk

Risk: 2/5 — isolated preset-value + copy change with test coverage, no BLE/migration/native code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012E5FpVHnkGvnFLNUJ1gJdF

---
_Generated by [Claude Code](https://claude.ai/code/session_012E5FpVHnkGvnFLNUJ1gJdF)_