### PR TITLE
test(shared): drop the Woods ring quarantine now every shipped outline covers its bolt

### DIFF
--- a/packages/shared/board-art-geometry/src/__tests__/ring.test.ts
+++ b/packages/shared/board-art-geometry/src/__tests__/ring.test.ts
@@ -346,20 +346,7 @@ describe('the centre gate the write path applies', () => {
 
     expect(outlinesChecked).toBeGreaterThan(10_000);
 
-    // QUARANTINE, not an exemption — see #4880. These five Woods holds ship an
-    // outline the write gate refuses, which means they are the one thing this
-    // invariant exists to rule out: a hold nobody can correct, because the
-    // correction is what the gate rejects. CENTRE_TOLERANCE_RADII was calibrated
-    // on Kilter (worst shipped miss 0.03 radii) before Woods shipped any shard;
-    // Woods' outlines are small polygons that routinely sit off to one side of
-    // their bolt, out to 0.322. Fixing it is a call about the tolerance or the
-    // Woods tracing, not something a test should decide — so the list is
-    // asserted as a ceiling and deleted with the fix.
-    const quarantined = new Set(['woods/1-2#330', 'woods/1-2#375', 'woods/1-2#402', 'woods/1-2#456', 'woods/1-2#470']);
-    expect(failing.filter((entry) => !quarantined.has(entry))).toEqual([]);
-    // Subset, not equality, so the fix does not have to touch this file — but
-    // the quarantine can never grow without someone saying so here.
-    expect(failing.length).toBeLessThanOrEqual(quarantined.size);
+    expect(failing).toEqual([]);
 
     // The tolerance is meant to rescue the occasional concave hold, not to paper
     // over a tracer that routinely puts a bolt outside its own silhouette.
@@ -368,7 +355,9 @@ describe('the centre gate the write path applies', () => {
     // when the shipped boards were Kilter and friends, and Woods alone brought
     // 34 the day its shards landed. A count that has to be renumbered per board
     // measures the catalogue; the share measures the tracer, which is the thing
-    // worth asserting. Currently ~0.3% (49 of ~16,400).
-    expect(missingTheirCentre.length / outlinesChecked).toBeLessThan(0.01);
+    // worth asserting. Currently 0.02% (4 of 16,603) — the Woods retrace (#4971)
+    // dropped the empty mounting slots it had been tracing, which is what left
+    // bolts outside their own silhouette, so the bar tightens with it.
+    expect(missingTheirCentre.length / outlinesChecked).toBeLessThan(0.001);
   });
 });


### PR DESCRIPTION
## Summary

Closes #4880.

The five quarantined `woods/1-2` holds — 330, 375, 402, 456, 470 — turned out to be empty mounting slots the old tracer outlined anyway. That is why their rings sat up to 0.322 radii off the bolt: there was no hold under them to sit on. The Woods recalibration in #4971 (PR #5140) traces only the physical holds, so those five now carry no outline at all, and the placements around them (329, 331, 373, 376, 455, 457, 469, 471) all still do.

A full sweep of the committed shards on `main` today:

- 51 shards, 16,603 outlines
- **0** fail the write gate (`pointInRing || distanceToRing <= 0.25`)
- 4 miss their own centre at all, worst 0.051 radii (`kilter/1-28#4810`); Woods contributes **0**, down from 34

So `CENTRE_TOLERANCE_RADII` needs no change — option 3 from the issue happened on its own. This PR deletes the quarantine, restores the plain `expect(failing).toEqual([])`, and tightens the tracer-quality bound from 1% to 0.1% (current value 0.02%, so ~4x headroom).

Validation: `vp test run packages/shared/board-art-geometry packages/shared/board-render` — 20 files, 321 tests pass.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 1/5 — test-only; deletes a quarantine and tightens one bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwJWZqbYEdg9zAT6GijopW
