### PR TITLE
fix(playlists): say what the start-playlist sheet actually does

### DIFF
--- a/packages/shared/i18n/locales/de/playlists.json
+++ b/packages/shared/i18n/locales/de/playlists.json
@@ -135,9 +135,9 @@
     "deleteFailed": "Die Playlist ließ sich nicht löschen",
     "queueReplace": {
       "title": "Playlist starten?",
-      "message_one": "Damit fliegt {{count}} Boulder aus der Warteschlange hinter deinem aktuellen Boulder.",
-      "message_other": "Damit fliegen {{count}} Boulder aus der Warteschlange hinter deinem aktuellen Boulder.",
-      "cancel": "Warteschlange behalten",
+      "message_one": "Die Playlist läuft ab hier der Reihe nach. Der Boulder in der Warteschlange hinter deinem aktuellen fliegt raus.",
+      "message_other": "Die Playlist läuft ab hier der Reihe nach. Die {{count}} Boulder in der Warteschlange hinter deinem aktuellen fliegen raus.",
+      "cancel": "Abbrechen",
       "confirm": "Playlist starten",
       "loadFailed": "Die Playlist ließ sich nicht starten. Versuch's nochmal."
     },

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -135,9 +135,9 @@
     "deleteFailed": "Failed to delete playlist",
     "queueReplace": {
       "title": "Start playlist?",
-      "message_one": "This will clear {{count}} queued climb after your current climb.",
-      "message_other": "This will clear {{count}} queued climbs after your current climb.",
-      "cancel": "Keep queue",
+      "message_one": "Plays the playlist in order from here. The climb queued after your current one drops out.",
+      "message_other": "Plays the playlist in order from here. The {{count}} climbs queued after your current one drop out.",
+      "cancel": "Cancel",
       "confirm": "Start playlist",
       "loadFailed": "Couldn't start playlist. Try again."
     },

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -135,9 +135,9 @@
     "deleteFailed": "No se pudo eliminar la playlist",
     "queueReplace": {
       "title": "¿Iniciar playlist?",
-      "message_one": "Esto borrará {{count}} bloque en cola después de tu bloque actual.",
-      "message_other": "Esto borrará {{count}} bloques en cola después de tu bloque actual.",
-      "cancel": "Mantener cola",
+      "message_one": "Reproduce la playlist en orden desde aquí. El bloque en cola después de tu bloque actual se elimina.",
+      "message_other": "Reproduce la playlist en orden desde aquí. Los {{count}} bloques en cola después de tu bloque actual se eliminan.",
+      "cancel": "Cancelar",
       "confirm": "Iniciar playlist",
       "loadFailed": "No se pudo iniciar la playlist. Inténtalo de nuevo."
     },

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -135,9 +135,9 @@
     "deleteFailed": "Impossible de supprimer la playlist",
     "queueReplace": {
       "title": "Lancer la playlist ?",
-      "message_one": "Cela supprimera {{count}} bloc en file après votre bloc actuel.",
-      "message_other": "Cela supprimera {{count}} blocs en file après votre bloc actuel.",
-      "cancel": "Garder la file",
+      "message_one": "La playlist se lance dans l'ordre à partir d'ici. Le bloc en file après votre bloc actuel disparaît.",
+      "message_other": "La playlist se lance dans l'ordre à partir d'ici. Les {{count}} blocs en file après votre bloc actuel disparaissent.",
+      "cancel": "Annuler",
       "confirm": "Lancer la playlist",
       "loadFailed": "Impossible de lancer la playlist. Réessayez."
     },


### PR DESCRIPTION
## Summary

Tapping a climb in a playlist raises "Start playlist?" with **Keep queue** / **Start playlist** — and neither label described what the button did.

"Keep queue" reads like a second way to play the climb: queue it up, keep what's already lined up. It isn't. `cancelQueueReplacement` (`packages/mobile/src/lib/playlists/use-playlist-activation.ts`) aborts the pending load, drops the pending replacement, and stops — no climb activates, no drawer opens, you stay on the playlist screen. It's a plain cancel wearing an action's name.

The message had the matching problem from the other side: it named only the cost ("This will clear 2 queued climbs") and never the benefit, so there was nothing to weigh the cost against.

So: rename the cancel button to "Cancel", and rewrite the message to lead with what starting gets you before what it clears.

> **Start playlist?**
> Plays the playlist in order from here. The 2 climbs queued after your current one drop out.
>
> [ Cancel ] [ Start playlist ]

Copy only, in all four locales (en-US, es, fr, de) — no queue logic touched, no keys added or removed, singular/plural forms kept. Behaviour is identical.

Verified locally: all four catalogs parse, key sets are identical across locales (143 keys each), `{{count}}` survives in every plural form, and the diff is 3 lines per file with no reformatting. The repo toolchain (`vp`) can't install in this sandbox — viteplus.dev is blocked by the egress proxy — so lint/tests run in CI rather than here.

## Release Notes

- The playlist start prompt now says what starting does, not just what it clears

## Test plan

1. Play a climb, then queue two more climbs.
2. Open a playlist and tap any climb.
3. Sheet reads "Plays the playlist in order from here."
4. Tap Cancel → you stay on the playlist, queue intact.
5. Tap the climb again → Start playlist → playlist plays in order.

## Risk

Risk: 1/5 — copy only, four locale JSON files, no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWCCuaWeshDRH5Eoe7sm4U

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWCCuaWeshDRH5Eoe7sm4U)_