### PR TITLE
feat(mobile): show a heart on favourited climbs in the list

### DIFF
--- a/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
+++ b/packages/mobile/app/(tabs)/climbs/__tests__/index-keyboard.test.tsx
@@ -124,6 +124,12 @@ vi.mock('../../../../src/lib/onboarding/onboarding-storage', () => ({
   clearBoardRevealTipPending: vi.fn(async () => {}),
 }));
 
+// The favourite-hearts fetcher reads the signed-in user's id, which reaches
+// `expo-secure-store` (a native module) through `local-user-id`. Stub the hook
+// so this screen test doesn't pull the native graph in for an id it never uses.
+vi.mock('../../../../src/hooks/use-current-user-id', () => ({
+  useStoredUserId: () => ({ userId: undefined, isLoading: false }),
+}));
 vi.mock('expo-crypto', () => ({ randomUUID: () => 'queue-item-1' }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
 

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -63,6 +63,7 @@ import { useGrades } from '../../../src/lib/graphql/hooks';
 import { useGradeFormat } from '../../../src/hooks/use-grade-format';
 import { useLastUsedGrade } from '../../../src/hooks/use-last-used-grade';
 import { useClimbListPlaylistMemberships } from '../../../src/hooks/use-climb-list-playlist-memberships';
+import { useClimbListFavorites } from '../../../src/hooks/use-climb-list-favorites';
 import { useInfiniteSearchClimbs } from '../../../src/lib/graphql/hooks/use-infinite-search-climbs';
 import { offlineAwareRequest } from '../../../src/lib/graphql/offline-request';
 import { isOfflineSearchSupported } from '../../../src/db/queries/search-climbs-local';
@@ -746,6 +747,11 @@ function ClimbListInner() {
   const visibleClimbUuids = useMemo(() => visibleClimbs.map((climb) => climb.uuid), [visibleClimbs]);
   useClimbListPlaylistMemberships({ boardName, layoutId, climbUuids: visibleClimbUuids });
 
+  // Same batched shape for the favourite hearts: fetch the visible UUIDs' state
+  // once per board+angle and write it into `favoritesStore`, which each row's
+  // heart subscribes to per-uuid.
+  useClimbListFavorites({ boardName, angle, climbUuids: visibleClimbUuids });
+
   const handleRefresh = useCallback(() => {
     isLoadingMoreRef.current = false;
     void refetch();
@@ -1376,6 +1382,7 @@ function ClimbListInner() {
         onOpenPlaylist={openAddToPlaylist}
         onAddToQueue={handleAddToQueue}
         showPlaylistChips
+        showFavorite
         showMoreButton={quickActionsButtonEnabled}
       />
     ),

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -13,6 +13,7 @@ import { Icon } from './Icon';
 import { ClimbAttributeIcons } from './ClimbAttributeIcons';
 import { ClimbPlaylistChips } from './ClimbPlaylistChips';
 import { isClimbResolved } from '../lib/queue-climb-resolution';
+import { useIsClimbFavorited } from '../hooks/use-is-climb-favorited';
 import type { IconName } from './icon-map';
 import type { AscentStatusValue } from '../lib/ascent-status-utils';
 
@@ -109,7 +110,39 @@ type ClimbListItemContentProps = {
    * fetched membership data, so passing `true` alone doesn't force them on.
    */
   showPlaylistChips?: boolean;
+  /**
+   * Render the favourite heart beside the ascent status. Opt-in per surface
+   * (default off) for the same reason as `showPlaylistChips`: only the main
+   * climb list feeds `favoritesStore` with its visible UUIDs, so a queue or
+   * session row would otherwise show a heart on the climbs you happened to
+   * scroll past and nothing on the rest.
+   */
+  showFavorite?: boolean;
 };
+
+/**
+ * Isolated, memoized favourite heart. Same boundary as `AscentStatusGlyph`: the
+ * only part of the row subscribed to `favoritesStore`, over a primitive uuid, so
+ * favouriting one climb re-renders one 14px icon rather than every visible row.
+ *
+ * Filled rather than outlined, and drawn in the platform's favourite colour
+ * (`actionColors.favorite` — red under Material, monochrome under Liquid Glass,
+ * matching the heart in the actions sheet). Renders nothing when the climb isn't
+ * favourited, which is the common case, so it costs an unfavourited row nothing
+ * but the subscription.
+ */
+const FavoriteGlyph = React.memo(function FavoriteGlyph({ climbUuid }: { climbUuid: string }) {
+  const { t } = useTranslation('climbs');
+  const { actionColors } = useTheme();
+  const isFavorited = useIsClimbFavorited(climbUuid);
+
+  if (!isFavorited) return null;
+  return (
+    <View accessibilityRole="image" accessibilityLabel={t('mobile.climbRow.favorited')}>
+      <Icon name="favorite.fill" size={14} color={actionColors.favorite} />
+    </View>
+  );
+});
 
 /**
  * Isolated, memoized ascent-status glyph. It is the ONLY part of the climb row
@@ -264,6 +297,7 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
   consensusGrade,
   gradeIsConsensus = false,
   showPlaylistChips = false,
+  showFavorite = false,
 }: ClimbListItemContentProps) {
   const { t: tSession } = useTranslation('session');
 
@@ -343,8 +377,9 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
         {showPlaylistChips ? <ClimbPlaylistChips climbUuid={climb.uuid} /> : null}
       </View>
 
-      {/* Right: ascent-status glyph + colorized grade — the two scan keys together */}
+      {/* Right: favourite heart + ascent-status glyph + colorized grade */}
       <View style={styles.rightSection}>
+        {showFavorite ? <FavoriteGlyph climbUuid={climb.uuid} /> : null}
         {showAscentStatus ? <AscentStatusGlyph climbUuid={climb.uuid} angle={angle} /> : null}
         <LiveClimbGrade
           climb={climb}

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -125,21 +125,26 @@ type ClimbListItemContentProps = {
  * only part of the row subscribed to `favoritesStore`, over a primitive uuid, so
  * favouriting one climb re-renders one 14px icon rather than every visible row.
  *
- * Filled rather than outlined, and drawn in the platform's favourite colour
- * (`actionColors.favorite` — red under Material, monochrome under Liquid Glass,
- * matching the heart in the actions sheet). Renders nothing when the climb isn't
- * favourited, which is the common case, so it costs an unfavourited row nothing
- * but the subscription.
+ * Same neutral grey and size as the ascent-status glyph it sits beside, for the
+ * reason given above `ASCENT_STATUS_ICON`: this cluster carries meaning by glyph
+ * SHAPE, leaving colour to mean grade and nothing else. A red heart here would
+ * read as a third colour signal next to the colour-coded grade and would carry
+ * its meaning in a way colour-blind users can't see. The filled silhouette is
+ * what distinguishes it — the actions sheet keeps the red heart, where it's a
+ * control rather than a scan-line marker.
+ *
+ * Renders nothing when the climb isn't favourited, which is the common case, so
+ * it costs an unfavourited row nothing but the subscription.
  */
 const FavoriteGlyph = React.memo(function FavoriteGlyph({ climbUuid }: { climbUuid: string }) {
   const { t } = useTranslation('climbs');
-  const { actionColors } = useTheme();
+  const theme = useTheme();
   const isFavorited = useIsClimbFavorited(climbUuid);
 
   if (!isFavorited) return null;
   return (
     <View accessibilityRole="image" accessibilityLabel={t('mobile.climbRow.favorited')}>
-      <Icon name="favorite.fill" size={14} color={actionColors.favorite} />
+      <Icon name="favorite.fill" size={16} color={theme.systemColors.secondaryLabel} />
     </View>
   );
 });

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -198,6 +198,13 @@ type ClimbListRowProps = {
    */
   showPlaylistChips?: boolean;
   /**
+   * Show the favourite heart beside the ascent status in the default content
+   * layout. Only the main filtered climb list opts in — it's the surface that
+   * feeds `favoritesStore` with its visible UUIDs. Ignored when `renderContent`
+   * supplies a custom layout.
+   */
+  showFavorite?: boolean;
+  /**
    * Show a trailing ⋮ button that opens the reaction menu on tap — a visible,
    * discoverable entry point beside the long-press. The climbs list passes the
    * "Show quick-actions button" user setting (on by default), other surfaces keep
@@ -225,6 +232,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
   separatorStyle,
   showSeparator = true,
   showPlaylistChips = false,
+  showFavorite = false,
   showMoreButton = false,
 }: ClimbListRowProps) {
   const { t } = useTranslation('climbs');
@@ -478,6 +486,7 @@ const ClimbListRow = React.memo(function ClimbListRow({
       setIds={setIds}
       angle={angle}
       showPlaylistChips={showPlaylistChips}
+      showFavorite={showFavorite}
     />
   );
 

--- a/packages/mobile/src/components/__tests__/ClimbListItemContent.test.tsx
+++ b/packages/mobile/src/components/__tests__/ClimbListItemContent.test.tsx
@@ -49,7 +49,7 @@ vi.mock('../../hooks/use-ascent-status', () => ({
 }));
 
 vi.mock('../../providers/theme-provider', () => ({
-  useTheme: () => ({ systemColors: { secondaryLabel: '#8E8E93' } }),
+  useTheme: () => ({ systemColors: { secondaryLabel: '#8E8E93' }, actionColors: { favorite: '#FF3B30' } }),
 }));
 
 vi.mock('../../lib/format-climb-stats', () => ({
@@ -76,10 +76,16 @@ vi.mock('../ClimbListThumbnail', () => ({
   THUMBNAIL_HEIGHT: 80,
 }));
 
-vi.mock('../Icon', () => ({ Icon: () => null }));
+// Icons render as a marker span so tests can assert WHICH glyph appeared (the
+// favourite heart) without pulling in the real SF-Symbol / vector-icon stack.
+vi.mock('../Icon', () => ({
+  Icon: ({ name, color }: { name: string; color?: string }) =>
+    createElement('i', { 'data-icon': name, 'data-color': color }),
+}));
 vi.mock('../ClimbAttributeIcons', () => ({ ClimbAttributeIcons: () => null }));
 vi.mock('../ClimbPlaylistChips', () => ({ ClimbPlaylistChips: () => null }));
 
+import { favoritesStore } from '@boardsesh/climb-actions';
 import { ClimbListItemContent } from '../ClimbListItemContent';
 
 const baseClimb = {
@@ -143,5 +149,53 @@ describe('ClimbListItemContent grade', () => {
 
     expect(resolveGrade).toHaveBeenCalledWith(expect.objectContaining({ difficulty: null }));
     expect(container.textContent).not.toContain('4.5★');
+  });
+});
+
+describe('ClimbListItemContent favourite heart', () => {
+  beforeEach(() => {
+    favoritesStore.reset();
+    resolveGrade.mockReturnValue({ label: 'V4', color: '#111111', isBoardsesh: false });
+  });
+
+  const heart = (container: HTMLElement) => container.querySelector('[data-icon="favorite.fill"]');
+
+  it('renders a filled heart in the favourite colour when the store says favorited', () => {
+    favoritesStore.setIsFavorited('c1', true);
+    const { container } = render(
+      <ClimbListItemContent
+        climb={baseClimb}
+        boardName="kilter"
+        layoutId={1}
+        sizeId={1}
+        setIds="1"
+        angle={40}
+        showFavorite
+      />,
+    );
+    expect(heart(container)?.getAttribute('data-color')).toBe('#FF3B30');
+  });
+
+  it('renders no heart for a climb that is not favorited', () => {
+    const { container } = render(
+      <ClimbListItemContent
+        climb={baseClimb}
+        boardName="kilter"
+        layoutId={1}
+        sizeId={1}
+        setIds="1"
+        angle={40}
+        showFavorite
+      />,
+    );
+    expect(heart(container)).toBeNull();
+  });
+
+  it('stays hidden on surfaces that do not opt in, even when the climb is favorited', () => {
+    favoritesStore.setIsFavorited('c1', true);
+    const { container } = render(
+      <ClimbListItemContent climb={baseClimb} boardName="kilter" layoutId={1} sizeId={1} setIds="1" angle={40} />,
+    );
+    expect(heart(container)).toBeNull();
   });
 });

--- a/packages/mobile/src/components/__tests__/ClimbListItemContent.test.tsx
+++ b/packages/mobile/src/components/__tests__/ClimbListItemContent.test.tsx
@@ -160,7 +160,7 @@ describe('ClimbListItemContent favourite heart', () => {
 
   const heart = (container: HTMLElement) => container.querySelector('[data-icon="favorite.fill"]');
 
-  it('renders a filled heart in the favourite colour when the store says favorited', () => {
+  it('renders a filled heart in the same neutral grey as the ascent-status glyph', () => {
     favoritesStore.setIsFavorited('c1', true);
     const { container } = render(
       <ClimbListItemContent
@@ -173,7 +173,8 @@ describe('ClimbListItemContent favourite heart', () => {
         showFavorite
       />,
     );
-    expect(heart(container)?.getAttribute('data-color')).toBe('#FF3B30');
+    // Matches AscentStatusGlyph: this cluster means by shape, not colour.
+    expect(heart(container)?.getAttribute('data-color')).toBe('#8E8E93');
   });
 
   it('renders no heart for a climb that is not favorited', () => {

--- a/packages/mobile/src/components/climb-actions/use-climb-actions.ts
+++ b/packages/mobile/src/components/climb-actions/use-climb-actions.ts
@@ -242,7 +242,13 @@ export function useClimbActions({
           layoutId,
           source: 'mobile_climb_actions',
         });
-        toggleFavoriteMutate({ input: { boardName, climbUuid: climb.uuid, angle } });
+        // Pass the state the row just rendered from: it flips the heart in the
+        // climb list optimistically, and it's what the offline local-first path
+        // needs to know which way to write.
+        toggleFavoriteMutate({
+          input: { boardName, climbUuid: climb.uuid, angle },
+          currentlyFavorited: isFavorited,
+        });
         after();
       },
     });

--- a/packages/mobile/src/hooks/__tests__/use-climb-list-favorites.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-climb-list-favorites.test.ts
@@ -120,6 +120,42 @@ describe('useClimbListFavorites', () => {
     expect(request).not.toHaveBeenCalled();
   });
 
+  // >500 visible climbs is two chunks. Navigating away (or the window changing)
+  // between them used to leave the second chunk's uuids marked as fetched but
+  // never fetched, so those hearts stayed dark for the rest of the session.
+  it('re-queues the chunks it never merged when a multi-chunk fetch is cancelled', async () => {
+    const manyUuids = Array.from({ length: 600 }, (_index, position) => `climb-${position}`);
+
+    let resolveSecondChunk: (value: { favorites: string[] }) => void = () => {};
+    request.mockResolvedValueOnce({ favorites: [] });
+    request.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSecondChunk = resolve;
+        }),
+    );
+
+    const { rerender } = renderHook(
+      (props: { climbUuids: string[] }) => useClimbListFavorites({ boardName: 'kilter', angle: 40, ...props }),
+      { initialProps: { climbUuids: manyUuids } },
+    );
+    await flush();
+    expect(request).toHaveBeenCalledTimes(2);
+
+    // The window changes while chunk 2 is in flight, cancelling this batch.
+    rerender({ climbUuids: [...manyUuids, 'climb-600'] });
+    await flush();
+    resolveSecondChunk({ favorites: [] });
+    await flush();
+
+    // The 100 uuids chunk 2 never merged are retryable again.
+    request.mockResolvedValue({ favorites: ['climb-550'] });
+    rerender({ climbUuids: [...manyUuids, 'climb-600', 'climb-601'] });
+    await flush();
+
+    expect(favoritesStore.getIsFavorited('climb-550')).toBe(true);
+  });
+
   it('retries a failed batch on the next visible-window change', async () => {
     request.mockRejectedValueOnce(new Error('offline'));
 

--- a/packages/mobile/src/hooks/__tests__/use-climb-list-favorites.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-climb-list-favorites.test.ts
@@ -4,19 +4,23 @@ import { renderHook } from '@testing-library/react';
 
 // Run scheduled interaction callbacks immediately — this hook's deferral is
 // covered by the shared `runAfterInteractions` contract, not by these tests.
-const { runAfterInteractions, request, isAuthenticated } = vi.hoisted(() => ({
+const { runAfterInteractions, request, isAuthenticated, storedUser } = vi.hoisted(() => ({
   runAfterInteractions: vi.fn((callback: () => void) => {
     callback();
     return { cancel: vi.fn() };
   }),
   request: vi.fn(),
   isAuthenticated: { value: true },
+  storedUser: { userId: 'user-a' as string | undefined, isLoading: false },
 }));
 
 vi.mock('react-native', () => ({ InteractionManager: { runAfterInteractions } }));
 vi.mock('../../lib/graphql/client', () => ({ getHttpClient: () => ({ request }) }));
 vi.mock('../../providers/auth-provider', () => ({
   useAuth: () => ({ isAuthenticated: isAuthenticated.value }),
+}));
+vi.mock('../use-current-user-id', () => ({
+  useStoredUserId: () => storedUser,
 }));
 
 import { favoritesStore } from '@boardsesh/climb-actions';
@@ -33,6 +37,8 @@ describe('useClimbListFavorites', () => {
     request.mockReset();
     runAfterInteractions.mockClear();
     isAuthenticated.value = true;
+    storedUser.userId = 'user-a';
+    storedUser.isLoading = false;
   });
 
   it('writes the favorited subset of the visible climbs into the store', async () => {
@@ -109,6 +115,44 @@ describe('useClimbListFavorites', () => {
       climbUuids: ['a'],
       angle: 25,
     });
+  });
+
+  // A shared device where the account switch never renders a signed-out state
+  // between the two users: the auth bit stays 1, so only the id distinguishes
+  // whose favourites the store is holding.
+  it('clears one user\u2019s hearts when another signs in at the same board and angle', async () => {
+    request.mockResolvedValue({ favorites: ['a'] });
+
+    const { rerender } = renderHook(() => useClimbListFavorites({ boardName: 'kilter', angle: 40, climbUuids: ['a'] }));
+    await flush();
+    expect(favoritesStore.getIsFavorited('a')).toBe(true);
+
+    request.mockResolvedValue({ favorites: [] });
+    storedUser.userId = 'user-b';
+    rerender();
+    await flush();
+
+    expect(favoritesStore.getIsFavorited('a')).toBe(false);
+  });
+
+  it('waits for the user id to resolve before fetching', async () => {
+    storedUser.userId = undefined;
+    storedUser.isLoading = true;
+
+    const { rerender } = renderHook(() => useClimbListFavorites({ boardName: 'kilter', angle: 40, climbUuids: ['a'] }));
+    await flush();
+    expect(request).not.toHaveBeenCalled();
+
+    // Fetching under a placeholder key would only be reset and refetched the
+    // moment the real id landed.
+    request.mockResolvedValue({ favorites: ['a'] });
+    storedUser.userId = 'user-a';
+    storedUser.isLoading = false;
+    rerender();
+    await flush();
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(favoritesStore.getIsFavorited('a')).toBe(true);
   });
 
   it('does not fetch while signed out', async () => {

--- a/packages/mobile/src/hooks/__tests__/use-climb-list-favorites.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-climb-list-favorites.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// Run scheduled interaction callbacks immediately — this hook's deferral is
+// covered by the shared `runAfterInteractions` contract, not by these tests.
+const { runAfterInteractions, request, isAuthenticated } = vi.hoisted(() => ({
+  runAfterInteractions: vi.fn((callback: () => void) => {
+    callback();
+    return { cancel: vi.fn() };
+  }),
+  request: vi.fn(),
+  isAuthenticated: { value: true },
+}));
+
+vi.mock('react-native', () => ({ InteractionManager: { runAfterInteractions } }));
+vi.mock('../../lib/graphql/client', () => ({ getHttpClient: () => ({ request }) }));
+vi.mock('../../providers/auth-provider', () => ({
+  useAuth: () => ({ isAuthenticated: isAuthenticated.value }),
+}));
+
+import { favoritesStore } from '@boardsesh/climb-actions';
+import { useClimbListFavorites, resetFavoritesListContextForTests } from '../use-climb-list-favorites';
+
+// A promise the request resolves with, awaited via a microtask flush so the
+// hook's async batch completes before assertions.
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('useClimbListFavorites', () => {
+  beforeEach(() => {
+    favoritesStore.reset();
+    resetFavoritesListContextForTests();
+    request.mockReset();
+    runAfterInteractions.mockClear();
+    isAuthenticated.value = true;
+  });
+
+  it('writes the favorited subset of the visible climbs into the store', async () => {
+    request.mockResolvedValue({ favorites: ['b'] });
+
+    renderHook(() => useClimbListFavorites({ boardName: 'kilter', angle: 40, climbUuids: ['a', 'b'] }));
+    await flush();
+
+    expect(favoritesStore.getIsFavorited('a')).toBe(false);
+    expect(favoritesStore.getIsFavorited('b')).toBe(true);
+    expect(request).toHaveBeenCalledWith(expect.anything(), {
+      boardName: 'kilter',
+      climbUuids: ['a', 'b'],
+      angle: 40,
+    });
+  });
+
+  it('keeps earlier pages favorited when a later page comes back empty', async () => {
+    request.mockResolvedValueOnce({ favorites: ['first-page'] });
+
+    const { rerender } = renderHook(
+      (props: { climbUuids: string[] }) => useClimbListFavorites({ boardName: 'kilter', angle: 40, ...props }),
+      { initialProps: { climbUuids: ['first-page'] } },
+    );
+    await flush();
+    expect(favoritesStore.getIsFavorited('first-page')).toBe(true);
+
+    // Paging in a second screenful only asks about the NEW uuids, so the merge
+    // must not treat "not in this response" as "unfavourite everything".
+    request.mockResolvedValueOnce({ favorites: [] });
+    rerender({ climbUuids: ['first-page', 'second-page'] });
+    await flush();
+
+    expect(favoritesStore.getIsFavorited('first-page')).toBe(true);
+    expect(favoritesStore.getIsFavorited('second-page')).toBe(false);
+  });
+
+  it('requests each uuid once as the visible window grows', async () => {
+    request.mockResolvedValue({ favorites: [] });
+
+    const { rerender } = renderHook(
+      (props: { climbUuids: string[] }) => useClimbListFavorites({ boardName: 'kilter', angle: 40, ...props }),
+      { initialProps: { climbUuids: ['a'] } },
+    );
+    await flush();
+    rerender({ climbUuids: ['a', 'b'] });
+    await flush();
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenLastCalledWith(expect.anything(), {
+      boardName: 'kilter',
+      climbUuids: ['b'],
+      angle: 40,
+    });
+  });
+
+  it('clears the store and refetches when the angle changes — favorites are per-angle', async () => {
+    request.mockResolvedValue({ favorites: ['a'] });
+
+    const { rerender } = renderHook(
+      (props: { angle: number }) => useClimbListFavorites({ boardName: 'kilter', climbUuids: ['a'], ...props }),
+      { initialProps: { angle: 40 } },
+    );
+    await flush();
+    expect(favoritesStore.getIsFavorited('a')).toBe(true);
+
+    request.mockResolvedValue({ favorites: [] });
+    rerender({ angle: 25 });
+    await flush();
+
+    expect(favoritesStore.getIsFavorited('a')).toBe(false);
+    expect(request).toHaveBeenLastCalledWith(expect.anything(), {
+      boardName: 'kilter',
+      climbUuids: ['a'],
+      angle: 25,
+    });
+  });
+
+  it('does not fetch while signed out', async () => {
+    isAuthenticated.value = false;
+
+    renderHook(() => useClimbListFavorites({ boardName: 'kilter', angle: 40, climbUuids: ['a'] }));
+    await flush();
+
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('retries a failed batch on the next visible-window change', async () => {
+    request.mockRejectedValueOnce(new Error('offline'));
+
+    const { rerender } = renderHook(
+      (props: { climbUuids: string[] }) => useClimbListFavorites({ boardName: 'kilter', angle: 40, ...props }),
+      { initialProps: { climbUuids: ['a'] } },
+    );
+    await flush();
+
+    request.mockResolvedValue({ favorites: ['a'] });
+    rerender({ climbUuids: ['a', 'b'] });
+    await flush();
+
+    expect(favoritesStore.getIsFavorited('a')).toBe(true);
+  });
+});

--- a/packages/mobile/src/hooks/__tests__/use-climb-list-favorites.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-climb-list-favorites.test.ts
@@ -20,7 +20,7 @@ vi.mock('../../providers/auth-provider', () => ({
 }));
 
 import { favoritesStore } from '@boardsesh/climb-actions';
-import { useClimbListFavorites, resetFavoritesListContextForTests } from '../use-climb-list-favorites';
+import { useClimbListFavorites } from '../use-climb-list-favorites';
 
 // A promise the request resolves with, awaited via a microtask flush so the
 // hook's async batch completes before assertions.
@@ -28,8 +28,8 @@ const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 describe('useClimbListFavorites', () => {
   beforeEach(() => {
+    // Also forgets the context the store held, so each test starts unscoped.
     favoritesStore.reset();
-    resetFavoritesListContextForTests();
     request.mockReset();
     runAfterInteractions.mockClear();
     isAuthenticated.value = true;

--- a/packages/mobile/src/hooks/__tests__/use-climb-list-favorites.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-climb-list-favorites.test.ts
@@ -155,6 +155,55 @@ describe('useClimbListFavorites', () => {
     expect(favoritesStore.getIsFavorited('a')).toBe(true);
   });
 
+  // The batch is deferred past the fling, so there's a real window in which the
+  // user hearts a climb the in-flight lookup is about to report as unfavourited.
+  it('does not let a lookup that raced a toggle clear the newly set heart', async () => {
+    let resolveLookup: (value: { favorites: string[] }) => void = () => {};
+    request.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveLookup = resolve;
+        }),
+    );
+
+    renderHook(() => useClimbListFavorites({ boardName: 'kilter', angle: 40, climbUuids: ['a'] }));
+    await flush();
+
+    // The toggle lands first; the server's pre-toggle answer arrives after.
+    favoritesStore.setIsFavorited('a', true);
+    resolveLookup({ favorites: [] });
+    await flush();
+
+    expect(favoritesStore.getIsFavorited('a')).toBe(true);
+  });
+
+  it('re-queues a cancelled batch in time for the replacement fetch to pick it up', async () => {
+    let resolveFirst: (value: { favorites: string[] }) => void = () => {};
+    request.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+
+    const { rerender } = renderHook(
+      (props: { climbUuids: string[] }) => useClimbListFavorites({ boardName: 'kilter', angle: 40, ...props }),
+      { initialProps: { climbUuids: ['a'] } },
+    );
+    await flush();
+
+    // The window changes while 'a' is still in flight. The cleanup must release
+    // 'a' before the replacement effect computes what to fetch, so the new run
+    // asks about it again rather than skipping it as already-fetched.
+    request.mockResolvedValue({ favorites: ['a'] });
+    rerender({ climbUuids: ['a', 'b'] });
+    await flush();
+    resolveFirst({ favorites: [] });
+    await flush();
+
+    expect(favoritesStore.getIsFavorited('a')).toBe(true);
+  });
+
   it('does not fetch while signed out', async () => {
     isAuthenticated.value = false;
 

--- a/packages/mobile/src/hooks/use-climb-list-favorites.ts
+++ b/packages/mobile/src/hooks/use-climb-list-favorites.ts
@@ -1,0 +1,98 @@
+import { useEffect, useRef } from 'react';
+import { InteractionManager } from 'react-native';
+import { GET_FAVORITES, type FavoritesQueryResponse } from '@boardsesh/graphql/operations/favorites';
+import { favoritesStore } from '@boardsesh/climb-actions';
+import { getHttpClient } from '../lib/graphql/client';
+import { useAuth } from '../providers/auth-provider';
+
+// `FavoritesQueryClimbUuidsSchema` caps the query at 500 uuids; chunk longer
+// visible sets rather than eating a validation error.
+const CHUNK_SIZE = 500;
+
+// The context (board + angle + auth) the shared store currently holds hearts
+// for. Module-scoped rather than a ref, because remounting the climb list gives
+// this hook a fresh instance while `favoritesStore` keeps whatever the previous
+// mount wrote — a ref initialised to the current context would miss a board or
+// angle change that happened while the list was unmounted.
+let storeContextKey: string | null = null;
+
+/** Test-only: forget which context the store holds, so each test starts clean. */
+export function resetFavoritesListContextForTests(): void {
+  storeContextKey = null;
+}
+
+type UseClimbListFavoritesArgs = {
+  boardName: string;
+  // Favourites are keyed by (userId, boardName, climbUuid, angle) on the backend,
+  // so the same climb can be favourited at 40° and not at 25°.
+  angle: number;
+  // Must be a referentially-stable array (memoize at the call site) — the effect
+  // depends on it, so a fresh array every render would refetch every render.
+  climbUuids: readonly string[];
+};
+
+/**
+ * Feed the shared `favoritesStore` with the favourited state of the currently
+ * visible climbs, so each row's heart can render. This is the batched fetcher
+ * the store was built for — the `use-mobile-climb-actions-data` note called it
+ * out as the missing piece — and it follows the same "fetch the visible UUIDs,
+ * write into the external store" shape as `useClimbListPlaylistMemberships`.
+ *
+ * No-op while signed out (`favorites` returns an empty list for an anonymous
+ * reader anyway). Dedupes via a ref so each climb is requested once; resets the
+ * ref and clears the store whenever board/angle/auth flips, so one board's
+ * hearts can't paint another's rows. Deferred past the active fling via
+ * `runAfterInteractions`, mirroring the logbook and playlist-tag fetches.
+ */
+export function useClimbListFavorites({ boardName, angle, climbUuids }: UseClimbListFavoritesArgs): void {
+  const { isAuthenticated } = useAuth();
+
+  const fetchedRef = useRef<Set<string>>(new Set());
+  const contextKey = `${boardName}:${angle}:${isAuthenticated ? 1 : 0}`;
+
+  // Reset before any fetch when the context changes. Runs in the same render
+  // pass via the effect ordering below (this effect is declared first).
+  useEffect(() => {
+    if (storeContextKey === contextKey) return;
+    storeContextKey = contextKey;
+    fetchedRef.current = new Set();
+    favoritesStore.reset();
+  }, [contextKey]);
+
+  useEffect(() => {
+    if (!isAuthenticated || !boardName || climbUuids.length === 0) return;
+    const toFetch = climbUuids.filter((uuid) => !fetchedRef.current.has(uuid));
+    if (toFetch.length === 0) return;
+
+    let cancelled = false;
+    const handle = InteractionManager.runAfterInteractions(async () => {
+      // Mark up-front so an overlapping effect run doesn't double-request the
+      // same uuids while this batch is in flight.
+      for (const uuid of toFetch) fetchedRef.current.add(uuid);
+      try {
+        for (let offset = 0; offset < toFetch.length; offset += CHUNK_SIZE) {
+          const chunk = toFetch.slice(offset, offset + CHUNK_SIZE);
+          const response = await getHttpClient().request<FavoritesQueryResponse>(GET_FAVORITES, {
+            boardName,
+            climbUuids: chunk,
+            angle,
+          });
+          if (cancelled) return;
+          // The query returns only the favourited subset; `mergeFavorites`
+          // clears the rest of the chunk so an unfavourite made elsewhere
+          // doesn't leave a stale heart behind.
+          favoritesStore.mergeFavorites(chunk, response.favorites);
+        }
+      } catch {
+        // A failed batch must not wedge future fetches — drop these uuids so a
+        // later scroll or refresh retries them.
+        if (!cancelled) for (const uuid of toFetch) fetchedRef.current.delete(uuid);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      handle.cancel();
+    };
+  }, [isAuthenticated, boardName, angle, climbUuids]);
+}

--- a/packages/mobile/src/hooks/use-climb-list-favorites.ts
+++ b/packages/mobile/src/hooks/use-climb-list-favorites.ts
@@ -4,6 +4,7 @@ import { GET_FAVORITES, type FavoritesQueryResponse } from '@boardsesh/graphql/o
 import { favoritesStore } from '@boardsesh/climb-actions';
 import { getHttpClient } from '../lib/graphql/client';
 import { useAuth } from '../providers/auth-provider';
+import { useStoredUserId } from './use-current-user-id';
 
 // `FavoritesQueryClimbUuidsSchema` caps the query at 500 uuids; chunk longer
 // visible sets rather than eating a validation error.
@@ -34,9 +35,16 @@ type UseClimbListFavoritesArgs = {
  */
 export function useClimbListFavorites({ boardName, angle, climbUuids }: UseClimbListFavoritesArgs): void {
   const { isAuthenticated } = useAuth();
+  // Keyed on WHOSE favourites these are, not just whether someone is signed in.
+  // On a shared device an account switch that never renders a signed-out state
+  // in between (both updates batched into one render) leaves the auth bit at 1
+  // throughout, so without the id the key wouldn't change and the incoming user
+  // would see the previous one's hearts. A cheap local read — cached with
+  // `staleTime: Infinity` and dropped by the sign-out cache clear.
+  const { userId, isLoading: isUserIdLoading } = useStoredUserId(isAuthenticated);
 
   const fetchedRef = useRef<Set<string>>(new Set());
-  const contextKey = `${boardName}:${angle}:${isAuthenticated ? 1 : 0}`;
+  const contextKey = `${userId ?? 'anonymous'}:${boardName}:${angle}:${isAuthenticated ? 1 : 0}`;
 
   // Reset before any fetch when the context changes. Runs in the same render
   // pass via the effect ordering below (this effect is declared first). The
@@ -48,7 +56,9 @@ export function useClimbListFavorites({ boardName, angle, climbUuids }: UseClimb
   }, [contextKey]);
 
   useEffect(() => {
-    if (!isAuthenticated || !boardName || climbUuids.length === 0) return;
+    // Waiting out the id read costs nothing and saves a wasted round trip: the
+    // key changes the moment it resolves, which would reset and refetch anyway.
+    if (!isAuthenticated || isUserIdLoading || !boardName || climbUuids.length === 0) return;
     const toFetch = climbUuids.filter((uuid) => !fetchedRef.current.has(uuid));
     if (toFetch.length === 0) return;
 
@@ -92,5 +102,5 @@ export function useClimbListFavorites({ boardName, angle, climbUuids }: UseClimb
       cancelled = true;
       handle.cancel();
     };
-  }, [isAuthenticated, boardName, angle, climbUuids]);
+  }, [isAuthenticated, isUserIdLoading, boardName, angle, climbUuids]);
 }

--- a/packages/mobile/src/hooks/use-climb-list-favorites.ts
+++ b/packages/mobile/src/hooks/use-climb-list-favorites.ts
@@ -53,10 +53,15 @@ export function useClimbListFavorites({ boardName, angle, climbUuids }: UseClimb
     if (toFetch.length === 0) return;
 
     let cancelled = false;
+    // Capture the set itself, not `fetchedRef.current`: a context change swaps
+    // in a fresh one, and the bookkeeping below belongs to THIS context. Writing
+    // through the ref after that swap would edit the new context's set.
+    const fetchedForContext = fetchedRef.current;
     const handle = InteractionManager.runAfterInteractions(async () => {
       // Mark up-front so an overlapping effect run doesn't double-request the
       // same uuids while this batch is in flight.
-      for (const uuid of toFetch) fetchedRef.current.add(uuid);
+      for (const uuid of toFetch) fetchedForContext.add(uuid);
+      let mergedCount = 0;
       try {
         for (let offset = 0; offset < toFetch.length; offset += CHUNK_SIZE) {
           const chunk = toFetch.slice(offset, offset + CHUNK_SIZE);
@@ -70,11 +75,16 @@ export function useClimbListFavorites({ boardName, angle, climbUuids }: UseClimb
           // clears the rest of the chunk so an unfavourite made elsewhere
           // doesn't leave a stale heart behind.
           favoritesStore.mergeFavorites(chunk, response.favorites);
+          mergedCount = offset + chunk.length;
         }
       } catch {
-        // A failed batch must not wedge future fetches — drop these uuids so a
-        // later scroll or refresh retries them.
-        if (!cancelled) for (const uuid of toFetch) fetchedRef.current.delete(uuid);
+        // Handled by the finally below: whatever didn't merge goes back.
+      } finally {
+        // Every uuid whose chunk never merged — the batch failed, or it was
+        // cancelled part-way through a multi-chunk fetch — goes back in the
+        // pool so a later scroll or refresh retries it. Leaving them marked
+        // would wedge those climbs' hearts for the rest of the session.
+        for (const uuid of toFetch.slice(mergedCount)) fetchedForContext.delete(uuid);
       }
     });
 

--- a/packages/mobile/src/hooks/use-climb-list-favorites.ts
+++ b/packages/mobile/src/hooks/use-climb-list-favorites.ts
@@ -67,14 +67,22 @@ export function useClimbListFavorites({ boardName, angle, climbUuids }: UseClimb
     // in a fresh one, and the bookkeeping below belongs to THIS context. Writing
     // through the ref after that swap would edit the new context's set.
     const fetchedForContext = fetchedRef.current;
+    let mergedCount = 0;
+    // Puts back every uuid whose chunk never merged, so a later run retries it.
+    // Leaving them marked would wedge those climbs' hearts for the session.
+    const releaseUnmerged = () => {
+      for (const uuid of toFetch.slice(mergedCount)) fetchedForContext.delete(uuid);
+    };
     const handle = InteractionManager.runAfterInteractions(async () => {
       // Mark up-front so an overlapping effect run doesn't double-request the
       // same uuids while this batch is in flight.
       for (const uuid of toFetch) fetchedForContext.add(uuid);
-      let mergedCount = 0;
       try {
         for (let offset = 0; offset < toFetch.length; offset += CHUNK_SIZE) {
           const chunk = toFetch.slice(offset, offset + CHUNK_SIZE);
+          // Read the clock BEFORE asking, so a toggle that lands while this is
+          // in flight is recognisably newer than the answer coming back.
+          const startedAtStamp = favoritesStore.getWriteStamp();
           const response = await getHttpClient().request<FavoritesQueryResponse>(GET_FAVORITES, {
             boardName,
             climbUuids: chunk,
@@ -83,24 +91,28 @@ export function useClimbListFavorites({ boardName, angle, climbUuids }: UseClimb
           if (cancelled) return;
           // The query returns only the favourited subset; `mergeFavorites`
           // clears the rest of the chunk so an unfavourite made elsewhere
-          // doesn't leave a stale heart behind.
-          favoritesStore.mergeFavorites(chunk, response.favorites);
+          // doesn't leave a stale heart behind — except for climbs toggled
+          // since `startedAtStamp`, whose newer state wins.
+          favoritesStore.mergeFavorites(chunk, response.favorites, startedAtStamp);
           mergedCount = offset + chunk.length;
         }
       } catch {
-        // Handled by the finally below: whatever didn't merge goes back.
-      } finally {
-        // Every uuid whose chunk never merged — the batch failed, or it was
-        // cancelled part-way through a multi-chunk fetch — goes back in the
-        // pool so a later scroll or refresh retries it. Leaving them marked
-        // would wedge those climbs' hearts for the rest of the session.
-        for (const uuid of toFetch.slice(mergedCount)) fetchedForContext.delete(uuid);
+        // The batch failed; put its uuids back so a later run retries them.
+        // Deliberately no immediate re-run: an offline device would spin.
+        releaseUnmerged();
       }
     });
 
     return () => {
       cancelled = true;
       handle.cancel();
+      // Release SYNCHRONOUSLY here rather than from the async callback. React
+      // runs this cleanup before the replacement effect, so the uuids are back
+      // in the pool in time for that run to pick them up. Releasing them later
+      // (when the cancelled request finally settles) mutates the ref without
+      // scheduling anything, leaving those rows unfetched until some unrelated
+      // list change happened to come along.
+      releaseUnmerged();
     };
   }, [isAuthenticated, isUserIdLoading, boardName, angle, climbUuids]);
 }

--- a/packages/mobile/src/hooks/use-climb-list-favorites.ts
+++ b/packages/mobile/src/hooks/use-climb-list-favorites.ts
@@ -9,18 +9,6 @@ import { useAuth } from '../providers/auth-provider';
 // visible sets rather than eating a validation error.
 const CHUNK_SIZE = 500;
 
-// The context (board + angle + auth) the shared store currently holds hearts
-// for. Module-scoped rather than a ref, because remounting the climb list gives
-// this hook a fresh instance while `favoritesStore` keeps whatever the previous
-// mount wrote — a ref initialised to the current context would miss a board or
-// angle change that happened while the list was unmounted.
-let storeContextKey: string | null = null;
-
-/** Test-only: forget which context the store holds, so each test starts clean. */
-export function resetFavoritesListContextForTests(): void {
-  storeContextKey = null;
-}
-
 type UseClimbListFavoritesArgs = {
   boardName: string;
   // Favourites are keyed by (userId, boardName, climbUuid, angle) on the backend,
@@ -39,10 +27,10 @@ type UseClimbListFavoritesArgs = {
  * write into the external store" shape as `useClimbListPlaylistMemberships`.
  *
  * No-op while signed out (`favorites` returns an empty list for an anonymous
- * reader anyway). Dedupes via a ref so each climb is requested once; resets the
- * ref and clears the store whenever board/angle/auth flips, so one board's
- * hearts can't paint another's rows. Deferred past the active fling via
- * `runAfterInteractions`, mirroring the logbook and playlist-tag fetches.
+ * reader anyway). Dedupes via a ref so each climb is requested once; hands the
+ * board/angle/auth context to the store, which clears itself when it flips so
+ * one board's hearts can't paint another's rows. Deferred past the active fling
+ * via `runAfterInteractions`, mirroring the logbook and playlist-tag fetches.
  */
 export function useClimbListFavorites({ boardName, angle, climbUuids }: UseClimbListFavoritesArgs): void {
   const { isAuthenticated } = useAuth();
@@ -51,12 +39,12 @@ export function useClimbListFavorites({ boardName, angle, climbUuids }: UseClimb
   const contextKey = `${boardName}:${angle}:${isAuthenticated ? 1 : 0}`;
 
   // Reset before any fetch when the context changes. Runs in the same render
-  // pass via the effect ordering below (this effect is declared first).
+  // pass via the effect ordering below (this effect is declared first). The
+  // store owns the "which context is this data for" check, so it still fires
+  // for a board or angle change that happened while the list was unmounted.
   useEffect(() => {
-    if (storeContextKey === contextKey) return;
-    storeContextKey = contextKey;
+    if (!favoritesStore.applyContext(contextKey)) return;
     fetchedRef.current = new Set();
-    favoritesStore.reset();
   }, [contextKey]);
 
   useEffect(() => {

--- a/packages/mobile/src/hooks/use-is-climb-favorited.ts
+++ b/packages/mobile/src/hooks/use-is-climb-favorited.ts
@@ -1,0 +1,19 @@
+import { useSyncExternalStore } from 'react';
+import { favoritesStore } from '@boardsesh/climb-actions';
+
+/**
+ * Subscribe to a single climb's favourited state from the shared
+ * `favoritesStore`. Per-UUID subscription: a row only re-renders when its OWN
+ * climb's heart flips, never when another row's does. The snapshot is a
+ * primitive boolean, so `useSyncExternalStore`'s `Object.is` check holds.
+ *
+ * Reads whatever the store currently holds — `useClimbListFavorites` fills it
+ * for the visible list, and `useToggleFavorite` writes each toggle straight in.
+ */
+export function useIsClimbFavorited(climbUuid: string): boolean {
+  return useSyncExternalStore(
+    favoritesStore.subscribe,
+    () => favoritesStore.getIsFavorited(climbUuid),
+    () => false,
+  );
+}

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/favorite-toggle-order.test.ts
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/favorite-toggle-order.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { FavoriteToggleOrder } from '../favorite-toggle-order';
+
+describe('FavoriteToggleOrder', () => {
+  it('treats the newest toggle for a climb as the owner', () => {
+    const order = new FavoriteToggleOrder();
+    const first = order.begin('climb-1');
+    const second = order.begin('climb-1');
+
+    expect(order.isLatest('climb-1', first)).toBe(false);
+    expect(order.isLatest('climb-1', second)).toBe(true);
+  });
+
+  it('tracks climbs independently', () => {
+    const order = new FavoriteToggleOrder();
+    const one = order.begin('climb-1');
+    order.begin('climb-2');
+
+    expect(order.isLatest('climb-1', one)).toBe(true);
+  });
+
+  it('releases the climb when its newest toggle settles', () => {
+    const order = new FavoriteToggleOrder();
+    const token = order.begin('climb-1');
+    order.settle('climb-1', token);
+
+    expect(order.isLatest('climb-1', token)).toBe(false);
+  });
+
+  it('a superseded toggle settling leaves the newer one owning the climb', () => {
+    const order = new FavoriteToggleOrder();
+    const first = order.begin('climb-1');
+    const second = order.begin('climb-1');
+
+    order.settle('climb-1', first);
+
+    expect(order.isLatest('climb-1', second)).toBe(true);
+  });
+});

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/use-favorite-status.test.tsx
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/use-favorite-status.test.tsx
@@ -241,6 +241,37 @@ describe('useToggleFavorite', () => {
     expect(favoritesStore.getIsFavorited('climb-1')).toBe(false);
   });
 
+  // The store is a singleton scoped to one board+angle+user. A toggle that
+  // resolves after the user switched angles must not paint its result onto the
+  // list now showing a different angle.
+  it('drops its store write when the favourite context changed while in flight', async () => {
+    let resolveToggle: (value: { toggleFavorite: { favorited: boolean } }) => void = () => {};
+    requestMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveToggle = resolve;
+        }),
+    );
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useToggleFavorite(), { wrapper: Wrapper });
+
+    const pending = result.current.mutateAsync({
+      input: { boardName: 'kilter', climbUuid: 'climb-1', angle: 40 },
+      currentlyFavorited: false,
+    });
+    // Let onMutate run (React Query awaits it) so the request is actually in
+    // flight and the optimistic write has landed.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(favoritesStore.getIsFavorited('climb-1')).toBe(true);
+
+    // The list re-scopes to another angle, clearing the store.
+    favoritesStore.applyContext('kilter:25:1');
+    resolveToggle({ toggleFavorite: { favorited: true } });
+    await pending;
+
+    expect(favoritesStore.getIsFavorited('climb-1')).toBe(false);
+  });
+
   // Two taps in flight, both failing: the FIRST failure must not roll back over
   // the second tap's optimistic write, or the heart lands on the state of an
   // older attempt. Only the toggle whose value still stands rolls it back.

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/use-favorite-status.test.tsx
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/use-favorite-status.test.tsx
@@ -56,6 +56,7 @@ vi.mock('../use-integrations', () => ({
   useSyncSessionToIntegration: vi.fn(),
 }));
 
+import { favoritesStore } from '@boardsesh/climb-actions';
 import { useFavoriteStatus, useToggleFavorite } from '../index';
 
 function makeWrapper() {
@@ -71,6 +72,7 @@ function makeWrapper() {
 beforeEach(() => {
   requestMock.mockReset();
   adapterAuth.isAuthenticated = true;
+  favoritesStore.reset();
 });
 
 describe('useFavoriteStatus', () => {
@@ -192,5 +194,92 @@ describe('useToggleFavorite', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['favoriteStatus', 'kilter', 'climb-1', 40],
     });
+  });
+
+  // The climb list's hearts read `favoritesStore`, so the toggle owns keeping it
+  // truthful — including when the network says no.
+  it('writes the toggle into the shared store optimistically and confirms with server truth', async () => {
+    requestMock.mockResolvedValue({ toggleFavorite: { favorited: true } });
+    const { Wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useToggleFavorite(), { wrapper: Wrapper });
+    await result.current.mutateAsync({
+      input: { boardName: 'kilter', climbUuid: 'climb-1', angle: 40 },
+      currentlyFavorited: false,
+    });
+
+    expect(favoritesStore.getIsFavorited('climb-1')).toBe(true);
+  });
+
+  it('follows server truth when it contradicts the optimistic guess', async () => {
+    // Already favourited on the server (another device got there first), so the
+    // toggle removes it even though this client guessed "adding".
+    requestMock.mockResolvedValue({ toggleFavorite: { favorited: false } });
+    const { Wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useToggleFavorite(), { wrapper: Wrapper });
+    await result.current.mutateAsync({
+      input: { boardName: 'kilter', climbUuid: 'climb-1', angle: 40 },
+      currentlyFavorited: false,
+    });
+
+    expect(favoritesStore.getIsFavorited('climb-1')).toBe(false);
+  });
+
+  it('rolls the store back when the toggle fails', async () => {
+    requestMock.mockRejectedValue(new Error('offline'));
+    const { Wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useToggleFavorite(), { wrapper: Wrapper });
+    await expect(
+      result.current.mutateAsync({
+        input: { boardName: 'kilter', climbUuid: 'climb-1', angle: 40 },
+        currentlyFavorited: false,
+      }),
+    ).rejects.toThrow('offline');
+
+    expect(favoritesStore.getIsFavorited('climb-1')).toBe(false);
+  });
+
+  // Two taps in flight, both failing: the FIRST failure must not roll back over
+  // the second tap's optimistic write, or the heart lands on the state of an
+  // older attempt. Only the toggle whose value still stands rolls it back.
+  it('does not let an older failed toggle stomp a newer one still in flight', async () => {
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useToggleFavorite(), { wrapper: Wrapper });
+
+    // Tap 1 (add) fails slowly; tap 2 (remove, from the optimistic `true`)
+    // fails fast, so its rollback to `true` lands before tap 1's rollback runs.
+    let failFirst: (reason: Error) => void = () => {};
+    requestMock.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          failFirst = reject;
+        }),
+    );
+    requestMock.mockRejectedValueOnce(new Error('second failed'));
+
+    const first = result.current.mutateAsync({
+      input: { boardName: 'kilter', climbUuid: 'climb-1', angle: 40 },
+      currentlyFavorited: false,
+    });
+    first.catch(() => {});
+    expect(favoritesStore.getIsFavorited('climb-1')).toBe(true);
+
+    await expect(
+      result.current.mutateAsync({
+        input: { boardName: 'kilter', climbUuid: 'climb-1', angle: 40 },
+        currentlyFavorited: true,
+      }),
+    ).rejects.toThrow('second failed');
+    // Tap 2 rolled back to the state it started from.
+    expect(favoritesStore.getIsFavorited('climb-1')).toBe(true);
+
+    failFirst(new Error('first failed'));
+    await expect(first).rejects.toThrow('first failed');
+
+    // Tap 1's rollback would have written `false`. The guard sees the store no
+    // longer holds tap 1's optimistic value and leaves tap 2's result standing.
+    expect(favoritesStore.getIsFavorited('climb-1')).toBe(true);
   });
 });

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/use-mobile-climb-actions-data.test.tsx
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/use-mobile-climb-actions-data.test.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { UserBoard } from '@boardsesh/shared-schema';
 import type { Playlist } from '@boardsesh/graphql/operations/playlists';
 import { TOGGLE_FAVORITE } from '@boardsesh/graphql/operations/favorites';
+import { favoritesStore } from '@boardsesh/climb-actions';
 import {
   GET_ALL_USER_PLAYLISTS,
   ADD_CLIMB_TO_PLAYLIST,
@@ -151,6 +152,10 @@ describe('useMobileClimbActionsData', () => {
     addFavoriteLocalMock.mockClear();
     removeFavoriteLocalMock.mockClear();
     drainMutationQueueMock.mockClear();
+    // The toggle reads its "currently favorited" from — and writes its result
+    // back into — the shared singleton store, so a previous test's toggle would
+    // otherwise decide the next one's direction.
+    favoritesStore.reset();
     offlineEnabled = false;
     signedIn();
     withActiveBoard(kilterBoard);

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/use-mobile-climb-actions-data.test.tsx
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/use-mobile-climb-actions-data.test.tsx
@@ -266,6 +266,32 @@ describe('useMobileClimbActionsData', () => {
       expect(removeFavoriteLocalMock).not.toHaveBeenCalled();
       expect(drainMutationQueueMock).not.toHaveBeenCalled();
     });
+
+    // The store holds one board+angle+user at a time. A toggle fired at 40°
+    // that resolves after the user moved to 25° must not paint that list.
+    it('does not write server truth into a store that was re-scoped mid-flight', async () => {
+      requestMock.mockResolvedValueOnce({ allUserPlaylists: { playlists: [] } });
+      let resolveToggle: (value: { toggleFavorite: { favorited: boolean } }) => void = () => {};
+      requestMock.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveToggle = resolve;
+          }),
+      );
+
+      const { Wrapper } = makeWrapper();
+      const { result } = renderHook(() => useMobileClimbActionsData(), { wrapper: Wrapper });
+      await waitFor(() => expect(requestMock).toHaveBeenCalledWith(GET_ALL_USER_PLAYLISTS, expect.anything()));
+
+      const pending = result.current.favoritesProviderProps.toggleFavorite('climb-x');
+      await waitFor(() => expect(requestMock).toHaveBeenCalledWith(TOGGLE_FAVORITE, expect.anything()));
+
+      favoritesStore.applyContext('kilter:25:1');
+      resolveToggle({ toggleFavorite: { favorited: true } });
+      await pending;
+
+      expect(favoritesStore.getIsFavorited('climb-x')).toBe(false);
+    });
   });
 
   describe('addToPlaylist + removeFromPlaylist', () => {

--- a/packages/mobile/src/lib/graphql/hooks/favorite-toggle-order.ts
+++ b/packages/mobile/src/lib/graphql/hooks/favorite-toggle-order.ts
@@ -1,0 +1,34 @@
+/**
+ * Tracks which favourite toggle is the newest per climb, so a slow failure
+ * can't roll back over a newer tap's result.
+ *
+ * Comparing values instead is NOT enough, which is the subtle part: tap 1 (add)
+ * optimistically writes `true`; tap 2 (remove) writes `false`; tap 2 fails and
+ * rolls back to `true`. Now tap 1 fails, sees `true` — its own optimistic value —
+ * and "correctly" rolls back to `false`, landing the heart on the state of the
+ * older attempt. Identity, not equality, is what decides who owns the rollback.
+ */
+export class FavoriteToggleOrder {
+  private latest = new Map<string, number>();
+  private counter = 0;
+
+  /** Claim ownership of a climb's state for a new toggle; returns its token. */
+  begin(climbUuid: string): number {
+    this.counter += 1;
+    this.latest.set(climbUuid, this.counter);
+    return this.counter;
+  }
+
+  /** Whether this toggle is still the newest one for the climb. */
+  isLatest(climbUuid: string, token: number): boolean {
+    return this.latest.get(climbUuid) === token;
+  }
+
+  /** Release ownership once a toggle settles, so the map doesn't grow with the
+   *  session. A superseded toggle leaves the newer one's entry alone. */
+  settle(climbUuid: string, token: number): void {
+    if (this.latest.get(climbUuid) === token) this.latest.delete(climbUuid);
+  }
+}
+
+export const favoriteToggleOrder = new FavoriteToggleOrder();

--- a/packages/mobile/src/lib/graphql/hooks/favorite-toggle-order.ts
+++ b/packages/mobile/src/lib/graphql/hooks/favorite-toggle-order.ts
@@ -1,3 +1,5 @@
+import { favoritesStore } from '@boardsesh/climb-actions';
+
 /**
  * Tracks which favourite toggle is the newest per climb, so a slow failure
  * can't roll back over a newer tap's result.
@@ -32,3 +34,15 @@ export class FavoriteToggleOrder {
 }
 
 export const favoriteToggleOrder = new FavoriteToggleOrder();
+
+/**
+ * Whether a settling favourite toggle may still write to the shared store: it
+ * must be the newest toggle for that climb AND the store must still be scoped
+ * to the context the toggle started in (board + angle + user). Both toggle
+ * mutations write the same singleton, so both ask this rather than each
+ * re-deriving half of it.
+ */
+export function ownsFavoriteWrite(climbUuid: string, context: { token: number; contextEpoch: number }): boolean {
+  if (favoritesStore.getContextEpoch() !== context.contextEpoch) return false;
+  return favoriteToggleOrder.isLatest(climbUuid, context.token);
+}

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -1044,7 +1044,11 @@ export function useToggleFavorite() {
       if (context) favoriteToggleOrder.settle(variables.input.climbUuid, context.token);
     },
     onSuccess: (data, variables, context) => {
-      if (!context || ownsFavoriteWrite(variables.input.climbUuid, context)) {
+      // Same ownership test as the rollback above, written the same way round:
+      // write only when this toggle still owns the climb's state. React Query
+      // always hands back the onMutate context, so the null branch is
+      // unreachable — it reads as "no claim, no write" rather than the opposite.
+      if (context && ownsFavoriteWrite(variables.input.climbUuid, context)) {
         favoritesStore.setIsFavorited(variables.input.climbUuid, data.toggleFavorite.favorited);
       }
       void queryClient.invalidateQueries({ queryKey: ['searchClimbs'] });

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -46,6 +46,7 @@ import { getDatabaseHandle } from '../../../db';
 import { offlineAwareRequest } from '../offline-request';
 import { useOfflineDownloadsEnabled } from '../../../providers/feature-flags-provider';
 import { favoritesStore } from '@boardsesh/climb-actions';
+import { favoriteToggleOrder } from './favorite-toggle-order';
 import { addFavoriteLocal, removeFavoriteLocal } from '../../../hooks/use-offline-mutations';
 import type { GraphQLFetch } from '@boardsesh/offline-sync';
 import { drainMutationQueue } from '../../../offline/offline-sync-adapter';
@@ -1009,21 +1010,29 @@ export function useToggleFavorite() {
     // list's heart flips the moment you favourite from the play drawer or the
     // actions sheet — the list's batched fetch only covers uuids it hasn't
     // already seen, so it would never re-read this one on its own.
+    //
+    // Every write below is gated on this toggle still being the newest one for
+    // the climb: with two taps in flight, whichever settles LAST must own the
+    // heart, whether it succeeded or failed.
     onMutate: (variables) => {
-      if (typeof variables.currentlyFavorited !== 'boolean') return;
-      favoritesStore.setIsFavorited(variables.input.climbUuid, !variables.currentlyFavorited);
+      const token = favoriteToggleOrder.begin(variables.input.climbUuid);
+      if (typeof variables.currentlyFavorited === 'boolean') {
+        favoritesStore.setIsFavorited(variables.input.climbUuid, !variables.currentlyFavorited);
+      }
+      return { token };
     },
-    onError: (_error, variables) => {
+    onError: (_error, variables, context) => {
       if (typeof variables.currentlyFavorited !== 'boolean') return;
-      // Only roll back while the store still holds the value THIS toggle wrote;
-      // a newer tap that already landed owns the state (mirrors
-      // `resolveFavoriteRollback` in the play drawer).
-      const optimistic = !variables.currentlyFavorited;
-      if (favoritesStore.getIsFavorited(variables.input.climbUuid) !== optimistic) return;
+      if (!context || !favoriteToggleOrder.isLatest(variables.input.climbUuid, context.token)) return;
       favoritesStore.setIsFavorited(variables.input.climbUuid, variables.currentlyFavorited);
     },
-    onSuccess: (data, variables) => {
-      favoritesStore.setIsFavorited(variables.input.climbUuid, data.toggleFavorite.favorited);
+    onSettled: (_data, _error, variables, context) => {
+      if (context) favoriteToggleOrder.settle(variables.input.climbUuid, context.token);
+    },
+    onSuccess: (data, variables, context) => {
+      if (!context || favoriteToggleOrder.isLatest(variables.input.climbUuid, context.token)) {
+        favoritesStore.setIsFavorited(variables.input.climbUuid, data.toggleFavorite.favorited);
+      }
       void queryClient.invalidateQueries({ queryKey: ['searchClimbs'] });
       void queryClient.invalidateQueries({ queryKey: ['infiniteSearchClimbs'] });
       // Bust the per-climb favorite-status cache so a re-open reflects the new

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -46,17 +46,7 @@ import { getDatabaseHandle } from '../../../db';
 import { offlineAwareRequest } from '../offline-request';
 import { useOfflineDownloadsEnabled } from '../../../providers/feature-flags-provider';
 import { favoritesStore } from '@boardsesh/climb-actions';
-import { favoriteToggleOrder } from './favorite-toggle-order';
-
-/**
- * Whether a settling favourite toggle may still write to the shared store: it
- * must be the newest toggle for that climb AND the store must still be scoped
- * to the context the toggle started in (board + angle + user).
- */
-function ownsFavoriteWrite(climbUuid: string, context: { token: number; contextEpoch: number }): boolean {
-  if (favoritesStore.getContextEpoch() !== context.contextEpoch) return false;
-  return favoriteToggleOrder.isLatest(climbUuid, context.token);
-}
+import { favoriteToggleOrder, ownsFavoriteWrite } from './favorite-toggle-order';
 import { addFavoriteLocal, removeFavoriteLocal } from '../../../hooks/use-offline-mutations';
 import type { GraphQLFetch } from '@boardsesh/offline-sync';
 import { drainMutationQueue } from '../../../offline/offline-sync-adapter';

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -47,6 +47,16 @@ import { offlineAwareRequest } from '../offline-request';
 import { useOfflineDownloadsEnabled } from '../../../providers/feature-flags-provider';
 import { favoritesStore } from '@boardsesh/climb-actions';
 import { favoriteToggleOrder } from './favorite-toggle-order';
+
+/**
+ * Whether a settling favourite toggle may still write to the shared store: it
+ * must be the newest toggle for that climb AND the store must still be scoped
+ * to the context the toggle started in (board + angle + user).
+ */
+function ownsFavoriteWrite(climbUuid: string, context: { token: number; contextEpoch: number }): boolean {
+  if (favoritesStore.getContextEpoch() !== context.contextEpoch) return false;
+  return favoriteToggleOrder.isLatest(climbUuid, context.token);
+}
 import { addFavoriteLocal, removeFavoriteLocal } from '../../../hooks/use-offline-mutations';
 import type { GraphQLFetch } from '@boardsesh/offline-sync';
 import { drainMutationQueue } from '../../../offline/offline-sync-adapter';
@@ -1016,21 +1026,25 @@ export function useToggleFavorite() {
     // heart, whether it succeeded or failed.
     onMutate: (variables) => {
       const token = favoriteToggleOrder.begin(variables.input.climbUuid);
+      // The store is a singleton scoped to one board+angle+user at a time. Note
+      // which scope this toggle belongs to so a slow response can't write a 40°
+      // result into a store the user has since re-scoped to 25°.
+      const contextEpoch = favoritesStore.getContextEpoch();
       if (typeof variables.currentlyFavorited === 'boolean') {
         favoritesStore.setIsFavorited(variables.input.climbUuid, !variables.currentlyFavorited);
       }
-      return { token };
+      return { token, contextEpoch };
     },
     onError: (_error, variables, context) => {
       if (typeof variables.currentlyFavorited !== 'boolean') return;
-      if (!context || !favoriteToggleOrder.isLatest(variables.input.climbUuid, context.token)) return;
+      if (!context || !ownsFavoriteWrite(variables.input.climbUuid, context)) return;
       favoritesStore.setIsFavorited(variables.input.climbUuid, variables.currentlyFavorited);
     },
     onSettled: (_data, _error, variables, context) => {
       if (context) favoriteToggleOrder.settle(variables.input.climbUuid, context.token);
     },
     onSuccess: (data, variables, context) => {
-      if (!context || favoriteToggleOrder.isLatest(variables.input.climbUuid, context.token)) {
+      if (!context || ownsFavoriteWrite(variables.input.climbUuid, context)) {
         favoritesStore.setIsFavorited(variables.input.climbUuid, data.toggleFavorite.favorited);
       }
       void queryClient.invalidateQueries({ queryKey: ['searchClimbs'] });

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -45,6 +45,7 @@ import { myBoardsQueryKey } from '../query-keys';
 import { getDatabaseHandle } from '../../../db';
 import { offlineAwareRequest } from '../offline-request';
 import { useOfflineDownloadsEnabled } from '../../../providers/feature-flags-provider';
+import { favoritesStore } from '@boardsesh/climb-actions';
 import { addFavoriteLocal, removeFavoriteLocal } from '../../../hooks/use-offline-mutations';
 import type { GraphQLFetch } from '@boardsesh/offline-sync';
 import { drainMutationQueue } from '../../../offline/offline-sync-adapter';
@@ -1004,7 +1005,25 @@ export function useToggleFavorite() {
         input: variables.input,
       });
     },
+    // Keep the shared `favoritesStore` in step with the toggle so the climb
+    // list's heart flips the moment you favourite from the play drawer or the
+    // actions sheet — the list's batched fetch only covers uuids it hasn't
+    // already seen, so it would never re-read this one on its own.
+    onMutate: (variables) => {
+      if (typeof variables.currentlyFavorited !== 'boolean') return;
+      favoritesStore.setIsFavorited(variables.input.climbUuid, !variables.currentlyFavorited);
+    },
+    onError: (_error, variables) => {
+      if (typeof variables.currentlyFavorited !== 'boolean') return;
+      // Only roll back while the store still holds the value THIS toggle wrote;
+      // a newer tap that already landed owns the state (mirrors
+      // `resolveFavoriteRollback` in the play drawer).
+      const optimistic = !variables.currentlyFavorited;
+      if (favoritesStore.getIsFavorited(variables.input.climbUuid) !== optimistic) return;
+      favoritesStore.setIsFavorited(variables.input.climbUuid, variables.currentlyFavorited);
+    },
     onSuccess: (data, variables) => {
+      favoritesStore.setIsFavorited(variables.input.climbUuid, data.toggleFavorite.favorited);
       void queryClient.invalidateQueries({ queryKey: ['searchClimbs'] });
       void queryClient.invalidateQueries({ queryKey: ['infiniteSearchClimbs'] });
       // Bust the per-climb favorite-status cache so a re-open reflects the new

--- a/packages/mobile/src/lib/graphql/hooks/use-mobile-climb-actions-data.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-mobile-climb-actions-data.ts
@@ -142,7 +142,7 @@ export function useMobileClimbActionsData(): MobileClimbActionsData {
   mutationDepsRef.current = { activeBoard, queryClient, isAuthenticated, offlineEnabled };
 
   const toggleFavoriteMutation = useMutation({
-    mutationFn: async (climbUuid: string): Promise<{ uuid: string; favorited: boolean }> => {
+    mutationFn: async (climbUuid: string): Promise<{ uuid: string; favorited: boolean; contextEpoch: number }> => {
       const { activeBoard: board, queryClient: client, offlineEnabled: offline } = mutationDepsRef.current;
       if (!board) throw new Error('Cannot toggle favorite: no active board selected.');
       // The favorite key is (userId, boardName, climbUuid, angle) on the
@@ -153,6 +153,10 @@ export function useMobileClimbActionsData(): MobileClimbActionsData {
       if (board.angle == null) throw new Error('Cannot toggle favorite: active board has no angle.');
       const input = { boardName: board.boardType, climbUuid, angle: board.angle };
       const currentlyFavorited = favoritesStore.getIsFavorited(climbUuid);
+      // The scope this toggle belongs to. The store is a singleton holding one
+      // board+angle+user at a time, so a slow response must not write a 40°
+      // result into a store the user has since re-scoped to 25°.
+      const contextEpoch = favoritesStore.getContextEpoch();
       const db = getDatabaseHandle();
 
       // Local-first only with the offline flag on; otherwise the plain
@@ -164,18 +168,21 @@ export function useMobileClimbActionsData(): MobileClimbActionsData {
           await addFavoriteLocal(db, input);
         }
         scheduleDrain(db, client);
-        return { uuid: climbUuid, favorited: !currentlyFavorited };
+        return { uuid: climbUuid, favorited: !currentlyFavorited, contextEpoch };
       }
 
       const response = await getHttpClient().request<ToggleFavoriteMutationResponse>(TOGGLE_FAVORITE, {
         input,
       });
-      return { uuid: climbUuid, favorited: response.toggleFavorite.favorited };
+      return { uuid: climbUuid, favorited: response.toggleFavorite.favorited, contextEpoch };
     },
     // Write server truth back into the store this mutation read
     // `currentlyFavorited` from, so a heart in the climb list reflects the
-    // toggle without waiting for a refetch.
-    onSuccess: ({ uuid, favorited }) => {
+    // toggle without waiting for a refetch — unless the store has been
+    // re-scoped while the request was in flight, in which case the result
+    // belongs to a context that is no longer on screen.
+    onSuccess: ({ uuid, favorited, contextEpoch }) => {
+      if (favoritesStore.getContextEpoch() !== contextEpoch) return;
       favoritesStore.setIsFavorited(uuid, favorited);
     },
   });

--- a/packages/mobile/src/lib/graphql/hooks/use-mobile-climb-actions-data.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-mobile-climb-actions-data.ts
@@ -13,12 +13,12 @@
 // Tracked in #2449 as a backend cleanup — favorites should be keyed by climb
 // UUID alone. Once #2449 lands, drop those args from the mutation.
 //
-// Favorites Set is left empty: the current `GET_FAVORITES` query takes a
-// `climbUuids` list (web batches it as the user scrolls a climb list), and
-// mobile has no equivalent batched fetcher today. When a mobile screen needs
-// per-climb favorited state, fetch with `GET_FAVORITES` for the visible
-// UUIDs and write the result into `favoritesStore` directly so subscribers
-// re-render — the toggle path here doesn't touch that store.
+// No `favorites` Set is passed to the provider. `GET_FAVORITES` takes a
+// `climbUuids` list, so there is no single query that returns "everything the
+// user favourited"; the state arrives incrementally instead, from
+// `useClimbListFavorites` (the visible climb list's UUIDs) and from every
+// toggle. Both write into `favoritesStore` directly, and FavoritesProvider
+// leaves the set alone while the prop is omitted.
 
 import { useCallback, useRef } from 'react';
 import { useMutation, useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query';
@@ -87,7 +87,6 @@ function bumpPlaylistClimbCount(queryClient: QueryClient, playlistUuid: string, 
 
 type MobileClimbActionsData = {
   favoritesProviderProps: {
-    favorites: Set<string>;
     toggleFavorite: (uuid: string) => Promise<boolean>;
     isLoading: boolean;
     isAuthenticated: boolean;
@@ -172,6 +171,12 @@ export function useMobileClimbActionsData(): MobileClimbActionsData {
         input,
       });
       return { uuid: climbUuid, favorited: response.toggleFavorite.favorited };
+    },
+    // Write server truth back into the store this mutation read
+    // `currentlyFavorited` from, so a heart in the climb list reflects the
+    // toggle without waiting for a refetch.
+    onSuccess: ({ uuid, favorited }) => {
+      favoritesStore.setIsFavorited(uuid, favorited);
     },
   });
 
@@ -301,12 +306,10 @@ export function useMobileClimbActionsData(): MobileClimbActionsData {
 
   return {
     favoritesProviderProps: {
-      // Fresh empty Set per render rather than a module-scoped constant —
-      // a future provider that calls `.add()`/`.delete()` on its own copy
-      // can't accidentally mutate a shared singleton this way. Allocating an
-      // empty Set is essentially free; the mobile UI doesn't yet read this
-      // anyway, so even the trigger-effect cost is moot.
-      favorites: new Set<string>(),
+      // `favorites` is deliberately omitted — see the module note. Passing a
+      // fresh empty Set here re-ran the provider's layout effect on every
+      // render and bulk-replaced the store with nothing, wiping the hearts the
+      // climb list had just fetched.
       toggleFavorite,
       isLoading: isAuthLoading,
       isAuthenticated,

--- a/packages/mobile/src/lib/graphql/hooks/use-mobile-climb-actions-data.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-mobile-climb-actions-data.ts
@@ -23,6 +23,7 @@
 import { useCallback, useRef } from 'react';
 import { useMutation, useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { favoritesStore } from '@boardsesh/climb-actions';
+import { favoriteToggleOrder, ownsFavoriteWrite } from './favorite-toggle-order';
 import { TOGGLE_FAVORITE, type ToggleFavoriteMutationResponse } from '@boardsesh/graphql/operations/favorites';
 import {
   GET_ALL_USER_PLAYLISTS,
@@ -142,7 +143,7 @@ export function useMobileClimbActionsData(): MobileClimbActionsData {
   mutationDepsRef.current = { activeBoard, queryClient, isAuthenticated, offlineEnabled };
 
   const toggleFavoriteMutation = useMutation({
-    mutationFn: async (climbUuid: string): Promise<{ uuid: string; favorited: boolean; contextEpoch: number }> => {
+    mutationFn: async (climbUuid: string): Promise<{ uuid: string; favorited: boolean }> => {
       const { activeBoard: board, queryClient: client, offlineEnabled: offline } = mutationDepsRef.current;
       if (!board) throw new Error('Cannot toggle favorite: no active board selected.');
       // The favorite key is (userId, boardName, climbUuid, angle) on the
@@ -153,10 +154,6 @@ export function useMobileClimbActionsData(): MobileClimbActionsData {
       if (board.angle == null) throw new Error('Cannot toggle favorite: active board has no angle.');
       const input = { boardName: board.boardType, climbUuid, angle: board.angle };
       const currentlyFavorited = favoritesStore.getIsFavorited(climbUuid);
-      // The scope this toggle belongs to. The store is a singleton holding one
-      // board+angle+user at a time, so a slow response must not write a 40°
-      // result into a store the user has since re-scoped to 25°.
-      const contextEpoch = favoritesStore.getContextEpoch();
       const db = getDatabaseHandle();
 
       // Local-first only with the offline flag on; otherwise the plain
@@ -168,22 +165,32 @@ export function useMobileClimbActionsData(): MobileClimbActionsData {
           await addFavoriteLocal(db, input);
         }
         scheduleDrain(db, client);
-        return { uuid: climbUuid, favorited: !currentlyFavorited, contextEpoch };
+        return { uuid: climbUuid, favorited: !currentlyFavorited };
       }
 
       const response = await getHttpClient().request<ToggleFavoriteMutationResponse>(TOGGLE_FAVORITE, {
         input,
       });
-      return { uuid: climbUuid, favorited: response.toggleFavorite.favorited, contextEpoch };
+      return { uuid: climbUuid, favorited: response.toggleFavorite.favorited };
     },
+    // Claim the climb before the request so this toggle can tell, when it
+    // settles, whether a newer tap has taken over — the same ordering the
+    // `useToggleFavorite` path uses. Both mutations write the same singleton
+    // store, so they need the same rules.
+    onMutate: (climbUuid: string) => ({
+      token: favoriteToggleOrder.begin(climbUuid),
+      contextEpoch: favoritesStore.getContextEpoch(),
+    }),
     // Write server truth back into the store this mutation read
     // `currentlyFavorited` from, so a heart in the climb list reflects the
-    // toggle without waiting for a refetch — unless the store has been
-    // re-scoped while the request was in flight, in which case the result
-    // belongs to a context that is no longer on screen.
-    onSuccess: ({ uuid, favorited, contextEpoch }) => {
-      if (favoritesStore.getContextEpoch() !== contextEpoch) return;
+    // toggle without waiting for a refetch — unless a newer tap owns the climb
+    // now, or the store was re-scoped to another board/angle/user in flight.
+    onSuccess: ({ uuid, favorited }, _climbUuid, context) => {
+      if (!context || !ownsFavoriteWrite(uuid, context)) return;
       favoritesStore.setIsFavorited(uuid, favorited);
+    },
+    onSettled: (_data, _error, climbUuid, context) => {
+      if (context) favoriteToggleOrder.settle(climbUuid, context.token);
     },
   });
 

--- a/packages/mobile/src/providers/__tests__/favorites-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/favorites-provider.test.tsx
@@ -73,6 +73,30 @@ describe('FavoritesProvider', () => {
     expect(favoritesStore.getIsAuthenticated()).toBe(true);
   });
 
+  it('leaves the store alone when no `favorites` prop is given (mobile fills it incrementally)', () => {
+    favoritesStore.setFavorites(new Set(['from-the-climb-list']));
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <FavoritesProvider isAuthenticated>{children}</FavoritesProvider>
+    );
+    const { rerender } = renderHook(() => useFavoritesContext(), { wrapper });
+    rerender();
+
+    expect(favoritesStore.getIsFavorited('from-the-climb-list')).toBe(true);
+  });
+
+  it('toggleFavorite from context writes the result into the store', async () => {
+    const toggleFavorite = vi.fn(async (_uuid: string) => true);
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <FavoritesProvider toggleFavorite={toggleFavorite}>{children}</FavoritesProvider>
+    );
+    const { result } = renderHook(() => useFavoritesContext(), { wrapper });
+
+    await result.current.toggleFavorite('climb-1');
+
+    expect(favoritesStore.getIsFavorited('climb-1')).toBe(true);
+  });
+
   it('toggleFavorite from context calls the prop function and tracks `added` once', async () => {
     const toggleFavorite = vi.fn(async (_uuid: string) => true);
     const wrapper = ({ children }: { children: ReactNode }) => (

--- a/packages/mobile/src/providers/__tests__/favorites-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/favorites-provider.test.tsx
@@ -17,7 +17,7 @@ import { FavoritesProvider, useFavoritesContext } from '../favorites-provider';
 describe('FavoritesProvider', () => {
   beforeEach(() => {
     // Reset the shared store between tests so subscriber state doesn't leak.
-    favoritesStore.setFavorites(new Set());
+    favoritesStore.reset();
     favoritesStore.setMeta(false, false);
     trackMock.mockClear();
   });

--- a/packages/mobile/src/providers/favorites-provider.tsx
+++ b/packages/mobile/src/providers/favorites-provider.tsx
@@ -4,12 +4,13 @@
 // components subscribe per-uuid via `useSyncExternalStore`, avoiding the
 // React Context "all consumers re-render" cascade.
 //
-// Mobile has no consumer screens for favorites today, so the provider
-// accepts optional `favorites` / `toggleFavorite` / `isLoading` /
-// `isAuthenticated` props and falls back to empty defaults. The data
-// hook (parallel to web's `useClimbActionsData`) is a follow-up — when a
-// mobile screen needs favorites, build `useMobileClimbActionsData` and
-// wire its output into this provider's props.
+// On mobile the store is filled incrementally rather than in one shot:
+// `useClimbListFavorites` fetches the visible climb list's UUIDs and
+// `useToggleFavorite` writes each toggle straight in. So the `favorites`
+// prop is OPTIONAL here and, when omitted, this provider never writes the
+// set at all — handing it an empty Set each render would wipe whatever the
+// list just fetched. Web still passes a full set and keeps the old
+// bulk-replace behaviour.
 
 import { createContext, useContext, useCallback, useLayoutEffect, useMemo, type ReactNode } from 'react';
 import { favoritesStore } from '@boardsesh/climb-actions';
@@ -32,8 +33,6 @@ type FavoritesProviderProps = {
   children: ReactNode;
 };
 
-const EMPTY_FAVORITES: ReadonlySet<string> = new Set();
-
 export function FavoritesProvider({
   favorites,
   toggleFavorite = noopToggleFavorite,
@@ -51,7 +50,8 @@ export function FavoritesProvider({
   // subscriber is in the tree to observe the leftover data either. A future
   // remount will overwrite via `setFavorites` on its own mount.
   useLayoutEffect(() => {
-    favoritesStore.setFavorites(favorites ?? (EMPTY_FAVORITES as Set<string>));
+    if (!favorites) return;
+    favoritesStore.setFavorites(favorites);
   }, [favorites]);
 
   useLayoutEffect(() => {
@@ -61,6 +61,11 @@ export function FavoritesProvider({
   const trackedToggleFavorite = useCallback(
     async (uuid: string): Promise<boolean> => {
       const isNowFavorited = await toggleFavorite(uuid);
+      // Reflect the result in the store so a heart flips wherever it's rendered.
+      // The wired-up `toggleFavorite` writes this too; doing it here as well
+      // keeps the provider correct for any other implementation of the prop,
+      // and the store no-ops a write that doesn't change the value.
+      favoritesStore.setIsFavorited(uuid, isNowFavorited);
       track(SHARED_EVENTS.FavoriteToggle, {
         action: isNowFavorited ? 'added' : 'removed',
         climbUuid: uuid,

--- a/packages/mobile/src/providers/favorites-provider.tsx
+++ b/packages/mobile/src/providers/favorites-provider.tsx
@@ -60,12 +60,18 @@ export function FavoritesProvider({
 
   const trackedToggleFavorite = useCallback(
     async (uuid: string): Promise<boolean> => {
+      // Capture the scope BEFORE awaiting: the store holds one board+angle+user
+      // at a time, and re-scoping while this is in flight makes the result
+      // belong to a list that is no longer on screen.
+      const contextEpoch = favoritesStore.getContextEpoch();
       const isNowFavorited = await toggleFavorite(uuid);
       // Reflect the result in the store so a heart flips wherever it's rendered.
-      // The wired-up `toggleFavorite` writes this too; doing it here as well
-      // keeps the provider correct for any other implementation of the prop,
-      // and the store no-ops a write that doesn't change the value.
-      favoritesStore.setIsFavorited(uuid, isNowFavorited);
+      // The wired-up `toggleFavorite` writes this too (under the same guard);
+      // doing it here as well keeps the provider correct for any other
+      // implementation of the prop, and the store no-ops an unchanged value.
+      if (favoritesStore.getContextEpoch() === contextEpoch) {
+        favoritesStore.setIsFavorited(uuid, isNowFavorited);
+      }
       track(SHARED_EVENTS.FavoriteToggle, {
         action: isNowFavorited ? 'added' : 'removed',
         climbUuid: uuid,

--- a/packages/shared/climb-actions/src/__tests__/favorites-store.test.ts
+++ b/packages/shared/climb-actions/src/__tests__/favorites-store.test.ts
@@ -41,6 +41,69 @@ describe('FavoritesStore', () => {
     expect(listener).toHaveBeenCalledTimes(2);
   });
 
+  it('mergeFavorites adds the favorited subset and clears the rest of the batch', () => {
+    const store = new FavoritesStore();
+    store.setFavorites(new Set(['a']));
+
+    store.mergeFavorites(['a', 'b'], ['b']);
+
+    expect(store.getIsFavorited('a')).toBe(false);
+    expect(store.getIsFavorited('b')).toBe(true);
+  });
+
+  it('mergeFavorites leaves uuids outside the batch alone', () => {
+    const store = new FavoritesStore();
+    store.setFavorites(new Set(['earlier-page']));
+
+    store.mergeFavorites(['a'], []);
+
+    expect(store.getIsFavorited('earlier-page')).toBe(true);
+  });
+
+  it('mergeFavorites only notifies when something actually changed', () => {
+    const store = new FavoritesStore();
+    store.setFavorites(new Set(['a']));
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    store.mergeFavorites(['a'], ['a']);
+    expect(listener).not.toHaveBeenCalled();
+
+    store.mergeFavorites(['a'], []);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('setIsFavorited flips one uuid and notifies only on a real change', () => {
+    const store = new FavoritesStore();
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    store.setIsFavorited('a', true);
+    expect(store.getIsFavorited('a')).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    store.setIsFavorited('a', true);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    store.setIsFavorited('a', false);
+    expect(store.getIsFavorited('a')).toBe(false);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('reset clears everything, and no-ops when already empty', () => {
+    const store = new FavoritesStore();
+    store.setFavorites(new Set(['a', 'b']));
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    store.reset();
+    expect(store.getIsFavorited('a')).toBe(false);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    store.reset();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
   it('unsubscribe stops further notifications', () => {
     const store = new FavoritesStore();
     const listener = vi.fn();

--- a/packages/shared/climb-actions/src/__tests__/favorites-store.test.ts
+++ b/packages/shared/climb-actions/src/__tests__/favorites-store.test.ts
@@ -90,6 +90,29 @@ describe('FavoritesStore', () => {
     expect(listener).toHaveBeenCalledTimes(2);
   });
 
+  it('applyContext clears the set when the context changes, and reports it', () => {
+    const store = new FavoritesStore();
+    store.applyContext('kilter:40:1');
+    store.setFavorites(new Set(['a']));
+
+    expect(store.applyContext('kilter:40:1')).toBe(false);
+    expect(store.getIsFavorited('a')).toBe(true);
+
+    // A different angle is a different favourite key on the backend.
+    expect(store.applyContext('kilter:25:1')).toBe(true);
+    expect(store.getIsFavorited('a')).toBe(false);
+  });
+
+  it('applyContext treats a reset store as unscoped, so the same context re-applies', () => {
+    const store = new FavoritesStore();
+    store.applyContext('kilter:40:1');
+    store.reset();
+
+    // reset() forgets the context too — otherwise a caller that reset the store
+    // would never be told to re-fetch the context it is still on.
+    expect(store.applyContext('kilter:40:1')).toBe(true);
+  });
+
   it('reset clears everything, and no-ops when already empty', () => {
     const store = new FavoritesStore();
     store.setFavorites(new Set(['a', 'b']));

--- a/packages/shared/climb-actions/src/__tests__/favorites-store.test.ts
+++ b/packages/shared/climb-actions/src/__tests__/favorites-store.test.ts
@@ -90,6 +90,40 @@ describe('FavoritesStore', () => {
     expect(listener).toHaveBeenCalledTimes(2);
   });
 
+  it('mergeFavorites leaves a climb toggled after the lookup was issued alone', () => {
+    const store = new FavoritesStore();
+    const startedAtStamp = store.getWriteStamp();
+
+    // The user hearts the climb while the batch is still in flight.
+    store.setIsFavorited('a', true);
+
+    // The response reflects the pre-toggle server state; applying it would
+    // clear the heart the user just set.
+    store.mergeFavorites(['a', 'b'], [], startedAtStamp);
+
+    expect(store.getIsFavorited('a')).toBe(true);
+    expect(store.getIsFavorited('b')).toBe(false);
+  });
+
+  it('mergeFavorites still applies to climbs untouched since the lookup', () => {
+    const store = new FavoritesStore();
+    store.setIsFavorited('a', true);
+    const startedAtStamp = store.getWriteStamp();
+
+    store.mergeFavorites(['a'], [], startedAtStamp);
+
+    expect(store.getIsFavorited('a')).toBe(false);
+  });
+
+  it('bumps the context epoch on reset so in-flight writers can tell', () => {
+    const store = new FavoritesStore();
+    const before = store.getContextEpoch();
+
+    store.applyContext('kilter:40:1');
+
+    expect(store.getContextEpoch()).not.toBe(before);
+  });
+
   it('applyContext clears the set when the context changes, and reports it', () => {
     const store = new FavoritesStore();
     store.applyContext('kilter:40:1');

--- a/packages/shared/climb-actions/src/favorites-store.ts
+++ b/packages/shared/climb-actions/src/favorites-store.ts
@@ -10,6 +10,7 @@
  */
 export class FavoritesStore {
   private favorites = new Set<string>();
+  private contextKeyValue: string | null = null;
   private isLoadingValue = false;
   private isAuthenticatedValue = false;
   private listeners = new Set<() => void>();
@@ -79,10 +80,28 @@ export class FavoritesStore {
     this.notify();
   }
 
-  /** Drop everything. Used when the board/angle/auth context changes, since
-   *  favorites are keyed by (board, climb, angle) on the backend and a previous
-   *  context's hearts must not paint the new one's rows. */
+  /**
+   * Scope the set to a context — mobile passes board + angle + auth. Clears
+   * everything when it differs from the context the current data was fetched
+   * for, since favorites are keyed by (board, climb, angle) on the backend and
+   * a previous context's hearts must not paint the new one's rows. Returns
+   * whether the context changed, so a caller can drop its own fetched-uuid
+   * bookkeeping in the same step.
+   *
+   * Lives on the store rather than in the calling hook because the store
+   * outlives any one hook instance: remounting the climb list must still notice
+   * a board or angle change that happened while it was unmounted.
+   */
+  applyContext(contextKey: string): boolean {
+    if (this.contextKeyValue === contextKey) return false;
+    this.reset();
+    this.contextKeyValue = contextKey;
+    return true;
+  }
+
+  /** Drop everything, including the context the data was fetched for. */
   reset(): void {
+    this.contextKeyValue = null;
     if (this.favorites.size === 0) return;
     this.favorites = new Set();
     this.notify();

--- a/packages/shared/climb-actions/src/favorites-store.ts
+++ b/packages/shared/climb-actions/src/favorites-store.ts
@@ -42,6 +42,52 @@ export class FavoritesStore {
   /** Read auth state. Stable for the lifetime of a session. */
   getIsAuthenticated = (): boolean => this.isAuthenticatedValue;
 
+  /**
+   * Merge one batched lookup into the set. `knownUuids` is every climb the
+   * lookup asked about; `favoritedUuids` is the subset that came back favorited.
+   * Climbs in `knownUuids` but absent from `favoritedUuids` are cleared, so a
+   * favourite removed on another device stops showing a heart once its row is
+   * re-fetched. Climbs outside `knownUuids` are left alone — batches cover a
+   * scroll window, not the whole list, so they must not wipe earlier pages.
+   */
+  mergeFavorites(knownUuids: readonly string[], favoritedUuids: readonly string[]): void {
+    const favoritedSet = new Set(favoritedUuids);
+    let changed = false;
+    const next = new Set(this.favorites);
+    for (const uuid of knownUuids) {
+      if (favoritedSet.has(uuid)) {
+        if (!next.has(uuid)) {
+          next.add(uuid);
+          changed = true;
+        }
+      } else if (next.delete(uuid)) {
+        changed = true;
+      }
+    }
+    if (!changed) return;
+    this.favorites = next;
+    this.notify();
+  }
+
+  /** Set one climb's favorited state (a toggle's optimistic write / server truth). */
+  setIsFavorited(uuid: string, favorited: boolean): void {
+    if (this.favorites.has(uuid) === favorited) return;
+    const next = new Set(this.favorites);
+    if (favorited) next.add(uuid);
+    else next.delete(uuid);
+    this.favorites = next;
+    this.notify();
+  }
+
+  /** Drop everything. Used when the board/angle/auth context changes, since
+   *  favorites are keyed by (board, climb, angle) on the backend and a previous
+   *  context's hearts must not paint the new one's rows. */
+  reset(): void {
+    if (this.favorites.size === 0) return;
+    this.favorites = new Set();
+    this.notify();
+  }
+
   /** Bulk-replace the favorites set (called when React Query data changes). */
   setFavorites(next: Set<string>): void {
     // React Query creates new Set instances on each fetch, so reference equality

--- a/packages/shared/climb-actions/src/favorites-store.ts
+++ b/packages/shared/climb-actions/src/favorites-store.ts
@@ -11,6 +11,19 @@
 export class FavoritesStore {
   private favorites = new Set<string>();
   private contextKeyValue: string | null = null;
+  /**
+   * Monotonic clock for single-climb writes. A batched lookup carries the
+   * stamp it started at, so a response that raced a toggle can tell that the
+   * climb changed under it and leave the newer value alone.
+   */
+  private writeClock = 0;
+  private toggleStamps = new Map<string, number>();
+  /**
+   * Bumped whenever the data is scoped to a different context. An in-flight
+   * toggle captures it and drops its write if the store has moved on — a 40°
+   * favourite must not paint a heart on the 25° list.
+   */
+  private contextEpochValue = 0;
   private isLoadingValue = false;
   private isAuthenticatedValue = false;
   private listeners = new Set<() => void>();
@@ -36,6 +49,15 @@ export class FavoritesStore {
     return this.favorites.has(uuid);
   };
 
+  /** The current write clock. Take this BEFORE starting a batched lookup and
+   *  hand it back to `mergeFavorites`, so the merge can skip climbs a toggle
+   *  changed while the request was in flight. */
+  getWriteStamp = (): number => this.writeClock;
+
+  /** Identifies the context the data is currently scoped to. An async writer
+   *  captures this at the start and discards its write if it no longer matches. */
+  getContextEpoch = (): number => this.contextEpochValue;
+
   /** Read loading state. Used via useSyncExternalStore so only components
    *  that actually read this value re-render when it changes. */
   getIsLoading = (): boolean => this.isLoadingValue;
@@ -51,11 +73,16 @@ export class FavoritesStore {
    * re-fetched. Climbs outside `knownUuids` are left alone — batches cover a
    * scroll window, not the whole list, so they must not wipe earlier pages.
    */
-  mergeFavorites(knownUuids: readonly string[], favoritedUuids: readonly string[]): void {
+  mergeFavorites(knownUuids: readonly string[], favoritedUuids: readonly string[], startedAtStamp?: number): void {
     const favoritedSet = new Set(favoritedUuids);
     let changed = false;
     const next = new Set(this.favorites);
     for (const uuid of knownUuids) {
+      // A toggle that landed after this lookup was issued is newer than the
+      // answer in hand: the server read the pre-toggle state, so applying it
+      // would undo a heart the user just set (and the caller's fetched-uuid
+      // dedupe means nothing would correct it).
+      if (startedAtStamp !== undefined && (this.toggleStamps.get(uuid) ?? 0) > startedAtStamp) continue;
       if (favoritedSet.has(uuid)) {
         if (!next.has(uuid)) {
           next.add(uuid);
@@ -72,6 +99,10 @@ export class FavoritesStore {
 
   /** Set one climb's favorited state (a toggle's optimistic write / server truth). */
   setIsFavorited(uuid: string, favorited: boolean): void {
+    // Stamped even when the value doesn't change, so a batch that raced this
+    // toggle still recognises the climb as newer than its own answer.
+    this.writeClock += 1;
+    this.toggleStamps.set(uuid, this.writeClock);
     if (this.favorites.has(uuid) === favorited) return;
     const next = new Set(this.favorites);
     if (favorited) next.add(uuid);
@@ -102,6 +133,8 @@ export class FavoritesStore {
   /** Drop everything, including the context the data was fetched for. */
   reset(): void {
     this.contextKeyValue = null;
+    this.contextEpochValue += 1;
+    this.toggleStamps.clear();
     if (this.favorites.size === 0) return;
     this.favorites = new Set();
     this.notify();

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -466,6 +466,7 @@
     "climbRow": {
       "addToQueue": "Zur Warteschlange hinzufügen",
       "toggleFavorite": "Favorit umschalten",
+      "favorited": "Favorit",
       "share": "Boulder teilen",
       "moreActions": "Mehr Aktionen",
       "projectFallback": "Projekt",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -466,6 +466,7 @@
     "climbRow": {
       "addToQueue": "Add to queue",
       "toggleFavorite": "Toggle favorite",
+      "favorited": "Favorited",
       "share": "Share climb",
       "moreActions": "More actions",
       "projectFallback": "Project",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -466,6 +466,7 @@
     "climbRow": {
       "addToQueue": "Añadir a la cola",
       "toggleFavorite": "Alternar favorito",
+      "favorited": "Favorito",
       "share": "Compartir bloque",
       "moreActions": "Más acciones",
       "projectFallback": "Proyecto",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -466,6 +466,7 @@
     "climbRow": {
       "addToQueue": "Ajouter à la file",
       "toggleFavorite": "Basculer favori",
+      "favorited": "Favori",
       "share": "Partager le bloc",
       "moreActions": "Plus d'actions",
       "projectFallback": "Projet",


### PR DESCRIPTION
## Summary

You could heart a climb but never see it again while scrolling the list. Asked whether that was deliberate — it wasn't. The plumbing was already there and the code said so: `favoritesStore` exists precisely so rows can subscribe per-uuid without a context re-render cascade, and the note at the top of `use-mobile-climb-actions-data.ts` named the missing piece — `GET_FAVORITES` takes a `climbUuids` list, mobile had no batched fetcher, so the provider handed the store an empty Set forever. Favourite state was only ever read one climb at a time, on opening the play drawer or the actions sheet.

This adds the fetcher and the indicator it feeds:

- **`useClimbListFavorites`** batches the visible climbs' uuids into `GET_FAVORITES` (chunked at the backend's 500 cap) and merges the result into the store. Same shape as the existing `useClimbListPlaylistMemberships`: deferred past the active fling via `runAfterInteractions`, deduped so each climb is asked about once, and re-scoped when board / angle / **user** changes — favourites are keyed per-angle server-side, so 40°'s hearts must not paint 25°'s rows, and an account switch on a shared device must not show one climber another's. Signed-out is a no-op. The context check lives on the store (`applyContext`) rather than in the hook, because the store outlives any one hook instance: remounting the list must still notice a change that happened while it was unmounted.
- **The heart** renders beside the ascent-status glyph in the same neutral grey and 16pt size as that glyph. The rule for this cluster is already documented above `ASCENT_STATUS_ICON`: meaning is carried by glyph SHAPE in a single neutral grey, so colour keeps meaning grade and nothing else, and the signal survives for colour-blind users. The filled silhouette is what marks it as a favourite; the actions sheet keeps the red heart, where it is a control rather than a scan-line marker. It's its own `React.memo`'d component subscribed over the primitive uuid, so favouriting one climb re-renders one 16pt icon — not the row, not the list. Opt-in per surface (`showFavorite`), like the playlist chips, since only the climb list feeds the store.
- **Toggle sync**: both toggle mutations write into the store — optimistic on tap, server truth on success, rollback on failure — and every write asks one shared rule (`ownsFavoriteWrite`): this toggle must still be the newest for that climb, and the store must still be scoped to the context the toggle started in.

Four races fixed along the way, each with a test verified to fail without its fix:

1. **A batched lookup could undo a toggle.** The batch is deferred past the fling, so there is a real window in which the user hearts a climb the in-flight lookup is about to report as unfavourited; the merge cleared it, permanently, since the uuid stayed marked as fetched. The store now keeps a monotonic write clock — a lookup takes a stamp before asking, and the merge skips any climb toggled since.
2. **Value comparison couldn't order rollbacks.** Tap 1 (add) writes `true`; tap 2 (remove) writes `false`; tap 2 fails and rolls back to `true`; tap 1 then fails, sees its own optimistic value, and "correctly" rolls back to `false` — landing the heart on the older attempt. `FavoriteToggleOrder` gives each toggle a token so identity, not equality, decides who owns the write.
3. **A toggle could outlive its context.** A 40° toggle resolving after the user switched to 25° wrote into the re-scoped singleton. Each toggle now captures a context epoch and drops its write if the store has moved on.
4. **A cancelled multi-chunk fetch leaked.** Uuids stayed marked as fetched but never were, so those hearts stayed dark for the session. Release moved into the effect cleanup, which React runs before the replacement effect. The error path still releases asynchronously on purpose — retrying immediately would spin on an offline device.

Also fixes a latent wipe found on the way: the provider was handed a fresh empty `Set` every render, which re-ran its layout effect and bulk-replaced the store with nothing — it would have erased the hearts the list had just fetched. The provider now leaves the set alone when the prop is omitted; web keeps passing a full set and its bulk-replace behaviour.

Author-side verification: `vp run typecheck:mobile`, `vp check` (0 errors), `vp run check:i18n` + `check:i18n:orphans`, `vp run check:mobile-bundle` (android bundle OK, 20.3 MB), and `vp run test:mobile` — 799 files / 8,291 tests green.

**Known limitation, not fixed here:** if the backend processes two rapid toggles out of order, no client-side token can know — the client only has invocation order. Fixing it needs either per-climb serialization or a reconcile fetch after a contended burst; both are more than a race fix, so they're left as a follow-up decision.

## Release Notes

- Favourited climbs now show a heart in the climb list, so you can spot your saved projects while scrolling

## Test plan

1. Sign in, open Climbs tab, heart a climb.
2. Close the sheet → heart shows on that row.
3. Unheart it from the row's ⋮ menu → heart disappears.
4. Change the board angle → hearts reload for that angle.
5. Scroll a few pages → hearts stay on earlier rows.

## Risk

Risk: 2/5 — additive read-only indicator on an existing list, plus one shared store the play drawer and actions sheet already wrote through; covered by unit tests and the full mobile suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBy2XMdkxzDqp42G2PhFnB