### PR TITLE
fix(mobile): localize QA preview screens

### DIFF
--- a/packages/mobile/src/components/qa/QaBriefScreen.tsx
+++ b/packages/mobile/src/components/qa/QaBriefScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
+import { useTranslation } from 'react-i18next';
 import { ActivityIndicator } from '../ActivityIndicator';
 import { Button } from '../Button';
 import { Text } from '../Text';
@@ -18,37 +19,12 @@ import { riskTone, type QaRiskTone } from '../../lib/qa/qa-pick-rows';
 import { useQaPreviews } from '../../lib/qa/use-qa-previews';
 import { QA_PREVIEW_LEFT_EVENT, QA_SURF_FAILED_EVENT, surfFailureReason } from '../../lib/qa/qa-analytics';
 
-// Tester-only screen: hardcoded English with `i18n-ignore`, like Feature Flags.
+// This screen was tester-only (hardcoded English, like Feature Flags) until it
+// opened to every user in #5126. `DEV_HINT` is the one string left
+// English-only: it's a dev-build-only hint no shipped user ever sees.
 
-// i18n-ignore-next-line — tester-only screen
-const SCREEN_TITLE = 'What to test';
-// i18n-ignore-next-line
-const START_LABEL = 'Start testing';
-// i18n-ignore-next-line
-const FINISH_LABEL = 'Finish testing';
-// i18n-ignore-next-line
-const GITHUB_LABEL = 'Open on GitHub';
-// i18n-ignore-next-line
-const LEAVE_LABEL = 'Leave preview';
-// i18n-ignore-next-line
-const NO_PLAN_TEXT = 'No test plan on this PR yet — open it on GitHub and use your judgement.';
-// i18n-ignore-next-line
-const UNKNOWN_PR_BODY = 'is closed or unknown. Nothing here to test.';
-// i18n-ignore-next-line
-const ON_PRODUCTION_TITLE = "You're on production";
-// i18n-ignore-next-line
-const ON_PRODUCTION_BODY = 'Pick a PR preview to start testing one.';
-// i18n-ignore-next-line
-const PICK_LABEL = 'Test a PR preview';
-// i18n-ignore-next-line
+// i18n-ignore-next-line — dev-build-only hint, never shown in a shipped build
 const DEV_HINT = 'Surfing is unavailable in a dev build — Leave preview is disabled here.';
-// i18n-ignore-next-line
-const BACK_ON_PRODUCTION_TOAST = 'Back on production at the next update';
-// The thrown message goes to Sentry and to the event's `reason`; the tester gets
-// the one sentence that tells them what to do. (Before this, an empty-message
-// Error surfaced as an empty toast and a non-Error surfaced the button label.)
-// i18n-ignore-next-line
-const LEAVE_FAILED_TOAST = 'Could not switch off this preview — try again';
 
 /**
  * What this preview is and what to try — shown once per surfed bundle by
@@ -60,6 +36,7 @@ const LEAVE_FAILED_TOAST = 'Could not switch off this preview — try again';
  */
 export function QaBriefScreen() {
   const insets = useSafeAreaInsets();
+  const { t } = useTranslation('common');
   const { systemColors, brandColors } = useTheme();
   const { showToast } = useToast();
   const { presentQaVerdict } = useUserDrawer();
@@ -105,15 +82,15 @@ export function QaBriefScreen() {
         // Production is not *newer* than a fresh pr-N bundle, so the running JS
         // usually stays until production publishes again. The pin is gone either
         // way, which is what actually matters.
-        if (outcome === 'nothing-to-load') showToast(BACK_ON_PRODUCTION_TOAST, 'info');
+        if (outcome === 'nothing-to-load') showToast(t('qa.shared.backOnProduction'), 'info');
       })
       .catch((error: unknown) => {
         setLeaving(false);
         reportHandledError(error, { tags: { source: 'qa', op: 'surf-to-production' } });
         track(QA_SURF_FAILED_EVENT, { prNumber: null, reason: surfFailureReason(error) });
-        showToast(LEAVE_FAILED_TOAST, 'error');
+        showToast(t('qa.shared.leaveFailed'), 'error');
       });
-  }, [leaving, runningPrNumber, showToast, surfingAvailable]);
+  }, [leaving, runningPrNumber, showToast, surfingAvailable, t]);
 
   const containerStyle = [styles.root, { backgroundColor: systemColors.groupedBackground, paddingTop: insets.top }];
 
@@ -122,14 +99,18 @@ export function QaBriefScreen() {
       <View style={containerStyle}>
         <ScrollView contentContainerStyle={styles.content}>
           <Text variant="title3" style={styles.title}>
-            {ON_PRODUCTION_TITLE}
+            {t('qa.brief.onProductionTitle')}
           </Text>
           <Text variant="body" color={systemColors.secondaryLabel}>
-            {ON_PRODUCTION_BODY}
+            {t('qa.brief.onProductionBody')}
           </Text>
-          <Button title={PICK_LABEL} onPress={() => router.replace('/qa/pick')} variant="filled" size="large" />
-          {/* i18n-ignore-next-line */}
-          <Button title="Close" onPress={() => router.back()} variant="text" size="large" />
+          <Button
+            title={t('userDrawer.qa.pick')}
+            onPress={() => router.replace('/qa/pick')}
+            variant="filled"
+            size="large"
+          />
+          <Button title={t('actions.close')} onPress={() => router.back()} variant="text" size="large" />
         </ScrollView>
       </View>
     );
@@ -143,7 +124,7 @@ export function QaBriefScreen() {
     <View style={containerStyle}>
       <ScrollView contentContainerStyle={styles.content}>
         <Text variant="footnote" color={systemColors.secondaryLabel}>
-          {`${SCREEN_TITLE} · #${runningPrNumber}`}
+          {`${t('qa.brief.screenTitle')} · #${runningPrNumber}`}
         </Text>
 
         {showLoading ? <ActivityIndicator /> : null}
@@ -154,7 +135,7 @@ export function QaBriefScreen() {
 
         {preview === null && !showLoading ? (
           <Text variant="body" color={systemColors.secondaryLabel}>
-            {`PR #${runningPrNumber} ${UNKNOWN_PR_BODY}`}
+            {t('qa.brief.unknownPr', { prNumber: runningPrNumber })}
           </Text>
         ) : null}
 
@@ -166,7 +147,7 @@ export function QaBriefScreen() {
             {preview.risk !== null ? (
               <View style={[styles.riskChip, { backgroundColor: riskColorFor(riskTone(preview.risk), brandColors) }]}>
                 <Text variant="caption2" color={brandColors.onPrimary} style={styles.chipLabel}>
-                  {`Risk ${preview.risk}/5`}
+                  {t('qa.brief.riskLabel', { risk: preview.risk })}
                 </Text>
               </View>
             ) : null}
@@ -201,7 +182,7 @@ export function QaBriefScreen() {
           </View>
         ) : !showLoading ? (
           <Text variant="subheadline" color={systemColors.secondaryLabel}>
-            {NO_PLAN_TEXT}
+            {t('qa.brief.noPlanText')}
           </Text>
         ) : null}
 
@@ -212,11 +193,11 @@ export function QaBriefScreen() {
         ) : null}
 
         <View style={styles.actions}>
-          <Button title={START_LABEL} onPress={() => router.back()} variant="filled" size="large" />
-          <Button title={FINISH_LABEL} onPress={handleFinishTesting} variant="tonal" size="large" />
+          <Button title={t('qa.brief.startLabel')} onPress={() => router.back()} variant="filled" size="large" />
+          <Button title={t('qa.brief.finishLabel')} onPress={handleFinishTesting} variant="tonal" size="large" />
           {preview?.url ? (
             <Button
-              title={GITHUB_LABEL}
+              title={t('qa.brief.githubLabel')}
               onPress={() => void openExternalUrl(preview.url, 'qa-brief')}
               variant="outlined"
               size="large"
@@ -224,7 +205,7 @@ export function QaBriefScreen() {
             />
           ) : null}
           <Button
-            title={LEAVE_LABEL}
+            title={t('qa.brief.leaveLabel')}
             onPress={handleLeavePreview}
             variant="text"
             size="large"

--- a/packages/mobile/src/components/qa/QaPickScreen.tsx
+++ b/packages/mobile/src/components/qa/QaPickScreen.tsx
@@ -5,6 +5,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { ActivityIndicator } from '../ActivityIndicator';
 import { Icon } from '../Icon';
 import { PressableSurface } from '../PressableSurface';
@@ -174,9 +175,15 @@ export function QaPickScreen() {
 
   const renderItem = useCallback(
     ({ item }: { item: QaPickRow }) => (
-      <QaPickRowItem row={item} disabled={rowsDisabled} busy={surfingPrNumber === item.prNumber} onPress={handlePick} />
+      <QaPickRowItem
+        row={item}
+        disabled={rowsDisabled}
+        busy={surfingPrNumber === item.prNumber}
+        onPress={handlePick}
+        t={t}
+      />
     ),
-    [handlePick, rowsDisabled, surfingPrNumber],
+    [handlePick, rowsDisabled, surfingPrNumber, t],
   );
 
   const surfingDisabledForChannel = branchesQuery.isSuccess && branches === null;
@@ -262,12 +269,14 @@ type QaPickRowItemProps = {
   disabled: boolean;
   busy: boolean;
   onPress: (row: QaPickRow) => void;
+  t: TFunction<'common'>;
 };
 
 // Memoized so scrolling the list doesn't re-render every row for one row's
-// spinner (perf playbook rule 2).
-const QaPickRowItem = memo(function QaPickRowItem({ row, disabled, busy, onPress }: QaPickRowItemProps) {
-  const { t } = useTranslation('common');
+// spinner (perf playbook rule 2). `t` is passed down from the screen rather
+// than read via `useTranslation` here, so the list doesn't pay for a hook
+// subscription per row.
+const QaPickRowItem = memo(function QaPickRowItem({ row, disabled, busy, onPress, t }: QaPickRowItemProps) {
   const { systemColors, brandColors } = useTheme();
   // A separate context from `useTheme` on purpose — it only changes when the
   // user switches theme, so a row in a virtualized list is not re-rendered by

--- a/packages/mobile/src/components/qa/QaPickScreen.tsx
+++ b/packages/mobile/src/components/qa/QaPickScreen.tsx
@@ -4,6 +4,7 @@ import { FlashList } from '@shopify/flash-list';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 import { ActivityIndicator } from '../ActivityIndicator';
 import { Icon } from '../Icon';
 import { PressableSurface } from '../PressableSurface';
@@ -35,43 +36,13 @@ import {
   surfFailureReason,
 } from '../../lib/qa/qa-analytics';
 
-// Tester-only screen: every string is hardcoded English with `i18n-ignore`,
-// matching Feature Flags and the branch switcher.
+// This screen was tester-only (hardcoded English, matching Feature Flags and
+// the branch switcher) until it opened to every user in #5126. `DEV_HINT` is
+// the one string left English-only: it's a dev-build-only hint no shipped
+// user ever sees.
 
-// i18n-ignore-next-line — tester-only screen
-const SCREEN_TITLE = 'Test a PR';
-// i18n-ignore-next-line
-const SKIP_LABEL = 'Skip';
-// i18n-ignore-next-line
-const EMPTY_TITLE = 'Nothing to test right now';
-// i18n-ignore-next-line
-const EMPTY_BODY = 'No PR has published a preview for this build yet. Check back after the next push.';
-// i18n-ignore-next-line
-const SURFING_OFF_TITLE = 'Previews are switched off';
-// i18n-ignore-next-line
-const SURFING_OFF_BODY = 'This channel is not serving PR previews at the moment.';
-// i18n-ignore-next-line
-const UNREACHABLE_TITLE = 'Could not reach the update server';
-// i18n-ignore-next-line
+// i18n-ignore-next-line — dev-build-only hint, never shown in a shipped build
 const DEV_HINT = 'Surfing is unavailable in a dev build — the list is read-only here.';
-// i18n-ignore-next-line
-const DRAFT_CHIP = 'Draft';
-// i18n-ignore-next-line
-const APPROVED_CHIP = 'You approved';
-// i18n-ignore-next-line
-const DECLINED_CHIP = 'You declined';
-// i18n-ignore-next-line
-const HEAD_CHANGED_CHIP = 'Head changed since';
-// i18n-ignore-next-line
-const CRASHED_CHIP = 'Crashed on launch';
-// i18n-ignore-next-line
-const BUILDING_CHIP = 'Building';
-// i18n-ignore-next-line
-const BUILDING_NEWER_CHIP = 'Building newer';
-// i18n-ignore-next-line
-const BUILDING_TOAST = 'Still publishing — it appears here when the bundle lands';
-// i18n-ignore-next-line
-const BUILDING_HINT = 'This preview is still publishing and cannot be loaded yet';
 
 const NO_ROWS: QaPickRow[] = [];
 const keyExtractor = (row: QaPickRow) => row.branch;
@@ -86,6 +57,7 @@ const keyExtractor = (row: QaPickRow) => row.branch;
  */
 export function QaPickScreen() {
   const insets = useSafeAreaInsets();
+  const { t } = useTranslation('common');
   const { systemColors, brandColors } = useTheme();
   const { showToast } = useToast();
   const { data: profile } = useProfile();
@@ -160,7 +132,7 @@ export function QaPickScreen() {
       // A building row has no branch yet. It is rendered unpressable, but say
       // why rather than swallow a tap that reached here anyway.
       if (!row.loadable) {
-        showToast(BUILDING_TOAST, 'info');
+        showToast(t('qa.pick.buildingToast'), 'info');
         return;
       }
       surfInFlightRef.current = true;
@@ -174,11 +146,7 @@ export function QaPickScreen() {
           if (outcome === 'nothing-to-load') {
             surfInFlightRef.current = false;
             setSurfingPrNumber(null);
-            showToast(
-              // i18n-ignore-next-line
-              `Nothing new for #${row.prNumber} on this build — its next publish applies on relaunch`,
-              'info',
-            );
+            showToast(t('qa.pick.nothingNewToast', { prNumber: row.prNumber }), 'info');
           }
         })
         .catch((error: unknown) => {
@@ -191,11 +159,12 @@ export function QaPickScreen() {
           // update server (502)", "Branch surfing is unavailable on this build"),
           // which is worth showing — but an Error can carry an empty message, and
           // an empty toast tells the tester nothing.
-          const message = error instanceof Error && error.message.length > 0 ? error.message : UNREACHABLE_TITLE;
+          const message =
+            error instanceof Error && error.message.length > 0 ? error.message : t('qa.pick.unreachableTitle');
           showToast(message, 'error');
         });
     },
-    [showToast, surfingAvailable],
+    [showToast, surfingAvailable, t],
   );
 
   // Every row goes flat while a surf is in flight, not just the one that was
@@ -218,17 +187,17 @@ export function QaPickScreen() {
     <View style={[styles.root, { backgroundColor: systemColors.groupedBackground, paddingTop: insets.top }]}>
       <View style={styles.header}>
         <Text variant="title3" style={styles.headerTitle}>
-          {SCREEN_TITLE}
+          {t('qa.pick.title')}
         </Text>
         <PressableSurface
           onPress={() => router.back()}
           feedback="opacity"
           hitSlop={8}
           accessibilityRole="button"
-          accessibilityLabel={SKIP_LABEL}
+          accessibilityLabel={t('qa.pick.skip')}
         >
           <Text variant="subheadline" color={brandColors.primary}>
-            {SKIP_LABEL}
+            {t('qa.pick.skip')}
           </Text>
         </PressableSurface>
       </View>
@@ -245,17 +214,19 @@ export function QaPickScreen() {
         </View>
       ) : null}
 
-      {surfingDisabledForChannel ? <Placard title={SURFING_OFF_TITLE} body={SURFING_OFF_BODY} /> : null}
+      {surfingDisabledForChannel ? (
+        <Placard title={t('qa.pick.surfingOffTitle')} body={t('qa.pick.surfingOffBody')} />
+      ) : null}
 
       {listFailed ? (
         <Placard
-          title={UNREACHABLE_TITLE}
+          title={t('qa.pick.unreachableTitle')}
           body={branchesQuery.error instanceof Error ? branchesQuery.error.message : ''}
         />
       ) : null}
 
       {!listLoading && !listFailed && !surfingDisabledForChannel && rows.length === 0 ? (
-        <Placard title={EMPTY_TITLE} body={EMPTY_BODY} />
+        <Placard title={t('qa.pick.emptyTitle')} body={t('qa.pick.emptyBody')} />
       ) : null}
 
       <FlashList
@@ -296,6 +267,7 @@ type QaPickRowItemProps = {
 // Memoized so scrolling the list doesn't re-render every row for one row's
 // spinner (perf playbook rule 2).
 const QaPickRowItem = memo(function QaPickRowItem({ row, disabled, busy, onPress }: QaPickRowItemProps) {
+  const { t } = useTranslation('common');
   const { systemColors, brandColors } = useTheme();
   // A separate context from `useTheme` on purpose — it only changes when the
   // user switches theme, so a row in a virtualized list is not re-rendered by
@@ -316,7 +288,7 @@ const QaPickRowItem = memo(function QaPickRowItem({ row, disabled, busy, onPress
       accessibilityLabel={`#${row.prNumber} ${title}`}
       // Says out loud what the dimming says visually, for a screen reader that
       // would otherwise hear an ordinary button.
-      accessibilityHint={row.loadable ? undefined : BUILDING_HINT}
+      accessibilityHint={row.loadable ? undefined : t('qa.pick.buildingHint')}
       style={[
         styles.row,
         { backgroundColor: systemColors.elevatedSurface },
@@ -348,13 +320,16 @@ const QaPickRowItem = memo(function QaPickRowItem({ row, disabled, busy, onPress
         </Text>
 
         <View style={styles.chipRow}>
-          {row.isDraft ? <Chip label={DRAFT_CHIP} /> : null}
-          {row.myVerdict === 'approved' ? <Chip label={APPROVED_CHIP} tone={brandColors.success} /> : null}
-          {row.myVerdict === 'declined' ? <Chip label={DECLINED_CHIP} tone={brandColors.error} /> : null}
-          {row.verdictIsStale ? <Chip label={HEAD_CHANGED_CHIP} tone={brandColors.warning} /> : null}
-          {row.refused ? <Chip label={CRASHED_CHIP} tone={brandColors.error} /> : null}
+          {row.isDraft ? <Chip label={t('qa.pick.draftChip')} /> : null}
+          {row.myVerdict === 'approved' ? <Chip label={t('qa.pick.approvedChip')} tone={brandColors.success} /> : null}
+          {row.myVerdict === 'declined' ? <Chip label={t('qa.pick.declinedChip')} tone={brandColors.error} /> : null}
+          {row.verdictIsStale ? <Chip label={t('qa.pick.headChangedChip')} tone={brandColors.warning} /> : null}
+          {row.refused ? <Chip label={t('qa.pick.crashedChip')} tone={brandColors.error} /> : null}
           {row.otaBuild === 'building' ? (
-            <Chip label={row.loadable ? BUILDING_NEWER_CHIP : BUILDING_CHIP} tone={brandColors.warning} />
+            <Chip
+              label={row.loadable ? t('qa.pick.buildingNewerChip') : t('qa.pick.buildingChip')}
+              tone={brandColors.warning}
+            />
           ) : null}
           {visibleLabels(row.labels).map((label) => (
             <Chip key={label.name} label={label.name} tone={labelChipColor(label.color, colorScheme) ?? undefined} />

--- a/packages/mobile/src/components/qa/__tests__/qa-brief-screen.test.tsx
+++ b/packages/mobile/src/components/qa/__tests__/qa-brief-screen.test.tsx
@@ -10,6 +10,33 @@ vi.mock('react-native', () => ({
 }));
 vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0, bottom: 0 }) }));
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    // Interpolates `{{name}}` like the real `t`, so assertions on toasts and
+    // labels match the string a tester actually reads.
+    t: (key: string, values?: Record<string, unknown>) => {
+      const template =
+        {
+          'actions.close': 'Close',
+          'userDrawer.qa.pick': 'Test a PR preview',
+          'qa.shared.backOnProduction': 'Back on production at the next update',
+          'qa.shared.leaveFailed': 'Could not switch off this preview — try again',
+          'qa.brief.screenTitle': 'What to test',
+          'qa.brief.startLabel': 'Start testing',
+          'qa.brief.finishLabel': 'Finish testing',
+          'qa.brief.githubLabel': 'Open on GitHub',
+          'qa.brief.leaveLabel': 'Leave preview',
+          'qa.brief.noPlanText': 'No test plan on this PR yet — open it on GitHub and use your judgement.',
+          'qa.brief.unknownPr': 'PR #{{prNumber}} is closed or unknown. Nothing here to test.',
+          'qa.brief.onProductionTitle': "You're on production",
+          'qa.brief.onProductionBody': 'Pick a PR preview to start testing one.',
+          'qa.brief.riskLabel': 'Risk {{risk}}/5',
+        }[key] ?? key;
+      return template.replace(/\{\{(\w+)\}\}/g, (_, name: string) => String(values?.[name] ?? ''));
+    },
+  }),
+}));
+
 const routerMock = vi.hoisted(() => ({ back: vi.fn(), replace: vi.fn() }));
 vi.mock('expo-router', () => ({
   router: routerMock,

--- a/packages/mobile/src/components/qa/__tests__/qa-pick-screen.test.tsx
+++ b/packages/mobile/src/components/qa/__tests__/qa-pick-screen.test.tsx
@@ -29,6 +29,33 @@ vi.mock('@shopify/flash-list', () => ({
 }));
 vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0, bottom: 0 }) }));
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    // Interpolates `{{name}}` like the real `t`, so assertions on toasts and
+    // labels match the string a tester actually reads.
+    t: (key: string, values?: Record<string, unknown>) => {
+      const template =
+        {
+          'qa.pick.title': 'Test a PR',
+          'qa.pick.skip': 'Skip',
+          'qa.pick.emptyTitle': 'Nothing to test right now',
+          'qa.pick.emptyBody': 'No PR has published a preview for this build yet. Check back after the next push.',
+          'qa.pick.surfingOffTitle': 'Previews are switched off',
+          'qa.pick.surfingOffBody': 'This channel is not serving PR previews at the moment.',
+          'qa.pick.unreachableTitle': 'Could not reach the update server',
+          'qa.pick.draftChip': 'Draft',
+          'qa.pick.approvedChip': 'You approved',
+          'qa.pick.declinedChip': 'You declined',
+          'qa.pick.headChangedChip': 'Head changed since',
+          'qa.pick.crashedChip': 'Crashed on launch',
+          'qa.pick.nothingNewToast':
+            'Nothing new for #{{prNumber}} on this build — its next publish applies on relaunch',
+        }[key] ?? key;
+      return template.replace(/\{\{(\w+)\}\}/g, (_, name: string) => String(values?.[name] ?? ''));
+    },
+  }),
+}));
+
 const routerMock = vi.hoisted(() => ({ back: vi.fn(), push: vi.fn() }));
 const params = vi.hoisted(() => ({
   prNumbers: undefined as string | undefined,

--- a/packages/mobile/src/components/qa/__tests__/qa-pick-screen.test.tsx
+++ b/packages/mobile/src/components/qa/__tests__/qa-pick-screen.test.tsx
@@ -50,6 +50,10 @@ vi.mock('react-i18next', () => ({
           'qa.pick.crashedChip': 'Crashed on launch',
           'qa.pick.nothingNewToast':
             'Nothing new for #{{prNumber}} on this build — its next publish applies on relaunch',
+          'qa.pick.buildingChip': 'Building',
+          'qa.pick.buildingNewerChip': 'Building newer',
+          'qa.pick.buildingToast': 'Still publishing — it appears here when the bundle lands',
+          'qa.pick.buildingHint': 'This preview is still publishing and cannot be loaded yet',
         }[key] ?? key;
       return template.replace(/\{\{(\w+)\}\}/g, (_, name: string) => String(values?.[name] ?? ''));
     },

--- a/packages/mobile/src/components/user-drawer/QaVerdictSheet.tsx
+++ b/packages/mobile/src/components/user-drawer/QaVerdictSheet.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useRef, useState, type RefObject } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
 import * as Updates from 'expo-updates';
+import { useTranslation } from 'react-i18next';
 import type { QaVerdictKind } from '@boardsesh/shared-schema';
 import { useProfile } from '../../lib/graphql/hooks';
 import { ModalSheet } from '../ModalSheet';
@@ -28,49 +29,16 @@ import {
 } from '../../lib/qa/qa-analytics';
 import type { ManagedSheetHandle } from '../../providers/sheet-presentation-provider';
 
-// Tester-only surface: hardcoded English with `i18n-ignore`, like the other QA
-// screens and the dev rows on the More tab.
+// This sheet was tester-only (hardcoded English, like the other QA screens and
+// the dev rows on the More tab) until it opened to every user in #5126.
+// `DEV_HINT` is the one string left English-only: it's a dev-build-only hint
+// no shipped user ever sees.
 
-// i18n-ignore-next-line — tester-only sheet
-const SHEET_TITLE = 'How did it go?';
-// i18n-ignore-next-line
-const CLOSE_LABEL = 'Close';
-// i18n-ignore-next-line
-const APPROVE_LABEL = 'Approve';
-// i18n-ignore-next-line
-const DECLINE_LABEL = 'Decline';
-// i18n-ignore-next-line
-const VERDICT_GROUP_LABEL = 'Verdict';
-// i18n-ignore-next-line
-const APPROVE_PLACEHOLDER = 'Anything worth noting? (optional)';
-// i18n-ignore-next-line
-const DECLINE_PLACEHOLDER = 'What went wrong? Steps help.';
-// i18n-ignore-next-line
-const SUBMIT_LABEL = 'Send verdict';
-// i18n-ignore-next-line
-const LEAVE_LABEL = 'Leave preview without feedback';
-// i18n-ignore-next-line
-const SUBMIT_ERROR = 'Could not send that verdict — try again';
-// i18n-ignore-next-line
-const BACK_ON_PRODUCTION_TOAST = 'Back on production at the next update';
-// Only the surf back failed; on the submit path the verdict has already landed
-// and been toasted, so saying "could not send that verdict" here would be a lie
-// about which half broke. The thrown message itself goes to Sentry and to the
-// event's `reason` rather than into the tester's face.
-// i18n-ignore-next-line
-const LEAVE_FAILED_TOAST = 'Could not switch off this preview — try again';
-// i18n-ignore-next-line
-const NOT_ON_PREVIEW = "You're on production — nothing to file a verdict on.";
-// i18n-ignore-next-line
+// i18n-ignore-next-line — dev-build-only hint, never shown in a shipped build
 const DEV_HINT = 'Surfing is unavailable in a dev build — the sheet will not switch back.';
 
 const DECLINE_COMMENT_MIN_LENGTH = 10;
 const COMMENT_MAX_LENGTH = 2000;
-
-const VERDICT_OPTIONS: { key: QaVerdictKind; label: string }[] = [
-  { key: 'approved', label: APPROVE_LABEL },
-  { key: 'declined', label: DECLINE_LABEL },
-];
 
 type QaVerdictSheetProps = {
   sheetRef: RefObject<ManagedSheetHandle | null>;
@@ -89,9 +57,18 @@ type QaVerdictSheetProps = {
  * live native presentation.
  */
 export function QaVerdictSheet({ sheetRef }: QaVerdictSheetProps) {
+  const { t } = useTranslation('common');
   const { systemColors, brandColors } = useTheme();
   const { showToast } = useToast();
   const { mutateAsync, isPending } = useSubmitQaVerdict();
+
+  const verdictOptions = useMemo<{ key: QaVerdictKind; label: string }[]>(
+    () => [
+      { key: 'approved', label: t('qa.verdict.approveLabel') },
+      { key: 'declined', label: t('qa.verdict.declineLabel') },
+    ],
+    [t],
+  );
 
   const runningPrNumber = useMemo(() => readRunningPrNumber(), []);
   const prNumbers = useMemo(() => (runningPrNumber === null ? [] : [runningPrNumber]), [runningPrNumber]);
@@ -126,14 +103,18 @@ export function QaVerdictSheet({ sheetRef }: QaVerdictSheetProps) {
         // Production is not *newer* than a fresh pr-N bundle, so the running JS
         // usually stays put until production publishes again. The branch pin is
         // gone either way, which is the part that matters.
-        if (outcome === 'nothing-to-load') showToast(BACK_ON_PRODUCTION_TOAST, 'info');
+        if (outcome === 'nothing-to-load') showToast(t('qa.shared.backOnProduction'), 'info');
       })
       .catch((error: unknown) => {
         reportHandledError(error, { tags: { source: 'qa', op: 'surf-to-production' } });
         track(QA_SURF_FAILED_EVENT, { prNumber: null, reason: surfFailureReason(error) });
-        showToast(LEAVE_FAILED_TOAST, 'error');
+        // Only the surf back failed; on the submit path the verdict has already
+        // landed and been toasted, so saying "could not send that verdict" here
+        // would be a lie about which half broke. The thrown message itself goes
+        // to Sentry and to the event's `reason` rather than into the tester's face.
+        showToast(t('qa.shared.leaveFailed'), 'error');
       });
-  }, [showToast, surfingAvailable]);
+  }, [showToast, surfingAvailable, t]);
 
   const handleFullyDismissed = useCallback(() => {
     if (!leaveAfterDismissRef.current) return;
@@ -157,8 +138,7 @@ export function QaVerdictSheet({ sheetRef }: QaVerdictSheetProps) {
       // so the marker is what stops the gate re-prompting.
       setSetting('qaVerdictSubmittedKey', qaSessionKey(userId, branch, Updates.updateId));
       track(QA_VERDICT_SUBMITTED_EVENT, { prNumber: runningPrNumber, verdict, risk: preview?.risk ?? null });
-      // i18n-ignore-next-line
-      showToast(`Verdict sent to #${runningPrNumber}`, 'success');
+      showToast(t('qa.verdict.verdictSentToast', { prNumber: runningPrNumber }), 'success');
       leaveAfterDismissRef.current = true;
       sheetRef.current?.dismiss();
       // The sheet lives at the provider root for the whole app session, so it is
@@ -168,7 +148,7 @@ export function QaVerdictSheet({ sheetRef }: QaVerdictSheetProps) {
       setComment('');
     } catch (error) {
       reportHandledError(error, { tags: { source: 'qa', op: 'submit-verdict' } });
-      showToast(SUBMIT_ERROR, 'error');
+      showToast(t('qa.verdict.submitError'), 'error');
     }
   };
 
@@ -178,7 +158,8 @@ export function QaVerdictSheet({ sheetRef }: QaVerdictSheetProps) {
     sheetRef.current?.dismiss();
   };
 
-  const title = runningPrNumber === null ? SHEET_TITLE : `#${runningPrNumber} ${preview?.title ?? ''}`.trim();
+  const title =
+    runningPrNumber === null ? t('qa.verdict.sheetTitle') : `#${runningPrNumber} ${preview?.title ?? ''}`.trim();
 
   return (
     <ModalSheet
@@ -198,7 +179,7 @@ export function QaVerdictSheet({ sheetRef }: QaVerdictSheetProps) {
           feedback="opacity"
           hitSlop={8}
           accessibilityRole="button"
-          accessibilityLabel={CLOSE_LABEL}
+          accessibilityLabel={t('actions.close')}
           style={styles.closeButton}
         >
           <Icon name="close" size={20} color={systemColors.secondaryLabel} />
@@ -207,15 +188,15 @@ export function QaVerdictSheet({ sheetRef }: QaVerdictSheetProps) {
 
       {runningPrNumber === null ? (
         <Text variant="subheadline" color={systemColors.secondaryLabel}>
-          {NOT_ON_PREVIEW}
+          {t('qa.verdict.notOnPreview')}
         </Text>
       ) : null}
 
       <SegmentedControl<QaVerdictKind>
-        options={VERDICT_OPTIONS}
+        options={verdictOptions}
         selectedKey={verdict}
         onSelect={setVerdict}
-        accessibilityLabel={VERDICT_GROUP_LABEL}
+        accessibilityLabel={t('qa.verdict.verdictGroupLabel')}
         tint={verdict === 'declined' ? brandColors.error : brandColors.success}
       />
 
@@ -228,7 +209,7 @@ export function QaVerdictSheet({ sheetRef }: QaVerdictSheetProps) {
             color: systemColors.label,
           },
         ]}
-        placeholder={verdict === 'declined' ? DECLINE_PLACEHOLDER : APPROVE_PLACEHOLDER}
+        placeholder={verdict === 'declined' ? t('qa.verdict.declinePlaceholder') : t('qa.verdict.approvePlaceholder')}
         placeholderTextColor={systemColors.tertiaryLabel}
         value={comment}
         onChangeText={setComment}
@@ -239,8 +220,7 @@ export function QaVerdictSheet({ sheetRef }: QaVerdictSheetProps) {
 
       {verdict === 'declined' && remainingDeclineChars > 0 ? (
         <Text variant="footnote" color={systemColors.secondaryLabel} style={styles.helperText}>
-          {/* i18n-ignore-next-line */}
-          {`${remainingDeclineChars} more characters needed`}
+          {t('qa.verdict.moreCharsNeeded', { count: remainingDeclineChars })}
         </Text>
       ) : null}
 
@@ -251,7 +231,7 @@ export function QaVerdictSheet({ sheetRef }: QaVerdictSheetProps) {
       ) : null}
 
       <Button
-        title={SUBMIT_LABEL}
+        title={t('qa.verdict.submitLabel')}
         onPress={() => {
           void handleSubmit();
         }}
@@ -263,7 +243,7 @@ export function QaVerdictSheet({ sheetRef }: QaVerdictSheetProps) {
       />
 
       <Button
-        title={LEAVE_LABEL}
+        title={t('qa.verdict.leaveLabel')}
         onPress={handleLeaveWithoutFeedback}
         variant="text"
         size="large"

--- a/packages/mobile/src/components/user-drawer/__tests__/QaVerdictSheet.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/QaVerdictSheet.test.tsx
@@ -98,6 +98,14 @@ vi.mock('react-i18next', () => ({
     // Interpolates `{{name}}` like the real `t`, so assertions on toasts and
     // labels match the string a tester actually reads.
     t: (key: string, values?: Record<string, unknown>) => {
+      // i18next picks the `_one`/`_other` variant from `count`; mirror that
+      // here rather than hardcoding one form, so a test can't drift from the
+      // pluralization the real catalog enforces.
+      if (key === 'qa.verdict.moreCharsNeeded') {
+        const count = Number(values?.count ?? 0);
+        const template = count === 1 ? '{{count}} more character needed' : '{{count}} more characters needed';
+        return template.replace('{{count}}', String(count));
+      }
       const template =
         {
           'actions.close': 'Close',
@@ -114,7 +122,6 @@ vi.mock('react-i18next', () => ({
           'qa.verdict.submitError': 'Could not send that verdict — try again',
           'qa.verdict.notOnPreview': "You're on production — nothing to file a verdict on.",
           'qa.verdict.verdictSentToast': 'Verdict sent to #{{prNumber}}',
-          'qa.verdict.moreCharsNeeded': '{{count}} more characters needed',
         }[key] ?? key;
       return template.replace(/\{\{(\w+)\}\}/g, (_, name: string) => String(values?.[name] ?? ''));
     },

--- a/packages/mobile/src/components/user-drawer/__tests__/QaVerdictSheet.test.tsx
+++ b/packages/mobile/src/components/user-drawer/__tests__/QaVerdictSheet.test.tsx
@@ -93,6 +93,34 @@ vi.mock('../../../providers/theme-provider', () => ({
 const showToast = vi.hoisted(() => vi.fn());
 vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast }) }));
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    // Interpolates `{{name}}` like the real `t`, so assertions on toasts and
+    // labels match the string a tester actually reads.
+    t: (key: string, values?: Record<string, unknown>) => {
+      const template =
+        {
+          'actions.close': 'Close',
+          'qa.shared.backOnProduction': 'Back on production at the next update',
+          'qa.shared.leaveFailed': 'Could not switch off this preview — try again',
+          'qa.verdict.sheetTitle': 'How did it go?',
+          'qa.verdict.approveLabel': 'Approve',
+          'qa.verdict.declineLabel': 'Decline',
+          'qa.verdict.verdictGroupLabel': 'Verdict',
+          'qa.verdict.approvePlaceholder': 'Anything worth noting? (optional)',
+          'qa.verdict.declinePlaceholder': 'What went wrong? Steps help.',
+          'qa.verdict.submitLabel': 'Send verdict',
+          'qa.verdict.leaveLabel': 'Leave preview without feedback',
+          'qa.verdict.submitError': 'Could not send that verdict — try again',
+          'qa.verdict.notOnPreview': "You're on production — nothing to file a verdict on.",
+          'qa.verdict.verdictSentToast': 'Verdict sent to #{{prNumber}}',
+          'qa.verdict.moreCharsNeeded': '{{count}} more characters needed',
+        }[key] ?? key;
+      return template.replace(/\{\{(\w+)\}\}/g, (_, name: string) => String(values?.[name] ?? ''));
+    },
+  }),
+}));
+
 const setSettingMock = vi.hoisted(() => vi.fn());
 vi.mock('../../../settings', () => ({ setSetting: setSettingMock }));
 

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -649,7 +649,8 @@
       "submitError": "Das Urteil konnte nicht gesendet werden — versuch es noch mal",
       "notOnPreview": "Du bist auf Produktion — hier gibt es nichts zu beurteilen.",
       "verdictSentToast": "Urteil für #{{prNumber}} gesendet",
-      "moreCharsNeeded": "Noch {{count}} Zeichen nötig"
+      "moreCharsNeeded_one": "Noch {{count}} Zeichen nötig",
+      "moreCharsNeeded_other": "Noch {{count}} Zeichen nötig"
     }
   },
   "loading": {

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -601,6 +601,57 @@
       "badge": "QA"
     }
   },
+  "qa": {
+    "shared": {
+      "backOnProduction": "Zurück auf Produktion bei der nächsten Aktualisierung",
+      "leaveFailed": "Diese Vorschau konnte nicht deaktiviert werden — versuch es noch mal"
+    },
+    "pick": {
+      "title": "PR testen",
+      "skip": "Überspringen",
+      "emptyTitle": "Gerade nichts zu testen",
+      "emptyBody": "Für diesen Build hat noch kein PR eine Vorschau veröffentlicht. Schau nach dem nächsten Push wieder vorbei.",
+      "surfingOffTitle": "Vorschauen sind ausgeschaltet",
+      "surfingOffBody": "Dieser Kanal liefert derzeit keine PR-Vorschauen.",
+      "unreachableTitle": "Update-Server nicht erreichbar",
+      "draftChip": "Entwurf",
+      "approvedChip": "Du hast zugestimmt",
+      "declinedChip": "Du hast abgelehnt",
+      "headChangedChip": "Head hat sich seitdem geändert",
+      "crashedChip": "Beim Start abgestürzt",
+      "nothingNewToast": "Nichts Neues für #{{prNumber}} in diesem Build — die nächste Veröffentlichung greift beim nächsten Neustart",
+      "buildingChip": "Wird gebaut",
+      "buildingNewerChip": "Neuere Version wird gebaut",
+      "buildingToast": "Wird noch veröffentlicht — erscheint hier, sobald der Build fertig ist",
+      "buildingHint": "Diese Vorschau wird noch veröffentlicht und kann noch nicht geladen werden"
+    },
+    "brief": {
+      "screenTitle": "Was du testen sollst",
+      "startLabel": "Test starten",
+      "finishLabel": "Test abschließen",
+      "githubLabel": "Auf GitHub öffnen",
+      "leaveLabel": "Vorschau verlassen",
+      "noPlanText": "Für diesen PR gibt es noch keinen Testplan — öffne ihn auf GitHub und nutze dein eigenes Urteil.",
+      "unknownPr": "PR #{{prNumber}} ist geschlossen oder unbekannt. Hier gibt es nichts zu testen.",
+      "onProductionTitle": "Du bist auf Produktion",
+      "onProductionBody": "Wähl eine PR-Vorschau, um mit dem Testen zu beginnen.",
+      "riskLabel": "Risiko {{risk}}/5"
+    },
+    "verdict": {
+      "sheetTitle": "Wie lief's?",
+      "approveLabel": "Zustimmen",
+      "declineLabel": "Ablehnen",
+      "verdictGroupLabel": "Urteil",
+      "approvePlaceholder": "Etwas Erwähnenswertes? (optional)",
+      "declinePlaceholder": "Was ist schiefgelaufen? Schritte helfen.",
+      "submitLabel": "Urteil senden",
+      "leaveLabel": "Vorschau ohne Feedback verlassen",
+      "submitError": "Das Urteil konnte nicht gesendet werden — versuch es noch mal",
+      "notOnPreview": "Du bist auf Produktion — hier gibt es nichts zu beurteilen.",
+      "verdictSentToast": "Urteil für #{{prNumber}} gesendet",
+      "moreCharsNeeded": "Noch {{count}} Zeichen nötig"
+    }
+  },
   "loading": {
     "messages": [
       "Dein Board wird eingerichtet...",

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -601,6 +601,57 @@
       "badge": "QA"
     }
   },
+  "qa": {
+    "shared": {
+      "backOnProduction": "Back on production at the next update",
+      "leaveFailed": "Could not switch off this preview — try again"
+    },
+    "pick": {
+      "title": "Test a PR",
+      "skip": "Skip",
+      "emptyTitle": "Nothing to test right now",
+      "emptyBody": "No PR has published a preview for this build yet. Check back after the next push.",
+      "surfingOffTitle": "Previews are switched off",
+      "surfingOffBody": "This channel is not serving PR previews at the moment.",
+      "unreachableTitle": "Could not reach the update server",
+      "draftChip": "Draft",
+      "approvedChip": "You approved",
+      "declinedChip": "You declined",
+      "headChangedChip": "Head changed since",
+      "crashedChip": "Crashed on launch",
+      "nothingNewToast": "Nothing new for #{{prNumber}} on this build — its next publish applies on relaunch",
+      "buildingChip": "Building",
+      "buildingNewerChip": "Building newer",
+      "buildingToast": "Still publishing — it appears here when the bundle lands",
+      "buildingHint": "This preview is still publishing and cannot be loaded yet"
+    },
+    "brief": {
+      "screenTitle": "What to test",
+      "startLabel": "Start testing",
+      "finishLabel": "Finish testing",
+      "githubLabel": "Open on GitHub",
+      "leaveLabel": "Leave preview",
+      "noPlanText": "No test plan on this PR yet — open it on GitHub and use your judgement.",
+      "unknownPr": "PR #{{prNumber}} is closed or unknown. Nothing here to test.",
+      "onProductionTitle": "You're on production",
+      "onProductionBody": "Pick a PR preview to start testing one.",
+      "riskLabel": "Risk {{risk}}/5"
+    },
+    "verdict": {
+      "sheetTitle": "How did it go?",
+      "approveLabel": "Approve",
+      "declineLabel": "Decline",
+      "verdictGroupLabel": "Verdict",
+      "approvePlaceholder": "Anything worth noting? (optional)",
+      "declinePlaceholder": "What went wrong? Steps help.",
+      "submitLabel": "Send verdict",
+      "leaveLabel": "Leave preview without feedback",
+      "submitError": "Could not send that verdict — try again",
+      "notOnPreview": "You're on production — nothing to file a verdict on.",
+      "verdictSentToast": "Verdict sent to #{{prNumber}}",
+      "moreCharsNeeded": "{{count}} more characters needed"
+    }
+  },
   "loading": {
     "messages": [
       "Setting up your board...",

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -649,7 +649,8 @@
       "submitError": "Could not send that verdict — try again",
       "notOnPreview": "You're on production — nothing to file a verdict on.",
       "verdictSentToast": "Verdict sent to #{{prNumber}}",
-      "moreCharsNeeded": "{{count}} more characters needed"
+      "moreCharsNeeded_one": "{{count}} more character needed",
+      "moreCharsNeeded_other": "{{count}} more characters needed"
     }
   },
   "loading": {

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -130,7 +130,8 @@
       "submitError": "No se pudo enviar el veredicto — inténtalo de nuevo",
       "notOnPreview": "Estás en producción — no hay nada sobre lo que dar un veredicto.",
       "verdictSentToast": "Veredicto enviado para el #{{prNumber}}",
-      "moreCharsNeeded": "Faltan {{count}} caracteres"
+      "moreCharsNeeded_one": "Falta {{count}} carácter",
+      "moreCharsNeeded_other": "Faltan {{count}} caracteres"
     }
   },
   "loading": {

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -82,6 +82,57 @@
       "badge": "QA"
     }
   },
+  "qa": {
+    "shared": {
+      "backOnProduction": "De vuelta en producción en la próxima actualización",
+      "leaveFailed": "No se pudo desactivar esta vista previa — inténtalo de nuevo"
+    },
+    "pick": {
+      "title": "Prueba un PR",
+      "skip": "Omitir",
+      "emptyTitle": "Nada que probar por ahora",
+      "emptyBody": "Ningún PR ha publicado una vista previa para esta versión todavía. Vuelve a mirar después del próximo push.",
+      "surfingOffTitle": "Las vistas previas están desactivadas",
+      "surfingOffBody": "Este canal no está sirviendo vistas previas de PR en este momento.",
+      "unreachableTitle": "No se pudo contactar con el servidor de actualizaciones",
+      "draftChip": "Borrador",
+      "approvedChip": "Aprobaste",
+      "declinedChip": "Rechazaste",
+      "headChangedChip": "El head cambió desde entonces",
+      "crashedChip": "Se cerró al abrir",
+      "nothingNewToast": "No hay nada nuevo para el #{{prNumber}} en esta versión — su próxima publicación se aplicará al reabrir",
+      "buildingChip": "Compilando",
+      "buildingNewerChip": "Compilando una más reciente",
+      "buildingToast": "Todavía se está publicando — aparecerá aquí cuando el paquete esté listo",
+      "buildingHint": "Esta vista previa se sigue publicando y aún no se puede cargar"
+    },
+    "brief": {
+      "screenTitle": "Qué probar",
+      "startLabel": "Empezar a probar",
+      "finishLabel": "Terminar de probar",
+      "githubLabel": "Abrir en GitHub",
+      "leaveLabel": "Salir de la vista previa",
+      "noPlanText": "Este PR no tiene plan de pruebas todavía — ábrelo en GitHub y usa tu criterio.",
+      "unknownPr": "El PR #{{prNumber}} está cerrado o no se encuentra. No hay nada que probar aquí.",
+      "onProductionTitle": "Estás en producción",
+      "onProductionBody": "Elige una vista previa de PR para empezar a probarla.",
+      "riskLabel": "Riesgo {{risk}}/5"
+    },
+    "verdict": {
+      "sheetTitle": "¿Qué tal fue?",
+      "approveLabel": "Aprobar",
+      "declineLabel": "Rechazar",
+      "verdictGroupLabel": "Veredicto",
+      "approvePlaceholder": "¿Algo que valga la pena anotar? (opcional)",
+      "declinePlaceholder": "¿Qué salió mal? Los pasos ayudan.",
+      "submitLabel": "Enviar veredicto",
+      "leaveLabel": "Salir de la vista previa sin comentarios",
+      "submitError": "No se pudo enviar el veredicto — inténtalo de nuevo",
+      "notOnPreview": "Estás en producción — no hay nada sobre lo que dar un veredicto.",
+      "verdictSentToast": "Veredicto enviado para el #{{prNumber}}",
+      "moreCharsNeeded": "Faltan {{count}} caracteres"
+    }
+  },
   "loading": {
     "messages": [
       "Preparando tu plafón...",

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -649,7 +649,8 @@
       "submitError": "Impossible d'envoyer ce verdict — réessaie",
       "notOnPreview": "Tu es en production — rien sur quoi donner un verdict.",
       "verdictSentToast": "Verdict envoyé pour le #{{prNumber}}",
-      "moreCharsNeeded": "Encore {{count}} caractères nécessaires"
+      "moreCharsNeeded_one": "Encore {{count}} caractère nécessaire",
+      "moreCharsNeeded_other": "Encore {{count}} caractères nécessaires"
     }
   },
   "loading": {

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -601,6 +601,57 @@
       "badge": "QA"
     }
   },
+  "qa": {
+    "shared": {
+      "backOnProduction": "De retour en production à la prochaine mise à jour",
+      "leaveFailed": "Impossible de désactiver cet aperçu — réessaie"
+    },
+    "pick": {
+      "title": "Tester un PR",
+      "skip": "Passer",
+      "emptyTitle": "Rien à tester pour le moment",
+      "emptyBody": "Aucun PR n'a encore publié d'aperçu pour cette version. Reviens après le prochain push.",
+      "surfingOffTitle": "Les aperçus sont désactivés",
+      "surfingOffBody": "Ce canal ne diffuse pas d'aperçus de PR pour le moment.",
+      "unreachableTitle": "Impossible de joindre le serveur de mises à jour",
+      "draftChip": "Brouillon",
+      "approvedChip": "Tu as approuvé",
+      "declinedChip": "Tu as refusé",
+      "headChangedChip": "Le head a changé depuis",
+      "crashedChip": "Plantage au lancement",
+      "nothingNewToast": "Rien de nouveau pour le #{{prNumber}} sur cette version — sa prochaine publication s'appliquera au prochain relancement",
+      "buildingChip": "En cours de build",
+      "buildingNewerChip": "Nouveau build en cours",
+      "buildingToast": "Toujours en cours de publication — il apparaîtra ici une fois le build prêt",
+      "buildingHint": "Cet aperçu est encore en cours de publication et ne peut pas être chargé pour l'instant"
+    },
+    "brief": {
+      "screenTitle": "Quoi tester",
+      "startLabel": "Commencer le test",
+      "finishLabel": "Terminer le test",
+      "githubLabel": "Ouvrir sur GitHub",
+      "leaveLabel": "Quitter l'aperçu",
+      "noPlanText": "Ce PR n'a pas encore de plan de test — ouvre-le sur GitHub et fie-toi à ton jugement.",
+      "unknownPr": "Le PR #{{prNumber}} est fermé ou introuvable. Rien à tester ici.",
+      "onProductionTitle": "Tu es en production",
+      "onProductionBody": "Choisis un aperçu de PR pour commencer à le tester.",
+      "riskLabel": "Risque {{risk}}/5"
+    },
+    "verdict": {
+      "sheetTitle": "Comment ça s'est passé ?",
+      "approveLabel": "Approuver",
+      "declineLabel": "Refuser",
+      "verdictGroupLabel": "Verdict",
+      "approvePlaceholder": "Quelque chose à signaler ? (facultatif)",
+      "declinePlaceholder": "Qu'est-ce qui n'a pas marché ? Les étapes aident.",
+      "submitLabel": "Envoyer le verdict",
+      "leaveLabel": "Quitter l'aperçu sans donner d'avis",
+      "submitError": "Impossible d'envoyer ce verdict — réessaie",
+      "notOnPreview": "Tu es en production — rien sur quoi donner un verdict.",
+      "verdictSentToast": "Verdict envoyé pour le #{{prNumber}}",
+      "moreCharsNeeded": "Encore {{count}} caractères nécessaires"
+    }
+  },
   "loading": {
     "messages": [
       "Préparation de la board...",


### PR DESCRIPTION
## Summary

The three mobile QA-preview screens (`QaPickScreen`, `QaBriefScreen`, `QaVerdictSheet`) were tester-only and hardcoded English. #5126 opened the whole preview flow to every user, but left these three screens untranslated to keep that PR's size down — so a device set to Spanish/French/German now hits the localized `userDrawer.qa.*` / `mobile.more.previews.*` menu rows and then lands on an all-English pick list, brief, and verdict sheet.

This PR adds a `qa.*` section to the `common` catalog (`en-US`, `es`, `fr`, `de`) and switches the three screens (plus their `Chip`/`Placard`/row sub-components) to read from it via `useTranslation('common')`. A few strings are reused rather than duplicated (`actions.close`, `userDrawer.qa.pick`). The one exception is `DEV_HINT` in each file — a dev-build-only hint no shipped user ever sees — which stays hardcoded English with `// i18n-ignore-next-line`, per the issue's own suggestion.

Closes #5128

Author-side verification:
- `vp run typecheck:mobile` — clean
- `vp test run --project mobile` — 8265/8265 passing (updated the existing `qa-pick-screen.test.tsx`, `qa-brief-screen.test.tsx`, and `QaVerdictSheet.test.tsx` suites to mock `react-i18next` with the real catalog strings, matching the existing pattern in `user-drawer-provider.test.tsx`)
- `vp test run --project i18n` (catalog completeness + placeholder parity across en-US/es/fr/de) — passing
- `vp run check:i18n:orphans` — passing (no orphaned or unresolved keys)
- `vp check` — 0 errors

## Release Notes

- [ ] No release note needed (internal / technical change)

Testing a PR preview, leaving one, and filing a verdict now show up in your language.

## Test plan

1. Set device language to Spanish (or French/German), open the app.
2. Open the user drawer → tap the previews row → pick list shows Spanish text (no English titles/buttons).
3. Tap a PR row → the "what to test" brief screen is fully Spanish.
4. Tap "Finish testing" → the verdict sheet (title, buttons, placeholders) is Spanish.
5. Submit a verdict → the confirmation toast reads in Spanish.

## Risk

Risk: 2/5 — copy-only change behind existing i18n plumbing, no new screens or data writes; covered by existing component tests plus the catalog-completeness suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEL9s6u2Tjxtw68whtXRkD

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEL9s6u2Tjxtw68whtXRkD)_