### PR TITLE
fix(mobile): stop forcing fill style in the create-climb board editor

### DIFF
--- a/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
+++ b/packages/mobile/src/components/create-climb/InteractiveCreateBoard.tsx
@@ -52,11 +52,14 @@ type InteractiveCreateBoardProps = {
 /**
  * The no-SVG interactive board editor. The board and its painted holds come from
  * the same renderer the play view uses (BoardImageNative, fed the active frame),
- * so a climb looks the same while you build it as it will once it is saved. The
- * veil is off here — the glow lands on an unwashed wall, so the unlit holds you
- * still have to find and tap stay readable. Tap targets are plain RN Views placed
- * INSIDE the zoom-transformed Animated.View, so RNGH hit-tests them in board-local
- * space and taps land correctly at any zoom level with zero manual coordinate math.
+ * so a climb looks the same while you build it as it will once it is saved — it
+ * mirrors the climber's own Aura settings exactly (mark style, glow, fill) rather
+ * than the small-surface `filledStyle`/thumbnail treatment, with one deliberate
+ * exception: the veil is off here — the glow lands on an unwashed wall, so the
+ * unlit holds you still have to find and tap stay readable. Tap targets are plain
+ * RN Views placed INSIDE the zoom-transformed Animated.View, so RNGH hit-tests
+ * them in board-local space and taps land correctly at any zoom level with zero
+ * manual coordinate math.
  * PaintedHoldsLayer survives as the fallback for a build with no native renderer,
  * where no overlay ever arrives.
  *
@@ -211,7 +214,6 @@ export const InteractiveCreateBoard = React.memo(function InteractiveCreateBoard
               boardWidth={boardWidth}
               boardHeight={boardHeight}
               mirrored={mirrored}
-              filledStyle
               renderWidth={overlayRenderWidth}
               backgroundVariant="full"
               maxVeilOpacity={EDITING_VEIL_OPACITY}

--- a/packages/mobile/src/components/create-climb/__tests__/interactive-create-board-layers.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/interactive-create-board-layers.test.tsx
@@ -119,4 +119,14 @@ describe('InteractiveCreateBoard layer order', () => {
     // the unlit holds the climber still has to find stay readable.
     expect(boardImageProps.current?.maxVeilOpacity).toBe(0);
   });
+
+  it("does not force the small-surface filled style, so the editor mirrors the climber's own mark style", () => {
+    render(createElement(InteractiveCreateBoard, BOARD_PROPS));
+
+    // filledStyle routes the render through settings.thumbnailStyle instead of
+    // the climber's markStyle — that's the accessory-thumbnail treatment, not
+    // this full-size editor. Left unset here so Aura fill only shows when the
+    // climber's own settings ask for it.
+    expect(boardImageProps.current?.filledStyle).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

- `InteractiveCreateBoard` (the climb-setting board editor) passed `filledStyle` unconditionally to `BoardImageNative`. That prop is the small-surface "thumbnail" treatment (meant for things like 40×40 accessory thumbnails), which routes the render through `settings.thumbnailStyle` (default `'fill'`, mapping to `mark_style: 'glow-fill'`) instead of the climber's actual `markStyle` setting (default `'glow'`, no fill).
- Net effect: a climber with the default/Glow-only Aura look still saw a fill on every hold while setting a climb, even though they never enabled fill.
- Fix: drop the `filledStyle` prop from the create-climb editor's `BoardImageNative` call. It now renders through the normal (non-thumbnail) path, which mirrors the climber's Aura settings exactly — same as the play view. The one deliberate difference from a normal read view is unchanged: the veil stays forced off via `maxVeilOpacity={EDITING_VEIL_OPACITY}`, since the unlit holds are what the climber is still finding and tapping.
- Verified locally: `vp check` (clean on the changed file), `vp run typecheck:mobile` (clean), `vp test run --project mobile` (8207 tests passed), `vp run check:mobile-bundle` (OK).

## Release Notes

- Setting a climb now shows your board look exactly as you configured it — no more fill sneaking in if you only turned on Glow.

## Test plan

1. Settings → Board look → set Mark style to "Glow" (no fill). You tab → More → Board look.
2. Start a new climb on any board. Create → pick a board → New climb.
3. Tap a few holds. Holds glow only — no filled/tinted circle underneath.
4. Confirm the wall around unlit holds still looks clear, not washed out. No veil overlay.

## Risk

Risk: 2/5 — isolated rendering-config change on one screen, covered by existing mobile test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yzMZjQvbG3KaFGHRbEb7k

---
_Generated by [Claude Code](https://claude.ai/code/session_019yzMZjQvbG3KaFGHRbEb7k)_