### PR TITLE
fix(mobile): give the climb row's text column its width back

### DIFF
--- a/.github/workflows/mobile-ota-preview.yml
+++ b/.github/workflows/mobile-ota-preview.yml
@@ -299,13 +299,90 @@ jobs:
             core.setOutput('cleanup_reason', cleanupReason);
             core.setOutput('head_sha', headSha);
 
+  # ── Resolve the per-platform OTA verdict BEFORE anything mutates the branch.
+  # Secret-free by construction: it runs PR-author code (`vp install`, app.config
+  # execSync) exactly as `publish` does, so it must never hold EOO_TOKEN or the
+  # dashboard admin creds. Its only consumer is the `reset` gate below.
+  #
+  # It exists because `reset` DELETES the branch while `publish` may legitimately
+  # upload nothing: eoas skips an export whose bundle is byte-identical to the
+  # previous publish ("No changes found in the update, nothing to deploy"). A
+  # test-only, docs-only or CI-only push is exactly that — none of it reaches the
+  # Metro bundle — so an unconditional reset destroyed the preview and put nothing
+  # back, while the run still reported success and the sticky comment still said
+  # the branch was ready. Observed on PR #5166: two test-only pushes in a row each
+  # deleted `pr-5166` and republished nothing.
+  compat:
+    needs: gate
+    if: needs.gate.outputs.action == 'publish'
+    runs-on: ubuntu-latest
+    # Checkout + two installs + fingerprint resolution; measured ~2.5 minutes.
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    outputs:
+      verdict_ios: ${{ steps.compat.outputs.verdict_ios }}
+      verdict_android: ${{ steps.compat.outputs.verdict_android }}
+    steps:
+      # Same pin as `publish`: the exact commit the secret-free gate captured, so
+      # this verdict describes the revision that will actually be published.
+      - name: Checkout PR head (pinned to the gate-captured SHA)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.gate.outputs.head_sha }}
+          persist-credentials: false
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: '22.x'
+          cache: true
+
+      - name: Install dependencies (PR tree)
+        run: vp install --frozen-lockfile
+
+      - name: Materialize origin/main baseline
+        run: |
+          git fetch origin main --depth=1
+          git worktree add "$RUNNER_TEMP/main-baseline" origin/main
+
+      - name: Install dependencies (main baseline)
+        working-directory: ${{ runner.temp }}/main-baseline
+        run: vp install --frozen-lockfile
+
+      # Byte-identical invocation to the `publish` job's own resolution step, under
+      # the same workflow-level env, so the two cannot disagree about which
+      # platforms are publishable.
+      - name: Resolve OTA compatibility (and write .env)
+        id: compat
+        run: |
+          vp run check:mobile-ota-compat -- --write-env --base-dir "$RUNNER_TEMP/main-baseline"
+
   # ── Reconcile the mutable pr-N branch before publishing this revision. The
   # management delete runs without a checkout, install, or PR-authored code and
   # completes before the token-bearing publisher starts. This removes stale
   # platform updates when a newer revision becomes native-only.
+  #
+  # ONLY when a platform is about to be skipped. A stale update can only outlive
+  # this revision on a platform that publishes nothing, and `publish` skips
+  # exactly the `native-change-required` ones — so on an all-compatible revision
+  # there is nothing to reconcile and deleting the branch is pure loss: eoas
+  # uploads nothing when the bundle is unchanged, leaving the preview gone with
+  # no replacement (see the `compat` job above). An all-compatible revision whose
+  # bundle DID change supersedes the old update by publishing over it, which is
+  # what made the delete redundant there in the first place.
+  #
+  # Fails SAFE toward the old always-reset behaviour: an inconclusive verdict (the
+  # compat job errored, timed out, or was skipped) resets, because the hazard it
+  # guards is the one we cannot see from here.
   reset:
-    needs: gate
-    if: needs.gate.outputs.action == 'publish'
+    needs: [gate, compat]
+    if: >-
+      !cancelled() && needs.gate.outputs.action == 'publish' &&
+      (needs.compat.result != 'success' ||
+       needs.compat.outputs.verdict_ios == 'native-change-required' ||
+       needs.compat.outputs.verdict_android == 'native-change-required')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
@@ -389,8 +466,16 @@ jobs:
   # collaborators are trusted. Branch surfing removes the old per-PR mapping, so dashboard
   # admin credentials are never in scope while PR-author code runs.
   publish:
-    needs: [gate, reset]
-    if: needs.gate.outputs.action == 'publish'
+    needs: [gate, compat, reset]
+    # `reset` is now conditional, and a skipped `needs` would skip this job too
+    # under the default success() gate — hence the explicit `!cancelled()`. A reset
+    # that FAILED still blocks: it holds the admin creds, and publishing over a
+    # branch whose reconciliation half-ran would leave a stale platform surfable
+    # with nothing saying so. `compat` failing does not block — this job resolves
+    # its own verdicts below, and the failure has already forced a reset.
+    if: >-
+      !cancelled() && needs.gate.outputs.action == 'publish' &&
+      needs.reset.result != 'failure' && needs.reset.result != 'cancelled'
     runs-on: ubuntu-latest
     # Each platform may perform six attempts with 34 minutes of backoff. The job
     # publishes iOS then Android, so leave room for both bounded retry sets — a

--- a/docs/crowdsourced-qa-mobile.md
+++ b/docs/crowdsourced-qa-mobile.md
@@ -201,6 +201,14 @@ vp run mobile:ota-surf-doctor -- --platform ios --runtime-version <hash>
   published a preview, or a native change has landed on `main` since they did: a `pr-<n>` branch is
   offered only to a binary whose runtimeVersion matches it exactly, so every un-rebased PR goes
   invisible at once. Rebasing those PRs onto `main` republishes them.
+- **One PR missing while the rest are listed** — search its number first and take the escape hatch
+  above; that re-reads `/branch_lists` live and answers it on the device, without a laptop. Reach
+  for the doctor only when the hatch says the branch still is not listed and you need to know why.
+  Both it and `listPrBranches` ask for the whole list (`?all=1`), so the two agree: a branch the
+  doctor lists and the app does not is an app bug, not a publish that never landed. Neither listing
+  it means the preview was never published, or was published and then removed — read the PR's
+  `Mobile OTA Preview` run, and see `docs/mobile-ota-updates.md` for why a push that does not move
+  the JS bundle deploys nothing and used to take the branch with it.
 
 Take `<hash>` from a native build's `EXPO_UPDATES_FINGERPRINT_OVERRIDE`. Run the command bare to
 check only the switch — the branch list needs a real fingerprint, so the script declines to read it

--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -1149,12 +1149,31 @@ above — no per-tester build. Workflow: `.github/workflows/mobile-ota-preview.y
 
 - **Reconcile, then publish.** Every same-repository PR synchronization runs, even after the last
   mobile file leaves the diff. A no-longer-mobile revision removes its preview. A mobile revision
-  first deletes the mutable `pr-<number>` branch, then runs `eoas publish --branch pr-<number>` for
-  each compatible platform. That reset prevents an older compatible update from remaining surfable
-  when a newer commit is native-only on one or both platforms. The production channel stays baked in
-  app config and no same-named channel or map job is created. Xprem exposes the branch through
-  `/branch_lists` when it matches the production channel's `pr-*` surfing pattern and the running
-  binary's exact runtimeVersion/platform.
+  resolves the per-platform OTA verdict in a secret-free `compat` job, then runs
+  `eoas publish --branch pr-<number>` for each compatible platform. The production channel stays
+  baked in app config and no same-named channel or map job is created. Xprem exposes the branch
+  through `/branch_lists` when it matches the production channel's `pr-*` surfing pattern and the
+  running binary's exact runtimeVersion/platform.
+- **The branch is deleted first only when a platform is about to publish nothing.** The `reset` job
+  still deletes the mutable `pr-<number>` branch before `publish`, which is what stops an older
+  compatible update from staying surfable when a newer commit is native-only on one or both
+  platforms — but it now runs only when `compat` says a platform is `native-change-required`, or
+  when `compat` gave no usable answer at all (it errored, timed out or was skipped; an inconclusive
+  verdict resets, because that hazard is the one the workflow cannot see).
+  **Why it is conditional:** the reset is unconditional in its effect and the publish is not. eoas
+  compares each export against the update already on the branch and uploads nothing when they match
+  — `⚠️ No changes found in the update, nothing to deploy`, on stdout, exit code 0. A push that
+  changes only tests, docs or CI is exactly that: none of it reaches the Metro bundle, so the export
+  is byte-identical. Pairing the two meant any such push deleted the preview and put nothing back,
+  while the run still went green and the sticky comment still said the branch was ready. PR #5166
+  lost `pr-5166` to two consecutive test-only pushes that way. On an all-compatible revision there
+  is nothing to reconcile anyway: a changed bundle supersedes the old update by publishing over it,
+  and an unchanged one is already what the branch serves.
+  `scripts/mobile-publish.ts` reports the difference either way — a platform that uploaded nothing
+  now reads `ios=unchanged` rather than `ios=success` in the platform-results line.
+  **If a preview branch is missing** and the log shows "nothing to deploy": push a commit that
+  actually moves the bundle, or re-point the branch locally with
+  `vp run mobile:ota-rollback -- --platform <ios|android> --mode republish`.
 - **Source maps stay local to the runner.** The shared publisher generates external maps for these
   exports, but the preview workflow intentionally has no `SENTRY_AUTH_TOKEN` and never uploads them.
   It runs PR-authored code, so granting a Sentry upload credential would cross the preview security

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -1387,6 +1387,7 @@ function ClimbListInner() {
         onAddToQueue={handleAddToQueue}
         showPlaylistChips
         showFavorite
+        stableRail
         showMoreButton={quickActionsButtonEnabled}
       />
     ),

--- a/packages/mobile/app/(tabs)/climbs/index.tsx
+++ b/packages/mobile/app/(tabs)/climbs/index.tsx
@@ -1387,7 +1387,6 @@ function ClimbListInner() {
         onAddToQueue={handleAddToQueue}
         showPlaylistChips
         showFavorite
-        stableRail
         showMoreButton={quickActionsButtonEnabled}
       />
     ),

--- a/packages/mobile/src/components/ClimbAttributeIcons.tsx
+++ b/packages/mobile/src/components/ClimbAttributeIcons.tsx
@@ -62,10 +62,12 @@ function extraCharacteristicLabels(characteristics: string[] | null | undefined,
   if (isCampus(characteristics)) labels.push(t('mobile.climbRow.campus'));
   else if (isAnyFeet(characteristics)) labels.push(t('mobile.climbRow.anyFeet'));
   // `no_kickboard` and `method_no_kickboard` are independent tokens, and a climb
-  // can carry both. The method badge already says it, and in en/es/fr the two
-  // strings are word-for-word identical, so rendering both printed "No KB  No
-  // KB". Only German distinguishes them (Ohne KB vs Ohne FL), and there the
-  // method spelling is the one that belongs next to the other method badges.
+  // can carry both. The method badge already states the rule, so rendering both
+  // says it twice — and in en-US and fr the two strings are word-for-word
+  // identical ("No KB  No KB" / "Sans KB  Sans KB"). es and de do distinguish
+  // them ("Sin repisa" vs "Sin KB", "Ohne FL" vs "Ohne KB"), but it is the same
+  // rule either way, and the method spelling is the one that belongs beside the
+  // other method badges.
   if (
     isNoKickboard(characteristics) &&
     getMoonBoardMethod(characteristics) !== CLIMB_CHARACTERISTICS.METHOD_NO_KICKBOARD

--- a/packages/mobile/src/components/ClimbAttributeIcons.tsx
+++ b/packages/mobile/src/components/ClimbAttributeIcons.tsx
@@ -61,7 +61,17 @@ function extraCharacteristicLabels(characteristics: string[] | null | undefined,
   const labels: string[] = [];
   if (isCampus(characteristics)) labels.push(t('mobile.climbRow.campus'));
   else if (isAnyFeet(characteristics)) labels.push(t('mobile.climbRow.anyFeet'));
-  if (isNoKickboard(characteristics)) labels.push(t('mobile.climbRow.noKickboard'));
+  // `no_kickboard` and `method_no_kickboard` are independent tokens, and a climb
+  // can carry both. The method badge already says it, and in en/es/fr the two
+  // strings are word-for-word identical, so rendering both printed "No KB  No
+  // KB". Only German distinguishes them (Ohne KB vs Ohne FL), and there the
+  // method spelling is the one that belongs next to the other method badges.
+  if (
+    isNoKickboard(characteristics) &&
+    getMoonBoardMethod(characteristics) !== CLIMB_CHARACTERISTICS.METHOD_NO_KICKBOARD
+  ) {
+    labels.push(t('mobile.climbRow.noKickboard'));
+  }
   return labels;
 }
 
@@ -104,10 +114,18 @@ export const ClimbAttributeIcons = memo(function ClimbAttributeIcons({
         </View>
       ) : null}
       {method ? (
-        <Text style={[styles.method, { fontSize: size - 2, color: theme.systemColors.secondaryLabel }]}>{method}</Text>
+        <Text
+          numberOfLines={1}
+          style={[styles.method, { fontSize: size - 2, color: theme.systemColors.secondaryLabel }]}
+        >
+          {method}
+        </Text>
       ) : null}
       {extraLabels.length > 0 ? (
-        <Text style={[styles.method, { fontSize: size - 2, color: theme.systemColors.secondaryLabel }]}>
+        <Text
+          numberOfLines={1}
+          style={[styles.method, { fontSize: size - 2, color: theme.systemColors.secondaryLabel }]}
+        >
           {extraLabels.join(' · ')}
         </Text>
       ) : null}
@@ -122,7 +140,12 @@ const styles = StyleSheet.create({
   },
   method: {
     marginLeft: 6,
-    flexShrink: 0,
+    // Shrink these before the climb name does. They were `flexShrink: 0` while
+    // the name was `flexShrink: 1`, so the row's unique identifier absorbed all
+    // the truncation to protect an optional rule badge — and a MoonBoard climb
+    // carrying several of them pushed ~95pt of unshrinkable text through the
+    // name and on over the grade, since nothing in the row clips.
+    flexShrink: 1,
     fontWeight: '600',
     textTransform: 'uppercase',
     letterSpacing: 0.3,

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -13,6 +13,7 @@ import { Icon } from './Icon';
 import { ClimbAttributeIcons } from './ClimbAttributeIcons';
 import { ClimbPlaylistChips } from './ClimbPlaylistChips';
 import { splitGradeLabel } from '@boardsesh/play-view';
+import { ESTIMATE_PREFIX } from '../lib/boardsesh-grade-display';
 import { isClimbResolved } from '../lib/queue-climb-resolution';
 import { useIsClimbFavorited } from '../hooks/use-is-climb-favorited';
 import type { IconName } from './icon-map';
@@ -294,7 +295,11 @@ const LiveClimbGrade = React.memo(function LiveClimbGrade({
   });
   // The canonical community difficulty may change, but the Boardsesh grade
   // fields remain authoritative when that preference is active.
-  const { label: formattedGrade, color: gradeColor } = resolveGrade({
+  const {
+    label: formattedGrade,
+    color: gradeColor,
+    isEstimated,
+  } = resolveGrade({
     ...climb,
     difficulty: liveStats.difficulty,
   });
@@ -305,6 +310,14 @@ const LiveClimbGrade = React.memo(function LiveClimbGrade({
   // spending the rail's unused height. `splitGradeLabel` returns a single
   // element for the one-scale formats, so those rows are unchanged.
   const gradeLines = splitGradeLabel(formattedGrade);
+  // `resolveDisplayGrade` marks a projected grade by prefixing the WHOLE label
+  // ("≈V5 / 6C+"), so splitting it leaves the second line reading as an exact,
+  // crowd-backed grade. Re-mark it: the two lines are one grade in two scales,
+  // and the confidence marker belongs to the grade, not to its first spelling.
+  const secondaryGradeLine =
+    gradeLines.length > 1 && isEstimated && gradeLines[1] && !gradeLines[1].startsWith(ESTIMATE_PREFIX)
+      ? `${ESTIMATE_PREFIX}${gradeLines[1]}`
+      : gradeLines[1];
 
   return (
     <View style={styles.gradeColumn}>
@@ -316,7 +329,7 @@ const LiveClimbGrade = React.memo(function LiveClimbGrade({
       </View>
       {gradeLines.length > 1 ? (
         <Text variant="caption2" numberOfLines={1} style={[styles.gradeSecondaryText, { color: gradeColor }]}>
-          {gradeLines[1]}
+          {secondaryGradeLine}
         </Text>
       ) : null}
       {consensusGrade ? (

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -505,8 +505,12 @@ const styles = StyleSheet.create({
     paddingHorizontal: 5,
     paddingVertical: 1,
     borderRadius: 4,
-    // Never absorbs the row's truncation — the name does (see `climbName`).
-    flexShrink: 0,
+    // Shrinks with the other attribute badges rather than ahead of the climb
+    // name. This read `flexShrink: 0` when it landed, against a `flexShrink: 1`
+    // name — correct then, but this change flips that rule (see the badge styles
+    // in ClimbAttributeIcons), so leaving it rigid would make the hidden chip the
+    // one badge that still pushes the row's identifier into an ellipsis.
+    flexShrink: 1,
   },
   subtitle: {
     opacity: 0.6,

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, type ReactNode } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { BoardName } from '@boardsesh/shared-schema';
@@ -12,10 +12,24 @@ import { useTheme } from '../providers/theme-provider';
 import { Icon } from './Icon';
 import { ClimbAttributeIcons } from './ClimbAttributeIcons';
 import { ClimbPlaylistChips } from './ClimbPlaylistChips';
+import { splitGradeLabel } from '@boardsesh/play-view';
 import { isClimbResolved } from '../lib/queue-climb-resolution';
 import { useIsClimbFavorited } from '../hooks/use-is-climb-favorited';
 import type { IconName } from './icon-map';
 import type { AscentStatusValue } from '../lib/ascent-status-utils';
+
+/**
+ * Fixed width of the trailing rail when `stableRail` is on: two 16pt status
+ * slots, their 6pt gaps, and 44pt for the grade.
+ *
+ * Reserving the status slots costs a plain row ~44pt, and buys the list ONE
+ * truncation edge. Without it the rail is 40 / 62 / 84pt depending on whether
+ * that particular climb is favourited and/or ticked — the glyphs return null
+ * and a missing child emits no flex gap — so names cut at three different x
+ * positions down a single screen, and the rows that lose the most are the
+ * favourited-and-tried ones the climber cares about most.
+ */
+const STABLE_RAIL_WIDTH = 88;
 
 // Scan-line status marker. Status is carried by glyph SHAPE in a single neutral
 // grey — not a colour — so it can't be mistaken for the colour-coded grade right
@@ -121,6 +135,19 @@ type ClimbListItemContentProps = {
    * scroll past and nothing on the rest.
    */
   showFavorite?: boolean;
+  /**
+   * Pin the trailing rail to a constant width so every row in the list
+   * truncates at the same x. Opt-in: surfaces with a tighter budget than the
+   * climbs list (`QueueItemRow` runs a ~97pt text column) would rather have the
+   * variable rail's extra room than the alignment.
+   */
+  stableRail?: boolean;
+  /**
+   * Rendered UNDER the grade, inside the trailing rail, spending the vertical
+   * space the rail already occupies rather than taking another 56pt of the text
+   * column. The climbs list puts its ⋮ quick-actions button here.
+   */
+  trailingAccessory?: ReactNode;
 };
 
 /**
@@ -288,14 +315,26 @@ const LiveClimbGrade = React.memo(function LiveClimbGrade({
     difficulty: liveStats.difficulty,
   });
 
+  // A "both" preference renders as "V10 / 7C+", which needs ~88pt at title3 —
+  // more than the rail has once the status glyphs are in it, so the label
+  // overflowed the row and painted over the name. Stack the two scales instead,
+  // spending the rail's unused height. `splitGradeLabel` returns a single
+  // element for the one-scale formats, so those rows are unchanged.
+  const gradeLines = splitGradeLabel(formattedGrade);
+
   return (
     <View style={styles.gradeColumn}>
       <View style={styles.iconGradeRow}>
         {gradeIsConsensus ? <Icon name="people" size={13} color={systemColors.secondaryLabel} /> : null}
         <Text variant="title3" numberOfLines={1} style={[styles.gradeText, { color: gradeColor }]}>
-          {formattedGrade}
+          {gradeLines[0] ?? formattedGrade}
         </Text>
       </View>
+      {gradeLines.length > 1 ? (
+        <Text variant="caption2" numberOfLines={1} style={[styles.gradeSecondaryText, { color: gradeColor }]}>
+          {gradeLines[1]}
+        </Text>
+      ) : null}
       {consensusGrade ? (
         <View style={styles.iconGradeRow}>
           <Icon name="people" size={11} color={systemColors.secondaryLabel} />
@@ -334,6 +373,8 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
   gradeIsConsensus = false,
   showPlaylistChips = false,
   showFavorite = false,
+  stableRail = false,
+  trailingAccessory,
 }: ClimbListItemContentProps) {
   const { t: tSession } = useTranslation('session');
 
@@ -358,7 +399,7 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
             {tSession('mobile.queue.unknownClimb')}
           </Text>
         </View>
-        <View style={styles.rightSection} />
+        <View style={[styles.rightSection, stableRail && styles.rightSectionStable]} />
       </>
     );
   }
@@ -414,18 +455,22 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
         {showPlaylistChips ? <ClimbPlaylistChips climbUuid={climb.uuid} /> : null}
       </View>
 
-      {/* Right: favourite heart + ascent-status glyph + colorized grade */}
-      <View style={styles.rightSection}>
-        {showFavorite ? <FavoriteGlyph climbUuid={climb.uuid} /> : null}
-        {showAscentStatus ? <AscentStatusGlyph climbUuid={climb.uuid} angle={angle} /> : null}
-        <LiveClimbGrade
-          climb={climb}
-          boardName={boardName}
-          layoutId={layoutId}
-          angle={angle}
-          gradeIsConsensus={gradeIsConsensus}
-          consensusGrade={consensusGrade}
-        />
+      {/* Right rail: status glyphs + colorized grade, with any trailing
+          accessory stacked beneath them in the rail's own vertical space. */}
+      <View style={[styles.rightSection, stableRail && styles.rightSectionStable]}>
+        <View style={styles.railPrimaryRow}>
+          {showFavorite ? <FavoriteGlyph climbUuid={climb.uuid} /> : null}
+          {showAscentStatus ? <AscentStatusGlyph climbUuid={climb.uuid} angle={angle} /> : null}
+          <LiveClimbGrade
+            climb={climb}
+            boardName={boardName}
+            layoutId={layoutId}
+            angle={angle}
+            gradeIsConsensus={gradeIsConsensus}
+            consensusGrade={consensusGrade}
+          />
+        </View>
+        {trailingAccessory}
       </View>
     </>
   );
@@ -472,19 +517,35 @@ const styles = StyleSheet.create({
   },
   rightSection: {
     flexShrink: 0,
+    alignItems: 'flex-end',
+    justifyContent: 'center',
+    gap: 4,
+  },
+  rightSectionStable: {
+    width: STABLE_RAIL_WIDTH,
+  },
+  railPrimaryRow: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'flex-end',
+    alignSelf: 'stretch',
     gap: 6,
   },
   gradeText: {
     fontWeight: '700',
-    minWidth: 40,
     textAlign: 'right',
   },
+  // Takes the rail width the status glyphs don't, so a long label (`≈V16+`, or
+  // either half of a stacked V/font pair) gets the whole rail on a row with no
+  // glyphs instead of being held to a 40pt minimum and overflowing.
   gradeColumn: {
+    flexShrink: 1,
+    minWidth: 40,
     alignItems: 'flex-end',
     gap: 1,
+  },
+  gradeSecondaryText: {
+    fontWeight: '700',
   },
   iconGradeRow: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -544,8 +544,12 @@ const styles = StyleSheet.create({
     alignItems: 'flex-end',
     gap: 1,
   },
+  // Matches `gradeText`. `gradeColumn` right-aligns both lines at their natural
+  // width, so this is invisible until the column is squeezed — at which point
+  // the shrunk box needs to know which edge its glyphs hug, same as the primary.
   gradeSecondaryText: {
     fontWeight: '700',
+    textAlign: 'right',
   },
   iconGradeRow: {
     flexDirection: 'row',

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -18,19 +18,10 @@ import { useIsClimbFavorited } from '../hooks/use-is-climb-favorited';
 import type { IconName } from './icon-map';
 import type { AscentStatusValue } from '../lib/ascent-status-utils';
 
-/**
- * Fixed width of the trailing rail when `stableRail` is on: two 16pt status
- * slots, their 6pt gaps, and 44pt for the grade.
- *
- * Reserving the status slots costs a plain row ~44pt, and buys the list ONE
- * truncation edge. Without it the rail is 40 / 62 / 84pt depending on whether
- * that particular climb is favourited and/or ticked — the glyphs return null
- * and a missing child emits no flex gap — so names cut at three different x
- * positions down a single screen, and the rows that lose the most are the
- * favourited-and-tried ones the climber cares about most.
- */
-const STABLE_RAIL_WIDTH = 88;
-
+/** Size of each status glyph in the rail (favourite heart, ascent status). */
+const RAIL_GLYPH_SIZE = 16;
+/** Gap between the rail's status glyphs and the grade. */
+const RAIL_GLYPH_GAP = 6;
 // Scan-line status marker. Status is carried by glyph SHAPE in a single neutral
 // grey — not a colour — so it can't be mistaken for the colour-coded grade right
 // beside it, and so it stays readable for colour-blind users. ⚡ flashed,
@@ -136,13 +127,6 @@ type ClimbListItemContentProps = {
    */
   showFavorite?: boolean;
   /**
-   * Pin the trailing rail to a constant width so every row in the list
-   * truncates at the same x. Opt-in: surfaces with a tighter budget than the
-   * climbs list (`QueueItemRow` runs a ~97pt text column) would rather have the
-   * variable rail's extra room than the alignment.
-   */
-  stableRail?: boolean;
-  /**
    * Rendered UNDER the grade, inside the trailing rail, spending the vertical
    * space the rail already occupies rather than taking another 56pt of the text
    * column. The climbs list puts its ⋮ quick-actions button here.
@@ -174,7 +158,7 @@ const FavoriteGlyph = React.memo(function FavoriteGlyph({ climbUuid }: { climbUu
   if (!isFavorited) return null;
   return (
     <View accessibilityRole="image" accessibilityLabel={t('mobile.climbRow.favorited')}>
-      <Icon name="favorite.fill" size={16} color={theme.systemColors.secondaryLabel} />
+      <Icon name="favorite.fill" size={RAIL_GLYPH_SIZE} color={theme.systemColors.secondaryLabel} />
     </View>
   );
 });
@@ -240,7 +224,7 @@ const AscentStatusGlyph = React.memo(function AscentStatusGlyph({
   if (!ascentStatus) return null;
   return (
     <View accessibilityRole="image" accessibilityLabel={ascentStatusLabel}>
-      <Icon name={ASCENT_STATUS_ICON[ascentStatus]} size={16} color={theme.systemColors.secondaryLabel} />
+      <Icon name={ASCENT_STATUS_ICON[ascentStatus]} size={RAIL_GLYPH_SIZE} color={theme.systemColors.secondaryLabel} />
     </View>
   );
 });
@@ -373,7 +357,6 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
   gradeIsConsensus = false,
   showPlaylistChips = false,
   showFavorite = false,
-  stableRail = false,
   trailingAccessory,
 }: ClimbListItemContentProps) {
   const { t: tSession } = useTranslation('session');
@@ -399,7 +382,7 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
             {tSession('mobile.queue.unknownClimb')}
           </Text>
         </View>
-        <View style={[styles.rightSection, stableRail && styles.rightSectionStable]} />
+        <View style={styles.rightSection} />
       </>
     );
   }
@@ -457,7 +440,7 @@ const ClimbListItemContent = React.memo(function ClimbListItemContent({
 
       {/* Right rail: status glyphs + colorized grade, with any trailing
           accessory stacked beneath them in the rail's own vertical space. */}
-      <View style={[styles.rightSection, stableRail && styles.rightSectionStable]}>
+      <View style={styles.rightSection}>
         <View style={styles.railPrimaryRow}>
           {showFavorite ? <FavoriteGlyph climbUuid={climb.uuid} /> : null}
           {showAscentStatus ? <AscentStatusGlyph climbUuid={climb.uuid} angle={angle} /> : null}
@@ -521,15 +504,12 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     gap: 4,
   },
-  rightSectionStable: {
-    width: STABLE_RAIL_WIDTH,
-  },
   railPrimaryRow: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'flex-end',
     alignSelf: 'stretch',
-    gap: 6,
+    gap: RAIL_GLYPH_GAP,
   },
   gradeText: {
     fontWeight: '700',

--- a/packages/mobile/src/components/ClimbListItemContent.tsx
+++ b/packages/mobile/src/components/ClimbListItemContent.tsx
@@ -311,7 +311,7 @@ const LiveClimbGrade = React.memo(function LiveClimbGrade({
       <View style={styles.iconGradeRow}>
         {gradeIsConsensus ? <Icon name="people" size={13} color={systemColors.secondaryLabel} /> : null}
         <Text variant="title3" numberOfLines={1} style={[styles.gradeText, { color: gradeColor }]}>
-          {gradeLines[0] ?? formattedGrade}
+          {gradeLines[0]}
         </Text>
       </View>
       {gradeLines.length > 1 ? (

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -206,12 +206,6 @@ type ClimbListRowProps = {
    */
   showFavorite?: boolean;
   /**
-   * Pin the trailing rail to a constant width so the whole list truncates at
-   * one x. Only the climbs list opts in; tighter surfaces prefer the room.
-   * Ignored when `renderContent` supplies a custom layout.
-   */
-  stableRail?: boolean;
-  /**
    * Show a trailing ⋮ button that opens the reaction menu on tap — a visible,
    * discoverable entry point beside the long-press. The climbs list passes the
    * "Show quick-actions button" user setting (on by default), other surfaces keep
@@ -240,7 +234,6 @@ const ClimbListRow = React.memo(function ClimbListRow({
   showSeparator = true,
   showPlaylistChips = false,
   showFavorite = false,
-  stableRail = false,
   showMoreButton = false,
 }: ClimbListRowProps) {
   const { t } = useTranslation('climbs');
@@ -486,27 +479,42 @@ const ClimbListRow = React.memo(function ClimbListRow({
     [dragArmedRef],
   );
 
-  const moreButton =
-    showMoreButton && onOpenActions ? (
-      <GestureDetector gesture={moreButtonGesture} touchAction="pan-y">
-        <View
-          testID="climb-row-more-button"
-          style={[styles.moreButton, isMaterial && styles.moreButtonMaterial]}
-          accessible
-          accessibilityRole="button"
-          accessibilityLabel={t('mobile.climbRow.moreActions')}
-          onAccessibilityTap={handleOpenActions}
-          accessibilityActions={ACTIVATE_ACCESSIBILITY_ACTIONS}
-          onAccessibilityAction={handleMoreButtonAccessibilityAction}
-        >
-          {/* iOS has no vertical-ellipsis SF Symbol, so rotate the horizontal one;
+  // Memoized: it is handed to a `React.memo` child, so a fresh element each
+  // render would defeat that boundary — and this row re-renders on every
+  // active-climb change and twice per swipe arm/disarm.
+  const moreButton = useMemo(
+    () =>
+      showMoreButton && onOpenActions ? (
+        <GestureDetector gesture={moreButtonGesture} touchAction="pan-y">
+          <View
+            testID="climb-row-more-button"
+            style={[styles.moreButton, isMaterial && styles.moreButtonMaterial]}
+            accessible
+            accessibilityRole="button"
+            accessibilityLabel={t('mobile.climbRow.moreActions')}
+            onAccessibilityTap={handleOpenActions}
+            accessibilityActions={ACTIVATE_ACCESSIBILITY_ACTIONS}
+            onAccessibilityAction={handleMoreButtonAccessibilityAction}
+          >
+            {/* iOS has no vertical-ellipsis SF Symbol, so rotate the horizontal one;
               Android's dots-vertical is already vertical (no rotation). */}
-          <View style={Platform.OS === 'ios' ? styles.moreIconRotate : undefined}>
-            <Icon name="more.vertical" size={20} color={systemColors.secondaryLabel} />
+            <View style={Platform.OS === 'ios' ? styles.moreIconRotate : undefined}>
+              <Icon name="more.vertical" size={20} color={systemColors.secondaryLabel} />
+            </View>
           </View>
-        </View>
-      </GestureDetector>
-    ) : null;
+        </GestureDetector>
+      ) : null,
+    [
+      showMoreButton,
+      onOpenActions,
+      moreButtonGesture,
+      isMaterial,
+      t,
+      handleOpenActions,
+      handleMoreButtonAccessibilityAction,
+      systemColors.secondaryLabel,
+    ],
+  );
 
   const rowContent = renderContent ? (
     renderContent({ climb, boardName, layoutId, sizeId, setIds, angle })
@@ -520,7 +528,6 @@ const ClimbListRow = React.memo(function ClimbListRow({
       angle={angle}
       showPlaylistChips={showPlaylistChips}
       showFavorite={showFavorite}
-      stableRail={stableRail}
       // Stacked under the grade rather than beside the text: the rail already
       // occupies the row's full height for a 25pt grade, so the button is free
       // there, where as a fourth flex child it cost 56pt (its 44 plus a gap) of

--- a/packages/mobile/src/components/ClimbListRow.tsx
+++ b/packages/mobile/src/components/ClimbListRow.tsx
@@ -26,6 +26,7 @@ import { ClimbListItemContent } from './ClimbListItemContent';
 import { climbListRowStyles } from './climb-list-row-styles';
 import { hapticLight, hapticMedium, hapticSuccess } from '../lib/haptics';
 import { useTheme } from '../providers/theme-provider';
+import { useVariantValue } from '../theme/variants';
 import { iosSystemColors } from '../theme/ios-colors';
 import { brandColors } from '../theme/colors';
 import { selectedRowColors } from './climb-list-row-colors';
@@ -205,6 +206,12 @@ type ClimbListRowProps = {
    */
   showFavorite?: boolean;
   /**
+   * Pin the trailing rail to a constant width so the whole list truncates at
+   * one x. Only the climbs list opts in; tighter surfaces prefer the room.
+   * Ignored when `renderContent` supplies a custom layout.
+   */
+  stableRail?: boolean;
+  /**
    * Show a trailing ⋮ button that opens the reaction menu on tap — a visible,
    * discoverable entry point beside the long-press. The climbs list passes the
    * "Show quick-actions button" user setting (on by default), other surfaces keep
@@ -233,10 +240,14 @@ const ClimbListRow = React.memo(function ClimbListRow({
   showSeparator = true,
   showPlaylistChips = false,
   showFavorite = false,
+  stableRail = false,
   showMoreButton = false,
 }: ClimbListRowProps) {
   const { t } = useTranslation('climbs');
   const { systemColors, brandColors: brand } = useTheme();
+  // M3 wants ≥48dp; iOS wants ≥44pt. In the rail the button is stacked under
+  // the grade, so the larger Android target costs no width at all.
+  const isMaterial = useVariantValue({ material: true, liquidGlass: false });
   // Active-row highlight colours, derived from the scheme-aware brand so the wash
   // + accent stay visible in dark (lifted #A78BFA) as well as light.
   const highlight = useMemo(() => selectedRowColors(brand.primary), [brand.primary]);
@@ -475,6 +486,28 @@ const ClimbListRow = React.memo(function ClimbListRow({
     [dragArmedRef],
   );
 
+  const moreButton =
+    showMoreButton && onOpenActions ? (
+      <GestureDetector gesture={moreButtonGesture} touchAction="pan-y">
+        <View
+          testID="climb-row-more-button"
+          style={[styles.moreButton, isMaterial && styles.moreButtonMaterial]}
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel={t('mobile.climbRow.moreActions')}
+          onAccessibilityTap={handleOpenActions}
+          accessibilityActions={ACTIVATE_ACCESSIBILITY_ACTIONS}
+          onAccessibilityAction={handleMoreButtonAccessibilityAction}
+        >
+          {/* iOS has no vertical-ellipsis SF Symbol, so rotate the horizontal one;
+              Android's dots-vertical is already vertical (no rotation). */}
+          <View style={Platform.OS === 'ios' ? styles.moreIconRotate : undefined}>
+            <Icon name="more.vertical" size={20} color={systemColors.secondaryLabel} />
+          </View>
+        </View>
+      </GestureDetector>
+    ) : null;
+
   const rowContent = renderContent ? (
     renderContent({ climb, boardName, layoutId, sizeId, setIds, angle })
   ) : (
@@ -487,6 +520,12 @@ const ClimbListRow = React.memo(function ClimbListRow({
       angle={angle}
       showPlaylistChips={showPlaylistChips}
       showFavorite={showFavorite}
+      stableRail={stableRail}
+      // Stacked under the grade rather than beside the text: the rail already
+      // occupies the row's full height for a 25pt grade, so the button is free
+      // there, where as a fourth flex child it cost 56pt (its 44 plus a gap) of
+      // the text column on every row.
+      trailingAccessory={moreButton}
     />
   );
 
@@ -537,26 +576,9 @@ const ClimbListRow = React.memo(function ClimbListRow({
 
             {rowContent}
 
-            {showMoreButton && onOpenActions ? (
-              <GestureDetector gesture={moreButtonGesture} touchAction="pan-y">
-                <View
-                  testID="climb-row-more-button"
-                  style={styles.moreButton}
-                  accessible
-                  accessibilityRole="button"
-                  accessibilityLabel={t('mobile.climbRow.moreActions')}
-                  onAccessibilityTap={handleOpenActions}
-                  accessibilityActions={ACTIVATE_ACCESSIBILITY_ACTIONS}
-                  onAccessibilityAction={handleMoreButtonAccessibilityAction}
-                >
-                  {/* iOS has no vertical-ellipsis SF Symbol, so rotate the horizontal one;
-                      Android's dots-vertical is already vertical (no rotation). */}
-                  <View style={Platform.OS === 'ios' ? styles.moreIconRotate : undefined}>
-                    <Icon name="more.vertical" size={20} color={systemColors.secondaryLabel} />
-                  </View>
-                </View>
-              </GestureDetector>
-            ) : null}
+            {/* A custom layout doesn't render the rail, so the button falls back
+                to its own column there rather than disappearing. */}
+            {renderContent ? moreButton : null}
           </View>
         </GestureDetector>
       </ReanimatedSwipeable>
@@ -626,6 +648,10 @@ const styles = StyleSheet.create({
     height: 44,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  moreButtonMaterial: {
+    width: 48,
+    height: 48,
   },
   moreIconRotate: {
     transform: [{ rotate: '90deg' }],

--- a/packages/mobile/src/components/__tests__/ClimbAttributeIcons.test.tsx
+++ b/packages/mobile/src/components/__tests__/ClimbAttributeIcons.test.tsx
@@ -127,3 +127,36 @@ describe('ClimbAttributeIcons', () => {
     expect(badgeTexts(container)).toEqual(['mobile.climbRow.campus · mobile.climbRow.noKickboard']);
   });
 });
+
+describe('ClimbAttributeIcons no-kickboard duplication', () => {
+  const textOf = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('span'))
+      .map((node) => node.textContent ?? '')
+      .filter((text) => text.length > 0);
+
+  // `no_kickboard` and `method_no_kickboard` are independent tokens and a climb
+  // can carry both. In en/es/fr the two strings are identical, so the row read
+  // "No KB  No KB".
+  it('names the no-kickboard rule once when a climb carries both tokens', () => {
+    const { container } = render(<ClimbAttributeIcons characteristics={['method_no_kickboard', 'no_kickboard']} />);
+
+    const labels = textOf(container).filter((text) => text.includes('noKickboard'));
+    expect(labels).toHaveLength(1);
+  });
+
+  it('still shows the standalone no-kickboard badge without the method token', () => {
+    const { container } = render(<ClimbAttributeIcons characteristics={['no_kickboard']} />);
+
+    expect(textOf(container).some((text) => text.includes('mobile.climbRow.noKickboard'))).toBe(true);
+  });
+
+  it('keeps a different method badge alongside the no-kickboard badge', () => {
+    const { container } = render(
+      <ClimbAttributeIcons characteristics={['method_footless_kickboard', 'no_kickboard']} />,
+    );
+    const labels = textOf(container);
+
+    expect(labels.some((text) => text.includes('method.footlessKickboard'))).toBe(true);
+    expect(labels.some((text) => text.includes('mobile.climbRow.noKickboard'))).toBe(true);
+  });
+});

--- a/packages/mobile/src/components/__tests__/ClimbAttributeIcons.test.tsx
+++ b/packages/mobile/src/components/__tests__/ClimbAttributeIcons.test.tsx
@@ -135,8 +135,10 @@ describe('ClimbAttributeIcons no-kickboard duplication', () => {
       .filter((text) => text.length > 0);
 
   // `no_kickboard` and `method_no_kickboard` are independent tokens and a climb
-  // can carry both. In en/es/fr the two strings are identical, so the row read
-  // "No KB  No KB".
+  // can carry both. In en-US and fr the two strings are word-for-word identical,
+  // so the row read "No KB  No KB" / "Sans KB  Sans KB"; es and de word them
+  // differently ("Sin repisa" vs "Sin KB", "Ohne FL" vs "Ohne KB") but it is
+  // the same rule stated twice either way.
   it('names the no-kickboard rule once when a climb carries both tokens', () => {
     const { container } = render(<ClimbAttributeIcons characteristics={['method_no_kickboard', 'no_kickboard']} />);
 

--- a/packages/mobile/src/components/__tests__/ClimbListItemContent.test.tsx
+++ b/packages/mobile/src/components/__tests__/ClimbListItemContent.test.tsx
@@ -33,7 +33,17 @@ vi.mock('@boardsesh/board-react', () => ({
 
 vi.mock('react-native', () => ({
   StyleSheet: { create: (styles: unknown) => styles },
-  View: ({ children }: { children?: ReactNode }) => createElement('div', {}, children),
+  // Surfaces `testID` and the flattened `flexShrink` so a layout rule this file
+  // cares about is assertable here. Most style regressions still need a device —
+  // the mock has no layout engine — but "does this badge shrink before the climb
+  // name does" is a single declared property, and it is the rule a new badge is
+  // most likely to get wrong.
+  View: ({ children, style, testID }: { children?: ReactNode; style?: unknown; testID?: string }) => {
+    const flattened = (Array.isArray(style) ? Object.assign({}, ...style.filter(Boolean)) : (style ?? {})) as {
+      flexShrink?: number;
+    };
+    return createElement('div', { 'data-testid': testID, 'data-flex-shrink': flattened.flexShrink }, children);
+  },
 }));
 
 vi.mock('react-i18next', () => ({
@@ -228,6 +238,27 @@ describe('ClimbListItemContent hidden chip', () => {
       <ClimbListItemContent climb={baseClimb} boardName="kilter" layoutId={1} sizeId={1} setIds="1" angle={40} />,
     );
     expect(chipIcon(container)).toBeNull();
+  });
+
+  // The chip landed with `flexShrink: 0` against a `flexShrink: 1` name, which
+  // was right at the time. This change flips that rule so the badges shrink and
+  // the climb name — the row's identifier — keeps its width, and a rigid chip
+  // would quietly opt hidden climbs back out of it.
+  it('shrinks with the other badges rather than pushing the name into an ellipsis', () => {
+    const { container } = render(
+      <ClimbListItemContent
+        climb={{ ...baseClimb, is_hidden: true }}
+        boardName="kilter"
+        layoutId={1}
+        sizeId={1}
+        setIds="1"
+        angle={40}
+      />,
+    );
+
+    expect(container.querySelector('[data-testid="climb-row-hidden-chip"]')?.getAttribute('data-flex-shrink')).toBe(
+      '1',
+    );
   });
 
   it('leaves a queue row without the field unmarked rather than guessing', () => {

--- a/packages/mobile/src/components/__tests__/ClimbListItemContent.test.tsx
+++ b/packages/mobile/src/components/__tests__/ClimbListItemContent.test.tsx
@@ -244,3 +244,53 @@ describe('ClimbListItemContent hidden chip', () => {
     expect(chipIcon(container)).toBeNull();
   });
 });
+
+describe('ClimbListItemContent trailing rail', () => {
+  beforeEach(() => {
+    favoritesStore.reset();
+    resolveGrade.mockReturnValue({ label: 'V4', color: '#111111', isBoardsesh: false });
+  });
+
+  const render_ = (props: Record<string, unknown> = {}) =>
+    render(
+      <ClimbListItemContent
+        climb={baseClimb}
+        boardName="kilter"
+        layoutId={1}
+        sizeId={1}
+        setIds="1"
+        angle={40}
+        {...props}
+      />,
+    );
+
+  it('renders a trailing accessory inside the rail, not as a column of its own', () => {
+    const { container } = render_({ trailingAccessory: createElement('i', { 'data-testid': 'more' }) });
+    expect(container.querySelector('[data-testid="more"]')).not.toBeNull();
+  });
+
+  it('renders nothing extra when no accessory is supplied', () => {
+    const { container } = render_();
+    expect(container.querySelector('[data-testid="more"]')).toBeNull();
+  });
+
+  // "V10 / 7C+" needs ~88pt at title3 — more than the rail holds once the status
+  // glyphs are in it — so it used to overflow the row and paint over the name.
+  it('stacks a two-scale grade onto two lines', () => {
+    resolveGrade.mockReturnValue({ label: 'V10 / 7C+', color: '#abcdef', isBoardsesh: false });
+    const { container } = render_();
+
+    const primary = container.querySelector('[data-variant="title3"]');
+    const secondary = container.querySelector('[data-variant="caption2"]');
+    expect(primary?.textContent).toBe('V10');
+    expect(secondary?.textContent).toBe('7C+');
+  });
+
+  it('leaves a single-scale grade on one line', () => {
+    resolveGrade.mockReturnValue({ label: 'V10', color: '#abcdef', isBoardsesh: false });
+    const { container } = render_();
+
+    expect(container.querySelector('[data-variant="title3"]')?.textContent).toBe('V10');
+    expect(container.querySelector('[data-variant="caption2"]')).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/__tests__/ClimbListItemContent.test.tsx
+++ b/packages/mobile/src/components/__tests__/ClimbListItemContent.test.tsx
@@ -266,7 +266,17 @@ describe('ClimbListItemContent trailing rail', () => {
 
   it('renders a trailing accessory inside the rail, not as a column of its own', () => {
     const { container } = render_({ trailingAccessory: createElement('i', { 'data-testid': 'more' }) });
-    expect(container.querySelector('[data-testid="more"]')).not.toBeNull();
+
+    const accessory = container.querySelector('[data-testid="more"]');
+    const grade = container.querySelector('[data-variant="title3"]');
+    expect(accessory).not.toBeNull();
+    // The structural claim, and both halves are needed to make it one. The
+    // component returns a fragment, so a sibling accessory would ALSO have a
+    // parent containing the grade — that parent would just be the render root.
+    // Requiring a parent that is not the root is what distinguishes "in the
+    // rail, beside the grade" from "a fourth column of the row".
+    expect(accessory?.parentElement).not.toBe(container);
+    expect(accessory?.parentElement?.contains(grade as Node)).toBe(true);
   });
 
   it('renders nothing extra when no accessory is supplied', () => {

--- a/packages/mobile/src/components/__tests__/ClimbListItemContent.test.tsx
+++ b/packages/mobile/src/components/__tests__/ClimbListItemContent.test.tsx
@@ -286,6 +286,25 @@ describe('ClimbListItemContent trailing rail', () => {
     expect(secondary?.textContent).toBe('7C+');
   });
 
+  // `resolveDisplayGrade` marks a projected grade by prefixing the whole label,
+  // so a naive split leaves the second scale reading as crowd-backed. The
+  // confidence-tier contract in docs/boardsesh-grade.md says a projected grade
+  // has to stay visibly marked.
+  it('keeps the estimate marker on both lines of a stacked projected grade', () => {
+    resolveGrade.mockReturnValue({ label: '≈V5 / 6C+', color: '#abcdef', isBoardsesh: true, isEstimated: true });
+    const { container } = render_();
+
+    expect(container.querySelector('[data-variant="title3"]')?.textContent).toBe('≈V5');
+    expect(container.querySelector('[data-variant="caption2"]')?.textContent).toBe('≈6C+');
+  });
+
+  it('does not mark a stacked grade that is not an estimate', () => {
+    resolveGrade.mockReturnValue({ label: 'V5 / 6C+', color: '#abcdef', isBoardsesh: true, isEstimated: false });
+    const { container } = render_();
+
+    expect(container.querySelector('[data-variant="caption2"]')?.textContent).toBe('6C+');
+  });
+
   it('leaves a single-scale grade on one line', () => {
     resolveGrade.mockReturnValue({ label: 'V10', color: '#abcdef', isBoardsesh: false });
     const { container } = render_();

--- a/packages/mobile/src/components/__tests__/climb-list-row-accessibility.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-list-row-accessibility.test.tsx
@@ -114,9 +114,12 @@ vi.mock('../use-swipe-arm', () => ({
 
 vi.mock('../Icon', () => ({ Icon: () => createElement('span', { 'data-icon': 'true' }) }));
 
+// Renders `trailingAccessory` because the real component does: the ⋮ lives in
+// the trailing rail, stacked under the grade, rather than as its own column in
+// the row. A stub that dropped it would hide the button these tests assert on.
 vi.mock('../ClimbListItemContent', () => ({
-  ClimbListItemContent: ({ climb }: { climb?: { name?: string } }) =>
-    createElement('span', { 'data-climb-name': climb?.name ?? '' }),
+  ClimbListItemContent: ({ climb, trailingAccessory }: { climb?: { name?: string }; trailingAccessory?: unknown }) =>
+    createElement('span', { 'data-climb-name': climb?.name ?? '' }, trailingAccessory as never),
 }));
 
 vi.mock('../climb-list-row-styles', () => ({

--- a/packages/mobile/src/components/__tests__/climb-list-row-accessibility.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-list-row-accessibility.test.tsx
@@ -118,8 +118,8 @@ vi.mock('../Icon', () => ({ Icon: () => createElement('span', { 'data-icon': 'tr
 // the trailing rail, stacked under the grade, rather than as its own column in
 // the row. A stub that dropped it would hide the button these tests assert on.
 vi.mock('../ClimbListItemContent', () => ({
-  ClimbListItemContent: ({ climb, trailingAccessory }: { climb?: { name?: string }; trailingAccessory?: unknown }) =>
-    createElement('span', { 'data-climb-name': climb?.name ?? '' }, trailingAccessory as never),
+  ClimbListItemContent: ({ climb, trailingAccessory }: { climb?: { name?: string }; trailingAccessory?: ReactNode }) =>
+    createElement('span', { 'data-climb-name': climb?.name ?? '' }, trailingAccessory),
 }));
 
 vi.mock('../climb-list-row-styles', () => ({
@@ -185,6 +185,26 @@ describe('ClimbListRow screen-reader activation', () => {
     a11y.row?.onAccessibilityTap?.();
     a11y.row?.onAccessibilityAction?.({ nativeEvent: { actionName: 'activate' } });
     expect(onPress).not.toHaveBeenCalled();
+  });
+
+  // The ⋮ normally rides in the trailing rail, which `renderContent` replaces.
+  // Without the fallback, opting into the button from a custom layout would
+  // silently render nothing — including its screen-reader route.
+  it('keeps the ⋮ reachable when a custom layout replaces the default content', () => {
+    const onOpenActions = vi.fn();
+    render(
+      <ClimbListRow
+        climb={climb}
+        {...boardProps}
+        onOpenActions={onOpenActions}
+        showMoreButton
+        renderContent={() => null}
+      />,
+    );
+
+    expect(a11y.moreButton?.onAccessibilityTap).toBeTypeOf('function');
+    a11y.moreButton?.onAccessibilityTap?.();
+    expect(onOpenActions).toHaveBeenCalledTimes(1);
   });
 
   it('opens the actions menu from a screen-reader activation of the ⋮ button', () => {

--- a/scripts/lib/mobile-publish-retry.test.ts
+++ b/scripts/lib/mobile-publish-retry.test.ts
@@ -125,9 +125,86 @@ describe('self-hosted publish retries', () => {
       success: true,
       attempts: SELF_HOSTED_PUBLISH_MAX_ATTEMPTS,
       failureKind: null,
+      deployed: true,
     });
     expect(attempts).toHaveLength(SELF_HOSTED_PUBLISH_MAX_ATTEMPTS);
     expect(sleeper.mock.calls.map(([delayMs]) => delayMs)).toEqual([...SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS]);
+  });
+
+  // The exact lines eoas@3.1.2 prints when it finds the export identical to the
+  // update already on the branch, copied from the PR #5166 preview publish log.
+  // It says this on stdout and still exits 0, which is what made the no-op
+  // indistinguishable from a publish.
+  const EOAS_NO_CHANGE_LOG = [
+    '\u25cf  \u26a0\ufe0f There is no change in the update for android, ignored...\n',
+    '\u25b2  \u26a0\ufe0f No changes found in the update, nothing to deploy\n',
+  ];
+
+  it('reports a zero-exit run that uploaded nothing as not deployed', async () => {
+    const runner: PublishCommandRunner = async ({ onStdout }) => {
+      for (const line of EOAS_NO_CHANGE_LOG) onStdout(line);
+      return { exitCode: 0 };
+    };
+
+    const outcome = await publishSelfHostedPlatformWithRetry(
+      { platform: 'android', command: 'vp', args: [], cwd: '/repo', env: emptyChildEnvironment },
+      {
+        runner,
+        sleeper: vi.fn(async () => undefined),
+        stdout: outputCollector().output,
+        stderr: outputCollector().output,
+      },
+    );
+
+    expect(outcome).toEqual({
+      platform: 'android',
+      success: true,
+      attempts: 1,
+      failureKind: null,
+      deployed: false,
+    });
+  });
+
+  it('sees the no-change verdict even when a long asset listing follows it', async () => {
+    // eoas prints the export's whole asset list, which is far longer than the
+    // scanner's rolling window. The verdict must survive falling out of it —
+    // otherwise the detection works locally and silently fails in CI, where the
+    // bundle carries ~380 assets.
+    const runner: PublishCommandRunner = async ({ onStdout }) => {
+      for (const line of EOAS_NO_CHANGE_LOG) onStdout(line);
+      onStdout('assets/material-icons/tune.xml (363B)\n'.repeat(500));
+      return { exitCode: 0 };
+    };
+
+    const outcome = await publishSelfHostedPlatformWithRetry(
+      { platform: 'ios', command: 'vp', args: [], cwd: '/repo', env: emptyChildEnvironment },
+      {
+        runner,
+        sleeper: vi.fn(async () => undefined),
+        stdout: outputCollector().output,
+        stderr: outputCollector().output,
+      },
+    );
+
+    expect(outcome.deployed).toBe(false);
+  });
+
+  it('does not let a no-change run be mistaken for a retryable failure', async () => {
+    // The no-change signal must never feed the retry decision: re-running an
+    // unchanged export produces the same unchanged export.
+    const runner = vi.fn<PublishCommandRunner>(async ({ onStdout }) => {
+      for (const line of EOAS_NO_CHANGE_LOG) onStdout(line);
+      return { exitCode: 0 };
+    });
+    const sleeper = vi.fn(async () => undefined);
+
+    await publishSelfHostedPlatformWithRetry(
+      { platform: 'ios', command: 'vp', args: [], cwd: '/repo', env: emptyChildEnvironment },
+      { runner, sleeper, stdout: outputCollector().output, stderr: outputCollector().output },
+    );
+
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(sleeper).not.toHaveBeenCalled();
   });
 
   it('does not retry permanent or mixed evidence', async () => {
@@ -144,7 +221,13 @@ describe('self-hosted publish retries', () => {
       { runner, sleeper, stdout: outputCollector().output, stderr: stderr.output },
     );
 
-    expect(outcome).toEqual({ platform: 'android', success: false, attempts: 1, failureKind: 'permanent' });
+    expect(outcome).toEqual({
+      platform: 'android',
+      success: false,
+      attempts: 1,
+      failureKind: 'permanent',
+      deployed: false,
+    });
     expect(runner).toHaveBeenCalledTimes(1);
     expect(sleeper).not.toHaveBeenCalled();
   });
@@ -164,7 +247,7 @@ describe('self-hosted publish retries', () => {
       { runner, sleeper, stdout: outputCollector().output, stderr: stderr.output },
     );
 
-    expect(outcome).toEqual({ platform: 'ios', success: false, attempts: 1, failureKind: 'http-5xx' });
+    expect(outcome).toEqual({ platform: 'ios', success: false, attempts: 1, failureKind: 'http-5xx', deployed: false });
     expect(runner).toHaveBeenCalledOnce();
     expect(sleeper).toHaveBeenCalledOnce();
     expect(sleeper).toHaveBeenCalledWith(SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS[0]);
@@ -200,13 +283,14 @@ describe('platform aggregation', () => {
         success: platform === 'android',
         attempts: 1,
         failureKind: platform === 'ios' ? 'unknown' : null,
+        deployed: platform === 'android',
       };
     });
 
     expect(calls).toEqual(['ios', 'android']);
     expect(outcomes).toEqual([
-      { platform: 'ios', success: false, attempts: 1, failureKind: 'unknown' },
-      { platform: 'android', success: true, attempts: 1, failureKind: null },
+      { platform: 'ios', success: false, attempts: 1, failureKind: 'unknown', deployed: false },
+      { platform: 'android', success: true, attempts: 1, failureKind: null, deployed: true },
     ]);
   });
 
@@ -215,13 +299,13 @@ describe('platform aggregation', () => {
     const outcomes = await publishPlatformsSequentially(['ios', 'android'], async (platform) => {
       calls.push(platform);
       if (platform === 'ios') throw new Error('fixture callback failure');
-      return { platform, success: true, attempts: 1, failureKind: null };
+      return { platform, success: true, attempts: 1, failureKind: null, deployed: true };
     });
 
     expect(calls).toEqual(['ios', 'android']);
     expect(outcomes).toEqual([
-      { platform: 'ios', success: false, attempts: 0, failureKind: 'unknown' },
-      { platform: 'android', success: true, attempts: 1, failureKind: null },
+      { platform: 'ios', success: false, attempts: 0, failureKind: 'unknown', deployed: false },
+      { platform: 'android', success: true, attempts: 1, failureKind: null, deployed: true },
     ]);
   });
 });

--- a/scripts/lib/mobile-publish-retry.ts
+++ b/scripts/lib/mobile-publish-retry.ts
@@ -101,6 +101,14 @@ export type PlatformPublishOutcome = {
   success: boolean;
   attempts: number;
   failureKind: PublishFailureKind | null;
+  /**
+   * Whether the run actually put an update on the branch. A successful publish
+   * can still deploy NOTHING: eoas compares the export against the previous
+   * update and skips an identical one. So `success && !deployed` is a real
+   * state, and conflating it with a publish is what let a destroyed preview
+   * branch be announced as ready (PR #5166). False on every failure.
+   */
+  deployed: boolean;
 };
 
 export type PublishRetryDependencies = {
@@ -172,6 +180,38 @@ export class PublishFailureEvidenceScanner {
     if (this.evidence.hasSlowDownCode && this.evidence.hasSlowDownMessage) return 's3-slowdown';
     if (this.evidence.hasHttp5xx) return 'http-5xx';
     return 'unknown';
+  }
+}
+
+// eoas announces a skipped upload on stdout and still exits 0. Both lines are
+// matched because they carry different information and neither is guaranteed:
+// the per-platform one names the platform it ignored, the summary one is the
+// verdict for the command as a whole. Either alone means nothing was uploaded.
+const EOAS_PLATFORM_UNCHANGED = /there is no change in the update for (?:ios|android)/i;
+const EOAS_NOTHING_TO_DEPLOY = /no changes found in the update, nothing to deploy/i;
+
+/**
+ * Tracks whether eoas said it uploaded nothing. Deliberately NOT folded into
+ * PublishFailureEvidenceScanner: this is not failure evidence and must never
+ * feed a retry decision — a re-run of an unchanged export is unchanged again.
+ *
+ * Same rolling-window shape as the failure scanner, for the same reason: the bit
+ * survives after the text falls out of the window, so a long asset listing
+ * printed afterwards cannot bury the verdict.
+ */
+export class PublishNoChangeScanner {
+  private sawNoChange = false;
+  private window = '';
+
+  push(chunk: string): void {
+    const searchable = `${this.window}${chunk}`;
+    this.sawNoChange ||= EOAS_PLATFORM_UNCHANGED.test(searchable) || EOAS_NOTHING_TO_DEPLOY.test(searchable);
+    this.window = searchable.slice(-CLASSIFIER_WINDOW_CHARS);
+  }
+
+  /** True when eoas reported it had nothing to upload. */
+  deployedNothing(): boolean {
+    return this.sawNoChange;
   }
 }
 
@@ -247,6 +287,7 @@ export async function publishSelfHostedPlatformWithRetry(
 
   for (let attempt = 1; attempt <= SELF_HOSTED_PUBLISH_MAX_ATTEMPTS; attempt++) {
     const scanner = new PublishFailureEvidenceScanner();
+    const noChange = new PublishNoChangeScanner();
     let exitCode = 1;
     try {
       const result = await runner({
@@ -257,10 +298,12 @@ export async function publishSelfHostedPlatformWithRetry(
         onStdout: (chunk) => {
           stdout.write(chunk);
           scanner.push(chunk);
+          noChange.push(chunk);
         },
         onStderr: (chunk) => {
           stderr.write(chunk);
           scanner.push(chunk);
+          noChange.push(chunk);
         },
       });
       exitCode = result.exitCode;
@@ -268,11 +311,23 @@ export async function publishSelfHostedPlatformWithRetry(
       // A runner failure has no retryable server evidence. Keep the diagnostic
       // intentionally generic: thrown errors can embed argv/env or a raw tail.
       stderr.write(`[mobile:publish] ${label} publish process failed to run; not retrying.\n`);
-      return { platform: invocation.platform, success: false, attempts: attempt, failureKind: 'unknown' };
+      return {
+        platform: invocation.platform,
+        success: false,
+        attempts: attempt,
+        failureKind: 'unknown',
+        deployed: false,
+      };
     }
 
     if (exitCode === 0) {
-      return { platform: invocation.platform, success: true, attempts: attempt, failureKind: null };
+      return {
+        platform: invocation.platform,
+        success: true,
+        attempts: attempt,
+        failureKind: null,
+        deployed: !noChange.deployedNothing(),
+      };
     }
 
     const failureKind = scanner.classify();
@@ -282,7 +337,7 @@ export async function publishSelfHostedPlatformWithRetry(
       stderr.write(
         `[mobile:publish] ${label} publish failed (${failureDescription(failureKind)})${exhausted}; not retrying.\n`,
       );
-      return { platform: invocation.platform, success: false, attempts: attempt, failureKind };
+      return { platform: invocation.platform, success: false, attempts: attempt, failureKind, deployed: false };
     }
 
     const delayMs = SELF_HOSTED_PUBLISH_RETRY_DELAYS_MS[attempt - 1];
@@ -293,7 +348,7 @@ export async function publishSelfHostedPlatformWithRetry(
       await sleeper(delayMs);
     } catch {
       stderr.write(`[mobile:publish] ${label} retry wait failed; not retrying.\n`);
-      return { platform: invocation.platform, success: false, attempts: attempt, failureKind };
+      return { platform: invocation.platform, success: false, attempts: attempt, failureKind, deployed: false };
     }
   }
 
@@ -304,6 +359,7 @@ export async function publishSelfHostedPlatformWithRetry(
     success: false,
     attempts: SELF_HOSTED_PUBLISH_MAX_ATTEMPTS,
     failureKind: 'unknown',
+    deployed: false,
   };
 }
 
@@ -317,7 +373,7 @@ export async function publishPlatformsSequentially(
     try {
       outcomes.push(await publishPlatform(platform));
     } catch {
-      outcomes.push({ platform, success: false, attempts: 0, failureKind: 'unknown' });
+      outcomes.push({ platform, success: false, attempts: 0, failureKind: 'unknown', deployed: false });
     }
   }
   return outcomes;

--- a/scripts/mobile-ci-env-parity.test.ts
+++ b/scripts/mobile-ci-env-parity.test.ts
@@ -556,14 +556,50 @@ describe('mobile OTA preview branch isolation + S3 lifecycle coupling', () => {
 
   it('resets a mutable preview branch before publishing the current compatible platforms', () => {
     const preview = readWorkflow(OTA_PREVIEW);
+    const compatOffset = preview.indexOf('\n  compat:');
     const resetOffset = preview.indexOf('\n  reset:');
     const publishOffset = preview.indexOf('\n  publish:');
 
-    expect(resetOffset).toBeGreaterThan(0);
+    expect(compatOffset).toBeGreaterThan(0);
+    expect(resetOffset).toBeGreaterThan(compatOffset);
     expect(publishOffset).toBeGreaterThan(resetOffset);
-    expect(preview).toMatch(/^  publish:\n\s+needs: \[gate, reset\]/m);
+    expect(preview).toMatch(/^  publish:\n\s+needs: \[gate, compat, reset\]/m);
     expect(preview).toContain("['legacy channel', `/api/apps/${appId}/channels/${encoded}`]");
     expect(preview).toContain("['branch', `/api/apps/${appId}/branches/${encoded}`]");
+  });
+
+  it('deletes the preview branch only when a platform is about to publish nothing', () => {
+    // The reset is destructive and the publish is conditional: eoas uploads
+    // nothing when the export matches the update already on the branch, so an
+    // unconditional reset deleted the preview and put nothing back on any push
+    // that did not move the bundle (PR #5166 lost it to two test-only pushes).
+    const preview = readWorkflow(OTA_PREVIEW);
+    const resetIf = preview.match(/^  reset:\n\s+needs: \[gate, compat\]\n\s+if: >-\n((?:\s{6}.*\n)+)/m)?.[1] ?? '';
+
+    expect(resetIf).toContain("needs.compat.outputs.verdict_ios == 'native-change-required'");
+    expect(resetIf).toContain("needs.compat.outputs.verdict_android == 'native-change-required'");
+    // Fail-safe: an inconclusive verdict must still reset, or a compat job that
+    // errored would silently leave a stale platform update surfable.
+    expect(resetIf).toContain("needs.compat.result != 'success'");
+  });
+
+  it('keeps the reset-gating verdict on a job that never holds a publish secret', () => {
+    // `compat` runs PR-author code (vp install, app.config execSync) for the same
+    // reason `publish` does. It must stay secret-free: giving it EOO_TOKEN or the
+    // dashboard admin creds would hand a production-capable credential to PR code
+    // on a job that exists only to answer a yes/no question.
+    const preview = readWorkflow(OTA_PREVIEW);
+    const compatJob = preview.match(/^  compat:\n([\s\S]*?)(?=^  reset:)/m)?.[1] ?? '';
+
+    expect(compatJob).not.toBe('');
+    expect(compatJob).not.toContain('EOO_TOKEN');
+    expect(compatJob).not.toContain('OTA_ADMIN_PASSWORD');
+    expect(compatJob).not.toContain('OTA_ADMIN_EMAIL');
+    expect(compatJob).not.toMatch(/^\s+environment:/m);
+    // Same pinned commit as publish, so the verdict describes the revision that
+    // actually gets published rather than a moving head.
+    expect(compatJob).toContain('ref: ${{ needs.gate.outputs.head_sha }}');
+    expect(compatJob).toContain('persist-credentials: false');
   });
 
   it('authorizes comments before dispatching them into the trusted PR lifecycle lane', () => {

--- a/scripts/mobile-publish.test.ts
+++ b/scripts/mobile-publish.test.ts
@@ -216,6 +216,17 @@ describe('mobile publish argument routing', () => {
     ]);
   });
 
+  it('does not claim a publish when every platform had nothing to upload', () => {
+    // eoas exits 0 after skipping an unchanged export, so this path is reached on
+    // a green run. Saying "Published every requested platform" there is what made
+    // a preview that never got republished look ready.
+    const messages = selfHostedPublishSuccessMessages('pr-5166', false);
+
+    expect(messages.join('\n')).not.toContain('Published every requested platform');
+    expect(messages[0]).toContain('No changes to deploy');
+    expect(messages[0]).toContain('pr-5166');
+  });
+
   it('labels self-hosted production and preview modes accurately', () => {
     expect(selfHostedPublishModeLabel('production')).toBe('production (self-hosted expo-open-ota)');
     expect(selfHostedPublishModeLabel('pr-1234')).toBe('preview (self-hosted expo-open-ota)');

--- a/scripts/mobile-publish.ts
+++ b/scripts/mobile-publish.ts
@@ -196,9 +196,13 @@ export function requestedSelfHostedPlatforms(platform: string): OtaPublishPlatfo
 }
 
 function summarizePlatformOutcome(outcome: PlatformPublishOutcome): string {
-  if (outcome.success)
-    return `${outcome.platform}=success (${outcome.attempts} attempt${outcome.attempts === 1 ? '' : 's'})`;
-  return `${outcome.platform}=failed (${outcome.attempts} attempt${outcome.attempts === 1 ? '' : 's'}, ${outcome.failureKind ?? 'unknown'})`;
+  const attempts = `${outcome.attempts} attempt${outcome.attempts === 1 ? '' : 's'}`;
+  if (outcome.success) {
+    // `success` alone used to be the whole story here, which is how a run that
+    // uploaded nothing still read as a publish in the log and in the PR comment.
+    return `${outcome.platform}=${outcome.deployed ? 'success' : 'unchanged'} (${attempts})`;
+  }
+  return `${outcome.platform}=failed (${attempts}, ${outcome.failureKind ?? 'unknown'})`;
 }
 
 async function publishToSelfHostedBranch(
@@ -283,11 +287,26 @@ async function publishToSelfHostedBranch(
     return 1;
   }
 
-  for (const line of selfHostedPublishSuccessMessages(branchName)) console.log(line);
+  const deployedAny = outcomes.some((outcome) => outcome.deployed);
+  for (const line of selfHostedPublishSuccessMessages(branchName, deployedAny)) console.log(line);
   return 0;
 }
 
-export function selfHostedPublishSuccessMessages(branchName: string): string[] {
+/**
+ * `deployedAny` is false when eoas found every requested platform's export
+ * identical to what the branch already carries and uploaded nothing. That is a
+ * normal outcome for a push that changes only tests, docs or CI — none of it
+ * reaches the Metro bundle — and it is NOT a failure: the branch keeps serving
+ * the same bundle. It stops being harmless only if something deleted the branch
+ * first, which is why mobile-ota-preview.yml no longer resets unconditionally.
+ */
+export function selfHostedPublishSuccessMessages(branchName: string, deployedAny = true): string[] {
+  if (!deployedAny) {
+    return [
+      `[mobile:publish] No changes to deploy: every requested platform's bundle already matches "${branchName}".`,
+      '[mobile:publish] Nothing was uploaded. The branch still serves the update it had.',
+    ];
+  }
   const published = `[mobile:publish] Published every requested platform to self-hosted branch "${branchName}".`;
   if (branchName === 'production') {
     return [published, '[mobile:publish] Production builds receive it on their next update check.'];


### PR DESCRIPTION
## Summary

Follow-up to #5153. With the ⋮ quick-actions button on, climb names truncated to "Lightest Pair of…" and the subtitle lost the setter entirely. The ⋮ was a fourth flex child of the row, so on a 393pt phone it cost **56pt** — its 44 plus a gap — of the text column.

The row was starving horizontally while wasting height: the thumbnail pins it at 96pt and the text uses ~42 of that. **The button moves into the trailing rail, stacked under the grade**, spending space the rail already occupies. Nothing else in the row moves, and the rail only widens if the button is wider than the grade block.

Text column on a 393pt phone, button on:

| row | before | after |
|---|---|---|
| plain | 181pt | **229pt** |
| one status glyph | 159pt | **215pt** |
| favourited **and** ticked | 137pt | **193pt** |

Alongside that, three things that were breaking the row independently:

- **A "both" grade** (`V10 / 7C+`) is ~88pt wide at title3, and nothing in the row clips, so it pushed the rail out and squeezed the name. It now stacks the two scales, reusing `splitGradeLabel` and the same stacking `grade-bar-labels.ts` already does. This helps every surface that shows a grade — `QueueItemRow` runs the tightest text column in the app (~97pt) and gets ~49pt back for anyone on that preference.
- **The attribute badges shrink before the name does.** They were `flexShrink: 0` against a shrinkable name, so the row's unique identifier absorbed all the truncation to protect an optional rule badge.
- **The grade flexes inside the rail** rather than holding a 40pt floor.

Two bugs found on the way: the **no-kickboard badge rendered twice** on a climb carrying both `no_kickboard` and `method_no_kickboard` (identical strings in `en-US` and `fr`; `es`/`de` word it differently but it's the same rule), and the **Android ⋮ target was 44dp** against M3's 48 — free to fix now that it's stacked rather than beside the text.

### Reconciling with #5188's Hidden chip

#5188 landed on `main` while this sat in review and added a **"Hidden" chip** to this same row, styled `flexShrink: 0` with the comment *"Never absorbs the row's truncation — the name does"*. That was correct when written — the name was `flexShrink: 1` and every attribute badge was rigid.

This PR inverts that rule. Rebasing merged both **without a conflict** and left the chip as the one badge that still pushes the climb name into an ellipsis, on exactly the surfaces that show a hidden climb: a name search, the setter's own climbs, a direct link. `git merge-tree` reported zero conflict markers; the defect is entirely semantic.

The chip now shrinks with the rest, and the comment says why it flipped.

Guarding it needed the test file's `react-native` mock to stop discarding `style` and `testID` — **which is why this file could not catch a layout rule before**, and it revises what I said in an earlier version of this description. The mock still has no layout engine, so most width regressions remain a device problem; but "does this badge shrink before the name does" is a single declared property, and it is the rule a newly added badge is most likely to get wrong, as this one did. Verified failing with the chip back at `flexShrink: 0`.

### Also here: the OTA preview branch this PR kept losing

Unrelated to the layout, found while working out why `pr-5166` never appeared in the app's PR-test picker. `mobile-ota-preview.yml` deletes the `pr-<n>` branch before publishing, but the publish that follows is conditional — eoas compares each export against the update already on the branch and uploads nothing when they match (`No changes found in the update, nothing to deploy`, on stdout, exit code 0).

A push that changes only tests, docs or CI is exactly that: none of it reaches the Metro bundle, so the export is byte-identical. Pairing the two meant any such push deleted the preview and put nothing back — while the run still went green and the sticky comment still said the branch was ready. This PR lost its preview to two consecutive test-only pushes that way (`edd1a0b`, `5aa44dc`); the reset job logged `branch 'pr-5166' was deleted.` and both platforms then reported nothing to deploy.

The reset now runs only when a platform is about to publish nothing. A stale update can only outlive a revision on a platform that skips, and `publish` skips exactly the `native-change-required` ones, so a new secret-free `compat` job resolves the verdicts before anything mutates the branch. On an all-compatible revision there is nothing to reconcile anyway: a changed bundle supersedes the old update by publishing over it, and an unchanged one is already what the branch serves. An inconclusive verdict still resets — that hazard is the one the workflow cannot see from here.

`compat` runs PR-author code for the same reason `publish` does, so it holds no secrets, and a parity test asserts that. Separately, a platform that uploaded nothing now reads `ios=unchanged` rather than `ios=success`, so a green run stops reading as a publish that did not happen.

Confirmed live across three pushes: `compat` succeeds and **`reset` is skipped** every time, and the preview republishes when the bundle actually moves.

### The picker half was already fixed on main

`/branch_lists` answers with its newest-50 page unless asked for the rest, and `listPrBranches` never asked — so a published, loadable `pr-<n>` could be absent from the pick list with nothing on screen saying it was cut short. I wrote that fix here as a conditional second request; #5173 (`9755741`) had already landed it on `main` as an unconditional `all`, which is simpler and names the part I had missed: **the server applies the cap before the `pr-<n>` filter**, so any other branch on the same runtime version spends one of the fifty. Dropped mine in the rebase and took main's. What survives is a runbook entry in `docs/crowdsourced-qa-mobile.md` for telling "never published" apart from "the app did not render it".

### Considered and dropped

- **A fixed-width rail**, so the list truncates at one x instead of three (the status glyphs return `null` and a missing child emits no flex gap, so the rail is 40/62/84pt). I built it, then took it out: it reserves both status slots on every row, which costs a plain row ~40pt, and most rows are plain. It also shipped unconditionally while the ⋮ is a user setting, so anyone who turned the button **off** would have gone from 237pt to 189. The ragged edge is real, but trading width on the majority of rows to align a minority is a product call, not something to slip into a change whose point was reclaiming space. It can come back on its own merits.
- **Absolute-positioning the ⋮**, the leading design proposal. It removes the width reservation, so the grade — `minWidth` with no max in a `flexShrink: 0` rail — expands underneath the floating button and overprints it. Invisible in the default config (English, iOS, `v-grade`, no favourite), broken outside it.
- **`QueueItemRow`'s 36pt trailing button**, under even iOS's 44pt floor. Widening it takes 8–12pt from that row's ~97pt text column — a real cost deserving its own decision.

Verification, rebased onto `main` at `73751df`: `vp check` 0 errors, `vp run typecheck:mobile` clean, `vp run test:mobile` 848 files / 9,164 tests, `vp test run scripts/` 77 files / 1,251 tests. Every new bug-fix test was confirmed to fail without its fix — the estimate marker, the no-KB dedupe, the rail containment, the no-change detection, and the hidden chip's shrink.

**Worth a reviewer's eye:** the pt figures above are computed from source, not measured on a device, and the tests still prove behaviour rather than layout — `flexShrink` is now assertable, but nothing here measures a width. The workflow change cannot be exercised until it merges to `main`; its mixed-verdict path (one platform native, one not) is the one no run here will cover.

## Release Notes

- More room for climb names in the list — the quick-actions button now tucks under the grade instead of taking a column of its own
- Climbs showing both a V-grade and a font grade no longer squeeze the name

## Test plan

1. Climbs tab, quick-actions button on → names are longer, ⋮ sits under the grade.
2. Tap ⋮ → actions menu opens; swipe the row → still queues.
3. More → Display → grade format "Both" → grade shows stacked, name not squeezed.
4. Search a climb marked Hidden → name stays readable beside the chip.
5. On Android, the ⋮ is comfortable to hit.

## Risk

Risk: 3/5 — layout change to a shared row visual used by 8 surfaces; gesture, swipe and accessibility paths are unchanged and covered by existing tests, but the grade stacking is visible on every surface for anyone on the "both" preference, and the shrink rule now also governs #5188's Hidden chip. The OTA-preview workflow change ships nothing to users and fails safe toward the old always-reset behaviour, but it only takes effect once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBy2XMdkxzDqp42G2PhFnB