### PR TITLE
chore(web): delete the caller-less profile PUT, and stop /docs advertising verbs that 405

### DIFF
--- a/packages/web/app/__tests__/rest-surface-inventory.test.ts
+++ b/packages/web/app/__tests__/rest-surface-inventory.test.ts
@@ -88,9 +88,10 @@ const VERDICTS: Record<string, Verdict> = {
   'app/api/internal/controllers/route.ts': 'keep-caller',
   'app/api/internal/set-password/route.ts': 'keep-caller',
   'app/api/internal/join/[sessionId]/route.ts': 'keep-caller',
-  // GET is live for /settings. The PUT operation on this same file has zero
-  // callers and is tracked for method-level deprecation in a follow-up issue
-  // — that doesn't change this file's verdict, since GET keeps it alive.
+  // GET only, and the caller is /settings. The caller-less PUT that used to sit
+  // beside it is deleted (#4662): it was never published in the OpenAPI
+  // document, so it had no third-party contract to wind down the way the Aurora
+  // proxies did.
   'app/api/internal/profile/route.ts': 'keep-caller',
   'app/api/internal/profile/[userId]/route.ts': 'keep-caller',
   'app/api/internal/feature-flags/route.ts': 'keep-caller',

--- a/packages/web/app/api/internal/profile/route.ts
+++ b/packages/web/app/api/internal/profile/route.ts
@@ -1,16 +1,16 @@
 import { getServerSession } from 'next-auth/next';
-import { type NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { getDb } from '@/app/lib/db/db';
 import * as schema from '@/app/lib/db/schema';
 import { eq } from 'drizzle-orm';
-import { z } from 'zod';
 import { authOptions } from '@/app/lib/auth/auth-options';
 
-const updateProfileSchema = z.object({
-  displayName: z.string().max(100, 'Display name must be less than 100 characters').optional().nullable(),
-  avatarUrl: z.string().url('Invalid avatar URL').optional().nullable(),
-  instagramUrl: z.string().url('Invalid Instagram URL').optional().nullable(),
-});
+// GET only. The PUT that used to live here had zero callers anywhere in the
+// repo — `/settings` reads this route and writes through GraphQL
+// `Mutation.updateProfile` — and it was never in the published OpenAPI
+// document either, so no third party could have been told it existed. What
+// the document DID advertise on this path was a POST the route has never
+// exported (#4662).
 
 export async function GET() {
   try {
@@ -62,72 +62,5 @@ export async function GET() {
   } catch (error) {
     console.error('Failed to get profile:', error);
     return NextResponse.json({ error: 'Failed to get profile' }, { status: 500 });
-  }
-}
-
-export async function PUT(request: NextRequest) {
-  try {
-    const session = await getServerSession(authOptions);
-
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const body = await request.json();
-
-    // Validate input
-    const validationResult = updateProfileSchema.safeParse(body);
-    if (!validationResult.success) {
-      return NextResponse.json({ error: validationResult.error.issues[0].message }, { status: 400 });
-    }
-
-    const { displayName, avatarUrl, instagramUrl } = validationResult.data;
-    const db = getDb();
-
-    // Check if profile exists
-    const existingProfile = await db
-      .select()
-      .from(schema.userProfiles)
-      .where(eq(schema.userProfiles.userId, session.user.id))
-      .limit(1);
-
-    const now = new Date();
-
-    if (existingProfile.length > 0) {
-      // Update existing profile
-      await db
-        .update(schema.userProfiles)
-        .set({
-          displayName: displayName ?? null,
-          avatarUrl: avatarUrl ?? null,
-          instagramUrl: instagramUrl ?? null,
-          updatedAt: now,
-        })
-        .where(eq(schema.userProfiles.userId, session.user.id));
-    } else {
-      // Create new profile
-      await db.insert(schema.userProfiles).values({
-        userId: session.user.id,
-        displayName: displayName ?? null,
-        avatarUrl: avatarUrl ?? null,
-        instagramUrl: instagramUrl ?? null,
-      });
-    }
-
-    // Also update the user's name if displayName is provided
-    if (displayName !== undefined) {
-      await db
-        .update(schema.users)
-        .set({
-          name: displayName || null,
-          updatedAt: now,
-        })
-        .where(eq(schema.users.id, session.user.id));
-    }
-
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    console.error('Failed to update profile:', error);
-    return NextResponse.json({ error: 'Failed to update profile' }, { status: 500 });
   }
 }

--- a/packages/web/app/lib/api-docs/__tests__/openapi-document.test.ts
+++ b/packages/web/app/lib/api-docs/__tests__/openapi-document.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as openApiRegistry from '../openapi-registry';
@@ -19,6 +19,26 @@ function toRouteDir(path: string): string {
 function routeFileExists(path: string): boolean {
   const dir = toRouteDir(path);
   return existsSync(join(WEB_ROOT, dir, 'route.ts')) || existsSync(join(WEB_ROOT, dir, 'route.tsx'));
+}
+
+/** The route file's source, or null when there is no route file. */
+function routeSource(path: string): string | null {
+  const dir = toRouteDir(path);
+  for (const candidate of ['route.ts', 'route.tsx']) {
+    const file = join(WEB_ROOT, dir, candidate);
+    if (existsSync(file)) return readFileSync(file, 'utf8');
+  }
+  return null;
+}
+
+/**
+ * Read as SOURCE, not by importing: a route module opens a database pool in its
+ * body, and this suite must run with no `DATABASE_URL`. Next recognises a
+ * handler declared any of these three ways.
+ */
+function routeExportsMethod(source: string, method: string): boolean {
+  const verb = method.toUpperCase();
+  return new RegExp(`export\\s+(?:async\\s+function|function|const)\\s+${verb}\\b`).test(source);
 }
 
 describe('generated OpenAPI document', () => {
@@ -69,6 +89,29 @@ describe('generated OpenAPI document', () => {
     // Delete-safety half: an over-broad edit that empties the spec reds here.
     expect(paths.length).toBeGreaterThan(10);
     expect(paths).toContain('/api/internal/profile');
+  });
+
+  it('never advertises an operation whose route file does not export that verb', () => {
+    // The path-only check below cannot see this. `/api/internal/profile` was
+    // published as a POST while the route exported GET and PUT, and
+    // `/api/auth/verify-email` as a JSON POST while the route was a GET that
+    // redirects — two operations on `/docs` and in the crawlable
+    // `/openapi.json` that answered 405 to anyone who believed them (#4662).
+    // A wrong verb is worse than a missing entry: it reads as a working
+    // contract.
+    const wrong: string[] = [];
+
+    for (const [path, item] of Object.entries(document.paths ?? {})) {
+      const source = routeSource(path);
+      // A missing route file is the next test's finding, not this one's.
+      if (source === null) continue;
+
+      for (const method of Object.keys(item as Record<string, unknown>)) {
+        if (!routeExportsMethod(source, method)) wrong.push(`${method.toUpperCase()} ${path}`);
+      }
+    }
+
+    expect(wrong).toEqual([]);
   });
 
   it('never advertises a registered path whose route file is gone', () => {

--- a/packages/web/app/lib/api-docs/openapi-registry.ts
+++ b/packages/web/app/lib/api-docs/openapi-registry.ts
@@ -182,12 +182,6 @@ export const RegisterResponseSchema = z
   })
   .openapi('RegisterResponse');
 
-export const VerifyEmailRequestSchema = z
-  .object({
-    token: z.string().describe('Email verification token'),
-  })
-  .openapi('VerifyEmailRequest');
-
 export const ResendVerificationRequestSchema = z
   .object({
     email: z.string().email().describe('Email address to resend verification to'),
@@ -228,14 +222,6 @@ export const UserProfileSchema = z
     instagramUrl: z.string().nullable().describe('Instagram profile URL'),
   })
   .openapi('UserProfile');
-
-export const UpdateProfileRequestSchema = z
-  .object({
-    displayName: z.string().max(100).optional().describe('New display name'),
-    avatarUrl: z.string().url().optional().describe('New avatar URL'),
-    instagramUrl: z.string().url().optional().describe('Instagram profile URL'),
-  })
-  .openapi('UpdateProfileRequest');
 
 // ============================================
 // WebSocket Auth Schema

--- a/packages/web/app/lib/api-docs/openapi-routes.ts
+++ b/packages/web/app/lib/api-docs/openapi-routes.ts
@@ -29,11 +29,9 @@ import {
   SetsSlugResponseSchema,
   RegisterRequestSchema,
   RegisterResponseSchema,
-  VerifyEmailRequestSchema,
   ResendVerificationRequestSchema,
   ErrorResponseSchema,
   UserProfileSchema,
-  UpdateProfileRequestSchema,
   WsAuthResponseSchema,
 } from './openapi-registry';
 
@@ -403,37 +401,26 @@ registry.registerPath({
   },
 });
 
+// A GET that REDIRECTS, because this is the target of a link in an email — the
+// browser follows it, nothing posts JSON to it. It was published as a JSON POST
+// returning `{ message }`, which the route has never exported (#4662).
 registry.registerPath({
-  method: 'post',
+  method: 'get',
   path: '/api/auth/verify-email',
   summary: 'Verify email address',
-  description: 'Verifies a user email address using the token sent via email.',
+  description:
+    'Verifies a user email address using the token sent via email. Always redirects to /auth/verify-request; the outcome is carried in that URL, never in a response body.',
   tags: ['Authentication'],
   request: {
-    body: {
-      content: {
-        'application/json': {
-          schema: VerifyEmailRequestSchema,
-        },
-      },
-    },
+    query: z.object({
+      token: z.string().describe('The verification token from the email link'),
+      email: z.string().email().describe('The address being verified'),
+    }),
   },
   responses: {
-    200: {
-      description: 'Email verified successfully',
-      content: {
-        'application/json': {
-          schema: z.object({ message: z.string() }),
-        },
-      },
-    },
-    400: {
-      description: 'Invalid or expired token',
-      content: {
-        'application/json': {
-          schema: ErrorResponseSchema,
-        },
-      },
+    302: {
+      description:
+        'Always. `/auth/verify-request?verified=true` on success, or the same path with `?error=InvalidToken`, `?error=TokenExpired` or `?error=TooManyAttempts`.',
     },
   },
 });
@@ -487,42 +474,6 @@ registry.registerPath({
   responses: {
     200: {
       description: 'User profile',
-      content: {
-        'application/json': {
-          schema: UserProfileSchema,
-        },
-      },
-    },
-    401: {
-      description: 'Not authenticated',
-      content: {
-        'application/json': {
-          schema: ErrorResponseSchema,
-        },
-      },
-    },
-  },
-});
-
-registry.registerPath({
-  method: 'post',
-  path: '/api/internal/profile',
-  summary: 'Update user profile',
-  description: 'Updates the profile of the currently authenticated user.',
-  tags: ['User Profile'],
-  security: [{ session: [] }],
-  request: {
-    body: {
-      content: {
-        'application/json': {
-          schema: UpdateProfileRequestSchema,
-        },
-      },
-    },
-  },
-  responses: {
-    200: {
-      description: 'Profile updated',
       content: {
         'application/json': {
           schema: UserProfileSchema,


### PR DESCRIPTION
## Summary

Deletes `PUT /api/internal/profile` — zero callers anywhere in the repo — and fixes two operations the published API document advertised with the wrong HTTP verb.

`/settings` reads this route (`fetch('/api/internal/profile')`, a bare GET at `settings-page-content.tsx:62`) and writes through GraphQL `Mutation.updateProfile`. Nothing in `packages/web`, `packages/mobile` or `scripts` issues a PUT to it. **GET is untouched.**

### Why not the 410 deprecation window #4662 asked for

#4662 proposed generalising `packages/web/app/lib/api-deprecation.ts` and giving the PUT the same `Deprecation`/`Sunset` treatment W-25a gave the Aurora proxies. Two things make that the wrong shape now:

- **The rubric doesn't reach it.** #1889 asks for a deprecation window when an operation is *published* on the indexable, sitemapped `/docs` and the crawlable `/openapi.json` — "no in-repo caller" is not evidence a documented endpoint is dead to third parties. This PUT was never in the document. Nobody was ever told it existed.
- **The helper is gone.** W-25b deleted `api-deprecation.ts`, and `deleted-aurora-proxies.test.ts:34` pins its absence. Honouring the issue as written would mean writing a fresh deprecation helper, plus a second retired-endpoints cohort card on `/docs` in four locales, to wind down a contract nobody was offered.

### The two verb mismatches, which are the sharper finding

Chasing the registration turned up that the document and the routes disagree in two places. Both are on `/docs` and in `/openapi.json`; both answer **405** to anyone who believes them.

| published | the route actually exports |
|---|---|
| `POST /api/internal/profile` — "Update user profile", JSON body | `GET`, and (until this PR) `PUT` |
| `POST /api/auth/verify-email` — JSON body, returns `{ message }` | `GET`, which **redirects** and never returns a body |

A wrong verb is worse than a missing entry: it reads as a working contract.

- The POST on `/api/internal/profile` is deleted.
- `/api/auth/verify-email` is re-registered as the GET it is, with its real query parameters (`token`, `email`) and its real response — a 302 to `/auth/verify-request`, carrying the outcome in the URL (`?verified=true`, or `?error=InvalidToken` / `TokenExpired` / `TooManyAttempts`).
- `UpdateProfileRequestSchema` and `VerifyEmailRequestSchema` go with them. zod-to-openapi only emits a `components.schemas` entry for a schema some registered path references, so leaving them behind would have been dead surface either way.

### The oracle that would have caught both

`openapi-document.test.ts` already reconciled the document against the filesystem — but only by **path**, which is exactly why a wrong verb survived. It now walks every `(path, method)` the document registers and reads the route file's source for a matching `export`.

Source text, not an import: a route module opens a database pool in its body, and this suite runs with no `DATABASE_URL`. The regex accepts all three shapes Next recognises (`export async function GET`, `export function GET`, `export const GET`). A path with no route file is skipped — that is the neighbouring test's finding, not this one's.

**Mutation-tested:** put `/api/auth/verify-email` back to `post` → red, naming `POST /api/auth/verify-email`. Reverted.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. Open the developer docs page → it still lists the API.
2. Find "Verify email address" → it reads GET, not POST.
3. Open Settings → your profile still loads.

## Risk

Risk: 2/5 — deletes an unreachable handler and corrects two document entries.
The one thing worth checking is that GET survived the edit, since it shares the
file and `/settings` depends on it; `settings-page-content.test.tsx` and the
rest-surface inventory both still pass. `/openapi.json` is a build artefact
generated at image build, so the published document follows the code with no
separate step.

## Author verification

- `vp test run --reporter=agent --project web app/lib/api-docs app/__tests__/rest-surface-inventory.test.ts app/settings` — 3 files, 27 tests green.
- Mutation on the new oracle applied, watched go red, reverted; `git status --porcelain` clean.

## Production targets

**`www.boardsesh.com` only.** No `packages/mobile` file changes, no native fingerprint change, no OTA to `app.boardsesh.com` or the store fleet.

Closes #4662. Part of #4358, and the last open item on #1889.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5Jti1UCBFtwGaJswYKY5Z
