### PR TITLE
fix(mobile): [native-train] relayout the tab bar when the accessory detaches

### DIFF
--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -430,7 +430,15 @@ bottom tab (e.g. `/wall`, the "On the Wall" tab — `app/(tabs)/wall/`):
 `patches/react-native-screens@4.26.2.patch` carries the iOS 26 bottom-accessory fix: UIKit lays
 an accessory in for free when it's set during the tab controller's initial setup, but not when
 it's attached after the tab bar has appeared — which is exactly our case, since the accessory
-only mounts once a current climb exists. The patch nudges a layout pass on that attach.
+only mounts once a current climb exists. The patch nudges a layout pass on that attach, **and on
+the detach**: `[_controller.tabBar setNeedsLayout]` before the pass, because a docked
+`role="search"` item's frame comes out of `-[UITabBar layoutSubviews]` and nothing else
+invalidates it — that asymmetry left the Climbs search item shoved and unhittable until a
+force-quit (#5055). The nudge fires on the accessory-**identity** edge (so attach→attach with a
+new wrapper counts), and an edge arriving while a pass is in flight is queued in
+`_rnscreens_bottomAccessoryRelayoutNeedsRepeat` rather than dropped. Only
+`applyBottomAccessoryVisibility` may set that flag and it is cleared before re-arming, so the
+layout pass can never schedule itself — that termination property is what BOARDSESH-9K lacked.
 
 **The nudge must never run synchronously.** `applyBottomAccessoryVisibility` is called from
 `updateContainer`, inside a React Native mounting transaction. The first version of the patch
@@ -455,11 +463,15 @@ pnpm keys patches by exact version, so a bump means re-keying. The runbook:
    and the `overrides` pin in `pnpm-workspace.yaml`.
 4. `vp run check:mobile-patches`.
 
-That check is the backstop, and it asserts shape, not just symbols: the deferral sentinels
-(`rnscreens_layoutBottomAccessoryOutsideTransition`, `_rnscreens_bottomAccessoryRelayoutScheduled`,
-`animateAlongsideTransition`) plus a negative assertion that no synchronous layout sits inside
-`applyBottomAccessoryVisibility`. A re-keyed patch that kept the entry-point symbol but restored
-the crashing line would otherwise pass green. If it reports it can't locate the anchor method,
+That check is the backstop, and it asserts shape, not just symbols. Guarding both directions:
+back into the crash — the deferral sentinels (`rnscreens_layoutBottomAccessoryOutsideTransition`,
+`_rnscreens_bottomAccessoryRelayoutScheduled`, `animateAlongsideTransition`) plus a negative
+assertion that no synchronous layout sits inside `applyBottomAccessoryVisibility`; and back into
+#5055 — the `[_controller.tabBar setNeedsLayout];` line, the repeat/identity ivars, an
+`orderedSentinels` triple proving the schedule call sits AFTER both branches rather than nested in
+the attach one, plus negative assertions on the old attach-only method name and on the layout pass
+arming its own repeat. A re-keyed patch that kept the entry-point symbol but restored either
+regression would otherwise pass green. If it reports it can't locate the anchor method,
 upstream reshaped it — re-verify the patch by hand and update the rule. Don't delete the
 assertion to get green.
 

--- a/patches/react-native-screens@4.26.2.patch
+++ b/patches/react-native-screens@4.26.2.patch
@@ -1,5 +1,5 @@
 diff --git a/ios/helpers/scroll-view/RNSScrollViewFinder.h b/ios/helpers/scroll-view/RNSScrollViewFinder.h
-index 04d40b3..3ae83fe 100644
+index 04d40b38bad73bedd79c6aa8b85125dc79093db7..3ae83feb969f4aba8ce05207669998f68b463e9a 100644
 --- a/ios/helpers/scroll-view/RNSScrollViewFinder.h
 +++ b/ios/helpers/scroll-view/RNSScrollViewFinder.h
 @@ -25,4 +25,15 @@
@@ -19,7 +19,7 @@ index 04d40b3..3ae83fe 100644
 +
  @end
 diff --git a/ios/helpers/scroll-view/RNSScrollViewFinder.mm b/ios/helpers/scroll-view/RNSScrollViewFinder.mm
-index 2434c61..fb36bbf 100644
+index 2434c612951a40bd1ecfcc476acebb9a9a6b500e..fb36bbf917abaf3365cd045e5b97ce9b4301f2e9 100644
 --- a/ios/helpers/scroll-view/RNSScrollViewFinder.mm
 +++ b/ios/helpers/scroll-view/RNSScrollViewFinder.mm
 @@ -1,4 +1,6 @@
@@ -150,19 +150,21 @@ index 2434c61..fb36bbf 100644
 +
  @end
 diff --git a/ios/tabs/host/RNSTabsHostComponentView.mm b/ios/tabs/host/RNSTabsHostComponentView.mm
-index 8b61f5b..3dc76cc 100644
+index 8b61f5b7d3800bf090ff4a7878ad44676b50bbaf..750a3e7675412e79738bda66cb59582c65246836 100644
 --- a/ios/tabs/host/RNSTabsHostComponentView.mm
 +++ b/ios/tabs/host/RNSTabsHostComponentView.mm
-@@ -53,6 +53,8 @@ namespace react = facebook::react;
+@@ -53,6 +53,10 @@ namespace react = facebook::react;
  
  #if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
    UIView *_Nullable _bottomAccessoryWrapperView;
 +  // rnscreens_bottomAccessoryDynamicAttachFix
 +  BOOL _rnscreens_bottomAccessoryRelayoutScheduled;
++  BOOL _rnscreens_bottomAccessoryRelayoutNeedsRepeat;
++  UIView *__weak _rnscreens_lastAppliedBottomAccessoryView;
  #endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
  }
  
-@@ -88,6 +90,11 @@ namespace react = facebook::react;
+@@ -88,6 +92,13 @@ namespace react = facebook::react;
  
  #if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
    _bottomAccessoryWrapperView = nil;
@@ -171,24 +173,51 @@ index 8b61f5b..3dc76cc 100644
 +  // this flag suppresses every later relayout while it's set, so if recycling is
 +  // ever turned on a stale YES would silently break the accessory forever.
 +  _rnscreens_bottomAccessoryRelayoutScheduled = NO;
++  _rnscreens_bottomAccessoryRelayoutNeedsRepeat = NO;
++  _rnscreens_lastAppliedBottomAccessoryView = nil;
  #endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
  }
  
-@@ -411,12 +418,116 @@ namespace react = facebook::react;
-   if (_bottomAccessoryWrapperView != nil && !_bottomAccessoryHidden) {
-     [_controller setBottomAccessory:[[UITabAccessory alloc] initWithContentView:_bottomAccessoryWrapperView]
-                            animated:YES];
-+    // rnscreens_bottomAccessoryDynamicAttachFix
-+    // ATTACH ONLY. Detaching (`setBottomAccessory:nil`) is what happens on every
-+    // route push that leaves an accessory surface, and it never needed a forced
-+    // relayout — UIKit removes the accessory itself. Nudging there was pure risk.
-+    [self rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance];
+@@ -408,14 +419,166 @@ namespace react = facebook::react;
+ #if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
+ - (void)applyBottomAccessoryVisibility API_AVAILABLE(ios(26.0))
+ {
+-  if (_bottomAccessoryWrapperView != nil && !_bottomAccessoryHidden) {
+-    [_controller setBottomAccessory:[[UITabAccessory alloc] initWithContentView:_bottomAccessoryWrapperView]
+-                           animated:YES];
++  UIView *accessoryView =
++      (_bottomAccessoryWrapperView != nil && !_bottomAccessoryHidden) ? _bottomAccessoryWrapperView : nil;
++
++  if (accessoryView != nil) {
++    [_controller setBottomAccessory:[[UITabAccessory alloc] initWithContentView:accessoryView] animated:YES];
    } else {
      [_controller setBottomAccessory:nil animated:YES];
    }
- }
- #endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
- 
++
++  // rnscreens_bottomAccessoryDynamicAttachFix
++  // ATTACH **AND** DETACH. The previous shape scheduled only on attach, on the
++  // theory that UIKit removes the accessory itself. It does — but nothing marks
++  // `-[UITabBar layoutSubviews]` dirty, and that is what owns the frame of a
++  // docked `role="search"` tab item. So a detach during a route push left that
++  // item on a stale frame, drawn wrong and hit-testing to nowhere, until the
++  // process restarted (boardsesh/boardsesh#5055).
++  //
++  // Schedule on the accessory-IDENTITY edge, not on every call: this method also
++  // runs for transactions that don't change the accessory, and an unconditional
++  // schedule would add forced tab-bar layout passes that never existed before.
++  // Identity, not a BOOL: attach→attach with a NEW wrapper (the accessory
++  // component remounting with different content) is a real edge, and it is the
++  // original case this whole fix exists for.
++  //
++  // NEVER LAY OUT SYNCHRONOUSLY HERE — see
++  // `rnscreens_layoutBottomAccessoryOutsideTransition` for why (BOARDSESH-9K).
++  if (accessoryView != _rnscreens_lastAppliedBottomAccessoryView) {
++    _rnscreens_lastAppliedBottomAccessoryView = accessoryView;
++    [self rnscreens_scheduleBottomAccessoryRelayoutAfterVisibilityChange];
++  }
++}
++#endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
++
 +// rnscreens_bottomAccessoryDynamicAttachFix
 +// iOS 26's UITabBarController.setBottomAccessory lays the accessory in for free
 +// when it's set during the controller's initial setup, but NOT when it's set
@@ -198,7 +227,13 @@ index 8b61f5b..3dc76cc 100644
 +// current climb exists, so the very first climb set (while the user is already
 +// on a tab) attaches an accessory that never renders until something else
 +// (a tab-item badge, a tab change) re-lays-out the bar. Force the layout pass
-+// ourselves whenever we ATTACH the accessory after the host is on screen.
++// ourselves whenever the accessory CHANGES after the host is on screen — attach
++// and detach alike, since #5055 showed the detach edge needs it just as much.
++//
++// Renamed from `rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance`: the
++// old name encoded the attach-only assumption that #5055 disproved, and the
++// rename is what makes `scripts/mobile-patches-check.ts` reject a re-applied
++// attach-only patch instead of passing it green.
 +//
 +// Anchored on `applyBottomAccessoryVisibility` (4.26.0 extracted it out of
 +// `updateContainer`), so it also covers the `bottomAccessoryHidden` prop path —
@@ -223,7 +258,7 @@ index 8b61f5b..3dc76cc 100644
 +// deferred hop also still covers the original async-sizing case (the accessory
 +// content is sized by the shadow-state proxy, so an immediate pass could lay in
 +// a zero-size accessory before its frame KVO lands).
-+- (void)rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance
++- (void)rnscreens_scheduleBottomAccessoryRelayoutAfterVisibilityChange
 +{
 +#if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
 +  if (self.window == nil) {
@@ -232,21 +267,23 @@ index 8b61f5b..3dc76cc 100644
 +    return;
 +  }
 +  if (_rnscreens_bottomAccessoryRelayoutScheduled) {
-+    // `applyBottomAccessoryVisibility` can fire several times per transaction
-+    // (mount/unmount plus the `bottomAccessoryHidden` prop path). One pending
-+    // pass is enough, and it also stops any re-entry from queueing more work.
-+    // Stays armed until the layout actually RUNS, not just until the hop fires,
-+    // so a re-entry during a pending coordinator wait can't start a second chain.
++    // A pass is already in flight. Do NOT drop this edge: the flag stays armed
++    // until the layout actually RUNS, so a coordinator wait that outlives an
++    // attach would otherwise swallow the detach that follows it — exactly the
++    // #5055 sequence. Remember it instead, and re-arm once that pass has laid
++    // out. One in-flight pass at a time, one queued edge, no second chain.
++    _rnscreens_bottomAccessoryRelayoutNeedsRepeat = YES;
 +    return;
 +  }
 +  _rnscreens_bottomAccessoryRelayoutScheduled = YES;
++  _rnscreens_bottomAccessoryRelayoutNeedsRepeat = NO;
 +
 +  __weak __typeof__(self) weakSelf = self;
 +  dispatch_async(dispatch_get_main_queue(), ^{
 +    [weakSelf rnscreens_layoutBottomAccessoryOutsideTransition];
 +  });
 +#endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
-+}
+ }
 +
 +// rnscreens_bottomAccessoryDynamicAttachFix
 +// Forcing layout while a presentation/dismissal is in flight is the dangerous
@@ -284,10 +321,30 @@ index 8b61f5b..3dc76cc 100644
 +  _rnscreens_bottomAccessoryRelayoutScheduled = NO;
 +#endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
 +  UIView *controllerView = _controller.view;
++  // rnscreens_bottomAccessoryDynamicAttachFix
++  // Marking only the controller view is not enough on a DETACH. The accessory
++  // lives in the tab bar's own subtree, and a docked `role="search"` item's frame
++  // comes out of `-[UITabBar layoutSubviews]`; if the bar isn't dirty, the
++  // recursive `layoutIfNeeded` below walks straight past it and the item keeps
++  // its accessory-era frame — visually shoved, hit-test misses (#5055).
++  // This is invalidation, not layout: it adds no synchronous work of its own, it
++  // only widens the reach of the ONE pass below.
++  [_controller.tabBar setNeedsLayout];
 +  [controllerView setNeedsLayout];
 +  [controllerView layoutIfNeeded];
++#if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
++  // Drain a single edge that arrived while this pass was in flight. This flag is
++  // set ONLY by an accessory-identity change in `applyBottomAccessoryVisibility`,
++  // never by this method, and it is cleared before re-arming — so a layout pass
++  // can never schedule itself, and the chain terminates as soon as React stops
++  // changing the accessory. That termination property is what BOARDSESH-9K's
++  // self-sustaining loop lacked.
++  if (_rnscreens_bottomAccessoryRelayoutNeedsRepeat) {
++    _rnscreens_bottomAccessoryRelayoutNeedsRepeat = NO;
++    [self rnscreens_scheduleBottomAccessoryRelayoutAfterVisibilityChange];
++  }
+ #endif // RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
 +}
-+
+ 
  - (void)setLayoutDirection:(UITraitEnvironmentLayoutDirection)layoutDirection
  {
-   _layoutDirection = layoutDirection;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ patchedDependencies:
   expo-dev-launcher@57.0.16: ba11bf1ad99f2bed1d9c959e8e68d1fe44e76bed157286850cde1dd5fc342d56
   expo-image@57.0.3: 68cfa579530a19eff0353bb5b9c0ea543980992877a93a69d832471f6ef91f60
   expo-updates@57.0.19: 67f24f95aa789e95b632312352bca97ddc9fd5264328d4c85a8fcc929f96f50a
-  react-native-screens@4.26.2: bcc3f2ba296e6ff8ff6c2a403e1b3606dace925fe10db81ed01d785b92718d0b
+  react-native-screens@4.26.2: 6b77eaedcf3b2210551b4099df209748d8135cff58ee4d89c3b20d8e6d2cf246
 
 importers:
 
@@ -699,7 +699,7 @@ importers:
         version: 57.0.17(expo-router@57.0.17)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       expo-router:
         specifier: 57.0.17
-        version: 57.0.17(6cb3000118c7cca45b0d29acad696f08)
+        version: 57.0.17(f3a769bcffbf4c6bf4f92ce630382ede)
       expo-secure-store:
         specifier: 57.0.2
         version: 57.0.2(expo@57.0.18)
@@ -783,7 +783,7 @@ importers:
         version: 5.8.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       react-native-screens:
         specifier: 4.26.2
-        version: 4.26.2(patch_hash=bcc3f2ba296e6ff8ff6c2a403e1b3606dace925fe10db81ed01d785b92718d0b)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+        version: 4.26.2(patch_hash=6b77eaedcf3b2210551b4099df209748d8135cff58ee4d89c3b20d8e6d2cf246)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
       react-native-svg:
         specifier: 15.15.5
         version: 15.15.5(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
@@ -12804,7 +12804,7 @@ snapshots:
       ws: 8.21.3(bufferutil@4.1.0)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 57.0.17(976521e5196c7b1e78ad4fcbaf204119)
+      expo-router: 57.0.17(782889f83b21d908976cd18c2fe15712)
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -12882,7 +12882,7 @@ snapshots:
       ws: 8.21.3(bufferutil@4.1.0)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 57.0.17(6cb3000118c7cca45b0d29acad696f08)
+      expo-router: 57.0.17(f3a769bcffbf4c6bf4f92ce630382ede)
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -12960,7 +12960,7 @@ snapshots:
       ws: 8.21.3(bufferutil@4.1.0)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 57.0.17(976521e5196c7b1e78ad4fcbaf204119)
+      expo-router: 57.0.17(782889f83b21d908976cd18c2fe15712)
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -13421,7 +13421,7 @@ snapshots:
       react: 19.2.8
     optionalDependencies:
       '@expo/metro-runtime': 57.0.14(@expo/log-box@57.0.4)(expo@57.0.18)(react-dom@19.2.8(react@19.2.8))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      expo-router: 57.0.17(976521e5196c7b1e78ad4fcbaf204119)
+      expo-router: 57.0.17(782889f83b21d908976cd18c2fe15712)
       react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
       - supports-color
@@ -13436,7 +13436,7 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@expo/metro-runtime': 57.0.14(@expo/log-box@57.0.4)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
-      expo-router: 57.0.17(6cb3000118c7cca45b0d29acad696f08)
+      expo-router: 57.0.17(f3a769bcffbf4c6bf4f92ce630382ede)
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
@@ -13451,7 +13451,7 @@ snapshots:
       react: 19.2.8
     optionalDependencies:
       '@expo/metro-runtime': 57.0.14(@expo/log-box@57.0.4)(expo@57.0.18)(react-dom@19.2.8(react@19.2.8))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      expo-router: 57.0.17(976521e5196c7b1e78ad4fcbaf204119)
+      expo-router: 57.0.17(782889f83b21d908976cd18c2fe15712)
       react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
       - supports-color
@@ -18609,56 +18609,9 @@ snapshots:
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)
     optionalDependencies:
-      expo-router: 57.0.17(6cb3000118c7cca45b0d29acad696f08)
+      expo-router: 57.0.17(f3a769bcffbf4c6bf4f92ce630382ede)
 
-  expo-router@57.0.17(6cb3000118c7cca45b0d29acad696f08):
-    dependencies:
-      '@expo/log-box': 57.0.4(@expo/dom-webview@57.0.1)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
-      '@expo/metro-runtime': 57.0.14(@expo/log-box@57.0.4)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
-      '@expo/schema-utils': 57.0.2
-      '@expo/ui': 57.0.14(patch_hash=d825156bd91cb501a656fd080d68ee309ac894db648e5337d39f93947aabb8d0)(@babel/core@7.29.7(supports-color@8.1.1))(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
-      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.18)(react@19.2.3)
-      '@radix-ui/react-tabs': 1.1.21(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@react-native-masked-view/masked-view': 0.3.2(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
-      client-only: 0.0.1
-      color: 4.2.3
-      debug: 4.4.3(supports-color@8.1.1)
-      escape-string-regexp: 4.0.0
-      expo: 57.0.18(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.14)(bufferutil@4.1.0)(expo-router@57.0.17)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@7.0.2)
-      expo-constants: 57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(supports-color@8.1.1)
-      expo-glass-effect: 57.0.1(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
-      expo-linking: 57.0.8(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)
-      expo-server: 57.0.3
-      expo-symbols: 57.0.2(expo-font@57.0.2)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
-      fast-deep-equal: 3.1.3
-      invariant: 2.2.4
-      nanoid: 3.3.18
-      query-string: 7.1.3
-      react: 19.2.3
-      react-fast-compare: 3.2.2
-      react-is: 19.2.8
-      react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)
-      react-native-drawer-layout: 4.2.10(b48dd6a5edc1423d5fade205b2df8c17)
-      react-native-safe-area-context: 5.8.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
-      react-native-screens: 4.26.2(patch_hash=bcc3f2ba296e6ff8ff6c2a403e1b3606dace925fe10db81ed01d785b92718d0b)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
-      server-only: 0.0.1
-      sf-symbols-typescript: 2.2.0
-      shallowequal: 1.1.0
-      standard-navigation: 0.0.5
-      vaul: 1.1.2(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-    optionalDependencies:
-      react-dom: 19.2.3(react@19.2.3)
-      react-native-gesture-handler: 2.32.0(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
-      react-native-reanimated: 4.5.3(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@types/react'
-      - '@types/react-dom'
-      - expo-font
-      - react-native-worklets
-      - supports-color
-
-  expo-router@57.0.17(976521e5196c7b1e78ad4fcbaf204119):
+  expo-router@57.0.17(782889f83b21d908976cd18c2fe15712):
     dependencies:
       '@expo/log-box': 57.0.4(@expo/dom-webview@57.0.1)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
       '@expo/metro-runtime': 57.0.14(@expo/log-box@57.0.4)(expo@57.0.18)(react-dom@19.2.8(react@19.2.8))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
@@ -18687,7 +18640,7 @@ snapshots:
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1)
       react-native-drawer-layout: 4.2.10(b6c180dfab701ba0d1c28bf4c802fe4e)
       react-native-safe-area-context: 5.8.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
-      react-native-screens: 4.26.2(patch_hash=bcc3f2ba296e6ff8ff6c2a403e1b3606dace925fe10db81ed01d785b92718d0b)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
+      react-native-screens: 4.26.2(patch_hash=6b77eaedcf3b2210551b4099df209748d8135cff58ee4d89c3b20d8e6d2cf246)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8)
       server-only: 0.0.1
       sf-symbols-typescript: 2.2.0
       shallowequal: 1.1.0
@@ -18705,6 +18658,53 @@ snapshots:
       - react-native-worklets
       - supports-color
     optional: true
+
+  expo-router@57.0.17(f3a769bcffbf4c6bf4f92ce630382ede):
+    dependencies:
+      '@expo/log-box': 57.0.4(@expo/dom-webview@57.0.1)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+      '@expo/metro-runtime': 57.0.14(@expo/log-box@57.0.4)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+      '@expo/schema-utils': 57.0.2
+      '@expo/ui': 57.0.14(patch_hash=d825156bd91cb501a656fd080d68ee309ac894db648e5337d39f93947aabb8d0)(@babel/core@7.29.7(supports-color@8.1.1))(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.18)(react@19.2.3)
+      '@radix-ui/react-tabs': 1.1.21(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@react-native-masked-view/masked-view': 0.3.2(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+      client-only: 0.0.1
+      color: 4.2.3
+      debug: 4.4.3(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
+      expo: 57.0.18(@babel/core@7.29.7(supports-color@8.1.1))(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.14)(bufferutil@4.1.0)(expo-router@57.0.17)(react-dom@19.2.3(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)(typescript@7.0.2)
+      expo-constants: 57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(supports-color@8.1.1)
+      expo-glass-effect: 57.0.1(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+      expo-linking: 57.0.8(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1)
+      expo-server: 57.0.3
+      expo-symbols: 57.0.2(expo-font@57.0.2)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+      fast-deep-equal: 3.1.3
+      invariant: 2.2.4
+      nanoid: 3.3.18
+      query-string: 7.1.3
+      react: 19.2.3
+      react-fast-compare: 3.2.2
+      react-is: 19.2.8
+      react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)
+      react-native-drawer-layout: 4.2.10(b48dd6a5edc1423d5fade205b2df8c17)
+      react-native-safe-area-context: 5.8.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+      react-native-screens: 4.26.2(patch_hash=6b77eaedcf3b2210551b4099df209748d8135cff58ee4d89c3b20d8e6d2cf246)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+      server-only: 0.0.1
+      sf-symbols-typescript: 2.2.0
+      shallowequal: 1.1.0
+      standard-navigation: 0.0.5
+      vaul: 1.1.2(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    optionalDependencies:
+      react-dom: 19.2.3(react@19.2.3)
+      react-native-gesture-handler: 2.32.0(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+      react-native-reanimated: 4.5.3(react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)(supports-color@8.1.1))(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/react'
+      - '@types/react-dom'
+      - expo-font
+      - react-native-worklets
+      - supports-color
 
   expo-secure-store@57.0.2(expo@57.0.18):
     dependencies:
@@ -21129,14 +21129,14 @@ snapshots:
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1)
     optional: true
 
-  react-native-screens@4.26.2(patch_hash=bcc3f2ba296e6ff8ff6c2a403e1b3606dace925fe10db81ed01d785b92718d0b)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
+  react-native-screens@4.26.2(patch_hash=6b77eaedcf3b2210551b4099df209748d8135cff58ee4d89c3b20d8e6d2cf246)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3):
     dependencies:
       react: 19.2.3
       react-freeze: 1.0.4(react@19.2.3)
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.3)(supports-color@8.1.1)
       warn-once: 0.1.1
 
-  react-native-screens@4.26.2(patch_hash=bcc3f2ba296e6ff8ff6c2a403e1b3606dace925fe10db81ed01d785b92718d0b)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
+  react-native-screens@4.26.2(patch_hash=6b77eaedcf3b2210551b4099df209748d8135cff58ee4d89c3b20d8e6d2cf246)(react-native@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@8.1.1))(bufferutil@4.1.0)(supports-color@8.1.1))(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(supports-color@8.1.1))(react@19.2.8):
     dependencies:
       react: 19.2.8
       react-freeze: 1.0.4(react@19.2.8)

--- a/scripts/__tests__/mobile-patches-check.test.ts
+++ b/scripts/__tests__/mobile-patches-check.test.ts
@@ -502,10 +502,16 @@ const TABS_RULES: PatchRule[] = [
     package: PKG,
     file: TABS_FILE,
     sentinels: [
-      'rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance',
+      'rnscreens_scheduleBottomAccessoryRelayoutAfterVisibilityChange',
       'rnscreens_layoutBottomAccessoryOutsideTransition',
       '_rnscreens_bottomAccessoryRelayoutScheduled',
+      '_rnscreens_bottomAccessoryRelayoutNeedsRepeat',
+      '[_controller.tabBar setNeedsLayout];',
       'animateAlongsideTransition',
+    ],
+    orderedSentinels: [
+      '[_controller setBottomAccessory:nil animated:YES];',
+      '[self rnscreens_scheduleBottomAccessoryRelayoutAfterVisibilityChange];',
     ],
     patchedKey: TABS_KEY,
     forbiddenInMethod: [
@@ -514,22 +520,91 @@ const TABS_RULES: PatchRule[] = [
         substrings: ['layoutIfNeeded', 'layoutBelowIfNeeded'],
         why: 'synchronous layout inside the RN mounting transaction — BOARDSESH-9K',
       },
+      {
+        method: 'applyBottomAccessoryVisibility',
+        substrings: ['rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance'],
+        why: 'the ATTACH-ONLY nudge left the docked search item shoved on detach — #5055',
+      },
+      {
+        method: 'rnscreens_layoutBottomAccessoryOutsideTransition',
+        substrings: ['_rnscreens_bottomAccessoryRelayoutNeedsRepeat = YES'],
+        why: 'the layout pass must never arm its own repeat — BOARDSESH-9K loop shape',
+      },
     ],
   },
 ];
 
-/** The shipped (2.3.1) shape: attach-only nudge, layout deferred off-transaction. */
+/** The shipped shape: schedule on both edges, layout deferred off-transaction,
+ *  tab bar invalidated so the docked search item is re-framed (#5055). */
 const TABS_FIXED_SOURCE = `
 - (void)applyBottomAccessoryVisibility API_AVAILABLE(ios(26.0))
 {
-  if (_bottomAccessoryWrapperView != nil) {
+  if (accessoryView != nil) {
     [_controller setBottomAccessory:accessory animated:YES];
-    [self rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance];
+  } else {
+    [_controller setBottomAccessory:nil animated:YES];
+  }
+
+  if (accessoryView != _rnscreens_lastAppliedBottomAccessoryView) {
+    _rnscreens_lastAppliedBottomAccessoryView = accessoryView;
+    [self rnscreens_scheduleBottomAccessoryRelayoutAfterVisibilityChange];
   }
 }
 
 // The original version of this method called -layoutIfNeeded right there, and
 // that synchronous layout got pulled into a UIKit feedback loop.
+- (void)rnscreens_scheduleBottomAccessoryRelayoutAfterVisibilityChange
+{
+  if (_rnscreens_bottomAccessoryRelayoutScheduled) {
+    _rnscreens_bottomAccessoryRelayoutNeedsRepeat = YES;
+    return;
+  }
+  _rnscreens_bottomAccessoryRelayoutScheduled = YES;
+  _rnscreens_bottomAccessoryRelayoutNeedsRepeat = NO;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [weakSelf rnscreens_layoutBottomAccessoryOutsideTransition];
+  });
+}
+
+- (void)rnscreens_layoutBottomAccessoryOutsideTransition
+{
+  if (transitionCoordinator != nil) {
+    BOOL registered = [transitionCoordinator animateAlongsideTransition:nil completion:^(id context) {
+      [weakSelf rnscreens_layoutBottomAccessoryOutsideTransition];
+    }];
+    if (registered) {
+      return;
+    }
+  }
+  _rnscreens_bottomAccessoryRelayoutScheduled = NO;
+  [_controller.tabBar setNeedsLayout];
+  [controllerView setNeedsLayout];
+  [controllerView layoutIfNeeded];
+  if (_rnscreens_bottomAccessoryRelayoutNeedsRepeat) {
+    _rnscreens_bottomAccessoryRelayoutNeedsRepeat = NO;
+    [self rnscreens_scheduleBottomAccessoryRelayoutAfterVisibilityChange];
+  }
+}
+`;
+
+/** A re-keyed patch that kept the symbols but restored the crashing layout. */
+const TABS_REGRESSED_SOURCE = TABS_FIXED_SOURCE.replace(
+  '[self rnscreens_scheduleBottomAccessoryRelayoutAfterVisibilityChange];\n  }',
+  '[self rnscreens_scheduleBottomAccessoryRelayoutAfterVisibilityChange];\n    [_controller.view layoutIfNeeded];\n  }',
+);
+
+/** The pre-#5055 shape: nudge nested inside the attach branch, nothing on detach. */
+const TABS_ATTACH_ONLY_SOURCE = `
+- (void)applyBottomAccessoryVisibility API_AVAILABLE(ios(26.0))
+{
+  if (_bottomAccessoryWrapperView != nil) {
+    [_controller setBottomAccessory:accessory animated:YES];
+    [self rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance];
+  } else {
+    [_controller setBottomAccessory:nil animated:YES];
+  }
+}
+
 - (void)rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance
 {
   if (_rnscreens_bottomAccessoryRelayoutScheduled) {
@@ -557,10 +632,10 @@ const TABS_FIXED_SOURCE = `
 }
 `;
 
-/** A re-keyed patch that kept the symbols but restored the crashing layout. */
-const TABS_REGRESSED_SOURCE = TABS_FIXED_SOURCE.replace(
-  '[self rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance];',
-  '[self rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance];\n    [_controller.view layoutIfNeeded];',
+/** The layout pass arming its own repeat — the self-sustaining loop shape. */
+const TABS_SELF_ARMING_SOURCE = TABS_FIXED_SOURCE.replace(
+  '  _rnscreens_bottomAccessoryRelayoutScheduled = NO;\n  [_controller.tabBar setNeedsLayout];',
+  '  _rnscreens_bottomAccessoryRelayoutScheduled = NO;\n  _rnscreens_bottomAccessoryRelayoutNeedsRepeat = YES;\n  [_controller.tabBar setNeedsLayout];',
 );
 
 const tabsEnv = (source: string) =>
@@ -574,7 +649,7 @@ describe('extractObjCMethodBody', () => {
   it('extracts a body and stops at the closing brace, not the next declaration', () => {
     const body = extractObjCMethodBody(TABS_FIXED_SOURCE, 'applyBottomAccessoryVisibility');
 
-    expect(body).toContain('rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance');
+    expect(body).toContain('rnscreens_scheduleBottomAccessoryRelayoutAfterVisibilityChange');
     expect(body).not.toContain('dispatch_async');
     expect(body).not.toContain('layoutIfNeeded');
   });
@@ -671,9 +746,12 @@ describe('checkPatchesApplied forbiddenInMethod', () => {
 
     const result = checkPatchesApplied(TABS_RULES, tabsEnv(renamed));
 
-    expect(result.errors).toHaveLength(1);
-    expect(result.errors[0]).toContain('cannot locate');
-    expect(result.errors[0]).toContain('re-verify');
+    // One per rule anchored on that method — both must say so, loudly.
+    expect(result.errors).toHaveLength(2);
+    for (const error of result.errors) {
+      expect(error).toContain('cannot locate');
+      expect(error).toContain('re-verify');
+    }
   });
 
   it.each([
@@ -686,6 +764,73 @@ describe('checkPatchesApplied forbiddenInMethod', () => {
     const result = checkPatchesApplied(TABS_RULES, tabsEnv(withoutSentinel));
 
     expect(result.errors.join('\n')).toContain(sentinel);
+  });
+
+  it('fails on the pre-#5055 attach-only shape', () => {
+    // A re-applied older patch keeps the deferral machinery and would sail past a
+    // sentinel-only check, while leaving the docked search item shoved on detach.
+    const result = checkPatchesApplied(TABS_RULES, tabsEnv(TABS_ATTACH_ONLY_SOURCE));
+
+    expect(result.errors.join('\n')).toContain('rnscreens_scheduleBottomAccessoryRelayoutAfterVisibilityChange');
+  });
+
+  it('fails when the tab-bar invalidation is dropped (the one line that fixes #5055)', () => {
+    const withoutTabBarDirty = TABS_FIXED_SOURCE.replace('  [_controller.tabBar setNeedsLayout];\n', '');
+
+    const result = checkPatchesApplied(TABS_RULES, tabsEnv(withoutTabBarDirty));
+
+    expect(result.errors.join('\n')).toContain('[_controller.tabBar setNeedsLayout];');
+  });
+
+  it('fails when the schedule call is nested back inside the attach branch', () => {
+    // Ordered sentinels are what catch this: every symbol is still present, but the
+    // call now sits BEFORE the detach branch, so a detach schedules nothing.
+    const nested = `
+- (void)applyBottomAccessoryVisibility API_AVAILABLE(ios(26.0))
+{
+  if (accessoryView != nil) {
+    [_controller setBottomAccessory:accessory animated:YES];
+    [self rnscreens_scheduleBottomAccessoryRelayoutAfterVisibilityChange];
+  } else {
+    [_controller setBottomAccessory:nil animated:YES];
+  }
+}
+${TABS_FIXED_SOURCE.slice(TABS_FIXED_SOURCE.indexOf('// The original version'))}`;
+
+    const result = checkPatchesApplied(TABS_RULES, tabsEnv(nested));
+
+    expect(result.errors.join('\n')).toContain('must appear before');
+  });
+
+  it('fails when the layout pass arms its own repeat (the loop shape)', () => {
+    const result = checkPatchesApplied(TABS_RULES, tabsEnv(TABS_SELF_ARMING_SOURCE));
+
+    expect(result.errors.join('\n')).toContain('rnscreens_layoutBottomAccessoryOutsideTransition');
+  });
+});
+
+describe('the shipped react-native-screens tab-host rule', () => {
+  // Runs the REAL rule, not a fixture copy of it — the fixture above can drift from
+  // what ships, and this is the assertion that would notice.
+  const shippedRule = REAL_RULES.find(
+    (rule) => rule.package === PKG && rule.file === 'ios/tabs/host/RNSTabsHostComponentView.mm',
+  );
+
+  it('is present', () => {
+    expect(shippedRule).toBeDefined();
+  });
+
+  it('rejects the pre-#5055 attach-only shape', () => {
+    const result = checkPatchesApplied(
+      [shippedRule as PatchRule],
+      makeEnv({
+        patchedDependencies: { [TABS_KEY]: `patches/${TABS_KEY}.patch` },
+        versions: { [PKG]: '4.26.2' },
+        files: { [`${PKG}::ios/tabs/host/RNSTabsHostComponentView.mm`]: TABS_ATTACH_ONLY_SOURCE },
+      }),
+    );
+
+    expect(result.errors.length).toBeGreaterThan(0);
   });
 });
 
@@ -773,7 +918,7 @@ describe('the shipped RULES', () => {
   it('asserts the deferral machinery, not just the entry-point symbol', () => {
     expect(tabsHostRule?.sentinels).toEqual(
       expect.arrayContaining([
-        'rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance',
+        'rnscreens_scheduleBottomAccessoryRelayoutAfterVisibilityChange',
         'rnscreens_layoutBottomAccessoryOutsideTransition',
         '_rnscreens_bottomAccessoryRelayoutScheduled',
         'animateAlongsideTransition',
@@ -781,10 +926,48 @@ describe('the shipped RULES', () => {
     );
   });
 
-  it('forbids a synchronous layout inside applyBottomAccessoryVisibility', () => {
-    const forbidden = tabsHostRule?.forbiddenInMethod?.find(
-      (entry) => entry.method === 'applyBottomAccessoryVisibility',
+  it('asserts the #5055 detach machinery too', () => {
+    // The tab-bar invalidation is the line that actually re-frames the docked
+    // role="search" item; the repeat slot is what stops an in-flight pass from
+    // swallowing the detach edge behind it.
+    expect(tabsHostRule?.sentinels).toEqual(
+      expect.arrayContaining([
+        '[_controller.tabBar setNeedsLayout];',
+        '_rnscreens_bottomAccessoryRelayoutNeedsRepeat',
+        '_rnscreens_lastAppliedBottomAccessoryView',
+      ]),
     );
+    // Ordered: the schedule call must come after BOTH branches, not inside attach.
+    expect(tabsHostRule?.orderedSentinels).toEqual(
+      expect.arrayContaining([
+        '[_controller setBottomAccessory:nil animated:YES];',
+        '[self rnscreens_scheduleBottomAccessoryRelayoutAfterVisibilityChange];',
+      ]),
+    );
+  });
+
+  it('forbids the attach-only nudge coming back', () => {
+    const forbidden = tabsHostRule?.forbiddenInMethod?.find((entry) =>
+      entry.substrings.includes('rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance'),
+    );
+
+    expect(forbidden?.method).toBe('applyBottomAccessoryVisibility');
+    expect(forbidden?.why).toContain('#5055');
+  });
+
+  it('forbids the layout pass arming its own repeat', () => {
+    const forbidden = tabsHostRule?.forbiddenInMethod?.find(
+      (entry) => entry.method === 'rnscreens_layoutBottomAccessoryOutsideTransition',
+    );
+
+    expect(forbidden?.substrings).toEqual(
+      expect.arrayContaining(['_rnscreens_bottomAccessoryRelayoutNeedsRepeat = YES']),
+    );
+    expect(forbidden?.why).toContain('BOARDSESH-9K');
+  });
+
+  it('forbids a synchronous layout inside applyBottomAccessoryVisibility', () => {
+    const forbidden = tabsHostRule?.forbiddenInMethod?.find((entry) => entry.substrings.includes('layoutIfNeeded'));
 
     expect(forbidden?.substrings).toEqual(expect.arrayContaining(['layoutIfNeeded']));
     expect(forbidden?.why).toContain('BOARDSESH-9K');

--- a/scripts/mobile-patches-check.ts
+++ b/scripts/mobile-patches-check.ts
@@ -124,33 +124,68 @@ export const RULES: readonly PatchRule[] = [
     ],
     patchedKey: 'react-native-screens@4.26.2',
   },
-  // The bottom-accessory attach nudge. The FIRST sentinel alone is not enough:
-  // the crashing pre-#4198 version of this patch also defined
-  // `rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance`, it just laid
-  // out synchronously inside the RN mounting transaction. A patch re-keyed for
-  // a react-native-screens bump could reintroduce exactly that and still pass a
-  // one-sentinel check, silently regressing BOARDSESH-9K. So the deferral
-  // machinery itself is asserted: the coalescing ivar, the out-of-transition
-  // helper, and the transition-coordinator hand-off — plus a negative assertion
-  // that no synchronous layout crept back into the mounting-transaction path.
+  // The bottom-accessory relayout nudge. No single sentinel is enough, because
+  // this hunk has TWO regressions to guard, in opposite directions.
+  //
+  // Backwards into a crash: the pre-#4198 version also defined a relayout helper,
+  // it just laid out synchronously inside the RN mounting transaction, which
+  // re-entered UITabBar/_minimizeBehavior under a sheet animation (BOARDSESH-9K).
+  // So the deferral machinery is asserted directly — the coalescing ivar, the
+  // out-of-transition helper, the transition-coordinator hand-off — plus a
+  // negative assertion that no synchronous layout crept back into the
+  // mounting-transaction path.
+  //
+  // Backwards into #5055: the pre-#5055 version scheduled on ATTACH ONLY and left
+  // `-[UITabBar layoutSubviews]` uninvalidated on detach, which stranded the
+  // docked `role="search"` Climbs item on a stale frame until a process restart.
+  // Three things pin that: the tab-bar invalidation line itself, the queued-repeat
+  // ivar, and an ordered check proving the schedule call sits AFTER both branches
+  // of `applyBottomAccessoryVisibility` rather than nested back inside the attach
+  // one — which `forbiddenInMethod` cannot express.
   {
     package: 'react-native-screens',
     file: 'ios/tabs/host/RNSTabsHostComponentView.mm',
     sentinels: [
-      'rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance',
+      'rnscreens_scheduleBottomAccessoryRelayoutAfterVisibilityChange',
       'rnscreens_layoutBottomAccessoryOutsideTransition',
       '_rnscreens_bottomAccessoryRelayoutScheduled',
+      '_rnscreens_bottomAccessoryRelayoutNeedsRepeat',
+      '_rnscreens_lastAppliedBottomAccessoryView',
       'animateAlongsideTransition',
+      // The one line that fixes #5055. A re-keyed patch could keep every other
+      // symbol and quietly drop this, leaving the search item shoved again.
+      '[_controller.tabBar setNeedsLayout];',
+    ],
+    orderedSentinels: [
+      '[[UITabAccessory alloc] initWithContentView:',
+      '[_controller setBottomAccessory:nil animated:YES];',
+      '[self rnscreens_scheduleBottomAccessoryRelayoutAfterVisibilityChange];',
     ],
     patchedKey: 'react-native-screens@4.26.2',
     forbiddenInMethod: [
       {
         method: 'applyBottomAccessoryVisibility',
-        substrings: ['layoutIfNeeded', 'layoutBelowIfNeeded'],
+        substrings: ['layoutIfNeeded', 'layoutBelowIfNeeded', 'layoutSubviews]', 'CATransaction flush'],
         why:
           'synchronous layout inside the RN mounting transaction re-enters UITabBar/_minimizeBehavior under a ' +
           'UISheetPresentationController animation — BOARDSESH-9K. Lay out from ' +
           'rnscreens_layoutBottomAccessoryOutsideTransition instead.',
+      },
+      {
+        method: 'applyBottomAccessoryVisibility',
+        substrings: ['rnscreens_relayoutBottomAccessoryIfAttachedAfterAppearance'],
+        why:
+          'that is the ATTACH-ONLY nudge. A detach then left -[UITabBar layoutSubviews] uninvalidated and the ' +
+          'docked role="search" Climbs item shoved and unhittable until a process restart (#5055). Schedule from ' +
+          'both branches via rnscreens_scheduleBottomAccessoryRelayoutAfterVisibilityChange.',
+      },
+      {
+        method: 'rnscreens_layoutBottomAccessoryOutsideTransition',
+        substrings: ['_rnscreens_bottomAccessoryRelayoutNeedsRepeat = YES'],
+        why:
+          'the layout pass must never arm its own repeat — that turns the coalescing drain into a ' +
+          'self-sustaining layout loop, the shape BOARDSESH-9K crashed on. Only an accessory-identity change in ' +
+          'applyBottomAccessoryVisibility may set it.',
       },
     ],
   },


### PR DESCRIPTION
## Summary

Refs #5055. The native half. **Do not squash with #5158** — `mobile-ota-backport.yml` aborts unless the resolved runtimeVersion prefix matches the anchor's `shortfp`, so combining them would make the JS fix un-backportable and nobody on 2.3.1 or 2.4.0 would get anything until the next store release.

`patches/react-native-screens@4.26.2.patch` nudged a deferred relayout on **ATTACH ONLY**, with an in-patch comment stating detach "never needed a forced relayout — UIKit removes the accessory itself. Nudging there was pure risk." Half of that is true. UIKit does remove the accessory, but nothing marks `-[UITabBar layoutSubviews]` dirty, and that is what owns the frame of a docked `role="search"` item. So an accessory detach with the bar still on screen left the Climbs search item drawn wrong and hit-testing to nowhere until the process restarted.

Three changes, none of which put a layout statement back into `applyBottomAccessoryVisibility`:

1. **Schedule on the accessory-identity edge**, attach and detach alike. Identity rather than a `BOOL` because attach→attach with a new wrapper is a real edge — and it is the case this whole fix originally existed for. Comparing identity also keeps the transactions that don't touch the accessory from forcing layout passes that never existed before.
2. **Queue the repeat instead of dropping it.** The coalescing flag stays armed until the layout *runs*, so a coordinator wait outliving an attach used to swallow the detach behind it — exactly the #5055 sequence. Only `applyBottomAccessoryVisibility` may set the repeat, and it is cleared before re-arming, so a layout pass can never schedule itself.
3. **`[_controller.tabBar setNeedsLayout]`** before the existing pass. The line that actually fixes it: invalidation, not layout, widening the reach of the one synchronous pass we already had.

**BOARDSESH-9K cannot come back through this.** No layout statement is added to the mounting-transaction path, so the guard's negative assertion still means what it meant. Every forced layout still runs a runloop turn later. The transition-coordinator handoff is untouched, and a sheet over the tabs has its coordinator on `_controller` — the exact window this code still refuses to lay out in. The passes are bounded and edge-driven with no self-arming, which is the termination property the crashing loop lacked.

**Guard.** `scripts/mobile-patches-check.ts` gains sentinels for all of it (including the literal `[_controller.tabBar setNeedsLayout];`, which a re-key could otherwise quietly drop while keeping every other symbol), an `orderedSentinels` triple proving the schedule call sits after **both** branches rather than nested in the attach one, and negative assertions on the old attach-only method name and on the layout pass arming its own repeat. The tests run those against the **real shipped rule**, not a fixture copy.

**Author-side verification.** `vp run check:mobile-patches` OK (8 patches applied, 6 files accounted for); `scripts/__tests__/mobile-patches-check.test.ts` 64/64; `vp run test:mobile` 8265/8265; `vp check` 0 errors. The patch was regenerated via `pnpm patch` / `patch-commit` and re-keyed to the versioned filename, then `vp install` re-applied it cleanly — no hand-edited hunks. `expo-updates runtimeversion:resolve --platform ios` moves `2c968cde…` → `ff9d5652…`, which is the point: this is a native change and it needs a store build.

**Not verifiable on Linux.** No iOS simulator here. The BOARDSESH-9K non-regression specifically needs an **iOS 27** device or beta sim — iOS 26 will not show it.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. Start a session, pick a climb. Platter shows above tabs.
2. Discover tab → open a playlist → go back.
3. Tap Climbs. Search opens, every time.
4. Clear the queue from a tab. Tap Climbs. Still opens.
5. Scroll Climbs down. Tab bar still shrinks away.

## Risk

Risk: 5/5 — edits a native react-native-screens patch and moves the OTA fingerprint, so it needs a store build and it touches the UIKit tab-bar layout path that produced BOARDSESH-9K. The added work is invalidation plus one already-existing deferred pass, guarded by ordered sentinels and two new negative assertions, but the proof is on device — and the crash non-regression needs iOS 27 specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEUfEzX4DQx1otWSuGVADG
