### PR TITLE
feat(web): draft build-plans manufacturing licence page and legal reword (build plans 6/10)

### DIFF
--- a/LEGAL.md
+++ b/LEGAL.md
@@ -2,7 +2,7 @@
 
 ## What This Project Is
 
-This is a free, open-source, community-built alternative for browsing and interacting with standardised LED climbing training boards (Kilter Board, Tension Board, MoonBoard, and others). It is non-commercial and maintained entirely by volunteers.
+This is a free, open-source, community-built alternative for browsing and interacting with standardised LED climbing training boards (Kilter Board, Tension Board, MoonBoard, and others). The app is free, the source is open, and the people who build it are volunteers. Boardsesh sells one optional thing — CNC build plans for a home wall, under a separate manufacturing licence — and that revenue pays for hosting and development.
 
 We believe climbers should have the freedom to choose how they interact with hardware they've purchased, and that community-created data should remain accessible to the community.
 
@@ -62,6 +62,20 @@ We use board and product names (e.g. "Kilter Board", "MoonBoard", "Tension Board
 
 ---
 
+## Build Plans
+
+Boardsesh sells CNC build plans for a climbing home wall: a generated set of DXF cutting files, PDFs and a bill of materials for one wall, in the size and the manufacturing options the buyer picked.
+
+What is sold is the generated pack, not the generator. The software that produces the plans is closed source and is not distributed; the app itself stays Apache 2.0 and free.
+
+Each pack is generated individually for one order, carries its own licence id, and is licensed for one wall rather than sold outright. The terms are on the [build plans manufacturing licence](https://boardsesh.com/build-plans/licence) page.
+
+The plans are compatible with the Kilter Homewall hole pattern. That is a statement about hole positions, not a relationship: Boardsesh is not affiliated with, endorsed by, or sponsored by Aurora Climbing or any board manufacturer. Holds, LED kits and app access are not part of a pack and are bought from the manufacturer.
+
+The licence text is a draft pending review by an Australian IP lawyer, and build plans are not on sale until that review is done.
+
+---
+
 ## Third-Party Notices
 
 - **Person Falling icon** from [Font Awesome Free 6.7.2](https://fontawesome.com) by @fontawesome. License: [CC BY 4.0](https://fontawesome.com/license/free). Copyright 2024 Fonticons, Inc.
@@ -94,4 +108,4 @@ If you are a board manufacturer and would like to discuss collaboration or have 
 
 ---
 
-_This document is provided for informational purposes and does not constitute legal advice. Last updated: 08-02-2026_
+_This document is provided for informational purposes and does not constitute legal advice. Last updated: 06-09-2026_

--- a/packages/shared/i18n/locales/de/cnc-legal.json
+++ b/packages/shared/i18n/locales/de/cnc-legal.json
@@ -1,0 +1,105 @@
+{
+  "metadata": {
+    "licence": {
+      "title": "Fertigungslizenz für Baupläne",
+      "description": "Die Lizenz, die zu jedem Bauplan-Paket von Boardsesh gehört: was du fertigen darfst, was du nicht weitergeben darfst und wer für die fertige Wand geradesteht."
+    }
+  },
+  "licence": {
+    "headerTitle": "Fertigungslizenz für Baupläne",
+    "draft": {
+      "title": "Entwurf einer Lizenz",
+      "body": "Lizenzentwurf, wartet auf die Prüfung durch eine australische Anwältin oder einen Anwalt für gewerblichen Rechtsschutz; verlass dich noch nicht darauf. Der Text ändert sich, bevor die Baupläne verkauft werden."
+    },
+    "intro": {
+      "title": "Boardsesh Fertigungslizenz für Baupläne",
+      "p1": "Das ist die Vereinbarung, die zu jedem Bauplan-Paket gehört. Sie sagt, was du bauen darfst, was du nicht weitergeben darfst und wer das Risiko trägt, sobald die Teile geschnitten sind. Absichtlich in einfacher Sprache."
+    },
+    "parties": {
+      "title": "1. Parteien und Begriffe",
+      "boardsesh": {
+        "term": "Boardsesh",
+        "definition": "Das Projekt, das die Dateien erzeugt, die Lizenz ausstellt und den Lizenzeintrag führt."
+      },
+      "licensee": {
+        "term": "Der Lizenznehmer (du)",
+        "definition": "Die Person oder Firma, die im Lizenzeintrag zu einem Paket steht. Die Lizenz läuft auf diesen Namen und ist ohne unsere schriftliche Zustimmung nicht übertragbar."
+      },
+      "pack": {
+        "term": "Das Paket",
+        "definition": "Der Satz Dateien, den Boardsesh für eine Bestellung erzeugt hat, erkennbar an der Lizenz-ID darin (zum Beispiel BS-CNC-4K7QP2). Jedes Paket wird für seine eigene Bestellung erzeugt; keine zwei sind gleich."
+      },
+      "wall": {
+        "term": "Eine Wand",
+        "definition": "Eine physische Installation, einmal gebaut, an einer Adresse. Dieselbe Wand nach einem Schaden neu aufzubauen bleibt dieselbe Wand. Eine zweite Wand woanders ist eine zweite Wand."
+      }
+    },
+    "grant": {
+      "title": "2. Was du bekommst",
+      "p1": "Mit einem Paket kaufst du eine Lizenz zum Fertigen. Es überträgt kein Eigentum an den Dateien, an der Geometrie oder an dem Generator, der sie erzeugt hat. Boardsesh behält alle Rechte am Paket.",
+      "p2": "Die Lizenz beginnt mit der Auslieferung des Pakets und gilt, solange du dich an die Bedingungen unten hältst. Es gibt nichts zu verlängern."
+    },
+    "personal": {
+      "title": "3. Persönliche Lizenz (149 A$)",
+      "summary": "Eine Wand, für deinen eigenen nicht kommerziellen Gebrauch.",
+      "allowed1": "Aus dem Paket eine Wand für deinen eigenen nicht kommerziellen Gebrauch fertigen.",
+      "allowed2": "Die Teile selbst schneiden oder von einer Werkstatt schneiden lassen, solange die fertige Wand dir gehört.",
+      "notAllowed1": "Keine Fertigung zum Verkauf und keine Fertigung im Auftrag anderer.",
+      "notAllowed2": "Kein Weiterverkauf, keine Weitergabe, kein Teilen und kein öffentliches Posten der Dateien, ganz oder in Teilen, verändert oder nicht.",
+      "notAllowed3": "Keine Nutzung der Dateien oder der Vorlagen darin, um abgeleitete Fertigungsdateien für Dritte zu erzeugen.",
+      "notAllowed4": "Eine zweite Wand braucht eine zweite Lizenz."
+    },
+    "commercial": {
+      "title": "4. Gewerbliche Lizenz für einen Bau (750 A$)",
+      "summary": "Eine benannte Kundeninstallation, auf der Lizenz eingetragen.",
+      "allowed1": "Eine Wand für die Kundeninstallation fertigen, die auf der Lizenz steht.",
+      "allowed2": "Diesem Kunden den Bau in Rechnung stellen, so hoch du willst. Genau dafür ist diese Stufe da.",
+      "notAllowed1": "Kein Weiterverkauf, keine Weitergabe, kein Teilen und kein öffentliches Posten der Dateien, ganz oder in Teilen, verändert oder nicht.",
+      "notAllowed2": "Keine Nutzung der Dateien oder der Vorlagen darin, um abgeleitete Fertigungsdateien für Dritte zu erzeugen — auch nicht für deine anderen Kunden.",
+      "notAllowed3": "Jede weitere Installation braucht ihre eigene Lizenz mit eigenem Lizenzeintrag."
+    },
+    "labels": {
+      "allowed": "Du darfst",
+      "notAllowed": "Du darfst nicht"
+    },
+    "volume": {
+      "title": "5. Zehn Bauten und OEM",
+      "body": "Du schneidest in Serie oder willst diese Paneele in ein Produkt einbauen, das du verkaufst? Zehner-Pakete und OEM-Bedingungen vereinbaren wir einzeln. <mail>Schreib uns</mail>, was du baust und in welcher Stückzahl."
+    },
+    "fingerprint": {
+      "title": "6. Markierung und Durchsetzung",
+      "p1": "Jedes Paket wird einzeln für eine Bestellung erzeugt und trägt seine Lizenz-ID in den Dateien.",
+      "p2": "Die Dateien tragen außerdem Markierungen, die am Kauf hängen. Ein Paket, das auftaucht, wo es nicht hingehört, lässt sich bis zur Bestellung zurückverfolgen, die es gekauft hat.",
+      "p3": "Ein Verstoß gegen die Bedingungen oben beendet die Lizenz. Wer danach weiterfertigt, fertigt ohne Lizenz, und wir gehen dem nach."
+    },
+    "compatibility": {
+      "title": "7. Kompatibilität",
+      "p1": "Die Baupläne sind mit dem Lochbild des Kilter Homewall kompatibel. Das ist eine Kompatibilitätsaussage über Lochpositionen, mehr nicht.",
+      "p2": "Boardsesh steht in keiner Verbindung zu Aurora Climbing oder einem anderen Board-Hersteller und wird von ihnen weder unterstützt noch gesponsert. Produktnamen stehen nur da, um Hardware-Kompatibilität zu beschreiben — siehe unsere <legal>Richtlinie zu Rechtlichem und geistigem Eigentum</legal>.",
+      "p3": "Griffe, LED-Kits und App-Zugang gehören nicht zum Paket. Die kaufst du beim Hersteller."
+    },
+    "safety": {
+      "title": "8. Sicherheit und Verantwortung",
+      "p1": "Für Statik, Befestigung, Material und die örtlichen Bauvorschriften deiner Wand bist du verantwortlich. Eine Kletterwand trägt dynamische Lasten und verletzt Menschen, wenn sie versagt.",
+      "p2": "Die Dateien kommen wie sie sind, ohne Zusicherung, dass sie für einen bestimmten Bau taugen. Prüf jedes Maß gegen deine eigenen Platten, deine Maschine und deinen Raum, bevor du schneidest.",
+      "p3": "Boardsesh haftet nicht für Verluste, Schäden oder Verletzungen aus einer Wand, die aus einem Paket gebaut wurde. Nichts hier nimmt dir ein Recht, das dir das australische Verbraucherrecht zwingend gibt."
+    },
+    "refunds": {
+      "title": "9. Erstattungen",
+      "body": "Erzeugte Dateien lassen sich nicht zurückliefern, deshalb ist ein Paket nach dem Download nicht erstattungsfähig. Vor dem Download liegt eine Erstattung im Ermessen von Boardsesh — schreib uns, wir kriegen das hin."
+    },
+    "privacy": {
+      "title": "10. Datenschutz",
+      "body": "Der Lizenzeintrag — dein Name, deine E-Mail, die Lizenz-ID und die bestellte Konfiguration — wird als Vertragsunterlage aufbewahrt. Er bleibt auch nach dem Löschen des Kontos, weil die Lizenz und ihr Kaufnachweis das Konto überdauern. Alles andere folgt der <privacy>Datenschutzerklärung</privacy>."
+    },
+    "governingLaw": {
+      "title": "11. Anwendbares Recht",
+      "body": "Für diese Lizenz gilt das Recht des Bundesstaats Victoria (Australien), zuständig sind die Gerichte in Victoria. Platzhalterformulierung, wartet auf die juristische Prüfung."
+    },
+    "contact": {
+      "title": "12. Kontakt",
+      "body": "Fragen zur Lizenz oder eine Lizenz, die neu ausgestellt werden muss: <mail>legal@boardsesh.com</mail>."
+    },
+    "footer": "Diese Seite ist ein Entwurf, dient der Information und ist keine Rechtsberatung."
+  }
+}

--- a/packages/shared/i18n/locales/de/marketing.json
+++ b/packages/shared/i18n/locales/de/marketing.json
@@ -111,7 +111,7 @@
     "headerTitle": "Rechtliches",
     "intro": {
       "title": "Rechtliches & Richtlinie zum geistigen Eigentum",
-      "p1": "Boardsesh ist eine kostenlose, quelloffene, von der Community gebaute Alternative, um standardisierte LED-Trainingsboards (Kilter Board, Tension Board, MoonBoard und andere) zu durchstöbern und zu bedienen. Das Projekt ist nicht kommerziell und wird ausschließlich von Freiwilligen betreut.",
+      "p1": "Boardsesh ist eine kostenlose, quelloffene, von der Community gebaute Alternative, um standardisierte LED-Trainingsboards (Kilter Board, Tension Board, MoonBoard und andere) zu durchstöbern und zu bedienen. Die App ist kostenlos, der Quellcode offen, und gebaut wird sie von Freiwilligen. Boardsesh verkauft genau eine optionale Sache — CNC-Baupläne für eine Wand zu Hause, unter einer eigenen Fertigungslizenz — und davon werden Hosting und Entwicklung bezahlt.",
       "p2": "Wir finden: Kletternde sollten frei entscheiden dürfen, wie sie mit Hardware umgehen, die sie gekauft haben, und Daten, die die Community erzeugt hat, sollten der Community zugänglich bleiben."
     },
     "climbData": {
@@ -159,6 +159,10 @@
     "trademark": {
       "title": "Markennutzung",
       "body": "Wir verwenden Board- und Produktnamen (z. B. „Kilter Board“, „MoonBoard“, „Tension Board“) ausschließlich, um Hardware-Kompatibilität und Interoperabilität zu beschreiben. Diese Namen sind Marken der jeweiligen Inhaber. Dieses Projekt steht in keiner Verbindung zu Aurora Climbing, Moon Climbing oder einem anderen Board-Hersteller und wird von ihnen weder unterstützt noch gesponsert."
+    },
+    "buildPlans": {
+      "title": "Baupläne",
+      "body": "Boardsesh verkauft CNC-Baupläne für eine Wand zu Hause: erzeugte Schnittdateien für eine Wand, lizenziert für eine Wand statt verkauft. Der Generator dahinter ist geschlossen und wird nicht verteilt; die App selbst bleibt kostenlos und quelloffen. Die Pläne sind mit dem Lochbild des Kilter Homewall kompatibel — eine Aussage über Lochpositionen, keine Verbindung zu einem Hersteller. Die vollständigen Bedingungen stehen auf der Seite <licence>Fertigungslizenz für Baupläne</licence>."
     },
     "dmca": {
       "title": "DMCA & Anfragen zur Entfernung",

--- a/packages/shared/i18n/locales/en-US/cnc-legal.json
+++ b/packages/shared/i18n/locales/en-US/cnc-legal.json
@@ -1,0 +1,105 @@
+{
+  "metadata": {
+    "licence": {
+      "title": "Build Plans Manufacturing Licence",
+      "description": "The licence that comes with a Boardsesh build plans pack: what you may manufacture, what you may not share, and who is responsible for the finished wall."
+    }
+  },
+  "licence": {
+    "headerTitle": "Build plans manufacturing licence",
+    "draft": {
+      "title": "Draft licence",
+      "body": "Draft licence, pending review by an Australian IP lawyer; do not rely on it yet. The wording will change before build plans go on sale."
+    },
+    "intro": {
+      "title": "Boardsesh Build Plans Manufacturing Licence",
+      "p1": "This is the agreement that comes with every build plans pack. It says what you may build, what you may not pass on, and who carries the risk once the parts are cut. Plain language on purpose."
+    },
+    "parties": {
+      "title": "1. Parties and definitions",
+      "boardsesh": {
+        "term": "Boardsesh",
+        "definition": "The project that generates the files, issues the licence and keeps the licence record."
+      },
+      "licensee": {
+        "term": "The licensee (you)",
+        "definition": "The person or company named on the licence record for a pack. The licence is issued to that name and is not transferable without our written agreement."
+      },
+      "pack": {
+        "term": "The pack",
+        "definition": "The set of files Boardsesh generated for one order, identified by the licence id printed in them (for example BS-CNC-4K7QP2). Every pack is generated for its own order; no two are the same file."
+      },
+      "wall": {
+        "term": "One wall",
+        "definition": "One physical installation, built once, at one address. Rebuilding the same wall after damage is the same wall. A second wall anywhere else is a second wall."
+      }
+    },
+    "grant": {
+      "title": "2. What you get",
+      "p1": "Buying a pack buys a licence to manufacture. It does not transfer ownership of the files, the geometry or the generator that produced them. Boardsesh keeps every right it holds in the pack.",
+      "p2": "The licence starts when the pack is delivered and lasts as long as you keep to the terms below. There is nothing to renew."
+    },
+    "personal": {
+      "title": "3. Personal licence (A$149)",
+      "summary": "One wall, your own non-commercial use.",
+      "allowed1": "Manufacture one wall from the pack for your own non-commercial use.",
+      "allowed2": "Cut the parts yourself or hand them to a fabricator, as long as the finished wall is yours.",
+      "notAllowed1": "No manufacture for sale, and no manufacture on behalf of anyone else.",
+      "notAllowed2": "No resale, redistribution, sharing or public posting of the files, whole or in part, modified or not.",
+      "notAllowed3": "No using the files or the templates in them to produce derivative manufacturing files for third parties.",
+      "notAllowed4": "A second wall needs a second licence."
+    },
+    "commercial": {
+      "title": "4. Commercial single-build licence (A$750)",
+      "summary": "One identified customer installation, named on the licence.",
+      "allowed1": "Manufacture one wall for the customer installation named on the licence.",
+      "allowed2": "Charge that customer whatever you like for the build. That is the point of this tier.",
+      "notAllowed1": "No resale, redistribution, sharing or public posting of the files, whole or in part, modified or not.",
+      "notAllowed2": "No using the files or the templates in them to produce derivative manufacturing files for third parties, including other customers of yours.",
+      "notAllowed3": "Each further installation needs its own licence, named on its own licence record."
+    },
+    "labels": {
+      "allowed": "You may",
+      "notAllowed": "You may not"
+    },
+    "volume": {
+      "title": "5. Ten builds and OEM",
+      "body": "Cutting at volume, or putting these panels into a product you sell? Ten-build packs and OEM terms are by agreement. <mail>Email us</mail> with what you are building and how many."
+    },
+    "fingerprint": {
+      "title": "6. Fingerprinting and enforcement",
+      "p1": "Every pack is generated individually for one order and carries its licence id in the files.",
+      "p2": "The files also carry markings tied to the purchase. A pack that turns up somewhere it should not can be traced back to the order that bought it.",
+      "p3": "Breaking the terms above ends the licence. Manufacturing after that point is manufacturing without a licence, and we will pursue it."
+    },
+    "compatibility": {
+      "title": "7. Compatibility",
+      "p1": "Build plans are compatible with the Kilter Homewall hole pattern. That is a compatibility statement about hole positions, nothing more.",
+      "p2": "Boardsesh is not affiliated with, endorsed by or sponsored by Aurora Climbing or any board manufacturer. Product names appear only to describe hardware compatibility — see our <legal>legal and intellectual property policy</legal>.",
+      "p3": "Holds, LED kits and app access are not part of a pack. Buy those from the manufacturer."
+    },
+    "safety": {
+      "title": "8. Safety and responsibility",
+      "p1": "You are responsible for the structural engineering, the fixings, the materials and the local building codes for your wall. A climbing wall carries dynamic load and hurts people when it fails.",
+      "p2": "The files are supplied as-is, with no warranty of fitness for any build. Check every dimension against your own sheets, your machine and your space before you cut.",
+      "p3": "Boardsesh is not liable for loss, damage or injury arising from a wall built from a pack. Nothing here removes a right you have under Australian Consumer Law that cannot be excluded."
+    },
+    "refunds": {
+      "title": "9. Refunds",
+      "body": "Generated files cannot be un-delivered, so a pack is not refundable once it has been downloaded. Before download, refunds are at Boardsesh's discretion — email us and we will sort it out."
+    },
+    "privacy": {
+      "title": "10. Privacy",
+      "body": "The licence record — your name, email, licence id and the configuration you ordered — is kept as a contract record. It stays after an account is deleted, because the licence and its proof of purchase outlive the account. Everything else follows the <privacy>privacy policy</privacy>."
+    },
+    "governingLaw": {
+      "title": "11. Governing law",
+      "body": "This licence is governed by the law of Victoria, Australia, and the courts of Victoria have jurisdiction. Placeholder wording, pending legal review."
+    },
+    "contact": {
+      "title": "12. Contact",
+      "body": "Questions about the licence, or a licence you need reissued: <mail>legal@boardsesh.com</mail>."
+    },
+    "footer": "This page is a draft, is provided for information, and is not legal advice."
+  }
+}

--- a/packages/shared/i18n/locales/en-US/marketing.json
+++ b/packages/shared/i18n/locales/en-US/marketing.json
@@ -111,7 +111,7 @@
     "headerTitle": "Legal",
     "intro": {
       "title": "Legal & Intellectual Property Policy",
-      "p1": "Boardsesh is a free, open-source, community-built alternative for browsing and interacting with standardised LED climbing training boards (Kilter Board, Tension Board, MoonBoard, and others). It is non-commercial and maintained entirely by volunteers.",
+      "p1": "Boardsesh is a free, open-source, community-built alternative for browsing and interacting with standardised LED climbing training boards (Kilter Board, Tension Board, MoonBoard, and others). The app is free, the source is open, and the people who build it are volunteers. Boardsesh sells one optional thing — CNC build plans for a home wall, under a separate manufacturing licence — and that revenue pays for hosting and development.",
       "p2": "We believe climbers should have the freedom to choose how they interact with hardware they've purchased, and that community-created data should remain accessible to the community."
     },
     "climbData": {
@@ -159,6 +159,10 @@
     "trademark": {
       "title": "Trademark Usage",
       "body": "We use board and product names (e.g. \"Kilter Board\", \"MoonBoard\", \"Tension Board\") solely to describe hardware compatibility and interoperability. These names are trademarks of their respective owners. This project is not affiliated with, endorsed by, or sponsored by Aurora Climbing, Moon Climbing, or any board manufacturer."
+    },
+    "buildPlans": {
+      "title": "Build Plans",
+      "body": "Boardsesh sells CNC build plans for a home wall: generated cutting files for one wall, licensed for one wall rather than sold outright. The generator that makes them is closed and is not distributed; the app itself stays free and open source. The plans are compatible with the Kilter Homewall hole pattern — a statement about hole positions, not a relationship with any manufacturer. Full terms are on the <licence>build plans manufacturing licence</licence> page."
     },
     "dmca": {
       "title": "DMCA & Takedown Requests",

--- a/packages/shared/i18n/locales/es/cnc-legal.json
+++ b/packages/shared/i18n/locales/es/cnc-legal.json
@@ -1,0 +1,105 @@
+{
+  "metadata": {
+    "licence": {
+      "title": "Licencia de fabricación de los planos de construcción",
+      "description": "La licencia que acompaña a cada pack de planos de construcción de Boardsesh: qué puedes fabricar, qué no puedes compartir y quién responde del muro terminado."
+    }
+  },
+  "licence": {
+    "headerTitle": "Licencia de fabricación de los planos de construcción",
+    "draft": {
+      "title": "Licencia en borrador",
+      "body": "Licencia en borrador, pendiente de revisión por un abogado australiano de propiedad intelectual; todavía no te bases en ella. El texto cambiará antes de que los planos de construcción salgan a la venta."
+    },
+    "intro": {
+      "title": "Licencia de fabricación de los planos de construcción de Boardsesh",
+      "p1": "Este es el acuerdo que acompaña a cada pack de planos de construcción. Explica qué puedes construir, qué no puedes ceder a nadie y quién asume el riesgo una vez cortadas las piezas. En lenguaje claro, a propósito."
+    },
+    "parties": {
+      "title": "1. Partes y definiciones",
+      "boardsesh": {
+        "term": "Boardsesh",
+        "definition": "El proyecto que genera los archivos, emite la licencia y conserva el registro de licencias."
+      },
+      "licensee": {
+        "term": "El licenciatario (tú)",
+        "definition": "La persona o empresa que figura en el registro de licencias de un pack. La licencia se emite a ese nombre y no es transferible sin nuestro acuerdo por escrito."
+      },
+      "pack": {
+        "term": "El pack",
+        "definition": "El conjunto de archivos que Boardsesh generó para un pedido, identificado por el id de licencia impreso en ellos (por ejemplo, BS-CNC-4K7QP2). Cada pack se genera para su propio pedido; no hay dos iguales."
+      },
+      "wall": {
+        "term": "Un muro",
+        "definition": "Una instalación física, construida una vez, en una dirección. Reconstruir el mismo muro tras un daño sigue siendo el mismo muro. Un segundo muro en cualquier otro sitio es un segundo muro."
+      }
+    },
+    "grant": {
+      "title": "2. Qué obtienes",
+      "p1": "Comprar un pack compra una licencia para fabricar. No transfiere la propiedad de los archivos, de la geometría ni del generador que los produjo. Boardsesh conserva todos los derechos que tiene sobre el pack.",
+      "p2": "La licencia empieza cuando se entrega el pack y dura mientras cumplas las condiciones de abajo. No hay nada que renovar."
+    },
+    "personal": {
+      "title": "3. Licencia personal (149 A$)",
+      "summary": "Un muro, para tu propio uso no comercial.",
+      "allowed1": "Fabricar un muro a partir del pack para tu propio uso no comercial.",
+      "allowed2": "Cortar las piezas tú mismo o encargárselas a un taller, siempre que el muro terminado sea tuyo.",
+      "notAllowed1": "Nada de fabricar para vender ni de fabricar por cuenta de otra persona.",
+      "notAllowed2": "Nada de revender, redistribuir, compartir ni publicar los archivos, enteros o en parte, modificados o no.",
+      "notAllowed3": "Nada de usar los archivos ni las plantillas que contienen para producir archivos de fabricación derivados para terceros.",
+      "notAllowed4": "Un segundo muro necesita una segunda licencia."
+    },
+    "commercial": {
+      "title": "4. Licencia comercial de una construcción (750 A$)",
+      "summary": "Una instalación concreta de un cliente, indicada en la licencia.",
+      "allowed1": "Fabricar un muro para la instalación del cliente indicada en la licencia.",
+      "allowed2": "Cobrar a ese cliente lo que quieras por la construcción. Para eso está este nivel.",
+      "notAllowed1": "Nada de revender, redistribuir, compartir ni publicar los archivos, enteros o en parte, modificados o no.",
+      "notAllowed2": "Nada de usar los archivos ni las plantillas que contienen para producir archivos de fabricación derivados para terceros, incluidos otros clientes tuyos.",
+      "notAllowed3": "Cada instalación adicional necesita su propia licencia, con su propio registro de licencia."
+    },
+    "labels": {
+      "allowed": "Puedes",
+      "notAllowed": "No puedes"
+    },
+    "volume": {
+      "title": "5. Diez construcciones y OEM",
+      "body": "¿Cortas en volumen o quieres integrar estos paneles en un producto que vendes? Los packs de diez construcciones y las condiciones OEM se acuerdan caso por caso. <mail>Escríbenos</mail> contando qué vas a construir y cuántas unidades."
+    },
+    "fingerprint": {
+      "title": "6. Marcado y cumplimiento",
+      "p1": "Cada pack se genera individualmente para un pedido y lleva su id de licencia en los archivos.",
+      "p2": "Los archivos también llevan marcas ligadas a la compra. Un pack que aparezca donde no debe se puede rastrear hasta el pedido que lo compró.",
+      "p3": "Incumplir las condiciones de arriba termina la licencia. Fabricar a partir de ese momento es fabricar sin licencia, y lo perseguiremos."
+    },
+    "compatibility": {
+      "title": "7. Compatibilidad",
+      "p1": "Los planos de construcción son compatibles con el patrón de agujeros del Kilter Homewall. Es una declaración de compatibilidad sobre posiciones de agujeros, nada más.",
+      "p2": "Boardsesh no está afiliado, respaldado ni patrocinado por Aurora Climbing ni por ningún fabricante de plafones. Los nombres de producto aparecen únicamente para describir la compatibilidad de hardware; consulta nuestra <legal>política legal y de propiedad intelectual</legal>.",
+      "p3": "Las presas, los kits de LED y el acceso a la app no forman parte del pack. Cómpralos al fabricante."
+    },
+    "safety": {
+      "title": "8. Seguridad y responsabilidad",
+      "p1": "Tú respondes del cálculo estructural, de las fijaciones, de los materiales y de la normativa de construcción local de tu muro. Un muro de escalada soporta cargas dinámicas y hace daño a la gente cuando falla.",
+      "p2": "Los archivos se entregan tal cual, sin garantía de idoneidad para ninguna construcción. Comprueba cada medida con tus propios tableros, tu máquina y tu espacio antes de cortar.",
+      "p3": "Boardsesh no responde de pérdidas, daños ni lesiones derivados de un muro construido a partir de un pack. Nada de lo dicho aquí elimina un derecho irrenunciable que te reconozca la legislación australiana de consumo."
+    },
+    "refunds": {
+      "title": "9. Devoluciones",
+      "body": "Los archivos generados no se pueden «des-entregar», así que un pack no es reembolsable una vez descargado. Antes de la descarga, los reembolsos quedan a criterio de Boardsesh: escríbenos y lo arreglamos."
+    },
+    "privacy": {
+      "title": "10. Privacidad",
+      "body": "El registro de la licencia —tu nombre, tu correo, el id de licencia y la configuración que pediste— se conserva como registro contractual. Se mantiene aunque borres la cuenta, porque la licencia y su prueba de compra sobreviven a la cuenta. Todo lo demás sigue la <privacy>política de privacidad</privacy>."
+    },
+    "governingLaw": {
+      "title": "11. Ley aplicable",
+      "body": "Esta licencia se rige por la ley de Victoria (Australia), y los tribunales de Victoria son los competentes. Texto provisional, pendiente de revisión legal."
+    },
+    "contact": {
+      "title": "12. Contacto",
+      "body": "Dudas sobre la licencia, o una licencia que necesitas que reemitamos: <mail>legal@boardsesh.com</mail>."
+    },
+    "footer": "Esta página es un borrador, se ofrece a título informativo y no constituye asesoramiento legal."
+  }
+}

--- a/packages/shared/i18n/locales/es/marketing.json
+++ b/packages/shared/i18n/locales/es/marketing.json
@@ -187,7 +187,7 @@
     "headerTitle": "Legal",
     "intro": {
       "title": "Política Legal y de Propiedad Intelectual",
-      "p1": "Boardsesh es una alternativa gratuita, de código abierto y construida por la comunidad para navegar e interactuar con plafones de entrenamiento de escalada con LEDs estandarizados (Kilter Board, Tension Board, MoonBoard y otros). No tiene fines comerciales y está mantenida íntegramente por voluntarios.",
+      "p1": "Boardsesh es una alternativa gratuita, de código abierto y construida por la comunidad para navegar e interactuar con plafones de entrenamiento de escalada con LEDs estandarizados (Kilter Board, Tension Board, MoonBoard y otros). La app es gratuita, el código es abierto y quienes la construyen son voluntarios. Boardsesh vende una sola cosa opcional —planos de construcción CNC para un muro en casa, con una licencia de fabricación aparte— y ese dinero paga el alojamiento y el desarrollo.",
       "p2": "Creemos que los escaladores deben tener la libertad de elegir cómo interactúan con el hardware que han comprado y que los datos creados por la comunidad deben seguir siendo accesibles para la comunidad."
     },
     "climbData": {
@@ -235,6 +235,10 @@
     "trademark": {
       "title": "Uso de Marcas Registradas",
       "body": "Usamos los nombres de plafones y productos (por ejemplo, «Kilter Board», «MoonBoard», «Tension Board») únicamente para describir la compatibilidad e interoperabilidad de hardware. Estos nombres son marcas registradas de sus respectivos propietarios. Este proyecto no está afiliado, respaldado ni patrocinado por Aurora Climbing, Moon Climbing ni ningún fabricante de plafones."
+    },
+    "buildPlans": {
+      "title": "Planos de construcción",
+      "body": "Boardsesh vende planos de construcción CNC para un muro en casa: archivos de corte generados para un muro, con licencia para un muro y no vendidos en propiedad. El generador que los produce es cerrado y no se distribuye; la app sigue siendo gratuita y de código abierto. Los planos son compatibles con el patrón de agujeros del Kilter Homewall, lo que dice algo sobre posiciones de agujeros y nada sobre una relación con ningún fabricante. Las condiciones completas están en la página de la <licence>licencia de fabricación de los planos de construcción</licence>."
     },
     "dmca": {
       "title": "DMCA y Solicitudes de Retirada",

--- a/packages/shared/i18n/locales/fr/cnc-legal.json
+++ b/packages/shared/i18n/locales/fr/cnc-legal.json
@@ -1,0 +1,105 @@
+{
+  "metadata": {
+    "licence": {
+      "title": "Licence de fabrication des plans de construction",
+      "description": "La licence fournie avec chaque pack de plans de construction Boardsesh : ce que tu peux fabriquer, ce que tu ne peux pas diffuser et qui répond du mur fini."
+    }
+  },
+  "licence": {
+    "headerTitle": "Licence de fabrication des plans de construction",
+    "draft": {
+      "title": "Licence à l'état de brouillon",
+      "body": "Licence provisoire, en attente de relecture par un avocat australien en propriété intellectuelle ; ne t'appuie pas encore dessus. Le texte changera avant la mise en vente des plans de construction."
+    },
+    "intro": {
+      "title": "Licence de fabrication des plans de construction Boardsesh",
+      "p1": "Voici l'accord fourni avec chaque pack de plans de construction. Il dit ce que tu peux construire, ce que tu ne peux transmettre à personne et qui porte le risque une fois les pièces découpées. En langage clair, volontairement."
+    },
+    "parties": {
+      "title": "1. Parties et définitions",
+      "boardsesh": {
+        "term": "Boardsesh",
+        "definition": "Le projet qui génère les fichiers, délivre la licence et conserve le registre des licences."
+      },
+      "licensee": {
+        "term": "Le licencié (toi)",
+        "definition": "La personne ou l'entreprise inscrite au registre des licences pour un pack. La licence est délivrée à ce nom et n'est pas transférable sans notre accord écrit."
+      },
+      "pack": {
+        "term": "Le pack",
+        "definition": "L'ensemble des fichiers que Boardsesh a générés pour une commande, identifié par l'id de licence inscrit dedans (par exemple BS-CNC-4K7QP2). Chaque pack est généré pour sa propre commande ; il n'y en a pas deux identiques."
+      },
+      "wall": {
+        "term": "Un mur",
+        "definition": "Une installation physique, construite une fois, à une adresse. Reconstruire le même mur après un dommage reste le même mur. Un deuxième mur ailleurs est un deuxième mur."
+      }
+    },
+    "grant": {
+      "title": "2. Ce que tu obtiens",
+      "p1": "Acheter un pack achète une licence de fabrication. Cela ne transfère la propriété ni des fichiers, ni de la géométrie, ni du générateur qui les a produits. Boardsesh conserve tous les droits qu'il détient sur le pack.",
+      "p2": "La licence commence à la livraison du pack et dure tant que tu respectes les conditions ci-dessous. Il n'y a rien à renouveler."
+    },
+    "personal": {
+      "title": "3. Licence personnelle (149 A$)",
+      "summary": "Un mur, pour ton propre usage non commercial.",
+      "allowed1": "Fabriquer un mur à partir du pack, pour ton propre usage non commercial.",
+      "allowed2": "Découper les pièces toi-même ou les confier à un atelier, tant que le mur fini est le tien.",
+      "notAllowed1": "Pas de fabrication destinée à la vente, ni de fabrication pour le compte de quelqu'un d'autre.",
+      "notAllowed2": "Pas de revente, de rediffusion, de partage ni de publication des fichiers, en tout ou en partie, modifiés ou non.",
+      "notAllowed3": "Pas d'utilisation des fichiers ni des gabarits qu'ils contiennent pour produire des fichiers de fabrication dérivés destinés à des tiers.",
+      "notAllowed4": "Un deuxième mur demande une deuxième licence."
+    },
+    "commercial": {
+      "title": "4. Licence commerciale pour une construction (750 A$)",
+      "summary": "Une installation client identifiée, nommée sur la licence.",
+      "allowed1": "Fabriquer un mur pour l'installation client nommée sur la licence.",
+      "allowed2": "Facturer ce client au prix que tu veux pour la construction. C'est tout l'objet de ce palier.",
+      "notAllowed1": "Pas de revente, de rediffusion, de partage ni de publication des fichiers, en tout ou en partie, modifiés ou non.",
+      "notAllowed2": "Pas d'utilisation des fichiers ni des gabarits qu'ils contiennent pour produire des fichiers de fabrication dérivés destinés à des tiers, y compris tes autres clients.",
+      "notAllowed3": "Chaque installation supplémentaire demande sa propre licence, avec son propre registre de licence."
+    },
+    "labels": {
+      "allowed": "Tu peux",
+      "notAllowed": "Tu ne peux pas"
+    },
+    "volume": {
+      "title": "5. Dix constructions et OEM",
+      "body": "Tu découpes en volume, ou tu veux intégrer ces panneaux dans un produit que tu vends ? Les packs de dix constructions et les conditions OEM se négocient au cas par cas. <mail>Écris-nous</mail> en précisant ce que tu construis et en quelle quantité."
+    },
+    "fingerprint": {
+      "title": "6. Marquage et application",
+      "p1": "Chaque pack est généré individuellement pour une commande et porte son id de licence dans les fichiers.",
+      "p2": "Les fichiers portent aussi des marquages liés à l'achat. Un pack qui réapparaît là où il ne devrait pas peut être remonté jusqu'à la commande qui l'a acheté.",
+      "p3": "Enfreindre les conditions ci-dessus met fin à la licence. Fabriquer après ce point, c'est fabriquer sans licence, et nous le poursuivrons."
+    },
+    "compatibility": {
+      "title": "7. Compatibilité",
+      "p1": "Les plans de construction sont compatibles avec le plan de perçage du Kilter Homewall. C'est une déclaration de compatibilité sur des positions de trous, rien de plus.",
+      "p2": "Boardsesh n'est ni affilié à, ni approuvé ou sponsorisé par Aurora Climbing ou un quelconque fabricant de boards. Les noms de produits n'apparaissent que pour décrire la compatibilité matérielle — voir notre <legal>politique légale et de propriété intellectuelle</legal>.",
+      "p3": "Les prises, les kits LED et l'accès à l'app ne font pas partie du pack. Achète-les chez le fabricant."
+    },
+    "safety": {
+      "title": "8. Sécurité et responsabilité",
+      "p1": "Tu réponds du calcul structurel, des fixations, des matériaux et des règles de construction locales pour ton mur. Un mur d'escalade encaisse des charges dynamiques et blesse quand il lâche.",
+      "p2": "Les fichiers sont fournis tels quels, sans garantie d'adéquation à une construction. Vérifie chaque cote avec tes propres panneaux, ta machine et ton espace avant de découper.",
+      "p3": "Boardsesh n'est pas responsable des pertes, dommages ou blessures liés à un mur construit à partir d'un pack. Rien ici ne supprime un droit non renonçable que te reconnaît le droit australien de la consommation."
+    },
+    "refunds": {
+      "title": "9. Remboursements",
+      "body": "Des fichiers générés ne peuvent pas être « dé-livrés » : un pack n'est donc pas remboursable une fois téléchargé. Avant le téléchargement, les remboursements restent à la discrétion de Boardsesh — écris-nous et on règle ça."
+    },
+    "privacy": {
+      "title": "10. Confidentialité",
+      "body": "Le registre de la licence — ton nom, ton e-mail, l'id de licence et la configuration commandée — est conservé comme pièce contractuelle. Il reste après la suppression du compte, parce que la licence et sa preuve d'achat survivent au compte. Tout le reste suit la <privacy>politique de confidentialité</privacy>."
+    },
+    "governingLaw": {
+      "title": "11. Droit applicable",
+      "body": "Cette licence est régie par le droit de l'État de Victoria (Australie), et les tribunaux de Victoria sont compétents. Formulation provisoire, en attente de relecture juridique."
+    },
+    "contact": {
+      "title": "12. Contact",
+      "body": "Une question sur la licence, ou une licence à faire rééditer : <mail>legal@boardsesh.com</mail>."
+    },
+    "footer": "Cette page est un brouillon, fournie à titre d'information, et ne constitue pas un conseil juridique."
+  }
+}

--- a/packages/shared/i18n/locales/fr/marketing.json
+++ b/packages/shared/i18n/locales/fr/marketing.json
@@ -111,7 +111,7 @@
     "headerTitle": "Mentions légales",
     "intro": {
       "title": "Politique légale et de propriété intellectuelle",
-      "p1": "Boardsesh est une alternative gratuite, open source et communautaire pour parcourir et interagir avec les boards d'entraînement à LED standardisées (Kilter Board, Tension Board, MoonBoard et autres). Le projet est non commercial et entièrement maintenu par des bénévoles.",
+      "p1": "Boardsesh est une alternative gratuite, open source et communautaire pour parcourir et interagir avec les boards d'entraînement à LED standardisées (Kilter Board, Tension Board, MoonBoard et autres). L'app est gratuite, le code est ouvert et les personnes qui la construisent sont bénévoles. Boardsesh ne vend qu'une chose, facultative — des plans de construction CNC pour un mur à la maison, sous une licence de fabrication distincte — et ces revenus paient l'hébergement et le développement.",
       "p2": "Nous pensons que les grimpeurs doivent être libres de choisir comment ils interagissent avec le matériel qu'ils ont acheté, et que les données créées par la communauté doivent rester accessibles à la communauté."
     },
     "climbData": {
@@ -159,6 +159,10 @@
     "trademark": {
       "title": "Usage des marques",
       "body": "Nous utilisons les noms de boards et de produits (par exemple « Kilter Board », « MoonBoard », « Tension Board ») uniquement pour décrire la compatibilité matérielle et l'interopérabilité. Ces noms sont des marques déposées de leurs propriétaires respectifs. Ce projet n'est ni affilié à, ni approuvé ou sponsorisé par Aurora Climbing, Moon Climbing ou tout autre fabricant de boards."
+    },
+    "buildPlans": {
+      "title": "Plans de construction",
+      "body": "Boardsesh vend des plans de construction CNC pour un mur à la maison : des fichiers de découpe générés pour un mur, sous licence pour un mur et non vendus en pleine propriété. Le générateur qui les produit est fermé et n'est pas distribué ; l'app, elle, reste gratuite et open source. Les plans sont compatibles avec le plan de perçage du Kilter Homewall — une indication sur des positions de trous, pas une relation avec un fabricant. Les conditions complètes sont sur la page <licence>licence de fabrication des plans de construction</licence>."
     },
     "dmca": {
       "title": "DMCA et demandes de retrait",

--- a/packages/shared/i18n/src/config.ts
+++ b/packages/shared/i18n/src/config.ts
@@ -46,6 +46,7 @@ export const ALL_NAMESPACES = [
   'boards',
   'kiosk',
   'gyms',
+  'cnc-legal',
 ] as const;
 export type Namespace = (typeof ALL_NAMESPACES)[number];
 

--- a/packages/web/app/__test-helpers__/i18n-mock.ts
+++ b/packages/web/app/__test-helpers__/i18n-mock.ts
@@ -28,6 +28,7 @@ import enAurora from '@boardsesh/i18n/locales/en-US/aurora.json';
 import enAuth from '@boardsesh/i18n/locales/en-US/auth.json';
 import enBoards from '@boardsesh/i18n/locales/en-US/boards.json';
 import enClimbs from '@boardsesh/i18n/locales/en-US/climbs.json';
+import enCncLegal from '@boardsesh/i18n/locales/en-US/cnc-legal.json';
 import enCommon from '@boardsesh/i18n/locales/en-US/common.json';
 import enFeed from '@boardsesh/i18n/locales/en-US/feed.json';
 import enGyms from '@boardsesh/i18n/locales/en-US/gyms.json';
@@ -46,6 +47,7 @@ const CATALOGS: Record<string, unknown> = {
   auth: enAuth,
   boards: enBoards,
   climbs: enClimbs,
+  'cnc-legal': enCncLegal,
   common: enCommon,
   feed: enFeed,
   gyms: enGyms,

--- a/packages/web/app/api/internal/feature-flags/route.ts
+++ b/packages/web/app/api/internal/feature-flags/route.ts
@@ -13,9 +13,8 @@ import {
 
 /**
  * Admin-only diagnostics for the SERVER-side feature flags — the ones that gate
- * whether a route renders at all. `SERVER_FEATURE_FLAG_KEYS` is empty since
- * `/gyms` launched unconditionally, so today every question comes in through
- * `?key=`; a registered flag is covered automatically once one exists again.
+ * whether a route renders at all. Every key in `SERVER_FEATURE_FLAG_KEYS` is
+ * reported automatically; anything else is asked for ad hoc through `?key=`.
  *
  * It exists because "the dashboard says 100% and the page still 404s" has half a
  * dozen causes that look identical from outside: no project key in the runtime

--- a/packages/web/app/build-plans/licence/__tests__/licence-content.test.tsx
+++ b/packages/web/app/build-plans/licence/__tests__/licence-content.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vite-plus/test';
+import { render, screen } from '@testing-library/react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import LicenceContent from '../licence-content';
+
+// The licence puts four of its links inside `<Trans>` blocks, so the usual
+// `children ?? null` stub would render a document with no anchors at all and
+// the href assertions below would pass vacuously. This stub renders each slot
+// element instead, labelled with the slot name, which is enough for the hrefs
+// to be real and for the count to be meaningful.
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ i18nKey, components }: { i18nKey?: string; components?: Record<string, React.ReactElement> }) => (
+    <>
+      {Object.entries(components ?? {}).map(([slot, element]) =>
+        React.cloneElement(element, { key: slot }, `${i18nKey ?? ''}:${slot}`),
+      )}
+    </>
+  ),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => '/build-plans/licence',
+}));
+
+function renderLicence() {
+  return render(<LicenceContent />);
+}
+
+describe('LicenceContent', () => {
+  it('leads with the DRAFT banner', () => {
+    // First thing in the document flow on purpose: someone arriving from a
+    // purchase flow has to see "not lawyer-reviewed" before they read terms.
+    renderLicence();
+    expect(screen.getByText('Draft licence')).toBeTruthy();
+    expect(screen.getByText(/pending review by an Australian IP lawyer/)).toBeTruthy();
+  });
+
+  it('renders both licence tiers with their prices', () => {
+    renderLicence();
+    expect(screen.getByText('3. Personal licence (A$149)')).toBeTruthy();
+    expect(screen.getByText('4. Commercial single-build licence (A$750)')).toBeTruthy();
+  });
+
+  it('links the licence contact and the volume enquiry at different addresses', () => {
+    // Two distinct mailboxes, and the split is the point: legal@ answers
+    // licence questions and reissues, support@ takes ten-build and OEM
+    // enquiries. A single address here would route contract questions into the
+    // support queue.
+    const { container } = renderLicence();
+    const hrefs = Array.from(container.querySelectorAll('a')).map((anchor) => anchor.getAttribute('href'));
+    expect(hrefs).toContain('mailto:legal@boardsesh.com');
+    expect(hrefs).toContain('mailto:support@boardsesh.com');
+  });
+
+  it('cross-links the legal and privacy policies', () => {
+    // The compatibility and privacy sections both defer to a policy that lives
+    // elsewhere, so these two hrefs are load-bearing: a broken one leaves the
+    // licence making a claim it never substantiates.
+    const { container } = renderLicence();
+    const hrefs = Array.from(container.querySelectorAll('a')).map((anchor) => anchor.getAttribute('href'));
+    expect(hrefs).toContain('/legal');
+    expect(hrefs).toContain('/privacy');
+  });
+
+  it('renders exactly those four link targets and no others', () => {
+    // In document order: volume enquiry (5), compatibility (7), privacy (10),
+    // licence contact (12). Asserting the whole list catches a fifth link
+    // arriving without a home for it in this file.
+    const { container } = renderLicence();
+    const hrefs = Array.from(container.querySelectorAll('a')).map((anchor) => anchor.getAttribute('href'));
+    expect(hrefs).toEqual(['mailto:support@boardsesh.com', '/legal', '/privacy', 'mailto:legal@boardsesh.com']);
+  });
+});

--- a/packages/web/app/build-plans/licence/__tests__/licence-metadata.test.ts
+++ b/packages/web/app/build-plans/licence/__tests__/licence-metadata.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import enCncLegal from '@boardsesh/i18n/locales/en-US/cnc-legal.json';
+
+vi.mock('server-only', () => ({}));
+
+const getServerTranslation = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/i18n/server', () => ({ getServerTranslation, loadServerResources: vi.fn() }));
+
+const getLocale = vi.hoisted(() => vi.fn(async () => 'en-US'));
+vi.mock('@/app/lib/i18n/get-locale', () => ({ getLocale }));
+
+const getServerFeatureFlag = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/feature-flags/server-feature-flag', () => ({ getServerFeatureFlag }));
+
+const getPosthogDistinctId = vi.hoisted(() => vi.fn(async (): Promise<string | null> => null));
+vi.mock('@/app/lib/feature-flags/server-distinct-id', () => ({ getPosthogDistinctId }));
+
+// `notFound()` really throws in Next; the assertions below depend on that, so
+// the mock throws a sentinel rather than returning quietly.
+class NotFoundError extends Error {}
+const notFound = vi.hoisted(() => vi.fn());
+vi.mock('next/navigation', () => ({ notFound }));
+
+// The page body and the i18n provider are React trees this suite never renders
+// — stubbing them keeps the metadata + gate assertions off MUI and i18next.
+vi.mock('../licence-content', () => ({ default: () => null }));
+vi.mock('@/app/components/providers/i18n-provider', () => ({ default: () => null }));
+
+const route = await import('../page');
+
+function translate(key: string): string {
+  const value = key.split('.').reduce<unknown>((node, segment) => {
+    if (node !== null && typeof node === 'object' && segment in node) {
+      return (node as Record<string, unknown>)[segment];
+    }
+    return undefined;
+  }, enCncLegal);
+  if (typeof value !== 'string') {
+    throw new Error(`cnc-legal catalog has no string at "${key}"`);
+  }
+  return value;
+}
+
+function mockLocale(locale: string) {
+  getServerTranslation.mockResolvedValue({ t: translate, i18n: {}, locale });
+}
+
+beforeEach(() => {
+  getServerTranslation.mockReset();
+  getServerFeatureFlag.mockReset();
+  notFound.mockReset();
+  notFound.mockImplementation(() => {
+    throw new NotFoundError('NEXT_NOT_FOUND');
+  });
+  getLocale.mockResolvedValue('en-US');
+  getPosthogDistinctId.mockResolvedValue(null);
+  mockLocale('en-US');
+});
+
+describe('metadata', () => {
+  it('ships noindex, follow while the licence is a flag-gated draft', async () => {
+    const metadata = await route.generateMetadata();
+    // Both halves of the gate matter: the page also 404s when the flag is off.
+    // The noindex is what keeps a DRAFT licence out of the index in the window
+    // between flipping the flag on and the lawyer sign-off.
+    expect(metadata.robots).toEqual({ index: false, follow: true });
+  });
+
+  it('canonicalises to the clean licence path', async () => {
+    const metadata = await route.generateMetadata();
+    expect(metadata.alternates?.canonical).toBe('/build-plans/licence');
+  });
+
+  it('carries the canonical into the locale prefix', async () => {
+    mockLocale('de');
+    const metadata = await route.generateMetadata();
+    expect(metadata.alternates?.canonical).toBe('/de/build-plans/licence');
+  });
+
+  it('emits hreflang alternates for every locale plus x-default', async () => {
+    const metadata = await route.generateMetadata();
+    expect(metadata.alternates?.languages).toEqual({
+      'en-US': '/build-plans/licence',
+      es: '/es/build-plans/licence',
+      fr: '/fr/build-plans/licence',
+      de: '/de/build-plans/licence',
+      'x-default': '/build-plans/licence',
+    });
+  });
+
+  it('titles the page from the catalog, brand-suffixed', async () => {
+    const metadata = await route.generateMetadata();
+    expect(metadata.title).toEqual({ absolute: `${translate('metadata.licence.title')} | Boardsesh` });
+  });
+});
+
+describe('feature gate', () => {
+  it('404s while cnc-packs is off', async () => {
+    getServerFeatureFlag.mockResolvedValue(false);
+    await expect(route.default()).rejects.toBeInstanceOf(NotFoundError);
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it('renders once cnc-packs is on', async () => {
+    getServerFeatureFlag.mockResolvedValue(true);
+    await expect(route.default()).resolves.toBeTruthy();
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
+  it('evaluates the flag for the signed-in person, with allowAnonymous for everyone else', async () => {
+    // Both halves are load-bearing. The distinct id has to be the session's, or
+    // person-property targeting evaluates false against a stranger; and
+    // `allowAnonymous` has to be on, or the page stays signed-in-only however
+    // the dashboard is configured.
+    getPosthogDistinctId.mockResolvedValue('user-123');
+    getServerFeatureFlag.mockResolvedValue(true);
+    await route.default();
+    expect(getServerFeatureFlag).toHaveBeenCalledWith('cnc-packs', {
+      distinctId: 'user-123',
+      allowAnonymous: true,
+    });
+  });
+});

--- a/packages/web/app/build-plans/licence/__tests__/licence-metadata.test.ts
+++ b/packages/web/app/build-plans/licence/__tests__/licence-metadata.test.ts
@@ -54,6 +54,9 @@ beforeEach(() => {
   });
   getLocale.mockResolvedValue('en-US');
   getPosthogDistinctId.mockResolvedValue(null);
+  // `generateMetadata` reads the same gate the body does, so the describing
+  // cases below need the flag on to reach the branch they are about.
+  getServerFeatureFlag.mockResolvedValue(true);
   mockLocale('en-US');
 });
 
@@ -91,6 +94,17 @@ describe('metadata', () => {
   it('titles the page from the catalog, brand-suffixed', async () => {
     const metadata = await route.generateMetadata();
     expect(metadata.title).toEqual({ absolute: `${translate('metadata.licence.title')} | Boardsesh` });
+  });
+
+  it('describes nothing while the flag is off, because the page 404s', async () => {
+    // The body calls `notFound()` in this state. A title and description would
+    // hand a crawler — or a share unfurl — a licence that is not there, so the
+    // flag-off branch keeps only the robots directive.
+    getServerFeatureFlag.mockResolvedValue(false);
+    const metadata = await route.generateMetadata();
+    expect(metadata.robots).toEqual({ index: false, follow: true });
+    expect(metadata.title).toBeUndefined();
+    expect(metadata.description).toBeUndefined();
   });
 });
 

--- a/packages/web/app/build-plans/licence/licence-content.tsx
+++ b/packages/web/app/build-plans/licence/licence-content.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+import React from 'react';
+import MuiCard from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import MuiLink from '@mui/material/Link';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import { GavelOutlined } from '@mui/icons-material';
+import { Trans, useTranslation } from 'react-i18next';
+import BackButton from '@/app/components/back-button';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import styles from '../../about/about.module.css';
+
+const LICENCE_EMAIL = 'mailto:legal@boardsesh.com';
+const VOLUME_EMAIL = 'mailto:support@boardsesh.com';
+
+/**
+ * The manufacturing licence that ships with every build-plans pack.
+ *
+ * Deliberately a plain reading page, not a sales page: the copy above it sells
+ * the packs, this states the terms. The DRAFT banner is the first thing in the
+ * document flow because the text has not been through an Australian IP lawyer
+ * yet, and someone landing here from a purchase flow has to see that before
+ * they read a price.
+ */
+export default function LicenceContent() {
+  const { t } = useTranslation('cnc-legal');
+
+  const definitions = [
+    { key: 'boardsesh', term: t('licence.parties.boardsesh.term'), body: t('licence.parties.boardsesh.definition') },
+    { key: 'licensee', term: t('licence.parties.licensee.term'), body: t('licence.parties.licensee.definition') },
+    { key: 'pack', term: t('licence.parties.pack.term'), body: t('licence.parties.pack.definition') },
+    { key: 'wall', term: t('licence.parties.wall.term'), body: t('licence.parties.wall.definition') },
+  ];
+
+  const personalAllowed = [t('licence.personal.allowed1'), t('licence.personal.allowed2')];
+  const personalNotAllowed = [
+    t('licence.personal.notAllowed1'),
+    t('licence.personal.notAllowed2'),
+    t('licence.personal.notAllowed3'),
+    t('licence.personal.notAllowed4'),
+  ];
+  const commercialAllowed = [t('licence.commercial.allowed1'), t('licence.commercial.allowed2')];
+  const commercialNotAllowed = [
+    t('licence.commercial.notAllowed1'),
+    t('licence.commercial.notAllowed2'),
+    t('licence.commercial.notAllowed3'),
+  ];
+
+  const renderRules = (label: string, rules: string[]) => (
+    <>
+      <Typography variant="subtitle2" component="p" sx={{ mt: 2 }}>
+        {label}
+      </Typography>
+      <ul className={styles.featureList}>
+        {rules.map((rule) => (
+          <li key={rule}>
+            <Typography variant="body1" component="span">
+              {rule}
+            </Typography>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+
+  return (
+    <Box className={styles.pageLayout}>
+      <Box component="header" className={styles.header}>
+        {/* Home, not /build-plans: the shop page arrives in a later PR, and a
+            back button that lands on a 404 is worse than one that lands home. */}
+        <BackButton fallbackUrl="/" />
+        <Typography variant="h4" className={styles.headerTitle}>
+          {t('licence.headerTitle')}
+        </Typography>
+      </Box>
+
+      <Box component="main" className={styles.content}>
+        <Alert severity="warning" className={styles.alert}>
+          <AlertTitle>{t('licence.draft.title')}</AlertTitle>
+          {t('licence.draft.body')}
+        </Alert>
+
+        <MuiCard>
+          <CardContent>
+            <Stack spacing={3} className={styles.cardContent}>
+              <section>
+                <Typography variant="h3" component="h1">
+                  <GavelOutlined className={`${styles.sectionIcon} ${styles.primaryIcon}`} />
+                  {t('licence.intro.title')}
+                </Typography>
+                <Typography variant="body1" component="p">
+                  {t('licence.intro.p1')}
+                </Typography>
+              </section>
+
+              {/* 1. Parties and definitions */}
+              <section>
+                <Typography variant="h3">{t('licence.parties.title')}</Typography>
+                {definitions.map((definition) => (
+                  <Typography key={definition.key} variant="body1" component="p">
+                    <strong>{definition.term}</strong> {definition.body}
+                  </Typography>
+                ))}
+              </section>
+
+              {/* 2. What you get */}
+              <section>
+                <Typography variant="h3">{t('licence.grant.title')}</Typography>
+                <Typography variant="body1" component="p">
+                  {t('licence.grant.p1')}
+                </Typography>
+                <Typography variant="body1" component="p">
+                  {t('licence.grant.p2')}
+                </Typography>
+              </section>
+
+              {/* 3. Personal licence */}
+              <section>
+                <Typography variant="h3">{t('licence.personal.title')}</Typography>
+                <Typography variant="body1" component="p">
+                  {t('licence.personal.summary')}
+                </Typography>
+                {renderRules(t('licence.labels.allowed'), personalAllowed)}
+                {renderRules(t('licence.labels.notAllowed'), personalNotAllowed)}
+              </section>
+
+              {/* 4. Commercial single-build licence */}
+              <section>
+                <Typography variant="h3">{t('licence.commercial.title')}</Typography>
+                <Typography variant="body1" component="p">
+                  {t('licence.commercial.summary')}
+                </Typography>
+                {renderRules(t('licence.labels.allowed'), commercialAllowed)}
+                {renderRules(t('licence.labels.notAllowed'), commercialNotAllowed)}
+              </section>
+
+              {/* 5. Ten builds and OEM */}
+              <section>
+                <Typography variant="h3">{t('licence.volume.title')}</Typography>
+                <Typography variant="body1" component="p">
+                  <Trans i18nKey="licence.volume.body" t={t} components={{ mail: <MuiLink href={VOLUME_EMAIL} /> }} />
+                </Typography>
+              </section>
+
+              {/* 6. Fingerprinting and enforcement */}
+              <section>
+                <Typography variant="h3">{t('licence.fingerprint.title')}</Typography>
+                <Typography variant="body1" component="p">
+                  {t('licence.fingerprint.p1')}
+                </Typography>
+                <Typography variant="body1" component="p">
+                  {t('licence.fingerprint.p2')}
+                </Typography>
+                <Typography variant="body1" component="p">
+                  {t('licence.fingerprint.p3')}
+                </Typography>
+              </section>
+
+              {/* 7. Compatibility */}
+              <section>
+                <Typography variant="h3">{t('licence.compatibility.title')}</Typography>
+                <Typography variant="body1" component="p">
+                  {t('licence.compatibility.p1')}
+                </Typography>
+                <Typography variant="body1" component="p">
+                  <Trans
+                    i18nKey="licence.compatibility.p2"
+                    t={t}
+                    components={{ legal: <MuiLink component={LocaleLink} href="/legal" /> }}
+                  />
+                </Typography>
+                <Typography variant="body1" component="p">
+                  {t('licence.compatibility.p3')}
+                </Typography>
+              </section>
+
+              {/* 8. Safety and responsibility */}
+              <section>
+                <Typography variant="h3">{t('licence.safety.title')}</Typography>
+                <Typography variant="body1" component="p">
+                  {t('licence.safety.p1')}
+                </Typography>
+                <Typography variant="body1" component="p">
+                  {t('licence.safety.p2')}
+                </Typography>
+                <Typography variant="body1" component="p">
+                  {t('licence.safety.p3')}
+                </Typography>
+              </section>
+
+              {/* 9. Refunds */}
+              <section>
+                <Typography variant="h3">{t('licence.refunds.title')}</Typography>
+                <Typography variant="body1" component="p">
+                  {t('licence.refunds.body')}
+                </Typography>
+              </section>
+
+              {/* 10. Privacy */}
+              <section>
+                <Typography variant="h3">{t('licence.privacy.title')}</Typography>
+                <Typography variant="body1" component="p">
+                  <Trans
+                    i18nKey="licence.privacy.body"
+                    t={t}
+                    components={{ privacy: <MuiLink component={LocaleLink} href="/privacy" /> }}
+                  />
+                </Typography>
+              </section>
+
+              {/* 11. Governing law */}
+              <section>
+                <Typography variant="h3">{t('licence.governingLaw.title')}</Typography>
+                <Typography variant="body1" component="p">
+                  {t('licence.governingLaw.body')}
+                </Typography>
+              </section>
+
+              {/* 12. Contact */}
+              <section>
+                <Typography variant="h3">{t('licence.contact.title')}</Typography>
+                <Typography variant="body1" component="p">
+                  <Trans i18nKey="licence.contact.body" t={t} components={{ mail: <MuiLink href={LICENCE_EMAIL} /> }} />
+                </Typography>
+              </section>
+
+              <section className={styles.callToAction}>
+                <Typography variant="body2" component="p" color="text.secondary">
+                  {t('licence.footer')}
+                </Typography>
+              </section>
+            </Stack>
+          </CardContent>
+        </MuiCard>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/web/app/build-plans/licence/page.tsx
+++ b/packages/web/app/build-plans/licence/page.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { notFound } from 'next/navigation';
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { getLocale } from '@/app/lib/i18n/get-locale';
+import { getServerFeatureFlag } from '@/app/lib/feature-flags/server-feature-flag';
+import { getPosthogDistinctId } from '@/app/lib/feature-flags/server-distinct-id';
+import { CNC_PACKS_FLAG } from '@/app/flags';
+import I18nProvider from '@/app/components/providers/i18n-provider';
+import LicenceContent from './licence-content';
+
+export async function generateMetadata() {
+  const { t, locale } = await getServerTranslation('cnc-legal');
+  // `noindex, follow` for as long as the flag gates the page: a licence that is
+  // still a draft must not be the thing Google shows for "boardsesh licence".
+  // Launch removes this line and nothing else.
+  return createNoIndexMetadata({
+    title: t('metadata.licence.title'),
+    description: t('metadata.licence.description'),
+    path: '/build-plans/licence',
+    locale,
+  });
+}
+
+export default async function BuildPlansLicencePage() {
+  // Same gate as every other `/build-plans` route. `allowAnonymous` because the
+  // licence has to be readable before you buy — and therefore before you sign
+  // in — the moment the flag goes to 100%.
+  const distinctId = await getPosthogDistinctId();
+  const enabled = await getServerFeatureFlag(CNC_PACKS_FLAG, { distinctId, allowAnonymous: true });
+  if (!enabled) {
+    notFound();
+  }
+
+  const locale = await getLocale();
+  return (
+    <I18nProvider locale={locale} namespaces={['cnc-legal', 'common']}>
+      <LicenceContent />
+    </I18nProvider>
+  );
+}

--- a/packages/web/app/build-plans/licence/page.tsx
+++ b/packages/web/app/build-plans/licence/page.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import { createNoIndexMetadata, NOINDEX_FOLLOW_ROBOTS } from '@/app/lib/seo/metadata';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { getLocale } from '@/app/lib/i18n/get-locale';
 import { getServerFeatureFlag } from '@/app/lib/feature-flags/server-feature-flag';
@@ -21,9 +21,10 @@ export async function generateMetadata(): Promise<Metadata> {
   const distinctId = await getPosthogDistinctId();
   const enabled = await getServerFeatureFlag(CNC_PACKS_FLAG, { distinctId, allowAnonymous: true });
   if (!enabled) {
-    // Same robots value `createNoIndexMetadata` produces, so both branches agree
-    // on indexability and differ only in what they describe.
-    return { robots: { index: false, follow: true } };
+    // The same constant `createNoIndexMetadata` puts on the flag-on branch, so
+    // the two cannot drift on indexability and differ only in what they
+    // describe.
+    return { robots: NOINDEX_FOLLOW_ROBOTS };
   }
 
   const { t, locale } = await getServerTranslation('cnc-legal');

--- a/packages/web/app/build-plans/licence/page.tsx
+++ b/packages/web/app/build-plans/licence/page.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
 import { getServerTranslation } from '@/app/lib/i18n/server';
@@ -9,7 +10,22 @@ import { CNC_PACKS_FLAG } from '@/app/flags';
 import I18nProvider from '@/app/components/providers/i18n-provider';
 import LicenceContent from './licence-content';
 
-export async function generateMetadata() {
+export async function generateMetadata(): Promise<Metadata> {
+  // The same gate the page body runs, for the same reason: while `cnc-packs` is
+  // off this route calls `notFound()`, and describing a page that does not exist
+  // is metadata for nothing. A title and description on a 404 is worse than
+  // none — a crawler that follows a stale link gets a plausible-looking licence
+  // title attached to an error page, and share unfurls do the same to a human.
+  // So the flag-off branch keeps the robots directive and drops everything that
+  // makes a claim about content.
+  const distinctId = await getPosthogDistinctId();
+  const enabled = await getServerFeatureFlag(CNC_PACKS_FLAG, { distinctId, allowAnonymous: true });
+  if (!enabled) {
+    // Same robots value `createNoIndexMetadata` produces, so both branches agree
+    // on indexability and differ only in what they describe.
+    return { robots: { index: false, follow: true } };
+  }
+
   const { t, locale } = await getServerTranslation('cnc-legal');
   // `noindex, follow` for as long as the flag gates the page: a licence that is
   // still a draft must not be the thing Google shows for "boardsesh licence".

--- a/packages/web/app/flags.ts
+++ b/packages/web/app/flags.ts
@@ -28,13 +28,20 @@ export const GYM_KIOSK_FLAG = 'gym-kiosk';
 // here — matching the documented "flags gate the UI entry point only" pattern.
 export const MOONBOARD_WIDE_ANGLES_FLAG = 'moonboard-wide-angles';
 
+// Gates the `/build-plans` surface: the configurator, the orders pages and the
+// manufacturing licence. Server-resolved, because those routes have to 404
+// rather than merely hide a link — the licence text is a draft awaiting review
+// by an Australian IP lawyer, so nothing about it may be publicly reachable
+// yet. `allowAnonymous: true` at every call site so the eventual public launch
+// is a dashboard flip and not a code change.
+export const CNC_PACKS_FLAG = 'cnc-packs';
+
 // Keys read from PostHog by FeatureFlagsProvider. Each must have a matching
 // PostHog feature flag; values stay `undefined` (OFF) until that flag resolves.
 export const FEATURE_FLAG_KEYS = [BOARDSESH_GRADE_FLAG, GYM_KIOSK_FLAG, MOONBOARD_WIDE_ANGLES_FLAG] as const;
 
 // Keys resolved server-side by `getServerFeatureFlag`, which gate whether a
-// route renders at all. Empty since `/gyms` launched unconditionally; the
-// machinery stays because that is a different gate from the client keys above
-// (see docs/feature-flags.md). Deliberately kept out of FEATURE_FLAG_KEYS: the
+// route renders at all — a different gate from the client keys above (see
+// docs/feature-flags.md). Deliberately kept out of FEATURE_FLAG_KEYS: the
 // browser provider would fetch a flag no client component reads.
-export const SERVER_FEATURE_FLAG_KEYS = [] as const;
+export const SERVER_FEATURE_FLAG_KEYS = [CNC_PACKS_FLAG] as const;

--- a/packages/web/app/legal/__tests__/legal-page.test.ts
+++ b/packages/web/app/legal/__tests__/legal-page.test.ts
@@ -1,0 +1,68 @@
+import type { ReactElement } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { CNC_PACKS_FLAG } from '@/app/flags';
+
+vi.mock('server-only', () => ({}));
+
+const getServerTranslation = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/i18n/server', () => ({ getServerTranslation, loadServerResources: vi.fn() }));
+
+const getLocale = vi.hoisted(() => vi.fn(async () => 'en-US'));
+vi.mock('@/app/lib/i18n/get-locale', () => ({ getLocale }));
+
+const getServerFeatureFlag = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/feature-flags/server-feature-flag', () => ({ getServerFeatureFlag }));
+
+// Spy components rather than the real trees: this suite is about the gate and
+// the prop it produces, so keeping MUI and i18next out of it means a styling
+// change can never turn one of these assertions red.
+const LegalContent = vi.hoisted(() => vi.fn(() => null));
+vi.mock('../legal-content', () => ({ default: LegalContent }));
+const I18nProvider = vi.hoisted(() => vi.fn(() => null));
+vi.mock('@/app/components/providers/i18n-provider', () => ({ default: I18nProvider }));
+
+const route = await import('../page');
+
+beforeEach(() => {
+  getServerFeatureFlag.mockReset();
+  getLocale.mockResolvedValue('en-US');
+  getServerTranslation.mockResolvedValue({ t: (key: string) => key, i18n: {}, locale: 'en-US' });
+});
+
+// The page never renders here — it returns the provider element with the
+// content element as its only child, so reading that child's props is the same
+// thing React would hand the component, without a DOM.
+async function renderLegalPage() {
+  const tree = (await route.default()) as ReactElement<{ children: ReactElement<{ showBuildPlans: boolean }> }>;
+  expect(tree.type).toBe(I18nProvider);
+  const content = tree.props.children;
+  expect(content.type).toBe(LegalContent);
+  return content.props;
+}
+
+describe('LegalPage build-plans gate', () => {
+  it('resolves the flag anonymously, without a distinct id', async () => {
+    // Both arguments are load-bearing. `distinctId: null` keeps the cached flag
+    // lookup to a single entry, because the answer is identical for everybody;
+    // `allowAnonymous` keeps it resolvable for the signed-out visitors who are
+    // most of /legal's traffic.
+    getServerFeatureFlag.mockResolvedValue(false);
+    await route.default();
+    expect(getServerFeatureFlag).toHaveBeenCalledWith(CNC_PACKS_FLAG, {
+      distinctId: null,
+      allowAnonymous: true,
+    });
+  });
+
+  it('shows the build-plans section once cnc-packs is on', async () => {
+    getServerFeatureFlag.mockResolvedValue(true);
+    await expect(renderLegalPage()).resolves.toEqual({ showBuildPlans: true });
+  });
+
+  it('hides the build-plans section while cnc-packs is off', async () => {
+    // /legal is indexed, and `/build-plans/licence` 404s while the flag is off.
+    // Passing `false` here is what keeps an indexed page from linking into a 404.
+    getServerFeatureFlag.mockResolvedValue(false);
+    await expect(renderLegalPage()).resolves.toEqual({ showBuildPlans: false });
+  });
+});

--- a/packages/web/app/legal/legal-content.tsx
+++ b/packages/web/app/legal/legal-content.tsx
@@ -10,9 +10,20 @@ import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { Trans, useTranslation } from 'react-i18next';
 import BackButton from '@/app/components/back-button';
+import LocaleLink from '@/app/components/i18n/locale-link';
 import styles from '../about/about.module.css';
 
-export default function LegalContent() {
+type LegalContentProps = {
+  /**
+   * Whether to show the build-plans section. It links to
+   * `/build-plans/licence`, which 404s while the `cnc-packs` flag is off — an
+   * indexed page must not carry a link into a 404, so the section appears with
+   * the rest of the surface rather than ahead of it.
+   */
+  showBuildPlans?: boolean;
+};
+
+export default function LegalContent({ showBuildPlans = false }: LegalContentProps) {
   const { t } = useTranslation('marketing');
   return (
     <Box className={styles.pageLayout}>
@@ -144,6 +155,20 @@ export default function LegalContent() {
                   {t('legal.trademark.body')}
                 </Typography>
               </section>
+
+              {/* Build plans */}
+              {showBuildPlans && (
+                <section>
+                  <Typography variant="h3">{t('legal.buildPlans.title')}</Typography>
+                  <Typography variant="body1" component="p">
+                    <Trans
+                      i18nKey="legal.buildPlans.body"
+                      t={t}
+                      components={{ licence: <MuiLink component={LocaleLink} href="/build-plans/licence" /> }}
+                    />
+                  </Typography>
+                </section>
+              )}
 
               {/* DMCA */}
               <section>

--- a/packages/web/app/legal/page.tsx
+++ b/packages/web/app/legal/page.tsx
@@ -19,9 +19,12 @@ export async function generateMetadata() {
 
 export default async function LegalPage() {
   const locale = await getLocale();
-  // `distinctId: null` with `allowAnonymous` on purpose: /legal is public and
-  // indexable, so it must not read the session (that would make every render
-  // dynamic) and the build-plans mention is the same for everyone.
+  // `distinctId: null` with `allowAnonymous` on purpose, and it is about cache
+  // cardinality rather than staying static: `getLocale()` above reads `headers()`,
+  // so this page is dynamically rendered either way. The build-plans mention is
+  // the same for every visitor, so passing a per-person distinct id would only
+  // fan the cached flag lookup out into one entry per user for an answer that
+  // never varies between them.
   const showBuildPlans = await getServerFeatureFlag(CNC_PACKS_FLAG, { distinctId: null, allowAnonymous: true });
   return (
     <I18nProvider locale={locale} namespaces={['marketing']}>

--- a/packages/web/app/legal/page.tsx
+++ b/packages/web/app/legal/page.tsx
@@ -3,6 +3,8 @@ import { createPageMetadata } from '@/app/lib/seo/metadata';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { getLocale } from '@/app/lib/i18n/get-locale';
 import I18nProvider from '@/app/components/providers/i18n-provider';
+import { getServerFeatureFlag } from '@/app/lib/feature-flags/server-feature-flag';
+import { CNC_PACKS_FLAG } from '@/app/flags';
 import LegalContent from './legal-content';
 
 export async function generateMetadata() {
@@ -17,9 +19,13 @@ export async function generateMetadata() {
 
 export default async function LegalPage() {
   const locale = await getLocale();
+  // `distinctId: null` with `allowAnonymous` on purpose: /legal is public and
+  // indexable, so it must not read the session (that would make every render
+  // dynamic) and the build-plans mention is the same for everyone.
+  const showBuildPlans = await getServerFeatureFlag(CNC_PACKS_FLAG, { distinctId: null, allowAnonymous: true });
   return (
     <I18nProvider locale={locale} namespaces={['marketing']}>
-      <LegalContent />
+      <LegalContent showBuildPlans={showBuildPlans} />
     </I18nProvider>
   );
 }

--- a/packages/web/app/lib/seo/metadata.ts
+++ b/packages/web/app/lib/seo/metadata.ts
@@ -192,10 +192,21 @@ export function createBoardContentPageMetadata(options: PageMetadataOptions): Me
   };
 }
 
+/**
+ * The robots directive every `createNoIndexMetadata` page ships.
+ *
+ * Exported for the pages that need the directive without the description: a
+ * flag-gated route whose off branch calls `notFound()` still has to say
+ * `noindex`, but must not hand a crawler a title and description for a page
+ * that 404s. Importing this is what keeps such a branch from restating the
+ * literal and drifting from the helper.
+ */
+export const NOINDEX_FOLLOW_ROBOTS = { index: false, follow: true } as const;
+
 export function createNoIndexMetadata(options: Omit<PageMetadataOptions, 'robots'>): Metadata {
   return createPageMetadata({
     ...options,
-    robots: { index: false, follow: true },
+    robots: NOINDEX_FOLLOW_ROBOTS,
   });
 }
 


### PR DESCRIPTION
## Summary

Build plans (CNC packs) slice 6 of 10: the draft manufacturing licence page and the legal reword. Stacked on #5168.

- `/build-plans/licence`: a DRAFT-bannered plain-language licence with both tiers (Personal, Commercial single-build), fingerprinting and enforcement, compatibility-not-affiliation wording, safety and responsibility, refunds, privacy retention, governing law placeholder and contact. Flag-gated by `cnc-packs`, `noindex` while flagged. New `cnc-legal` i18n namespace in all four locales.
- `LEGAL.md` and the `/legal` page: the "non-commercial" opener is reworded (the app stays free and open source; Boardsesh sells optional build plans under a separate manufacturing licence) and a Build Plans section links to the licence page. The `/legal` link is only rendered while the flag is on so the public page never links to a 404.
- `packages/web/app/flags.ts`: `CNC_PACKS_FLAG` added to `SERVER_FEATURE_FLAG_KEYS` (same line as slice 5; merges cleanly).

**Pending lawyer review before the flag goes public.** Items to raise with the Australian IP lawyer:

1. Australian Consumer Law carve-out and a proper limitation-of-liability clause for the safety section.
2. Refund wording vs consumer guarantees for digital goods and card chargebacks.
3. "We will pursue it" needs a real termination and remedies clause.
4. Whether "markings tied to the purchase" is enough fingerprinting disclosure.
5. Retention after account deletion: APP 11.2 wants a stated period, and the privacy policy must match.
6. Governing law placeholder (Victoria).
7. The "one wall" definition (rebuilding after damage counts as the same wall).
8. Non-transferability vs consumer resale rights.
9. The personal-tier boundary between "hand it to a fabricator" and "no manufacture on behalf of others".
10. Translations are working renderings, not certified; declare English authoritative if non-English buyers are bound.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

1. CI green.

## Risk

Risk: 1/5 — copy and a flag-gated page; the public `/legal` page changes one paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBHWJfrtZ29m47uCvX5yQC
